### PR TITLE
perf: scope LangSmith exports per execution and tune Spark ingestion

### DIFF
--- a/infra/label_evaluator_step_functions/step_function_states.py
+++ b/infra/label_evaluator_step_functions/step_function_states.py
@@ -514,6 +514,7 @@ def build_langsmith_export_states(emr: EmrConfig) -> dict[str, Any]:
                 "FunctionName": emr.trigger_export_lambda_arn,
                 "Payload": {
                     "project_name.$": "$.init.langchain_project",
+                    "start_time.$": "$.init.start_time",
                 },
             },
             "ResultSelector": {
@@ -614,6 +615,11 @@ def build_emr_states(emr: EmrConfig) -> dict[str, Any]:
     artifacts_bucket = emr.spark_artifacts_bucket
     spark_submit_params = (
         "--conf spark.sql.legacy.parquet.nanosAsLong=true "
+        "--conf spark.sql.adaptive.enabled=true "
+        "--conf spark.sql.files.openCostInBytes=134217728 "
+        "--conf spark.sql.files.maxPartitionBytes=268435456 "
+        "--conf spark.eventLog.enabled=true "
+        f"--conf spark.eventLog.dir=s3://{artifacts_bucket}/spark-event-logs/ "
         "--conf spark.sql.parquet.enableVectorizedReader=false "
         "--conf spark.dynamicAllocation.enabled=false "
         "--conf spark.executor.cores=2 "

--- a/infra/qa_agent_step_functions/infrastructure.py
+++ b/infra/qa_agent_step_functions/infrastructure.py
@@ -617,6 +617,7 @@ def _build_state_machine_definition(
                     "FunctionName": trigger_export_arn,
                     "Payload": {
                         "project_name.$": "$.questions_result.langchain_project",
+                        "start_time.$": "$$.Execution.StartTime",
                         "export_fields": [
                             "id",
                             "name",
@@ -748,6 +749,11 @@ def _build_state_machine_definition(
                                 ")"
                             ),
                             "SparkSubmitParameters": (
+                                "--conf spark.sql.adaptive.enabled=true "
+                                "--conf spark.sql.files.openCostInBytes=134217728 "
+                                "--conf spark.sql.files.maxPartitionBytes=268435456 "
+                                "--conf spark.eventLog.enabled=true "
+                                f"--conf spark.eventLog.dir=s3://{spark_artifacts_bucket}/spark-event-logs/ "
                                 "--conf spark.executor.memory=4g "
                                 "--conf spark.executor.cores=2 "
                                 "--conf spark.dynamicAllocation.enabled=true "

--- a/receipt_langsmith/receipt_langsmith/spark/label_validation_viz_cache_job.py
+++ b/receipt_langsmith/receipt_langsmith/spark/label_validation_viz_cache_job.py
@@ -21,6 +21,7 @@ Usage:
         --conf spark.sql.legacy.parquet.nanosAsLong=true \
         label_validation_viz_cache_job.py \
         --parquet-bucket langsmith-export-bucket \
+        --parquet-prefix traces/export_id=<export-id>/ \
         --cache-bucket viz-cache-bucket \
         --receipts-json s3://cache-bucket/receipts-lookup.json
 """
@@ -57,9 +58,11 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--parquet-prefix",
-        default="traces/",
-        help="Parquet prefix (default: traces/)."
-        " If not a specific export_id, the latest export is used.",
+        required=True,
+        help=(
+            "Parquet prefix for a specific export, e.g. "
+            "'traces/export_id=<export-id>/'"
+        ),
     )
     add_cache_bucket_arg(parser)
     add_receipts_json_arg(parser)


### PR DESCRIPTION
# Pull Request

## Summary

- Scope LangSmith exports and Spark reads to explicit execution windows / `export_id` paths to avoid scanning broad historical prefixes.
- Remove expensive "latest export" discovery/listing in label-validation cache generation, and pass `--parquet-prefix traces/export_id=<id>/` directly from Step Functions.
- Add Spark AQE + file scan packing + event log configuration across label-validation, evaluator, and QA EMR submit paths; plus quick Spark job wins (`count()` consolidation and driver-collection guardrail logging).

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that resolves an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [x] 🔧 Refactoring (no functional changes)
- [x] ⚡ Performance improvement
- [ ] 🧪 Test changes or improved coverage

## Which Package(s) are Affected?

- [ ] receipt_dynamo
- [ ] receipt_dynamo_stream
- [ ] receipt_chroma
- [ ] receipt_upload
- [ ] receipt_places
- [ ] receipt_agent
- [ ] Portfolio (TypeScript/Next.js)
- [x] Infrastructure (Pulumi)
- [ ] CI/CD Workflows
- [x] Other: `receipt_langsmith`

## Testing

- [x] Unit tests pass locally (`pytest` or `npm test`)
- [ ] Integration tests pass locally (if applicable)
- [ ] Added or updated tests for new functionality
- [x] All existing tests still pass with these changes
- [ ] Manual testing completed (if applicable)

Executed:
- `pytest receipt_langsmith/tests/spark -q` (88 passed)
- `python3 -m py_compile` on all touched Python modules

## Documentation & Code Quality

- [x] Documentation or comments updated for complex logic
- [ ] README updated (if introducing new feature/dependency)
- [ ] TypeDoc/JSDoc comments added where needed
- [x] No new warnings or linting issues introduced
- [x] Code follows project style guidelines

## Related Issues

- N/A

## Impact Analysis

- Positive: lower S3 listing/scan overhead, narrower export scope, and more deterministic EMR inputs.
- Behavioral tightening: label-validation cache job now requires an explicit export prefix containing `export_id=`.
- Operational visibility improved via Spark event logs.

## Deployment Notes

- Requires Pulumi deployment for Step Function / Lambda inline-code changes.
- Validate state machine input wiring for `start_time` and `export_id` usage in dev stack before prod rollout.
- Rollback is straightforward by reverting this PR and redeploying Pulumi.

---

This PR will be reviewed by CI/CD checks and automated analysis tools. Please ensure all checks pass before requesting human review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configurable export time windows for bulk data exports with customizable start and end times
  * Customizable export field selection for export payloads
  * Enhanced export validation and error handling

* **Improvements**
  * Optimized Spark job configurations for better performance and event logging
  * Improved tracing and debugging capabilities through enhanced logging

<!-- end of auto-generated comment: release notes by coderabbit.ai -->