### PR TITLE
fix(portfolio): drop BetweenReceiptVisualization, keep LabelValidationTimeline

### DIFF
--- a/portfolio/pages/receipt.tsx
+++ b/portfolio/pages/receipt.tsx
@@ -12,7 +12,6 @@ import AnimatedInView from "../components/ui/AnimatedInView";
 import {
   AddressSimilaritySideBySide,
   AWSFlowDiagram,
-  BetweenReceiptVisualization,
   CICDLoop,
   CodeBuildDiagram,
   DynamoStreamAnimation,
@@ -328,23 +327,9 @@ M1LK 2%           1    $4.4g`}</code>
       </ClientOnly>
 
       <p>
-        Then I compare the labels across receipts from the same store. If
-        every other Trader Joe's receipt calls that field a line total, but
-        this one says subtotal, something's off.
+        Even with the math checks, the labels weren't perfect. So I corrected
+        the results by asking AI to verify them. And again. And again.
       </p>
-
-      <ClientOnly>
-        <BetweenReceiptVisualization />
-      </ClientOnly>
-
-      <p>
-        This works, kind of. AI isn't consistent. It would call the price of
-        milk the subtotal. It confused "DAIRY" with "MILK." I can't trust
-        something that doesn't know what milk is. So I corrected the results
-        by asking AI to verify again.
-      </p>
-
-      <p>And again. And again.</p>
 
       <ClientOnly>
         <LabelValidationTimeline />


### PR DESCRIPTION
## Problem

After PR #888 restored the cross-receipt section, prod showed **"No between-receipt data available"** where \`BetweenReceiptVisualization\` should be.

## Root cause

PR #888 brought back JSX for two visualizations in the same narrative block, but they have **different data fates** post-#860:

| Component | Data status | Verdict |
|---|---|---|
| \`BetweenReceiptVisualization\` | Reads \`receipt.review.all_decisions\` — null on every receipt since #860 retired the fused-review pipeline | **Remove** |
| \`LabelValidationTimeline\` | Reads \`/label_validation_timeline\` — returns 52,946 records, 202 keyframes, generated 2026-05-17 | **Keep** |

The narrative block conflated two stories (cross-receipt fused review + iterative verification). The first describes a thing the codebase no longer does; the second still happens. Keep the prose that matches reality, drop the prose that doesn't.

## Diff summary

- Remove: \`BetweenReceiptVisualization\` import + render + 2 prose paragraphs that set it up
- Keep: \`LabelValidationTimeline\` import + render + the surrounding "iterative verification" prose (tightened)
- Net: -17 / +2 LOC

## Test plan

- [x] Page narrative still flows: FinancialMath → iterative verification setup → timeline → "slow and expensive" → "Making it Faster and Cheaper"
- [x] LabelValidationTimeline endpoint verified live on prod (200, 431KB)
- [ ] Visual check after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)