### PR TITLE
chore(docs): redact AWS account ID from archived docs (pre-public prep)

### DIFF
--- a/docs/archive/issue-analyses/EXECUTION_9F229EDF_ANALYSIS.md
+++ b/docs/archive/issue-analyses/EXECUTION_9F229EDF_ANALYSIS.md
@@ -1,7 +1,7 @@
 # Execution 9f229edf-35c9-4d5a-8acb-d64057aa0fd7 Analysis
 
 ## Execution Details
-- **Execution ARN**: `arn:aws:states:us-east-1:681647709217:execution:word-ingest-sf-dev-8fa425a:9f229edf-35c9-4d5a-8acb-d64057aa0fd7`
+- **Execution ARN**: `arn:aws:states:us-east-1:<ACCOUNT_ID>:execution:word-ingest-sf-dev-8fa425a:9f229edf-35c9-4d5a-8acb-d64057aa0fd7`
 - **Status**: SUCCEEDED
 - **Start Time**: 2025-11-16T21:26:14.733000-08:00
 - **Stop Time**: 2025-11-16T21:28:16.796000-08:00

--- a/docs/archive/issue-analyses/EXECUTION_E3D0FCE8_ANALYSIS.md
+++ b/docs/archive/issue-analyses/EXECUTION_E3D0FCE8_ANALYSIS.md
@@ -1,7 +1,7 @@
 # Execution e3d0fce8-9a5f-41ed-8dd0-37c2e0219eeb Analysis
 
 ## Execution Details
-- **Execution ARN**: `arn:aws:states:us-east-1:681647709217:execution:word-ingest-sf-dev-8fa425a:e3d0fce8-9a5f-41ed-8dd0-37c2e0219eeb`
+- **Execution ARN**: `arn:aws:states:us-east-1:<ACCOUNT_ID>:execution:word-ingest-sf-dev-8fa425a:e3d0fce8-9a5f-41ed-8dd0-37c2e0219eeb`
 - **Status**: SUCCEEDED
 - **Start Time**: 2025-11-16T21:38:29.049000-08:00
 - **Stop Time**: 2025-11-16T21:40:33.277000-08:00

--- a/docs/archive/issue-analyses/EXECUTION_ECR_IMAGE_COMPARISON.md
+++ b/docs/archive/issue-analyses/EXECUTION_ECR_IMAGE_COMPARISON.md
@@ -26,8 +26,8 @@
 
 | Execution | Image URI | Image Digest | Image Pushed At | Image Tags |
 |-----------|-----------|--------------|-----------------|------------|
-| **Success** | `681647709217.dkr.ecr.us-east-1.amazonaws.com/embedding-line-poll-docker-repo-4146688@sha256:47ed87f9aaae891107c6ec326537468098b35583b441739f5c0df027638c5905` | `sha256:47ed87f9aaae891107c6ec326537468098b35583b441739f5c0df027638c5905` | 2025-11-16T18:51:24.932000-08:00 | `latest`, `cache`, `8fbaa10875b4` |
-| **Failed** | `681647709217.dkr.ecr.us-east-1.amazonaws.com/embedding-line-poll-docker-repo-4146688@sha256:47ed87f9aaae891107c6ec326537468098b35583b441739f5c0df027638c5905` | `sha256:47ed87f9aaae891107c6ec326537468098b35583b441739f5c0df027638c5905` | 2025-11-16T18:51:24.932000-08:00 | `latest`, `cache`, `8fbaa10875b4` |
+| **Success** | `<ACCOUNT_ID>.dkr.ecr.us-east-1.amazonaws.com/embedding-line-poll-docker-repo-4146688@sha256:47ed87f9aaae891107c6ec326537468098b35583b441739f5c0df027638c5905` | `sha256:47ed87f9aaae891107c6ec326537468098b35583b441739f5c0df027638c5905` | 2025-11-16T18:51:24.932000-08:00 | `latest`, `cache`, `8fbaa10875b4` |
+| **Failed** | `<ACCOUNT_ID>.dkr.ecr.us-east-1.amazonaws.com/embedding-line-poll-docker-repo-4146688@sha256:47ed87f9aaae891107c6ec326537468098b35583b441739f5c0df027638c5905` | `sha256:47ed87f9aaae891107c6ec326537468098b35583b441739f5c0df027638c5905` | 2025-11-16T18:51:24.932000-08:00 | `latest`, `cache`, `8fbaa10875b4` |
 
 **Result**: ✅ **SAME IMAGE** - Both executions used identical ECR image
 

--- a/docs/archive/root-docs/status/DEPLOYMENT_SUCCESS.md
+++ b/docs/archive/root-docs/status/DEPLOYMENT_SUCCESS.md
@@ -8,7 +8,7 @@ The container-based `process_ocr_results` Lambda has been successfully deployed!
 
 **Lambda Function**: `upload-images-dev-process-ocr-results`
 - ✅ Package Type: **Image** (was Zip)
-- ✅ Image URI: `681647709217.dkr.ecr.us-east-1.amazonaws.com/upload-images-process-ocr-image-repo-74f6d53:latest`
+- ✅ Image URI: `<ACCOUNT_ID>.dkr.ecr.us-east-1.amazonaws.com/upload-images-process-ocr-image-repo-74f6d53:latest`
 - ✅ Timeout: 600 seconds (10 minutes)
 - ✅ Memory: 2048 MB (2 GB)
 

--- a/infra/IAM_FIXES.md
+++ b/infra/IAM_FIXES.md
@@ -9,7 +9,7 @@ During the implementation of the lambda layer components, we encountered **three
 ### Error
 
 ```
-ACCESS_DENIED: Service role arn:aws:iam::681647709217:role/receipt-dynamo-fast-codebuild-role-bf856b5 does not allow AWS CodeBuild to create Amazon CloudWatch Logs log streams for build arn:aws:codebuild:us-east-1:681647709217:build/receipt-dynamo-fast-layer-build-dev:817f3b8c-54de-45c7-b547-05ace80ed7fd. Error message: User: arn:aws:sts::681647709217:assumed-role/receipt-dynamo-fast-codebuild-role-bf856b5/AWSCodeBuild-817f3b8c-54de-45c7-b547-05ace80ed7fd is not authorized to perform: logs:CreateLogStream on resource: arn:aws:logs:us-east-1:681647709217:log-group:/aws/codebuild/receipt-dynamo-fast-layer-build-dev:log-stream:817f3b8c-54de-45c7-b547-05ace80ed7fd because no identity-based policy allows the logs:CreateLogStream action
+ACCESS_DENIED: Service role arn:aws:iam::<ACCOUNT_ID>:role/receipt-dynamo-fast-codebuild-role-bf856b5 does not allow AWS CodeBuild to create Amazon CloudWatch Logs log streams for build arn:aws:codebuild:us-east-1:<ACCOUNT_ID>:build/receipt-dynamo-fast-layer-build-dev:817f3b8c-54de-45c7-b547-05ace80ed7fd. Error message: User: arn:aws:sts::<ACCOUNT_ID>:assumed-role/receipt-dynamo-fast-codebuild-role-bf856b5/AWSCodeBuild-817f3b8c-54de-45c7-b547-05ace80ed7fd is not authorized to perform: logs:CreateLogStream on resource: arn:aws:logs:us-east-1:<ACCOUNT_ID>:log-group:/aws/codebuild/receipt-dynamo-fast-layer-build-dev:log-stream:817f3b8c-54de-45c7-b547-05ace80ed7fd because no identity-based policy allows the logs:CreateLogStream action
 ```
 
 ### Root Cause
@@ -40,7 +40,7 @@ The second ARN pattern (`/*:*`) allows access to log streams within the log grou
 ### Error
 
 ```
-An error occurred (AccessDeniedException) when calling the PublishLayerVersion operation: User: arn:aws:sts::681647709217:assumed-role/receipt-upload-fast-codebuild-role-97b2436/AWSCodeBuild-0b9b626f-4066-49df-97b6-1f0491acd3dc is not authorized to perform: lambda:PublishLayerVersion on resource: arn:aws:lambda:us-east-1:681647709217:layer:receipt-upload-dev because no identity-based policy allows the lambda:PublishLayerVersion action
+An error occurred (AccessDeniedException) when calling the PublishLayerVersion operation: User: arn:aws:sts::<ACCOUNT_ID>:assumed-role/receipt-upload-fast-codebuild-role-97b2436/AWSCodeBuild-0b9b626f-4066-49df-97b6-1f0491acd3dc is not authorized to perform: lambda:PublishLayerVersion on resource: arn:aws:lambda:us-east-1:<ACCOUNT_ID>:layer:receipt-upload-dev because no identity-based policy allows the lambda:PublishLayerVersion action
 ```
 
 ### Root Cause
@@ -69,7 +69,7 @@ The IAM policy only allowed access to versioned layer ARNs (`layer:name:version`
 ### Error
 
 ```
-An error occurred (AccessDeniedException) when calling the PublishLayerVersion operation: Your access has been denied by S3, please make sure your request credentials have permission to GetObject for fast-lambda-layer-receipt-dynamo-artifacts-dev/receipt-dynamo-dev/layer.zip. S3 Error Code: AccessDenied. S3 Error Message: User: arn:aws:sts::681647709217:assumed-role/receipt-dynamo-fast-codebuild-role-bf856b5/AWSCodeBuild-913409e2-2793-4865-a1f3-66e02d53aa00 is not authorized to perform: s3:ListBucket on resource: "arn:aws:s3:::fast-lambda-layer-receipt-dynamo-artifacts-dev" because no identity-based policy allows the s3:ListBucket action
+An error occurred (AccessDeniedException) when calling the PublishLayerVersion operation: Your access has been denied by S3, please make sure your request credentials have permission to GetObject for fast-lambda-layer-receipt-dynamo-artifacts-dev/receipt-dynamo-dev/layer.zip. S3 Error Code: AccessDenied. S3 Error Message: User: arn:aws:sts::<ACCOUNT_ID>:assumed-role/receipt-dynamo-fast-codebuild-role-bf856b5/AWSCodeBuild-913409e2-2793-4865-a1f3-66e02d53aa00 is not authorized to perform: s3:ListBucket on resource: "arn:aws:s3:::fast-lambda-layer-receipt-dynamo-artifacts-dev" because no identity-based policy allows the s3:ListBucket action
 ```
 
 ### Root Cause


### PR DESCRIPTION
## What
Redacts the hardcoded AWS account ID (`681647709217` → `<ACCOUNT_ID>`) in throwaway/archived documentation, which also de-identifies the real ARNs quoted inside those files (Step Functions execution ARNs, ECR image URIs, IAM/CodeBuild `AccessDenied` error dumps).

## Why
Prep for potentially making this repo public (see the exposure audit). Account IDs and ARNs **aren't secrets and aren't exploitable without credentials** — this is low-risk polish, not a security fix — but there's no reason to publish reconnaissance detail sitting in disposable status/analysis notes.

## Scope (deliberately narrow)
Docs only:
- \`docs/archive/issue-analyses/EXECUTION_9F229EDF_ANALYSIS.md\`
- \`docs/archive/issue-analyses/EXECUTION_E3D0FCE8_ANALYSIS.md\`
- \`docs/archive/issue-analyses/EXECUTION_ECR_IMAGE_COMPARISON.md\`
- \`docs/archive/root-docs/status/DEPLOYMENT_SUCCESS.md\`
- \`infra/IAM_FIXES.md\`

**Left untouched on purpose** (they need the real value; changing them would break deploys/tests): \`infra/Pulumi.dev.yaml\`, \`infra/chromadb_compaction/tests/**\`, \`infra/embedding_step_functions/get_embedding_metrics.sh\`, \`infra/ml_packages.py\`.

## Not in scope
- **No git-history rewrite** — the full-history secret audit found no live credentials committed (all gitleaks hits were false positives; `.env` was never tracked). Account IDs in old commits are low-risk and not worth rewriting 11k commits over.
- **Commit messages** were scanned and are clean (no secrets, nothing embarrassing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Replaced hard-coded AWS account IDs with placeholder values across deployment, execution, image comparison, and IAM troubleshooting notes.
  * Kept the rest of the documented ARNs, image references, and error details unchanged for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->