### PR TITLE
hotfix: remove duplicate words= kwarg in unified_receipt_evaluator

### DIFF
--- a/infra/label_evaluator_step_functions/lambdas/unified_receipt_evaluator.py
+++ b/infra/label_evaluator_step_functions/lambdas/unified_receipt_evaluator.py
@@ -1108,8 +1108,6 @@ async def unified_receipt_evaluator(
                     image_id=image_id,
                     receipt_id=receipt_id,
                     merchant_name=merchant_name,
-                    words=words,
-                    line_item_patterns=line_item_patterns,
                 )
                 financial_result = two_tier_result.decisions
                 financial_duration = two_tier_result.duration_seconds


### PR DESCRIPTION
## Summary
- Prod `label-evaluator-prod-unified-evaluator` Lambda is crashing on every invocation with `Runtime.UserCodeSyntaxError: keyword argument repeated: words` (handler.py line 1111). 130 of 165 invocations failed in execution `38b889e1-03e3-4f0f-b24b-fc69bb47d8a8`, causing the step function to fail with `States.DataLimitExceeded` (the aggregated error tracebacks blew past the 256 KB Map result cap).
- Root cause: when #861 was rebased onto #774, the conflict resolution accidentally kept #774's call-site kwargs (`words=words`, `line_item_patterns=line_item_patterns`) on the new `run_two_tier_financial_validation_async` call. The function signature doesn't take `line_item_patterns` — classification now uses `labels` instead.
- CI didn't catch this because none of the Python test suites import the Lambda handler module, and Smoke Tests don't exercise this Lambda.

## Test plan
- [x] `python3 -c "import ast; ast.parse(...)"` confirms syntax now valid
- [ ] CI passes
- [ ] Deploy job redeploys prod Lambdas
- [ ] Re-run prod step function to confirm crashing path is fixed

## Follow-ups (separate PRs)
- Add a smoke test that imports the unified_evaluator handler so this class of bug fails CI in the future.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved receipt context handling in financial validation processing to ensure more accurate validation of receipt data.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tnorlund/Portfolio/pull/876?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->