### PR TITLE
fix(fix-place): handle concurrent ReceiptPlace write race

### DIFF
--- a/infra/fix_place_lambda/lambdas/fix_place.py
+++ b/infra/fix_place_lambda/lambdas/fix_place.py
@@ -42,6 +42,8 @@ import os
 from datetime import datetime, timezone
 from typing import Any
 
+from botocore.exceptions import ClientError
+
 # LangSmith tracing - ensure traces are flushed before Lambda exits
 try:
     from langsmith.run_trees import get_cached_client as get_langsmith_client
@@ -375,5 +377,18 @@ def _update_receipt_place(
         timestamp=now,
     )
 
-    dynamo_client.add_receipt_place(new_place)
+    try:
+        dynamo_client.add_receipt_place(new_place)
+    except ClientError as exc:
+        if exc.response["Error"]["Code"] != "ConditionalCheckFailedException":
+            raise
+        # A concurrent invocation (e.g. word vs. line poll) already wrote
+        # the ReceiptPlace. Our agent found the same place, so this is a
+        # success — don't fail just because we lost the write race.
+        logger.info(
+            "ReceiptPlace already created by concurrent invocation for "
+            "%s#%s — treating as success",
+            image_id,
+            receipt_id,
+        )
     return new_place


### PR DESCRIPTION
## Summary

- Word and line poll lambdas invoke `fix_place_lambda` simultaneously for the same receipt when it has no `ReceiptPlace`
- Both agents race to `add_receipt_place` in DynamoDB; the loser gets `ConditionalCheckFailedException`
- Previously this propagated as `"Error fixing place"` → `success: False` → step function failure
- Fix: catch `ConditionalCheckFailedException` on the create path and treat it as success — the place was already written correctly by the concurrent winner

## Root cause evidence (CloudWatch)

Both word poll (`c550d7c7`) and line poll (`582bfa2c`) invoked fix_place for `d2ef1ed7#1` at 22:38:16. Line won at 22:38:46; word got "Error fixing place" at 22:38:53. Same pattern for `5925105a#1` (roles reversed). Both agents independently found the correct place — Skull's Rainbow Room / Target.

## Test plan

- [ ] Deploy via CI container build
- [ ] Kick word-ingest-sf-prod and line-ingest-sf-prod step functions
- [ ] Both pass `d2ef1ed7#1` and `5925105a#1` without error
- [ ] CloudWatch shows "ReceiptPlace already created by concurrent invocation" log instead of "Error fixing place"

🤖 Generated with [Claude Code](https://claude.com/claude-code)