### PR TITLE
Refactor geometry utils into modules

### DIFF
--- a/portfolio/components/ui/Figures/PhotoReceiptBoundingBox.tsx
+++ b/portfolio/components/ui/Figures/PhotoReceiptBoundingBox.tsx
@@ -26,12 +26,10 @@ import {
 import {
   findBoundaryLinesWithSkew,
   estimateReceiptPolygonFromLines,
-} from "../../../utils/receiptGeometry";
-import {
   findHullExtentsRelativeToCentroid,
   computeReceiptBoxFromHull,
   findLineEdgesAtPrimaryExtremes,
-} from "../../../utils/receiptBoundingBox";
+} from "../../../utils/receipt";
 
 // Define simple point and line-segment shapes
 const isDevelopment = process.env.NODE_ENV === "development";

--- a/portfolio/components/ui/animations/AnimatedPrimaryEdges.tsx
+++ b/portfolio/components/ui/animations/AnimatedPrimaryEdges.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useTransition, animated } from "@react-spring/web";
 import type { Line, Point } from "../../../types/api";
-import { findBoundaryLinesWithSkew } from "../../../utils/receiptGeometry";
+import { findBoundaryLinesWithSkew } from "../../../utils/receipt";
 
 interface AnimatedPrimaryEdgesProps {
   lines: Line[];

--- a/portfolio/utils/geometry/basic.ts
+++ b/portfolio/utils/geometry/basic.ts
@@ -1,0 +1,87 @@
+export interface Point {
+  x: number;
+  y: number;
+}
+
+
+export const convexHull = (points: Point[]): Point[] => {
+  const sorted = Array.from(new Set(points.map(p => `${p.x},${p.y}`))).map(s => {
+    const [x, y] = s.split(',').map(Number);
+    return { x, y } as Point;
+  }).sort((a, b) => (a.x === b.x ? a.y - b.y : a.x - b.x));
+  if (sorted.length <= 1) {
+    return sorted;
+  }
+
+  const cross = (o: Point, a: Point, b: Point): number =>
+    (a.x - o.x) * (b.y - o.y) - (a.y - o.y) * (b.x - o.x);
+
+  const lower: Point[] = [];
+  for (const p of sorted) {
+    while (lower.length >= 2 && cross(lower[lower.length - 2], lower[lower.length - 1], p) <= 0) {
+      lower.pop();
+    }
+    lower.push(p);
+  }
+
+  const upper: Point[] = [];
+  for (const p of [...sorted].reverse()) {
+    while (upper.length >= 2 && cross(upper[upper.length - 2], upper[upper.length - 1], p) <= 0) {
+      upper.pop();
+    }
+    upper.push(p);
+  }
+
+  upper.pop();
+  lower.pop();
+  return lower.concat(upper);
+};
+
+export const computeHullCentroid = (hull: Point[]): Point => {
+  const n = hull.length;
+  if (n === 0) return { x: 0, y: 0 };
+  if (n === 1) return { x: hull[0].x, y: hull[0].y };
+  if (n === 2) return { x: (hull[0].x + hull[1].x) / 2, y: (hull[0].y + hull[1].y) / 2 };
+
+  let areaSum = 0;
+  let cx = 0;
+  let cy = 0;
+  for (let i = 0; i < n; i++) {
+    const p0 = hull[i];
+    const p1 = hull[(i + 1) % n];
+    const crossVal = p0.x * p1.y - p1.x * p0.y;
+    areaSum += crossVal;
+    cx += (p0.x + p1.x) * crossVal;
+    cy += (p0.y + p1.y) * crossVal;
+  }
+  const area = areaSum / 2;
+  if (Math.abs(area) < 1e-14) {
+    const xAvg = hull.reduce((acc, p) => acc + p.x, 0) / n;
+    const yAvg = hull.reduce((acc, p) => acc + p.y, 0) / n;
+    return { x: xAvg, y: yAvg };
+  }
+  cx /= 6 * area;
+  cy /= 6 * area;
+  return { x: cx, y: cy };
+};
+export const theilSen = (pts: Point[]) => {
+  if (pts.length < 2) return { slope: 0, intercept: pts[0] ? pts[0].y : 0 };
+
+  const slopes: number[] = [];
+  for (let i = 0; i < pts.length; i++) {
+    for (let j = i + 1; j < pts.length; j++) {
+      if (pts[i].y === pts[j].y) continue;
+      slopes.push((pts[j].x - pts[i].x) / (pts[j].y - pts[i].y));
+    }
+  }
+  if (slopes.length === 0) {
+    return { slope: 0, intercept: pts[0].y };
+  }
+  slopes.sort((a, b) => a - b);
+  const slope = slopes[Math.floor(slopes.length / 2)];
+
+  const intercepts = pts.map(p => p.x - slope * p.y).sort((a, b) => a - b);
+  const intercept = intercepts[Math.floor(intercepts.length / 2)];
+
+  return { slope, intercept };
+};

--- a/portfolio/utils/geometry/index.ts
+++ b/portfolio/utils/geometry/index.ts
@@ -1,0 +1,2 @@
+export * from "./basic";
+export * from "./receipt";

--- a/portfolio/utils/geometry/receipt.ts
+++ b/portfolio/utils/geometry/receipt.ts
@@ -1,70 +1,5 @@
-export interface Point {
-  x: number;
-  y: number;
-}
-
-import type { Line } from "../types/api";
-
-export const convexHull = (points: Point[]): Point[] => {
-  const sorted = Array.from(new Set(points.map(p => `${p.x},${p.y}`))).map(s => {
-    const [x, y] = s.split(',').map(Number);
-    return { x, y } as Point;
-  }).sort((a, b) => (a.x === b.x ? a.y - b.y : a.x - b.x));
-  if (sorted.length <= 1) {
-    return sorted;
-  }
-
-  const cross = (o: Point, a: Point, b: Point): number =>
-    (a.x - o.x) * (b.y - o.y) - (a.y - o.y) * (b.x - o.x);
-
-  const lower: Point[] = [];
-  for (const p of sorted) {
-    while (lower.length >= 2 && cross(lower[lower.length - 2], lower[lower.length - 1], p) <= 0) {
-      lower.pop();
-    }
-    lower.push(p);
-  }
-
-  const upper: Point[] = [];
-  for (const p of [...sorted].reverse()) {
-    while (upper.length >= 2 && cross(upper[upper.length - 2], upper[upper.length - 1], p) <= 0) {
-      upper.pop();
-    }
-    upper.push(p);
-  }
-
-  upper.pop();
-  lower.pop();
-  return lower.concat(upper);
-};
-
-export const computeHullCentroid = (hull: Point[]): Point => {
-  const n = hull.length;
-  if (n === 0) return { x: 0, y: 0 };
-  if (n === 1) return { x: hull[0].x, y: hull[0].y };
-  if (n === 2) return { x: (hull[0].x + hull[1].x) / 2, y: (hull[0].y + hull[1].y) / 2 };
-
-  let areaSum = 0;
-  let cx = 0;
-  let cy = 0;
-  for (let i = 0; i < n; i++) {
-    const p0 = hull[i];
-    const p1 = hull[(i + 1) % n];
-    const crossVal = p0.x * p1.y - p1.x * p0.y;
-    areaSum += crossVal;
-    cx += (p0.x + p1.x) * crossVal;
-    cy += (p0.y + p1.y) * crossVal;
-  }
-  const area = areaSum / 2;
-  if (Math.abs(area) < 1e-14) {
-    const xAvg = hull.reduce((acc, p) => acc + p.x, 0) / n;
-    const yAvg = hull.reduce((acc, p) => acc + p.y, 0) / n;
-    return { x: xAvg, y: yAvg };
-  }
-  cx /= 6 * area;
-  cy /= 6 * area;
-  return { x: cx, y: cy };
-};
+import type { Line } from "../../types/api";
+import { Point, theilSen } from "./basic";
 
 export const computeReceiptBoxFromSkewedExtents = (
   hull: Point[],
@@ -125,29 +60,6 @@ export const computeReceiptBoxFromSkewedExtents = (
   const corners = [leftTopPoint, rightTopPoint, rightBottomPoint, leftBottomPoint].map(inverse);
   return corners.map(p => ({ x: Math.round(p.x), y: Math.round(p.y) }));
 };
-
-export const theilSen = (pts: Point[]) => {
-  if (pts.length < 2) return { slope: 0, intercept: pts[0] ? pts[0].y : 0 };
-
-  const slopes: number[] = [];
-  for (let i = 0; i < pts.length; i++) {
-    for (let j = i + 1; j < pts.length; j++) {
-      if (pts[i].y === pts[j].y) continue;
-      slopes.push((pts[j].x - pts[i].x) / (pts[j].y - pts[i].y));
-    }
-  }
-  if (slopes.length === 0) {
-    return { slope: 0, intercept: pts[0].y };
-  }
-  slopes.sort((a, b) => a - b);
-  const slope = slopes[Math.floor(slopes.length / 2)];
-
-  const intercepts = pts.map(p => p.x - slope * p.y).sort((a, b) => a - b);
-  const intercept = intercepts[Math.floor(intercepts.length / 2)];
-
-  return { slope, intercept };
-};
-
 export const computeHullEdge = (
   hull: Point[],
   bins = 12,
@@ -391,3 +303,4 @@ export const computeReceiptBoxFromLineEdges = (
 
   return [topLeft, topRight, bottomRight, bottomLeft];
 };
+

--- a/portfolio/utils/receipt.test.ts
+++ b/portfolio/utils/receipt.test.ts
@@ -1,0 +1,78 @@
+import {
+  findHullExtentsRelativeToCentroid,
+  computeReceiptBoxFromHull,
+  findBoundaryLinesWithSkew,
+  estimateReceiptPolygonFromLines,
+} from "./receipt";
+import type { Line, Point } from "../types/api";
+
+describe("receipt utilities", () => {
+  const hull: Point[] = [
+    { x: 0, y: 0 },
+    { x: 2, y: 0 },
+    { x: 2, y: 1 },
+    { x: 0, y: 1 },
+  ];
+  const centroid: Point = { x: 1, y: 0.5 };
+  const lines: Array<Line & { angle_degrees: number }> = [
+    {
+      top_left: { x: 0, y: 0.9 },
+      top_right: { x: 1, y: 0.9 },
+      bottom_left: { x: 0, y: 0.8 },
+      bottom_right: { x: 1, y: 0.8 },
+      angle_degrees: 0,
+    } as unknown as Line & { angle_degrees: number },
+    {
+      top_left: { x: 1, y: 0.7 },
+      top_right: { x: 2, y: 0.7 },
+      bottom_left: { x: 1, y: 0.6 },
+      bottom_right: { x: 2, y: 0.6 },
+      angle_degrees: 0,
+    } as unknown as Line & { angle_degrees: number },
+    {
+      top_left: { x: 2, y: 0.5 },
+      top_right: { x: 3, y: 0.5 },
+      bottom_left: { x: 2, y: 0.4 },
+      bottom_right: { x: 3, y: 0.4 },
+      angle_degrees: 0,
+    } as unknown as Line & { angle_degrees: number },
+    {
+      top_left: { x: 3, y: 0.3 },
+      top_right: { x: 4, y: 0.3 },
+      bottom_left: { x: 3, y: 0.2 },
+      bottom_right: { x: 4, y: 0.2 },
+      angle_degrees: 0,
+    } as unknown as Line & { angle_degrees: number },
+  ];
+
+  test("findHullExtentsRelativeToCentroid computes extents", () => {
+    const ext = findHullExtentsRelativeToCentroid(hull, centroid);
+    expect(ext.minX).toBeCloseTo(-1);
+    expect(ext.maxX).toBeCloseTo(1);
+    expect(ext.minY).toBeCloseTo(-0.5);
+    expect(ext.maxY).toBeCloseTo(0.5);
+  });
+
+  test("computeReceiptBoxFromHull returns four points", () => {
+    const box = computeReceiptBoxFromHull(hull, centroid, 0);
+    expect(box).toHaveLength(4);
+  });
+
+  test("estimateReceiptPolygonFromLines computes polygon", () => {
+    const poly = estimateReceiptPolygonFromLines(lines);
+    expect(poly).not.toBeNull();
+    if (poly) {
+      expect(poly.top_left).toBeDefined();
+      expect(poly.bottom_right).toBeDefined();
+    }
+  });
+
+  test("findBoundaryLinesWithSkew returns edge points", () => {
+    const result = findBoundaryLinesWithSkew(lines, hull, centroid, 0);
+    expect(Array.isArray(result.leftEdgePoints)).toBe(true);
+    expect(Array.isArray(result.rightEdgePoints)).toBe(true);
+    expect(typeof result.leftBoundaryAngle).toBe("number");
+    expect(typeof result.rightBoundaryAngle).toBe("number");
+  });
+});
+

--- a/portfolio/utils/receipt/boundingBox.ts
+++ b/portfolio/utils/receipt/boundingBox.ts
@@ -1,4 +1,4 @@
-import type { Line, Point } from "../types/api";
+import type { Line, Point } from "../../types/api";
 
 export const findHullExtentsRelativeToCentroid = (
   hull: Point[],

--- a/portfolio/utils/receipt/geometry.ts
+++ b/portfolio/utils/receipt/geometry.ts
@@ -1,5 +1,5 @@
-import type { Line } from "../types/api";
-import { computeEdge, Point } from "./geometry";
+import type { Line } from "../../types/api";
+import { computeEdge, Point } from "../geometry";
 
 export const findBoundaryLinesWithSkew = (
   lines: Line[],

--- a/portfolio/utils/receipt/index.ts
+++ b/portfolio/utils/receipt/index.ts
@@ -1,0 +1,2 @@
+export * from "./geometry";
+export * from "./boundingBox";


### PR DESCRIPTION
## Summary
- modularize geometry helpers under `utils/geometry`
- group receipt-specific helpers under `utils/receipt`
- update imports across components
- add new receipt utility tests

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f03a3775c832b97596c04b725c13b