### PR TITLE
perf: pre-compact intermediates before lock acquisition

### DIFF
--- a/infra/embedding_step_functions/unified_embedding/handlers/compaction.py
+++ b/infra/embedding_step_functions/unified_embedding/handlers/compaction.py
@@ -1372,14 +1372,12 @@ def final_merge_handler(event: Dict[str, Any]) -> Dict[str, Any]:
 
     # Check if a pre-compacted intermediate was provided (from final_merge_all)
     precompacted = event.get("_precompacted_intermediate")
-    owns_precompacted_dir = False  # Track if we need to clean up the precompacted dir
 
     if precompacted:
         # Use the pre-compacted intermediate directly - skip S3 download entirely
         synthetic_key = precompacted["key"]
         temp_dir = precompacted["temp_dir"]
         predownloaded_intermediates.append((synthetic_key, temp_dir))
-        owns_precompacted_dir = True  # We're responsible for cleanup
 
         logger.info(
             "Using pre-compacted intermediate (skipping S3 download)",


### PR DESCRIPTION
# Pull Request

## Summary

- Pre-compact all ~8 intermediates into single ChromaDB **before** acquiring lock
- Reduces lock hold time by moving bulk of merge work outside critical section
- Adds `_precompacted_intermediate` parameter to `final_merge_handler` to skip S3 download

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that resolves an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [x] ⚡ Performance improvement
- [ ] 🧪 Test changes or improved coverage

## Which Package(s) are Affected?

- [ ] receipt_dynamo
- [ ] receipt_dynamo_stream
- [ ] receipt_chroma
- [ ] receipt_upload
- [ ] receipt_places
- [ ] receipt_agent
- [ ] Portfolio (TypeScript/Next.js)
- [x] Infrastructure (Pulumi)
- [ ] CI/CD Workflows
- [ ] Other: _______________

## Testing

- [ ] Unit tests pass locally (`pytest` or `npm test`)
- [ ] Integration tests pass locally (if applicable)
- [ ] Added or updated tests for new functionality
- [ ] All existing tests still pass with these changes
- [ ] Manual testing completed (if applicable)

## Documentation & Code Quality

- [x] Documentation or comments updated for complex logic
- [ ] README updated (if introducing new feature/dependency)
- [ ] TypeDoc/JSDoc comments added where needed
- [ ] No new warnings or linting issues introduced
- [x] Code follows project style guidelines

## Related Issues

None

## Impact Analysis

**Before:**
```
1. Pre-download 8 intermediates     ← no lock
2. Acquire lock                     ← LOCK START
3. Download snapshot from S3        
4. Merge 8 intermediates → snapshot ← slow, sequential
5. Upload snapshot to S3            
6. Release lock                     ← LOCK END
```

**After:**
```
1. Pre-download 8 intermediates     ← no lock
2. Compact 8 → 1 intermediate       ← no lock, bulk of work here
3. Acquire lock                     ← LOCK START
4. Download snapshot from S3        
5. Merge 1 intermediate → snapshot  ← fast, single merge
6. Upload snapshot to S3            
7. Release lock                     ← LOCK END
```

This reduces lock contention when multiple step function executions run concurrently.

## Deployment Notes

No special deployment instructions. The change is backward compatible - `final_merge_handler` still works without the `_precompacted_intermediate` parameter.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)