### PR TITLE
Make synthetic render deterministic: seed paper texture from content, not output path

### DIFF
--- a/scripts/render_synthetic_receipts.py
+++ b/scripts/render_synthetic_receipts.py
@@ -1401,6 +1401,38 @@ def resolve_bitmap_thin(
     return thin
 
 
+def _content_texture_seed(receipt: dict) -> int:
+    """A stable paper-texture seed derived from the receipt's CONTENT.
+
+    The texture must be a property of the receipt, not of where the render is
+    written. Keying the seed on the output filename coupled the render to an
+    incidental input: an evaluator that re-renders the same receipt to a fresh
+    debug path (glyph_review / the line scorecard write ``det_1.png``,
+    ``det_2.png`` ...) got a different paper texture per run, which shifted the
+    thresholded glyph-height measurements and made the scorecard gates bounce
+    run-to-run on identical inputs. Seeding from the content instead keeps a
+    given receipt's render byte-identical regardless of the output path, while
+    distinct receipts still get distinct textures (dataset variety survives,
+    since distinct examples differ in merchant/word content).
+    """
+    parts = [str(receipt.get("merchant_name") or "")]
+    words = receipt.get("words") or []
+
+    def _key(word: dict):
+        return (
+            int(word.get("line_id") or 0),
+            int(word.get("word_id") or 0),
+        )
+
+    for word in sorted(words, key=_key):
+        line_id, word_id = _key(word)
+        bbox = word.get("bbox") or []
+        bbox_str = ",".join(f"{float(v):.2f}" for v in bbox)
+        text = word.get("text", "")
+        parts.append(f"{line_id}:{word_id}:{text}:{bbox_str}")
+    return zlib.crc32("\n".join(parts).encode("utf-8"))
+
+
 def _render_cached_hybrid(
     receipt: dict,
     atlas,
@@ -1629,8 +1661,11 @@ def _render_cached_hybrid(
         coord_max=1000.0,
         reserved=stamped_bands,
     )
-    # Deterministic per-output seed so re-rendering the same file is stable.
-    texture_seed = zlib.crc32(os.path.basename(path).encode("utf-8"))
+    # Content-derived seed so a given receipt renders the SAME paper texture
+    # regardless of the output path. Keying on the filename made scorecard
+    # metrics (measured on the textured image) bounce run-to-run whenever an
+    # evaluator re-rendered to a fresh debug path. See _content_texture_seed.
+    texture_seed = _content_texture_seed(receipt)
     image = _composite_paper_texture(image, seed=texture_seed)
     os.makedirs(os.path.dirname(os.path.abspath(path)), exist_ok=True)
     image.convert("RGB").save(path, format="PNG")

--- a/scripts/test_render_texture_seed.py
+++ b/scripts/test_render_texture_seed.py
@@ -1,0 +1,71 @@
+"""Regression test for paper-texture determinism in render_synthetic_receipts.
+
+The paper-texture seed used to be ``crc32(basename(output_path))``, coupling
+the render to an incidental input: an evaluator (glyph_review / the line
+scorecard) re-renders the SAME receipt to a fresh debug path each run
+(``det_1.png``, ``det_2.png`` ...), so each run got a different paper texture,
+which shifted the thresholded glyph-height measurements and made the scorecard
+gates bounce run-to-run on identical inputs.
+
+The seed is now derived from the receipt CONTENT, so a given receipt renders
+the same texture regardless of where it is written, while distinct receipts
+still get distinct textures.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import render_synthetic_receipts as rsr  # noqa: E402
+
+
+def _receipt():
+    return {
+        "merchant_name": "In-N-Out Burger",
+        "words": [
+            {
+                "line_id": 2,
+                "word_id": 1,
+                "text": "DOUBLE-DOUBLE",
+                "bbox": [10.0, 20.0, 120.0, 45.0],
+            },
+            {
+                "line_id": 1,
+                "word_id": 3,
+                "text": "TOTAL",
+                "bbox": [10.5, 4.25, 60.0, 30.0],
+            },
+        ],
+    }
+
+
+def test_seed_is_stable_for_identical_content():
+    assert rsr._content_texture_seed(_receipt()) == rsr._content_texture_seed(
+        _receipt()
+    )
+
+
+def test_seed_is_independent_of_word_order():
+    r = _receipt()
+    shuffled = {
+        "merchant_name": r["merchant_name"],
+        "words": list(reversed(r["words"])),
+    }
+    assert rsr._content_texture_seed(r) == rsr._content_texture_seed(shuffled)
+
+
+def test_seed_changes_with_content():
+    r = _receipt()
+    other = _receipt()
+    other["words"][0]["text"] = "CHEESEBURGER"
+    assert rsr._content_texture_seed(r) != rsr._content_texture_seed(other)
+
+    other2 = _receipt()
+    other2["merchant_name"] = "Target"
+    assert rsr._content_texture_seed(r) != rsr._content_texture_seed(other2)
+
+
+def test_seed_handles_empty_and_missing_fields():
+    # Must not raise on sparse dicts (barcodes-only / logo-only receipts).
+    assert isinstance(rsr._content_texture_seed({}), int)
+    assert isinstance(rsr._content_texture_seed({"merchant_name": "X"}), int)


### PR DESCRIPTION
## Root cause

`_render_cached_hybrid` seeded the paper texture from the **output filename**:

```python
texture_seed = zlib.crc32(os.path.basename(path).encode("utf-8"))
```

That couples the render to an incidental input. The evaluators
(`synthesis_loop/glyph_review.py` and `receipt_line_scorecard.py`) re-render the
**same** receipt to a **fresh** debug path each invocation (`det_1.png`,
`det_2.png`, ...). Because the scorecard measures glyph geometry on the
*textured* synthetic image, the texture's low-frequency luma field + ink-bleed
blur shift the thresholded cap-height measurement from run to run.

Observed on In-N-Out (`9afeb902-…:2`): `synth_h_med` bounced **31 / 32 / 36 /
36.5 / 37 px** across identical invocations, breaking every scorecard gate.

The render was otherwise fully deterministic — rendering to a **fixed** path
produced byte-identical `.syn.png` every run. The defect was purely that the
texture was keyed on *where* output is written rather than *what* is rendered.

### Evidence

| condition | `synth_h_med` across 5 runs | `.syn.png` bytes |
|---|---|---|
| before, varying filenames | 31 / 32 / 36 / 36.5 / 37 | all differ |
| before, **fixed** filename | 32 / 32 / 32 / 32 / 32 | identical |
| before, texture off, varying filenames | 31 / 31 / 31 | identical |

The texture-off row confirms the paper texture (the sole path-dependency in the
module) is the entire cause.

## Fix

Derive the seed from the receipt **content** (`_content_texture_seed`): merchant
name + each word's line/word id, text, and rounded bbox, in a stable order. A
given receipt now renders byte-identically regardless of the output path, while
distinct receipts still get distinct textures — dataset variety is preserved
(each cached example differs in content), and the `out_dir`/`public_dir` pair
(same basename today) stays consistent.

## Verification

5 consecutive runs to **varying** filenames now produce byte-identical `.syn.png`
and identical scorecard metrics, cross-merchant:

- In-N-Out `9afeb902-…:2` → `synth_h_med`=34.50, one `.syn.png` hash for all 5 runs
- Target `249e7199-…:1` → `synth_h_med`=40.00, one `.syn.png` hash for all 5 runs

Added `scripts/test_render_texture_seed.py` (seed is stable, order-independent,
content-sensitive, and robust to sparse dicts). `black`/`isort` clean at
line-length 79.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HTrJ8omKZfEHQhZVTW5qYV