### PR TITLE
fix: remove deprecated Pulumi AWS provider arguments

### DIFF
--- a/infra/chroma/service.py
+++ b/infra/chroma/service.py
@@ -91,9 +91,7 @@ class ChromaEcsService(ComponentResource):
                 ],
                 routing_policy="MULTIVALUE",
             ),
-            health_check_custom_config=aws.servicediscovery.ServiceHealthCheckCustomConfigArgs(
-                failure_threshold=1
-            ),
+            health_check_custom_config=aws.servicediscovery.ServiceHealthCheckCustomConfigArgs(),
             opts=ResourceOptions(parent=self),
         )
 

--- a/infra/combine_receipts_step_functions/infrastructure.py
+++ b/infra/combine_receipts_step_functions/infrastructure.py
@@ -33,8 +33,8 @@ from pulumi_aws.iam import Role, RolePolicy, RolePolicyAttachment
 from pulumi_aws.lambda_ import Function, FunctionEnvironmentArgs
 from pulumi_aws.s3 import (
     Bucket,
-    BucketVersioningV2,
-    BucketVersioningV2VersioningConfigurationArgs,
+    BucketVersioning,
+    BucketVersioningVersioningConfigurationArgs,
 )
 from pulumi_aws.sfn import StateMachine, StateMachineLoggingConfigurationArgs
 
@@ -109,10 +109,10 @@ class CombineReceiptsStepFunction(ComponentResource):
             opts=ResourceOptions(parent=self),
         )
 
-        BucketVersioningV2(
+        BucketVersioning(
             f"{name}-batch-bucket-versioning",
             bucket=self.batch_bucket.id,
-            versioning_configuration=BucketVersioningV2VersioningConfigurationArgs(
+            versioning_configuration=BucketVersioningVersioningConfigurationArgs(
                 status="Enabled"
             ),
             opts=ResourceOptions(parent=self.batch_bucket),

--- a/infra/label_harmonizer_step_functions/infrastructure.py
+++ b/infra/label_harmonizer_step_functions/infrastructure.py
@@ -32,8 +32,8 @@ from pulumi_aws.iam import Role, RolePolicy, RolePolicyAttachment
 from pulumi_aws.lambda_ import Function, FunctionEnvironmentArgs
 from pulumi_aws.s3 import (
     Bucket,
-    BucketVersioningV2,
-    BucketVersioningV2VersioningConfigurationArgs,
+    BucketVersioning,
+    BucketVersioningVersioningConfigurationArgs,
 )
 from pulumi_aws.sfn import StateMachine, StateMachineLoggingConfigurationArgs
 
@@ -137,10 +137,10 @@ class LabelHarmonizerStepFunction(ComponentResource):
             opts=ResourceOptions(parent=self),
         )
 
-        BucketVersioningV2(
+        BucketVersioning(
             f"{name}-batch-bucket-versioning",
             bucket=self.batch_bucket.id,
-            versioning_configuration=BucketVersioningV2VersioningConfigurationArgs(
+            versioning_configuration=BucketVersioningVersioningConfigurationArgs(
                 status="Enabled"
             ),
             opts=ResourceOptions(parent=self.batch_bucket),
@@ -936,10 +936,10 @@ class LabelHarmonizerV3StepFunction(ComponentResource):
             opts=ResourceOptions(parent=self),
         )
 
-        BucketVersioningV2(
+        BucketVersioning(
             f"{name}-v3-batch-bucket-versioning",
             bucket=self.batch_bucket.id,
-            versioning_configuration=BucketVersioningV2VersioningConfigurationArgs(
+            versioning_configuration=BucketVersioningVersioningConfigurationArgs(
                 status="Enabled"
             ),
             opts=ResourceOptions(parent=self.batch_bucket),

--- a/infra/label_suggestion_step_functions/infrastructure.py
+++ b/infra/label_suggestion_step_functions/infrastructure.py
@@ -32,8 +32,8 @@ from pulumi_aws.iam import Role, RolePolicy, RolePolicyAttachment
 from pulumi_aws.lambda_ import Function, FunctionEnvironmentArgs
 from pulumi_aws.s3 import (
     Bucket,
-    BucketVersioningV2,
-    BucketVersioningV2VersioningConfigurationArgs,
+    BucketVersioning,
+    BucketVersioningVersioningConfigurationArgs,
 )
 from pulumi_aws.sfn import StateMachine, StateMachineLoggingConfigurationArgs
 
@@ -111,10 +111,10 @@ class LabelSuggestionStepFunction(ComponentResource):
             opts=ResourceOptions(parent=self),
         )
 
-        BucketVersioningV2(
+        BucketVersioning(
             f"{name}-batch-bucket-versioning",
             bucket=self.batch_bucket.id,
-            versioning_configuration=BucketVersioningV2VersioningConfigurationArgs(
+            versioning_configuration=BucketVersioningVersioningConfigurationArgs(
                 status="Enabled"
             ),
             opts=ResourceOptions(parent=self.batch_bucket),

--- a/infra/label_validation_agent_step_functions/infrastructure.py
+++ b/infra/label_validation_agent_step_functions/infrastructure.py
@@ -32,8 +32,8 @@ from pulumi_aws.iam import Role, RolePolicy, RolePolicyAttachment
 from pulumi_aws.lambda_ import Function, FunctionEnvironmentArgs
 from pulumi_aws.s3 import (
     Bucket,
-    BucketVersioningV2,
-    BucketVersioningV2VersioningConfigurationArgs,
+    BucketVersioning,
+    BucketVersioningVersioningConfigurationArgs,
 )
 from pulumi_aws.sfn import StateMachine, StateMachineLoggingConfigurationArgs
 
@@ -137,10 +137,10 @@ class LabelValidationAgentStepFunction(ComponentResource):
             opts=ResourceOptions(parent=self),
         )
 
-        BucketVersioningV2(
+        BucketVersioning(
             f"{name}-batch-bucket-versioning",
             bucket=self.batch_bucket.id,
-            versioning_configuration=BucketVersioningV2VersioningConfigurationArgs(
+            versioning_configuration=BucketVersioningVersioningConfigurationArgs(
                 status="Enabled"
             ),
             opts=ResourceOptions(parent=self.batch_bucket),

--- a/infra/metadata_harmonizer_step_functions/infrastructure.py
+++ b/infra/metadata_harmonizer_step_functions/infrastructure.py
@@ -32,8 +32,8 @@ from pulumi_aws.iam import Role, RolePolicy, RolePolicyAttachment
 from pulumi_aws.lambda_ import Function, FunctionEnvironmentArgs
 from pulumi_aws.s3 import (
     Bucket,
-    BucketVersioningV2,
-    BucketVersioningV2VersioningConfigurationArgs,
+    BucketVersioning,
+    BucketVersioningVersioningConfigurationArgs,
 )
 from pulumi_aws.sfn import StateMachine, StateMachineLoggingConfigurationArgs
 
@@ -117,10 +117,10 @@ class MetadataHarmonizerStepFunction(ComponentResource):
             opts=ResourceOptions(parent=self),
         )
 
-        BucketVersioningV2(
+        BucketVersioning(
             f"{name}-batch-bucket-versioning",
             bucket=self.batch_bucket.id,
-            versioning_configuration=BucketVersioningV2VersioningConfigurationArgs(
+            versioning_configuration=BucketVersioningVersioningConfigurationArgs(
                 status="Enabled"
             ),
             opts=ResourceOptions(parent=self.batch_bucket),


### PR DESCRIPTION
## Summary
- Remove deprecated `failure_threshold` from `ServiceHealthCheckCustomConfig` in Chroma ECS service (AWS always sets this to 1 now)
- Replace `BucketVersioningV2` with `BucketVersioning` in 5 step function infrastructure files (7 total usages)

## Warnings Fixed
- `failure_threshold is deprecated. The argument is no longer supported by AWS and the value is always set to 1`
- `BucketVersioningV2 is deprecated: aws.s3/bucketversioningv2.BucketVersioningV2 has been deprecated in favor of aws.s3/bucketversioning.BucketVersioning`

## Files Changed
- `infra/chroma/service.py`
- `infra/combine_receipts_step_functions/infrastructure.py`
- `infra/label_harmonizer_step_functions/infrastructure.py`
- `infra/label_suggestion_step_functions/infrastructure.py`
- `infra/label_validation_agent_step_functions/infrastructure.py`
- `infra/metadata_harmonizer_step_functions/infrastructure.py`

## Test plan
- [ ] CI passes
- [ ] Run `pulumi preview` or `pulumi up` and verify warnings are eliminated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated cloud infrastructure configurations to use current API versions for S3 bucket versioning across multiple services.
  * Simplified health check configuration for Cloud Map service to use default settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->