### PR TITLE
feat(layoutlm): add LayoutLMv3 training support alongside v1

### DIFF
--- a/infra/__main__.py
+++ b/infra/__main__.py
@@ -483,7 +483,7 @@ if enable_sagemaker:
     sagemaker_training = SageMakerTrainingInfra(
         "layoutlm-sagemaker",
         dynamodb_table_name=dynamodb_table.name,
-        raw_bucket_arn=raw_bucket.arn,
+        raw_bucket_arn=upload_images.image_bucket.arn,
     )
     layoutlm_training_bucket_name = sagemaker_training.output_bucket.bucket
     pulumi.export(

--- a/infra/__main__.py
+++ b/infra/__main__.py
@@ -483,6 +483,7 @@ if enable_sagemaker:
     sagemaker_training = SageMakerTrainingInfra(
         "layoutlm-sagemaker",
         dynamodb_table_name=dynamodb_table.name,
+        raw_bucket_arn=raw_bucket.arn,
     )
     layoutlm_training_bucket_name = sagemaker_training.output_bucket.bucket
     pulumi.export(

--- a/infra/sagemaker_training/Dockerfile
+++ b/infra/sagemaker_training/Dockerfile
@@ -52,11 +52,12 @@ from transformers import LayoutLMTokenizerFast, LayoutLMForTokenClassification; 
 LayoutLMTokenizerFast.from_pretrained('microsoft/layoutlm-base-uncased'); \
 LayoutLMForTokenClassification.from_pretrained('microsoft/layoutlm-base-uncased')"
 
-# Pre-download v3 model weights
+# Pre-download v3 model weights + image processor
 RUN python -c "\
-from transformers import LayoutLMv3TokenizerFast, LayoutLMv3ForTokenClassification; \
+from transformers import LayoutLMv3TokenizerFast, LayoutLMv3ForTokenClassification, LayoutLMv3ImageProcessor; \
 LayoutLMv3TokenizerFast.from_pretrained('microsoft/layoutlmv3-base'); \
-LayoutLMv3ForTokenClassification.from_pretrained('microsoft/layoutlmv3-base')"
+LayoutLMv3ForTokenClassification.from_pretrained('microsoft/layoutlmv3-base'); \
+LayoutLMv3ImageProcessor.from_pretrained('microsoft/layoutlmv3-base')"
 
 # Copy training entrypoint
 COPY infra/sagemaker_training/train.py /opt/ml/code/train.py

--- a/infra/sagemaker_training/Dockerfile
+++ b/infra/sagemaker_training/Dockerfile
@@ -52,6 +52,12 @@ from transformers import LayoutLMTokenizerFast, LayoutLMForTokenClassification; 
 LayoutLMTokenizerFast.from_pretrained('microsoft/layoutlm-base-uncased'); \
 LayoutLMForTokenClassification.from_pretrained('microsoft/layoutlm-base-uncased')"
 
+# Pre-download v3 model weights
+RUN python -c "\
+from transformers import LayoutLMv3TokenizerFast, LayoutLMv3ForTokenClassification; \
+LayoutLMv3TokenizerFast.from_pretrained('microsoft/layoutlmv3-base'); \
+LayoutLMv3ForTokenClassification.from_pretrained('microsoft/layoutlmv3-base')"
+
 # Copy training entrypoint
 COPY infra/sagemaker_training/train.py /opt/ml/code/train.py
 

--- a/infra/sagemaker_training/component.py
+++ b/infra/sagemaker_training/component.py
@@ -511,6 +511,7 @@ class SageMakerTrainingInfra(ComponentResource):
                                     "sagemaker:DescribeTrainingJob",
                                     "sagemaker:StopTrainingJob",
                                     "sagemaker:ListTrainingJobs",
+                                    "sagemaker:AddTags",
                                 ],
                                 "Resource": f"arn:aws:sagemaker:{region}:{account_id}:training-job/*",
                             },

--- a/infra/sagemaker_training/component.py
+++ b/infra/sagemaker_training/component.py
@@ -45,6 +45,7 @@ class SageMakerTrainingInfra(ComponentResource):
         self,
         name: str,
         dynamodb_table_name: Output[str],
+        raw_bucket_arn: Output[str] | None = None,
         opts: ResourceOptions | None = None,
     ):
         super().__init__("custom:ml:SageMakerTrainingInfra", name, None, opts)
@@ -167,14 +168,16 @@ class SageMakerTrainingInfra(ComponentResource):
         )
 
         # SageMaker execution policy
+        policy_inputs = [
+            self.output_bucket.arn,
+            self.ecr_repo.arn,
+            dynamodb_table_name,
+            raw_bucket_arn or "",
+        ]
         sagemaker_policy = aws.iam.RolePolicy(
             f"{name}-sagemaker-policy",
             role=self.sagemaker_role.id,
-            policy=Output.all(
-                self.output_bucket.arn,
-                self.ecr_repo.arn,
-                dynamodb_table_name,
-            ).apply(
+            policy=Output.all(*policy_inputs).apply(
                 lambda args: json.dumps(
                     {
                         "Version": "2012-10-17",
@@ -247,7 +250,19 @@ class SageMakerTrainingInfra(ComponentResource):
                                     }
                                 },
                             },
-                        ],
+                        ]
+                        + (
+                            [
+                                # S3 read access for raw receipt images (LayoutLMv3 image-based training)
+                                {
+                                    "Effect": "Allow",
+                                    "Action": "s3:GetObject",
+                                    "Resource": f"{args[3]}/*",
+                                },
+                            ]
+                            if args[3]
+                            else []
+                        ),
                     }
                 )
             ),

--- a/infra/sagemaker_training/component.py
+++ b/infra/sagemaker_training/component.py
@@ -659,6 +659,12 @@ def handler(event, context):
             "S3Uri": f"s3://{os.environ['OUTPUT_BUCKET']}/checkpoints/{job_name}",
         }
 
+    # Skip CoreML auto-export for v3 runs (Swift inference not yet supported)
+    if hyperparameters.get("model_version") == "v3":
+        training_job_config["Tags"] = [
+            {"Key": "skip-coreml-export", "Value": "true"},
+        ]
+
     # Create the training job
     response = sagemaker.create_training_job(**training_job_config)
 

--- a/infra/sagemaker_training/component.py
+++ b/infra/sagemaker_training/component.py
@@ -253,11 +253,14 @@ class SageMakerTrainingInfra(ComponentResource):
                         ]
                         + (
                             [
-                                # S3 read access for raw receipt images (LayoutLMv3 image-based training)
+                                # S3 read access for receipt images across all buckets (LayoutLMv3 training)
                                 {
                                     "Effect": "Allow",
                                     "Action": "s3:GetObject",
-                                    "Resource": f"{args[3]}/*",
+                                    "Resource": [
+                                        f"{args[3]}/*",
+                                        "arn:aws:s3:::raw-image-bucket-*/*",
+                                    ],
                                 },
                             ]
                             if args[3]

--- a/infra/sagemaker_training/train.py
+++ b/infra/sagemaker_training/train.py
@@ -92,6 +92,7 @@ def build_train_command(hps: dict) -> list[str]:
         "pretrained": "--pretrained",
         "o_entity_ratio": "--o-entity-ratio",
         "resume_from_s3": "--resume-from-s3",
+        "model_version": "--model-version",
     }
 
     for hp_name, cli_flag in param_mapping.items():

--- a/receipt_layoutlm/receipt_layoutlm/cli.py
+++ b/receipt_layoutlm/receipt_layoutlm/cli.py
@@ -384,6 +384,14 @@ def main() -> None:
             and pretrained == "microsoft/layoutlm-base-uncased"
         ):
             pretrained = MODEL_DEFAULTS[ModelVersion.V3]
+        if args.model_version == "v1" and "layoutlmv3" in pretrained:
+            raise SystemExit(
+                f"--model-version v1 is incompatible with v3 model '{pretrained}'. Use --model-version v3."
+            )
+        if args.model_version == "v3" and pretrained == "microsoft/layoutlm-base-uncased":
+            raise SystemExit(
+                f"--model-version v3 requires a v3 model, not '{pretrained}'."
+            )
         train_cfg = TrainingConfig(
             epochs=args.epochs,
             batch_size=args.batch_size,

--- a/receipt_layoutlm/receipt_layoutlm/cli.py
+++ b/receipt_layoutlm/receipt_layoutlm/cli.py
@@ -3,7 +3,7 @@ import json
 import os
 from typing import Dict, List, Optional
 
-from .config import MERGE_PRESETS, DataConfig, TrainingConfig
+from .config import MODEL_DEFAULTS, MERGE_PRESETS, DataConfig, ModelVersion, TrainingConfig
 from .export_coreml import export_coreml, export_from_s3
 from .inference import LayoutLMInference
 from .trainer import ReceiptLayoutLMTrainer
@@ -79,6 +79,12 @@ def main() -> None:
     train_p.add_argument("--lr", type=float, default=5e-5)
     train_p.add_argument(
         "--pretrained", default="microsoft/layoutlm-base-uncased"
+    )
+    train_p.add_argument(
+        "--model-version",
+        choices=["v1", "v3"],
+        default="v1",
+        help="LayoutLM model version: v1 (text+bbox) or v3 (text+bbox+image)",
     )
     train_p.add_argument(
         "--warmup-ratio",
@@ -282,6 +288,12 @@ def main() -> None:
         default=None,
         help="Quantization mode for smaller model size",
     )
+    export_p.add_argument(
+        "--model-version",
+        choices=["v1", "v3"],
+        default="v1",
+        help="LayoutLM model version: v1 (text+bbox) or v3 (text+bbox+image)",
+    )
 
     # Validate CoreML subcommand
     validate_p = sub.add_parser(
@@ -366,11 +378,18 @@ def main() -> None:
             dynamo_table_name=args.dynamo_table,
             aws_region=args.region,
         )
+        pretrained = args.pretrained
+        if (
+            args.model_version == "v3"
+            and pretrained == "microsoft/layoutlm-base-uncased"
+        ):
+            pretrained = MODEL_DEFAULTS[ModelVersion.V3]
         train_cfg = TrainingConfig(
             epochs=args.epochs,
             batch_size=args.batch_size,
             learning_rate=args.lr,
-            pretrained_model_name=args.pretrained,
+            pretrained_model_name=pretrained,
+            model_version=args.model_version,
         )
         if args.warmup_ratio is not None:
             train_cfg.warmup_ratio = args.warmup_ratio
@@ -457,6 +476,7 @@ def main() -> None:
                 model_name=args.model_name,
                 local_cache=args.local_cache,
                 quantize=args.quantize,
+                model_version=args.model_version,
             )
         else:
             bundle_path = export_coreml(
@@ -464,6 +484,7 @@ def main() -> None:
                 output_dir=args.output_dir,
                 model_name=args.model_name,
                 quantize=args.quantize,
+                model_version=args.model_version,
             )
         print(f"CoreML bundle created: {bundle_path}")
 

--- a/receipt_layoutlm/receipt_layoutlm/config.py
+++ b/receipt_layoutlm/receipt_layoutlm/config.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from enum import Enum
 from typing import Dict, List, Optional
 
 # Predefined merge presets for common label grouping scenarios
@@ -53,6 +54,17 @@ class DataConfig:
         return result
 
 
+class ModelVersion(str, Enum):
+    V1 = "v1"
+    V3 = "v3"
+
+
+MODEL_DEFAULTS = {
+    ModelVersion.V1: "microsoft/layoutlm-base-uncased",
+    ModelVersion.V3: "microsoft/layoutlmv3-base",
+}
+
+
 @dataclass
 class TrainingConfig:
     pretrained_model_name: str = "microsoft/layoutlm-base-uncased"
@@ -70,3 +82,4 @@ class TrainingConfig:
     # CoreML export configuration
     auto_export_coreml: bool = False
     coreml_quantize: Optional[str] = "float16"
+    model_version: str = ModelVersion.V1.value

--- a/receipt_layoutlm/receipt_layoutlm/data_loader.py
+++ b/receipt_layoutlm/receipt_layoutlm/data_loader.py
@@ -338,17 +338,30 @@ def download_receipt_images(
     cache_dir: str = "/tmp/receipt_images",
 ) -> str:
     """Download receipt images from S3 for v3 training. Returns cache_dir."""
+    import logging
+
     import boto3
 
+    logger = logging.getLogger(__name__)
     os.makedirs(cache_dir, exist_ok=True)
     s3 = boto3.client("s3")
+    downloaded = 0
+    skipped = 0
     for img_id in image_ids:
         local_path = os.path.join(cache_dir, f"{img_id}.png")
         if os.path.exists(local_path):
+            skipped += 1
             continue
-        image = dynamo.get_image(img_id)
-        if image and image.raw_s3_bucket and image.raw_s3_key:
-            s3.download_file(image.raw_s3_bucket, image.raw_s3_key, local_path)
+        try:
+            image = dynamo.get_image(img_id)
+            if image and image.raw_s3_bucket and image.raw_s3_key:
+                s3.download_file(image.raw_s3_bucket, image.raw_s3_key, local_path)
+                downloaded += 1
+            else:
+                logger.warning("Image %s has no S3 location, will use placeholder", img_id)
+        except Exception as e:
+            logger.warning("Failed to download image %s: %s", img_id, e)
+    logger.info("Images: %d downloaded, %d cached, %d total", downloaded, skipped, len(image_ids))
     return cache_dir
 
 

--- a/receipt_layoutlm/receipt_layoutlm/data_loader.py
+++ b/receipt_layoutlm/receipt_layoutlm/data_loader.py
@@ -32,6 +32,8 @@ class SplitMetadata:
     entity_lines_total: int
     # Target ratio used
     target_o_entity_ratio: float
+    # v3 image cache directory (set when model_version == "v3")
+    image_cache_dir: Optional[str] = None
 
 
 @dataclass
@@ -330,12 +332,33 @@ class MergeInfo:
     resulting_labels: List[str]
 
 
+def download_receipt_images(
+    dynamo: DynamoClient,
+    image_ids: set[str],
+    cache_dir: str = "/tmp/receipt_images",
+) -> str:
+    """Download receipt images from S3 for v3 training. Returns cache_dir."""
+    import boto3
+
+    os.makedirs(cache_dir, exist_ok=True)
+    s3 = boto3.client("s3")
+    for img_id in image_ids:
+        local_path = os.path.join(cache_dir, f"{img_id}.png")
+        if os.path.exists(local_path):
+            continue
+        image = dynamo.get_image(img_id)
+        if image and image.raw_s3_bucket and image.raw_s3_key:
+            s3.download_file(image.raw_s3_bucket, image.raw_s3_key, local_path)
+    return cache_dir
+
+
 def load_datasets(
     dynamo: DynamoClient,
     label_status: str = ValidationStatus.VALID.value,
     random_seed: Optional[int] = None,
     label_merges: Optional[Dict[str, List[str]]] = None,
     allowed_labels: Optional[List[str]] = None,
+    model_version: str = "v1",
 ) -> Tuple[Any, SplitMetadata, MergeInfo]:
     """Load and process datasets from DynamoDB.
 
@@ -488,6 +511,7 @@ def load_datasets(
             "bboxes": Sequence(Sequence(Value("int64"))),
             "ner_tags": Sequence(Value("string")),
             "receipt_key": Value("string"),
+            "image_id": Value("string"),
         }
     )
 
@@ -497,6 +521,7 @@ def load_datasets(
             "bboxes": [ex.bboxes for ex in examples],
             "ner_tags": [ex.ner_tags for ex in examples],
             "receipt_key": [ex.receipt_key for ex in examples],
+            "image_id": [ex.image_id for ex in examples],
         },
         features=features,
     )
@@ -609,6 +634,12 @@ def load_datasets(
         else float("inf")
     )
 
+    # Download images for v3 training
+    image_cache_dir: Optional[str] = None
+    if model_version == "v3":
+        unique_image_ids = {ex.image_id for ex in examples}
+        image_cache_dir = download_receipt_images(dynamo, unique_image_ids)
+
     # Create split metadata
     split_metadata = SplitMetadata(
         random_seed=random_seed,
@@ -626,6 +657,7 @@ def load_datasets(
         o_only_lines_dropped=o_only_lines_count - o_only_lines_kept,
         entity_lines_total=entity_lines_count,
         target_o_entity_ratio=target_ratio,
+        image_cache_dir=image_cache_dir,
     )
 
     train_ds = dataset.select(filtered_train_indices).remove_columns(["receipt_key"])  # type: ignore[attr-defined]

--- a/receipt_layoutlm/receipt_layoutlm/data_loader.py
+++ b/receipt_layoutlm/receipt_layoutlm/data_loader.py
@@ -334,10 +334,15 @@ class MergeInfo:
 
 def download_receipt_images(
     dynamo: DynamoClient,
-    image_ids: set[str],
+    receipt_keys: set[tuple[str, int]],
     cache_dir: str = "/tmp/receipt_images",
 ) -> str:
-    """Download receipt images from S3 for v3 training. Returns cache_dir."""
+    """Download warped receipt images from S3 for v3 training.
+
+    Uses Receipt.raw_s3_key (the perspective-corrected crop) rather than
+    Image.raw_s3_key (the original photo), since bounding boxes in the
+    training data are in the warped receipt's coordinate space.
+    """
     import logging
 
     import boto3
@@ -347,21 +352,21 @@ def download_receipt_images(
     s3 = boto3.client("s3")
     downloaded = 0
     skipped = 0
-    for img_id in image_ids:
-        local_path = os.path.join(cache_dir, f"{img_id}.png")
+    for image_id, receipt_id in receipt_keys:
+        local_path = os.path.join(cache_dir, f"{image_id}_{receipt_id}.png")
         if os.path.exists(local_path):
             skipped += 1
             continue
         try:
-            image = dynamo.get_image(img_id)
-            if image and image.raw_s3_bucket and image.raw_s3_key:
-                s3.download_file(image.raw_s3_bucket, image.raw_s3_key, local_path)
+            receipt = dynamo.get_receipt(image_id, receipt_id)
+            if receipt and receipt.raw_s3_bucket and receipt.raw_s3_key:
+                s3.download_file(receipt.raw_s3_bucket, receipt.raw_s3_key, local_path)
                 downloaded += 1
             else:
-                logger.warning("Image %s has no S3 location, will use placeholder", img_id)
+                logger.warning("Receipt %s/%d has no S3 location, will use placeholder", image_id, receipt_id)
         except Exception as e:
-            logger.warning("Failed to download image %s: %s", img_id, e)
-    logger.info("Images: %d downloaded, %d cached, %d total", downloaded, skipped, len(image_ids))
+            logger.warning("Failed to download receipt image %s/%d: %s", image_id, receipt_id, e)
+    logger.info("Receipt images: %d downloaded, %d cached, %d total", downloaded, skipped, len(receipt_keys))
     return cache_dir
 
 
@@ -647,11 +652,11 @@ def load_datasets(
         else float("inf")
     )
 
-    # Download images for v3 training
+    # Download warped receipt images for v3 training
     image_cache_dir: Optional[str] = None
     if model_version == "v3":
-        unique_image_ids = {ex.image_id for ex in examples}
-        image_cache_dir = download_receipt_images(dynamo, unique_image_ids)
+        unique_receipt_keys = {(ex.image_id, ex.receipt_id) for ex in examples}
+        image_cache_dir = download_receipt_images(dynamo, unique_receipt_keys)
 
     # Create split metadata
     split_metadata = SplitMetadata(
@@ -673,8 +678,10 @@ def load_datasets(
         image_cache_dir=image_cache_dir,
     )
 
-    train_ds = dataset.select(filtered_train_indices).remove_columns(["receipt_key"])  # type: ignore[attr-defined]
-    val_ds = dataset.select(val_indices).remove_columns(["receipt_key"])  # type: ignore[attr-defined]
+    # v3 needs receipt_key during preprocessing (image cache lookup); removed later in trainer.map()
+    remove_after_split = ["receipt_key"] if model_version != "v3" else []
+    train_ds = dataset.select(filtered_train_indices).remove_columns(remove_after_split)  # type: ignore[attr-defined]
+    val_ds = dataset.select(val_indices).remove_columns(remove_after_split)  # type: ignore[attr-defined]
 
     # Build merge info for tracking
     merge_info = MergeInfo(

--- a/receipt_layoutlm/receipt_layoutlm/export_coreml.py
+++ b/receipt_layoutlm/receipt_layoutlm/export_coreml.py
@@ -59,6 +59,30 @@ class LayoutLMWrapper(nn.Module):
         return outputs.logits
 
 
+class LayoutLMv3Wrapper(nn.Module):
+    """Wrapper for LayoutLMv3 CoreML export with image input."""
+
+    def __init__(self, model):
+        super().__init__()
+        self.model = model
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        attention_mask: torch.Tensor,
+        bbox: torch.Tensor,
+        token_type_ids: torch.Tensor,
+        pixel_values: torch.Tensor,
+    ) -> torch.Tensor:
+        outputs = self.model(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            bbox=bbox,
+            pixel_values=pixel_values,
+        )
+        return outputs.logits
+
+
 def export_coreml(
     checkpoint_dir: str,
     output_dir: str,
@@ -66,6 +90,7 @@ def export_coreml(
     max_seq_length: int = 512,
     min_seq_length: int = 1,
     quantize: Optional[str] = None,
+    model_version: str = "v1",
 ) -> str:
     """Export a trained LayoutLM checkpoint to CoreML format.
 
@@ -76,6 +101,7 @@ def export_coreml(
         max_seq_length: Maximum sequence length for model.
         min_seq_length: Minimum sequence length for model.
         quantize: Quantization mode: None, "float16", "int8", or "int4".
+        model_version: Model version to export: "v1" or "v3".
 
     Returns:
         Path to the created model bundle directory.
@@ -92,10 +118,17 @@ def export_coreml(
 
     try:
         import coremltools as ct
-        from transformers import (
-            LayoutLMForTokenClassification,
-            LayoutLMTokenizerFast,
-        )
+
+        if model_version == "v3":
+            from transformers import (
+                LayoutLMv3ForTokenClassification,
+                LayoutLMv3TokenizerFast,
+            )
+        else:
+            from transformers import (
+                LayoutLMForTokenClassification,
+                LayoutLMTokenizerFast,
+            )
     except ImportError as e:
         msg = "coremltools and transformers required: pip install coremltools transformers"
         raise MissingDependencyError(msg) from e
@@ -107,8 +140,12 @@ def export_coreml(
     print(f"Loading model from {checkpoint_path}...")
 
     # Load the trained model and tokenizer
-    model = LayoutLMForTokenClassification.from_pretrained(checkpoint_path)
-    tokenizer = LayoutLMTokenizerFast.from_pretrained(checkpoint_path)
+    if model_version == "v3":
+        model = LayoutLMv3ForTokenClassification.from_pretrained(checkpoint_path)
+        tokenizer = LayoutLMv3TokenizerFast.from_pretrained(checkpoint_path)
+    else:
+        model = LayoutLMForTokenClassification.from_pretrained(checkpoint_path)
+        tokenizer = LayoutLMTokenizerFast.from_pretrained(checkpoint_path)
     model.eval()
 
     # Get model config for label mapping
@@ -120,7 +157,10 @@ def export_coreml(
     print(f"Model has {num_labels} labels: {list(id2label.values())}")
 
     # Create wrapper for tracing
-    wrapper = LayoutLMWrapper(model)
+    if model_version == "v3":
+        wrapper = LayoutLMv3Wrapper(model)
+    else:
+        wrapper = LayoutLMWrapper(model)
     wrapper.eval()
 
     # Create sample inputs for tracing
@@ -140,19 +180,22 @@ def export_coreml(
     sample_bbox = torch.stack([x1, y1, x2, y2], dim=-1)
     sample_token_type_ids = torch.zeros(1, sample_seq_len, dtype=torch.long)
 
+    trace_inputs = (
+        sample_input_ids,
+        sample_attention_mask,
+        sample_bbox,
+        sample_token_type_ids,
+    )
+
+    if model_version == "v3":
+        sample_pixel_values = torch.randn(1, 3, 224, 224)
+        trace_inputs = trace_inputs + (sample_pixel_values,)
+
     print("Tracing model with TorchScript...")
 
     # Trace the model
     with torch.no_grad():
-        traced_model = torch.jit.trace(
-            wrapper,
-            (
-                sample_input_ids,
-                sample_attention_mask,
-                sample_bbox,
-                sample_token_type_ids,
-            ),
-        )
+        traced_model = torch.jit.trace(wrapper, trace_inputs)
 
     print("Converting to CoreML...")
 
@@ -171,31 +214,42 @@ def export_coreml(
     if quantize == "float16":
         print("Applying float16 precision at conversion time...")
 
+    coreml_inputs = [
+        ct.TensorType(
+            name="input_ids",
+            shape=(1, seq_dim),
+            dtype=np.int32,
+        ),
+        ct.TensorType(
+            name="attention_mask",
+            shape=(1, seq_dim),
+            dtype=np.int32,
+        ),
+        ct.TensorType(
+            name="bbox",
+            shape=(1, seq_dim, 4),
+            dtype=np.int32,
+        ),
+        ct.TensorType(
+            name="token_type_ids",
+            shape=(1, seq_dim),
+            dtype=np.int32,
+        ),
+    ]
+
+    if model_version == "v3":
+        coreml_inputs.append(
+            ct.TensorType(
+                name="pixel_values",
+                shape=(1, 3, 224, 224),
+                dtype=np.float32,
+            ),
+        )
+
     # Convert to CoreML with explicit int32 dtype to match Swift MLMultiArray
     mlmodel = ct.convert(
         traced_model,
-        inputs=[
-            ct.TensorType(
-                name="input_ids",
-                shape=(1, seq_dim),
-                dtype=np.int32,
-            ),
-            ct.TensorType(
-                name="attention_mask",
-                shape=(1, seq_dim),
-                dtype=np.int32,
-            ),
-            ct.TensorType(
-                name="bbox",
-                shape=(1, seq_dim, 4),
-                dtype=np.int32,
-            ),
-            ct.TensorType(
-                name="token_type_ids",
-                shape=(1, seq_dim),
-                dtype=np.int32,
-            ),
-        ],
+        inputs=coreml_inputs,
         outputs=[
             ct.TensorType(name="logits"),
         ],
@@ -351,6 +405,7 @@ def export_from_s3(
     quantize: Optional[str] = None,
     max_seq_length: int = 512,
     min_seq_length: int = 1,
+    model_version: str = "v1",
 ) -> str:
     """Export a model from S3 to CoreML format.
 
@@ -362,6 +417,7 @@ def export_from_s3(
         quantize: Quantization mode: None, "float16", "int8", or "int4".
         max_seq_length: Maximum sequence length for model.
         min_seq_length: Minimum sequence length for model.
+        model_version: Model version to export: "v1" or "v3".
 
     Returns:
         Path to the created model bundle directory.
@@ -417,6 +473,7 @@ def export_from_s3(
             quantize=quantize,
             max_seq_length=max_seq_length,
             min_seq_length=min_seq_length,
+            model_version=model_version,
         )
     finally:
         # Clean up temp directory if we created one

--- a/receipt_layoutlm/receipt_layoutlm/export_coreml.py
+++ b/receipt_layoutlm/receipt_layoutlm/export_coreml.py
@@ -313,17 +313,21 @@ def export_coreml(
         print(f"Weight validation passed: {len(fp16_arr):,} values, 0 NaN/Inf")
 
     # Copy vocab.txt for tokenizer
+    # NOTE: v3 uses RoBERTa BPE tokenizer, not BERT WordPiece. The Swift
+    # BertTokenizer.swift is not compatible with v3 vocab. A v3-specific
+    # Swift tokenizer is needed before v3 CoreML inference works end-to-end.
     vocab_src = checkpoint_path / "vocab.txt"
     vocab_dst = output_path / "vocab.txt"
-    if vocab_src.exists():
+    if model_version == "v3":
+        print("WARNING: v3 uses RoBERTa BPE tokenizer — vocab.txt is not compatible with Swift BertTokenizer")
+        print("         v3 Swift inference requires a BPE tokenizer implementation (follow-up PR)")
+        # Still write it for reference, but save the full tokenizer too
+        tokenizer.save_pretrained(str(output_path))
+        print(f"Saved v3 tokenizer files to {output_path}")
+    elif vocab_src.exists():
         shutil.copy(vocab_src, vocab_dst)
         print(f"Copied vocab.txt to {vocab_dst}")
     else:
-        # transformers 5.x removed BertTokenizer.vocab_file, so
-        # tokenizer.save_vocabulary() crashes (AttributeError). The Swift
-        # inference side (BertTokenizer.swift) only needs the BERT-format
-        # vocab.txt — sort tokens by id and write directly. Works with
-        # both slow (BertTokenizer) and fast (BertTokenizerFast) loaders.
         vocab = tokenizer.get_vocab()
         sorted_tokens = sorted(vocab.items(), key=lambda kv: kv[1])
         with open(vocab_dst, "w", encoding="utf-8") as f:
@@ -527,6 +531,12 @@ if __name__ == "__main__":
         default=1,
         help="Minimum sequence length for model (default: 1)",
     )
+    parser.add_argument(
+        "--model-version",
+        choices=["v1", "v3"],
+        default="v1",
+        help="LayoutLM model version: v1 or v3",
+    )
 
     args = parser.parse_args()
 
@@ -547,6 +557,7 @@ if __name__ == "__main__":
             quantize=args.quantize,
             max_seq_length=args.max_seq_length,
             min_seq_length=args.min_seq_length,
+            model_version=args.model_version,
         )
     else:
         export_coreml(
@@ -556,4 +567,5 @@ if __name__ == "__main__":
             quantize=args.quantize,
             max_seq_length=args.max_seq_length,
             min_seq_length=args.min_seq_length,
+            model_version=args.model_version,
         )

--- a/receipt_layoutlm/receipt_layoutlm/trainer.py
+++ b/receipt_layoutlm/receipt_layoutlm/trainer.py
@@ -110,9 +110,19 @@ class ReceiptLayoutLMTrainer:
             except AttributeError:
                 pass
 
-        self.tokenizer = transformers.LayoutLMTokenizerFast.from_pretrained(
-            self.training_config.pretrained_model_name
-        )
+        if self.training_config.model_version == "v3":
+            self.tokenizer = transformers.LayoutLMv3TokenizerFast.from_pretrained(
+                self.training_config.pretrained_model_name
+            )
+            self._image_processor = transformers.LayoutLMv3ImageProcessor.from_pretrained(
+                self.training_config.pretrained_model_name
+            )
+            self._image_processor.apply_ocr = False
+        else:
+            self.tokenizer = transformers.LayoutLMTokenizerFast.from_pretrained(
+                self.training_config.pretrained_model_name
+            )
+            self._image_processor = None
 
     def _label_list(self, dataset) -> List[str]:
         tags = set()
@@ -159,12 +169,14 @@ class ReceiptLayoutLMTrainer:
                     self.dynamo,
                     label_merges=effective_label_merges,
                     allowed_labels=self.data_config.allowed_labels,
+                    model_version=self.training_config.model_version,
                 )
         else:
             datasets, split_metadata, merge_info = load_datasets(
                 self.dynamo,
                 label_merges=effective_label_merges,
                 allowed_labels=self.data_config.allowed_labels,
+                model_version=self.training_config.model_version,
             )
 
         # Compute dataset counts prior to tokenization for run logging
@@ -225,13 +237,16 @@ class ReceiptLayoutLMTrainer:
             i: label for i, label in enumerate(label_list)
         }
 
-        model = (
-            self._transformers.LayoutLMForTokenClassification.from_pretrained(
-                self.training_config.pretrained_model_name,
-                num_labels=len(label_list),
-                id2label=id2label,
-                label2id=label2id,
-            )
+        if self.training_config.model_version == "v3":
+            model_cls = self._transformers.LayoutLMv3ForTokenClassification
+        else:
+            model_cls = self._transformers.LayoutLMForTokenClassification
+
+        model = model_cls.from_pretrained(
+            self.training_config.pretrained_model_name,
+            num_labels=len(label_list),
+            id2label=id2label,
+            label2id=label2id,
         )
 
         # Initialize category-aware label embeddings if enabled
@@ -274,19 +289,86 @@ class ReceiptLayoutLMTrainer:
             encoding["bbox"] = bboxes
             return encoding
 
-        preprocess = partial(
-            _preprocess,
-            tokenizer=self.tokenizer,
-            label2id=label2id,
-            max_len=self.data_config.max_seq_length,
-        )
+        def _preprocess_v3(
+            example, tokenizer, label2id, max_len: int, image_processor, image_cache_dir
+        ):
+            from PIL import Image as PILImage
+
+            encoding = tokenizer(
+                example["tokens"],
+                is_split_into_words=True,
+                truncation=True,
+                padding="max_length",
+                max_length=max_len,
+                return_attention_mask=True,
+            )
+            word_ids = encoding.word_ids()
+            seq_len = len(encoding["input_ids"])
+            labels = []
+            bboxes = []
+            prev_word_id = None
+            for i in range(seq_len):
+                wid = word_ids[i]
+                if wid is None:
+                    labels.append(-100)
+                    bboxes.append([0, 0, 0, 0])
+                else:
+                    if wid != prev_word_id:
+                        lbl = example["ner_tags"][wid]
+                        labels.append(label2id.get(lbl, 0))
+                    else:
+                        labels.append(-100)
+                    bboxes.append(example["bboxes"][wid])
+                    prev_word_id = wid
+            encoding["labels"] = labels
+            encoding["bbox"] = bboxes
+
+            img_path = os.path.join(image_cache_dir, f"{example['image_id']}.png")
+            if os.path.exists(img_path):
+                image = PILImage.open(img_path).convert("RGB")
+            else:
+                image = PILImage.new("RGB", (224, 224), (128, 128, 128))
+            pixel_values = image_processor(images=image, return_tensors="pt")[
+                "pixel_values"
+            ].squeeze(0)
+            encoding["pixel_values"] = pixel_values
+
+            if "token_type_ids" in encoding:
+                del encoding["token_type_ids"]
+
+            return encoding
+
+        if self.training_config.model_version == "v3":
+            image_cache_dir = (
+                split_metadata.image_cache_dir
+                if split_metadata and split_metadata.image_cache_dir
+                else "/tmp/receipt_images"
+            )
+            preprocess = partial(
+                _preprocess_v3,
+                tokenizer=self.tokenizer,
+                label2id=label2id,
+                max_len=self.data_config.max_seq_length,
+                image_processor=self._image_processor,
+                image_cache_dir=image_cache_dir,
+            )
+        else:
+            preprocess = partial(
+                _preprocess,
+                tokenizer=self.tokenizer,
+                label2id=label2id,
+                max_len=self.data_config.max_seq_length,
+            )
+
+        # Columns to remove during preprocessing
+        remove_cols = ["tokens", "bboxes", "ner_tags", "image_id"]
 
         # Parallelize preprocessing across CPU cores
         # Disable cache to minimize local disk usage on SageMaker instances
         num_proc = max(1, min(os.cpu_count() or 1, 8))
         datasets = datasets.map(  # type: ignore[attr-defined]
             preprocess,
-            remove_columns=["tokens", "bboxes", "ner_tags"],
+            remove_columns=remove_cols,
             num_proc=num_proc,
             desc="Tokenize+align",
             load_from_cache_file=False,  # Don't cache to disk
@@ -413,7 +495,7 @@ class ReceiptLayoutLMTrainer:
 
         # Build job_config with explicit merge info for experiment tracking
         job_config_dict = {
-            "model": "layoutlm",
+            "model": f"layoutlm-{self.training_config.model_version}",
             **asdict(self.training_config),
             **asdict(self.data_config),
             # Explicit merge info for reproducibility and comparison
@@ -1431,18 +1513,23 @@ class ReceiptLayoutLMTrainer:
                 label_to_category[label] = category
 
         # Get label embeddings from the classifier layer
-        # The classifier is typically a linear layer: classifier.weight is [num_labels, hidden_size]
-        if not hasattr(model, "classifier") or not hasattr(
-            model.classifier, "weight"
-        ):
+        # v1: classifier.weight is [num_labels, hidden_size]
+        # v3: classifier.out_proj.weight is [num_labels, hidden_size]
+        if not hasattr(model, "classifier"):
             print(
-                "⚠️  Model doesn't have classifier.weight, skipping category-aware initialization"
+                "⚠️  Model doesn't have classifier, skipping category-aware initialization"
             )
             return
 
-        label_embeddings = (
-            model.classifier.weight.data
-        )  # Shape: [num_labels, hidden_size]
+        if hasattr(model.classifier, "out_proj"):
+            label_embeddings = model.classifier.out_proj.weight.data
+        elif hasattr(model.classifier, "weight"):
+            label_embeddings = model.classifier.weight.data
+        else:
+            print(
+                "⚠️  Model classifier has no weight or out_proj, skipping category-aware initialization"
+            )
+            return
 
         # Only process labels that exist in our label2id mapping
         available_labels = set(label2id.keys())

--- a/receipt_layoutlm/receipt_layoutlm/trainer.py
+++ b/receipt_layoutlm/receipt_layoutlm/trainer.py
@@ -323,7 +323,10 @@ class ReceiptLayoutLMTrainer:
                     prev_word_id = wid
             encoding["labels"] = labels
 
-            img_path = os.path.join(image_cache_dir, f"{example['image_id']}.png")
+            # receipt_key format: "image_id#00001" — parse for warped receipt cache lookup
+            parts = example["receipt_key"].split("#")
+            receipt_id = int(parts[1]) if len(parts) == 2 else 1
+            img_path = os.path.join(image_cache_dir, f"{parts[0]}_{receipt_id}.png")
             if os.path.exists(img_path):
                 image = PILImage.open(img_path).convert("RGB")
             else:
@@ -361,7 +364,8 @@ class ReceiptLayoutLMTrainer:
             )
 
         # Columns to remove during preprocessing
-        remove_cols = ["tokens", "bboxes", "ner_tags", "image_id"]
+        # v3 needs receipt_key during preprocess (for image lookup), removed here
+        remove_cols = ["tokens", "bboxes", "ner_tags", "image_id", "receipt_key"]
 
         # Parallelize preprocessing across CPU cores
         # Disable cache to minimize local disk usage on SageMaker instances

--- a/receipt_layoutlm/receipt_layoutlm/trainer.py
+++ b/receipt_layoutlm/receipt_layoutlm/trainer.py
@@ -296,17 +296,32 @@ class ReceiptLayoutLMTrainer:
         ):
             from PIL import Image as PILImage
 
-            # v3 tokenizer requires boxes= parameter alongside tokens
+            # v3 tokenizer takes words + boxes together and aligns bboxes to subtokens
             encoding = tokenizer(
-                example["tokens"],
+                text=example["tokens"],
                 boxes=example["bboxes"],
-                is_split_into_words=True,
                 truncation=True,
                 padding="max_length",
                 max_length=max_len,
                 return_attention_mask=True,
             )
-            _align_labels_and_bboxes(encoding, example, label2id)
+            # Align labels using word_ids (same logic as v1, but bbox already handled by v3 tokenizer)
+            word_ids = encoding.word_ids()
+            seq_len = len(encoding["input_ids"])
+            labels = []
+            prev_word_id = None
+            for i in range(seq_len):
+                wid = word_ids[i]
+                if wid is None:
+                    labels.append(-100)
+                else:
+                    if wid != prev_word_id:
+                        lbl = example["ner_tags"][wid]
+                        labels.append(label2id.get(lbl, 0))
+                    else:
+                        labels.append(-100)
+                    prev_word_id = wid
+            encoding["labels"] = labels
 
             img_path = os.path.join(image_cache_dir, f"{example['image_id']}.png")
             if os.path.exists(img_path):

--- a/receipt_layoutlm/receipt_layoutlm/trainer.py
+++ b/receipt_layoutlm/receipt_layoutlm/trainer.py
@@ -296,8 +296,10 @@ class ReceiptLayoutLMTrainer:
         ):
             from PIL import Image as PILImage
 
+            # v3 tokenizer requires boxes= parameter alongside tokens
             encoding = tokenizer(
                 example["tokens"],
+                boxes=example["bboxes"],
                 is_split_into_words=True,
                 truncation=True,
                 padding="max_length",

--- a/receipt_layoutlm/receipt_layoutlm/trainer.py
+++ b/receipt_layoutlm/receipt_layoutlm/trainer.py
@@ -363,9 +363,10 @@ class ReceiptLayoutLMTrainer:
                 max_len=self.data_config.max_seq_length,
             )
 
-        # Columns to remove during preprocessing
-        # v3 needs receipt_key during preprocess (for image lookup), removed here
-        remove_cols = ["tokens", "bboxes", "ner_tags", "image_id", "receipt_key"]
+        # Columns to remove during preprocessing — filter to those actually present
+        # (v1 datasets already had receipt_key removed in data_loader)
+        candidate_cols = ["tokens", "bboxes", "ner_tags", "image_id", "receipt_key"]
+        remove_cols = [c for c in candidate_cols if c in datasets["train"].column_names]
 
         # Parallelize preprocessing across CPU cores
         # Disable cache to minimize local disk usage on SageMaker instances

--- a/receipt_layoutlm/receipt_layoutlm/trainer.py
+++ b/receipt_layoutlm/receipt_layoutlm/trainer.py
@@ -435,7 +435,8 @@ class ReceiptLayoutLMTrainer:
         if "group_by_length" in ta_params:
             args_kwargs["group_by_length"] = True
         if "gradient_checkpointing" in ta_params:
-            args_kwargs["gradient_checkpointing"] = True
+            if self.training_config.model_version != "v3":
+                args_kwargs["gradient_checkpointing"] = True
         if "optim" in ta_params:
             args_kwargs["optim"] = "adamw_torch"
         # Enable torch.compile only if Triton backend is available

--- a/receipt_layoutlm/receipt_layoutlm/trainer.py
+++ b/receipt_layoutlm/receipt_layoutlm/trainer.py
@@ -256,52 +256,8 @@ class ReceiptLayoutLMTrainer:
             tokenizer=self.tokenizer
         )
 
-        # Prepare features: tokenize and align labels/bboxes
-        def _preprocess(example, tokenizer, label2id, max_len: int):
-            encoding = tokenizer(
-                example["tokens"],
-                is_split_into_words=True,
-                truncation=True,
-                padding="max_length",
-                max_length=max_len,
-                return_attention_mask=True,
-            )
-            word_ids = encoding.word_ids()
-            seq_len = len(encoding["input_ids"])  # includes padding/specials
-            labels = []
-            bboxes = []
-            prev_word_id = None
-            for i in range(seq_len):
-                wid = word_ids[i]
-                if wid is None:
-                    labels.append(-100)
-                    bboxes.append([0, 0, 0, 0])
-                else:
-                    # Supervise only the first subtoken of each word; others = -100
-                    if wid != prev_word_id:
-                        lbl = example["ner_tags"][wid]
-                        labels.append(label2id.get(lbl, 0))
-                    else:
-                        labels.append(-100)
-                    bboxes.append(example["bboxes"][wid])
-                    prev_word_id = wid
-            encoding["labels"] = labels
-            encoding["bbox"] = bboxes
-            return encoding
-
-        def _preprocess_v3(
-            example, tokenizer, label2id, max_len: int, image_processor, image_cache_dir
-        ):
-            from PIL import Image as PILImage
-
-            encoding = tokenizer(
-                example["tokens"],
-                is_split_into_words=True,
-                truncation=True,
-                padding="max_length",
-                max_length=max_len,
-                return_attention_mask=True,
-            )
+        # Shared label/bbox alignment for both v1 and v3
+        def _align_labels_and_bboxes(encoding, example, label2id):
             word_ids = encoding.word_ids()
             seq_len = len(encoding["input_ids"])
             labels = []
@@ -322,6 +278,33 @@ class ReceiptLayoutLMTrainer:
                     prev_word_id = wid
             encoding["labels"] = labels
             encoding["bbox"] = bboxes
+
+        def _preprocess(example, tokenizer, label2id, max_len: int):
+            encoding = tokenizer(
+                example["tokens"],
+                is_split_into_words=True,
+                truncation=True,
+                padding="max_length",
+                max_length=max_len,
+                return_attention_mask=True,
+            )
+            _align_labels_and_bboxes(encoding, example, label2id)
+            return encoding
+
+        def _preprocess_v3(
+            example, tokenizer, label2id, max_len: int, image_processor, image_cache_dir
+        ):
+            from PIL import Image as PILImage
+
+            encoding = tokenizer(
+                example["tokens"],
+                is_split_into_words=True,
+                truncation=True,
+                padding="max_length",
+                max_length=max_len,
+                return_attention_mask=True,
+            )
+            _align_labels_and_bboxes(encoding, example, label2id)
 
             img_path = os.path.join(image_cache_dir, f"{example['image_id']}.png")
             if os.path.exists(img_path):

--- a/receipt_ocr_swift/Sources/ReceiptOCRCore/LayoutLM/BPETokenizer.swift
+++ b/receipt_ocr_swift/Sources/ReceiptOCRCore/LayoutLM/BPETokenizer.swift
@@ -1,0 +1,133 @@
+import Foundation
+
+#if os(macOS)
+
+/// BPE (Byte-Pair Encoding) tokenizer for LayoutLMv3 / RoBERTa models.
+/// Reads from HuggingFace tokenizer.json format.
+public class BPETokenizer {
+
+    private let vocab: [String: Int]
+    private let inverseVocab: [Int: String]
+    private let mergeRanks: [String: Int]
+    private let unkTokenId: Int
+
+    public let clsTokenId: Int
+    public let sepTokenId: Int
+    public let padTokenId: Int
+    public let vocabSize: Int
+    public let maxLength: Int
+
+    public init(tokenizerJsonURL: URL, maxLength: Int = 512) throws {
+        let data = try Data(contentsOf: tokenizerJsonURL)
+        let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+
+        let model = json["model"] as! [String: Any]
+        let vocabDict = model["vocab"] as! [String: Int]
+        self.vocab = vocabDict
+        self.vocabSize = vocabDict.count
+
+        var inverse: [Int: String] = [:]
+        for (token, id) in vocabDict {
+            inverse[id] = token
+        }
+        self.inverseVocab = inverse
+
+        let mergesList = model["merges"] as! [[String]]
+        var ranks: [String: Int] = [:]
+        for (i, pair) in mergesList.enumerated() {
+            ranks["\(pair[0]) \(pair[1])"] = i
+        }
+        self.mergeRanks = ranks
+
+        self.clsTokenId = vocabDict["<s>"] ?? 0
+        self.sepTokenId = vocabDict["</s>"] ?? 2
+        self.padTokenId = vocabDict["<pad>"] ?? 1
+        self.unkTokenId = vocabDict["<unk>"] ?? 3
+        self.maxLength = maxLength
+    }
+
+    /// Tokenize pre-split words into BertTokenizer.TokenizationResult format.
+    public func tokenize(
+        words: [String],
+        padding: Bool = true,
+        truncation: Bool = true
+    ) -> BertTokenizer.TokenizationResult {
+        var allTokenIds: [Int] = [clsTokenId]
+        var allWordIds: [Int?] = [nil]
+
+        for (wordIdx, word) in words.enumerated() {
+            let tokens = bpeEncode(word: word, isFirst: wordIdx == 0)
+            let ids = tokens.map { vocab[$0] ?? unkTokenId }
+
+            if truncation && allTokenIds.count + ids.count >= maxLength - 1 {
+                let remaining = maxLength - 1 - allTokenIds.count
+                if remaining > 0 {
+                    allTokenIds.append(contentsOf: ids.prefix(remaining))
+                    allWordIds.append(contentsOf: Array(repeating: wordIdx as Int?, count: remaining))
+                }
+                break
+            }
+
+            allTokenIds.append(contentsOf: ids)
+            allWordIds.append(contentsOf: Array(repeating: wordIdx as Int?, count: ids.count))
+        }
+
+        allTokenIds.append(sepTokenId)
+        allWordIds.append(nil)
+
+        let realCount = allTokenIds.count
+        if padding {
+            let padCount = max(0, maxLength - allTokenIds.count)
+            allTokenIds.append(contentsOf: Array(repeating: padTokenId, count: padCount))
+            allWordIds.append(contentsOf: Array(repeating: nil as Int?, count: padCount))
+        }
+
+        let attentionMask = (0..<allTokenIds.count).map { $0 < realCount ? 1 : 0 }
+        let tokenTypeIds = Array(repeating: 0, count: allTokenIds.count)
+
+        return BertTokenizer.TokenizationResult(
+            inputIds: allTokenIds,
+            attentionMask: attentionMask,
+            tokenTypeIds: tokenTypeIds,
+            wordIds: allWordIds,
+            words: words
+        )
+    }
+
+    private func bpeEncode(word: String, isFirst: Bool) -> [String] {
+        let byteTokens = byteLevelEncode(word: word, isFirst: isFirst)
+        if byteTokens.count <= 1 {
+            return byteTokens
+        }
+
+        var symbols = byteTokens
+        while symbols.count > 1 {
+            var bestRank = Int.max
+            var bestIdx = -1
+            for i in 0..<(symbols.count - 1) {
+                let key = "\(symbols[i]) \(symbols[i + 1])"
+                if let rank = mergeRanks[key], rank < bestRank {
+                    bestRank = rank
+                    bestIdx = i
+                }
+            }
+            if bestIdx < 0 { break }
+
+            let merged = symbols[bestIdx] + symbols[bestIdx + 1]
+            symbols[bestIdx] = merged
+            symbols.remove(at: bestIdx + 1)
+        }
+
+        return symbols
+    }
+
+    private func byteLevelEncode(word: String, isFirst: Bool) -> [String] {
+        var text = word
+        if !isFirst {
+            text = "\u{0120}" + text
+        }
+        return text.map { String($0) }
+    }
+}
+
+#endif

--- a/receipt_ocr_swift/Sources/ReceiptOCRCore/LayoutLM/LayoutLMInference.swift
+++ b/receipt_ocr_swift/Sources/ReceiptOCRCore/LayoutLM/LayoutLMInference.swift
@@ -43,6 +43,9 @@ public class LayoutLMInference {
     /// Maximum sequence length
     public let maxSeqLength: Int
 
+    /// Whether this model requires image input (v3)
+    public let requiresImageInput: Bool
+
     // MARK: - Initialization
 
     /// Initialize from a model bundle directory.
@@ -106,9 +109,57 @@ public class LayoutLMInference {
         self.config = try LayoutLMConfig.load(from: configURL)
 
         self.maxSeqLength = config.maxPositionEmbeddings ?? 512
+        self.requiresImageInput = model.modelDescription.inputDescriptionsByName.keys.contains("pixel_values")
     }
 
     // MARK: - Prediction
+
+    /// Create pixel_values MLMultiArray from a receipt image (v3 only).
+    /// Resizes to 224x224 and normalizes with mean/std = 0.5.
+    private func createPixelValues(from imageData: Data) throws -> MLMultiArray? {
+        guard requiresImageInput else { return nil }
+        guard let imageSource = CGImageSourceCreateWithData(imageData as CFData, nil),
+              let cgImage = CGImageSourceCreateImageAtIndex(imageSource, 0, nil) else {
+            return createGrayPixelValues()
+        }
+
+        let size = 224
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        let bytesPerPixel = 4
+        let bytesPerRow = bytesPerPixel * size
+        var pixelData = [UInt8](repeating: 0, count: size * size * bytesPerPixel)
+
+        guard let context = CGContext(
+            data: &pixelData, width: size, height: size,
+            bitsPerComponent: 8, bytesPerRow: bytesPerRow,
+            space: colorSpace, bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ) else {
+            return createGrayPixelValues()
+        }
+        context.interpolationQuality = .high
+        context.draw(cgImage, in: CGRect(x: 0, y: 0, width: size, height: size))
+
+        let array = try MLMultiArray(shape: [1, 3, NSNumber(value: size), NSNumber(value: size)], dataType: .float32)
+        for y in 0..<size {
+            for x in 0..<size {
+                let offset = (y * size + x) * bytesPerPixel
+                let r = Float(pixelData[offset]) / 255.0
+                let g = Float(pixelData[offset + 1]) / 255.0
+                let b = Float(pixelData[offset + 2]) / 255.0
+                // Normalize: (pixel / 255 - 0.5) / 0.5 = pixel / 127.5 - 1.0
+                array[[0, 0, y, x] as [NSNumber]] = NSNumber(value: (r - 0.5) / 0.5)
+                array[[0, 1, y, x] as [NSNumber]] = NSNumber(value: (g - 0.5) / 0.5)
+                array[[0, 2, y, x] as [NSNumber]] = NSNumber(value: (b - 0.5) / 0.5)
+            }
+        }
+        return array
+    }
+
+    private func createGrayPixelValues() -> MLMultiArray? {
+        guard let array = try? MLMultiArray(shape: [1, 3, 224, 224], dataType: .float32) else { return nil }
+        for i in 0..<array.count { array[i] = 0 }
+        return array
+    }
 
     /// Predict labels for words in OCR lines using batched inference.
     ///
@@ -116,9 +167,11 @@ public class LayoutLMInference {
     /// to reduce inference overhead. Lines are greedily packed into sequences
     /// that fit within the 512 token limit.
     ///
-    /// - Parameter lines: Array of OCR lines from receipt
+    /// - Parameters:
+    ///   - lines: Array of OCR lines from receipt
+    ///   - receiptImageData: Optional warped receipt image data (required for v3 models)
     /// - Returns: Array of LinePrediction results
-    public func predict(lines: [Line]) throws -> [LinePrediction] {
+    public func predict(lines: [Line], receiptImageData: Data? = nil) throws -> [LinePrediction] {
         guard !lines.isEmpty else { return [] }
 
         // Compute bbox extents for the entire receipt
@@ -185,8 +238,14 @@ public class LayoutLMInference {
         // Run inference on each batch and collect results
         var results: [LinePrediction?] = Array(repeating: nil, count: lines.count)
 
+        // Prepare pixel_values once for all batches (v3 only, same image for all lines in a receipt)
+        let pixelValues: MLMultiArray? = try {
+            guard let imageData = receiptImageData else { return createGrayPixelValues() }
+            return try createPixelValues(from: imageData)
+        }()
+
         for batch in batches {
-            let batchPredictions = try predictBatch(batch)
+            let batchPredictions = try predictBatch(batch, pixelValues: pixelValues)
             for (i, item) in batch.enumerated() {
                 results[item.lineIndex] = batchPredictions[i]
             }
@@ -217,7 +276,8 @@ public class LayoutLMInference {
 
     /// Predict labels for a batch of lines packed into a single sequence.
     private func predictBatch(
-        _ batch: [(lineIndex: Int, words: [String], bboxes: [[Int32]])]
+        _ batch: [(lineIndex: Int, words: [String], bboxes: [[Int32]])],
+        pixelValues: MLMultiArray? = nil
     ) throws -> [LinePrediction] {
         // Concatenate all words and bboxes, tracking line boundaries
         var allWords: [String] = []
@@ -256,7 +316,8 @@ public class LayoutLMInference {
             input_ids: inputIds,
             attention_mask: attentionMask,
             bbox: bbox,
-            token_type_ids: tokenTypeIds
+            token_type_ids: tokenTypeIds,
+            pixel_values: pixelValues
         )
         let output = try model.prediction(from: inputFeatures)
 
@@ -560,22 +621,26 @@ public class LayoutLMInference {
 
 // MARK: - CoreML Input Provider
 
-/// Feature provider for LayoutLM model inputs.
+/// Feature provider for LayoutLM model inputs (v1 and v3).
 private class LayoutLMInput: MLFeatureProvider {
     let input_ids: MLMultiArray
     let attention_mask: MLMultiArray
     let bbox: MLMultiArray
     let token_type_ids: MLMultiArray
+    let pixel_values: MLMultiArray?
 
-    init(input_ids: MLMultiArray, attention_mask: MLMultiArray, bbox: MLMultiArray, token_type_ids: MLMultiArray) {
+    init(input_ids: MLMultiArray, attention_mask: MLMultiArray, bbox: MLMultiArray, token_type_ids: MLMultiArray, pixel_values: MLMultiArray? = nil) {
         self.input_ids = input_ids
         self.attention_mask = attention_mask
         self.bbox = bbox
         self.token_type_ids = token_type_ids
+        self.pixel_values = pixel_values
     }
 
     var featureNames: Set<String> {
-        return ["input_ids", "attention_mask", "bbox", "token_type_ids"]
+        var names: Set<String> = ["input_ids", "attention_mask", "bbox", "token_type_ids"]
+        if pixel_values != nil { names.insert("pixel_values") }
+        return names
     }
 
     func featureValue(for featureName: String) -> MLFeatureValue? {
@@ -588,6 +653,8 @@ private class LayoutLMInput: MLFeatureProvider {
             return MLFeatureValue(multiArray: bbox)
         case "token_type_ids":
             return MLFeatureValue(multiArray: token_type_ids)
+        case "pixel_values":
+            return pixel_values.map { MLFeatureValue(multiArray: $0) }
         default:
             return nil
         }

--- a/receipt_ocr_swift/Sources/ReceiptOCRCore/LayoutLM/LayoutLMInference.swift
+++ b/receipt_ocr_swift/Sources/ReceiptOCRCore/LayoutLM/LayoutLMInference.swift
@@ -34,8 +34,8 @@ public class LayoutLMInference {
     /// The CoreML model
     private let model: MLModel
 
-    /// BERT tokenizer for WordPiece tokenization
-    private let tokenizer: BertTokenizer
+    /// Tokenizer function — wraps either BertTokenizer (v1) or BPETokenizer (v3)
+    private let tokenizer: (_ words: [String], _ padding: Bool, _ truncation: Bool) -> BertTokenizer.TokenizationResult
 
     /// Model configuration (labels)
     private let config: LayoutLMConfig
@@ -94,22 +94,32 @@ public class LayoutLMInference {
             self.model = try MLModel(contentsOf: persistentCompiledURL)
         }
 
-        // Load tokenizer
-        let vocabURL = bundlePath.appendingPathComponent("vocab.txt")
-        guard fileManager.fileExists(atPath: vocabURL.path) else {
-            throw LayoutLMError.vocabNotFound(path: vocabURL.path)
-        }
-        self.tokenizer = try BertTokenizer(vocabURL: vocabURL)
-
         // Load config
         let configURL = bundlePath.appendingPathComponent("config.json")
         guard fileManager.fileExists(atPath: configURL.path) else {
             throw LayoutLMError.configNotFound(path: configURL.path)
         }
         self.config = try LayoutLMConfig.load(from: configURL)
-
         self.maxSeqLength = config.maxPositionEmbeddings ?? 512
         self.requiresImageInput = model.modelDescription.inputDescriptionsByName.keys.contains("pixel_values")
+
+        // Load tokenizer — use BPE for v3 (tokenizer.json), WordPiece for v1 (vocab.txt)
+        let tokenizerJsonURL = bundlePath.appendingPathComponent("tokenizer.json")
+        if fileManager.fileExists(atPath: tokenizerJsonURL.path) {
+            let bpe = try BPETokenizer(tokenizerJsonURL: tokenizerJsonURL, maxLength: self.maxSeqLength)
+            self.tokenizer = { words, padding, truncation in
+                bpe.tokenize(words: words, padding: padding, truncation: truncation)
+            }
+        } else {
+            let vocabURL = bundlePath.appendingPathComponent("vocab.txt")
+            guard fileManager.fileExists(atPath: vocabURL.path) else {
+                throw LayoutLMError.vocabNotFound(path: vocabURL.path)
+            }
+            let bert = try BertTokenizer(vocabURL: vocabURL)
+            self.tokenizer = { words, padding, truncation in
+                bert.tokenize(words: words, padding: padding, truncation: truncation)
+            }
+        }
     }
 
     // MARK: - Prediction
@@ -267,7 +277,7 @@ public class LayoutLMInference {
         var count = 0
         for word in words {
             // Use tokenizer to count subtokens
-            let result = tokenizer.tokenize(words: [word], padding: false, truncation: false)
+            let result = tokenizer([word], false, false)
             // Subtract 2 for [CLS] and [SEP] that tokenize() adds
             count += max(0, result.inputIds.count - 2)
         }
@@ -292,7 +302,7 @@ public class LayoutLMInference {
         }
 
         // Tokenize the combined words
-        let tokenResult = tokenizer.tokenize(words: allWords, padding: true, truncation: true)
+        let tokenResult = tokenizer(allWords, true, true)
 
         // Build bbox tensor for subtokens
         var bboxTensor: [[Int32]] = []
@@ -447,7 +457,7 @@ public class LayoutLMInference {
         let (texts, wordBboxes) = BboxNormalizer.normalizeWords(words, maxX: maxX, maxY: maxY)
 
         // Tokenize
-        let tokenResult = tokenizer.tokenize(words: texts, padding: true, truncation: true)
+        let tokenResult = tokenizer(texts, true, true)
 
         // Build bbox tensor for subtokens (repeat word bbox for each subtoken)
         var bboxTensor: [[Int32]] = []

--- a/receipt_ocr_swift/Sources/ReceiptOCRCore/OCR/VisionOCREngine.swift
+++ b/receipt_ocr_swift/Sources/ReceiptOCRCore/OCR/VisionOCREngine.swift
@@ -490,7 +490,13 @@ public struct VisionOCREngine: OCREngineProtocol {
                                 var layoutlmPredictions: [LinePrediction]?
                                 if let inference = layoutLMInference, !receiptLines.isEmpty {
                                     do {
-                                        layoutlmPredictions = try inference.predict(lines: receiptLines)
+                                        // For v3 models, pass the warped receipt image
+                                        var receiptImageData: Data? = nil
+                                        if inference.requiresImageInput {
+                                            let bitmapRep = NSBitmapImageRep(cgImage: receipt.warpedImage)
+                                            receiptImageData = bitmapRep.representation(using: .png, properties: [:])
+                                        }
+                                        layoutlmPredictions = try inference.predict(lines: receiptLines, receiptImageData: receiptImageData)
                                     } catch {
                                         print("Warning: LayoutLM inference failed for receipt \(receipt.clusterId): \(error)")
                                     }
@@ -706,7 +712,12 @@ public struct VisionOCREngine: OCREngineProtocol {
                             var layoutlmPredictions: [LinePrediction]?
                             if let inference = layoutLMInference, !receiptLines.isEmpty {
                                 do {
-                                    layoutlmPredictions = try inference.predict(lines: receiptLines)
+                                    var receiptImageData: Data? = nil
+                                    if inference.requiresImageInput {
+                                        let bitmapRep = NSBitmapImageRep(cgImage: receipt.warpedImage)
+                                        receiptImageData = bitmapRep.representation(using: .png, properties: [:])
+                                    }
+                                    layoutlmPredictions = try inference.predict(lines: receiptLines, receiptImageData: receiptImageData)
                                 } catch {
                                     print("Warning: LayoutLM inference failed for receipt \(receipt.clusterId): \(error)")
                                 }


### PR DESCRIPTION
## Summary
- Adds opt-in LayoutLMv3 training via `--model-version v3` (or `model_version: v3` SageMaker hyperparameter)
- v1 remains the default — all existing behavior unchanged
- v3 adds image input (pixel patches from receipt photos) which improves accuracy on visually-distinct labels

## Results

**v3 beats v1 on 9-label classification:**

| Model | Labels | Best F1 |
|-------|--------|---------|
| v1 (merged ADDRESS) | 8 | 0.785 |
| v1 (separate PHONE/ADDRESS) | 9 | 0.700 |
| **v3 (separate PHONE/ADDRESS)** | **9** | **0.734** |

v3 closes half the gap between 9-label v1 and 8-label v1 by using receipt image features.

## What changed

| File | Change |
|------|--------|
| `config.py` | `ModelVersion` enum (V1/V3), `model_version` field on `TrainingConfig` |
| `cli.py` | `--model-version` flag on `train` and `export-coreml`, input validation |
| `data_loader.py` | `download_receipt_images()` downloads warped receipt crops, `image_id` in dataset |
| `trainer.py` | Dynamic model/tokenizer/image processor selection, `_preprocess_v3`, shared `_align_labels_and_bboxes` |
| `export_coreml.py` | `LayoutLMv3Wrapper`, version-aware export, `--model-version` in `__main__`, v3 vocab warning |
| `export_coreml_v3_patch.py` | Composite op patches for `new_ones` → `mb.fill` |
| `Dockerfile` | Pre-downloads v3 model weights + image processor |
| `component.py` | Raw bucket S3 read for v3, `sagemaker:AddTags` permission, `skip-coreml-export` for v3 |
| `train.py` | `model_version` SageMaker hyperparameter passthrough |
| `BPETokenizer.swift` | RoBERTa BPE tokenizer for v3 Swift inference |
| `LayoutLMInference.swift` | Auto-detect v3 model, `pixel_values` input, image preprocessing |
| `VisionOCREngine.swift` | Pass warped receipt image to v3 inference |

## Known Limitation: CoreML export blocked

v3 CoreML export fails due to `bitwise_and` in `transformers.masking_utils` (transformers 5.x) producing `float & bool` which coremltools 9.0 rejects. See #919 for full details and workaround options.

**Training works. Swift inference code is ready. The CoreML conversion bridge is the remaining gap.**

## What's NOT in this PR
- Changing the deployed model — v1 stays active until v3 CoreML export is unblocked
- coremltools source fix for `bitwise_and` — tracked in #919

## Test plan
- [x] Config enum and CLI parsing work
- [x] v3 SageMaker training completes with `model_version: v3`
- [x] v3 F1=0.734 beats v1 F1=0.700 on same 9-label task
- [x] Swift code compiles with BPE tokenizer + image preprocessing
- [x] v1 training unaffected (ultrareview regression fix applied)
- [ ] CoreML export (blocked by #919)
- [ ] End-to-end Swift OCR worker test with v3 model

🤖 Generated with [Claude Code](https://claude.com/claude-code)