### PR TITLE
fix(ecr): remove duplicate lifecycle policy from CodeBuildDockerImage base

### DIFF
--- a/infra/components/codebuild_docker_image.py
+++ b/infra/components/codebuild_docker_image.py
@@ -41,7 +41,6 @@ from pulumi_aws.codepipeline import (
     PipelineStageArgs,
 )
 from pulumi_aws.ecr import (
-    LifecyclePolicy,
     Repository,
     RepositoryImageScanningConfigurationArgs,
     RepositoryPolicy,
@@ -155,41 +154,6 @@ class CodeBuildDockerImage(ComponentResource):
             ),
             force_delete=True,
             opts=ResourceOptions(parent=self),
-        )
-
-        # Lifecycle policy: expire untagged images after 1 day, keep last 10 tagged
-        LifecyclePolicy(
-            f"{self.name}-repo-lifecycle",
-            repository=self.ecr_repo.name,
-            policy=json.dumps(
-                {
-                    "rules": [
-                        {
-                            "rulePriority": 1,
-                            "description": "Expire untagged images after 1 day",
-                            "selection": {
-                                "tagStatus": "untagged",
-                                "countType": "sinceImagePushed",
-                                "countUnit": "days",
-                                "countNumber": 1,
-                            },
-                            "action": {"type": "expire"},
-                        },
-                        {
-                            "rulePriority": 2,
-                            "description": "Keep last 10 tagged images",
-                            "selection": {
-                                "tagStatus": "tagged",
-                                "tagPatternList": ["*"],
-                                "countType": "imageCountMoreThan",
-                                "countNumber": 10,
-                            },
-                            "action": {"type": "expire"},
-                        },
-                    ]
-                }
-            ),
-            opts=ResourceOptions(parent=self.ecr_repo),
         )
 
         # Add ECR repository policy to allow Lambda to pull images

--- a/scripts/apply_ecr_lifecycle_policies.sh
+++ b/scripts/apply_ecr_lifecycle_policies.sh
@@ -29,6 +29,11 @@ DRY_RUN=false
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --region)
+      if [[ $# -lt 2 || -z "${2:-}" || "${2:0:1}" == "-" ]]; then
+        echo "Missing value for --region" >&2
+        echo "Usage: $0 [--region REGION] [--dry-run]" >&2
+        exit 1
+      fi
       REGION="$2"
       shift 2
       ;;


### PR DESCRIPTION
## Summary

- PR #952 added an `aws.ecr.LifecyclePolicy` to the `CodeBuildDockerImage` base class
- The `chromadb_compaction` and `embedding_step_functions` wrapper components already manage their own lifecycle policies on `self.ecr_repo` (the same ECR repo the base creates)
- Result: two Pulumi `LifecyclePolicy` resources targeting the same ECR repository → last writer wins in AWS → Pulumi state drift (Codex P1 from PR #952)

## Fix

- Remove `LifecyclePolicy` from `infra/components/codebuild_docker_image.py` — wrappers already cover their repos; direct users can apply policies via `scripts/apply_ecr_lifecycle_policies.sh`
- Guard `--region` value in the shell script against missing arguments (CodeRabbit minor from PR #952)

## Repos affected

| Component | Policy owner |
|-----------|-------------|
| `chromadb_compaction/components/docker_image.py` | wrapper (pre-existing, configurable `max_age_days`) |
| `embedding_step_functions/components/docker_image.py` | wrapper (pre-existing, configurable `max_age_days`) |
| `emr_serverless_docker_image.py` | base (no wrapper, PR #952 addition kept) |
| All other direct `CodeBuildDockerImage` users | shell script |

## Test plan

- [ ] `pulumi preview` shows no `ecr.LifecyclePolicy` additions/deletions for chromadb or embedding SF repos
- [ ] Deploy completes without resource conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)