### PR TITLE
fix: sanitize oversized metadata keys before Chroma Cloud sync

### DIFF
--- a/receipt_chroma/receipt_chroma/compaction/dual_write.py
+++ b/receipt_chroma/receipt_chroma/compaction/dual_write.py
@@ -363,7 +363,7 @@ def _sanitize_metadatas(
 
     for md in metadatas:
         if not md:
-            sanitized.append(md or {})
+            sanitized.append(None)
             continue
         clean: Dict[str, Any] = {}
         for key, value in md.items():
@@ -371,7 +371,7 @@ def _sanitize_metadatas(
                 dropped_keys.add(key)
             else:
                 clean[key] = value
-        sanitized.append(clean)
+        sanitized.append(clean or None)
 
     if dropped_keys:
         logger.warning(

--- a/receipt_chroma/tests/unit/test_dual_write.py
+++ b/receipt_chroma/tests/unit/test_dual_write.py
@@ -164,20 +164,27 @@ class TestSanitizeMetadatas:
         assert key in result[0]
 
     def test_none_entry_in_list(self):
-        """None metadata entries in the list don't raise AttributeError."""
+        """None metadata entries become None (Chroma rejects empty dicts)."""
         metadatas = [{"text": "a"}, None, {"text": "c"}]
         result = _sanitize_metadatas(metadatas)
         assert result[0] == {"text": "a"}
-        assert result[1] == {}
+        assert result[1] is None
         assert result[2] == {"text": "c"}
 
     def test_empty_dict_entry_in_list(self):
-        """Empty dict entries pass through as empty dicts."""
+        """Empty dict entries become None (Chroma rejects empty dicts)."""
         metadatas = [{"text": "a"}, {}, {"text": "c"}]
         result = _sanitize_metadatas(metadatas)
         assert result[0] == {"text": "a"}
-        assert result[1] == {}
+        assert result[1] is None
         assert result[2] == {"text": "c"}
+
+    def test_all_keys_oversized_becomes_none(self):
+        """Entry where all keys exceed limit becomes None, not empty dict."""
+        long_key = "a" * 37
+        metadatas = [{long_key: True}]
+        result = _sanitize_metadatas(metadatas)
+        assert result[0] is None
 
     def test_oversized_key_logs_warning(self):
         """A warning is emitted when oversized keys are dropped."""


### PR DESCRIPTION
# Pull Request

## Summary

- Adds `_sanitize_metadatas()` to `dual_write.py` that strips metadata keys exceeding Chroma Cloud's 36-byte key limit before cloud upsert
- Historical label data from LayoutLM merge presets and LLM free-text reasoning produced keys like `label_SUBTOTAL SHOULD BE 50.63 (OR THE DISCOUNT AMOUNTS NEED SIGN CORRECTION)` (77 bytes) that fail Chroma Cloud's `MetadataKeySizeBytes` quota
- Affected 4 batches consistently across compaction runs (batches 81, 136, 159, 269 in the `words` collection)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that resolves an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [x] 🧪 Test changes or improved coverage

## Which Package(s) are Affected?

- [ ] receipt_dynamo
- [ ] receipt_dynamo_stream
- [x] receipt_chroma
- [ ] receipt_upload
- [ ] receipt_places
- [ ] receipt_agent
- [ ] Portfolio (TypeScript/Next.js)
- [ ] Infrastructure (Pulumi)
- [ ] CI/CD Workflows
- [ ] Other: _______________

## Testing

- [x] Unit tests pass locally (`pytest` or `npm test`)
- [ ] Integration tests pass locally (if applicable)
- [x] Added or updated tests for new functionality
- [x] All existing tests still pass with these changes
- [x] Manual testing completed (if applicable)

## Documentation & Code Quality

- [x] Documentation or comments updated for complex logic
- [ ] README updated (if introducing new feature/dependency)
- [ ] TypeDoc/JSDoc comments added where needed
- [x] No new warnings or linting issues introduced
- [x] Code follows project style guidelines

## Related Issues

Relates to #822 (filter LayoutLM merge-preset labels in Swift OCR worker)
Relates to #823 (LLM label validator writing non-CORE labels)

## Root Cause

Two active sources write non-CORE labels to DynamoDB:

1. **LayoutLM merge presets** → Swift OCR Worker → DynamoDB: Model trained with `merge_amounts=true` outputs `AMOUNT`, `ADDRESS` as labels. The Swift worker writes these directly with no CORE_LABELS filter.
2. **LLM Label Validator**: Sometimes returns free-text reasoning as label values (e.g., dollar amounts, correction notes).

When these labels are stored as ChromaDB metadata keys (`label_{NAME}`), the local ChromaDB accepts them (no size limit), but Chroma Cloud rejects keys > 36 bytes during bulk sync.

## Fix

The `_sanitize_metadatas()` function runs once per batch before the cloud upsert retry loop. It:
- Checks each metadata key's UTF-8 byte length against the 36-byte limit
- Drops oversized keys (with a warning log showing up to 5 examples)
- Handles `None` metadata entries in the list without raising `AttributeError`
- Passes all compliant keys through unchanged

The incremental dual-write path (`apply_collection_updates` → `process_collection_updates` → `labels.py`) already has a 36-byte guard at write time — only the bulk sync path was unprotected.

## Impact Analysis

- Only affects the Chroma Cloud bulk sync path in `dual_write.py`
- Local ChromaDB snapshot (S3) is unaffected — all metadata keys are preserved locally
- Cloud writes are already non-blocking (failures logged but don't fail the batch), so this is a defense-in-depth fix
- No changes to the MCP server, upload pipeline, or any other package

## Deployment Notes

No special deployment needed. The fix is applied at the Lambda layer during compaction. No configuration changes required.

---

This PR will be reviewed by CI/CD checks and automated analysis tools. Please ensure all checks pass before requesting human review.