### PR TITLE
Update pagination param names

### DIFF
--- a/receipt_dynamo/receipt_dynamo/data/_image.py
+++ b/receipt_dynamo/receipt_dynamo/data/_image.py
@@ -73,7 +73,7 @@ class _Image:
     deleteImages(images: list[Image]):
         Deletes multiple Image items in chunks of up to 25 items.
     listImageDetails(limit: Optional[int] = None,
-                     last_evaluated_key: Optional[Dict] = None)
+                     lastEvaluatedKey: Optional[Dict] = None)
                      -> Tuple[Dict[int, Dict[str, Union[Image, List[Receipt], List[Line]]]],
                               Optional[Dict]]:
         Lists images (via GSI) with optional pagination and returns their basic details.
@@ -531,7 +531,7 @@ class _Image:
     def listImageDetails(
         self,
         limit: Optional[int] = None,
-        last_evaluated_key: Optional[Dict] = None,
+        lastEvaluatedKey: Optional[Dict] = None,
     ) -> Tuple[
         Dict[int, Dict[str, Union[Image, List[Receipt], List[Line]]]],
         Optional[Dict],
@@ -545,7 +545,7 @@ class _Image:
         limit : int, optional
             The maximum number of images to return in this call.
             If None, all images are returned (paginating until exhausted).
-        last_evaluated_key : dict, optional
+        lastEvaluatedKey : dict, optional
             The DynamoDB key from where the next page should start (for pagination).
 
         Returns
@@ -558,7 +558,7 @@ class _Image:
                    "receipts": List[Receipt], }
             2) The LastEvaluatedKey dict if more items remain, otherwise None.
         """
-        if limit is None and last_evaluated_key is None:
+        if limit is None and lastEvaluatedKey is None:
             # CASE 1: Return *all* images
             all_items = []
             response = None
@@ -621,7 +621,7 @@ class _Image:
         images_found = 0
         lek_to_return = None
 
-        next_key = last_evaluated_key
+        next_key = lastEvaluatedKey
 
         while True:
             query_params = {

--- a/receipt_dynamo/receipt_dynamo/data/_letter.py
+++ b/receipt_dynamo/receipt_dynamo/data/_letter.py
@@ -156,7 +156,7 @@ class _Letter:
     def listLetters(
         self,
         limit: Optional[int] = None,
-        last_evaluated_key: Optional[Dict] = None,
+        lastEvaluatedKey: Optional[Dict] = None,
     ) -> Tuple[list[Letter], Optional[Dict]]:
         """Lists all letters in the database"""
         letters = []
@@ -169,8 +169,8 @@ class _Letter:
                 "ExpressionAttributeValues": {":val": {"S": "LETTER"}},
                 "ScanIndexForward": True,
             }
-            if last_evaluated_key is not None:
-                query_params["ExclusiveStartKey"] = last_evaluated_key
+            if lastEvaluatedKey is not None:
+                query_params["ExclusiveStartKey"] = lastEvaluatedKey
             if limit is not None:
                 query_params["Limit"] = limit
             response = self._client.query(**query_params)

--- a/receipt_dynamo/receipt_dynamo/data/_line.py
+++ b/receipt_dynamo/receipt_dynamo/data/_line.py
@@ -158,7 +158,7 @@ class _Line:
     def listLines(
         self,
         limit: Optional[int] = None,
-        last_evaluated_key: Optional[Dict] = None,
+        lastEvaluatedKey: Optional[Dict] = None,
     ) -> Tuple[list[Line], Optional[Dict]]:
         """Lists all lines in the database"""
         lines = []
@@ -171,8 +171,8 @@ class _Line:
                 "ExpressionAttributeValues": {":val": {"S": "LINE"}},
                 "ScanIndexForward": True,  # Sorts the results in ascending order by PK
             }
-            if last_evaluated_key is not None:
-                query_params["ExclusiveStartKey"] = last_evaluated_key
+            if lastEvaluatedKey is not None:
+                query_params["ExclusiveStartKey"] = lastEvaluatedKey
 
             if limit is not None:
                 query_params["Limit"] = limit

--- a/receipt_dynamo/receipt_dynamo/data/_receipt.py
+++ b/receipt_dynamo/receipt_dynamo/data/_receipt.py
@@ -8,12 +8,12 @@ from receipt_dynamo.entities.receipt_letter import (
     ReceiptLetter,
     itemToReceiptLetter,
 )
+from receipt_dynamo.entities.receipt_line import ReceiptLine, itemToReceiptLine
+from receipt_dynamo.entities.receipt_word import ReceiptWord, itemToReceiptWord
 from receipt_dynamo.entities.receipt_word_label import (
     ReceiptWordLabel,
     itemToReceiptWordLabel,
 )
-from receipt_dynamo.entities.receipt_line import ReceiptLine, itemToReceiptLine
-from receipt_dynamo.entities.receipt_word import ReceiptWord, itemToReceiptWord
 from receipt_dynamo.entities.receipt_word_tag import (
     ReceiptWordTag,
     itemToReceiptWordTag,
@@ -613,7 +613,7 @@ class _Receipt:
     def listReceiptDetails(
         self,
         limit: Optional[int] = None,
-        last_evaluated_key: Optional[dict] = None,
+        lastEvaluatedKey: Optional[dict] = None,
     ) -> Tuple[
         Dict[
             str,
@@ -630,7 +630,7 @@ class _Receipt:
 
         Args:
             limit (Optional[int], optional): The maximum number of receipt details to return. Defaults to None.
-            last_evaluated_key (Optional[dict], optional): The key to start the query from for pagination. Defaults to None.
+            lastEvaluatedKey (Optional[dict], optional): The key to start the query from for pagination. Defaults to None.
 
         Returns:
             Tuple[Dict[str, Dict], Optional[Dict]]: A tuple containing:
@@ -652,8 +652,8 @@ class _Receipt:
                 "ScanIndexForward": True,
             }
 
-            if last_evaluated_key is not None:
-                query_params["ExclusiveStartKey"] = last_evaluated_key
+            if lastEvaluatedKey is not None:
+                query_params["ExclusiveStartKey"] = lastEvaluatedKey
 
             payload = {}
             current_receipt = None

--- a/receipt_dynamo/tests/integration/test__image.py
+++ b/receipt_dynamo/tests/integration/test__image.py
@@ -470,10 +470,10 @@ def test_listImageDetails_pagination_uses_lastEvaluatedKey(dynamodb_table):
         images_created.append(img)
     page_1_payload, lek_1 = client.listImageDetails(limit=2)
     page_2_payload, lek_2 = client.listImageDetails(
-        limit=2, last_evaluated_key=lek_1
+        limit=2, lastEvaluatedKey=lek_1
     )
     page_3_payload, lek_3 = client.listImageDetails(
-        limit=2, last_evaluated_key=lek_2
+        limit=2, lastEvaluatedKey=lek_2
     )
 
     def extract_images(payload_dict):
@@ -613,15 +613,11 @@ def test_listImageDetails_lek_structure_and_usage(dynamodb_table):
     for key in ("PK", "SK", "GSI1PK", "GSI1SK"):
         assert key in lek_1, f"LEK dictionary should contain {key}"
 
-    payload_2, lek_2 = client.listImageDetails(
-        limit=2, last_evaluated_key=lek_1
-    )
+    payload_2, lek_2 = client.listImageDetails(limit=2, lastEvaluatedKey=lek_1)
     assert len(payload_2) == 2, "Page 2 should return the next 2 images"
     assert lek_2 is not None, "We still have a third image left"
 
-    payload_3, lek_3 = client.listImageDetails(
-        limit=2, last_evaluated_key=lek_2
-    )
+    payload_3, lek_3 = client.listImageDetails(limit=2, lastEvaluatedKey=lek_2)
     assert len(payload_3) == 1, "Page 3 should have the last remaining image"
     assert lek_3 is None, "No more pages expected"
 


### PR DESCRIPTION
## Summary
- standardize camelCase pagination parameters
- adjust integration tests for updated parameter names

## Testing
- `flake8 --config receipt_dynamo/setup.cfg receipt_dynamo/receipt_dynamo/data/_letter.py receipt_dynamo/receipt_dynamo/data/_image.py receipt_dynamo/receipt_dynamo/data/_line.py receipt_dynamo/receipt_dynamo/data/_receipt.py receipt_dynamo/tests/integration/test__image.py`
- `mypy receipt_dynamo/receipt_dynamo/data/_letter.py receipt_dynamo/receipt_dynamo/data/_image.py receipt_dynamo/receipt_dynamo/data/_line.py receipt_dynamo/receipt_dynamo/data/_receipt.py receipt_dynamo/tests/integration/test__image.py`
- `pytest -m unit receipt_dynamo`
- `pytest -m integration receipt_dynamo`

------
https://chatgpt.com/codex/tasks/task_e_68447ee75898832bad70ceb863a1a111