### PR TITLE
Centralize animation timing config

### DIFF
--- a/portfolio/components/ui/Figures/PhotoReceiptBoundingBox.test.tsx
+++ b/portfolio/components/ui/Figures/PhotoReceiptBoundingBox.test.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import PhotoReceiptBoundingBox from "./PhotoReceiptBoundingBox";
 import fixtureData from "../../../tests/fixtures/target_receipt.json";
 import useImageDetails from "../../../hooks/useImageDetails";
+import { getAnimationConfig } from "./animationConfig";
 
 import * as animations from "../animations";
 import { convexHull, computeHullCentroid } from "../../../utils/geometry";
@@ -119,12 +120,13 @@ describe("PhotoReceiptBoundingBox", () => {
           )
         : avgAngle;
 
-    const totalDelayForLines =
-      lines.length > 0 ? (lines.length - 1) * 30 + 800 : 0;
-    const convexHullDelay = totalDelayForLines + 300;
-    const convexHullDuration = hullPoints.length * 200 + 500;
-    const centroidDelay = convexHullDelay + convexHullDuration + 200;
-    const extentsDelay = centroidDelay + 600;
+    const {
+      totalDelayForLines,
+      convexHullDelay,
+      convexHullDuration,
+      centroidDelay,
+      extentsDelay,
+    } = getAnimationConfig(lines.length, hullPoints.length);
 
     // Calculate refined segments for AnimatedPrimaryBoundaryLines test
     const hullExtremes =

--- a/portfolio/components/ui/Figures/PhotoReceiptBoundingBox.tsx
+++ b/portfolio/components/ui/Figures/PhotoReceiptBoundingBox.tsx
@@ -18,6 +18,7 @@ import { getBestImageUrl } from "../../../utils/imageFormat";
 import useImageDetails from "../../../hooks/useImageDetails";
 import { estimateReceiptPolygonFromLines } from "../../../utils/receipt";
 import useReceiptGeometry from "../../../hooks/useReceiptGeometry";
+import { getAnimationConfig } from "./animationConfig";
 
 // Define simple point and line-segment shapes
 const isDevelopment = process.env.NODE_ENV === "development";
@@ -92,16 +93,16 @@ const PhotoReceiptBoundingBox: React.FC = () => {
   });
 
   // Compute animation timing
-  const totalDelayForLines =
-    lines.length > 0 ? (lines.length - 1) * 30 + 800 : 0;
-  const convexHullDelay = totalDelayForLines + 300; // Start convex hull after lines
-  const convexHullDuration = convexHullPoints.length * 200 + 500;
-  const centroidDelay = convexHullDelay + convexHullDuration + 200; // Hull centroid after convex hull
-  const extentsDelay = centroidDelay + 600; // Extents after centroid
-  const extentsDuration = 4 * 300 + 500; // 4 extent lines * 300ms + buffer
-  const hullEdgeAlignmentDuration = 800 + 1000; // 2 steps total duration
-  const receiptDelay =
-    extentsDelay + extentsDuration + hullEdgeAlignmentDuration + 300; // Receipt after Hull Edge Alignment
+  const {
+    totalDelayForLines,
+    convexHullDelay,
+    convexHullDuration,
+    centroidDelay,
+    extentsDelay,
+    extentsDuration,
+    hullEdgeAlignmentDuration,
+    receiptDelay,
+  } = getAnimationConfig(lines.length, convexHullPoints.length);
 
   // Use the first image from the API.
   const firstImage = imageDetails?.image;

--- a/portfolio/components/ui/Figures/animationConfig.ts
+++ b/portfolio/components/ui/Figures/animationConfig.ts
@@ -1,0 +1,36 @@
+export interface AnimationConfig {
+  totalDelayForLines: number;
+  convexHullDelay: number;
+  convexHullDuration: number;
+  centroidDelay: number;
+  extentsDelay: number;
+  extentsDuration: number;
+  hullEdgeAlignmentDuration: number;
+  receiptDelay: number;
+}
+
+export function getAnimationConfig(
+  lineCount: number,
+  hullPointCount: number,
+): AnimationConfig {
+  const totalDelayForLines = lineCount > 0 ? (lineCount - 1) * 30 + 800 : 0;
+  const convexHullDelay = totalDelayForLines + 300; // Start convex hull after lines
+  const convexHullDuration = hullPointCount * 200 + 500;
+  const centroidDelay = convexHullDelay + convexHullDuration + 200; // Hull centroid after convex hull
+  const extentsDelay = centroidDelay + 600; // Extents after centroid
+  const extentsDuration = 4 * 300 + 500; // 4 extent lines * 300ms + buffer
+  const hullEdgeAlignmentDuration = 800 + 1000; // 2 steps total duration
+  const receiptDelay =
+    extentsDelay + extentsDuration + hullEdgeAlignmentDuration + 300; // Receipt after Hull Edge Alignment
+
+  return {
+    totalDelayForLines,
+    convexHullDelay,
+    convexHullDuration,
+    centroidDelay,
+    extentsDelay,
+    extentsDuration,
+    hullEdgeAlignmentDuration,
+    receiptDelay,
+  };
+}


### PR DESCRIPTION
## Summary
- add animation config generator module
- use animationConfig in PhotoReceiptBoundingBox component and tests

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6854833f40a8832b951d06945832cd5b