### PR TITLE
fix: Add Docker setup to CI/CD deploy job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -521,6 +521,9 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build Next.js app
         working-directory: portfolio
         run: |


### PR DESCRIPTION
## Summary
- Adds `docker/setup-buildx-action@v3` to the deploy job in CI/CD workflow
- Eliminates the "Docker not found locally" warning during Pulumi deployment
- Ensures Docker is available for CodeBuildDockerImage bootstrap image push

## Context
The Pulumi `CodeBuildDockerImage` component tries to push a bootstrap image to ECR during deployment. Without Docker available locally, it prints:
```
⚠️  Docker not found locally. Skipping bootstrap image push.
```

While the deployment still works (CodeBuild handles the actual build), adding explicit Docker setup:
1. Eliminates the warning message
2. Enables the bootstrap image push as a fallback
3. Ensures consistent CI/CD behavior

## Test plan
- [ ] Verify CI/CD deploy job runs without Docker warning
- [ ] Confirm bootstrap image push succeeds when Docker is available

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced deployment infrastructure with Docker Buildx support, improving build efficiency for containerized deployments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->