### PR TITLE
fix: Swift ISO8601 formatter produces Z instead of +00:00

### DIFF
--- a/receipt_ocr_swift/Sources/ReceiptOCRCore/Util/ISO8601Python.swift
+++ b/receipt_ocr_swift/Sources/ReceiptOCRCore/Util/ISO8601Python.swift
@@ -5,7 +5,7 @@ enum ISO8601Python {
         let df = DateFormatter()
         df.locale = Locale(identifier: "en_US_POSIX")
         df.timeZone = TimeZone(secondsFromGMT: 0)
-        df.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSXXXXX" // +00:00 offset
+        df.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSxxx" // +00:00 offset (xxx not XXXXX to avoid Z)
         return df
     }()
 
@@ -13,7 +13,7 @@ enum ISO8601Python {
         let df = DateFormatter()
         df.locale = Locale(identifier: "en_US_POSIX")
         df.timeZone = TimeZone(secondsFromGMT: 0)
-        df.dateFormat = "yyyy-MM-dd'T'HH:mm:ssXXXXX" // +00:00 offset
+        df.dateFormat = "yyyy-MM-dd'T'HH:mm:ssxxx" // +00:00 offset (xxx not XXXXX to avoid Z)
         return df
     }()
 


### PR DESCRIPTION
## Summary

- Apple's `DateFormatter` with `XXXXX` format produces `Z` for UTC timezone offsets (e.g., `2026-02-20T06:48:10.322Z`)
- Python 3.10's `datetime.fromisoformat()` cannot parse the `Z` suffix (only supported in 3.11+)
- This caused SageMaker training jobs to crash when reading `ReceiptWordLabel` records written by the Swift OCR worker
- Switch to `xxx` format which always produces `+00:00` (e.g., `2026-02-20T06:48:10.322+00:00`)

## Test plan

- [x] Verified `xxx` produces `+00:00` and `XXXXX` produces `Z` with a live Swift test
- [x] `swift build` compiles cleanly
- [x] Cleaned up 133 existing bad records in DynamoDB

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected timezone offset formatting in date representations to ensure consistent and proper display across different time zones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->