### PR TITLE
fix: bulk receipt ingest correctness (Grok 4.3 + place_id retry + GSI4)

### DIFF
--- a/infra/fix_place_lambda/infrastructure.py
+++ b/infra/fix_place_lambda/infrastructure.py
@@ -180,7 +180,7 @@ class FixPlaceLambda(ComponentResource):
                 "RECEIPT_PLACES_AWS_REGION": "us-east-1",
                 # OpenRouter (for LLM calls)
                 "OPENROUTER_API_KEY": openrouter_api_key,
-                "OPENROUTER_MODEL": "x-ai/grok-4.1-fast",
+                "OPENROUTER_MODEL": "x-ai/grok-4.3",
                 # OpenAI (for embeddings)
                 "RECEIPT_AGENT_OPENAI_API_KEY": openai_api_key,
                 # Chroma Cloud

--- a/infra/fix_place_lambda/lambdas/fix_place.py
+++ b/infra/fix_place_lambda/lambdas/fix_place.py
@@ -195,12 +195,44 @@ def handler(  # pylint: disable=unused-argument
 
         _propagate_env_vars()
 
-        # Run the LangGraph agent on the persistent event loop
-        agent_result, details = _loop.run_until_complete(
-            _run_place_finder(image_id, receipt_id, reason)
-        )
+        # The agent occasionally returns found=true with merchant_name but
+        # empty/None place_id. place_id is the canonical key — without it
+        # we can't write a usable ReceiptPlace. Retry up to MAX_ATTEMPTS,
+        # augmenting the reason on each retry so the agent knows to find
+        # the Google Places place_id explicitly.
+        MAX_ATTEMPTS = 3
+        agent_result = None
+        details = None
+        attempted_reason = reason
+        for attempt in range(1, MAX_ATTEMPTS + 1):
+            agent_result, details = _loop.run_until_complete(
+                _run_place_finder(image_id, receipt_id, attempted_reason)
+            )
+            if (
+                agent_result
+                and agent_result.get("found")
+                and agent_result.get("merchant_name")
+                and agent_result.get("place_id")
+            ):
+                break
+            logger.warning(
+                "place_finder attempt %d/%d incomplete: found=%s merchant=%s "
+                "place_id=%s",
+                attempt,
+                MAX_ATTEMPTS,
+                bool(agent_result and agent_result.get("found")),
+                bool(agent_result and agent_result.get("merchant_name")),
+                bool(agent_result and agent_result.get("place_id")),
+            )
+            attempted_reason = (
+                f"{reason}\n\n[Retry {attempt}] Previous attempt returned "
+                f"merchant='{agent_result.get('merchant_name') if agent_result else ''}' "
+                f"but no Google Places place_id. The place_id is REQUIRED. "
+                f"Use the Google Places search tools to find a matching "
+                f"place_id (format ChIJ…) before submitting."
+            )
 
-        current_place = details.place
+        current_place = details.place if details else None
         old_merchant = current_place.merchant_name if current_place else None
 
         if not agent_result or not agent_result.get("found"):
@@ -210,6 +242,7 @@ def handler(  # pylint: disable=unused-argument
                 "image_id": image_id,
                 "receipt_id": receipt_id,
                 "old_merchant": old_merchant,
+                "attempts": MAX_ATTEMPTS,
                 "reasoning": (
                     agent_result.get("reasoning", "") if agent_result else ""
                 ),
@@ -225,6 +258,24 @@ def handler(  # pylint: disable=unused-argument
                 "image_id": image_id,
                 "receipt_id": receipt_id,
                 "old_merchant": old_merchant,
+                "reasoning": agent_result.get("reasoning", ""),
+                "fields_found": agent_result.get("fields_found", []),
+            }
+
+        # Guard: place_id is the canonical Google Places key. Without it,
+        # downstream consumers can't refresh the place data later.
+        if not agent_result.get("place_id"):
+            return {
+                "success": False,
+                "error": (
+                    f"Agent found a place named "
+                    f"'{agent_result.get('merchant_name')}' but no "
+                    f"Google Places place_id after {MAX_ATTEMPTS} attempts"
+                ),
+                "image_id": image_id,
+                "receipt_id": receipt_id,
+                "old_merchant": old_merchant,
+                "attempts": MAX_ATTEMPTS,
                 "reasoning": agent_result.get("reasoning", ""),
                 "fields_found": agent_result.get("fields_found", []),
             }

--- a/infra/upload_images/infra.py
+++ b/infra/upload_images/infra.py
@@ -474,7 +474,7 @@ class UploadImages(ComponentResource):
                 # OpenRouter LLM provider
                 "OPENROUTER_API_KEY": openrouter_api_key,
                 "OPENROUTER_BASE_URL": "https://openrouter.ai/api/v1",
-                "OPENROUTER_MODEL": "x-ai/grok-4.1-fast",
+                "OPENROUTER_MODEL": "x-ai/grok-4.3",
                 "LANGCHAIN_API_KEY": langchain_api_key,
                 "LANGCHAIN_TRACING_V2": "true",  # Enable Langsmith tracing (LangChain)
                 "LANGSMITH_TRACING": "true",  # Enable Langsmith tracing (@traceable decorator)
@@ -685,7 +685,7 @@ class UploadImages(ComponentResource):
                 # OpenRouter LLM provider
                 "OPENROUTER_API_KEY": openrouter_api_key,
                 "OPENROUTER_BASE_URL": "https://openrouter.ai/api/v1",
-                "OPENROUTER_MODEL": "x-ai/grok-4.1-fast",
+                "OPENROUTER_MODEL": "x-ai/grok-4.3",
                 "LANGCHAIN_API_KEY": langchain_api_key,
                 "LANGCHAIN_TRACING_V2": "true",  # Enable Langsmith tracing (LangChain)
                 "LANGSMITH_TRACING": "true",  # Enable Langsmith tracing (@traceable decorator)

--- a/receipt_ocr_swift/Sources/ReceiptOCRCore/Models/ReceiptWordLabel.swift
+++ b/receipt_ocr_swift/Sources/ReceiptOCRCore/Models/ReceiptWordLabel.swift
@@ -96,6 +96,17 @@ public struct ReceiptWordLabel: Equatable {
         )
     }
 
+    /// GSI4 key for the receipt-details access pattern.
+    /// Used by `get_receipt_details` to fetch every entity for a receipt
+    /// (Receipt + Lines + Words + Labels + Place) in a single GSI query.
+    /// Must match `ReceiptWordLabel.gsi4_key()` in receipt_dynamo (Python).
+    public var gsi4Key: (pk: String, sk: String) {
+        (
+            pk: String(format: "IMAGE#%@#RECEIPT#%05d", imageId, receiptId),
+            sk: String(format: "4_LABEL#%05d#%05d#%@", lineId, wordId, label)
+        )
+    }
+
     /// Convert to DynamoDB item dictionary for batch write.
     /// Returns a dictionary with keys and string/number values.
     /// The actual DynamoDB.AttributeValue conversion happens in SotoDynamoClient.
@@ -104,6 +115,7 @@ public struct ReceiptWordLabel: Equatable {
         let gsi1 = gsi1Key
         let gsi2 = gsi2Key
         let gsi3 = gsi3Key
+        let gsi4 = gsi4Key
 
         var item: [String: Any] = [
             "PK": keys.pk,
@@ -114,6 +126,8 @@ public struct ReceiptWordLabel: Equatable {
             "GSI2SK": gsi2.sk,
             "GSI3PK": gsi3.pk,
             "GSI3SK": gsi3.sk,
+            "GSI4PK": gsi4.pk,
+            "GSI4SK": gsi4.sk,
             "TYPE": "RECEIPT_WORD_LABEL",
             "timestamp_added": ISO8601Python.format(timestampAdded),
             "validation_status": validationStatus.rawValue,

--- a/scripts/backfill_receipt_word_label_gsi4.py
+++ b/scripts/backfill_receipt_word_label_gsi4.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Backfill GSI4PK/GSI4SK on RECEIPT_WORD_LABEL items missing them.
+
+The Swift Mac worker historically wrote ReceiptWordLabel items without GSI4
+keys, making them invisible to get_receipt_details (which queries GSI4).
+This script scans the table and patches any such items.
+"""
+import boto3
+
+TABLE = "ReceiptsTable-dc5be22"
+ddb = boto3.client("dynamodb")
+
+
+def parse_sk(sk: str):
+    # SK = RECEIPT#00001#LINE#00002#WORD#00003#LABEL#ADDRESS_LINE
+    parts = sk.split("#")
+    return {
+        "receipt_id": int(parts[1]),
+        "line_id": int(parts[3]),
+        "word_id": int(parts[5]),
+        "label": parts[7],
+    }
+
+
+def main():
+    patched = 0
+    already_ok = 0
+    scanned = 0
+    paginator = ddb.get_paginator("scan")
+    page_iter = paginator.paginate(
+        TableName=TABLE,
+        FilterExpression="#t = :t AND attribute_not_exists(GSI4PK)",
+        ExpressionAttributeNames={"#t": "TYPE"},
+        ExpressionAttributeValues={":t": {"S": "RECEIPT_WORD_LABEL"}},
+        ProjectionExpression="PK, SK",
+    )
+    for page in page_iter:
+        for item in page.get("Items", []):
+            scanned += 1
+            pk = item["PK"]["S"]  # IMAGE#<uuid>
+            sk = item["SK"]["S"]
+            image_id = pk.split("#", 1)[1]
+            meta = parse_sk(sk)
+            gsi4pk = f"IMAGE#{image_id}#RECEIPT#{meta['receipt_id']:05d}"
+            gsi4sk = f"4_LABEL#{meta['line_id']:05d}#{meta['word_id']:05d}#{meta['label']}"
+            ddb.update_item(
+                TableName=TABLE,
+                Key={"PK": {"S": pk}, "SK": {"S": sk}},
+                UpdateExpression="SET GSI4PK = :pk, GSI4SK = :sk",
+                ConditionExpression="attribute_not_exists(GSI4PK)",
+                ExpressionAttributeValues={
+                    ":pk": {"S": gsi4pk},
+                    ":sk": {"S": gsi4sk},
+                },
+            )
+            patched += 1
+            if patched % 25 == 0:
+                print(f"  patched {patched}/{scanned}")
+    print(f"\nDONE — scanned {scanned} items missing GSI4PK, patched {patched}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
Three bugs surfaced during a 49-receipt bulk ingest on dev. All have source fixes; dev was already patched out-of-band (env vars + DB backfill) so the in-flight batch could complete.

### 1. OpenRouter `grok-4.1-fast` is deprecated → 404
Switched three Lambda env configs to `x-ai/grok-4.3`:
- `infra/fix_place_lambda/infrastructure.py`
- `infra/upload_images/infra.py` (process_ocr — runs merchant validation on every fresh ingest)
- `infra/upload_images/infra.py` (embed_ndjson)

### 2. `fix_place` Lambda silently accepts empty `place_id`
The place_finder LangGraph agent sometimes returns `found=true` with a valid `merchant_name` but `place_id=None`. `place_id` is the canonical Google Places key — without it, ReceiptPlace can't be refreshed later. 19 of 49 receipts hit this on the bulk ingest.

Fix: retry the agent up to 3 times with augmented reason instructing it to find a `place_id` (ChIJ… format) before submitting. Hard-fail with a clear error if all 3 attempts return empty.

### 3. Swift Mac worker writes `ReceiptWordLabel` without `GSI4PK`/`GSI4SK`
`get_receipt_details` (Python) reads from GSI4; labels missing GSI4 keys are invisible to it. Symptom: `get_receipt_words` MCP returned `labels: null` on words that demonstrably had labels (proven via raw DynamoDB query and `list_words_by_label`). All 8 parallel labeling agents hit "already exists" errors on the bulk ingest because of this.

Fix:
- Add `gsi4Key` to `ReceiptWordLabel.swift` matching `ReceiptWordLabel.gsi4_key()` (Python)
- Include `GSI4PK`/`GSI4SK` in `toDynamoItemDict()`
- One-shot backfill script (`scripts/backfill_receipt_word_label_gsi4.py`) — already run on dev (patched 194 items)

## Out of scope (followup PRs)
- `infra/qa_agent_step_functions/infrastructure.py` (4th grok-4.1-fast reference)
- `receipt_agent/receipt_agent/agents/question_answering/graph.py` (5th reference, default value)
- `scripts/test_qa_agent.py`, `scripts/evaluate_qa_agent.py`, `scripts/test_label_validation.py`, `scripts/test_qa_marquee_questions.py`

## Test plan
- [x] Grok env patches applied to `fix-place-dev-fix-place`, `upload-images-process-ocr-image-dev`
- [x] Verified `fix_place` MCP returns Chipotle on `bf3fae63-...` post-patch
- [x] Backfill ran on dev (194 RECEIPT_WORD_LABEL items patched)
- [x] Verified post-backfill: `get_receipt_words` now returns both ADDRESS_LINE PENDING + MERCHANT_NAME VALID on the same word
- [ ] fix_place retry behavior — requires Lambda rebuild via Pulumi (deferred)
- [ ] Swift GSI4 fix — requires Mac worker rebuild before any future ingest

## Deployment note
Do NOT `pulumi up --stack dev` from this branch — provider versions are older than what's deployed (`aws default_7_30_0 → 7_10_0`, `command 1_2_0 → 1_1_3`), triggering ~85 unrelated changes. Merge to main, deploy from a provider-aligned branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)