### PR TITLE
fix: handle optional ConditionExpression in put_places_cache

### DIFF
--- a/receipt_dynamo/receipt_dynamo/data/base_operations/base.py
+++ b/receipt_dynamo/receipt_dynamo/data/base_operations/base.py
@@ -159,7 +159,7 @@ class DynamoDBBaseOperations(DynamoClientProtocol):
     def _execute_delete_item(
         self,
         entity: Any,
-        condition_expression: str,
+        condition_expression: Optional[str],
         **kwargs: Any,
     ) -> None:
         """
@@ -167,7 +167,7 @@ class DynamoDBBaseOperations(DynamoClientProtocol):
 
         Args:
             entity: The entity to delete
-            condition_expression: Condition expression for the operation
+            condition_expression: Condition expression for the operation (optional)
             **kwargs: Additional arguments for delete_item
         """
         # Build delete_item parameters

--- a/receipt_dynamo/tests/integration/test__places_cache.py
+++ b/receipt_dynamo/tests/integration/test__places_cache.py
@@ -146,7 +146,7 @@ def test_addPlacesCache_client_errors(
 def test_putPlacesCache_success(
     dynamodb_table: Literal["MyMockedTable"],
     sample_places_cache: PlacesCache,
-):
+) -> None:
     """Test successful unconditional put of a PlacesCache."""
     # Arrange
     dynamo = DynamoClient(dynamodb_table)
@@ -165,7 +165,7 @@ def test_putPlacesCache_success(
 def test_putPlacesCache_overwrites_existing(
     dynamodb_table: Literal["MyMockedTable"],
     sample_places_cache: PlacesCache,
-):
+) -> None:
     """Test that put_places_cache can overwrite an existing entry."""
     # Arrange
     dynamo = DynamoClient(dynamodb_table)


### PR DESCRIPTION
## Summary

Fixes the `put_places_cache` error: `Invalid type for parameter ConditionExpression, value: None`

- `_execute_put_item` was always including `ConditionExpression` in DynamoDB params, even when `None`
- DynamoDB rejects `None` values - the parameter must be omitted for unconditional puts
- `put_places_cache` intentionally passes `None` to allow overwriting expired cache entries

## Why put_places_cache needs unconditional puts

DynamoDB TTL deletion is async - expired entries can linger up to 48 hours. When refreshing an expired cache entry:
1. App-level TTL check returns cache miss
2. Fresh data fetched from Google Places API  
3. `add_places_cache` would fail ("already exists") because old entry still in table
4. `put_places_cache` overwrites unconditionally

## Changes

- `base.py`: Make `condition_expression` parameter `Optional[str]`, only include in params when not `None`
- `test__places_cache.py`: Add tests for `put_places_cache` (was previously untested)

## Test plan

- [x] New test `test_putPlacesCache_success` - unconditional put works
- [x] New test `test_putPlacesCache_overwrites_existing` - can overwrite existing entries
- [ ] All places_cache tests pass (21 tests)
- [ ] Full integration test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Write operations now accept optional condition expressions, allowing unconditional or conditional create/update/delete behavior for more flexible persistence.

* **Tests**
  * New integration tests verify cache behavior: creating new entries and overwriting existing entries with updated data and counts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->