### PR TITLE
Remove unused imports from PhotoReceiptBoundingBox

### DIFF
--- a/portfolio/components/ui/Figures/PhotoReceiptBoundingBox.tsx
+++ b/portfolio/components/ui/Figures/PhotoReceiptBoundingBox.tsx
@@ -18,16 +18,10 @@ import { getBestImageUrl } from "../../../utils/imageFormat";
 import useImageDetails from "../../../hooks/useImageDetails";
 import {
   computeHullCentroid,
-  computeReceiptBoxFromLineEdges,
-  computeEdge,
   convexHull,
 } from "../../../utils/geometry";
 import {
-  findBoundaryLinesWithSkew,
   estimateReceiptPolygonFromLines,
-  findHullExtentsRelativeToCentroid,
-  computeReceiptBoxFromHull,
-  findLineEdgesAtPrimaryExtremes,
   computeFinalReceiptTilt,
 } from "../../../utils/receipt";
 import {


### PR DESCRIPTION
## Summary
- clean up unused geometry and receipt imports in PhotoReceiptBoundingBox

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68547ccbc1e8832bb45f7a3ec9902857