### PR TITLE
LayoutLM: honest eval, windowed inference, granular taxonomy, best-model viz

### DIFF
--- a/infra/__main__.py
+++ b/infra/__main__.py
@@ -565,6 +565,7 @@ if layoutlm_training_bucket_name is not None:
     # No placeholder bucket names - only use the real bucket
     layoutlm_inference_lambda = create_layoutlm_inference_lambda(
         cache_bucket_name=layoutlm_cache_generator.cache_bucket.id,
+        training_bucket_name=layoutlm_training_bucket_name,
     )
 
     # Export the Lambda so api_gateway.py can use it

--- a/infra/__main__.py
+++ b/infra/__main__.py
@@ -507,6 +507,28 @@ if enable_sagemaker:
         "layoutlm_model_s3_bucket", sagemaker_training.output_bucket.bucket
     )
     pulumi.export("layoutlm_model_s3_key", "coreml/layoutlm-coreml-bundle.zip")
+
+    # Per-epoch checkpoint evaluation. Reuses the training container image and
+    # execution role to launch an ephemeral SageMaker Processing job that scores
+    # every checkpoint on the frozen val set. Auto-trigger on training
+    # completion is opt-in (ml-training:auto-epoch-eval) to avoid surprise GPU
+    # cost.
+    from sagemaker_epoch_eval import EpochEvalInfra
+
+    epoch_eval = EpochEvalInfra(
+        "layoutlm-epoch-eval",
+        ecr_repo_url=sagemaker_training.ecr_repo.repository_url,
+        sagemaker_role_arn=sagemaker_training.sagemaker_role.arn,
+        output_bucket=sagemaker_training.output_bucket.bucket,
+        dynamodb_table_name=dynamodb_table.name,
+        region=aws.get_region().name,
+        account_id=aws.get_caller_identity().account_id,
+        enable_auto_trigger=ml_cfg.get_bool("auto-epoch-eval") or False,
+    )
+    pulumi.export(
+        "layoutlm_epoch_eval_trigger_lambda",
+        epoch_eval.trigger_lambda.arn,
+    )
 else:
     # Check if training bucket name is provided as config (for inference-only usage)
     training_bucket_config = ml_cfg.get("training-bucket-name")
@@ -551,6 +573,16 @@ if layoutlm_training_bucket_name is not None:
 
     inference_module.layoutlm_inference_lambda = layoutlm_inference_lambda
 
+    # Per-epoch evaluation API: serves epoch-eval/ artifacts from the training
+    # bucket (written by the eval-checkpoints Processing job).
+    from routes.layoutlm_epochs.infra import create_layoutlm_epochs_lambda
+    import routes.layoutlm_epochs.infra as epochs_module
+
+    layoutlm_epochs_lambda = create_layoutlm_epochs_lambda(
+        cache_bucket_name=layoutlm_training_bucket_name,
+    )
+    epochs_module.layoutlm_epochs_lambda = layoutlm_epochs_lambda
+
     # Create API Gateway route for layoutlm_inference
     # This must be done here after Lambda is created, not in api_gateway.py
     # because api_gateway.py is imported before the Lambda exists
@@ -594,6 +626,37 @@ if layoutlm_training_bucket_name is not None:
             "layoutlm_inference_lambda_permission",
             action="lambda:InvokeFunction",
             function=layoutlm_inference_lambda.name,
+            principal="apigateway.amazonaws.com",
+            source_arn=api_gateway.api.execution_arn.apply(
+                lambda arn: f"{arn}/*/*"
+            ),
+        )
+
+        # Route for the per-epoch evaluation API.
+        integration_layoutlm_epochs = aws.apigatewayv2.Integration(
+            "layoutlm_epochs_lambda_integration",
+            api_id=api_gateway.api.id,
+            integration_type="AWS_PROXY",
+            integration_uri=layoutlm_epochs_lambda.invoke_arn,
+            integration_method="POST",
+            payload_format_version="2.0",
+        )
+        route_layoutlm_epochs = aws.apigatewayv2.Route(
+            "layoutlm_epochs_route",
+            api_id=api_gateway.api.id,
+            route_key="GET /layoutlm_epochs",
+            target=integration_layoutlm_epochs.id.apply(
+                lambda id: f"integrations/{id}"
+            ),
+            opts=pulumi.ResourceOptions(
+                replace_on_changes=["route_key", "target"],
+                delete_before_replace=True,
+            ),
+        )
+        lambda_permission_layoutlm_epochs = aws.lambda_.Permission(
+            "layoutlm_epochs_lambda_permission",
+            action="lambda:InvokeFunction",
+            function=layoutlm_epochs_lambda.name,
             principal="apigateway.amazonaws.com",
             source_arn=api_gateway.api.execution_arn.apply(
                 lambda arn: f"{arn}/*/*"

--- a/infra/routes/job_training_metrics/handler/index.py
+++ b/infra/routes/job_training_metrics/handler/index.py
@@ -7,6 +7,7 @@ Returns F1 scores, confusion matrices, and per-label metrics for a training job.
 import json
 import logging
 import os
+import re
 from collections import defaultdict
 from typing import Any, Dict, List, Optional
 
@@ -38,6 +39,28 @@ FEATURED_JOB_ID = os.environ.get(
 )
 
 
+def _resolve_newest_layoutlm_job(client: "DynamoClient") -> Optional[str]:
+    """Return the job_id of the newest ``layoutlm-vNN`` run (highest version),
+    so the confusion matrix tracks the SAME model the inference viz auto-picks.
+    Falls back to None on any error (caller then uses FEATURED_JOB_ID)."""
+    try:
+        jobs, _ = client.list_jobs(limit=500)
+    except Exception:  # pylint: disable=broad-exception-caught
+        logger.exception("list_jobs failed; falling back to FEATURED_JOB_ID")
+        return None
+
+    def vnum(name: Optional[str]) -> int:
+        m = re.search(r"-v(\d+)", name or "")
+        return int(m.group(1)) if m else -1
+
+    cands = [j for j in jobs if vnum(getattr(j, "name", "")) >= 0]
+    if not cands:
+        return None
+    best = max(cands, key=lambda j: (vnum(j.name), j.created_at or ""))
+    logger.info("Newest layoutlm job: %s (%s)", best.name, best.job_id)
+    return best.job_id
+
+
 def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
     """
     Get training metrics for a specific job.
@@ -62,10 +85,8 @@ def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
                 400, "Missing required path parameter: job_id"
             )
 
-        # Support "featured" as a special job_id alias
-        if job_id == "featured":
-            logger.info("Resolved featured -> %s", FEATURED_JOB_ID)
-            job_id = FEATURED_JOB_ID
+        # "featured" is resolved after the client is created (below) so it can
+        # track the newest run dynamically.
 
         # Parse query parameters
         query_params = event.get("queryStringParameters") or {}
@@ -88,6 +109,12 @@ def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
         client = DynamoClient(
             table_name=DYNAMODB_TABLE_NAME, region="us-east-1"
         )
+
+        # Resolve "featured" to the newest layoutlm run — the same model the
+        # inference viz auto-selects — falling back to the configured default.
+        if job_id == "featured":
+            job_id = _resolve_newest_layoutlm_job(client) or FEATURED_JOB_ID
+            logger.info("Resolved featured -> %s", job_id)
 
         # Get job metadata
         try:

--- a/infra/routes/layoutlm_epochs/__init__.py
+++ b/infra/routes/layoutlm_epochs/__init__.py
@@ -1,0 +1,1 @@
+"""LayoutLM per-epoch evaluation API route."""

--- a/infra/routes/layoutlm_epochs/handler/index.py
+++ b/infra/routes/layoutlm_epochs/handler/index.py
@@ -1,10 +1,15 @@
 """Lambda handler serving per-epoch checkpoint-evaluation results from S3.
 
-Reads artifacts written by the ``eval-checkpoints`` SageMaker Processing job,
-which live in the training bucket under ``epoch-eval/<job>/``:
+Reads per-epoch eval artifacts from EITHER location:
+  - ``epoch-eval/<job>/`` — written by the standalone ``eval-checkpoints``
+    SageMaker Processing job (retro-eval of a finished run).
+  - ``runs/<job>/`` — written live DURING training by the in-trainer held-out
+    eval callback (no separate job). Same ``epochs.json`` shape.
 
-    epoch-eval/<job>/epochs.json
-    epoch-eval/<job>/receipts/epoch-<n>/receipt-<image_id>-<receipt_id>.json
+    <prefix>/<job>/epochs.json
+    <prefix>/<job>/receipts/epoch-<n>/receipt-<image_id>-<receipt_id>.json
+
+The standalone copy is preferred when both exist.
 
 Query parameters:
     (none)              -> list job names that have an epochs.json
@@ -24,7 +29,9 @@ logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
 S3_CACHE_BUCKET = os.environ["S3_CACHE_BUCKET"]
-PREFIX = "epoch-eval/"
+# Standalone Processing-job evals, preferred when both exist; then live
+# in-training evals written under each run's prefix.
+PREFIXES = ("epoch-eval/", "runs/")
 
 s3_client = boto3.client("s3")
 
@@ -50,24 +57,41 @@ def _resp(status, body, extra_headers=None):
     }
 
 
+def _job_prefix(job):
+    """Return the prefix holding this job's epochs.json (standalone preferred
+    over the in-training live copy), or None if neither exists."""
+    for pfx in PREFIXES:
+        try:
+            s3_client.head_object(
+                Bucket=S3_CACHE_BUCKET, Key=f"{pfx}{job}/epochs.json"
+            )
+            return pfx
+        except ClientError:
+            continue
+    return None
+
+
 def _list_jobs():
-    """Return job names that have an epochs.json under the eval prefix."""
-    jobs = []
+    """Return job names that have an epochs.json under either prefix."""
+    jobs = {}
     paginator = s3_client.get_paginator("list_objects_v2")
-    for page in paginator.paginate(
-        Bucket=S3_CACHE_BUCKET, Prefix=PREFIX, Delimiter="/"
-    ):
-        for cp in page.get("CommonPrefixes", []) or []:
-            job = cp["Prefix"][len(PREFIX):].rstrip("/")
-            try:
-                s3_client.head_object(
-                    Bucket=S3_CACHE_BUCKET,
-                    Key=f"{PREFIX}{job}/epochs.json",
-                )
-                jobs.append(job)
-            except ClientError:
-                continue
-    return jobs
+    for pfx in PREFIXES:
+        for page in paginator.paginate(
+            Bucket=S3_CACHE_BUCKET, Prefix=pfx, Delimiter="/"
+        ):
+            for cp in page.get("CommonPrefixes", []) or []:
+                job = cp["Prefix"][len(pfx):].rstrip("/")
+                if job in jobs:
+                    continue  # already found (standalone wins)
+                try:
+                    s3_client.head_object(
+                        Bucket=S3_CACHE_BUCKET,
+                        Key=f"{pfx}{job}/epochs.json",
+                    )
+                    jobs[job] = pfx
+                except ClientError:
+                    continue
+    return sorted(jobs)
 
 
 def _get_json(key):
@@ -93,13 +117,17 @@ def handler(event, _context):
         if not job:
             return _resp(200, {"jobs": _list_jobs()}, _CACHE)
 
+        prefix = _job_prefix(job)
+        if prefix is None:
+            return _resp(404, {"error": f"Not found for job '{job}'"})
+
         # Guard against path traversal: confine reads to this job's prefix.
         if receipt_path:
             if ".." in receipt_path or receipt_path.startswith("/"):
                 return _resp(400, {"error": "invalid receipt_path"})
-            key = f"{PREFIX}{job}/{receipt_path}"
+            key = f"{prefix}{job}/{receipt_path}"
         else:
-            key = f"{PREFIX}{job}/epochs.json"
+            key = f"{prefix}{job}/epochs.json"
 
         return _resp(200, _get_json(key), _CACHE)
 

--- a/infra/routes/layoutlm_epochs/handler/index.py
+++ b/infra/routes/layoutlm_epochs/handler/index.py
@@ -1,0 +1,114 @@
+"""Lambda handler serving per-epoch checkpoint-evaluation results from S3.
+
+Reads artifacts written by the ``eval-checkpoints`` SageMaker Processing job,
+which live in the training bucket under ``epoch-eval/<job>/``:
+
+    epoch-eval/<job>/epochs.json
+    epoch-eval/<job>/receipts/epoch-<n>/receipt-<image_id>-<receipt_id>.json
+
+Query parameters:
+    (none)              -> list job names that have an epochs.json
+    ?job=<name>         -> that job's epochs.json (the held-out F1 curve)
+    ?job=<name>&receipt_path=receipts/epoch-5/receipt-...json
+                        -> a single per-epoch showcase receipt record
+"""
+
+import json
+import logging
+import os
+
+import boto3
+from botocore.exceptions import ClientError
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+S3_CACHE_BUCKET = os.environ["S3_CACHE_BUCKET"]
+PREFIX = "epoch-eval/"
+
+s3_client = boto3.client("s3")
+
+_CORS = {
+    "Content-Type": "application/json",
+    "Access-Control-Allow-Origin": "*",
+}
+_CACHE = {
+    "Cache-Control": (
+        "public, max-age=60, s-maxage=60, stale-while-revalidate=300"
+    )
+}
+
+
+def _resp(status, body, extra_headers=None):
+    headers = dict(_CORS)
+    if extra_headers:
+        headers.update(extra_headers)
+    return {
+        "statusCode": status,
+        "body": json.dumps(body, default=str),
+        "headers": headers,
+    }
+
+
+def _list_jobs():
+    """Return job names that have an epochs.json under the eval prefix."""
+    jobs = []
+    paginator = s3_client.get_paginator("list_objects_v2")
+    for page in paginator.paginate(
+        Bucket=S3_CACHE_BUCKET, Prefix=PREFIX, Delimiter="/"
+    ):
+        for cp in page.get("CommonPrefixes", []) or []:
+            job = cp["Prefix"][len(PREFIX):].rstrip("/")
+            try:
+                s3_client.head_object(
+                    Bucket=S3_CACHE_BUCKET,
+                    Key=f"{PREFIX}{job}/epochs.json",
+                )
+                jobs.append(job)
+            except ClientError:
+                continue
+    return jobs
+
+
+def _get_json(key):
+    obj = s3_client.get_object(Bucket=S3_CACHE_BUCKET, Key=key)
+    return json.loads(obj["Body"].read().decode("utf-8"))
+
+
+def handler(event, _context):
+    http_method = (
+        event.get("requestContext", {})
+        .get("http", {})
+        .get("method", "GET")
+        .upper()
+    )
+    if http_method != "GET":
+        return _resp(405, {"error": f"Method {http_method} not allowed"})
+
+    params = event.get("queryStringParameters") or {}
+    job = params.get("job")
+    receipt_path = params.get("receipt_path")
+
+    try:
+        if not job:
+            return _resp(200, {"jobs": _list_jobs()}, _CACHE)
+
+        # Guard against path traversal: confine reads to this job's prefix.
+        if receipt_path:
+            if ".." in receipt_path or receipt_path.startswith("/"):
+                return _resp(400, {"error": "invalid receipt_path"})
+            key = f"{PREFIX}{job}/{receipt_path}"
+        else:
+            key = f"{PREFIX}{job}/epochs.json"
+
+        return _resp(200, _get_json(key), _CACHE)
+
+    except ClientError as e:
+        code = e.response.get("Error", {}).get("Code", "Unknown")
+        if code in ("NoSuchKey", "404", "NotFound"):
+            return _resp(404, {"error": f"Not found for job '{job}'"})
+        logger.error("S3 error: %s", e)
+        return _resp(500, {"error": "Failed to retrieve epoch evaluation"})
+    except Exception as e:  # pylint: disable=broad-exception-caught
+        logger.error("Unexpected error: %s", e, exc_info=True)
+        return _resp(500, {"error": "Internal error"})

--- a/infra/routes/layoutlm_epochs/infra.py
+++ b/infra/routes/layoutlm_epochs/infra.py
@@ -1,0 +1,108 @@
+"""LayoutLM epochs API Lambda - serves per-epoch evaluation results from S3.
+
+Mirrors the word_similarity route: a small GET Lambda that reads the
+``epoch-eval/`` artifacts produced by the eval-checkpoints Processing job. The
+Lambda is wired into API Gateway from __main__.py after the bucket is known.
+"""
+
+import json
+import os
+
+import pulumi
+import pulumi_aws as aws
+from pulumi import AssetArchive, FileArchive, Input, Output
+
+HANDLER_DIR = os.path.join(os.path.dirname(__file__), "handler")
+ROUTE_NAME = os.path.basename(os.path.dirname(__file__))
+
+stack = pulumi.get_stack()
+
+
+def create_layoutlm_epochs_lambda(
+    cache_bucket_name: Input[str],
+) -> aws.lambda_.Function:
+    """Create the LayoutLM epochs API Lambda.
+
+    Args:
+        cache_bucket_name: S3 bucket holding ``epoch-eval/`` artifacts (the
+            LayoutLM training/output bucket).
+
+    Returns:
+        The Lambda function resource.
+    """
+    lambda_role = aws.iam.Role(
+        f"api_{ROUTE_NAME}_lambda_role",
+        assume_role_policy="""{
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Action": "sts:AssumeRole",
+                    "Principal": {"Service": "lambda.amazonaws.com"},
+                    "Effect": "Allow",
+                    "Sid": ""
+                }
+            ]
+        }""",
+    )
+
+    s3_policy = aws.iam.Policy(
+        f"api_{ROUTE_NAME}_s3_policy",
+        description="Allow Lambda to read LayoutLM epoch-eval artifacts",
+        policy=Output.from_input(cache_bucket_name).apply(
+            lambda bucket: json.dumps(
+                {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Action": ["s3:GetObject", "s3:ListBucket"],
+                            "Resource": [
+                                f"arn:aws:s3:::{bucket}/*",
+                                f"arn:aws:s3:::{bucket}",
+                            ],
+                        }
+                    ],
+                }
+            )
+        ),
+    )
+
+    aws.iam.RolePolicyAttachment(
+        f"api_{ROUTE_NAME}_s3_policy_attachment",
+        role=lambda_role.name,
+        policy_arn=s3_policy.arn,
+    )
+    aws.iam.RolePolicyAttachment(
+        f"api_{ROUTE_NAME}_basic_execution",
+        role=lambda_role.name,
+        policy_arn="arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+    )
+
+    epochs_lambda = aws.lambda_.Function(
+        f"api_{ROUTE_NAME}_GET_lambda",
+        runtime="python3.12",
+        architectures=["arm64"],
+        role=lambda_role.arn,
+        code=AssetArchive({".": FileArchive(HANDLER_DIR)}),
+        handler="index.handler",
+        environment={
+            "variables": {
+                "S3_CACHE_BUCKET": Output.from_input(cache_bucket_name),
+            }
+        },
+        memory_size=512,
+        timeout=30,
+        tags={"environment": stack},
+    )
+
+    aws.cloudwatch.LogGroup(
+        f"api_{ROUTE_NAME}_lambda_log_group",
+        name=epochs_lambda.name.apply(lambda fn: f"/aws/lambda/{fn}"),
+        retention_in_days=30,
+    )
+
+    return epochs_lambda
+
+
+# Set by __main__.py after the Lambda is created (for api_gateway wiring).
+layoutlm_epochs_lambda: aws.lambda_.Function | None = None

--- a/infra/routes/layoutlm_inference/handler/index.py
+++ b/infra/routes/layoutlm_inference/handler/index.py
@@ -1,15 +1,22 @@
-"""Lambda handler for serving LayoutLM inference cache.
+"""Lambda handler for serving LayoutLM inference results to the viz.
 
-This Lambda function serves batches of cached LayoutLM inference results from S3.
-It randomly selects receipts from the cache pool to provide variety for the visualization.
+Primary source: the per-epoch eval showcase records the trainer/eval already
+produce with the BEST model (windowed inference, real GPU ``inference_time_ms``)
+under ``<prefix>/<run>/receipts/epoch-<best>/`` in the training bucket. We serve
+the newest run's best held-out epoch, so the viz tracks the latest experiment
+with fast, real times instead of a separately-generated (slow, stale) cache.
+
+Falls back to the legacy ``layoutlm-inference-cache/`` pool if the training
+source is unavailable.
 """
 
 import json
 import logging
 import os
 import random
+import re
 from datetime import datetime, timezone
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional, Tuple
 
 import boto3
 from botocore.exceptions import ClientError
@@ -19,6 +26,9 @@ logger.setLevel(logging.INFO)
 
 # Environment variables
 S3_CACHE_BUCKET = os.environ.get("S3_CACHE_BUCKET")
+# Training bucket holding per-epoch eval records (runs/<job>/ + epoch-eval/<job>/)
+TRAINING_BUCKET = os.environ.get("TRAINING_BUCKET")
+EPOCH_PREFIXES = ("runs/", "epoch-eval/")
 CACHE_PREFIX = "layoutlm-inference-cache/receipts/"
 LEGACY_CACHE_KEY = "layoutlm-inference-cache/latest.json"
 BATCH_SIZE = 5  # Number of receipts to return per request
@@ -28,6 +38,95 @@ if not S3_CACHE_BUCKET:
 
 # Initialize S3 client
 s3_client = boto3.client("s3")
+
+
+def _vnum(job: str) -> int:
+    m = re.search(r"-v(\d+)", job)
+    return int(m.group(1)) if m else -1
+
+
+def _newest_eval_run() -> Tuple[Optional[str], Optional[str]]:
+    """Find the newest run (highest -vNN) with an epochs.json, and its prefix."""
+    runs: Dict[str, str] = {}
+    paginator = s3_client.get_paginator("list_objects_v2")
+    for pfx in EPOCH_PREFIXES:
+        for page in paginator.paginate(
+            Bucket=TRAINING_BUCKET, Prefix=pfx, Delimiter="/"
+        ):
+            for cp in page.get("CommonPrefixes", []) or []:
+                run = cp["Prefix"][len(pfx):].rstrip("/")
+                if run in runs:
+                    continue
+                try:
+                    s3_client.head_object(
+                        Bucket=TRAINING_BUCKET, Key=f"{pfx}{run}/epochs.json"
+                    )
+                    runs[run] = pfx
+                except ClientError:
+                    continue
+    if not runs:
+        return None, None
+    best = sorted(runs, key=lambda r: (_vnum(r), r))[-1]
+    return best, runs[best]
+
+
+def _best_epoch_records(run: str, prefix: str) -> Tuple[List[Dict[str, Any]], Any]:
+    """Read the run's best held-out epoch showcase receipt records."""
+    epochs = json.loads(
+        s3_client.get_object(
+            Bucket=TRAINING_BUCKET, Key=f"{prefix}{run}/epochs.json"
+        )["Body"].read()
+    )
+    best_epoch = epochs.get("best_epoch_heldout")
+    if best_epoch is None:
+        scored = [e for e in epochs.get("epochs", []) if e.get("epoch") is not None]
+        best_epoch = (
+            max(scored, key=lambda e: e.get("heldout_f1", 0))["epoch"]
+            if scored
+            else None
+        )
+    if best_epoch is None:
+        return [], None
+    rec_prefix = f"{prefix}{run}/receipts/epoch-{best_epoch}/"
+    records: List[Dict[str, Any]] = []
+    for page in s3_client.get_paginator("list_objects_v2").paginate(
+        Bucket=TRAINING_BUCKET, Prefix=rec_prefix
+    ):
+        for obj in page.get("Contents", []):
+            if obj.get("Key", "").endswith(".json"):
+                try:
+                    records.append(
+                        json.loads(
+                            s3_client.get_object(
+                                Bucket=TRAINING_BUCKET, Key=obj["Key"]
+                            )["Body"].read()
+                        )
+                    )
+                except ClientError:
+                    logger.exception("Error fetching %s", obj["Key"])
+    return records, best_epoch
+
+
+def _agg_from_records(records: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Aggregate stats from eval records (accuracy from per-word is_correct)."""
+    times = [r.get("inference_time_ms", 0) for r in records]
+    accs, total_words = [], 0
+    for r in records:
+        preds = (r.get("original") or {}).get("predictions") or []
+        if preds:
+            accs.append(sum(1 for p in preds if p.get("is_correct")) / len(preds))
+            total_words += len(preds)
+    avg_t = sum(times) / len(times) if times else 0.0
+    return {
+        "avg_accuracy": sum(accs) / len(accs) if accs else 0.0,
+        "min_accuracy": min(accs) if accs else 0.0,
+        "max_accuracy": max(accs) if accs else 0.0,
+        "avg_inference_time_ms": round(avg_t, 2),
+        "total_receipts_in_pool": len(records),
+        "batch_size": len(records),
+        "total_words_processed": total_words,
+        "estimated_throughput_per_hour": round(3600 * 1000 / avg_t) if avg_t else 0,
+    }
 
 
 def _list_cached_receipts() -> List[str]:
@@ -227,8 +326,46 @@ def handler(event, _context):
             },
         }
 
+    # Primary: serve the newest run's best-epoch eval records (best model,
+    # windowed inference, real GPU times) from the training bucket.
+    if TRAINING_BUCKET:
+        try:
+            run, prefix = _newest_eval_run()
+            if run:
+                records, best_epoch = _best_epoch_records(run, prefix)
+                if records:
+                    logger.info(
+                        "Serving %d records from %s epoch %s",
+                        len(records),
+                        run,
+                        best_epoch,
+                    )
+                    return {
+                        "statusCode": 200,
+                        "body": json.dumps(
+                            {
+                                "receipts": records,
+                                "aggregate_stats": _agg_from_records(records),
+                                "fetched_at": datetime.now(
+                                    timezone.utc
+                                ).isoformat(),
+                                "source_run": run,
+                                "source_epoch": best_epoch,
+                            },
+                            default=str,
+                        ),
+                        "headers": {
+                            "Content-Type": "application/json",
+                            "Access-Control-Allow-Origin": "*",
+                            "Cache-Control": "public, max-age=60, s-maxage=60, stale-while-revalidate=300",
+                        },
+                    }
+            logger.warning("No eval records in training bucket; using legacy cache")
+        except Exception:  # pylint: disable=broad-exception-caught
+            logger.exception("Training-source read failed; using legacy cache")
+
     try:
-        # List all cached receipts
+        # Fallback: legacy cached-receipt pool.
         logger.info("Listing cached receipts from %s", CACHE_PREFIX)
         cached_keys = _list_cached_receipts()
 

--- a/infra/routes/layoutlm_inference/handler/index.py
+++ b/infra/routes/layoutlm_inference/handler/index.py
@@ -28,7 +28,9 @@ logger.setLevel(logging.INFO)
 S3_CACHE_BUCKET = os.environ.get("S3_CACHE_BUCKET")
 # Training bucket holding per-epoch eval records (runs/<job>/ + epoch-eval/<job>/)
 TRAINING_BUCKET = os.environ.get("TRAINING_BUCKET")
-EPOCH_PREFIXES = ("runs/", "epoch-eval/")
+# Standalone Processing-job evals preferred when both exist (matches the
+# layoutlm_epochs handler); fall back to the live in-training copy.
+EPOCH_PREFIXES = ("epoch-eval/", "runs/")
 CACHE_PREFIX = "layoutlm-inference-cache/receipts/"
 LEGACY_CACHE_KEY = "layoutlm-inference-cache/latest.json"
 BATCH_SIZE = 5  # Number of receipts to return per request

--- a/infra/routes/layoutlm_inference/infra.py
+++ b/infra/routes/layoutlm_inference/infra.py
@@ -27,6 +27,7 @@ lambda_role: Optional[aws.iam.Role] = None
 
 def create_layoutlm_inference_lambda(
     cache_bucket_name: Input[str],
+    training_bucket_name: Input[str],
 ) -> aws.lambda_.Function:
     """Create the LayoutLM inference API Lambda function.
 
@@ -63,8 +64,8 @@ def create_layoutlm_inference_lambda(
     s3_policy = aws.iam.RolePolicy(
         f"api_{ROUTE_NAME}_s3_policy",
         role=lambda_role.id,
-        policy=Output.from_input(cache_bucket_name).apply(
-            lambda bucket: json.dumps(
+        policy=Output.all(cache_bucket_name, training_bucket_name).apply(
+            lambda buckets: json.dumps(
                 {
                     "Version": "2012-10-17",
                     "Statement": [
@@ -72,8 +73,12 @@ def create_layoutlm_inference_lambda(
                             "Effect": "Allow",
                             "Action": ["s3:GetObject", "s3:ListBucket"],
                             "Resource": [
-                                f"arn:aws:s3:::{bucket}/*",
-                                f"arn:aws:s3:::{bucket}",
+                                arn
+                                for b in buckets
+                                for arn in (
+                                    f"arn:aws:s3:::{b}/*",
+                                    f"arn:aws:s3:::{b}",
+                                )
                             ],
                         }
                     ],
@@ -102,10 +107,11 @@ def create_layoutlm_inference_lambda(
         ),
         handler="index.handler",
         layers=[dynamo_layer.arn] if dynamo_layer.arn else None,
-        environment=Output.from_input(cache_bucket_name).apply(
-            lambda bucket: aws.lambda_.FunctionEnvironmentArgs(
+        environment=Output.all(cache_bucket_name, training_bucket_name).apply(
+            lambda buckets: aws.lambda_.FunctionEnvironmentArgs(
                 variables={
-                    "S3_CACHE_BUCKET": bucket,
+                    "S3_CACHE_BUCKET": buckets[0],
+                    "TRAINING_BUCKET": buckets[1],
                 }
             )
         ),

--- a/infra/sagemaker_epoch_eval/__init__.py
+++ b/infra/sagemaker_epoch_eval/__init__.py
@@ -1,0 +1,5 @@
+"""SageMaker per-epoch checkpoint evaluation infrastructure."""
+
+from .component import EpochEvalInfra
+
+__all__ = ["EpochEvalInfra"]

--- a/infra/sagemaker_epoch_eval/component.py
+++ b/infra/sagemaker_epoch_eval/component.py
@@ -1,0 +1,292 @@
+"""Pulumi component that runs per-epoch checkpoint evaluation on SageMaker.
+
+This reuses the *existing* LayoutLM training container image and execution
+role — no new container is built. A small trigger Lambda launches an ephemeral
+SageMaker **Processing** job that runs ``layoutlm-cli eval-checkpoints`` against
+a finished training run, scoring every retained checkpoint on the run's frozen
+validation set and writing ``epochs.json`` (plus per-epoch showcase receipts)
+back into the training bucket under ``epoch-eval/<job>/``.
+
+Processing jobs are ephemeral: they spin up, run, write to S3, and terminate.
+Nothing is left running between evaluations.
+
+The optional EventBridge rule (off by default) re-evaluates a run automatically
+when its SageMaker training job completes — mirroring the auto-CoreML-export
+pattern. It is gated so training completions don't silently incur GPU cost.
+"""
+
+import json
+from typing import Optional
+
+import pulumi
+import pulumi_aws as aws
+from pulumi import ComponentResource, Input, Output, ResourceOptions
+
+stack = pulumi.get_stack()
+
+
+class EpochEvalInfra(ComponentResource):
+    """Trigger + IAM for SageMaker Processing-based checkpoint evaluation."""
+
+    def __init__(
+        self,
+        name: str,
+        *,
+        ecr_repo_url: Input[str],
+        sagemaker_role_arn: Input[str],
+        output_bucket: Input[str],
+        dynamodb_table_name: Input[str],
+        region: str,
+        account_id: str,
+        instance_type: str = "ml.g4dn.xlarge",
+        enable_auto_trigger: bool = False,
+        opts: Optional[ResourceOptions] = None,
+    ):
+        super().__init__(
+            f"custom:sagemaker-epoch-eval:{name}", name, None, opts
+        )
+
+        # IAM role for the trigger Lambda.
+        self.lambda_role = aws.iam.Role(
+            f"{name}-trigger-role",
+            assume_role_policy=json.dumps(
+                {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Principal": {"Service": "lambda.amazonaws.com"},
+                            "Action": "sts:AssumeRole",
+                        }
+                    ],
+                }
+            ),
+            managed_policy_arns=[
+                "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+            ],
+            tags={"Component": name},
+            opts=ResourceOptions(parent=self),
+        )
+
+        aws.iam.RolePolicy(
+            f"{name}-trigger-policy",
+            role=self.lambda_role.id,
+            policy=Output.from_input(sagemaker_role_arn).apply(
+                lambda role_arn: json.dumps(
+                    {
+                        "Version": "2012-10-17",
+                        "Statement": [
+                            {
+                                "Effect": "Allow",
+                                "Action": [
+                                    "sagemaker:CreateProcessingJob",
+                                    "sagemaker:DescribeProcessingJob",
+                                    "sagemaker:ListProcessingJobs",
+                                    "sagemaker:StopProcessingJob",
+                                    "sagemaker:AddTags",
+                                ],
+                                "Resource": (
+                                    f"arn:aws:sagemaker:{region}:"
+                                    f"{account_id}:processing-job/*"
+                                ),
+                            },
+                            # Hand the SageMaker execution role to the job.
+                            {
+                                "Effect": "Allow",
+                                "Action": "iam:PassRole",
+                                "Resource": role_arn,
+                                "Condition": {
+                                    "StringEquals": {
+                                        "iam:PassedToService": (
+                                            "sagemaker.amazonaws.com"
+                                        )
+                                    }
+                                },
+                            },
+                        ],
+                    }
+                )
+            ),
+            opts=ResourceOptions(parent=self.lambda_role),
+        )
+
+        self.trigger_lambda = aws.lambda_.Function(
+            f"{name}-trigger",
+            runtime="python3.12",
+            handler="index.handler",
+            role=self.lambda_role.arn,
+            timeout=30,
+            memory_size=256,
+            code=pulumi.AssetArchive(
+                {"index.py": pulumi.StringAsset(_TRIGGER_CODE)}
+            ),
+            environment=aws.lambda_.FunctionEnvironmentArgs(
+                variables=Output.all(
+                    ecr_repo_url,
+                    output_bucket,
+                    sagemaker_role_arn,
+                    dynamodb_table_name,
+                ).apply(
+                    lambda args: {
+                        "ECR_IMAGE_URI": f"{args[0]}:latest",
+                        "OUTPUT_BUCKET": args[1],
+                        "SAGEMAKER_ROLE_ARN": args[2],
+                        "DYNAMO_TABLE_NAME": args[3],
+                        "DEFAULT_INSTANCE_TYPE": instance_type,
+                    }
+                ),
+            ),
+            tags={"Component": name},
+            opts=ResourceOptions(parent=self),
+        )
+
+        aws.cloudwatch.LogGroup(
+            f"{name}-trigger-logs",
+            name=self.trigger_lambda.name.apply(
+                lambda fn: f"/aws/lambda/{fn}"
+            ),
+            retention_in_days=30,
+            opts=ResourceOptions(parent=self),
+        )
+
+        # Optional: auto-evaluate when a training job completes.
+        if enable_auto_trigger:
+            rule = aws.cloudwatch.EventRule(
+                f"{name}-on-training-complete",
+                description=(
+                    "Run per-epoch evaluation when a LayoutLM training job "
+                    "completes"
+                ),
+                event_pattern=json.dumps(
+                    {
+                        "source": ["aws.sagemaker"],
+                        "detail-type": [
+                            "SageMaker Training Job State Change"
+                        ],
+                        "detail": {
+                            "TrainingJobStatus": ["Completed"],
+                            "TrainingJobName": [{"prefix": "layoutlm-"}],
+                        },
+                    }
+                ),
+                tags={"Component": name},
+                opts=ResourceOptions(parent=self),
+            )
+            aws.cloudwatch.EventTarget(
+                f"{name}-on-training-complete-target",
+                rule=rule.name,
+                arn=self.trigger_lambda.arn,
+                opts=ResourceOptions(parent=self),
+            )
+            aws.lambda_.Permission(
+                f"{name}-eventbridge-permission",
+                action="lambda:InvokeFunction",
+                function=self.trigger_lambda.name,
+                principal="events.amazonaws.com",
+                source_arn=rule.arn,
+                opts=ResourceOptions(parent=self),
+            )
+
+        self.register_outputs(
+            {"trigger_lambda_arn": self.trigger_lambda.arn}
+        )
+
+
+# Inline Lambda that launches the SageMaker Processing job. Kept inline (like
+# the start-training Lambda) so it ships with the component.
+_TRIGGER_CODE = '''
+import json
+import os
+import re
+from datetime import datetime
+
+import boto3
+
+sagemaker = boto3.client("sagemaker")
+
+
+def _resolve_job_name(event):
+    """Accept a direct invoke ({"job_name": ...}) or a training-complete event."""
+    if event.get("job_name"):
+        return event["job_name"]
+    detail = event.get("detail") or {}
+    return detail.get("TrainingJobName")
+
+
+def handler(event, context):
+    event = event or {}
+    job_name = _resolve_job_name(event)
+    if not job_name:
+        raise ValueError("job_name (or detail.TrainingJobName) is required")
+
+    output_bucket = os.environ["OUTPUT_BUCKET"]
+    table = os.environ["DYNAMO_TABLE_NAME"]
+    region = os.environ.get("AWS_REGION", "us-east-1")
+    instance_type = event.get(
+        "instance_type", os.environ.get("DEFAULT_INSTANCE_TYPE", "ml.g4dn.xlarge")
+    )
+
+    # Processing job names: <=63 chars, [a-zA-Z0-9-]. Sanitize + timestamp.
+    ts = datetime.now().strftime("%Y%m%d-%H%M%S")
+    slug = re.sub(r"[^a-zA-Z0-9-]", "-", job_name)[:40].strip("-")
+    proc_name = f"epoch-eval-{slug}-{ts}"[:63]
+
+    output_s3 = f"s3://{output_bucket}/epoch-eval/{job_name}/"
+    args = [
+        "--job-name", job_name,
+        "--dynamo-table", table,
+        "--region", region,
+        "--output-dir", "/opt/ml/processing/output",
+        "--output-s3-uri", output_s3,
+    ]
+    if event.get("max_receipts") is not None:
+        args += ["--max-receipts", str(event["max_receipts"])]
+    if event.get("num_showcase") is not None:
+        args += ["--num-showcase", str(event["num_showcase"])]
+    # Older runs (pre val_receipt_keys persistence) drift, so default to
+    # tolerating a hash mismatch unless the caller explicitly forbids it.
+    if event.get("allow_hash_mismatch", True):
+        args += ["--allow-hash-mismatch"]
+
+    config = {
+        "ProcessingJobName": proc_name,
+        "RoleArn": os.environ["SAGEMAKER_ROLE_ARN"],
+        "AppSpecification": {
+            "ImageUri": os.environ["ECR_IMAGE_URI"],
+            "ContainerEntrypoint": ["layoutlm-cli", "eval-checkpoints"],
+            "ContainerArguments": args,
+        },
+        "ProcessingResources": {
+            "ClusterConfig": {
+                "InstanceCount": 1,
+                "InstanceType": instance_type,
+                "VolumeSizeInGB": int(event.get("volume_size", 50)),
+            }
+        },
+        "StoppingCondition": {
+            "MaxRuntimeInSeconds": int(event.get("max_runtime_seconds", 7200))
+        },
+        "Environment": {
+            "DYNAMO_TABLE_NAME": table,
+            "AWS_REGION": region,
+        },
+        "Tags": [
+            {"Key": "purpose", "Value": "layoutlm-epoch-eval"},
+            {"Key": "training-job", "Value": job_name[:256]},
+        ],
+    }
+
+    resp = sagemaker.create_processing_job(**config)
+    return {
+        "statusCode": 200,
+        "body": json.dumps(
+            {
+                "processing_job_name": proc_name,
+                "processing_job_arn": resp["ProcessingJobArn"],
+                "training_job": job_name,
+                "output_s3": output_s3,
+                "instance_type": instance_type,
+            }
+        ),
+    }
+'''

--- a/infra/sagemaker_epoch_eval/component.py
+++ b/infra/sagemaker_epoch_eval/component.py
@@ -38,10 +38,11 @@ class EpochEvalInfra(ComponentResource):
         dynamodb_table_name: Input[str],
         region: str,
         account_id: str,
-        # GPU processing-job quotas (ml.g4dn/g5/p3) are 0 on this account, so
-        # default to a high-core CPU instance that has quota. Override per
-        # invocation via the trigger event's "instance_type".
-        instance_type: str = "ml.c5.9xlarge",
+        # GPU processing-job quota (ml.g4dn.xlarge) was granted, so default to
+        # GPU — the full checkpoint sweep runs in ~10 min vs ~hours on CPU.
+        # Override per invocation via the trigger event's "instance_type"
+        # (e.g. ml.c5.9xlarge if GPU quota is ever exhausted).
+        instance_type: str = "ml.g4dn.xlarge",
         enable_auto_trigger: bool = False,
         opts: Optional[ResourceOptions] = None,
     ):

--- a/infra/sagemaker_epoch_eval/component.py
+++ b/infra/sagemaker_epoch_eval/component.py
@@ -38,7 +38,10 @@ class EpochEvalInfra(ComponentResource):
         dynamodb_table_name: Input[str],
         region: str,
         account_id: str,
-        instance_type: str = "ml.g4dn.xlarge",
+        # GPU processing-job quotas (ml.g4dn/g5/p3) are 0 on this account, so
+        # default to a high-core CPU instance that has quota. Override per
+        # invocation via the trigger event's "instance_type".
+        instance_type: str = "ml.c5.9xlarge",
         enable_auto_trigger: bool = False,
         opts: Optional[ResourceOptions] = None,
     ):
@@ -264,7 +267,7 @@ def handler(event, context):
             }
         },
         "StoppingCondition": {
-            "MaxRuntimeInSeconds": int(event.get("max_runtime_seconds", 7200))
+            "MaxRuntimeInSeconds": int(event.get("max_runtime_seconds", 10800))
         },
         "Environment": {
             "DYNAMO_TABLE_NAME": table,

--- a/infra/sagemaker_epoch_eval/component.py
+++ b/infra/sagemaker_epoch_eval/component.py
@@ -247,6 +247,12 @@ def handler(event, context):
         args += ["--max-receipts", str(event["max_receipts"])]
     if event.get("num_showcase") is not None:
         args += ["--num-showcase", str(event["num_showcase"])]
+    # Window config: forward when the caller knows the run's training values
+    # (runs predating window persistence don't record them in run.json).
+    if event.get("window_size") is not None:
+        args += ["--window-size", str(event["window_size"])]
+    if event.get("window_stride") is not None:
+        args += ["--window-stride", str(event["window_stride"])]
     # Older runs (pre val_receipt_keys persistence) drift, so default to
     # tolerating a hash mismatch unless the caller explicitly forbids it.
     if event.get("allow_hash_mismatch", True):

--- a/infra/sagemaker_epoch_eval/component.py
+++ b/infra/sagemaker_epoch_eval/component.py
@@ -279,6 +279,9 @@ def handler(event, context):
         "Environment": {
             "DYNAMO_TABLE_NAME": table,
             "AWS_REGION": region,
+            # Surfaced in epochs.json so the viz can label the timing with the
+            # exact instance (e.g. ml.g4dn.xlarge) the eval ran on.
+            "EVAL_INSTANCE_TYPE": instance_type,
         },
         "Tags": [
             {"Key": "purpose", "Value": "layoutlm-epoch-eval"},

--- a/infra/sagemaker_training/train.py
+++ b/infra/sagemaker_training/train.py
@@ -134,6 +134,10 @@ def build_train_command(hps: dict) -> list[str]:
     if str(hps.get("eval_heldout_windowed", "")).lower() == "false":
         cmd.append("--no-eval-heldout-windowed")
 
+    # Pinned canonical val split (shared across runs for comparability).
+    if hps.get("val_keys_s3"):
+        cmd.extend(["--val-keys-s3", str(hps["val_keys_s3"])])
+
     # Output path - use SageMaker's model dir
     # The trainer will save here, and SageMaker uploads to S3 automatically
     output_path = hps.get("output_s3_path")

--- a/infra/sagemaker_training/train.py
+++ b/infra/sagemaker_training/train.py
@@ -129,6 +129,11 @@ def build_train_command(hps: dict) -> list[str]:
         for label in labels:
             cmd.extend(["--allowed-label", label.strip()])
 
+    # In-training windowed held-out eval is ON by default; allow opting out via
+    # hyperparameter (eval_heldout_windowed=false).
+    if str(hps.get("eval_heldout_windowed", "")).lower() == "false":
+        cmd.append("--no-eval-heldout-windowed")
+
     # Output path - use SageMaker's model dir
     # The trainer will save here, and SageMaker uploads to S3 automatically
     output_path = hps.get("output_s3_path")

--- a/portfolio/components/ui/Figures/EpochEvaluation/EpochEvaluation.module.css
+++ b/portfolio/components/ui/Figures/EpochEvaluation/EpochEvaluation.module.css
@@ -1,0 +1,206 @@
+.container {
+  width: 100%;
+  max-width: 760px;
+  margin: 0 auto;
+  font-family: var(--font-family, system-ui, sans-serif);
+  color: var(--color-text, #222);
+}
+
+.header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 4px;
+}
+
+.title {
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.jobName {
+  font-size: 0.75rem;
+  color: var(--color-text-muted, #888);
+  font-family: var(--font-mono, ui-monospace, monospace);
+}
+
+.legend {
+  display: flex;
+  gap: 16px;
+  font-size: 0.72rem;
+  color: var(--color-text-muted, #777);
+  margin: 6px 0 2px;
+}
+
+.legendItem {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.swatch {
+  width: 18px;
+  height: 0;
+  border-top-width: 2px;
+  border-top-style: solid;
+  display: inline-block;
+}
+
+.chartWrap {
+  position: relative;
+  width: 100%;
+}
+
+.chart {
+  width: 100%;
+  height: auto;
+  display: block;
+  touch-action: none;
+  cursor: crosshair;
+}
+
+.detail {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 10px 18px;
+  margin-top: 10px;
+  padding: 10px 12px;
+  border: 1px solid var(--color-border, #e3e3e3);
+  border-radius: 8px;
+  background: var(--color-surface, #fafafa);
+}
+
+.metric {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.metricLabel {
+  font-size: 0.66rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--color-text-muted, #999);
+}
+
+.metricValue {
+  font-size: 1.05rem;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+.metricSub {
+  font-size: 0.68rem;
+  color: var(--color-text-muted, #999);
+  font-variant-numeric: tabular-nums;
+}
+
+.perLabel {
+  margin-top: 10px;
+}
+
+.perLabelTitle {
+  font-size: 0.66rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--color-text-muted, #999);
+  margin-bottom: 6px;
+}
+
+.bars {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.barRow {
+  display: grid;
+  grid-template-columns: 84px 1fr 38px;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.72rem;
+}
+
+.barName {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.barTrack {
+  height: 8px;
+  border-radius: 4px;
+  background: var(--color-border, #eaeaea);
+  overflow: hidden;
+}
+
+.barFill {
+  height: 100%;
+  border-radius: 4px;
+  transition: width 0.35s ease;
+}
+
+.barValue {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  color: var(--color-text-muted, #777);
+}
+
+.scrubber {
+  margin-top: 14px;
+}
+
+.scrubberHead {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  font-size: 0.72rem;
+  color: var(--color-text-muted, #888);
+  margin-bottom: 6px;
+}
+
+.receiptFrame {
+  position: relative;
+  width: 100%;
+  max-width: 280px;
+  margin: 0 auto;
+  border-radius: 6px;
+  overflow: hidden;
+  background: var(--color-surface, #f3f3f3);
+}
+
+.receiptImg {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+
+.overlay {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.notice {
+  font-size: 0.72rem;
+  color: var(--color-text-muted, #999);
+  text-align: center;
+  padding: 8px;
+}
+
+.loading {
+  min-height: 120px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-text-muted, #999);
+  font-size: 0.8rem;
+}
+
+.warnFlag {
+  font-size: 0.66rem;
+  color: var(--color-orange, #c47d1a);
+}

--- a/portfolio/components/ui/Figures/EpochEvaluation/EpochEvaluation.module.css
+++ b/portfolio/components/ui/Figures/EpochEvaluation/EpochEvaluation.module.css
@@ -26,6 +26,19 @@
   font-family: var(--font-mono, ui-monospace, monospace);
 }
 
+.computeBadge {
+  font-size: 0.68rem;
+  font-weight: 600;
+  color: var(--color-green, #3aa757);
+  background: color-mix(in srgb, var(--color-green, #3aa757) 12%, transparent);
+  border: 1px solid
+    color-mix(in srgb, var(--color-green, #3aa757) 35%, transparent);
+  border-radius: 999px;
+  padding: 1px 8px;
+  white-space: nowrap;
+  font-family: var(--font-mono, ui-monospace, monospace);
+}
+
 .legend {
   display: flex;
   gap: 16px;

--- a/portfolio/components/ui/Figures/EpochEvaluation/EpochEvaluation.module.css
+++ b/portfolio/components/ui/Figures/EpochEvaluation/EpochEvaluation.module.css
@@ -26,6 +26,18 @@
   font-family: var(--font-mono, ui-monospace, monospace);
 }
 
+.jobSelect {
+  font-size: 0.75rem;
+  color: var(--color-text-muted, #888);
+  font-family: var(--font-mono, ui-monospace, monospace);
+  background: transparent;
+  border: 1px solid var(--color-border, #ddd);
+  border-radius: 4px;
+  padding: 1px 4px;
+  max-width: 60vw;
+  cursor: pointer;
+}
+
 .computeBadge {
   font-size: 0.68rem;
   font-weight: 600;

--- a/portfolio/components/ui/Figures/EpochEvaluation/EpochEvaluation.module.css
+++ b/portfolio/components/ui/Figures/EpochEvaluation/EpochEvaluation.module.css
@@ -26,18 +26,6 @@
   font-family: var(--font-mono, ui-monospace, monospace);
 }
 
-.jobSelect {
-  font-size: 0.75rem;
-  color: var(--color-text-muted, #888);
-  font-family: var(--font-mono, ui-monospace, monospace);
-  background: transparent;
-  border: 1px solid var(--color-border, #ddd);
-  border-radius: 4px;
-  padding: 1px 4px;
-  max-width: 60vw;
-  cursor: pointer;
-}
-
 .computeBadge {
   font-size: 0.68rem;
   font-weight: 600;

--- a/portfolio/components/ui/Figures/EpochEvaluation/index.tsx
+++ b/portfolio/components/ui/Figures/EpochEvaluation/index.tsx
@@ -1,0 +1,658 @@
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { useInView } from "react-intersection-observer";
+import { api } from "../../../../services/api";
+import {
+  EpochEvaluationEntry,
+  EpochEvaluationReceiptRecord,
+  EpochEvaluationResponse,
+} from "../../../../types/api";
+import { getBestImageUrl } from "../../../../utils/imageFormat";
+import { useImageFormatSupport } from "../ReceiptFlow/useImageFormatSupport";
+import styles from "./EpochEvaluation.module.css";
+
+// ---------------------------------------------------------------------------
+// Label presentation (mirrors the other LayoutLM figures)
+// ---------------------------------------------------------------------------
+
+const normalizeLabel = (label: string): string =>
+  label === "ADDRESS_LINE" ? "ADDRESS" : label;
+
+const LABEL_COLORS: Record<string, string> = {
+  MERCHANT_NAME: "var(--color-yellow)",
+  DATE: "var(--color-blue)",
+  TIME: "var(--color-blue)",
+  AMOUNT: "var(--color-green)",
+  ADDRESS: "var(--color-red)",
+  PHONE_NUMBER: "var(--color-pink)",
+  WEBSITE: "var(--color-purple)",
+  STORE_HOURS: "var(--color-orange)",
+  PAYMENT_METHOD: "var(--color-orange)",
+};
+
+const labelColor = (label: string): string =>
+  LABEL_COLORS[normalizeLabel(label)] || "var(--color-gray, #888)";
+
+const formatLabel = (label: string): string => {
+  const n = normalizeLabel(label);
+  if (n === "O") return "None";
+  return n
+    .split("_")
+    .map((w) => w.charAt(0) + w.slice(1).toLowerCase())
+    .join(" ");
+};
+
+const isAggregate = (key: string): boolean => key.toLowerCase().includes("avg");
+
+// ---------------------------------------------------------------------------
+// Held-out vs training-reported F1 curve
+// ---------------------------------------------------------------------------
+
+const VB_W = 600;
+const VB_H = 190;
+const PAD_L = 34;
+const PAD_R = 12;
+const PAD_T = 16;
+const PAD_B = 24;
+
+interface CurveProps {
+  epochs: EpochEvaluationEntry[];
+  bestHeldoutEpoch: number | null;
+  bestReportedEpoch: number | null;
+  selectedEpoch: number | null;
+  onSelect: (epoch: number) => void;
+}
+
+const EpochCurveChart: React.FC<CurveProps> = ({
+  epochs,
+  bestHeldoutEpoch,
+  bestReportedEpoch,
+  selectedEpoch,
+  onSelect,
+}) => {
+  const svgRef = useRef<SVGSVGElement>(null);
+
+  const minEpoch = epochs[0].epoch as number;
+  const maxEpoch = epochs[epochs.length - 1].epoch as number;
+  const epochSpan = Math.max(1, maxEpoch - minEpoch);
+
+  // y-domain: pad the top a little above the best score, floor at 0.
+  const allF1 = epochs.flatMap((e) =>
+    [e.heldout_f1, e.training_reported_f1 ?? 0].filter((v) => v != null)
+  );
+  const yMax = Math.min(1, Math.max(0.1, Math.max(...allF1) * 1.12));
+
+  const xOf = useCallback(
+    (epoch: number) =>
+      PAD_L + ((epoch - minEpoch) / epochSpan) * (VB_W - PAD_L - PAD_R),
+    [minEpoch, epochSpan]
+  );
+  const yOf = useCallback(
+    (f1: number) => PAD_T + (1 - f1 / yMax) * (VB_H - PAD_T - PAD_B),
+    [yMax]
+  );
+
+  const heldoutPath = useMemo(
+    () =>
+      epochs
+        .map(
+          (e, i) =>
+            `${i === 0 ? "M" : "L"}${xOf(e.epoch as number).toFixed(1)} ${yOf(
+              e.heldout_f1
+            ).toFixed(1)}`
+        )
+        .join(" "),
+    [epochs, xOf, yOf]
+  );
+
+  const reportedPts = epochs.filter((e) => e.training_reported_f1 != null);
+  const reportedPath = useMemo(
+    () =>
+      reportedPts
+        .map(
+          (e, i) =>
+            `${i === 0 ? "M" : "L"}${xOf(e.epoch as number).toFixed(1)} ${yOf(
+              e.training_reported_f1 as number
+            ).toFixed(1)}`
+        )
+        .join(" "),
+    [reportedPts, xOf, yOf]
+  );
+
+  const handlePointer = useCallback(
+    (clientX: number) => {
+      const svg = svgRef.current;
+      if (!svg) return;
+      const rect = svg.getBoundingClientRect();
+      const vbX = ((clientX - rect.left) / rect.width) * VB_W;
+      // nearest epoch by x
+      let nearest = epochs[0];
+      let best = Infinity;
+      for (const e of epochs) {
+        const d = Math.abs(xOf(e.epoch as number) - vbX);
+        if (d < best) {
+          best = d;
+          nearest = e;
+        }
+      }
+      onSelect(nearest.epoch as number);
+    },
+    [epochs, xOf, onSelect]
+  );
+
+  // y gridlines at 0, 0.25, 0.5, 0.75, 1 (only those within domain)
+  const gridY = [0, 0.25, 0.5, 0.75, 1].filter((v) => v <= yMax + 0.001);
+
+  const selectedEntry = epochs.find((e) => e.epoch === selectedEpoch);
+
+  return (
+    <svg
+      ref={svgRef}
+      className={styles.chart}
+      viewBox={`0 0 ${VB_W} ${VB_H}`}
+      role="img"
+      aria-label="Held-out F1 across epochs"
+      onPointerMove={(e) => e.buttons !== 0 && handlePointer(e.clientX)}
+      onPointerDown={(e) => handlePointer(e.clientX)}
+    >
+      {/* gridlines + y labels */}
+      {gridY.map((v) => (
+        <g key={v}>
+          <line
+            x1={PAD_L}
+            x2={VB_W - PAD_R}
+            y1={yOf(v)}
+            y2={yOf(v)}
+            stroke="var(--color-border, #eee)"
+            strokeWidth={1}
+          />
+          <text
+            x={PAD_L - 6}
+            y={yOf(v) + 3}
+            textAnchor="end"
+            fontSize={9}
+            fill="var(--color-text-muted, #aaa)"
+          >
+            {v.toFixed(2)}
+          </text>
+        </g>
+      ))}
+
+      {/* training-reported (dashed, muted) */}
+      {reportedPath && (
+        <path
+          d={reportedPath}
+          fill="none"
+          stroke="var(--color-blue, #4a90d9)"
+          strokeWidth={1.5}
+          strokeDasharray="4 3"
+          opacity={0.7}
+        />
+      )}
+
+      {/* held-out (solid, accent) */}
+      <path
+        d={heldoutPath}
+        fill="none"
+        stroke="var(--color-green, #3aa757)"
+        strokeWidth={2}
+      />
+
+      {/* best-epoch markers */}
+      {bestReportedEpoch != null &&
+        (() => {
+          const e = epochs.find((x) => x.epoch === bestReportedEpoch);
+          if (!e || e.training_reported_f1 == null) return null;
+          return (
+            <circle
+              cx={xOf(bestReportedEpoch)}
+              cy={yOf(e.training_reported_f1)}
+              r={3}
+              fill="none"
+              stroke="var(--color-blue, #4a90d9)"
+              strokeWidth={1.5}
+            />
+          );
+        })()}
+      {bestHeldoutEpoch != null &&
+        (() => {
+          const e = epochs.find((x) => x.epoch === bestHeldoutEpoch);
+          if (!e) return null;
+          return (
+            <g>
+              <circle
+                cx={xOf(bestHeldoutEpoch)}
+                cy={yOf(e.heldout_f1)}
+                r={4}
+                fill="var(--color-green, #3aa757)"
+              />
+              <text
+                x={xOf(bestHeldoutEpoch)}
+                y={yOf(e.heldout_f1) - 7}
+                textAnchor="middle"
+                fontSize={9}
+                fontWeight={700}
+                fill="var(--color-green, #3aa757)"
+              >
+                BEST
+              </text>
+            </g>
+          );
+        })()}
+
+      {/* selection scrub line + dot */}
+      {selectedEntry && (
+        <g>
+          <line
+            x1={xOf(selectedEntry.epoch as number)}
+            x2={xOf(selectedEntry.epoch as number)}
+            y1={PAD_T}
+            y2={VB_H - PAD_B}
+            stroke="var(--color-text-muted, #bbb)"
+            strokeWidth={1}
+            strokeDasharray="2 2"
+          />
+          <circle
+            cx={xOf(selectedEntry.epoch as number)}
+            cy={yOf(selectedEntry.heldout_f1)}
+            r={3}
+            fill="var(--color-background, #fff)"
+            stroke="var(--color-green, #3aa757)"
+            strokeWidth={2}
+          />
+        </g>
+      )}
+
+      {/* x-axis epoch ticks (first, best, last) */}
+      {Array.from(
+        new Set(
+          [minEpoch, bestHeldoutEpoch ?? maxEpoch, maxEpoch].filter(
+            (v): v is number => v != null
+          )
+        )
+      ).map((ep) => (
+        <text
+          key={ep}
+          x={xOf(ep)}
+          y={VB_H - 8}
+          textAnchor="middle"
+          fontSize={9}
+          fill="var(--color-text-muted, #aaa)"
+        >
+          {ep}
+        </text>
+      ))}
+      <text
+        x={(VB_W + PAD_L) / 2}
+        y={VB_H - 0.5}
+        textAnchor="middle"
+        fontSize={8}
+        fill="var(--color-text-muted, #bbb)"
+      >
+        epoch
+      </text>
+    </svg>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Receipt scrubber: render predicted-label boxes for the selected epoch
+// ---------------------------------------------------------------------------
+
+interface ScrubberProps {
+  job: string;
+  selectedEntry: EpochEvaluationEntry | null;
+  showcaseKey: string | null;
+}
+
+const ReceiptScrubber: React.FC<ScrubberProps> = ({
+  job,
+  selectedEntry,
+  showcaseKey,
+}) => {
+  const formatSupport = useImageFormatSupport();
+  const [cache, setCache] = useState<
+    Record<string, EpochEvaluationReceiptRecord>
+  >({});
+  const [loadingKey, setLoadingKey] = useState<string | null>(null);
+
+  const epochFolder =
+    selectedEntry == null
+      ? null
+      : selectedEntry.epoch != null
+        ? String(selectedEntry.epoch)
+        : selectedEntry.checkpoint;
+
+  // showcaseKey is "image_id_receiptId"; image_id is a UUID (no underscores).
+  const receiptPath = useMemo(() => {
+    if (!showcaseKey || epochFolder == null) return null;
+    const i = showcaseKey.lastIndexOf("_");
+    if (i < 0) return null;
+    const img = showcaseKey.slice(0, i);
+    const rid = showcaseKey.slice(i + 1);
+    return `receipts/epoch-${epochFolder}/receipt-${img}-${rid}.json`;
+  }, [showcaseKey, epochFolder]);
+
+  useEffect(() => {
+    if (!receiptPath || cache[receiptPath]) return;
+    let cancelled = false;
+    setLoadingKey(receiptPath);
+    api
+      .fetchEpochEvaluationReceipt(job, receiptPath)
+      .then((rec) => {
+        if (!cancelled) setCache((c) => ({ ...c, [receiptPath]: rec }));
+      })
+      .catch(() => {
+        /* missing showcase for this epoch — leave blank */
+      })
+      .finally(() => {
+        if (!cancelled) setLoadingKey(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [receiptPath, job, cache]);
+
+  const record = receiptPath ? cache[receiptPath] : null;
+
+  const imageUrl = useMemo(() => {
+    if (!record || !formatSupport) return null;
+    return getBestImageUrl(record.original.receipt, formatSupport);
+  }, [record, formatSupport]);
+
+  // Map (line_id, word_id) -> word bbox for joining predictions to geometry.
+  const wordBox = useMemo(() => {
+    const m = new Map<string, EpochEvaluationReceiptRecord["original"]["words"][number]>();
+    if (record) {
+      for (const w of record.original.words) {
+        m.set(`${w.line_id}:${w.word_id}`, w);
+      }
+    }
+    return m;
+  }, [record]);
+
+  if (!showcaseKey) return null;
+
+  const W = record?.original.receipt.width ?? 1;
+  const H = record?.original.receipt.height ?? 1;
+
+  return (
+    <div className={styles.scrubber}>
+      <div className={styles.scrubberHead}>
+        <span>
+          Predictions on a held-out receipt
+          {selectedEntry?.epoch != null ? ` @ epoch ${selectedEntry.epoch}` : ""}
+        </span>
+        {record && (
+          <span>{Math.round(record.inference_time_ms)}&nbsp;ms</span>
+        )}
+      </div>
+      <div className={styles.receiptFrame}>
+        {imageUrl ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img className={styles.receiptImg} src={imageUrl} alt="Receipt" />
+        ) : (
+          <div className={styles.loading}>
+            {loadingKey ? "Loading…" : "—"}
+          </div>
+        )}
+        {record && (
+          <svg
+            className={styles.overlay}
+            viewBox={`0 0 ${W} ${H}`}
+            preserveAspectRatio="none"
+          >
+            {record.original.predictions.map((p, idx) => {
+              if (!p.predicted_label_base || p.predicted_label_base === "O")
+                return null;
+              const w =
+                p.word_id != null
+                  ? wordBox.get(`${p.line_id}:${p.word_id}`)
+                  : undefined;
+              if (!w) return null;
+              const b = w.bounding_box;
+              const x = b.x * W;
+              const y = (1 - b.y - b.height) * H;
+              const color = labelColor(p.predicted_label_base);
+              return (
+                <rect
+                  key={idx}
+                  x={x}
+                  y={y}
+                  width={b.width * W}
+                  height={b.height * H}
+                  fill={color}
+                  fillOpacity={0.22}
+                  stroke={color}
+                  strokeWidth={Math.max(1, W / 400)}
+                  strokeOpacity={p.is_correct ? 0.95 : 0.5}
+                  strokeDasharray={p.is_correct ? undefined : `${W / 90} ${W / 120}`}
+                />
+              );
+            })}
+          </svg>
+        )}
+      </div>
+    </div>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+interface EpochEvaluationProps {
+  /** Optional explicit job; otherwise the first available job is used. */
+  job?: string;
+}
+
+const fmtPct = (v: number | null | undefined): string =>
+  v == null ? "—" : `${(v * 100).toFixed(1)}%`;
+
+const EpochEvaluation: React.FC<EpochEvaluationProps> = ({ job }) => {
+  const { ref, inView } = useInView({ triggerOnce: true, rootMargin: "200px" });
+  const [data, setData] = useState<EpochEvaluationResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedEpoch, setSelectedEpoch] = useState<number | null>(null);
+  const fetched = useRef(false);
+
+  useEffect(() => {
+    if (!inView || fetched.current) return;
+    fetched.current = true;
+    (async () => {
+      try {
+        let jobName = job;
+        if (!jobName) {
+          const { jobs } = await api.fetchEpochEvaluationJobs();
+          if (!jobs.length) {
+            setError("No epoch evaluations available yet.");
+            return;
+          }
+          jobName = jobs[0];
+        }
+        const resp = await api.fetchEpochEvaluation(jobName);
+        setData(resp);
+        setSelectedEpoch(resp.best_epoch_heldout ?? null);
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "Failed to load.");
+      }
+    })();
+  }, [inView, job]);
+
+  // Epochs with a real epoch number, sorted — the curve excludes the
+  // synthetic "best" alias (epoch null).
+  const epochs = useMemo(
+    () =>
+      (data?.epochs ?? [])
+        .filter((e) => e.epoch != null)
+        .sort((a, b) => (a.epoch as number) - (b.epoch as number)),
+    [data]
+  );
+
+  const selectedEntry = useMemo(
+    () => epochs.find((e) => e.epoch === selectedEpoch) ?? null,
+    [epochs, selectedEpoch]
+  );
+
+  if (error) {
+    return (
+      <div ref={ref} className={styles.container}>
+        <div className={styles.notice}>{error}</div>
+      </div>
+    );
+  }
+
+  if (!data || epochs.length === 0) {
+    return (
+      <div ref={ref} className={styles.container}>
+        <div className={styles.loading}>Loading epoch evaluation…</div>
+      </div>
+    );
+  }
+
+  const perLabel = selectedEntry
+    ? Object.entries(selectedEntry.per_label_f1)
+        .filter(([k]) => !isAggregate(k))
+        .sort((a, b) => b[1] - a[1])
+    : [];
+
+  return (
+    <div ref={ref} className={styles.container}>
+      <div className={styles.header}>
+        <span className={styles.title}>
+          Which epoch actually generalizes best?
+        </span>
+        <span className={styles.jobName}>{data.job_name}</span>
+      </div>
+
+      <div className={styles.legend}>
+        <span className={styles.legendItem}>
+          <span
+            className={styles.swatch}
+            style={{ borderTopColor: "var(--color-green, #3aa757)" }}
+          />
+          Held-out (re-scored on frozen val set)
+        </span>
+        <span className={styles.legendItem}>
+          <span
+            className={styles.swatch}
+            style={{
+              borderTopColor: "var(--color-blue, #4a90d9)",
+              borderTopStyle: "dashed",
+            }}
+          />
+          Training-reported
+        </span>
+      </div>
+
+      <div className={styles.chartWrap}>
+        <EpochCurveChart
+          epochs={epochs}
+          bestHeldoutEpoch={data.best_epoch_heldout}
+          bestReportedEpoch={data.best_epoch_training_reported}
+          selectedEpoch={selectedEpoch}
+          onSelect={setSelectedEpoch}
+        />
+      </div>
+
+      {selectedEntry && (
+        <div className={styles.detail}>
+          <div className={styles.metric}>
+            <span className={styles.metricLabel}>Epoch</span>
+            <span className={styles.metricValue}>{selectedEntry.epoch}</span>
+            <span className={styles.metricSub}>
+              {selectedEntry.epoch === data.best_epoch_heldout
+                ? "best held-out"
+                : `best is ${data.best_epoch_heldout}`}
+            </span>
+          </div>
+          <div className={styles.metric}>
+            <span className={styles.metricLabel}>Held-out F1</span>
+            <span className={styles.metricValue}>
+              {fmtPct(selectedEntry.heldout_f1)}
+            </span>
+            <span className={styles.metricSub}>
+              P {fmtPct(selectedEntry.heldout_precision)} · R{" "}
+              {fmtPct(selectedEntry.heldout_recall)}
+            </span>
+          </div>
+          <div className={styles.metric}>
+            <span className={styles.metricLabel}>Training-reported</span>
+            <span className={styles.metricValue}>
+              {fmtPct(selectedEntry.training_reported_f1)}
+            </span>
+            <span className={styles.metricSub}>
+              {selectedEntry.training_reported_f1 != null
+                ? `${(
+                    (selectedEntry.training_reported_f1 -
+                      selectedEntry.heldout_f1) *
+                    100
+                  ).toFixed(1)} pt gap`
+                : "—"}
+            </span>
+          </div>
+          <div className={styles.metric}>
+            <span className={styles.metricLabel}>Token accuracy</span>
+            <span className={styles.metricValue}>
+              {fmtPct(selectedEntry.token_accuracy)}
+            </span>
+            <span className={styles.metricSub}>
+              {selectedEntry.num_receipts_evaluated} receipts
+            </span>
+          </div>
+
+          {perLabel.length > 0 && (
+            <div className={styles.perLabel} style={{ gridColumn: "1 / -1" }}>
+              <div className={styles.perLabelTitle}>
+                Per-label held-out F1
+              </div>
+              <div className={styles.bars}>
+                {perLabel.map(([label, f1]) => (
+                  <div key={label} className={styles.barRow}>
+                    <span className={styles.barName}>
+                      {formatLabel(label)}
+                    </span>
+                    <span className={styles.barTrack}>
+                      <span
+                        className={styles.barFill}
+                        style={{
+                          width: `${Math.round(f1 * 100)}%`,
+                          background: labelColor(label),
+                        }}
+                      />
+                    </span>
+                    <span className={styles.barValue}>
+                      {(f1 * 100).toFixed(0)}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+
+      <ReceiptScrubber
+        job={data.job_name}
+        selectedEntry={selectedEntry}
+        showcaseKey={data.showcase_receipt_keys[0] ?? null}
+      />
+
+      {!data.val_receipts_hash_verified && (
+        <div className={styles.notice}>
+          <span className={styles.warnFlag}>⚠ </span>
+          Evaluated on the current reconstructed held-out set — the exact
+          training-time split couldn&apos;t be verified (data drift since the
+          run). Epoch comparison is still apples-to-apples.
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default EpochEvaluation;

--- a/portfolio/components/ui/Figures/EpochEvaluation/index.tsx
+++ b/portfolio/components/ui/Figures/EpochEvaluation/index.tsx
@@ -454,8 +454,8 @@ interface EpochEvaluationProps {
 const fmtPct = (v: number | null | undefined): string =>
   v == null ? "—" : `${(v * 100).toFixed(1)}%`;
 
-// Default to the newest experiment (highest -vNN), so the latest run shows
-// first instead of the alphabetically-first one.
+// Pick the newest experiment (highest -vNN) so the current/best run shows,
+// instead of the alphabetically-first (oldest) one.
 const pickDefaultJob = (jobs: string[]): string => {
   const vnum = (j: string) => {
     const m = j.match(/-v(\d+)/);
@@ -469,53 +469,30 @@ const EpochEvaluation: React.FC<EpochEvaluationProps> = ({ job }) => {
   const [data, setData] = useState<EpochEvaluationResponse | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [selectedEpoch, setSelectedEpoch] = useState<number | null>(null);
-  const [jobs, setJobs] = useState<string[]>([]);
-  const [selectedJob, setSelectedJob] = useState<string | null>(job ?? null);
-  const jobsFetched = useRef(false);
+  const fetched = useRef(false);
 
-  // Fetch the job list once (unless an explicit job prop is given).
   useEffect(() => {
-    if (!inView || jobsFetched.current) return;
-    jobsFetched.current = true;
-    if (job) {
-      setSelectedJob(job);
-      return;
-    }
-    api
-      .fetchEpochEvaluationJobs()
-      .then(({ jobs }) => {
-        if (!jobs.length) {
-          setError("No epoch evaluations available yet.");
-          return;
+    if (!inView || fetched.current) return;
+    fetched.current = true;
+    (async () => {
+      try {
+        let jobName = job;
+        if (!jobName) {
+          const { jobs } = await api.fetchEpochEvaluationJobs();
+          if (!jobs.length) {
+            setError("No epoch evaluations available yet.");
+            return;
+          }
+          jobName = pickDefaultJob(jobs);
         }
-        setJobs(jobs);
-        setSelectedJob(pickDefaultJob(jobs));
-      })
-      .catch((e) =>
-        setError(e instanceof Error ? e.message : "Failed to load.")
-      );
-  }, [inView, job]);
-
-  // Fetch the selected job's curve (re-runs when you switch jobs).
-  useEffect(() => {
-    if (!selectedJob) return;
-    let cancelled = false;
-    setData(null);
-    api
-      .fetchEpochEvaluation(selectedJob)
-      .then((resp) => {
-        if (cancelled) return;
+        const resp = await api.fetchEpochEvaluation(jobName);
         setData(resp);
         setSelectedEpoch(resp.best_epoch_heldout ?? null);
-      })
-      .catch((e) => {
-        if (!cancelled)
-          setError(e instanceof Error ? e.message : "Failed to load.");
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [selectedJob]);
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "Failed to load.");
+      }
+    })();
+  }, [inView, job]);
 
   // Epochs with a real epoch number, sorted — the curve excludes the
   // synthetic "best" alias (epoch null).
@@ -560,22 +537,7 @@ const EpochEvaluation: React.FC<EpochEvaluationProps> = ({ job }) => {
         <span className={styles.title}>
           Which epoch actually generalizes best?
         </span>
-        {jobs.length > 1 ? (
-          <select
-            className={styles.jobSelect}
-            value={selectedJob ?? ""}
-            onChange={(e) => setSelectedJob(e.target.value)}
-            aria-label="Select training run"
-          >
-            {jobs.map((j) => (
-              <option key={j} value={j}>
-                {j}
-              </option>
-            ))}
-          </select>
-        ) : (
-          <span className={styles.jobName}>{data.job_name}</span>
-        )}
+        <span className={styles.jobName}>{data.job_name}</span>
         {data.compute?.device === "cuda" && (
           <span className={styles.computeBadge}>
             ⚡ GPU{data.compute.instance_type

--- a/portfolio/components/ui/Figures/EpochEvaluation/index.tsx
+++ b/portfolio/components/ui/Figures/EpochEvaluation/index.tsx
@@ -528,6 +528,15 @@ const EpochEvaluation: React.FC<EpochEvaluationProps> = ({ job }) => {
           Which epoch actually generalizes best?
         </span>
         <span className={styles.jobName}>{data.job_name}</span>
+        {data.compute?.device === "cuda" && (
+          <span className={styles.computeBadge}>
+            ⚡ GPU{data.compute.instance_type
+              ? ` · ${data.compute.instance_type}`
+              : data.compute.gpu_name
+                ? ` · ${data.compute.gpu_name}`
+                : ""}
+          </span>
+        )}
       </div>
 
       <div className={styles.legend}>
@@ -603,6 +612,25 @@ const EpochEvaluation: React.FC<EpochEvaluationProps> = ({ job }) => {
             </span>
             <span className={styles.metricSub}>
               {selectedEntry.num_receipts_evaluated} receipts
+            </span>
+          </div>
+          <div className={styles.metric}>
+            <span className={styles.metricLabel}>Inference</span>
+            <span className={styles.metricValue}>
+              {selectedEntry.avg_inference_ms != null
+                ? `${selectedEntry.avg_inference_ms.toFixed(0)} ms`
+                : "—"}
+            </span>
+            <span className={styles.metricSub}>
+              {data.compute?.device === "cuda"
+                ? `per receipt · GPU${
+                    data.compute.gpu_name ? ` · ${data.compute.gpu_name}` : ""
+                  }`
+                : `per receipt${
+                    data.compute?.device
+                      ? ` · ${data.compute.device.toUpperCase()}`
+                      : ""
+                  }`}
             </span>
           </div>
 

--- a/portfolio/components/ui/Figures/EpochEvaluation/index.tsx
+++ b/portfolio/components/ui/Figures/EpochEvaluation/index.tsx
@@ -454,35 +454,68 @@ interface EpochEvaluationProps {
 const fmtPct = (v: number | null | undefined): string =>
   v == null ? "—" : `${(v * 100).toFixed(1)}%`;
 
+// Default to the newest experiment (highest -vNN), so the latest run shows
+// first instead of the alphabetically-first one.
+const pickDefaultJob = (jobs: string[]): string => {
+  const vnum = (j: string) => {
+    const m = j.match(/-v(\d+)/);
+    return m ? parseInt(m[1], 10) : -1;
+  };
+  return [...jobs].sort((a, b) => vnum(b) - vnum(a) || (a < b ? 1 : -1))[0];
+};
+
 const EpochEvaluation: React.FC<EpochEvaluationProps> = ({ job }) => {
   const { ref, inView } = useInView({ triggerOnce: true, rootMargin: "200px" });
   const [data, setData] = useState<EpochEvaluationResponse | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [selectedEpoch, setSelectedEpoch] = useState<number | null>(null);
-  const fetched = useRef(false);
+  const [jobs, setJobs] = useState<string[]>([]);
+  const [selectedJob, setSelectedJob] = useState<string | null>(job ?? null);
+  const jobsFetched = useRef(false);
 
+  // Fetch the job list once (unless an explicit job prop is given).
   useEffect(() => {
-    if (!inView || fetched.current) return;
-    fetched.current = true;
-    (async () => {
-      try {
-        let jobName = job;
-        if (!jobName) {
-          const { jobs } = await api.fetchEpochEvaluationJobs();
-          if (!jobs.length) {
-            setError("No epoch evaluations available yet.");
-            return;
-          }
-          jobName = jobs[0];
+    if (!inView || jobsFetched.current) return;
+    jobsFetched.current = true;
+    if (job) {
+      setSelectedJob(job);
+      return;
+    }
+    api
+      .fetchEpochEvaluationJobs()
+      .then(({ jobs }) => {
+        if (!jobs.length) {
+          setError("No epoch evaluations available yet.");
+          return;
         }
-        const resp = await api.fetchEpochEvaluation(jobName);
+        setJobs(jobs);
+        setSelectedJob(pickDefaultJob(jobs));
+      })
+      .catch((e) =>
+        setError(e instanceof Error ? e.message : "Failed to load.")
+      );
+  }, [inView, job]);
+
+  // Fetch the selected job's curve (re-runs when you switch jobs).
+  useEffect(() => {
+    if (!selectedJob) return;
+    let cancelled = false;
+    setData(null);
+    api
+      .fetchEpochEvaluation(selectedJob)
+      .then((resp) => {
+        if (cancelled) return;
         setData(resp);
         setSelectedEpoch(resp.best_epoch_heldout ?? null);
-      } catch (e) {
-        setError(e instanceof Error ? e.message : "Failed to load.");
-      }
-    })();
-  }, [inView, job]);
+      })
+      .catch((e) => {
+        if (!cancelled)
+          setError(e instanceof Error ? e.message : "Failed to load.");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedJob]);
 
   // Epochs with a real epoch number, sorted — the curve excludes the
   // synthetic "best" alias (epoch null).
@@ -527,7 +560,22 @@ const EpochEvaluation: React.FC<EpochEvaluationProps> = ({ job }) => {
         <span className={styles.title}>
           Which epoch actually generalizes best?
         </span>
-        <span className={styles.jobName}>{data.job_name}</span>
+        {jobs.length > 1 ? (
+          <select
+            className={styles.jobSelect}
+            value={selectedJob ?? ""}
+            onChange={(e) => setSelectedJob(e.target.value)}
+            aria-label="Select training run"
+          >
+            {jobs.map((j) => (
+              <option key={j} value={j}>
+                {j}
+              </option>
+            ))}
+          </select>
+        ) : (
+          <span className={styles.jobName}>{data.job_name}</span>
+        )}
         {data.compute?.device === "cuda" && (
           <span className={styles.computeBadge}>
             ⚡ GPU{data.compute.instance_type

--- a/portfolio/components/ui/Figures/LayoutLMBatchVisualization/index.tsx
+++ b/portfolio/components/ui/Figures/LayoutLMBatchVisualization/index.tsx
@@ -287,15 +287,26 @@ const EntityLegend: React.FC<EntityLegendProps> = ({
 
   return (
     <div className={styles.entityLegend}>
-      {/* Desktop: full legend (hidden on mobile via CSS) */}
+      {/* Desktop: taxonomy-family legend (hidden on mobile via CSS) — 9 groups
+          instead of one row per granular label. */}
       <div className={styles.legendDesktop}>
-        {ENTITY_TYPES.map((entityType) => (
-          <LegendItem
-            key={entityType}
-            entityType={entityType}
-            isRevealed={revealedEntityTypes.has(entityType)}
-          />
-        ))}
+        {MOBILE_LEGEND_GROUPS.map((group) => {
+          const isRevealed = group.types.some((t) =>
+            revealedEntityTypes.has(t)
+          );
+          return (
+            <div
+              key={group.label}
+              className={`${styles.legendItem} ${isRevealed ? styles.revealed : ""}`}
+            >
+              <div
+                className={styles.legendDot}
+                style={{ backgroundColor: group.color }}
+              />
+              <span className={styles.legendLabel}>{group.label}</span>
+            </div>
+          );
+        })}
       </div>
       {/* Mobile: grouped legend (hidden on desktop via CSS) */}
       <div className={styles.legendMobile}>

--- a/portfolio/components/ui/Figures/LayoutLMBatchVisualization/index.tsx
+++ b/portfolio/components/ui/Figures/LayoutLMBatchVisualization/index.tsx
@@ -116,25 +116,28 @@ const ENTITY_TYPES = [
   "PAYMENT_METHOD",
 ];
 
-// Mobile legend groups - combine same-colored labels into taxonomy families
+// Legend groups — taxonomy families. `title` (hover) carries the breakdown so
+// the labels stay short.
 const MOBILE_LEGEND_GROUPS = [
-  { color: "var(--color-yellow)", label: "Merchant", types: ["MERCHANT_NAME"] },
-  { color: "var(--color-blue)", label: "Date / Time", types: ["DATE", "TIME"] },
+  { color: "var(--color-yellow)", label: "Merchant", title: "Merchant name", types: ["MERCHANT_NAME"] },
+  { color: "var(--color-blue)", label: "Date / Time", title: "Date · Time", types: ["DATE", "TIME"] },
   {
     color: CHARGE_GREEN,
-    label: "Charges (total · subtotal · tax · line · unit)",
+    label: "Charges",
+    title: "Total · Subtotal · Tax · Line total · Unit price",
     types: ["GRAND_TOTAL", "SUBTOTAL", "TAX", "LINE_TOTAL", "UNIT_PRICE", "AMOUNT"],
   },
   {
     color: "var(--color-teal)",
-    label: "Credits (discount · tip · change)",
+    label: "Credits",
+    title: "Discount · Coupon · Tip · Change · Cash back · Refund",
     types: ["DISCOUNT", "COUPON", "TIP", "CHANGE", "CASH_BACK", "REFUND"],
   },
-  { color: "var(--color-cyan)", label: "Quantity", types: ["QUANTITY"] },
-  { color: "var(--color-red)", label: "Address", types: ["ADDRESS", "ADDRESS_LINE"] },
-  { color: "var(--color-pink)", label: "Phone", types: ["PHONE_NUMBER"] },
-  { color: "var(--color-purple)", label: "Website", types: ["WEBSITE"] },
-  { color: "var(--color-orange)", label: "Hours / Payment", types: ["STORE_HOURS", "PAYMENT_METHOD"] },
+  { color: "var(--color-cyan)", label: "Quantity", title: "Quantity", types: ["QUANTITY"] },
+  { color: "var(--color-red)", label: "Address", title: "Address line", types: ["ADDRESS", "ADDRESS_LINE"] },
+  { color: "var(--color-pink)", label: "Phone", title: "Phone number", types: ["PHONE_NUMBER"] },
+  { color: "var(--color-purple)", label: "Website", title: "Website", types: ["WEBSITE"] },
+  { color: "var(--color-orange)", label: "Hours / Payment", title: "Store hours · Payment method", types: ["STORE_HOURS", "PAYMENT_METHOD"] },
 ];
 
 // Animation timing
@@ -297,6 +300,7 @@ const EntityLegend: React.FC<EntityLegendProps> = ({
           return (
             <div
               key={group.label}
+              title={group.title}
               className={`${styles.legendItem} ${isRevealed ? styles.revealed : ""}`}
             >
               <div
@@ -315,6 +319,7 @@ const EntityLegend: React.FC<EntityLegendProps> = ({
           return (
             <div
               key={group.label}
+              title={group.title}
               className={`${styles.legendItem} ${isRevealed ? styles.revealed : ""}`}
             >
               <div className={styles.legendDot} style={{ backgroundColor: group.color }} />

--- a/portfolio/components/ui/Figures/LayoutLMBatchVisualization/index.tsx
+++ b/portfolio/components/ui/Figures/LayoutLMBatchVisualization/index.tsx
@@ -38,7 +38,7 @@ const CHARGE_GREEN_MED = "color-mix(in srgb, var(--color-green) 72%, white)";
 const CHARGE_GREEN_LIGHT = "color-mix(in srgb, var(--color-green) 48%, white)";
 
 // Label colors. New model is granular: currency split into charges (green
-// family) vs credits (cyan), plus QUANTITY (lime) and ADDRESS_LINE.
+// family) vs credits (teal), plus QUANTITY (cyan) and ADDRESS_LINE.
 const LABEL_COLORS: Record<string, string> = {
   MERCHANT_NAME: "var(--color-yellow)",
   DATE: "var(--color-blue)",
@@ -50,15 +50,15 @@ const LABEL_COLORS: Record<string, string> = {
   LINE_TOTAL: CHARGE_GREEN_MED,
   UNIT_PRICE: CHARGE_GREEN_LIGHT,
   AMOUNT: CHARGE_GREEN, // legacy merged label (back-compat)
-  // Credits / money back — cyan
-  DISCOUNT: "var(--color-cyan)",
-  COUPON: "var(--color-cyan)",
-  TIP: "var(--color-cyan)",
-  CHANGE: "var(--color-cyan)",
-  CASH_BACK: "var(--color-cyan)",
-  REFUND: "var(--color-cyan)",
+  // Credits / money back — teal
+  DISCOUNT: "var(--color-teal)",
+  COUPON: "var(--color-teal)",
+  TIP: "var(--color-teal)",
+  CHANGE: "var(--color-teal)",
+  CASH_BACK: "var(--color-teal)",
+  REFUND: "var(--color-teal)",
   // Quantity (a count, not a dollar amount)
-  QUANTITY: "var(--color-lime)",
+  QUANTITY: "var(--color-cyan)",
   // Address / contact
   ADDRESS_LINE: "var(--color-red)",
   ADDRESS: "var(--color-red)", // back-compat
@@ -126,11 +126,11 @@ const MOBILE_LEGEND_GROUPS = [
     types: ["GRAND_TOTAL", "SUBTOTAL", "TAX", "LINE_TOTAL", "UNIT_PRICE", "AMOUNT"],
   },
   {
-    color: "var(--color-cyan)",
+    color: "var(--color-teal)",
     label: "Credits (discount · tip · change)",
     types: ["DISCOUNT", "COUPON", "TIP", "CHANGE", "CASH_BACK", "REFUND"],
   },
-  { color: "var(--color-lime)", label: "Quantity", types: ["QUANTITY"] },
+  { color: "var(--color-cyan)", label: "Quantity", types: ["QUANTITY"] },
   { color: "var(--color-red)", label: "Address", types: ["ADDRESS", "ADDRESS_LINE"] },
   { color: "var(--color-pink)", label: "Phone", types: ["PHONE_NUMBER"] },
   { color: "var(--color-purple)", label: "Website", types: ["WEBSITE"] },

--- a/portfolio/components/ui/Figures/LayoutLMBatchVisualization/index.tsx
+++ b/portfolio/components/ui/Figures/LayoutLMBatchVisualization/index.tsx
@@ -27,17 +27,41 @@ const emptyStringSet = new Set<string>();
 
 // Normalize ADDRESS_LINE to ADDRESS for display purposes
 const normalizeLabel = (label: string): string => {
-  if (label === "ADDRESS_LINE") return "ADDRESS";
+  // Keep granular labels as-is (LABEL_COLORS covers both ADDRESS and
+  // ADDRESS_LINE, the currency roles, QUANTITY, etc.).
   return label;
 };
 
-// Label colors for hybrid model
+// Charge shades (green family) — GRAND_TOTAL boldest, then medium, then light.
+const CHARGE_GREEN = "var(--color-green)";
+const CHARGE_GREEN_MED = "color-mix(in srgb, var(--color-green) 72%, white)";
+const CHARGE_GREEN_LIGHT = "color-mix(in srgb, var(--color-green) 48%, white)";
+
+// Label colors. New model is granular: currency split into charges (green
+// family) vs credits (cyan), plus QUANTITY (lime) and ADDRESS_LINE.
 const LABEL_COLORS: Record<string, string> = {
   MERCHANT_NAME: "var(--color-yellow)",
   DATE: "var(--color-blue)",
   TIME: "var(--color-blue)",
-  AMOUNT: "var(--color-green)",
-  ADDRESS: "var(--color-red)",
+  // Charges — green family
+  GRAND_TOTAL: CHARGE_GREEN,
+  SUBTOTAL: CHARGE_GREEN_MED,
+  TAX: CHARGE_GREEN_MED,
+  LINE_TOTAL: CHARGE_GREEN_MED,
+  UNIT_PRICE: CHARGE_GREEN_LIGHT,
+  AMOUNT: CHARGE_GREEN, // legacy merged label (back-compat)
+  // Credits / money back — cyan
+  DISCOUNT: "var(--color-cyan)",
+  COUPON: "var(--color-cyan)",
+  TIP: "var(--color-cyan)",
+  CHANGE: "var(--color-cyan)",
+  CASH_BACK: "var(--color-cyan)",
+  REFUND: "var(--color-cyan)",
+  // Quantity (a count, not a dollar amount)
+  QUANTITY: "var(--color-lime)",
+  // Address / contact
+  ADDRESS_LINE: "var(--color-red)",
+  ADDRESS: "var(--color-red)", // back-compat
   PHONE_NUMBER: "var(--color-pink)",
   WEBSITE: "var(--color-purple)",
   STORE_HOURS: "var(--color-orange)",
@@ -50,7 +74,20 @@ const ENTITY_DISPLAY_NAMES: Record<string, string> = {
   MERCHANT_NAME: "Merchant",
   DATE: "Date",
   TIME: "Time",
+  GRAND_TOTAL: "Total",
+  SUBTOTAL: "Subtotal",
+  TAX: "Tax",
+  LINE_TOTAL: "Line total",
+  UNIT_PRICE: "Unit price",
   AMOUNT: "Amount",
+  DISCOUNT: "Discount",
+  COUPON: "Coupon",
+  TIP: "Tip",
+  CHANGE: "Change",
+  CASH_BACK: "Cash back",
+  REFUND: "Refund",
+  QUANTITY: "Qty",
+  ADDRESS_LINE: "Address",
   ADDRESS: "Address",
   PHONE_NUMBER: "Phone",
   WEBSITE: "Website",
@@ -58,25 +95,43 @@ const ENTITY_DISPLAY_NAMES: Record<string, string> = {
   PAYMENT_METHOD: "Payment",
 };
 
-// Entity types in order (grouped by color for visual clarity)
+// Entity types in order (grouped by color family for visual clarity)
 const ENTITY_TYPES = [
   "MERCHANT_NAME",
   "DATE",
   "TIME",
-  "AMOUNT",
-  "ADDRESS",
+  "GRAND_TOTAL",
+  "SUBTOTAL",
+  "TAX",
+  "LINE_TOTAL",
+  "UNIT_PRICE",
+  "DISCOUNT",
+  "TIP",
+  "CHANGE",
+  "QUANTITY",
+  "ADDRESS_LINE",
   "PHONE_NUMBER",
   "WEBSITE",
   "STORE_HOURS",
   "PAYMENT_METHOD",
 ];
 
-// Mobile legend groups - combine same-colored labels
+// Mobile legend groups - combine same-colored labels into taxonomy families
 const MOBILE_LEGEND_GROUPS = [
   { color: "var(--color-yellow)", label: "Merchant", types: ["MERCHANT_NAME"] },
   { color: "var(--color-blue)", label: "Date / Time", types: ["DATE", "TIME"] },
-  { color: "var(--color-green)", label: "Amount", types: ["AMOUNT"] },
-  { color: "var(--color-red)", label: "Address", types: ["ADDRESS"] },
+  {
+    color: CHARGE_GREEN,
+    label: "Charges (total · subtotal · tax · line · unit)",
+    types: ["GRAND_TOTAL", "SUBTOTAL", "TAX", "LINE_TOTAL", "UNIT_PRICE", "AMOUNT"],
+  },
+  {
+    color: "var(--color-cyan)",
+    label: "Credits (discount · tip · change)",
+    types: ["DISCOUNT", "COUPON", "TIP", "CHANGE", "CASH_BACK", "REFUND"],
+  },
+  { color: "var(--color-lime)", label: "Quantity", types: ["QUANTITY"] },
+  { color: "var(--color-red)", label: "Address", types: ["ADDRESS", "ADDRESS_LINE"] },
   { color: "var(--color-pink)", label: "Phone", types: ["PHONE_NUMBER"] },
   { color: "var(--color-purple)", label: "Website", types: ["WEBSITE"] },
   { color: "var(--color-orange)", label: "Hours / Payment", types: ["STORE_HOURS", "PAYMENT_METHOD"] },
@@ -322,44 +377,14 @@ const ActiveReceiptViewer: React.FC<ActiveReceiptViewerProps> = ({
             className={styles.receiptImage}
           />
 
-          {/* SVG overlay for bounding boxes and scan line */}
-          {/* Use unique IDs per receipt to avoid conflicts during crossfade */}
+          {/* SVG overlay for the labeled bounding boxes. The old red scan
+              line was removed — inference is now ~15ms, so labels appear
+              effectively instantly. */}
           <svg
             className={styles.svgOverlay}
             viewBox={`0 0 ${receiptData.width} ${receiptData.height}`}
             preserveAspectRatio="none"
           >
-            {/* Scan line - positioned in image coordinates */}
-            <defs>
-              <linearGradient id={`scanLineGradient-${receipt.receipt_id}`} x1="0%" y1="0%" x2="100%" y2="0%">
-                <stop offset="0%" stopColor="transparent" />
-                <stop offset="20%" stopColor="var(--color-red)" />
-                <stop offset="80%" stopColor="var(--color-red)" />
-                <stop offset="100%" stopColor="transparent" />
-              </linearGradient>
-            </defs>
-            {/* Only show scan line when scanProgress > 0 to avoid flash at top during transitions */}
-            {scanProgress > 0 && (
-              <>
-                {/* Soft glow behind scan line (no GPU-expensive blur filter) */}
-                <rect
-                  x="0"
-                  y={(scanProgress / 100) * receiptData.height - receiptData.height * 0.008}
-                  width={receiptData.width}
-                  height={Math.max(receiptData.height * 0.02, 8)}
-                  fill={`url(#scanLineGradient-${receipt.receipt_id})`}
-                  opacity={0.3}
-                />
-                <rect
-                  x="0"
-                  y={(scanProgress / 100) * receiptData.height}
-                  width={receiptData.width}
-                  height={Math.max(receiptData.height * 0.005, 3)}
-                  fill={`url(#scanLineGradient-${receipt.receipt_id})`}
-                />
-              </>
-            )}
-
             {/* Bounding boxes */}
             {visiblePredictions.map((pred, idx) => {
               const key = `${pred.line_id}_${pred.word_id}`;

--- a/portfolio/components/ui/Figures/TrainingMetricsAnimation/TrainingMetricsAnimation.module.css
+++ b/portfolio/components/ui/Figures/TrainingMetricsAnimation/TrainingMetricsAnimation.module.css
@@ -389,6 +389,10 @@
   flex-direction: column;
   gap: 0.5rem;
   width: fit-content;
+  /* Never let a wide matrix force the whole figure (and the sparkline that
+     measures it) past the viewport — scroll within the box instead. */
+  max-width: 100%;
+  overflow-x: auto;
 
   /* Responsive sizing via CSS custom properties (avoids SSR hydration issues) */
   --matrix-cell-size: 34px;
@@ -418,6 +422,35 @@
   writing-mode: vertical-rl;
   text-orientation: mixed;
   transform: rotate(180deg);
+}
+
+.matrixAxisLabelClickable {
+  cursor: pointer;
+  opacity: 1;
+  font-weight: 700;
+}
+.matrixAxisLabelClickable:hover {
+  color: var(--color-link, var(--color-blue));
+}
+
+.matrixBack {
+  font-size: 0.72rem;
+  color: var(--color-link, var(--color-blue));
+  background: transparent;
+  border: none;
+  padding: 2px 0;
+  cursor: pointer;
+  text-align: left;
+  width: fit-content;
+}
+.matrixBack:hover {
+  text-decoration: underline;
+}
+
+.matrixHint {
+  font-size: 0.62rem;
+  color: var(--color-text-muted, #888);
+  opacity: 0.7;
 }
 
 .matrixCell {

--- a/portfolio/components/ui/Figures/TrainingMetricsAnimation/TrainingMetricsAnimation.module.css
+++ b/portfolio/components/ui/Figures/TrainingMetricsAnimation/TrainingMetricsAnimation.module.css
@@ -389,10 +389,9 @@
   flex-direction: column;
   gap: 0.5rem;
   width: fit-content;
-  /* Never let a wide matrix force the whole figure (and the sparkline that
-     measures it) past the viewport — scroll within the box instead. */
+  /* The ~10-family matrix fits the figure on its own (no scroll); cap at the
+     parent so it can never force the figure past the viewport. */
   max-width: 100%;
-  overflow-x: auto;
 
   /* Responsive sizing via CSS custom properties (avoids SSR hydration issues) */
   --matrix-cell-size: 34px;

--- a/portfolio/components/ui/Figures/TrainingMetricsAnimation/index.tsx
+++ b/portfolio/components/ui/Figures/TrainingMetricsAnimation/index.tsx
@@ -45,18 +45,105 @@ const formatLabel = (label: string): string => {
     .join(" ");
 };
 
-// Abbreviated labels for confusion matrix
+// Abbreviated labels for confusion matrix (drill-in member labels)
 const LABEL_ABBREV: Record<string, string> = {
   MERCHANT_NAME: "Merch",
   DATE: "Date",
   TIME: "Time",
   AMOUNT: "Amt",
+  GRAND_TOTAL: "Total",
+  SUBTOTAL: "Subt",
+  TAX: "Tax",
+  LINE_TOTAL: "Line",
+  UNIT_PRICE: "Unit",
+  DISCOUNT: "Disc",
+  COUPON: "Coup",
+  TIP: "Tip",
+  CHANGE: "Chng",
+  CASH_BACK: "Cash",
+  REFUND: "Rfnd",
+  QUANTITY: "Qty",
   ADDRESS: "Addr",
+  ADDRESS_LINE: "Addr",
   PHONE_NUMBER: "Phone",
   WEBSITE: "Web",
   STORE_HOURS: "Hours",
   PAYMENT_METHOD: "Pay",
   O: "O",
+};
+
+// Confusion-matrix families — collapse the granular labels into ~10 groups so
+// the matrix is readable. Multi-member families (Charges, Credits, Date/Time,
+// Hours/Pay, Address) can be drilled into to see their sub-matrix.
+const CM_FAMILIES: { key: string; abbr: string; full: string; members: string[] }[] = [
+  { key: "MERCHANT", abbr: "Merch", full: "Merchant", members: ["MERCHANT_NAME"] },
+  { key: "DATETIME", abbr: "D/T", full: "Date / Time", members: ["DATE", "TIME"] },
+  { key: "CHARGES", abbr: "Chrg", full: "Charges (total·subtotal·tax·line·unit)", members: ["GRAND_TOTAL", "SUBTOTAL", "TAX", "LINE_TOTAL", "UNIT_PRICE", "AMOUNT"] },
+  { key: "CREDITS", abbr: "Crdt", full: "Credits (discount·tip·change…)", members: ["DISCOUNT", "COUPON", "TIP", "CHANGE", "CASH_BACK", "REFUND"] },
+  { key: "QTY", abbr: "Qty", full: "Quantity", members: ["QUANTITY"] },
+  { key: "ADDRESS", abbr: "Addr", full: "Address", members: ["ADDRESS_LINE", "ADDRESS"] },
+  { key: "PHONE", abbr: "Phone", full: "Phone", members: ["PHONE_NUMBER"] },
+  { key: "WEBSITE", abbr: "Web", full: "Website", members: ["WEBSITE"] },
+  { key: "HOURSPAY", abbr: "Hr/Py", full: "Hours / Payment", members: ["STORE_HOURS", "PAYMENT_METHOD"] },
+  { key: "O", abbr: "O", full: "O (no label)", members: ["O"] },
+];
+
+interface MatrixView {
+  labels: string[];
+  titles: string[];
+  matrix: number[][];
+  drillKeys: (string | null)[];
+}
+
+const buildFamilyView = (labels: string[], matrix: number[][]): MatrixView => {
+  const labelToFam = new Map<string, number>();
+  CM_FAMILIES.forEach((f, fi) => f.members.forEach((m) => labelToFam.set(m, fi)));
+  const present = CM_FAMILIES.map((_f, fi) => fi).filter((fi) =>
+    CM_FAMILIES[fi].members.some((m) => labels.includes(m))
+  );
+  const compact = new Map<number, number>();
+  present.forEach((fi, k) => compact.set(fi, k));
+  const n = present.length;
+  const out = Array.from({ length: n }, () => Array(n).fill(0));
+  labels.forEach((rl, i) => {
+    const rf = labelToFam.get(rl);
+    if (rf === undefined || !compact.has(rf)) return;
+    labels.forEach((cl, j) => {
+      const cf = labelToFam.get(cl);
+      if (cf === undefined || !compact.has(cf)) return;
+      out[compact.get(rf) as number][compact.get(cf) as number] +=
+        matrix[i]?.[j] || 0;
+    });
+  });
+  return {
+    labels: present.map((fi) => CM_FAMILIES[fi].abbr),
+    titles: present.map((fi) => CM_FAMILIES[fi].full),
+    matrix: out,
+    drillKeys: present.map((fi) =>
+      CM_FAMILIES[fi].members.filter((m) => labels.includes(m)).length > 1
+        ? CM_FAMILIES[fi].key
+        : null
+    ),
+  };
+};
+
+const buildSubView = (
+  labels: string[],
+  matrix: number[][],
+  famKey: string
+): MatrixView | null => {
+  const fam = CM_FAMILIES.find((f) => f.key === famKey);
+  if (!fam) return null;
+  const idxs = fam.members
+    .map((m) => labels.indexOf(m))
+    .filter((x) => x >= 0);
+  if (idxs.length < 2) return null;
+  return {
+    labels: idxs.map((x) => formatLabelAbbrev(labels[x])),
+    titles: idxs.map((x) => formatLabel(labels[x])),
+    matrix: idxs.map((ri) => idxs.map((ci) => matrix[ri]?.[ci] || 0)),
+    drillKeys: idxs.map(() => null),
+  };
 };
 
 const formatLabelAbbrev = (label: string): string => {
@@ -541,17 +628,43 @@ interface ConfusionMatrixProps {
 }
 
 const ConfusionMatrix: React.FC<ConfusionMatrixProps> = ({ labels, matrix }) => {
-  // Calculate row sums for row-normalized coloring
-  const rowSums = useMemo(() => {
-    return matrix.map((row) => row.reduce((sum, val) => sum + val, 0) || 1);
-  }, [matrix]);
+  // Default to a ~10-family heatmap; drill into a multi-member family on click.
+  const [expanded, setExpanded] = useState<string | null>(null);
 
-  // Grid template uses CSS custom properties for responsive sizing (avoids SSR hydration issues)
-  const gridTemplateColumns = `var(--matrix-label-col) repeat(${labels.length}, var(--matrix-cell-size))`;
-  const gridTemplateRows = `var(--matrix-header-row) repeat(${labels.length}, var(--matrix-cell-size))`;
+  const familyView = useMemo(
+    () => buildFamilyView(labels, matrix),
+    [labels, matrix]
+  );
+  const subView = useMemo(
+    () => (expanded ? buildSubView(labels, matrix, expanded) : null),
+    [expanded, labels, matrix]
+  );
+  const view = subView || familyView;
+
+  const rowSums = useMemo(
+    () => view.matrix.map((row) => row.reduce((s, v) => s + v, 0) || 1),
+    [view]
+  );
+  const expandedFull = expanded
+    ? CM_FAMILIES.find((f) => f.key === expanded)?.full
+    : null;
+
+  const gridTemplateColumns = `var(--matrix-label-col) repeat(${view.labels.length}, var(--matrix-cell-size))`;
+  const gridTemplateRows = `var(--matrix-header-row) repeat(${view.labels.length}, var(--matrix-cell-size))`;
 
   return (
     <div className={styles.matrixContainer}>
+      {expanded ? (
+        <button
+          type="button"
+          className={styles.matrixBack}
+          onClick={() => setExpanded(null)}
+        >
+          ← all families · {expandedFull}
+        </button>
+      ) : (
+        <div className={styles.matrixHint}>tap a ▸ group to drill in</div>
+      )}
       <div
         className={styles.matrixGrid}
         style={{ gridTemplateColumns, gridTemplateRows }}
@@ -560,38 +673,46 @@ const ConfusionMatrix: React.FC<ConfusionMatrixProps> = ({ labels, matrix }) => 
         <div className={styles.matrixCorner} />
 
         {/* X-axis labels (top) */}
-        {labels.map((label) => (
+        {view.labels.map((label, j) => (
           <div
-            key={`x-${label}`}
+            key={`x-${j}-${label}`}
             className={styles.matrixAxisLabel}
-            title={formatLabel(label)}
+            title={view.titles[j]}
           >
-            {formatLabelAbbrev(label)}
+            {label}
           </div>
         ))}
 
         {/* Matrix rows */}
-        {matrix.map((row, i) => (
-          <React.Fragment key={`row-${i}-${labels[i]}`}>
-            {/* Y-axis label */}
-            <div
-              className={`${styles.matrixAxisLabel} ${styles.matrixAxisLabelY}`}
-              title={formatLabel(labels[i])}
-            >
-              {formatLabelAbbrev(labels[i])}
-            </div>
+        {view.matrix.map((row, i) => {
+          const drill = view.drillKeys[i];
+          return (
+            <React.Fragment key={`row-${i}-${view.labels[i]}`}>
+              {/* Y-axis label (clickable when the family can be drilled in) */}
+              <div
+                className={`${styles.matrixAxisLabel} ${styles.matrixAxisLabelY} ${
+                  drill ? styles.matrixAxisLabelClickable : ""
+                }`}
+                title={view.titles[i]}
+                role={drill ? "button" : undefined}
+                onClick={drill ? () => setExpanded(drill) : undefined}
+              >
+                {view.labels[i]}
+                {drill ? " ▸" : ""}
+              </div>
 
-            {/* Cells */}
-            {row.map((value, j) => (
-              <MatrixCell
-                key={`${i}-${j}`}
-                value={value}
-                rowSum={rowSums[i]}
-                isDiagonal={i === j}
-              />
-            ))}
-          </React.Fragment>
-        ))}
+              {/* Cells */}
+              {row.map((value, j) => (
+                <MatrixCell
+                  key={`${i}-${j}`}
+                  value={value}
+                  rowSum={rowSums[i]}
+                  isDiagonal={i === j}
+                />
+              ))}
+            </React.Fragment>
+          );
+        })}
       </div>
     </div>
   );

--- a/portfolio/components/ui/Figures/index.ts
+++ b/portfolio/components/ui/Figures/index.ts
@@ -98,6 +98,10 @@ export const TrainingMetricsAnimation = dynamic(
   () => import("./TrainingMetricsAnimation"),
   { ssr: false }
 );
+export const EpochEvaluation = dynamic(
+  () => import("./EpochEvaluation"),
+  { ssr: false }
+);
 export const LabelWordCloud = dynamic(
   () => import("./LabelWordCloud"),
   { ssr: false }

--- a/portfolio/package-lock.json
+++ b/portfolio/package-lock.json
@@ -101,6 +101,7 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -680,6 +681,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -703,6 +705,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2825,6 +2828,7 @@
       "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "playwright": "1.58.2"
       },
@@ -3275,6 +3279,7 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -3584,6 +3589,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3594,6 +3600,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3691,6 +3698,7 @@
       "integrity": "sha512-npiaib8XzbjtzS2N4HlqPvlpxpmZ14FjSJrteZpPxGUaYPlvhzlzUZ4mZyABo0EFrOWnvyd0Xxroq//hKhtAWg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.53.0",
         "@typescript-eslint/types": "8.53.0",
@@ -4220,6 +4228,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4957,6 +4966,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5930,7 +5940,8 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1467305.tgz",
       "integrity": "sha512-LxwMLqBoPPGpMdRL4NkLFRNy3QLp6Uqa7GNp1v6JaBheop2QrB9Q7q0A/q/CYYP9sBfZdHOyszVx4gc9zyk7ow==",
       "dev": true,
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/doctrine": {
       "version": "2.1.0",
@@ -6330,6 +6341,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6515,6 +6527,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -7828,6 +7841,7 @@
       "integrity": "sha512-U7tt8JsyrxSRKspfhtLET79pU8K+tInj5QZXs1jSugO1Vq5dFj3kmZsRldo29mTBfcjDRVRXrEZ6LS63Cog9ZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -10034,6 +10048,7 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -12360,6 +12375,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -12695,6 +12711,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -12704,6 +12721,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -14287,6 +14305,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -14636,6 +14655,7 @@
       "integrity": "sha512-ZkJ2G7mZrbxrKxinTQMjFqsCoYY6a5Luwv2GKbTnBCEgV2ihYm5CflA9JnJAwH0pZWavqfYxmDkFHPt4yx2oDQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@gerrit0/mini-shiki": "^3.17.0",
         "lunr": "^2.3.9",
@@ -14726,6 +14746,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -15761,6 +15782,7 @@
       "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/portfolio/pages/receipt.tsx
+++ b/portfolio/pages/receipt.tsx
@@ -16,6 +16,7 @@ import {
   CICDLoop,
   CodeBuildDiagram,
   DynamoStreamAnimation,
+  EpochEvaluation,
   LabelValidationTimeline,
   LabelWordCloud,
   LayoutLMInferenceVisualization,
@@ -432,6 +433,20 @@ M1LK 2%           1    $4.4g`}</code>
       <FigureBoundary intrinsicSize="640px">
         <ClientOnly>
           <TrainingMetricsAnimation />
+        </ClientOnly>
+      </FigureBoundary>
+
+      <p>
+        The catch with those training graphs is that the model is grading its
+        own homework — the F1 it reports mid-run can latch onto a lucky epoch.
+        So I went back and re-scored every saved checkpoint against the exact
+        same held-out receipts to see which epoch actually generalizes best.
+        It wasn&apos;t the one training picked.
+      </p>
+
+      <FigureBoundary intrinsicSize="720px">
+        <ClientOnly>
+          <EpochEvaluation />
         </ClientOnly>
       </FigureBoundary>
 

--- a/portfolio/pages/receipt.tsx
+++ b/portfolio/pages/receipt.tsx
@@ -16,7 +16,6 @@ import {
   CICDLoop,
   CodeBuildDiagram,
   DynamoStreamAnimation,
-  EpochEvaluation,
   LabelValidationTimeline,
   LabelWordCloud,
   LayoutLMInferenceVisualization,
@@ -433,20 +432,6 @@ M1LK 2%           1    $4.4g`}</code>
       <FigureBoundary intrinsicSize="640px">
         <ClientOnly>
           <TrainingMetricsAnimation />
-        </ClientOnly>
-      </FigureBoundary>
-
-      <p>
-        The catch with those training graphs is that the model is grading its
-        own homework — the F1 it reports mid-run can latch onto a lucky epoch.
-        So I went back and re-scored every saved checkpoint against the exact
-        same held-out receipts to see which epoch actually generalizes best.
-        It wasn&apos;t the one training picked.
-      </p>
-
-      <FigureBoundary intrinsicSize="720px">
-        <ClientOnly>
-          <EpochEvaluation />
         </ClientOnly>
       </FigureBoundary>
 

--- a/portfolio/services/api/index.ts
+++ b/portfolio/services/api/index.ts
@@ -15,6 +15,9 @@ import {
   MilkSimilarityResponse,
   TrainingMetricsResponse,
   LayoutLMBatchInferenceResponse,
+  EpochEvaluationResponse,
+  EpochEvaluationJobsResponse,
+  EpochEvaluationReceiptRecord,
   FinancialMathResponse,
   ReceiptHealthResponse,
   ReceiptHealthIssuesResponse,
@@ -264,6 +267,52 @@ const baseApi = {
     const apiUrl = getAPIUrl();
     const response = await fetch(
       `${apiUrl}/jobs/featured/training-metrics?collapse_bio=true`,
+      fetchConfig
+    );
+    if (!response.ok) {
+      throw new Error(
+        `Network response was not ok (status: ${response.status})`
+      );
+    }
+    return response.json();
+  },
+
+  // List training jobs that have a per-epoch evaluation available.
+  async fetchEpochEvaluationJobs(): Promise<EpochEvaluationJobsResponse> {
+    const apiUrl = getAPIUrl();
+    const response = await fetch(`${apiUrl}/layoutlm_epochs`, fetchConfig);
+    if (!response.ok) {
+      throw new Error(
+        `Network response was not ok (status: ${response.status})`
+      );
+    }
+    return response.json();
+  },
+
+  // The held-out F1 curve (and training-reported comparison) for one run.
+  async fetchEpochEvaluation(job: string): Promise<EpochEvaluationResponse> {
+    const apiUrl = getAPIUrl();
+    const response = await fetch(
+      `${apiUrl}/layoutlm_epochs?job=${encodeURIComponent(job)}`,
+      fetchConfig
+    );
+    if (!response.ok) {
+      throw new Error(
+        `Network response was not ok (status: ${response.status})`
+      );
+    }
+    return response.json();
+  },
+
+  // A single per-(epoch, receipt) showcase record for the scrubber.
+  async fetchEpochEvaluationReceipt(
+    job: string,
+    receiptPath: string
+  ): Promise<EpochEvaluationReceiptRecord> {
+    const apiUrl = getAPIUrl();
+    const params = new URLSearchParams({ job, receipt_path: receiptPath });
+    const response = await fetch(
+      `${apiUrl}/layoutlm_epochs?${params.toString()}`,
       fetchConfig
     );
     if (!response.ok) {

--- a/portfolio/styles/globals.css
+++ b/portfolio/styles/globals.css
@@ -48,6 +48,8 @@ html {
   --color-teal: #00897B;
   --color-teal-rgb: 0, 137, 123;
   /* RGB values for #00897B */
+  --color-cyan: #00ACC1;
+  --color-cyan-rgb: 0, 172, 193;
   --color-pink: #D81B60;
   --color-pink-rgb: 216, 27, 96;
   /* RGB values for #D81B60 */
@@ -254,6 +256,8 @@ li {
     --color-teal: #26A69A;
     --color-teal-rgb: 38, 166, 154;
     /* RGB values for #26A69A */
+    --color-cyan: #4DD0E1;
+    --color-cyan-rgb: 77, 208, 225;
     --color-pink: #EC407A;
     --color-pink-rgb: 236, 64, 122;
     /* RGB values for #EC407A */

--- a/portfolio/types/api.ts
+++ b/portfolio/types/api.ts
@@ -476,6 +476,68 @@ export interface LayoutLMBatchInferenceResponse {
   legacy_mode?: boolean;
 }
 
+// Per-Epoch Checkpoint Evaluation Types
+// Produced by the eval-checkpoints SageMaker Processing job and served by
+// GET /layoutlm_epochs. Each entry re-scores one checkpoint on the run's
+// frozen validation set, so the curve proves which epoch generalizes best.
+
+export interface EpochEvaluationEntry {
+  checkpoint: string;
+  step: number | null;
+  epoch: number | null;
+  heldout_f1: number;
+  heldout_precision: number;
+  heldout_recall: number;
+  heldout_metric: string;
+  per_label_f1: Record<string, number>;
+  token_accuracy: number;
+  // The value training reported for this epoch from inside the loop (for
+  // comparison against the honest held-out re-evaluation). May be null.
+  training_reported_f1: number | null;
+  num_receipts_evaluated: number;
+}
+
+export interface EpochEvaluationResponse {
+  job_name: string;
+  run_s3_uri: string;
+  // "persisted_val_receipt_keys" (drift-proof) or "reconstructed_from_seed".
+  val_set_source: string;
+  val_receipts_hash: string;
+  val_receipts_hash_recorded: string | null;
+  val_receipts_hash_verified: boolean;
+  num_val_receipts: number;
+  random_seed: number | null;
+  label_list: string[] | null;
+  label_merges: Record<string, string[]>;
+  metric: string;
+  epochs: EpochEvaluationEntry[];
+  best_epoch_heldout: number | null;
+  best_checkpoint_heldout: string | null;
+  best_epoch_training_reported: number | null;
+  showcase_receipt_keys: string[];
+  generated_at: string;
+}
+
+export interface EpochEvaluationJobsResponse {
+  jobs: string[];
+}
+
+// Per-(epoch, receipt) showcase record for the epoch scrubber. The `original`
+// block matches LayoutLMReceiptInference so the same receipt+bbox rendering
+// applies.
+export interface EpochEvaluationReceiptRecord {
+  receipt_id: string;
+  epoch: number | null;
+  checkpoint: string;
+  label_list: string[];
+  original: {
+    receipt: LayoutLMReceiptInference["original"]["receipt"];
+    words: LayoutLMReceiptWord[];
+    predictions: LayoutLMPrediction[];
+  };
+  inference_time_ms: number;
+}
+
 // Label Evaluator Visualization Types
 
 export interface LabelEvaluatorWord {

--- a/portfolio/types/api.ts
+++ b/portfolio/types/api.ts
@@ -495,6 +495,17 @@ export interface EpochEvaluationEntry {
   // comparison against the honest held-out re-evaluation). May be null.
   training_reported_f1: number | null;
   num_receipts_evaluated: number;
+  // Windowed-inference wall-time for this checkpoint over the val set. Avg is
+  // per-receipt; null on older caches generated before timing was recorded.
+  avg_inference_ms: number | null;
+  total_inference_ms: number | null;
+}
+
+// Compute the eval ran on, so timing can be labeled GPU vs CPU.
+export interface EpochEvaluationCompute {
+  device: string; // "cuda" | "cpu" | "unknown"
+  gpu_name: string | null;
+  instance_type: string | null;
 }
 
 export interface EpochEvaluationResponse {
@@ -510,6 +521,8 @@ export interface EpochEvaluationResponse {
   label_list: string[] | null;
   label_merges: Record<string, string[]>;
   metric: string;
+  // Present on caches generated after timing was added; absent on older ones.
+  compute?: EpochEvaluationCompute;
   epochs: EpochEvaluationEntry[];
   best_epoch_heldout: number | null;
   best_checkpoint_heldout: string | null;

--- a/portfolio/types/api.ts
+++ b/portfolio/types/api.ts
@@ -440,7 +440,9 @@ export interface LayoutLMReceiptInference {
     words: LayoutLMReceiptWord[];
     predictions: LayoutLMPrediction[];
   };
-  metrics: {
+  // Present on the legacy generated cache; absent on records sourced from the
+  // per-epoch eval (the viz only reads `original` + `inference_time_ms`).
+  metrics?: {
     overall_accuracy: number;
     total_words: number;
     correct_predictions: number;
@@ -448,14 +450,14 @@ export interface LayoutLMReceiptInference {
     per_label_precision?: Record<string, number>;
     per_label_recall?: Record<string, number>;
   };
-  model_info: {
+  model_info?: {
     model_name: string;
     device: string;
     s3_uri: string;
   };
-  entities_summary: LayoutLMEntitiesSummary;
+  entities_summary?: LayoutLMEntitiesSummary;
   inference_time_ms: number;
-  cached_at: string;
+  cached_at?: string;
 }
 
 export interface LayoutLMAggregateStats {

--- a/receipt_layoutlm/receipt_layoutlm/cli.py
+++ b/receipt_layoutlm/receipt_layoutlm/cli.py
@@ -218,6 +218,15 @@ def main() -> None:
         help="Quantization mode for CoreML export (default: float16).",
     )
     train_p.add_argument(
+        "--no-eval-heldout-windowed",
+        action="store_true",
+        help=(
+            "Disable the in-training windowed held-out eval (which emits "
+            "epochs.json live). On by default; pass this to skip the "
+            "per-epoch eval cost."
+        ),
+    )
+    train_p.add_argument(
         "--resume-from-s3",
         default=None,
         help=(
@@ -511,6 +520,8 @@ def main() -> None:
         train_cfg.output_s3_path = args.output_s3_path
         train_cfg.auto_export_coreml = args.export_coreml
         train_cfg.coreml_quantize = args.coreml_quantize
+        if getattr(args, "no_eval_heldout_windowed", False):
+            train_cfg.eval_heldout_windowed = False
         trainer = ReceiptLayoutLMTrainer(data_cfg, train_cfg)
         if args.resume_from_s3:
             from .resume import sync_resume_checkpoint

--- a/receipt_layoutlm/receipt_layoutlm/cli.py
+++ b/receipt_layoutlm/receipt_layoutlm/cli.py
@@ -366,6 +366,72 @@ def main() -> None:
         help="Run continuously until interrupted (default behavior)",
     )
 
+    # Evaluate-checkpoints subcommand: re-score every epoch on the frozen val set
+    eval_p = sub.add_parser(
+        "eval-checkpoints",
+        help=(
+            "Re-evaluate every saved checkpoint of a run on its frozen val "
+            "set to prove which epoch generalizes best"
+        ),
+    )
+    eval_p.add_argument(
+        "--job-name",
+        help="Training job name; run location is resolved via DynamoDB",
+    )
+    eval_p.add_argument(
+        "--run-s3-uri",
+        help=(
+            "Explicit s3://bucket/runs/<job>/ prefix (overrides --job-name "
+            "resolution)"
+        ),
+    )
+    eval_p.add_argument(
+        "--dynamo-table",
+        default=os.getenv("DYNAMO_TABLE_NAME"),
+        help="DynamoDB table (or DYNAMO_TABLE_NAME env)",
+    )
+    eval_p.add_argument(
+        "--region",
+        default=os.getenv("AWS_REGION", "us-east-1"),
+        help="AWS region",
+    )
+    eval_p.add_argument(
+        "--output-dir",
+        default=os.getenv("SM_OUTPUT_DATA_DIR", "./epoch-eval"),
+        help="Local directory for epochs.json + per-receipt JSON",
+    )
+    eval_p.add_argument(
+        "--output-s3-uri",
+        default=None,
+        help="Optional s3://bucket/prefix/ to upload outputs to",
+    )
+    eval_p.add_argument(
+        "--seed",
+        type=int,
+        default=None,
+        help="Override the run's recorded random seed (else read run.json)",
+    )
+    eval_p.add_argument(
+        "--max-receipts",
+        type=int,
+        default=None,
+        help="Cap val receipts evaluated (default: full frozen set)",
+    )
+    eval_p.add_argument(
+        "--num-showcase",
+        type=int,
+        default=5,
+        help="Val receipts to persist per epoch for scrubbing (default: 5)",
+    )
+    eval_p.add_argument(
+        "--allow-hash-mismatch",
+        action="store_true",
+        help=(
+            "Proceed even if the reconstructed val set no longer matches the "
+            "run's recorded hash (data drift). Default fails loudly."
+        ),
+    )
+
     args = parser.parse_args()
 
     if args.cmd == "train":
@@ -534,6 +600,96 @@ def main() -> None:
             dynamo_table=args.dynamo_table,
             region=args.region,
             run_once=args.once,
+        )
+
+    elif args.cmd == "eval-checkpoints":
+        import logging
+        from urllib.parse import urlparse
+
+        from receipt_dynamo import DynamoClient
+
+        from .evaluate_checkpoints import evaluate_run, sync_outputs_to_s3
+
+        logging.basicConfig(
+            level=logging.INFO,
+            format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+        )
+
+        if not args.dynamo_table:
+            raise SystemExit(
+                "--dynamo-table or DYNAMO_TABLE_NAME env is required"
+            )
+
+        dyn = DynamoClient(table_name=args.dynamo_table, region=args.region)
+
+        # Resolve the run's S3 location: explicit URI wins, else look it up by
+        # job name (newest match) via the Job entity's storage prefixes.
+        run_s3_uri = args.run_s3_uri
+        job_name = args.job_name
+        if not run_s3_uri:
+            if not job_name:
+                raise SystemExit(
+                    "Provide --run-s3-uri or --job-name to locate the run"
+                )
+            jobs, _ = dyn.get_job_by_name(job_name, limit=1)
+            if not jobs:
+                raise SystemExit(f"No job found with name '{job_name}'")
+            job = jobs[0]
+            run_s3_uri = job.s3_uri_for_prefix("run_root_prefix")
+            if not run_s3_uri:
+                best = (job.results or {}).get("best_checkpoint_s3_path")
+                if best:
+                    # Strip a trailing best/ or checkpoint-*/ to get the run root
+                    trimmed = best.rstrip("/").rsplit("/", 1)[0]
+                    run_s3_uri = trimmed + "/"
+            if not run_s3_uri:
+                raise SystemExit(
+                    f"Could not resolve run S3 location for job '{job_name}'. "
+                    f"Pass --run-s3-uri explicitly."
+                )
+        if not job_name:
+            job_name = run_s3_uri.rstrip("/").rsplit("/", 1)[-1]
+
+        parsed = urlparse(run_s3_uri)
+        bucket = parsed.netloc
+        run_prefix = parsed.path.lstrip("/")
+
+        payload = evaluate_run(
+            dynamo=dyn,
+            bucket=bucket,
+            run_prefix=run_prefix,
+            job_name=job_name,
+            output_dir=args.output_dir,
+            seed=args.seed,
+            max_receipts=args.max_receipts,
+            num_showcase=args.num_showcase,
+            allow_hash_mismatch=args.allow_hash_mismatch,
+        )
+
+        if args.output_s3_uri:
+            sync_outputs_to_s3(args.output_dir, args.output_s3_uri)
+
+        best_epoch = payload.get("best_epoch_heldout")
+        best_ckpt = payload.get("best_checkpoint_heldout")
+        print(
+            json.dumps(
+                {
+                    "job_name": payload["job_name"],
+                    "num_checkpoints": len(payload["epochs"]),
+                    "num_val_receipts": payload["num_val_receipts"],
+                    "val_receipts_hash_verified": payload[
+                        "val_receipts_hash_verified"
+                    ],
+                    "best_epoch_heldout": best_epoch,
+                    "best_checkpoint_heldout": best_ckpt,
+                    "best_epoch_training_reported": payload[
+                        "best_epoch_training_reported"
+                    ],
+                    "output_dir": args.output_dir,
+                    "output_s3_uri": args.output_s3_uri,
+                },
+                indent=2,
+            )
         )
 
 

--- a/receipt_layoutlm/receipt_layoutlm/cli.py
+++ b/receipt_layoutlm/receipt_layoutlm/cli.py
@@ -227,6 +227,15 @@ def main() -> None:
         ),
     )
     train_p.add_argument(
+        "--val-keys-s3",
+        default=None,
+        help=(
+            "S3 URI of a JSON file pinning the canonical val receipt keys. "
+            "When set, the run holds out exactly those receipts (shared across "
+            "runs for direct comparability) instead of a random seeded split."
+        ),
+    )
+    train_p.add_argument(
         "--resume-from-s3",
         default=None,
         help=(
@@ -503,6 +512,12 @@ def main() -> None:
         # Optional O:entity ratio for downsampling all-O lines (training only)
         if args.o_entity_ratio is not None:
             os.environ["LAYOUTLM_O_TO_ENTITY_RATIO"] = str(args.o_entity_ratio)
+
+        # Pinned canonical val split (shared across runs for comparability).
+        # Env drives the loader; data_cfg records it for Job-entity lineage.
+        if getattr(args, "val_keys_s3", None):
+            os.environ["LAYOUTLM_VAL_KEYS_S3"] = args.val_keys_s3
+            data_cfg.val_keys_s3 = args.val_keys_s3
 
         # Optional label whitelist
         data_cfg.allowed_labels = (

--- a/receipt_layoutlm/receipt_layoutlm/cli.py
+++ b/receipt_layoutlm/receipt_layoutlm/cli.py
@@ -424,6 +424,21 @@ def main() -> None:
         help="Val receipts to persist per epoch for scrubbing (default: 5)",
     )
     eval_p.add_argument(
+        "--window-size",
+        type=int,
+        default=None,
+        help=(
+            "Inference window size; overrides the run's recorded value. "
+            "Default: run.json window_size, else 200 (data_loader default)"
+        ),
+    )
+    eval_p.add_argument(
+        "--window-stride",
+        type=int,
+        default=None,
+        help="Inference window stride; overrides the run's recorded value",
+    )
+    eval_p.add_argument(
         "--allow-hash-mismatch",
         action="store_true",
         help=(
@@ -663,6 +678,8 @@ def main() -> None:
             seed=args.seed,
             max_receipts=args.max_receipts,
             num_showcase=args.num_showcase,
+            window_size=args.window_size,
+            window_stride=args.window_stride,
             allow_hash_mismatch=args.allow_hash_mismatch,
         )
 

--- a/receipt_layoutlm/receipt_layoutlm/config.py
+++ b/receipt_layoutlm/receipt_layoutlm/config.py
@@ -30,6 +30,9 @@ class DataConfig:
     merge_amounts: bool = False
     dataset_snapshot_load: Optional[str] = None
     dataset_snapshot_save: Optional[str] = None
+    # S3 URI of the pinned canonical val split (recorded for run lineage so the
+    # Job entity / run.json says which shared val set this run held out).
+    val_keys_s3: Optional[str] = None
 
     def get_effective_label_merges(self) -> Dict[str, List[str]]:
         """Return the effective label merges, combining explicit config and legacy flags.

--- a/receipt_layoutlm/receipt_layoutlm/config.py
+++ b/receipt_layoutlm/receipt_layoutlm/config.py
@@ -83,3 +83,8 @@ class TrainingConfig:
     auto_export_coreml: bool = False
     coreml_quantize: Optional[str] = "float16"
     model_version: str = ModelVersion.V1.value
+    # Run the windowed held-out eval in-process after each epoch's checkpoint
+    # is saved, emitting epochs.json live (the viz cache) on the training GPU —
+    # no separate Processing job needed for new runs. Best-effort: failures are
+    # logged and never interrupt training. Disable to skip the per-epoch cost.
+    eval_heldout_windowed: bool = True

--- a/receipt_layoutlm/receipt_layoutlm/data_loader.py
+++ b/receipt_layoutlm/receipt_layoutlm/data_loader.py
@@ -590,6 +590,10 @@ def load_datasets(
         # then directly comparable. Seed is recorded but not used for the split.
         if random_seed is None:
             random_seed = 0
+        # Seed the global PRNG even though the split is deterministic — the
+        # downstream O-only line downsampling consumes random.random(), so two
+        # pinned-val runs must seed identically to keep the SAME training lines.
+        random.seed(random_seed)
         val_receipts_list = [r for r in unique_receipts if r in fixed_val]
         train_receipts_list = [
             r for r in unique_receipts if r not in fixed_val

--- a/receipt_layoutlm/receipt_layoutlm/data_loader.py
+++ b/receipt_layoutlm/receipt_layoutlm/data_loader.py
@@ -380,6 +380,31 @@ def download_receipt_images(
     return cache_dir
 
 
+def _load_fixed_val_keys() -> Optional[set]:
+    """Load a PINNED canonical val set from ``LAYOUTLM_VAL_KEYS_S3``.
+
+    The env var points at a JSON file (``{"val_receipt_keys": [...]}`` or a bare
+    list) of ``"<image_id>#<receipt_id:05d>"`` keys. When set, every run holds
+    out exactly these receipts (those present in its data) and trains on the
+    rest — making runs directly comparable instead of each drawing its own
+    random split. Returns None when unset (fall back to the seeded split).
+    """
+    uri = os.getenv("LAYOUTLM_VAL_KEYS_S3")
+    if not uri:
+        return None
+    import json
+    from urllib.parse import urlparse
+
+    boto3 = importlib.import_module("boto3")
+    p = urlparse(uri)
+    obj = boto3.client("s3").get_object(
+        Bucket=p.netloc, Key=p.path.lstrip("/")
+    )
+    data = json.loads(obj["Body"].read().decode("utf-8"))
+    keys = data.get("val_receipt_keys") if isinstance(data, dict) else data
+    return set(keys) if keys else None
+
+
 def load_datasets(
     dynamo: DynamoClient,
     label_status: str = ValidationStatus.VALID.value,
@@ -554,19 +579,30 @@ def load_datasets(
         features=features,
     )
 
-    # Receipt-level split (90/10) by unique (image_id, receipt_id)
-    # Use provided seed or generate one for reproducibility
-    if random_seed is None:
-        random_seed = random.randint(0, 2**31 - 1)
-    random.seed(random_seed)
-
+    # Receipt-level split by unique (image_id, receipt_id).
     unique_receipts = sorted(
         {ex.receipt_key for ex in examples}
     )  # Sort for determinism
-    random.shuffle(unique_receipts)
-    cut = max(1, int(len(unique_receipts) * 0.9))
-    train_receipts_list = unique_receipts[:cut]
-    val_receipts_list = unique_receipts[cut:]
+    fixed_val = _load_fixed_val_keys()
+    if fixed_val:
+        # Pinned canonical val set: hold out exactly these receipts (those
+        # present in this run's data); train on everything else. Every run is
+        # then directly comparable. Seed is recorded but not used for the split.
+        if random_seed is None:
+            random_seed = 0
+        val_receipts_list = [r for r in unique_receipts if r in fixed_val]
+        train_receipts_list = [
+            r for r in unique_receipts if r not in fixed_val
+        ]
+    else:
+        # Use provided seed or generate one for reproducibility
+        if random_seed is None:
+            random_seed = random.randint(0, 2**31 - 1)
+        random.seed(random_seed)
+        random.shuffle(unique_receipts)
+        cut = max(1, int(len(unique_receipts) * 0.9))
+        train_receipts_list = unique_receipts[:cut]
+        val_receipts_list = unique_receipts[cut:]
     train_receipts = set(train_receipts_list)
     val_receipts = set(val_receipts_list)
 

--- a/receipt_layoutlm/receipt_layoutlm/data_loader.py
+++ b/receipt_layoutlm/receipt_layoutlm/data_loader.py
@@ -39,6 +39,11 @@ class SplitMetadata:
     # reproduce the exact held-out set even after the labeled data drifts, which
     # the hash alone cannot guarantee.
     val_receipt_keys: Optional[List[str]] = None
+    # Sliding-window config used to build training examples. Persisted so
+    # per-epoch evaluation windows inference identically to training (a
+    # different window/stride shifts the F1 curve by inference, not quality).
+    window_size: Optional[int] = None
+    window_stride: Optional[int] = None
 
 
 @dataclass
@@ -682,6 +687,8 @@ def load_datasets(
         target_o_entity_ratio=target_ratio,
         image_cache_dir=image_cache_dir,
         val_receipt_keys=sorted(val_receipts_list),
+        window_size=window_size,
+        window_stride=window_stride,
     )
 
     # v3 needs receipt_key during preprocessing (image cache lookup); removed later in trainer.map()

--- a/receipt_layoutlm/receipt_layoutlm/data_loader.py
+++ b/receipt_layoutlm/receipt_layoutlm/data_loader.py
@@ -34,6 +34,11 @@ class SplitMetadata:
     target_o_entity_ratio: float
     # v3 image cache directory (set when model_version == "v3")
     image_cache_dir: Optional[str] = None
+    # Full sorted list of validation receipt keys ("image_id#receipt_id").
+    # Persisted so downstream tooling (e.g. per-epoch checkpoint evaluation) can
+    # reproduce the exact held-out set even after the labeled data drifts, which
+    # the hash alone cannot guarantee.
+    val_receipt_keys: Optional[List[str]] = None
 
 
 @dataclass
@@ -676,6 +681,7 @@ def load_datasets(
         entity_lines_total=entity_lines_count,
         target_o_entity_ratio=target_ratio,
         image_cache_dir=image_cache_dir,
+        val_receipt_keys=sorted(val_receipts_list),
     )
 
     # v3 needs receipt_key during preprocessing (image cache lookup); removed later in trainer.map()

--- a/receipt_layoutlm/receipt_layoutlm/evaluate_checkpoints.py
+++ b/receipt_layoutlm/receipt_layoutlm/evaluate_checkpoints.py
@@ -982,9 +982,12 @@ def evaluate_run(
 def sync_outputs_to_s3(
     output_dir: str, output_s3_uri: str, s3_client: Any = None
 ) -> None:
-    """Upload ``epochs.json`` and the ``receipts/`` tree to an S3 prefix.
+    """Upload ONLY the eval artifacts (``epochs.json`` + the ``receipts/`` tree)
+    to an S3 prefix.
 
-    The model cache under ``_models/`` is skipped — it's just checkpoint weights.
+    Deliberately scoped: in the in-training path ``output_dir`` is the HF Trainer
+    output dir, which also holds multi-GB ``checkpoint-*/`` binaries (synced
+    separately) and ``_models/`` checkpoint weights — none of which belong here.
     """
     if s3_client is None:
         boto3 = importlib.import_module("boto3")
@@ -995,19 +998,24 @@ def sync_outputs_to_s3(
 
     for root, _dirs, files in os.walk(output_dir):
         rel_root = os.path.relpath(root, output_dir)
-        if rel_root.split(os.sep)[0] == "_models":
+        top = rel_root.split(os.sep)[0]
+        # Only the top-level epochs.json and everything under receipts/.
+        if top not in (".", "receipts"):
             continue
         for fname in files:
+            if top == "." and fname != "epochs.json":
+                continue
             local_path = os.path.join(root, fname)
             rel = os.path.relpath(local_path, output_dir).replace(os.sep, "/")
-            key = f"{prefix}{rel}"
-            s3_client.upload_file(
-                local_path,
-                bucket,
-                key,
-                ExtraArgs={"ContentType": "application/json"},
+            extra = (
+                {"ContentType": "application/json"}
+                if fname.endswith(".json")
+                else None
             )
-    logger.info("Synced outputs to %s", output_s3_uri)
+            s3_client.upload_file(
+                local_path, bucket, f"{prefix}{rel}", ExtraArgs=extra
+            )
+    logger.info("Synced eval outputs to %s", output_s3_uri)
 
 
 # ---------------------------------------------------------------------------

--- a/receipt_layoutlm/receipt_layoutlm/evaluate_checkpoints.py
+++ b/receipt_layoutlm/receipt_layoutlm/evaluate_checkpoints.py
@@ -1008,3 +1008,176 @@ def sync_outputs_to_s3(
                 ExtraArgs={"ContentType": "application/json"},
             )
     logger.info("Synced outputs to %s", output_s3_uri)
+
+
+# ---------------------------------------------------------------------------
+# Live (in-training) evaluation
+#
+# The standalone ``evaluate_run`` spins up a separate Processing job that
+# re-downloads every checkpoint. But during training the model, the frozen val
+# set, and the GPU are already hot — so the trainer can score each epoch's
+# just-saved checkpoint in-process and emit the same ``epochs.json`` live. These
+# helpers expose the per-checkpoint primitives for that path; they reuse the
+# exact scoring used by ``evaluate_run`` so live and retro numbers match.
+# ---------------------------------------------------------------------------
+
+
+def load_val_details(
+    dynamo: Any, val_keys: List[Tuple[str, int]]
+) -> Dict[Tuple[str, int], Any]:
+    """Load ``ReceiptDetails`` for the given (image_id, receipt_id) val keys."""
+    details_by_receipt: Dict[Tuple[str, int], Any] = {}
+    for (image_id, receipt_id) in val_keys:
+        try:
+            details_by_receipt[(image_id, receipt_id)] = (
+                dynamo.get_receipt_details(image_id, receipt_id)
+            )
+        except Exception as e:  # pylint: disable=broad-exception-caught
+            logger.warning(
+                "Failed to load val receipt %s/%s: %s",
+                image_id,
+                receipt_id,
+                e,
+            )
+    return details_by_receipt
+
+
+def evaluate_live_checkpoint(
+    checkpoint_dir: str,
+    details_by_receipt: Dict[Tuple[str, int], Any],
+    *,
+    output_dir: str,
+    step: Optional[int],
+    epoch_num: Optional[int],
+    training_reported_f1: Optional[float],
+    showcase_keys: List[str],
+    valid_status: Any,
+) -> Tuple[Dict[str, Any], List[str], Dict[str, List[str]]]:
+    """Score one just-saved checkpoint dir against pre-loaded val receipts.
+
+    Loads ``LayoutLMInference`` from the checkpoint dir (same as the standalone
+    path → identical numbers), runs windowed inference, writes showcase records
+    under ``output_dir/receipts/epoch-<n>/``, and returns
+    ``(entry, label_list, label_merges)`` where ``entry`` matches the shape of
+    ``evaluate_run``'s epoch entries.
+    """
+    infer = LayoutLMInference(model_dir=checkpoint_dir)
+    label_list = infer.label_list
+    label_merges = infer.label_merges
+
+    all_true, all_pred, showcase, inf_times = _score_checkpoint(
+        infer, details_by_receipt, showcase_keys, valid_status
+    )
+
+    epoch_label = epoch_num if epoch_num is not None else step
+    checkpoint_name = (
+        f"checkpoint-{step}" if step is not None else "live"
+    )
+    for key, record in showcase.items():
+        img, rid = key.rsplit("_", 1)
+        showcase_dir = os.path.join(
+            output_dir, "receipts", f"epoch-{epoch_label}"
+        )
+        os.makedirs(showcase_dir, exist_ok=True)
+        record["epoch"] = epoch_num
+        record["checkpoint"] = checkpoint_name
+        record["label_list"] = label_list
+        with open(
+            os.path.join(showcase_dir, f"receipt-{img}-{rid}.json"),
+            "w",
+            encoding="utf-8",
+        ) as f:
+            json.dump(record, f, default=str)
+
+    scores = _seqeval_scores(all_true, all_pred)
+    entry = {
+        "checkpoint": checkpoint_name,
+        "step": step,
+        "epoch": epoch_num,
+        "heldout_f1": scores["f1"],
+        "heldout_precision": scores["precision"],
+        "heldout_recall": scores["recall"],
+        "heldout_metric": scores["metric"],
+        "per_label_f1": scores["per_label_f1"],
+        "token_accuracy": _token_accuracy(all_true, all_pred),
+        "training_reported_f1": training_reported_f1,
+        "num_receipts_evaluated": len(details_by_receipt),
+        "avg_inference_ms": (
+            round(sum(inf_times) / len(inf_times), 2) if inf_times else None
+        ),
+        "total_inference_ms": (
+            round(sum(inf_times), 2) if inf_times else None
+        ),
+    }
+
+    # Free the inference model promptly — during training this runs alongside
+    # the (much larger) training model + optimizer state on the same GPU.
+    del infer
+    try:
+        import torch
+
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+    except Exception:  # pylint: disable=broad-exception-caught
+        pass
+
+    return entry, label_list, label_merges
+
+
+def write_epochs_json_live(
+    output_dir: str,
+    *,
+    job_name: str,
+    run_s3_uri: str,
+    epoch_entries: List[Dict[str, Any]],
+    label_list: Optional[List[str]],
+    label_merges: Optional[Dict[str, List[str]]],
+    window_size: int,
+    window_stride: int,
+    val_set_source: str,
+    val_hash: Optional[str],
+    num_val_receipts: int,
+    seed: Optional[int],
+    showcase_keys: List[str],
+    best_reported: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Assemble + write ``epochs.json`` from accumulated live entries.
+
+    Produces the SAME payload shape as ``evaluate_run`` so the API and viz are
+    unchanged. Kept as a focused writer (rather than refactoring the working
+    ``evaluate_run``) — the key set must stay in sync with that function.
+    """
+    scored = [e for e in epoch_entries if e.get("checkpoint") != "best"]
+    best_entry = (
+        max(scored, key=lambda e: e["heldout_f1"]) if scored else None
+    )
+    payload = {
+        "job_name": job_name,
+        "run_s3_uri": run_s3_uri,
+        "val_set_source": val_set_source,
+        "val_receipts_hash": val_hash,
+        "val_receipts_hash_recorded": val_hash,
+        "val_receipts_hash_verified": True,
+        "num_val_receipts": num_val_receipts,
+        "random_seed": int(seed) if seed is not None else None,
+        "label_list": label_list,
+        "label_merges": label_merges,
+        "metric": "seqeval_entity_f1",
+        "inference_mode": os.getenv("LAYOUTLM_INFERENCE_MODE", "windowed"),
+        "window_size": window_size,
+        "window_stride": window_stride,
+        "compute": _device_info(),
+        "epochs": epoch_entries,
+        "best_epoch_heldout": (best_entry["epoch"] if best_entry else None),
+        "best_checkpoint_heldout": (
+            best_entry["checkpoint"] if best_entry else None
+        ),
+        "best_epoch_training_reported": best_reported,
+        "showcase_receipt_keys": showcase_keys,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+    }
+    with open(
+        os.path.join(output_dir, "epochs.json"), "w", encoding="utf-8"
+    ) as f:
+        json.dump(payload, f, indent=2, default=str)
+    return payload

--- a/receipt_layoutlm/receipt_layoutlm/evaluate_checkpoints.py
+++ b/receipt_layoutlm/receipt_layoutlm/evaluate_checkpoints.py
@@ -418,16 +418,24 @@ def build_receipt_record(
     Returns ``(record, y_true_lines, y_pred_lines)`` where the two sequence lists
     are per-line BIO tag lists suitable for seqeval entity-level scoring.
     """
-    tokens_per_line, boxes_per_line, line_ids = _receipt_line_inputs(details)
     t0 = time.perf_counter()
-    line_preds = infer.predict_lines(tokens_per_line, boxes_per_line, line_ids)
+    # Default to windowed inference (matches how the model was trained); set
+    # LAYOUTLM_INFERENCE_MODE=per_line to A/B against the legacy per-line path.
+    if os.getenv("LAYOUTLM_INFERENCE_MODE", "windowed") == "windowed":
+        inference_result = infer.predict_receipt_windowed(
+            image_id, receipt_id, details.words
+        )
+    else:
+        tokens_per_line, boxes_per_line, line_ids = _receipt_line_inputs(details)
+        inference_result = InferenceResult(
+            image_id=image_id,
+            receipt_id=receipt_id,
+            lines=infer.predict_lines(
+                tokens_per_line, boxes_per_line, line_ids
+            ),
+            meta={},
+        )
     inference_time_ms = (time.perf_counter() - t0) * 1000.0
-    inference_result = InferenceResult(
-        image_id=image_id,
-        receipt_id=receipt_id,
-        lines=line_preds,
-        meta={},
-    )
 
     # Ground truth (base labels, keyed by (line_id, word_id) since word_id is
     # only unique within a line).

--- a/receipt_layoutlm/receipt_layoutlm/evaluate_checkpoints.py
+++ b/receipt_layoutlm/receipt_layoutlm/evaluate_checkpoints.py
@@ -1,0 +1,859 @@
+"""Evaluate every saved checkpoint of a training run on its frozen val set.
+
+Training reports a per-epoch ``val_f1`` from inside the loop, but that number
+can be misleading (eval-set drift across runs, early-stopping latching onto a
+noisy peak, label-merge config differences). To *prove* which epoch actually
+generalizes best, this module re-scores **every** retained checkpoint against
+the **same** held-out receipts and emits an honest entity-level F1 curve.
+
+The key correctness guarantee is the frozen split. ``data_loader.load_datasets``
+derives the train/val split by:
+
+    random.seed(seed)
+    unique_receipts = sorted({receipt_key for ex in examples})
+    random.shuffle(unique_receipts)
+    cut = max(1, int(len(unique_receipts) * 0.9))
+    val_receipts = unique_receipts[cut:]
+
+and records ``sha256(",".join(sorted(val_receipts)))[:16]`` as
+``val_receipts_hash``. The set of ``unique_receipts`` is exactly the set of
+receipts that have at least one VALID label (every such receipt yields words,
+hence windowed examples, hence a ``receipt_key``). So we can reconstruct the
+identical val set from the recorded seed alone and *verify* it by recomputing
+the hash — a mismatch means the underlying data changed since training, which
+we surface loudly rather than silently scoring a different set.
+
+Outputs (written under ``output_dir`` and optionally synced to S3):
+
+    epochs.json
+        The curve: one entry per checkpoint with held-out F1/precision/recall
+        (entity-level, seqeval) plus the training-time reported number for
+        comparison, per-label F1, token accuracy, and the argmax best epoch.
+
+    receipts/epoch-<n>/receipt-<image_id>-<receipt_id>.json
+        Per-(epoch, showcase-receipt) predictions in the same shape the
+        existing inference viz cache emits, so the frontend can scrub a sample
+        receipt across epochs and watch labels stabilize.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib
+import json
+import logging
+import os
+import random
+import time
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Tuple
+from urllib.parse import urlparse
+
+from .inference import InferenceResult, LayoutLMInference
+from .data_loader import _box_from_word, _normalize_box_from_extents
+
+logger = logging.getLogger(__name__)
+
+# ----------------------------------------------------------------------------
+# BIO / label helpers (mirrors the inference-cache Lambda so the per-receipt
+# records this emits are byte-compatible with what the frontend already renders)
+# ----------------------------------------------------------------------------
+
+
+def _get_base_label(bio_label: Optional[str]) -> str:
+    """Strip a BIO prefix: ``B-DATE``/``I-DATE`` -> ``DATE``; ``O``/None -> ``O``."""
+    if not bio_label or bio_label == "O":
+        return "O"
+    if bio_label.startswith("B-") or bio_label.startswith("I-"):
+        return bio_label[2:]
+    return bio_label
+
+
+def _combine_bio_probabilities(
+    all_probs: Dict[str, float],
+) -> Dict[str, float]:
+    """Sum B-/I- probabilities into base-label probabilities (preserves sum)."""
+    base_probs: Dict[str, float] = {}
+    for bio_label, prob in all_probs.items():
+        base = _get_base_label(bio_label)
+        base_probs[base] = base_probs.get(base, 0.0) + prob
+    return base_probs
+
+
+def _normalize_label_with_model(
+    raw_label: Optional[str], infer: LayoutLMInference
+) -> str:
+    """Normalize a DB label to the model's base label set (uses run.json merges)."""
+    if not raw_label:
+        return "O"
+    label = raw_label.upper()
+    if label.startswith("B-") or label.startswith("I-"):
+        label = label[2:]
+    return infer.normalize_label(label)
+
+
+def _bio_from_base_labels(base_labels: List[str]) -> List[str]:
+    """Convert a per-line sequence of base labels to BIO (B- first, I- contiguous)."""
+    bio: List[str] = []
+    prev = "O"
+    for base in base_labels:
+        if base == "O":
+            bio.append("O")
+            prev = "O"
+        else:
+            bio.append(("B-" if prev != base else "I-") + base)
+            prev = base
+    return bio
+
+
+# ----------------------------------------------------------------------------
+# Frozen val-split reconstruction
+# ----------------------------------------------------------------------------
+
+
+def reconstruct_val_receipts(
+    dynamo: Any,
+    seed: int,
+    *,
+    label_status: str = "VALID",
+    val_fraction: float = 0.1,
+) -> Tuple[List[Tuple[str, int]], str]:
+    """Rebuild the exact held-out receipt set a run trained against.
+
+    Mirrors the receipt-level split in ``data_loader.load_datasets`` so the same
+    seed yields the same val receipts. Returns ``(receipts, val_receipts_hash)``
+    where ``receipts`` is a list of ``(image_id, receipt_id)`` and the hash is
+    the 16-char sha256 used by ``SplitMetadata.val_receipts_hash`` for
+    verification against the run's recorded value.
+
+    Args:
+        dynamo: DynamoClient instance.
+        seed: The run's ``random_seed`` (from run.json / JobMetric).
+        label_status: Validation status that defines the labeled universe.
+        val_fraction: Fraction held out for validation (training uses 0.1).
+    """
+    from receipt_dynamo.constants import ValidationStatus
+
+    all_labels, _ = dynamo.list_receipt_word_labels_with_status(
+        ValidationStatus(label_status), limit=None, last_evaluated_key=None
+    )
+
+    # receipt_key format matches data_loader: f"{image_id}#{receipt_id:05d}"
+    receipt_keys = sorted(
+        {f"{lbl.image_id}#{lbl.receipt_id:05d}" for lbl in all_labels}
+    )
+
+    # Reproduce the deterministic shuffle. random.Random(seed) and
+    # `random.seed(seed); random.shuffle` share the Mersenne Twister state, so
+    # the shuffle order is identical without touching global RNG state.
+    rng = random.Random(seed)
+    rng.shuffle(receipt_keys)
+    cut = max(1, int(len(receipt_keys) * (1.0 - val_fraction)))
+    val_keys = receipt_keys[cut:]
+
+    return [_parse_receipt_key(k) for k in val_keys], _hash_receipt_keys(
+        val_keys
+    )
+
+
+def _parse_receipt_key(key: str) -> Tuple[str, int]:
+    """Parse a ``"image_id#receipt_id"`` split key into ``(image_id, receipt_id)``."""
+    image_id, rec_str = key.rsplit("#", 1)
+    return image_id, int(rec_str)
+
+
+def _hash_receipt_keys(keys: List[str]) -> str:
+    """16-char sha256 of sorted keys (matches ``SplitMetadata.val_receipts_hash``)."""
+    return hashlib.sha256(
+        ",".join(sorted(keys)).encode()
+    ).hexdigest()[:16]
+
+
+# ----------------------------------------------------------------------------
+# S3 discovery
+# ----------------------------------------------------------------------------
+
+
+def _parse_s3_uri(uri: str) -> Tuple[str, str]:
+    parsed = urlparse(uri)
+    return parsed.netloc, parsed.path.lstrip("/")
+
+
+def list_checkpoints(
+    s3: Any, bucket: str, run_prefix: str
+) -> List[Dict[str, Any]]:
+    """List every checkpoint directory under a run prefix.
+
+    The trainer keeps the full per-epoch set under ``<run>/checkpoints/`` and
+    only the last few (plus ``best/``) at the run root, so both locations are
+    scanned and deduped by step. Returns ``{"name", "step", "s3_uri"}`` sorted
+    by step with a synthetic ``best`` entry (step=None) last. Only directories
+    that actually contain model weights are included.
+    """
+    if not run_prefix.endswith("/"):
+        run_prefix += "/"
+
+    by_step: Dict[int, Dict[str, Any]] = {}
+    best: Optional[Dict[str, Any]] = None
+
+    # checkpoints/ first so it wins ties; run root supplies best/ and any
+    # checkpoints not retained in the subdir.
+    for base in (run_prefix + "checkpoints/", run_prefix):
+        token: Optional[str] = None
+        while True:
+            kwargs: Dict[str, Any] = {
+                "Bucket": bucket,
+                "Prefix": base,
+                "Delimiter": "/",
+            }
+            if token:
+                kwargs["ContinuationToken"] = token
+            resp = s3.list_objects_v2(**kwargs)
+            for cp in resp.get("CommonPrefixes", []) or []:
+                prefix = cp["Prefix"]
+                name = prefix[len(base):].rstrip("/")
+                if name == "best":
+                    if best is None and _has_weights(s3, bucket, prefix):
+                        best = {
+                            "name": "best",
+                            "step": None,
+                            "s3_uri": f"s3://{bucket}/{prefix}",
+                        }
+                    continue
+                if not name.startswith("checkpoint-"):
+                    continue
+                try:
+                    step = int(name.split("-", 1)[1])
+                except ValueError:
+                    continue
+                if step in by_step:
+                    continue
+                if not _has_weights(s3, bucket, prefix):
+                    continue
+                by_step[step] = {
+                    "name": name,
+                    "step": step,
+                    "s3_uri": f"s3://{bucket}/{prefix}",
+                }
+            if resp.get("IsTruncated"):
+                token = resp.get("NextContinuationToken")
+            else:
+                break
+
+    checkpoints = sorted(by_step.values(), key=lambda c: c["step"])
+    if best is not None:
+        checkpoints.append(best)
+    return checkpoints
+
+
+def _has_weights(s3: Any, bucket: str, prefix: str) -> bool:
+    page = s3.list_objects_v2(Bucket=bucket, Prefix=prefix, MaxKeys=1000)
+    for obj in page.get("Contents", []) or []:
+        key = obj["Key"]
+        if key.endswith("model.safetensors") or key.endswith(
+            "pytorch_model.bin"
+        ):
+            return True
+    return False
+
+
+def load_run_json(s3: Any, bucket: str, run_prefix: str) -> Dict[str, Any]:
+    """Download and parse ``<run_prefix>/run.json`` (empty dict if absent)."""
+    if not run_prefix.endswith("/"):
+        run_prefix += "/"
+    key = f"{run_prefix}run.json"
+    try:
+        obj = s3.get_object(Bucket=bucket, Key=key)
+        return json.loads(obj["Body"].read())
+    except Exception as e:  # pylint: disable=broad-exception-caught
+        logger.warning(
+            "Could not load run.json at s3://%s/%s: %s", bucket, key, e
+        )
+        return {}
+
+
+def _build_step_epoch_map(
+    run_json: Dict[str, Any],
+) -> Tuple[Dict[int, int], Dict[int, float]]:
+    """From run.json, map global_step -> (epoch, training-reported f1).
+
+    Tolerant of schema differences: scans any list of per-epoch dicts and reads
+    step/epoch/f1 under common key aliases.
+    """
+    step_to_epoch: Dict[int, int] = {}
+    step_to_f1: Dict[int, float] = {}
+
+    candidates: List[Dict[str, Any]] = []
+    for key in ("epoch_metrics", "epochs", "metrics", "history"):
+        val = run_json.get(key)
+        if isinstance(val, list):
+            candidates = [e for e in val if isinstance(e, dict)]
+            if candidates:
+                break
+
+    for entry in candidates:
+        step = entry.get("global_step", entry.get("step"))
+        epoch = entry.get("epoch")
+        if step is None:
+            continue
+        try:
+            step = int(step)
+        except (TypeError, ValueError):
+            continue
+        if epoch is not None:
+            try:
+                step_to_epoch[step] = int(round(float(epoch)))
+            except (TypeError, ValueError):
+                pass
+        for f1_key in ("eval_f1", "val_f1", "f1", "eval_val_f1"):
+            if f1_key in entry and entry[f1_key] is not None:
+                try:
+                    step_to_f1[step] = float(entry[f1_key])
+                except (TypeError, ValueError):
+                    pass
+                break
+
+    return step_to_epoch, step_to_f1
+
+
+# ----------------------------------------------------------------------------
+# Per-receipt inference + scoring
+# ----------------------------------------------------------------------------
+
+
+def _receipt_line_inputs(
+    details: Any,
+) -> Tuple[List[List[str]], List[List[List[int]]], List[int]]:
+    """Build per-line tokens + normalized boxes from cached receipt details.
+
+    Replicates ``LayoutLMInference.predict_receipt_from_dynamo`` normalization so
+    we can reuse one DynamoDB fetch across all checkpoints instead of re-fetching
+    each receipt for every epoch.
+    """
+    by_line: Dict[int, List[Tuple[int, str, List[float]]]] = {}
+    max_x = 0.0
+    max_y = 0.0
+    for w in details.words:
+        x0, y0, x1, y1 = _box_from_word(w)
+        max_x = max(max_x, x1)
+        max_y = max(max_y, y1)
+        by_line.setdefault(w.line_id, []).append(
+            (w.word_id, w.text, [x0, y0, x1, y1])
+        )
+
+    tokens_per_line: List[List[str]] = []
+    boxes_per_line: List[List[List[int]]] = []
+    line_ids: List[int] = []
+    for line_id, items in sorted(by_line.items()):
+        items.sort(key=lambda t: t[0])
+        tokens_per_line.append([tok for _, tok, _ in items])
+        boxes_per_line.append(
+            [
+                _normalize_box_from_extents(
+                    b[0], b[1], b[2], b[3], max_x, max_y
+                )
+                for _, _, b in items
+            ]
+        )
+        line_ids.append(line_id)
+    return tokens_per_line, boxes_per_line, line_ids
+
+
+def build_receipt_record(
+    infer: LayoutLMInference,
+    details: Any,
+    image_id: str,
+    receipt_id: int,
+    *,
+    valid_status: Any,
+) -> Tuple[Dict[str, Any], List[List[str]], List[List[str]]]:
+    """Run inference for one receipt and build a viz-cache-shaped record.
+
+    Returns ``(record, y_true_lines, y_pred_lines)`` where the two sequence lists
+    are per-line BIO tag lists suitable for seqeval entity-level scoring.
+    """
+    tokens_per_line, boxes_per_line, line_ids = _receipt_line_inputs(details)
+    t0 = time.perf_counter()
+    line_preds = infer.predict_lines(tokens_per_line, boxes_per_line, line_ids)
+    inference_time_ms = (time.perf_counter() - t0) * 1000.0
+    inference_result = InferenceResult(
+        image_id=image_id,
+        receipt_id=receipt_id,
+        lines=line_preds,
+        meta={},
+    )
+
+    # Ground truth (base labels, keyed by (line_id, word_id) since word_id is
+    # only unique within a line).
+    ground_truth_base: Dict[Tuple[int, int], str] = {}
+    ground_truth_original: Dict[Tuple[int, int], str] = {}
+    for label in details.labels:
+        if label.validation_status == valid_status:
+            ground_truth_original[(label.line_id, label.word_id)] = label.label
+            ground_truth_base[(label.line_id, label.word_id)] = (
+                _normalize_label_with_model(label.label, infer)
+            )
+
+    # Map tokens back to word_ids per line (position first, then text fallback).
+    words_by_line: Dict[int, List[Any]] = {}
+    word_lookup: Dict[Tuple[int, str], int] = {}
+    for w in details.words:
+        word_lookup[(w.line_id, w.text)] = w.word_id
+        word_lookup[(w.line_id, w.text.strip())] = w.word_id
+        words_by_line.setdefault(w.line_id, []).append(w)
+    for line_id in words_by_line:
+        words_by_line[line_id].sort(key=lambda w: w.word_id)
+
+    predictions: List[Dict[str, Any]] = []
+    y_true_lines: List[List[str]] = []
+    y_pred_lines: List[List[str]] = []
+
+    for line_pred in inference_result.lines:
+        line_id = line_pred.line_id
+        line_words = words_by_line.get(line_id, [])
+
+        line_word_ids: List[Optional[int]] = []
+        line_base_labels: List[str] = []
+        for idx, token in enumerate(line_pred.tokens):
+            word_id: Optional[int] = None
+            if idx < len(line_words):
+                w = line_words[idx]
+                if token == w.text or token.strip() == w.text.strip():
+                    word_id = w.word_id
+            if word_id is None:
+                word_id = word_lookup.get((line_id, token)) or word_lookup.get(
+                    (line_id, token.strip())
+                )
+            if word_id is None:
+                for w in line_words:
+                    if token == w.text or token.strip() == w.text.strip():
+                        word_id = w.word_id
+                        break
+            line_word_ids.append(word_id)
+            line_base_labels.append(
+                ground_truth_base.get((line_id, word_id), "O")
+                if word_id is not None
+                else "O"
+            )
+
+        line_bio_gt = _bio_from_base_labels(line_base_labels)
+
+        # Predicted BIO labels straight from the model (id2label values).
+        line_bio_pred = [
+            line_pred.labels[i] if i < len(line_pred.labels) else "O"
+            for i in range(len(line_pred.tokens))
+        ]
+        y_true_lines.append(line_bio_gt)
+        y_pred_lines.append(line_bio_pred)
+
+        for idx, token in enumerate(line_pred.tokens):
+            word_id = line_word_ids[idx]
+            gt_bio = line_bio_gt[idx]
+            pred_label = (
+                line_pred.labels[idx] if idx < len(line_pred.labels) else "O"
+            )
+            confidence = (
+                line_pred.confidences[idx]
+                if idx < len(line_pred.confidences)
+                else 0.0
+            )
+            all_probs = {}
+            if line_pred.all_probabilities and idx < len(
+                line_pred.all_probabilities
+            ):
+                all_probs = line_pred.all_probabilities[idx]
+
+            predictions.append(
+                {
+                    "word_id": word_id,
+                    "line_id": line_id,
+                    "text": token,
+                    "predicted_label": pred_label,
+                    "ground_truth_label": gt_bio if gt_bio != "O" else None,
+                    "predicted_label_base": _get_base_label(pred_label),
+                    "ground_truth_label_base": (
+                        _get_base_label(gt_bio) if gt_bio != "O" else None
+                    ),
+                    "ground_truth_label_original": (
+                        ground_truth_original.get((line_id, word_id))
+                        if word_id is not None
+                        else None
+                    ),
+                    "predicted_confidence": float(confidence),
+                    "is_correct": pred_label == gt_bio,
+                    "all_class_probabilities": all_probs,
+                    "all_class_probabilities_base": _combine_bio_probabilities(
+                        all_probs
+                    ),
+                }
+            )
+
+    record = {
+        "receipt_id": f"{image_id}_{receipt_id}",
+        "original": {
+            "receipt": dict(details.receipt),
+            "words": [dict(w) for w in details.words],
+            "predictions": predictions,
+        },
+        "inference_time_ms": round(inference_time_ms, 2),
+    }
+    return record, y_true_lines, y_pred_lines
+
+
+def _seqeval_scores(
+    y_true_lines: List[List[str]],
+    y_pred_lines: List[List[str]],
+) -> Dict[str, Any]:
+    """Entity-level F1/precision/recall via seqeval, with per-label breakdown.
+
+    Falls back to token-level accuracy if seqeval is unavailable.
+    """
+    try:
+        seqeval = importlib.import_module("seqeval.metrics")
+    except ModuleNotFoundError:
+        acc = _token_accuracy(y_true_lines, y_pred_lines)
+        return {
+            "metric": "token_accuracy",
+            "f1": acc,
+            "precision": acc,
+            "recall": acc,
+            "per_label_f1": {},
+        }
+
+    f1 = float(seqeval.f1_score(y_true_lines, y_pred_lines))
+    precision = float(seqeval.precision_score(y_true_lines, y_pred_lines))
+    recall = float(seqeval.recall_score(y_true_lines, y_pred_lines))
+
+    per_label_f1: Dict[str, float] = {}
+    report_fn = getattr(seqeval, "classification_report", None)
+    if report_fn is not None:
+        try:
+            report = report_fn(
+                y_true_lines, y_pred_lines, output_dict=True, zero_division=0
+            )
+            for label, stats in report.items():
+                if isinstance(stats, dict) and "f1-score" in stats:
+                    per_label_f1[label] = float(stats["f1-score"])
+        except Exception:  # pylint: disable=broad-exception-caught
+            pass
+
+    return {
+        "metric": "seqeval_entity_f1",
+        "f1": f1,
+        "precision": precision,
+        "recall": recall,
+        "per_label_f1": per_label_f1,
+    }
+
+
+def _token_accuracy(
+    y_true_lines: List[List[str]], y_pred_lines: List[List[str]]
+) -> float:
+    total = correct = 0
+    for yt, yp in zip(y_true_lines, y_pred_lines):
+        for a, b in zip(yt, yp):
+            total += 1
+            correct += int(a == b)
+    return correct / total if total else 0.0
+
+
+# ----------------------------------------------------------------------------
+# Orchestration
+# ----------------------------------------------------------------------------
+
+
+def evaluate_run(
+    *,
+    dynamo: Any,
+    bucket: str,
+    run_prefix: str,
+    job_name: str,
+    output_dir: str,
+    seed: Optional[int] = None,
+    max_receipts: Optional[int] = None,
+    num_showcase: int = 5,
+    allow_hash_mismatch: bool = False,
+    s3_client: Any = None,
+) -> Dict[str, Any]:
+    """Evaluate all checkpoints of a run on its frozen val set.
+
+    Args:
+        dynamo: DynamoClient instance.
+        bucket: S3 bucket holding the run.
+        run_prefix: Key prefix of the run (e.g. ``runs/<job>/``).
+        job_name: Human-readable job name (recorded in the output).
+        output_dir: Local directory to write ``epochs.json`` + per-receipt JSON.
+        seed: Override the run's recorded random seed (else read from run.json).
+        max_receipts: Cap val receipts evaluated (None = full frozen set).
+        num_showcase: How many val receipts to persist per epoch for scrubbing.
+        allow_hash_mismatch: Proceed (with a warning) if the reconstructed val
+            hash doesn't match the run's recorded value. Default fails loudly.
+        s3_client: Optional boto3 S3 client (created if not supplied).
+
+    Returns:
+        The ``epochs.json`` payload (also written to disk).
+    """
+    from receipt_dynamo.constants import ValidationStatus
+
+    valid_status = ValidationStatus.VALID
+    if s3_client is None:
+        boto3 = importlib.import_module("boto3")
+        s3_client = boto3.client("s3")
+
+    if not run_prefix.endswith("/"):
+        run_prefix += "/"
+
+    run_json = load_run_json(s3_client, bucket, run_prefix)
+    split_meta = (run_json.get("split_metadata") or {}) if run_json else {}
+    recorded_hash = split_meta.get("val_receipts_hash")
+    recorded_seed = split_meta.get("random_seed")
+
+    persisted_keys = split_meta.get("val_receipt_keys")
+    if persisted_keys:
+        # Drift-proof: use exactly the receipts training held out. Newer runs
+        # persist this list, so no re-derivation (or drift risk) is needed.
+        val_set_source = "persisted_val_receipt_keys"
+        val_receipts = [_parse_receipt_key(k) for k in persisted_keys]
+        computed_hash = _hash_receipt_keys(list(persisted_keys))
+        hash_verified = (
+            computed_hash == recorded_hash if recorded_hash else True
+        )
+        if seed is None:
+            seed = recorded_seed
+        logger.info(
+            "Using persisted val set: %d receipts (hash %s, verified=%s)",
+            len(val_receipts),
+            computed_hash,
+            hash_verified,
+        )
+    else:
+        # Older runs only recorded the seed + hash. Reconstruct the split and
+        # verify against the recorded hash; a mismatch means the labeled data
+        # drifted since training (the exact training set is unrecoverable).
+        val_set_source = "reconstructed_from_seed"
+        if seed is None:
+            seed = recorded_seed
+        if seed is None:
+            raise ValueError(
+                "No random seed available: pass seed= or ensure run.json "
+                "contains split_metadata.random_seed"
+            )
+        logger.info("Reconstructing frozen val split (seed=%s)", seed)
+        val_receipts, computed_hash = reconstruct_val_receipts(
+            dynamo, int(seed)
+        )
+        hash_verified = bool(recorded_hash) and computed_hash == recorded_hash
+        if recorded_hash and not hash_verified:
+            msg = (
+                f"val_receipts_hash mismatch: recorded={recorded_hash} "
+                f"computed={computed_hash}. The labeled receipt set changed "
+                f"since training, so this is NOT the exact set the model "
+                f"trained against (every epoch is still scored on the same "
+                f"reconstructed set, so the comparison remains valid)."
+            )
+            if not allow_hash_mismatch:
+                raise ValueError(
+                    msg + " Pass allow_hash_mismatch=True to override."
+                )
+            logger.warning(msg)
+        logger.info(
+            "Reconstructed val set: %d receipts (hash %s, verified=%s)",
+            len(val_receipts),
+            computed_hash,
+            hash_verified,
+        )
+
+    if max_receipts is not None:
+        val_receipts = val_receipts[:max_receipts]
+    showcase_keys = [f"{i}_{r}" for i, r in val_receipts[:num_showcase]]
+
+    # Fetch each val receipt's details once and reuse across all checkpoints.
+    logger.info("Prefetching %d receipt details", len(val_receipts))
+    details_by_receipt: Dict[Tuple[str, int], Any] = {}
+    for image_id, receipt_id in val_receipts:
+        try:
+            details_by_receipt[(image_id, receipt_id)] = (
+                dynamo.get_receipt_details(image_id, receipt_id)
+            )
+        except Exception as e:  # pylint: disable=broad-exception-caught
+            logger.warning(
+                "Skipping receipt %s/%s (details fetch failed: %s)",
+                image_id,
+                receipt_id,
+                e,
+            )
+
+    checkpoints = list_checkpoints(s3_client, bucket, run_prefix)
+    if not checkpoints:
+        raise ValueError(
+            f"No checkpoints with weights found under "
+            f"s3://{bucket}/{run_prefix}"
+        )
+    step_to_epoch, step_to_f1 = _build_step_epoch_map(run_json)
+    logger.info("Found %d checkpoints to evaluate", len(checkpoints))
+
+    os.makedirs(output_dir, exist_ok=True)
+
+    epoch_entries: List[Dict[str, Any]] = []
+    label_list: Optional[List[str]] = None
+    label_merges: Dict[str, Any] = {}
+
+    for ckpt in checkpoints:
+        name = ckpt["name"]
+        step = ckpt["step"]
+        logger.info("Evaluating checkpoint %s", name)
+        model_cache = os.path.join(output_dir, "_models", name)
+        infer = LayoutLMInference(
+            model_dir=model_cache, model_s3_uri=ckpt["s3_uri"]
+        )
+        if label_list is None:
+            label_list = infer.label_list
+            label_merges = infer.label_merges
+
+        all_true: List[List[str]] = []
+        all_pred: List[List[str]] = []
+        epoch_num = step_to_epoch.get(step) if step is not None else None
+        epoch_label = (
+            epoch_num
+            if epoch_num is not None
+            else (name if name == "best" else step)
+        )
+
+        for (image_id, receipt_id), details in details_by_receipt.items():
+            try:
+                record, yt, yp = build_receipt_record(
+                    infer,
+                    details,
+                    image_id,
+                    receipt_id,
+                    valid_status=valid_status,
+                )
+            except Exception as e:  # pylint: disable=broad-exception-caught
+                logger.warning(
+                    "Inference failed for %s/%s @ %s: %s",
+                    image_id,
+                    receipt_id,
+                    name,
+                    e,
+                )
+                continue
+            all_true.extend(yt)
+            all_pred.extend(yp)
+
+            if f"{image_id}_{receipt_id}" in showcase_keys:
+                showcase_dir = os.path.join(
+                    output_dir, "receipts", f"epoch-{epoch_label}"
+                )
+                os.makedirs(showcase_dir, exist_ok=True)
+                record["epoch"] = epoch_num
+                record["checkpoint"] = name
+                record["label_list"] = label_list
+                with open(
+                    os.path.join(
+                        showcase_dir,
+                        f"receipt-{image_id}-{receipt_id}.json",
+                    ),
+                    "w",
+                    encoding="utf-8",
+                ) as f:
+                    json.dump(record, f, default=str)
+
+        scores = _seqeval_scores(all_true, all_pred)
+        entry = {
+            "checkpoint": name,
+            "step": step,
+            "epoch": epoch_num,
+            "heldout_f1": scores["f1"],
+            "heldout_precision": scores["precision"],
+            "heldout_recall": scores["recall"],
+            "heldout_metric": scores["metric"],
+            "per_label_f1": scores["per_label_f1"],
+            "token_accuracy": _token_accuracy(all_true, all_pred),
+            "training_reported_f1": (
+                step_to_f1.get(step) if step is not None else None
+            ),
+            "num_receipts_evaluated": len(details_by_receipt),
+        }
+        epoch_entries.append(entry)
+        logger.info(
+            "  %s: held-out F1=%.4f (training reported=%s)",
+            name,
+            entry["heldout_f1"],
+            entry["training_reported_f1"],
+        )
+
+    # Best epoch by held-out F1, excluding the synthetic "best" alias so the
+    # winner is an actual epoch the curve can point at.
+    scored_epochs = [e for e in epoch_entries if e["checkpoint"] != "best"]
+    best_entry = (
+        max(scored_epochs, key=lambda e: e["heldout_f1"])
+        if scored_epochs
+        else None
+    )
+
+    job_results = (run_json.get("results") or {}) if run_json else {}
+    best_reported = job_results.get("best_epoch")
+    if best_reported is None and step_to_f1:
+        # run.json carries no results block (best_epoch lives on the Dynamo Job
+        # entity), so derive the training-reported winner from epoch_metrics.
+        best_step = max(step_to_f1, key=step_to_f1.get)
+        best_reported = step_to_epoch.get(best_step, best_step)
+    payload = {
+        "job_name": job_name,
+        "run_s3_uri": f"s3://{bucket}/{run_prefix}",
+        "val_set_source": val_set_source,
+        "val_receipts_hash": computed_hash,
+        "val_receipts_hash_recorded": recorded_hash,
+        "val_receipts_hash_verified": hash_verified,
+        "num_val_receipts": len(details_by_receipt),
+        "random_seed": int(seed) if seed is not None else None,
+        "label_list": label_list,
+        "label_merges": label_merges,
+        "metric": "seqeval_entity_f1",
+        "epochs": epoch_entries,
+        "best_epoch_heldout": (best_entry["epoch"] if best_entry else None),
+        "best_checkpoint_heldout": (
+            best_entry["checkpoint"] if best_entry else None
+        ),
+        "best_epoch_training_reported": best_reported,
+        "showcase_receipt_keys": showcase_keys,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+    with open(
+        os.path.join(output_dir, "epochs.json"), "w", encoding="utf-8"
+    ) as f:
+        json.dump(payload, f, indent=2, default=str)
+
+    return payload
+
+
+def sync_outputs_to_s3(
+    output_dir: str, output_s3_uri: str, s3_client: Any = None
+) -> None:
+    """Upload ``epochs.json`` and the ``receipts/`` tree to an S3 prefix.
+
+    The model cache under ``_models/`` is skipped — it's just checkpoint weights.
+    """
+    if s3_client is None:
+        boto3 = importlib.import_module("boto3")
+        s3_client = boto3.client("s3")
+    bucket, prefix = _parse_s3_uri(output_s3_uri)
+    if prefix and not prefix.endswith("/"):
+        prefix += "/"
+
+    for root, _dirs, files in os.walk(output_dir):
+        rel_root = os.path.relpath(root, output_dir)
+        if rel_root.split(os.sep)[0] == "_models":
+            continue
+        for fname in files:
+            local_path = os.path.join(root, fname)
+            rel = os.path.relpath(local_path, output_dir).replace(os.sep, "/")
+            key = f"{prefix}{rel}"
+            s3_client.upload_file(
+                local_path,
+                bucket,
+                key,
+                ExtraArgs={"ContentType": "application/json"},
+            )
+    logger.info("Synced outputs to %s", output_s3_uri)

--- a/receipt_layoutlm/receipt_layoutlm/evaluate_checkpoints.py
+++ b/receipt_layoutlm/receipt_layoutlm/evaluate_checkpoints.py
@@ -658,6 +658,8 @@ def evaluate_run(
     seed: Optional[int] = None,
     max_receipts: Optional[int] = None,
     num_showcase: int = 5,
+    window_size: Optional[int] = None,
+    window_stride: Optional[int] = None,
     allow_hash_mismatch: bool = False,
     s3_client: Any = None,
 ) -> Dict[str, Any]:
@@ -693,6 +695,35 @@ def evaluate_run(
     split_meta = (run_json.get("split_metadata") or {}) if run_json else {}
     recorded_hash = split_meta.get("val_receipts_hash")
     recorded_seed = split_meta.get("random_seed")
+
+    # Window inference exactly as the run trained. Precedence: explicit arg >
+    # the run's recorded window config > env > data_loader defaults (200/150).
+    # Export to env so predict_receipt_windowed (called without window args in
+    # build_receipt_record) uses the resolved values.
+    resolved_ws = (
+        window_size
+        if window_size is not None
+        else split_meta.get("window_size")
+        if split_meta.get("window_size") is not None
+        else int(os.getenv("LAYOUTLM_WINDOW_SIZE", "200"))
+    )
+    resolved_stride = (
+        window_stride
+        if window_stride is not None
+        else split_meta.get("window_stride")
+        if split_meta.get("window_stride") is not None
+        else int(os.getenv("LAYOUTLM_WINDOW_STRIDE", "150"))
+    )
+    os.environ["LAYOUTLM_WINDOW_SIZE"] = str(resolved_ws)
+    os.environ["LAYOUTLM_WINDOW_STRIDE"] = str(resolved_stride)
+    logger.info(
+        "Windowed inference config: window_size=%s stride=%s (source: %s)",
+        resolved_ws,
+        resolved_stride,
+        "arg" if window_size is not None
+        else "run.json" if split_meta.get("window_size") is not None
+        else "env/default",
+    )
 
     persisted_keys = split_meta.get("val_receipt_keys")
     if persisted_keys:
@@ -881,6 +912,9 @@ def evaluate_run(
         "label_list": label_list,
         "label_merges": label_merges,
         "metric": "seqeval_entity_f1",
+        "inference_mode": os.getenv("LAYOUTLM_INFERENCE_MODE", "windowed"),
+        "window_size": resolved_ws,
+        "window_stride": resolved_stride,
         "epochs": epoch_entries,
         "best_epoch_heldout": (best_entry["epoch"] if best_entry else None),
         "best_checkpoint_heldout": (

--- a/receipt_layoutlm/receipt_layoutlm/evaluate_checkpoints.py
+++ b/receipt_layoutlm/receipt_layoutlm/evaluate_checkpoints.py
@@ -621,15 +621,20 @@ def _score_checkpoint(
     details_by_receipt: Dict[Tuple[str, int], Any],
     showcase_keys: List[str],
     valid_status: Any,
-) -> Tuple[List[List[str]], List[List[str]], Dict[str, Dict[str, Any]]]:
+) -> Tuple[
+    List[List[str]], List[List[str]], Dict[str, Dict[str, Any]], List[float]
+]:
     """Run one checkpoint over all val receipts; collect sequences + showcase.
 
-    Returns ``(y_true_lines, y_pred_lines, showcase_records)`` where the records
-    dict is keyed by ``"image_id_receipt_id"`` for the showcase subset.
+    Returns ``(y_true_lines, y_pred_lines, showcase_records, inference_times_ms)``
+    where the records dict is keyed by ``"image_id_receipt_id"`` for the
+    showcase subset and ``inference_times_ms`` is the per-receipt windowed
+    inference wall-time (used to surface device throughput in the viz).
     """
     all_true: List[List[str]] = []
     all_pred: List[List[str]] = []
     showcase: Dict[str, Dict[str, Any]] = {}
+    inference_times_ms: List[float] = []
     for (image_id, receipt_id), details in details_by_receipt.items():
         try:
             record, yt, yp = build_receipt_record(
@@ -642,10 +647,42 @@ def _score_checkpoint(
             continue
         all_true.extend(yt)
         all_pred.extend(yp)
+        t = record.get("inference_time_ms")
+        if isinstance(t, (int, float)):
+            inference_times_ms.append(float(t))
         key = f"{image_id}_{receipt_id}"
         if key in showcase_keys:
             showcase[key] = record
-    return all_true, all_pred, showcase
+    return all_true, all_pred, showcase, inference_times_ms
+
+
+def _device_info() -> Dict[str, Any]:
+    """Best-effort descriptor of the compute the eval ran on.
+
+    Lets the viz label the timing as GPU vs CPU (and name the GPU), so the
+    "faster GPU times" are self-describing rather than a bare millisecond count.
+    """
+    info: Dict[str, Any] = {
+        "device": "unknown",
+        "gpu_name": None,
+        # Set by the Processing job / trainer when known (see infra component).
+        "instance_type": os.getenv("EVAL_INSTANCE_TYPE")
+        or os.getenv("SM_CURRENT_INSTANCE_TYPE"),
+    }
+    try:
+        import torch  # heavy dep; imported lazily
+
+        if torch.cuda.is_available():
+            info["device"] = "cuda"
+            try:
+                info["gpu_name"] = torch.cuda.get_device_name(0)
+            except Exception:  # pylint: disable=broad-exception-caught
+                pass
+        else:
+            info["device"] = "cpu"
+    except Exception:  # pylint: disable=broad-exception-caught
+        pass
+    return info
 
 
 def evaluate_run(
@@ -837,7 +874,7 @@ def evaluate_run(
                 else (name if name == "best" else step)
             )
 
-            all_true, all_pred, showcase = _score_checkpoint(
+            all_true, all_pred, showcase, inf_times = _score_checkpoint(
                 infer, details_by_receipt, showcase_keys, valid_status
             )
 
@@ -872,6 +909,14 @@ def evaluate_run(
                     step_to_f1.get(step) if step is not None else None
                 ),
                 "num_receipts_evaluated": len(details_by_receipt),
+                "avg_inference_ms": (
+                    round(sum(inf_times) / len(inf_times), 2)
+                    if inf_times
+                    else None
+                ),
+                "total_inference_ms": (
+                    round(sum(inf_times), 2) if inf_times else None
+                ),
             }
             epoch_entries.append(entry)
             logger.info(
@@ -915,6 +960,7 @@ def evaluate_run(
         "inference_mode": os.getenv("LAYOUTLM_INFERENCE_MODE", "windowed"),
         "window_size": resolved_ws,
         "window_stride": resolved_stride,
+        "compute": _device_info(),
         "epochs": epoch_entries,
         "best_epoch_heldout": (best_entry["epoch"] if best_entry else None),
         "best_checkpoint_heldout": (

--- a/receipt_layoutlm/receipt_layoutlm/evaluate_checkpoints.py
+++ b/receipt_layoutlm/receipt_layoutlm/evaluate_checkpoints.py
@@ -44,6 +44,7 @@ import json
 import logging
 import os
 import random
+import shutil
 import time
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Tuple
@@ -244,6 +245,51 @@ def list_checkpoints(
     if best is not None:
         checkpoints.append(best)
     return checkpoints
+
+
+# Only these files are needed to load a model for inference. Crucially this
+# excludes optimizer.pt (~900MB) / scheduler.pt / rng_state, which would
+# otherwise be downloaded for every checkpoint.
+_INFERENCE_FILES = (
+    "config.json",
+    "model.safetensors",
+    "pytorch_model.bin",
+    "tokenizer.json",
+    "tokenizer_config.json",
+    "vocab.txt",
+    "special_tokens_map.json",
+    "preprocessor_config.json",
+)
+
+
+def _download_checkpoint_files(
+    s3: Any,
+    ckpt_s3_uri: str,
+    dest: str,
+    run_json: Optional[Dict[str, Any]] = None,
+) -> None:
+    """Download just the inference files of a checkpoint into ``dest``.
+
+    Also writes ``run.json`` locally so ``LayoutLMInference`` picks up the
+    label-merge config without a second S3 round trip. Skips the large
+    optimizer/scheduler state that is irrelevant to inference.
+    """
+    os.makedirs(dest, exist_ok=True)
+    bucket, prefix = _parse_s3_uri(ckpt_s3_uri)
+    if not prefix.endswith("/"):
+        prefix += "/"
+    for fname in _INFERENCE_FILES:
+        try:
+            s3.download_file(bucket, prefix + fname, os.path.join(dest, fname))
+        except Exception:  # pylint: disable=broad-exception-caught
+            # Most checkpoints have only one of safetensors/bin; missing
+            # optional files are expected.
+            continue
+    if run_json is not None:
+        with open(
+            os.path.join(dest, "run.json"), "w", encoding="utf-8"
+        ) as f:
+            json.dump(run_json, f)
 
 
 def _has_weights(s3: Any, bucket: str, prefix: str) -> bool:
@@ -562,6 +608,38 @@ def _token_accuracy(
 # ----------------------------------------------------------------------------
 
 
+def _score_checkpoint(
+    infer: LayoutLMInference,
+    details_by_receipt: Dict[Tuple[str, int], Any],
+    showcase_keys: List[str],
+    valid_status: Any,
+) -> Tuple[List[List[str]], List[List[str]], Dict[str, Dict[str, Any]]]:
+    """Run one checkpoint over all val receipts; collect sequences + showcase.
+
+    Returns ``(y_true_lines, y_pred_lines, showcase_records)`` where the records
+    dict is keyed by ``"image_id_receipt_id"`` for the showcase subset.
+    """
+    all_true: List[List[str]] = []
+    all_pred: List[List[str]] = []
+    showcase: Dict[str, Dict[str, Any]] = {}
+    for (image_id, receipt_id), details in details_by_receipt.items():
+        try:
+            record, yt, yp = build_receipt_record(
+                infer, details, image_id, receipt_id, valid_status=valid_status
+            )
+        except Exception as e:  # pylint: disable=broad-exception-caught
+            logger.warning(
+                "Inference failed for %s/%s: %s", image_id, receipt_id, e
+            )
+            continue
+        all_true.extend(yt)
+        all_pred.extend(yp)
+        key = f"{image_id}_{receipt_id}"
+        if key in showcase_keys:
+            showcase[key] = record
+    return all_true, all_pred, showcase
+
+
 def evaluate_run(
     *,
     dynamo: Any,
@@ -703,44 +781,29 @@ def evaluate_run(
         step = ckpt["step"]
         logger.info("Evaluating checkpoint %s", name)
         model_cache = os.path.join(output_dir, "_models", name)
-        infer = LayoutLMInference(
-            model_dir=model_cache, model_s3_uri=ckpt["s3_uri"]
-        )
-        if label_list is None:
-            label_list = infer.label_list
-            label_merges = infer.label_merges
+        try:
+            # Pull only inference files (not optimizer state) and load locally.
+            _download_checkpoint_files(
+                s3_client, ckpt["s3_uri"], model_cache, run_json=run_json
+            )
+            infer = LayoutLMInference(model_dir=model_cache)
+            if label_list is None:
+                label_list = infer.label_list
+                label_merges = infer.label_merges
 
-        all_true: List[List[str]] = []
-        all_pred: List[List[str]] = []
-        epoch_num = step_to_epoch.get(step) if step is not None else None
-        epoch_label = (
-            epoch_num
-            if epoch_num is not None
-            else (name if name == "best" else step)
-        )
+            epoch_num = step_to_epoch.get(step) if step is not None else None
+            epoch_label = (
+                epoch_num
+                if epoch_num is not None
+                else (name if name == "best" else step)
+            )
 
-        for (image_id, receipt_id), details in details_by_receipt.items():
-            try:
-                record, yt, yp = build_receipt_record(
-                    infer,
-                    details,
-                    image_id,
-                    receipt_id,
-                    valid_status=valid_status,
-                )
-            except Exception as e:  # pylint: disable=broad-exception-caught
-                logger.warning(
-                    "Inference failed for %s/%s @ %s: %s",
-                    image_id,
-                    receipt_id,
-                    name,
-                    e,
-                )
-                continue
-            all_true.extend(yt)
-            all_pred.extend(yp)
+            all_true, all_pred, showcase = _score_checkpoint(
+                infer, details_by_receipt, showcase_keys, valid_status
+            )
 
-            if f"{image_id}_{receipt_id}" in showcase_keys:
+            for key, record in showcase.items():
+                img, rid = key.rsplit("_", 1)
                 showcase_dir = os.path.join(
                     output_dir, "receipts", f"epoch-{epoch_label}"
                 )
@@ -749,38 +812,38 @@ def evaluate_run(
                 record["checkpoint"] = name
                 record["label_list"] = label_list
                 with open(
-                    os.path.join(
-                        showcase_dir,
-                        f"receipt-{image_id}-{receipt_id}.json",
-                    ),
+                    os.path.join(showcase_dir, f"receipt-{img}-{rid}.json"),
                     "w",
                     encoding="utf-8",
                 ) as f:
                     json.dump(record, f, default=str)
 
-        scores = _seqeval_scores(all_true, all_pred)
-        entry = {
-            "checkpoint": name,
-            "step": step,
-            "epoch": epoch_num,
-            "heldout_f1": scores["f1"],
-            "heldout_precision": scores["precision"],
-            "heldout_recall": scores["recall"],
-            "heldout_metric": scores["metric"],
-            "per_label_f1": scores["per_label_f1"],
-            "token_accuracy": _token_accuracy(all_true, all_pred),
-            "training_reported_f1": (
-                step_to_f1.get(step) if step is not None else None
-            ),
-            "num_receipts_evaluated": len(details_by_receipt),
-        }
-        epoch_entries.append(entry)
-        logger.info(
-            "  %s: held-out F1=%.4f (training reported=%s)",
-            name,
-            entry["heldout_f1"],
-            entry["training_reported_f1"],
-        )
+            scores = _seqeval_scores(all_true, all_pred)
+            entry = {
+                "checkpoint": name,
+                "step": step,
+                "epoch": epoch_num,
+                "heldout_f1": scores["f1"],
+                "heldout_precision": scores["precision"],
+                "heldout_recall": scores["recall"],
+                "heldout_metric": scores["metric"],
+                "per_label_f1": scores["per_label_f1"],
+                "token_accuracy": _token_accuracy(all_true, all_pred),
+                "training_reported_f1": (
+                    step_to_f1.get(step) if step is not None else None
+                ),
+                "num_receipts_evaluated": len(details_by_receipt),
+            }
+            epoch_entries.append(entry)
+            logger.info(
+                "  %s: held-out F1=%.4f (training reported=%s)",
+                name,
+                entry["heldout_f1"],
+                entry["training_reported_f1"],
+            )
+        finally:
+            # Free disk before the next checkpoint (~450MB weights each).
+            shutil.rmtree(model_cache, ignore_errors=True)
 
     # Best epoch by held-out F1, excluding the synthetic "best" alias so the
     # winner is an actual epoch the curve can point at.

--- a/receipt_layoutlm/receipt_layoutlm/inference.py
+++ b/receipt_layoutlm/receipt_layoutlm/inference.py
@@ -155,7 +155,9 @@ class LayoutLMInference:
         with open(path, "r") as f:
             config = json.load(f)
 
-        self._label_merges = config.get("label_merges", {})
+        # Runs trained without merges serialize "label_merges": null, so
+        # `.get(..., {})` still yields None — coalesce to {} to avoid a crash.
+        self._label_merges = config.get("label_merges") or {}
 
         # Build reverse mapping: original_label -> merged_label
         for merged_label, original_labels in self._label_merges.items():
@@ -525,10 +527,13 @@ class LayoutLMInference:
         (LAYOUTLM_WINDOW_SIZE / LAYOUTLM_WINDOW_STRIDE), so setting them to the
         values a model trained with makes inference match it exactly.
         """
+        # Default to the trainer's data_loader defaults (NOT 250/200) so an
+        # unconfigured eval scores under the same windowing the model trained
+        # with. Callers should pass the run's actual window config when known.
         if window_size is None:
-            window_size = int(os.getenv("LAYOUTLM_WINDOW_SIZE", "250"))
+            window_size = int(os.getenv("LAYOUTLM_WINDOW_SIZE", "200"))
         if stride is None:
-            stride = int(os.getenv("LAYOUTLM_WINDOW_STRIDE", "200"))
+            stride = int(os.getenv("LAYOUTLM_WINDOW_STRIDE", "150"))
 
         # Per-receipt extents → normalized boxes (matches training + per-line).
         max_x = max_y = 0.0

--- a/receipt_layoutlm/receipt_layoutlm/inference.py
+++ b/receipt_layoutlm/receipt_layoutlm/inference.py
@@ -575,7 +575,20 @@ class LayoutLMInference:
         boxes = [it[3] for it in ordered]
         n = len(ordered)
 
-        starts = [0] if n <= window_size else list(range(0, n, stride))
+        # Replicate the trainer's start sequence EXACTLY: step by stride but
+        # stop as soon as a window reaches the end, so we don't emit an extra
+        # short trailing window the trainer never produced (and over-weight the
+        # tail in overlap averaging). See data_loader._build_receipt_window_examples.
+        if n <= window_size:
+            starts = [0]
+        else:
+            starts = []
+            s = 0
+            while s < n:
+                starts.append(s)
+                if s + window_size >= n:
+                    break
+                s += stride
         win_tokens = [tokens[s : min(s + window_size, n)] for s in starts]
         win_boxes = [boxes[s : min(s + window_size, n)] for s in starts]
         win_preds = self.predict_lines(win_tokens, win_boxes)

--- a/receipt_layoutlm/receipt_layoutlm/inference.py
+++ b/receipt_layoutlm/receipt_layoutlm/inference.py
@@ -499,3 +499,137 @@ class LayoutLMInference:
                 "model_dir": self._model_dir,
             },
         )
+
+    def predict_receipt_windowed(
+        self,
+        image_id: str,
+        receipt_id: int,
+        words: List[Any],
+        window_size: Optional[int] = None,
+        stride: Optional[int] = None,
+    ) -> InferenceResult:
+        """Run inference over sliding windows that mirror training.
+
+        Training builds examples by sorting a receipt's words by ascending
+        normalized (y, x) and cutting ``window_size``-word windows with
+        ``stride`` step (see
+        ``data_loader._build_receipt_window_examples``). The per-line path used
+        elsewhere instead feeds one line at a time, so the model never sees the
+        multi-line context it was trained on. This method reproduces the
+        training windowing, predicts each window (batched), averages per-label
+        probabilities for words that fall in overlapping windows, and returns
+        the result as per-line ``LinePrediction``s so downstream code is
+        unchanged.
+
+        window_size/stride default to the same env vars training reads
+        (LAYOUTLM_WINDOW_SIZE / LAYOUTLM_WINDOW_STRIDE), so setting them to the
+        values a model trained with makes inference match it exactly.
+        """
+        if window_size is None:
+            window_size = int(os.getenv("LAYOUTLM_WINDOW_SIZE", "250"))
+        if stride is None:
+            stride = int(os.getenv("LAYOUTLM_WINDOW_STRIDE", "200"))
+
+        # Per-receipt extents → normalized boxes (matches training + per-line).
+        max_x = max_y = 0.0
+        raw: List[Tuple[int, int, str, Tuple[float, float, float, float]]] = []
+        for w in words:
+            x0, y0, x1, y1 = _box_from_word(w)
+            max_x = max(max_x, x1)
+            max_y = max(max_y, y1)
+            raw.append((w.line_id, w.word_id, w.text, (x0, y0, x1, y1)))
+
+        if not raw:
+            return InferenceResult(
+                image_id=image_id, receipt_id=receipt_id, lines=[], meta={}
+            )
+
+        items = [
+            (
+                lid,
+                wid,
+                text,
+                _normalize_box_from_extents(
+                    b[0], b[1], b[2], b[3], max_x, max_y
+                ),
+            )
+            for (lid, wid, text, b) in raw
+        ]
+
+        # Order words by ascending normalized (y, x) — the EXACT key training
+        # uses (data_loader._build_receipt_window_examples). NB: boxes come from
+        # Apple Vision (origin bottom-left, y increases upward), so this is not
+        # human top-to-bottom — but matching training is the whole point, so do
+        # NOT "correct" it here without also changing the trainer.
+        order = sorted(
+            range(len(items)),
+            key=lambda i: (items[i][3][1], items[i][3][0]),
+        )
+        ordered = [items[i] for i in order]
+        tokens = [it[2] for it in ordered]
+        boxes = [it[3] for it in ordered]
+        n = len(ordered)
+
+        starts = [0] if n <= window_size else list(range(0, n, stride))
+        win_tokens = [tokens[s : min(s + window_size, n)] for s in starts]
+        win_boxes = [boxes[s : min(s + window_size, n)] for s in starts]
+        win_preds = self.predict_lines(win_tokens, win_boxes)
+
+        # Average per-label probabilities across windows covering each word.
+        prob_sums: List[Optional[Dict[str, float]]] = [None] * n
+        prob_counts: List[int] = [0] * n
+        for wi, s in enumerate(starts):
+            for j, ap in enumerate(win_preds[wi].all_probabilities or []):
+                oi = s + j
+                if oi >= n:
+                    break
+                bucket = prob_sums[oi]
+                if bucket is None:
+                    bucket = {}
+                    prob_sums[oi] = bucket
+                for k, v in ap.items():
+                    bucket[k] = bucket.get(k, 0.0) + v
+                prob_counts[oi] += 1
+
+        # Finalize each word, then regroup into per-line predictions ordered by
+        # word_id (the order downstream token→word matching expects).
+        by_line: Dict[int, List[Tuple[int, str, str, float, Dict[str, float]]]] = {}
+        for oi in range(n):
+            lid, wid, text, _box = ordered[oi]
+            sums = prob_sums[oi]
+            cnt = prob_counts[oi]
+            if not sums or cnt == 0:
+                by_line.setdefault(lid, []).append((wid, text, "O", 0.0, {}))
+                continue
+            probs = {k: v / cnt for k, v in sums.items()}
+            label = max(probs, key=probs.get)
+            by_line.setdefault(lid, []).append(
+                (wid, text, label, probs[label], probs)
+            )
+
+        lines: List[LinePrediction] = []
+        for lid in sorted(by_line):
+            ws = sorted(by_line[lid], key=lambda t: t[0])
+            lines.append(
+                LinePrediction(
+                    line_id=lid,
+                    tokens=[t[1] for t in ws],
+                    boxes=[],
+                    labels=[t[2] for t in ws],
+                    confidences=[t[3] for t in ws],
+                    all_probabilities=[t[4] for t in ws],
+                )
+            )
+
+        return InferenceResult(
+            image_id=image_id,
+            receipt_id=receipt_id,
+            lines=lines,
+            meta={
+                "windowed": True,
+                "window_size": window_size,
+                "stride": stride,
+                "num_windows": len(starts),
+                "num_words": n,
+            },
+        )

--- a/receipt_layoutlm/receipt_layoutlm/inference.py
+++ b/receipt_layoutlm/receipt_layoutlm/inference.py
@@ -316,87 +316,122 @@ class LayoutLMInference:
         boxes must be LayoutLM-style per-subtoken bboxes after alignment or
         per-word boxes (we align internally to subtokens by repeating word boxes).
         """
-        results: List[LinePrediction] = []
         tok = self._tokenizer
         model = self._model
         device = self._device
+        torch = self._torch
+        id2label = model.config.id2label
+        id2label_items = list(id2label.items())
 
-        for idx, (tokens, word_boxes) in enumerate(
-            zip(tokens_per_line, boxes_per_line)
-        ):
+        n = len(tokens_per_line)
+        results: List[Optional[LinePrediction]] = [None] * n
+        if n == 0:
+            return []
+
+        # Each line is an independent LayoutLM sequence, but they were
+        # previously run one forward at a time — for a ~40-line receipt that's
+        # ~40 tiny GPU launches. Batch them (capped, so a huge receipt doesn't
+        # blow up memory) into single padded forwards instead. Padded positions
+        # are masked, so per-token outputs are identical to the per-line path.
+        MAX_LINES_PER_BATCH = 64
+
+        def _empty(idx: int) -> LinePrediction:
+            return LinePrediction(
+                line_id=(line_ids[idx] if line_ids else idx),
+                tokens=tokens_per_line[idx],
+                boxes=boxes_per_line[idx],
+                labels=[],
+                confidences=[],
+                all_probabilities=[],
+            )
+
+        for start in range(0, n, MAX_LINES_PER_BATCH):
+            end = min(start + MAX_LINES_PER_BATCH, n)
+            # Lines with no tokens can't be tokenized; emit them as empty.
+            members = [
+                i for i in range(start, end) if len(tokens_per_line[i]) > 0
+            ]
+            for i in range(start, end):
+                if len(tokens_per_line[i]) == 0:
+                    results[i] = _empty(i)
+            if not members:
+                continue
+
             enc = tok(
-                tokens,
+                [tokens_per_line[i] for i in members],
                 is_split_into_words=True,
                 truncation=True,
                 padding="longest",
                 return_attention_mask=True,
             )
-            wids = enc.word_ids()
-            bbox_aligned = [
-                [0, 0, 0, 0] if wid is None else word_boxes[wid]
-                for wid in wids
-            ]
+            bbox_batch: List[List[List[int]]] = []
+            word_ids_per_member: List[List[Optional[int]]] = []
+            for bi, line_idx in enumerate(members):
+                wids = enc.word_ids(batch_index=bi)
+                word_ids_per_member.append(wids)
+                wb = boxes_per_line[line_idx]
+                bbox_batch.append(
+                    [[0, 0, 0, 0] if wid is None else wb[wid] for wid in wids]
+                )
 
             inputs = {
-                "input_ids": self._torch.tensor(
-                    [enc["input_ids"]], device=device
+                "input_ids": torch.tensor(enc["input_ids"], device=device),
+                "attention_mask": torch.tensor(
+                    enc["attention_mask"], device=device
                 ),
-                "attention_mask": self._torch.tensor(
-                    [enc["attention_mask"]], device=device
-                ),
-                "bbox": self._torch.tensor([bbox_aligned], device=device),
+                "bbox": torch.tensor(bbox_batch, device=device),
             }
-            with self._torch.no_grad():
-                logits = model(**inputs).logits  # [1, seq_len, num_labels]
-            id2label = model.config.id2label
+            with torch.no_grad():
+                logits = model(**inputs).logits  # [B, seq_len, num_labels]
+            # Move raw logits to CPU once. The per-word aggregation below does
+            # thousands of scalar reads; against a GPU tensor each forces a sync,
+            # far slower than the matmul it follows. Aggregating logits (then
+            # softmax per word) keeps this bit-equivalent to the per-line path.
+            logits_batch = logits.cpu()
+            softmax = torch.nn.functional.softmax
 
-            # Aggregate logits per word (average over subtokens), compute softmax
-            seq_logits = logits[0]  # [seq_len, num_labels]
+            for bi, line_idx in enumerate(members):
+                wids = word_ids_per_member[bi]
+                seq_logits = logits_batch[bi]  # [seq_len, num_labels]
+                word_to_token_indices: Dict[int, List[int]] = {}
+                for j, wid in enumerate(wids):
+                    if wid is None:
+                        continue
+                    word_to_token_indices.setdefault(int(wid), []).append(j)
 
-            # Collect token indices per word id
-            word_to_token_indices: Dict[int, List[int]] = {}
-            for i, wid in enumerate(wids):
-                if wid is None:
-                    continue
-                word_to_token_indices.setdefault(int(wid), []).append(i)
+                word_boxes = boxes_per_line[line_idx]
+                labels_per_word: List[str] = []
+                confidences_per_word: List[float] = []
+                all_probabilities_per_word: List[Dict[str, float]] = []
+                for wid in range(len(word_boxes)):
+                    token_idxs = word_to_token_indices.get(wid, [])
+                    if not token_idxs:
+                        labels_per_word.append("O")
+                        confidences_per_word.append(0.0)
+                        all_probabilities_per_word.append({})
+                        continue
+                    # Average logits across this word's subtokens, then softmax
+                    # (matches the original per-line semantics exactly).
+                    avg_logits = seq_logits[token_idxs].mean(dim=0)
+                    probs = softmax(avg_logits, dim=-1)
+                    conf, pred_id = torch.max(probs, dim=-1)
+                    labels_per_word.append(id2label.get(int(pred_id.item()), "O"))
+                    confidences_per_word.append(float(conf.item()))
+                    probs_list = probs.tolist()
+                    all_probabilities_per_word.append(
+                        {name: probs_list[lid] for lid, name in id2label_items}
+                    )
 
-            labels_per_word: List[str] = []
-            confidences_per_word: List[float] = []
-            all_probabilities_per_word: List[Dict[str, float]] = []
-            for wid in range(len(word_boxes)):
-                token_idxs = word_to_token_indices.get(wid, [])
-                if not token_idxs:
-                    # If tokenizer dropped the word (rare), fallback to zeros
-                    labels_per_word.append("O")
-                    confidences_per_word.append(0.0)
-                    all_probabilities_per_word.append({})
-                    continue
-                # Average logits across subtokens of this word
-                stacked = self._torch.stack(
-                    [seq_logits[i] for i in token_idxs]
-                )
-                avg_logits = stacked.mean(dim=0)
-                probs = self._torch.nn.functional.softmax(avg_logits, dim=-1)
-                conf, pred_id = self._torch.max(probs, dim=-1)
-                labels_per_word.append(id2label.get(int(pred_id.item()), "O"))
-                confidences_per_word.append(float(conf.item()))
-
-                # Store all class probabilities
-                word_probs: Dict[str, float] = {}
-                for label_id, label_name in id2label.items():
-                    word_probs[label_name] = float(probs[label_id].item())
-                all_probabilities_per_word.append(word_probs)
-
-            results.append(
-                LinePrediction(
-                    line_id=(line_ids[idx] if line_ids else idx),
-                    tokens=tokens,
+                results[line_idx] = LinePrediction(
+                    line_id=(line_ids[line_idx] if line_ids else line_idx),
+                    tokens=tokens_per_line[line_idx],
                     boxes=word_boxes,
                     labels=labels_per_word,
                     confidences=confidences_per_word,
                     all_probabilities=all_probabilities_per_word,
                 )
-            )
+
+        return [r if r is not None else _empty(i) for i, r in enumerate(results)]
 
         return results
 

--- a/receipt_layoutlm/receipt_layoutlm/inference.py
+++ b/receipt_layoutlm/receipt_layoutlm/inference.py
@@ -437,8 +437,6 @@ class LayoutLMInference:
 
         return [r if r is not None else _empty(i) for i, r in enumerate(results)]
 
-        return results
-
     def predict_receipt_from_dynamo(
         self,
         dynamo_client: Any,

--- a/receipt_layoutlm/receipt_layoutlm/inference.py
+++ b/receipt_layoutlm/receipt_layoutlm/inference.py
@@ -412,10 +412,12 @@ class LayoutLMInference:
                         confidences_per_word.append(0.0)
                         all_probabilities_per_word.append({})
                         continue
-                    # Average logits across this word's subtokens, then softmax
-                    # (matches the original per-line semantics exactly).
-                    avg_logits = seq_logits[token_idxs].mean(dim=0)
-                    probs = softmax(avg_logits, dim=-1)
+                    # Use the FIRST subtoken's logits, then softmax. This
+                    # matches training supervision (the trainer labels a word's
+                    # first subtoken and sets the rest to -100) and the Swift
+                    # on-device path, keeping training/Python/Swift consistent.
+                    first_logits = seq_logits[token_idxs[0]]
+                    probs = softmax(first_logits, dim=-1)
                     conf, pred_id = torch.max(probs, dim=-1)
                     labels_per_word.append(id2label.get(int(pred_id.item()), "O"))
                     confidences_per_word.append(float(conf.item()))

--- a/receipt_layoutlm/receipt_layoutlm/inference.py
+++ b/receipt_layoutlm/receipt_layoutlm/inference.py
@@ -10,6 +10,13 @@ from typing import Any, Dict, List, Optional, Set, Tuple
 from .data_loader import _box_from_word, _normalize_box_from_extents
 
 
+def _strip_bio(label: str) -> str:
+    """Strip a leading ``B-``/``I-`` prefix from a label (``B-DATE`` -> ``DATE``)."""
+    if label.startswith("B-") or label.startswith("I-"):
+        return label[2:]
+    return label
+
+
 @dataclass
 class LinePrediction:
     line_id: int
@@ -84,6 +91,13 @@ class LayoutLMInference:
         self._label_list: List[str] = list(
             self._model.config.id2label.values()
         )
+        # Base labels the model predicts, derived by stripping BIO prefixes
+        # (e.g. {"ADDRESS", "AMOUNT", "DATE", ...}). normalize_label() needs
+        # this because label_list itself is BIO-prefixed, so a base label like
+        # "DATE" would otherwise never be recognized.
+        self._base_label_set: Set[str] = {
+            _strip_bio(lbl) for lbl in self._label_list if lbl != "O"
+        }
         self._label_merges: Dict[str, List[str]] = {}
         self._reverse_label_map: Dict[str, str] = {}
         self._load_run_config(model_s3_uri)
@@ -160,20 +174,28 @@ class LayoutLMInference:
 
     @property
     def base_labels(self) -> Set[str]:
-        """Set of base labels (excluding O)."""
-        return {lbl for lbl in self._label_list if lbl != "O"}
+        """Set of base labels the model predicts (excluding O, BIO stripped)."""
+        return set(self._base_label_set)
 
     def normalize_label(self, raw_label: str) -> str:
-        """Normalize a raw label to match the model's label set.
+        """Normalize a raw label to the model's base label set.
 
-        Uses label_merges from run.json to map original labels to merged ones.
-        Returns 'O' for unknown labels.
+        A label is recognized if it is one of the model's base labels (after
+        stripping any BIO prefix), or maps to one via the run.json merges.
+        Returns 'O' for anything else.
         """
-        # Already a valid label
+        base = _strip_bio(raw_label)
+
+        # Base label the model directly predicts (e.g. DATE, MERCHANT_NAME).
+        if base in self._base_label_set:
+            return base
+
+        # Fully-qualified label already in the model's list (defensive).
         if raw_label in self._label_list:
             return raw_label
 
-        # Check if it's a label that was merged
+        # Original label that was merged into a base label (e.g. ADDRESS_LINE
+        # -> ADDRESS, LINE_TOTAL -> AMOUNT).
         if raw_label in self._reverse_label_map:
             return self._reverse_label_map[raw_label]
 

--- a/receipt_layoutlm/receipt_layoutlm/trainer.py
+++ b/receipt_layoutlm/receipt_layoutlm/trainer.py
@@ -881,7 +881,22 @@ class ReceiptLayoutLMTrainer:
                     self.num_showcase = num_showcase
                     self._details = None  # lazy-loaded once
                     self._showcase_keys: List[str] = []
+                    # Seed from any epochs.json already on disk so a managed-spot
+                    # resume (SageMaker re-hydrates output_dir from S3) keeps the
+                    # pre-resume F1 curve instead of overwriting it with one entry.
                     self._entries: List[dict] = []
+                    try:
+                        ep_path = os.path.join(output_dir, "epochs.json")
+                        if os.path.exists(ep_path):
+                            with open(ep_path, "r", encoding="utf-8") as f:
+                                prior = json.load(f)
+                            self._entries = [
+                                e
+                                for e in (prior.get("epochs") or [])
+                                if e.get("checkpoint") != "best"
+                            ]
+                    except Exception as e:  # noqa: BLE001
+                        print(f"⚠️  Could not seed epochs.json: {e}")
 
                 def _ensure_details(self) -> None:
                     if self._details is not None:

--- a/receipt_layoutlm/receipt_layoutlm/trainer.py
+++ b/receipt_layoutlm/receipt_layoutlm/trainer.py
@@ -9,7 +9,7 @@ from dataclasses import asdict
 from datetime import datetime, timezone
 from functools import partial
 from glob import glob
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import urlparse
 
 from receipt_dynamo import DynamoClient
@@ -843,6 +843,142 @@ class ReceiptLayoutLMTrainer:
                     except Exception as e:
                         print(f"⚠️  Failed to sync checkpoint to S3: {e}")
 
+            class _HeldoutEvalCallback(TrainerCallback):  # type: ignore
+                """Run the windowed held-out eval after each saved checkpoint.
+
+                Reuses the in-process model/data/GPU to emit ``epochs.json`` (the
+                viz cache) live — no separate Processing job. Entirely
+                best-effort: any failure logs a warning and training proceeds.
+                """
+
+                def __init__(
+                    self,
+                    *,
+                    output_dir: str,
+                    dynamo_client: Any,
+                    val_keys: List[Tuple[str, int]],
+                    val_hash: Optional[str],
+                    seed: Optional[int],
+                    window_size: int,
+                    window_stride: int,
+                    job_name: str,
+                    s3_bucket: str | None,
+                    s3_prefix: str | None,
+                    valid_status: str = "VALID",
+                    num_showcase: int = 5,
+                ) -> None:
+                    self.output_dir = output_dir
+                    self.dynamo = dynamo_client
+                    self.val_keys = val_keys
+                    self.val_hash = val_hash
+                    self.seed = seed
+                    self.window_size = window_size
+                    self.window_stride = window_stride
+                    self.job_name = job_name
+                    self.s3_bucket = s3_bucket
+                    self.s3_prefix = s3_prefix
+                    self.valid_status = valid_status
+                    self.num_showcase = num_showcase
+                    self._details = None  # lazy-loaded once
+                    self._showcase_keys: List[str] = []
+                    self._entries: List[dict] = []
+
+                def _ensure_details(self) -> None:
+                    if self._details is not None:
+                        return
+                    from receipt_layoutlm import evaluate_checkpoints as ec
+
+                    # Pin the inference window to the values training used so the
+                    # held-out scoring matches the model's training distribution.
+                    os.environ["LAYOUTLM_WINDOW_SIZE"] = str(self.window_size)
+                    os.environ["LAYOUTLM_WINDOW_STRIDE"] = str(
+                        self.window_stride
+                    )
+                    self._details = ec.load_val_details(
+                        self.dynamo, self.val_keys
+                    )
+                    self._showcase_keys = [
+                        f"{i}_{r}"
+                        for (i, r) in self.val_keys[: self.num_showcase]
+                    ]
+
+                def on_save(self, args, state, control, **kwargs):  # type: ignore[override]
+                    del control, kwargs
+                    try:
+                        from receipt_layoutlm import evaluate_checkpoints as ec
+
+                        self._ensure_details()
+                        if not self._details:
+                            return
+                        checkpoint_dir = os.path.join(
+                            args.output_dir,
+                            f"checkpoint-{state.global_step}",
+                        )
+                        if not os.path.exists(checkpoint_dir):
+                            return
+
+                        epoch_num = (
+                            int(round(state.epoch))
+                            if state.epoch is not None
+                            else None
+                        )
+                        reported = None
+                        for log in reversed(state.log_history or []):
+                            if "eval_f1" in log:
+                                reported = log["eval_f1"]
+                                break
+
+                        entry, _ll, _lm = ec.evaluate_live_checkpoint(
+                            checkpoint_dir,
+                            self._details,
+                            output_dir=self.output_dir,
+                            step=state.global_step,
+                            epoch_num=epoch_num,
+                            training_reported_f1=reported,
+                            showcase_keys=self._showcase_keys,
+                            valid_status=self.valid_status,
+                        )
+                        self._entries.append(entry)
+                        run_s3_uri = (
+                            f"s3://{self.s3_bucket}/{self.s3_prefix}"
+                            if self.s3_bucket and self.s3_prefix
+                            else ""
+                        )
+                        ec.write_epochs_json_live(
+                            self.output_dir,
+                            job_name=self.job_name,
+                            run_s3_uri=run_s3_uri,
+                            epoch_entries=self._entries,
+                            label_list=_ll,
+                            label_merges=_lm,
+                            window_size=self.window_size,
+                            window_stride=self.window_stride,
+                            val_set_source="persisted_val_receipt_keys",
+                            val_hash=self.val_hash,
+                            num_val_receipts=len(self._details),
+                            seed=self.seed,
+                            showcase_keys=self._showcase_keys,
+                        )
+                        print(
+                            f"📈 Live held-out eval epoch {epoch_num}: "
+                            f"F1={entry['heldout_f1']:.4f} "
+                            f"({entry.get('avg_inference_ms')}ms/receipt)"
+                        )
+                        # Sync epochs.json + showcase receipts to S3.
+                        if self.s3_bucket and self.s3_prefix:
+                            try:
+                                ec.sync_outputs_to_s3(
+                                    self.output_dir,
+                                    f"s3://{self.s3_bucket}/{self.s3_prefix}",
+                                )
+                            except Exception as se:  # noqa: BLE001
+                                print(
+                                    f"⚠️  Failed to sync epochs.json: {se}"
+                                )
+                    except Exception as e:  # noqa: BLE001
+                        # Never let the held-out eval break training.
+                        print(f"⚠️  Live held-out eval failed: {e}")
+
             # Parse S3 config for per-epoch checkpoint syncing
             s3_bucket = None
             s3_prefix = None
@@ -868,6 +1004,47 @@ class ReceiptLayoutLMTrainer:
                     s3_prefix=s3_prefix,
                 )
             )
+
+            # Live held-out eval (emits epochs.json during training). Needs the
+            # persisted val keys; older split logic without them is skipped.
+            val_keys_raw = (
+                getattr(split_metadata, "val_receipt_keys", None)
+                if split_metadata
+                else None
+            )
+            if (
+                self.training_config.eval_heldout_windowed
+                and val_keys_raw
+            ):
+                parsed_val_keys: List[Tuple[str, int]] = []
+                for k in val_keys_raw:
+                    try:
+                        img, rid = k.split("#")
+                        parsed_val_keys.append((img, int(rid)))
+                    except (ValueError, AttributeError):
+                        continue
+                callbacks.append(
+                    _HeldoutEvalCallback(
+                        output_dir=output_dir,
+                        dynamo_client=self.dynamo,
+                        val_keys=parsed_val_keys,
+                        val_hash=getattr(
+                            split_metadata, "val_receipts_hash", None
+                        ),
+                        seed=getattr(split_metadata, "random_seed", None),
+                        window_size=(
+                            getattr(split_metadata, "window_size", None) or 200
+                        ),
+                        window_stride=(
+                            getattr(split_metadata, "window_stride", None)
+                            or 150
+                        ),
+                        job_name=job_name,
+                        s3_bucket=s3_bucket,
+                        s3_prefix=s3_prefix,
+                        valid_status=self.data_config.validation_status,
+                    )
+                )
         except AttributeError:
             # Older transformers versions may lack TrainerCallback
             pass

--- a/receipt_ocr_swift/Sources/ReceiptOCRCore/LayoutLM/LayoutLMInference.swift
+++ b/receipt_ocr_swift/Sources/ReceiptOCRCore/LayoutLM/LayoutLMInference.swift
@@ -46,6 +46,19 @@ public class LayoutLMInference {
     /// Whether this model requires image input (v3)
     public let requiresImageInput: Bool
 
+    /// Sliding-window config for inference. Must match how the model was
+    /// trained (data_loader._build_receipt_window_examples): words are sorted
+    /// into reading order and cut into `windowSize`-word windows stepped by
+    /// `windowStride`, so the model sees the multi-line context it trained on
+    /// instead of one packed line at a time. Overridable via
+    /// LAYOUTLM_WINDOW_SIZE / LAYOUTLM_WINDOW_STRIDE.
+    public let windowSize: Int
+    public let windowStride: Int
+
+    /// When false (LAYOUTLM_INFERENCE_MODE=line_packed) falls back to the
+    /// legacy greedy line-packing path. Default is windowed.
+    public let useWindowedInference: Bool
+
     // MARK: - Initialization
 
     /// Initialize from a model bundle directory.
@@ -102,6 +115,11 @@ public class LayoutLMInference {
         self.config = try LayoutLMConfig.load(from: configURL)
         self.maxSeqLength = config.maxPositionEmbeddings ?? 512
         self.requiresImageInput = model.modelDescription.inputDescriptionsByName.keys.contains("pixel_values")
+
+        let env = ProcessInfo.processInfo.environment
+        self.windowSize = env["LAYOUTLM_WINDOW_SIZE"].flatMap { Int($0) } ?? 250
+        self.windowStride = env["LAYOUTLM_WINDOW_STRIDE"].flatMap { Int($0) } ?? 200
+        self.useWindowedInference = (env["LAYOUTLM_INFERENCE_MODE"] ?? "windowed") != "line_packed"
 
         // Load tokenizer — use BPE for v3 (tokenizer.json), WordPiece for v1 (vocab.txt)
         let tokenizerJsonURL = bundlePath.appendingPathComponent("tokenizer.json")
@@ -183,6 +201,11 @@ public class LayoutLMInference {
     /// - Returns: Array of LinePrediction results
     public func predict(lines: [Line], receiptImageData: Data? = nil) throws -> [LinePrediction] {
         guard !lines.isEmpty else { return [] }
+
+        // Default: window like training (multi-line reading-order context).
+        if useWindowedInference {
+            return try predictWindowed(lines: lines, receiptImageData: receiptImageData)
+        }
 
         // Compute bbox extents for the entire receipt
         let (maxX, maxY) = BboxNormalizer.computeExtents(lines: lines)
@@ -270,6 +293,186 @@ public class LayoutLMInference {
                 allProbabilities: nil
             )
         }
+    }
+
+    /// Windowed prediction that mirrors training.
+    ///
+    /// Flattens every word across all OCR lines, sorts them into reading order
+    /// by ascending normalized (y, x) — the EXACT key the trainer uses
+    /// (data_loader._build_receipt_window_examples; note Apple Vision boxes are
+    /// bottom-left origin, so this is intentionally not human top-to-bottom) —
+    /// cuts `windowSize`-word windows stepped by `windowStride`, runs each
+    /// window through CoreML, averages per-label probabilities for words that
+    /// fall in overlapping windows, and regroups the result back into per-line
+    /// `LinePrediction`s so the worker is unchanged.
+    private func predictWindowed(lines: [Line], receiptImageData: Data?) throws -> [LinePrediction] {
+        let empty = LinePrediction(tokens: [], labels: [], confidences: [], allProbabilities: nil)
+
+        // Flatten words, tracking each word's (line, position-in-line).
+        var allWords: [Word] = []
+        var flatLine: [Int] = []
+        var flatPos: [Int] = []
+        for (li, line) in lines.enumerated() {
+            for (pi, w) in line.words.enumerated() {
+                allWords.append(w)
+                flatLine.append(li)
+                flatPos.append(pi)
+            }
+        }
+        if allWords.isEmpty { return lines.map { _ in empty } }
+
+        // Per-receipt extents → normalized boxes + texts (same as the per-line path).
+        let (maxX, maxY) = BboxNormalizer.computeExtents(words: allWords)
+        let (texts, nboxes) = BboxNormalizer.normalizeWords(allWords, maxX: maxX, maxY: maxY)
+
+        // Reading order: ascending normalized y0 (box[1]) then x0 (box[0]).
+        let order = Array(0..<allWords.count).sorted { a, b in
+            if nboxes[a][1] != nboxes[b][1] { return nboxes[a][1] < nboxes[b][1] }
+            return nboxes[a][0] < nboxes[b][0]
+        }
+        let n = order.count
+        let oTexts = order.map { texts[$0] }
+        let oBoxes = order.map { nboxes[$0] }
+
+        // Window starts — replicate the trainer's loop exactly: step by stride,
+        // stop as soon as a window reaches the end (no extra short trailing window).
+        var starts: [Int] = []
+        if n <= windowSize {
+            starts = [0]
+        } else {
+            var s = 0
+            while s < n {
+                starts.append(s)
+                if s + windowSize >= n { break }
+                s += windowStride
+            }
+        }
+
+        let pixelValues: MLMultiArray? = try {
+            guard requiresImageInput else { return nil }
+            guard let imageData = receiptImageData else { return createGrayPixelValues() }
+            return try createPixelValues(from: imageData)
+        }()
+
+        // Accumulate per-(ordered-index) probability dicts across the windows
+        // covering each word, then average — matches predict_receipt_windowed.
+        var probSums = Array(repeating: [String: Float](), count: n)
+        var counts = [Int](repeating: 0, count: n)
+        for s in starts {
+            let end = min(s + windowSize, n)
+            let winProbs = try runWindowProbs(
+                words: Array(oTexts[s..<end]),
+                bboxes: Array(oBoxes[s..<end]),
+                pixelValues: pixelValues
+            )
+            for (j, dict) in winProbs.enumerated() where !dict.isEmpty {
+                let oi = s + j
+                for (k, v) in dict { probSums[oi][k, default: 0] += v }
+                counts[oi] += 1
+            }
+        }
+
+        // Finalize each word and scatter back to its (line, position).
+        var lineTokens = lines.map { [String](repeating: "", count: $0.words.count) }
+        var lineLabels = lines.map { [String](repeating: "O", count: $0.words.count) }
+        var lineConf = lines.map { [Float](repeating: 0, count: $0.words.count) }
+        var lineProbs = lines.map { [[String: Float]](repeating: [:], count: $0.words.count) }
+        for flatIdx in 0..<allWords.count {
+            lineTokens[flatLine[flatIdx]][flatPos[flatIdx]] = texts[flatIdx]
+        }
+        for oi in 0..<n {
+            let flatIdx = order[oi]
+            let li = flatLine[flatIdx], pi = flatPos[flatIdx]
+            if counts[oi] == 0 { continue }
+            let c = Float(counts[oi])
+            var bestLabel = "O"
+            var bestProb: Float = -1
+            var dict: [String: Float] = [:]
+            for (k, v) in probSums[oi] {
+                let avg = v / c
+                dict[k] = avg
+                if avg > bestProb { bestProb = avg; bestLabel = k }
+            }
+            lineLabels[li][pi] = bestLabel
+            lineConf[li][pi] = bestProb < 0 ? 0 : bestProb
+            lineProbs[li][pi] = dict
+        }
+
+        return lines.enumerated().map { (li, line) in
+            line.words.isEmpty ? empty : LinePrediction(
+                tokens: lineTokens[li],
+                labels: lineLabels[li],
+                confidences: lineConf[li],
+                allProbabilities: lineProbs[li]
+            )
+        }
+    }
+
+    /// Run one window of words through CoreML and return per-word softmax
+    /// probability dicts (using the first subtoken per word, matching the
+    /// trainer's first-subtoken supervision). Empty dict = word dropped by the
+    /// tokenizer.
+    private func runWindowProbs(
+        words: [String],
+        bboxes: [[Int32]],
+        pixelValues: MLMultiArray?
+    ) throws -> [[String: Float]] {
+        guard !words.isEmpty else { return [] }
+
+        let tokenResult = tokenizer(words, true, true)
+        var bboxTensor: [[Int32]] = []
+        for wordId in tokenResult.wordIds {
+            if let wid = wordId, wid < bboxes.count {
+                bboxTensor.append(bboxes[wid])
+            } else {
+                bboxTensor.append([0, 0, 0, 0])
+            }
+        }
+
+        let seqLength = tokenResult.inputIds.count
+        let inputIds = try createMultiArray(from: tokenResult.inputIds, shape: [1, seqLength])
+        let attentionMask = try createMultiArray(from: tokenResult.attentionMask, shape: [1, seqLength])
+        let tokenTypeIds = try createMultiArray(from: tokenResult.tokenTypeIds, shape: [1, seqLength])
+        let bbox = try createBboxMultiArray(from: bboxTensor, shape: [1, seqLength, 4])
+        let inputFeatures = LayoutLMInput(
+            input_ids: inputIds,
+            attention_mask: attentionMask,
+            bbox: bbox,
+            token_type_ids: tokenTypeIds,
+            pixel_values: pixelValues
+        )
+        let output = try model.prediction(from: inputFeatures)
+        guard let logits = output.featureValue(for: "logits")?.multiArrayValue else {
+            throw LayoutLMError.outputNotFound
+        }
+        let numLabels = logits.shape[2].intValue
+
+        var wordToFirstToken: [Int: Int] = [:]
+        for (tokenIdx, wordId) in tokenResult.wordIds.enumerated() {
+            if let wid = wordId, wordToFirstToken[wid] == nil {
+                wordToFirstToken[wid] = tokenIdx
+            }
+        }
+
+        var result: [[String: Float]] = []
+        for wordIdx in 0..<words.count {
+            guard let tokenIdx = wordToFirstToken[wordIdx] else {
+                result.append([:])
+                continue
+            }
+            var wordLogits = [Float](repeating: 0, count: numLabels)
+            for labelIdx in 0..<numLabels {
+                wordLogits[labelIdx] = logits[tokenIdx * numLabels + labelIdx].floatValue
+            }
+            let probs = softmax(wordLogits)
+            var dict: [String: Float] = [:]
+            for labelIdx in 0..<numLabels {
+                let p = probs[labelIdx]
+                dict[config.labelName(for: labelIdx)] = p.isNaN ? 0 : p
+            }
+            result.append(dict)
+        }
+        return result
     }
 
     /// Count tokens for a list of words (without special tokens or padding).

--- a/receipt_ocr_swift/Sources/ReceiptOCRCore/LayoutLM/LayoutLMInference.swift
+++ b/receipt_ocr_swift/Sources/ReceiptOCRCore/LayoutLM/LayoutLMInference.swift
@@ -117,9 +117,13 @@ public class LayoutLMInference {
         self.requiresImageInput = model.modelDescription.inputDescriptionsByName.keys.contains("pixel_values")
 
         let env = ProcessInfo.processInfo.environment
-        self.windowSize = env["LAYOUTLM_WINDOW_SIZE"].flatMap { Int($0) } ?? 250
-        self.windowStride = env["LAYOUTLM_WINDOW_STRIDE"].flatMap { Int($0) } ?? 200
-        self.useWindowedInference = (env["LAYOUTLM_INFERENCE_MODE"] ?? "windowed") != "line_packed"
+        // Defaults MUST match the Python trainer/data_loader defaults (200/150),
+        // not 250/200 — a model trained at 200/150 must run windowed the same way.
+        self.windowSize = env["LAYOUTLM_WINDOW_SIZE"].flatMap { Int($0) } ?? 200
+        self.windowStride = env["LAYOUTLM_WINDOW_STRIDE"].flatMap { Int($0) } ?? 150
+        // Windowed unless explicitly some other mode (matches Python, where any
+        // value other than "windowed" — e.g. "per_line" — disables windowing).
+        self.useWindowedInference = (env["LAYOUTLM_INFERENCE_MODE"] ?? "windowed") == "windowed"
 
         // Load tokenizer — use BPE for v3 (tokenizer.json), WordPiece for v1 (vocab.txt)
         let tokenizerJsonURL = bundlePath.appendingPathComponent("tokenizer.json")


### PR DESCRIPTION
## Summary

What started as "make the inference visualization honest" grew into an end-to-end overhaul of how we evaluate, improve, deploy, and visualize the receipt LayoutLM model. The model now uses a **granular financial taxonomy**, is evaluated **live during training** on a **pinned canonical val set**, runs **windowed inference** in Python *and* Swift, and the receipt page renders the **best model's real predictions** at ~15 ms.

## What's in it

**Honest per-checkpoint evaluation** (`receipt_layoutlm/evaluate_checkpoints.py`, `cli.py`)
- `eval-checkpoints` re-scores every saved checkpoint on the run's frozen val set via real windowed inference → `epochs.json` (held-out F1 curve vs training-reported, best epoch marked) + per-(epoch,receipt) showcase records.
- `data_loader` persists `val_receipt_keys` + window config for drift-proof reproduction.

**Eval *in* the training run** (`trainer.py`)
- `_HeldoutEvalCallback` scores each epoch's just-saved checkpoint in-process on the training GPU and emits `epochs.json` **live** — reusing the standalone scoring so numbers match. No separate job needed for new runs; the standalone Processing job stays for retro/alternative re-eval. On by default (`eval_heldout_windowed`).

**Windowed + first-subtoken inference** (`inference.py`)
- `predict_receipt_windowed` reproduces training's reading-order sliding windows (closed the train↔infer gap: F1 0.68→0.82 on v14). Batched per-receipt forward (~7.4× faster). First-subtoken aggregation matches training supervision *and* the Swift device path.
- Fixed `normalize_label` (BIO-prefix bug that silently wiped direct labels to O — also corrupted the production cache).

**On-device parity** (`receipt_ocr_swift/.../LayoutLMInference.swift`)
- Swift `predictWindowed` mirrors Python exactly (bbox norm, reading-order sort, window start/break, cross-window averaging, first-subtoken). v18 exported to CoreML and validated **lossless vs PyTorch (100% / RMSE ~2e-6)**, rolled to the dev device (model + worker).

**Pinned canonical val split** (`data_loader.py`, `config.py`, `cli.py`)
- `LAYOUTLM_VAL_KEYS_S3` holds out one fixed 15% set for every run, so cross-run F1 is directly comparable (the split variance was producing false alarms). Recorded on the Job entity for lineage.

**Infra** (`infra/sagemaker_epoch_eval/`, `infra/routes/layoutlm_epochs/`, `infra/routes/layoutlm_inference/`, `infra/routes/job_training_metrics/`)
- Ephemeral SageMaker Processing job + `GET /layoutlm_epochs` API (serves both `epoch-eval/` and live `runs/` artifacts).
- `/layoutlm_inference` now serves the **newest run's best-epoch eval records** (best model, real GPU times) instead of a separate stale cache — eliminating the slow Lambda generator.
- Confusion-matrix endpoint resolves "featured" → newest run, tracking the same model as inference.

**Receipt-page viz** (`portfolio/.../`)
- `EpochEvaluation` card (held-out F1 curve, per-label bars, receipt scrubber, ⚡GPU timing) — built, then removed from the page per design feedback.
- `LayoutLMBatchVisualization`: granular label colors (charges green-family / credits teal / quantity cyan / address red), 9-family legend, removed the (now-pointless) scan bar.
- `TrainingMetricsAnimation`: **family confusion heatmap** (~10 groups, drill into Charges/Credits/etc.) replacing the unreadable 21×21 grid; responsive so it can't force the figure past the viewport.

## Key findings
- **Windowed inference is a free win** — same checkpoint, F1 0.68→0.82.
- **Data quality is the ceiling, not volume** — per-label F1 inversely correlated with label count; MERCHANT cleanup lifted it 0.45→0.76.
- **Split variance dominated cross-model differences** — controlled same-split evals showed v18≈v19≈v20≈v22 in aggregate; merged-AMOUNT's apparent edge was split luck. → pinned val split.
- **Granular currency is viable** at no real accuracy cost vs merged AMOUNT, and adds the financial breakdown.
- **Line items (PRODUCT_NAME) dilute the flat model** — pushed to a two-pass design instead.
- **The currency INVALID labels are deliberate** — a financial label-evaluator already vets them (unit-price vs line-total, arithmetic), so geometric relabeling is wrong.

## Test plan
- [x] `eval-checkpoints` against real runs (v14/v17/v18/v19/v20/v22); split reconstruction bit-identical to trainer
- [x] Batched & windowed inference verified equivalent/correct; window start/break proven identical for all n
- [x] CoreML export validated lossless vs PyTorch (100%); Swift worker builds + runs windowed e2e
- [x] Live eval-in-training validated on v21/v22/v23 (epochs.json emitted per-epoch on the training GPU)
- [x] Frontend type-checks; receipt page verified in a headless browser (fast times, family heatmap, no overflow)
- [x] `pulumi up --stack dev` clean; ultrareview findings addressed
- [ ] Promote to prod; receipt_layoutlm CI coverage; locked test split

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-epoch model checkpoint evaluation and visualization during training with interactive F1 curves and receipt prediction overlays.
  * New API endpoints for accessing evaluation results and per-checkpoint scoring data.
  * Interactive UI component displaying training progress across checkpoints with per-label performance metrics and receipt inspection.
  * Windowed inference mode for consistent evaluation methodology across training and deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->