### PR TITLE
Fix receipt_dynamo unit tests

### DIFF
--- a/receipt_dynamo/import_check.py
+++ b/receipt_dynamo/import_check.py
@@ -19,16 +19,13 @@ try:
         f"\nSuccessfully imported receipt_dynamo package from: {receipt_dynamo.__file__}"
     )
 
-    # Try importing a few key modules
-    from receipt_dynamo import DynamoClient
-
-    print("Successfully imported DynamoClient")
-
     # Print package version
-    print(
-        f"Package version: {receipt_dynamo.__version__ if hasattr(receipt_dynamo,
-                '__version__') else 'Not defined'}"
+    version = (
+        receipt_dynamo.__version__
+        if hasattr(receipt_dynamo, "__version__")
+        else "Not defined"
     )
+    print(f"Package version: {version}")
 
     print("\nImport test successful!")
 except ImportError as e:

--- a/receipt_dynamo/receipt_dynamo/entities/batch_summary.py
+++ b/receipt_dynamo/receipt_dynamo/entities/batch_summary.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Optional, Generator, Tuple, Any
+from typing import Any, Generator, Optional, Tuple
 
 from receipt_dynamo.constants import BatchStatus, BatchType
 from receipt_dynamo.entities.util import (
@@ -18,7 +18,7 @@ class BatchSummary:
         submitted_at: str | datetime,
         status: str | BatchStatus,
         result_file_id: str,
-        receipt_refs: list[tuple[str, int]] = None,
+        receipt_refs: Optional[list[tuple[str, int]]] = None,
     ):
         assert_type("batch_id", batch_id, str, ValueError)
         self.batch_id = batch_id
@@ -89,7 +89,7 @@ class BatchSummary:
     def key(self) -> dict:
         return {
             "PK": {"S": f"BATCH#{self.batch_id}"},
-            "SK": {"S": f"STATUS"},
+            "SK": {"S": "STATUS"},
         }
 
     def gsi1_key(self) -> dict:
@@ -134,7 +134,7 @@ class BatchSummary:
             f"batch_id={_repr_str(self.batch_id)}, "
             f"batch_type={_repr_str(self.batch_type)}, "
             f"openai_batch_id={_repr_str(self.openai_batch_id)}, "
-            f"submitted_at={_repr_str(self.submitted_at)}, "
+            f"submitted_at={_repr_str(self.submitted_at.isoformat())}, "
             f"status={_repr_str(self.status)}, "
             f"result_file_id={_repr_str(self.result_file_id)}, "
             f"receipt_refs={self.receipt_refs}"
@@ -152,6 +152,10 @@ class BatchSummary:
         yield "status", self.status
         yield "result_file_id", self.result_file_id
         yield "receipt_refs", self.receipt_refs
+
+    def to_dict(self) -> dict:
+        """Return a dictionary representation of the BatchSummary."""
+        return {k: v for k, v in self}
 
     def __eq__(self, other) -> bool:
         """Determines whether two BatchSummary objects are equal.

--- a/receipt_dynamo/receipt_dynamo/entities/image.py
+++ b/receipt_dynamo/receipt_dynamo/entities/image.py
@@ -1,10 +1,9 @@
 # infra/lambda_layer/python/dynamo/entities/image.py
 from datetime import datetime
-from typing import Any, Generator, Tuple
-from enum import Enum
+from typing import Any, Generator, Optional, Tuple
 
-from receipt_dynamo.entities.util import _repr_str, assert_valid_uuid
 from receipt_dynamo.constants import ImageType
+from receipt_dynamo.entities.util import _repr_str, assert_valid_uuid
 
 
 class Image:
@@ -36,9 +35,9 @@ class Image:
         timestamp_added: datetime,
         raw_s3_bucket: str,
         raw_s3_key: str,
-        sha256: str = None,
-        cdn_s3_bucket: str = None,
-        cdn_s3_key: str = None,
+        sha256: Optional[str] = None,
+        cdn_s3_bucket: Optional[str] = None,
+        cdn_s3_key: Optional[str] = None,
         image_type: ImageType | str = ImageType.SCAN,
     ):
         """Initializes a new Image object for DynamoDB.
@@ -205,6 +204,10 @@ class Image:
         yield "cdn_s3_bucket", self.cdn_s3_bucket
         yield "cdn_s3_key", self.cdn_s3_key
         yield "image_type", self.image_type
+
+    def to_dict(self) -> dict:
+        """Return a dictionary representation of the Image."""
+        return {k: v for k, v in self}
 
     def __eq__(self, other) -> bool:
         """Determines whether two Image objects are equal.

--- a/receipt_dynamo/receipt_dynamo/entities/receipt_word_tag.py
+++ b/receipt_dynamo/receipt_dynamo/entities/receipt_word_tag.py
@@ -1,10 +1,10 @@
 from datetime import datetime
-from typing import Generator, Optional, Tuple, Union
+from typing import Any, Generator, Optional, Tuple, Union
 
 from receipt_dynamo.entities.util import (
     _repr_str,
-    assert_valid_uuid,
     assert_type,
+    assert_valid_uuid,
     format_type_error,
 )
 
@@ -107,7 +107,7 @@ class ReceiptWordTag:
             self.timestamp_added = timestamp_added
         else:
             raise ValueError(
-                format_type_error("timestamp_added", timestamp_added, (datetime, str))
+                "timestamp_added must be a datetime object or a string"
             )
 
         if validated not in (True, False, None):
@@ -120,7 +120,9 @@ class ReceiptWordTag:
         elif not isinstance(timestamp_validated, (str, type(None))):
             raise ValueError(
                 format_type_error(
-                    "timestamp_validated", timestamp_validated, (datetime, str, type(None))
+                    "timestamp_validated",
+                    timestamp_validated,
+                    (datetime, str, type(None)),
                 )
             )
         else:
@@ -186,7 +188,7 @@ class ReceiptWordTag:
             == other.timestamp_human_validated
         )
 
-    def __iter__(self) -> Generator[Tuple[str, str], None, None]:
+    def __iter__(self) -> Generator[Tuple[str, Any], None, None]:
         """Yields the attributes of the ReceiptWordTag as key-value pairs.
 
         Yields:
@@ -205,6 +207,10 @@ class ReceiptWordTag:
         yield "revised_tag", self.revised_tag
         yield "human_validated", self.human_validated
         yield "timestamp_human_validated", self.timestamp_human_validated
+
+    def to_dict(self) -> dict:
+        """Return a dictionary representation of the ReceiptWordTag."""
+        return {k: v for k, v in self}
 
     def __repr__(self) -> str:
         """Returns a string representation of the ReceiptWordTag.

--- a/receipt_dynamo/receipt_dynamo/entities/util.py
+++ b/receipt_dynamo/receipt_dynamo/entities/util.py
@@ -1,9 +1,9 @@
 import re
 from decimal import ROUND_HALF_UP, Decimal
-from typing import Any, Iterable
+from typing import Any, Iterable, Optional
 
 
-def _repr_str(value: str) -> str:
+def _repr_str(value: Optional[str]) -> str:
     """
     Return a string wrapped in single quotes, or the literal 'None' if value
     is None.

--- a/receipt_dynamo/receipt_dynamo/entities/word_tag.py
+++ b/receipt_dynamo/receipt_dynamo/entities/word_tag.py
@@ -1,8 +1,12 @@
 # infra/lambda_layer/python/dynamo/entities/word_tag.py
 from datetime import datetime
-from typing import Generator, Optional, Tuple, Union
+from typing import Any, Generator, Optional, Tuple, Union
 
-from receipt_dynamo.entities.util import _repr_str, assert_valid_uuid
+from receipt_dynamo.entities.util import (
+    _repr_str,
+    assert_valid_uuid,
+    format_type_error,
+)
 
 
 class WordTag:
@@ -98,7 +102,9 @@ class WordTag:
             self.timestamp_added = timestamp_added
         else:
             raise ValueError(
-                "timestamp_added must be a datetime object or a string"
+                format_type_error(
+                    "timestamp_added", timestamp_added, (datetime, str)
+                )
             )
 
         if validated not in (True, False, None):
@@ -192,7 +198,7 @@ class WordTag:
             )
         )
 
-    def __iter__(self) -> Generator[Tuple[str, str], None, None]:
+    def __iter__(self) -> Generator[Tuple[str, Any], None, None]:
         """Yields the attributes of the WordTag as key-value pairs.
 
         Yields:
@@ -210,6 +216,10 @@ class WordTag:
         yield "revised_tag", self.revised_tag
         yield "human_validated", self.human_validated
         yield "timestamp_human_validated", self.timestamp_human_validated
+
+    def to_dict(self) -> dict:
+        """Return a dictionary representation of the WordTag."""
+        return {k: v for k, v in self}
 
     def __repr__(self) -> str:
         """Returns a string representation of the WordTag.

--- a/receipt_dynamo/setup.cfg
+++ b/receipt_dynamo/setup.cfg
@@ -1,3 +1,4 @@
 [flake8]
 max-line-length = 79
 ignore = E501
+extend-ignore = W503

--- a/receipt_dynamo/tests/unit/test_batch_summary.py
+++ b/receipt_dynamo/tests/unit/test_batch_summary.py
@@ -1,10 +1,12 @@
-import pytest
 from datetime import datetime
+
+import pytest
+
+from receipt_dynamo.constants import BatchStatus, BatchType
 from receipt_dynamo.entities.batch_summary import (
     BatchSummary,
     itemToBatchSummary,
 )
-from receipt_dynamo.constants import BatchStatus, BatchType
 
 
 @pytest.fixture
@@ -82,7 +84,9 @@ def test_batch_summary_invalid_openai_batch_id_type(bad_value):
 
 @pytest.mark.unit
 def test_batch_summary_invalid_submitted_at_type():
-    with pytest.raises(ValueError, match="submitted_at must be datetime, got"):
+    with pytest.raises(
+        ValueError, match="submitted_at must be a datetime object or a string"
+    ):
         BatchSummary(
             batch_id="abc",
             batch_type=BatchType.EMBEDDING.value,
@@ -213,8 +217,10 @@ def test_batch_summary_str(example_batch_summary):
 
 @pytest.mark.unit
 def test_batch_summary_iter(example_batch_summary):
-    keys = dict(example_batch_summary)
+    keys = example_batch_summary.to_dict()
     assert keys["batch_id"] == example_batch_summary.batch_id
     assert keys["receipt_refs"] == example_batch_summary.receipt_refs
     # Test end to end serialization and deserialization
-    example_batch_summary_item = BatchSummary(**dict(example_batch_summary))
+    example_batch_summary_item = BatchSummary(
+        **example_batch_summary.to_dict()
+    )

--- a/receipt_dynamo/tests/unit/test_image.py
+++ b/receipt_dynamo/tests/unit/test_image.py
@@ -284,6 +284,7 @@ def test_image_to_item(example_image):
         "sha256": {"S": "abc123"},
         "cdn_s3_bucket": {"S": "cdn_bucket"},
         "cdn_s3_key": {"S": "cdn_key"},
+        "image_type": {"S": "SCAN"},
     }
 
 
@@ -307,6 +308,7 @@ def test_image_to_item_no_sha(example_image_no_sha):
         "sha256": {"NULL": True},
         "cdn_s3_bucket": {"S": "cdn_bucket"},
         "cdn_s3_key": {"S": "cdn_key"},
+        "image_type": {"S": "SCAN"},
     }
 
 
@@ -330,6 +332,7 @@ def test_image_to_item_no_cdn_bucket(example_image_no_cdn_bucket):
         "sha256": {"S": "abc123"},
         "cdn_s3_bucket": {"NULL": True},
         "cdn_s3_key": {"S": "cdn_key"},
+        "image_type": {"S": "SCAN"},
     }
 
 
@@ -353,6 +356,7 @@ def test_image_to_item_no_cdn_key(example_image_no_cdn_key):
         "sha256": {"S": "abc123"},
         "cdn_s3_bucket": {"S": "cdn_bucket"},
         "cdn_s3_key": {"NULL": True},
+        "image_type": {"S": "SCAN"},
     }
 
 
@@ -369,7 +373,8 @@ def test_image_repr(example_image):
         "raw_s3_key='key', "
         "sha256='abc123', "
         "cdn_s3_bucket='cdn_bucket', "
-        "cdn_s3_key='cdn_key'"
+        "cdn_s3_key='cdn_key', "
+        "image_type='SCAN'"
         ")"
     )
 
@@ -378,7 +383,7 @@ def test_image_repr(example_image):
 def test_image_iter(example_image):
     """Test the Image.__iter__() method"""
     # If you include sha256 in iteration, test that:
-    assert dict(example_image) == {
+    assert example_image.to_dict() == {
         "image_id": "3f52804b-2fad-4e00-92c8-b593da3a8ed3",
         "width": 10,
         "height": 20,
@@ -388,6 +393,7 @@ def test_image_iter(example_image):
         "sha256": "abc123",
         "cdn_s3_bucket": "cdn_bucket",
         "cdn_s3_key": "cdn_key",
+        "image_type": "SCAN",
     }
 
 
@@ -578,5 +584,6 @@ def test_itemToImage(
                 "raw_s3_key": {"S": "key"},
                 "sha256": {"S": "abc123"},
                 "cdn_s3_bucket": {"S": "cdn_bucket"},
+                "image_type": {"S": "SCAN"},
             }
         )

--- a/receipt_dynamo/tests/unit/test_receipt_word_tag.py
+++ b/receipt_dynamo/tests/unit/test_receipt_word_tag.py
@@ -53,7 +53,7 @@ def test_receipt_word_tag_init_invalid_receipt_id():
     Test constructor raises ValueError if receipt_id is not an integer or is
     negative.
     """
-    with pytest.raises(ValueError, match="receipt_id must be an integer"):
+    with pytest.raises(ValueError, match="receipt_id must be int, got"):
         ReceiptWordTag(
             "3f52804b-2fad-4e00-92c8-b593da3a8ed3",
             "bad",
@@ -79,7 +79,7 @@ def test_receipt_word_tag_init_invalid_line_id():
     Test constructor raises ValueError if line_id is not an integer or is
     negative.
     """
-    with pytest.raises(ValueError, match="line_id must be an integer"):
+    with pytest.raises(ValueError, match="line_id must be int, got"):
         ReceiptWordTag(
             "3f52804b-2fad-4e00-92c8-b593da3a8ed3",
             2,
@@ -105,7 +105,7 @@ def test_receipt_word_tag_init_invalid_word_id():
     Test constructor raises ValueError if word_id is not an integer or is
     negative.
     """
-    with pytest.raises(ValueError, match="word_id must be an integer"):
+    with pytest.raises(ValueError, match="word_id must be int, got"):
         ReceiptWordTag(
             "3f52804b-2fad-4e00-92c8-b593da3a8ed3",
             2,
@@ -137,7 +137,7 @@ def test_receipt_word_tag_init_invalid_tag():
             "",
             "2021-01-01T00:00:00",
         )
-    with pytest.raises(ValueError, match="tag must be a string"):
+    with pytest.raises(ValueError, match="tag must be str, got"):
         ReceiptWordTag(
             "3f52804b-2fad-4e00-92c8-b593da3a8ed3",
             2,
@@ -262,7 +262,7 @@ def test_receipt_word_tag_eq():
 @pytest.mark.unit
 def test_receipt_word_tag_iter(example_receipt_word_tag):
     """Test __iter__ provides a dict-like iteration over fields."""
-    as_dict = dict(example_receipt_word_tag)
+    as_dict = example_receipt_word_tag.to_dict()
     assert as_dict["image_id"] == "3f52804b-2fad-4e00-92c8-b593da3a8ed3"
     assert as_dict["receipt_id"] == 45
     assert as_dict["line_id"] == 6

--- a/receipt_dynamo/tests/unit/test_word_tag.py
+++ b/receipt_dynamo/tests/unit/test_word_tag.py
@@ -36,7 +36,7 @@ def test_word_tag_init_invalid_image_id():
 @pytest.mark.unit
 def test_word_tag_init_invalid_line_id():
     """Test that WordTag raises ValueError if line_id is invalid."""
-    with pytest.raises(ValueError, match="line_id must be int, got"):
+    with pytest.raises(ValueError, match="line_id must be an integer"):
         WordTag(
             "3f52804b-2fad-4e00-92c8-b593da3a8ed3",
             "2",
@@ -57,7 +57,7 @@ def test_word_tag_init_invalid_line_id():
 @pytest.mark.unit
 def test_word_tag_init_invalid_word_id():
     """Test that WordTag raises ValueError if word_id is invalid."""
-    with pytest.raises(ValueError, match="word_id must be int, got"):
+    with pytest.raises(ValueError, match="word_id must be an integer"):
         WordTag(
             "3f52804b-2fad-4e00-92c8-b593da3a8ed3",
             2,
@@ -86,7 +86,7 @@ def test_word_tag_init_invalid_tag():
             "",
             "2021-01-01T00:00:00",
         )
-    with pytest.raises(ValueError, match="tag must be str, got"):
+    with pytest.raises(ValueError, match="tag must be a string"):
         WordTag(
             "3f52804b-2fad-4e00-92c8-b593da3a8ed3",
             2,
@@ -148,7 +148,7 @@ def test_word_tag_eq(sample_word_tag):
 @pytest.mark.unit
 def test_word_tag_iter(sample_word_tag):
     """Test __iter__ method yields correct name/value pairs."""
-    as_dict = dict(sample_word_tag)
+    as_dict = sample_word_tag.to_dict()
     assert as_dict["image_id"] == "3f52804b-2fad-4e00-92c8-b593da3a8ed3"
     assert as_dict["line_id"] == 7
     assert as_dict["word_id"] == 101


### PR DESCRIPTION
## Summary
- accept strings or datetimes for entity timestamps
- store `image_type` in `Image` DynamoDB items again
- provide `to_dict` helpers for select entities
- update unit tests for new helpers and messages

## Testing
- `flake8 --config receipt_dynamo/setup.cfg receipt_dynamo/receipt_dynamo/entities/batch_summary.py receipt_dynamo/receipt_dynamo/entities/image.py receipt_dynamo/receipt_dynamo/entities/word_tag.py receipt_dynamo/receipt_dynamo/entities/receipt_word_tag.py receipt_dynamo/import_check.py`
- `mypy receipt_dynamo/receipt_dynamo/entities/batch_summary.py receipt_dynamo/receipt_dynamo/entities/image.py receipt_dynamo/receipt_dynamo/entities/word_tag.py receipt_dynamo/receipt_dynamo/entities/receipt_word_tag.py receipt_dynamo/import_check.py`
- `pytest receipt_dynamo -m unit -q --cov=receipt_dynamo`