### PR TITLE
[codex] Fix staged mobile receipt health transition

### DIFF
--- a/portfolio/components/ui/Figures/ReceiptFlow/ReceiptFlowShell.module.css
+++ b/portfolio/components/ui/Figures/ReceiptFlow/ReceiptFlowShell.module.css
@@ -112,7 +112,16 @@
   }
 
   .receiptContainer.fade-out {
-    animation: mobile-receipt-fade-under 0.6s ease-out forwards;
+    animation: mobile-flow-content-out 0.14s ease-out forwards;
+  }
+
+  .nextReceipt.fade-in {
+    opacity: 1;
+    animation: none;
+  }
+
+  .nextReceipt.fade-in > * {
+    animation: mobile-flow-content-in 0.24s ease-out 0.16s both;
   }
 
   .legendColumn {
@@ -133,21 +142,47 @@
     pointer-events: none;
   }
 
-}
+  .currentLegend.fade-out {
+    animation: mobile-flow-content-out 0.14s ease-out forwards;
+  }
 
-@keyframes mobile-receipt-fade-under {
-  0%,
-  55% {
+  .nextLegend.fade-in {
+    z-index: 2;
     opacity: 1;
+    background: var(--background-color, #fff);
+    animation: none;
   }
 
-  100% {
-    opacity: 0;
+  .nextLegend.fade-in > * {
+    animation: mobile-flow-content-in 0.24s ease-out 0.16s both;
   }
+
 }
 
 @media (max-width: 480px) {
   .centerColumn {
     height: var(--rf-mobile-center-height-sm, 320px);
+  }
+}
+
+@keyframes mobile-flow-content-out {
+  from {
+    opacity: 1;
+  }
+
+  to {
+    opacity: 0;
+  }
+}
+
+@keyframes mobile-flow-content-in {
+  from {
+    opacity: 0;
+    transform: translateY(3px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
   }
 }

--- a/portfolio/components/ui/Figures/ReceiptHealthExplorer/index.tsx
+++ b/portfolio/components/ui/Figures/ReceiptHealthExplorer/index.tsx
@@ -2150,6 +2150,7 @@ export default function ReceiptHealthExplorer() {
   const lastManualSelectionRef = useRef(0);
   const transitionTimerRef = useRef<number | null>(null);
   const transitionInFlightRef = useRef(false);
+  const transitionRequestIdRef = useRef(0);
   const isMountedRef = useRef(true);
   const currentIndexRef = useRef(currentIndex);
   const receiptsRef = useRef(receipts);
@@ -2280,6 +2281,7 @@ export default function ReceiptHealthExplorer() {
       if (transitionTimerRef.current !== null) {
         window.clearTimeout(transitionTimerRef.current);
       }
+      transitionRequestIdRef.current += 1;
       transitionInFlightRef.current = false;
     };
   }, []);
@@ -2369,32 +2371,36 @@ export default function ReceiptHealthExplorer() {
 
     if (transitionTimerRef.current !== null || transitionInFlightRef.current) return;
 
+    const transitionRequestId = transitionRequestIdRef.current + 1;
+    transitionRequestIdRef.current = transitionRequestId;
     transitionInFlightRef.current = true;
+    setTransitionLedgerContext(null);
+    setTransitionTargetIndex(index);
+    setIsTransitioning(true);
+
     fetchLedgerContext(receipt)
       .catch((err) => {
         console.warn("Failed to prefetch receipt health issues:", err);
         return null;
       })
       .then((nextContext) => {
-        if (!isMountedRef.current) {
-          transitionInFlightRef.current = false;
-          return;
-        }
-
+        if (
+          !isMountedRef.current ||
+          transitionRequestIdRef.current !== transitionRequestId
+        ) return;
         setTransitionLedgerContext(nextContext);
-        setTransitionTargetIndex(index);
-        setIsTransitioning(true);
-
-        transitionTimerRef.current = window.setTimeout(() => {
-          setCurrentIndex(index);
-          focusReceiptCheck(receipt);
-          setIsTransitioning(false);
-          setTransitionTargetIndex(null);
-          setTransitionLedgerContext(null);
-          transitionTimerRef.current = null;
-          transitionInFlightRef.current = false;
-        }, TRANSITION_DURATION_MS);
       });
+
+    transitionTimerRef.current = window.setTimeout(() => {
+      setCurrentIndex(index);
+      focusReceiptCheck(receipt);
+      setIsTransitioning(false);
+      setTransitionTargetIndex(null);
+      setTransitionLedgerContext(null);
+      transitionRequestIdRef.current += 1;
+      transitionTimerRef.current = null;
+      transitionInFlightRef.current = false;
+    }, TRANSITION_DURATION_MS);
   }, [fetchLedgerContext, focusReceiptCheck]);
 
   useEffect(() => {

--- a/portfolio/components/ui/Figures/ReceiptHealthExplorer/index.tsx
+++ b/portfolio/components/ui/Figures/ReceiptHealthExplorer/index.tsx
@@ -2135,6 +2135,7 @@ export default function ReceiptHealthExplorer() {
   const [findingIssue, setFindingIssue] = useState(false);
   const [ledgerIssues, setLedgerIssues] = useState<ReceiptHealthLedgerIssue[]>([]);
   const [ledgerSummary, setLedgerSummary] = useState<ReceiptHealthLedgerSummary | null>(null);
+  const [transitionLedgerContext, setTransitionLedgerContext] = useState<LedgerContext | null>(null);
   const [loadingLedgerIssues, setLoadingLedgerIssues] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [hasMore, setHasMore] = useState(false);
@@ -2148,6 +2149,8 @@ export default function ReceiptHealthExplorer() {
   const ledgerContextCacheRef = useRef<Map<string, LedgerContext>>(new Map());
   const lastManualSelectionRef = useRef(0);
   const transitionTimerRef = useRef<number | null>(null);
+  const transitionInFlightRef = useRef(false);
+  const isMountedRef = useRef(true);
   const currentIndexRef = useRef(currentIndex);
   const receiptsRef = useRef(receipts);
   const formatSupport = useImageFormatSupport();
@@ -2214,6 +2217,27 @@ export default function ReceiptHealthExplorer() {
     return scenarioReceipts;
   }, [loadReceipts]);
 
+  const fetchLedgerContext = useCallback(async (
+    receipt: ReceiptHealthReceipt,
+  ): Promise<LedgerContext> => {
+    const contextKey = receiptKey(receipt);
+    const cachedContext = ledgerContextCacheRef.current.get(contextKey);
+    if (cachedContext) return cachedContext;
+
+    const response = await api.fetchReceiptHealthIssues({
+      state: "all",
+      imageId: receipt.image_id,
+      receiptId: receipt.receipt_id,
+      limit: 50,
+    });
+    const nextContext = {
+      issues: response.issues,
+      summary: response.summary ?? null,
+    };
+    ledgerContextCacheRef.current.set(contextKey, nextContext);
+    return nextContext;
+  }, []);
+
   useEffect(() => {
     if (!nearViewport || fetchedInitial.current) return;
     fetchedInitial.current = true;
@@ -2249,10 +2273,14 @@ export default function ReceiptHealthExplorer() {
   }, [receipts]);
 
   useEffect(() => {
+    isMountedRef.current = true;
+
     return () => {
+      isMountedRef.current = false;
       if (transitionTimerRef.current !== null) {
         window.clearTimeout(transitionTimerRef.current);
       }
+      transitionInFlightRef.current = false;
     };
   }, []);
 
@@ -2264,8 +2292,7 @@ export default function ReceiptHealthExplorer() {
       return;
     }
 
-    const contextKey = receiptKey(currentReceipt);
-    const cachedContext = ledgerContextCacheRef.current.get(contextKey);
+    const cachedContext = ledgerContextCacheRef.current.get(receiptKey(currentReceipt));
     if (cachedContext) {
       setLedgerIssues(cachedContext.issues);
       setLedgerSummary(cachedContext.summary);
@@ -2277,19 +2304,9 @@ export default function ReceiptHealthExplorer() {
     setLoadingLedgerIssues(true);
     setLedgerIssues([]);
     setLedgerSummary(null);
-    api.fetchReceiptHealthIssues({
-      state: "all",
-      imageId: currentReceipt.image_id,
-      receiptId: currentReceipt.receipt_id,
-      limit: 50,
-    })
-      .then((response) => {
+    fetchLedgerContext(currentReceipt)
+      .then((nextContext) => {
         if (!cancelled) {
-          const nextContext = {
-            issues: response.issues,
-            summary: response.summary ?? null,
-          };
-          ledgerContextCacheRef.current.set(contextKey, nextContext);
           setLedgerIssues(nextContext.issues);
           setLedgerSummary(nextContext.summary);
         }
@@ -2310,7 +2327,7 @@ export default function ReceiptHealthExplorer() {
     return () => {
       cancelled = true;
     };
-  }, [currentReceipt]);
+  }, [currentReceipt, fetchLedgerContext]);
 
   const orderedChecks = useMemo(() => {
     return orderedChecksForReceipt(currentReceipt);
@@ -2350,19 +2367,35 @@ export default function ReceiptHealthExplorer() {
       return;
     }
 
-    if (transitionTimerRef.current !== null) return;
+    if (transitionTimerRef.current !== null || transitionInFlightRef.current) return;
 
-    setTransitionTargetIndex(index);
-    setIsTransitioning(true);
+    transitionInFlightRef.current = true;
+    fetchLedgerContext(receipt)
+      .catch((err) => {
+        console.warn("Failed to prefetch receipt health issues:", err);
+        return null;
+      })
+      .then((nextContext) => {
+        if (!isMountedRef.current) {
+          transitionInFlightRef.current = false;
+          return;
+        }
 
-    transitionTimerRef.current = window.setTimeout(() => {
-      setCurrentIndex(index);
-      focusReceiptCheck(receipt);
-      setIsTransitioning(false);
-      setTransitionTargetIndex(null);
-      transitionTimerRef.current = null;
-    }, TRANSITION_DURATION_MS);
-  }, [focusReceiptCheck]);
+        setTransitionLedgerContext(nextContext);
+        setTransitionTargetIndex(index);
+        setIsTransitioning(true);
+
+        transitionTimerRef.current = window.setTimeout(() => {
+          setCurrentIndex(index);
+          focusReceiptCheck(receipt);
+          setIsTransitioning(false);
+          setTransitionTargetIndex(null);
+          setTransitionLedgerContext(null);
+          transitionTimerRef.current = null;
+          transitionInFlightRef.current = false;
+        }, TRANSITION_DURATION_MS);
+      });
+  }, [fetchLedgerContext, focusReceiptCheck]);
 
   useEffect(() => {
     if (
@@ -2686,12 +2719,12 @@ export default function ReceiptHealthExplorer() {
               receipt={transitionTargetReceipt}
               checks={transitionTargetChecks}
               activeCheck={transitionTargetCheck}
-              ledgerIssues={[]}
-              ledgerSummary={null}
-              loadingLedgerIssues={true}
+              ledgerIssues={transitionLedgerContext?.issues ?? []}
+              ledgerSummary={transitionLedgerContext?.summary ?? null}
+              loadingLedgerIssues={!transitionLedgerContext}
               receipts={receipts}
               currentIndex={transitionTargetIndex ?? currentIndex}
-              muteExplanations={true}
+              muteExplanations={false}
               onSelectCheck={setActiveCheckId}
               onSelectReceipt={selectReceipt}
             />


### PR DESCRIPTION
## Summary
- Stage the mobile receipt health transition so the outgoing layer fades out before incoming receipt and rail content fades in.
- Keep the incoming receipt and legend on an opaque white layer to prevent overlapping receipt text and mixed validation icons.
- Prefetch the target receipt's ledger context before starting the transition so Merchant/Format/Math explanations are available when the incoming rail appears.
- Add a mounted guard around the async transition prefetch path.

## Validation
- `npm run type-check`
- `npm run lint -- --quiet`
- `NEXT_PUBLIC_API_URL=https://dev-api.tylernorlund.com npm run build`
- Local mobile browser sampling at 390x844 confirmed the outgoing layer reaches opacity 0 before incoming child content fades in, and incoming explanations are populated before the fade-in completes.