### PR TITLE
fix(milk-cache): strip dollar sign from price before float conversion

### DIFF
--- a/infra/routes/word_similarity_cache_generator/lambdas/index.py
+++ b/infra/routes/word_similarity_cache_generator/lambdas/index.py
@@ -62,10 +62,7 @@ def find_milk_line(lines, target_word: str = "MILK") -> tuple[str, int] | None:
         if target_word in line.text.upper():
             # Check exclusions
             text_upper = line.text.upper()
-            excluded = any(
-                term in text_upper
-                for term in ["CHOCOLATE", "CHOC", "COCONUT", "ALMOND", "OAT", "DAT"]
-            )
+            excluded = any(term in text_upper for term in DAIRY_EXCLUDE_TERMS)
             if not excluded:
                 return (line.text, line.line_id)
     return None

--- a/infra/routes/word_similarity_cache_generator/lambdas/index.py
+++ b/infra/routes/word_similarity_cache_generator/lambdas/index.py
@@ -777,7 +777,9 @@ def handler(_event, _context):
             )
             if r["price"]:
                 try:
-                    summary[key]["prices"].append(float(r["price"]))
+                    summary[key]["prices"].append(
+                        float(str(r["price"]).replace("$", "").replace(",", ""))
+                    )
                 except ValueError:
                     pass
 

--- a/infra/routes/word_similarity_cache_generator/lambdas/index.py
+++ b/infra/routes/word_similarity_cache_generator/lambdas/index.py
@@ -41,7 +41,7 @@ CHROMA_CLOUD_ENABLED = (
 )
 
 # Exclusion terms for dairy milk filtering
-DAIRY_EXCLUDE_TERMS = ["CHOCOLATE", "CHOC", "COCONUT", "ALMOND"]
+DAIRY_EXCLUDE_TERMS = ["CHOCOLATE", "CHOC", "COCONUT", "ALMOND", "OAT", "DAT"]
 
 # Pattern to match price-like tokens (used to extract product name from row text)
 def find_milk_line(lines, target_word: str = "MILK") -> tuple[str, int] | None:


### PR DESCRIPTION
## Summary
- `float(r["price"])` silently discarded prices prefixed with `$` (e.g. `$1.79` on Trader Joe's receipts) because `float("$1.79")` raises `ValueError`
- `infer_size()` already stripped `$` and `,` before parsing; this fix applies the same treatment to the summary table aggregation step
- Root cause of `MILK QUART WHOLE` / `MILK QUART $7.58` showing `avg_price: null` despite a valid VALID `LINE_TOTAL` label on line 8

## Test plan
- [ ] CI passes
- [ ] After merge + CI deploy to prod, invoke dev milk cache lambda and verify `MILK QUART $7.58` for `b9800d3c` shows `avg_price: 1.79`
- [ ] Invoke prod milk cache lambda and verify same entry resolves (once labels sync'd to prod)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved dairy product filtering to more accurately exclude non-dairy alternatives
* Enhanced price parsing to robustly handle various price formats, ensuring more reliable price calculations and aggregations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->