### PR TITLE
fix(label-refresh): include receipt_dynamo_stream in Dockerfile

### DIFF
--- a/infra/label_refresh_lambda/lambdas/Dockerfile
+++ b/infra/label_refresh_lambda/lambdas/Dockerfile
@@ -1,10 +1,17 @@
 FROM public.ecr.aws/lambda/python:3.12
 
+# Local package install chain. receipt_chroma depends on receipt_dynamo_stream
+# which depends on receipt_dynamo. All three must be COPYed into the build
+# context and installed in order (pip won't find them on PyPI). Matches the
+# pattern used by every other chroma-consuming Dockerfile in this repo
+# (combine_receipts, fix_place, chromadb_compaction).
 COPY receipt_dynamo/ /tmp/receipt_dynamo/
-RUN pip install --no-cache-dir /tmp/receipt_dynamo && rm -rf /tmp/receipt_dynamo
-
+COPY receipt_dynamo_stream/ /tmp/receipt_dynamo_stream/
 COPY receipt_chroma/ /tmp/receipt_chroma/
-RUN pip install --no-cache-dir /tmp/receipt_chroma && rm -rf /tmp/receipt_chroma
+RUN pip install --no-cache-dir /tmp/receipt_dynamo && \
+    pip install --no-cache-dir /tmp/receipt_dynamo_stream && \
+    pip install --no-cache-dir /tmp/receipt_chroma && \
+    rm -rf /tmp/receipt_dynamo /tmp/receipt_dynamo_stream /tmp/receipt_chroma
 
 COPY infra/label_refresh_lambda/lambdas/label_refresh.py ${LAMBDA_TASK_ROOT}/handler.py
 


### PR DESCRIPTION
## Summary

The label_refresh Lambda's Dockerfile installs `receipt_chroma` but never COPYs or installs `receipt_dynamo_stream` (a transitive dep). CodeBuild fails BUILD with:

```
ERROR: Could not find a version that satisfies the requirement receipt-dynamo-stream
  (from receipt-chroma)
ERROR: No matching distribution found for receipt-dynamo-stream
```

This breaks every prod Deploy because Pulumi's local-exec `sync_pipeline` triggers the CodePipeline build, exit code 1 propagates up, and Pulumi marks the resource as errored. The Deploy job fails, and downstream S3 sync + CloudFront invalidation are skipped — so frontend changes from recent merges (#909 sparkline, #911 logo fix) never reach prod.

## Fix

Add `receipt_dynamo_stream` to the COPY + install chain, matching the pattern of every other chroma-consuming Dockerfile in the repo:

| Dockerfile | Has all 3 (`receipt_dynamo` + `_stream` + `_chroma`) |
|------------|-------------------------------------------------------|
| `combine_receipts_step_functions/lambdas/Dockerfile` | ✅ |
| `fix_place_lambda/lambdas/Dockerfile` | ✅ |
| `chromadb_compaction/lambdas/Dockerfile` | ✅ |
| `label_evaluator_step_functions/lambdas/Dockerfile.*` | ✅ |
| `label_refresh_lambda/lambdas/Dockerfile` | ❌ (this PR fixes) |

Also collapses the install commands into one `RUN` for consistency (single Docker layer, same as the other Dockerfiles).

## How this got missed

Two CI-side gaps let this Dockerfile reach `main`:

1. **No CI step builds Lambda Docker images.** `lambda-syntax` runs `py_compile` on every `.py` under `infra/`, but nothing actually invokes `docker build` against the modified Dockerfiles. Bugs only surface during prod Deploy when CodeBuild runs the image, which is too late.
2. **No dependency-graph validation.** A Dockerfile listing `receipt_chroma` without `receipt_dynamo_stream` is statically detectable — `receipt_chroma/pyproject.toml` declares `receipt_dynamo_stream` as a runtime dep. A pre-deploy script could parse Dockerfile COPYs vs. pyproject deps and reject mismatches.

(Filed a follow-up note in the PR — happy to add either of these as a separate IaC-hardening PR.)

## Test plan

- [x] Verified all other chroma-consuming Dockerfiles include `receipt_dynamo_stream`
- [x] Verified `receipt_chroma/pyproject.toml` declares `receipt_dynamo_stream` as a runtime dep (not optional)
- [ ] CI green
- [ ] Post-merge: confirm prod Deploy completes successfully (no "2 errored" from Pulumi)
- [ ] Post-deploy: tylernorlund.com/receipt shows v14 sparkline + logos persist across scroll-back

🤖 Generated with [Claude Code](https://claude.com/claude-code)