### PR TITLE
Fix mint-loop review findings (PRs #1036, #1037)

### DIFF
--- a/infra/components/codebuild_docker_image.py
+++ b/infra/components/codebuild_docker_image.py
@@ -399,6 +399,23 @@ class CodeBuildDockerImage(ComponentResource):
                 if context_path.exists():
                     paths.append(context_path)
 
+        # Extra context paths may carry baked non-code assets (e.g. glyph font
+        # JSONs: font.json, stylemap.json, glyphs/*.json) that the include_globs
+        # below deliberately exclude, so a font-only edit would not rebuild the
+        # image. Fold those JSONs in via a sub-hash keyed only when extra paths
+        # exist, keeping the digest byte-identical for callers with none.
+        extra_strings = None
+        if self.extra_context_paths:
+            extra_roots = [
+                Path(PROJECT_DIR) / extra
+                for extra in sorted(self.extra_context_paths)
+            ]
+            json_hash = compute_hash(
+                [p for p in extra_roots if p.exists()],
+                include_globs=["**/*.json"],
+            )
+            extra_strings = {"extra_context_json": json_hash}
+
         return compute_hash(
             paths,
             include_globs=[
@@ -407,6 +424,7 @@ class CodeBuildDockerImage(ComponentResource):
                 "**/requirements.txt",
                 "Dockerfile",
             ],
+            extra_strings=extra_strings,
         )
 
     def _generate_upload_script(self, bucket: str, content_hash: str) -> str:

--- a/infra/components/test_codebuild_content_hash.py
+++ b/infra/components/test_codebuild_content_hash.py
@@ -1,0 +1,102 @@
+"""Finding H: baked JSON assets under extra_context_paths must feed the image
+content hash, and the hash for callers with NO extra_context_paths must be
+byte-identical to the pre-fix behavior.
+
+The build context rsync copies the entire extra_context_paths tree (font.json,
+stylemap.json, glyphs/*.json), but the image content hash filtered to
+python/project files only -- so a font-only edit would not rebuild the image.
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+)
+import infra.components.codebuild_docker_image as cdi  # noqa: E402
+from infra.shared.build_utils import compute_hash  # noqa: E402
+
+
+def _bare_instance(**attrs):
+    """A CodeBuildDockerImage with only the attrs _calculate_content_hash reads,
+    bypassing __init__ (which provisions pulumi resources)."""
+    obj = object.__new__(cdi.CodeBuildDockerImage)
+    obj.dockerfile_path = attrs["dockerfile_path"]
+    obj.build_context_path = attrs.get("build_context_path", ".")
+    obj.source_paths = attrs.get("source_paths")
+    obj.extra_context_paths = attrs.get("extra_context_paths", [])
+    return obj
+
+
+def _make_project(tmp_path):
+    (tmp_path / "Dockerfile").write_text("FROM scratch\n")
+    extra = tmp_path / "fonts" / "sprouts"
+    (extra / "glyphs").mkdir(parents=True)
+    (extra / "font.json").write_text('{"params": {"weight": 1.0}}')
+    (extra / "glyphs" / "u0046.json").write_text('{"codepoint": 70}')
+    return tmp_path
+
+
+def test_json_edit_under_extra_context_changes_hash(tmp_path, monkeypatch):
+    _make_project(tmp_path)
+    monkeypatch.setattr(cdi, "PROJECT_DIR", str(tmp_path))
+
+    inst = _bare_instance(
+        dockerfile_path="Dockerfile",
+        extra_context_paths=["fonts/sprouts"],
+    )
+    before = inst._calculate_content_hash()
+
+    # Editing a baked font JSON must now change the image content hash.
+    (tmp_path / "fonts" / "sprouts" / "font.json").write_text(
+        '{"params": {"weight": 1.33}}'
+    )
+    after = inst._calculate_content_hash()
+    assert before != after
+
+    # Editing a nested glyph JSON also triggers it.
+    (tmp_path / "fonts" / "sprouts" / "glyphs" / "u0046.json").write_text(
+        '{"codepoint": 70, "overrides": {"weight": 1.2}}'
+    )
+    after2 = inst._calculate_content_hash()
+    assert after2 != after
+
+
+def test_no_extra_context_hash_unchanged(tmp_path, monkeypatch):
+    """Callers with no extra_context_paths keep the exact pre-fix digest."""
+    _make_project(tmp_path)
+    monkeypatch.setattr(cdi, "PROJECT_DIR", str(tmp_path))
+
+    inst = _bare_instance(dockerfile_path="Dockerfile", extra_context_paths=[])
+    # Pre-fix behavior == compute_hash over the same roots with the same globs
+    # and NO extra_strings. The Dockerfile parent (".") handler dir has no .py.
+    baseline = compute_hash(
+        [tmp_path / "Dockerfile"],
+        include_globs=[
+            "**/*.py",
+            "**/pyproject.toml",
+            "**/requirements.txt",
+            "Dockerfile",
+        ],
+    )
+    assert inst._calculate_content_hash() == baseline
+
+    # And a font JSON edit elsewhere in the tree does NOT affect a no-extra
+    # caller (it never references those paths).
+    (tmp_path / "fonts" / "sprouts" / "font.json").write_text('{"x": 9}')
+    assert inst._calculate_content_hash() == baseline
+
+
+def test_extra_strings_none_is_noop():
+    """The mechanism relied on: extra_strings=None must not perturb the hash."""
+    roots = [os.path.dirname(os.path.abspath(__file__))]
+    globs = ["**/*.py"]
+    assert compute_hash(roots, include_globs=globs) == compute_hash(
+        roots, include_globs=globs, extra_strings=None
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-q"]))

--- a/infra/glyph_mcp_lambda/infrastructure.py
+++ b/infra/glyph_mcp_lambda/infrastructure.py
@@ -148,6 +148,9 @@ class GlyphMcpLambda(ComponentResource):
             "role_arn": lambda_role.arn,
             "timeout": 300,  # 5 min — compile/compare are well under this
             "memory_size": 1536,  # numpy + PIL rasterization headroom
+            # Public (auth NONE) Function URL — cap concurrency so a burst of
+            # requests can't fan out into unbounded 1.5 GB invocations.
+            "reserved_concurrent_executions": 10,
             "tags": {"environment": stack},
             "environment": {
                 "GLYPH_FONTS_DIR": "/var/task/fonts",

--- a/receipt_agent/pyproject.toml
+++ b/receipt_agent/pyproject.toml
@@ -42,6 +42,10 @@ dependencies = [
     "langsmith>=0.1.0",
     # HTTP client for async operations
     "httpx>=0.27.0",
+    # Receipt graphics rendering (label_evaluator): QR + linear barcodes.
+    # Lazily imported in rendering/receipt_graphics.py but required at runtime.
+    "segno>=1.6.0",
+    "python-barcode>=0.15.0",
 ]
 
 [project.optional-dependencies]

--- a/scripts/render_synthetic_receipts.py
+++ b/scripts/render_synthetic_receipts.py
@@ -948,22 +948,33 @@ def load_merchant_profiles(refresh: bool = False) -> dict:
     return _MERCHANT_PROFILES_CACHE
 
 
-def get_merchant_profile(merchant: str | None) -> dict:
-    """The registry record for ``merchant`` (exact match, then declared alias).
+def get_merchant_profile_key(
+    merchant: str | None,
+) -> tuple[str | None, dict]:
+    """The canonical registry KEY and record for ``merchant``.
 
     Dynamo holds name variants of the same store ("TRADER JOE'S", "CVS
     pharmacy(r)"); a profile lists those under "aliases" so every variant
-    resolves to the one canonical record.
+    resolves to the one canonical record. Returns the profile's canonical KEY
+    alongside the record so callers that key external systems off the canonical
+    merchant name -- e.g. the MerchantFont Dynamo pointer, published under the
+    canonical name, not a receipt's alias -- resolve the same record the
+    profile does. ``(None, {})`` when unknown.
     """
     profiles = load_merchant_profiles()
     name = merchant or ""
     hit = profiles.get(name)
     if hit is not None:
-        return hit
-    for record in profiles.values():
+        return name, hit
+    for key, record in profiles.items():
         if name in record.get("aliases", ()):
-            return record
-    return {}
+            return key, record
+    return None, {}
+
+
+def get_merchant_profile(merchant: str | None) -> dict:
+    """The registry record for ``merchant`` (exact match, then declared alias)."""
+    return get_merchant_profile_key(merchant)[1]
 
 
 def section_scale_for_merchant(merchant: str | None) -> dict:
@@ -1018,14 +1029,19 @@ def _ensure_font_cached(filename: str, merchant: str, face: str) -> str:
 
         table = os.environ.get("DYNAMODB_TABLE_NAME", "ReceiptsTable-dc5be22")
         client = DynamoClient(table)
+        # Pointers are published under the profile's CANONICAL name; a render
+        # invoked with a receipt-variant alias ("CVS pharmacy", "TRADER JOE'S")
+        # must resolve to that key first or the lookup misses and the font
+        # silently drops.
+        lookup = get_merchant_profile_key(merchant)[0] or merchant
         if face in ("stylemap", "logo"):
-            ptr = client.get_merchant_font(merchant, "regular")
+            ptr = client.get_merchant_font(lookup, "regular")
             bucket = ptr.s3_bucket if ptr else None
             attr = "stylemap_s3_key" if face == "stylemap" else "logo_s3_key"
             key = getattr(ptr, attr, None) if ptr else None
             want_hash = None
         else:
-            ptr = client.get_merchant_font(merchant, face)
+            ptr = client.get_merchant_font(lookup, face)
             bucket = ptr.s3_bucket if ptr else None
             key = ptr.s3_key if ptr else None
             want_hash = ptr.content_hash if ptr else None
@@ -1033,11 +1049,15 @@ def _ensure_font_cached(filename: str, merchant: str, face: str) -> str:
             return local
         # A pointer may only satisfy the exact filename it was published as
         # (a merchant can have several atlases; never let a studio build
-        # masquerade as e.g. Costco's chart-derived production font).
+        # masquerade as e.g. Costco's chart-derived production font). Stylemaps
+        # and logos ride on the regular pointer under their own key fields
+        # (stylemap_s3_key/logo_s3_key), so the atlas cache_filename guard does
+        # not apply to them -- it would always mismatch and drop the download.
         want_name = getattr(ptr, "cache_filename", None)
-        if want_name and want_name != filename and face != "stylemap":
+        guarded = face not in ("stylemap", "logo")
+        if want_name and want_name != filename and guarded:
             return local
-        if not want_name and face != "stylemap":
+        if not want_name and guarded:
             return local
         os.makedirs(_BITMATRIX_DIR, exist_ok=True)
         tmp = local + ".fetch"
@@ -2500,6 +2520,23 @@ def _render_cached_synthetic_examples(args: argparse.Namespace) -> int:
     )
     fallback = make_ttf_fallback(atlas)
 
+    # Resolve the merchant's minted typography (bitmap font, section scale,
+    # derived ink erosion) so the hybrid path renders in the minted font, not
+    # the default TTF. Mirrors the direct render path (synthesis_loop
+    # glyph_review). bitmap_thin is derived only when a bitmap font is in play.
+    section_scale = section_scale_for_merchant(merchant)
+    typography = merchant_typography(merchant)
+    if "bitmap_font" in typography and "bitmap_thin" not in typography:
+        typography["bitmap_thin"] = resolve_bitmap_thin(
+            table_name,
+            merchant,
+            region=args.aws_region,
+            atlas=atlas,
+            profile=profile,
+            section_scale=section_scale,
+            typography=typography,
+        )
+
     os.makedirs(args.out_dir, exist_ok=True)
     if args.public_dir:
         os.makedirs(args.public_dir, exist_ok=True)
@@ -2527,6 +2564,8 @@ def _render_cached_synthetic_examples(args: argparse.Namespace) -> int:
                 width=width,
                 height=height,
                 path=out_path,
+                section_scale=section_scale,
+                **typography,
             )
         else:
             config = GlyphRenderConfig(
@@ -2557,6 +2596,8 @@ def _render_cached_synthetic_examples(args: argparse.Namespace) -> int:
                     width=width,
                     height=height,
                     path=public_path,
+                    section_scale=section_scale,
+                    **typography,
                 )
             else:
                 save_receipt_glyphs(

--- a/scripts/test_merchant_font_cache.py
+++ b/scripts/test_merchant_font_cache.py
@@ -1,0 +1,135 @@
+"""Regression tests for the MerchantFont cache fetch in render_synthetic_receipts.
+
+Covers two cold-cache bugs:
+
+A. Alias merchant names ("CVS pharmacy", "TRADER JOE'S") must resolve to the
+   canonical profile key before the Dynamo pointer lookup, because pointers are
+   published under the canonical name ("CVS", "Trader Joe's").
+B. Logo (and stylemap) faces ride on the REGULAR pointer under their own key
+   fields; the atlas ``cache_filename`` guard must not reject them, or the logo
+   PNG never downloads on a fresh host.
+"""
+
+import hashlib
+import os
+import sys
+import types
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import render_synthetic_receipts as rsr  # noqa: E402
+
+
+class _FakePtr:
+    def __init__(self, **kw):
+        self.s3_bucket = kw.get("s3_bucket", "raw-bucket")
+        self.s3_key = kw.get("s3_key")
+        self.content_hash = kw.get("content_hash")
+        self.cache_filename = kw.get("cache_filename")
+        self.logo_s3_key = kw.get("logo_s3_key")
+        self.stylemap_s3_key = kw.get("stylemap_s3_key")
+
+
+def _install_fakes(monkeypatch, tmp_path, ptr, payload):
+    """Point the cache dir at tmp, and fake DynamoClient + boto3 S3."""
+    monkeypatch.setattr(rsr, "_BITMATRIX_DIR", str(tmp_path))
+    calls = []
+
+    class FakeClient:
+        def __init__(self, table):
+            pass
+
+        def get_merchant_font(self, merchant, face):
+            calls.append((merchant, face))
+            return ptr
+
+    fake_dynamo = types.ModuleType("receipt_dynamo")
+    fake_dynamo.DynamoClient = FakeClient
+    monkeypatch.setitem(sys.modules, "receipt_dynamo", fake_dynamo)
+
+    class FakeS3:
+        def download_file(self, bucket, key, dest):
+            with open(dest, "wb") as fh:
+                fh.write(payload)
+
+    fake_boto3 = types.ModuleType("boto3")
+    fake_boto3.client = lambda *a, **k: FakeS3()
+    monkeypatch.setitem(sys.modules, "boto3", fake_boto3)
+    return calls
+
+
+def test_alias_resolves_to_canonical_pointer(monkeypatch, tmp_path):
+    """Finding A: a receipt alias fetches the pointer under the canonical name."""
+    payload = b"ATLAS-BYTES"
+    ptr = _FakePtr(
+        s3_key="merchant_fonts/cvs/regular-abc.npz",
+        content_hash=hashlib.sha256(payload).hexdigest(),
+        cache_filename="cvs.glyphs.npz",
+    )
+    calls = _install_fakes(monkeypatch, tmp_path, ptr, payload)
+
+    out = rsr._ensure_font_cached("cvs.glyphs.npz", "CVS pharmacy", "regular")
+
+    # The Dynamo lookup used the canonical key, not the receipt's alias.
+    assert calls == [("CVS", "regular")]
+    # And the font actually landed in the cache (fetch happened, not dropped).
+    assert os.path.exists(out)
+    with open(out, "rb") as fh:
+        assert fh.read() == payload
+
+
+def test_alias_trader_joes_uppercase(monkeypatch, tmp_path):
+    """Finding A: the SCREAMING-CASE Trader Joe's variant resolves too."""
+    payload = b"TJ-ATLAS"
+    ptr = _FakePtr(
+        s3_key="merchant_fonts/trader_joe_s/regular-def.npz",
+        content_hash=hashlib.sha256(payload).hexdigest(),
+        cache_filename="tj.glyphs.npz",
+    )
+    calls = _install_fakes(monkeypatch, tmp_path, ptr, payload)
+
+    rsr._ensure_font_cached("tj.glyphs.npz", "TRADER JOE'S", "regular")
+
+    assert calls == [("Trader Joe's", "regular")]
+
+
+def test_logo_downloads_despite_atlas_cache_filename(monkeypatch, tmp_path):
+    """Finding B: a logo PNG downloads even though the regular pointer's
+    cache_filename names the atlas npz, not the logo file."""
+    payload = b"\x89PNG-LOGO"
+    ptr = _FakePtr(
+        s3_key="merchant_fonts/cvs/regular-abc.npz",
+        content_hash="unused-for-logo",
+        cache_filename="cvs.glyphs.npz",  # atlas name != the logo filename
+        logo_s3_key="merchant_fonts/cvs/logo-1234.png",
+    )
+    calls = _install_fakes(monkeypatch, tmp_path, ptr, payload)
+
+    out = rsr._ensure_font_cached("cvs_logo.png", "CVS", "logo")
+
+    assert calls == [("CVS", "regular")]  # logo rides the regular pointer
+    assert os.path.exists(out)  # previously dropped by the atlas guard
+    with open(out, "rb") as fh:
+        assert fh.read() == payload
+
+
+def test_atlas_guard_still_rejects_mismatched_filename(monkeypatch, tmp_path):
+    """The guard must still protect regular atlases from masquerading builds."""
+    payload = b"WRONG-ATLAS"
+    ptr = _FakePtr(
+        s3_key="merchant_fonts/costco/regular-abc.npz",
+        content_hash=hashlib.sha256(payload).hexdigest(),
+        cache_filename="costco-chart.glyphs.npz",  # != requested filename
+    )
+    _install_fakes(monkeypatch, tmp_path, ptr, payload)
+
+    out = rsr._ensure_font_cached(
+        "costco-studio.glyphs.npz", "Costco Wholesale", "regular"
+    )
+    # Guard rejects: nothing downloaded, local (missing) path returned.
+    assert not os.path.exists(out)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-q"]))

--- a/synthesis_loop/publish_merchant_font.py
+++ b/synthesis_loop/publish_merchant_font.py
@@ -123,12 +123,30 @@ def _heavy_variant_dir(font_dir: str, tmp: str) -> str:
         float(font["params"].get("weight", 1.0)) * HEAVY_RATIO, 4
     )
     json.dump(font, open(fpath, "w", encoding="utf-8"), indent=1)
+    # Per-glyph weight overrides REPLACE (not scale) font.params.weight in
+    # glyphstudio.schema.merged_params, so scaling only the font-level weight
+    # leaves overridden glyphs at their body weight -- a mixed-weight heavy
+    # face. Scale each glyph's overrides.weight by the same ratio.
+    glyph_dir = os.path.join(hdir, "glyphs")
+    if os.path.isdir(glyph_dir):
+        for name in os.listdir(glyph_dir):
+            if not name.endswith(".json"):
+                continue
+            gpath = os.path.join(glyph_dir, name)
+            glyph = json.load(open(gpath, encoding="utf-8"))
+            overrides = glyph.get("overrides")
+            if isinstance(overrides, dict) and "weight" in overrides:
+                overrides["weight"] = round(
+                    float(overrides["weight"]) * HEAVY_RATIO, 4
+                )
+                json.dump(glyph, open(gpath, "w", encoding="utf-8"), indent=1)
     return hdir
 
 
 def _prebuilt_report(npz_path: str) -> dict:
     """Metrics for a prebuilt atlas (e.g. chart-derived) via BitmapFont."""
     import numpy as np  # noqa: PLC0415
+
     from receipt_agent.agents.label_evaluator.rendering.bitmap_font import (  # noqa: PLC0415,E501
         BitmapFont,
     )

--- a/synthesis_loop/test_publish_merchant_font_heavy.py
+++ b/synthesis_loop/test_publish_merchant_font_heavy.py
@@ -1,0 +1,108 @@
+"""Finding D: the heavy face variant must scale per-glyph weight overrides.
+
+``glyphstudio.schema.merged_params`` applies a glyph's ``overrides.weight`` as a
+REPLACEMENT of the font-level weight, not a delta. So building the heavy face by
+scaling only ``font.json`` params.weight leaves any overridden glyph at its body
+weight -- a mixed-weight heavy face. ``_heavy_variant_dir`` must scale the glyph
+overrides by the same ratio.
+"""
+
+import json
+import os
+import sys
+import tempfile
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import publish_merchant_font as pmf  # noqa: E402
+
+
+def _write(path, obj):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as fh:
+        json.dump(obj, fh)
+
+
+def test_heavy_variant_scales_glyph_weight_overrides():
+    with tempfile.TemporaryDirectory() as root:
+        font_dir = os.path.join(root, "font")
+        os.makedirs(font_dir)
+        _write(
+            os.path.join(font_dir, "font.json"),
+            {"params": {"weight": 1.0, "dot": 30}},
+        )
+        # One glyph with a weight override, one without, one with a non-weight
+        # override that must be left untouched.
+        _write(
+            os.path.join(font_dir, "glyphs", "u0046.json"),
+            {"codepoint": 70, "overrides": {"weight": 1.2}, "strokes": []},
+        )
+        _write(
+            os.path.join(font_dir, "glyphs", "u0041.json"),
+            {"codepoint": 65, "strokes": []},
+        )
+        _write(
+            os.path.join(font_dir, "glyphs", "u003a.json"),
+            {
+                "codepoint": 58,
+                "overrides": {"weight": 0.88, "baselineNudgePx": 2},
+                "strokes": [],
+            },
+        )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            hdir = pmf._heavy_variant_dir(font_dir, tmp)
+
+            font = json.load(
+                open(os.path.join(hdir, "font.json"), encoding="utf-8")
+            )
+            assert font["params"]["weight"] == round(1.0 * pmf.HEAVY_RATIO, 4)
+
+            f_glyph = json.load(
+                open(
+                    os.path.join(hdir, "glyphs", "u0046.json"),
+                    encoding="utf-8",
+                )
+            )
+            assert f_glyph["overrides"]["weight"] == round(
+                1.2 * pmf.HEAVY_RATIO, 4
+            )
+
+            colon = json.load(
+                open(
+                    os.path.join(hdir, "glyphs", "u003a.json"),
+                    encoding="utf-8",
+                )
+            )
+            assert colon["overrides"]["weight"] == round(
+                0.88 * pmf.HEAVY_RATIO, 4
+            )
+            # Non-weight overrides are untouched.
+            assert colon["overrides"]["baselineNudgePx"] == 2
+
+            # Glyph without overrides is unchanged.
+            a_glyph = json.load(
+                open(
+                    os.path.join(hdir, "glyphs", "u0041.json"),
+                    encoding="utf-8",
+                )
+            )
+            assert "overrides" not in a_glyph
+
+        # The source font dir is never mutated.
+        src_font = json.load(
+            open(os.path.join(font_dir, "font.json"), encoding="utf-8")
+        )
+        assert src_font["params"]["weight"] == 1.0
+        src_glyph = json.load(
+            open(
+                os.path.join(font_dir, "glyphs", "u0046.json"),
+                encoding="utf-8",
+            )
+        )
+        assert src_glyph["overrides"]["weight"] == 1.2
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-q"]))

--- a/tools/glyph-studio/README.md
+++ b/tools/glyph-studio/README.md
@@ -10,14 +10,20 @@ hand-polished in the editor.
 
 ## Run
 
+The interactive GUI is gone; the tool now drives from the MCP server (agent
+loop) or the Python CLIs. Start a server with:
+
 ```bash
 cd tools/glyph-studio
 npm install          # once
-npm run dev          # server :5177 + vite app
+npm run mcp          # stdio MCP server (agent tools) — see "MCP server" below
+npm run server       # or the HTTP server on :5177 over the same core
 ```
 
 Python side uses `~/Portfolio/.venv/bin/python` (numpy + PIL only — no new
-deps by design; scipy/skimage are deliberately absent from the venv).
+deps by design; scipy/skimage are deliberately absent from the venv). See the
+CLIs below for the trace/compile/test loop, and `ADD_MERCHANT.md` for
+onboarding a new merchant font.
 
 ## CLIs
 

--- a/tools/glyph-studio/server/env.mjs
+++ b/tools/glyph-studio/server/env.mjs
@@ -21,6 +21,23 @@ export const SAMPLES = {
   cvs: "/tmp/gridfix/cvs_studio/cvs.refined.npz",
 };
 
+// Font dir -> canonical merchant name. The receipt renderer caches per-merchant
+// ink-erosion pickles under a slug of the CANONICAL merchant name (see
+// scripts/render_synthetic_receipts.py::_render_cache_path). publish_font seeds
+// that pickle, so it must resolve the font's merchant to hit the right file.
+export const FONT_MERCHANTS = {
+  sprouts: "Sprouts Farmers Market",
+  costco: "Costco Wholesale",
+  vons: "Vons",
+  traderjoes: "Trader Joe's",
+  cvs: "CVS",
+};
+
+// Mirror _render_cache_path's slug: runs of non-alphanumerics -> single "_".
+export function renderCacheSlug(merchant) {
+  return (merchant || "none").replace(/[^A-Za-z0-9]+/g, "_");
+}
+
 export const PY_ENV = {
   ...process.env,
   PYTHONPATH: [

--- a/tools/glyph-studio/server/lib.mjs
+++ b/tools/glyph-studio/server/lib.mjs
@@ -9,11 +9,13 @@ import path from "node:path";
 import { promisify } from "node:util";
 import {
   BITMATRIX_DIR,
+  FONT_MERCHANTS,
   FONTS_DIR,
   OUT_DIR,
   PYTHON,
   PY_ENV,
   RENDER_CACHE_DIR,
+  renderCacheSlug,
   SAMPLES,
   STUDIO_ROOT,
   WORKTREE,
@@ -25,11 +27,13 @@ const execFileP = promisify(execFile);
 // Re-export env so consumers can pull everything from one module if they like.
 export {
   BITMATRIX_DIR,
+  FONT_MERCHANTS,
   FONTS_DIR,
   OUT_DIR,
   PYTHON,
   PY_ENV,
   RENDER_CACHE_DIR,
+  renderCacheSlug,
   SAMPLES,
   STUDIO_ROOT,
   WORKTREE,

--- a/tools/glyph-studio/server/mcp.mjs
+++ b/tools/glyph-studio/server/mcp.mjs
@@ -18,6 +18,8 @@ import { z } from "zod";
 
 import {
   SAMPLES,
+  FONT_MERCHANTS,
+  renderCacheSlug,
   PYTHON,
   PY_ENV,
   STUDIO_ROOT,
@@ -734,12 +736,20 @@ server.registerTool(
       } catch {}
       let seedWritten = null;
       if (typeof thinSeed === "number") {
+        // The renderer keys its inkthin pickle off the CANONICAL merchant name
+        // (see _render_cache_path), not the font dir name — resolve it so we
+        // seed the file the renderer will actually read.
+        const merchant = FONT_MERCHANTS[font];
+        if (!merchant) {
+          throw new Error(
+            `no merchant mapping for font "${font}" — cannot target its ` +
+              "inkthin render cache; add it to FONT_MERCHANTS in env.mjs",
+          );
+        }
         await fsp.mkdir(RENDER_CACHE_DIR, { recursive: true });
-        // TODO: the pickle filename derives from the merchant; only Sprouts is
-        // wired today. Generalize when a second merchant ships.
         const seedFile = path.join(
           RENDER_CACHE_DIR,
-          "Sprouts_Farmers_Market__inkthin__n1.pkl",
+          `${renderCacheSlug(merchant)}__inkthin__n1.pkl`,
         );
         await execFileP(
           PYTHON,


### PR DESCRIPTION
Addresses the post-merge review findings on the merchant font mint loop (#1036, #1037). Every finding was verified adversarially against the code before fixing.

## Finding status

| # | Source | Finding | Status |
|---|--------|---------|--------|
| A | codex | `_ensure_font_cached` passes receipt-variant aliases ("CVS pharmacy", "TRADER JOE'S") to the MerchantFont Dynamo lookup, but pointers are published under the canonical name -> fonts silently drop on cold cache | **Verified + fixed** (canonical-key resolution via new `get_merchant_profile_key`) + regression test |
| B | codex | logo `face="logo"` compared against the regular pointer's atlas `cache_filename`, so logo PNGs never download on a fresh host | **Verified + fixed** (exempt logo/stylemap from the atlas guard) + test |
| C | codex | `receipt_graphics` lazily imports `segno` + `python-barcode`, neither declared | **Verified + fixed** (added to `receipt_agent/pyproject.toml`; local versions segno 1.6.6 / python-barcode 0.16.1) |
| D | codex | heavy face scales only `font.json` params.weight; per-glyph `overrides.weight` (a REPLACEMENT in `merged_params`) stayed unscaled -> mixed-weight heavy face | **Verified + fixed** (scale glyph overrides in `_heavy_variant_dir`; blast radius: Sprouts) + test |
| E | codex | `--cached-synthetic-dir` hybrid path didn't pass `section_scale_for_merchant`/`merchant_typography`/`resolve_bitmap_thin` -> cached renders used the default TTF | **Verified + fixed** (wired the same typography resolution as `glyph_review`) |
| F | codex | `publish_font`'s `thinSeed` wrote a hardcoded `Sprouts_Farmers_Market__inkthin__n1.pkl` | **Verified + fixed** (derive from `FONT_MERCHANTS` + `renderCacheSlug`, matching `_render_cache_path`; slugs verified equal to the Python path for all 5 fonts) |
| G | codex | README `npm run dev` no longer exists (GUI app removed) | **Verified + fixed** (Run section now points to `npm run mcp`/`server`, CLIs, `ADD_MERCHANT.md`) |
| H | codex (#1037) | `extra_context_paths` JSON (font.json, stylemap.json, glyphs/*.json) isn't hashed -> baked font edits don't rebuild the image | **Verified + fixed** (fold `*.json` under extra paths into the hash; digest byte-identical for callers with no extra paths) + test |
| I | coderabbit | public (auth NONE) Function URL lambda has no concurrency cap | **Verified + fixed** (`reserved_concurrent_executions=10`; authorization stays NONE, matching the receipt connector) |
| - | codex | P1: `stdio_server_adapter` can't serve Function URLs | **Refuted, not changed** — the identical pattern is the live receipt-tools connector |

## Tests
- New: `scripts/test_merchant_font_cache.py` (A/B), `synthesis_loop/test_publish_merchant_font_heavy.py` (D), `infra/components/test_codebuild_content_hash.py` (H).
- Passing existing suites: `receipt_dynamo` merchant_font unit (33), glyph-studio pytest (15), `receipt_agent` rendering (56).
- Python files linted with black 26.5.1 / isort at `--line-length=79`; JS syntax-checked.

Not run: pulumi. Do not merge without maintainer review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HTrJ8omKZfEHQhZVTW5qYV