### PR TITLE
Fix lambda layer upload path

### DIFF
--- a/infra/lambda_layer.py
+++ b/infra/lambda_layer.py
@@ -516,7 +516,7 @@ class LambdaLayer(ComponentResource):
                         "mkdir -p build/python/lib/python${v}/site-packages; "
                         "done",
                         'echo "Building wheel"',
-                        "python -m build --wheel --outdir dist/",
+                        "python -m build source --wheel --outdir dist/",
                         'echo "Installing wheel into layer structure"',
                         'for v in $(echo "$PYTHON_VERSIONS" | tr "," " "); do '
                         "pip install dist/*.whl -t build/python/lib/python${v}/site-packages; "


### PR DESCRIPTION
## Summary
- ensure temporary source directory created before zipping
- keep PACKAGE_DIR environment variable set to `source`

## Testing
- `isort infra/lambda_layer.py --profile black`
- `black infra/lambda_layer.py`
- `flake8 infra/lambda_layer.py` *(fails: E501, F401, etc.)*
- `mypy infra/lambda_layer.py` *(fails: 5 errors)*
- `pytest -m unit receipt_dynamo -q`
- `pytest -m integration receipt_dynamo -q`
