### PR TITLE
fix: read DYNAMODB_TABLE_NAME for DynamoDB table name in PlacesConfig and Settings

### DIFF
--- a/receipt_agent/receipt_agent/config/settings.py
+++ b/receipt_agent/receipt_agent/config/settings.py
@@ -20,6 +20,7 @@ class Settings(BaseSettings):
         env_file_encoding="utf-8",
         case_sensitive=False,
         extra="ignore",
+        populate_by_name=True,
     )
 
     # ==========================================================================
@@ -80,6 +81,9 @@ class Settings(BaseSettings):
     # ==========================================================================
     dynamo_table_name: str = Field(
         default="receipts",
+        validation_alias=AliasChoices(
+            "RECEIPT_AGENT_DYNAMO_TABLE_NAME", "DYNAMODB_TABLE_NAME"
+        ),
         description="DynamoDB table name",
     )
     aws_region: str = Field(

--- a/receipt_places/receipt_places/config.py
+++ b/receipt_places/receipt_places/config.py
@@ -38,7 +38,9 @@ class PlacesConfig(BaseSettings):
     )
     aws_region: str = Field(
         default="us-east-1",
-        validation_alias=AliasChoices("RECEIPT_PLACES_AWS_REGION", "AWS_REGION"),
+        validation_alias=AliasChoices(
+            "RECEIPT_PLACES_AWS_REGION", "AWS_REGION"
+        ),
         description="AWS region for DynamoDB",
     )
 

--- a/receipt_places/receipt_places/config.py
+++ b/receipt_places/receipt_places/config.py
@@ -19,6 +19,7 @@ class PlacesConfig(BaseSettings):
         env_file_encoding="utf-8",
         case_sensitive=False,
         extra="ignore",
+        populate_by_name=True,
     )
 
     # Google Places API
@@ -30,13 +31,14 @@ class PlacesConfig(BaseSettings):
     # DynamoDB Configuration
     table_name: str = Field(
         default="receipts",
+        validation_alias=AliasChoices(
+            "RECEIPT_PLACES_TABLE_NAME", "DYNAMODB_TABLE_NAME"
+        ),
         description="DynamoDB table name for caching",
     )
     aws_region: str = Field(
         default="us-east-1",
-        validation_alias=AliasChoices(
-            "RECEIPT_PLACES_AWS_REGION", "AWS_REGION"
-        ),
+        validation_alias=AliasChoices("RECEIPT_PLACES_AWS_REGION", "AWS_REGION"),
         description="AWS region for DynamoDB",
     )
 


### PR DESCRIPTION
## Summary

- `PlacesConfig.table_name` and `Settings.dynamo_table_name` both default to `"receipts"` with no alias for the Lambda-injected `DYNAMODB_TABLE_NAME` env var
- The prod table is `ReceiptsTable-d7ff76a` (set as `DYNAMODB_TABLE_NAME` in Lambda env), so `PlacesClient`'s `CacheManager` was hitting `AccessDeniedException` on `DescribeTable` for a non-existent `receipts` table in `us-east-1`
- Same fix pattern as #947 (region): `AliasChoices` tries the prefixed form first, then falls back to bare `DYNAMODB_TABLE_NAME`
- Added `populate_by_name=True` so direct Python construction (`PlacesConfig(table_name=...)`) still works alongside the `validation_alias`

## Test plan

- [ ] CI passes (all `receipt_places` config tests green locally)
- [ ] After deploy: re-run `word-ingest-sf-prod` and `line-ingest-sf-prod` — `PlacesClient` should initialize without `AccessDeniedException`

🤖 Generated with [Claude Code](https://claude.com/claude-code)