### PR TITLE
fix: Pin exact Pulumi package versions for CI consistency

### DIFF
--- a/infra/requirements.txt
+++ b/infra/requirements.txt
@@ -1,5 +1,5 @@
-pulumi>=3.0.0,<4.0.0
-pulumi-aws>=7.1.0,<8.0.0
-pulumi-command>=1.0.0,<2.0.0
-pulumi-docker>=4.0.0,<5.0.0
-pulumi-docker-build>=0.0.12
+pulumi==3.186.0
+pulumi-aws==7.1.0
+pulumi-command==1.1.0
+pulumi-docker==4.8.0
+pulumi-docker-build==0.0.12


### PR DESCRIPTION
## Problem
The CI/CD pipeline is failing during Pulumi deployment. Local development works fine with specific Pulumi package versions, but CI may be installing different (newer) versions that have breaking changes.

## Root Cause
The requirements.txt file uses version ranges (e.g., `>=7.1.0,<8.0.0`) which allows pip to install newer versions that might have breaking changes. For example, pulumi-aws 7.4.0 (latest) might have changes that break code written for 7.1.0.

## Solution
Pin to the exact versions that work in local development to ensure CI uses identical packages.

## Changes
Updated `infra/requirements.txt` to pin exact versions:
- `pulumi==3.186.0` (was `>=3.0.0,<4.0.0`)
- `pulumi-aws==7.1.0` (was `>=7.1.0,<8.0.0`)
- `pulumi-command==1.1.0` (was `>=1.0.0,<2.0.0`)
- `pulumi-docker==4.8.0` (was `>=4.0.0,<5.0.0`)
- `pulumi-docker-build==0.0.12` (unchanged)

## Testing
- These exact versions work in local development
- CI will now use identical versions, eliminating version mismatch issues

## Future Considerations
- Consider using a tool like `pip-compile` or `poetry` for better dependency management
- Set up automated dependency updates with testing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned infrastructure dependencies to exact versions for Pulumi and related providers.
  * Improves predictability of deployments and reduces unexpected changes during provisioning.
  * No user-facing functionality changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->