### PR TITLE
[codex] Smooth mobile receipt health blink

### DIFF
--- a/portfolio/components/ui/Figures/ReceiptFlow/ReceiptFlowShell.module.css
+++ b/portfolio/components/ui/Figures/ReceiptFlow/ReceiptFlowShell.module.css
@@ -109,6 +109,11 @@
     height: 100%;
   }
 
+  .receiptContainer.fade-out {
+    animation: none;
+    opacity: 1;
+  }
+
   .legendColumn {
     width: 100%;
   }

--- a/portfolio/components/ui/Figures/ReceiptFlow/ReceiptFlowShell.module.css
+++ b/portfolio/components/ui/Figures/ReceiptFlow/ReceiptFlowShell.module.css
@@ -107,11 +107,12 @@
     left: 0;
     width: 100%;
     height: 100%;
+    z-index: 2;
+    background: var(--background-color, #fff);
   }
 
   .receiptContainer.fade-out {
-    animation: none;
-    opacity: 1;
+    animation: mobile-receipt-fade-under 0.6s ease-out forwards;
   }
 
   .legendColumn {
@@ -132,6 +133,17 @@
     pointer-events: none;
   }
 
+}
+
+@keyframes mobile-receipt-fade-under {
+  0%,
+  55% {
+    opacity: 1;
+  }
+
+  100% {
+    opacity: 0;
+  }
 }
 
 @media (max-width: 480px) {

--- a/portfolio/components/ui/Figures/ReceiptHealthExplorer/ReceiptHealthExplorer.module.css
+++ b/portfolio/components/ui/Figures/ReceiptHealthExplorer/ReceiptHealthExplorer.module.css
@@ -239,6 +239,17 @@
     opacity 0.14s ease 0.18s;
 }
 
+.validationReasonSlotMuted {
+  opacity: 0;
+  transition:
+    max-height 0.18s ease,
+    opacity 0.01s linear;
+}
+
+.validationReasonSlotMuted .validationReasonClip {
+  min-height: 2.4rem;
+}
+
 @keyframes validation-reason-text-in {
   from {
     opacity: 0;

--- a/portfolio/components/ui/Figures/ReceiptHealthExplorer/index.tsx
+++ b/portfolio/components/ui/Figures/ReceiptHealthExplorer/index.tsx
@@ -1001,8 +1001,8 @@ function ValidationReason({
         hasExplanation ? styles.validationReasonSlotVisible : "",
         muted ? styles.validationReasonSlotMuted : "",
       ].filter(Boolean).join(" ")}
-      aria-live="polite"
-      aria-hidden={!hasExplanation}
+      aria-live={muted ? "off" : "polite"}
+      aria-hidden={muted || !hasExplanation}
     >
       <div className={styles.validationReasonClip}>
         <div

--- a/portfolio/components/ui/Figures/ReceiptHealthExplorer/index.tsx
+++ b/portfolio/components/ui/Figures/ReceiptHealthExplorer/index.tsx
@@ -987,28 +987,32 @@ function validationRowExplanation(
 
 function ValidationReason({
   explanation,
+  muted = false,
 }: {
   explanation: string | null;
+  muted?: boolean;
 }) {
   const hasExplanation = Boolean(explanation);
+  const visibleExplanation = muted ? null : explanation;
   return (
     <div
       className={[
         styles.validationReasonSlot,
         hasExplanation ? styles.validationReasonSlotVisible : "",
+        muted ? styles.validationReasonSlotMuted : "",
       ].filter(Boolean).join(" ")}
       aria-live="polite"
       aria-hidden={!hasExplanation}
     >
       <div className={styles.validationReasonClip}>
         <div
-          key={explanation ?? "empty"}
+          key={visibleExplanation ?? (muted ? "muted" : "empty")}
           className={[
             styles.validationReasonInner,
-            hasExplanation ? styles.validationReasonInnerVisible : "",
+            visibleExplanation ? styles.validationReasonInnerVisible : "",
           ].filter(Boolean).join(" ")}
         >
-          {explanation}
+          {visibleExplanation}
         </div>
       </div>
     </div>
@@ -1147,12 +1151,14 @@ function ValidationChecks({
   activeCheck,
   ledgerIssues,
   loadingLedgerIssues,
+  muteExplanations = false,
   onSelectCheck,
 }: {
   checks: ReceiptHealthCheck[];
   activeCheck: ReceiptHealthCheck;
   ledgerIssues: ReceiptHealthLedgerIssue[];
   loadingLedgerIssues: boolean;
+  muteExplanations?: boolean;
   onSelectCheck: (checkId: CheckId) => void;
 }) {
   const validationRows = checks.map((check) => {
@@ -1186,7 +1192,7 @@ function ValidationChecks({
             <span className={styles.validationLabel}>{CHECK_LABELS[check.id]}</span>
             <ValidationStatusIcon status={check.status} />
           </button>
-          <ValidationReason explanation={explanation} />
+          <ValidationReason explanation={explanation} muted={muteExplanations} />
         </div>
       ))}
     </div>
@@ -1351,6 +1357,7 @@ function DiagnosisRail({
   loadingLedgerIssues,
   receipts,
   currentIndex,
+  muteExplanations = false,
   onSelectCheck,
   onSelectReceipt,
 }: {
@@ -1363,6 +1370,7 @@ function DiagnosisRail({
   loadingLedgerIssues: boolean;
   receipts: ReceiptHealthReceipt[];
   currentIndex: number;
+  muteExplanations?: boolean;
   onSelectCheck: (checkId: CheckId) => void;
   onSelectReceipt: (index: number) => void;
 }) {
@@ -1393,6 +1401,7 @@ function DiagnosisRail({
         activeCheck={activeCheck}
         ledgerIssues={ledgerIssues}
         loadingLedgerIssues={loadingLedgerIssues}
+        muteExplanations={muteExplanations}
         onSelectCheck={onSelectCheck}
       />
 
@@ -1930,6 +1939,7 @@ function ReceiptHealthFlowLegend({
   loadingLedgerIssues,
   receipts,
   currentIndex,
+  muteExplanations = false,
   onSelectCheck,
   onSelectReceipt,
 }: {
@@ -1941,6 +1951,7 @@ function ReceiptHealthFlowLegend({
   loadingLedgerIssues: boolean;
   receipts: ReceiptHealthReceipt[];
   currentIndex: number;
+  muteExplanations?: boolean;
   onSelectCheck: (checkId: CheckId) => void;
   onSelectReceipt: (index: number) => void;
 }) {
@@ -1959,6 +1970,7 @@ function ReceiptHealthFlowLegend({
         loadingLedgerIssues={loadingLedgerIssues}
         receipts={receipts}
         currentIndex={currentIndex}
+        muteExplanations={muteExplanations}
         onSelectCheck={onSelectCheck}
         onSelectReceipt={onSelectReceipt}
       />
@@ -2663,6 +2675,7 @@ export default function ReceiptHealthExplorer() {
             loadingLedgerIssues={loadingLedgerIssues}
             receipts={receipts}
             currentIndex={currentIndex}
+            muteExplanations={isTransitioning}
             onSelectCheck={setActiveCheckId}
             onSelectReceipt={selectReceipt}
           />
@@ -2678,6 +2691,7 @@ export default function ReceiptHealthExplorer() {
               loadingLedgerIssues={true}
               receipts={receipts}
               currentIndex={transitionTargetIndex ?? currentIndex}
+              muteExplanations={true}
               onSelectCheck={setActiveCheckId}
               onSelectReceipt={selectReceipt}
             />


### PR DESCRIPTION
## Summary

Follow-up to #948. Fixes the remaining mobile blink/pop in the receipt health explorer transition.

## What I found

I inspected `/Users/tnorlund/ScreenRecording_06-16-2026 14-19-37_1.mov` frame-by-frame. The issue was two separate transition artifacts:

- The old validation explanation text stayed visible for the first part of the transition while the next receipt was already fading in.
- The current receipt image faded out while the next receipt faded in, which let the white page background show through and produced a brief bright flash.

## Changes

- Mute explanation text during receipt transitions while preserving the row slot height.
- Keep the current receipt image opaque on mobile while the next receipt fades over it.
- Let the final explanation text mount and use the existing reason-text fade after the transition commits.

## Validation

- Extracted frame sheets from the supplied `.mov` to identify the blink windows around ~2.0s and ~8.0s.
- Reproduced locally at `390x844` on `http://localhost:3000/receipt?rail=blink-repro-local`.
- Sampled transition frames at ~50ms intervals after the fix:
  - `transitionReasonTextCount: 0`
  - `currentReceiptFadingCount: 0`
- Deployed to dev and repeated the same mobile sampling on `https://dev.tylernorlund.com/receipt?rail=blink-fix-1781645715`:
  - `transitionReasonTextCount: 0`
  - `currentReceiptFadingCount: 0`
- `npm run type-check`
- `npm run lint -- --quiet`
- `NEXT_PUBLIC_API_URL=https://dev-api.tylernorlund.com npm run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Fixed receipt visibility on mobile devices by preventing fade-out animations on smaller screens.

* **New Features**
  * Added the ability to mute validation explanations while preserving layout consistency.
  * Improved handling of validation explanations during state transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->