### PR TITLE
perf: Hybrid SQS architecture (4 queues) for enhanced compactor

### DIFF
--- a/infra/chromadb_compaction/components/sqs_queues.py
+++ b/infra/chromadb_compaction/components/sqs_queues.py
@@ -3,6 +3,10 @@ SQS Queues for ChromaDB Compaction Pipeline
 
 This module defines the SQS queue infrastructure for notifying the compactor
 about new delta files.
+
+Architecture:
+- Standard queues for INSERT/MODIFY operations (high throughput, batch up to 1000)
+- FIFO queues for REMOVE operations only (ordered deletes, batch 10)
 """
 
 # pylint: disable=too-many-instance-attributes  # Pulumi components need many attributes
@@ -15,15 +19,47 @@ import pulumi_aws as aws
 from pulumi import ComponentResource, Output, ResourceOptions
 
 
+def _create_queue_policy_document(
+    queue_arn: Output[str], account_id: str
+) -> Output[str]:
+    """Create a queue policy document for Lambda access."""
+    return Output.all(queue_arn, account_id).apply(
+        lambda args: json.dumps(
+            {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Sid": "AllowLambdaAccess",
+                        "Effect": "Allow",
+                        "Principal": {"Service": "lambda.amazonaws.com"},
+                        "Action": [
+                            "sqs:ReceiveMessage",
+                            "sqs:DeleteMessage",
+                            "sqs:GetQueueAttributes",
+                        ],
+                        "Resource": args[0],
+                    },
+                    {
+                        "Sid": "AllowAccountAccess",
+                        "Effect": "Allow",
+                        "Principal": {"AWS": f"arn:aws:iam::{args[1]}:root"},
+                        "Action": "sqs:*",
+                        "Resource": args[0],
+                    },
+                ],
+            }
+        )
+    )
+
+
 class ChromaDBQueues(ComponentResource):
     """
     ComponentResource that creates SQS queues for ChromaDB delta notifications.
 
-    Creates separate queues for lines and words collections:
-    - Lines queue for line embedding updates
-    - Words queue for word embedding updates
+    Creates a hybrid queue architecture:
+    - Standard queues for INSERT/MODIFY (high throughput)
+    - FIFO queues for REMOVE only (ordered deletes)
     - Dead letter queues for failed messages
-    - Proper visibility timeout for Lambda processing
     """
 
     def __init__(
@@ -42,193 +78,245 @@ class ChromaDBQueues(ComponentResource):
         """
         super().__init__("chromadb:queues:SQSQueues", name, None, opts)
 
-        # Get stack
         if stack is None:
             stack = pulumi.get_stack()
 
-        # Create dead letter queues for each collection (FIFO)
-        self.lines_dlq = aws.sqs.Queue(
-            f"{name}-lines-dlq",
-            fifo_queue=True,
-            content_based_deduplication=True,
+        account_id = aws.get_caller_identity().account_id
+
+        # =========================================================================
+        # Standard Queues (INSERT/MODIFY) - High Throughput
+        # =========================================================================
+
+        # Standard DLQs
+        self.lines_standard_dlq = aws.sqs.Queue(
+            f"{name}-lines-standard-dlq",
             message_retention_seconds=1209600,  # 14 days
-            visibility_timeout_seconds=300,  # 5 minutes
-            receive_wait_time_seconds=0,  # Short polling
+            visibility_timeout_seconds=300,
+            receive_wait_time_seconds=0,
             tags={
                 "Project": "ChromaDB",
-                "Component": "Lines-DLQ",
+                "Component": "Lines-Standard-DLQ",
                 "Environment": stack,
                 "ManagedBy": "Pulumi",
             },
             opts=ResourceOptions(parent=self),
         )
 
-        self.words_dlq = aws.sqs.Queue(
-            f"{name}-words-dlq",
-            fifo_queue=True,
-            content_based_deduplication=True,
+        self.words_standard_dlq = aws.sqs.Queue(
+            f"{name}-words-standard-dlq",
             message_retention_seconds=1209600,  # 14 days
-            visibility_timeout_seconds=300,  # 5 minutes
-            receive_wait_time_seconds=0,  # Short polling
+            visibility_timeout_seconds=300,
+            receive_wait_time_seconds=0,
             tags={
                 "Project": "ChromaDB",
-                "Component": "Words-DLQ",
+                "Component": "Words-Standard-DLQ",
                 "Environment": stack,
                 "ManagedBy": "Pulumi",
             },
             opts=ResourceOptions(parent=self),
         )
 
-        # Create lines queue with redrive policy (FIFO)
-        self.lines_queue = aws.sqs.Queue(
-            f"{name}-lines-queue",
-            fifo_queue=True,
-            content_based_deduplication=True,
-            message_retention_seconds=345600,
-            # Visibility timeout must be >= Lambda timeout per AWS requirements.
-            # Lambda typically completes in ~25s, timeout set to 120s for headroom.
+        # Standard queues for INSERT/MODIFY operations
+        self.lines_standard_queue = aws.sqs.Queue(
+            f"{name}-lines-standard-queue",
+            message_retention_seconds=345600,  # 4 days
             visibility_timeout_seconds=120,
-            receive_wait_time_seconds=20,
-            redrive_policy=Output.all(self.lines_dlq.arn).apply(
+            receive_wait_time_seconds=20,  # Long polling
+            redrive_policy=Output.all(self.lines_standard_dlq.arn).apply(
                 lambda args: json.dumps(
-                    {
-                        "deadLetterTargetArn": args[0],
-                        "maxReceiveCount": 3,  # Retry 3 times before DLQ
-                    }
+                    {"deadLetterTargetArn": args[0], "maxReceiveCount": 3}
                 )
             ),
             tags={
                 "Project": "ChromaDB",
-                "Component": "Lines-Queue",
+                "Component": "Lines-Standard-Queue",
                 "Environment": stack,
                 "ManagedBy": "Pulumi",
             },
             opts=ResourceOptions(parent=self),
         )
 
-        # Create words queue with redrive policy (FIFO)
-        self.words_queue = aws.sqs.Queue(
-            f"{name}-words-queue",
-            fifo_queue=True,
-            content_based_deduplication=True,
-            message_retention_seconds=345600,
-            # Visibility timeout must be >= Lambda timeout per AWS requirements.
-            # Lambda typically completes in ~25s, timeout set to 120s for headroom.
+        self.words_standard_queue = aws.sqs.Queue(
+            f"{name}-words-standard-queue",
+            message_retention_seconds=345600,  # 4 days
             visibility_timeout_seconds=120,
-            receive_wait_time_seconds=20,
-            redrive_policy=Output.all(self.words_dlq.arn).apply(
+            receive_wait_time_seconds=20,  # Long polling
+            redrive_policy=Output.all(self.words_standard_dlq.arn).apply(
                 lambda args: json.dumps(
-                    {
-                        "deadLetterTargetArn": args[0],
-                        "maxReceiveCount": 3,  # Retry 3 times before DLQ
-                    }
+                    {"deadLetterTargetArn": args[0], "maxReceiveCount": 3}
                 )
             ),
             tags={
                 "Project": "ChromaDB",
-                "Component": "Words-Queue",
+                "Component": "Words-Standard-Queue",
                 "Environment": stack,
                 "ManagedBy": "Pulumi",
             },
             opts=ResourceOptions(parent=self),
         )
 
-        # Create queue policies for Lambda access
-        self.lines_queue_policy_document = Output.all(
-            self.lines_queue.arn, aws.get_caller_identity().account_id
-        ).apply(
-            lambda args: json.dumps(
-                {
-                    "Version": "2012-10-17",
-                    "Statement": [
-                        {
-                            "Sid": "AllowLambdaAccess",
-                            "Effect": "Allow",
-                            "Principal": {"Service": "lambda.amazonaws.com"},
-                            "Action": [
-                                "sqs:ReceiveMessage",
-                                "sqs:DeleteMessage",
-                                "sqs:GetQueueAttributes",
-                            ],
-                            "Resource": args[0],
-                        },
-                        {
-                            "Sid": "AllowAccountAccess",
-                            "Effect": "Allow",
-                            "Principal": {
-                                "AWS": f"arn:aws:iam::{args[1]}:root"
-                            },
-                            "Action": "sqs:*",
-                            "Resource": args[0],
-                        },
-                    ],
-                }
-            )
-        )
+        # =========================================================================
+        # FIFO Queues (REMOVE only) - Ordered Deletes
+        # =========================================================================
 
-        self.words_queue_policy_document = Output.all(
-            self.words_queue.arn, aws.get_caller_identity().account_id
-        ).apply(
-            lambda args: json.dumps(
-                {
-                    "Version": "2012-10-17",
-                    "Statement": [
-                        {
-                            "Sid": "AllowLambdaAccess",
-                            "Effect": "Allow",
-                            "Principal": {"Service": "lambda.amazonaws.com"},
-                            "Action": [
-                                "sqs:ReceiveMessage",
-                                "sqs:DeleteMessage",
-                                "sqs:GetQueueAttributes",
-                            ],
-                            "Resource": args[0],
-                        },
-                        {
-                            "Sid": "AllowAccountAccess",
-                            "Effect": "Allow",
-                            "Principal": {
-                                "AWS": f"arn:aws:iam::{args[1]}:root"
-                            },
-                            "Action": "sqs:*",
-                            "Resource": args[0],
-                        },
-                    ],
-                }
-            )
-        )
-
-        self.lines_queue_policy = aws.sqs.QueuePolicy(
-            f"{name}-lines-queue-policy",
-            queue_url=self.lines_queue.url,
-            policy=self.lines_queue_policy_document,
+        # FIFO DLQs for delete operations
+        self.lines_delete_dlq = aws.sqs.Queue(
+            f"{name}-lines-delete-dlq",
+            fifo_queue=True,
+            content_based_deduplication=True,
+            message_retention_seconds=1209600,  # 14 days
+            visibility_timeout_seconds=300,
+            receive_wait_time_seconds=0,
+            tags={
+                "Project": "ChromaDB",
+                "Component": "Lines-Delete-DLQ",
+                "Environment": stack,
+                "ManagedBy": "Pulumi",
+            },
             opts=ResourceOptions(parent=self),
         )
 
-        self.words_queue_policy = aws.sqs.QueuePolicy(
-            f"{name}-words-queue-policy",
-            queue_url=self.words_queue.url,
-            policy=self.words_queue_policy_document,
+        self.words_delete_dlq = aws.sqs.Queue(
+            f"{name}-words-delete-dlq",
+            fifo_queue=True,
+            content_based_deduplication=True,
+            message_retention_seconds=1209600,  # 14 days
+            visibility_timeout_seconds=300,
+            receive_wait_time_seconds=0,
+            tags={
+                "Project": "ChromaDB",
+                "Component": "Words-Delete-DLQ",
+                "Environment": stack,
+                "ManagedBy": "Pulumi",
+            },
             opts=ResourceOptions(parent=self),
         )
 
-        # Export useful properties
-        self.lines_queue_url = self.lines_queue.url
-        self.lines_queue_arn = self.lines_queue.arn
-        self.words_queue_url = self.words_queue.url
-        self.words_queue_arn = self.words_queue.arn
-        self.lines_dlq_arn = self.lines_dlq.arn
-        self.words_dlq_arn = self.words_dlq.arn
+        # FIFO queues for REMOVE operations only
+        self.lines_delete_queue = aws.sqs.Queue(
+            f"{name}-lines-delete-queue",
+            fifo_queue=True,
+            content_based_deduplication=True,
+            message_retention_seconds=345600,  # 4 days
+            visibility_timeout_seconds=120,
+            receive_wait_time_seconds=20,
+            redrive_policy=Output.all(self.lines_delete_dlq.arn).apply(
+                lambda args: json.dumps(
+                    {"deadLetterTargetArn": args[0], "maxReceiveCount": 3}
+                )
+            ),
+            tags={
+                "Project": "ChromaDB",
+                "Component": "Lines-Delete-Queue",
+                "Environment": stack,
+                "ManagedBy": "Pulumi",
+            },
+            opts=ResourceOptions(parent=self),
+        )
+
+        self.words_delete_queue = aws.sqs.Queue(
+            f"{name}-words-delete-queue",
+            fifo_queue=True,
+            content_based_deduplication=True,
+            message_retention_seconds=345600,  # 4 days
+            visibility_timeout_seconds=120,
+            receive_wait_time_seconds=20,
+            redrive_policy=Output.all(self.words_delete_dlq.arn).apply(
+                lambda args: json.dumps(
+                    {"deadLetterTargetArn": args[0], "maxReceiveCount": 3}
+                )
+            ),
+            tags={
+                "Project": "ChromaDB",
+                "Component": "Words-Delete-Queue",
+                "Environment": stack,
+                "ManagedBy": "Pulumi",
+            },
+            opts=ResourceOptions(parent=self),
+        )
+
+        # =========================================================================
+        # Queue Policies
+        # =========================================================================
+
+        # Standard queue policies
+        self.lines_standard_queue_policy = aws.sqs.QueuePolicy(
+            f"{name}-lines-standard-queue-policy",
+            queue_url=self.lines_standard_queue.url,
+            policy=_create_queue_policy_document(
+                self.lines_standard_queue.arn, account_id
+            ),
+            opts=ResourceOptions(parent=self),
+        )
+
+        self.words_standard_queue_policy = aws.sqs.QueuePolicy(
+            f"{name}-words-standard-queue-policy",
+            queue_url=self.words_standard_queue.url,
+            policy=_create_queue_policy_document(
+                self.words_standard_queue.arn, account_id
+            ),
+            opts=ResourceOptions(parent=self),
+        )
+
+        # FIFO delete queue policies
+        self.lines_delete_queue_policy = aws.sqs.QueuePolicy(
+            f"{name}-lines-delete-queue-policy",
+            queue_url=self.lines_delete_queue.url,
+            policy=_create_queue_policy_document(
+                self.lines_delete_queue.arn, account_id
+            ),
+            opts=ResourceOptions(parent=self),
+        )
+
+        self.words_delete_queue_policy = aws.sqs.QueuePolicy(
+            f"{name}-words-delete-queue-policy",
+            queue_url=self.words_delete_queue.url,
+            policy=_create_queue_policy_document(
+                self.words_delete_queue.arn, account_id
+            ),
+            opts=ResourceOptions(parent=self),
+        )
+
+        # =========================================================================
+        # Export Properties
+        # =========================================================================
+
+        # Standard queue exports (INSERT/MODIFY)
+        self.lines_standard_queue_url = self.lines_standard_queue.url
+        self.lines_standard_queue_arn = self.lines_standard_queue.arn
+        self.words_standard_queue_url = self.words_standard_queue.url
+        self.words_standard_queue_arn = self.words_standard_queue.arn
+
+        # FIFO delete queue exports (REMOVE)
+        self.lines_delete_queue_url = self.lines_delete_queue.url
+        self.lines_delete_queue_arn = self.lines_delete_queue.arn
+        self.words_delete_queue_url = self.words_delete_queue.url
+        self.words_delete_queue_arn = self.words_delete_queue.arn
+
+        # DLQ exports
+        self.lines_standard_dlq_arn = self.lines_standard_dlq.arn
+        self.words_standard_dlq_arn = self.words_standard_dlq.arn
+        self.lines_delete_dlq_arn = self.lines_delete_dlq.arn
+        self.words_delete_dlq_arn = self.words_delete_dlq.arn
 
         # Register outputs
         self.register_outputs(
             {
-                "lines_queue_url": self.lines_queue_url,
-                "lines_queue_arn": self.lines_queue_arn,
-                "words_queue_url": self.words_queue_url,
-                "words_queue_arn": self.words_queue_arn,
-                "lines_dlq_arn": self.lines_dlq_arn,
-                "words_dlq_arn": self.words_dlq_arn,
+                # Standard queues
+                "lines_standard_queue_url": self.lines_standard_queue_url,
+                "lines_standard_queue_arn": self.lines_standard_queue_arn,
+                "words_standard_queue_url": self.words_standard_queue_url,
+                "words_standard_queue_arn": self.words_standard_queue_arn,
+                # FIFO delete queues
+                "lines_delete_queue_url": self.lines_delete_queue_url,
+                "lines_delete_queue_arn": self.lines_delete_queue_arn,
+                "words_delete_queue_url": self.words_delete_queue_url,
+                "words_delete_queue_arn": self.words_delete_queue_arn,
+                # DLQs
+                "lines_standard_dlq_arn": self.lines_standard_dlq_arn,
+                "words_standard_dlq_arn": self.words_standard_dlq_arn,
+                "lines_delete_dlq_arn": self.lines_delete_dlq_arn,
+                "words_delete_dlq_arn": self.words_delete_dlq_arn,
             }
         )
 

--- a/receipt_chroma/receipt_chroma/data/operations.py
+++ b/receipt_chroma/receipt_chroma/data/operations.py
@@ -149,8 +149,10 @@ def update_receipt_place(
             metrics.gauge("CompactionChromaDBRecordsFound", found_count)
 
         if found_count == 0:
-            logger.error(
-                "No matching embeddings found in ChromaDB for place update",
+            # Not an error - embedding may have been deleted before update was processed
+            # (expected with hybrid queue architecture where deletes race ahead)
+            logger.info(
+                "No embeddings found for place update - may have been deleted",
                 receipt_id=receipt_id,
                 image_id=image_id,
                 expected=len(chromadb_ids),
@@ -486,9 +488,11 @@ def update_word_labels(
         # Get the specific record from ChromaDB
         result = collection.get(ids=[chromadb_id], include=["metadatas"])
         if not result["ids"]:
+            # Not an error - embedding may have been deleted before update was processed
+            # (expected with hybrid queue architecture where deletes race ahead)
             if logger:
-                logger.error(
-                    "Word embedding not found in snapshot",
+                logger.info(
+                    "Word embedding not found - may have been deleted",
                     chromadb_id=chromadb_id,
                     image_id=image_id,
                     receipt_id=receipt_id,

--- a/receipt_dynamo_stream/receipt_dynamo_stream/__init__.py
+++ b/receipt_dynamo_stream/receipt_dynamo_stream/__init__.py
@@ -36,7 +36,8 @@ from receipt_dynamo_stream.parsing.parsers import (
 )
 from receipt_dynamo_stream.sqs_publisher import (
     publish_messages,
-    send_batch_to_queue,
+    send_batch_to_fifo_queue,
+    send_batch_to_standard_queue,
 )
 from receipt_dynamo_stream.stream_types import (
     APIGatewayResponse,
@@ -70,7 +71,8 @@ __all__ = [
     "parse_entity",
     "parse_stream_record",
     "publish_messages",
-    "send_batch_to_queue",
+    "send_batch_to_fifo_queue",
+    "send_batch_to_standard_queue",
     # Type definitions
     "APIGatewayResponse",
     "AttributeValue",

--- a/receipt_dynamo_stream/tests/integration/test_sqs_publisher_with_moto.py
+++ b/receipt_dynamo_stream/tests/integration/test_sqs_publisher_with_moto.py
@@ -25,28 +25,48 @@ def moto_sqs() -> Any:
 
 
 @pytest.fixture
-def fifo_queues(moto_sqs: Any) -> dict[str, str]:
-    lines_queue = moto_sqs.create_queue(
-        QueueName="lines.fifo",
+def hybrid_queues(moto_sqs: Any) -> dict[str, str]:
+    """Create hybrid queue architecture: Standard for writes, FIFO for deletes."""
+    # Standard queues for INSERT/MODIFY (high throughput)
+    lines_standard = moto_sqs.create_queue(
+        QueueName="lines-standard",
+    )["QueueUrl"]
+    words_standard = moto_sqs.create_queue(
+        QueueName="words-standard",
+    )["QueueUrl"]
+
+    # FIFO queues for REMOVE only (ordered deletes)
+    lines_delete = moto_sqs.create_queue(
+        QueueName="lines-delete.fifo",
         Attributes={
             "FifoQueue": "true",
             "ContentBasedDeduplication": "true",
         },
     )["QueueUrl"]
-    words_queue = moto_sqs.create_queue(
-        QueueName="words.fifo",
+    words_delete = moto_sqs.create_queue(
+        QueueName="words-delete.fifo",
         Attributes={
             "FifoQueue": "true",
             "ContentBasedDeduplication": "true",
         },
     )["QueueUrl"]
 
-    os.environ["LINES_QUEUE_URL"] = lines_queue
-    os.environ["WORDS_QUEUE_URL"] = words_queue
-    return {"lines": lines_queue, "words": words_queue}
+    # Set environment variables for new queue architecture
+    os.environ["LINES_STANDARD_QUEUE_URL"] = lines_standard
+    os.environ["WORDS_STANDARD_QUEUE_URL"] = words_standard
+    os.environ["LINES_DELETE_QUEUE_URL"] = lines_delete
+    os.environ["WORDS_DELETE_QUEUE_URL"] = words_delete
+
+    return {
+        "lines_standard": lines_standard,
+        "words_standard": words_standard,
+        "lines_delete": lines_delete,
+        "words_delete": words_delete,
+    }
 
 
 def _sample_place_message() -> StreamMessage:
+    """MODIFY event - should go to Standard queues."""
     return StreamMessage(
         entity_type="RECEIPT_PLACE",
         entity_data={"image_id": "img-1", "receipt_id": 1},
@@ -63,7 +83,24 @@ def _sample_place_message() -> StreamMessage:
     )
 
 
+def _sample_place_remove() -> StreamMessage:
+    """REMOVE event - should go to FIFO delete queues."""
+    return StreamMessage(
+        entity_type="RECEIPT_PLACE",
+        entity_data={"image_id": "img-1", "receipt_id": 1},
+        changes={},
+        event_name="REMOVE",
+        collections=(ChromaDBCollection.LINES, ChromaDBCollection.WORDS),
+        context=StreamRecordContext(
+            timestamp=datetime.now().isoformat(),
+            record_id="event-1",
+            aws_region="us-east-1",
+        ),
+    )
+
+
 def _sample_word_label_remove() -> StreamMessage:
+    """REMOVE event - should go to FIFO delete queue."""
     return StreamMessage(
         entity_type="RECEIPT_WORD_LABEL",
         entity_data={
@@ -85,6 +122,7 @@ def _sample_word_label_remove() -> StreamMessage:
 
 
 def _sample_compaction_run() -> StreamMessage:
+    """INSERT event - should go to Standard queues."""
     return StreamMessage(
         entity_type="COMPACTION_RUN",
         entity_data={
@@ -113,65 +151,114 @@ def _get_messages(sqs: Any, queue_url: str) -> list[dict[str, Any]]:
     return cast(list[dict[str, Any]], resp.get("Messages", []))
 
 
-def test_place_routed_to_both_queues(
-    moto_sqs: Any, fifo_queues: dict[str, str]
+def test_modify_routed_to_standard_queues(
+    moto_sqs: Any, hybrid_queues: dict[str, str]
 ) -> None:
+    """MODIFY events go to Standard queues, not FIFO."""
     msg = _sample_place_message()
     sent = publish_messages([msg])
     assert sent == 2
 
-    lines_msgs = _get_messages(moto_sqs, fifo_queues["lines"])
-    words_msgs = _get_messages(moto_sqs, fifo_queues["words"])
-
+    # Should be in Standard queues
+    lines_msgs = _get_messages(moto_sqs, hybrid_queues["lines_standard"])
+    words_msgs = _get_messages(moto_sqs, hybrid_queues["words_standard"])
     assert len(lines_msgs) == 1
     assert len(words_msgs) == 1
 
+    # Should NOT be in FIFO queues
+    lines_delete_msgs = _get_messages(moto_sqs, hybrid_queues["lines_delete"])
+    words_delete_msgs = _get_messages(moto_sqs, hybrid_queues["words_delete"])
+    assert len(lines_delete_msgs) == 0
+    assert len(words_delete_msgs) == 0
+
     body = json.loads(lines_msgs[0]["Body"])
     assert body["entity_type"] == "RECEIPT_PLACE"
+    assert body["event_name"] == "MODIFY"
     assert body["entity_data"]["receipt_id"] == 1
-    assert "merchant_name" in body["changes"]
 
     attrs = lines_msgs[0].get("MessageAttributes", {})
     assert attrs["collection"]["StringValue"] == "lines"
 
 
-def test_word_label_remove_only_words_queue(
-    moto_sqs: Any, fifo_queues: dict[str, str]
+def test_remove_routed_to_fifo_queues(
+    moto_sqs: Any, hybrid_queues: dict[str, str]
 ) -> None:
+    """REMOVE events go to FIFO queues, not Standard."""
+    msg = _sample_place_remove()
+    sent = publish_messages([msg])
+    assert sent == 2
+
+    # Should be in FIFO queues
+    lines_delete_msgs = _get_messages(moto_sqs, hybrid_queues["lines_delete"])
+    words_delete_msgs = _get_messages(moto_sqs, hybrid_queues["words_delete"])
+    assert len(lines_delete_msgs) == 1
+    assert len(words_delete_msgs) == 1
+
+    # Should NOT be in Standard queues
+    lines_msgs = _get_messages(moto_sqs, hybrid_queues["lines_standard"])
+    words_msgs = _get_messages(moto_sqs, hybrid_queues["words_standard"])
+    assert len(lines_msgs) == 0
+    assert len(words_msgs) == 0
+
+    body = json.loads(lines_delete_msgs[0]["Body"])
+    assert body["entity_type"] == "RECEIPT_PLACE"
+    assert body["event_name"] == "REMOVE"
+
+
+def test_word_label_remove_only_words_fifo_queue(
+    moto_sqs: Any, hybrid_queues: dict[str, str]
+) -> None:
+    """RECEIPT_WORD_LABEL REMOVE goes to words FIFO queue only."""
     msg = _sample_word_label_remove()
     sent = publish_messages([msg])
     assert sent == 1
 
-    lines_msgs = _get_messages(moto_sqs, fifo_queues["lines"])
-    words_msgs = _get_messages(moto_sqs, fifo_queues["words"])
+    # Should be in words FIFO queue only
+    words_delete_msgs = _get_messages(moto_sqs, hybrid_queues["words_delete"])
+    assert len(words_delete_msgs) == 1
 
+    # Should NOT be in any other queue
+    lines_msgs = _get_messages(moto_sqs, hybrid_queues["lines_standard"])
+    words_msgs = _get_messages(moto_sqs, hybrid_queues["words_standard"])
+    lines_delete_msgs = _get_messages(moto_sqs, hybrid_queues["lines_delete"])
     assert len(lines_msgs) == 0
-    assert len(words_msgs) == 1
-    body = json.loads(words_msgs[0]["Body"])
+    assert len(words_msgs) == 0
+    assert len(lines_delete_msgs) == 0
+
+    body = json.loads(words_delete_msgs[0]["Body"])
     assert body["event_name"] == "REMOVE"
     assert body["entity_type"] == "RECEIPT_WORD_LABEL"
 
 
-def test_compaction_run_sends_one_per_collection(
-    moto_sqs: Any, fifo_queues: dict[str, str]
+def test_insert_routed_to_standard_queues(
+    moto_sqs: Any, hybrid_queues: dict[str, str]
 ) -> None:
+    """INSERT events (like COMPACTION_RUN) go to Standard queues."""
     msg = _sample_compaction_run()
     sent = publish_messages([msg])
     assert sent == 2
 
-    lines_msgs = _get_messages(moto_sqs, fifo_queues["lines"])
-    words_msgs = _get_messages(moto_sqs, fifo_queues["words"])
-
+    # Should be in Standard queues
+    lines_msgs = _get_messages(moto_sqs, hybrid_queues["lines_standard"])
+    words_msgs = _get_messages(moto_sqs, hybrid_queues["words_standard"])
     assert len(lines_msgs) == 1
     assert len(words_msgs) == 1
+
+    # Should NOT be in FIFO queues
+    lines_delete_msgs = _get_messages(moto_sqs, hybrid_queues["lines_delete"])
+    words_delete_msgs = _get_messages(moto_sqs, hybrid_queues["words_delete"])
+    assert len(lines_delete_msgs) == 0
+    assert len(words_delete_msgs) == 0
+
     body = json.loads(lines_msgs[0]["Body"])
     assert body["entity_type"] == "COMPACTION_RUN"
     assert body["entity_data"]["run_id"] == "run-123"
 
 
 def test_batches_above_ten_messages(
-    moto_sqs: Any, fifo_queues: dict[str, str]
+    moto_sqs: Any, hybrid_queues: dict[str, str]
 ) -> None:
+    """Large batches are split correctly across Standard queues."""
     msgs = [
         StreamMessage(
             entity_type="RECEIPT_PLACE",
@@ -192,15 +279,46 @@ def test_batches_above_ten_messages(
     # 15 records, two queues each => 30
     assert sent == 30
 
-    lines_msgs = _get_messages(moto_sqs, fifo_queues["lines"])
-    words_msgs = _get_messages(moto_sqs, fifo_queues["words"])
+    lines_msgs = _get_messages(moto_sqs, hybrid_queues["lines_standard"])
+    words_msgs = _get_messages(moto_sqs, hybrid_queues["words_standard"])
     assert len(lines_msgs) == 10  # moto default receive max
     assert len(words_msgs) == 10
 
 
+def test_mixed_events_route_correctly(
+    moto_sqs: Any, hybrid_queues: dict[str, str]
+) -> None:
+    """Mixed INSERT/MODIFY/REMOVE events route to correct queues."""
+    msgs = [
+        _sample_compaction_run(),  # INSERT -> Standard
+        _sample_place_message(),  # MODIFY -> Standard
+        _sample_place_remove(),  # REMOVE -> FIFO
+        _sample_word_label_remove(),  # REMOVE -> FIFO (words only)
+    ]
+
+    sent = publish_messages(msgs)
+    # INSERT: 2, MODIFY: 2, place REMOVE: 2, word_label REMOVE: 1 = 7
+    assert sent == 7
+
+    # Standard queues should have INSERT and MODIFY
+    lines_standard = _get_messages(moto_sqs, hybrid_queues["lines_standard"])
+    words_standard = _get_messages(moto_sqs, hybrid_queues["words_standard"])
+    assert len(lines_standard) == 2  # 1 INSERT + 1 MODIFY
+    assert len(words_standard) == 2  # 1 INSERT + 1 MODIFY
+
+    # FIFO queues should have REMOVE only
+    lines_delete = _get_messages(moto_sqs, hybrid_queues["lines_delete"])
+    words_delete = _get_messages(moto_sqs, hybrid_queues["words_delete"])
+    assert len(lines_delete) == 1  # 1 place REMOVE
+    assert len(words_delete) == 2  # 1 place REMOVE + 1 word_label REMOVE
+
+
 def test_missing_queue_env_returns_zero(moto_sqs: Any) -> None:
-    os.environ.pop("LINES_QUEUE_URL", None)
-    os.environ.pop("WORDS_QUEUE_URL", None)
+    """Missing queue URLs cause zero messages to be sent."""
+    os.environ.pop("LINES_STANDARD_QUEUE_URL", None)
+    os.environ.pop("WORDS_STANDARD_QUEUE_URL", None)
+    os.environ.pop("LINES_DELETE_QUEUE_URL", None)
+    os.environ.pop("WORDS_DELETE_QUEUE_URL", None)
     msg = _sample_place_message()
     sent = publish_messages([msg])
     assert sent == 0


### PR DESCRIPTION
# Pull Request

## Summary

- Implement hybrid 4-queue architecture: 2 Standard (INSERT/MODIFY) + 2 FIFO (REMOVE)
- Route messages by event type at publisher level
- FIFO guarantees ordering for deletes

## Type of Change

- [x] ⚡ Performance improvement

## Which Package(s) are Affected?

- [x] receipt_dynamo_stream
- [x] receipt_chroma  
- [x] Infrastructure (Pulumi)

---

⚠️ **This PR is being closed in favor of #602 (sorted approach)**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure Changes**
  * Implemented hybrid SQS queue architecture: standard queues for insert/modify operations (high throughput) and FIFO queues for ordered delete operations.
  * Separated queue management with dedicated standard and delete queue URLs for lines and words collections.
  * Increased maximum messages per compaction batch from 500 to 1000 for standard queues.

* **Testing**
  * Updated test coverage to validate hybrid queue routing behavior for different operation types.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->