### PR TITLE
chore(deps): update React and Next.js related packages

### DIFF
--- a/portfolio/package-lock.json
+++ b/portfolio/package-lock.json
@@ -10,8 +10,8 @@
       "dependencies": {
         "@react-spring/web": "^10.0.3",
         "next": "^16.1.6",
-        "react": "^19.2.3",
-        "react-dom": "^19.2.3",
+        "react": "^19.2.4",
+        "react-dom": "^19.2.4",
         "react-intersection-observer": "^10.0.0",
         "react-markdown": "^10.1.0"
       },
@@ -28,10 +28,10 @@
         "@testing-library/user-event": "^14.6.1",
         "@types/jest": "^27.0.1",
         "@types/node": "^25.0.3",
-        "@types/react": "^19.2.7",
+        "@types/react": "^19.2.11",
         "@types/react-dom": "^19.2.3",
         "eslint": "^9.39.2",
-        "eslint-config-next": "16.1.4",
+        "eslint-config-next": "^16.1.6",
         "jest": "^30.0.0",
         "jest-environment-jsdom": "^30.2.0",
         "typedoc": "^0.28.15",
@@ -2553,9 +2553,9 @@
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "16.1.4",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.1.4.tgz",
-      "integrity": "sha512-38WMjGP8y+1MN4bcZFs+GTcBe0iem5GGTzFE5GWW/dWdRKde7LOXH3lQT2QuoquVWyfl2S0fQRchGmeacGZ4Wg==",
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.1.6.tgz",
+      "integrity": "sha512-/Qq3PTagA6+nYVfryAtQ7/9FEr/6YVyvOtl6rZnGsbReGLf0jZU6gkpr1FuChAQpvV46a78p4cmHOVP8mbfSMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3479,9 +3479,9 @@
       }
     },
     "node_modules/@types/react": {
-      "version": "19.2.8",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.8.tgz",
-      "integrity": "sha512-3MbSL37jEchWZz2p2mjntRZtPt837ij10ApxKfgmXCTuHWagYg7iA5bqPw6C8BMPfwidlvfPI/fxOc42HLhcyg==",
+      "version": "19.2.11",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.11.tgz",
+      "integrity": "sha512-tORuanb01iEzWvMGVGv2ZDhYZVeRMrw453DCSAIn/5yvcSVnMoUMTyf33nQJLahYEnv9xqrTNbgz4qY5EfSh0g==",
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -6294,13 +6294,13 @@
       }
     },
     "node_modules/eslint-config-next": {
-      "version": "16.1.4",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-16.1.4.tgz",
-      "integrity": "sha512-iCrrNolUPpn/ythx0HcyNRfUBgTkaNBXByisKUbusPGCl8DMkDXXAu7exlSTSLGTIsH9lFE/c4s/3Qiyv2qwdA==",
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-16.1.6.tgz",
+      "integrity": "sha512-vKq40io2B0XtkkNDYyleATwblNt8xuh3FWp8SpSz3pt7P01OkBFlKsJZ2mWt5WsCySlDQLckb1zMY9yE9Qy0LA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@next/eslint-plugin-next": "16.1.4",
+        "@next/eslint-plugin-next": "16.1.6",
         "eslint-import-resolver-node": "^0.3.6",
         "eslint-import-resolver-typescript": "^3.5.2",
         "eslint-plugin-import": "^2.32.0",
@@ -12672,24 +12672,24 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.3",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
-      "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
+      "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.3",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
-      "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
+      "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.3"
+        "react": "^19.2.4"
       }
     },
     "node_modules/react-intersection-observer": {

--- a/portfolio/package.json
+++ b/portfolio/package.json
@@ -5,8 +5,8 @@
   "dependencies": {
     "@react-spring/web": "^10.0.3",
     "next": "^16.1.6",
-    "react": "^19.2.3",
-    "react-dom": "^19.2.3",
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4",
     "react-intersection-observer": "^10.0.0",
     "react-markdown": "^10.1.0"
   },
@@ -68,10 +68,10 @@
     "@testing-library/user-event": "^14.6.1",
     "@types/jest": "^27.0.1",
     "@types/node": "^25.0.3",
-    "@types/react": "^19.2.7",
+    "@types/react": "^19.2.11",
     "@types/react-dom": "^19.2.3",
     "eslint": "^9.39.2",
-    "eslint-config-next": "16.1.4",
+    "eslint-config-next": "^16.1.6",
     "jest": "^30.0.0",
     "jest-environment-jsdom": "^30.2.0",
     "typedoc": "^0.28.15",


### PR DESCRIPTION
## Summary

Updates React ecosystem and Next.js linting packages:

- `react`: 19.2.3 → 19.2.4
- `react-dom`: 19.2.3 → 19.2.4
- `@types/react`: 19.2.7 → 19.2.11
- `eslint-config-next`: 16.1.4 → 16.1.6

### React 19.2.4 Changes
- Add more DoS mitigations to Server Actions
- Harden Server Components ([facebook/react#35632](https://github.com/facebook/react/pull/35632))

### Why Combined?
These packages should be updated together to maintain compatibility. This PR replaces:
- #703 (react-dom only)
- #698 (eslint-config-next only)

## Test plan

- [ ] CI passes (TypeScript, Browser Tests, Python tests)
- [ ] No regressions in local development

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated React and React DOM to the latest patch release
  * Updated TypeScript React type definitions to the latest patch release
  * Updated ESLint configuration package to the latest patch release
<!-- end of auto-generated comment: release notes by coderabbit.ai -->