### PR TITLE
[codex] Lazy mount receipt figures near viewport

### DIFF
--- a/portfolio/pages/receipt.tsx
+++ b/portfolio/pages/receipt.tsx
@@ -1,6 +1,7 @@
 import { GetStaticProps } from "next";
 import Head from "next/head";
 import React, { useCallback, useEffect, useState } from "react";
+import { useInView } from "react-intersection-observer";
 import ClientOnly from "../components/ClientOnly";
 import UploadProgressPanel from "../components/ui/UploadProgressPanel";
 import { useQAQueue } from "../hooks/useQAQueue";
@@ -54,17 +55,56 @@ interface FigureBoundaryProps {
   intrinsicSize?: string;
 }
 
+const FIGURE_LAZY_ROOT_MARGIN = "1000px 0px";
+
 const FigureBoundary = ({
   children,
   intrinsicSize = "600px",
-}: FigureBoundaryProps) => (
-  <div
-    className={styles.figureBoundary}
-    style={{ "--figure-intrinsic-size": intrinsicSize } as React.CSSProperties}
-  >
-    {children}
-  </div>
-);
+}: FigureBoundaryProps) => {
+  const { ref, inView } = useInView({
+    rootMargin: FIGURE_LAZY_ROOT_MARGIN,
+    triggerOnce: true,
+    fallbackInView: false,
+  });
+  const [shouldRender, setShouldRender] = useState(false);
+
+  useEffect(() => {
+    if (inView) {
+      setShouldRender(true);
+    }
+  }, [inView]);
+
+  return (
+    <div
+      ref={ref}
+      className={styles.figureBoundary}
+      data-lazy-pending={shouldRender ? undefined : "true"}
+      style={
+        {
+          "--figure-intrinsic-size": intrinsicSize,
+          minHeight: shouldRender ? undefined : intrinsicSize,
+        } as React.CSSProperties
+      }
+    >
+      {shouldRender ? children : null}
+    </div>
+  );
+};
+
+const QAAgentFigure = () => {
+  const {
+    data: qaData,
+    questionIndex: selectedQuestion,
+    advance: advanceQuestion,
+    selectQuestion: setSelectedQuestion,
+  } = useQAQueue();
+
+  return (
+    <QAAgentFlow autoPlay={true} questionData={qaData ?? undefined} onCycleComplete={advanceQuestion}>
+      <QuestionMarquee rows={4} speed={25} onQuestionClick={setSelectedQuestion} activeQuestion={selectedQuestion} />
+    </QAAgentFlow>
+  );
+};
 
 // Use getStaticProps for static generation - this runs at build time
 export const getStaticProps: GetStaticProps<ReceiptPageProps> = async () => {
@@ -119,9 +159,6 @@ export default function ReceiptPage({
   }, []);
 
   const { fileStates, addFiles, clearAll } = useUploadProgress(apiUrl);
-
-  // --- QA Agent live data ---
-  const { data: qaData, questionIndex: selectedQuestion, advance: advanceQuestion, selectQuestion: setSelectedQuestion } = useQAQueue();
 
   const handleDrop = useCallback(
     (e: DragEvent) => {
@@ -497,9 +534,7 @@ M1LK 2%           1    $4.4g`}</code>
 
       <FigureBoundary intrinsicSize="760px">
         <ClientOnly>
-          <QAAgentFlow autoPlay={true} questionData={qaData ?? undefined} onCycleComplete={advanceQuestion}>
-            <QuestionMarquee rows={4} speed={25} onQuestionClick={setSelectedQuestion} activeQuestion={selectedQuestion} />
-          </QAAgentFlow>
+          <QAAgentFigure />
         </ClientOnly>
       </FigureBoundary>
 


### PR DESCRIPTION
## Summary
- Lazy-mount `/receipt` figure islands only when their boundary approaches the viewport.
- Reserve each figure's intrinsic space while pending so the article layout does not collapse.
- Keep triggered figures mounted after first reveal so visuals do not disappear when scrolling back up.
- Move `useQAQueue` into the lazily mounted QA figure so QA data fetch/prefetch work does not start on initial page mount.

## Why
The deployed follow-up from PR #934 improved scroll behavior, but the production probe still showed heavy up-front and accumulated DOM work:
- prod top-after-hydration: 3,047 elements, 642 animated-style elements
- prod bottom-after-scroll-down: 4,326 elements, 1,187 animated-style elements
- prod scroll-up: 17 frames over 16ms, max frame 41.7ms

This pass reduces the initial page cost and defers lower-page figure hydration until the reader is close to those sections.

## Local Probe
Against a production static export at `http://127.0.0.1:4317/receipt`:
- top-after-hydration: 313 elements, 7 animated-style elements
- bottom-after-scroll-down: 2,847 elements, 627 animated-style elements
- scroll-up: 0 frames over 16ms, max frame 9.4ms

Note: the local static probe blocks cross-origin API calls from `127.0.0.1`, so prod should still be used for final post-deploy confirmation. The top-of-page hydration reduction is still representative of the lazy mounting change.

## Validation
- `npm run type-check`
- `npm run build`
- `npm run lint` (warnings only, no errors)
- `npm test -- --runTestsByPath hooks/useOptimizedInView.test.ts --runInBand`
- `RECEIPT_PROBE_URL=http://127.0.0.1:4317/receipt node scripts/receipt-scroll-probe.mjs`
- Browser sanity check on local static build: placeholders reserve space, figures mount while scrolling, mounted figures remain mounted when returning upward.