### PR TITLE
perf(infra): add DynamoDB connection pool config and VPC for cache generator

### DIFF
--- a/infra/api_gateway.py
+++ b/infra/api_gateway.py
@@ -5,10 +5,10 @@ import pulumi_aws as aws
 import routes.address_similarity_cache_generator.infra  # noqa: F401
 import routes.image_details_cache_generator.infra  # noqa: F401
 import routes.layoutlm_inference_cache_generator.infra  # noqa: F401
-import routes.word_similarity_cache_generator.infra  # noqa: F401
+# word_similarity_cache_generator is now created in __main__.py with VPC config
 from routes.address_similarity.infra import address_similarity_lambda
 from routes.image_details_cache.infra import image_details_cache_lambda
-from routes.word_similarity.infra import word_similarity_lambda
+# word_similarity_lambda is created in __main__.py after cache generator
 from routes.ai_usage.infra import ai_usage_lambda
 from routes.job_training_metrics.infra import job_training_metrics_lambda
 
@@ -343,34 +343,7 @@ lambda_permission_address_similarity = aws.lambda_.Permission(
     source_arn=api.execution_arn.apply(lambda arn: f"{arn}/*/*"),
 )
 
-# /word_similarity
-integration_word_similarity = aws.apigatewayv2.Integration(
-    "word_similarity_lambda_integration",
-    api_id=api.id,
-    integration_type="AWS_PROXY",
-    integration_uri=word_similarity_lambda.invoke_arn,
-    integration_method="POST",
-    payload_format_version="2.0",
-)
-route_word_similarity = aws.apigatewayv2.Route(
-    "word_similarity_route",
-    api_id=api.id,
-    route_key="GET /word_similarity",
-    target=integration_word_similarity.id.apply(
-        lambda id: f"integrations/{id}"
-    ),
-    opts=pulumi.ResourceOptions(
-        replace_on_changes=["route_key", "target"],
-        delete_before_replace=True,
-    ),
-)
-lambda_permission_word_similarity = aws.lambda_.Permission(
-    "word_similarity_lambda_permission",
-    action="lambda:InvokeFunction",
-    function=word_similarity_lambda.name,
-    principal="apigateway.amazonaws.com",
-    source_arn=api.execution_arn.apply(lambda arn: f"{arn}/*/*"),
-)
+# /word_similarity - route created in __main__.py after cache generator with VPC config
 
 # /image_details_cache
 integration_image_details_cache = aws.apigatewayv2.Integration(

--- a/infra/routes/word_similarity_cache_generator/lambdas/index.py
+++ b/infra/routes/word_similarity_cache_generator/lambdas/index.py
@@ -372,7 +372,8 @@ def handler(_event, _context):
     temp_dir = tempfile.mkdtemp()
 
     try:
-        dynamo_client = DynamoClient(DYNAMODB_TABLE_NAME)
+        # Use larger connection pool to match parallel workers (25) + headroom for retries
+        dynamo_client = DynamoClient(DYNAMODB_TABLE_NAME, max_pool_connections=50)
 
         # Step 1: Download ChromaDB lines snapshot
         logger.info("Downloading ChromaDB lines snapshot from %s", CHROMADB_BUCKET)


### PR DESCRIPTION
# Pull Request

## Summary

- Add configurable `max_pool_connections` parameter to DynamoClient for boto3 connection pool sizing
- Put word_similarity_cache_generator Lambda in VPC with private subnet to use DynamoDB Gateway endpoint
- Configure connection pool size (50) to match parallel workers (25) plus headroom for retries

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that resolves an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [x] ⚡ Performance improvement
- [ ] 🧪 Test changes or improved coverage

## Which Package(s) are Affected?

- [x] receipt_dynamo
- [ ] receipt_dynamo_stream
- [ ] receipt_chroma
- [ ] receipt_upload
- [ ] receipt_places
- [ ] receipt_agent
- [ ] Portfolio (TypeScript/Next.js)
- [x] Infrastructure (Pulumi)
- [ ] CI/CD Workflows
- [ ] Other: _______________

## Testing

- [x] Unit tests pass locally (`pytest` or `npm test`)
- [ ] Integration tests pass locally (if applicable)
- [ ] Added or updated tests for new functionality
- [x] All existing tests still pass with these changes
- [x] Manual testing completed (if applicable)

## Documentation & Code Quality

- [x] Documentation or comments updated for complex logic
- [ ] README updated (if introducing new feature/dependency)
- [x] TypeDoc/JSDoc comments added where needed
- [x] No new warnings or linting issues introduced
- [x] Code follows project style guidelines

## Related Issues

Addresses DynamoDB query latency variance issue observed in word_similarity_cache_generator Lambda (9x variance: 358ms to 3,285ms)

## Impact Analysis

**Positive impacts:**
- Reduced DynamoDB query latency variance by using AWS backbone via Gateway endpoint
- Eliminated "Connection pool is full" warnings from boto3 when using parallel workers
- More consistent cache generation times

**Backward compatibility:**
- DynamoClient change is backward compatible (new parameter has `None` default)
- All existing call sites continue to work unchanged

## Deployment Notes

1. Deploy with `pulumi up` - will create:
   - VPC access policy attachment for Lambda role
   - Lambda VPC configuration pointing to private subnet
   
2. First invocation after deploy will have ~1-2s additional cold start due to VPC ENI attachment

3. Verify improvements by checking:
   - CloudWatch logs for absence of "Connection pool is full" warnings
   - Timing data in cached JSON files for reduced variance

---

This PR will be reviewed by CI/CD checks and automated analysis tools. Please ensure all checks pass before requesting human review.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure & Performance**
  * Improved database connection management for better concurrency and system reliability.
  * Enhanced backend infrastructure for word similarity processing with improved network isolation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->