### PR TITLE
Fix receipt page route

### DIFF
--- a/infra/s3_website.py
+++ b/infra/s3_website.py
@@ -165,9 +165,14 @@ function handler(event) {
         };
     }
     
-    // Handle SPA routing - serve index.html for non-asset requests
+    // Handle static pages and SPA fallback
     if (!uri.includes('.') && uri !== '/' && !uri.startsWith('/assets/')) {
-        request.uri = '/index.html';
+        var staticPages = ['/receipt', '/resume'];
+        if (staticPages.indexOf(uri) > -1) {
+            request.uri = uri + '.html';
+        } else {
+            request.uri = '/index.html';
+        }
     }
     
     return request;


### PR DESCRIPTION
## Summary
- fix CloudFront SPA fallback logic so `/receipt` and `/resume` routes work

## Testing
- `flake8 infra/s3_website.py` *(fails: E501 line too long)*
- `mypy infra/s3_website.py`
- `pytest -m unit receipt_dynamo`
- `pytest -m integration receipt_dynamo`


------
https://chatgpt.com/codex/tasks/task_e_6845d63ca63c832b89890a7be0eca604