### PR TITLE
Add photo receipt bounding box visualization

### DIFF
--- a/portfolio/components/ui/Figures/PhotoReceiptBoundingBox.tsx
+++ b/portfolio/components/ui/Figures/PhotoReceiptBoundingBox.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, Fragment } from "react";
+import React, { useEffect, useState } from "react";
 
 import { api } from "../../../services/api";
 import {
@@ -7,8 +7,465 @@ import {
 } from "../../../types/api";
 import { useSpring, useTransition, animated } from "@react-spring/web";
 
+const isDevelopment = process.env.NODE_ENV === "development";
+
+// Browser format detection utilities
+const detectImageFormatSupport = (): Promise<{
+  supportsAVIF: boolean;
+  supportsWebP: boolean;
+}> => {
+  return new Promise((resolve) => {
+    const userAgent = navigator.userAgent;
+
+    // Safari version detection
+    const getSafariVersion = (): number | null => {
+      if (userAgent.includes("Chrome")) return null; // Chrome has Safari in UA, exclude it
+
+      const safariMatch = userAgent.match(/Version\/([0-9.]+).*Safari/);
+      if (safariMatch) {
+        return parseFloat(safariMatch[1]);
+      }
+      return null;
+    };
+
+    const isChrome =
+      userAgent.includes("Chrome") && userAgent.includes("Google Chrome");
+    const isFirefox = userAgent.includes("Firefox");
+    const safariVersion = getSafariVersion();
+    const isSafari = safariVersion !== null;
+
+    // WebP support detection
+    let supportsWebP = false;
+
+    if (isChrome || isFirefox) {
+      // Chrome and Firefox have excellent WebP support
+      supportsWebP = true;
+    } else if (isSafari && safariVersion && safariVersion >= 14) {
+      // Safari 14+ supports WebP (macOS Big Sur, iOS 14)
+      supportsWebP = true;
+    } else {
+      // Try canvas test as fallback
+      try {
+        const canvas = document.createElement("canvas");
+        canvas.width = 1;
+        canvas.height = 1;
+        const ctx = canvas.getContext("2d");
+        if (ctx) {
+          const webpDataUrl = canvas.toDataURL("image/webp", 0.5);
+          supportsWebP = webpDataUrl.indexOf("data:image/webp") === 0;
+        }
+      } catch (error) {
+        supportsWebP = false;
+      }
+    }
+
+    // AVIF support detection
+    const detectAVIF = (): Promise<boolean> => {
+      if (isChrome) {
+        // Chrome 85+ supports AVIF (September 2020)
+        const chromeMatch = userAgent.match(/Chrome\/([0-9]+)/);
+        if (chromeMatch && parseInt(chromeMatch[1]) >= 85) {
+          return Promise.resolve(true);
+        }
+      }
+
+      if (isFirefox) {
+        // Firefox 93+ supports AVIF (October 2021)
+        const firefoxMatch = userAgent.match(/Firefox\/([0-9]+)/);
+        if (firefoxMatch && parseInt(firefoxMatch[1]) >= 93) {
+          return Promise.resolve(true);
+        }
+      }
+
+      if (isSafari && safariVersion && safariVersion >= 16.4) {
+        // Safari 16.4+ supports AVIF (March 2023)
+        return Promise.resolve(true);
+      }
+
+      // Fallback to image test for unknown browsers or older versions
+      return new Promise<boolean>((resolveAVIF) => {
+        const img = new Image();
+        img.onload = () => resolveAVIF(true);
+        img.onerror = () => resolveAVIF(false);
+        img.src =
+          "data:image/avif;base64,AAAAIGZ0eXBhdmlmAAAAAGF2aWZtaWYxbWlhZk1BMUIAAADybWV0YQAAAAAAAAAoaGRscgAAAAAAAAAAcGljdAAAAAAAAAAAAAAAAGxpYmF2aWYAAAAADnBpdG0AAAAAAAEAAAAeaWxvYwAAAABEAAABAAEAAAABAAABGgAAAB0AAAAoaWluZgAAAAAAAQAAABppbmZlAgAAAAABAABhdjAxQ29sb3IAAAAAamlwcnAAAABLaXBjbwAAABRpc3BlAAAAAAAAAAEAAAABAAAAEHBpeGkAAAAAAwgICAAAAAxhdjFDgQ0MAAAAABNjb2xybmNseAACAAIAAYAAAAAXaXBtYQAAAAAAAAABAAEEAQKDBAAAACVtZGF0EgAKCBgABogQEAwgMg8f8D///8WfhwB8+ErK42A=";
+      });
+    };
+
+    detectAVIF().then((supportsAVIF) => {
+      resolve({ supportsAVIF, supportsWebP });
+    });
+  });
+};
+
+// Get the best available image URL based on browser support and available formats
+const getBestImageUrl = (
+  image: ImageType,
+  formatSupport: { supportsAVIF: boolean; supportsWebP: boolean }
+): string => {
+  const baseUrl = isDevelopment
+    ? "https://dev.tylernorlund.com"
+    : "https://www.tylernorlund.com";
+
+  // Try AVIF first (best compression)
+  if (formatSupport.supportsAVIF && image.cdn_avif_s3_key) {
+    return `${baseUrl}/${image.cdn_avif_s3_key}`;
+  }
+
+  // Try WebP second (good compression, wide support)
+  if (formatSupport.supportsWebP && image.cdn_webp_s3_key) {
+    return `${baseUrl}/${image.cdn_webp_s3_key}`;
+  }
+
+  // Fallback to JPEG (universal support)
+  return `${baseUrl}/${image.cdn_s3_key}`;
+};
+
+// AnimatedLineBox: already defined for words
+interface AnimatedLineBoxProps {
+  line: any; // Adjust type as needed
+  svgWidth: number;
+  svgHeight: number;
+  delay: number;
+}
+
+const AnimatedLineBox: React.FC<AnimatedLineBoxProps> = ({
+  line,
+  svgWidth,
+  svgHeight,
+  delay,
+}) => {
+  // Convert normalized coordinates to absolute pixel values.
+  const x1 = line.top_left.x * svgWidth;
+  const y1 = (1 - line.top_left.y) * svgHeight;
+  const x2 = line.top_right.x * svgWidth;
+  const y2 = (1 - line.top_right.y) * svgHeight;
+  const x3 = line.bottom_right.x * svgWidth;
+  const y3 = (1 - line.bottom_right.y) * svgHeight;
+  const x4 = line.bottom_left.x * svgWidth;
+  const y4 = (1 - line.bottom_left.y) * svgHeight;
+  const points = `${x1},${y1} ${x2},${y2} ${x3},${y3} ${x4},${y4}`;
+
+  // Compute the polygon's centroid.
+  const centroidX = (x1 + x2 + x3 + x4) / 4;
+  const centroidY = (y1 + y2 + y3 + y4) / 4;
+
+  // Animate the polygon scaling from 0 to 1, with the centroid as the origin.
+  const polygonSpring = useSpring({
+    from: { transform: "scale(0)" },
+    to: { transform: "scale(1)" },
+    delay: delay,
+    config: { duration: 800 },
+  });
+
+  // Animate the centroid marker:
+  // 1. Fade in at the computed centroid.
+  // 2. Then animate its y coordinate to mid‑Y.
+  const centroidSpring = useSpring({
+    from: { opacity: 0, cy: centroidY },
+    to: async (next) => {
+      await next({ opacity: 1, cy: centroidY, config: { duration: 300 } });
+      await next({ cy: svgHeight / 2, config: { duration: 800 } });
+    },
+    delay: delay + 30,
+  });
+
+  return (
+    <>
+      <animated.polygon
+        style={{
+          ...polygonSpring,
+          transformOrigin: "50% 50%",
+          transformBox: "fill-box",
+        }}
+        points={points}
+        fill="none"
+        stroke="red"
+        strokeWidth="2"
+      />
+      <animated.circle
+        cx={centroidX}
+        cy={centroidSpring.cy}
+        r={10}
+        fill="red"
+        style={{ opacity: centroidSpring.opacity }}
+      />
+    </>
+  );
+};
+
+// AnimatedReceipt: component for receipt bounding box and centroid animation
+interface AnimatedReceiptProps {
+  receipt: any; // Adjust type accordingly
+  svgWidth: number;
+  svgHeight: number;
+  delay: number;
+}
+
+const AnimatedReceipt: React.FC<AnimatedReceiptProps> = ({
+  receipt,
+  svgWidth,
+  svgHeight,
+  delay,
+}) => {
+  // Compute the receipt bounding box corners.
+  const x1 = receipt.top_left.x * svgWidth;
+  const y1 = (1 - receipt.top_left.y) * svgHeight;
+  const x2 = receipt.top_right.x * svgWidth;
+  const y2 = (1 - receipt.top_right.y) * svgHeight;
+  const x3 = receipt.bottom_right.x * svgWidth;
+  const y3 = (1 - receipt.bottom_right.y) * svgHeight;
+  const x4 = receipt.bottom_left.x * svgWidth;
+  const y4 = (1 - receipt.bottom_left.y) * svgHeight;
+  const points = `${x1},${y1} ${x2},${y2} ${x3},${y3} ${x4},${y4}`;
+
+  // Compute the centroid of the receipt bounding box.
+  const centroidX = (x1 + x2 + x3 + x4) / 4;
+  const centroidY = (y1 + y2 + y3 + y4) / 4;
+  const midY = svgHeight / 2;
+
+  // Animate the receipt bounding box to fade in.
+  const boxSpring = useSpring({
+    from: { opacity: 0 },
+    to: { opacity: 1 },
+    delay: delay,
+    config: { duration: 800 },
+  });
+
+  // Animate the receipt centroid marker:
+  // Start at midY, then animate to the computed receipt centroid.
+  const centroidSpring = useSpring({
+    from: { opacity: 0, cy: midY },
+    to: async (next) => {
+      await next({ opacity: 1, cy: midY, config: { duration: 400 } });
+      await next({ cy: centroidY, config: { duration: 800 } });
+    },
+    delay: delay, // Same delay as the bounding box fade in.
+  });
+
+  return (
+    <>
+      <animated.polygon
+        style={boxSpring}
+        points={points}
+        fill="none"
+        stroke="blue"
+        strokeWidth="4"
+      />
+      <animated.circle
+        cx={centroidX}
+        cy={centroidSpring.cy}
+        r={10}
+        fill="blue"
+        style={{ opacity: centroidSpring.opacity }}
+      />
+    </>
+  );
+};
+
+// Main PhotoReceiptBoundingBox component
 const PhotoReceiptBoundingBox: React.FC = () => {
-  return <div>PhotoReceiptBoundingBox</div>;
+  const [imageDetails, setImageDetails] =
+    useState<ImageDetailsApiResponse | null>(null);
+  const [error, setError] = useState<Error | null>(null);
+  const [formatSupport, setFormatSupport] = useState<{
+    supportsAVIF: boolean;
+    supportsWebP: boolean;
+  } | null>(null);
+  const [isClient, setIsClient] = useState(false);
+  const [resetKey, setResetKey] = useState(0);
+
+  // Ensure client-side hydration consistency
+  useEffect(() => {
+    setIsClient(true);
+  }, []);
+
+  useEffect(() => {
+    if (!isClient) return; // Only run on client-side
+
+    const loadImageDetails = async () => {
+      try {
+        // Run format detection and API call in parallel
+        const [details, support] = await Promise.all([
+          api.fetchRandomImageDetails("PHOTO"),
+          detectImageFormatSupport(),
+        ]);
+
+        setImageDetails(details);
+        setFormatSupport(support);
+      } catch (err) {
+        console.error("Error loading image details:", err);
+        setError(err as Error);
+      }
+    };
+
+    loadImageDetails();
+  }, [isClient]);
+
+  // Reserve default dimensions while waiting for the API.
+  const defaultSvgWidth = 400;
+  const defaultSvgHeight = 565.806;
+
+  // Extract lines and receipts
+  const lines = imageDetails?.lines ?? [];
+  const receipts = imageDetails?.receipts ?? [];
+
+  // Animate word bounding boxes using a transition.
+  const lineTransitions = useTransition(lines, {
+    // Include resetKey in the key so that each item gets a new key on reset.
+    keys: (line) => `${resetKey}-${line.line_id}`,
+    from: { opacity: 0, transform: "scale(0.8)" },
+    enter: (item, index) => ({
+      opacity: 1,
+      transform: "scale(1)",
+      delay: index * 30,
+    }),
+    config: { duration: 800 },
+  });
+
+  // Compute the total delay for word animations.
+  const totalDelayForLines =
+    lines.length > 0 ? (lines.length - 1) * 30 + 1130 : 0;
+
+  // Use the first image from the API.
+  const firstImage = imageDetails?.image;
+
+  // Get the optimal image URL based on browser support and available formats
+  // Use fallback URL during SSR/initial render to prevent hydration mismatch
+  const cdnUrl =
+    firstImage && formatSupport && isClient
+      ? getBestImageUrl(firstImage, formatSupport)
+      : firstImage
+      ? `${
+          isDevelopment
+            ? "https://dev.tylernorlund.com"
+            : "https://www.tylernorlund.com"
+        }/${firstImage.cdn_s3_key}`
+      : "";
+
+  // When imageDetails is loaded, compute these values;
+  // otherwise, fall back on default dimensions.
+  const svgWidth = firstImage ? firstImage.width : defaultSvgWidth;
+  const svgHeight = firstImage ? firstImage.height : defaultSvgHeight;
+
+  // Scale the displayed SVG (using the API data if available).
+  const maxDisplayWidth = 400;
+  const scaleFactor = Math.min(1, maxDisplayWidth / svgWidth);
+  const displayWidth = svgWidth * scaleFactor;
+  const displayHeight = svgHeight * scaleFactor;
+
+  if (error) {
+    return (
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "center",
+          minHeight: displayHeight,
+          alignItems: "center",
+        }}
+      >
+        Error loading image details
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "center",
+          minHeight: displayHeight,
+          alignItems: "center",
+        }}
+      >
+        <div
+          style={{
+            height: displayHeight,
+            width: displayWidth,
+            borderRadius: "15px",
+            overflow: "hidden",
+          }}
+        >
+          {imageDetails && formatSupport ? (
+            <svg
+              key={resetKey}
+              onClick={() => setResetKey((k) => k + 1)}
+              viewBox={`0 0 ${svgWidth} ${svgHeight}`}
+              width={displayWidth}
+              height={displayHeight}
+            >
+              <image
+                href={cdnUrl}
+                x="0"
+                y="0"
+                width={svgWidth}
+                height={svgHeight}
+              />
+
+              {/* Render animated word bounding boxes (via transition) */}
+              {lineTransitions((style, line) => {
+                const x1 = line.top_left.x * svgWidth;
+                const y1 = (1 - line.top_left.y) * svgHeight;
+                const x2 = line.top_right.x * svgWidth;
+                const y2 = (1 - line.top_right.y) * svgHeight;
+                const x3 = line.bottom_right.x * svgWidth;
+                const y3 = (1 - line.bottom_right.y) * svgHeight;
+                const x4 = line.bottom_left.x * svgWidth;
+                const y4 = (1 - line.bottom_left.y) * svgHeight;
+                const points = `${x1},${y1} ${x2},${y2} ${x3},${y3} ${x4},${y4}`;
+                return (
+                  <animated.polygon
+                    key={`${line.line_id}`}
+                    style={style}
+                    points={points}
+                    fill="none"
+                    stroke="red"
+                    strokeWidth="2"
+                  />
+                );
+              })}
+
+              {/* Render animated word centroids */}
+              {lines.map((line, index) => (
+                <AnimatedLineBox
+                  key={`${line.line_id}`}
+                  line={line}
+                  svgWidth={svgWidth}
+                  svgHeight={svgHeight}
+                  delay={index * 30}
+                />
+              ))}
+
+              {/* Render animated receipt bounding boxes and centroids */}
+              {receipts.map((receipt, index) => (
+                <AnimatedReceipt
+                  key={`receipt-${receipt.receipt_id}`}
+                  receipt={receipt}
+                  svgWidth={svgWidth}
+                  svgHeight={svgHeight}
+                  delay={totalDelayForLines + index * 100}
+                />
+              ))}
+            </svg>
+          ) : (
+            // While loading, show a "Loading" message centered in the reserved space.
+            <div
+              style={{
+                display: "flex",
+                justifyContent: "center",
+                alignItems: "center",
+                width: "100%",
+                height: "100%",
+              }}
+            >
+              Loading...
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
 };
 
 export default PhotoReceiptBoundingBox;

--- a/portfolio/utils/geometry.ts
+++ b/portfolio/utils/geometry.ts
@@ -1,0 +1,125 @@
+export interface Point {
+  x: number;
+  y: number;
+}
+
+export const convexHull = (points: Point[]): Point[] => {
+  const sorted = Array.from(new Set(points.map(p => `${p.x},${p.y}`))).map(s => {
+    const [x, y] = s.split(',').map(Number);
+    return { x, y } as Point;
+  }).sort((a, b) => (a.x === b.x ? a.y - b.y : a.x - b.x));
+  if (sorted.length <= 1) {
+    return sorted;
+  }
+
+  const cross = (o: Point, a: Point, b: Point): number =>
+    (a.x - o.x) * (b.y - o.y) - (a.y - o.y) * (b.x - o.x);
+
+  const lower: Point[] = [];
+  for (const p of sorted) {
+    while (lower.length >= 2 && cross(lower[lower.length - 2], lower[lower.length - 1], p) <= 0) {
+      lower.pop();
+    }
+    lower.push(p);
+  }
+
+  const upper: Point[] = [];
+  for (const p of [...sorted].reverse()) {
+    while (upper.length >= 2 && cross(upper[upper.length - 2], upper[upper.length - 1], p) <= 0) {
+      upper.pop();
+    }
+    upper.push(p);
+  }
+
+  upper.pop();
+  lower.pop();
+  return lower.concat(upper);
+};
+
+export const computeHullCentroid = (hull: Point[]): Point => {
+  const n = hull.length;
+  if (n === 0) return { x: 0, y: 0 };
+  if (n === 1) return { x: hull[0].x, y: hull[0].y };
+  if (n === 2) return { x: (hull[0].x + hull[1].x) / 2, y: (hull[0].y + hull[1].y) / 2 };
+
+  let areaSum = 0;
+  let cx = 0;
+  let cy = 0;
+  for (let i = 0; i < n; i++) {
+    const p0 = hull[i];
+    const p1 = hull[(i + 1) % n];
+    const crossVal = p0.x * p1.y - p1.x * p0.y;
+    areaSum += crossVal;
+    cx += (p0.x + p1.x) * crossVal;
+    cy += (p0.y + p1.y) * crossVal;
+  }
+  const area = areaSum / 2;
+  if (Math.abs(area) < 1e-14) {
+    const xAvg = hull.reduce((acc, p) => acc + p.x, 0) / n;
+    const yAvg = hull.reduce((acc, p) => acc + p.y, 0) / n;
+    return { x: xAvg, y: yAvg };
+  }
+  cx /= 6 * area;
+  cy /= 6 * area;
+  return { x: cx, y: cy };
+};
+
+export const computeReceiptBoxFromSkewedExtents = (
+  hull: Point[],
+  cx: number,
+  cy: number,
+  rotationDeg: number
+): Point[] | null => {
+  if (hull.length === 0) return null;
+  const theta = (rotationDeg * Math.PI) / 180;
+  const cosT = Math.cos(theta);
+  const sinT = Math.sin(theta);
+
+  const deskew = (p: Point): Point => {
+    const dx = p.x - cx;
+    const dy = p.y - cy;
+    return { x: dx * cosT + dy * sinT, y: -dx * sinT + dy * cosT };
+  };
+
+  const deskewed = hull.map(deskew);
+  const top = deskewed.filter(p => p.y < 0);
+  const bottom = deskewed.filter(p => p.y >= 0);
+  const topHalf = top.length ? top : deskewed.slice();
+  const bottomHalf = bottom.length ? bottom : deskewed.slice();
+
+  const minX = (pts: Point[]) => pts.reduce((a, b) => (a.x < b.x ? a : b));
+  const maxX = (pts: Point[]) => pts.reduce((a, b) => (a.x > b.x ? a : b));
+
+  const leftTop = minX(topHalf);
+  const rightTop = maxX(topHalf);
+  const leftBottom = minX(bottomHalf);
+  const rightBottom = maxX(bottomHalf);
+
+  const allY = deskewed.map(p => p.y);
+  const topY = Math.min(...allY);
+  const bottomY = Math.max(...allY);
+
+  const interpolate = (vTop: Point, vBottom: Point, desiredY: number): Point => {
+    const dy = vBottom.y - vTop.y;
+    if (Math.abs(dy) < 1e-9) return { x: vTop.x, y: desiredY };
+    const t = (desiredY - vTop.y) / dy;
+    const x = vTop.x + t * (vBottom.x - vTop.x);
+    return { x, y: desiredY };
+  };
+
+  const leftTopPoint = interpolate(leftTop, leftBottom, topY);
+  const leftBottomPoint = interpolate(leftTop, leftBottom, bottomY);
+  const rightTopPoint = interpolate(rightTop, rightBottom, topY);
+  const rightBottomPoint = interpolate(rightTop, rightBottom, bottomY);
+
+  const cosInv = Math.cos(-theta);
+  const sinInv = Math.sin(-theta);
+  const inverse = (p: Point): Point => {
+    const rx = p.x * cosInv + p.y * sinInv;
+    const ry = -p.x * sinInv + p.y * cosInv;
+    return { x: rx + cx, y: ry + cy };
+  };
+
+  const corners = [leftTopPoint, rightTopPoint, rightBottomPoint, leftBottomPoint].map(inverse);
+  return corners.map(p => ({ x: Math.round(p.x), y: Math.round(p.y) }));
+};


### PR DESCRIPTION
## Summary
- visualize random photo receipt with bounding boxes
- export helper geometry functions for convex hull and deskewed extents

## Testing
- `pytest -m unit receipt_dynamo`
- `pytest -m integration receipt_dynamo`
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_684720771724832bb4df05bf33a20e9a