### PR TITLE
feat(langsmith): pattern discovery viz-cache helper + evidence gaps doc

### DIFF
--- a/receipt_langsmith/docs/chromadb_evidence_gaps.md
+++ b/receipt_langsmith/docs/chromadb_evidence_gaps.md
@@ -1,0 +1,242 @@
+# ChromaDB Evidence Gaps in Label Evaluator Traces
+
+## Status
+
+Evidence lookup is **broken** in the current label evaluator step function
+traces.  All 353 `phase3_llm_review` spans in the February 2026 batch
+(session `d142b135`) produced empty `{}` outputs, and the LLM prompts
+show no ChromaDB evidence blocks.  This document describes the bug, the
+expected data model, and the changes needed to fix evidence collection
+and make it traceable in the viz-cache pipeline.
+
+---
+
+## 1. The numpy array comparison bug
+
+### Symptom
+
+When `query_similar_words()` (or `query_label_evidence()`) returns
+results from ChromaDB, the embeddings come back as **numpy arrays**.
+Code that later does a truthiness check like:
+
+```python
+if embeddings:          # ValueError!
+```
+
+...triggers:
+
+> `ValueError: The truth value of an array is ambiguous.
+> Use a.any() or a.all()`
+
+because `bool(np.array([...]))` is undefined for multi-element arrays.
+
+### Root cause
+
+`chroma_client.get(collection_name="words", ids=[...], include=["embeddings"])`
+returns embeddings as `numpy.ndarray` objects when the underlying
+ChromaDB PersistentClient is backed by an `onnxruntime`-based embedding
+function.  Several call sites in `chroma_helpers.py` (lines 421-430,
+866-868) guard with `if embeddings:` or `len(embeddings) == 0`.  The
+`if embeddings:` pattern works for Python lists but **not** for numpy
+arrays with more than one element.
+
+The unified receipt evaluator Lambda (`unified_receipt_evaluator.py`)
+calls `query_similar_words()` inside `phase3_llm_review`, which
+silently catches the `ValueError` and returns an empty evidence list.
+The LLM therefore never sees ChromaDB evidence and makes decisions
+purely from receipt text and line-item patterns.
+
+### Fix
+
+Replace bare truthiness checks with explicit length/None checks:
+
+```python
+# Before (broken for numpy)
+if embeddings:
+    ...
+
+# After (works for both list and ndarray)
+if embeddings is not None and len(embeddings) > 0:
+    ...
+```
+
+Affected locations in `receipt_agent/receipt_agent/utils/chroma_helpers.py`:
+- Line 421: `if not embeddings:`
+- Line 430: `if not isinstance(embedding, list) or not embedding:`
+- Line 866: `if embeddings is None or len(embeddings) == 0:`
+- Line 884-885: `if metadatas is None or len(metadatas) == 0 or len(metadatas[0]) == 0:`
+
+The `hasattr(embedding, "tolist")` guard already exists (line 427, 459,
+504, 872) but the truthiness check before it swallows the exception.
+
+---
+
+## 2. What ChromaDB evidence SHOULD provide
+
+When working correctly, each flagged word gets a `LabelEvidence` record
+(defined at `chroma_helpers.py:330`) from `query_label_evidence()`:
+
+| Field | Type | Description |
+|---|---|---|
+| `word_text` | `str` | Text of the similar word from ChromaDB |
+| `similarity_score` | `float` | Cosine similarity (0-1), converted from L2 distance |
+| `chroma_id` | `str` | Canonical `IMAGE#...#WORD#...` identifier |
+| `label_valid` | `bool` | `True` = validated AS this label; `False` = validated as NOT this label |
+| `merchant_name` | `str` | Merchant the similar word belongs to |
+| `is_same_merchant` | `bool` | Whether the similar word is from the same merchant |
+| `position_description` | `str` | Human-readable position like "top-left" |
+| `left_neighbor` | `str` | Text of word to the left (or `<EDGE>`) |
+| `right_neighbor` | `str` | Text of word to the right (or `<EDGE>`) |
+| `evidence_source` | `str` | `"words"` or `"lines"` collection |
+
+### Consensus score
+
+`compute_label_consensus()` (line 705) produces a weighted score
+`[-1.0, +1.0]` where positive = evidence supports VALID and negative
+= evidence supports INVALID.  Same-merchant matches get a configurable
+boost (default `+0.1`).
+
+### Formatted prompt output
+
+`format_label_evidence_for_prompt()` (line 752) renders evidence into
+the LLM prompt as:
+
+```
+Evidence validated AS PRODUCT_NAME:
+  - [WORD] "Avocado" [middle-left] 92% similar (same merchant)
+  - [LINE] "Bananas 1.29" [middle-left] 87% similar
+Evidence validated as NOT PRODUCT_NAME:
+  - [WORD] "SUBTOTAL" [bottom-right] 78% similar
+
+Consensus: Evidence suggests VALID (3 for, 1 against, score: +0.42)
+```
+
+---
+
+## 3. What needs to change in the step function
+
+### 3a. Fix the numpy truthiness bug
+
+In `chroma_helpers.py`, replace all `if embeddings:` and
+`if not embeddings:` patterns with explicit checks (see Section 1).
+This single fix will restore evidence to the LLM prompt.
+
+### 3b. Trace the evidence in span outputs
+
+Currently `phase3_llm_review` spans have empty `{}` outputs.  After
+fixing the evidence bug, the handler should record per-issue evidence
+summaries in the span output so the viz-cache pipeline can extract them:
+
+```python
+trace_ctx.set_outputs({
+    "issues_reviewed": len(reviewed_issues),
+    "decisions": dict(decisions),
+    "evidence_summary": {
+        "total_evidence_items": total_evidence_count,
+        "words_with_evidence": words_with_evidence,
+        "avg_similarity": avg_similarity,
+        "avg_consensus": avg_consensus,
+    },
+})
+```
+
+### 3c. Record per-issue evidence in the reviewed issues JSON
+
+Each reviewed issue uploaded to S3 should include the evidence that was
+used (currently only `similar_word_count` is stored):
+
+```python
+reviewed_issues.append({
+    "image_id": image_id,
+    "receipt_id": receipt_id,
+    "issue": issue,
+    "llm_review": review_result,
+    "similar_word_count": len(similar_evidence),
+    # NEW: store evidence details for viz
+    "evidence": [
+        {
+            "word_text": e["word_text"],
+            "similarity_score": e["similarity_score"],
+            "label_valid": any(v["label"] == target_label for v in e["validated_as"]),
+            "evidence_source": "words",
+            "is_same_merchant": e["is_same_merchant"],
+        }
+        for e in similar_evidence[:10]
+    ],
+    "consensus_score": consensus_score,
+})
+```
+
+---
+
+## 4. Proposed viz-cache structure for evidence
+
+Once evidence is flowing and traced, a new viz-cache helper
+(`evaluator_evidence_viz_cache.py`) can extract per-receipt evidence
+summaries.  Proposed output format per receipt:
+
+```json
+{
+    "image_id": "abc-123",
+    "receipt_id": 1,
+    "merchant_name": "Sprouts Farmers Market",
+    "trace_id": "...",
+    "issues": [
+        {
+            "word_text": "Avocado",
+            "line_id": 5,
+            "word_id": 2,
+            "issue_type": "missing_label_cluster",
+            "current_label": null,
+            "suggested_label": "PRODUCT_NAME",
+            "llm_decision": "VALID",
+            "evidence": [
+                {
+                    "word_text": "Avocado",
+                    "similarity_score": 0.92,
+                    "label_valid": true,
+                    "evidence_source": "words",
+                    "is_same_merchant": true,
+                    "consensus_score": 0.65
+                }
+            ]
+        }
+    ],
+    "evidence_stats": {
+        "total_evidence_items": 45,
+        "avg_similarity": 0.84,
+        "avg_consensus": 0.42,
+        "words_with_evidence": 12,
+        "words_without_evidence": 3
+    }
+}
+```
+
+### Aggregation for the dashboard
+
+The index file would include:
+
+```json
+{
+    "total_receipts": 588,
+    "receipts_with_evidence": 0,
+    "evidence_status": "broken",
+    "evidence_error": "numpy array truthiness bug",
+    "avg_evidence_per_issue": 0.0,
+    "fix_pr": null
+}
+```
+
+Once the fix is deployed and a new batch is run, these fields would
+populate with real data and `evidence_status` would change to
+`"available"`.
+
+---
+
+## 5. Action items
+
+1. **Fix numpy truthiness bug** in `chroma_helpers.py` (4 locations)
+2. **Add evidence to span outputs** in `llm_review.py` handler
+3. **Store per-issue evidence** in reviewed issues JSON on S3
+4. **Re-run a batch** to generate traces with real evidence
+5. **Build evidence viz-cache helper** once traces contain evidence data

--- a/receipt_langsmith/tests/spark/test_evaluator_patterns_viz_cache.py
+++ b/receipt_langsmith/tests/spark/test_evaluator_patterns_viz_cache.py
@@ -1,0 +1,172 @@
+"""Tests for evaluator_patterns_viz_cache against real trace data."""
+
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+
+from receipt_langsmith.spark.evaluator_patterns_viz_cache import (
+    build_patterns_cache,
+)
+
+PARQUET_DIR = "/tmp/langsmith-traces/"
+OUTPUT_DIR = "/tmp/viz-cache-output/patterns/"
+
+
+@pytest.fixture(scope="module")
+def patterns_cache() -> list[dict]:
+    """Build the patterns cache once for all tests in this module."""
+    if not os.path.isdir(PARQUET_DIR):
+        pytest.skip("Trace parquet data not available at /tmp/langsmith-traces/")
+    return build_patterns_cache(PARQUET_DIR)
+
+
+class TestMerchantPatterns:
+    """Verify pattern extraction from llm_pattern_discovery spans."""
+
+    def test_finds_at_least_18_merchant_patterns(self, patterns_cache: list[dict]):
+        merchants_with_patterns = [
+            e for e in patterns_cache if e.get("pattern") is not None
+        ]
+        assert len(merchants_with_patterns) >= 18, (
+            f"Expected >= 18 merchants with patterns, got {len(merchants_with_patterns)}"
+        )
+
+    def test_pattern_has_required_fields(self, patterns_cache: list[dict]):
+        merchants_with_patterns = [
+            e for e in patterns_cache if e.get("pattern") is not None
+        ]
+        required_fields = {
+            "receipt_type",
+            "label_positions",
+            "grouping_rule",
+        }
+        for entry in merchants_with_patterns:
+            pattern = entry["pattern"]
+            for field in required_fields:
+                assert field in pattern, (
+                    f"Missing field '{field}' in pattern for {entry['merchant_name']}"
+                )
+
+    def test_known_merchants_present(self, patterns_cache: list[dict]):
+        merchant_names = {e["merchant_name"] for e in patterns_cache}
+        expected = {"Urbane Cafe", "CVS", "Costco Wholesale", "In-N-Out Burger"}
+        missing = expected - merchant_names
+        assert not missing, f"Expected merchants not found: {missing}"
+
+    def test_trace_ids_present(self, patterns_cache: list[dict]):
+        for entry in patterns_cache:
+            if entry.get("pattern") is not None:
+                assert len(entry["trace_ids"]) >= 1, (
+                    f"No trace_ids for {entry['merchant_name']}"
+                )
+
+
+class TestGeometricSummary:
+    """Verify geometric anomaly aggregation from flag_geometric_anomalies spans."""
+
+    def test_total_issues_match(self, patterns_cache: list[dict]):
+        total_issues = sum(
+            e["geometric_summary"]["total_issues"] for e in patterns_cache
+        )
+        assert total_issues == 1608, (
+            f"Expected 1608 total geometric issues, got {total_issues}"
+        )
+
+    def test_issue_type_breakdown(self, patterns_cache: list[dict]):
+        global_types: dict[str, int] = {}
+        for entry in patterns_cache:
+            for issue_type, count in entry["geometric_summary"]["issue_types"].items():
+                global_types[issue_type] = global_types.get(issue_type, 0) + count
+
+        assert global_types.get("missing_label_cluster", 0) == 1073, (
+            f"Expected 1073 missing_label_cluster, got {global_types.get('missing_label_cluster', 0)}"
+        )
+        assert global_types.get("missing_constellation_member", 0) == 346, (
+            f"Expected 346 missing_constellation_member, got {global_types.get('missing_constellation_member', 0)}"
+        )
+        assert global_types.get("text_label_conflict", 0) == 189, (
+            f"Expected 189 text_label_conflict, got {global_types.get('text_label_conflict', 0)}"
+        )
+
+    def test_geometric_summary_always_present(self, patterns_cache: list[dict]):
+        for entry in patterns_cache:
+            assert "geometric_summary" in entry, (
+                f"Missing geometric_summary for {entry['merchant_name']}"
+            )
+            assert "total_issues" in entry["geometric_summary"]
+            assert "issue_types" in entry["geometric_summary"]
+
+
+class TestOutputWriting:
+    """Write the cache to disk and verify it is valid JSON."""
+
+    def test_write_patterns_to_output(self, patterns_cache: list[dict]):
+        os.makedirs(OUTPUT_DIR, exist_ok=True)
+        for entry in patterns_cache:
+            merchant_slug = (
+                entry["merchant_name"]
+                .lower()
+                .replace(" ", "_")
+                .replace("'", "")
+                .replace("&", "and")
+                .replace("/", "-")
+            )
+            path = os.path.join(OUTPUT_DIR, f"{merchant_slug}.json")
+            with open(path, "w") as f:
+                json.dump(entry, f, indent=2, default=str)
+
+        # Write index file
+        index_path = os.path.join(OUTPUT_DIR, "_index.json")
+        index = {
+            "merchant_count": len(patterns_cache),
+            "merchants_with_patterns": len(
+                [e for e in patterns_cache if e.get("pattern") is not None]
+            ),
+            "total_geometric_issues": sum(
+                e["geometric_summary"]["total_issues"] for e in patterns_cache
+            ),
+            "merchants": [
+                {
+                    "merchant_name": e["merchant_name"],
+                    "has_pattern": e.get("pattern") is not None,
+                    "geometric_issues": e["geometric_summary"]["total_issues"],
+                }
+                for e in patterns_cache
+            ],
+        }
+        with open(index_path, "w") as f:
+            json.dump(index, f, indent=2)
+
+        # Verify files were written
+        written = [
+            f for f in os.listdir(OUTPUT_DIR) if f.endswith(".json")
+        ]
+        assert len(written) >= 19, (
+            f"Expected >= 19 files written (18 merchants + index), got {len(written)}"
+        )
+
+    def test_print_merchant_summary(self, patterns_cache: list[dict], capsys):
+        print("\n--- Merchant Pattern Summary ---")
+        for entry in patterns_cache:
+            name = entry["merchant_name"]
+            has_pattern = entry.get("pattern") is not None
+            geo_issues = entry["geometric_summary"]["total_issues"]
+            receipt_type = ""
+            if has_pattern:
+                receipt_type = f" [{entry['pattern'].get('receipt_type', '?')}]"
+            if has_pattern or geo_issues > 0:
+                print(
+                    f"  {name}: pattern={'yes' if has_pattern else 'no'}"
+                    f"{receipt_type}, geo_issues={geo_issues}"
+                )
+        total = sum(
+            e["geometric_summary"]["total_issues"] for e in patterns_cache
+        )
+        merchants_with_patterns = len(
+            [e for e in patterns_cache if e.get("pattern") is not None]
+        )
+        print(f"\nTotal: {merchants_with_patterns} patterns, {total} geometric issues")
+        print(f"Merchants in cache: {len(patterns_cache)}")


### PR DESCRIPTION
## Summary
- Add `evaluator_patterns_viz_cache.py` to extract per-merchant LLM-discovered patterns and aggregate geometric anomaly issues
- 18+ merchants with patterns (receipt_type, label_positions, grouping_rule, barcode_pattern, etc.)
- 1,608 geometric issues aggregated across 100+ merchants (1,073 missing_label_cluster, 346 missing_constellation_member, 189 text_label_conflict)
- Add `chromadb_evidence_gaps.md` documenting the numpy array truthiness bug that breaks all ChromaDB evidence lookups

## Evidence gaps (can't build viz from current traces)
- numpy `if embeddings:` check fails for multi-element arrays — 4 locations in `chroma_helpers.py`
- All 353 `phase3_llm_review` spans have empty outputs, LLM never sees evidence
- Doc proposes: fix truthiness checks, add evidence to span outputs, store per-issue evidence in S3 JSON

## Test plan
- [x] `build_patterns_cache("/tmp/langsmith-traces/")` finds 18+ merchant patterns
- [x] Total geometric issues = 1,608 (1,073 + 346 + 189)
- [x] All merchant patterns written to `/tmp/viz-cache-output/patterns/`
- [x] Index file with merchant summary generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)