### PR TITLE
ci(deps): update GitHub Actions dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -83,7 +83,7 @@ jobs:
             --cov --cov-report=xml
 
       - name: Upload coverage
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: coverage-${{ matrix.package }}
           path: ${{ matrix.package }}/coverage.xml
@@ -95,7 +95,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "22"
 
@@ -108,7 +108,7 @@ jobs:
           npm run test:ci
 
       - name: Upload coverage
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: coverage-portfolio
           path: portfolio/coverage
@@ -120,7 +120,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "22"
 
@@ -135,7 +135,7 @@ jobs:
           npx playwright test e2e/hydration.spec.ts --project=chromium --project=firefox --project=webkit
 
       - name: Upload test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: failure()
         with:
           name: playwright-report
@@ -159,7 +159,7 @@ jobs:
         with:
           python-version: "3.12"
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "22"
           cache: "npm"
@@ -243,7 +243,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "22"
           cache: "npm"


### PR DESCRIPTION
## Summary

Updates GitHub Actions dependencies:

- `actions/setup-node`: v4 → v6
- `actions/upload-artifact`: v4 → v6

This PR replaces:
- #704 (upload-artifact only)
- #705 (setup-node only)

## Test plan

- [ ] CI passes on all jobs

🤖 Generated with [Claude Code](https://claude.ai/code)