### PR TITLE
Fix stream_processor lambda and resolve module import issues

### DIFF
--- a/infra/__main__.py
+++ b/infra/__main__.py
@@ -2,6 +2,11 @@
 
 import base64
 import os
+import sys
+from pathlib import Path
+
+# Add parent directory to path so 'infra' package can be imported
+sys.path.insert(0, str(Path(__file__).parent.parent))
 
 import api_gateway
 import pulumi

--- a/infra/chromadb_compaction/lambdas/stream_processor.py
+++ b/infra/chromadb_compaction/lambdas/stream_processor.py
@@ -279,23 +279,3 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
     finally:
         # Stop monitoring
         stop_compaction_lambda_monitoring()
-
-
-# Re-export for backward compatibility with existing tests
-from processor import (
-    ChromaDBCollection,
-    FieldChange,
-    ParsedStreamRecord,
-    StreamMessage,
-)
-from processor import detect_entity_type as _detect_entity_type
-from processor import (
-    get_chromadb_relevant_changes,
-)
-from processor import is_compaction_run as _is_compaction_run
-from processor import parse_compaction_run as _parse_compaction_run
-from processor import parse_entity as _parse_entity
-from processor import (
-    parse_stream_record,
-)
-from processor import publish_messages as send_messages_to_queues


### PR DESCRIPTION
## Summary

Fixes the stream_processor lambda import errors and resolves Pulumi deployment issues.

## Changes

1. **Remove unused processor imports from stream_processor lambda**
   - The lambda was trying to import from a non-existent 'processor' module
   - These imports were marked as 'backward compatibility with existing tests' but were never actually used
   - The stream processor only needs `receipt_dynamo_stream` (for parsing DynamoDB events and queuing messages) and `utils` (for logging/monitoring)
   - Fixes: `No module named processor` runtime error

2. **Add parent directory to sys.path in infra/__main__.py**
   - Resolves `No module named infra` error during Pulumi deployment
   - Allows absolute imports like `from infra.components` to work correctly
   - Required for chromadb_compaction component to import dependencies

## Testing

✅ Verified with `pulumi up --stack dev --yes --skip-preview`
- All 51 infrastructure changes deployed successfully
- No import errors during deployment
- Stream processor lambda now has correct module dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)