### PR TITLE
fix(ui): stop AnimatedInView from hiding logos after scroll-back

### DIFF
--- a/portfolio/components/ui/AnimatedInView.tsx
+++ b/portfolio/components/ui/AnimatedInView.tsx
@@ -34,14 +34,19 @@ const AnimatedInView = ({
   }));
   const [replaced, setReplaced] = useState(false);
 
-  // Reset state when component goes out of view
+  // Reset the replacement state when the component goes out of view so the
+  // first-paint sequence replays cleanly if it comes back. Do NOT reset
+  // opacity here — the underlying hook uses `triggerOnce: true`, but if a
+  // remount or fallbackInView race makes `inView` momentarily false after a
+  // successful fade-in, calling `api.set({ opacity: 0 })` permanently hides
+  // the content even after the element is fully in viewport again (no
+  // observer callback ever fires to bring it back). See AnimatedInView
+  // logo-disappear bug from May 2026.
   useEffect(() => {
     if (!inView) {
-      // Reset to initial state when out of view
       setReplaced(false);
-      api.set({ opacity: 0 });
     }
-  }, [inView, api]);
+  }, [inView]);
 
   // Initial fade in when component comes into view
   useEffect(() => {


### PR DESCRIPTION
## Summary

AnimatedInView did `api.set({ opacity: 0 })` whenever its IntersectionObserver reported `!inView`. Combined with `useOptimizedInView`'s `triggerOnce: true` semantics (observer disconnects after first sighting), this can leave content permanently hidden — no callback ever fires to bring opacity back to 1.

## Reproduction

On tylernorlund.com/receipt, scroll all the way down and then back up: several company logos (consistently `GoogleMaps`) stay invisible at opacity=0 even though they're in the viewport.

Playwright progressive-scroll repro on the **live prod site**:
```
=== AT_BOTTOM_AFTER_SLOW_SCROLL ===
  GoogleMaps           top= -10298  opacity=0   ← bug: never faded in
  ChromaLogo           top= -10096  opacity=1
  LangChainLogo        top=  -2381  opacity=1
  ...
```

## Fix

Drop the `api.set({ opacity: 0 })` line. Keep the `setReplaced(false)` reset (different visual sequence that benefits from replay).

The intent of the component is "fade in once, never fade out" — the reset line contradicted that. With `triggerOnce: true` the !inView branch is also functionally dead code after first sighting (observer disconnects), so removing the opacity reset doesn't change steady-state behavior; it just stops a transient `inView: true → false → true` race during hydration/remount from permanently hiding the element.

## Verification

Same Playwright repro against a local **production build** (`next build + serve out -l 3001`) after the fix:

```
=== BACK_AT_LOGO_CLUSTER ===
  GoogleMaps           top= -4106  opacity=1   ✓ (was 0)
  ChromaLogo           top= -3905  opacity=1   ✓
  LangChainLogo        top=  1757  opacity=1   ✓
  CursorLogo           top=  3465  opacity=1   ✓
  ... all 9 logos opacity=1 ...
```

All 9 logos now stay at opacity=1 after scroll-down + scroll-back. Existing `AnimatedInView` unit tests still pass (3/3).

## Test plan

- [x] Existing AnimatedInView tests pass
- [x] Playwright progressive-scroll repro against prod build shows fix
- [ ] CI green
- [ ] Post-deploy: verify on tylernorlund.com/receipt manually

🤖 Generated with [Claude Code](https://claude.com/claude-code)