### PR TITLE
fix: improve browser test reliability by replacing networkidle

### DIFF
--- a/portfolio/e2e/hydration.spec.ts
+++ b/portfolio/e2e/hydration.spec.ts
@@ -113,19 +113,23 @@ test.describe('Hydration', () => {
 
     // Navigate to resume
     await page.click('button:has-text("Résumé")');
+    await expect(page).toHaveURL(/\/resume/);
     await expect(page.locator('#__next')).not.toBeEmpty();
-    // Wait for resume page content to load
-    await expect(page.locator('header h1')).toBeVisible();
+    // Wait for resume-specific content (not shared header)
+    await expect(page.locator('.resume-box').first()).toBeVisible();
 
     // Navigate back to home
     await page.click('header h1 a');
+    await expect(page).toHaveURL(/\/$/);
     await expect(page.locator('#__next')).not.toBeEmpty();
+    // Wait for homepage-specific content (navigation buttons)
     await expect(page.locator('button:has-text("Receipt")')).toBeVisible();
 
     // Navigate to receipt
     await page.click('button:has-text("Receipt")');
+    await expect(page).toHaveURL(/\/receipt/);
     await expect(page.locator('#__next')).not.toBeEmpty();
-    // Wait for receipt page content
+    // Wait for receipt-specific content
     await expect(page.locator('h1', { hasText: 'Introduction' })).toBeVisible({ timeout: 15000 });
 
     expect(pageErrors, 'Navigation should not cause JavaScript errors').toEqual([]);


### PR DESCRIPTION
## Summary

- Replace unreliable `waitForLoadState('networkidle')` with element-based waits
- Add new `Interactivity` test suite to verify buttons work after hydration
- Fix flaky receipt page test that was timing out in CI

## Problem

The browser tests were using `networkidle` to wait for hydration, which waits for "no network activity for 500ms". This is unreliable because:

1. Pages with animations or polling connections never reach network idle
2. The receipt page has many animated components (`QuestionMarquee`, `TrainingMetricsAnimation`, etc.)
3. `networkidle` conflates "fully loaded" with "hydration complete" - they're different things

## Solution

Replace `networkidle` with element-based waits:
- Wait for specific content (`header h1`, page headings) to be visible
- Add explicit timeouts (15s for receipt page with many components)
- Add interactivity tests that verify buttons actually respond to clicks

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that resolves an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [x] 🧪 Test changes or improved coverage

## Which Package(s) are Affected?

- [ ] receipt_dynamo
- [ ] receipt_dynamo_stream
- [ ] receipt_chroma
- [ ] receipt_upload
- [ ] receipt_places
- [ ] receipt_agent
- [x] Portfolio (TypeScript/Next.js)
- [ ] Infrastructure (Pulumi)
- [ ] CI/CD Workflows
- [ ] Other: _______________

## Testing

- [ ] Unit tests pass locally (`pytest` or `npm test`)
- [ ] Integration tests pass locally (if applicable)
- [x] Added or updated tests for new functionality
- [ ] All existing tests still pass with these changes
- [ ] Manual testing completed (if applicable)

## Documentation & Code Quality

- [x] Documentation or comments updated for complex logic
- [ ] README updated (if introducing new feature/dependency)
- [ ] TypeDoc/JSDoc comments added where needed
- [x] No new warnings or linting issues introduced
- [x] Code follows project style guidelines

## Related Issues

Fixes the browser test failure in PR #657 (CI workflow improvements)

## Impact Analysis

- Existing tests now wait for specific elements instead of network idle
- Added 2 new interactivity tests to verify hydration is complete
- Receipt page test timeout increased to 15s to account for many components

## Test plan

- [ ] CI browser tests pass on all browsers (chromium, firefox, webkit)
- [ ] No test timeouts on the receipt page

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)