### PR TITLE
Address CodeRabbit follow-ups from PR #936

### DIFF
--- a/portfolio/__tests__/integration/PhotoReceiptBoundingBox.integration.test.tsx
+++ b/portfolio/__tests__/integration/PhotoReceiptBoundingBox.integration.test.tsx
@@ -40,6 +40,7 @@ const server = setupServer(
 beforeAll(() => server.listen());
 afterEach(() => {
   server.resetHandlers();
+  jest.restoreAllMocks();
 });
 afterAll(() => server.close());
 

--- a/portfolio/hooks/useImageDetails.test.tsx
+++ b/portfolio/hooks/useImageDetails.test.tsx
@@ -13,6 +13,11 @@ const mockedDetect = detectImageFormatSupport as jest.MockedFunction<typeof dete
 describe('useImageDetails', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    // Empty cache pool so the hook falls back to the random-details endpoint
+    mockedApi.fetchCachedImageDetails.mockResolvedValue({
+      images: [],
+      cached_at: '2026-01-01T00:00:00Z',
+    });
     mockedApi.fetchRandomImageDetails.mockResolvedValue({
       image: { image_id: '1' } as any,
       lines: [],

--- a/portfolio/hooks/useQAQueue.ts
+++ b/portfolio/hooks/useQAQueue.ts
@@ -112,6 +112,7 @@ export function useQAQueue(prefetchAhead = 3): UseQAQueueResult {
         queryKey: ["qa", "metadata"],
         queryFn: async () => {
           const r = await fetch(`${API_CONFIG.baseUrl}/qa/visualization`);
+          if (!r.ok) throw new Error("Failed to fetch QA metadata");
           return r.json();
         },
         staleTime: Infinity,


### PR DESCRIPTION
## Summary

Batches the three Minor findings CodeRabbit posted on #936 (all hygiene/robustness, no behavior bugs):

- **`useQAQueue`** — check `res.ok` on the metadata fetch before parsing. Previously a parseable error body could be cached forever (`staleTime: Infinity`) as metadata; the `?? 32` fallback kept behavior correct, but now a transient server error is never pinned in the cache. Also matches its sibling `fetchQuestion`.
- **`PhotoReceiptBoundingBox` integration test** — restore the global `fetch` spy in `afterEach` so it can't leak between tests.
- **`useImageDetails` test** — explicitly mock `fetchCachedImageDetails` with an empty pool instead of relying on the automock's `undefined` return throwing a `TypeError` to exercise the fallback path.

## Test plan

- [x] `npm run type-check` clean
- [x] `npx jest --ci` — 40 suites / 181 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)