### PR TITLE
fix: restore TrainingMetricsAnimation mobile styling

### DIFF
--- a/portfolio/components/ui/Figures/TrainingMetricsAnimation/TrainingMetricsAnimation.module.css
+++ b/portfolio/components/ui/Figures/TrainingMetricsAnimation/TrainingMetricsAnimation.module.css
@@ -355,7 +355,7 @@
 @media (max-width: 600px) {
   .container {
     grid-template-columns: 1fr;
-    max-width: 100%;
+    max-width: 400px;
     padding: 1rem;
     gap: 1rem;
   }
@@ -375,13 +375,17 @@
   }
 
   .timelineArrow {
-    background: transparent;
-    border: 1px solid rgba(var(--text-color-rgb), 0.3);
+    background: var(--text-color);
+    border: none;
     border-radius: 50%;
     width: 32px;
     height: 32px;
+    min-width: 32px;
+    min-height: 32px;
+    aspect-ratio: 1;
+    flex-shrink: 0;
     font-size: 1.25rem;
-    color: var(--text-color);
+    color: var(--background-color);
     cursor: pointer;
     display: flex;
     align-items: center;
@@ -390,8 +394,7 @@
   }
 
   .timelineArrow:hover:not(:disabled) {
-    background: rgba(var(--text-color-rgb), 0.1);
-    border-color: var(--text-color);
+    opacity: 0.8;
   }
 
   .timelineArrow:focus-visible {
@@ -400,7 +403,7 @@
   }
 
   .timelineArrow:disabled {
-    opacity: 0.3;
+    opacity: 0.25;
     cursor: not-allowed;
   }
 
@@ -454,10 +457,6 @@
     flex: 0 0 auto;
   }
 
-  .gaugeValue {
-    font-size: 1.5rem;
-  }
-
   .gaugeBar {
     max-width: 80px;
   }
@@ -475,7 +474,7 @@
 
   .labelName {
     width: 55px;
-    font-size: 0.5rem;
+    font-size: 0.6rem;
   }
 
   .labelBarSegmented {
@@ -484,7 +483,7 @@
   }
 
   .labelBarValue {
-    font-size: 0.55rem;
+    font-size: 0.65rem;
     min-width: 28px;
   }
 
@@ -501,10 +500,10 @@
   }
 
   .matrixCell {
-    font-size: 0.45rem;
+    font-size: 0.5rem;
   }
 
   .matrixAxisLabel {
-    font-size: 0.45rem;
+    font-size: 0.5rem;
   }
 }


### PR DESCRIPTION
## Summary
- Restore font sizes to match desktop values on mobile (were reduced too much in #610)
- Fix component centering by restoring `max-width: 400px` constraint
- Style epoch navigation arrows as filled circles with inverted colors
- Add `aspect-ratio: 1` and `flex-shrink: 0` to ensure arrow buttons remain perfectly circular

## Changes
| Property | Before | After |
|----------|--------|-------|
| `.labelName` font-size | 0.5rem | 0.6rem |
| `.labelBarValue` font-size | 0.55rem | 0.65rem |
| `.matrixCell` font-size | 0.45rem | 0.5rem |
| `.matrixAxisLabel` font-size | 0.45rem | 0.5rem |
| `.gaugeValue` font-size | 1.5rem | 2rem (removed override) |
| `.container` max-width | 100% | 400px |
| `.timelineArrow` background | transparent | var(--text-color) |
| `.timelineArrow` color | var(--text-color) | var(--background-color) |

## Test plan
- [ ] View TrainingMetricsAnimation on mobile viewport (<600px)
- [ ] Verify component is centered
- [ ] Verify font sizes are readable
- [ ] Verify epoch navigation arrows are circular (not oval)
- [ ] Verify arrows have filled background with inverted arrow color

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Optimized training metrics visualization for mobile devices with improved typography sizing for better readability.
  * Refined timeline arrow interactions with simplified visual states.
  * Enhanced mobile layout with better-centered content and optimized spacing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->