### PR TITLE
Add result_processor tests

### DIFF
--- a/receipt_label/receipt_label/tests/merchant_validation/conftest.py
+++ b/receipt_label/receipt_label/tests/merchant_validation/conftest.py
@@ -1,0 +1,59 @@
+"""
+Pytest configuration for merchant validation tests.
+
+This module provides fixtures specifically for merchant validation tests.
+"""
+
+import os
+from typing import Dict, Iterator
+
+import pytest
+
+
+@pytest.fixture(scope="function")
+def clean_env_vars() -> Iterator[Dict[str, str]]:
+    """
+    Fixture to temporarily override environment variables for tests.
+    
+    This fixture:
+    1. Saves the current environment state
+    2. Allows tests to modify environment variables
+    3. Restores the original environment state after the test
+    
+    Usage:
+        def test_something(clean_env_vars):
+            os.environ["SOME_VAR"] = "test_value"
+            # Test code here
+            # Environment will be restored automatically
+    """
+    # Save current environment
+    original_env = dict(os.environ)
+    
+    # Define the test environment defaults
+    test_env = {
+        "DYNAMO_TABLE_NAME": "test-table",
+        "OPENAI_API_KEY": "test-openai-key",
+        "PINECONE_API_KEY": "test-pinecone-key",
+        "PINECONE_INDEX_NAME": "test-index",
+        "PINECONE_HOST": "test-host",
+    }
+    
+    try:
+        yield test_env
+    finally:
+        # Restore original environment
+        os.environ.clear()
+        os.environ.update(original_env)
+
+
+@pytest.fixture
+def mock_agents():
+    """
+    Fixture to get the mocked agents module.
+    
+    Note: The actual mocking happens in test_helpers.setup_test_environment()
+    which must be called before imports. This fixture just provides access
+    to the already-mocked module for tests that need to configure it.
+    """
+    import sys
+    return sys.modules.get('agents')

--- a/receipt_label/receipt_label/tests/merchant_validation/test_clustering.py
+++ b/receipt_label/receipt_label/tests/merchant_validation/test_clustering.py
@@ -1,6 +1,12 @@
 """Unit tests for merchant metadata clustering."""
 
+# Set up test environment before imports
+import sys
 import os
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from test_helpers import setup_test_environment
+setup_test_environment()
+
 import uuid as uuid_module
 from datetime import datetime, timezone
 from typing import List, Optional
@@ -8,9 +14,6 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from receipt_dynamo.entities import ReceiptMetadata
-
-# Set environment variable before imports
-os.environ.setdefault("DYNAMO_TABLE_NAME", "test")
 
 
 def _build_metadata(
@@ -44,10 +47,7 @@ def _build_metadata(
     )
 
 
-# Mock the agents module at module level to avoid import errors
-mock_agents = MagicMock()
-with patch.dict("sys.modules", {"agents": mock_agents}):
-    from receipt_label.merchant_validation.clustering import cluster_by_metadata
+from receipt_label.merchant_validation.clustering import cluster_by_metadata
 
 
 def test_cluster_by_metadata_groups_similar_records() -> None:

--- a/receipt_label/receipt_label/tests/merchant_validation/test_helpers.py
+++ b/receipt_label/receipt_label/tests/merchant_validation/test_helpers.py
@@ -1,0 +1,40 @@
+"""
+Test helper utilities for merchant validation tests.
+
+This module provides common test setup functionality that needs to run
+before imports, such as mocking the agents module.
+"""
+
+import os
+import sys
+from unittest.mock import MagicMock
+
+
+def setup_test_environment():
+    """
+    Set up the test environment with required mocks and environment variables.
+    
+    This function should be called at the top of test modules before any
+    imports from the merchant_validation package.
+    """
+    # Set environment variables if not already set
+    env_defaults = {
+        "DYNAMO_TABLE_NAME": "test-table",
+        "OPENAI_API_KEY": "test-openai-key",
+        "PINECONE_API_KEY": "test-pinecone-key",
+        "PINECONE_INDEX_NAME": "test-index",
+        "PINECONE_HOST": "test-host",
+    }
+    
+    for key, value in env_defaults.items():
+        os.environ.setdefault(key, value)
+    
+    # Mock the agents module if not already mocked
+    if 'agents' not in sys.modules:
+        mock_agents = MagicMock()
+        mock_agents.Agent = MagicMock()
+        mock_agents.Runner = MagicMock()
+        mock_agents.function_tool = MagicMock()
+        sys.modules['agents'] = mock_agents
+    
+    return sys.modules['agents']

--- a/receipt_label/receipt_label/tests/merchant_validation/test_metadata_builder.py
+++ b/receipt_label/receipt_label/tests/merchant_validation/test_metadata_builder.py
@@ -1,14 +1,16 @@
 """Unit tests for merchant metadata builders."""
 
+# Set up test environment before imports
+import sys
+import os
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from test_helpers import setup_test_environment
+setup_test_environment()
+
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
 import pytest
-
-# Mock the agents module before importing
-import sys
-mock_agents = MagicMock()
-sys.modules['agents'] = mock_agents
 
 from receipt_label.merchant_validation.metadata_builder import (
     build_receipt_metadata_from_result,

--- a/receipt_label/receipt_label/tests/merchant_validation/test_result_processor.py
+++ b/receipt_label/receipt_label/tests/merchant_validation/test_result_processor.py
@@ -1,26 +1,25 @@
 """Tests for merchant validation result_processor module."""
 
+# Set up test environment before imports
+import sys
 import os
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from test_helpers import setup_test_environment
+setup_test_environment()
+
 from datetime import datetime
-from importlib import util
 from unittest.mock import Mock, patch
 
 import pytest
 from receipt_dynamo.constants import ValidationMethod
 
-# Environment must be set before importing the module under test
-os.environ.setdefault("DYNAMO_TABLE_NAME", "table")
-os.environ.setdefault("PINECONE_API_KEY", "key")
-os.environ.setdefault("OPENAI_API_KEY", "key")
-os.environ.setdefault("PINECONE_INDEX_NAME", "index")
-os.environ.setdefault("PINECONE_HOST", "host")
-spec = util.spec_from_file_location(
-    "rp", "receipt_label/receipt_label/merchant_validation/result_processor.py"
+from receipt_label.merchant_validation.result_processor import (
+    _validate_match_quality,
+    extract_best_partial_match,
+    build_receipt_metadata_from_partial_result,
+    sanitize_string,
+    sanitize_metadata_strings,
 )
-assert spec and spec.loader
-rp = util.module_from_spec(spec)
-spec.loader.exec_module(rp)  # type: ignore[attr-defined]
-# pylint: disable=protected-access
 
 
 @pytest.mark.unit
@@ -32,7 +31,7 @@ def test_validate_match_quality_all_high():
         "address": "123 Main St, City",
         "matched_fields": ["name", "phone", "address"],
     }
-    result = rp._validate_match_quality(data)
+    result = _validate_match_quality(data)
     assert set(result) == {"name", "phone", "address"}
 
 
@@ -45,7 +44,49 @@ def test_validate_match_quality_low_quality():
         "address": "Unit",
         "matched_fields": ["name", "phone", "address"],
     }
-    assert rp._validate_match_quality(data) == []
+    assert _validate_match_quality(data) == []
+
+
+@pytest.mark.unit
+def test_validate_match_quality_mixed_high_low():
+    """Mixed quality: keep high-quality fields, discard low-quality ones."""
+    data = {
+        "merchant_name": "Starbucks Coffee Company",  # High quality
+        "phone_number": "123",  # Low quality (< 10 digits)
+        "address": "123 Main Street, San Francisco, CA",  # High quality
+        "matched_fields": ["name", "phone", "address"],
+    }
+    result = _validate_match_quality(data)
+    assert set(result) == {"name", "address"}
+    assert "phone" not in result
+
+
+@pytest.mark.unit
+def test_validate_match_quality_partial_address():
+    """Address with only one meaningful component should be discarded."""
+    data = {
+        "merchant_name": "Target Store",
+        "phone_number": "(415) 555-0123",
+        "address": "Unit",  # Only one meaningful component
+        "matched_fields": ["name", "phone", "address"],
+    }
+    result = _validate_match_quality(data)
+    assert set(result) == {"name", "phone"}
+    assert "address" not in result
+
+
+@pytest.mark.unit
+def test_validate_match_quality_short_name():
+    """Very short names should be discarded."""
+    data = {
+        "merchant_name": "AB",  # Too short (≤ 2 chars)
+        "phone_number": "415-555-0123",
+        "address": "123 Main St",
+        "matched_fields": ["name", "phone", "address"],
+    }
+    result = _validate_match_quality(data)
+    assert set(result) == {"phone", "address"}
+    assert "name" not in result
 
 
 @pytest.mark.unit
@@ -71,7 +112,7 @@ def test_extract_best_partial_match_phone_preferred():
             },
         },
     ]
-    match = rp.extract_best_partial_match(partial_results, {})
+    match = extract_best_partial_match(partial_results, {})
     assert match["source"] == "phone_lookup"
     assert match["place_id"] == "pid1"
     assert match["matched_fields"] == ["phone"]
@@ -100,7 +141,7 @@ def test_extract_best_partial_match_address_fallback():
             },
         },
     ]
-    match = rp.extract_best_partial_match(partial_results, {})
+    match = extract_best_partial_match(partial_results, {})
     assert match["source"] == "address_lookup"
     assert match["place_id"] == "pid2"
     assert match["matched_fields"] == ["address"]
@@ -119,7 +160,87 @@ def test_extract_best_partial_match_none_returned():
             "result": {"place_id": "", "name": ""},
         },
     ]
-    assert rp.extract_best_partial_match(partial_results, {}) is None
+    assert extract_best_partial_match(partial_results, {}) is None
+
+
+@pytest.mark.unit
+def test_extract_best_partial_match_text_search_fallback():
+    """Text search is used as last resort when phone/address fail."""
+    partial_results = [
+        {
+            "function": "search_by_phone",
+            "result": {"place_id": "", "name": ""},  # Empty result
+        },
+        {
+            "function": "search_by_address",
+            "result": {"place_id": "pid1", "name": "A"},  # Name too short
+        },
+        {
+            "function": "search_by_text",
+            "result": {
+                "place_id": "pid3",
+                "name": "Whole Foods Market",
+                "formatted_address": "123 Market St",
+            },
+        },
+    ]
+    match = extract_best_partial_match(partial_results, {})
+    assert match["source"] == "text_search"
+    assert match["place_id"] == "pid3"
+    assert match["matched_fields"] == ["name"]
+
+
+@pytest.mark.unit
+def test_extract_best_partial_match_text_search_short_name():
+    """Text search with short name is rejected."""
+    partial_results = [
+        {
+            "function": "search_by_text",
+            "result": {
+                "place_id": "pid1",
+                "name": "AB",  # Too short
+                "formatted_address": "123 Main St",
+            },
+        },
+    ]
+    assert extract_best_partial_match(partial_results, {}) is None
+
+
+@pytest.mark.unit
+def test_extract_best_partial_match_priority_order():
+    """Verify priority: phone > address > text search."""
+    partial_results = [
+        {
+            "function": "search_by_text",
+            "result": {
+                "place_id": "pid_text",
+                "name": "Text Search Result",
+                "formatted_address": "789 Text St",
+            },
+        },
+        {
+            "function": "search_by_address",
+            "result": {
+                "place_id": "pid_addr",
+                "name": "Address Result",
+                "formatted_address": "456 Address Ave",
+                "formatted_phone_number": "(555) 222-3333",
+            },
+        },
+        {
+            "function": "search_by_phone",
+            "result": {
+                "place_id": "pid_phone",
+                "name": "Phone Result",
+                "formatted_address": "123 Phone Ln",
+                "formatted_phone_number": "(555) 111-2222",
+            },
+        },
+    ]
+    # Phone should win even if it appears last
+    match = extract_best_partial_match(partial_results, {})
+    assert match["source"] == "phone_lookup"
+    assert match["place_id"] == "pid_phone"
 
 
 @pytest.mark.unit
@@ -134,10 +255,11 @@ def test_build_receipt_metadata_from_partial_result():
         "source": "phone_lookup",
     }
     mock_metadata = Mock()
-    with patch.object(
-        rp, "ReceiptMetadata", return_value=mock_metadata
+    with patch(
+        "receipt_label.merchant_validation.result_processor.ReceiptMetadata",
+        return_value=mock_metadata
     ) as meta:
-        result = rp.build_receipt_metadata_from_partial_result(
+        result = build_receipt_metadata_from_partial_result(
             "img",
             1,
             partial,
@@ -158,7 +280,143 @@ def test_build_receipt_metadata_from_partial_result():
 @pytest.mark.unit
 def test_sanitize_string_various_cases():
     """Ensure sanitize_string handles quoting and non-strings."""
-    assert rp.sanitize_string('"Hello"') == "Hello"
-    assert rp.sanitize_string("'\"Hello\"'") == "Hello"
-    assert rp.sanitize_string(123) == "123"
-    assert rp.sanitize_string("  world  ") == "world"
+    assert sanitize_string('"Hello"') == "Hello"
+    assert sanitize_string("'\"Hello\"'") == "Hello"
+    assert sanitize_string(123) == "123"
+    assert sanitize_string("  world  ") == "world"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("input_value,expected", [
+    # Basic quote removal
+    ('"Hello"', "Hello"),
+    ("'Hello'", "Hello"),
+    ('""Hello""', "Hello"),  # Double quotes
+    ("''Hello''", "'Hello'"),  # Inner single quotes have unmatched quotes
+    
+    # Mixed quotes
+    ('"\'Hello\'"', "Hello"),  # JSON parsing handles this
+    ('"\\"Hello\\""', "Hello"),  # JSON parsing handles escaped quotes
+    ('"Hello\'s"', "Hello's"),  # Apostrophe preserved
+    
+    # Complex nested quotes
+    ('"""Hello"""', "Hello"),  # Multiple iterations strip all quotes
+    ("'''Hello'''", "''Hello''"),  # Single quotes don't iterate as deeply
+    ('""\\"Nested\\"""', '"Nested"'),  # JSON parsing handles this
+    
+    # Unicode quotes
+    ('"Hello"', "Hello"),  # Left/right double quotes
+    ("'Hello'", "Hello"),  # Left/right single quotes
+    ('""Hello""', "Hello"),  # Mixed unicode quotes
+    
+    # Mismatched quotes
+    ('"Hello\'', "Hello"),
+    ('\'Hello"', "Hello"),
+    ('"Hello', '"Hello'),  # Keep if no closing quote
+    
+    # Edge cases
+    ("", ""),
+    ("   ", ""),
+    (None, ""),
+    ('"', '"'),  # Single quote char
+    ('""', '""'),  # Empty quotes - sanitize_string preserves original if result would be empty
+    ("'\"'", '"'),  # Quote inside quotes
+    
+    # Non-string inputs
+    (123, "123"),
+    (45.67, "45.67"),
+    (True, "True"),
+    (False, "False"),
+    
+    # Whitespace handling
+    ("  Hello  ", "Hello"),
+    ("\tHello\n", "Hello"),
+    ('"  Hello  "', "Hello"),
+    
+    # JSON-like strings
+    ('"\\"quoted\\""', 'quoted'),  # JSON parsing removes escaped quotes
+    ('"{\\"key\\": \\"value\\"}"', '{"key": "value"}'),  # JSON parsing handles escapes
+])
+def test_sanitize_string_comprehensive(input_value, expected):
+    """Comprehensive test cases for sanitize_string."""
+    assert sanitize_string(input_value) == expected
+
+
+@pytest.mark.unit
+def test_sanitize_string_preserves_original_on_error():
+    """Verify that sanitize_string converts non-strings using str()."""
+    # For non-string inputs, the function returns str(value) without processing
+    class CustomObject:
+        def __str__(self):
+            return "  custom object  "
+    
+    custom_input = CustomObject()
+    # The function converts to string but doesn't strip for non-string inputs
+    assert sanitize_string(custom_input) == "  custom object  "
+
+
+@pytest.mark.unit
+def test_sanitize_metadata_strings():
+    """Test sanitize_metadata_strings function."""
+    # Test with quoted strings in various fields
+    metadata = {
+        "place_id": '"pid123"',
+        "merchant_name": "'Store Name'",
+        "address": '""123 Main St""',
+        "phone_number": '"(555) 123-4567"',
+        "merchant_category": '"restaurant"',
+        "reasoning": '"Selected based on phone match"',
+        "other_field": '"should not be touched"',  # Non-string fields preserved
+        "matched_fields": ["phone", "name"],  # Lists preserved
+        "timestamp": datetime.now(),  # Other types preserved
+    }
+    
+    result = sanitize_metadata_strings(metadata)
+    
+    # Check string fields are sanitized
+    assert result["place_id"] == "pid123"
+    assert result["merchant_name"] == "Store Name"
+    assert result["address"] == "123 Main St"
+    assert result["phone_number"] == "(555) 123-4567"
+    assert result["merchant_category"] == "restaurant"
+    assert result["reasoning"] == "Selected based on phone match"
+    
+    # Check non-string fields are preserved as-is
+    assert result["other_field"] == '"should not be touched"'
+    assert result["matched_fields"] == ["phone", "name"]
+    assert isinstance(result["timestamp"], datetime)
+    
+    # Check original dict is not modified
+    assert metadata["place_id"] == '"pid123"'
+
+
+@pytest.mark.unit
+def test_sanitize_metadata_strings_empty():
+    """Test sanitize_metadata_strings with empty/missing fields."""
+    metadata = {
+        "place_id": '""',
+        "merchant_name": None,
+        "address": "",
+        # phone_number is missing
+    }
+    
+    result = sanitize_metadata_strings(metadata)
+    
+    assert result["place_id"] == '""'  # Empty quotes preserved as per sanitize_string
+    assert result["merchant_name"] == ""  # None converted to empty string
+    assert result["address"] == ""
+    assert "phone_number" not in result  # Missing fields not added
+
+
+@pytest.mark.unit
+def test_environment_isolation(clean_env_vars):
+    """Demonstrate that environment variables are properly isolated in tests."""
+    # Store original value
+    original_table_name = os.environ.get("DYNAMO_TABLE_NAME")
+    
+    # Test can modify environment
+    os.environ["DYNAMO_TABLE_NAME"] = "modified-table"
+    assert os.environ["DYNAMO_TABLE_NAME"] == "modified-table"
+    
+    # After this test, clean_env_vars fixture will restore original environment
+    # This prevents test pollution between tests


### PR DESCRIPTION
## Summary
- add merchant validation result processor tests

## Testing
- `isort receipt_label/receipt_label/tests/merchant_validation/test_result_processor.py --profile black`
- `black receipt_label/receipt_label/tests/merchant_validation/test_result_processor.py`
- `mypy receipt_label/receipt_label/tests/merchant_validation/test_result_processor.py` *(fails: Skipping analyzing "receipt_dynamo.constants"; module is installed, but missing stubs)*
- `pylint receipt_label/receipt_label/tests/merchant_validation/test_result_processor.py`
- `pytest --confcutdir=receipt_label/receipt_label/tests/merchant_validation receipt_label/receipt_label/tests/merchant_validation/test_result_processor.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685a46cff9a4832b94a17297a464ec66