### PR TITLE
fix(merchant-resolution): corroboration guard + persist place confidence

### DIFF
--- a/receipt_upload/receipt_upload/merchant_resolution/embedding_processor.py
+++ b/receipt_upload/receipt_upload/merchant_resolution/embedding_processor.py
@@ -302,7 +302,9 @@ def _run_lines_pipeline_worker(
             log = logging.getLogger(__name__)
 
             # Get project name to ensure child traces go to same project
-            project = os.environ.get("LANGCHAIN_PROJECT", "receipt-label-validation")
+            project = os.environ.get(
+                "LANGCHAIN_PROJECT", "receipt-label-validation"
+            )
             log.info(
                 "[LINES_WORKER] Setting up tracing: project=%s, headers=%s",
                 project,
@@ -439,10 +441,13 @@ def _run_words_pipeline_worker(
                             # Update the label object with validation results
                             label.validation_status = (
                                 ValidationStatus.VALID.value
-                                if result.decision == ValidationDecision.AUTO_VALIDATE
+                                if result.decision
+                                == ValidationDecision.AUTO_VALIDATE
                                 else ValidationStatus.INVALID.value
                             )
-                            label.label_proposed_by = f"chroma_{result.decision.value}"
+                            label.label_proposed_by = (
+                                f"chroma_{result.decision.value}"
+                            )
                             dynamo.update_receipt_word_label(label)
                             chroma_validated += 1
                         else:
@@ -476,8 +481,16 @@ def _run_words_pipeline_worker(
                     # Build words context for LLM
                     llm_words_context = []
                     for w in words:
-                        x_center = (w.x_min + w.x_max) / 2 if hasattr(w, "x_min") else 0
-                        y_center = (w.y_min + w.y_max) / 2 if hasattr(w, "y_min") else 0
+                        x_center = (
+                            (w.x_min + w.x_max) / 2
+                            if hasattr(w, "x_min")
+                            else 0
+                        )
+                        y_center = (
+                            (w.y_min + w.y_max) / 2
+                            if hasattr(w, "y_min")
+                            else 0
+                        )
                         llm_words_context.append(
                             {
                                 "text": w.text,
@@ -513,13 +526,11 @@ def _run_words_pipeline_worker(
                                 (label.line_id, label.word_id)
                             )
                             if embedding:
-                                similar = (
-                                    lightweight_validator._query_similar_for_label(
-                                        embedding=embedding,
-                                        exclude_id=chroma_id,
-                                        predicted_label=label.label,
-                                        n_results_per_query=5,
-                                    )
+                                similar = lightweight_validator._query_similar_for_label(
+                                    embedding=embedding,
+                                    exclude_id=chroma_id,
+                                    predicted_label=label.label,
+                                    n_results_per_query=5,
                                 )
                                 similar_evidence[word_id_str] = similar
                             else:
@@ -529,7 +540,9 @@ def _run_words_pipeline_worker(
 
                     # Call LLM validator
                     try:
-                        llm_validator = LLMBatchValidator(temperature=0.0, timeout=120)
+                        llm_validator = LLMBatchValidator(
+                            temperature=0.0, timeout=120
+                        )
                         llm_results = llm_validator.validate_receipt_labels(
                             pending_labels=pending_labels_data,
                             words=llm_words_context,
@@ -561,7 +574,9 @@ def _run_words_pipeline_worker(
                                     label.validation_status = (
                                         ValidationStatus.NEEDS_REVIEW.value
                                     )
-                                    label.label_proposed_by = "llm_needs_review"
+                                    label.label_proposed_by = (
+                                        "llm_needs_review"
+                                    )
                                     if llm_result.reasoning:
                                         label.reasoning = llm_result.reasoning
                                     dynamo.update_receipt_word_label(label)
@@ -594,12 +609,16 @@ def _run_words_pipeline_worker(
                                             word_id=label.word_id,
                                             label=llm_result.label,
                                             reasoning=llm_result.reasoning,
-                                            timestamp_added=datetime.now(timezone.utc),
+                                            timestamp_added=datetime.now(
+                                                timezone.utc
+                                            ),
                                             validation_status=ValidationStatus.VALID.value,
                                             label_proposed_by=f"llm_corrected:{label.label}",
                                             label_consolidated_from=label.label,
                                         )
-                                        dynamo.add_receipt_word_label(new_label)
+                                        dynamo.add_receipt_word_label(
+                                            new_label
+                                        )
                                         llm_validated += 1
                                     else:
                                         # LLM returned invalid label (AMOUNT, TIP, etc.)
@@ -607,7 +626,9 @@ def _run_words_pipeline_worker(
                                         label.validation_status = (
                                             ValidationStatus.NEEDS_REVIEW.value
                                         )
-                                        label.label_proposed_by = "llm_invalid_label"
+                                        label.label_proposed_by = (
+                                            "llm_invalid_label"
+                                        )
                                         label.reasoning = (
                                             f"LLM suggested '{llm_result.label}' but it's not "
                                             f"a valid CORE_LABEL. {llm_result.reasoning or ''}"
@@ -681,7 +702,9 @@ def _run_words_pipeline_worker(
             log = logging.getLogger(__name__)
 
             # Get project name to ensure child traces go to same project
-            project = os.environ.get("LANGCHAIN_PROJECT", "receipt-label-validation")
+            project = os.environ.get(
+                "LANGCHAIN_PROJECT", "receipt-label-validation"
+            )
             log.info(
                 "[WORDS_WORKER] Setting up tracing: project=%s, headers=%s",
                 project,
@@ -750,7 +773,9 @@ class MerchantResolvingEmbeddingProcessor:
             try:
                 from receipt_places import PlacesClient
 
-                self.places_client = PlacesClient(api_key=google_places_api_key)
+                self.places_client = PlacesClient(
+                    api_key=google_places_api_key
+                )
             except ImportError:
                 _log("WARNING: receipt_places not available")
 
@@ -837,9 +862,15 @@ class MerchantResolvingEmbeddingProcessor:
         """
         # Fetch lines/words if not provided
         if lines is None or words is None:
-            lines = self.dynamo.list_receipt_lines_from_receipt(image_id, receipt_id)
-            words = self.dynamo.list_receipt_words_from_receipt(image_id, receipt_id)
-            _log(f"Fetched {len(lines)} lines and {len(words)} words from DynamoDB")
+            lines = self.dynamo.list_receipt_lines_from_receipt(
+                image_id, receipt_id
+            )
+            words = self.dynamo.list_receipt_words_from_receipt(
+                image_id, receipt_id
+            )
+            _log(
+                f"Fetched {len(lines)} lines and {len(words)} words from DynamoDB"
+            )
         else:
             _log(f"Using provided {len(lines)} lines and {len(words)} words")
 
@@ -873,7 +904,9 @@ class MerchantResolvingEmbeddingProcessor:
             from openai import OpenAI
 
             openai_client = OpenAI()
-            model = os.environ.get("OPENAI_EMBEDDING_MODEL", "text-embedding-3-small")
+            model = os.environ.get(
+                "OPENAI_EMBEDDING_MODEL", "text-embedding-3-small"
+            )
 
             (
                 local_lines_dir,
@@ -956,7 +989,9 @@ class MerchantResolvingEmbeddingProcessor:
             executor_class = _get_phase2_executor_class()
             executor_name = executor_class.__name__
             with executor_class(max_workers=2) as executor:
-                _log(f"Submitting lines and words pipelines to {executor_name}")
+                _log(
+                    f"Submitting lines and words pipelines to {executor_name}"
+                )
 
                 lines_future = executor.submit(
                     _run_lines_pipeline_worker,
@@ -1016,9 +1051,15 @@ class MerchantResolvingEmbeddingProcessor:
                                     receipt_id=m["receipt_id"],
                                     merchant_name=m.get("merchant_name"),
                                     normalized_phone=m.get("normalized_phone"),
-                                    normalized_address=m.get("normalized_address"),
-                                    embedding_similarity=m["embedding_similarity"],
-                                    metadata_boost=m.get("metadata_boost", 0.0),
+                                    normalized_address=m.get(
+                                        "normalized_address"
+                                    ),
+                                    embedding_similarity=m[
+                                        "embedding_similarity"
+                                    ],
+                                    metadata_boost=m.get(
+                                        "metadata_boost", 0.0
+                                    ),
                                     place_id=m.get("place_id"),
                                 )
                                 for m in lines_result["similarity_matches"]
@@ -1027,12 +1068,18 @@ class MerchantResolvingEmbeddingProcessor:
                         merchant_result = MerchantResult(
                             merchant_name=lines_result.get("merchant_name"),
                             place_id=lines_result.get("place_id"),
-                            resolution_tier=lines_result.get("resolution_tier"),
+                            resolution_tier=lines_result.get(
+                                "resolution_tier"
+                            ),
                             confidence=lines_result.get("confidence"),
                             phone=lines_result.get("phone"),
                             address=lines_result.get("address"),
-                            source_image_id=lines_result.get("source_image_id"),
-                            source_receipt_id=lines_result.get("source_receipt_id"),
+                            source_image_id=lines_result.get(
+                                "source_image_id"
+                            ),
+                            source_receipt_id=lines_result.get(
+                                "source_receipt_id"
+                            ),
                             similarity_matches=similarity_matches,
                         )
                 except Exception as e:
@@ -1072,7 +1119,9 @@ class MerchantResolvingEmbeddingProcessor:
                 )
                 _log(f"Phase 3 complete: created compaction run {run_id}")
             else:
-                _log("WARNING: Skipping compaction run - missing delta prefixes")
+                _log(
+                    "WARNING: Skipping compaction run - missing delta prefixes"
+                )
                 compaction_run = None
 
             # =================================================================
@@ -1192,7 +1241,9 @@ class MerchantResolvingEmbeddingProcessor:
 
                 if merchant_result.merchant_name:
                     if not place.merchant_name:
-                        updates["merchant_name"] = merchant_result.merchant_name
+                        updates["merchant_name"] = (
+                            merchant_result.merchant_name
+                        )
 
                 if merchant_result.address:
                     if not place.formatted_address:
@@ -1216,6 +1267,21 @@ class MerchantResolvingEmbeddingProcessor:
                 if merchant_result.place_id and merchant_result.merchant_name:
                     from receipt_dynamo.entities import ReceiptPlace
 
+                    # Persist the resolver's match-quality signals. These
+                    # were historically dropped, so every chroma-resolved
+                    # place was stored with confidence=0.0 / empty status,
+                    # making low-confidence places impossible to filter or
+                    # audit later.
+                    confidence = merchant_result.confidence or 0.0
+                    matched_fields = [
+                        name
+                        for name, value in (
+                            ("merchant_name", merchant_result.merchant_name),
+                            ("phone", merchant_result.phone),
+                            ("address", merchant_result.address),
+                        )
+                        if value
+                    ]
                     new_place = ReceiptPlace(
                         image_id=image_id,
                         receipt_id=receipt_id,
@@ -1223,9 +1289,16 @@ class MerchantResolvingEmbeddingProcessor:
                         merchant_name=merchant_result.merchant_name,
                         formatted_address=merchant_result.address or "",
                         phone_number=merchant_result.phone or "",
+                        confidence=confidence,
+                        validation_status=(
+                            "MATCHED" if confidence >= 0.8 else "UNSURE"
+                        ),
+                        matched_fields=matched_fields,
                     )
                     self.dynamo.add_receipt_place(new_place)
-                    _log(f"Created new receipt place for {image_id}#{receipt_id}")
+                    _log(
+                        f"Created new receipt place for {image_id}#{receipt_id}"
+                    )
                 elif merchant_result.place_id:
                     # Have place_id but no merchant_name - log for debugging
                     # This can happen when ChromaDB matches don't have merchant_name
@@ -1287,7 +1360,8 @@ class MerchantResolvingEmbeddingProcessor:
             label
             for label in word_labels
             if label.validation_status == ValidationStatus.PENDING.value
-            and label.label != "O"  # Skip "O" labels - they're background/no-label
+            and label.label
+            != "O"  # Skip "O" labels - they're background/no-label
         ]
 
         # Count "O" labels for logging
@@ -1380,9 +1454,7 @@ class MerchantResolvingEmbeddingProcessor:
                 elif result.decision == ValidationDecision.AUTO_INVALID:
                     # Strong evidence AGAINST the prediction - mark as invalid
                     label.validation_status = ValidationStatus.INVALID.value
-                    label.label_proposed_by = (
-                        f"chroma-invalidated:{label.label_proposed_by or 'auto'}"
-                    )
+                    label.label_proposed_by = f"chroma-invalidated:{label.label_proposed_by or 'auto'}"
                     label.reasoning = result.reason
                     self.dynamo.update_receipt_word_label(label)
 
@@ -1451,7 +1523,9 @@ class MerchantResolvingEmbeddingProcessor:
 
         # Create lookup for chroma results (for labels that had NEEDS_REVIEW)
         chroma_results_lookup = {
-            (item["label"].line_id, item["label"].word_id): item["chroma_result"]
+            (item["label"].line_id, item["label"].word_id): item[
+                "chroma_result"
+            ]
             for item in chroma_needs_review
         }
 
@@ -1523,7 +1597,9 @@ class MerchantResolvingEmbeddingProcessor:
                 else:
                     similar_evidence[word_id_str] = []
             except Exception as e:
-                _log(f"WARNING: Failed to get similar words for {word_id_str}: {e}")
+                _log(
+                    f"WARNING: Failed to get similar words for {word_id_str}: {e}"
+                )
                 similar_evidence[word_id_str] = []
 
         # Call LLM to validate remaining labels
@@ -1565,7 +1641,9 @@ class MerchantResolvingEmbeddingProcessor:
             try:
                 # Map LLM confidence to numeric value
                 confidence_map = {"high": 0.9, "medium": 0.7, "low": 0.5}
-                confidence_score = confidence_map.get(llm_result.confidence, 0.7)
+                confidence_score = confidence_map.get(
+                    llm_result.confidence, 0.7
+                )
 
                 # Normalize decision: CORRECT/CORRECTED -> INVALID
                 decision = llm_result.decision.upper()
@@ -1595,10 +1673,10 @@ class MerchantResolvingEmbeddingProcessor:
 
                 if decision == "VALID":
                     # Keep original label, mark as validated
-                    label_entity.validation_status = ValidationStatus.VALID.value
-                    label_entity.label_proposed_by = (
-                        f"llm-validated:{label_entity.label_proposed_by or 'auto'}"
+                    label_entity.validation_status = (
+                        ValidationStatus.VALID.value
                     )
+                    label_entity.label_proposed_by = f"llm-validated:{label_entity.label_proposed_by or 'auto'}"
                     label_entity.reasoning = llm_result.reasoning
                     self.dynamo.update_receipt_word_label(label_entity)
                     validated_count += 1
@@ -1624,10 +1702,10 @@ class MerchantResolvingEmbeddingProcessor:
 
                 elif decision == "NEEDS_REVIEW":
                     # LLM couldn't decide - mark for human review
-                    label_entity.validation_status = ValidationStatus.NEEDS_REVIEW.value
-                    label_entity.label_proposed_by = (
-                        f"llm-needs-review:{label_entity.label_proposed_by or 'auto'}"
+                    label_entity.validation_status = (
+                        ValidationStatus.NEEDS_REVIEW.value
                     )
+                    label_entity.label_proposed_by = f"llm-needs-review:{label_entity.label_proposed_by or 'auto'}"
                     label_entity.reasoning = llm_result.reasoning
                     self.dynamo.update_receipt_word_label(label_entity)
 
@@ -1661,7 +1739,9 @@ class MerchantResolvingEmbeddingProcessor:
                         from datetime import datetime, timezone
 
                         # 1. Mark old label as INVALID (audit trail)
-                        label_entity.validation_status = ValidationStatus.INVALID.value
+                        label_entity.validation_status = (
+                            ValidationStatus.INVALID.value
+                        )
                         label_entity.reasoning = (
                             f"Invalidated by LLM - corrected to {llm_result.label}. "
                             f"{llm_result.reasoning}"
@@ -1708,10 +1788,10 @@ class MerchantResolvingEmbeddingProcessor:
                         )
                     else:
                         # Same label, just validate it
-                        label_entity.validation_status = ValidationStatus.VALID.value
-                        label_entity.label_proposed_by = (
-                            f"llm-validated:{label_entity.label_proposed_by or 'auto'}"
+                        label_entity.validation_status = (
+                            ValidationStatus.VALID.value
                         )
+                        label_entity.label_proposed_by = f"llm-validated:{label_entity.label_proposed_by or 'auto'}"
                         label_entity.reasoning = llm_result.reasoning
                         self.dynamo.update_receipt_word_label(label_entity)
                         validated_count += 1
@@ -1736,13 +1816,11 @@ class MerchantResolvingEmbeddingProcessor:
                         )
 
                 else:
-                    label_entity.validation_status = ValidationStatus.NEEDS_REVIEW.value
-                    label_entity.label_proposed_by = (
-                        f"llm-needs-review:{label_entity.label_proposed_by or 'auto'}"
+                    label_entity.validation_status = (
+                        ValidationStatus.NEEDS_REVIEW.value
                     )
-                    label_entity.reasoning = (
-                        f"Unrecognized decision '{decision}'. {llm_result.reasoning}"
-                    )
+                    label_entity.label_proposed_by = f"llm-needs-review:{label_entity.label_proposed_by or 'auto'}"
+                    label_entity.reasoning = f"Unrecognized decision '{decision}'. {llm_result.reasoning}"
                     self.dynamo.update_receipt_word_label(label_entity)
 
                     log_label_validation(

--- a/receipt_upload/receipt_upload/merchant_resolution/resolver.py
+++ b/receipt_upload/receipt_upload/merchant_resolution/resolver.py
@@ -115,8 +115,10 @@ def merchant_name_matches_receipt(
         return True  # No receipt text to validate against
 
     # Build a token set from the top N receipt lines (by y-coordinate)
-    sorted_lines = sorted(lines, key=lambda l: l.calculate_centroid()[1])
-    receipt_text = " ".join(l.text for l in sorted_lines[:n_lines] if l.text)
+    sorted_lines = sorted(lines, key=lambda line: line.calculate_centroid()[1])
+    receipt_text = " ".join(
+        line.text for line in sorted_lines[:n_lines] if line.text
+    )
     receipt_tokens = tokenize_text(receipt_text)
 
     return bool(merchant_tokens & receipt_tokens)
@@ -464,7 +466,9 @@ class MerchantResolver:
         if not lines:
             return None
         # Sort by y-coordinate (top to bottom) and return first
-        sorted_lines = sorted(lines, key=lambda l: l.calculate_centroid()[1])
+        sorted_lines = sorted(
+            lines, key=lambda line: line.calculate_centroid()[1]
+        )
         return sorted_lines[0] if sorted_lines else None
 
     def _similarity_search(

--- a/receipt_upload/receipt_upload/merchant_resolution/resolver.py
+++ b/receipt_upload/receipt_upload/merchant_resolution/resolver.py
@@ -115,12 +115,8 @@ def merchant_name_matches_receipt(
         return True  # No receipt text to validate against
 
     # Build a token set from the top N receipt lines (by y-coordinate)
-    sorted_lines = sorted(
-        lines, key=lambda l: l.calculate_centroid()[1]
-    )
-    receipt_text = " ".join(
-        l.text for l in sorted_lines[:n_lines] if l.text
-    )
+    sorted_lines = sorted(lines, key=lambda l: l.calculate_centroid()[1])
+    receipt_text = " ".join(l.text for l in sorted_lines[:n_lines] if l.text)
     receipt_tokens = tokenize_text(receipt_text)
 
     return bool(merchant_tokens & receipt_tokens)
@@ -382,9 +378,18 @@ class MerchantResolver:
                 expected_address=address,
                 resolution_tier="chroma_text",
             )
+            # chroma_text is the weakest signal: it matches on the
+            # merchant-name line alone, with no corroborating identifier
+            # (unlike the phone/address tiers). A mid-band embedding neighbor
+            # can therefore be wrong -- e.g. a brand-new merchant landing
+            # ~0.79 from an unrelated one ("Poke Market" -> "Jamba").
+            # result.confidence already includes PHONE/ADDRESS_MATCH_BOOST,
+            # so require HIGH_CONFIDENCE_THRESHOLD: accept only when the text
+            # match is strong on its own OR metadata corroborates it;
+            # otherwise fall through to the Google Places tier.
             if (
                 result.place_id
-                and result.confidence >= MIN_SIMILARITY_THRESHOLD
+                and result.confidence >= HIGH_CONFIDENCE_THRESHOLD
             ):
                 _log(
                     "Tier 1 SUCCESS (merchant): %s (place_id=%s, conf=%.2f)",
@@ -393,6 +398,14 @@ class MerchantResolver:
                     result.confidence,
                 )
                 return result
+            if result.place_id:
+                _log(
+                    "Tier 1 chroma_text below corroboration bar "
+                    "(%s conf=%.2f < %.2f); deferring to Tier 2",
+                    result.merchant_name,
+                    result.confidence,
+                    HIGH_CONFIDENCE_THRESHOLD,
+                )
 
         # Tier 2: Fall back to Place ID Finder agent (Google Places API)
         _log("Tier 1 failed, invoking Tier 2: Place ID Finder agent")
@@ -658,10 +671,7 @@ class MerchantResolver:
                     # Prefer DynamoDB merchant_name (authoritative, may be
                     # corrected via fix-place) over ChromaDB metadata which
                     # can be stale/poisoned.
-                    merchant_name = (
-                        dynamo_merchant_name
-                        or match.merchant_name
-                    )
+                    merchant_name = dynamo_merchant_name or match.merchant_name
                     return MerchantResult(
                         place_id=place_id,
                         merchant_name=merchant_name,
@@ -806,7 +816,9 @@ class MerchantResolver:
             place = self.dynamo.get_receipt_place(image_id, receipt_id)
             if place and place.place_id:
                 if place.place_id not in INVALID_PLACE_IDS:
-                    return place.place_id, getattr(place, "merchant_name", None)
+                    return place.place_id, getattr(
+                        place, "merchant_name", None
+                    )
         except Exception as exc:  # pylint: disable=broad-exception-caught
             _log("Error getting place from receipt_place: %s", exc)
             logger.exception("DynamoDB lookup failed")

--- a/receipt_upload/test/test_merchant_embedding_processor.py
+++ b/receipt_upload/test/test_merchant_embedding_processor.py
@@ -558,3 +558,60 @@ class TestMerchantResolvingEmbeddingProcessorInit:
             os.environ.get("CHROMADB_WORDS_QUEUE_URL")
             == "https://sqs.us-east-1.amazonaws.com/words"
         )
+
+
+class TestEnrichReceiptPlacePersistsConfidence:
+    """New ReceiptPlace records must persist the resolver's match-quality
+    signals (confidence / validation_status / matched_fields), not drop them
+    to defaults (the bug that stored every chroma place as confidence=0.0)."""
+
+    @pytest.fixture
+    def mock_dynamo_client(self):
+        with patch(
+            "receipt_upload.merchant_resolution.embedding_processor.DynamoClient"
+        ) as MockDynamo:
+            client = MagicMock()
+            MockDynamo.return_value = client
+            yield client
+
+    def _create_place(self, mock_dynamo_client, confidence):
+        # No existing place -> exercises the create path.
+        mock_dynamo_client.get_receipt_place.return_value = None
+        with patch(
+            "receipt_upload.merchant_resolution.embedding_processor.boto3"
+        ):
+            processor = MerchantResolvingEmbeddingProcessor(
+                table_name="test-table",
+                chromadb_bucket="test-bucket",
+            )
+            processor._enrich_receipt_place(
+                image_id="550e8400-e29b-41d4-a716-446655440000",
+                receipt_id=1,
+                merchant_result=MerchantResult(
+                    place_id="ChIJ_poke",
+                    merchant_name="Poke Market",
+                    address="6815 Tom Rodriguez St, Las Vegas, NV 89113",
+                    phone=None,
+                    confidence=confidence,
+                    resolution_tier="chroma_text",
+                ),
+            )
+        mock_dynamo_client.add_receipt_place.assert_called_once()
+        return mock_dynamo_client.add_receipt_place.call_args[0][0]
+
+    def test_create_persists_confidence_and_matched_fields(
+        self, mock_dynamo_client
+    ):
+        place = self._create_place(mock_dynamo_client, confidence=0.79)
+        assert place.confidence == 0.79
+        # 0.79 < 0.8 -> UNSURE (mirrors fix-place lambda semantics)
+        assert place.validation_status == "UNSURE"
+        # phone was None, so only name + address are recorded
+        assert "merchant_name" in place.matched_fields
+        assert "address" in place.matched_fields
+        assert "phone" not in place.matched_fields
+
+    def test_create_high_confidence_is_matched(self, mock_dynamo_client):
+        place = self._create_place(mock_dynamo_client, confidence=0.9)
+        assert place.confidence == 0.9
+        assert place.validation_status == "MATCHED"

--- a/receipt_upload/test/test_merchant_resolver.py
+++ b/receipt_upload/test/test_merchant_resolver.py
@@ -57,7 +57,9 @@ class TestMerchantResolverTier1Phone:
                 extracted_data={"type": "phone", "value": "5551234567"},
             )
         ]
-        mock_line = MagicMock(spec=ReceiptLine, line_id=1, text="Matching Store")
+        mock_line = MagicMock(
+            spec=ReceiptLine, line_id=1, text="Matching Store"
+        )
         mock_line.calculate_centroid.return_value = (0.5, 0.1)
         lines = [mock_line]
 
@@ -896,9 +898,7 @@ class TestGetPlaceFromDynamo:
         mock_place.merchant_name = "Corrected Name"
         mock_dynamo_client.get_receipt_place.return_value = mock_place
 
-        place_id, merchant_name = resolver._get_place_from_dynamo(
-            "img-1", 1
-        )
+        place_id, merchant_name = resolver._get_place_from_dynamo("img-1", 1)
 
         assert place_id == "ChIJ_test"
         assert merchant_name == "Corrected Name"
@@ -912,9 +912,7 @@ class TestGetPlaceFromDynamo:
         mock_place.merchant_name = None
         mock_dynamo_client.get_receipt_place.return_value = mock_place
 
-        place_id, merchant_name = resolver._get_place_from_dynamo(
-            "img-1", 1
-        )
+        place_id, merchant_name = resolver._get_place_from_dynamo("img-1", 1)
 
         assert place_id == "ChIJ_test"
         assert merchant_name is None
@@ -928,9 +926,7 @@ class TestGetPlaceFromDynamo:
         mock_place.merchant_name = "Some Name"
         mock_dynamo_client.get_receipt_place.return_value = mock_place
 
-        place_id, merchant_name = resolver._get_place_from_dynamo(
-            "img-1", 1
-        )
+        place_id, merchant_name = resolver._get_place_from_dynamo("img-1", 1)
 
         assert place_id is None
         assert merchant_name is None
@@ -1068,6 +1064,97 @@ class TestWriteTimeValidationLogic:
             self._make_line(1, "Sprouts Farmers Market", y=0.1),
             self._make_line(2, "740 N MOORPARK RD", y=0.2),
         ]
-        assert merchant_name_matches_receipt(
-            "Sprouts Farmers Market", lines
+        assert merchant_name_matches_receipt("Sprouts Farmers Market", lines)
+
+
+class TestMerchantResolverChromaTextGuard:
+    """Tier 1 chroma_text requires corroboration (HIGH_CONFIDENCE_THRESHOLD).
+
+    Regression guard for a brand-new merchant ("Poke Market") being
+    mislabeled as a 0.79 embedding neighbor ("Jamba") on a name-only match
+    with no phone and a non-matching address.
+    """
+
+    @pytest.fixture
+    def mock_dynamo_client(self):
+        return MagicMock()
+
+    @pytest.fixture
+    def mock_places_client(self):
+        return MagicMock()
+
+    @pytest.fixture
+    def mock_lines_client(self):
+        return MagicMock()
+
+    def _setup(self, mock_dynamo_client, mock_places_client):
+        resolver = MerchantResolver(
+            dynamo_client=mock_dynamo_client,
+            places_client=mock_places_client,
         )
+        words = [MagicMock(spec=ReceiptWord, line_id=1, extracted_data={})]
+        line = MagicMock(spec=ReceiptLine, line_id=1, text="POKE MARKET")
+        line.calculate_centroid.return_value = (0.5, 0.1)
+        return resolver, words, [line], {1: [0.1] * 1536}
+
+    def test_chroma_text_below_high_confidence_defers_to_tier2(
+        self, mock_dynamo_client, mock_places_client, mock_lines_client
+    ):
+        resolver, words, lines, embeds = self._setup(
+            mock_dynamo_client, mock_places_client
+        )
+        weak = MerchantResult(
+            place_id="ChIJ_jamba",
+            merchant_name="Jamba",
+            confidence=0.79,
+            resolution_tier="chroma_text",
+        )
+        tier2 = MerchantResult(
+            place_id="ChIJ_poke",
+            merchant_name="Poke Market",
+            confidence=0.9,
+            resolution_tier="place_id_finder",
+        )
+        with (
+            patch.object(resolver, "_similarity_search", return_value=weak),
+            patch.object(resolver, "_run_place_id_finder", return_value=tier2),
+        ):
+            result = resolver.resolve(
+                lines_client=mock_lines_client,
+                lines=lines,
+                words=words,
+                image_id="img",
+                receipt_id=1,
+                line_embeddings=embeds,
+            )
+        # 0.79 name-only match must NOT win; Tier 2 result is used instead.
+        assert result.place_id == "ChIJ_poke"
+        assert result.merchant_name == "Poke Market"
+        assert result.resolution_tier == "place_id_finder"
+
+    def test_chroma_text_at_high_confidence_is_accepted(
+        self, mock_dynamo_client, mock_places_client, mock_lines_client
+    ):
+        resolver, words, lines, embeds = self._setup(
+            mock_dynamo_client, mock_places_client
+        )
+        strong = MerchantResult(
+            place_id="ChIJ_strong",
+            merchant_name="Strong Match",
+            confidence=0.87,
+            resolution_tier="chroma_text",
+        )
+        with (
+            patch.object(resolver, "_similarity_search", return_value=strong),
+            patch.object(resolver, "_run_place_id_finder") as mock_tier2,
+        ):
+            result = resolver.resolve(
+                lines_client=mock_lines_client,
+                lines=lines,
+                words=words,
+                image_id="img",
+                receipt_id=1,
+                line_embeddings=embeds,
+            )
+        assert result.place_id == "ChIJ_strong"
+        mock_tier2.assert_not_called()


### PR DESCRIPTION
Hardens merchant resolution after a brand-new merchant **"Poke Market"** resolved to **"Jamba"**. Bundles the two real fixes from a full audit of the subsystem.

## Fix 1 — `chroma_text` requires corroboration (the false-positive cause)

Resolution trace:
```
[MERCHANT_RESOLVER] Resolving merchant for …#1 (phone=none, address=6815 TOM RODRIGUEZ ST STE 110 …)
[LANGSMITH] merchant resolution: …#1 — Jamba via chroma_text (conf=0.79)
```
Tier-1 has three signals — `chroma_phone`, `chroma_address`, `chroma_text` — all accepting `>= MIN_SIMILARITY_THRESHOLD` (0.70). `chroma_text` matches on the merchant-name line alone with no corroborating identifier, so a mid-band neighbor (0.70–0.85) could win. Poke Market had no phone and a non-matching address (no boost), landed 0.79 from "Jamba", and was accepted.

**Fix:** gate `chroma_text` on `HIGH_CONFIDENCE_THRESHOLD` (0.85). `result.confidence` already includes `PHONE/ADDRESS_MATCH_BOOST`, so a name-only match is accepted only when strong on its own or metadata-corroborated; otherwise it defers to Tier 2 (Google Places, which resolved this correctly at 0.9). The phone/address tiers keep 0.70 (already corroborated).

## Fix 2 — persist match-quality on created places (P1 data bug)

When `_enrich_receipt_place` **creates** a `ReceiptPlace`, it only set place_id/merchant_name/address/phone — so `confidence` defaulted to 0.0, `validation_status` to `""`, `matched_fields` to `[]`. Every chroma-resolved place was a zero-confidence stub (verified: the "Jamba" record stored 0.0 despite the resolver logging 0.79), so low-confidence places can't be filtered or audited later. Now persists `confidence`, `matched_fields`, and `validation_status` (`MATCHED` if ≥0.8 else `UNSURE`, mirroring the fix-place lambda).

## Audit conclusions (verified, NOT changed — with rationale)

- **Tier-1 → Tier-2 deferral when neighbors lack a `place_id`: working as designed.** Tier-1 borrows a place_id from a similar already-resolved receipt; with none to borrow it correctly falls to Google Places and self-heals. (Agent flagged this as a bug; returning a place_id-less match would *reintroduce* weak matches — rejected.)
- **Write-time `merchant_name`→`None` on token-mismatch: a deliberate poison-guard**, left intact.
- Noted out of scope: the `_enrich_receipt_place` **update** path calls `update_receipt_place(**kwargs)` while the data layer takes a `ReceiptPlace` entity — a separate pre-existing mismatch; and `receipt_upload` isn't in the CI matrix (7 pre-existing test failures there go unrun).

## Test plan
- [x] `TestMerchantResolverChromaTextGuard`: 0.79 defers to Tier 2; 0.87 still accepted.
- [x] `TestEnrichReceiptPlacePersistsConfidence`: created place carries confidence + matched_fields + status.
- [x] `test_merchant_resolver.py` 37 passed; new enrichment tests pass. black/isort clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)