### PR TITLE
Add titles to Next.js pages

### DIFF
--- a/portfolio/pages/index.tsx
+++ b/portfolio/pages/index.tsx
@@ -1,9 +1,13 @@
 import React from "react";
+import Head from "next/head";
 import Link from "next/link";
 
 export default function Home() {
   return (
     <div className="container">
+      <Head>
+        <title>Home | Tyler Norlund</title>
+      </Head>
       <main>
         <img
           src="/face.png"

--- a/portfolio/pages/receipt.tsx
+++ b/portfolio/pages/receipt.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useCallback } from "react";
+import Head from "next/head";
 import styles from "../styles/Receipt.module.css";
 import { GetStaticProps } from "next";
 import {
@@ -190,6 +191,9 @@ export default function ReceiptPage({ uploadDiagramChars }: ReceiptPageProps) {
         transition: "background-color 0.3s ease",
       }}
     >
+      <Head>
+        <title>Receipt | Tyler Norlund</title>
+      </Head>
       {/* Upload area overlay when dragging */}
       {dragging && (
         <div

--- a/portfolio/pages/resume.tsx
+++ b/portfolio/pages/resume.tsx
@@ -1,3 +1,6 @@
+import React from "react";
+import Head from "next/head";
+
 export interface ResumeRoleProps {
   title: string;
   business?: string;
@@ -109,6 +112,9 @@ export const ResumeRole: React.FC<ResumeRoleProps> = ({
 export default function ResumePage() {
   return (
     <div className="container">
+      <Head>
+        <title>Résumé | Tyler Norlund</title>
+      </Head>
       <h1>Education</h1>
       <div className="resume-box">
         <div>


### PR DESCRIPTION
## Summary
- add missing `<title>` elements with Head to Next.js pages

## Testing
- `pytest -m unit receipt_dynamo`
- `pytest -m integration receipt_dynamo`

------
https://chatgpt.com/codex/tasks/task_e_6844b34d4000832bb3872d55a9264c2d