### PR TITLE
feat(infra): add ECR lifecycle policies to auto-clean old images

### DIFF
--- a/infra/components/codebuild_docker_image.py
+++ b/infra/components/codebuild_docker_image.py
@@ -41,6 +41,7 @@ from pulumi_aws.codepipeline import (
     PipelineStageArgs,
 )
 from pulumi_aws.ecr import (
+    LifecyclePolicy,
     Repository,
     RepositoryImageScanningConfigurationArgs,
     RepositoryPolicy,
@@ -154,6 +155,41 @@ class CodeBuildDockerImage(ComponentResource):
             ),
             force_delete=True,
             opts=ResourceOptions(parent=self),
+        )
+
+        # Lifecycle policy: expire untagged images after 1 day, keep last 10 tagged
+        LifecyclePolicy(
+            f"{self.name}-repo-lifecycle",
+            repository=self.ecr_repo.name,
+            policy=json.dumps(
+                {
+                    "rules": [
+                        {
+                            "rulePriority": 1,
+                            "description": "Expire untagged images after 1 day",
+                            "selection": {
+                                "tagStatus": "untagged",
+                                "countType": "sinceImagePushed",
+                                "countUnit": "days",
+                                "countNumber": 1,
+                            },
+                            "action": {"type": "expire"},
+                        },
+                        {
+                            "rulePriority": 2,
+                            "description": "Keep last 10 tagged images",
+                            "selection": {
+                                "tagStatus": "tagged",
+                                "tagPatternList": ["*"],
+                                "countType": "imageCountMoreThan",
+                                "countNumber": 10,
+                            },
+                            "action": {"type": "expire"},
+                        },
+                    ]
+                }
+            ),
+            opts=ResourceOptions(parent=self.ecr_repo),
         )
 
         # Add ECR repository policy to allow Lambda to pull images

--- a/infra/components/emr_serverless_docker_image.py
+++ b/infra/components/emr_serverless_docker_image.py
@@ -37,6 +37,7 @@ from pulumi_aws.codepipeline import (
     PipelineStageArgs,
 )
 from pulumi_aws.ecr import (
+    LifecyclePolicy,
     Repository,
     RepositoryImageScanningConfigurationArgs,
     RepositoryPolicy,
@@ -215,6 +216,41 @@ class EMRServerlessDockerImage(ComponentResource):
             ),
             force_delete=True,
             opts=ResourceOptions(parent=self),
+        )
+
+        # Lifecycle policy: expire untagged images after 1 day, keep last 10 tagged
+        LifecyclePolicy(
+            f"{self.name}-emr-repo-lifecycle",
+            repository=self.ecr_repo.name,
+            policy=json.dumps(
+                {
+                    "rules": [
+                        {
+                            "rulePriority": 1,
+                            "description": "Expire untagged images after 1 day",
+                            "selection": {
+                                "tagStatus": "untagged",
+                                "countType": "sinceImagePushed",
+                                "countUnit": "days",
+                                "countNumber": 1,
+                            },
+                            "action": {"type": "expire"},
+                        },
+                        {
+                            "rulePriority": 2,
+                            "description": "Keep last 10 tagged images",
+                            "selection": {
+                                "tagStatus": "tagged",
+                                "tagPatternList": ["*"],
+                                "countType": "imageCountMoreThan",
+                                "countNumber": 10,
+                            },
+                            "action": {"type": "expire"},
+                        },
+                    ]
+                }
+            ),
+            opts=ResourceOptions(parent=self.ecr_repo),
         )
 
         # Add ECR repository policy to allow EMR Serverless to pull images

--- a/scripts/apply_ecr_lifecycle_policies.sh
+++ b/scripts/apply_ecr_lifecycle_policies.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# apply_ecr_lifecycle_policies.sh
+#
+# Applies a standard ECR lifecycle policy to ALL existing repositories in the
+# current AWS account/region immediately, without waiting for Pulumi to touch
+# each repo.
+#
+# Policy:
+#   Rule 1 (priority 1): expire untagged images after 1 day
+#   Rule 2 (priority 2): keep only the last 10 tagged images
+#
+# Usage:
+#   ./scripts/apply_ecr_lifecycle_policies.sh [--region us-east-1] [--dry-run]
+#
+# Prerequisites: aws CLI configured with sufficient permissions
+#   ecr:DescribeRepositories, ecr:PutLifecyclePolicy
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Defaults
+# ---------------------------------------------------------------------------
+REGION="${AWS_DEFAULT_REGION:-us-east-1}"
+DRY_RUN=false
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --region)
+      REGION="$2"
+      shift 2
+      ;;
+    --dry-run)
+      DRY_RUN=true
+      shift
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      echo "Usage: $0 [--region REGION] [--dry-run]" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# ---------------------------------------------------------------------------
+# Lifecycle policy JSON
+# ---------------------------------------------------------------------------
+LIFECYCLE_POLICY=$(cat <<'EOF'
+{
+  "rules": [
+    {
+      "rulePriority": 1,
+      "description": "Expire untagged images after 1 day",
+      "selection": {
+        "tagStatus": "untagged",
+        "countType": "sinceImagePushed",
+        "countUnit": "days",
+        "countNumber": 1
+      },
+      "action": {"type": "expire"}
+    },
+    {
+      "rulePriority": 2,
+      "description": "Keep last 10 tagged images",
+      "selection": {
+        "tagStatus": "tagged",
+        "tagPatternList": ["*"],
+        "countType": "imageCountMoreThan",
+        "countNumber": 10
+      },
+      "action": {"type": "expire"}
+    }
+  ]
+}
+EOF
+)
+
+# ---------------------------------------------------------------------------
+# Gather all repository names (handles pagination automatically via --no-paginate
+# equivalent: aws ecr describe-repositories pages automatically in recent CLI)
+# ---------------------------------------------------------------------------
+echo "Fetching ECR repositories in region '${REGION}'..."
+
+REPOS=$(aws ecr describe-repositories \
+  --region "${REGION}" \
+  --query 'repositories[*].repositoryName' \
+  --output text)
+
+if [[ -z "$REPOS" ]]; then
+  echo "No ECR repositories found in region '${REGION}'."
+  exit 0
+fi
+
+REPO_COUNT=$(echo "$REPOS" | wc -w | tr -d ' ')
+echo "Found ${REPO_COUNT} repositories."
+
+if [[ "$DRY_RUN" == "true" ]]; then
+  echo "[DRY-RUN] Would apply lifecycle policy to:"
+  for REPO in $REPOS; do
+    echo "  - ${REPO}"
+  done
+  echo "[DRY-RUN] No changes were made."
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Apply policy to each repo
+# ---------------------------------------------------------------------------
+SUCCESS=0
+FAILED=0
+
+for REPO in $REPOS; do
+  echo -n "  Applying policy to '${REPO}'... "
+  if aws ecr put-lifecycle-policy \
+    --region "${REGION}" \
+    --repository-name "${REPO}" \
+    --lifecycle-policy-text "${LIFECYCLE_POLICY}" \
+    --output text > /dev/null 2>&1; then
+    echo "OK"
+    SUCCESS=$((SUCCESS + 1))
+  else
+    echo "FAILED"
+    FAILED=$((FAILED + 1))
+  fi
+done
+
+echo ""
+echo "Done. ${SUCCESS} succeeded, ${FAILED} failed (out of ${REPO_COUNT} total)."
+if [[ $FAILED -gt 0 ]]; then
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- **2 repo definitions updated**: `CodeBuildDockerImage` (`infra/components/codebuild_docker_image.py`) and `EMRServerlessDockerImage` (`infra/components/emr_serverless_docker_image.py`) — these are the only two places in the codebase that call `aws.ecr.Repository` directly; every other ECR reference delegates to one of these components.
- Each repo now has an `aws.ecr.LifecyclePolicy` resource placed immediately after its `Repository`, parented to the repo (`ResourceOptions(parent=self.ecr_repo)`).
- `LifecyclePolicy` was added to the `pulumi_aws.ecr` import in both files (no new dependency — already part of `pulumi-aws`).

## Policy rules applied to every repo

| Priority | Targets | Action |
|---|---|---|
| 1 | Untagged images | Expire after **1 day** |
| 2 | Tagged images (`*`) | Keep last **10**, expire the rest |

## Immediate cleanup: shell script

`scripts/apply_ecr_lifecycle_policies.sh` (executable) applies the identical policy to **all existing ECR repos right now** via `aws ecr put-lifecycle-policy`, without waiting for a `pulumi up` to touch each repo. Supports `--region` and `--dry-run` flags.

```bash
# Preview what will be touched
./scripts/apply_ecr_lifecycle_policies.sh --dry-run

# Apply to all repos in us-east-1
./scripts/apply_ecr_lifecycle_policies.sh --region us-east-1
```

## What was NOT changed

- No changes to IAM policies, CodeBuild/CodePipeline config, or Lambda setup.
- No `pulumi up` was run.

## Test plan

- [ ] Run `./scripts/apply_ecr_lifecycle_policies.sh --dry-run` to confirm all 50 repos are listed
- [ ] Run the script without `--dry-run` to apply immediately and start reclaiming the 2.2 TB
- [ ] On next `pulumi up`, verify Pulumi creates the two `LifecyclePolicy` resources without errors
- [ ] Confirm in AWS console that lifecycle policies appear on newly created repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic lifecycle management for container image repositories, which expires untagged images after 1 day and retains only the 10 most recent tagged images.
  * Added utility script to apply lifecycle policies across all repositories in a region with dry-run support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->