### PR TITLE
fix: skip missing receipts during embedding ingest

### DIFF
--- a/infra/embedding_step_functions/unified_embedding/handlers/line_polling.py
+++ b/infra/embedding_step_functions/unified_embedding/handlers/line_polling.py
@@ -107,8 +107,14 @@ async def _ensure_receipt_place_async(
     *,
     line_results: Optional[List[dict]] = None,
     batch_id: Optional[str] = None,
-) -> None:
-    """Create receipt_place if missing using receipt_agent + local Chroma."""
+) -> bool:
+    """Create receipt_place if missing using receipt_agent + local Chroma.
+
+    Returns:
+        True if place exists or was created; False if the receipt entity
+        is missing (orphaned receipt that can never have a place created).
+        Raises on transient / unexpected errors.
+    """
     try:
         dynamo_client.get_receipt_place(image_id, receipt_id)
         logger.debug(
@@ -116,7 +122,7 @@ async def _ensure_receipt_place_async(
             image_id=image_id,
             receipt_id=receipt_id,
         )
-        return
+        return True
     except EntityNotFoundError:
         logger.info(
             "Receipt place missing; will attempt creation",
@@ -147,7 +153,7 @@ async def _ensure_receipt_place_async(
             image_id=image_id,
             receipt_id=receipt_id,
         )
-        return
+        return False
 
     row_records: List[RowEmbeddingRecord] = []
     if line_results:
@@ -323,6 +329,7 @@ async def _ensure_receipt_place_async(
             receipt_id=receipt_id,
             place_id=place_entity.place_id,
         )
+        return True
     finally:
         try:
             chroma_client.close()
@@ -339,11 +346,16 @@ def _ensure_receipt_place(
     *,
     line_results: Optional[List[dict]] = None,
     batch_id: Optional[str] = None,
-) -> None:
-    """Synchronous wrapper for async place creation."""
+) -> bool:
+    """Synchronous wrapper for async place creation.
+
+    Returns:
+        True if place exists or was created; False if the receipt entity
+        is missing (orphaned).  Raises on transient errors.
+    """
     import asyncio
 
-    asyncio.run(
+    return asyncio.run(
         _ensure_receipt_place_async(
             image_id=image_id,
             receipt_id=receipt_id,
@@ -793,16 +805,22 @@ def _handle_internal_core(
         # and embeddings need metadata to work properly
         with operation_with_timeout("ensure_receipt_place", max_duration=120):
             unique_receipts = get_unique_receipt_and_image_ids(results)
+            skipped_orphans: set[tuple[str, int]] = set()
             missing_places = []
             for receipt_id, image_id in unique_receipts:
                 try:
-                    _ensure_receipt_place(
+                    created = _ensure_receipt_place(
                         image_id,
                         receipt_id,
                         dynamo_client,
                         line_results=results,
                         batch_id=batch_id,
                     )
+                    if not created:
+                        # Orphaned receipt — no Receipt entity in DynamoDB.
+                        # Permanently unfixable; safe to skip.
+                        skipped_orphans.add((image_id, receipt_id))
+                        continue
                     # Verify place was created (or already existed)
                     try:
                         dynamo_client.get_receipt_place(image_id, receipt_id)
@@ -829,15 +847,22 @@ def _handle_internal_core(
                     )
                     missing_places.append((image_id, receipt_id))
 
-            # Filter out receipts with missing place data instead of failing
-            # the entire batch — orphaned receipts (missing Receipt entity)
-            # will never have a place created successfully.
+            # Transient failures are still fatal — raise so the batch retries
             if missing_places:
-                missing_set = set(missing_places)
+                error_msg = (
+                    f"Receipt place is required but missing for "
+                    f"{len(missing_places)} receipt(s). "
+                    f"Failed to create place for: {missing_places[:5]}"
+                )
+                logger.error(error_msg)
+                raise ValueError(error_msg)
+
+            # Filter out permanently-orphaned receipts only
+            if skipped_orphans:
                 logger.warning(
-                    "Filtering out receipts with missing place data",
-                    missing_count=len(missing_places),
-                    missing_places=missing_places[:5],
+                    "Filtering out orphaned receipts with no Receipt entity",
+                    orphan_count=len(skipped_orphans),
+                    orphans=list(skipped_orphans)[:5],
                 )
                 filtered: list[dict] = []
                 for r in results:
@@ -848,13 +873,13 @@ def _handle_internal_core(
                     if (
                         meta["image_id"],
                         meta["receipt_id"],
-                    ) not in missing_set:
+                    ) not in skipped_orphans:
                         filtered.append(r)
                 results = filtered
 
         if not results:
             logger.warning(
-                "All results filtered out due to missing receipt places; "
+                "All results filtered out due to orphaned receipts; "
                 "marking batch complete with no embeddings saved"
             )
             if not skip_sqs:
@@ -870,7 +895,7 @@ def _handle_internal_core(
                 "openai_batch_id": openai_batch_id,
                 "status": "completed",
                 "skipped_all": True,
-                "skipped_receipt_count": len(missing_places) if missing_places else 0,
+                "skipped_receipt_count": len(skipped_orphans),
                 "result_s3_key": None,
                 "result_s3_bucket": None,
             }
@@ -1187,18 +1212,22 @@ def _handle_internal_core(
             )
 
             # Ensure receipt_place exists for partial results
+            skipped_orphans_partial: set[tuple[str, int]] = set()
             missing_places = []
             for receipt_id, image_id in get_unique_receipt_and_image_ids(
                 partial_results
             ):
                 try:
-                    _ensure_receipt_place(
+                    created = _ensure_receipt_place(
                         image_id,
                         receipt_id,
                         dynamo_client,
                         line_results=partial_results,
                         batch_id=batch_id,
                     )
+                    if not created:
+                        skipped_orphans_partial.add((image_id, receipt_id))
+                        continue
                     dynamo_client.get_receipt_place(image_id, receipt_id)
                 except Exception:
                     logger.exception(
@@ -1208,11 +1237,16 @@ def _handle_internal_core(
                     )
                     missing_places.append((image_id, receipt_id))
             if missing_places:
-                missing_set = set(missing_places)
+                raise ValueError(
+                    "Receipt place is required but missing for "
+                    f"{len(missing_places)} receipt(s) in partial results. "
+                    f"Failed to create place for: {missing_places[:5]}"
+                )
+            if skipped_orphans_partial:
                 logger.warning(
-                    "Filtering out partial results with missing place data",
-                    missing_count=len(missing_places),
-                    missing_places=missing_places[:5],
+                    "Filtering orphaned receipts from partial results",
+                    orphan_count=len(skipped_orphans_partial),
+                    orphans=list(skipped_orphans_partial)[:5],
                 )
                 filtered_partial_place: list[dict] = []
                 for r in partial_results:
@@ -1223,7 +1257,7 @@ def _handle_internal_core(
                     if (
                         meta["image_id"],
                         meta["receipt_id"],
-                    ) not in missing_set:
+                    ) not in skipped_orphans_partial:
                         filtered_partial_place.append(r)
                 partial_results = filtered_partial_place
 

--- a/infra/embedding_step_functions/unified_embedding/handlers/word_polling.py
+++ b/infra/embedding_step_functions/unified_embedding/handlers/word_polling.py
@@ -222,8 +222,14 @@ async def _ensure_receipt_place_async(
     *,
     word_results: Optional[List[dict]] = None,
     batch_id: Optional[str] = None,
-) -> None:
-    """Create receipt_place if missing using receipt_agent + local Chroma."""
+) -> bool:
+    """Create receipt_place if missing using receipt_agent + local Chroma.
+
+    Returns:
+        True if place exists or was created; False if the receipt entity
+        is missing (orphaned receipt that can never have a place created).
+        Raises on transient / unexpected errors.
+    """
     try:
         dynamo_client.get_receipt_place(image_id, receipt_id)
         logger.debug(
@@ -231,7 +237,7 @@ async def _ensure_receipt_place_async(
             image_id=image_id,
             receipt_id=receipt_id,
         )
-        return
+        return True
     except EntityNotFoundError:
         logger.info(
             "Receipt place missing; will attempt creation",
@@ -262,7 +268,7 @@ async def _ensure_receipt_place_async(
             image_id=image_id,
             receipt_id=receipt_id,
         )
-        return
+        return False
 
     word_records: List[WordEmbeddingRecord] = []
     if word_results:
@@ -436,6 +442,7 @@ async def _ensure_receipt_place_async(
             receipt_id=receipt_id,
             place_id=place_entity.place_id,
         )
+        return True
     finally:
         try:
             chroma_client.close()
@@ -452,9 +459,14 @@ def _ensure_receipt_place(
     *,
     word_results: Optional[List[dict]] = None,
     batch_id: Optional[str] = None,
-) -> None:
-    """Synchronous wrapper for async place creation."""
-    asyncio.run(
+) -> bool:
+    """Synchronous wrapper for async place creation.
+
+    Returns:
+        True if place exists or was created; False if the receipt entity
+        is missing (orphaned).  Raises on transient errors.
+    """
+    return asyncio.run(
         _ensure_receipt_place_async(
             image_id=image_id,
             receipt_id=receipt_id,
@@ -920,16 +932,22 @@ def _handle_internal_core(
         # and embeddings need place data to work properly
         with operation_with_timeout("ensure_receipt_place", max_duration=120):
             unique_receipts = get_unique_receipt_and_image_ids(results)
+            skipped_orphans: set[tuple[str, int]] = set()
             missing_places = []
             for receipt_id, image_id in unique_receipts:
                 try:
-                    _ensure_receipt_place(
+                    created = _ensure_receipt_place(
                         image_id,
                         receipt_id,
                         dynamo_client,
                         word_results=results,
                         batch_id=batch_id,
                     )
+                    if not created:
+                        # Orphaned receipt — no Receipt entity in DynamoDB.
+                        # Permanently unfixable; safe to skip.
+                        skipped_orphans.add((image_id, receipt_id))
+                        continue
                     # Verify place was created (or already existed)
                     try:
                         dynamo_client.get_receipt_place(image_id, receipt_id)
@@ -956,15 +974,22 @@ def _handle_internal_core(
                     )
                     missing_places.append((image_id, receipt_id))
 
-            # Filter out receipts with missing place data instead of failing
-            # the entire batch — orphaned receipts (missing Receipt entity)
-            # will never have a place created successfully.
+            # Transient failures are still fatal — raise so the batch retries
             if missing_places:
-                missing_set = set(missing_places)
+                error_msg = (
+                    f"Receipt place is required but missing for "
+                    f"{len(missing_places)} receipt(s). "
+                    f"Failed to create place for: {missing_places[:5]}"
+                )
+                logger.error(error_msg)
+                raise ValueError(error_msg)
+
+            # Filter out permanently-orphaned receipts only
+            if skipped_orphans:
                 logger.warning(
-                    "Filtering out receipts with missing place data",
-                    missing_count=len(missing_places),
-                    missing_places=missing_places[:5],
+                    "Filtering out orphaned receipts with no Receipt entity",
+                    orphan_count=len(skipped_orphans),
+                    orphans=list(skipped_orphans)[:5],
                 )
                 filtered: list[dict] = []
                 for r in results:
@@ -975,13 +1000,13 @@ def _handle_internal_core(
                     if (
                         meta["image_id"],
                         meta["receipt_id"],
-                    ) not in missing_set:
+                    ) not in skipped_orphans:
                         filtered.append(r)
                 results = filtered
 
         if not results:
             logger.warning(
-                "All results filtered out due to missing receipt places; "
+                "All results filtered out due to orphaned receipts; "
                 "marking batch complete with no embeddings saved"
             )
             if not skip_sqs:
@@ -997,7 +1022,7 @@ def _handle_internal_core(
                 "openai_batch_id": openai_batch_id,
                 "status": "completed",
                 "skipped_all": True,
-                "skipped_receipt_count": len(missing_places) if missing_places else 0,
+                "skipped_receipt_count": len(skipped_orphans),
                 "result_s3_key": None,
                 "result_s3_bucket": None,
             }
@@ -1272,18 +1297,22 @@ def _handle_internal_core(
             )
 
             # Ensure receipt_place exists for partial results
+            skipped_orphans_partial: set[tuple[str, int]] = set()
             missing_places = []
             for receipt_id, image_id in get_unique_receipt_and_image_ids(
                 partial_results
             ):
                 try:
-                    _ensure_receipt_place(
+                    created = _ensure_receipt_place(
                         image_id,
                         receipt_id,
                         dynamo_client,
                         word_results=partial_results,
                         batch_id=batch_id,
                     )
+                    if not created:
+                        skipped_orphans_partial.add((image_id, receipt_id))
+                        continue
                     dynamo_client.get_receipt_place(image_id, receipt_id)
                 except Exception:
                     logger.exception(
@@ -1293,11 +1322,16 @@ def _handle_internal_core(
                     )
                     missing_places.append((image_id, receipt_id))
             if missing_places:
-                missing_set = set(missing_places)
+                raise ValueError(
+                    "Receipt place is required but missing for "
+                    f"{len(missing_places)} receipt(s) in partial results. "
+                    f"Failed to create place for: {missing_places[:5]}"
+                )
+            if skipped_orphans_partial:
                 logger.warning(
-                    "Filtering out partial results with missing place data",
-                    missing_count=len(missing_places),
-                    missing_places=missing_places[:5],
+                    "Filtering orphaned receipts from partial results",
+                    orphan_count=len(skipped_orphans_partial),
+                    orphans=list(skipped_orphans_partial)[:5],
                 )
                 filtered_partial_place: list[dict] = []
                 for r in partial_results:
@@ -1308,7 +1342,7 @@ def _handle_internal_core(
                     if (
                         meta["image_id"],
                         meta["receipt_id"],
-                    ) not in missing_set:
+                    ) not in skipped_orphans_partial:
                         filtered_partial_place.append(r)
                 partial_results = filtered_partial_place
 


### PR DESCRIPTION
# Pull Request

## Summary

- Skip missing `Receipt` entities during embedding ingest instead of failing the entire step function
- 228 images have orphaned lines/words/letters (sub-items exist under `RECEIPT#00001#LINE#...` but the `RECEIPT#00001` entity itself is missing) — a long-standing data integrity issue spanning Sep 2025 to Feb 2026
- Both line and word ingest step functions now gracefully skip these orphaned receipts, process the valid ones, and log warnings for observability

## Type of Change

- [x] Bug fix (non-breaking change that resolves an issue)

## Which Package(s) are Affected?

- [x] Infrastructure (Pulumi)

## Testing

- [ ] Unit tests pass locally (`pytest` or `npm test`)
- [ ] Integration tests pass locally (if applicable)
- [ ] Added or updated tests for new functionality
- [x] All existing tests still pass with these changes
- [x] Manual testing completed (if applicable)

## Documentation & Code Quality

- [x] Documentation or comments updated for complex logic
- [ ] README updated (if introducing new feature/dependency)
- [ ] TypeDoc/JSDoc comments added where needed
- [x] No new warnings or linting issues introduced
- [x] Code follows project style guidelines

## Related Issues

- Blocks embedding reset/re-ingestion after PR #821 (sanitize oversized metadata keys)
- Related to PR #824 (`REGIONAL_REOCR` enum fix that also unblocked the reset)
- Root cause: 228 images missing `RECEIPT#00001` and `RECEIPT_PLACE` entities while having all sub-items (lines, words, letters, labels). This predates the current session and spans back to Sep 2025.

## Impact Analysis

- **Line ingest Lambda** (`line_polling.py`): `_get_receipt_descriptions()` now catches `EntityNotFoundError` per-receipt and returns a set of skipped `(image_id, receipt_id)` pairs. Results are filtered to exclude skipped receipts before delta save. If all results are skipped, the batch is marked complete and the Lambda returns early.
- **Word ingest Lambda** (`word_polling.py`): Same changes as line ingest.
- **No impact on other packages** — changes are isolated to the two polling handlers.
- **Existing valid receipts are unaffected** — only orphaned items (no `Receipt` entity) are skipped.

## Deployment Notes

- After merging, run `pulumi up` to rebuild the Lambda container images (CodeBuild auto-triggers on source change).
- Then re-trigger the ingest step functions:
  ```bash
  aws stepfunctions start-execution \
    --state-machine-arn "arn:aws:states:us-east-1:681647709217:stateMachine:line-ingest-sf-dev-1554303" \
    --region us-east-1
  aws stepfunctions start-execution \
    --state-machine-arn "arn:aws:states:us-east-1:681647709217:stateMachine:word-ingest-sf-dev-8fa425a" \
    --region us-east-1
  ```
- The 228 orphaned images should be investigated separately to determine why the `Receipt` entity creation fails.

---

This PR will be reviewed by CI/CD checks and automated analysis tools. Please ensure all checks pass before requesting human review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Gracefully skip items with missing receipt/place data instead of failing processing; return explicit skip indicators so flows can continue.
  * Ensure batches complete correctly when some or all items are missing, including a skipped_all outcome when appropriate.
  * Filter partial and full result sets to exclude missing items, avoiding erroneous saves or updates.
  * Expanded logging and metrics for skipped items, filtered counts, and batch state to improve observability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->