### PR TITLE
Fix empty flying receipt by preloading images

### DIFF
--- a/portfolio/components/ui/Figures/BetweenReceiptVisualization/index.tsx
+++ b/portfolio/components/ui/Figures/BetweenReceiptVisualization/index.tsx
@@ -8,7 +8,7 @@ import {
   ReviewDecision,
   ReviewEvidence,
 } from "../../../../types/api";
-import { getBestImageUrl, getJpegFallbackUrl } from "../../../../utils/imageFormat";
+import { getBestImageUrl, getJpegFallbackUrl, usePreloadReceiptImages } from "../../../../utils/imageFormat";
 import { ReceiptFlowShell } from "../ReceiptFlow/ReceiptFlowShell";
 import {
   getQueuePosition,
@@ -395,6 +395,8 @@ const BetweenReceiptVisualization: React.FC = () => {
   const [revealedCards, setRevealedCards] = useState<RevealedCard[]>([]);
   const formatSupport = useImageFormatSupport();
   const [isTransitioning, setIsTransitioning] = useState(false);
+
+  usePreloadReceiptImages(receipts, formatSupport);
 
   const animationRef = useRef<number | null>(null);
   const isAnimatingRef = useRef(false);

--- a/portfolio/components/ui/Figures/FinancialMathOverlay/index.tsx
+++ b/portfolio/components/ui/Figures/FinancialMathOverlay/index.tsx
@@ -8,6 +8,7 @@ import {
 import {
   getBestImageUrl,
   getJpegFallbackUrl,
+  usePreloadReceiptImages,
 } from "../../../../utils/imageFormat";
 import { ReceiptFlowShell } from "../ReceiptFlow/ReceiptFlowShell";
 import {
@@ -387,6 +388,8 @@ export default function FinancialMathOverlay() {
   const [isTransitioning, setIsTransitioning] = useState(false);
   const formatSupport = useImageFormatSupport();
   const [isPoolExhausted, setIsPoolExhausted] = useState(false);
+
+  usePreloadReceiptImages(receipts, formatSupport);
 
   const animationRef = useRef<number | null>(null);
   const isAnimatingRef = useRef(false);

--- a/portfolio/components/ui/Figures/LabelEvaluatorVisualization/index.tsx
+++ b/portfolio/components/ui/Figures/LabelEvaluatorVisualization/index.tsx
@@ -5,7 +5,7 @@ import { api } from "../../../../services/api";
 import {
   LabelEvaluatorReceipt,
 } from "../../../../types/api";
-import { getBestImageUrl } from "../../../../utils/imageFormat";
+import { getBestImageUrl, usePreloadReceiptImages } from "../../../../utils/imageFormat";
 import { ReceiptFlowShell } from "../ReceiptFlow/ReceiptFlowShell";
 import {
   getQueuePosition,
@@ -1475,6 +1475,8 @@ const LabelEvaluatorVisualization: React.FC = () => {
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const formatSupport = useImageFormatSupport();
+
+  usePreloadReceiptImages(receipts, formatSupport);
 
   // Fetch visualization data
   useEffect(() => {

--- a/portfolio/components/ui/Figures/LabelValidationVisualization/index.tsx
+++ b/portfolio/components/ui/Figures/LabelValidationVisualization/index.tsx
@@ -6,7 +6,7 @@ import {
   LabelValidationReceipt,
   LabelValidationWord,
 } from "../../../../types/api";
-import { getBestImageUrl } from "../../../../utils/imageFormat";
+import { getBestImageUrl, usePreloadReceiptImages } from "../../../../utils/imageFormat";
 import { ReceiptFlowShell } from "../ReceiptFlow/ReceiptFlowShell";
 import {
   getQueuePosition,
@@ -841,6 +841,8 @@ const LabelValidationVisualization: React.FC = () => {
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const formatSupport = useImageFormatSupport();
+
+  usePreloadReceiptImages(receipts, formatSupport);
 
   // Fetch visualization data
   useEffect(() => {

--- a/portfolio/components/ui/Figures/LayoutLMBatchVisualization/index.tsx
+++ b/portfolio/components/ui/Figures/LayoutLMBatchVisualization/index.tsx
@@ -7,7 +7,7 @@ import {
   LayoutLMReceiptInference,
   LayoutLMReceiptWord,
 } from "../../../../types/api";
-import { getBestImageUrl } from "../../../../utils/imageFormat";
+import { getBestImageUrl, usePreloadReceiptImages } from "../../../../utils/imageFormat";
 import { ReceiptFlowShell } from "../ReceiptFlow/ReceiptFlowShell";
 import {
   getQueuePosition,
@@ -690,6 +690,9 @@ const LayoutLMBatchVisualization: React.FC = () => {
   const [initialLoading, setInitialLoading] = useState(true);
   const formatSupport = useImageFormatSupport();
   const [isPoolExhausted, setIsPoolExhausted] = useState(false);
+
+  const allImageFormats = useMemo(() => receipts.map((r) => r.original.receipt), [receipts]);
+  usePreloadReceiptImages(allImageFormats, formatSupport);
 
   const isFetchingRef = useRef(false);
   const seenReceiptIds = useRef<Set<string>>(new Set());

--- a/portfolio/components/ui/Figures/WithinReceiptVerification/index.tsx
+++ b/portfolio/components/ui/Figures/WithinReceiptVerification/index.tsx
@@ -5,7 +5,7 @@ import {
   WithinReceiptVerificationReceipt,
   WithinReceiptWordDecision,
 } from "../../../../types/api";
-import { getBestImageUrl, getJpegFallbackUrl } from "../../../../utils/imageFormat";
+import { getBestImageUrl, getJpegFallbackUrl, usePreloadReceiptImages } from "../../../../utils/imageFormat";
 import { ReceiptFlowShell } from "../ReceiptFlow/ReceiptFlowShell";
 import {
   getQueuePosition,
@@ -457,6 +457,8 @@ const WithinReceiptVerification: React.FC = () => {
   const formatSupport = useImageFormatSupport();
   const [isTransitioning, setIsTransitioning] = useState(false);
   const [activePass, setActivePass] = useState<PassName | null>(null);
+
+  usePreloadReceiptImages(receipts, formatSupport);
 
   const { flyingItem: flyingReceipt, showFlying: showFlyingReceipt } = useFlyingReceipt(
     isTransitioning,

--- a/scripts/copy_dynamodb_dev_to_prod.py
+++ b/scripts/copy_dynamodb_dev_to_prod.py
@@ -46,7 +46,8 @@ from receipt_dynamo.entities.receipt import Receipt
 from receipt_dynamo.entities.receipt_letter import ReceiptLetter
 from receipt_dynamo.entities.receipt_line import ReceiptLine
 from receipt_dynamo.entities.receipt_metadata import ReceiptMetadata
-from receipt_dynamo.entities.receipt_word import EmbeddingStatus, ReceiptWord
+from receipt_dynamo.constants import EmbeddingStatus
+from receipt_dynamo.entities.receipt_word import ReceiptWord
 from receipt_dynamo.entities.receipt_word_label import ReceiptWordLabel
 from receipt_dynamo.entities.word import Word
 


### PR DESCRIPTION
## Summary

- Add shared `usePreloadReceiptImages` hook in `imageFormat.ts` that preloads both full-size and thumbnail images once data and format support are ready, using a ref-based dedup set so components that continuously fetch more receipts only preload new ones
- Apply to all 6 receipt visualization components that use flying-receipt animations:
  - `BetweenReceiptVisualization`
  - `LabelEvaluatorVisualization`
  - `WithinReceiptVerification`
  - `FinancialMathOverlay` (maps via `getCdnKeys`)
  - `LabelValidationVisualization`
  - `LayoutLMBatchVisualization` (maps via `receipt.original.receipt`)
- Fix `EmbeddingStatus` import in `copy_dynamodb_dev_to_prod.py` after it moved from `receipt_word.py` to `constants.py`

### Root Cause

The flying receipt animation appeared empty when the browser hadn't cached the full-size image in time for the 600ms transition. Queue items use thumbnail-sized images, but the flying receipt and center viewer use full-size images. Without preloading, the browser had to fetch the full-size image on-the-fly during the animation, resulting in a blank flash.

## Test plan

- [ ] Verify flying receipt animation shows the image immediately (no blank flash) on first cycle through all receipts in each visualization
- [ ] Verify queue thumbnails load without delay
- [ ] Verify components that continuously fetch (FinancialMathOverlay, LayoutLMBatchVisualization) preload new batches as they arrive
- [ ] Verify `copy_dynamodb_dev_to_prod.py` runs without import errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)