### PR TITLE
Standardize type error messages

### DIFF
--- a/receipt_dynamo/receipt_dynamo/entities/batch_summary.py
+++ b/receipt_dynamo/receipt_dynamo/entities/batch_summary.py
@@ -2,7 +2,11 @@ from datetime import datetime
 from typing import Optional, Generator, Tuple, Any
 
 from receipt_dynamo.constants import BatchStatus, BatchType
-from receipt_dynamo.entities.util import _repr_str
+from receipt_dynamo.entities.util import (
+    _repr_str,
+    assert_type,
+    format_type_error,
+)
 
 
 class BatchSummary:
@@ -16,8 +20,7 @@ class BatchSummary:
         result_file_id: str,
         receipt_refs: list[tuple[str, int]] = None,
     ):
-        if not isinstance(batch_id, str):
-            raise ValueError("batch_id must be a string")
+        assert_type("batch_id", batch_id, str, ValueError)
         self.batch_id = batch_id
 
         # Accept batch_type as either BatchType or str
@@ -27,7 +30,7 @@ class BatchSummary:
             batch_type_str = batch_type
         else:
             raise ValueError(
-                f"batch_type must be either a BatchType enum or a string; got {type(batch_type).__name__}"
+                format_type_error("batch_type", batch_type, (BatchType, str))
             )
 
         # Validate batch_type_str against allowed values
@@ -38,8 +41,7 @@ class BatchSummary:
             )
         self.batch_type = batch_type_str
 
-        if not isinstance(openai_batch_id, str):
-            raise ValueError("openai_batch_id must be a string")
+        assert_type("openai_batch_id", openai_batch_id, str, ValueError)
         self.openai_batch_id = openai_batch_id
 
         if isinstance(submitted_at, str):
@@ -51,7 +53,9 @@ class BatchSummary:
                 )
         elif not isinstance(submitted_at, datetime):
             raise ValueError(
-                "submitted_at must be a datetime object or a string"
+                format_type_error(
+                    "submitted_at", submitted_at, (datetime, str)
+                )
             )
         self.submitted_at = submitted_at
 
@@ -62,7 +66,7 @@ class BatchSummary:
             status_str = status
         else:
             raise ValueError(
-                f"status must be either a BatchStatus enum or a string; got {type(status).__name__}"
+                format_type_error("status", status, (BatchStatus, str))
             )
 
         # Validate the string against allowed values
@@ -73,8 +77,7 @@ class BatchSummary:
             )
         self.status = status_str
 
-        if not isinstance(result_file_id, str):
-            raise ValueError("result_file_id must be a string")
+        assert_type("result_file_id", result_file_id, str, ValueError)
         self.result_file_id = result_file_id
 
         if not isinstance(receipt_refs, list):

--- a/receipt_dynamo/receipt_dynamo/entities/completion_batch_result.py
+++ b/receipt_dynamo/receipt_dynamo/entities/completion_batch_result.py
@@ -1,7 +1,12 @@
 from datetime import datetime
 from typing import Any, Generator, Optional, Tuple
 
-from receipt_dynamo.entities.util import _repr_str, assert_valid_uuid
+from receipt_dynamo.entities.util import (
+    _repr_str,
+    assert_valid_uuid,
+    assert_type,
+    format_type_error,
+)
 from receipt_dynamo.constants import ValidationStatus, PassNumber, BatchStatus
 
 
@@ -28,28 +33,32 @@ class CompletionBatchResult:
         assert_valid_uuid(image_id)
         self.image_id = image_id
 
-        if not isinstance(receipt_id, int):
-            raise ValueError("receipt_id must be an integer")
+        assert_type("receipt_id", receipt_id, int, ValueError)
         self.receipt_id = receipt_id
 
-        if not isinstance(line_id, int):
-            raise ValueError("line_id must be an integer")
+        assert_type("line_id", line_id, int, ValueError)
         self.line_id = line_id
 
-        if not isinstance(word_id, int):
-            raise ValueError("word_id must be an integer")
+        assert_type("word_id", word_id, int, ValueError)
         self.word_id = word_id
 
-        if not isinstance(original_label, str):
-            raise ValueError("original_label must be a string")
+        assert_type("original_label", original_label, str, ValueError)
         self.original_label = original_label
 
         if not isinstance(gpt_suggested_label, str | None):
-            raise ValueError("gpt_suggested_label must be a string or None")
+            raise ValueError(
+                format_type_error(
+                    "gpt_suggested_label",
+                    gpt_suggested_label,
+                    (str, type(None)),
+                )
+            )
         self.gpt_suggested_label = gpt_suggested_label
 
         if not isinstance(status, str | BatchStatus):
-            raise ValueError("status must be a string or BatchStatus")
+            raise ValueError(
+                format_type_error("status", status, (str, BatchStatus))
+            )
         if isinstance(status, str) and not status in [
             s.value for s in BatchStatus
         ]:
@@ -62,8 +71,7 @@ class CompletionBatchResult:
             status_str = status
         self.status = status_str
 
-        if not isinstance(validated_at, datetime):
-            raise ValueError("validated_at must be a datetime object")
+        assert_type("validated_at", validated_at, datetime, ValueError)
         self.validated_at = validated_at
 
     def key(self) -> dict:

--- a/receipt_dynamo/receipt_dynamo/entities/embedding_batch_result.py
+++ b/receipt_dynamo/receipt_dynamo/entities/embedding_batch_result.py
@@ -1,6 +1,11 @@
 from typing import Any, Generator, Optional, Tuple
 
-from receipt_dynamo.entities.util import _repr_str, assert_valid_uuid
+from receipt_dynamo.entities.util import (
+    _repr_str,
+    assert_valid_uuid,
+    assert_type,
+    format_type_error,
+)
 from receipt_dynamo.constants import EmbeddingStatus
 import re
 
@@ -55,38 +60,33 @@ class EmbeddingBatchResult:
         assert_valid_uuid(image_id)
         self.image_id = image_id
 
-        if not isinstance(receipt_id, int):
-            raise ValueError("receipt_id must be an integer")
+        assert_type("receipt_id", receipt_id, int, ValueError)
         if receipt_id <= 0:
             raise ValueError("receipt_id must be greater than zero")
         self.receipt_id = receipt_id
 
-        if not isinstance(line_id, int):
-            raise ValueError("line_id must be an integer")
+        assert_type("line_id", line_id, int, ValueError)
         if line_id < 0:
             raise ValueError("line_id must be greater than or equal to zero")
         self.line_id = line_id
 
-        if not isinstance(word_id, int):
-            raise ValueError("word_id must be an integer")
+        assert_type("word_id", word_id, int, ValueError)
         if word_id < 0:
             raise ValueError("word_id must be greater than or equal to zero")
         self.word_id = word_id
 
-        if not isinstance(status, str):
-            raise ValueError("status must be a string")
+        assert_type("status", status, str, ValueError)
         if status not in [s.value for s in EmbeddingStatus]:
             raise ValueError(
                 f"status must be one of: {', '.join(s.value for s in EmbeddingStatus)}"
             )
         self.status = status
 
-        if not isinstance(text, str):
-            raise ValueError("text must be a string")
+        assert_type("text", text, str, ValueError)
         self.text = text
 
-        if error_message is not None and not isinstance(error_message, str):
-            raise ValueError("error_message must be a string")
+        if error_message is not None:
+            assert_type("error_message", error_message, str, ValueError)
         self.error_message = error_message
 
         # validate pinecone_id format

--- a/receipt_dynamo/receipt_dynamo/entities/job_metric.py
+++ b/receipt_dynamo/receipt_dynamo/entities/job_metric.py
@@ -2,7 +2,12 @@ import json
 from datetime import datetime
 from typing import Any, Dict, Generator, Optional, Tuple, Union
 
-from receipt_dynamo.entities.util import _repr_str, assert_valid_uuid
+from receipt_dynamo.entities.util import (
+    _repr_str,
+    assert_valid_uuid,
+    assert_type,
+    format_type_error,
+)
 
 
 class JobMetric:
@@ -49,7 +54,8 @@ class JobMetric:
         assert_valid_uuid(job_id)
         self.job_id = job_id
 
-        if not isinstance(metric_name, str) or not metric_name:
+        assert_type("metric_name", metric_name, str, ValueError)
+        if not metric_name:
             raise ValueError("metric_name must be a non-empty string")
         self.metric_name = metric_name
 
@@ -58,7 +64,9 @@ class JobMetric:
         elif isinstance(timestamp, str):
             self.timestamp = timestamp
         else:
-            raise ValueError("timestamp must be a datetime object or a string")
+            raise ValueError(
+                format_type_error("timestamp", timestamp, (datetime, str))
+            )
 
         if not isinstance(value, (float, int, dict)):
             try:

--- a/receipt_dynamo/receipt_dynamo/entities/label_metadata.py
+++ b/receipt_dynamo/receipt_dynamo/entities/label_metadata.py
@@ -1,7 +1,12 @@
 from datetime import datetime
 from typing import Optional, List, Tuple
 
-from receipt_dynamo.entities.util import _repr_str, assert_valid_uuid
+from receipt_dynamo.entities.util import (
+    _repr_str,
+    assert_valid_uuid,
+    assert_type,
+    format_type_error,
+)
 from receipt_dynamo.constants import LabelStatus
 
 
@@ -17,40 +22,35 @@ class LabelMetadata:
         label_target: Optional[str] = None,
         receipt_refs: list[tuple[str, int]] = None,
     ):
-        if not isinstance(label, str):
-            raise ValueError("label must be a string")
+        assert_type("label", label, str, ValueError)
         self.label = label
 
-        if not isinstance(status, str):
-            raise ValueError("status must be a string")
+        assert_type("status", status, str, ValueError)
         if not status in [s.value for s in LabelStatus]:
             raise ValueError(
                 f"status must be one of: {', '.join([s.value for s in LabelStatus])}"
             )
         self.status = status
 
-        if not isinstance(aliases, list):
-            raise ValueError("aliases must be a list")
+        assert_type("aliases", aliases, list, ValueError)
         self.aliases = aliases
 
-        if not isinstance(description, str):
-            raise ValueError("description must be a string")
+        assert_type("description", description, str, ValueError)
         self.description = description
 
-        if not isinstance(schema_version, int):
-            raise ValueError("schema_version must be an integer")
+        assert_type("schema_version", schema_version, int, ValueError)
         self.schema_version = schema_version
 
-        if not isinstance(last_updated, datetime):
-            raise ValueError("last_updated must be a datetime object")
+        assert_type("last_updated", last_updated, datetime, ValueError)
         self.last_updated = last_updated
 
-        if label_target is not None and not isinstance(label_target, str):
-            raise ValueError("label_target must be a string or None")
+        if label_target is not None:
+            assert_type("label_target", label_target, str, ValueError)
         self.label_target = label_target
 
         if receipt_refs is not None:
-            if not isinstance(receipt_refs, list) or not all(
+            assert_type("receipt_refs", receipt_refs, list, ValueError)
+            if not all(
                 isinstance(ref, tuple)
                 and len(ref) == 2
                 and isinstance(ref[0], str)

--- a/receipt_dynamo/receipt_dynamo/entities/receipt_structure_analysis.py
+++ b/receipt_dynamo/receipt_dynamo/entities/receipt_structure_analysis.py
@@ -8,6 +8,7 @@ import json
 import hashlib
 import decimal
 from datetime import datetime
+from receipt_dynamo.entities.util import assert_type, format_type_error
 
 
 class SpatialPattern:
@@ -36,18 +37,10 @@ class SpatialPattern:
             TypeError: If the input types are not as expected
             ValueError: If required values are missing or invalid
         """
-        if not isinstance(pattern_type, str):
-            raise TypeError(
-                f"pattern_type must be str, got {type(pattern_type).__name__}"
-            )
-        if not isinstance(description, str):
-            raise TypeError(
-                f"description must be str, got {type(description).__name__}"
-            )
-        if metadata is not None and not isinstance(metadata, dict):
-            raise TypeError(
-                f"metadata must be dict or None, got {type(metadata).__name__}"
-            )
+        assert_type("pattern_type", pattern_type, str)
+        assert_type("description", description, str)
+        if metadata is not None:
+            assert_type("metadata", metadata, dict)
 
         self.pattern_type = pattern_type
         self.description = description
@@ -76,8 +69,7 @@ class SpatialPattern:
             TypeError: If data is not a dictionary
             KeyError: If required keys are missing
         """
-        if not isinstance(data, dict):
-            raise TypeError(f"data must be dict, got {type(data).__name__}")
+        assert_type("data", data, dict)
 
         return cls(
             pattern_type=str(
@@ -130,22 +122,12 @@ class ContentPattern:
             TypeError: If the input types are not as expected
             ValueError: If required values are missing or invalid
         """
-        if not isinstance(pattern_type, str):
-            raise TypeError(
-                f"pattern_type must be str, got {type(pattern_type).__name__}"
-            )
-        if not isinstance(description, str):
-            raise TypeError(
-                f"description must be str, got {type(description).__name__}"
-            )
-        if examples is not None and not isinstance(examples, list):
-            raise TypeError(
-                f"examples must be list or None, got {type(examples).__name__}"
-            )
-        if metadata is not None and not isinstance(metadata, dict):
-            raise TypeError(
-                f"metadata must be dict or None, got {type(metadata).__name__}"
-            )
+        assert_type("pattern_type", pattern_type, str)
+        assert_type("description", description, str)
+        if examples is not None:
+            assert_type("examples", examples, list)
+        if metadata is not None:
+            assert_type("metadata", metadata, dict)
 
         self.pattern_type = pattern_type
         self.description = description
@@ -154,10 +136,7 @@ class ContentPattern:
 
         # Validate that all examples are strings
         for i, example in enumerate(self.examples):
-            if not isinstance(example, str):
-                raise TypeError(
-                    f"examples[{i}] must be str, got {type(example).__name__}"
-                )
+            assert_type(f"examples[{i}]", example, str)
 
     def to_dict(self) -> Dict[str, Any]:
         """Convert the ContentPattern to a dictionary."""
@@ -183,8 +162,7 @@ class ContentPattern:
             TypeError: If data is not a dictionary
             KeyError: If required keys are missing
         """
-        if not isinstance(data, dict):
-            raise TypeError(f"data must be dict, got {type(data).__name__}")
+        assert_type("data", data, dict)
 
         examples = data.get("examples", [])
         if examples and not isinstance(examples, list):
@@ -255,42 +233,27 @@ class ReceiptSection:
             TypeError: If the input types are not as expected
             ValueError: If required values are missing or invalid
         """
-        if not isinstance(name, str):
-            raise TypeError(f"name must be str, got {type(name).__name__}")
-        if not isinstance(line_ids, list):
-            raise TypeError(
-                f"line_ids must be list, got {type(line_ids).__name__}"
-            )
-        if not isinstance(spatial_patterns, list):
-            raise TypeError(
-                f"spatial_patterns must be list, got {type(spatial_patterns).__name__}"
-            )
-        if not isinstance(content_patterns, list):
-            raise TypeError(
-                f"content_patterns must be list, got {type(content_patterns).__name__}"
-            )
-        if not isinstance(reasoning, str):
-            raise TypeError(
-                f"reasoning must be str, got {type(reasoning).__name__}"
-            )
-        if start_line is not None and not isinstance(start_line, int):
-            raise TypeError(
-                f"start_line must be int or None, got {type(start_line).__name__}"
-            )
-        if end_line is not None and not isinstance(end_line, int):
-            raise TypeError(
-                f"end_line must be int or None, got {type(end_line).__name__}"
-            )
-        if metadata is not None and not isinstance(metadata, dict):
-            raise TypeError(
-                f"metadata must be dict or None, got {type(metadata).__name__}"
-            )
+        assert_type("name", name, str)
+        assert_type("line_ids", line_ids, list)
+        assert_type("spatial_patterns", spatial_patterns, list)
+        assert_type("content_patterns", content_patterns, list)
+        assert_type("reasoning", reasoning, str)
+        if start_line is not None:
+            assert_type("start_line", start_line, int)
+        if end_line is not None:
+            assert_type("end_line", end_line, int)
+        if metadata is not None:
+            assert_type("metadata", metadata, dict)
 
         # Validate line_ids are integers
         for i, line_id in enumerate(line_ids):
             if not isinstance(line_id, (int, float, decimal.Decimal)):
                 raise TypeError(
-                    f"line_ids[{i}] must be numeric, got {type(line_id).__name__}"
+                    format_type_error(
+                        f"line_ids[{i}]",
+                        line_id,
+                        (int, float, decimal.Decimal),
+                    )
                 )
             if isinstance(line_id, (float, decimal.Decimal)):
                 line_ids[i] = int(line_id)
@@ -306,7 +269,11 @@ class ReceiptSection:
                     )
                 else:
                     raise TypeError(
-                        f"spatial_patterns[{i}] must be SpatialPattern or dict, got {type(pattern).__name__}"
+                        format_type_error(
+                            f"spatial_patterns[{i}]",
+                            pattern,
+                            (SpatialPattern, dict),
+                        )
                     )
 
         for i, pattern in enumerate(content_patterns):
@@ -319,7 +286,11 @@ class ReceiptSection:
                     )
                 else:
                     raise TypeError(
-                        f"content_patterns[{i}] must be ContentPattern or dict, got {type(pattern).__name__}"
+                        format_type_error(
+                            f"content_patterns[{i}]",
+                            pattern,
+                            (ContentPattern, dict),
+                        )
                     )
 
         self.name = name
@@ -374,8 +345,7 @@ class ReceiptSection:
             TypeError: If data is not a dictionary
             KeyError: If required keys are missing
         """
-        if not isinstance(data, dict):
-            raise TypeError(f"data must be dict, got {type(data).__name__}")
+        assert_type("data", data, dict)
 
         # Convert content patterns from dict to ContentPattern objects if needed
         content_patterns = []
@@ -393,7 +363,9 @@ class ReceiptSection:
                 content_patterns.append(pattern)
             else:
                 raise TypeError(
-                    f"content_pattern must be dict, str, or ContentPattern, got {type(pattern).__name__}"
+                    format_type_error(
+                        "content_pattern", pattern, (dict, str, ContentPattern)
+                    )
                 )
 
         # Convert spatial patterns from dict to SpatialPattern objects if needed
@@ -412,7 +384,9 @@ class ReceiptSection:
                 spatial_patterns.append(pattern)
             else:
                 raise TypeError(
-                    f"spatial_pattern must be dict, str, or SpatialPattern, got {type(pattern).__name__}"
+                    format_type_error(
+                        "spatial_pattern", pattern, (dict, str, SpatialPattern)
+                    )
                 )
 
         # Ensure line_ids are integers
@@ -424,9 +398,7 @@ class ReceiptSection:
                 try:
                     line_ids.append(int(line_id))
                 except (ValueError, TypeError):
-                    raise TypeError(
-                        f"line_id must be numeric, got {type(line_id).__name__}"
-                    )
+                    raise TypeError(format_type_error("line_id", line_id, int))
 
         # Handle start_line and end_line
         start_line = data.get("start_line")
@@ -521,7 +493,11 @@ class ReceiptStructureAnalysis:
         # Type checking for each parameter
         if not isinstance(receipt_id, (int, float, decimal.Decimal, str)):
             raise TypeError(
-                f"receipt_id must be numeric or string, got {type(receipt_id).__name__}"
+                format_type_error(
+                    "receipt_id",
+                    receipt_id,
+                    (int, float, decimal.Decimal, str),
+                )
             )
         try:
             receipt_id = int(receipt_id)
@@ -530,54 +506,22 @@ class ReceiptStructureAnalysis:
                 f"receipt_id must be convertible to int, got {receipt_id}"
             )
 
-        if not isinstance(image_id, str):
-            raise TypeError(
-                f"image_id must be str, got {type(image_id).__name__}"
-            )
-        if not isinstance(sections, list):
-            raise TypeError(
-                f"sections must be list, got {type(sections).__name__}"
-            )
-        if not isinstance(overall_reasoning, str):
-            raise TypeError(
-                f"overall_reasoning must be str, got {type(overall_reasoning).__name__}"
-            )
-        if not isinstance(version, str):
-            raise TypeError(
-                f"version must be str, got {type(version).__name__}"
-            )
-        if metadata is not None and not isinstance(metadata, dict):
-            raise TypeError(
-                f"metadata must be dict or None, got {type(metadata).__name__}"
-            )
-        if timestamp_added is not None and not isinstance(
-            timestamp_added, datetime
-        ):
-            raise TypeError(
-                f"timestamp_added must be datetime or None, got {type(timestamp_added).__name__}"
-            )
-        if timestamp_updated is not None and not isinstance(
-            timestamp_updated, datetime
-        ):
-            raise TypeError(
-                f"timestamp_updated must be datetime or None, got {type(timestamp_updated).__name__}"
-            )
-        if processing_metrics is not None and not isinstance(
-            processing_metrics, dict
-        ):
-            raise TypeError(
-                f"processing_metrics must be dict or None, got {type(processing_metrics).__name__}"
-            )
-        if source_info is not None and not isinstance(source_info, dict):
-            raise TypeError(
-                f"source_info must be dict or None, got {type(source_info).__name__}"
-            )
-        if processing_history is not None and not isinstance(
-            processing_history, list
-        ):
-            raise TypeError(
-                f"processing_history must be list or None, got {type(processing_history).__name__}"
-            )
+        assert_type("image_id", image_id, str)
+        assert_type("sections", sections, list)
+        assert_type("overall_reasoning", overall_reasoning, str)
+        assert_type("version", version, str)
+        if metadata is not None:
+            assert_type("metadata", metadata, dict)
+        if timestamp_added is not None:
+            assert_type("timestamp_added", timestamp_added, datetime)
+        if timestamp_updated is not None:
+            assert_type("timestamp_updated", timestamp_updated, datetime)
+        if processing_metrics is not None:
+            assert_type("processing_metrics", processing_metrics, dict)
+        if source_info is not None:
+            assert_type("source_info", source_info, dict)
+        if processing_history is not None:
+            assert_type("processing_history", processing_history, list)
 
         # Validate each section is a ReceiptSection or can be converted to one
         validated_sections = []
@@ -588,7 +532,9 @@ class ReceiptStructureAnalysis:
                 validated_sections.append(ReceiptSection.from_dict(section))
             else:
                 raise TypeError(
-                    f"sections[{i}] must be ReceiptSection or dict, got {type(section).__name__}"
+                    format_type_error(
+                        f"sections[{i}]", section, (ReceiptSection, dict)
+                    )
                 )
 
         self.receipt_id = receipt_id

--- a/receipt_dynamo/receipt_dynamo/entities/receipt_word_tag.py
+++ b/receipt_dynamo/receipt_dynamo/entities/receipt_word_tag.py
@@ -1,7 +1,12 @@
 from datetime import datetime
 from typing import Generator, Optional, Tuple, Union
 
-from receipt_dynamo.entities.util import _repr_str, assert_valid_uuid
+from receipt_dynamo.entities.util import (
+    _repr_str,
+    assert_valid_uuid,
+    assert_type,
+    format_type_error,
+)
 
 
 class ReceiptWordTag:
@@ -72,28 +77,24 @@ class ReceiptWordTag:
         assert_valid_uuid(image_id)
         self.image_id = image_id
 
-        if not isinstance(receipt_id, int):
-            raise ValueError("receipt_id must be an integer")
+        assert_type("receipt_id", receipt_id, int, ValueError)
         if receipt_id < 0:
             raise ValueError("receipt_id must be positive")
         self.receipt_id = receipt_id
 
-        if not isinstance(line_id, int):
-            raise ValueError("line_id must be an integer")
+        assert_type("line_id", line_id, int, ValueError)
         if line_id < 0:
             raise ValueError("line_id must be positive")
         self.line_id = line_id
 
-        if not isinstance(word_id, int):
-            raise ValueError("word_id must be an integer")
+        assert_type("word_id", word_id, int, ValueError)
         if word_id < 0:
             raise ValueError("word_id must be positive")
         self.word_id = word_id
 
         if not tag:
             raise ValueError("tag must not be empty")
-        if not isinstance(tag, str):
-            raise ValueError("tag must be a string")
+        assert_type("tag", tag, str, ValueError)
         if len(tag) > 40:
             raise ValueError("tag must not exceed 40 characters")
         if tag.startswith("_"):
@@ -106,7 +107,7 @@ class ReceiptWordTag:
             self.timestamp_added = timestamp_added
         else:
             raise ValueError(
-                "timestamp_added must be a datetime object or a string"
+                format_type_error("timestamp_added", timestamp_added, (datetime, str))
             )
 
         if validated not in (True, False, None):
@@ -117,24 +118,25 @@ class ReceiptWordTag:
             # Convert datetime to an ISO-formatted string.
             self.timestamp_validated = timestamp_validated.isoformat()
         elif not isinstance(timestamp_validated, (str, type(None))):
-            # Raise an error if it's neither a string nor None.
             raise ValueError(
-                "timestamp_validated must be a datetime object, a string, or None"
+                format_type_error(
+                    "timestamp_validated", timestamp_validated, (datetime, str, type(None))
+                )
             )
         else:
             # If it's already a string or None, just assign it.
             self.timestamp_validated = timestamp_validated
 
-        if gpt_confidence is not None and not isinstance(gpt_confidence, int):
-            raise ValueError("gpt_confidence must be an integer")
+        if gpt_confidence is not None:
+            assert_type("gpt_confidence", gpt_confidence, int, ValueError)
         self.gpt_confidence = gpt_confidence
 
-        if flag is not None and not isinstance(flag, str):
-            raise ValueError("flag must be a string")
+        if flag is not None:
+            assert_type("flag", flag, str, ValueError)
         self.flag = flag
 
-        if revised_tag is not None and not isinstance(revised_tag, str):
-            raise ValueError("revised_tag must be a string")
+        if revised_tag is not None:
+            assert_type("revised_tag", revised_tag, str, ValueError)
         self.revised_tag = revised_tag
 
         if human_validated not in (True, False, None):
@@ -147,7 +149,11 @@ class ReceiptWordTag:
             )
         elif not isinstance(timestamp_human_validated, (str, type(None))):
             raise ValueError(
-                "timestamp_human_validated must be a datetime object, a string, or None"
+                format_type_error(
+                    "timestamp_human_validated",
+                    timestamp_human_validated,
+                    (datetime, str, type(None)),
+                )
             )
         else:
             self.timestamp_human_validated = timestamp_human_validated

--- a/receipt_dynamo/receipt_dynamo/entities/util.py
+++ b/receipt_dynamo/receipt_dynamo/entities/util.py
@@ -1,5 +1,6 @@
 import re
 from decimal import ROUND_HALF_UP, Decimal
+from typing import Any, Iterable
 
 
 def _repr_str(value: str) -> str:
@@ -8,6 +9,30 @@ def _repr_str(value: str) -> str:
     is None.
     """
     return "None" if value is None else f"'{value}'"
+
+
+def format_type_error(
+    name: str, value: Any, expected: Iterable[type] | type
+) -> str:
+    """Return a standardized type error message."""
+    if isinstance(expected, Iterable) and not isinstance(expected, type):
+        expected_names = ", ".join(t.__name__ for t in expected)
+    else:
+        expected_names = (
+            expected.__name__ if isinstance(expected, type) else str(expected)
+        )
+    return f"{name} must be {expected_names}, got {type(value).__name__}"
+
+
+def assert_type(
+    name: str,
+    value: Any,
+    expected: Iterable[type] | type,
+    exc_type: type[Exception] = TypeError,
+) -> None:
+    """Raise an exception if ``value`` is not an instance of ``expected``."""
+    if not isinstance(value, expected):
+        raise exc_type(format_type_error(name, value, expected))
 
 
 # Regex for UUID version 4 (case-insensitive, enforcing the '4' and the

--- a/receipt_dynamo/receipt_dynamo/entities/word.py
+++ b/receipt_dynamo/receipt_dynamo/entities/word.py
@@ -8,6 +8,8 @@ from receipt_dynamo.entities.util import (
     assert_valid_bounding_box,
     assert_valid_point,
     assert_valid_uuid,
+    assert_type,
+    format_type_error,
     compute_histogram,
     shear_point,
 )
@@ -80,20 +82,17 @@ class Word:
         assert_valid_uuid(image_id)
         self.image_id = image_id
 
-        if not isinstance(line_id, int):
-            raise ValueError("line_id must be an integer")
+        assert_type("line_id", line_id, int, ValueError)
         if line_id < 0:
             raise ValueError("line_id must be positive")
         self.line_id = line_id
 
-        if not isinstance(word_id, int):
-            raise ValueError("id must be an integer")
+        assert_type("word_id", word_id, int, ValueError)
         if word_id < 0:
             raise ValueError("id must be positive")
         self.word_id = word_id
 
-        if not isinstance(text, str):
-            raise ValueError("text must be a string")
+        assert_type("text", text, str, ValueError)
         self.text = text
 
         assert_valid_bounding_box(bounding_box)
@@ -111,24 +110,21 @@ class Word:
         assert_valid_point(bottom_left)
         self.bottom_left = bottom_left
 
-        if not isinstance(angle_degrees, (float, int)):
-            raise ValueError("angle_degrees must be a float or int")
+        assert_type("angle_degrees", angle_degrees, (float, int), ValueError)
         self.angle_degrees = angle_degrees
 
-        if not isinstance(angle_radians, (float, int)):
-            raise ValueError("angle_radians must be a float or int")
+        assert_type("angle_radians", angle_radians, (float, int), ValueError)
         self.angle_radians = angle_radians
 
         if isinstance(confidence, int):
             confidence = float(confidence)
-        if not isinstance(confidence, float):
-            raise ValueError("confidence must be a float")
+        assert_type("confidence", confidence, float, ValueError)
         if confidence <= 0.0 or confidence > 1.0:
             raise ValueError("confidence must be between 0 and 1")
         self.confidence = confidence
 
-        if extracted_data is not None and not isinstance(extracted_data, dict):
-            raise ValueError("extracted_data must be a dict")
+        if extracted_data is not None:
+            assert_type("extracted_data", extracted_data, dict, ValueError)
         self.extracted_data = extracted_data
 
         if histogram is None:

--- a/receipt_dynamo/tests/unit/test_batch_summary.py
+++ b/receipt_dynamo/tests/unit/test_batch_summary.py
@@ -53,7 +53,7 @@ def test_batch_summary_to_item_and_back(example_batch_summary):
 @pytest.mark.unit
 @pytest.mark.parametrize("bad_value", [123, None])
 def test_batch_summary_invalid_batch_id_type(bad_value):
-    with pytest.raises(ValueError, match="batch_id must be a string"):
+    with pytest.raises(ValueError, match="batch_id must be str, got"):
         BatchSummary(
             batch_id=bad_value,
             batch_type=BatchType.EMBEDDING.value,
@@ -68,7 +68,7 @@ def test_batch_summary_invalid_batch_id_type(bad_value):
 @pytest.mark.unit
 @pytest.mark.parametrize("bad_value", [123, None])
 def test_batch_summary_invalid_openai_batch_id_type(bad_value):
-    with pytest.raises(ValueError, match="openai_batch_id must be a string"):
+    with pytest.raises(ValueError, match="openai_batch_id must be str, got"):
         BatchSummary(
             batch_id="abc",
             batch_type=BatchType.EMBEDDING.value,
@@ -82,9 +82,7 @@ def test_batch_summary_invalid_openai_batch_id_type(bad_value):
 
 @pytest.mark.unit
 def test_batch_summary_invalid_submitted_at_type():
-    with pytest.raises(
-        ValueError, match="submitted_at must be a datetime object"
-    ):
+    with pytest.raises(ValueError, match="submitted_at must be datetime, got"):
         BatchSummary(
             batch_id="abc",
             batch_type=BatchType.EMBEDDING.value,
@@ -99,7 +97,7 @@ def test_batch_summary_invalid_submitted_at_type():
 @pytest.mark.unit
 @pytest.mark.parametrize("bad_value", [123, None])
 def test_batch_summary_invalid_result_file_id_type(bad_value):
-    with pytest.raises(ValueError, match="result_file_id must be a string"):
+    with pytest.raises(ValueError, match="result_file_id must be str, got"):
         BatchSummary(
             batch_id="abc",
             batch_type=BatchType.EMBEDDING.value,
@@ -143,7 +141,7 @@ def test_batch_summary_invalid_status():
 def test_batch_summary_status_not_string():
     with pytest.raises(
         ValueError,
-        match="status must be either a BatchStatus enum or a string; got int",
+        match="status must be BatchStatus, str, got int",
     ):
         BatchSummary(
             batch_id="abc123",

--- a/receipt_dynamo/tests/unit/test_completion_batch_result.py
+++ b/receipt_dynamo/tests/unit/test_completion_batch_result.py
@@ -78,16 +78,20 @@ def test_completion_batch_result_iter(example_completion_batch_result):
 @pytest.mark.parametrize(
     "field, bad_value, err_msg",
     [
-        ("receipt_id", "1001", "receipt_id must be an integer"),
-        ("line_id", "4", "line_id must be an integer"),
-        ("word_id", "7", "word_id must be an integer"),
-        ("original_label", 123, "original_label must be a string"),
-        ("gpt_suggested_label", 123, "gpt_suggested_label must be a string"),
-        ("status", 1.5, "status must be a string"),
+        ("receipt_id", "1001", "receipt_id must be int, got str"),
+        ("line_id", "4", "line_id must be int, got str"),
+        ("word_id", "7", "word_id must be int, got str"),
+        ("original_label", 123, "original_label must be str, got int"),
+        (
+            "gpt_suggested_label",
+            123,
+            "gpt_suggested_label must be str, NoneType, got int",
+        ),
+        ("status", 1.5, "status must be str, BatchStatus, got float"),
         (
             "validated_at",
             "not-a-datetime",
-            "validated_at must be a datetime object",
+            "validated_at must be datetime, got str",
         ),
     ],
 )

--- a/receipt_dynamo/tests/unit/test_embedding_batch_result.py
+++ b/receipt_dynamo/tests/unit/test_embedding_batch_result.py
@@ -90,13 +90,13 @@ def test_embedding_batch_result_iter(example_embedding_batch_result):
 @pytest.mark.parametrize(
     "field, value, expected_error",
     [
-        ("receipt_id", "not-an-int", "receipt_id must be an integer"),
-        ("line_id", "nope", "line_id must be an integer"),
-        ("word_id", "fail", "word_id must be an integer"),
+        ("receipt_id", "not-an-int", "receipt_id must be int, got str"),
+        ("line_id", "nope", "line_id must be int, got str"),
+        ("word_id", "fail", "word_id must be int, got str"),
         ("pinecone_id", "invalid", "pinecone_id must be in the format"),
-        ("status", 123, "status must be a string"),
-        ("text", 456, "text must be a string"),
-        ("error_message", 999, "error_message must be a string"),
+        ("status", 123, "status must be str, got int"),
+        ("text", 456, "text must be str, got int"),
+        ("error_message", 999, "error_message must be str, got int"),
     ],
 )
 def test_embedding_batch_result_invalid_field(field, value, expected_error):

--- a/receipt_dynamo/tests/unit/test_job_metric.py
+++ b/receipt_dynamo/tests/unit/test_job_metric.py
@@ -86,9 +86,7 @@ def test_job_metric_init_invalid_metric_name():
             0.15,
         )
 
-    with pytest.raises(
-        ValueError, match="metric_name must be a non-empty string"
-    ):
+    with pytest.raises(ValueError, match="metric_name must be str, got int"):
         JobMetric(
             "3f52804b-2fad-4e00-92c8-b593da3a8ed3",
             123,  # Invalid: not a string
@@ -116,7 +114,7 @@ def test_job_metric_init_invalid_value():
 def test_job_metric_init_invalid_timestamp():
     """Test the JobMetric constructor with invalid timestamp."""
     with pytest.raises(
-        ValueError, match="timestamp must be a datetime object or a string"
+        ValueError, match="timestamp must be datetime, str, got"
     ):
         JobMetric(
             "3f52804b-2fad-4e00-92c8-b593da3a8ed3",

--- a/receipt_dynamo/tests/unit/test_label_metadata.py
+++ b/receipt_dynamo/tests/unit/test_label_metadata.py
@@ -26,13 +26,13 @@ def example_label_metadata():
 @pytest.mark.parametrize(
     "field,value,message",
     [
-        ("label", 123, "label must be a string"),
-        ("status", 456, "status must be a string"),
-        ("aliases", "not-a-list", "aliases must be a list"),
-        ("description", 789, "description must be a string"),
-        ("schema_version", "1", "schema_version must be an integer"),
-        ("last_updated", "now", "last_updated must be a datetime object"),
-        ("label_target", 123, "label_target must be a string or None"),
+        ("label", 123, "label must be str, got int"),
+        ("status", 456, "status must be str, got int"),
+        ("aliases", "not-a-list", "aliases must be list, got str"),
+        ("description", 789, "description must be str, got int"),
+        ("schema_version", "1", "schema_version must be int, got str"),
+        ("last_updated", "now", "last_updated must be datetime, got str"),
+        ("label_target", 123, "label_target must be str, got int"),
         (
             "receipt_refs",
             [("img", "not-an-int")],

--- a/receipt_dynamo/tests/unit/test_word.py
+++ b/receipt_dynamo/tests/unit/test_word.py
@@ -107,7 +107,7 @@ def test_word_init_invalid_uuid():
 @pytest.mark.unit
 def test_word_init_invalid_line_id():
     """Test that Word raises a ValueError if the line_id is not an integer"""
-    with pytest.raises(ValueError, match="line_id must be an integer"):
+    with pytest.raises(ValueError, match="line_id must be int, got"):
         Word(
             "3f52804b-2fad-4e00-92c8-b593da3a8ed3",
             "bad-line-id",
@@ -142,7 +142,7 @@ def test_word_init_invalid_line_id():
 @pytest.mark.unit
 def test_word_init_invalid_id():
     """Test that Word raises a ValueError if the id is not an integer"""
-    with pytest.raises(ValueError, match="id must be an integer"):
+    with pytest.raises(ValueError, match="word_id must be int, got"):
         Word(
             "3f52804b-2fad-4e00-92c8-b593da3a8ed3",
             2,
@@ -177,7 +177,7 @@ def test_word_init_invalid_id():
 @pytest.mark.unit
 def test_word_init_invalid_text():
     """Test that Word raises a ValueError if the text is not a string"""
-    with pytest.raises(ValueError, match="text must be a string"):
+    with pytest.raises(ValueError, match="text must be str, got"):
         Word(
             "3f52804b-2fad-4e00-92c8-b593da3a8ed3",
             2,
@@ -270,7 +270,7 @@ def test_word_init_invalid_corners():
 def test_word_init_invalid_angle():
     """Test that Word raises a ValueError if the angle is not a float"""
     with pytest.raises(
-        ValueError, match="angle_degrees must be a float or int"
+        ValueError, match="angle_degrees must be float, int, got"
     ):
         Word(
             "3f52804b-2fad-4e00-92c8-b593da3a8ed3",
@@ -287,7 +287,7 @@ def test_word_init_invalid_angle():
             0.90,
         )
     with pytest.raises(
-        ValueError, match="angle_radians must be a float or int"
+        ValueError, match="angle_radians must be float, int, got"
     ):
         Word(
             "3f52804b-2fad-4e00-92c8-b593da3a8ed3",
@@ -308,7 +308,7 @@ def test_word_init_invalid_angle():
 @pytest.mark.unit
 def test_word_init_invalid_confidence():
     """Test that Word raises a ValueError if the confidence is not a float"""
-    with pytest.raises(ValueError, match="confidence must be a float"):
+    with pytest.raises(ValueError, match="confidence must be float, got"):
         Word(
             "3f52804b-2fad-4e00-92c8-b593da3a8ed3",
             2,
@@ -358,7 +358,7 @@ def test_word_init_invalid_confidence():
 @pytest.mark.unit
 def test_word_init_invalid_extracted_data():
     """Test that Word raises a ValueError if the extracted_data is not a dict"""
-    with pytest.raises(ValueError, match="extracted_data must be a dict"):
+    with pytest.raises(ValueError, match="extracted_data must be dict, got"):
         Word(
             image_id="3f52804b-2fad-4e00-92c8-b593da3a8ed3",
             line_id=2,

--- a/receipt_dynamo/tests/unit/test_word_tag.py
+++ b/receipt_dynamo/tests/unit/test_word_tag.py
@@ -36,7 +36,7 @@ def test_word_tag_init_invalid_image_id():
 @pytest.mark.unit
 def test_word_tag_init_invalid_line_id():
     """Test that WordTag raises ValueError if line_id is invalid."""
-    with pytest.raises(ValueError, match="line_id must be an integer"):
+    with pytest.raises(ValueError, match="line_id must be int, got"):
         WordTag(
             "3f52804b-2fad-4e00-92c8-b593da3a8ed3",
             "2",
@@ -57,7 +57,7 @@ def test_word_tag_init_invalid_line_id():
 @pytest.mark.unit
 def test_word_tag_init_invalid_word_id():
     """Test that WordTag raises ValueError if word_id is invalid."""
-    with pytest.raises(ValueError, match="word_id must be an integer"):
+    with pytest.raises(ValueError, match="word_id must be int, got"):
         WordTag(
             "3f52804b-2fad-4e00-92c8-b593da3a8ed3",
             2,
@@ -86,7 +86,7 @@ def test_word_tag_init_invalid_tag():
             "",
             "2021-01-01T00:00:00",
         )
-    with pytest.raises(ValueError, match="tag must be a string"):
+    with pytest.raises(ValueError, match="tag must be str, got"):
         WordTag(
             "3f52804b-2fad-4e00-92c8-b593da3a8ed3",
             2,
@@ -120,7 +120,7 @@ def test_word_tag_init_invalid_timestamp_added():
     """Test that WordTag raises ValueError if timestamp_added is invalid."""
     with pytest.raises(
         ValueError,
-        match="timestamp_added must be a datetime object or a string",
+        match="timestamp_added must be datetime, str, got",
     ):
         WordTag(
             "3f52804b-2fad-4e00-92c8-b593da3a8ed3", 2, 3, "example", 1234567890


### PR DESCRIPTION
## Summary
- add `assert_type` and `format_type_error` usage in more entity classes
- update tests for unified error text

## Testing
- `python3 -m pytest -q` *(fails: ModuleNotFoundError)*