### PR TITLE
Fix pylint line length errors in receipt structure analysis

### DIFF
--- a/receipt_dynamo/receipt_dynamo/data/_receipt_structure_analysis.py
+++ b/receipt_dynamo/receipt_dynamo/data/_receipt_structure_analysis.py
@@ -1,19 +1,21 @@
 """Receipt Structure Analysis data access using base operations framework.
 
-This refactored version reduces code from ~806 lines to ~260 lines (68% reduction)
-while maintaining full backward compatibility and all functionality.
+This refactored version reduces code from ~806 lines to ~260 lines (68%
+reduction) while maintaining full backward compatibility and all
+functionality.
 """
 
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
-from receipt_dynamo.entities.receipt_structure_analysis import ReceiptStructureAnalysis
-from receipt_dynamo.entities import item_to_receipt_structure_analysis
-from receipt_dynamo.data._base import DynamoClientProtocol
 from receipt_dynamo.data.base_operations import (
     BatchOperationsMixin,
     DynamoDBBaseOperations,
     SingleEntityCRUDMixin,
     handle_dynamodb_errors,
+)
+from receipt_dynamo.entities import item_to_receipt_structure_analysis
+from receipt_dynamo.entities.receipt_structure_analysis import (
+    ReceiptStructureAnalysis,
 )
 from receipt_dynamo.entities.util import assert_valid_uuid
 
@@ -62,7 +64,9 @@ class _ReceiptStructureAnalysis(
         self._validate_entity(analysis, ReceiptStructureAnalysis, "analysis")
         self._add_entity(
             analysis,
-            condition_expression="attribute_not_exists(PK) AND attribute_not_exists(SK)",
+            condition_expression=(
+                "attribute_not_exists(PK) AND attribute_not_exists(SK)"
+            ),
         )
 
     @handle_dynamodb_errors("add_receipt_structure_analyses")
@@ -98,7 +102,8 @@ class _ReceiptStructureAnalysis(
         """Updates an existing ReceiptStructureAnalysis in the database.
 
         Args:
-            analysis (ReceiptStructureAnalysis): The ReceiptStructureAnalysis to update.
+            analysis (ReceiptStructureAnalysis): The ReceiptStructureAnalysis
+                to update.
 
         Raises:
             ValueError: If the analysis is None or not an instance of
@@ -108,7 +113,9 @@ class _ReceiptStructureAnalysis(
         self._validate_entity(analysis, ReceiptStructureAnalysis, "analysis")
         self._update_entity(
             analysis,
-            condition_expression="attribute_exists(PK) AND attribute_exists(SK)",
+            condition_expression=(
+                "attribute_exists(PK) AND attribute_exists(SK)"
+            ),
         )
 
     @handle_dynamodb_errors("update_receipt_structure_analyses")
@@ -118,7 +125,8 @@ class _ReceiptStructureAnalysis(
         """Updates multiple ReceiptStructureAnalyses in the database.
 
         Args:
-            analyses (list[ReceiptStructureAnalysis]): The ReceiptStructureAnalyses to update.
+            analyses (list[ReceiptStructureAnalysis]): The
+                ReceiptStructureAnalyses to update.
 
         Raises:
             ValueError: If the analyses are None or not a list.
@@ -143,7 +151,8 @@ class _ReceiptStructureAnalysis(
         """Deletes a single ReceiptStructureAnalysis by IDs.
 
         Args:
-            analysis (ReceiptStructureAnalysis): The ReceiptStructureAnalysis to delete.
+            analysis (ReceiptStructureAnalysis): The ReceiptStructureAnalysis
+                to delete.
 
         Raises:
             ValueError: If the analysis is None or not an instance of
@@ -160,7 +169,8 @@ class _ReceiptStructureAnalysis(
         """Deletes multiple ReceiptStructureAnalyses in batch.
 
         Args:
-            analyses (list[ReceiptStructureAnalysis]): The ReceiptStructureAnalyses to delete.
+            analyses (list[ReceiptStructureAnalysis]): The
+                ReceiptStructureAnalyses to delete.
 
         Raises:
             ValueError: If the analyses are None or not a list.
@@ -176,7 +186,10 @@ class _ReceiptStructureAnalysis(
                     Key={
                         "PK": {"S": f"IMAGE#{analysis.image_id}"},
                         "SK": {
-                            "S": f"RECEIPT#{analysis.receipt_id:05d}#ANALYSIS#STRUCTURE#{analysis.version}"
+                            "S": (
+                                f"RECEIPT#{analysis.receipt_id:05d}"
+                                f"#ANALYSIS#STRUCTURE#{analysis.version}"
+                            )
                         },
                     }
                 )
@@ -197,26 +210,37 @@ class _ReceiptStructureAnalysis(
         Args:
             receipt_id (int): The Receipt ID to query.
             image_id (str): The Image ID to query.
-            version (Optional[str]): The version of the analysis. If None, returns the first analysis found.
+            version (Optional[str]): The version of the analysis. If None,
+                returns the first analysis found.
 
         Returns:
             ReceiptStructureAnalysis: The retrieved ReceiptStructureAnalysis.
 
         Raises:
             ValueError: If the receipt_id or image_id are invalid.
-            Exception: If the ReceiptStructureAnalysis cannot be retrieved from DynamoDB.
+            Exception: If the ReceiptStructureAnalysis cannot be retrieved from
+                DynamoDB.
         """
         if not isinstance(receipt_id, int):
             raise ValueError(
-                f"receipt_id must be an integer, got {type(receipt_id).__name__}"
+                (
+                    f"receipt_id must be an integer, got"
+                    f" {type(receipt_id).__name__}"
+                )
             )
         if not isinstance(image_id, str):
             raise ValueError(
-                f"image_id must be a string, got {type(image_id).__name__}"
+                (
+                    f"image_id must be a string, got"
+                    f" {type(image_id).__name__}"
+                )
             )
         if version is not None and not isinstance(version, str):
             raise ValueError(
-                f"version must be a string or None, got {type(version).__name__}"
+                (
+                    "version must be a string or None, got"
+                    f" {type(version).__name__}"
+                )
             )
 
         assert_valid_uuid(image_id)
@@ -228,43 +252,51 @@ class _ReceiptStructureAnalysis(
                 Key={
                     "PK": {"S": f"IMAGE#{image_id}"},
                     "SK": {
-                        "S": f"RECEIPT#{receipt_id:05d}#ANALYSIS#STRUCTURE#{version}"
+                        "S": (
+                            f"RECEIPT#{receipt_id:05d}#ANALYSIS#STRUCTURE"
+                            f"#{version}"
+                        )
                     },
                 },
             )
             item = response.get("Item")
             if not item:
                 raise ValueError(
-                    f"No ReceiptStructureAnalysis found for receipt {receipt_id}, image {image_id}, and version {version}"
+                    "No ReceiptStructureAnalysis found for receipt "
+                    f"{receipt_id}, image {image_id}, and version {version}"
                 )
             return item_to_receipt_structure_analysis(item)
-        else:
-            # If no version is provided, query for all analyses and return the first one
-            query_params: QueryInputTypeDef = {
-                "TableName": self.table_name,
-                "KeyConditionExpression": "#pk = :pk AND begins_with(#sk, :sk_prefix)",
-                "ExpressionAttributeNames": {
-                    "#pk": "PK",
-                    "#sk": "SK",
+
+        # If no version is provided, query for all analyses and return the
+        # first one
+        query_params: QueryInputTypeDef = {
+            "TableName": self.table_name,
+            "KeyConditionExpression": (
+                "#pk = :pk AND begins_with(#sk, :sk_prefix)"
+            ),
+            "ExpressionAttributeNames": {
+                "#pk": "PK",
+                "#sk": "SK",
+            },
+            "ExpressionAttributeValues": {
+                ":pk": {"S": f"IMAGE#{image_id}"},
+                ":sk_prefix": {
+                    "S": f"RECEIPT#{receipt_id:05d}#ANALYSIS#STRUCTURE"
                 },
-                "ExpressionAttributeValues": {
-                    ":pk": {"S": f"IMAGE#{image_id}"},
-                    ":sk_prefix": {
-                        "S": f"RECEIPT#{receipt_id:05d}#ANALYSIS#STRUCTURE"
-                    },
-                },
-                "Limit": 1,  # We only need one result
-            }
+            },
+            "Limit": 1,  # We only need one result
+        }
 
-            query_response = self._client.query(**query_params)
-            items = query_response.get("Items", [])
+        query_response = self._client.query(**query_params)
+        items = query_response.get("Items", [])
 
-            if not items:
-                raise ValueError(
-                    f"Receipt Structure Analysis for Image ID {image_id} and Receipt ID {receipt_id} does not exist"
-                )
+        if not items:
+            raise ValueError(
+                "Receipt Structure Analysis for Image ID "
+                f"{image_id} and Receipt ID {receipt_id} does not exist"
+            )
 
-            return item_to_receipt_structure_analysis(items[0])
+        return item_to_receipt_structure_analysis(items[0])
 
     @handle_dynamodb_errors("list_receipt_structure_analyses")
     def list_receipt_structure_analyses(
@@ -275,15 +307,20 @@ class _ReceiptStructureAnalysis(
         """Lists all ReceiptStructureAnalyses.
 
         Args:
-            limit (Optional[int], optional): The maximum number of items to return. Defaults to None.
-            last_evaluated_key (Optional[Dict[str, Any]], optional): The key to start from for pagination. Defaults to None.
+            limit (Optional[int], optional): The maximum number of items to
+                return. Defaults to None.
+            last_evaluated_key (Optional[Dict[str, Any]], optional): The key to
+                start from for pagination. Defaults to None.
 
         Returns:
-            Tuple[List[ReceiptStructureAnalysis], Optional[Dict[str, Any]]]: A tuple containing the list of ReceiptStructureAnalyses and the last evaluated key for pagination.
+            Tuple[List[ReceiptStructureAnalysis], Optional[Dict[str, Any]]]:
+                A tuple containing the list of ReceiptStructureAnalyses and the
+                last evaluated key for pagination.
 
         Raises:
             ValueError: If the limit or last_evaluated_key are invalid.
-            Exception: If the ReceiptStructureAnalyses cannot be retrieved from DynamoDB.
+            Exception: If the ReceiptStructureAnalyses cannot be retrieved from
+                DynamoDB.
         """
         if limit is not None and not isinstance(limit, int):
             raise ValueError("limit must be an integer or None")
@@ -348,22 +385,31 @@ class _ReceiptStructureAnalysis(
 
         Raises:
             ValueError: If the receipt_id or image_id are invalid.
-            Exception: If the ReceiptStructureAnalyses cannot be retrieved from DynamoDB.
+            Exception: If the ReceiptStructureAnalyses cannot be retrieved from
+                DynamoDB.
         """
         if not isinstance(receipt_id, int):
             raise ValueError(
-                f"receipt_id must be an integer, got {type(receipt_id).__name__}"
+                (
+                    f"receipt_id must be an integer, got"
+                    f" {type(receipt_id).__name__}"
+                )
             )
         if not isinstance(image_id, str):
             raise ValueError(
-                f"image_id must be a string, got {type(image_id).__name__}"
+                (
+                    f"image_id must be a string, got"
+                    f" {type(image_id).__name__}"
+                )
             )
 
         assert_valid_uuid(image_id)
 
         query_params: QueryInputTypeDef = {
             "TableName": self.table_name,
-            "KeyConditionExpression": "#pk = :pk AND begins_with(#sk, :sk_prefix)",
+            "KeyConditionExpression": (
+                "#pk = :pk AND begins_with(#sk, :sk_prefix)"
+            ),
             "ExpressionAttributeNames": {
                 "#pk": "PK",
                 "#sk": "SK",


### PR DESCRIPTION
## Summary
- resolve C0301 issues in receipt structure analysis module
- format long strings and docstrings to 79 chars
- drop unused DynamoClientProtocol import
- avoid else after return for cleaner logic

## Testing
- `mypy receipt_dynamo/receipt_dynamo/data/_receipt_structure_analysis.py`
- `pylint receipt_dynamo/receipt_dynamo/data/_receipt_structure_analysis.py`
- `pytest -m unit receipt_dynamo`
- `pytest -m integration receipt_dynamo`

------
https://chatgpt.com/codex/tasks/task_e_6881522b2a94832bb23574cbef5ff093