### PR TITLE
Add component unit tests

### DIFF
--- a/portfolio/components/ClientOnly.test.tsx
+++ b/portfolio/components/ClientOnly.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import ClientOnly from "./ClientOnly";
+import { act } from "react";
+
+describe("ClientOnly", () => {
+  test("replaces fallback with children after mount", () => {
+    jest.useFakeTimers();
+    render(
+      <ClientOnly fallback={<span data-testid="fallback">loading</span>}>
+        <span>content</span>
+      </ClientOnly>,
+    );
+    act(() => {
+      jest.runAllTimers();
+    });
+    expect(screen.queryByTestId("fallback")).not.toBeInTheDocument();
+    expect(screen.getByText("content")).toBeInTheDocument();
+    jest.useRealTimers();
+  });
+});

--- a/portfolio/components/ui/LoadingSpinner/LoadingSpinner.test.tsx
+++ b/portfolio/components/ui/LoadingSpinner/LoadingSpinner.test.tsx
@@ -1,0 +1,22 @@
+import { render } from "@testing-library/react";
+import React from "react";
+import LoadingSpinner from "./LoadingSpinner";
+import styles from "./LoadingSpinner.module.css";
+
+describe("LoadingSpinner", () => {
+  test("defaults to medium size", () => {
+    const { container } = render(<LoadingSpinner />);
+    const outer = container.firstChild as HTMLElement;
+    expect(outer).toHaveClass(styles.spinner);
+    expect(outer).toHaveClass(styles.medium);
+  });
+
+  (['small', 'medium', 'large'] as const).forEach(size => {
+    test(`applies ${size} class`, () => {
+      const { container } = render(<LoadingSpinner size={size} />);
+      const outer = container.firstChild as HTMLElement;
+      expect(outer).toHaveClass(styles.spinner);
+      expect(outer).toHaveClass(styles[size]);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add unit test for ClientOnly to verify fallback is removed
- add LoadingSpinner unit tests for CSS classes

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684f4f603db0832b938ca84409864a46