### PR TITLE
fix: default aws_region to AWS_REGION env var instead of hardcoding us-west-2

### DIFF
--- a/receipt_agent/receipt_agent/config/settings.py
+++ b/receipt_agent/receipt_agent/config/settings.py
@@ -4,6 +4,7 @@ Configuration settings for receipt_agent.
 Uses pydantic-settings for environment variable management with validation.
 """
 
+import os
 from functools import lru_cache
 from typing import Literal, Optional
 
@@ -83,7 +84,7 @@ class Settings(BaseSettings):
         description="DynamoDB table name",
     )
     aws_region: str = Field(
-        default="us-west-2",
+        default_factory=lambda: os.environ.get("AWS_REGION", "us-east-1"),
         description="AWS region for DynamoDB",
     )
 

--- a/receipt_agent/receipt_agent/config/settings.py
+++ b/receipt_agent/receipt_agent/config/settings.py
@@ -4,7 +4,6 @@ Configuration settings for receipt_agent.
 Uses pydantic-settings for environment variable management with validation.
 """
 
-import os
 from functools import lru_cache
 from typing import Literal, Optional
 
@@ -84,7 +83,8 @@ class Settings(BaseSettings):
         description="DynamoDB table name",
     )
     aws_region: str = Field(
-        default_factory=lambda: os.environ.get("AWS_REGION", "us-east-1"),
+        default="us-east-1",
+        validation_alias=AliasChoices("RECEIPT_AGENT_AWS_REGION", "AWS_REGION"),
         description="AWS region for DynamoDB",
     )
 

--- a/receipt_places/receipt_places/config.py
+++ b/receipt_places/receipt_places/config.py
@@ -34,7 +34,9 @@ class PlacesConfig(BaseSettings):
     )
     aws_region: str = Field(
         default="us-east-1",
-        validation_alias=AliasChoices("RECEIPT_PLACES_AWS_REGION", "AWS_REGION"),
+        validation_alias=AliasChoices(
+            "RECEIPT_PLACES_AWS_REGION", "AWS_REGION"
+        ),
         description="AWS region for DynamoDB",
     )
 

--- a/receipt_places/receipt_places/config.py
+++ b/receipt_places/receipt_places/config.py
@@ -4,6 +4,7 @@ Configuration for receipt_places package.
 Uses pydantic-settings for environment variable management.
 """
 
+import os
 from functools import lru_cache
 
 from pydantic import Field, SecretStr
@@ -33,7 +34,7 @@ class PlacesConfig(BaseSettings):
         description="DynamoDB table name for caching",
     )
     aws_region: str = Field(
-        default="us-west-2",
+        default_factory=lambda: os.environ.get("AWS_REGION", "us-east-1"),
         description="AWS region for DynamoDB",
     )
 

--- a/receipt_places/receipt_places/config.py
+++ b/receipt_places/receipt_places/config.py
@@ -4,10 +4,9 @@ Configuration for receipt_places package.
 Uses pydantic-settings for environment variable management.
 """
 
-import os
 from functools import lru_cache
 
-from pydantic import Field, SecretStr
+from pydantic import AliasChoices, Field, SecretStr
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -34,7 +33,8 @@ class PlacesConfig(BaseSettings):
         description="DynamoDB table name for caching",
     )
     aws_region: str = Field(
-        default_factory=lambda: os.environ.get("AWS_REGION", "us-east-1"),
+        default="us-east-1",
+        validation_alias=AliasChoices("RECEIPT_PLACES_AWS_REGION", "AWS_REGION"),
         description="AWS region for DynamoDB",
     )
 

--- a/receipt_places/tests/test_config.py
+++ b/receipt_places/tests/test_config.py
@@ -18,7 +18,7 @@ class TestPlacesConfig:
         config = PlacesConfig()
 
         assert config.table_name == "receipts"
-        assert config.aws_region == "us-west-2"
+        assert config.aws_region == "us-east-1"
         assert config.cache_ttl_days == 30
         assert config.cache_enabled is True
         assert config.request_timeout == 30


### PR DESCRIPTION
## Summary

- Both `PlacesConfig` (`receipt_places`) and `Settings` (`receipt_agent`) hardcoded `"us-west-2"` as the DynamoDB `aws_region` default
- Lambda runtimes auto-inject `AWS_REGION` — prod Lambdas get `us-east-1`, so the hardcoded default caused `AccessDeniedException` on `DescribeTable` whenever a receipt needed place creation, crashing the ingest Step Function
- Fix is at the source (the config defaults), matching the pattern already used in `infra/embedding_step_functions/unified_embedding/config.py`:  `os.environ.get("AWS_REGION", "us-east-1")`

## Why here and not in the caller

The previous attempt patched `factory.py` to pass `aws_region` explicitly. That works but puts the fix in the wrong place — the configs themselves are broken. `RECEIPT_PLACES_AWS_REGION` / `RECEIPT_AGENT_AWS_REGION` can still override per-env if needed.

## Test plan

- [ ] CI passes (existing `receipt_places` tests use local DynamoDB with explicit `us-west-2`, unaffected)
- [ ] After deploy: re-run `word-ingest-sf-prod` and `line-ingest-sf-prod` — place creation should succeed for the backlog receipts

🤖 Generated with [Claude Code](https://claude.com/claude-code)