### PR TITLE
Add receipt_langsmith to the CI test matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        package: [receipt_dynamo, receipt_dynamo_stream, receipt_chroma, receipt_places]
+        package: [receipt_dynamo, receipt_dynamo_stream, receipt_chroma, receipt_places, receipt_langsmith]
     steps:
       - uses: actions/checkout@v6
         with:
@@ -93,6 +93,10 @@ jobs:
               pip install --no-deps -e receipt_places
               pip install pydantic pydantic-settings structlog boto3 requests tenacity
               pip install pytest pytest-mock pytest-cov pytest-xdist pytest-timeout pytest-rerunfailures moto responses
+              ;;
+            receipt_langsmith)
+              # Standalone package; pyspark extra needed for tests/spark
+              pip install -e "receipt_langsmith[pyspark,dev]"
               ;;
             *)
               pip install -e "${{ matrix.package }}[test]"

--- a/receipt_langsmith/pyproject.toml
+++ b/receipt_langsmith/pyproject.toml
@@ -43,12 +43,22 @@ dev = [
     "pytest>=8.3.0,<10.0.0",
     "pytest-asyncio>=0.23.0",
     "pytest-mock>=3.14.0,<4.0.0",
+    "pytest-cov>=6.1.0,<8.0.0",
+    "pytest-xdist>=3.6.0,<4.0.0",
+    "pytest-timeout>=2.1.0,<3.0.0",
+    "pytest-rerunfailures>=14.0,<17.0",
     "moto>=5.1.0",
-    "black==26.1.0",
+    "black==26.5.1",
     "pylint>=3.0.0,<5.0.0",
     "mypy>=1.19.0",
     "pyarrow-stubs>=15.0.0",
-    "isort==8.0.0",
+    "isort==8.0.1",
+]
+
+# Lint-only dependencies (installed by CI's lint step)
+lint = [
+    "black==26.5.1",
+    "isort==8.0.1",
 ]
 
 [tool.hatch.build]

--- a/receipt_langsmith/receipt_langsmith/__init__.py
+++ b/receipt_langsmith/receipt_langsmith/__init__.py
@@ -190,6 +190,7 @@ def __getattr__(name: str):
 
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
+
 # Public re-export list is intentionally duplicated to keep a stable API.
 # pylint: disable=duplicate-code
 __all__ = [

--- a/receipt_langsmith/receipt_langsmith/_lazy_imports.py
+++ b/receipt_langsmith/receipt_langsmith/_lazy_imports.py
@@ -73,4 +73,5 @@ def resolve_pyspark_attr(name: str) -> Any | None:
 
     return None
 
+
 # pylint: enable=import-outside-toplevel

--- a/receipt_langsmith/receipt_langsmith/client/api.py
+++ b/receipt_langsmith/receipt_langsmith/client/api.py
@@ -265,8 +265,8 @@ class LangSmithClient:
         if filters.name_filter:
             # Sanitize name_filter to prevent filter injection
             # Escape backslashes first, then quotes (order matters)
-            sanitized = (
-                filters.name_filter.replace("\\", "\\\\").replace('"', '\\"')
+            sanitized = filters.name_filter.replace("\\", "\\\\").replace(
+                '"', '\\"'
             )
             params["filter"] = f'eq(name, "{sanitized}")'
         if filters.start_time:

--- a/receipt_langsmith/receipt_langsmith/parsers/__init__.py
+++ b/receipt_langsmith/receipt_langsmith/parsers/__init__.py
@@ -9,6 +9,7 @@ This module provides:
 
 from receipt_langsmith.parsers.json_fields import parse_extra, parse_json
 from receipt_langsmith.parsers.parquet import ParquetReader
+
 # Label validation helpers (receipt-label-validation project)
 from receipt_langsmith.parsers.trace_helpers import (
     LabelValidationTraceIndex,

--- a/receipt_langsmith/receipt_langsmith/parsers/parquet.py
+++ b/receipt_langsmith/receipt_langsmith/parsers/parquet.py
@@ -12,9 +12,9 @@ from pathlib import Path
 from typing import Iterator, Optional, Union
 
 import boto3
-from botocore.exceptions import BotoCoreError, ClientError
 import pyarrow
 import pyarrow.parquet as pq
+from botocore.exceptions import BotoCoreError, ClientError
 from pydantic import ValidationError
 
 from receipt_langsmith.entities.base import LangSmithRun

--- a/receipt_langsmith/receipt_langsmith/parsers/trace_helpers.py
+++ b/receipt_langsmith/receipt_langsmith/parsers/trace_helpers.py
@@ -253,6 +253,7 @@ def get_relative_timing(
 
     return (start_ms, duration_ms)
 
+
 # pylint: disable=too-many-arguments,too-many-positional-arguments
 def load_s3_result(
     s3_client: Any,

--- a/receipt_langsmith/receipt_langsmith/spark/analytics_helpers.py
+++ b/receipt_langsmith/receipt_langsmith/spark/analytics_helpers.py
@@ -49,9 +49,9 @@ def duration_stats(
     for percentile in percentiles:
         label = f"p{int(percentile * 100)}_duration_ms"
         aggs.append(
-            F.expr(
-                f"percentile_approx(duration_ms, {percentile})"
-            ).alias(label)
+            F.expr(f"percentile_approx(duration_ms, {percentile})").alias(
+                label
+            )
         )
     aggs.extend(
         [

--- a/receipt_langsmith/receipt_langsmith/spark/evaluator_financial_math_viz_cache.py
+++ b/receipt_langsmith/receipt_langsmith/spark/evaluator_financial_math_viz_cache.py
@@ -135,7 +135,8 @@ def _build_confirmed_equations(
     expected_value / actual_value are left as None.
     """
     valid_decisions = [
-        d for d in decisions
+        d
+        for d in decisions
         if d.get("llm_review", {}).get("decision") == "VALID"
     ]
     if not valid_decisions:
@@ -229,7 +230,9 @@ def _build_confirmed_equations(
                 line_groups[lid]["LINE_TOTAL"].append(d)
 
         for lid, group in sorted(line_groups.items()):
-            all_d = group["QUANTITY"] + group["UNIT_PRICE"] + group["LINE_TOTAL"]
+            all_d = (
+                group["QUANTITY"] + group["UNIT_PRICE"] + group["LINE_TOTAL"]
+            )
             # Need a LINE_TOTAL (the result) plus at least one operand
             if not group["LINE_TOTAL"]:
                 continue
@@ -257,7 +260,8 @@ def _build_equations(
     """Group decisions by description (equation) and build equation dicts."""
     # Filter out VALID confirmations — they lack equation metadata
     equation_decisions = [
-        d for d in decisions
+        d
+        for d in decisions
         if d.get("llm_review", {}).get("decision") != "VALID"
     ]
 
@@ -412,7 +416,9 @@ def build_financial_math_cache(
 
         # Build equations grouped by description
         equations = _build_equations(output_list, word_lookup)
-        confirmed_equations = _build_confirmed_equations(output_list, word_lookup)
+        confirmed_equations = _build_confirmed_equations(
+            output_list, word_lookup
+        )
         equations.extend(confirmed_equations)
         summary = _build_summary(
             equations, total_confirmed=len(confirmed_equations)
@@ -423,9 +429,7 @@ def build_financial_math_cache(
         width = 0
         height = 0
         if receipt_lookup and receipt_id is not None:
-            lookup_row = receipt_lookup.get(
-                (str(image_id), int(receipt_id))
-            )
+            lookup_row = receipt_lookup.get((str(image_id), int(receipt_id)))
             if lookup_row:
                 for key in (
                     "cdn_s3_key",
@@ -444,7 +448,9 @@ def build_financial_math_cache(
         # Skip receipts with no equations — nothing to visualize.
         if not equations:
             logger.debug(
-                "Skipping %s/%s: no equations to visualize", image_id, receipt_id
+                "Skipping %s/%s: no equations to visualize",
+                image_id,
+                receipt_id,
             )
             continue
 
@@ -459,11 +465,11 @@ def build_financial_math_cache(
                 "summary": summary,
                 "width": width,
                 "height": height,
-                "reocr_region": reocr_lookup.get(
-                    (str(image_id), int(receipt_id))
-                )
-                if receipt_id is not None
-                else None,
+                "reocr_region": (
+                    reocr_lookup.get((str(image_id), int(receipt_id)))
+                    if receipt_id is not None
+                    else None
+                ),
                 **cdn_fields,
             }
         )

--- a/receipt_langsmith/receipt_langsmith/spark/evaluator_patterns_viz_cache.py
+++ b/receipt_langsmith/receipt_langsmith/spark/evaluator_patterns_viz_cache.py
@@ -456,9 +456,7 @@ def _build_constellation_data(
 
         result[merchant_name] = entry
 
-    logger.info(
-        "Extracted constellation data for %d merchants", len(result)
-    )
+    logger.info("Extracted constellation data for %d merchants", len(result))
     return result
 
 
@@ -520,11 +518,7 @@ def build_patterns_cache(
         if tid:
             rows_by_trace[tid].append(row)
         # Map merchant -> ReceiptEvaluation trace_ids
-        if (
-            _is_root(row)
-            and row.get("name") == "ReceiptEvaluation"
-            and tid
-        ):
+        if _is_root(row) and row.get("name") == "ReceiptEvaluation" and tid:
             merchant = _extract_merchant_from_extra(row.get("extra"))
             merchant_eval_traces[merchant].append(tid)
 

--- a/receipt_langsmith/receipt_langsmith/spark/evaluator_within_receipt_viz_cache.py
+++ b/receipt_langsmith/receipt_langsmith/spark/evaluator_within_receipt_viz_cache.py
@@ -18,21 +18,25 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 # Label sets for each verification pass
-PLACE_LABELS = frozenset({
-    "MERCHANT_NAME",
-    "ADDRESS_LINE",
-    "PHONE_NUMBER",
-    "WEBSITE",
-    "STORE_HOURS",
-})
+PLACE_LABELS = frozenset(
+    {
+        "MERCHANT_NAME",
+        "ADDRESS_LINE",
+        "PHONE_NUMBER",
+        "WEBSITE",
+        "STORE_HOURS",
+    }
+)
 
-FORMAT_LABELS = frozenset({
-    "DATE",
-    "TIME",
-    "PAYMENT_METHOD",
-    "COUPON",
-    "LOYALTY_ID",
-})
+FORMAT_LABELS = frozenset(
+    {
+        "DATE",
+        "TIME",
+        "PAYMENT_METHOD",
+        "COUPON",
+        "LOYALTY_ID",
+    }
+)
 
 
 def _parse_json(raw: Any) -> Any:
@@ -105,9 +109,16 @@ def _build_decision_entry(
         "decision": llm_review.get("decision"),
         "confidence": llm_review.get("confidence"),
         "reasoning": llm_review.get("reasoning"),
-        "bbox": _extract_bbox(word) if word else {
-            "x": 0.0, "y": 0.0, "width": 0.0, "height": 0.0,
-        },
+        "bbox": (
+            _extract_bbox(word)
+            if word
+            else {
+                "x": 0.0,
+                "y": 0.0,
+                "width": 0.0,
+                "height": 0.0,
+            }
+        ),
     }
 
 
@@ -139,15 +150,14 @@ def _build_decision_summary(
     """Count V/I/R decisions."""
     total = len(decisions)
     valid = sum(
-        1 for d in decisions
-        if (d.get("decision") or "").upper() == "VALID"
+        1 for d in decisions if (d.get("decision") or "").upper() == "VALID"
     )
     invalid = sum(
-        1 for d in decisions
-        if (d.get("decision") or "").upper() == "INVALID"
+        1 for d in decisions if (d.get("decision") or "").upper() == "INVALID"
     )
     needs_review = sum(
-        1 for d in decisions
+        1
+        for d in decisions
         if (d.get("decision") or "").upper() == "NEEDS_REVIEW"
     )
     return {
@@ -204,14 +214,16 @@ def _build_financial_equations(
     for desc, group in groups.items():
         first_issue = group[0].get("issue", {})
         involved_words = [_build_decision_entry(d, word_lookup) for d in group]
-        equations.append({
-            "issue_type": first_issue.get("issue_type", ""),
-            "description": desc,
-            "expected_value": first_issue.get("expected_value"),
-            "actual_value": first_issue.get("actual_value"),
-            "difference": first_issue.get("difference"),
-            "involved_words": involved_words,
-        })
+        equations.append(
+            {
+                "issue_type": first_issue.get("issue_type", ""),
+                "description": desc,
+                "expected_value": first_issue.get("expected_value"),
+                "actual_value": first_issue.get("actual_value"),
+                "difference": first_issue.get("difference"),
+                "involved_words": involved_words,
+            }
+        )
 
     return equations
 
@@ -243,13 +255,15 @@ def _build_word_list(words: list[dict]) -> list[dict[str, Any]]:
     """Build simplified word list with bboxes for the frontend."""
     result: list[dict[str, Any]] = []
     for w in words:
-        result.append({
-            "text": w.get("text", ""),
-            "label": w.get("label"),
-            "line_id": w.get("line_id"),
-            "word_id": w.get("word_id"),
-            "bbox": _extract_bbox(w),
-        })
+        result.append(
+            {
+                "text": w.get("text", ""),
+                "label": w.get("label"),
+                "line_id": w.get("line_id"),
+                "word_id": w.get("word_id"),
+                "bbox": _extract_bbox(w),
+            }
+        )
     return result
 
 
@@ -359,9 +373,11 @@ def build_within_receipt_cache(
         merchant_name = urow.get("merchant_name", "")
 
         # Lookup data row for place + words + CDN keys
-        data_row = data_lookup.get(
-            (str(image_id), int(receipt_id))
-        ) if receipt_id is not None else None
+        data_row = (
+            data_lookup.get((str(image_id), int(receipt_id)))
+            if receipt_id is not None
+            else None
+        )
 
         # Words and bbox lookup
         raw_words = data_row.get("words", []) if data_row else []
@@ -369,23 +385,30 @@ def build_within_receipt_cache(
 
         # Place data
         place_raw = data_row.get("place") if data_row else None
-        place_parsed = _parse_json(place_raw) if isinstance(place_raw, str) else place_raw
+        place_parsed = (
+            _parse_json(place_raw) if isinstance(place_raw, str) else place_raw
+        )
         place_info = _extract_place_info(place_parsed)
 
         # Parse metadata_all_decisions
         metadata_raw = urow.get("metadata_all_decisions")
-        metadata_decisions = _parse_json(metadata_raw) if metadata_raw else None
+        metadata_decisions = (
+            _parse_json(metadata_raw) if metadata_raw else None
+        )
         if not isinstance(metadata_decisions, list):
             metadata_decisions = []
 
         # Split into place and format
         place_decisions, format_decisions = _split_metadata_decisions(
-            metadata_decisions, word_lookup,
+            metadata_decisions,
+            word_lookup,
         )
 
         # Parse financial_all_decisions from unified row
         financial_raw = urow.get("financial_all_decisions")
-        financial_decisions = _parse_json(financial_raw) if financial_raw else None
+        financial_decisions = (
+            _parse_json(financial_raw) if financial_raw else None
+        )
         if not isinstance(financial_decisions, list):
             financial_decisions = []
 
@@ -393,7 +416,8 @@ def build_within_receipt_cache(
         equations = financial_trace_lookup.get(trace_id, [])
         if not equations and financial_decisions:
             equations = _build_financial_equations(
-                financial_decisions, word_lookup,
+                financial_decisions,
+                word_lookup,
             )
 
         # Duration seconds
@@ -428,8 +452,11 @@ def build_within_receipt_cache(
         cdn_source = lookup_row or data_row
         if cdn_source:
             for key in (
-                "cdn_s3_key", "cdn_webp_s3_key", "cdn_avif_s3_key",
-                "cdn_medium_s3_key", "cdn_medium_webp_s3_key",
+                "cdn_s3_key",
+                "cdn_webp_s3_key",
+                "cdn_avif_s3_key",
+                "cdn_medium_s3_key",
+                "cdn_medium_webp_s3_key",
                 "cdn_medium_avif_s3_key",
             ):
                 val = cdn_source.get(key)

--- a/receipt_langsmith/receipt_langsmith/spark/label_validation_processor.py
+++ b/receipt_langsmith/receipt_langsmith/spark/label_validation_processor.py
@@ -311,10 +311,9 @@ class LabelValidationSparkProcessor(BaseSparkProcessor):
 
         steps = steps.withColumn("step_type", step_type_expr)
 
-        result = (
-            step_timing_stats(steps, group_cols=["name", "step_type"])
-            .withColumnRenamed("name", "step_name")
-        )
+        result = step_timing_stats(
+            steps, group_cols=["name", "step_type"]
+        ).withColumnRenamed("name", "step_name")
 
         logger.info("Computed step timing")
         return result
@@ -398,9 +397,9 @@ class LabelValidationSparkProcessor(BaseSparkProcessor):
                 F.sum(F.when(F.col("merchant_found"), 1).otherwise(0)).alias(
                     "success_count"
                 ),
-                F.sum(
-                    F.when(~F.col("merchant_found"), 1).otherwise(0)
-                ).alias("failure_count"),
+                F.sum(F.when(~F.col("merchant_found"), 1).otherwise(0)).alias(
+                    "failure_count"
+                ),
                 F.avg(
                     F.when(F.col("merchant_found"), F.col("confidence"))
                 ).alias("avg_confidence"),

--- a/receipt_langsmith/receipt_langsmith/spark/label_validation_viz_cache_helpers.py
+++ b/receipt_langsmith/receipt_langsmith/spark/label_validation_viz_cache_helpers.py
@@ -15,8 +15,8 @@ from pyspark.sql import functions as F
 
 from receipt_langsmith.spark.cli import run_spark_job
 from receipt_langsmith.spark.s3_io import (
-    load_json_from_s3,
     ReceiptsCachePointer,
+    load_json_from_s3,
     write_json_with_default,
     write_receipt_cache_index,
     write_receipt_json,
@@ -243,6 +243,7 @@ def extract_validation_traces(
 
 # --- Visualization Building ---
 
+
 def build_viz_receipt(
     root_trace: dict[str, Any],
     validation_traces: list[dict],
@@ -377,6 +378,7 @@ def _prepare_receipt_context(
         root_outputs=root_outputs,
         validation=validation,
     )
+
 
 def _extract_validations(
     validation_traces: list[dict],
@@ -757,7 +759,6 @@ def _resolve_parquet_prefix(
         )
         return None
     return normalized
-
 
 
 def _build_viz_receipts(

--- a/receipt_langsmith/receipt_langsmith/spark/merged_job.py
+++ b/receipt_langsmith/receipt_langsmith/spark/merged_job.py
@@ -658,7 +658,9 @@ def build_decisions_block(row: dict[str, Any], prefix: str) -> dict[str, Any]:
         receipt_id = row.get("receipt_id", "?")
         logger.warning(
             "Null %s for receipt %s/%s — evaluator may not have run for this prefix",
-            decisions_key, image_id, receipt_id,
+            decisions_key,
+            image_id,
+            receipt_id,
         )
         decisions = {}
     return {
@@ -679,7 +681,9 @@ def build_geometric_block(row: dict[str, Any]) -> dict[str, Any]:
         image_id = row.get("image_id", "?")
         receipt_id = row.get("receipt_id", "?")
         logger.warning(
-            "Null geometric_issues for receipt %s/%s", image_id, receipt_id,
+            "Null geometric_issues for receipt %s/%s",
+            image_id,
+            receipt_id,
         )
         issues = []
     return {
@@ -1056,9 +1060,7 @@ def _load_data_rows(
     try:
         df = read_json_df(spark, data_path)
     except AnalysisException:
-        logger.warning(
-            "Could not read data rows from %s", data_path
-        )
+        logger.warning("Could not read data rows from %s", data_path)
         return []
 
     wanted_cols = (
@@ -1138,9 +1140,7 @@ def _clean_cache_prefix(
     # delete_objects accepts up to 1000 keys per call
     for i in range(0, len(to_delete), 1000):
         batch = to_delete[i : i + 1000]
-        s3_client.delete_objects(
-            Bucket=bucket, Delete={"Objects": batch}
-        )
+        s3_client.delete_objects(Bucket=bucket, Delete={"Objects": batch})
     logger.info(
         "Cleaned %d stale objects from %s/%s/",
         len(to_delete),
@@ -1434,9 +1434,7 @@ def main() -> int:
                 cache_bucket=args.cache_bucket,
                 execution_id=args.execution_id,
                 batch_bucket=args.batch_bucket,
-                receipts_lookup_path=getattr(
-                    args, "receipts_lookup", None
-                ),
+                receipts_lookup_path=getattr(args, "receipts_lookup", None),
             )
             logger.info("Evaluator viz-cache phase complete")
 
@@ -1449,9 +1447,7 @@ def main() -> int:
                 cache_bucket=args.cache_bucket,
                 execution_id=args.execution_id,
                 batch_bucket=args.batch_bucket,
-                receipts_lookup_path=getattr(
-                    args, "receipts_lookup", None
-                ),
+                receipts_lookup_path=getattr(args, "receipts_lookup", None),
             )
             logger.info("Evaluator viz-cache phase complete")
 

--- a/receipt_langsmith/receipt_langsmith/spark/qa_viz_cache_helpers.py
+++ b/receipt_langsmith/receipt_langsmith/spark/qa_viz_cache_helpers.py
@@ -23,9 +23,9 @@ from receipt_langsmith.spark.s3_io import (
     write_metadata_json,
 )
 from receipt_langsmith.spark.utils import (
+    TRACE_BASE_COLUMNS,
     parse_json_object,
     parse_s3_path,
-    TRACE_BASE_COLUMNS,
     to_s3a,
 )
 
@@ -320,12 +320,18 @@ def derive_trace_steps(
             for child in tool_children:
                 if child.get("run_type") == "tool":
                     child_inputs = parse_json_object(child.get("inputs"))
-                    steps.append({
-                        "type": "tools",
-                        "content": child.get("name", "Tool"),
-                        "detail": json.dumps(child_inputs, default=str) if child_inputs else "",
-                        "durationMs": _compute_duration_ms(child),
-                    })
+                    steps.append(
+                        {
+                            "type": "tools",
+                            "content": child.get("name", "Tool"),
+                            "detail": (
+                                json.dumps(child_inputs, default=str)
+                                if child_inputs
+                                else ""
+                            ),
+                            "durationMs": _compute_duration_ms(child),
+                        }
+                    )
             if tool_children:
                 continue
 

--- a/receipt_langsmith/receipt_langsmith/spark/qa_viz_cache_job.py
+++ b/receipt_langsmith/receipt_langsmith/spark/qa_viz_cache_job.py
@@ -43,10 +43,10 @@ from receipt_langsmith.spark.cli import (
     run_spark_job,
 )
 from receipt_langsmith.spark.qa_viz_cache_helpers import (
-    build_qa_baseline_profile,
     QACacheJobConfig,
     QACacheWriteContext,
     build_cache_files_from_parquet,
+    build_qa_baseline_profile,
     load_question_results,
     load_receipts_lookup,
     qa_cache_config_from_args,

--- a/receipt_langsmith/receipt_langsmith/spark/trace_df.py
+++ b/receipt_langsmith/receipt_langsmith/spark/trace_df.py
@@ -113,9 +113,7 @@ def read_parquet_df(
         df = spark.read.option("recursiveFileLookup", "true").parquet(
             spark_path
         )
-    logger.info(
-        "Available columns in parquet: %s", sorted(df.columns)
-    )
+    logger.info("Available columns in parquet: %s", sorted(df.columns))
 
     df = normalize_trace_df(df, options)
     df = df.select(*trace_columns(options))
@@ -141,9 +139,9 @@ def add_metadata_fields(df: DataFrame) -> DataFrame:
         )
         .withColumn(
             "metadata_receipt_id",
-            F.get_json_object(
-                F.col("extra"), "$.metadata.receipt_id"
-            ).cast("int"),
+            F.get_json_object(F.col("extra"), "$.metadata.receipt_id").cast(
+                "int"
+            ),
         )
     )
 
@@ -157,9 +155,6 @@ def add_duration_ms(
     """Add duration_ms computed from start/end timestamps."""
     return df.withColumn(
         "duration_ms",
-        (
-            F.col(end_col).cast("double")
-            - F.col(start_col).cast("double")
-        )
+        (F.col(end_col).cast("double") - F.col(start_col).cast("double"))
         * 1000,
     )

--- a/receipt_langsmith/tests/spark/test_evaluator_patterns_viz_cache.py
+++ b/receipt_langsmith/tests/spark/test_evaluator_patterns_viz_cache.py
@@ -41,6 +41,7 @@ def constellation_data() -> dict:
     """Load constellation data from S3 pattern files."""
     try:
         import boto3
+
         boto3.client("s3").head_bucket(Bucket=BATCH_BUCKET)
     except Exception:
         pytest.skip("S3 batch bucket not accessible")
@@ -220,27 +221,27 @@ class TestSampleReceipt:
         with_sample = [
             e for e in patterns_cache if e.get("sample_receipt") is not None
         ]
-        assert len(with_sample) > 0, (
-            "Expected at least one merchant with a sample_receipt"
-        )
+        assert (
+            len(with_sample) > 0
+        ), "Expected at least one merchant with a sample_receipt"
 
     def test_sample_receipt_structure(self, patterns_cache: list[dict]):
         for entry in patterns_cache:
             sample = entry.get("sample_receipt")
             if sample is None:
                 continue
-            assert "image_id" in sample, (
-                f"Missing image_id in sample_receipt for {entry['merchant_name']}"
-            )
-            assert "receipt_id" in sample, (
-                f"Missing receipt_id in sample_receipt for {entry['merchant_name']}"
-            )
-            assert isinstance(sample["words"], list), (
-                f"words should be a list for {entry['merchant_name']}"
-            )
-            assert len(sample["words"]) > 0, (
-                f"words should not be empty for {entry['merchant_name']}"
-            )
+            assert (
+                "image_id" in sample
+            ), f"Missing image_id in sample_receipt for {entry['merchant_name']}"
+            assert (
+                "receipt_id" in sample
+            ), f"Missing receipt_id in sample_receipt for {entry['merchant_name']}"
+            assert isinstance(
+                sample["words"], list
+            ), f"words should be a list for {entry['merchant_name']}"
+            assert (
+                len(sample["words"]) > 0
+            ), f"words should not be empty for {entry['merchant_name']}"
 
     def test_sample_receipt_word_fields(self, patterns_cache: list[dict]):
         for entry in patterns_cache:
@@ -266,46 +267,38 @@ class TestSampleReceipt:
                 continue
             for word in sample["words"]:
                 bbox = word["bbox"]
-                assert 0 <= bbox["x"] <= 1, (
-                    f"bbox.x out of range: {bbox['x']}"
-                )
-                assert 0 <= bbox["y"] <= 1, (
-                    f"bbox.y out of range: {bbox['y']}"
-                )
-                assert 0 <= bbox["width"] <= 1, (
-                    f"bbox.width out of range: {bbox['width']}"
-                )
-                assert 0 <= bbox["height"] <= 1, (
-                    f"bbox.height out of range: {bbox['height']}"
-                )
+                assert 0 <= bbox["x"] <= 1, f"bbox.x out of range: {bbox['x']}"
+                assert 0 <= bbox["y"] <= 1, f"bbox.y out of range: {bbox['y']}"
+                assert (
+                    0 <= bbox["width"] <= 1
+                ), f"bbox.width out of range: {bbox['width']}"
+                assert (
+                    0 <= bbox["height"] <= 1
+                ), f"bbox.height out of range: {bbox['height']}"
 
 
 class TestConstellationData:
     """Verify constellation and label position data from S3 pattern files."""
 
-    def test_constellation_data_loaded(
-        self, constellation_data: dict
-    ):
+    def test_constellation_data_loaded(self, constellation_data: dict):
         assert len(constellation_data) > 0, "No constellation data loaded"
 
-    def test_label_positions_structure(
-        self, constellation_data: dict
-    ):
+    def test_label_positions_structure(self, constellation_data: dict):
         for merchant, data in constellation_data.items():
             positions = data.get("label_positions", {})
             for label, stats in positions.items():
-                assert "mean_y" in stats, (
-                    f"Missing mean_y for {label} in {merchant}"
-                )
-                assert "std_y" in stats, (
-                    f"Missing std_y for {label} in {merchant}"
-                )
-                assert "count" in stats, (
-                    f"Missing count for {label} in {merchant}"
-                )
-                assert isinstance(stats["mean_y"], (int, float)), (
-                    f"mean_y not numeric for {label} in {merchant}"
-                )
+                assert (
+                    "mean_y" in stats
+                ), f"Missing mean_y for {label} in {merchant}"
+                assert (
+                    "std_y" in stats
+                ), f"Missing std_y for {label} in {merchant}"
+                assert (
+                    "count" in stats
+                ), f"Missing count for {label} in {merchant}"
+                assert isinstance(
+                    stats["mean_y"], (int, float)
+                ), f"mean_y not numeric for {label} in {merchant}"
 
     def test_constellation_relative_positions_structure(
         self, constellation_data: dict
@@ -318,17 +311,15 @@ class TestConstellationData:
                 assert "observation_count" in c
                 assert "relative_positions" in c
                 for label, pos in c["relative_positions"].items():
-                    assert "mean_dx" in pos, (
-                        f"Missing mean_dx for {label} in {merchant}"
-                    )
+                    assert (
+                        "mean_dx" in pos
+                    ), f"Missing mean_dx for {label} in {merchant}"
                     assert "mean_dy" in pos
                     assert "std_dx" in pos
                     assert "std_dy" in pos
         assert found_constellations, "No constellations found in any merchant"
 
-    def test_label_pairs_structure(
-        self, constellation_data: dict
-    ):
+    def test_label_pairs_structure(self, constellation_data: dict):
         for _merchant, data in constellation_data.items():
             for p in data.get("label_pairs", []):
                 assert "labels" in p
@@ -345,18 +336,18 @@ class TestConstellationInCache:
         self, patterns_cache: list[dict]
     ):
         for entry in patterns_cache:
-            assert "receipt_count" in entry, (
-                f"Missing receipt_count for {entry['merchant_name']}"
-            )
-            assert "label_positions" in entry, (
-                f"Missing label_positions for {entry['merchant_name']}"
-            )
-            assert "constellations" in entry, (
-                f"Missing constellations for {entry['merchant_name']}"
-            )
-            assert "label_pairs" in entry, (
-                f"Missing label_pairs for {entry['merchant_name']}"
-            )
+            assert (
+                "receipt_count" in entry
+            ), f"Missing receipt_count for {entry['merchant_name']}"
+            assert (
+                "label_positions" in entry
+            ), f"Missing label_positions for {entry['merchant_name']}"
+            assert (
+                "constellations" in entry
+            ), f"Missing constellations for {entry['merchant_name']}"
+            assert (
+                "label_pairs" in entry
+            ), f"Missing label_pairs for {entry['merchant_name']}"
 
     def test_some_merchants_have_constellations(
         self, patterns_cache: list[dict]
@@ -364,9 +355,9 @@ class TestConstellationInCache:
         with_constellations = [
             e for e in patterns_cache if len(e.get("constellations", [])) > 0
         ]
-        assert len(with_constellations) > 0, (
-            "Expected at least one merchant with constellations"
-        )
+        assert (
+            len(with_constellations) > 0
+        ), "Expected at least one merchant with constellations"
 
     def test_some_merchants_have_label_positions(
         self, patterns_cache: list[dict]
@@ -374,6 +365,6 @@ class TestConstellationInCache:
         with_positions = [
             e for e in patterns_cache if len(e.get("label_positions", {})) > 0
         ]
-        assert len(with_positions) > 0, (
-            "Expected at least one merchant with label_positions"
-        )
+        assert (
+            len(with_positions) > 0
+        ), "Expected at least one merchant with label_positions"

--- a/receipt_langsmith/tests/spark/test_merged_job_evaluator_viz_cache.py
+++ b/receipt_langsmith/tests/spark/test_merged_job_evaluator_viz_cache.py
@@ -111,7 +111,10 @@ def test_diff_cache_accepts_preloaded_rows() -> None:
             ),
         },
         {
-            "name": "currency_evaluation",
+            # metadata_evaluation supplies both words (inputs) and
+            # decisions (outputs); the legacy currency_evaluation span
+            # name was dropped from the diff cache in #860
+            "name": "metadata_evaluation",
             "trace_id": "trace-2",
             "inputs": json.dumps(
                 {
@@ -433,6 +436,9 @@ def test_load_unified_rows_uses_multiline_reader(
         return _FakeDataFrame(unified_rows)
 
     monkeypatch.setattr(merged_job_mod, "read_json_df", _fake_read_json_df)
+    # F.lit requires a live SparkContext; _FakeDataFrame.withColumn ignores
+    # the expression, so stub it to keep the missing-column path exercised
+    monkeypatch.setattr(merged_job_mod.F, "lit", lambda _value: None)
     rows = merged_job_mod._load_unified_rows(
         spark=cast(Any, object()),
         batch_bucket="batch-bucket",
@@ -442,6 +448,8 @@ def test_load_unified_rows_uses_multiline_reader(
     assert len(rows) == 2
     assert rows[0]["image_id"] == "img-1"
     assert isinstance(rows[0]["review_all_decisions"], list)
+    # Columns absent from the source data are backfilled with None
+    assert rows[0]["metadata_all_decisions"] is None
 
 
 def test_load_evaluator_rows_enforces_hard_limit(
@@ -457,7 +465,9 @@ def test_load_evaluator_rows_enforces_hard_limit(
     monkeypatch.setattr(merged_job_mod, "F", _FakeFunctions())
     monkeypatch.setattr(merged_job_mod, "DRIVER_COLLECTION_HARD_LIMIT", 1)
 
-    with pytest.raises(RuntimeError, match="driver collection exceeded hard limit"):
+    with pytest.raises(
+        RuntimeError, match="driver collection exceeded hard limit"
+    ):
         merged_job_mod._load_evaluator_trace_rows(
             cast(Any, spark),
             "s3://input/traces/",

--- a/receipt_langsmith/tests/spark/test_qa_viz_cache_helpers.py
+++ b/receipt_langsmith/tests/spark/test_qa_viz_cache_helpers.py
@@ -14,10 +14,10 @@ from receipt_langsmith.spark.qa_viz_cache_helpers import (
     derive_trace_steps,
 )
 
-
 # ---------------------------------------------------------------------------
 # Helpers to build fake run dicts
 # ---------------------------------------------------------------------------
+
 
 def _make_run(
     *,
@@ -51,6 +51,7 @@ def _make_run(
 # ---------------------------------------------------------------------------
 # Test: derive_trace_steps expands ToolNode wrapper children
 # ---------------------------------------------------------------------------
+
 
 class TestDeriveTraceStepsExpandsToolChildren:
     """A depth-1 'tools' wrapper (run_type='chain') with two depth-2 tool runs
@@ -139,6 +140,7 @@ class TestDeriveTraceStepsExpandsToolChildren:
 # Test: derive_trace_steps with all_runs=None skips wrapper (backward compat)
 # ---------------------------------------------------------------------------
 
+
 class TestDeriveTraceStepsNoAllRunsSkipsWrapper:
     """When all_runs is None the 'tools' wrapper is silently skipped."""
 
@@ -167,36 +169,55 @@ class TestDeriveTraceStepsNoAllRunsSkipsWrapper:
 # Test: Agent→tools→agent→tools produces interleaved steps
 # ---------------------------------------------------------------------------
 
+
 class TestDeriveTraceStepsMultipleLoops:
     """Agent→tools→agent→tools pattern produces interleaved steps."""
 
     def test_interleaved_order(self):
         agent1 = _make_run(
-            id="agent-1", name="agent", run_type="chain",
-            parent_run_id="root", dotted_order="1.1",
+            id="agent-1",
+            name="agent",
+            run_type="chain",
+            parent_run_id="root",
+            dotted_order="1.1",
             outputs={"content": "Let me search"},
         )
         tools_wrapper1 = _make_run(
-            id="tools-w1", name="tools", run_type="chain",
-            parent_run_id="root", dotted_order="1.2",
+            id="tools-w1",
+            name="tools",
+            run_type="chain",
+            parent_run_id="root",
+            dotted_order="1.2",
         )
         agent2 = _make_run(
-            id="agent-2", name="agent", run_type="chain",
-            parent_run_id="root", dotted_order="1.3",
+            id="agent-2",
+            name="agent",
+            run_type="chain",
+            parent_run_id="root",
+            dotted_order="1.3",
             outputs={"content": "Found it"},
         )
         tools_wrapper2 = _make_run(
-            id="tools-w2", name="tools", run_type="chain",
-            parent_run_id="root", dotted_order="1.4",
+            id="tools-w2",
+            name="tools",
+            run_type="chain",
+            parent_run_id="root",
+            dotted_order="1.4",
         )
         tool_child1 = _make_run(
-            id="tc1", name="search_receipts", run_type="tool",
-            parent_run_id="tools-w1", dotted_order="1.2.1",
+            id="tc1",
+            name="search_receipts",
+            run_type="tool",
+            parent_run_id="tools-w1",
+            dotted_order="1.2.1",
             inputs={"query": "coffee"},
         )
         tool_child2 = _make_run(
-            id="tc2", name="get_receipt", run_type="tool",
-            parent_run_id="tools-w2", dotted_order="1.4.1",
+            id="tc2",
+            name="get_receipt",
+            run_type="tool",
+            parent_run_id="tools-w2",
+            dotted_order="1.4.1",
             inputs={"id": "r1"},
         )
 
@@ -220,6 +241,7 @@ class TestDeriveTraceStepsMultipleLoops:
 # Test: _classify_run unchanged for existing types
 # ---------------------------------------------------------------------------
 
+
 class TestClassifyRunUnchanged:
     @pytest.mark.parametrize(
         "name,run_type,expected",
@@ -242,24 +264,37 @@ class TestClassifyRunUnchanged:
 # Test: build_question_cache includes tool steps end-to-end
 # ---------------------------------------------------------------------------
 
+
 class TestBuildQuestionCacheIncludesToolSteps:
     def test_tool_steps_in_trace(self):
         _make_run(
-            id="root-1", name="qa_graph", run_type="chain",
-            is_root=True, dotted_order="1",
+            id="root-1",
+            name="qa_graph",
+            run_type="chain",
+            is_root=True,
+            dotted_order="1",
         )
         agent = _make_run(
-            id="agent-1", name="agent", run_type="chain",
-            parent_run_id="root-1", dotted_order="1.1",
+            id="agent-1",
+            name="agent",
+            run_type="chain",
+            parent_run_id="root-1",
+            dotted_order="1.1",
             outputs={"content": "reasoning"},
         )
         tools_wrapper = _make_run(
-            id="tools-w", name="tools", run_type="chain",
-            parent_run_id="root-1", dotted_order="1.2",
+            id="tools-w",
+            name="tools",
+            run_type="chain",
+            parent_run_id="root-1",
+            dotted_order="1.2",
         )
         tool_run = _make_run(
-            id="tool-1", name="search_receipts", run_type="tool",
-            parent_run_id="tools-w", dotted_order="1.2.1",
+            id="tool-1",
+            name="search_receipts",
+            run_type="tool",
+            parent_run_id="tools-w",
+            dotted_order="1.2.1",
             inputs={"query": "groceries"},
         )
 
@@ -289,6 +324,7 @@ class TestBuildQuestionCacheIncludesToolSteps:
 # ---------------------------------------------------------------------------
 # Test: compute_stats still counts depth-2 tools correctly
 # ---------------------------------------------------------------------------
+
 
 class TestComputeStatsStillCorrect:
     def test_tool_invocations_count_depth2(self):
@@ -359,7 +395,10 @@ class _FakeDataFrame:
 
     def select(self, *columns: str) -> "_FakeDataFrame":
         return _FakeDataFrame(
-            [{column: row.get(column) for column in columns} for row in self._rows]
+            [
+                {column: row.get(column) for column in columns}
+                for row in self._rows
+            ]
         )
 
     def toLocalIterator(self):
@@ -408,7 +447,9 @@ def test_read_parquet_traces_retries_with_recursive(monkeypatch):
 
     reader = _FakeReader(fail_plain=True, fail_recursive=False)
     spark = _FakeSparkSession(reader)
-    monkeypatch.setattr(qa_helpers, "AnalysisException", _FakeAnalysisException)
+    monkeypatch.setattr(
+        qa_helpers, "AnalysisException", _FakeAnalysisException
+    )
 
     result = qa_helpers.read_parquet_traces(spark, "s3://bucket/traces/")
 
@@ -424,7 +465,9 @@ def test_read_parquet_traces_returns_none_when_both_reads_fail(monkeypatch):
 
     reader = _FakeReader(fail_plain=True, fail_recursive=True)
     spark = _FakeSparkSession(reader)
-    monkeypatch.setattr(qa_helpers, "AnalysisException", _FakeAnalysisException)
+    monkeypatch.setattr(
+        qa_helpers, "AnalysisException", _FakeAnalysisException
+    )
 
     result = qa_helpers.read_parquet_traces(spark, "s3://bucket/traces/")
 
@@ -438,8 +481,18 @@ def test_collect_root_runs_filters_non_root_rows(monkeypatch):
     monkeypatch.setattr(qa_helpers, "F", _FakeFunctions())
     df = _FakeDataFrame(
         [
-            {"trace_id": "trace-1", "id": "root-1", "inputs": "{}", "is_root": True},
-            {"trace_id": "trace-2", "id": "child-1", "inputs": "{}", "is_root": False},
+            {
+                "trace_id": "trace-1",
+                "id": "root-1",
+                "inputs": "{}",
+                "is_root": True,
+            },
+            {
+                "trace_id": "trace-2",
+                "id": "child-1",
+                "inputs": "{}",
+                "is_root": False,
+            },
         ]
     )
 
@@ -502,12 +555,24 @@ def test_collect_root_runs_enforces_hard_limit(monkeypatch):
     monkeypatch.setattr(qa_helpers, "QA_DRIVER_ROOT_HARD_LIMIT", 1)
     df = _FakeDataFrame(
         [
-            {"trace_id": "trace-1", "id": "root-1", "inputs": "{}", "is_root": True},
-            {"trace_id": "trace-2", "id": "root-2", "inputs": "{}", "is_root": True},
+            {
+                "trace_id": "trace-1",
+                "id": "root-1",
+                "inputs": "{}",
+                "is_root": True,
+            },
+            {
+                "trace_id": "trace-2",
+                "id": "root-2",
+                "inputs": "{}",
+                "is_root": True,
+            },
         ]
     )
 
-    with pytest.raises(RuntimeError, match="root runs driver collection exceeded"):
+    with pytest.raises(
+        RuntimeError, match="root runs driver collection exceeded"
+    ):
         qa_helpers.collect_root_runs(df)
 
 
@@ -551,5 +616,7 @@ def test_collect_traces_enforces_hard_limit(monkeypatch):
         ]
     )
 
-    with pytest.raises(RuntimeError, match="trace rows driver collection exceeded"):
+    with pytest.raises(
+        RuntimeError, match="trace rows driver collection exceeded"
+    ):
         qa_helpers.collect_traces(df)

--- a/receipt_langsmith/tests/spark/test_trace_df.py
+++ b/receipt_langsmith/tests/spark/test_trace_df.py
@@ -55,7 +55,9 @@ def test_read_parquet_df_retries_with_recursive_lookup(monkeypatch):
 
     reader = _FakeReader(fail_plain=True)
     spark = _FakeSparkSession(reader)
-    monkeypatch.setattr(trace_df_mod, "AnalysisException", _FakeAnalysisException)
+    monkeypatch.setattr(
+        trace_df_mod, "AnalysisException", _FakeAnalysisException
+    )
     monkeypatch.setattr(
         trace_df_mod,
         "normalize_trace_df",
@@ -82,7 +84,9 @@ def test_read_parquet_df_uses_standard_read_when_available(monkeypatch):
 
     reader = _FakeReader(fail_plain=False)
     spark = _FakeSparkSession(reader)
-    monkeypatch.setattr(trace_df_mod, "AnalysisException", _FakeAnalysisException)
+    monkeypatch.setattr(
+        trace_df_mod, "AnalysisException", _FakeAnalysisException
+    )
     monkeypatch.setattr(
         trace_df_mod,
         "normalize_trace_df",


### PR DESCRIPTION
## Summary

receipt_langsmith was the only Python package with no CI job — which is exactly how two of its spark tests rotted and its formatting drifted from the repo-wide pins. This adds it to the `python-tests` matrix and fixes everything needed to make the job green:

- **Matrix + install case**: standalone package (no receipt_dynamo dependency); `[pyspark,dev]` extras cover `tests/spark`
- **Test rot fix 1** — `test_diff_cache_accepts_preloaded_rows`: fixture used the legacy `currency_evaluation` span name, which #860 dropped from the diff cache; `metadata_evaluation` is the current words+decisions source
- **Test rot fix 2** — `test_load_unified_rows_uses_multiline_reader`: `F.lit(None)` asserts a live SparkContext; stub it so the missing-column backfill path runs against the fake DataFrame without a JVM
- **Extras**: add pytest-cov/xdist/timeout/rerunfailures to `dev` (CI's pytest command needs them) and a `lint` extra (CI's lint step installs it)
- **Version alignment**: black/isort to the repo-wide `26.5.1`/`8.0.1` (were `26.1.0`/`8.0.0`), reformatting the 18 files that had drifted

The 40 skipped tests are data-dependent (require local parquet traces at `/tmp/langsmith-traces/`) and skip cleanly in CI.

## Test plan

- [x] Full local simulation of the CI job (fresh venv, identical install/lint/pytest commands): black/isort clean, **69 passed, 40 skipped**, coverage.xml written
- [x] The new `Python (receipt_langsmith)` job runs on this very PR — green check below is the proof

🤖 Generated with [Claude Code](https://claude.com/claude-code)