### PR TITLE
fix(#996): string-key the word-embedding cache (source-side fix for langsmith#3071)

### DIFF
--- a/receipt_upload/receipt_upload/label_validation/llm_runner.py
+++ b/receipt_upload/receipt_upload/label_validation/llm_runner.py
@@ -105,7 +105,7 @@ def build_pending_and_evidence(
     image_id: str,
     receipt_id: int,
     lightweight_validator: Any,
-    word_embedding_cache: Dict[Tuple[int, int], List[float]],
+    word_embedding_cache: Dict[str, List[float]],
 ) -> Tuple[List[Dict[str, Any]], Dict[str, List[Dict]]]:
     """Build ``pending_labels_data`` and per-word ``similar_evidence``.
 
@@ -131,9 +131,7 @@ def build_pending_and_evidence(
                 f"IMAGE#{image_id}#RECEIPT#{receipt_id:05d}"
                 f"#LINE#{label.line_id:05d}#WORD#{label.word_id:05d}"
             )
-            embedding = word_embedding_cache.get(
-                (label.line_id, label.word_id)
-            )
+            embedding = word_embedding_cache.get(word_id_str)
             if embedding:
                 similar_evidence[word_id_str] = (
                     lightweight_validator._query_similar_for_label(
@@ -348,7 +346,7 @@ def run_llm_validation_sync(
     dynamo: Any,
     word_labels: List[ReceiptWordLabel],
     lightweight_validator: Any,
-    word_embedding_cache: Dict[Tuple[int, int], List[float]],
+    word_embedding_cache: Dict[str, List[float]],
     merchant_name: Optional[str] = None,
 ) -> int:
     """Build the grok payload and apply it inline (original behavior)."""
@@ -398,7 +396,7 @@ def build_async_payload(
     receipt_id: int,
     table_name: str,
     lightweight_validator: Any,
-    word_embedding_cache: Dict[Tuple[int, int], List[float]],
+    word_embedding_cache: Dict[str, List[float]],
     merchant_name: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Build a self-contained, JSON-safe payload for the async consumer.

--- a/receipt_upload/receipt_upload/label_validation/validator.py
+++ b/receipt_upload/receipt_upload/label_validation/validator.py
@@ -91,7 +91,7 @@ class LightweightLabelValidator:
         self,
         words_client: ChromaClient,
         merchant_name: Optional[str] = None,
-        word_embeddings: Optional[Dict[Tuple[int, int], List[float]]] = None,
+        word_embeddings: Optional[Dict[str, List[float]]] = None,
     ):
         """Initialize the validator.
 
@@ -120,8 +120,9 @@ class LightweightLabelValidator:
         Returns:
             The embedding vector or None if not found
         """
-        # Check cache first (embeddings from current receipt)
-        cached = self.word_embeddings.get((line_id, word_id))
+        # Check cache first (embeddings from current receipt). Key is the
+        # "line_id_word_id" STRING (JSON-safe for tracing; see #3071).
+        cached = self.word_embeddings.get(f"{line_id}_{word_id}")
         if cached:
             return cached
 

--- a/receipt_upload/receipt_upload/line_items/semantic_proposer.py
+++ b/receipt_upload/receipt_upload/line_items/semantic_proposer.py
@@ -202,7 +202,7 @@ def propose_product_names(
     words: List,
     existing_labels: List[ReceiptWordLabel],
     words_client,
-    word_embeddings: Dict[Tuple[int, int], List[float]],
+    word_embeddings: Dict[str, List[float]],
     *,
     k: int = 5,
     min_similarity: float = 0.5,
@@ -214,7 +214,7 @@ def propose_product_names(
         existing_labels: labels already on the receipt (anchors + any proposals
             from the geometry pass); only unlabeled words are candidates.
         words_client: ChromaClient exposing ``.query(collection_name=..., ...)``.
-        word_embeddings: cached embeddings keyed by ``(line_id, word_id)``.
+        word_embeddings: cached embeddings keyed by ``"line_id_word_id"``.
     """
     # A word counts as "already labeled" only if it carries a real, non-rejected
     # core label. A pending ``O`` (background) label or an INVALID-only label
@@ -258,7 +258,7 @@ def propose_product_names(
             continue
         if _is_field_keyword(w.text):
             continue
-        emb = word_embeddings.get(key)
+        emb = word_embeddings.get(f"{w.line_id}_{w.word_id}")
         if emb is None:
             continue
         if _knn_is_product(words_client, emb, w.image_id, k, min_similarity):

--- a/receipt_upload/receipt_upload/merchant_resolution/embedding_processor.py
+++ b/receipt_upload/receipt_upload/merchant_resolution/embedding_processor.py
@@ -631,9 +631,13 @@ def _run_words_pipeline_worker(
         client = _make_read_client(local_words_dir, cloud_cfg)
 
         try:
-            # Build embedding cache
-            word_embedding_cache: Dict[Tuple[int, int], List[float]] = {
-                (w.line_id, w.word_id): emb
+            # Build embedding cache. Keyed by "line_id_word_id" STRING (not a
+            # (line_id, word_id) tuple): this cache is passed into functions that
+            # langchain/langsmith can auto-trace, and their JSON serializer can't
+            # encode tuple dict keys (langchain-ai/langsmith-sdk#3071), which
+            # silently drops the run's trace outputs. A string key is JSON-safe.
+            word_embedding_cache: Dict[str, List[float]] = {
+                f"{w.line_id}_{w.word_id}": emb
                 for w, emb in zip(words, word_embeddings_list, strict=True)
             }
 

--- a/receipt_upload/tests/test_llm_runner.py
+++ b/receipt_upload/tests/test_llm_runner.py
@@ -81,7 +81,7 @@ def test_build_async_payload_is_json_safe_and_complete():
         receipt_id=1,
         table_name="tbl",
         lightweight_validator=_FakeLV(),
-        word_embedding_cache={(8, 1): [0.1] * 4},
+        word_embedding_cache={"8_1": [0.1] * 4},
     )
     json.dumps(payload)  # raises if anything is not JSON-safe
     assert payload["image_id"] == IMAGE_ID

--- a/receipt_upload/tests/test_semantic_proposer.py
+++ b/receipt_upload/tests/test_semantic_proposer.py
@@ -71,7 +71,7 @@ def _setup():
         _w(13, 1, "$9.99", 0.72, 0.50),
     ]
     anchors = [_anchor(1, 1, "STORE_HOURS"), _anchor(13, 1, "GRAND_TOTAL")]
-    embeddings = {(8, 1): [0.1] * 8, (8, 2): [0.1] * 8, (8, 3): [0.1] * 8}
+    embeddings = {"8_1": [0.1] * 8, "8_2": [0.1] * 8, "8_3": [0.1] * 8}
     return words, anchors, embeddings
 
 
@@ -179,7 +179,7 @@ def test_keyword_substring_is_not_blocked():
         _w(8, 1, "Taxidermy", 0.1, 0.70),
         _w(13, 1, "$9.99", 0.72, 0.50),
     ]
-    embeddings = {(8, 1): [0.1] * 8}
+    embeddings = {"8_1": [0.1] * 8}
     out = propose_product_names(words, anchors, _FakeClient(), embeddings)
     assert keys_has(out, 8, 1)
 


### PR DESCRIPTION
Eliminates the non-fatal `Unable to process trace outputs: TypeError('keys must be str...not tuple')` warning by keying our embedding cache with `"line_id_word_id"` strings instead of `(line_id, word_id)` tuples — so no tuple-keyed dict can reach LangSmith's serializer (upstream bug langchain-ai/langsmith-sdk#3071; we're already on the latest 0.9.0). Source-side, no library patching. Full receipt_upload suite green. Closes #996.

🤖 Generated with [Claude Code](https://claude.com/claude-code)