### PR TITLE
Fix strict-tsc error blocking main CI (pipelineLabels test)

### DIFF
--- a/portfolio/components/ui/Figures/SynthesisPipeline/pipelineLabels.test.ts
+++ b/portfolio/components/ui/Figures/SynthesisPipeline/pipelineLabels.test.ts
@@ -35,13 +35,15 @@ describe.each(["sprouts", "costco"])("%s final labels", (merchant) => {
   });
 
   test("a missing margin degrades to finite rects (never NaN)", () => {
+    const render = file.metadata?.render;
+    expect(render).toBeDefined();
     const stripped = {
       ...file,
       metadata: {
         ...file.metadata,
         render: {
-          width: file.metadata.render.width,
-          height: file.metadata.render.height,
+          width: render!.width,
+          height: render!.height,
         },
       },
     } as ShowcaseLabelFile;


### PR DESCRIPTION
Main's CI/CD run failed at the TypeScript job (tsc strict: metadata possibly undefined in pipelineLabels.test.ts), so the production deploy never ran. This guards the optional field; tsc and jest both green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HTrJ8omKZfEHQhZVTW5qYV

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Strengthened a regression test to handle missing rendering metadata more defensively.
  * Kept the focus on verifying label box calculations stay finite and do not produce invalid values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->