### PR TITLE
fix: add TYPE filter to GSI queries in ReceiptPlace

### DIFF
--- a/receipt_dynamo/receipt_dynamo/data/_receipt_place.py
+++ b/receipt_dynamo/receipt_dynamo/data/_receipt_place.py
@@ -531,8 +531,12 @@ class _ReceiptPlace(FlattenedStandardMixin):
         return self._query_entities(
             index_name="GSI1",
             key_condition_expression="#pk = :pk",
-            expression_attribute_names={"#pk": "GSI1PK"},
-            expression_attribute_values={":pk": {"S": gsi1_pk}},
+            expression_attribute_names={"#pk": "GSI1PK", "#type": "TYPE"},
+            expression_attribute_values={
+                ":pk": {"S": gsi1_pk},
+                ":type_value": {"S": "RECEIPT_PLACE"},
+            },
+            filter_expression="#type = :type_value",
             converter_func=item_to_receipt_place,
             limit=limit,
             last_evaluated_key=last_evaluated_key,
@@ -588,8 +592,12 @@ class _ReceiptPlace(FlattenedStandardMixin):
         return self._query_entities(
             index_name="GSI2",
             key_condition_expression="GSI2PK = :pk",
-            expression_attribute_names=None,
-            expression_attribute_values={":pk": {"S": f"PLACE#{place_id}"}},
+            expression_attribute_names={"#type": "TYPE"},
+            expression_attribute_values={
+                ":pk": {"S": f"PLACE#{place_id}"},
+                ":type_value": {"S": "RECEIPT_PLACE"},
+            },
+            filter_expression="#type = :type_value",
             converter_func=item_to_receipt_place,
             limit=limit,
             last_evaluated_key=last_evaluated_key,


### PR DESCRIPTION
## Summary

- Fixed GSI queries that could return wrong entity types due to shared key patterns
- `get_receipt_places_by_merchant` (GSI1) and `list_receipt_places_with_place_id` (GSI2) now filter by `TYPE = RECEIPT_PLACE`
- Added integration tests for the fix

## Problem

When querying by merchant name or place_id, both `ReceiptPlace` and `ReceiptMetadata` records could be returned since they share the same GSI key patterns. This caused deserialization errors when `ReceiptMetadata` records were passed to `ReceiptPlace` converters.

## Test plan

- [x] Added integration tests for GSI1 and GSI2 queries with TYPE filtering
- [x] Verified existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved receipt place queries to apply proper filtering, ensuring searches by merchant or location ID return only receipt place records and exclude other related data types that may share similar identifiers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->