### PR TITLE
fix(imageFormat): size-tier OUTER, format INNER in fallback loop

### DIFF
--- a/portfolio/utils/imageFormat.test.ts
+++ b/portfolio/utils/imageFormat.test.ts
@@ -131,6 +131,31 @@ describe("getBestImageUrl", () => {
     process.env = { ...process.env, NODE_ENV: originalEnv };
   });
 
+  test("prefers thumbnail JPEG over medium AVIF when caller asked for thumbnail", () => {
+    // Codex P2 regression guard: a 'thumbnail' request must NOT skip a
+    // tiny thumbnail JPEG just because a larger medium AVIF exists.
+    // Bandwidth at the smallest tier beats codec efficiency.
+    const image = {
+      cdn_s3_key: "a.jpg",
+      cdn_avif_s3_key: "a.avif",
+      cdn_medium_avif_s3_key: "a_med.avif",
+      cdn_thumbnail_s3_key: "a_thumb.jpg",
+      // Note: no thumbnail AVIF or WebP available
+    };
+
+    const originalEnv = process.env.NODE_ENV;
+    process.env = { ...process.env, NODE_ENV: "production" };
+
+    const url = getBestImageUrl(
+      image,
+      { supportsAVIF: true, supportsWebP: true },
+      "thumbnail"
+    );
+    expect(url).toBe("https://www.tylernorlund.com/a_thumb.jpg");
+
+    process.env = { ...process.env, NODE_ENV: originalEnv };
+  });
+
   test("full request returns full-size even when medium variants exist", () => {
     // Full-size request must not "borrow" the medium variant just because
     // it exists at a different size tier.

--- a/portfolio/utils/imageFormat.ts
+++ b/portfolio/utils/imageFormat.ts
@@ -181,37 +181,25 @@ export const getBestImageUrl = (
     }
   };
 
-  const getKey = (format: 'jpeg' | 'webp' | 'avif'): string | undefined => {
-    for (const s of sizeFallback[size]) {
+  // Iterate size tier OUTER, format INNER: a 'thumbnail' request must
+  // prefer a thumbnail-JPEG over a medium-AVIF (bandwidth beats format
+  // quality at the smallest tiers). Only fall through to a larger size
+  // when no format at the current tier is available.
+  const preferredFormats: Array<'avif' | 'webp' | 'jpeg'> = [];
+  if (formatSupport.supportsAVIF) preferredFormats.push('avif');
+  if (formatSupport.supportsWebP) preferredFormats.push('webp');
+  preferredFormats.push('jpeg');
+
+  for (const s of sizeFallback[size]) {
+    for (const format of preferredFormats) {
       const key = keyForSize(s, format);
-      if (key) return key;
-    }
-    return undefined;
-  };
-
-  // Try AVIF first if supported
-  if (formatSupport.supportsAVIF) {
-    const avifKey = getKey('avif');
-    if (avifKey) {
-      return `${baseUrl}/${avifKey}`;
+      if (key) {
+        return `${baseUrl}/${key}`;
+      }
     }
   }
 
-  // Try WebP if supported
-  if (formatSupport.supportsWebP) {
-    const webpKey = getKey('webp');
-    if (webpKey) {
-      return `${baseUrl}/${webpKey}`;
-    }
-  }
-
-  // Fallback to JPEG
-  const jpegKey = getKey('jpeg');
-  if (jpegKey) {
-    return `${baseUrl}/${jpegKey}`;
-  }
-
-  // Ultimate fallback to full-size JPEG if specific size not available
+  // Ultimate fallback to full-size JPEG if nothing else available
   return `${baseUrl}/${image.cdn_s3_key}`;
 };
 


### PR DESCRIPTION
## Why

Addresses [Codex's P2 review comment on #880](https://github.com/tnorlund/Portfolio/pull/880#discussion). The previous fallback loop tried AVIF across all size tiers before trying WebP/JPEG at the requested size — so a \`'thumbnail'\` request could return a **medium AVIF (~52 KB)** when a **thumbnail JPEG (~6.8 KB)** was available. That's a 7× bandwidth regression that contradicts the explicit size intent.

## Fix

Restructure the loop to iterate **size-tier OUTER, format INNER**:

```ts
// Before: format outer, size inner
for each format (AVIF → WebP → JPEG):
  for each size (requested → fallback chain):
    if key exists: return

// After: size outer, format inner
for each size (requested → fallback chain):
  for each format (AVIF → WebP → JPEG):
    if key exists: return
```

Now the function picks the best format **at the smallest available size**, only falling through to a larger tier when no format exists for the current tier.

## Impact today

**Zero on current production traffic.** I verified that the upload pipeline generates all 12 variants (3 formats × 4 sizes) and every receipt's DynamoDB record has all 13 CDN fields populated. The partial-variant scenario doesn't happen for real data.

This is defensive — it makes the code match its documented size-tier intent and is robust to future partial-variant cases (e.g., AVIF generation failing for some receipts, or a new pipeline phase that ships fewer variants).

## Test plan
- [x] New test \`prefers thumbnail JPEG over medium AVIF when caller asked for thumbnail\` covers Codex's exact scenario
- [x] All 8 existing imageFormat tests pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)