### PR TITLE
feat(spark): add ChromaDB evidence viz-cache helper

### DIFF
--- a/receipt_langsmith/receipt_langsmith/spark/evaluator_evidence_viz_cache.py
+++ b/receipt_langsmith/receipt_langsmith/spark/evaluator_evidence_viz_cache.py
@@ -1,0 +1,231 @@
+"""Helper to extract ChromaDB evidence data from LangSmith trace parquet exports.
+
+Reads parquet trace exports, finds ``ReceiptEvaluation`` root spans and their
+``phase3_llm_review`` children, then returns per-receipt evidence summaries
+suitable for visualization cache generation.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+import pyarrow.parquet as pq
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Parquet reading helpers
+# ---------------------------------------------------------------------------
+
+
+def _list_parquet_files(parquet_dir: str) -> list[Path]:
+    """Recursively find all .parquet files under *parquet_dir*."""
+    root = Path(parquet_dir)
+    if root.is_file():
+        return [root]
+    return sorted(root.rglob("*.parquet"))
+
+
+def _read_all_rows(parquet_dir: str) -> list[dict[str, Any]]:
+    """Read every row from all parquet files into a list of dicts."""
+    files = _list_parquet_files(parquet_dir)
+    if not files:
+        logger.warning("No parquet files found in %s", parquet_dir)
+        return []
+
+    rows: list[dict[str, Any]] = []
+    for path in files:
+        try:
+            table = pq.read_table(str(path))
+            rows.extend(table.to_pylist())
+        except Exception:  # noqa: BLE001
+            logger.exception("Failed to read %s", path)
+    logger.info("Read %d rows from %d parquet files", len(rows), len(files))
+    return rows
+
+
+def _parse_json(value: Any) -> Any:
+    """Parse a JSON string, returning the original value if not a string."""
+    if isinstance(value, str):
+        try:
+            return json.loads(value)
+        except (json.JSONDecodeError, ValueError):
+            return {}
+    if isinstance(value, dict):
+        return value
+    return {}
+
+
+# ---------------------------------------------------------------------------
+# Trace extraction
+# ---------------------------------------------------------------------------
+
+
+def _find_root_spans(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Return rows that are ``ReceiptEvaluation`` root spans."""
+    roots: list[dict[str, Any]] = []
+    for row in rows:
+        if row.get("name") != "ReceiptEvaluation":
+            continue
+        if row.get("parent_run_id") is not None:
+            continue
+        roots.append(row)
+    return roots
+
+
+def _extract_metadata(row: dict[str, Any]) -> dict[str, Any]:
+    """Pull image_id, receipt_id, merchant_name from ``extra.metadata``."""
+    extra = _parse_json(row.get("extra"))
+    metadata = extra.get("metadata", {}) if isinstance(extra, dict) else {}
+    return {
+        "image_id": metadata.get("image_id", ""),
+        "receipt_id": metadata.get("receipt_id"),
+        "merchant_name": metadata.get("merchant_name", ""),
+    }
+
+
+def _find_child_span(
+    rows: list[dict[str, Any]],
+    trace_id: str,
+    child_name: str,
+) -> dict[str, Any] | None:
+    """Find the first child span matching *child_name* in the same trace."""
+    for row in rows:
+        if row.get("trace_id") != trace_id:
+            continue
+        if row.get("name") == child_name and row.get("parent_run_id") is not None:
+            return row
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Evidence parsing
+# ---------------------------------------------------------------------------
+
+
+def _parse_review_decisions(
+    child_span: dict[str, Any],
+) -> list[dict[str, Any]]:
+    """Extract ``review_all_decisions`` from the child span outputs."""
+    outputs = _parse_json(child_span.get("outputs"))
+    decisions = outputs.get("review_all_decisions")
+    if isinstance(decisions, list):
+        return decisions
+    return []
+
+
+def _build_issue_entry(decision: dict[str, Any]) -> dict[str, Any]:
+    """Convert a single review_all_decisions entry to the output format."""
+    issue = decision.get("issue", {})
+    llm_review = decision.get("llm_review", {})
+    evidence = decision.get("evidence", [])
+
+    return {
+        "line_id": issue.get("line_id"),
+        "word_id": issue.get("word_id"),
+        "word_text": issue.get("word_text", ""),
+        "current_label": issue.get("current_label", ""),
+        "issue_type": issue.get("type", ""),
+        "suggested_label": issue.get("suggested_label", ""),
+        "decision": llm_review.get("decision", ""),
+        "confidence": llm_review.get("confidence", ""),
+        "reasoning": llm_review.get("reasoning", ""),
+        "consensus_score": decision.get("consensus_score", 0.0),
+        "similar_word_count": decision.get("similar_word_count", 0),
+        "evidence": evidence[:10] if isinstance(evidence, list) else [],
+    }
+
+
+def _build_summary(issues: list[dict[str, Any]]) -> dict[str, Any]:
+    """Build aggregate summary from the list of issue entries."""
+    total = len(issues)
+    with_evidence = sum(1 for i in issues if i.get("similar_word_count", 0) > 0)
+
+    consensus_scores = [
+        i["consensus_score"]
+        for i in issues
+        if isinstance(i.get("consensus_score"), (int, float))
+    ]
+    avg_consensus = (
+        sum(consensus_scores) / len(consensus_scores) if consensus_scores else 0.0
+    )
+
+    all_top_sims: list[float] = []
+    for issue in issues:
+        for ev in issue.get("evidence", []):
+            score = ev.get("similarity_score")
+            if isinstance(score, (int, float)):
+                all_top_sims.append(float(score))
+    avg_similarity = (
+        sum(all_top_sims) / len(all_top_sims) if all_top_sims else 0.0
+    )
+
+    decisions: dict[str, int] = {"VALID": 0, "INVALID": 0, "NEEDS_REVIEW": 0}
+    for issue in issues:
+        d = (issue.get("decision") or "").upper()
+        if d in decisions:
+            decisions[d] += 1
+
+    return {
+        "total_issues_reviewed": total,
+        "issues_with_evidence": with_evidence,
+        "avg_consensus_score": round(avg_consensus, 4),
+        "avg_similarity": round(avg_similarity, 4),
+        "decisions": decisions,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def build_evidence_cache(parquet_dir: str) -> list[dict[str, Any]]:
+    """Build per-receipt evidence cache from LangSmith parquet exports.
+
+    Args:
+        parquet_dir: Path to a directory containing parquet files
+            (or a single parquet file).
+
+    Returns:
+        List of per-receipt dicts with ``image_id``, ``receipt_id``,
+        ``merchant_name``, ``trace_id``, ``issues_with_evidence``,
+        and ``summary``.
+    """
+    rows = _read_all_rows(parquet_dir)
+    if not rows:
+        return []
+
+    roots = _find_root_spans(rows)
+    logger.info("Found %d ReceiptEvaluation root spans", len(roots))
+
+    results: list[dict[str, Any]] = []
+    for root in roots:
+        trace_id = root.get("trace_id", "")
+        meta = _extract_metadata(root)
+
+        child = _find_child_span(rows, trace_id, "phase3_llm_review")
+        if child is None:
+            continue
+
+        decisions = _parse_review_decisions(child)
+        if not decisions:
+            continue
+
+        issues = [_build_issue_entry(d) for d in decisions]
+
+        results.append({
+            "image_id": meta["image_id"],
+            "receipt_id": meta["receipt_id"],
+            "merchant_name": meta["merchant_name"],
+            "trace_id": trace_id,
+            "issues_with_evidence": issues,
+            "summary": _build_summary(issues),
+        })
+
+    logger.info("Built evidence cache for %d receipts", len(results))
+    return results

--- a/receipt_langsmith/tests/spark/test_evaluator_evidence_viz_cache.py
+++ b/receipt_langsmith/tests/spark/test_evaluator_evidence_viz_cache.py
@@ -1,0 +1,485 @@
+"""Tests for evaluator_evidence_viz_cache helper."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+from receipt_langsmith.spark.evaluator_evidence_viz_cache import (
+    build_evidence_cache,
+    _build_issue_entry,
+    _build_summary,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+EVIDENCE_ITEMS = [
+    {
+        "word_text": "5.99",
+        "similarity_score": 0.92,
+        "label_valid": True,
+        "evidence_source": "merchant_history",
+        "is_same_merchant": True,
+    },
+    {
+        "word_text": "6.49",
+        "similarity_score": 0.87,
+        "label_valid": True,
+        "evidence_source": "global",
+        "is_same_merchant": False,
+    },
+]
+
+REVIEW_DECISION: dict[str, Any] = {
+    "issue": {
+        "line_id": 3,
+        "word_id": 1,
+        "word_text": "5.99",
+        "current_label": "LINE_TOTAL",
+        "type": "low_confidence",
+        "suggested_label": "LINE_TOTAL",
+    },
+    "llm_review": {
+        "decision": "VALID",
+        "reasoning": "Price is consistent with merchant history",
+        "suggested_label": "LINE_TOTAL",
+        "confidence": "HIGH",
+    },
+    "similar_word_count": 8,
+    "evidence": EVIDENCE_ITEMS,
+    "consensus_score": 0.85,
+}
+
+
+def _make_trace_row(
+    *,
+    row_id: str = "run-1",
+    trace_id: str = "trace-1",
+    name: str = "ReceiptEvaluation",
+    parent_run_id: str | None = None,
+    extra: dict | str | None = None,
+    outputs: dict | str | None = None,
+) -> dict[str, Any]:
+    """Build a minimal trace row dict."""
+    row: dict[str, Any] = {
+        "id": row_id,
+        "trace_id": trace_id,
+        "name": name,
+        "parent_run_id": parent_run_id,
+        "run_type": "chain",
+        "status": "success",
+        "start_time": "2025-01-01T00:00:00",
+        "end_time": "2025-01-01T00:00:05",
+    }
+    if extra is not None:
+        row["extra"] = json.dumps(extra) if isinstance(extra, dict) else extra
+    else:
+        row["extra"] = None
+    if outputs is not None:
+        row["outputs"] = (
+            json.dumps(outputs) if isinstance(outputs, dict) else outputs
+        )
+    else:
+        row["outputs"] = None
+    return row
+
+
+def _write_parquet(rows: list[dict[str, Any]], directory: str) -> str:
+    """Write rows as a parquet file and return the directory path."""
+    table = pa.table({k: [r.get(k) for r in rows] for k in rows[0]})
+    pq.write_table(table, os.path.join(directory, "traces.parquet"))
+    return directory
+
+
+def _sample_rows() -> list[dict[str, Any]]:
+    """Return a standard set of root + child rows for testing."""
+    root = _make_trace_row(
+        row_id="root-1",
+        trace_id="trace-1",
+        name="ReceiptEvaluation",
+        parent_run_id=None,
+        extra={
+            "metadata": {
+                "image_id": "img-abc",
+                "receipt_id": 1,
+                "merchant_name": "Test Cafe",
+            }
+        },
+    )
+    child = _make_trace_row(
+        row_id="child-1",
+        trace_id="trace-1",
+        name="phase3_llm_review",
+        parent_run_id="root-1",
+        outputs={"review_all_decisions": [REVIEW_DECISION]},
+    )
+    return [root, child]
+
+
+# ---------------------------------------------------------------------------
+# Test: receipt structure has required fields
+# ---------------------------------------------------------------------------
+
+
+class TestReceiptStructure:
+    """Receipts returned by build_evidence_cache have the required fields."""
+
+    def test_required_top_level_fields(self, tmp_path: Path):
+        rows = _sample_rows()
+        _write_parquet(rows, str(tmp_path))
+
+        results = build_evidence_cache(str(tmp_path))
+        assert len(results) == 1
+
+        receipt = results[0]
+        assert "image_id" in receipt
+        assert "receipt_id" in receipt
+        assert "merchant_name" in receipt
+        assert "trace_id" in receipt
+        assert "issues_with_evidence" in receipt
+        assert "summary" in receipt
+
+    def test_metadata_values(self, tmp_path: Path):
+        rows = _sample_rows()
+        _write_parquet(rows, str(tmp_path))
+
+        receipt = build_evidence_cache(str(tmp_path))[0]
+        assert receipt["image_id"] == "img-abc"
+        assert receipt["receipt_id"] == 1
+        assert receipt["merchant_name"] == "Test Cafe"
+        assert receipt["trace_id"] == "trace-1"
+
+
+# ---------------------------------------------------------------------------
+# Test: evidence items have required fields
+# ---------------------------------------------------------------------------
+
+
+class TestEvidenceItems:
+    """Evidence entries have the expected shape."""
+
+    def test_evidence_required_fields(self, tmp_path: Path):
+        rows = _sample_rows()
+        _write_parquet(rows, str(tmp_path))
+
+        receipt = build_evidence_cache(str(tmp_path))[0]
+        evidence = receipt["issues_with_evidence"][0]["evidence"]
+        assert len(evidence) == 2
+
+        for item in evidence:
+            assert "word_text" in item
+            assert "similarity_score" in item
+            assert "label_valid" in item
+            assert "evidence_source" in item
+            assert "is_same_merchant" in item
+
+    def test_evidence_values(self, tmp_path: Path):
+        rows = _sample_rows()
+        _write_parquet(rows, str(tmp_path))
+
+        receipt = build_evidence_cache(str(tmp_path))[0]
+        first_ev = receipt["issues_with_evidence"][0]["evidence"][0]
+        assert first_ev["word_text"] == "5.99"
+        assert first_ev["similarity_score"] == 0.92
+        assert first_ev["label_valid"] is True
+        assert first_ev["evidence_source"] == "merchant_history"
+        assert first_ev["is_same_merchant"] is True
+
+
+# ---------------------------------------------------------------------------
+# Test: issue entries have required fields
+# ---------------------------------------------------------------------------
+
+
+class TestIssueEntries:
+    """Each issue entry has the expected keys from the task spec."""
+
+    def test_issue_required_fields(self, tmp_path: Path):
+        rows = _sample_rows()
+        _write_parquet(rows, str(tmp_path))
+
+        receipt = build_evidence_cache(str(tmp_path))[0]
+        issue = receipt["issues_with_evidence"][0]
+
+        required_keys = {
+            "line_id",
+            "word_id",
+            "word_text",
+            "current_label",
+            "issue_type",
+            "suggested_label",
+            "decision",
+            "confidence",
+            "reasoning",
+            "consensus_score",
+            "similar_word_count",
+            "evidence",
+        }
+        assert required_keys.issubset(issue.keys())
+
+    def test_issue_values(self, tmp_path: Path):
+        rows = _sample_rows()
+        _write_parquet(rows, str(tmp_path))
+
+        issue = build_evidence_cache(str(tmp_path))[0]["issues_with_evidence"][0]
+        assert issue["line_id"] == 3
+        assert issue["word_id"] == 1
+        assert issue["word_text"] == "5.99"
+        assert issue["current_label"] == "LINE_TOTAL"
+        assert issue["issue_type"] == "low_confidence"
+        assert issue["decision"] == "VALID"
+        assert issue["confidence"] == "HIGH"
+        assert issue["consensus_score"] == 0.85
+        assert issue["similar_word_count"] == 8
+
+
+# ---------------------------------------------------------------------------
+# Test: summary has correct keys
+# ---------------------------------------------------------------------------
+
+
+class TestSummary:
+    """The summary dict has the correct shape and values."""
+
+    def test_summary_keys(self, tmp_path: Path):
+        rows = _sample_rows()
+        _write_parquet(rows, str(tmp_path))
+
+        summary = build_evidence_cache(str(tmp_path))[0]["summary"]
+        assert "total_issues_reviewed" in summary
+        assert "issues_with_evidence" in summary
+        assert "avg_consensus_score" in summary
+        assert "avg_similarity" in summary
+        assert "decisions" in summary
+
+    def test_summary_values(self, tmp_path: Path):
+        rows = _sample_rows()
+        _write_parquet(rows, str(tmp_path))
+
+        summary = build_evidence_cache(str(tmp_path))[0]["summary"]
+        assert summary["total_issues_reviewed"] == 1
+        assert summary["issues_with_evidence"] == 1  # similar_word_count=8 > 0
+        assert summary["avg_consensus_score"] == 0.85
+        assert summary["decisions"]["VALID"] == 1
+        assert summary["decisions"]["INVALID"] == 0
+        assert summary["decisions"]["NEEDS_REVIEW"] == 0
+
+    def test_avg_similarity(self, tmp_path: Path):
+        rows = _sample_rows()
+        _write_parquet(rows, str(tmp_path))
+
+        summary = build_evidence_cache(str(tmp_path))[0]["summary"]
+        expected = round((0.92 + 0.87) / 2, 4)
+        assert summary["avg_similarity"] == expected
+
+
+# ---------------------------------------------------------------------------
+# Test: write sample outputs to /tmp/viz-cache-output/evidence/
+# ---------------------------------------------------------------------------
+
+
+class TestWriteSampleOutput:
+    """Write sample output to the expected cache directory for integration."""
+
+    def test_write_sample(self, tmp_path: Path):
+        rows = _sample_rows()
+        _write_parquet(rows, str(tmp_path))
+
+        results = build_evidence_cache(str(tmp_path))
+
+        output_dir = Path("/tmp/viz-cache-output/evidence")
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        for receipt in results:
+            image_id = receipt["image_id"]
+            receipt_id = receipt["receipt_id"]
+            filename = f"evidence-{image_id}-{receipt_id}.json"
+            output_path = output_dir / filename
+            output_path.write_text(json.dumps(receipt, indent=2))
+
+        assert (output_dir / "evidence-img-abc-1.json").exists()
+        content = json.loads(
+            (output_dir / "evidence-img-abc-1.json").read_text()
+        )
+        assert content["image_id"] == "img-abc"
+        assert len(content["issues_with_evidence"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# Test: edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    """Edge cases that should be handled gracefully."""
+
+    def test_empty_directory(self, tmp_path: Path):
+        results = build_evidence_cache(str(tmp_path))
+        assert results == []
+
+    def test_root_without_child(self, tmp_path: Path):
+        """Root span with no phase3_llm_review child is skipped."""
+        root = _make_trace_row(
+            row_id="root-1",
+            trace_id="trace-1",
+            name="ReceiptEvaluation",
+            extra={"metadata": {"image_id": "img-1", "receipt_id": 1}},
+        )
+        _write_parquet([root], str(tmp_path))
+
+        results = build_evidence_cache(str(tmp_path))
+        assert results == []
+
+    def test_child_with_empty_decisions(self, tmp_path: Path):
+        """Child span with empty review_all_decisions is skipped."""
+        root = _make_trace_row(
+            row_id="root-1",
+            trace_id="trace-1",
+            name="ReceiptEvaluation",
+            extra={"metadata": {"image_id": "img-1", "receipt_id": 1}},
+        )
+        child = _make_trace_row(
+            row_id="child-1",
+            trace_id="trace-1",
+            name="phase3_llm_review",
+            parent_run_id="root-1",
+            outputs={"review_all_decisions": []},
+        )
+        _write_parquet([root, child], str(tmp_path))
+
+        results = build_evidence_cache(str(tmp_path))
+        assert results == []
+
+    def test_multiple_receipts(self, tmp_path: Path):
+        """Multiple ReceiptEvaluation roots produce multiple entries."""
+        rows = _sample_rows()  # trace-1
+
+        root2 = _make_trace_row(
+            row_id="root-2",
+            trace_id="trace-2",
+            name="ReceiptEvaluation",
+            extra={
+                "metadata": {
+                    "image_id": "img-def",
+                    "receipt_id": 2,
+                    "merchant_name": "Another Store",
+                }
+            },
+        )
+        child2 = _make_trace_row(
+            row_id="child-2",
+            trace_id="trace-2",
+            name="phase3_llm_review",
+            parent_run_id="root-2",
+            outputs={
+                "review_all_decisions": [
+                    {
+                        "issue": {
+                            "line_id": 1,
+                            "word_id": 0,
+                            "word_text": "TAX",
+                            "current_label": "TAX",
+                            "type": "mismatch",
+                            "suggested_label": "O",
+                        },
+                        "llm_review": {
+                            "decision": "INVALID",
+                            "reasoning": "Not a tax value",
+                            "suggested_label": "O",
+                            "confidence": "MEDIUM",
+                        },
+                        "similar_word_count": 0,
+                        "evidence": [],
+                        "consensus_score": -0.5,
+                    }
+                ]
+            },
+        )
+        rows.extend([root2, child2])
+        _write_parquet(rows, str(tmp_path))
+
+        results = build_evidence_cache(str(tmp_path))
+        assert len(results) == 2
+
+        ids = {(r["image_id"], r["receipt_id"]) for r in results}
+        assert ("img-abc", 1) in ids
+        assert ("img-def", 2) in ids
+
+    def test_evidence_capped_at_10(self):
+        """_build_issue_entry caps evidence to 10 items."""
+        many_evidence = [
+            {
+                "word_text": f"item-{i}",
+                "similarity_score": 0.5,
+                "label_valid": True,
+                "evidence_source": "global",
+                "is_same_merchant": False,
+            }
+            for i in range(15)
+        ]
+        decision = {
+            "issue": {"line_id": 1, "word_id": 0, "word_text": "x"},
+            "llm_review": {"decision": "VALID"},
+            "similar_word_count": 15,
+            "evidence": many_evidence,
+            "consensus_score": 0.0,
+        }
+        entry = _build_issue_entry(decision)
+        assert len(entry["evidence"]) == 10
+
+
+# ---------------------------------------------------------------------------
+# Test: _build_summary unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestBuildSummaryUnit:
+    """Direct unit tests for _build_summary."""
+
+    def test_no_issues(self):
+        summary = _build_summary([])
+        assert summary["total_issues_reviewed"] == 0
+        assert summary["issues_with_evidence"] == 0
+        assert summary["avg_consensus_score"] == 0.0
+        assert summary["avg_similarity"] == 0.0
+        assert summary["decisions"] == {"VALID": 0, "INVALID": 0, "NEEDS_REVIEW": 0}
+
+    def test_mixed_decisions(self):
+        issues = [
+            {
+                "decision": "VALID",
+                "consensus_score": 0.8,
+                "similar_word_count": 5,
+                "evidence": [{"similarity_score": 0.9}],
+            },
+            {
+                "decision": "INVALID",
+                "consensus_score": -0.6,
+                "similar_word_count": 0,
+                "evidence": [],
+            },
+            {
+                "decision": "NEEDS_REVIEW",
+                "consensus_score": 0.1,
+                "similar_word_count": 2,
+                "evidence": [{"similarity_score": 0.7}, {"similarity_score": 0.5}],
+            },
+        ]
+        summary = _build_summary(issues)
+        assert summary["total_issues_reviewed"] == 3
+        assert summary["issues_with_evidence"] == 2
+        assert summary["decisions"]["VALID"] == 1
+        assert summary["decisions"]["INVALID"] == 1
+        assert summary["decisions"]["NEEDS_REVIEW"] == 1
+        assert summary["avg_consensus_score"] == round((0.8 - 0.6 + 0.1) / 3, 4)
+        assert summary["avg_similarity"] == round((0.9 + 0.7 + 0.5) / 3, 4)


### PR DESCRIPTION
## Summary
- New Spark helper `evaluator_evidence_viz_cache.py` that extracts ChromaDB evidence data from LangSmith trace parquet exports
- Reads `phase3_llm_review` spans to extract per-issue evidence (similar words, consensus scores, LLM decisions)
- Returns per-receipt dicts with `issues_with_evidence` array and `summary` stats (avg consensus, avg similarity, decision breakdown)
- Includes test file with structure validation tests

Enabled by PR #733 which fixed the numpy truthiness bug — evidence data now flows in traces.

## Test plan
- [ ] Verify helper reads parquet and produces per-receipt evidence dicts
- [ ] Verify each issue has evidence array with word_text, similarity_score, label_valid, evidence_source, is_same_merchant
- [ ] Verify summary contains total_issues_reviewed, issues_with_evidence, avg_consensus_score, decisions breakdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)