### PR TITLE
Add text-based financial math for service/terminal receipts

### DIFF
--- a/infra/label_evaluator_step_functions/lambdas/build_viz_cache.py
+++ b/infra/label_evaluator_step_functions/lambdas/build_viz_cache.py
@@ -204,6 +204,11 @@ def _build_cdn_fields(
 # Financial math cache builder
 # ---------------------------------------------------------------------------
 
+# Service/terminal receipts emit pre-formed equations from text-scan rather
+# than per-word label decisions. The financial_subagent stamps issue_type
+# directly on these and they need no reconstruction.
+TEXT_SCAN_ISSUE_TYPES = frozenset({"HAS_TOTAL", "TOTAL_CHECK", "TIP_CHECK"})
+
 
 def _parse_numeric(text: str) -> float | None:
     """Parse a numeric value from word text, stripping currency symbols."""
@@ -212,6 +217,39 @@ def _parse_numeric(text: str) -> float | None:
         return float(cleaned)
     except (ValueError, TypeError):
         return None
+
+
+def _extract_receipt_type(decisions: list[dict]) -> str:
+    """Detect receipt_type from financial decisions. Defaults to 'itemized'."""
+    if not decisions:
+        return "itemized"
+    rt = decisions[0].get("receipt_type")
+    if rt in ("service", "terminal"):
+        return rt
+    return "itemized"
+
+
+def _build_text_scan_equations(
+    decisions: list[dict],
+    word_lookup: dict[tuple[int, int], dict],
+) -> list[dict[str, Any]]:
+    """Wrap pre-formed text-scan issues as equations for service/terminal receipts."""
+    equations: list[dict[str, Any]] = []
+    for d in decisions:
+        issue = d.get("issue", {})
+        issue_type = issue.get("issue_type")
+        if issue_type not in TEXT_SCAN_ISSUE_TYPES:
+            continue
+        entry = _build_decision_entry(d, word_lookup)
+        equations.append({
+            "issue_type": issue_type,
+            "description": issue.get("description", ""),
+            "expected_value": issue.get("expected_value"),
+            "actual_value": issue.get("actual_value"),
+            "difference": issue.get("difference"),
+            "involved_words": [entry],
+        })
+    return equations
 
 
 def _build_equations(
@@ -227,9 +265,15 @@ def _build_equations(
       - GRAND_TOTAL_DIRECT = sum(LINE_TOTAL) + TAX + TIP - DISCOUNT (no SUBTOTAL)
       - SUBTOTAL = sum(LINE_TOTAL)
       - LINE_ITEM_BALANCED = QUANTITY × UNIT_PRICE = LINE_TOTAL (per line)
+
+    Service/terminal receipts skip reconstruction — their decisions already
+    carry issue_type (HAS_TOTAL/TOTAL_CHECK/TIP_CHECK) from text-scan.
     """
     if not decisions:
         return []
+
+    if _extract_receipt_type(decisions) in ("service", "terminal"):
+        return _build_text_scan_equations(decisions, word_lookup)
 
     # Build word entries and group by label
     by_label: dict[str, list[dict[str, Any]]] = {}
@@ -407,6 +451,7 @@ def build_financial_math_entry(
         "receipt_id": unified_row.get("receipt_id"),
         "merchant_name": unified_row.get("merchant_name"),
         "trace_id": unified_row.get("trace_id", ""),
+        "receipt_type": _extract_receipt_type(financial_decisions),
         "equations": equations,
         "summary": summary,
         "width": width,
@@ -543,6 +588,7 @@ def build_within_receipt_entry(
         "receipt_id": unified_row.get("receipt_id"),
         "merchant_name": unified_row.get("merchant_name"),
         "trace_id": unified_row.get("trace_id", ""),
+        "receipt_type": _extract_receipt_type(financial_decisions),
         "place_validation": {
             "place": place_info,
             "decisions": place_decisions,

--- a/infra/label_evaluator_step_functions/lambdas/unified_receipt_evaluator.py
+++ b/infra/label_evaluator_step_functions/lambdas/unified_receipt_evaluator.py
@@ -1094,6 +1094,8 @@ async def unified_receipt_evaluator(
                     image_id=image_id,
                     receipt_id=receipt_id,
                     merchant_name=merchant_name,
+                    words=words,
+                    line_item_patterns=line_item_patterns,
                 )
                 financial_duration = time.time() - financial_start
 

--- a/portfolio/components/ui/Figures/FinancialMathOverlay/FinancialMathOverlay.module.css
+++ b/portfolio/components/ui/Figures/FinancialMathOverlay/FinancialMathOverlay.module.css
@@ -81,6 +81,21 @@
   pointer-events: none;
 }
 
+/* Receipt type badge */
+.receiptTypeBadge {
+  font-family: "Monaco", "Menlo", "Consolas", monospace;
+  font-size: 0.6rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  padding: 0.15rem 0.4rem;
+  border-radius: 3px;
+  background: rgba(var(--text-color-rgb), 0.08);
+  color: var(--text-color);
+  opacity: 0.6;
+  text-align: center;
+  align-self: center;
+}
+
 /* Equation Panel - Right Column */
 .equationPanel {
   width: 200px;

--- a/portfolio/components/ui/Figures/FinancialMathOverlay/index.tsx
+++ b/portfolio/components/ui/Figures/FinancialMathOverlay/index.tsx
@@ -256,6 +256,45 @@ function buildEquationNotation(eq: FinancialMathEquation): EquationNotation {
   const words = eq.involved_words;
   const issueType = eq.issue_type || "";
 
+  // HAS_TOTAL: simple single-value display (no addends)
+  if (issueType === "HAS_TOTAL") {
+    return {
+      addends: [],
+      result: eq.actual_value != null ? formatDollar(eq.actual_value) : "N/A",
+    };
+  }
+
+  // TOTAL_CHECK: SUBTOTAL + TAX = TOTAL (text-scanned)
+  if (issueType === "TOTAL_CHECK") {
+    // Parse values from description: "TOTAL ($X) = SUBTOTAL ($Y) + TAX ($Z) = $W"
+    const desc = eq.description || "";
+    const subtotalMatch = desc.match(/SUBTOTAL\s*\(\$?([\d.]+)\)/);
+    const taxMatch = desc.match(/TAX\s*\(\$?([\d.]+)\)/);
+    const totalMatch = desc.match(/TOTAL\s*\(\$?([\d.]+)\)/);
+    const addends = [];
+    if (subtotalMatch) addends.push(`$${subtotalMatch[1]}`);
+    if (taxMatch) addends.push(`$${taxMatch[1]}`);
+    return {
+      addends: addends.length > 0 ? addends : [formatDollar(eq.expected_value)],
+      result: totalMatch ? `$${totalMatch[1]}` : formatDollar(eq.actual_value),
+    };
+  }
+
+  // TIP_CHECK: SUBTOTAL + TIP = TOTAL (text-scanned)
+  if (issueType === "TIP_CHECK") {
+    const desc = eq.description || "";
+    const subtotalMatch = desc.match(/SUBTOTAL\s*\(\$?([\d.]+)\)/);
+    const tipMatch = desc.match(/TIP\s*\(\$?([\d.]+)\)/);
+    const totalMatch = desc.match(/TOTAL\s*\(\$?([\d.]+)\)/);
+    const addends = [];
+    if (subtotalMatch) addends.push(`$${subtotalMatch[1]}`);
+    if (tipMatch) addends.push(`$${tipMatch[1]}`);
+    return {
+      addends: addends.length > 0 ? addends : [formatDollar(eq.expected_value)],
+      result: totalMatch ? `$${totalMatch[1]}` : formatDollar(eq.actual_value),
+    };
+  }
+
   if (issueType.includes("GRAND_TOTAL")) {
     const subtotals = words.filter((w) => w.current_label === "SUBTOTAL");
     const taxes = words.filter((w) => w.current_label === "TAX");
@@ -298,18 +337,25 @@ interface EquationPanelProps {
   equations: FinancialMathEquation[];
   revealedEquationIndices: Set<number>;
   isTransitioning?: boolean;
+  receiptType?: "itemized" | "service" | "terminal";
 }
 
 const EquationPanel: React.FC<EquationPanelProps> = ({
   equations,
   revealedEquationIndices,
   isTransitioning = false,
+  receiptType,
 }) => {
   return (
     <div
       className={styles.equationPanel}
       style={{ opacity: isTransitioning ? 0 : 1, transition: 'opacity 0.3s ease' }}
     >
+      {receiptType && receiptType !== "itemized" && (
+        <div className={styles.receiptTypeBadge}>
+          {receiptType.toUpperCase()}
+        </div>
+      )}
       {equations.map((eq, idx) => {
         const color = getEquationColor(eq);
         const isRevealed = revealedEquationIndices.has(idx);
@@ -326,6 +372,7 @@ const EquationPanel: React.FC<EquationPanelProps> = ({
         );
         const isValid = !hasInvalid && !hasReview;
         const notation = buildEquationNotation(eq);
+        const isHasTotal = eq.issue_type === "HAS_TOTAL";
 
         return (
           <div
@@ -334,38 +381,52 @@ const EquationPanel: React.FC<EquationPanelProps> = ({
             style={{ borderColor: isRevealed ? color : undefined }}
           >
             <div className={styles.summation}>
-              {/* Addends stacked vertically */}
-              <div className={styles.addends}>
-                {notation.addends.map((val, i) => (
-                  <div key={i} className={styles.addendRow}>
-                    <span className={styles.addendOp}>
-                      {i === notation.addends.length - 1 && notation.addends.length > 1
-                        ? "+"
-                        : ""}
-                    </span>
-                    <span className={styles.addendVal}>{val}</span>
-                  </div>
-                ))}
-              </div>
-              {/* Horizontal rule = the "equals" line */}
-              <div className={styles.sumLine} />
-              {/* Result row with validity indicator */}
-              <div className={styles.resultRow}>
-                <span className={styles.resultVal}>{notation.result}</span>
-                <span
-                  className={`${styles.resultIcon} ${isValid ? styles.resultValid : styles.resultInvalid}`}
-                >
-                  {isValid ? "\u2713" : "\u2717"}
-                </span>
-              </div>
-              {hasDiff && (
-                <div
-                  className={styles.equationDiff}
-                  style={isValid ? { color: "rgba(var(--text-color-rgb), 0.4)" } : undefined}
-                >
-                  {diff > 0 ? "+" : ""}
-                  {diff.toFixed(2)}
+              {isHasTotal ? (
+                /* HAS_TOTAL: simple single-value display */
+                <div className={styles.resultRow}>
+                  <span className={styles.resultVal}>{notation.result}</span>
+                  <span
+                    className={`${styles.resultIcon} ${isValid ? styles.resultValid : styles.resultInvalid}`}
+                  >
+                    {isValid ? "\u2713" : "\u2717"}
+                  </span>
                 </div>
+              ) : (
+                <>
+                  {/* Addends stacked vertically */}
+                  <div className={styles.addends}>
+                    {notation.addends.map((val, i) => (
+                      <div key={i} className={styles.addendRow}>
+                        <span className={styles.addendOp}>
+                          {i === notation.addends.length - 1 && notation.addends.length > 1
+                            ? "+"
+                            : ""}
+                        </span>
+                        <span className={styles.addendVal}>{val}</span>
+                      </div>
+                    ))}
+                  </div>
+                  {/* Horizontal rule = the "equals" line */}
+                  <div className={styles.sumLine} />
+                  {/* Result row with validity indicator */}
+                  <div className={styles.resultRow}>
+                    <span className={styles.resultVal}>{notation.result}</span>
+                    <span
+                      className={`${styles.resultIcon} ${isValid ? styles.resultValid : styles.resultInvalid}`}
+                    >
+                      {isValid ? "\u2713" : "\u2717"}
+                    </span>
+                  </div>
+                  {hasDiff && (
+                    <div
+                      className={styles.equationDiff}
+                      style={isValid ? { color: "rgba(var(--text-color-rgb), 0.4)" } : undefined}
+                    >
+                      {diff > 0 ? "+" : ""}
+                      {diff.toFixed(2)}
+                    </div>
+                  )}
+                </>
               )}
             </div>
           </div>
@@ -522,6 +583,14 @@ export default function FinancialMathOverlay() {
       const revealed = new Set<number>();
       const scanY = progress / 100;
       receipt.equations.forEach((eq, eqIdx) => {
+        // Text-scanned equations have zero bboxes — reveal immediately
+        const hasRealBbox = eq.involved_words.some(
+          (w) => w.bbox.width > 0 || w.bbox.height > 0
+        );
+        if (!hasRealBbox) {
+          if (progress > 0) revealed.add(eqIdx);
+          return;
+        }
         // An equation is revealed when at least one of its words' top edge is above the scan line
         const anyRevealed = eq.involved_words.some((word) => {
           const wordTopY = 1 - word.bbox.y - word.bbox.height;
@@ -718,6 +787,7 @@ export default function FinancialMathOverlay() {
           equations={currentReceipt.equations}
           revealedEquationIndices={revealedEquationIndices}
           isTransitioning={isTransitioning}
+          receiptType={currentReceipt.receipt_type}
           />
         }
       />

--- a/portfolio/types/api.ts
+++ b/portfolio/types/api.ts
@@ -732,6 +732,7 @@ export interface FinancialMathReceipt {
   receipt_id: number;
   merchant_name: string | null;
   trace_id: string;
+  receipt_type?: "itemized" | "service" | "terminal";
   equations: FinancialMathEquation[];
   summary: {
     total_equations: number;

--- a/receipt_agent/receipt_agent/prompts/structured_outputs.py
+++ b/receipt_agent/receipt_agent/prompts/structured_outputs.py
@@ -84,6 +84,7 @@ class ReceiptTypeEnum(str, Enum):
 
     ITEMIZED = "itemized"
     SERVICE = "service"
+    TERMINAL = "terminal"
 
 
 class ItemStructureEnum(str, Enum):


### PR DESCRIPTION
## Summary
- Adds **text scanning** with a pending-keyword queue to extract financial values (subtotal, tax, tip, total) from service and terminal receipts that lack LayoutLM labels
- Classifies receipts as `itemized`, `service`, or `terminal` using `line_item_patterns.receipt_type` from Phase 1 pattern discovery, with text-scan fallback
- Adds type-specific equation checks: `HAS_TOTAL` (terminal), `TOTAL_CHECK` and `TIP_CHECK` (service) — all deterministic, no LLM needed
- Updates the frontend `FinancialMathOverlay` to render new equation types and display a receipt type badge

## Test plan
- [x] Deploy to dev: `cd infra && pulumi up --yes --skip-preview`
- [x] Run label evaluator step function on all receipts
- [x] Check CloudWatch logs for `"Text-scan"` and `"receipt_type"` messages
- [x] Verify 36 service + 9 terminal receipts processed via text-scan path
- [ ] Confirm no regressions in itemized receipt financial math
- [ ] Check frontend: navigate to receipt page → Financial Math section, confirm service/terminal receipts appear with equations

Closes #772

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for service and terminal receipt types in addition to itemized receipts
  * Visual receipt-type badge in the financial overlay UI
  * Improved financial math validation using text-scanning for service/terminal receipts
  * Faster reveal of text-scanned equations for better responsiveness

* **Chores**
  * Financial math results now include receipt type metadata for downstream use

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tnorlund/Portfolio/pull/774?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->