### PR TITLE
Add useImageDetails hook and visualization components

### DIFF
--- a/portfolio/components/ui/BoundingBox/ConvexHull.tsx
+++ b/portfolio/components/ui/BoundingBox/ConvexHull.tsx
@@ -1,0 +1,99 @@
+import React, { useEffect, useState } from "react";
+import type { Point } from "../../../types/api";
+
+interface ConvexHullProps {
+  hullPoints: Point[];
+  svgWidth: number;
+  svgHeight: number;
+  delay: number;
+}
+
+const ConvexHull: React.FC<ConvexHullProps> = ({
+  hullPoints,
+  svgWidth,
+  svgHeight,
+  delay,
+}) => {
+  const [visiblePoints, setVisiblePoints] = useState(0);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      const interval = setInterval(() => {
+        setVisiblePoints(prev => {
+          if (prev >= hullPoints.length) {
+            clearInterval(interval);
+            return prev;
+          }
+          return prev + 1;
+        });
+      }, 200);
+      return () => clearInterval(interval);
+    }, delay);
+    return () => clearTimeout(timer);
+  }, [delay, hullPoints.length]);
+
+  useEffect(() => {
+    setVisiblePoints(0);
+  }, [hullPoints]);
+
+  if (hullPoints.length === 0) return null;
+
+  const svgPoints = hullPoints.map(point => ({
+    x: point.x * svgWidth,
+    y: (1 - point.y) * svgHeight,
+  }));
+  const visibleSvgPoints = svgPoints.slice(0, visiblePoints);
+
+  if (visibleSvgPoints.length < 2) {
+    return (
+      <>
+        {visibleSvgPoints.map((point, index) => (
+          <circle
+            key={index}
+            cx={point.x}
+            cy={point.y}
+            r={12}
+            fill="var(--color-red)"
+            opacity={1}
+            strokeWidth={2}
+          />
+        ))}
+      </>
+    );
+  }
+
+  const pathData = visibleSvgPoints.reduce((acc, point, index) => {
+    if (index === 0) return `M ${point.x} ${point.y}`;
+    return `${acc} L ${point.x} ${point.y}`;
+  }, "");
+  const finalPath =
+    visiblePoints >= hullPoints.length ? `${pathData} Z` : pathData;
+
+  return (
+    <>
+      {visibleSvgPoints.map((point, index) => (
+        <circle
+          key={index}
+          cx={point.x}
+          cy={point.y}
+          r={12}
+          fill="var(--color-red)"
+          opacity={1}
+          strokeWidth={2}
+        />
+      ))}
+      <path
+        d={finalPath}
+        fill="none"
+        stroke="var(--color-red)"
+        strokeWidth={4}
+        opacity={1}
+      />
+      {visiblePoints >= hullPoints.length && (
+        <path d={finalPath} fill="var(--color-red)" opacity={0.1} />
+      )}
+    </>
+  );
+};
+
+export default ConvexHull;

--- a/portfolio/components/ui/BoundingBox/HullCentroid.tsx
+++ b/portfolio/components/ui/BoundingBox/HullCentroid.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import { animated, useSpring } from "@react-spring/web";
+import type { Point } from "../../../types/api";
+
+interface HullCentroidProps {
+  centroid: Point;
+  svgWidth: number;
+  svgHeight: number;
+  delay: number;
+}
+
+const HullCentroid: React.FC<HullCentroidProps> = ({
+  centroid,
+  svgWidth,
+  svgHeight,
+  delay,
+}) => {
+  const centroidSpring = useSpring({
+    from: { opacity: 0, scale: 0 },
+    to: { opacity: 1, scale: 1 },
+    delay,
+    config: { duration: 600 },
+  });
+
+  const centroidX = centroid.x * svgWidth;
+  const centroidY = (1 - centroid.y) * svgHeight;
+
+  return (
+    <animated.circle
+      cx={centroidX}
+      cy={centroidY}
+      r={15}
+      fill="var(--color-red)"
+      strokeWidth={3}
+      style={{
+        opacity: centroidSpring.opacity,
+        transform: centroidSpring.scale.to(s => `scale(${s})`),
+        transformOrigin: `${centroidX}px ${centroidY}px`,
+      }}
+    />
+  );
+};
+
+export default HullCentroid;

--- a/portfolio/components/ui/BoundingBox/OrientedAxes.tsx
+++ b/portfolio/components/ui/BoundingBox/OrientedAxes.tsx
@@ -1,0 +1,172 @@
+import React, { useEffect, useState } from "react";
+import type { Line, Point } from "../../../types/api";
+
+interface OrientedAxesProps {
+  hull: Point[];
+  centroid: Point;
+  lines: Line[];
+  svgWidth: number;
+  svgHeight: number;
+  delay: number;
+}
+
+const OrientedAxes: React.FC<OrientedAxesProps> = ({
+  hull,
+  centroid,
+  lines,
+  svgWidth,
+  svgHeight,
+  delay,
+}) => {
+  const [visibleElements, setVisibleElements] = useState(0);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      const interval = setInterval(() => {
+        setVisibleElements(prev => {
+          if (prev >= 3) {
+            clearInterval(interval);
+            return prev;
+          }
+          return prev + 1;
+        });
+      }, 400);
+      return () => clearInterval(interval);
+    }, delay);
+    return () => clearTimeout(timer);
+  }, [delay]);
+
+  useEffect(() => {
+    setVisibleElements(0);
+  }, [hull, lines]);
+
+  if (hull.length === 0 || lines.length === 0) return null;
+
+  const computedAngles = lines
+    .map(line => {
+      const dx = line.bottom_right.x - line.bottom_left.x;
+      const dy = line.bottom_right.y - line.bottom_left.y;
+      return (Math.atan2(dy, dx) * 180) / Math.PI;
+    })
+    .filter(angle => Math.abs(angle) > 1e-3);
+
+  const avgAngle =
+    computedAngles.length > 0
+      ? computedAngles.reduce((sum, a) => sum + a, 0) / computedAngles.length
+      : 0;
+
+  const centroidX = centroid.x * svgWidth;
+  const centroidY = (1 - centroid.y) * svgHeight;
+
+  const angleRad = (avgAngle * Math.PI) / 180;
+  const primaryAxisAngle = angleRad;
+  const secondaryAxisAngle = angleRad + Math.PI / 2;
+
+  const axisLength = 200;
+
+  const primaryAxis = {
+    x1: centroidX,
+    y1: centroidY,
+    x2: centroidX + axisLength * Math.cos(primaryAxisAngle),
+    y2: centroidY + axisLength * Math.sin(primaryAxisAngle),
+  };
+
+  const secondaryAxis = {
+    x1: centroidX,
+    y1: centroidY,
+    x2: centroidX,
+    y2: centroidY - axisLength,
+  };
+
+  let minPrimary = Infinity,
+    maxPrimary = -Infinity;
+  let minSecondary = Infinity,
+    maxSecondary = -Infinity;
+  let primaryMinPoint = hull[0],
+    primaryMaxPoint = hull[0];
+  let secondaryMinPoint = hull[0],
+    secondaryMaxPoint = hull[0];
+
+  const hullProjections = hull.map(point => {
+    const px = point.x * svgWidth;
+    const py = (1 - point.y) * svgHeight;
+    const relX = px - centroidX;
+    const relY = py - centroidY;
+    const primaryProjection = relX * Math.cos(primaryAxisAngle) + relY * Math.sin(primaryAxisAngle);
+    const secondaryProjection = relX * Math.cos(secondaryAxisAngle) + relY * Math.sin(secondaryAxisAngle);
+
+    return { point: { x: px, y: py }, primaryProjection, secondaryProjection };
+  });
+
+  hullProjections.forEach(({ point, primaryProjection, secondaryProjection }) => {
+    if (primaryProjection < minPrimary) {
+      minPrimary = primaryProjection;
+      primaryMinPoint = point;
+    }
+    if (primaryProjection > maxPrimary) {
+      maxPrimary = primaryProjection;
+      primaryMaxPoint = point;
+    }
+    if (secondaryProjection < minSecondary) {
+      minSecondary = secondaryProjection;
+      secondaryMinPoint = point;
+    }
+    if (secondaryProjection > maxSecondary) {
+      maxSecondary = secondaryProjection;
+      secondaryMaxPoint = point;
+    }
+  });
+
+  return (
+    <>
+      {visibleElements >= 1 && (
+        <line
+          x1={primaryAxis.x1}
+          y1={primaryAxis.y1}
+          x2={primaryAxis.x2}
+          y2={primaryAxis.y2}
+          stroke="var(--color-green)"
+          strokeWidth={10}
+          opacity={0.8}
+        />
+      )}
+      {visibleElements >= 2 && (
+        <line
+          x1={secondaryAxis.x1}
+          y1={secondaryAxis.y1}
+          x2={secondaryAxis.x2}
+          y2={secondaryAxis.y2}
+          stroke="var(--color-yellow)"
+          strokeWidth={10}
+          opacity={0.8}
+        />
+      )}
+      {visibleElements >= 3 && [primaryMinPoint, primaryMaxPoint].map((point, index) => (
+        <circle
+          key={`primary-${index}`}
+          cx={point.x}
+          cy={point.y}
+          r={10}
+          fill="var(--color-green)"
+          stroke="white"
+          strokeWidth={2}
+          opacity={0.9}
+        />
+      ))}
+      {visibleElements >= 3 && [secondaryMinPoint, secondaryMaxPoint].map((point, idx) => (
+        <circle
+          key={`secondary-${idx}`}
+          cx={point.x}
+          cy={point.y}
+          r={10}
+          fill="var(--color-green)"
+          stroke="white"
+          strokeWidth={2}
+          opacity={0.9}
+        />
+      ))}
+    </>
+  );
+};
+
+export default OrientedAxes;

--- a/portfolio/components/ui/BoundingBox/PrimaryBoundaryLines.tsx
+++ b/portfolio/components/ui/BoundingBox/PrimaryBoundaryLines.tsx
@@ -1,0 +1,73 @@
+import React from "react";
+import { animated, useTransition } from "@react-spring/web";
+import type { Point } from "../../../types/api";
+
+interface LineSegment {
+  x1: number;
+  y1: number;
+  x2: number;
+  y2: number;
+  key: string;
+}
+
+interface PrimaryBoundaryLinesProps {
+  segments: LineSegment[];
+  delay: number;
+}
+
+const PrimaryBoundaryLines: React.FC<PrimaryBoundaryLinesProps> = ({
+  segments,
+  delay,
+}) => {
+  const transitions = useTransition(segments, {
+    keys: seg => seg.key,
+    from: { opacity: 0, strokeDasharray: "12,8", strokeDashoffset: 20 },
+    enter: (_item, idx) => ({
+      opacity: 1,
+      strokeDashoffset: 0,
+      delay: delay + idx * 300,
+    }),
+    config: { duration: 800 },
+  });
+
+  return (
+    <g>
+      {segments.map(seg => (
+        <React.Fragment key={`pts-${seg.key}`}>
+          <circle
+            cx={seg.x1}
+            cy={seg.y1}
+            r={8}
+            fill="var(--color-green)"
+            stroke="white"
+            strokeWidth={2}
+          />
+          <circle
+            cx={seg.x2}
+            cy={seg.y2}
+            r={8}
+            fill="var(--color-green)"
+            stroke="white"
+            strokeWidth={2}
+          />
+        </React.Fragment>
+      ))}
+      {transitions((style, seg) => (
+        <animated.line
+          key={seg.key}
+          style={style}
+          x1={seg.x1}
+          y1={seg.y1}
+          x2={seg.x2}
+          y2={seg.y2}
+          stroke="var(--color-green)"
+          strokeWidth={5}
+          strokeDasharray="12,8"
+        />
+      ))}
+    </g>
+  );
+};
+
+export default PrimaryBoundaryLines;
+export type { LineSegment, PrimaryBoundaryLinesProps };

--- a/portfolio/components/ui/BoundingBox/index.ts
+++ b/portfolio/components/ui/BoundingBox/index.ts
@@ -1,0 +1,5 @@
+export { default as ConvexHull } from "./ConvexHull";
+export { default as HullCentroid } from "./HullCentroid";
+export { default as OrientedAxes } from "./OrientedAxes";
+export { default as PrimaryBoundaryLines } from "./PrimaryBoundaryLines";
+export type { LineSegment } from "./PrimaryBoundaryLines";

--- a/portfolio/hooks/useImageDetails.ts
+++ b/portfolio/hooks/useImageDetails.ts
@@ -1,0 +1,54 @@
+import { useEffect, useState } from "react";
+
+import { api } from "../services/api";
+import type { ImageDetailsApiResponse } from "../types/api";
+import type { FormatSupport } from "../utils/image";
+import { detectImageFormatSupport } from "../utils/image";
+
+interface UseImageDetailsResult {
+  imageDetails: ImageDetailsApiResponse | null;
+  formatSupport: FormatSupport | null;
+  error: Error | null;
+  loading: boolean;
+}
+
+export const useImageDetails = (
+  imageType?: string
+): UseImageDetailsResult => {
+  const [imageDetails, setImageDetails] = useState<ImageDetailsApiResponse | null>(null);
+  const [formatSupport, setFormatSupport] = useState<FormatSupport | null>(null);
+  const [error, setError] = useState<Error | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let isMounted = true;
+    const load = async () => {
+      try {
+        const [details, support] = await Promise.all([
+          api.fetchRandomImageDetails(imageType),
+          detectImageFormatSupport(),
+        ]);
+        if (isMounted) {
+          setImageDetails(details);
+          setFormatSupport(support);
+        }
+      } catch (err) {
+        if (isMounted) {
+          setError(err as Error);
+        }
+      } finally {
+        if (isMounted) {
+          setLoading(false);
+        }
+      }
+    };
+    load();
+    return () => {
+      isMounted = false;
+    };
+  }, [imageType]);
+
+  return { imageDetails, formatSupport, error, loading };
+};
+
+export default useImageDetails;

--- a/portfolio/utils/image.ts
+++ b/portfolio/utils/image.ts
@@ -1,0 +1,94 @@
+export interface FormatSupport {
+  supportsAVIF: boolean;
+  supportsWebP: boolean;
+}
+
+export const detectImageFormatSupport = (): Promise<FormatSupport> => {
+  return new Promise((resolve) => {
+    const userAgent = navigator.userAgent;
+
+    const getSafariVersion = (): number | null => {
+      if (userAgent.includes("Chrome")) return null;
+      const safariMatch = userAgent.match(/Version\/([0-9.]+).*Safari/);
+      if (safariMatch) {
+        return parseFloat(safariMatch[1]);
+      }
+      return null;
+    };
+
+    const isChrome = userAgent.includes("Chrome") && userAgent.includes("Google Chrome");
+    const isFirefox = userAgent.includes("Firefox");
+    const safariVersion = getSafariVersion();
+    const isSafari = safariVersion !== null;
+
+    let supportsWebP = false;
+    if (isChrome || isFirefox) {
+      supportsWebP = true;
+    } else if (isSafari && safariVersion && safariVersion >= 14) {
+      supportsWebP = true;
+    } else {
+      try {
+        const canvas = document.createElement("canvas");
+        canvas.width = 1;
+        canvas.height = 1;
+        const ctx = canvas.getContext("2d");
+        if (ctx) {
+          const webpDataUrl = canvas.toDataURL("image/webp", 0.5);
+          supportsWebP = webpDataUrl.indexOf("data:image/webp") === 0;
+        }
+      } catch {
+        supportsWebP = false;
+      }
+    }
+
+    const detectAVIF = (): Promise<boolean> => {
+      if (isChrome) {
+        const chromeMatch = userAgent.match(/Chrome\/([0-9]+)/);
+        if (chromeMatch && parseInt(chromeMatch[1]) >= 85) {
+          return Promise.resolve(true);
+        }
+      }
+      if (isFirefox) {
+        const firefoxMatch = userAgent.match(/Firefox\/([0-9]+)/);
+        if (firefoxMatch && parseInt(firefoxMatch[1]) >= 93) {
+          return Promise.resolve(true);
+        }
+      }
+      if (isSafari && safariVersion && safariVersion >= 16.4) {
+        return Promise.resolve(true);
+      }
+      return new Promise((resolveAVIF) => {
+        const img = new Image();
+        img.onload = () => resolveAVIF(true);
+        img.onerror = () => resolveAVIF(false);
+        img.src =
+          "data:image/avif;base64,AAAAIGZ0eXBhdmlmAAAAAGF2aWZtaWYxbWlhZk1BMUIAAADybWV0YQAAAAAAAAAoaGRscgAAAAAAAAAAcGljdAAAAAAAAAAAAAAAAGxpYmF2aWYAAAAADnBpdG0AAAAAAAEAAAAeaWxvYwAAAABEAAABAAEAAAABAAABGgAAAB0AAAAoaWluZgAAAAAAAQAAABppbmZlAgAAAABAABhdjAxQ29sb3IAAAAAamlwcnAAAABLaXBjbwAAABRpc3BlAAAAAAAAAAEAAAABAAAAEHBpeGkAAAAAAwgICAAAAAxhdjFDgQ0MAAAAABNjb2xybmNseAACAAIAAYAAAAAXaXBtYQAAAAAAAAABAAEEAQKDBAAAACVtZGF0EgAKCBgABogQEAwgMg8f8D///8WfhwB8+ErK42A=";
+      });
+    };
+
+    detectAVIF().then((supportsAVIF) => {
+      resolve({ supportsAVIF, supportsWebP });
+    });
+  });
+};
+
+import type { Image } from "../types/api";
+
+const isDevelopment = process.env.NODE_ENV === "development";
+
+export const getBestImageUrl = (
+  image: Image,
+  formatSupport: FormatSupport
+): string => {
+  const baseUrl = isDevelopment
+    ? "https://dev.tylernorlund.com"
+    : "https://www.tylernorlund.com";
+
+  if (formatSupport.supportsAVIF && image.cdn_avif_s3_key) {
+    return `${baseUrl}/${image.cdn_avif_s3_key}`;
+  }
+  if (formatSupport.supportsWebP && image.cdn_webp_s3_key) {
+    return `${baseUrl}/${image.cdn_webp_s3_key}`;
+  }
+  return `${baseUrl}/${image.cdn_s3_key}`;
+};


### PR DESCRIPTION
## Summary
- add image format detection utilities
- create `useImageDetails` hook
- create basic visualization components for bounding boxes

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run type-check` *(fails: missing dependencies)*
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e50f3f044832ba30b9afdde054331