### PR TITLE
Add bounding box component tests

### DIFF
--- a/portfolio/components/ui/BoundingBox/__tests__/ConvexHull.test.tsx
+++ b/portfolio/components/ui/BoundingBox/__tests__/ConvexHull.test.tsx
@@ -1,0 +1,42 @@
+import { render } from "@testing-library/react";
+import { act } from "@testing-library/react";
+import React from "react";
+import ConvexHull from "../ConvexHull";
+
+describe("ConvexHull", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    jest.useRealTimers();
+  });
+
+  test("renders hull points sequentially", () => {
+    const points = [
+      { x: 0, y: 0 },
+      { x: 0.5, y: 0.5 },
+      { x: 1, y: 1 },
+    ];
+    const { container } = render(
+      <svg>
+        <ConvexHull hullPoints={points} svgWidth={100} svgHeight={100} delay={0} />
+      </svg>,
+    );
+
+    expect(container.querySelectorAll("circle")).toHaveLength(0);
+
+    act(() => {
+      jest.advanceTimersByTime(200);
+    });
+    expect(container.querySelectorAll("circle")).toHaveLength(1);
+
+    act(() => {
+      jest.advanceTimersByTime(400);
+    });
+    expect(container.querySelectorAll("circle")).toHaveLength(points.length);
+  });
+});

--- a/portfolio/components/ui/BoundingBox/__tests__/HullCentroid.test.tsx
+++ b/portfolio/components/ui/BoundingBox/__tests__/HullCentroid.test.tsx
@@ -1,0 +1,30 @@
+import { render } from "@testing-library/react";
+import React from "react";
+import HullCentroid from "../HullCentroid";
+
+jest.mock("@react-spring/web", () => ({
+  useSpring: () => ({
+    opacity: 1,
+    scale: { to: (fn: (v: number) => any) => fn(1) },
+  }),
+  animated: {
+    circle: (props: any) => <circle {...props} />,
+  },
+}));
+
+test("renders centroid circle at correct position", () => {
+  const { container } = render(
+    <svg>
+      <HullCentroid
+        centroid={{ x: 0.5, y: 0.25 }}
+        svgWidth={100}
+        svgHeight={200}
+        delay={0}
+      />
+    </svg>,
+  );
+
+  const circle = container.querySelector("circle");
+  expect(circle).toHaveAttribute("cx", "50");
+  expect(circle).toHaveAttribute("cy", "150");
+});

--- a/portfolio/components/ui/BoundingBox/__tests__/OrientedAxes.test.tsx
+++ b/portfolio/components/ui/BoundingBox/__tests__/OrientedAxes.test.tsx
@@ -1,0 +1,66 @@
+import { render } from "@testing-library/react";
+import { act } from "@testing-library/react";
+import React from "react";
+import OrientedAxes from "../OrientedAxes";
+
+const line = {
+  image_id: "1",
+  line_id: 1,
+  text: "",
+  bounding_box: { x: 0, y: 0, width: 1, height: 1 },
+  top_left: { x: 0, y: 1 },
+  top_right: { x: 1, y: 1 },
+  bottom_left: { x: 0, y: 0 },
+  bottom_right: { x: 1, y: 0 },
+  angle_degrees: 0,
+  angle_radians: 0,
+  confidence: 1,
+};
+
+describe("OrientedAxes", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    jest.useRealTimers();
+  });
+
+  test("draws axes and extreme points", () => {
+    const hull = [
+      { x: 0, y: 0 },
+      { x: 0, y: 1 },
+      { x: 1, y: 0 },
+    ];
+    const centroid = { x: 0.5, y: 0.5 };
+    const { container } = render(
+      <svg>
+        <OrientedAxes
+          hull={hull}
+          centroid={centroid}
+          lines={[line] as any}
+          svgWidth={100}
+          svgHeight={100}
+          delay={0}
+        />
+      </svg>,
+    );
+
+    expect(container.querySelectorAll("line")).toHaveLength(0);
+    act(() => {
+      jest.advanceTimersByTime(400);
+    });
+    expect(container.querySelectorAll("line")).toHaveLength(1);
+    act(() => {
+      jest.advanceTimersByTime(400);
+    });
+    expect(container.querySelectorAll("line")).toHaveLength(2);
+    act(() => {
+      jest.advanceTimersByTime(400);
+    });
+    expect(container.querySelectorAll("circle")).toHaveLength(4);
+  });
+});

--- a/portfolio/components/ui/BoundingBox/__tests__/PrimaryBoundaryLines.test.tsx
+++ b/portfolio/components/ui/BoundingBox/__tests__/PrimaryBoundaryLines.test.tsx
@@ -1,0 +1,26 @@
+import { render } from "@testing-library/react";
+import React from "react";
+import PrimaryBoundaryLines, { LineSegment } from "../PrimaryBoundaryLines";
+
+jest.mock("@react-spring/web", () => ({
+  useTransition: (items: any[]) => (fn: (style: any, item: any) => JSX.Element) =>
+    items.map(item => fn({}, item)),
+  animated: {
+    line: (props: any) => <line {...props} />,
+  },
+}));
+
+test("renders circles and lines for segments", () => {
+  const segments: LineSegment[] = [
+    { x1: 0, y1: 0, x2: 10, y2: 10, key: "a" },
+    { x1: 10, y1: 10, x2: 20, y2: 20, key: "b" },
+  ];
+  const { container } = render(
+    <svg>
+      <PrimaryBoundaryLines segments={segments} delay={0} />
+    </svg>,
+  );
+
+  expect(container.querySelectorAll("circle")).toHaveLength(segments.length * 2);
+  expect(container.querySelectorAll("line")).toHaveLength(segments.length);
+});


### PR DESCRIPTION
## Summary
- test `ConvexHull` rendering timing
- test `HullCentroid` rendering
- test `OrientedAxes` sequential drawing
- test `PrimaryBoundaryLines` output

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`
- `npm run test:coverage` (fails due to coverage threshold)

------
https://chatgpt.com/codex/tasks/task_e_684f4f54ea40832b89db5cc67769bb96