### PR TITLE
SynthesisPipeline: text-color act dots, drop the progress ring

### DIFF
--- a/portfolio/components/ui/Figures/SynthesisPipeline/SynthesisPipeline.module.css
+++ b/portfolio/components/ui/Figures/SynthesisPipeline/SynthesisPipeline.module.css
@@ -181,7 +181,7 @@
 }
 
 .progressDot[data-active="true"] {
-  background: var(--color-blue);
+  background: var(--text-color);
   transform: scale(1.18);
 }
 
@@ -191,29 +191,6 @@
 
 .progressDot[data-done="true"] {
   background: rgba(var(--text-color-rgb), 0.5);
-}
-
-/* Progress ring around the active dot: strokeDashoffset (set inline from act
-   progress) sweeps it clockwise as the autoplay dwell elapses, so the dot
-   telegraphs how long until the next act. */
-.progressRing {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  width: 1.35rem;
-  height: 1.35rem;
-  transform: translate(-50%, -50%) rotate(-90deg);
-  pointer-events: none;
-  overflow: visible;
-}
-
-.progressRingFill {
-  fill: none;
-  stroke: var(--color-blue);
-  stroke-width: 2.5;
-  stroke-linecap: round;
-  opacity: 0.85;
-  transition: stroke-dashoffset 0.12s linear;
 }
 
 /* ---- Reduced-motion static stack ------------------------------------ */
@@ -790,7 +767,6 @@
   .fontCellHero,
   .thumb,
   .progressDot,
-  .progressRingFill,
   .finaleCard {
     transition: none;
   }

--- a/portfolio/components/ui/Figures/SynthesisPipeline/index.tsx
+++ b/portfolio/components/ui/Figures/SynthesisPipeline/index.tsx
@@ -353,24 +353,6 @@ const SynthesisPipeline: React.FC = () => {
                 onClick={() => jumpToAct(meta.index)}
                 data-testid={`act-dot-${meta.index}`}
               />
-              {isActive ? (
-                <svg
-                  className={styles.progressRing}
-                  viewBox="0 0 24 24"
-                  aria-hidden="true"
-                  data-testid="act-progress-ring"
-                >
-                  <circle
-                    className={styles.progressRingFill}
-                    cx="12"
-                    cy="12"
-                    r="9"
-                    pathLength={1}
-                    strokeDasharray={1}
-                    strokeDashoffset={Math.min(1, Math.max(0, 1 - actProgress))}
-                  />
-                </svg>
-              ) : null}
             </li>
           );
         })}


### PR DESCRIPTION
Small polish to the SynthesisPipeline act dots (per Tyler):

- The active act dot is now the page **text color** (black on light, white on dark) instead of blue.
- Removed the sweeping **progress ring** that circled the active dot as the autoplay dwell elapsed (the "wheel"). The dots are now simple text-color dots — active bigger, done half-strength, upcoming faint.

Net −42 lines (dropped the ring SVG + its CSS + reduced-motion entry).

## Gates
- `npx jest components/ui/Figures` — 117 passed
- `npm run build` — green
- local `npx playwright test --config e2e/playwright.config.ts e2e/synthesis-pipeline.spec.ts` — passed
- Verified light + dark.

Independent of #1044 (finale scroll); branched off `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HTrJ8omKZfEHQhZVTW5qYV