### PR TITLE
Auto-zip CoreML bundle to canonical S3 path after export

### DIFF
--- a/receipt_layoutlm/receipt_layoutlm/export_worker.py
+++ b/receipt_layoutlm/receipt_layoutlm/export_worker.py
@@ -22,7 +22,7 @@ from typing import Any, Dict, Optional
 from urllib.parse import urlparse
 
 import boto3
-import botocore.exceptions
+from botocore.exceptions import ClientError
 
 from .export_coreml import export_coreml
 
@@ -177,7 +177,7 @@ def process_export_job(message: Dict[str, Any]) -> Dict[str, Any]:
                     f"Uploaded canonical bundle to "
                     f"s3://{bucket}/{CANONICAL_BUNDLE_KEY}"
                 )
-            except (OSError, botocore.exceptions.ClientError) as e:
+            except (OSError, ClientError) as e:
                 print(
                     f"Warning: Failed to upload canonical bundle zip: {e}"
                 )


### PR DESCRIPTION
## Summary
- After each successful CoreML export, zips the bundle directory and uploads it to `coreml/layoutlm-coreml-bundle.zip` — the canonical path the Swift OCR worker downloads from
- The per-job upload to `coreml/{job-name}/` is unchanged
- Wrapped in try/except so a zip/upload failure logs a warning but doesn't fail the overall export

## Context
The Swift worker downloads its model from a hardcoded S3 key (`coreml/layoutlm-coreml-bundle.zip`), but the export worker only uploaded to per-job directories. This meant new exports never updated the zip the Swift worker uses, leaving it on a stale model.

## Test plan
- [ ] Run the export worker with `--once` against a queued export job
- [ ] Confirm `s3://{bucket}/coreml/layoutlm-coreml-bundle.zip` has a new timestamp
- [ ] Download and unzip; verify it contains `LayoutLM.mlpackage/`, `vocab.txt`, `config.json`, `label_map.json`
- [ ] Verify the per-job upload still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Export jobs now automatically create and upload a compressed archive of the CoreML bundle to a canonical S3 location for easier distribution and access.

* **Improvements**
  * Enhanced robustness by isolating bundle archiving and upload operations to prevent export failures due to archive-related issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->