### PR TITLE
fix(layoutlm/export-coreml): write vocab.txt manually for transformers 5.x

### DIFF
--- a/receipt_layoutlm/receipt_layoutlm/export_coreml.py
+++ b/receipt_layoutlm/receipt_layoutlm/export_coreml.py
@@ -265,9 +265,17 @@ def export_coreml(
         shutil.copy(vocab_src, vocab_dst)
         print(f"Copied vocab.txt to {vocab_dst}")
     else:
-        # Try to save vocab from tokenizer (may create additional files like added_tokens.json)
-        tokenizer.save_vocabulary(str(output_path))
-        print(f"Saved vocabulary to {output_path}")
+        # transformers 5.x removed BertTokenizer.vocab_file, so
+        # tokenizer.save_vocabulary() crashes (AttributeError). The Swift
+        # inference side (BertTokenizer.swift) only needs the BERT-format
+        # vocab.txt — sort tokens by id and write directly. Works with
+        # both slow (BertTokenizer) and fast (BertTokenizerFast) loaders.
+        vocab = tokenizer.get_vocab()
+        sorted_tokens = sorted(vocab.items(), key=lambda kv: kv[1])
+        with open(vocab_dst, "w", encoding="utf-8") as f:
+            for token, _ in sorted_tokens:
+                f.write(token + "\n")
+        print(f"Wrote vocab.txt to {vocab_dst} ({len(sorted_tokens)} tokens)")
 
     # Sort label IDs for consistent ordering in JSON output
     sorted_ids = sorted(id2label.keys())


### PR DESCRIPTION
## Summary

\`export_coreml.py\`'s fallback path called \`tokenizer.save_vocabulary()\` when the checkpoint dir didn't contain \`vocab.txt\`. In transformers 5.x, \`BertTokenizer\`'s \`vocab_file\` attribute was removed, so \`save_vocabulary\` crashes with:

\`\`\`
AttributeError: BertTokenizer has no attribute vocab_file.
Did you mean: 'vocab_size'?
\`\`\`

This broke CoreML export for any v6+ checkpoint (those are saved by transformers 5.x and produce \`tokenizer.json\` rather than the legacy \`vocab.txt\`).

## Fix

Write vocab.txt directly from \`tokenizer.get_vocab()\` — the dict is sorted by id and dumped one token per line, identical to BERT's legacy \`vocab.txt\` format. Works with both slow (\`BertTokenizer\`) and fast (\`BertTokenizerFast\`) loaders, across transformers 4.x and 5.x.

## Verification

Re-exported v10 checkpoint to \`/tmp/v10_coreml_v3\`:

\`\`\`
CoreML bundle created at: /tmp/v10_coreml_v3
Contents:
  tokenizer_config.json
  config.json
  LayoutLM.mlpackage/
  label_map.json
  vocab.txt
\`\`\`

No \`AttributeError\`, bundle complete with all expected files.

## Test plan

- [x] Local re-export with transformers 5.9.0 succeeds (was failing before)
- [ ] Resulting bundle loads correctly in receipt-ocr Swift binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)