### PR TITLE
fix(label-evaluator): correct parameter name for LangSmith export trigger

### DIFF
--- a/infra/label_evaluator_step_functions/step_function_states.py
+++ b/infra/label_evaluator_step_functions/step_function_states.py
@@ -513,7 +513,7 @@ def build_langsmith_export_states(emr: EmrConfig) -> dict[str, Any]:
             "Parameters": {
                 "FunctionName": emr.trigger_export_lambda_arn,
                 "Payload": {
-                    "langchain_project.$": "$.init.langchain_project",
+                    "project_name.$": "$.init.langchain_project",
                 },
             },
             "ResultSelector": {


### PR DESCRIPTION
## Summary
- Fix parameter name mismatch between Step Function and Lambda
- Step Function was passing `langchain_project`, but Lambda expected `project_name`
- This caused LangSmith exports to fail with "Project not found" when `run_analytics=true`

## Test plan
- [x] Deployed to dev and verified Step Function progresses past export step
- [x] LangSmith export triggered successfully with correct project name

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated internal data mapping for LangSmith export functionality to improve data source identification during exports.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->