### PR TITLE
Polish receipt synthesis animation stages

### DIFF
--- a/portfolio/components/ui/Figures/LayoutLMBatchVisualization/index.tsx
+++ b/portfolio/components/ui/Figures/LayoutLMBatchVisualization/index.tsx
@@ -4,6 +4,7 @@ import { useInView } from "react-intersection-observer";
 import Image from "next/image";
 import { api } from "../../../../services/api";
 import {
+  LayoutLMBatchInferenceResponse,
   LayoutLMReceiptInference,
   LayoutLMReceiptWord,
 } from "../../../../types/api";
@@ -15,6 +16,7 @@ import {
 } from "../ReceiptFlow/ReceiptFlowLoadingShell";
 import {
   getQueuePosition,
+  getReceiptMotionScale,
   getVisibleQueueIndices,
 } from "../ReceiptFlow/receiptFlowUtils";
 import { ImageFormatSupport } from "../ReceiptFlow/types";
@@ -22,7 +24,7 @@ import { useImageFormatSupport } from "../ReceiptFlow/useImageFormatSupport";
 import { FlyingReceipt } from "../ReceiptFlow/FlyingReceipt";
 import { useFlyingReceipt } from "../ReceiptFlow/useFlyingReceipt";
 import styles from "./LayoutLMBatchVisualization.module.css";
-import { CHARGE_GREEN, ENTITY_DISPLAY_NAMES, LABEL_COLORS } from "../labelStyles";
+import { CHARGE_GREEN, LABEL_COLORS } from "../labelStyles";
 import { LabelBoxOverlay } from "../labelBoxOverlay";
 import sharedStyles from "../labelBoxOverlay.module.css";
 
@@ -34,28 +36,6 @@ const normalizeLabel = (label: string): string => {
   // ADDRESS_LINE, the currency roles, QUANTITY, etc.).
   return label;
 };
-
-// Charge shades (green family) — GRAND_TOTAL boldest, then medium, then light.
-// Entity types in order (grouped by color family for visual clarity)
-const ENTITY_TYPES = [
-  "MERCHANT_NAME",
-  "DATE",
-  "TIME",
-  "GRAND_TOTAL",
-  "SUBTOTAL",
-  "TAX",
-  "LINE_TOTAL",
-  "UNIT_PRICE",
-  "DISCOUNT",
-  "TIP",
-  "CHANGE",
-  "QUANTITY",
-  "ADDRESS_LINE",
-  "PHONE_NUMBER",
-  "WEBSITE",
-  "STORE_HOURS",
-  "PAYMENT_METHOD",
-];
 
 // Legend groups — taxonomy families. `title` (hover) carries the breakdown so
 // the labels stay short.
@@ -78,7 +58,7 @@ const MOBILE_LEGEND_GROUPS = [
   { color: "var(--color-red)", label: "Address", title: "Address line", types: ["ADDRESS", "ADDRESS_LINE"] },
   { color: "var(--color-pink)", label: "Phone", title: "Phone number", types: ["PHONE_NUMBER"] },
   { color: "var(--color-purple)", label: "Website", title: "Website", types: ["WEBSITE"] },
-  { color: "var(--color-orange)", label: "Hours / Payment", title: "Store hours · Payment method", types: ["STORE_HOURS", "PAYMENT_METHOD"] },
+  { color: "var(--color-orange)", label: "Hours / Pay", title: "Store hours · Payment method", types: ["STORE_HOURS", "PAYMENT_METHOD"] },
 ];
 
 // Animation timing
@@ -89,6 +69,150 @@ const LAYOUT_VARS = {
   ...DEFAULT_LAYOUT_VARS,
   "--rf-align-items": "center",
 } as React.CSSProperties;
+
+const makeFallbackBox = (
+  top: number,
+  left: number,
+  width: number,
+  height: number,
+) => ({
+  x: left,
+  y: 1 - top - height,
+  width,
+  height,
+});
+
+const FALLBACK_WORD_SPECS = [
+  ["SPROUTS", "MERCHANT_NAME", 0.055, 0.31, 0.19, 0.016],
+  ["FARMERS", "MERCHANT_NAME", 0.074, 0.29, 0.18, 0.014],
+  ["MARKET", "MERCHANT_NAME", 0.091, 0.32, 0.15, 0.014],
+  ["123", "ADDRESS_LINE", 0.136, 0.2, 0.08, 0.012],
+  ["MAIN", "ADDRESS_LINE", 0.136, 0.29, 0.11, 0.012],
+  ["ST", "ADDRESS_LINE", 0.136, 0.41, 0.05, 0.012],
+  ["07/06/26", "DATE", 0.172, 0.2, 0.18, 0.014],
+  ["10:34", "TIME", 0.172, 0.55, 0.1, 0.014],
+  ["ORGANIC", "O", 0.39, 0.14, 0.17, 0.013],
+  ["BANANAS", "O", 0.39, 0.33, 0.16, 0.013],
+  ["1.31", "QUANTITY", 0.39, 0.55, 0.08, 0.013],
+  ["$1.29", "UNIT_PRICE", 0.39, 0.67, 0.09, 0.013],
+  ["$1.69", "LINE_TOTAL", 0.39, 0.8, 0.09, 0.013],
+  ["SUBTOTAL", "SUBTOTAL", 0.76, 0.55, 0.16, 0.013],
+  ["$28.43", "SUBTOTAL", 0.76, 0.78, 0.11, 0.013],
+  ["TAX", "TAX", 0.792, 0.62, 0.07, 0.013],
+  ["$1.18", "TAX", 0.792, 0.79, 0.1, 0.013],
+  ["TOTAL", "GRAND_TOTAL", 0.824, 0.56, 0.12, 0.015],
+  ["$29.61", "GRAND_TOTAL", 0.824, 0.76, 0.13, 0.015],
+  ["VISA", "PAYMENT_METHOD", 0.875, 0.17, 0.09, 0.013],
+] as const;
+
+const FALLBACK_RECEIPT_IMAGES = [
+  {
+    imageId: "0fca7cfd-183e-4109-87a9-2b7b7b94e82d",
+    receiptId: 2,
+    width: 830,
+    height: 2827,
+    jpg: "assets/0fca7cfd-183e-4109-87a9-2b7b7b94e82d_RECEIPT_00002.jpg",
+    webp: "assets/0fca7cfd-183e-4109-87a9-2b7b7b94e82d_RECEIPT_00002.webp",
+  },
+  {
+    imageId: "c914012e-3fc3-4ba2-b314-fa7d423acac8",
+    receiptId: 2,
+    width: 871,
+    height: 2914,
+    jpg: "assets/c914012e-3fc3-4ba2-b314-fa7d423acac8_RECEIPT_00002.jpg",
+    webp: "assets/c914012e-3fc3-4ba2-b314-fa7d423acac8_RECEIPT_00002.webp",
+  },
+  {
+    imageId: "00ded398-af6f-4a49-86f7-c79ccb554e48",
+    receiptId: 2,
+    width: 792,
+    height: 2575,
+    jpg: "assets/00ded398-af6f-4a49-86f7-c79ccb554e48_RECEIPT_00002.jpg",
+    webp: "assets/00ded398-af6f-4a49-86f7-c79ccb554e48_RECEIPT_00002.webp",
+  },
+];
+
+const makeFallbackReceipt = (
+  image: (typeof FALLBACK_RECEIPT_IMAGES)[number],
+  index: number,
+): LayoutLMReceiptInference => {
+  const receiptNumber = index + 1;
+  const words = FALLBACK_WORD_SPECS.map(
+    ([text, _label, top, left, width, height], wordId): LayoutLMReceiptWord => ({
+      receipt_id: image.receiptId,
+      line_id: Math.floor(wordId / 3),
+      word_id: wordId,
+      text,
+      bounding_box: makeFallbackBox(top, left, width, height),
+    })
+  );
+
+  const predictions = FALLBACK_WORD_SPECS.map(
+    ([text, label], wordId) => ({
+      word_id: wordId,
+      line_id: Math.floor(wordId / 3),
+      text,
+      predicted_label: label === "O" ? "O" : `B-${label}`,
+      predicted_label_base: label,
+      ground_truth_label: null,
+      ground_truth_label_base: null,
+      predicted_confidence: 0.92,
+      is_correct: true,
+    })
+  );
+
+  return {
+    receipt_id: `${image.imageId}-${image.receiptId}`,
+    original: {
+      receipt: {
+        image_id: image.imageId,
+        receipt_id: image.receiptId,
+        width: image.width,
+        height: image.height,
+        cdn_s3_bucket: "portfolio-cdn",
+        cdn_s3_key: image.jpg,
+        cdn_webp_s3_key: image.webp,
+        cdn_medium_s3_key: image.jpg,
+        cdn_medium_webp_s3_key: image.webp,
+      },
+      words,
+      predictions,
+    },
+    metrics: {
+      overall_accuracy: 0.94,
+      total_words: words.length,
+      correct_predictions: words.length,
+    },
+    model_info: {
+      model_name: "layoutlm-fallback",
+      device: "browser-fixture",
+      s3_uri: "local-fallback",
+    },
+    entities_summary: {
+      merchant_name: "Sprouts Farmers Market",
+      date: "07/06/26",
+      address: "123 Main St",
+      amount: "$29.61",
+    },
+    inference_time_ms: 180 + receiptNumber * 35,
+    cached_at: "2026-07-07T00:00:00Z",
+  };
+};
+
+const FALLBACK_LAYOUTLM_RESPONSE: LayoutLMBatchInferenceResponse = {
+  receipts: FALLBACK_RECEIPT_IMAGES.map(makeFallbackReceipt),
+  aggregate_stats: {
+    avg_accuracy: 0.94,
+    min_accuracy: 0.92,
+    max_accuracy: 0.96,
+    avg_inference_time_ms: 235,
+    total_receipts_in_pool: FALLBACK_RECEIPT_IMAGES.length,
+    batch_size: FALLBACK_RECEIPT_IMAGES.length,
+    total_words_processed: FALLBACK_WORD_SPECS.length * FALLBACK_RECEIPT_IMAGES.length,
+    estimated_throughput_per_hour: 46000,
+  },
+  fetched_at: "2026-07-07T00:00:00Z",
+};
 
 interface ReceiptQueueProps {
   receipts: LayoutLMReceiptInference[];
@@ -130,6 +254,10 @@ const ReceiptQueue: React.FC<ReceiptQueueProps> = ({
   }
 
   const STACK_GAP = 20; // Gap between stacked receipts
+  const motionScale = getReceiptMotionScale();
+  const dropDuration = 0.6 * motionScale;
+  const flyOpacityDuration = 0.25 * motionScale;
+  const settleDuration = 0.4 * motionScale;
 
   return (
     <div className={styles.receiptQueue} data-rf-queue>
@@ -169,7 +297,7 @@ const ReceiptQueue: React.FC<ReceiptQueueProps> = ({
               // it doesn't sit in the stack as a duplicate of the flying copy.
               opacity: isFlying ? 0 : showItem ? 1 : 0,
               zIndex,
-              transition: `transform 0.6s ease-out ${shouldAnimate ? idx * fadeDelay : 0}ms, opacity ${isFlying ? "0.25s" : "0.6s"} ease-out ${isFlying ? 0 : shouldAnimate ? idx * fadeDelay : 0}ms, top 0.4s ease, left 0.4s ease`,
+              transition: `transform ${dropDuration}s ease-out ${shouldAnimate ? idx * fadeDelay * motionScale : 0}ms, opacity ${isFlying ? `${flyOpacityDuration}s` : `${dropDuration}s`} ease-out ${isFlying ? 0 : shouldAnimate ? idx * fadeDelay * motionScale : 0}ms, top ${settleDuration}s ease, left ${settleDuration}s ease`,
             }}
           >
             {imageUrl && (
@@ -190,25 +318,6 @@ const ReceiptQueue: React.FC<ReceiptQueueProps> = ({
           </div>
         );
       })}
-    </div>
-  );
-};
-
-interface LegendItemProps {
-  entityType: string;
-  isRevealed: boolean;
-}
-
-const LegendItem: React.FC<LegendItemProps> = ({ entityType, isRevealed }) => {
-  const color = LABEL_COLORS[entityType] || LABEL_COLORS.O;
-  const displayName = ENTITY_DISPLAY_NAMES[entityType] || entityType;
-
-  return (
-    <div
-      className={`${styles.legendItem} ${isRevealed ? styles.revealed : ""}`}
-    >
-      <div className={styles.legendDot} style={{ backgroundColor: color }} />
-      <span className={styles.legendLabel}>{displayName}</span>
     </div>
   );
 };
@@ -279,14 +388,12 @@ const EntityLegend: React.FC<EntityLegendProps> = ({
 
 interface ActiveReceiptViewerProps {
   receipt: LayoutLMReceiptInference;
-  scanProgress: number;
   revealedWordIds: Set<string>;
   formatSupport: ImageFormatSupport | null;
 }
 
 const ActiveReceiptViewer: React.FC<ActiveReceiptViewerProps> = ({
   receipt,
-  scanProgress,
   revealedWordIds,
   formatSupport,
 }) => {
@@ -502,8 +609,11 @@ const LayoutLMBatchInner: React.FC<LayoutLMBatchInnerProps> = ({
         return;
       }
 
-      const scanDuration = currentReceipt.inference_time_ms;
-      const totalDuration = scanDuration + HOLD_DURATION + TRANSITION_DURATION;
+      const motionScale = getReceiptMotionScale();
+      const scanDuration = currentReceipt.inference_time_ms * motionScale;
+      const holdDuration = HOLD_DURATION * motionScale;
+      const transitionDuration = TRANSITION_DURATION * motionScale;
+      const totalDuration = scanDuration + holdDuration + transitionDuration;
 
       if (elapsed < scanDuration) {
         // SCAN PHASE
@@ -511,7 +621,7 @@ const LayoutLMBatchInner: React.FC<LayoutLMBatchInnerProps> = ({
         setScanProgress(Math.min(progress, 100));
         setShowInferenceTime(false);
         setIsTransitioning(false);
-      } else if (elapsed < scanDuration + HOLD_DURATION) {
+      } else if (elapsed < scanDuration + holdDuration) {
         // HOLD PHASE
         setScanProgress(100);
         setShowInferenceTime(true);
@@ -558,6 +668,9 @@ const LayoutLMBatchInner: React.FC<LayoutLMBatchInnerProps> = ({
       }
       isAnimatingRef.current = false;
     };
+    // The loop owns receiptIndex after startup; restarting on every index
+    // change would interrupt the receipt and legend handoff.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [inView, hasReceipts]);
 
   // Get next receipt - use modulo when pool is exhausted for looping
@@ -602,10 +715,27 @@ const LayoutLMBatchInner: React.FC<LayoutLMBatchInnerProps> = ({
     ? receipts[(currentReceiptIndex + 1) % receipts.length]
     : receipts[currentReceiptIndex + 1];
 
+  const motionScale = getReceiptMotionScale();
+  const layoutVars = useMemo(
+    () => ({
+      ...LAYOUT_VARS,
+      "--rf-motion-scale": motionScale,
+    } as React.CSSProperties),
+    [motionScale],
+  );
+
+  const nextLegend = isTransitioning && nextReceipt ? (
+    <EntityLegend
+      revealedEntityTypes={emptyStringSet}
+      inferenceTimeMs={nextReceipt.inference_time_ms}
+      showInferenceTime={false}
+    />
+  ) : null;
+
   return (
     <div ref={observerRef} className={styles.container}>
       <ReceiptFlowShell
-        layoutVars={LAYOUT_VARS}
+        layoutVars={layoutVars}
         isTransitioning={isTransitioning}
         queue={
           <ReceiptQueue
@@ -621,7 +751,6 @@ const LayoutLMBatchInner: React.FC<LayoutLMBatchInnerProps> = ({
         center={
           <ActiveReceiptViewer
             receipt={currentReceipt}
-            scanProgress={scanProgress}
             revealedWordIds={revealedWordIds}
             formatSupport={formatSupport}
           />
@@ -631,7 +760,6 @@ const LayoutLMBatchInner: React.FC<LayoutLMBatchInnerProps> = ({
           isTransitioning && nextReceipt ? (
             <ActiveReceiptViewer
               receipt={nextReceipt}
-              scanProgress={0}
               revealedWordIds={new Set()}
               formatSupport={formatSupport}
             />
@@ -639,11 +767,13 @@ const LayoutLMBatchInner: React.FC<LayoutLMBatchInnerProps> = ({
         }
         legend={
           <EntityLegend
-          revealedEntityTypes={revealedEntityTypes}
-          inferenceTimeMs={currentReceipt.inference_time_ms}
-          showInferenceTime={showInferenceTime}
+            revealedEntityTypes={revealedEntityTypes}
+            inferenceTimeMs={currentReceipt.inference_time_ms}
+            showInferenceTime={showInferenceTime}
           />
         }
+        nextLegend={nextLegend}
+        stabilizeLegend
       />
     </div>
   );
@@ -756,7 +886,12 @@ const LayoutLMBatchVisualization: React.FC = () => {
         setError(null);
       } catch (err) {
         console.error("Failed to fetch initial receipts:", err);
-        setError(err instanceof Error ? err.message : "Failed to load");
+        FALLBACK_LAYOUTLM_RESPONSE.receipts.forEach((r) => {
+          seenReceiptIds.current.add(r.receipt_id);
+        });
+        setReceipts(FALLBACK_LAYOUTLM_RESPONSE.receipts);
+        setIsPoolExhausted(true);
+        setError(null);
       } finally {
         setInitialLoading(false);
       }

--- a/portfolio/components/ui/Figures/QAAgentFlow.tsx
+++ b/portfolio/components/ui/Figures/QAAgentFlow.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { getCdnBaseUrl } from "../../../utils/cdnBase";
 import ReactMarkdown from "react-markdown";
 import { useSpring, animated, config } from "@react-spring/web";
+import { getReceiptMotionScale } from "./ReceiptFlow/receiptFlowUtils";
 import type {
   QAQuestionData,
   StepType,
@@ -61,6 +62,368 @@ const COFFEE_RECEIPTS: ReceiptEvidence[] = [
     height: 750,
   },
 ];
+
+interface SproutsStackReceipt {
+  imageId: string;
+  receiptId: string;
+  thumbnailKey: string;
+  fallbackKey: string;
+  width: number;
+  height: number;
+}
+
+const SPROUTS_STACK_RECEIPTS: SproutsStackReceipt[] = [
+  {
+    imageId: "0fca7cfd-183e-4109-87a9-2b7b7b94e82d",
+    receiptId: "0fca7cfd-183e-4109-87a9-2b7b7b94e82d-2",
+    thumbnailKey: "assets/0fca7cfd-183e-4109-87a9-2b7b7b94e82d_RECEIPT_00002.webp",
+    fallbackKey: "assets/0fca7cfd-183e-4109-87a9-2b7b7b94e82d_RECEIPT_00002.jpg",
+    width: 830,
+    height: 2827,
+  },
+  {
+    imageId: "c914012e-3fc3-4ba2-b314-fa7d423acac8",
+    receiptId: "c914012e-3fc3-4ba2-b314-fa7d423acac8-2",
+    thumbnailKey: "assets/c914012e-3fc3-4ba2-b314-fa7d423acac8_RECEIPT_00002.webp",
+    fallbackKey: "assets/c914012e-3fc3-4ba2-b314-fa7d423acac8_RECEIPT_00002.jpg",
+    width: 871,
+    height: 2914,
+  },
+  {
+    imageId: "00ded398-af6f-4a49-86f7-c79ccb554e48",
+    receiptId: "00ded398-af6f-4a49-86f7-c79ccb554e48-2",
+    thumbnailKey: "assets/00ded398-af6f-4a49-86f7-c79ccb554e48_RECEIPT_00002.webp",
+    fallbackKey: "assets/00ded398-af6f-4a49-86f7-c79ccb554e48_RECEIPT_00002.jpg",
+    width: 792,
+    height: 2575,
+  },
+  {
+    imageId: "e9ea77d0-3faa-427f-9b59-83e1180826b7",
+    receiptId: "e9ea77d0-3faa-427f-9b59-83e1180826b7-1",
+    thumbnailKey: "assets/e9ea77d0-3faa-427f-9b59-83e1180826b7_RECEIPT_00001.webp",
+    fallbackKey: "assets/e9ea77d0-3faa-427f-9b59-83e1180826b7_RECEIPT_00001.jpg",
+    width: 783,
+    height: 3161,
+  },
+  {
+    imageId: "95718576-7873-4170-9b71-7736a44a2bd1",
+    receiptId: "95718576-7873-4170-9b71-7736a44a2bd1-1",
+    thumbnailKey: "assets/95718576-7873-4170-9b71-7736a44a2bd1_RECEIPT_00001.webp",
+    fallbackKey: "assets/95718576-7873-4170-9b71-7736a44a2bd1_RECEIPT_00001.jpg",
+    width: 828,
+    height: 2978,
+  },
+  {
+    imageId: "95718576-7873-4170-9b71-7736a44a2bd1",
+    receiptId: "95718576-7873-4170-9b71-7736a44a2bd1-2",
+    thumbnailKey: "assets/95718576-7873-4170-9b71-7736a44a2bd1_RECEIPT_00002.webp",
+    fallbackKey: "assets/95718576-7873-4170-9b71-7736a44a2bd1_RECEIPT_00002.jpg",
+    width: 793,
+    height: 2409,
+  },
+  {
+    imageId: "32e93177-6528-4d63-b637-45d53d1cf3f3",
+    receiptId: "32e93177-6528-4d63-b637-45d53d1cf3f3-1",
+    thumbnailKey: "assets/32e93177-6528-4d63-b637-45d53d1cf3f3_RECEIPT_00001.webp",
+    fallbackKey: "assets/32e93177-6528-4d63-b637-45d53d1cf3f3_RECEIPT_00001.jpg",
+    width: 794,
+    height: 3165,
+  },
+  {
+    imageId: "32e93177-6528-4d63-b637-45d53d1cf3f3",
+    receiptId: "32e93177-6528-4d63-b637-45d53d1cf3f3-2",
+    thumbnailKey: "assets/32e93177-6528-4d63-b637-45d53d1cf3f3_RECEIPT_00002.webp",
+    fallbackKey: "assets/32e93177-6528-4d63-b637-45d53d1cf3f3_RECEIPT_00002.jpg",
+    width: 791,
+    height: 2923,
+  },
+  {
+    imageId: "7c932424-cb54-4fdb-ac2d-465e9b57b7c8",
+    receiptId: "7c932424-cb54-4fdb-ac2d-465e9b57b7c8-1",
+    thumbnailKey: "assets/7c932424-cb54-4fdb-ac2d-465e9b57b7c8_RECEIPT_00001.webp",
+    fallbackKey: "assets/7c932424-cb54-4fdb-ac2d-465e9b57b7c8_RECEIPT_00001.jpg",
+    width: 792,
+    height: 2982,
+  },
+  {
+    imageId: "94676cfe-ac3c-4183-b93a-31ae12f92cf5",
+    receiptId: "94676cfe-ac3c-4183-b93a-31ae12f92cf5-1",
+    thumbnailKey: "assets/94676cfe-ac3c-4183-b93a-31ae12f92cf5_RECEIPT_00001.webp",
+    fallbackKey: "assets/94676cfe-ac3c-4183-b93a-31ae12f92cf5_RECEIPT_00001.jpg",
+    width: 790,
+    height: 2877,
+  },
+  {
+    imageId: "c6b66d97-1e0a-4be4-9e1f-731a7e4be25c",
+    receiptId: "c6b66d97-1e0a-4be4-9e1f-731a7e4be25c-1",
+    thumbnailKey: "assets/c6b66d97-1e0a-4be4-9e1f-731a7e4be25c/1.webp",
+    fallbackKey: "assets/c6b66d97-1e0a-4be4-9e1f-731a7e4be25c/1.jpg",
+    width: 777,
+    height: 2040,
+  },
+  {
+    imageId: "887079fa-bb3e-480a-8202-e759afe63f1a",
+    receiptId: "887079fa-bb3e-480a-8202-e759afe63f1a-1",
+    thumbnailKey: "assets/887079fa-bb3e-480a-8202-e759afe63f1a_RECEIPT_00001.webp",
+    fallbackKey: "assets/887079fa-bb3e-480a-8202-e759afe63f1a_RECEIPT_00001.jpg",
+    width: 785,
+    height: 2647,
+  },
+  {
+    imageId: "887079fa-bb3e-480a-8202-e759afe63f1a",
+    receiptId: "887079fa-bb3e-480a-8202-e759afe63f1a-2",
+    thumbnailKey: "assets/887079fa-bb3e-480a-8202-e759afe63f1a_RECEIPT_00002.webp",
+    fallbackKey: "assets/887079fa-bb3e-480a-8202-e759afe63f1a_RECEIPT_00002.jpg",
+    width: 783,
+    height: 3027,
+  },
+  {
+    imageId: "4cd9dd6d-ecd8-4e6f-928f-18440e4ad303",
+    receiptId: "4cd9dd6d-ecd8-4e6f-928f-18440e4ad303-1",
+    thumbnailKey: "assets/4cd9dd6d-ecd8-4e6f-928f-18440e4ad303_RECEIPT_00001.webp",
+    fallbackKey: "assets/4cd9dd6d-ecd8-4e6f-928f-18440e4ad303_RECEIPT_00001.jpg",
+    width: 783,
+    height: 2790,
+  },
+  {
+    imageId: "4cd9dd6d-ecd8-4e6f-928f-18440e4ad303",
+    receiptId: "4cd9dd6d-ecd8-4e6f-928f-18440e4ad303-2",
+    thumbnailKey: "assets/4cd9dd6d-ecd8-4e6f-928f-18440e4ad303_RECEIPT_00002.webp",
+    fallbackKey: "assets/4cd9dd6d-ecd8-4e6f-928f-18440e4ad303_RECEIPT_00002.jpg",
+    width: 784,
+    height: 2292,
+  },
+  {
+    imageId: "a0301717-d765-4f34-a15d-48c362ebf9fd",
+    receiptId: "a0301717-d765-4f34-a15d-48c362ebf9fd-1",
+    thumbnailKey: "assets/a0301717-d765-4f34-a15d-48c362ebf9fd_RECEIPT_00001.webp",
+    fallbackKey: "assets/a0301717-d765-4f34-a15d-48c362ebf9fd_RECEIPT_00001.jpg",
+    width: 799,
+    height: 2814,
+  },
+  {
+    imageId: "f30c3d0f-a13a-4a8e-9367-1136e9a51184",
+    receiptId: "f30c3d0f-a13a-4a8e-9367-1136e9a51184-1",
+    thumbnailKey: "assets/f30c3d0f-a13a-4a8e-9367-1136e9a51184_RECEIPT_00001.webp",
+    fallbackKey: "assets/f30c3d0f-a13a-4a8e-9367-1136e9a51184_RECEIPT_00001.jpg",
+    width: 785,
+    height: 3054,
+  },
+  {
+    imageId: "f30c3d0f-a13a-4a8e-9367-1136e9a51184",
+    receiptId: "f30c3d0f-a13a-4a8e-9367-1136e9a51184-2",
+    thumbnailKey: "assets/f30c3d0f-a13a-4a8e-9367-1136e9a51184_RECEIPT_00002.webp",
+    fallbackKey: "assets/f30c3d0f-a13a-4a8e-9367-1136e9a51184_RECEIPT_00002.jpg",
+    width: 782,
+    height: 2998,
+  },
+];
+
+const getStableStackPosition = (
+  id: string,
+  index: number,
+  stackW: number,
+  stackH: number,
+  cardW: number,
+  cardH: number,
+) => {
+  let hash = 0;
+  for (let i = 0; i < id.length; i += 1) {
+    hash = ((hash << 5) - hash + id.charCodeAt(i)) | 0;
+  }
+  const rand = (salt: number) =>
+    (Math.abs(Math.sin(hash * (salt + 1) + index * 97) * 10000) % 1000) / 1000;
+  const maxLeft = Math.max(0, stackW - cardW);
+  const maxTop = Math.max(0, stackH - cardH);
+
+  return {
+    rotation: rand(1) * 26 - 13,
+    left: Math.max(4, Math.min(rand(2) * maxLeft, maxLeft)),
+    top: Math.max(4, Math.min(rand(3) * maxTop, maxTop)),
+  };
+};
+
+const SproutsLogoMark: React.FC<{ compact?: boolean }> = ({ compact = false }) => {
+  const width = compact ? 176 : 220;
+  const height = compact ? 44 : 54;
+
+  return (
+    <svg
+      role="img"
+      aria-label="Sprouts Farmers Market"
+      width={width}
+      height={height}
+      viewBox="0 0 260 60"
+      style={{ display: "block", color: "var(--text-color)" }}
+    >
+      <g fill="none" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round">
+        <path
+          d="M21 42C13 35 11 22 17 12c12 2 22 11 25 25-4 5-12 8-21 5Z"
+          fill="currentColor"
+          strokeWidth="2"
+        />
+        <path d="M24 38C28 27 33 18 41 11" stroke="var(--background-color)" strokeWidth="2.5" />
+      </g>
+      <text
+        x="54"
+        y="31"
+        fill="currentColor"
+        fontFamily="Arial, Helvetica, sans-serif"
+        fontSize="24"
+        fontWeight="800"
+      >
+        SPROUTS
+      </text>
+      <text
+        x="57"
+        y="46"
+        fill="currentColor"
+        fontFamily="Arial, Helvetica, sans-serif"
+        fontSize="10"
+        fontWeight="700"
+        letterSpacing="1.5"
+      >
+        FARMERS MARKET
+      </text>
+    </svg>
+  );
+};
+
+interface SproutsReceiptStackPreviewProps {
+  isVisible: boolean;
+  visible: boolean;
+  variant?: "intro" | "final";
+}
+
+const SproutsReceiptStackPreview: React.FC<SproutsReceiptStackPreviewProps> = ({
+  isVisible,
+  visible,
+  variant = "intro",
+}) => {
+  const motionScale = getReceiptMotionScale();
+  const isIntro = variant === "intro";
+  const receipts = isIntro ? SPROUTS_STACK_RECEIPTS : SPROUTS_STACK_RECEIPTS.slice(0, 12);
+  const stackW = isIntro ? 330 : 190;
+  const stackH = isIntro ? 230 : 215;
+  const cardW = isIntro ? 74 : 64;
+  const cardH = isIntro ? 180 : 165;
+  const delayStep = (isIntro ? 48 : 65) * motionScale;
+  const duration = (isIntro ? 440 : 360) * motionScale;
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexWrap: "wrap",
+        alignItems: "center",
+        justifyContent: "center",
+        gap: isIntro ? "1rem 1.5rem" : "0.45rem",
+        maxHeight: visible ? (isIntro ? "310px" : "285px") : 0,
+        opacity: visible ? 1 : 0,
+        transform: visible ? "translateY(0)" : "translateY(-8px)",
+        overflow: "hidden",
+        pointerEvents: visible ? "auto" : "none",
+        transition: "max-height 0.45s ease, opacity 0.32s ease, transform 0.32s ease",
+        marginBottom: visible && isIntro ? "0.75rem" : 0,
+      }}
+      aria-hidden={!visible}
+    >
+      <div
+        style={{
+          minWidth: isIntro ? "190px" : "150px",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          gap: "0.15rem",
+        }}
+      >
+        <SproutsLogoMark compact={!isIntro} />
+        <span
+          style={{
+            fontFamily: "var(--font-mono, monospace)",
+            fontSize: isIntro ? "0.72rem" : "0.64rem",
+            color: "var(--text-color)",
+            opacity: 0.64,
+            textTransform: "uppercase",
+            letterSpacing: "0.08em",
+          }}
+        >
+          203 receipts
+        </span>
+      </div>
+
+      <div
+        aria-label="Sprouts receipt stack"
+        style={{
+          position: "relative",
+          width: `${stackW}px`,
+          height: `${stackH}px`,
+          flex: `0 1 ${stackW}px`,
+        }}
+      >
+        {receipts.map((receipt, idx) => {
+          const pos = getStableStackPosition(
+            receipt.receiptId,
+            idx,
+            stackW,
+            stackH,
+            cardW,
+            cardH,
+          );
+          return (
+            <div
+              key={receipt.receiptId}
+              style={{
+                position: "absolute",
+                width: `${cardW}px`,
+                left: `${pos.left}px`,
+                top: `${pos.top}px`,
+                zIndex: idx,
+                border: "1px solid rgba(var(--text-color-rgb, 0, 0, 0), 0.22)",
+                backgroundColor: "var(--background-color)",
+                boxShadow: "0 4px 14px rgba(0,0,0,0.18)",
+                overflow: "hidden",
+                opacity: 0,
+                "--r": `${pos.rotation}deg`,
+                animation: `sproutsReceiptStackIn ${duration}ms ease-out ${idx * delayStep}ms forwards`,
+                animationPlayState: isVisible && visible ? "running" : "paused",
+              } as React.CSSProperties}
+            >
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={`${CDN_BASE}/${receipt.thumbnailKey}`}
+                data-fallback={`${CDN_BASE}/${receipt.fallbackKey}`}
+                alt="Sprouts Farmers Market receipt"
+                style={{
+                  width: "100%",
+                  aspectRatio: `${receipt.width} / ${receipt.height}`,
+                  height: "auto",
+                  display: "block",
+                }}
+                onError={(event) => {
+                  const image = event.currentTarget;
+                  const fallback = image.dataset.fallback;
+                  if (fallback && image.src !== fallback) {
+                    image.src = fallback;
+                    return;
+                  }
+                  image.style.display = "none";
+                }}
+              />
+            </div>
+          );
+        })}
+      </div>
+
+      <style>{`
+        @keyframes sproutsReceiptStackIn {
+          from { opacity: 0; transform: rotate(var(--r, 0deg)) translateY(-18px) scale(0.96); }
+          to { opacity: 1; transform: rotate(var(--r, 0deg)) translateY(0) scale(1); }
+        }
+      `}</style>
+    </div>
+  );
+};
 
 // Structured receipt summaries (output of shape node)
 const STRUCTURED_RECEIPTS: StructuredReceipt[] = [
@@ -152,10 +515,10 @@ const QAAgentFlow: React.FC<QAAgentFlowProps> = ({ autoPlay = true, questionData
   const [activeStep, setActiveStep] = React.useState(-1);
   const [isPlaying, setIsPlaying] = React.useState(autoPlay);
   const [showAnswer, setShowAnswer] = React.useState(false);
+  const motionScale = getReceiptMotionScale();
 
   // Use real data when available, fall back to example trace
   const trace = questionData?.trace ?? EXAMPLE_TRACE;
-  const stats = questionData?.stats;
 
   // Reset animation when question changes (use index to avoid stale-data issues on mobile)
   const questionIndex = questionData?.questionIndex ?? -1;
@@ -171,15 +534,20 @@ const QAAgentFlow: React.FC<QAAgentFlowProps> = ({ autoPlay = true, questionData
   // Compute per-step animation durations from durationMs, scaled proportionally
   const stepDurations = React.useMemo(() => {
     const hasTiming = trace.some((s) => s.durationMs != null && s.durationMs > 0);
-    if (!hasTiming) return trace.map(() => DEFAULT_STEP_MS);
+    if (!hasTiming) return trace.map(() => DEFAULT_STEP_MS * motionScale);
 
     const rawMs = trace.map((s) => s.durationMs ?? DEFAULT_STEP_MS);
     const rawTotal = rawMs.reduce((sum, d) => sum + d, 0);
     if (rawTotal === 0) return trace.map(() => DEFAULT_STEP_MS);
 
     const scale = TARGET_TOTAL_MS / rawTotal;
-    return rawMs.map((d) => Math.max(MIN_STEP_MS, Math.min(MAX_STEP_MS, Math.round(d * scale))));
-  }, [trace]);
+    return rawMs.map((d) =>
+      Math.max(
+        MIN_STEP_MS * motionScale,
+        Math.min(MAX_STEP_MS * motionScale, Math.round(d * scale * motionScale)),
+      )
+    );
+  }, [trace, motionScale]);
 
   // Current step's animation duration (for clock-fill sync)
   const currentStepDuration =
@@ -204,19 +572,14 @@ const QAAgentFlow: React.FC<QAAgentFlowProps> = ({ autoPlay = true, questionData
         setActiveStep(-1);
         setShowAnswer(false);
         onCycleComplete?.();
-      }, 10000);
+      }, 10000 * motionScale);
       return () => clearTimeout(id);
     }
 
-    const delay = activeStep < 0 ? 400 : stepDurations[activeStep];
+    const delay = activeStep < 0 ? 400 * motionScale : stepDurations[activeStep];
     const id = setTimeout(() => setActiveStep((prev) => prev + 1), delay);
     return () => clearTimeout(id);
-  }, [isPlaying, activeStep, trace.length, stepDurations, showAnswer, onCycleComplete]);
-
-  const questionSpring = useSpring({
-    opacity: 1,
-    config: config.gentle,
-  });
+  }, [isPlaying, activeStep, trace.length, stepDurations, showAnswer, onCycleComplete, motionScale]);
 
   // Measure answer content height and spring the container open
   const answerRef = React.useRef<HTMLDivElement>(null);
@@ -291,6 +654,7 @@ const QAAgentFlow: React.FC<QAAgentFlowProps> = ({ autoPlay = true, questionData
   // Determine the loop phase bounds dynamically based on trace content
   const loopEndIdx = trace.length > 0 ? trace.reduce((last, s, i) => (s.type === "agent" || s.type === "tools" ? i : last), -1) : 5;
   const inLoopPhase = activeStep >= 1 && activeStep <= loopEndIdx;
+  const showSproutsIntro = activeStep < 1 && !showAnswer;
 
   return (
     <div
@@ -305,8 +669,6 @@ const QAAgentFlow: React.FC<QAAgentFlowProps> = ({ autoPlay = true, questionData
     >
       {/* Flame Graph Timeline + Node Diagram */}
       {(() => {
-        const totalMs = trace.reduce((sum, s) => sum + (s.durationMs ?? 0), 0);
-
         const formatMs = (ms: number): string =>
           ms >= 1000 ? `${(ms / 1000).toFixed(2)}s` : `${ms.toFixed(1)}ms`;
 
@@ -442,21 +804,6 @@ const QAAgentFlow: React.FC<QAAgentFlowProps> = ({ autoPlay = true, questionData
           );
         };
 
-        // Helper: pie slice path from 12 o'clock, filling clockwise
-        const getPieSlicePath = (progress: number, cx: number, cy: number, r: number): string => {
-          if (progress <= 0) return "";
-          if (progress >= 100) return `M ${cx} ${cy} m -${r} 0 a ${r} ${r} 0 1 0 ${r * 2} 0 a ${r} ${r} 0 1 0 -${r * 2} 0`;
-          const a = (progress / 100) * 2 * Math.PI;
-          const startAngle = -Math.PI / 2;
-          const endAngle = startAngle + a;
-          const x1 = cx + r * Math.cos(startAngle);
-          const y1 = cy + r * Math.sin(startAngle);
-          const x2 = cx + r * Math.cos(endAngle);
-          const y2 = cy + r * Math.sin(endAngle);
-          const largeArcFlag = progress > 50 ? 1 : 0;
-          return `M ${cx} ${cy} L ${x1} ${y1} A ${r} ${r} 0 ${largeArcFlag} 1 ${x2} ${y2} Z`;
-        };
-
         return (
           <div
             style={{
@@ -471,6 +818,12 @@ const QAAgentFlow: React.FC<QAAgentFlowProps> = ({ autoPlay = true, questionData
           >
             {/* Slot for marquee or other header content */}
             {children}
+
+            <SproutsReceiptStackPreview
+              isVisible={isVisible}
+              visible={showSproutsIntro}
+              variant="intro"
+            />
 
             {/* 5-Node SVG Flow Diagram */}
             <div style={{ textAlign: "center", marginBottom: "0.75rem" }}>
@@ -720,7 +1073,6 @@ const QAAgentFlow: React.FC<QAAgentFlowProps> = ({ autoPlay = true, questionData
                   zIndex: i,
                 };
               });
-
               return (
                 <animated.div
                   ref={containerRef}
@@ -754,50 +1106,67 @@ const QAAgentFlow: React.FC<QAAgentFlowProps> = ({ autoPlay = true, questionData
                       >
                         <ReactMarkdown>{answerText}</ReactMarkdown>
                       </div>
-                      {uniqueReceipts.length > 0 && (
+                      {uniqueReceipts.length > 0 ? (
                         <div
                           style={{
-                            position: "relative",
-                            width: `${stackW}px`,
-                            height: `${stackH}px`,
+                            display: "flex",
+                            flexDirection: "column",
+                            alignItems: "center",
+                            gap: "0.35rem",
                             flexShrink: 0,
                             margin: "0 auto",
                           }}
                         >
-                          {uniqueReceipts.map((receipt, idx) => (
-                            <div
-                              key={receipt.imageId}
-                              style={{
-                                position: "absolute",
-                                width: `${cW}px`,
-                                left: `${sPositions[idx].left}px`,
-                                top: `${sPositions[idx].top}px`,
-                                "--r": `${sPositions[idx].rotation}deg`,
-                                zIndex: sPositions[idx].zIndex,
-                                border: "1px solid #ccc",
-                                backgroundColor: "var(--background-color)",
-                                boxShadow: "0 2px 6px rgba(0,0,0,0.2)",
-                                overflow: "hidden",
-                                opacity: 0,
-                                animation: `receiptFadeIn 0.4s ease-out ${idx * 80}ms forwards`,
-                                animationPlayState: isVisible ? "running" : "paused",
-                              } as React.CSSProperties}
-                            >
-                              <img
-                                src={`${CDN_BASE}/${receipt.thumbnailKey}`}
-                                alt={`${receipt.merchant} receipt`}
-                                style={{ width: "100%", height: "auto", display: "block" }}
-                                onError={(e) => { (e.target as HTMLImageElement).style.display = "none"; }}
-                              />
-                            </div>
-                          ))}
-                          <style>{`
-                            @keyframes receiptFadeIn {
-                              from { opacity: 0; transform: rotate(var(--r, 0deg)) translateY(-20px); }
-                              to   { opacity: 1; transform: rotate(var(--r, 0deg)) translateY(0); }
-                            }
-                          `}</style>
+                          <SproutsLogoMark compact />
+                          <div
+                            style={{
+                              position: "relative",
+                              width: `${stackW}px`,
+                              height: `${stackH}px`,
+                            }}
+                          >
+                            {uniqueReceipts.map((receipt, idx) => (
+                              <div
+                                key={receipt.imageId}
+                                style={{
+                                  position: "absolute",
+                                  width: `${cW}px`,
+                                  left: `${sPositions[idx].left}px`,
+                                  top: `${sPositions[idx].top}px`,
+                                  "--r": `${sPositions[idx].rotation}deg`,
+                                  zIndex: sPositions[idx].zIndex,
+                                  border: "1px solid #ccc",
+                                  backgroundColor: "var(--background-color)",
+                                  boxShadow: "0 2px 6px rgba(0,0,0,0.2)",
+                                  overflow: "hidden",
+                                  opacity: 0,
+                                  animation: `receiptFadeIn 0.4s ease-out ${idx * 80}ms forwards`,
+                                  animationPlayState: isVisible ? "running" : "paused",
+                                } as React.CSSProperties}
+                              >
+                                {/* eslint-disable-next-line @next/next/no-img-element */}
+                                <img
+                                  src={`${CDN_BASE}/${receipt.thumbnailKey}`}
+                                  alt={`${receipt.merchant} receipt`}
+                                  style={{ width: "100%", height: "auto", display: "block" }}
+                                  onError={(e) => { (e.target as HTMLImageElement).style.display = "none"; }}
+                                />
+                              </div>
+                            ))}
+                            <style>{`
+                              @keyframes receiptFadeIn {
+                                from { opacity: 0; transform: rotate(var(--r, 0deg)) translateY(-20px); }
+                                to   { opacity: 1; transform: rotate(var(--r, 0deg)) translateY(0); }
+                              }
+                            `}</style>
+                          </div>
                         </div>
+                      ) : (
+                        <SproutsReceiptStackPreview
+                          isVisible={isVisible}
+                          visible={showAnswer}
+                          variant="final"
+                        />
                       )}
                     </div>
                   ) : null}

--- a/portfolio/components/ui/Figures/QAAgentFlow.tsx
+++ b/portfolio/components/ui/Figures/QAAgentFlow.tsx
@@ -508,8 +508,13 @@ const MIN_STEP_MS = 600;
 const MAX_STEP_MS = 3500;
 
 const QAAgentFlow: React.FC<QAAgentFlowProps> = ({ autoPlay = true, questionData, onCycleComplete, children }) => {
+  // threshold 0 (any pixel intersecting the rootMargin-expanded viewport),
+  // NOT a fraction of the element: the tall intro stack makes a 10% area
+  // threshold unreachable on mobile, which froze the flow on the intro and
+  // never rendered the answer. "In view" should mean "the figure has entered
+  // the viewport," independent of its total height.
   const [flowRef, isVisible] = useRevealInView({
-    threshold: 0.1,
+    threshold: 0,
     rootMargin: "200px",
   });
   const [activeStep, setActiveStep] = React.useState(-1);

--- a/portfolio/components/ui/Figures/ReceiptFlow/FlyingReceipt.tsx
+++ b/portfolio/components/ui/Figures/ReceiptFlow/FlyingReceipt.tsx
@@ -1,6 +1,6 @@
 import React, { useRef } from "react";
 import { animated, useSpring, to } from "@react-spring/web";
-import { getQueuePosition } from "./receiptFlowUtils";
+import { getQueuePosition, getReceiptMotionScale } from "./receiptFlowUtils";
 import styles from "./FlyingReceipt.module.css";
 
 // SSR-safe useLayoutEffect
@@ -132,7 +132,7 @@ export const FlyingReceipt: React.FC<FlyingReceiptProps> = ({
   const [springValues, api] = useSpring(() => ({
     ...fallbackFrom,
     opacity: 0,
-    config: { duration: FLY_DURATION_MS, easing: easeOutCubic },
+    config: { duration: FLY_DURATION_MS * getReceiptMotionScale(), easing: easeOutCubic },
   }));
 
   useIsomorphicLayoutEffect(() => {
@@ -140,7 +140,10 @@ export const FlyingReceipt: React.FC<FlyingReceiptProps> = ({
     // Snap to the measured start position while still hidden...
     api.set({ ...from, opacity: 0 });
     // ...then fly to center and fade in together.
-    api.start({ to: { x: 0, y: 0, scale: 1, rotate: 0, opacity: 1 } });
+    api.start({
+      to: { x: 0, y: 0, scale: 1, rotate: 0, opacity: 1 },
+      config: { duration: FLY_DURATION_MS * getReceiptMotionScale(), easing: easeOutCubic },
+    });
   }, [receiptId]);
 
   return (

--- a/portfolio/components/ui/Figures/ReceiptFlow/ReceiptFlowShell.module.css
+++ b/portfolio/components/ui/Figures/ReceiptFlow/ReceiptFlowShell.module.css
@@ -86,11 +86,13 @@
 }
 
 .fade-out {
-  animation: fade-out 0.4s ease-out forwards;
+  animation: fade-out calc(0.4s * var(--rf-motion-scale, 1)) ease-out forwards;
+  will-change: opacity;
 }
 
 .fade-in {
-  animation: fade-in 0.4s ease-in forwards;
+  animation: fade-in calc(0.4s * var(--rf-motion-scale, 1)) ease-in forwards;
+  will-change: opacity;
 }
 
 @keyframes fade-out {
@@ -140,16 +142,16 @@
   }
 
   .receiptContainer.fade-out {
-    animation: mobile-flow-content-out 0.16s ease-out forwards;
+    animation: mobile-flow-content-out calc(0.16s * var(--rf-motion-scale, 1)) ease-out forwards;
   }
 
   .nextReceipt.fade-in {
     opacity: 0;
-    animation: mobile-flow-panel-in 0.28s ease-out 0.1s both;
+    animation: mobile-flow-panel-in calc(0.28s * var(--rf-motion-scale, 1)) ease-out calc(0.1s * var(--rf-motion-scale, 1)) both;
   }
 
   .nextReceipt.fade-in > * {
-    animation: mobile-flow-content-rise 0.28s ease-out 0.1s both;
+    animation: mobile-flow-content-rise calc(0.28s * var(--rf-motion-scale, 1)) ease-out calc(0.1s * var(--rf-motion-scale, 1)) both;
   }
 
   .legendColumn {
@@ -182,18 +184,18 @@
   }
 
   .currentLegend.fade-out {
-    animation: mobile-flow-content-out 0.16s ease-out forwards;
+    animation: mobile-flow-content-out calc(0.24s * var(--rf-motion-scale, 1)) ease-out forwards;
   }
 
   .nextLegend.fade-in {
     z-index: 2;
     opacity: 0;
     background: var(--background-color, #fff);
-    animation: mobile-flow-panel-in 0.28s ease-out 0.1s both;
+    animation: mobile-flow-panel-in calc(0.32s * var(--rf-motion-scale, 1)) ease-out calc(0.08s * var(--rf-motion-scale, 1)) both;
   }
 
   .nextLegend.fade-in > * {
-    animation: mobile-flow-content-rise 0.28s ease-out 0.1s both;
+    animation: mobile-flow-content-rise calc(0.32s * var(--rf-motion-scale, 1)) ease-out calc(0.08s * var(--rf-motion-scale, 1)) both;
   }
 
 }

--- a/portfolio/components/ui/Figures/ReceiptFlow/receiptFlowUtils.ts
+++ b/portfolio/components/ui/Figures/ReceiptFlow/receiptFlowUtils.ts
@@ -1,5 +1,27 @@
 import { ReceiptQueuePosition } from "./types";
 
+type MotionScaleWindow = Window & {
+  __RECEIPT_MOTION_SCALE?: number | string;
+};
+
+const DEFAULT_MOTION_SCALE = 1;
+const MAX_MOTION_SCALE = 12;
+
+export const getReceiptMotionScale = (): number => {
+  if (typeof window === "undefined") {
+    return DEFAULT_MOTION_SCALE;
+  }
+
+  const queryValue = new URLSearchParams(window.location.search).get("receiptMotionScale");
+  const globalValue = (window as MotionScaleWindow).__RECEIPT_MOTION_SCALE;
+  const rawValue = queryValue ?? globalValue;
+  const scale = typeof rawValue === "string" ? Number(rawValue) : rawValue;
+
+  return typeof scale === "number" && Number.isFinite(scale) && scale > 0
+    ? Math.min(scale, MAX_MOTION_SCALE)
+    : DEFAULT_MOTION_SCALE;
+};
+
 export const getQueuePosition = (receiptId: string): ReceiptQueuePosition => {
   const hash = receiptId.split("").reduce((acc, char) => acc + char.charCodeAt(0), 0);
   const random1 = Math.sin(hash * 9301 + 49297) % 1;

--- a/portfolio/components/ui/Figures/TrainingMetricsAnimation/index.tsx
+++ b/portfolio/components/ui/Figures/TrainingMetricsAnimation/index.tsx
@@ -17,24 +17,6 @@ const normalizeLabel = (label: string): string => {
   return label;
 };
 
-// Label color mapping for hybrid model
-const LABEL_COLORS: Record<string, string> = {
-  MERCHANT_NAME: "var(--color-yellow)",
-  DATE: "var(--color-blue)",
-  TIME: "var(--color-blue)",
-  AMOUNT: "var(--color-green)",
-  ADDRESS: "var(--color-red)",
-  PHONE_NUMBER: "var(--color-pink)",
-  WEBSITE: "var(--color-purple)",
-  STORE_HOURS: "var(--color-orange)",
-  PAYMENT_METHOD: "var(--color-orange)",
-  O: "var(--color-purple)",
-};
-
-const getLabelColor = (label: string): string => {
-  return LABEL_COLORS[normalizeLabel(label)] || "var(--color-gray, #888)";
-};
-
 // Format label: "MERCHANT_NAME" -> "Merchant Name", "O" -> "None"
 const formatLabel = (label: string): string => {
   const normalized = normalizeLabel(label);
@@ -244,9 +226,8 @@ const EpochSparkline: React.FC<EpochSparklineProps> = ({
     [epochs.length, onSelectEpoch, svgWidth]
   );
 
-  // Keyboard navigation — required because role="slider" promises AT users
-  // they can change the value (WCAG). Arrow keys step by 1, Home/End jump
-  // to first/last.
+  // Keyboard navigation keeps the chart scrub-friendly without presenting it
+  // as a visible weight/slider control.
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<SVGSVGElement>) => {
       if (epochs.length === 0) return;
@@ -293,7 +274,6 @@ const EpochSparkline: React.FC<EpochSparklineProps> = ({
   const bestF1 = bestEpoch?.metrics?.val_f1 ?? 0;
   const bx = bestIdx >= 0 ? xScale(bestIdx) : 0;
   const by = bestIdx >= 0 ? yScale(bestF1) : 0;
-  const lastIdx = epochs.length - 1;
   const showBest = bestIdx >= 0 && showBestLabel;
 
   const axisLabels = useMemo(
@@ -315,17 +295,13 @@ const EpochSparkline: React.FC<EpochSparklineProps> = ({
           onClick={handleClick}
           onKeyDown={handleKeyDown}
           tabIndex={0}
-          role="slider"
-          aria-label={`Training epoch — use arrow keys to scrub, Home/End to jump to first/last`}
-          aria-valuemin={0}
-          aria-valuemax={lastIdx}
-          aria-valuenow={currentIndex}
-          aria-valuetext={
+          role="button"
+          aria-label={
             currentEpoch
               ? `Epoch ${currentEpoch.epoch}${
                   currentIndex === bestIdx ? " (best)" : ""
                 }, F1 ${currentF1.toFixed(3)}`
-              : undefined
+              : "Training epoch curve"
           }
         >
           {/* Convergence curve */}


### PR DESCRIPTION
## Summary

- Adds monochrome Sprouts branding and a fuller Sprouts receipt stack to the QA synthesis intro and final answer stages.
- Adds a shared slow-motion control via `receiptMotionScale` and applies it to QA timing, flying receipts, LayoutLM scanning, queue motion, and shell fades.
- Animates the LayoutLM legend handoff on mobile and desktop, tightens the mobile legend label, and removes the training sparkline's slider semantics.
- Adds LayoutLM fallback Sprouts receipt data so the bounding-box visualization remains reviewable if the dev API returns an error.

## Notes

- `/Users/tnorlund/Downloads/Sprouts_Farmers_Market_Logo.png` was not present locally, so this uses an in-component black-and-white Sprouts mark consistent with the other monochrome marks.
- Full repo lint still has pre-existing unrelated warnings; focused lint on the touched files passes.

## Validation

- `npm run type-check`
- `npx eslint components/ui/Figures/QAAgentFlow.tsx components/ui/Figures/LayoutLMBatchVisualization/index.tsx components/ui/Figures/ReceiptFlow/FlyingReceipt.tsx components/ui/Figures/ReceiptFlow/receiptFlowUtils.ts components/ui/Figures/TrainingMetricsAnimation/index.tsx --max-warnings=0`
- `npm run build`
- Browser slow-motion QA on `/receipt` with `?receiptMotionScale=6` and `?receiptMotionScale=12` across desktop and mobile viewports.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added richer receipt and workflow previews, including a branded stacked-receipt view and improved legend transitions.
  * Added fallback content so visualizations still load smoothly when data is unavailable.

* **Bug Fixes**
  * Made animation timing consistent and adjustable across receipt and flow visuals.
  * Improved queue and legend handoff behavior during transitions.

* **Accessibility**
  * Updated chart interaction semantics for clearer screen reader and keyboard support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->