### PR TITLE
feat(glyph-rendering): style-aware glyph atlas + thermal-realistic receipt renderer

### DIFF
--- a/CHARTER.md
+++ b/CHARTER.md
@@ -1,0 +1,65 @@
+# Branch charter — `feat/receipt-glyph-rendering`
+
+Branches off `integration/synthesis-next` (has #994 font analysis, font-render's
+renderer + font profiles, merchant-intel's research/taxonomy, the tax gate).
+Read `CONTEXT.md` first for the shared session context + cadence.
+
+## Goal
+Render synthesized receipts using each receipt's **actual letterforms** — a
+per-merchant **glyph atlas** built from the real letter crops — **style-aware**
+so intra-receipt font variation is reproduced, with an **embedding-matched
+thermal/POS TTF fallback** for characters the atlas lacks. Build on #994's
+`receipt_upload/receipt_upload/font_letter_analysis.py` + `font_analysis.py`
+and `rendering/` (font-render). This is **review-realism only** — the structured
+receipt (tokens+boxes+labels) stays the only training artifact; image-training is
+OUT (no CoreML v3). Realistic renders make human review sharper.
+
+## Resolve FIRST (empirically): do receipts have multiple fonts within them?
+Almost certainly yes (header vs body vs totals vs bold; #994 reports
+`style_label_counts` with multiple styles per merchant). Confirm with data:
+per receipt, how many distinct letter styles/regions, with examples. The atlas
+MUST be keyed by style/region, not one font per merchant.
+
+## Milestones (review-first cadence; see CONTEXT.md)
+- **M1 — Style-aware glyph atlas.** From a merchant's real receipts, cluster
+  labeled letter crops by style/region (header / body / totals / bold) using
+  #994's letter analysis + its style labels. Build `{style -> {char -> glyph
+  image}}`. Report the intra-receipt style variation you find.
+- **M2 — Glyph-stamping renderer.** Render a synthesized receipt by compositing
+  the real glyph crops, picking the atlas style by each line's role (header line
+  -> header glyphs, TOTAL -> totals glyphs, item -> body glyphs). Add a
+  thermal-paper background + light noise for photo-realism. Emit real-vs-synthetic
+  comparisons. Extends `rendering/`; do not change the existing geometry renderer's
+  contract.
+- **M3 — Embedding-matched TTF fallback.** For chars absent from the atlas, pick
+  the nearest thermal/POS TTF by letter-crop embedding similarity (reuse #994's
+  Chroma letter embeddings; optionally a HF vision embedder — DINOv2 or CLIP —
+  over glyph crops; DeepFont is the reference but is NOT trained on thermal fonts,
+  so use HF models as the *embedder*, not a turnkey classifier). Render missing
+  glyphs from the matched TTF at atlas scale.
+- **M4 — Realism evaluation + review gallery.** Render a sample across operations
+  (add-item, remove, field-replace) and 2-3 merchants; iterate to convincing
+  realism; produce a side-by-side gallery.
+
+## Review is DUAL — code AND images (mandatory)
+- **Code:** codex-review each milestone diff before committing (the cadence).
+- **Images:** this output is visual — a visual review is REQUIRED.
+  1. After each render milestone, **Read the rendered PNGs yourself** (you are
+     multimodal — actually look at them) and critique realism vs the real receipt
+     image; iterate until convincing. Do NOT declare "realistic" without looking.
+  2. Save a sample gallery and surface it for human review (`SendUserFile` the
+     comparison PNGs). If your codex build accepts image input, attach a sample
+     render for an independent visual critique; otherwise state that the human
+     reviews the gallery and codex reviewed the code.
+
+## Boundaries (do NOT touch)
+- Synthesis gates / tax config / `data_loader.py` / `merchant_research/`. You
+  consume their outputs; you don't change them.
+- Own: a NEW glyph-rendering module under `rendering/` (atlas + glyph renderer +
+  TTF fallback + realism eval) + a render CLI/extension.
+
+## Acceptance
+A synthesized Vons add-item receipt rendered with the glyph atlas is, at a glance,
+hard to tell from a real Vons receipt (same letterforms), and intra-receipt style
+variation is reproduced (header differs from body as on the real). Code green;
+codex-reviewed; images visually reviewed (gallery surfaced).

--- a/docs/glyph-atlas-style-findings.md
+++ b/docs/glyph-atlas-style-findings.md
@@ -1,0 +1,106 @@
+# Glyph atlas — intra-receipt style findings (M0/M1)
+
+> Branch: `feat/receipt-glyph-rendering`. Builds on PR #994's letter/line font
+> analysis. This is **review-realism only** — the atlas is DATA consumed by the
+> glyph renderer; it never feeds or relaxes a training gate (see CHARTER.md).
+
+## The question the charter told us to resolve first
+
+> "Do receipts have multiple fonts within them? Almost certainly yes (header vs
+> body vs totals vs bold)."
+
+We resolved it empirically against real Vons receipts (dev table
+`ReceiptsTable-dc5be22`) before designing the atlas, using #994's letter- and
+line-level clustering **and by looking at the receipt images directly**.
+
+## What the data actually shows
+
+The "header / body / totals / bold = four fonts" framing is **not** what real
+Vons receipts contain. On the densest Vons receipt (image `d38424eb…`, 1247
+letters):
+
+1. **The body is one monospace family.** Items, prices, addresses, the
+   `Price / You Pay` column headers, and the `TAX` / `BALANCE` totals block are
+   all the same face at the same size. Letter-level #994 clustering keeps the
+   whole receipt as **one cluster** from `eps=0.78` down to `eps=0.32`; only at
+   `eps=0.25` does it shatter into 3 noisy, non-semantic groups. **Totals are
+   not a distinct font.**
+
+2. **The only genuine in-body variation is a bold weight**, applied to whole
+   lines — the `Member Savings -X.XX` promo lines and the category section
+   headers (`GROCERY`, `PRODUCE`, `LIQUOR`). The letterforms are identical; the
+   ink is heavier. #994's *letter* vectors are character-centered and miss this;
+   #994's *line* clustering **does** separate those lines (the line signature
+   carries ink/stroke aggregates) — e.g. line clusters `lc3`/`lc5` are exactly
+   the `Member Savings` lines.
+
+3. **A logo wordmark (`VONS`) sits at the top** — height `0.047` normalized vs a
+   body median of `~0.0135` (≈3.5×). It is a large display mark, effectively a
+   fixed image, not glyph-composable body text.
+
+Visual confirmation (the receipt crops are in the review gallery): the `VONS`
+mark is a heavy custom wordmark; the address block and every line item share one
+clean thermal monospace; the `Member Savings` lines are visibly bolder.
+
+## How the atlas is keyed (consequence)
+
+`GlyphAtlas` is keyed by **weight tier**, not by header/body/totals:
+
+- `body` — the dominant regular monospace (covers items, prices, **totals**,
+  addresses, column headers).
+- `bold` — the heavier weight, derived at the **line** level: a line whose
+  median ink_ratio exceeds the receipt's body-ink baseline by ≥`1.18×` is bold.
+  Reported in `variation_report()` so a reviewer sees the separation that
+  justified it. Absent → noted, atlas is single-weight.
+- The **logo** is captured separately as an image asset (`atlas.logo`), cropped
+  from the tallest top line (≥`1.9×` body height); its glyphs are excluded from
+  the per-char styles.
+
+This stays generic: a merchant that genuinely prints a second *face* forms a
+second #994 letter cluster, which the builder keeps as its own `clusterN` style;
+a merchant that only varies weight (the common case) gets the regular/bold split
+the builder derives at the line level. The atlas retains the **actual ink crops**
+(ink-as-alpha RGBA, tight to content) so the renderer stamps real letterforms.
+
+## Atlas aggregate (real Vons, 6 receipts)
+
+`build_glyph_atlas_from_dynamo("ReceiptsTable-dc5be22", "Vons", max_receipts=6)`
+→ `variation_report()`:
+
+| field | value |
+|---|---|
+| receipts | 6 |
+| #994 letter clusters (median) | **1** (single face — confirms the finding) |
+| logo | present, text `VONS.` |
+| chars covered | 76 |
+| `body` style | 2054 glyph samples, 171 lines, 75 distinct chars, median ink 0.117 |
+| `bold` style | 645 glyph samples, 64 lines, 60 distinct chars, median ink **0.180** |
+
+The bold ink ratio (0.180) is ~1.5x the body baseline (0.117) — a clean,
+well-separated weight tier, exactly the `Member Savings` / section-header lines.
+
+### Crop quality guards (why the stamped glyphs are single letterforms)
+
+The atlas must stamp ONE letterform per cell, so the extractor rejects merged
+crops with three layered guards (a visual review of the first build caught
+neighbor-bleed doubles and whole-word crops like `Main:` / `questions`):
+
+1. **Tight crop, zero horizontal pad** — `_glyph_crop_bounds` crops to the OCR
+   letter box and never expands sideways into the neighbor glyph.
+2. **Box-size guards** — skip any letter whose box is wider than `2.4x` the
+   receipt median *and* above an absolute `0.055` normalized ceiling (a receipt
+   that mis-segments most letters into word boxes inflates its own median, so
+   the absolute ceiling is the backstop), or taller than the logo cut.
+3. **Glyph-aspect guard** — after extraction, reject any glyph wider than `1.7x`
+   its height; removes multi-char / horizontal-streak crops the box guards miss.
+   Char-agnostic (no punctuation exemption) so it leaves no merge hole: on real
+   thermal receipts a tight-ink hyphen / equals crop measures only ~1.1-1.6
+   aspect (the mark is thick), so it passes the guard on its own.
+
+Representatives are then ordered cleanest-first by nearest-median **aspect** (a
+bled crop is wider, so it sorts last) and height, so `glyph_for()` returns the
+cleanest variant.
+
+Ink polarity is decided from the crop's **border ring** (the background), not a
+global minority-class count, so a dense or bold glyph that has more ink than
+paper is not wrongly inverted.

--- a/docs/glyph-atlas-style-findings.md
+++ b/docs/glyph-atlas-style-findings.md
@@ -104,3 +104,41 @@ cleanest variant.
 Ink polarity is decided from the crop's **border ring** (the background), not a
 global minority-class count, so a dense or bold glyph that has more ink than
 paper is not wrongly inverted.
+
+## Rendering (M2) + TTF fallback (M3)
+
+`glyph_renderer.render_receipt_glyphs(receipt, atlas, fallback=…)` stamps a
+synthesized receipt with the atlas's real glyph crops:
+
+- It reuses `receipt_renderer`'s coordinate helpers (`_to_pixel_box`,
+  `_detect_coord_max`, `_iter_words`), so the **geometry contract is unchanged** —
+  only glyph drawing is swapped (generic TTF → real-crop stamping).
+- Per line it picks **body vs bold** (line ink / emphasis hints) and stamps the
+  real **logo wordmark** on the genuine display-height `MERCHANT_NAME` line.
+- Each glyph is rescaled by its own height-relative-to-style-median (clamped to
+  `[0.5, 1.0]`, which removes per-instance jitter), bottom-aligned to the word
+  baseline, and **width-fitted to its monospace cell** so glyphs never bleed into
+  neighbours. A thermal-paper background + light speckle/blur complete the look.
+
+What looking at the renders caught (and fixed): neighbour-glyph **slivers** that
+stamped as stray strokes between letters (now trimmed at extraction, see above);
+glyph **overlap** from missing cell width-fit; and the logo stamping over footer
+lines (now gated on display height). After those, re-stamping a real Vons
+receipt's own tokens is recognizable as the real receipt at a glance — same
+letterforms, with the logo / body / bold variation reproduced.
+
+`glyph_ttf_fallback.make_ttf_fallback(atlas)` covers characters the atlas lacks:
+it picks the monospace TTF whose glyphs best match the merchant's real glyphs
+(mean cosine over a small normalized ink vector) and renders missing chars from
+it at atlas scale. On the real Vons atlas it selects Andale Mono / PT Mono over
+serif Courier — a sensible thermal-ish match. This is a **pixel-embedding** match,
+not a learned DINOv2/DeepFont one (those need weights unavailable here); a learned
+embedder drops into the `score_font` hook without touching callers.
+
+### Honest residual limits
+
+- Letter *rhythm* is good at a glance but not pixel-perfect: the body font is
+  treated as monospace (it nearly is), so proportional nuance is approximated.
+- A few low-sample glyphs (e.g. a bold `a`) render faint; more receipts per
+  atlas would supply cleaner representatives.
+- The fallback is visual-similarity, not a learned font embedding (scoped above).

--- a/receipt_agent/receipt_agent/agents/label_evaluator/rendering/__init__.py
+++ b/receipt_agent/receipt_agent/agents/label_evaluator/rendering/__init__.py
@@ -26,6 +26,17 @@ from receipt_agent.agents.label_evaluator.rendering.glyph_atlas import (
     load_atlas,
     save_atlas,
 )
+from receipt_agent.agents.label_evaluator.rendering.glyph_renderer import (
+    GlyphRenderConfig,
+    render_real_vs_glyph,
+    render_receipt_glyphs,
+    save_receipt_glyphs,
+)
+from receipt_agent.agents.label_evaluator.rendering.glyph_ttf_fallback import (
+    FontMatch,
+    make_ttf_fallback,
+    match_fallback_font,
+)
 from receipt_agent.agents.label_evaluator.rendering.receipt_renderer import (
     RenderConfig,
     render_real_vs_synthetic,
@@ -51,4 +62,11 @@ __all__ = [
     "extract_glyph_image",
     "save_atlas",
     "load_atlas",
+    "GlyphRenderConfig",
+    "render_receipt_glyphs",
+    "render_real_vs_glyph",
+    "save_receipt_glyphs",
+    "FontMatch",
+    "make_ttf_fallback",
+    "match_fallback_font",
 ]

--- a/receipt_agent/receipt_agent/agents/label_evaluator/rendering/__init__.py
+++ b/receipt_agent/receipt_agent/agents/label_evaluator/rendering/__init__.py
@@ -16,6 +16,16 @@ from receipt_agent.agents.label_evaluator.rendering.font_profile import (
     build_merchant_font_profile_from_dynamo,
     extract_receipt_font_profile,
 )
+from receipt_agent.agents.label_evaluator.rendering.glyph_atlas import (
+    AtlasStyle,
+    GlyphAtlas,
+    GlyphCrop,
+    build_glyph_atlas,
+    build_glyph_atlas_from_dynamo,
+    extract_glyph_image,
+    load_atlas,
+    save_atlas,
+)
 from receipt_agent.agents.label_evaluator.rendering.receipt_renderer import (
     RenderConfig,
     render_real_vs_synthetic,
@@ -33,4 +43,12 @@ __all__ = [
     "render_receipt",
     "render_real_vs_synthetic",
     "save_receipt_png",
+    "AtlasStyle",
+    "GlyphAtlas",
+    "GlyphCrop",
+    "build_glyph_atlas",
+    "build_glyph_atlas_from_dynamo",
+    "extract_glyph_image",
+    "save_atlas",
+    "load_atlas",
 ]

--- a/receipt_agent/receipt_agent/agents/label_evaluator/rendering/glyph_atlas.py
+++ b/receipt_agent/receipt_agent/agents/label_evaluator/rendering/glyph_atlas.py
@@ -310,13 +310,16 @@ def extract_glyph_image(
     y_origin: str = "bottom_left",
     expand_x_ratio: float = 0.0,
     expand_y_ratio: float = 0.12,
+    trim_edge_slivers: bool = True,
 ) -> Image.Image | None:
     """Crop one letterform from the raw receipt as ink-on-transparent RGBA.
 
     Crops tight to the OCR letter box (no horizontal neighbor pad), then converts
     to alpha where alpha encodes ink darkness (paper -> transparent) and tightens
     to the ink bbox so the renderer can place it by content. The antialiased ink
-    edge is preserved. Returns ``None`` when the crop has no usable ink.
+    edge is preserved. ``trim_edge_slivers`` drops a thin detached neighbour-glyph
+    sliver at the left/right edge (see :func:`_trim_edge_slivers`). Returns
+    ``None`` when the crop has no usable ink.
     """
     bounds = _glyph_crop_bounds(
         box,
@@ -366,9 +369,66 @@ def extract_glyph_image(
     if alpha.width < 1 or alpha.height < 1:
         return None
 
+    if trim_edge_slivers:
+        alpha = _trim_edge_slivers(alpha)
+        if alpha is None:
+            return None
+
     glyph = Image.new("RGBA", alpha.size, (0, 0, 0, 0))
     glyph.putalpha(alpha)
     return glyph
+
+
+def _trim_edge_slivers(alpha: Image.Image) -> Image.Image | None:
+    """Drop thin detached ink columns at the left/right edge of a glyph crop.
+
+    OCR letter boxes can overlap a neighbour by a pixel or two, leaving a thin
+    vertical sliver of the next glyph in the crop; stamped, those read as stray
+    strokes between letters. The crop is split into runs of ink-bearing columns
+    separated by blank columns; a *leading or trailing* run that is much narrower
+    than the widest run is a sliver and is trimmed. Interior structure is left
+    alone, and characters whose parts split only *vertically* (``i``, ``:``,
+    ``%``, ``=``) are a single column-run, so they are never touched.
+    """
+    width, height = alpha.size
+    if width < 3:
+        return alpha
+    px = alpha.load()
+    col_ink = [
+        any(px[x, y] >= _MIN_INK_ALPHA for y in range(height))
+        for x in range(width)
+    ]
+    runs: list[tuple[int, int]] = []
+    start = None
+    for x, has in enumerate(col_ink):
+        if has and start is None:
+            start = x
+        elif not has and start is not None:
+            runs.append((start, x - 1))
+            start = None
+    if start is not None:
+        runs.append((start, width - 1))
+    if len(runs) <= 1:
+        return alpha
+
+    widest = max(run[1] - run[0] + 1 for run in runs)
+    sliver_max = max(2, int(widest * 0.30))
+
+    def is_sliver(run: tuple[int, int]) -> bool:
+        # A sliver is narrow AND separated from the main mass; require the gap to
+        # the neighbour run to be real (>=1 blank col, already guaranteed).
+        return (run[1] - run[0] + 1) <= sliver_max
+
+    keep = list(runs)
+    while len(keep) > 1 and is_sliver(keep[0]):
+        keep.pop(0)
+    while len(keep) > 1 and is_sliver(keep[-1]):
+        keep.pop()
+    left = keep[0][0]
+    right = keep[-1][1]
+    if left == 0 and right == width - 1:
+        return alpha
+    return alpha.crop((left, 0, right + 1, height))
 
 
 def _border_median(gray: Image.Image) -> float:

--- a/receipt_agent/receipt_agent/agents/label_evaluator/rendering/glyph_atlas.py
+++ b/receipt_agent/receipt_agent/agents/label_evaluator/rendering/glyph_atlas.py
@@ -1033,11 +1033,15 @@ def _logo_match_score(text: str, merchant_name: str) -> float:
     merchant_tokens = _merchant_tokens(merchant_name)
     if logo_tokens and merchant_tokens:
         if merchant_tokens[:len(logo_tokens)] == logo_tokens:
-            return 1.0
+            if len(logo_tokens) >= 2 or len(merchant_tokens) == 1:
+                return 1.0
 
         merchant_set = set(merchant_tokens)
         matches = [token for token in logo_tokens if token in merchant_set]
         if matches:
+            if len(logo_tokens) == 1 and len(merchant_tokens) > 1:
+                merchant_chars = sum(len(token) for token in merchant_tokens)
+                return len(matches[0]) / max(merchant_chars, 1)
             token_coverage = len(matches) / max(len(logo_tokens), 1)
             matched = sum(len(token) for token in matches)
             logo_chars = sum(len(token) for token in logo_tokens)

--- a/receipt_agent/receipt_agent/agents/label_evaluator/rendering/glyph_atlas.py
+++ b/receipt_agent/receipt_agent/agents/label_evaluator/rendering/glyph_atlas.py
@@ -133,6 +133,19 @@ _MAX_GLYPH_ASPECT = 1.7
 # Drop near-transparent paper noise below this alpha when building a glyph.
 _MIN_INK_ALPHA = 24
 
+# Horizontal pad for body glyph crops. The OCR letter box is sometimes a pixel
+# tight on the round side of a capital (D / O / G), clipping the right bowl so it
+# reads open (D->C). A hair of pad recovers that edge; kept tiny (0.02) so it
+# pulls in at most a 1-2px neighbour sliver, which the area-aware edge-sliver
+# trim then removes. Larger pads (0.04+) drag in ink-heavy neighbour fragments
+# that survive the trim and stamp as raised specks, so this stays small.
+_BODY_GLYPH_EXPAND_X = 0.02
+
+# An edge column-run is trimmed as a neighbour sliver only if it carries at most
+# this share of the glyph's ink (in addition to being narrow). A detached letter
+# bowl exceeds this and is kept; a thin neighbour fragment falls under it.
+_SLIVER_MAX_INK_FRAC = 0.18
+
 
 @dataclass(frozen=True)
 class GlyphCrop:
@@ -399,19 +412,24 @@ def _trim_edge_slivers(alpha: Image.Image) -> Image.Image | None:
     OCR letter boxes can overlap a neighbour by a pixel or two, leaving a thin
     vertical sliver of the next glyph in the crop; stamped, those read as stray
     strokes between letters. The crop is split into runs of ink-bearing columns
-    separated by blank columns; a *leading or trailing* run that is much narrower
-    than the widest run is a sliver and is trimmed. Interior structure is left
-    alone, and characters whose parts split only *vertically* (``i``, ``:``,
-    ``%``, ``=``) are a single column-run, so they are never touched.
+    separated by blank columns; a *leading or trailing* run that is both much
+    narrower than the widest run AND carries only a sliver of the total ink is a
+    neighbour fragment and is trimmed. The ink-area guard is what keeps a round
+    letter's *detached* right bowl (D / O / G, whose top/bottom join faded on
+    thermal print): the bowl is a narrow column run but a substantial share of the
+    glyph's ink, so it survives where a 1-2px neighbour edge does not. Interior
+    structure is left alone, and characters whose parts split only *vertically*
+    (``i``, ``:``, ``%``, ``=``) are a single column-run, so they are untouched.
     """
     width, height = alpha.size
     if width < 3:
         return alpha
     px = alpha.load()
-    col_ink = [
-        any(px[x, y] >= _MIN_INK_ALPHA for y in range(height))
+    col_count = [
+        sum(1 for y in range(height) if px[x, y] >= _MIN_INK_ALPHA)
         for x in range(width)
     ]
+    col_ink = [c > 0 for c in col_count]
     runs: list[tuple[int, int]] = []
     start = None
     for x, has in enumerate(col_ink):
@@ -427,11 +445,15 @@ def _trim_edge_slivers(alpha: Image.Image) -> Image.Image | None:
 
     widest = max(run[1] - run[0] + 1 for run in runs)
     sliver_max = max(2, int(widest * 0.30))
+    total_ink = sum(col_count) or 1
 
     def is_sliver(run: tuple[int, int]) -> bool:
-        # A sliver is narrow AND separated from the main mass; require the gap to
-        # the neighbour run to be real (>=1 blank col, already guaranteed).
-        return (run[1] - run[0] + 1) <= sliver_max
+        # Narrow AND ink-light: a neighbour fragment is a few columns carrying a
+        # tiny share of the ink. A detached letter bowl is narrow too but ink-
+        # heavy, so the area guard spares it.
+        narrow = (run[1] - run[0] + 1) <= sliver_max
+        light = sum(col_count[run[0] : run[1] + 1]) <= total_ink * _SLIVER_MAX_INK_FRAC
+        return narrow and light
 
     keep = list(runs)
     while len(keep) > 1 and is_sliver(keep[0]):
@@ -591,7 +613,10 @@ def build_glyph_atlas(
             if height_cap is not None and box["height"] >= height_cap:
                 continue  # stray display-size glyph on a body line
             glyph_image = extract_glyph_image(
-                raw_image, box, y_origin=image_y_origin
+                raw_image,
+                box,
+                y_origin=image_y_origin,
+                expand_x_ratio=_BODY_GLYPH_EXPAND_X,
             )
             if glyph_image is None:
                 continue

--- a/receipt_agent/receipt_agent/agents/label_evaluator/rendering/glyph_atlas.py
+++ b/receipt_agent/receipt_agent/agents/label_evaluator/rendering/glyph_atlas.py
@@ -970,8 +970,13 @@ def _capture_logo(
         raw_image,
         union,
         y_origin=y_origin,
-        expand_x_ratio=0.02,
-        expand_y_ratio=0.08,
+        expand_x_ratio=0.06,
+        expand_y_ratio=0.12,
+        # A wordmark is a multi-letter graphic, NOT a single glyph: the
+        # edge-sliver trim (meant to drop a neighbour-bleed column) was
+        # clipping the leading/trailing letter (SPROUTS -> PROUT, the heart
+        # in CVS). Keep the full mark.
+        trim_edge_slivers=False,
     )
     if image is None:
         return None

--- a/receipt_agent/receipt_agent/agents/label_evaluator/rendering/glyph_atlas.py
+++ b/receipt_agent/receipt_agent/agents/label_evaluator/rendering/glyph_atlas.py
@@ -1,0 +1,981 @@
+"""Style-aware glyph atlas built from a merchant's real receipt letter crops.
+
+Milestone M1 of the glyph-rendering charter. A :class:`GlyphAtlas` holds the
+*actual letterform crops* a merchant prints — one library of real ink glyphs,
+keyed by visual *style* so a renderer can stamp a synthesized receipt in the
+merchant's own font instead of a generic monospace.
+
+What the data actually shows (resolved empirically before this was written, see
+``docs/glyph-atlas-style-findings.md``)
+----------------------------------------------------------------------------
+The charter's working assumption was that a receipt mixes several fonts
+(header / body / totals / bold). Looking at real Vons receipts plus #994's
+letter- and line-level clustering, that is **not** what the data shows:
+
+* The body is **one monospace family**. Items, prices, addresses, column
+  headers and the totals block are all the same face at the same size — the
+  totals are *not* a distinct font.
+* The only genuine intra-receipt variation is a **bold weight** applied to whole
+  lines (the "Member Savings" promo lines and category section headers). #994's
+  *letter*-level clustering collapses this to one cluster (same letterforms,
+  heavier ink); #994's *line*-level clustering separates those lines because the
+  line signature carries ink/stroke aggregates.
+* A **logo wordmark** ("VONS") sits at the top — a large display mark, ~3.5x the
+  body height, effectively a fixed image rather than glyph-composable text.
+
+So the atlas is keyed by **weight tier** (``body`` regular vs ``bold``), with the
+logo captured separately as an image asset. This keeps the structure honest to
+the data and generic: a merchant that genuinely prints a second face will form a
+second #994 letter cluster, which :func:`build_glyph_atlas` keeps as its own
+style; a merchant that only varies weight (the common case) gets the
+regular/bold split this module derives at the line level.
+
+Organizing principle (CHARTER.md): this is *review-realism only*. The atlas is
+DATA consumed by the renderer; it never feeds or relaxes a training gate.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from collections import defaultdict
+from dataclasses import dataclass, field
+from statistics import median
+from typing import Any, Iterable, Mapping, Sequence
+
+
+def _ensure_receipt_upload_on_path() -> None:
+    """Make the sibling ``receipt_upload`` package importable (see font_profile)."""
+    try:  # pragma: no cover - fast path when already importable
+        import receipt_upload.font_letter_analysis  # noqa: F401
+
+        return
+    except ImportError:
+        pass
+    repo_root = os.path.abspath(
+        os.path.join(os.path.dirname(__file__), *([os.pardir] * 5))
+    )
+    candidate = os.path.join(repo_root, "receipt_upload")
+    if candidate not in sys.path:
+        sys.path.insert(0, candidate)
+    cached = sys.modules.get("receipt_upload")
+    if cached is not None and getattr(cached, "__file__", None) is None:
+        del sys.modules["receipt_upload"]
+
+
+_ensure_receipt_upload_on_path()
+
+from PIL import Image, ImageOps  # noqa: E402
+
+from receipt_upload.font_analysis import (  # noqa: E402
+    _coerce_image,
+    _is_normalized_box,
+    _otsu_threshold,
+)
+from receipt_upload.font_letter_analysis import (  # noqa: E402
+    LetterImageSample,
+    build_letter_image_samples,
+    cluster_letter_styles,
+)
+
+_EPSILON = 1e-9
+
+# --------------------------------------------------------------------------- #
+# tunables (documented; conservative)
+# --------------------------------------------------------------------------- #
+
+# A line whose median ink_ratio exceeds the receipt body baseline by this factor
+# is treated as a *bold* line. Heuristic — bold is a per-line decision because
+# that is how receipts apply it (whole promo / section-header lines). Reported in
+# the variation report so a reviewer can see the separation that justified it.
+_BOLD_INK_FACTOR = 1.18
+
+# A line whose median glyph height exceeds the body median by this factor is a
+# display / logo line, not body text; its glyphs are excluded from the per-char
+# styles and the line is captured as a logo image asset instead.
+_LOGO_HEIGHT_FACTOR = 1.9
+
+# Cap stored crops per (style, char) to bound atlas size; representatives are
+# chosen nearest the style's median glyph height.
+_MAX_VARIANTS_PER_CHAR = 8
+
+# Skip any "letter" whose box is wider than this multiple of the receipt's median
+# glyph width — those are whole-word / merged OCR boxes, not single glyphs. The
+# relative cap is paired with an absolute normalized ceiling because a receipt
+# whose OCR mis-segments most letters into word boxes inflates its own median.
+_MAX_LETTER_WIDTH_FACTOR = 2.4
+_MAX_LETTER_WIDTH_NORM = 0.055
+
+# Reject an extracted glyph whose ink is wider than this multiple of its height.
+# Single characters top out around 1.3-1.6 ('W', 'M', '%'); anything wider is a
+# multi-char / horizontal-streak crop. Char-agnostic, so it catches merged crops
+# the box guards miss (e.g. a per-receipt median that is itself inflated).
+# Punctuation does NOT need an exemption: on real thermal receipts a tight-ink
+# hyphen / equals crop measures ~1.1-1.6 aspect (the mark is thick), so it passes
+# this guard on its own — and a char-agnostic guard keeps no merge hole open.
+_MAX_GLYPH_ASPECT = 1.7
+
+# Drop near-transparent paper noise below this alpha when building a glyph.
+_MIN_INK_ALPHA = 24
+
+
+@dataclass(frozen=True)
+class GlyphCrop:
+    """A single real letterform crop, ink-on-transparent, tight to content."""
+
+    char: str
+    normalized_char: str
+    image: Image.Image  # RGBA, ink alpha; black ink (recolorable by renderer)
+    width: int
+    height: int
+    aspect: float  # content width / height
+    ink_ratio: float
+    box_height_norm: float  # normalized receipt height — scale reference
+    source_image_id: str | None
+    source_receipt_id: int | None
+    sample_id: str
+
+
+@dataclass(frozen=True)
+class AtlasStyle:
+    """One visual style in the atlas: a library of real glyph crops by char."""
+
+    style_id: str  # "body", "bold", or "cluster<N>" for extra #994 faces
+    weight: str  # "regular" | "bold"
+    glyphs: Mapping[str, tuple[GlyphCrop, ...]]  # normalized_char -> crops
+    sample_count: int
+    line_count: int
+    median_box_height: float
+    median_ink_ratio: float
+    y_span: tuple[float, float]
+    cluster_label: str  # #994 descriptive label for the dominant face
+
+    def chars(self) -> set[str]:
+        return set(self.glyphs)
+
+    def glyph_for(
+        self, char: str, *, index: int = 0
+    ) -> GlyphCrop | None:
+        crops = self.glyphs.get(_norm_char(char))
+        if not crops:
+            return None
+        return crops[index % len(crops)]
+
+
+@dataclass(frozen=True)
+class GlyphAtlas:
+    """A merchant's style-aware library of real glyph crops."""
+
+    merchant_name: str
+    receipt_count: int
+    styles: Mapping[str, AtlasStyle]
+    logo: Image.Image | None
+    logo_text: str | None
+    letter_cluster_count: int  # #994 letter-style clusters observed (median)
+    notes: tuple[str, ...] = ()
+
+    # ----- lookup -----
+    def style_for_role(
+        self, role: str = "body", *, bold: bool = False
+    ) -> AtlasStyle | None:
+        """Pick the atlas style for a line role.
+
+        ``role`` is a coarse semantic hint (``header`` / ``body`` / ``total`` /
+        ``item``). Empirically only weight separates body text, so this maps to
+        the ``bold`` style when ``bold`` is requested and one exists, else
+        ``body``. ``header`` falls back to body glyphs (the logo is a separate
+        image asset, not glyph-composed).
+        """
+        if bold and "bold" in self.styles:
+            return self.styles["bold"]
+        if "body" in self.styles:
+            return self.styles["body"]
+        # Degenerate atlas: return the largest style by sample count.
+        if not self.styles:
+            return None
+        return max(self.styles.values(), key=lambda s: s.sample_count)
+
+    def glyph(
+        self,
+        char: str,
+        *,
+        role: str = "body",
+        bold: bool = False,
+        index: int = 0,
+    ) -> GlyphCrop | None:
+        style = self.style_for_role(role, bold=bold)
+        if style is None:
+            return None
+        crop = style.glyph_for(char, index=index)
+        if crop is None and bold:  # bold lacks this char -> body fallback
+            body = self.styles.get("body")
+            if body is not None:
+                crop = body.glyph_for(char, index=index)
+        return crop
+
+    def covered_chars(self) -> set[str]:
+        chars: set[str] = set()
+        for style in self.styles.values():
+            chars |= style.chars()
+        return chars
+
+    # ----- reporting -----
+    def variation_report(self) -> dict[str, Any]:
+        """Human-readable summary of the intra-receipt style variation found."""
+        return {
+            "merchant_name": self.merchant_name,
+            "receipt_count": self.receipt_count,
+            "letter_cluster_count_median": self.letter_cluster_count,
+            "logo_present": self.logo is not None,
+            "logo_text": self.logo_text,
+            "covered_char_count": len(self.covered_chars()),
+            "styles": {
+                style_id: {
+                    "weight": style.weight,
+                    "samples": style.sample_count,
+                    "lines": style.line_count,
+                    "distinct_chars": len(style.chars()),
+                    "median_box_height": round(style.median_box_height, 5),
+                    "median_ink_ratio": round(style.median_ink_ratio, 4),
+                    "y_span": [round(v, 3) for v in style.y_span],
+                    "cluster_label": style.cluster_label,
+                }
+                for style_id, style in sorted(self.styles.items())
+            },
+            "notes": list(self.notes),
+        }
+
+
+# --------------------------------------------------------------------------- #
+# glyph crop extraction
+# --------------------------------------------------------------------------- #
+
+
+def _glyph_crop_bounds(
+    box: Mapping[str, float],
+    *,
+    image_size: tuple[int, int],
+    y_origin: str,
+    expand_x_ratio: float,
+    expand_y_ratio: float,
+) -> tuple[int, int, int, int] | None:
+    """Pixel bounds for a glyph crop.
+
+    Unlike #994's ``_image_crop_bounds`` (which forces a >=2px pad on every side
+    to capture neighborhood context for *feature* extraction), this expands by a
+    fraction of the box and defaults to **zero horizontal expansion** — letter
+    advances are tight, so any horizontal pad bleeds the neighbor glyph into the
+    crop. A small vertical pad recovers ascenders/descenders the OCR box clips.
+    """
+    image_width, image_height = image_size
+    x, y = box["x"], box["y"]
+    width = max(box["width"], _EPSILON)
+    height = max(box["height"], _EPSILON)
+    if _is_normalized_box(box):
+        left = x * image_width
+        right = (x + width) * image_width
+        if y_origin == "bottom_left":
+            top = (1.0 - y - height) * image_height
+            bottom = (1.0 - y) * image_height
+        else:
+            top = y * image_height
+            bottom = (y + height) * image_height
+    else:
+        left = x
+        right = x + width
+        if y_origin == "bottom_left":
+            top = image_height - y - height
+            bottom = image_height - y
+        else:
+            top = y
+            bottom = y + height
+    crop_w = max(right - left, 1.0)
+    crop_h = max(bottom - top, 1.0)
+    ex = crop_w * expand_x_ratio
+    ey = crop_h * expand_y_ratio
+    left = max(0, int(round(left - ex)))
+    top = max(0, int(round(top - ey)))
+    right = min(image_width, int(round(right + ex)))
+    bottom = min(image_height, int(round(bottom + ey)))
+    if right <= left or bottom <= top:
+        return None
+    return (left, top, right, bottom)
+
+
+def extract_glyph_image(
+    raw_image: Image.Image,
+    box: Mapping[str, float],
+    *,
+    y_origin: str = "bottom_left",
+    expand_x_ratio: float = 0.0,
+    expand_y_ratio: float = 0.12,
+) -> Image.Image | None:
+    """Crop one letterform from the raw receipt as ink-on-transparent RGBA.
+
+    Crops tight to the OCR letter box (no horizontal neighbor pad), then converts
+    to alpha where alpha encodes ink darkness (paper -> transparent) and tightens
+    to the ink bbox so the renderer can place it by content. The antialiased ink
+    edge is preserved. Returns ``None`` when the crop has no usable ink.
+    """
+    bounds = _glyph_crop_bounds(
+        box,
+        image_size=raw_image.size,
+        y_origin=y_origin,
+        expand_x_ratio=expand_x_ratio,
+        expand_y_ratio=expand_y_ratio,
+    )
+    if bounds is None:
+        return None
+    crop = raw_image.crop(bounds)
+    if crop.width < 2 or crop.height < 2:
+        return None
+
+    gray = ImageOps.autocontrast(ImageOps.grayscale(crop))
+    pixels = list(gray.getdata())
+    if not pixels:
+        return None
+    threshold = _otsu_threshold(pixels)
+
+    # Decide ink polarity from the BACKGROUND, not a global minority count: a
+    # dense or bold glyph can have more ink than paper, so "ink = minority" would
+    # wrongly flip it and turn paper into opaque ink. The crop's border ring is
+    # overwhelmingly paper (the vertical pad guarantees paper top/bottom rows
+    # even when a glyph touches the left/right edges); if that border is dark,
+    # the scan is inverted (light ink on dark paper) and we flip so paper -> ~255.
+    if _border_median(gray) <= threshold:
+        gray = ImageOps.invert(gray)
+        pixels = list(gray.getdata())
+        threshold = _otsu_threshold(pixels)
+
+    # alpha = ink darkness = 255 - gray; zero out paper-bright pixels + faint noise.
+    alpha_pixels = bytearray(len(pixels))
+    cutoff = min(255, threshold + 1)
+    for i, value in enumerate(pixels):
+        if value >= cutoff:
+            continue
+        a = 255 - value
+        if a >= _MIN_INK_ALPHA:
+            alpha_pixels[i] = a
+    alpha = Image.frombytes("L", gray.size, bytes(alpha_pixels))
+
+    ink_bbox = alpha.getbbox()
+    if ink_bbox is None:
+        return None
+    alpha = alpha.crop(ink_bbox)
+    if alpha.width < 1 or alpha.height < 1:
+        return None
+
+    glyph = Image.new("RGBA", alpha.size, (0, 0, 0, 0))
+    glyph.putalpha(alpha)
+    return glyph
+
+
+def _border_median(gray: Image.Image) -> float:
+    """Median gray of the crop's 1px border ring (its background sample)."""
+    width, height = gray.size
+    px = gray.load()
+    values: list[int] = []
+    for x in range(width):
+        values.append(px[x, 0])
+        values.append(px[x, height - 1])
+    for y in range(height):
+        values.append(px[0, y])
+        values.append(px[width - 1, y])
+    if not values:
+        return 255.0
+    return float(median(values))
+
+
+# --------------------------------------------------------------------------- #
+# atlas construction
+# --------------------------------------------------------------------------- #
+
+
+@dataclass
+class _ReceiptInput:
+    image_id: str | None
+    receipt_id: int | None
+    letters: Sequence[Any]
+    raw_image: Any
+
+
+def build_glyph_atlas(
+    receipts: Iterable[Mapping[str, Any] | _ReceiptInput],
+    merchant_name: str,
+    *,
+    image_y_origin: str = "bottom_left",
+    eps: float = 0.78,
+    min_samples: int = 5,
+    min_letters_per_line: int = 3,
+    max_variants_per_char: int = _MAX_VARIANTS_PER_CHAR,
+    bold_ink_factor: float = _BOLD_INK_FACTOR,
+    logo_height_factor: float = _LOGO_HEIGHT_FACTOR,
+    max_letter_width_factor: float = _MAX_LETTER_WIDTH_FACTOR,
+    max_glyph_aspect: float = _MAX_GLYPH_ASPECT,
+) -> GlyphAtlas | None:
+    """Build a style-aware glyph atlas from real receipts.
+
+    ``receipts`` is an iterable of ``{"image_id", "receipt_id", "letters",
+    "raw_image"}`` mappings (``raw_image`` a PIL image or anything #994 can
+    coerce). Pure / testable — the Dynamo wiring lives in
+    :func:`build_glyph_atlas_from_dynamo`.
+    """
+    # style_id -> normalized_char -> list[GlyphCrop]
+    style_glyphs: dict[str, dict[str, list[GlyphCrop]]] = defaultdict(
+        lambda: defaultdict(list)
+    )
+    style_samples: dict[str, list[LetterImageSample]] = defaultdict(list)
+    style_lines: dict[str, set[tuple[Any, int]]] = defaultdict(set)
+    style_labels: dict[str, list[str]] = defaultdict(list)
+    cluster_counts: list[int] = []
+    logo: Image.Image | None = None
+    logo_text: str | None = None
+    logo_height = 0.0
+    receipts_used = 0
+    notes: list[str] = []
+
+    for entry in receipts:
+        image_id, receipt_id, letters, raw = _unpack_receipt(entry)
+        if not letters or raw is None:
+            continue
+        try:
+            raw_image = _coerce_image(raw)
+        except Exception:  # noqa: BLE001 - a bad image must not sink the atlas
+            continue
+        samples = build_letter_image_samples(
+            letters, raw_image=raw_image, image_y_origin=image_y_origin
+        )
+        if not samples:
+            continue
+        receipts_used += 1
+
+        analysis = cluster_letter_styles(
+            samples, eps=eps, min_samples=min_samples
+        )
+        cluster_counts.append(max(1, len(analysis.clusters)))
+
+        body_height = _median([s.metrics.get("box_height", 0.0) for s in samples])
+        body_width = _median([s.metrics.get("box_width", 0.0) for s in samples])
+        # Some OCR "letters" carry a whole-word (or line) box; cropping those
+        # yields a multi-char blob that would double-ink stamped text. Skip any
+        # letter whose box is far wider/taller than the receipt's median glyph.
+        width_cap = (
+            min(body_width * max_letter_width_factor, _MAX_LETTER_WIDTH_NORM)
+            if body_width > 0
+            else _MAX_LETTER_WIDTH_NORM
+        )
+        height_cap = (
+            body_height * logo_height_factor if body_height > 0 else None
+        )
+        line_groups = _group_by_line(samples)
+        line_tier = _classify_lines(
+            line_groups,
+            body_height=body_height,
+            bold_ink_factor=bold_ink_factor,
+            logo_height_factor=logo_height_factor,
+        )
+
+        # Capture the tallest logo line as an image asset (best across receipts).
+        for line_key, tier in line_tier.items():
+            if tier != "logo":
+                continue
+            line_samples = line_groups[line_key]
+            lh = _median([s.metrics.get("box_height", 0.0) for s in line_samples])
+            if lh <= logo_height:
+                continue
+            captured = _capture_logo(
+                line_samples, raw_image, image_y_origin
+            )
+            if captured is not None:
+                logo, logo_text = captured
+                logo_height = lh
+
+        # Assign each sample to a weight-tier style and stamp its real glyph.
+        # Style id is the line tier (body / bold) only — #994 letter clusters are
+        # NOT used as style ids because DBSCAN cluster ids are local to each
+        # receipt's clustering, so they cannot be aggregated across receipts into
+        # one merchant atlas (same id != same face). The cluster *label* is kept
+        # for description; a >1-cluster merchant is flagged in notes as needing
+        # global cross-receipt clustering (future work).
+        cluster_label_by_id: dict[int, str] = {
+            c.cluster_id: c.label for c in analysis.clusters
+        }
+        for sample in samples:
+            line_key = (sample.image_id, sample.line_id)
+            tier = line_tier.get(line_key, "body")
+            if tier == "logo":
+                continue  # display mark, not a body glyph
+            box = _box_from_metrics(sample.metrics)
+            if box is None:
+                continue
+            if box["width"] > width_cap:
+                continue  # whole-word / merged box, not a single glyph
+            if height_cap is not None and box["height"] >= height_cap:
+                continue  # stray display-size glyph on a body line
+            glyph_image = extract_glyph_image(
+                raw_image, box, y_origin=image_y_origin
+            )
+            if glyph_image is None:
+                continue
+            if glyph_image.width > glyph_image.height * max_glyph_aspect:
+                continue  # multi-char / streak crop the box guards missed
+            style_id = "bold" if tier == "bold" else "body"
+            cluster_id = analysis.cluster_for_sample(sample.sample_id)
+            crop = GlyphCrop(
+                char=sample.text,
+                normalized_char=sample.normalized_char,
+                image=glyph_image,
+                width=glyph_image.width,
+                height=glyph_image.height,
+                aspect=glyph_image.width / max(glyph_image.height, 1),
+                ink_ratio=float(sample.metrics.get("ink_ratio", 0.0)),
+                box_height_norm=float(sample.metrics.get("box_height", 0.0)),
+                source_image_id=sample.image_id,
+                source_receipt_id=sample.receipt_id,
+                sample_id=sample.sample_id,
+            )
+            style_glyphs[style_id][sample.normalized_char].append(crop)
+            style_samples[style_id].append(sample)
+            style_lines[style_id].add(line_key)
+            label = (
+                cluster_label_by_id.get(cluster_id, "")
+                if cluster_id is not None
+                else ""
+            )
+            if label:
+                style_labels[style_id].append(label)
+
+    if receipts_used == 0 or not style_glyphs:
+        return None
+
+    styles = _finalize_styles(
+        style_glyphs,
+        style_samples,
+        style_lines,
+        style_labels,
+        max_variants_per_char=max_variants_per_char,
+    )
+    if "bold" not in styles:
+        notes.append(
+            "no bold weight tier separated; receipt(s) appear single-weight"
+        )
+    if logo is None:
+        notes.append("no logo/display line detected above body height")
+    median_clusters = int(_median(cluster_counts)) if cluster_counts else 1
+    if median_clusters > 1:
+        notes.append(
+            f"#994 letter clustering found >1 face (median {median_clusters}); "
+            "this atlas keys by weight only — a genuinely multi-face merchant "
+            "needs global cross-receipt clustering to separate faces (future work)"
+        )
+
+    return GlyphAtlas(
+        merchant_name=merchant_name,
+        receipt_count=receipts_used,
+        styles=styles,
+        logo=logo,
+        logo_text=logo_text,
+        letter_cluster_count=median_clusters,
+        notes=tuple(notes),
+    )
+
+
+def build_glyph_atlas_from_dynamo(
+    table_name: str,
+    merchant_name: str,
+    *,
+    region: str = "us-east-1",
+    max_receipts: int | None = 8,
+    image_y_origin: str = "bottom_left",
+    **atlas_kwargs: Any,
+) -> GlyphAtlas | None:
+    """Build a merchant glyph atlas from real receipts in Dynamo/S3.
+
+    Resolves receipts via :class:`ReceiptPlace` (``ReceiptMetadata`` is
+    deprecated), loads letters + the raw receipt crop per receipt, and delegates
+    to :func:`build_glyph_atlas`. ``max_receipts`` bounds the S3 image pulls.
+    """
+    from receipt_dynamo.data.dynamo_client import DynamoClient
+    from receipt_upload.font_analysis import load_raw_image_from_s3
+
+    client = DynamoClient(table_name=table_name, region=region)
+    places, _ = client.get_receipt_places_by_merchant(merchant_name)
+    seen: set[tuple[str, int]] = set()
+    targets: list[tuple[str, int]] = []
+    for place in places:
+        key = (str(place.image_id), int(place.receipt_id))
+        if key in seen:
+            continue
+        seen.add(key)
+        targets.append(key)
+    if max_receipts is not None:
+        targets = targets[:max_receipts]
+
+    receipt_inputs: list[_ReceiptInput] = []
+    for image_id, receipt_id in targets:
+        try:
+            details = client.get_image_details(image_id)
+            letters = [
+                letter
+                for letter in details.receipt_letters
+                if letter.receipt_id == receipt_id
+            ]
+            if not letters:
+                continue
+            receipt = next(
+                (
+                    candidate
+                    for candidate in details.receipts
+                    if candidate.receipt_id == receipt_id
+                ),
+                None,
+            )
+            if receipt is None:
+                continue
+            raw_image = load_raw_image_from_s3(receipt)
+        except Exception:  # noqa: BLE001 - one bad receipt must not abort
+            continue
+        receipt_inputs.append(
+            _ReceiptInput(
+                image_id=image_id,
+                receipt_id=receipt_id,
+                letters=letters,
+                raw_image=raw_image,
+            )
+        )
+
+    return build_glyph_atlas(
+        receipt_inputs,
+        merchant_name,
+        image_y_origin=image_y_origin,
+        **atlas_kwargs,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# persistence (so M2/M3 reuse an atlas without re-fetching)
+# --------------------------------------------------------------------------- #
+
+
+def save_atlas(atlas: GlyphAtlas, directory: str) -> str:
+    """Persist an atlas as PNG glyph crops + an ``atlas.json`` index."""
+    os.makedirs(directory, exist_ok=True)
+    index: dict[str, Any] = {
+        "merchant_name": atlas.merchant_name,
+        "receipt_count": atlas.receipt_count,
+        "letter_cluster_count": atlas.letter_cluster_count,
+        "logo_text": atlas.logo_text,
+        "logo_file": None,
+        "notes": list(atlas.notes),
+        "styles": {},
+    }
+    if atlas.logo is not None:
+        logo_file = "logo.png"
+        atlas.logo.save(os.path.join(directory, logo_file))
+        index["logo_file"] = logo_file
+
+    for style_id, style in atlas.styles.items():
+        style_dir = os.path.join(directory, style_id)
+        os.makedirs(style_dir, exist_ok=True)
+        glyph_index: dict[str, list[dict[str, Any]]] = {}
+        for char, crops in style.glyphs.items():
+            entries = []
+            for i, crop in enumerate(crops):
+                fname = f"{_safe_char_name(char)}_{i}.png"
+                crop.image.save(os.path.join(style_dir, fname))
+                entries.append(
+                    {
+                        "file": fname,
+                        "char": crop.char,
+                        "aspect": round(crop.aspect, 4),
+                        "ink_ratio": round(crop.ink_ratio, 4),
+                        "box_height_norm": round(crop.box_height_norm, 5),
+                        "source_image_id": crop.source_image_id,
+                        "source_receipt_id": crop.source_receipt_id,
+                    }
+                )
+            glyph_index[char] = entries
+        index["styles"][style_id] = {
+            "weight": style.weight,
+            "sample_count": style.sample_count,
+            "line_count": style.line_count,
+            "median_box_height": round(style.median_box_height, 5),
+            "median_ink_ratio": round(style.median_ink_ratio, 4),
+            "y_span": list(style.y_span),
+            "cluster_label": style.cluster_label,
+            "glyphs": glyph_index,
+        }
+
+    path = os.path.join(directory, "atlas.json")
+    with open(path, "w", encoding="utf-8") as handle:
+        json.dump(index, handle, indent=2)
+    return path
+
+
+def load_atlas(directory: str) -> GlyphAtlas:
+    """Load an atlas previously written by :func:`save_atlas`."""
+    with open(os.path.join(directory, "atlas.json"), encoding="utf-8") as handle:
+        index = json.load(handle)
+
+    styles: dict[str, AtlasStyle] = {}
+    for style_id, raw_style in index.get("styles", {}).items():
+        style_dir = os.path.join(directory, style_id)
+        glyphs: dict[str, tuple[GlyphCrop, ...]] = {}
+        for char, entries in raw_style.get("glyphs", {}).items():
+            crops = []
+            for entry in entries:
+                image = Image.open(
+                    os.path.join(style_dir, entry["file"])
+                ).convert("RGBA")
+                image.load()
+                crops.append(
+                    GlyphCrop(
+                        char=entry["char"],
+                        normalized_char=char,
+                        image=image,
+                        width=image.width,
+                        height=image.height,
+                        aspect=float(entry["aspect"]),
+                        ink_ratio=float(entry["ink_ratio"]),
+                        box_height_norm=float(entry["box_height_norm"]),
+                        source_image_id=entry.get("source_image_id"),
+                        source_receipt_id=entry.get("source_receipt_id"),
+                        sample_id="",
+                    )
+                )
+            glyphs[char] = tuple(crops)
+        styles[style_id] = AtlasStyle(
+            style_id=style_id,
+            weight=raw_style["weight"],
+            glyphs=glyphs,
+            sample_count=raw_style["sample_count"],
+            line_count=raw_style["line_count"],
+            median_box_height=raw_style["median_box_height"],
+            median_ink_ratio=raw_style["median_ink_ratio"],
+            y_span=tuple(raw_style["y_span"]),
+            cluster_label=raw_style["cluster_label"],
+        )
+
+    logo = None
+    if index.get("logo_file"):
+        logo = Image.open(
+            os.path.join(directory, index["logo_file"])
+        ).convert("RGBA")
+        logo.load()
+
+    return GlyphAtlas(
+        merchant_name=index["merchant_name"],
+        receipt_count=index["receipt_count"],
+        styles=styles,
+        logo=logo,
+        logo_text=index.get("logo_text"),
+        letter_cluster_count=index.get("letter_cluster_count", 1),
+        notes=tuple(index.get("notes", ())),
+    )
+
+
+# --------------------------------------------------------------------------- #
+# internals
+# --------------------------------------------------------------------------- #
+
+
+def _unpack_receipt(
+    entry: Mapping[str, Any] | _ReceiptInput,
+) -> tuple[str | None, int | None, Sequence[Any], Any]:
+    if isinstance(entry, _ReceiptInput):
+        return entry.image_id, entry.receipt_id, entry.letters, entry.raw_image
+    return (
+        entry.get("image_id"),
+        entry.get("receipt_id"),
+        entry.get("letters") or (),
+        entry.get("raw_image"),
+    )
+
+
+def _group_by_line(
+    samples: Sequence[LetterImageSample],
+) -> dict[tuple[Any, int], list[LetterImageSample]]:
+    groups: dict[tuple[Any, int], list[LetterImageSample]] = defaultdict(list)
+    for sample in samples:
+        groups[(sample.image_id, sample.line_id)].append(sample)
+    return groups
+
+
+def _classify_lines(
+    line_groups: Mapping[tuple[Any, int], Sequence[LetterImageSample]],
+    *,
+    body_height: float,
+    bold_ink_factor: float,
+    logo_height_factor: float,
+) -> dict[tuple[Any, int], str]:
+    """Tag each line ``body`` / ``bold`` / ``logo`` from height + ink density.
+
+    Bold is decided relative to the receipt's *body* ink baseline (the median
+    over non-logo lines), so it is robust to overall scan darkness.
+    """
+    line_height: dict[tuple[Any, int], float] = {}
+    line_ink: dict[tuple[Any, int], float] = {}
+    for key, line_samples in line_groups.items():
+        line_height[key] = _median(
+            [s.metrics.get("box_height", 0.0) for s in line_samples]
+        )
+        line_ink[key] = _median(
+            [s.metrics.get("ink_ratio", 0.0) for s in line_samples]
+        )
+
+    logo_cut = body_height * logo_height_factor if body_height > 0 else None
+    tiers: dict[tuple[Any, int], str] = {}
+    body_inks: list[float] = []
+    for key in line_groups:
+        if logo_cut is not None and line_height[key] >= logo_cut:
+            tiers[key] = "logo"
+        else:
+            body_inks.append(line_ink[key])
+    body_ink_baseline = _median(body_inks) if body_inks else 0.0
+    bold_cut = body_ink_baseline * bold_ink_factor
+
+    for key in line_groups:
+        if tiers.get(key) == "logo":
+            continue
+        if bold_cut > 0 and line_ink[key] >= bold_cut:
+            tiers[key] = "bold"
+        else:
+            tiers[key] = "body"
+    return tiers
+
+
+def _box_from_metrics(metrics: Mapping[str, float]) -> dict[str, float] | None:
+    try:
+        return {
+            "x": float(metrics["box_x"]),
+            "y": float(metrics["box_y"]),
+            "width": max(float(metrics["box_width"]), _EPSILON),
+            "height": max(float(metrics["box_height"]), _EPSILON),
+        }
+    except (KeyError, TypeError, ValueError):
+        return None
+
+
+def _capture_logo(
+    line_samples: Sequence[LetterImageSample],
+    raw_image: Image.Image,
+    y_origin: str,
+) -> tuple[Image.Image, str] | None:
+    """Crop the union box of a display line as the logo image + its text."""
+    boxes = [_box_from_metrics(s.metrics) for s in line_samples]
+    boxes = [b for b in boxes if b is not None]
+    if not boxes:
+        return None
+    min_x = min(b["x"] for b in boxes)
+    min_y = min(b["y"] for b in boxes)
+    max_x = max(b["x"] + b["width"] for b in boxes)
+    max_y = max(b["y"] + b["height"] for b in boxes)
+    union = {
+        "x": min_x,
+        "y": min_y,
+        "width": max(max_x - min_x, _EPSILON),
+        "height": max(max_y - min_y, _EPSILON),
+    }
+    image = extract_glyph_image(
+        raw_image,
+        union,
+        y_origin=y_origin,
+        expand_x_ratio=0.02,
+        expand_y_ratio=0.08,
+    )
+    if image is None:
+        return None
+    ordered = sorted(
+        line_samples, key=lambda s: s.metrics.get("box_center_x", 0.0)
+    )
+    text = "".join(s.text for s in ordered)
+    return image, text
+
+
+def _finalize_styles(
+    style_glyphs: Mapping[str, Mapping[str, Sequence[GlyphCrop]]],
+    style_samples: Mapping[str, Sequence[LetterImageSample]],
+    style_lines: Mapping[str, set[tuple[Any, int]]],
+    style_labels: Mapping[str, Sequence[str]],
+    *,
+    max_variants_per_char: int,
+) -> dict[str, AtlasStyle]:
+    styles: dict[str, AtlasStyle] = {}
+    for style_id, char_map in style_glyphs.items():
+        samples = style_samples[style_id]
+        heights = [s.metrics.get("box_height", 0.0) for s in samples]
+        med_height = _median(heights)
+        capped: dict[str, tuple[GlyphCrop, ...]] = {}
+        for char, crops in char_map.items():
+            chosen = _select_representatives(
+                crops, med_height, max_variants_per_char
+            )
+            capped[char] = tuple(chosen)  # chosen[0] is the cleanest variant
+        ys = [s.metrics.get("box_center_y", 0.0) for s in samples]
+        styles[style_id] = AtlasStyle(
+            style_id=style_id,
+            weight="bold" if style_id == "bold" else "regular",
+            glyphs=capped,
+            sample_count=len(samples),
+            line_count=len(style_lines[style_id]),
+            median_box_height=med_height,
+            median_ink_ratio=_median(
+                [s.metrics.get("ink_ratio", 0.0) for s in samples]
+            ),
+            y_span=(min(ys), max(ys)) if ys else (0.0, 0.0),
+            cluster_label=_most_common(style_labels.get(style_id, ())) or "n/a",
+        )
+    return styles
+
+
+def _select_representatives(
+    crops: Sequence[GlyphCrop], target_height: float, limit: int
+) -> list[GlyphCrop]:
+    """Order crops cleanest-first and keep up to ``limit``.
+
+    "Cleanest" = nearest this char's *median* ink aspect (so a crop that bled a
+    neighbor glyph, which is wider, sorts last and never becomes the
+    representative) and nearest the style's median glyph height. Always sorted —
+    even under the cap — so ``chosen[0]`` is the best variant for stamping.
+    """
+    aspects = sorted(c.aspect for c in crops)
+    median_aspect = aspects[len(aspects) // 2]
+    target_h = target_height if target_height > 0 else (
+        median(c.box_height_norm for c in crops) if crops else 0.0
+    )
+
+    def rank(crop: GlyphCrop) -> tuple[float, float]:
+        aspect_dev = abs(crop.aspect - median_aspect) / max(median_aspect, 1e-6)
+        height_dev = abs(crop.box_height_norm - target_h) / max(target_h, 1e-6)
+        return (aspect_dev, height_dev)
+
+    ordered = sorted(crops, key=rank)
+    return ordered[:limit]
+
+
+def _median(values: Sequence[float]) -> float:
+    numbers = [float(v) for v in values if v is not None]
+    if not numbers:
+        return 0.0
+    return float(median(numbers))
+
+
+def _most_common(values: Sequence[str]) -> str | None:
+    if not values:
+        return None
+    counts: dict[str, int] = defaultdict(int)
+    for value in values:
+        counts[value] += 1
+    return max(counts.items(), key=lambda kv: kv[1])[0]
+
+
+def _norm_char(char: str) -> str:
+    # Mirror #994's _normalize_char (strip) so lookups match stored keys.
+    text = str(char).strip()
+    return text[:1] if text else text
+
+
+def _safe_char_name(char: str) -> str:
+    """Filesystem-safe name for a glyph char (handles ``/``, ``.``, etc.)."""
+    return "u%04x" % ord(char[0]) if char else "uempty"

--- a/receipt_agent/receipt_agent/agents/label_evaluator/rendering/glyph_atlas.py
+++ b/receipt_agent/receipt_agent/agents/label_evaluator/rendering/glyph_atlas.py
@@ -38,6 +38,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import sys
 from collections import defaultdict
 from dataclasses import dataclass, field
@@ -95,6 +96,19 @@ _BOLD_INK_FACTOR = 1.18
 # display / logo line, not body text; its glyphs are excluded from the per-char
 # styles and the line is captured as a logo image asset instead.
 _LOGO_HEIGHT_FACTOR = 1.9
+
+# A captured logo line must be the merchant wordmark, not a promo/coupon banner
+# (those are often the tallest text on the receipt). Reject lines whose text reads
+# as a promo, and prefer lines that match the merchant name.
+_PROMO_TERMS = frozenset({
+    "OFF", "SAVE", "SAVINGS", "SAVING", "COUPON", "REWARD", "REWARDS", "HOT",
+    "DEAL", "DEALS", "FREE", "BUY", "GET", "SCAN", "BONUS", "EARN", "SALE",
+    "EXTRABUCKS", "EXTRACARE", "POINTS", "MEMBER", "VALUE", "PROMO", "%",
+})
+_COMPACT_PROMO_PHRASES = frozenset({
+    "MEMBERSAVINGS", "MEMBERREWARDS", "HOTDEAL", "HOTDEALS", "BUYGET",
+    "BUYGETFREE", "SCANCOUPON", "SAVEBIG", "SAVEMORE", "YOUSAVED",
+})
 
 # Cap stored crops per (style, char) to bound atlas size; representatives are
 # chosen nearest the style's median glyph height.
@@ -489,9 +503,9 @@ def build_glyph_atlas(
     style_lines: dict[str, set[tuple[Any, int]]] = defaultdict(set)
     style_labels: dict[str, list[str]] = defaultdict(list)
     cluster_counts: list[int] = []
-    logo: Image.Image | None = None
-    logo_text: str | None = None
-    logo_height = 0.0
+    # (merchant_match_score, line_height, image, text) for each display line that
+    # is NOT a promo/coupon banner — the wordmark is chosen from these afterwards.
+    logo_candidates: list[tuple[float, float, "Image.Image", str]] = []
     receipts_used = 0
     notes: list[str] = []
 
@@ -536,20 +550,23 @@ def build_glyph_atlas(
             logo_height_factor=logo_height_factor,
         )
 
-        # Capture the tallest logo line as an image asset (best across receipts).
+        # Collect display lines as logo candidates, rejecting promo/coupon banners
+        # (often the tallest text on the receipt — e.g. Sprouts "$5 OFF $30").
         for line_key, tier in line_tier.items():
             if tier != "logo":
                 continue
             line_samples = line_groups[line_key]
             lh = _median([s.metrics.get("box_height", 0.0) for s in line_samples])
-            if lh <= logo_height:
+            captured = _capture_logo(line_samples, raw_image, image_y_origin)
+            if captured is None:
                 continue
-            captured = _capture_logo(
-                line_samples, raw_image, image_y_origin
+            image_crop, text = captured
+            score = _logo_match_score(text, merchant_name)
+            if _is_promo_text(text) and score < 0.75:
+                continue
+            logo_candidates.append(
+                (score, lh, image_crop, text)
             )
-            if captured is not None:
-                logo, logo_text = captured
-                logo_height = lh
 
         # Assign each sample to a weight-tier style and stamp its real glyph.
         # Style id is the line tier (body / bold) only — #994 letter clusters are
@@ -608,6 +625,18 @@ def build_glyph_atlas(
 
     if receipts_used == 0 or not style_glyphs:
         return None
+
+    # Choose the wordmark: highest merchant-name match, tie-broken by height. A
+    # promo-free tall line wins even if its OCR text is garbled (score 0).
+    logo, logo_text = (None, None)
+    if logo_candidates:
+        score, _, logo, logo_text = max(
+            logo_candidates, key=lambda c: (c[0], c[1])
+        )
+        if score == 0.0:
+            notes.append(
+                "logo wordmark chosen by height only (no merchant-name match)"
+            )
 
     styles = _finalize_styles(
         style_glyphs,
@@ -946,11 +975,95 @@ def _capture_logo(
     )
     if image is None:
         return None
+    text = _line_text_from_samples(line_samples)
+    return image, text
+
+
+def _line_text_from_samples(line_samples: Sequence[LetterImageSample]) -> str:
     ordered = sorted(
         line_samples, key=lambda s: s.metrics.get("box_center_x", 0.0)
     )
-    text = "".join(s.text for s in ordered)
-    return image, text
+    word_ids = {s.word_id for s in ordered if s.word_id >= 0}
+    if len(word_ids) <= 1:
+        return "".join(s.text for s in ordered)
+
+    grouped: dict[int, list[LetterImageSample]] = defaultdict(list)
+    for sample in ordered:
+        grouped[sample.word_id].append(sample)
+
+    words: list[str] = []
+    for _, samples in sorted(
+        grouped.items(),
+        key=lambda item: min(s.metrics.get("box_center_x", 0.0) for s in item[1]),
+    ):
+        letters = sorted(
+            samples,
+            key=lambda s: (
+                s.letter_id if s.letter_id >= 0 else 1_000_000,
+                s.metrics.get("box_center_x", 0.0),
+            ),
+        )
+        words.append("".join(s.text for s in letters))
+    return " ".join(word for word in words if word)
+
+
+def _is_promo_text(text: str) -> bool:
+    """Return True when a tall display line reads like an offer, not a logo."""
+    upper = str(text).upper()
+    tokens = set(re.findall(r"[A-Z]+", upper))
+    compact = _merchant_match_text(upper)
+    return (
+        "$" in upper
+        or "%" in upper
+        or bool(tokens & _PROMO_TERMS)
+        or any(phrase in compact for phrase in _COMPACT_PROMO_PHRASES)
+    )
+
+
+def _logo_match_score(text: str, merchant_name: str) -> float:
+    """Score how strongly a captured display line matches the merchant name."""
+    logo = _merchant_match_text(text)
+    merchant = _merchant_match_text(merchant_name)
+    if not logo or not merchant:
+        return 0.0
+    if logo == merchant:
+        return 1.0
+
+    logo_tokens = _merchant_tokens(text)
+    merchant_tokens = _merchant_tokens(merchant_name)
+    if logo_tokens and merchant_tokens:
+        if merchant_tokens[:len(logo_tokens)] == logo_tokens:
+            return 1.0
+
+        merchant_set = set(merchant_tokens)
+        matches = [token for token in logo_tokens if token in merchant_set]
+        if matches:
+            token_coverage = len(matches) / max(len(logo_tokens), 1)
+            matched = sum(len(token) for token in matches)
+            logo_chars = sum(len(token) for token in logo_tokens)
+            char_coverage = matched / max(logo_chars, 1)
+            return token_coverage * char_coverage
+
+    if logo in merchant or merchant in logo:
+        return min(len(logo), len(merchant)) / max(len(logo), len(merchant))
+
+    matches = [token for token in merchant_tokens if token and token in logo]
+    if not matches:
+        return 0.0
+    matched = sum(len(token) for token in matches)
+    return matched / max(len(merchant), 1)
+
+
+def _merchant_match_text(text: str) -> str:
+    return re.sub(r"[^A-Z0-9]+", "", str(text).upper())
+
+
+def _merchant_tokens(text: str) -> list[str]:
+    return [
+        token
+        for token in re.findall(r"[A-Z0-9]+", str(text).upper())
+        if len(token) >= 3
+    ]
 
 
 def _finalize_styles(
@@ -1005,12 +1118,28 @@ def _select_representatives(
         median(c.box_height_norm for c in crops) if crops else 0.0
     )
 
+    median_ink = median(c.ink_ratio for c in crops) if crops else 0.0
+
+    def aspect_dev(crop: GlyphCrop) -> float:
+        return abs(crop.aspect - median_aspect) / max(median_aspect, 1e-6)
+
     def rank(crop: GlyphCrop) -> tuple[float, float]:
-        aspect_dev = abs(crop.aspect - median_aspect) / max(median_aspect, 1e-6)
         height_dev = abs(crop.box_height_norm - target_h) / max(target_h, 1e-6)
-        return (aspect_dev, height_dev)
+        return (aspect_dev(crop), height_dev)
 
     ordered = sorted(crops, key=rank)
+    # Drop strong outliers — a doubled-strike / broken / neighbour-bled crop has a
+    # markedly different aspect or much heavier ink than the char's norm, and if
+    # it became a stored variant it would surface via variant rotation. Keep the
+    # consistent crops (always at least the single best one).
+    if len(ordered) > 2:
+        kept = [
+            c
+            for c in ordered
+            if aspect_dev(c) <= 0.5
+            and (median_ink <= 0 or c.ink_ratio <= median_ink * 1.6)
+        ]
+        ordered = kept or ordered[:1]
     return ordered[:limit]
 
 

--- a/receipt_agent/receipt_agent/agents/label_evaluator/rendering/glyph_renderer.py
+++ b/receipt_agent/receipt_agent/agents/label_evaluator/rendering/glyph_renderer.py
@@ -65,6 +65,13 @@ _CATEGORY_HINTS = (
     "HOUSEHOLD", "BEVERAGE",
 )
 _MERCHANT_LABELS = ("MERCHANT_NAME", "STORE_NAME")
+# A genuine wordmark line is short ("SPROUTS", "SPROUTS FARMERS MARKET",
+# "CVS pharmacy"). A promo sentence that merely *mentions* the merchant
+# ("to WIN a $250 Sprouts gift card. Go to:") tags one word MERCHANT_NAME and is
+# display-height, so the height gate alone lets the big logo image stamp over it
+# and bleed onto neighbouring text. Cap the word count so only true wordmarks
+# (not sentences) are replaced by the logo asset.
+_LOGO_MAX_WORDS = 4
 
 # Tokens that are right-aligned into the price/amount column.
 _AMOUNT_LABELS = frozenset({
@@ -148,8 +155,9 @@ def render_receipt_glyphs(
     row_pitch_px = _row_pitch_px(
         line_words, scale, config, inner_w, inner_h
     )
+    wordmark = atlas.logo_text or atlas.merchant_name
     for line in line_words:
-        is_logo = _line_is_logo(line, body_h_ref)
+        is_logo = _line_is_logo(line, body_h_ref, wordmark)
         bold = _line_is_bold(line)
         if is_logo and config.use_logo and atlas.logo is not None:
             if _stamp_logo(image, line, atlas, scale, config, inner_w, inner_h):
@@ -875,15 +883,46 @@ def _line_labels(line: Sequence[Mapping[str, Any]]) -> set[str]:
     return labels
 
 
+def _norm_wordmark(text: str) -> str:
+    """Uppercase letters+digits only — for matching a line against the wordmark."""
+    return "".join(ch for ch in text.upper() if ch.isalnum())
+
+
+def _line_matches_wordmark(line: Sequence[Mapping[str, Any]], wordmark: str) -> bool:
+    """The line's text actually reads as the merchant wordmark (not just shares a
+    stray MERCHANT_NAME label). Source OCR mislabels times, prices, phone numbers
+    and stray words as MERCHANT_NAME; without this, the big logo image is stamped
+    over "6:33", "17.49", a phone number, etc. Requires a >=3 char overlap so a
+    short accidental substring ("ON" in "VONS") does not match."""
+    mark = _norm_wordmark(wordmark)
+    if len(mark) < 3:
+        return True  # no usable wordmark text — fall back to label+height gates
+    lt = _norm_wordmark(_line_text(line))
+    if len(lt) < 3:
+        return False
+    return (lt in mark or mark in lt)
+
+
 def _line_is_logo(
-    line: Sequence[Mapping[str, Any]], body_h_ref: float
+    line: Sequence[Mapping[str, Any]],
+    body_h_ref: float,
+    wordmark: str | None = None,
 ) -> bool:
-    """A line is the logo only if it is a merchant/store name AND display-size.
+    """A line is the logo only if it is a merchant/store name AND display-size AND
+    its text actually matches the merchant wordmark.
 
     Real receipts label MERCHANT_NAME on the big top wordmark; the same label can
     also tag a small footer repeat, so the height gate keeps the logo image from
-    being stamped over ordinary lines."""
+    being stamped over ordinary lines. A promo *sentence* that merely mentions the
+    merchant is excluded by the word-count cap, and a mislabelled time/price/phone
+    line is excluded by the wordmark text match — so the logo asset never bleeds
+    over body text it happens to share a tall, MERCHANT_NAME-tagged line with."""
     if not (_line_labels(line) & set(_MERCHANT_LABELS)):
+        return False
+    words = [w for w in line if str(w.get("text") or "").strip()]
+    if len(words) > _LOGO_MAX_WORDS:
+        return False
+    if wordmark is not None and not _line_matches_wordmark(line, wordmark):
         return False
     if body_h_ref <= 0:
         return True

--- a/receipt_agent/receipt_agent/agents/label_evaluator/rendering/glyph_renderer.py
+++ b/receipt_agent/receipt_agent/agents/label_evaluator/rendering/glyph_renderer.py
@@ -25,9 +25,12 @@ bottom-aligned to the word-box baseline (with a small descender allowance).
 
 from __future__ import annotations
 
+import math
 import os
 import random
+import re
 from dataclasses import dataclass, field
+from statistics import median
 from typing import Any, Callable, Mapping, Sequence
 
 from PIL import Image, ImageDraw, ImageFilter
@@ -61,6 +64,13 @@ _CATEGORY_HINTS = (
     "HOUSEHOLD", "BEVERAGE",
 )
 _MERCHANT_LABELS = ("MERCHANT_NAME", "STORE_NAME")
+
+# Tokens that are right-aligned into the price/amount column.
+_AMOUNT_LABELS = frozenset({
+    "LINE_TOTAL", "SUBTOTAL", "TAX", "GRAND_TOTAL", "UNIT_PRICE", "AMOUNT",
+    "BALANCE", "TOTAL", "PRICE",
+})
+_AMOUNT_RE = re.compile(r"^\$?\d{1,4}(?:,\d{3})*\.\d{2}\$?[A-Z]?-?$")
 
 
 @dataclass(frozen=True)
@@ -113,17 +123,23 @@ def render_receipt_glyphs(
 
     line_words = _group_words_by_line(receipt, words)
     body_h_ref = _median_word_height(words)
+    # Character pitch (advance) in normalized inner-width units: prefer the
+    # merchant profile (a real fixed pitch), else the receipt's own median
+    # advance. This is what makes lines render on a true grid instead of each
+    # word being squeezed into its own box (the collapsed-spacing failure).
+    pitch_norm = _pitch_norm(words, scale, profile)
+    font_h_norm = profile.font_height if (profile and profile.font_height) else None
     for line in line_words:
         is_logo = _line_is_logo(line, body_h_ref)
         bold = _line_is_bold(line)
         if is_logo and config.use_logo and atlas.logo is not None:
             if _stamp_logo(image, line, atlas, scale, config, inner_w, inner_h):
                 continue  # logo stamped; skip per-char rendering for this line
-        for word in line:
-            _stamp_word(
-                image, word, atlas, scale, config, inner_w, inner_h,
-                bold=bold, rng=rng, fallback=fallback,
-            )
+        _stamp_line_fixed_pitch(
+            image, line, atlas, scale, config, inner_w, inner_h,
+            bold=bold, rng=rng, fallback=fallback,
+            pitch_norm=pitch_norm, font_h_norm=font_h_norm,
+        )
 
     return _thermal_finish(image, config)
 
@@ -133,6 +149,7 @@ def render_real_vs_glyph(
     receipt: Mapping[str, Any],
     atlas: GlyphAtlas,
     *,
+    profile: MerchantFontProfile | None = None,
     config: GlyphRenderConfig | None = None,
     coord_max: float | None = None,
     fallback: GlyphFallback | None = None,
@@ -141,7 +158,8 @@ def render_real_vs_glyph(
     """A real receipt photo beside its glyph-stamped render, for visual diffing."""
     config = config or GlyphRenderConfig()
     rendered = render_receipt_glyphs(
-        receipt, atlas, config=config, coord_max=coord_max, fallback=fallback
+        receipt, atlas, profile=profile, config=config, coord_max=coord_max,
+        fallback=fallback
     )
     left = _fit_height(real_image.convert("RGB"), rendered.height)
     return _hstack_labeled(left, rendered, labels)
@@ -152,13 +170,15 @@ def save_receipt_glyphs(
     atlas: GlyphAtlas,
     path: str,
     *,
+    profile: MerchantFontProfile | None = None,
     config: GlyphRenderConfig | None = None,
     coord_max: float | None = None,
     fallback: GlyphFallback | None = None,
 ) -> str:
     """Render and write a glyph-stamped receipt PNG. Returns ``path``."""
     image = render_receipt_glyphs(
-        receipt, atlas, config=config, coord_max=coord_max, fallback=fallback
+        receipt, atlas, profile=profile, config=config, coord_max=coord_max,
+        fallback=fallback
     )
     os.makedirs(os.path.dirname(os.path.abspath(path)), exist_ok=True)
     image.save(path, format="PNG")
@@ -168,6 +188,163 @@ def save_receipt_glyphs(
 # --------------------------------------------------------------------------- #
 # stamping
 # --------------------------------------------------------------------------- #
+
+
+def _pitch_norm(
+    words: Sequence[Mapping[str, Any]],
+    scale: float,
+    profile: MerchantFontProfile | None,
+) -> float:
+    """Character advance as a fraction of the inner render width.
+
+    Prefer the merchant profile's measured ``char_width`` (a real printer pitch);
+    otherwise estimate the receipt's own median advance = word_width / char_count.
+    """
+    if profile is not None and profile.char_width and profile.char_width > 0:
+        return float(profile.char_width)
+    advances: list[float] = []
+    for word in words:
+        text = str(word.get("text") or "")
+        n = len(text.strip())
+        if n < 2:
+            continue
+        bbox = word.get("bbox")
+        if not isinstance(bbox, Sequence) or len(bbox) < 4:
+            continue
+        try:
+            w_norm = abs(float(bbox[2]) - float(bbox[0])) / max(scale, 1e-9)
+        except (TypeError, ValueError):
+            continue
+        if w_norm > 0 and math.isfinite(w_norm):
+            advances.append(w_norm / n)
+    return median(advances) if advances else 0.012
+
+
+def _is_amount(word: Mapping[str, Any]) -> bool:
+    labels = {_strip_bio(label) for label in (word.get("labels") or [])}
+    if labels & _AMOUNT_LABELS:
+        return True
+    return bool(_AMOUNT_RE.match(str(word.get("text") or "").strip()))
+
+
+def _snap_to_pitch(value: float, pitch: float, *, origin: float) -> float:
+    """Snap a pixel coordinate to the fixed character grid."""
+    if pitch <= 0:
+        return value
+    return origin + round((value - origin) / pitch) * pitch
+
+
+def _stamp_line_fixed_pitch(
+    image: Image.Image,
+    line: Sequence[Mapping[str, Any]],
+    atlas: GlyphAtlas,
+    scale: float,
+    config: GlyphRenderConfig,
+    inner_w: int,
+    inner_h: int,
+    *,
+    bold: bool,
+    rng: random.Random,
+    fallback: GlyphFallback | None,
+    pitch_norm: float,
+    font_h_norm: float | None,
+) -> None:
+    """Render one line on a fixed character pitch.
+
+    Words keep their real grid positions (so columns and inter-word gaps survive),
+    but every glyph advances by the SAME pitch, and a running cursor guarantees at
+    least one blank cell between words — eliminating collapsed spacing and
+    cross-word overprinting. Amount tokens are right-aligned by their ending edge
+    so the price column stays straight.
+    """
+    style = atlas.style_for_role("body", bold=bold)
+    if style is None:
+        return
+    placed = []
+    for word in line:
+        text = str(word.get("text") or "")
+        if not text.strip():
+            continue
+        px = _to_pixel_box(word.get("bbox"), scale, _PixelCfg(config), inner_w, inner_h)
+        if px is not None:
+            placed.append((word, text, px))
+    if not placed:
+        return
+    placed.sort(key=lambda t: t[2][0])  # left-to-right
+
+    pitch = max(2.0, pitch_norm * inner_w)
+    box_heights = [b - t for _, _, (l, t, r, b) in placed]
+    line_h = median(box_heights)
+    glyph_h = (
+        max(line_h * 0.7, min(line_h * 1.15, font_h_norm * inner_h))
+        if font_h_norm
+        else line_h
+    )
+    baseline = median([b for _, _, (l, t, r, b) in placed]) - line_h * config.descender_frac
+    ref_h = style.median_box_height or 1.0
+    max_glyph_w = pitch * (1.0 - config.char_tracking)
+    grid_origin = float(config.margin)
+
+    cursor = -1.0  # right edge (px) of the last glyph cell drawn on this line
+    for word, text, (left, top, right, bottom) in placed:
+        n = len(text)
+        if _is_amount(word):
+            end_x = _snap_to_pitch(right, pitch, origin=grid_origin)
+            start_x = end_x - n * pitch
+        else:
+            start_x = _snap_to_pitch(left, pitch, origin=grid_origin)
+        if start_x < cursor:  # never overlap the previous word
+            start_x = cursor
+        for i, char in enumerate(text):
+            cell_left = start_x + i * pitch
+            if char.strip():
+                glyph_img = _render_glyph(
+                    char, atlas, style, bold=bold, target_h=glyph_h,
+                    ref_h=ref_h, max_w=max_glyph_w, config=config, rng=rng,
+                    fallback=fallback,
+                )
+                if glyph_img is not None:
+                    gx = int(cell_left + (pitch - glyph_img.width) / 2)
+                    gy = int(baseline - glyph_img.height)
+                    image.alpha_composite(glyph_img, (max(0, gx), max(0, gy)))
+        cursor = start_x + n * pitch + pitch  # one blank cell before next word
+
+
+def _render_glyph(
+    char: str,
+    atlas: GlyphAtlas,
+    style: AtlasStyle,
+    *,
+    bold: bool,
+    target_h: float,
+    ref_h: float,
+    max_w: float,
+    config: GlyphRenderConfig,
+    rng: random.Random,
+    fallback: GlyphFallback | None,
+) -> Image.Image | None:
+    """Produce a sized, inked glyph for one character (atlas crop or fallback)."""
+    crop = atlas.glyph(char, role="body", bold=bold)
+    if crop is not None:
+        rel = max(0.5, min(1.0, crop.box_height_norm / ref_h if ref_h else 1.0))
+        h = max(2.0, target_h * rel)
+        w = h * crop.aspect
+        if w > max_w:
+            h *= max_w / w
+        glyph_img = _scaled_inked(crop, h, config, rng)
+    elif fallback is not None:
+        glyph_img = fallback(char, style, int(max(2, target_h)))
+    else:
+        return None
+    if glyph_img is None:
+        return None
+    if glyph_img.width > max_w:  # cap fallback glyphs to the cell
+        s = max_w / glyph_img.width
+        glyph_img = glyph_img.resize(
+            (max(1, int(glyph_img.width * s)), max(1, int(glyph_img.height * s))),
+            Image.LANCZOS,
+        )
+    return glyph_img
 
 
 def _stamp_word(

--- a/receipt_agent/receipt_agent/agents/label_evaluator/rendering/glyph_renderer.py
+++ b/receipt_agent/receipt_agent/agents/label_evaluator/rendering/glyph_renderer.py
@@ -29,6 +29,7 @@ import math
 import os
 import random
 import re
+import zlib
 from dataclasses import dataclass, field
 from statistics import median
 from typing import Any, Callable, Mapping, Sequence
@@ -78,6 +79,9 @@ _AMOUNT_RE = re.compile(r"^\$?\d{1,4}(?:,\d{3})*\.\d{2}\$?[A-Z]?-?$")
 # mistaken for a scannable barcode.
 _BARCODE_RE = re.compile(r"^\d{14,}$")
 _BARCODE_MIN_WIDTH_FRAC = 0.35
+# A line that is mostly dash/underscore/star chars is a separator rule;
+# real receipts print a continuous (often dashed) rule, not stamped glyphs.
+_RULE_CHARS = frozenset("-_=*.~")
 _BARCODE_MAX_CENTER_OFFSET_FRAC = 0.16
 _BARCODE_MAX_EXISTING_INK_FRAC = 0.01
 
@@ -149,6 +153,9 @@ def render_receipt_glyphs(
         if is_logo and config.use_logo and atlas.logo is not None:
             if _stamp_logo(image, line, atlas, scale, config, inner_w, inner_h):
                 continue  # logo stamped; skip per-char rendering for this line
+        if _line_is_rule(line):
+            _stamp_rule(image, line, scale, config, inner_w, inner_h, rng)
+            continue
         if config.draw_barcodes:
             digits = _line_barcode_digits(line)
             if digits is not None:
@@ -332,30 +339,91 @@ def _stamp_line_fixed_pitch(
     ref_h = style.median_box_height or 1.0
     max_glyph_w = pitch * (1.0 - config.char_tracking)
     grid_origin = float(config.margin)
+    page_right = config.margin + inner_w
 
     cursor = -1.0  # right edge (px) of the last glyph cell drawn on this line
     for word, text, (left, top, right, bottom) in placed:
         n = len(text)
+        word_pitch = pitch
+        word_max_glyph_w = max_glyph_w
+        span_w = n * word_pitch
         if _is_amount(word):
-            end_x = _snap_to_pitch(right, pitch, origin=grid_origin)
-            start_x = end_x - n * pitch
+            end_x = min(
+                _snap_to_pitch(right, word_pitch, origin=grid_origin),
+                page_right,
+            )
+            start_x = end_x - span_w
         else:
-            start_x = _snap_to_pitch(left, pitch, origin=grid_origin)
+            start_x = _snap_to_pitch(left, word_pitch, origin=grid_origin)
+            if start_x + span_w > page_right:
+                start_x = page_right - span_w
         if start_x < cursor:  # never overlap the previous word
             start_x = cursor
+        if start_x + span_w > page_right:
+            fitted_start = page_right - span_w
+            if fitted_start >= cursor:
+                start_x = fitted_start
+            else:
+                start_x = max(cursor, grid_origin)
+                available_w = page_right - start_x
+                if available_w <= 0:
+                    continue
+                word_pitch = max(1.0, available_w / n)
+                word_max_glyph_w = word_pitch * (1.0 - config.char_tracking)
+                span_w = n * word_pitch
+        word_seed = _stable_u32(
+            config.seed, style.style_id, "bold" if bold else "regular",
+            text, round(left, 2), round(top, 2), round(right, 2),
+            round(bottom, 2),
+        )
+        if config.ink_jitter > 0:
+            word_rng = random.Random(word_seed)
+            word_ink_jitter = word_rng.randint(
+                -config.ink_jitter, config.ink_jitter
+            )
+        else:
+            word_ink_jitter = 0
         for i, char in enumerate(text):
-            cell_left = start_x + i * pitch
+            cell_left = start_x + i * word_pitch
             if char.strip():
+                variant_index = _glyph_variant_index(
+                    config, style, bold=bold, word_seed=word_seed, char=char
+                )
                 glyph_img = _render_glyph(
                     char, atlas, style, bold=bold, target_h=glyph_h,
-                    ref_h=ref_h, max_w=max_glyph_w, config=config, rng=rng,
-                    fallback=fallback,
+                    ref_h=ref_h, max_w=word_max_glyph_w, config=config, rng=rng,
+                    fallback=fallback, variant_index=variant_index,
+                    ink_jitter=word_ink_jitter,
                 )
                 if glyph_img is not None:
-                    gx = int(cell_left + (pitch - glyph_img.width) / 2)
+                    gx = int(cell_left + (word_pitch - glyph_img.width) / 2)
                     gy = int(baseline - glyph_img.height)
                     image.alpha_composite(glyph_img, (max(0, gx), max(0, gy)))
-        cursor = start_x + n * pitch + pitch  # one blank cell before next word
+        cursor = start_x + span_w + word_pitch  # one blank cell before next word
+
+
+def _stable_u32(*parts: object) -> int:
+    payload = "\0".join(str(part) for part in parts).encode("utf-8", "ignore")
+    return zlib.crc32(payload) & 0xFFFFFFFF
+
+
+def _glyph_variant_index(
+    config: GlyphRenderConfig,
+    style: AtlasStyle,
+    *,
+    bold: bool,
+    word_seed: int,
+    char: str,
+) -> int:
+    """Stable crop choice for a char within a word.
+
+    Repeated letters in one word should not randomly alternate between clean and
+    degraded crops; that reads as mismatched type instead of thermal variation.
+    Word-level ink jitter and the paper finish provide thermal variation; crop
+    rotation itself is too risky because a lower-quality stored crop can read as
+    a different character in review images.
+    """
+    return 0
 
 
 def _render_glyph(
@@ -370,19 +438,22 @@ def _render_glyph(
     config: GlyphRenderConfig,
     rng: random.Random,
     fallback: GlyphFallback | None,
+    variant_index: int | None = None,
+    ink_jitter: int | None = None,
 ) -> Image.Image | None:
     """Produce a sized, inked glyph for one character (atlas crop or fallback)."""
     # Rotate among the char's stored variants (seeded rng) so a repeated letter
     # is not the identical crop every time — natural variation, and no single
     # imperfect crop repeats across the whole receipt.
-    crop = atlas.glyph(char, role="body", bold=bold, index=rng.randrange(1 << 16))
+    index = variant_index if variant_index is not None else rng.randrange(1 << 16)
+    crop = atlas.glyph(char, role="body", bold=bold, index=index)
     if crop is not None:
         rel = max(0.5, min(1.0, crop.box_height_norm / ref_h if ref_h else 1.0))
         h = max(2.0, target_h * rel)
         w = h * crop.aspect
         if w > max_w:
             h *= max_w / w
-        glyph_img = _scaled_inked(crop, h, config, rng)
+        glyph_img = _scaled_inked(crop, h, config, rng, ink_jitter=ink_jitter)
     elif fallback is not None:
         glyph_img = fallback(char, style, int(max(2, target_h)))
     else:
@@ -480,6 +551,8 @@ def _scaled_inked(
     target_h: float,
     config: GlyphRenderConfig,
     rng: random.Random,
+    *,
+    ink_jitter: int | None = None,
 ) -> Image.Image:
     """Scale a glyph crop to ``target_h`` and tint its alpha with thermal ink."""
     target_h = max(2, int(round(target_h)))
@@ -487,11 +560,50 @@ def _scaled_inked(
     alpha = crop.image.getchannel("A").resize(
         (target_w, target_h), Image.LANCZOS
     )
-    jitter = rng.randint(-config.ink_jitter, config.ink_jitter)
+    jitter = (
+        ink_jitter
+        if ink_jitter is not None
+        else rng.randint(-config.ink_jitter, config.ink_jitter)
+    )
     ink = tuple(max(0, min(255, c + jitter)) for c in config.ink)
     glyph = Image.new("RGBA", (target_w, target_h), ink + (0,))
     glyph.putalpha(alpha)
     return glyph
+
+
+def _line_is_rule(line: Sequence[Mapping[str, Any]]) -> bool:
+    """A separator line made of dashes/stars/underscores (a printed rule)."""
+    text = "".join(str(w.get("text") or "") for w in line).strip()
+    if len(text) < 6:
+        return False
+    ruleish = sum(1 for c in text if c in _RULE_CHARS)
+    return ruleish / len(text) >= 0.8
+
+
+def _stamp_rule(
+    image: Image.Image,
+    line: Sequence[Mapping[str, Any]],
+    scale: float,
+    config: GlyphRenderConfig,
+    inner_w: int,
+    inner_h: int,
+    rng: random.Random,
+) -> None:
+    """Draw a continuous (dashed) horizontal rule across the line's box."""
+    box = _union_pixel_box(line, scale, _PixelCfg(config), inner_w, inner_h)
+    if box is None:
+        return
+    left, top, right, bottom = box
+    y = int((top + bottom) / 2)
+    draw = ImageDraw.Draw(image)
+    ink = config.ink + (255,)
+    text = "".join(str(w.get("text") or "") for w in line)
+    star = text.count("*") > text.count("-")  # '****' rules stay dashed-dense
+    dash, gap = (6, 4) if not star else (3, 2)
+    x = int(left)
+    while x < right:
+        draw.line([(x, y), (min(x + dash, int(right)), y)], fill=ink, width=2)
+        x += dash + gap
 
 
 def _line_barcode_digits(line: Sequence[Mapping[str, Any]]) -> str | None:

--- a/receipt_agent/receipt_agent/agents/label_evaluator/rendering/glyph_renderer.py
+++ b/receipt_agent/receipt_agent/agents/label_evaluator/rendering/glyph_renderer.py
@@ -71,6 +71,15 @@ _AMOUNT_LABELS = frozenset({
     "BALANCE", "TOTAL", "PRICE",
 })
 _AMOUNT_RE = re.compile(r"^\$?\d{1,4}(?:,\d{3})*\.\d{2}\$?[A-Z]?-?$")
+# A standalone long digit run is the human-readable barcode number; real receipts
+# print the bar field just above it (OCR never captures the bars themselves).
+# Require 14+ digits (UPC/product codes are 11-13) AND, at draw time, that the
+# number spans a wide central band — so left-aligned item product codes are not
+# mistaken for a scannable barcode.
+_BARCODE_RE = re.compile(r"^\d{14,}$")
+_BARCODE_MIN_WIDTH_FRAC = 0.35
+_BARCODE_MAX_CENTER_OFFSET_FRAC = 0.16
+_BARCODE_MAX_EXISTING_INK_FRAC = 0.01
 
 
 @dataclass(frozen=True)
@@ -89,6 +98,7 @@ class GlyphRenderConfig:
     blur: float = 0.4  # gaussian blur radius for thermal softness
     seed: int = 7
     use_logo: bool = True
+    draw_barcodes: bool = True  # render bar fields above long-numeric lines
 
 
 def render_receipt_glyphs(
@@ -138,6 +148,12 @@ def render_receipt_glyphs(
         if is_logo and config.use_logo and atlas.logo is not None:
             if _stamp_logo(image, line, atlas, scale, config, inner_w, inner_h):
                 continue  # logo stamped; skip per-char rendering for this line
+        if config.draw_barcodes:
+            digits = _line_barcode_digits(line)
+            if digits is not None:
+                _stamp_barcode(
+                    image, line, scale, config, inner_w, inner_h, digits
+                )  # then fall through to print the human-readable number below
         _stamp_line_fixed_pitch(
             image, line, atlas, scale, config, inner_w, inner_h,
             bold=bold, rng=rng, fallback=fallback,
@@ -475,6 +491,93 @@ def _scaled_inked(
     glyph = Image.new("RGBA", (target_w, target_h), ink + (0,))
     glyph.putalpha(alpha)
     return glyph
+
+
+def _line_barcode_digits(line: Sequence[Mapping[str, Any]]) -> str | None:
+    """Return the digit string if this line is a long all-numeric barcode number.
+
+    Accepts both a single long run and space-grouped digit groups (e.g. CVS prints
+    ``3509 7155 1559 7491 20``); every token must be pure digits so dates / mixed
+    lines are excluded. The wide-span gate in :func:`_stamp_barcode` then rejects
+    short left-aligned product codes.
+    """
+    tokens = [str(w.get("text") or "").strip() for w in line]
+    tokens = [t for t in tokens if t]
+    if not tokens or not all(t.isdigit() for t in tokens):
+        return None
+    digits = "".join(tokens)
+    return digits if _BARCODE_RE.match(digits) else None
+
+
+def _stamp_barcode(
+    image: Image.Image,
+    line: Sequence[Mapping[str, Any]],
+    scale: float,
+    config: GlyphRenderConfig,
+    inner_w: int,
+    inner_h: int,
+    digits: str,
+) -> None:
+    """Draw a deterministic bar field in the band just above the number.
+
+    Not real symbology (decode accuracy is irrelevant for review realism) — but a
+    believable alternating-width bar field reads as a barcode at a glance, where
+    the renderer previously left blank paper (a giveaway codex flagged on every
+    merchant).
+    """
+    box = _union_pixel_box(line, scale, config, inner_w, inner_h)
+    if box is None:
+        return
+    nleft, ntop, nright, _ = box
+    span = nright - nleft
+    if span < max(16.0, inner_w * _BARCODE_MIN_WIDTH_FRAC):
+        return  # narrow left-aligned number (e.g. an item product code), not a barcode
+    page_center = config.margin + inner_w / 2.0
+    if abs(((nleft + nright) / 2.0) - page_center) > (
+        inner_w * _BARCODE_MAX_CENTER_OFFSET_FRAC
+    ):
+        return  # wide but off-center reference/member/order number, not a barcode
+    band_h = max(16.0, min((box[3] - box[1]) * 2.4, 55.0))
+    band_bottom = ntop - 2.0
+    band_top = max(float(config.margin), band_bottom - band_h)
+    if band_bottom - band_top < 8:
+        return
+    quiet = span * 0.06
+    bx0, bx1 = nleft + quiet, nright - quiet
+    if bx1 - bx0 < 8:
+        return
+    if _band_has_existing_ink(image, (bx0, band_top, bx1, band_bottom)):
+        return
+    draw = ImageDraw.Draw(image)
+    ink = config.ink + (255,)
+    seed = int(digits[:12]) if digits[:12].isdigit() else abs(hash(digits))
+    rng = random.Random(seed)
+    unit = max(1.0, (bx1 - bx0) / 95.0)
+    x = bx0
+    is_bar = True
+    while x < bx1:
+        w = rng.choice((1, 1, 2, 3)) * unit
+        if is_bar:
+            draw.rectangle(
+                [x, band_top, min(x + w, bx1), band_bottom], fill=ink
+            )
+        x += w
+        is_bar = not is_bar
+
+
+def _band_has_existing_ink(
+    image: Image.Image, box: tuple[float, float, float, float]
+) -> bool:
+    left = max(0, int(box[0]))
+    top = max(0, int(box[1]))
+    right = min(image.width, int(math.ceil(box[2])))
+    bottom = min(image.height, int(math.ceil(box[3])))
+    if right <= left or bottom <= top:
+        return True
+    gray = image.crop((left, top, right, bottom)).convert("L")
+    dark = sum(1 for value in gray.getdata() if value < 170)
+    limit = max(3, int((right - left) * (bottom - top) * _BARCODE_MAX_EXISTING_INK_FRAC))
+    return dark > limit
 
 
 def _stamp_logo(

--- a/receipt_agent/receipt_agent/agents/label_evaluator/rendering/glyph_renderer.py
+++ b/receipt_agent/receipt_agent/agents/label_evaluator/rendering/glyph_renderer.py
@@ -129,6 +129,9 @@ def render_receipt_glyphs(
     # word being squeezed into its own box (the collapsed-spacing failure).
     pitch_norm = _pitch_norm(words, scale, profile)
     font_h_norm = profile.font_height if (profile and profile.font_height) else None
+    row_pitch_px = _row_pitch_px(
+        line_words, scale, config, inner_w, inner_h
+    )
     for line in line_words:
         is_logo = _line_is_logo(line, body_h_ref)
         bold = _line_is_bold(line)
@@ -139,6 +142,7 @@ def render_receipt_glyphs(
             image, line, atlas, scale, config, inner_w, inner_h,
             bold=bold, rng=rng, fallback=fallback,
             pitch_norm=pitch_norm, font_h_norm=font_h_norm,
+            row_pitch_px=row_pitch_px,
         )
 
     return _thermal_finish(image, config)
@@ -197,11 +201,11 @@ def _pitch_norm(
 ) -> float:
     """Character advance as a fraction of the inner render width.
 
-    Prefer the merchant profile's measured ``char_width`` (a real printer pitch);
-    otherwise estimate the receipt's own median advance = word_width / char_count.
+    Estimate the receipt's own median advance = word_width / char_count, then
+    let the merchant profile refine that pitch only within a very small
+    band. The receipt boxes still own the geometry contract; an over-wide profile
+    must not blow text past the price column or right paper edge.
     """
-    if profile is not None and profile.char_width and profile.char_width > 0:
-        return float(profile.char_width)
     advances: list[float] = []
     for word in words:
         text = str(word.get("text") or "")
@@ -217,7 +221,20 @@ def _pitch_norm(
             continue
         if w_norm > 0 and math.isfinite(w_norm):
             advances.append(w_norm / n)
-    return median(advances) if advances else 0.012
+    measured = median(advances) if advances else None
+    profile_pitch = (
+        float(profile.char_width)
+        if profile is not None
+        and profile.char_width
+        and profile.char_width > 0
+        and math.isfinite(float(profile.char_width))
+        else None
+    )
+    if measured is not None and profile_pitch is not None:
+        return max(measured * 0.95, min(profile_pitch, measured * 1.05))
+    if profile_pitch is not None:
+        return profile_pitch
+    return measured if measured is not None else 0.012
 
 
 def _is_amount(word: Mapping[str, Any]) -> bool:
@@ -234,6 +251,23 @@ def _snap_to_pitch(value: float, pitch: float, *, origin: float) -> float:
     return origin + round((value - origin) / pitch) * pitch
 
 
+def _glyph_height_px(
+    line_h: float,
+    inner_h: int,
+    font_h_norm: float | None,
+    row_pitch_px: float | None,
+) -> float:
+    """Glyph cap height for a row, bounded by measured row geometry."""
+    target = max(1.0, line_h)
+    if font_h_norm is not None and font_h_norm > 0:
+        profile_h = font_h_norm * inner_h
+        if math.isfinite(profile_h) and profile_h > 0:
+            target = max(line_h * 0.95, min(profile_h, line_h * 1.05))
+    if row_pitch_px is not None and row_pitch_px > 0:
+        target = min(target, row_pitch_px * 0.75)
+    return max(1.0, target)
+
+
 def _stamp_line_fixed_pitch(
     image: Image.Image,
     line: Sequence[Mapping[str, Any]],
@@ -248,6 +282,7 @@ def _stamp_line_fixed_pitch(
     fallback: GlyphFallback | None,
     pitch_norm: float,
     font_h_norm: float | None,
+    row_pitch_px: float | None,
 ) -> None:
     """Render one line on a fixed character pitch.
 
@@ -275,11 +310,7 @@ def _stamp_line_fixed_pitch(
     pitch = max(2.0, pitch_norm * inner_w)
     box_heights = [b - t for _, _, (l, t, r, b) in placed]
     line_h = median(box_heights)
-    glyph_h = (
-        max(line_h * 0.7, min(line_h * 1.15, font_h_norm * inner_h))
-        if font_h_norm
-        else line_h
-    )
+    glyph_h = _glyph_height_px(line_h, inner_h, font_h_norm, row_pitch_px)
     baseline = median([b for _, _, (l, t, r, b) in placed]) - line_h * config.descender_frac
     ref_h = style.median_box_height or 1.0
     max_glyph_w = pitch * (1.0 - config.char_tracking)
@@ -324,7 +355,10 @@ def _render_glyph(
     fallback: GlyphFallback | None,
 ) -> Image.Image | None:
     """Produce a sized, inked glyph for one character (atlas crop or fallback)."""
-    crop = atlas.glyph(char, role="body", bold=bold)
+    # Rotate among the char's stored variants (seeded rng) so a repeated letter
+    # is not the identical crop every time — natural variation, and no single
+    # imperfect crop repeats across the whole receipt.
+    crop = atlas.glyph(char, role="body", bold=bold, index=rng.randrange(1 << 16))
     if crop is not None:
         rel = max(0.5, min(1.0, crop.box_height_norm / ref_h if ref_h else 1.0))
         h = max(2.0, target_h * rel)
@@ -520,6 +554,34 @@ def _group_words_by_line(
 
 def _line_text(line: Sequence[Mapping[str, Any]]) -> str:
     return " ".join(str(w.get("text") or "") for w in line).strip()
+
+
+def _row_pitch_px(
+    lines: Sequence[Sequence[Mapping[str, Any]]],
+    scale: float,
+    config: GlyphRenderConfig,
+    inner_w: int,
+    inner_h: int,
+) -> float | None:
+    centers: list[float] = []
+    for line in lines:
+        boxes = [
+            _to_pixel_box(
+                word.get("bbox"), scale, _PixelCfg(config), inner_w, inner_h
+            )
+            for word in line
+        ]
+        boxes = [box for box in boxes if box is not None]
+        if not boxes:
+            continue
+        centers.append(median([(top + bottom) / 2 for _, top, _, bottom in boxes]))
+    centers = sorted(centers)
+    gaps = [
+        centers[index + 1] - centers[index]
+        for index in range(len(centers) - 1)
+        if centers[index + 1] > centers[index]
+    ]
+    return median(gaps) if gaps else None
 
 
 def _line_labels(line: Sequence[Mapping[str, Any]]) -> set[str]:

--- a/receipt_agent/receipt_agent/agents/label_evaluator/rendering/glyph_renderer.py
+++ b/receipt_agent/receipt_agent/agents/label_evaluator/rendering/glyph_renderer.py
@@ -1,0 +1,514 @@
+"""Stamp a synthesized receipt with a merchant's REAL glyph crops (M2).
+
+Where ``receipt_renderer.py`` draws a synthesized receipt in a generic monospace
+TTF, this renderer composites the actual ink letterforms from a
+:class:`GlyphAtlas` (M1) so the result carries the merchant's own typeface, its
+intra-receipt **bold** weight, the real **logo** wordmark, and thermal-paper
+texture — a render that is, at a glance, hard to tell from a photo of a real
+receipt. It is for HUMAN REVIEW realism only (CHARTER.md): the structured
+receipt stays the only training artifact; nothing here feeds a training gate.
+
+Geometry contract
+-----------------
+The word boxes drive placement exactly as in ``receipt_renderer`` — the same
+``_to_pixel_box`` / ``_detect_coord_max`` helpers are reused, so this renderer
+does not change the existing geometry renderer's contract; it only swaps glyph
+drawing (TTF -> real-crop stamping).
+
+Glyph scale + baseline
+----------------------
+Atlas crops are tight to ink, which drops cap-height / baseline info. Each glyph
+is rescaled by its own ``box_height_norm`` relative to the style's median glyph
+height, so a tall ``H`` and a short ``-`` keep their real relative sizes, and is
+bottom-aligned to the word-box baseline (with a small descender allowance).
+"""
+
+from __future__ import annotations
+
+import os
+import random
+from dataclasses import dataclass, field
+from typing import Any, Callable, Mapping, Sequence
+
+from PIL import Image, ImageDraw, ImageFilter
+
+from receipt_agent.agents.label_evaluator.rendering.font_profile import (
+    MerchantFontProfile,
+)
+from receipt_agent.agents.label_evaluator.rendering.glyph_atlas import (
+    AtlasStyle,
+    GlyphAtlas,
+    GlyphCrop,
+)
+from receipt_agent.agents.label_evaluator.rendering.receipt_renderer import (
+    _detect_coord_max,
+    _iter_words,
+    _strip_bio,
+    _to_pixel_box,
+)
+
+# A fallback hook (char, style) -> RGBA ink glyph at a given pixel height, used
+# for characters the atlas lacks. M3 (TTF fallback) supplies one; by default
+# missing glyphs are simply skipped (a faint gap, like a light receipt strike).
+GlyphFallback = Callable[[str, AtlasStyle, int], "Image.Image | None"]
+
+# Bold is applied to whole lines on real receipts (promo + category headers).
+# When a synthesized receipt does not mark emphasis, fall back to these cues.
+_BOLD_LINE_HINTS = ("MEMBER SAVINGS", "SAVINGS", "YOU SAVED")
+_CATEGORY_HINTS = (
+    "GROCERY", "PRODUCE", "LIQUOR", "BAKERY", "BAKED GOODS", "DELI", "DAIRY",
+    "REFRIG", "FROZEN", "MEAT", "SEAFOOD", "GENERAL", "HEALTH", "BEAUTY",
+    "HOUSEHOLD", "BEVERAGE",
+)
+_MERCHANT_LABELS = ("MERCHANT_NAME", "STORE_NAME")
+
+
+@dataclass(frozen=True)
+class GlyphRenderConfig:
+    """Tunable parameters for glyph stamping + thermal realism."""
+
+    width: int = 460
+    height: int = 1100
+    margin: int = 10
+    paper: tuple[int, int, int] = (250, 249, 245)
+    ink: tuple[int, int, int] = (38, 36, 34)
+    ink_jitter: int = 26  # per-glyph brightness variation (thermal unevenness)
+    char_tracking: float = 0.04  # extra advance as a fraction of the cell width
+    descender_frac: float = 0.12  # baseline raised this fraction above box bottom
+    noise: float = 0.5  # 0 = clean, 1 = heavy paper/scan noise
+    blur: float = 0.4  # gaussian blur radius for thermal softness
+    seed: int = 7
+    use_logo: bool = True
+
+
+def render_receipt_glyphs(
+    receipt: Mapping[str, Any],
+    atlas: GlyphAtlas,
+    *,
+    profile: MerchantFontProfile | None = None,
+    config: GlyphRenderConfig | None = None,
+    coord_max: float | None = None,
+    fallback: GlyphFallback | None = None,
+) -> Image.Image:
+    """Render a receipt dict by stamping ``atlas`` glyph crops.
+
+    Args:
+        receipt: ``{"lines":[{"words":[{"text","bbox","labels"}]}]}`` (a flat
+            ``receipt["words"]`` list is also accepted), boxes ``[x0,y0,x1,y1]``
+            with y high-is-top — the same shape ``receipt_renderer`` consumes.
+        atlas: the merchant glyph atlas (M1).
+        profile: optional font profile (reserved for advance tuning).
+        config: render parameters.
+        coord_max: coordinate scale; auto-detected when ``None``.
+        fallback: optional glyph fallback for chars absent from the atlas (M3).
+    """
+    config = config or GlyphRenderConfig()
+    rng = random.Random(config.seed)
+    words = _iter_words(receipt)
+    scale = coord_max or _detect_coord_max(words)
+
+    image = _thermal_paper(config, rng)
+    inner_w = config.width - 2 * config.margin
+    inner_h = config.height - 2 * config.margin
+
+    line_words = _group_words_by_line(receipt, words)
+    body_h_ref = _median_word_height(words)
+    for line in line_words:
+        is_logo = _line_is_logo(line, body_h_ref)
+        bold = _line_is_bold(line)
+        if is_logo and config.use_logo and atlas.logo is not None:
+            if _stamp_logo(image, line, atlas, scale, config, inner_w, inner_h):
+                continue  # logo stamped; skip per-char rendering for this line
+        for word in line:
+            _stamp_word(
+                image, word, atlas, scale, config, inner_w, inner_h,
+                bold=bold, rng=rng, fallback=fallback,
+            )
+
+    return _thermal_finish(image, config)
+
+
+def render_real_vs_glyph(
+    real_image: Image.Image,
+    receipt: Mapping[str, Any],
+    atlas: GlyphAtlas,
+    *,
+    config: GlyphRenderConfig | None = None,
+    coord_max: float | None = None,
+    fallback: GlyphFallback | None = None,
+    labels: tuple[str, str] = ("real", "glyph-render"),
+) -> Image.Image:
+    """A real receipt photo beside its glyph-stamped render, for visual diffing."""
+    config = config or GlyphRenderConfig()
+    rendered = render_receipt_glyphs(
+        receipt, atlas, config=config, coord_max=coord_max, fallback=fallback
+    )
+    left = _fit_height(real_image.convert("RGB"), rendered.height)
+    return _hstack_labeled(left, rendered, labels)
+
+
+def save_receipt_glyphs(
+    receipt: Mapping[str, Any],
+    atlas: GlyphAtlas,
+    path: str,
+    *,
+    config: GlyphRenderConfig | None = None,
+    coord_max: float | None = None,
+    fallback: GlyphFallback | None = None,
+) -> str:
+    """Render and write a glyph-stamped receipt PNG. Returns ``path``."""
+    image = render_receipt_glyphs(
+        receipt, atlas, config=config, coord_max=coord_max, fallback=fallback
+    )
+    os.makedirs(os.path.dirname(os.path.abspath(path)), exist_ok=True)
+    image.save(path, format="PNG")
+    return path
+
+
+# --------------------------------------------------------------------------- #
+# stamping
+# --------------------------------------------------------------------------- #
+
+
+def _stamp_word(
+    image: Image.Image,
+    word: Mapping[str, Any],
+    atlas: GlyphAtlas,
+    scale: float,
+    config: GlyphRenderConfig,
+    inner_w: int,
+    inner_h: int,
+    *,
+    bold: bool,
+    rng: random.Random,
+    fallback: GlyphFallback | None,
+) -> None:
+    text = str(word.get("text") or "")
+    bbox = word.get("bbox")
+    if not text.strip() or not bbox:
+        return
+    px = _to_pixel_box(bbox, scale, _PixelCfg(config), inner_w, inner_h)
+    if px is None:
+        return
+    left, top, right, bottom = px
+    box_w = max(1.0, right - left)
+    box_h = max(1.0, bottom - top)
+
+    style = atlas.style_for_role("body", bold=bold)
+    if style is None:
+        return
+    ref_h = style.median_box_height or 1.0
+    baseline = bottom - box_h * config.descender_frac
+
+    n = len(text)
+    cell_w = box_w / n
+    max_glyph_w = cell_w * (1.0 - config.char_tracking)
+    for i, char in enumerate(text):
+        cell_left = left + i * cell_w
+        if not char.strip():
+            continue
+        crop = atlas.glyph(char, role="body", bold=bold)
+        glyph_img: Image.Image | None
+        if crop is not None:
+            # Scale by this glyph's real height relative to the style median, so
+            # tall caps and short x-height/punctuation keep their relative sizes.
+            # Clamp the ratio: caps land at the box height and the shortest marks
+            # at ~0.5, which removes the per-instance height jitter (the same
+            # char from different receipts varies) that reads as ragged text.
+            rel = crop.box_height_norm / ref_h if ref_h else 1.0
+            rel = max(0.5, min(1.0, rel))
+            target_h = max(2.0, box_h * rel)
+            target_w = target_h * crop.aspect
+            # ...but never wider than the monospace cell, so glyphs do not bleed
+            # into their neighbours (keeps inter-word gaps and avoids ink bands).
+            if target_w > max_glyph_w:
+                shrink = max_glyph_w / target_w
+                target_h *= shrink
+                target_w = max_glyph_w
+            glyph_img = _scaled_inked(crop, target_h, config, rng)
+        elif fallback is not None:
+            glyph_img = fallback(char, style, int(box_h))
+        else:
+            glyph_img = None
+        if glyph_img is None:
+            continue
+        # A fallback glyph (M3 TTF) has not been width-fitted; cap any glyph to
+        # the cell so it cannot bleed into its neighbour.
+        if glyph_img.width > max_glyph_w:
+            s = max_glyph_w / glyph_img.width
+            glyph_img = glyph_img.resize(
+                (max(1, int(glyph_img.width * s)),
+                 max(1, int(glyph_img.height * s))),
+                Image.LANCZOS,
+            )
+        # Center in the cell horizontally; bottom-align to the baseline.
+        gx = int(cell_left + (cell_w - glyph_img.width) / 2)
+        gy = int(baseline - glyph_img.height)
+        image.alpha_composite(glyph_img, (max(0, gx), max(0, gy)))
+
+
+def _scaled_inked(
+    crop: GlyphCrop,
+    target_h: float,
+    config: GlyphRenderConfig,
+    rng: random.Random,
+) -> Image.Image:
+    """Scale a glyph crop to ``target_h`` and tint its alpha with thermal ink."""
+    target_h = max(2, int(round(target_h)))
+    target_w = max(1, int(round(target_h * crop.aspect)))
+    alpha = crop.image.getchannel("A").resize(
+        (target_w, target_h), Image.LANCZOS
+    )
+    jitter = rng.randint(-config.ink_jitter, config.ink_jitter)
+    ink = tuple(max(0, min(255, c + jitter)) for c in config.ink)
+    glyph = Image.new("RGBA", (target_w, target_h), ink + (0,))
+    glyph.putalpha(alpha)
+    return glyph
+
+
+def _stamp_logo(
+    image: Image.Image,
+    line: Sequence[Mapping[str, Any]],
+    atlas: GlyphAtlas,
+    scale: float,
+    config: GlyphRenderConfig,
+    inner_w: int,
+    inner_h: int,
+) -> bool:
+    """Composite the real logo wordmark into the line's pixel box."""
+    box = _union_pixel_box(line, scale, config, inner_w, inner_h)
+    if box is None or atlas.logo is None:
+        return False
+    left, top, right, bottom = box
+    box_w = max(1.0, right - left)
+    box_h = max(1.0, bottom - top)
+    logo = atlas.logo
+    s = min(box_w / logo.width, box_h / logo.height)
+    new = (max(1, int(logo.width * s)), max(1, int(logo.height * s)))
+    scaled = logo.resize(new, Image.LANCZOS)
+    inked = Image.new("RGBA", scaled.size, config.ink + (0,))
+    inked.putalpha(scaled.getchannel("A"))
+    gx = int(left + (box_w - inked.width) / 2)
+    gy = int(top + (box_h - inked.height) / 2)
+    image.alpha_composite(inked, (max(0, gx), max(0, gy)))
+    return True
+
+
+# --------------------------------------------------------------------------- #
+# line role / emphasis
+# --------------------------------------------------------------------------- #
+
+
+def _group_words_by_line(
+    receipt: Mapping[str, Any], words: Sequence[Mapping[str, Any]]
+) -> list[list[Mapping[str, Any]]]:
+    """Group words into visual lines.
+
+    Uses the receipt's own ``lines`` structure when present; otherwise clusters
+    the flat word list by vertical position (box center-y).
+    """
+    lines = receipt.get("lines")
+    if isinstance(lines, list) and lines:
+        grouped = []
+        for line in lines:
+            line_words = [
+                w for w in (line.get("words") or []) if isinstance(w, Mapping)
+            ]
+            if line_words:
+                grouped.append(line_words)
+        if grouped:
+            return grouped
+    # Flat fallback: bucket by center-y (boxes are y high-is-top). Bad/degenerate
+    # bboxes are skipped here the same way ``_to_pixel_box`` ignores them, so a
+    # non-numeric coordinate never crashes the render.
+    rows: list[tuple[float, Mapping[str, Any]]] = []
+    for w in words:
+        cy = _bbox_center_y(w)
+        if cy is not None:
+            rows.append((cy, w))
+    rows.sort(key=lambda r: -r[0])
+    grouped, current, last_cy = [], [], None
+    tol = _row_tolerance(rows)
+    for cy, w in rows:
+        if last_cy is None or abs(cy - last_cy) <= tol:
+            current.append(w)
+        else:
+            grouped.append(current)
+            current = [w]
+        last_cy = cy
+    if current:
+        grouped.append(current)
+    return grouped
+
+
+def _line_text(line: Sequence[Mapping[str, Any]]) -> str:
+    return " ".join(str(w.get("text") or "") for w in line).strip()
+
+
+def _line_labels(line: Sequence[Mapping[str, Any]]) -> set[str]:
+    labels: set[str] = set()
+    for w in line:
+        for label in w.get("labels") or []:
+            labels.add(_strip_bio(label))
+    return labels
+
+
+def _line_is_logo(
+    line: Sequence[Mapping[str, Any]], body_h_ref: float
+) -> bool:
+    """A line is the logo only if it is a merchant/store name AND display-size.
+
+    Real receipts label MERCHANT_NAME on the big top wordmark; the same label can
+    also tag a small footer repeat, so the height gate keeps the logo image from
+    being stamped over ordinary lines."""
+    if not (_line_labels(line) & set(_MERCHANT_LABELS)):
+        return False
+    if body_h_ref <= 0:
+        return True
+    return _line_max_height(line) >= body_h_ref * 1.6
+
+
+def _line_is_bold(line: Sequence[Mapping[str, Any]]) -> bool:
+    # Explicit emphasis hint on any word wins.
+    for w in line:
+        emphasis = str(w.get("emphasis") or w.get("weight") or "").lower()
+        if emphasis in ("bold", "heavy"):
+            return True
+    text = _line_text(line).upper()
+    if any(hint in text for hint in _BOLD_LINE_HINTS):
+        return True
+    # A short all-caps line that is exactly a category name is a section header.
+    compact = text.replace("/", " ")
+    if any(compact == hint or compact.startswith(hint) for hint in _CATEGORY_HINTS):
+        return True
+    return False
+
+
+# --------------------------------------------------------------------------- #
+# thermal paper + noise
+# --------------------------------------------------------------------------- #
+
+
+def _thermal_paper(config: GlyphRenderConfig, rng: random.Random) -> Image.Image:
+    image = Image.new("RGBA", (config.width, config.height), config.paper + (255,))
+    if config.noise <= 0:
+        return image
+    # Sparse darker speckle + faint horizontal scan banding for thermal realism.
+    draw = ImageDraw.Draw(image)
+    speckles = int(config.width * config.height * 0.0006 * config.noise)
+    for _ in range(speckles):
+        x = rng.randint(0, config.width - 1)
+        y = rng.randint(0, config.height - 1)
+        d = rng.randint(6, 22)
+        base = config.paper
+        shade = tuple(max(0, c - d) for c in base)
+        draw.point((x, y), fill=shade + (255,))
+    return image
+
+
+def _thermal_finish(image: Image.Image, config: GlyphRenderConfig) -> Image.Image:
+    out = image.convert("RGB")
+    if config.blur > 0:
+        out = out.filter(ImageFilter.GaussianBlur(radius=config.blur))
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# small helpers
+# --------------------------------------------------------------------------- #
+
+
+class _PixelCfg:
+    """Adapter exposing the few attrs ``_to_pixel_box`` reads from a config."""
+
+    def __init__(self, config: GlyphRenderConfig) -> None:
+        self.margin = config.margin
+
+
+def _union_pixel_box(
+    line: Sequence[Mapping[str, Any]],
+    scale: float,
+    config: GlyphRenderConfig,
+    inner_w: int,
+    inner_h: int,
+) -> tuple[float, float, float, float] | None:
+    boxes = []
+    for w in line:
+        px = _to_pixel_box(
+            w.get("bbox"), scale, _PixelCfg(config), inner_w, inner_h
+        )
+        if px is not None:
+            boxes.append(px)
+    if not boxes:
+        return None
+    return (
+        min(b[0] for b in boxes),
+        min(b[1] for b in boxes),
+        max(b[2] for b in boxes),
+        max(b[3] for b in boxes),
+    )
+
+
+def _bbox_yspan(word: Mapping[str, Any]) -> tuple[float, float] | None:
+    """``(y0, y1)`` of a word's bbox, or ``None`` for a missing/degenerate box."""
+    bbox = word.get("bbox")
+    if isinstance(bbox, Sequence) and not isinstance(bbox, (str, bytes)):
+        if len(bbox) >= 4:
+            try:
+                y0, y1 = float(bbox[1]), float(bbox[3])
+            except (TypeError, ValueError):
+                return None
+            if y0 == y0 and y1 == y1:  # reject NaN
+                return (y0, y1)
+    return None
+
+
+def _bbox_height(word: Mapping[str, Any]) -> float:
+    span = _bbox_yspan(word)
+    return abs(span[1] - span[0]) if span else 0.0
+
+
+def _bbox_center_y(word: Mapping[str, Any]) -> float | None:
+    span = _bbox_yspan(word)
+    return (span[0] + span[1]) / 2 if span else None
+
+
+def _median_word_height(words: Sequence[Mapping[str, Any]]) -> float:
+    heights = sorted(h for h in (_bbox_height(w) for w in words) if h > 0)
+    if not heights:
+        return 0.0
+    return heights[len(heights) // 2]
+
+
+def _line_max_height(line: Sequence[Mapping[str, Any]]) -> float:
+    heights = [_bbox_height(w) for w in line]
+    return max(heights) if heights else 0.0
+
+
+def _row_tolerance(rows: Sequence[tuple[float, Mapping[str, Any]]]) -> float:
+    heights = sorted(h for h in (_bbox_height(w) for _, w in rows) if h > 0)
+    if not heights:
+        return 1.0
+    return max(heights[len(heights) // 2] * 0.6, 1e-6)
+
+
+def _fit_height(image: Image.Image, height: int) -> Image.Image:
+    if image.height == height:
+        return image
+    w = max(1, int(image.width * height / image.height))
+    return image.resize((w, height), Image.LANCZOS)
+
+
+def _hstack_labeled(
+    left: Image.Image, right: Image.Image, labels: tuple[str, str]
+) -> Image.Image:
+    gap, banner = 14, 22
+    height = max(left.height, right.height) + banner
+    width = left.width + right.width + gap
+    canvas = Image.new("RGB", (width, height), (255, 255, 255))
+    canvas.paste(left, (0, banner))
+    canvas.paste(right, (left.width + gap, banner))
+    draw = ImageDraw.Draw(canvas)
+    draw.text((4, 4), labels[0], fill=(0, 0, 0))
+    draw.text((left.width + gap + 4, 4), labels[1], fill=(0, 0, 0))
+    return canvas

--- a/receipt_agent/receipt_agent/agents/label_evaluator/rendering/glyph_renderer.py
+++ b/receipt_agent/receipt_agent/agents/label_evaluator/rendering/glyph_renderer.py
@@ -99,6 +99,7 @@ class GlyphRenderConfig:
     seed: int = 7
     use_logo: bool = True
     draw_barcodes: bool = True  # render bar fields above long-numeric lines
+    paper_realism: float = 0.6  # 0=flat; thermal fade + banding + vignette + grain
 
 
 def render_receipt_glyphs(
@@ -752,7 +753,44 @@ def _thermal_finish(image: Image.Image, config: GlyphRenderConfig) -> Image.Imag
     out = image.convert("RGB")
     if config.blur > 0:
         out = out.filter(ImageFilter.GaussianBlur(radius=config.blur))
+    if config.paper_realism > 0:
+        out = _apply_paper_effects(out, config)
     return out
+
+
+def _apply_paper_effects(
+    out: Image.Image, config: GlyphRenderConfig
+) -> Image.Image:
+    """Photographic thermal-paper degradation (vectorized).
+
+    A real receipt photo is never flat white: exposure rolls off toward the
+    ends, the scanner adds faint horizontal banding, the edges darken
+    (vignette), and there is fine grain. Applied after layout so it never
+    hides a layout bug; strength is bounded by ``paper_realism``.
+    """
+    try:
+        import numpy as np
+    except Exception:  # numpy absent -> skip (no crash)
+        return out
+    amt = max(0.0, min(1.0, float(config.paper_realism)))
+    arr = np.asarray(out).astype(np.float32)
+    h, w, _ = arr.shape
+    rng = np.random.default_rng(config.seed + 17)
+    yy = np.linspace(0.0, 1.0, h)[:, None]
+    xx = np.linspace(0.0, 1.0, w)[None, :]
+    # Exposure rolloff near the top and bottom paper ends.
+    fade = 1.0 - amt * 0.05 * (np.abs(yy - 0.5) * 2.0)
+    # faint horizontal scan banding
+    period = float(rng.integers(7, 14))
+    banding = 1.0 - amt * 0.025 * (0.5 + 0.5 * np.sin(np.arange(h) / period))[:, None]
+    # edge vignette (stronger at the left/right paper edges)
+    vignette = 1.0 - amt * 0.10 * ((np.abs(xx - 0.5) * 2.0) ** 3)
+    mask = (fade * banding * vignette)[..., None]
+    arr = arr * mask
+    # fine grain
+    grain = rng.normal(0.0, amt * 4.5, size=arr.shape).astype(np.float32)
+    arr = np.clip(arr + grain, 0.0, 255.0).astype(np.uint8)
+    return Image.fromarray(arr)
 
 
 # --------------------------------------------------------------------------- #

--- a/receipt_agent/receipt_agent/agents/label_evaluator/rendering/glyph_renderer.py
+++ b/receipt_agent/receipt_agent/agents/label_evaluator/rendering/glyph_renderer.py
@@ -104,6 +104,7 @@ class GlyphRenderConfig:
     use_logo: bool = True
     draw_barcodes: bool = True  # render bar fields above long-numeric lines
     paper_realism: float = 0.6  # 0=flat; thermal fade + banding + vignette + grain
+    body_glyph_source: str = "atlas"  # "numeric" or "font" opts into TTF body
 
 
 def render_receipt_glyphs(
@@ -383,6 +384,7 @@ def _stamp_line_fixed_pitch(
             )
         else:
             word_ink_jitter = 0
+        prefer_font = _prefer_font_for_word(config, word, text)
         for i, char in enumerate(text):
             cell_left = start_x + i * word_pitch
             if char.strip():
@@ -392,7 +394,8 @@ def _stamp_line_fixed_pitch(
                 glyph_img = _render_glyph(
                     char, atlas, style, bold=bold, target_h=glyph_h,
                     ref_h=ref_h, max_w=word_max_glyph_w, config=config, rng=rng,
-                    fallback=fallback, variant_index=variant_index,
+                    fallback=fallback, prefer_font=prefer_font,
+                    variant_index=variant_index,
                     ink_jitter=word_ink_jitter,
                 )
                 if glyph_img is not None:
@@ -426,6 +429,25 @@ def _glyph_variant_index(
     return 0
 
 
+def _prefer_font_for_word(
+    config: GlyphRenderConfig, word: Mapping[str, Any], text: str
+) -> bool:
+    mode = str(config.body_glyph_source).lower()
+    if mode in {"font", "ttf", "matched"}:
+        return True
+    if mode in {"atlas", "crops", "glyphs"}:
+        return False
+    return _is_amount(word) or _mostly_numeric_token(text)
+
+
+def _mostly_numeric_token(text: str) -> bool:
+    digits = sum(1 for char in text if char.isdigit())
+    letters = sum(1 for char in text if char.isalpha())
+    if digits < 2:
+        return False
+    return digits / max(1, digits + letters) >= 0.45
+
+
 def _render_glyph(
     char: str,
     atlas: GlyphAtlas,
@@ -438,10 +460,18 @@ def _render_glyph(
     config: GlyphRenderConfig,
     rng: random.Random,
     fallback: GlyphFallback | None,
+    prefer_font: bool = False,
     variant_index: int | None = None,
     ink_jitter: int | None = None,
 ) -> Image.Image | None:
     """Produce a sized, inked glyph for one character (atlas crop or fallback)."""
+    if prefer_font and fallback is not None:
+        glyph_img = fallback(char, style, int(max(2, target_h)))
+        if glyph_img is not None:
+            if ink_jitter is not None:
+                glyph_img = _retint_glyph(glyph_img, config, ink_jitter)
+            return _fit_glyph_width(glyph_img, max_w)
+
     # Rotate among the char's stored variants (seeded rng) so a repeated letter
     # is not the identical crop every time — natural variation, and no single
     # imperfect crop repeats across the whole receipt.
@@ -460,13 +490,50 @@ def _render_glyph(
         return None
     if glyph_img is None:
         return None
-    if glyph_img.width > max_w:  # cap fallback glyphs to the cell
-        s = max_w / glyph_img.width
-        glyph_img = glyph_img.resize(
-            (max(1, int(glyph_img.width * s)), max(1, int(glyph_img.height * s))),
-            Image.LANCZOS,
-        )
-    return glyph_img
+    return _fit_glyph_width(glyph_img, max_w)
+
+
+def _fit_glyph_width(glyph_img: Image.Image, max_w: float) -> Image.Image:
+    if glyph_img.width <= max_w:
+        return glyph_img
+    s = max_w / glyph_img.width
+    return glyph_img.resize(
+        (max(1, int(glyph_img.width * s)), max(1, int(glyph_img.height * s))),
+        Image.LANCZOS,
+    )
+
+
+def _retint_glyph(
+    glyph_img: Image.Image, config: GlyphRenderConfig, ink_jitter: int
+) -> Image.Image:
+    alpha = _thermalize_font_alpha(glyph_img.getchannel("A"))
+    ink = tuple(max(0, min(255, c + ink_jitter)) for c in config.ink)
+    out = Image.new("RGBA", glyph_img.size, ink + (0,))
+    out.putalpha(alpha)
+    return out
+
+
+def _thermalize_font_alpha(alpha: Image.Image) -> Image.Image:
+    """Soften matched-font glyphs so they do not stand apart from atlas crops."""
+    alpha = alpha.point(lambda value: int(value * 0.68))
+    if alpha.width <= 2 or alpha.height <= 2:
+        return alpha
+    px = alpha.load()
+    for y in range(alpha.height):
+        for x in range(alpha.width):
+            if px[x, y] == 0:
+                continue
+            edge = (
+                x == 0 or y == 0 or x == alpha.width - 1
+                or y == alpha.height - 1
+                or px[x - 1, y] == 0
+                or px[min(x + 1, alpha.width - 1), y] == 0
+                or px[x, y - 1] == 0
+                or px[x, min(y + 1, alpha.height - 1)] == 0
+            )
+            if edge and ((x * 19 + y * 23 + alpha.width * 5) % 17 == 0):
+                px[x, y] = 0
+    return alpha
 
 
 def _stamp_word(

--- a/receipt_agent/receipt_agent/agents/label_evaluator/rendering/glyph_ttf_fallback.py
+++ b/receipt_agent/receipt_agent/agents/label_evaluator/rendering/glyph_ttf_fallback.py
@@ -1,0 +1,269 @@
+"""Embedding-matched TTF fallback for glyphs the atlas lacks (M3).
+
+A real glyph atlas (M1) only covers the characters a merchant happened to print.
+When a synthesized receipt needs a character the atlas is missing, this module
+renders it from a monospace TTF — choosing the TTF whose letterforms most
+resemble the merchant's *real* glyphs, so the substitute does not jar against the
+stamped originals.
+
+"Embedding-matched", honestly scoped
+------------------------------------
+The charter points at #994's Chroma letter embeddings / an HF vision embedder
+(DINOv2, CLIP) as the matcher. Those need network/model weights that are not
+available in every run, and DeepFont is not trained on thermal fonts anyway. So
+the default matcher here is a self-contained **visual similarity**: render each
+candidate font's glyphs for the characters the atlas DOES have, reduce both the
+candidate and the real glyph to a small normalized ink vector, and score by mean
+cosine similarity. It is a pixel-embedding match, not a learned one — it picks
+the closest available monospace, which is all the fallback needs. A learned
+embedder can be dropped in via the ``score_font`` hook without touching callers.
+
+This is review-realism DATA only (CHARTER.md): it renders substitute glyphs for
+human-review images; it never feeds a training gate.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Callable, Mapping, Sequence
+
+from PIL import Image, ImageFont
+
+from receipt_agent.agents.label_evaluator.rendering.glyph_atlas import (
+    AtlasStyle,
+    GlyphAtlas,
+    GlyphCrop,
+)
+
+# Monospace candidates, most receipt-like first. None are true thermal fonts
+# (those are not freely available); the matcher picks the closest of these.
+THERMAL_TTF_CANDIDATES: tuple[str, ...] = (
+    "/System/Library/Fonts/Supplemental/Andale Mono.ttf",
+    "/System/Library/Fonts/Supplemental/Courier New.ttf",
+    "/System/Library/Fonts/Menlo.ttc",
+    "/System/Library/Fonts/Monaco.ttf",
+    "/System/Library/Fonts/SFNSMono.ttf",
+    "/System/Library/Fonts/Supplemental/PTMono.ttc",
+    "/usr/share/fonts/truetype/dejavu/DejaVuSansMono.ttf",
+    "/usr/share/fonts/truetype/liberation/LiberationMono-Regular.ttf",
+)
+
+_SIM_GLYPH_SIZE = 16  # side of the normalized ink vector used for matching
+
+
+@dataclass(frozen=True)
+class FontMatch:
+    """The chosen fallback font and how well it matched the atlas."""
+
+    font_path: str | None
+    score: float
+    scores: dict[str, float]  # path -> mean similarity (for transparency)
+    probe_chars: tuple[str, ...]
+
+
+def available_candidates(
+    candidates: Sequence[str] = THERMAL_TTF_CANDIDATES,
+) -> list[str]:
+    return [path for path in candidates if os.path.exists(path)]
+
+
+def match_fallback_font(
+    atlas: GlyphAtlas,
+    *,
+    candidates: Sequence[str] = THERMAL_TTF_CANDIDATES,
+    max_probe_chars: int = 24,
+    score_font: "Callable[[str, Mapping[str, GlyphCrop]], float] | None" = None,
+) -> FontMatch:
+    """Pick the candidate TTF whose glyphs best match the atlas's real glyphs.
+
+    Probes on the characters the atlas already has (preferring letters/digits),
+    so the score reflects how close a candidate is to the merchant's true font.
+    """
+    body = atlas.styles.get("body") or next(iter(atlas.styles.values()), None)
+    paths = available_candidates(candidates)
+    if body is None or not paths:
+        return FontMatch(paths[0] if paths else None, 0.0, {}, ())
+
+    probe = _probe_glyphs(body, max_probe_chars)
+    if not probe:
+        return FontMatch(paths[0], 0.0, {path: 0.0 for path in paths}, ())
+
+    real_vectors = {
+        char: _alpha_vector(crop.image.getchannel("A"))
+        for char, crop in probe.items()
+    }
+    scores: dict[str, float] = {}
+    for path in paths:
+        if score_font is not None:
+            scores[path] = score_font(path, probe)
+            continue
+        scores[path] = _mean_similarity(path, probe, real_vectors)
+
+    best_path = max(scores, key=lambda p: scores[p])
+    return FontMatch(
+        font_path=best_path,
+        score=scores[best_path],
+        scores=scores,
+        probe_chars=tuple(sorted(probe)),
+    )
+
+
+def make_ttf_fallback(
+    atlas: GlyphAtlas,
+    *,
+    font_path: str | None = None,
+    candidates: Sequence[str] = THERMAL_TTF_CANDIDATES,
+    ink: tuple[int, int, int] = (38, 36, 34),
+    cap_ratio: float = 0.7,
+) -> "Callable[[str, AtlasStyle, int], Image.Image | None]":
+    """Build a glyph fallback (the renderer's ``fallback`` hook) for an atlas.
+
+    Picks the best-matching font once (unless ``font_path`` is given) and returns
+    ``fallback(char, style, px_height)`` rendering a missing character from that
+    font, ink-on-transparent, sized so a capital lands at ~``px_height``.
+    """
+    if font_path is None:
+        font_path = match_fallback_font(atlas, candidates=candidates).font_path
+
+    cache: dict[tuple[str, int, bool], Image.Image | None] = {}
+
+    def fallback(
+        char: str, style: AtlasStyle, px_height: int
+    ) -> Image.Image | None:
+        if not char.strip() or px_height <= 1 or font_path is None:
+            return None
+        bold = style.weight == "bold"
+        key = (char, int(px_height), bold)
+        if key in cache:
+            cached = cache[key]
+            return cached.copy() if cached is not None else None
+        glyph = _render_ttf_glyph(
+            char, font_path, px_height, ink=ink, cap_ratio=cap_ratio, bold=bold
+        )
+        cache[key] = glyph
+        return glyph.copy() if glyph is not None else None
+
+    return fallback
+
+
+# --------------------------------------------------------------------------- #
+# internals
+# --------------------------------------------------------------------------- #
+
+
+def _probe_glyphs(
+    style: AtlasStyle, limit: int
+) -> dict[str, GlyphCrop]:
+    """Pick representative real glyphs to match against (letters/digits first)."""
+    preferred = [c for c in style.chars() if c.isalnum()]
+    ordered = sorted(preferred) or sorted(style.chars())
+    probe: dict[str, GlyphCrop] = {}
+    for char in ordered[:limit]:
+        crop = style.glyph_for(char)
+        if crop is not None:
+            probe[char] = crop
+    return probe
+
+
+_TTF_CACHE: dict[tuple[str, int], ImageFont.FreeTypeFont] = {}
+
+
+def _load_ttf(path: str, size: int) -> ImageFont.FreeTypeFont | None:
+    size = max(4, int(size))
+    key = (path, size)
+    cached = _TTF_CACHE.get(key)
+    if cached is not None:
+        return cached
+    try:
+        font = ImageFont.truetype(path, size)
+    except OSError:
+        return None
+    _TTF_CACHE[key] = font
+    return font
+
+
+def _render_ttf_glyph(
+    char: str,
+    font_path: str,
+    px_height: int,
+    *,
+    ink: tuple[int, int, int],
+    cap_ratio: float,
+    bold: bool,
+) -> Image.Image | None:
+    """Render one character to a tight ink-on-transparent RGBA at cap≈px_height."""
+    size = max(6, int(round(px_height / max(cap_ratio, 0.1))))
+    font = _load_ttf(font_path, size)
+    if font is None:
+        return None
+    # Draw on a generous scratch layer, then crop to ink.
+    scratch = Image.new("L", (size * 2, size * 2), 0)
+    from PIL import ImageDraw
+
+    draw = ImageDraw.Draw(scratch)
+    draw.text((size // 2, size // 2), char, fill=255, font=font)
+    if bold:  # fake-bold: overlay a 1px-offset copy
+        draw.text((size // 2 + 1, size // 2), char, fill=255, font=font)
+    bbox = scratch.getbbox()
+    if bbox is None:
+        return None
+    alpha = scratch.crop(bbox)
+    glyph = Image.new("RGBA", alpha.size, ink + (0,))
+    glyph.putalpha(alpha)
+    return glyph
+
+
+def _mean_similarity(
+    font_path: str,
+    probe: Mapping[str, GlyphCrop],
+    real_vectors: Mapping[str, tuple[float, ...]],
+) -> float:
+    font = _load_ttf(font_path, _SIM_GLYPH_SIZE * 3)
+    if font is None:
+        return 0.0
+    sims: list[float] = []
+    for char, real_vec in real_vectors.items():
+        cand = _render_plain_alpha(char, font)
+        if cand is None:
+            continue
+        sims.append(_cosine(real_vec, _alpha_vector(cand)))
+    if not sims:
+        return 0.0
+    return sum(sims) / len(sims)
+
+
+def _render_plain_alpha(
+    char: str, font: ImageFont.FreeTypeFont
+) -> Image.Image | None:
+    from PIL import ImageDraw
+
+    size = _SIM_GLYPH_SIZE * 3
+    scratch = Image.new("L", (size * 2, size * 2), 0)
+    ImageDraw.Draw(scratch).text(
+        (size // 2, size // 2), char, fill=255, font=font
+    )
+    bbox = scratch.getbbox()
+    if bbox is None:
+        return None
+    return scratch.crop(bbox)
+
+
+def _alpha_vector(alpha: Image.Image) -> tuple[float, ...]:
+    """Normalize an alpha image to a square ink vector (shape, not size/aspect)."""
+    side = max(alpha.width, alpha.height, 1)
+    square = Image.new("L", (side, side), 0)
+    square.paste(alpha, ((side - alpha.width) // 2, (side - alpha.height) // 2))
+    small = square.resize((_SIM_GLYPH_SIZE, _SIM_GLYPH_SIZE), Image.BOX)
+    return tuple(v / 255.0 for v in small.getdata())
+
+
+def _cosine(a: Sequence[float], b: Sequence[float]) -> float:
+    if len(a) != len(b):
+        return 0.0
+    dot = sum(x * y for x, y in zip(a, b))
+    na = sum(x * x for x in a) ** 0.5
+    nb = sum(y * y for y in b) ** 0.5
+    if na <= 0 or nb <= 0:
+        return 0.0
+    return dot / (na * nb)

--- a/receipt_agent/tests/test_glyph_atlas.py
+++ b/receipt_agent/tests/test_glyph_atlas.py
@@ -1,0 +1,244 @@
+"""Tests for the style-aware glyph atlas (deterministic, no AWS).
+
+A synthetic raw receipt image is painted with three line tiers — a tall logo
+line, thin-ink regular body lines, and heavy-ink bold lines — so the atlas's
+weight/logo separation, real-crop retention, lookup, and round-trip persistence
+can be checked without touching Dynamo/S3.
+"""
+
+from __future__ import annotations
+
+from PIL import Image, ImageDraw
+
+from receipt_agent.agents.label_evaluator.rendering.glyph_atlas import (
+    GlyphAtlas,
+    build_glyph_atlas,
+    extract_glyph_image,
+    load_atlas,
+    save_atlas,
+)
+
+_W, _H = 320, 1600
+
+
+def _letter(char, x, y, w, h, *, line_id, word_id, letter_id):
+    """A normalized (bottom-left origin) OCR letter dict #994 accepts."""
+    return {
+        "text": char,
+        "confidence": 0.99,
+        "image_id": "img-1",
+        "receipt_id": 1,
+        "line_id": line_id,
+        "word_id": word_id,
+        "letter_id": letter_id,
+        "bounding_box": {"x": x, "y": y, "width": w, "height": h},
+    }
+
+
+def _paint(draw, letter, *, ink_coverage):
+    """Paint a letter's ink into the raw image at its (flipped) pixel box."""
+    box = letter["bounding_box"]
+    left = box["x"] * _W
+    right = (box["x"] + box["width"]) * _W
+    top = (1.0 - box["y"] - box["height"]) * _H
+    bottom = (1.0 - box["y"]) * _H
+    bw, bh = right - left, bottom - top
+    # Center an ink rectangle covering `ink_coverage` of the box area.
+    import math
+
+    frac = math.sqrt(ink_coverage)
+    iw, ih = bw * frac, bh * frac
+    cx, cy = (left + right) / 2, (top + bottom) / 2
+    draw.rectangle(
+        [cx - iw / 2, cy - ih / 2, cx + iw / 2, cy + ih / 2], fill=(10, 10, 10)
+    )
+
+
+def _build_inputs():
+    letters = []
+    image = Image.new("RGB", (_W, _H), (250, 249, 246))
+    draw = ImageDraw.Draw(image)
+
+    def add(char, x, y, w, h, *, line_id, word_id, letter_id, coverage):
+        lt = _letter(char, x, y, w, h, line_id=line_id, word_id=word_id,
+                     letter_id=letter_id)
+        _paint(draw, lt, ink_coverage=coverage)
+        letters.append(lt)
+
+    # Logo line near the top: tall (h=0.045) display chars (~3x body height).
+    add("V", 0.30, 0.94, 0.05, 0.045, line_id=1, word_id=1, letter_id=1, coverage=0.6)
+    add("S", 0.40, 0.94, 0.05, 0.045, line_id=1, word_id=1, letter_id=2, coverage=0.6)
+
+    # Regular body lines: realistic narrow glyphs (w=0.022), thin ink, height 0.02.
+    chars = "AB12"
+    for li, ytop in enumerate((0.80, 0.74, 0.68), start=2):
+        for wi, ch in enumerate(chars):
+            add(ch, 0.10 + wi * 0.05, ytop, 0.022, 0.02,
+                line_id=li, word_id=2, letter_id=wi + 1, coverage=0.20)
+
+    # Bold lines: heavy ink (higher coverage), same glyph box.
+    for li, ytop in enumerate((0.55, 0.49), start=5):
+        for wi, ch in enumerate(chars):
+            add(ch, 0.10 + wi * 0.05, ytop, 0.022, 0.02,
+                line_id=li, word_id=3, letter_id=wi + 1, coverage=0.55)
+
+    return [{"image_id": "img-1", "receipt_id": 1, "letters": letters,
+             "raw_image": image}]
+
+
+def _atlas() -> GlyphAtlas:
+    atlas = build_glyph_atlas(_build_inputs(), "TestMart", min_samples=5)
+    assert atlas is not None
+    return atlas
+
+
+def test_extract_glyph_image_returns_tight_rgba_ink():
+    image = Image.new("RGB", (60, 60), (255, 255, 255))
+    ImageDraw.Draw(image).rectangle([20, 20, 40, 50], fill=(0, 0, 0))
+    box = {"x": 0.2, "y": 0.2, "width": 0.4, "height": 0.5}
+    glyph = extract_glyph_image(image, box, y_origin="top_left")
+    assert glyph is not None
+    assert glyph.mode == "RGBA"
+    # Tight to ink: bbox of alpha equals the whole crop.
+    assert glyph.getbbox() == (0, 0, glyph.width, glyph.height)
+    # The ink is opaque, the background fully transparent somewhere is N/A after
+    # the tight crop, but max alpha must be high (real ink retained).
+    assert max(glyph.getchannel("A").getdata()) > 200
+
+
+def test_extract_glyph_image_dense_glyph_not_inverted():
+    """A glyph that fills most of its box (more ink than paper) must NOT flip
+    polarity and turn the paper margin into ink — the regression codex flagged."""
+    image = Image.new("RGB", (40, 40), (250, 250, 250))
+    # Ink fills most of the box (a thin paper border remains): ink is the
+    # majority class, so the old "ink = minority" heuristic would wrongly flip.
+    ImageDraw.Draw(image).rectangle([6, 6, 34, 34], fill=(8, 8, 8))
+    box = {"x": 0.1, "y": 0.1, "width": 0.8, "height": 0.8}
+    glyph = extract_glyph_image(image, box, y_origin="top_left",
+                                expand_x_ratio=0.0, expand_y_ratio=0.0)
+    assert glyph is not None
+    alpha = glyph.getchannel("A")
+    # The dark block is ink (opaque); had polarity flipped, the corners (paper)
+    # would be opaque and the center transparent. Check the center is opaque.
+    cx, cy = glyph.width // 2, glyph.height // 2
+    assert alpha.getpixel((cx, cy)) > 200
+
+
+def test_extract_glyph_image_handles_inverted_ink():
+    # Light ink on dark paper -> still produces ink-as-alpha after polarity flip.
+    image = Image.new("RGB", (60, 60), (15, 15, 15))
+    ImageDraw.Draw(image).rectangle([20, 20, 40, 50], fill=(240, 240, 240))
+    box = {"x": 0.2, "y": 0.2, "width": 0.4, "height": 0.5}
+    glyph = extract_glyph_image(image, box, y_origin="top_left")
+    assert glyph is not None
+    assert max(glyph.getchannel("A").getdata()) > 200
+
+
+def test_atlas_separates_body_and_bold_weight():
+    atlas = _atlas()
+    assert "body" in atlas.styles
+    assert "bold" in atlas.styles
+    body = atlas.styles["body"]
+    bold = atlas.styles["bold"]
+    # Bold detected via higher ink density than the body baseline.
+    assert bold.median_ink_ratio > body.median_ink_ratio
+    assert bold.weight == "bold"
+    assert body.weight == "regular"
+
+
+def test_atlas_captures_logo_and_excludes_it_from_body():
+    atlas = _atlas()
+    assert atlas.logo is not None
+    assert atlas.logo_text in ("VS", "SV")  # order by center-x
+    # The tall logo glyphs (V, S) must not pollute the body char set.
+    assert "V" not in atlas.styles["body"].chars()
+
+
+def test_atlas_covers_expected_body_chars_with_real_crops():
+    atlas = _atlas()
+    for ch in "AB12":
+        crop = atlas.glyph(ch, role="body")
+        assert crop is not None, ch
+        assert crop.image.mode == "RGBA"
+        assert crop.width >= 1 and crop.height >= 1
+
+
+def test_bold_lookup_falls_back_to_body_for_missing_char():
+    atlas = _atlas()
+    # '@' is in neither style; bold lookup returns None without raising.
+    assert atlas.glyph("@", bold=True) is None
+    # A char present in body but (hypothetically) not bold still resolves.
+    assert atlas.glyph("A", bold=True) is not None
+
+
+def test_variation_report_shape():
+    report = _atlas().variation_report()
+    assert report["merchant_name"] == "TestMart"
+    assert report["logo_present"] is True
+    assert "body" in report["styles"]
+    assert report["styles"]["bold"]["weight"] == "bold"
+    assert report["covered_char_count"] >= 4
+
+
+def test_save_and_load_atlas_round_trips(tmp_path):
+    atlas = _atlas()
+    save_atlas(atlas, str(tmp_path))
+    loaded = load_atlas(str(tmp_path))
+    assert loaded.merchant_name == atlas.merchant_name
+    assert set(loaded.styles) == set(atlas.styles)
+    assert loaded.logo is not None
+    assert loaded.covered_chars() == atlas.covered_chars()
+    # Glyph images survive the round trip as RGBA.
+    crop = loaded.glyph("A", role="body")
+    assert crop is not None and crop.image.mode == "RGBA"
+
+
+def test_oversized_letter_box_is_rejected():
+    """A 'letter' whose box spans a whole word must not enter the atlas."""
+    inputs = _build_inputs()
+    letters = inputs[0]["letters"]
+    image = inputs[0]["raw_image"]
+    draw = ImageDraw.Draw(image)
+    # A bogus 'Z' letter with a word-wide box (10x the median glyph width).
+    bogus = _letter("Z", 0.05, 0.30, 0.80, 0.02,
+                    line_id=99, word_id=9, letter_id=1)
+    _paint(draw, bogus, ink_coverage=0.4)
+    letters.append(bogus)
+    atlas = build_glyph_atlas(inputs, "TestMart", min_samples=5)
+    assert atlas is not None
+    # 'Z' only ever appears as the bogus word-wide box; rejecting it means no 'Z'
+    # glyph enters the atlas at all.
+    assert "Z" not in atlas.covered_chars()
+
+
+def test_real_thermal_dash_passes_aspect_guard():
+    """On real thermal receipts a tight-ink hyphen is ~1.2 aspect (thick mark),
+    so it passes the char-agnostic aspect guard with no special-case exemption —
+    and keeping the guard char-agnostic leaves no merge hole for a '-x' crop."""
+    inputs = _build_inputs()
+    letters = inputs[0]["letters"]
+    image = inputs[0]["raw_image"]
+    draw = ImageDraw.Draw(image)
+    for li, ytop in enumerate((0.62, 0.60), start=20):
+        dash = _letter("-", 0.30, ytop, 0.022, 0.02,
+                       line_id=li, word_id=7, letter_id=1)
+        box = dash["bounding_box"]
+        left = box["x"] * _W
+        right = (box["x"] + box["width"]) * _W
+        midy = (1.0 - box["y"] - box["height"] / 2) * _H
+        # A thick dash mark (~1.3 aspect), like the real Vons '-' crops.
+        draw.rectangle([left + 1, midy - 3, right - 1, midy + 3], fill=(10, 10, 10))
+        letters.append(dash)
+    atlas = build_glyph_atlas(inputs, "TestMart", min_samples=5)
+    assert atlas is not None
+    crop = atlas.glyph("-")
+    assert crop is not None
+    assert crop.aspect <= 1.7  # naturally passes; no exemption needed
+
+
+def test_build_returns_none_without_usable_receipts():
+    assert build_glyph_atlas([], "Empty") is None
+    assert build_glyph_atlas(
+        [{"image_id": "x", "receipt_id": 1, "letters": [], "raw_image": None}],
+        "Empty",
+    ) is None

--- a/receipt_agent/tests/test_glyph_atlas.py
+++ b/receipt_agent/tests/test_glyph_atlas.py
@@ -236,6 +236,40 @@ def test_real_thermal_dash_passes_aspect_guard():
     assert crop.aspect <= 1.7  # naturally passes; no exemption needed
 
 
+def test_edge_sliver_is_trimmed():
+    """A thin detached ink column at a glyph's edge (neighbour bleed) is removed,
+    while the main glyph body is kept."""
+    image = Image.new("RGB", (60, 40), (250, 250, 250))
+    d = ImageDraw.Draw(image)
+    d.rectangle([18, 10, 40, 34], fill=(8, 8, 8))   # main glyph body
+    d.rectangle([6, 12, 7, 32], fill=(8, 8, 8))      # 1px detached sliver, gap between
+    box = {"x": 0.05, "y": 0.05, "width": 0.9, "height": 0.85}
+    trimmed = extract_glyph_image(image, box, y_origin="top_left",
+                                  expand_x_ratio=0.0, expand_y_ratio=0.0,
+                                  trim_edge_slivers=True)
+    untrimmed = extract_glyph_image(image, box, y_origin="top_left",
+                                    expand_x_ratio=0.0, expand_y_ratio=0.0,
+                                    trim_edge_slivers=False)
+    assert trimmed is not None and untrimmed is not None
+    # Trimming drops the sliver + the gap, so the trimmed glyph is narrower.
+    assert trimmed.width < untrimmed.width
+
+
+def test_vertically_split_glyph_not_trimmed():
+    """A char split only vertically (like ':') is a single column-run, so the
+    sliver trim must leave it intact."""
+    image = Image.new("RGB", (40, 60), (250, 250, 250))
+    d = ImageDraw.Draw(image)
+    d.rectangle([16, 8, 24, 16], fill=(8, 8, 8))    # top dot
+    d.rectangle([16, 40, 24, 48], fill=(8, 8, 8))   # bottom dot
+    box = {"x": 0.05, "y": 0.05, "width": 0.9, "height": 0.9}
+    glyph = extract_glyph_image(image, box, y_origin="top_left",
+                                expand_x_ratio=0.0, expand_y_ratio=0.0)
+    assert glyph is not None
+    # Both dots retained: the glyph spans the full vertical extent of the marks.
+    assert glyph.height >= 30
+
+
 def test_build_returns_none_without_usable_receipts():
     assert build_glyph_atlas([], "Empty") is None
     assert build_glyph_atlas(

--- a/receipt_agent/tests/test_glyph_atlas.py
+++ b/receipt_agent/tests/test_glyph_atlas.py
@@ -182,6 +182,9 @@ def test_tall_promo_line_does_not_replace_logo():
     assert _logo_match_score("SAVE MART", "Save Mart") == 1.0
     assert _logo_match_score("SAVE MART", "Save Mart Supermarkets") == 1.0
     assert _logo_match_score("HOT TOPIC", "Hot Topic Inc") == 1.0
+    assert _logo_match_score("MART", "Save Mart") < 0.75
+    assert _logo_match_score("SAVE", "Save Mart Supermarkets") < 0.75
+    assert _logo_match_score("TOPIC", "Hot Topic Inc") < 0.75
     assert _logo_match_score("SAVE BIG", "Save Mart Supermarkets") < 0.75
 
     atlas = build_glyph_atlas(inputs, "TestMart", min_samples=5)

--- a/receipt_agent/tests/test_glyph_atlas.py
+++ b/receipt_agent/tests/test_glyph_atlas.py
@@ -12,6 +12,8 @@ from PIL import Image, ImageDraw
 
 from receipt_agent.agents.label_evaluator.rendering.glyph_atlas import (
     GlyphAtlas,
+    _is_promo_text,
+    _logo_match_score,
     build_glyph_atlas,
     extract_glyph_image,
     load_atlas,
@@ -152,6 +154,39 @@ def test_atlas_captures_logo_and_excludes_it_from_body():
     assert atlas.logo_text in ("VS", "SV")  # order by center-x
     # The tall logo glyphs (V, S) must not pollute the body char set.
     assert "V" not in atlas.styles["body"].chars()
+
+
+def test_tall_promo_line_does_not_replace_logo():
+    inputs = _build_inputs()
+    letters = inputs[0]["letters"]
+    image = inputs[0]["raw_image"]
+    draw = ImageDraw.Draw(image)
+    x = 0.05
+    for word_id, word in enumerate(("MEMBER", "SAVINGS"), start=1):
+        for i, ch in enumerate(word, start=1):
+            letter = _letter(
+                ch, x, 0.88, 0.030, 0.07,
+                line_id=77, word_id=word_id, letter_id=i,
+            )
+            _paint(draw, letter, ink_coverage=0.6)
+            letters.append(letter)
+            x += 0.038
+        x += 0.045
+
+    assert _is_promo_text("SAVE50%OFF")
+    assert _is_promo_text("MEMBER SAVINGS")
+    assert _is_promo_text("MEMBERSAVINGS")
+    assert not _is_promo_text("TARGET")
+    assert not _is_promo_text("OFFICE DEPOT")
+    assert _logo_match_score("VONS", "Vons") == 1.0
+    assert _logo_match_score("SAVE MART", "Save Mart") == 1.0
+    assert _logo_match_score("SAVE MART", "Save Mart Supermarkets") == 1.0
+    assert _logo_match_score("HOT TOPIC", "Hot Topic Inc") == 1.0
+    assert _logo_match_score("SAVE BIG", "Save Mart Supermarkets") < 0.75
+
+    atlas = build_glyph_atlas(inputs, "TestMart", min_samples=5)
+    assert atlas is not None
+    assert atlas.logo_text in ("VS", "SV")
 
 
 def test_atlas_covers_expected_body_chars_with_real_crops():

--- a/receipt_agent/tests/test_glyph_renderer.py
+++ b/receipt_agent/tests/test_glyph_renderer.py
@@ -151,6 +151,40 @@ def test_missing_glyph_invokes_fallback():
     assert "Z" in calls
 
 
+def test_numeric_body_source_uses_fallback_for_amount_tokens():
+    atlas = _atlas()
+    calls = []
+
+    def fallback(char, style, px_height):
+        calls.append(char)
+        return Image.new("RGBA", (px_height // 2, px_height), (0, 0, 0, 255))
+
+    receipt = {"words": [_word("12.30", 100, 800, 260, 830, ["LINE_TOTAL"])]}
+    config = GlyphRenderConfig(
+        width=300, height=700, noise=0.0, blur=0.0,
+        body_glyph_source="numeric",
+    )
+    render_receipt_glyphs(receipt, atlas, config=config, fallback=fallback)
+    assert calls == list("12.30")
+
+
+def test_numeric_body_source_keeps_plain_words_on_atlas():
+    atlas = _atlas()
+    calls = []
+
+    def fallback(char, style, px_height):
+        calls.append(char)
+        return Image.new("RGBA", (px_height // 2, px_height), (0, 0, 0, 255))
+
+    receipt = {"words": [_word("ABC", 100, 800, 260, 830)]}
+    config = GlyphRenderConfig(
+        width=300, height=700, noise=0.0, blur=0.0,
+        body_glyph_source="numeric",
+    )
+    render_receipt_glyphs(receipt, atlas, config=config, fallback=fallback)
+    assert calls == []
+
+
 def test_bold_line_renders_without_error():
     atlas = _atlas()
     receipt = {"lines": [

--- a/receipt_agent/tests/test_glyph_renderer.py
+++ b/receipt_agent/tests/test_glyph_renderer.py
@@ -241,6 +241,22 @@ def test_stamp_barcode_draws_only_for_wide_barcode_lines():
     )
     assert sum(1 for px in narrow.convert("L").getdata() if px < 80) == 0
 
+    off_center = Image.new("RGBA", (config.width, config.height), config.paper + (255,))
+    _stamp_barcode(
+        off_center, [_word(digits, 0, 500, 450, 520)], 1000.0,
+        config, inner_w, inner_h, digits,
+    )
+    assert sum(1 for px in off_center.convert("L").getdata() if px < 80) == 0
+
+    occupied = Image.new("RGBA", (config.width, config.height), config.paper + (255,))
+    ImageDraw.Draw(occupied).rectangle([100, 130, 200, 138], fill=config.ink + (255,))
+    before = sum(1 for px in occupied.convert("L").getdata() if px < 80)
+    _stamp_barcode(
+        occupied, [_word(digits, 100, 500, 900, 520)], 1000.0,
+        config, inner_w, inner_h, digits,
+    )
+    assert sum(1 for px in occupied.convert("L").getdata() if px < 80) == before
+
 
 def test_flat_receipt_with_degenerate_bboxes_does_not_crash():
     # Non-numeric / short / NaN bboxes in a FLAT word list must be skipped during

--- a/receipt_agent/tests/test_glyph_renderer.py
+++ b/receipt_agent/tests/test_glyph_renderer.py
@@ -18,8 +18,10 @@ from receipt_agent.agents.label_evaluator.rendering.font_profile import (
 from receipt_agent.agents.label_evaluator.rendering.glyph_renderer import (
     GlyphRenderConfig,
     _glyph_height_px,
+    _line_barcode_digits,
     _pitch_norm,
     _snap_to_pitch,
+    _stamp_barcode,
     render_real_vs_glyph,
     render_receipt_glyphs,
     save_receipt_glyphs,
@@ -205,6 +207,39 @@ def test_profile_height_is_clamped_to_row_geometry():
     assert _glyph_height_px(
         line_h=12.0, inner_h=1000, font_h_norm=0.03, row_pitch_px=16.0
     ) == 12.0
+
+
+def test_barcode_digits_accept_long_and_grouped_numbers_only():
+    assert _line_barcode_digits([
+        _word("3509", 100, 200, 180, 220),
+        _word("7155", 190, 200, 270, 220),
+        _word("1559", 280, 200, 360, 220),
+        _word("749120", 370, 200, 500, 220),
+    ]) == "350971551559749120"
+    assert _line_barcode_digits([_word("1234567890123", 100, 200, 300, 220)]) is None
+    assert _line_barcode_digits([_word("12345678901234A", 100, 200, 300, 220)]) is None
+
+
+def test_stamp_barcode_draws_only_for_wide_barcode_lines():
+    config = GlyphRenderConfig(width=300, height=300, margin=10, noise=0.0, blur=0.0)
+    inner_w = config.width - config.margin * 2
+    inner_h = config.height - config.margin * 2
+    digits = "123456789012345678"
+
+    wide = Image.new("RGBA", (config.width, config.height), config.paper + (255,))
+    _stamp_barcode(
+        wide, [_word(digits, 100, 500, 900, 520)], 1000.0,
+        config, inner_w, inner_h, digits,
+    )
+    wide_dark = sum(1 for px in wide.convert("L").getdata() if px < 80)
+    assert wide_dark > 100
+
+    narrow = Image.new("RGBA", (config.width, config.height), config.paper + (255,))
+    _stamp_barcode(
+        narrow, [_word(digits, 100, 500, 300, 520)], 1000.0,
+        config, inner_w, inner_h, digits,
+    )
+    assert sum(1 for px in narrow.convert("L").getdata() if px < 80) == 0
 
 
 def test_flat_receipt_with_degenerate_bboxes_does_not_crash():

--- a/receipt_agent/tests/test_glyph_renderer.py
+++ b/receipt_agent/tests/test_glyph_renderer.py
@@ -7,6 +7,7 @@ stamped, the logo gate works, and missing-glyph fallback is invoked.
 
 from __future__ import annotations
 
+import pytest
 from PIL import Image, ImageDraw
 
 from receipt_agent.agents.label_evaluator.rendering.glyph_atlas import (
@@ -22,6 +23,7 @@ from receipt_agent.agents.label_evaluator.rendering.glyph_renderer import (
     _pitch_norm,
     _snap_to_pitch,
     _stamp_barcode,
+    _thermal_finish,
     render_real_vs_glyph,
     render_receipt_glyphs,
     save_receipt_glyphs,
@@ -256,6 +258,28 @@ def test_stamp_barcode_draws_only_for_wide_barcode_lines():
         config, inner_w, inner_h, digits,
     )
     assert sum(1 for px in occupied.convert("L").getdata() if px < 80) == before
+
+
+def test_thermal_finish_paper_realism_is_deterministic_and_disableable():
+    pytest.importorskip("numpy")
+    base = Image.new("RGBA", (12, 12), (250, 249, 245, 255))
+    ImageDraw.Draw(base).rectangle([3, 4, 8, 7], fill=(30, 30, 30, 255))
+
+    flat_config = GlyphRenderConfig(
+        width=12, height=12, blur=0.0, paper_realism=0.0
+    )
+    flat = _thermal_finish(base, flat_config)
+    assert flat.mode == "RGB"
+    assert flat.getpixel((0, 0)) == (250, 249, 245)
+
+    realism_config = GlyphRenderConfig(
+        width=12, height=12, blur=0.0, seed=123, paper_realism=0.8
+    )
+    first = _thermal_finish(base, realism_config)
+    second = _thermal_finish(base, realism_config)
+    assert first.mode == "RGB"
+    assert first.tobytes() == second.tobytes()
+    assert first.tobytes() != flat.tobytes()
 
 
 def test_flat_receipt_with_degenerate_bboxes_does_not_crash():

--- a/receipt_agent/tests/test_glyph_renderer.py
+++ b/receipt_agent/tests/test_glyph_renderer.py
@@ -12,8 +12,13 @@ from PIL import Image, ImageDraw
 from receipt_agent.agents.label_evaluator.rendering.glyph_atlas import (
     build_glyph_atlas,
 )
+from receipt_agent.agents.label_evaluator.rendering.font_profile import (
+    MerchantFontProfile,
+)
 from receipt_agent.agents.label_evaluator.rendering.glyph_renderer import (
     GlyphRenderConfig,
+    _snap_to_pitch,
+    render_real_vs_glyph,
     render_receipt_glyphs,
     save_receipt_glyphs,
 )
@@ -80,6 +85,19 @@ def _receipt():
     ]}
 
 
+def _profile(char_width=0.02, font_height=0.02):
+    return MerchantFontProfile(
+        merchant_name="TestMart",
+        receipt_count=1,
+        font_height=font_height,
+        char_width=char_width,
+        char_aspect=char_width / font_height,
+        line_pitch=None,
+        price_column_x=None,
+        dominant_style_label="test",
+    )
+
+
 def test_render_returns_image_of_config_size():
     config = GlyphRenderConfig(width=300, height=700, noise=0.0, blur=0.0)
     image = render_receipt_glyphs(_receipt(), _atlas(), config=config)
@@ -142,6 +160,31 @@ def test_save_receipt_glyphs(tmp_path):
                                config=GlyphRenderConfig(noise=0.0, blur=0.0))
     with Image.open(path) as img:
         assert img.format == "PNG"
+
+
+def test_save_and_comparison_helpers_accept_font_profile(tmp_path):
+    config = GlyphRenderConfig(width=300, height=700, noise=0.0, blur=0.0)
+    profile = _profile(char_width=0.018)
+
+    out = str(tmp_path / "profiled.png")
+    save_receipt_glyphs(_receipt(), _atlas(), out, profile=profile,
+                        config=config)
+    with Image.open(out) as img:
+        assert img.size == (300, 700)
+
+    real = Image.new("RGB", (80, 160), (255, 255, 255))
+    comparison = render_real_vs_glyph(
+        real, _receipt(), _atlas(), profile=profile, config=config
+    )
+    assert comparison.height == 722  # render height plus label banner
+
+
+def test_snap_to_pitch_uses_render_margin_as_grid_origin():
+    # The renderer's pixel boxes already include config.margin. Fixed-pitch
+    # snapping must preserve that origin, otherwise every line drifts by
+    # margin % pitch and price columns no longer sit on the receipt grid.
+    assert _snap_to_pitch(19.0, 6.0, origin=10.0) == 22.0
+    assert _snap_to_pitch(19.0, 6.0, origin=0.0) == 18.0
 
 
 def test_flat_receipt_with_degenerate_bboxes_does_not_crash():

--- a/receipt_agent/tests/test_glyph_renderer.py
+++ b/receipt_agent/tests/test_glyph_renderer.py
@@ -20,6 +20,7 @@ from receipt_agent.agents.label_evaluator.rendering.glyph_renderer import (
     GlyphRenderConfig,
     _glyph_variant_index,
     _glyph_height_px,
+    _line_is_logo,
     _line_is_rule,
     _line_barcode_digits,
     _pitch_norm,
@@ -133,6 +134,36 @@ def test_logo_gate_only_fires_on_tall_merchant_line():
     # Should render glyphs (not crash, not stamp logo); ink present.
     image = render_receipt_glyphs(receipt, atlas, config=config)
     assert image.convert("L").getextrema()[0] < 150
+
+
+def _tall(text, labels, x0=100):
+    # A display-height word (height 30) near the top of the receipt.
+    return _word(text, x0, 950, x0 + max(1, len(text)) * 12, 980, labels)
+
+
+def test_logo_gate_matches_wordmark_and_rejects_mislabelled_lines():
+    BODY = 10.0  # body_h_ref; tall words are 30 -> 3x, past the 1.6x gate
+    # genuine wordmark line is stamped as the logo
+    assert _line_is_logo([_tall("VONS", ["MERCHANT_NAME"])], BODY, "VONS")
+    # a partial wordmark token still matches the full mark ("CVS" in "CVS pharmacy")
+    assert _line_is_logo([_tall("CVS", ["MERCHANT_NAME"])], BODY, "•CVS pharmacy")
+    # a mislabelled time / price / phone that happens to be tall + MERCHANT_NAME
+    # tagged must NOT pull in the logo image (it does not match the wordmark)
+    assert not _line_is_logo([_tall("6:33", ["MERCHANT_NAME"])], BODY, "COSTCO")
+    assert not _line_is_logo([_tall("17.49", ["MERCHANT_NAME"])], BODY, "COSTCO")
+    assert not _line_is_logo([_tall("495-4938", ["MERCHANT_NAME"])], BODY, "•CVS pharmacy")
+
+
+def test_logo_gate_rejects_promo_sentence_mentioning_merchant():
+    BODY = 10.0
+    # "to WIN a $250 Sprouts gift card. Go to:" — tall, one word MERCHANT_NAME
+    # tagged, but a sentence, so the logo image must not stamp over it.
+    promo = [
+        _tall("to", [], 60), _tall("WIN", [], 90), _tall("a", [], 140),
+        _tall("$250", [], 170), _tall("Sprouts", ["MERCHANT_NAME"], 230),
+        _tall("gift", [], 320), _tall("card", [], 380), _tall("Go", [], 440),
+    ]
+    assert not _line_is_logo(promo, BODY, "SPROUTS")
 
 
 def test_missing_glyph_invokes_fallback():

--- a/receipt_agent/tests/test_glyph_renderer.py
+++ b/receipt_agent/tests/test_glyph_renderer.py
@@ -1,0 +1,165 @@
+"""Tests for the glyph-stamping renderer (deterministic, no AWS).
+
+Builds a tiny atlas from a synthetic raw image (same approach as
+``test_glyph_atlas``), then renders synthesized receipt dicts and asserts ink is
+stamped, the logo gate works, and missing-glyph fallback is invoked.
+"""
+
+from __future__ import annotations
+
+from PIL import Image, ImageDraw
+
+from receipt_agent.agents.label_evaluator.rendering.glyph_atlas import (
+    build_glyph_atlas,
+)
+from receipt_agent.agents.label_evaluator.rendering.glyph_renderer import (
+    GlyphRenderConfig,
+    render_receipt_glyphs,
+    save_receipt_glyphs,
+)
+
+_W, _H = 320, 1600
+
+
+def _letter(char, x, y, w, h, *, line_id, word_id, letter_id):
+    return {
+        "text": char, "confidence": 0.99, "image_id": "img-1", "receipt_id": 1,
+        "line_id": line_id, "word_id": word_id, "letter_id": letter_id,
+        "bounding_box": {"x": x, "y": y, "width": w, "height": h},
+    }
+
+
+def _atlas():
+    import math
+    letters = []
+    image = Image.new("RGB", (_W, _H), (250, 249, 246))
+    draw = ImageDraw.Draw(image)
+
+    def add(char, x, y, w, h, *, line_id, word_id, letter_id, coverage):
+        lt = _letter(char, x, y, w, h, line_id=line_id, word_id=word_id,
+                     letter_id=letter_id)
+        box = lt["bounding_box"]
+        left = box["x"] * _W
+        right = (box["x"] + box["width"]) * _W
+        top = (1.0 - box["y"] - box["height"]) * _H
+        bottom = (1.0 - box["y"]) * _H
+        frac = math.sqrt(coverage)
+        iw, ih = (right - left) * frac, (bottom - top) * frac
+        cx, cy = (left + right) / 2, (top + bottom) / 2
+        draw.rectangle([cx - iw / 2, cy - ih / 2, cx + iw / 2, cy + ih / 2],
+                       fill=(10, 10, 10))
+        letters.append(lt)
+
+    # Logo line + body lines covering the chars we render below.
+    add("V", 0.30, 0.94, 0.05, 0.045, line_id=1, word_id=1, letter_id=1, coverage=0.6)
+    add("S", 0.40, 0.94, 0.05, 0.045, line_id=1, word_id=1, letter_id=2, coverage=0.6)
+    chars = "ABC123"
+    for li, ytop in enumerate((0.80, 0.74, 0.68, 0.62), start=2):
+        for wi, ch in enumerate(chars):
+            add(ch, 0.10 + wi * 0.05, ytop, 0.022, 0.02,
+                line_id=li, word_id=2, letter_id=wi + 1, coverage=0.22)
+    atlas = build_glyph_atlas(
+        [{"image_id": "img-1", "receipt_id": 1, "letters": letters,
+          "raw_image": image}], "TestMart", min_samples=5)
+    assert atlas is not None
+    return atlas
+
+
+def _word(text, x0, y0, x1, y1, labels=None):
+    return {"text": text, "bbox": [x0, y0, x1, y1], "labels": labels or []}
+
+
+def _receipt():
+    # 0-1000 space, y high-is-top.
+    return {"lines": [
+        {"line_id": 1, "words": [_word("ABC", 100, 950, 300, 985,
+                                       ["MERCHANT_NAME"])]},  # tall logo line
+        {"line_id": 2, "words": [_word("ABC", 80, 800, 240, 820),
+                                 _word("123", 820, 800, 900, 820,
+                                       ["LINE_TOTAL"])]},
+    ]}
+
+
+def test_render_returns_image_of_config_size():
+    config = GlyphRenderConfig(width=300, height=700, noise=0.0, blur=0.0)
+    image = render_receipt_glyphs(_receipt(), _atlas(), config=config)
+    assert isinstance(image, Image.Image)
+    assert image.size == (300, 700)
+
+
+def test_render_stamps_ink_on_paper():
+    config = GlyphRenderConfig(width=300, height=700, noise=0.0, blur=0.0)
+    image = render_receipt_glyphs(_receipt(), _atlas(), config=config)
+    gray = image.convert("L")
+    darks = [v for v in gray.getdata() if v < 120]
+    assert len(darks) > 50  # real ink was stamped
+
+
+def test_logo_gate_only_fires_on_tall_merchant_line():
+    # A small MERCHANT_NAME line (same height as body) must NOT be replaced by the
+    # logo image — only the genuinely tall display line is.
+    atlas = _atlas()
+    receipt = {"lines": [
+        {"line_id": 1, "words": [_word("ABC", 100, 800, 240, 820,
+                                       ["MERCHANT_NAME"])]},  # body-height
+    ]}
+    config = GlyphRenderConfig(width=300, height=700, noise=0.0, blur=0.0)
+    # Should render glyphs (not crash, not stamp logo); ink present.
+    image = render_receipt_glyphs(receipt, atlas, config=config)
+    assert image.convert("L").getextrema()[0] < 150
+
+
+def test_missing_glyph_invokes_fallback():
+    atlas = _atlas()
+    calls = []
+
+    def fallback(char, style, px_height):
+        calls.append(char)
+        g = Image.new("RGBA", (px_height // 2, px_height), (0, 0, 0, 255))
+        return g
+
+    # 'Z' is not in the atlas -> fallback must be asked for it.
+    receipt = {"words": [_word("Z", 100, 800, 160, 830)]}
+    config = GlyphRenderConfig(width=300, height=700, noise=0.0, blur=0.0)
+    render_receipt_glyphs(receipt, atlas, config=config, fallback=fallback)
+    assert "Z" in calls
+
+
+def test_bold_line_renders_without_error():
+    atlas = _atlas()
+    receipt = {"lines": [
+        {"line_id": 1, "words": [_word("MEMBER", 80, 800, 300, 820),
+                                 _word("SAVINGS", 320, 800, 520, 820)]},
+    ]}
+    config = GlyphRenderConfig(width=400, height=600, noise=0.0, blur=0.0)
+    image = render_receipt_glyphs(receipt, atlas, config=config)
+    assert image.size == (400, 600)
+
+
+def test_save_receipt_glyphs(tmp_path):
+    out = str(tmp_path / "nested" / "r.png")
+    path = save_receipt_glyphs(_receipt(), _atlas(), out,
+                               config=GlyphRenderConfig(noise=0.0, blur=0.0))
+    with Image.open(path) as img:
+        assert img.format == "PNG"
+
+
+def test_flat_receipt_with_degenerate_bboxes_does_not_crash():
+    # Non-numeric / short / NaN bboxes in a FLAT word list must be skipped during
+    # line grouping, not crash (matches receipt_renderer's defensive handling).
+    atlas = _atlas()
+    receipt = {"words": [
+        {"text": "BAD", "bbox": [float("nan"), 0, 1, 1]},
+        {"text": "STR", "bbox": "nope"},
+        {"text": "SHORT", "bbox": [1, 2, 3]},
+        {"text": "OK", "bbox": [100, 800, 200, 830]},
+    ]}
+    config = GlyphRenderConfig(width=300, height=400, noise=0.0, blur=0.0)
+    image = render_receipt_glyphs(receipt, atlas, config=config)
+    assert image.size == (300, 400)
+
+
+def test_empty_receipt_returns_paper():
+    config = GlyphRenderConfig(width=80, height=120, noise=0.0, blur=0.0)
+    image = render_receipt_glyphs({"lines": []}, _atlas(), config=config)
+    assert image.size == (80, 120)

--- a/receipt_agent/tests/test_glyph_renderer.py
+++ b/receipt_agent/tests/test_glyph_renderer.py
@@ -17,6 +17,8 @@ from receipt_agent.agents.label_evaluator.rendering.font_profile import (
 )
 from receipt_agent.agents.label_evaluator.rendering.glyph_renderer import (
     GlyphRenderConfig,
+    _glyph_height_px,
+    _pitch_norm,
     _snap_to_pitch,
     render_real_vs_glyph,
     render_receipt_glyphs,
@@ -185,6 +187,24 @@ def test_snap_to_pitch_uses_render_margin_as_grid_origin():
     # margin % pitch and price columns no longer sit on the receipt grid.
     assert _snap_to_pitch(19.0, 6.0, origin=10.0) == 22.0
     assert _snap_to_pitch(19.0, 6.0, origin=0.0) == 18.0
+
+
+def test_profile_pitch_is_clamped_to_receipt_geometry():
+    # A merchant profile is an anchor, not permission to outgrow the row boxes.
+    # The synthetic receipt's own word boxes show 0.01 advance; a noisy/wide
+    # profile should be clipped near that measured pitch instead of causing
+    # right-edge overflow in dense price columns.
+    words = [
+        _word("ABCD", 100, 800, 140, 820),
+        _word("1234", 820, 800, 860, 820, ["LINE_TOTAL"]),
+    ]
+    assert _pitch_norm(words, 1000.0, _profile(char_width=0.03)) == 0.0105
+
+
+def test_profile_height_is_clamped_to_row_geometry():
+    assert _glyph_height_px(
+        line_h=12.0, inner_h=1000, font_h_norm=0.03, row_pitch_px=16.0
+    ) == 12.0
 
 
 def test_flat_receipt_with_degenerate_bboxes_does_not_crash():

--- a/receipt_agent/tests/test_glyph_renderer.py
+++ b/receipt_agent/tests/test_glyph_renderer.py
@@ -18,7 +18,9 @@ from receipt_agent.agents.label_evaluator.rendering.font_profile import (
 )
 from receipt_agent.agents.label_evaluator.rendering.glyph_renderer import (
     GlyphRenderConfig,
+    _glyph_variant_index,
     _glyph_height_px,
+    _line_is_rule,
     _line_barcode_digits,
     _pitch_norm,
     _snap_to_pitch,
@@ -209,6 +211,53 @@ def test_profile_height_is_clamped_to_row_geometry():
     assert _glyph_height_px(
         line_h=12.0, inner_h=1000, font_h_norm=0.03, row_pitch_px=16.0
     ) == 12.0
+
+
+def test_right_edge_overflow_is_clamped_inside_printable_margin():
+    atlas = _atlas()
+    config = GlyphRenderConfig(
+        width=160, height=220, margin=10, noise=0.0, blur=0.0,
+        ink_jitter=0, paper_realism=0.0,
+    )
+    receipt = {"lines": [
+        {"line_id": 1, "words": [_word("ABC123", 900, 800, 1080, 830)]},
+    ]}
+    image = render_receipt_glyphs(receipt, atlas, config=config, coord_max=1000.0)
+    gray = image.convert("L")
+    assert any(value < 120 for value in gray.getdata())
+    page_right = config.width - config.margin
+    right_margin = [
+        gray.getpixel((x, y))
+        for x in range(page_right, config.width)
+        for y in range(config.height)
+    ]
+    assert all(value >= 120 for value in right_margin)
+
+
+def test_glyph_variant_index_uses_cleanest_crop_for_text_legibility():
+    style = _atlas().style_for_role("body")
+    assert style is not None
+    config = GlyphRenderConfig(seed=77)
+    word_seed = 12345
+
+    first = _glyph_variant_index(
+        config, style, bold=False, word_seed=word_seed, char="s"
+    )
+    second = _glyph_variant_index(
+        config, style, bold=False, word_seed=word_seed, char="S"
+    )
+    assert first == second
+    assert first == 0
+
+
+def test_rule_lines_are_detected_as_structural_rules():
+    assert _line_is_rule([_word("********", 100, 500, 300, 520)])
+    assert _line_is_rule([
+        _word("----", 100, 500, 180, 520),
+        _word("----", 190, 500, 270, 520),
+    ])
+    assert not _line_is_rule([_word("TOTAL", 100, 500, 180, 520)])
+    assert not _line_is_rule([_word("***", 100, 500, 130, 520)])
 
 
 def test_barcode_digits_accept_long_and_grouped_numbers_only():

--- a/receipt_agent/tests/test_glyph_ttf_fallback.py
+++ b/receipt_agent/tests/test_glyph_ttf_fallback.py
@@ -1,0 +1,124 @@
+"""Tests for the embedding-matched TTF fallback (M3).
+
+Builds a small real-crop atlas, then checks the fallback font matcher and the
+fallback glyph hook. A monospace TTF must be available; the suite skips if the
+host has none (CI without system fonts)."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+from PIL import Image, ImageDraw
+
+from receipt_agent.agents.label_evaluator.rendering.glyph_atlas import (
+    build_glyph_atlas,
+)
+from receipt_agent.agents.label_evaluator.rendering.glyph_ttf_fallback import (
+    available_candidates,
+    make_ttf_fallback,
+    match_fallback_font,
+)
+
+_W, _H = 320, 1600
+_HAS_TTF = bool(available_candidates())
+_skip_no_ttf = pytest.mark.skipif(not _HAS_TTF, reason="no monospace TTF on host")
+
+
+def _letter(char, x, y, w, h, *, line_id, word_id, letter_id):
+    return {
+        "text": char, "confidence": 0.99, "image_id": "img-1", "receipt_id": 1,
+        "line_id": line_id, "word_id": word_id, "letter_id": letter_id,
+        "bounding_box": {"x": x, "y": y, "width": w, "height": h},
+    }
+
+
+def _atlas():
+    letters = []
+    image = Image.new("RGB", (_W, _H), (250, 249, 246))
+    draw = ImageDraw.Draw(image)
+
+    def add(char, x, y, w, h, *, line_id, word_id, letter_id, coverage):
+        lt = _letter(char, x, y, w, h, line_id=line_id, word_id=word_id,
+                     letter_id=letter_id)
+        box = lt["bounding_box"]
+        left, right = box["x"] * _W, (box["x"] + box["width"]) * _W
+        top = (1.0 - box["y"] - box["height"]) * _H
+        bottom = (1.0 - box["y"]) * _H
+        frac = math.sqrt(coverage)
+        iw, ih = (right - left) * frac, (bottom - top) * frac
+        cx, cy = (left + right) / 2, (top + bottom) / 2
+        draw.rectangle([cx - iw / 2, cy - ih / 2, cx + iw / 2, cy + ih / 2],
+                       fill=(10, 10, 10))
+        letters.append(lt)
+
+    chars = "ABCEHOST0123"
+    for li, ytop in enumerate((0.80, 0.74, 0.68), start=2):
+        for wi, ch in enumerate(chars):
+            add(ch, 0.06 + wi * 0.06, ytop, 0.022, 0.02,
+                line_id=li, word_id=2, letter_id=wi + 1, coverage=0.22)
+    atlas = build_glyph_atlas(
+        [{"image_id": "img-1", "receipt_id": 1, "letters": letters,
+          "raw_image": image}], "TestMart", min_samples=5)
+    assert atlas is not None
+    return atlas
+
+
+@_skip_no_ttf
+def test_match_picks_an_available_font_with_scores():
+    match = match_fallback_font(_atlas())
+    assert match.font_path in available_candidates()
+    assert match.scores  # one score per candidate
+    assert 0.0 <= match.score <= 1.0
+    # The chosen font is the argmax of the per-font scores.
+    assert match.score == max(match.scores.values())
+
+
+@_skip_no_ttf
+def test_fallback_renders_missing_char_glyph():
+    atlas = _atlas()
+    fallback = make_ttf_fallback(atlas)
+    style = atlas.styles["body"]
+    glyph = fallback("Z", style, 30)  # 'Z' is not in the atlas
+    assert glyph is not None
+    assert glyph.mode == "RGBA"
+    # Real ink drawn, sized roughly to the requested cap height.
+    assert max(glyph.getchannel("A").getdata()) > 200
+    assert 12 <= glyph.height <= 60
+
+
+@_skip_no_ttf
+def test_fallback_skips_blank_and_degenerate():
+    atlas = _atlas()
+    fallback = make_ttf_fallback(atlas)
+    style = atlas.styles["body"]
+    assert fallback(" ", style, 30) is None
+    assert fallback("Z", style, 0) is None
+
+
+@_skip_no_ttf
+def test_custom_score_font_hook_is_used():
+    # A scorer that always prefers the last candidate must drive the choice.
+    cands = available_candidates()
+    target = cands[-1]
+
+    def scorer(path, probe):
+        return 1.0 if path == target else 0.0
+
+    match = match_fallback_font(_atlas(), score_font=scorer)
+    assert match.font_path == target
+
+
+@_skip_no_ttf
+def test_fallback_integrates_with_renderer():
+    from receipt_agent.agents.label_evaluator.rendering.glyph_renderer import (
+        GlyphRenderConfig, render_receipt_glyphs,
+    )
+    atlas = _atlas()
+    fallback = make_ttf_fallback(atlas)
+    # 'Z'/'Q' missing from atlas -> fallback fills them; render must not crash.
+    receipt = {"words": [{"text": "ZQ", "bbox": [100, 800, 220, 830],
+                          "labels": []}]}
+    cfg = GlyphRenderConfig(width=300, height=700, noise=0.0, blur=0.0)
+    image = render_receipt_glyphs(receipt, atlas, config=cfg, fallback=fallback)
+    assert image.convert("L").getextrema()[0] < 150  # ink present


### PR DESCRIPTION
## What this is
Renders synthesized receipts using each receipt's **actual letterforms** — a per-merchant **glyph atlas** built from real letter crops, style-aware (header/body/totals), with an embedding-matched thermal/POS **TTF fallback** for missing chars. **Review-realism only** — the structured receipt (tokens+boxes+labels) stays the sole training artifact; image-training is out (no CoreML v3). Realistic renders make human review of synthesis sharper.

Modules under `receipt_agent/.../rendering/`: `glyph_atlas.py`, `glyph_renderer.py`, `glyph_ttf_fallback.py` (charter M1–M3), on top of the merged font-render foundation. 14 commits, including "hill-climb" iterations for photographic thermal-paper realism, barcode rendering, row-pitch spacing, promo-aware logo, and atlas-crop fixes.

## Result (visually reviewed)
A Vons remove-line-item receipt rendered with the glyph atlas is, at a glance, **hard to distinguish from the real receipt** — same letterforms, thermal-paper texture, barcode, and promo footer. Honest nits: body text slightly heavier than real, paper noise a touch uniform — polish, not failures. (Real-vs-render gallery reviewed; the glyph render is convincing.)

## What happened (recovery note)
The entire implementation was **committed locally on the mini but never pushed** — all 14 commits were stranded on the box, plus uncommitted in-flight changes to `glyph_renderer.py` + its test. The mini had become unreachable from a remote MacBook due to a **`192.168.0.x` subnet collision** (both networks used the same private range, so the OS routed the mini's LAN IP locally and never through WARP). Resolved by adding a `/32` Cloudflare tunnel route for the mini + moving the MacBook onto a phone hotspot to dodge the collision. The work was then committed (`87d6a6f4c` checkpoints the in-flight renderer changes) and pushed — nothing is stranded now.

## Status
- Review-realism only; not wired into training.
- The glyph-rendering session is still iterating; this PR captures the current state and protects the work.
- Follow-up before merge: broaden the gallery to 2–3 merchants × operations (charter acceptance), and a codex pass on the latest renderer diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)