### PR TITLE
feat(portfolio): restore QA agent + cross-receipt verification sections

### DIFF
--- a/portfolio/components/ui/Figures/QAAgentFlow.tsx
+++ b/portfolio/components/ui/Figures/QAAgentFlow.tsx
@@ -123,12 +123,12 @@ const EXAMPLE_TRACE: TraceStep[] = [
   },
 ];
 
-const STEP_CONFIG: Record<StepType, { color: string; label: string; icon: string; node: string }> = {
-  plan: { color: "var(--color-purple)", label: "Plan", icon: "📋", node: "1" },
-  agent: { color: "var(--color-blue)", label: "Agent", icon: "🤖", node: "2" },
-  tools: { color: "var(--color-green)", label: "Tools", icon: "🔧", node: "3" },
-  shape: { color: "var(--color-orange)", label: "Shape", icon: "📊", node: "4" },
-  synthesize: { color: "var(--color-red)", label: "Synthesize", icon: "✓", node: "5" },
+const STEP_CONFIG: Record<StepType, { color: string; label: string; icon: string; node: string; description: string }> = {
+  plan: { color: "var(--color-purple)", label: "Plan", icon: "📋", node: "1", description: "Classifying the question and picking a retrieval strategy" },
+  agent: { color: "var(--color-blue)", label: "Agent", icon: "🤖", node: "2", description: "Reasoning about the question and deciding which tools to call" },
+  tools: { color: "var(--color-green)", label: "Tools", icon: "🔧", node: "3", description: "Searching DynamoDB and ChromaDB for relevant receipts" },
+  shape: { color: "var(--color-orange)", label: "Shape", icon: "📊", node: "4", description: "Filtering and structuring receipt summaries for synthesis" },
+  synthesize: { color: "var(--color-red)", label: "Synthesize", icon: "✓", node: "5", description: "Composing the final answer with evidence citations" },
 };
 
 const CDN_BASE = "https://dev.tylernorlund.com";
@@ -531,6 +531,31 @@ const QAAgentFlow: React.FC<QAAgentFlowProps> = ({ autoPlay = true, questionData
               </svg>
             </div>
 
+            {/* Active-phase narrative — shows what the agent is doing right now */}
+            <div
+              style={{
+                minHeight: "1.6rem",
+                marginBottom: "0.5rem",
+                fontSize: "0.85rem",
+                lineHeight: "1.4",
+                color: "var(--text-color)",
+                opacity: activeStep >= 0 && trace[activeStep] ? 1 : 0.4,
+                transition: "opacity 0.3s ease",
+                textAlign: "center",
+              }}
+            >
+              {activeStep >= 0 && trace[activeStep] ? (
+                <>
+                  <strong style={{ color: STEP_CONFIG[trace[activeStep].type].color }}>
+                    {STEP_CONFIG[trace[activeStep].type].label}:
+                  </strong>{" "}
+                  {STEP_CONFIG[trace[activeStep].type].description}
+                </>
+              ) : (
+                <span style={{ fontStyle: "italic" }}>Ready</span>
+              )}
+            </div>
+
             {/* Progress bar — animated with spring */}
             <div
               style={{
@@ -566,17 +591,32 @@ const QAAgentFlow: React.FC<QAAgentFlowProps> = ({ autoPlay = true, questionData
               >
                 {trace.map((step, idx) => {
                   const cfg = STEP_CONFIG[step.type];
+                  // Only render a duration label if the segment is wide enough to read it
+                  const widthPct = barWidths[idx];
+                  const showLabel = widthPct >= 6 && step.durationMs;
                   return (
                     <div
                       key={`bar-${idx}-${step.type}`}
-                      title={`${cfg.label}: ${step.durationMs ? formatMs(step.durationMs) : "—"} (${barWidths[idx].toFixed(1)}%)`}
+                      title={`${cfg.label}: ${step.durationMs ? formatMs(step.durationMs) : "—"} (${widthPct.toFixed(1)}%)`}
                       style={{
-                        width: `${barWidths[idx]}%`,
+                        width: `${widthPct}%`,
                         height: "100%",
                         backgroundColor: cfg.color,
                         flexShrink: 0,
+                        display: "flex",
+                        alignItems: "center",
+                        justifyContent: "center",
+                        color: "rgba(255,255,255,0.95)",
+                        fontSize: "0.7rem",
+                        fontFamily: "var(--font-mono, monospace)",
+                        fontWeight: 600,
+                        textShadow: "0 0 2px rgba(0,0,0,0.4)",
+                        overflow: "hidden",
+                        whiteSpace: "nowrap",
                       }}
-                    />
+                    >
+                      {showLabel && formatMs(step.durationMs!)}
+                    </div>
                   );
                 })}
               </animated.div>

--- a/portfolio/pages/receipt.tsx
+++ b/portfolio/pages/receipt.tsx
@@ -41,7 +41,6 @@ import {
   GithubLogo,
   GoogleMapsLogo,
   LangChainLogo,
-  LangSmithLogo,
   PulumiLogo
 } from "../components/ui/Logos";
 import QueryLabelTransform from "../components/ui/QueryLabelTransform";
@@ -475,12 +474,6 @@ M1LK 2%           1    $4.4g`}</code>
       <p>
         Some work. Some don't. That's the point.
       </p>
-
-      <ClientOnly>
-        <AnimatedInView>
-          <LangSmithLogo />
-        </AnimatedInView>
-      </ClientOnly>
 
       <p>
         LangSmith records what happened: which questions worked, which failed,

--- a/portfolio/pages/receipt.tsx
+++ b/portfolio/pages/receipt.tsx
@@ -3,6 +3,7 @@ import Head from "next/head";
 import React, { useCallback, useEffect, useState } from "react";
 import ClientOnly from "../components/ClientOnly";
 import UploadProgressPanel from "../components/ui/UploadProgressPanel";
+import { useQAQueue } from "../hooks/useQAQueue";
 import { useUploadProgress } from "../hooks/useUploadProgress";
 import styles from "../styles/Receipt.module.css";
 
@@ -11,14 +12,18 @@ import AnimatedInView from "../components/ui/AnimatedInView";
 import {
   AddressSimilaritySideBySide,
   AWSFlowDiagram,
+  BetweenReceiptVisualization,
   CICDLoop,
   CodeBuildDiagram,
   DynamoStreamAnimation,
   FinancialMathOverlay,
+  LabelValidationTimeline,
   LabelWordCloud,
   LayoutLMInferenceVisualization,
   PageCurlLetter,
   PrecisionRecallDartboard,
+  QAAgentFlow,
+  QuestionMarquee,
   ReceiptBoundingBoxGrid,
   ReceiptStack,
   StreamBitsRoutingDiagram,
@@ -35,6 +40,8 @@ import {
   GithubActionsLogo,
   GithubLogo,
   GoogleMapsLogo,
+  LangChainLogo,
+  LangSmithLogo,
   PulumiLogo
 } from "../components/ui/Logos";
 import QueryLabelTransform from "../components/ui/QueryLabelTransform";
@@ -97,6 +104,9 @@ export default function ReceiptPage({
   }, []);
 
   const { fileStates, addFiles, clearAll } = useUploadProgress(apiUrl);
+
+  // --- QA Agent live data ---
+  const { data: qaData, questionIndex: selectedQuestion, advance: advanceQuestion, selectQuestion: setSelectedQuestion } = useQAQueue();
 
   const handleDrop = useCallback(
     (e: DragEvent) => {
@@ -318,6 +328,35 @@ M1LK 2%           1    $4.4g`}</code>
         <FinancialMathOverlay />
       </ClientOnly>
 
+      <p>
+        Then I compare the labels across receipts from the same store. If
+        every other Trader Joe's receipt calls that field a line total, but
+        this one says subtotal, something's off.
+      </p>
+
+      <ClientOnly>
+        <BetweenReceiptVisualization />
+      </ClientOnly>
+
+      <p>
+        This works, kind of. AI isn't consistent. It would call the price of
+        milk the subtotal. It confused "DAIRY" with "MILK." I can't trust
+        something that doesn't know what milk is. So I corrected the results
+        by asking AI to verify again.
+      </p>
+
+      <p>And again. And again.</p>
+
+      <ClientOnly>
+        <LabelValidationTimeline />
+      </ClientOnly>
+
+      <p>
+        Each pass got a little better. The red shrinks, the green grows. But
+        asking ~4 different AI, 5+ times to verify the results was slow and
+        expensive. I needed a better way.
+      </p>
+
 
       <h2>Making it Faster and Cheaper</h2>
 
@@ -413,6 +452,40 @@ M1LK 2%           1    $4.4g`}</code>
         What if I ask it a weird question? What if the receipt is formatted in
         a way I've never seen? What if the AI hallucinates a grocery store that
         doesn't exist? I need to find out.
+      </p>
+
+      <ClientOnly>
+        <AnimatedInView>
+          <LangChainLogo />
+        </AnimatedInView>
+      </ClientOnly>
+
+      <p>
+        LangChain lets me wire up the whole pipeline: question in, answer out.
+        But more importantly, it lets me throw hundreds of fake questions at
+        the system to see what breaks.
+      </p>
+
+      <ClientOnly>
+        <QAAgentFlow autoPlay={true} questionData={qaData ?? undefined} onCycleComplete={advanceQuestion}>
+          <QuestionMarquee rows={4} speed={25} onQuestionClick={setSelectedQuestion} activeQuestion={selectedQuestion} />
+        </QAAgentFlow>
+      </ClientOnly>
+
+      <p>
+        Some work. Some don't. That's the point.
+      </p>
+
+      <ClientOnly>
+        <AnimatedInView>
+          <LangSmithLogo />
+        </AnimatedInView>
+      </ClientOnly>
+
+      <p>
+        LangSmith records what happened: which questions worked, which failed,
+        and why. I can use AI to annotate bad answers, use AI to evaluate why
+        it went wrong, and plan a new experiment.
       </p>
 
       <ClientOnly>


### PR DESCRIPTION
## Summary

Restore two narrative blocks removed by PR #860 (LangSmith+EMR cleanup):

1. **Cross-receipt verification + iterative AI passes** — `BetweenReceiptVisualization` + `LabelValidationTimeline`, between `FinancialMathOverlay` and "Making it Faster and Cheaper"
2. **QA agent / ReAct trace** — `LangChainLogo` → `QAAgentFlow` (wrapping `QuestionMarquee`) → `LangSmithLogo`, between "What if I ask it a weird question?" and `<CICDLoop />`

Both sections were removed from `pages/receipt.tsx` in #860 alongside the legacy-Lambda + LangSmith→EMR viz-cache cleanup. The components, the `useQAQueue` hook, and the backend `/qa/visualization` endpoint were all retained in the codebase — only the page-level wiring went missing.

## Why

The page narrative jumps without these blocks: it goes straight from "I run financial math on every receipt" to "I needed to stop paying OpenAI to argue about milk" with no setup for *why* training a model was needed. Likewise it goes from "what if the AI hallucinates?" straight to CICDLoop with no exposition on how the question→answer pipeline works.

## Test plan

- [x] Local dev server: `npm run dev` → `/receipt` returns 200 with no compile errors
- [x] `QAAgentFlow` renders correctly at desktop (1280×1400) — shows scrolling question marquee, active question, ReAct flow diagram (Plan → Agent → Tools → Shape → Synthesize)
- [x] `QAAgentFlow` renders correctly at mobile (375×1000) — same content stacked vertically
- [x] Live data: dev `/qa/visualization` returns 32 cached questions; component fetches and animates them
- [ ] Recommend: trigger fresh `qa-agent-dev` step function run before merge — current viz cache is from 2026-02-06 (~3.5 months old)
- [ ] Recommend: trigger fresh `qa-agent-prod` step function run after merge — prod cache from 2026-02-05

## Notes on freshness

The QA agent Lambdas (`qa-agent-{dev,prod}-run-question`) are pinned to `OPENROUTER_MODEL=x-ai/grok-4.1-fast` (current). Step functions exist and end with the new `BuildVizCache` Lambda from #860. To refresh:

```bash
aws stepfunctions start-execution \
  --state-machine-arn "arn:aws:states:us-east-1:681647709217:stateMachine:qa-agent-dev" \
  --input '{"langsmith_project": "qa-agent-marquee-<YYYYMMDD-HHMMSS>"}' \
  --region us-east-1
```

(~20–25 min each)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * QA agent live-data visualization added to the receipt page for validation timeline and cross-receipt label comparison
  * Interactive QA agent flow viewer with autoplay and manual question navigation
  * Active-phase narrative shown for the current QA step (label + description)
  * Flame-graph progress segments now adaptively show duration labels and sizing for clearer progress indication
  * LangChain branding integrated into the UI

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tnorlund/Portfolio/pull/888?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->