### PR TITLE
perf(api): mirror #880 perf pattern across 7 user-facing Lambdas + shrink WordSimilarity placeholder

### DIFF
--- a/infra/routes/address_similarity/handler/index.py
+++ b/infra/routes/address_similarity/handler/index.py
@@ -56,6 +56,7 @@ def handler(event, _context):
             "headers": {
                 "Content-Type": "application/json",
                 "Access-Control-Allow-Origin": "*",
+                "Cache-Control": "public, max-age=60, s-maxage=60, stale-while-revalidate=300",
             },
         }
 

--- a/infra/routes/address_similarity/infra.py
+++ b/infra/routes/address_similarity/infra.py
@@ -100,7 +100,7 @@ def create_address_similarity_lambda(
                 "S3_CACHE_BUCKET": Output.from_input(cache_bucket_name),
             }
         },
-        memory_size=256,
+        memory_size=1024,
         timeout=30,  # Should be very fast since it's just reading from S3
         tags={"environment": stack},
     )

--- a/infra/routes/image_details_cache/handler/index.py
+++ b/infra/routes/image_details_cache/handler/index.py
@@ -83,6 +83,7 @@ def handler(event, _context):
             "headers": {
                 "Content-Type": "application/json",
                 "Access-Control-Allow-Origin": "*",
+                "Cache-Control": "public, max-age=60, s-maxage=60, stale-while-revalidate=300",
             },
         }
 

--- a/infra/routes/image_details_cache/infra.py
+++ b/infra/routes/image_details_cache/infra.py
@@ -99,7 +99,7 @@ def create_image_details_cache_lambda(
                 "S3_CACHE_BUCKET": Output.from_input(cache_bucket_name),
             }
         },
-        memory_size=256,
+        memory_size=1024,
         timeout=30,
         tags={"environment": stack},
     )

--- a/infra/routes/label_validation_timeline/handler/index.py
+++ b/infra/routes/label_validation_timeline/handler/index.py
@@ -99,6 +99,7 @@ def handler(event, _context):
             "headers": {
                 "Content-Type": "application/json",
                 "Access-Control-Allow-Origin": "*",
+                "Cache-Control": "public, max-age=60, s-maxage=60, stale-while-revalidate=300",
             },
         }
 

--- a/infra/routes/label_validation_timeline/infra.py
+++ b/infra/routes/label_validation_timeline/infra.py
@@ -109,7 +109,7 @@ def create_label_validation_timeline_lambda(
                 }
             )
         ),
-        memory_size=256,
+        memory_size=1024,
         timeout=30,  # Fast since it just reads from S3
         tags={"environment": stack},
     )

--- a/infra/routes/label_validation_viz_cache/infra.py
+++ b/infra/routes/label_validation_viz_cache/infra.py
@@ -202,7 +202,7 @@ class LabelValidationVizCache(ComponentResource):
                     "S3_CACHE_BUCKET": cache_bucket_output,
                 }
             ),
-            memory_size=256,
+            memory_size=1024,
             timeout=30,
             tags={"environment": stack},
             opts=ResourceOptions(parent=self),

--- a/infra/routes/label_validation_viz_cache/lambdas/index.py
+++ b/infra/routes/label_validation_viz_cache/lambdas/index.py
@@ -325,6 +325,7 @@ def handler(event: dict[str, Any], _context: Any) -> dict[str, Any]:
             "headers": {
                 "Content-Type": "application/json",
                 "Access-Control-Allow-Origin": "*",
+                "Cache-Control": "public, max-age=60, s-maxage=60, stale-while-revalidate=300",
             },
         }
 

--- a/infra/routes/layoutlm_inference/handler/index.py
+++ b/infra/routes/layoutlm_inference/handler/index.py
@@ -244,6 +244,7 @@ def handler(event, _context):
                     "headers": {
                         "Content-Type": "application/json",
                         "Access-Control-Allow-Origin": "*",
+                        "Cache-Control": "public, max-age=60, s-maxage=60, stale-while-revalidate=300",
                     },
                 }
 
@@ -321,6 +322,7 @@ def handler(event, _context):
             "headers": {
                 "Content-Type": "application/json",
                 "Access-Control-Allow-Origin": "*",
+                "Cache-Control": "public, max-age=60, s-maxage=60, stale-while-revalidate=300",
             },
         }
 

--- a/infra/routes/layoutlm_inference/infra.py
+++ b/infra/routes/layoutlm_inference/infra.py
@@ -109,7 +109,7 @@ def create_layoutlm_inference_lambda(
                 }
             )
         ),
-        memory_size=256,
+        memory_size=1024,
         timeout=30,  # Should be very fast since it's just reading from S3
         tags={"environment": stack},
     )

--- a/infra/routes/qa_viz_cache/infra.py
+++ b/infra/routes/qa_viz_cache/infra.py
@@ -126,7 +126,7 @@ class QAVizCache(ComponentResource):
                     "S3_CACHE_BUCKET": cache_bucket_output,
                 }
             ),
-            memory_size=256,
+            memory_size=1024,
             timeout=30,
             tags={"environment": stack},
             opts=ResourceOptions(parent=self),

--- a/infra/routes/qa_viz_cache/lambdas/index.py
+++ b/infra/routes/qa_viz_cache/lambdas/index.py
@@ -33,13 +33,18 @@ s3_client = boto3.client("s3")
 
 def _cors_response(status_code: int, body: Any) -> dict:
     """Build an API Gateway v2 response with CORS headers."""
+    headers = {
+        "Content-Type": "application/json",
+        "Access-Control-Allow-Origin": "*",
+    }
+    if status_code == 200:
+        headers["Cache-Control"] = (
+            "public, max-age=60, s-maxage=60, stale-while-revalidate=300"
+        )
     return {
         "statusCode": status_code,
         "body": json.dumps(body, default=str),
-        "headers": {
-            "Content-Type": "application/json",
-            "Access-Control-Allow-Origin": "*",
-        },
+        "headers": headers,
     }
 
 

--- a/infra/routes/word_similarity/handler/index.py
+++ b/infra/routes/word_similarity/handler/index.py
@@ -56,6 +56,7 @@ def handler(event, _context):
             "headers": {
                 "Content-Type": "application/json",
                 "Access-Control-Allow-Origin": "*",
+                "Cache-Control": "public, max-age=60, s-maxage=60, stale-while-revalidate=300",
             },
         }
 

--- a/infra/routes/word_similarity/infra.py
+++ b/infra/routes/word_similarity/infra.py
@@ -104,7 +104,7 @@ def create_word_similarity_lambda(
                 "S3_CACHE_BUCKET": Output.from_input(cache_bucket_name),
             }
         },
-        memory_size=256,
+        memory_size=1024,
         timeout=30,
         tags={"environment": stack},
     )

--- a/portfolio/components/ui/Figures/WordSimilarity.tsx
+++ b/portfolio/components/ui/Figures/WordSimilarity.tsx
@@ -255,7 +255,7 @@ const WordSimilarity: React.FC = () => {
   }, []);
 
   if (!nearViewport || loading) {
-    const reservedHeight = windowWidth <= 768 ? 600 : 900;
+    const reservedHeight = windowWidth <= 768 ? 100 : 120;
     return (
       <div
         ref={lazyRef}


### PR DESCRIPTION
## Context

User reported a regression on www.tylernorlund.com: the **So Now What?** section appeared to take a long time to load on the homepage. After investigating, the *visible* symptom is actually the **WordSimilarity** figure loading slowly — ~9 s end-to-end — which reserves a **900 px** placeholder on desktop / 600 px on mobile. While the API request is in flight, the page has a giant blank gap above and below the next figure, making it look like everything below is broken.

## Root cause

Three things were happening at once for `word_similarity` (and turned out to be the same story for 6 other user-facing routes):

1. The API Lambda is provisioned at **256 MB**, which gets fractional CPU. JSON serialization + S3 reads take ~1.5-2 s per invocation when they could take ~500 ms.
2. The handler returns no `Cache-Control` header, so CloudFront cannot cache responses. Every page view, every reload, every pagination request hits the origin.
3. The frontend reserves a 900 px placeholder on desktop while loading. Even after fixes 1+2, there's still a network round-trip — and that placeholder makes it look catastrophic when really it's just one slow image.

## Precedent

PR **#880** ([perf(receipt page): cache API + bump Lambda memory + use thumbnails](https://github.com/tnorlund/Portfolio/pull/880)) applied exactly this pattern to `label_evaluator_viz_cache`. PR **#881** was the follow-up image-format fix. This PR mirrors **#880's** Lambda pattern across the remaining 7 user-facing 256 MB Lambdas in one sweep, plus the WordSimilarity placeholder shrink.

## Backend changes

For each route below, two sub-changes:
- `infra.py`: `memory_size=256` -> `memory_size=1024` on the API/user-facing Lambda only
- `handler/index.py` (or `lambdas/index.py`): add `"Cache-Control": "public, max-age=60, s-maxage=60, stale-while-revalidate=300"` to every 200 success response's headers

| Route                       | Infra file                                                | Handler file                                                  |
|-----------------------------|-----------------------------------------------------------|---------------------------------------------------------------|
| word_similarity             | `infra/routes/word_similarity/infra.py`                   | `infra/routes/word_similarity/handler/index.py`               |
| address_similarity          | `infra/routes/address_similarity/infra.py`                | `infra/routes/address_similarity/handler/index.py`            |
| image_details_cache         | `infra/routes/image_details_cache/infra.py`               | `infra/routes/image_details_cache/handler/index.py`           |
| label_validation_timeline   | `infra/routes/label_validation_timeline/infra.py`         | `infra/routes/label_validation_timeline/handler/index.py`     |
| label_validation_viz_cache  | `infra/routes/label_validation_viz_cache/infra.py`        | `infra/routes/label_validation_viz_cache/lambdas/index.py`    |
| layoutlm_inference          | `infra/routes/layoutlm_inference/infra.py`                | `infra/routes/layoutlm_inference/handler/index.py`            |
| qa_viz_cache                | `infra/routes/qa_viz_cache/infra.py`                      | `infra/routes/qa_viz_cache/lambdas/index.py`                  |

### Edge cases handled

- **`label_validation_viz_cache/infra.py`** has 4 `memory_size=` lines (API Lambda + cache generator + 2 step-function workers). Only the **API Lambda** at line 205 was bumped — generators and workers were left alone.
- **`layoutlm_inference/handler/index.py`** has two 200 success paths (main + legacy fallback). Both got `Cache-Control`.
- **`qa_viz_cache/lambdas/index.py`** routes every response through a `_cors_response(status_code, body)` helper. Updated the helper to add `Cache-Control` only when `status_code == 200` so 4xx/5xx responses are unaffected.
- Non-user-facing 256 MB Lambdas (`*_cache_generator`, `qa_agent_step_functions` workers, etc.) were intentionally left at 256 MB — they're invoked off the request path and don't benefit from the CPU bump or browser caching.

## Frontend change

`portfolio/components/ui/Figures/WordSimilarity.tsx` — shrunk the loading-state placeholder from **600 px (mobile) / 900 px (desktop)** to **100 px / 120 px**. Behavior is unchanged; only the inline `minHeight` value moves. Now the page no longer reserves a massive blank gap while the API loads.

## Cost notes

Lambda billing is GB-s. **4× memory at ~4× speed** is approximately cost-neutral. Cache-Control TTL of 60 s + SWR 300 s further reduces invocations on busy paths. Expected net cost change: negligible to slightly negative.

## Verification

- All 14 modified Python files pass `python3 -c "import ast; ast.parse(open(f).read())"`.
- `git diff --stat` shows 15 files / +24 / -12, exactly within the expected envelope.
- No tests changed, no dependencies touched, no opportunistic refactors.

## Test plan

- [ ] CI green on this branch
- [ ] After merge, deploy to dev and verify `curl -I https://dev-api.tylernorlund.com/word-similarity` returns the `Cache-Control` header on the 200 response
- [ ] Spot-check Lambda memory in AWS console for each of the 7 routes — should show 1024 MB after `pulumi up`
- [ ] Visual check on www.tylernorlund.com that the loading placeholder for WordSimilarity is no longer a giant gap

🤖 Generated with [Claude Code](https://claude.com/claude-code)