### PR TITLE
Replace prints with pulumi logging

### DIFF
--- a/infra/fast_lambda_layer.py
+++ b/infra/fast_lambda_layer.py
@@ -24,7 +24,6 @@ import pulumi_aws as aws
 import pulumi_aws.codepipeline as codepipeline
 import pulumi_command as command
 from pulumi import ComponentResource, Output
-import json
 
 
 def _find_project_root():
@@ -130,15 +129,19 @@ class FastLambdaLayer(ComponentResource):
 
         # Show build mode and change detection info
         if self.sync_mode:
-            print(
+            pulumi.log.info(
                 f"🔄 Building layer '{self.name}' in SYNC mode (will wait for completion)"
             )
         else:
-            print(f"⚡ Layer '{self.name}' in ASYNC mode (fast pulumi up)")
+            pulumi.log.info(
+                f"⚡ Layer '{self.name}' in ASYNC mode (fast pulumi up)"
+            )
             if self.force_rebuild:
-                print(f"   🔨 Force rebuild enabled - will trigger build")
+                pulumi.log.info(
+                    "   🔨 Force rebuild enabled - will trigger build"
+                )
             else:
-                print(
+                pulumi.log.info(
                     f"   📦 Hash: {package_hash[:12]}... - will build only if changed"
                 )
 


### PR DESCRIPTION
## Summary
- replace `print()` calls with `pulumi.log.info()`/`warn()` in infra modules
- keep original messages for clarity

## Testing
- `isort --profile black infra/fast_lambda_layer.py infra/word_label_step_functions/poll_single_batch.py infra/ingestion/utils.py infra/ingestion/upload_images_to_s3.py`
- `black infra/fast_lambda_layer.py infra/word_label_step_functions/poll_single_batch.py infra/ingestion/utils.py infra/ingestion/upload_images_to_s3.py`
- `flake8 infra/fast_lambda_layer.py infra/word_label_step_functions/poll_single_batch.py infra/ingestion/utils.py infra/ingestion/upload_images_to_s3.py` *(fails: E501 and other existing issues)*
- `mypy infra/fast_lambda_layer.py infra/word_label_step_functions/poll_single_batch.py infra/ingestion/utils.py infra/ingestion/upload_images_to_s3.py` *(fails: missing stubs and attribute errors)*
- `pytest -m unit receipt_dynamo`
- `pytest -m integration receipt_dynamo`

------
https://chatgpt.com/codex/tasks/task_e_683b8b399e80832b950acce559d64e3b