### PR TITLE
fix(milk-cache): add OAT/DAT to DAIRY_EXCLUDE_TERMS primary filter

### DIFF
--- a/infra/routes/word_similarity_cache_generator/lambdas/index.py
+++ b/infra/routes/word_similarity_cache_generator/lambdas/index.py
@@ -41,7 +41,7 @@ CHROMA_CLOUD_ENABLED = (
 )
 
 # Exclusion terms for dairy milk filtering
-DAIRY_EXCLUDE_TERMS = ["CHOCOLATE", "CHOC", "COCONUT", "ALMOND"]
+DAIRY_EXCLUDE_TERMS = ["CHOCOLATE", "CHOC", "COCONUT", "ALMOND", "OAT", "DAT"]
 
 # Pattern to match price-like tokens (used to extract product name from row text)
 def find_milk_line(lines, target_word: str = "MILK") -> tuple[str, int] | None:


### PR DESCRIPTION
## Summary

- `DAIRY_EXCLUDE_TERMS` (used in the Chroma pre-filter at query time) was missing OAT and DAT — these terms were only added to `find_milk_line`'s local list, which runs *after* lines have already been included as work items
- Without this fix, `PL DAT MILK` (OCR misread of "PL OAT MILK" on Smith's receipt) still appeared in the milk cache as Unknown

## Test plan

- [ ] Deploy via CI on merge
- [ ] Invoke `word-similarity-cache-generator-prod-lambda-prod`
- [ ] Confirm `PL DAT MILK` no longer appears in `milk.json` summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated filtering logic to exclude additional product-related terms from word similarity cache generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->