### PR TITLE
[codex] Fix receipt label hygiene

### DIFF
--- a/infra/upload_images/container_ocr/handler/ocr_processor.py
+++ b/infra/upload_images/container_ocr/handler/ocr_processor.py
@@ -21,7 +21,12 @@ from PIL import Image as PIL_Image
 from PIL import UnidentifiedImageError
 from PIL.Image import Resampling, Transform
 from receipt_dynamo import DynamoClient
-from receipt_dynamo.constants import ImageType, OCRJobType, OCRStatus
+from receipt_dynamo.constants import (
+    ImageType,
+    OCRJobType,
+    OCRStatus,
+    ValidationStatus,
+)
 from receipt_dynamo.entities import (
     Image,
     Letter,
@@ -822,6 +827,7 @@ class OCRProcessor:
         letters_to_delete: list[ReceiptLetter] = []
         letters_to_add: list[ReceiptLetter] = []
         words_rejected = 0
+        changed_word_ids: set[tuple[int, int]] = set()
 
         for new_word, existing_word in matches:
             # Guard 3a: Absolute confidence floor.
@@ -883,6 +889,11 @@ class OCRProcessor:
                 )
                 words_rejected += 1
                 continue
+
+            if new_word.text != existing_word.text:
+                changed_word_ids.add(
+                    (existing_word.line_id, existing_word.word_id)
+                )
 
             existing_word.text = new_word.text
             existing_word.bounding_box = new_word.bounding_box
@@ -1070,10 +1081,41 @@ class OCRProcessor:
                 orphan.word_id,
             )
 
+        deleted_word_ids = {(w.line_id, w.word_id) for w in words_to_delete}
+        labels_to_revalidate = [
+            label
+            for label in labels
+            if (label.line_id, label.word_id) in changed_word_ids
+            and (label.line_id, label.word_id) not in deleted_word_ids
+        ]
+        labels_to_delete = [
+            label
+            for label in labels
+            if (label.line_id, label.word_id) in deleted_word_ids
+        ]
+
+        for label in labels_to_revalidate:
+            label.validation_status = ValidationStatus.PENDING.value
+            label.label_proposed_by = "regional_reocr_revalidation"
+            label.reasoning = (
+                "Regional re-OCR changed this word text; label requires "
+                "revalidation."
+            )
+
+        labels_for_embedding = [
+            label
+            for label in labels
+            if (label.line_id, label.word_id) not in deleted_word_ids
+        ]
+
         if words_to_update:
             self.dynamo.update_receipt_words(words_to_update)
         if words_to_add:
             self.dynamo.add_receipt_words(words_to_add)
+        if labels_to_revalidate:
+            self.dynamo.update_receipt_word_labels(labels_to_revalidate)
+        if labels_to_delete:
+            self.dynamo.delete_receipt_word_labels(labels_to_delete)
         # Delete old letters BEFORE adding replacements. The old letters
         # and new letters can share the same (line_id, word_id, letter_id)
         # keys, so adding first then deleting would clobber the new data.
@@ -1157,7 +1199,9 @@ class OCRProcessor:
                     receipt_id=ocr_job.receipt_id,
                     chromadb_bucket=self.chromadb_bucket,
                     dynamo_client=self.dynamo,
-                    receipt_word_labels=labels if labels else None,
+                    receipt_word_labels=(
+                        labels_for_embedding if labels_for_embedding else None
+                    ),
                 )
                 embedding_result = create_embeddings_and_compaction_run(
                     receipt_lines=all_lines,
@@ -1188,6 +1232,8 @@ class OCRProcessor:
             "words_added": len(words_to_add),
             "words_deleted": len(words_to_delete),
             "words_rejected": words_rejected,
+            "labels_revalidated": len(labels_to_revalidate),
+            "labels_deleted": len(labels_to_delete),
             "lines_rebuilt": len(lines_to_update),
             "compaction_run_id": compaction_run_id,
         }

--- a/infra/upload_images/container_ocr/handler/tests/test_overlay.py
+++ b/infra/upload_images/container_ocr/handler/tests/test_overlay.py
@@ -26,7 +26,13 @@ if _container_ocr_dir not in sys.path:
     sys.path.insert(0, _container_ocr_dir)
 
 import pytest
-from receipt_dynamo.entities import ReceiptLetter, ReceiptLine, ReceiptWord
+from receipt_dynamo.constants import ValidationStatus
+from receipt_dynamo.entities import (
+    ReceiptLetter,
+    ReceiptLine,
+    ReceiptWord,
+    ReceiptWordLabel,
+)
 
 # Import OCRProcessor via importlib to avoid pytest's package resolution
 # chain through infra/upload_images/__init__.py (which imports Pulumi).
@@ -129,6 +135,26 @@ def _make_letter(
         angle_degrees=0.0,
         angle_radians=0.0,
         **g,
+    )
+
+
+def _make_label(
+    image_id: str = _IMG_ID,
+    receipt_id: int = 1,
+    line_id: int = 1,
+    word_id: int = 1,
+    label: str = "LINE_TOTAL",
+    validation_status: str = ValidationStatus.VALID.value,
+) -> ReceiptWordLabel:
+    return ReceiptWordLabel(
+        image_id=image_id,
+        receipt_id=receipt_id,
+        line_id=line_id,
+        word_id=word_id,
+        label=label,
+        reasoning="Test label",
+        timestamp_added="2026-01-01T00:00:00+00:00",
+        validation_status=validation_status,
     )
 
 
@@ -523,7 +549,12 @@ class TestUnmatchedWordAddition:
 
         proc.dynamo.list_receipt_words_from_receipt.return_value = existing_words
         proc.dynamo.list_receipt_word_labels_for_receipt.return_value = (
-            [SimpleNamespace(line_id=l.line_id, word_id=l.word_id) for l in (labels or [])],
+            [
+                l
+                if hasattr(l, "label")
+                else SimpleNamespace(line_id=l.line_id, word_id=l.word_id)
+                for l in (labels or [])
+            ],
             None,
         )
         proc.dynamo.list_receipt_letters_from_word.return_value = []
@@ -615,6 +646,51 @@ class TestUnmatchedWordAddition:
         assert proc.dynamo.update_receipt_lines.called
         updated_lines = proc.dynamo.update_receipt_lines.call_args[0][0]
         assert any("8.68" in line.text for line in updated_lines)
+
+    def test_changed_word_label_reset_to_pending(self):
+        """When re-OCR changes word text, attached labels need revalidation."""
+        proc = _make_processor()
+        existing = _make_word(
+            text="579199", x=0.1, y=0.5, w=0.15, h=0.05,
+            line_id=1, word_id=1,
+        )
+        new_word = _make_word(
+            text="579.99", x=0.1, y=0.5, w=0.15, h=0.05,
+            line_id=1, word_id=1,
+        )
+        label = _make_label(line_id=1, word_id=1)
+
+        result = self._run_overlay(
+            proc, [existing], [new_word], labels=[label]
+        )
+
+        assert result["labels_revalidated"] == 1
+        proc.dynamo.update_receipt_word_labels.assert_called_once()
+        updated_labels = proc.dynamo.update_receipt_word_labels.call_args[0][0]
+        assert (
+            updated_labels[0].validation_status
+            == ValidationStatus.PENDING.value
+        )
+        assert (
+            updated_labels[0].label_proposed_by
+            == "regional_reocr_revalidation"
+        )
+
+    def test_deleted_word_labels_are_removed(self):
+        """Labels attached to words deleted by re-OCR must not be orphaned."""
+        proc = _make_processor()
+        existing = _make_word(
+            text="GARBLED", x=0.1, y=0.5, w=0.15, h=0.05,
+            line_id=1, word_id=1,
+        )
+        label = _make_label(line_id=1, word_id=1)
+
+        result = self._run_overlay(proc, [existing], [], labels=[label])
+
+        assert result["labels_deleted"] == 1
+        proc.dynamo.delete_receipt_word_labels.assert_called_once()
+        deleted_labels = proc.dynamo.delete_receipt_word_labels.call_args[0][0]
+        assert deleted_labels == [label]
 
 
 # ===========================================================================

--- a/receipt_ocr_swift/Sources/ReceiptOCRCore/Models/ReceiptWordLabel.swift
+++ b/receipt_ocr_swift/Sources/ReceiptOCRCore/Models/ReceiptWordLabel.swift
@@ -15,6 +15,31 @@ public enum ValidationStatus: String {
 /// Represents a label for a word in a receipt line, matching DynamoDB schema.
 /// This mirrors the Python ReceiptWordLabel entity in receipt_dynamo.
 public struct ReceiptWordLabel: Equatable {
+    private static let coreLabels: Set<String> = [
+        "ADDRESS_LINE",
+        "CASH_BACK",
+        "CHANGE",
+        "COUPON",
+        "DATE",
+        "DISCOUNT",
+        "GRAND_TOTAL",
+        "LINE_TOTAL",
+        "LOYALTY_ID",
+        "MERCHANT_NAME",
+        "PAYMENT_METHOD",
+        "PHONE_NUMBER",
+        "PRODUCT_NAME",
+        "QUANTITY",
+        "REFUND",
+        "STORE_HOURS",
+        "SUBTOTAL",
+        "TAX",
+        "TIME",
+        "TIP",
+        "UNIT_PRICE",
+        "WEBSITE",
+    ]
+
     public let imageId: String
     public let receiptId: Int
     public let lineId: Int
@@ -173,11 +198,11 @@ public struct ReceiptWordLabel: Equatable {
                 let rawLabel = linePred.labels[wordIndex]
                 let confidence = linePred.confidences[wordIndex]
 
-                // Strip B-/I- prefix
-                let strippedLabel = stripBIOPrefix(rawLabel)
+                // Strip B-/I- prefix and keep only canonical CORE_LABELS.
+                let strippedLabel = stripBIOPrefix(rawLabel).uppercased()
 
                 // Skip "O" labels (Other/None) - they don't provide meaningful labeling
-                if strippedLabel == "O" {
+                if strippedLabel == "O" || !coreLabels.contains(strippedLabel) {
                     continue
                 }
 

--- a/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/ReceiptWordLabelTests.swift
+++ b/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/ReceiptWordLabelTests.swift
@@ -1,0 +1,29 @@
+import XCTest
+@testable import ReceiptOCRCore
+
+final class ReceiptWordLabelTests: XCTestCase {
+    func test_fromLinePredictions_filtersNonCoreMergePresetLabels() {
+        let predictions = [
+            LinePrediction(
+                tokens: ["store", "123", "visa", "tip"],
+                labels: [
+                    "B-MERCHANT_NAME",
+                    "B-AMOUNT",
+                    "B-CARD_NUMBER",
+                    "B-TIP",
+                ],
+                confidences: [0.95, 0.91, 0.88, 0.93],
+                allProbabilities: nil
+            )
+        ]
+
+        let labels = ReceiptWordLabel.fromLinePredictions(
+            predictions: predictions,
+            imageId: "img-1",
+            receiptId: 1
+        )
+
+        XCTAssertEqual(labels.map(\.label), ["MERCHANT_NAME", "TIP"])
+        XCTAssertEqual(labels.map(\.wordId), [1, 4])
+    }
+}

--- a/receipt_upload/receipt_upload/label_validation/label_normalization.py
+++ b/receipt_upload/receipt_upload/label_validation/label_normalization.py
@@ -1,0 +1,35 @@
+"""Helpers for keeping receipt word labels inside CORE_LABELS."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from receipt_dynamo.constants import CORE_LABELS
+
+
+NON_CORE_LABEL_ALIASES: dict[str, str] = {
+    "ADDRESS": "ADDRESS_LINE",
+    "BUSINESS_NAME": "MERCHANT_NAME",
+    "CARD_NUMBER": "PAYMENT_METHOD",
+    "PAYMENT_TYPE": "PAYMENT_METHOD",
+}
+
+
+def canonical_label_name(label: Any) -> str:
+    """Normalize a model or stored label into the Dynamo label format."""
+    if label is None:
+        return ""
+    return str(label).strip().upper()
+
+
+def is_core_label(label: Any) -> bool:
+    """Return whether a label is part of the canonical receipt label set."""
+    return canonical_label_name(label) in CORE_LABELS
+
+
+def normalize_label_alias(label: Any) -> str | None:
+    """Map known non-core aliases to CORE_LABELS, if the mapping is safe."""
+    canonical = canonical_label_name(label)
+    if canonical in CORE_LABELS:
+        return canonical
+    return NON_CORE_LABEL_ALIASES.get(canonical)

--- a/receipt_upload/receipt_upload/label_validation/llm_validator.py
+++ b/receipt_upload/receipt_upload/label_validation/llm_validator.py
@@ -25,6 +25,8 @@ from pydantic import BaseModel, Field, ValidationError
 from receipt_agent.constants import CORE_LABELS
 from receipt_agent.utils.llm_factory import create_resilient_llm
 
+from .label_normalization import canonical_label_name, normalize_label_alias
+
 logger = logging.getLogger(__name__)
 
 # Enable Langsmith tracing if API key is set
@@ -48,9 +50,9 @@ ConfidenceType = Literal["high", "medium", "low"]
 # Note: Some extra labels are included so Pydantic parsing succeeds if LLM
 # returns them. These are NOT valid final labels:
 #   - AMOUNT: Merged label that needs reclassification
-#   - TIP: LLM sometimes returns this for gratuity amounts
 #   - NEEDS_REVIEW: LLM incorrectly uses this as a label (should be decision)
-# convert_structured_response() handles these by marking them NEEDS_REVIEW.
+#   - PAYMENT_TYPE/CARD_NUMBER/ADDRESS/BUSINESS_NAME: safe aliases
+# convert_structured_response() normalizes these before Dynamo writes.
 LabelType = Literal[
     "MERCHANT_NAME",
     "STORE_HOURS",
@@ -69,14 +71,20 @@ LabelType = Literal[
     "LINE_TOTAL",
     "SUBTOTAL",
     "TAX",
+    "TIP",
     "GRAND_TOTAL",
     "CHANGE",
     "CASH_BACK",
     "REFUND",
     # Invalid labels that LLM sometimes returns - handled in post-processing
     "AMOUNT",
-    "TIP",
+    "ADDRESS",
+    "BUSINESS_NAME",
+    "CARD_NUMBER",
+    "NULL",
+    "PAYMENT_TYPE",
     "NEEDS_REVIEW",
+    "UNLABELED",
 ]
 
 
@@ -117,6 +125,40 @@ class LLMValidationResult:
     label: str  # Final label (original if VALID, corrected if INVALID)
     confidence: str  # "high", "medium", "low"
     reasoning: str
+
+
+def _sanitize_label_decision(
+    candidate_label: Any,
+    original_label: Any,
+    decision: str,
+    reasoning: str,
+) -> tuple[str, str, str]:
+    """Normalize label values before they reach Dynamo write code."""
+    original = canonical_label_name(original_label)
+    candidate = canonical_label_name(candidate_label)
+    mapped_candidate = normalize_label_alias(candidate)
+
+    if mapped_candidate:
+        if mapped_candidate != original:
+            decision = "INVALID"
+            if candidate != mapped_candidate:
+                reasoning = (
+                    f"Mapped non-core label '{candidate}' to "
+                    f"'{mapped_candidate}'. {reasoning}"
+                )
+        return mapped_candidate, decision, reasoning
+
+    if original in CORE_LABELS:
+        decision = "NEEDS_REVIEW"
+        reasoning = f"Invalid label '{candidate}'. {reasoning}"
+        return original, decision, reasoning
+
+    decision = "NEEDS_REVIEW"
+    reasoning = (
+        f"Original label '{original}' and LLM label '{candidate}' are not "
+        f"in CORE_LABELS. {reasoning}"
+    )
+    return original, decision, reasoning
 
 
 def convert_structured_response(
@@ -193,23 +235,12 @@ def convert_structured_response(
         confidence = llm_decision.confidence
         reasoning = llm_decision.reasoning
 
-        if final_label not in CORE_LABELS:
-            logger.warning(
-                "LLM returned invalid label '%s', keeping original '%s'",
-                final_label,
-                label["label"],
-            )
-            final_label = label["label"]
-            if decision_str == "INVALID":
-                decision_str = "NEEDS_REVIEW"
-                reasoning = (
-                    f"Invalid label '{llm_decision.label}'. {reasoning}"
-                )
-
-        # AMOUNT is not a valid CORE_LABEL - force NEEDS_REVIEW if it persists
-        if final_label == "AMOUNT":
-            decision_str = "NEEDS_REVIEW"
-            reasoning = f"AMOUNT requires reclassification to LINE_TOTAL/SUBTOTAL/TAX/GRAND_TOTAL. {reasoning}"
+        final_label, decision_str, reasoning = _sanitize_label_decision(
+            candidate_label=final_label,
+            original_label=label["label"],
+            decision=decision_str,
+            reasoning=reasoning,
+        )
 
         # If INVALID but label unchanged, mark as NEEDS_REVIEW
         if decision_str == "INVALID" and final_label == label["label"]:
@@ -678,20 +709,12 @@ def parse_validation_response(
         confidence = llm_result.get("confidence", "medium")
         reasoning = llm_result.get("reasoning", "")
 
-        # Validate label is in CORE_LABELS
-        if final_label not in CORE_LABELS:
-            logger.warning(
-                "LLM returned invalid label '%s', keeping original '%s'",
-                final_label,
-                label["label"],
-            )
-            final_label = label["label"]
-            # If decision was INVALID but label is invalid, mark as NEEDS_REVIEW
-            if decision == "INVALID":
-                decision = "NEEDS_REVIEW"
-                reasoning = (
-                    f"Invalid label '{llm_result.get('label')}'. {reasoning}"
-                )
+        final_label, decision, reasoning = _sanitize_label_decision(
+            candidate_label=final_label,
+            original_label=label["label"],
+            decision=decision,
+            reasoning=reasoning,
+        )
 
         if decision == "INVALID" and final_label == label["label"]:
             decision = "NEEDS_REVIEW"

--- a/receipt_upload/receipt_upload/merchant_resolution/embedding_processor.py
+++ b/receipt_upload/receipt_upload/merchant_resolution/embedding_processor.py
@@ -30,6 +30,7 @@ import shutil
 import tempfile
 import uuid
 from concurrent.futures import ProcessPoolExecutor, as_completed
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Tuple, Type
 
 import boto3
@@ -55,6 +56,9 @@ from receipt_upload.label_validation import (
     LightweightLabelValidator,
     LLMBatchValidator,
 )
+from receipt_upload.label_validation.label_normalization import (
+    normalize_label_alias,
+)
 from receipt_upload.label_validation.langsmith_logging import (
     log_label_validation,
     log_merchant_resolution,
@@ -65,6 +69,61 @@ from receipt_upload.merchant_resolution.resolver import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _prepare_pending_core_labels(
+    dynamo: Any,
+    word_labels: List[ReceiptWordLabel],
+    label_proposed_by: str,
+) -> List[ReceiptWordLabel]:
+    """Remove non-core pending labels before validation starts."""
+    existing_keys = {
+        (label.line_id, label.word_id, label.label) for label in word_labels
+    }
+    pending_core_labels: List[ReceiptWordLabel] = []
+
+    for label in list(word_labels):
+        if label.validation_status != ValidationStatus.PENDING.value:
+            continue
+        if label.label == "O":
+            continue
+        if label.label in CORE_LABELS:
+            pending_core_labels.append(label)
+            continue
+
+        mapped_label = normalize_label_alias(label.label)
+        original_label = label.label
+        dynamo.delete_receipt_word_label(label)
+        word_labels.remove(label)
+
+        if mapped_label is None:
+            continue
+
+        mapped_key = (label.line_id, label.word_id, mapped_label)
+        if mapped_key in existing_keys:
+            continue
+
+        new_label = ReceiptWordLabel(
+            image_id=label.image_id,
+            receipt_id=label.receipt_id,
+            line_id=label.line_id,
+            word_id=label.word_id,
+            label=mapped_label,
+            reasoning=(
+                f"Mapped from non-core label '{original_label}' before "
+                "validation."
+            ),
+            timestamp_added=datetime.now(timezone.utc),
+            validation_status=ValidationStatus.PENDING.value,
+            label_proposed_by=f"{label_proposed_by}:{original_label}",
+            label_consolidated_from=original_label,
+        )
+        dynamo.add_receipt_word_label(new_label)
+        word_labels.append(new_label)
+        existing_keys.add(mapped_key)
+        pending_core_labels.append(new_label)
+
+    return pending_core_labels
 
 
 def _get_traceable():
@@ -392,11 +451,11 @@ def _run_words_pipeline_worker(
             dynamo = DynamoClient(table_name)
             validation_stats: Dict[str, Any] = {}
 
-            pending_labels = [
-                wl
-                for wl in word_labels
-                if wl.validation_status == ValidationStatus.PENDING.value
-            ]
+            pending_labels = _prepare_pending_core_labels(
+                dynamo=dynamo,
+                word_labels=word_labels,
+                label_proposed_by="non_core_label_guard",
+            )
 
             if pending_labels:
                 from receipt_upload.label_validation import ValidationDecision
@@ -1355,14 +1414,12 @@ class MerchantResolvingEmbeddingProcessor:
                 "chroma_validated": 0,
             }
 
-        # Filter to only PENDING labels, excluding "O" (no-label) which don't need validation
-        pending_label_entities = [
-            label
-            for label in word_labels
-            if label.validation_status == ValidationStatus.PENDING.value
-            and label.label
-            != "O"  # Skip "O" labels - they're background/no-label
-        ]
+        # Filter to only valid PENDING CORE labels, excluding "O" (no-label).
+        pending_label_entities = _prepare_pending_core_labels(
+            dynamo=self.dynamo,
+            word_labels=word_labels,
+            label_proposed_by="non_core_label_guard",
+        )
 
         # Count "O" labels for logging
         o_label_count = sum(

--- a/receipt_upload/test/test_embedding_processor_label_hygiene.py
+++ b/receipt_upload/test/test_embedding_processor_label_hygiene.py
@@ -1,0 +1,54 @@
+from unittest.mock import MagicMock
+
+from receipt_dynamo.constants import ValidationStatus
+from receipt_dynamo.entities import ReceiptWordLabel
+from receipt_upload.merchant_resolution.embedding_processor import (
+    _prepare_pending_core_labels,
+)
+
+
+def _label(label: str) -> ReceiptWordLabel:
+    return ReceiptWordLabel(
+        image_id="00000000-0000-4000-8000-000000000001",
+        receipt_id=1,
+        line_id=1,
+        word_id=1,
+        label=label,
+        reasoning="test",
+        timestamp_added="2026-01-01T00:00:00+00:00",
+        validation_status=ValidationStatus.PENDING.value,
+    )
+
+
+def test_prepare_pending_core_labels_maps_safe_aliases():
+    dynamo = MagicMock()
+    original = _label("PAYMENT_TYPE")
+    word_labels = [original]
+
+    pending = _prepare_pending_core_labels(
+        dynamo=dynamo,
+        word_labels=word_labels,
+        label_proposed_by="test_guard",
+    )
+
+    assert original not in word_labels
+    dynamo.delete_receipt_word_label.assert_called_once_with(original)
+    dynamo.add_receipt_word_label.assert_called_once()
+    assert len(pending) == 1
+    assert pending[0].label == "PAYMENT_METHOD"
+    assert pending[0].validation_status == ValidationStatus.PENDING.value
+
+
+def test_prepare_pending_core_labels_deletes_ambiguous_labels():
+    dynamo = MagicMock()
+    original = _label("AMOUNT")
+
+    pending = _prepare_pending_core_labels(
+        dynamo=dynamo,
+        word_labels=[original],
+        label_proposed_by="test_guard",
+    )
+
+    assert pending == []
+    dynamo.delete_receipt_word_label.assert_called_once_with(original)
+    dynamo.add_receipt_word_label.assert_not_called()

--- a/receipt_upload/test/test_llm_validator.py
+++ b/receipt_upload/test/test_llm_validator.py
@@ -206,6 +206,43 @@ class TestParseValidationResponse:
         assert results[0].label == "GRAND_TOTAL"
         assert "invalid" in results[0].reasoning.lower()
 
+    def test_parse_alias_label_normalized_to_core_label(self):
+        """Known non-core aliases should become valid CORE_LABELS."""
+        pending_labels = [
+            {"line_id": 1, "word_id": 1, "label": "PAYMENT_TYPE"},
+        ]
+
+        response_text = """
+        [
+            {"index": 0, "decision": "VALID", "label": "PAYMENT_TYPE", "confidence": "high", "reasoning": "Card payment"}
+        ]
+        """
+
+        results = parse_validation_response(response_text, pending_labels)
+
+        assert len(results) == 1
+        assert results[0].decision == "INVALID"
+        assert results[0].label == "PAYMENT_METHOD"
+
+    def test_parse_amount_label_requires_review(self):
+        """Ambiguous merged amount labels should not be guessed."""
+        pending_labels = [
+            {"line_id": 1, "word_id": 1, "label": "AMOUNT"},
+        ]
+
+        response_text = """
+        [
+            {"index": 0, "decision": "VALID", "label": "AMOUNT", "confidence": "high", "reasoning": "Looks monetary"}
+        ]
+        """
+
+        results = parse_validation_response(response_text, pending_labels)
+
+        assert len(results) == 1
+        assert results[0].decision == "NEEDS_REVIEW"
+        assert results[0].label == "AMOUNT"
+        assert "not in core_labels" in results[0].reasoning.lower()
+
 
 class TestConvertStructuredResponse:
     """Test the convert_structured_response function with Pydantic models."""
@@ -370,6 +407,30 @@ class TestConvertStructuredResponse:
         # INVALID but same label should become NEEDS_REVIEW
         assert results[0].decision == "NEEDS_REVIEW"
         assert "without a corrected label" in results[0].reasoning.lower()
+
+    def test_convert_alias_label_normalized_to_core_label(self):
+        """Structured responses can normalize safe non-core aliases."""
+        pending_labels = [
+            {"line_id": 1, "word_id": 1, "label": "CARD_NUMBER"},
+        ]
+
+        response = LabelValidationResponse(
+            decisions=[
+                LabelDecision(
+                    index=0,
+                    decision="VALID",
+                    label="CARD_NUMBER",
+                    confidence="high",
+                    reasoning="Card digits",
+                ),
+            ]
+        )
+
+        results = convert_structured_response(response, pending_labels)
+
+        assert len(results) == 1
+        assert results[0].decision == "INVALID"
+        assert results[0].label == "PAYMENT_METHOD"
 
     def test_convert_empty_decisions(self):
         """Test that empty decisions list marks all as NEEDS_REVIEW."""


### PR DESCRIPTION
## Summary

- Reset regional re-OCR labels to pending when word text changes, and delete labels for words removed by the overlay.
- Filter Swift OCR auto-label writes to the core label set.
- Normalize safe non-core aliases before LLM validation while deleting ambiguous pending non-core labels instead of guessing.

## Root cause

The receipt cleanup paths had three ways to preserve invalid label state: re-OCR could mutate words without invalidating dependent labels, Swift OCR could emit merge-preset/non-core labels, and the LLM validation path could keep or write non-core labels such as `PAYMENT_TYPE`, `CARD_NUMBER`, and `AMOUNT`.

## Validation

- `PYTHONPATH="$PWD/receipt_upload:$PWD/receipt_agent:$PWD/receipt_dynamo:$PWD/receipt_chroma:$PWD/receipt_dynamo_stream:$PWD/receipt_places" /usr/local/bin/python3.12 -m pytest receipt_upload/test/test_llm_validator.py receipt_upload/test/test_embedding_processor_label_hygiene.py` — 22 passed
- `PYTHONPATH="$PWD/handler:$PWD/../../../receipt_upload:$PWD/../../../receipt_agent:$PWD/../../../receipt_dynamo:$PWD/../../../receipt_chroma:$PWD/../../../receipt_dynamo_stream:$PWD/../../../receipt_places" /usr/local/bin/python3.12 -m pytest handler/tests/test_overlay.py` from `infra/upload_images/container_ocr` — 53 passed
- `swift build --package-path receipt_ocr_swift --target ReceiptOCRCore` — passed

Local caveat: `swift test --package-path receipt_ocr_swift --filter ReceiptWordLabelTests` could not run in this CommandLineTools Swift environment because it cannot import `XCTest`; the `ReceiptOCRCore` target itself builds cleanly.

Fixes #921
Fixes #822
Fixes #823
