### PR TITLE
Update merchant validation READMEs

### DIFF
--- a/infra/validate_merchant_step_functions/README.md
+++ b/infra/validate_merchant_step_functions/README.md
@@ -1,0 +1,18 @@
+# Validate Merchant Step Functions
+
+This module defines a Step Function that validates merchants **per receipt**. The
+workflow is designed to run after receipt OCR ingestion to consolidate merchant
+metadata.
+
+## Workflow
+
+1. **ListReceipts** – gathers receipt identifiers that require merchant
+   validation.
+2. **ValidateReceipt** – a `Map` state invoking a Lambda to validate each
+   receipt individually.
+3. **ConsolidateMetadata** – merges the validated merchant information for
+   reporting and further processing.
+
+The focus here is on validating the merchant for each receipt. If you need to
+validate existing word labels grouped by merchant, see the companion module in
+`infra/validation_by_merchant`.

--- a/infra/validation_by_merchant/README.md
+++ b/infra/validation_by_merchant/README.md
@@ -1,0 +1,16 @@
+# Validation by Merchant
+
+This directory defines a Step Function that validates word labels **grouped by
+merchant**. It first lists all unique merchants with their associated receipts
+and then runs validation for each batch.
+
+## Workflow
+
+1. **ListUniqueMerchants** – a Lambda collects receipt IDs grouped by canonical
+   merchant name.
+2. **ValidateLabel** – a `Map` state iterating over each batch and validating the
+   selected labels for every receipt.
+
+Use this when validating labels across receipts owned by the same merchant.
+For receipt-level merchant metadata validation, see
+`infra/validate_merchant_step_functions`.


### PR DESCRIPTION
## Summary
- document validate-merchant step functions
- add README for validation-by-merchant

## Testing
- `pytest -m unit receipt_dynamo -q`

------
https://chatgpt.com/codex/tasks/task_e_6858c4fb7a54832b867d9fa1546d9750