### PR TITLE
fix: replace nonexistent geocode_address with search_by_address

### DIFF
--- a/receipt_agent/receipt_agent/agents/agentic/tools/agentic.py
+++ b/receipt_agent/receipt_agent/agents/agentic/tools/agentic.py
@@ -29,7 +29,7 @@ from receipt_agent.utils.label_metadata import (
     combine_where_clauses,
     metadata_matches_label_state,
 )
-from receipt_agent.tools.places import _place_to_dict
+from receipt_agent.tools.places import _format_place_result, _place_to_dict
 from receipt_agent.utils.receipt_text import format_receipt_text_receipt_space
 
 logger = logging.getLogger(__name__)
@@ -1300,8 +1300,19 @@ def create_agentic_tools(
                     radius=50,
                 )
 
+                if not businesses:
+                    return {
+                        "address": address,
+                        "coordinates": {"lat": lat, "lng": lng},
+                        "count": 0,
+                        "businesses": [],
+                        "place_ids": [],
+                        "message": f"No businesses found within 50m of {address}",
+                    }
+
                 formatted = [
-                    _place_to_dict(b) for b in businesses
+                    _format_place_result(_place_to_dict(b))
+                    for b in businesses[:10]
                 ]
 
                 return {
@@ -1310,7 +1321,7 @@ def create_agentic_tools(
                     "count": len(formatted),
                     "businesses": formatted,
                     "place_ids": [b.get("place_id") for b in formatted],
-                    "message": f"Found {len(formatted)} business(es) at address",
+                    "message": f"Found {len(formatted)} business(es) at {address}",
                 }
 
             except Exception as e:

--- a/receipt_agent/receipt_agent/tools/places.py
+++ b/receipt_agent/receipt_agent/tools/places.py
@@ -268,7 +268,7 @@ def find_businesses_at_address(
                 "businesses": [],
                 "address_searched": address,
                 "coordinates": {"lat": lat, "lng": lng},
-                "message": f"No businesses found within 50m of address",
+                "message": f"No businesses found within 50m of {address}",
             }
 
         # Format results
@@ -303,7 +303,7 @@ def _format_place_result(place_data: dict[str, Any]) -> dict[str, Any]:
         "business_status": place_data.get("business_status"),
         "rating": place_data.get("rating"),
         "user_ratings_total": place_data.get("user_ratings_total"),
-        "geometry": place_data.get("geometry", {}).get("location"),
+        "geometry": (place_data.get("geometry") or {}).get("location"),
     }
 
 


### PR DESCRIPTION
## Summary

`find_businesses_at_address_wrapper` in `agentic.py` called `places_api.geocode_address()` which doesn't exist on `PlacesClient`, causing `AttributeError` on every invocation. Discovered via CloudWatch logs after deploying #815 — the agent recovered by falling back to other search methods, but this tool was silently broken.

Replaced with `search_by_address()` (the correct method) and added proper `_place_to_dict` + `_format_place_result` conversion, `is None` coordinate checks, defensive `or {}` guards for optional Pydantic fields, a `None` guard on `search_nearby`, and a 10-result cap to match `places.py`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Package(s) Affected

- [x] `receipt_agent`
- [ ] `receipt_dynamo`
- [ ] `receipt_chroma`
- [ ] `receipt_upload`
- [ ] `receipt_layoutlm`
- [ ] `receipt_ocr_swift`
- [ ] `infra`
- [ ] `portfolio` (frontend)

## Changes

- **`receipt_agent/receipt_agent/agents/agentic/tools/agentic.py`**:
  - `geocode_address()` → `search_by_address()` with `_place_to_dict()` wrapper
  - Extract lat/lng from nested `geometry.location` with `is None` fallback checks
  - Defensive `or {}` guards for geometry/location that may be `None` from Pydantic `model_dump()`
  - Guard `search_nearby` returning `None` with explicit empty-result response
  - Cap results to `[:10]` and normalize via `_format_place_result` for consistency with `places.py`
  - Interpolate `{address}` in response messages

- **`receipt_agent/receipt_agent/tools/places.py`**:
  - `or {}` guards on geometry/location extraction in `find_businesses_at_address`
  - `or {}` guard on geometry in `_format_place_result` for same `None` safety
  - `is None` check for lat/lng instead of falsy check (preserves valid 0.0 coordinates)
  - Interpolate `{address}` in "no businesses found" message

## Testing

- [x] Verified fix-place Lambda logs show no `AttributeError` for the Pydantic `.get()` issue after #815
- [ ] Deploy and verify no `geocode_address` `AttributeError` in logs
- [ ] Run `fix_place` on a receipt and confirm `find_businesses_at_address` works end-to-end

## Documentation & Code Quality

- [x] Docstring coverage ≥ 80%
- [x] No new warnings introduced
- [x] Changes are consistent across both `agentic.py` and `places.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)