### PR TITLE
fix: skip permanently unplaceable receipts instead of crashing ingest

### DIFF
--- a/infra/embedding_step_functions/unified_embedding/handlers/line_polling.py
+++ b/infra/embedding_step_functions/unified_embedding/handlers/line_polling.py
@@ -287,10 +287,19 @@ async def _ensure_receipt_place_async(
         )
 
         if not result.get("found"):
+            result_type = result.get("type", "agent_decided")
+            if result_type in ("agent_error", "agent_timeout"):
+                # Transient failure — raise so the Lambda fails and Step Functions retries
+                raise RuntimeError(
+                    f"Place finder failed transiently ({result_type}) for "
+                    f"{image_id}#{receipt_id}: {result.get('reasoning', '')}"
+                )
+            # agent_decided: agent ran fully and found nothing — permanently unplaceable
             logger.warning(
                 "Place finder could not identify merchant; receipt is permanently unplaceable",
                 image_id=image_id,
                 receipt_id=receipt_id,
+                reasoning=result.get("reasoning"),
             )
             return False
 

--- a/infra/embedding_step_functions/unified_embedding/handlers/line_polling.py
+++ b/infra/embedding_step_functions/unified_embedding/handlers/line_polling.py
@@ -287,16 +287,21 @@ async def _ensure_receipt_place_async(
         )
 
         if not result.get("found"):
-            raise ValueError(
-                f"Place finder could not create place for {image_id}#{receipt_id}"
+            logger.warning(
+                "Place finder could not identify merchant; receipt is permanently unplaceable",
+                image_id=image_id,
+                receipt_id=receipt_id,
             )
+            return False
 
         merchant_name = result.get("merchant_name") or ""
         if not merchant_name.strip():
-            raise ValueError(
-                "Place finder returned empty merchant_name for "
-                f"{image_id}#{receipt_id}"
+            logger.warning(
+                "Place finder returned empty merchant_name; receipt is permanently unplaceable",
+                image_id=image_id,
+                receipt_id=receipt_id,
             )
+            return False
 
         matched_fields = []
         if result.get("merchant_name"):

--- a/infra/embedding_step_functions/unified_embedding/handlers/word_polling.py
+++ b/infra/embedding_step_functions/unified_embedding/handlers/word_polling.py
@@ -83,10 +83,6 @@ get_operation_logger = utils.logging.get_operation_logger
 logger = get_operation_logger(__name__)
 
 
-class PlaceFinderError(ValueError):
-    """Raised when place finder fails to produce place data."""
-
-
 s3_client = boto3.client("s3")
 
 
@@ -400,16 +396,21 @@ async def _ensure_receipt_place_async(
         )
 
         if not result.get("found"):
-            raise PlaceFinderError(
-                f"Place finder could not create place data for {image_id}#{receipt_id}"
+            logger.warning(
+                "Place finder could not identify merchant; receipt is permanently unplaceable",
+                image_id=image_id,
+                receipt_id=receipt_id,
             )
+            return False
 
         merchant_name = result.get("merchant_name") or ""
         if not merchant_name.strip():
-            raise PlaceFinderError(
-                "Place finder returned empty merchant_name for "
-                f"{image_id}#{receipt_id}"
+            logger.warning(
+                "Place finder returned empty merchant_name; receipt is permanently unplaceable",
+                image_id=image_id,
+                receipt_id=receipt_id,
             )
+            return False
 
         matched_fields = []
         if result.get("merchant_name"):

--- a/infra/embedding_step_functions/unified_embedding/handlers/word_polling.py
+++ b/infra/embedding_step_functions/unified_embedding/handlers/word_polling.py
@@ -396,10 +396,19 @@ async def _ensure_receipt_place_async(
         )
 
         if not result.get("found"):
+            result_type = result.get("type", "agent_decided")
+            if result_type in ("agent_error", "agent_timeout"):
+                # Transient failure — raise so the Lambda fails and Step Functions retries
+                raise RuntimeError(
+                    f"Place finder failed transiently ({result_type}) for "
+                    f"{image_id}#{receipt_id}: {result.get('reasoning', '')}"
+                )
+            # agent_decided: agent ran fully and found nothing — permanently unplaceable
             logger.warning(
                 "Place finder could not identify merchant; receipt is permanently unplaceable",
                 image_id=image_id,
                 receipt_id=receipt_id,
+                reasoning=result.get("reasoning"),
             )
             return False
 

--- a/receipt_agent/receipt_agent/subagents/place_finder/graph.py
+++ b/receipt_agent/receipt_agent/subagents/place_finder/graph.py
@@ -564,9 +564,12 @@ async def run_receipt_place_finder(
                 len(result.get("fields_found", [])),
                 result.get("confidence", 0) * 100,
             )
+            # type="agent_decided" — agent ran fully and submitted its conclusion
+            result.setdefault("type", "agent_decided")
             return result
         else:
-            # Agent ended without submitting result
+            # Agent ended without calling submit_place — treat as transient
+            # (LLM may have timed out or stalled; not a definitive "not found")
             logger.warning(
                 "Agent ended without submitting place data for %s#%s",
                 image_id,
@@ -580,6 +583,7 @@ async def run_receipt_place_finder(
                 "address": None,
                 "phone_number": None,
                 "found": False,
+                "type": "agent_timeout",
                 "confidence": 0.0,
                 "reasoning": "Agent did not submit place data result",
                 "fields_found": [],
@@ -595,6 +599,7 @@ async def run_receipt_place_finder(
             "address": None,
             "phone_number": None,
             "found": False,
+            "type": "agent_error",
             "confidence": 0.0,
             "reasoning": f"Error during place finding: {e!s}",
             "fields_found": [],


### PR DESCRIPTION
## Problem

The prod embedding ingest step functions (`word-ingest-sf-prod`, `line-ingest-sf-prod`) have been broken since 2026-05-25. They crash on every execution because a small number of backlog receipts don't have a `ReceiptPlace` record and the place-finder agent can't identify their merchant.

When `run_receipt_place_finder` returned `{"found": False}` or an empty `merchant_name`, `_ensure_receipt_place_async` raised an exception. That exception propagated to `missing_places`, which then raised a `ValueError` that failed the entire step function — blocking all 89k+ PENDING embeddings including freshly-promoted prod receipts.

## Root Cause

Two distinct failure modes were treated identically:
- **Permanent** — agent definitively cannot identify the merchant (`found=False`, empty `merchant_name`)
- **Transient** — API timeout, rate limit, network error

Both caused the same exception path → `missing_places` → crash.

## Fix

In `_ensure_receipt_place_async` (both `word_polling.py` and `line_polling.py`), when the agent returns a definitive "not found" or empty merchant answer, return `False` instead of raising. The caller already maps `False → skipped_orphans`, which filters that receipt's results out of the batch and lets all other receipts proceed.

Transient failures (API errors, timeouts) still propagate as exceptions so the Lambda fails and Step Functions retries the batch.

## Why skip rather than embed with a placeholder?

`merchant_name`, `formatted_address`, and other place fields are included in the Chroma embedding metadata. An embedding without a valid merchant would produce meaningless semantic search results. Skipping is correct — the receipt stays `PENDING` in DynamoDB until a place can be manually provided via `fix_place`.

## Behavior after this fix

| Scenario | Before | After |
|---|---|---|
| Agent says `found=False` | Crash entire step function | Skip this receipt, process all others |
| Agent returns empty merchant | Crash entire step function | Skip this receipt, process all others |
| API timeout / rate limit | Crash entire step function | Crash (Lambda retries batch) |
| Receipt entity missing in DynamoDB | Skip (already working) | Skip (unchanged) |

## Test plan

- [ ] Deploy to prod via `pulumi up`
- [ ] Re-run `word-ingest-sf-prod` and `line-ingest-sf-prod`
- [ ] Confirm executions complete (SUCCEEDED) rather than FAILED
- [ ] Confirm CloudWatch logs show `"permanently unplaceable"` warnings for the known bad receipts
- [ ] Confirm `embedding_status=SUCCESS` for receipts that do have places
- [ ] Confirm prod Chroma `latest-pointer` advances past `20260525_181850`

🤖 Generated with [Claude Code](https://claude.com/claude-code)