### PR TITLE
Fix Duplicate resource URN for shared label-evaluator component under pulumi --target

### DIFF
--- a/infra/__main__.py
+++ b/infra/__main__.py
@@ -130,6 +130,25 @@ notification_system = NotificationSystem(
 # Import shared ChromaDB bucket (created in chromadb_buckets.py for route access)
 from chromadb_buckets import shared_chromadb_buckets
 
+# Shared resources for the label evaluator pipeline (S3 buckets used by the EMR
+# analytics and Step Function components created ~1300 lines below).
+#
+# This MUST be registered early, near the top of the program, rather than next
+# to its consumers. Under `pulumi --target`, the engine resolves the target
+# closure against the *existing state* and eagerly emits a "same" step for this
+# component from state. If the program's own RegisterResource for the component
+# arrives after that (which happens when it is constructed late in module
+# execution), the engine sees the URN twice and fails with
+# "Duplicate resource URN ...; try giving it a unique name". Constructing it
+# here lets the program registration reconcile with the engine's same-step.
+# Untargeted previews/deploys are unaffected (registration order does not
+# matter there), so prod CI is unchanged.
+from components.shared_label_evaluator_resources import (
+    create_shared_label_evaluator_resources,
+)
+
+label_evaluator_shared = create_shared_label_evaluator_resources()
+
 # Create ChromaDB compaction infrastructure using shared bucket
 # Note: currency validation, create labels, and validation-by-merchant workflows are
 # temporarily disabled to decouple from receipt_label.
@@ -1444,13 +1463,10 @@ pulumi.export("emr_docker_image_uri", emr_docker_image.image_uri)
 # EMR Serverless Analytics infrastructure (for Spark analytics on LangSmith traces)
 from components.emr_serverless_analytics import create_emr_serverless_analytics
 
-# Shared resources for label evaluator pipeline (buckets used by multiple components)
-# Creating these first breaks circular dependencies between EMR and Step Function
-from components.shared_label_evaluator_resources import (
-    create_shared_label_evaluator_resources,
-)
-
-label_evaluator_shared = create_shared_label_evaluator_resources()
+# Shared resources for the label evaluator pipeline (buckets used by multiple
+# components) are constructed near the top of this program (search for
+# label_evaluator_shared) so that `pulumi --target` reconciles cleanly; see the
+# comment there. The instance is reused here via label_evaluator_shared.
 
 # NOTE: On first deployment, don't pass custom_image_uri - the EMR Application will use
 # the default EMR image initially. After the CodeBuild pipeline completes, it will


### PR DESCRIPTION
## Summary

Fixes the `Duplicate resource URN` failure that occurs on any `pulumi --target` run against the `dev` stack:

```
error: Duplicate resource URN
'urn:pulumi:dev::portfolio::custom:shared-label-evaluator-resources:label-evaluator-dev::label-evaluator-dev';
try giving it a unique name
```

Untargeted previews/deploys (including prod CI) were always fine — only `--target` runs failed.

The one-line fix: construct `SharedLabelEvaluatorResources` **early** in `infra/__main__.py` (next to the other shared-bucket resources near the top), instead of ~1300 lines down beside its EMR / Step Function consumers. Its identity (URN, parent, children) is unchanged; only its position in program execution order moves.

## Root cause — the runtime mechanics

The component is constructed exactly **once** (confirmed by instrumenting `__init__` with a per-process counter — it printed `count=1`; what looked like two invocations was Pulumi echoing each stderr line twice, once decorated with the `Stack … running` prefix and once raw). So the duplicate is **not** a double registration in the Python program — it is synthesized engine-side, and only in `--target` mode.

Engine debug logs (`-v=11`) show the sequence:

1. **11:44:58.827** — while the program is still registering unrelated resources early in the file, the engine's step generator emits a **`same` step for the shared component from existing state** and retires it. Under `--target`, the engine resolves the target closure against the prior state and eagerly materializes resources it expects, pulling this component (and its bucket children) in from state.
2. **11:45:01.287** (~2.5s later) — the program finally reaches the component's construction (it lived at line ~1453 of a ~1900-line program) and issues its own `RegisterResource`. The URN is already in the step generator's `urns` map from step 1, so the engine rejects it as a duplicate.

For every other resource, the program's `RegisterResource` arrives *before* the engine needs the URN, so the registration reconciles with the state entry into a single `same` step. This component was uniquely affected because it registered so late relative to when `--target` closure resolution wanted it.

Constructing it early makes its `RegisterResource` arrive before the engine's state-driven same-step, so the two reconcile normally. Untargeted runs never do state-driven closure resolution, so registration order is irrelevant there — which is exactly why prod CI never hit this.

## Verification (stack `dev`, `pulumi_aws` 7.33.0, preview only)

- **Targeted** — `pulumi preview --target 'urn:…glyph_mcp_lambda.infrastructure-glyph-mcp::glyph-mcp' --target-dependents`:
  - before: `1 errored` (Duplicate resource URN)
  - after: **`+ 26 to create`, `1279 unchanged`, 0 errored**
- **Untargeted** — `pulumi preview`:
  - **153 changes, 1152 unchanged**, and the per-URN plan is **byte-identical** before vs after (same 153 non-`same` URNs, same steps) — captured via `--save-plan` and diffed. This change does not alter the untargeted plan at all.

No `pulumi up` was run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HTrJ8omKZfEHQhZVTW5qYV