### PR TITLE
[codex] Polish receipt health transitions

### DIFF
--- a/portfolio/components/ui/Figures/ReceiptFlow/ReceiptFlowShell.module.css
+++ b/portfolio/components/ui/Figures/ReceiptFlow/ReceiptFlowShell.module.css
@@ -112,20 +112,21 @@
   }
 
   .receiptContainer.fade-out {
-    animation: mobile-flow-content-out 0.14s ease-out forwards;
+    animation: mobile-flow-content-out 0.16s ease-out forwards;
   }
 
   .nextReceipt.fade-in {
-    opacity: 1;
-    animation: none;
+    opacity: 0;
+    animation: mobile-flow-panel-in 0.28s ease-out 0.1s both;
   }
 
   .nextReceipt.fade-in > * {
-    animation: mobile-flow-content-in 0.24s ease-out 0.16s both;
+    animation: mobile-flow-content-rise 0.28s ease-out 0.1s both;
   }
 
   .legendColumn {
     width: 100%;
+    min-height: 9rem;
   }
 
   .currentLegend {
@@ -143,18 +144,18 @@
   }
 
   .currentLegend.fade-out {
-    animation: mobile-flow-content-out 0.14s ease-out forwards;
+    animation: mobile-flow-content-out 0.16s ease-out forwards;
   }
 
   .nextLegend.fade-in {
     z-index: 2;
-    opacity: 1;
+    opacity: 0;
     background: var(--background-color, #fff);
-    animation: none;
+    animation: mobile-flow-panel-in 0.28s ease-out 0.1s both;
   }
 
   .nextLegend.fade-in > * {
-    animation: mobile-flow-content-in 0.24s ease-out 0.16s both;
+    animation: mobile-flow-content-rise 0.28s ease-out 0.1s both;
   }
 
 }
@@ -175,14 +176,22 @@
   }
 }
 
-@keyframes mobile-flow-content-in {
+@keyframes mobile-flow-panel-in {
   from {
     opacity: 0;
-    transform: translateY(3px);
   }
 
   to {
     opacity: 1;
+  }
+}
+
+@keyframes mobile-flow-content-rise {
+  from {
+    transform: translateY(3px);
+  }
+
+  to {
     transform: translateY(0);
   }
 }

--- a/portfolio/components/ui/Figures/ReceiptFlow/ReceiptFlowShell.module.css
+++ b/portfolio/components/ui/Figures/ReceiptFlow/ReceiptFlowShell.module.css
@@ -50,12 +50,32 @@
   flex-shrink: 0;
 }
 
+.legendColumnOverlay {
+  display: grid;
+  align-items: center;
+  width: var(--rf-legend-width, auto);
+  min-height: var(--rf-legend-height, auto);
+}
+
 .currentLegend {
   display: contents;
 }
 
+.legendColumnOverlay .currentLegend,
+.legendColumnOverlay .nextLegend {
+  grid-area: 1 / 1;
+  display: block;
+  width: 100%;
+  min-height: var(--rf-legend-stage-height, auto);
+}
+
 .nextLegend {
   display: none;
+}
+
+.legendColumnOverlay .nextLegend {
+  opacity: 0;
+  pointer-events: none;
 }
 
 .fade-out {
@@ -81,6 +101,7 @@
     flex-direction: column;
     gap: 1rem;
     align-items: center;
+    min-height: var(--rf-mobile-shell-height, var(--rf-center-height, 500px));
   }
 
   .queuePane {
@@ -126,7 +147,17 @@
 
   .legendColumn {
     width: 100%;
-    min-height: 9rem;
+    min-height: var(--rf-mobile-legend-height, 9rem);
+  }
+
+  .legendColumnOverlay {
+    height: var(--rf-mobile-legend-height, auto);
+    min-height: var(--rf-mobile-legend-height, 9rem);
+  }
+
+  .legendColumnOverlay .currentLegend,
+  .legendColumnOverlay .nextLegend {
+    min-height: var(--rf-mobile-legend-height, var(--rf-legend-stage-height, auto));
   }
 
   .currentLegend {
@@ -161,6 +192,10 @@
 }
 
 @media (max-width: 480px) {
+  .mainWrapper {
+    min-height: var(--rf-mobile-shell-height-sm, var(--rf-mobile-shell-height, var(--rf-center-height, 500px)));
+  }
+
   .centerColumn {
     height: var(--rf-mobile-center-height-sm, 320px);
   }

--- a/portfolio/components/ui/Figures/ReceiptFlow/ReceiptFlowShell.tsx
+++ b/portfolio/components/ui/Figures/ReceiptFlow/ReceiptFlowShell.tsx
@@ -9,6 +9,7 @@ interface ReceiptFlowShellProps {
   next?: React.ReactNode;
   nextLegend?: React.ReactNode;
   isTransitioning: boolean;
+  stabilizeLegend?: boolean;
   layoutVars?: React.CSSProperties;
 }
 
@@ -20,8 +21,11 @@ export const ReceiptFlowShell: React.FC<ReceiptFlowShellProps> = ({
   next,
   nextLegend,
   isTransitioning,
+  stabilizeLegend = false,
   layoutVars,
 }) => {
+  const useLegendOverlay = stabilizeLegend || Boolean(nextLegend);
+
   return (
     <div className={styles.mainWrapper} style={layoutVars} data-rf-shell>
       <div className={styles.queuePane}>{queue}</div>
@@ -40,7 +44,9 @@ export const ReceiptFlowShell: React.FC<ReceiptFlowShellProps> = ({
         ) : null}
       </div>
 
-      <div className={styles.legendColumn}>
+      <div
+        className={`${styles.legendColumn} ${useLegendOverlay ? styles.legendColumnOverlay : ""}`}
+      >
         <div
           className={`${styles.currentLegend} ${isTransitioning && nextLegend ? styles["fade-out"] : ""}`}
         >

--- a/portfolio/components/ui/Figures/ReceiptHealthExplorer/ReceiptHealthExplorer.module.css
+++ b/portfolio/components/ui/Figures/ReceiptHealthExplorer/ReceiptHealthExplorer.module.css
@@ -60,6 +60,10 @@
   animation: receipt-health-fade-in 0.28s ease-out both;
 }
 
+.flowActiveReceiptNoIntro {
+  animation: none;
+}
+
 .flowReceiptImageWrapper {
   position: relative;
   width: 100%;
@@ -110,6 +114,14 @@
   gap: 0.7rem;
   flex-shrink: 0;
   padding: 1rem;
+}
+
+.flowEntityLegendNoIntro .validationReasonSlotVisible {
+  transition: none;
+}
+
+.flowEntityLegendNoIntro .validationReasonInnerVisible {
+  animation: none;
 }
 
 .diagnosisRail {

--- a/portfolio/components/ui/Figures/ReceiptHealthExplorer/index.tsx
+++ b/portfolio/components/ui/Figures/ReceiptHealthExplorer/index.tsx
@@ -63,6 +63,72 @@ type LedgerContext = {
   summary: ReceiptHealthLedgerSummary | null;
 };
 
+const emptyLedgerContext: LedgerContext = {
+  issues: [],
+  summary: null,
+};
+
+function imageUrlMatches(src: string, target: string): boolean {
+  if (!src) return false;
+
+  try {
+    return src === new URL(target, window.location.href).href;
+  } catch {
+    return src === target;
+  }
+}
+
+function setReceiptImageFallback(image: HTMLImageElement, fallbackUrl: string): boolean {
+  if (imageUrlMatches(image.currentSrc || image.src, fallbackUrl)) {
+    return false;
+  }
+
+  image.src = fallbackUrl;
+  return true;
+}
+
+function preloadReceiptImageForTransition(
+  receipt: ReceiptHealthReceipt,
+  formatSupport: ImageFormatSupport,
+): Promise<void> {
+  const imageUrl = getBestImageUrl(receipt, formatSupport, "medium");
+  const fallbackUrl = getJpegFallbackUrl(receipt);
+
+  return new Promise((resolve) => {
+    let settled = false;
+    let attemptedFallback = imageUrl === fallbackUrl;
+    const image = new Image();
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      resolve();
+    };
+    const timeout = window.setTimeout(finish, 2500);
+    const finishAndClear = () => {
+      window.clearTimeout(timeout);
+      finish();
+    };
+
+    image.onload = () => {
+      const decode = image.decode?.();
+      if (decode) {
+        decode.then(finishAndClear).catch(finishAndClear);
+        return;
+      }
+      finishAndClear();
+    };
+    image.onerror = () => {
+      if (!attemptedFallback) {
+        attemptedFallback = true;
+        image.src = fallbackUrl;
+        return;
+      }
+      finishAndClear();
+    };
+    image.src = imageUrl;
+  });
+}
+
 const FLOW_MOCK_SCENARIOS: Array<{
   label: string;
   imageId: string;
@@ -419,8 +485,7 @@ function ReceiptImage({
           }}
           onError={(event) => {
             const fallback = getJpegFallbackUrl(receipt);
-            if (event.currentTarget.src !== fallback) {
-              event.currentTarget.src = fallback;
+            if (setReceiptImageFallback(event.currentTarget, fallback)) {
               return;
             }
             setImageFailed(true);
@@ -1700,9 +1765,7 @@ function ReceiptHealthFlowQueue({
                 className={styles.flowQueuedReceiptImage}
                 onError={(event) => {
                   const fallback = getJpegFallbackUrl(receipt);
-                  if (event.currentTarget.src !== fallback) {
-                    event.currentTarget.src = fallback;
-                  }
+                  setReceiptImageFallback(event.currentTarget, fallback);
                 }}
               />
             ) : null}
@@ -1716,18 +1779,20 @@ function ReceiptHealthFlowQueue({
 function ReceiptHealthFlowReceipt({
   receipt,
   activeCheck,
+  formatSupport,
+  suppressIntro = false,
   onImageUnavailable,
 }: {
   receipt: ReceiptHealthReceipt;
   activeCheck: ReceiptHealthCheck;
+  formatSupport: ImageFormatSupport;
+  suppressIntro?: boolean;
   onImageUnavailable: (receipt: ReceiptHealthReceipt) => void;
 }) {
-  const formatSupport = useImageFormatSupport();
   const [naturalSize, setNaturalSize] = useState<{ width: number; height: number } | null>(null);
   const [imageFailed, setImageFailed] = useState(false);
 
   const imageUrl = useMemo(() => {
-    if (!formatSupport) return null;
     return getBestImageUrl(receipt, formatSupport, "medium");
   }, [formatSupport, receipt]);
 
@@ -1750,7 +1815,12 @@ function ReceiptHealthFlowReceipt({
   const color = STATUS_COLOR[activeCheck.status];
 
   return (
-    <div className={styles.flowActiveReceipt}>
+    <div
+      className={[
+        styles.flowActiveReceipt,
+        suppressIntro ? styles.flowActiveReceiptNoIntro : "",
+      ].filter(Boolean).join(" ")}
+    >
       <div className={styles.flowReceiptImageWrapper}>
         <div className={styles.flowReceiptImageInner}>
           {/* eslint-disable-next-line @next/next/no-img-element */}
@@ -1771,8 +1841,7 @@ function ReceiptHealthFlowReceipt({
             }}
             onError={(event) => {
               const fallback = getJpegFallbackUrl(receipt);
-              if (event.currentTarget.src !== fallback) {
-                event.currentTarget.src = fallback;
+              if (setReceiptImageFallback(event.currentTarget, fallback)) {
                 return;
               }
               setImageFailed(true);
@@ -1940,6 +2009,7 @@ function ReceiptHealthFlowLegend({
   receipts,
   currentIndex,
   muteExplanations = false,
+  suppressIntro = false,
   onSelectCheck,
   onSelectReceipt,
 }: {
@@ -1952,6 +2022,7 @@ function ReceiptHealthFlowLegend({
   receipts: ReceiptHealthReceipt[];
   currentIndex: number;
   muteExplanations?: boolean;
+  suppressIntro?: boolean;
   onSelectCheck: (checkId: CheckId) => void;
   onSelectReceipt: (index: number) => void;
 }) {
@@ -1959,7 +2030,12 @@ function ReceiptHealthFlowLegend({
   const activeLedgerIssue = selectDisplayIssue(ledgerIssues, activeCheck.id) ?? firstLedgerIssue;
 
   return (
-    <aside className={styles.flowEntityLegend}>
+    <aside
+      className={[
+        styles.flowEntityLegend,
+        suppressIntro ? styles.flowEntityLegendNoIntro : "",
+      ].filter(Boolean).join(" ")}
+    >
       <DiagnosisRail
         receipt={receipt}
         checks={checks}
@@ -2068,9 +2144,7 @@ function ReceiptStackNav({
                   className={styles.stackReceiptImage}
                   onError={(event) => {
                     const fallback = getJpegFallbackUrl(receipt);
-                    if (event.currentTarget.src !== fallback) {
-                      event.currentTarget.src = fallback;
-                    }
+                    setReceiptImageFallback(event.currentTarget, fallback);
                   }}
                 />
               ) : (
@@ -2142,11 +2216,13 @@ export default function ReceiptHealthExplorer() {
   const [totalCount, setTotalCount] = useState(0);
   const [isTransitioning, setIsTransitioning] = useState(false);
   const [transitionTargetIndex, setTransitionTargetIndex] = useState<number | null>(null);
+  const [promotedReceiptKey, setPromotedReceiptKey] = useState<string | null>(null);
   const [unavailableImageKeys, setUnavailableImageKeys] = useState<Set<string>>(
     () => new Set(),
   );
   const fetchedInitial = useRef(false);
   const ledgerContextCacheRef = useRef<Map<string, LedgerContext>>(new Map());
+  const ledgerContextRequestCacheRef = useRef<Map<string, Promise<LedgerContext>>>(new Map());
   const lastManualSelectionRef = useRef(0);
   const transitionTimerRef = useRef<number | null>(null);
   const transitionInFlightRef = useRef(false);
@@ -2225,18 +2301,27 @@ export default function ReceiptHealthExplorer() {
     const cachedContext = ledgerContextCacheRef.current.get(contextKey);
     if (cachedContext) return cachedContext;
 
-    const response = await api.fetchReceiptHealthIssues({
+    const pendingContext = ledgerContextRequestCacheRef.current.get(contextKey);
+    if (pendingContext) return pendingContext;
+
+    const contextRequest = api.fetchReceiptHealthIssues({
       state: "all",
       imageId: receipt.image_id,
       receiptId: receipt.receipt_id,
       limit: 50,
+    }).then((response) => {
+      const nextContext = {
+        issues: response.issues,
+        summary: response.summary ?? null,
+      };
+      ledgerContextCacheRef.current.set(contextKey, nextContext);
+      return nextContext;
+    }).finally(() => {
+      ledgerContextRequestCacheRef.current.delete(contextKey);
     });
-    const nextContext = {
-      issues: response.issues,
-      summary: response.summary ?? null,
-    };
-    ledgerContextCacheRef.current.set(contextKey, nextContext);
-    return nextContext;
+
+    ledgerContextRequestCacheRef.current.set(contextKey, contextRequest);
+    return contextRequest;
   }, []);
 
   useEffect(() => {
@@ -2356,9 +2441,9 @@ export default function ReceiptHealthExplorer() {
     }
   }, []);
 
-  const selectReceipt = useCallback((index: number, options: { manual?: boolean } = {}) => {
+  const selectReceipt = useCallback(async (index: number, options: { manual?: boolean } = {}) => {
     const receipt = receiptsRef.current[index];
-    if (!receipt) return;
+    if (!receipt || !formatSupport) return;
 
     if (options.manual ?? true) {
       lastManualSelectionRef.current = Date.now();
@@ -2375,25 +2460,48 @@ export default function ReceiptHealthExplorer() {
     transitionRequestIdRef.current = transitionRequestId;
     transitionInFlightRef.current = true;
     setTransitionLedgerContext(null);
+    setTransitionTargetIndex(null);
+
+    let prefetchedLedgerContext =
+      ledgerContextCacheRef.current.get(receiptKey(receipt)) ?? null;
+    const ledgerContextPromise = fetchLedgerContext(receipt)
+      .catch((err): LedgerContext => {
+        console.warn("Failed to prefetch receipt health issues:", err);
+        return emptyLedgerContext;
+      })
+      .then((nextContext) => {
+        prefetchedLedgerContext = nextContext;
+        return nextContext;
+      });
+    await preloadReceiptImageForTransition(receipt, formatSupport);
+
+    if (
+      !isMountedRef.current ||
+      transitionRequestIdRef.current !== transitionRequestId
+    ) {
+      transitionInFlightRef.current = false;
+      return;
+    }
+
+    setPromotedReceiptKey(null);
+    setTransitionLedgerContext(prefetchedLedgerContext ?? emptyLedgerContext);
     setTransitionTargetIndex(index);
     setIsTransitioning(true);
 
-    fetchLedgerContext(receipt)
-      .catch((err) => {
-        console.warn("Failed to prefetch receipt health issues:", err);
-        return null;
-      })
-      .then((nextContext) => {
-        if (
-          !isMountedRef.current ||
-          transitionRequestIdRef.current !== transitionRequestId
-        ) return;
-        setTransitionLedgerContext(nextContext);
-      });
-
     transitionTimerRef.current = window.setTimeout(() => {
+      const nextReceiptKey = receiptKey(receipt);
+      if (prefetchedLedgerContext) {
+        setLedgerIssues(prefetchedLedgerContext.issues);
+        setLedgerSummary(prefetchedLedgerContext.summary);
+        setLoadingLedgerIssues(false);
+      } else {
+        setLedgerIssues([]);
+        setLedgerSummary(null);
+        setLoadingLedgerIssues(true);
+      }
       setCurrentIndex(index);
       focusReceiptCheck(receipt);
+      setPromotedReceiptKey(nextReceiptKey);
       setIsTransitioning(false);
       setTransitionTargetIndex(null);
       setTransitionLedgerContext(null);
@@ -2401,7 +2509,8 @@ export default function ReceiptHealthExplorer() {
       transitionTimerRef.current = null;
       transitionInFlightRef.current = false;
     }, TRANSITION_DURATION_MS);
-  }, [fetchLedgerContext, focusReceiptCheck]);
+    void ledgerContextPromise;
+  }, [fetchLedgerContext, focusReceiptCheck, formatSupport]);
 
   useEffect(() => {
     if (
@@ -2600,9 +2709,7 @@ export default function ReceiptHealthExplorer() {
         receiptId={receiptId}
         onImageError={(event) => {
           const fallback = getJpegFallbackUrl(flyingItem);
-          if (event.currentTarget.src !== fallback) {
-            event.currentTarget.src = fallback;
-          }
+          setReceiptImageFallback(event.currentTarget, fallback);
         }}
       />
     );
@@ -2690,6 +2797,8 @@ export default function ReceiptHealthExplorer() {
             key={receiptKey(currentReceipt)}
             receipt={currentReceipt}
             activeCheck={activeCheck}
+            formatSupport={formatSupport}
+            suppressIntro={promotedReceiptKey === receiptKey(currentReceipt)}
             onImageUnavailable={handleImageUnavailable}
           />
         }
@@ -2700,6 +2809,7 @@ export default function ReceiptHealthExplorer() {
               key={`next-${receiptKey(transitionTargetReceipt)}`}
               receipt={transitionTargetReceipt}
               activeCheck={transitionTargetCheck}
+              formatSupport={formatSupport}
               onImageUnavailable={handleImageUnavailable}
             />
           ) : null
@@ -2715,6 +2825,7 @@ export default function ReceiptHealthExplorer() {
             receipts={receipts}
             currentIndex={currentIndex}
             muteExplanations={isTransitioning}
+            suppressIntro={promotedReceiptKey === receiptKey(currentReceipt)}
             onSelectCheck={setActiveCheckId}
             onSelectReceipt={selectReceipt}
           />

--- a/portfolio/components/ui/Figures/ReceiptHealthExplorer/index.tsx
+++ b/portfolio/components/ui/Figures/ReceiptHealthExplorer/index.tsx
@@ -2477,6 +2477,12 @@ export default function ReceiptHealthExplorer() {
       })
       .then((nextContext) => {
         prefetchedLedgerContext = nextContext;
+        if (
+          isMountedRef.current &&
+          transitionRequestIdRef.current === transitionRequestId
+        ) {
+          setTransitionLedgerContext(nextContext);
+        }
         return nextContext;
       });
     await preloadReceiptImageForTransition(receipt, formatSupport);

--- a/portfolio/components/ui/Figures/ReceiptHealthExplorer/index.tsx
+++ b/portfolio/components/ui/Figures/ReceiptHealthExplorer/index.tsx
@@ -52,8 +52,14 @@ const FLOW_LAYOUT_VARS = {
   "--rf-queue-height": "400px",
   "--rf-center-max-width": "350px",
   "--rf-center-height": "500px",
+  "--rf-legend-width": "280px",
+  "--rf-legend-height": "500px",
+  "--rf-legend-stage-height": "280px",
   "--rf-mobile-center-height": "400px",
   "--rf-mobile-center-height-sm": "320px",
+  "--rf-mobile-legend-height": "212px",
+  "--rf-mobile-shell-height": "628px",
+  "--rf-mobile-shell-height-sm": "548px",
   "--rf-gap": "1.5rem",
   "--rf-align-items": "center",
 } as React.CSSProperties;
@@ -2784,6 +2790,7 @@ export default function ReceiptHealthExplorer() {
       <ReceiptFlowShell
         layoutVars={FLOW_LAYOUT_VARS}
         isTransitioning={isTransitioning}
+        stabilizeLegend
         queue={
           <ReceiptHealthFlowQueue
             receipts={receipts}

--- a/portfolio/utils/imageFormat.ts
+++ b/portfolio/utils/imageFormat.ts
@@ -204,7 +204,7 @@ export const getBestImageUrl = (
 };
 
 /**
- * Preload full-size and thumbnail images for all receipts so they're
+ * Preload full-size, medium, and thumbnail images for all receipts so they're
  * browser-cached before flying-receipt animations need them.
  * Uses a ref-based set to avoid re-fetching already-preloaded URLs,
  * which keeps it efficient for components that continuously append receipts.
@@ -223,6 +223,12 @@ export const usePreloadReceiptImages = (
         preloadedRef.current.add(fullUrl);
         const img = new Image();
         img.src = fullUrl;
+      }
+      const mediumUrl = getBestImageUrl(image, formatSupport, "medium");
+      if (mediumUrl !== fullUrl && !preloadedRef.current.has(mediumUrl)) {
+        preloadedRef.current.add(mediumUrl);
+        const img = new Image();
+        img.src = mediumUrl;
       }
       const thumbUrl = getBestImageUrl(image, formatSupport, "thumbnail");
       if (thumbUrl !== fullUrl && !preloadedRef.current.has(thumbUrl)) {


### PR DESCRIPTION
## Summary

Polishes the receipt-health flow transition so switching receipts no longer flashes `Loading`, blanks the incoming receipt panel, drops the validation explanation, or replays the promoted receipt intro animation.

## Root Cause

The transition started before the incoming receipt image and ledger context were both ready. At commit time the target receipt remounted as the normal center receipt, which re-applied intro animations and briefly relied on the regular ledger fetch path again.

## Changes

- Preload incoming medium receipt images before starting the transition.
- Prefetch and promote the incoming ledger context at the same time as the receipt commit.
- Suppress the one-time receipt and legend intro animations only for the receipt that was just promoted.
- Align mobile receipt and legend fades and reserve legend height during transitions.
- Harden receipt image fallback URL handling so normalized browser URLs do not cause repeated fallback attempts.

## Validation

- `npm run type-check`
- `npm run lint -- --quiet`
- Playwright visual checks on mobile `390x844` and desktop `1280x900`, confirming no loading flash, no blank image panel, stable figure height, persistent explanation text, and clean transition-layer unmount after commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added animation suppression options for receipt and legend displays to enhance UI flexibility.

* **Improvements**
  * Enhanced image preloading strategy with optimized medium-sized variants for faster load times.
  * Refined receipt transition animations with improved fade-in and rise effects.
  * Improved image fallback handling for more reliable display across receipt flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->