### PR TITLE
[codex] Add Portfolio remote-control skill

### DIFF
--- a/.claude/skills/portfolio-remote-control/.claude-plugin/plugin.json
+++ b/.claude/skills/portfolio-remote-control/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://anthropic.com/claude-code/plugin.schema.json",
+  "name": "portfolio-remote-control",
+  "version": "0.1.0",
+  "description": "Launch the Portfolio Claude remote-control trio.",
+  "author": {
+    "name": "Tyler Norlund",
+    "email": "tnorlund@icloud.com"
+  },
+  "skills": [
+    "./"
+  ]
+}

--- a/.claude/skills/portfolio-remote-control/SKILL.md
+++ b/.claude/skills/portfolio-remote-control/SKILL.md
@@ -53,7 +53,7 @@ Before reporting success, verify all of the following:
 
 - `ps` shows all three `claude --permission-mode bypassPermissions --remote-control ...` processes with names `merchant-intel`, `font-render`, and `orchestration`.
 - `screen -ls` shows the three target screens: `claude-merchant-intel-rc`, `claude-font-render-rc`, and `claude-orchestration-rc`.
-- Each screen log under `/tmp/claude-remote-screen/<label>/screenlog.0` shows that the session moved past the warning and began work, ideally including `CONTEXT.md`, `CHARTER.md`, or tool-use text.
+- Each screen log under `/tmp/claude-remote-screen/<label>/screenlog.0` shows actual tool use, such as `Reading 1 file`, `Bash(`, `Edit(`, or `TodoWrite`; the echoed mission prompt alone is not success evidence.
 - A `caffeinate -dimsu` process is alive, preferably the skill-managed 24-hour helper recorded under `/tmp/claude-remote-screen/caffeinate.pid`.
 - Tell the user that the three Claude sessions should now appear by name in the Claude app on their phone for remote control.
 

--- a/.claude/skills/portfolio-remote-control/SKILL.md
+++ b/.claude/skills/portfolio-remote-control/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: portfolio-remote-control
+description: Launch and verify the three autonomous Claude Code remote-control sessions for the Portfolio repo. Use when the user asks Codex or Claude to turn on, start, restart, supervise, or verify the Portfolio remote-control trio for merchant intelligence, receipt font rendering, and synthesis orchestration worktrees.
+---
+
+# Portfolio Remote Control
+
+## Purpose
+
+Use this skill to start the three Portfolio Claude Code remote-control sessions and get them past the interactive bypass warning into real autonomous work. The supported sessions are:
+
+| Label | Worktree | Remote-control name |
+| --- | --- | --- |
+| `merchant-intel` | `~/Portfolio/.claude/worktrees/merchant-intel` | `merchant-intel` |
+| `font-render` | `~/Portfolio/.claude/worktrees/font-render` | `font-render` |
+| `orchestration` | `~/Portfolio/.claude/worktrees/orchestration` | `orchestration` |
+
+The mission prompt to send to each session is fixed:
+
+```text
+Read CONTEXT.md then CHARTER.md in this worktree. They hold the full context from the session that set this branch up plus your specific mission. Follow the charter milestones in order and self-review with codex along the way exactly as CONTEXT.md mandates. Begin with milestone 1 now.
+```
+
+## Fast Path
+
+Resolve paths relative to this `SKILL.md`, then run:
+
+```bash
+scripts/portfolio_remote_control.sh launch
+```
+
+This helper:
+
+1. Cleans only the three target Portfolio remote-control sessions.
+2. Starts one detached `screen` session per worktree with `/opt/homebrew/bin/claude --permission-mode bypassPermissions --remote-control <name>`.
+3. Attaches to each `screen` through a real pseudo-terminal, accepts Claude's bypass prompt with `2`, bracket-pastes the mission prompt, submits it with a separate carriage return, and detaches.
+4. Opens Terminal.app attachers for the three screens when a GUI session is available.
+5. Starts a skill-managed durable `caffeinate -dimsu /bin/sleep 86400` if one is not already alive.
+6. Prints process, screen, and log status.
+
+Use these focused commands as needed:
+
+```bash
+scripts/portfolio_remote_control.sh status
+scripts/portfolio_remote_control.sh prime
+scripts/portfolio_remote_control.sh start
+scripts/portfolio_remote_control.sh cleanup
+```
+
+## Verification Contract
+
+Before reporting success, verify all of the following:
+
+- `ps` shows all three `claude --permission-mode bypassPermissions --remote-control ...` processes with names `merchant-intel`, `font-render`, and `orchestration`.
+- `screen -ls` shows the three target screens: `claude-merchant-intel-rc`, `claude-font-render-rc`, and `claude-orchestration-rc`.
+- Each screen log under `/tmp/claude-remote-screen/<label>/screenlog.0` shows that the session moved past the warning and began work, ideally including `CONTEXT.md`, `CHARTER.md`, or tool-use text.
+- A `caffeinate -dimsu` process is alive, preferably the skill-managed 24-hour helper recorded under `/tmp/claude-remote-screen/caffeinate.pid`.
+- Tell the user that the three Claude sessions should now appear by name in the Claude app on their phone for remote control.
+
+## Manual Fallback
+
+If the helper starts the screens but cannot prime one, attach with a real PTY. Do not use `screen -X stuff`; it can fail to deliver input to Claude's TUI on this Mac.
+
+```bash
+TERM=xterm-256color screen -x claude-merchant-intel-rc
+TERM=xterm-256color screen -x claude-font-render-rc
+TERM=xterm-256color screen -x claude-orchestration-rc
+```
+
+Inside each attached screen:
+
+1. If the bypass warning appears, type `2` then Enter. Prefer numeric `2`; Down arrow can select the wrong option in this TUI.
+2. If the fullscreen renderer prompt appears, type `2` then Enter for "Not now".
+3. If a folder trust prompt appears, accept it.
+4. After `/remote-control is active` and the prompt box is ready, bracket-paste the full mission prompt, then send Enter as a separate input.
+5. Detach with Ctrl-A then `d`, leaving the session running.
+
+The separate paste and submit matter. Sending the long prompt plus Enter as one raw write can leave the prompt unsubmitted or drop characters.
+
+## Details
+
+For a fuller runbook and troubleshooting notes, read `references/portfolio-remote-control-runbook.md`.

--- a/.claude/skills/portfolio-remote-control/references/portfolio-remote-control-runbook.md
+++ b/.claude/skills/portfolio-remote-control/references/portfolio-remote-control-runbook.md
@@ -51,3 +51,19 @@ grep -aE 'CONTEXT\.md|CHARTER\.md|Read\(|Bash\(|Edit\(|TodoWrite' /tmp/claude-re
 ```
 
 Successful launch means all three remote-control processes are alive, all three screens exist, the logs show the sessions moved past warnings into work, and the user can see `merchant-intel`, `font-render`, and `orchestration` in the Claude mobile app.
+
+## Supervising the cadence
+
+The review-first commit/push cadence must be **supervised**, not just stated. Its
+presence in each worktree's `CONTEXT.md` makes an agent *intend* it; it does not
+enforce it. Run `portfolio_remote_control.sh status` periodically:
+
+- `cadence=DRIFT` for a session means it is hoarding uncommitted WIP (more than
+  `PORTFOLIO_RC_DIRTY_WARN`, default 8, changed files) or sitting on unpushed
+  commits. Re-nudge it to codex-review → commit → push before it accumulates more
+  (a session reached 20 uncommitted files this way).
+- The "Unexpected remote-control sessions" block lists any remote-control claude
+  sessions that are not the trio — close strays so they don't compete for
+  resources or confuse status.
+- `check_push_auth` runs at launch; if it warns, fix gh/remote on the mini before
+  the agents try to push, or their work strands locally on the box.

--- a/.claude/skills/portfolio-remote-control/references/portfolio-remote-control-runbook.md
+++ b/.claude/skills/portfolio-remote-control/references/portfolio-remote-control-runbook.md
@@ -47,10 +47,10 @@ The durable path is:
 ps axww -o pid= -o command= | grep '[c]laude .*--remote-control'
 screen -ls
 pgrep -fl 'caffeinate.*-dimsu'
-grep -aE 'CONTEXT\.md|CHARTER\.md|Read\(|Bash\(|Edit\(|TodoWrite' /tmp/claude-remote-screen/*/screenlog.0
+scripts/portfolio_remote_control.sh status
 ```
 
-Successful launch means all three remote-control processes are alive, all three screens exist, the logs show the sessions moved past warnings into work, and the user can see `merchant-intel`, `font-render`, and `orchestration` in the Claude mobile app.
+Successful launch means all three remote-control processes are alive, all three screens exist, `status` reports `log_evidence=1` from normalized tool-use text after the mission prompt was submitted, and the user can see `merchant-intel`, `font-render`, and `orchestration` in the Claude mobile app.
 
 ## Supervising the cadence
 

--- a/.claude/skills/portfolio-remote-control/references/portfolio-remote-control-runbook.md
+++ b/.claude/skills/portfolio-remote-control/references/portfolio-remote-control-runbook.md
@@ -1,0 +1,53 @@
+# Portfolio Remote Control Runbook
+
+## Target Sessions
+
+Use this exact mapping unless the user gives an explicit replacement:
+
+| Label | Worktree | Branch | Remote name | Screen name |
+| --- | --- | --- | --- | --- |
+| `merchant-intel` | `~/Portfolio/.claude/worktrees/merchant-intel` | `feat/merchant-intelligence-agents` | `merchant-intel` | `claude-merchant-intel-rc` |
+| `font-render` | `~/Portfolio/.claude/worktrees/font-render` | `feat/receipt-font-render` | `font-render` | `claude-font-render-rc` |
+| `orchestration` | `~/Portfolio/.claude/worktrees/orchestration` | `feat/synthesis-orchestration` | `orchestration` | `claude-orchestration-rc` |
+
+Each worktree should contain committed `CONTEXT.md` and `CHARTER.md` files. The remote Claude sessions should read those files before doing implementation work.
+
+## Reliable Startup Sequence
+
+The durable path is:
+
+1. Clean only the target Portfolio sessions:
+   - Quit target `screen` sessions.
+   - Kill only Claude processes whose command line includes one of the three target remote-control names.
+   - Run `screen -wipe`.
+2. Start each Claude inside a detached `screen -L -dmS ...` from `/tmp/claude-remote-screen/<label>`.
+3. Attach with a real PTY using `TERM=xterm-256color screen -x <screen-name>`.
+4. Respond to prompts:
+   - Bypass permissions warning: send `2` then Enter.
+   - Fullscreen renderer prompt: send `2` then Enter.
+   - Folder trust prompt: accept.
+5. Wait for the prompt box after `/remote-control is active`.
+6. Send bracketed paste: `ESC [ 200 ~`, mission prompt, `ESC [ 201 ~`.
+7. Send Enter as a separate write.
+8. Wait for signs of work, then detach with Ctrl-A then `d`.
+9. Open Terminal.app attachers so the user has visible GUI Terminal windows/tabs.
+10. Start a skill-managed `caffeinate -dimsu /bin/sleep 86400` unless the skill's PID file already points to a live keep-awake process.
+
+## Known Pitfalls
+
+- Avoid `screen -X stuff` for Claude TUI input. It can appear to send keys but not actually reach the prompt correctly on this Mac's old `screen`.
+- Avoid Down-arrow plus Enter for the bypass warning. Numeric `2` is more reliable.
+- Avoid writing the long mission prompt and Enter in one operation. Use bracketed paste first, then Enter.
+- Avoid broad `pkill -f 'claude.*remote-control'` unless the user explicitly wants every remote-control session killed. This machine may have unrelated remote-control sessions.
+- Old macOS `screen` does not support `-Logfile`; use `screen -L` and expect `screenlog.0` in the screen's working directory.
+
+## Verification Commands
+
+```bash
+ps axww -o pid= -o command= | grep '[c]laude .*--remote-control'
+screen -ls
+pgrep -fl 'caffeinate.*-dimsu'
+grep -aE 'CONTEXT\.md|CHARTER\.md|Read\(|Bash\(|Edit\(|TodoWrite' /tmp/claude-remote-screen/*/screenlog.0
+```
+
+Successful launch means all three remote-control processes are alive, all three screens exist, the logs show the sessions moved past warnings into work, and the user can see `merchant-intel`, `font-render`, and `orchestration` in the Claude mobile app.

--- a/.claude/skills/portfolio-remote-control/scripts/portfolio_remote_control.sh
+++ b/.claude/skills/portfolio-remote-control/scripts/portfolio_remote_control.sh
@@ -10,6 +10,7 @@ CAFFEINATE_PID_FILE="$BASE_DIR/caffeinate.pid"
 PRIME_TIMEOUT="${PORTFOLIO_RC_PRIME_TIMEOUT:-180}"
 CAFFEINATE_SECONDS="${PORTFOLIO_RC_CAFFEINATE_SECONDS:-86400}"
 DIRTY_WARN="${PORTFOLIO_RC_DIRTY_WARN:-8}"
+LOG_EVIDENCE_PATTERN='Read\(|Bash\(|Edit\(|MultiEdit\(|Write\(|TodoWrite|Grep\(|Glob\(|LS\(|Reading\s*[0-9]+\s*files?'
 
 MISSION_PROMPT="${PORTFOLIO_RC_MISSION:-Read CONTEXT.md then CHARTER.md in this worktree. They hold the full context from the session that set this branch up plus your specific mission. Follow the charter milestones in order and self-review with codex along the way exactly as CONTEXT.md mandates. Begin with milestone 1 now.}"
 
@@ -192,6 +193,26 @@ prime_screens() {
   return "$failed"
 }
 
+log_has_evidence() {
+  local log_file="$1"
+  python3 - "$log_file" "$LOG_EVIDENCE_PATTERN" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+pattern = sys.argv[2]
+data = path.read_bytes()
+data = re.sub(
+    rb"\x1b\[[0-9;?]*[ -/]*[@-~]|\x1b\][^\x07]*(?:\x07|\x1b\\)|\x1b[@-_]",
+    b"",
+    data,
+)
+text = data.replace(b"\x00", b"").decode("utf-8", errors="ignore")
+raise SystemExit(0 if re.search(pattern, text) else 1)
+PY
+}
+
 ensure_caffeinate() {
   if [[ -s "$CAFFEINATE_PID_FILE" ]]; then
     local existing_pid
@@ -289,7 +310,7 @@ status() {
       missing=1
     fi
 
-    if [[ -f "$log_file" ]] && grep -aE 'CONTEXT\.md|CHARTER\.md|Read\(|Bash\(|Edit\(|TodoWrite' "$log_file" >/dev/null 2>&1; then
+    if [[ -f "$log_file" ]] && log_has_evidence "$log_file"; then
       log_ok=1
     else
       missing=1

--- a/.claude/skills/portfolio-remote-control/scripts/portfolio_remote_control.sh
+++ b/.claude/skills/portfolio-remote-control/scripts/portfolio_remote_control.sh
@@ -1,0 +1,249 @@
+#!/bin/bash
+set -euo pipefail
+
+SKILL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CLAUDE_BIN="${CLAUDE_BIN:-/opt/homebrew/bin/claude}"
+PORTFOLIO_ROOT="${PORTFOLIO_ROOT:-$HOME/Portfolio}"
+BASE_DIR="${PORTFOLIO_RC_BASE:-/tmp/claude-remote-screen}"
+ATTACH_DIR="$BASE_DIR/attachers"
+CAFFEINATE_PID_FILE="$BASE_DIR/caffeinate.pid"
+PRIME_TIMEOUT="${PORTFOLIO_RC_PRIME_TIMEOUT:-180}"
+CAFFEINATE_SECONDS="${PORTFOLIO_RC_CAFFEINATE_SECONDS:-86400}"
+
+MISSION_PROMPT="${PORTFOLIO_RC_MISSION:-Read CONTEXT.md then CHARTER.md in this worktree. They hold the full context from the session that set this branch up plus your specific mission. Follow the charter milestones in order and self-review with codex along the way exactly as CONTEXT.md mandates. Begin with milestone 1 now.}"
+
+usage() {
+  cat <<'EOF'
+Usage: portfolio_remote_control.sh <command>
+
+Commands:
+  launch   Clean target sessions, start screens, prime Claude, open Terminal attachers, caffeinate, verify.
+  start    Clean target sessions and start screens/Terminal attachers without typing into Claude.
+  prime    Attach to existing target screens through a PTY and send the startup prompt.
+  status   Show processes, screens, log evidence, and caffeinate status.
+  verify   Alias for status.
+  cleanup  Stop only the three Portfolio remote-control Claude/screen sessions.
+
+Environment:
+  CLAUDE_BIN                         Path to claude binary. Default: /opt/homebrew/bin/claude
+  PORTFOLIO_ROOT                     Portfolio checkout root. Default: $HOME/Portfolio
+  PORTFOLIO_RC_OPEN_TERMINAL=0       Skip opening Terminal.app attachers.
+  PORTFOLIO_RC_PRIME_TIMEOUT=180     Seconds to wait while priming each screen.
+  PORTFOLIO_RC_CAFFEINATE_SECONDS    Duration for the caffeinate sleep helper. Default: 86400
+EOF
+}
+
+entries() {
+  cat <<EOF
+merchant-intel|$PORTFOLIO_ROOT/.claude/worktrees/merchant-intel|merchant-intel|claude-merchant-intel-rc
+font-render|$PORTFOLIO_ROOT/.claude/worktrees/font-render|font-render|claude-font-render-rc
+orchestration|$PORTFOLIO_ROOT/.claude/worktrees/orchestration|orchestration|claude-orchestration-rc
+EOF
+}
+
+quote_arg() {
+  printf "%q" "$1"
+}
+
+require_prereqs() {
+  if [[ ! -x "$CLAUDE_BIN" ]]; then
+    echo "Missing executable Claude binary: $CLAUDE_BIN" >&2
+    return 1
+  fi
+  if [[ ! -x /usr/bin/screen ]]; then
+    echo "Missing /usr/bin/screen" >&2
+    return 1
+  fi
+  while IFS='|' read -r label worktree session_name screen_name; do
+    if [[ ! -d "$worktree" ]]; then
+      echo "Missing worktree for $label: $worktree" >&2
+      return 1
+    fi
+    if [[ ! -f "$worktree/CONTEXT.md" || ! -f "$worktree/CHARTER.md" ]]; then
+      echo "Missing CONTEXT.md or CHARTER.md in $worktree" >&2
+      return 1
+    fi
+  done < <(entries)
+}
+
+cleanup_targets() {
+  echo "Stopping target Portfolio remote-control sessions..."
+  while IFS='|' read -r label worktree session_name screen_name; do
+    /usr/bin/screen -S "$screen_name" -X quit >/dev/null 2>&1 || true
+    pkill -9 -f "claude.*--remote-control[[:space:]]+$session_name" >/dev/null 2>&1 || true
+    pkill -9 -f "claude.*remote-control.*$session_name" >/dev/null 2>&1 || true
+  done < <(entries)
+  /usr/bin/screen -wipe >/dev/null 2>&1 || true
+}
+
+write_attacher() {
+  local label="$1"
+  local screen_name="$2"
+  local file="$ATTACH_DIR/$label.command"
+
+  mkdir -p "$ATTACH_DIR"
+  cat >"$file" <<EOF
+#!/bin/zsh
+export TERM=xterm-256color
+exec /usr/bin/screen -x $screen_name
+EOF
+  chmod +x "$file"
+}
+
+start_screens() {
+  require_prereqs
+  mkdir -p "$BASE_DIR" "$ATTACH_DIR"
+
+  while IFS='|' read -r label worktree session_name screen_name; do
+    local workdir="$BASE_DIR/$label"
+    mkdir -p "$workdir"
+    rm -f "$workdir/screenlog.0"
+    write_attacher "$label" "$screen_name"
+
+    echo "Starting $label in $screen_name..."
+    (
+      cd "$workdir"
+      /usr/bin/screen -L -dmS "$screen_name" /bin/bash -lc \
+        "cd $(quote_arg "$worktree") && exec $(quote_arg "$CLAUDE_BIN") --permission-mode bypassPermissions --remote-control $(quote_arg "$session_name")"
+    )
+    sleep 1
+  done < <(entries)
+}
+
+open_attachers() {
+  if [[ "${PORTFOLIO_RC_OPEN_TERMINAL:-1}" == "0" ]]; then
+    return 0
+  fi
+  if [[ ! -x /usr/bin/open ]]; then
+    return 0
+  fi
+
+  while IFS='|' read -r label worktree session_name screen_name; do
+    local file="$ATTACH_DIR/$label.command"
+    if [[ -x "$file" ]]; then
+      /usr/bin/open -a Terminal "$file" >/dev/null 2>&1 || true
+    fi
+  done < <(entries)
+}
+
+prime_screens() {
+  local failed=0
+  local primer="$SKILL_DIR/scripts/prime_claude_screen.py"
+
+  if [[ ! -f "$primer" ]]; then
+    echo "Missing primer script: $primer" >&2
+    return 1
+  fi
+
+  while IFS='|' read -r label worktree session_name screen_name; do
+    echo "Priming $label..."
+    if ! PORTFOLIO_RC_MISSION="$MISSION_PROMPT" python3 "$primer" --screen "$screen_name" --label "$label" --timeout "$PRIME_TIMEOUT"; then
+      echo "Prime failed for $label; attach manually with: TERM=xterm-256color screen -x $screen_name" >&2
+      failed=1
+    fi
+  done < <(entries)
+
+  return "$failed"
+}
+
+ensure_caffeinate() {
+  if [[ -s "$CAFFEINATE_PID_FILE" ]]; then
+    local existing_pid
+    existing_pid="$(cat "$CAFFEINATE_PID_FILE" 2>/dev/null || true)"
+    if [[ "$existing_pid" =~ ^[0-9]+$ ]] && kill -0 "$existing_pid" >/dev/null 2>&1; then
+      echo "Skill-managed caffeinate is already running as PID $existing_pid."
+      return 0
+    fi
+  fi
+
+  mkdir -p "$BASE_DIR"
+  echo "Starting caffeinate for $CAFFEINATE_SECONDS seconds..."
+  nohup /usr/bin/caffeinate -dimsu /bin/sleep "$CAFFEINATE_SECONDS" >"$BASE_DIR/caffeinate.log" 2>&1 &
+  echo "$!" >"$CAFFEINATE_PID_FILE"
+}
+
+status() {
+  local missing=0
+  local screen_listing
+  screen_listing="$(/usr/bin/screen -ls 2>/dev/null || true)"
+
+  echo
+  echo "Claude remote-control processes:"
+  ps axww -o pid= -o command= | grep '[c]laude .*--remote-control' || true
+
+  echo
+  echo "Target screen sessions:"
+  printf "%s\n" "$screen_listing" | grep -E 'claude-(merchant-intel|font-render|orchestration)-rc' || true
+
+  echo
+  while IFS='|' read -r label worktree session_name screen_name; do
+    local process_ok=0
+    local screen_ok=0
+    local log_ok=0
+    local log_file="$BASE_DIR/$label/screenlog.0"
+
+    if ps axww -o command= | grep '[c]laude .*--remote-control' | grep -F -- "--remote-control $session_name" >/dev/null 2>&1; then
+      process_ok=1
+    else
+      missing=1
+    fi
+
+    if printf "%s\n" "$screen_listing" | grep -E "[0-9]+\\.$screen_name[[:space:]]" >/dev/null 2>&1; then
+      screen_ok=1
+    else
+      missing=1
+    fi
+
+    if [[ -f "$log_file" ]] && grep -aE 'CONTEXT\.md|CHARTER\.md|Read\(|Bash\(|Edit\(|TodoWrite|remote-control is active' "$log_file" >/dev/null 2>&1; then
+      log_ok=1
+    fi
+
+    printf "%-16s process=%s screen=%s log_evidence=%s log=%s\n" \
+      "$label" "$process_ok" "$screen_ok" "$log_ok" "$log_file"
+  done < <(entries)
+
+  echo
+  echo "Caffeinate:"
+  pgrep -fl "caffeinate.*-dimsu" || true
+
+  return "$missing"
+}
+
+command="${1:-launch}"
+case "$command" in
+  launch)
+    cleanup_targets
+    start_screens
+    sleep 2
+    prime_failed=0
+    prime_screens || prime_failed=1
+    ensure_caffeinate
+    open_attachers
+    status || true
+    exit "$prime_failed"
+    ;;
+  start)
+    cleanup_targets
+    start_screens
+    ensure_caffeinate
+    open_attachers
+    status || true
+    ;;
+  prime)
+    prime_screens
+    status || true
+    ;;
+  status|verify)
+    status
+    ;;
+  cleanup)
+    cleanup_targets
+    ;;
+  -h|--help|help)
+    usage
+    ;;
+  *)
+    usage >&2
+    exit 2
+    ;;
+esac

--- a/.claude/skills/portfolio-remote-control/scripts/portfolio_remote_control.sh
+++ b/.claude/skills/portfolio-remote-control/scripts/portfolio_remote_control.sh
@@ -47,50 +47,86 @@ quote_arg() {
   printf "%q" "$1"
 }
 
-remote_control_pids() {
-  local session_name="$1"
-  ps axww -o pid= -o command= | awk -v target="$session_name" '
+canonical_dir() {
+  cd "$1" 2>/dev/null && pwd -P
+}
+
+process_cwd() {
+  local pid="$1"
+  /usr/sbin/lsof -a -p "$pid" -d cwd -Fn 2>/dev/null | awk '
+    /^n/ {
+      print substr($0, 2)
+      exit
+    }
+  '
+}
+
+process_cwd_matches() {
+  local pid="$1"
+  local expected_dir="$2"
+  local expected actual
+
+  expected="$(canonical_dir "$expected_dir" || true)"
+  actual="$(process_cwd "$pid")"
+  [[ -n "$expected" && -n "$actual" && "$actual" == "$expected" ]]
+}
+
+remote_control_candidates() {
+  ps axww -o pid= -o command= | awk '
     function strip_quotes(value) {
       gsub(/^[\"\047]+|[\"\047]+$/, "", value)
       return value
+    }
+    function print_candidate(value) {
+      value = strip_quotes(value)
+      if (value != "") {
+        print pid "|" value
+      }
     }
     {
       pid = $1
       executable = strip_quotes($2)
       sub(/^.*\//, "", executable)
-      if (executable != "claude") {
+      if (executable == "SCREEN" || executable == "screen" || executable == "login" || executable == "awk") {
         next
       }
       for (i = 3; i <= NF; i++) {
         arg = strip_quotes($i)
         if (arg == "--remote-control" && i < NF) {
-          value = strip_quotes($(i + 1))
-          if (value == target) {
-            print pid
-            next
-          }
+          print_candidate($(i + 1))
+          next
         }
         if (arg ~ /^--remote-control=/) {
-          value = strip_quotes(substr(arg, 18))
-          if (value == target) {
-            print pid
-            next
-          }
+          print_candidate(substr(arg, 18))
+          next
         }
       }
     }
   '
 }
 
+remote_control_pids() {
+  local session_name="$1"
+  local worktree="$2"
+  local pid found_session
+
+  while IFS='|' read -r pid found_session; do
+    if [[ "$found_session" == "$session_name" ]] && process_cwd_matches "$pid" "$worktree"; then
+      printf "%s\n" "$pid"
+    fi
+  done < <(remote_control_candidates)
+}
+
 kill_remote_control_processes() {
   local session_name="$1"
+  local worktree="$2"
   local pid
 
   while IFS= read -r pid; do
     if [[ "$pid" =~ ^[0-9]+$ ]]; then
       kill -9 "$pid" >/dev/null 2>&1 || true
     fi
-  done < <(remote_control_pids "$session_name")
+  done < <(remote_control_pids "$session_name" "$worktree")
 }
 
 require_prereqs() {
@@ -118,7 +154,7 @@ cleanup_targets() {
   echo "Stopping target Portfolio remote-control sessions..."
   while IFS='|' read -r label worktree session_name screen_name; do
     /usr/bin/screen -S "$screen_name" -X quit >/dev/null 2>&1 || true
-    kill_remote_control_processes "$session_name"
+    kill_remote_control_processes "$session_name" "$worktree"
   done < <(entries)
   /usr/bin/screen -wipe >/dev/null 2>&1 || true
 }
@@ -213,69 +249,112 @@ raise SystemExit(0 if re.search(pattern, text) else 1)
 PY
 }
 
+caffeinate_pid_is_managed() {
+  local pid="$1"
+  local command
+
+  command="$(ps -p "$pid" -o command= 2>/dev/null || true)"
+  [[ "$command" == *caffeinate* && "$command" == *-dimsu* ]]
+}
+
 ensure_caffeinate() {
   if [[ -s "$CAFFEINATE_PID_FILE" ]]; then
     local existing_pid
     existing_pid="$(cat "$CAFFEINATE_PID_FILE" 2>/dev/null || true)"
-    if [[ "$existing_pid" =~ ^[0-9]+$ ]] && kill -0 "$existing_pid" >/dev/null 2>&1; then
+    if [[ "$existing_pid" =~ ^[0-9]+$ ]] && caffeinate_pid_is_managed "$existing_pid"; then
       echo "Skill-managed caffeinate is already running as PID $existing_pid."
       return 0
     fi
+    rm -f "$CAFFEINATE_PID_FILE"
   fi
 
   mkdir -p "$BASE_DIR"
   echo "Starting caffeinate for $CAFFEINATE_SECONDS seconds..."
-  nohup /usr/bin/caffeinate -dimsu /bin/sleep "$CAFFEINATE_SECONDS" >"$BASE_DIR/caffeinate.log" 2>&1 &
+  nohup /usr/bin/caffeinate -dimsu -t "$CAFFEINATE_SECONDS" >"$BASE_DIR/caffeinate.log" 2>&1 &
   echo "$!" >"$CAFFEINATE_PID_FILE"
 }
 
 # Agents are useless if they cannot push: the mini's gh token expires and origin
 # can be a dead SSH remote. Verify a real authenticated remote op works.
 check_push_auth() {
-  if git -C "$PORTFOLIO_ROOT" ls-remote origin HEAD >/dev/null 2>&1; then
-    return 0
+  local failed=0
+
+  if ! command -v gh >/dev/null 2>&1 || ! gh auth status -h github.com >/dev/null 2>&1; then
+    echo "WARNING: gh is not authenticated for GitHub; agents may not be able to push." >&2
+    failed=1
+  elif ! gh api repos/tnorlund/Portfolio --jq '.permissions.push' 2>/dev/null | grep -q '^true$'; then
+    echo "WARNING: gh token does not report push permission for tnorlund/Portfolio." >&2
+    failed=1
   fi
-  echo "WARNING: cannot reach GitHub origin from $PORTFOLIO_ROOT -- agents will NOT be able to push." >&2
-  echo "  Fix on the mini, then relaunch:" >&2
-  echo "    gh auth status            # if invalid, re-auth (e.g. from a good machine:" >&2
-  echo "    #   gh auth token | ssh <mini> 'gh auth login --with-token')" >&2
-  echo "    gh auth setup-git" >&2
-  echo "    git -C $PORTFOLIO_ROOT remote set-url origin https://github.com/tnorlund/Portfolio.git  # if origin is a dead SSH remote" >&2
-  return 1
+
+  while IFS='|' read -r label worktree session_name screen_name; do
+    local branch
+    branch="$(git -C "$worktree" branch --show-current 2>/dev/null || true)"
+    if [[ -z "$branch" ]] || ! git -C "$worktree" push --dry-run origin "HEAD:refs/heads/$branch" >/dev/null 2>&1; then
+      echo "WARNING: dry-run push failed for $label from $worktree." >&2
+      failed=1
+    fi
+  done < <(entries)
+
+  if [[ "$failed" -ne 0 ]]; then
+    echo "  Fix on the mini, then relaunch:" >&2
+    echo "    gh auth status            # if invalid, re-auth (e.g. from a good machine:" >&2
+    echo "    #   gh auth token | ssh <mini> 'gh auth login --with-token')" >&2
+    echo "    gh auth setup-git" >&2
+    echo "    git -C $PORTFOLIO_ROOT remote set-url origin https://github.com/tnorlund/Portfolio.git  # if origin is a dead SSH remote" >&2
+    return 1
+  fi
+
+  return 0
 }
 
-# Remote-control claude sessions whose name is not one of the expected trio.
+# Remote-control sessions outside the expected trio and worktrees.
 stray_sessions() {
-  ps axww -o command= | awk '
-    function strip_quotes(value) {
-      gsub(/^[\"\047]+|[\"\047]+$/, "", value)
-      return value
-    }
-    function print_if_stray(value) {
-      value = strip_quotes(value)
-      if (value != "merchant-intel" && value != "font-render" && value != "orchestration") {
-        print value
-      }
-    }
+  local pid found_session expected_worktree cwd
+
+  while IFS='|' read -r pid found_session; do
+    expected_worktree=""
+    while IFS='|' read -r label worktree session_name screen_name; do
+      if [[ "$found_session" == "$session_name" ]]; then
+        expected_worktree="$worktree"
+        break
+      fi
+    done < <(entries)
+
+    if [[ -n "$expected_worktree" ]] && process_cwd_matches "$pid" "$expected_worktree"; then
+      continue
+    fi
+
+    cwd="$(process_cwd "$pid")"
+    if [[ -n "$cwd" ]]; then
+      printf "%s pid=%s cwd=%s\n" "$found_session" "$pid" "$cwd"
+    else
+      printf "%s pid=%s\n" "$found_session" "$pid"
+    fi
+  done < <(remote_control_candidates) | sort -u || true
+}
+
+dirty_count() {
+  local worktree="$1"
+  local count
+
+  if count="$(git -C "$worktree" status --porcelain 2>/dev/null | wc -l | tr -d ' ')"; then
+    echo "${count:-0}"
+  else
+    echo 0
+  fi
+}
+
+caffeinate_processes() {
+  ps axww -o pid= -o command= | awk '
     {
-      executable = strip_quotes($1)
+      executable = $2
       sub(/^.*\//, "", executable)
-      if (executable != "claude") {
-        next
-      }
-      for (i = 2; i <= NF; i++) {
-        arg = strip_quotes($i)
-        if (arg == "--remote-control" && i < NF) {
-          print_if_stray($(i + 1))
-          next
-        }
-        if (arg ~ /^--remote-control=/) {
-          print_if_stray(substr(arg, 18))
-          next
-        }
+      if (executable == "caffeinate" && $0 ~ /-dimsu/) {
+        print
       }
     }
-  ' | sort -u || true
+  '
 }
 
 status() {
@@ -298,7 +377,7 @@ status() {
     local log_ok=0
     local log_file="$BASE_DIR/$label/screenlog.0"
 
-    if remote_control_pids "$session_name" | grep -q .; then
+    if remote_control_pids "$session_name" "$worktree" | grep -q .; then
       process_ok=1
     else
       missing=1
@@ -317,7 +396,7 @@ status() {
     fi
 
     local dirty unpushed cadence
-    dirty="$(git -C "$worktree" status --porcelain 2>/dev/null | wc -l | tr -d ' ' || echo 0)"
+    dirty="$(dirty_count "$worktree")"
     unpushed="$(git -C "$worktree" rev-list --count '@{u}..HEAD' 2>/dev/null || echo 0)"
     cadence=ok
     if [[ "${dirty:-0}" -gt "$DIRTY_WARN" || "${unpushed:-0}" -gt 0 ]]; then
@@ -332,7 +411,7 @@ status() {
   echo "Unexpected remote-control sessions:"
   local strays; strays="$(stray_sessions)"
   if [[ -n "$strays" ]]; then
-    printf "  %s\n" "$strays"
+    printf "%s\n" "$strays" | sed 's/^/  /'
     echo "  (not part of the trio -- close with: screen -S <name> -X quit, or kill the claude pid)"
   else
     echo "  none"
@@ -340,7 +419,10 @@ status() {
 
   echo
   echo "Caffeinate:"
-  if ! pgrep -fl "caffeinate.*-dimsu"; then
+  local caffeinate_lines; caffeinate_lines="$(caffeinate_processes)"
+  if [[ -n "$caffeinate_lines" ]]; then
+    printf "%s\n" "$caffeinate_lines"
+  else
     missing=1
   fi
 

--- a/.claude/skills/portfolio-remote-control/scripts/portfolio_remote_control.sh
+++ b/.claude/skills/portfolio-remote-control/scripts/portfolio_remote_control.sh
@@ -45,6 +45,52 @@ quote_arg() {
   printf "%q" "$1"
 }
 
+remote_control_pids() {
+  local session_name="$1"
+  ps axww -o pid= -o command= | awk -v target="$session_name" '
+    function strip_quotes(value) {
+      gsub(/^[\"\047]+|[\"\047]+$/, "", value)
+      return value
+    }
+    {
+      pid = $1
+      executable = strip_quotes($2)
+      sub(/^.*\//, "", executable)
+      if (executable != "claude") {
+        next
+      }
+      for (i = 3; i <= NF; i++) {
+        arg = strip_quotes($i)
+        if (arg == "--remote-control" && i < NF) {
+          value = strip_quotes($(i + 1))
+          if (value == target) {
+            print pid
+            next
+          }
+        }
+        if (arg ~ /^--remote-control=/) {
+          value = strip_quotes(substr(arg, 18))
+          if (value == target) {
+            print pid
+            next
+          }
+        }
+      }
+    }
+  '
+}
+
+kill_remote_control_processes() {
+  local session_name="$1"
+  local pid
+
+  while IFS= read -r pid; do
+    if [[ "$pid" =~ ^[0-9]+$ ]]; then
+      kill -9 "$pid" >/dev/null 2>&1 || true
+    fi
+  done < <(remote_control_pids "$session_name")
+}
+
 require_prereqs() {
   if [[ ! -x "$CLAUDE_BIN" ]]; then
     echo "Missing executable Claude binary: $CLAUDE_BIN" >&2
@@ -70,8 +116,7 @@ cleanup_targets() {
   echo "Stopping target Portfolio remote-control sessions..."
   while IFS='|' read -r label worktree session_name screen_name; do
     /usr/bin/screen -S "$screen_name" -X quit >/dev/null 2>&1 || true
-    pkill -9 -f "claude.*--remote-control[[:space:]]+$session_name" >/dev/null 2>&1 || true
-    pkill -9 -f "claude.*remote-control.*$session_name" >/dev/null 2>&1 || true
+    kill_remote_control_processes "$session_name"
   done < <(entries)
   /usr/bin/screen -wipe >/dev/null 2>&1 || true
 }
@@ -182,7 +227,7 @@ status() {
     local log_ok=0
     local log_file="$BASE_DIR/$label/screenlog.0"
 
-    if ps axww -o command= | grep '[c]laude .*--remote-control' | grep -F -- "--remote-control $session_name" >/dev/null 2>&1; then
+    if remote_control_pids "$session_name" | grep -q .; then
       process_ok=1
     else
       missing=1
@@ -194,8 +239,10 @@ status() {
       missing=1
     fi
 
-    if [[ -f "$log_file" ]] && grep -aE 'CONTEXT\.md|CHARTER\.md|Read\(|Bash\(|Edit\(|TodoWrite|remote-control is active' "$log_file" >/dev/null 2>&1; then
+    if [[ -f "$log_file" ]] && grep -aE 'CONTEXT\.md|CHARTER\.md|Read\(|Bash\(|Edit\(|TodoWrite' "$log_file" >/dev/null 2>&1; then
       log_ok=1
+    else
+      missing=1
     fi
 
     printf "%-16s process=%s screen=%s log_evidence=%s log=%s\n" \
@@ -204,7 +251,9 @@ status() {
 
   echo
   echo "Caffeinate:"
-  pgrep -fl "caffeinate.*-dimsu" || true
+  if ! pgrep -fl "caffeinate.*-dimsu"; then
+    missing=1
+  fi
 
   return "$missing"
 }
@@ -219,8 +268,11 @@ case "$command" in
     prime_screens || prime_failed=1
     ensure_caffeinate
     open_attachers
-    status || true
-    exit "$prime_failed"
+    status_failed=0
+    status || status_failed=1
+    if [[ "$prime_failed" -ne 0 || "$status_failed" -ne 0 ]]; then
+      exit 1
+    fi
     ;;
   start)
     cleanup_targets

--- a/.claude/skills/portfolio-remote-control/scripts/portfolio_remote_control.sh
+++ b/.claude/skills/portfolio-remote-control/scripts/portfolio_remote_control.sh
@@ -225,11 +225,36 @@ check_push_auth() {
 
 # Remote-control claude sessions whose name is not one of the expected trio.
 stray_sessions() {
-  ps axww -o command= \
-    | grep '[c]laude .*--remote-control' \
-    | sed -E 's/.*--remote-control[= ]+([A-Za-z0-9_-]+).*/\1/' \
-    | grep -vxE 'merchant-intel|font-render|orchestration' \
-    | sort -u || true
+  ps axww -o command= | awk '
+    function strip_quotes(value) {
+      gsub(/^[\"\047]+|[\"\047]+$/, "", value)
+      return value
+    }
+    function print_if_stray(value) {
+      value = strip_quotes(value)
+      if (value != "merchant-intel" && value != "font-render" && value != "orchestration") {
+        print value
+      }
+    }
+    {
+      executable = strip_quotes($1)
+      sub(/^.*\//, "", executable)
+      if (executable != "claude") {
+        next
+      }
+      for (i = 2; i <= NF; i++) {
+        arg = strip_quotes($i)
+        if (arg == "--remote-control" && i < NF) {
+          print_if_stray($(i + 1))
+          next
+        }
+        if (arg ~ /^--remote-control=/) {
+          print_if_stray(substr(arg, 18))
+          next
+        }
+      }
+    }
+  ' | sort -u || true
 }
 
 status() {

--- a/.claude/skills/portfolio-remote-control/scripts/portfolio_remote_control.sh
+++ b/.claude/skills/portfolio-remote-control/scripts/portfolio_remote_control.sh
@@ -9,6 +9,7 @@ ATTACH_DIR="$BASE_DIR/attachers"
 CAFFEINATE_PID_FILE="$BASE_DIR/caffeinate.pid"
 PRIME_TIMEOUT="${PORTFOLIO_RC_PRIME_TIMEOUT:-180}"
 CAFFEINATE_SECONDS="${PORTFOLIO_RC_CAFFEINATE_SECONDS:-86400}"
+DIRTY_WARN="${PORTFOLIO_RC_DIRTY_WARN:-8}"
 
 MISSION_PROMPT="${PORTFOLIO_RC_MISSION:-Read CONTEXT.md then CHARTER.md in this worktree. They hold the full context from the session that set this branch up plus your specific mission. Follow the charter milestones in order and self-review with codex along the way exactly as CONTEXT.md mandates. Begin with milestone 1 now.}"
 
@@ -207,6 +208,30 @@ ensure_caffeinate() {
   echo "$!" >"$CAFFEINATE_PID_FILE"
 }
 
+# Agents are useless if they cannot push: the mini's gh token expires and origin
+# can be a dead SSH remote. Verify a real authenticated remote op works.
+check_push_auth() {
+  if git -C "$PORTFOLIO_ROOT" ls-remote origin HEAD >/dev/null 2>&1; then
+    return 0
+  fi
+  echo "WARNING: cannot reach GitHub origin from $PORTFOLIO_ROOT -- agents will NOT be able to push." >&2
+  echo "  Fix on the mini, then relaunch:" >&2
+  echo "    gh auth status            # if invalid, re-auth (e.g. from a good machine:" >&2
+  echo "    #   gh auth token | ssh <mini> 'gh auth login --with-token')" >&2
+  echo "    gh auth setup-git" >&2
+  echo "    git -C $PORTFOLIO_ROOT remote set-url origin https://github.com/tnorlund/Portfolio.git  # if origin is a dead SSH remote" >&2
+  return 1
+}
+
+# Remote-control claude sessions whose name is not one of the expected trio.
+stray_sessions() {
+  ps axww -o command= \
+    | grep '[c]laude .*--remote-control' \
+    | sed -E 's/.*--remote-control[= ]+([A-Za-z0-9_-]+).*/\1/' \
+    | grep -vxE 'merchant-intel|font-render|orchestration' \
+    | sort -u || true
+}
+
 status() {
   local missing=0
   local screen_listing
@@ -245,9 +270,27 @@ status() {
       missing=1
     fi
 
-    printf "%-16s process=%s screen=%s log_evidence=%s log=%s\n" \
-      "$label" "$process_ok" "$screen_ok" "$log_ok" "$log_file"
+    local dirty unpushed cadence
+    dirty="$(git -C "$worktree" status --porcelain 2>/dev/null | wc -l | tr -d ' ' || echo 0)"
+    unpushed="$(git -C "$worktree" rev-list --count '@{u}..HEAD' 2>/dev/null || echo 0)"
+    cadence=ok
+    if [[ "${dirty:-0}" -gt "$DIRTY_WARN" || "${unpushed:-0}" -gt 0 ]]; then
+      cadence=DRIFT
+    fi
+
+    printf "%-16s process=%s screen=%s log_evidence=%s dirty=%s unpushed=%s cadence=%s log=%s\n" \
+      "$label" "$process_ok" "$screen_ok" "$log_ok" "$dirty" "$unpushed" "$cadence" "$log_file"
   done < <(entries)
+
+  echo
+  echo "Unexpected remote-control sessions:"
+  local strays; strays="$(stray_sessions)"
+  if [[ -n "$strays" ]]; then
+    printf "  %s\n" "$strays"
+    echo "  (not part of the trio -- close with: screen -S <name> -X quit, or kill the claude pid)"
+  else
+    echo "  none"
+  fi
 
   echo
   echo "Caffeinate:"
@@ -262,6 +305,7 @@ command="${1:-launch}"
 case "$command" in
   launch)
     cleanup_targets
+    check_push_auth || echo "  (continuing launch; fix push auth before the agents try to push)" >&2
     start_screens
     sleep 2
     prime_failed=0

--- a/.claude/skills/portfolio-remote-control/scripts/portfolio_remote_control.sh
+++ b/.claude/skills/portfolio-remote-control/scripts/portfolio_remote_control.sh
@@ -31,15 +31,15 @@ Environment:
   PORTFOLIO_ROOT                     Portfolio checkout root. Default: $HOME/Portfolio
   PORTFOLIO_RC_OPEN_TERMINAL=0       Skip opening Terminal.app attachers.
   PORTFOLIO_RC_PRIME_TIMEOUT=180     Seconds to wait while priming each screen.
-  PORTFOLIO_RC_CAFFEINATE_SECONDS    Duration for the caffeinate sleep helper. Default: 86400
+  PORTFOLIO_RC_CAFFEINATE_SECONDS    Duration for the caffeinate helper. Default: 86400
 EOF
 }
 
 entries() {
   cat <<EOF
-merchant-intel|$PORTFOLIO_ROOT/.claude/worktrees/merchant-intel|merchant-intel|claude-merchant-intel-rc
-font-render|$PORTFOLIO_ROOT/.claude/worktrees/font-render|font-render|claude-font-render-rc
-orchestration|$PORTFOLIO_ROOT/.claude/worktrees/orchestration|orchestration|claude-orchestration-rc
+merchant-intel|$PORTFOLIO_ROOT/.claude/worktrees/merchant-intel|merchant-intel|claude-merchant-intel-rc|feat/merchant-intelligence-agents
+font-render|$PORTFOLIO_ROOT/.claude/worktrees/font-render|font-render|claude-font-render-rc|feat/receipt-font-render
+orchestration|$PORTFOLIO_ROOT/.claude/worktrees/orchestration|orchestration|claude-orchestration-rc|feat/synthesis-orchestration
 EOF
 }
 
@@ -138,7 +138,7 @@ require_prereqs() {
     echo "Missing /usr/bin/screen" >&2
     return 1
   fi
-  while IFS='|' read -r label worktree session_name screen_name; do
+  while IFS='|' read -r label worktree session_name screen_name expected_branch; do
     if [[ ! -d "$worktree" ]]; then
       echo "Missing worktree for $label: $worktree" >&2
       return 1
@@ -147,12 +147,18 @@ require_prereqs() {
       echo "Missing CONTEXT.md or CHARTER.md in $worktree" >&2
       return 1
     fi
+    local branch
+    branch="$(git -C "$worktree" branch --show-current 2>/dev/null || true)"
+    if [[ "$branch" != "$expected_branch" ]]; then
+      echo "Wrong branch for $label: expected $expected_branch, got ${branch:-unknown}" >&2
+      return 1
+    fi
   done < <(entries)
 }
 
 cleanup_targets() {
   echo "Stopping target Portfolio remote-control sessions..."
-  while IFS='|' read -r label worktree session_name screen_name; do
+  while IFS='|' read -r label worktree session_name screen_name expected_branch; do
     /usr/bin/screen -S "$screen_name" -X quit >/dev/null 2>&1 || true
     kill_remote_control_processes "$session_name" "$worktree"
   done < <(entries)
@@ -177,7 +183,7 @@ start_screens() {
   require_prereqs
   mkdir -p "$BASE_DIR" "$ATTACH_DIR"
 
-  while IFS='|' read -r label worktree session_name screen_name; do
+  while IFS='|' read -r label worktree session_name screen_name expected_branch; do
     local workdir="$BASE_DIR/$label"
     mkdir -p "$workdir"
     rm -f "$workdir/screenlog.0"
@@ -201,7 +207,7 @@ open_attachers() {
     return 0
   fi
 
-  while IFS='|' read -r label worktree session_name screen_name; do
+  while IFS='|' read -r label worktree session_name screen_name expected_branch; do
     local file="$ATTACH_DIR/$label.command"
     if [[ -x "$file" ]]; then
       /usr/bin/open -a Terminal "$file" >/dev/null 2>&1 || true
@@ -218,7 +224,7 @@ prime_screens() {
     return 1
   fi
 
-  while IFS='|' read -r label worktree session_name screen_name; do
+  while IFS='|' read -r label worktree session_name screen_name expected_branch; do
     echo "Priming $label..."
     if ! PORTFOLIO_RC_MISSION="$MISSION_PROMPT" python3 "$primer" --screen "$screen_name" --label "$label" --timeout "$PRIME_TIMEOUT"; then
       echo "Prime failed for $label; attach manually with: TERM=xterm-256color screen -x $screen_name" >&2
@@ -287,7 +293,7 @@ check_push_auth() {
     failed=1
   fi
 
-  while IFS='|' read -r label worktree session_name screen_name; do
+  while IFS='|' read -r label worktree session_name screen_name expected_branch; do
     local branch
     branch="$(git -C "$worktree" branch --show-current 2>/dev/null || true)"
     if [[ -z "$branch" ]] || ! git -C "$worktree" push --dry-run origin "HEAD:refs/heads/$branch" >/dev/null 2>&1; then
@@ -314,7 +320,7 @@ stray_sessions() {
 
   while IFS='|' read -r pid found_session; do
     expected_worktree=""
-    while IFS='|' read -r label worktree session_name screen_name; do
+    while IFS='|' read -r label worktree session_name screen_name expected_branch; do
       if [[ "$found_session" == "$session_name" ]]; then
         expected_worktree="$worktree"
         break
@@ -345,6 +351,17 @@ dirty_count() {
   fi
 }
 
+unpushed_count() {
+  local worktree="$1"
+  local count
+
+  if count="$(git -C "$worktree" rev-list --count '@{u}..HEAD' 2>/dev/null)"; then
+    echo "${count:-0}"
+  else
+    echo unknown
+  fi
+}
+
 caffeinate_processes() {
   ps axww -o pid= -o command= | awk '
     {
@@ -371,7 +388,7 @@ status() {
   printf "%s\n" "$screen_listing" | grep -E 'claude-(merchant-intel|font-render|orchestration)-rc' || true
 
   echo
-  while IFS='|' read -r label worktree session_name screen_name; do
+  while IFS='|' read -r label worktree session_name screen_name expected_branch; do
     local process_ok=0
     local screen_ok=0
     local log_ok=0
@@ -397,9 +414,9 @@ status() {
 
     local dirty unpushed cadence
     dirty="$(dirty_count "$worktree")"
-    unpushed="$(git -C "$worktree" rev-list --count '@{u}..HEAD' 2>/dev/null || echo 0)"
+    unpushed="$(unpushed_count "$worktree")"
     cadence=ok
-    if [[ "${dirty:-0}" -gt "$DIRTY_WARN" || "${unpushed:-0}" -gt 0 ]]; then
+    if [[ "${dirty:-0}" -gt "$DIRTY_WARN" || "$unpushed" == "unknown" || "$unpushed" -gt 0 ]]; then
       cadence=DRIFT
     fi
 
@@ -432,6 +449,7 @@ status() {
 command="${1:-launch}"
 case "$command" in
   launch)
+    require_prereqs
     cleanup_targets
     check_push_auth || echo "  (continuing launch; fix push auth before the agents try to push)" >&2
     start_screens
@@ -447,6 +465,7 @@ case "$command" in
     fi
     ;;
   start)
+    require_prereqs
     cleanup_targets
     start_screens
     ensure_caffeinate

--- a/.claude/skills/portfolio-remote-control/scripts/prime_claude_screen.py
+++ b/.claude/skills/portfolio-remote-control/scripts/prime_claude_screen.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+import argparse
+import fcntl
+import os
+import pty
+import re
+import select
+import signal
+import struct
+import subprocess
+import sys
+import termios
+import time
+
+DEFAULT_MISSION = (
+    "Read CONTEXT.md then CHARTER.md in this worktree. They hold the full context "
+    "from the session that set this branch up plus your specific mission. Follow "
+    "the charter milestones in order and self-review with codex along the way "
+    "exactly as CONTEXT.md mandates. Begin with milestone 1 now."
+)
+
+ANSI_RE = re.compile(
+    rb"\x1b\[[0-9;?]*[ -/]*[@-~]"
+    rb"|\x1b\][^\x07]*(?:\x07|\x1b\\)"
+    rb"|\x1b[@-_]"
+)
+
+
+def strip_control(data: bytes) -> str:
+    data = ANSI_RE.sub(b"", data)
+    data = data.replace(b"\x00", b"")
+    return data.decode("utf-8", errors="ignore")
+
+
+def set_winsize(fd: int, rows: int = 40, cols: int = 140) -> None:
+    size = struct.pack("HHHH", rows, cols, 0, 0)
+    fcntl.ioctl(fd, termios.TIOCSWINSZ, size)
+
+
+def write_all(fd: int, data: bytes) -> None:
+    total = 0
+    while total < len(data):
+        total += os.write(fd, data[total:])
+
+
+def send_line(fd: int, text: str) -> None:
+    write_all(fd, text.encode("utf-8") + b"\r")
+
+
+def send_mission(fd: int, mission: str) -> None:
+    payload = b"\x1b[200~" + mission.encode("utf-8") + b"\x1b[201~"
+    write_all(fd, payload)
+    time.sleep(0.5)
+    write_all(fd, b"\r")
+
+
+def attach_and_prime(screen_name: str, label: str, mission: str, timeout: float, post_wait: float) -> int:
+    master, slave = pty.openpty()
+    set_winsize(slave)
+
+    env = os.environ.copy()
+    if env.get("TERM", "") in ("", "dumb"):
+        env["TERM"] = "xterm-256color"
+
+    proc = subprocess.Popen(
+        ["/usr/bin/screen", "-x", screen_name],
+        stdin=slave,
+        stdout=slave,
+        stderr=slave,
+        close_fds=True,
+        preexec_fn=os.setsid,
+        env=env,
+    )
+    os.close(slave)
+
+    flags = fcntl.fcntl(master, fcntl.F_GETFL)
+    fcntl.fcntl(master, fcntl.F_SETFL, flags | os.O_NONBLOCK)
+
+    buffer = b""
+    deadline = time.monotonic() + timeout
+    last_action = 0.0
+    sent_bypass = False
+    sent_fullscreen = False
+    sent_trust = False
+    submitted = False
+    submitted_at = 0.0
+
+    print(f"[{label}] attached to {screen_name}", file=sys.stderr)
+
+    try:
+        while time.monotonic() < deadline:
+            readable, _, _ = select.select([master], [], [], 0.25)
+            if readable:
+                try:
+                    chunk = os.read(master, 8192)
+                except BlockingIOError:
+                    chunk = b""
+                if chunk:
+                    buffer = (buffer + chunk)[-60000:]
+
+            if proc.poll() is not None:
+                print(f"[{label}] screen client exited before priming finished", file=sys.stderr)
+                sample = strip_control(buffer[-2000:])
+                if sample.strip():
+                    print(f"[{label}] recent screen text:\n{sample[-1200:]}", file=sys.stderr)
+                return 1
+
+            plain = strip_control(buffer).lower()
+            now = time.monotonic()
+
+            if not sent_bypass and (
+                "bypass permissions" in plain
+                or "warning: claude code running" in plain
+                or "yes, i accept" in plain
+            ):
+                send_line(master, "2")
+                sent_bypass = True
+                last_action = now
+                print(f"[{label}] accepted bypass warning with numeric 2", file=sys.stderr)
+                time.sleep(1.0)
+                continue
+
+            if not sent_fullscreen and "fullscreen" in plain and ("renderer" in plain or "try" in plain):
+                send_line(master, "2")
+                sent_fullscreen = True
+                last_action = now
+                print(f"[{label}] declined fullscreen renderer prompt with numeric 2", file=sys.stderr)
+                time.sleep(1.0)
+                continue
+
+            if not sent_trust and "trust" in plain and ("folder" in plain or "workspace" in plain or "files in this" in plain):
+                send_line(master, "1")
+                sent_trust = True
+                last_action = now
+                print(f"[{label}] accepted folder trust prompt", file=sys.stderr)
+                time.sleep(1.0)
+                continue
+
+            remote_active = "/remote-control is active" in plain or "remote-control is active" in plain
+            readyish = remote_active or ("remote control" in plain and "active" in plain)
+            if not submitted and readyish and now - last_action > 1.5:
+                time.sleep(0.8)
+                send_mission(master, mission)
+                submitted = True
+                submitted_at = time.monotonic()
+                print(f"[{label}] pasted mission prompt and submitted it", file=sys.stderr)
+                continue
+
+            if submitted and now - submitted_at >= post_wait:
+                write_all(master, b"\x01d")
+                time.sleep(0.5)
+                print(f"[{label}] detached after post-submit wait", file=sys.stderr)
+                return 0
+
+        if submitted:
+            write_all(master, b"\x01d")
+            time.sleep(0.5)
+            print(f"[{label}] detached after timeout; prompt had been submitted", file=sys.stderr)
+            return 0
+
+        sample = strip_control(buffer[-4000:])
+        print(f"[{label}] timed out before detecting a ready remote-control prompt", file=sys.stderr)
+        if sample.strip():
+            print(f"[{label}] recent screen text:\n{sample[-1200:]}", file=sys.stderr)
+        return 1
+    finally:
+        try:
+            if proc.poll() is None:
+                write_all(master, b"\x01d")
+                time.sleep(0.2)
+        except OSError:
+            pass
+        try:
+            os.close(master)
+        except OSError:
+            pass
+        if proc.poll() is None:
+            try:
+                os.killpg(proc.pid, signal.SIGTERM)
+            except OSError:
+                pass
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Prime a Claude Code remote-control screen through a real PTY.")
+    parser.add_argument("--screen", required=True, help="screen session name to attach to")
+    parser.add_argument("--label", default="claude", help="label for log messages")
+    parser.add_argument("--mission", default=os.environ.get("PORTFOLIO_RC_MISSION", DEFAULT_MISSION))
+    parser.add_argument("--timeout", type=float, default=180.0)
+    parser.add_argument("--post-wait", type=float, default=14.0)
+    args = parser.parse_args()
+
+    return attach_and_prime(args.screen, args.label, args.mission, args.timeout, args.post_wait)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.codex/skills/portfolio-remote-control/SKILL.md
+++ b/.codex/skills/portfolio-remote-control/SKILL.md
@@ -53,7 +53,7 @@ Before reporting success, verify all of the following:
 
 - `ps` shows all three `claude --permission-mode bypassPermissions --remote-control ...` processes with names `merchant-intel`, `font-render`, and `orchestration`.
 - `screen -ls` shows the three target screens: `claude-merchant-intel-rc`, `claude-font-render-rc`, and `claude-orchestration-rc`.
-- Each screen log under `/tmp/claude-remote-screen/<label>/screenlog.0` shows that the session moved past the warning and began work, ideally including `CONTEXT.md`, `CHARTER.md`, or tool-use text.
+- Each screen log under `/tmp/claude-remote-screen/<label>/screenlog.0` shows actual tool use, such as `Reading 1 file`, `Bash(`, `Edit(`, or `TodoWrite`; the echoed mission prompt alone is not success evidence.
 - A `caffeinate -dimsu` process is alive, preferably the skill-managed 24-hour helper recorded under `/tmp/claude-remote-screen/caffeinate.pid`.
 - Tell the user that the three Claude sessions should now appear by name in the Claude app on their phone for remote control.
 

--- a/.codex/skills/portfolio-remote-control/SKILL.md
+++ b/.codex/skills/portfolio-remote-control/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: portfolio-remote-control
+description: Launch and verify the three autonomous Claude Code remote-control sessions for the Portfolio repo. Use when the user asks Codex or Claude to turn on, start, restart, supervise, or verify the Portfolio remote-control trio for merchant intelligence, receipt font rendering, and synthesis orchestration worktrees.
+---
+
+# Portfolio Remote Control
+
+## Purpose
+
+Use this skill to start the three Portfolio Claude Code remote-control sessions and get them past the interactive bypass warning into real autonomous work. The supported sessions are:
+
+| Label | Worktree | Remote-control name |
+| --- | --- | --- |
+| `merchant-intel` | `~/Portfolio/.claude/worktrees/merchant-intel` | `merchant-intel` |
+| `font-render` | `~/Portfolio/.claude/worktrees/font-render` | `font-render` |
+| `orchestration` | `~/Portfolio/.claude/worktrees/orchestration` | `orchestration` |
+
+The mission prompt to send to each session is fixed:
+
+```text
+Read CONTEXT.md then CHARTER.md in this worktree. They hold the full context from the session that set this branch up plus your specific mission. Follow the charter milestones in order and self-review with codex along the way exactly as CONTEXT.md mandates. Begin with milestone 1 now.
+```
+
+## Fast Path
+
+Resolve paths relative to this `SKILL.md`, then run:
+
+```bash
+scripts/portfolio_remote_control.sh launch
+```
+
+This helper:
+
+1. Cleans only the three target Portfolio remote-control sessions.
+2. Starts one detached `screen` session per worktree with `/opt/homebrew/bin/claude --permission-mode bypassPermissions --remote-control <name>`.
+3. Attaches to each `screen` through a real pseudo-terminal, accepts Claude's bypass prompt with `2`, bracket-pastes the mission prompt, submits it with a separate carriage return, and detaches.
+4. Opens Terminal.app attachers for the three screens when a GUI session is available.
+5. Starts a skill-managed durable `caffeinate -dimsu /bin/sleep 86400` if one is not already alive.
+6. Prints process, screen, and log status.
+
+Use these focused commands as needed:
+
+```bash
+scripts/portfolio_remote_control.sh status
+scripts/portfolio_remote_control.sh prime
+scripts/portfolio_remote_control.sh start
+scripts/portfolio_remote_control.sh cleanup
+```
+
+## Verification Contract
+
+Before reporting success, verify all of the following:
+
+- `ps` shows all three `claude --permission-mode bypassPermissions --remote-control ...` processes with names `merchant-intel`, `font-render`, and `orchestration`.
+- `screen -ls` shows the three target screens: `claude-merchant-intel-rc`, `claude-font-render-rc`, and `claude-orchestration-rc`.
+- Each screen log under `/tmp/claude-remote-screen/<label>/screenlog.0` shows that the session moved past the warning and began work, ideally including `CONTEXT.md`, `CHARTER.md`, or tool-use text.
+- A `caffeinate -dimsu` process is alive, preferably the skill-managed 24-hour helper recorded under `/tmp/claude-remote-screen/caffeinate.pid`.
+- Tell the user that the three Claude sessions should now appear by name in the Claude app on their phone for remote control.
+
+## Manual Fallback
+
+If the helper starts the screens but cannot prime one, attach with a real PTY. Do not use `screen -X stuff`; it can fail to deliver input to Claude's TUI on this Mac.
+
+```bash
+TERM=xterm-256color screen -x claude-merchant-intel-rc
+TERM=xterm-256color screen -x claude-font-render-rc
+TERM=xterm-256color screen -x claude-orchestration-rc
+```
+
+Inside each attached screen:
+
+1. If the bypass warning appears, type `2` then Enter. Prefer numeric `2`; Down arrow can select the wrong option in this TUI.
+2. If the fullscreen renderer prompt appears, type `2` then Enter for "Not now".
+3. If a folder trust prompt appears, accept it.
+4. After `/remote-control is active` and the prompt box is ready, bracket-paste the full mission prompt, then send Enter as a separate input.
+5. Detach with Ctrl-A then `d`, leaving the session running.
+
+The separate paste and submit matter. Sending the long prompt plus Enter as one raw write can leave the prompt unsubmitted or drop characters.
+
+## Details
+
+For a fuller runbook and troubleshooting notes, read `references/portfolio-remote-control-runbook.md`.

--- a/.codex/skills/portfolio-remote-control/agents/openai.yaml
+++ b/.codex/skills/portfolio-remote-control/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Portfolio Remote Control"
+  short_description: "Launch the Portfolio Claude remote-control trio."
+  default_prompt: "Launch the three Portfolio Claude remote-control sessions and verify they are working."

--- a/.codex/skills/portfolio-remote-control/references/portfolio-remote-control-runbook.md
+++ b/.codex/skills/portfolio-remote-control/references/portfolio-remote-control-runbook.md
@@ -51,3 +51,19 @@ grep -aE 'CONTEXT\.md|CHARTER\.md|Read\(|Bash\(|Edit\(|TodoWrite' /tmp/claude-re
 ```
 
 Successful launch means all three remote-control processes are alive, all three screens exist, the logs show the sessions moved past warnings into work, and the user can see `merchant-intel`, `font-render`, and `orchestration` in the Claude mobile app.
+
+## Supervising the cadence
+
+The review-first commit/push cadence must be **supervised**, not just stated. Its
+presence in each worktree's `CONTEXT.md` makes an agent *intend* it; it does not
+enforce it. Run `portfolio_remote_control.sh status` periodically:
+
+- `cadence=DRIFT` for a session means it is hoarding uncommitted WIP (more than
+  `PORTFOLIO_RC_DIRTY_WARN`, default 8, changed files) or sitting on unpushed
+  commits. Re-nudge it to codex-review → commit → push before it accumulates more
+  (a session reached 20 uncommitted files this way).
+- The "Unexpected remote-control sessions" block lists any remote-control claude
+  sessions that are not the trio — close strays so they don't compete for
+  resources or confuse status.
+- `check_push_auth` runs at launch; if it warns, fix gh/remote on the mini before
+  the agents try to push, or their work strands locally on the box.

--- a/.codex/skills/portfolio-remote-control/references/portfolio-remote-control-runbook.md
+++ b/.codex/skills/portfolio-remote-control/references/portfolio-remote-control-runbook.md
@@ -47,10 +47,10 @@ The durable path is:
 ps axww -o pid= -o command= | grep '[c]laude .*--remote-control'
 screen -ls
 pgrep -fl 'caffeinate.*-dimsu'
-grep -aE 'CONTEXT\.md|CHARTER\.md|Read\(|Bash\(|Edit\(|TodoWrite' /tmp/claude-remote-screen/*/screenlog.0
+scripts/portfolio_remote_control.sh status
 ```
 
-Successful launch means all three remote-control processes are alive, all three screens exist, the logs show the sessions moved past warnings into work, and the user can see `merchant-intel`, `font-render`, and `orchestration` in the Claude mobile app.
+Successful launch means all three remote-control processes are alive, all three screens exist, `status` reports `log_evidence=1` from normalized tool-use text after the mission prompt was submitted, and the user can see `merchant-intel`, `font-render`, and `orchestration` in the Claude mobile app.
 
 ## Supervising the cadence
 

--- a/.codex/skills/portfolio-remote-control/references/portfolio-remote-control-runbook.md
+++ b/.codex/skills/portfolio-remote-control/references/portfolio-remote-control-runbook.md
@@ -1,0 +1,53 @@
+# Portfolio Remote Control Runbook
+
+## Target Sessions
+
+Use this exact mapping unless the user gives an explicit replacement:
+
+| Label | Worktree | Branch | Remote name | Screen name |
+| --- | --- | --- | --- | --- |
+| `merchant-intel` | `~/Portfolio/.claude/worktrees/merchant-intel` | `feat/merchant-intelligence-agents` | `merchant-intel` | `claude-merchant-intel-rc` |
+| `font-render` | `~/Portfolio/.claude/worktrees/font-render` | `feat/receipt-font-render` | `font-render` | `claude-font-render-rc` |
+| `orchestration` | `~/Portfolio/.claude/worktrees/orchestration` | `feat/synthesis-orchestration` | `orchestration` | `claude-orchestration-rc` |
+
+Each worktree should contain committed `CONTEXT.md` and `CHARTER.md` files. The remote Claude sessions should read those files before doing implementation work.
+
+## Reliable Startup Sequence
+
+The durable path is:
+
+1. Clean only the target Portfolio sessions:
+   - Quit target `screen` sessions.
+   - Kill only Claude processes whose command line includes one of the three target remote-control names.
+   - Run `screen -wipe`.
+2. Start each Claude inside a detached `screen -L -dmS ...` from `/tmp/claude-remote-screen/<label>`.
+3. Attach with a real PTY using `TERM=xterm-256color screen -x <screen-name>`.
+4. Respond to prompts:
+   - Bypass permissions warning: send `2` then Enter.
+   - Fullscreen renderer prompt: send `2` then Enter.
+   - Folder trust prompt: accept.
+5. Wait for the prompt box after `/remote-control is active`.
+6. Send bracketed paste: `ESC [ 200 ~`, mission prompt, `ESC [ 201 ~`.
+7. Send Enter as a separate write.
+8. Wait for signs of work, then detach with Ctrl-A then `d`.
+9. Open Terminal.app attachers so the user has visible GUI Terminal windows/tabs.
+10. Start a skill-managed `caffeinate -dimsu /bin/sleep 86400` unless the skill's PID file already points to a live keep-awake process.
+
+## Known Pitfalls
+
+- Avoid `screen -X stuff` for Claude TUI input. It can appear to send keys but not actually reach the prompt correctly on this Mac's old `screen`.
+- Avoid Down-arrow plus Enter for the bypass warning. Numeric `2` is more reliable.
+- Avoid writing the long mission prompt and Enter in one operation. Use bracketed paste first, then Enter.
+- Avoid broad `pkill -f 'claude.*remote-control'` unless the user explicitly wants every remote-control session killed. This machine may have unrelated remote-control sessions.
+- Old macOS `screen` does not support `-Logfile`; use `screen -L` and expect `screenlog.0` in the screen's working directory.
+
+## Verification Commands
+
+```bash
+ps axww -o pid= -o command= | grep '[c]laude .*--remote-control'
+screen -ls
+pgrep -fl 'caffeinate.*-dimsu'
+grep -aE 'CONTEXT\.md|CHARTER\.md|Read\(|Bash\(|Edit\(|TodoWrite' /tmp/claude-remote-screen/*/screenlog.0
+```
+
+Successful launch means all three remote-control processes are alive, all three screens exist, the logs show the sessions moved past warnings into work, and the user can see `merchant-intel`, `font-render`, and `orchestration` in the Claude mobile app.

--- a/.codex/skills/portfolio-remote-control/scripts/portfolio_remote_control.sh
+++ b/.codex/skills/portfolio-remote-control/scripts/portfolio_remote_control.sh
@@ -10,6 +10,7 @@ CAFFEINATE_PID_FILE="$BASE_DIR/caffeinate.pid"
 PRIME_TIMEOUT="${PORTFOLIO_RC_PRIME_TIMEOUT:-180}"
 CAFFEINATE_SECONDS="${PORTFOLIO_RC_CAFFEINATE_SECONDS:-86400}"
 DIRTY_WARN="${PORTFOLIO_RC_DIRTY_WARN:-8}"
+LOG_EVIDENCE_PATTERN='Read\(|Bash\(|Edit\(|MultiEdit\(|Write\(|TodoWrite|Grep\(|Glob\(|LS\(|Reading\s*[0-9]+\s*files?'
 
 MISSION_PROMPT="${PORTFOLIO_RC_MISSION:-Read CONTEXT.md then CHARTER.md in this worktree. They hold the full context from the session that set this branch up plus your specific mission. Follow the charter milestones in order and self-review with codex along the way exactly as CONTEXT.md mandates. Begin with milestone 1 now.}"
 
@@ -192,6 +193,26 @@ prime_screens() {
   return "$failed"
 }
 
+log_has_evidence() {
+  local log_file="$1"
+  python3 - "$log_file" "$LOG_EVIDENCE_PATTERN" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+pattern = sys.argv[2]
+data = path.read_bytes()
+data = re.sub(
+    rb"\x1b\[[0-9;?]*[ -/]*[@-~]|\x1b\][^\x07]*(?:\x07|\x1b\\)|\x1b[@-_]",
+    b"",
+    data,
+)
+text = data.replace(b"\x00", b"").decode("utf-8", errors="ignore")
+raise SystemExit(0 if re.search(pattern, text) else 1)
+PY
+}
+
 ensure_caffeinate() {
   if [[ -s "$CAFFEINATE_PID_FILE" ]]; then
     local existing_pid
@@ -289,7 +310,7 @@ status() {
       missing=1
     fi
 
-    if [[ -f "$log_file" ]] && grep -aE 'CONTEXT\.md|CHARTER\.md|Read\(|Bash\(|Edit\(|TodoWrite' "$log_file" >/dev/null 2>&1; then
+    if [[ -f "$log_file" ]] && log_has_evidence "$log_file"; then
       log_ok=1
     else
       missing=1

--- a/.codex/skills/portfolio-remote-control/scripts/portfolio_remote_control.sh
+++ b/.codex/skills/portfolio-remote-control/scripts/portfolio_remote_control.sh
@@ -1,0 +1,249 @@
+#!/bin/bash
+set -euo pipefail
+
+SKILL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CLAUDE_BIN="${CLAUDE_BIN:-/opt/homebrew/bin/claude}"
+PORTFOLIO_ROOT="${PORTFOLIO_ROOT:-$HOME/Portfolio}"
+BASE_DIR="${PORTFOLIO_RC_BASE:-/tmp/claude-remote-screen}"
+ATTACH_DIR="$BASE_DIR/attachers"
+CAFFEINATE_PID_FILE="$BASE_DIR/caffeinate.pid"
+PRIME_TIMEOUT="${PORTFOLIO_RC_PRIME_TIMEOUT:-180}"
+CAFFEINATE_SECONDS="${PORTFOLIO_RC_CAFFEINATE_SECONDS:-86400}"
+
+MISSION_PROMPT="${PORTFOLIO_RC_MISSION:-Read CONTEXT.md then CHARTER.md in this worktree. They hold the full context from the session that set this branch up plus your specific mission. Follow the charter milestones in order and self-review with codex along the way exactly as CONTEXT.md mandates. Begin with milestone 1 now.}"
+
+usage() {
+  cat <<'EOF'
+Usage: portfolio_remote_control.sh <command>
+
+Commands:
+  launch   Clean target sessions, start screens, prime Claude, open Terminal attachers, caffeinate, verify.
+  start    Clean target sessions and start screens/Terminal attachers without typing into Claude.
+  prime    Attach to existing target screens through a PTY and send the startup prompt.
+  status   Show processes, screens, log evidence, and caffeinate status.
+  verify   Alias for status.
+  cleanup  Stop only the three Portfolio remote-control Claude/screen sessions.
+
+Environment:
+  CLAUDE_BIN                         Path to claude binary. Default: /opt/homebrew/bin/claude
+  PORTFOLIO_ROOT                     Portfolio checkout root. Default: $HOME/Portfolio
+  PORTFOLIO_RC_OPEN_TERMINAL=0       Skip opening Terminal.app attachers.
+  PORTFOLIO_RC_PRIME_TIMEOUT=180     Seconds to wait while priming each screen.
+  PORTFOLIO_RC_CAFFEINATE_SECONDS    Duration for the caffeinate sleep helper. Default: 86400
+EOF
+}
+
+entries() {
+  cat <<EOF
+merchant-intel|$PORTFOLIO_ROOT/.claude/worktrees/merchant-intel|merchant-intel|claude-merchant-intel-rc
+font-render|$PORTFOLIO_ROOT/.claude/worktrees/font-render|font-render|claude-font-render-rc
+orchestration|$PORTFOLIO_ROOT/.claude/worktrees/orchestration|orchestration|claude-orchestration-rc
+EOF
+}
+
+quote_arg() {
+  printf "%q" "$1"
+}
+
+require_prereqs() {
+  if [[ ! -x "$CLAUDE_BIN" ]]; then
+    echo "Missing executable Claude binary: $CLAUDE_BIN" >&2
+    return 1
+  fi
+  if [[ ! -x /usr/bin/screen ]]; then
+    echo "Missing /usr/bin/screen" >&2
+    return 1
+  fi
+  while IFS='|' read -r label worktree session_name screen_name; do
+    if [[ ! -d "$worktree" ]]; then
+      echo "Missing worktree for $label: $worktree" >&2
+      return 1
+    fi
+    if [[ ! -f "$worktree/CONTEXT.md" || ! -f "$worktree/CHARTER.md" ]]; then
+      echo "Missing CONTEXT.md or CHARTER.md in $worktree" >&2
+      return 1
+    fi
+  done < <(entries)
+}
+
+cleanup_targets() {
+  echo "Stopping target Portfolio remote-control sessions..."
+  while IFS='|' read -r label worktree session_name screen_name; do
+    /usr/bin/screen -S "$screen_name" -X quit >/dev/null 2>&1 || true
+    pkill -9 -f "claude.*--remote-control[[:space:]]+$session_name" >/dev/null 2>&1 || true
+    pkill -9 -f "claude.*remote-control.*$session_name" >/dev/null 2>&1 || true
+  done < <(entries)
+  /usr/bin/screen -wipe >/dev/null 2>&1 || true
+}
+
+write_attacher() {
+  local label="$1"
+  local screen_name="$2"
+  local file="$ATTACH_DIR/$label.command"
+
+  mkdir -p "$ATTACH_DIR"
+  cat >"$file" <<EOF
+#!/bin/zsh
+export TERM=xterm-256color
+exec /usr/bin/screen -x $screen_name
+EOF
+  chmod +x "$file"
+}
+
+start_screens() {
+  require_prereqs
+  mkdir -p "$BASE_DIR" "$ATTACH_DIR"
+
+  while IFS='|' read -r label worktree session_name screen_name; do
+    local workdir="$BASE_DIR/$label"
+    mkdir -p "$workdir"
+    rm -f "$workdir/screenlog.0"
+    write_attacher "$label" "$screen_name"
+
+    echo "Starting $label in $screen_name..."
+    (
+      cd "$workdir"
+      /usr/bin/screen -L -dmS "$screen_name" /bin/bash -lc \
+        "cd $(quote_arg "$worktree") && exec $(quote_arg "$CLAUDE_BIN") --permission-mode bypassPermissions --remote-control $(quote_arg "$session_name")"
+    )
+    sleep 1
+  done < <(entries)
+}
+
+open_attachers() {
+  if [[ "${PORTFOLIO_RC_OPEN_TERMINAL:-1}" == "0" ]]; then
+    return 0
+  fi
+  if [[ ! -x /usr/bin/open ]]; then
+    return 0
+  fi
+
+  while IFS='|' read -r label worktree session_name screen_name; do
+    local file="$ATTACH_DIR/$label.command"
+    if [[ -x "$file" ]]; then
+      /usr/bin/open -a Terminal "$file" >/dev/null 2>&1 || true
+    fi
+  done < <(entries)
+}
+
+prime_screens() {
+  local failed=0
+  local primer="$SKILL_DIR/scripts/prime_claude_screen.py"
+
+  if [[ ! -f "$primer" ]]; then
+    echo "Missing primer script: $primer" >&2
+    return 1
+  fi
+
+  while IFS='|' read -r label worktree session_name screen_name; do
+    echo "Priming $label..."
+    if ! PORTFOLIO_RC_MISSION="$MISSION_PROMPT" python3 "$primer" --screen "$screen_name" --label "$label" --timeout "$PRIME_TIMEOUT"; then
+      echo "Prime failed for $label; attach manually with: TERM=xterm-256color screen -x $screen_name" >&2
+      failed=1
+    fi
+  done < <(entries)
+
+  return "$failed"
+}
+
+ensure_caffeinate() {
+  if [[ -s "$CAFFEINATE_PID_FILE" ]]; then
+    local existing_pid
+    existing_pid="$(cat "$CAFFEINATE_PID_FILE" 2>/dev/null || true)"
+    if [[ "$existing_pid" =~ ^[0-9]+$ ]] && kill -0 "$existing_pid" >/dev/null 2>&1; then
+      echo "Skill-managed caffeinate is already running as PID $existing_pid."
+      return 0
+    fi
+  fi
+
+  mkdir -p "$BASE_DIR"
+  echo "Starting caffeinate for $CAFFEINATE_SECONDS seconds..."
+  nohup /usr/bin/caffeinate -dimsu /bin/sleep "$CAFFEINATE_SECONDS" >"$BASE_DIR/caffeinate.log" 2>&1 &
+  echo "$!" >"$CAFFEINATE_PID_FILE"
+}
+
+status() {
+  local missing=0
+  local screen_listing
+  screen_listing="$(/usr/bin/screen -ls 2>/dev/null || true)"
+
+  echo
+  echo "Claude remote-control processes:"
+  ps axww -o pid= -o command= | grep '[c]laude .*--remote-control' || true
+
+  echo
+  echo "Target screen sessions:"
+  printf "%s\n" "$screen_listing" | grep -E 'claude-(merchant-intel|font-render|orchestration)-rc' || true
+
+  echo
+  while IFS='|' read -r label worktree session_name screen_name; do
+    local process_ok=0
+    local screen_ok=0
+    local log_ok=0
+    local log_file="$BASE_DIR/$label/screenlog.0"
+
+    if ps axww -o command= | grep '[c]laude .*--remote-control' | grep -F -- "--remote-control $session_name" >/dev/null 2>&1; then
+      process_ok=1
+    else
+      missing=1
+    fi
+
+    if printf "%s\n" "$screen_listing" | grep -E "[0-9]+\\.$screen_name[[:space:]]" >/dev/null 2>&1; then
+      screen_ok=1
+    else
+      missing=1
+    fi
+
+    if [[ -f "$log_file" ]] && grep -aE 'CONTEXT\.md|CHARTER\.md|Read\(|Bash\(|Edit\(|TodoWrite|remote-control is active' "$log_file" >/dev/null 2>&1; then
+      log_ok=1
+    fi
+
+    printf "%-16s process=%s screen=%s log_evidence=%s log=%s\n" \
+      "$label" "$process_ok" "$screen_ok" "$log_ok" "$log_file"
+  done < <(entries)
+
+  echo
+  echo "Caffeinate:"
+  pgrep -fl "caffeinate.*-dimsu" || true
+
+  return "$missing"
+}
+
+command="${1:-launch}"
+case "$command" in
+  launch)
+    cleanup_targets
+    start_screens
+    sleep 2
+    prime_failed=0
+    prime_screens || prime_failed=1
+    ensure_caffeinate
+    open_attachers
+    status || true
+    exit "$prime_failed"
+    ;;
+  start)
+    cleanup_targets
+    start_screens
+    ensure_caffeinate
+    open_attachers
+    status || true
+    ;;
+  prime)
+    prime_screens
+    status || true
+    ;;
+  status|verify)
+    status
+    ;;
+  cleanup)
+    cleanup_targets
+    ;;
+  -h|--help|help)
+    usage
+    ;;
+  *)
+    usage >&2
+    exit 2
+    ;;
+esac

--- a/.codex/skills/portfolio-remote-control/scripts/portfolio_remote_control.sh
+++ b/.codex/skills/portfolio-remote-control/scripts/portfolio_remote_control.sh
@@ -47,50 +47,86 @@ quote_arg() {
   printf "%q" "$1"
 }
 
-remote_control_pids() {
-  local session_name="$1"
-  ps axww -o pid= -o command= | awk -v target="$session_name" '
+canonical_dir() {
+  cd "$1" 2>/dev/null && pwd -P
+}
+
+process_cwd() {
+  local pid="$1"
+  /usr/sbin/lsof -a -p "$pid" -d cwd -Fn 2>/dev/null | awk '
+    /^n/ {
+      print substr($0, 2)
+      exit
+    }
+  '
+}
+
+process_cwd_matches() {
+  local pid="$1"
+  local expected_dir="$2"
+  local expected actual
+
+  expected="$(canonical_dir "$expected_dir" || true)"
+  actual="$(process_cwd "$pid")"
+  [[ -n "$expected" && -n "$actual" && "$actual" == "$expected" ]]
+}
+
+remote_control_candidates() {
+  ps axww -o pid= -o command= | awk '
     function strip_quotes(value) {
       gsub(/^[\"\047]+|[\"\047]+$/, "", value)
       return value
+    }
+    function print_candidate(value) {
+      value = strip_quotes(value)
+      if (value != "") {
+        print pid "|" value
+      }
     }
     {
       pid = $1
       executable = strip_quotes($2)
       sub(/^.*\//, "", executable)
-      if (executable != "claude") {
+      if (executable == "SCREEN" || executable == "screen" || executable == "login" || executable == "awk") {
         next
       }
       for (i = 3; i <= NF; i++) {
         arg = strip_quotes($i)
         if (arg == "--remote-control" && i < NF) {
-          value = strip_quotes($(i + 1))
-          if (value == target) {
-            print pid
-            next
-          }
+          print_candidate($(i + 1))
+          next
         }
         if (arg ~ /^--remote-control=/) {
-          value = strip_quotes(substr(arg, 18))
-          if (value == target) {
-            print pid
-            next
-          }
+          print_candidate(substr(arg, 18))
+          next
         }
       }
     }
   '
 }
 
+remote_control_pids() {
+  local session_name="$1"
+  local worktree="$2"
+  local pid found_session
+
+  while IFS='|' read -r pid found_session; do
+    if [[ "$found_session" == "$session_name" ]] && process_cwd_matches "$pid" "$worktree"; then
+      printf "%s\n" "$pid"
+    fi
+  done < <(remote_control_candidates)
+}
+
 kill_remote_control_processes() {
   local session_name="$1"
+  local worktree="$2"
   local pid
 
   while IFS= read -r pid; do
     if [[ "$pid" =~ ^[0-9]+$ ]]; then
       kill -9 "$pid" >/dev/null 2>&1 || true
     fi
-  done < <(remote_control_pids "$session_name")
+  done < <(remote_control_pids "$session_name" "$worktree")
 }
 
 require_prereqs() {
@@ -118,7 +154,7 @@ cleanup_targets() {
   echo "Stopping target Portfolio remote-control sessions..."
   while IFS='|' read -r label worktree session_name screen_name; do
     /usr/bin/screen -S "$screen_name" -X quit >/dev/null 2>&1 || true
-    kill_remote_control_processes "$session_name"
+    kill_remote_control_processes "$session_name" "$worktree"
   done < <(entries)
   /usr/bin/screen -wipe >/dev/null 2>&1 || true
 }
@@ -213,69 +249,112 @@ raise SystemExit(0 if re.search(pattern, text) else 1)
 PY
 }
 
+caffeinate_pid_is_managed() {
+  local pid="$1"
+  local command
+
+  command="$(ps -p "$pid" -o command= 2>/dev/null || true)"
+  [[ "$command" == *caffeinate* && "$command" == *-dimsu* ]]
+}
+
 ensure_caffeinate() {
   if [[ -s "$CAFFEINATE_PID_FILE" ]]; then
     local existing_pid
     existing_pid="$(cat "$CAFFEINATE_PID_FILE" 2>/dev/null || true)"
-    if [[ "$existing_pid" =~ ^[0-9]+$ ]] && kill -0 "$existing_pid" >/dev/null 2>&1; then
+    if [[ "$existing_pid" =~ ^[0-9]+$ ]] && caffeinate_pid_is_managed "$existing_pid"; then
       echo "Skill-managed caffeinate is already running as PID $existing_pid."
       return 0
     fi
+    rm -f "$CAFFEINATE_PID_FILE"
   fi
 
   mkdir -p "$BASE_DIR"
   echo "Starting caffeinate for $CAFFEINATE_SECONDS seconds..."
-  nohup /usr/bin/caffeinate -dimsu /bin/sleep "$CAFFEINATE_SECONDS" >"$BASE_DIR/caffeinate.log" 2>&1 &
+  nohup /usr/bin/caffeinate -dimsu -t "$CAFFEINATE_SECONDS" >"$BASE_DIR/caffeinate.log" 2>&1 &
   echo "$!" >"$CAFFEINATE_PID_FILE"
 }
 
 # Agents are useless if they cannot push: the mini's gh token expires and origin
 # can be a dead SSH remote. Verify a real authenticated remote op works.
 check_push_auth() {
-  if git -C "$PORTFOLIO_ROOT" ls-remote origin HEAD >/dev/null 2>&1; then
-    return 0
+  local failed=0
+
+  if ! command -v gh >/dev/null 2>&1 || ! gh auth status -h github.com >/dev/null 2>&1; then
+    echo "WARNING: gh is not authenticated for GitHub; agents may not be able to push." >&2
+    failed=1
+  elif ! gh api repos/tnorlund/Portfolio --jq '.permissions.push' 2>/dev/null | grep -q '^true$'; then
+    echo "WARNING: gh token does not report push permission for tnorlund/Portfolio." >&2
+    failed=1
   fi
-  echo "WARNING: cannot reach GitHub origin from $PORTFOLIO_ROOT -- agents will NOT be able to push." >&2
-  echo "  Fix on the mini, then relaunch:" >&2
-  echo "    gh auth status            # if invalid, re-auth (e.g. from a good machine:" >&2
-  echo "    #   gh auth token | ssh <mini> 'gh auth login --with-token')" >&2
-  echo "    gh auth setup-git" >&2
-  echo "    git -C $PORTFOLIO_ROOT remote set-url origin https://github.com/tnorlund/Portfolio.git  # if origin is a dead SSH remote" >&2
-  return 1
+
+  while IFS='|' read -r label worktree session_name screen_name; do
+    local branch
+    branch="$(git -C "$worktree" branch --show-current 2>/dev/null || true)"
+    if [[ -z "$branch" ]] || ! git -C "$worktree" push --dry-run origin "HEAD:refs/heads/$branch" >/dev/null 2>&1; then
+      echo "WARNING: dry-run push failed for $label from $worktree." >&2
+      failed=1
+    fi
+  done < <(entries)
+
+  if [[ "$failed" -ne 0 ]]; then
+    echo "  Fix on the mini, then relaunch:" >&2
+    echo "    gh auth status            # if invalid, re-auth (e.g. from a good machine:" >&2
+    echo "    #   gh auth token | ssh <mini> 'gh auth login --with-token')" >&2
+    echo "    gh auth setup-git" >&2
+    echo "    git -C $PORTFOLIO_ROOT remote set-url origin https://github.com/tnorlund/Portfolio.git  # if origin is a dead SSH remote" >&2
+    return 1
+  fi
+
+  return 0
 }
 
-# Remote-control claude sessions whose name is not one of the expected trio.
+# Remote-control sessions outside the expected trio and worktrees.
 stray_sessions() {
-  ps axww -o command= | awk '
-    function strip_quotes(value) {
-      gsub(/^[\"\047]+|[\"\047]+$/, "", value)
-      return value
-    }
-    function print_if_stray(value) {
-      value = strip_quotes(value)
-      if (value != "merchant-intel" && value != "font-render" && value != "orchestration") {
-        print value
-      }
-    }
+  local pid found_session expected_worktree cwd
+
+  while IFS='|' read -r pid found_session; do
+    expected_worktree=""
+    while IFS='|' read -r label worktree session_name screen_name; do
+      if [[ "$found_session" == "$session_name" ]]; then
+        expected_worktree="$worktree"
+        break
+      fi
+    done < <(entries)
+
+    if [[ -n "$expected_worktree" ]] && process_cwd_matches "$pid" "$expected_worktree"; then
+      continue
+    fi
+
+    cwd="$(process_cwd "$pid")"
+    if [[ -n "$cwd" ]]; then
+      printf "%s pid=%s cwd=%s\n" "$found_session" "$pid" "$cwd"
+    else
+      printf "%s pid=%s\n" "$found_session" "$pid"
+    fi
+  done < <(remote_control_candidates) | sort -u || true
+}
+
+dirty_count() {
+  local worktree="$1"
+  local count
+
+  if count="$(git -C "$worktree" status --porcelain 2>/dev/null | wc -l | tr -d ' ')"; then
+    echo "${count:-0}"
+  else
+    echo 0
+  fi
+}
+
+caffeinate_processes() {
+  ps axww -o pid= -o command= | awk '
     {
-      executable = strip_quotes($1)
+      executable = $2
       sub(/^.*\//, "", executable)
-      if (executable != "claude") {
-        next
-      }
-      for (i = 2; i <= NF; i++) {
-        arg = strip_quotes($i)
-        if (arg == "--remote-control" && i < NF) {
-          print_if_stray($(i + 1))
-          next
-        }
-        if (arg ~ /^--remote-control=/) {
-          print_if_stray(substr(arg, 18))
-          next
-        }
+      if (executable == "caffeinate" && $0 ~ /-dimsu/) {
+        print
       }
     }
-  ' | sort -u || true
+  '
 }
 
 status() {
@@ -298,7 +377,7 @@ status() {
     local log_ok=0
     local log_file="$BASE_DIR/$label/screenlog.0"
 
-    if remote_control_pids "$session_name" | grep -q .; then
+    if remote_control_pids "$session_name" "$worktree" | grep -q .; then
       process_ok=1
     else
       missing=1
@@ -317,7 +396,7 @@ status() {
     fi
 
     local dirty unpushed cadence
-    dirty="$(git -C "$worktree" status --porcelain 2>/dev/null | wc -l | tr -d ' ' || echo 0)"
+    dirty="$(dirty_count "$worktree")"
     unpushed="$(git -C "$worktree" rev-list --count '@{u}..HEAD' 2>/dev/null || echo 0)"
     cadence=ok
     if [[ "${dirty:-0}" -gt "$DIRTY_WARN" || "${unpushed:-0}" -gt 0 ]]; then
@@ -332,7 +411,7 @@ status() {
   echo "Unexpected remote-control sessions:"
   local strays; strays="$(stray_sessions)"
   if [[ -n "$strays" ]]; then
-    printf "  %s\n" "$strays"
+    printf "%s\n" "$strays" | sed 's/^/  /'
     echo "  (not part of the trio -- close with: screen -S <name> -X quit, or kill the claude pid)"
   else
     echo "  none"
@@ -340,7 +419,10 @@ status() {
 
   echo
   echo "Caffeinate:"
-  if ! pgrep -fl "caffeinate.*-dimsu"; then
+  local caffeinate_lines; caffeinate_lines="$(caffeinate_processes)"
+  if [[ -n "$caffeinate_lines" ]]; then
+    printf "%s\n" "$caffeinate_lines"
+  else
     missing=1
   fi
 

--- a/.codex/skills/portfolio-remote-control/scripts/portfolio_remote_control.sh
+++ b/.codex/skills/portfolio-remote-control/scripts/portfolio_remote_control.sh
@@ -45,6 +45,52 @@ quote_arg() {
   printf "%q" "$1"
 }
 
+remote_control_pids() {
+  local session_name="$1"
+  ps axww -o pid= -o command= | awk -v target="$session_name" '
+    function strip_quotes(value) {
+      gsub(/^[\"\047]+|[\"\047]+$/, "", value)
+      return value
+    }
+    {
+      pid = $1
+      executable = strip_quotes($2)
+      sub(/^.*\//, "", executable)
+      if (executable != "claude") {
+        next
+      }
+      for (i = 3; i <= NF; i++) {
+        arg = strip_quotes($i)
+        if (arg == "--remote-control" && i < NF) {
+          value = strip_quotes($(i + 1))
+          if (value == target) {
+            print pid
+            next
+          }
+        }
+        if (arg ~ /^--remote-control=/) {
+          value = strip_quotes(substr(arg, 18))
+          if (value == target) {
+            print pid
+            next
+          }
+        }
+      }
+    }
+  '
+}
+
+kill_remote_control_processes() {
+  local session_name="$1"
+  local pid
+
+  while IFS= read -r pid; do
+    if [[ "$pid" =~ ^[0-9]+$ ]]; then
+      kill -9 "$pid" >/dev/null 2>&1 || true
+    fi
+  done < <(remote_control_pids "$session_name")
+}
+
 require_prereqs() {
   if [[ ! -x "$CLAUDE_BIN" ]]; then
     echo "Missing executable Claude binary: $CLAUDE_BIN" >&2
@@ -70,8 +116,7 @@ cleanup_targets() {
   echo "Stopping target Portfolio remote-control sessions..."
   while IFS='|' read -r label worktree session_name screen_name; do
     /usr/bin/screen -S "$screen_name" -X quit >/dev/null 2>&1 || true
-    pkill -9 -f "claude.*--remote-control[[:space:]]+$session_name" >/dev/null 2>&1 || true
-    pkill -9 -f "claude.*remote-control.*$session_name" >/dev/null 2>&1 || true
+    kill_remote_control_processes "$session_name"
   done < <(entries)
   /usr/bin/screen -wipe >/dev/null 2>&1 || true
 }
@@ -182,7 +227,7 @@ status() {
     local log_ok=0
     local log_file="$BASE_DIR/$label/screenlog.0"
 
-    if ps axww -o command= | grep '[c]laude .*--remote-control' | grep -F -- "--remote-control $session_name" >/dev/null 2>&1; then
+    if remote_control_pids "$session_name" | grep -q .; then
       process_ok=1
     else
       missing=1
@@ -194,8 +239,10 @@ status() {
       missing=1
     fi
 
-    if [[ -f "$log_file" ]] && grep -aE 'CONTEXT\.md|CHARTER\.md|Read\(|Bash\(|Edit\(|TodoWrite|remote-control is active' "$log_file" >/dev/null 2>&1; then
+    if [[ -f "$log_file" ]] && grep -aE 'CONTEXT\.md|CHARTER\.md|Read\(|Bash\(|Edit\(|TodoWrite' "$log_file" >/dev/null 2>&1; then
       log_ok=1
+    else
+      missing=1
     fi
 
     printf "%-16s process=%s screen=%s log_evidence=%s log=%s\n" \
@@ -204,7 +251,9 @@ status() {
 
   echo
   echo "Caffeinate:"
-  pgrep -fl "caffeinate.*-dimsu" || true
+  if ! pgrep -fl "caffeinate.*-dimsu"; then
+    missing=1
+  fi
 
   return "$missing"
 }
@@ -219,8 +268,11 @@ case "$command" in
     prime_screens || prime_failed=1
     ensure_caffeinate
     open_attachers
-    status || true
-    exit "$prime_failed"
+    status_failed=0
+    status || status_failed=1
+    if [[ "$prime_failed" -ne 0 || "$status_failed" -ne 0 ]]; then
+      exit 1
+    fi
     ;;
   start)
     cleanup_targets

--- a/.codex/skills/portfolio-remote-control/scripts/portfolio_remote_control.sh
+++ b/.codex/skills/portfolio-remote-control/scripts/portfolio_remote_control.sh
@@ -225,11 +225,36 @@ check_push_auth() {
 
 # Remote-control claude sessions whose name is not one of the expected trio.
 stray_sessions() {
-  ps axww -o command= \
-    | grep '[c]laude .*--remote-control' \
-    | sed -E 's/.*--remote-control[= ]+([A-Za-z0-9_-]+).*/\1/' \
-    | grep -vxE 'merchant-intel|font-render|orchestration' \
-    | sort -u || true
+  ps axww -o command= | awk '
+    function strip_quotes(value) {
+      gsub(/^[\"\047]+|[\"\047]+$/, "", value)
+      return value
+    }
+    function print_if_stray(value) {
+      value = strip_quotes(value)
+      if (value != "merchant-intel" && value != "font-render" && value != "orchestration") {
+        print value
+      }
+    }
+    {
+      executable = strip_quotes($1)
+      sub(/^.*\//, "", executable)
+      if (executable != "claude") {
+        next
+      }
+      for (i = 2; i <= NF; i++) {
+        arg = strip_quotes($i)
+        if (arg == "--remote-control" && i < NF) {
+          print_if_stray($(i + 1))
+          next
+        }
+        if (arg ~ /^--remote-control=/) {
+          print_if_stray(substr(arg, 18))
+          next
+        }
+      }
+    }
+  ' | sort -u || true
 }
 
 status() {

--- a/.codex/skills/portfolio-remote-control/scripts/portfolio_remote_control.sh
+++ b/.codex/skills/portfolio-remote-control/scripts/portfolio_remote_control.sh
@@ -9,6 +9,7 @@ ATTACH_DIR="$BASE_DIR/attachers"
 CAFFEINATE_PID_FILE="$BASE_DIR/caffeinate.pid"
 PRIME_TIMEOUT="${PORTFOLIO_RC_PRIME_TIMEOUT:-180}"
 CAFFEINATE_SECONDS="${PORTFOLIO_RC_CAFFEINATE_SECONDS:-86400}"
+DIRTY_WARN="${PORTFOLIO_RC_DIRTY_WARN:-8}"
 
 MISSION_PROMPT="${PORTFOLIO_RC_MISSION:-Read CONTEXT.md then CHARTER.md in this worktree. They hold the full context from the session that set this branch up plus your specific mission. Follow the charter milestones in order and self-review with codex along the way exactly as CONTEXT.md mandates. Begin with milestone 1 now.}"
 
@@ -207,6 +208,30 @@ ensure_caffeinate() {
   echo "$!" >"$CAFFEINATE_PID_FILE"
 }
 
+# Agents are useless if they cannot push: the mini's gh token expires and origin
+# can be a dead SSH remote. Verify a real authenticated remote op works.
+check_push_auth() {
+  if git -C "$PORTFOLIO_ROOT" ls-remote origin HEAD >/dev/null 2>&1; then
+    return 0
+  fi
+  echo "WARNING: cannot reach GitHub origin from $PORTFOLIO_ROOT -- agents will NOT be able to push." >&2
+  echo "  Fix on the mini, then relaunch:" >&2
+  echo "    gh auth status            # if invalid, re-auth (e.g. from a good machine:" >&2
+  echo "    #   gh auth token | ssh <mini> 'gh auth login --with-token')" >&2
+  echo "    gh auth setup-git" >&2
+  echo "    git -C $PORTFOLIO_ROOT remote set-url origin https://github.com/tnorlund/Portfolio.git  # if origin is a dead SSH remote" >&2
+  return 1
+}
+
+# Remote-control claude sessions whose name is not one of the expected trio.
+stray_sessions() {
+  ps axww -o command= \
+    | grep '[c]laude .*--remote-control' \
+    | sed -E 's/.*--remote-control[= ]+([A-Za-z0-9_-]+).*/\1/' \
+    | grep -vxE 'merchant-intel|font-render|orchestration' \
+    | sort -u || true
+}
+
 status() {
   local missing=0
   local screen_listing
@@ -245,9 +270,27 @@ status() {
       missing=1
     fi
 
-    printf "%-16s process=%s screen=%s log_evidence=%s log=%s\n" \
-      "$label" "$process_ok" "$screen_ok" "$log_ok" "$log_file"
+    local dirty unpushed cadence
+    dirty="$(git -C "$worktree" status --porcelain 2>/dev/null | wc -l | tr -d ' ' || echo 0)"
+    unpushed="$(git -C "$worktree" rev-list --count '@{u}..HEAD' 2>/dev/null || echo 0)"
+    cadence=ok
+    if [[ "${dirty:-0}" -gt "$DIRTY_WARN" || "${unpushed:-0}" -gt 0 ]]; then
+      cadence=DRIFT
+    fi
+
+    printf "%-16s process=%s screen=%s log_evidence=%s dirty=%s unpushed=%s cadence=%s log=%s\n" \
+      "$label" "$process_ok" "$screen_ok" "$log_ok" "$dirty" "$unpushed" "$cadence" "$log_file"
   done < <(entries)
+
+  echo
+  echo "Unexpected remote-control sessions:"
+  local strays; strays="$(stray_sessions)"
+  if [[ -n "$strays" ]]; then
+    printf "  %s\n" "$strays"
+    echo "  (not part of the trio -- close with: screen -S <name> -X quit, or kill the claude pid)"
+  else
+    echo "  none"
+  fi
 
   echo
   echo "Caffeinate:"
@@ -262,6 +305,7 @@ command="${1:-launch}"
 case "$command" in
   launch)
     cleanup_targets
+    check_push_auth || echo "  (continuing launch; fix push auth before the agents try to push)" >&2
     start_screens
     sleep 2
     prime_failed=0

--- a/.codex/skills/portfolio-remote-control/scripts/portfolio_remote_control.sh
+++ b/.codex/skills/portfolio-remote-control/scripts/portfolio_remote_control.sh
@@ -31,15 +31,15 @@ Environment:
   PORTFOLIO_ROOT                     Portfolio checkout root. Default: $HOME/Portfolio
   PORTFOLIO_RC_OPEN_TERMINAL=0       Skip opening Terminal.app attachers.
   PORTFOLIO_RC_PRIME_TIMEOUT=180     Seconds to wait while priming each screen.
-  PORTFOLIO_RC_CAFFEINATE_SECONDS    Duration for the caffeinate sleep helper. Default: 86400
+  PORTFOLIO_RC_CAFFEINATE_SECONDS    Duration for the caffeinate helper. Default: 86400
 EOF
 }
 
 entries() {
   cat <<EOF
-merchant-intel|$PORTFOLIO_ROOT/.claude/worktrees/merchant-intel|merchant-intel|claude-merchant-intel-rc
-font-render|$PORTFOLIO_ROOT/.claude/worktrees/font-render|font-render|claude-font-render-rc
-orchestration|$PORTFOLIO_ROOT/.claude/worktrees/orchestration|orchestration|claude-orchestration-rc
+merchant-intel|$PORTFOLIO_ROOT/.claude/worktrees/merchant-intel|merchant-intel|claude-merchant-intel-rc|feat/merchant-intelligence-agents
+font-render|$PORTFOLIO_ROOT/.claude/worktrees/font-render|font-render|claude-font-render-rc|feat/receipt-font-render
+orchestration|$PORTFOLIO_ROOT/.claude/worktrees/orchestration|orchestration|claude-orchestration-rc|feat/synthesis-orchestration
 EOF
 }
 
@@ -138,7 +138,7 @@ require_prereqs() {
     echo "Missing /usr/bin/screen" >&2
     return 1
   fi
-  while IFS='|' read -r label worktree session_name screen_name; do
+  while IFS='|' read -r label worktree session_name screen_name expected_branch; do
     if [[ ! -d "$worktree" ]]; then
       echo "Missing worktree for $label: $worktree" >&2
       return 1
@@ -147,12 +147,18 @@ require_prereqs() {
       echo "Missing CONTEXT.md or CHARTER.md in $worktree" >&2
       return 1
     fi
+    local branch
+    branch="$(git -C "$worktree" branch --show-current 2>/dev/null || true)"
+    if [[ "$branch" != "$expected_branch" ]]; then
+      echo "Wrong branch for $label: expected $expected_branch, got ${branch:-unknown}" >&2
+      return 1
+    fi
   done < <(entries)
 }
 
 cleanup_targets() {
   echo "Stopping target Portfolio remote-control sessions..."
-  while IFS='|' read -r label worktree session_name screen_name; do
+  while IFS='|' read -r label worktree session_name screen_name expected_branch; do
     /usr/bin/screen -S "$screen_name" -X quit >/dev/null 2>&1 || true
     kill_remote_control_processes "$session_name" "$worktree"
   done < <(entries)
@@ -177,7 +183,7 @@ start_screens() {
   require_prereqs
   mkdir -p "$BASE_DIR" "$ATTACH_DIR"
 
-  while IFS='|' read -r label worktree session_name screen_name; do
+  while IFS='|' read -r label worktree session_name screen_name expected_branch; do
     local workdir="$BASE_DIR/$label"
     mkdir -p "$workdir"
     rm -f "$workdir/screenlog.0"
@@ -201,7 +207,7 @@ open_attachers() {
     return 0
   fi
 
-  while IFS='|' read -r label worktree session_name screen_name; do
+  while IFS='|' read -r label worktree session_name screen_name expected_branch; do
     local file="$ATTACH_DIR/$label.command"
     if [[ -x "$file" ]]; then
       /usr/bin/open -a Terminal "$file" >/dev/null 2>&1 || true
@@ -218,7 +224,7 @@ prime_screens() {
     return 1
   fi
 
-  while IFS='|' read -r label worktree session_name screen_name; do
+  while IFS='|' read -r label worktree session_name screen_name expected_branch; do
     echo "Priming $label..."
     if ! PORTFOLIO_RC_MISSION="$MISSION_PROMPT" python3 "$primer" --screen "$screen_name" --label "$label" --timeout "$PRIME_TIMEOUT"; then
       echo "Prime failed for $label; attach manually with: TERM=xterm-256color screen -x $screen_name" >&2
@@ -287,7 +293,7 @@ check_push_auth() {
     failed=1
   fi
 
-  while IFS='|' read -r label worktree session_name screen_name; do
+  while IFS='|' read -r label worktree session_name screen_name expected_branch; do
     local branch
     branch="$(git -C "$worktree" branch --show-current 2>/dev/null || true)"
     if [[ -z "$branch" ]] || ! git -C "$worktree" push --dry-run origin "HEAD:refs/heads/$branch" >/dev/null 2>&1; then
@@ -314,7 +320,7 @@ stray_sessions() {
 
   while IFS='|' read -r pid found_session; do
     expected_worktree=""
-    while IFS='|' read -r label worktree session_name screen_name; do
+    while IFS='|' read -r label worktree session_name screen_name expected_branch; do
       if [[ "$found_session" == "$session_name" ]]; then
         expected_worktree="$worktree"
         break
@@ -345,6 +351,17 @@ dirty_count() {
   fi
 }
 
+unpushed_count() {
+  local worktree="$1"
+  local count
+
+  if count="$(git -C "$worktree" rev-list --count '@{u}..HEAD' 2>/dev/null)"; then
+    echo "${count:-0}"
+  else
+    echo unknown
+  fi
+}
+
 caffeinate_processes() {
   ps axww -o pid= -o command= | awk '
     {
@@ -371,7 +388,7 @@ status() {
   printf "%s\n" "$screen_listing" | grep -E 'claude-(merchant-intel|font-render|orchestration)-rc' || true
 
   echo
-  while IFS='|' read -r label worktree session_name screen_name; do
+  while IFS='|' read -r label worktree session_name screen_name expected_branch; do
     local process_ok=0
     local screen_ok=0
     local log_ok=0
@@ -397,9 +414,9 @@ status() {
 
     local dirty unpushed cadence
     dirty="$(dirty_count "$worktree")"
-    unpushed="$(git -C "$worktree" rev-list --count '@{u}..HEAD' 2>/dev/null || echo 0)"
+    unpushed="$(unpushed_count "$worktree")"
     cadence=ok
-    if [[ "${dirty:-0}" -gt "$DIRTY_WARN" || "${unpushed:-0}" -gt 0 ]]; then
+    if [[ "${dirty:-0}" -gt "$DIRTY_WARN" || "$unpushed" == "unknown" || "$unpushed" -gt 0 ]]; then
       cadence=DRIFT
     fi
 
@@ -432,6 +449,7 @@ status() {
 command="${1:-launch}"
 case "$command" in
   launch)
+    require_prereqs
     cleanup_targets
     check_push_auth || echo "  (continuing launch; fix push auth before the agents try to push)" >&2
     start_screens
@@ -447,6 +465,7 @@ case "$command" in
     fi
     ;;
   start)
+    require_prereqs
     cleanup_targets
     start_screens
     ensure_caffeinate

--- a/.codex/skills/portfolio-remote-control/scripts/prime_claude_screen.py
+++ b/.codex/skills/portfolio-remote-control/scripts/prime_claude_screen.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+import argparse
+import fcntl
+import os
+import pty
+import re
+import select
+import signal
+import struct
+import subprocess
+import sys
+import termios
+import time
+
+DEFAULT_MISSION = (
+    "Read CONTEXT.md then CHARTER.md in this worktree. They hold the full context "
+    "from the session that set this branch up plus your specific mission. Follow "
+    "the charter milestones in order and self-review with codex along the way "
+    "exactly as CONTEXT.md mandates. Begin with milestone 1 now."
+)
+
+ANSI_RE = re.compile(
+    rb"\x1b\[[0-9;?]*[ -/]*[@-~]"
+    rb"|\x1b\][^\x07]*(?:\x07|\x1b\\)"
+    rb"|\x1b[@-_]"
+)
+
+
+def strip_control(data: bytes) -> str:
+    data = ANSI_RE.sub(b"", data)
+    data = data.replace(b"\x00", b"")
+    return data.decode("utf-8", errors="ignore")
+
+
+def set_winsize(fd: int, rows: int = 40, cols: int = 140) -> None:
+    size = struct.pack("HHHH", rows, cols, 0, 0)
+    fcntl.ioctl(fd, termios.TIOCSWINSZ, size)
+
+
+def write_all(fd: int, data: bytes) -> None:
+    total = 0
+    while total < len(data):
+        total += os.write(fd, data[total:])
+
+
+def send_line(fd: int, text: str) -> None:
+    write_all(fd, text.encode("utf-8") + b"\r")
+
+
+def send_mission(fd: int, mission: str) -> None:
+    payload = b"\x1b[200~" + mission.encode("utf-8") + b"\x1b[201~"
+    write_all(fd, payload)
+    time.sleep(0.5)
+    write_all(fd, b"\r")
+
+
+def attach_and_prime(screen_name: str, label: str, mission: str, timeout: float, post_wait: float) -> int:
+    master, slave = pty.openpty()
+    set_winsize(slave)
+
+    env = os.environ.copy()
+    if env.get("TERM", "") in ("", "dumb"):
+        env["TERM"] = "xterm-256color"
+
+    proc = subprocess.Popen(
+        ["/usr/bin/screen", "-x", screen_name],
+        stdin=slave,
+        stdout=slave,
+        stderr=slave,
+        close_fds=True,
+        preexec_fn=os.setsid,
+        env=env,
+    )
+    os.close(slave)
+
+    flags = fcntl.fcntl(master, fcntl.F_GETFL)
+    fcntl.fcntl(master, fcntl.F_SETFL, flags | os.O_NONBLOCK)
+
+    buffer = b""
+    deadline = time.monotonic() + timeout
+    last_action = 0.0
+    sent_bypass = False
+    sent_fullscreen = False
+    sent_trust = False
+    submitted = False
+    submitted_at = 0.0
+
+    print(f"[{label}] attached to {screen_name}", file=sys.stderr)
+
+    try:
+        while time.monotonic() < deadline:
+            readable, _, _ = select.select([master], [], [], 0.25)
+            if readable:
+                try:
+                    chunk = os.read(master, 8192)
+                except BlockingIOError:
+                    chunk = b""
+                if chunk:
+                    buffer = (buffer + chunk)[-60000:]
+
+            if proc.poll() is not None:
+                print(f"[{label}] screen client exited before priming finished", file=sys.stderr)
+                sample = strip_control(buffer[-2000:])
+                if sample.strip():
+                    print(f"[{label}] recent screen text:\n{sample[-1200:]}", file=sys.stderr)
+                return 1
+
+            plain = strip_control(buffer).lower()
+            now = time.monotonic()
+
+            if not sent_bypass and (
+                "bypass permissions" in plain
+                or "warning: claude code running" in plain
+                or "yes, i accept" in plain
+            ):
+                send_line(master, "2")
+                sent_bypass = True
+                last_action = now
+                print(f"[{label}] accepted bypass warning with numeric 2", file=sys.stderr)
+                time.sleep(1.0)
+                continue
+
+            if not sent_fullscreen and "fullscreen" in plain and ("renderer" in plain or "try" in plain):
+                send_line(master, "2")
+                sent_fullscreen = True
+                last_action = now
+                print(f"[{label}] declined fullscreen renderer prompt with numeric 2", file=sys.stderr)
+                time.sleep(1.0)
+                continue
+
+            if not sent_trust and "trust" in plain and ("folder" in plain or "workspace" in plain or "files in this" in plain):
+                send_line(master, "1")
+                sent_trust = True
+                last_action = now
+                print(f"[{label}] accepted folder trust prompt", file=sys.stderr)
+                time.sleep(1.0)
+                continue
+
+            remote_active = "/remote-control is active" in plain or "remote-control is active" in plain
+            readyish = remote_active or ("remote control" in plain and "active" in plain)
+            if not submitted and readyish and now - last_action > 1.5:
+                time.sleep(0.8)
+                send_mission(master, mission)
+                submitted = True
+                submitted_at = time.monotonic()
+                print(f"[{label}] pasted mission prompt and submitted it", file=sys.stderr)
+                continue
+
+            if submitted and now - submitted_at >= post_wait:
+                write_all(master, b"\x01d")
+                time.sleep(0.5)
+                print(f"[{label}] detached after post-submit wait", file=sys.stderr)
+                return 0
+
+        if submitted:
+            write_all(master, b"\x01d")
+            time.sleep(0.5)
+            print(f"[{label}] detached after timeout; prompt had been submitted", file=sys.stderr)
+            return 0
+
+        sample = strip_control(buffer[-4000:])
+        print(f"[{label}] timed out before detecting a ready remote-control prompt", file=sys.stderr)
+        if sample.strip():
+            print(f"[{label}] recent screen text:\n{sample[-1200:]}", file=sys.stderr)
+        return 1
+    finally:
+        try:
+            if proc.poll() is None:
+                write_all(master, b"\x01d")
+                time.sleep(0.2)
+        except OSError:
+            pass
+        try:
+            os.close(master)
+        except OSError:
+            pass
+        if proc.poll() is None:
+            try:
+                os.killpg(proc.pid, signal.SIGTERM)
+            except OSError:
+                pass
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Prime a Claude Code remote-control screen through a real PTY.")
+    parser.add_argument("--screen", required=True, help="screen session name to attach to")
+    parser.add_argument("--label", default="claude", help="label for log messages")
+    parser.add_argument("--mission", default=os.environ.get("PORTFOLIO_RC_MISSION", DEFAULT_MISSION))
+    parser.add_argument("--timeout", type=float, default=180.0)
+    parser.add_argument("--post-wait", type=float, default=14.0)
+    args = parser.parse_args()
+
+    return attach_and_prime(args.screen, args.label, args.mission, args.timeout, args.post_wait)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,25 @@
+# Branch Context
+
+## Workflow Rule For This Branch
+
+For the rest of this branch, work in milestone-sized units. At each
+milestone, follow this order:
+
+1. Make the entire intended milestone visible in the diff. For any new
+   files, stage them or mark them intent-to-add with `git add -N` before
+   review. Then run Codex on the current diff:
+
+   ```bash
+   git diff HEAD | codex exec --skip-git-repo-check "<focused review naming the change and the invariant it must hold; ask only for real HIGH/MEDIUM>"
+   ```
+
+2. Address every HIGH or MEDIUM finding and re-run Codex until it
+   returns none.
+3. Only then commit the milestone.
+4. Push immediately after each milestone commit.
+
+Never commit or push milestone work that has not passed a clean Codex
+review over all staged, unstaged, and new files included in that milestone,
+and do not accumulate large uncommitted WIP between milestones. The earlier
+one-time WIP commit and push was only a backup and does not replace this
+review-first cadence going forward.


### PR DESCRIPTION
## Summary
- Add a Codex skill source for launching the three Portfolio Claude remote-control sessions.
- Add a Claude Code skills-dir plugin copy with the same runbook and helper scripts.
- Encode the reliable screen/PTY workflow, bypass prompt handling, bracketed paste submission, Terminal attachers, caffeinate keep-awake, and status verification.

## Validation
- `python3 ~/.codex/skills/.system/skill-creator/scripts/quick_validate.py .codex/skills/portfolio-remote-control`
- `claude plugin validate .claude/skills/portfolio-remote-control`
- `python3 -m py_compile` on both primer scripts
- `bash -n` on both launch scripts
- Fake `screen` primer test for bypass prompt, mission paste, submit, and detach

## Notes
- Existing local installed copies remain available under `~/.codex/skills/portfolio-remote-control` and `~/.claude/skills/portfolio-remote-control`.
- The PR stages only the new skill sources; existing untracked local worktree/cache directories were left alone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new remote-control workflow to launch and manage three concurrent Portfolio sessions from one command, with automated priming and keep-awake handling.
  * Added enhanced status/verification (process + screen presence, log evidence scanning, and cadence/drift detection) plus improved cleanup of expected targets.

* **Documentation**
  * Added skill runbooks and a Codex runbook detailing startup, verification, manual PTY fallback, and troubleshooting.
  * Added a branch-specific milestone workflow context describing how to run and gate Codex review before committing/pushing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->