### PR TITLE
refactor: poll lambdas delegate place finding to fix_place Lambda

### DIFF
--- a/infra/embedding_step_functions/components/lambda_functions.py
+++ b/infra/embedding_step_functions/components/lambda_functions.py
@@ -259,6 +259,11 @@ class LambdaFunctionsComponent(ComponentResource):
                     },
                     {
                         "Effect": "Allow",
+                        "Action": ["lambda:InvokeFunction"],
+                        "Resource": f"arn:aws:lambda:*:*:function:fix-place-{stack}-fix-place",
+                    },
+                    {
+                        "Effect": "Allow",
                         "Action": [
                             "elasticfilesystem:ClientMount",
                             "elasticfilesystem:ClientWrite",
@@ -631,34 +636,7 @@ class LambdaFunctionsComponent(ComponentResource):
                 "OPENAI_API_KEY": openai_api_key,
                 "S3_BUCKET": self.batch_bucket.bucket,
                 "CHROMA_PERSIST_DIRECTORY": "/tmp/chroma",  # Polling Lambdas don't use EFS
-                "GOOGLE_PLACES_API_KEY": portfolio_config.get_secret(
-                    "GOOGLE_PLACES_API_KEY"
-                )
-                or "",
-                "LANGCHAIN_API_KEY": portfolio_config.get_secret(
-                    "LANGCHAIN_API_KEY"
-                )
-                or "",
-                # OpenRouter LLM provider
-                "OPENROUTER_API_KEY": portfolio_config.get_secret(
-                    "OPENROUTER_API_KEY"
-                )
-                or "",
-                "OPENROUTER_BASE_URL": "https://openrouter.ai/api/v1",
-                "OPENROUTER_MODEL": "openai/gpt-oss-120b",
-                # receipt_agent expects RECEIPT_AGENT_* but we mirror base vars too
-                "RECEIPT_AGENT_OPENAI_API_KEY": openai_api_key,
-                "RECEIPT_AGENT_GOOGLE_PLACES_API_KEY": portfolio_config.get_secret(
-                    "GOOGLE_PLACES_API_KEY"
-                )
-                or "",
-                "RECEIPT_AGENT_LANGCHAIN_API_KEY": portfolio_config.get_secret(
-                    "LANGCHAIN_API_KEY"
-                )
-                or "",
-                "RECEIPT_AGENT_LANGCHAIN_PROJECT": portfolio_config.get(
-                    "LANGCHAIN_PROJECT", "receipt-agent"
-                ),
+                "FIX_PLACE_LAMBDA_NAME": f"fix-place-{stack}-fix-place",
                 "ENABLE_XRAY": "true",
                 "ENABLE_METRICS": "true",
                 "LOG_LEVEL": "INFO",

--- a/infra/embedding_step_functions/unified_embedding/handlers/line_polling.py
+++ b/infra/embedding_step_functions/unified_embedding/handlers/line_polling.py
@@ -8,20 +8,9 @@ import logging
 import os
 import tempfile
 import time
-from datetime import datetime, timezone
-from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 import boto3
-from receipt_agent.clients.factory import (
-    create_embed_fn,
-    create_places_client,
-)
-from receipt_agent.config.settings import get_settings
-from receipt_agent.subagents.place_finder import (
-    create_receipt_place_finder_graph,
-    run_receipt_place_finder,
-)
 from receipt_chroma.data.chroma_client import ChromaClient
 from receipt_chroma.embedding.delta import save_line_embeddings_as_delta
 from receipt_chroma.embedding.formatting.line_format import (
@@ -45,7 +34,6 @@ from receipt_chroma.s3 import download_snapshot_atomic
 from receipt_dynamo.constants import BatchStatus, EmbeddingStatus
 from receipt_dynamo.data.dynamo_client import DynamoClient
 from receipt_dynamo.data.shared_exceptions import EntityNotFoundError
-from receipt_dynamo.entities.receipt_place import ReceiptPlace
 
 import utils.logging  # pylint: disable=import-error
 from utils.circuit_breaker import (  # pylint: disable=import-error
@@ -87,20 +75,7 @@ logger = get_operation_logger(__name__)
 s3_client = boto3.client("s3")
 
 
-def _propagate_agent_env() -> None:
-    """Ensure receipt_agent settings pick up the base env vars."""
-    env_aliases = [
-        ("OPENAI_API_KEY", "RECEIPT_AGENT_OPENAI_API_KEY"),
-        ("GOOGLE_PLACES_API_KEY", "RECEIPT_AGENT_GOOGLE_PLACES_API_KEY"),
-        ("LANGCHAIN_API_KEY", "RECEIPT_AGENT_LANGCHAIN_API_KEY"),
-        ("LANGCHAIN_PROJECT", "RECEIPT_AGENT_LANGCHAIN_PROJECT"),
-    ]
-    for src, dest in env_aliases:
-        if dest not in os.environ and src in os.environ:
-            os.environ[dest] = os.environ[src]
-
-
-async def _ensure_receipt_place_async(
+def _ensure_receipt_place(
     image_id: str,
     receipt_id: int,
     dynamo_client: DynamoClient,
@@ -108,12 +83,14 @@ async def _ensure_receipt_place_async(
     line_results: Optional[List[dict]] = None,
     batch_id: Optional[str] = None,
 ) -> bool:
-    """Create receipt_place if missing using receipt_agent + local Chroma.
+    """Create receipt_place if missing by delegating to the fix_place Lambda.
 
     Returns:
-        True if place exists or was created; False if the receipt entity
-        is missing (orphaned receipt that can never have a place created).
-        Raises on transient / unexpected errors.
+        True if the place exists or was successfully created.
+        False if the receipt entity is missing (orphaned) or the agent
+        permanently could not identify a merchant.
+        Raises RuntimeError on transient / infrastructure errors so the
+        Step Function can retry.
     """
     try:
         dynamo_client.get_receipt_place(image_id, receipt_id)
@@ -125,7 +102,7 @@ async def _ensure_receipt_place_async(
         return True
     except EntityNotFoundError:
         logger.info(
-            "Receipt place missing; will attempt creation",
+            "Receipt place missing; will attempt creation via fix_place Lambda",
             image_id=image_id,
             receipt_id=receipt_id,
         )
@@ -138,245 +115,74 @@ async def _ensure_receipt_place_async(
         )
         raise
 
-    _propagate_agent_env()
-    settings = get_settings()
-
+    # Confirm the receipt entity itself exists before invoking the agent.
     try:
-        receipt_details = dynamo_client.get_receipt_details(
-            image_id=image_id,
-            receipt_id=receipt_id,
-        )
+        dynamo_client.get_receipt_details(image_id=image_id, receipt_id=receipt_id)
     except EntityNotFoundError:
         logger.warning(
-            "Receipt entity missing during place creation; "
-            "skipping orphaned receipt",
+            "Receipt entity missing; skipping orphaned receipt",
             image_id=image_id,
             receipt_id=receipt_id,
         )
         return False
 
-    row_records: List[RowEmbeddingRecord] = []
-    if line_results:
-        # Group lines into visual rows for row-based embedding records
-        visual_rows = group_lines_into_visual_rows(receipt_details.lines)
-        # Build a mapping from primary_line_id to the full row
-        primary_to_row = {
-            get_primary_line_id(row): row for row in visual_rows if row
-        }
+    fix_place_fn = os.environ.get("FIX_PLACE_LAMBDA_NAME")
+    if not fix_place_fn:
+        raise RuntimeError("FIX_PLACE_LAMBDA_NAME environment variable not set")
 
-        for result in line_results:
-            try:
-                meta = parse_line_custom_id(result["custom_id"])
-            except Exception as parse_error:  # pylint: disable=broad-except
-                logger.warning(
-                    "Skipping line embedding result with invalid custom_id",
-                    custom_id=result.get("custom_id"),
-                    error=str(parse_error),
-                )
-                continue
+    lambda_client = boto3.client("lambda")
+    payload = json.dumps({
+        "image_id": image_id,
+        "receipt_id": receipt_id,
+        "reason": "Missing place detected during line embedding ingest",
+    }).encode()
 
-            if (
-                meta["image_id"] != image_id
-                or meta["receipt_id"] != receipt_id
-            ):
-                continue
-
-            # The line_id in custom_id is the primary line of a visual row
-            primary_line_id = meta["line_id"]
-            target_row = primary_to_row.get(primary_line_id)
-            if not target_row:
-                logger.warning(
-                    "Visual row not found for primary line_id",
-                    image_id=image_id,
-                    receipt_id=receipt_id,
-                    primary_line_id=primary_line_id,
-                )
-                continue
-
-            row_records.append(
-                RowEmbeddingRecord(
-                    row_lines=tuple(target_row),
-                    embedding=result.get("embedding") or [],
-                    batch_id=batch_id,
-                )
-            )
-
-    line_embeddings_map = {
-        record.chroma_id: record.embedding for record in row_records
-    } or None
-
-    chroma_root = Path("/tmp/chroma/place_finder")
-    lines_dir = chroma_root / "lines"
-    words_dir = chroma_root / "words"
-    lines_dir.mkdir(parents=True, exist_ok=True)
-    words_dir.mkdir(parents=True, exist_ok=True)
-
-    chromadb_bucket = os.environ.get("CHROMADB_BUCKET")
-    if chromadb_bucket:
-        try:
-            download_snapshot_atomic(
-                bucket=chromadb_bucket,
-                collection="lines",
-                local_path=str(lines_dir),
-                verify_integrity=False,
-            )
-        except Exception as e:  # pylint: disable=broad-exception-caught
-            logger.warning(
-                "Failed to download lines snapshot for place finder",
-                error=str(e),
-            )
-        try:
-            download_snapshot_atomic(
-                bucket=chromadb_bucket,
-                collection="words",
-                local_path=str(words_dir),
-                verify_integrity=False,
-            )
-        except Exception as e:  # pylint: disable=broad-exception-caught
-            logger.warning(
-                "Failed to download words snapshot for place finder",
-                error=str(e),
-            )
-
-    lines_client = ChromaClient(
-        persist_directory=str(lines_dir), mode="write", metadata_only=True
-    )
-    words_client = ChromaClient(
-        persist_directory=str(words_dir), mode="write", metadata_only=True
-    )
-
-    chroma_client = DualChromaClient(lines_client, words_client, logger)
     try:
-        payload = build_row_payload(
-            records=row_records,
-            all_words=receipt_details.words,
-            merchant_name=None,
+        response = lambda_client.invoke(
+            FunctionName=fix_place_fn,
+            InvocationType="RequestResponse",
+            Payload=payload,
+        )
+    except Exception as invoke_err:
+        raise RuntimeError(
+            f"Failed to invoke fix_place Lambda for {image_id}#{receipt_id}: {invoke_err}"
+        ) from invoke_err
+
+    if response.get("FunctionError"):
+        error_body = response["Payload"].read().decode()
+        raise RuntimeError(
+            f"fix_place Lambda error for {image_id}#{receipt_id}: {error_body}"
         )
 
-        if payload["ids"]:
-            collection = chroma_client.get_collection(
-                "lines", create_if_missing=True
-            )
-            collection.upsert(
-                ids=payload["ids"],
-                embeddings=payload["embeddings"],
-                documents=payload["documents"],
-                metadatas=payload["metadatas"],
-            )
+    result = json.loads(response["Payload"].read().decode())
 
-        embed_fn = create_embed_fn(settings=settings)
-        places_client = create_places_client(settings=settings)
-
-        graph, state_holder = create_receipt_place_finder_graph(
-            dynamo_client=dynamo_client,
-            chroma_client=chroma_client,
-            embed_fn=embed_fn,
-            places_api=places_client,
-            settings=settings,
-        )
-
-        result = await run_receipt_place_finder(
-            graph=graph,
-            state_holder=state_holder,
-            image_id=image_id,
-            receipt_id=receipt_id,
-            line_embeddings=line_embeddings_map,
-            word_embeddings=None,
-            receipt_lines=receipt_details.lines,
-            receipt_words=receipt_details.words,
-        )
-
-        if not result.get("found"):
-            result_type = result.get("type", "agent_decided")
-            if result_type in ("agent_error", "agent_timeout"):
-                # Transient failure — raise so the Lambda fails and Step Functions retries
-                raise RuntimeError(
-                    f"Place finder failed transiently ({result_type}) for "
-                    f"{image_id}#{receipt_id}: {result.get('reasoning', '')}"
-                )
-            # agent_decided: agent ran fully and found nothing — permanently unplaceable
-            logger.warning(
-                "Place finder could not identify merchant; receipt is permanently unplaceable",
-                image_id=image_id,
-                receipt_id=receipt_id,
-                reasoning=result.get("reasoning"),
-            )
-            return False
-
-        merchant_name = result.get("merchant_name") or ""
-        if not merchant_name.strip():
-            logger.warning(
-                "Place finder returned empty merchant_name; receipt is permanently unplaceable",
-                image_id=image_id,
-                receipt_id=receipt_id,
-            )
-            return False
-
-        matched_fields = []
-        if result.get("merchant_name"):
-            matched_fields.append("name")
-        if result.get("address"):
-            matched_fields.append("address")
-        if result.get("phone_number"):
-            matched_fields.append("phone")
-        if result.get("place_id"):
-            matched_fields.append("place_id")
-
-        place_entity = ReceiptPlace(
-            image_id=image_id,
-            receipt_id=receipt_id,
-            place_id=result.get("place_id") or "",
-            merchant_name=merchant_name,
-            matched_fields=matched_fields,
-            timestamp=datetime.now(timezone.utc),
-            merchant_category="",
-            formatted_address=result.get("address") or "",
-            phone_number=result.get("phone_number") or "",
-            validated_by="place_finder_agent",
-            reasoning=result.get("reasoning") or "",
-        )
-        dynamo_client.add_receipt_places([place_entity])
-
+    if result.get("success"):
         logger.info(
-            "Created receipt_place via place finder",
+            "Created receipt_place via fix_place Lambda",
             image_id=image_id,
             receipt_id=receipt_id,
-            place_id=place_entity.place_id,
+            merchant=result.get("new_merchant"),
         )
         return True
-    finally:
-        try:
-            chroma_client.close()
-        except Exception as e:
-            logger.debug(
-                "Failed to close chroma_client during cleanup", error=str(e)
-            )
 
-
-def _ensure_receipt_place(
-    image_id: str,
-    receipt_id: int,
-    dynamo_client: DynamoClient,
-    *,
-    line_results: Optional[List[dict]] = None,
-    batch_id: Optional[str] = None,
-) -> bool:
-    """Synchronous wrapper for async place creation.
-
-    Returns:
-        True if place exists or was created; False if the receipt entity
-        is missing (orphaned).  Raises on transient errors.
-    """
-    import asyncio
-
-    return asyncio.run(
-        _ensure_receipt_place_async(
+    error_msg = result.get("error", "")
+    # These messages indicate the agent ran fully but could not find the merchant.
+    permanent_phrases = (
+        "agent could not find correct place",
+        "merchant_name is missing",
+        "no google places place_id",
+    )
+    if any(p in error_msg.lower() for p in permanent_phrases):
+        logger.warning(
+            "Place finder could not identify merchant; receipt is permanently unplaceable",
             image_id=image_id,
             receipt_id=receipt_id,
-            dynamo_client=dynamo_client,
-            line_results=line_results,
-            batch_id=batch_id,
+            reasoning=result.get("reasoning"),
         )
+        return False
+
+    raise RuntimeError(
+        f"fix_place Lambda returned failure for {image_id}#{receipt_id}: {error_msg}"
     )
 
 

--- a/infra/embedding_step_functions/unified_embedding/handlers/line_polling.py
+++ b/infra/embedding_step_functions/unified_embedding/handlers/line_polling.py
@@ -11,6 +11,7 @@ import time
 from typing import Any, Dict, List, Optional
 
 import boto3
+from botocore.config import Config
 from receipt_chroma.data.chroma_client import ChromaClient
 from receipt_chroma.embedding.delta import save_line_embeddings_as_delta
 from receipt_chroma.embedding.formatting.line_format import (
@@ -73,6 +74,10 @@ get_operation_logger = utils.logging.get_operation_logger
 logger = get_operation_logger(__name__)
 
 s3_client = boto3.client("s3")
+# fix_place_lambda can run up to 900s; extend read timeout to cover its full budget.
+_fix_place_lambda_client = boto3.client(
+    "lambda", config=Config(read_timeout=910, connect_timeout=10)
+)
 
 
 def _ensure_receipt_place(
@@ -130,7 +135,6 @@ def _ensure_receipt_place(
     if not fix_place_fn:
         raise RuntimeError("FIX_PLACE_LAMBDA_NAME environment variable not set")
 
-    lambda_client = boto3.client("lambda")
     payload = json.dumps({
         "image_id": image_id,
         "receipt_id": receipt_id,
@@ -138,7 +142,7 @@ def _ensure_receipt_place(
     }).encode()
 
     try:
-        response = lambda_client.invoke(
+        response = _fix_place_lambda_client.invoke(
             FunctionName=fix_place_fn,
             InvocationType="RequestResponse",
             Payload=payload,

--- a/infra/embedding_step_functions/unified_embedding/handlers/word_polling.py
+++ b/infra/embedding_step_functions/unified_embedding/handlers/word_polling.py
@@ -3,29 +3,17 @@
 Pure business logic - no Lambda-specific code.
 """
 
-import asyncio
 import json
 import logging
 import os
 import random
 import tempfile
 import time
-from datetime import datetime, timezone
 from functools import wraps
-from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, TypeVar
 
 import boto3
 from openai import OpenAI
-from receipt_agent.clients.factory import (
-    create_embed_fn,
-    create_places_client,
-)
-from receipt_agent.config.settings import get_settings
-from receipt_agent.subagents.place_finder import (
-    create_receipt_place_finder_graph,
-    run_receipt_place_finder,
-)
 from receipt_chroma.data.chroma_client import ChromaClient
 from receipt_chroma.embedding.delta import save_word_embeddings_as_delta
 from receipt_chroma.embedding.openai import (
@@ -43,7 +31,6 @@ from receipt_chroma.s3 import download_snapshot_atomic
 from receipt_dynamo.constants import BatchStatus
 from receipt_dynamo.data.dynamo_client import DynamoClient
 from receipt_dynamo.data.shared_exceptions import EntityNotFoundError
-from receipt_dynamo.entities.receipt_place import ReceiptPlace
 
 import utils.logging  # pylint: disable=import-error
 from utils.circuit_breaker import (  # pylint: disable=import-error
@@ -198,20 +185,7 @@ def retry_openai_api_call(
     return decorator
 
 
-def _propagate_agent_env() -> None:
-    """Ensure receipt_agent settings pick up the base env vars."""
-    env_aliases = [
-        ("OPENAI_API_KEY", "RECEIPT_AGENT_OPENAI_API_KEY"),
-        ("GOOGLE_PLACES_API_KEY", "RECEIPT_AGENT_GOOGLE_PLACES_API_KEY"),
-        ("LANGCHAIN_API_KEY", "RECEIPT_AGENT_LANGCHAIN_API_KEY"),
-        ("LANGCHAIN_PROJECT", "RECEIPT_AGENT_LANGCHAIN_PROJECT"),
-    ]
-    for src, dest in env_aliases:
-        if dest not in os.environ and src in os.environ:
-            os.environ[dest] = os.environ[src]
-
-
-async def _ensure_receipt_place_async(
+def _ensure_receipt_place(
     image_id: str,
     receipt_id: int,
     dynamo_client: DynamoClient,
@@ -219,12 +193,14 @@ async def _ensure_receipt_place_async(
     word_results: Optional[List[dict]] = None,
     batch_id: Optional[str] = None,
 ) -> bool:
-    """Create receipt_place if missing using receipt_agent + local Chroma.
+    """Create receipt_place if missing by delegating to the fix_place Lambda.
 
     Returns:
-        True if place exists or was created; False if the receipt entity
-        is missing (orphaned receipt that can never have a place created).
-        Raises on transient / unexpected errors.
+        True if the place exists or was successfully created.
+        False if the receipt entity is missing (orphaned) or the agent
+        permanently could not identify a merchant.
+        Raises RuntimeError on transient / infrastructure errors so the
+        Step Function can retry.
     """
     try:
         dynamo_client.get_receipt_place(image_id, receipt_id)
@@ -236,7 +212,7 @@ async def _ensure_receipt_place_async(
         return True
     except EntityNotFoundError:
         logger.info(
-            "Receipt place missing; will attempt creation",
+            "Receipt place missing; will attempt creation via fix_place Lambda",
             image_id=image_id,
             receipt_id=receipt_id,
         )
@@ -249,241 +225,74 @@ async def _ensure_receipt_place_async(
         )
         raise
 
-    _propagate_agent_env()
-    settings = get_settings()
-
+    # Confirm the receipt entity itself exists before invoking the agent.
     try:
-        receipt_details = dynamo_client.get_receipt_details(
-            image_id=image_id,
-            receipt_id=receipt_id,
-        )
+        dynamo_client.get_receipt_details(image_id=image_id, receipt_id=receipt_id)
     except EntityNotFoundError:
         logger.warning(
-            "Receipt entity missing during place creation; "
-            "skipping orphaned receipt",
+            "Receipt entity missing; skipping orphaned receipt",
             image_id=image_id,
             receipt_id=receipt_id,
         )
         return False
 
-    word_records: List[WordEmbeddingRecord] = []
-    if word_results:
-        words_by_key = {
-            (w.line_id, w.word_id): w for w in receipt_details.words
-        }
-        for result in word_results:
-            try:
-                meta = parse_word_custom_id(result["custom_id"])
-            except Exception as parse_error:  # pylint: disable=broad-except
-                logger.warning(
-                    "Skipping word embedding result with invalid custom_id",
-                    custom_id=result.get("custom_id"),
-                    error=str(parse_error),
-                )
-                continue
+    fix_place_fn = os.environ.get("FIX_PLACE_LAMBDA_NAME")
+    if not fix_place_fn:
+        raise RuntimeError("FIX_PLACE_LAMBDA_NAME environment variable not set")
 
-            if (
-                meta["image_id"] != image_id
-                or meta["receipt_id"] != receipt_id
-            ):
-                continue
+    lambda_client = boto3.client("lambda")
+    payload = json.dumps({
+        "image_id": image_id,
+        "receipt_id": receipt_id,
+        "reason": "Missing place detected during word embedding ingest",
+    }).encode()
 
-            target_word = words_by_key.get((meta["line_id"], meta["word_id"]))
-            if not target_word:
-                logger.warning(
-                    "Word not found for embedding result",
-                    image_id=image_id,
-                    receipt_id=receipt_id,
-                    line_id=meta["line_id"],
-                    word_id=meta["word_id"],
-                )
-                continue
-
-            word_records.append(
-                WordEmbeddingRecord(
-                    word=target_word,
-                    embedding=result.get("embedding") or [],
-                    batch_id=batch_id,
-                )
-            )
-
-    word_embeddings_map = (
-        {record.chroma_id: record.embedding for record in word_records}
-        if word_records
-        else None
-    )
-
-    chroma_root = Path("/tmp/chroma/place_finder")
-    lines_dir = chroma_root / "lines"
-    words_dir = chroma_root / "words"
-    lines_dir.mkdir(parents=True, exist_ok=True)
-    words_dir.mkdir(parents=True, exist_ok=True)
-
-    chromadb_bucket = os.environ.get("CHROMADB_BUCKET")
-    if chromadb_bucket:
-        try:
-            download_snapshot_atomic(
-                bucket=chromadb_bucket,
-                collection="lines",
-                local_path=str(lines_dir),
-                verify_integrity=False,
-            )
-        except Exception as e:  # pylint: disable=broad-exception-caught
-            logger.warning(
-                "Failed to download lines snapshot for place finder",
-                error=str(e),
-            )
-        try:
-            download_snapshot_atomic(
-                bucket=chromadb_bucket,
-                collection="words",
-                local_path=str(words_dir),
-                verify_integrity=False,
-            )
-        except Exception as e:  # pylint: disable=broad-exception-caught
-            logger.warning(
-                "Failed to download words snapshot for place finder",
-                error=str(e),
-            )
-
-    lines_client = ChromaClient(
-        persist_directory=str(lines_dir), mode="write", metadata_only=True
-    )
-    words_client = ChromaClient(
-        persist_directory=str(words_dir), mode="write", metadata_only=True
-    )
-
-    chroma_client = DualChromaClient(lines_client, words_client, logger)
     try:
-        payload = build_word_payload(
-            records=word_records,
-            all_words=receipt_details.words,
-            word_labels=getattr(receipt_details, "labels", []),
-            merchant_name=None,
+        response = lambda_client.invoke(
+            FunctionName=fix_place_fn,
+            InvocationType="RequestResponse",
+            Payload=payload,
+        )
+    except Exception as invoke_err:
+        raise RuntimeError(
+            f"Failed to invoke fix_place Lambda for {image_id}#{receipt_id}: {invoke_err}"
+        ) from invoke_err
+
+    if response.get("FunctionError"):
+        error_body = response["Payload"].read().decode()
+        raise RuntimeError(
+            f"fix_place Lambda error for {image_id}#{receipt_id}: {error_body}"
         )
 
-        if payload["ids"]:
-            collection = chroma_client.get_collection(
-                "words", create_if_missing=True
-            )
-            collection.upsert(
-                ids=payload["ids"],
-                embeddings=payload["embeddings"],
-                documents=payload["documents"],
-                metadatas=payload["metadatas"],
-            )
+    result = json.loads(response["Payload"].read().decode())
 
-        embed_fn = create_embed_fn(settings=settings)
-        places_client = create_places_client(settings=settings)
-
-        graph, state_holder = create_receipt_place_finder_graph(
-            dynamo_client=dynamo_client,
-            chroma_client=chroma_client,
-            embed_fn=embed_fn,
-            places_api=places_client,
-            settings=settings,
-        )
-
-        result = await run_receipt_place_finder(
-            graph=graph,
-            state_holder=state_holder,
-            image_id=image_id,
-            receipt_id=receipt_id,
-            line_embeddings=None,
-            word_embeddings=word_embeddings_map,
-            receipt_lines=receipt_details.lines,
-            receipt_words=receipt_details.words,
-        )
-
-        if not result.get("found"):
-            result_type = result.get("type", "agent_decided")
-            if result_type in ("agent_error", "agent_timeout"):
-                # Transient failure — raise so the Lambda fails and Step Functions retries
-                raise RuntimeError(
-                    f"Place finder failed transiently ({result_type}) for "
-                    f"{image_id}#{receipt_id}: {result.get('reasoning', '')}"
-                )
-            # agent_decided: agent ran fully and found nothing — permanently unplaceable
-            logger.warning(
-                "Place finder could not identify merchant; receipt is permanently unplaceable",
-                image_id=image_id,
-                receipt_id=receipt_id,
-                reasoning=result.get("reasoning"),
-            )
-            return False
-
-        merchant_name = result.get("merchant_name") or ""
-        if not merchant_name.strip():
-            logger.warning(
-                "Place finder returned empty merchant_name; receipt is permanently unplaceable",
-                image_id=image_id,
-                receipt_id=receipt_id,
-            )
-            return False
-
-        matched_fields = []
-        if result.get("merchant_name"):
-            matched_fields.append("name")
-        if result.get("address"):
-            matched_fields.append("address")
-        if result.get("phone_number"):
-            matched_fields.append("phone")
-        if result.get("place_id"):
-            matched_fields.append("place_id")
-
-        place_entity = ReceiptPlace(
-            image_id=image_id,
-            receipt_id=receipt_id,
-            place_id=result.get("place_id") or "",
-            merchant_name=merchant_name,
-            matched_fields=matched_fields,
-            timestamp=datetime.now(timezone.utc),
-            merchant_category="",
-            formatted_address=result.get("address") or "",
-            phone_number=result.get("phone_number") or "",
-            validated_by="place_finder_agent",
-            reasoning=result.get("reasoning") or "",
-        )
-        dynamo_client.add_receipt_places([place_entity])
-
+    if result.get("success"):
         logger.info(
-            "Created receipt_place via place finder",
+            "Created receipt_place via fix_place Lambda",
             image_id=image_id,
             receipt_id=receipt_id,
-            place_id=place_entity.place_id,
+            merchant=result.get("new_merchant"),
         )
         return True
-    finally:
-        try:
-            chroma_client.close()
-        except Exception as e:
-            logger.debug(
-                "Failed to close chroma_client during cleanup", error=str(e)
-            )
 
-
-def _ensure_receipt_place(
-    image_id: str,
-    receipt_id: int,
-    dynamo_client: DynamoClient,
-    *,
-    word_results: Optional[List[dict]] = None,
-    batch_id: Optional[str] = None,
-) -> bool:
-    """Synchronous wrapper for async place creation.
-
-    Returns:
-        True if place exists or was created; False if the receipt entity
-        is missing (orphaned).  Raises on transient errors.
-    """
-    return asyncio.run(
-        _ensure_receipt_place_async(
+    error_msg = result.get("error", "")
+    # These messages indicate the agent ran fully but could not find the merchant.
+    permanent_phrases = (
+        "agent could not find correct place",
+        "merchant_name is missing",
+        "no google places place_id",
+    )
+    if any(p in error_msg.lower() for p in permanent_phrases):
+        logger.warning(
+            "Place finder could not identify merchant; receipt is permanently unplaceable",
             image_id=image_id,
             receipt_id=receipt_id,
-            dynamo_client=dynamo_client,
-            word_results=word_results,
-            batch_id=batch_id,
+            reasoning=result.get("reasoning"),
         )
+        return False
+
+    raise RuntimeError(
+        f"fix_place Lambda returned failure for {image_id}#{receipt_id}: {error_msg}"
     )
 
 

--- a/infra/embedding_step_functions/unified_embedding/handlers/word_polling.py
+++ b/infra/embedding_step_functions/unified_embedding/handlers/word_polling.py
@@ -13,6 +13,7 @@ from functools import wraps
 from typing import Any, Callable, Dict, List, Optional, TypeVar
 
 import boto3
+from botocore.config import Config
 from openai import OpenAI
 from receipt_chroma.data.chroma_client import ChromaClient
 from receipt_chroma.embedding.delta import save_word_embeddings_as_delta
@@ -71,6 +72,10 @@ logger = get_operation_logger(__name__)
 
 
 s3_client = boto3.client("s3")
+# fix_place_lambda can run up to 900s; extend read timeout to cover its full budget.
+_fix_place_lambda_client = boto3.client(
+    "lambda", config=Config(read_timeout=910, connect_timeout=10)
+)
 
 
 # Type variable for retry decorator
@@ -240,7 +245,6 @@ def _ensure_receipt_place(
     if not fix_place_fn:
         raise RuntimeError("FIX_PLACE_LAMBDA_NAME environment variable not set")
 
-    lambda_client = boto3.client("lambda")
     payload = json.dumps({
         "image_id": image_id,
         "receipt_id": receipt_id,
@@ -248,7 +252,7 @@ def _ensure_receipt_place(
     }).encode()
 
     try:
-        response = lambda_client.invoke(
+        response = _fix_place_lambda_client.invoke(
             FunctionName=fix_place_fn,
             InvocationType="RequestResponse",
             Payload=payload,


### PR DESCRIPTION
## Summary

- `word_polling.py` and `line_polling.py` each ran their own copy of the place-finder agent (ChromaDB snapshot download, LangGraph, OpenRouter, Google Places API, DynamoDB write). This created two diverging code paths.
- The poll lambdas were stuck on `openai/gpt-oss-120b` (a reasoning-mandatory model that returns HTTP 400 when called without reasoning params), causing every missing-place receipt to fail transiently in a retry loop.
- `fix_place_lambda` already owns the canonical implementation using `x-ai/grok-4.3` with 3-attempt retry logic and Chroma Cloud.

`_ensure_receipt_place` in both handlers now does a boto3 `lambda:invoke` on `fix-place-{stack}-fix-place`. The poll lambdas no longer carry `receipt_agent`, `receipt_places`, OpenRouter, or Google Places env vars.

**IAM**: added `lambda:InvokeFunction` on `fix-place-{stack}-fix-place` to the unified embedding role.

## Net change
- −407 lines of duplicated agent setup code removed from handlers
- Single place-finder implementation to maintain going forward
- Model changes only need to happen in one place (`fix_place_lambda/infrastructure.py`)

## Test plan
- [ ] CI passes (Lambda Syntax + Python jobs)
- [ ] After deploy: kick `word-ingest-sf-prod-2b98dad` and `line-ingest-sf-prod-a6116b0` and confirm they complete without place-finder errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)