### PR TITLE
Fix typedoc warnings

### DIFF
--- a/portfolio/typedoc.json
+++ b/portfolio/typedoc.json
@@ -6,7 +6,7 @@
 
   /* Let TypeDoc start from every .ts/.tsx file under /app           *
    * (If your code lives in /src or somewhere else, change this.)    */
-  "entryPoints": ["utils"],
+  "entryPoints": ["utils", "types"],
   "entryPointStrategy": "expand",
 
   /* Where the HTML docs go */


### PR DESCRIPTION
## Summary
- document utility types by including the `types` directory in Typedoc

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684f48063cc4832b84b81ece153b3de9