### PR TITLE
fix(portfolio): env-aware CDN base for receipt images (dev→dev, prod→prod)

### DIFF
--- a/portfolio/components/ui/Figures/AddressSimilaritySideBySide.tsx
+++ b/portfolio/components/ui/Figures/AddressSimilaritySideBySide.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
+import { getCdnBaseUrl } from "../../../utils/cdnBase";
 import { api } from "../../../services/api";
 import { AddressBoundingBox, AddressSimilarityResponse } from "../../../types/api";
 import {
@@ -229,9 +230,7 @@ const AddressSimilaritySideBySide: React.FC = () => {
   }
 
   const baseUrl =
-    process.env.NODE_ENV === "development"
-      ? "https://dev.tylernorlund.com"
-      : "https://www.tylernorlund.com";
+    getCdnBaseUrl();
 
   // Helper function to calculate crop region from bbox or lines
   const calculateCropRegion = (

--- a/portfolio/components/ui/Figures/CroppedAddressImage.tsx
+++ b/portfolio/components/ui/Figures/CroppedAddressImage.tsx
@@ -1,4 +1,5 @@
 import NextImage from "next/image";
+import { getCdnBaseUrl } from "../../../utils/cdnBase";
 import React, { useMemo, useState, useCallback } from "react";
 import { Line, Receipt, AddressBoundingBox } from "../../../types/api";
 import { getBestImageUrl } from "../../../utils/imageFormat";
@@ -139,9 +140,7 @@ const CroppedAddressImage: React.FC<CroppedAddressImageProps> = ({
 
   // Get image URL
   const baseUrl =
-    process.env.NODE_ENV === "development"
-      ? "https://dev.tylernorlund.com"
-      : "https://www.tylernorlund.com";
+    getCdnBaseUrl();
   const imageSrc = formatSupport
     ? getBestImageUrl(receipt, formatSupport, "medium")
     : receipt.cdn_medium_s3_key

--- a/portfolio/components/ui/Figures/PhotoReceiptBoundingBox.tsx
+++ b/portfolio/components/ui/Figures/PhotoReceiptBoundingBox.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import { getCdnBaseUrl } from "../../../utils/cdnBase";
 
 import { animated, useTransition } from "@react-spring/web";
 import useImageDetails from "../../../hooks/useImageDetails";
@@ -16,8 +17,6 @@ import {
 } from "../animations";
 import { getAnimationConfig } from "./animationConfig";
 import ReceiptBoundingBoxFrame from "./ReceiptBoundingBoxFrame";
-
-const isDevelopment = process.env.NODE_ENV === "development";
 
 /**
  * Display a random photo image with animated overlays that illustrate
@@ -109,9 +108,7 @@ const PhotoReceiptBoundingBox: React.FC = () => {
     firstImage && formatSupport && isClient
       ? getBestImageUrl(firstImage, formatSupport, "medium")
       : firstImage
-        ? `${isDevelopment
-          ? "https://dev.tylernorlund.com"
-          : "https://www.tylernorlund.com"
+        ? `${getCdnBaseUrl()
         }/${firstImage.cdn_s3_key}`
         : "";
 

--- a/portfolio/components/ui/Figures/PhotoReceiptDBSCAN.tsx
+++ b/portfolio/components/ui/Figures/PhotoReceiptDBSCAN.tsx
@@ -1,12 +1,11 @@
 import React, { useEffect, useMemo, useState } from "react";
+import { getCdnBaseUrl } from "../../../utils/cdnBase";
 import { type Point as ApiPoint } from "../../../types/api";
 import { useTransition, animated } from "@react-spring/web";
 import useOptimizedInView from "../../../hooks/useOptimizedInView";
 import { getBestImageUrl } from "../../../utils/imageFormat";
 import useImageDetails from "../../../hooks/useImageDetails";
 import useReceiptClustering, { calculateEpsilonFromLines } from "../../../hooks/useReceiptClustering";
-
-const isDevelopment = process.env.NODE_ENV === "development";
 
 const colors = [
   "var(--color-red)",
@@ -129,9 +128,7 @@ const PhotoReceiptDBSCAN: React.FC = () => {
       ? getBestImageUrl(firstImage, formatSupport)
       : firstImage
       ? `${
-          isDevelopment
-            ? "https://dev.tylernorlund.com"
-            : "https://www.tylernorlund.com"
+          getCdnBaseUrl()
         }/${firstImage.cdn_s3_key}`
       : "";
 

--- a/portfolio/components/ui/Figures/QAAgentFlow.tsx
+++ b/portfolio/components/ui/Figures/QAAgentFlow.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { getCdnBaseUrl } from "../../../utils/cdnBase";
 import ReactMarkdown from "react-markdown";
 import { useSpring, animated, config } from "@react-spring/web";
 import type {
@@ -132,7 +133,7 @@ const STEP_CONFIG: Record<StepType, { color: string; label: string; icon: string
   synthesize: { color: "var(--color-red)", label: "Synthesize", icon: "✓", node: "5", description: "Composing the final answer with evidence citations" },
 };
 
-const CDN_BASE = "https://dev.tylernorlund.com";
+const CDN_BASE = getCdnBaseUrl();
 
 /** Default step duration (ms) when durationMs is not available */
 const DEFAULT_STEP_MS = 1500;

--- a/portfolio/components/ui/Figures/ScanReceiptBoundingBox.tsx
+++ b/portfolio/components/ui/Figures/ScanReceiptBoundingBox.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import { getCdnBaseUrl } from "../../../utils/cdnBase";
 
 import { animated, useSpring, useTransition } from "@react-spring/web";
 import useImageDetails from "../../../hooks/useImageDetails";
@@ -7,8 +8,6 @@ import { getBestImageUrl } from "../../../utils/imageFormat";
 import AnimatedLineBox from "../animations/AnimatedLineBox";
 import ReceiptBoundingBoxFrame from "./ReceiptBoundingBoxFrame";
 import type { CropViewBox } from "./utils/smartCrop";
-
-const isDevelopment = process.env.NODE_ENV === "development";
 
 // AnimatedReceipt: component for receipt bounding box and centroid animation
 interface AnimatedReceiptProps {
@@ -143,9 +142,7 @@ const ImageBoundingBox: React.FC = () => {
     firstImage && formatSupport && isClient
       ? getBestImageUrl(firstImage, formatSupport, 'medium')
       : firstImage
-        ? `${isDevelopment
-          ? "https://dev.tylernorlund.com"
-          : "https://www.tylernorlund.com"
+        ? `${getCdnBaseUrl()
         }/${firstImage.cdn_s3_key}`
         : "";
 

--- a/portfolio/components/ui/Figures/WordSimilarity.tsx
+++ b/portfolio/components/ui/Figures/WordSimilarity.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { getCdnBaseUrl } from "../../../utils/cdnBase";
 import { useInView } from "react-intersection-observer";
 import { api } from "../../../services/api";
 import { AddressBoundingBox, MilkSimilarityResponse, MilkReceiptData, MilkSimilarityTiming } from "../../../types/api";
@@ -305,9 +306,7 @@ const WordSimilarity: React.FC = () => {
   }
 
   const baseUrl =
-    process.env.NODE_ENV === "development"
-      ? "https://dev.tylernorlund.com"
-      : "https://www.tylernorlund.com";
+    getCdnBaseUrl();
 
   // Helper function to calculate crop region from bbox
   const calculateCropRegion = (

--- a/portfolio/utils/cdnBase.ts
+++ b/portfolio/utils/cdnBase.ts
@@ -1,0 +1,15 @@
+/**
+ * Base URL for receipt image assets (CDN), resolved at build time.
+ *
+ * Images must come from the SAME environment as the data: the dev site shows
+ * dev data (dev API) whose image variants live on the dev CDN, and prod shows
+ * prod data on the prod CDN. We bake `NEXT_PUBLIC_CDN_URL` per deployment
+ * (e.g. `https://dev.tylernorlund.com` for the dev build) so the site loads
+ * images from the right CDN. The `NODE_ENV` branch is only a local dev-server
+ * fallback when the env var isn't set.
+ */
+export const getCdnBaseUrl = (): string =>
+  process.env.NEXT_PUBLIC_CDN_URL ||
+  (process.env.NODE_ENV === "development"
+    ? "https://dev.tylernorlund.com"
+    : "https://www.tylernorlund.com");

--- a/portfolio/utils/image.ts
+++ b/portfolio/utils/image.ts
@@ -73,16 +73,13 @@ export const detectImageFormatSupport = (): Promise<FormatSupport> => {
 };
 
 import type { Image } from "../types/api";
-
-const isDevelopment = process.env.NODE_ENV === "development";
+import { getCdnBaseUrl } from "./cdnBase";
 
 export const getBestImageUrl = (
   image: Image,
   formatSupport: FormatSupport
 ): string => {
-  const baseUrl = isDevelopment
-    ? "https://dev.tylernorlund.com"
-    : "https://www.tylernorlund.com";
+  const baseUrl = getCdnBaseUrl();
 
   if (formatSupport.supportsAVIF && image.cdn_avif_s3_key) {
     return `${baseUrl}/${image.cdn_avif_s3_key}`;

--- a/portfolio/utils/imageFormat.ts
+++ b/portfolio/utils/imageFormat.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from "react";
+import { getCdnBaseUrl } from "./cdnBase";
 
 export interface FormatSupport {
   supportsAVIF: boolean;
@@ -144,9 +145,7 @@ export const getBestImageUrl = (
   size: ImageSize = 'full',
 ): string => {
   const baseUrl =
-    process.env.NODE_ENV === "development"
-      ? "https://dev.tylernorlund.com"
-      : "https://www.tylernorlund.com";
+    getCdnBaseUrl();
 
   // Cascade requested size through smaller-to-larger fallbacks so that a
   // 'thumbnail' request never silently falls back to the FULL-SIZE asset
@@ -246,8 +245,6 @@ export const usePreloadReceiptImages = (
  */
 export const getJpegFallbackUrl = (image: ImageFormats): string => {
   const baseUrl =
-    process.env.NODE_ENV === "development"
-      ? "https://dev.tylernorlund.com"
-      : "https://www.tylernorlund.com";
+    getCdnBaseUrl();
   return `${baseUrl}/${image.cdn_s3_key}`;
 };


### PR DESCRIPTION
## Problem
The image base URL was `NODE_ENV`-based (`development ? dev : www`). But **both** the dev and prod sites are *production* builds, so both resolved to the **prod CDN (`www`)**. The dev site shows **dev data** (via `dev-api`) whose image variants live on the **dev CDN** — so any dev-only receipt's image 404'd. CloudFront serves the SPA `index.html` (200) for a missing asset, and the browser can't decode HTML as an image → **empty boxes** (e.g. the Chroma address-similarity figure).

## Fix
Single `getCdnBaseUrl()` helper that reads a build-time `NEXT_PUBLIC_CDN_URL` (falls back to the old `NODE_ENV` behavior for the local dev server). All 9 image-base computations route through it. The dev build bakes `NEXT_PUBLIC_CDN_URL=https://dev.tylernorlund.com`; prod leaves it unset → prod CDN. **Data and images now come from the same environment (dev→dev, prod→prod).**

## Verified
Built + deployed to dev: the address-similarity figure went from 1/3 → **2/3** crops loading (the previously-blank `9405 Russell` now renders), and all images now resolve to the dev CDN. The one remaining empty box is a receipt with **no asset anywhere** (`05de0b2d`) — a separate data-completeness issue (audit: 313 dev / 66 prod receipts have no CDN variant), not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
