### PR TITLE
chore(infra): migrate CodePipeline V1 to V2

### DIFF
--- a/infra/components/codebuild_docker_image.py
+++ b/infra/components/codebuild_docker_image.py
@@ -859,6 +859,8 @@ echo "✅ Uploaded context.zip (hash: $HASH_SHORT..., size: $CONTEXT_SIZE)"
         pipeline = Pipeline(
             f"{self.name}-pipeline",
             role_arn=pipeline_role.arn,
+            pipeline_type="V2",
+            execution_mode="SUPERSEDED",
             artifact_stores=[
                 PipelineArtifactStoreArgs(
                     type="S3",

--- a/infra/components/ecs_lambda.py
+++ b/infra/components/ecs_lambda.py
@@ -745,6 +745,8 @@ echo "✅ Uploaded source.zip"
         pipeline = Pipeline(
             f"{self.name}-fn-pipeline-{pulumi.get_stack()}",
             role_arn=pipeline_role.arn,
+            pipeline_type="V2",
+            execution_mode="SUPERSEDED",
             artifact_stores=[
                 PipelineArtifactStoreArgs(
                     type="S3",

--- a/infra/components/emr_serverless_docker_image.py
+++ b/infra/components/emr_serverless_docker_image.py
@@ -687,6 +687,8 @@ echo "Uploaded context.zip (hash: $HASH_SHORT..., size: $CONTEXT_SIZE)"
         pipeline = Pipeline(
             f"{self.name}-emr-pipeline",
             role_arn=pipeline_role.arn,
+            pipeline_type="V2",
+            execution_mode="SUPERSEDED",
             artifact_stores=[
                 PipelineArtifactStoreArgs(
                     type="S3",

--- a/infra/components/lambda_layer.py
+++ b/infra/components/lambda_layer.py
@@ -905,6 +905,8 @@ echo "🎉 Parallel function updates completed!"'''
         pipeline = Pipeline(
             f"{self.name}-pipeline-{stack_name}",  # Pulumi logical name with stack
             role_arn=pipeline_role.arn,
+            pipeline_type="V2",
+            execution_mode="SUPERSEDED",
             artifact_stores=[
                 PipelineArtifactStoreArgs(
                     type="S3",


### PR DESCRIPTION
# Pull Request

## Summary

- Migrate all 4 CodePipeline definitions from V1 to V2 to eliminate ~$41/month in per-pipeline fees
- V2 charges $0.002/action-minute instead of $1/pipeline/month, saving ~90% for short-lived builds
- Uses `SUPERSEDED` execution mode to match V1 default behavior (no behavioral change)

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that resolves an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [x] ⚡ Performance improvement
- [ ] 🧪 Test changes or improved coverage

## Which Package(s) are Affected?

- [ ] receipt_dynamo
- [ ] receipt_dynamo_stream
- [ ] receipt_chroma
- [ ] receipt_upload
- [ ] receipt_places
- [ ] receipt_agent
- [ ] Portfolio (TypeScript/Next.js)
- [x] Infrastructure (Pulumi)
- [ ] CI/CD Workflows
- [ ] Other: _______________

## Testing

- [ ] Unit tests pass locally (`pytest` or `npm test`)
- [ ] Integration tests pass locally (if applicable)
- [ ] Added or updated tests for new functionality
- [x] All existing tests still pass with these changes
- [x] Manual testing completed (if applicable)

Verified on dev stack:
- `pulumi preview --stack dev` confirmed in-place updates (`[diff: ~pipelineType]`), no replacements
- `pulumi up --stack dev` succeeded (77 updated, 53 replaced local commands, 0 errors)
- Confirmed pipeline type via CLI:
  ```bash
  aws codepipeline get-pipeline --name "label-evaluator-dev-eval-img-pipeline-a110d33" \
    --query 'pipeline.{type:pipelineType,mode:executionMode}'
  # {"type": "V2", "mode": "SUPERSEDED"}
  ```

## Documentation & Code Quality

- [ ] Documentation or comments updated for complex logic
- [ ] README updated (if introducing new feature/dependency)
- [ ] TypeDoc/JSDoc comments added where needed
- [x] No new warnings or linting issues introduced
- [x] Code follows project style guidelines

## Related Issues

N/A

## Impact Analysis

Minimal risk — adds `pipeline_type="V2"` and `execution_mode="SUPERSEDED"` to 4 Pulumi component files. No IAM, stage, or action changes required. `SUPERSEDED` is identical to V1's default behavior.

**Files changed:**
- `infra/components/codebuild_docker_image.py` — used by 12+ Lambda Docker image builds
- `infra/components/lambda_layer.py` — Lambda layer builds (3-stage with parallel Python versions)
- `infra/components/emr_serverless_docker_image.py` — EMR Spark image builds
- `infra/components/ecs_lambda.py` — ECS-based Lambda function builds

**Rollback:** Remove the two added parameters and re-deploy.

## Deployment Notes

1. Deploy dev first: `pulumi up --stack dev` — **done, verified**
2. Deploy prod: `pulumi up --stack prod`
3. Monitor Cost Explorer after 24-48h to confirm V2 action-minute pricing replaces V1 monthly fees

No configuration changes, new dependencies, or secret updates required.

---

This PR will be reviewed by CI/CD checks and automated analysis tools. Please ensure all checks pass before requesting human review.