### PR TITLE
Fix phase3 label review consensus routing and unlabeled parsing

### DIFF
--- a/infra/label_evaluator_step_functions/lambdas/unified_receipt_evaluator.py
+++ b/infra/label_evaluator_step_functions/lambdas/unified_receipt_evaluator.py
@@ -1339,22 +1339,34 @@ async def unified_receipt_evaluator(
                         # Then short-circuit high-consensus cases without an LLM
                         # call to reduce latency/cost and make decision provenance
                         # explicit in outputs.
-                        consensus_threshold = float(
-                            os.environ.get(
-                                "LLM_REVIEW_CONSENSUS_THRESHOLD", "0.75"
-                            )
+                        raw_threshold = os.environ.get(
+                            "LLM_REVIEW_CONSENSUS_THRESHOLD", "0.75"
                         )
+                        try:
+                            consensus_threshold = float(raw_threshold)
+                        except (TypeError, ValueError):
+                            logger.warning(
+                                "Invalid LLM_REVIEW_CONSENSUS_THRESHOLD '%s'; "
+                                "falling back to 0.75",
+                                raw_threshold,
+                            )
+                            consensus_threshold = 0.75
                         consensus_threshold = min(
                             max(consensus_threshold, 0.0), 1.0
                         )
-                        consensus_min_evidence = max(
-                            1,
-                            int(
-                                os.environ.get(
-                                    "LLM_REVIEW_CONSENSUS_MIN_EVIDENCE", "4"
-                                )
-                            ),
+                        raw_min_evidence = os.environ.get(
+                            "LLM_REVIEW_CONSENSUS_MIN_EVIDENCE", "4"
                         )
+                        try:
+                            parsed_min_evidence = int(raw_min_evidence)
+                        except (TypeError, ValueError):
+                            logger.warning(
+                                "Invalid LLM_REVIEW_CONSENSUS_MIN_EVIDENCE '%s'; "
+                                "falling back to 4",
+                                raw_min_evidence,
+                            )
+                            parsed_min_evidence = 4
+                        consensus_min_evidence = max(1, parsed_min_evidence)
 
                         issues_with_context = []
                         for issue_index, issue in enumerate(

--- a/receipt_agent/receipt_agent/prompts/label_evaluator.py
+++ b/receipt_agent/receipt_agent/prompts/label_evaluator.py
@@ -862,17 +862,15 @@ def _infer_label_from_reasoning(reasoning: str) -> Optional[str]:
         return None
 
     upper_reasoning = reasoning.upper()
-    if not any(
-        marker in upper_reasoning
-        for marker in (
-            "SHOULD BE",
-            "LABEL SHOULD BE",
-            "CORRECT LABEL",
-            "SET TO",
-            "MARK AS",
-            "USE",
-        )
-    ):
+    assignment_markers = (
+        r"\bSHOULD BE\b",
+        r"\bLABEL SHOULD BE\b",
+        r"\bCORRECT LABEL\b",
+        r"\bSET TO\b",
+        r"\bMARK AS\b",
+        r"\bUSE\b",
+    )
+    if not any(re.search(pattern, upper_reasoning) for pattern in assignment_markers):
         return None
 
     for label in sorted(CORE_LABELS_SET, key=len, reverse=True):

--- a/receipt_agent/tests/test_label_evaluator_prompt_parsing.py
+++ b/receipt_agent/tests/test_label_evaluator_prompt_parsing.py
@@ -70,3 +70,19 @@ def test_parse_batched_llm_response_normalizes_invalid_and_valid_cases():
     assert result[0]["suggested_label"] == "GRAND_TOTAL"
     assert result[1]["decision"] == "VALID"
     assert result[1]["suggested_label"] is None
+
+
+@pytest.mark.unit
+def test_parse_llm_response_does_not_infer_from_because_use_substring():
+    """`USE` marker should not match inside words like `because`."""
+    payload = {
+        "decision": "INVALID",
+        "reasoning": "Wrong because tax details are footer text.",
+        "suggested_label": "OTHER",
+        "confidence": "medium",
+    }
+
+    result = parse_llm_response(json.dumps(payload))
+
+    assert result["decision"] == "INVALID"
+    assert result["suggested_label"] is None


### PR DESCRIPTION
# Pull Request

## Summary

- Add Phase 3 Chroma consensus short-circuiting in the unified evaluator so high-confidence issues can be auto-decided before LLM review.
- Add per-issue `decision_source` (`chroma_consensus` vs `llm_review`) and include source summaries in trace outputs for observability.
- Clarify unlabeled-word decision semantics in label-review prompts and normalize parser behavior (including inferred CORE_LABEL recovery from reasoning when needed).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that resolves an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [x] ⚡ Performance improvement
- [x] 🧪 Test changes or improved coverage

## Which Package(s) are Affected?

- [ ] receipt_dynamo
- [ ] receipt_dynamo_stream
- [ ] receipt_chroma
- [ ] receipt_upload
- [ ] receipt_places
- [x] receipt_agent
- [ ] Portfolio (TypeScript/Next.js)
- [x] Infrastructure (Pulumi)
- [ ] CI/CD Workflows
- [ ] Other: _______________

## Testing

- [x] Unit tests pass locally (`pytest` or `npm test`)
- [ ] Integration tests pass locally (if applicable)
- [x] Added or updated tests for new functionality
- [ ] All existing tests still pass with these changes
- [x] Manual testing completed (if applicable)

Manual/targeted checks run:
- `black` (touched files)
- `isort` (touched files)
- `mypy --follow-imports=skip --ignore-missing-imports` (touched files)
- `pylint --disable=all --enable=E,F` (touched files)
- `pytest -q receipt_agent/tests/test_label_evaluator_prompt_parsing.py`

## Documentation & Code Quality

- [x] Documentation or comments updated for complex logic
- [ ] README updated (if introducing new feature/dependency)
- [ ] TypeDoc/JSDoc comments added where needed
- [x] No new warnings or linting issues introduced
- [x] Code follows project style guidelines

## Related Issues

Closes #755
Closes #757
Closes #760

## Impact Analysis

- Phase 3 review now avoids unnecessary LLM calls for issues with decisive Chroma evidence, reducing latency/cost.
- Decision provenance is explicit (`decision_source`) for downstream analysis/viz.
- Prompt + parser behavior for unlabeled words is now consistent:
  - correctly unlabeled -> `VALID` + `suggested_label=null`
  - incorrect existing label that should be removed -> `INVALID` + `suggested_label=null`
- Parser normalization also reduces inconsistent outputs and can recover a valid CORE_LABEL from reasoning text for INVALID decisions when `suggested_label` is missing/invalid.

## Deployment Notes

- No schema migration required.
- Optional runtime tuning for consensus auto-decision behavior:
  - `LLM_REVIEW_CONSENSUS_THRESHOLD` (default `0.75`)
  - `LLM_REVIEW_CONSENSUS_MIN_EVIDENCE` (default `4`)
- Safe rollback: revert this PR to return to always-LLM phase-3 review behavior.

---

This PR will be reviewed by CI/CD checks and automated analysis tools. Please ensure all checks pass before requesting human review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Optimized label review system to auto-decide issues based on consensus analysis, reducing processing latency when thresholds are met.
  * Enhanced consistency in label validation and normalization across single and batch review workflows.

* **Tests**
  * Added comprehensive test coverage for label evaluation and prompt parsing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->