### PR TITLE
[Figures] Verify geometry with msw stub

### DIFF
--- a/portfolio/__tests__/integration/PhotoReceiptBoundingBox.integration.test.tsx
+++ b/portfolio/__tests__/integration/PhotoReceiptBoundingBox.integration.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen } from "@testing-library/react";
+import { rest, setupServer } from "../../test-utils/msw";
+import React from "react";
+import PhotoReceiptBoundingBox from "../../components/ui/Figures/PhotoReceiptBoundingBox";
+import fixtureData from "../../tests/fixtures/target_receipt.json";
+
+jest.mock("../../components/ui/animations", () => ({
+  AnimatedConvexHull: () => <g data-testid="AnimatedConvexHull" />,
+  AnimatedHullCentroid: () => <g data-testid="AnimatedHullCentroid" />,
+  AnimatedOrientedAxes: () => <g data-testid="AnimatedOrientedAxes" />,
+  AnimatedPrimaryEdges: () => <g data-testid="AnimatedPrimaryEdges" />,
+  AnimatedSecondaryBoundaryLines: () => <g data-testid="AnimatedSecondaryBoundaryLines" />,
+  AnimatedPrimaryBoundaryLines: () => <g data-testid="AnimatedPrimaryBoundaryLines" />,
+  AnimatedReceiptFromHull: () => <g data-testid="AnimatedReceiptFromHull" />,
+  AnimatedLineBox: () => <g data-testid="AnimatedLineBox" />,
+}));
+
+jest.mock("../../hooks/useOptimizedInView", () => ({
+  __esModule: true,
+  default: () => [React.createRef(), true] as const,
+}));
+
+jest.mock("../../utils/image", () => {
+  const actual = jest.requireActual("../../utils/image");
+  return {
+    ...actual,
+    detectImageFormatSupport: () =>
+      Promise.resolve({ supportsAVIF: true, supportsWebP: true }),
+  };
+});
+
+const server = setupServer(
+  rest.get(
+    "https://api.tylernorlund.com/random_image_details",
+    () => fixtureData,
+  ),
+);
+
+beforeAll(() => server.listen());
+afterEach(() => {
+  server.resetHandlers();
+});
+afterAll(() => server.close());
+
+describe("PhotoReceiptBoundingBox integration", () => {
+
+  test("fetches image details and displays overlays", async () => {
+    const fetchSpy = jest.spyOn(global, "fetch");
+    render(<PhotoReceiptBoundingBox />);
+
+    expect(
+      await screen.findByTestId("AnimatedConvexHull", {}, { timeout: 10000 })
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("AnimatedHullCentroid")).toBeInTheDocument();
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      expect.stringContaining("/random_image_details"),
+      expect.any(Object),
+    );
+  });
+});

--- a/portfolio/components/ui/Figures/PhotoReceiptBoundingBox.md
+++ b/portfolio/components/ui/Figures/PhotoReceiptBoundingBox.md
@@ -54,3 +54,13 @@ This document outlines the step-by-step process used to detect and draw the rece
 ### Alternative Approaches
 
 _(List the other approaches here if desired)_
+### Test Coverage
+
+The accompanying `PhotoReceiptBoundingBox.test.tsx` verifies that each animated overlay receives the expected geometry derived from fixture data. We mock the animation components to plain `<g>` elements so their invocation props can be inspected. By recomputing the convex hull, centroid and receipt tilt, the test ensures the calculations and render sequence match the algorithm described above. This guards against subtle regressions that might otherwise break the visual demonstration.
+
+A separate `receipt.fixture.test.ts` exercises the geometry utilities directly using the same fixture payload. It confirms the hull size, centroid and final tilt match predetermined values so the underlying math remains stable independent of the React component.
+
+An integration test under `__tests__/integration` loads the saved API payload via
+`fetch` and confirms the bounding box overlays render when real data is
+returned. This ensures the demo continues to function when API responses are
+wired through the hooks.

--- a/portfolio/test-utils/msw.ts
+++ b/portfolio/test-utils/msw.ts
@@ -1,0 +1,33 @@
+export type Handler = { url: string; resolver: () => any };
+
+export const rest = {
+  get: (url: string, resolver: Handler["resolver"]) => ({ url, resolver }),
+};
+
+export const setupServer = (...handlers: Handler[]) => {
+  let fetchMock: jest.Mock;
+  return {
+    listen: () => {
+      fetchMock = jest.fn(async (input: RequestInfo) => {
+        const url = typeof input === "string" ? input : input.toString();
+        const handler = handlers.find(h => url.startsWith(h.url));
+        if (handler) {
+          const result = await handler.resolver();
+          return {
+            ok: true,
+            status: 200,
+            json: async () => result,
+          } as Response;
+        }
+        return { ok: false, status: 404, json: async () => ({}) } as Response;
+      });
+      (global as any).fetch = fetchMock;
+    },
+    resetHandlers: () => {
+      if (fetchMock) fetchMock.mockReset();
+    },
+    close: () => {
+      if (fetchMock) fetchMock.mockReset();
+    },
+  };
+};

--- a/portfolio/utils/receipt.fixture.test.ts
+++ b/portfolio/utils/receipt.fixture.test.ts
@@ -1,0 +1,34 @@
+import fixtureData from "../tests/fixtures/target_receipt.json";
+import { convexHull, computeHullCentroid } from "./geometry";
+import { computeFinalReceiptTilt } from "./receipt";
+
+describe("bounding box algorithm with fixture", () => {
+  const lines = fixtureData.lines;
+  const allCorners: { x: number; y: number }[] = [];
+  lines.forEach(line => {
+    allCorners.push(
+      { x: line.top_left.x, y: line.top_left.y },
+      { x: line.top_right.x, y: line.top_right.y },
+      { x: line.bottom_right.x, y: line.bottom_right.y },
+      { x: line.bottom_left.x, y: line.bottom_left.y },
+    );
+  });
+
+  const hull = convexHull([...allCorners]);
+  const centroid = computeHullCentroid(hull);
+  const avgAngle = lines.reduce((s: number, l: any) => s + l.angle_degrees, 0) / lines.length;
+  const finalAngle = computeFinalReceiptTilt(lines as any, hull, centroid, avgAngle);
+
+  test("computes expected hull size", () => {
+    expect(hull).toHaveLength(13);
+  });
+
+  test("computes expected centroid", () => {
+    expect(centroid.x).toBeCloseTo(0.57128, 5);
+    expect(centroid.y).toBeCloseTo(0.47067, 5);
+  });
+
+  test("computes expected final angle", () => {
+    expect(finalAngle).toBeCloseTo(78.2377, 4);
+  });
+});


### PR DESCRIPTION
## Summary
- replace fetch stubbing in integration test with msw-style server
- add stub implementation under test-utils for msw
- create receipt.fixture.test.ts to validate algorithm outputs
- document the new algorithm test coverage

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test -- components/ui/Figures/PhotoReceiptBoundingBox.test.tsx __tests__/integration/PhotoReceiptBoundingBox.integration.test.tsx utils/receipt.fixture.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_684f173bf9c4832b94633423481e6957