### PR TITLE
feat(langsmith): decision journey viz-cache helper + dedup gaps doc

### DIFF
--- a/receipt_langsmith/docs/dedup_conflict_resolution_gaps.md
+++ b/receipt_langsmith/docs/dedup_conflict_resolution_gaps.md
@@ -1,0 +1,240 @@
+# Dedup Conflict Resolution Gaps
+
+## Problem Statement
+
+When the unified receipt evaluator (`unified_receipt_evaluator.py`) runs Phase 1,
+it executes `currency_evaluation` and `metadata_evaluation` concurrently via
+`asyncio.gather()`. Both evaluators independently examine words on the receipt and
+produce decisions (VALID / INVALID / NEEDS_REVIEW). Because they run in parallel
+on the same receipt, **the same word can receive decisions from multiple phases** --
+and those decisions can conflict.
+
+After Phase 1 completes, an `apply_phase1_corrections` step is supposed to
+reconcile these overlapping decisions before Phase 2 (financial validation) begins.
+However, **this step currently records no trace data**, making it impossible to
+understand how conflicts were resolved.
+
+## Current State of the Data
+
+Analysis of 588 receipt traces from the label-evaluator-dev LangSmith project:
+
+| Metric | Value |
+|--------|-------|
+| Total decisions across all phases | 20,543 |
+| Words appearing in 2+ phases | 401 |
+| Words with **conflicting** decisions across phases | 182 |
+| Traces with overlapping currency+metadata decisions | 55 of 588 |
+| Overlapping (line_id, word_id) pairs | 119 |
+| Pairs with different decisions | 53 |
+
+### Labels Most Affected by Conflicts
+
+| Label | Conflicting Words |
+|-------|-------------------|
+| LINE_TOTAL | 50 |
+| SUBTOTAL | 25 |
+| PRODUCT_NAME | 21 |
+| TAX | 16 |
+| QUANTITY | 11 |
+| UNIT_PRICE | 11 |
+| GRAND_TOTAL | 11 |
+| DISCOUNT | 10 |
+
+### Most Common Conflict Patterns
+
+| Phase Pair | Conflicts |
+|------------|-----------|
+| currency_evaluation vs financial_validation | 139 |
+| currency_evaluation vs metadata_evaluation | 53 |
+
+## What Data Is Missing
+
+The `apply_phase1_corrections` span in **all 588 traces** has:
+
+```json
+{
+  "inputs": {},
+  "outputs": {}
+}
+```
+
+Both inputs and outputs are empty dicts. This means:
+
+1. **No record of which evaluator "won"** when currency and metadata disagree.
+2. **No record of the resolution logic** -- was it last-writer-wins, confidence
+   comparison, phase priority, or something else?
+3. **No confidence comparison** between the competing decisions.
+4. **No audit trail** for corrections applied to DynamoDB labels.
+
+## What Should Be Traced
+
+The `apply_phase1_corrections` child trace (line ~892 of `unified_receipt_evaluator.py`)
+currently uses a bare `with child_trace(...)` context manager that records nothing.
+It should record:
+
+### Inputs
+
+```python
+{
+    "currency_decisions": [
+        {
+            "line_id": 12, "word_id": 1,
+            "decision": "INVALID", "confidence": "high",
+            "suggested_label": "LINE_TOTAL"
+        },
+        # ...
+    ],
+    "metadata_decisions": [
+        {
+            "line_id": 12, "word_id": 1,
+            "decision": "VALID", "confidence": "medium",
+            "suggested_label": null
+        },
+        # ...
+    ],
+    "overlapping_words": 3,
+    "conflicting_words": 1
+}
+```
+
+### Outputs
+
+```python
+{
+    "resolutions": [
+        {
+            "line_id": 12,
+            "word_id": 1,
+            "word_text": "$19.99",
+            "current_label": "LINE_TOTAL",
+            "currency_decision": "INVALID",
+            "currency_confidence": "high",
+            "metadata_decision": "VALID",
+            "metadata_confidence": "medium",
+            "winner": "currency",           # which evaluator's decision was applied
+            "resolution_reason": "higher_confidence",  # why it won
+            "applied_label": "PRODUCT_NAME",  # what label was written to DynamoDB
+            "was_corrected": true            # whether a DynamoDB write happened
+        }
+    ],
+    "total_corrections_applied": 1,
+    "resolution_strategy": "confidence_priority"  # or "phase_priority", "last_writer"
+}
+```
+
+## How the Step Function Should Be Instrumented
+
+### Current Code (lines ~887-925 of `unified_receipt_evaluator.py`)
+
+```python
+if dynamo_table:
+    with child_trace("apply_phase1_corrections", trace_ctx):
+        # ... applies corrections but records nothing
+```
+
+### Proposed Instrumentation
+
+```python
+if dynamo_table:
+    # 1. Identify overlaps BEFORE applying corrections
+    currency_by_word = {
+        (d["issue"]["line_id"], d["issue"]["word_id"]): d
+        for d in currency_result
+    }
+    metadata_by_word = {
+        (d["issue"]["line_id"], d["issue"]["word_id"]): d
+        for d in metadata_result
+    }
+    overlapping_keys = set(currency_by_word) & set(metadata_by_word)
+    conflicting = [
+        k for k in overlapping_keys
+        if currency_by_word[k]["llm_review"]["decision"]
+        != metadata_by_word[k]["llm_review"]["decision"]
+    ]
+
+    # 2. Record inputs and outputs in the trace
+    correction_trace_ctx = start_child_trace(
+        "apply_phase1_corrections",
+        trace_ctx,
+        inputs={
+            "currency_invalid_count": len([
+                d for d in currency_result
+                if d["llm_review"]["decision"] == "INVALID"
+            ]),
+            "metadata_invalid_count": len([
+                d for d in metadata_result
+                if d["llm_review"]["decision"] == "INVALID"
+            ]),
+            "overlapping_words": len(overlapping_keys),
+            "conflicting_words": len(conflicting),
+        },
+    )
+
+    try:
+        resolutions = []
+        # ... existing apply logic, but for each conflict,
+        #     record which evaluator won and why ...
+
+        end_child_trace(
+            correction_trace_ctx,
+            outputs={
+                "resolutions": resolutions,
+                "total_corrections_applied": applied_count,
+                "resolution_strategy": "confidence_priority",
+            },
+        )
+    except Exception:
+        end_child_trace(correction_trace_ctx, error=traceback.format_exc())
+        raise
+```
+
+### Key Changes Required
+
+1. **Switch from `with child_trace(...)` to `start_child_trace()` / `end_child_trace()`**
+   so that inputs and outputs can be passed explicitly.
+
+2. **Compute overlaps before applying** by indexing both `currency_result` and
+   `metadata_result` by `(line_id, word_id)`.
+
+3. **Define a resolution strategy** and record it. Currently both currency and
+   metadata corrections are applied independently (currency first, then metadata),
+   which means metadata silently overwrites currency corrections for the same word.
+   This is effectively a "last-writer-wins / metadata-priority" strategy, but it
+   is not documented or recorded.
+
+4. **Record per-word resolution details** including both decisions, both confidences,
+   which won, and what label was written.
+
+## Impact on the Viz-Cache
+
+The journey viz-cache (`evaluator_journey_viz_cache.py`) currently has no way to
+determine how conflicts were resolved. For all 182 conflicting words, the
+`final_outcome` field simply uses the last phase's decision in trace order, which
+may not reflect what was actually written to DynamoDB.
+
+Once the step function is instrumented:
+
+1. The viz-cache builder can read the `apply_phase1_corrections` outputs to
+   determine the actual resolution for each word.
+2. Each journey entry can include a `resolution` field:
+   ```json
+   {
+     "resolution": {
+       "winner": "currency",
+       "reason": "higher_confidence",
+       "applied_label": "PRODUCT_NAME"
+     }
+   }
+   ```
+   Instead of the current implicit `"resolution": "unknown"`.
+3. The frontend can display which evaluator won and why, enabling operators to
+   audit and improve the resolution logic.
+
+## Recommended Next Steps
+
+1. Instrument `apply_phase1_corrections` as described above.
+2. Define and document the resolution strategy (confidence priority is recommended
+   over last-writer-wins).
+3. Re-run the evaluator on a small batch to verify trace outputs.
+4. Update `evaluator_journey_viz_cache.py` to consume the new resolution data.
+5. Add a conflict resolution summary to the receipt-level output JSON.

--- a/receipt_langsmith/receipt_langsmith/spark/evaluator_journey_viz_cache.py
+++ b/receipt_langsmith/receipt_langsmith/spark/evaluator_journey_viz_cache.py
@@ -1,0 +1,203 @@
+"""Decision journey viz-cache builder for receipt evaluator traces.
+
+Builds a per-receipt journey cache that tracks each word's evaluation path
+across phases (currency_evaluation, metadata_evaluation, financial_validation,
+phase3_llm_review), detects conflicts where the same word receives different
+decisions in different phases, and produces a JSON structure suitable for
+visualization.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any
+
+import pyarrow.parquet as pq
+
+logger = logging.getLogger(__name__)
+
+PHASE_NAMES = (
+    "currency_evaluation",
+    "metadata_evaluation",
+    "financial_validation",
+    "phase3_llm_review",
+)
+
+
+def _read_all_parquet(parquet_dir: str):
+    """Read all parquet files under *parquet_dir* into a single pandas DataFrame."""
+    import pandas as pd
+
+    frames = []
+    for root, _dirs, files in os.walk(parquet_dir):
+        for fname in sorted(files):
+            if not fname.endswith(".parquet"):
+                continue
+            path = os.path.join(root, fname)
+            table = pq.ParquetFile(path).read()
+            frames.append(table.to_pandas())
+
+    if not frames:
+        raise FileNotFoundError(f"No parquet files found under {parquet_dir}")
+    return pd.concat(frames, ignore_index=True)
+
+
+def _extract_root_metadata(row) -> dict[str, Any]:
+    """Pull image_id, receipt_id, merchant_name from a ReceiptEvaluation root."""
+    extra = json.loads(row["extra"]) if row["extra"] else {}
+    meta = extra.get("metadata", {})
+    return {
+        "image_id": meta.get("image_id"),
+        "receipt_id": meta.get("receipt_id"),
+        "merchant_name": meta.get("merchant_name"),
+    }
+
+
+def _parse_phase_decisions(
+    row, phase_name: str
+) -> list[dict[str, Any]]:
+    """Parse the output list from a phase span into flat decision dicts."""
+    raw = row["outputs"]
+    if not raw:
+        return []
+    parsed = json.loads(raw) if isinstance(raw, str) else raw
+    output_list = parsed.get("output", [])
+    if not isinstance(output_list, list):
+        return []
+
+    decisions = []
+    for item in output_list:
+        issue = item.get("issue", {})
+        llm_review = item.get("llm_review", {})
+        decisions.append({
+            "phase": phase_name,
+            "line_id": issue.get("line_id"),
+            "word_id": issue.get("word_id"),
+            "word_text": issue.get("word_text", ""),
+            "current_label": issue.get("current_label", ""),
+            "decision": llm_review.get("decision"),
+            "confidence": llm_review.get("confidence"),
+            "reasoning": llm_review.get("reasoning"),
+            "suggested_label": llm_review.get("suggested_label"),
+            "start_time": str(row["start_time"]) if row["start_time"] is not None else None,
+            "end_time": str(row["end_time"]) if row["end_time"] is not None else None,
+        })
+    return decisions
+
+
+def build_journey_cache(parquet_dir: str) -> list[dict]:
+    """Build decision journey cache from parquet trace exports.
+
+    Parameters
+    ----------
+    parquet_dir:
+        Root directory containing LangSmith parquet exports.
+
+    Returns
+    -------
+    list[dict]
+        One dict per receipt with the structure documented in the module
+        docstring.
+    """
+    df = _read_all_parquet(parquet_dir)
+    logger.info("Loaded %d spans from parquet", len(df))
+
+    # Index root ReceiptEvaluation runs by trace_id
+    roots = df[df["name"] == "ReceiptEvaluation"]
+    root_by_trace: dict[str, dict[str, Any]] = {}
+    for _, row in roots.iterrows():
+        root_by_trace[row["trace_id"]] = _extract_root_metadata(row)
+
+    logger.info("Found %d root ReceiptEvaluation traces", len(root_by_trace))
+
+    # Collect all decisions across phases, grouped by trace_id
+    # trace_id -> list of flat decision dicts
+    decisions_by_trace: dict[str, list[dict[str, Any]]] = {}
+    for phase in PHASE_NAMES:
+        phase_df = df[df["name"] == phase]
+        for _, row in phase_df.iterrows():
+            trace_id = row["trace_id"]
+            decs = _parse_phase_decisions(row, phase)
+            if decs:
+                decisions_by_trace.setdefault(trace_id, []).extend(decs)
+
+    logger.info(
+        "Collected decisions for %d traces across %d phases",
+        len(decisions_by_trace),
+        len(PHASE_NAMES),
+    )
+
+    # Build per-receipt journey objects
+    results: list[dict] = []
+    for trace_id, root_meta in root_by_trace.items():
+        all_decisions = decisions_by_trace.get(trace_id, [])
+
+        # Group decisions by (line_id, word_id)
+        word_groups: dict[tuple[int, int], list[dict]] = {}
+        for dec in all_decisions:
+            key = (dec["line_id"], dec["word_id"])
+            word_groups.setdefault(key, []).append(dec)
+
+        journeys: list[dict] = []
+        for (line_id, word_id), phases_list in sorted(word_groups.items()):
+            # Sort phases by predefined order
+            phase_order = {name: i for i, name in enumerate(PHASE_NAMES)}
+            phases_list.sort(key=lambda d: phase_order.get(d["phase"], 99))
+
+            # Detect conflicts: different non-null decisions across phases
+            unique_decisions = {
+                d["decision"]
+                for d in phases_list
+                if d["decision"] is not None
+            }
+            has_conflict = len(unique_decisions) > 1
+
+            # Final outcome is the last phase's decision
+            final_outcome = phases_list[-1]["decision"]
+
+            phase_entries = []
+            for d in phases_list:
+                phase_entries.append({
+                    "phase": d["phase"],
+                    "decision": d["decision"],
+                    "confidence": d["confidence"],
+                    "reasoning": d["reasoning"],
+                    "suggested_label": d["suggested_label"],
+                    "start_time": d["start_time"],
+                    "end_time": d["end_time"],
+                })
+
+            journeys.append({
+                "line_id": line_id,
+                "word_id": word_id,
+                "word_text": phases_list[0]["word_text"],
+                "current_label": phases_list[0]["current_label"],
+                "phases": phase_entries,
+                "has_conflict": has_conflict,
+                "final_outcome": final_outcome,
+            })
+
+        multi_phase_words = sum(
+            1 for j in journeys if len(j["phases"]) > 1
+        )
+        words_with_conflicts = sum(
+            1 for j in journeys if j["has_conflict"]
+        )
+
+        results.append({
+            "image_id": root_meta.get("image_id"),
+            "receipt_id": root_meta.get("receipt_id"),
+            "merchant_name": root_meta.get("merchant_name"),
+            "trace_id": trace_id,
+            "journeys": journeys,
+            "summary": {
+                "total_words_evaluated": len(journeys),
+                "multi_phase_words": multi_phase_words,
+                "words_with_conflicts": words_with_conflicts,
+            },
+        })
+
+    logger.info("Built journey cache for %d receipts", len(results))
+    return results

--- a/receipt_langsmith/tests/spark/test_evaluator_journey_viz_cache.py
+++ b/receipt_langsmith/tests/spark/test_evaluator_journey_viz_cache.py
@@ -1,0 +1,176 @@
+"""Tests for the decision journey viz-cache builder.
+
+Runs against the real parquet exports in /tmp/langsmith-traces/ and
+writes sample outputs to /tmp/viz-cache-output/journey/.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+
+from receipt_langsmith.spark.evaluator_journey_viz_cache import (
+    build_journey_cache,
+)
+
+PARQUET_DIR = "/tmp/langsmith-traces/"
+OUTPUT_DIR = "/tmp/viz-cache-output/journey"
+
+
+@pytest.fixture(scope="module")
+def journey_cache() -> list[dict]:
+    """Build the journey cache once for all tests."""
+    return build_journey_cache(PARQUET_DIR)
+
+
+def test_receipt_count(journey_cache: list[dict]) -> None:
+    """We should get data for 588 receipts (one per ReceiptEvaluation root)."""
+    assert len(journey_cache) == 588, (
+        f"Expected 588 receipts, got {len(journey_cache)}"
+    )
+
+
+def test_multi_phase_words(journey_cache: list[dict]) -> None:
+    """At least 401 words should appear in 2+ phases."""
+    multi_phase_total = 0
+    for receipt in journey_cache:
+        multi_phase_total += receipt["summary"]["multi_phase_words"]
+    assert multi_phase_total >= 401, (
+        f"Expected >= 401 multi-phase words, got {multi_phase_total}"
+    )
+
+
+def test_journeys_have_required_fields(journey_cache: list[dict]) -> None:
+    """Every receipt must have the required top-level fields."""
+    for receipt in journey_cache:
+        assert "image_id" in receipt
+        assert "receipt_id" in receipt
+        assert "trace_id" in receipt
+        assert "journeys" in receipt
+        assert "summary" in receipt
+        summary = receipt["summary"]
+        assert "total_words_evaluated" in summary
+        assert "multi_phase_words" in summary
+        assert "words_with_conflicts" in summary
+
+
+def test_conflict_detection(journey_cache: list[dict]) -> None:
+    """Conflict detection should find words with diverging decisions."""
+    total_conflicts = 0
+    for receipt in journey_cache:
+        total_conflicts += receipt["summary"]["words_with_conflicts"]
+
+    print(f"\nTotal words with conflicts: {total_conflicts}")
+    # We know from the data that 182 words have conflicting decisions
+    assert total_conflicts > 0, "Expected at least some conflicts"
+
+
+def test_write_sample_outputs(journey_cache: list[dict]) -> None:
+    """Write 3 sample outputs to /tmp/viz-cache-output/journey/."""
+    os.makedirs(OUTPUT_DIR, exist_ok=True)
+
+    # Pick interesting samples: one with conflicts, one without, one with many phases
+    with_conflicts = [
+        r for r in journey_cache if r["summary"]["words_with_conflicts"] > 0
+    ]
+    without_conflicts = [
+        r for r in journey_cache
+        if r["summary"]["words_with_conflicts"] == 0
+        and r["summary"]["total_words_evaluated"] > 0
+    ]
+    most_multi_phase = sorted(
+        journey_cache,
+        key=lambda r: r["summary"]["multi_phase_words"],
+        reverse=True,
+    )
+
+    samples = []
+    if with_conflicts:
+        samples.append(("sample_with_conflicts.json", with_conflicts[0]))
+    if without_conflicts:
+        samples.append(("sample_no_conflicts.json", without_conflicts[0]))
+    if most_multi_phase:
+        samples.append(("sample_most_multi_phase.json", most_multi_phase[0]))
+
+    for filename, sample in samples:
+        path = os.path.join(OUTPUT_DIR, filename)
+        with open(path, "w") as f:
+            json.dump(sample, f, indent=2, default=str)
+        print(f"Wrote {path}")
+
+    assert len(samples) == 3, f"Expected 3 samples, wrote {len(samples)}"
+
+
+def test_print_conflict_statistics(journey_cache: list[dict]) -> None:
+    """Print detailed conflict statistics."""
+    total_words = 0
+    total_multi_phase = 0
+    total_conflicts = 0
+    phase_pair_conflicts: dict[tuple[str, str], int] = {}
+    label_conflicts: dict[str, int] = {}
+
+    for receipt in journey_cache:
+        total_words += receipt["summary"]["total_words_evaluated"]
+        total_multi_phase += receipt["summary"]["multi_phase_words"]
+        total_conflicts += receipt["summary"]["words_with_conflicts"]
+
+        for journey in receipt["journeys"]:
+            if journey["has_conflict"]:
+                label = journey["current_label"]
+                label_conflicts[label] = label_conflicts.get(label, 0) + 1
+
+                phases = [p["phase"] for p in journey["phases"]]
+                for i in range(len(phases)):
+                    for j in range(i + 1, len(phases)):
+                        pair = (phases[i], phases[j])
+                        phase_pair_conflicts[pair] = (
+                            phase_pair_conflicts.get(pair, 0) + 1
+                        )
+
+    print("\n=== Decision Journey Statistics ===")
+    print(f"Total receipts: {len(journey_cache)}")
+    print(f"Total words evaluated: {total_words}")
+    print(f"Multi-phase words: {total_multi_phase}")
+    print(f"Words with conflicts: {total_conflicts}")
+    print(f"\nConflicts by label:")
+    for label, count in sorted(
+        label_conflicts.items(), key=lambda x: x[1], reverse=True
+    ):
+        print(f"  {label}: {count}")
+    print(f"\nConflicts by phase pair:")
+    for (p1, p2), count in sorted(
+        phase_pair_conflicts.items(), key=lambda x: x[1], reverse=True
+    ):
+        print(f"  {p1} vs {p2}: {count}")
+
+    # Phase-level decision distribution
+    phase_decisions: dict[str, dict[str, int]] = {}
+    for receipt in journey_cache:
+        for journey in receipt["journeys"]:
+            for phase in journey["phases"]:
+                pname = phase["phase"]
+                dec = phase["decision"] or "UNKNOWN"
+                phase_decisions.setdefault(pname, {})
+                phase_decisions[pname][dec] = (
+                    phase_decisions[pname].get(dec, 0) + 1
+                )
+
+    print(f"\nDecisions by phase:")
+    for pname in (
+        "currency_evaluation",
+        "metadata_evaluation",
+        "financial_validation",
+        "phase3_llm_review",
+    ):
+        decs = phase_decisions.get(pname, {})
+        total = sum(decs.values())
+        if total == 0:
+            print(f"  {pname}: 0 decisions")
+            continue
+        parts = ", ".join(
+            f"{d}: {c} ({c/total*100:.1f}%)"
+            for d, c in sorted(decs.items(), key=lambda x: x[1], reverse=True)
+        )
+        print(f"  {pname}: {total} decisions ({parts})")


### PR DESCRIPTION
## Summary
- Add `evaluator_journey_viz_cache.py` to track each word's evaluation path across phases (currency, metadata, financial, phase3)
- Detects conflicts where the same word receives different decisions across phases
- 588 receipts, 401 multi-phase words, 182 conflicts detected
- Add `dedup_conflict_resolution_gaps.md` documenting that `apply_phase1_corrections` has empty I/O in all 588 traces, preventing the dedup conflict resolution visualization from being built

## Dedup gaps (can't build viz from current traces)
- `apply_phase1_corrections` records empty `{}` inputs and outputs
- No record of which evaluator "won" when currency and metadata disagree
- Doc proposes instrumentation: switch to `start_child_trace()`/`end_child_trace()`, record per-word resolution details

## Test plan
- [x] `build_journey_cache("/tmp/langsmith-traces/")` returns 588 receipts
- [x] 401+ words have multi-phase journeys
- [x] Conflict detection finds words with diverging decisions
- [x] 3 sample outputs written to `/tmp/viz-cache-output/journey/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)