### PR TITLE
Fix Image Details API

### DIFF
--- a/infra/lambda_layer/python/requirements-dev.txt
+++ b/infra/lambda_layer/python/requirements-dev.txt
@@ -1,5 +1,6 @@
 pytest==8.3.4
 pytest-cov==6.0.0
+pytest-mock==3.14.0
 black==24.10.0
 moto==5.0.24
 freezegun

--- a/infra/routes/image_details/handler/index.py
+++ b/infra/routes/image_details/handler/index.py
@@ -19,7 +19,10 @@ def handler(event, context):
         try:
             # Use the client to list the first 50 images
             client = DynamoClient(dynamodb_table_name)
-            receipts, _ = client.listReceipts(50)
+            receipts, lek = client.listReceipts(500)
+            while lek:
+                next_receipts, lek = client.listReceipts(500, lek)
+                receipts.extend(next_receipts)
 
             # Group all receipts by their image_id
             # Set the value to the dict to the number of receipts with that image_id

--- a/infra/routes/image_details/infra.py
+++ b/infra/routes/image_details/infra.py
@@ -87,6 +87,7 @@ image_details_lambda = aws.lambda_.Function(
         }
     },
     memory_size=1024,  # Increase the RAM to 1024 MB
+    timeout=30,  # Increase the timeout to 30 seconds
 )
 
 # CloudWatch log group for the Lambda function


### PR DESCRIPTION
The image details API's timeout was increased. The API was also modified to pick a random image ID based on all images in DynamoDB.