### PR TITLE
Fix: Add receipt_dynamo_stream to Docker builds and source paths

### DIFF
--- a/infra/chromadb_compaction/lambdas/Dockerfile
+++ b/infra/chromadb_compaction/lambdas/Dockerfile
@@ -10,12 +10,14 @@ ENV HNSWLIB_NO_NATIVE=1
 
 # Copy only the dependency packages (triggers rebuild only when these change)
 COPY receipt_dynamo/ /tmp/receipt_dynamo/
+COPY receipt_dynamo_stream/ /tmp/receipt_dynamo_stream/
 COPY receipt_chroma/ /tmp/receipt_chroma/
 
 # Install dependencies
 RUN pip install --no-cache-dir /tmp/receipt_dynamo && \
+    pip install --no-cache-dir /tmp/receipt_dynamo_stream && \
     pip install --no-cache-dir /tmp/receipt_chroma && \
-    rm -rf /tmp/receipt_dynamo /tmp/receipt_chroma
+    rm -rf /tmp/receipt_dynamo /tmp/receipt_dynamo_stream /tmp/receipt_chroma
 
 # Stage 2: Copy Lambda-specific code (changes frequently, but doesn't invalidate deps cache)
 FROM dependencies

--- a/infra/combine_receipts_step_functions/infrastructure.py
+++ b/infra/combine_receipts_step_functions/infrastructure.py
@@ -431,6 +431,7 @@ class CombineReceiptsStepFunction(ComponentResource):
             build_context_path=".",
             source_paths=[
                 "receipt_dynamo",
+                "receipt_dynamo_stream",
                 "receipt_chroma",
                 "receipt_agent",
                 "receipt_places",

--- a/infra/combine_receipts_step_functions/lambdas/Dockerfile
+++ b/infra/combine_receipts_step_functions/lambdas/Dockerfile
@@ -21,6 +21,7 @@ ENV HNSWLIB_NO_NATIVE=1
 
 # Copy only the dependency packages (triggers rebuild only when these change)
 COPY receipt_dynamo/ /tmp/receipt_dynamo/
+COPY receipt_dynamo_stream/ /tmp/receipt_dynamo_stream/
 COPY receipt_chroma/ /tmp/receipt_chroma/
 COPY receipt_places/ /tmp/receipt_places/
 COPY receipt_agent/ /tmp/receipt_agent/
@@ -29,11 +30,12 @@ COPY receipt_upload/ /tmp/receipt_upload/
 # Install dependencies from pyproject.toml files
 # Install in dependency order
 RUN pip install --no-cache-dir /tmp/receipt_dynamo && \
+    pip install --no-cache-dir /tmp/receipt_dynamo_stream && \
     pip install --no-cache-dir /tmp/receipt_chroma && \
     pip install --no-cache-dir /tmp/receipt_places && \
     pip install --no-cache-dir /tmp/receipt_upload && \
     pip install --no-cache-dir /tmp/receipt_agent && \
-    rm -rf /tmp/receipt_dynamo /tmp/receipt_chroma /tmp/receipt_places /tmp/receipt_upload /tmp/receipt_agent
+    rm -rf /tmp/receipt_dynamo /tmp/receipt_dynamo_stream /tmp/receipt_chroma /tmp/receipt_places /tmp/receipt_upload /tmp/receipt_agent
 
 # Stage 2: Copy Lambda-specific code (changes frequently, but doesn't invalidate deps cache)
 FROM dependencies

--- a/infra/components/codebuild_docker_image.py
+++ b/infra/components/codebuild_docker_image.py
@@ -370,6 +370,7 @@ class CodeBuildDockerImage(ComponentResource):
         # Default minimal packages that all Lambdas need
         packages_to_include = [
             "receipt_dynamo",
+            "receipt_dynamo_stream",
             "receipt_chroma",
             "receipt_places",
             "receipt_agent",

--- a/infra/embedding_step_functions/unified_embedding/Dockerfile
+++ b/infra/embedding_step_functions/unified_embedding/Dockerfile
@@ -9,16 +9,18 @@ ENV HNSWLIB_NO_NATIVE=1
 
 # Copy only the dependency packages (triggers rebuild only when these change)
 COPY receipt_dynamo/ /tmp/receipt_dynamo/
+COPY receipt_dynamo_stream/ /tmp/receipt_dynamo_stream/
 COPY receipt_chroma/ /tmp/receipt_chroma/
 COPY receipt_places/ /tmp/receipt_places/
 COPY receipt_agent/ /tmp/receipt_agent/
 
 # Install dependencies (receipt_label no longer required for ingest handlers)
 RUN pip install --no-cache-dir /tmp/receipt_dynamo && \
+    pip install --no-cache-dir /tmp/receipt_dynamo_stream && \
     pip install --no-cache-dir /tmp/receipt_chroma && \
     pip install --no-cache-dir /tmp/receipt_places && \
     pip install --no-cache-dir /tmp/receipt_agent && \
-    rm -rf /tmp/receipt_dynamo /tmp/receipt_chroma /tmp/receipt_places /tmp/receipt_agent
+    rm -rf /tmp/receipt_dynamo /tmp/receipt_dynamo_stream /tmp/receipt_chroma /tmp/receipt_places /tmp/receipt_agent
 
 # Stage 2: Copy Lambda-specific code (changes frequently, but doesn't invalidate deps cache)
 FROM dependencies

--- a/infra/label_harmonizer_step_functions/lambdas/Dockerfile
+++ b/infra/label_harmonizer_step_functions/lambdas/Dockerfile
@@ -8,6 +8,7 @@ ENV HNSWLIB_NO_NATIVE=1
 
 # Copy only the dependency packages (triggers rebuild only when these change)
 COPY receipt_dynamo/ /tmp/receipt_dynamo/
+COPY receipt_dynamo_stream/ /tmp/receipt_dynamo_stream/
 COPY receipt_chroma/ /tmp/receipt_chroma/
 COPY receipt_places/ /tmp/receipt_places/
 COPY receipt_agent/ /tmp/receipt_agent/
@@ -15,10 +16,11 @@ COPY receipt_agent/ /tmp/receipt_agent/
 # Install dependencies from pyproject.toml files
 # receipt_agent depends on receipt_dynamo, receipt_chroma, and receipt_places, so install in order
 RUN pip install --no-cache-dir /tmp/receipt_dynamo && \
+    pip install --no-cache-dir /tmp/receipt_dynamo_stream && \
     pip install --no-cache-dir /tmp/receipt_chroma && \
     pip install --no-cache-dir /tmp/receipt_places && \
     pip install --no-cache-dir /tmp/receipt_agent && \
-    rm -rf /tmp/receipt_dynamo /tmp/receipt_chroma /tmp/receipt_places /tmp/receipt_agent
+    rm -rf /tmp/receipt_dynamo /tmp/receipt_dynamo_stream /tmp/receipt_chroma /tmp/receipt_places /tmp/receipt_agent
 
 # Stage 2: Copy Lambda-specific code (changes frequently, but doesn't invalidate deps cache)
 FROM dependencies

--- a/infra/label_suggestion_step_functions/lambdas/Dockerfile
+++ b/infra/label_suggestion_step_functions/lambdas/Dockerfile
@@ -1,4 +1,4 @@
-# Multi-stage build for Label Validation Agent Lambda
+# Multi-stage build for Label Suggestion Lambda
 
 # Stage 1: Build and install dependencies (cached layer)
 FROM public.ecr.aws/lambda/python:3.12 AS dependencies
@@ -8,6 +8,7 @@ ENV HNSWLIB_NO_NATIVE=1
 
 # Copy only the dependency packages (triggers rebuild only when these change)
 COPY receipt_dynamo/ /tmp/receipt_dynamo/
+COPY receipt_dynamo_stream/ /tmp/receipt_dynamo_stream/
 COPY receipt_chroma/ /tmp/receipt_chroma/
 COPY receipt_places/ /tmp/receipt_places/
 COPY receipt_agent/ /tmp/receipt_agent/
@@ -15,10 +16,11 @@ COPY receipt_agent/ /tmp/receipt_agent/
 # Install dependencies from pyproject.toml files
 # receipt_agent depends on receipt_dynamo, receipt_chroma, and receipt_places, so install in order
 RUN pip install --no-cache-dir /tmp/receipt_dynamo && \
+    pip install --no-cache-dir /tmp/receipt_dynamo_stream && \
     pip install --no-cache-dir /tmp/receipt_chroma && \
     pip install --no-cache-dir /tmp/receipt_places && \
     pip install --no-cache-dir /tmp/receipt_agent && \
-    rm -rf /tmp/receipt_dynamo /tmp/receipt_chroma /tmp/receipt_places /tmp/receipt_agent
+    rm -rf /tmp/receipt_dynamo /tmp/receipt_dynamo_stream /tmp/receipt_chroma /tmp/receipt_places /tmp/receipt_agent
 
 # Stage 2: Copy Lambda-specific code (changes frequently, but doesn't invalidate deps cache)
 FROM dependencies

--- a/infra/label_validation_agent_step_functions/lambdas/Dockerfile
+++ b/infra/label_validation_agent_step_functions/lambdas/Dockerfile
@@ -8,19 +8,23 @@ ENV HNSWLIB_NO_NATIVE=1
 
 # Copy only the dependency packages (triggers rebuild only when these change)
 COPY receipt_dynamo/ /tmp/receipt_dynamo/
+COPY receipt_dynamo_stream/ /tmp/receipt_dynamo_stream/
 COPY receipt_chroma/ /tmp/receipt_chroma/
 COPY receipt_places/ /tmp/receipt_places/
 COPY receipt_upload/ /tmp/receipt_upload/
 COPY receipt_agent/ /tmp/receipt_agent/
 
-# Install dependencies from pyproject.toml files
-# receipt_agent depends on receipt_dynamo, receipt_chroma, and receipt_places, so install in order
+# Install dependencies from pyproject.toml files in dependency order
+# receipt_dynamo_stream depends on receipt_dynamo
+# receipt_chroma depends on receipt_dynamo_stream
+# receipt_agent depends on receipt_dynamo, receipt_chroma, receipt_places, and receipt_upload
 RUN pip install --no-cache-dir /tmp/receipt_dynamo && \
+    pip install --no-cache-dir /tmp/receipt_dynamo_stream && \
     pip install --no-cache-dir /tmp/receipt_chroma && \
     pip install --no-cache-dir /tmp/receipt_places && \
     pip install --no-cache-dir /tmp/receipt_upload && \
     pip install --no-cache-dir /tmp/receipt_agent && \
-    rm -rf /tmp/receipt_dynamo /tmp/receipt_chroma /tmp/receipt_places /tmp/receipt_upload /tmp/receipt_agent
+    rm -rf /tmp/receipt_dynamo /tmp/receipt_dynamo_stream /tmp/receipt_chroma /tmp/receipt_places /tmp/receipt_upload /tmp/receipt_agent
 
 # Stage 2: Copy Lambda-specific code (changes frequently, but doesn't invalidate deps cache)
 FROM dependencies

--- a/infra/metadata_harmonizer_step_functions/lambdas/Dockerfile
+++ b/infra/metadata_harmonizer_step_functions/lambdas/Dockerfile
@@ -8,19 +8,23 @@ ENV HNSWLIB_NO_NATIVE=1
 
 # Copy only the dependency packages (triggers rebuild only when these change)
 COPY receipt_dynamo/ /tmp/receipt_dynamo/
+COPY receipt_dynamo_stream/ /tmp/receipt_dynamo_stream/
 COPY receipt_chroma/ /tmp/receipt_chroma/
 COPY receipt_upload/ /tmp/receipt_upload/
 COPY receipt_places/ /tmp/receipt_places/
 COPY receipt_agent/ /tmp/receipt_agent/
 
-# Install dependencies from pyproject.toml files
-# receipt_agent depends on receipt_dynamo, receipt_chroma, receipt_upload, and receipt_places, so install in order
+# Install dependencies from pyproject.toml files in dependency order
+# receipt_dynamo_stream depends on receipt_dynamo
+# receipt_chroma depends on receipt_dynamo_stream
+# receipt_agent depends on receipt_dynamo, receipt_chroma, receipt_upload, and receipt_places
 RUN pip install --no-cache-dir /tmp/receipt_dynamo && \
+    pip install --no-cache-dir /tmp/receipt_dynamo_stream && \
     pip install --no-cache-dir /tmp/receipt_chroma && \
     pip install --no-cache-dir /tmp/receipt_upload && \
     pip install --no-cache-dir /tmp/receipt_places && \
     pip install --no-cache-dir /tmp/receipt_agent && \
-    rm -rf /tmp/receipt_dynamo /tmp/receipt_chroma /tmp/receipt_upload /tmp/receipt_places /tmp/receipt_agent
+    rm -rf /tmp/receipt_dynamo /tmp/receipt_dynamo_stream /tmp/receipt_chroma /tmp/receipt_upload /tmp/receipt_places /tmp/receipt_agent
 
 # Stage 2: Copy Lambda-specific code (changes frequently, but doesn't invalidate deps cache)
 FROM dependencies

--- a/infra/routes/address_similarity_cache_generator/lambdas/Dockerfile
+++ b/infra/routes/address_similarity_cache_generator/lambdas/Dockerfile
@@ -9,14 +9,17 @@ ENV HNSWLIB_NO_NATIVE=1
 
 # Copy only the dependency packages (triggers rebuild only when these change)
 COPY receipt_dynamo/ /tmp/receipt_dynamo/
+COPY receipt_dynamo_stream/ /tmp/receipt_dynamo_stream/
 COPY receipt_chroma/ /tmp/receipt_chroma/
 
 # Install dependencies with full ChromaDB support
 # receipt_dynamo: DynamoDB client and constants
+# receipt_dynamo_stream: DynamoDB stream utilities
 # receipt_chroma: ChromaDB snapshot management and compaction logic
 RUN pip install --no-cache-dir /tmp/receipt_dynamo && \
+    pip install --no-cache-dir /tmp/receipt_dynamo_stream && \
     pip install --no-cache-dir /tmp/receipt_chroma && \
-    rm -rf /tmp/receipt_dynamo /tmp/receipt_chroma
+    rm -rf /tmp/receipt_dynamo /tmp/receipt_dynamo_stream /tmp/receipt_chroma
 
 # Stage 2: Copy Lambda-specific code (changes frequently, but doesn't invalidate deps cache)
 FROM dependencies

--- a/infra/upload_images/container/Dockerfile
+++ b/infra/upload_images/container/Dockerfile
@@ -9,16 +9,18 @@ ENV HNSWLIB_NO_NATIVE=1
 
 # Copy only the dependency packages (triggers rebuild only when these change)
 COPY receipt_dynamo/ /tmp/receipt_dynamo/
+COPY receipt_dynamo_stream/ /tmp/receipt_dynamo_stream/
 COPY receipt_chroma/ /tmp/receipt_chroma/
 COPY receipt_agent/ /tmp/receipt_agent/
 COPY receipt_places/ /tmp/receipt_places/
 
 # Install dependencies with full ChromaDB support
 RUN pip install --no-cache-dir /tmp/receipt_dynamo && \
+    pip install --no-cache-dir /tmp/receipt_dynamo_stream && \
     pip install --no-cache-dir /tmp/receipt_chroma && \
     pip install --no-cache-dir /tmp/receipt_agent && \
     pip install --no-cache-dir /tmp/receipt_places && \
-    rm -rf /tmp/receipt_dynamo /tmp/receipt_chroma /tmp/receipt_agent /tmp/receipt_places
+    rm -rf /tmp/receipt_dynamo /tmp/receipt_dynamo_stream /tmp/receipt_chroma /tmp/receipt_agent /tmp/receipt_places
 
 # Stage 2: Copy Lambda-specific code (changes frequently, but doesn't invalidate deps cache)
 FROM dependencies

--- a/infra/upload_images/container_ocr/Dockerfile
+++ b/infra/upload_images/container_ocr/Dockerfile
@@ -9,6 +9,7 @@ ENV HNSWLIB_NO_NATIVE=1
 
 # Copy only the dependency packages (triggers rebuild only when these change)
 COPY receipt_dynamo/ /tmp/receipt_dynamo/
+COPY receipt_dynamo_stream/ /tmp/receipt_dynamo_stream/
 COPY receipt_chroma/ /tmp/receipt_chroma/
 COPY receipt_agent/ /tmp/receipt_agent/
 COPY receipt_places/ /tmp/receipt_places/
@@ -17,11 +18,12 @@ COPY receipt_upload/ /tmp/receipt_upload/
 # Install dependencies with full ChromaDB support
 # receipt_upload depends on receipt_dynamo
 RUN pip install --no-cache-dir /tmp/receipt_dynamo && \
+    pip install --no-cache-dir /tmp/receipt_dynamo_stream && \
     pip install --no-cache-dir /tmp/receipt_chroma && \
     pip install --no-cache-dir /tmp/receipt_agent && \
     pip install --no-cache-dir /tmp/receipt_places && \
     pip install --no-cache-dir /tmp/receipt_upload && \
-    rm -rf /tmp/receipt_dynamo /tmp/receipt_chroma /tmp/receipt_agent /tmp/receipt_places /tmp/receipt_upload
+    rm -rf /tmp/receipt_dynamo /tmp/receipt_dynamo_stream /tmp/receipt_chroma /tmp/receipt_agent /tmp/receipt_places /tmp/receipt_upload
 
 # Stage 2: Copy Lambda-specific code (changes frequently, but doesn't invalidate deps cache)
 FROM dependencies

--- a/infra/upload_images/infra.py
+++ b/infra/upload_images/infra.py
@@ -505,6 +505,7 @@ class UploadImages(ComponentResource):
             build_context_path=".",  # Project root for monorepo access
             source_paths=[
                 "receipt_dynamo",
+                "receipt_dynamo_stream",
                 "receipt_chroma",
                 "receipt_agent",
                 "receipt_places",


### PR DESCRIPTION
## 📋 Description

Fixes failing CodeBuild pipelines that use `receipt_chroma`. The issue is that `receipt_chroma`'s `pyproject.toml` now declares `receipt-dynamo-stream` as a dependency, but the Docker builds were not copying `receipt_dynamo_stream` into the build context, causing `pip install` to fail with dependency resolution errors.

## Root Cause

- `receipt_chroma` requires `receipt_dynamo_stream` as a dependency
- Dockerfiles manually copy local packages into the build context
- `receipt_dynamo_stream` was missing from all COPY instructions
- When `pip install receipt_chroma` runs, it can't find `receipt-dynamo-stream`

## Solution

Added `receipt_dynamo_stream` to:
1. **10 Dockerfiles**: Added COPY line and pip install in correct dependency order (after receipt_dynamo, before receipt_chroma)
2. **CodeBuildDockerImage component**: Added to default packages list so all builds auto-include it in S3 upload via rsync
3. **Infrastructure files**: Updated source_paths where explicitly specified

## 🔄 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## 🧪 Testing

- [x] No local testing required (cloud-only deployment)
- [x] Code review completed - syntax and structure verified
- [x] Dockerfile syntax is valid (verified COPY and RUN commands)
- [x] Dependency order is correct in all files

## 📚 Documentation

- [x] No documentation updates needed for this infrastructure fix

## ✅ Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed for correctness
- [x] No new warnings introduced
- [x] All 10 Dockerfiles updated with consistent pattern
- [x] CodeBuildDockerImage default packages updated to propagate to S3 upload
- [x] Dependency order verified (receipt_dynamo → receipt_dynamo_stream → receipt_chroma → others)

## 🚀 Deployment Notes

CodeBuild pipelines should now complete successfully. The Docker builds will:
1. Copy `receipt_dynamo_stream` from the S3 build context (via updated rsync in CodeBuildDockerImage)
2. Install `receipt_dynamo_stream` before attempting to install `receipt_chroma`
3. Successfully resolve all dependencies when `pip install receipt_chroma` runs

No rollback procedures needed - this is purely additive.

## Files Modified

- 10 Dockerfiles (added COPY and pip install for receipt_dynamo_stream)
- `infra/components/codebuild_docker_image.py` (added receipt_dynamo_stream to default packages)
- `infra/upload_images/infra.py` (added to source_paths)
- `infra/combine_receipts_step_functions/infrastructure.py` (added to source_paths)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Included a new internal dependency package across multiple services and container images.
  * Synchronized Docker build steps to install and clean up the new package alongside existing dependencies.
  * Updated build contexts and infrastructure configuration so the new package is consistently available during builds.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->