### PR TITLE
chore(deps): update boto3 upper bound across all packages

### DIFF
--- a/infra/pyproject.toml
+++ b/infra/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "pulumi-command>=0.9.0,<2.0.0",  # Updated to allow 1.x versions
     "pulumi-docker-build>=0.0.12",  # Used for Docker image building
     # Lambda Layer Version Update Tool dependencies
-    "boto3>=1.26.0,<1.42.0",
+    "boto3>=1.26.0,<1.43.0",
     "PyYAML>=6.0",
 ]
 

--- a/receipt_dynamo/pyproject.toml
+++ b/receipt_dynamo/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 ]
 dependencies = [
     "requests",
-    "boto3>=1.34.0,<1.42.0",
+    "boto3>=1.34.0,<1.43.0",
 ]
 keywords = ["dynamo", "dynamodb", "receipts", "aws", "database"]
 

--- a/receipt_upload/pyproject.toml
+++ b/receipt_upload/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
   "receipt-places",  # Local package for Google Places API
   "Pillow>=11.2.1",
   "pillow-avif-plugin>=1.3.0",
-  "boto3>=1.26.0,<1.42.0",
+  "boto3>=1.26.0,<1.43.0",
   "langsmith>=0.1.0",  # For Langsmith tracing
 ]
 keywords = ["dynamo", "dynamodb", "receipts", "aws", "database"]


### PR DESCRIPTION
## Summary

Updates boto3 upper bound from `<1.42.0` to `<1.43.0` in:
- `infra/pyproject.toml`
- `receipt_dynamo/pyproject.toml`
- `receipt_upload/pyproject.toml`

Latest boto3 version is 1.42.42.

This PR replaces:
- #699 (receipt_upload only)
- #701 (receipt_dynamo only)
- #702 (infra only)

## Test plan

- [ ] CI passes (Python tests for all affected packages)

🤖 Generated with [Claude Code](https://claude.ai/code)