### PR TITLE
fix(logging): OperationLogger accepts positional %-format args

### DIFF
--- a/infra/chromadb_compaction/lambdas/utils/logging.py
+++ b/infra/chromadb_compaction/lambdas/utils/logging.py
@@ -48,28 +48,38 @@ class OperationLogger:
         self.logger = logger
         self.correlation_id = str(uuid.uuid4())
 
-    def info(self, message: str, **kwargs):
+    def info(self, message: str, *args, **kwargs):
         """Log info message with additional context."""
-        self._log_with_context(logging.INFO, message, **kwargs)
+        self._log_with_context(logging.INFO, message, *args, **kwargs)
 
-    def error(self, message: str, **kwargs):
+    def error(self, message: str, *args, **kwargs):
         """Log error message with additional context."""
-        self._log_with_context(logging.ERROR, message, **kwargs)
+        self._log_with_context(logging.ERROR, message, *args, **kwargs)
 
-    def warning(self, message: str, **kwargs):
+    def warning(self, message: str, *args, **kwargs):
         """Log warning message with additional context."""
-        self._log_with_context(logging.WARNING, message, **kwargs)
+        self._log_with_context(logging.WARNING, message, *args, **kwargs)
 
-    def debug(self, message: str, **kwargs):
+    def debug(self, message: str, *args, **kwargs):
         """Log debug message with additional context."""
-        self._log_with_context(logging.DEBUG, message, **kwargs)
+        self._log_with_context(logging.DEBUG, message, *args, **kwargs)
 
-    def exception(self, message: str, **kwargs):
+    def exception(self, message: str, *args, **kwargs):
         """Log error message with exception traceback."""
-        self._log_with_context(logging.ERROR, message, exc_info=True, **kwargs)
+        self._log_with_context(
+            logging.ERROR, message, *args, exc_info=True, **kwargs
+        )
 
-    def _log_with_context(self, level: int, message: str, **kwargs):
-        """Log message with correlation ID and extra context."""
+    def _log_with_context(self, level: int, message: str, *args, **kwargs):
+        """Log message with correlation ID and extra context.
+
+        Supports both stdlib `logging.Logger` styles:
+        - kwargs-only:  logger.info("event", run_id=x)
+        - %-formatting: logger.info("Run %s of %d", run_id, total)
+
+        Positional args are passed to ``makeRecord`` so standard ``%``-style
+        formatting still runs via ``record.getMessage()`` downstream.
+        """
         import sys
 
         exc_info = kwargs.pop("exc_info", None)
@@ -81,7 +91,7 @@ class OperationLogger:
         extra_fields = {"correlation_id": self.correlation_id, **kwargs}
 
         record = self.logger.makeRecord(
-            self.logger.name, level, "", 0, message, (), exc_info
+            self.logger.name, level, "", 0, message, args, exc_info
         )
         record.extra_fields = extra_fields
         self.logger.handle(record)

--- a/infra/embedding_step_functions/unified_embedding/utils/logging.py
+++ b/infra/embedding_step_functions/unified_embedding/utils/logging.py
@@ -48,30 +48,40 @@ class OperationLogger:
         self.logger = logger
         self.correlation_id = str(uuid.uuid4())
 
-    def info(self, message: str, **kwargs):
+    def info(self, message: str, *args, **kwargs):
         """Log info message with additional context."""
-        self._log_with_context(logging.INFO, message, **kwargs)
+        self._log_with_context(logging.INFO, message, *args, **kwargs)
 
-    def error(self, message: str, **kwargs):
+    def error(self, message: str, *args, **kwargs):
         """Log error message with additional context."""
-        self._log_with_context(logging.ERROR, message, **kwargs)
+        self._log_with_context(logging.ERROR, message, *args, **kwargs)
 
-    def warning(self, message: str, **kwargs):
+    def warning(self, message: str, *args, **kwargs):
         """Log warning message with additional context."""
-        self._log_with_context(logging.WARNING, message, **kwargs)
+        self._log_with_context(logging.WARNING, message, *args, **kwargs)
 
-    def debug(self, message: str, **kwargs):
+    def debug(self, message: str, *args, **kwargs):
         """Log debug message with additional context."""
-        self._log_with_context(logging.DEBUG, message, **kwargs)
+        self._log_with_context(logging.DEBUG, message, *args, **kwargs)
 
-    def exception(self, message: str, **kwargs):
+    def exception(self, message: str, *args, **kwargs):
         """Log exception message with traceback."""
-        self._log_with_context(logging.ERROR, message, exc_info=True, **kwargs)
+        self._log_with_context(
+            logging.ERROR, message, *args, exc_info=True, **kwargs
+        )
 
     def _log_with_context(
-        self, level: int, message: str, exc_info: bool = False, **kwargs
+        self, level: int, message: str, *args, exc_info: bool = False, **kwargs
     ):
-        """Log message with correlation ID and extra context."""
+        """Log message with correlation ID and extra context.
+
+        Supports both stdlib `logging.Logger` styles:
+        - kwargs-only:  logger.info("event", run_id=x)
+        - %-formatting: logger.info("Run %s of %d", run_id, total)
+
+        Positional args are passed to ``makeRecord`` so standard ``%``-style
+        formatting still runs via ``record.getMessage()`` downstream.
+        """
         import sys
 
         extra_fields = {"correlation_id": self.correlation_id, **kwargs}
@@ -81,7 +91,7 @@ class OperationLogger:
 
         # Create a new LogRecord with extra fields
         record = self.logger.makeRecord(
-            self.logger.name, level, "", 0, message, (), exc_info_tuple
+            self.logger.name, level, "", 0, message, args, exc_info_tuple
         )
         record.extra_fields = extra_fields
         self.logger.handle(record)


### PR DESCRIPTION
## Summary
Both `OperationLogger` classes (in `infra/chromadb_compaction/lambdas/utils/logging.py` and `infra/embedding_step_functions/unified_embedding/utils/logging.py`) declared `info(self, message: str, **kwargs)`, accepting kwargs only. Any caller using stdlib-style `%`-formatting with positional args crashes:

```
TypeError: OperationLogger.info() takes 2 positional arguments but 6 were given
```

`receipt_chroma` calls them this way in 18+ places (e.g. `compaction/deltas.py:98`):

```python
logger.info(
    "Processing compaction run: run_id=%s, image_id=%s, receipt_id=%s, delta_prefix=%s",
    run_id, image_id, receipt_id, delta_prefix,
)
```

## Symptom on dev
Discovered while debugging why backfilled embeddings for 44 receipts never reached Chroma Cloud. The `chromadb-dev-docker-dev` Lambda metrics showed:
- `CompactionLambdaSuccess: 37` (in a 12-min window)
- `CompactionDeltasMergedCount: 0`

CloudWatch logs revealed every `COMPACTION_RUN` message hitting `_process_single_run` crashed at the first `logger.info(...)` call. So **no deltas were ever merged into the snapshot**, and the dual-write to Chroma Cloud never got the new embeddings.

Existing 4 merge-delta runs from earlier today + 15 backfill runs (~19 total) all silently failed for the same reason.

## Fix
Extend the public `info`/`error`/`warning`/`debug`/`exception` signatures to `(message: str, *args, **kwargs)` and forward `args` to `logger.makeRecord`. The standard `LogRecord.getMessage()` already does `message % args` for the stdlib format.

Both styles now work:

```python
logger.info("event", run_id=x)              # kwargs-only (existing)
logger.info("Run %s of %d", run_id, total)  # stdlib %-formatting (new)
```

Applied to both `OperationLogger` copies for consistency.

## Test plan
- [x] Verified the crash + missing-delta-merges via CloudWatch logs on `chromadb-dev-docker-dev`
- [ ] Deploy compaction Lambda — should start successfully merging the 19+ backlogged `COMPACTION_RUN` records once the new image is live
- [ ] After deploy, query Chroma Cloud for any of the backfilled image_ids; should return non-empty

## Out of scope
- The original positional-style logging in `receipt_chroma` is still fine and now intentional — caller doesn't need to change. Could also be normalized to kwargs in a separate cleanup PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)