### PR TITLE
Fix: Add remote image domains to Next.js config

### DIFF
--- a/portfolio/next.config.js
+++ b/portfolio/next.config.js
@@ -8,6 +8,20 @@ const nextConfig = {
   trailingSlash: false,
   images: {
     unoptimized: true,
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'dev.tylernorlund.com',
+      },
+      {
+        protocol: 'https',
+        hostname: 'www.tylernorlund.com',
+      },
+      {
+        protocol: 'https',
+        hostname: 'tylernorlund.com',
+      },
+    ],
   },
   compress: true,
   poweredByHeader: false,


### PR DESCRIPTION
## Summary
Adds `remotePatterns` configuration to Next.js to fix empty images in receipt and image stack components.

## Problem
Both `ReceiptStack` and `ImageStack` components were displaying empty image placeholders because Next.js was blocking external image loads when using static export mode.

## Solution
Updated `next.config.js` to include `remotePatterns` that allow loading images from:
- dev.tylernorlund.com
- www.tylernorlund.com  
- tylernorlund.com

## Changes
- Only modifies `portfolio/next.config.js`
- No Python or other code changes included

🤖 Generated with [Claude Code](https://claude.ai/code)