### PR TITLE
chore(secrets): rotate Google Places (prod+dev) + LangSmith dev key

### DIFF
--- a/infra/Pulumi.dev.yaml
+++ b/infra/Pulumi.dev.yaml
@@ -5,7 +5,7 @@ config:
   portfolio:environment: dev
   portfolio:cloudFrontLogRetentionDays: "30"
   portfolio:GOOGLE_PLACES_API_KEY:
-    secure: AAABALTCiuLmoSvqaspn8wdijYSLhzp3touLTPPzUqDzbDVYvvB6FhVqfjJJ2ny0/cX8byG0NHoU/FIUijNFKFtyaE0HaCM=
+    secure: AAABAMdOnUV9nUeit+P9YPMiDy4umwO9lKpzqcDkePvg0IpPsRmthwzeAeWvjVqq6QGr2TWt1gbYn67zGP6a1pfq2o6HL0o=
   ml-training:force-rebuild: "true"
   portfolio:PINECONE_API_KEY:
     secure: AAABAB6y1jBmasYCd0JbmQetWvndVC15ZSa7jtgyj2pNQ1y18JrMbJuCkSthuTX02pG7G2YYMmh4ee8Ck16UuQML90lKCiw3IIHBHK2dXNJeSI5ewuBW2KSdjLzhQA+K6bKNQCdYUT5O6N8=
@@ -30,7 +30,7 @@ config:
   portfolio:aws-account-id: "681647709217"
   portfolio:aws-region: us-east-1
   portfolio:LANGCHAIN_API_KEY:
-    secure: AAABAC+PSTc8uajZqSWQTNyqcOPjK4cW+DP3snxJOYFRRA6LSBZq4/7mfZiY2bGuw0fOrpHuyXpwPKDHm5+Y+0cCcj02h1fiUb59JXnOPsM4Hvs=
+    secure: AAABAJiHEdWOgkHMQWv/1wPGA98jO46C73wQxl5XrIokyOkRuCt50jAQ7DEe/+cxJANSERRUrbC1es+8J2ZQFnWzOMygi3nW1JaQU6+VndVnGs4=
   portfolio:ecr-max-images: "4"
   portfolio:ecr-max-age-days: "7"
   docker-build:sync-mode: "true" # Async mode for faster pulumi up in dev

--- a/infra/Pulumi.prod.yaml
+++ b/infra/Pulumi.prod.yaml
@@ -11,7 +11,7 @@ config:
   portfolio:PINECONE_INDEX_NAME: "receipt-validation-dev"
   portfolio:PINECONE_HOST: "https://receipt-validation-dev-sy23fax.svc.aped-4627-b74a.pinecone.io"
   portfolio:GOOGLE_PLACES_API_KEY:
-    secure: AAABAFBK29wOt7co839BA0yF2Tg+jpxiXpEW6dG2EKllKSkCWNaO+AP3kmdtd9lyx+76kwnEMLuzrTpPGWjtsRL6tJl/W9c=
+    secure: AAABAJa1JM+ynYtukEgxlYR/hIjEC0SMpJ/JZeo064/xEgCk6o3/Vou7sbzH22r1zq9gMsdh5QdOKMHdW3JSww9DAfHIJdE=
   portfolio:privateSubnetCidrs:
     - 10.20.10.0/24
     - 10.20.11.0/24


### PR DESCRIPTION
## What
Rotates two credentials that were sitting in plaintext in the local `.env`, as security hygiene ahead of possibly making the repo public. Only Pulumi-encrypted `secure:` config values change.

- **`GOOGLE_PLACES_API_KEY`** (prod + dev): replaced with a **new key restricted to the Places API** (was effectively unrestricted). Created + verified working against the legacy Places endpoint before wiring.
- **`LANGCHAIN_API_KEY`** (dev only): the exposed personal token backed the **dev** stack — rotated to a fresh key. **Prod uses a different key** and is deliberately untouched (confirmed by suffix).

## Diff
3 encrypted secret values: `Pulumi.prod.yaml` (Google) + `Pulumi.dev.yaml` (Google + LangChain). No code changes.

## Activation
- **prod** activates automatically via CI on merge (deploys mcp_server / fix_place / upload_images with the new Places key).
- **dev** is a manual `pulumi up --stack dev`.

## Old-key deletion (after this merges)
- **Google `…VxDN8`**: delete only after prod deploys + a Places call is verified (prod still uses it until then).
- **LangSmith `…e627`**: safe to delete now (prod never used it; dev tracing just stops uploading until dev is redeployed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated encrypted configuration secrets for the development and production environments.
  * Rotated a set of API credentials without changing app behavior or visible functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->