### PR TITLE
Fix Chroma Cloud where clause in label compaction

### DIFF
--- a/receipt_chroma/receipt_chroma/compaction/labels.py
+++ b/receipt_chroma/receipt_chroma/compaction/labels.py
@@ -205,7 +205,12 @@ def _apply_line_label_updates(
         try:
             # Query all line embeddings for this receipt
             existing_results = collection_obj.get(
-                where={"image_id": image_id, "receipt_id": receipt_id},
+                where={
+                    "$and": [
+                        {"image_id": {"$eq": image_id}},
+                        {"receipt_id": {"$eq": receipt_id}},
+                    ]
+                },
                 include=["metadatas"],
             )
 


### PR DESCRIPTION
## Summary

- Fix `ValueError: Expected where to have exactly one operator` in Chroma Cloud by wrapping multi-key `where` filter with `$and` operator
- Matches the pattern already used in `deletions.py:359`

### Root Cause

`_apply_line_label_updates()` in `labels.py:208` passes a plain dict with two keys to ChromaDB's `.get()`:

```python
where={"image_id": image_id, "receipt_id": receipt_id}
```

The local ChromaDB SDK silently accepts this, but Chroma Cloud rejects it:

```
ValueError: Expected where to have exactly one operator,
got {'image_id': '...', 'receipt_id': 1} in get.
```

### Fix

Use the `$and` operator with explicit `$eq` comparisons, matching the pattern in `deletions.py`:

```python
where={
    "$and": [
        {"image_id": {"$eq": image_id}},
        {"receipt_id": {"$eq": receipt_id}},
    ]
}
```

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that resolves an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test changes or improved coverage

## Which Package(s) are Affected?

- [ ] receipt_dynamo
- [ ] receipt_dynamo_stream
- [x] receipt_chroma
- [ ] receipt_upload
- [ ] receipt_places
- [ ] receipt_agent
- [ ] Portfolio (TypeScript/Next.js)
- [ ] Infrastructure (Pulumi)
- [ ] CI/CD Workflows
- [ ] Other: _______________

## Testing

- [ ] Unit tests pass locally (`pytest` or `npm test`)
- [ ] Integration tests pass locally (if applicable)
- [ ] Added or updated tests for new functionality
- [ ] All existing tests still pass with these changes
- [x] Manual testing completed (if applicable)

## Documentation & Code Quality

- [ ] Documentation or comments updated for complex logic
- [ ] README updated (if introducing new feature/dependency)
- [ ] TypeDoc/JSDoc comments added where needed
- [x] No new warnings or linting issues introduced
- [x] Code follows project style guidelines

## Related Issues

Relates to #765 (OperationLogger fix) and #766 (timeout fix) — same Lambda, same investigation

## Impact Analysis

This fix affects the `chromadb-dev-docker-dev` compaction Lambda's label update path. Without it, every label update event fails when writing to Chroma Cloud, meaning line embeddings never get their label metadata updated. The fix is backward-compatible — the `$and`/`$eq` syntax works with both local ChromaDB and Chroma Cloud.

## Deployment Notes

- Deploy via `pulumi up --stack dev` — CodeBuild will rebuild the Lambda Docker image
- Verify by checking CloudWatch logs: the `ValueError: Expected where to have exactly one operator` errors should stop
- No rollback concerns — `$and` syntax is valid for both local and cloud ChromaDB

---

This PR will be reviewed by CI/CD checks and automated analysis tools. Please ensure all checks pass before requesting human review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized internal database query construction for improved consistency and maintainability.

**Note:** No user-facing changes in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->