### PR TITLE
fix(merchant_counts): display human-readable merchant names

### DIFF
--- a/infra/routes/merchant_counts/handler/index.py
+++ b/infra/routes/merchant_counts/handler/index.py
@@ -13,6 +13,14 @@ dynamodb_table_name = os.environ["DYNAMODB_TABLE_NAME"]
 dynamo_client = DynamoClient(dynamodb_table_name)
 
 
+def normalize_for_display(name: str) -> str:
+    """Convert normalized name to display format.
+
+    Example: "SPROUTS_FARMERS_MARKET" -> "Sprouts Farmers Market"
+    """
+    return " ".join(word.capitalize() for word in name.split("_"))
+
+
 def fetch_merchant_counts():
     receipt_places, last_evaluated_key = (
         dynamo_client.list_receipt_places(
@@ -58,9 +66,10 @@ def handler(event, _):
             sorted_merchant_counts = sorted(
                 merchant_counts.items(), key=lambda x: x[1], reverse=True
             )
-            # Convert back to JSON
+            # Convert to display-friendly format
             sorted_merchant_counts = [
-                {name: count} for name, count in sorted_merchant_counts
+                {normalize_for_display(name): count}
+                for name, count in sorted_merchant_counts
             ]
             return {
                 "statusCode": 200,


### PR DESCRIPTION
## Summary
- Fix ugly merchant names in "Top 5 Merchants" bar graph (e.g., "SPROUTS_FARMERS_MARKET" → "Sprouts Farmers Market")
- Add `normalize_for_display()` helper to convert normalized keys back to title case

## Context
The ReceiptPlace migration (PR #550, commit `bbf091b4b`) introduced normalization that converted merchant names to uppercase with underscores for grouping purposes. This caused the frontend to display ugly names like "SPROUTS_FARMERS_MARKET" instead of "Sprouts Farmers Market".

## Changes
- Add `normalize_for_display()` function that splits by `_` and capitalizes each word
- Apply formatting when building the API response
- Normalization for grouping/counting is preserved to handle variations in merchant name casing

## Test plan
- [ ] Deploy to dev stack
- [ ] Verify "Top 5 Merchants" displays readable names like "Sprouts Farmers Market"
- [ ] Verify counts are still correctly grouped (variations like "SPROUTS" and "Sprouts" should merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved merchant name formatting in API responses to display in a more readable format (e.g., 'Sprouts Farmers Market' instead of 'SPROUTS_FARMERS_MARKET').

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->