### PR TITLE
Add useOptimizedInView tests

### DIFF
--- a/portfolio/hooks/useOptimizedInView.test.ts
+++ b/portfolio/hooks/useOptimizedInView.test.ts
@@ -1,0 +1,48 @@
+import { renderHook } from '@testing-library/react';
+import { useInView } from 'react-intersection-observer';
+import useOptimizedInView from './useOptimizedInView';
+
+jest.mock('react-intersection-observer', () => ({
+  __esModule: true,
+  useInView: jest.fn(),
+}));
+
+const mockedUseInView = useInView as jest.MockedFunction<typeof useInView>;
+
+const ref = { current: null } as React.RefObject<Element>;
+const mockedReturn: ReturnType<typeof useInView> = [ref as any, true, undefined] as any;
+
+describe('useOptimizedInView', () => {
+  beforeEach(() => {
+    mockedUseInView.mockReturnValue(mockedReturn);
+    jest.clearAllMocks();
+  });
+
+  test('forwards default options', () => {
+    const { result } = renderHook(() => useOptimizedInView());
+    expect(result.current).toBe(mockedReturn);
+    expect(mockedUseInView).toHaveBeenCalledWith({
+      threshold: 0.3,
+      triggerOnce: true,
+      rootMargin: '100px',
+      skip: false,
+      fallbackInView: true,
+    });
+  });
+
+  test('custom options override defaults', () => {
+    const options = {
+      threshold: 0.5,
+      triggerOnce: false,
+      rootMargin: '50px',
+      skip: true,
+    } as const;
+
+    const { result } = renderHook(() => useOptimizedInView(options));
+    expect(result.current).toBe(mockedReturn);
+    expect(mockedUseInView).toHaveBeenCalledWith({
+      ...options,
+      fallbackInView: true,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add missing test for `useOptimizedInView`

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684f497ab6d8832bb013234ea033ab14