### PR TITLE
Add unit tests for PhotoReceiptBoundingBox

### DIFF
--- a/portfolio/components/ui/Figures/PhotoReceiptBoundingBox.test.tsx
+++ b/portfolio/components/ui/Figures/PhotoReceiptBoundingBox.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import PhotoReceiptBoundingBox from "./PhotoReceiptBoundingBox";
+import fixtureData from "../../../tests/fixtures/target_receipt.json";
+import useImageDetails from "../../../hooks/useImageDetails";
+
+jest.mock("../../../hooks/useImageDetails");
+
+jest.mock("../animations", () => ({
+  AnimatedConvexHull: () => <g data-testid="AnimatedConvexHull" />,
+  AnimatedHullCentroid: () => <g data-testid="AnimatedHullCentroid" />,
+  AnimatedOrientedAxes: () => <g data-testid="AnimatedOrientedAxes" />,
+  AnimatedPrimaryEdges: () => <g data-testid="AnimatedPrimaryEdges" />,
+  AnimatedSecondaryBoundaryLines: () => (
+    <g data-testid="AnimatedSecondaryBoundaryLines" />
+  ),
+  AnimatedPrimaryBoundaryLines: () => (
+    <g data-testid="AnimatedPrimaryBoundaryLines" />
+  ),
+  AnimatedReceiptFromHull: () => <g data-testid="AnimatedReceiptFromHull" />,
+  AnimatedLineBox: () => <g data-testid="AnimatedLineBox" />,
+}));
+
+jest.mock("../../../hooks/useOptimizedInView", () => ({
+  __esModule: true,
+  default: () => [React.createRef(), true] as const,
+}));
+
+const mockedUseImageDetails = useImageDetails as jest.Mock;
+
+describe("PhotoReceiptBoundingBox", () => {
+  beforeEach(() => {
+    mockedUseImageDetails.mockReturnValue({
+      imageDetails: fixtureData,
+      formatSupport: { supportsAVIF: true, supportsWebP: true },
+      error: null,
+      loading: false,
+    });
+  });
+
+  test("renders polygons for each line", () => {
+    render(<PhotoReceiptBoundingBox />);
+    const polygons = document.querySelectorAll("polygon");
+    expect(polygons).toHaveLength(fixtureData.lines.length);
+  });
+
+  test("shows animated convex hull", () => {
+    render(<PhotoReceiptBoundingBox />);
+    expect(screen.getByTestId("AnimatedConvexHull")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add PhotoReceiptBoundingBox.test.tsx to test SVG rendering using fixture data

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test -- components/ui/Figures/PhotoReceiptBoundingBox.test.tsx`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684f11e31750832b84d67e92fbe433a7