### PR TITLE
fix: correct parameter names in Lambda route handlers

### DIFF
--- a/infra/routes/images/handler/index.py
+++ b/infra/routes/images/handler/index.py
@@ -43,7 +43,7 @@ def handler(event, _):
             raw_images, lek = client.list_images_by_type(
                 image_type=image_type,
                 limit=limit,
-                lastEvaluatedKey=last_evaluated_key,
+                last_evaluated_key=last_evaluated_key,
             )
             # Remove duplicates
             seen_ids = set()
@@ -69,7 +69,7 @@ def handler(event, _):
             photo_images, photo_lek = client.list_images_by_type(
                 image_type=ImageType.PHOTO.value,
                 limit=photo_limit,
-                lastEvaluatedKey=(
+                last_evaluated_key=(
                     last_evaluated_key.get("photo")
                     if last_evaluated_key
                     and isinstance(last_evaluated_key, dict)
@@ -81,7 +81,7 @@ def handler(event, _):
             scan_images, scan_lek = client.list_images_by_type(
                 image_type=ImageType.SCAN.value,
                 limit=scan_limit,
-                lastEvaluatedKey=(
+                last_evaluated_key=(
                     last_evaluated_key.get("scan")
                     if last_evaluated_key
                     and isinstance(last_evaluated_key, dict)

--- a/infra/routes/label_validation_count/handler/index.py
+++ b/infra/routes/label_validation_count/handler/index.py
@@ -58,7 +58,7 @@ def fetch_label_counts(core_label):
             dynamo_client.get_receipt_word_labels_by_label(
                 label=core_label,
                 limit=1000,
-                lastEvaluatedKey=last_evaluated_key,
+                last_evaluated_key=last_evaluated_key,
             )
         )
         receipt_word_labels.extend(next_receipt_word_labels)

--- a/infra/routes/merchant_counts/handler/index.py
+++ b/infra/routes/merchant_counts/handler/index.py
@@ -22,7 +22,7 @@ def fetch_merchant_counts():
         next_receipt_metadatas, last_evaluated_key = (
             dynamo_client.list_receipt_metadatas(
                 limit=1000,
-                lastEvaluatedKey=last_evaluated_key,
+                last_evaluated_key=last_evaluated_key,
             )
         )
         receipt_metadatas.extend(next_receipt_metadatas)

--- a/infra/routes/receipt_count/handler/index.py
+++ b/infra/routes/receipt_count/handler/index.py
@@ -24,7 +24,9 @@ def handler(event, context):
             # Paginate through all images to get the final count
             receipts, lek = client.list_receipts(QUERY_LIMIT)
             while lek:
-                next_receipts, lek = client.list_receipts(QUERY_LIMIT, lek)
+                next_receipts, lek = client.list_receipts(
+                    QUERY_LIMIT, last_evaluated_key=lek
+                )
                 receipts.extend(next_receipts)
 
             return {

--- a/infra/routes/receipts/handler/index.py
+++ b/infra/routes/receipts/handler/index.py
@@ -35,7 +35,7 @@ def handler(event, _):
 
         # Call listReceipts with the provided parameters.
         receipts, lek = client.list_receipts(
-            limit=limit, lastEvaluatedKey=lastEvaluatedKey
+            limit=limit, last_evaluated_key=lastEvaluatedKey
         )
 
         response_body = {


### PR DESCRIPTION
## Summary

Fixes TypeError exceptions in multiple API endpoints by correcting parameter names in Lambda route handlers.

## Problem
Lambda handlers were calling DynamoDB client methods with `lastEvaluatedKey` while the methods expect `last_evaluated_key`, causing runtime errors:
```
[ERROR] TypeError: _Receipt.list_receipts() got an unexpected keyword argument 'lastEvaluatedKey'
```

## Changes
**Scope**: Only `infra/routes/` directory changes

Updated parameter names in 5 route handlers:
- `receipts/handler/index.py`
- `images/handler/index.py` 
- `receipt_count/handler/index.py`
- `label_validation_count/handler/index.py`
- `merchant_counts/handler/index.py`

## Testing
- ✅ Already deployed and verified in dev environment
- ✅ All affected endpoints now return successful responses

## Impact
- Fixes 500 Internal Server Error on multiple API endpoints
- Ensures consistency with receipt_dynamo method signatures
- No breaking changes to API interface