### PR TITLE
perf(word_similarity): drop unused per-receipt lines[] (3MB → 150KB)

### DIFF
--- a/infra/routes/word_similarity_cache_generator/lambdas/index.py
+++ b/infra/routes/word_similarity_cache_generator/lambdas/index.py
@@ -620,8 +620,12 @@ def handler(_event, _context):
                 price = line_total or unit_price
                 size = infer_size(product_text, price)
 
-                # Convert lines to dict format
-                lines_dict = [line_to_dict(line) for line in details.lines]
+                # NOTE: details.lines (the full per-receipt line list, ~75 lines
+                # × 69 receipts ≈ 2.8 MB across the response) is intentionally
+                # NOT included in the cache entry. WordSimilarity.tsx builds a
+                # cropped image from `receipt` + `bbox` only and never reads
+                # `lines`. Including it inflated the API payload ~20× for no
+                # frontend benefit. See PR notes / type def MilkReceiptData.
 
                 return {
                     "image_id": image_id,
@@ -631,9 +635,9 @@ def handler(_event, _context):
                     "price": price,
                     "size": size,
                     "line_id": milk_line_id,
-                    # Full receipt data for visual display
+                    # Receipt header (image_id, dimensions, CDN keys) — used
+                    # to build the image URL for visual display.
                     "receipt": receipt_to_dict(details.receipt),
-                    "lines": lines_dict,
                     "bbox": bbox,
                     "_timings": timings,
                 }

--- a/portfolio/types/api.ts
+++ b/portfolio/types/api.ts
@@ -285,7 +285,13 @@ export interface MilkReceiptData {
   size: string;
   line_id: number;
   receipt: Receipt;
-  lines: Line[];
+  /**
+   * Per-receipt line list. The frontend never reads this — the cropped
+   * image is built from `receipt` + `bbox`. Cache generator no longer
+   * emits it (saves ~95% of payload). Kept optional only so older cached
+   * responses still type-check during rollout.
+   */
+  lines?: Line[];
   bbox: AddressBoundingBox | null;
 }
 


### PR DESCRIPTION
## Why

After landing #882 (Lambda memory bump + Cache-Control on `word_similarity`), the API itself responds in ~700ms — but the user still sees \"Loading…\" for ~7.5s on the receipt page. The remaining slowness is React decoding + rendering a 3 MB JSON payload, of which 95% is unused.

## Diagnosis

Frontend audit of `WordSimilarity.tsx`:

| Field used | Source | Bytes/receipt | Notes |
|---|---|---|---|
| `image_id`, `receipt_id`, `product`, `merchant` | top-level | ~226 B | identity + alt text |
| `receipt` (image_id, dims, CDN keys) | top-level | ~1.8 KB | image URL building |
| `bbox` | top-level | ~196 B | `calculateCropRegion` |
| `summary_table`, `timing`, `commentary`, `grand_total` | top-level | small | rendered directly |
| **`lines[]`** | top-level | **~36 KB** | **never read by the component** |

`grep -n '\\.lines\\b' WordSimilarity.tsx` returns zero matches. The 5,156 ReceiptLine objects in the response account for 2.8 MB / 95% of the payload.

## Fix

- `infra/routes/word_similarity_cache_generator/lambdas/index.py` — stop bundling `details.lines` into each per-receipt cache entry.
- `portfolio/types/api.ts` — mark `MilkReceiptData.lines` as `optional` so an in-flight cache that still contains `lines` continues to type-check during rollout.

## Expected impact

| Metric | Before | After |
|---|---|---|
| `word_similarity` API response | ~3.0 MB | **~150 KB** |
| Transfer time (warm CDN) | ~700 ms | ~50 ms |
| WordSimilarity \"Loading…\" duration | ~7.5 s | **~1-2 s** |

## After-deploy step

The cache lives at `s3://<bucket>/word-similarity-cache/milk.json`. After this PR deploys, invoke the cache-generator Lambda once to regenerate the file with the trimmed payload. (Or wait for whatever cron/schedule normally regenerates it — TBD.)

## Test plan
- [x] `python3 -c "import ast; ast.parse(...)"` on the cache generator
- [x] `npx tsc --noEmit` clean
- [x] `npm run test:ci`: 39 suites / 155 tests pass
- [ ] CI green
- [ ] Post-deploy: trigger cache regeneration; re-time the API response (~150 KB) and re-time the page's WordSimilarity loading duration

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized receipt data caching by removing detailed OCR line content, reducing payload sizes and improving system efficiency.

* **API Changes**
  * Updated receipt API response structure to make OCR line details optional, maintaining backward compatibility while supporting a leaner data format.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tnorlund/Portfolio/pull/884?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->