### PR TITLE
[codex] fix analytics production deploy

### DIFF
--- a/infra/api_gateway.py
+++ b/infra/api_gateway.py
@@ -547,6 +547,7 @@ stage = aws.apigatewayv2.Stage(
             "}"
         ),
     ),
+    opts=pulumi.ResourceOptions(depends_on=[route_reader_summary]),
 )
 
 reader_summary_web_acl = aws.wafv2.WebAcl(

--- a/portfolio/utils/analytics.ts
+++ b/portfolio/utils/analytics.ts
@@ -63,17 +63,17 @@ const CLOUDFRONT_BEACON_PARAM_KEYS = [
   "quick_jump",
 ];
 
-type AnalyticsParams = Record<
+export type AnalyticsParams = Record<
   string,
   string | number | boolean | undefined
 >;
 
-type AnalyticsEventMeta = {
+export type AnalyticsEventMeta = {
   sessionId: string;
   eventId: string;
 };
 
-type WebVitalMetric = {
+export type WebVitalMetric = {
   name: string;
   value: number;
   delta: number;


### PR DESCRIPTION
## Summary

- Make the API Gateway stage depend on the new `POST /reader_summary` route before applying per-route throttling settings.
- Export analytics helper types so TypeDoc includes them instead of failing the docs job on referenced-but-undocumented warnings.

## Validation

- `git diff --check`
- `python3 -m py_compile infra/api_gateway.py`
- `npm run docs`
- `pulumi preview --stack prod --diff --non-interactive` (no missing-route diagnostic; preview shows `reader_summary_route` before `api_stage` route settings)

## Context

The merged analytics PR reached `main`, but the production run failed before S3/CloudFront sync because API Gateway returned `NotFoundException: Unable to find Route by key POST /reader_summary within the provided RouteSettings`. The same run also showed TypeDoc exiting with code 4 for analytics helper type warnings.