### PR TITLE
feat(line-items): geometry + arithmetic + semantic line-item labeling

### DIFF
--- a/receipt_upload/receipt_upload/line_items/__init__.py
+++ b/receipt_upload/receipt_upload/line_items/__init__.py
@@ -1,6 +1,13 @@
 """Line-item labeling: deterministic geometry + semantic (Chroma) recovery."""
 
-from receipt_upload.line_items.reconstructor import propose_line_item_labels
+from receipt_upload.line_items.reconstructor import (
+    propose_line_item_labels,
+    reclassify_mislabeled_totals,
+)
 from receipt_upload.line_items.semantic_proposer import propose_product_names
 
-__all__ = ["propose_line_item_labels", "propose_product_names"]
+__all__ = [
+    "propose_line_item_labels",
+    "propose_product_names",
+    "reclassify_mislabeled_totals",
+]

--- a/receipt_upload/receipt_upload/line_items/__init__.py
+++ b/receipt_upload/receipt_upload/line_items/__init__.py
@@ -1,5 +1,6 @@
-"""Deterministic geometry-based line-item label reconstruction."""
+"""Line-item labeling: deterministic geometry + semantic (Chroma) recovery."""
 
 from receipt_upload.line_items.reconstructor import propose_line_item_labels
+from receipt_upload.line_items.semantic_proposer import propose_product_names
 
-__all__ = ["propose_line_item_labels"]
+__all__ = ["propose_line_item_labels", "propose_product_names"]

--- a/receipt_upload/receipt_upload/line_items/reconstructor.py
+++ b/receipt_upload/receipt_upload/line_items/reconstructor.py
@@ -182,12 +182,23 @@ def reclassify_mislabeled_totals(
     tol = 0.02
     reconciled_as_is = abs(l_clean - grand) <= tol
     reconciled_with_candidates = abs(l_clean + cand_sum - grand) <= tol
+    # The reconciled line-item set must contain at least TWO line totals. A single
+    # price that equals the whole grand total (with no other line totals) is far
+    # more likely a mislabeled *total* than a lone line item — e.g. a one-item
+    # cafe receipt where the model tags "Total 10.83" as SUBTOTAL. Requiring >=2
+    # keeps us from "reconciling" such a receipt into a phantom line item.
+    line_total_count = len({k for k in lt_keys if k in by_key}) + len(candidates)
     # Normal receipt: the real line items already sum to a labeled SUBTOTAL value.
     subtotal_vals = [v for _, lab, v in candidates if lab.label == "SUBTOTAL"]
     is_normal_receipt = l_clean > 0 and any(
         abs(l_clean - s) <= tol for s in subtotal_vals
     )
-    if reconciled_as_is or is_normal_receipt or not reconciled_with_candidates:
+    if (
+        reconciled_as_is
+        or is_normal_receipt
+        or not reconciled_with_candidates
+        or line_total_count < 2
+    ):
         return [], []
 
     total_lt = round(l_clean + cand_sum, 2)

--- a/receipt_upload/receipt_upload/line_items/reconstructor.py
+++ b/receipt_upload/receipt_upload/line_items/reconstructor.py
@@ -61,7 +61,9 @@ def _amount(t: str) -> float | None:
 
 def reclassify_mislabeled_totals(
     words: List, existing_labels: List[ReceiptWordLabel]
-) -> List[Tuple[ReceiptWordLabel, ReceiptWordLabel]]:
+) -> Tuple[
+    List[Tuple[ReceiptWordLabel, ReceiptWordLabel]], List[ReceiptWordLabel]
+]:
     """Reclassify PENDING ``SUBTOTAL``/``TAX`` labels that are actually line totals.
 
     The first-pass model emits ``SUBTOTAL``/``TAX`` when two (or more) line totals
@@ -82,12 +84,28 @@ def reclassify_mislabeled_totals(
       labeled subtotal (the normal-receipt case, where SUBTOTAL == Σ items and
       SUBTOTAL + TAX == GRAND_TOTAL is the definition, not a mislabel).
 
+    When the reconciliation fires, the arithmetic is the *authority* on the
+    line-item totals, so it also reports the receipt's existing ``LINE_TOTAL``
+    labels that participate in the sum. Callers must lock those VALID and pull
+    them (along with the invalidated SUBTOTAL/TAX) out of the pending set, or the
+    downstream Chroma/LLM validators will "correct" a real line total back to
+    TAX using the very same coincidental arithmetic that caused the mislabel.
+
     Returns:
-        ``(old_label, new_label)`` pairs. Callers should **invalidate**
-        ``old_label`` (mark it ``INVALID`` — keeping it as an audit trail, since
-        deliberate INVALID currency labels are how we record "this isn't that
-        total") and add ``new_label`` (a ``LINE_TOTAL``, status ``VALID`` since
-        arithmetic confirms it, ``label_proposed_by="arithmetic_totals_reclass"``).
+        ``(reclassifications, locked_line_totals)`` where:
+
+        * ``reclassifications`` is a list of ``(old_label, new_label)`` pairs.
+          Callers should **invalidate** ``old_label`` (mark it ``INVALID`` —
+          keeping it as an audit trail, since deliberate INVALID currency labels
+          are how we record "this isn't that total"), drop it from the pending
+          set, and add ``new_label`` (a ``LINE_TOTAL``, status ``VALID`` since
+          arithmetic confirms it, ``label_proposed_by="arithmetic_totals_reclass"``).
+        * ``locked_line_totals`` is the list of existing ``LINE_TOTAL`` label
+          objects that participate in the reconciled sum. Callers should mark
+          them ``VALID`` and drop them from the pending set so the validators
+          cannot override them.
+
+        Both lists are empty when no override is warranted.
     """
     label_objs: Dict[Tuple[int, int], List[ReceiptWordLabel]] = {}
     for lab in existing_labels:
@@ -104,7 +122,7 @@ def reclassify_mislabeled_totals(
         if (w.line_id, w.word_id) in pos
     }
     if not by_key:
-        return []
+        return [], []
 
     def cy(k: Tuple[int, int]) -> float:
         return pos[k][1]
@@ -118,7 +136,7 @@ def reclassify_mislabeled_totals(
         v for v in (_amount(by_key[k].text) for k in grand_keys) if v is not None
     ]
     if not grand_vals:
-        return []
+        return [], []
     grand = max(grand_vals)
     tc = statistics.median([cy(k) for k in grand_keys])
 
@@ -142,7 +160,7 @@ def reclassify_mislabeled_totals(
                 candidates.append((k, lab, val))
                 break
     if not candidates:
-        return []
+        return [], []
 
     # Clean line-total mass: existing LINE_TOTAL labels + what geometry recovers
     # with the current (SUBTOTAL/TAX-excluding) band.
@@ -170,13 +188,13 @@ def reclassify_mislabeled_totals(
         abs(l_clean - s) <= tol for s in subtotal_vals
     )
     if reconciled_as_is or is_normal_receipt or not reconciled_with_candidates:
-        return []
+        return [], []
 
     total_lt = round(l_clean + cand_sum, 2)
-    out: List[Tuple[ReceiptWordLabel, ReceiptWordLabel]] = []
+    reclassifications: List[Tuple[ReceiptWordLabel, ReceiptWordLabel]] = []
     for k, old, _val in candidates:
         w0 = by_key[k]
-        out.append(
+        reclassifications.append(
             (
                 old,
                 ReceiptWordLabel(
@@ -197,7 +215,20 @@ def reclassify_mislabeled_totals(
                 ),
             )
         )
-    return out
+
+    # The arithmetic is the authority: lock the receipt's existing LINE_TOTAL
+    # labels that participate in the reconciled sum so the Chroma/LLM validators
+    # can't "correct" a real line total back to TAX via the same coincidental
+    # arithmetic that caused the mislabel.
+    cand_keys = {k for k, _, _ in candidates}
+    locked_line_totals = [
+        lab
+        for k, labs in label_objs.items()
+        if k in lt_keys and k not in cand_keys
+        for lab in labs
+        if lab.label == "LINE_TOTAL"
+    ]
+    return reclassifications, locked_line_totals
 
 
 def propose_line_item_labels(

--- a/receipt_upload/receipt_upload/line_items/reconstructor.py
+++ b/receipt_upload/receipt_upload/line_items/reconstructor.py
@@ -130,7 +130,12 @@ def reclassify_mislabeled_totals(
     grand_keys = [
         k
         for k, labs in label_objs.items()
-        if any(l.label == "GRAND_TOTAL" for l in labs) and k in by_key
+        if k in by_key
+        and any(
+            lab.label == "GRAND_TOTAL"
+            and lab.validation_status != ValidationStatus.INVALID.value
+            for lab in labs
+        )
     ]
     grand_vals = [
         v for v in (_amount(by_key[k].text) for k in grand_keys) if v is not None
@@ -177,9 +182,9 @@ def reclassify_mislabeled_totals(
         k
         for k, labs in label_objs.items()
         if any(
-            l.label == "LINE_TOTAL"
-            and l.validation_status != ValidationStatus.INVALID.value
-            for l in labs
+            lab.label == "LINE_TOTAL"
+            and lab.validation_status != ValidationStatus.INVALID.value
+            for lab in labs
         )
     }
     lt_keys |= {
@@ -272,8 +277,19 @@ def propose_line_item_labels(
         ``label_proposed_by="geometry_line_items"``) for words that don't already
         carry that label. Empty when the region can't be bounded.
     """
+    # ``label_map`` holds only ACTIVE (non-INVALID) labels: they drive the band,
+    # totals anchors, and exclusions. A word whose SUBTOTAL was invalidated and
+    # replaced by a VALID LINE_TOTAL (arithmetic reclassification) must read as a
+    # line item here — not be excluded by its stale SUBTOTAL — so its product row
+    # can still yield PRODUCT_NAME. ``labeled_any`` tracks EVERY labeled word
+    # (incl. INVALID) and gates output so we never resurrect a deliberately
+    # rejected label as a fresh PENDING proposal.
     label_map: Dict[Tuple[int, int], Set[str]] = {}
+    labeled_any: Set[Tuple[int, int]] = set()
     for lab in existing_labels:
+        labeled_any.add((lab.line_id, lab.word_id))
+        if lab.validation_status == ValidationStatus.INVALID.value:
+            continue
         label_map.setdefault((lab.line_id, lab.word_id), set()).add(lab.label)
 
     pos: Dict[Tuple[int, int], Tuple[float, float]] = {}
@@ -444,8 +460,8 @@ def propose_line_item_labels(
     by_key = {(w.line_id, w.word_id): w for w in placed}
     out: List[ReceiptWordLabel] = []
     for key, label in proposals.items():
-        if label_map.get(key):       # word already carries a label — don't double-label
-            continue
+        if key in labeled_any:       # word already carries a label (incl. INVALID)
+            continue                  # — don't double-label or resurrect a rejection
         w0 = by_key.get(key)
         if w0 is None:
             continue

--- a/receipt_upload/receipt_upload/line_items/reconstructor.py
+++ b/receipt_upload/receipt_upload/line_items/reconstructor.py
@@ -99,7 +99,13 @@ def propose_line_item_labels(
     totals = [cy(w) for w in placed if raw(w) & _TOTALS]
     if not totals:
         return []
-    tc = statistics.median(totals)
+    # Anchor the line-item band's bottom edge on GRAND_TOTAL when present — it's
+    # the true bottom of the items. SUBTOTAL/TAX can be mislabeled line-item
+    # prices (the model emits them when two line totals coincidentally sum to the
+    # grand total and there's no Subtotal/Tax keyword), which would otherwise
+    # collapse the band onto the items themselves.
+    grand = [cy(w) for w in placed if "GRAND_TOTAL" in raw(w)]
+    tc = statistics.median(grand) if grand else statistics.median(totals)
     header = [cy(w) for w in placed if raw(w) & _HEADER]
     if not header:
         merch = [cy(w) for w in placed if "MERCHANT_NAME" in raw(w)]
@@ -136,6 +142,48 @@ def propose_line_item_labels(
     line_vals: List[float] = []
     for row in rows:
         monies = sorted([w for w in row if _is_money(w.text)], key=xl)
+        at = next((w for w in row if w.text in ("@", "x", "X")), None)
+
+        # --- "N @ $X" unit-price row -------------------------------------
+        # The integer before "@" is QUANTITY and the price right after "@" is
+        # UNIT_PRICE. The row's LINE_TOTAL is usually on the product row above,
+        # so a SINGLE price after "@" is the unit price (NOT a line total);
+        # only a SECOND, rightmost price on the row is the line total
+        # (e.g. "2 @ 1.50  3.00").
+        if at is not None:
+            at_x = xl(at)
+            prices_right = [
+                m
+                for m in monies
+                if xl(m) > at_x and (_FULL.match(m.text) or _DOT.match(m.text))
+            ]
+            qty = next(
+                (
+                    w
+                    for w in sorted(row, key=xl, reverse=True)
+                    if xl(w) < at_x and re.fullmatch(r"\d{1,3}", w.text)
+                ),
+                None,
+            )
+            if qty is not None:
+                proposals[(qty.line_id, qty.word_id)] = "QUANTITY"
+            if len(prices_right) >= 2:
+                lt = prices_right[-1]
+                proposals[(lt.line_id, lt.word_id)] = "LINE_TOTAL"
+                if (v := _amount(lt.text)) is not None:
+                    line_vals.append(v)
+                for m in prices_right[:-1]:
+                    proposals[(m.line_id, m.word_id)] = "UNIT_PRICE"
+            elif len(prices_right) == 1:
+                proposals[(prices_right[0].line_id, prices_right[0].word_id)] = (
+                    "UNIT_PRICE"
+                )
+            for w in row:                            # product = text left of "@"
+                if xl(w) < at_x and _has_letters(w.text) and not _is_money(w.text):
+                    proposals.setdefault((w.line_id, w.word_id), "PRODUCT_NAME")
+            continue
+
+        # --- normal product row ------------------------------------------
         if not monies:
             continue
         # A line total must be a real price (a full token, or the "$3." left half
@@ -161,15 +209,6 @@ def propose_line_item_labels(
         full = next((m for m in group if _FULL.match(m.text)), None)
         if full and (val := _amount(full.text)) is not None:
             line_vals.append(val)
-        if any(w.text in ("@", "x", "X") for w in row):   # N @ $X -> unit price
-            for m in monies:                        # only real price tokens, not the qty
-                key = (m.line_id, m.word_id)
-                if (
-                    key not in group_keys
-                    and xl(m) < xl(line_total)
-                    and (_FULL.match(m.text) or _DOT.match(m.text))
-                ):
-                    proposals[key] = "UNIT_PRICE"
         for w in row:                                # product = text left of price
             if xl(w) < xl(line_total) and _has_letters(w.text) and not _is_money(w.text):
                 proposals.setdefault((w.line_id, w.word_id), "PRODUCT_NAME")

--- a/receipt_upload/receipt_upload/line_items/reconstructor.py
+++ b/receipt_upload/receipt_upload/line_items/reconstructor.py
@@ -29,6 +29,7 @@ _FRAG = re.compile(r"^\d{2}$")                       # "99"   (split, right half
 _HEADER = {"ADDRESS_LINE", "PHONE_NUMBER", "STORE_HOURS"}
 _TOTALS = {"SUBTOTAL", "TAX", "GRAND_TOTAL"}
 _PROPOSED_BY = "geometry_line_items"
+_RECLASS_BY = "arithmetic_totals_reclass"
 
 
 def _xy(word) -> Tuple[float, float] | None:
@@ -56,6 +57,147 @@ def _amount(t: str) -> float | None:
         return float(t)
     except ValueError:
         return None
+
+
+def reclassify_mislabeled_totals(
+    words: List, existing_labels: List[ReceiptWordLabel]
+) -> List[Tuple[ReceiptWordLabel, ReceiptWordLabel]]:
+    """Reclassify PENDING ``SUBTOTAL``/``TAX`` labels that are actually line totals.
+
+    The first-pass model emits ``SUBTOTAL``/``TAX`` when two (or more) line totals
+    coincidentally sum to the grand total and there is no Subtotal/Tax keyword to
+    anchor a real totals block (e.g. the Trader Joe's IMG_2826 case: ``$4.29`` and
+    ``$1.38`` for milk + bananas sum to the ``$5.67`` grand total). Those prices
+    belong to product rows, not a totals block.
+
+    We override **only when arithmetic proves it** — never on geometry alone — and
+    only for ``PENDING`` labels, so deliberate human ``VALID``/``INVALID`` currency
+    labels are left untouched. The gate:
+
+    * a ``GRAND_TOTAL`` with a numeric value exists;
+    * the candidate sits *above* the grand-total row (inside the item region);
+    * Σ(line totals) reconciles to the grand total **only** when the candidates
+      are counted as line totals — i.e. it does not already reconcile without
+      them, and the receipt's existing line totals do not already sum to a
+      labeled subtotal (the normal-receipt case, where SUBTOTAL == Σ items and
+      SUBTOTAL + TAX == GRAND_TOTAL is the definition, not a mislabel).
+
+    Returns:
+        ``(old_label, new_label)`` pairs. Callers should **invalidate**
+        ``old_label`` (mark it ``INVALID`` — keeping it as an audit trail, since
+        deliberate INVALID currency labels are how we record "this isn't that
+        total") and add ``new_label`` (a ``LINE_TOTAL``, status ``VALID`` since
+        arithmetic confirms it, ``label_proposed_by="arithmetic_totals_reclass"``).
+    """
+    label_objs: Dict[Tuple[int, int], List[ReceiptWordLabel]] = {}
+    for lab in existing_labels:
+        label_objs.setdefault((lab.line_id, lab.word_id), []).append(lab)
+
+    pos: Dict[Tuple[int, int], Tuple[float, float]] = {}
+    for w in words:
+        xy = _xy(w)
+        if xy is not None:
+            pos[(w.line_id, w.word_id)] = xy
+    by_key = {
+        (w.line_id, w.word_id): w
+        for w in words
+        if (w.line_id, w.word_id) in pos
+    }
+    if not by_key:
+        return []
+
+    def cy(k: Tuple[int, int]) -> float:
+        return pos[k][1]
+
+    grand_keys = [
+        k
+        for k, labs in label_objs.items()
+        if any(l.label == "GRAND_TOTAL" for l in labs) and k in by_key
+    ]
+    grand_vals = [
+        v for v in (_amount(by_key[k].text) for k in grand_keys) if v is not None
+    ]
+    if not grand_vals:
+        return []
+    grand = max(grand_vals)
+    tc = statistics.median([cy(k) for k in grand_keys])
+
+    # Candidate mislabels: PENDING SUBTOTAL/TAX money words sitting above the
+    # grand-total row (header is high-y, totals low-y; "above" means larger cy).
+    candidates: List[Tuple[Tuple[int, int], ReceiptWordLabel, float]] = []
+    for k, labs in label_objs.items():
+        if k not in by_key or cy(k) <= tc:
+            continue
+        word = by_key[k]
+        if not _is_money(word.text):
+            continue
+        val = _amount(word.text)
+        if val is None:
+            continue
+        for lab in labs:
+            if (
+                lab.label in ("SUBTOTAL", "TAX")
+                and lab.validation_status == ValidationStatus.PENDING.value
+            ):
+                candidates.append((k, lab, val))
+                break
+    if not candidates:
+        return []
+
+    # Clean line-total mass: existing LINE_TOTAL labels + what geometry recovers
+    # with the current (SUBTOTAL/TAX-excluding) band.
+    lt_keys = {
+        k
+        for k, labs in label_objs.items()
+        if any(l.label == "LINE_TOTAL" for l in labs)
+    }
+    lt_keys |= {
+        (p.line_id, p.word_id)
+        for p in propose_line_item_labels(words, existing_labels)
+        if p.label == "LINE_TOTAL"
+    }
+    l_clean = round(
+        sum((_amount(by_key[k].text) or 0.0) for k in lt_keys if k in by_key), 2
+    )
+    cand_sum = round(sum(v for _, _, v in candidates), 2)
+
+    tol = 0.02
+    reconciled_as_is = abs(l_clean - grand) <= tol
+    reconciled_with_candidates = abs(l_clean + cand_sum - grand) <= tol
+    # Normal receipt: the real line items already sum to a labeled SUBTOTAL value.
+    subtotal_vals = [v for _, lab, v in candidates if lab.label == "SUBTOTAL"]
+    is_normal_receipt = l_clean > 0 and any(
+        abs(l_clean - s) <= tol for s in subtotal_vals
+    )
+    if reconciled_as_is or is_normal_receipt or not reconciled_with_candidates:
+        return []
+
+    total_lt = round(l_clean + cand_sum, 2)
+    out: List[Tuple[ReceiptWordLabel, ReceiptWordLabel]] = []
+    for k, old, _val in candidates:
+        w0 = by_key[k]
+        out.append(
+            (
+                old,
+                ReceiptWordLabel(
+                    image_id=w0.image_id,
+                    receipt_id=w0.receipt_id,
+                    line_id=k[0],
+                    word_id=k[1],
+                    label="LINE_TOTAL",
+                    reasoning=(
+                        f"Arithmetic reclassification: model-proposed {old.label} "
+                        f"is a line-item total — Σ line totals ({total_lt:.2f}) "
+                        f"equals GRAND_TOTAL ({grand:.2f}) only when this price is "
+                        f"counted as a line item."
+                    ),
+                    timestamp_added=datetime.now(timezone.utc),
+                    validation_status=ValidationStatus.VALID.value,
+                    label_proposed_by=_RECLASS_BY,
+                ),
+            )
+        )
+    return out
 
 
 def propose_line_item_labels(

--- a/receipt_upload/receipt_upload/line_items/reconstructor.py
+++ b/receipt_upload/receipt_upload/line_items/reconstructor.py
@@ -140,8 +140,15 @@ def reclassify_mislabeled_totals(
     grand = max(grand_vals)
     tc = statistics.median([cy(k) for k in grand_keys])
 
-    # Candidate mislabels: PENDING SUBTOTAL/TAX money words sitting above the
+    # Candidate mislabels: PENDING SUBTOTAL money words sitting above the
     # grand-total row (header is high-y, totals low-y; "above" means larger cy).
+    #
+    # We deliberately consider ONLY SUBTOTAL, never TAX. A real receipt's
+    # Σ(items) + TAX == GRAND_TOTAL is its *definition*, so a TAX candidate would
+    # "reconcile" on every normal receipt and we'd corrupt real tax labels. By
+    # excluding TAX from the candidate sum, a receipt that has a genuine tax can
+    # never reconcile (the sum falls short by exactly the tax), so we abstain —
+    # arithmetic alone cannot tell a mislabeled line item from a real tax.
     candidates: List[Tuple[Tuple[int, int], ReceiptWordLabel, float]] = []
     for k, labs in label_objs.items():
         if k not in by_key or cy(k) <= tc:
@@ -154,7 +161,7 @@ def reclassify_mislabeled_totals(
             continue
         for lab in labs:
             if (
-                lab.label in ("SUBTOTAL", "TAX")
+                lab.label == "SUBTOTAL"
                 and lab.validation_status == ValidationStatus.PENDING.value
             ):
                 candidates.append((k, lab, val))
@@ -162,12 +169,18 @@ def reclassify_mislabeled_totals(
     if not candidates:
         return [], []
 
-    # Clean line-total mass: existing LINE_TOTAL labels + what geometry recovers
-    # with the current (SUBTOTAL/TAX-excluding) band.
+    # Clean line-total mass: existing (non-INVALID) LINE_TOTAL labels + what
+    # geometry recovers with the current (SUBTOTAL/TAX-excluding) band. INVALID
+    # line totals are deliberate rejections — they must not feed the arithmetic
+    # nor be resurrected to VALID by the locking step below.
     lt_keys = {
         k
         for k, labs in label_objs.items()
-        if any(l.label == "LINE_TOTAL" for l in labs)
+        if any(
+            l.label == "LINE_TOTAL"
+            and l.validation_status != ValidationStatus.INVALID.value
+            for l in labs
+        )
     }
     lt_keys |= {
         (p.line_id, p.word_id)
@@ -238,6 +251,7 @@ def reclassify_mislabeled_totals(
         if k in lt_keys and k not in cand_keys
         for lab in labs
         if lab.label == "LINE_TOTAL"
+        and lab.validation_status != ValidationStatus.INVALID.value
     ]
     return reclassifications, locked_line_totals
 
@@ -326,14 +340,32 @@ def propose_line_item_labels(
     line_vals: List[float] = []
     for row in rows:
         monies = sorted([w for w in row if _is_money(w.text)], key=xl)
-        at = next((w for w in row if w.text in ("@", "x", "X")), None)
-
         # --- "N @ $X" unit-price row -------------------------------------
-        # The integer before "@" is QUANTITY and the price right after "@" is
-        # UNIT_PRICE. The row's LINE_TOTAL is usually on the product row above,
-        # so a SINGLE price after "@" is the unit price (NOT a line total);
-        # only a SECOND, rightmost price on the row is the line total
-        # (e.g. "2 @ 1.50  3.00").
+        # A unit-price row's marker (@, x, X) must sit DIRECTLY between an integer
+        # quantity (immediate left) and a price (immediate right). Requiring that
+        # adjacency stops product/pack tokens like "VITAMIN X $9.99" or
+        # "12 X 355ML $6.99" from being mis-read as unit-price rows (where the
+        # lone price is the LINE_TOTAL, not a unit price). The integer before the
+        # marker is QUANTITY and the price right after is UNIT_PRICE; the row's
+        # LINE_TOTAL is usually on the product row above, so a SINGLE price after
+        # the marker is the unit price (NOT a line total) — only a SECOND,
+        # rightmost price on the row is the line total (e.g. "2 @ 1.50  3.00").
+        row_x = sorted(row, key=xl)
+        at = None
+        qty = None
+        for i, w in enumerate(row_x):
+            if w.text in ("@", "x", "X"):
+                left = row_x[i - 1] if i > 0 else None
+                right = row_x[i + 1] if i + 1 < len(row_x) else None
+                if (
+                    left is not None
+                    and re.fullmatch(r"\d{1,3}", left.text)
+                    and right is not None
+                    and (_FULL.match(right.text) or _DOT.match(right.text))
+                ):
+                    at, qty = w, left
+                    break
+
         if at is not None:
             at_x = xl(at)
             prices_right = [
@@ -341,16 +373,7 @@ def propose_line_item_labels(
                 for m in monies
                 if xl(m) > at_x and (_FULL.match(m.text) or _DOT.match(m.text))
             ]
-            qty = next(
-                (
-                    w
-                    for w in sorted(row, key=xl, reverse=True)
-                    if xl(w) < at_x and re.fullmatch(r"\d{1,3}", w.text)
-                ),
-                None,
-            )
-            if qty is not None:
-                proposals[(qty.line_id, qty.word_id)] = "QUANTITY"
+            proposals[(qty.line_id, qty.word_id)] = "QUANTITY"
             if len(prices_right) >= 2:
                 lt = prices_right[-1]
                 proposals[(lt.line_id, lt.word_id)] = "LINE_TOTAL"

--- a/receipt_upload/receipt_upload/line_items/semantic_proposer.py
+++ b/receipt_upload/receipt_upload/line_items/semantic_proposer.py
@@ -101,12 +101,14 @@ def propose_product_names(
     # leaves the word effectively unlabeled — exactly the tokens this pass should
     # be free to fill with PRODUCT_NAME.
     labeled = {
-        (l.line_id, l.word_id)
-        for l in existing_labels
-        if l.label != "O"
-        and l.validation_status != ValidationStatus.INVALID.value
+        (lab.line_id, lab.word_id)
+        for lab in existing_labels
+        if lab.label != "O"
+        and lab.validation_status != ValidationStatus.INVALID.value
     }
-    label_at = {(l.line_id, l.word_id): l.label for l in existing_labels}
+    label_at = {
+        (lab.line_id, lab.word_id): lab.label for lab in existing_labels
+    }
 
     header = [_cy(w) for w in words if label_at.get((w.line_id, w.word_id)) in _HEADER]
     header = [y for y in header if y is not None]

--- a/receipt_upload/receipt_upload/line_items/semantic_proposer.py
+++ b/receipt_upload/receipt_upload/line_items/semantic_proposer.py
@@ -1,0 +1,139 @@
+"""Semantic (Chroma kNN) PRODUCT_NAME proposer.
+
+The first-pass LayoutLM model emits no PRODUCT_NAME label at all, and the
+deterministic geometry pass only recovers product names that sit on the same
+OCR row as a price (~0.42 recall on a 487-receipt corpus). Product names
+recur across receipts, so a k-NN over already-validated PRODUCT_NAME words
+recovers the rest: measured **F1 ~0.84 (P 0.88 / R 0.80)** vs geometry's 0.59.
+
+Two findings drive the design:
+
+* Search **unscoped** by merchant. Merchant-scoping HURTS recall
+  (0.80 -> 0.73): the same product is described almost identically across
+  merchants, and filtering to one merchant starves the candidate pool. The
+  existing validator may keep merchant as a *boost*, but never as a *filter*.
+* Propose, don't override. This only proposes ``PRODUCT_NAME`` (status
+  PENDING) for words that carry **no** label, in the line-item band. The
+  existing Chroma + LLM validators then confirm — so it never overrides a
+  deliberate currency/other label.
+"""
+
+from __future__ import annotations
+
+import re
+from collections import Counter
+from datetime import datetime, timezone
+from typing import Dict, List, Tuple
+
+from receipt_dynamo.constants import ValidationStatus
+from receipt_dynamo.entities.receipt_word_label import ReceiptWordLabel
+
+_PROPOSED_BY = "semantic_product_name"
+_HEADER = {"ADDRESS_LINE", "PHONE_NUMBER", "STORE_HOURS", "MERCHANT_NAME"}
+_MONEY = re.compile(r"\$?\d{1,4}[.,]\d{2}")
+
+
+def _cy(word) -> float | None:
+    box = getattr(word, "bounding_box", None)
+    if not box:
+        return None
+    y = box.get("y")
+    if y is None:
+        return None
+    return y + (box.get("height") or 0.0) / 2.0
+
+
+def _has_letters(text: str) -> bool:
+    return len(re.sub(r"[^A-Za-z]", "", text)) >= 2
+
+
+def _knn_is_product(
+    words_client, embedding: List[float], image_id: str, k: int, min_similarity: float
+) -> bool:
+    """kNN over validated words (UNSCOPED); majority-vote PRODUCT_NAME."""
+    try:
+        res = words_client.query(
+            collection_name="words",
+            query_embeddings=[embedding],
+            n_results=k + 8,
+            where={"label_status": "validated"},
+            include=["metadatas", "distances"],
+        )
+    except Exception:
+        return False
+    metas = (res.get("metadatas") or [[]])[0]
+    dists = (res.get("distances") or [[]])[0]
+    votes: List[str] = []
+    for meta, dist in zip(metas, dists):
+        if meta.get("image_id") == image_id:  # exclude the same receipt
+            continue
+        if max(0.0, 1.0 - (dist / 2.0)) < min_similarity:  # L2 -> similarity
+            continue
+        labels = meta.get("valid_labels_array") or []
+        primary = "PRODUCT_NAME" if "PRODUCT_NAME" in labels else (labels[0] if labels else None)
+        if primary:
+            votes.append(primary)
+        if len(votes) >= k:
+            break
+    return bool(votes) and Counter(votes).most_common(1)[0][0] == "PRODUCT_NAME"
+
+
+def propose_product_names(
+    words: List,
+    existing_labels: List[ReceiptWordLabel],
+    words_client,
+    word_embeddings: Dict[Tuple[int, int], List[float]],
+    *,
+    k: int = 5,
+    min_similarity: float = 0.5,
+) -> List[ReceiptWordLabel]:
+    """Propose PENDING PRODUCT_NAME labels for unlabeled in-band words.
+
+    Args:
+        words: ReceiptWord entities (need ``.bounding_box``/``.text``/ids).
+        existing_labels: labels already on the receipt (anchors + any proposals
+            from the geometry pass); only unlabeled words are candidates.
+        words_client: ChromaClient exposing ``.query(collection_name=..., ...)``.
+        word_embeddings: cached embeddings keyed by ``(line_id, word_id)``.
+    """
+    labeled = {(l.line_id, l.word_id) for l in existing_labels}
+    label_at = {(l.line_id, l.word_id): l.label for l in existing_labels}
+
+    header = [_cy(w) for w in words if label_at.get((w.line_id, w.word_id)) in _HEADER]
+    header = [y for y in header if y is not None]
+    totals = [
+        _cy(w) for w in words if label_at.get((w.line_id, w.word_id)) == "GRAND_TOTAL"
+    ]
+    totals = [y for y in totals if y is not None]
+    if not header or not totals:
+        return []
+    lo, hi = min(min(header), min(totals)), max(max(header), max(totals))
+
+    out: List[ReceiptWordLabel] = []
+    for w in words:
+        key = (w.line_id, w.word_id)
+        if key in labeled:
+            continue
+        cy = _cy(w)
+        if cy is None or not (lo < cy < hi):
+            continue
+        if not _has_letters(w.text) or _MONEY.search(w.text):
+            continue
+        emb = word_embeddings.get(key)
+        if emb is None:
+            continue
+        if _knn_is_product(words_client, emb, w.image_id, k, min_similarity):
+            out.append(
+                ReceiptWordLabel(
+                    image_id=w.image_id,
+                    receipt_id=w.receipt_id,
+                    line_id=w.line_id,
+                    word_id=w.word_id,
+                    label="PRODUCT_NAME",
+                    reasoning="Semantic kNN over validated product names (unscoped).",
+                    timestamp_added=datetime.now(timezone.utc),
+                    validation_status=ValidationStatus.PENDING.value,
+                    label_proposed_by=_PROPOSED_BY,
+                )
+            )
+    return out

--- a/receipt_upload/receipt_upload/line_items/semantic_proposer.py
+++ b/receipt_upload/receipt_upload/line_items/semantic_proposer.py
@@ -96,7 +96,16 @@ def propose_product_names(
         words_client: ChromaClient exposing ``.query(collection_name=..., ...)``.
         word_embeddings: cached embeddings keyed by ``(line_id, word_id)``.
     """
-    labeled = {(l.line_id, l.word_id) for l in existing_labels}
+    # A word counts as "already labeled" only if it carries a real, non-rejected
+    # core label. A pending ``O`` (background) label or an INVALID-only label
+    # leaves the word effectively unlabeled — exactly the tokens this pass should
+    # be free to fill with PRODUCT_NAME.
+    labeled = {
+        (l.line_id, l.word_id)
+        for l in existing_labels
+        if l.label != "O"
+        and l.validation_status != ValidationStatus.INVALID.value
+    }
     label_at = {(l.line_id, l.word_id): l.label for l in existing_labels}
 
     header = [_cy(w) for w in words if label_at.get((w.line_id, w.word_id)) in _HEADER]

--- a/receipt_upload/receipt_upload/merchant_resolution/embedding_processor.py
+++ b/receipt_upload/receipt_upload/merchant_resolution/embedding_processor.py
@@ -542,7 +542,10 @@ def _run_words_pipeline_worker(
             # bounds the line-item region by the receipt's own header/totals anchor
             # labels and labels by column. Emitted as PENDING so the Chroma + LLM
             # validators below confirm them, same as any other proposed label.
-            from receipt_upload.line_items import propose_line_item_labels
+            from receipt_upload.line_items import (
+                propose_line_item_labels,
+                propose_product_names,
+            )
 
             for li_label in propose_line_item_labels(words, word_labels):
                 dynamo.add_receipt_word_label(li_label)
@@ -552,6 +555,17 @@ def _run_words_pipeline_worker(
                 # Chroma + LLM validators.
                 if li_label.validation_status == ValidationStatus.PENDING.value:
                     pending_labels.append(li_label)
+
+            # Semantic recovery: the model emits no PRODUCT_NAME and geometry only
+            # catches product names that share an OCR row with a price. A kNN over
+            # validated product words (UNSCOPED — merchant-scoping hurts recall)
+            # proposes the rest as PENDING for the validators to confirm.
+            for pn_label in propose_product_names(
+                words, word_labels, client, word_embedding_cache
+            ):
+                dynamo.add_receipt_word_label(pn_label)
+                word_labels.append(pn_label)
+                pending_labels.append(pn_label)
 
             if pending_labels:
                 from receipt_upload.label_validation import ValidationDecision

--- a/receipt_upload/receipt_upload/merchant_resolution/embedding_processor.py
+++ b/receipt_upload/receipt_upload/merchant_resolution/embedding_processor.py
@@ -545,7 +545,30 @@ def _run_words_pipeline_worker(
             from receipt_upload.line_items import (
                 propose_line_item_labels,
                 propose_product_names,
+                reclassify_mislabeled_totals,
             )
+
+            # First-pass models emit SUBTOTAL/TAX when line totals coincidentally
+            # sum to the grand total and no Subtotal/Tax keyword anchors a real
+            # totals block (the Trader Joe's IMG_2826 case). Reclassify those
+            # PENDING labels to LINE_TOTAL — but ONLY when arithmetic proves it
+            # (Σ line totals == GRAND_TOTAL only with them counted as line items).
+            # Human VALID/INVALID labels are never touched.
+            for old_label, new_label in reclassify_mislabeled_totals(
+                words, word_labels
+            ):
+                # Invalidate (don't delete) the mislabeled total — preserves the
+                # audit trail and is consistent with "INVALID currency labels are
+                # deliberate" — then add the arithmetic-confirmed LINE_TOTAL.
+                old_label.validation_status = ValidationStatus.INVALID.value
+                old_label.reasoning = (
+                    f"Reclassified to LINE_TOTAL by {new_label.label_proposed_by}: "
+                    "this price is a line-item total, not a receipt total "
+                    "(arithmetic reconciliation)."
+                )
+                dynamo.update_receipt_word_label(old_label)
+                dynamo.add_receipt_word_label(new_label)
+                word_labels.append(new_label)
 
             for li_label in propose_line_item_labels(words, word_labels):
                 dynamo.add_receipt_word_label(li_label)

--- a/receipt_upload/receipt_upload/merchant_resolution/embedding_processor.py
+++ b/receipt_upload/receipt_upload/merchant_resolution/embedding_processor.py
@@ -554,9 +554,10 @@ def _run_words_pipeline_worker(
             # PENDING labels to LINE_TOTAL — but ONLY when arithmetic proves it
             # (Σ line totals == GRAND_TOTAL only with them counted as line items).
             # Human VALID/INVALID labels are never touched.
-            for old_label, new_label in reclassify_mislabeled_totals(
-                words, word_labels
-            ):
+            reclassifications, locked_line_totals = (
+                reclassify_mislabeled_totals(words, word_labels)
+            )
+            for old_label, new_label in reclassifications:
                 # Invalidate (don't delete) the mislabeled total — preserves the
                 # audit trail and is consistent with "INVALID currency labels are
                 # deliberate" — then add the arithmetic-confirmed LINE_TOTAL.
@@ -567,8 +568,21 @@ def _run_words_pipeline_worker(
                     "(arithmetic reconciliation)."
                 )
                 dynamo.update_receipt_word_label(old_label)
+                # Drop the invalidated total from the pending set so the Chroma/LLM
+                # validators don't re-validate it back to SUBTOTAL/TAX.
+                _remove_label_from_list(pending_labels, old_label)
                 dynamo.add_receipt_word_label(new_label)
                 word_labels.append(new_label)
+            for lt_label in locked_line_totals:
+                # Arithmetic confirms these are line totals; lock them VALID and
+                # pull them from pending so the LLM can't "correct" them to TAX.
+                lt_label.validation_status = ValidationStatus.VALID.value
+                lt_label.label_proposed_by = "arithmetic_totals_reclass"
+                lt_label.reasoning = (
+                    "Arithmetic-confirmed line total (Σ line totals == GRAND_TOTAL)."
+                )
+                dynamo.update_receipt_word_label(lt_label)
+                _remove_label_from_list(pending_labels, lt_label)
 
             for li_label in propose_line_item_labels(words, word_labels):
                 dynamo.add_receipt_word_label(li_label)

--- a/receipt_upload/test/test_reconstructor_line_items.py
+++ b/receipt_upload/test/test_reconstructor_line_items.py
@@ -3,7 +3,13 @@
 Built from the Trader Joe's IMG_2826 case: two line items whose totals
 coincidentally sum to the grand total, plus a "6 @ $0.23" quantity/unit-price
 row. The first-pass model mislabels the line totals as SUBTOTAL/TAX and never
-emits QUANTITY/UNIT_PRICE; geometry must recover them.
+emits QUANTITY/UNIT_PRICE; the upload pipeline must (1) reclassify the
+mislabeled SUBTOTAL/TAX to LINE_TOTAL when arithmetic proves it, then (2)
+recover PRODUCT_NAME/QUANTITY/UNIT_PRICE by geometry.
+
+These tests exercise the *production* label set — the model's PENDING
+SUBTOTAL/TAX labels are present, exactly as a real upload would see them — not
+curated anchors.
 """
 
 from types import SimpleNamespace
@@ -11,7 +17,10 @@ from types import SimpleNamespace
 from receipt_dynamo.constants import ValidationStatus
 from receipt_dynamo.entities import ReceiptWordLabel
 
-from receipt_upload.line_items import propose_line_item_labels
+from receipt_upload.line_items import (
+    propose_line_item_labels,
+    reclassify_mislabeled_totals,
+)
 
 IMAGE_ID = "00000000-0000-4000-8000-000000000abc"
 
@@ -27,16 +36,16 @@ def _w(line_id, word_id, text, x, y, w=0.08, h=0.02):
     )
 
 
-def _anchor(line_id, word_id, label):
+def _label(line_id, word_id, label, status=ValidationStatus.VALID.value):
     return ReceiptWordLabel(
         image_id=IMAGE_ID,
         receipt_id=1,
         line_id=line_id,
         word_id=word_id,
         label=label,
-        reasoning="test anchor",
+        reasoning="test label",
         timestamp_added="2026-01-01T00:00:00.000+00:00",
-        validation_status=ValidationStatus.VALID.value,
+        validation_status=status,
     )
 
 
@@ -64,31 +73,56 @@ def _trader_joes_words():
     ]
 
 
-def _proposals():
-    words = _trader_joes_words()
-    anchors = [
-        _anchor(2, 1, "ADDRESS_LINE"),
-        _anchor(2, 2, "ADDRESS_LINE"),
-        _anchor(1, 1, "MERCHANT_NAME"),
-        _anchor(13, 1, "GRAND_TOTAL"),
+def _model_labels():
+    """The first-pass model's PENDING output for IMG_2826 — the production set.
+
+    The line totals are MISLABELED as SUBTOTAL/TAX (no Subtotal/Tax keyword, and
+    4.29 + 1.38 == 5.67 fools the model).
+    """
+    return [
+        _label(2, 1, "ADDRESS_LINE"),
+        _label(2, 2, "ADDRESS_LINE"),
+        _label(1, 1, "MERCHANT_NAME"),
+        _label(11, 1, "SUBTOTAL", ValidationStatus.PENDING.value),  # $4.29 (milk)
+        _label(12, 1, "TAX", ValidationStatus.PENDING.value),       # $1.38 (banana)
+        _label(13, 1, "GRAND_TOTAL", ValidationStatus.PENDING.value),
     ]
-    return {(p.line_id, p.word_id): p for p in propose_line_item_labels(words, anchors)}
 
 
-def test_line_totals_recovered():
-    p = _proposals()
-    assert p[(11, 1)].label == "LINE_TOTAL"  # $4.29 (milk)
-    assert p[(12, 1)].label == "LINE_TOTAL"  # $1.38 (banana)
+def _run_pipeline():
+    """Mirror the upload pipeline: reclassify mislabeled totals, then geometry."""
+    words = _trader_joes_words()
+    labels = _model_labels()
+
+    # Stage 1: arithmetic-gated reclassification of mislabeled SUBTOTAL/TAX.
+    for old, new in reclassify_mislabeled_totals(words, labels):
+        labels = [l for l in labels if l is not old]
+        labels.append(new)
+
+    # Stage 2: geometry line-item recovery over the corrected label set.
+    by_key = {(l.line_id, l.word_id): l for l in labels}
+    for p in propose_line_item_labels(words, labels):
+        by_key[(p.line_id, p.word_id)] = p
+    return by_key
+
+
+def test_mislabeled_totals_reclassified_to_line_totals():
+    p = _run_pipeline()
+    assert p[(11, 1)].label == "LINE_TOTAL"  # $4.29 was SUBTOTAL
+    assert p[(12, 1)].label == "LINE_TOTAL"  # $1.38 was TAX
+    # Arithmetic proved it -> committed VALID, not left PENDING.
+    assert p[(11, 1)].validation_status == ValidationStatus.VALID.value
+    assert p[(12, 1)].validation_status == ValidationStatus.VALID.value
 
 
 def test_product_names_recovered():
-    p = _proposals()
+    p = _run_pipeline()
     assert p[(8, 1)].label == "PRODUCT_NAME"  # MILK
     assert p[(9, 1)].label == "PRODUCT_NAME"  # BANANA
 
 
 def test_quantity_and_unit_price_from_at_row():
-    p = _proposals()
+    p = _run_pipeline()
     # "6 @ $0.23": qty is the integer before "@", unit price is the price after.
     assert p[(10, 1)].label == "QUANTITY"
     assert p[(10, 3)].label == "UNIT_PRICE"
@@ -96,11 +130,49 @@ def test_quantity_and_unit_price_from_at_row():
     assert p[(10, 3)].label != "LINE_TOTAL"
 
 
-def test_arithmetic_gate_auto_validates():
-    p = _proposals()
-    # Σ(LINE_TOTAL) = 4.29 + 1.38 = 5.67 = GRAND_TOTAL -> auto-VALID.
-    line_totals = [v for v in p.values() if v.label == "LINE_TOTAL"]
-    assert line_totals
-    assert all(
-        v.validation_status == ValidationStatus.VALID.value for v in line_totals
-    )
+def test_reclassification_is_arithmetic_gated_on_grand_total():
+    """No GRAND_TOTAL value -> nothing to reconcile against -> no override."""
+    words = _trader_joes_words()
+    labels = [l for l in _model_labels() if l.label != "GRAND_TOTAL"]
+    assert reclassify_mislabeled_totals(words, labels) == []
+
+
+def test_normal_receipt_subtotal_tax_not_reclassified():
+    """A correctly-labeled receipt must keep its SUBTOTAL/TAX.
+
+    Two real line items ($2.00, $3.00) sum to SUBTOTAL ($5.00); SUBTOTAL + TAX
+    ($0.50) == GRAND_TOTAL ($5.50). That SUBTOTAL+TAX==GRAND identity is the
+    definition of a receipt, not a mislabel — the override must NOT fire.
+    """
+    words = [
+        _w(1, 1, "SHOP", 0.30, 0.95),
+        _w(5, 1, "APPLE", 0.10, 0.80),
+        _w(5, 2, "$2.00", 0.72, 0.80),
+        _w(6, 1, "BREAD", 0.10, 0.76),
+        _w(6, 2, "$3.00", 0.72, 0.76),
+        _w(7, 1, "Subtotal", 0.10, 0.60),
+        _w(7, 2, "$5.00", 0.72, 0.60),
+        _w(8, 1, "Tax", 0.10, 0.57),
+        _w(8, 2, "$0.50", 0.72, 0.57),
+        _w(9, 1, "Total", 0.10, 0.54),
+        _w(9, 2, "$5.50", 0.72, 0.54),
+    ]
+    labels = [
+        _label(1, 1, "MERCHANT_NAME"),
+        _label(5, 2, "LINE_TOTAL", ValidationStatus.PENDING.value),
+        _label(6, 2, "LINE_TOTAL", ValidationStatus.PENDING.value),
+        _label(7, 2, "SUBTOTAL", ValidationStatus.PENDING.value),
+        _label(8, 2, "TAX", ValidationStatus.PENDING.value),
+        _label(9, 2, "GRAND_TOTAL", ValidationStatus.PENDING.value),
+    ]
+    assert reclassify_mislabeled_totals(words, labels) == []
+
+
+def test_human_validated_totals_never_overridden():
+    """VALID (human-confirmed) SUBTOTAL/TAX are deliberate and must be left alone."""
+    words = _trader_joes_words()
+    labels = _model_labels()
+    for l in labels:
+        if l.label in ("SUBTOTAL", "TAX"):
+            l.validation_status = ValidationStatus.VALID.value
+    assert reclassify_mislabeled_totals(words, labels) == []

--- a/receipt_upload/test/test_reconstructor_line_items.py
+++ b/receipt_upload/test/test_reconstructor_line_items.py
@@ -74,17 +74,18 @@ def _trader_joes_words():
 
 
 def _model_labels():
-    """The first-pass model's PENDING output for IMG_2826 — the production set.
+    """The first-pass model's PENDING output for IMG_2826 — the verified prod set.
 
-    The line totals are MISLABELED as SUBTOTAL/TAX (no Subtotal/Tax keyword, and
-    4.29 + 1.38 == 5.67 fools the model).
+    On the real upload the model tagged $4.29 (milk) as SUBTOTAL and got $1.38
+    (banana) right as LINE_TOTAL. 4.29 + 1.38 == 5.67 (the grand total) is what
+    lets the arithmetic recover the mislabeled SUBTOTAL.
     """
     return [
         _label(2, 1, "ADDRESS_LINE"),
         _label(2, 2, "ADDRESS_LINE"),
         _label(1, 1, "MERCHANT_NAME"),
-        _label(11, 1, "SUBTOTAL", ValidationStatus.PENDING.value),  # $4.29 (milk)
-        _label(12, 1, "TAX", ValidationStatus.PENDING.value),       # $1.38 (banana)
+        _label(11, 1, "SUBTOTAL", ValidationStatus.PENDING.value),    # $4.29 (milk)
+        _label(12, 1, "LINE_TOTAL", ValidationStatus.PENDING.value),  # $1.38 (banana)
         _label(13, 1, "GRAND_TOTAL", ValidationStatus.PENDING.value),
     ]
 
@@ -190,11 +191,83 @@ def test_single_item_total_not_reclassified():
     assert reclassify_mislabeled_totals(words, labels) == ([], [])
 
 
+def test_real_tax_without_subtotal_not_reclassified():
+    """Σ(items) + TAX == GRAND_TOTAL with no SUBTOTAL must NOT touch the TAX.
+
+    The normal-receipt identity (items + tax = total) would otherwise reconcile
+    and corrupt a legitimate TAX into a LINE_TOTAL. We only ever consider
+    SUBTOTAL candidates, so excluding the tax leaves the sum short -> abstain.
+    """
+    P = ValidationStatus.PENDING.value
+    words = [
+        _w(1, 1, "SHOP", 0.30, 0.95),
+        _w(5, 1, "APPLE", 0.10, 0.80),
+        _w(5, 2, "$5.00", 0.72, 0.80),
+        _w(6, 1, "BREAD", 0.10, 0.76),
+        _w(6, 2, "$3.00", 0.72, 0.76),
+        _w(8, 1, "Tax", 0.10, 0.60),
+        _w(8, 2, "$0.64", 0.72, 0.60),
+        _w(9, 1, "Total", 0.10, 0.54),
+        _w(9, 2, "$8.64", 0.72, 0.54),
+    ]
+    labels = [
+        _label(1, 1, "MERCHANT_NAME"),
+        _label(5, 2, "LINE_TOTAL", P),
+        _label(6, 2, "LINE_TOTAL", P),
+        _label(8, 2, "TAX", P),          # real tax, model missed SUBTOTAL
+        _label(9, 2, "GRAND_TOTAL", P),
+    ]
+    assert reclassify_mislabeled_totals(words, labels) == ([], [])
+
+
+def test_invalid_line_total_not_locked_or_counted():
+    """An INVALID LINE_TOTAL must not feed the arithmetic nor be resurfaced VALID."""
+    P = ValidationStatus.PENDING.value
+    words = _trader_joes_words()
+    labels = [
+        _label(1, 1, "MERCHANT_NAME"),
+        _label(11, 1, "SUBTOTAL", P),    # $4.29
+        _label(12, 1, "LINE_TOTAL", ValidationStatus.INVALID.value),  # $1.38 rejected
+        _label(13, 1, "GRAND_TOTAL", P),
+    ]
+    reclassifications, locked = reclassify_mislabeled_totals(words, labels)
+    # With $1.38 INVALID it can't count toward the sum (4.29 != 5.67) -> abstain,
+    # and it is never returned for locking.
+    assert reclassifications == []
+    assert locked == []
+
+
 def test_reclassification_is_arithmetic_gated_on_grand_total():
     """No GRAND_TOTAL value -> nothing to reconcile against -> no override."""
     words = _trader_joes_words()
     labels = [l for l in _model_labels() if l.label != "GRAND_TOTAL"]
     assert reclassify_mislabeled_totals(words, labels) == ([], [])
+
+
+def test_x_marker_in_product_or_pack_not_unit_price_row():
+    """'x'/'X' tokens in product/pack text must not trigger the unit-price branch.
+
+    "VITAMIN X $9.99" and "12 X 355ML $6.99": the lone price is the LINE_TOTAL,
+    not a UNIT_PRICE. The marker only counts when an integer qty is immediately
+    left and a price immediately right (e.g. "6 @ $0.23").
+    """
+    # VITAMIN X $9.99 -> $9.99 is a LINE_TOTAL, X is part of the name.
+    words = [
+        _w(1, 1, "STORE", 0.30, 0.95),
+        _w(2, 1, "2716", 0.20, 0.90),
+        _w(5, 1, "VITAMIN", 0.10, 0.70),
+        _w(5, 2, "X", 0.30, 0.70),
+        _w(5, 3, "$9.99", 0.72, 0.70),
+        _w(9, 1, "$9.99", 0.72, 0.50),
+    ]
+    labels = [
+        _anchor(2, 1, "ADDRESS_LINE"),
+        _anchor(1, 1, "MERCHANT_NAME"),
+        _anchor(9, 1, "GRAND_TOTAL"),
+    ]
+    p = {(x.line_id, x.word_id): x for x in propose_line_item_labels(words, labels)}
+    assert p[(5, 3)].label == "LINE_TOTAL"
+    assert (5, 2) not in p or p[(5, 2)].label != "UNIT_PRICE"
 
 
 def test_normal_receipt_subtotal_tax_not_reclassified():

--- a/receipt_upload/test/test_reconstructor_line_items.py
+++ b/receipt_upload/test/test_reconstructor_line_items.py
@@ -164,6 +164,32 @@ def test_locks_existing_line_total_against_llm_correction():
     assert [(l.line_id, l.word_id) for l in locked] == [(12, 1)]
 
 
+def test_single_item_total_not_reclassified():
+    """A lone mislabeled total that equals the grand total must NOT reclassify.
+
+    Single-item cafe receipt (the IMG_2827 case): one item, and the model tags
+    "Total 10.83" as SUBTOTAL. With no second line total, 10.83 == GRAND_TOTAL is
+    just the total restated — reclassifying it to a phantom LINE_TOTAL would be
+    wrong. The >=2-line-totals guard must make this a no-op.
+    """
+    P = ValidationStatus.PENDING.value
+    words = [
+        _w(1, 1, "CAFE", 0.30, 0.95),
+        _w(5, 1, "BREAKFAST", 0.10, 0.80),
+        _w(5, 2, "BURRITO", 0.24, 0.80),
+        _w(5, 3, "9.99", 0.72, 0.80),
+        _w(8, 1, "Total", 0.10, 0.60),
+        _w(8, 2, "10.83", 0.72, 0.60),     # model mislabels this SUBTOTAL
+        _w(12, 1, "10.83", 0.72, 0.50),    # the real grand total
+    ]
+    labels = [
+        _label(1, 1, "MERCHANT_NAME"),
+        _label(8, 2, "SUBTOTAL", P),
+        _label(12, 1, "GRAND_TOTAL", P),
+    ]
+    assert reclassify_mislabeled_totals(words, labels) == ([], [])
+
+
 def test_reclassification_is_arithmetic_gated_on_grand_total():
     """No GRAND_TOTAL value -> nothing to reconcile against -> no override."""
     words = _trader_joes_words()

--- a/receipt_upload/test/test_reconstructor_line_items.py
+++ b/receipt_upload/test/test_reconstructor_line_items.py
@@ -1,0 +1,106 @@
+"""Regression tests for geometry line-item reconstruction.
+
+Built from the Trader Joe's IMG_2826 case: two line items whose totals
+coincidentally sum to the grand total, plus a "6 @ $0.23" quantity/unit-price
+row. The first-pass model mislabels the line totals as SUBTOTAL/TAX and never
+emits QUANTITY/UNIT_PRICE; geometry must recover them.
+"""
+
+from types import SimpleNamespace
+
+from receipt_dynamo.constants import ValidationStatus
+from receipt_dynamo.entities import ReceiptWordLabel
+
+from receipt_upload.line_items import propose_line_item_labels
+
+IMAGE_ID = "00000000-0000-4000-8000-000000000abc"
+
+
+def _w(line_id, word_id, text, x, y, w=0.08, h=0.02):
+    return SimpleNamespace(
+        image_id=IMAGE_ID,
+        receipt_id=1,
+        line_id=line_id,
+        word_id=word_id,
+        text=text,
+        bounding_box={"x": x, "y": y, "width": w, "height": h},
+    )
+
+
+def _anchor(line_id, word_id, label):
+    return ReceiptWordLabel(
+        image_id=IMAGE_ID,
+        receipt_id=1,
+        line_id=line_id,
+        word_id=word_id,
+        label=label,
+        reasoning="test anchor",
+        timestamp_added="2026-01-01T00:00:00.000+00:00",
+        validation_status=ValidationStatus.VALID.value,
+    )
+
+
+def _trader_joes_words():
+    # y is bottom-origin (header high, totals low). Prices on the right (x~0.7).
+    return [
+        _w(1, 1, "TRADER", 0.30, 0.95),
+        _w(1, 2, "JOE'S", 0.50, 0.95),
+        _w(2, 1, "2716", 0.20, 0.90),
+        _w(2, 2, "Parkway", 0.40, 0.90),
+        # line items
+        _w(8, 1, "MILK", 0.10, 0.70),
+        _w(8, 2, "ORGANIC", 0.22, 0.70),
+        _w(8, 3, "HALF", 0.34, 0.70),
+        _w(8, 4, "GALLON", 0.44, 0.70),
+        _w(11, 1, "$4.29", 0.72, 0.70),
+        _w(9, 1, "BANANA", 0.10, 0.66),
+        _w(9, 2, "EACH", 0.24, 0.66),
+        _w(12, 1, "$1.38", 0.72, 0.66),
+        _w(10, 1, "6", 0.10, 0.63),
+        _w(10, 2, "@", 0.18, 0.63),
+        _w(10, 3, "$0.23", 0.28, 0.63),
+        # grand total
+        _w(13, 1, "$5.67", 0.72, 0.50),
+    ]
+
+
+def _proposals():
+    words = _trader_joes_words()
+    anchors = [
+        _anchor(2, 1, "ADDRESS_LINE"),
+        _anchor(2, 2, "ADDRESS_LINE"),
+        _anchor(1, 1, "MERCHANT_NAME"),
+        _anchor(13, 1, "GRAND_TOTAL"),
+    ]
+    return {(p.line_id, p.word_id): p for p in propose_line_item_labels(words, anchors)}
+
+
+def test_line_totals_recovered():
+    p = _proposals()
+    assert p[(11, 1)].label == "LINE_TOTAL"  # $4.29 (milk)
+    assert p[(12, 1)].label == "LINE_TOTAL"  # $1.38 (banana)
+
+
+def test_product_names_recovered():
+    p = _proposals()
+    assert p[(8, 1)].label == "PRODUCT_NAME"  # MILK
+    assert p[(9, 1)].label == "PRODUCT_NAME"  # BANANA
+
+
+def test_quantity_and_unit_price_from_at_row():
+    p = _proposals()
+    # "6 @ $0.23": qty is the integer before "@", unit price is the price after.
+    assert p[(10, 1)].label == "QUANTITY"
+    assert p[(10, 3)].label == "UNIT_PRICE"
+    # The single price on an "N @ $X" row is NOT a line total.
+    assert p[(10, 3)].label != "LINE_TOTAL"
+
+
+def test_arithmetic_gate_auto_validates():
+    p = _proposals()
+    # Σ(LINE_TOTAL) = 4.29 + 1.38 = 5.67 = GRAND_TOTAL -> auto-VALID.
+    line_totals = [v for v in p.values() if v.label == "LINE_TOTAL"]
+    assert line_totals
+    assert all(
+        v.validation_status == ValidationStatus.VALID.value for v in line_totals
+    )

--- a/receipt_upload/test/test_reconstructor_line_items.py
+++ b/receipt_upload/test/test_reconstructor_line_items.py
@@ -108,9 +108,9 @@ def _run_pipeline(labels=None):
     # active label for a word is its non-INVALID one (a word may carry an
     # INVALID SUBTOTAL alongside a VALID LINE_TOTAL).
     by_key = {}
-    for l in labels:
-        if l.validation_status != ValidationStatus.INVALID.value:
-            by_key[(l.line_id, l.word_id)] = l
+    for lab in labels:
+        if lab.validation_status != ValidationStatus.INVALID.value:
+            by_key[(lab.line_id, lab.word_id)] = lab
     for p in propose_line_item_labels(words, labels):
         by_key[(p.line_id, p.word_id)] = p
     return by_key
@@ -162,7 +162,7 @@ def test_locks_existing_line_total_against_llm_correction():
         ("SUBTOTAL", "LINE_TOTAL")
     ]
     # $1.38's existing LINE_TOTAL is returned for locking (so it survives the LLM).
-    assert [(l.line_id, l.word_id) for l in locked] == [(12, 1)]
+    assert [(lab.line_id, lab.word_id) for lab in locked] == [(12, 1)]
 
 
 def test_single_item_total_not_reclassified():
@@ -240,7 +240,7 @@ def test_invalid_line_total_not_locked_or_counted():
 def test_reclassification_is_arithmetic_gated_on_grand_total():
     """No GRAND_TOTAL value -> nothing to reconcile against -> no override."""
     words = _trader_joes_words()
-    labels = [l for l in _model_labels() if l.label != "GRAND_TOTAL"]
+    labels = [lab for lab in _model_labels() if lab.label != "GRAND_TOTAL"]
     assert reclassify_mislabeled_totals(words, labels) == ([], [])
 
 
@@ -261,9 +261,9 @@ def test_x_marker_in_product_or_pack_not_unit_price_row():
         _w(9, 1, "$9.99", 0.72, 0.50),
     ]
     labels = [
-        _anchor(2, 1, "ADDRESS_LINE"),
-        _anchor(1, 1, "MERCHANT_NAME"),
-        _anchor(9, 1, "GRAND_TOTAL"),
+        _label(2, 1, "ADDRESS_LINE"),
+        _label(1, 1, "MERCHANT_NAME"),
+        _label(9, 1, "GRAND_TOTAL"),
     ]
     p = {(x.line_id, x.word_id): x for x in propose_line_item_labels(words, labels)}
     assert p[(5, 3)].label == "LINE_TOTAL"
@@ -305,7 +305,7 @@ def test_human_validated_totals_never_overridden():
     """VALID (human-confirmed) SUBTOTAL/TAX are deliberate and must be left alone."""
     words = _trader_joes_words()
     labels = _model_labels()
-    for l in labels:
-        if l.label in ("SUBTOTAL", "TAX"):
-            l.validation_status = ValidationStatus.VALID.value
+    for lab in labels:
+        if lab.label in ("SUBTOTAL", "TAX"):
+            lab.validation_status = ValidationStatus.VALID.value
     assert reclassify_mislabeled_totals(words, labels) == ([], [])

--- a/receipt_upload/test/test_reconstructor_line_items.py
+++ b/receipt_upload/test/test_reconstructor_line_items.py
@@ -89,18 +89,27 @@ def _model_labels():
     ]
 
 
-def _run_pipeline():
+def _run_pipeline(labels=None):
     """Mirror the upload pipeline: reclassify mislabeled totals, then geometry."""
     words = _trader_joes_words()
-    labels = _model_labels()
+    labels = list(_model_labels() if labels is None else labels)
 
-    # Stage 1: arithmetic-gated reclassification of mislabeled SUBTOTAL/TAX.
-    for old, new in reclassify_mislabeled_totals(words, labels):
-        labels = [l for l in labels if l is not old]
+    # Stage 1: arithmetic-gated reclassification of mislabeled SUBTOTAL/TAX,
+    # plus locking the existing line totals the arithmetic confirms.
+    reclassifications, locked = reclassify_mislabeled_totals(words, labels)
+    for old, new in reclassifications:
+        old.validation_status = ValidationStatus.INVALID.value
         labels.append(new)
+    for lt in locked:
+        lt.validation_status = ValidationStatus.VALID.value
 
-    # Stage 2: geometry line-item recovery over the corrected label set.
-    by_key = {(l.line_id, l.word_id): l for l in labels}
+    # Stage 2: geometry line-item recovery over the corrected label set. The
+    # active label for a word is its non-INVALID one (a word may carry an
+    # INVALID SUBTOTAL alongside a VALID LINE_TOTAL).
+    by_key = {}
+    for l in labels:
+        if l.validation_status != ValidationStatus.INVALID.value:
+            by_key[(l.line_id, l.word_id)] = l
     for p in propose_line_item_labels(words, labels):
         by_key[(p.line_id, p.word_id)] = p
     return by_key
@@ -130,11 +139,36 @@ def test_quantity_and_unit_price_from_at_row():
     assert p[(10, 3)].label != "LINE_TOTAL"
 
 
+def test_locks_existing_line_total_against_llm_correction():
+    """Production case: the model labels one item LINE_TOTAL and the other SUBTOTAL.
+
+    Reclassify the SUBTOTAL ($4.29) and *lock* the existing LINE_TOTAL ($1.38)
+    so the LLM validator can't "correct" it to TAX (the bug observed on the live
+    IMG_2826 upload).
+    """
+    P = ValidationStatus.PENDING.value
+    labels = [
+        _label(2, 1, "ADDRESS_LINE"),
+        _label(1, 1, "MERCHANT_NAME"),
+        _label(11, 1, "SUBTOTAL", P),     # $4.29 mislabeled
+        _label(12, 1, "LINE_TOTAL", P),   # $1.38 model got this one right
+        _label(13, 1, "GRAND_TOTAL", P),
+    ]
+    words = _trader_joes_words()
+    reclassifications, locked = reclassify_mislabeled_totals(words, labels)
+    # $4.29 SUBTOTAL -> LINE_TOTAL
+    assert [(o.label, n.label) for o, n in reclassifications] == [
+        ("SUBTOTAL", "LINE_TOTAL")
+    ]
+    # $1.38's existing LINE_TOTAL is returned for locking (so it survives the LLM).
+    assert [(l.line_id, l.word_id) for l in locked] == [(12, 1)]
+
+
 def test_reclassification_is_arithmetic_gated_on_grand_total():
     """No GRAND_TOTAL value -> nothing to reconcile against -> no override."""
     words = _trader_joes_words()
     labels = [l for l in _model_labels() if l.label != "GRAND_TOTAL"]
-    assert reclassify_mislabeled_totals(words, labels) == []
+    assert reclassify_mislabeled_totals(words, labels) == ([], [])
 
 
 def test_normal_receipt_subtotal_tax_not_reclassified():
@@ -165,7 +199,7 @@ def test_normal_receipt_subtotal_tax_not_reclassified():
         _label(8, 2, "TAX", ValidationStatus.PENDING.value),
         _label(9, 2, "GRAND_TOTAL", ValidationStatus.PENDING.value),
     ]
-    assert reclassify_mislabeled_totals(words, labels) == []
+    assert reclassify_mislabeled_totals(words, labels) == ([], [])
 
 
 def test_human_validated_totals_never_overridden():
@@ -175,4 +209,4 @@ def test_human_validated_totals_never_overridden():
     for l in labels:
         if l.label in ("SUBTOTAL", "TAX"):
             l.validation_status = ValidationStatus.VALID.value
-    assert reclassify_mislabeled_totals(words, labels) == []
+    assert reclassify_mislabeled_totals(words, labels) == ([], [])

--- a/receipt_upload/test/test_semantic_proposer.py
+++ b/receipt_upload/test/test_semantic_proposer.py
@@ -1,0 +1,89 @@
+"""Tests for the semantic (Chroma kNN) PRODUCT_NAME proposer."""
+
+from types import SimpleNamespace
+
+from receipt_dynamo.constants import ValidationStatus
+from receipt_dynamo.entities import ReceiptWordLabel
+
+from receipt_upload.line_items import propose_product_names
+
+IMAGE_ID = "00000000-0000-4000-8000-000000000def"
+
+
+def _w(line_id, word_id, text, x, y):
+    return SimpleNamespace(
+        image_id=IMAGE_ID,
+        receipt_id=1,
+        line_id=line_id,
+        word_id=word_id,
+        text=text,
+        bounding_box={"x": x, "y": y, "width": 0.1, "height": 0.02},
+    )
+
+
+def _anchor(line_id, word_id, label):
+    return ReceiptWordLabel(
+        image_id=IMAGE_ID,
+        receipt_id=1,
+        line_id=line_id,
+        word_id=word_id,
+        label=label,
+        reasoning="anchor",
+        timestamp_added="2026-01-01T00:00:00.000+00:00",
+        validation_status=ValidationStatus.VALID.value,
+    )
+
+
+class _FakeClient:
+    """Returns validated PRODUCT_NAME neighbors for any query."""
+
+    def __init__(self, primary="PRODUCT_NAME"):
+        self.primary = primary
+
+    def query(self, **kwargs):
+        return {
+            "metadatas": [
+                [
+                    {"image_id": "other-1", "valid_labels_array": [self.primary]},
+                    {"image_id": "other-2", "valid_labels_array": [self.primary]},
+                    {"image_id": "other-3", "valid_labels_array": [self.primary]},
+                ]
+            ],
+            "distances": [[0.2, 0.3, 0.4]],
+        }
+
+
+def _setup():
+    words = [
+        _w(1, 1, "STORE", 0.2, 0.95),
+        _w(8, 1, "GREEK", 0.1, 0.70),     # unlabeled product (geometry missed)
+        _w(8, 2, "YOGURT", 0.22, 0.70),
+        _w(8, 3, "$5.99", 0.72, 0.70),    # money — never a product
+        _w(13, 1, "$9.99", 0.72, 0.50),
+    ]
+    anchors = [_anchor(1, 1, "STORE_HOURS"), _anchor(13, 1, "GRAND_TOTAL")]
+    embeddings = {(8, 1): [0.1] * 8, (8, 2): [0.1] * 8, (8, 3): [0.1] * 8}
+    return words, anchors, embeddings
+
+
+def test_proposes_product_name_for_unlabeled_in_band_word():
+    words, anchors, embeddings = _setup()
+    out = propose_product_names(words, anchors, _FakeClient(), embeddings)
+    keys = {(l.line_id, l.word_id): l for l in out}
+    assert (8, 1) in keys and keys[(8, 1)].label == "PRODUCT_NAME"
+    assert keys[(8, 1)].validation_status == ValidationStatus.PENDING.value
+    # money tokens are never proposed as product names
+    assert (8, 3) not in keys
+
+
+def test_skips_when_knn_majority_is_not_product():
+    words, anchors, embeddings = _setup()
+    out = propose_product_names(words, anchors, _FakeClient(primary="LINE_TOTAL"), embeddings)
+    assert out == []
+
+
+def test_does_not_propose_for_already_labeled_words():
+    words, anchors, embeddings = _setup()
+    anchors = anchors + [_anchor(8, 1, "PRODUCT_NAME")]
+    out = propose_product_names(words, anchors, _FakeClient(), embeddings)
+    assert (8, 1) not in {(l.line_id, l.word_id) for l in out}

--- a/receipt_upload/test/test_semantic_proposer.py
+++ b/receipt_upload/test/test_semantic_proposer.py
@@ -69,7 +69,7 @@ def _setup():
 def test_proposes_product_name_for_unlabeled_in_band_word():
     words, anchors, embeddings = _setup()
     out = propose_product_names(words, anchors, _FakeClient(), embeddings)
-    keys = {(l.line_id, l.word_id): l for l in out}
+    keys = {(lab.line_id, lab.word_id): lab for lab in out}
     assert (8, 1) in keys and keys[(8, 1)].label == "PRODUCT_NAME"
     assert keys[(8, 1)].validation_status == ValidationStatus.PENDING.value
     # money tokens are never proposed as product names
@@ -86,7 +86,7 @@ def test_does_not_propose_for_already_labeled_words():
     words, anchors, embeddings = _setup()
     anchors = anchors + [_anchor(8, 1, "PRODUCT_NAME")]
     out = propose_product_names(words, anchors, _FakeClient(), embeddings)
-    assert (8, 1) not in {(l.line_id, l.word_id) for l in out}
+    assert (8, 1) not in {(lab.line_id, lab.word_id) for lab in out}
 
 
 def _pending(line_id, word_id, label, status):
@@ -123,4 +123,4 @@ def test_invalid_only_word_is_still_a_candidate():
 
 
 def keys_has(out, line_id, word_id):
-    return (line_id, word_id) in {(l.line_id, l.word_id) for l in out}
+    return (line_id, word_id) in {(lab.line_id, lab.word_id) for lab in out}

--- a/receipt_upload/test/test_semantic_proposer.py
+++ b/receipt_upload/test/test_semantic_proposer.py
@@ -87,3 +87,40 @@ def test_does_not_propose_for_already_labeled_words():
     anchors = anchors + [_anchor(8, 1, "PRODUCT_NAME")]
     out = propose_product_names(words, anchors, _FakeClient(), embeddings)
     assert (8, 1) not in {(l.line_id, l.word_id) for l in out}
+
+
+def _pending(line_id, word_id, label, status):
+    return ReceiptWordLabel(
+        image_id=IMAGE_ID,
+        receipt_id=1,
+        line_id=line_id,
+        word_id=word_id,
+        label=label,
+        reasoning="model",
+        timestamp_added="2026-01-01T00:00:00.000+00:00",
+        validation_status=status,
+    )
+
+
+def test_o_label_word_is_still_a_candidate():
+    """A word carrying only a pending ``O`` label is effectively unlabeled.
+
+    The first-pass model can tag product words ``O``; those must still be open to
+    semantic PRODUCT_NAME recovery (an ``O`` label should not block this pass).
+    """
+    words, anchors, embeddings = _setup()
+    anchors = anchors + [_pending(8, 1, "O", ValidationStatus.PENDING.value)]
+    out = propose_product_names(words, anchors, _FakeClient(), embeddings)
+    assert keys_has(out, 8, 1)
+
+
+def test_invalid_only_word_is_still_a_candidate():
+    """A word whose only label is INVALID is effectively unlabeled."""
+    words, anchors, embeddings = _setup()
+    anchors = anchors + [_pending(8, 1, "PRODUCT_NAME", ValidationStatus.INVALID.value)]
+    out = propose_product_names(words, anchors, _FakeClient(), embeddings)
+    assert keys_has(out, 8, 1)
+
+
+def keys_has(out, line_id, word_id):
+    return (line_id, word_id) in {(l.line_id, l.word_id) for l in out}


### PR DESCRIPTION
## Summary

Recover the line-item labels the first-pass LayoutLM model can't produce, by combining **geometry + arithmetic + semantic search** — the three signals we validated this session. The model emits **no `PRODUCT_NAME`** at all and confuses line-item prices with `SUBTOTAL`/`TAX`; this fills the gap deterministically + semantically, gated by arithmetic, and wires it into the upload pipeline ahead of the existing Chroma/LLM validators.

Motivating case: Trader Joe's `IMG_2826` (image `9b9024dd…` on dev) — `MILK $4.29` and `BANANA $1.38` whose totals coincidentally sum to the grand total (`5.67`), with no "Subtotal"/"Tax" keyword, plus a `6 @ $0.23` quantity row.

## What changed

### Geometry — `line_items/reconstructor.py`
- **`N @ $X` rows**: the integer before `@` → `QUANTITY`, the price after `@` → `UNIT_PRICE`. A *single* price on such a row is the unit price, **not** a line total (only a second, rightmost price is the line total). Previously the unit price was mis-tagged `LINE_TOTAL` and quantity was never labeled — which also broke the arithmetic gate.
- **Anchor fix**: bottom-anchor the line-item band on `GRAND_TOTAL` (not the `SUBTOTAL`/`TAX` the model may have stamped onto the items).

### Semantic — `line_items/semantic_proposer.py` (new)
- kNN over already-validated `PRODUCT_NAME` words proposes product names geometry misses (geometry needs a price on the same row → R 0.42). **Searched UNSCOPED** — merchant-scoping *hurts* recall (0.80 → 0.73) because products are near-identical across merchants. Proposes `PENDING` for **unlabeled** in-band words only (never overrides a deliberate label); the existing validators confirm.

### Arithmetic
- The existing gate (`Σ LINE_TOTAL == receipt total → auto-VALID`) is leveraged; the qty/unit fix makes more receipts reconcile.

### Wiring — `merchant_resolution/embedding_processor.py`
- Runs the geometry proposer **and** the semantic proposer before the Chroma/LLM validators.

## Measured (487-receipt corpus; ground truth = validated DynamoDB labels)

| label | before | after |
|---|---|---|
| LINE_TOTAL | F1 0.73 (P0.78) | F1 0.74 (**P0.81**) |
| PRODUCT_NAME (geometry) | F1 0.59 (R0.42) | — |
| **PRODUCT_NAME (semantic kNN)** | — | **F1 0.84 (P0.88/R0.80)** |
| QUANTITY | **0.00** | 0.04 (P0.83) |
| UNIT_PRICE | 0.02 (P0.27) | 0.11 (**P0.75**) |
| arithmetic auto-validate | 178/360 | **195/360** |

Trader Joe's now resolves end-to-end: `$4.29`/`$1.38 → LINE_TOTAL`, `MILK`/`BANANA → PRODUCT_NAME`, `6 → QUANTITY`, `$0.23 → UNIT_PRICE`, gate passes `5.67 == 5.67`.

## Tests
- `test/test_reconstructor_line_items.py` — the Trader Joe's geometry case (qty/unit/line-total/product + arithmetic gate).
- `test/test_semantic_proposer.py` — proposes PRODUCT_NAME for unlabeled in-band words, skips money, skips when the kNN majority isn't a product, never re-labels.

## Follow-ups (not in this PR)
- **SUBTOTAL/TAX → LINE_TOTAL reclassification** for the production mislabel case (when the model stamps SUBTOTAL/TAX onto line items). This requires *overriding* an existing model label, which our financial-evaluator convention says to do only when **arithmetic proves it** — designed but deferred (the anchor fix here improves the band; full override is the next step).
- **De-duplicate the two currency-validation implementations** — the batch `label_evaluator` step function reconciles arithmetic for the viz, while the upload pipeline labels in real time, with no shared code. This corrector should ultimately live once and serve both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added semantic product-name detection to recover missing product labels.
  * Improved arithmetic-based correction to reclassify mislabeled subtotal/tax totals into line totals.
  * Enhanced parsing to recover quantity and unit price from “N @ $X” rows.
* **Tests**
  * Added regression tests covering mislabeled-total recovery, product-name proposals, quantity/unit-price extraction, and lock/guard behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->