### PR TITLE
[codex] simplify reader insight footer

### DIFF
--- a/portfolio/components/analytics/ReaderInsight.module.css
+++ b/portfolio/components/analytics/ReaderInsight.module.css
@@ -20,39 +20,9 @@
   line-height: 1.45;
 }
 
-.metrics {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-  gap: 1rem;
-  margin: 1rem 0 0;
-}
-
-.metric {
-  min-width: 0;
-  padding-left: 0.75rem;
-  border-left: 2px solid rgba(var(--text-color-rgb), 0.18);
-}
-
-.metric dt {
-  margin: 0;
-  font-size: 0.8rem;
-  font-weight: 700;
-  color: rgba(var(--text-color-rgb), 0.64);
-}
-
-.metric dd {
-  margin: 0.15rem 0 0;
-  font-size: 1rem;
-  font-weight: 700;
-}
-
 @media (max-width: 480px) {
   .readerInsight {
     margin-top: 2rem;
     padding: 1rem 1rem 0;
-  }
-
-  .metrics {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }

--- a/portfolio/components/analytics/ReaderInsight.test.tsx
+++ b/portfolio/components/analytics/ReaderInsight.test.tsx
@@ -193,9 +193,9 @@ describe("ReaderInsight", () => {
         "You reached the bottom 49% faster than the average reader."
       )
     ).toBeInTheDocument();
-    expect(screen.getByText("1m 01s")).toBeInTheDocument();
-    expect(screen.getByText("4.2 screens/min")).toBeInTheDocument();
-    expect(screen.getByText("12 reads")).toBeInTheDocument();
+    expect(screen.queryByText("Your time")).not.toBeInTheDocument();
+    expect(screen.queryByText("Active pace")).not.toBeInTheDocument();
+    expect(screen.queryByText("Average sample")).not.toBeInTheDocument();
   });
 
   test("marks short active scrolling as a quick jump and keeps fallback UI", async () => {
@@ -222,11 +222,11 @@ describe("ReaderInsight", () => {
       )
     );
 
-    expect(screen.getByText("Quick jump")).toBeInTheDocument();
-    expect(screen.getByText("Collecting")).toBeInTheDocument();
+    expect(screen.queryByText("Quick jump")).not.toBeInTheDocument();
+    expect(screen.queryByText("Collecting")).not.toBeInTheDocument();
     expect(
       screen.getByText(
-        "You reached the bottom in 2s. The average will appear here after a few completed reads."
+        "You reached the bottom in 2s. The average will appear here after 5 previous completed reads."
       )
     ).toBeInTheDocument();
   });

--- a/portfolio/components/analytics/ReaderInsight.tsx
+++ b/portfolio/components/analytics/ReaderInsight.tsx
@@ -98,7 +98,7 @@ function getComparisonText(
   if (!usableBaseline?.averageTimeToBottomMs) {
     return `You reached the bottom in ${formatDuration(
       result.timeToBottomMs
-    )}. The average will appear here after a few completed reads.`;
+    )}. The average will appear here after 5 previous completed reads.`;
   }
 
   const deltaPercent = Math.round(
@@ -117,14 +117,6 @@ function getComparisonText(
   const direction = deltaPercent > 0 ? "faster" : "slower";
 
   return `You reached the bottom ${absoluteDelta}% ${direction} than the average reader.`;
-}
-
-function getPaceText(result: ReaderResult): string {
-  if (result.quickJump) {
-    return "Quick jump";
-  }
-
-  return `${result.screensPerMinute.toFixed(1)} screens/min`;
 }
 
 export default function ReaderInsight() {
@@ -321,7 +313,6 @@ export default function ReaderInsight() {
   const comparisonText = result
     ? getComparisonText(result, effectiveBaseline)
     : "Calculating your read.";
-  const baselineSampleSize = effectiveBaseline?.sampleSize ?? 0;
 
   return (
     <section
@@ -331,30 +322,6 @@ export default function ReaderInsight() {
     >
       <p className={styles.label}>Reading pace</p>
       <p className={styles.summary}>{comparisonText}</p>
-      {result && (
-        <dl className={styles.metrics}>
-          <div className={styles.metric}>
-            <dt>Your time</dt>
-            <dd>{formatDuration(result.timeToBottomMs)}</dd>
-          </div>
-          <div className={styles.metric}>
-            <dt>Active pace</dt>
-            <dd>{getPaceText(result)}</dd>
-          </div>
-          <div className={styles.metric}>
-            <dt>This session</dt>
-            <dd>{result.sessionPageViews} pages</dd>
-          </div>
-          <div className={styles.metric}>
-            <dt>Average sample</dt>
-            <dd>
-              {baselineSampleSize >= MIN_BASELINE_SAMPLE_SIZE
-                ? `${baselineSampleSize} reads`
-                : "Collecting"}
-            </dd>
-          </div>
-        </dl>
-      )}
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- remove the metric grid under the reader insight sentence
- keep the reader-summary analytics payload unchanged
- replace the vague "few completed reads" copy with the actual threshold: 5 previous completed reads

## Notes
The frontend and Lambda both require a minimum sample size of 5. Because the Lambda compares a visitor against the baseline that existed before that visitor's submission, the first live percentage comparison appears once there are 5 previous valid completed reads for that page.

## Validation
- `npm test -- ReaderInsight.test.tsx --runInBand`
- `npx eslint components/analytics/ReaderInsight.tsx components/analytics/ReaderInsight.test.tsx`
- `git diff --check`

Jest still prints the existing async baseline-fetch `act(...)` warning, but the focused suite passes.