### PR TITLE
Restore CompactionRun state updates in compaction handler

### DIFF
--- a/infra/chromadb_compaction/components/sqs_queues.py
+++ b/infra/chromadb_compaction/components/sqs_queues.py
@@ -153,7 +153,7 @@ class ChromaDBQueues(ComponentResource):
             receive_wait_time_seconds=20,  # Long polling
             redrive_policy=Output.all(self.lines_dlq.arn).apply(
                 lambda args: json.dumps(
-                    {"deadLetterTargetArn": args[0], "maxReceiveCount": 3}
+                    {"deadLetterTargetArn": args[0], "maxReceiveCount": 10}
                 )
             ),
             tags={
@@ -173,7 +173,7 @@ class ChromaDBQueues(ComponentResource):
             receive_wait_time_seconds=20,  # Long polling
             redrive_policy=Output.all(self.words_dlq.arn).apply(
                 lambda args: json.dumps(
-                    {"deadLetterTargetArn": args[0], "maxReceiveCount": 3}
+                    {"deadLetterTargetArn": args[0], "maxReceiveCount": 10}
                 )
             ),
             tags={


### PR DESCRIPTION
# Pull Request

## Summary

- Restore `mark_compaction_run_completed()` calls that were accidentally removed in PR #523 (Dec 2025), causing all CompactionRuns since then (~1,731) to stay stuck at PENDING
- Increase SQS `maxReceiveCount` from 3 to 10 on lines/words queues to prevent premature DLQ escalation during high-traffic events

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that resolves an issue)

## Which Package(s) are Affected?

- [x] Infrastructure (Pulumi)

## Testing

- [ ] Unit tests pass locally (`pytest` or `npm test`)
- [ ] Integration tests pass locally (if applicable)
- [ ] Added or updated tests for new functionality
- [x] All existing tests still pass with these changes
- [x] Manual testing completed (if applicable)

## Documentation & Code Quality

- [x] Documentation or comments updated for complex logic
- [ ] README updated (if introducing new feature/dependency)
- [ ] TypeDoc/JSDoc comments added where needed
- [x] No new warnings or linting issues introduced
- [x] Code follows project style guidelines

## Related Issues

Relates to #780 (merge receipt Lambda compaction timeout)

## Impact Analysis

**Root cause:** PR #523 (`b81b0090d`, Dec 16 2025) rewrote the enhanced compaction handler and dropped the code that called `mark_compaction_run_completed()` after processing deltas. The handler correctly downloads, extracts, and upserts vectors into snapshots, but never updates the CompactionRun DynamoDB record from PENDING to COMPLETED.

**Scope of impact:** Every CompactionRun since Dec 2025 (~1,731 records) is stuck at PENDING/PENDING. The underlying vector data was merged correctly — only the state tracking is broken. This blocks the merge receipt Lambda which polls CompactionRun status.

**Changes:**

1. `enhanced_compaction_handler.py` — After Phase 3 (successful snapshot upload), iterates over `result.delta_merge_results` and calls `dynamo_client.mark_compaction_run_completed()` for each run. Uses broad exception handling to avoid failing the entire compaction if a single state update fails.

2. `sqs_queues.py` — Increases `maxReceiveCount` from 3 to 10 on both lines and words queues. With `reserved_concurrent_executions=1` and `visibility_timeout_seconds=120`, messages could exhaust 3 retries (360s) before being processed during traffic spikes. 10 retries (1,200s) provides adequate buffer.

## Deployment Notes

1. `cd infra && pulumi up --stack dev` — deploys handler code change (CodeBuild rebuild) + SQS queue config update
2. After deploy, new CompactionRuns will correctly transition to COMPLETED
3. Existing 1,731 stuck runs may need a backfill script to mark as COMPLETED (the vector data is already correct)

---

This PR will be reviewed by CI/CD checks and automated analysis tools. Please ensure all checks pass before requesting human review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced reliability of the background data compaction process with increased error tolerance, allowing for more retry attempts before marking processing tasks as failed, resulting in better resilience against temporary failures.
  * Improved completion status tracking for compaction operations, ensuring accurate record-keeping and timely status updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->