### PR TITLE
fix(CICDLoop): stop overlap-effect re-render from resetting springs

### DIFF
--- a/portfolio/components/ui/Figures/CICDLoop.tsx
+++ b/portfolio/components/ui/Figures/CICDLoop.tsx
@@ -842,8 +842,13 @@ const CICDLoop: React.FC<CICDLoopProps> = ({
   const ribbonRefs = useRef<(SVGPathElement | null)[]>([]);
   const textRefs = useRef<(SVGTextElement | null)[]>([]);
 
-  // State for text offset adjustments due to overlap
-  const [textOffsetAdjustments, setTextOffsetAdjustments] = useState<number[]>([]);
+  // State for text offset adjustments due to overlap. Initialize to a
+  // zero-filled array of the right length so the no-overlap setState call
+  // is dedupe'd in the overlap-detection effect — avoiding a needless
+  // re-render that would otherwise reset useSprings in @react-spring/web@10.
+  const [textOffsetAdjustments, setTextOffsetAdjustments] = useState<number[]>(
+    () => new Array(segments.length).fill(0),
+  );
 
   // Find the "Plan" segment index
   const planIndex = useMemo(() => {
@@ -918,7 +923,19 @@ const CICDLoop: React.FC<CICDLoopProps> = ({
         }
       });
 
-      setTextOffsetAdjustments(adjustments);
+      // Only setState if values actually changed — every re-render of
+      // CICDLoop triggers @react-spring/web@10 to reset segment springs
+      // to their init state (opacity:0), so we avoid spurious setState
+      // that would cause an unnecessary re-render here.
+      setTextOffsetAdjustments((prev) => {
+        if (
+          prev.length === adjustments.length &&
+          prev.every((v, idx) => v === adjustments[idx])
+        ) {
+          return prev;
+        }
+        return adjustments;
+      });
     }, animationCompleteDelay);
 
     return () => clearTimeout(timeoutId);


### PR DESCRIPTION
## Summary

Follow-up to #901. The React.memo there guards against parent re-renders from `receipt.tsx`, but a re-render still happens *inside* CICDLoop ~1.65s after entry — and that's enough to trip the same @react-spring/web@10 reset bug.

**Root cause:** the overlap-detection `useEffect` fires `setTextOffsetAdjustments` after `animationCompleteDelay`. The state was initialized to `[]`, so the first run always sets it to a fresh length-N array — a legitimate state change, triggering a re-render. react-spring v10 interprets the re-render as a signal to reset the segment springs to their init opacity (0), producing a visible "show once, disappear, throb back in" sequence at the 1.5–2s mark.

**Fix:**
- Initialize `textOffsetAdjustments` to a zero-filled array of length `segments.length` (the no-overlap baseline).
- Dedupe the setState by value — if the computed adjustments match the previous array, return the prev reference so React skips the render entirely.

## Verification

Playwright opacity sampling (250ms cadence over 12s) shows segments stable at 1.00 from ~0.75s through 12s, no dip:

```
[0.00s] 1.00,1.00,1.03,1.07,0.84,0.09,1.00  ← entrance still in progress
[0.75s] 1.00,1.00,1.00,1.00,1.00,1.00,1.00
[1.50s] 1.00,1.00,1.00,1.00,1.00,1.00,1.00  ← previously dipped to 0 here
[2.00s] 1.00,1.00,1.00,1.00,1.00,1.00,1.00
…
[11.75s] 1.00,1.00,1.00,1.00,1.00,1.00,1.00
```

Three rapid question clicks above the diagram: segments still 1.00 throughout.

## Test plan

- [x] Playwright stability test: segments stay at 1.00 for 12s after entrance
- [x] Three rapid clicks on questions above: no flicker
- [ ] CodeRabbit review
- [ ] Visual smoke on prod after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved animation smoothness in the CI/CD Loop visualization by reducing unnecessary re-renders that were interfering with animation playback.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tnorlund/Portfolio/pull/903?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->