### PR TITLE
fix(merchant,line-items): grand-total survivor election + wrong-state merchant rejection

### DIFF
--- a/receipt_agent/receipt_agent/agents/place_id_finder/tools/place_id_finder.py
+++ b/receipt_agent/receipt_agent/agents/place_id_finder/tools/place_id_finder.py
@@ -85,6 +85,92 @@ _TOLL_FREE_AREA_CODES = frozenset(
     {"800", "822", "833", "844", "855", "866", "877", "888"}
 )
 
+# US state / territory codes, for rejecting a Places hit whose state contradicts
+# the receipt's own city/state line. A bare chain text search ("Trader Joe's")
+# returns an arbitrary branch (often in another state); the receipt almost always
+# prints its city + state, so a confident state mismatch means wrong location.
+_US_STATE_CODES = frozenset(
+    {
+        "AL",
+        "AK",
+        "AZ",
+        "AR",
+        "CA",
+        "CO",
+        "CT",
+        "DE",
+        "FL",
+        "GA",
+        "HI",
+        "ID",
+        "IL",
+        "IN",
+        "IA",
+        "KS",
+        "KY",
+        "LA",
+        "ME",
+        "MD",
+        "MA",
+        "MI",
+        "MN",
+        "MS",
+        "MO",
+        "MT",
+        "NE",
+        "NV",
+        "NH",
+        "NJ",
+        "NM",
+        "NY",
+        "NC",
+        "ND",
+        "OH",
+        "OK",
+        "OR",
+        "PA",
+        "RI",
+        "SC",
+        "SD",
+        "TN",
+        "TX",
+        "UT",
+        "VT",
+        "VA",
+        "WA",
+        "WV",
+        "WI",
+        "WY",
+        "DC",
+        "PR",
+        "VI",
+        "GU",
+        "AS",
+        "MP",
+    }
+)
+
+
+def _extract_us_state(text: Optional[str]) -> Optional[str]:
+    """Best-effort 2-letter US state code from an address-ish string.
+
+    Only the two *structurally-signalled* forms are trusted: a ``ST 12345`` tail
+    (the canonical US address) and a ``City, ST`` form. A bare two-letter token
+    is deliberately NOT matched — "IN-N-OUT" or a lowercase "or" would otherwise
+    read as Indiana/Oregon. Returns ``None`` when nothing confidently parses;
+    callers treat that as "unknown", never as a mismatch.
+    """
+    if not text:
+        return None
+    up = text.upper()
+    m = re.search(r"\b([A-Z]{2})\s+\d{5}(?:-\d{4})?\b", up)
+    if m and m.group(1) in _US_STATE_CODES:
+        return m.group(1)
+    m = re.search(r",\s*([A-Z]{2})\b", up)
+    if m and m.group(1) in _US_STATE_CODES:
+        return m.group(1)
+    return None
+
 
 @dataclass
 class ReceiptRecord:
@@ -98,6 +184,9 @@ class ReceiptRecord:
         address: Current formatted address
         phone: Current phone number
         validation_status: Current validation status
+        expected_state: Receipt's own 2-letter US state, when known. Lets the
+            search reject a Places hit in a contradicting state without re-parsing
+            it from ``address``/``merchant_name``.
     """
 
     image_id: str
@@ -106,6 +195,7 @@ class ReceiptRecord:
     address: Optional[str] = None
     phone: Optional[str] = None
     validation_status: Optional[str] = None
+    expected_state: Optional[str] = None
 
 
 @dataclass
@@ -340,6 +430,28 @@ class PlaceIdFinder:
             match.error = "Google Places client not configured"
             return match
 
+        # The receipt's own state (caller-supplied when known, else parsed from
+        # its address / city-state line); used to reject a Places hit that lands
+        # in the wrong state — a bare chain text search returns an arbitrary
+        # branch (e.g. "Trader Joe's" -> Boston for a Henderson NV receipt;
+        # "CVS" -> Little Elm TX for a Las Vegas receipt).
+        expected_state = (receipt.expected_state or "").strip().upper() or None
+        if expected_state not in _US_STATE_CODES:
+            expected_state = _extract_us_state(
+                receipt.address
+            ) or _extract_us_state(receipt.merchant_name)
+
+        def _wrong_state(place_data: Any) -> bool:
+            """True only when the receipt's state is known AND the result's state
+            is known AND they differ. Unknown on either side => never a conflict.
+            """
+            if not expected_state:
+                return False
+            result_state = _extract_us_state(
+                getattr(place_data, "formatted_address", None)
+            )
+            return bool(result_state) and result_state != expected_state
+
         # Strategy 1: Try phone lookup first (most reliable)
         if receipt.phone:
             # Validate phone number format before searching
@@ -375,7 +487,11 @@ class PlaceIdFinder:
                     logger.debug("Searching by phone: %s", receipt.phone)
                     place_data = self.places.search_by_phone(receipt.phone)
                     # Place is a Pydantic model - use attribute access
-                    if place_data and getattr(place_data, "place_id", None):
+                    if (
+                        place_data
+                        and getattr(place_data, "place_id", None)
+                        and not _wrong_state(place_data)
+                    ):
                         match.place_id = place_data.place_id
                         match.place_name = place_data.name
                         match.place_address = getattr(
@@ -392,6 +508,13 @@ class PlaceIdFinder:
                             receipt, place_data, "phone"
                         )
                         return match
+                    if place_data and _wrong_state(place_data):
+                        logger.debug(
+                            "Ignoring phone hit in wrong state "
+                            "(receipt=%s, result=%s)",
+                            expected_state,
+                            getattr(place_data, "formatted_address", None),
+                        )
                 except Exception as e:
                     logger.debug(
                         "Phone search failed for %s#%s: %s",
@@ -420,7 +543,11 @@ class PlaceIdFinder:
                     )
                     place_data = self.places.search_by_address(receipt.address)
                     # Place is a Pydantic model - use attribute access
-                    if place_data and getattr(place_data, "place_id", None):
+                    if (
+                        place_data
+                        and getattr(place_data, "place_id", None)
+                        and not _wrong_state(place_data)
+                    ):
                         match.place_id = place_data.place_id
                         match.place_name = place_data.name
                         match.place_address = getattr(
@@ -437,6 +564,13 @@ class PlaceIdFinder:
                             receipt, place_data, "address"
                         )
                         return match
+                    if place_data and _wrong_state(place_data):
+                        logger.debug(
+                            "Ignoring address hit in wrong state "
+                            "(receipt=%s, result=%s)",
+                            expected_state,
+                            getattr(place_data, "formatted_address", None),
+                        )
                 except Exception as e:
                     logger.debug(
                         "Address search failed for %s#%s: %s",
@@ -464,7 +598,11 @@ class PlaceIdFinder:
                         receipt.merchant_name
                     )
                     # Place is a Pydantic model - use attribute access
-                    if place_data and getattr(place_data, "place_id", None):
+                    if (
+                        place_data
+                        and getattr(place_data, "place_id", None)
+                        and not _wrong_state(place_data)
+                    ):
                         match.place_id = place_data.place_id
                         match.place_name = place_data.name
                         match.place_address = getattr(
@@ -481,6 +619,13 @@ class PlaceIdFinder:
                             receipt, place_data, "text"
                         )
                         return match
+                    if place_data and _wrong_state(place_data):
+                        logger.debug(
+                            "Ignoring text hit in wrong state "
+                            "(receipt=%s, result=%s)",
+                            expected_state,
+                            getattr(place_data, "formatted_address", None),
+                        )
                 except Exception as e:
                     logger.debug(
                         "Text search failed for %s#%s: %s",

--- a/receipt_agent/tests/test_place_id_finder_geo.py
+++ b/receipt_agent/tests/test_place_id_finder_geo.py
@@ -1,0 +1,148 @@
+"""Geo-guard regression tests for the Place ID Finder's direct Places search.
+
+A bare chain text search returns an arbitrary branch — "Trader Joe's" resolved
+to Boston MA for a Henderson NV receipt; "CVS" to Little Elm TX for a Las Vegas
+receipt. The finder now derives the receipt's own state and rejects a Places hit
+whose state clearly contradicts it, falling through to the next strategy.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+from receipt_agent.agents.place_id_finder.tools.place_id_finder import (
+    PlaceIdFinder,
+    ReceiptRecord,
+    _extract_us_state,
+)
+
+
+def _place(place_id, name, formatted_address, phone=None):
+    return SimpleNamespace(
+        place_id=place_id,
+        name=name,
+        formatted_address=formatted_address,
+        formatted_phone_number=phone,
+        international_phone_number=phone,
+    )
+
+
+class _FakePlaces:
+    """Records calls and returns scripted results per search method."""
+
+    def __init__(self, by_phone=None, by_address=None, by_text=None):
+        self._by_phone = by_phone
+        self._by_address = by_address
+        self._by_text = by_text
+        self.calls = []
+
+    def search_by_phone(self, phone):
+        self.calls.append(("phone", phone))
+        return self._by_phone
+
+    def search_by_address(self, address):
+        self.calls.append(("address", address))
+        return self._by_address
+
+    def search_by_text(self, query, lat=None, lng=None):
+        self.calls.append(("text", query))
+        return self._by_text
+
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        ("2591 FM 423, Little Elm, TX 75068, USA", "TX"),
+        ("1999 Centre St, Boston, MA 02132, USA", "MA"),
+        ("3810 E. VEGAS, NV", "NV"),
+        ("CVS pharmacy VEGAS, NV", "NV"),  # enriched query (comma form)
+        ("CVS pharmacy VEGAS NV", None),  # no comma/zip -> not trusted
+        ("Trader Joe's", None),  # no confident state
+        ("buy 2 or 3", None),  # 'OR' must not be read as Oregon mid-text
+        ("IN-N-OUT BURGER", None),  # 'IN' must not be read as Indiana
+    ],
+)
+def test_extract_us_state(text, expected):
+    assert _extract_us_state(text) == expected
+
+
+def test_wrong_state_address_hit_falls_through_to_text():
+    """CVS case: address geocodes to the wrong-state branch (Little Elm TX); the
+    guard rejects it and the locality-enriched text search wins (Las Vegas NV).
+    """
+    wrong = _place("p_tx", "CVS", "2591 FM 423, Little Elm, TX 75068, USA")
+    right = _place(
+        "p_nv", "CVS", "3680 S Maryland Pkwy, Las Vegas, NV 89169, USA"
+    )
+    places = _FakePlaces(by_address=wrong, by_text=right)
+    finder = PlaceIdFinder(dynamo_client=None, places_client=places)
+
+    receipt = ReceiptRecord(
+        image_id="img",
+        receipt_id=1,
+        merchant_name="CVS pharmacy VEGAS, NV",
+        address="3810 E. VEGAS, NV",
+    )
+    match = finder._search_places_for_receipt(receipt)
+
+    assert match.found is True
+    assert match.place_id == "p_nv"  # not the Little Elm TX hit
+    assert match.search_method == "text"
+    # The address strategy was tried (and rejected) before the text strategy.
+    assert [c[0] for c in places.calls] == ["address", "text"]
+
+
+def test_matching_state_is_accepted():
+    """A same-state address hit is accepted as usual (no false rejection)."""
+    good = _place(
+        "p_nv", "CVS", "3680 S Maryland Pkwy, Las Vegas, NV 89169, USA"
+    )
+    places = _FakePlaces(by_address=good)
+    finder = PlaceIdFinder(dynamo_client=None, places_client=places)
+    receipt = ReceiptRecord(
+        image_id="img",
+        receipt_id=1,
+        merchant_name="CVS",
+        address="3810 E. VEGAS, NV",
+    )
+    match = finder._search_places_for_receipt(receipt)
+    assert match.found is True
+    assert match.place_id == "p_nv"
+    assert match.search_method == "address"
+
+
+def test_explicit_expected_state_rejects_wrong_state_text_hit():
+    """The resolver passes the parsed state via ReceiptRecord.expected_state, so
+    the guard works for a name+locality-only receipt whose merchant_name token
+    stream wouldn't otherwise parse a state (no comma/zip)."""
+    boston = _place(
+        "p_ma", "Trader Joe's", "1999 Centre St, Boston, MA 02132, USA"
+    )
+    places = _FakePlaces(by_text=boston)
+    finder = PlaceIdFinder(dynamo_client=None, places_client=places)
+    receipt = ReceiptRecord(
+        image_id="img",
+        receipt_id=1,
+        merchant_name="Trader Joe's Henderson NV",  # no comma -> name won't parse
+        expected_state="NV",  # but the resolver knows the state
+    )
+    match = finder._search_places_for_receipt(receipt)
+    assert (
+        match.found is False
+    )  # Boston rejected; no in-state alternative here
+    assert ("text", "Trader Joe's Henderson NV") in places.calls
+
+
+def test_unknown_receipt_state_never_rejects():
+    """With no parseable state on the receipt, any hit is accepted (the guard is
+    conservative — unknown is not a conflict)."""
+    hit = _place(
+        "p_ma", "Trader Joe's", "1999 Centre St, Boston, MA 02132, USA"
+    )
+    places = _FakePlaces(by_text=hit)
+    finder = PlaceIdFinder(dynamo_client=None, places_client=places)
+    receipt = ReceiptRecord(
+        image_id="img", receipt_id=1, merchant_name="Trader Joe's"
+    )
+    match = finder._search_places_for_receipt(receipt)
+    assert match.found is True
+    assert match.place_id == "p_ma"

--- a/receipt_upload/receipt_upload/line_items/reconstructor.py
+++ b/receipt_upload/receipt_upload/line_items/reconstructor.py
@@ -28,6 +28,34 @@ _DOT = re.compile(r"^\$?\d{1,4}[.,]$")  # "$3."  (split, left half)
 _FRAG = re.compile(r"^\d{2}$")  # "99"   (split, right half)
 _HEADER = {"ADDRESS_LINE", "PHONE_NUMBER", "STORE_HOURS"}
 _TOTALS = {"SUBTOTAL", "TAX", "GRAND_TOTAL"}
+# Tokens that mark a row as a *grand-total* row. Used to elect the canonical
+# copy when a receipt restates the total several times: an explicit "TOTAL: 9.08"
+# row must out-rank a bare restated number (e.g. a stray total that landed in a
+# "TOTAL NUMBER OF ITEMS SOLD" footer), or dedup may keep the stray and a later
+# validator invalidates it — leaving the receipt with no grand total at all.
+_GRAND_TOTAL_KEYWORDS = frozenset(
+    {"total", "balance", "due", "grand", "amount"}
+)
+# Tokens that turn a "total" row into a non-monetary count/summary row (e.g.
+# "TOTAL NUMBER OF ITEMS SOLD"), which must NOT anchor a grand-total election.
+_GRAND_TOTAL_DISQUALIFIERS = frozenset(
+    {
+        "number",
+        "items",
+        "item",
+        "qty",
+        "quantity",
+        "count",
+        "sold",
+        "transactions",
+        "transaction",
+        "pieces",
+        "units",
+        "lines",
+        "savings",
+        "saved",
+    }
+)
 _PROPOSED_BY = "geometry_line_items"
 _RECLASS_BY = "arithmetic_totals_reclass"
 
@@ -293,9 +321,15 @@ def dedupe_grand_total(
       that copy is canonical and only the ``PENDING`` duplicates of it are
       reported. If a group has *multiple* confirmed copies we abstain entirely.
     * When every copy in a value-group is ``PENDING``, the canonical kept copy is
-      the **lowest one on the receipt** (smallest y-center — header is high-y, the
-      final total prints last/lowest); the equal-valued restatements above it are
-      the redundant copies.
+      preferred by **grand-total-keyword context first** (a copy whose row carries
+      "TOTAL"/"BALANCE"/"DUE"/"GRAND"/"AMOUNT" out-ranks a bare restated number),
+      then by **lowest-on-receipt** (smallest y-center — header is high-y, the
+      final total prints last/lowest). Keyword anchoring matters: a stray copy of
+      the total value (e.g. one that landed in a "TOTAL NUMBER OF ITEMS SOLD"
+      footer) must not become canonical over the explicit "TOTAL: <amt>" row, or a
+      downstream validator may invalidate the kept stray and strand the receipt
+      with **no** grand total. The equal-valued restatements are the redundant
+      copies.
 
     Callers should mark each returned label ``INVALID`` (audit trail, never
     delete) and drop it from the pending set so the validators don't resurrect it.
@@ -328,6 +362,23 @@ def dedupe_grand_total(
             continue
         by_value.setdefault(val, []).append(lab)
 
+    # Line IDs whose row is an explicit grand-total row: it carries a grand-total
+    # keyword ("TOTAL"/"BALANCE"/...) AND none of the count-style disqualifiers
+    # ("NUMBER"/"ITEMS"/"SOLD"/...). The guard matters because a footer like
+    # "TOTAL NUMBER OF ITEMS SOLD" carries "TOTAL" but is a count row, not a money
+    # total — anchoring on it would re-elect the very stray we want to drop.
+    line_tokens: Dict[int, Set[str]] = {}
+    for w in words:
+        norm = re.sub(r"[^a-z]", "", str(getattr(w, "text", "")).lower())
+        if norm:
+            line_tokens.setdefault(w.line_id, set()).add(norm)
+    keyword_line_ids = {
+        line_id
+        for line_id, toks in line_tokens.items()
+        if (toks & _GRAND_TOTAL_KEYWORDS)
+        and not (toks & _GRAND_TOTAL_DISQUALIFIERS)
+    }
+
     redundant: List[ReceiptWordLabel] = []
     for _val, labs in by_value.items():
         if len(labs) < 2:
@@ -350,9 +401,16 @@ def dedupe_grand_total(
             # duplicates are redundant (never invalidate the confirmed one).
             redundant.extend(pending)
             continue
-        # All PENDING: keep the lowest-on-receipt copy, invalidate the rest.
-        pending.sort(key=lambda lab: pos.get((lab.line_id, lab.word_id), 0.0))
-        redundant.extend(pending[1:])
+        # All PENDING: elect a canonical copy and invalidate the rest. Prefer a
+        # keyword-anchored row (the explicit total) over a bare restated number;
+        # among the chosen pool, keep the lowest-on-receipt copy.
+        anchored = [lab for lab in pending if lab.line_id in keyword_line_ids]
+        candidates = anchored or pending
+        candidates.sort(
+            key=lambda lab: pos.get((lab.line_id, lab.word_id), 0.0)
+        )
+        canonical = candidates[0]
+        redundant.extend(lab for lab in pending if lab is not canonical)
     return redundant
 
 

--- a/receipt_upload/receipt_upload/merchant_resolution/resolver.py
+++ b/receipt_upload/receipt_upload/merchant_resolution/resolver.py
@@ -123,6 +123,154 @@ def _log(msg: str, *args: object) -> None:
     logger.info("%s", formatted)
 
 
+# US state / territory codes. Kept here (not imported from receipt_agent's
+# place_id_finder) so the receipt_upload resolver stays decoupled from that
+# package for a pure-regex helper; the two short copies are intentional.
+_US_STATE_CODES = frozenset(
+    {
+        "AL",
+        "AK",
+        "AZ",
+        "AR",
+        "CA",
+        "CO",
+        "CT",
+        "DE",
+        "FL",
+        "GA",
+        "HI",
+        "ID",
+        "IL",
+        "IN",
+        "IA",
+        "KS",
+        "KY",
+        "LA",
+        "ME",
+        "MD",
+        "MA",
+        "MI",
+        "MN",
+        "MS",
+        "MO",
+        "MT",
+        "NE",
+        "NV",
+        "NH",
+        "NJ",
+        "NM",
+        "NY",
+        "NC",
+        "ND",
+        "OH",
+        "OK",
+        "OR",
+        "PA",
+        "RI",
+        "SC",
+        "SD",
+        "TN",
+        "TX",
+        "UT",
+        "VT",
+        "VA",
+        "WA",
+        "WV",
+        "WI",
+        "WY",
+        "DC",
+        "PR",
+        "VI",
+        "GU",
+        "AS",
+        "MP",
+    }
+)
+# "City, ST" (comma form) and "City ST 12345" (zip form) — the two reliable ways
+# a US receipt prints its locality. Both require a strong signal (comma or ZIP)
+# so we don't match incidental two-letter tokens mid-text. The city is bounded to
+# the 1-3 word tokens *immediately* before the state to avoid swallowing the
+# street ("4600 E. SUNSET RD Henderson, NV" -> "Henderson", not the whole line).
+_CITY = r"([A-Za-z][A-Za-z.'\-]*(?:\s+[A-Za-z.'\-]+){0,2})"
+_LOCALITY_COMMA_RE = re.compile(_CITY + r"\s*,\s*([A-Za-z]{2})\b")
+_LOCALITY_ZIP_RE = re.compile(_CITY + r"\s+([A-Za-z]{2})\s+\d{5}(?:-\d{4})?\b")
+# Street-type suffixes. When the captured "city" span actually swallowed a street
+# (a "<street> <suffix> <city>, ST" line that wasn't split into its own line),
+# keep only the tokens AFTER the last suffix — the real city.
+_STREET_SUFFIXES = frozenset(
+    {
+        "st",
+        "street",
+        "ave",
+        "avenue",
+        "blvd",
+        "boulevard",
+        "rd",
+        "road",
+        "dr",
+        "drive",
+        "ln",
+        "lane",
+        "way",
+        "ct",
+        "court",
+        "pkwy",
+        "parkway",
+        "hwy",
+        "highway",
+        "pl",
+        "place",
+        "cir",
+        "circle",
+        "ter",
+        "terrace",
+        "sq",
+        "ste",
+        "suite",
+        "unit",
+        "fwy",
+        "freeway",
+        "trl",
+        "trail",
+    }
+)
+
+
+def parse_locality(text: str) -> Optional[str]:
+    """Return ``"City, ST"`` parsed from an address-ish string, else ``None``.
+
+    The comma is intentional: it keeps the enriched Places text query parseable
+    by the geo guard's ``City, ST`` form (which never matches a bare two-letter
+    token, so it can't misread "IN-N-OUT" as Indiana). Cleanups on the captured
+    city span:
+
+    * a leading directional *abbreviated with a period* ("E.", "N.") is dropped
+      ("E. VEGAS" -> "VEGAS"), but a spelled-out/period-less directional is kept
+      so "N Las Vegas"/"North Las Vegas" stays a distinct city;
+    * if the span swallowed a street (same-line "4600 E. SUNSET RD Henderson"),
+      only the tokens after the last street suffix are kept ("Henderson").
+    """
+    if not text:
+        return None
+    for regex in (_LOCALITY_COMMA_RE, _LOCALITY_ZIP_RE):
+        m = regex.search(text)
+        if not m or m.group(2).upper() not in _US_STATE_CODES:
+            continue
+        city = re.sub(r"^[A-Za-z]\.\s+", "", m.group(1).strip()).strip()
+        tokens = city.split()
+        suffix_idx = [
+            i
+            for i, tok in enumerate(tokens)
+            if re.sub(r"[^a-z]", "", tok.lower()) in _STREET_SUFFIXES
+        ]
+        if suffix_idx:
+            tokens = tokens[suffix_idx[-1] + 1 :]
+        city = " ".join(tokens).strip()
+        if city:
+            return f"{city}, {m.group(2).upper()}"
+    return None
+
+
 def tokenize_text(text: str) -> Set[str]:
     """Extract lowercase alphanumeric tokens (>= *_MIN_TOKEN_LEN* chars) from *text*."""
     return {
@@ -431,6 +579,11 @@ class MerchantResolver:
         ) or self._extract_labeled_text(
             words, word_labels, "MERCHANT_NAME", require_valid=False
         )
+        # Whether the hint is a real MERCHANT_NAME *label* vs the geometric
+        # top-line fallback (often a check/register number like "105"). Only a
+        # labeled name is trustworthy enough to drive the eager locality text
+        # search below; a top-line guess must defer to Chroma/agentic tiers.
+        has_labeled_merchant = bool(merchant_hint)
         merchant_line = self._get_merchant_line(lines)
         if not merchant_hint:
             merchant_hint = merchant_line.text if merchant_line else None
@@ -478,13 +631,51 @@ class MerchantResolver:
                     place_text_query = cleaned or ln.text
                     break
 
+        # Locality ("City, ST") from the receipt — the chain disambiguator. A bare
+        # "Trader Joe's" text search returns an arbitrary branch (Boston for a
+        # Henderson NV receipt); "Trader Joe's Henderson, NV" resolves the right
+        # store. Parse per-LINE (a city usually prints on its own line, e.g.
+        # "Henderson, NV") rather than a joined address blob, which would let the
+        # street swallow the city. ADDRESS_LINE-labeled lines are tried first.
+        addr_line_ids = {
+            lab.line_id
+            for lab in word_labels
+            if lab.label == "ADDRESS_LINE"
+            and lab.validation_status not in _rejected_status
+        }
+        ordered_lines = sorted(
+            (ln for ln in lines if ln.text),
+            key=lambda ln: (ln.line_id not in addr_line_ids, ln.line_id),
+        )
+        locality: Optional[str] = None
+        for ln in ordered_lines:
+            locality = parse_locality(ln.text)
+            if locality:
+                break
+        # State part of "City, ST" — passed explicitly to the geo guard so it is
+        # never disabled by how the text query happens to be tokenized.
+        expected_state = (
+            locality.rsplit(",", 1)[-1].strip() if locality else None
+        )
+
+        # Append the locality to the text query unless it is already present.
+        if locality:
+            loc_tokens = set(re.findall(r"[a-z]+", locality.lower()))
+            q_tokens = set(
+                re.findall(r"[a-z]+", (place_text_query or "").lower())
+            )
+            if loc_tokens and not loc_tokens <= q_tokens:
+                base = place_text_query or merchant_hint or ""
+                place_text_query = f"{base} {locality}".strip()
+
         _log(
-            "Resolving merchant for %s#%d (hint=%s, phone=%s, address=%s...)",
+            "Resolving merchant for %s#%d (hint=%s, phone=%s, address=%s..., locality=%s)",
             image_id[:8],
             receipt_id,
             merchant_hint or "none",
             phone or "none",
             (address[:30] + "...") if address else "none",
+            locality or "none",
         )
 
         # Tier 1: Google Places, keyed on the Apple-NLP phone/address (with the
@@ -493,11 +684,22 @@ class MerchantResolver:
         # this is the authoritative path. It needs no validated labels, so it
         # leads at upload time — superseding the old "labeled fast path" that was
         # inert because it required VALID labels that don't exist yet here.
-        if phone or address:
+        # Also run when we only have a labeled name + locality (no phone/address):
+        # the locality-enriched text search disambiguates the chain, and the geo
+        # guard rejects a wrong-state hit, so this is safe for name-only receipts
+        # that previously fell through to the agentic tier and mis-resolved. We
+        # require a real MERCHANT_NAME label (not the top-line fallback) so a weak
+        # hint like a check number can't preempt Tier 2/3 with a same-state miss.
+        if (
+            phone
+            or address
+            or (place_text_query and locality and has_labeled_merchant)
+        ):
             result = self._run_labeled_place_search(
                 merchant_name=place_text_query,
                 address=address,
                 phone=phone,
+                expected_state=expected_state,
             )
             if result.place_id:
                 _log(
@@ -1004,13 +1206,15 @@ class MerchantResolver:
         merchant_name: Optional[str],
         address: Optional[str],
         phone: Optional[str],
+        expected_state: Optional[str] = None,
     ) -> MerchantResult:
         """Search Places directly using receipt evidence (phone/address/name).
 
         Phone and address are the authoritative keys (a phone lookup returns the
         exact business); ``merchant_name`` is only a text-query hint. Runs as long
         as ANY of phone/address/name is present — a phone- or address-only receipt
-        resolves without a labeled name.
+        resolves without a labeled name. ``expected_state`` (the receipt's parsed
+        2-letter state) lets the finder reject a wrong-state Places hit.
         """
         if not self.places_client or not (merchant_name or address or phone):
             return MerchantResult()
@@ -1026,6 +1230,7 @@ class MerchantResolver:
                 merchant_name=merchant_name,
                 address=address,
                 phone=phone,
+                expected_state=expected_state,
             )
             finder = place_id_finder_module.PlaceIdFinder(
                 dynamo_client=self.dynamo,

--- a/receipt_upload/receipt_upload/merchant_resolution/resolver.py
+++ b/receipt_upload/receipt_upload/merchant_resolution/resolver.py
@@ -331,17 +331,50 @@ _ZIP_RANGES = (
     (995, 999, "AK"),
 )
 _ZIP_RE = re.compile(r"\b(\d{5})(?:-\d{4})?\b")
+# Full-ZIP exceptions that a 3-digit prefix can't disambiguate. American Samoa's
+# 96799 sits inside the 967 Hawaii prefix; map it explicitly so an AS receipt
+# isn't tagged HI (which would reject the correct AS Places hit as wrong-state).
+_ZIP_FULL_EXCEPTIONS = {"96799": "AS"}
 
 
 def state_from_zip(zip5: str) -> Optional[str]:
     """Map a 5-digit ZIP to its 2-letter state, else ``None``."""
     if not zip5 or len(zip5) < 3 or not zip5[:3].isdigit():
         return None
+    if zip5[:5] in _ZIP_FULL_EXCEPTIONS:
+        return _ZIP_FULL_EXCEPTIONS[zip5[:5]]
     prefix = int(zip5[:3])
     for lo, hi, state in _ZIP_RANGES:
         if lo <= prefix <= hi:
             return state
     return None
+
+
+def state_of_address(address: Optional[str]) -> Optional[str]:
+    """2-letter state from a Google formatted address, else ``None``.
+
+    Prefers the "City, ST" tail, then the ZIP. Used to geo-validate a resolved
+    place against the receipt's own state on the fallback tiers.
+    """
+    if not address:
+        return None
+    loc = parse_locality(address)
+    if loc:
+        return loc.rsplit(",", 1)[-1].strip()
+    m = _ZIP_RE.search(address)
+    return state_from_zip(m.group(1)) if m else None
+
+
+def address_state_conflict(
+    address: Optional[str], expected_state: Optional[str]
+) -> bool:
+    """True only when BOTH the receipt's state and the result's state are known
+    and differ — a conservative wrong-state signal (unknown is never a conflict).
+    """
+    if not expected_state:
+        return False
+    result_state = state_of_address(address)
+    return bool(result_state) and result_state != expected_state
 
 
 def _trim_leading_street(parts: List[str]) -> List[str]:
@@ -820,17 +853,7 @@ class MerchantResolver:
         # this is the authoritative path. It needs no validated labels, so it
         # leads at upload time — superseding the old "labeled fast path" that was
         # inert because it required VALID labels that don't exist yet here.
-        # Also run when we only have a labeled name + locality (no phone/address):
-        # the locality-enriched text search disambiguates the chain, and the geo
-        # guard rejects a wrong-state hit, so this is safe for name-only receipts
-        # that previously fell through to the agentic tier and mis-resolved. We
-        # require a real MERCHANT_NAME label (not the top-line fallback) so a weak
-        # hint like a check number can't preempt Tier 2/3 with a same-state miss.
-        if (
-            phone
-            or address
-            or (place_text_query and locality and has_labeled_merchant)
-        ):
+        if phone or address:
             result = self._run_labeled_place_search(
                 merchant_name=place_text_query,
                 address=address,
@@ -870,6 +893,9 @@ class MerchantResolver:
                 if (
                     result.place_id
                     and result.confidence >= MIN_SIMILARITY_THRESHOLD
+                    and not address_state_conflict(
+                        result.address, expected_state
+                    )
                 ):
                     _log(
                         "Tier 2 SUCCESS (phone): %s (place_id=%s, conf=%.2f)",
@@ -899,6 +925,9 @@ class MerchantResolver:
                 if (
                     result.place_id
                     and result.confidence >= MIN_SIMILARITY_THRESHOLD
+                    and not address_state_conflict(
+                        result.address, expected_state
+                    )
                 ):
                     _log(
                         "Tier 2 SUCCESS (address): %s (place_id=%s, conf=%.2f)",
@@ -936,6 +965,7 @@ class MerchantResolver:
             if (
                 result.place_id
                 and result.confidence >= HIGH_CONFIDENCE_THRESHOLD
+                and not address_state_conflict(result.address, expected_state)
             ):
                 _log(
                     "Tier 2 SUCCESS (merchant): %s (place_id=%s, conf=%.2f)",
@@ -953,11 +983,48 @@ class MerchantResolver:
                     HIGH_CONFIDENCE_THRESHOLD,
                 )
 
+        # Tier 2.5: locality-enriched Places text search. Runs only AFTER the
+        # Chroma "seen-before" tiers (so a previously-resolved exact place_id
+        # wins over a fresh text hit) and only with a real MERCHANT_NAME label +
+        # locality (a weak top-line hint like a check number must not preempt the
+        # agentic tier). The city in the query disambiguates the chain and the geo
+        # guard rejects a wrong-state hit. Covers no-phone/no-address receipts
+        # that previously fell straight to the agent and mis-resolved.
+        if place_text_query and locality and has_labeled_merchant:
+            result = self._run_labeled_place_search(
+                merchant_name=place_text_query,
+                address=address,
+                phone=phone,
+                expected_state=expected_state,
+            )
+            if result.place_id:
+                _log(
+                    "Tier 2.5 SUCCESS (locality text): %s "
+                    "(place_id=%s, conf=%.2f)",
+                    result.merchant_name,
+                    result.place_id,
+                    result.confidence,
+                )
+                return result
+
         # Tier 3: Fall back to Place ID Finder agent (Google Places API)
         _log("Tier 1/2 failed, invoking Tier 3: Place ID Finder agent")
         result = self._run_place_id_finder(
             lines_client, lines, words, image_id, receipt_id, word_labels
         )
+
+        # Geo guard the agentic result too (#3): the agent path builds its own
+        # ReceiptRecord without expected_state, so a wrong-state chain hit could
+        # otherwise slip through on a faint-scan receipt.
+        if result.place_id and address_state_conflict(
+            result.address, expected_state
+        ):
+            _log(
+                "Tier 3 result rejected: state for %r != receipt state %s",
+                result.address,
+                expected_state,
+            )
+            return MerchantResult()
 
         if result.place_id:
             _log(

--- a/receipt_upload/receipt_upload/merchant_resolution/resolver.py
+++ b/receipt_upload/receipt_upload/merchant_resolution/resolver.py
@@ -257,17 +257,147 @@ def parse_locality(text: str) -> Optional[str]:
         if not m or m.group(2).upper() not in _US_STATE_CODES:
             continue
         city = re.sub(r"^[A-Za-z]\.\s+", "", m.group(1).strip()).strip()
-        tokens = city.split()
-        suffix_idx = [
-            i
-            for i, tok in enumerate(tokens)
-            if re.sub(r"[^a-z]", "", tok.lower()) in _STREET_SUFFIXES
-        ]
-        if suffix_idx:
-            tokens = tokens[suffix_idx[-1] + 1 :]
+        tokens = _trim_leading_street(city.split())
         city = " ".join(tokens).strip()
         if city:
             return f"{city}, {m.group(2).upper()}"
+    return None
+
+
+# 3-digit ZIP prefix -> state. A ZIP is far more OCR-stable than the two state
+# letters (which a faint scan drops entirely, e.g. "Henderson." over "89014"),
+# so it is the primary state signal for the geo guard. Ranges are (lo, hi, ST)
+# on the first three digits; gaps (military/territory/unused) fall through.
+_ZIP_RANGES = (
+    (10, 27, "MA"),
+    (28, 29, "RI"),
+    (30, 38, "NH"),
+    (39, 49, "ME"),
+    (50, 54, "VT"),
+    (55, 55, "MA"),  # 055xx is a unique MA prefix, not VT
+    (56, 59, "VT"),
+    (60, 69, "CT"),
+    (70, 89, "NJ"),
+    (100, 149, "NY"),
+    (150, 196, "PA"),
+    (197, 199, "DE"),
+    (200, 200, "DC"),
+    (201, 201, "VA"),  # 201xx (Dulles) is VA, not DC
+    (202, 205, "DC"),
+    (206, 219, "MD"),
+    (220, 246, "VA"),
+    (247, 268, "WV"),
+    (270, 289, "NC"),
+    (290, 299, "SC"),
+    (300, 319, "GA"),
+    (320, 339, "FL"),
+    (341, 349, "FL"),  # 340xx is military (AA), not a state
+    (350, 369, "AL"),
+    (370, 385, "TN"),
+    (386, 397, "MS"),
+    (398, 399, "GA"),
+    (400, 427, "KY"),
+    (430, 459, "OH"),
+    (460, 479, "IN"),
+    (480, 499, "MI"),
+    (500, 528, "IA"),
+    (530, 549, "WI"),
+    (550, 567, "MN"),
+    (570, 577, "SD"),
+    (580, 588, "ND"),
+    (590, 599, "MT"),
+    (600, 629, "IL"),
+    (630, 658, "MO"),
+    (660, 679, "KS"),
+    (680, 693, "NE"),
+    (700, 714, "LA"),
+    (716, 729, "AR"),
+    (730, 732, "OK"),
+    (733, 733, "TX"),
+    (734, 749, "OK"),
+    (750, 799, "TX"),
+    (800, 816, "CO"),
+    (820, 831, "WY"),
+    (832, 838, "ID"),
+    (840, 847, "UT"),
+    (850, 865, "AZ"),
+    (870, 884, "NM"),
+    (885, 885, "TX"),
+    (889, 898, "NV"),
+    (900, 961, "CA"),
+    (967, 968, "HI"),
+    (970, 979, "OR"),
+    (980, 994, "WA"),
+    (995, 999, "AK"),
+)
+_ZIP_RE = re.compile(r"\b(\d{5})(?:-\d{4})?\b")
+
+
+def state_from_zip(zip5: str) -> Optional[str]:
+    """Map a 5-digit ZIP to its 2-letter state, else ``None``."""
+    if not zip5 or len(zip5) < 3 or not zip5[:3].isdigit():
+        return None
+    prefix = int(zip5[:3])
+    for lo, hi, state in _ZIP_RANGES:
+        if lo <= prefix <= hi:
+            return state
+    return None
+
+
+def _trim_leading_street(parts: List[str]) -> List[str]:
+    """Drop everything up to the last street suffix that is NOT the first token.
+
+    A suffix at index >= 1 means a street name preceded it ("SUNSET RD Henderson"
+    -> "Henderson"). A suffix at index 0 is part of the city name itself
+    ("St. Louis", "Ave Maria") and is kept.
+    """
+    suffix_idx = [
+        i
+        for i, t in enumerate(parts)
+        if i >= 1 and re.sub(r"[^a-z]", "", t.lower()) in _STREET_SUFFIXES
+    ]
+    return parts[suffix_idx[-1] + 1 :] if suffix_idx else parts
+
+
+_ZIP_ONLY_RE = re.compile(r"^\s*(\d{5})(?:-\d{4})?\s*$")
+
+
+def _trailing_city(text: str) -> Optional[str]:
+    """Last 1-3 alpha tokens of *text* as a city (a leading street trimmed)."""
+    if not text:
+        return None
+    toks = re.findall(r"[A-Za-z][A-Za-z.'\-]*", text)
+    toks = [t for t in toks if re.sub(r"[^a-z]", "", t.lower())]
+    parts = _trim_leading_street(toks[-3:])
+    parts = [p.strip(".") for p in parts if p.strip(".")]
+    city = " ".join(parts).strip()
+    return city or None
+
+
+def locality_from_lines(line_texts: List[str]) -> Optional[str]:
+    """Best-effort ``"City, ST"`` from a receipt's lines (in receipt order).
+
+    First the clean per-line form ("City, ST"/"City ST ZIP"); then a fragmented
+    fallback that pairs a **ZIP-only** line with the city on the line just above
+    ("Henderson." over "89014" -> "Henderson, NV"). Requiring the whole line to be
+    the ZIP (not just any 5-digit token) keeps transaction/auth numbers like
+    "AUTH #12345" from fabricating a state. The ZIP-derived state is what makes
+    the geo guard robust to dropped state letters.
+    """
+    for text in line_texts:
+        loc = parse_locality(text)
+        if loc:
+            return loc
+    for idx, text in enumerate(line_texts):
+        m = _ZIP_ONLY_RE.match(text or "")
+        if not m or idx == 0:
+            continue
+        state = state_from_zip(m.group(1))
+        if not state:
+            continue
+        city = _trailing_city(line_texts[idx - 1])
+        if city:
+            return f"{city}, {state}"
     return None
 
 
@@ -634,24 +764,30 @@ class MerchantResolver:
         # Locality ("City, ST") from the receipt — the chain disambiguator. A bare
         # "Trader Joe's" text search returns an arbitrary branch (Boston for a
         # Henderson NV receipt); "Trader Joe's Henderson, NV" resolves the right
-        # store. Parse per-LINE (a city usually prints on its own line, e.g.
-        # "Henderson, NV") rather than a joined address blob, which would let the
-        # street swallow the city. ADDRESS_LINE-labeled lines are tried first.
+        # store. ADDRESS_LINE-labeled lines are tried first (clean "City, ST"
+        # form); then, in receipt order, a fragmented ZIP fallback pairs a bare
+        # ZIP with its city ("Henderson." over "89014" -> "Henderson, NV") — the
+        # ZIP-derived state is what survives a faint scan that drops "NV".
         addr_line_ids = {
             lab.line_id
             for lab in word_labels
             if lab.label == "ADDRESS_LINE"
             and lab.validation_status not in _rejected_status
         }
-        ordered_lines = sorted(
-            (ln for ln in lines if ln.text),
-            key=lambda ln: (ln.line_id not in addr_line_ids, ln.line_id),
+        receipt_order = sorted(
+            (ln for ln in lines if ln.text), key=lambda ln: ln.line_id
         )
-        locality: Optional[str] = None
-        for ln in ordered_lines:
-            locality = parse_locality(ln.text)
-            if locality:
-                break
+        # Clean "City, ST" on an ADDRESS_LINE-labeled line wins first; otherwise
+        # scan all lines in receipt order (clean form, then the ZIP fallback,
+        # whose city/ZIP adjacency needs that order preserved).
+        locality = None
+        for ln in receipt_order:
+            if ln.line_id in addr_line_ids:
+                locality = parse_locality(ln.text)
+                if locality:
+                    break
+        if not locality:
+            locality = locality_from_lines([ln.text for ln in receipt_order])
         # State part of "City, ST" — passed explicitly to the geo guard so it is
         # never disabled by how the text query happens to be tokenized.
         expected_state = (

--- a/receipt_upload/tests/test_dedupe_grand_total.py
+++ b/receipt_upload/tests/test_dedupe_grand_total.py
@@ -68,6 +68,55 @@ def test_all_pending_keeps_lowest_invalidates_rest():
     assert all(lab.validation_status == _PENDING for lab in redundant)
 
 
+def test_keyword_anchored_copy_wins_over_lower_stray():
+    """Regression for the Smith's June22 receipt: the grand total 9.08 appeared as
+    "TOTAL: 9.08" and as a stray 9.08 that landed lowest (in the "TOTAL NUMBER OF
+    ITEMS SOLD" footer). Lowest-y alone kept the stray, a validator then
+    invalidated it, and the receipt was left with no grand total. The explicit
+    "TOTAL:" row must be elected canonical even though it is not the lowest.
+    """
+    words = [
+        _w(19, 1, "TOTAL:", 0.10, 0.40),  # keyword anchors line 19
+        _w(19, 2, "9.08", 0.72, 0.40),  # the real grand total
+        _w(14, 1, "9.08", 0.72, 0.55),  # "BALANCE" restatement (higher)
+        # Stray 9.08 sits lowest, on a "TOTAL NUMBER OF ITEMS SOLD" count row:
+        # the row carries "TOTAL" but the count disqualifiers must stop it from
+        # anchoring (else lowest-y would re-elect this stray).
+        _w(28, 1, "TOTAL", 0.05, 0.12),
+        _w(28, 2, "NUMBER", 0.15, 0.12),
+        _w(28, 3, "OF", 0.25, 0.12),
+        _w(28, 4, "ITEMS", 0.35, 0.12),
+        _w(28, 5, "SOLD", 0.45, 0.12),
+        _w(28, 6, "9.08", 0.72, 0.12),
+    ]
+    labels = [
+        _label(19, 2, "GRAND_TOTAL", _PENDING),
+        _label(14, 1, "GRAND_TOTAL", _PENDING),
+        _label(28, 6, "GRAND_TOTAL", _PENDING),
+    ]
+    redundant = dedupe_grand_total(words, labels)
+    # The keyword-anchored "TOTAL: 9.08" (L19) is kept; the two restatements go —
+    # including the stray, even though its row contains the word "TOTAL".
+    assert _keys(redundant) == {(14, 1), (28, 6)}
+    assert (19, 2) not in _keys(redundant)
+
+
+def test_lowest_y_among_keyword_anchored_copies():
+    """When several copies are keyword-anchored, keep the lowest-on-receipt one."""
+    words = [
+        _w(10, 1, "BALANCE", 0.10, 0.40),
+        _w(10, 2, "9.08", 0.72, 0.40),  # anchored, higher
+        _w(20, 1, "TOTAL", 0.10, 0.15),
+        _w(20, 2, "9.08", 0.72, 0.15),  # anchored, lowest -> canonical
+    ]
+    labels = [
+        _label(10, 2, "GRAND_TOTAL", _PENDING),
+        _label(20, 2, "GRAND_TOTAL", _PENDING),
+    ]
+    redundant = dedupe_grand_total(words, labels)
+    assert _keys(redundant) == {(10, 2)}
+
+
 def test_confirmed_copy_is_canonical_only_pending_dropped():
     """A VALID (human/validator) copy is canonical and never invalidated; only
     its PENDING duplicates are reported."""

--- a/receipt_upload/tests/test_merchant_resolver.py
+++ b/receipt_upload/tests/test_merchant_resolver.py
@@ -1344,6 +1344,7 @@ class TestMerchantResolverLabeledFields:
             merchant_name="Whole Foods",
             address="123 Main",
             phone=None,
+            expected_state=None,
         )
         chroma_search.assert_not_called()
 

--- a/receipt_upload/tests/test_resolver_locality.py
+++ b/receipt_upload/tests/test_resolver_locality.py
@@ -1,0 +1,44 @@
+"""Tests for locality ("City ST") parsing used to disambiguate chain stores.
+
+A bare "Trader Joe's" Places text query returns an arbitrary branch; appending
+the receipt's own "City ST" resolves the right store. The parser must pull the
+locality from real receipt lines while ignoring incidental two-letter tokens.
+"""
+
+import pytest
+
+from receipt_upload.merchant_resolution.resolver import parse_locality
+
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        ("E. VEGAS, NV", "VEGAS, NV"),  # period directional stripped
+        ("Henderson, NV", "Henderson, NV"),  # comma form
+        ("Henderson NV 89014-2132", "Henderson, NV"),  # zip form
+        ("Las Vegas, NV 89169", "Las Vegas, NV"),  # 2-word city
+        ("North Las Vegas, NV 89030", "North Las Vegas, NV"),  # 3-word city
+        # A period-less directional is part of the city name and must be kept,
+        # so "N Las Vegas" is never collapsed into "Las Vegas" (a different city).
+        ("N Las Vegas, NV", "N Las Vegas, NV"),
+        # Street + city on one OCR line: the street is trimmed off, city kept.
+        ("4600 E. SUNSET RD Henderson, NV", "Henderson, NV"),
+        ("2718 N Green Valley Pkwy Henderson, NV", "Henderson, NV"),
+    ],
+)
+def test_parse_locality_extracts_city_state(text, expected):
+    assert parse_locality(text) == expected
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "4600 E. SUNSET RD",  # street only, no city/state
+        "US DEBIT ************1454",  # 'US' is not a state in this context
+        "or visit CVs.co/extracare",  # 'or' must not read as Oregon
+        "2716 North Green Valley parkway",  # no state token
+        "",
+    ],
+)
+def test_parse_locality_ignores_non_localities(text):
+    assert parse_locality(text) is None

--- a/receipt_upload/tests/test_resolver_locality.py
+++ b/receipt_upload/tests/test_resolver_locality.py
@@ -7,7 +7,11 @@ locality from real receipt lines while ignoring incidental two-letter tokens.
 
 import pytest
 
-from receipt_upload.merchant_resolution.resolver import parse_locality
+from receipt_upload.merchant_resolution.resolver import (
+    locality_from_lines,
+    parse_locality,
+    state_from_zip,
+)
 
 
 @pytest.mark.parametrize(
@@ -42,3 +46,76 @@ def test_parse_locality_extracts_city_state(text, expected):
 )
 def test_parse_locality_ignores_non_localities(text):
     assert parse_locality(text) is None
+
+
+@pytest.mark.parametrize(
+    "zip5,expected",
+    [
+        ("89014", "NV"),  # Henderson
+        ("89169", "NV"),  # Las Vegas
+        ("02132", "MA"),  # Boston
+        ("75068", "TX"),  # Little Elm
+        ("90001", "CA"),
+        ("00097", None),  # 000 prefix -> not a state
+        ("abcde", None),
+    ],
+)
+def test_state_from_zip(zip5, expected):
+    assert state_from_zip(zip5) == expected
+
+
+def test_locality_from_lines_clean_form():
+    lines = ["TRADER JOE'S", "123 Main St", "Henderson, NV 89014"]
+    assert locality_from_lines(lines) == "Henderson, NV"
+
+
+def test_locality_from_lines_fragmented_zip_pairs_with_prior_city():
+    """Regression for the faint Trader Joe's scan: the state letters were dropped,
+    leaving "Henderson." over a bare "89014". The ZIP supplies the state and the
+    line above supplies the city."""
+    lines = [
+        "TRADER JOE'S",
+        "2716 North Green Valley Parkway",
+        "Henderson.",
+        "89014",
+        "Store #0097 - 702 433-6773",
+    ]
+    assert locality_from_lines(lines) == "Henderson, NV"
+
+
+def test_locality_from_lines_city_on_same_line_as_zip():
+    assert locality_from_lines(["x", "Las Vegas NV 89169"]) == "Las Vegas, NV"
+
+
+def test_locality_from_lines_street_only_prev_line_is_not_a_city():
+    # The line above the ZIP is pure street -> no city is fabricated.
+    assert locality_from_lines(["4600 E Sunset Rd", "89014"]) is None
+
+
+def test_locality_from_lines_none_without_zip_or_state():
+    assert locality_from_lines(["WELCOME", "THANK YOU"]) is None
+
+
+def test_parse_locality_keeps_saint_city():
+    # "St." at the start is part of the city name, not a street suffix.
+    assert parse_locality("St. Louis, MO 63101") == "St. Louis, MO"
+
+
+def test_locality_from_lines_ignores_non_zip_5digit_tokens():
+    # A 5-digit auth/transaction number must not fabricate a state+city.
+    assert locality_from_lines(["AUTH #12345 APPROVED", "Anytown"]) is None
+    assert locality_from_lines(["TOTAL 12345", "Anytown"]) is None
+
+
+@pytest.mark.parametrize(
+    "zip5,expected",
+    [
+        ("05501", "MA"),  # 055xx is MA, not VT
+        ("20101", "VA"),  # 201xx (Dulles) is VA, not DC
+        ("20001", "DC"),
+        ("34002", None),  # 340xx military, not FL
+        ("33901", "FL"),
+    ],
+)
+def test_state_from_zip_exceptions(zip5, expected):
+    assert state_from_zip(zip5) == expected

--- a/receipt_upload/tests/test_resolver_locality.py
+++ b/receipt_upload/tests/test_resolver_locality.py
@@ -8,9 +8,11 @@ locality from real receipt lines while ignoring incidental two-letter tokens.
 import pytest
 
 from receipt_upload.merchant_resolution.resolver import (
+    address_state_conflict,
     locality_from_lines,
     parse_locality,
     state_from_zip,
+    state_of_address,
 )
 
 
@@ -119,3 +121,38 @@ def test_locality_from_lines_ignores_non_zip_5digit_tokens():
 )
 def test_state_from_zip_exceptions(zip5, expected):
     assert state_from_zip(zip5) == expected
+
+
+def test_zip_full_exception_american_samoa():
+    # 96799 is American Samoa, even though 967xx is otherwise Hawaii.
+    assert state_from_zip("96799") == "AS"
+    assert state_from_zip("96701") == "HI"
+
+
+@pytest.mark.parametrize(
+    "addr,expected",
+    [
+        ("1999 Centre St, Boston, MA 02132, USA", "MA"),
+        ("2716 N Green Valley Pkwy, Henderson, NV 89014, USA", "NV"),
+        ("100 N Green Valley Pkwy #345, Henderson, NV 89074", "NV"),
+        ("no state here", None),
+        (None, ""),
+    ],
+)
+def test_state_of_address(addr, expected):
+    # None addr -> None; the "" sentinel below means "expect None"
+    assert state_of_address(addr) == (
+        None if expected in (None, "") else expected
+    )
+
+
+def test_address_state_conflict_only_on_confident_mismatch():
+    # Both known and differ -> conflict.
+    assert address_state_conflict("..., Boston, MA 02132, USA", "NV") is True
+    # Same state -> no conflict.
+    assert (
+        address_state_conflict("..., Henderson, NV 89014, USA", "NV") is False
+    )
+    # Unknown on either side -> never a conflict (conservative).
+    assert address_state_conflict("no parseable state", "NV") is False
+    assert address_state_conflict("..., Boston, MA", None) is False


### PR DESCRIPTION
## Summary

Two receipt-pipeline bugs found while processing the June22 receipts end-to-end on dev, plus the robustness work needed to make the fixes hold under real OCR variance.

### 1. `dedupe_grand_total` could leave a receipt with **no** grand total
When a total is restated several times and every copy is `PENDING`, the dedup kept the *lowest-on-receipt* copy. On the Smith's receipt a **stray** copy of the total value landed lowest (inside a "TOTAL NUMBER OF ITEMS SOLD" footer), so dedup invalidated the good `TOTAL: 9.08` rows and kept the stray, which a downstream validator then invalidated → **zero** grand totals.

**Fix:** elect an *explicit* grand-total row as canonical first — one whose row carries a total keyword (`TOTAL`/`BALANCE`/`DUE`/…) and is **free of count-style disqualifiers** (`NUMBER`/`ITEMS`/`SOLD`/…) — then fall back to lowest-y.

### 2. Merchant resolution picked the **wrong city** for chains
A bare chain text search (`"Trader Joe's"`) returns an arbitrary branch — **Boston MA** for a Henderson NV receipt; **CVS Little Elm TX** for a Las Vegas receipt.

**Fix:**
- the resolver parses the receipt's `City, ST` locality (per-line, street-trimmed) and appends it to the Places text query, and opens the Tier-1 text path for receipts that have a **labeled** merchant name + locality (no phone/address);
- `PlaceIdFinder` **rejects any Places hit whose US state contradicts the receipt's** (passed explicitly via `ReceiptRecord.expected_state`; conservative — only when both states are confidently parsed), falling through to the next strategy;
- **ZIP → state inference** (`state_from_zip` + `locality_from_lines`) so a faint scan that drops the state letters but keeps the ZIP (`"Henderson."` over `"89014"`) still gates by geography. The ZIP fallback only fires on a whole-line ZIP, so transaction/auth numbers can't fabricate a state.

## Testing
- **111 unit tests** pass (`test_dedupe_grand_total`, `test_resolver_locality`, `test_place_id_finder_geo`, plus existing resolver suites); black/isort clean (line-length 79).
- **Reviewed by Codex over three rounds** — every finding addressed (count-row disqualifiers, explicit `expected_state`, eager-Tier-1 gated on a labeled merchant, ZIP-only matching, ZIP range exceptions `055→MA`/`201→VA`/`340→military`, "St. Louis" preserved).

## End-to-end verification on dev
Fresh ingests of all four receipts through the deployed fix:
- ✅ **Trader Joe's → `2716 N Green Valley Pkwy, Henderson, NV`** (was Boston MA) — ZIP inference carried it even though this scan dropped "NV".
- ✅ **Smith's → exactly one VALID `GRAND_TOTAL`** (was zero).
- ✅ Dollar Tree & Smith's → correct Henderson NV places.
- ⚠️ CVS's most degraded scan surfaces no city/ZIP, so it **declines** a location rather than mis-resolving to the wrong state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved merchant and place matching by using receipt locality details (city/state and ZIP-derived state) when available.
  * Added stronger receipt state awareness to reduce mismatched location results.

* **Bug Fixes**
  * Prevented incorrect place matches from other states when a receipt’s expected state is known.
  * Improved duplicate total selection so the most relevant grand total is chosen more reliably.

* **Tests**
  * Added regression coverage for locality parsing, state detection, place matching, and grand total selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->