### PR TITLE
[codex] add receipt font analysis pilots

### DIFF
--- a/docs/receipt-font-analysis-pilot.md
+++ b/docs/receipt-font-analysis-pilot.md
@@ -1,0 +1,185 @@
+# Receipt Font Analysis Pilot
+
+Date: 2026-06-22
+
+## Scope
+
+Ran the new OCR geometry + raw image pixel font clustering prototype against prod receipt rows whose `RECEIPT.raw_s3_*` objects are known to exist.
+
+Code used:
+
+- `receipt_upload/receipt_upload/font_analysis.py`
+- Main function: `analyze_receipt_fonts(...)`
+
+This pilot used receipt-level OCR:
+
+- `ReceiptLine`
+- `ReceiptWord`
+- `ReceiptLetter`
+- raw receipt crop image from S3
+
+## Important Caveat
+
+This does not identify real font family names like Helvetica, Arial, OCR-B, etc. It identifies relative font-style groups from OCR geometry and image pixels:
+
+- relative text size
+- condensed/normal/wide glyph shape
+- uppercase/numeric/mixed text style
+- ink density and crop texture
+- similarity between word-level embeddings
+
+To infer actual typeface names, we would need a reference library of known fonts rendered into comparable word crops, then compare receipt clusters against those reference embeddings.
+
+## Section Mapping
+
+The sample did not have persisted `ReceiptSection` entities:
+
+```text
+persisted_section_entities_seen=0 out of 30 analysed receipts
+```
+
+So section-level results below use a heuristic mapper:
+
+- `header`: top receipt lines and merchant-like top text
+- `line_items`: middle lines with price-like values
+- `totals_payments`: lines with total/tax/payment/card/cash keywords
+- `footer`: bottom receipt lines
+- `body_other`: remaining middle/body lines
+
+For production use, this should be replaced with persisted `ReceiptSection` entities or a dedicated section classifier.
+
+## Pilot Results
+
+Prod sample:
+
+```text
+analysed_receipts=30
+errors=0
+total_word_style_samples=2737
+total_clusters=445
+total_noise_samples=1007
+median_samples_per_receipt=77.5
+median_clusters_per_receipt=15.0
+```
+
+Default clustering radius was `eps=2.2`. That worked but over-segmented receipt crops.
+
+Global top cluster labels:
+
+| Cluster label | Assigned samples |
+|---|---:|
+| `regular wide mixed` | 815 |
+| `regular normal mixed` | 266 |
+| `regular condensed mixed` | 213 |
+| `regular wide uppercase` | 105 |
+| `regular wide numeric` | 48 |
+| `small wide mixed` | 43 |
+| `small normal mixed` | 34 |
+| `large condensed mixed` | 30 |
+| `small wide punctuated` | 20 |
+| `large condensed uppercase` | 19 |
+
+## Patterns By Section
+
+At `eps=2.2`, section-level assignments looked like this:
+
+| Heuristic section | Samples | Avg size ratio | Avg ink ratio | Avg aspect | Most common style labels |
+|---|---:|---:|---:|---:|---|
+| `body_other` | 785 | 1.099 | 0.125 | 1.270 | `regular wide mixed`, `regular condensed mixed`, `regular normal mixed`, `regular wide uppercase`, `regular wide numeric` |
+| `footer` | 319 | 1.041 | 0.126 | 1.267 | `regular wide mixed`, `regular normal mixed`, `regular condensed mixed`, `small wide mixed`, `small wide punctuated` |
+| `header` | 271 | 1.100 | 0.121 | 1.079 | `regular wide mixed`, `regular condensed mixed`, `regular normal mixed`, `regular wide uppercase`, `regular wide numeric` |
+| `totals_payments` | 242 | 1.040 | 0.127 | 1.078 | `regular wide mixed`, `regular normal mixed`, `regular wide uppercase`, `regular condensed mixed`, `regular normal uppercase` |
+| `line_items` | 113 | 1.022 | 0.112 | 1.193 | `regular wide mixed`, `regular normal mixed`, `small wide mixed`, `large wide numeric`, `small normal mixed` |
+
+Interpretation:
+
+- Body, footer, and line-item text are often the same base receipt font style.
+- Header and totals/payment sections show more uppercase/numeric variants, but still often share the same base receipt font.
+- Distinct visual styles do show up when present, for example large uppercase recall notices, small punctuated separator rows, numeric price clusters, and authorization/payment footer text.
+- Section-level mapping is feasible, but the section labels are currently heuristic.
+
+## Parameter Check
+
+I reran a smaller 10-receipt subset across several DBSCAN radii.
+
+| `eps` | Median clusters/receipt | Median noise samples | Noise rate | Avg cluster section purity |
+|---:|---:|---:|---:|---:|
+| 2.2 | 14.0 | 31.0 | 0.33 | 0.85 |
+| 2.6 | 11.5 | 18.5 | 0.23 | 0.83 |
+| 3.0 | 6.5 | 10.5 | 0.17 | 0.82 |
+| 3.4 | 5.0 | 9.0 | 0.13 | 0.81 |
+
+Recommendation:
+
+- Use `eps=3.0` for receipt-level crop analysis.
+- Keep `eps=2.2` available for finer-grained inspection of one receipt at a time.
+
+`eps=3.0` keeps nearly the same section purity while substantially reducing over-segmentation and noise.
+
+## Example Observations
+
+From one receipt with a recall block:
+
+```text
+image=6539deb9-52cc-49a0-81a0-3a64989bee49
+receipt=4
+lines=83
+words=217
+letters=1260
+samples=207
+clusters=19
+```
+
+Notable clusters included:
+
+- `regular normal mixed`: main body/receipt text, 102 samples
+- `regular wide mixed`: fuel points and footer/body explanatory text, 20 samples
+- `small wide mixed`: header/body/totals smaller text, 17 samples
+- `small wide punctuated`: separator/star rows, 5 samples
+- `large wide uppercase`: `RECALL NOTICE`, 4 samples
+
+This is the clearest evidence that the method can separate distinctive section-specific visual text styles.
+
+## Can We Find Fonts Used In Receipt Sections?
+
+Yes, with the current prototype we can find font-style clusters and attach them to receipt sections.
+
+What works now:
+
+- Find repeated style groups within a receipt.
+- Attach each OCR word to a style cluster.
+- Summarize which style clusters appear in header, item lines, totals/payment, footer, and body.
+- Find visually similar words via embedding similarity.
+- Detect distinctive styles such as large uppercase notices, numeric price blocks, small footer/legal text, and separator/punctuation rows.
+
+What does not work yet:
+
+- Exact typeface names.
+- Stable cross-merchant global font IDs.
+- Reliable section labels without a real section source.
+
+## Recommended Next Step
+
+Run a full prod pass using:
+
+```python
+analyze_receipt_fonts(
+    receipt_letters,
+    words=receipt_words,
+    lines=receipt_lines,
+    raw_image=receipt_image,
+    eps=3.0,
+    min_samples=2,
+    min_letters_per_sample=2,
+)
+```
+
+For image loading, use this order:
+
+1. `RECEIPT.raw_s3_*` if the raw receipt crop exists.
+2. receipt full-size CDN image if the receipt raw crop is missing.
+3. parent `IMAGE.raw_s3_*` plus receipt geometry when analysing from the original uploaded photo.
+4. parent image full-size CDN fallback if the parent raw image is missing.
+
+For section mapping, prefer persisted `ReceiptSection` entities if they are available. If not, use a receipt section classifier before treating section-level font assignments as production-quality.
+

--- a/docs/receipt-image-s3-damage-audit.md
+++ b/docs/receipt-image-s3-damage-audit.md
@@ -1,0 +1,131 @@
+# Receipt Image S3 Damage Audit
+
+Date: 2026-06-22
+
+## Scope
+
+Audited all live DynamoDB `IMAGE` and `RECEIPT` rows in:
+
+- dev table: `ReceiptsTable-dc5be22`
+- prod table: `ReceiptsTable-d7ff76a`
+
+For each row, I checked whether the referenced raw S3 object exists using S3 `HeadObject`. For rows whose raw object was missing, I also checked the Dynamo CDN fields:
+
+- full-size: `cdn_s3_key`, `cdn_webp_s3_key`, `cdn_avif_s3_key`
+- thumbnail, small, and medium variants for JPEG/WebP/AVIF
+
+## Summary
+
+| Environment | Entity | Rows | Raw S3 missing | Raw missing rate | Recovery status |
+|---|---:|---:|---:|---:|---|
+| dev | `IMAGE` originals | 583 | 0 | 0.0% | All original raw uploads exist |
+| dev | `RECEIPT` crops | 738 | 160 | 21.7% | All missing raw crops have full CDN copies; all parent originals exist |
+| prod | `IMAGE` originals | 490 | 25 | 5.1% | All missing raw originals have full CDN copies |
+| prod | `RECEIPT` crops | 649 | 117 | 18.0% | All missing raw crops have full CDN copies |
+
+Across both tables:
+
+- Total rows audited: 2,460
+- Row-level missing raw S3 references: 302
+- Unique missing raw S3 objects: 192
+
+The row/object difference is because dev and prod share many of the same missing `upload-images-image-bucket-4bcea7e/receipts/...` receipt crop keys.
+
+## Main Findings
+
+The damage is real S3 `404`, not missing Dynamo metadata. All affected rows have bucket/key values.
+
+The biggest issue is missing generated receipt crop raw files under:
+
+```text
+s3://upload-images-image-bucket-4bcea7e/receipts/...
+```
+
+These are concentrated in May and June 2026:
+
+- dev missing receipt crops: 87 from 2026-05, 69 from 2026-06, 4 from 2026-02
+- prod missing receipt crops: 81 from 2026-05, 36 from 2026-06
+
+Prod also has missing original raw upload objects:
+
+- 21 old originals in `s3://raw-image-bucket-0facc78/raw/...` from 2025-02
+- 4 newer originals in `s3://upload-images-image-bucket-4bcea7e/raw-receipts/...` from 2026-06
+
+## Recoverability
+
+Every missing raw object checked has CDN artifacts available.
+
+For each missing row, all 12 CDN variants existed:
+
+- full JPEG
+- full WebP
+- full AVIF
+- thumbnail JPEG/WebP/AVIF
+- small JPEG/WebP/AVIF
+- medium JPEG/WebP/AVIF
+
+That means none of the audited rows are completely image-less. The raw source object may be gone, but a full-size derived image still exists.
+
+## Parent Image Correlation
+
+For missing `RECEIPT.raw_s3_*` rows:
+
+- dev: 160 missing receipt crops, all 160 parent `IMAGE.raw_s3_*` objects exist
+- prod: 117 missing receipt crops; 113 parent `IMAGE.raw_s3_*` objects exist, 4 parent raw originals are also missing
+
+The 4 prod receipt rows whose parent raw image is also missing are:
+
+| Date | Image ID | Receipt ID |
+|---|---|---:|
+| 2026-06-15 | `5578d3d6-d036-421f-8b42-8cc143b62ab4` | 1 |
+| 2026-06-15 | `5ff2d6b4-0ca8-4903-a428-e70236f422d3` | 1 |
+| 2026-06-15 | `9942d0ed-a516-4d2b-9a99-900481d57767` | 1 |
+| 2026-06-15 | `b9800d3c-bd5f-4246-861c-b07ac6247756` | 1 |
+
+Those four still have full CDN copies for both the image row and receipt row.
+
+## Implications For Font Analysis
+
+For font/style clustering, avoid assuming `RECEIPT.raw_s3_*` exists.
+
+Recommended lookup order:
+
+1. Use parent `IMAGE.raw_s3_*` when available, with OCR geometry to crop the text regions.
+2. If the parent raw image is missing, use the image full-size CDN object.
+3. If analyzing receipt-level crops, use `RECEIPT.raw_s3_*` only when it exists.
+4. If `RECEIPT.raw_s3_*` is missing, fall back to the receipt full-size CDN object.
+
+This is enough for the ML-style font clustering work because the current method can use OCR letter/word geometry plus pixel features from whatever full-size image artifact is available.
+
+## Likely Cause Pattern
+
+The missing receipt crops are not randomly distributed. They are all in the newer upload bucket and cluster heavily in May and June 2026. That points toward a recent upload/cleanup/migration issue around generated receipt crop raw objects, not an OCR segmentation issue and not a general S3 permission issue.
+
+## Raw Counts
+
+```text
+dev IMAGE:
+  records=583
+  ok=583
+  missing_object=0
+  missing_field=0
+
+dev RECEIPT:
+  records=738
+  ok=578
+  missing_object=160
+  missing_field=0
+
+prod IMAGE:
+  records=490
+  ok=465
+  missing_object=25
+  missing_field=0
+
+prod RECEIPT:
+  records=649
+  ok=532
+  missing_object=117
+  missing_field=0
+```
+

--- a/docs/receipt-letter-font-chroma-pilot.json
+++ b/docs/receipt-letter-font-chroma-pilot.json
@@ -27,17 +27,7 @@
         "header": 944,
         "line_items": 222,
         "totals_payments": 777
-      },
-      "text_examples": [
-        "T",
-        "a",
-        "6",
-        ",",
-        "2",
-        "0",
-        "2",
-        "6"
-      ]
+      }
     },
     {
       "avg_box_height": 0.01069,
@@ -65,17 +55,7 @@
         "footer": 14,
         "header": 8,
         "totals_payments": 5
-      },
-      "text_examples": [
-        "a",
-        "a",
-        "d",
-        "0",
-        "9",
-        "a",
-        "#",
-        "o"
-      ]
+      }
     },
     {
       "avg_box_height": 0.01067,
@@ -103,17 +83,7 @@
         "footer": 10,
         "header": 5,
         "totals_payments": 8
-      },
-      "text_examples": [
-        "1",
-        "S",
-        "C",
-        "A",
-        "T",
-        "L",
-        "T",
-        "l"
-      ]
+      }
     },
     {
       "avg_box_height": 0.00943,
@@ -129,17 +99,7 @@
       "sections": {
         "body_other": 22,
         "footer": 8
-      },
-      "text_examples": [
-        "*",
-        "*",
-        "*",
-        "*",
-        "*",
-        "*",
-        "*",
-        "*"
-      ]
+      }
     },
     {
       "avg_box_height": 0.02041,
@@ -163,17 +123,7 @@
         "footer": 2,
         "header": 1,
         "totals_payments": 2
-      },
-      "text_examples": [
-        "E",
-        "g",
-        "d",
-        "A",
-        "e",
-        "R",
-        "4",
-        "e"
-      ]
+      }
     },
     {
       "avg_box_height": 0.0093,
@@ -189,17 +139,7 @@
       "sections": {
         "body_other": 6,
         "footer": 2
-      },
-      "text_examples": [
-        "*",
-        "*",
-        "*",
-        "*",
-        "*",
-        "*",
-        "4",
-        "*"
-      ]
+      }
     },
     {
       "avg_box_height": 0.01096,
@@ -218,17 +158,7 @@
       "sections": {
         "body_other": 5,
         "footer": 3
-      },
-      "text_examples": [
-        "8",
-        "g",
-        "p",
-        "B",
-        "e",
-        "e",
-        "g",
-        "e"
-      ]
+      }
     },
     {
       "avg_box_height": 0.0228,
@@ -249,15 +179,7 @@
         "footer": 2,
         "line_items": 1,
         "totals_payments": 1
-      },
-      "text_examples": [
-        "e",
-        "9",
-        "g",
-        "o",
-        "e",
-        "h"
-      ]
+      }
     }
   ],
   "errors": [],
@@ -277,17 +199,7 @@
         "header": 32,
         "line_items": 9,
         "totals_payments": 35
-      },
-      "text_examples": [
-        "Cafe does not cover",
-        "additional",
-        "costs for",
-        "Application ID",
-        "$1.52",
-        "$3.15",
-        "+ 2%: (Tip $0.42 Total $22.94)",
-        "* 3%: (Tip $0.63"
-      ]
+      }
     },
     {
       "avg_dominant_letter_cluster_ratio": 0.65042,
@@ -304,17 +216,7 @@
         "header": 3,
         "line_items": 4,
         "totals_payments": 7
-      },
-      "text_examples": [
-        "180 Promenade Way",
-        "Ordered:",
-        "ESPRESSO",
-        "VISA DEBIT",
-        "Approval Code",
-        "Application ID",
-        "Card Reader",
-        "$4.80"
-      ]
+      }
     },
     {
       "avg_dominant_letter_cluster_ratio": 0.66003,
@@ -329,17 +231,7 @@
         "body_other": 5,
         "footer": 2,
         "header": 1
-      },
-      "text_examples": [
-        "Server: Lachlan B",
-        "C (EMV Chip Read)",
-        "Food & Drinks: For",
-        "regarding food and drink",
-        "Retail & Clothing: All",
-        "receive an incorrect or",
-        "days with photos of the",
-        "to be unworn, unwashed, and"
-      ]
+      }
     },
     {
       "avg_dominant_letter_cluster_ratio": 0.97,
@@ -352,14 +244,7 @@
       "line_count": 5,
       "sections": {
         "footer": 5
-      },
-      "text_examples": [
-        "****************************************",
-        "****************************************",
-        "**********",
-        "******",
-        "****************************************"
-      ]
+      }
     },
     {
       "avg_dominant_letter_cluster_ratio": 1.0,
@@ -372,12 +257,7 @@
       "line_count": 3,
       "sections": {
         "line_items": 3
-      },
-      "text_examples": [
-        "$4.80",
-        "$0.96",
-        "$21.00"
-      ]
+      }
     },
     {
       "avg_dominant_letter_cluster_ratio": 0.62222,
@@ -390,12 +270,7 @@
       "line_count": 3,
       "sections": {
         "body_other": 3
-      },
-      "text_examples": [
-        "************2777",
-        "********************",
-        "+ Tip::"
-      ]
+      }
     },
     {
       "avg_dominant_letter_cluster_ratio": 0.74074,
@@ -409,12 +284,7 @@
       "sections": {
         "body_other": 1,
         "totals_payments": 2
-      },
-      "text_examples": [
-        "TOTAL:",
-        "GRATUITY:",
-        "TOTAL:"
-      ]
+      }
     },
     {
       "avg_dominant_letter_cluster_ratio": 0.87202,
@@ -428,12 +298,7 @@
       "sections": {
         "body_other": 2,
         "header": 1
-      },
-      "text_examples": [
-        "Main St Provisions",
-        "Las Vegas, NU 89109",
-        "Server: Makella"
-      ]
+      }
     },
     {
       "avg_dominant_letter_cluster_ratio": 0.875,
@@ -446,11 +311,7 @@
       "line_count": 2,
       "sections": {
         "header": 2
-      },
-      "text_examples": [
-        "Lava",
-        "band"
-      ]
+      }
     },
     {
       "avg_dominant_letter_cluster_ratio": 0.8125,
@@ -463,11 +324,7 @@
       "line_count": 2,
       "sections": {
         "totals_payments": 2
-      },
-      "text_examples": [
-        "Subtotal",
-        "Subtotal"
-      ]
+      }
     },
     {
       "avg_dominant_letter_cluster_ratio": 0.7,
@@ -480,11 +337,7 @@
       "line_count": 2,
       "sections": {
         "totals_payments": 2
-      },
-      "text_examples": [
-        "Total",
-        "Total"
-      ]
+      }
     },
     {
       "avg_dominant_letter_cluster_ratio": 0.96875,
@@ -497,11 +350,7 @@
       "line_count": 2,
       "sections": {
         "body_other": 2
-      },
-      "text_examples": [
-        "items, please",
-        "item, please email"
-      ]
+      }
     },
     {
       "avg_dominant_letter_cluster_ratio": 0.94077,
@@ -514,11 +363,7 @@
       "line_count": 2,
       "sections": {
         "body_other": 2
-      },
-      "text_examples": [
-        "info@lalalandkindcafe.com.",
-        "shop@lalalandkindcafe.com"
-      ]
+      }
     },
     {
       "avg_dominant_letter_cluster_ratio": 0.96667,
@@ -532,11 +377,7 @@
       "sections": {
         "body_other": 1,
         "header": 1
-      },
-      "text_examples": [
-        "Zen Leaf Las Vegas",
-        "RECEIPT 86233955"
-      ]
+      }
     },
     {
       "avg_dominant_letter_cluster_ratio": 0.9,
@@ -549,11 +390,7 @@
       "line_count": 2,
       "sections": {
         "line_items": 2
-      },
-      "text_examples": [
-        "$2.79",
-        "$2.34"
-      ]
+      }
     },
     {
       "avg_dominant_letter_cluster_ratio": 0.50505,
@@ -567,11 +404,7 @@
       "sections": {
         "body_other": 1,
         "line_items": 1
-      },
-      "text_examples": [
-        "1 \u20ac 99/0.00",
-        "*******0658"
-      ]
+      }
     },
     {
       "avg_dominant_letter_cluster_ratio": 0.80808,
@@ -585,11 +418,7 @@
       "sections": {
         "body_other": 1,
         "totals_payments": 1
-      },
-      "text_examples": [
-        "Annual Card Savings $0.00",
-        "You nay have purchased a product"
-      ]
+      }
     },
     {
       "avg_dominant_letter_cluster_ratio": 0.55556,
@@ -602,11 +431,7 @@
       "line_count": 2,
       "sections": {
         "body_other": 2
-      },
-      "text_examples": [
-        "*********",
-        "******************"
-      ]
+      }
     },
     {
       "avg_dominant_letter_cluster_ratio": 0.29167,
@@ -620,11 +445,7 @@
       "sections": {
         "body_other": 1,
         "footer": 1
-      },
-      "text_examples": [
-        "************",
-        "******"
-      ]
+      }
     },
     {
       "avg_dominant_letter_cluster_ratio": 0.83333,
@@ -637,11 +458,7 @@
       "line_count": 2,
       "sections": {
         "header": 2
-      },
-      "text_examples": [
-        "- APPROVED",
-        "- APPROVED"
-      ]
+      }
     }
   ],
   "line_eps_sweep": [
@@ -693,14 +510,14 @@
       "dominant_cluster_share": 0.6811594202898551,
       "section": "body_other",
       "top_cluster_ids": {
+        "13": 3,
+        "15": 2,
+        "19": 2,
         "2": 20,
         "3": 5,
         "7": 2,
         "8": 2,
-        "9": 94,
-        "13": 3,
-        "15": 2,
-        "19": 2
+        "9": 94
       },
       "top_cluster_labels": {
         "large-line normal light tight": 1,
@@ -720,12 +537,12 @@
       "dominant_cluster_share": 0.7142857142857143,
       "section": "totals_payments",
       "top_cluster_ids": {
+        "14": 1,
+        "17": 2,
         "2": 7,
         "4": 2,
         "5": 2,
-        "9": 35,
-        "14": 1,
-        "17": 2
+        "9": 35
       },
       "top_cluster_labels": {
         "large-line normal light tight": 2,
@@ -743,14 +560,14 @@
       "dominant_cluster_share": 0.6530612244897959,
       "section": "footer",
       "top_cluster_ids": {
-        "2": 4,
-        "3": 2,
-        "9": 32,
         "16": 1,
+        "2": 4,
         "20": 5,
         "21": 2,
         "22": 2,
-        "25": 1
+        "25": 1,
+        "3": 2,
+        "9": 32
       },
       "top_cluster_labels": {
         "large-line wide medium tight": 32,
@@ -770,12 +587,12 @@
       "section": "header",
       "top_cluster_ids": {
         "1": 2,
-        "2": 3,
-        "3": 1,
-        "9": 32,
         "10": 1,
         "18": 2,
-        "24": 1
+        "2": 3,
+        "24": 1,
+        "3": 1,
+        "9": 32
       },
       "top_cluster_labels": {
         "large-line wide medium tight": 34,
@@ -794,12 +611,12 @@
       "dominant_cluster_share": 0.42857142857142855,
       "section": "line_items",
       "top_cluster_ids": {
-        "2": 4,
-        "6": 3,
-        "9": 9,
         "11": 2,
         "12": 1,
-        "23": 2
+        "2": 4,
+        "23": 2,
+        "6": 3,
+        "9": 9
       },
       "top_cluster_labels": {
         "large-line wide medium tight": 9,
@@ -811,327 +628,135 @@
   ],
   "receipt_summaries": [
     {
-      "bottom_lines": [
-        "$24.33",
-        "Total",
-        "$24.33",
-        "Visa 1454 (Contactless)"
-      ],
-      "date": "2026-05-26",
       "embedded_letter_count": 258,
-      "image_id": "fc408bf9-7b71-401d-ab5b-cd508fb2db3b",
       "image_size": [
         405,
         666
       ],
       "letter_count": 258,
       "line_count": 28,
-      "raw_s3_bucket": "raw-image-bucket-0facc78",
-      "raw_s3_key": "raw/fc408bf9-7b71-401d-ab5b-cd508fb2db3b_RECEIPT_00003.png",
-      "receipt_id": 3,
-      "top_lines": [
-        "GT Poke",
-        "8610 Spring Mountain Rd",
-        "May 6, 2026",
-        "6:13 PM"
-      ],
+      "receipt_index": 1,
       "word_count": 57
     },
     {
-      "bottom_lines": [
-        "I agree to pay above total",
-        "amount according to my card",
-        "ssuer agreement'",
-        "issuer agreement"
-      ],
-      "date": "2026-05-21",
       "embedded_letter_count": 459,
-      "image_id": "c137dfd9-351c-4d4e-9dae-7950ab7db753",
       "image_size": [
         883,
         1120
       ],
       "letter_count": 462,
       "line_count": 57,
-      "raw_s3_bucket": "raw-image-bucket-0facc78",
-      "raw_s3_key": "raw/c137dfd9-351c-4d4e-9dae-7950ab7db753_RECEIPT_00003.png",
-      "receipt_id": 3,
-      "top_lines": [
-        "03/30/26",
-        "03/30/26",
-        "SALES DRAFT",
-        "Carousel"
-      ],
+      "receipt_index": 2,
       "word_count": 86
     },
     {
-      "bottom_lines": [
-        "total amount according to the",
-        "card issuer agreement.",
-        "Thank you and Come Again",
-        "** PLEASE SIGN **"
-      ],
-      "date": "2026-05-21",
       "embedded_letter_count": 392,
-      "image_id": "9167c199-8808-487c-a55b-ea065ee336e5",
       "image_size": [
         771,
         1002
       ],
       "letter_count": 392,
       "line_count": 35,
-      "raw_s3_bucket": "raw-image-bucket-0facc78",
-      "raw_s3_key": "raw/9167c199-8808-487c-a55b-ea065ee336e5_RECEIPT_00005.png",
-      "receipt_id": 5,
-      "top_lines": [
-        "Main St Provisions",
-        "1214 S Main St.",
-        "Las Vegas, NV 89109",
-        "(702) 457-0111"
-      ],
+      "receipt_index": 3,
       "word_count": 80
     },
     {
-      "bottom_lines": [
-        "58.53",
-        "Balance Due",
-        "58.53",
-        "Thank you and Come Again"
-      ],
-      "date": "2026-05-21",
       "embedded_letter_count": 292,
-      "image_id": "fb44b8a7-1a34-40c6-9f2b-011665b20f88",
       "image_size": [
         656,
         980
       ],
       "letter_count": 292,
       "line_count": 34,
-      "raw_s3_bucket": "raw-image-bucket-0facc78",
-      "raw_s3_key": "raw/fb44b8a7-1a34-40c6-9f2b-011665b20f88_RECEIPT_00005.png",
-      "receipt_id": 5,
-      "top_lines": [
-        "2026",
-        "/2026",
-        "40006",
-        "097153"
-      ],
+      "receipt_index": 4,
       "word_count": 60
     },
     {
-      "bottom_lines": [
-        "Total pald:",
-        "$35.00",
-        "Change due:",
-        "$1.95"
-      ],
-      "date": "2026-05-21",
       "embedded_letter_count": 556,
-      "image_id": "5b1ea5d7-4f9e-44ff-9802-6c7ff11194a6",
       "image_size": [
         407,
         923
       ],
       "letter_count": 556,
       "line_count": 43,
-      "raw_s3_bucket": "raw-image-bucket-0facc78",
-      "raw_s3_key": "raw/5b1ea5d7-4f9e-44ff-9802-6c7ff11194a6_RECEIPT_00003.png",
-      "receipt_id": 3,
-      "top_lines": [
-        "Zen Leaf Las Vegas",
-        "5335 South Fort Apache Road, Las Vegas,",
-        "Nevada, United States",
-        "support-nv@zenleafdispensaries.com"
-      ],
+      "receipt_index": 5,
       "word_count": 85
     },
     {
-      "bottom_lines": [
-        "4*744*****",
-        "******",
-        "RECALL NOTICE",
-        "You mau run nurchased a productor"
-      ],
-      "date": "2026-05-21",
       "embedded_letter_count": 1260,
-      "image_id": "6539deb9-52cc-49a0-81a0-3a64989bee49",
       "image_size": [
         634,
         1081
       ],
       "letter_count": 1260,
       "line_count": 83,
-      "raw_s3_bucket": "raw-image-bucket-0facc78",
-      "raw_s3_key": "raw/6539deb9-52cc-49a0-81a0-3a64989bee49_RECEIPT_00004.png",
-      "receipt_id": 4,
-      "top_lines": [
-        "HEALTH",
-        "0940601",
-        "094030-",
-        "194058"
-      ],
+      "receipt_index": 6,
       "word_count": 217
     },
     {
-      "bottom_lines": [
-        "the method of payment used.",
-        "original receipt, th",
-        "ipt. Limits apply to",
-        "without a recei"
-      ],
-      "date": "2026-02-06",
       "embedded_letter_count": 302,
-      "image_id": "ff649c4b-5c31-4247-b78c-d9b0c56610ad",
       "image_size": [
         768,
         879
       ],
       "letter_count": 302,
       "line_count": 18,
-      "raw_s3_bucket": "upload-images-image-bucket-4bcea7e",
-      "raw_s3_key": "receipts/ff649c4b-5c31-4247-b78c-d9b0c56610ad/receipt_ 7-3a26c6b2-9799-47fb-ab15-397ea4d07152_RECEIPT_00001.png",
-      "receipt_id": 1,
-      "top_lines": [
-        "How was your visit?",
-        "Let us know at SproutsFeedback.com",
-        "so we can grow and improve!",
-        "***"
-      ],
+      "receipt_index": 7,
       "word_count": 65
     },
     {
-      "bottom_lines": [
-        "99022003313520071320",
-        "****************************************",
-        "To join our rewards program please go to",
-        "www.sprouts.com/rewards or scan the OR"
-      ],
-      "date": "2026-02-06",
       "embedded_letter_count": 681,
-      "image_id": "ff649c4b-5c31-4247-b78c-d9b0c56610ad",
       "image_size": [
         849,
         2297
       ],
       "letter_count": 681,
       "line_count": 59,
-      "raw_s3_bucket": "upload-images-image-bucket-4bcea7e",
-      "raw_s3_key": "receipts/ff649c4b-5c31-4247-b78c-d9b0c56610ad/receipt_ 7-3a26c6b2-9799-47fb-ab15-397ea4d07152_RECEIPT_00002.png",
-      "receipt_id": 2,
-      "top_lines": [
-        "01/07/2026",
-        "13:20:55",
-        "US DEBIT",
-        "Entry Method: Cntctless"
-      ],
+      "receipt_index": 8,
       "word_count": 105
     },
     {
-      "bottom_lines": [
-        "0003265563651604",
-        "****************************************",
-        "To join our rewards program please go to",
-        "www. sprouts. com/newards or scan the OR"
-      ],
-      "date": "2026-02-06",
       "embedded_letter_count": 468,
-      "image_id": "eaeee5ef-ba10-48c6-9cfe-591d043d7d65",
       "image_size": [
         881,
         2378
       ],
       "letter_count": 468,
       "line_count": 56,
-      "raw_s3_bucket": "upload-images-image-bucket-4bcea7e",
-      "raw_s3_key": "receipts/eaeee5ef-ba10-48c6-9cfe-591d043d7d65/receipt_ 11-28fc9489-8ffd-4884-8767-9c39a9bb9ec9_RECEIPT_00002.png",
-      "receipt_id": 2,
-      "top_lines": [
-        "16:04:54",
-        "12/31/2025",
-        "Entry Method: Ontotless",
-        "US DEBIT"
-      ],
+      "receipt_index": 9,
       "word_count": 75
     },
     {
-      "bottom_lines": [
-        "....",
-        ".....",
-        "without a receipt.",
-        "to returne"
-      ],
-      "date": "2026-02-06",
       "embedded_letter_count": 396,
-      "image_id": "eaeee5ef-ba10-48c6-9cfe-591d043d7d65",
       "image_size": [
         830,
         993
       ],
       "letter_count": 396,
       "line_count": 26,
-      "raw_s3_bucket": "upload-images-image-bucket-4bcea7e",
-      "raw_s3_key": "receipts/eaeee5ef-ba10-48c6-9cfe-591d043d7d65/receipt_ 11-28fc9489-8ffd-4884-8767-9c39a9bb9ec9_RECEIPT_00001.png",
-      "receipt_id": 1,
-      "top_lines": [
-        "How was your visit?",
-        "Let us know at SproutsFeedback.com",
-        "so we can grow and improve!",
-        "******\u2022"
-      ],
+      "receipt_index": 10,
       "word_count": 81
     },
     {
-      "bottom_lines": [
-        "Cafe does not cover",
-        "additional",
-        "costs for",
-        "port"
-      ],
-      "date": "2026-02-06",
       "embedded_letter_count": 834,
-      "image_id": "14587777-4f26-4bd2-a160-1d0a85fe7796",
       "image_size": [
         837,
         3705
       ],
       "letter_count": 846,
       "line_count": 73,
-      "raw_s3_bucket": "upload-images-image-bucket-4bcea7e",
-      "raw_s3_key": "receipts/14587777-4f26-4bd2-a160-1d0a85fe7796/receipt_ 5-ec68ebc0-16b1-42a9-9f40-8d2c1e79cecf_RECEIPT_00001.png",
-      "receipt_id": 1,
-      "top_lines": [
-        "Lava",
-        "band",
-        "La La Land Kind Cafe",
-        "180 Promenade Way"
-      ],
+      "receipt_index": 11,
       "word_count": 152
     },
     {
-      "bottom_lines": [
-        "www.mouthfuleatery.com",
-        "\"People who love to eat are always",
-        "the best people\"",
-        "-Julia Child"
-      ],
-      "date": "2026-02-06",
       "embedded_letter_count": 607,
-      "image_id": "534f5ac3-528e-44a5-81c3-b2164691ed34",
       "image_size": [
         844,
         1845
       ],
       "letter_count": 619,
       "line_count": 51,
-      "raw_s3_bucket": "upload-images-image-bucket-4bcea7e",
-      "raw_s3_key": "receipts/534f5ac3-528e-44a5-81c3-b2164691ed34/receipt_ 13-b93805f6-fa95-47c5-bfca-2eb30e8d3f89_RECEIPT_00001.png",
-      "receipt_id": 1,
-      "top_lines": [
-        "Mouthful Eatery",
-        "2626 Thousand Oaks Blvd",
-        "Thousand Oaks, CA 91362",
-        "805-777-9222"
-      ],
+      "receipt_index": 12,
       "word_count": 113
     }
   ],
@@ -1254,126 +879,106 @@
           "neighbors": [
             {
               "cluster": 1,
-              "id": "image=ff649c4b-5c31-4247-b78c-d9b0c56610ad:receipt=2:line=43:word=2:letter=2",
               "label": "large wide medium",
               "section": "line_items"
             },
             {
               "cluster": 1,
-              "id": "image=ff649c4b-5c31-4247-b78c-d9b0c56610ad:receipt=2:line=5:word=1:letter=3",
               "label": "large wide medium",
               "section": "header"
             },
             {
               "cluster": 1,
-              "id": "image=534f5ac3-528e-44a5-81c3-b2164691ed34:receipt=1:line=46:word=1:letter=1",
               "label": "large wide medium",
               "section": "footer"
             }
           ],
           "query_char": "T",
-          "query_cluster": 1,
-          "query_id": "image=fc408bf9-7b71-401d-ab5b-cd508fb2db3b:receipt=3:line=1:word=1:letter=96"
+          "query_cluster": 1
         },
         {
           "neighbors": [
             {
               "cluster": 1,
-              "id": "image=534f5ac3-528e-44a5-81c3-b2164691ed34:receipt=1:line=49:word=7:letter=4",
               "label": "large wide medium",
               "section": "footer"
             },
             {
               "cluster": 1,
-              "id": "image=534f5ac3-528e-44a5-81c3-b2164691ed34:receipt=1:line=48:word=1:letter=14",
               "label": "large wide medium",
               "section": "footer"
             },
             {
               "cluster": 1,
-              "id": "image=534f5ac3-528e-44a5-81c3-b2164691ed34:receipt=1:line=22:word=2:letter=3",
               "label": "large wide medium",
               "section": "totals_payments"
             }
           ],
           "query_char": "a",
-          "query_cluster": 1,
-          "query_id": "image=fc408bf9-7b71-401d-ab5b-cd508fb2db3b:receipt=3:line=2:word=7:letter=212"
+          "query_cluster": 1
         },
         {
           "neighbors": [
             {
               "cluster": 1,
-              "id": "image=6539deb9-52cc-49a0-81a0-3a64989bee49:receipt=4:line=31:word=54:letter=109",
               "label": "large wide medium",
               "section": "line_items"
             },
             {
               "cluster": 1,
-              "id": "image=fc408bf9-7b71-401d-ab5b-cd508fb2db3b:receipt=3:line=2:word=9:letter=241",
               "label": "large wide medium",
               "section": "header"
             },
             {
               "cluster": 1,
-              "id": "image=fb44b8a7-1a34-40c6-9f2b-011665b20f88:receipt=5:line=5:word=3:letter=142",
               "label": "large wide medium",
               "section": "header"
             }
           ],
           "query_char": "6",
-          "query_cluster": 1,
-          "query_id": "image=fc408bf9-7b71-401d-ab5b-cd508fb2db3b:receipt=3:line=2:word=8:letter=257"
+          "query_cluster": 1
         },
         {
           "neighbors": [
             {
               "cluster": 1,
-              "id": "image=5b1ea5d7-4f9e-44ff-9802-6c7ff11194a6:receipt=3:line=3:word=8:letter=456",
               "label": "large wide medium",
               "section": "header"
             },
             {
               "cluster": 1,
-              "id": "image=c137dfd9-351c-4d4e-9dae-7950ab7db753:receipt=3:line=25:word=10:letter=226",
               "label": "large wide medium",
               "section": "header"
             },
             {
               "cluster": 1,
-              "id": "image=5b1ea5d7-4f9e-44ff-9802-6c7ff11194a6:receipt=3:line=5:word=12:letter=367",
               "label": "large wide medium",
               "section": "header"
             }
           ],
           "query_char": ",",
-          "query_cluster": 1,
-          "query_id": "image=fc408bf9-7b71-401d-ab5b-cd508fb2db3b:receipt=3:line=2:word=8:letter=258"
+          "query_cluster": 1
         },
         {
           "neighbors": [
             {
               "cluster": 1,
-              "id": "image=fc408bf9-7b71-401d-ab5b-cd508fb2db3b:receipt=3:line=2:word=9:letter=240",
               "label": "large wide medium",
               "section": "header"
             },
             {
               "cluster": 1,
-              "id": "image=534f5ac3-528e-44a5-81c3-b2164691ed34:receipt=1:line=41:word=4:letter=5",
               "label": "large wide medium",
               "section": "totals_payments"
             },
             {
               "cluster": 1,
-              "id": "image=fb44b8a7-1a34-40c6-9f2b-011665b20f88:receipt=5:line=13:word=8:letter=215",
               "label": "large wide medium",
               "section": "body_other"
             }
           ],
           "query_char": "2",
-          "query_cluster": 1,
-          "query_id": "image=fc408bf9-7b71-401d-ab5b-cd508fb2db3b:receipt=3:line=2:word=9:letter=238"
+          "query_cluster": 1
         }
       ],
       "same_char_neighbor_found": 200,
@@ -1391,6 +996,6 @@
     "receipts_seen": 645,
     "style_clusters": 8,
     "style_vector_dim": 333,
-    "table": "ReceiptsTable-d7ff76a"
+    "table": "redacted"
   }
 }

--- a/docs/receipt-letter-font-chroma-pilot.json
+++ b/docs/receipt-letter-font-chroma-pilot.json
@@ -1,0 +1,1396 @@
+{
+  "cluster_summaries": [
+    {
+      "avg_box_height": 0.03546,
+      "avg_edge_density": 0.31982,
+      "avg_ink_ratio": 0.15043,
+      "cluster_id": 1,
+      "label": "large wide medium",
+      "normalized_chars": [
+        "e",
+        "a",
+        "*",
+        "0",
+        "o",
+        "t",
+        "r",
+        "i",
+        "n",
+        "s",
+        "1",
+        "."
+      ],
+      "sample_count": 5425,
+      "sections": {
+        "body_other": 2450,
+        "footer": 1032,
+        "header": 944,
+        "line_items": 222,
+        "totals_payments": 777
+      },
+      "text_examples": [
+        "T",
+        "a",
+        "6",
+        ",",
+        "2",
+        "0",
+        "2",
+        "6"
+      ]
+    },
+    {
+      "avg_box_height": 0.01069,
+      "avg_edge_density": 0.21217,
+      "avg_ink_ratio": 0.10302,
+      "cluster_id": 6,
+      "label": "small wide medium",
+      "normalized_chars": [
+        "d",
+        "a",
+        "e",
+        "D",
+        "A",
+        "p",
+        "r",
+        "0",
+        "R",
+        "g",
+        "o",
+        "#"
+      ],
+      "sample_count": 56,
+      "sections": {
+        "body_other": 29,
+        "footer": 14,
+        "header": 8,
+        "totals_payments": 5
+      },
+      "text_examples": [
+        "a",
+        "a",
+        "d",
+        "0",
+        "9",
+        "a",
+        "#",
+        "o"
+      ]
+    },
+    {
+      "avg_box_height": 0.01067,
+      "avg_edge_density": 0.19253,
+      "avg_ink_ratio": 0.08636,
+      "cluster_id": 7,
+      "label": "small wide light",
+      "normalized_chars": [
+        "T",
+        "l",
+        "I",
+        "t",
+        ",",
+        "C",
+        "f",
+        "A",
+        "F",
+        "(",
+        "1",
+        "3"
+      ],
+      "sample_count": 46,
+      "sections": {
+        "body_other": 23,
+        "footer": 10,
+        "header": 5,
+        "totals_payments": 8
+      },
+      "text_examples": [
+        "1",
+        "S",
+        "C",
+        "A",
+        "T",
+        "L",
+        "T",
+        "l"
+      ]
+    },
+    {
+      "avg_box_height": 0.00943,
+      "avg_edge_density": 0.59666,
+      "avg_ink_ratio": 0.17523,
+      "cluster_id": 3,
+      "label": "small wide dark",
+      "normalized_chars": [
+        "*",
+        "4"
+      ],
+      "sample_count": 30,
+      "sections": {
+        "body_other": 22,
+        "footer": 8
+      },
+      "text_examples": [
+        "*",
+        "*",
+        "*",
+        "*",
+        "*",
+        "*",
+        "*",
+        "*"
+      ]
+    },
+    {
+      "avg_box_height": 0.02041,
+      "avg_edge_density": 0.22271,
+      "avg_ink_ratio": 0.12046,
+      "cluster_id": 8,
+      "label": "regular wide medium",
+      "normalized_chars": [
+        "d",
+        "e",
+        "4",
+        "A",
+        "E",
+        "R",
+        "b",
+        "g"
+      ],
+      "sample_count": 10,
+      "sections": {
+        "body_other": 5,
+        "footer": 2,
+        "header": 1,
+        "totals_payments": 2
+      },
+      "text_examples": [
+        "E",
+        "g",
+        "d",
+        "A",
+        "e",
+        "R",
+        "4",
+        "e"
+      ]
+    },
+    {
+      "avg_box_height": 0.0093,
+      "avg_edge_density": 0.58715,
+      "avg_ink_ratio": 0.16785,
+      "cluster_id": 4,
+      "label": "small wide dark",
+      "normalized_chars": [
+        "*",
+        "4"
+      ],
+      "sample_count": 8,
+      "sections": {
+        "body_other": 6,
+        "footer": 2
+      },
+      "text_examples": [
+        "*",
+        "*",
+        "*",
+        "*",
+        "*",
+        "*",
+        "4",
+        "*"
+      ]
+    },
+    {
+      "avg_box_height": 0.01096,
+      "avg_edge_density": 0.29478,
+      "avg_ink_ratio": 0.18185,
+      "cluster_id": 5,
+      "label": "small wide medium",
+      "normalized_chars": [
+        "e",
+        "g",
+        "8",
+        "B",
+        "p"
+      ],
+      "sample_count": 8,
+      "sections": {
+        "body_other": 5,
+        "footer": 3
+      },
+      "text_examples": [
+        "8",
+        "g",
+        "p",
+        "B",
+        "e",
+        "e",
+        "g",
+        "e"
+      ]
+    },
+    {
+      "avg_box_height": 0.0228,
+      "avg_edge_density": 0.27804,
+      "avg_ink_ratio": 0.16459,
+      "cluster_id": 2,
+      "label": "regular wide medium",
+      "normalized_chars": [
+        "e",
+        "9",
+        "g",
+        "h",
+        "o"
+      ],
+      "sample_count": 6,
+      "sections": {
+        "body_other": 2,
+        "footer": 2,
+        "line_items": 1,
+        "totals_payments": 1
+      },
+      "text_examples": [
+        "e",
+        "9",
+        "g",
+        "o",
+        "e",
+        "h"
+      ]
+    }
+  ],
+  "errors": [],
+  "line_cluster_summaries": [
+    {
+      "avg_dominant_letter_cluster_ratio": 0.93151,
+      "avg_gap_to_height_ratio": 0.0,
+      "avg_ink_ratio": 0.16621,
+      "avg_letter_height": 0.04746,
+      "avg_line_height": 0.07845,
+      "cluster_id": 9,
+      "label": "large-line wide medium tight",
+      "line_count": 202,
+      "sections": {
+        "body_other": 94,
+        "footer": 32,
+        "header": 32,
+        "line_items": 9,
+        "totals_payments": 35
+      },
+      "text_examples": [
+        "Cafe does not cover",
+        "additional",
+        "costs for",
+        "Application ID",
+        "$1.52",
+        "$3.15",
+        "+ 2%: (Tip $0.42 Total $22.94)",
+        "* 3%: (Tip $0.63"
+      ]
+    },
+    {
+      "avg_dominant_letter_cluster_ratio": 0.65042,
+      "avg_gap_to_height_ratio": 0.0,
+      "avg_ink_ratio": 0.12759,
+      "avg_letter_height": 0.01942,
+      "avg_line_height": 0.0215,
+      "cluster_id": 2,
+      "label": "regular-line wide medium tight",
+      "line_count": 38,
+      "sections": {
+        "body_other": 20,
+        "footer": 4,
+        "header": 3,
+        "line_items": 4,
+        "totals_payments": 7
+      },
+      "text_examples": [
+        "180 Promenade Way",
+        "Ordered:",
+        "ESPRESSO",
+        "VISA DEBIT",
+        "Approval Code",
+        "Application ID",
+        "Card Reader",
+        "$4.80"
+      ]
+    },
+    {
+      "avg_dominant_letter_cluster_ratio": 0.66003,
+      "avg_gap_to_height_ratio": 0.0,
+      "avg_ink_ratio": 0.11015,
+      "avg_letter_height": 0.01057,
+      "avg_line_height": 0.01059,
+      "cluster_id": 3,
+      "label": "small-line wide medium tight",
+      "line_count": 8,
+      "sections": {
+        "body_other": 5,
+        "footer": 2,
+        "header": 1
+      },
+      "text_examples": [
+        "Server: Lachlan B",
+        "C (EMV Chip Read)",
+        "Food & Drinks: For",
+        "regarding food and drink",
+        "Retail & Clothing: All",
+        "receive an incorrect or",
+        "days with photos of the",
+        "to be unworn, unwashed, and"
+      ]
+    },
+    {
+      "avg_dominant_letter_cluster_ratio": 0.97,
+      "avg_gap_to_height_ratio": 0.0,
+      "avg_ink_ratio": 0.10318,
+      "avg_letter_height": 0.01044,
+      "avg_line_height": 0.01044,
+      "cluster_id": 20,
+      "label": "small-line wide medium tight",
+      "line_count": 5,
+      "sections": {
+        "footer": 5
+      },
+      "text_examples": [
+        "****************************************",
+        "****************************************",
+        "**********",
+        "******",
+        "****************************************"
+      ]
+    },
+    {
+      "avg_dominant_letter_cluster_ratio": 1.0,
+      "avg_gap_to_height_ratio": 0.0,
+      "avg_ink_ratio": 0.11818,
+      "avg_letter_height": 0.01792,
+      "avg_line_height": 0.01792,
+      "cluster_id": 6,
+      "label": "regular-line wide medium tight",
+      "line_count": 3,
+      "sections": {
+        "line_items": 3
+      },
+      "text_examples": [
+        "$4.80",
+        "$0.96",
+        "$21.00"
+      ]
+    },
+    {
+      "avg_dominant_letter_cluster_ratio": 0.62222,
+      "avg_gap_to_height_ratio": 0.0,
+      "avg_ink_ratio": 0.14913,
+      "avg_letter_height": 0.01505,
+      "avg_line_height": 0.01689,
+      "cluster_id": 13,
+      "label": "regular-line wide medium tight",
+      "line_count": 3,
+      "sections": {
+        "body_other": 3
+      },
+      "text_examples": [
+        "************2777",
+        "********************",
+        "+ Tip::"
+      ]
+    },
+    {
+      "avg_dominant_letter_cluster_ratio": 0.74074,
+      "avg_gap_to_height_ratio": 0.0,
+      "avg_ink_ratio": 0.05032,
+      "avg_letter_height": 0.0589,
+      "avg_line_height": 0.07024,
+      "cluster_id": 17,
+      "label": "large-line normal light tight",
+      "line_count": 3,
+      "sections": {
+        "body_other": 1,
+        "totals_payments": 2
+      },
+      "text_examples": [
+        "TOTAL:",
+        "GRATUITY:",
+        "TOTAL:"
+      ]
+    },
+    {
+      "avg_dominant_letter_cluster_ratio": 0.87202,
+      "avg_gap_to_height_ratio": 0.0,
+      "avg_ink_ratio": 0.13103,
+      "avg_letter_height": 0.029,
+      "avg_line_height": 0.037,
+      "cluster_id": 24,
+      "label": "regular-line normal medium tight",
+      "line_count": 3,
+      "sections": {
+        "body_other": 2,
+        "header": 1
+      },
+      "text_examples": [
+        "Main St Provisions",
+        "Las Vegas, NU 89109",
+        "Server: Makella"
+      ]
+    },
+    {
+      "avg_dominant_letter_cluster_ratio": 0.875,
+      "avg_gap_to_height_ratio": 0.0,
+      "avg_ink_ratio": 0.15616,
+      "avg_letter_height": 0.05339,
+      "avg_line_height": 0.05339,
+      "cluster_id": 1,
+      "label": "large-line wide medium tight",
+      "line_count": 2,
+      "sections": {
+        "header": 2
+      },
+      "text_examples": [
+        "Lava",
+        "band"
+      ]
+    },
+    {
+      "avg_dominant_letter_cluster_ratio": 0.8125,
+      "avg_gap_to_height_ratio": 0.0,
+      "avg_ink_ratio": 0.12701,
+      "avg_letter_height": 0.01601,
+      "avg_line_height": 0.01601,
+      "cluster_id": 4,
+      "label": "regular-line wide medium tight",
+      "line_count": 2,
+      "sections": {
+        "totals_payments": 2
+      },
+      "text_examples": [
+        "Subtotal",
+        "Subtotal"
+      ]
+    },
+    {
+      "avg_dominant_letter_cluster_ratio": 0.7,
+      "avg_gap_to_height_ratio": 0.0,
+      "avg_ink_ratio": 0.11786,
+      "avg_letter_height": 0.01582,
+      "avg_line_height": 0.01582,
+      "cluster_id": 5,
+      "label": "regular-line wide medium tight",
+      "line_count": 2,
+      "sections": {
+        "totals_payments": 2
+      },
+      "text_examples": [
+        "Total",
+        "Total"
+      ]
+    },
+    {
+      "avg_dominant_letter_cluster_ratio": 0.96875,
+      "avg_gap_to_height_ratio": 0.0,
+      "avg_ink_ratio": 0.11072,
+      "avg_letter_height": 0.0119,
+      "avg_line_height": 0.01198,
+      "cluster_id": 7,
+      "label": "small-line wide medium tight",
+      "line_count": 2,
+      "sections": {
+        "body_other": 2
+      },
+      "text_examples": [
+        "items, please",
+        "item, please email"
+      ]
+    },
+    {
+      "avg_dominant_letter_cluster_ratio": 0.94077,
+      "avg_gap_to_height_ratio": 0.0,
+      "avg_ink_ratio": 0.12815,
+      "avg_letter_height": 0.01083,
+      "avg_line_height": 0.01083,
+      "cluster_id": 8,
+      "label": "small-line wide medium tight",
+      "line_count": 2,
+      "sections": {
+        "body_other": 2
+      },
+      "text_examples": [
+        "info@lalalandkindcafe.com.",
+        "shop@lalalandkindcafe.com"
+      ]
+    },
+    {
+      "avg_dominant_letter_cluster_ratio": 0.96667,
+      "avg_gap_to_height_ratio": 0.0,
+      "avg_ink_ratio": 0.14769,
+      "avg_letter_height": 0.02448,
+      "avg_line_height": 0.03432,
+      "cluster_id": 10,
+      "label": "regular-line wide medium tight",
+      "line_count": 2,
+      "sections": {
+        "body_other": 1,
+        "header": 1
+      },
+      "text_examples": [
+        "Zen Leaf Las Vegas",
+        "RECEIPT 86233955"
+      ]
+    },
+    {
+      "avg_dominant_letter_cluster_ratio": 0.9,
+      "avg_gap_to_height_ratio": 0.0,
+      "avg_ink_ratio": 0.12175,
+      "avg_letter_height": 0.02153,
+      "avg_line_height": 0.02196,
+      "cluster_id": 11,
+      "label": "regular-line wide medium tight",
+      "line_count": 2,
+      "sections": {
+        "line_items": 2
+      },
+      "text_examples": [
+        "$2.79",
+        "$2.34"
+      ]
+    },
+    {
+      "avg_dominant_letter_cluster_ratio": 0.50505,
+      "avg_gap_to_height_ratio": 0.0,
+      "avg_ink_ratio": 0.23522,
+      "avg_letter_height": 0.01231,
+      "avg_line_height": 0.01273,
+      "cluster_id": 12,
+      "label": "small-line wide medium tight",
+      "line_count": 2,
+      "sections": {
+        "body_other": 1,
+        "line_items": 1
+      },
+      "text_examples": [
+        "1 \u20ac 99/0.00",
+        "*******0658"
+      ]
+    },
+    {
+      "avg_dominant_letter_cluster_ratio": 0.80808,
+      "avg_gap_to_height_ratio": 0.0,
+      "avg_ink_ratio": 0.23305,
+      "avg_letter_height": 0.01415,
+      "avg_line_height": 0.01776,
+      "cluster_id": 14,
+      "label": "regular-line wide medium tight",
+      "line_count": 2,
+      "sections": {
+        "body_other": 1,
+        "totals_payments": 1
+      },
+      "text_examples": [
+        "Annual Card Savings $0.00",
+        "You nay have purchased a product"
+      ]
+    },
+    {
+      "avg_dominant_letter_cluster_ratio": 0.55556,
+      "avg_gap_to_height_ratio": 0.0,
+      "avg_ink_ratio": 0.15405,
+      "avg_letter_height": 0.0093,
+      "avg_line_height": 0.00994,
+      "cluster_id": 15,
+      "label": "small-line wide medium tight",
+      "line_count": 2,
+      "sections": {
+        "body_other": 2
+      },
+      "text_examples": [
+        "*********",
+        "******************"
+      ]
+    },
+    {
+      "avg_dominant_letter_cluster_ratio": 0.29167,
+      "avg_gap_to_height_ratio": 0.0,
+      "avg_ink_ratio": 0.18255,
+      "avg_letter_height": 0.01024,
+      "avg_line_height": 0.01072,
+      "cluster_id": 16,
+      "label": "small-line wide medium tight",
+      "line_count": 2,
+      "sections": {
+        "body_other": 1,
+        "footer": 1
+      },
+      "text_examples": [
+        "************",
+        "******"
+      ]
+    },
+    {
+      "avg_dominant_letter_cluster_ratio": 0.83333,
+      "avg_gap_to_height_ratio": 0.0,
+      "avg_ink_ratio": 0.11455,
+      "avg_letter_height": 0.01544,
+      "avg_line_height": 0.01548,
+      "cluster_id": 18,
+      "label": "regular-line wide medium tight",
+      "line_count": 2,
+      "sections": {
+        "header": 2
+      },
+      "text_examples": [
+        "- APPROVED",
+        "- APPROVED"
+      ]
+    }
+  ],
+  "line_eps_sweep": [
+    {
+      "assigned_lines": 125,
+      "clusters": 10,
+      "eps": 0.58,
+      "median_clusters_per_receipt": 2,
+      "noise_lines": 401,
+      "noise_rate": 0.7623574144486692,
+      "section_purity": 0.584
+    },
+    {
+      "assigned_lines": 176,
+      "clusters": 13,
+      "eps": 0.7,
+      "median_clusters_per_receipt": 2.0,
+      "noise_lines": 350,
+      "noise_rate": 0.6653992395437263,
+      "section_purity": 0.5909090909090909
+    },
+    {
+      "assigned_lines": 299,
+      "clusters": 25,
+      "eps": 0.85,
+      "median_clusters_per_receipt": 4.5,
+      "noise_lines": 227,
+      "noise_rate": 0.43155893536121676,
+      "section_purity": 0.5451505016722408
+    },
+    {
+      "assigned_lines": 431,
+      "clusters": 11,
+      "eps": 1.0,
+      "median_clusters_per_receipt": 1.5,
+      "noise_lines": 95,
+      "noise_rate": 0.1806083650190114,
+      "section_purity": 0.4756380510440835
+    }
+  ],
+  "line_section_summaries": [
+    {
+      "assigned_lines": 138,
+      "avg_dominant_letter_cluster_ratio": 0.85824,
+      "avg_gap_to_height_ratio": 0.0,
+      "avg_ink_ratio": 0.15127,
+      "avg_letter_height": 0.04256,
+      "avg_line_height": 0.0657,
+      "dominant_cluster_share": 0.6811594202898551,
+      "section": "body_other",
+      "top_cluster_ids": {
+        "2": 20,
+        "3": 5,
+        "7": 2,
+        "8": 2,
+        "9": 94,
+        "13": 3,
+        "15": 2,
+        "19": 2
+      },
+      "top_cluster_labels": {
+        "large-line normal light tight": 1,
+        "large-line wide medium tight": 94,
+        "regular-line normal medium tight": 3,
+        "regular-line wide medium tight": 27,
+        "small-line wide medium tight": 13
+      }
+    },
+    {
+      "assigned_lines": 49,
+      "avg_dominant_letter_cluster_ratio": 0.87286,
+      "avg_gap_to_height_ratio": 0.0,
+      "avg_ink_ratio": 0.15117,
+      "avg_letter_height": 0.03068,
+      "avg_line_height": 0.0508,
+      "dominant_cluster_share": 0.7142857142857143,
+      "section": "totals_payments",
+      "top_cluster_ids": {
+        "2": 7,
+        "4": 2,
+        "5": 2,
+        "9": 35,
+        "14": 1,
+        "17": 2
+      },
+      "top_cluster_labels": {
+        "large-line normal light tight": 2,
+        "large-line wide medium tight": 35,
+        "regular-line wide medium tight": 12
+      }
+    },
+    {
+      "assigned_lines": 49,
+      "avg_dominant_letter_cluster_ratio": 0.87547,
+      "avg_gap_to_height_ratio": 0.0,
+      "avg_ink_ratio": 0.15323,
+      "avg_letter_height": 0.03486,
+      "avg_line_height": 0.05165,
+      "dominant_cluster_share": 0.6530612244897959,
+      "section": "footer",
+      "top_cluster_ids": {
+        "2": 4,
+        "3": 2,
+        "9": 32,
+        "16": 1,
+        "20": 5,
+        "21": 2,
+        "22": 2,
+        "25": 1
+      },
+      "top_cluster_labels": {
+        "large-line wide medium tight": 32,
+        "regular-line normal medium tight": 1,
+        "regular-line wide medium tight": 8,
+        "small-line wide medium tight": 8
+      }
+    },
+    {
+      "assigned_lines": 42,
+      "avg_dominant_letter_cluster_ratio": 0.87291,
+      "avg_gap_to_height_ratio": 0.0,
+      "avg_ink_ratio": 0.16593,
+      "avg_letter_height": 0.04532,
+      "avg_line_height": 0.07974,
+      "dominant_cluster_share": 0.7619047619047619,
+      "section": "header",
+      "top_cluster_ids": {
+        "1": 2,
+        "2": 3,
+        "3": 1,
+        "9": 32,
+        "10": 1,
+        "18": 2,
+        "24": 1
+      },
+      "top_cluster_labels": {
+        "large-line wide medium tight": 34,
+        "regular-line normal medium tight": 1,
+        "regular-line wide medium tight": 6,
+        "small-line wide medium tight": 1
+      }
+    },
+    {
+      "assigned_lines": 21,
+      "avg_dominant_letter_cluster_ratio": 0.85357,
+      "avg_gap_to_height_ratio": 0.0,
+      "avg_ink_ratio": 0.15162,
+      "avg_letter_height": 0.02238,
+      "avg_line_height": 0.02318,
+      "dominant_cluster_share": 0.42857142857142855,
+      "section": "line_items",
+      "top_cluster_ids": {
+        "2": 4,
+        "6": 3,
+        "9": 9,
+        "11": 2,
+        "12": 1,
+        "23": 2
+      },
+      "top_cluster_labels": {
+        "large-line wide medium tight": 9,
+        "regular-line normal medium tight": 2,
+        "regular-line wide medium tight": 9,
+        "small-line wide medium tight": 1
+      }
+    }
+  ],
+  "receipt_summaries": [
+    {
+      "bottom_lines": [
+        "$24.33",
+        "Total",
+        "$24.33",
+        "Visa 1454 (Contactless)"
+      ],
+      "date": "2026-05-26",
+      "embedded_letter_count": 258,
+      "image_id": "fc408bf9-7b71-401d-ab5b-cd508fb2db3b",
+      "image_size": [
+        405,
+        666
+      ],
+      "letter_count": 258,
+      "line_count": 28,
+      "raw_s3_bucket": "raw-image-bucket-0facc78",
+      "raw_s3_key": "raw/fc408bf9-7b71-401d-ab5b-cd508fb2db3b_RECEIPT_00003.png",
+      "receipt_id": 3,
+      "top_lines": [
+        "GT Poke",
+        "8610 Spring Mountain Rd",
+        "May 6, 2026",
+        "6:13 PM"
+      ],
+      "word_count": 57
+    },
+    {
+      "bottom_lines": [
+        "I agree to pay above total",
+        "amount according to my card",
+        "ssuer agreement'",
+        "issuer agreement"
+      ],
+      "date": "2026-05-21",
+      "embedded_letter_count": 459,
+      "image_id": "c137dfd9-351c-4d4e-9dae-7950ab7db753",
+      "image_size": [
+        883,
+        1120
+      ],
+      "letter_count": 462,
+      "line_count": 57,
+      "raw_s3_bucket": "raw-image-bucket-0facc78",
+      "raw_s3_key": "raw/c137dfd9-351c-4d4e-9dae-7950ab7db753_RECEIPT_00003.png",
+      "receipt_id": 3,
+      "top_lines": [
+        "03/30/26",
+        "03/30/26",
+        "SALES DRAFT",
+        "Carousel"
+      ],
+      "word_count": 86
+    },
+    {
+      "bottom_lines": [
+        "total amount according to the",
+        "card issuer agreement.",
+        "Thank you and Come Again",
+        "** PLEASE SIGN **"
+      ],
+      "date": "2026-05-21",
+      "embedded_letter_count": 392,
+      "image_id": "9167c199-8808-487c-a55b-ea065ee336e5",
+      "image_size": [
+        771,
+        1002
+      ],
+      "letter_count": 392,
+      "line_count": 35,
+      "raw_s3_bucket": "raw-image-bucket-0facc78",
+      "raw_s3_key": "raw/9167c199-8808-487c-a55b-ea065ee336e5_RECEIPT_00005.png",
+      "receipt_id": 5,
+      "top_lines": [
+        "Main St Provisions",
+        "1214 S Main St.",
+        "Las Vegas, NV 89109",
+        "(702) 457-0111"
+      ],
+      "word_count": 80
+    },
+    {
+      "bottom_lines": [
+        "58.53",
+        "Balance Due",
+        "58.53",
+        "Thank you and Come Again"
+      ],
+      "date": "2026-05-21",
+      "embedded_letter_count": 292,
+      "image_id": "fb44b8a7-1a34-40c6-9f2b-011665b20f88",
+      "image_size": [
+        656,
+        980
+      ],
+      "letter_count": 292,
+      "line_count": 34,
+      "raw_s3_bucket": "raw-image-bucket-0facc78",
+      "raw_s3_key": "raw/fb44b8a7-1a34-40c6-9f2b-011665b20f88_RECEIPT_00005.png",
+      "receipt_id": 5,
+      "top_lines": [
+        "2026",
+        "/2026",
+        "40006",
+        "097153"
+      ],
+      "word_count": 60
+    },
+    {
+      "bottom_lines": [
+        "Total pald:",
+        "$35.00",
+        "Change due:",
+        "$1.95"
+      ],
+      "date": "2026-05-21",
+      "embedded_letter_count": 556,
+      "image_id": "5b1ea5d7-4f9e-44ff-9802-6c7ff11194a6",
+      "image_size": [
+        407,
+        923
+      ],
+      "letter_count": 556,
+      "line_count": 43,
+      "raw_s3_bucket": "raw-image-bucket-0facc78",
+      "raw_s3_key": "raw/5b1ea5d7-4f9e-44ff-9802-6c7ff11194a6_RECEIPT_00003.png",
+      "receipt_id": 3,
+      "top_lines": [
+        "Zen Leaf Las Vegas",
+        "5335 South Fort Apache Road, Las Vegas,",
+        "Nevada, United States",
+        "support-nv@zenleafdispensaries.com"
+      ],
+      "word_count": 85
+    },
+    {
+      "bottom_lines": [
+        "4*744*****",
+        "******",
+        "RECALL NOTICE",
+        "You mau run nurchased a productor"
+      ],
+      "date": "2026-05-21",
+      "embedded_letter_count": 1260,
+      "image_id": "6539deb9-52cc-49a0-81a0-3a64989bee49",
+      "image_size": [
+        634,
+        1081
+      ],
+      "letter_count": 1260,
+      "line_count": 83,
+      "raw_s3_bucket": "raw-image-bucket-0facc78",
+      "raw_s3_key": "raw/6539deb9-52cc-49a0-81a0-3a64989bee49_RECEIPT_00004.png",
+      "receipt_id": 4,
+      "top_lines": [
+        "HEALTH",
+        "0940601",
+        "094030-",
+        "194058"
+      ],
+      "word_count": 217
+    },
+    {
+      "bottom_lines": [
+        "the method of payment used.",
+        "original receipt, th",
+        "ipt. Limits apply to",
+        "without a recei"
+      ],
+      "date": "2026-02-06",
+      "embedded_letter_count": 302,
+      "image_id": "ff649c4b-5c31-4247-b78c-d9b0c56610ad",
+      "image_size": [
+        768,
+        879
+      ],
+      "letter_count": 302,
+      "line_count": 18,
+      "raw_s3_bucket": "upload-images-image-bucket-4bcea7e",
+      "raw_s3_key": "receipts/ff649c4b-5c31-4247-b78c-d9b0c56610ad/receipt_ 7-3a26c6b2-9799-47fb-ab15-397ea4d07152_RECEIPT_00001.png",
+      "receipt_id": 1,
+      "top_lines": [
+        "How was your visit?",
+        "Let us know at SproutsFeedback.com",
+        "so we can grow and improve!",
+        "***"
+      ],
+      "word_count": 65
+    },
+    {
+      "bottom_lines": [
+        "99022003313520071320",
+        "****************************************",
+        "To join our rewards program please go to",
+        "www.sprouts.com/rewards or scan the OR"
+      ],
+      "date": "2026-02-06",
+      "embedded_letter_count": 681,
+      "image_id": "ff649c4b-5c31-4247-b78c-d9b0c56610ad",
+      "image_size": [
+        849,
+        2297
+      ],
+      "letter_count": 681,
+      "line_count": 59,
+      "raw_s3_bucket": "upload-images-image-bucket-4bcea7e",
+      "raw_s3_key": "receipts/ff649c4b-5c31-4247-b78c-d9b0c56610ad/receipt_ 7-3a26c6b2-9799-47fb-ab15-397ea4d07152_RECEIPT_00002.png",
+      "receipt_id": 2,
+      "top_lines": [
+        "01/07/2026",
+        "13:20:55",
+        "US DEBIT",
+        "Entry Method: Cntctless"
+      ],
+      "word_count": 105
+    },
+    {
+      "bottom_lines": [
+        "0003265563651604",
+        "****************************************",
+        "To join our rewards program please go to",
+        "www. sprouts. com/newards or scan the OR"
+      ],
+      "date": "2026-02-06",
+      "embedded_letter_count": 468,
+      "image_id": "eaeee5ef-ba10-48c6-9cfe-591d043d7d65",
+      "image_size": [
+        881,
+        2378
+      ],
+      "letter_count": 468,
+      "line_count": 56,
+      "raw_s3_bucket": "upload-images-image-bucket-4bcea7e",
+      "raw_s3_key": "receipts/eaeee5ef-ba10-48c6-9cfe-591d043d7d65/receipt_ 11-28fc9489-8ffd-4884-8767-9c39a9bb9ec9_RECEIPT_00002.png",
+      "receipt_id": 2,
+      "top_lines": [
+        "16:04:54",
+        "12/31/2025",
+        "Entry Method: Ontotless",
+        "US DEBIT"
+      ],
+      "word_count": 75
+    },
+    {
+      "bottom_lines": [
+        "....",
+        ".....",
+        "without a receipt.",
+        "to returne"
+      ],
+      "date": "2026-02-06",
+      "embedded_letter_count": 396,
+      "image_id": "eaeee5ef-ba10-48c6-9cfe-591d043d7d65",
+      "image_size": [
+        830,
+        993
+      ],
+      "letter_count": 396,
+      "line_count": 26,
+      "raw_s3_bucket": "upload-images-image-bucket-4bcea7e",
+      "raw_s3_key": "receipts/eaeee5ef-ba10-48c6-9cfe-591d043d7d65/receipt_ 11-28fc9489-8ffd-4884-8767-9c39a9bb9ec9_RECEIPT_00001.png",
+      "receipt_id": 1,
+      "top_lines": [
+        "How was your visit?",
+        "Let us know at SproutsFeedback.com",
+        "so we can grow and improve!",
+        "******\u2022"
+      ],
+      "word_count": 81
+    },
+    {
+      "bottom_lines": [
+        "Cafe does not cover",
+        "additional",
+        "costs for",
+        "port"
+      ],
+      "date": "2026-02-06",
+      "embedded_letter_count": 834,
+      "image_id": "14587777-4f26-4bd2-a160-1d0a85fe7796",
+      "image_size": [
+        837,
+        3705
+      ],
+      "letter_count": 846,
+      "line_count": 73,
+      "raw_s3_bucket": "upload-images-image-bucket-4bcea7e",
+      "raw_s3_key": "receipts/14587777-4f26-4bd2-a160-1d0a85fe7796/receipt_ 5-ec68ebc0-16b1-42a9-9f40-8d2c1e79cecf_RECEIPT_00001.png",
+      "receipt_id": 1,
+      "top_lines": [
+        "Lava",
+        "band",
+        "La La Land Kind Cafe",
+        "180 Promenade Way"
+      ],
+      "word_count": 152
+    },
+    {
+      "bottom_lines": [
+        "www.mouthfuleatery.com",
+        "\"People who love to eat are always",
+        "the best people\"",
+        "-Julia Child"
+      ],
+      "date": "2026-02-06",
+      "embedded_letter_count": 607,
+      "image_id": "534f5ac3-528e-44a5-81c3-b2164691ed34",
+      "image_size": [
+        844,
+        1845
+      ],
+      "letter_count": 619,
+      "line_count": 51,
+      "raw_s3_bucket": "upload-images-image-bucket-4bcea7e",
+      "raw_s3_key": "receipts/534f5ac3-528e-44a5-81c3-b2164691ed34/receipt_ 13-b93805f6-fa95-47c5-bfca-2eb30e8d3f89_RECEIPT_00001.png",
+      "receipt_id": 1,
+      "top_lines": [
+        "Mouthful Eatery",
+        "2626 Thousand Oaks Blvd",
+        "Thousand Oaks, CA 91362",
+        "805-777-9222"
+      ],
+      "word_count": 113
+    }
+  ],
+  "section_summaries": [
+    {
+      "assigned_samples": 2542,
+      "avg_box_aspect": 1.1505,
+      "avg_box_height": 0.03612,
+      "avg_edge_density": 0.32808,
+      "avg_ink_ratio": 0.15523,
+      "section": "body_other",
+      "top_cluster_labels": {
+        "large wide medium": 2450,
+        "regular wide medium": 7,
+        "small wide dark": 28,
+        "small wide light": 23,
+        "small wide medium": 34
+      }
+    },
+    {
+      "assigned_samples": 1073,
+      "avg_box_aspect": 1.23311,
+      "avg_box_height": 0.02847,
+      "avg_edge_density": 0.3125,
+      "avg_ink_ratio": 0.14529,
+      "section": "footer",
+      "top_cluster_labels": {
+        "large wide medium": 1032,
+        "regular wide medium": 4,
+        "small wide dark": 10,
+        "small wide light": 10,
+        "small wide medium": 17
+      }
+    },
+    {
+      "assigned_samples": 958,
+      "avg_box_aspect": 1.00033,
+      "avg_box_height": 0.04218,
+      "avg_edge_density": 0.29245,
+      "avg_ink_ratio": 0.13546,
+      "section": "header",
+      "top_cluster_labels": {
+        "large wide medium": 944,
+        "regular wide medium": 1,
+        "small wide light": 5,
+        "small wide medium": 8
+      }
+    },
+    {
+      "assigned_samples": 793,
+      "avg_box_aspect": 0.9378,
+      "avg_box_height": 0.0331,
+      "avg_edge_density": 0.33216,
+      "avg_ink_ratio": 0.15508,
+      "section": "totals_payments",
+      "top_cluster_labels": {
+        "large wide medium": 777,
+        "regular wide medium": 3,
+        "small wide light": 8,
+        "small wide medium": 5
+      }
+    },
+    {
+      "assigned_samples": 223,
+      "avg_box_aspect": 1.03388,
+      "avg_box_height": 0.02348,
+      "avg_edge_density": 0.32165,
+      "avg_ink_ratio": 0.14731,
+      "section": "line_items",
+      "top_cluster_labels": {
+        "large wide medium": 222,
+        "regular wide medium": 1
+      }
+    }
+  ],
+  "summary": {
+    "analysed_receipts": 12,
+    "assigned_letters": 5589,
+    "assigned_lines": 299,
+    "chroma_count": 6505,
+    "collection_name": "letter_font_glyphs",
+    "common_ocr_chars": {
+      "*": 377,
+      "0": 335,
+      "1": 157,
+      "2": 131,
+      "A": 136,
+      "T": 140,
+      "a": 334,
+      "e": 360,
+      "i": 197,
+      "l": 132,
+      "n": 187,
+      "o": 246,
+      "r": 218,
+      "s": 179,
+      "t": 238
+    },
+    "embedded_letters": 6505,
+    "embedded_lines": 526,
+    "eps": 0.15,
+    "errors": 0,
+    "letter_cluster_section_purity": 0.4548219717301843,
+    "line_cluster_section_purity": 0.5451505016722408,
+    "line_eps": 0.85,
+    "line_min_samples": 2,
+    "line_style_clusters": 25,
+    "line_vector_dim": 884,
+    "median_clusters_per_receipt": 1.0,
+    "median_letters_per_receipt": 463.5,
+    "median_line_clusters_per_receipt": 4.5,
+    "metrics_per_letter": 64,
+    "metrics_per_line": 218,
+    "min_letters_per_line": 3,
+    "min_samples": 5,
+    "neighbor_quality": {
+      "checked": 200,
+      "examples": [
+        {
+          "neighbors": [
+            {
+              "cluster": 1,
+              "id": "image=ff649c4b-5c31-4247-b78c-d9b0c56610ad:receipt=2:line=43:word=2:letter=2",
+              "label": "large wide medium",
+              "section": "line_items"
+            },
+            {
+              "cluster": 1,
+              "id": "image=ff649c4b-5c31-4247-b78c-d9b0c56610ad:receipt=2:line=5:word=1:letter=3",
+              "label": "large wide medium",
+              "section": "header"
+            },
+            {
+              "cluster": 1,
+              "id": "image=534f5ac3-528e-44a5-81c3-b2164691ed34:receipt=1:line=46:word=1:letter=1",
+              "label": "large wide medium",
+              "section": "footer"
+            }
+          ],
+          "query_char": "T",
+          "query_cluster": 1,
+          "query_id": "image=fc408bf9-7b71-401d-ab5b-cd508fb2db3b:receipt=3:line=1:word=1:letter=96"
+        },
+        {
+          "neighbors": [
+            {
+              "cluster": 1,
+              "id": "image=534f5ac3-528e-44a5-81c3-b2164691ed34:receipt=1:line=49:word=7:letter=4",
+              "label": "large wide medium",
+              "section": "footer"
+            },
+            {
+              "cluster": 1,
+              "id": "image=534f5ac3-528e-44a5-81c3-b2164691ed34:receipt=1:line=48:word=1:letter=14",
+              "label": "large wide medium",
+              "section": "footer"
+            },
+            {
+              "cluster": 1,
+              "id": "image=534f5ac3-528e-44a5-81c3-b2164691ed34:receipt=1:line=22:word=2:letter=3",
+              "label": "large wide medium",
+              "section": "totals_payments"
+            }
+          ],
+          "query_char": "a",
+          "query_cluster": 1,
+          "query_id": "image=fc408bf9-7b71-401d-ab5b-cd508fb2db3b:receipt=3:line=2:word=7:letter=212"
+        },
+        {
+          "neighbors": [
+            {
+              "cluster": 1,
+              "id": "image=6539deb9-52cc-49a0-81a0-3a64989bee49:receipt=4:line=31:word=54:letter=109",
+              "label": "large wide medium",
+              "section": "line_items"
+            },
+            {
+              "cluster": 1,
+              "id": "image=fc408bf9-7b71-401d-ab5b-cd508fb2db3b:receipt=3:line=2:word=9:letter=241",
+              "label": "large wide medium",
+              "section": "header"
+            },
+            {
+              "cluster": 1,
+              "id": "image=fb44b8a7-1a34-40c6-9f2b-011665b20f88:receipt=5:line=5:word=3:letter=142",
+              "label": "large wide medium",
+              "section": "header"
+            }
+          ],
+          "query_char": "6",
+          "query_cluster": 1,
+          "query_id": "image=fc408bf9-7b71-401d-ab5b-cd508fb2db3b:receipt=3:line=2:word=8:letter=257"
+        },
+        {
+          "neighbors": [
+            {
+              "cluster": 1,
+              "id": "image=5b1ea5d7-4f9e-44ff-9802-6c7ff11194a6:receipt=3:line=3:word=8:letter=456",
+              "label": "large wide medium",
+              "section": "header"
+            },
+            {
+              "cluster": 1,
+              "id": "image=c137dfd9-351c-4d4e-9dae-7950ab7db753:receipt=3:line=25:word=10:letter=226",
+              "label": "large wide medium",
+              "section": "header"
+            },
+            {
+              "cluster": 1,
+              "id": "image=5b1ea5d7-4f9e-44ff-9802-6c7ff11194a6:receipt=3:line=5:word=12:letter=367",
+              "label": "large wide medium",
+              "section": "header"
+            }
+          ],
+          "query_char": ",",
+          "query_cluster": 1,
+          "query_id": "image=fc408bf9-7b71-401d-ab5b-cd508fb2db3b:receipt=3:line=2:word=8:letter=258"
+        },
+        {
+          "neighbors": [
+            {
+              "cluster": 1,
+              "id": "image=fc408bf9-7b71-401d-ab5b-cd508fb2db3b:receipt=3:line=2:word=9:letter=240",
+              "label": "large wide medium",
+              "section": "header"
+            },
+            {
+              "cluster": 1,
+              "id": "image=534f5ac3-528e-44a5-81c3-b2164691ed34:receipt=1:line=41:word=4:letter=5",
+              "label": "large wide medium",
+              "section": "totals_payments"
+            },
+            {
+              "cluster": 1,
+              "id": "image=fb44b8a7-1a34-40c6-9f2b-011665b20f88:receipt=5:line=13:word=8:letter=215",
+              "label": "large wide medium",
+              "section": "body_other"
+            }
+          ],
+          "query_char": "2",
+          "query_cluster": 1,
+          "query_id": "image=fc408bf9-7b71-401d-ab5b-cd508fb2db3b:receipt=3:line=2:word=9:letter=238"
+        }
+      ],
+      "same_char_neighbor_found": 200,
+      "top1_same_cluster_rate": 0.97,
+      "top3_any_same_cluster_rate": 0.995
+    },
+    "noise_letters": 916,
+    "noise_line_rate": 0.43155893536121676,
+    "noise_lines": 227,
+    "noise_rate": 0.14081475787855496,
+    "persist_dir": "/tmp/receipt-letter-font-chroma-pilot-rich",
+    "raw_ok_candidates": 48,
+    "raw_vector_dim": 316,
+    "receipt_limit": 12,
+    "receipts_seen": 645,
+    "style_clusters": 8,
+    "style_vector_dim": 333,
+    "table": "ReceiptsTable-d7ff76a"
+  }
+}

--- a/docs/receipt-letter-font-chroma-pilot.md
+++ b/docs/receipt-letter-font-chroma-pilot.md
@@ -1,0 +1,133 @@
+# Receipt Letter Font Chroma Pilot
+
+Date: 2026-06-22
+
+## Run Summary
+
+- Dynamo table: `ReceiptsTable-d7ff76a`
+- Local Chroma DB: `/tmp/receipt-letter-font-chroma-pilot-rich`
+- Collection: `letter_font_glyphs`
+- Analysed receipts: 12
+- Embedded letters stored in Chroma: 6505
+- Letter style clusters: 8
+- Noise letters: 916 (14.1%)
+- Median letters per receipt: 463.5
+- Median letter clusters per receipt: 1.0
+- Line signatures: 526
+- Line style clusters: 25
+- Noise lines: 227 (43.2%)
+- Assigned lines: 299
+- Median line clusters per receipt: 4.5
+- Letter cluster section purity: 45.5%
+- Line cluster section purity: 54.5%
+- Letter DBSCAN `eps`: 0.15
+- Letter DBSCAN `min_samples`: 5
+- Line DBSCAN `eps`: 0.85
+- Line DBSCAN `min_samples`: 2
+- Errors: 0
+- Metrics per letter: 64
+- Raw vector dimension: 316
+- Style vector dimension: 333
+- Metrics per line: 218
+- Line vector dimension: 884
+
+## Line Threshold Sweep
+
+| Line eps | Clusters | Assigned lines | Noise | Section purity | Median clusters/receipt |
+|---:|---:|---:|---:|---:|---:|
+| 0.58 | 10 | 125 | 76.2% | 58.4% | 2 |
+| 0.70 | 13 | 176 | 66.5% | 59.1% | 2.0 |
+| 0.85 (selected) | 25 | 299 | 43.2% | 54.5% | 4.5 |
+| 1.00 | 11 | 431 | 18.1% | 47.6% | 1.5 |
+
+## Feature Inventory
+
+Each letter embedding combines deterministic visual features before any clustering:
+
+- normalized glyph bitmap
+- OCR character-centered residual vector
+- bbox size/aspect and OCR confidence
+- ink density and content coverage
+- edge density and horizontal/vertical transition rates
+- row and column projection bins
+- HOG-style unsigned gradient orientation bins
+- stroke-width run estimates
+- top/bottom/left/right contour profile stats
+- horizontal and vertical symmetry
+- connected component count and largest component ratio
+- enclosed hole count and hole area ratio
+
+Each line signature then aggregates those letter features with line geometry, letter spacing, word/letter counts, OCR character mix, dominant letter-cluster mix, and averaged letter style-vector centroids/spread.
+
+## Chroma Neighbor Check
+
+- Same-character queries checked: 200
+- Top-1 same-cluster rate: 97.0%
+- Top-3 any same-cluster rate: 99.5%
+
+The neighbor check queries Chroma with a letter style vector, filtered to the same OCR character, and checks whether nearest neighbors share the discovered style cluster.
+
+## Letter Section Patterns
+
+| Section | Assigned letters | Avg height | Avg ink | Avg edge | Top style labels |
+|---|---:|---:|---:|---:|---|
+| `body_other` | 2542 | 0.0361 | 0.155 | 0.328 | `large wide medium` (2450), `small wide medium` (34), `small wide dark` (28), `small wide light` (23), `regular wide medium` (7) |
+| `footer` | 1073 | 0.0285 | 0.145 | 0.312 | `large wide medium` (1032), `small wide medium` (17), `small wide dark` (10), `small wide light` (10), `regular wide medium` (4) |
+| `header` | 958 | 0.0422 | 0.135 | 0.292 | `large wide medium` (944), `small wide medium` (8), `small wide light` (5), `regular wide medium` (1) |
+| `totals_payments` | 793 | 0.0331 | 0.155 | 0.332 | `large wide medium` (777), `small wide light` (8), `small wide medium` (5), `regular wide medium` (3) |
+| `line_items` | 223 | 0.0235 | 0.147 | 0.322 | `large wide medium` (222), `regular wide medium` (1) |
+
+## Line Section Patterns
+
+| Section | Assigned lines | Dominant cluster share | Avg line height | Avg letter height | Avg ink | Gap/height | Top line labels |
+|---|---:|---:|---:|---:|---:|---:|---|
+| `body_other` | 138 | 68.1% | 0.0657 | 0.0426 | 0.151 | 0.000 | `large-line wide medium tight` (94), `regular-line wide medium tight` (27), `small-line wide medium tight` (13), `regular-line normal medium tight` (3), `large-line normal light tight` (1) |
+| `totals_payments` | 49 | 71.4% | 0.0508 | 0.0307 | 0.151 | 0.000 | `large-line wide medium tight` (35), `regular-line wide medium tight` (12), `large-line normal light tight` (2) |
+| `footer` | 49 | 65.3% | 0.0517 | 0.0349 | 0.153 | 0.000 | `large-line wide medium tight` (32), `small-line wide medium tight` (8), `regular-line wide medium tight` (8), `regular-line normal medium tight` (1) |
+| `header` | 42 | 76.2% | 0.0797 | 0.0453 | 0.166 | 0.000 | `large-line wide medium tight` (34), `regular-line wide medium tight` (6), `small-line wide medium tight` (1), `regular-line normal medium tight` (1) |
+| `line_items` | 21 | 42.9% | 0.0232 | 0.0224 | 0.152 | 0.000 | `regular-line wide medium tight` (9), `large-line wide medium tight` (9), `regular-line normal medium tight` (2), `small-line wide medium tight` (1) |
+
+## Largest Letter Style Clusters
+
+| Cluster | Label | Letters | Chars | Sections |
+|---:|---|---:|---|---|
+| 1 | `large wide medium` | 5425 | `e` `a` `*` `0` `o` `t` `r` `i` | `body_other` (2450), `footer` (1032), `header` (944), `totals_payments` (777), `line_items` (222) |
+| 6 | `small wide medium` | 56 | `d` `a` `e` `D` `A` `p` `r` `0` | `body_other` (29), `footer` (14), `header` (8), `totals_payments` (5) |
+| 7 | `small wide light` | 46 | `T` `l` `I` `t` `,` `C` `f` `A` | `body_other` (23), `footer` (10), `totals_payments` (8), `header` (5) |
+| 3 | `small wide dark` | 30 | `*` `4` | `body_other` (22), `footer` (8) |
+| 8 | `regular wide medium` | 10 | `d` `e` `4` `A` `E` `R` `b` `g` | `body_other` (5), `totals_payments` (2), `footer` (2), `header` (1) |
+| 4 | `small wide dark` | 8 | `*` `4` | `body_other` (6), `footer` (2) |
+| 5 | `small wide medium` | 8 | `e` `g` `8` `B` `p` | `body_other` (5), `footer` (3) |
+| 2 | `regular wide medium` | 6 | `e` `9` `g` `h` `o` | `body_other` (2), `footer` (2), `totals_payments` (1), `line_items` (1) |
+
+## Largest Line Style Clusters
+
+| Cluster | Label | Lines | Sections | Examples |
+|---:|---|---:|---|---|
+| 9 | `large-line wide medium tight` | 202 | `body_other` (94), `totals_payments` (35), `footer` (32), `header` (32), `line_items` (9) | Cafe does not cover; additional; costs for |
+| 2 | `regular-line wide medium tight` | 38 | `body_other` (20), `totals_payments` (7), `footer` (4), `line_items` (4), `header` (3) | 180 Promenade Way; Ordered:; ESPRESSO |
+| 3 | `small-line wide medium tight` | 8 | `body_other` (5), `footer` (2), `header` (1) | Server: Lachlan B; C (EMV Chip Read); Food & Drinks: For |
+| 20 | `small-line wide medium tight` | 5 | `footer` (5) | ****************************************; ****************************************; ********** |
+| 6 | `regular-line wide medium tight` | 3 | `line_items` (3) | $4.80; $0.96; $21.00 |
+| 13 | `regular-line wide medium tight` | 3 | `body_other` (3) | ************2777; ********************; + Tip:: |
+| 17 | `large-line normal light tight` | 3 | `totals_payments` (2), `body_other` (1) | TOTAL:; GRATUITY:; TOTAL: |
+| 24 | `regular-line normal medium tight` | 3 | `body_other` (2), `header` (1) | Main St Provisions; Las Vegas, NU 89109; Server: Makella |
+| 1 | `large-line wide medium tight` | 2 | `header` (2) | Lava; band |
+| 4 | `regular-line wide medium tight` | 2 | `totals_payments` (2) | Subtotal; Subtotal |
+| 5 | `regular-line wide medium tight` | 2 | `totals_payments` (2) | Total; Total |
+| 7 | `small-line wide medium tight` | 2 | `body_other` (2) | items, please; item, please email |
+
+## Interpretation
+
+This end-to-end pilot proves the mechanics work: individual OCR letter crops can be embedded, persisted in a separate Chroma DB, queried by same-character nearest neighbors, clustered into visual style groups, and aggregated into line-level font signatures.
+
+Line-level signatures are the better unit for section inference because they carry stable typography and layout context. The purity scores above compare how often each discovered cluster is dominated by a single heuristic receipt section.
+
+It is not yet an exact font-family recognizer. The current output is relative font/style clustering: size, width, stroke darkness, and visual similarity. Exact font names would require a reference library of rendered fonts and a calibration step against that library.
+
+## Next Improvements
+
+- Tune `eps` per dataset or switch to HDBSCAN when available.
+- Prefer persisted `ReceiptSection` entities over the heuristic line classifier used in this pilot.
+- Add a reference-font corpus to map clusters to likely font family names.
+- Use line signatures as features for a supervised section model once section labels exist.

--- a/docs/receipt-letter-font-chroma-pilot.md
+++ b/docs/receipt-letter-font-chroma-pilot.md
@@ -4,7 +4,7 @@ Date: 2026-06-22
 
 ## Run Summary
 
-- Dynamo table: `ReceiptsTable-d7ff76a`
+- Dynamo table: `redacted`
 - Local Chroma DB: `/tmp/receipt-letter-font-chroma-pilot-rich`
 - Collection: `letter_font_glyphs`
 - Analysed receipts: 12
@@ -71,51 +71,51 @@ The neighbor check queries Chroma with a letter style vector, filtered to the sa
 
 | Section | Assigned letters | Avg height | Avg ink | Avg edge | Top style labels |
 |---|---:|---:|---:|---:|---|
-| `body_other` | 2542 | 0.0361 | 0.155 | 0.328 | `large wide medium` (2450), `small wide medium` (34), `small wide dark` (28), `small wide light` (23), `regular wide medium` (7) |
-| `footer` | 1073 | 0.0285 | 0.145 | 0.312 | `large wide medium` (1032), `small wide medium` (17), `small wide dark` (10), `small wide light` (10), `regular wide medium` (4) |
-| `header` | 958 | 0.0422 | 0.135 | 0.292 | `large wide medium` (944), `small wide medium` (8), `small wide light` (5), `regular wide medium` (1) |
-| `totals_payments` | 793 | 0.0331 | 0.155 | 0.332 | `large wide medium` (777), `small wide light` (8), `small wide medium` (5), `regular wide medium` (3) |
+| `body_other` | 2542 | 0.0361 | 0.155 | 0.328 | `large wide medium` (2450), `regular wide medium` (7), `small wide dark` (28), `small wide light` (23), `small wide medium` (34) |
+| `footer` | 1073 | 0.0285 | 0.145 | 0.312 | `large wide medium` (1032), `regular wide medium` (4), `small wide dark` (10), `small wide light` (10), `small wide medium` (17) |
+| `header` | 958 | 0.0422 | 0.135 | 0.292 | `large wide medium` (944), `regular wide medium` (1), `small wide light` (5), `small wide medium` (8) |
+| `totals_payments` | 793 | 0.0331 | 0.155 | 0.332 | `large wide medium` (777), `regular wide medium` (3), `small wide light` (8), `small wide medium` (5) |
 | `line_items` | 223 | 0.0235 | 0.147 | 0.322 | `large wide medium` (222), `regular wide medium` (1) |
 
 ## Line Section Patterns
 
 | Section | Assigned lines | Dominant cluster share | Avg line height | Avg letter height | Avg ink | Gap/height | Top line labels |
 |---|---:|---:|---:|---:|---:|---:|---|
-| `body_other` | 138 | 68.1% | 0.0657 | 0.0426 | 0.151 | 0.000 | `large-line wide medium tight` (94), `regular-line wide medium tight` (27), `small-line wide medium tight` (13), `regular-line normal medium tight` (3), `large-line normal light tight` (1) |
-| `totals_payments` | 49 | 71.4% | 0.0508 | 0.0307 | 0.151 | 0.000 | `large-line wide medium tight` (35), `regular-line wide medium tight` (12), `large-line normal light tight` (2) |
-| `footer` | 49 | 65.3% | 0.0517 | 0.0349 | 0.153 | 0.000 | `large-line wide medium tight` (32), `small-line wide medium tight` (8), `regular-line wide medium tight` (8), `regular-line normal medium tight` (1) |
-| `header` | 42 | 76.2% | 0.0797 | 0.0453 | 0.166 | 0.000 | `large-line wide medium tight` (34), `regular-line wide medium tight` (6), `small-line wide medium tight` (1), `regular-line normal medium tight` (1) |
-| `line_items` | 21 | 42.9% | 0.0232 | 0.0224 | 0.152 | 0.000 | `regular-line wide medium tight` (9), `large-line wide medium tight` (9), `regular-line normal medium tight` (2), `small-line wide medium tight` (1) |
+| `body_other` | 138 | 68.1% | 0.0657 | 0.0426 | 0.151 | 0.000 | `large-line normal light tight` (1), `large-line wide medium tight` (94), `regular-line normal medium tight` (3), `regular-line wide medium tight` (27), `small-line wide medium tight` (13) |
+| `totals_payments` | 49 | 71.4% | 0.0508 | 0.0307 | 0.151 | 0.000 | `large-line normal light tight` (2), `large-line wide medium tight` (35), `regular-line wide medium tight` (12) |
+| `footer` | 49 | 65.3% | 0.0517 | 0.0349 | 0.153 | 0.000 | `large-line wide medium tight` (32), `regular-line normal medium tight` (1), `regular-line wide medium tight` (8), `small-line wide medium tight` (8) |
+| `header` | 42 | 76.2% | 0.0797 | 0.0453 | 0.166 | 0.000 | `large-line wide medium tight` (34), `regular-line normal medium tight` (1), `regular-line wide medium tight` (6), `small-line wide medium tight` (1) |
+| `line_items` | 21 | 42.9% | 0.0232 | 0.0224 | 0.152 | 0.000 | `large-line wide medium tight` (9), `regular-line normal medium tight` (2), `regular-line wide medium tight` (9), `small-line wide medium tight` (1) |
 
 ## Largest Letter Style Clusters
 
 | Cluster | Label | Letters | Chars | Sections |
 |---:|---|---:|---|---|
-| 1 | `large wide medium` | 5425 | `e` `a` `*` `0` `o` `t` `r` `i` | `body_other` (2450), `footer` (1032), `header` (944), `totals_payments` (777), `line_items` (222) |
+| 1 | `large wide medium` | 5425 | `e` `a` `*` `0` `o` `t` `r` `i` | `body_other` (2450), `footer` (1032), `header` (944), `line_items` (222), `totals_payments` (777) |
 | 6 | `small wide medium` | 56 | `d` `a` `e` `D` `A` `p` `r` `0` | `body_other` (29), `footer` (14), `header` (8), `totals_payments` (5) |
-| 7 | `small wide light` | 46 | `T` `l` `I` `t` `,` `C` `f` `A` | `body_other` (23), `footer` (10), `totals_payments` (8), `header` (5) |
+| 7 | `small wide light` | 46 | `T` `l` `I` `t` `,` `C` `f` `A` | `body_other` (23), `footer` (10), `header` (5), `totals_payments` (8) |
 | 3 | `small wide dark` | 30 | `*` `4` | `body_other` (22), `footer` (8) |
-| 8 | `regular wide medium` | 10 | `d` `e` `4` `A` `E` `R` `b` `g` | `body_other` (5), `totals_payments` (2), `footer` (2), `header` (1) |
+| 8 | `regular wide medium` | 10 | `d` `e` `4` `A` `E` `R` `b` `g` | `body_other` (5), `footer` (2), `header` (1), `totals_payments` (2) |
 | 4 | `small wide dark` | 8 | `*` `4` | `body_other` (6), `footer` (2) |
 | 5 | `small wide medium` | 8 | `e` `g` `8` `B` `p` | `body_other` (5), `footer` (3) |
-| 2 | `regular wide medium` | 6 | `e` `9` `g` `h` `o` | `body_other` (2), `footer` (2), `totals_payments` (1), `line_items` (1) |
+| 2 | `regular wide medium` | 6 | `e` `9` `g` `h` `o` | `body_other` (2), `footer` (2), `line_items` (1), `totals_payments` (1) |
 
 ## Largest Line Style Clusters
 
-| Cluster | Label | Lines | Sections | Examples |
-|---:|---|---:|---|---|
-| 9 | `large-line wide medium tight` | 202 | `body_other` (94), `totals_payments` (35), `footer` (32), `header` (32), `line_items` (9) | Cafe does not cover; additional; costs for |
-| 2 | `regular-line wide medium tight` | 38 | `body_other` (20), `totals_payments` (7), `footer` (4), `line_items` (4), `header` (3) | 180 Promenade Way; Ordered:; ESPRESSO |
-| 3 | `small-line wide medium tight` | 8 | `body_other` (5), `footer` (2), `header` (1) | Server: Lachlan B; C (EMV Chip Read); Food & Drinks: For |
-| 20 | `small-line wide medium tight` | 5 | `footer` (5) | ****************************************; ****************************************; ********** |
-| 6 | `regular-line wide medium tight` | 3 | `line_items` (3) | $4.80; $0.96; $21.00 |
-| 13 | `regular-line wide medium tight` | 3 | `body_other` (3) | ************2777; ********************; + Tip:: |
-| 17 | `large-line normal light tight` | 3 | `totals_payments` (2), `body_other` (1) | TOTAL:; GRATUITY:; TOTAL: |
-| 24 | `regular-line normal medium tight` | 3 | `body_other` (2), `header` (1) | Main St Provisions; Las Vegas, NU 89109; Server: Makella |
-| 1 | `large-line wide medium tight` | 2 | `header` (2) | Lava; band |
-| 4 | `regular-line wide medium tight` | 2 | `totals_payments` (2) | Subtotal; Subtotal |
-| 5 | `regular-line wide medium tight` | 2 | `totals_payments` (2) | Total; Total |
-| 7 | `small-line wide medium tight` | 2 | `body_other` (2) | items, please; item, please email |
+| Cluster | Label | Lines | Sections |
+|---:|---|---:|---|
+| 9 | `large-line wide medium tight` | 202 | `body_other` (94), `footer` (32), `header` (32), `line_items` (9), `totals_payments` (35) |
+| 2 | `regular-line wide medium tight` | 38 | `body_other` (20), `footer` (4), `header` (3), `line_items` (4), `totals_payments` (7) |
+| 3 | `small-line wide medium tight` | 8 | `body_other` (5), `footer` (2), `header` (1) |
+| 20 | `small-line wide medium tight` | 5 | `footer` (5) |
+| 6 | `regular-line wide medium tight` | 3 | `line_items` (3) |
+| 13 | `regular-line wide medium tight` | 3 | `body_other` (3) |
+| 17 | `large-line normal light tight` | 3 | `body_other` (1), `totals_payments` (2) |
+| 24 | `regular-line normal medium tight` | 3 | `body_other` (2), `header` (1) |
+| 1 | `large-line wide medium tight` | 2 | `header` (2) |
+| 4 | `regular-line wide medium tight` | 2 | `totals_payments` (2) |
+| 5 | `regular-line wide medium tight` | 2 | `totals_payments` (2) |
+| 7 | `small-line wide medium tight` | 2 | `body_other` (2) |
 
 ## Interpretation
 
@@ -131,3 +131,4 @@ It is not yet an exact font-family recognizer. The current output is relative fo
 - Prefer persisted `ReceiptSection` entities over the heuristic line classifier used in this pilot.
 - Add a reference-font corpus to map clusters to likely font family names.
 - Use line signatures as features for a supervised section model once section labels exist.
+

--- a/receipt_upload/receipt_upload/__init__.py
+++ b/receipt_upload/receipt_upload/__init__.py
@@ -1,11 +1,57 @@
 from .cluster import dbscan_lines
+from .font_analysis import (
+    FontCluster,
+    FontSimilarityMatch,
+    FontStyleSample,
+    ReceiptFontAnalysis,
+    analyze_dynamo_image_fonts,
+    analyze_receipt_fonts,
+    build_font_style_samples,
+    find_similar_font_samples,
+    load_raw_image_from_s3,
+)
+from .font_letter_analysis import (
+    LetterFontAnalysis,
+    LetterImageSample,
+    LetterStyleCluster,
+    LineFontAnalysis,
+    LineFontCluster,
+    LineFontSample,
+    build_letter_image_samples,
+    build_line_font_samples,
+    cluster_letter_styles,
+    cluster_line_font_styles,
+    query_similar_letters,
+    upsert_letter_samples_to_chroma,
+)
 from .geometry import min_area_rect
 from .route_images import classify_image_layout
 from .utils import send_message_to_sqs
 
 __all__ = [
+    "FontCluster",
+    "FontSimilarityMatch",
+    "FontStyleSample",
+    "LetterFontAnalysis",
+    "LetterImageSample",
+    "LetterStyleCluster",
+    "LineFontAnalysis",
+    "LineFontCluster",
+    "LineFontSample",
+    "ReceiptFontAnalysis",
+    "analyze_dynamo_image_fonts",
+    "analyze_receipt_fonts",
+    "build_font_style_samples",
+    "build_letter_image_samples",
+    "build_line_font_samples",
+    "cluster_letter_styles",
+    "cluster_line_font_styles",
     "dbscan_lines",
+    "find_similar_font_samples",
+    "load_raw_image_from_s3",
     "min_area_rect",
+    "query_similar_letters",
     "classify_image_layout",
     "send_message_to_sqs",
+    "upsert_letter_samples_to_chroma",
 ]

--- a/receipt_upload/receipt_upload/font_analysis.py
+++ b/receipt_upload/receipt_upload/font_analysis.py
@@ -8,8 +8,8 @@ the embeddings to find font-like groups.
 
 from __future__ import annotations
 
-from io import BytesIO
 from dataclasses import dataclass
+from io import BytesIO
 from math import cos, log, sin, sqrt
 from statistics import mean
 from typing import Any, Iterable, Mapping, Sequence

--- a/receipt_upload/receipt_upload/font_analysis.py
+++ b/receipt_upload/receipt_upload/font_analysis.py
@@ -1,0 +1,1234 @@
+"""Infer receipt font-style groups from OCR geometry and raw image crops.
+
+The OCR pipeline already segments letters, but those entities currently carry
+geometry rather than image crops. This module turns OCR geometry, and
+optionally raw receipt image pixels, into compact style embeddings and clusters
+the embeddings to find font-like groups.
+"""
+
+from __future__ import annotations
+
+from io import BytesIO
+from dataclasses import dataclass
+from math import cos, log, sin, sqrt
+from statistics import mean
+from typing import Any, Iterable, Mapping, Sequence
+
+import boto3
+from PIL import Image as PILImage
+from PIL import ImageFilter, ImageOps
+
+BoundingBox = dict[str, float]
+
+_EPSILON = 1e-9
+_GEOMETRY_FEATURE_WEIGHTS = (
+    2.0,  # font size relative to the receipt
+    1.7,  # glyph advance relative to the receipt
+    1.4,  # glyph aspect/condensing
+    1.0,  # word height relative to line height
+    0.8,  # vertical alignment inside the line
+    0.7,  # glyph width consistency
+    0.5,  # glyph height consistency
+    0.4,  # uppercase ratio
+    0.35,  # digit ratio
+    0.25,  # punctuation ratio
+    0.3,  # OCR confidence
+    0.25,  # text angle sine
+    0.25,  # text angle cosine
+)
+_PIXEL_FEATURE_NAMES = (
+    "pixel_ink_ratio",
+    "pixel_edge_density",
+    "pixel_horizontal_transition_rate",
+    "pixel_vertical_transition_rate",
+    "pixel_content_width_ratio",
+    "pixel_content_height_ratio",
+    "pixel_content_aspect",
+    "pixel_top_ink_ratio",
+    "pixel_middle_ink_ratio",
+    "pixel_bottom_ink_ratio",
+    "pixel_left_ink_ratio",
+    "pixel_center_ink_ratio",
+    "pixel_right_ink_ratio",
+    "pixel_row_bin_0",
+    "pixel_row_bin_1",
+    "pixel_row_bin_2",
+    "pixel_row_bin_3",
+    "pixel_row_bin_4",
+    "pixel_row_bin_5",
+    "pixel_row_bin_6",
+    "pixel_row_bin_7",
+)
+_PIXEL_FEATURE_WEIGHTS = tuple(0.35 for _ in _PIXEL_FEATURE_NAMES)
+
+
+@dataclass(frozen=True)
+class FontStyleSample:
+    """A word-level style sample embedded from segmented letters."""
+
+    sample_id: str
+    image_id: str | None
+    receipt_id: int | None
+    line_id: int
+    word_id: int | None
+    text: str
+    letter_count: int
+    vector: tuple[float, ...]
+    metrics: dict[str, float]
+
+
+@dataclass(frozen=True)
+class FontCluster:
+    """A discovered font-like group within one receipt/image."""
+
+    cluster_id: int
+    sample_ids: tuple[str, ...]
+    line_ids: tuple[int, ...]
+    word_ids: tuple[tuple[int, int], ...]
+    text_examples: tuple[str, ...]
+    sample_count: int
+    letter_count: int
+    centroid: tuple[float, ...]
+    metrics: dict[str, float]
+    label: str
+
+
+@dataclass(frozen=True)
+class FontSimilarityMatch:
+    """Nearest-neighbor result for embedding similarity search."""
+
+    sample_id: str
+    score: float
+    cluster_id: int | None
+
+
+@dataclass(frozen=True)
+class ReceiptFontAnalysis:
+    """Font clustering result with helper methods for similarity search."""
+
+    samples: tuple[FontStyleSample, ...]
+    clusters: tuple[FontCluster, ...]
+    noise_sample_ids: tuple[str, ...]
+    assignments: dict[str, int]
+
+    def cluster_for_sample(self, sample_id: str) -> int | None:
+        """Return the cluster id for a sample, or None when it is noise."""
+        cluster_id = self.assignments.get(sample_id)
+        if cluster_id is None or cluster_id < 0:
+            return None
+        return cluster_id
+
+    def similar_samples(
+        self, sample_id: str, top_k: int = 5
+    ) -> tuple[FontSimilarityMatch, ...]:
+        """Find samples with the closest font-style embeddings."""
+        by_id = {sample.sample_id: sample for sample in self.samples}
+        query = by_id.get(sample_id)
+        if query is None:
+            raise ValueError(f"Unknown font sample: {sample_id}")
+
+        candidates = [
+            sample for sample in self.samples if sample.sample_id != sample_id
+        ]
+        return find_similar_font_samples(
+            query,
+            candidates,
+            assignments=self.assignments,
+            top_k=top_k,
+        )
+
+
+def analyze_receipt_fonts(
+    letters: Sequence[Any],
+    *,
+    words: Sequence[Any] | None = None,
+    lines: Sequence[Any] | None = None,
+    raw_image: Any | None = None,
+    image_y_origin: str = "bottom_left",
+    crop_padding: float = 0.08,
+    eps: float = 2.2,
+    min_samples: int = 2,
+    min_letters_per_sample: int = 2,
+    promote_singletons_min_letters: int | None = 8,
+) -> ReceiptFontAnalysis:
+    """Embed OCR letter groups and cluster them into receipt font styles.
+
+    Args:
+        letters: OCR Letter or ReceiptLetter entities.
+        words: Optional Word or ReceiptWord entities for word boxes/text.
+        lines: Optional Line or ReceiptLine entities for line context.
+        raw_image: Optional Pillow image, image path, or image bytes for pixel
+            crop features from the original raw receipt.
+        image_y_origin: Coordinate convention for normalized OCR boxes.
+            Vision-style OCR uses ``bottom_left``.
+        crop_padding: Fractional padding added around each OCR word crop.
+        eps: DBSCAN radius in standardized embedding space.
+        min_samples: Minimum neighboring samples to form a dense cluster.
+        min_letters_per_sample: Drop very short words from clustering.
+        promote_singletons_min_letters: Promote long noise samples into
+            singleton clusters, useful for unique receipt headers.
+
+    Returns:
+        ReceiptFontAnalysis with samples, clusters, noise, and assignments.
+    """
+    samples = build_font_style_samples(
+        letters,
+        words=words,
+        lines=lines,
+        raw_image=raw_image,
+        image_y_origin=image_y_origin,
+        crop_padding=crop_padding,
+        min_letters_per_sample=min_letters_per_sample,
+    )
+    if not samples:
+        return ReceiptFontAnalysis((), (), (), {})
+
+    labels = _dbscan(
+        [sample.vector for sample in samples],
+        eps=eps,
+        min_samples=min_samples,
+    )
+
+    labels = _promote_singleton_samples(
+        labels,
+        samples,
+        promote_singletons_min_letters=promote_singletons_min_letters,
+    )
+    return _build_analysis(samples, labels)
+
+
+def build_font_style_samples(
+    letters: Sequence[Any],
+    *,
+    words: Sequence[Any] | None = None,
+    lines: Sequence[Any] | None = None,
+    raw_image: Any | None = None,
+    image_y_origin: str = "bottom_left",
+    crop_padding: float = 0.08,
+    min_letters_per_sample: int = 2,
+) -> tuple[FontStyleSample, ...]:
+    """Build word-level embeddings from segmented OCR letters and image crops."""
+    line_index = _index_by_line(lines or ())
+    word_index = _index_by_word(words or ())
+    letters_by_word = _group_letters_by_word(letters)
+    image = _coerce_image(raw_image) if raw_image is not None else None
+
+    measurements: list[dict[str, Any]] = []
+    for (line_id, word_id), grouped_letters in sorted(letters_by_word.items()):
+        clean_letters = [
+            letter
+            for letter in sorted(grouped_letters, key=_letter_sort_key)
+            if _text(letter).strip()
+        ]
+        if len(clean_letters) < min_letters_per_sample:
+            continue
+
+        word = word_index.get((line_id, word_id))
+        line = line_index.get(line_id)
+        word_box = _box(word) if word is not None else None
+        if word_box is None:
+            word_box = _union_boxes(
+                box
+                for box in (_box(letter) for letter in clean_letters)
+                if box is not None
+            )
+        if word_box is None:
+            continue
+
+        line_box = _box(line) if line is not None else None
+        text = str(_get(word, "text", "")) if word is not None else ""
+        if not text:
+            text = "".join(_text(letter) for letter in clean_letters)
+        text = text.strip()
+        if not text:
+            continue
+
+        letter_boxes = [
+            box
+            for box in (_box(letter) for letter in clean_letters)
+            if box is not None
+        ]
+        pixel_metrics = None
+        if image is not None:
+            pixel_metrics = _extract_word_crop_metrics(
+                image,
+                word_box,
+                y_origin=image_y_origin,
+                padding_ratio=crop_padding,
+            )
+        measurements.append(
+            _measure_sample(
+                text=text,
+                line_id=line_id,
+                word_id=word_id,
+                word_box=word_box,
+                line_box=line_box,
+                letters=clean_letters,
+                letter_boxes=letter_boxes,
+                pixel_metrics=pixel_metrics,
+            )
+        )
+
+    if not measurements:
+        return ()
+
+    raw_rows, weights = _raw_feature_rows(measurements)
+    vectors = _robust_standardize(raw_rows, weights=weights)
+
+    samples = []
+    for measured, vector in zip(measurements, vectors):
+        sample_id = _sample_id(
+            image_id=measured["image_id"],
+            receipt_id=measured["receipt_id"],
+            line_id=measured["line_id"],
+            word_id=measured["word_id"],
+        )
+        samples.append(
+            FontStyleSample(
+                sample_id=sample_id,
+                image_id=measured["image_id"],
+                receipt_id=measured["receipt_id"],
+                line_id=measured["line_id"],
+                word_id=measured["word_id"],
+                text=measured["text"],
+                letter_count=measured["letter_count"],
+                vector=tuple(vector),
+                metrics=measured["metrics"],
+            )
+        )
+    return tuple(samples)
+
+
+def load_raw_image_from_s3(
+    image: Any,
+    *,
+    s3_client: Any | None = None,
+) -> PILImage.Image:
+    """Download and open the raw S3 image referenced by a Dynamo Image entity."""
+    bucket = _get(image, "raw_s3_bucket")
+    key = _get(image, "raw_s3_key")
+    if not bucket or not key:
+        raise ValueError("image must include raw_s3_bucket and raw_s3_key")
+
+    client = s3_client or boto3.client("s3")
+    response = client.get_object(Bucket=bucket, Key=key)
+    body = response["Body"].read()
+    opened = PILImage.open(BytesIO(body))
+    return opened.convert("RGB")
+
+
+def analyze_dynamo_image_fonts(
+    table_name: str,
+    image_id: str,
+    *,
+    receipt_id: int | None = None,
+    region: str = "us-east-1",
+    prefer_receipt_ocr: bool = False,
+    s3_client: Any | None = None,
+    eps: float = 2.2,
+    min_samples: int = 2,
+    min_letters_per_sample: int = 2,
+    promote_singletons_min_letters: int | None = 8,
+) -> ReceiptFontAnalysis:
+    """Load OCR details and raw image from Dynamo/S3, then analyze fonts."""
+    from receipt_dynamo.data.dynamo_client import DynamoClient
+
+    client = DynamoClient(table_name=table_name, region=region)
+    details = client.get_image_details(image_id)
+    if not details.images:
+        raise ValueError(f"Image {image_id} not found")
+
+    selected_receipt = None
+    if prefer_receipt_ocr and details.receipts:
+        if receipt_id is None:
+            selected_receipt = sorted(
+                details.receipts, key=lambda receipt: receipt.receipt_id
+            )[0]
+        else:
+            selected_receipt = next(
+                (
+                    receipt
+                    for receipt in details.receipts
+                    if receipt.receipt_id == receipt_id
+                ),
+                None,
+            )
+            if selected_receipt is None:
+                raise ValueError(
+                    f"Receipt {receipt_id} not found for image {image_id}"
+                )
+
+    if selected_receipt is not None:
+        raw_image = load_raw_image_from_s3(
+            selected_receipt, s3_client=s3_client
+        )
+        selected_receipt_id = selected_receipt.receipt_id
+        lines = [
+            line
+            for line in details.receipt_lines
+            if line.receipt_id == selected_receipt_id
+        ]
+        words = [
+            word
+            for word in details.receipt_words
+            if word.receipt_id == selected_receipt_id
+        ]
+        letters = [
+            letter
+            for letter in details.receipt_letters
+            if letter.receipt_id == selected_receipt_id
+        ]
+    else:
+        raw_image = load_raw_image_from_s3(
+            details.images[0], s3_client=s3_client
+        )
+        lines = details.lines
+        words = details.words
+        letters = details.letters
+
+    return analyze_receipt_fonts(
+        letters,
+        words=words,
+        lines=lines,
+        raw_image=raw_image,
+        eps=eps,
+        min_samples=min_samples,
+        min_letters_per_sample=min_letters_per_sample,
+        promote_singletons_min_letters=promote_singletons_min_letters,
+    )
+
+
+def find_similar_font_samples(
+    query: FontStyleSample,
+    candidates: Sequence[FontStyleSample],
+    *,
+    assignments: Mapping[str, int] | None = None,
+    top_k: int = 5,
+) -> tuple[FontSimilarityMatch, ...]:
+    """Return nearest samples by cosine similarity over style embeddings."""
+    scored = []
+    for candidate in candidates:
+        score = _cosine_similarity(query.vector, candidate.vector)
+        cluster_id = None
+        if assignments is not None:
+            assigned = assignments.get(candidate.sample_id)
+            cluster_id = (
+                assigned if assigned is not None and assigned > 0 else None
+            )
+        scored.append(
+            FontSimilarityMatch(
+                sample_id=candidate.sample_id,
+                score=score,
+                cluster_id=cluster_id,
+            )
+        )
+    scored.sort(key=lambda match: match.score, reverse=True)
+    return tuple(scored[: max(0, top_k)])
+
+
+def _measure_sample(
+    *,
+    text: str,
+    line_id: int,
+    word_id: int,
+    word_box: BoundingBox,
+    line_box: BoundingBox | None,
+    letters: Sequence[Any],
+    letter_boxes: Sequence[BoundingBox],
+    pixel_metrics: Mapping[str, float] | None,
+) -> dict[str, Any]:
+    width = max(word_box["width"], _EPSILON)
+    height = max(word_box["height"], _EPSILON)
+    letter_count = max(len(letters), 1)
+    width_per_char = width / letter_count
+    line_height = (
+        max(line_box["height"], _EPSILON) if line_box is not None else height
+    )
+    line_center_y = (
+        line_box["y"] + line_height / 2.0
+        if line_box is not None
+        else word_box["y"] + height / 2.0
+    )
+    word_center_y = word_box["y"] + height / 2.0
+
+    letter_widths = [max(box["width"], _EPSILON) for box in letter_boxes]
+    letter_heights = [max(box["height"], _EPSILON) for box in letter_boxes]
+    confidences = [
+        _float(_get(letter, "confidence", 1.0), default=1.0)
+        for letter in letters
+    ]
+    angles = [
+        _float(_get(letter, "angle_radians", 0.0), default=0.0)
+        for letter in letters
+    ]
+    characters = [_text(letter) for letter in letters]
+
+    metrics = {
+        "height": height,
+        "width": width,
+        "area": width * height,
+        "width_per_char": width_per_char,
+        "aspect_per_char": width_per_char / height,
+        "height_to_line": height / line_height,
+        "baseline_offset": (word_center_y - line_center_y) / line_height,
+        "glyph_width_cv": _coefficient_of_variation(letter_widths),
+        "glyph_height_cv": _coefficient_of_variation(letter_heights),
+        "uppercase_ratio": _ratio(characters, str.isupper),
+        "digit_ratio": _ratio(characters, str.isdigit),
+        "punctuation_ratio": _ratio(
+            characters, lambda char: not char.isalnum()
+        ),
+        "confidence": mean(confidences) if confidences else 1.0,
+        "angle_radians": mean(angles) if angles else 0.0,
+    }
+    if pixel_metrics is not None:
+        metrics.update(pixel_metrics)
+
+    first = letters[0]
+    return {
+        "image_id": _get(first, "image_id"),
+        "receipt_id": _get(first, "receipt_id"),
+        "line_id": line_id,
+        "word_id": word_id,
+        "text": text,
+        "letter_count": len(letters),
+        "metrics": metrics,
+    }
+
+
+def _raw_feature_rows(
+    measurements: Sequence[dict[str, Any]],
+) -> tuple[list[tuple[float, ...]], tuple[float, ...]]:
+    heights = [item["metrics"]["height"] for item in measurements]
+    advances = [item["metrics"]["width_per_char"] for item in measurements]
+    aspects = [item["metrics"]["aspect_per_char"] for item in measurements]
+    median_height = _median(heights)
+    median_advance = _median(advances)
+    median_aspect = _median(aspects)
+
+    include_pixel_features = any(
+        "pixel_ink_ratio" in item["metrics"] for item in measurements
+    )
+    rows = []
+    for item in measurements:
+        metrics = item["metrics"]
+        font_size_ratio = metrics["height"] / max(median_height, _EPSILON)
+        advance_ratio = metrics["width_per_char"] / max(
+            median_advance, _EPSILON
+        )
+        aspect_ratio = metrics["aspect_per_char"] / max(
+            median_aspect, _EPSILON
+        )
+
+        metrics["font_size_ratio"] = font_size_ratio
+        metrics["advance_ratio"] = advance_ratio
+        metrics["aspect_ratio"] = aspect_ratio
+
+        angle = metrics["angle_radians"]
+        row = (
+            log(max(font_size_ratio, _EPSILON)),
+            log(max(advance_ratio, _EPSILON)),
+            log(max(aspect_ratio, _EPSILON)),
+            metrics["height_to_line"],
+            metrics["baseline_offset"],
+            metrics["glyph_width_cv"],
+            metrics["glyph_height_cv"],
+            metrics["uppercase_ratio"],
+            metrics["digit_ratio"],
+            metrics["punctuation_ratio"],
+            metrics["confidence"],
+            sin(angle),
+            cos(angle),
+        )
+        if include_pixel_features:
+            row = row + tuple(
+                metrics.get(feature_name, 0.0)
+                for feature_name in _PIXEL_FEATURE_NAMES
+            )
+        rows.append(row)
+    weights = _GEOMETRY_FEATURE_WEIGHTS
+    if include_pixel_features:
+        weights = weights + _PIXEL_FEATURE_WEIGHTS
+    return rows, weights
+
+
+def _robust_standardize(
+    rows: Sequence[Sequence[float]], *, weights: Sequence[float]
+) -> list[tuple[float, ...]]:
+    if not rows:
+        return []
+
+    column_count = len(rows[0])
+    columns = [[row[index] for row in rows] for index in range(column_count)]
+    centers = [_median(column) for column in columns]
+    scales = [_mad(column, center) for column, center in zip(columns, centers)]
+
+    vectors = []
+    for row in rows:
+        vector = []
+        for index, value in enumerate(row):
+            scale = scales[index] if scales[index] > _EPSILON else 1.0
+            weight = weights[index] if index < len(weights) else 1.0
+            vector.append(((value - centers[index]) / scale) * weight)
+        vectors.append(tuple(vector))
+    return vectors
+
+
+def _dbscan(
+    vectors: Sequence[Sequence[float]], *, eps: float, min_samples: int
+) -> list[int]:
+    if not vectors:
+        return []
+    if min_samples <= 1:
+        return [index + 1 for index in range(len(vectors))]
+
+    visited = [False for _ in vectors]
+    labels = [0 for _ in vectors]
+    cluster_id = 0
+
+    def neighbors(point_index: int) -> list[int]:
+        return [
+            index
+            for index, candidate in enumerate(vectors)
+            if _euclidean(vectors[point_index], candidate) <= eps
+        ]
+
+    for point_index in range(len(vectors)):
+        if visited[point_index]:
+            continue
+        visited[point_index] = True
+        point_neighbors = neighbors(point_index)
+        if len(point_neighbors) < min_samples:
+            labels[point_index] = -1
+            continue
+
+        cluster_id += 1
+        labels[point_index] = cluster_id
+        seeds = [idx for idx in point_neighbors if idx != point_index]
+        while seeds:
+            seed = seeds.pop(0)
+            if not visited[seed]:
+                visited[seed] = True
+                seed_neighbors = neighbors(seed)
+                if len(seed_neighbors) >= min_samples:
+                    for neighbor in seed_neighbors:
+                        if neighbor not in seeds:
+                            seeds.append(neighbor)
+            if labels[seed] <= 0:
+                labels[seed] = cluster_id
+
+    return labels
+
+
+def _promote_singleton_samples(
+    labels: Sequence[int],
+    samples: Sequence[FontStyleSample],
+    *,
+    promote_singletons_min_letters: int | None,
+) -> list[int]:
+    next_cluster = max([label for label in labels if label > 0], default=0) + 1
+    promoted = list(labels)
+    if promote_singletons_min_letters is None:
+        return promoted
+
+    for index, sample in enumerate(samples):
+        if promoted[index] > 0:
+            continue
+        if sample.letter_count < promote_singletons_min_letters:
+            continue
+        promoted[index] = next_cluster
+        next_cluster += 1
+    return promoted
+
+
+def _build_analysis(
+    samples: Sequence[FontStyleSample], labels: Sequence[int]
+) -> ReceiptFontAnalysis:
+    grouped: dict[int, list[FontStyleSample]] = {}
+    noise = []
+    for sample, label in zip(samples, labels):
+        if label > 0:
+            grouped.setdefault(label, []).append(sample)
+        else:
+            noise.append(sample.sample_id)
+
+    ordered_labels = sorted(
+        grouped,
+        key=lambda label: min(
+            samples.index(sample) for sample in grouped[label]
+        ),
+    )
+    relabel = {
+        old_label: new_label
+        for new_label, old_label in enumerate(ordered_labels, start=1)
+    }
+    assignments = {
+        sample.sample_id: relabel[label] if label > 0 else -1
+        for sample, label in zip(samples, labels)
+    }
+
+    clusters = []
+    for old_label in ordered_labels:
+        cluster_samples = grouped[old_label]
+        cluster_id = relabel[old_label]
+        clusters.append(_make_cluster(cluster_id, cluster_samples))
+
+    return ReceiptFontAnalysis(
+        samples=tuple(samples),
+        clusters=tuple(clusters),
+        noise_sample_ids=tuple(noise),
+        assignments=assignments,
+    )
+
+
+def _make_cluster(
+    cluster_id: int, samples: Sequence[FontStyleSample]
+) -> FontCluster:
+    sample_ids = tuple(sample.sample_id for sample in samples)
+    line_ids = tuple(sorted({sample.line_id for sample in samples}))
+    word_ids = tuple(
+        sorted(
+            {
+                (sample.line_id, sample.word_id)
+                for sample in samples
+                if sample.word_id is not None
+            }
+        )
+    )
+    letter_count = sum(sample.letter_count for sample in samples)
+    centroid = _centroid([sample.vector for sample in samples])
+    metrics = _average_metrics(samples)
+
+    return FontCluster(
+        cluster_id=cluster_id,
+        sample_ids=sample_ids,
+        line_ids=line_ids,
+        word_ids=word_ids,
+        text_examples=tuple(sample.text for sample in samples[:5]),
+        sample_count=len(samples),
+        letter_count=letter_count,
+        centroid=centroid,
+        metrics=metrics,
+        label=_describe_cluster(metrics),
+    )
+
+
+def _average_metrics(samples: Sequence[FontStyleSample]) -> dict[str, float]:
+    metric_names = sorted(
+        {
+            metric_name
+            for sample in samples
+            for metric_name in sample.metrics.keys()
+        }
+    )
+    averaged = {}
+    for name in metric_names:
+        values = [
+            sample.metrics[name]
+            for sample in samples
+            if name in sample.metrics
+        ]
+        if values:
+            averaged[name] = mean(values)
+    return averaged
+
+
+def _describe_cluster(metrics: Mapping[str, float]) -> str:
+    size_ratio = metrics.get("font_size_ratio", 1.0)
+    aspect = metrics.get("aspect_per_char", 0.6)
+    uppercase = metrics.get("uppercase_ratio", 0.0)
+    digit = metrics.get("digit_ratio", 0.0)
+    punctuation = metrics.get("punctuation_ratio", 0.0)
+
+    if size_ratio >= 1.25:
+        size = "large"
+    elif size_ratio <= 0.85:
+        size = "small"
+    else:
+        size = "regular"
+
+    if aspect <= 0.45:
+        width = "condensed"
+    elif aspect >= 0.8:
+        width = "wide"
+    else:
+        width = "normal"
+
+    if digit >= 0.7:
+        text_style = "numeric"
+    elif uppercase >= 0.7:
+        text_style = "uppercase"
+    elif punctuation >= 0.4:
+        text_style = "punctuated"
+    else:
+        text_style = "mixed"
+
+    return f"{size} {width} {text_style}"
+
+
+def _coerce_image(raw_image: Any) -> PILImage.Image:
+    if isinstance(raw_image, PILImage.Image):
+        return raw_image.convert("RGB")
+    if isinstance(raw_image, (bytes, bytearray)):
+        return PILImage.open(BytesIO(raw_image)).convert("RGB")
+    if hasattr(raw_image, "read"):
+        return PILImage.open(raw_image).convert("RGB")
+    return PILImage.open(raw_image).convert("RGB")
+
+
+def _extract_word_crop_metrics(
+    image: PILImage.Image,
+    word_box: BoundingBox,
+    *,
+    y_origin: str,
+    padding_ratio: float,
+) -> dict[str, float] | None:
+    bounds = _image_crop_bounds(
+        word_box,
+        image_size=image.size,
+        y_origin=y_origin,
+        padding_ratio=padding_ratio,
+    )
+    if bounds is None:
+        return None
+
+    crop = image.crop(bounds)
+    if crop.width < 3 or crop.height < 3:
+        return None
+
+    gray = ImageOps.autocontrast(ImageOps.grayscale(crop))
+    width, height = gray.size
+    pixels = list(gray.tobytes())
+    if not pixels:
+        return None
+
+    threshold = _otsu_threshold(pixels)
+    dark_mask = [1 if pixel <= threshold else 0 for pixel in pixels]
+    light_mask = [1 if pixel > threshold else 0 for pixel in pixels]
+    mask = dark_mask if sum(dark_mask) <= sum(light_mask) else light_mask
+    ink_pixels = sum(mask)
+    total_pixels = len(mask)
+    if ink_pixels == 0:
+        return _empty_pixel_metrics()
+
+    content_bbox = _mask_bbox(mask, width, height)
+    if content_bbox is None:
+        return _empty_pixel_metrics()
+
+    left, top, right, bottom = content_bbox
+    content_width = max(right - left + 1, 1)
+    content_height = max(bottom - top + 1, 1)
+    edge_values = list(gray.filter(ImageFilter.FIND_EDGES).tobytes())
+
+    metrics = {
+        "pixel_ink_ratio": ink_pixels / total_pixels,
+        "pixel_edge_density": (
+            sum(1 for value in edge_values if value >= 32) / total_pixels
+        ),
+        "pixel_horizontal_transition_rate": _horizontal_transition_rate(
+            mask, width, height
+        ),
+        "pixel_vertical_transition_rate": _vertical_transition_rate(
+            mask, width, height
+        ),
+        "pixel_content_width_ratio": content_width / width,
+        "pixel_content_height_ratio": content_height / height,
+        "pixel_content_aspect": content_width / content_height,
+        "pixel_top_ink_ratio": _mask_density(
+            mask, width, height, 0, 0, width, height // 3
+        ),
+        "pixel_middle_ink_ratio": _mask_density(
+            mask, width, height, 0, height // 3, width, (height * 2) // 3
+        ),
+        "pixel_bottom_ink_ratio": _mask_density(
+            mask, width, height, 0, (height * 2) // 3, width, height
+        ),
+        "pixel_left_ink_ratio": _mask_density(
+            mask, width, height, 0, 0, width // 3, height
+        ),
+        "pixel_center_ink_ratio": _mask_density(
+            mask, width, height, width // 3, 0, (width * 2) // 3, height
+        ),
+        "pixel_right_ink_ratio": _mask_density(
+            mask, width, height, (width * 2) // 3, 0, width, height
+        ),
+    }
+    metrics.update(_row_profile_metrics(mask, width, height, bins=8))
+    return metrics
+
+
+def _image_crop_bounds(
+    box: BoundingBox,
+    *,
+    image_size: tuple[int, int],
+    y_origin: str,
+    padding_ratio: float,
+) -> tuple[int, int, int, int] | None:
+    image_width, image_height = image_size
+    x = box["x"]
+    y = box["y"]
+    width = box["width"]
+    height = box["height"]
+    normalized = _is_normalized_box(box)
+
+    if normalized:
+        left = x * image_width
+        right = (x + width) * image_width
+        if y_origin == "bottom_left":
+            top = (1.0 - y - height) * image_height
+            bottom = (1.0 - y) * image_height
+        elif y_origin == "top_left":
+            top = y * image_height
+            bottom = (y + height) * image_height
+        else:
+            raise ValueError(
+                "image_y_origin must be 'bottom_left' or 'top_left'"
+            )
+    else:
+        left = x
+        right = x + width
+        if y_origin == "bottom_left":
+            top = image_height - y - height
+            bottom = image_height - y
+        elif y_origin == "top_left":
+            top = y
+            bottom = y + height
+        else:
+            raise ValueError(
+                "image_y_origin must be 'bottom_left' or 'top_left'"
+            )
+
+    crop_width = max(right - left, 1.0)
+    crop_height = max(bottom - top, 1.0)
+    padding = max(2.0, max(crop_width, crop_height) * padding_ratio)
+
+    left = max(0, int(left - padding))
+    top = max(0, int(top - padding))
+    right = min(image_width, int(right + padding + 0.999))
+    bottom = min(image_height, int(bottom + padding + 0.999))
+    if right <= left or bottom <= top:
+        return None
+    return (left, top, right, bottom)
+
+
+def _is_normalized_box(box: BoundingBox) -> bool:
+    return (
+        -0.1 <= box["x"] <= 1.1
+        and -0.1 <= box["y"] <= 1.1
+        and 0.0 <= box["width"] <= 1.2
+        and 0.0 <= box["height"] <= 1.2
+    )
+
+
+def _otsu_threshold(pixels: Sequence[int]) -> int:
+    histogram = [0] * 256
+    for pixel in pixels:
+        histogram[max(0, min(255, int(pixel)))] += 1
+
+    total = len(pixels)
+    sum_total = sum(value * count for value, count in enumerate(histogram))
+    sum_background = 0.0
+    weight_background = 0
+    max_variance = -1.0
+    threshold = 127
+
+    for value, count in enumerate(histogram):
+        weight_background += count
+        if weight_background == 0:
+            continue
+        weight_foreground = total - weight_background
+        if weight_foreground == 0:
+            break
+
+        sum_background += value * count
+        mean_background = sum_background / weight_background
+        mean_foreground = (sum_total - sum_background) / weight_foreground
+        variance = (
+            weight_background
+            * weight_foreground
+            * (mean_background - mean_foreground) ** 2
+        )
+        if variance > max_variance:
+            max_variance = variance
+            threshold = value
+
+    return threshold
+
+
+def _empty_pixel_metrics() -> dict[str, float]:
+    metrics = {name: 0.0 for name in _PIXEL_FEATURE_NAMES}
+    return metrics
+
+
+def _mask_bbox(
+    mask: Sequence[int], width: int, height: int
+) -> tuple[int, int, int, int] | None:
+    xs = []
+    ys = []
+    for index, value in enumerate(mask):
+        if not value:
+            continue
+        y, x = divmod(index, width)
+        xs.append(x)
+        ys.append(y)
+    if not xs or not ys:
+        return None
+    return (min(xs), min(ys), max(xs), max(ys))
+
+
+def _mask_density(
+    mask: Sequence[int],
+    width: int,
+    height: int,
+    left: int,
+    top: int,
+    right: int,
+    bottom: int,
+) -> float:
+    left = max(0, min(width, left))
+    right = max(left, min(width, right))
+    top = max(0, min(height, top))
+    bottom = max(top, min(height, bottom))
+    area = max((right - left) * (bottom - top), 1)
+    ink = 0
+    for y in range(top, bottom):
+        row_offset = y * width
+        ink += sum(mask[row_offset + x] for x in range(left, right))
+    return ink / area
+
+
+def _row_profile_metrics(
+    mask: Sequence[int], width: int, height: int, *, bins: int
+) -> dict[str, float]:
+    metrics = {}
+    for bin_index in range(bins):
+        top = (height * bin_index) // bins
+        bottom = (height * (bin_index + 1)) // bins
+        metrics[f"pixel_row_bin_{bin_index}"] = _mask_density(
+            mask, width, height, 0, top, width, bottom
+        )
+    return metrics
+
+
+def _horizontal_transition_rate(
+    mask: Sequence[int], width: int, height: int
+) -> float:
+    if width <= 1:
+        return 0.0
+    transitions = 0
+    for y in range(height):
+        offset = y * width
+        for x in range(1, width):
+            if mask[offset + x] != mask[offset + x - 1]:
+                transitions += 1
+    return transitions / ((width - 1) * height)
+
+
+def _vertical_transition_rate(
+    mask: Sequence[int], width: int, height: int
+) -> float:
+    if height <= 1:
+        return 0.0
+    transitions = 0
+    for y in range(1, height):
+        offset = y * width
+        previous_offset = (y - 1) * width
+        for x in range(width):
+            if mask[offset + x] != mask[previous_offset + x]:
+                transitions += 1
+    return transitions / (width * (height - 1))
+
+
+def _group_letters_by_word(
+    letters: Iterable[Any],
+) -> dict[tuple[int, int], list[Any]]:
+    grouped: dict[tuple[int, int], list[Any]] = {}
+    for letter in letters:
+        line_id = _int(_get(letter, "line_id"), default=-1)
+        word_id = _int(_get(letter, "word_id"), default=-1)
+        if line_id < 0 or word_id < 0:
+            continue
+        grouped.setdefault((line_id, word_id), []).append(letter)
+    return grouped
+
+
+def _index_by_line(lines: Iterable[Any]) -> dict[int, Any]:
+    return {
+        _int(_get(line, "line_id"), default=-1): line
+        for line in lines
+        if _int(_get(line, "line_id"), default=-1) >= 0
+    }
+
+
+def _index_by_word(words: Iterable[Any]) -> dict[tuple[int, int], Any]:
+    return {
+        (
+            _int(_get(word, "line_id"), default=-1),
+            _int(_get(word, "word_id"), default=-1),
+        ): word
+        for word in words
+        if _int(_get(word, "line_id"), default=-1) >= 0
+        and _int(_get(word, "word_id"), default=-1) >= 0
+    }
+
+
+def _letter_sort_key(letter: Any) -> tuple[int, float]:
+    letter_id = _int(_get(letter, "letter_id"), default=0)
+    box = _box(letter)
+    x = box["x"] if box is not None else 0.0
+    return (letter_id, x)
+
+
+def _sample_id(
+    *,
+    image_id: str | None,
+    receipt_id: int | None,
+    line_id: int,
+    word_id: int | None,
+) -> str:
+    prefix = []
+    if image_id:
+        prefix.append(f"image={image_id}")
+    if receipt_id is not None:
+        prefix.append(f"receipt={receipt_id}")
+    prefix.append(f"line={line_id}")
+    if word_id is not None:
+        prefix.append(f"word={word_id}")
+    return ":".join(prefix)
+
+
+def _box(value: Any) -> BoundingBox | None:
+    if value is None:
+        return None
+
+    bounding_box = _get(value, "bounding_box")
+    if isinstance(bounding_box, Mapping):
+        return {
+            "x": _float(bounding_box.get("x")),
+            "y": _float(bounding_box.get("y")),
+            "width": max(_float(bounding_box.get("width")), _EPSILON),
+            "height": max(_float(bounding_box.get("height")), _EPSILON),
+        }
+
+    corners = [
+        _get(value, "top_left"),
+        _get(value, "top_right"),
+        _get(value, "bottom_left"),
+        _get(value, "bottom_right"),
+    ]
+    points = [
+        (_float(point.get("x")), _float(point.get("y")))
+        for point in corners
+        if isinstance(point, Mapping)
+    ]
+    if not points:
+        return None
+
+    xs = [point[0] for point in points]
+    ys = [point[1] for point in points]
+    min_x = min(xs)
+    min_y = min(ys)
+    return {
+        "x": min_x,
+        "y": min_y,
+        "width": max(max(xs) - min_x, _EPSILON),
+        "height": max(max(ys) - min_y, _EPSILON),
+    }
+
+
+def _union_boxes(boxes: Iterable[BoundingBox]) -> BoundingBox | None:
+    materialized = list(boxes)
+    if not materialized:
+        return None
+
+    min_x = min(box["x"] for box in materialized)
+    min_y = min(box["y"] for box in materialized)
+    max_x = max(box["x"] + box["width"] for box in materialized)
+    max_y = max(box["y"] + box["height"] for box in materialized)
+    return {
+        "x": min_x,
+        "y": min_y,
+        "width": max(max_x - min_x, _EPSILON),
+        "height": max(max_y - min_y, _EPSILON),
+    }
+
+
+def _ratio(characters: Sequence[str], predicate: Any) -> float:
+    visible = [char for char in characters if char.strip()]
+    if not visible:
+        return 0.0
+    return sum(1 for char in visible if predicate(char)) / len(visible)
+
+
+def _coefficient_of_variation(values: Sequence[float]) -> float:
+    if len(values) < 2:
+        return 0.0
+    value_mean = mean(values)
+    if abs(value_mean) <= _EPSILON:
+        return 0.0
+    variance = sum((value - value_mean) ** 2 for value in values) / len(values)
+    return sqrt(variance) / abs(value_mean)
+
+
+def _median(values: Sequence[float]) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    middle = len(ordered) // 2
+    if len(ordered) % 2:
+        return ordered[middle]
+    return (ordered[middle - 1] + ordered[middle]) / 2.0
+
+
+def _mad(values: Sequence[float], center: float) -> float:
+    if not values:
+        return 1.0
+    deviations = [abs(value - center) for value in values]
+    return _median(deviations) * 1.4826
+
+
+def _centroid(vectors: Sequence[Sequence[float]]) -> tuple[float, ...]:
+    if not vectors:
+        return ()
+    return tuple(
+        mean(vector[index] for vector in vectors)
+        for index in range(len(vectors[0]))
+    )
+
+
+def _cosine_similarity(a: Sequence[float], b: Sequence[float]) -> float:
+    numerator = sum(left * right for left, right in zip(a, b))
+    a_norm = sqrt(sum(value * value for value in a))
+    b_norm = sqrt(sum(value * value for value in b))
+    denominator = a_norm * b_norm
+    if denominator <= _EPSILON:
+        return 0.0
+    return numerator / denominator
+
+
+def _euclidean(a: Sequence[float], b: Sequence[float]) -> float:
+    return sqrt(sum((left - right) ** 2 for left, right in zip(a, b)))
+
+
+def _get(value: Any, name: str, default: Any = None) -> Any:
+    if isinstance(value, Mapping):
+        return value.get(name, default)
+    return getattr(value, name, default)
+
+
+def _text(value: Any) -> str:
+    return str(_get(value, "text", ""))
+
+
+def _float(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _int(value: Any, default: int = 0) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default

--- a/receipt_upload/receipt_upload/font_analysis.py
+++ b/receipt_upload/receipt_upload/font_analysis.py
@@ -579,8 +579,7 @@ def _dbscan(
 ) -> list[int]:
     if not vectors:
         return []
-    if min_samples <= 1:
-        return [index + 1 for index in range(len(vectors))]
+    min_samples = max(1, min_samples)
 
     visited = [False for _ in vectors]
     labels = [0 for _ in vectors]

--- a/receipt_upload/receipt_upload/font_letter_analysis.py
+++ b/receipt_upload/receipt_upload/font_letter_analysis.py
@@ -411,7 +411,9 @@ def build_line_font_samples(
                 line_id=key[2],
                 text=text,
                 section=section,
-                letter_sample_ids=tuple(sample.sample_id for sample in samples),
+                letter_sample_ids=tuple(
+                    sample.sample_id for sample in samples
+                ),
                 vector=vector,
                 metrics=metrics,
             )
@@ -481,9 +483,7 @@ def upsert_letter_samples_to_chroma(
                 metadatas=[
                     {
                         **_sample_metadata(sample),
-                        **dict(
-                            extra_metadata_by_id.get(sample.sample_id, {})
-                        ),
+                        **dict(extra_metadata_by_id.get(sample.sample_id, {})),
                     }
                     for sample in batch
                 ],
@@ -672,18 +672,13 @@ def _hog_orientation_metrics(
     values = list(gray.tobytes())
     histogram = [0.0 for _ in range(bins)]
     if width < 3 or height < 3:
-        return {
-            f"hog_orientation_{index}": 0.0 for index in range(bins)
-        }
+        return {f"hog_orientation_{index}": 0.0 for index in range(bins)}
 
     for y in range(1, height - 1):
         offset = y * width
         for x in range(1, width - 1):
             gx = values[offset + x + 1] - values[offset + x - 1]
-            gy = (
-                values[offset + width + x]
-                - values[offset - width + x]
-            )
+            gy = values[offset + width + x] - values[offset - width + x]
             magnitude = (gx * gx + gy * gy) ** 0.5
             if magnitude <= _EPSILON:
                 continue
@@ -693,9 +688,7 @@ def _hog_orientation_metrics(
 
     total = sum(histogram)
     if total <= _EPSILON:
-        return {
-            f"hog_orientation_{index}": 0.0 for index in range(bins)
-        }
+        return {f"hog_orientation_{index}": 0.0 for index in range(bins)}
     return {
         f"hog_orientation_{index}": value / total
         for index, value in enumerate(histogram)
@@ -1080,7 +1073,9 @@ def _build_letter_analysis(
 
     ordered_labels = sorted(
         grouped,
-        key=lambda label: min(samples.index(sample) for sample in grouped[label]),
+        key=lambda label: min(
+            samples.index(sample) for sample in grouped[label]
+        ),
     )
     relabel = {
         old_label: new_label
@@ -1152,7 +1147,9 @@ def _cluster_vectors(
         raw_labels = DBSCAN(eps=eps, min_samples=min_samples).fit_predict(
             list(vectors)
         )
-        return [int(label) + 1 if int(label) >= 0 else -1 for label in raw_labels]
+        return [
+            int(label) + 1 if int(label) >= 0 else -1 for label in raw_labels
+        ]
     except Exception:
         return _dbscan(vectors, eps=eps, min_samples=min_samples)
 
@@ -1168,7 +1165,10 @@ def _make_letter_cluster(
         sample_count=len(samples),
         line_ids=tuple(sorted({sample.line_id for sample in samples})),
         normalized_chars=tuple(
-            char for char, _ in _top_counts(sample.normalized_char for sample in samples)
+            char
+            for char, _ in _top_counts(
+                sample.normalized_char for sample in samples
+            )
         ),
         text_examples=tuple(sample.text for sample in samples[:8]),
         centroid=_centroid([sample.style_vector for sample in samples]),
@@ -1214,7 +1214,9 @@ def _average_metrics(
     )
     return {
         name: mean(
-            sample.metrics[name] for sample in samples if name in sample.metrics
+            sample.metrics[name]
+            for sample in samples
+            if name in sample.metrics
         )
         for name in metric_names
     }
@@ -1273,7 +1275,8 @@ def _line_metrics(
         "line_box_y": line_box["y"],
         "line_box_width": line_box["width"],
         "line_box_height": line_box["height"],
-        "line_box_aspect": line_box["width"] / max(line_box["height"], _EPSILON),
+        "line_box_aspect": line_box["width"]
+        / max(line_box["height"], _EPSILON),
         "line_center_x": line_box["x"] + line_box["width"] / 2,
         "line_center_y": line_box["y"] + line_box["height"] / 2,
         "letter_area_ratio": letter_area / line_area,
@@ -1298,7 +1301,9 @@ def _aggregated_letter_metrics(
     return metrics
 
 
-def _line_box(line: Any | None, samples: Sequence[LetterImageSample]) -> BoundingBox:
+def _line_box(
+    line: Any | None, samples: Sequence[LetterImageSample]
+) -> BoundingBox:
     box = _box(line) if line is not None else None
     if box is not None:
         return box
@@ -1310,7 +1315,8 @@ def _line_box(line: Any | None, samples: Sequence[LetterImageSample]) -> Boundin
     )
     bottom = min(sample.metrics.get("box_y", 0.0) for sample in samples)
     top = max(
-        sample.metrics.get("box_y", 0.0) + sample.metrics.get("box_height", 0.0)
+        sample.metrics.get("box_y", 0.0)
+        + sample.metrics.get("box_height", 0.0)
         for sample in samples
     )
     return {
@@ -1332,10 +1338,9 @@ def _spacing_metrics(
     inter_word_gaps = []
     advances = []
     for current, following in zip(ordered, ordered[1:]):
-        current_right = (
-            current.metrics.get("box_x", 0.0)
-            + current.metrics.get("box_width", 0.0)
-        )
+        current_right = current.metrics.get(
+            "box_x", 0.0
+        ) + current.metrics.get("box_width", 0.0)
         gap = max(following.metrics.get("box_x", 0.0) - current_right, 0.0)
         advance = max(
             following.metrics.get("box_center_x", 0.0)
@@ -1356,15 +1361,16 @@ def _spacing_metrics(
         "median_gap": median_gap,
         "mean_gap": gap_mean,
         "std_gap": gap_std,
-        "median_intra_word_gap": median(intra_word_gaps)
-        if intra_word_gaps
-        else 0.0,
-        "median_inter_word_gap": median(inter_word_gaps)
-        if inter_word_gaps
-        else 0.0,
+        "median_intra_word_gap": (
+            median(intra_word_gaps) if intra_word_gaps else 0.0
+        ),
+        "median_inter_word_gap": (
+            median(inter_word_gaps) if inter_word_gaps else 0.0
+        ),
         "median_advance": median_advance,
         "gap_to_height_ratio": median_gap / max(median_height, _EPSILON),
-        "advance_to_height_ratio": median_advance / max(median_height, _EPSILON),
+        "advance_to_height_ratio": median_advance
+        / max(median_height, _EPSILON),
     }
 
 
@@ -1398,8 +1404,7 @@ def _letter_cluster_mix_metrics(
         }
 
     cluster_ids = [
-        int(letter_assignments.get(sample.sample_id, -1))
-        for sample in samples
+        int(letter_assignments.get(sample.sample_id, -1)) for sample in samples
     ]
     assigned = [cluster_id for cluster_id in cluster_ids if cluster_id > 0]
     count = max(len(cluster_ids), 1)
@@ -1428,7 +1433,9 @@ def _line_text_for_key(
     word_text = " ".join(_text(word) for word in words).strip()
     if word_text:
         return word_text
-    return "".join(sample.text for sample in sorted(samples, key=_letter_sort_value))
+    return "".join(
+        sample.text for sample in sorted(samples, key=_letter_sort_value)
+    )
 
 
 def _lookup_line_mapping(
@@ -1565,7 +1572,9 @@ def _describe_letter_cluster(metrics: Mapping[str, float]) -> str:
 
 
 def _describe_line_cluster(metrics: Mapping[str, float]) -> str:
-    height = metrics.get("median_box_height", metrics.get("line_box_height", 0.0))
+    height = metrics.get(
+        "median_box_height", metrics.get("line_box_height", 0.0)
+    )
     aspect = metrics.get("mean_box_aspect", 0.0)
     ink = metrics.get("mean_ink_ratio", 0.0)
     spacing = metrics.get("gap_to_height_ratio", 0.0)

--- a/receipt_upload/receipt_upload/font_letter_analysis.py
+++ b/receipt_upload/receipt_upload/font_letter_analysis.py
@@ -450,8 +450,12 @@ def upsert_letter_samples_to_chroma(
     collection_name: str = "letter_font_glyphs",
     extra_metadata_by_id: Mapping[str, Mapping[str, object]] | None = None,
     batch_size: int = 1000,
+    reset_collection: bool = False,
 ) -> int:
-    """Persist letter style vectors into a separate local Chroma collection."""
+    """Persist letter style vectors into a separate local Chroma collection.
+
+    Existing rows are preserved unless ``reset_collection`` is explicitly set.
+    """
     from receipt_chroma import ChromaClient
 
     extra_metadata_by_id = extra_metadata_by_id or {}
@@ -467,7 +471,7 @@ def upsert_letter_samples_to_chroma(
                 "description": "Receipt OCR letter crop style embeddings"
             },
         )
-        if collection.count():
+        if reset_collection and collection.count():
             existing = collection.get(include=["metadatas"])
             existing_ids = list(existing.get("ids") or [])
             for start in range(0, len(existing_ids), batch_size):

--- a/receipt_upload/receipt_upload/font_letter_analysis.py
+++ b/receipt_upload/receipt_upload/font_letter_analysis.py
@@ -1,0 +1,1693 @@
+"""Letter-crop embeddings for receipt font/style clustering.
+
+This module embeds individual OCR letter crops using visual features rather
+than semantic text embeddings. OCR's character guess is used to remove glyph
+identity from the style vector, so clustering has a better chance of grouping
+visual font/style differences instead of just grouping "A" separately from
+"7".
+"""
+
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from math import atan2, pi
+from statistics import mean, median
+from typing import Any, Mapping, Sequence
+
+from PIL import Image as PILImage
+from PIL import ImageFilter, ImageOps
+
+from receipt_upload.font_analysis import (
+    _EPSILON,
+    _box,
+    _centroid,
+    _coerce_image,
+    _dbscan,
+    _float,
+    _get,
+    _horizontal_transition_rate,
+    _image_crop_bounds,
+    _int,
+    _mask_bbox,
+    _mask_density,
+    _otsu_threshold,
+    _text,
+    _vertical_transition_rate,
+)
+
+BoundingBox = dict[str, float]
+LineKey = tuple[str | None, int | None, int]
+
+_GLYPH_SIZE = 16
+_PROJECTION_BINS = 8
+_HOG_BINS = 8
+_ROW_PROJECTION_NAMES = tuple(
+    f"row_projection_{index}" for index in range(_PROJECTION_BINS)
+)
+_COLUMN_PROJECTION_NAMES = tuple(
+    f"column_projection_{index}" for index in range(_PROJECTION_BINS)
+)
+_HOG_FEATURE_NAMES = tuple(
+    f"hog_orientation_{index}" for index in range(_HOG_BINS)
+)
+_STROKE_FEATURE_NAMES = (
+    "stroke_width_mean",
+    "stroke_width_std",
+    "stroke_width_max",
+    "stroke_width_mean_norm",
+    "stroke_width_max_norm",
+)
+_CONTOUR_FEATURE_NAMES = (
+    "top_profile_mean",
+    "top_profile_std",
+    "bottom_profile_mean",
+    "bottom_profile_std",
+    "left_profile_mean",
+    "left_profile_std",
+    "right_profile_mean",
+    "right_profile_std",
+    "vertical_symmetry",
+    "horizontal_symmetry",
+)
+_COMPONENT_FEATURE_NAMES = (
+    "component_count",
+    "largest_component_ratio",
+    "hole_count",
+    "hole_area_ratio",
+)
+_STYLE_METRIC_NAMES = (
+    "box_width",
+    "box_height",
+    "box_aspect",
+    "ink_ratio",
+    "edge_density",
+    "horizontal_transition_rate",
+    "vertical_transition_rate",
+    "content_width_ratio",
+    "content_height_ratio",
+    "content_aspect",
+    "top_ink_ratio",
+    "middle_ink_ratio",
+    "bottom_ink_ratio",
+    "left_ink_ratio",
+    "center_ink_ratio",
+    "right_ink_ratio",
+    "confidence",
+) + (
+    *_ROW_PROJECTION_NAMES,
+    *_COLUMN_PROJECTION_NAMES,
+    *_HOG_FEATURE_NAMES,
+    *_STROKE_FEATURE_NAMES,
+    *_CONTOUR_FEATURE_NAMES,
+    *_COMPONENT_FEATURE_NAMES,
+)
+_ABSOLUTE_STYLE_NAMES = (
+    "box_width",
+    "box_height",
+    "box_aspect",
+    "ink_ratio",
+    "edge_density",
+    "horizontal_transition_rate",
+    "vertical_transition_rate",
+    "content_aspect",
+    "confidence",
+) + (
+    "stroke_width_mean_norm",
+    "stroke_width_max_norm",
+    "component_count",
+    "largest_component_ratio",
+    "hole_count",
+    "hole_area_ratio",
+    "vertical_symmetry",
+    "horizontal_symmetry",
+)
+_LINE_LETTER_AGGREGATE_SOURCE_NAMES = (
+    "box_x",
+    "box_y",
+    "box_center_x",
+    "box_center_y",
+    *_STYLE_METRIC_NAMES,
+)
+_LINE_AGGREGATE_STATS = ("mean", "median", "std")
+_LINE_BASE_METRIC_NAMES = (
+    "letter_count",
+    "word_count",
+    "line_box_x",
+    "line_box_y",
+    "line_box_width",
+    "line_box_height",
+    "line_box_aspect",
+    "line_center_x",
+    "line_center_y",
+    "letter_area_ratio",
+    "median_gap",
+    "mean_gap",
+    "std_gap",
+    "median_intra_word_gap",
+    "median_inter_word_gap",
+    "median_advance",
+    "gap_to_height_ratio",
+    "advance_to_height_ratio",
+    "alpha_ratio",
+    "uppercase_ratio",
+    "digit_ratio",
+    "punctuation_ratio",
+    "assigned_letter_cluster_ratio",
+    "noise_letter_cluster_ratio",
+    "dominant_letter_cluster_ratio",
+    "distinct_letter_cluster_ratio",
+)
+_LINE_AGGREGATE_METRIC_NAMES = tuple(
+    f"{stat}_{name}"
+    for name in _LINE_LETTER_AGGREGATE_SOURCE_NAMES
+    for stat in _LINE_AGGREGATE_STATS
+)
+_LINE_METRIC_NAMES = _LINE_BASE_METRIC_NAMES + _LINE_AGGREGATE_METRIC_NAMES
+
+
+@dataclass(frozen=True)
+class LetterImageSample:
+    """A single OCR letter crop embedded as a visual style vector."""
+
+    sample_id: str
+    image_id: str | None
+    receipt_id: int | None
+    line_id: int
+    word_id: int
+    letter_id: int
+    text: str
+    normalized_char: str
+    vector: tuple[float, ...]
+    style_vector: tuple[float, ...]
+    metrics: dict[str, float]
+
+
+@dataclass(frozen=True)
+class LetterStyleCluster:
+    """A discovered visual style cluster over letter crops."""
+
+    cluster_id: int
+    sample_ids: tuple[str, ...]
+    sample_count: int
+    line_ids: tuple[int, ...]
+    normalized_chars: tuple[str, ...]
+    text_examples: tuple[str, ...]
+    centroid: tuple[float, ...]
+    metrics: dict[str, float]
+    label: str
+
+
+@dataclass(frozen=True)
+class LetterFontAnalysis:
+    """Letter-level font/style clustering result."""
+
+    samples: tuple[LetterImageSample, ...]
+    clusters: tuple[LetterStyleCluster, ...]
+    noise_sample_ids: tuple[str, ...]
+    assignments: dict[str, int]
+
+    def cluster_for_sample(self, sample_id: str) -> int | None:
+        cluster_id = self.assignments.get(sample_id)
+        if cluster_id is None or cluster_id < 0:
+            return None
+        return cluster_id
+
+
+@dataclass(frozen=True)
+class LineFontSample:
+    """A line-level font/style signature aggregated from OCR letter crops."""
+
+    sample_id: str
+    image_id: str | None
+    receipt_id: int | None
+    line_id: int
+    text: str
+    section: str | None
+    letter_sample_ids: tuple[str, ...]
+    vector: tuple[float, ...]
+    metrics: dict[str, float]
+
+
+@dataclass(frozen=True)
+class LineFontCluster:
+    """A discovered visual style cluster over receipt lines."""
+
+    cluster_id: int
+    sample_ids: tuple[str, ...]
+    sample_count: int
+    line_ids: tuple[int, ...]
+    sections: tuple[str, ...]
+    text_examples: tuple[str, ...]
+    centroid: tuple[float, ...]
+    metrics: dict[str, float]
+    label: str
+
+
+@dataclass(frozen=True)
+class LineFontAnalysis:
+    """Line-level font/style clustering result."""
+
+    samples: tuple[LineFontSample, ...]
+    clusters: tuple[LineFontCluster, ...]
+    noise_sample_ids: tuple[str, ...]
+    assignments: dict[str, int]
+
+    def cluster_for_sample(self, sample_id: str) -> int | None:
+        cluster_id = self.assignments.get(sample_id)
+        if cluster_id is None or cluster_id < 0:
+            return None
+        return cluster_id
+
+
+def build_letter_image_samples(
+    letters: Sequence[Any],
+    *,
+    raw_image: Any,
+    image_y_origin: str = "bottom_left",
+    crop_padding: float = 0.24,
+    glyph_size: int = _GLYPH_SIZE,
+    min_confidence: float = 0.35,
+) -> tuple[LetterImageSample, ...]:
+    """Build one visual embedding per OCR letter crop.
+
+    The returned ``style_vector`` is character-centered: each glyph's visual
+    embedding is centered against other OCR-identical glyphs before absolute
+    style metrics are appended. This keeps the OCR guess useful without making
+    the clustering mostly about glyph identity.
+    """
+    image = _coerce_image(raw_image)
+    records: list[dict[str, Any]] = []
+
+    for letter in letters:
+        char = _text(letter)
+        if len(char) != 1 or not char.strip():
+            continue
+
+        confidence = _float(_get(letter, "confidence", 1.0), default=1.0)
+        if confidence < min_confidence:
+            continue
+
+        box = _box(letter)
+        if box is None:
+            continue
+
+        crop_features = _extract_letter_crop_features(
+            image,
+            box,
+            y_origin=image_y_origin,
+            padding_ratio=crop_padding,
+            glyph_size=glyph_size,
+        )
+        if crop_features is None:
+            continue
+
+        metrics = {
+            **crop_features["metrics"],
+            "box_x": box["x"],
+            "box_y": box["y"],
+            "box_width": box["width"],
+            "box_height": box["height"],
+            "box_center_x": box["x"] + box["width"] / 2,
+            "box_center_y": box["y"] + box["height"] / 2,
+            "box_aspect": box["width"] / max(box["height"], _EPSILON),
+            "confidence": confidence,
+        }
+        base_vector = tuple(crop_features["glyph_vector"]) + tuple(
+            metrics[name] for name in _STYLE_METRIC_NAMES
+        )
+        normalized_vector = _l2_normalize(base_vector)
+
+        records.append(
+            {
+                "image_id": _get(letter, "image_id"),
+                "receipt_id": _optional_int(_get(letter, "receipt_id")),
+                "line_id": _int(_get(letter, "line_id"), default=-1),
+                "word_id": _int(_get(letter, "word_id"), default=-1),
+                "letter_id": _int(_get(letter, "letter_id"), default=-1),
+                "text": char,
+                "normalized_char": _normalize_char(char),
+                "vector": normalized_vector,
+                "metrics": metrics,
+            }
+        )
+
+    return _with_style_vectors(records)
+
+
+def cluster_letter_styles(
+    samples: Sequence[LetterImageSample],
+    *,
+    eps: float = 0.78,
+    min_samples: int = 5,
+    promote_singletons_min_samples: int | None = None,
+) -> LetterFontAnalysis:
+    """Cluster character-centered letter style vectors."""
+    if not samples:
+        return LetterFontAnalysis((), (), (), {})
+
+    labels = _cluster_vectors(
+        [sample.style_vector for sample in samples],
+        eps=eps,
+        min_samples=min_samples,
+    )
+    if promote_singletons_min_samples is not None:
+        labels = _promote_large_noise_groups(
+            labels,
+            samples,
+            min_group_size=promote_singletons_min_samples,
+        )
+    return _build_letter_analysis(samples, labels)
+
+
+def build_line_font_samples(
+    letter_samples: Sequence[LetterImageSample],
+    *,
+    lines: Sequence[Any] | None = None,
+    words: Sequence[Any] | None = None,
+    letter_assignments: Mapping[str, int] | None = None,
+    section_by_line: Mapping[Any, str] | None = None,
+    min_letters_per_line: int = 3,
+) -> tuple[LineFontSample, ...]:
+    """Aggregate letter crop features into one font/style signature per line."""
+    if not letter_samples:
+        return ()
+
+    line_by_key, words_by_key = _line_context_maps(lines, words)
+    groups: dict[LineKey, list[LetterImageSample]] = defaultdict(list)
+    for sample in letter_samples:
+        groups[_line_key_from_sample(sample)].append(sample)
+
+    line_samples = []
+    for key in sorted(groups, key=_line_key_sort_value):
+        samples = sorted(groups[key], key=_letter_sort_value)
+        if len(samples) < min_letters_per_line:
+            continue
+
+        line = line_by_key.get(key)
+        text = _line_text_for_key(key, line, words_by_key, samples)
+        section = _lookup_line_mapping(section_by_line, key, key[2])
+        metrics = _line_metrics(
+            samples,
+            line=line,
+            words=words_by_key.get(key, ()),
+            letter_assignments=letter_assignments,
+        )
+        style_centroid = _centroid([sample.style_vector for sample in samples])
+        style_spread = _componentwise_std(
+            [sample.style_vector for sample in samples],
+            style_centroid,
+        )
+        vector = (
+            tuple(metrics[name] for name in _LINE_METRIC_NAMES)
+            + style_centroid
+            + style_spread
+        )
+        line_samples.append(
+            LineFontSample(
+                sample_id=_line_sample_id(key),
+                image_id=key[0],
+                receipt_id=key[1],
+                line_id=key[2],
+                text=text,
+                section=section,
+                letter_sample_ids=tuple(sample.sample_id for sample in samples),
+                vector=vector,
+                metrics=metrics,
+            )
+        )
+
+    return tuple(line_samples)
+
+
+def cluster_line_font_styles(
+    samples: Sequence[LineFontSample],
+    *,
+    eps: float = 0.58,
+    min_samples: int = 2,
+) -> LineFontAnalysis:
+    """Cluster line-level font/style signatures."""
+    if not samples:
+        return LineFontAnalysis((), (), (), {})
+
+    prepared_vectors = _robust_standardized_l2_vectors(
+        [sample.vector for sample in samples]
+    )
+    labels = _cluster_vectors(
+        prepared_vectors,
+        eps=eps,
+        min_samples=min_samples,
+    )
+    return _build_line_analysis(samples, labels, prepared_vectors)
+
+
+def upsert_letter_samples_to_chroma(
+    samples: Sequence[LetterImageSample],
+    *,
+    persist_directory: str,
+    collection_name: str = "letter_font_glyphs",
+    extra_metadata_by_id: Mapping[str, Mapping[str, object]] | None = None,
+    batch_size: int = 1000,
+) -> int:
+    """Persist letter style vectors into a separate local Chroma collection."""
+    from receipt_chroma import ChromaClient
+
+    extra_metadata_by_id = extra_metadata_by_id or {}
+    with ChromaClient(
+        persist_directory=persist_directory,
+        mode="write",
+        metadata_only=True,
+    ) as client:
+        collection = client.get_collection(
+            collection_name,
+            create_if_missing=True,
+            metadata={
+                "description": "Receipt OCR letter crop style embeddings"
+            },
+        )
+        if collection.count():
+            existing = collection.get(include=["metadatas"])
+            existing_ids = list(existing.get("ids") or [])
+            for start in range(0, len(existing_ids), batch_size):
+                collection.delete(ids=existing_ids[start : start + batch_size])
+
+        for start in range(0, len(samples), batch_size):
+            batch = samples[start : start + batch_size]
+            client.upsert(
+                collection_name=collection_name,
+                ids=[sample.sample_id for sample in batch],
+                embeddings=[list(sample.style_vector) for sample in batch],
+                documents=[sample.text for sample in batch],
+                metadatas=[
+                    {
+                        **_sample_metadata(sample),
+                        **dict(
+                            extra_metadata_by_id.get(sample.sample_id, {})
+                        ),
+                    }
+                    for sample in batch
+                ],
+            )
+
+        return client.count(collection_name)
+
+
+def query_similar_letters(
+    *,
+    persist_directory: str,
+    query_sample: LetterImageSample,
+    collection_name: str = "letter_font_glyphs",
+    n_results: int = 8,
+    same_character_only: bool = True,
+) -> dict[str, Any]:
+    """Query Chroma for similar letter style vectors."""
+    from receipt_chroma import ChromaClient
+
+    where = None
+    if same_character_only:
+        where = {"normalized_char": query_sample.normalized_char}
+
+    with ChromaClient(
+        persist_directory=persist_directory,
+        mode="read",
+    ) as client:
+        return client.query(
+            collection_name=collection_name,
+            query_embeddings=[list(query_sample.style_vector)],
+            n_results=n_results,
+            where=where,
+            include=["metadatas", "documents", "distances"],
+        )
+
+
+def _extract_letter_crop_features(
+    image: PILImage.Image,
+    box: BoundingBox,
+    *,
+    y_origin: str,
+    padding_ratio: float,
+    glyph_size: int,
+) -> dict[str, Any] | None:
+    bounds = _image_crop_bounds(
+        box,
+        image_size=image.size,
+        y_origin=y_origin,
+        padding_ratio=padding_ratio,
+    )
+    if bounds is None:
+        return None
+
+    crop = image.crop(bounds)
+    if crop.width < 3 or crop.height < 3:
+        return None
+
+    gray = ImageOps.autocontrast(ImageOps.grayscale(crop))
+    width, height = gray.size
+    pixels = list(gray.tobytes())
+    if not pixels:
+        return None
+
+    threshold = _otsu_threshold(pixels)
+    dark_mask = [1 if pixel <= threshold else 0 for pixel in pixels]
+    light_mask = [1 if pixel > threshold else 0 for pixel in pixels]
+    mask = dark_mask if sum(dark_mask) <= sum(light_mask) else light_mask
+    ink_pixels = sum(mask)
+    total_pixels = len(mask)
+    if ink_pixels == 0:
+        return None
+
+    content_bbox = _mask_bbox(mask, width, height)
+    if content_bbox is None:
+        return None
+
+    left, top, right, bottom = content_bbox
+    content_width = max(right - left + 1, 1)
+    content_height = max(bottom - top + 1, 1)
+    edge_values = list(gray.filter(ImageFilter.FIND_EDGES).tobytes())
+
+    metrics = {
+        "ink_ratio": ink_pixels / total_pixels,
+        "edge_density": (
+            sum(1 for value in edge_values if value >= 32) / total_pixels
+        ),
+        "horizontal_transition_rate": _horizontal_transition_rate(
+            mask, width, height
+        ),
+        "vertical_transition_rate": _vertical_transition_rate(
+            mask, width, height
+        ),
+        "content_width_ratio": content_width / width,
+        "content_height_ratio": content_height / height,
+        "content_aspect": content_width / content_height,
+        "top_ink_ratio": _mask_density(
+            mask, width, height, 0, 0, width, height // 3
+        ),
+        "middle_ink_ratio": _mask_density(
+            mask, width, height, 0, height // 3, width, (height * 2) // 3
+        ),
+        "bottom_ink_ratio": _mask_density(
+            mask, width, height, 0, (height * 2) // 3, width, height
+        ),
+        "left_ink_ratio": _mask_density(
+            mask, width, height, 0, 0, width // 3, height
+        ),
+        "center_ink_ratio": _mask_density(
+            mask, width, height, width // 3, 0, (width * 2) // 3, height
+        ),
+        "right_ink_ratio": _mask_density(
+            mask, width, height, (width * 2) // 3, 0, width, height
+        ),
+    }
+    metrics.update(
+        _projection_metrics(
+            mask,
+            width=width,
+            height=height,
+            bins=_PROJECTION_BINS,
+        )
+    )
+    metrics.update(
+        _hog_orientation_metrics(
+            gray,
+            width=width,
+            height=height,
+            bins=_HOG_BINS,
+        )
+    )
+    metrics.update(
+        _stroke_width_metrics(
+            mask,
+            width=width,
+            height=height,
+            content_bbox=content_bbox,
+        )
+    )
+    metrics.update(
+        _contour_profile_metrics(
+            mask,
+            width=width,
+            height=height,
+            content_bbox=content_bbox,
+        )
+    )
+    metrics.update(
+        _component_metrics(
+            mask,
+            width=width,
+            height=height,
+            content_bbox=content_bbox,
+        )
+    )
+    glyph_vector = _normalized_glyph_vector(
+        mask,
+        width=width,
+        height=height,
+        content_bbox=content_bbox,
+        glyph_size=glyph_size,
+    )
+    return {"glyph_vector": glyph_vector, "metrics": metrics}
+
+
+def _projection_metrics(
+    mask: Sequence[int], *, width: int, height: int, bins: int
+) -> dict[str, float]:
+    metrics = {}
+    for bin_index in range(bins):
+        top = (height * bin_index) // bins
+        bottom = (height * (bin_index + 1)) // bins
+        left = (width * bin_index) // bins
+        right = (width * (bin_index + 1)) // bins
+        metrics[f"row_projection_{bin_index}"] = _mask_density(
+            mask, width, height, 0, top, width, bottom
+        )
+        metrics[f"column_projection_{bin_index}"] = _mask_density(
+            mask, width, height, left, 0, right, height
+        )
+    return metrics
+
+
+def _hog_orientation_metrics(
+    gray: PILImage.Image, *, width: int, height: int, bins: int
+) -> dict[str, float]:
+    values = list(gray.tobytes())
+    histogram = [0.0 for _ in range(bins)]
+    if width < 3 or height < 3:
+        return {
+            f"hog_orientation_{index}": 0.0 for index in range(bins)
+        }
+
+    for y in range(1, height - 1):
+        offset = y * width
+        for x in range(1, width - 1):
+            gx = values[offset + x + 1] - values[offset + x - 1]
+            gy = (
+                values[offset + width + x]
+                - values[offset - width + x]
+            )
+            magnitude = (gx * gx + gy * gy) ** 0.5
+            if magnitude <= _EPSILON:
+                continue
+            angle = atan2(gy, gx) % pi
+            bin_index = min(int((angle / pi) * bins), bins - 1)
+            histogram[bin_index] += magnitude
+
+    total = sum(histogram)
+    if total <= _EPSILON:
+        return {
+            f"hog_orientation_{index}": 0.0 for index in range(bins)
+        }
+    return {
+        f"hog_orientation_{index}": value / total
+        for index, value in enumerate(histogram)
+    }
+
+
+def _stroke_width_metrics(
+    mask: Sequence[int],
+    *,
+    width: int,
+    height: int,
+    content_bbox: tuple[int, int, int, int],
+) -> dict[str, float]:
+    left, top, right, bottom = content_bbox
+    horizontal_runs = _ink_run_lengths(mask, width=width, height=height)
+    vertical_runs = _ink_run_lengths(
+        mask, width=width, height=height, transpose=True
+    )
+    local_widths = []
+    for y in range(top, bottom + 1):
+        row_offset = y * width
+        for x in range(left, right + 1):
+            index = row_offset + x
+            if not mask[index]:
+                continue
+            local_widths.append(
+                min(horizontal_runs[index], vertical_runs[index])
+            )
+
+    if not local_widths:
+        return {
+            "stroke_width_mean": 0.0,
+            "stroke_width_std": 0.0,
+            "stroke_width_max": 0.0,
+            "stroke_width_mean_norm": 0.0,
+            "stroke_width_max_norm": 0.0,
+        }
+
+    width_mean = mean(local_widths)
+    width_std = _std(local_widths, width_mean)
+    width_max = max(local_widths)
+    content_height = max(bottom - top + 1, 1)
+    return {
+        "stroke_width_mean": width_mean,
+        "stroke_width_std": width_std,
+        "stroke_width_max": float(width_max),
+        "stroke_width_mean_norm": width_mean / content_height,
+        "stroke_width_max_norm": width_max / content_height,
+    }
+
+
+def _ink_run_lengths(
+    mask: Sequence[int],
+    *,
+    width: int,
+    height: int,
+    transpose: bool = False,
+) -> list[int]:
+    runs = [0 for _ in mask]
+    outer = width if transpose else height
+    inner = height if transpose else width
+    for outer_index in range(outer):
+        start: int | None = None
+        for inner_index in range(inner + 1):
+            if inner_index < inner:
+                x = outer_index if transpose else inner_index
+                y = inner_index if transpose else outer_index
+                index = y * width + x
+                is_ink = bool(mask[index])
+            else:
+                index = -1
+                is_ink = False
+
+            if is_ink and start is None:
+                start = inner_index
+            elif not is_ink and start is not None:
+                run_length = inner_index - start
+                for run_index in range(start, inner_index):
+                    x = outer_index if transpose else run_index
+                    y = run_index if transpose else outer_index
+                    runs[y * width + x] = run_length
+                start = None
+    return runs
+
+
+def _contour_profile_metrics(
+    mask: Sequence[int],
+    *,
+    width: int,
+    height: int,
+    content_bbox: tuple[int, int, int, int],
+) -> dict[str, float]:
+    del height
+    left, top, right, bottom = content_bbox
+    content_width = max(right - left + 1, 1)
+    content_height = max(bottom - top + 1, 1)
+    top_profile = []
+    bottom_profile = []
+    for x in range(left, right + 1):
+        ys = [y for y in range(top, bottom + 1) if mask[y * width + x]]
+        if not ys:
+            continue
+        top_profile.append((min(ys) - top) / content_height)
+        bottom_profile.append((bottom - max(ys)) / content_height)
+
+    left_profile = []
+    right_profile = []
+    for y in range(top, bottom + 1):
+        xs = [x for x in range(left, right + 1) if mask[y * width + x]]
+        if not xs:
+            continue
+        left_profile.append((min(xs) - left) / content_width)
+        right_profile.append((right - max(xs)) / content_width)
+
+    top_mean, top_std = _mean_std(top_profile)
+    bottom_mean, bottom_std = _mean_std(bottom_profile)
+    left_mean, left_std = _mean_std(left_profile)
+    right_mean, right_std = _mean_std(right_profile)
+    return {
+        "top_profile_mean": top_mean,
+        "top_profile_std": top_std,
+        "bottom_profile_mean": bottom_mean,
+        "bottom_profile_std": bottom_std,
+        "left_profile_mean": left_mean,
+        "left_profile_std": left_std,
+        "right_profile_mean": right_mean,
+        "right_profile_std": right_std,
+        "vertical_symmetry": _binary_symmetry(
+            mask,
+            width=width,
+            content_bbox=content_bbox,
+            axis="vertical",
+        ),
+        "horizontal_symmetry": _binary_symmetry(
+            mask,
+            width=width,
+            content_bbox=content_bbox,
+            axis="horizontal",
+        ),
+    }
+
+
+def _binary_symmetry(
+    mask: Sequence[int],
+    *,
+    width: int,
+    content_bbox: tuple[int, int, int, int],
+    axis: str,
+) -> float:
+    left, top, right, bottom = content_bbox
+    differences = 0
+    comparisons = 0
+    if axis == "vertical":
+        for y in range(top, bottom + 1):
+            for x in range(left, right + 1):
+                mirrored_x = right - (x - left)
+                differences += (
+                    mask[y * width + x] != mask[y * width + mirrored_x]
+                )
+                comparisons += 1
+    elif axis == "horizontal":
+        for y in range(top, bottom + 1):
+            mirrored_y = bottom - (y - top)
+            for x in range(left, right + 1):
+                differences += (
+                    mask[y * width + x] != mask[mirrored_y * width + x]
+                )
+                comparisons += 1
+    else:
+        return 0.0
+    if comparisons == 0:
+        return 0.0
+    return 1.0 - (differences / comparisons)
+
+
+def _component_metrics(
+    mask: Sequence[int],
+    *,
+    width: int,
+    height: int,
+    content_bbox: tuple[int, int, int, int],
+) -> dict[str, float]:
+    del height
+    left, top, right, bottom = content_bbox
+    content_area = max((right - left + 1) * (bottom - top + 1), 1)
+    component_sizes = _connected_component_sizes(
+        mask,
+        width=width,
+        content_bbox=content_bbox,
+        target=1,
+        connectivity=8,
+    )
+    hole_sizes = _hole_sizes(mask, width=width, content_bbox=content_bbox)
+    return {
+        "component_count": float(len(component_sizes)),
+        "largest_component_ratio": (
+            max(component_sizes) / sum(component_sizes)
+            if component_sizes
+            else 0.0
+        ),
+        "hole_count": float(len(hole_sizes)),
+        "hole_area_ratio": sum(hole_sizes) / content_area,
+    }
+
+
+def _connected_component_sizes(
+    mask: Sequence[int],
+    *,
+    width: int,
+    content_bbox: tuple[int, int, int, int],
+    target: int,
+    connectivity: int,
+) -> list[int]:
+    left, top, right, bottom = content_bbox
+    visited: set[tuple[int, int]] = set()
+    sizes = []
+    if connectivity == 8:
+        neighbors = (
+            (-1, -1),
+            (0, -1),
+            (1, -1),
+            (-1, 0),
+            (1, 0),
+            (-1, 1),
+            (0, 1),
+            (1, 1),
+        )
+    else:
+        neighbors = ((0, -1), (-1, 0), (1, 0), (0, 1))
+
+    for y in range(top, bottom + 1):
+        for x in range(left, right + 1):
+            if (x, y) in visited or mask[y * width + x] != target:
+                continue
+            stack = [(x, y)]
+            visited.add((x, y))
+            size = 0
+            while stack:
+                cx, cy = stack.pop()
+                size += 1
+                for dx, dy in neighbors:
+                    nx = cx + dx
+                    ny = cy + dy
+                    if (
+                        nx < left
+                        or nx > right
+                        or ny < top
+                        or ny > bottom
+                        or (nx, ny) in visited
+                        or mask[ny * width + nx] != target
+                    ):
+                        continue
+                    visited.add((nx, ny))
+                    stack.append((nx, ny))
+            sizes.append(size)
+    return sizes
+
+
+def _hole_sizes(
+    mask: Sequence[int],
+    *,
+    width: int,
+    content_bbox: tuple[int, int, int, int],
+) -> list[int]:
+    left, top, right, bottom = content_bbox
+    visited: set[tuple[int, int]] = set()
+    holes = []
+    neighbors = ((0, -1), (-1, 0), (1, 0), (0, 1))
+
+    for y in range(top, bottom + 1):
+        for x in range(left, right + 1):
+            if (x, y) in visited or mask[y * width + x]:
+                continue
+            stack = [(x, y)]
+            visited.add((x, y))
+            size = 0
+            touches_border = False
+            while stack:
+                cx, cy = stack.pop()
+                size += 1
+                touches_border = touches_border or (
+                    cx in (left, right) or cy in (top, bottom)
+                )
+                for dx, dy in neighbors:
+                    nx = cx + dx
+                    ny = cy + dy
+                    if (
+                        nx < left
+                        or nx > right
+                        or ny < top
+                        or ny > bottom
+                        or (nx, ny) in visited
+                        or mask[ny * width + nx]
+                    ):
+                        continue
+                    visited.add((nx, ny))
+                    stack.append((nx, ny))
+            if not touches_border:
+                holes.append(size)
+    return holes
+
+
+def _normalized_glyph_vector(
+    mask: Sequence[int],
+    *,
+    width: int,
+    height: int,
+    content_bbox: tuple[int, int, int, int],
+    glyph_size: int,
+) -> tuple[float, ...]:
+    values = bytes(255 if value else 0 for value in mask)
+    mask_image = PILImage.frombytes("L", (width, height), values)
+    left, top, right, bottom = content_bbox
+    content = mask_image.crop((left, top, right + 1, bottom + 1))
+    side = max(content.width, content.height, 1)
+    square = PILImage.new("L", (side, side), 0)
+    offset = ((side - content.width) // 2, (side - content.height) // 2)
+    square.paste(content, offset)
+    resized = square.resize((glyph_size, glyph_size), PILImage.Resampling.BOX)
+    return tuple(pixel / 255.0 for pixel in resized.tobytes())
+
+
+def _with_style_vectors(
+    records: Sequence[dict[str, Any]],
+) -> tuple[LetterImageSample, ...]:
+    if not records:
+        return ()
+
+    vectors_by_char: dict[str, list[tuple[float, ...]]] = {}
+    for record in records:
+        vectors_by_char.setdefault(record["normalized_char"], []).append(
+            record["vector"]
+        )
+    char_centers = {
+        char: _centroid(vectors)
+        for char, vectors in vectors_by_char.items()
+        if len(vectors) >= 3
+    }
+    global_center = _centroid([record["vector"] for record in records])
+
+    samples = []
+    for record in records:
+        center = char_centers.get(record["normalized_char"], global_center)
+        residual = tuple(
+            value - center[index]
+            for index, value in enumerate(record["vector"])
+        )
+        absolute_metrics = tuple(
+            record["metrics"][name] for name in _ABSOLUTE_STYLE_NAMES
+        )
+        style_vector = _l2_normalize(residual + absolute_metrics)
+        sample_id = _letter_sample_id(record)
+        samples.append(
+            LetterImageSample(
+                sample_id=sample_id,
+                image_id=record["image_id"],
+                receipt_id=record["receipt_id"],
+                line_id=record["line_id"],
+                word_id=record["word_id"],
+                letter_id=record["letter_id"],
+                text=record["text"],
+                normalized_char=record["normalized_char"],
+                vector=record["vector"],
+                style_vector=style_vector,
+                metrics=record["metrics"],
+            )
+        )
+    return tuple(samples)
+
+
+def _build_letter_analysis(
+    samples: Sequence[LetterImageSample],
+    labels: Sequence[int],
+) -> LetterFontAnalysis:
+    grouped: dict[int, list[LetterImageSample]] = {}
+    noise = []
+    for sample, label in zip(samples, labels):
+        if label > 0:
+            grouped.setdefault(label, []).append(sample)
+        else:
+            noise.append(sample.sample_id)
+
+    ordered_labels = sorted(
+        grouped,
+        key=lambda label: min(samples.index(sample) for sample in grouped[label]),
+    )
+    relabel = {
+        old_label: new_label
+        for new_label, old_label in enumerate(ordered_labels, start=1)
+    }
+    assignments = {
+        sample.sample_id: relabel[label] if label > 0 else -1
+        for sample, label in zip(samples, labels)
+    }
+    clusters = tuple(
+        _make_letter_cluster(relabel[old_label], grouped[old_label])
+        for old_label in ordered_labels
+    )
+    return LetterFontAnalysis(
+        samples=tuple(samples),
+        clusters=clusters,
+        noise_sample_ids=tuple(noise),
+        assignments=assignments,
+    )
+
+
+def _build_line_analysis(
+    samples: Sequence[LineFontSample],
+    labels: Sequence[int],
+    prepared_vectors: Sequence[Sequence[float]],
+) -> LineFontAnalysis:
+    grouped: dict[int, list[tuple[int, LineFontSample]]] = {}
+    noise = []
+    for index, (sample, label) in enumerate(zip(samples, labels)):
+        if label > 0:
+            grouped.setdefault(label, []).append((index, sample))
+        else:
+            noise.append(sample.sample_id)
+
+    ordered_labels = sorted(
+        grouped,
+        key=lambda label: min(index for index, _ in grouped[label]),
+    )
+    relabel = {
+        old_label: new_label
+        for new_label, old_label in enumerate(ordered_labels, start=1)
+    }
+    assignments = {
+        sample.sample_id: relabel[label] if label > 0 else -1
+        for sample, label in zip(samples, labels)
+    }
+    clusters = tuple(
+        _make_line_cluster(
+            relabel[old_label],
+            [sample for _, sample in grouped[old_label]],
+            [prepared_vectors[index] for index, _ in grouped[old_label]],
+        )
+        for old_label in ordered_labels
+    )
+    return LineFontAnalysis(
+        samples=tuple(samples),
+        clusters=clusters,
+        noise_sample_ids=tuple(noise),
+        assignments=assignments,
+    )
+
+
+def _cluster_vectors(
+    vectors: Sequence[Sequence[float]], *, eps: float, min_samples: int
+) -> list[int]:
+    try:
+        from sklearn.cluster import DBSCAN
+
+        raw_labels = DBSCAN(eps=eps, min_samples=min_samples).fit_predict(
+            list(vectors)
+        )
+        return [int(label) + 1 if int(label) >= 0 else -1 for label in raw_labels]
+    except Exception:
+        return _dbscan(vectors, eps=eps, min_samples=min_samples)
+
+
+def _make_letter_cluster(
+    cluster_id: int,
+    samples: Sequence[LetterImageSample],
+) -> LetterStyleCluster:
+    metrics = _average_metrics(samples)
+    return LetterStyleCluster(
+        cluster_id=cluster_id,
+        sample_ids=tuple(sample.sample_id for sample in samples),
+        sample_count=len(samples),
+        line_ids=tuple(sorted({sample.line_id for sample in samples})),
+        normalized_chars=tuple(
+            char for char, _ in _top_counts(sample.normalized_char for sample in samples)
+        ),
+        text_examples=tuple(sample.text for sample in samples[:8]),
+        centroid=_centroid([sample.style_vector for sample in samples]),
+        metrics=metrics,
+        label=_describe_letter_cluster(metrics),
+    )
+
+
+def _make_line_cluster(
+    cluster_id: int,
+    samples: Sequence[LineFontSample],
+    vectors: Sequence[Sequence[float]],
+) -> LineFontCluster:
+    metrics = _average_metric_dicts([sample.metrics for sample in samples])
+    sections = tuple(
+        section
+        for section, _ in _top_counts(
+            [sample.section or "unknown" for sample in samples]
+        )
+    )
+    return LineFontCluster(
+        cluster_id=cluster_id,
+        sample_ids=tuple(sample.sample_id for sample in samples),
+        sample_count=len(samples),
+        line_ids=tuple(sorted({sample.line_id for sample in samples})),
+        sections=sections,
+        text_examples=tuple(sample.text for sample in samples[:8]),
+        centroid=_centroid(vectors),
+        metrics=metrics,
+        label=_describe_line_cluster(metrics),
+    )
+
+
+def _average_metrics(
+    samples: Sequence[LetterImageSample],
+) -> dict[str, float]:
+    metric_names = sorted(
+        {
+            metric_name
+            for sample in samples
+            for metric_name in sample.metrics.keys()
+        }
+    )
+    return {
+        name: mean(
+            sample.metrics[name] for sample in samples if name in sample.metrics
+        )
+        for name in metric_names
+    }
+
+
+def _average_metric_dicts(
+    rows: Sequence[Mapping[str, float]],
+) -> dict[str, float]:
+    metric_names = sorted({name for row in rows for name in row.keys()})
+    return {
+        name: mean(row[name] for row in rows if name in row)
+        for name in metric_names
+    }
+
+
+def _line_context_maps(
+    lines: Sequence[Any] | None,
+    words: Sequence[Any] | None,
+) -> tuple[dict[LineKey, Any], dict[LineKey, list[Any]]]:
+    line_by_key = {}
+    for line in lines or ():
+        line_by_key[_line_key_from_object(line)] = line
+
+    words_by_key: dict[LineKey, list[Any]] = defaultdict(list)
+    for word in words or ():
+        words_by_key[_line_key_from_object(word)].append(word)
+    for values in words_by_key.values():
+        values.sort(key=lambda word: _int(_get(word, "word_id"), default=0))
+    return line_by_key, words_by_key
+
+
+def _line_metrics(
+    samples: Sequence[LetterImageSample],
+    *,
+    line: Any | None,
+    words: Sequence[Any],
+    letter_assignments: Mapping[str, int] | None,
+) -> dict[str, float]:
+    line_box = _line_box(line, samples)
+    median_height = _median_metric(samples, "box_height")
+    spacing = _spacing_metrics(samples, median_height=median_height)
+    char_mix = _character_mix_metrics(samples)
+    cluster_mix = _letter_cluster_mix_metrics(samples, letter_assignments)
+    word_count = len(words) or len({sample.word_id for sample in samples})
+    letter_area = sum(
+        sample.metrics.get("box_width", 0.0)
+        * sample.metrics.get("box_height", 0.0)
+        for sample in samples
+    )
+    line_area = max(line_box["width"] * line_box["height"], _EPSILON)
+
+    metrics = {
+        "letter_count": float(len(samples)),
+        "word_count": float(word_count),
+        "line_box_x": line_box["x"],
+        "line_box_y": line_box["y"],
+        "line_box_width": line_box["width"],
+        "line_box_height": line_box["height"],
+        "line_box_aspect": line_box["width"] / max(line_box["height"], _EPSILON),
+        "line_center_x": line_box["x"] + line_box["width"] / 2,
+        "line_center_y": line_box["y"] + line_box["height"] / 2,
+        "letter_area_ratio": letter_area / line_area,
+        **spacing,
+        **char_mix,
+        **cluster_mix,
+    }
+    metrics.update(_aggregated_letter_metrics(samples))
+    return metrics
+
+
+def _aggregated_letter_metrics(
+    samples: Sequence[LetterImageSample],
+) -> dict[str, float]:
+    metrics = {}
+    for name in _LINE_LETTER_AGGREGATE_SOURCE_NAMES:
+        values = [sample.metrics.get(name, 0.0) for sample in samples]
+        value_mean, value_std = _mean_std(values)
+        metrics[f"mean_{name}"] = value_mean
+        metrics[f"median_{name}"] = median(values) if values else 0.0
+        metrics[f"std_{name}"] = value_std
+    return metrics
+
+
+def _line_box(line: Any | None, samples: Sequence[LetterImageSample]) -> BoundingBox:
+    box = _box(line) if line is not None else None
+    if box is not None:
+        return box
+
+    left = min(sample.metrics.get("box_x", 0.0) for sample in samples)
+    right = max(
+        sample.metrics.get("box_x", 0.0) + sample.metrics.get("box_width", 0.0)
+        for sample in samples
+    )
+    bottom = min(sample.metrics.get("box_y", 0.0) for sample in samples)
+    top = max(
+        sample.metrics.get("box_y", 0.0) + sample.metrics.get("box_height", 0.0)
+        for sample in samples
+    )
+    return {
+        "x": left,
+        "y": bottom,
+        "width": max(right - left, _EPSILON),
+        "height": max(top - bottom, _EPSILON),
+    }
+
+
+def _spacing_metrics(
+    samples: Sequence[LetterImageSample],
+    *,
+    median_height: float,
+) -> dict[str, float]:
+    ordered = sorted(samples, key=_letter_sort_value)
+    gaps = []
+    intra_word_gaps = []
+    inter_word_gaps = []
+    advances = []
+    for current, following in zip(ordered, ordered[1:]):
+        current_right = (
+            current.metrics.get("box_x", 0.0)
+            + current.metrics.get("box_width", 0.0)
+        )
+        gap = max(following.metrics.get("box_x", 0.0) - current_right, 0.0)
+        advance = max(
+            following.metrics.get("box_center_x", 0.0)
+            - current.metrics.get("box_center_x", 0.0),
+            0.0,
+        )
+        gaps.append(gap)
+        advances.append(advance)
+        if current.word_id == following.word_id:
+            intra_word_gaps.append(gap)
+        else:
+            inter_word_gaps.append(gap)
+
+    median_gap = median(gaps) if gaps else 0.0
+    median_advance = median(advances) if advances else 0.0
+    gap_mean, gap_std = _mean_std(gaps)
+    return {
+        "median_gap": median_gap,
+        "mean_gap": gap_mean,
+        "std_gap": gap_std,
+        "median_intra_word_gap": median(intra_word_gaps)
+        if intra_word_gaps
+        else 0.0,
+        "median_inter_word_gap": median(inter_word_gaps)
+        if inter_word_gaps
+        else 0.0,
+        "median_advance": median_advance,
+        "gap_to_height_ratio": median_gap / max(median_height, _EPSILON),
+        "advance_to_height_ratio": median_advance / max(median_height, _EPSILON),
+    }
+
+
+def _character_mix_metrics(
+    samples: Sequence[LetterImageSample],
+) -> dict[str, float]:
+    count = max(len(samples), 1)
+    chars = [sample.text for sample in samples]
+    alpha = sum(1 for char in chars if char.isalpha())
+    uppercase = sum(1 for char in chars if char.isalpha() and char.isupper())
+    digits = sum(1 for char in chars if char.isdigit())
+    punctuation = sum(1 for char in chars if not char.isalnum())
+    return {
+        "alpha_ratio": alpha / count,
+        "uppercase_ratio": uppercase / count,
+        "digit_ratio": digits / count,
+        "punctuation_ratio": punctuation / count,
+    }
+
+
+def _letter_cluster_mix_metrics(
+    samples: Sequence[LetterImageSample],
+    letter_assignments: Mapping[str, int] | None,
+) -> dict[str, float]:
+    if not letter_assignments:
+        return {
+            "assigned_letter_cluster_ratio": 0.0,
+            "noise_letter_cluster_ratio": 1.0,
+            "dominant_letter_cluster_ratio": 0.0,
+            "distinct_letter_cluster_ratio": 0.0,
+        }
+
+    cluster_ids = [
+        int(letter_assignments.get(sample.sample_id, -1))
+        for sample in samples
+    ]
+    assigned = [cluster_id for cluster_id in cluster_ids if cluster_id > 0]
+    count = max(len(cluster_ids), 1)
+    assigned_count = len(assigned)
+    dominant_count = Counter(assigned).most_common(1)[0][1] if assigned else 0
+    return {
+        "assigned_letter_cluster_ratio": assigned_count / count,
+        "noise_letter_cluster_ratio": (count - assigned_count) / count,
+        "dominant_letter_cluster_ratio": dominant_count / count,
+        "distinct_letter_cluster_ratio": len(set(assigned)) / count,
+    }
+
+
+def _line_text_for_key(
+    key: LineKey,
+    line: Any | None,
+    words_by_key: Mapping[LineKey, Sequence[Any]],
+    samples: Sequence[LetterImageSample],
+) -> str:
+    del key
+    if line is not None:
+        text = _text(line).strip()
+        if text:
+            return text
+    words = words_by_key.get(_line_key_from_sample(samples[0]), ())
+    word_text = " ".join(_text(word) for word in words).strip()
+    if word_text:
+        return word_text
+    return "".join(sample.text for sample in sorted(samples, key=_letter_sort_value))
+
+
+def _lookup_line_mapping(
+    mapping: Mapping[Any, str] | None,
+    key: LineKey,
+    line_id: int,
+) -> str | None:
+    if not mapping:
+        return None
+    if key in mapping:
+        return mapping[key]
+    key_text = _line_key_to_string(key)
+    if key_text in mapping:
+        return mapping[key_text]
+    if line_id in mapping:
+        return mapping[line_id]
+    return None
+
+
+def _line_key_from_sample(sample: LetterImageSample) -> LineKey:
+    return (sample.image_id, sample.receipt_id, sample.line_id)
+
+
+def _line_key_from_object(value: Any) -> LineKey:
+    image_id = _get(value, "image_id")
+    return (
+        str(image_id) if image_id is not None else None,
+        _optional_int(_get(value, "receipt_id")),
+        _int(_get(value, "line_id"), default=-1),
+    )
+
+
+def _line_key_sort_value(key: LineKey) -> tuple[str, int, int]:
+    return (key[0] or "", key[1] if key[1] is not None else -1, key[2])
+
+
+def _line_sample_id(key: LineKey) -> str:
+    parts = []
+    if key[0]:
+        parts.append(f"image={key[0]}")
+    if key[1] is not None:
+        parts.append(f"receipt={key[1]}")
+    parts.append(f"line={key[2]}")
+    return ":".join(parts)
+
+
+def _line_key_to_string(key: LineKey) -> str:
+    return _line_sample_id(key)
+
+
+def _letter_sort_value(
+    sample: LetterImageSample,
+) -> tuple[float, int, int, int]:
+    return (
+        sample.metrics.get("box_x", 0.0),
+        sample.word_id,
+        sample.letter_id,
+        sample.line_id,
+    )
+
+
+def _median_metric(samples: Sequence[LetterImageSample], name: str) -> float:
+    values = [sample.metrics.get(name, 0.0) for sample in samples]
+    return median(values) if values else 0.0
+
+
+def _componentwise_std(
+    vectors: Sequence[Sequence[float]],
+    center: Sequence[float],
+) -> tuple[float, ...]:
+    if not vectors:
+        return ()
+    return tuple(
+        _std([vector[index] for vector in vectors], center[index])
+        for index in range(len(center))
+    )
+
+
+def _robust_standardized_l2_vectors(
+    vectors: Sequence[Sequence[float]],
+) -> list[tuple[float, ...]]:
+    if not vectors:
+        return []
+
+    columns = list(zip(*vectors))
+    centers = [median(column) for column in columns]
+    scales = []
+    for column, center in zip(columns, centers):
+        deviations = [abs(value - center) for value in column]
+        scale = median(deviations) * 1.4826
+        scales.append(scale if scale > _EPSILON else 1.0)
+
+    standardized = []
+    for vector in vectors:
+        standardized.append(
+            _l2_normalize(
+                tuple(
+                    (value - centers[index]) / scales[index]
+                    for index, value in enumerate(vector)
+                )
+            )
+        )
+    return standardized
+
+
+def _describe_letter_cluster(metrics: Mapping[str, float]) -> str:
+    height = metrics.get("box_height", 0.0)
+    aspect = metrics.get("box_aspect", 0.0)
+    ink = metrics.get("ink_ratio", 0.0)
+    edge = metrics.get("edge_density", 0.0)
+
+    if height >= 0.035:
+        size = "large"
+    elif height <= 0.014:
+        size = "small"
+    else:
+        size = "regular"
+
+    if aspect <= 0.45:
+        width = "condensed"
+    elif aspect >= 0.85:
+        width = "wide"
+    else:
+        width = "normal"
+
+    if ink >= 0.24 or edge >= 0.32:
+        weight = "dark"
+    elif ink <= 0.09:
+        weight = "light"
+    else:
+        weight = "medium"
+
+    return f"{size} {width} {weight}"
+
+
+def _describe_line_cluster(metrics: Mapping[str, float]) -> str:
+    height = metrics.get("median_box_height", metrics.get("line_box_height", 0.0))
+    aspect = metrics.get("mean_box_aspect", 0.0)
+    ink = metrics.get("mean_ink_ratio", 0.0)
+    spacing = metrics.get("gap_to_height_ratio", 0.0)
+
+    if height >= 0.035:
+        size = "large-line"
+    elif height <= 0.014:
+        size = "small-line"
+    else:
+        size = "regular-line"
+
+    if aspect <= 0.45:
+        width = "condensed"
+    elif aspect >= 0.85:
+        width = "wide"
+    else:
+        width = "normal"
+
+    if ink >= 0.24:
+        weight = "dark"
+    elif ink <= 0.09:
+        weight = "light"
+    else:
+        weight = "medium"
+
+    if spacing >= 0.75:
+        cadence = "loose"
+    elif spacing <= 0.18:
+        cadence = "tight"
+    else:
+        cadence = "regular"
+
+    return f"{size} {width} {weight} {cadence}"
+
+
+def _promote_large_noise_groups(
+    labels: Sequence[int],
+    samples: Sequence[LetterImageSample],
+    *,
+    min_group_size: int,
+) -> list[int]:
+    next_cluster = max([label for label in labels if label > 0], default=0) + 1
+    promoted = list(labels)
+    noise_by_line: dict[int, list[int]] = {}
+    for index, (label, sample) in enumerate(zip(labels, samples)):
+        if label > 0:
+            continue
+        noise_by_line.setdefault(sample.line_id, []).append(index)
+
+    for indexes in noise_by_line.values():
+        if len(indexes) < min_group_size:
+            continue
+        for index in indexes:
+            promoted[index] = next_cluster
+        next_cluster += 1
+    return promoted
+
+
+def _sample_metadata(sample: LetterImageSample) -> dict[str, object]:
+    metadata: dict[str, object] = {
+        "ocr_char": sample.text,
+        "normalized_char": sample.normalized_char,
+        "line_id": sample.line_id,
+        "word_id": sample.word_id,
+        "letter_id": sample.letter_id,
+        "confidence": sample.metrics.get("confidence", 0.0),
+        "ink_ratio": sample.metrics.get("ink_ratio", 0.0),
+        "box_height": sample.metrics.get("box_height", 0.0),
+        "box_width": sample.metrics.get("box_width", 0.0),
+    }
+    if sample.image_id is not None:
+        metadata["image_id"] = sample.image_id
+    if sample.receipt_id is not None:
+        metadata["receipt_id"] = sample.receipt_id
+    return metadata
+
+
+def _top_counts(values: Sequence[str]) -> list[tuple[str, int]]:
+    counts: dict[str, int] = {}
+    for value in values:
+        counts[value] = counts.get(value, 0) + 1
+    return sorted(counts.items(), key=lambda item: (-item[1], item[0]))
+
+
+def _letter_sample_id(record: Mapping[str, Any]) -> str:
+    parts = []
+    if record.get("image_id"):
+        parts.append(f"image={record['image_id']}")
+    if record.get("receipt_id") is not None:
+        parts.append(f"receipt={record['receipt_id']}")
+    parts.append(f"line={record['line_id']}")
+    parts.append(f"word={record['word_id']}")
+    parts.append(f"letter={record['letter_id']}")
+    return ":".join(parts)
+
+
+def _normalize_char(char: str) -> str:
+    return char.strip()
+
+
+def _optional_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    return _int(value)
+
+
+def _l2_normalize(values: Sequence[float]) -> tuple[float, ...]:
+    norm = sum(value * value for value in values) ** 0.5
+    if norm <= _EPSILON:
+        return tuple(0.0 for _ in values)
+    return tuple(value / norm for value in values)
+
+
+def _mean_std(values: Sequence[float]) -> tuple[float, float]:
+    if not values:
+        return 0.0, 0.0
+    value_mean = mean(values)
+    return value_mean, _std(values, value_mean)
+
+
+def _std(values: Sequence[float], value_mean: float) -> float:
+    if len(values) < 2:
+        return 0.0
+    variance = sum((value - value_mean) ** 2 for value in values) / len(values)
+    return variance**0.5

--- a/receipt_upload/test/test_font_analysis.py
+++ b/receipt_upload/test/test_font_analysis.py
@@ -5,7 +5,7 @@ from types import SimpleNamespace
 import pytest
 from PIL import Image, ImageDraw
 
-from receipt_upload.font_analysis import analyze_receipt_fonts
+from receipt_upload.font_analysis import _dbscan, analyze_receipt_fonts
 
 
 def _box(x: float, y: float, width: float, height: float) -> dict[str, float]:
@@ -340,6 +340,17 @@ def test_similar_samples_prefers_same_font_cluster():
     assert matches[0].cluster_id == analysis.cluster_for_sample(
         samples["STORE"].sample_id
     )
+
+
+@pytest.mark.unit
+def test_dbscan_min_samples_one_still_honors_eps():
+    labels = _dbscan(
+        [(0.0, 0.0), (0.01, 0.0), (5.0, 5.0)],
+        eps=0.05,
+        min_samples=1,
+    )
+
+    assert labels == [1, 1, 2]
 
 
 @pytest.mark.unit

--- a/receipt_upload/test/test_font_analysis.py
+++ b/receipt_upload/test/test_font_analysis.py
@@ -1,0 +1,419 @@
+"""Tests for receipt font-style embedding and clustering."""
+
+from types import SimpleNamespace
+
+import pytest
+from PIL import Image, ImageDraw
+
+from receipt_upload.font_analysis import analyze_receipt_fonts
+
+
+def _box(x: float, y: float, width: float, height: float) -> dict[str, float]:
+    return {"x": x, "y": y, "width": width, "height": height}
+
+
+def _word_with_letters(
+    *,
+    text: str,
+    line_id: int,
+    word_id: int,
+    x: float,
+    y: float,
+    glyph_width: float,
+    height: float,
+    image_id: str = "image-1",
+    receipt_id: int = 1,
+) -> tuple[SimpleNamespace, list[SimpleNamespace]]:
+    word_width = glyph_width * len(text)
+    word = SimpleNamespace(
+        image_id=image_id,
+        receipt_id=receipt_id,
+        line_id=line_id,
+        word_id=word_id,
+        text=text,
+        bounding_box=_box(x, y, word_width, height),
+        confidence=0.96,
+        angle_radians=0.0,
+    )
+    letters = []
+    for index, character in enumerate(text, start=1):
+        letter_x = x + (index - 1) * glyph_width
+        letters.append(
+            SimpleNamespace(
+                image_id=image_id,
+                receipt_id=receipt_id,
+                line_id=line_id,
+                word_id=word_id,
+                letter_id=index,
+                text=character,
+                bounding_box=_box(letter_x, y, glyph_width, height),
+                confidence=0.96,
+                angle_radians=0.0,
+            )
+        )
+    return word, letters
+
+
+def _line(
+    *,
+    line_id: int,
+    text: str,
+    x: float,
+    y: float,
+    width: float,
+    height: float,
+    image_id: str = "image-1",
+    receipt_id: int = 1,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        image_id=image_id,
+        receipt_id=receipt_id,
+        line_id=line_id,
+        text=text,
+        bounding_box=_box(x, y, width, height),
+        confidence=0.96,
+        angle_radians=0.0,
+    )
+
+
+def _two_style_receipt() -> tuple[
+    list[SimpleNamespace],
+    list[SimpleNamespace],
+    list[SimpleNamespace],
+]:
+    lines = [
+        _line(
+            line_id=1,
+            text="STORE TOTAL",
+            x=0.1,
+            y=0.82,
+            width=0.4,
+            height=0.06,
+        ),
+        _line(
+            line_id=2,
+            text="milk bread",
+            x=0.1,
+            y=0.62,
+            width=0.25,
+            height=0.026,
+        ),
+        _line(
+            line_id=3,
+            text="apple banana",
+            x=0.1,
+            y=0.57,
+            width=0.3,
+            height=0.026,
+        ),
+    ]
+
+    words = []
+    letters = []
+    for args in (
+        {
+            "text": "STORE",
+            "line_id": 1,
+            "word_id": 1,
+            "x": 0.1,
+            "y": 0.82,
+            "glyph_width": 0.026,
+            "height": 0.052,
+        },
+        {
+            "text": "TOTAL",
+            "line_id": 1,
+            "word_id": 2,
+            "x": 0.26,
+            "y": 0.82,
+            "glyph_width": 0.026,
+            "height": 0.052,
+        },
+        {
+            "text": "milk",
+            "line_id": 2,
+            "word_id": 1,
+            "x": 0.1,
+            "y": 0.62,
+            "glyph_width": 0.012,
+            "height": 0.022,
+        },
+        {
+            "text": "bread",
+            "line_id": 2,
+            "word_id": 2,
+            "x": 0.17,
+            "y": 0.62,
+            "glyph_width": 0.012,
+            "height": 0.022,
+        },
+        {
+            "text": "apple",
+            "line_id": 3,
+            "word_id": 1,
+            "x": 0.1,
+            "y": 0.57,
+            "glyph_width": 0.012,
+            "height": 0.022,
+        },
+        {
+            "text": "banana",
+            "line_id": 3,
+            "word_id": 2,
+            "x": 0.17,
+            "y": 0.57,
+            "glyph_width": 0.012,
+            "height": 0.022,
+        },
+    ):
+        word, word_letters = _word_with_letters(**args)
+        words.append(word)
+        letters.extend(word_letters)
+
+    return lines, words, letters
+
+
+def _draw_word_style(
+    draw: ImageDraw.ImageDraw,
+    *,
+    image_size: tuple[int, int],
+    box: dict[str, float],
+    stroke_width: int,
+) -> None:
+    image_width, image_height = image_size
+    left = int(box["x"] * image_width)
+    right = int((box["x"] + box["width"]) * image_width)
+    top = int((1.0 - box["y"] - box["height"]) * image_height)
+    bottom = int((1.0 - box["y"]) * image_height)
+    glyph_width = max((right - left) // 4, 1)
+    for glyph_index in range(4):
+        glyph_left = left + glyph_index * glyph_width + 3
+        glyph_right = left + (glyph_index + 1) * glyph_width - 3
+        draw.rectangle(
+            [glyph_left, top + 3, glyph_right, bottom - 3],
+            outline="black",
+            width=stroke_width,
+        )
+        draw.line(
+            [
+                (glyph_left + glyph_right) // 2,
+                top + 4,
+                (glyph_left + glyph_right) // 2,
+                bottom - 4,
+            ],
+            fill="black",
+            width=stroke_width,
+        )
+
+
+def _same_geometry_pixel_receipt() -> tuple[
+    Image.Image,
+    list[SimpleNamespace],
+    list[SimpleNamespace],
+    list[SimpleNamespace],
+]:
+    image = Image.new("RGB", (480, 220), "white")
+    draw = ImageDraw.Draw(image)
+    lines = [
+        _line(
+            line_id=1,
+            text="THIN LINE",
+            x=0.1,
+            y=0.68,
+            width=0.55,
+            height=0.12,
+        ),
+        _line(
+            line_id=2,
+            text="THICK LINE",
+            x=0.1,
+            y=0.42,
+            width=0.55,
+            height=0.12,
+        ),
+    ]
+
+    words = []
+    letters = []
+    for args in (
+        {
+            "text": "thin",
+            "line_id": 1,
+            "word_id": 1,
+            "x": 0.12,
+            "y": 0.69,
+            "glyph_width": 0.045,
+            "height": 0.09,
+            "stroke_width": 1,
+        },
+        {
+            "text": "fine",
+            "line_id": 1,
+            "word_id": 2,
+            "x": 0.34,
+            "y": 0.69,
+            "glyph_width": 0.045,
+            "height": 0.09,
+            "stroke_width": 1,
+        },
+        {
+            "text": "bold",
+            "line_id": 2,
+            "word_id": 1,
+            "x": 0.12,
+            "y": 0.43,
+            "glyph_width": 0.045,
+            "height": 0.09,
+            "stroke_width": 6,
+        },
+        {
+            "text": "dark",
+            "line_id": 2,
+            "word_id": 2,
+            "x": 0.34,
+            "y": 0.43,
+            "glyph_width": 0.045,
+            "height": 0.09,
+            "stroke_width": 6,
+        },
+    ):
+        stroke_width = args.pop("stroke_width")
+        word, word_letters = _word_with_letters(**args)
+        _draw_word_style(
+            draw,
+            image_size=image.size,
+            box=word.bounding_box,
+            stroke_width=stroke_width,
+        )
+        words.append(word)
+        letters.extend(word_letters)
+
+    return image, lines, words, letters
+
+
+@pytest.mark.unit
+def test_analyze_receipt_fonts_clusters_distinct_styles():
+    lines, words, letters = _two_style_receipt()
+
+    analysis = analyze_receipt_fonts(
+        letters,
+        words=words,
+        lines=lines,
+        promote_singletons_min_letters=None,
+    )
+
+    assert len(analysis.clusters) == 2
+
+    samples = {sample.text: sample for sample in analysis.samples}
+    store_cluster = analysis.cluster_for_sample(samples["STORE"].sample_id)
+    total_cluster = analysis.cluster_for_sample(samples["TOTAL"].sample_id)
+    milk_cluster = analysis.cluster_for_sample(samples["milk"].sample_id)
+    bread_cluster = analysis.cluster_for_sample(samples["bread"].sample_id)
+
+    assert store_cluster == total_cluster
+    assert milk_cluster == bread_cluster
+    assert store_cluster != milk_cluster
+    assert not analysis.noise_sample_ids
+
+    clusters = {cluster.cluster_id: cluster for cluster in analysis.clusters}
+    assert clusters[store_cluster].label.startswith("large")
+    assert (
+        clusters[store_cluster].metrics["font_size_ratio"]
+        > clusters[milk_cluster].metrics["font_size_ratio"]
+    )
+
+
+@pytest.mark.unit
+def test_similar_samples_prefers_same_font_cluster():
+    lines, words, letters = _two_style_receipt()
+    analysis = analyze_receipt_fonts(
+        letters,
+        words=words,
+        lines=lines,
+        promote_singletons_min_letters=None,
+    )
+
+    samples = {sample.text: sample for sample in analysis.samples}
+    matches = analysis.similar_samples(samples["STORE"].sample_id, top_k=2)
+
+    assert matches[0].sample_id == samples["TOTAL"].sample_id
+    assert matches[0].cluster_id == analysis.cluster_for_sample(
+        samples["STORE"].sample_id
+    )
+
+
+@pytest.mark.unit
+def test_short_letter_groups_are_filtered_from_font_samples():
+    lines, words, letters = _two_style_receipt()
+    word, word_letters = _word_with_letters(
+        text="X",
+        line_id=4,
+        word_id=1,
+        x=0.1,
+        y=0.5,
+        glyph_width=0.02,
+        height=0.04,
+    )
+    lines.append(
+        _line(
+            line_id=4,
+            text="X",
+            x=0.1,
+            y=0.5,
+            width=0.02,
+            height=0.04,
+        )
+    )
+    words.append(word)
+    letters.extend(word_letters)
+
+    analysis = analyze_receipt_fonts(
+        letters,
+        words=words,
+        lines=lines,
+        promote_singletons_min_letters=None,
+    )
+
+    assert "X" not in {sample.text for sample in analysis.samples}
+
+
+@pytest.mark.unit
+def test_raw_image_pixels_split_same_geometry_font_styles():
+    image, lines, words, letters = _same_geometry_pixel_receipt()
+
+    geometry_only = analyze_receipt_fonts(
+        letters,
+        words=words,
+        lines=lines,
+        eps=0.75,
+        promote_singletons_min_letters=None,
+    )
+    pixel_analysis = analyze_receipt_fonts(
+        letters,
+        words=words,
+        lines=lines,
+        raw_image=image,
+        eps=1.2,
+        promote_singletons_min_letters=None,
+    )
+
+    assert len(geometry_only.clusters) == 1
+    assert len(pixel_analysis.clusters) == 2
+
+    samples = {sample.text: sample for sample in pixel_analysis.samples}
+    thin_cluster = pixel_analysis.cluster_for_sample(samples["thin"].sample_id)
+    fine_cluster = pixel_analysis.cluster_for_sample(samples["fine"].sample_id)
+    bold_cluster = pixel_analysis.cluster_for_sample(samples["bold"].sample_id)
+    dark_cluster = pixel_analysis.cluster_for_sample(samples["dark"].sample_id)
+
+    assert thin_cluster == fine_cluster
+    assert bold_cluster == dark_cluster
+    assert thin_cluster != bold_cluster
+
+    clusters = {
+        cluster.cluster_id: cluster for cluster in pixel_analysis.clusters
+    }
+    assert (
+        clusters[bold_cluster].metrics["pixel_ink_ratio"]
+        > clusters[thin_cluster].metrics["pixel_ink_ratio"]
+    )

--- a/receipt_upload/test/test_font_letter_analysis.py
+++ b/receipt_upload/test/test_font_letter_analysis.py
@@ -6,10 +6,12 @@ import pytest
 from PIL import Image, ImageDraw
 
 from receipt_upload.font_letter_analysis import (
+    LetterImageSample,
     build_letter_image_samples,
     build_line_font_samples,
     cluster_letter_styles,
     cluster_line_font_styles,
+    upsert_letter_samples_to_chroma,
 )
 
 
@@ -215,3 +217,70 @@ def test_letter_embeddings_skip_low_confidence_letters():
 
     assert len(samples) == 19
     assert all(sample.metrics["confidence"] >= 0.35 for sample in samples)
+
+
+@pytest.mark.unit
+def test_chroma_upsert_preserves_existing_rows_by_default(
+    tmp_path, monkeypatch
+):
+    class FakeCollection:
+        def __init__(self) -> None:
+            self.ids = ["existing"]
+            self.deleted: list[str] = []
+
+        def count(self) -> int:
+            return len(self.ids)
+
+        def get(self, include=None):
+            return {"ids": list(self.ids)}
+
+        def delete(self, ids):
+            self.deleted.extend(ids)
+            self.ids = [value for value in self.ids if value not in ids]
+
+    class FakeClient:
+        collection = FakeCollection()
+
+        def __init__(self, **kwargs) -> None:
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, traceback) -> None:
+            pass
+
+        def get_collection(self, *args, **kwargs):
+            return self.collection
+
+        def upsert(self, *, ids, **kwargs) -> None:
+            self.collection.ids.extend(ids)
+
+        def count(self, collection_name: str) -> int:
+            return self.collection.count()
+
+    import receipt_chroma
+
+    monkeypatch.setattr(receipt_chroma, "ChromaClient", FakeClient)
+    sample = LetterImageSample(
+        sample_id="new",
+        image_id="image-1",
+        receipt_id=1,
+        line_id=1,
+        word_id=1,
+        letter_id=1,
+        text="A",
+        normalized_char="A",
+        vector=(0.1, 0.2),
+        style_vector=(0.1, 0.2),
+        metrics={"confidence": 0.99},
+    )
+
+    count = upsert_letter_samples_to_chroma(
+        [sample],
+        persist_directory=str(tmp_path),
+    )
+
+    assert count == 2
+    assert FakeClient.collection.ids == ["existing", "new"]
+    assert FakeClient.collection.deleted == []

--- a/receipt_upload/test/test_font_letter_analysis.py
+++ b/receipt_upload/test/test_font_letter_analysis.py
@@ -1,0 +1,215 @@
+"""Tests for letter-crop font/style embeddings."""
+
+from types import SimpleNamespace
+
+import pytest
+from PIL import Image, ImageDraw
+
+from receipt_upload.font_letter_analysis import (
+    build_letter_image_samples,
+    build_line_font_samples,
+    cluster_letter_styles,
+    cluster_line_font_styles,
+)
+
+
+def _box(x: float, y: float, width: float, height: float) -> dict[str, float]:
+    return {"x": x, "y": y, "width": width, "height": height}
+
+
+def _draw_a(
+    draw: ImageDraw.ImageDraw,
+    *,
+    image_size: tuple[int, int],
+    box: dict[str, float],
+    stroke_width: int,
+) -> None:
+    image_width, image_height = image_size
+    left = int(box["x"] * image_width)
+    right = int((box["x"] + box["width"]) * image_width)
+    top = int((1.0 - box["y"] - box["height"]) * image_height)
+    bottom = int((1.0 - box["y"]) * image_height)
+    middle = (left + right) // 2
+    crossbar_y = (top + bottom) // 2
+    draw.line(
+        [middle, top + 2, left + 2, bottom - 2],
+        fill="black",
+        width=stroke_width,
+    )
+    draw.line(
+        [middle, top + 2, right - 2, bottom - 2],
+        fill="black",
+        width=stroke_width,
+    )
+    draw.line(
+        [left + 7, crossbar_y, right - 7, crossbar_y],
+        fill="black",
+        width=stroke_width,
+    )
+
+
+def _same_character_two_weight_image() -> tuple[Image.Image, list[object]]:
+    image = Image.new("RGB", (800, 220), "white")
+    draw = ImageDraw.Draw(image)
+    letters = []
+    letter_id = 1
+
+    for line_id, y, stroke_width in ((1, 0.62, 1), (2, 0.28, 6)):
+        for word_id in range(1, 11):
+            box = _box(0.08 + (word_id - 1) * 0.08, y, 0.035, 0.16)
+            _draw_a(
+                draw,
+                image_size=image.size,
+                box=box,
+                stroke_width=stroke_width,
+            )
+            letters.append(
+                SimpleNamespace(
+                    image_id="image-1",
+                    receipt_id=1,
+                    line_id=line_id,
+                    word_id=word_id,
+                    letter_id=letter_id,
+                    text="A",
+                    bounding_box=box,
+                    confidence=0.99,
+                    angle_radians=0.0,
+                )
+            )
+            letter_id += 1
+
+    return image, letters
+
+
+def _same_character_four_line_weight_image() -> tuple[Image.Image, list[object]]:
+    image = Image.new("RGB", (800, 440), "white")
+    draw = ImageDraw.Draw(image)
+    letters = []
+    letter_id = 1
+
+    rows = (
+        (1, 0.78, 1),
+        (2, 0.56, 1),
+        (3, 0.34, 6),
+        (4, 0.12, 6),
+    )
+    for line_id, y, stroke_width in rows:
+        for word_id in range(1, 11):
+            box = _box(0.08 + (word_id - 1) * 0.08, y, 0.035, 0.10)
+            _draw_a(
+                draw,
+                image_size=image.size,
+                box=box,
+                stroke_width=stroke_width,
+            )
+            letters.append(
+                SimpleNamespace(
+                    image_id="image-1",
+                    receipt_id=1,
+                    line_id=line_id,
+                    word_id=word_id,
+                    letter_id=letter_id,
+                    text="A",
+                    bounding_box=box,
+                    confidence=0.99,
+                    angle_radians=0.0,
+                )
+            )
+            letter_id += 1
+
+    return image, letters
+
+
+@pytest.mark.unit
+def test_letter_style_clustering_separates_same_ocr_char_by_weight():
+    image, letters = _same_character_two_weight_image()
+
+    samples = build_letter_image_samples(letters, raw_image=image)
+    analysis = cluster_letter_styles(samples, eps=0.35, min_samples=2)
+
+    assert len(samples) == 20
+    assert len(analysis.clusters) == 2
+    assert not analysis.noise_sample_ids
+
+    line_clusters = {}
+    for sample in samples:
+        line_clusters.setdefault(sample.line_id, set()).add(
+            analysis.cluster_for_sample(sample.sample_id)
+        )
+
+    assert len(line_clusters[1]) == 1
+    assert len(line_clusters[2]) == 1
+    assert line_clusters[1] != line_clusters[2]
+
+    thin = samples[0]
+    thick = samples[-1]
+    assert len(thin.metrics) >= 60
+    assert len(thin.vector) > 300
+    assert len(thin.style_vector) > len(thin.vector)
+    assert "hog_orientation_0" in thin.metrics
+    assert "row_projection_3" in thin.metrics
+    assert "column_projection_3" in thin.metrics
+    assert "top_profile_mean" in thin.metrics
+    assert "component_count" in thin.metrics
+    assert "hole_count" in thin.metrics
+    assert (
+        thick.metrics["stroke_width_mean_norm"]
+        > thin.metrics["stroke_width_mean_norm"]
+    )
+
+
+@pytest.mark.unit
+def test_line_style_clustering_aggregates_letter_features_by_line():
+    image, letters = _same_character_four_line_weight_image()
+
+    samples = build_letter_image_samples(letters, raw_image=image)
+    letter_analysis = cluster_letter_styles(samples, eps=0.35, min_samples=2)
+    line_samples = build_line_font_samples(
+        samples,
+        letter_assignments=letter_analysis.assignments,
+    )
+    line_analysis = cluster_line_font_styles(
+        line_samples,
+        eps=0.75,
+        min_samples=2,
+    )
+
+    assert len(line_samples) == 4
+    assert len(line_analysis.clusters) == 2
+    assert not line_analysis.noise_sample_ids
+
+    cluster_by_line = {
+        sample.line_id: line_analysis.cluster_for_sample(sample.sample_id)
+        for sample in line_samples
+    }
+    assert cluster_by_line[1] == cluster_by_line[2]
+    assert cluster_by_line[3] == cluster_by_line[4]
+    assert cluster_by_line[1] != cluster_by_line[3]
+
+    thin_line = line_samples[0]
+    thick_line = line_samples[-1]
+    assert len(thin_line.metrics) >= 200
+    assert len(thin_line.vector) > 800
+    assert "median_box_height" in thin_line.metrics
+    assert "mean_stroke_width_mean_norm" in thin_line.metrics
+    assert "dominant_letter_cluster_ratio" in thin_line.metrics
+    assert "uppercase_ratio" in thin_line.metrics
+    assert (
+        thick_line.metrics["mean_stroke_width_mean_norm"]
+        > thin_line.metrics["mean_stroke_width_mean_norm"]
+    )
+
+
+@pytest.mark.unit
+def test_letter_embeddings_skip_low_confidence_letters():
+    image, letters = _same_character_two_weight_image()
+    letters[0].confidence = 0.1
+
+    samples = build_letter_image_samples(
+        letters,
+        raw_image=image,
+        min_confidence=0.35,
+    )
+
+    assert len(samples) == 19
+    assert all(sample.metrics["confidence"] >= 0.35 for sample in samples)

--- a/receipt_upload/test/test_font_letter_analysis.py
+++ b/receipt_upload/test/test_font_letter_analysis.py
@@ -81,7 +81,9 @@ def _same_character_two_weight_image() -> tuple[Image.Image, list[object]]:
     return image, letters
 
 
-def _same_character_four_line_weight_image() -> tuple[Image.Image, list[object]]:
+def _same_character_four_line_weight_image() -> (
+    tuple[Image.Image, list[object]]
+):
     image = Image.new("RGB", (800, 440), "white")
     draw = ImageDraw.Draw(image)
     letters = []

--- a/scripts/run_letter_font_embedding_pilot.py
+++ b/scripts/run_letter_font_embedding_pilot.py
@@ -1,0 +1,1153 @@
+#!/usr/bin/env python3
+"""Run an end-to-end receipt letter font/style embedding pilot.
+
+The pilot uses OCR letter boxes to crop individual glyphs, embeds each crop as
+a visual style vector, stores those vectors in a separate local Chroma DB, then
+clusters and summarizes the inferred styles by receipt section.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import sys
+from collections import Counter, defaultdict
+from io import BytesIO
+from pathlib import Path
+from statistics import mean, median
+from typing import Any
+
+import boto3
+from botocore.exceptions import ClientError
+from PIL import Image as PILImage
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "receipt_upload"))
+sys.path.insert(0, str(REPO_ROOT / "receipt_chroma"))
+
+from receipt_dynamo import DynamoClient  # noqa: E402
+from receipt_upload.font_letter_analysis import (  # noqa: E402
+    LetterFontAnalysis,
+    LetterImageSample,
+    LineFontAnalysis,
+    LineFontSample,
+    build_letter_image_samples,
+    build_line_font_samples,
+    cluster_letter_styles,
+    cluster_line_font_styles,
+)
+from receipt_chroma import ChromaClient  # noqa: E402
+
+PROD_TABLE = "ReceiptsTable-d7ff76a"
+COLLECTION_NAME = "letter_font_glyphs"
+
+PRICE_RE = re.compile(r"(?<!\d)(?:\$\s*)?\d{1,4}[.,]\d{2}(?!\d)")
+TOTAL_RE = re.compile(
+    r"\b("
+    r"TOTAL|SUBTOTAL|SUB\s*TOTAL|TAX|BALANCE|AMOUNT|CHANGE|CASH|CARD|"
+    r"CREDIT|DEBIT|VISA|MASTERCARD|PAYMENT|TEND|DUE"
+    r")\b",
+    re.IGNORECASE,
+)
+HEADER_RE = re.compile(
+    r"\b("
+    r"STORE|MARKET|PHARMACY|WALGREENS|WALMART|TARGET|COSTCO|SAFEWAY|"
+    r"TRADER|KROGER|CVS|RITE|FOODS|MART|RECEIPT"
+    r")\b",
+    re.IGNORECASE,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Embed OCR letter crops into Chroma and cluster styles."
+    )
+    parser.add_argument("--table", default=PROD_TABLE)
+    parser.add_argument("--limit", type=int, default=12)
+    parser.add_argument("--candidate-multiplier", type=int, default=4)
+    parser.add_argument("--region", default="us-east-1")
+    parser.add_argument(
+        "--persist-dir",
+        default="/tmp/receipt-letter-font-chroma-pilot",
+        help="Separate local Chroma DB directory for letter glyph vectors.",
+    )
+    parser.add_argument("--collection-name", default=COLLECTION_NAME)
+    parser.add_argument("--eps", type=float, default=0.55)
+    parser.add_argument("--min-samples", type=int, default=5)
+    parser.add_argument("--line-eps", type=float, default=0.58)
+    parser.add_argument(
+        "--line-eps-sweep",
+        default="0.58,0.70,0.85,1.00",
+        help="Comma-separated line DBSCAN eps values to evaluate in memory.",
+    )
+    parser.add_argument("--line-min-samples", type=int, default=2)
+    parser.add_argument("--min-letters-per-line", type=int, default=3)
+    parser.add_argument("--min-confidence", type=float, default=0.35)
+    parser.add_argument("--query-check-limit", type=int, default=200)
+    parser.add_argument(
+        "--report-md",
+        default=str(REPO_ROOT / "docs" / "receipt-letter-font-chroma-pilot.md"),
+    )
+    parser.add_argument(
+        "--report-json",
+        default=str(
+            REPO_ROOT / "docs" / "receipt-letter-font-chroma-pilot.json"
+        ),
+    )
+    parser.add_argument(
+        "--no-reset",
+        action="store_true",
+        help="Do not remove the Chroma persist directory before running.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    persist_dir = Path(args.persist_dir)
+    if persist_dir.exists() and not args.no_reset:
+        shutil.rmtree(persist_dir)
+    persist_dir.mkdir(parents=True, exist_ok=True)
+
+    s3_client = boto3.client("s3")
+    dynamo = DynamoClient(table_name=args.table, region=args.region)
+    receipts = _list_all(dynamo.list_receipts)
+    receipts = sorted(
+        receipts,
+        key=lambda receipt: str(receipt.timestamp_added),
+        reverse=True,
+    )
+
+    selected = []
+    raw_ok_checked = 0
+    for receipt in receipts:
+        if not receipt.raw_s3_bucket or not receipt.raw_s3_key:
+            continue
+        if not _s3_exists(s3_client, receipt.raw_s3_bucket, receipt.raw_s3_key):
+            continue
+        raw_ok_checked += 1
+        selected.append(receipt)
+        if raw_ok_checked >= args.limit * args.candidate_multiplier:
+            break
+
+    all_samples: list[LetterImageSample] = []
+    all_lines: list[Any] = []
+    all_words: list[Any] = []
+    extra_metadata: dict[str, dict[str, object]] = {}
+    receipt_summaries = []
+    section_by_sample: dict[str, str] = {}
+    section_by_line_key: dict[tuple[str | None, int | None, int], str] = {}
+    errors = []
+
+    for receipt in selected:
+        if len(receipt_summaries) >= args.limit:
+            break
+        try:
+            details = dynamo.get_image_details(receipt.image_id)
+            lines = [
+                line
+                for line in details.receipt_lines
+                if line.receipt_id == receipt.receipt_id
+            ]
+            words = [
+                word
+                for word in details.receipt_words
+                if word.receipt_id == receipt.receipt_id
+            ]
+            letters = [
+                letter
+                for letter in details.receipt_letters
+                if letter.receipt_id == receipt.receipt_id
+            ]
+            if len(lines) < 5 or len(words) < 20 or len(letters) < 100:
+                continue
+
+            image = _load_image(
+                s3_client, receipt.raw_s3_bucket, receipt.raw_s3_key
+            )
+            section_by_line, ordered_lines, line_text_by_id = _classify_lines(
+                lines, words
+            )
+            all_lines.extend(lines)
+            all_words.extend(words)
+            for line in lines:
+                section_by_line_key[_line_key(line)] = section_by_line.get(
+                    line.line_id, "unknown"
+                )
+            samples = build_letter_image_samples(
+                letters,
+                raw_image=image,
+                min_confidence=args.min_confidence,
+            )
+            if len(samples) < 100:
+                continue
+
+            for sample in samples:
+                section = section_by_line.get(sample.line_id, "unknown")
+                section_by_sample[sample.sample_id] = section
+                extra_metadata[sample.sample_id] = {
+                    "section": section,
+                    "source": "receipt_raw_s3",
+                }
+
+            all_samples.extend(samples)
+            receipt_summaries.append(
+                {
+                    "image_id": receipt.image_id,
+                    "receipt_id": receipt.receipt_id,
+                    "date": str(receipt.timestamp_added)[:10],
+                    "raw_s3_bucket": receipt.raw_s3_bucket,
+                    "raw_s3_key": receipt.raw_s3_key,
+                    "image_size": list(image.size),
+                    "line_count": len(lines),
+                    "word_count": len(words),
+                    "letter_count": len(letters),
+                    "embedded_letter_count": len(samples),
+                    "top_lines": [
+                        line_text_by_id[line.line_id]
+                        for line in ordered_lines[:4]
+                    ],
+                    "bottom_lines": [
+                        line_text_by_id[line.line_id]
+                        for line in ordered_lines[-4:]
+                    ],
+                }
+            )
+        except Exception as exc:  # noqa: BLE001
+            errors.append(
+                {
+                    "image_id": receipt.image_id,
+                    "receipt_id": receipt.receipt_id,
+                    "error_type": type(exc).__name__,
+                    "error": str(exc)[:300],
+                }
+            )
+
+    analysis = cluster_letter_styles(
+        all_samples,
+        eps=args.eps,
+        min_samples=args.min_samples,
+    )
+    line_samples = build_line_font_samples(
+        analysis.samples,
+        lines=all_lines,
+        words=all_words,
+        letter_assignments=analysis.assignments,
+        section_by_line=section_by_line_key,
+        min_letters_per_line=args.min_letters_per_line,
+    )
+    line_eps_values = _line_eps_values(args.line_eps, args.line_eps_sweep)
+    line_analyses_by_eps = {
+        eps: cluster_line_font_styles(
+            line_samples,
+            eps=eps,
+            min_samples=args.line_min_samples,
+        )
+        for eps in line_eps_values
+    }
+    line_analysis = line_analyses_by_eps[args.line_eps]
+    line_eps_sweep = [
+        _line_eps_result(eps, analysis)
+        for eps, analysis in line_analyses_by_eps.items()
+    ]
+    cluster_by_id = {cluster.cluster_id: cluster for cluster in analysis.clusters}
+    for sample_id, cluster_id in analysis.assignments.items():
+        if cluster_id > 0:
+            extra_metadata.setdefault(sample_id, {})[
+                "style_cluster_id"
+            ] = cluster_id
+            extra_metadata[sample_id]["style_cluster_label"] = cluster_by_id[
+                cluster_id
+            ].label
+
+    chroma_count, neighbor_quality = _persist_and_evaluate_chroma(
+        samples=analysis.samples,
+        assignments=analysis.assignments,
+        persist_directory=str(persist_dir),
+        collection_name=args.collection_name,
+        extra_metadata_by_id=extra_metadata,
+        limit=args.query_check_limit,
+    )
+
+    report = _build_report(
+        args=args,
+        persist_dir=persist_dir,
+        chroma_count=chroma_count,
+        receipts_seen=len(receipts),
+        raw_ok_candidates=len(selected),
+        receipt_summaries=receipt_summaries,
+        analysis=analysis,
+        line_analysis=line_analysis,
+        line_eps_sweep=line_eps_sweep,
+        section_by_sample=section_by_sample,
+        neighbor_quality=neighbor_quality,
+        errors=errors,
+    )
+
+    report_json = Path(args.report_json)
+    report_md = Path(args.report_md)
+    report_json.parent.mkdir(parents=True, exist_ok=True)
+    report_md.parent.mkdir(parents=True, exist_ok=True)
+    report_json.write_text(json.dumps(report, indent=2, sort_keys=True))
+    report_md.write_text(_render_markdown(report))
+
+    print(json.dumps(report["summary"], indent=2, sort_keys=True))
+    print(f"wrote_json={report_json}")
+    print(f"wrote_markdown={report_md}")
+    print(f"chroma_persist_dir={persist_dir}")
+
+
+def _list_all(method: Any) -> list[Any]:
+    results = []
+    last_evaluated_key = None
+    while True:
+        batch, last_evaluated_key = method(
+            last_evaluated_key=last_evaluated_key
+        )
+        results.extend(batch)
+        if not last_evaluated_key:
+            return results
+
+
+def _s3_exists(s3_client: Any, bucket: str, key: str) -> bool:
+    try:
+        s3_client.head_object(Bucket=bucket, Key=key)
+        return True
+    except ClientError:
+        return False
+
+
+def _load_image(s3_client: Any, bucket: str, key: str) -> PILImage.Image:
+    response = s3_client.get_object(Bucket=bucket, Key=key)
+    return PILImage.open(BytesIO(response["Body"].read())).convert("RGB")
+
+
+def _classify_lines(
+    lines: list[Any],
+    words: list[Any],
+) -> tuple[dict[int, str], list[Any], dict[int, str]]:
+    words_by_line: dict[int, list[Any]] = defaultdict(list)
+    for word in words:
+        words_by_line[word.line_id].append(word)
+
+    ordered = sorted(
+        lines,
+        key=lambda line: (
+            _bbox(line).get("y", 0.0) + _bbox(line).get("height", 0.0),
+            -line.line_id,
+        ),
+        reverse=True,
+    )
+    line_text_by_id = {
+        line.line_id: _line_text(line, words_by_line) for line in lines
+    }
+    total_lines = len(ordered)
+    top_cut = max(3, round(total_lines * 0.16)) if total_lines else 0
+    bottom_cut = max(3, round(total_lines * 0.18)) if total_lines else 0
+
+    mapping = {}
+    for rank, line in enumerate(ordered):
+        text = line_text_by_id[line.line_id]
+        if TOTAL_RE.search(text):
+            section = "totals_payments"
+        elif rank < top_cut or (
+            rank < max(6, top_cut + 2) and HEADER_RE.search(text)
+        ):
+            section = "header"
+        elif rank >= total_lines - bottom_cut:
+            section = "footer"
+        elif PRICE_RE.search(text):
+            section = "line_items"
+        else:
+            section = "body_other"
+        mapping[line.line_id] = section
+
+    return mapping, ordered, line_text_by_id
+
+
+def _line_text(line: Any, words_by_line: dict[int, list[Any]]) -> str:
+    text = (getattr(line, "text", "") or "").strip()
+    if text:
+        return text
+    return " ".join(
+        getattr(word, "text", "")
+        for word in sorted(
+            words_by_line.get(line.line_id, []),
+            key=lambda word: word.word_id,
+        )
+    ).strip()
+
+
+def _bbox(value: Any) -> dict[str, float]:
+    return getattr(value, "bounding_box", None) or {}
+
+
+def _line_key(value: Any) -> tuple[str | None, int | None, int]:
+    return (
+        getattr(value, "image_id", None),
+        getattr(value, "receipt_id", None),
+        getattr(value, "line_id", -1),
+    )
+
+
+def _line_eps_values(selected_eps: float, sweep: str) -> list[float]:
+    values = {round(selected_eps, 6)}
+    for raw_value in sweep.split(","):
+        raw_value = raw_value.strip()
+        if not raw_value:
+            continue
+        values.add(round(float(raw_value), 6))
+    return sorted(values)
+
+
+def _line_eps_result(eps: float, analysis: LineFontAnalysis) -> dict[str, Any]:
+    assigned = [
+        sample
+        for sample in analysis.samples
+        if analysis.cluster_for_sample(sample.sample_id) is not None
+    ]
+    cluster_counts_by_receipt = _line_cluster_counts_by_receipt(analysis)
+    return {
+        "eps": eps,
+        "clusters": len(analysis.clusters),
+        "assigned_lines": len(assigned),
+        "noise_lines": len(analysis.noise_sample_ids),
+        "noise_rate": (
+            len(analysis.noise_sample_ids) / len(analysis.samples)
+            if analysis.samples
+            else 0.0
+        ),
+        "section_purity": _line_cluster_section_purity(analysis),
+        "median_clusters_per_receipt": median(cluster_counts_by_receipt)
+        if cluster_counts_by_receipt
+        else 0,
+    }
+
+
+def _persist_and_evaluate_chroma(
+    *,
+    samples: Sequence[LetterImageSample],
+    assignments: dict[str, int],
+    persist_directory: str,
+    collection_name: str,
+    extra_metadata_by_id: dict[str, dict[str, object]],
+    limit: int,
+    batch_size: int = 1000,
+) -> tuple[int, dict[str, Any]]:
+    with ChromaClient(
+        persist_directory=persist_directory,
+        mode="write",
+        metadata_only=True,
+    ) as client:
+        collection = client.get_collection(
+            collection_name,
+            create_if_missing=True,
+            metadata={
+                "description": "Receipt OCR letter crop style embeddings"
+            },
+        )
+        if collection.count():
+            existing = collection.get(include=["metadatas"])
+            existing_ids = list(existing.get("ids") or [])
+            for start in range(0, len(existing_ids), batch_size):
+                collection.delete(ids=existing_ids[start : start + batch_size])
+
+        for start in range(0, len(samples), batch_size):
+            batch = samples[start : start + batch_size]
+            client.upsert(
+                collection_name=collection_name,
+                ids=[sample.sample_id for sample in batch],
+                embeddings=[list(sample.style_vector) for sample in batch],
+                documents=[sample.text for sample in batch],
+                metadatas=[
+                    {
+                        **_sample_metadata(sample),
+                        **dict(
+                            extra_metadata_by_id.get(sample.sample_id, {})
+                        ),
+                    }
+                    for sample in batch
+                ],
+            )
+
+        chroma_count = client.count(collection_name)
+        neighbor_quality = _evaluate_chroma_neighbors(
+            client=client,
+            samples=samples,
+            assignments=assignments,
+            collection_name=collection_name,
+            limit=limit,
+        )
+        return chroma_count, neighbor_quality
+
+
+def _evaluate_chroma_neighbors(
+    *,
+    client: ChromaClient,
+    samples: Sequence[LetterImageSample],
+    assignments: dict[str, int],
+    collection_name: str,
+    limit: int,
+) -> dict[str, Any]:
+    checked = 0
+    top1_same_cluster = 0
+    top3_any_same_cluster = 0
+    same_char_neighbor_found = 0
+    examples = []
+
+    for sample in samples:
+        cluster_id = assignments.get(sample.sample_id, -1)
+        if cluster_id <= 0:
+            continue
+        result = client.query(
+            collection_name=collection_name,
+            query_embeddings=[list(sample.style_vector)],
+            n_results=6,
+            where={"normalized_char": sample.normalized_char},
+            include=["metadatas", "documents", "distances"],
+        )
+        ids = (result.get("ids") or [[]])[0]
+        metadatas = (result.get("metadatas") or [[]])[0]
+        neighbors = [
+            (neighbor_id, metadata)
+            for neighbor_id, metadata in zip(ids, metadatas)
+            if neighbor_id != sample.sample_id
+        ]
+        if not neighbors:
+            continue
+
+        checked += 1
+        same_char_neighbor_found += 1
+        top_ids = [
+            int(metadata.get("style_cluster_id", -1))
+            for _, metadata in neighbors[:3]
+        ]
+        if top_ids and top_ids[0] == cluster_id:
+            top1_same_cluster += 1
+        if cluster_id in top_ids:
+            top3_any_same_cluster += 1
+        if len(examples) < 5:
+            examples.append(
+                {
+                    "query_id": sample.sample_id,
+                    "query_char": sample.text,
+                    "query_cluster": cluster_id,
+                    "neighbors": [
+                        {
+                            "id": neighbor_id,
+                            "cluster": metadata.get("style_cluster_id"),
+                            "label": metadata.get("style_cluster_label"),
+                            "section": metadata.get("section"),
+                        }
+                        for neighbor_id, metadata in neighbors[:3]
+                    ],
+                }
+            )
+        if checked >= limit:
+            break
+
+    return {
+        "checked": checked,
+        "same_char_neighbor_found": same_char_neighbor_found,
+        "top1_same_cluster_rate": (
+            top1_same_cluster / checked if checked else 0.0
+        ),
+        "top3_any_same_cluster_rate": (
+            top3_any_same_cluster / checked if checked else 0.0
+        ),
+        "examples": examples,
+    }
+
+
+def _build_report(
+    *,
+    args: argparse.Namespace,
+    persist_dir: Path,
+    chroma_count: int,
+    receipts_seen: int,
+    raw_ok_candidates: int,
+    receipt_summaries: list[dict[str, Any]],
+    analysis: LetterFontAnalysis,
+    line_analysis: LineFontAnalysis,
+    line_eps_sweep: list[dict[str, Any]],
+    section_by_sample: dict[str, str],
+    neighbor_quality: dict[str, Any],
+    errors: list[dict[str, Any]],
+) -> dict[str, Any]:
+    assigned_samples = [
+        sample
+        for sample in analysis.samples
+        if analysis.cluster_for_sample(sample.sample_id) is not None
+    ]
+    clusters_by_id = {cluster.cluster_id: cluster for cluster in analysis.clusters}
+    section_counts: Counter[str] = Counter()
+    section_cluster_labels: dict[str, Counter[str]] = defaultdict(Counter)
+    section_metrics: dict[str, dict[str, list[float]]] = defaultdict(
+        lambda: defaultdict(list)
+    )
+    char_counts = Counter(sample.normalized_char for sample in analysis.samples)
+
+    for sample in assigned_samples:
+        cluster_id = analysis.cluster_for_sample(sample.sample_id)
+        if cluster_id is None:
+            continue
+        section = section_by_sample.get(sample.sample_id, "unknown")
+        cluster = clusters_by_id[cluster_id]
+        section_counts[section] += 1
+        section_cluster_labels[section][cluster.label] += 1
+        for metric in ("box_height", "ink_ratio", "edge_density", "box_aspect"):
+            section_metrics[section][metric].append(sample.metrics[metric])
+
+    cluster_summaries = _cluster_summaries(
+        analysis,
+        section_by_sample=section_by_sample,
+        limit=20,
+    )
+    line_cluster_summaries = _line_cluster_summaries(line_analysis, limit=20)
+    line_section_summaries = _line_section_summaries(line_analysis)
+    assigned_line_samples = [
+        sample
+        for sample in line_analysis.samples
+        if line_analysis.cluster_for_sample(sample.sample_id) is not None
+    ]
+    section_summaries = []
+    for section, count in section_counts.most_common():
+        section_summaries.append(
+            {
+                "section": section,
+                "assigned_samples": count,
+                "avg_box_height": _avg(section_metrics[section]["box_height"]),
+                "avg_ink_ratio": _avg(section_metrics[section]["ink_ratio"]),
+                "avg_edge_density": _avg(
+                    section_metrics[section]["edge_density"]
+                ),
+                "avg_box_aspect": _avg(section_metrics[section]["box_aspect"]),
+                "top_cluster_labels": dict(
+                    section_cluster_labels[section].most_common(8)
+                ),
+            }
+        )
+
+    sample_counts = [item["embedded_letter_count"] for item in receipt_summaries]
+    cluster_counts_by_receipt = _cluster_counts_by_receipt(analysis)
+    line_cluster_counts_by_receipt = _line_cluster_counts_by_receipt(
+        line_analysis
+    )
+
+    summary = {
+        "table": args.table,
+        "receipt_limit": args.limit,
+        "receipts_seen": receipts_seen,
+        "raw_ok_candidates": raw_ok_candidates,
+        "analysed_receipts": len(receipt_summaries),
+        "embedded_letters": len(analysis.samples),
+        "chroma_count": chroma_count,
+        "style_clusters": len(analysis.clusters),
+        "noise_letters": len(analysis.noise_sample_ids),
+        "noise_rate": (
+            len(analysis.noise_sample_ids) / len(analysis.samples)
+            if analysis.samples
+            else 0.0
+        ),
+        "assigned_letters": len(assigned_samples),
+        "embedded_lines": len(line_analysis.samples),
+        "line_style_clusters": len(line_analysis.clusters),
+        "noise_lines": len(line_analysis.noise_sample_ids),
+        "noise_line_rate": (
+            len(line_analysis.noise_sample_ids) / len(line_analysis.samples)
+            if line_analysis.samples
+            else 0.0
+        ),
+        "assigned_lines": len(assigned_line_samples),
+        "median_line_clusters_per_receipt": median(line_cluster_counts_by_receipt)
+        if line_cluster_counts_by_receipt
+        else 0,
+        "letter_cluster_section_purity": _letter_cluster_section_purity(
+            analysis,
+            section_by_sample,
+        ),
+        "line_cluster_section_purity": _line_cluster_section_purity(
+            line_analysis
+        ),
+        "median_letters_per_receipt": median(sample_counts)
+        if sample_counts
+        else 0,
+        "median_clusters_per_receipt": median(cluster_counts_by_receipt)
+        if cluster_counts_by_receipt
+        else 0,
+        "common_ocr_chars": dict(char_counts.most_common(15)),
+        "neighbor_quality": neighbor_quality,
+        "errors": len(errors),
+        "persist_dir": str(persist_dir),
+        "collection_name": args.collection_name,
+        "eps": args.eps,
+        "min_samples": args.min_samples,
+        "line_eps": args.line_eps,
+        "line_min_samples": args.line_min_samples,
+        "min_letters_per_line": args.min_letters_per_line,
+    }
+    if analysis.samples:
+        summary["metrics_per_letter"] = len(analysis.samples[0].metrics)
+        summary["raw_vector_dim"] = len(analysis.samples[0].vector)
+        summary["style_vector_dim"] = len(analysis.samples[0].style_vector)
+    if line_analysis.samples:
+        summary["metrics_per_line"] = len(line_analysis.samples[0].metrics)
+        summary["line_vector_dim"] = len(line_analysis.samples[0].vector)
+
+    return {
+        "summary": summary,
+        "section_summaries": section_summaries,
+        "cluster_summaries": cluster_summaries,
+        "line_section_summaries": line_section_summaries,
+        "line_cluster_summaries": line_cluster_summaries,
+        "line_eps_sweep": line_eps_sweep,
+        "receipt_summaries": receipt_summaries,
+        "errors": errors,
+    }
+
+
+def _cluster_summaries(
+    analysis: LetterFontAnalysis,
+    *,
+    section_by_sample: dict[str, str],
+    limit: int,
+) -> list[dict[str, Any]]:
+    rows = []
+    for cluster in sorted(
+        analysis.clusters,
+        key=lambda item: item.sample_count,
+        reverse=True,
+    )[:limit]:
+        sections = Counter(
+            section_by_sample.get(sample_id, "unknown")
+            for sample_id in cluster.sample_ids
+        )
+        rows.append(
+            {
+                "cluster_id": cluster.cluster_id,
+                "label": cluster.label,
+                "sample_count": cluster.sample_count,
+                "normalized_chars": list(cluster.normalized_chars[:12]),
+                "text_examples": list(cluster.text_examples),
+                "sections": dict(sections.most_common()),
+                "avg_box_height": round(cluster.metrics.get("box_height", 0), 5),
+                "avg_ink_ratio": round(cluster.metrics.get("ink_ratio", 0), 5),
+                "avg_edge_density": round(
+                    cluster.metrics.get("edge_density", 0), 5
+                ),
+            }
+        )
+    return rows
+
+
+def _cluster_counts_by_receipt(analysis: LetterFontAnalysis) -> list[int]:
+    clusters_by_receipt: dict[tuple[str | None, int | None], set[int]] = defaultdict(
+        set
+    )
+    for sample in analysis.samples:
+        cluster_id = analysis.cluster_for_sample(sample.sample_id)
+        if cluster_id is None:
+            continue
+        clusters_by_receipt[(sample.image_id, sample.receipt_id)].add(cluster_id)
+    return [len(clusters) for clusters in clusters_by_receipt.values()]
+
+
+def _line_cluster_counts_by_receipt(analysis: LineFontAnalysis) -> list[int]:
+    clusters_by_receipt: dict[tuple[str | None, int | None], set[int]] = defaultdict(
+        set
+    )
+    for sample in analysis.samples:
+        cluster_id = analysis.cluster_for_sample(sample.sample_id)
+        if cluster_id is None:
+            continue
+        clusters_by_receipt[(sample.image_id, sample.receipt_id)].add(cluster_id)
+    return [len(clusters) for clusters in clusters_by_receipt.values()]
+
+
+def _line_cluster_summaries(
+    analysis: LineFontAnalysis,
+    *,
+    limit: int,
+) -> list[dict[str, Any]]:
+    rows = []
+    samples_by_id = {sample.sample_id: sample for sample in analysis.samples}
+    for cluster in sorted(
+        analysis.clusters,
+        key=lambda item: item.sample_count,
+        reverse=True,
+    )[:limit]:
+        samples = [samples_by_id[sample_id] for sample_id in cluster.sample_ids]
+        sections = Counter(sample.section or "unknown" for sample in samples)
+        rows.append(
+            {
+                "cluster_id": cluster.cluster_id,
+                "label": cluster.label,
+                "line_count": cluster.sample_count,
+                "sections": dict(sections.most_common()),
+                "text_examples": list(cluster.text_examples[:8]),
+                "avg_line_height": round(
+                    cluster.metrics.get("line_box_height", 0.0), 5
+                ),
+                "avg_letter_height": round(
+                    cluster.metrics.get("median_box_height", 0.0), 5
+                ),
+                "avg_ink_ratio": round(
+                    cluster.metrics.get("mean_ink_ratio", 0.0), 5
+                ),
+                "avg_gap_to_height_ratio": round(
+                    cluster.metrics.get("gap_to_height_ratio", 0.0), 5
+                ),
+                "avg_dominant_letter_cluster_ratio": round(
+                    cluster.metrics.get("dominant_letter_cluster_ratio", 0.0),
+                    5,
+                ),
+            }
+        )
+    return rows
+
+
+def _line_section_summaries(
+    analysis: LineFontAnalysis,
+) -> list[dict[str, Any]]:
+    clusters_by_id = {cluster.cluster_id: cluster for cluster in analysis.clusters}
+    section_counts: Counter[str] = Counter()
+    section_cluster_labels: dict[str, Counter[str]] = defaultdict(Counter)
+    section_cluster_ids: dict[str, Counter[int]] = defaultdict(Counter)
+    section_metrics: dict[str, dict[str, list[float]]] = defaultdict(
+        lambda: defaultdict(list)
+    )
+
+    for sample in analysis.samples:
+        cluster_id = analysis.cluster_for_sample(sample.sample_id)
+        if cluster_id is None:
+            continue
+        section = sample.section or "unknown"
+        cluster = clusters_by_id[cluster_id]
+        section_counts[section] += 1
+        section_cluster_labels[section][cluster.label] += 1
+        section_cluster_ids[section][cluster_id] += 1
+        for metric in (
+            "line_box_height",
+            "median_box_height",
+            "mean_ink_ratio",
+            "gap_to_height_ratio",
+            "dominant_letter_cluster_ratio",
+        ):
+            section_metrics[section][metric].append(sample.metrics[metric])
+
+    summaries = []
+    for section, count in section_counts.most_common():
+        dominant_count = (
+            section_cluster_ids[section].most_common(1)[0][1]
+            if section_cluster_ids[section]
+            else 0
+        )
+        summaries.append(
+            {
+                "section": section,
+                "assigned_lines": count,
+                "dominant_cluster_share": (
+                    dominant_count / count if count else 0.0
+                ),
+                "avg_line_height": _avg(
+                    section_metrics[section]["line_box_height"]
+                ),
+                "avg_letter_height": _avg(
+                    section_metrics[section]["median_box_height"]
+                ),
+                "avg_ink_ratio": _avg(
+                    section_metrics[section]["mean_ink_ratio"]
+                ),
+                "avg_gap_to_height_ratio": _avg(
+                    section_metrics[section]["gap_to_height_ratio"]
+                ),
+                "avg_dominant_letter_cluster_ratio": _avg(
+                    section_metrics[section]["dominant_letter_cluster_ratio"]
+                ),
+                "top_cluster_labels": dict(
+                    section_cluster_labels[section].most_common(8)
+                ),
+                "top_cluster_ids": dict(
+                    section_cluster_ids[section].most_common(8)
+                ),
+            }
+        )
+    return summaries
+
+
+def _letter_cluster_section_purity(
+    analysis: LetterFontAnalysis,
+    section_by_sample: dict[str, str],
+) -> float:
+    if not analysis.clusters:
+        return 0.0
+    numerator = 0
+    denominator = 0
+    for cluster in analysis.clusters:
+        sections = Counter(
+            section_by_sample.get(sample_id, "unknown")
+            for sample_id in cluster.sample_ids
+        )
+        numerator += max(sections.values()) if sections else 0
+        denominator += sum(sections.values())
+    return numerator / denominator if denominator else 0.0
+
+
+def _line_cluster_section_purity(analysis: LineFontAnalysis) -> float:
+    if not analysis.clusters:
+        return 0.0
+    samples_by_id = {sample.sample_id: sample for sample in analysis.samples}
+    numerator = 0
+    denominator = 0
+    for cluster in analysis.clusters:
+        sections = Counter(
+            samples_by_id[sample_id].section or "unknown"
+            for sample_id in cluster.sample_ids
+        )
+        numerator += max(sections.values()) if sections else 0
+        denominator += sum(sections.values())
+    return numerator / denominator if denominator else 0.0
+
+
+def _sample_metadata(sample: LetterImageSample) -> dict[str, object]:
+    metadata: dict[str, object] = {
+        "ocr_char": sample.text,
+        "normalized_char": sample.normalized_char,
+        "line_id": sample.line_id,
+        "word_id": sample.word_id,
+        "letter_id": sample.letter_id,
+        "confidence": sample.metrics.get("confidence", 0.0),
+        "ink_ratio": sample.metrics.get("ink_ratio", 0.0),
+        "box_height": sample.metrics.get("box_height", 0.0),
+        "box_width": sample.metrics.get("box_width", 0.0),
+    }
+    if sample.image_id is not None:
+        metadata["image_id"] = sample.image_id
+    if sample.receipt_id is not None:
+        metadata["receipt_id"] = sample.receipt_id
+    return metadata
+
+
+def _render_markdown(report: dict[str, Any]) -> str:
+    summary = report["summary"]
+    lines = [
+        "# Receipt Letter Font Chroma Pilot",
+        "",
+        "Date: 2026-06-22",
+        "",
+        "## Run Summary",
+        "",
+        f"- Dynamo table: `{summary['table']}`",
+        f"- Local Chroma DB: `{summary['persist_dir']}`",
+        f"- Collection: `{summary['collection_name']}`",
+        f"- Analysed receipts: {summary['analysed_receipts']}",
+        f"- Embedded letters stored in Chroma: {summary['chroma_count']}",
+        f"- Letter style clusters: {summary['style_clusters']}",
+        f"- Noise letters: {summary['noise_letters']} "
+        f"({summary['noise_rate']:.1%})",
+        f"- Median letters per receipt: {summary['median_letters_per_receipt']}",
+        f"- Median letter clusters per receipt: {summary['median_clusters_per_receipt']}",
+        f"- Line signatures: {summary['embedded_lines']}",
+        f"- Line style clusters: {summary['line_style_clusters']}",
+        f"- Noise lines: {summary['noise_lines']} "
+        f"({summary['noise_line_rate']:.1%})",
+        f"- Assigned lines: {summary['assigned_lines']}",
+        f"- Median line clusters per receipt: {summary['median_line_clusters_per_receipt']}",
+        f"- Letter cluster section purity: "
+        f"{summary['letter_cluster_section_purity']:.1%}",
+        f"- Line cluster section purity: "
+        f"{summary['line_cluster_section_purity']:.1%}",
+        f"- Letter DBSCAN `eps`: {summary['eps']}",
+        f"- Letter DBSCAN `min_samples`: {summary['min_samples']}",
+        f"- Line DBSCAN `eps`: {summary['line_eps']}",
+        f"- Line DBSCAN `min_samples`: {summary['line_min_samples']}",
+        f"- Errors: {summary['errors']}",
+        f"- Metrics per letter: {summary.get('metrics_per_letter', 0)}",
+        f"- Raw vector dimension: {summary.get('raw_vector_dim', 0)}",
+        f"- Style vector dimension: {summary.get('style_vector_dim', 0)}",
+        f"- Metrics per line: {summary.get('metrics_per_line', 0)}",
+        f"- Line vector dimension: {summary.get('line_vector_dim', 0)}",
+        "",
+        "## Line Threshold Sweep",
+        "",
+        "| Line eps | Clusters | Assigned lines | Noise | Section purity | Median clusters/receipt |",
+        "|---:|---:|---:|---:|---:|---:|",
+    ]
+    for row in report["line_eps_sweep"]:
+        selected = " (selected)" if row["eps"] == summary["line_eps"] else ""
+        lines.append(
+            f"| {row['eps']:.2f}{selected} | {row['clusters']} | "
+            f"{row['assigned_lines']} | {row['noise_rate']:.1%} | "
+            f"{row['section_purity']:.1%} | "
+            f"{row['median_clusters_per_receipt']} |"
+        )
+    lines.extend(
+        [
+            "",
+            "## Feature Inventory",
+            "",
+            "Each letter embedding combines deterministic visual features before "
+            "any clustering:",
+            "",
+            "- normalized glyph bitmap",
+            "- OCR character-centered residual vector",
+            "- bbox size/aspect and OCR confidence",
+            "- ink density and content coverage",
+            "- edge density and horizontal/vertical transition rates",
+            "- row and column projection bins",
+            "- HOG-style unsigned gradient orientation bins",
+            "- stroke-width run estimates",
+            "- top/bottom/left/right contour profile stats",
+            "- horizontal and vertical symmetry",
+            "- connected component count and largest component ratio",
+            "- enclosed hole count and hole area ratio",
+            "",
+            "Each line signature then aggregates those letter features with line "
+            "geometry, letter spacing, word/letter counts, OCR character mix, "
+            "dominant letter-cluster mix, and averaged letter style-vector "
+            "centroids/spread.",
+            "",
+            "## Chroma Neighbor Check",
+            "",
+        ]
+    )
+    neighbor = summary["neighbor_quality"]
+    lines.extend(
+        [
+            f"- Same-character queries checked: {neighbor['checked']}",
+            f"- Top-1 same-cluster rate: "
+            f"{neighbor['top1_same_cluster_rate']:.1%}",
+            f"- Top-3 any same-cluster rate: "
+            f"{neighbor['top3_any_same_cluster_rate']:.1%}",
+            "",
+            "The neighbor check queries Chroma with a letter style vector, "
+            "filtered to the same OCR character, and checks whether nearest "
+            "neighbors share the discovered style cluster.",
+            "",
+            "## Letter Section Patterns",
+            "",
+            "| Section | Assigned letters | Avg height | Avg ink | Avg edge | Top style labels |",
+            "|---|---:|---:|---:|---:|---|",
+        ]
+    )
+    for section in report["section_summaries"]:
+        labels = ", ".join(
+            f"`{label}` ({count})"
+            for label, count in section["top_cluster_labels"].items()
+        )
+        lines.append(
+            f"| `{section['section']}` | {section['assigned_samples']} | "
+            f"{section['avg_box_height']:.4f} | "
+            f"{section['avg_ink_ratio']:.3f} | "
+            f"{section['avg_edge_density']:.3f} | {labels} |"
+        )
+    lines.extend(
+        [
+            "",
+            "## Line Section Patterns",
+            "",
+            "| Section | Assigned lines | Dominant cluster share | Avg line height | Avg letter height | Avg ink | Gap/height | Top line labels |",
+            "|---|---:|---:|---:|---:|---:|---:|---|",
+        ]
+    )
+    for section in report["line_section_summaries"]:
+        labels = ", ".join(
+            f"`{label}` ({count})"
+            for label, count in section["top_cluster_labels"].items()
+        )
+        lines.append(
+            f"| `{section['section']}` | {section['assigned_lines']} | "
+            f"{section['dominant_cluster_share']:.1%} | "
+            f"{section['avg_line_height']:.4f} | "
+            f"{section['avg_letter_height']:.4f} | "
+            f"{section['avg_ink_ratio']:.3f} | "
+            f"{section['avg_gap_to_height_ratio']:.3f} | {labels} |"
+        )
+    lines.extend(
+        [
+            "",
+            "## Largest Letter Style Clusters",
+            "",
+            "| Cluster | Label | Letters | Chars | Sections |",
+            "|---:|---|---:|---|---|",
+        ]
+    )
+    for cluster in report["cluster_summaries"][:12]:
+        chars = " ".join(f"`{char}`" for char in cluster["normalized_chars"][:8])
+        sections = ", ".join(
+            f"`{section}` ({count})"
+            for section, count in cluster["sections"].items()
+        )
+        lines.append(
+            f"| {cluster['cluster_id']} | `{cluster['label']}` | "
+            f"{cluster['sample_count']} | {chars} | {sections} |"
+        )
+    lines.extend(
+        [
+            "",
+            "## Largest Line Style Clusters",
+            "",
+            "| Cluster | Label | Lines | Sections | Examples |",
+            "|---:|---|---:|---|---|",
+        ]
+    )
+    for cluster in report["line_cluster_summaries"][:12]:
+        sections = ", ".join(
+            f"`{section}` ({count})"
+            for section, count in cluster["sections"].items()
+        )
+        examples = "; ".join(
+            example.replace("|", " ")
+            for example in cluster["text_examples"][:3]
+            if example
+        )
+        lines.append(
+            f"| {cluster['cluster_id']} | `{cluster['label']}` | "
+            f"{cluster['line_count']} | {sections} | {examples} |"
+        )
+    lines.extend(
+        [
+            "",
+            "## Interpretation",
+            "",
+            "This end-to-end pilot proves the mechanics work: individual OCR "
+            "letter crops can be embedded, persisted in a separate Chroma DB, "
+            "queried by same-character nearest neighbors, clustered into "
+            "visual style groups, and aggregated into line-level font "
+            "signatures.",
+            "",
+            "Line-level signatures are the better unit for section inference "
+            "because they carry stable typography and layout context. The "
+            "purity scores above compare how often each discovered cluster is "
+            "dominated by a single heuristic receipt section.",
+            "",
+            "It is not yet an exact font-family recognizer. The current output "
+            "is relative font/style clustering: size, width, stroke darkness, "
+            "and visual similarity. Exact font names would require a reference "
+            "library of rendered fonts and a calibration step against that "
+            "library.",
+            "",
+            "## Next Improvements",
+            "",
+            "- Tune `eps` per dataset or switch to HDBSCAN when available.",
+            "- Prefer persisted `ReceiptSection` entities over the heuristic "
+            "line classifier used in this pilot.",
+            "- Add a reference-font corpus to map clusters to likely font "
+            "family names.",
+            "- Use line signatures as features for a supervised section model "
+            "once section labels exist.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _avg(values: list[float]) -> float:
+    return round(mean(values), 5) if values else 0.0
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_letter_font_embedding_pilot.py
+++ b/scripts/run_letter_font_embedding_pilot.py
@@ -28,6 +28,7 @@ sys.path.insert(0, str(REPO_ROOT))
 sys.path.insert(0, str(REPO_ROOT / "receipt_upload"))
 sys.path.insert(0, str(REPO_ROOT / "receipt_chroma"))
 
+from receipt_chroma import ChromaClient  # noqa: E402
 from receipt_dynamo import DynamoClient  # noqa: E402
 from receipt_upload.font_letter_analysis import (  # noqa: E402
     LetterFontAnalysis,
@@ -39,7 +40,6 @@ from receipt_upload.font_letter_analysis import (  # noqa: E402
     cluster_letter_styles,
     cluster_line_font_styles,
 )
-from receipt_chroma import ChromaClient  # noqa: E402
 
 PROD_TABLE = "ReceiptsTable-d7ff76a"
 COLLECTION_NAME = "letter_font_glyphs"
@@ -89,7 +89,9 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--query-check-limit", type=int, default=200)
     parser.add_argument(
         "--report-md",
-        default=str(REPO_ROOT / "docs" / "receipt-letter-font-chroma-pilot.md"),
+        default=str(
+            REPO_ROOT / "docs" / "receipt-letter-font-chroma-pilot.md"
+        ),
     )
     parser.add_argument(
         "--report-json",
@@ -126,7 +128,9 @@ def main() -> None:
     for receipt in receipts:
         if not receipt.raw_s3_bucket or not receipt.raw_s3_key:
             continue
-        if not _s3_exists(s3_client, receipt.raw_s3_bucket, receipt.raw_s3_key):
+        if not _s3_exists(
+            s3_client, receipt.raw_s3_bucket, receipt.raw_s3_key
+        ):
             continue
         raw_ok_checked += 1
         selected.append(receipt)
@@ -253,7 +257,9 @@ def main() -> None:
         _line_eps_result(eps, analysis)
         for eps, analysis in line_analyses_by_eps.items()
     ]
-    cluster_by_id = {cluster.cluster_id: cluster for cluster in analysis.clusters}
+    cluster_by_id = {
+        cluster.cluster_id: cluster for cluster in analysis.clusters
+    }
     for sample_id, cluster_id in analysis.assignments.items():
         if cluster_id > 0:
             extra_metadata.setdefault(sample_id, {})[
@@ -421,9 +427,11 @@ def _line_eps_result(eps: float, analysis: LineFontAnalysis) -> dict[str, Any]:
             else 0.0
         ),
         "section_purity": _line_cluster_section_purity(analysis),
-        "median_clusters_per_receipt": median(cluster_counts_by_receipt)
-        if cluster_counts_by_receipt
-        else 0,
+        "median_clusters_per_receipt": (
+            median(cluster_counts_by_receipt)
+            if cluster_counts_by_receipt
+            else 0
+        ),
     }
 
 
@@ -465,9 +473,7 @@ def _persist_and_evaluate_chroma(
                 metadatas=[
                     {
                         **_sample_metadata(sample),
-                        **dict(
-                            extra_metadata_by_id.get(sample.sample_id, {})
-                        ),
+                        **dict(extra_metadata_by_id.get(sample.sample_id, {})),
                     }
                     for sample in batch
                 ],
@@ -582,13 +588,17 @@ def _build_report(
         for sample in analysis.samples
         if analysis.cluster_for_sample(sample.sample_id) is not None
     ]
-    clusters_by_id = {cluster.cluster_id: cluster for cluster in analysis.clusters}
+    clusters_by_id = {
+        cluster.cluster_id: cluster for cluster in analysis.clusters
+    }
     section_counts: Counter[str] = Counter()
     section_cluster_labels: dict[str, Counter[str]] = defaultdict(Counter)
     section_metrics: dict[str, dict[str, list[float]]] = defaultdict(
         lambda: defaultdict(list)
     )
-    char_counts = Counter(sample.normalized_char for sample in analysis.samples)
+    char_counts = Counter(
+        sample.normalized_char for sample in analysis.samples
+    )
 
     for sample in assigned_samples:
         cluster_id = analysis.cluster_for_sample(sample.sample_id)
@@ -598,7 +608,12 @@ def _build_report(
         cluster = clusters_by_id[cluster_id]
         section_counts[section] += 1
         section_cluster_labels[section][cluster.label] += 1
-        for metric in ("box_height", "ink_ratio", "edge_density", "box_aspect"):
+        for metric in (
+            "box_height",
+            "ink_ratio",
+            "edge_density",
+            "box_aspect",
+        ):
             section_metrics[section][metric].append(sample.metrics[metric])
 
     cluster_summaries = _cluster_summaries(
@@ -631,7 +646,9 @@ def _build_report(
             }
         )
 
-    sample_counts = [item["embedded_letter_count"] for item in receipt_summaries]
+    sample_counts = [
+        item["embedded_letter_count"] for item in receipt_summaries
+    ]
     cluster_counts_by_receipt = _cluster_counts_by_receipt(analysis)
     line_cluster_counts_by_receipt = _line_cluster_counts_by_receipt(
         line_analysis
@@ -662,9 +679,11 @@ def _build_report(
             else 0.0
         ),
         "assigned_lines": len(assigned_line_samples),
-        "median_line_clusters_per_receipt": median(line_cluster_counts_by_receipt)
-        if line_cluster_counts_by_receipt
-        else 0,
+        "median_line_clusters_per_receipt": (
+            median(line_cluster_counts_by_receipt)
+            if line_cluster_counts_by_receipt
+            else 0
+        ),
         "letter_cluster_section_purity": _letter_cluster_section_purity(
             analysis,
             section_by_sample,
@@ -672,12 +691,14 @@ def _build_report(
         "line_cluster_section_purity": _line_cluster_section_purity(
             line_analysis
         ),
-        "median_letters_per_receipt": median(sample_counts)
-        if sample_counts
-        else 0,
-        "median_clusters_per_receipt": median(cluster_counts_by_receipt)
-        if cluster_counts_by_receipt
-        else 0,
+        "median_letters_per_receipt": (
+            median(sample_counts) if sample_counts else 0
+        ),
+        "median_clusters_per_receipt": (
+            median(cluster_counts_by_receipt)
+            if cluster_counts_by_receipt
+            else 0
+        ),
         "common_ocr_chars": dict(char_counts.most_common(15)),
         "neighbor_quality": neighbor_quality,
         "errors": len(errors),
@@ -733,7 +754,9 @@ def _cluster_summaries(
                 "normalized_chars": list(cluster.normalized_chars[:12]),
                 "text_examples": list(cluster.text_examples),
                 "sections": dict(sections.most_common()),
-                "avg_box_height": round(cluster.metrics.get("box_height", 0), 5),
+                "avg_box_height": round(
+                    cluster.metrics.get("box_height", 0), 5
+                ),
                 "avg_ink_ratio": round(cluster.metrics.get("ink_ratio", 0), 5),
                 "avg_edge_density": round(
                     cluster.metrics.get("edge_density", 0), 5
@@ -744,26 +767,30 @@ def _cluster_summaries(
 
 
 def _cluster_counts_by_receipt(analysis: LetterFontAnalysis) -> list[int]:
-    clusters_by_receipt: dict[tuple[str | None, int | None], set[int]] = defaultdict(
-        set
+    clusters_by_receipt: dict[tuple[str | None, int | None], set[int]] = (
+        defaultdict(set)
     )
     for sample in analysis.samples:
         cluster_id = analysis.cluster_for_sample(sample.sample_id)
         if cluster_id is None:
             continue
-        clusters_by_receipt[(sample.image_id, sample.receipt_id)].add(cluster_id)
+        clusters_by_receipt[(sample.image_id, sample.receipt_id)].add(
+            cluster_id
+        )
     return [len(clusters) for clusters in clusters_by_receipt.values()]
 
 
 def _line_cluster_counts_by_receipt(analysis: LineFontAnalysis) -> list[int]:
-    clusters_by_receipt: dict[tuple[str | None, int | None], set[int]] = defaultdict(
-        set
+    clusters_by_receipt: dict[tuple[str | None, int | None], set[int]] = (
+        defaultdict(set)
     )
     for sample in analysis.samples:
         cluster_id = analysis.cluster_for_sample(sample.sample_id)
         if cluster_id is None:
             continue
-        clusters_by_receipt[(sample.image_id, sample.receipt_id)].add(cluster_id)
+        clusters_by_receipt[(sample.image_id, sample.receipt_id)].add(
+            cluster_id
+        )
     return [len(clusters) for clusters in clusters_by_receipt.values()]
 
 
@@ -779,7 +806,9 @@ def _line_cluster_summaries(
         key=lambda item: item.sample_count,
         reverse=True,
     )[:limit]:
-        samples = [samples_by_id[sample_id] for sample_id in cluster.sample_ids]
+        samples = [
+            samples_by_id[sample_id] for sample_id in cluster.sample_ids
+        ]
         sections = Counter(sample.section or "unknown" for sample in samples)
         rows.append(
             {
@@ -812,7 +841,9 @@ def _line_cluster_summaries(
 def _line_section_summaries(
     analysis: LineFontAnalysis,
 ) -> list[dict[str, Any]]:
-    clusters_by_id = {cluster.cluster_id: cluster for cluster in analysis.clusters}
+    clusters_by_id = {
+        cluster.cluster_id: cluster for cluster in analysis.clusters
+    }
     section_counts: Counter[str] = Counter()
     section_cluster_labels: dict[str, Counter[str]] = defaultdict(Counter)
     section_cluster_ids: dict[str, Counter[int]] = defaultdict(Counter)
@@ -1076,7 +1107,9 @@ def _render_markdown(report: dict[str, Any]) -> str:
         ]
     )
     for cluster in report["cluster_summaries"][:12]:
-        chars = " ".join(f"`{char}`" for char in cluster["normalized_chars"][:8])
+        chars = " ".join(
+            f"`{char}`" for char in cluster["normalized_chars"][:8]
+        )
         sections = ", ".join(
             f"`{section}` ({count})"
             for section, count in cluster["sections"].items()

--- a/scripts/run_letter_font_embedding_pilot.py
+++ b/scripts/run_letter_font_embedding_pilot.py
@@ -276,6 +276,7 @@ def main() -> None:
         collection_name=args.collection_name,
         extra_metadata_by_id=extra_metadata,
         limit=args.query_check_limit,
+        reset_collection=not args.no_reset,
     )
 
     report = _build_report(
@@ -444,6 +445,7 @@ def _persist_and_evaluate_chroma(
     extra_metadata_by_id: dict[str, dict[str, object]],
     limit: int,
     batch_size: int = 1000,
+    reset_collection: bool = False,
 ) -> tuple[int, dict[str, Any]]:
     with ChromaClient(
         persist_directory=persist_directory,
@@ -457,7 +459,7 @@ def _persist_and_evaluate_chroma(
                 "description": "Receipt OCR letter crop style embeddings"
             },
         )
-        if collection.count():
+        if reset_collection and collection.count():
             existing = collection.get(include=["metadatas"])
             existing_ids = list(existing.get("ids") or [])
             for start in range(0, len(existing_ids), batch_size):

--- a/scripts/run_letter_font_embedding_pilot.py
+++ b/scripts/run_letter_font_embedding_pilot.py
@@ -172,9 +172,7 @@ def main() -> None:
             image = _load_image(
                 s3_client, receipt.raw_s3_bucket, receipt.raw_s3_key
             )
-            section_by_line, ordered_lines, line_text_by_id = _classify_lines(
-                lines, words
-            )
+            section_by_line, _, _ = _classify_lines(lines, words)
             all_lines.extend(lines)
             all_words.extend(words)
             for line in lines:
@@ -200,33 +198,22 @@ def main() -> None:
             all_samples.extend(samples)
             receipt_summaries.append(
                 {
-                    "image_id": receipt.image_id,
-                    "receipt_id": receipt.receipt_id,
-                    "date": str(receipt.timestamp_added)[:10],
-                    "raw_s3_bucket": receipt.raw_s3_bucket,
-                    "raw_s3_key": receipt.raw_s3_key,
+                    "receipt_index": len(receipt_summaries) + 1,
                     "image_size": list(image.size),
                     "line_count": len(lines),
                     "word_count": len(words),
                     "letter_count": len(letters),
                     "embedded_letter_count": len(samples),
-                    "top_lines": [
-                        line_text_by_id[line.line_id]
-                        for line in ordered_lines[:4]
-                    ],
-                    "bottom_lines": [
-                        line_text_by_id[line.line_id]
-                        for line in ordered_lines[-4:]
-                    ],
+                    "section_line_counts": dict(
+                        Counter(section_by_line.values()).most_common()
+                    ),
                 }
             )
         except Exception as exc:  # noqa: BLE001
             errors.append(
                 {
-                    "image_id": receipt.image_id,
-                    "receipt_id": receipt.receipt_id,
+                    "receipt_offset": len(receipt_summaries) + len(errors) + 1,
                     "error_type": type(exc).__name__,
-                    "error": str(exc)[:300],
                 }
             )
 
@@ -540,17 +527,15 @@ def _evaluate_chroma_neighbors(
         if len(examples) < 5:
             examples.append(
                 {
-                    "query_id": sample.sample_id,
                     "query_char": sample.text,
                     "query_cluster": cluster_id,
                     "neighbors": [
                         {
-                            "id": neighbor_id,
                             "cluster": metadata.get("style_cluster_id"),
                             "label": metadata.get("style_cluster_label"),
                             "section": metadata.get("section"),
                         }
-                        for neighbor_id, metadata in neighbors[:3]
+                        for _, metadata in neighbors[:3]
                     ],
                 }
             )
@@ -657,7 +642,7 @@ def _build_report(
     )
 
     summary = {
-        "table": args.table,
+        "table": "redacted",
         "receipt_limit": args.limit,
         "receipts_seen": receipts_seen,
         "raw_ok_candidates": raw_ok_candidates,
@@ -754,7 +739,6 @@ def _cluster_summaries(
                 "label": cluster.label,
                 "sample_count": cluster.sample_count,
                 "normalized_chars": list(cluster.normalized_chars[:12]),
-                "text_examples": list(cluster.text_examples),
                 "sections": dict(sections.most_common()),
                 "avg_box_height": round(
                     cluster.metrics.get("box_height", 0), 5
@@ -818,7 +802,6 @@ def _line_cluster_summaries(
                 "label": cluster.label,
                 "line_count": cluster.sample_count,
                 "sections": dict(sections.most_common()),
-                "text_examples": list(cluster.text_examples[:8]),
                 "avg_line_height": round(
                     cluster.metrics.get("line_box_height", 0.0), 5
                 ),
@@ -1125,8 +1108,8 @@ def _render_markdown(report: dict[str, Any]) -> str:
             "",
             "## Largest Line Style Clusters",
             "",
-            "| Cluster | Label | Lines | Sections | Examples |",
-            "|---:|---|---:|---|---|",
+            "| Cluster | Label | Lines | Sections |",
+            "|---:|---|---:|---|",
         ]
     )
     for cluster in report["line_cluster_summaries"][:12]:
@@ -1134,14 +1117,9 @@ def _render_markdown(report: dict[str, Any]) -> str:
             f"`{section}` ({count})"
             for section, count in cluster["sections"].items()
         )
-        examples = "; ".join(
-            example.replace("|", " ")
-            for example in cluster["text_examples"][:3]
-            if example
-        )
         lines.append(
             f"| {cluster['cluster_id']} | `{cluster['label']}` | "
-            f"{cluster['line_count']} | {sections} | {examples} |"
+            f"{cluster['line_count']} | {sections} |"
         )
     lines.extend(
         [


### PR DESCRIPTION
## Summary

Adds a reproducible receipt font/style analysis pilot that starts from OCR geometry and raw receipt images, then produces both word/letter-level and line-level typography signals.

Changes include:
- deterministic word-level font/style feature extraction and clustering helpers
- letter crop visual embeddings with Chroma persistence/query support
- line-level font signatures that aggregate glyph metrics, OCR character mix, layout, and letter-cluster mix
- a raw-image S3 damage audit documenting missing raw objects and CDN recovery paths
- pilot Markdown/JSON artifacts with section-pattern results and threshold sweeps
- focused unit tests for word-level and letter/line-level clustering behavior

## Results

The latest pilot used 12 prod raw receipts:
- 6,505 letter embeddings persisted to local Chroma
- 8 letter style clusters with 14.1% letter noise
- 526 line signatures
- selected line clustering produced 25 line style clusters, 299 assigned lines, and 43.2% line noise
- letter cluster section purity: 45.5%
- selected line cluster section purity: 54.5%
- threshold sweep showed the best purity at 59.1%, but with lower coverage

This suggests font/line signatures are useful section features, but not sufficient as a standalone section detector.

## Codex-Friendly Handoff

This is Codex friendly because another agent can continue from durable local artifacts instead of re-running discovery:
- report and JSON artifacts capture the experiment inputs, results, and caveats
- scripts are runnable with explicit flags and local Chroma paths
- features are deterministic and inspectable rather than hidden model state
- tests cover the clustering mechanics on synthetic OCR glyphs
- reports call out raw-image S3 damage and fallback order for future runs

## Validation

- `PYTHONPATH=.:receipt_upload:receipt_chroma /usr/local/bin/python3.12 -m pytest receipt_upload/test/test_font_analysis.py receipt_upload/test/test_font_letter_analysis.py -q`
- Result: `7 passed`

## Notes

Exact font-family naming is not implemented here. That would require a rendered reference-font corpus and calibration pass. The current implementation clusters relative font/style traits such as size, width, darkness, spacing, and glyph similarity.