### PR TITLE
chore: add promote_dev_to_prod runbook with embedding SF kick

### DIFF
--- a/scripts/promote_dev_to_prod.sh
+++ b/scripts/promote_dev_to_prod.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+# Promote new receipts from dev → prod and kick prod embedding ingestion.
+#
+# Steps:
+#   1. Sync S3 images  (dev → prod bucket)
+#   2. Sync DynamoDB records
+#   3. Sync OCR jobs
+#   4. Sync word labels
+#   5. Start prod word + line embedding step functions
+#
+# Usage: ./scripts/promote_dev_to_prod.sh [--skip-sync] [--skip-embed] [--dry-run]
+#   --skip-sync   Skip S3/DynamoDB sync (useful when already synced)
+#   --skip-embed  Skip step function kick (data-only promotion)
+#   --dry-run     Print what would run, do nothing
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+SKIP_SYNC=false
+SKIP_EMBED=false
+DRY_RUN=false
+
+for arg in "$@"; do
+  case "$arg" in
+    --skip-sync)  SKIP_SYNC=true ;;
+    --skip-embed) SKIP_EMBED=true ;;
+    --dry-run)    DRY_RUN=true ;;
+    --help|-h)
+      sed -n '/^# /p' "$0" | sed 's/^# //'
+      exit 0
+      ;;
+    *)
+      echo -e "${RED}Unknown argument: $arg${NC}" >&2
+      exit 1
+      ;;
+  esac
+done
+
+run() {
+  if [[ "$DRY_RUN" == "true" ]]; then
+    echo -e "${YELLOW}[dry-run] $*${NC}"
+  else
+    "$@"
+  fi
+}
+
+echo -e "${BLUE}=== Promote dev → prod ===${NC}"
+echo ""
+
+# ── Step 1-4: Data sync ─────────────────────────────────────────────────────
+if [[ "$SKIP_SYNC" == "true" ]]; then
+  echo -e "${YELLOW}Skipping data sync (--skip-sync)${NC}"
+else
+  echo -e "${GREEN}[1/4] Syncing S3 images (dev → prod)...${NC}"
+  run bash "$SCRIPT_DIR/sync_images_dev_to_prod_fast.sh"
+  echo ""
+
+  echo -e "${GREEN}[2/4] Syncing DynamoDB records (dev → prod)...${NC}"
+  run python3 "$SCRIPT_DIR/copy_dynamodb_dev_to_prod.py"
+  echo ""
+
+  echo -e "${GREEN}[3/4] Syncing OCR jobs (dev → prod)...${NC}"
+  run python3 "$SCRIPT_DIR/sync_ocr_jobs_dev_to_prod.py"
+  echo ""
+
+  echo -e "${GREEN}[4/4] Syncing word labels (dev → prod)...${NC}"
+  run python3 "$SCRIPT_DIR/sync_labels_dev_to_prod.py"
+  echo ""
+fi
+
+# ── Step 5: Kick prod embedding SFs ─────────────────────────────────────────
+if [[ "$SKIP_EMBED" == "true" ]]; then
+  echo -e "${YELLOW}Skipping embedding step functions (--skip-embed)${NC}"
+else
+  echo -e "${GREEN}[5/5] Starting prod embedding step functions...${NC}"
+  run bash "$SCRIPT_DIR/start_ingestion_prod.sh" both
+  echo ""
+  echo -e "${BLUE}Monitor ingestion:${NC}"
+  echo "  aws stepfunctions list-executions --state-machine-arn \$(aws stepfunctions list-state-machines --query 'stateMachines[?contains(name,\`word-ingest-sf-prod\`)].stateMachineArn' --output text) --query 'executions[0]' --output json"
+fi
+
+echo ""
+echo -e "${GREEN}Done. Prod embedding will run in the background.${NC}"

--- a/scripts/start_ingestion_prod.sh
+++ b/scripts/start_ingestion_prod.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# Start prod embedding ingestion step functions (word + line).
+# Usage: ./scripts/start_ingestion_prod.sh [line|word|both]
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INFRA_DIR="$(dirname "$SCRIPT_DIR")/infra"
+
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+WORKFLOW_TYPE="${1:-both}"
+
+case "$WORKFLOW_TYPE" in
+  line|word|both) ;;
+  --help|-h)
+    echo "Usage: $0 [line|word|both]"
+    echo "Default: both"
+    exit 0
+    ;;
+  *)
+    echo -e "${RED}Unknown argument: $WORKFLOW_TYPE${NC}" >&2
+    echo "Usage: $0 [line|word|both]" >&2
+    exit 1
+    ;;
+esac
+
+cd "$INFRA_DIR"
+
+echo -e "${YELLOW}Fetching prod Step Function ARNs...${NC}"
+
+PULUMI_OUTPUTS=$(pulumi stack output --stack tnorlund/portfolio/prod --json 2>/dev/null) || PULUMI_OUTPUTS="{}"
+LINE_INGEST_ARN=$(echo "$PULUMI_OUTPUTS" | python3 -c "import sys,json; d=json.load(sys.stdin); v=d.get('embedding_line_ingest_sf_arn'); print((v.get('value','') if isinstance(v,dict) else v) or '')" 2>/dev/null || echo "")
+WORD_INGEST_ARN=$(echo "$PULUMI_OUTPUTS" | python3 -c "import sys,json; d=json.load(sys.stdin); v=d.get('embedding_word_ingest_sf_arn'); print((v.get('value','') if isinstance(v,dict) else v) or '')" 2>/dev/null || echo "")
+
+# Fallback to AWS CLI
+if [[ -z "$LINE_INGEST_ARN" ]]; then
+  LINE_INGEST_ARN=$(aws stepfunctions list-state-machines --query 'stateMachines[?contains(name,`line-ingest`) && contains(name,`prod`)].stateMachineArn' --output text 2>/dev/null | head -1)
+fi
+if [[ -z "$WORD_INGEST_ARN" ]]; then
+  WORD_INGEST_ARN=$(aws stepfunctions list-state-machines --query 'stateMachines[?contains(name,`word-ingest`) && contains(name,`prod`)].stateMachineArn' --output text 2>/dev/null | head -1)
+fi
+
+start_sf() {
+  local ARN="$1" TYPE="$2"
+  if [[ -z "$ARN" ]]; then
+    echo -e "${YELLOW}Skipping $TYPE — ARN not found${NC}" >&2
+    return
+  fi
+  local NAME="manual-run-$(date +%s)-$TYPE"
+  local EXEC_ARN
+  EXEC_ARN=$(aws stepfunctions start-execution --state-machine-arn "$ARN" --name "$NAME" --query 'executionArn' --output text)
+  echo -e "${GREEN}Started $TYPE ingestion: $EXEC_ARN${NC}"
+  echo "$EXEC_ARN"
+}
+
+case "$WORKFLOW_TYPE" in
+  line)
+    [[ -z "$LINE_INGEST_ARN" ]] && { echo -e "${RED}Could not find line-ingest SF${NC}" >&2; exit 1; }
+    start_sf "$LINE_INGEST_ARN" "line"
+    ;;
+  word)
+    [[ -z "$WORD_INGEST_ARN" ]] && { echo -e "${RED}Could not find word-ingest SF${NC}" >&2; exit 1; }
+    start_sf "$WORD_INGEST_ARN" "word"
+    ;;
+  both)
+    [[ -z "$LINE_INGEST_ARN" ]] && echo -e "${YELLOW}Warning: line-ingest SF not found${NC}" >&2
+    [[ -z "$WORD_INGEST_ARN" ]] && echo -e "${YELLOW}Warning: word-ingest SF not found${NC}" >&2
+    [[ -n "$LINE_INGEST_ARN" ]] && start_sf "$LINE_INGEST_ARN" "line"
+    [[ -n "$WORD_INGEST_ARN" ]] && start_sf "$WORD_INGEST_ARN" "word"
+    ;;
+esac


### PR DESCRIPTION
## Summary

Adds the promote-dev-to-prod runbook requested in the embedding pipeline repair work.

- **`scripts/promote_dev_to_prod.sh`** — one-command dev→prod promotion: syncs S3 images, DynamoDB records, OCR jobs, word labels, then kicks both prod embedding step functions
- **`scripts/start_ingestion_prod.sh`** — standalone script to start word/line/both prod ingestion SFs (mirrors `start_ingestion_dev.sh`)

## Flags

| Flag | Effect |
|------|--------|
| `--skip-sync` | Skip S3/DynamoDB sync (already synced) |
| `--skip-embed` | Skip SF kick (data-only promotion) |
| `--dry-run` | Print what would run, nothing executed |

## Test plan

- [ ] `./scripts/promote_dev_to_prod.sh --dry-run` prints all steps without executing
- [ ] `./scripts/start_ingestion_prod.sh word` starts only word SF on prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)