### PR TITLE
fix: prevent asset deletion in main deployment workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -384,6 +384,7 @@ jobs:
         run: |
           aws s3 sync portfolio/out s3://${{ steps.pulumi-outputs.outputs.bucket_name }} \
             --delete \
+            --exclude "assets/*" \
             --cache-control "public, max-age=3600"
 
       - name: Invalidate CloudFront


### PR DESCRIPTION
## Critical Fix

The main.yml deployment workflow was missing the `--exclude "assets/*"` flag, causing all uploaded receipt images to be deleted on every deployment to production.

## The Issue

Line 385 in main.yml:
```bash
aws s3 sync portfolio/out s3://${{ steps.pulumi-outputs.outputs.bucket_name }} \
  --delete \
  --cache-control "public, max-age=3600"
```

The `--delete` flag removes any files in S3 that don't exist in the source, which includes all the receipt images uploaded by the `receipt_upload` package.

## The Fix

Added `--exclude "assets/*"` to preserve the assets directory:
```bash
aws s3 sync portfolio/out s3://${{ steps.pulumi-outputs.outputs.bucket_name }} \
  --delete \
  --exclude "assets/*" \
  --cache-control "public, max-age=3600"
```

This matches the solution already documented in:
- `deploy.yml.disabled` (had the fix but wasn't the active workflow)
- `docs/deployment-asset-preservation.md` (documented the issue and solution)
- PR #200 (added recovery scripts and documentation)

## Testing

Once merged, the next deployment should preserve all assets in the `/assets/` directory instead of deleting them.