### PR TITLE
Fix CoreML export status enum mismatch

### DIFF
--- a/infra/coreml_export/process_results.py
+++ b/infra/coreml_export/process_results.py
@@ -88,7 +88,7 @@ def process_export_result(
         return
 
     # Update status
-    if status == "SUCCESS":
+    if status in ("SUCCESS", "SUCCEEDED"):
         export_job.status = CoreMLExportStatus.SUCCEEDED.value
         export_job.mlpackage_s3_uri = message.get("mlpackage_s3_uri")
         export_job.bundle_s3_uri = message.get("bundle_s3_uri")
@@ -107,7 +107,7 @@ def process_export_result(
     print(f"Updated export job {export_id} status to {export_job.status}")
 
     # Also update the training Job record with the CoreML bundle location
-    if status == "SUCCESS" and export_job.bundle_s3_uri:
+    if status in ("SUCCESS", "SUCCEEDED") and export_job.bundle_s3_uri:
         try:
             job = dynamo.get_job(job_id)
             if job.results is None:

--- a/receipt_layoutlm/receipt_layoutlm/export_worker.py
+++ b/receipt_layoutlm/receipt_layoutlm/export_worker.py
@@ -190,7 +190,7 @@ def process_export_job(message: Dict[str, Any]) -> Dict[str, Any]:
             return {
                 "export_id": export_id,
                 "job_id": job_id,
-                "status": "SUCCESS",
+                "status": "SUCCEEDED",
                 "mlpackage_s3_uri": mlpackage_s3_uri,
                 "bundle_s3_uri": bundle_s3_uri,
                 "canonical_bundle_s3_uri": f"s3://{parsed.netloc}/{CANONICAL_BUNDLE_KEY}",


### PR DESCRIPTION
## Summary
- The export worker was writing `"SUCCESS"` to DynamoDB but `CoreMLExportStatus` expects `"SUCCEEDED"`, causing the `process_results` Lambda to silently fail when reading export job records
- The worker's direct DynamoDB update via `update_export_status()` wrote the invalid status, and when the results Lambda tried to deserialize the entity, status validation rejected it
- This left `bundle_s3_uri`, `mlpackage_s3_uri`, and `model_size_bytes` unpopulated on export job records

## Changes
- `export_worker.py`: Return `"SUCCEEDED"` instead of `"SUCCESS"` in the result dict
- `process_results.py`: Accept both `"SUCCESS"` and `"SUCCEEDED"` for backward compatibility with any in-flight SQS messages

## Test plan
- [x] Verified fix locally — export worker now writes `SUCCEEDED` which matches the enum
- [x] Manually corrected the two existing export job records in DynamoDB
- [ ] Next CoreML export should populate all fields correctly end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency in export job status handling and recognition of success indicators across the export workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->