### PR TITLE
Add test for API config env overrides

### DIFF
--- a/portfolio/services/api/config.test.ts
+++ b/portfolio/services/api/config.test.ts
@@ -1,0 +1,24 @@
+describe('API_CONFIG', () => {
+  const originalEnv = process.env.NEXT_PUBLIC_API_URL;
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.NEXT_PUBLIC_API_URL;
+    } else {
+      process.env.NEXT_PUBLIC_API_URL = originalEnv;
+    }
+    jest.resetModules();
+  });
+
+  test('reflects NEXT_PUBLIC_API_URL when set', () => {
+    process.env.NEXT_PUBLIC_API_URL = 'https://example.com';
+    const { API_CONFIG } = require('./config');
+    expect(API_CONFIG.baseUrl).toBe('https://example.com');
+  });
+
+  test('falls back to default when NEXT_PUBLIC_API_URL not set', () => {
+    delete process.env.NEXT_PUBLIC_API_URL;
+    const { API_CONFIG } = require('./config');
+    expect(API_CONFIG.baseUrl).toBe('https://api.tylernorlund.com');
+  });
+});


### PR DESCRIPTION
## Summary
- ensure API config reads NEXT_PUBLIC_API_URL at runtime

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684f4f684898832baf62c89f59193ff9