### PR TITLE
feat: add prediction entropy metrics for overfitting detection

### DIFF
--- a/receipt_layoutlm/pyproject.toml
+++ b/receipt_layoutlm/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
   "transformers>=4.40.0",
   "datasets>=2.19.0",
   "numpy>=1.26.0",
+  "scipy>=1.11.0",
   "boto3>=1.34.0",
   "pydantic>=2.10.6",
   "tqdm>=4.66.0",


### PR DESCRIPTION
# Pull Request

## Summary

- Add prediction entropy metrics to track model confidence during training
- Entropy helps detect overfitting: if entropy drops while F1 plateaus, the model may be becoming overconfident on incorrect predictions
- Track mean, std, p10, and p90 percentiles for distribution insight

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that resolves an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test changes or improved coverage

## Which Package(s) are Affected?

- [ ] receipt_dynamo
- [ ] receipt_dynamo_stream
- [ ] receipt_chroma
- [ ] receipt_upload
- [ ] receipt_places
- [ ] receipt_agent
- [ ] Portfolio (TypeScript/Next.js)
- [ ] Infrastructure (Pulumi)
- [ ] CI/CD Workflows
- [x] Other: receipt_layoutlm

## New Metrics

| Metric | Description | Unit |
|--------|-------------|------|
| `entropy_mean` | Average prediction entropy across all tokens | nats |
| `entropy_std` | Standard deviation of entropy | nats |
| `entropy_p10` | 10th percentile (most confident predictions) | nats |
| `entropy_p90` | 90th percentile (least confident predictions) | nats |

## How to Interpret

```
Epoch 1:  F1=0.50, entropy=1.8  (uncertain, learning)
Epoch 5:  F1=0.75, entropy=1.2  (more confident, improving)
Epoch 10: F1=0.80, entropy=0.8  (confident, good)
Epoch 15: F1=0.80, entropy=0.4  ← Warning: entropy dropped but F1 flat
                                  (overconfident on mistakes = overfitting)
```

## Testing

- [x] Unit tests pass locally (`pytest` or `npm test`)
- [ ] Integration tests pass locally (if applicable)
- [ ] Added or updated tests for new functionality
- [x] All existing tests still pass with these changes
- [x] Manual testing completed (if applicable)

## Documentation & Code Quality

- [x] Documentation or comments updated for complex logic
- [ ] README updated (if introducing new feature/dependency)
- [x] TypeDoc/JSDoc comments added where needed
- [x] No new warnings or linting issues introduced
- [x] Code follows project style guidelines

## Impact Analysis

- Adds `scipy>=1.11.0` as explicit dependency (already transitively installed via scikit-learn)
- Entropy calculation adds ~5-10ms per evaluation step (negligible)
- Metrics stored in DynamoDB alongside existing F1/precision/recall metrics

## Deployment Notes

- Requires rebuilding the SageMaker training container to include the new code
- Next training job after deployment will automatically log entropy metrics
- No infrastructure changes required

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added four new entropy metrics (entropy_mean, entropy_std, entropy_p10, entropy_p90) for per-epoch training analysis with built-in error handling.

* **Documentation**
  * Added comprehensive guidance on entropy metrics including definitions, interpretation guidance, practical examples, and query patterns for extracting results.

* **Chores**
  * Updated Python package dependencies.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->