### PR TITLE
fix: add OpenRouter API key to prod Pulumi stack

### DIFF
--- a/infra/Pulumi.prod.yaml
+++ b/infra/Pulumi.prod.yaml
@@ -37,3 +37,5 @@ config:
   docker-build:force-rebuild: "false"
   docker-build:debug-mode: "false"
   ml-training:enable-minimal: "true"
+  portfolio:OPENROUTER_API_KEY:
+    secure: AAABAO7+SJCT6LDKboMx7/VKP85FJcr+oO6qhoUVkLsMXsuV+9KlnSV1EP6xXDS+2+kU6qSiTOIQVkkS/Mej8F0Joqg615isPExbCJeEkauGxHgpNxSueMVwEAk4dMXkjX+mCC+9I2Sv


### PR DESCRIPTION
## Summary

Add the missing `OPENROUTER_API_KEY` secret to the production Pulumi stack.

## Problem

The prod CI/CD was failing because the `OPENROUTER_API_KEY` secret was missing from `Pulumi.prod.yaml`. This key is required for the resilient LLM fallback feature (Ollama → OpenRouter) that was added in PRs #569-#572.

## Solution

Added the encrypted secret using `pulumi config set --secret`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Testing

- CI/CD should pass after this is merged

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added production environment configuration to support API service integration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->