### PR TITLE
fix: prevent deletion of uploaded assets during deployment

### DIFF
--- a/.github/workflows/deploy.yml.disabled
+++ b/.github/workflows/deploy.yml.disabled
@@ -1,4 +1,7 @@
 name: Deploy to Production
+# IMPORTANT: This workflow preserves the /assets/ directory in S3
+# which contains uploaded receipt images from the receipt_upload package.
+# The --exclude "assets/*" flag prevents deletion of these files during deployment.
 on:
   push:
     branches:
@@ -158,9 +161,10 @@ jobs:
           BUCKET=$(pulumi stack output cdn_bucket_name)
           DISTRIBUTION=$(pulumi stack output cdn_distribution_id)
 
-          # Sync files
+          # Sync files - exclude assets directory to preserve uploaded images
           aws s3 sync ../portfolio/out "s3://$BUCKET" \
             --delete \
+            --exclude "assets/*" \
             --cache-control "public, max-age=3600"
 
           # Invalidate CloudFront

--- a/docs/deployment-asset-preservation.md
+++ b/docs/deployment-asset-preservation.md
@@ -1,0 +1,50 @@
+# Deployment Asset Preservation
+
+## Issue
+
+When deploying the Next.js site to S3, the `aws s3 sync` command with the `--delete` flag was removing all files in the S3 bucket that weren't part of the Next.js build output. This included all receipt images uploaded by the `receipt_upload` package to the `/assets/` directory.
+
+## Root Cause
+
+The deployment workflow used:
+```bash
+aws s3 sync ../portfolio/out "s3://$BUCKET" \
+  --delete \
+  --cache-control "public, max-age=3600"
+```
+
+The `--delete` flag removes any files in the destination (S3) that don't exist in the source (Next.js build output).
+
+## Solution
+
+Added `--exclude "assets/*"` to preserve the assets directory:
+```bash
+aws s3 sync ../portfolio/out "s3://$BUCKET" \
+  --delete \
+  --exclude "assets/*" \
+  --cache-control "public, max-age=3600"
+```
+
+## Alternative Solutions
+
+1. **Remove --delete flag entirely**: Simpler but may leave old Next.js files
+2. **Separate buckets**: Use different S3 buckets for static site vs uploaded assets
+3. **Upload assets to build**: Include assets in Next.js build (not practical for dynamic uploads)
+
+## Recovery Process
+
+If assets are deleted, use the sync scripts:
+```bash
+# Quick recovery from dev bucket
+./scripts/quick_sync_images.sh
+
+# Or sync from another environment
+./scripts/sync_images_dev_to_prod.sh
+```
+
+## Prevention
+
+- Always use `--exclude "assets/*"` when syncing with `--delete`
+- Consider enabling S3 versioning for recovery
+- Add bucket protection (`protect=True` in Pulumi)
+- Monitor deployments to ensure assets remain accessible


### PR DESCRIPTION
## Problem
Every time we deploy with `pulumi up`, all receipt images in the S3 bucket are deleted. This happens because the deployment workflow uses `aws s3 sync --delete` which removes files that aren't in the Next.js build output.

## Root Cause
The deployment workflow syncs the Next.js build output to S3 with:
```bash
aws s3 sync ../portfolio/out "s3://$BUCKET" --delete
```

Since receipt images are uploaded dynamically to `/assets/` by the `receipt_upload` package (not part of the Next.js build), they get deleted.

## Solution
Add `--exclude "assets/*"` to preserve the assets directory:
```bash
aws s3 sync ../portfolio/out "s3://$BUCKET" \
  --delete \
  --exclude "assets/*" \
  --cache-control "public, max-age=3600"
```

## Changes
- Update deploy workflow to exclude assets from deletion
- Add documentation explaining the issue

## Testing
1. Deploy with this change
2. Verify receipt images remain accessible
3. Confirm Next.js files are still properly updated

🤖 Generated with [Claude Code](https://claude.ai/code)