### PR TITLE
SynthesisPipeline finale: horizontally scrollable pairs + mobile REAL/SYNTH indicator

### DIFF
--- a/portfolio/components/ui/Figures/SynthesisPipeline/Acts.tsx
+++ b/portfolio/components/ui/Figures/SynthesisPipeline/Acts.tsx
@@ -628,6 +628,12 @@ const AssembleAct: React.FC<ActProps> = ({
  * matches the real. The card renders at a common width and its own natural
  * height (Costco taller than Vons taller than Sprouts).
  */
+/* Every logo is sized to the SAME visual weight (equal ink AREA) at its own
+   natural aspect, so wide wordmarks (Trader Joe's, CVS) read short-and-wide and
+   a squarer mark reads compact — none stretched. Area in (logo-height-unit)^2;
+   the box height is clamped so tall/square marks don't push the receipt down. */
+const LOGO_AREA = 1450;
+
 const FinaleCard: React.FC<{
   merchant: Merchant;
   shown: boolean;
@@ -635,10 +641,31 @@ const FinaleCard: React.FC<{
 }> = ({ merchant, shown, wipe }) => {
   const [synthFailed, setSynthFailed] = useState(false);
   const [realFailed, setRealFailed] = useState(false);
+  // Natural logo aspect, read from the mask image (works for any merchant — no
+  // hardcoded per-logo dimensions needed as new merchants are added).
+  const [logoAspect, setLogoAspect] = useState<number | null>(null);
   const dims = RECEIPT_DIMS[merchant];
   const logoUrl = `url(${logoSrc(merchant)})`;
   const wipePct = Math.round(clamp01(wipe) * 1000) / 10;
   const pair = !synthFailed && !realFailed;
+
+  useEffect(() => {
+    const img = new window.Image();
+    img.onload = () => {
+      if (img.naturalWidth && img.naturalHeight) {
+        setLogoAspect(img.naturalWidth / img.naturalHeight);
+      }
+    };
+    img.src = logoSrc(merchant);
+    return () => {
+      img.onload = null;
+    };
+  }, [merchant]);
+
+  // Equal-area sizing: w = sqrt(AREA * aspect), h = sqrt(AREA / aspect).
+  const aspect = logoAspect ?? 4;
+  const logoW = Math.sqrt(LOGO_AREA * aspect);
+  const logoH = Math.sqrt(LOGO_AREA / aspect);
 
   return (
     <figure
@@ -648,17 +675,21 @@ const FinaleCard: React.FC<{
       data-merchant={merchant}
     >
       {/* Merchant logo mark: currentColor through an alpha mask (theme-aware),
-          above the pair — replaces the text caption. A fixed box + mask
-          contain fits every aspect (Trader Joe's/CVS are long wordmarks). */}
-      <div
-        className={styles.finaleLogo}
-        role="img"
-        aria-label={`${MERCHANT_LABELS[merchant]} logo`}
-        style={{
-          WebkitMaskImage: logoUrl,
-          maskImage: logoUrl,
-        }}
-      />
+          at its natural aspect + equal ink area, centered in a fixed-height
+          slot so the receipts below stay tops-aligned. */}
+      <div className={styles.finaleLogoSlot}>
+        <div
+          className={styles.finaleLogo}
+          role="img"
+          aria-label={`${MERCHANT_LABELS[merchant]} logo`}
+          style={{
+            width: `${logoW}px`,
+            height: `${logoH}px`,
+            WebkitMaskImage: logoUrl,
+            maskImage: logoUrl,
+          }}
+        />
+      </div>
       <div
         className={styles.finaleFrame}
         data-testid="finale-frame"
@@ -714,25 +745,38 @@ const FinaleCard: React.FC<{
   );
 };
 
-const FinaleAct: React.FC<ActProps> = ({ progress, reducedMotion }) => {
+const FINALE_PAN_MS = 14000; // full left->right pan duration (fits the dwell)
+const FINALE_PAN_DELAY = 1200; // let the cards settle in before panning
+
+const FinaleAct: React.FC<ActProps> = ({
+  progress,
+  active,
+  reducedMotion,
+}) => {
   const p = reducedMotion ? 1 : progress;
   // Divider oscillates across the pair; rests centered (0.5) at p=0/1 so a
   // paused finale shows a clean real|synth split.
   const wipe = 0.5 + 0.42 * Math.sin(p * Math.PI * 2);
   const rowRef = useRef<HTMLDivElement>(null);
+  // Once the viewer touches the row (wheel/drag/touch) we hand over to manual
+  // snap-scroll and never fight them again for this mount.
+  const [manual, setManual] = useState(false);
+  const autoPan = active && !manual && !reducedMotion;
 
-  // Let a vertical mouse wheel scroll the pair row horizontally (trackpad and
-  // touch already scroll it natively). Only intercept when the row can scroll
-  // further in that direction, so the page still scrolls at the ends.
+  // Interaction cancels the auto-pan. A vertical mouse wheel also scrolls the
+  // row horizontally (trackpad/touch do that natively); only intercept when the
+  // row can scroll further, so the page still scrolls at the ends.
   useEffect(() => {
     const el = rowRef.current;
     if (!el) {
       return;
     }
+    const takeOver = () => setManual(true);
     const onWheel = (e: WheelEvent) => {
+      takeOver();
       const max = el.scrollWidth - el.clientWidth;
       if (max <= 1 || e.deltaY === 0 || Math.abs(e.deltaY) < Math.abs(e.deltaX)) {
-        return; // nothing to scroll, or already a horizontal gesture
+        return;
       }
       const atStart = el.scrollLeft <= 0;
       const atEnd = el.scrollLeft >= max - 1;
@@ -743,16 +787,58 @@ const FinaleAct: React.FC<ActProps> = ({ progress, reducedMotion }) => {
       el.scrollLeft += e.deltaY;
     };
     el.addEventListener("wheel", onWheel, { passive: false });
-    return () => el.removeEventListener("wheel", onWheel);
+    el.addEventListener("pointerdown", takeOver, { passive: true });
+    el.addEventListener("touchstart", takeOver, { passive: true });
+    return () => {
+      el.removeEventListener("wheel", onWheel);
+      el.removeEventListener("pointerdown", takeOver);
+      el.removeEventListener("touchstart", takeOver);
+    };
   }, []);
 
+  // Auto-pan: while the finale is active (and untouched), smoothly scroll the
+  // row left->right through every pair, then rest at the end. Time-based so it
+  // runs whether autoplay is playing or the act was jumped to.
+  useEffect(() => {
+    const el = rowRef.current;
+    if (!el || !autoPan) {
+      return;
+    }
+    const max = el.scrollWidth - el.clientWidth;
+    if (max <= 1) {
+      return; // everything fits — nothing to pan
+    }
+    let raf = 0;
+    let start = 0;
+    const ease = (t: number) => t * t * (3 - 2 * t);
+    const step = (ts: number) => {
+      if (!start) {
+        start = ts;
+      }
+      const t = clamp01((ts - start - FINALE_PAN_DELAY) / FINALE_PAN_MS);
+      el.scrollLeft = ease(t) * max;
+      if (t < 1) {
+        raf = requestAnimationFrame(step);
+      }
+    };
+    raf = requestAnimationFrame(step);
+    return () => cancelAnimationFrame(raf);
+  }, [autoPan]);
+
   return (
-    <div ref={rowRef} className={styles.finaleRow} data-testid="act-finale">
+    <div
+      ref={rowRef}
+      className={styles.finaleRow}
+      data-testid="act-finale"
+      data-autopan={autoPan || undefined}
+    >
       {MERCHANTS.map((m, i) => (
         <FinaleCard
           key={m}
           merchant={m}
-          shown={p >= (i / MERCHANTS.length) * 0.7}
+          // Cards settle in quickly (not spread across the long dwell) so the
+          // auto-pan reaches each one after it has appeared.
+          shown={p >= (i / MERCHANTS.length) * 0.08}
           wipe={wipe}
         />
       ))}

--- a/portfolio/components/ui/Figures/SynthesisPipeline/Acts.tsx
+++ b/portfolio/components/ui/Figures/SynthesisPipeline/Acts.tsx
@@ -702,6 +702,11 @@ const FinaleCard: React.FC<{
             <span className={`${styles.finaleChip} ${styles.finaleChipSynth}`}>
               synth
             </span>
+            {/* Mobile: one indicator that names whichever half currently
+                dominates the wipe (shown via CSS on narrow cards). */}
+            <span className={styles.finaleChipMobile}>
+              {wipePct >= 50 ? "real" : "synth"}
+            </span>
           </>
         ) : null}
       </div>
@@ -714,8 +719,35 @@ const FinaleAct: React.FC<ActProps> = ({ progress, reducedMotion }) => {
   // Divider oscillates across the pair; rests centered (0.5) at p=0/1 so a
   // paused finale shows a clean real|synth split.
   const wipe = 0.5 + 0.42 * Math.sin(p * Math.PI * 2);
+  const rowRef = useRef<HTMLDivElement>(null);
+
+  // Let a vertical mouse wheel scroll the pair row horizontally (trackpad and
+  // touch already scroll it natively). Only intercept when the row can scroll
+  // further in that direction, so the page still scrolls at the ends.
+  useEffect(() => {
+    const el = rowRef.current;
+    if (!el) {
+      return;
+    }
+    const onWheel = (e: WheelEvent) => {
+      const max = el.scrollWidth - el.clientWidth;
+      if (max <= 1 || e.deltaY === 0 || Math.abs(e.deltaY) < Math.abs(e.deltaX)) {
+        return; // nothing to scroll, or already a horizontal gesture
+      }
+      const atStart = el.scrollLeft <= 0;
+      const atEnd = el.scrollLeft >= max - 1;
+      if ((e.deltaY < 0 && atStart) || (e.deltaY > 0 && atEnd)) {
+        return; // let the page take over at the ends
+      }
+      e.preventDefault();
+      el.scrollLeft += e.deltaY;
+    };
+    el.addEventListener("wheel", onWheel, { passive: false });
+    return () => el.removeEventListener("wheel", onWheel);
+  }, []);
+
   return (
-    <div className={styles.finaleRow} data-testid="act-finale">
+    <div ref={rowRef} className={styles.finaleRow} data-testid="act-finale">
       {MERCHANTS.map((m, i) => (
         <FinaleCard
           key={m}

--- a/portfolio/components/ui/Figures/SynthesisPipeline/SynthesisPipeline.module.css
+++ b/portfolio/components/ui/Figures/SynthesisPipeline/SynthesisPipeline.module.css
@@ -561,6 +561,12 @@
   display: none; /* WebKit/Chrome — no scrollbar chrome */
 }
 
+/* While the auto-pan drives scrollLeft each frame, turn OFF snap so it can't
+   fight the animation; snap returns for manual scrolling. */
+.finaleRow[data-autopan] {
+  scroll-snap-type: none;
+}
+
 .finaleCard {
   display: flex;
   flex-direction: column;
@@ -687,15 +693,23 @@
   text-align: center;
 }
 
-/* Merchant logo mark: currentColor through an alpha mask, above each pair.
-   Rendered into a FIXED box (card width x a fixed band) with mask-size:contain,
-   so every logo — from the square-ish Vons mark to the long Trader Joe's / CVS
-   wordmarks — fits within the same box; the box is a constant height so the
-   receipts below stay tops-aligned regardless of logo aspect. */
-.finaleLogo {
-  width: var(--finale-w);
-  height: clamp(20px, 3.6vh, 34px);
+/* A constant-height slot the logo is centered in, so the receipts below stay
+   tops-aligned even though each logo's own height varies with its aspect. */
+.finaleLogoSlot {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: clamp(30px, 4.6vh, 42px);
+  width: 100%;
   flex-shrink: 0;
+}
+
+/* Merchant logo mark: currentColor through an alpha mask, at its NATURAL aspect
+   with an equal ink area across merchants (width/height set inline). The box
+   already matches the logo's aspect, so mask-size:contain fills it exactly. */
+.finaleLogo {
+  flex-shrink: 0;
+  max-width: 100%;
   background-color: currentColor;
   mask-mode: alpha;
   mask-repeat: no-repeat;

--- a/portfolio/components/ui/Figures/SynthesisPipeline/SynthesisPipeline.module.css
+++ b/portfolio/components/ui/Figures/SynthesisPipeline/SynthesisPipeline.module.css
@@ -534,19 +534,31 @@
 
 /* ==== Act 9: finale — same machine, every store ====================== */
 
-/* Tops aligned; every card shares one width so the natural height differences
-   show. --finale-w is capped by BOTH viewport height (so the tallest receipt,
-   Costco ≈ 3.95:1, fits the fixed stage) AND viewport width (so all five cards
-   fit the row without overflow, including narrow phones). */
+/* The finale scales to ANY number of merchants: cards keep a comfortable
+   readable width and the row scrolls horizontally (snap per pair) rather than
+   shrinking to cram them all in. Tops-aligned; natural heights, with the very
+   tallest receipts height-capped so the row never blows up the fixed stage. */
 .finaleRow {
   display: flex;
   align-items: flex-start;
-  justify-content: center;
-  gap: clamp(0.4rem, 2.5%, 1.25rem);
+  /* `safe center` centers the cards when they fit and left-aligns (so the first
+     card isn't clipped) once they overflow and the row scrolls. */
+  justify-content: safe center;
+  gap: clamp(0.5rem, 2%, 1.25rem);
   width: 100%;
   height: 100%;
   padding: 0.5rem 0.75rem;
-  --finale-w: clamp(46px, min(10vh, 16vw), 92px);
+  overflow-x: auto;
+  overflow-y: hidden;
+  scroll-snap-type: x mandatory;
+  scroll-padding-inline: 12%;
+  scrollbar-width: none; /* Firefox — no scrollbar chrome */
+  -webkit-overflow-scrolling: touch;
+  --finale-w: clamp(104px, 15vh, 128px);
+}
+
+.finaleRow::-webkit-scrollbar {
+  display: none; /* WebKit/Chrome — no scrollbar chrome */
 }
 
 .finaleCard {
@@ -555,8 +567,11 @@
   align-items: center;
   gap: 0.5rem;
   margin: 0;
+  height: 100%;
+  flex-shrink: 0;
+  scroll-snap-align: center;
   opacity: 0;
-  /* slide in from the right, beside the first (printed) receipt */
+  /* slide in from the right as each pair reveals */
   transform: translateX(28px) scale(0.96);
   transition:
     opacity 0.55s ease,
@@ -568,11 +583,18 @@
   transform: none;
 }
 
-/* Common width; height comes from the inline per-merchant aspect ratio, so the
-   three receipts differ in height, tops aligned. */
+/* Width is comfortable + common; height comes from the inline per-merchant
+   aspect ratio (so heights differ, tops aligned) but is capped so the tallest
+   receipts scale down (staying aspect-true, becoming a touch narrower) instead
+   of overflowing the fixed stage height. */
 .finaleFrame {
   position: relative;
   width: var(--finale-w);
+  /* Cap to the stage height (minus logo band, gap and shadow room) so the
+     tallest receipts scale down instead of overflowing / clipping the shadow.
+     100% resolves against the full-height card (interactive or static stage). */
+  max-height: calc(100% - 76px);
+  flex-shrink: 0;
   overflow: hidden;
   border-radius: 3px;
   background: var(--background-color, #fff);
@@ -629,6 +651,27 @@
 .finaleChipSynth {
   right: 4px;
   background: var(--color-blue);
+}
+
+/* Mobile only: a single centered indicator that flips label with the wipe, so
+   the two corner badges can never collide on a narrow card (shown via media
+   query below; the corner pair is hidden there). */
+.finaleChipMobile {
+  display: none;
+  position: absolute;
+  bottom: 4px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 4;
+  padding: 1px 7px;
+  border-radius: 999px;
+  font-size: 0.5rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #fff;
+  background: rgba(0, 0, 0, 0.66);
+  pointer-events: none;
 }
 
 .finaleFallback {
@@ -774,6 +817,16 @@
   .assembleSide {
     max-width: 100%;
     width: 100%;
+  }
+
+  /* Finale: swap the two corner badges (which collide on narrow cards) for a
+     single centered indicator that flips label with the wipe. */
+  .finaleChipReal,
+  .finaleChipSynth {
+    display: none;
+  }
+  .finaleChipMobile {
+    display: block;
   }
 }
 

--- a/portfolio/components/ui/Figures/SynthesisPipeline/pipelineData.ts
+++ b/portfolio/components/ui/Figures/SynthesisPipeline/pipelineData.ts
@@ -275,7 +275,7 @@ export const ACT_DWELL_MS: Record<ActId, number> = {
   character: 9500, // prints -> pen path + handles -> thermal dots, one beat
   font: 6500, // the hero glyph flies into the atlas — give it room
   assemble: 11000, // parallel section typing, then the label boxes draw on
-  finale: 7000,
+  finale: 18000, // slow gallery auto-pan through all the merchant pairs
 };
 
 /** How long autoplay stays paused after a manual interaction, then resumes. */

--- a/portfolio/e2e/synthesis-pipeline.spec.ts
+++ b/portfolio/e2e/synthesis-pipeline.spec.ts
@@ -109,5 +109,28 @@ test("figure loads, autoplays, and survives the full act cycle", async ({ page }
     ).toBeAttached();
   }
 
+  // The finale auto-pans through the pairs on its own, and any interaction
+  // hands over to manual scroll. Force the row to overflow (narrow viewport)
+  // then re-enter the finale so the pan starts fresh.
+  await page.setViewportSize({ width: 560, height: 900 });
+  await dots.nth(0).click();
+  await page.waitForTimeout(300);
+  await dots.nth(n - 1).click();
+  const row = page.getByTestId("act-finale");
+  await page.waitForTimeout(2000); // past the pan start delay
+  const s1 = await row.evaluate((el) => el.scrollLeft);
+  await page.waitForTimeout(1800);
+  const s2 = await row.evaluate((el) => el.scrollLeft);
+  // scrollLeft advances without any interaction...
+  expect(s2, "auto-pan advances scrollLeft").toBeGreaterThan(s1 + 5);
+  expect(await row.getAttribute("data-autopan")).not.toBeNull();
+  // ...and a wheel interaction cancels it (hands over to manual scroll).
+  await row.dispatchEvent("wheel", { deltaY: 20, deltaX: 0 });
+  await page.waitForTimeout(200);
+  expect(
+    await row.getAttribute("data-autopan"),
+    "a wheel interaction stops the auto-pan",
+  ).toBeNull();
+
   expect(errors, errors.join("\n")).toHaveLength(0);
 });


### PR DESCRIPTION
Round 7 of the SynthesisPipeline finale polish. Branched off `main` so it can land independently of the pending merchant-adding PRs (#1040 Target, Home Depot) — designed for N merchants, not a fixed 5.

## What changed
1. **Scrollable finale.** The pair row is now horizontally scroll-snap (one snap per card) instead of shrinking every card to fit. The next card peeks so scrollability is discoverable; the scrollbar chrome is hidden; a wheel handler maps a vertical mouse wheel to horizontal scroll (leaving page scroll intact at the ends — trackpad/touch already scroll natively). Cards return to a comfortable readable width; the tallest receipts are height-capped (aspect-true, a touch narrower) so the row never overflows the fixed stage. Tops-aligned natural heights preserved. Five cards still fit desktop; scroll kicks in as the count grows and on phones. All cards stay in the DOM (scrolled off-view) so the e2e still finds them.
2. **Mobile REAL/SYNTH collision.** The two corner badges overlapped on narrow cards; replaced on mobile with a single centered indicator that names whichever half the wipe currently favors — can't overlap by construction.

## Gates
- `npx jest components/ui/Figures` — 117 passed
- `npm run build` — green
- local `npx playwright test --config e2e/playwright.config.ts e2e/synthesis-pipeline.spec.ts` — passed
- Verified desktop + mobile, light + dark (including mid-scroll).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HTrJ8omKZfEHQhZVTW5qYV

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The finale view now auto-scrolls horizontally through merchant cards and can also be controlled manually by touch, wheel, or pointer interaction.
  * Merchant logos are now sized more consistently, keeping visual balance across different logo shapes.
  * Mobile users now see a single simplified status chip instead of separate corner chips.

* **Bug Fixes**
  * Improved finale layout to better handle more cards, prevent overflow, and keep receipts and logos aligned on smaller screens.
  * Extended the finale display timing so the end sequence stays visible longer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->