### PR TITLE
feat(qa-agent): capture LangGraph node trace + per-Q JSON to S3 (POC step 1)

### DIFF
--- a/infra/qa_agent_step_functions/lambdas/run_question.py
+++ b/infra/qa_agent_step_functions/lambdas/run_question.py
@@ -359,6 +359,10 @@ async def _run_all(
                     "durationSeconds": 0,
                     "success": False,
                     "error": str(result),
+                    # Always include trace so per-Q JSON consumers
+                    # (BuildVizCache Lambda, scripts) can rely on the key
+                    # existing — keep as empty list for exception cases.
+                    "trace": [],
                 }
             )
         else:

--- a/infra/qa_agent_step_functions/lambdas/run_question.py
+++ b/infra/qa_agent_step_functions/lambdas/run_question.py
@@ -13,9 +13,13 @@ import os
 import time
 from threading import Lock
 from typing import Any
+from uuid import UUID
 
 import boto3
 from langchain_core.callbacks import BaseCallbackHandler
+
+# LangGraph node names we care about for the trace.
+TRACE_NODE_NAMES = frozenset({"plan", "agent", "tools", "shape", "synthesize"})
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
@@ -132,6 +136,102 @@ class CostTrackingCallback(BaseCallbackHandler):
             }
 
 
+class TraceCaptureCallback(BaseCallbackHandler):
+    """Capture the LangGraph node firing sequence for the viz cache.
+
+    Each top-level node entry/exit is recorded as a trace event with
+    {type, start_ts, end_ts, duration_ms}. Thread-safe for asyncio use.
+
+    The "type" matches the QAAgentFlow frontend's expected phase names
+    (plan, agent, tools, shape, synthesize). Nodes can fire multiple
+    times in the ReAct loop — the trace preserves order.
+    """
+
+    def __init__(self):
+        self._events: list[dict] = []
+        # run_id → index in self._events, so on_chain_end can patch its event.
+        self._pending: dict[UUID, int] = {}
+        self._lock = Lock()
+
+    @staticmethod
+    def _node_name(metadata: dict | None) -> str | None:
+        if not metadata:
+            return None
+        node = metadata.get("langgraph_node")
+        if node and node in TRACE_NODE_NAMES:
+            return node
+        return None
+
+    def on_chain_start(
+        self,
+        serialized: dict,
+        inputs: dict,
+        *,
+        run_id: UUID,
+        parent_run_id: UUID | None = None,
+        tags: list[str] | None = None,
+        metadata: dict | None = None,
+        **kwargs,
+    ) -> None:
+        node = self._node_name(metadata)
+        if not node:
+            return
+        with self._lock:
+            self._events.append(
+                {
+                    "type": node,
+                    "start_ts": time.time(),
+                    "end_ts": None,
+                    "duration_ms": None,
+                    "status": "running",
+                }
+            )
+            self._pending[run_id] = len(self._events) - 1
+
+    def on_chain_end(
+        self,
+        outputs: dict,
+        *,
+        run_id: UUID,
+        parent_run_id: UUID | None = None,
+        **kwargs,
+    ) -> None:
+        with self._lock:
+            idx = self._pending.pop(run_id, None)
+            if idx is None:
+                return
+            event = self._events[idx]
+            event["end_ts"] = time.time()
+            event["duration_ms"] = round(
+                (event["end_ts"] - event["start_ts"]) * 1000, 1
+            )
+            event["status"] = "ok"
+
+    def on_chain_error(
+        self,
+        error: BaseException,
+        *,
+        run_id: UUID,
+        parent_run_id: UUID | None = None,
+        **kwargs,
+    ) -> None:
+        with self._lock:
+            idx = self._pending.pop(run_id, None)
+            if idx is None:
+                return
+            event = self._events[idx]
+            event["end_ts"] = time.time()
+            event["duration_ms"] = round(
+                (event["end_ts"] - event["start_ts"]) * 1000, 1
+            )
+            event["status"] = "error"
+            event["error"] = str(error)[:200]
+
+    def get_trace(self) -> list[dict]:
+        with self._lock:
+            return list(self._events)
+
+
 async def _run_question(
     semaphore: asyncio.Semaphore,
     answer_question_fn,
@@ -151,6 +251,7 @@ async def _run_question(
         )
 
         cost_callback = CostTrackingCallback()
+        trace_callback = TraceCaptureCallback()
         start_time = time.time()
 
         try:
@@ -158,7 +259,7 @@ async def _run_question(
                 graph,
                 state_holder,
                 question_text,
-                callbacks=[cost_callback],
+                callbacks=[cost_callback, trace_callback],
             )
             duration = time.time() - start_time
             stats = cost_callback.get_stats()
@@ -175,6 +276,7 @@ async def _run_question(
                 "toolInvocations": len(state_holder.get("searches", [])),
                 "durationSeconds": round(duration, 1),
                 "success": True,
+                "trace": trace_callback.get_trace(),
             }
         except Exception as e:
             logger.exception(
@@ -193,6 +295,7 @@ async def _run_question(
                 "durationSeconds": round(time.time() - start_time, 1),
                 "success": False,
                 "error": str(e),
+                "trace": trace_callback.get_trace(),
             }
 
 
@@ -276,6 +379,19 @@ async def _run_all(
         Body=ndjson_lines.encode("utf-8"),
         ContentType="application/x-ndjson",
     )
+
+    # Also write one JSON file per question with full trace + result.
+    # The forthcoming BuildVizCache Lambda will read these to assemble the
+    # viz cache, replacing the LangSmith export + EMR pipeline.
+    for r in processed:
+        q_idx = r.get("questionIndex", 0)
+        q_key = f"qa-runs/{execution_id}/q{q_idx:02d}.json"
+        s3_client.put_object(
+            Bucket=batch_bucket,
+            Key=q_key,
+            Body=json.dumps(r, default=str, indent=2).encode("utf-8"),
+            ContentType="application/json",
+        )
 
     success_count = sum(1 for r in processed if r.get("success"))
     total_cost = sum(r.get("cost", 0) for r in processed)


### PR DESCRIPTION
## Summary

POC step 1 of three for replacing the LangSmith + EMR Spark viz-cache pipeline with a direct Lambda. This PR is purely additive: it captures the LangGraph node firing sequence and writes per-question JSON to S3 alongside the existing NDJSON. The step function continues to use LangSmith/EMR for now — that part swaps in a follow-up PR once we've validated the trace shape.

## What it does

**`TraceCaptureCallback`** (sibling of the existing `CostTrackingCallback`):
- Hooks `on_chain_start` / `on_chain_end` on each LangGraph node
- Filters to top-level nodes only (`plan`, `agent`, `tools`, `shape`, `synthesize`)
- Records `{type, start_ts, end_ts, duration_ms, status}` per event, preserving order across ReAct loop iterations
- Thread-safe (uses Lock — needed since 10-question concurrent asyncio in this Lambda)

**Per-question JSON output**:
- Each question's full result + trace is written to `s3://{batch_bucket}/qa-runs/{execution_id}/qNN.json`
- Existing `question-results.ndjson` output is unchanged

## Why this approach

`run_question.py` already runs the agent and has all the data in memory. The only thing missing for a self-contained viz cache build was the per-node trace structure. LangSmith was capturing this via callbacks; EMR was reshaping LangSmith export back into the cache JSON. Capturing it directly in the Lambda removes the round trip entirely and unblocks killing the LangSmith dependency.

## What's NOT in this PR

- Step function changes (still hits LangSmith export + EMR; that fails until LangSmith plan is reactivated or we land PR 3)
- BuildVizCache Lambda (PR 2)
- EMR/Spark cleanup (follow-up)
- Frontend changes (none needed — same cache JSON shape eventually)

## Test plan

- [ ] Deploy to dev (`pulumi up --stack dev`)
- [ ] Trigger `qa-agent-dev` step function. RunAllQuestions Lambda should succeed and write per-Q JSONs to `s3://qa-agent-dev-batch-bucket-d587009/qa-runs/{exec_id}/qNN.json`. The step function will then fail at `TriggerLangSmithExport` (expected — LangSmith plan inactive), but that's fine for validating step 1.
- [ ] Verify trace shape with: `aws s3 cp s3://qa-agent-dev-batch-bucket-d587009/qa-runs/<exec_id>/q00.json -`
- [ ] Confirm trace order matches the ReAct flow: `plan` → `agent` → (`tools` → `agent`)* → `shape` → `synthesize`

## Related

- Replaces (in conjunction with follow-up PRs) the `infra/components/langsmith_bulk_export/` component dependency
- Follows the pattern established by PR #860 for the label_evaluator pipeline (`label_evaluator_step_functions/lambdas/build_viz_cache.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Capture detailed execution traces for QA question runs, recording per-step start/end times, durations, and status.
  * Include captured traces (or an empty trace on failure) in both success and failure results.
  * Export per-question execution results, including traces and error summaries, as individual JSON artifacts to S3 for improved visibility and debugging.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tnorlund/Portfolio/pull/889?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->