### PR TITLE
Grant merge-receipt Lambda S3 access to upload-images bucket

### DIFF
--- a/infra/__main__.py
+++ b/infra/__main__.py
@@ -1280,6 +1280,7 @@ merge_receipt_lambda = create_merge_receipt_lambda(
     dynamodb_table_arn=dynamodb_table.arn,
     raw_bucket_name=raw_bucket.bucket,
     site_bucket_name=site_bucket.bucket,
+    image_bucket_name=upload_images.image_bucket.bucket,
     chromadb_bucket_name=embedding_infrastructure.chromadb_buckets.bucket_name,
     chromadb_bucket_arn=embedding_infrastructure.chromadb_buckets.bucket_arn,
 )

--- a/infra/upload_images/infra.py
+++ b/infra/upload_images/infra.py
@@ -79,6 +79,7 @@ class UploadImages(ComponentResource):
             tags={"environment": stack},
             opts=ResourceOptions(parent=self),
         )
+        self.image_bucket = image_bucket
 
         # Dedicated artifacts bucket for NDJSON receipts (do not use site bucket)
         artifacts_bucket = Bucket(


### PR DESCRIPTION
## Summary

- Expose `image_bucket` from `UploadImages` component so other infra can reference it
- Add `image_bucket_name` parameter to `MergeReceiptLambda` and grant `s3:GetObject` on it
- Pass `upload_images.image_bucket.bucket` through in `__main__.py`

The merge-receipt Lambda downloads the original photo to create a warped receipt image. The original photo lives in the `upload-images-image-bucket` (not the raw bucket), but the Lambda's IAM policy only covered raw, site, and chromadb buckets — causing `AccessDenied` when invoking.

## Test plan

- [ ] `pulumi up --stack dev` succeeds with the new IAM policy
- [ ] Dry-run invoke no longer returns AccessDenied:
  ```bash
  aws lambda invoke --function-name merge-receipt-dev-merge-receipt \
    --payload '{"image_id":"d5a15b22-d73e-4cec-b3bd-18ebb79a19b3","receipt_ids":[2,3],"dry_run":true}' \
    --cli-binary-format raw-in-base64-out --region us-east-1 /tmp/merge-response.json
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure**
  * Enabled receipt merging service to access original uploaded images during processing.
  * Updated permissions to grant receipt service read access to image storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->