### PR TITLE
Fix Docker package installation dependency order

### DIFF
--- a/infra/label_harmonizer_step_functions/lambdas/Dockerfile.v3
+++ b/infra/label_harmonizer_step_functions/lambdas/Dockerfile.v3
@@ -8,20 +8,24 @@ ENV HNSWLIB_NO_NATIVE=1
 
 # Copy only the dependency packages (triggers rebuild only when these change)
 COPY receipt_dynamo/ /tmp/receipt_dynamo/
+COPY receipt_dynamo_stream/ /tmp/receipt_dynamo_stream/
 COPY receipt_chroma/ /tmp/receipt_chroma/
 COPY receipt_places/ /tmp/receipt_places/
 COPY receipt_upload/ /tmp/receipt_upload/
 COPY receipt_agent/ /tmp/receipt_agent/
 
 # Install dependencies from pyproject.toml files
+# receipt_dynamo_stream depends on receipt_dynamo
+# receipt_chroma depends on receipt_dynamo_stream
 # receipt_agent depends on receipt_dynamo, receipt_chroma, receipt_places, and receipt_upload
 # Install in order: base packages first, then receipt_agent
 RUN pip install --no-cache-dir /tmp/receipt_dynamo && \
+    pip install --no-cache-dir /tmp/receipt_dynamo_stream && \
     pip install --no-cache-dir /tmp/receipt_chroma && \
     pip install --no-cache-dir /tmp/receipt_places && \
     pip install --no-cache-dir /tmp/receipt_upload && \
     pip install --no-cache-dir /tmp/receipt_agent && \
-    rm -rf /tmp/receipt_dynamo /tmp/receipt_chroma /tmp/receipt_places /tmp/receipt_upload /tmp/receipt_agent
+    rm -rf /tmp/receipt_dynamo /tmp/receipt_dynamo_stream /tmp/receipt_chroma /tmp/receipt_places /tmp/receipt_upload /tmp/receipt_agent
 
 # Stage 2: Copy Lambda-specific code (changes frequently, but doesn't invalidate deps cache)
 FROM dependencies

--- a/infra/upload_images/container/Dockerfile
+++ b/infra/upload_images/container/Dockerfile
@@ -18,8 +18,8 @@ COPY receipt_places/ /tmp/receipt_places/
 RUN pip install --no-cache-dir /tmp/receipt_dynamo && \
     pip install --no-cache-dir /tmp/receipt_dynamo_stream && \
     pip install --no-cache-dir /tmp/receipt_chroma && \
-    pip install --no-cache-dir /tmp/receipt_agent && \
     pip install --no-cache-dir /tmp/receipt_places && \
+    pip install --no-cache-dir /tmp/receipt_agent && \
     rm -rf /tmp/receipt_dynamo /tmp/receipt_dynamo_stream /tmp/receipt_chroma /tmp/receipt_agent /tmp/receipt_places
 
 # Stage 2: Copy Lambda-specific code (changes frequently, but doesn't invalidate deps cache)

--- a/infra/upload_images/container_ocr/Dockerfile
+++ b/infra/upload_images/container_ocr/Dockerfile
@@ -20,8 +20,8 @@ COPY receipt_upload/ /tmp/receipt_upload/
 RUN pip install --no-cache-dir /tmp/receipt_dynamo && \
     pip install --no-cache-dir /tmp/receipt_dynamo_stream && \
     pip install --no-cache-dir /tmp/receipt_chroma && \
-    pip install --no-cache-dir /tmp/receipt_agent && \
     pip install --no-cache-dir /tmp/receipt_places && \
+    pip install --no-cache-dir /tmp/receipt_agent && \
     pip install --no-cache-dir /tmp/receipt_upload && \
     rm -rf /tmp/receipt_dynamo /tmp/receipt_dynamo_stream /tmp/receipt_chroma /tmp/receipt_agent /tmp/receipt_places /tmp/receipt_upload
 


### PR DESCRIPTION
## Summary

Fixes pip installation order in Lambda Dockerfiles to resolve recurring pipeline failures. The issue was caused by incorrect package dependency ordering during Docker image builds.

## Changes

- **infra/upload_images/container/Dockerfile**: Install `receipt_places` before `receipt_agent` to satisfy dependency
- **infra/upload_images/container_ocr/Dockerfile**: Install `receipt_places` before `receipt_agent` to satisfy dependency  
- **infra/label_harmonizer_step_functions/lambdas/Dockerfile.v3**: Add missing `receipt_dynamo_stream` dependency and correct installation order

## Issues Fixed

- ✅ `upload-images-embed-ndjson-image-pipeline-fb78b76` pipeline failures
- ✅ `label-harmonizer-v3-prod-v3-harmonize-img-pipeline-54c634f` pipeline failures

## Root Cause

The `receipt_agent` package depends on `receipt_places`, but the Dockerfiles were attempting to install `receipt_agent` first, causing pip's dependency resolver to fail with "Could not find a version that satisfies the requirement receipt-places".

Additionally, the v3 Dockerfile was missing `receipt_dynamo_stream` which is required by `receipt_chroma`.

## Dependency Graph

```
receipt_dynamo (base)
  ↓
receipt_dynamo_stream (depends on receipt_dynamo)
  ↓
receipt_chroma (depends on receipt_dynamo_stream)

receipt_places (depends on receipt_dynamo)

receipt_agent (depends on all above + receipt_upload)
```

The installation order now correctly reflects these dependencies.

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container build configurations to optimize internal service dependencies and installation ordering.
  * Improved build process organization across infrastructure services for enhanced efficiency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->