### PR TITLE
Fix 'argument list too long' error in Pulumi CI

### DIFF
--- a/infra/fast_lambda_layer.py
+++ b/infra/fast_lambda_layer.py
@@ -377,12 +377,12 @@ echo "🎉 Parallel function updates completed!"'''
         upload_cmd = command.local.Command(
             f"{self.name}-upload-source",
             create=build_bucket.bucket.apply(
-                lambda b: self._generate_upload_script(
+                lambda b: self._create_and_run_upload_script(
                     b, package_path, package_hash
                 )
             ),
             update=build_bucket.bucket.apply(
-                lambda b: self._generate_upload_script(
+                lambda b: self._create_and_run_upload_script(
                     b, package_path, package_hash
                 )
             ),
@@ -894,6 +894,23 @@ done
 
         # Pulumi no longer manages the LayerVersion resource; layer publication is handled by CodePipeline.
         self.arn = None  # Placeholder: Pulumi does not manage or export the layer ARN directly.
+
+    def _create_and_run_upload_script(self, bucket, package_path, package_hash):
+        """Create a temporary script file and execute it to avoid 'argument list too long' error."""
+        import tempfile
+        import os
+        
+        # Generate the script content
+        script_content = self._generate_upload_script(bucket, package_path, package_hash)
+        
+        # Create a temporary file
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.sh', delete=False) as f:
+            f.write(script_content)
+            script_path = f.name
+        
+        # Make it executable and run it, cleaning up afterwards
+        os.chmod(script_path, 0o755)
+        return f"bash {script_path} && rm -f {script_path}"
 
     def _generate_upload_script(self, bucket, package_path, package_hash):
         """Generate script to upload source package."""

--- a/infra/fast_lambda_layer.py
+++ b/infra/fast_lambda_layer.py
@@ -914,7 +914,7 @@ done
             # Use curly braces to ensure cleanup happens even if script fails
             return f"{{ bash {script_path}; rm -f {script_path}; }}"
         except (OSError, IOError) as e:
-            raise RuntimeError(f"Failed to create upload script: {e}")
+            raise RuntimeError(f"Failed to create upload script: {e}") from e
 
     def _generate_upload_script(self, bucket, package_path, package_hash):
         """Generate script to upload source package."""


### PR DESCRIPTION
## Problem
The Pulumi CI run was failing with the error:
```
error: fork/exec /bin/sh: argument list too long
```

This occurred when executing the receipt-dynamo-upload-source command in the fast_lambda_layer.py file.

## Root Cause
The `_generate_upload_script` method was creating a very long bash script (with multiple echo statements, file operations, AWS CLI commands, etc.) and passing it directly as a command string to `command.local.Command`. When this script exceeded the shell's argument size limit (typically ~128KB), it caused the error.

## Solution
- Added a new method `_create_and_run_upload_script` that:
  1. Generates the script content using the existing `_generate_upload_script` method
  2. Writes it to a temporary file
  3. Makes the file executable
  4. Returns a command to execute the file and clean it up afterwards
- Updated the upload command to use this new method instead of passing the script inline

## Testing
- Verified Python syntax is correct with `py_compile`
- The temporary file approach avoids the shell argument limitation

This fix should resolve the CI build failures in the deploy-on-main workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of the upload process to prevent errors when handling large argument lists during deployment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->