### PR TITLE
fix(sagemaker): bump Dockerfile base torch 2.2 → 2.5 for transformers 5.x

### DIFF
--- a/infra/sagemaker_training/Dockerfile
+++ b/infra/sagemaker_training/Dockerfile
@@ -1,7 +1,13 @@
 # LayoutLM Training Container for SageMaker
-# Based on PyTorch with CUDA support
-
-FROM pytorch/pytorch:2.2.0-cuda12.1-cudnn8-runtime
+# Based on PyTorch with CUDA support.
+#
+# Why torch >= 2.4: transformers >= 5.0 (see PR #859) requires PyTorch
+# 2.4+. With torch 2.2 the library logs "Disabling PyTorch because
+# PyTorch >= 2.4 is required but found 2.2.0" at import time, after
+# which LayoutLMForTokenClassification.from_pretrained() fails with
+# "PyTorch library not found." The Dockerfile's pre-download step
+# trips this, breaking every container build.
+FROM pytorch/pytorch:2.5.1-cuda12.4-cudnn9-runtime
 
 # Set environment variables
 ENV PYTHONUNBUFFERED=1 \

--- a/receipt_layoutlm/pyproject.toml
+++ b/receipt_layoutlm/pyproject.toml
@@ -17,7 +17,10 @@ classifiers = [
   "Operating System :: OS Independent",
 ]
 dependencies = [
-  "torch>=2.2.0,<2.8",
+  # transformers >= 5.0 requires PyTorch 2.4+ (#859 bumped transformers,
+  # so the torch floor needed to move with it). Keep transformers <6.0 to
+  # avoid blind dependabot bumps across the next major.
+  "torch>=2.4.0,<2.8",
   "transformers>=4.46.0,<6.0.0",
   "datasets>=2.19.0,<5.0.0",
   "numpy>=1.26.0,<3.0.0",


### PR DESCRIPTION
## Summary

PR #859 (dependabot) bumped \`receipt_layoutlm\`'s transformers constraint from \`<5.0\` to \`<6.0\`. Today's container rebuild was the first time the new constraint was actually applied — and it exposed that **transformers 5.x requires PyTorch >= 2.4**, while the Dockerfile pinned torch 2.2.0.

CodeBuild fails the Dockerfile's model pre-download step with:

\`\`\`
[transformers] Disabling PyTorch because PyTorch >= 2.4 is required but found 2.2.0
[transformers] PyTorch was not found.
LayoutLMForTokenClassification requires the PyTorch library but it was not found in your environment.
\`\`\`

This has been blocking the deploy of #890 (\`--resume-from-s3\`) and #893 (spot-restart fix).

## Empirical validation

Reproduced the failure and confirmed the fix in local Docker before raising this PR:

\`\`\`bash
# Repro:
$ docker run --rm python:3.10-slim bash -c "
    pip install 'torch==2.2.0' 'transformers==5.9.0'
    python -c 'from transformers import LayoutLMForTokenClassification'"
# Disabling PyTorch because PyTorch >= 2.4 is required but found 2.2.0  ← repro

# Fix:
$ docker run --rm python:3.10-slim bash -c "
    pip install 'torch==2.5.1' 'transformers==5.9.0'
    python -c 'from transformers import LayoutLMTokenizerFast, LayoutLMForTokenClassification
               LayoutLMTokenizerFast.from_pretrained(\"microsoft/layoutlm-base-uncased\")
               LayoutLMForTokenClassification.from_pretrained(\"microsoft/layoutlm-base-uncased\")
               print(\"OK\")'"
# FROM_PRETRAINED OK ✅
\`\`\`

Then ran the actual Dockerfile end-to-end with the new base image (with the temp-permissive .dockerignore swap from [[feedback_portfolio_targeted_lambda_deploy]]) — the full build including the pre-download step **succeeded**.

## Changes

| File | Change |
|---|---|
| \`infra/sagemaker_training/Dockerfile\` | base image: \`pytorch/pytorch:2.2.0-cuda12.1-cudnn8-runtime\` → \`pytorch/pytorch:2.5.1-cuda12.4-cudnn9-runtime\`. Added a comment explaining why so the next dependabot bump doesn't silently break this again. |
| \`receipt_layoutlm/pyproject.toml\` | \`torch>=2.2.0,<2.8\` → \`torch>=2.4.0,<2.8\`. Anything below 2.4 will silently break with the current transformers floor — keeping the constraint truthful. |

## Why this slipped past CI

PR #859's CI ran Python unit tests against whatever transformers/torch the GitHub Actions runner had installed (its own venv) — those tests passed. The Docker build doesn't run in CI; it's triggered by Pulumi/CodeBuild on infra deploy. So the broken pyproject constraint sat dormant until today's first \`pulumi up\` after the merge.

Filed separately as a process improvement: probably worth adding a smoke build of \`infra/sagemaker_training/Dockerfile\` to CI for any PR touching \`receipt_layoutlm/pyproject.toml\` or the Dockerfile itself.

## Test plan

- [x] Repro the failure with old base image locally
- [x] Confirm fix with new base image locally (FROM_PRETRAINED OK)
- [x] Full Dockerfile build with permissive .dockerignore — all 8 stages succeed
- [ ] After merge: CodeBuild rebuild of \`layoutlm-sagemaker-image-builder-*\` — should now succeed
- [ ] After build success: launch v7 with \`--resume-from-s3\` against v6's checkpoint to verify the resume code from #890 works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a compatibility issue with the transformers library.

* **Dependencies**
  * Updated minimum PyTorch version requirement to 2.4.0.
  * Updated SageMaker training environment to PyTorch 2.5.1 with CUDA 12.4.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tnorlund/Portfolio/pull/894?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->