### PR TITLE
Remove unused Fast Label Validation section from receipt page

### DIFF
--- a/portfolio/pages/receipt.tsx
+++ b/portfolio/pages/receipt.tsx
@@ -14,12 +14,8 @@ import {
   DynamoStreamAnimation,
   LabelEvaluatorVisualization,
   LabelValidationTimeline,
-  LabelValidationVisualization,
   LabelWordCloud,
-  LayoutLMBatchVisualization,
   LayoutLMInferenceVisualization,
-  LockingSwimlane,
-  MerchantCount,
   PageCurlLetter,
   PrecisionRecallDartboard,
   QuestionMarquee,
@@ -374,22 +370,6 @@ M1LK 2%           1    $4.4g`}</code>
       <ClientOnly>
         <LabelEvaluatorVisualization />
       </ClientOnly>
-
-      <h2>Fast Label Validation</h2>
-
-      <p>
-        Before the full label evaluation pipeline runs, a fast two-tier
-        validation system processes each receipt. First, ChromaDB consensus
-        checks each word against similar receipts from the same merchant. Words
-        that pass this fast check are marked as valid. Only words that fail
-        the consensus check escalate to an LLM for correction or review.
-      </p>
-
-      <ClientOnly>
-        <LabelValidationVisualization />
-      </ClientOnly>
-
-      <h1>What I Learned</h1>
 
       <p>
         This works, kind of. AI isn't consistent. It would call the price of


### PR DESCRIPTION
## Summary
- Removes the "Fast Label Validation" section and `LabelValidationVisualization` component that were accidentally added to `receipt.tsx` in PR #630
- Removes the "What I Learned" heading that was also added in that PR
- Removes unused imports: `LabelValidationVisualization`, `LayoutLMBatchVisualization`, `LockingSwimlane`, `MerchantCount`

This section describes backend infrastructure details that don't belong on the public-facing receipt page.

## Test plan
- [ ] Verify receipt page renders correctly without the removed section
- [ ] Verify no TypeScript/lint errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed a validation visualization section and related components from the portfolio receipt page.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->