### PR TITLE
feat(analytics): materialize IP geo/hosting, fold into is_bot, retire lookup_ip

### DIFF
--- a/infra/components/web_analytics/README.md
+++ b/infra/components/web_analytics/README.md
@@ -43,6 +43,13 @@ SERVE       analytics_* MCP tools SELECT from web_events (partition-pruned)
 - **Dedups** on `request_id` (CloudFront can re-deliver lines).
 - Partition is the **UTC** log date; the serve layer buckets to PT and widens
   the scan ±1 day so PT-day edges are correct.
+- **IP enrichment:** before each rebuild the transform resolves any newly-seen
+  (non-WARP) IP via an IP-info service, caching org/geo/hosting/proxy in the
+  `ip_geo` table (each IP looked up once). The rebuild LEFT JOINs `ip_geo` to
+  materialize `org` / `city` / `country` / `is_hosting` on `web_events` and to
+  fold **`hosting` into `is_bot`** — so datacenter beacons (Azure, Hetzner, AWS)
+  that fake a browser UA no longer leak into human counts. `human_sessions` is
+  now trustworthy without any client-side join.
 
 ### Backfill (after first deploy)
 ```
@@ -64,10 +71,9 @@ IaC.
 | Tool | Purpose |
 |---|---|
 | `analytics_traffic(start, end)` | per-PT-day requests, outside-human vs WARP vs bot, human sessions/pageviews |
-| `analytics_sessions(start, end, humans_only)` | reconstructed beacon sessions (pages, scroll, reader-summaries) |
-| `analytics_top(dimension, start, end)` | top `page` / `referrer` / `ip` |
+| `analytics_sessions(start, end, humans_only)` | reconstructed beacon sessions with **org / city / country / is_hosting** inline (pages, scroll, reader-summaries) |
+| `analytics_top(dimension, start, end)` | top `page` / `referrer` / `ip` / `country` / `org` |
 | `analytics_ip(ip, start, end)` | full page-level timeline for one IP |
-| `analytics_lookup_ip(ips)` | live org / geo / network-type (hosting/proxy) for IPs — who a visitor is |
 | `analytics_ga(start, end)` | daily GA4 metrics (sessions/users/pageviews/engaged) |
 | `analytics_reconcile(start, end)` | GA4 vs first-party beacon, per day (reveals adblock gap / bot leakage) |
 | `analytics_query(sql)` | read-only SELECT/WITH escape hatch |
@@ -97,13 +103,13 @@ side by side per day — beacon > GA usually means adblock loss.
 - **Human session:** an analytics-beacon (`/analytics/pixel.txt`) session id,
   excluding WARP + bots
 
-> Note: IP-level geo/org (e.g. "this IP is LangChain") is intentionally **not**
-> a materialized column — at this volume it's freshest on demand. Use the
-> `analytics_lookup_ip` tool (live IP-info lookup) to resolve org / geo /
-> hosting flags for IPs surfaced by the other tools.
-> Datacenter/residential-bot beacons that fake a browser UA can
-> still slip into `human_sessions`; treat that count as an upper bound and
-> confirm individual IPs with `analytics_ip` + an IP-info service.
+> Note: IP org/geo/hosting is now a **materialized column** on `web_events`
+> (enriched once per IP into `ip_geo`), and `is_bot` folds in the `hosting`
+> flag — so `analytics_sessions` returns org/city/country/is_hosting directly
+> and `human_sessions` excludes datacenter beacons without any client-side
+> lookup. Residual gap: residential-ISP bots (e.g. some mobile crawler farms)
+> aren't flagged `hosting`, so a small number can still register as human —
+> inspect with `analytics_top('country'/'org')` if a spike looks off.
 
 ## Deployment
 

--- a/infra/components/web_analytics/__init__.py
+++ b/infra/components/web_analytics/__init__.py
@@ -216,6 +216,11 @@ class WebAnalytics(ComponentResource):
             ("is_warp", "boolean"),
             ("is_bot", "boolean"),
             ("edge_location", "string"),
+            ("country", "string"),
+            ("city", "string"),
+            ("org", "string"),
+            ("asn", "string"),
+            ("is_hosting", "boolean"),
         ]
         self.web_events_table = aws.glue.CatalogTable(
             f"{name}-web-events-table",
@@ -368,6 +373,49 @@ class WebAnalytics(ComponentResource):
                         name=col, type=typ
                     )
                     for col, typ in ga_columns
+                ],
+                ser_de_info=_SerDeInfo(
+                    serialization_library=(
+                        "org.openx.data.jsonserde.JsonSerDe"
+                    ),
+                ),
+            ),
+            opts=child,
+        )
+
+        # --- IP geo/ASN/hosting dimension (NDJSON, upserted by transform) ---
+        ip_geo_columns = [
+            ("ip", "string"),
+            ("country", "string"),
+            ("region", "string"),
+            ("city", "string"),
+            ("isp", "string"),
+            ("org", "string"),
+            ("asn", "string"),
+            ("hosting", "boolean"),
+            ("proxy", "boolean"),
+            ("mobile", "boolean"),
+        ]
+        self.ip_geo_table = aws.glue.CatalogTable(
+            f"{name}-ip-geo-table",
+            name="ip_geo",
+            database_name=self.database.name,
+            table_type="EXTERNAL_TABLE",
+            parameters={"EXTERNAL": "TRUE", "classification": "json"},
+            storage_descriptor=aws.glue.CatalogTableStorageDescriptorArgs(
+                location=self.curated_bucket.bucket.apply(
+                    lambda b: f"s3://{b}/ip_geo/"
+                ),
+                input_format="org.apache.hadoop.mapred.TextInputFormat",
+                output_format=(
+                    "org.apache.hadoop.hive.ql.io."
+                    "HiveIgnoreKeyTextOutputFormat"
+                ),
+                columns=[
+                    aws.glue.CatalogTableStorageDescriptorColumnArgs(
+                        name=col, type=typ
+                    )
+                    for col, typ in ip_geo_columns
                 ],
                 ser_de_info=_SerDeInfo(
                     serialization_library=(

--- a/infra/components/web_analytics/__init__.py
+++ b/infra/components/web_analytics/__init__.py
@@ -378,6 +378,7 @@ class WebAnalytics(ComponentResource):
                     serialization_library=(
                         "org.openx.data.jsonserde.JsonSerDe"
                     ),
+                    parameters={"ignore.malformed.json": "true"},
                 ),
             ),
             opts=child,
@@ -421,6 +422,7 @@ class WebAnalytics(ComponentResource):
                     serialization_library=(
                         "org.openx.data.jsonserde.JsonSerDe"
                     ),
+                    parameters={"ignore.malformed.json": "true"},
                 ),
             ),
             opts=child,

--- a/infra/components/web_analytics/transform_lambda/handler.py
+++ b/infra/components/web_analytics/transform_lambda/handler.py
@@ -91,12 +91,22 @@ def _enrich_ips(dts: list, deadline: float) -> int:
     ip_geo NDJSON. Each IP is looked up once and cached; web_events joins it.
     """
     likes = " OR ".join(f"\"$path\" LIKE '%.{dt}-%'" for dt in dts)
+    # Anti-join against ip_geo and LIMIT in Athena so the Lambda only fetches
+    # up to the cap of *new* (uncached) IPs — never the full distinct set,
+    # which could OOM a small Lambda on a backfill or bot spike.
     rows = _query_rows(
-        f"SELECT DISTINCT request_ip FROM {DB}.cloudfront_logs_prod "
-        f"WHERE ({likes}) AND NOT regexp_like(request_ip, '{_WARP_RE}')",
+        f"SELECT d.ip FROM ("
+        f" SELECT DISTINCT request_ip AS ip FROM {DB}.cloudfront_logs_prod"
+        f" WHERE ({likes}) AND NOT regexp_like(request_ip, '{_WARP_RE}')"
+        f") d LEFT JOIN {DB}.ip_geo g ON d.ip = g.ip"
+        f" WHERE g.ip IS NULL LIMIT {MAX_NEW_IPS + 1}",
         deadline,
     )
-    seen = {r[0] for r in rows if r and r[0]}
+    new_candidates = [r[0] for r in rows if r and r[0]]
+    # More than the cap came back → truncated; mark incomplete so the caller
+    # defers the rebuild (retries resume, each resolved IP is cached).
+    complete = len(new_candidates) <= MAX_NEW_IPS
+    new_ips = new_candidates[:MAX_NEW_IPS]
 
     existing = {}
     try:
@@ -111,14 +121,6 @@ def _enrich_ips(dts: list, deadline: float) -> int:
                 existing[rec["ip"]] = rec
     except _s3.exceptions.NoSuchKey:
         pass
-
-    pending = [ip for ip in seen if ip not in existing]
-    new_ips = pending[:MAX_NEW_IPS]
-    # "complete" tracks whether we resolved every pending IP this run. If not
-    # (cap truncation, rate/deadline stop, or a failed batch), the caller
-    # defers the rebuild so partial geo never drives classification; retries
-    # converge because each resolved IP is cached.
-    complete = len(new_ips) == len(pending)
     fields = (
         "query,country,regionName,city,isp,org,as,mobile,proxy,hosting,status"
     )
@@ -160,8 +162,12 @@ def _enrich_ips(dts: list, deadline: float) -> int:
         # ip-api's batch endpoint allows ~15 requests/min; stay under it.
         time.sleep(4.0)
 
+    # Zero bytes (not a blank line) when empty, so the JSON SerDe never trips
+    # over an empty record on the LEFT JOIN.
     body_out = (
         "\n".join(json.dumps(existing[ip]) for ip in sorted(existing)) + "\n"
+        if existing
+        else ""
     )
     _s3.put_object(
         Bucket=CURATED_BUCKET,

--- a/infra/components/web_analytics/transform_lambda/handler.py
+++ b/infra/components/web_analytics/transform_lambda/handler.py
@@ -16,8 +16,10 @@ late-delivered logs) or ``{"start": "YYYY-MM-DD", "end": "YYYY-MM-DD"}`` to
 backfill a range.
 """
 
+import json
 import os
 import time
+import urllib.request
 from datetime import datetime, timedelta, timezone
 
 import boto3
@@ -26,7 +28,11 @@ DB = os.environ.get("ANALYTICS_DB", "portfolio_analytics")
 WORKGROUP = os.environ.get("ANALYTICS_WORKGROUP", "portfolio_analytics")
 CURATED_BUCKET = os.environ["CURATED_BUCKET"]
 CURATED_PREFIX = os.environ.get("CURATED_PREFIX", "web_events/")
+IP_GEO_KEY = os.environ.get("IP_GEO_KEY", "ip_geo/data.json")
 REGION = os.environ.get("AWS_REGION", "us-east-1")
+_WARP_RE = "^(104\\.28\\.|2a09:bac)"
+# Safety cap so a huge backfill can't hammer the IP-info service in one run.
+MAX_NEW_IPS = int(os.environ.get("GEO_MAX_NEW_IPS", "2000"))
 
 # Keep in sync with the MCP analytics tools' classification.
 _BOT_RE = (
@@ -62,6 +68,97 @@ def _run(sql: str, deadline: float) -> str:
             f"Athena {status['State']}: {status.get('StateChangeReason')}"
         )
     return qid
+
+
+def _query_rows(sql: str, deadline: float) -> list:
+    qid = _run(sql, deadline)
+    rows, token = [], None
+    while True:
+        kwargs = {"QueryExecutionId": qid, "MaxResults": 1000}
+        if token:
+            kwargs["NextToken"] = token
+        resp = _athena.get_query_results(**kwargs)
+        for row in resp["ResultSet"]["Rows"]:
+            rows.append([c.get("VarCharValue") for c in row["Data"]])
+        token = resp.get("NextToken")
+        if not token:
+            break
+    return rows[1:]  # drop header row
+
+
+def _enrich_ips(dts: list, deadline: float) -> int:
+    """Resolve org/geo/hosting for newly-seen (non-WARP) IPs and upsert the
+    ip_geo NDJSON. Each IP is looked up once and cached; web_events joins it.
+    """
+    likes = " OR ".join(f"\"$path\" LIKE '%.{dt}-%'" for dt in dts)
+    rows = _query_rows(
+        f"SELECT DISTINCT request_ip FROM {DB}.cloudfront_logs_prod "
+        f"WHERE ({likes}) AND NOT regexp_like(request_ip, '{_WARP_RE}')",
+        deadline,
+    )
+    seen = {r[0] for r in rows if r and r[0]}
+
+    existing = {}
+    try:
+        body = (
+            _s3.get_object(Bucket=CURATED_BUCKET, Key=IP_GEO_KEY)["Body"]
+            .read()
+            .decode()
+        )
+        for line in body.splitlines():
+            if line.strip():
+                rec = json.loads(line)
+                existing[rec["ip"]] = rec
+    except _s3.exceptions.NoSuchKey:
+        pass
+
+    new_ips = [ip for ip in seen if ip not in existing][:MAX_NEW_IPS]
+    fields = (
+        "query,country,regionName,city,isp,org,as,mobile,proxy,hosting,status"
+    )
+    for i in range(0, len(new_ips), 100):
+        batch = new_ips[i:i + 100]
+        payload = json.dumps(
+            [{"query": ip, "fields": fields} for ip in batch]
+        ).encode()
+        req = urllib.request.Request(
+            "http://ip-api.com/batch",
+            data=payload,
+            headers={"Content-Type": "application/json"},
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                data = json.load(resp)
+        except Exception:  # pylint: disable=broad-except
+            continue  # best-effort; unresolved IPs simply stay un-enriched
+        for g in data:
+            ip = g.get("query")
+            if not ip:
+                continue
+            existing[ip] = {
+                "ip": ip,
+                "country": g.get("country"),
+                "region": g.get("regionName"),
+                "city": g.get("city"),
+                "isp": g.get("isp"),
+                "org": g.get("org"),
+                "asn": g.get("as"),
+                "hosting": bool(g.get("hosting")),
+                "proxy": bool(g.get("proxy")),
+                "mobile": bool(g.get("mobile")),
+            }
+        time.sleep(1.0)  # be gentle with the IP-info rate limit
+
+    body_out = (
+        "\n".join(json.dumps(existing[ip]) for ip in sorted(existing)) + "\n"
+    )
+    _s3.put_object(
+        Bucket=CURATED_BUCKET,
+        Key=IP_GEO_KEY,
+        Body=body_out.encode(),
+        ContentType="application/x-ndjson",
+    )
+    return len(new_ips)
 
 
 def _insert_sql(dt: str) -> str:
@@ -104,12 +201,19 @@ SELECT
   {beacon_param('path')} AS evt_path,
   {beacon_param('sid')} AS sid,
   _eid AS eid,
-  regexp_like(request_ip, '^(104\\.28\\.|2a09:bac)') AS is_warp,
+  regexp_like(request_ip, '{_WARP_RE}') AS is_warp,
   (regexp_like({ua}, '{_BOT_RE}')
-     OR regexp_like(request_ip, '^185\\.177\\.72\\.')) AS is_bot,
+     OR regexp_like(request_ip, '^185\\.177\\.72\\.')
+     OR COALESCE(g.hosting, false)) AS is_bot,
   location AS edge_location,
+  g.country AS country,
+  g.city AS city,
+  g.org AS org,
+  g.asn AS asn,
+  COALESCE(g.hosting, false) AS is_hosting,
   cast(date as varchar) AS dt
 FROM dedup
+LEFT JOIN {DB}.ip_geo g ON dedup.request_ip = g.ip
 """
 
 
@@ -166,6 +270,9 @@ def handler(event, context):
     )
     deadline = time.time() + max(0.0, remaining_ms / 1000.0 - 15)
     targets = _target_dates(event)
+    # Enrich newly-seen IPs first so the rebuild can classify hosting/bot and
+    # materialize org/geo by joining ip_geo.
+    new_ips = _enrich_ips(targets, deadline)
     rebuilt = []
     for dt in targets:
         if time.time() >= deadline:
@@ -178,4 +285,4 @@ def handler(event, context):
         raise RuntimeError(
             f"Deadline reached: rebuilt {rebuilt}, skipped {skipped}"
         )
-    return {"rebuilt_partitions": rebuilt}
+    return {"rebuilt_partitions": rebuilt, "ips_enriched": new_ips}

--- a/infra/components/web_analytics/transform_lambda/handler.py
+++ b/infra/components/web_analytics/transform_lambda/handler.py
@@ -112,11 +112,20 @@ def _enrich_ips(dts: list, deadline: float) -> int:
     except _s3.exceptions.NoSuchKey:
         pass
 
-    new_ips = [ip for ip in seen if ip not in existing][:MAX_NEW_IPS]
+    pending = [ip for ip in seen if ip not in existing]
+    new_ips = pending[:MAX_NEW_IPS]
+    # "complete" tracks whether we resolved every pending IP this run. If not
+    # (cap truncation, rate/deadline stop, or a failed batch), the caller
+    # defers the rebuild so partial geo never drives classification; retries
+    # converge because each resolved IP is cached.
+    complete = len(new_ips) == len(pending)
     fields = (
         "query,country,regionName,city,isp,org,as,mobile,proxy,hosting,status"
     )
     for i in range(0, len(new_ips), 100):
+        if time.time() >= deadline:
+            complete = False
+            break
         batch = new_ips[i:i + 100]
         payload = json.dumps(
             [{"query": ip, "fields": fields} for ip in batch]
@@ -127,10 +136,11 @@ def _enrich_ips(dts: list, deadline: float) -> int:
             headers={"Content-Type": "application/json"},
         )
         try:
-            with urllib.request.urlopen(req, timeout=30) as resp:
+            with urllib.request.urlopen(req, timeout=15) as resp:
                 data = json.load(resp)
         except Exception:  # pylint: disable=broad-except
-            continue  # best-effort; unresolved IPs simply stay un-enriched
+            complete = False  # unresolved this run; a retry re-attempts it
+            continue
         for g in data:
             ip = g.get("query")
             if not ip:
@@ -147,7 +157,8 @@ def _enrich_ips(dts: list, deadline: float) -> int:
                 "proxy": bool(g.get("proxy")),
                 "mobile": bool(g.get("mobile")),
             }
-        time.sleep(1.0)  # be gentle with the IP-info rate limit
+        # ip-api's batch endpoint allows ~15 requests/min; stay under it.
+        time.sleep(4.0)
 
     body_out = (
         "\n".join(json.dumps(existing[ip]) for ip in sorted(existing)) + "\n"
@@ -158,7 +169,7 @@ def _enrich_ips(dts: list, deadline: float) -> int:
         Body=body_out.encode(),
         ContentType="application/x-ndjson",
     )
-    return len(new_ips)
+    return len(new_ips), complete
 
 
 def _insert_sql(dt: str) -> str:
@@ -272,7 +283,14 @@ def handler(event, context):
     targets = _target_dates(event)
     # Enrich newly-seen IPs first so the rebuild can classify hosting/bot and
     # materialize org/geo by joining ip_geo.
-    new_ips = _enrich_ips(targets, deadline)
+    new_ips, enrich_complete = _enrich_ips(targets, deadline)
+    if not enrich_complete:
+        # Don't rebuild with partial geo (unresolved IPs would misclassify as
+        # non-hosting); fail so the invocation retries and finishes enrichment.
+        raise RuntimeError(
+            f"IP enrichment incomplete ({new_ips} resolved this run); "
+            "deferring partition rebuild for retry"
+        )
     rebuilt = []
     for dt in targets:
         if time.time() >= deadline:

--- a/infra/mcp_server_lambda/lambdas/receipt_mcp_server_server.py
+++ b/infra/mcp_server_lambda/lambdas/receipt_mcp_server_server.py
@@ -954,7 +954,7 @@ Returns value + hit count + distinct sessions. Bots + WARP excluded by default."
             inputSchema={
                 "type": "object",
                 "properties": {
-                    "dimension": {"type": "string", "enum": ["page", "referrer", "ip"], "description": "What to rank"},
+                    "dimension": {"type": "string", "enum": ["page", "referrer", "ip", "country", "org"], "description": "What to rank"},
                     "start_date": {"type": "string", "description": "Start date YYYY-MM-DD (PT)"},
                     "end_date": {"type": "string", "description": "End date YYYY-MM-DD (PT)"},
                     "limit": {"type": "integer", "default": 15, "description": "Max rows"},
@@ -996,28 +996,6 @@ analytics_* tools; use this only when they don't fit.""",
                     "sql": {"type": "string", "description": "A single read-only SELECT/WITH query"},
                 },
                 "required": ["sql"],
-            },
-        ),
-        Tool(
-            name="analytics_lookup_ip",
-            description="""Look up org / geo / network type for one or more IPs (live).
-
-Returns country, region, city, ISP, org, ASN, and proxy/hosting/mobile flags
-per IP via a public IP-info service. Use to identify WHO a visitor is — e.g. a
-company office (org = "LangChain, Inc") vs a datacenter/bot (hosting=true) —
-after analytics_sessions / analytics_top / analytics_ip surface an IP.
-
-Best-effort third-party data; `org` comes from the IP registry. Up to 100 IPs.""",
-            inputSchema={
-                "type": "object",
-                "properties": {
-                    "ips": {
-                        "type": "array",
-                        "items": {"type": "string"},
-                        "description": "1-100 client IPs (v4 or v6) to resolve",
-                    },
-                },
-                "required": ["ips"],
             },
         ),
         Tool(
@@ -1341,8 +1319,6 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent]:
             )
         elif name == "analytics_query":
             result = await analytics_query_impl(sql=arguments["sql"])
-        elif name == "analytics_lookup_ip":
-            result = await analytics_lookup_ip_impl(ips=arguments["ips"])
         elif name == "analytics_ga":
             result = await analytics_ga_impl(
                 start_date=arguments["start_date"],
@@ -3160,7 +3136,8 @@ WITH base AS (
     date_format({pt}, '%Y-%m-%d') AS pt_date,
     date_format({pt}, '%Y-%m-%d %H:%i:%s') AS pt_time,
     request_ip, uri, status, referrer AS ref,
-    is_beacon, event, evt_path, sid, is_warp, is_bot
+    is_beacon, event, evt_path, sid, is_warp, is_bot,
+    org, city, country, is_hosting
   FROM {ANALYTICS_DB}.web_events
   WHERE dt BETWEEN date_format(date_add('day', -1, DATE '{s}'), '%Y-%m-%d')
               AND date_format(date_add('day',  1, DATE '{e}'), '%Y-%m-%d')
@@ -3208,6 +3185,10 @@ SELECT sid,
   min(pt_time) AS first_seen,
   max(pt_time) AS last_seen,
   arbitrary(request_ip) AS ip,
+  arbitrary(org) AS org,
+  arbitrary(city) AS city,
+  arbitrary(country) AS country,
+  bool_or(is_hosting) AS is_hosting,
   array_join(array_agg(DISTINCT evt_path) FILTER (WHERE evt_path <> ''), ', ') AS pages,
   count_if(event = 'page_view') AS pageviews,
   count_if(event = 'scroll_depth') AS scroll_events,
@@ -3247,8 +3228,14 @@ async def analytics_top_impl(
         elif dimension == "ip":
             col = "request_ip"
             extra = ""
+        elif dimension == "country":
+            col = "country"
+            extra = "AND country IS NOT NULL"
+        elif dimension == "org":
+            col = "org"
+            extra = "AND org IS NOT NULL"
         else:
-            return {"error": "dimension must be one of: page, referrer, ip"}
+            return {"error": "dimension must be: page, referrer, ip, country, org"}
         sql = _analytics_base_cte(s, e) + f"""
 SELECT {col} AS value, count(*) AS hits, count(DISTINCT IF(sid <> '', sid, NULL)) AS sessions
 FROM base
@@ -3313,53 +3300,6 @@ async def analytics_query_impl(sql: str) -> dict:
         return {"rows": _athena_run(stmt), "sql": stmt}
     except Exception as exc:
         logger.exception("analytics_query failed")
-        return {"error": str(exc)}
-
-
-async def analytics_lookup_ip_impl(ips) -> dict:
-    """Resolve org/geo/network-type for IPs via a public IP-info service."""
-    try:
-        import json as _json
-        import re
-        import urllib.request
-
-        if not isinstance(ips, list) or not ips:
-            return {"error": "ips must be a non-empty list"}
-        clean = [i for i in ips if re.match(r"^[0-9a-fA-F:.]+$", i or "")][:100]
-        if not clean:
-            return {"error": "no valid IPs provided"}
-        fields = (
-            "query,country,regionName,city,isp,org,as,mobile,proxy,hosting,"
-            "status,message"
-        )
-        body = _json.dumps(
-            [{"query": ip, "fields": fields} for ip in clean]
-        ).encode()
-        req = urllib.request.Request(
-            "http://ip-api.com/batch",
-            data=body,
-            headers={"Content-Type": "application/json"},
-        )
-        with urllib.request.urlopen(req, timeout=20) as resp:
-            data = _json.load(resp)
-        results = [
-            {
-                "ip": g.get("query"),
-                "country": g.get("country"),
-                "region": g.get("regionName"),
-                "city": g.get("city"),
-                "isp": g.get("isp"),
-                "org": g.get("org"),
-                "asn": g.get("as"),
-                "mobile": g.get("mobile"),
-                "proxy": g.get("proxy"),
-                "hosting": g.get("hosting"),
-            }
-            for g in data
-        ]
-        return {"results": results}
-    except Exception as exc:
-        logger.exception("analytics_lookup_ip failed")
         return {"error": str(exc)}
 
 

--- a/scripts/receipt_mcp_server.py
+++ b/scripts/receipt_mcp_server.py
@@ -940,7 +940,7 @@ Returns value + hit count + distinct sessions. Bots + WARP excluded by default."
             inputSchema={
                 "type": "object",
                 "properties": {
-                    "dimension": {"type": "string", "enum": ["page", "referrer", "ip"], "description": "What to rank"},
+                    "dimension": {"type": "string", "enum": ["page", "referrer", "ip", "country", "org"], "description": "What to rank"},
                     "start_date": {"type": "string", "description": "Start date YYYY-MM-DD (PT)"},
                     "end_date": {"type": "string", "description": "End date YYYY-MM-DD (PT)"},
                     "limit": {"type": "integer", "default": 15, "description": "Max rows"},
@@ -982,28 +982,6 @@ analytics_* tools; use this only when they don't fit.""",
                     "sql": {"type": "string", "description": "A single read-only SELECT/WITH query"},
                 },
                 "required": ["sql"],
-            },
-        ),
-        Tool(
-            name="analytics_lookup_ip",
-            description="""Look up org / geo / network type for one or more IPs (live).
-
-Returns country, region, city, ISP, org, ASN, and proxy/hosting/mobile flags
-per IP via a public IP-info service. Use to identify WHO a visitor is — e.g. a
-company office (org = "LangChain, Inc") vs a datacenter/bot (hosting=true) —
-after analytics_sessions / analytics_top / analytics_ip surface an IP.
-
-Best-effort third-party data; `org` comes from the IP registry. Up to 100 IPs.""",
-            inputSchema={
-                "type": "object",
-                "properties": {
-                    "ips": {
-                        "type": "array",
-                        "items": {"type": "string"},
-                        "description": "1-100 client IPs (v4 or v6) to resolve",
-                    },
-                },
-                "required": ["ips"],
             },
         ),
         Tool(
@@ -1327,8 +1305,6 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent]:
             )
         elif name == "analytics_query":
             result = await analytics_query_impl(sql=arguments["sql"])
-        elif name == "analytics_lookup_ip":
-            result = await analytics_lookup_ip_impl(ips=arguments["ips"])
         elif name == "analytics_ga":
             result = await analytics_ga_impl(
                 start_date=arguments["start_date"],
@@ -3146,7 +3122,8 @@ WITH base AS (
     date_format({pt}, '%Y-%m-%d') AS pt_date,
     date_format({pt}, '%Y-%m-%d %H:%i:%s') AS pt_time,
     request_ip, uri, status, referrer AS ref,
-    is_beacon, event, evt_path, sid, is_warp, is_bot
+    is_beacon, event, evt_path, sid, is_warp, is_bot,
+    org, city, country, is_hosting
   FROM {ANALYTICS_DB}.web_events
   WHERE dt BETWEEN date_format(date_add('day', -1, DATE '{s}'), '%Y-%m-%d')
               AND date_format(date_add('day',  1, DATE '{e}'), '%Y-%m-%d')
@@ -3194,6 +3171,10 @@ SELECT sid,
   min(pt_time) AS first_seen,
   max(pt_time) AS last_seen,
   arbitrary(request_ip) AS ip,
+  arbitrary(org) AS org,
+  arbitrary(city) AS city,
+  arbitrary(country) AS country,
+  bool_or(is_hosting) AS is_hosting,
   array_join(array_agg(DISTINCT evt_path) FILTER (WHERE evt_path <> ''), ', ') AS pages,
   count_if(event = 'page_view') AS pageviews,
   count_if(event = 'scroll_depth') AS scroll_events,
@@ -3233,8 +3214,14 @@ async def analytics_top_impl(
         elif dimension == "ip":
             col = "request_ip"
             extra = ""
+        elif dimension == "country":
+            col = "country"
+            extra = "AND country IS NOT NULL"
+        elif dimension == "org":
+            col = "org"
+            extra = "AND org IS NOT NULL"
         else:
-            return {"error": "dimension must be one of: page, referrer, ip"}
+            return {"error": "dimension must be: page, referrer, ip, country, org"}
         sql = _analytics_base_cte(s, e) + f"""
 SELECT {col} AS value, count(*) AS hits, count(DISTINCT IF(sid <> '', sid, NULL)) AS sessions
 FROM base
@@ -3299,53 +3286,6 @@ async def analytics_query_impl(sql: str) -> dict:
         return {"rows": _athena_run(stmt), "sql": stmt}
     except Exception as exc:
         logger.exception("analytics_query failed")
-        return {"error": str(exc)}
-
-
-async def analytics_lookup_ip_impl(ips) -> dict:
-    """Resolve org/geo/network-type for IPs via a public IP-info service."""
-    try:
-        import json as _json
-        import re
-        import urllib.request
-
-        if not isinstance(ips, list) or not ips:
-            return {"error": "ips must be a non-empty list"}
-        clean = [i for i in ips if re.match(r"^[0-9a-fA-F:.]+$", i or "")][:100]
-        if not clean:
-            return {"error": "no valid IPs provided"}
-        fields = (
-            "query,country,regionName,city,isp,org,as,mobile,proxy,hosting,"
-            "status,message"
-        )
-        body = _json.dumps(
-            [{"query": ip, "fields": fields} for ip in clean]
-        ).encode()
-        req = urllib.request.Request(
-            "http://ip-api.com/batch",
-            data=body,
-            headers={"Content-Type": "application/json"},
-        )
-        with urllib.request.urlopen(req, timeout=20) as resp:
-            data = _json.load(resp)
-        results = [
-            {
-                "ip": g.get("query"),
-                "country": g.get("country"),
-                "region": g.get("regionName"),
-                "city": g.get("city"),
-                "isp": g.get("isp"),
-                "org": g.get("org"),
-                "asn": g.get("as"),
-                "mobile": g.get("mobile"),
-                "proxy": g.get("proxy"),
-                "hosting": g.get("hosting"),
-            }
-            for g in data
-        ]
-        return {"results": results}
-    except Exception as exc:
-        logger.exception("analytics_lookup_ip failed")
         return {"error": str(exc)}
 
 


### PR DESCRIPTION
## Why
Follow-up to #1023. Analyzing real traffic exposed that answering *"who are the real humans?"* required a **client-side join** — pulling session IPs, looking up org/hosting separately, and merging by hand — because geo/hosting wasn't in the data. Worse, `is_bot` only used a UA regex, so **datacenter beacons (Azure/Hetzner/AWS) that run JS leaked into `human_sessions`**. This makes geo/hosting a first-class column so the tools are self-sufficient and trustworthy.

## ETL
- **`ip_geo` table** (NDJSON): the transform resolves each newly-seen (non-WARP) IP once via an IP-info service and caches org/geo/hosting/proxy. New IPs are enriched before the rebuild.
- **`web_events` gains `country`, `city`, `org`, `asn`, `is_hosting`**, materialized by a `LEFT JOIN ip_geo` during the partition rebuild.
- **`is_bot` folds in `hosting`** — validated on real data: `72.152.84.13` (Microsoft Azure) now `is_bot=true`; `79.78.206.48` (TalkTalk residential) stays `is_bot=false`; `64.125.113.178` (LangChain) `org` populated, stays human.

## Serve (tools get simpler + correct)
- `analytics_sessions` returns **org / city / country / is_hosting inline** — no more sessions⋈geo join by the caller.
- `analytics_top` adds **`country`** and **`org`** dimensions.
- **Retired `analytics_lookup_ip`** — org/geo is a column now.
- `human_sessions` is trustworthy without post-processing.

## Deploy notes
- `pulumi up` adds the 5 columns to `web_events` + creates `ip_geo`. Existing Parquet reads the new columns as NULL until re-backfilled.
- After deploy: invoke the transform to backfill (it enriches IPs then rebuilds) — `{"start":"2026-06-19","end":"<today>"}`.
- The transform Lambda already has internet egress (not in a VPC) for the IP lookup; it caches each IP once, with a `GEO_MAX_NEW_IPS` safety cap.

## Notes / residual
- IP lookup is HTTP (ip-api free tier); only public visitor IPs are sent, cached once. Documented tradeoff (as on #1023).
- Residual gap: residential-ISP bot farms aren't flagged `hosting`, so a few can still count as human — surfaced via `analytics_top('country'/'org')`.

pylint 10/10; both MCP servers compile; core SQL (join + hosting→is_bot + geo columns) validated against the deployed raw table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Web analytics now enriches events with country, city, organization, ASN, and hosting/geo attributes, improving session and event visibility.
  * “Top” analytics can now be grouped by **country** or **organization**.
  * Session analytics now includes organization, city, country, and hosting details inline.

* **Bug Fixes**
  * Improved attribution so hosted/datacenter traffic is less likely to be counted as human activity.
  * Rebuilds now enforce completed IP enrichment to prevent partial/incorrect classification.

* **Changes**
  * The live IP lookup tool was removed from the analytics toolset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->