### PR TITLE
fix(layoutlm/resume): allowlist numpy globals for torch 2.6 weights_only=True

### DIFF
--- a/receipt_layoutlm/receipt_layoutlm/resume.py
+++ b/receipt_layoutlm/receipt_layoutlm/resume.py
@@ -120,4 +120,54 @@ def sync_resume_checkpoint(
             bucket,
             prefix,
         )
+        return dest
+
+    _allowlist_numpy_pickle_globals()
     return dest
+
+
+def _allowlist_numpy_pickle_globals() -> None:
+    """Allowlist numpy globals so torch.load(weights_only=True) can
+    unpickle HuggingFace Trainer optimizer/scheduler/RNG checkpoints.
+
+    PyTorch 2.6 flipped ``torch.load`` to default ``weights_only=True``
+    as a CVE mitigation. HF Trainer checkpoints from earlier
+    transformers versions (e.g. v6's optimizer.pt produced by 4.57.6)
+    contain pickled numpy arrays — those raise
+    ``WeightsUnpickler error: Unsupported global: GLOBAL
+    numpy.core.multiarray._reconstruct`` under the new default.
+
+    Resume here is loading a checkpoint we trained ourselves on prior
+    SageMaker runs, so allowlisting the standard numpy globals is the
+    right CVE-aware fix per PyTorch's own guidance — not flipping
+    ``weights_only=False`` blanket.
+    """
+    try:
+        import numpy as np
+        import torch.serialization
+    except ImportError:
+        # If torch/numpy aren't importable we'll fail more loudly elsewhere.
+        return
+
+    # Collect the numpy items HuggingFace Trainer checkpoints pickle. We
+    # only allowlist what's actually needed; expand the list (rather than
+    # disabling weights_only) when a new unpickle error names a global.
+    safe_globals = [np.ndarray, np.dtype]
+    # numpy.core.multiarray was reorganized in newer numpy; try both
+    # locations so this code keeps working across upgrades.
+    for attr in ("_reconstruct", "scalar"):
+        for mod_name in ("numpy.core.multiarray", "numpy._core.multiarray"):
+            try:
+                mod = __import__(mod_name, fromlist=[attr])
+            except ImportError:
+                continue
+            fn = getattr(mod, attr, None)
+            if fn is not None:
+                safe_globals.append(fn)
+                break
+
+    torch.serialization.add_safe_globals(safe_globals)
+    logger.info(
+        "Resume: allowlisted %d numpy globals for torch.load(weights_only=True)",
+        len(safe_globals),
+    )

--- a/receipt_layoutlm/tests/unit/test_resume.py
+++ b/receipt_layoutlm/tests/unit/test_resume.py
@@ -7,7 +7,11 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from receipt_layoutlm.resume import _parse_s3_uri, sync_resume_checkpoint
+from receipt_layoutlm.resume import (
+    _allowlist_numpy_pickle_globals,
+    _parse_s3_uri,
+    sync_resume_checkpoint,
+)
 
 
 @pytest.mark.parametrize(
@@ -155,3 +159,83 @@ def test_sync_resume_checkpoint_empty_prefix_is_warning_not_error(
     assert any(
         "no objects found" in r.message for r in caplog.records
     ), "expected a warning when no objects matched the resume prefix"
+
+
+def test_allowlist_numpy_pickle_globals_registers_expected_items(monkeypatch):
+    """torch.load(weights_only=True) needs these numpy globals to unpickle
+    HF Trainer's optimizer.pt files — the helper must register at least
+    numpy.ndarray and numpy.dtype, plus _reconstruct from whichever module
+    path this version of numpy uses."""
+    captured: list = []
+
+    import torch.serialization
+
+    monkeypatch.setattr(
+        torch.serialization,
+        "add_safe_globals",
+        lambda items: captured.append(list(items)),
+    )
+
+    _allowlist_numpy_pickle_globals()
+
+    assert len(captured) == 1, "expected one call to add_safe_globals"
+    names = {getattr(item, "__qualname__", getattr(item, "__name__", str(item)))
+             for item in captured[0]}
+
+    import numpy as np
+
+    # Always-present essentials
+    assert np.ndarray in captured[0]
+    assert np.dtype in captured[0]
+    # _reconstruct path varies by numpy version — verify by name not module.
+    assert any(
+        "_reconstruct" in n for n in names
+    ), f"expected _reconstruct in {names}"
+
+
+def test_sync_resume_checkpoint_allowlists_when_files_downloaded(tmp_path):
+    """The sync function should register numpy globals on the happy path
+    (files actually downloaded), so HF Trainer's later torch.load succeeds.
+    Skip when there are no files — registering would be wasted work."""
+    objects = [{"Key": "runs/v6/checkpoint-1/optimizer.pt"}]
+    s3 = _build_fake_s3_client(objects)
+
+    import torch.serialization
+
+    calls = []
+    orig = torch.serialization.add_safe_globals
+    torch.serialization.add_safe_globals = lambda items: calls.append(items)
+    try:
+        sync_resume_checkpoint(
+            "s3://bucket/runs/v6/",
+            job_name="job",
+            s3_client=s3,
+            local_root=tmp_path,
+        )
+    finally:
+        torch.serialization.add_safe_globals = orig
+
+    assert len(calls) == 1, "allowlist should be invoked once when files exist"
+
+
+def test_sync_resume_checkpoint_skips_allowlist_when_empty(tmp_path):
+    """If the resume prefix is empty (zero downloads), there's nothing to
+    unpickle later — skip the allowlist call to keep the no-op cheap."""
+    s3 = _build_fake_s3_client([])
+
+    import torch.serialization
+
+    calls = []
+    orig = torch.serialization.add_safe_globals
+    torch.serialization.add_safe_globals = lambda items: calls.append(items)
+    try:
+        sync_resume_checkpoint(
+            "s3://bucket/empty/",
+            job_name="job",
+            s3_client=s3,
+            local_root=tmp_path,
+        )
+    finally:
+        torch.serialization.add_safe_globals = orig
+
+    assert calls == [], "allowlist must not run when no files downloaded"


### PR DESCRIPTION
## Summary

Third PR in tonight's transformers-5.x compatibility chain. v7-r2 reached the resume-from-checkpoint step (PR #890 worked!) but immediately failed:

\`\`\`
_pickle.UnpicklingError: Weights only load failed.
In PyTorch 2.6, we changed the default value of the \`weights_only\` argument
in \`torch.load\` from \`False\` to \`True\`.
WeightsUnpickler error: Unsupported global: GLOBAL numpy.core.multiarray._reconstruct
was not an allowed global by default.
\`\`\`

PyTorch 2.6 (which #895 adopted) made \`weights_only=True\` the new \`torch.load\` default. HF Trainer checkpoints from earlier transformers (v6's \`optimizer.pt\` from 4.57.6) contain pickled numpy arrays that the new default rejects.

## Why allowlist instead of flip back to weights_only=False

PyTorch's own error message literally suggests this is the right fix for trusted checkpoint sources:

> Re-running \`torch.load\` with \`weights_only\` set to \`False\` will likely succeed,
> but it can result in arbitrary code execution. Do it only if you got the file [from a trusted source].
> Alternatively, to load with \`weights_only=True\` please check the recommended steps in
> the following error message.

We control the checkpoint pipeline (our own prior SageMaker runs), but allowlisting **specific** globals keeps the CVE protection for everything else (random downloaded models, malicious payloads, etc.). The blanket \`weights_only=False\` would be a regression we don't need.

## Implementation

- \`receipt_layoutlm/resume.py\`: new \`_allowlist_numpy_pickle_globals()\` helper, called at end of \`sync_resume_checkpoint\` when files were actually downloaded
- Registers \`numpy.ndarray\`, \`numpy.dtype\`, and \`_reconstruct\` via \`torch.serialization.add_safe_globals\`
- Looks up \`_reconstruct\` in both \`numpy.core.multiarray\` (older) and \`numpy._core.multiarray\` (newer reorganization) so the code survives numpy upgrades

## Tests

3 new (18 total passing):
- \`test_allowlist_numpy_pickle_globals_registers_expected_items\` — verifies the helper hands the right items to \`add_safe_globals\` (monkey-patched)
- \`test_sync_resume_checkpoint_allowlists_when_files_downloaded\` — happy path triggers the call
- \`test_sync_resume_checkpoint_skips_allowlist_when_empty\` — no downloads, no wasted call

## Tonight's PR chain

| # | Purpose | Status |
|---|---|---|
| #890 | \`--resume-from-s3\` flag | ✅ merged |
| #893 | spot-restart checkpoint path | ✅ merged |
| #894 | Dockerfile base torch 2.5 | ✅ merged (fixed import guard) |
| #895 | Dockerfile base torch 2.6 | ✅ merged (fixed torch.load CVE guard) |
| **this** | **allowlist numpy globals** | 👈 **fixes weights_only=True default** |

## Test plan

- [x] \`pytest receipt_layoutlm/tests/unit/test_resume.py -v\` — 18/18 pass
- [ ] After merge: CodeBuild rebuilds trainer image
- [ ] Re-launch v8 with \`resume_from_s3\` against v6 — first-epoch val_f1 should land near v6's saturation (~0.75) ✅, not fresh-init (~0.03) ❌

🤖 Generated with [Claude Code](https://claude.com/claude-code)