### PR TITLE
[codex] Fix mobile receipt health transition

### DIFF
--- a/portfolio/components/ui/Figures/ReceiptFlow/ReceiptFlowShell.module.css
+++ b/portfolio/components/ui/Figures/ReceiptFlow/ReceiptFlowShell.module.css
@@ -45,6 +45,19 @@
   display: none;
 }
 
+.legendColumn {
+  position: relative;
+  flex-shrink: 0;
+}
+
+.currentLegend {
+  display: contents;
+}
+
+.nextLegend {
+  display: none;
+}
+
 .fade-out {
   animation: fade-out 0.4s ease-out forwards;
 }
@@ -95,6 +108,25 @@
     width: 100%;
     height: 100%;
   }
+
+  .legendColumn {
+    width: 100%;
+  }
+
+  .currentLegend {
+    display: block;
+    width: 100%;
+  }
+
+  .nextLegend {
+    display: block;
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    opacity: 0;
+    pointer-events: none;
+  }
+
 }
 
 @media (max-width: 480px) {

--- a/portfolio/components/ui/Figures/ReceiptFlow/ReceiptFlowShell.tsx
+++ b/portfolio/components/ui/Figures/ReceiptFlow/ReceiptFlowShell.tsx
@@ -7,6 +7,7 @@ interface ReceiptFlowShellProps {
   legend: React.ReactNode;
   flying?: React.ReactNode;
   next?: React.ReactNode;
+  nextLegend?: React.ReactNode;
   isTransitioning: boolean;
   layoutVars?: React.CSSProperties;
 }
@@ -17,6 +18,7 @@ export const ReceiptFlowShell: React.FC<ReceiptFlowShellProps> = ({
   legend,
   flying,
   next,
+  nextLegend,
   isTransitioning,
   layoutVars,
 }) => {
@@ -38,7 +40,18 @@ export const ReceiptFlowShell: React.FC<ReceiptFlowShellProps> = ({
         ) : null}
       </div>
 
-      {legend}
+      <div className={styles.legendColumn}>
+        <div
+          className={`${styles.currentLegend} ${isTransitioning && nextLegend ? styles["fade-out"] : ""}`}
+        >
+          {legend}
+        </div>
+        {nextLegend ? (
+          <div className={`${styles.nextLegend} ${isTransitioning ? styles["fade-in"] : ""}`}>
+            {nextLegend}
+          </div>
+        ) : null}
+      </div>
     </div>
   );
 };

--- a/portfolio/components/ui/Figures/ReceiptHealthExplorer/ReceiptHealthExplorer.module.css
+++ b/portfolio/components/ui/Figures/ReceiptHealthExplorer/ReceiptHealthExplorer.module.css
@@ -227,12 +227,28 @@
   -webkit-line-clamp: 2;
 }
 
+.validationReasonInnerVisible {
+  animation: validation-reason-text-in 0.22s ease-out both;
+}
+
 .validationReasonSlotVisible {
   max-height: 2.4rem;
   opacity: 0.62;
   transition:
     max-height 0.18s ease,
     opacity 0.14s ease 0.18s;
+}
+
+@keyframes validation-reason-text-in {
+  from {
+    opacity: 0;
+    transform: translateY(3px);
+  }
+
+  to {
+    opacity: 0.62;
+    transform: translateY(0);
+  }
 }
 
 @keyframes receipt-health-fade-in {
@@ -1686,6 +1702,7 @@
 
   .validationReasonClip,
   .validationReasonInner {
+    animation: none;
     transition: none;
   }
 }

--- a/portfolio/components/ui/Figures/ReceiptHealthExplorer/index.tsx
+++ b/portfolio/components/ui/Figures/ReceiptHealthExplorer/index.tsx
@@ -1001,7 +1001,13 @@ function ValidationReason({
       aria-hidden={!hasExplanation}
     >
       <div className={styles.validationReasonClip}>
-        <div className={styles.validationReasonInner}>
+        <div
+          key={explanation ?? "empty"}
+          className={[
+            styles.validationReasonInner,
+            hasExplanation ? styles.validationReasonInnerVisible : "",
+          ].filter(Boolean).join(" ")}
+        >
           {explanation}
         </div>
       </div>

--- a/portfolio/components/ui/Figures/ReceiptHealthExplorer/index.tsx
+++ b/portfolio/components/ui/Figures/ReceiptHealthExplorer/index.tsx
@@ -119,6 +119,15 @@ const CHECK_LABELS: Record<CheckId, string> = {
   financial_math: "Math",
 };
 
+function orderedChecksForReceipt(
+  receipt: ReceiptHealthReceipt | null | undefined,
+): ReceiptHealthCheck[] {
+  if (!receipt) return [];
+  return CHECK_ORDER
+    .map((id) => receipt.checks.find((check) => check.id === id))
+    .filter((check): check is ReceiptHealthCheck => Boolean(check));
+}
+
 const STATUS_LABELS: Record<ReceiptHealthStatus, string> = {
   pass: "Pass",
   review: "Review",
@@ -2286,10 +2295,7 @@ export default function ReceiptHealthExplorer() {
   }, [currentReceipt]);
 
   const orderedChecks = useMemo(() => {
-    if (!currentReceipt) return [];
-    return CHECK_ORDER
-      .map((id) => currentReceipt.checks.find((check) => check.id === id))
-      .filter((check): check is ReceiptHealthCheck => Boolean(check));
+    return orderedChecksForReceipt(currentReceipt);
   }, [currentReceipt]);
 
   const activeCheck = useMemo(() => {
@@ -2547,17 +2553,21 @@ export default function ReceiptHealthExplorer() {
 
   const transitionTargetReceipt =
     transitionTargetIndex === null ? null : receipts[transitionTargetIndex] ?? null;
+  const transitionTargetChecks = useMemo(
+    () => orderedChecksForReceipt(transitionTargetReceipt),
+    [transitionTargetReceipt],
+  );
   const transitionTargetCheck = useMemo(() => {
     if (!transitionTargetReceipt) return null;
     const preferredCheckId = preferredCheckIdForReceipt(transitionTargetReceipt);
     return (
-      transitionTargetReceipt.checks.find(
+      transitionTargetChecks.find(
         (check) => check.id === preferredCheckId,
       ) ??
-      transitionTargetReceipt.checks[0] ??
+      transitionTargetChecks[0] ??
       null
     );
-  }, [transitionTargetReceipt]);
+  }, [transitionTargetChecks, transitionTargetReceipt]);
 
   if (loading || !formatSupport) {
     return (
@@ -2650,6 +2660,22 @@ export default function ReceiptHealthExplorer() {
             onSelectCheck={setActiveCheckId}
             onSelectReceipt={selectReceipt}
           />
+        }
+        nextLegend={
+          isTransitioning && transitionTargetReceipt && transitionTargetCheck ? (
+            <ReceiptHealthFlowLegend
+              receipt={transitionTargetReceipt}
+              checks={transitionTargetChecks}
+              activeCheck={transitionTargetCheck}
+              ledgerIssues={[]}
+              ledgerSummary={null}
+              loadingLedgerIssues={true}
+              receipts={receipts}
+              currentIndex={transitionTargetIndex ?? currentIndex}
+              onSelectCheck={setActiveCheckId}
+              onSelectReceipt={selectReceipt}
+            />
+          ) : null
         }
       />
     </div>


### PR DESCRIPTION
## Summary

Fixes the mobile receipt health explorer transition so the visible receipt and the Merchant/Format/Math validation rail change as a matched pair.

## Root Cause

On mobile, `ReceiptFlowShell` renders a `next` receipt layer during the 600ms transition, while `ReceiptHealthExplorer` kept rendering the validation rail from `currentReceipt` until the transition timer committed. That produced a roughly 400-480ms mixed state where the user could see receipt A with receipt B's validation state.

Frame-level confirmation from the phone recording:

- First transition: Vons receipt became visible at ~1.883s, but Math did not flip red until ~2.350s, leaving ~467ms of mismatch.
- Second transition: In-N-Out receipt became visible at ~7.668s, but the rail did not flip all green until ~8.152s, leaving ~484ms of mismatch.

## Changes

- Added optional `nextLegend` support to `ReceiptFlowShell`.
- Kept `nextLegend` mobile-only, matching the existing mobile-only `next` receipt layer.
- Wired `ReceiptHealthExplorer` to render the transition target's validation rail during receipt transitions.
- Suppressed stale ledger explanations in the transition-target rail until that receipt becomes current.
- Left LayoutLM inference behavior unchanged; it does not opt into `nextLegend`.

## Validation

- `npm run type-check`
- `npm run lint -- --quiet`
- `npm run build`
- Local browser check at `http://localhost:3000/receipt?rail=mobile-transition-fix` with `390x844` viewport.
- Sampled 3 mobile auto-rotate transition groups at ~50ms intervals. In all groups, `nextReceipt` and `nextLegend` appeared in the same sample, with no samples where one existed without the other.