### PR TITLE
Add logo component tests

### DIFF
--- a/portfolio/components/ui/Figures/ReceiptStack.test.tsx
+++ b/portfolio/components/ui/Figures/ReceiptStack.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import ReceiptStack from "./ReceiptStack";
+
+jest.mock("../../../hooks/useOptimizedInView", () => ({
+  __esModule: true,
+  default: () => [React.createRef(), true] as const,
+}));
+
+jest.mock("../../../services/api", () => ({
+  api: {
+    fetchReceipts: jest.fn(() => new Promise(() => {})),
+  },
+}));
+
+jest.mock("../../../utils/imageFormat", () => ({
+  detectImageFormatSupport: jest.fn(() =>
+    Promise.resolve({ supportsAVIF: true, supportsWebP: true })
+  ),
+  getBestImageUrl: jest.fn(() => ""),
+}));
+
+test("displays loading state", async () => {
+  render(<ReceiptStack />);
+  expect(await screen.findByText(/loading receipts/i)).toBeInTheDocument();
+});

--- a/portfolio/components/ui/Logos/GithubLogo.test.tsx
+++ b/portfolio/components/ui/Logos/GithubLogo.test.tsx
@@ -1,0 +1,8 @@
+import { render } from "@testing-library/react";
+import React from "react";
+import GithubLogo from "./GithubLogo";
+
+test("renders Github logo SVG", () => {
+  const { container } = render(<GithubLogo />);
+  expect(container.querySelector("svg")).toBeInTheDocument();
+});

--- a/portfolio/components/ui/Logos/GooglePlacesLogo.test.tsx
+++ b/portfolio/components/ui/Logos/GooglePlacesLogo.test.tsx
@@ -1,0 +1,8 @@
+import { render } from "@testing-library/react";
+import React from "react";
+import GooglePlacesLogo from "./GooglePlacesLogo";
+
+test("renders Google Places logo SVG", () => {
+  const { container } = render(<GooglePlacesLogo />);
+  expect(container.querySelector("svg")).toBeInTheDocument();
+});

--- a/portfolio/components/ui/Logos/HuggingFaceLogo.test.tsx
+++ b/portfolio/components/ui/Logos/HuggingFaceLogo.test.tsx
@@ -1,0 +1,8 @@
+import { render } from "@testing-library/react";
+import React from "react";
+import HuggingFaceLogo from "./HuggingFaceLogo";
+
+test("renders Hugging Face logo SVG", () => {
+  const { container } = render(<HuggingFaceLogo />);
+  expect(container.querySelector("svg")).toBeInTheDocument();
+});

--- a/portfolio/components/ui/Logos/NextJSLogo.test.tsx
+++ b/portfolio/components/ui/Logos/NextJSLogo.test.tsx
@@ -1,0 +1,8 @@
+import { render } from "@testing-library/react";
+import React from "react";
+import NextJSLogo from "./NextJSLogo";
+
+test("renders Next.js logo SVG", () => {
+  const { container } = render(<NextJSLogo />);
+  expect(container.querySelector("svg")).toBeInTheDocument();
+});

--- a/portfolio/components/ui/Logos/OpenAILogo.test.tsx
+++ b/portfolio/components/ui/Logos/OpenAILogo.test.tsx
@@ -1,0 +1,8 @@
+import { render } from "@testing-library/react";
+import React from "react";
+import OpenAILogo from "./OpenAILogo";
+
+test("renders OpenAI logo SVG", () => {
+  const { container } = render(<OpenAILogo />);
+  expect(container.querySelector("svg")).toBeInTheDocument();
+});

--- a/portfolio/components/ui/Logos/PineconeLogo.test.tsx
+++ b/portfolio/components/ui/Logos/PineconeLogo.test.tsx
@@ -1,0 +1,8 @@
+import { render } from "@testing-library/react";
+import React from "react";
+import PineconeLogo from "./PineconeLogo";
+
+test("renders Pinecone logo SVG", () => {
+  const { container } = render(<PineconeLogo />);
+  expect(container.querySelector("svg")).toBeInTheDocument();
+});

--- a/portfolio/components/ui/Logos/PulumiLogo.test.tsx
+++ b/portfolio/components/ui/Logos/PulumiLogo.test.tsx
@@ -1,0 +1,8 @@
+import { render } from "@testing-library/react";
+import React from "react";
+import PulumiLogo from "./PulumiLogo";
+
+test("renders Pulumi logo SVG", () => {
+  const { container } = render(<PulumiLogo />);
+  expect(container.querySelector("svg")).toBeInTheDocument();
+});

--- a/portfolio/components/ui/Logos/PyTorchLogo.test.tsx
+++ b/portfolio/components/ui/Logos/PyTorchLogo.test.tsx
@@ -1,0 +1,8 @@
+import { render } from "@testing-library/react";
+import React from "react";
+import PyTorchLogo from "./PyTorchLogo";
+
+test("renders PyTorch logo SVG", () => {
+  const { container } = render(<PyTorchLogo />);
+  expect(container.querySelector("svg")).toBeInTheDocument();
+});

--- a/portfolio/components/ui/Logos/ReactLogo.test.tsx
+++ b/portfolio/components/ui/Logos/ReactLogo.test.tsx
@@ -1,0 +1,8 @@
+import { render } from "@testing-library/react";
+import React from "react";
+import ReactLogo from "./ReactLogo";
+
+test("renders React logo SVG", () => {
+  const { container } = render(<ReactLogo />);
+  expect(container.querySelector("svg")).toBeInTheDocument();
+});

--- a/portfolio/components/ui/Logos/TypeScriptLogo.test.tsx
+++ b/portfolio/components/ui/Logos/TypeScriptLogo.test.tsx
@@ -1,0 +1,8 @@
+import { render } from "@testing-library/react";
+import React from "react";
+import TypeScriptLogo from "./TypeScriptLogo";
+
+test("renders TypeScript logo SVG", () => {
+  const { container } = render(<TypeScriptLogo />);
+  expect(container.querySelector("svg")).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- add unit tests for each UI logo component
- add test ensuring ReceiptStack shows a loading message when mounted

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f498d299c832b9bcaa0525f13ac70