### PR TITLE
fix(layoutlm): write checkpoints to SageMaker's auto-synced dir for spot resilience

### DIFF
--- a/infra/sagemaker_training/train.py
+++ b/infra/sagemaker_training/train.py
@@ -130,23 +130,22 @@ def build_train_command(hps: dict) -> list[str]:
     return cmd
 
 
-def _training_dir(job_name: str) -> Path:
-    """Mirror of receipt_layoutlm.trainer._resolve_output_dir.
-
-    Kept in sync intentionally — the trainer writes checkpoints to
-    /opt/ml/checkpoints when SageMaker mounts it (so spot interruptions
-    can recover), otherwise to /tmp/receipt_layoutlm/{job_name}.
-    """
-    sagemaker_ckpt = Path("/opt/ml/checkpoints")
-    if sagemaker_ckpt.is_dir():
-        return sagemaker_ckpt
-    return Path(f"/tmp/receipt_layoutlm/{job_name}")
-
-
 def copy_model_to_sagemaker_dir(job_name: str):
-    """Copy trained model to SageMaker's model directory."""
+    """Copy trained model to SageMaker's model directory.
+
+    The training output directory is resolved by
+    ``receipt_layoutlm.trainer._resolve_output_dir`` so the SageMaker
+    container side stays in lockstep with the trainer's own writes
+    (avoids the kind of path-mismatch silent data loss this PR
+    addresses for spot restarts).
+    """
     model_dir = os.environ.get("SM_MODEL_DIR", "/opt/ml/model")
-    training_dir = _training_dir(job_name)
+    # Import locally so train.py is still importable in environments
+    # that don't have receipt_layoutlm installed (it's only required at
+    # SageMaker container runtime, not at static-analysis time).
+    from receipt_layoutlm.trainer import _resolve_output_dir
+
+    training_dir = Path(_resolve_output_dir(job_name))
 
     if not training_dir.exists():
         print(f"Warning: Training directory {training_dir} not found")

--- a/infra/sagemaker_training/train.py
+++ b/infra/sagemaker_training/train.py
@@ -130,10 +130,23 @@ def build_train_command(hps: dict) -> list[str]:
     return cmd
 
 
+def _training_dir(job_name: str) -> Path:
+    """Mirror of receipt_layoutlm.trainer._resolve_output_dir.
+
+    Kept in sync intentionally — the trainer writes checkpoints to
+    /opt/ml/checkpoints when SageMaker mounts it (so spot interruptions
+    can recover), otherwise to /tmp/receipt_layoutlm/{job_name}.
+    """
+    sagemaker_ckpt = Path("/opt/ml/checkpoints")
+    if sagemaker_ckpt.is_dir():
+        return sagemaker_ckpt
+    return Path(f"/tmp/receipt_layoutlm/{job_name}")
+
+
 def copy_model_to_sagemaker_dir(job_name: str):
     """Copy trained model to SageMaker's model directory."""
     model_dir = os.environ.get("SM_MODEL_DIR", "/opt/ml/model")
-    training_dir = Path(f"/tmp/receipt_layoutlm/{job_name}")
+    training_dir = _training_dir(job_name)
 
     if not training_dir.exists():
         print(f"Warning: Training directory {training_dir} not found")

--- a/receipt_layoutlm/receipt_layoutlm/trainer.py
+++ b/receipt_layoutlm/receipt_layoutlm/trainer.py
@@ -34,6 +34,33 @@ def _checkpoint_step(path: str) -> int:
     return int(m.group(1)) if m else 0
 
 
+SAGEMAKER_CHECKPOINT_DIR = "/opt/ml/checkpoints"
+
+
+def _resolve_output_dir(job_name: str) -> str:
+    """Pick the trainer's checkpoint directory.
+
+    When running inside a SageMaker BYOC container with managed-spot
+    checkpointing enabled, SageMaker mounts /opt/ml/checkpoints and
+    auto-syncs it with the S3 path configured in ``CheckpointConfig``
+    — both *during* training (so checkpoints survive a spot
+    interruption) and *at startup* on the replacement instance (so the
+    trainer's auto-resume can pick up where the previous run left off).
+
+    Writing to /tmp/receipt_layoutlm/{job_name}/ defeats that
+    mechanism: the spot-restart pulls an empty /opt/ml/checkpoints/
+    back from S3, the trainer's auto-resume looks in /tmp/ and finds
+    nothing, and training silently starts over from epoch 0.
+
+    Resolution order:
+      1. /opt/ml/checkpoints (when SageMaker mounted it)
+      2. /tmp/receipt_layoutlm/{job_name} (local dev fallback)
+    """
+    if os.path.isdir(SAGEMAKER_CHECKPOINT_DIR):
+        return SAGEMAKER_CHECKPOINT_DIR
+    return f"/tmp/receipt_layoutlm/{job_name}"
+
+
 class ReceiptLayoutLMTrainer:
     def __init__(
         self,
@@ -85,8 +112,12 @@ class ReceiptLayoutLMTrainer:
         return ["O", *labels]
 
     def train(self, job_name: str, created_by: str = "system") -> str:
-        # Derive output directory early for run logging
-        output_dir = f"/tmp/receipt_layoutlm/{job_name}"
+        # Derive output directory early for run logging. Inside SageMaker
+        # with managed-spot checkpointing this is /opt/ml/checkpoints (so
+        # CheckpointConfig auto-syncs it ↔ S3 and the trainer's
+        # auto-resume can survive spot interruptions); falls back to
+        # /tmp/receipt_layoutlm/{job_name} for local dev.
+        output_dir = _resolve_output_dir(job_name)
         # Best-effort create output directory
         os.makedirs(output_dir, exist_ok=True)
 

--- a/receipt_layoutlm/receipt_layoutlm/trainer.py
+++ b/receipt_layoutlm/receipt_layoutlm/trainer.py
@@ -35,6 +35,7 @@ def _checkpoint_step(path: str) -> int:
 
 
 SAGEMAKER_CHECKPOINT_DIR = "/opt/ml/checkpoints"
+_LOCAL_OUTPUT_ROOT = "/tmp/receipt_layoutlm"
 
 
 def _resolve_output_dir(job_name: str) -> str:
@@ -55,10 +56,21 @@ def _resolve_output_dir(job_name: str) -> str:
     Resolution order:
       1. /opt/ml/checkpoints (when SageMaker mounted it)
       2. /tmp/receipt_layoutlm/{job_name} (local dev fallback)
+
+    ``job_name`` is interpolated into the fallback path, so we validate
+    it can't contain path separators or ".." segments that would let
+    the path escape the local root.
     """
     if os.path.isdir(SAGEMAKER_CHECKPOINT_DIR):
         return SAGEMAKER_CHECKPOINT_DIR
-    return f"/tmp/receipt_layoutlm/{job_name}"
+
+    root = os.path.realpath(_LOCAL_OUTPUT_ROOT)
+    candidate = os.path.realpath(os.path.join(root, job_name))
+    if candidate == root or os.path.commonpath([root, candidate]) != root:
+        raise ValueError(
+            f"Invalid job_name {job_name!r}: would escape {root}"
+        )
+    return candidate
 
 
 class ReceiptLayoutLMTrainer:

--- a/receipt_layoutlm/tests/unit/test_resolve_output_dir.py
+++ b/receipt_layoutlm/tests/unit/test_resolve_output_dir.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from unittest import mock
 
+import pytest
+
 from receipt_layoutlm.trainer import (
     SAGEMAKER_CHECKPOINT_DIR,
     _resolve_output_dir,
@@ -26,14 +28,16 @@ def test_uses_sagemaker_dir_when_present():
 
 def test_falls_back_to_tmp_when_sagemaker_dir_absent():
     """On local dev machines /opt/ml/checkpoints doesn't exist, so the
-    fallback per-job tmp path is used."""
+    fallback per-job tmp path is used. The returned path is
+    realpath-resolved (so on macOS /tmp may show as /private/tmp)."""
     with mock.patch(
         "receipt_layoutlm.trainer.os.path.isdir",
         return_value=False,
     ):
         result = _resolve_output_dir("layoutlm-experiment-1")
 
-    assert result == "/tmp/receipt_layoutlm/layoutlm-experiment-1"
+    # endswith because /tmp symlinks differ across platforms.
+    assert result.endswith("/receipt_layoutlm/layoutlm-experiment-1"), result
 
 
 def test_fallback_includes_job_name():
@@ -55,3 +59,39 @@ def test_sagemaker_path_constant():
     SageMaker contract, not a configuration choice, so it's intentionally
     a constant."""
     assert SAGEMAKER_CHECKPOINT_DIR == "/opt/ml/checkpoints"
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "../escape",
+        "../../etc/passwd",
+        "..",
+        "/abs/path",
+        "",
+    ],
+)
+def test_fallback_rejects_traversal_job_name(bad):
+    """job_name is interpolated into the /tmp fallback path. Names
+    containing path separators or ``..`` segments could escape the
+    intended root — _resolve_output_dir must reject them."""
+    with mock.patch(
+        "receipt_layoutlm.trainer.os.path.isdir", return_value=False
+    ):
+        with pytest.raises(ValueError, match="Invalid job_name"):
+            _resolve_output_dir(bad)
+
+
+def test_fallback_accepts_normal_names():
+    """Sanity check: typical job names with hyphens, digits, and dots
+    still resolve to a path inside the local root."""
+    with mock.patch(
+        "receipt_layoutlm.trainer.os.path.isdir", return_value=False
+    ):
+        for name in (
+            "layoutlm-hybrid-8-labels-v6",
+            "experiment_42",
+            "v4.2.1",
+        ):
+            result = _resolve_output_dir(name)
+            assert result.endswith(f"/{name}"), result

--- a/receipt_layoutlm/tests/unit/test_resolve_output_dir.py
+++ b/receipt_layoutlm/tests/unit/test_resolve_output_dir.py
@@ -1,0 +1,57 @@
+"""Tests for _resolve_output_dir SageMaker-vs-local checkpoint directory."""
+
+from __future__ import annotations
+
+from unittest import mock
+
+from receipt_layoutlm.trainer import (
+    SAGEMAKER_CHECKPOINT_DIR,
+    _resolve_output_dir,
+)
+
+
+def test_uses_sagemaker_dir_when_present():
+    """Inside a SageMaker BYOC container with CheckpointConfig the
+    /opt/ml/checkpoints dir exists and gets auto-synced to S3 — the
+    trainer must write checkpoints there for spot-restart resilience."""
+    with mock.patch(
+        "receipt_layoutlm.trainer.os.path.isdir",
+        return_value=True,
+    ) as is_dir:
+        result = _resolve_output_dir("any-job-name")
+
+    assert result == SAGEMAKER_CHECKPOINT_DIR
+    is_dir.assert_called_once_with(SAGEMAKER_CHECKPOINT_DIR)
+
+
+def test_falls_back_to_tmp_when_sagemaker_dir_absent():
+    """On local dev machines /opt/ml/checkpoints doesn't exist, so the
+    fallback per-job tmp path is used."""
+    with mock.patch(
+        "receipt_layoutlm.trainer.os.path.isdir",
+        return_value=False,
+    ):
+        result = _resolve_output_dir("layoutlm-experiment-1")
+
+    assert result == "/tmp/receipt_layoutlm/layoutlm-experiment-1"
+
+
+def test_fallback_includes_job_name():
+    """Local dev runs are isolated per-job-name so concurrent runs
+    don't write into each other's directories."""
+    with mock.patch(
+        "receipt_layoutlm.trainer.os.path.isdir", return_value=False
+    ):
+        a = _resolve_output_dir("run-a")
+        b = _resolve_output_dir("run-b")
+
+    assert a != b
+    assert a.endswith("/run-a")
+    assert b.endswith("/run-b")
+
+
+def test_sagemaker_path_constant():
+    """SageMaker's CheckpointConfig mounts /opt/ml/checkpoints — this is
+    SageMaker contract, not a configuration choice, so it's intentionally
+    a constant."""
+    assert SAGEMAKER_CHECKPOINT_DIR == "/opt/ml/checkpoints"


### PR DESCRIPTION
## Summary

Fixes a silent data-loss bug: SageMaker spot interruptions throw away all training progress because of a path mismatch between two checkpoint mechanisms.

## How we hit it

Tonight's \`layoutlm-hybrid-8-labels-v6-may2026-merged\` run:

1. Trained for 21 epochs on a spot instance (best F1 = 0.7393)
2. AWS preempted the spot instance at 21:15 PDT
3. SageMaker started a fresh spot instance at 21:19 PDT
4. The new container's trainer looked for checkpoints, found nothing, restarted from epoch 0 — silently losing all 21 epochs

## Root cause

Two checkpoint mechanisms that don't connect:

| Mechanism | Path | Used by |
|---|---|---|
| HuggingFace Trainer | \`/tmp/receipt_layoutlm/{job_name}/checkpoint-N/\` | Set by trainer.py:89; auto-resume reads from same |
| SageMaker CheckpointConfig | \`/opt/ml/checkpoints/\` ↔ S3 | Set by component.py:643; survives spot interruptions |

When a spot instance is preempted and a fresh one starts:
1. SageMaker pulls S3 → \`/opt/ml/checkpoints/\` (which is empty because trainer never wrote there)
2. Trainer's auto-resume at trainer.py:1037 looks in \`/tmp/receipt_layoutlm/{job_name}/\` — also empty on a fresh instance
3. Training restarts from epoch 0

## Fix

Pick \`output_dir\` based on whether SageMaker mounted \`/opt/ml/checkpoints\`. When present (SageMaker with CheckpointConfig), write there so the auto-sync handles spot resilience. When absent (local dev), keep the existing \`/tmp/\` fallback.

\`\`\`python
SAGEMAKER_CHECKPOINT_DIR = \"/opt/ml/checkpoints\"

def _resolve_output_dir(job_name: str) -> str:
    if os.path.isdir(SAGEMAKER_CHECKPOINT_DIR):
        return SAGEMAKER_CHECKPOINT_DIR
    return f\"/tmp/receipt_layoutlm/{job_name}\"
\`\`\`

## Files

- \`receipt_layoutlm/trainer.py\` — new \`_resolve_output_dir()\` helper, called from \`train()\` (line ~89)
- \`infra/sagemaker_training/train.py\` — mirror the path resolution in \`copy_model_to_sagemaker_dir()\` so it still finds the trained model post-training
- \`receipt_layoutlm/tests/unit/test_resolve_output_dir.py\` — 4 unit tests (SageMaker branch, local branch, job-name isolation, path constant)

## Relationship to PR #890

These two PRs are complementary:

| PR | Solves |
|---|---|
| **#890** (merged) | \`--resume-from-s3\` hyperparam for *deliberate* continuation of a previous job's S3 checkpoint |
| **This PR** | Automatic *intra-job* spot resilience — recovers within the same job when SageMaker preempts a spot instance |

You need both: #890 lets you launch \`v7\` from \`v4\`'s S3 checkpoint; this PR makes sure \`v7\` doesn't silently restart from epoch 0 if its own spot instance gets preempted mid-training.

## Test plan

- [x] \`pytest receipt_layoutlm/tests/unit/test_resolve_output_dir.py -v\` — 4/4 pass
- [x] Full unit suite: 25/25 pass (4 new + 6 existing checkpoint_step + 15 resume from #890)
- [ ] After merge: trigger a deliberate spot-interrupted job (or wait for natural one) and confirm new instance's CloudWatch logs show \`Resume: ...\` from a real checkpoint, not epoch 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added intelligent checkpoint directory selection that prioritizes SageMaker's native storage when available, with automatic fallback to local temporary storage.

* **Tests**
  * Added unit tests for checkpoint directory resolution logic covering both SageMaker and local deployment scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tnorlund/Portfolio/pull/893?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->