### PR TITLE
fix(CICDLoop): stop cancelling segment animations on hasEntered flip

### DIFF
--- a/portfolio/components/ui/Figures/CICDLoop.tsx
+++ b/portfolio/components/ui/Figures/CICDLoop.tsx
@@ -586,7 +586,13 @@ const CICDLoop: React.FC<CICDLoopProps> = ({
     threshold: 0.3,
   });
   const [mounted, setMounted] = useState(false);
-  const [hasEntered, setHasEntered] = useState(false);
+  // Tracked as a ref (not state) so flipping it does NOT trigger a re-run
+  // of the animation effect below. A previous state-based version caused
+  // the effect's cleanup function to fire on the hasEntered=false→true
+  // re-render, which cancelled every staggered setTimeout the moment it
+  // was scheduled — leaving the segment springs stuck at opacity 0 (an
+  // invisible figure-8).
+  const hasEnteredRef = useRef(false);
   const timeoutIds = useRef<NodeJS.Timeout[]>([]);
   const pulseIntervalRef = useRef<NodeJS.Timeout | null>(null);
   const pulseTimeoutsRef = useRef<NodeJS.Timeout[]>([]);
@@ -608,12 +614,6 @@ const CICDLoop: React.FC<CICDLoopProps> = ({
     setMounted(true);
   }, []);
 
-  useEffect(() => {
-    if (inView && !hasEntered) {
-      setHasEntered(true);
-    }
-  }, [inView, hasEntered]);
-
   // Clear all pending timeouts
   const clearAllTimeouts = () => {
     timeoutIds.current.forEach((id) => clearTimeout(id));
@@ -630,11 +630,14 @@ const CICDLoop: React.FC<CICDLoopProps> = ({
     pulseTimeoutsRef.current = [];
   };
 
-  // Trigger animations when in view
+  // Trigger animations when in view. Note: hasEnteredRef is a ref (not
+  // state) so mutating it does not retrigger this effect — the cleanup
+  // only fires on real dep changes (inView, mounted) and on unmount.
   useEffect(() => {
     if (!mounted) return;
 
-    if (inView && !hasEntered) {
+    if (inView && !hasEnteredRef.current) {
+      hasEnteredRef.current = true;
       clearAllTimeouts();
 
       // Staggered fade-in for each segment
@@ -653,10 +656,10 @@ const CICDLoop: React.FC<CICDLoopProps> = ({
         }, index * staggerDelay);
         timeoutIds.current.push(id);
       });
-    } else if (!hasEntered) {
+    } else if (!hasEnteredRef.current) {
       clearAllTimeouts();
       clearPulseAnimation();
-      // Reset when out of view
+      // Reset when out of view (before first entrance)
       api.start(() => ({
         opacity: 0,
         transform: "scale(0.9)",
@@ -665,7 +668,7 @@ const CICDLoop: React.FC<CICDLoopProps> = ({
     }
 
     return () => clearAllTimeouts();
-  }, [inView, hasEntered, mounted, staggerDelay, api, N, segments]);
+  }, [inView, mounted, staggerDelay, api, N, segments]);
 
   // Continuous pulsing animation after all segments have animated in
   useEffect(() => {


### PR DESCRIPTION
## Why
The figure-8 animation under "So Now What?" on `/receipt` has been invisible — segment `<g>` parents stay at `opacity: 0` forever. The user-facing effect is a ~300 px tall blank space below the section's intro paragraphs.

## Diagnosis
Verified via Playwright on the deployed site:

| Path attribute | Value (pre-fix) |
|---|---|
| `path.fill` | `rgb(67, 160, 71)` (proper green) |
| `path.opacity` | `1` |
| `path.bbox` | `162 × 75` (correct) |
| **Ancestor `<g>.opacity`** | **`0`** ← invisible parent group |

So every ribbon path paints into a parent group that React-Spring leaves at `opacity: 0`. The entrance animation that's supposed to spring it to `1` never lands.

## Root cause
In `CICDLoop.tsx`, two effects raced:

1. The **animation effect** (was lines 633–668) scheduled `setTimeout(api.start, ...)` calls and registered `return () => clearAllTimeouts()` as its cleanup.
2. A **side-channel effect** (was lines 611–615) called `setHasEntered(true)` the moment `inView` flipped.

Because both `inView` and `hasEntered` were in the animation effect's dep array, the state flip caused the cleanup to fire **before any of the freshly-scheduled timeouts could execute** — wiping them all out.

```
inView: false → true
  ⤷ animation effect: schedules 7 staggered setTimeouts → timeoutIds[id1..id7]
  ⤷ side effect: setHasEntered(true)
hasEntered: false → true  (React re-render)
  ⤷ animation effect cleanup: clearAllTimeouts() ← cancels id1..id7 ❌
  ⤷ animation effect re-runs: neither branch matches → does nothing
  Springs stuck at { opacity: 0, scale: 0.9 }
```

## Fix
- Convert `hasEntered` from `useState` to `useRef`.
- Remove the side-channel effect entirely.
- Set `hasEnteredRef.current = true` inline at the moment the entrance animation is scheduled.
- Drop `hasEntered` from the animation effect's dep array.

Mutating a ref does not trigger a re-render or a dep-change re-run, so the cleanup no longer fires during the very window when the animation is being set up. The seven `api.start(...)` calls actually run, and the segment `<g>` groups spring to `opacity: 1`.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run test:ci` — 39 suites / 155 tests pass
- [ ] CI green
- [ ] Post-deploy: load `https://www.tylernorlund.com/receipt`, scroll to "So Now What?", confirm the figure-8 (Plan / Code / Build / Test / Review / Deploy / Monitor) renders and animates

🤖 Generated with [Claude Code](https://claude.com/claude-code)