### PR TITLE
fix(receipt-flow): land flying receipt on exact target (remove sub-pixel handoff pop)

### DIFF
--- a/portfolio/components/ui/Figures/ReceiptFlow/FlyingReceipt.tsx
+++ b/portfolio/components/ui/Figures/ReceiptFlow/FlyingReceipt.tsx
@@ -7,6 +7,14 @@ import styles from "./FlyingReceipt.module.css";
 const useIsomorphicLayoutEffect =
   typeof window !== "undefined" ? React.useLayoutEffect : React.useEffect;
 
+// Fly-in duration. Must stay comfortably below the consumers' transition timer
+// (TRANSITION_DURATION ~600ms) so the receipt reaches its exact resting target
+// and holds there before the flying copy is swapped for the static receipt.
+const FLY_DURATION_MS = 500;
+// Decelerating ease — keeps the spring-like "lands softly" feel while
+// guaranteeing the animation reaches its exact endpoint at FLY_DURATION_MS.
+const easeOutCubic = (t: number): number => 1 - Math.pow(1 - t, 3);
+
 export interface FlyingReceiptProps {
   imageUrl: string;
   displayWidth: number;
@@ -94,10 +102,18 @@ export const FlyingReceipt: React.FC<FlyingReceiptProps> = ({
   // here is what the browser paints on the first frame — starting from the
   // queue position + opacity 0 guarantees no full-size center flash even if the
   // measured-DOM correction lands a frame later.
+  //
+  // A duration-based ease (not a physics spring) is used deliberately: the
+  // consumer swaps the flying copy for the resting receipt on a fixed timer
+  // (~600ms). A physics spring only asymptotes toward its target, so at the
+  // swap it is still ~0.1% short (≈0.5px off-center, scale 0.999), and that
+  // last fraction snaps into place when the resting receipt is revealed — a
+  // subtle "pop". FLY_DURATION_MS is comfortably shorter than the swap timer,
+  // so the receipt reaches its EXACT target and holds there before the handoff.
   const [springValues, api] = useSpring(() => ({
     ...fallbackFrom,
     opacity: 0,
-    config: { tension: 170, friction: 26, clamp: true },
+    config: { duration: FLY_DURATION_MS, easing: easeOutCubic },
   }));
 
   useIsomorphicLayoutEffect(() => {


### PR DESCRIPTION
# Pull Request

## Summary

- Follow-up to #965. A subtle pop remained on some receipts (In-N-Out, Target): the flying receipt was removed on a fixed ~600ms timer while its **physics spring** was only ~99.9% settled, so the last ~0.5px (and scale 0.999 → 1.0) snapped into place when the static receipt was revealed.
- Replaced the asymptotic physics spring with a **fixed-duration decelerating ease** (`easeOutCubic` over `FLY_DURATION_MS = 500ms`, comfortably under the ~600ms swap timer). The receipt now reaches its **exact** endpoint and holds there before the handoff → pixel-perfect swap.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that resolves an issue)
- [ ] ⚡ Performance improvement

## Which Package(s) are Affected?

- [x] Portfolio (TypeScript/Next.js)

## Testing

- [x] Manual testing completed

Measured the handoff frame-by-frame (sub-pixel, real-time 60fps through the flying→static swap), on both localhost and the live deployment:

| | last-flying scale | dcx (fly−static) | dw / dh |
|---|---|---|---|
| **Before** | 0.999 | ≈ **−0.5px** | ~0 |
| **After** | **1.000** | **0.00–0.02px** | 0 |

Verified across Roast & Rice, Target, Millennium Maxwell, Smith's Marketplace, Vons. Launch is unchanged (still starts small/transparent at the queue and flies in).

The A/B that surfaced this: the inference component (`LayoutLMBatchVisualization`) had the same residual, just smaller (~0.3px) because its narrower queue means a shorter travel distance — and its post-landing scan animation masked it. Since `FlyingReceipt` is shared, this fix tightens both.

## Documentation & Code Quality

- [x] Documentation or comments updated for complex logic
- [x] No new warnings or linting issues introduced
- [x] Code follows project style guidelines

## Related Issues

Follow-up to #965.

## Impact Analysis

`FlyingReceipt` is shared across ReceiptFlow consumers (receipt-health viz, inference viz, Label Validation, etc.). The change only swaps the animation's easing model (physics spring → fixed-duration ease); start state, end state, and travel path are unchanged. `FLY_DURATION_MS` (500ms) must remain below consumers' transition timers (~600ms).

## Deployment Notes

None — frontend-only visual change.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced the receipt fly-in animation with improved easing functions and fade effects, delivering a smoother and more polished visual experience
  * Optimized receipt sizing consistency between flying and resting states for a unified appearance throughout the application
  * Improved mobile responsiveness with updated receipt display sizing and layout

<!-- end of auto-generated comment: release notes by coderabbit.ai -->