### PR TITLE
fix(iam): grant OCR processor role s3:ListBucket on the image bucket

### DIFF
--- a/infra/upload_images/infra.py
+++ b/infra/upload_images/infra.py
@@ -348,6 +348,21 @@ class UploadImages(ComponentResource):
                                         else []
                                     ),
                                 },
+                                {
+                                    # Explicit read access on the image
+                                    # bucket so a GetObject on a missing key
+                                    # returns a clean 404 instead of
+                                    # AccessDenied (requires s3:ListBucket).
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "s3:GetObject",
+                                        "s3:ListBucket",
+                                    ],
+                                    "Resource": [
+                                        args[3],  # image_bucket
+                                        args[3] + "/*",  # image_bucket/*
+                                    ],
+                                },
                             ]
                             + (
                                 [


### PR DESCRIPTION
## Why

Follow-up to #941. The OCR processor Lambda role (`upload-images-process-ocr-role-5afe492`) could `GetObject` existing objects in the image bucket but lacked **`s3:ListBucket`**. Without `ListBucket`, S3 returns **`AccessDenied`** for a *missing* key instead of a clean **404** — which is exactly what masked the "warped crop not found" condition in the blank-image incident (the error read `AccessDenied … s3:ListBucket` when the object was simply absent).

## Change

One least-privilege `Allow` statement added to the existing `process-ocr-dynamo-policy` RolePolicy in `infra/upload_images/infra.py`:
- Actions: `s3:GetObject`, `s3:ListBucket` (read-only)
- Resource: the image bucket ARN (for `ListBucket`) and `…/*` (for `GetObject`)
- Scoped to that one bucket and one role; no write/delete/wildcard.

After this, a missing crop surfaces as a 404 the handler can distinguish, instead of an opaque `AccessDenied`.

## Verification
- [x] `ast.parse` of the edited module passes.
- [x] `pulumi preview -s tnorlund/portfolio/dev --diff` shows the only IAM change is on `upload-images-process-ocr-dynamo-policy`, adding the `s3:GetObject`/`s3:ListBucket` statement on the image bucket. (Other resources in the preview are pre-existing drift, unrelated.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)