### PR TITLE
Add fix_place MCP tool for merchant corrections

### DIFF
--- a/scripts/receipt_mcp_server.py
+++ b/scripts/receipt_mcp_server.py
@@ -777,7 +777,7 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent]:
             result = await fix_place_impl(
                 image_id=arguments["image_id"],
                 receipt_id=arguments["receipt_id"],
-                reason=arguments.get("reason", "User reported incorrect merchant"),
+                reason=arguments["reason"],
             )
         elif name == "create_word_label":
             result = await create_word_label_impl(
@@ -1971,6 +1971,37 @@ async def create_word_label_impl(
         return {"error": str(e)}
 
 
+async def _invoke_lambda(function_name: str, payload: dict) -> dict:
+    """Invoke a Lambda function and return the parsed response payload."""
+    import boto3
+
+    logger.info(
+        "Invoking %s with payload: %s",
+        function_name,
+        json.dumps(payload),
+    )
+
+    def _invoke():
+        client = boto3.client("lambda", region_name="us-east-1")
+        return client.invoke(
+            FunctionName=function_name,
+            InvocationType="RequestResponse",
+            Payload=json.dumps(payload),
+        )
+
+    response = await asyncio.to_thread(_invoke)
+    response_payload = json.loads(response["Payload"].read())
+
+    if "FunctionError" in response:
+        return {
+            "error": "Lambda execution failed",
+            "function_error": response["FunctionError"],
+            "details": response_payload,
+        }
+
+    return response_payload
+
+
 async def fix_place_impl(
     image_id: str,
     receipt_id: int,
@@ -1978,46 +2009,11 @@ async def fix_place_impl(
 ) -> dict:
     """Invoke the fix-place Lambda to correct a receipt's merchant/place."""
     try:
-        import asyncio
-
-        import boto3
-
         env = os.environ.get("PORTFOLIO_ENV", "dev")
-        function_name = f"fix-place-{env}-fix-place"
-
-        payload = {
-            "image_id": image_id,
-            "receipt_id": receipt_id,
-            "reason": reason,
-        }
-
-        logger.info(
-            "Invoking %s with payload: %s",
-            function_name,
-            json.dumps(payload),
+        return await _invoke_lambda(
+            f"fix-place-{env}-fix-place",
+            {"image_id": image_id, "receipt_id": receipt_id, "reason": reason},
         )
-
-        def _invoke():
-            lambda_client = boto3.client("lambda", region_name="us-east-1")
-            return lambda_client.invoke(
-                FunctionName=function_name,
-                InvocationType="RequestResponse",
-                Payload=json.dumps(payload),
-            )
-
-        response = await asyncio.to_thread(_invoke)
-
-        response_payload = json.loads(response["Payload"].read())
-
-        if "FunctionError" in response:
-            return {
-                "error": "Lambda execution failed",
-                "function_error": response["FunctionError"],
-                "details": response_payload,
-            }
-
-        return response_payload
-
     except Exception as e:
         logger.exception("Error invoking fix-place Lambda")
         return {"error": str(e)}
@@ -2030,50 +2026,11 @@ async def merge_receipts_impl(
 ) -> dict:
     """Invoke the merge-receipt Lambda to combine two receipt fragments."""
     try:
-        import asyncio
-
-        import boto3
-
         env = os.environ.get("PORTFOLIO_ENV", "dev")
-        function_name = f"merge-receipt-{env}-merge-receipt"
-
-        payload = {
-            "image_id": image_id,
-            "receipt_ids": receipt_ids,
-            "dry_run": dry_run,
-        }
-
-        logger.info(
-            "Invoking %s with payload: %s",
-            function_name,
-            json.dumps(payload),
+        return await _invoke_lambda(
+            f"merge-receipt-{env}-merge-receipt",
+            {"image_id": image_id, "receipt_ids": receipt_ids, "dry_run": dry_run},
         )
-
-        def _invoke():
-            lambda_client = boto3.client("lambda", region_name="us-east-1")
-            return lambda_client.invoke(
-                FunctionName=function_name,
-                InvocationType="RequestResponse",
-                Payload=json.dumps(payload),
-            )
-
-        # Run in a thread to avoid blocking the async event loop —
-        # the Lambda can take 30+ seconds for image processing,
-        # embedding creation, and compaction waits.
-        response = await asyncio.to_thread(_invoke)
-
-        response_payload = json.loads(response["Payload"].read())
-
-        # Check for Lambda-level errors
-        if "FunctionError" in response:
-            return {
-                "error": "Lambda execution failed",
-                "function_error": response["FunctionError"],
-                "details": response_payload,
-            }
-
-        return response_payload
-
     except Exception as e:
         logger.exception("Error invoking merge-receipt Lambda")
         return {"error": str(e)}


### PR DESCRIPTION
## Summary

- Add `fix_place` MCP tool that invokes the fix-place Lambda to correct misidentified merchants directly from Claude Code
- Extract shared `_invoke_lambda()` helper to deduplicate Lambda invocation logic between `fix_place_impl` and `merge_receipts_impl`
- Fix `arguments.get("reason", ...)` → `arguments["reason"]` for consistency with other required schema fields

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that resolves an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [x] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test changes or improved coverage

## Which Package(s) are Affected?

- [ ] receipt_dynamo
- [ ] receipt_dynamo_stream
- [ ] receipt_chroma
- [ ] receipt_upload
- [ ] receipt_places
- [ ] receipt_agent
- [ ] Portfolio (TypeScript/Next.js)
- [ ] Infrastructure (Pulumi)
- [ ] CI/CD Workflows
- [x] Other: `scripts/receipt_mcp_server.py`

## Testing

- [ ] Unit tests pass locally (`pytest` or `npm test`)
- [ ] Integration tests pass locally (if applicable)
- [ ] Added or updated tests for new functionality
- [ ] All existing tests still pass with these changes
- [x] Manual testing completed (if applicable)

## Documentation & Code Quality

- [ ] Documentation or comments updated for complex logic
- [ ] README updated (if introducing new feature/dependency)
- [ ] TypeDoc/JSDoc comments added where needed
- [x] No new warnings or linting issues introduced
- [x] Code follows project style guidelines

## Related Issues

<!-- No related issues -->

## Impact Analysis

No impact on other packages. The MCP server is a standalone script; the new tool delegates entirely to the existing fix-place Lambda. The `_invoke_lambda` refactor is internal to the MCP server and doesn't change external behavior.

## Deployment Notes

The fix-place Lambda (`fix-place-{env}-fix-place`) must already be deployed. No new infrastructure or configuration changes required — the MCP server resolves the function name from the `PORTFOLIO_ENV` environment variable (defaults to `dev`).

---

This PR will be reviewed by CI/CD checks and automated analysis tools. Please ensure all checks pass before requesting human review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)