### PR TITLE
fix: update to non-deprecated BucketVersioning API

### DIFF
--- a/infra/lambda_layer.py
+++ b/infra/lambda_layer.py
@@ -688,11 +688,11 @@ echo "🎉 Parallel function updates completed!"'''
         )
 
         # Configure versioning as a separate resource
-        aws.s3.BucketVersioningV2(
+        aws.s3.BucketVersioning(
             f"{self.name}-artifacts-versioning",
             bucket=build_bucket.id,
             versioning_configuration=(
-                aws.s3.BucketVersioningV2VersioningConfigurationArgs(
+                aws.s3.BucketVersioningVersioningConfigurationArgs(
                     status="Enabled"
                 )
             ),


### PR DESCRIPTION
## Summary

Fixes deprecation warning in lambda_layer.py by updating from deprecated `aws.s3.BucketVersioningV2` to the current `aws.s3.BucketVersioning` API.

## Changes

- **File**: `infra/lambda_layer.py`
- **Change**: Replace `BucketVersioningV2` with `BucketVersioning`
- **Change**: Replace `BucketVersioningV2VersioningConfigurationArgs` with `BucketVersioningVersioningConfigurationArgs`

## Background

The old `BucketVersioningV2` API has been deprecated in favor of `BucketVersioning`. This change:
1. Resolves the deprecation warning: `aws.s3/bucketversioningv2.BucketVersioningV2 has been deprecated`
2. Brings lambda_layer.py in line with other parts of the codebase (e.g., chromadb_compaction module)
3. Uses the currently recommended Pulumi AWS API

## Testing

- [x] Python syntax validation passes
- [x] Change matches pattern used in other modules
- [ ] Deploy test to verify S3 versioning works correctly

## Impact

- **Risk**: Low - API-compatible change, same functionality
- **Scope**: Only affects lambda layer S3 bucket versioning setup
- **Benefits**: Removes deprecation warning, future-proofs code

🤖 Generated with [Claude Code](https://claude.ai/code)