### PR TITLE
chore: clean up noisy pulumi log output

### DIFF
--- a/infra/__main__.py
+++ b/infra/__main__.py
@@ -1,8 +1,14 @@
 """Main Pulumi program for AWS infrastructure."""
 
-import base64
 import os
 import sys
+
+# Suppress gRPC fork handler warnings before any gRPC imports
+# These warnings are benign but noisy during multiprocess operations
+os.environ.setdefault("GRPC_ENABLE_FORK_SUPPORT", "0")
+os.environ.setdefault("GRPC_VERBOSITY", "ERROR")
+
+import base64
 from pathlib import Path
 
 # Add parent directory to path so 'infra' package can be imported

--- a/infra/components/lambda_layer.py
+++ b/infra/components/lambda_layer.py
@@ -19,7 +19,10 @@ import json
 import os
 import shlex
 import tempfile
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Set
+
+# Cache to prevent duplicate dependency log messages
+_logged_dependencies: Set[str] = set()
 
 import pulumi
 import pulumi_command as command
@@ -230,9 +233,13 @@ class LambdaLayer(ComponentResource):
                         local_path = os.path.join(PROJECT_DIR, dir_name)
                         if os.path.exists(local_path):
                             local_deps.append(dir_name)
-                            pulumi.log.info(
-                                f"📦 Found local dependency: {dir_name} for {self.name}"
-                            )
+                            # Only log each dependency once per layer
+                            cache_key = f"{self.name}:{dir_name}"
+                            if cache_key not in _logged_dependencies:
+                                _logged_dependencies.add(cache_key)
+                                pulumi.log.info(
+                                    f"📦 Found local dependency: {dir_name} for {self.name}"
+                                )
             except (OSError, ValueError) as e:
                 pulumi.log.warn(f"Could not parse pyproject.toml: {e}")
                 raise


### PR DESCRIPTION
## Summary
- Fix duplicate "Found local dependency" messages appearing during `pulumi up`
- Suppress noisy gRPC fork handler warnings

## What was happening
1. **Duplicate dependency messages**: Each local dependency was being logged twice because `_get_local_dependencies()` is called in both the `create` and `update` callbacks of Pulumi's `Command` resource
2. **gRPC warnings**: The `fork_posix.cc` and `absl::InitializeLog` warnings appear when gRPC detects fork operations during multiprocess execution

## Fix
1. Added a module-level cache (`_logged_dependencies`) to track already-logged dependencies and skip duplicates
2. Set `GRPC_ENABLE_FORK_SUPPORT=0` and `GRPC_VERBOSITY=ERROR` early in `__main__.py` before any gRPC imports

## Before
```
📦 Found local dependency: receipt_dynamo for receipt-dynamo-stream
📦 Found local dependency: receipt_dynamo for receipt-dynamo-stream
WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
I0000 00:00:1766550550.010327 1035109 fork_posix.cc:71] Other threads are currently calling into gRPC, skipping fork() handlers
```

## After
```
📦 Found local dependency: receipt_dynamo for receipt-dynamo-stream
```

## Test plan
- [ ] CI passes
- [ ] Run `pulumi preview` or `pulumi up` and verify cleaner output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Configured environment settings to suppress unnecessary gRPC fork warnings and reduce startup logging verbosity, resulting in cleaner initialization output.
  * Suppressed duplicate dependency log messages in Lambda-related components by tracking already-reported entries per component, producing clearer, less noisy logs and improving visibility into genuine dependency issues.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->