### PR TITLE
fix(CICDLoop): keep pulse animation running after scroll-out

### DIFF
--- a/portfolio/components/ui/Figures/CICDLoop.tsx
+++ b/portfolio/components/ui/Figures/CICDLoop.tsx
@@ -670,12 +670,19 @@ const CICDLoop: React.FC<CICDLoopProps> = ({
     return () => clearAllTimeouts();
   }, [inView, mounted, staggerDelay, api, N, segments]);
 
-  // Continuous pulsing animation after all segments have animated in
+  // Continuous pulsing animation after all segments have animated in.
+  //
+  // Tracked as a ref (not state) so the pulse keeps running once started,
+  // even if the figure scrolls out of view (inView=false) and back again.
+  // The previous version's cleanup cleared the pulse on every inView flip,
+  // so scrolling away made the loop go static until you scrolled back.
+  // Now we start once on first entry and only clear on unmount.
+  const pulseStartedRef = useRef(false);
+
   useEffect(() => {
-    if (!inView || !mounted) {
-      clearPulseAnimation();
-      return;
-    }
+    if (!inView || !mounted) return;
+    if (pulseStartedRef.current) return; // already running — don't restart
+    pulseStartedRef.current = true;
 
     // Wait for all sections to finish initial animation
     const totalAnimationTime =
@@ -729,12 +736,10 @@ const CICDLoop: React.FC<CICDLoopProps> = ({
     }, totalAnimationTime);
 
     timeoutIds.current.push(continuousAnimationTimeout);
-
-    return () => {
-      clearTimeout(continuousAnimationTimeout);
-      clearPulseAnimation();
-    };
   }, [inView, mounted, staggerDelay, flowDuration, api, N, segments]);
+
+  // Unmount-only cleanup — clears the pulse when the component goes away.
+  useEffect(() => () => clearPulseAnimation(), []);
 
   // Generate segment geometries
   const segmentGeoms = useMemo(() => {


### PR DESCRIPTION
## Problem

The continuous pulse animation in \`CICDLoop\` stops the moment the figure scrolls out of the viewport. Scrolling back in restarts it with the full \`totalAnimationTime\` delay, so the figure sits static between views.

Root cause: the pulse \`useEffect\` is gated on \`inView\`. When \`inView\` flips to \`false\`, both the \`if (!inView)\` early-return AND the effect's cleanup call \`clearPulseAnimation()\`. The interval + staggered timeouts get wiped.

## Fix

Same pattern PR #886 used for segment-entrance: start once via a \`pulseStartedRef\` guard, don't restart on subsequent \`inView\` flips, move cleanup to an unmount-only \`useEffect\`.

\`\`\`diff
+  const pulseStartedRef = useRef(false);
+
   useEffect(() => {
-    if (!inView || !mounted) {
-      clearPulseAnimation();
-      return;
-    }
+    if (!inView || !mounted) return;
+    if (pulseStartedRef.current) return;
+    pulseStartedRef.current = true;
     // ... setup ...
-    return () => {
-      clearTimeout(continuousAnimationTimeout);
-      clearPulseAnimation();
-    };
   }, [inView, mounted, ...]);
+
+  useEffect(() => () => clearPulseAnimation(), []);
\`\`\`

## Test plan

- [x] Component builds
- [ ] Visual: scroll the receipt page so the CICDLoop enters view → throbbing starts. Scroll past it down the page → throbbing keeps running when scrolled back. Scroll up off-screen → throbbing keeps running.
- [ ] Refresh page: animation starts on first entry as before (no regression on initial behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CICD Loop animation behavior to ensure the pulse effect starts once and persists smoothly during scrolling interactions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tnorlund/Portfolio/pull/898?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->