### PR TITLE
fix(chroma): stop words-compaction DLQ from eating throttled messages (#990)

### DIFF
--- a/infra/chromadb_compaction/components/sqs_queues.py
+++ b/infra/chromadb_compaction/components/sqs_queues.py
@@ -151,9 +151,15 @@ class ChromaDBQueues(ComponentResource):
             # Visibility timeout must be >= Lambda timeout per AWS requirements.
             visibility_timeout_seconds=900,
             receive_wait_time_seconds=20,  # Long polling
+            # High maxReceiveCount so the INTENDED back-pressure works: the
+            # consumer is deliberately concurrency-limited (reserved=2), so SQS
+            # throttles polls when no slot is free — and each throttled poll
+            # increments ApproximateReceiveCount. With maxReceiveCount=10 those
+            # throttle-bounces dead-lettered messages before they ever got a
+            # processing slot. A high cap lets them wait for a slot instead.
             redrive_policy=Output.all(self.lines_dlq.arn).apply(
                 lambda args: json.dumps(
-                    {"deadLetterTargetArn": args[0], "maxReceiveCount": 10}
+                    {"deadLetterTargetArn": args[0], "maxReceiveCount": 1000}
                 )
             ),
             tags={
@@ -171,9 +177,14 @@ class ChromaDBQueues(ComponentResource):
             message_retention_seconds=345600,  # 4 days
             visibility_timeout_seconds=900,
             receive_wait_time_seconds=20,  # Long polling
+            # See lines_queue: high cap so throttle-bounces don't dead-letter
+            # before a slot opens. The words queue is where this bit hard — a
+            # bulk delete/label-revalidation flood (one stream message per
+            # word/label change) throttle-bounced ~12k messages into the DLQ
+            # without ever being processed. See issue #990.
             redrive_policy=Output.all(self.words_dlq.arn).apply(
                 lambda args: json.dumps(
-                    {"deadLetterTargetArn": args[0], "maxReceiveCount": 10}
+                    {"deadLetterTargetArn": args[0], "maxReceiveCount": 1000}
                 )
             ),
             tags={


### PR DESCRIPTION
Addresses #990.

## What

Raise `maxReceiveCount` 10 → 1000 on the lines/words compaction queue redrive policies (`infra/chromadb_compaction/components/sqs_queues.py`).

## Why

The compaction consumer is intentionally concurrency-limited (`reserved_concurrent_executions=2`). SQS throttles polls when no slot is free — the design's intended back-pressure — but **each throttled poll increments `ApproximateReceiveCount`**. With `maxReceiveCount=10`, throttle-bounces dead-lettered messages **before they ever got a processing slot**.

A bulk word-delete + label-revalidation flood (one stream message per word/label change) throttle-bounced **~12k words messages into the DLQ unprocessed**, leaving many `CompactionRun.words_state` stuck `PENDING` and Chroma drifted from DynamoDB (which stays correct).

Raising the cap lets throttled messages **wait for a slot** (as the design intended) instead of dying.

## Not included (tracked in #990)

- Root fix: coalesce compaction messages **per-receipt** instead of one-per-word/label-change, so bulk deletes/revalidations stop generating O(words) messages.
- Dedicated words concurrency.
- Draining/purging the existing 12k DLQ + rebuilding the drifted words collection from DynamoDB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience of message queue processing during high-traffic periods by adjusting retry thresholds to reduce premature message failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->