### PR TITLE
feat(layoutlm): resume training from a prior run's S3 checkpoint

### DIFF
--- a/infra/sagemaker_training/train.py
+++ b/infra/sagemaker_training/train.py
@@ -84,6 +84,7 @@ def build_train_command(hps: dict) -> list[str]:
         "early_stopping_patience": "--early-stopping-patience",
         "pretrained": "--pretrained",
         "o_entity_ratio": "--o-entity-ratio",
+        "resume_from_s3": "--resume-from-s3",
     }
 
     for hp_name, cli_flag in param_mapping.items():

--- a/receipt_layoutlm/receipt_layoutlm/cli.py
+++ b/receipt_layoutlm/receipt_layoutlm/cli.py
@@ -211,6 +211,17 @@ def main() -> None:
         default="float16",
         help="Quantization mode for CoreML export (default: float16).",
     )
+    train_p.add_argument(
+        "--resume-from-s3",
+        default=None,
+        help=(
+            "S3 URI to a previous training run's output directory "
+            "(e.g. s3://bucket/runs/layoutlm-hybrid-8-labels-v4/). "
+            "Files are synced to /tmp/receipt_layoutlm/{job_name}/ "
+            "before training, so the trainer's auto-resume picks up "
+            "the latest checkpoint and continues training from there."
+        ),
+    )
 
     infer_p = sub.add_parser("infer", help="Run LayoutLM inference")
     infer_p.add_argument(
@@ -393,6 +404,10 @@ def main() -> None:
         train_cfg.auto_export_coreml = args.export_coreml
         train_cfg.coreml_quantize = args.coreml_quantize
         trainer = ReceiptLayoutLMTrainer(data_cfg, train_cfg)
+        if args.resume_from_s3:
+            from .resume import sync_resume_checkpoint
+
+            sync_resume_checkpoint(args.resume_from_s3, args.job_name)
         job_id = trainer.train(job_name=args.job_name)
         print(job_id)
     elif args.cmd == "infer":

--- a/receipt_layoutlm/receipt_layoutlm/resume.py
+++ b/receipt_layoutlm/receipt_layoutlm/resume.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import logging
 import os
+import posixpath
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -63,7 +64,17 @@ def sync_resume_checkpoint(
         s3_client = boto3.client("s3")
 
     bucket, prefix = _parse_s3_uri(resume_from_s3)
-    dest = local_root / job_name
+
+    # Resolve local_root once so we can verify every path we write lands
+    # inside it. job_name comes from a hyperparameter and S3 keys come from
+    # a (potentially attacker-influenced) bucket prefix — both need
+    # containment checks to prevent path traversal via ".." segments.
+    root = local_root.resolve()
+    dest = (root / job_name).resolve()
+    if dest == root or root not in dest.parents:
+        raise ValueError(
+            f"Invalid job_name {job_name!r}: would escape {root}"
+        )
     dest.mkdir(parents=True, exist_ok=True)
 
     logger.info(
@@ -71,6 +82,7 @@ def sync_resume_checkpoint(
     )
     paginator = s3_client.get_paginator("list_objects_v2")
     count = 0
+    skipped = 0
     for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
         for obj in page.get("Contents", []) or []:
             key = obj["Key"]
@@ -78,7 +90,24 @@ def sync_resume_checkpoint(
             if key.endswith("/"):
                 continue
             rel = key[len(prefix):] if prefix else key
-            local_path = dest / rel
+            # Normalize using POSIX semantics since S3 keys use forward
+            # slashes regardless of host platform.
+            rel = posixpath.normpath(rel.lstrip("/"))
+            if rel.startswith("..") or rel.startswith("/") or rel == ".":
+                logger.warning(
+                    "Resume: skipping suspicious key %r", key
+                )
+                skipped += 1
+                continue
+            local_path = (dest / rel).resolve()
+            if dest not in local_path.parents and local_path != dest:
+                logger.warning(
+                    "Resume: skipping key %r — resolved path escapes %s",
+                    key,
+                    dest,
+                )
+                skipped += 1
+                continue
             local_path.parent.mkdir(parents=True, exist_ok=True)
             s3_client.download_file(bucket, key, str(local_path))
             count += 1

--- a/receipt_layoutlm/receipt_layoutlm/resume.py
+++ b/receipt_layoutlm/receipt_layoutlm/resume.py
@@ -1,0 +1,94 @@
+"""Sync a previous training run's S3 outputs into the local checkpoint
+directory so the trainer's auto-resume picks up where it left off.
+
+The trainer writes checkpoints to ``/tmp/receipt_layoutlm/{job_name}/`` and
+auto-resumes from the latest ``checkpoint-N/`` it finds there. To continue a
+prior run, we sync the prior run's S3 output prefix into that directory
+before calling ``trainer.train()``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from urllib.parse import urlparse
+
+logger = logging.getLogger(__name__)
+
+LOCAL_OUTPUT_ROOT = Path("/tmp/receipt_layoutlm")
+
+
+def _parse_s3_uri(uri: str) -> tuple[str, str]:
+    """Parse ``s3://bucket/key/prefix`` into ``(bucket, key_prefix)``.
+
+    The returned prefix always has a trailing ``/`` so it matches a
+    directory-style key.
+    """
+    parsed = urlparse(uri)
+    if parsed.scheme != "s3" or not parsed.netloc:
+        raise ValueError(f"Not a valid s3:// URI: {uri!r}")
+    prefix = parsed.path.lstrip("/")
+    if prefix and not prefix.endswith("/"):
+        prefix += "/"
+    return parsed.netloc, prefix
+
+
+def sync_resume_checkpoint(
+    resume_from_s3: str,
+    job_name: str,
+    *,
+    s3_client=None,
+    local_root: Path = LOCAL_OUTPUT_ROOT,
+) -> Path:
+    """Download all objects under ``resume_from_s3`` into the job's local
+    output directory.
+
+    Args:
+        resume_from_s3: ``s3://bucket/runs/<prior-job>/`` URI of a previous
+            training run's output directory (the one containing
+            ``checkpoint-N/`` subdirs).
+        job_name: The current training job's name; files land in
+            ``{local_root}/{job_name}/`` so HuggingFace Trainer's
+            auto-resume in ``trainer.py`` finds them.
+        s3_client: Optional pre-built boto3 S3 client (used by tests).
+        local_root: Override the local output root (used by tests).
+
+    Returns:
+        The local directory the files were synced into.
+    """
+    if s3_client is None:
+        import boto3
+
+        s3_client = boto3.client("s3")
+
+    bucket, prefix = _parse_s3_uri(resume_from_s3)
+    dest = local_root / job_name
+    dest.mkdir(parents=True, exist_ok=True)
+
+    logger.info(
+        "Resume: syncing s3://%s/%s -> %s", bucket, prefix, dest
+    )
+    paginator = s3_client.get_paginator("list_objects_v2")
+    count = 0
+    for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
+        for obj in page.get("Contents", []) or []:
+            key = obj["Key"]
+            # Skip the "directory placeholder" objects S3 sometimes returns.
+            if key.endswith("/"):
+                continue
+            rel = key[len(prefix):] if prefix else key
+            local_path = dest / rel
+            local_path.parent.mkdir(parents=True, exist_ok=True)
+            s3_client.download_file(bucket, key, str(local_path))
+            count += 1
+
+    logger.info("Resume: downloaded %d files into %s", count, dest)
+    if count == 0:
+        logger.warning(
+            "Resume: no objects found at s3://%s/%s — trainer will start "
+            "from scratch.",
+            bucket,
+            prefix,
+        )
+    return dest

--- a/receipt_layoutlm/tests/unit/test_resume.py
+++ b/receipt_layoutlm/tests/unit/test_resume.py
@@ -93,6 +93,51 @@ def test_sync_resume_checkpoint_creates_intermediate_dirs(tmp_path):
     )
 
 
+@pytest.mark.parametrize("bad_job_name", ["../escape", "..", "/abs/path", ""])
+def test_sync_resume_checkpoint_rejects_traversal_job_name(
+    tmp_path, bad_job_name
+):
+    """job_name must resolve to a subdirectory of local_root."""
+    s3 = _build_fake_s3_client([])
+    with pytest.raises(ValueError, match="Invalid job_name"):
+        sync_resume_checkpoint(
+            "s3://bucket/runs/v4/",
+            job_name=bad_job_name,
+            s3_client=s3,
+            local_root=tmp_path,
+        )
+    s3.download_file.assert_not_called()
+
+
+def test_sync_resume_checkpoint_skips_traversal_keys(tmp_path, caplog):
+    """S3 keys whose normalized rel path escapes the dest dir are skipped."""
+    objects = [
+        {"Key": "runs/v4/checkpoint-100/legit.bin"},
+        {"Key": "runs/v4/../../../etc/passwd"},
+        {"Key": "runs/v4/sub/../../escape.bin"},
+    ]
+    s3 = _build_fake_s3_client(objects)
+
+    with caplog.at_level("WARNING"):
+        sync_resume_checkpoint(
+            "s3://bucket/runs/v4/",
+            job_name="job",
+            s3_client=s3,
+            local_root=tmp_path,
+        )
+
+    # Only the legitimate key was downloaded; the two traversal attempts
+    # were skipped before any download_file call.
+    assert s3.download_file.call_count == 1
+    s3.download_file.assert_called_once_with(
+        "bucket",
+        "runs/v4/checkpoint-100/legit.bin",
+        str(tmp_path / "job/checkpoint-100/legit.bin"),
+    )
+    warnings = [r.message for r in caplog.records if r.levelname == "WARNING"]
+    assert any("suspicious key" in m or "escapes" in m for m in warnings)
+
+
 def test_sync_resume_checkpoint_empty_prefix_is_warning_not_error(
     tmp_path, caplog
 ):

--- a/receipt_layoutlm/tests/unit/test_resume.py
+++ b/receipt_layoutlm/tests/unit/test_resume.py
@@ -1,0 +1,112 @@
+"""Tests for receipt_layoutlm.resume.sync_resume_checkpoint."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from receipt_layoutlm.resume import _parse_s3_uri, sync_resume_checkpoint
+
+
+@pytest.mark.parametrize(
+    "uri,expected",
+    [
+        ("s3://bucket/runs/v4/", ("bucket", "runs/v4/")),
+        ("s3://bucket/runs/v4", ("bucket", "runs/v4/")),
+        ("s3://bucket/", ("bucket", "")),
+        ("s3://bucket", ("bucket", "")),
+    ],
+)
+def test_parse_s3_uri(uri, expected):
+    assert _parse_s3_uri(uri) == expected
+
+
+@pytest.mark.parametrize("bad", ["http://bucket/key", "bucket/key", ""])
+def test_parse_s3_uri_rejects_non_s3(bad):
+    with pytest.raises(ValueError):
+        _parse_s3_uri(bad)
+
+
+def _build_fake_s3_client(objects):
+    """Build a MagicMock S3 client whose paginator returns ``objects``."""
+    client = MagicMock(name="s3_client")
+    paginator = MagicMock(name="paginator")
+    paginator.paginate.return_value = [{"Contents": objects}]
+    client.get_paginator.return_value = paginator
+    return client
+
+
+def test_sync_resume_checkpoint_downloads_each_object(tmp_path):
+    objects = [
+        {"Key": "runs/v4/checkpoint-100/pytorch_model.bin"},
+        {"Key": "runs/v4/checkpoint-100/trainer_state.json"},
+        {"Key": "runs/v4/dataset_snapshot.pkl"},
+        # Directory placeholder — should be skipped.
+        {"Key": "runs/v4/checkpoint-100/"},
+    ]
+    s3 = _build_fake_s3_client(objects)
+
+    dest = sync_resume_checkpoint(
+        "s3://bucket/runs/v4/",
+        job_name="continuation",
+        s3_client=s3,
+        local_root=tmp_path,
+    )
+
+    assert dest == tmp_path / "continuation"
+    # Three real files downloaded; the trailing-slash placeholder is skipped.
+    assert s3.download_file.call_count == 3
+    s3.download_file.assert_any_call(
+        "bucket",
+        "runs/v4/checkpoint-100/pytorch_model.bin",
+        str(tmp_path / "continuation/checkpoint-100/pytorch_model.bin"),
+    )
+    s3.download_file.assert_any_call(
+        "bucket",
+        "runs/v4/dataset_snapshot.pkl",
+        str(tmp_path / "continuation/dataset_snapshot.pkl"),
+    )
+
+
+def test_sync_resume_checkpoint_creates_intermediate_dirs(tmp_path):
+    objects = [{"Key": "runs/v4/checkpoint-100/sub/deep/file.bin"}]
+    s3 = _build_fake_s3_client(objects)
+
+    sync_resume_checkpoint(
+        "s3://bucket/runs/v4/",
+        job_name="job",
+        s3_client=s3,
+        local_root=tmp_path,
+    )
+
+    expected_local = (
+        tmp_path / "job/checkpoint-100/sub/deep/file.bin"
+    )
+    # The parent dirs were created so download_file can write the file.
+    assert expected_local.parent.exists()
+    s3.download_file.assert_called_once_with(
+        "bucket",
+        "runs/v4/checkpoint-100/sub/deep/file.bin",
+        str(expected_local),
+    )
+
+
+def test_sync_resume_checkpoint_empty_prefix_is_warning_not_error(
+    tmp_path, caplog
+):
+    s3 = _build_fake_s3_client([])  # No objects at the prefix.
+
+    with caplog.at_level("WARNING"):
+        sync_resume_checkpoint(
+            "s3://bucket/missing/",
+            job_name="job",
+            s3_client=s3,
+            local_root=tmp_path,
+        )
+
+    s3.download_file.assert_not_called()
+    assert any(
+        "no objects found" in r.message for r in caplog.records
+    ), "expected a warning when no objects matched the resume prefix"


### PR DESCRIPTION
## Summary

Adds a `--resume-from-s3` hyperparameter to LayoutLM training. When set, the helper syncs a previous training run's S3 output directory into the new job's local `output_dir` *before* the trainer starts. HuggingFace Trainer's existing auto-resume at `trainer.py:1037` then picks up the latest `checkpoint-N/` and continues training.

This unblocks **extending a successful run** instead of starting from scratch — exactly what we discovered we needed today after burning v5 + v6 reproducing v4's result:

- `layoutlm-hybrid-8-labels-v4` finished at F1=0.7846 at **epoch 29 of 30** — model was still improving when training stopped
- Today's v6 (same config, +1,773 new labels) is tracking similarly but landing around 0.74-0.78 — within seed noise of v4
- Net of today: we can't actually tell if the new labels help unless we continue v4's training rather than restart from random init

With this PR, we can run:
\`\`\`bash
aws lambda invoke --function-name layoutlm-sagemaker-start-training-d28f7b4 \\
  --payload '{
    "job_name": "layoutlm-v4-continue-30ep-with-may2026-data",
    "use_spot": true,
    "hyperparameters": {
      "epochs": "30",
      "resume_from_s3": "s3://layoutlm-training-dev-.../runs/layoutlm-hybrid-8-labels-v4/",
      "learning_rate": "1e-5",
      ...
    }
  }' response.json
\`\`\`

And get a real apples-to-apples answer about whether the new data raises the ceiling above v4's plateau.

## Implementation

- **`receipt_layoutlm/resume.py`** (new) — thin S3 paginator-based sync helper
- **`receipt_layoutlm/cli.py`** — adds \`--resume-from-s3\` flag, calls sync before \`trainer.train()\`
- **\`infra/sagemaker_training/train.py\`** — forwards \`resume_from_s3\` hyperparam from SageMaker to the CLI
- **\`receipt_layoutlm/trainer.py\`** — *no changes*; auto-resume at line 1037 already works once files are in place
- **Tests** — 10 new unit tests (URI parsing, downloading multiple files, intermediate directory creation, empty-prefix warning)

## Test plan

- [x] \`pytest receipt_layoutlm/tests/unit/test_resume.py -v\` — 10/10 pass
- [x] \`layoutlm-cli train --help\` shows the new flag
- [ ] After merge: trigger \`layoutlm-v4-continue-test\` against v4's S3 prefix, verify SageMaker logs show "Resume: downloaded N files" and the trainer's first epoch starts from a high val_f1 (not 0.03)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--resume-from-s3` CLI option to resume training from previous S3 checkpoint outputs
  * Automatically syncs checkpoints to local directory for trainer auto-resume capability

* **Tests**
  * Added comprehensive unit tests for resume checkpoint functionality

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tnorlund/Portfolio/pull/890?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->