### PR TITLE
fix(CICDLoop): React.memo against parent re-renders (react-spring v10 regression)

### DIFF
--- a/portfolio/components/ui/Figures/CICDLoop.tsx
+++ b/portfolio/components/ui/Figures/CICDLoop.tsx
@@ -1022,4 +1022,10 @@ const CICDLoop: React.FC<CICDLoopProps> = ({
   );
 };
 
-export default CICDLoop;
+// React.memo guards against parent re-renders. The receipt page re-renders
+// every time a question is clicked in the QAAgentFlow marquee above us
+// (state in useQAQueue updates), which @react-spring/web@10 was treating
+// as a signal to reset all springs to their init state — leaving segments
+// invisible until the next pulse cycle (~5s). CICDLoop takes no props from
+// the page so a stable memo here is safe.
+export default React.memo(CICDLoop);


### PR DESCRIPTION
## Problem

Clicking a question in the QAAgentFlow marquee made the CICDLoop's segments fade to opacity 0 and stay invisible until the next pulse cycle (~5s). Visible as half-the-figure-disappearing every time the user interacted with the marquee above.

## Investigation (logged in commit body)

Battle-tested with monkey-patched \`api.start\` logging:

| Hypothesis | Result |
|---|---|
| Component remounts | ❌ SVG element identity preserved (data-tag survives click) |
| useSprings init function called again | ❌ Only called once |
| Entrance effect's reset branch fires | ❌ Doesn't run after click |
| Some \`api.start({opacity:0})\` call | ❌ No such call in trace |
| Yet segments settle at exactly opacity:0 + scale(0.9) | ✅ The spring's init state |

Root cause: **known regression in @react-spring/web@10** where useSprings internally resets springs to their init state on certain parent re-renders (see pmndrs/react-spring#366 + #2404). The receipt page re-renders every time \`useQAQueue\` state updates (question changes), and that re-render propagates into CICDLoop.

## Fix

Wrap the default export in \`React.memo\`. CICDLoop takes no props from the page (just \`<CICDLoop />\` in receipt.tsx), so memoization is safe and stops parent re-renders from propagating.

## Test plan

- [x] Click 3 different marquee questions back-to-back → all 7 segments held at opacity 1.00 throughout (vs. fading to 0 and recovering over 5s before the fix)
- [ ] Visual confirmation after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the CICD Loop animation would become invisible after page interactions, ensuring consistent visual display.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tnorlund/Portfolio/pull/901?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->