### PR TITLE
fix: add REGIONAL_REOCR to OCRJobType enum

### DIFF
--- a/receipt_dynamo/receipt_dynamo/constants.py
+++ b/receipt_dynamo/receipt_dynamo/constants.py
@@ -124,6 +124,7 @@ class OCRJobType(Enum):
 
     REFINEMENT = "REFINEMENT"
     FIRST_PASS = "FIRST_PASS"
+    REGIONAL_REOCR = "REGIONAL_REOCR"
 
 
 class ImageType(Enum):


### PR DESCRIPTION
# Pull Request

## Summary

- Adds `REGIONAL_REOCR` to the `OCRJobType` enum in `receipt_dynamo/constants.py`
- PR #820 merged regional re-OCR into the PR #775 feature branch, writing `REGIONAL_REOCR` OCR jobs to dev DynamoDB
- Since #820 targeted #775's branch (not `main`), the enum value doesn't exist on `main`
- Any script calling `get_image_details()` on images with regional re-OCR jobs throws `ValueError: 'REGIONAL_REOCR' is not a valid OCRJobType`, blocking `reset_embedding_status.py` and other maintenance scripts

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that resolves an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test changes or improved coverage

## Which Package(s) are Affected?

- [x] receipt_dynamo
- [ ] receipt_dynamo_stream
- [ ] receipt_chroma
- [ ] receipt_upload
- [ ] receipt_places
- [ ] receipt_agent
- [ ] Portfolio (TypeScript/Next.js)
- [ ] Infrastructure (Pulumi)
- [ ] CI/CD Workflows
- [ ] Other: _______________

## Testing

- [x] Unit tests pass locally (`pytest` or `npm test`)
- [ ] Integration tests pass locally (if applicable)
- [ ] Added or updated tests for new functionality
- [x] All existing tests still pass with these changes
- [ ] Manual testing completed (if applicable)

## Documentation & Code Quality

- [ ] Documentation or comments updated for complex logic
- [ ] README updated (if introducing new feature/dependency)
- [ ] TypeDoc/JSDoc comments added where needed
- [x] No new warnings or linting issues introduced
- [x] Code follows project style guidelines

## Related Issues & PRs

- Relates to #818 — Regional re-OCR issue
- Relates to #820 — PR that introduced `REGIONAL_REOCR` OCR jobs (merged into #775's branch, not `main`)
- Relates to #775 — Feature branch chain where the full re-OCR implementation lives
- Unblocks #821 follow-up — ChromaDB embedding reset requires `get_image_details()` to work for all images

## Impact Analysis

One-line enum addition. No behavioral change — just allows `receipt_dynamo` to deserialize OCR jobs that already exist in dev DynamoDB. The 3 affected images are:
- `25c91d78-ed11-4c68-8051-e1d364762bcb`
- `b4c2a475-d739-4a42-afbf-6b5e06443ba1`
- `a1c5d97c-6e8e-463a-8c27-9fb98a3e0c02`

## Deployment Notes

None. Safe to merge immediately. This is a prerequisite for running `scripts/reset_embedding_status.py` to do the full ChromaDB reset.

---

This PR will be reviewed by CI/CD checks and automated analysis tools. Please ensure all checks pass before requesting human review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for regional re-OCR processing to enhance document recognition capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->