### PR TITLE
Add ResumeRole tests

### DIFF
--- a/portfolio/pages/__tests__/ResumeRole.test.tsx
+++ b/portfolio/pages/__tests__/ResumeRole.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { ResumeRole } from "../resume";
+
+describe("ResumeRole", () => {
+  const sampleRole = {
+    title: "Engineer",
+    business: "ACME Corp",
+    location: "NYC",
+    dateRange: "2020-2021",
+    bullets: ["Did something", "Did another thing"],
+  };
+
+  test("renders bullets and date range", () => {
+    render(<ResumeRole {...sampleRole} />);
+    expect(screen.getByText(sampleRole.dateRange)).toBeInTheDocument();
+    expect(screen.getAllByRole("listitem")).toHaveLength(sampleRole.bullets.length);
+    sampleRole.bullets.forEach((text) => {
+      expect(screen.getByText(text)).toBeInTheDocument();
+    });
+  });
+
+  test("renders without business and location", () => {
+    const { container } = render(
+      <ResumeRole
+        title="Engineer"
+        dateRange="2020-2021"
+        bullets={["Did something"]}
+      />,
+    );
+
+    expect(container.querySelector("hr")).toBeNull();
+    expect(screen.getByText("2020-2021")).toBeInTheDocument();
+    expect(screen.getByText("Did something")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add test for ResumeRole component to verify bullets and date rendering
- ensure component skips business/location block when omitted

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684f4f6eeca4832b806459fd7745a02d