### PR TITLE
feat(layoutlm): configurable class-weight clip + env_* hyperparameter passthrough

### DIFF
--- a/infra/sagemaker_training/train.py
+++ b/infra/sagemaker_training/train.py
@@ -48,7 +48,14 @@ def get_hyperparameters() -> dict:
     # Also check individual SM_HP_* variables
     for key, value in os.environ.items():
         if key.startswith("SM_HP_"):
-            param_name = key[6:].lower()  # Remove SM_HP_ prefix
+            suffix = key[6:]  # Remove SM_HP_ prefix
+            # Preserve original case for `env_*` keys — they get promoted to
+            # process env vars in main() and the downstream code reads
+            # LAYOUTLM_CLASS_WEIGHT_MAX, not layoutlm_class_weight_max.
+            if suffix.lower().startswith("env_"):
+                param_name = "env_" + suffix[len("env_"):]
+            else:
+                param_name = suffix.lower()
             hps[param_name] = value
 
     return hps

--- a/infra/sagemaker_training/train.py
+++ b/infra/sagemaker_training/train.py
@@ -183,8 +183,19 @@ def main():
     print(f"Running: {' '.join(cmd)}")
     print("=" * 60)
 
+    # Promote hyperparameters of the form `env_VAR=val` to process env vars
+    # before launching the trainer. Lets callers tune env-driven knobs
+    # (LAYOUTLM_WINDOW_SIZE, LAYOUTLM_CLASS_WEIGHT_*, etc.) per training job
+    # without adding a new CLI flag for each one.
+    child_env = os.environ.copy()
+    for key, value in hps.items():
+        if key.startswith("env_"):
+            env_name = key[len("env_") :]
+            child_env[env_name] = str(value)
+            print(f"  setenv {env_name}={value}")
+
     # Run training
-    result = subprocess.run(cmd, check=False)
+    result = subprocess.run(cmd, check=False, env=child_env)
 
     if result.returncode != 0:
         print(f"Training failed with exit code {result.returncode}")

--- a/receipt_layoutlm/receipt_layoutlm/trainer.py
+++ b/receipt_layoutlm/receipt_layoutlm/trainer.py
@@ -1071,14 +1071,21 @@ class ReceiptLayoutLMTrainer:
         # frequency, clipped to [w_min, w_max]. Defaults preserve v13 behavior.
         # Tighten via LAYOUTLM_CLASS_WEIGHT_MIN / _MAX to reduce over-prediction
         # of rare classes at the cost of accepting more O bias.
-        try:
-            w_min = float(os.getenv("LAYOUTLM_CLASS_WEIGHT_MIN", "0.3"))
-        except ValueError:
-            w_min = 0.3
-        try:
-            w_max = float(os.getenv("LAYOUTLM_CLASS_WEIGHT_MAX", "5.0"))
-        except ValueError:
-            w_max = 5.0
+        def _read_float_env(name: str, default: float) -> float:
+            raw = os.getenv(name)
+            if raw is None:
+                return default
+            try:
+                return float(raw)
+            except ValueError:
+                print(
+                    f"[trainer] WARN: {name}={raw!r} is not a valid float; "
+                    f"falling back to default {default}"
+                )
+                return default
+
+        w_min = _read_float_env("LAYOUTLM_CLASS_WEIGHT_MIN", 0.3)
+        w_max = _read_float_env("LAYOUTLM_CLASS_WEIGHT_MAX", 5.0)
         if not (0 < w_min <= w_max):
             raise ValueError(
                 f"class weight clip range invalid: "

--- a/receipt_layoutlm/receipt_layoutlm/trainer.py
+++ b/receipt_layoutlm/receipt_layoutlm/trainer.py
@@ -1068,7 +1068,22 @@ class ReceiptLayoutLMTrainer:
         # Class-weighted cross-entropy to combat majority-class ("O") collapse.
         # Per-receipt-window training has O:entity ratio ~3.6:1; un-weighted
         # CE drives the model toward all-O predictions. Weight = inverse class
-        # frequency, clipped to [0.3, 5.0].
+        # frequency, clipped to [w_min, w_max]. Defaults preserve v13 behavior.
+        # Tighten via LAYOUTLM_CLASS_WEIGHT_MIN / _MAX to reduce over-prediction
+        # of rare classes at the cost of accepting more O bias.
+        try:
+            w_min = float(os.getenv("LAYOUTLM_CLASS_WEIGHT_MIN", "0.3"))
+        except ValueError:
+            w_min = 0.3
+        try:
+            w_max = float(os.getenv("LAYOUTLM_CLASS_WEIGHT_MAX", "5.0"))
+        except ValueError:
+            w_max = 5.0
+        if not (0 < w_min <= w_max):
+            raise ValueError(
+                f"class weight clip range invalid: "
+                f"min={w_min}, max={w_max} (require 0 < min <= max)"
+            )
         torch_mod = self._torch
         n_classes = len(label_list)
         class_counts = [0] * n_classes
@@ -1085,7 +1100,7 @@ class ReceiptLayoutLMTrainer:
                 weights.append(1.0)
             else:
                 w = total / (n_classes * c)
-                weights.append(max(0.3, min(w, 5.0)))
+                weights.append(max(w_min, min(w, w_max)))
         class_weights_tensor = torch_mod.tensor(
             weights, dtype=torch_mod.float32
         )


### PR DESCRIPTION
## Summary

Adds two configuration knobs that let future training experiments tune the loss + windowing without code changes per run.

- **\`trainer.py\`**: hardcoded class-weight clip \`[0.3, 5.0]\` (v13) is now configurable via \`LAYOUTLM_CLASS_WEIGHT_MIN\` / \`_MAX\` env vars. Defaults preserve v13 behavior. Raises \`ValueError\` on invalid ranges (negative, or min > max).
- **\`infra/sagemaker_training/train.py\`**: hyperparameters of the form \`env_VAR=val\` are promoted to process env vars before launching the trainer subprocess. Generic mechanism that lets the start-training Lambda payload tune \`LAYOUTLM_WINDOW_SIZE\`, \`LAYOUTLM_WINDOW_STRIDE\`, the new \`CLASS_WEIGHT_*\` clip, etc., without adding a CLI flag per knob.

## Why

PR #904 introduced per-receipt-window training + class-weighted loss. v13 (the first model trained with that pipeline) hit f1=0.543 but with significant over-prediction on rare classes (clip ceiling 5.0 was too aggressive). v14 was a follow-up experiment that needed runtime-configurable values for the class-weight clip + window size to test the hypothesis that loosening the clip would reduce over-prediction.

## Validation

v14 run uses only the new env vars (no other code changes vs v13):

| Param | v13 | v14 |
|-------|-----|-----|
| LAYOUTLM_CLASS_WEIGHT_MIN | 0.3 (default) | **0.5** |
| LAYOUTLM_CLASS_WEIGHT_MAX | 5.0 (default) | **3.0** |
| LAYOUTLM_WINDOW_SIZE | 200 (default) | **250** |
| LAYOUTLM_WINDOW_STRIDE | 150 (default) | **200** |
| learning_rate | 2e-5 | 1e-5 |
| epochs | 60 | 100 |

| Run | best_f1 (held-out) | precision | recall |
|-----|--------------------|-----------|--------|
| v13 | 0.543 | 0.479 | 0.624 |
| v14 | **0.785** | **0.748** | **0.826** |

End-to-end Mac OCR worker test (real Vision OCR + CoreML inference on a Freddy's receipt):

| Model | Useful labels on 115-word receipt |
|-------|-----------------------------------|
| v11 (current prod) | **0 / 115** (all-O) |
| v14 | **21 / 115** (correct MERCHANT_NAME, ADDRESS span, TIME, 9 AMOUNTs) |

## Test plan

- [ ] CI green
- [ ] Verify existing trained runs still use v13 defaults when env vars unset
- [ ] Future v15 runs can sweep clips/windows via Lambda payload alone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Environment variable injection: Hyperparameters with the `env_` prefix are now automatically promoted to environment variables during training subprocess execution, enabling flexible runtime configuration.
  * Configurable weight bounds: Per-class weight clamp limits are now adjustable through environment variables instead of hardcoded values, providing greater control for optimizing model training performance across different scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tnorlund/Portfolio/pull/905?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->