### PR TITLE
fix(embedding): use centroid overlap for visual row grouping

### DIFF
--- a/receipt_chroma/receipt_chroma/embedding/formatting/line_format.py
+++ b/receipt_chroma/receipt_chroma/embedding/formatting/line_format.py
@@ -6,11 +6,18 @@ including visual row detection and row-based embedding formatting.
 Visual Row Approach:
 Apple Vision OCR often splits a single visual row into multiple ReceiptLine
 entities (e.g., product name on left, price on right). This module groups
-lines into visual rows based on vertical overlap, then creates embeddings
+lines into visual rows based on centroid overlap, then creates embeddings
 with row context (row above + target row + row below).
+
+Centroid Overlap Algorithm:
+Two lines are considered part of the same visual row if one line's centroid
+falls within the other line's vertical bounding box span. This approach uses
+no hardcoded tolerances - just the actual geometry of the lines. Connected
+lines are grouped using union-find to form visual rows.
 """
 
 import re
+from collections import defaultdict
 from collections.abc import Sequence
 from typing import Protocol, runtime_checkable
 
@@ -35,9 +42,12 @@ class LineLike(Protocol):
 def group_lines_into_visual_rows(
     lines: Sequence[LineLike],
 ) -> list[list[LineLike]]:
-    """Group ReceiptLines into visual rows based on vertical span overlap.
+    """Group ReceiptLines into visual rows based on centroid overlap.
 
-    Lines that vertically overlap are considered part of the same visual row.
+    Two lines are on the same visual row if one line's vertical centroid
+    falls within the other line's bounding box height. This uses no hardcoded
+    tolerances - just the actual geometry of the lines.
+
     This handles Apple Vision OCR splitting rows into separate entities
     (e.g., "ORGANIC COFFEE" on left and "12.99" on right as separate lines).
 
@@ -51,46 +61,71 @@ def group_lines_into_visual_rows(
     if not lines:
         return []
 
-    # Sort lines by y-coordinate descending (top of receipt first)
-    sorted_lines = sorted(
-        lines,
-        key=lambda ln: -ln.bounding_box.get("y", 0),
-    )
+    lines_list = list(lines)
+    n = len(lines_list)
 
+    # Build adjacency: which lines share a row?
+    # Two lines are on the same row if one's centroid falls within the other's
+    # vertical span
+    same_row = [[False] * n for _ in range(n)]
+
+    for i in range(n):
+        same_row[i][i] = True
+        line_i = lines_list[i]
+        bb_i = line_i.bounding_box
+        cy_i = bb_i.get("y", 0) + bb_i.get("height", 0) / 2
+        y_min_i = bb_i.get("y", 0)
+        y_max_i = y_min_i + bb_i.get("height", 0)
+
+        for j in range(i + 1, n):
+            line_j = lines_list[j]
+            bb_j = line_j.bounding_box
+            cy_j = bb_j.get("y", 0) + bb_j.get("height", 0) / 2
+            y_min_j = bb_j.get("y", 0)
+            y_max_j = y_min_j + bb_j.get("height", 0)
+
+            # Check if centroids fall within each other's spans
+            i_centroid_in_j = y_min_j <= cy_i <= y_max_j
+            j_centroid_in_i = y_min_i <= cy_j <= y_max_i
+
+            if i_centroid_in_j or j_centroid_in_i:
+                same_row[i][j] = True
+                same_row[j][i] = True
+
+    # Find connected components using union-find
+    parent = list(range(n))
+
+    def find(x: int) -> int:
+        if parent[x] != x:
+            parent[x] = find(parent[x])
+        return parent[x]
+
+    def union(x: int, y: int) -> None:
+        px, py = find(x), find(y)
+        if px != py:
+            parent[px] = py
+
+    for i in range(n):
+        for j in range(i + 1, n):
+            if same_row[i][j]:
+                union(i, j)
+
+    # Group by component
+    components: dict[int, list[LineLike]] = defaultdict(list)
+    for i in range(n):
+        components[find(i)].append(lines_list[i])
+
+    # Sort lines within rows by x-coordinate (left to right)
     rows: list[list[LineLike]] = []
-    current_row: list[LineLike] = [sorted_lines[0]]
+    for comp_lines in components.values():
+        comp_lines.sort(key=lambda ln: ln.bounding_box.get("x", 0))
+        rows.append(comp_lines)
 
-    # Track the y-span of the current row
-    first_line = sorted_lines[0]
-    current_y_min = first_line.bounding_box.get("y", 0)
-    current_y_max = current_y_min + first_line.bounding_box.get("height", 0)
-
-    for line in sorted_lines[1:]:
-        line_y_min = line.bounding_box.get("y", 0)
-        line_y_max = line_y_min + line.bounding_box.get("height", 0)
-
-        # Check if this line overlaps vertically with the current row
-        # Overlap: line_y_min <= current_y_max AND line_y_max >= current_y_min
-        if line_y_min <= current_y_max and line_y_max >= current_y_min:
-            # Same visual row - add to current row
-            current_row.append(line)
-            # Expand the row's y-span
-            current_y_min = min(current_y_min, line_y_min)
-            current_y_max = max(current_y_max, line_y_max)
-        else:
-            # New visual row - finalize current row and start new one
-            # Sort current row left-to-right by x-coordinate
-            current_row.sort(key=lambda ln: ln.bounding_box.get("x", 0))
-            rows.append(current_row)
-
-            # Start new row
-            current_row = [line]
-            current_y_min = line_y_min
-            current_y_max = line_y_max
-
-    # Don't forget the last row
-    current_row.sort(key=lambda ln: ln.bounding_box.get("x", 0))
-    rows.append(current_row)
+    # Sort rows by average y-coordinate (top first, so descending)
+    rows.sort(
+        key=lambda row: -sum(ln.bounding_box.get("y", 0) for ln in row)
+        / len(row)
+    )
 
     return rows
 


### PR DESCRIPTION
## Summary

- Fixes incorrect visual row grouping that merged consecutive receipt lines with slight vertical overlap
- Uses centroid overlap algorithm with union-find instead of expanding y-spans
- No hardcoded tolerances - uses actual line geometry

## Problem

The previous algorithm expanded the y-span as lines were added to a row. When consecutive lines had slight vertical overlap (common in receipts where product names and prices are on the same visual line), this caused incorrect merging:

**Before (bug):**
```
Row 9: ALFRESCO SLTD BUTTER RAW WHOLE MILK 17.99 3.99
```

**After (fixed):**
```
Row 13: ALFRESCO SLTD BUTTER 3.99
Row 14: RAW WHOLE MILK 17.99
```

## Algorithm

Two lines are on the same visual row if:
- Line A's centroid falls within Line B's bounding box height, OR
- Line B's centroid falls within Line A's bounding box height

Connected lines are grouped using union-find.

## Test plan

- [x] All 29 existing unit tests pass
- [x] Verified fix with debug script on problematic receipt (image_id: `aabbf168-7a61-483b-97c7-e711de91ce5f`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced QA workflow with planning, context retrieval, and answer synthesis.
  * Golden dataset building and MCP server for receipt search and retrieval tools.

* **Improvements**
  * More robust visual line detection on receipts: centroid-overlap grouping for row formation, consistent left-to-right ordering within rows, and top-to-bottom row ordering for improved parsing.
  * New dataset schema for standardized QA examples and outputs.

* **Documentation**
  * Added model comparison and evaluation results for QA agents.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->