### PR TITLE
Implement final receipt tilt

### DIFF
--- a/portfolio/components/ui/Figures/PhotoReceiptBoundingBox.tsx
+++ b/portfolio/components/ui/Figures/PhotoReceiptBoundingBox.tsx
@@ -27,6 +27,7 @@ import {
   findHullExtentsRelativeToCentroid,
   computeReceiptBoxFromHull,
   findLineEdgesAtPrimaryExtremes,
+  computeFinalReceiptTilt,
 } from "../../../utils/receipt";
 
 // Define simple point and line-segment shapes
@@ -87,6 +88,15 @@ const PhotoReceiptBoundingBox: React.FC = () => {
   // Compute hull centroid for animation
   const hullCentroid =
     convexHullPoints.length > 0 ? computeHullCentroid(convexHullPoints) : null;
+
+  const avgAngle =
+    lines.length > 0
+      ? lines.reduce((sum, l) => sum + l.angle_degrees, 0) / lines.length
+      : 0;
+  const finalAngle =
+    hullCentroid && convexHullPoints.length > 0
+      ? computeFinalReceiptTilt(lines, convexHullPoints, hullCentroid, avgAngle)
+      : avgAngle;
 
   // Animate line bounding boxes using a transition.
   const lineTransitions = useTransition(inView ? lines : [], {
@@ -261,10 +271,7 @@ const PhotoReceiptBoundingBox: React.FC = () => {
                     lines={lines}
                     hull={convexHullPoints}
                     centroid={hullCentroid}
-                    avgAngle={
-                      lines.reduce((sum, line) => sum + line.angle_degrees, 0) /
-                      lines.length
-                    }
+                    avgAngle={finalAngle}
                     svgWidth={svgWidth}
                     svgHeight={svgHeight}
                     delay={extentsDelay + 1000}
@@ -281,10 +288,7 @@ const PhotoReceiptBoundingBox: React.FC = () => {
                     lines={lines}
                     hull={convexHullPoints}
                     centroid={hullCentroid}
-                    avgAngle={
-                      lines.reduce((sum, line) => sum + line.angle_degrees, 0) /
-                      lines.length
-                    }
+                    avgAngle={finalAngle}
                     svgWidth={svgWidth}
                     svgHeight={svgHeight}
                     delay={extentsDelay + 1500}
@@ -300,10 +304,7 @@ const PhotoReceiptBoundingBox: React.FC = () => {
                     key={`primary-boundary-lines-${resetKey}`}
                     hull={convexHullPoints}
                     centroid={hullCentroid}
-                    avgAngle={
-                      lines.reduce((sum, line) => sum + line.angle_degrees, 0) /
-                      lines.length
-                    }
+                    avgAngle={finalAngle}
                     svgWidth={svgWidth}
                     svgHeight={svgHeight}
                     delay={extentsDelay + 2000}

--- a/portfolio/utils/receipt.test.ts
+++ b/portfolio/utils/receipt.test.ts
@@ -2,6 +2,8 @@ import {
   findHullExtentsRelativeToCentroid,
   computeReceiptBoxFromHull,
   findBoundaryLinesWithSkew,
+  computeFinalReceiptTilt,
+  findHullExtremesAlongAngle,
   estimateReceiptPolygonFromLines,
 } from "./receipt";
 import type { Line, Point } from "../types/api";
@@ -73,6 +75,21 @@ describe("receipt utilities", () => {
     expect(Array.isArray(result.rightEdgePoints)).toBe(true);
     expect(typeof result.leftBoundaryAngle).toBe("number");
     expect(typeof result.rightBoundaryAngle).toBe("number");
+  });
+
+  test("computeFinalReceiptTilt returns expected angle", () => {
+    const angle = computeFinalReceiptTilt(lines as any, hull, centroid, 0);
+    expect(angle).toBeCloseTo(0);
+  });
+
+  test("findHullExtremesAlongAngle finds extremes", () => {
+    const { leftPoint, rightPoint } = findHullExtremesAlongAngle(
+      hull,
+      centroid,
+      0,
+    );
+    expect(leftPoint.x).toBeCloseTo(0);
+    expect(rightPoint.x).toBeCloseTo(2);
   });
 });
 


### PR DESCRIPTION
## Summary
- derive final receipt tilt from hull extremes
- project hull extremes using new helper
- use computed tilt when rendering receipt overlay
- test final tilt helpers

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f0d3da5f8832ba615ecded907d46d