### PR TITLE
feat(synthetic-replay): allow on-demand training (default off-spot)

### DIFF
--- a/infra/label_evaluator_step_functions/step_function_states.py
+++ b/infra/label_evaluator_step_functions/step_function_states.py
@@ -138,7 +138,7 @@ def build_input_normalization_states(
                 "synthetic_replay_max_instance_count": (
                     runtime.synthetic_replay_max_instance_count
                 ),
-                "synthetic_replay_use_spot": True,
+                "synthetic_replay_use_spot": False,
                 "synthetic_replay_max_runtime_hours": (
                     runtime.synthetic_replay_max_runtime_hours
                 ),
@@ -533,10 +533,6 @@ def build_synthetic_replay_states(
                             "NumericLessThanEqualsPath": (
                                 "$.defaults.synthetic_replay_max_instance_count"
                             ),
-                        },
-                        {
-                            "Variable": "$.config.merged.synthetic_replay_use_spot",
-                            "BooleanEquals": True,
                         },
                         {
                             "Variable": (

--- a/infra/sagemaker_training/component.py
+++ b/infra/sagemaker_training/component.py
@@ -721,10 +721,10 @@ def handler(event, context):
 
     instance_type = event.get("instance_type", "ml.g5.xlarge")
     instance_count = _int_value("instance_count", event.get("instance_count", 1))
-    use_spot = event.get(
-        "use_spot",
-        True if is_synthetic_replay else False,
-    )
+    # Default to on-demand; synthetic replay no longer *requires* spot.
+    # On-demand g5.xlarge provisions immediately (spot capacity is scarce and
+    # can queue for the full wait window). Callers may still pass use_spot=true.
+    use_spot = _truthy(event.get("use_spot", False))
     max_runtime_hours = _int_value(
         "max_runtime_hours",
         event.get("max_runtime_hours", 1 if is_synthetic_replay else 24),
@@ -747,8 +747,6 @@ def handler(event, context):
             raise ValueError("synthetic replay requires 1-3 source receipts")
         if instance_count != 1:
             raise ValueError("synthetic replay is capped at one SageMaker instance")
-        if not _truthy(use_spot):
-            raise ValueError("synthetic replay requires managed spot training")
         if max_runtime_hours > 1:
             raise ValueError("synthetic replay is capped at one runtime hour")
         _require_synthetic_replay_budget(event)

--- a/scripts/verify_synthetic_replay.py
+++ b/scripts/verify_synthetic_replay.py
@@ -218,8 +218,6 @@ def validate_start_args(args: argparse.Namespace) -> None:
         raise RuntimeError("--limit must be between 1 and 3 for this smoke test")
     if args.instance_count != 1:
         raise RuntimeError("--instance-count must be 1 for synthetic replay")
-    if not args.use_spot:
-        raise RuntimeError("synthetic replay requires managed spot: omit --no-spot")
     if args.max_runtime_hours > 1:
         raise RuntimeError("--max-runtime-hours must be 1 or less")
     if args.epochs is not None and args.epochs > 1:
@@ -5622,7 +5620,7 @@ def build_parser() -> argparse.ArgumentParser:
     start.add_argument("--early-stopping-patience", type=int, default=1)
     start.add_argument("--instance-type", default="ml.g5.xlarge")
     start.add_argument("--instance-count", type=int, default=1)
-    start.add_argument("--use-spot", dest="use_spot", action="store_true", default=True)
+    start.add_argument("--use-spot", dest="use_spot", action="store_true", default=False)
     start.add_argument("--no-spot", dest="use_spot", action="store_false")
     start.add_argument("--max-runtime-hours", type=int, default=1)
     start.add_argument(

--- a/tests/test_sagemaker_train_command.py
+++ b/tests/test_sagemaker_train_command.py
@@ -67,7 +67,7 @@ def test_start_training_lambda_can_promote_pattern_builder_output():
     ) in component_source
     assert 'event.get("synthetic_replay_cost_ack")' in component_source
     assert "synthetic replay requires 1-3 source receipts" in component_source
-    assert "synthetic replay requires managed spot training" in component_source
+    assert "synthetic replay requires managed spot training" not in component_source
     assert "synthetic replay is capped at one runtime hour" in component_source
     assert "synthetic replay is capped at one epoch" in component_source
     assert "ce:GetCostAndUsage" in component_source

--- a/tests/test_synthetic_replay_step_function.py
+++ b/tests/test_synthetic_replay_step_function.py
@@ -60,10 +60,11 @@ def test_definition_adds_synthetic_replay_launch_when_training_lambda_exists():
         "Variable": "$.config.merged.limit",
         "NumericLessThanEqualsPath": "$.defaults.synthetic_replay_max_limit",
     } in replay_conditions
+    # On-demand is allowed: the replay gate no longer requires managed spot.
     assert {
         "Variable": "$.config.merged.synthetic_replay_use_spot",
         "BooleanEquals": True,
-    } in replay_conditions
+    } not in replay_conditions
     assert {
         "Variable": "$.config.merged.synthetic_replay_max_runtime_hours",
         "NumericLessThanEqualsPath": ("$.defaults.synthetic_replay_max_runtime_hours"),

--- a/tests/test_verify_synthetic_replay_start_safety.py
+++ b/tests/test_verify_synthetic_replay_start_safety.py
@@ -41,7 +41,6 @@ def _valid_args(**overrides):
         ("limit", None, "--limit"),
         ("limit", 4, "--limit"),
         ("instance_count", 2, "--instance-count"),
-        ("use_spot", False, "managed spot"),
         ("max_runtime_hours", 2, "--max-runtime-hours"),
         ("epochs", 2, "--epochs"),
     ],


### PR DESCRIPTION
## Why
Spot `g5.xlarge` capacity queues badly — during the SyntheticTrainingSet E2E, both jobs sat in `SecondaryStatus: Starting` for 30+ min waiting on spot, with $0 billed but no progress. The team runs synthetic-replay **on-demand** (on-demand `g5.xlarge` quota is 2 and provisions in minutes).

## What
Removes the hard *requires managed spot* requirement and defaults to on-demand across the full path:
- **start-training Lambda** (`infra/sagemaker_training/component.py`): drop the `use_spot` requirement; default `use_spot=False`, normalize via `_truthy`. `CheckpointConfig` stays spot-only (only needed for spot interruption recovery).
- **Step Function** (`step_function_states.py`): default `synthetic_replay_use_spot=False` + remove the Choice condition that required `use_spot==True` before `StartSyntheticReplayTraining`. **All other caps unchanged** (limit 1-3, instance_count, runtime hours).
- **CLI** (`verify_synthetic_replay.py`): drop the 'requires managed spot' guard; default `--use-spot` off (still overridable).

Callers may still opt into spot with `use_spot=true`. Other cost guards (baseline_job_ref, cost_ack, 1 instance, ≤1hr, ≤1 epoch, monthly spend circuit-breaker) are untouched.

## Tests
Updated 3 tests that encoded the old spot requirement; `16 passed`. Reviewed by codex (runtime wiring consistent end-to-end; CheckpointConfig omission on-demand is fine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)