### PR TITLE
Fix receipt line item query parameters

### DIFF
--- a/receipt_dynamo/receipt_dynamo/data/_receipt_line_item_analysis.py
+++ b/receipt_dynamo/receipt_dynamo/data/_receipt_line_item_analysis.py
@@ -330,21 +330,17 @@ class _ReceiptLineItemAnalysis(
 
         line_item_analyses = []
         key_condition = "#pk = :pk AND begins_with(#sk, :sk_prefix)"
+        expr_values = {
+            ":pk": {"S": f"IMAGE#{image_id}"},
+            ":sk_prefix": {"S": "RECEIPT#"},
+            ":analysis_type": {"S": "#ANALYSIS#LINE_ITEMS"},
+        }
         query_params: QueryInputTypeDef = {
             "TableName": self.table_name,
             "KeyConditionExpression": key_condition,
-            "ExpressionAttributeNames": {
-                "#pk": "PK",
-                "#sk": "SK",
-            },
-            "ExpressionAttributeValues": {
-                ":pk": {"S": f"IMAGE#{image_id}"},
-                ":sk_prefix": {"S": "RECEIPT#"},
-            },
+            "ExpressionAttributeNames": {"#pk": "PK", "#sk": "SK"},
+            "ExpressionAttributeValues": expr_values,
             "FilterExpression": "contains(#sk, :analysis_type)",
-        }
-        query_params["ExpressionAttributeValues"][":analysis_type"] = {
-            "S": "#ANALYSIS#LINE_ITEMS"
         }
 
         response = self._client.query(**query_params)


### PR DESCRIPTION
## Summary
- streamline query parameters for line item analysis listing
- avoid mypy error by assigning expression values before building the query

## Testing
- `pytest -m unit receipt_dynamo`
- `pytest -m integration receipt_dynamo`


------
https://chatgpt.com/codex/tasks/task_e_68818979abe4832bbfe69d4f142855e7