### PR TITLE
Fix mobile layout for receipt labels component

### DIFF
--- a/portfolio/styles/RandomReceiptWithLabels.module.css
+++ b/portfolio/styles/RandomReceiptWithLabels.module.css
@@ -351,15 +351,19 @@
   }
 
   .mobileContainer {
+    flex-direction: row;
     gap: 1rem;
     align-items: stretch;
+    max-width: 100%;
+    margin: 0 auto;
   }
 
   .imageContainer {
-    flex: 1;
+    flex: 0 0 50%;
     min-width: 0;
     display: flex;
     align-items: center;
+    justify-content: center;
   }
 
   .imageWrapper {
@@ -368,7 +372,7 @@
   }
 
   .labelsList {
-    flex: 0 0 200px;
+    flex: 0 0 50%;
     display: flex;
     align-items: center;
     padding: 0.5rem;
@@ -396,8 +400,8 @@
   }
 }
 
-/* Very small mobile */
-@media (max-width: 480px) {
+/* Very small mobile - only stack on very tiny screens */
+@media (max-width: 360px) {
   .container {
     padding: 1rem 0;
   }


### PR DESCRIPTION
## Description

This PR fixes the mobile layout for the RandomReceiptWithLabels component to ensure proper 50/50 split between receipt image and labels legend, with the container centered horizontally.

## Changes

- Updated mobile layout to use 50% width for both receipt image container and labels list
- Centered the mobile container horizontally using margin auto
- Removed text centering from category headers (left-aligned text within centered container)
- Ensures receipt takes 50% of left side and legend takes 50% of right side on mobile

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Testing

- [x] Manual testing completed on mobile device
- [x] Verified receipt and legend are properly split 50/50
- [x] Verified container is centered horizontally

## Deployment

- Changes have been deployed to S3 and CloudFront cache invalidated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved mobile responsive layout with optimized content stacking for various screen sizes
  * Enhanced vertical layout for very small mobile devices with adjusted spacing and typography
  * Optimized image and label container sizing across mobile breakpoints
  * Full-width button display on very small screens for better usability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->