### PR TITLE
Add TSDoc comments for geometry utils

### DIFF
--- a/portfolio/utils/geometry/basic.ts
+++ b/portfolio/utils/geometry/basic.ts
@@ -1,9 +1,22 @@
+/**
+ * Represents a 2D coordinate used by the geometry utilities.
+ */
 export interface Point {
+  /** Horizontal coordinate in normalized [0,1] space. */
   x: number;
+  /** Vertical coordinate in normalized [0,1] space. */
   y: number;
 }
 
 
+/**
+ * Compute the convex hull of a set of points using a monotone chain
+ * algorithm.
+ *
+ * @param points - Points to compute the hull for.
+ * @returns An array of points describing the outer hull in
+ * counter‑clockwise order.
+ */
 export const convexHull = (points: Point[]): Point[] => {
   const sorted = Array.from(new Set(points.map(p => `${p.x},${p.y}`))).map(s => {
     const [x, y] = s.split(',').map(Number);
@@ -37,6 +50,15 @@ export const convexHull = (points: Point[]): Point[] => {
   return lower.concat(upper);
 };
 
+/**
+ * Compute the centroid of a polygon described by its convex hull.
+ *
+ * The function falls back to simple averages for degenerate cases such
+ * as a hull with less than three points.
+ *
+ * @param hull - Polygon vertices in counter‑clockwise order.
+ * @returns The centroid point of the polygon.
+ */
 export const computeHullCentroid = (hull: Point[]): Point => {
   const n = hull.length;
   if (n === 0) return { x: 0, y: 0 };
@@ -64,6 +86,14 @@ export const computeHullCentroid = (hull: Point[]): Point => {
   cy /= 6 * area;
   return { x: cx, y: cy };
 };
+/**
+ * Perform Theil–Sen regression to estimate a line through a set of
+ * points.
+ *
+ * @param pts - Sample points where `x` is the independent variable and
+ * `y` is the dependent variable.
+ * @returns The estimated slope and intercept of the regression line.
+ */
 export const theilSen = (pts: Point[]) => {
   if (pts.length < 2) return { slope: 0, intercept: pts[0] ? pts[0].y : 0 };
 

--- a/portfolio/utils/geometry/receipt.ts
+++ b/portfolio/utils/geometry/receipt.ts
@@ -1,6 +1,18 @@
 import type { Line } from "../../types/api";
 import { Point, theilSen } from "./basic";
 
+/**
+ * Determine a bounding box from a skewed hull by estimating the
+ * vertical extents after de-skewing.
+ *
+ * @param hull - Convex hull points of the receipt.
+ * @param cx - X‑coordinate of the hull centroid.
+ * @param cy - Y‑coordinate of the hull centroid.
+ * @param rotationDeg - Rotation angle in degrees used to deskew
+ * the hull.
+ * @returns Four points representing the receipt box in clockwise
+ * order or `null` when the hull is empty.
+ */
 export const computeReceiptBoxFromSkewedExtents = (
   hull: Point[],
   cx: number,
@@ -60,6 +72,18 @@ export const computeReceiptBoxFromSkewedExtents = (
   const corners = [leftTopPoint, rightTopPoint, rightBottomPoint, leftBottomPoint].map(inverse);
   return corners.map(p => ({ x: Math.round(p.x), y: Math.round(p.y) }));
 };
+/**
+ * Sample points from a convex hull to estimate the left or right edge
+ * as a straight line.
+ *
+ * @param hull - Polygon points representing the convex hull.
+ * @param bins - Number of vertical bins used to sample representative
+ * points.
+ * @param pick - Which side of the hull to estimate: `"left"` or
+ * `"right"`.
+ * @returns The line through the sampled points or `null` when not
+ * enough samples are available.
+ */
 export const computeHullEdge = (
   hull: Point[],
   bins = 12,
@@ -83,6 +107,15 @@ export const computeHullEdge = (
   };
 };
 
+/**
+ * Estimate a straight edge from OCR line data.
+ *
+ * @param lines - Detected OCR lines for the image.
+ * @param pick - Whether to compute the `"left"` or `"right"` edge.
+ * @param bins - Number of vertical bins to reduce the point cloud.
+ * @returns The approximated edge or `null` if there are not enough
+ * samples.
+ */
 export const computeEdge = (
   lines: Line[],
   pick: "left" | "right",
@@ -117,6 +150,17 @@ export const computeEdge = (
   };
 };
 
+/**
+ * Locate points along the top and bottom edges of the text lines at the
+ * extreme secondary-axis positions.
+ *
+ * @param lines - OCR lines used to derive the edges.
+ * @param hull - Convex hull of all line points.
+ * @param centroid - Centroid of the hull.
+ * @param avgAngle - Average rotation angle of the text lines in
+ * degrees.
+ * @returns Arrays of points describing the top and bottom edges.
+ */
 export const findLineEdgesAtSecondaryExtremes = (
   lines: Line[],
   hull: Point[],
@@ -216,6 +260,17 @@ export const findLineEdgesAtSecondaryExtremes = (
   return { topEdge: topEdgePoints, bottomEdge: bottomEdgePoints };
 };
 
+/**
+ * Build a four‑point bounding box for a receipt based on estimated
+ * line edges.
+ *
+ * @param lines - OCR lines from which the edges are derived.
+ * @param hull - Convex hull of all line corners.
+ * @param centroid - Centroid of the hull.
+ * @param avgAngle - Average orientation of the lines in degrees.
+ * @returns The receipt polygon defined in clockwise order. Returns an
+ * empty array when no lines are supplied.
+ */
 export const computeReceiptBoxFromLineEdges = (
   lines: Line[],
   hull: Point[],

--- a/portfolio/utils/receipt/boundingBox.ts
+++ b/portfolio/utils/receipt/boundingBox.ts
@@ -1,5 +1,15 @@
 import type { Line, Point } from "../../types/api";
 
+/**
+ * Get the extreme coordinates of a convex hull relative to its centroid.
+ *
+ * The hull is translated so that the centroid is at the origin. The
+ * returned values include both the minimum and maximum offsets as well
+ * as the corresponding hull points.
+ *
+ * @param hull - Convex hull points of the receipt.
+ * @param centroid - Centroid of the hull used for translation.
+ */
 export const findHullExtentsRelativeToCentroid = (
   hull: Point[],
   centroid: Point,
@@ -56,6 +66,18 @@ export const findHullExtentsRelativeToCentroid = (
   };
 };
 
+/**
+ * Compute a bounding box that best fits a skewed receipt hull.
+ *
+ * The hull is rotated so the receipt is axis aligned. After finding the
+ * minimum rectangle in that orientation, the corners are rotated back to
+ * the original space.
+ *
+ * @param hull - Convex hull of receipt points.
+ * @param centroid - Centroid of the hull.
+ * @param avgAngle - Average text angle in degrees used to deskew the hull.
+ * @returns Polygon describing the receipt in clockwise order.
+ */
 export const computeReceiptBoxFromHull = (
   hull: Point[],
   centroid: Point,
@@ -102,6 +124,20 @@ export const computeReceiptBoxFromHull = (
   }));
 };
 
+/**
+ * Gather points along the left and right edges of text lines that sit at
+ * the outermost positions along the primary axis.
+ *
+ * This is used when the receipt is skewed: lines are projected onto the
+ * secondary axis to determine which belong to the extreme left and right
+ * boundaries.
+ *
+ * @param lines - OCR lines detected on the receipt image.
+ * @param _hull - Unused hull points of the receipt.
+ * @param centroid - Centroid of the receipt hull.
+ * @param avgAngle - Average text angle in degrees.
+ * @returns Arrays of points approximating the left and right edges.
+ */
 export const findLineEdgesAtPrimaryExtremes = (
   lines: Line[],
   _hull: Point[],

--- a/portfolio/utils/receipt/geometry.ts
+++ b/portfolio/utils/receipt/geometry.ts
@@ -1,6 +1,20 @@
 import type { Line } from "../../types/api";
 import { computeEdge, Point } from "../geometry";
 
+/**
+ * Find the subset of lines that form the left and right boundaries of a
+ * skewed receipt.
+ *
+ * Lines are projected onto the secondary axis to determine which reside
+ * at the extremes. Those boundary lines are returned along with their
+ * average orientation.
+ *
+ * @param lines - OCR lines from the image.
+ * @param _hull - Convex hull of all line points (unused).
+ * @param centroid - Centroid of the hull.
+ * @param avgAngle - Average text angle in degrees.
+ * @returns Edge points and boundary angles for the left and right sides.
+ */
 export const findBoundaryLinesWithSkew = (
   lines: Line[],
   _hull: Point[],
@@ -93,6 +107,16 @@ export const findBoundaryLinesWithSkew = (
   };
 };
 
+/**
+ * Estimate a receipt polygon when only OCR line data is available.
+ *
+ * The function computes left and right edges from the lines and uses
+ * those to build a four point polygon. If either edge cannot be
+ * determined, `null` is returned.
+ *
+ * @param lines - OCR lines belonging to the receipt.
+ * @returns The estimated receipt polygon or `null`.
+ */
 export const estimateReceiptPolygonFromLines = (lines: Line[]) => {
   const left = computeEdge(lines, "left");
   const right = computeEdge(lines, "right");


### PR DESCRIPTION
## Summary
- document geometry utilities using TSDoc
- document receipt helpers

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684f112cf8cc832bad674e52a5f2349c