### PR TITLE
feat(spark): integrate evaluator viz-cache helpers into merged EMR job

### DIFF
--- a/receipt_langsmith/receipt_langsmith/spark/merged_job.py
+++ b/receipt_langsmith/receipt_langsmith/spark/merged_job.py
@@ -776,7 +776,7 @@ def run_evaluator_viz_cache(
 ) -> None:
     """Run evaluator viz-cache helpers and write results to S3.
 
-    Calls each of the 4 evaluator helpers independently. If one helper
+    Calls each of the 6 evaluator helpers independently. If one helper
     fails the remaining helpers still run.
     """
     # Import helpers at call-time so the module can be loaded even when the
@@ -794,6 +794,12 @@ def run_evaluator_viz_cache(
     from receipt_langsmith.spark.evaluator_patterns_viz_cache import (
         build_patterns_cache,
     )
+    from receipt_langsmith.spark.evaluator_evidence_viz_cache import (
+        build_evidence_cache,
+    )
+    from receipt_langsmith.spark.evaluator_dedup_viz_cache import (
+        build_dedup_cache,
+    )
     # pylint: enable=import-outside-toplevel
 
     s3_client = boto3.client("s3")
@@ -804,6 +810,8 @@ def run_evaluator_viz_cache(
         ("diff", build_diff_cache, False),
         ("journey", build_journey_cache, False),
         ("patterns", build_patterns_cache, True),
+        ("evidence", build_evidence_cache, False),
+        ("dedup", build_dedup_cache, False),
     ]
 
     for prefix, helper_fn, is_merchant_keyed in helpers:


### PR DESCRIPTION
## Summary
- Adds `run_evaluator_viz_cache()` to `merged_job.py` that calls 4 new viz-cache helpers (financial math, before/after diff, decision journey, pattern discovery)
- Writes each helper's output to S3 under separate prefixes (`financial-math/`, `diff/`, `journey/`, `patterns/`) with per-type `metadata.json`
- Adds new `evaluator-viz-cache` standalone job type; also runs as part of `--job-type all` when parquet input is available
- No Step Function changes needed — existing EMR arguments already provide `--parquet-input`, `--cache-bucket`, and `--execution-id`

Depends on: #721, #722, #723, #724 (the 4 viz-cache helper modules)

## Test plan
- [ ] Verify `--job-type evaluator-viz-cache` validates required args (`--parquet-input`, `--cache-bucket`, `--execution-id`)
- [ ] Verify `--job-type all` runs evaluator viz-cache after existing phases when parquet input is present
- [ ] Verify each helper writes individual JSON files + metadata.json to correct S3 prefix
- [ ] Verify failure in one helper doesn't block the others

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added evaluator-viz-cache workflow for standalone or batch execution
  * Generates and uploads evaluation visualization cache results to S3
  * Includes validation for required parameters (parquet input, cache bucket, execution ID)
  * Implements graceful error handling to continue processing on individual failures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->