### PR TITLE
fix: resolve Dependabot security vulnerability CVE-2025-54798 in tmp package

### DIFF
--- a/portfolio/package-lock.json
+++ b/portfolio/package-lock.json
@@ -6484,19 +6484,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/external-editor/node_modules/tmp": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "os-tmpdir": "~1.0.2"
-      },
-      "engines": {
-        "node": ">=0.6.0"
-      }
-    },
     "node_modules/extract-zip": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
@@ -10503,16 +10490,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/own-keys": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
@@ -12674,52 +12651,13 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.1.0.tgz",
-      "integrity": "sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.4.tgz",
+      "integrity": "sha512-UdiSoX6ypifLmrfQ/XfiawN6hkjSBpCjhKxxZcWlUUmoXLaCKQU0bx4HF/tdDK2uzRuchf1txGvrWBzYREssoQ==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "rimraf": "^2.6.3"
-      },
       "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/tmp/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/tmp/node_modules/rimraf": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
+        "node": ">=14.14"
       }
     },
     "node_modules/tmpl": {

--- a/portfolio/package.json
+++ b/portfolio/package.json
@@ -46,6 +46,9 @@
       "last 1 safari version"
     ]
   },
+  "overrides": {
+    "tmp": "0.2.4"
+  },
   "devDependencies": {
     "@babel/plugin-syntax-flow": "^7.26.0",
     "@eslint/eslintrc": "^3.1.0",


### PR DESCRIPTION
## Summary
- Fixes Dependabot security vulnerability #15 (CVE-2025-54798)
- Forces tmp package to version 0.2.4 using npm overrides
- Addresses low severity vulnerability in development dependencies

## Details
This PR resolves a security vulnerability in the `tmp` package (versions ≤ 0.2.3) that allowed arbitrary temporary file/directory writes via symbolic link attacks.

### Vulnerability Information
- **CVE**: CVE-2025-54798
- **GHSA**: GHSA-52f5-9888-hmc6
- **Severity**: Low (CVSS 2.5)
- **Impact**: Potential arbitrary file writes through symlink attacks on temp directory
- **Attack Vector**: Requires local access and specific conditions

### Fix Applied
Added npm override in `portfolio/package.json` to force all transitive dependencies to use `tmp@0.2.4`, which includes the security patch.

### Affected Dependencies Chain
```
@lhci/cli@0.15.1
├── inquirer@6.5.2
│   └── external-editor@3.1.0
│       └── tmp@0.0.33 → 0.2.4 (fixed)
└── tmp@0.1.0 → 0.2.4 (fixed)
```

## Test plan
- [x] Run `npm audit` - confirms 0 vulnerabilities
- [x] Run `npm install` - successfully installs with override
- [x] Verify tmp package versions with `npm ls tmp`

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced a top-level package override to pin the transitive dependency “tmp” to version 0.2.4 across the project.
  * No application logic, UI, or runtime behavior changed.
  * No other configuration keys or scripts were modified.
  * Dependency installation may update the lockfile on the next install.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->