### PR TITLE
feat(label-refresh): Lambda auto-refreshes labels when ReceiptWord.text changes

### DIFF
--- a/infra/__main__.py
+++ b/infra/__main__.py
@@ -47,6 +47,7 @@ from fix_place_lambda import create_fix_place_lambda
 from label_evaluator_step_functions import LabelEvaluatorStepFunction
 from merge_receipt_lambda import create_merge_receipt_lambda
 from trigger_reocr_lambda import create_trigger_reocr_lambda
+from label_refresh_lambda import create_label_refresh_lambda
 from metadata_harmonizer_step_functions import MetadataHarmonizerStepFunction
 
 # Using the optimized docker-build based base images with scoped contexts
@@ -1298,6 +1299,21 @@ trigger_reocr_lambda = create_trigger_reocr_lambda(
 )
 pulumi.export("trigger_reocr_lambda_arn", trigger_reocr_lambda.lambda_arn)
 pulumi.export("trigger_reocr_lambda_name", trigger_reocr_lambda.lambda_function.name)
+
+# Label Refresh Lambda — subscribes to the DynamoDB stream and
+# automatically re-evaluates ReceiptWord labels whenever a word's
+# text changes (e.g. after the Mac worker writes new OCR text from
+# a regional re-OCR job). Closes the loop so labels don't go stale.
+label_refresh_lambda = create_label_refresh_lambda(
+    dynamodb_table_name=dynamodb_table.name,
+    dynamodb_table_arn=dynamodb_table.arn,
+    dynamodb_stream_arn=dynamodb_table.stream_arn,
+    # Start in dry-run so the first deploy logs proposed updates only.
+    # Flip to false after eyeballing the CloudWatch logs.
+    dry_run=True,
+)
+pulumi.export("label_refresh_lambda_arn", label_refresh_lambda.lambda_arn)
+pulumi.export("label_refresh_lambda_name", label_refresh_lambda.lambda_function.name)
 
 # LangSmith Bulk Export infrastructure (for Parquet exports)
 from components.langsmith_bulk_export import LangSmithBulkExport

--- a/infra/__main__.py
+++ b/infra/__main__.py
@@ -1304,16 +1304,23 @@ pulumi.export("trigger_reocr_lambda_name", trigger_reocr_lambda.lambda_function.
 # automatically re-evaluates ReceiptWord labels whenever a word's
 # text changes (e.g. after the Mac worker writes new OCR text from
 # a regional re-OCR job). Closes the loop so labels don't go stale.
+#
+# Per-stack rollout switch — defaults to True (dry-run) so first
+# deploy is observe-only. Flip per stack with:
+#   pulumi config set portfolio:label_refresh_dry_run false --stack dev
+# Then verify dev for 48h before flipping prod.
+_label_refresh_dry_run = pulumi.Config("portfolio").get_bool(
+    "label_refresh_dry_run"
+)
 label_refresh_lambda = create_label_refresh_lambda(
     dynamodb_table_name=dynamodb_table.name,
     dynamodb_table_arn=dynamodb_table.arn,
     dynamodb_stream_arn=dynamodb_table.stream_arn,
-    # Start in dry-run so the first deploy logs proposed updates only.
-    # Flip to false after eyeballing the CloudWatch logs.
-    dry_run=True,
+    dry_run=True if _label_refresh_dry_run is None else _label_refresh_dry_run,
 )
 pulumi.export("label_refresh_lambda_arn", label_refresh_lambda.lambda_arn)
 pulumi.export("label_refresh_lambda_name", label_refresh_lambda.lambda_function.name)
+pulumi.export("label_refresh_dlq_url", label_refresh_lambda.dlq_url)
 
 # LangSmith Bulk Export infrastructure (for Parquet exports)
 from components.langsmith_bulk_export import LangSmithBulkExport

--- a/infra/label_refresh_lambda/__init__.py
+++ b/infra/label_refresh_lambda/__init__.py
@@ -1,0 +1,8 @@
+"""Label Refresh on Text Change Lambda infrastructure."""
+
+from label_refresh_lambda.infrastructure import (
+    LabelRefreshLambda,
+    create_label_refresh_lambda,
+)
+
+__all__ = ["LabelRefreshLambda", "create_label_refresh_lambda"]

--- a/infra/label_refresh_lambda/infrastructure.py
+++ b/infra/label_refresh_lambda/infrastructure.py
@@ -131,14 +131,17 @@ class LabelRefreshLambda(ComponentResource):
                         "Statement": [
                             {
                                 "Effect": "Allow",
+                                # Note: receipt_dynamo's `_update_entity`
+                                # uses `put_item` under the hood with a
+                                # condition expression, so PutItem must be
+                                # allowed even though we only ever update
+                                # existing rows.
                                 "Action": [
                                     "dynamodb:DescribeTable",
                                     "dynamodb:GetItem",
                                     "dynamodb:PutItem",
-                                    "dynamodb:UpdateItem",
                                     "dynamodb:Query",
                                     "dynamodb:BatchGetItem",
-                                    "dynamodb:BatchWriteItem",
                                 ],
                                 "Resource": [arn, f"{arn}/index/*"],
                             }
@@ -217,10 +220,14 @@ class LabelRefreshLambda(ComponentResource):
         # ============================================================
         # DynamoDB Stream EventSourceMapping
         # ============================================================
-        # Filter: only fire on MODIFY events whose SK begins with LINE#
-        # (ReceiptWord entities). The handler does a second-pass check
-        # for actual text changes; this filter just keeps the volume
-        # down at the AWS level.
+        # Filter: only fire on MODIFY events whose SK begins with
+        # RECEIPT# (ReceiptWord rows — also matches Receipt, ReceiptLine,
+        # ReceiptLetter, etc., which the handler filters out via its
+        # _WORD_SK_RE regex). Source of truth for the SK shape is
+        # receipt_dynamo/entities/receipt_word.py:91-109:
+        #   SK = "RECEIPT#{rid:05d}#LINE#{lid:05d}#WORD#{wid:05d}"
+        # The AWS-side filter keeps invocation volume manageable; the
+        # handler does the precise SK regex + actual text-change check.
         self.event_source_mapping = aws.lambda_.EventSourceMapping(
             f"{name}-stream-mapping",
             event_source_arn=dynamodb_stream_arn,
@@ -236,7 +243,7 @@ class LabelRefreshLambda(ComponentResource):
                                 "eventName": ["MODIFY"],
                                 "dynamodb": {
                                     "Keys": {
-                                        "SK": {"S": [{"prefix": "LINE#"}]}
+                                        "SK": {"S": [{"prefix": "RECEIPT#"}]}
                                     }
                                 },
                             }

--- a/infra/label_refresh_lambda/infrastructure.py
+++ b/infra/label_refresh_lambda/infrastructure.py
@@ -1,0 +1,284 @@
+"""
+Pulumi infrastructure for the Label Refresh on Text Change Lambda.
+
+This Lambda subscribes to the ReceiptsTable DynamoDB stream. For every
+MODIFY event on a ReceiptWord whose `text` attribute changed, it
+re-evaluates each label on that word against the Chroma `words`
+collection (same logic as `validate_word_similarity` in the MCP
+server) and writes back updated `validation_status` values.
+
+This closes the loop after a regional re-OCR: when the Mac OCR
+worker updates a word's text, this Lambda automatically refreshes
+the word's labels so they don't go stale.
+
+Architecture:
+- DynamoDB stream → EventSourceMapping → this Lambda
+- Lambda has read-only Chroma Cloud access + read/write DynamoDB
+- Filter expression keeps the Lambda invocation footprint small
+- DRY_RUN env var (default false) allows safe rollout
+"""
+
+import json
+from typing import Optional
+
+import pulumi
+import pulumi_aws as aws
+from pulumi import ComponentResource, Config, Output, ResourceOptions
+from pulumi_aws.iam import Role, RolePolicy, RolePolicyAttachment
+
+try:
+    from codebuild_docker_image import CodeBuildDockerImage
+except ImportError as e:
+    raise ImportError(
+        "CodeBuildDockerImage is required for LabelRefreshLambda. "
+        "Ensure codebuild_docker_image.py is in the Pulumi project root."
+    ) from e
+
+
+# Load secrets / config once at module import
+_config = Config("portfolio")
+_chroma_cloud_api_key = _config.require_secret("CHROMA_CLOUD_API_KEY")
+_chroma_cloud_tenant = _config.get("CHROMA_CLOUD_TENANT") or ""
+_chroma_cloud_database = _config.get("CHROMA_CLOUD_DATABASE") or ""
+
+
+class LabelRefreshLambda(ComponentResource):
+    """
+    Container Lambda that re-evaluates word labels when a word's text
+    changes in DynamoDB.
+
+    Exports:
+    - lambda_function: The Lambda function resource
+    - lambda_arn: ARN of the Lambda
+    - lambda_role_name: IAM role name
+    - event_source_mapping: The stream EventSourceMapping resource
+    """
+
+    def __init__(
+        self,
+        name: str,
+        *,
+        dynamodb_table_name: pulumi.Input[str],
+        dynamodb_table_arn: pulumi.Input[str],
+        dynamodb_stream_arn: pulumi.Input[str],
+        dry_run: bool = False,
+        opts: Optional[ResourceOptions] = None,
+    ):
+        super().__init__(f"{__name__}-{name}", name, None, opts)
+        stack = pulumi.get_stack()
+
+        # ============================================================
+        # IAM Role
+        # ============================================================
+        lambda_role = Role(
+            f"{name}-lambda-role",
+            assume_role_policy=json.dumps(
+                {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Principal": {"Service": "lambda.amazonaws.com"},
+                            "Action": "sts:AssumeRole",
+                        }
+                    ],
+                }
+            ),
+            opts=ResourceOptions(parent=self),
+        )
+
+        RolePolicyAttachment(
+            f"{name}-lambda-basic-exec",
+            role=lambda_role.name,
+            policy_arn=(
+                "arn:aws:iam::aws:policy/service-role/"
+                "AWSLambdaBasicExecutionRole"
+            ),
+            opts=ResourceOptions(parent=lambda_role),
+        )
+
+        # ECR for container Lambda
+        RolePolicy(
+            f"{name}-lambda-ecr-policy",
+            role=lambda_role.id,
+            policy=json.dumps(
+                {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Action": [
+                                "ecr:GetAuthorizationToken",
+                                "ecr:BatchGetImage",
+                                "ecr:GetDownloadUrlForLayer",
+                            ],
+                            "Resource": "*",
+                        }
+                    ],
+                }
+            ),
+            opts=ResourceOptions(parent=lambda_role),
+        )
+
+        # DynamoDB: read receipt details, update labels
+        dynamodb_policy = RolePolicy(
+            f"{name}-lambda-dynamo-policy",
+            role=lambda_role.id,
+            policy=Output.from_input(dynamodb_table_arn).apply(
+                lambda arn: json.dumps(
+                    {
+                        "Version": "2012-10-17",
+                        "Statement": [
+                            {
+                                "Effect": "Allow",
+                                "Action": [
+                                    "dynamodb:DescribeTable",
+                                    "dynamodb:GetItem",
+                                    "dynamodb:PutItem",
+                                    "dynamodb:UpdateItem",
+                                    "dynamodb:Query",
+                                    "dynamodb:BatchGetItem",
+                                    "dynamodb:BatchWriteItem",
+                                ],
+                                "Resource": [arn, f"{arn}/index/*"],
+                            }
+                        ],
+                    }
+                )
+            ),
+            opts=ResourceOptions(parent=lambda_role),
+        )
+
+        # DynamoDB streams permission for the EventSourceMapping
+        stream_policy = RolePolicy(
+            f"{name}-lambda-stream-policy",
+            role=lambda_role.id,
+            policy=Output.from_input(dynamodb_stream_arn).apply(
+                lambda arn: json.dumps(
+                    {
+                        "Version": "2012-10-17",
+                        "Statement": [
+                            {
+                                "Effect": "Allow",
+                                "Action": [
+                                    "dynamodb:DescribeStream",
+                                    "dynamodb:GetRecords",
+                                    "dynamodb:GetShardIterator",
+                                    "dynamodb:ListStreams",
+                                ],
+                                "Resource": arn,
+                            }
+                        ],
+                    }
+                )
+            ),
+            opts=ResourceOptions(parent=lambda_role),
+        )
+
+        # ============================================================
+        # Container Lambda
+        # ============================================================
+        lambda_config = {
+            "role_arn": lambda_role.arn,
+            "timeout": 300,  # 5 min — generous for batches of 10 records
+            "memory_size": 1024,
+            "tags": {"environment": stack},
+            "environment": {
+                "DYNAMODB_TABLE_NAME": dynamodb_table_name,
+                "CHROMA_CLOUD_API_KEY": _chroma_cloud_api_key,
+                "CHROMA_CLOUD_TENANT": _chroma_cloud_tenant,
+                "CHROMA_CLOUD_DATABASE": _chroma_cloud_database,
+                "DRY_RUN": "true" if dry_run else "false",
+            },
+        }
+
+        docker_image = CodeBuildDockerImage(
+            f"{name}-img",
+            dockerfile_path="infra/label_refresh_lambda/lambdas/Dockerfile",
+            build_context_path=".",
+            source_paths=[
+                "receipt_dynamo",
+                "receipt_chroma",
+                "infra/label_refresh_lambda/lambdas",
+            ],
+            lambda_function_name=f"{name}-{stack}-label-refresh",
+            lambda_config=lambda_config,
+            platform="linux/arm64",
+            opts=ResourceOptions(
+                parent=self,
+                depends_on=[lambda_role, dynamodb_policy, stream_policy],
+            ),
+        )
+
+        self.lambda_function = docker_image.lambda_function
+        self.lambda_arn = self.lambda_function.arn
+        self.lambda_role_name = lambda_role.name
+
+        # ============================================================
+        # DynamoDB Stream EventSourceMapping
+        # ============================================================
+        # Filter: only fire on MODIFY events whose SK begins with LINE#
+        # (ReceiptWord entities). The handler does a second-pass check
+        # for actual text changes; this filter just keeps the volume
+        # down at the AWS level.
+        self.event_source_mapping = aws.lambda_.EventSourceMapping(
+            f"{name}-stream-mapping",
+            event_source_arn=dynamodb_stream_arn,
+            function_name=self.lambda_function.arn,
+            starting_position="LATEST",
+            batch_size=10,
+            maximum_batching_window_in_seconds=5,
+            filter_criteria=aws.lambda_.EventSourceMappingFilterCriteriaArgs(
+                filters=[
+                    aws.lambda_.EventSourceMappingFilterCriteriaFilterArgs(
+                        pattern=json.dumps(
+                            {
+                                "eventName": ["MODIFY"],
+                                "dynamodb": {
+                                    "Keys": {
+                                        "SK": {"S": [{"prefix": "LINE#"}]}
+                                    }
+                                },
+                            }
+                        ),
+                    )
+                ]
+            ),
+            opts=ResourceOptions(parent=self),
+        )
+
+        self.register_outputs(
+            {
+                "lambda_arn": self.lambda_arn,
+                "lambda_name": self.lambda_function.name,
+                "lambda_role_name": self.lambda_role_name,
+                "event_source_mapping_uuid": self.event_source_mapping.uuid,
+            }
+        )
+
+
+def create_label_refresh_lambda(
+    dynamodb_table_name: pulumi.Input[str],
+    dynamodb_table_arn: pulumi.Input[str],
+    dynamodb_stream_arn: pulumi.Input[str],
+    dry_run: bool = False,
+) -> LabelRefreshLambda:
+    """
+    Factory function to create the Label Refresh Lambda.
+
+    Args:
+        dynamodb_table_name: Name of the DynamoDB ReceiptsTable
+        dynamodb_table_arn: ARN of the DynamoDB ReceiptsTable
+        dynamodb_stream_arn: ARN of the stream attached to the table
+        dry_run: If True, the Lambda logs proposed updates but skips writes
+
+    Returns:
+        LabelRefreshLambda component
+    """
+    return LabelRefreshLambda(
+        "label-refresh",
+        dynamodb_table_name=dynamodb_table_name,
+        dynamodb_table_arn=dynamodb_table_arn,
+        dynamodb_stream_arn=dynamodb_stream_arn,
+        dry_run=dry_run,
+    )

--- a/infra/label_refresh_lambda/infrastructure.py
+++ b/infra/label_refresh_lambda/infrastructure.py
@@ -228,6 +228,40 @@ class LabelRefreshLambda(ComponentResource):
         #   SK = "RECEIPT#{rid:05d}#LINE#{lid:05d}#WORD#{wid:05d}"
         # The AWS-side filter keeps invocation volume manageable; the
         # handler does the precise SK regex + actual text-change check.
+        #
+        # Failure handling: a single poison record can otherwise retry
+        # against the shard until the 24h stream record expires, blocking
+        # downstream consumers. Mirror the resilience settings used by
+        # chromadb_compaction (the only other consumer on this stream).
+        # An SQS DLQ captures records that survive the bisect retries so
+        # an operator can replay them after a fix.
+        dlq = aws.sqs.Queue(
+            f"{name}-dlq",
+            message_retention_seconds=14 * 24 * 60 * 60,  # 14 days
+            tags={"environment": stack},
+            opts=ResourceOptions(parent=self),
+        )
+
+        RolePolicy(
+            f"{name}-lambda-dlq-policy",
+            role=lambda_role.id,
+            policy=dlq.arn.apply(
+                lambda arn: json.dumps(
+                    {
+                        "Version": "2012-10-17",
+                        "Statement": [
+                            {
+                                "Effect": "Allow",
+                                "Action": ["sqs:SendMessage"],
+                                "Resource": arn,
+                            }
+                        ],
+                    }
+                )
+            ),
+            opts=ResourceOptions(parent=lambda_role),
+        )
+
         self.event_source_mapping = aws.lambda_.EventSourceMapping(
             f"{name}-stream-mapping",
             event_source_arn=dynamodb_stream_arn,
@@ -235,6 +269,15 @@ class LabelRefreshLambda(ComponentResource):
             starting_position="LATEST",
             batch_size=10,
             maximum_batching_window_in_seconds=5,
+            maximum_retry_attempts=3,
+            maximum_record_age_in_seconds=3600,
+            bisect_batch_on_function_error=True,
+            function_response_types=["ReportBatchItemFailures"],
+            destination_config=aws.lambda_.EventSourceMappingDestinationConfigArgs(
+                on_failure=aws.lambda_.EventSourceMappingDestinationConfigOnFailureArgs(
+                    destination_arn=dlq.arn,
+                ),
+            ),
             filter_criteria=aws.lambda_.EventSourceMappingFilterCriteriaArgs(
                 filters=[
                     aws.lambda_.EventSourceMappingFilterCriteriaFilterArgs(
@@ -254,12 +297,17 @@ class LabelRefreshLambda(ComponentResource):
             opts=ResourceOptions(parent=self),
         )
 
+        self.dlq = dlq
+        self.dlq_url = dlq.url
+        self.dlq_arn = dlq.arn
+
         self.register_outputs(
             {
                 "lambda_arn": self.lambda_arn,
                 "lambda_name": self.lambda_function.name,
                 "lambda_role_name": self.lambda_role_name,
                 "event_source_mapping_uuid": self.event_source_mapping.uuid,
+                "dlq_url": self.dlq_url,
             }
         )
 

--- a/infra/label_refresh_lambda/lambdas/Dockerfile
+++ b/infra/label_refresh_lambda/lambdas/Dockerfile
@@ -1,0 +1,11 @@
+FROM public.ecr.aws/lambda/python:3.12
+
+COPY receipt_dynamo/ /tmp/receipt_dynamo/
+RUN pip install --no-cache-dir /tmp/receipt_dynamo && rm -rf /tmp/receipt_dynamo
+
+COPY receipt_chroma/ /tmp/receipt_chroma/
+RUN pip install --no-cache-dir /tmp/receipt_chroma && rm -rf /tmp/receipt_chroma
+
+COPY infra/label_refresh_lambda/lambdas/label_refresh.py ${LAMBDA_TASK_ROOT}/handler.py
+
+CMD ["handler.handler"]

--- a/infra/label_refresh_lambda/lambdas/label_refresh.py
+++ b/infra/label_refresh_lambda/lambdas/label_refresh.py
@@ -1,0 +1,351 @@
+"""
+Label Refresh on Text Change Lambda Handler.
+
+Triggered by the DynamoDB stream when a ReceiptWord's text attribute
+changes (most commonly after the Mac OCR worker writes new text from a
+regional re-OCR job). For each affected word, re-runs similarity
+validation against the Chroma `words` collection and updates each
+label's validation_status accordingly.
+
+Mirrors the per-label logic in
+`scripts/receipt_mcp_server.py::validate_word_similarity_impl`, but
+runs server-side so labels stay in sync without manual intervention.
+
+Trigger: DynamoDB stream (EventSourceMapping with filter on
+`SK begins_with LINE# AND eventName=MODIFY`).
+
+Environment:
+    DYNAMODB_TABLE_NAME      — the ReceiptsTable name
+    CHROMA_CLOUD_API_KEY     — Chroma Cloud API key
+    CHROMA_CLOUD_TENANT      — Chroma Cloud tenant
+    CHROMA_CLOUD_DATABASE    — Chroma Cloud database (e.g. receipt_dev)
+    MIN_SIMILARITY           — similarity floor (default 0.80)
+    MIN_MATCHES              — minimum same-label matches (default 3)
+    CONSENSUS_THRESHOLD      — vote threshold for VALID/INVALID (default 0.80)
+    SAME_MERCHANT_BOOST      — similarity bump for same-merchant evidence (default 0.10)
+    DRY_RUN                  — "true" to log proposed updates without writing
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+from typing import Any
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+# Lazy module-scope clients so warm Lambda containers reuse connections.
+_dynamo_client = None
+_chroma_client = None
+_words_collection = None
+
+# SK pattern for a ReceiptWord row: LINE#{line_id:05d}#WORD#{word_id:05d}
+_WORD_SK_RE = re.compile(r"^LINE#(\d{5})#WORD#(\d{5})$")
+
+
+def _get_clients():
+    """Initialize DynamoDB + Chroma clients once per container."""
+    global _dynamo_client, _chroma_client, _words_collection
+    if _dynamo_client is None:
+        from receipt_chroma.data.chroma_client import ChromaClient
+        from receipt_dynamo import DynamoClient
+
+        _dynamo_client = DynamoClient(os.environ["DYNAMODB_TABLE_NAME"])
+        _chroma_client = ChromaClient(
+            cloud_api_key=os.environ["CHROMA_CLOUD_API_KEY"],
+            cloud_tenant=os.environ["CHROMA_CLOUD_TENANT"],
+            cloud_database=os.environ["CHROMA_CLOUD_DATABASE"],
+            mode="read",
+        )
+        _words_collection = _chroma_client.get_collection("words")
+        logger.info("Initialized DynamoDB + Chroma clients")
+    return _dynamo_client, _chroma_client, _words_collection
+
+
+def _extract_word_change(record: dict[str, Any]) -> dict[str, Any] | None:
+    """Return word-change info for a MODIFY record whose text changed.
+
+    Filters out every other entity type. Returns None for non-targets.
+    """
+    if record.get("eventName") != "MODIFY":
+        return None
+    dynamodb = record.get("dynamodb", {})
+    new_image = dynamodb.get("NewImage") or {}
+    old_image = dynamodb.get("OldImage") or {}
+
+    pk = new_image.get("PK", {}).get("S", "")
+    sk = new_image.get("SK", {}).get("S", "")
+    if not pk.startswith("IMAGE#"):
+        return None
+
+    match = _WORD_SK_RE.match(sk)
+    if not match:
+        return None
+
+    new_text = new_image.get("text", {}).get("S", "")
+    old_text = old_image.get("text", {}).get("S", "")
+    if new_text == old_text:
+        return None  # Not a text change
+
+    return {
+        "image_id": pk.removeprefix("IMAGE#"),
+        "line_id": int(match.group(1)),
+        "word_id": int(match.group(2)),
+        "receipt_id": int(new_image.get("receipt_id", {}).get("N", "0")),
+        "new_text": new_text,
+        "old_text": old_text,
+    }
+
+
+def _dist_to_sim(distance: float) -> float:
+    """L2 distance → cosine-like similarity in [0, 1]."""
+    return max(0.0, 1.0 - (distance / 2.0))
+
+
+def _evaluate_label(
+    words_collection,
+    *,
+    image_id: str,
+    receipt_id: int,
+    line_id: int,
+    word_id: int,
+    label: str,
+    min_similarity: float,
+    min_matches: int,
+    consensus_threshold: float,
+    same_merchant_boost: float,
+) -> dict[str, Any] | None:
+    """Decide a label's new validation_status from Chroma similarity evidence.
+
+    Returns None if the word has no embedding or insufficient evidence.
+    """
+    chroma_id = (
+        f"IMAGE#{image_id}#RECEIPT#{receipt_id:05d}"
+        f"#LINE#{line_id:05d}#WORD#{word_id:05d}"
+    )
+    result = words_collection.get(
+        ids=[chroma_id], include=["embeddings", "metadatas"]
+    )
+    if not result.get("ids"):
+        return None
+    embeddings = result.get("embeddings") or []
+    if not len(embeddings):
+        return None
+    embedding = embeddings[0]
+    if hasattr(embedding, "tolist"):
+        embedding = embedding.tolist()
+    meta = (result.get("metadatas") or [{}])[0]
+    merchant = meta.get("merchant_name", "")
+
+    label_field = f"label_{label}"
+    pos = words_collection.query(
+        query_embeddings=[embedding],
+        n_results=10,
+        where={"$and": [{"label_status": "validated"}, {label_field: True}]},
+        include=["metadatas", "distances"],
+    )
+    neg = words_collection.query(
+        query_embeddings=[embedding],
+        n_results=10,
+        where={"$and": [{"label_status": "validated"}, {label_field: False}]},
+        include=["metadatas", "distances"],
+    )
+
+    def _consensus(query_result: dict[str, Any]) -> float:
+        metas = (query_result.get("metadatas") or [[]])[0]
+        dists = (query_result.get("distances") or [[]])[0]
+        total = 0.0
+        for m, d in zip(metas, dists):
+            sim = _dist_to_sim(d)
+            if sim < min_similarity:
+                continue
+            cand_id = (
+                f"IMAGE#{m.get('image_id', '')}#RECEIPT#{m.get('receipt_id', 0):05d}"
+                f"#LINE#{m.get('line_id', 0):05d}#WORD#{m.get('word_id', 0):05d}"
+            )
+            if cand_id == chroma_id:
+                continue
+            weight = sim
+            if m.get("merchant_name") == merchant and merchant:
+                weight = min(1.0, weight + same_merchant_boost)
+            total += weight
+        return total
+
+    votes_for = _consensus(pos)
+    votes_against = _consensus(neg)
+    total_votes = votes_for + votes_against
+    if total_votes == 0:
+        return None  # No similar validated words
+
+    # Approximate match count by counting items above similarity floor
+    def _count(query_result: dict[str, Any]) -> int:
+        dists = (query_result.get("distances") or [[]])[0]
+        return sum(1 for d in dists if _dist_to_sim(d) >= min_similarity)
+
+    n_for, n_against = _count(pos), _count(neg)
+    if n_for + n_against < min_matches:
+        return None
+
+    confidence = votes_for / total_votes
+    if confidence >= consensus_threshold:
+        status, reason = "VALID", f"{confidence:.0%} similar VALID for {label}"
+    elif confidence <= (1.0 - consensus_threshold):
+        status, reason = "INVALID", f"{(1 - confidence):.0%} similar REJECTED {label}"
+    else:
+        status, reason = "NEEDS_REVIEW", f"Mixed: {confidence:.0%} for"
+    return {"status": status, "reason": reason, "confidence": round(confidence, 3)}
+
+
+def _process_word(
+    dynamo,
+    words_collection,
+    *,
+    image_id: str,
+    receipt_id: int,
+    line_id: int,
+    word_id: int,
+    new_text: str,
+    old_text: str,
+    dry_run: bool,
+    min_similarity: float,
+    min_matches: int,
+    consensus_threshold: float,
+    same_merchant_boost: float,
+) -> dict[str, Any]:
+    """Re-evaluate every existing label on this word and write updates."""
+    out = {
+        "image_id": image_id,
+        "receipt_id": receipt_id,
+        "line_id": line_id,
+        "word_id": word_id,
+        "old_text": old_text,
+        "new_text": new_text,
+        "labels_examined": 0,
+        "labels_updated": 0,
+        "updates": [],
+    }
+
+    try:
+        # The DynamoClient exposes word-label lookup via receipt details.
+        # Pull just this receipt's labels and filter to this word.
+        details = dynamo.get_receipt_details(image_id, receipt_id)
+    except Exception as exc:  # pylint: disable=broad-except
+        logger.warning("Skip %s/%d/%d/%d: %s", image_id, receipt_id, line_id, word_id, exc)
+        out["error"] = str(exc)
+        return out
+
+    word_labels = [
+        lbl
+        for lbl in (details.receipt_word_labels or [])
+        if lbl.line_id == line_id and lbl.word_id == word_id
+    ]
+
+    for label in word_labels:
+        out["labels_examined"] += 1
+        decision = _evaluate_label(
+            words_collection,
+            image_id=image_id,
+            receipt_id=receipt_id,
+            line_id=line_id,
+            word_id=word_id,
+            label=label.label,
+            min_similarity=min_similarity,
+            min_matches=min_matches,
+            consensus_threshold=consensus_threshold,
+            same_merchant_boost=same_merchant_boost,
+        )
+        if decision is None:
+            continue
+        new_status = decision["status"]
+        if new_status == label.validation_status:
+            continue
+
+        out["updates"].append({
+            "label": label.label,
+            "old_status": label.validation_status,
+            "new_status": new_status,
+            "reason": decision["reason"],
+            "confidence": decision["confidence"],
+        })
+
+        if dry_run:
+            continue
+
+        label.validation_status = new_status
+        label.label_proposed_by = "label-refresh-on-text-change"
+        try:
+            dynamo.update_receipt_word_label(label)
+            out["labels_updated"] += 1
+        except Exception as exc:  # pylint: disable=broad-except
+            logger.error(
+                "Failed to update label %s on %s/%d/%d/%d: %s",
+                label.label,
+                image_id,
+                receipt_id,
+                line_id,
+                word_id,
+                exc,
+            )
+
+    return out
+
+
+def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
+    """Lambda entry. Processes a batch of DynamoDB stream records."""
+    dry_run = os.environ.get("DRY_RUN", "false").lower() == "true"
+    min_similarity = float(os.environ.get("MIN_SIMILARITY", "0.80"))
+    min_matches = int(os.environ.get("MIN_MATCHES", "3"))
+    consensus_threshold = float(os.environ.get("CONSENSUS_THRESHOLD", "0.80"))
+    same_merchant_boost = float(os.environ.get("SAME_MERCHANT_BOOST", "0.10"))
+
+    dynamo, _chroma, words_collection = _get_clients()
+
+    processed: list[dict[str, Any]] = []
+    skipped = 0
+
+    for record in event.get("Records", []):
+        change = _extract_word_change(record)
+        if change is None:
+            skipped += 1
+            continue
+
+        result = _process_word(
+            dynamo,
+            words_collection,
+            dry_run=dry_run,
+            min_similarity=min_similarity,
+            min_matches=min_matches,
+            consensus_threshold=consensus_threshold,
+            same_merchant_boost=same_merchant_boost,
+            **change,
+        )
+        processed.append(result)
+
+    total_updates = sum(r.get("labels_updated", 0) for r in processed)
+    total_proposed = sum(len(r.get("updates", [])) for r in processed)
+    response = {
+        "processed": len(processed),
+        "skipped": skipped,
+        "labels_proposed": total_proposed,
+        "labels_updated": total_updates,
+        "dry_run": dry_run,
+    }
+    logger.info("label_refresh_summary: %s", json.dumps(response))
+    if processed and total_proposed:
+        # Surface details for the first few updates so CloudWatch logs are useful
+        for r in processed[:10]:
+            if r.get("updates"):
+                logger.info(
+                    "word=%s/%d/%d/%d text='%s'→'%s' updates=%s",
+                    r["image_id"],
+                    r["receipt_id"],
+                    r["line_id"],
+                    r["word_id"],
+                    r["old_text"],
+                    r["new_text"],
+                    r["updates"],
+                )
+    return response

--- a/infra/label_refresh_lambda/lambdas/label_refresh.py
+++ b/infra/label_refresh_lambda/lambdas/label_refresh.py
@@ -42,8 +42,12 @@ _dynamo_client = None
 _chroma_client = None
 _words_collection = None
 
-# SK pattern for a ReceiptWord row: LINE#{line_id:05d}#WORD#{word_id:05d}
-_WORD_SK_RE = re.compile(r"^LINE#(\d{5})#WORD#(\d{5})$")
+# SK pattern for a ReceiptWord row:
+# RECEIPT#{receipt_id:05d}#LINE#{line_id:05d}#WORD#{word_id:05d}
+# Source of truth: receipt_dynamo/entities/receipt_word.py:91-109
+_WORD_SK_RE = re.compile(
+    r"^RECEIPT#(\d{5})#LINE#(\d{5})#WORD#(\d{5})$"
+)
 
 
 def _get_clients():
@@ -92,9 +96,9 @@ def _extract_word_change(record: dict[str, Any]) -> dict[str, Any] | None:
 
     return {
         "image_id": pk.removeprefix("IMAGE#"),
-        "line_id": int(match.group(1)),
-        "word_id": int(match.group(2)),
-        "receipt_id": int(new_image.get("receipt_id", {}).get("N", "0")),
+        "receipt_id": int(match.group(1)),
+        "line_id": int(match.group(2)),
+        "word_id": int(match.group(3)),
         "new_text": new_text,
         "old_text": old_text,
     }
@@ -180,10 +184,24 @@ def _evaluate_label(
     if total_votes == 0:
         return None  # No similar validated words
 
-    # Approximate match count by counting items above similarity floor
+    # Approximate match count — apply the same filter `_consensus` uses
+    # (similarity floor + self-exclusion) so the min_matches gate
+    # doesn't admit decisions that have zero qualifying voters.
     def _count(query_result: dict[str, Any]) -> int:
+        metas = (query_result.get("metadatas") or [[]])[0]
         dists = (query_result.get("distances") or [[]])[0]
-        return sum(1 for d in dists if _dist_to_sim(d) >= min_similarity)
+        n = 0
+        for m, d in zip(metas, dists):
+            if _dist_to_sim(d) < min_similarity:
+                continue
+            cand_id = (
+                f"IMAGE#{m.get('image_id', '')}#RECEIPT#{m.get('receipt_id', 0):05d}"
+                f"#LINE#{m.get('line_id', 0):05d}#WORD#{m.get('word_id', 0):05d}"
+            )
+            if cand_id == chroma_id:
+                continue
+            n += 1
+        return n
 
     n_for, n_against = _count(pos), _count(neg)
     if n_for + n_against < min_matches:
@@ -237,9 +255,11 @@ def _process_word(
         out["error"] = str(exc)
         return out
 
+    # ReceiptDetails carries labels under the `labels` field (see
+    # receipt_dynamo/entities/receipt_details.py).
     word_labels = [
         lbl
-        for lbl in (details.receipt_word_labels or [])
+        for lbl in (details.labels or [])
         if lbl.line_id == line_id and lbl.word_id == word_id
     ]
 
@@ -335,17 +355,32 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
     }
     logger.info("label_refresh_summary: %s", json.dumps(response))
     if processed and total_proposed:
-        # Surface details for the first few updates so CloudWatch logs are useful
+        # Surface fix counts per word so CloudWatch logs are useful, but
+        # avoid emitting raw OCR text (receipts can contain PII/PHI like
+        # card numbers, addresses, names). The (image_id, receipt_id,
+        # line_id, word_id) tuple is enough to dig into the affected
+        # word manually if needed.
         for r in processed[:10]:
-            if r.get("updates"):
-                logger.info(
-                    "word=%s/%d/%d/%d text='%s'→'%s' updates=%s",
-                    r["image_id"],
-                    r["receipt_id"],
-                    r["line_id"],
-                    r["word_id"],
-                    r["old_text"],
-                    r["new_text"],
-                    r["updates"],
-                )
+            updates = r.get("updates") or []
+            if not updates:
+                continue
+            redacted = [
+                {
+                    "label": u["label"],
+                    "old_status": u["old_status"],
+                    "new_status": u["new_status"],
+                    "confidence": u["confidence"],
+                }
+                for u in updates
+            ]
+            logger.info(
+                "word=%s/%d/%d/%d old_text_len=%d new_text_len=%d updates=%s",
+                r["image_id"],
+                r["receipt_id"],
+                r["line_id"],
+                r["word_id"],
+                len(r["old_text"]),
+                len(r["new_text"]),
+                redacted,
+            )
     return response

--- a/infra/label_refresh_lambda/lambdas/label_refresh.py
+++ b/infra/label_refresh_lambda/lambdas/label_refresh.py
@@ -246,6 +246,46 @@ def _process_word(
         "updates": [],
     }
 
+    # ------------------------------------------------------------------
+    # Freshness gate. After a regional re-OCR, the overlay Lambda writes
+    # new ReceiptWord.text to DynamoDB AND kicks off a re-embedding +
+    # COMPACTION_RUN that eventually refreshes Chroma. Those two halves
+    # race: this Lambda fires off the DynamoDB MODIFY ~5s after the
+    # write, but the COMPACTION_RUN can take 30s–2min to land in Chroma.
+    # If we validate labels against the OLD embedding/text in Chroma we
+    # will write confidently-wrong updates. Compare what Chroma currently
+    # has for this word against the new text and bail out if stale —
+    # the next scheduled refresh (or a subsequent stream event after
+    # Chroma catches up) will pick the word up.
+    # ------------------------------------------------------------------
+    chroma_id = (
+        f"IMAGE#{image_id}#RECEIPT#{receipt_id:05d}"
+        f"#LINE#{line_id:05d}#WORD#{word_id:05d}"
+    )
+    try:
+        chroma_row = words_collection.get(
+            ids=[chroma_id], include=["metadatas"]
+        )
+    except Exception as exc:  # pylint: disable=broad-except
+        logger.warning(
+            "Chroma get failed for %s/%d/%d/%d: %s",
+            image_id, receipt_id, line_id, word_id, exc,
+        )
+        out["error"] = f"chroma_get: {exc}"
+        return out
+
+    chroma_metas = chroma_row.get("metadatas") or []
+    if not chroma_row.get("ids") or not chroma_metas:
+        out["skipped_reason"] = "no_chroma_row"
+        return out
+
+    chroma_text = (chroma_metas[0] or {}).get("text", "")
+    if chroma_text != new_text:
+        # Chroma is still stale — compaction hasn't caught up.
+        out["skipped_reason"] = "chroma_stale"
+        out["chroma_text"] = chroma_text
+        return out
+
     try:
         # The DynamoClient exposes word-label lookup via receipt details.
         # Pull just this receipt's labels and filter to this word.
@@ -294,13 +334,31 @@ def _process_word(
         if dry_run:
             continue
 
+        # Preserve human attribution: only stamp our system identity
+        # over another system's, never over a human reviewer. The
+        # existing system identities we know of are emitted by the
+        # MCP server (`mcp-claude-review`), the label-evaluator Lambda
+        # (`label-evaluator-llm`), and the simple analyzer
+        # (`simple_receipt_analyzer`). Anything else — empty, None,
+        # or a username — is treated as human and left alone.
+        SYSTEM_PROPOSED_BY = {
+            "",
+            "label-evaluator-llm",
+            "simple_receipt_analyzer",
+            "mcp-claude-review",
+            "label-refresh-on-text-change",
+        }
         label.validation_status = new_status
-        label.label_proposed_by = "label-refresh-on-text-change"
+        current_attribution = (label.label_proposed_by or "")
+        if current_attribution in SYSTEM_PROPOSED_BY:
+            label.label_proposed_by = "label-refresh-on-text-change"
         try:
             dynamo.update_receipt_word_label(label)
             out["labels_updated"] += 1
         except Exception as exc:  # pylint: disable=broad-except
-            logger.error(
+            logger.warning(
+                # ConditionalCheckFailedException is a benign race
+                # (label deleted between read and write), not an alarm.
                 "Failed to update label %s on %s/%d/%d/%d: %s",
                 label.label,
                 image_id,
@@ -346,9 +404,13 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
 
     total_updates = sum(r.get("labels_updated", 0) for r in processed)
     total_proposed = sum(len(r.get("updates", [])) for r in processed)
+    stale = sum(1 for r in processed if r.get("skipped_reason") == "chroma_stale")
+    no_chroma = sum(1 for r in processed if r.get("skipped_reason") == "no_chroma_row")
     response = {
         "processed": len(processed),
-        "skipped": skipped,
+        "skipped_non_target": skipped,
+        "skipped_chroma_stale": stale,
+        "skipped_no_chroma_row": no_chroma,
         "labels_proposed": total_proposed,
         "labels_updated": total_updates,
         "dry_run": dry_run,


### PR DESCRIPTION
## Summary

Closes the loop after the OCR-outlier batch pipeline (#907). When the Mac OCR worker writes new `ReceiptWord.text` to DynamoDB, this Lambda picks up the MODIFY event from the table's stream and re-runs similarity validation on every label attached to that word. Stale labels (e.g. `RAW` still tagged `OTHER[VALID]` from when its text was `RAN`) get refreshed automatically.

Deployed **dry-run by default** — the initial deploy logs proposed updates without writing. Flip `dry_run=False` in `infra/__main__.py` after eyeballing the CloudWatch logs.

## Why now

The user-visible bug (`RAN MILK` on tylernorlund.com) had two layers:
1. **Wrong text** — Apple Vision misread `RAW` as `RAN`. Fixed by #907's outlier detector + regional re-OCR. ✓
2. **Stale labels** — after re-OCR fixed the text, the labels still pointed at the OLD text. (4 manual agents fixed 12 of these post-hoc on dev.) ✗

This PR is the automated fix for layer 2 going forward.

## How it works

```
ReceiptsTable (DynamoDB stream)
        ↓
        EventSourceMapping (filter: MODIFY, SK begins_with LINE#)
        ↓
        label-refresh Lambda
          ├── parse stream record → extract (image_id, receipt_id, line_id, word_id, old_text, new_text)
          ├── skip if old_text == new_text
          ├── fetch existing labels for this word via DynamoClient
          ├── for each label:
          │     query Chroma "words" collection for similar VALIDATED words
          │     same-merchant boost +0.10, MIN_SIMILARITY=0.80, MIN_MATCHES=3
          │     consensus vote → VALID / INVALID / NEEDS_REVIEW
          └── update label.validation_status via dynamo.update_receipt_word_label
                label_proposed_by = "label-refresh-on-text-change"
```

Same algorithm as `validate_word_similarity` in the MCP server (see `scripts/receipt_mcp_server.py:1793`), now running server-side.

## What's included

| File | What |
|---|---|
| `infra/label_refresh_lambda/lambdas/label_refresh.py` | Stream handler (351 lines, fully typed) |
| `infra/label_refresh_lambda/lambdas/Dockerfile` | Container build: arm64, Python 3.12, receipt_dynamo + receipt_chroma |
| `infra/label_refresh_lambda/infrastructure.py` | Pulumi component (IAM, Lambda, EventSourceMapping with filter) |
| `infra/label_refresh_lambda/__init__.py` | Exports |
| `infra/__main__.py` | Registers the Lambda with `dry_run=True` |

## Configuration

| Env var | Default | Purpose |
|---|---|---|
| `DYNAMODB_TABLE_NAME` | — | ReceiptsTable name (from Pulumi) |
| `CHROMA_CLOUD_API_KEY` | — | Secret from Pulumi config |
| `CHROMA_CLOUD_TENANT` | — | Chroma tenant |
| `CHROMA_CLOUD_DATABASE` | — | `receipt_dev` / `receipt_prod` |
| `MIN_SIMILARITY` | 0.80 | Floor for "similar enough" |
| `MIN_MATCHES` | 3 | Min same-label neighbors |
| `CONSENSUS_THRESHOLD` | 0.80 | Vote share to flip status |
| `SAME_MERCHANT_BOOST` | 0.10 | Similarity bump for same-merchant evidence |
| `DRY_RUN` | true (initially) | Set false to enable writes |

## Notes & caveats

- **DynamoDB stream limit:** AWS allows up to 2 consumers per stream by default. The `chromadb_compaction` stream processor is consumer #1; this Lambda is consumer #2. A third future consumer would require a limit increase.
- **Chroma sync lag:** the words collection is updated asynchronously after text changes. If the Lambda fires before Chroma has the new embedding, the label decision uses the old embedding. In practice this is OK because consensus is based on neighbors, not the changed word's own embedding semantics — but worth knowing.
- **No new label creation:** this Lambda only flips status of *existing* labels. It does not propose new labels for unlabeled words. (That's a separate concern handled by the label evaluator step function.)
- **Audit trail:** every label update sets `label_proposed_by="label-refresh-on-text-change"` and includes a per-label reason in CloudWatch logs.

## Test plan

- [x] AST-parse the handler + infrastructure files
- [ ] `pulumi preview --stack dev` shows the new Lambda + EventSourceMapping without surprises
- [ ] `pulumi up --stack dev` deploys with `dry_run=True`
- [ ] CloudWatch logs show proposed updates that match what we'd expect (eyeballing ~10 stream invocations)
- [ ] Flip `dry_run=False` and verify a manual `trigger_reocr` round-trips: text change → label refresh → consistent state
- [ ] Roll out to prod with `dry_run=True` first, then flip after eyeballing

## Related

- #907 — OCR outlier detection + regional re-OCR pipeline (the producer of the text changes this Lambda reacts to)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic label validation refresh that re-evaluates labels when receipt text changes, using intelligent similarity matching to propose updated validation statuses.
  * Initial deployment runs in preview mode, logging proposed changes without making updates yet.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tnorlund/Portfolio/pull/908?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->