### PR TITLE
Fix portfolio routing with CloudFront function

### DIFF
--- a/portfolio/next.config.js
+++ b/portfolio/next.config.js
@@ -1,7 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: "export",
-  trailingSlash: true,
+  trailingSlash: false,
   images: {
     unoptimized: true,
   },


### PR DESCRIPTION
## Summary
- configure Next.js static export to omit trailing slashes
- add a CloudFront Function to rewrite clean URLs and redirect trailing slashes

## Testing
- `flake8 infra/s3_website.py`
- `mypy infra/s3_website.py --ignore-missing-imports --install-types --non-interactive` *(fails: hangs)*
- `pytest -m unit receipt_dynamo`
- `pytest -m integration receipt_dynamo` *(207 passed)*


------
https://chatgpt.com/codex/tasks/task_e_684496968930832bbe335944031a82e0