### PR TITLE
Remove unused AnimatedReceiptFromHull

### DIFF
--- a/portfolio/components/ui/Figures/PhotoReceiptBoundingBox.tsx
+++ b/portfolio/components/ui/Figures/PhotoReceiptBoundingBox.tsx
@@ -12,7 +12,6 @@ import {
   AnimatedSecondaryBoundaryLines,
   AnimatedPrimaryBoundaryLines,
   AnimatedHullEdgeAlignment,
-  AnimatedReceiptFromHull,
 } from "../animations";
 import { getBestImageUrl } from "../../../utils/imageFormat";
 import useImageDetails from "../../../hooks/useImageDetails";
@@ -366,17 +365,6 @@ const PhotoReceiptBoundingBox: React.FC = () => {
                   />
                 )}
 
-              {/* Render animated receipt using proper algorithm */}
-              {/* {convexHullPoints.length > 0 && lines.length > 0 && (
-                <AnimatedReceiptFromHull
-                  key={`receipt-from-hull-${resetKey}`}
-                  hull={convexHullPoints}
-                  lines={lines}
-                  svgWidth={svgWidth}
-                  svgHeight={svgHeight}
-                  delay={receiptDelay}
-                />
-              )} */}
             </svg>
           ) : (
             // While loading, show a "Loading" message centered in the reserved space.


### PR DESCRIPTION
## Summary
- clean up PhotoReceiptBoundingBox by dropping unused `AnimatedReceiptFromHull`

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6854878178e8832b905009a73d879aa9