### PR TITLE
Fix Pinecone import for v3.x compatibility

### DIFF
--- a/receipt_label/receipt_label/utils/client_manager.py
+++ b/receipt_label/receipt_label/utils/client_manager.py
@@ -11,7 +11,7 @@ from typing import Optional
 
 from openai import OpenAI
 from pinecone import Pinecone
-from pinecone.data.index import Index
+from pinecone import Index
 from receipt_dynamo import DynamoClient
 
 


### PR DESCRIPTION
## Summary
- Fixed Pinecone import to use v3.x API structure
- Changed `from pinecone.data.index import Index` to `from pinecone import Index`
- Resolves Lambda runtime error: "No module named 'pinecone.data.index'"

## Context
This fixes the import error seen in Lambda functions using the receipt_label package. The Pinecone SDK v3.x changed the import paths, and this updates our code to match.

🤖 Generated with [Claude Code](https://claude.ai/code)