### PR TITLE
Add ECR lifecycle policies to Docker image repositories

### DIFF
--- a/infra/Pulumi.dev.yaml
+++ b/infra/Pulumi.dev.yaml
@@ -32,3 +32,5 @@ config:
     secure: AAABANI698d7qNKtUwJyF0GZ/bFrhfeSIPr59m2d+91lkRq0NP8CyM3Xlcmg3GPG74dbr7/VOuE/RAIugIfvxIdc7s0yvhuahKjVN3L4A1a/D+opDgoQpvg=
   portfolio:LANGCHAIN_API_KEY:
     secure: AAABAC+PSTc8uajZqSWQTNyqcOPjK4cW+DP3snxJOYFRRA6LSBZq4/7mfZiY2bGuw0fOrpHuyXpwPKDHm5+Y+0cCcj02h1fiUb59JXnOPsM4Hvs=
+  portfolio:ecr-max-images: "4"
+  portfolio:ecr-max-age-days: "7"

--- a/infra/Pulumi.prod.yaml
+++ b/infra/Pulumi.prod.yaml
@@ -31,3 +31,5 @@ config:
     secure: AAABAGduWcFkT1+/496Ni1IoINBIEsDmtQvuV9BQPpHXZJ+VW3sz1VgbUX0Fhdhkr4W5zgAIOybOqWHr5VR1YiWiLuX0BxnzDu4XmDqnFH3XUpJ9Yy1oSSk=
   portfolio:LANGCHAIN_API_KEY:
     secure: AAABAE4K3AaVrtBdO8r3+ooYvm3vIBvWIkXebe3gIY3SqhFlUfHP+6GOIp8+Bb8YG82KuGLhpNS9s8GTIldJQ4azObv9qXN1p1INBhHL3cBbmBw=
+  portfolio:ecr-max-images: "4"
+  portfolio:ecr-max-age-days: "7"

--- a/infra/base_images/base_images.py
+++ b/infra/base_images/base_images.py
@@ -5,6 +5,7 @@ This module creates reusable base images that contain the installed packages,
 allowing Lambda containers to build faster by using these as base images.
 """
 
+import json
 import hashlib
 import os
 import subprocess
@@ -20,7 +21,6 @@ from pulumi_aws.ecr import (
     LifecyclePolicy,
 )
 import pulumi_docker_build as docker_build
-import json
 
 
 class BaseImages(ComponentResource):

--- a/infra/base_images/base_images.py
+++ b/infra/base_images/base_images.py
@@ -17,8 +17,10 @@ from pulumi_aws.ecr import (
     Repository,
     RepositoryImageScanningConfigurationArgs,
     get_authorization_token_output,  # Use output version for docker-build
+    LifecyclePolicy,
 )
 import pulumi_docker_build as docker_build
+import json
 
 
 class BaseImages(ComponentResource):
@@ -230,6 +232,76 @@ class BaseImages(ComponentResource):
             ),
             force_delete=True,
             opts=ResourceOptions(parent=self),
+        )
+
+        # Lifecycle policy configuration (retain N, expire untagged older than X)
+        portfolio_config = pulumi.Config("portfolio")
+        max_images = portfolio_config.get_int("ecr-max-images") or int(
+            os.environ.get("ECR_MAX_IMAGES", "10")
+        )
+        max_age_days = portfolio_config.get_int("ecr-max-age-days") or int(
+            os.environ.get("ECR_MAX_AGE_DAYS", "30")
+        )
+
+        # Only expire images with ephemeral tags (e.g., content-hash tags),
+        # preserving important tags like "latest" and "stable" by default.
+        ephemeral_prefixes_str = portfolio_config.get(
+            "ecr-ephemeral-tag-prefixes"
+        ) or os.environ.get("ECR_EPHEMERAL_TAG_PREFIXES", "git-,sha-")
+        ephemeral_prefixes = [
+            p.strip() for p in ephemeral_prefixes_str.split(",") if p.strip()
+        ] or ["git-", "sha-"]
+
+        lifecycle_policy_doc = json.dumps(
+            {
+                "rules": [
+                    {
+                        "rulePriority": 1,
+                        "description": (
+                            f"Keep only the {max_images} most recent ephemeral images"
+                        ),
+                        "selection": {
+                            "tagStatus": "tagged",
+                            "tagPrefixList": ephemeral_prefixes,
+                            "countType": "imageCountMoreThan",
+                            "countNumber": max_images,
+                        },
+                        "action": {"type": "expire"},
+                    },
+                    {
+                        "rulePriority": 2,
+                        "description": (
+                            f"Expire untagged images older than {max_age_days} days"
+                        ),
+                        "selection": {
+                            "tagStatus": "untagged",
+                            "countType": "sinceImagePushed",
+                            "countUnit": "days",
+                            "countNumber": max_age_days,
+                        },
+                        "action": {"type": "expire"},
+                    },
+                ]
+            }
+        )
+
+        # Attach lifecycle policies to both base repositories
+        self.dynamo_lifecycle = LifecyclePolicy(
+            f"base-receipt-dynamo-lifecycle-{stack}",
+            repository=self.dynamo_base_repo.name,
+            policy=lifecycle_policy_doc,
+            opts=ResourceOptions(
+                parent=self, depends_on=[self.dynamo_base_repo]
+            ),
+        )
+
+        self.label_lifecycle = LifecyclePolicy(
+            f"base-receipt-label-lifecycle-{stack}",
+            repository=self.label_base_repo.name,
+            policy=lifecycle_policy_doc,
+            opts=ResourceOptions(
+                parent=self, depends_on=[self.label_base_repo]
+            ),
         )
 
         # Get ECR authorization token (using output version for docker-build)

--- a/infra/chromadb_compaction/components/docker_image.py
+++ b/infra/chromadb_compaction/components/docker_image.py
@@ -11,6 +11,7 @@ from pulumi_aws.ecr import (
     Repository,
     RepositoryImageScanningConfigurationArgs,
     get_authorization_token_output,
+    LifecyclePolicy,
 )
 
 try:
@@ -18,6 +19,7 @@ try:
 except ImportError:
     # For testing environments, create a mock
     from unittest.mock import MagicMock
+
     docker_build = MagicMock()
 
 
@@ -118,29 +120,94 @@ class DockerImageComponent(ComponentResource):
             opts=ResourceOptions(parent=self),
         )
 
+        # Attach ECR lifecycle policy (retain N, expire untagged older than X)
+        portfolio_config = pulumi.Config("portfolio")
+        import os
+
+        max_images = portfolio_config.get_int("ecr-max-images") or int(
+            os.environ.get("ECR_MAX_IMAGES", "10")
+        )
+        max_age_days = portfolio_config.get_int("ecr-max-age-days") or int(
+            os.environ.get("ECR_MAX_AGE_DAYS", "30")
+        )
+        # Protect important tags (e.g., latest, stable) by scoping pruning to
+        # ephemeral tag prefixes like git-/sha- (configurable).
+        ephemeral_prefixes_str = portfolio_config.get(
+            "ecr-ephemeral-tag-prefixes"
+        ) or os.environ.get("ECR_EPHEMERAL_TAG_PREFIXES", "git-,sha-")
+        ephemeral_prefixes = [
+            p.strip() for p in ephemeral_prefixes_str.split(",") if p.strip()
+        ] or ["git-", "sha-"]
+
+        lifecycle_policy_doc = pulumi.Output.secret(
+            pulumi.Output.from_input(
+                {
+                    "rules": [
+                        {
+                            "rulePriority": 1,
+                            "description": pulumi.Output.concat(
+                                "Keep only the ",
+                                str(max_images),
+                                " most recent ephemeral images",
+                            ),
+                            "selection": {
+                                "tagStatus": "tagged",
+                                "tagPrefixList": ephemeral_prefixes,
+                                "countType": "imageCountMoreThan",
+                                "countNumber": max_images,
+                            },
+                            "action": {"type": "expire"},
+                        },
+                        {
+                            "rulePriority": 2,
+                            "description": pulumi.Output.concat(
+                                "Expire untagged images older than ",
+                                str(max_age_days),
+                                " days",
+                            ),
+                            "selection": {
+                                "tagStatus": "untagged",
+                                "countType": "sinceImagePushed",
+                                "countUnit": "days",
+                                "countNumber": max_age_days,
+                            },
+                            "action": {"type": "expire"},
+                        },
+                    ]
+                }
+            ).apply(lambda d: __import__("json").dumps(d))
+        )
+
+        self.ecr_lifecycle = LifecyclePolicy(
+            f"{name}-repo-lifecycle",
+            repository=self.ecr_repo.name,
+            policy=lifecycle_policy_doc,
+            opts=ResourceOptions(parent=self, depends_on=[self.ecr_repo]),
+        )
+
         # Add ECR repository policy to allow Lambda to pull images
         from pulumi_aws.ecr import RepositoryPolicy
         import json
-        
+
         RepositoryPolicy(
             f"{name}-repo-policy",
             repository=self.ecr_repo.name,
-            policy=json.dumps({
-                "Version": "2012-10-17",
-                "Statement": [
-                    {
-                        "Sid": "LambdaECRImageRetrievalPolicy",
-                        "Effect": "Allow",
-                        "Principal": {
-                            "Service": "lambda.amazonaws.com"
-                        },
-                        "Action": [
-                            "ecr:BatchGetImage",
-                            "ecr:GetDownloadUrlForLayer"
-                        ]
-                    }
-                ]
-            }),
+            policy=json.dumps(
+                {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Sid": "LambdaECRImageRetrievalPolicy",
+                            "Effect": "Allow",
+                            "Principal": {"Service": "lambda.amazonaws.com"},
+                            "Action": [
+                                "ecr:BatchGetImage",
+                                "ecr:GetDownloadUrlForLayer",
+                            ],
+                        }
+                    ],
+                }
+            ),
             opts=ResourceOptions(parent=self, depends_on=[self.ecr_repo]),
         )
 
@@ -185,7 +252,8 @@ class DockerImageComponent(ComponentResource):
             ],
             opts=ResourceOptions(
                 parent=self,
-                depends_on=[self.ecr_repo] + ([base_images] if base_images else []),
+                depends_on=[self.ecr_repo]
+                + ([base_images] if base_images else []),
                 replace_on_changes=["build_args", "dockerfile"],
             ),
         )

--- a/infra/chromadb_compaction/components/docker_image.py
+++ b/infra/chromadb_compaction/components/docker_image.py
@@ -1,5 +1,6 @@
 """Docker image building component for ChromaDB compaction Lambda functions."""
 
+import json
 import hashlib
 import subprocess
 from pathlib import Path
@@ -139,43 +140,37 @@ class DockerImageComponent(ComponentResource):
             p.strip() for p in ephemeral_prefixes_str.split(",") if p.strip()
         ] or ["git-", "sha-"]
 
-        lifecycle_policy_doc = pulumi.Output.secret(
-            pulumi.Output.from_input(
-                {
-                    "rules": [
-                        {
-                            "rulePriority": 1,
-                            "description": pulumi.Output.concat(
-                                "Keep only the ",
-                                str(max_images),
-                                " most recent ephemeral images",
-                            ),
-                            "selection": {
-                                "tagStatus": "tagged",
-                                "tagPrefixList": ephemeral_prefixes,
-                                "countType": "imageCountMoreThan",
-                                "countNumber": max_images,
-                            },
-                            "action": {"type": "expire"},
+        lifecycle_policy_doc = json.dumps(
+            {
+                "rules": [
+                    {
+                        "rulePriority": 1,
+                        "description": (
+                            f"Keep only the {max_images} most recent ephemeral images"
+                        ),
+                        "selection": {
+                            "tagStatus": "tagged",
+                            "tagPrefixList": ephemeral_prefixes,
+                            "countType": "imageCountMoreThan",
+                            "countNumber": max_images,
                         },
-                        {
-                            "rulePriority": 2,
-                            "description": pulumi.Output.concat(
-                                "Expire untagged images older than ",
-                                str(max_age_days),
-                                " days",
-                            ),
-                            "selection": {
-                                "tagStatus": "untagged",
-                                "countType": "sinceImagePushed",
-                                "countUnit": "days",
-                                "countNumber": max_age_days,
-                            },
-                            "action": {"type": "expire"},
+                        "action": {"type": "expire"},
+                    },
+                    {
+                        "rulePriority": 2,
+                        "description": (
+                            f"Expire untagged images older than {max_age_days} days"
+                        ),
+                        "selection": {
+                            "tagStatus": "untagged",
+                            "countType": "sinceImagePushed",
+                            "countUnit": "days",
+                            "countNumber": max_age_days,
                         },
-                    ]
-                }
-            ).apply(lambda d: __import__("json").dumps(d))
+                        "action": {"type": "expire"},
+                    },
+                ]
+            }
         )
 
         self.ecr_lifecycle = LifecyclePolicy(

--- a/infra/embedding_step_functions/components/docker_image.py
+++ b/infra/embedding_step_functions/components/docker_image.py
@@ -11,6 +11,7 @@ from pulumi_aws.ecr import (
     Repository,
     RepositoryImageScanningConfigurationArgs,
     get_authorization_token_output,
+    LifecyclePolicy,
 )
 
 # pylint: disable=import-error
@@ -102,6 +103,70 @@ class DockerImageComponent(ComponentResource):
             force_delete=True,
             tags={"environment": stack},
             opts=ResourceOptions(parent=self),
+        )
+
+        # Attach ECR lifecycle policy (retain N, expire untagged older than X)
+        portfolio_config = pulumi.Config("portfolio")
+        import os
+
+        max_images = portfolio_config.get_int("ecr-max-images") or int(
+            os.environ.get("ECR_MAX_IMAGES", "10")
+        )
+        max_age_days = portfolio_config.get_int("ecr-max-age-days") or int(
+            os.environ.get("ECR_MAX_AGE_DAYS", "30")
+        )
+        # Protect important tags by limiting pruning to ephemeral tag prefixes
+        ephemeral_prefixes_str = portfolio_config.get(
+            "ecr-ephemeral-tag-prefixes"
+        ) or os.environ.get("ECR_EPHEMERAL_TAG_PREFIXES", "git-,sha-")
+        ephemeral_prefixes = [
+            p.strip() for p in ephemeral_prefixes_str.split(",") if p.strip()
+        ] or ["git-", "sha-"]
+
+        lifecycle_policy_doc = pulumi.Output.secret(
+            pulumi.Output.from_input(
+                {
+                    "rules": [
+                        {
+                            "rulePriority": 1,
+                            "description": pulumi.Output.concat(
+                                "Keep only the ",
+                                str(max_images),
+                                " most recent ephemeral images",
+                            ),
+                            "selection": {
+                                "tagStatus": "tagged",
+                                "tagPrefixList": ephemeral_prefixes,
+                                "countType": "imageCountMoreThan",
+                                "countNumber": max_images,
+                            },
+                            "action": {"type": "expire"},
+                        },
+                        {
+                            "rulePriority": 2,
+                            "description": pulumi.Output.concat(
+                                "Expire untagged images older than ",
+                                str(max_age_days),
+                                " days",
+                            ),
+                            "selection": {
+                                "tagStatus": "untagged",
+                                "countType": "sinceImagePushed",
+                                "countUnit": "days",
+                                "countNumber": max_age_days,
+                            },
+                            "action": {"type": "expire"},
+                        },
+                    ]
+                }
+            ).apply(lambda d: __import__("json").dumps(d))
+        )
+
+        self.ecr_lifecycle = LifecyclePolicy(
+            f"{name}-repo-lifecycle",
+            repository=self.ecr_repo.name,
+            policy=lifecycle_policy_doc,
+            opts=ResourceOptions(parent=self, depends_on=[self.ecr_repo]),
         )
 
         # Get ECR auth token


### PR DESCRIPTION
# Pull Request

## 📋 Description

Implements metadata-first realtime matching and embeds receipt-level normalized fields in ChromaDB metadatas per Issue #374.

- Adds `normalized_phone_10` and `normalized_full_address` to line/word vectors during write paths (realtime + batch), and opportunistically backfills them during compaction.
- Provides shared normalization utilities for phone, address, URL, and full-address assembly.
- Updates the realtime development script to always download the latest Chroma snapshots and to support metadata-first candidate retrieval (feature-flagged), with DynamoDB fallback for older vectors.
- Adds unit tests for normalization helpers.
- Measures and reports performance improvements when using metadata-first retrieval.

## 🔄 Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] ⚡ Performance improvement
- [x] 🔧 Refactoring (no functional changes)
- [x] 🧪 Test changes

## 🧪 Testing

- [x] Tests pass locally
- [x] Added tests for new functionality (`receipt_label/tests/test_shared_normalize.py`)
- [x] Updated/validated existing flows (realtime and batch pollers)
- [x] Manual testing completed
  - Re-ran step functions to re-embed lines/words with new metadatas
  - Ran realtime dev script to download latest snapshots and benchmark metadata-first vs Dynamo fallback

## 📚 Documentation

- [x] Comments added for complex logic
- [ ] README updated if needed

## 🤖 AI Review Status

### Cursor Bot Review

- [ ] Waiting for Cursor bot analysis
- [x] Cursor findings addressed
- [x] No critical issues found

### AI Review (Cursor)

- [x] Cursor bot findings addressed (if any)

## ✅ Checklist

- [x] My code follows this project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## 🚀 Deployment Notes

- No schema changes to Chroma collections are required; fields are added to metadata only.
- Compaction lambda will backfill missing metadata over time. A one-time backfill is optional.
- Keep the metadata-first feature flag enabled while older vectors are still present (`USE_METADATA_FOR_CANDIDATES=1`).

## 📷 Screenshots

N/A (CLI output for benchmark included below).

---

### Summary of Changes

- New: `receipt_label/merchant_validation/normalize.py`
  - `normalize_phone`, `normalize_address`, `normalize_url`, `build_full_address_from_words`, `build_full_address_from_lines`.
- Realtime writers
  - `receipt_label/receipt_label/embedding/line/realtime.py`, `receipt_label/receipt_label/embedding/word/realtime.py`: add normalized fields to metadatas.
- Batch pollers
  - `receipt_label/receipt_label/embedding/line/poll.py`, `receipt_label/receipt_label/embedding/word/poll.py`: include normalized fields in deltas.
- Compaction
  - `infra/chromadb_compaction/lambdas/enhanced_compaction_handler.py`: backfill normalized fields during metadata updates.
- Dev script
  - `dev.realtime_embedding_new.py`: atomic snapshot download; metadata-first helpers; benchmark.
- Tests
  - `receipt_label/tests/test_shared_normalize.py`: unit tests for normalization helpers.

### Performance (dev script benchmark)

- Metadata-first candidate retrieval: ~0.43 s over 25 receipts
- Dynamo fallback retrieval: ~41.29 s over 25 receipts
- Approx. ~95× speedup for this step (numbers will vary per dataset)

### Acceptance Criteria Alignment

- Realtime matching can read normalized phone/address from `metadatas`.
- Prefetch time reduced significantly when neighbors carry new fields.
- Normalization outputs are consistent across realtime, batch, and compaction.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Automated ECR image lifecycle management applied to base images, ChromaDB compaction, and embedding step functions repositories.
  - Lifecycle rules keep recent ephemeral-tagged images and expire untagged images older than a configured age; lifecycle resources are now created and attached to repositories.

- Chores
  - New configuration keys: ecr-max-images, ecr-max-age-days (and support for ephemeral tag prefixes), with portfolio config and env-var overrides and sensible defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->