### PR TITLE
fix(spark): parse unified evaluator JSON correctly for evidence cache

### DIFF
--- a/receipt_langsmith/receipt_langsmith/spark/evaluator_evidence_viz_cache.py
+++ b/receipt_langsmith/receipt_langsmith/spark/evaluator_evidence_viz_cache.py
@@ -1,8 +1,9 @@
-"""Helper to extract ChromaDB evidence data from LangSmith traces.
+"""Helper to extract ChromaDB evidence data for visualization cache.
 
-Reads parquet trace exports, finds ``ReceiptEvaluation`` root spans and their
-``phase3_llm_review`` children, then returns per-receipt evidence summaries
-suitable for visualization cache generation.
+Preferred source is unified evaluator JSON rows (contains
+``review_all_decisions`` with per-issue evidence). For backwards
+compatibility, this helper can also parse LangSmith trace exports from
+``phase3_llm_review`` child spans when that payload is present.
 """
 
 from __future__ import annotations
@@ -228,6 +229,47 @@ def _build_summary(issues: list[dict[str, Any]]) -> dict[str, Any]:
 
 
 # ---------------------------------------------------------------------------
+# Unified results parsing (preferred source)
+# ---------------------------------------------------------------------------
+
+
+def _build_from_unified_rows(
+    unified_rows: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Build evidence payloads from unified evaluator output rows."""
+    results: list[dict[str, Any]] = []
+
+    for row in unified_rows:
+        decisions = row.get("review_all_decisions")
+        if not isinstance(decisions, list) or not decisions:
+            continue
+
+        image_id = row.get("image_id")
+        receipt_id = row.get("receipt_id")
+        if image_id in (None, "") or receipt_id is None:
+            continue
+
+        issues = [
+            _build_issue_entry(d) for d in decisions if isinstance(d, dict)
+        ]
+        if not issues:
+            continue
+
+        results.append(
+            {
+                "image_id": image_id,
+                "receipt_id": receipt_id,
+                "merchant_name": row.get("merchant_name", ""),
+                "trace_id": row.get("trace_id", ""),
+                "issues_with_evidence": issues,
+                "summary": _build_summary(issues),
+            }
+        )
+
+    return results
+
+
+# ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
 
@@ -236,22 +278,42 @@ def build_evidence_cache(
     parquet_dir: str | None = None,
     *,
     rows: list[dict[str, Any]] | None = None,
+    unified_rows: list[dict[str, Any]] | None = None,
 ) -> list[dict[str, Any]]:
-    """Build per-receipt evidence cache from LangSmith parquet exports.
+    """Build per-receipt evidence cache.
 
     Args:
         parquet_dir: Path to a directory containing parquet files
             (or a single parquet file).
         rows: Optional preloaded trace rows.
+        unified_rows: Optional preloaded unified evaluator rows.
+            If this yields evidence payloads, it is used as the
+            source of truth.
 
     Returns:
         List of per-receipt dicts with ``image_id``, ``receipt_id``,
         ``merchant_name``, ``trace_id``, ``issues_with_evidence``,
         and ``summary``.
     """
+    if unified_rows:
+        unified_results = _build_from_unified_rows(unified_rows)
+        if unified_results:
+            logger.info(
+                "Built evidence cache for %d receipts from unified rows",
+                len(unified_results),
+            )
+            return unified_results
+
+        logger.info(
+            "Unified rows provided but no evidence records found; "
+            "falling back to trace parsing",
+        )
+
     if rows is None:
         if parquet_dir is None:
-            raise ValueError("Either parquet_dir or rows must be provided")
+            raise ValueError(
+                "Provide unified_rows or (parquet_dir / rows) for evidence",
+            )
         rows = _read_all_rows(parquet_dir)
     if not rows:
         return []

--- a/receipt_langsmith/tests/spark/test_merged_job_evaluator_viz_cache.py
+++ b/receipt_langsmith/tests/spark/test_merged_job_evaluator_viz_cache.py
@@ -293,8 +293,10 @@ def test_run_evaluator_cache_reuses_shared_rows(
             parquet_dir: str | None = None,
             *,
             rows: list[dict[str, Any]] | None = None,
+            unified_rows: list[dict[str, Any]] | None = None,
         ) -> list[dict[str, Any]]:
             del parquet_dir
+            del unified_rows
             captured_rows[prefix] = rows
             if merchant_keyed:
                 return [{"merchant_name": "Test Merchant"}]
@@ -366,3 +368,49 @@ def test_run_evaluator_cache_reuses_shared_rows(
         "dedup",
     ):
         assert f"{prefix}/metadata.json" in keys
+
+
+def test_load_unified_rows_uses_multiline_reader(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unified rows should be read via read_json_df (multi-line JSON safe)."""
+    import receipt_langsmith.spark.merged_job as merged_job_mod
+
+    unified_rows = [
+        {
+            "image_id": "img-1",
+            "receipt_id": 1,
+            "merchant_name": "Store",
+            "trace_id": "trace-1",
+            "review_all_decisions": [{"issue": {"line_id": 1}}],
+        },
+        {
+            "image_id": "img-2",
+            "receipt_id": 2,
+            "merchant_name": "Store",
+            "trace_id": "trace-2",
+            "review_all_decisions": [],
+        },
+    ]
+
+    def _fake_read_json_df(
+        spark: Any,
+        path: str,
+        schema: Any = None,
+        multi_line: bool = True,
+    ) -> _FakeDataFrame:
+        del spark, schema
+        assert path == "s3://batch-bucket/unified/exec-1/"
+        assert multi_line is True
+        return _FakeDataFrame(unified_rows)
+
+    monkeypatch.setattr(merged_job_mod, "read_json_df", _fake_read_json_df)
+    rows = merged_job_mod._load_unified_rows(
+        spark=cast(Any, object()),
+        batch_bucket="batch-bucket",
+        execution_id="exec-1",
+    )
+
+    assert len(rows) == 2
+    assert rows[0]["image_id"] == "img-1"
+    assert isinstance(rows[0]["review_all_decisions"], list)


### PR DESCRIPTION
# Pull Request

## Summary

- Fix `_load_unified_rows` in `merged_job.py` to read unified evaluator JSON with multi-line parsing (`read_json_df`) so pretty-printed JSON files are parsed as one object per file.
- Preserve evidence helper behavior that prefers unified `review_all_decisions` and falls back to trace parsing only when needed.
- Add/extend Spark unit tests to lock in unified-row evidence extraction and multi-line unified-row loading behavior.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that resolves an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [x] 🧪 Test changes or improved coverage

## Which Package(s) are Affected?

- [ ] receipt_dynamo
- [ ] receipt_dynamo_stream
- [ ] receipt_chroma
- [ ] receipt_upload
- [ ] receipt_places
- [ ] receipt_agent
- [ ] Portfolio (TypeScript/Next.js)
- [ ] Infrastructure (Pulumi)
- [ ] CI/CD Workflows
- [x] Other: `receipt_langsmith` (Spark / evaluator viz-cache)

## Testing

- [x] Unit tests pass locally (`pytest` or `npm test`)
- [ ] Integration tests pass locally (if applicable)
- [x] Added or updated tests for new functionality
- [x] All existing tests still pass with these changes
- [x] Manual testing completed (if applicable)

Manual validation in dev:
- Pulumi dev deployment completed (updated EMR image and `merged_job.py` artifact).
- Step Function execution `evidence-smoke2-20260208182918` succeeded.
- Evidence metadata now shows non-zero count: `evidence/metadata.json` => `count: 7`.
- API validation: `GET /label_evaluator/evidence` returns `execution_id=evidence-smoke2-20260208182918` and `total_count=7` with non-empty `issues_with_evidence` payloads.

## Documentation & Code Quality

- [x] Documentation or comments updated for complex logic
- [ ] README updated (if introducing new feature/dependency)
- [ ] TypeDoc/JSDoc comments added where needed
- [x] No new warnings or linting issues introduced
- [x] Code follows project style guidelines

## Related Issues

- Relates to #726

## Impact Analysis

- Fixes the evidence cache population gap where unified rows were previously parsed incorrectly and produced `evidence` count `0`.
- No contract changes to evidence API response shape.
- Other evaluator viz-cache helpers are unchanged functionally.

## Deployment Notes

- Deploy stack (`pulumi up --stack dev`) so updated Spark script/artifact is published.
- Run a small label-evaluator Step Function execution and verify `s3://<viz-cache-bucket>/evidence/metadata.json` has non-zero `count`.
- Optional smoke: call `/label_evaluator/evidence` and confirm `total_count > 0`.

---

This PR will be reviewed by CI/CD checks and automated analysis tools. Please ensure all checks pass before requesting human review.
