### PR TITLE
Use useImageDetails hook in receipt components

### DIFF
--- a/portfolio/components/ui/Figures/PhotoReceiptBoundingBox.tsx
+++ b/portfolio/components/ui/Figures/PhotoReceiptBoundingBox.tsx
@@ -1,18 +1,13 @@
 import React, { useEffect, useState } from "react";
 
-import { api } from "../../../services/api";
 import {
-  ImageDetailsApiResponse,
-  type Image as ImageType,
   type Line,
   type Point as ApiPoint,
 } from "../../../types/api";
 import { useSpring, useTransition, animated } from "@react-spring/web";
 import AnimatedLineBox from "../animations/AnimatedLineBox";
-import {
-  detectImageFormatSupport,
-  getBestImageUrl,
-} from "../../../utils/imageFormat";
+import { getBestImageUrl } from "../../../utils/imageFormat";
+import useImageDetails from "../../../hooks/useImageDetails";
 import {
   computeHullCentroid,
   computeReceiptBoxFromLineEdges,
@@ -1255,13 +1250,7 @@ const AnimatedReceiptFromHull: React.FC<AnimatedReceiptFromHullProps> = ({
  * how the receipt bounding box is derived from OCR line data.
  */
 const PhotoReceiptBoundingBox: React.FC = () => {
-  const [imageDetails, setImageDetails] =
-    useState<ImageDetailsApiResponse | null>(null);
-  const [error, setError] = useState<Error | null>(null);
-  const [formatSupport, setFormatSupport] = useState<{
-    supportsAVIF: boolean;
-    supportsWebP: boolean;
-  } | null>(null);
+  const { imageDetails, formatSupport, error } = useImageDetails("PHOTO");
   const [isClient, setIsClient] = useState(false);
   const [resetKey, setResetKey] = useState(0);
 
@@ -1270,27 +1259,6 @@ const PhotoReceiptBoundingBox: React.FC = () => {
     setIsClient(true);
   }, []);
 
-  useEffect(() => {
-    if (!isClient) return; // Only run on client-side
-
-    const loadImageDetails = async () => {
-      try {
-        // Run format detection and API call in parallel
-        const [details, support] = await Promise.all([
-          api.fetchRandomImageDetails("PHOTO"),
-          detectImageFormatSupport(),
-        ]);
-
-        setImageDetails(details);
-        setFormatSupport(support);
-      } catch (err) {
-        console.error("Error loading image details:", err);
-        setError(err as Error);
-      }
-    };
-
-    loadImageDetails();
-  }, [isClient]);
 
   // Reserve default dimensions while waiting for the API.
   const defaultSvgWidth = 400;

--- a/portfolio/components/ui/Figures/ScanReceiptBoundingBox.tsx
+++ b/portfolio/components/ui/Figures/ScanReceiptBoundingBox.tsx
@@ -1,16 +1,9 @@
-import React, { useEffect, useState, Fragment } from "react";
+import React, { useEffect, useState } from "react";
 
-import { api } from "../../../services/api";
-import {
-  ImageDetailsApiResponse,
-  type Image as ImageType,
-} from "../../../types/api";
 import { useSpring, useTransition, animated } from "@react-spring/web";
 import AnimatedLineBox from "../animations/AnimatedLineBox";
-import {
-  detectImageFormatSupport,
-  getBestImageUrl,
-} from "../../../utils/imageFormat";
+import { getBestImageUrl } from "../../../utils/imageFormat";
+import useImageDetails from "../../../hooks/useImageDetails";
 
 const isDevelopment = process.env.NODE_ENV === "development";
 
@@ -85,13 +78,7 @@ const AnimatedReceipt: React.FC<AnimatedReceiptProps> = ({
 
 // Main ImageBoundingBox component
 const ImageBoundingBox: React.FC = () => {
-  const [imageDetails, setImageDetails] =
-    useState<ImageDetailsApiResponse | null>(null);
-  const [error, setError] = useState<Error | null>(null);
-  const [formatSupport, setFormatSupport] = useState<{
-    supportsAVIF: boolean;
-    supportsWebP: boolean;
-  } | null>(null);
+  const { imageDetails, formatSupport, error } = useImageDetails();
   const [isClient, setIsClient] = useState(false);
   const [resetKey, setResetKey] = useState(0);
 
@@ -100,27 +87,6 @@ const ImageBoundingBox: React.FC = () => {
     setIsClient(true);
   }, []);
 
-  useEffect(() => {
-    if (!isClient) return; // Only run on client-side
-
-    const loadImageDetails = async () => {
-      try {
-        // Run format detection and API call in parallel
-        const [details, support] = await Promise.all([
-          api.fetchRandomImageDetails(),
-          detectImageFormatSupport(),
-        ]);
-
-        setImageDetails(details);
-        setFormatSupport(support);
-      } catch (err) {
-        console.error("Error loading image details:", err);
-        setError(err as Error);
-      }
-    };
-
-    loadImageDetails();
-  }, [isClient]);
 
   // Reserve default dimensions while waiting for the API.
   const defaultSvgWidth = 400;


### PR DESCRIPTION
## Summary
- refactor PhotoReceiptBoundingBox and ScanReceiptBoundingBox to use the shared `useImageDetails` hook
- remove duplicate state and effect logic

## Testing
- `npm run lint`
- `npm run type-check` *(fails: components/ui/Figures/ReceiptStack.tsx TS2554)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684efbec1054832bad07f1799c295054