### PR TITLE
v1: font-calibration derivation (M1 render-free ink measurer)

### DIFF
--- a/tools/glyph-studio/ADD_MERCHANT.md
+++ b/tools/glyph-studio/ADD_MERCHANT.md
@@ -159,6 +159,36 @@ that happens to pass. Scorecard BLOCKERs must each be resolved or explained
 with evidence (scan skew gradients are the known benign class); "known
 alignment checks" is not an explanation.
 
+### Render-free pre-calibration (derive, don't eyeball)
+
+Before the slow render loop, derive starting values from the atlas in
+milliseconds with `glyphstudio.calibrate` (the render-time bisection re-renders
+the whole receipt 5-8× per probe; this measures the same ink signal straight
+from the glyphs). Two steps:
+
+1. **Sanity-check the atlas** — confirm its response is well-behaved before
+   spending renders on it:
+   ```bash
+   python -m glyphstudio.validate <compiled>.glyphs.npz --cap-px <synth_h_med>
+   ```
+   `OK True` means density is monotone in thin/weight, erosion saturates (the
+   `saturation thin` is the highest `bitmap_thin` worth trying — probing past it
+   is wasted), and cap height is linear. A merchant whose density is still too
+   high at the saturation thin can't be eroded into range: re-mint lighter
+   rather than chasing `bitmap_thin` (this is why Wild Fork railed at 0.6).
+2. **Derive the knobs** — feed the real-scan measurements (from a first
+   scorecard pass: `real_h_med`, median OCR word-box height, and the real
+   median per-word density as `target_density`) to
+   `calibrate.calibrate_merchant(font, receipts, ...)`. It returns
+   `ocr_cap_height_ratio` (M2), and `weight_iters` + `bitmap_thin` jointly (M3)
+   — starting values, not a substitute for the gate below.
+
+The production render gate (targets above) is still the **must-pass** check —
+the cheap solve's absolute density is in tight-ink units, not the scorecard's
+padded-crop units (see `calibrate.py` "Scope & units"), so always confirm on the
+production path. What this removes is the blind eyeballing: you render to
+*verify* a derived value, not to *search* for it.
+
 Knobs, in order of impact:
 - `font.json params.weight` — thermal prints are BOLD; TJ needed 1.4, CVS
   1.35, Vons 1.2. After changing weight, recompute `condense` (the pitch

--- a/tools/glyph-studio/VALIDATION.md
+++ b/tools/glyph-studio/VALIDATION.md
@@ -1,0 +1,65 @@
+# M1/M2 validation — render-free claim check on real merchant atlases
+
+The calibrate measurer (`glyphstudio.calibrate`, M1/M2) rests on three
+structural claims about how a real atlas responds to the render knobs.
+`glyphstudio.validate` checks them on any `.glyphs.npz` **without a receipt
+render**. This is the render-free half of the M1/M2 validation milestone; the
+other half (absolute agreement between a cheap solve and a real render) needs
+the render path and is measured against the scorecard — see the "Scope & units"
+note in `calibrate.py`.
+
+Run: `python -m glyphstudio.validate <atlas.npz> [--cap-px N]`.
+
+## Results — the 6 M0 merchants (cap_px 34, full atlas as corpus)
+
+| merchant | coverage | density 0→max thin | saturation thin | monotone (thin) | monotone (weight) | cap linear (34→68px) | OK |
+|---|---|---|---|---|---|---|---|
+| CVS | 1.000 | 0.450 → 0.348 | 0.40 | ✓ | ✓ | ✓ | ✓ |
+| Vons | 1.000 | 0.481 → 0.378 | 0.40 | ✓ | ✓ | ✓ | ✓ |
+| Trader Joe's | 1.000 | 0.428 → 0.324 | 0.40 | ✓ | ✓ | ✓ | ✓ |
+| Costco | 1.000 | 0.367 → 0.249 | 0.40 | ✓ | ✓ | ✓ | ✓ |
+| Sprouts | 1.000 | 0.371 → 0.269 | 0.40 | ✓ | ✓ | ✓ | ✓ |
+| Wild Fork | 1.000 | 0.415 → 0.307 | 0.40 | ✓ | ✓ | ✓ | ✓ |
+
+All three claims hold on every real atlas:
+
+1. **Erosion saturates at thin 0.40 for all six** — density stops falling
+   beyond it because `thin_ink_mask`'s drop-period floors at 2. The render-time
+   bisection probes up to 0.6 blindly, so **every probe in (0.40, 0.60] is
+   wasted** — the core M1 efficiency claim, now confirmed on real fonts, not
+   just asserted.
+2. **Monotone** in both thin (down) and weight (up) — the property the joint
+   solver relies on.
+3. **Cap height is exactly linear** — 34px → 68px doubles the cap glyph height
+   on all six, validating M2's two-point-fit premise.
+
+## Cross-check against the M0 pins
+
+The saturation result independently corroborates the M0 boundary flags without
+any render:
+
+- **Wild Fork was pinned at the 0.6 ceiling.** But erosion saturates at 0.40, so
+  0.6 does exactly what 0.4 does — the render-time bisection railed to the
+  ceiling only because the atlas is still too dense at saturation and can't
+  erode into range. The cheap curve would have flagged this before calibrating.
+- **Costco was pinned at the 0.0 floor** (too dense even with zero erosion). Its
+  un-eroded density (0.367) is on the lighter side here, so its floor-railing is
+  a padded-crop/scorecard-units effect rather than raw tight-ink density — a
+  reminder that the absolute-agreement half of validation still needs the real
+  render, exactly as the scope note says.
+
+Net: the pins that rail at a clamp (Wild Fork 0.6, Costco 0.0) are the atlases a
+future font-quality pass should re-mint; the four interior pins (CVS 0.15, Vons
+0.3, Trader Joe's 0.0, Sprouts 0.225) sit where erosion still has headroom.
+
+## What this does and does not establish
+
+- **Establishes (render-free):** the measurer's monotonicity, saturation, and
+  cap-linearity assumptions hold on all shipped merchant atlases, so the solver
+  is operating on the response shape it was designed for; and the render-time
+  bisection's probe range can be capped at the saturation thin.
+- **Still open (needs the render path):** that a cheap-solved `bitmap_thin`
+  lands the scorecard's `density_ratio` within tolerance of the render-time
+  solve. That comparison is unit-bridged through the scorecard's padded-crop
+  density and belongs to M5's regression lock, where a real render is the source
+  of truth.

--- a/tools/glyph-studio/VALIDATION.md
+++ b/tools/glyph-studio/VALIDATION.md
@@ -58,8 +58,53 @@ future font-quality pass should re-mint; the four interior pins (CVS 0.15, Vons
   cap-linearity assumptions hold on all shipped merchant atlases, so the solver
   is operating on the response shape it was designed for; and the render-time
   bisection's probe range can be capped at the saturation thin.
-- **Still open (needs the render path):** that a cheap-solved `bitmap_thin`
-  lands the scorecard's `density_ratio` within tolerance of the render-time
-  solve. That comparison is unit-bridged through the scorecard's padded-crop
-  density and belongs to M5's regression lock, where a real render is the source
-  of truth.
+- **Established (with the render path), below:** the cheap density tracks the
+  scorecard's by a stable per-merchant factor, so the cheap solve recovers the
+  same density-match thin the scorecard would — validated on Sprouts.
+
+## Absolute correlation — cheap vs. real render (Sprouts)
+
+The render-free checks above confirm the *shape*; this confirms the cheap
+density is a faithful *proxy* for the scorecard density the render-time solver
+targets. Sprouts (the cleanest M0 merchant) was rendered at a forced
+`bitmap_thin` sweep on its M0 review receipt (262 words, 251 scorecard-eligible,
+coverage 1.0), and the scorecard's per-word synth density compared against the
+cheap `median_word_density` at the same thins and cap_px (44). Sanity: thin
+0.225 reproduced the M0 derive exactly (`density_ratio` 0.955).
+
+| forced thin | scorecard synth density | cheap density | cheap / scorecard |
+|---|---|---|---|
+| 0.000 | 0.1950 | 0.3831 | 1.965 |
+| 0.100 | 0.1870 | 0.3687 | 1.972 |
+| 0.225 | 0.1760 | 0.3455 | 1.963 |
+| 0.350 | 0.1680 | 0.3325 | 1.979 |
+| 0.500 | 0.1570 | 0.3074 | 1.958 |
+
+- **Stable factor:** cheap/scorecard = **1.967 ± 0.007 (CV 0.37 %)** — a
+  near-constant per-merchant multiplier. The absolute-units gap (tight-ink vs
+  padded-crop) is a *scale*, not a distortion.
+- **Perfect rank agreement:** Spearman **1.000**, Pearson 0.999.
+- **Recovers the density optimum:** the scorecard's real-density target (0.1839,
+  padded units) maps through the 1.967 factor to a cheap target of 0.362, which
+  the cheap curve hits at **thin ≈ 0.138**. The scorecard's own
+  `density_ratio → 1.0` optimum is **thin ≈ 0.136** — the two independent
+  measurers agree to **within 0.002**. (The render-time bisection landed on
+  0.225 only because its blind grid stepped 0.0 → 0.3 → 0.15 → 0.225 and never
+  probed ~0.1; the cheap full-curve measurer would have found the better point,
+  so it is *more* faithful to the density optimum here, not less.)
+- The cheap curve was independently reproduced on the Sprouts atlas from this
+  worktree (end/start density ratio 0.79 vs the experiment's 0.80), confirming
+  the cheap side.
+
+**Verdict:** for Sprouts the render-free measurer is a faithful proxy — density
+tracks the scorecard by a stable ~1.97× factor and recovers its density-match
+thin to within 0.002.
+
+## Still open (for M5)
+
+- **Per-merchant factor spread + non-body regimes.** Only Sprouts (a
+  regular-face-dominant merchant) was measured, and only its body density. The
+  1.967 factor is per-merchant; whether it is stable enough *across* merchants
+  to bridge without a per-merchant render, and how stylemap heavy/scaled rows
+  shift it, is the remaining validation — it belongs to M5's retrofit, where
+  each merchant gets a real render as the source of truth.

--- a/tools/glyph-studio/py/glyphstudio/calibrate.py
+++ b/tools/glyph-studio/py/glyphstudio/calibrate.py
@@ -603,6 +603,33 @@ def cap_glyph_height(
     return float(heights[len(heights) // 2])
 
 
+def renderer_cap_px(
+    cap_ratio: float,
+    median_ocr_word_height_px: float,
+    *,
+    font_px: float | None = None,
+    bitmap_cap_ratio: float | None = None,
+    max_font_px: float | None = None,
+) -> int:
+    """The ``cap_px`` the renderer stamps, reproducing _derive_bitmap_metrics.
+
+    ``measured_cap = round(median * cap_ratio)``, floored at
+    ``round(base_cap * 0.9)`` (``base_cap = round(font_px * bitmap_cap_ratio)``,
+    the small-text floor) and capped at ``max_font_px`` (the large-text ceiling).
+    Floor/ceiling only apply when their inputs are given; otherwise this is the
+    unclamped rounded linear cap_px. Shared by ``solve_cap_ratio`` (h_ratio
+    projection) and ``calibrate_merchant`` (so the density solve runs at the
+    exact size production renders).
+    """
+    cap_px = int(round(cap_ratio * median_ocr_word_height_px))
+    if font_px is not None and bitmap_cap_ratio is not None:
+        base_cap = max(6, int(round(float(font_px) * float(bitmap_cap_ratio))))
+        cap_px = max(int(round(base_cap * 0.9)), cap_px)  # small-text floor
+    if max_font_px is not None:
+        cap_px = min(max(6, int(max_font_px)), cap_px)  # large-text ceiling
+    return cap_px
+
+
 def solve_cap_ratio(
     font: "BitmapFont",
     real_cap_height_px: float,
@@ -649,12 +676,113 @@ def solve_cap_ratio(
     ratio = target_cap_px / median_ocr_word_height_px
     clamped = max(CAP_RATIO_MIN, min(CAP_RATIO_MAX, ratio))
     # Reproduce the renderer's cap_px so the projection matches what it stamps.
-    cap_px = int(round(clamped * median_ocr_word_height_px))
-    if font_px is not None and bitmap_cap_ratio is not None:
-        base_cap = max(6, int(round(float(font_px) * float(bitmap_cap_ratio))))
-        cap_px = max(int(round(base_cap * 0.9)), cap_px)  # small-text floor
-    if max_font_px is not None:
-        cap_px = min(max(6, int(max_font_px)), cap_px)  # large-text ceiling
+    cap_px = renderer_cap_px(
+        clamped,
+        median_ocr_word_height_px,
+        font_px=font_px,
+        bitmap_cap_ratio=bitmap_cap_ratio,
+        max_font_px=max_font_px,
+    )
     projected_synth = slope * cap_px
     projected_h_ratio = projected_synth / real_cap_height_px
     return clamped, projected_h_ratio
+
+
+# --------------------------------------------------------------------------
+# M4: calibrate_merchant -- one call emits the full calibrated typography block.
+#
+# Composes the three solves (all render-free) into the block ADD_MERCHANT.md
+# step 7 used to reach by eye: ocr_cap_height_ratio (M2), then weight+bitmap_thin
+# jointly (M3) at the exact cap_px the renderer will stamp. The REAL-side
+# measurements (cap height, median OCR word height, target density) are measured
+# once from the scans by the caller/scorecard and injected -- this stays pure and
+# render-free; the render-time solver is only needed for the M5 validation pass.
+# --------------------------------------------------------------------------
+
+
+def calibrate_merchant(
+    font: "BitmapFont",
+    receipts: "Sequence[Mapping[str, object]]",
+    *,
+    real_cap_height_px: float,
+    median_ocr_word_height_px: float,
+    target_density: float,
+    condense: float = 1.0,
+    condense_glyphs: bool = False,
+    weight_iters_options: "Sequence[int]" = (0, 1, 2, 3, 4),
+    cap_probe_thin: float = 0.0,
+    font_px: "float | None" = None,
+    bitmap_cap_ratio: "float | None" = None,
+    max_font_px: "float | None" = None,
+    provenance: "str | None" = None,
+) -> dict:
+    """Derive ``{ocr_cap_height_ratio, weight_iters, bitmap_thin}`` in one call.
+
+    ``receipts`` supplies the corpus (each item is an OCR receipt dict with a
+    ``words`` list of ``{"text": ...}``); it is filtered through
+    ``scorecard_words`` so calibration measures the same tokens the scorecard
+    scores. The real-side scalars are measured once from the scans and injected:
+
+    * ``real_cap_height_px`` -- the scorecard's real_h_med (real cap ink height).
+    * ``median_ocr_word_height_px`` -- median OCR word-box height (the renderer's
+      ``cap_px = round(that * ratio)`` input).
+    * ``target_density`` -- the real receipts' median per-word density (the
+      value the synth density must match; scorecard density_ratio -> 1.0).
+
+    Returns a dict with the solved knobs plus ``projected`` (h_ratio + achieved
+    density the cheap model predicts), ``cap_px``, ``coverage`` (assert 1.0 for
+    an unbiased solve; see ``text_glyph_coverage``), and ``provenance``. The
+    weight is reported as ``weight_iters`` (dilation steps) -- mapping it to the
+    profile's ``weight`` float is the mint-specific step done at M5.
+
+    Raises ValueError if the corpus has no scorecard-eligible words with atlas
+    glyphs, or the atlas has no cap-reference glyphs.
+    """
+    words = scorecard_words(
+        [w for r in receipts for w in (r.get("words") or [])]
+    )
+    if not words:
+        raise ValueError("no scorecard-eligible words in receipts")
+
+    # M2: cap-height ratio, then the exact cap_px the renderer will stamp.
+    ratio, h_ratio = solve_cap_ratio(
+        font,
+        real_cap_height_px,
+        median_ocr_word_height_px,
+        thin=cap_probe_thin,
+        font_px=font_px,
+        bitmap_cap_ratio=bitmap_cap_ratio,
+        max_font_px=max_font_px,
+    )
+    cap_px = renderer_cap_px(
+        ratio,
+        median_ocr_word_height_px,
+        font_px=font_px,
+        bitmap_cap_ratio=bitmap_cap_ratio,
+        max_font_px=max_font_px,
+    )
+
+    # M3: weight + bitmap_thin jointly, measured at that cap_px.
+    eff_condense = effective_condense(condense, condense_glyphs)
+    density_at = weight_density_fn(font, words, cap_px, condense=eff_condense)
+    weight_iters, thin, achieved = solve_weight_and_thin(
+        density_at,
+        target_density,
+        weight_iters_options=weight_iters_options,
+    )
+
+    coverage = text_glyph_coverage(font, "".join(words))
+    n = len(list(receipts))
+    return {
+        "ocr_cap_height_ratio": ratio,
+        "weight_iters": weight_iters,
+        "bitmap_thin": thin,
+        "cap_px": cap_px,
+        "projected": {
+            "h_ratio": h_ratio,
+            "density": achieved,
+            "target_density": target_density,
+        },
+        "coverage": coverage,
+        "provenance": provenance or f"fleet-derived over {n} receipts",
+    }

--- a/tools/glyph-studio/py/glyphstudio/calibrate.py
+++ b/tools/glyph-studio/py/glyphstudio/calibrate.py
@@ -45,20 +45,43 @@ cannot be reproduced without a render, and are out of scope by design:
 
 from __future__ import annotations
 
+import os
+import sys
 from collections import Counter
 from typing import TYPE_CHECKING, Mapping, Sequence
 
 import numpy as np
 from PIL import Image
-from receipt_agent.agents.label_evaluator.rendering.bitmap_font import (
-    preserve_top_arc,
-    thin_ink_mask,
-)
 
 if TYPE_CHECKING:  # pragma: no cover
     from receipt_agent.agents.label_evaluator.rendering.bitmap_font import (
         BitmapFont,
     )
+
+# The renderer lives in a sibling monorepo package, not a declared dependency of
+# the ``glyphstudio`` package (pyproject only lists numpy/pillow). Match the
+# rest of the studio tooling (compile.py._import_bitmap_font): insert the
+# sibling package paths lazily and import on first use, so ``import
+# glyphstudio.calibrate`` still succeeds in a clean studio env where the
+# renderer is only needed when a measurement actually runs.
+_WORKTREE = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "..", "..")
+)
+
+
+def _renderer():
+    """Lazily import the renderer's ``thin_ink_mask`` / ``preserve_top_arc``."""
+    for pkg in ("receipt_agent", "receipt_upload", "receipt_dynamo"):
+        path = os.path.join(_WORKTREE, pkg)
+        if path not in sys.path:
+            sys.path.insert(0, path)
+    from receipt_agent.agents.label_evaluator.rendering.bitmap_font import (
+        preserve_top_arc,
+        thin_ink_mask,
+    )
+
+    return thin_ink_mask, preserve_top_arc
+
 
 # Beyond this thin, thin_ink_mask's drop-period (round(1/thin)) floors at 2 and
 # density stops falling -- probing higher is wasted work. Kept in sync with
@@ -99,6 +122,21 @@ def dilate_ink(mask: np.ndarray, iters: int) -> np.ndarray:
     return out
 
 
+def effective_condense(condense: float, condense_glyphs: bool) -> float:
+    """The x-resize factor the renderer applies to the glyph MASK, gated.
+
+    Critical distinction: ``condense`` in a merchant profile always narrows the
+    cell *advance* (spacing), but the renderer only resizes the glyph mask when
+    ``condense_glyphs`` is enabled (receipt_grid draw_token_chars/draw_text_run).
+    Target/Vons/CVS set ``condense < 1`` with ``condense_glyphs`` FALSE, so their
+    masks are NOT narrowed -- measuring them condensed would understate width and
+    solve the wrong density. Pass ``effective_condense(profile.condense,
+    profile.condense_glyphs)`` as the ``condense`` argument to the density
+    functions so the mask is only narrowed when production actually narrows it.
+    """
+    return float(condense) if condense_glyphs else 1.0
+
+
 def _rendered_glyph(
     font: "BitmapFont",
     ch: str,
@@ -111,11 +149,13 @@ def _rendered_glyph(
 
     Mirrors ``BitmapFont.glyph``: NEAREST scale to ``cap_px`` first, then
     ``thin_ink_mask`` -- the ordering matters, since erosion works on rendered-
-    size edges, not atlas-resolution edges. When ``condense < 1`` and the
-    merchant enables ``condense_glyphs`` (e.g. In-N-Out at 0.7), the renderer
-    resizes the thinned mask again along x before pasting (receipt_grid.py
-    draw_token_chars / draw_text_run); we replicate that so the measured density
-    matches the pixels actually stamped, not the un-condensed mask.
+    size edges, not atlas-resolution edges.
+
+    ``condense`` here is the EFFECTIVE mask-resize factor, i.e. already gated on
+    the merchant's ``condense_glyphs`` flag (use ``effective_condense``). The
+    renderer resizes the thinned mask along x before pasting ONLY when
+    ``condense_glyphs`` is enabled (e.g. In-N-Out at 0.7); when it is off,
+    ``condense`` affects only cell advance, not the mask, so pass ``1.0`` here.
 
     ``weight_iters`` models the mint's stroke-weight dilation (see ``dilate_ink``
     / ``solve_weight_and_thin``): dilation is applied AFTER scale and BEFORE
@@ -128,6 +168,7 @@ def _rendered_glyph(
     g = font.glyphs.get(ch)
     if g is None:
         return None
+    thin_ink_mask, preserve_top_arc = _renderer()
     scale = cap_px / font.cap_h
     h = max(1, int(round(g.shape[0] * scale)))
     w = max(1, int(round(g.shape[1] * scale)))
@@ -338,7 +379,17 @@ def thin_response_curve(
 # pixels for sparse glyphs). Distinct behavior therefore lives only at the
 # period representatives; enumerate them and pick the closest, rather than
 # bisecting on a false monotonicity assumption.
-_SOLVE_THINS = (0.0,) + tuple(round(1.0 / p, 4) for p in range(2, 21))
+#
+# Periods run 2..MAX so the grid reaches down to very slight erosion
+# (thin = 1/MAX): each larger period is a distinct mask (drops 1/period of the
+# edge pixels), so stopping early would force a merchant that only needs a hair
+# of erosion onto the 0.0 or a coarser plateau. MAX=60 -> finest thin ~0.017,
+# well below the scorecard's ~0.03 density tolerance; probes are milliseconds so
+# the extra plateaus are free.
+_MAX_SOLVE_PERIOD = 60
+_SOLVE_THINS = (0.0,) + tuple(
+    round(1.0 / p, 4) for p in range(2, _MAX_SOLVE_PERIOD + 1)
+)
 
 
 def solve_thin_for_density(

--- a/tools/glyph-studio/py/glyphstudio/calibrate.py
+++ b/tools/glyph-studio/py/glyphstudio/calibrate.py
@@ -276,8 +276,17 @@ _LONG_NUMERIC_RE = _re.compile(r"^[\[\]\(\)\sXx0-9\-]+$")
 
 
 def is_long_numeric_caption(text: str) -> bool:
-    """True for barcode/UPC-style captions the scorecard excludes from density."""
-    glyphs = _re.sub(r"\s+", "", text)
+    """True for barcode/UPC-style captions the scorecard excludes from density.
+
+    Mirrors ``_is_long_numeric_caption`` EXACTLY, including a quirk: the
+    scorecard's ``re.sub(r"\\s+", "", text)`` is a no-op (the raw pattern matches
+    a literal backslash-s, never real whitespace), so it counts digits and
+    length over the text WITH internal spaces retained. We must do the same --
+    stripping whitespace would raise the digit ratio and drop space-separated
+    captions the scorecard still scores, measuring a different corpus than the
+    target density. Keep in lockstep if that scorecard predicate is fixed.
+    """
+    glyphs = text  # scorecard's whitespace strip is a no-op; match it
     digits = sum(ch.isdigit() for ch in glyphs)
     return (
         digits >= 14
@@ -511,21 +520,21 @@ def solve_weight_and_thin(
     """Jointly solve (weight_iters, thin) for density closest to ``target``.
 
     ``density_at(weight_iters, thin) -> float | None`` is injected (cheap model
-    or real render). Un-eroded density (``thin`` at its minimum) is the MOST ink
-    a given weight can produce, so a weight can reach ``target`` by erosion iff
-    its un-eroded density >= target. Strategy (per the epic):
-
-    * Among weights whose un-eroded density >= target, pick the SMALLEST (least
-      thickening), then argmin ``thin`` to fine-tune down to target.
-    * If NO weight reaches target even un-eroded (target too dense), pick the
-      HEAVIEST weight and its closest thin (best effort from below).
+    or real render). Weight raises ink, thin lowers it. Rather than commit to the
+    least weight that *could* reach the target and then thin (which, on the
+    discrete/saturated thin grid, can leave the chosen weight's closest plateau
+    far from target while a lighter weight sits much nearer), evaluate the best
+    thin at EVERY weight and take the global argmin on achieved density,
+    tie-breaking toward the LEAST weight (least thickening). This keeps the
+    epic's "raise weight, then fine-tune thin" intent -- ties still prefer the
+    lighter weight -- without ever returning a worse density than a weight it
+    skipped.
 
     Returns ``(weight_iters, thin, achieved_density)``. Raises ValueError if
     ``density_at`` yields no measurable density for any (weight, thin).
     """
     weights = sorted(set(int(w) for w in weight_iters_options))
     thin_grid = sorted(set(float(t) for t in thins))
-    min_thin = thin_grid[0]
 
     def best_thin_at(weight: int) -> tuple[float, float] | None:
         best: tuple[float, float] | None = None
@@ -541,31 +550,22 @@ def solve_weight_and_thin(
                 best = (t, d)
         return best
 
-    # Un-eroded (max-ink) density per weight, to find which can reach target.
-    reachable: list[int] = []
-    heaviest_uneroded: tuple[int, float] | None = None
-    for w in weights:
-        d0 = density_at(w, min_thin)
-        if d0 is None:
+    best: tuple[int, float, float] | None = None
+    for w in weights:  # ascending, so ties keep the lighter weight
+        bt = best_thin_at(w)
+        if bt is None:
             continue
-        heaviest_uneroded = (w, d0)
-        if d0 >= target_density - 1e-12:
-            reachable.append(w)
+        thin, achieved = bt
+        if (
+            best is None
+            or abs(achieved - target_density)
+            < abs(best[2] - target_density) - 1e-12
+        ):
+            best = (w, thin, achieved)
 
-    if reachable:
-        chosen = min(reachable)  # least thickening that can erode to target
-    elif heaviest_uneroded is not None:
-        chosen = heaviest_uneroded[
-            0
-        ]  # target too dense: heaviest, best effort
-    else:
+    if best is None:
         raise ValueError("density_at yielded no measurable density")
-
-    bt = best_thin_at(chosen)
-    if bt is None:
-        raise ValueError("density_at yielded no measurable density")
-    thin, achieved = bt
-    return chosen, thin, achieved
+    return best
 
 
 # --------------------------------------------------------------------------
@@ -582,17 +582,23 @@ def solve_weight_and_thin(
 
 
 def cap_glyph_height(
-    font: "BitmapFont", cap_px: int, thin: float
+    font: "BitmapFont", cap_px: int, thin: float, weight_iters: int = 0
 ) -> float | None:
     """Median rendered ink-height (px) of the cap-reference glyphs at cap_px.
 
     This is the synth-side cap height the scorecard's ``synth_h_med`` measures,
-    computed from the atlas without rendering a receipt. ``None`` if the atlas
-    carries no cap-reference glyphs.
+    computed from the atlas without rendering a receipt. ``thin``/``weight_iters``
+    match the final render knobs: erosion can strip a cap glyph's boundary rows
+    (sparse/dot-matrix caps render shorter than the un-eroded height) and
+    dilation can add them, so the honest cap height is measured at the same
+    (thin, weight) production will stamp. ``None`` if the atlas carries no
+    cap-reference glyphs.
     """
     heights = []
     for ch in CAP_REF:
-        arr = _rendered_glyph(font, ch, cap_px, thin)
+        arr = _rendered_glyph(
+            font, ch, cap_px, thin, weight_iters=weight_iters
+        )
         if arr is None or not arr.any():
             continue
         rows = np.where(arr.any(axis=1))[0]
@@ -636,6 +642,7 @@ def solve_cap_ratio(
     median_ocr_word_height_px: float,
     thin: float = 0.0,
     *,
+    weight_iters: int = 0,
     probe_cap_px: int | None = None,
     font_px: float | None = None,
     bitmap_cap_ratio: float | None = None,
@@ -665,7 +672,7 @@ def solve_cap_ratio(
     unclamped linear cap_px (rounding still applied).
     """
     probe = probe_cap_px or max(6, int(round(font.cap_h)))
-    synth_at_probe = cap_glyph_height(font, probe, thin)
+    synth_at_probe = cap_glyph_height(font, probe, thin, weight_iters)
     if synth_at_probe is None or synth_at_probe <= 0:
         raise ValueError("atlas has no cap-reference glyphs")
     if median_ocr_word_height_px <= 0:
@@ -714,6 +721,7 @@ def calibrate_merchant(
     font_px: "float | None" = None,
     bitmap_cap_ratio: "float | None" = None,
     max_font_px: "float | None" = None,
+    min_words: int = 15,
     provenance: "str | None" = None,
 ) -> dict:
     """Derive ``{ocr_cap_height_ratio, weight_iters, bitmap_thin}`` in one call.
@@ -731,18 +739,33 @@ def calibrate_merchant(
 
     Returns a dict with the solved knobs plus ``projected`` (h_ratio + achieved
     density the cheap model predicts), ``cap_px``, ``coverage`` (assert 1.0 for
-    an unbiased solve; see ``text_glyph_coverage``), and ``provenance``. The
-    weight is reported as ``weight_iters`` (dilation steps) -- mapping it to the
-    profile's ``weight`` float is the mint-specific step done at M5.
+    an unbiased solve; see ``text_glyph_coverage``), ``measured_words``, and
+    ``provenance``. The weight is reported as ``weight_iters`` (dilation steps)
+    -- mapping it to the profile's ``weight`` float is the mint-specific step
+    done at M5.
 
-    Raises ValueError if the corpus has no scorecard-eligible words with atlas
-    glyphs, or the atlas has no cap-reference glyphs.
+    ``min_words`` mirrors ``ink_calibration.measure_density_ratio``'s 15-word
+    floor: too few measured words gives an overfit median, so calibrating on a
+    handful of tokens is refused. Raises ValueError if fewer than ``min_words``
+    scorecard-eligible words carry atlas glyphs, if the corpus is empty, or if
+    the atlas has no cap-reference glyphs.
     """
     words = scorecard_words(
         [w for r in receipts for w in (r.get("words") or [])]
     )
     if not words:
         raise ValueError("no scorecard-eligible words in receipts")
+    # Words that actually contribute a density measurement (>=1 atlas glyph,
+    # i.e. a non-None per-word density), matching the render-time path's
+    # min_words guard on measured word scores.
+    n_measured = sum(
+        1 for w in words if any(c in font.glyphs for c in w if not c.isspace())
+    )
+    if n_measured < min_words:
+        raise ValueError(
+            f"only {n_measured} measurable words (< min_words={min_words}); "
+            "corpus too small to calibrate reliably"
+        )
 
     # M2: cap-height ratio, then the exact cap_px the renderer will stamp.
     ratio, h_ratio = solve_cap_ratio(
@@ -771,6 +794,28 @@ def calibrate_merchant(
         weight_iters_options=weight_iters_options,
     )
 
+    # Re-project cap height at the SOLVED thin/weight: erosion can strip cap
+    # boundary rows (sparse/dot-matrix caps render shorter) and dilation can add
+    # them, so h_ratio at thin=0 would over-promise. One refinement pass -- the
+    # ratio's feedback onto cap_px (hence thin) is second-order and not iterated.
+    ratio, h_ratio = solve_cap_ratio(
+        font,
+        real_cap_height_px,
+        median_ocr_word_height_px,
+        thin=thin,
+        weight_iters=weight_iters,
+        font_px=font_px,
+        bitmap_cap_ratio=bitmap_cap_ratio,
+        max_font_px=max_font_px,
+    )
+    cap_px = renderer_cap_px(
+        ratio,
+        median_ocr_word_height_px,
+        font_px=font_px,
+        bitmap_cap_ratio=bitmap_cap_ratio,
+        max_font_px=max_font_px,
+    )
+
     coverage = text_glyph_coverage(font, "".join(words))
     n = len(list(receipts))
     return {
@@ -778,6 +823,7 @@ def calibrate_merchant(
         "weight_iters": weight_iters,
         "bitmap_thin": thin,
         "cap_px": cap_px,
+        "measured_words": n_measured,
         "projected": {
             "h_ratio": h_ratio,
             "density": achieved,

--- a/tools/glyph-studio/py/glyphstudio/calibrate.py
+++ b/tools/glyph-studio/py/glyphstudio/calibrate.py
@@ -43,11 +43,18 @@ if TYPE_CHECKING:  # pragma: no cover
 # thin_ink_mask's ``amount = min(0.9, amount)`` clamp / period floor.
 SATURATION_THIN = 0.5
 
+# Cap-reference glyphs (uppercase without descenders) that define cap height,
+# matching BitmapFont's own cap_h derivation.
+CAP_REF = "ABDEFGHKLMNPRSTUVXZ"
+# The renderer clamps ocr_cap_height_ratio to this band (receipt_renderer.py).
+CAP_RATIO_MIN = 0.65
+CAP_RATIO_MAX = 0.95
 
-def _rendered_glyph_ink(
+
+def _rendered_glyph(
     font: "BitmapFont", ch: str, cap_px: int, thin: float
-) -> tuple[int, int] | None:
-    """(ink_px, total_px) for one glyph at the EXACT pixels the renderer stamps.
+) -> np.ndarray | None:
+    """The eroded ink mask for one glyph at the EXACT pixels the renderer stamps.
 
     Mirrors ``BitmapFont.glyph``: NEAREST scale to ``cap_px`` first, then
     ``thin_ink_mask`` -- the ordering matters, since erosion works on rendered-
@@ -63,7 +70,16 @@ def _rendered_glyph_ink(
         (w, h), Image.NEAREST
     )
     im = thin_ink_mask(im, thin, preserve_top=preserve_top_arc(ch))
-    arr = np.asarray(im) > 0
+    return np.asarray(im) > 0
+
+
+def _rendered_glyph_ink(
+    font: "BitmapFont", ch: str, cap_px: int, thin: float
+) -> tuple[int, int] | None:
+    """(ink_px, total_px) for one glyph at the rendered pixels."""
+    arr = _rendered_glyph(font, ch, cap_px, thin)
+    if arr is None:
+        return None
     return int(arr.sum()), int(arr.size)
 
 
@@ -149,3 +165,77 @@ def solve_thin_for_density(
             hi = mid
     mid = (lo + hi) / 2.0
     return mid, text_ink_density(font, text, cap_px, mid) or target_density
+
+
+# --------------------------------------------------------------------------
+# Cap height: the h_ratio knob (ocr_cap_height_ratio), derived not eyeballed.
+#
+# The renderer sets cap_px = median(real OCR word heights) * ocr_cap_height_ratio,
+# then stamps cap glyphs scaled to cap_px -- so the rendered cap height is a
+# near-linear function of cap_px, and h_ratio (synth cap height / real cap
+# height) is near-linear in the ratio. The hand-tuned spread (0.649 Vons ->
+# 0.95 Target) was linear correction by eye. This solves it directly: measure
+# the synth cap height at a probe cap_px (cheap, from the atlas), and the real
+# cap height once from the scan, then back out the ratio. No synth render.
+# --------------------------------------------------------------------------
+
+
+def cap_glyph_height(
+    font: "BitmapFont", cap_px: int, thin: float
+) -> float | None:
+    """Median rendered ink-height (px) of the cap-reference glyphs at cap_px.
+
+    This is the synth-side cap height the scorecard's ``synth_h_med`` measures,
+    computed from the atlas without rendering a receipt. ``None`` if the atlas
+    carries no cap-reference glyphs.
+    """
+    heights = []
+    for ch in CAP_REF:
+        arr = _rendered_glyph(font, ch, cap_px, thin)
+        if arr is None or not arr.any():
+            continue
+        rows = np.where(arr.any(axis=1))[0]
+        heights.append(int(rows.max() - rows.min() + 1))
+    if not heights:
+        return None
+    heights.sort()
+    return float(heights[len(heights) // 2])
+
+
+def solve_cap_ratio(
+    font: "BitmapFont",
+    real_cap_height_px: float,
+    median_ocr_word_height_px: float,
+    thin: float = 0.0,
+    *,
+    probe_cap_px: int | None = None,
+) -> tuple[float, float]:
+    """Derive ocr_cap_height_ratio so the synth cap height matches the real scan.
+
+    ``real_cap_height_px`` is the real receipt's measured cap-glyph ink height
+    (the scorecard's real_h_med -- measured once from the scan, cheaply).
+    ``median_ocr_word_height_px`` is the median OCR word-box height the renderer
+    feeds into ``cap_px = round(that * ratio)``.
+
+    Rendered cap height is linear in cap_px through the origin, so one probe
+    fixes the slope: solve for the cap_px whose synth cap height equals the real
+    cap height, then ``ratio = cap_px / median_ocr_word_height``. Returns
+    ``(ratio, projected_h_ratio)`` where projected_h_ratio is the synth/real
+    height ratio at the (clamped) returned ratio -- 1.0 when unclamped.
+    """
+    probe = probe_cap_px or max(6, int(round(font.cap_h)))
+    synth_at_probe = cap_glyph_height(font, probe, thin)
+    if synth_at_probe is None or synth_at_probe <= 0:
+        raise ValueError("atlas has no cap-reference glyphs")
+    if median_ocr_word_height_px <= 0:
+        raise ValueError("median OCR word height must be positive")
+    # synth_cap(cap_px) ~= (synth_at_probe / probe) * cap_px  -> solve = real
+    slope = synth_at_probe / probe
+    target_cap_px = real_cap_height_px / slope
+    ratio = target_cap_px / median_ocr_word_height_px
+    clamped = max(CAP_RATIO_MIN, min(CAP_RATIO_MAX, ratio))
+    # projected h_ratio at the clamped ratio (1.0 if the solve wasn't clamped)
+    achieved_cap_px = clamped * median_ocr_word_height_px
+    projected_synth = slope * achieved_cap_px
+    projected_h_ratio = projected_synth / real_cap_height_px
+    return clamped, projected_h_ratio

--- a/tools/glyph-studio/py/glyphstudio/calibrate.py
+++ b/tools/glyph-studio/py/glyphstudio/calibrate.py
@@ -73,12 +73,39 @@ CAP_RATIO_MIN = 0.65
 CAP_RATIO_MAX = 0.95
 
 
+def dilate_ink(mask: np.ndarray, iters: int) -> np.ndarray:
+    """Morphological dilation by ``iters`` steps (8-connected), pure numpy.
+
+    Models stroke *weight*: the mint thickens glyph strokes before the atlas is
+    frozen, so a heavier weight stamps more ink. Each step grows the ink by one
+    pixel in all 8 directions; ``iters <= 0`` is the identity. This is the
+    weight analog of ``thin_ink_mask``'s erosion -- density rises monotonically
+    with ``iters``, which is the property the joint solver relies on.
+    """
+    if iters <= 0:
+        return mask
+    out = mask.astype(bool)
+    for _ in range(int(iters)):
+        d = out.copy()
+        d[1:, :] |= out[:-1, :]
+        d[:-1, :] |= out[1:, :]
+        d[:, 1:] |= out[:, :-1]
+        d[:, :-1] |= out[:, 1:]
+        d[1:, 1:] |= out[:-1, :-1]
+        d[1:, :-1] |= out[:-1, 1:]
+        d[:-1, 1:] |= out[1:, :-1]
+        d[:-1, :-1] |= out[1:, 1:]
+        out = d
+    return out
+
+
 def _rendered_glyph(
     font: "BitmapFont",
     ch: str,
     cap_px: int,
     thin: float,
     condense: float = 1.0,
+    weight_iters: int = 0,
 ) -> np.ndarray | None:
     """The eroded ink mask for one glyph at the EXACT pixels the renderer stamps.
 
@@ -89,6 +116,14 @@ def _rendered_glyph(
     resizes the thinned mask again along x before pasting (receipt_grid.py
     draw_token_chars / draw_text_run); we replicate that so the measured density
     matches the pixels actually stamped, not the un-condensed mask.
+
+    ``weight_iters`` models the mint's stroke-weight dilation (see ``dilate_ink``
+    / ``solve_weight_and_thin``): dilation is applied AFTER scale and BEFORE
+    erosion, mirroring the mint order (weight is baked into the atlas, then the
+    render erodes). ``weight_iters`` is an explicit pixel count rather than a
+    ``weight`` float because the weight->pixels magnitude is mint-specific and
+    is calibrated at M4/M5 against the real mint; the density *shape* (monotone
+    in iters) is faithful regardless. ``0`` = current render behavior.
     """
     g = font.glyphs.get(ch)
     if g is None:
@@ -99,6 +134,9 @@ def _rendered_glyph(
     im = Image.fromarray((np.clip(g, 0, 1) * 255).astype(np.uint8)).resize(
         (w, h), Image.NEAREST
     )
+    if weight_iters > 0:
+        arr = dilate_ink(np.asarray(im) > 0, weight_iters)
+        im = Image.fromarray(arr.astype(np.uint8) * 255)
     im = thin_ink_mask(im, thin, preserve_top=preserve_top_arc(ch))
     if condense < 0.999:
         im = im.resize(
@@ -114,9 +152,10 @@ def _rendered_glyph_ink(
     cap_px: int,
     thin: float,
     condense: float = 1.0,
+    weight_iters: int = 0,
 ) -> tuple[int, int] | None:
     """(ink_px, total_px) for one glyph at the rendered pixels."""
-    arr = _rendered_glyph(font, ch, cap_px, thin, condense)
+    arr = _rendered_glyph(font, ch, cap_px, thin, condense, weight_iters)
     if arr is None:
         return None
     return int(arr.sum()), int(arr.size)
@@ -144,14 +183,16 @@ def text_ink_density(
     cap_px: int,
     thin: float,
     condense: float = 1.0,
+    weight_iters: int = 0,
 ) -> float | None:
     """Frequency-weighted ink fraction of ``text`` rendered at cap_px/thin.
 
     Sums ink and area over each drawn glyph weighted by its count in ``text``
     (spaces skipped) -- the per-glyph density the renderer would stamp, before
     the paper-texture pass. ``condense`` replicates the ``condense_glyphs``
-    post-thin x-resize for merchants that enable it. ``None`` if no glyph in
-    ``text`` is in the atlas. NOTE: atlas misses are skipped, so at less than
+    post-thin x-resize for merchants that enable it. ``weight_iters`` models the
+    mint's stroke-weight dilation (see ``_rendered_glyph``). ``None`` if no glyph
+    in ``text`` is in the atlas. NOTE: atlas misses are skipped, so at less than
     full coverage this under-counts the TTF-fallback ink the renderer stamps --
     check ``text_glyph_coverage`` (the 94/94 publish gate normally guarantees
     it is 1.0).
@@ -159,7 +200,9 @@ def text_ink_density(
     counts = Counter(c for c in text if not c.isspace())
     ink = area = 0
     for ch, n in counts.items():
-        res = _rendered_glyph_ink(font, ch, cap_px, thin, condense)
+        res = _rendered_glyph_ink(
+            font, ch, cap_px, thin, condense, weight_iters
+        )
         if res is None:
             continue
         ink += res[0] * n
@@ -230,16 +273,18 @@ def word_ink_densities(
     cap_px: int,
     thin: float,
     condense: float = 1.0,
+    weight_iters: int = 0,
 ) -> list[float]:
     """Per-word tight-ink density for each of ``words`` (atlas-covered glyphs).
 
     One density per word (ink / drawn-glyph area within that word), so a single
     long dense token cannot dominate the aggregate the way a char-frequency
-    corpus mean lets it. Words with no atlas glyphs are skipped.
+    corpus mean lets it. ``weight_iters`` models the mint stroke-weight dilation.
+    Words with no atlas glyphs are skipped.
     """
     out = []
     for text in words:
-        d = text_ink_density(font, text, cap_px, thin, condense)
+        d = text_ink_density(font, text, cap_px, thin, condense, weight_iters)
         if d is not None:
             out.append(d)
     return out
@@ -251,15 +296,17 @@ def median_word_density(
     cap_px: int,
     thin: float,
     condense: float = 1.0,
+    weight_iters: int = 0,
 ) -> float | None:
     """Median of per-word densities -- the scorecard's aggregation protocol.
 
     ``ink_calibration.measure_density_ratio`` takes ``median`` over per-word
     ratios; this mirrors that on the synth side so the cheap signal moves with
-    ``density_ratio_median`` rather than an area-weighted corpus mean. ``None``
-    if no word carries atlas glyphs.
+    ``density_ratio_median`` rather than an area-weighted corpus mean.
+    ``weight_iters`` models the mint stroke-weight dilation. ``None`` if no word
+    carries atlas glyphs.
     """
-    ds = word_ink_densities(font, words, cap_px, thin, condense)
+    ds = word_ink_densities(font, words, cap_px, thin, condense, weight_iters)
     if not ds:
         return None
     ds.sort()
@@ -358,6 +405,116 @@ def solve_thin_for_word_density(
     if best is None:
         raise ValueError("no atlas glyphs in words; cannot measure density")
     return best
+
+
+# --------------------------------------------------------------------------
+# M3: derive weight + bitmap_thin JOINTLY.
+#
+# density_ratio (ink) is controlled by TWO coupled knobs: weight (mint stroke
+# dilation, ink UP) and bitmap_thin (render erosion, ink DOWN). The epic's
+# recipe: raise weight to bring density into range, then erode with thin to
+# fine-tune to target. Because density is monotone-increasing in weight and
+# (mostly) decreasing in thin, this is a 2-stage solve, not a 2-D search:
+# choose the LEAST weight whose un-eroded density still meets-or-exceeds the
+# target (so erosion can bring it down), then solve thin at that weight. This
+# generalizes derive_bitmap_thin (thin only) and moves it off the render path.
+#
+# The solver takes an INJECTED ``density_at(weight_iters, thin) -> float | None``
+# so it is agnostic to how weight/thin map to pixels: the cheap path passes the
+# render-free model (weight_density_fn below); a validation path can pass a real
+# render closure. weight is expressed as integer dilation ``weight_iters``; the
+# iters<->weight-float magnitude is mint-specific and calibrated at M4/M5.
+# --------------------------------------------------------------------------
+
+
+def weight_density_fn(
+    font: "BitmapFont",
+    words: Sequence[str],
+    cap_px: int,
+    *,
+    condense: float = 1.0,
+):
+    """Build ``density_at(weight_iters, thin)`` for ``solve_weight_and_thin``.
+
+    The returned closure measures the render-free median-word density with the
+    mint stroke-weight dilation modelled (``weight_iters`` dilation steps) and
+    the render erosion applied (``thin``). Injecting it keeps the solver's
+    algorithm independent of the (mint-specific) weight->pixels magnitude.
+    """
+
+    def density_at(weight_iters: int, thin: float) -> float | None:
+        return median_word_density(
+            font, words, cap_px, thin, condense, int(weight_iters)
+        )
+
+    return density_at
+
+
+def solve_weight_and_thin(
+    density_at,
+    target_density: float,
+    *,
+    weight_iters_options: Sequence[int] = (0, 1, 2, 3, 4),
+    thins: Sequence[float] = _SOLVE_THINS,
+) -> tuple[int, float, float]:
+    """Jointly solve (weight_iters, thin) for density closest to ``target``.
+
+    ``density_at(weight_iters, thin) -> float | None`` is injected (cheap model
+    or real render). Un-eroded density (``thin`` at its minimum) is the MOST ink
+    a given weight can produce, so a weight can reach ``target`` by erosion iff
+    its un-eroded density >= target. Strategy (per the epic):
+
+    * Among weights whose un-eroded density >= target, pick the SMALLEST (least
+      thickening), then argmin ``thin`` to fine-tune down to target.
+    * If NO weight reaches target even un-eroded (target too dense), pick the
+      HEAVIEST weight and its closest thin (best effort from below).
+
+    Returns ``(weight_iters, thin, achieved_density)``. Raises ValueError if
+    ``density_at`` yields no measurable density for any (weight, thin).
+    """
+    weights = sorted(set(int(w) for w in weight_iters_options))
+    thin_grid = sorted(set(float(t) for t in thins))
+    min_thin = thin_grid[0]
+
+    def best_thin_at(weight: int) -> tuple[float, float] | None:
+        best: tuple[float, float] | None = None
+        for t in thin_grid:
+            d = density_at(weight, t)
+            if d is None:
+                continue
+            if (
+                best is None
+                or abs(d - target_density)
+                < abs(best[1] - target_density) - 1e-12
+            ):
+                best = (t, d)
+        return best
+
+    # Un-eroded (max-ink) density per weight, to find which can reach target.
+    reachable: list[int] = []
+    heaviest_uneroded: tuple[int, float] | None = None
+    for w in weights:
+        d0 = density_at(w, min_thin)
+        if d0 is None:
+            continue
+        heaviest_uneroded = (w, d0)
+        if d0 >= target_density - 1e-12:
+            reachable.append(w)
+
+    if reachable:
+        chosen = min(reachable)  # least thickening that can erode to target
+    elif heaviest_uneroded is not None:
+        chosen = heaviest_uneroded[
+            0
+        ]  # target too dense: heaviest, best effort
+    else:
+        raise ValueError("density_at yielded no measurable density")
+
+    bt = best_thin_at(chosen)
+    if bt is None:
+        raise ValueError("density_at yielded no measurable density")
+    thin, achieved = bt
+    return chosen, thin, achieved
 
 
 # --------------------------------------------------------------------------

--- a/tools/glyph-studio/py/glyphstudio/calibrate.py
+++ b/tools/glyph-studio/py/glyphstudio/calibrate.py
@@ -18,6 +18,29 @@ This is the M1 foundation of the calibration-derivation epic (DERIVATION_EPIC.md
 a cheap measurer the mint-time solver stands on. It is deliberately dependency-
 light: only ``BitmapFont``/``thin_ink_mask`` from the renderer, so it can run
 in the studio without the full synthesis stack.
+
+Scope & units -- what this measures and what it deliberately does NOT
+--------------------------------------------------------------------
+The signal here is *synth-side, tight-ink* density: ink pixels over drawn-glyph
+area, aggregated to match the scorecard's protocol (``scorecard_words`` +
+``median_word_density`` mirror ``_word_scores`` / ``density_ratio_median``). Two
+parts of the scorecard's ABSOLUTE density are layout/pipeline effects that
+cannot be reproduced without a render, and are out of scope by design:
+
+* Padded-crop denominator: ``receipt_line_scorecard.measure_ink`` divides ink by
+  the padded word-crop area (word box + ``synth_margin`` + pad), so its absolute
+  density is margin- and cell-spacing-dominated, not a tight-glyph fraction.
+  This measurer therefore tracks the *shape* of the thin response and the
+  erosion saturation point; it is not a drop-in for the scorecard's absolute
+  number. Absolute agreement between the cheap solve and a real render is
+  established empirically by the M1/M2 validation milestone, and the render-time
+  solver remains the source of truth when they disagree.
+* Stylemap faces/scales: merchants whose stylemap renders header/total/footer
+  rows with a heavy face, a scale multiplier, or a double-strike stamp more ink
+  than a body-``cap_px`` regular glyph. This module samples one regular face at
+  one cap_px, so styled rows are measured light. Exclude those rows from the
+  corpus upstream (``scorecard_words`` handles word-class filtering but not
+  section styling) or calibrate them separately.
 """
 
 from __future__ import annotations
@@ -147,8 +170,103 @@ def text_ink_density(
 
 
 def corpus_text(words: Sequence[Mapping[str, object]]) -> str:
-    """Concatenate the text of OCR ``words`` (the glyph-frequency basis)."""
+    """Concatenate the text of OCR ``words`` (the glyph-frequency basis).
+
+    NOTE: this is the raw char-frequency basis (every token). For a signal that
+    tracks the scorecard's ``density_ratio_median`` -- which the render-time
+    solver actually targets -- filter with ``scorecard_words`` and aggregate
+    with ``median_word_density`` instead of taking one corpus-wide mean.
+    """
     return "".join(str(w.get("text") or "") for w in words)
+
+
+# The scorecard drops two word classes before measuring density
+# (receipt_line_scorecard._word_scores / _is_long_numeric_caption). We mirror
+# the predicates here -- rather than import the synthesis stack this module is
+# deliberately independent of -- so the corpus we measure matches the tokens
+# that actually contribute to ``density_ratio_median``. Spec source:
+# synthesis_loop/receipt_line_scorecard.py (keep in sync if it changes).
+import re as _re  # noqa: E402  (local: keep the module import surface minimal)
+
+_LONG_NUMERIC_RE = _re.compile(r"^[\[\]\(\)\sXx0-9\-]+$")
+
+
+def is_long_numeric_caption(text: str) -> bool:
+    """True for barcode/UPC-style captions the scorecard excludes from density."""
+    glyphs = _re.sub(r"\s+", "", text)
+    digits = sum(ch.isdigit() for ch in glyphs)
+    return (
+        digits >= 14
+        and digits >= 0.75 * max(1, len(glyphs))
+        and bool(_LONG_NUMERIC_RE.match(glyphs))
+    )
+
+
+def scorecard_words(
+    words: Sequence[Mapping[str, object]],
+) -> list[str]:
+    """The word texts that survive the scorecard's density-word filter.
+
+    Drops sub-2-char words and long-numeric captions exactly as
+    ``_word_scores`` does, so per-word density aggregates over the same tokens
+    the scorecard scores. Styled/heavy rows (stylemap sections) are NOT handled
+    here -- see the module "Scope" note; exclude them upstream if a merchant's
+    stylemap renders sections with a different face/scale.
+    """
+    out = []
+    for w in words:
+        text = str(w.get("text") or "").strip()
+        if len(text.replace(" ", "")) < 2:
+            continue
+        if is_long_numeric_caption(text):
+            continue
+        out.append(text)
+    return out
+
+
+def word_ink_densities(
+    font: "BitmapFont",
+    words: Sequence[str],
+    cap_px: int,
+    thin: float,
+    condense: float = 1.0,
+) -> list[float]:
+    """Per-word tight-ink density for each of ``words`` (atlas-covered glyphs).
+
+    One density per word (ink / drawn-glyph area within that word), so a single
+    long dense token cannot dominate the aggregate the way a char-frequency
+    corpus mean lets it. Words with no atlas glyphs are skipped.
+    """
+    out = []
+    for text in words:
+        d = text_ink_density(font, text, cap_px, thin, condense)
+        if d is not None:
+            out.append(d)
+    return out
+
+
+def median_word_density(
+    font: "BitmapFont",
+    words: Sequence[str],
+    cap_px: int,
+    thin: float,
+    condense: float = 1.0,
+) -> float | None:
+    """Median of per-word densities -- the scorecard's aggregation protocol.
+
+    ``ink_calibration.measure_density_ratio`` takes ``median`` over per-word
+    ratios; this mirrors that on the synth side so the cheap signal moves with
+    ``density_ratio_median`` rather than an area-weighted corpus mean. ``None``
+    if no word carries atlas glyphs.
+    """
+    ds = word_ink_densities(font, words, cap_px, thin, condense)
+    if not ds:
+        return None
+    ds.sort()
+    n = len(ds)
+    if n % 2:
+        return ds[n // 2]
+    return (ds[n // 2 - 1] + ds[n // 2]) / 2.0
 
 
 def thin_response_curve(
@@ -209,6 +327,39 @@ def solve_thin_for_density(
     return best
 
 
+def solve_thin_for_word_density(
+    font: "BitmapFont",
+    words: Sequence[str],
+    cap_px: int,
+    target_density: float,
+    *,
+    condense: float = 1.0,
+    thins: Sequence[float] = _SOLVE_THINS,
+) -> tuple[float, float]:
+    """``solve_thin_for_density`` over the median-of-per-word protocol.
+
+    Same plateau-argmin search, but the measured signal is
+    ``median_word_density`` (the scorecard's aggregation) rather than a single
+    char-weighted corpus mean -- so the solved thin tracks
+    ``density_ratio_median`` and is not skewed by one long dense token. Pass
+    ``scorecard_words(words)`` so the corpus matches the tokens the scorecard
+    scores. Raises ValueError if no word carries atlas glyphs.
+    """
+    best: tuple[float, float] | None = None
+    for t in sorted(set(float(x) for x in thins)):
+        d = median_word_density(font, words, cap_px, t, condense)
+        if d is None:
+            continue
+        if (
+            best is None
+            or abs(d - target_density) < abs(best[1] - target_density) - 1e-12
+        ):
+            best = (t, d)
+    if best is None:
+        raise ValueError("no atlas glyphs in words; cannot measure density")
+    return best
+
+
 # --------------------------------------------------------------------------
 # Cap height: the h_ratio knob (ocr_cap_height_ratio), derived not eyeballed.
 #
@@ -251,6 +402,9 @@ def solve_cap_ratio(
     thin: float = 0.0,
     *,
     probe_cap_px: int | None = None,
+    font_px: float | None = None,
+    bitmap_cap_ratio: float | None = None,
+    max_font_px: float | None = None,
 ) -> tuple[float, float]:
     """Derive ocr_cap_height_ratio so the synth cap height matches the real scan.
 
@@ -263,7 +417,17 @@ def solve_cap_ratio(
     fixes the slope: solve for the cap_px whose synth cap height equals the real
     cap height, then ``ratio = cap_px / median_ocr_word_height``. Returns
     ``(ratio, projected_h_ratio)`` where projected_h_ratio is the synth/real
-    height ratio at the (clamped) returned ratio -- 1.0 when unclamped.
+    height ratio the RENDERER will actually produce at the returned ratio --
+    1.0 when nothing binds.
+
+    The renderer does more than clamp the ratio (receipt_renderer.py
+    _derive_bitmap_metrics): it rounds ``measured_cap = round(median * ratio)``,
+    floors it at ``round(base_cap * 0.9)`` where ``base_cap = round(font_px *
+    bitmap_cap_ratio)`` (binds for small text), and caps it at ``max_font_px``
+    (binds for large text). Pass ``font_px``/``bitmap_cap_ratio``/``max_font_px``
+    to project through that exact cap_px so we don't advertise an h_ratio the
+    renderer can't reach when a floor/ceiling binds; omit them to project the
+    unclamped linear cap_px (rounding still applied).
     """
     probe = probe_cap_px or max(6, int(round(font.cap_h)))
     synth_at_probe = cap_glyph_height(font, probe, thin)
@@ -276,8 +440,13 @@ def solve_cap_ratio(
     target_cap_px = real_cap_height_px / slope
     ratio = target_cap_px / median_ocr_word_height_px
     clamped = max(CAP_RATIO_MIN, min(CAP_RATIO_MAX, ratio))
-    # projected h_ratio at the clamped ratio (1.0 if the solve wasn't clamped)
-    achieved_cap_px = clamped * median_ocr_word_height_px
-    projected_synth = slope * achieved_cap_px
+    # Reproduce the renderer's cap_px so the projection matches what it stamps.
+    cap_px = int(round(clamped * median_ocr_word_height_px))
+    if font_px is not None and bitmap_cap_ratio is not None:
+        base_cap = max(6, int(round(float(font_px) * float(bitmap_cap_ratio))))
+        cap_px = max(int(round(base_cap * 0.9)), cap_px)  # small-text floor
+    if max_font_px is not None:
+        cap_px = min(max(6, int(max_font_px)), cap_px)  # large-text ceiling
+    projected_synth = slope * cap_px
     projected_h_ratio = projected_synth / real_cap_height_px
     return clamped, projected_h_ratio

--- a/tools/glyph-studio/py/glyphstudio/calibrate.py
+++ b/tools/glyph-studio/py/glyphstudio/calibrate.py
@@ -27,7 +27,6 @@ from typing import TYPE_CHECKING, Mapping, Sequence
 
 import numpy as np
 from PIL import Image
-
 from receipt_agent.agents.label_evaluator.rendering.bitmap_font import (
     preserve_top_arc,
     thin_ink_mask,
@@ -52,13 +51,21 @@ CAP_RATIO_MAX = 0.95
 
 
 def _rendered_glyph(
-    font: "BitmapFont", ch: str, cap_px: int, thin: float
+    font: "BitmapFont",
+    ch: str,
+    cap_px: int,
+    thin: float,
+    condense: float = 1.0,
 ) -> np.ndarray | None:
     """The eroded ink mask for one glyph at the EXACT pixels the renderer stamps.
 
     Mirrors ``BitmapFont.glyph``: NEAREST scale to ``cap_px`` first, then
     ``thin_ink_mask`` -- the ordering matters, since erosion works on rendered-
-    size edges, not atlas-resolution edges.
+    size edges, not atlas-resolution edges. When ``condense < 1`` and the
+    merchant enables ``condense_glyphs`` (e.g. In-N-Out at 0.7), the renderer
+    resizes the thinned mask again along x before pasting (receipt_grid.py
+    draw_token_chars / draw_text_run); we replicate that so the measured density
+    matches the pixels actually stamped, not the un-condensed mask.
     """
     g = font.glyphs.get(ch)
     if g is None:
@@ -70,32 +77,66 @@ def _rendered_glyph(
         (w, h), Image.NEAREST
     )
     im = thin_ink_mask(im, thin, preserve_top=preserve_top_arc(ch))
+    if condense < 0.999:
+        im = im.resize(
+            (max(1, int(round(im.width * condense))), im.height),
+            Image.NEAREST,
+        )
     return np.asarray(im) > 0
 
 
 def _rendered_glyph_ink(
-    font: "BitmapFont", ch: str, cap_px: int, thin: float
+    font: "BitmapFont",
+    ch: str,
+    cap_px: int,
+    thin: float,
+    condense: float = 1.0,
 ) -> tuple[int, int] | None:
     """(ink_px, total_px) for one glyph at the rendered pixels."""
-    arr = _rendered_glyph(font, ch, cap_px, thin)
+    arr = _rendered_glyph(font, ch, cap_px, thin, condense)
     if arr is None:
         return None
     return int(arr.sum()), int(arr.size)
 
 
+def text_glyph_coverage(font: "BitmapFont", text: str) -> float:
+    """Fraction of ``text``'s drawn chars present in the atlas (1.0 = full).
+
+    The renderer stamps a TTF fallback for atlas misses rather than dropping
+    them (receipt_grid.py draw_token_chars/draw_text_run), so a measurer that
+    ignores misses is only unbiased at full coverage. In practice the publish
+    gate requires 94/94 coverage, so calibration runs on complete fonts -- this
+    lets a caller assert that rather than assume it.
+    """
+    chars = [c for c in text if not c.isspace()]
+    if not chars:
+        return 1.0
+    present = sum(1 for c in chars if c in font.glyphs)
+    return present / len(chars)
+
+
 def text_ink_density(
-    font: "BitmapFont", text: str, cap_px: int, thin: float
+    font: "BitmapFont",
+    text: str,
+    cap_px: int,
+    thin: float,
+    condense: float = 1.0,
 ) -> float | None:
-    """Frequency-weighted ink fraction of ``text`` rendered at ``cap_px``/``thin``.
+    """Frequency-weighted ink fraction of ``text`` rendered at cap_px/thin.
 
     Sums ink and area over each drawn glyph weighted by its count in ``text``
     (spaces skipped) -- the per-glyph density the renderer would stamp, before
-    the paper-texture pass. ``None`` if no glyph in ``text`` is in the atlas.
+    the paper-texture pass. ``condense`` replicates the ``condense_glyphs``
+    post-thin x-resize for merchants that enable it. ``None`` if no glyph in
+    ``text`` is in the atlas. NOTE: atlas misses are skipped, so at less than
+    full coverage this under-counts the TTF-fallback ink the renderer stamps --
+    check ``text_glyph_coverage`` (the 94/94 publish gate normally guarantees
+    it is 1.0).
     """
     counts = Counter(c for c in text if not c.isspace())
     ink = area = 0
     for ch, n in counts.items():
-        res = _rendered_glyph_ink(font, ch, cap_px, thin)
+        res = _rendered_glyph_ink(font, ch, cap_px, thin, condense)
         if res is None:
             continue
         ink += res[0] * n
@@ -115,14 +156,24 @@ def thin_response_curve(
     text: str,
     cap_px: int,
     thins: Sequence[float] = (0.0, 0.1, 0.2, 0.3, 0.4, 0.5),
+    condense: float = 1.0,
 ) -> list[tuple[float, float]]:
     """[(thin, density)] over ``thins`` -- the full response in one cheap pass."""
     out = []
     for t in thins:
-        d = text_ink_density(font, text, cap_px, t)
+        d = text_ink_density(font, text, cap_px, t, condense)
         if d is not None:
             out.append((float(t), d))
     return out
+
+
+# ``thin_ink_mask`` recomputes drops from the ORIGINAL glyph at
+# period = round(1/thin), so density is a step function of thin AND is NOT
+# guaranteed monotone across period boundaries (a period 3->2 change can re-add
+# pixels for sparse glyphs). Distinct behavior therefore lives only at the
+# period representatives; enumerate them and pick the closest, rather than
+# bisecting on a false monotonicity assumption.
+_SOLVE_THINS = (0.0,) + tuple(round(1.0 / p, 4) for p in range(2, 21))
 
 
 def solve_thin_for_density(
@@ -131,40 +182,31 @@ def solve_thin_for_density(
     cap_px: int,
     target_density: float,
     *,
-    lo: float = 0.0,
-    hi: float = SATURATION_THIN,
-    tol: float = 1e-3,
+    condense: float = 1.0,
+    thins: Sequence[float] = _SOLVE_THINS,
 ) -> tuple[float, float]:
-    """Solve for the ``thin`` whose synth density equals ``target_density``.
+    """Solve for the ``thin`` whose synth density is closest to ``target``.
 
-    Density falls monotonically in thin, so this interpolates the (cheap)
-    response curve rather than re-rendering. Returns ``(thin, achieved_density)``,
-    clamped to [lo, hi]: if even ``lo`` (no erosion) is already at/below target,
-    return ``lo`` (can't add ink); if ``hi`` (saturation) is still above target,
-    return ``hi`` (can't erode more). ``achieved_density`` lets the caller see
-    the residual when the target is unreachable.
+    Evaluates the (cheap) density at each ``thin`` -- one per distinct
+    ``thin_ink_mask`` period plateau -- and returns the ``(thin,
+    achieved_density)`` closest to ``target_density``. This makes no
+    monotonicity assumption (thinning is a non-monotone step function across
+    period boundaries), and among equally-close plateaus prefers the SMALLEST
+    thin so we never over-claim erosion. Ties on density -> least thin.
     """
-    d_lo = text_ink_density(font, text, cap_px, lo)
-    d_hi = text_ink_density(font, text, cap_px, hi)
-    if d_lo is None or d_hi is None:
-        raise ValueError("no atlas glyphs in text; cannot measure density")
-    if d_lo <= target_density:
-        return lo, d_lo
-    if d_hi >= target_density:
-        return hi, d_hi
-    for _ in range(40):
-        mid = (lo + hi) / 2.0
-        d = text_ink_density(font, text, cap_px, mid)
+    best: tuple[float, float] | None = None
+    for t in sorted(set(float(x) for x in thins)):
+        d = text_ink_density(font, text, cap_px, t, condense)
         if d is None:
-            break
-        if abs(d - target_density) <= tol:
-            return mid, d
-        if d > target_density:
-            lo = mid  # too dense -> erode more
-        else:
-            hi = mid
-    mid = (lo + hi) / 2.0
-    return mid, text_ink_density(font, text, cap_px, mid) or target_density
+            continue
+        if (
+            best is None
+            or abs(d - target_density) < abs(best[1] - target_density) - 1e-12
+        ):
+            best = (t, d)
+    if best is None:
+        raise ValueError("no atlas glyphs in text; cannot measure density")
+    return best
 
 
 # --------------------------------------------------------------------------

--- a/tools/glyph-studio/py/glyphstudio/calibrate.py
+++ b/tools/glyph-studio/py/glyphstudio/calibrate.py
@@ -1,0 +1,151 @@
+"""Cheap, render-free measurement of a bitmap font's ink response.
+
+The render-time ``bitmap_thin`` derivation (synthesis_loop/ink_calibration)
+bisects by re-rendering the WHOLE receipt 5-8 times to measure one scalar ink
+density. That is the dominant cost of calibrating -- and, when a profile leaves
+``bitmap_thin`` unpinned, of *rendering* -- most merchants (Home Depot's
+calibration render took ~10 min for exactly this reason).
+
+This module measures the same synth-side density signal directly from the atlas
+glyphs, scaled to the render cap height and eroded EXACTLY as ``BitmapFont``
+does (NEAREST scale, then ``thin_ink_mask``), weighted by how often each glyph
+appears in the receipt text. No receipt composite, no paper texture, no layout:
+a full thin response curve costs milliseconds, not minutes. It also exposes the
+erosion *saturation* -- beyond ~thin 0.4 the drop-period floors at 2 and no
+further edge pixels can be removed -- which the blind bisection wastes probes on.
+
+This is the M1 foundation of the calibration-derivation epic (DERIVATION_EPIC.md):
+a cheap measurer the mint-time solver stands on. It is deliberately dependency-
+light: only ``BitmapFont``/``thin_ink_mask`` from the renderer, so it can run
+in the studio without the full synthesis stack.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from typing import TYPE_CHECKING, Mapping, Sequence
+
+import numpy as np
+from PIL import Image
+
+from receipt_agent.agents.label_evaluator.rendering.bitmap_font import (
+    preserve_top_arc,
+    thin_ink_mask,
+)
+
+if TYPE_CHECKING:  # pragma: no cover
+    from receipt_agent.agents.label_evaluator.rendering.bitmap_font import (
+        BitmapFont,
+    )
+
+# Beyond this thin, thin_ink_mask's drop-period (round(1/thin)) floors at 2 and
+# density stops falling -- probing higher is wasted work. Kept in sync with
+# thin_ink_mask's ``amount = min(0.9, amount)`` clamp / period floor.
+SATURATION_THIN = 0.5
+
+
+def _rendered_glyph_ink(
+    font: "BitmapFont", ch: str, cap_px: int, thin: float
+) -> tuple[int, int] | None:
+    """(ink_px, total_px) for one glyph at the EXACT pixels the renderer stamps.
+
+    Mirrors ``BitmapFont.glyph``: NEAREST scale to ``cap_px`` first, then
+    ``thin_ink_mask`` -- the ordering matters, since erosion works on rendered-
+    size edges, not atlas-resolution edges.
+    """
+    g = font.glyphs.get(ch)
+    if g is None:
+        return None
+    scale = cap_px / font.cap_h
+    h = max(1, int(round(g.shape[0] * scale)))
+    w = max(1, int(round(g.shape[1] * scale)))
+    im = Image.fromarray((np.clip(g, 0, 1) * 255).astype(np.uint8)).resize(
+        (w, h), Image.NEAREST
+    )
+    im = thin_ink_mask(im, thin, preserve_top=preserve_top_arc(ch))
+    arr = np.asarray(im) > 0
+    return int(arr.sum()), int(arr.size)
+
+
+def text_ink_density(
+    font: "BitmapFont", text: str, cap_px: int, thin: float
+) -> float | None:
+    """Frequency-weighted ink fraction of ``text`` rendered at ``cap_px``/``thin``.
+
+    Sums ink and area over each drawn glyph weighted by its count in ``text``
+    (spaces skipped) -- the per-glyph density the renderer would stamp, before
+    the paper-texture pass. ``None`` if no glyph in ``text`` is in the atlas.
+    """
+    counts = Counter(c for c in text if not c.isspace())
+    ink = area = 0
+    for ch, n in counts.items():
+        res = _rendered_glyph_ink(font, ch, cap_px, thin)
+        if res is None:
+            continue
+        ink += res[0] * n
+        area += res[1] * n
+    if area == 0:
+        return None
+    return ink / area
+
+
+def corpus_text(words: Sequence[Mapping[str, object]]) -> str:
+    """Concatenate the text of OCR ``words`` (the glyph-frequency basis)."""
+    return "".join(str(w.get("text") or "") for w in words)
+
+
+def thin_response_curve(
+    font: "BitmapFont",
+    text: str,
+    cap_px: int,
+    thins: Sequence[float] = (0.0, 0.1, 0.2, 0.3, 0.4, 0.5),
+) -> list[tuple[float, float]]:
+    """[(thin, density)] over ``thins`` -- the full response in one cheap pass."""
+    out = []
+    for t in thins:
+        d = text_ink_density(font, text, cap_px, t)
+        if d is not None:
+            out.append((float(t), d))
+    return out
+
+
+def solve_thin_for_density(
+    font: "BitmapFont",
+    text: str,
+    cap_px: int,
+    target_density: float,
+    *,
+    lo: float = 0.0,
+    hi: float = SATURATION_THIN,
+    tol: float = 1e-3,
+) -> tuple[float, float]:
+    """Solve for the ``thin`` whose synth density equals ``target_density``.
+
+    Density falls monotonically in thin, so this interpolates the (cheap)
+    response curve rather than re-rendering. Returns ``(thin, achieved_density)``,
+    clamped to [lo, hi]: if even ``lo`` (no erosion) is already at/below target,
+    return ``lo`` (can't add ink); if ``hi`` (saturation) is still above target,
+    return ``hi`` (can't erode more). ``achieved_density`` lets the caller see
+    the residual when the target is unreachable.
+    """
+    d_lo = text_ink_density(font, text, cap_px, lo)
+    d_hi = text_ink_density(font, text, cap_px, hi)
+    if d_lo is None or d_hi is None:
+        raise ValueError("no atlas glyphs in text; cannot measure density")
+    if d_lo <= target_density:
+        return lo, d_lo
+    if d_hi >= target_density:
+        return hi, d_hi
+    for _ in range(40):
+        mid = (lo + hi) / 2.0
+        d = text_ink_density(font, text, cap_px, mid)
+        if d is None:
+            break
+        if abs(d - target_density) <= tol:
+            return mid, d
+        if d > target_density:
+            lo = mid  # too dense -> erode more
+        else:
+            hi = mid
+    mid = (lo + hi) / 2.0
+    return mid, text_ink_density(font, text, cap_px, mid) or target_density

--- a/tools/glyph-studio/py/glyphstudio/validate.py
+++ b/tools/glyph-studio/py/glyphstudio/validate.py
@@ -1,0 +1,178 @@
+"""Render-free validation of the calibrate measurer's assumptions on real atlases.
+
+M1/M2 (``glyphstudio.calibrate``) rest on three structural claims about how a
+real atlas responds to the render knobs. This harness checks them on any real
+``.glyphs.npz`` WITHOUT a receipt render -- so the cheap measurer's premises can
+be confirmed on the shipped merchant fonts, and a merchant whose response
+violates them (e.g. an atlas too heavy to erode into range) is flagged before it
+is calibrated:
+
+1. **Erosion saturates.** Density stops falling by ~thin 0.4-0.5 because
+   ``thin_ink_mask``'s drop-period floors at 2. The render-time bisection probes
+   up to 0.6 blindly; if the cheap curve is already flat there, those probes are
+   wasted -- and a merchant pinned AT the ceiling (Wild Fork 0.6) is railed, not
+   optimal.
+2. **Monotonicity.** Density is non-increasing in ``thin`` (erosion) and
+   non-decreasing in ``weight_iters`` (dilation) -- the property the joint solver
+   relies on to pick a weight then fine-tune thin.
+3. **Cap-height linearity.** Rendered cap height is ~linear in ``cap_px`` (the
+   M2 two-point-fit premise): doubling cap_px ~doubles the cap glyph height.
+
+This is the M1/M2 validation milestone's render-free half. The other half --
+absolute agreement between a cheap solve and a real render -- necessarily needs
+the render path and is measured against the scorecard (see calibrate's "Scope"
+note). Run: ``python -m glyphstudio.validate <atlas.npz> [--cap-px N]``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from typing import Sequence
+
+from . import calibrate
+
+
+def atlas_corpus_text(font) -> str:
+    """A merchant-representative corpus: each atlas glyph once.
+
+    Real receipt words aren't always on hand at validation time, and the claims
+    checked here (saturation, monotonicity, linearity) are about the density
+    *shape*, which is robust to the exact glyph mix. Using every atlas glyph
+    once gives a stable, coverage-complete corpus. Spaces are skipped.
+    """
+    return "".join(c for c in sorted(font.glyphs) if not c.isspace())
+
+
+def saturation_thin(
+    curve: Sequence[tuple[float, float]], tol: float = 1e-3
+) -> float:
+    """Smallest thin at/after which density is flat within ``tol`` to the end.
+
+    ``curve`` is ``[(thin, density)]`` sorted by thin. Returns the thin where
+    erosion stops mattering (the plateau the render-time bisection should stop
+    at); the last thin if it never flattens.
+    """
+    pts = sorted(curve)
+    for i in range(len(pts)):
+        base = pts[i][1]
+        if all(abs(pts[j][1] - base) <= tol for j in range(i, len(pts))):
+            return pts[i][0]
+    return pts[-1][0] if pts else 0.0
+
+
+def validate_atlas(
+    font,
+    cap_px: int = 40,
+    *,
+    text: str | None = None,
+    thins: Sequence[float] = tuple(round(0.05 * k, 2) for k in range(13)),
+    max_weight_iters: int = 4,
+    linear_tol: float = 0.06,
+    sat_tol: float = 1e-3,
+) -> dict:
+    """Check the three M1/M2 structural claims on ``font``; return a report dict.
+
+    ``thins`` sweeps 0.0..0.6 by default (the render-time bisection's range).
+    ``linear_tol`` is the allowed relative error on the cap-height doubling test.
+    The report's ``ok`` is True iff all three claims hold.
+    """
+    text = text if text is not None else atlas_corpus_text(font)
+    coverage = calibrate.text_glyph_coverage(font, text)
+
+    curve = calibrate.thin_response_curve(font, text, cap_px, thins=thins)
+    dens = [d for _, d in curve]
+    monotone_thin = all(b <= a + 1e-9 for a, b in zip(dens, dens[1:]))
+    eroded = bool(dens) and dens[-1] < dens[0] - 1e-9
+    sat = saturation_thin(curve, tol=sat_tol)
+
+    wdens = []
+    for k in range(max_weight_iters + 1):
+        d = calibrate.text_ink_density(font, text, cap_px, 0.0, weight_iters=k)
+        if d is not None:
+            wdens.append(d)
+    monotone_weight = all(b >= a - 1e-9 for a, b in zip(wdens, wdens[1:]))
+    thickened = bool(wdens) and wdens[-1] > wdens[0] + 1e-9
+
+    h1 = calibrate.cap_glyph_height(font, cap_px, 0.0)
+    h2 = calibrate.cap_glyph_height(font, 2 * cap_px, 0.0)
+    cap_linear = (
+        h1 is not None
+        and h2 is not None
+        and h1 > 0
+        and abs(h2 - 2 * h1) <= linear_tol * (2 * h1)
+    )
+
+    ok = bool(
+        monotone_thin
+        and monotone_weight
+        and eroded
+        and thickened
+        and cap_linear
+    )
+    return {
+        "cap_px": cap_px,
+        "coverage": coverage,
+        "glyph_count": len(font.glyphs),
+        "density_at_0": dens[0] if dens else None,
+        "density_at_max_thin": dens[-1] if dens else None,
+        "saturation_thin": sat,
+        "monotone_thin": monotone_thin,
+        "eroded": eroded,
+        "monotone_weight": monotone_weight,
+        "thickened": thickened,
+        "cap_height_px": h1,
+        "cap_height_2x": h2,
+        "cap_linear": cap_linear,
+        "thin_curve": curve,
+        "ok": ok,
+    }
+
+
+def _load_font(npz_path: str):
+    # calibrate._renderer inserts the sibling paths; reuse it, then import
+    # BitmapFont the same way so validation needs no extra PYTHONPATH.
+    calibrate._renderer()
+    from receipt_agent.agents.label_evaluator.rendering.bitmap_font import (
+        BitmapFont,
+    )
+
+    return BitmapFont(npz_path)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("atlas", help="path to a {name}.glyphs.npz atlas")
+    ap.add_argument("--cap-px", type=int, default=40)
+    ap.add_argument(
+        "--json", action="store_true", help="emit the full report as JSON"
+    )
+    args = ap.parse_args(argv)
+
+    font = _load_font(args.atlas)
+    report = validate_atlas(font, args.cap_px)
+    if args.json:
+        print(json.dumps(report, indent=2))
+    else:
+        print(f"atlas: {args.atlas}  ({report['glyph_count']} glyphs)")
+        print(f"  coverage           {report['coverage']:.3f}")
+        print(
+            f"  density 0 -> max    {report['density_at_0']:.3f} -> "
+            f"{report['density_at_max_thin']:.3f}"
+        )
+        print(
+            f"  saturation thin     {report['saturation_thin']:.2f}  "
+            f"(erosion flat beyond)"
+        )
+        print(f"  monotone (thin)     {report['monotone_thin']}")
+        print(f"  monotone (weight)   {report['monotone_weight']}")
+        print(
+            f"  cap linear          {report['cap_linear']}  "
+            f"({report['cap_height_px']} -> {report['cap_height_2x']} px)"
+        )
+        print(f"  OK                  {report['ok']}")
+    return 0 if report["ok"] else 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tools/glyph-studio/py/tests/test_calibrate.py
+++ b/tools/glyph-studio/py/tests/test_calibrate.py
@@ -121,6 +121,59 @@ def test_corpus_text_concatenates():
     assert calibrate.corpus_text(words) == "AB0"
 
 
+# --- scorecard-faithful word filtering + per-word aggregation ---
+
+
+def test_scorecard_words_drops_short_and_numeric_captions():
+    words = [
+        {"text": "AB"},  # kept
+        {"text": "A"},  # dropped: < 2 non-space chars
+        {"text": "  "},  # dropped: empty after strip
+        {"text": "0123456789012345"},  # dropped: 16-digit numeric caption
+        {"text": "AB0"},  # kept (only 1 digit)
+    ]
+    assert calibrate.scorecard_words(words) == ["AB", "AB0"]
+
+
+def test_is_long_numeric_caption():
+    assert calibrate.is_long_numeric_caption("01234567890123")  # 14 digits
+    assert calibrate.is_long_numeric_caption("X0123456789 0123X")  # 14d/16 ok
+    assert not calibrate.is_long_numeric_caption("0123456789")  # only 10
+    assert not calibrate.is_long_numeric_caption("TOTAL 12.99")  # letters
+    assert not calibrate.is_long_numeric_caption(
+        "(012) 345-678901 [23]"
+    )  # 14 digits but only 14/19 < 0.75 non-space -> not a caption
+
+
+def test_median_word_density_is_not_dominated_by_one_long_token(font):
+    # A char-weighted corpus mean lets one long dense token dominate; the
+    # per-word median does not. 'A' (solid) is dense, '0' (sparse cross) light.
+    words = ["AAAAAAAAAA", "0", "0"]  # one long dense word, two light words
+    corpus = calibrate.text_ink_density(font, "".join(words), 40, 0.0)
+    med = calibrate.median_word_density(font, words, 40, 0.0)
+    # median sits on a light word; corpus mean is pulled up by the long 'A' run.
+    assert med < corpus
+
+
+def test_median_word_density_none_without_atlas_glyphs(font):
+    assert calibrate.median_word_density(font, ["zz", "yy"], 40, 0.0) is None
+
+
+def test_solve_thin_for_word_density_recovers_target(font):
+    words = ["AB0", "AA0"]
+    target = calibrate.median_word_density(font, words, 40, 0.2)
+    thin, achieved = calibrate.solve_thin_for_word_density(
+        font, words, 40, target
+    )
+    assert 0.0 <= thin <= calibrate.SATURATION_THIN
+    assert achieved == pytest.approx(target, abs=1e-6)
+
+
+def test_solve_thin_for_word_density_rejects_empty(font):
+    with pytest.raises(ValueError):
+        calibrate.solve_thin_for_word_density(font, ["zz"], 40, 0.2)
+
+
 # --- M2: cap height ---
 
 
@@ -166,3 +219,30 @@ def test_solve_cap_ratio_clamps_to_band(font):
 def test_solve_cap_ratio_rejects_bad_inputs(font):
     with pytest.raises(ValueError):
         calibrate.solve_cap_ratio(font, 30.0, 0.0)
+
+
+def test_solve_cap_ratio_small_text_floor_binds(font):
+    # slope=1; real cap 30, ocr word box 40 -> unclamped cap_px 30. A large
+    # base_cap floors cap_px above 30, so the renderer stamps taller than the
+    # linear solve promised and projected h_ratio rises above 1.0.
+    _, h_ratio = calibrate.solve_cap_ratio(
+        font,
+        real_cap_height_px=30.0,
+        median_ocr_word_height_px=40.0,
+        font_px=50.0,
+        bitmap_cap_ratio=0.8,  # base_cap=40 -> floor round(40*0.9)=36 > 30
+    )
+    # floored cap_px 36 -> synth 36 vs real 30
+    assert h_ratio == pytest.approx(36.0 / 30.0, abs=1e-3)
+
+
+def test_solve_cap_ratio_max_font_ceiling_binds(font):
+    # Unclamped cap_px 30, but max_font_px caps it at 24 -> renderer stamps
+    # shorter, projected h_ratio drops below 1.0.
+    _, h_ratio = calibrate.solve_cap_ratio(
+        font,
+        real_cap_height_px=30.0,
+        median_ocr_word_height_px=40.0,
+        max_font_px=24.0,
+    )
+    assert h_ratio == pytest.approx(24.0 / 30.0, abs=1e-3)

--- a/tools/glyph-studio/py/tests/test_calibrate.py
+++ b/tools/glyph-studio/py/tests/test_calibrate.py
@@ -174,6 +174,105 @@ def test_solve_thin_for_word_density_rejects_empty(font):
         calibrate.solve_thin_for_word_density(font, ["zz"], 40, 0.2)
 
 
+# --- M3: weight (stroke dilation) + joint weight/thin solve ---
+
+
+def test_dilate_ink_grows_one_pixel_to_eight_neighbours():
+    m = np.zeros((5, 5), bool)
+    m[2, 2] = True
+    d1 = calibrate.dilate_ink(m, 1)
+    assert d1.sum() == 9  # center + 8 neighbours
+    assert calibrate.dilate_ink(m, 0).sum() == 1  # identity
+    assert calibrate.dilate_ink(m, 2).sum() == 25  # full 5x5
+
+
+def test_weight_iters_raises_density(font):
+    # The ring 'B' and sparse '0' have room to thicken; more weight -> more ink.
+    d0 = calibrate.text_ink_density(font, "B0", 40, 0.0, weight_iters=0)
+    d1 = calibrate.text_ink_density(font, "B0", 40, 0.0, weight_iters=1)
+    d2 = calibrate.text_ink_density(font, "B0", 40, 0.0, weight_iters=2)
+    assert d1 > d0
+    assert d2 >= d1
+
+
+def test_weight_iters_zero_is_unchanged(font):
+    # Default weight_iters=0 must reproduce the pre-M3 measurement exactly.
+    plain = calibrate.text_ink_density(font, "B0", 40, 0.2)
+    zero = calibrate.text_ink_density(font, "B0", 40, 0.2, weight_iters=0)
+    assert plain == zero
+
+
+def _synthetic_density():
+    # density_at(w, thin) = 0.30 + 0.10*w - 0.50*thin: monotone up in weight,
+    # down in thin -- the shape the joint solver assumes.
+    return lambda w, thin: 0.30 + 0.10 * w - 0.50 * thin
+
+
+def test_solve_weight_and_thin_picks_least_weight_then_fine_tunes():
+    dens = _synthetic_density()
+    # un-eroded d0: w0=.30 w1=.40 w2=.50 w3=.60. target .45 reachable by w2,w3;
+    # least is w2, then erode: t=0.1 gives .45 exactly.
+    w, thin, ach = calibrate.solve_weight_and_thin(
+        dens,
+        0.45,
+        weight_iters_options=(0, 1, 2, 3),
+        thins=(0.0, 0.1, 0.2, 0.3),
+    )
+    assert w == 2
+    assert thin == pytest.approx(0.1)
+    assert ach == pytest.approx(0.45)
+
+
+def test_solve_weight_and_thin_target_too_dense_uses_heaviest():
+    dens = _synthetic_density()
+    # target .99 exceeds every un-eroded density -> heaviest weight, least thin.
+    w, thin, ach = calibrate.solve_weight_and_thin(
+        dens,
+        0.99,
+        weight_iters_options=(0, 1, 2, 3),
+        thins=(0.0, 0.1, 0.2, 0.3),
+    )
+    assert w == 3
+    assert thin == pytest.approx(0.0)
+    assert ach == pytest.approx(0.60)
+
+
+def test_solve_weight_and_thin_lightest_already_dense_erodes_down():
+    dens = _synthetic_density()
+    # target .10 is below every un-eroded density -> least weight w0, erode to
+    # the closest achievable (.15 at t=0.3 on this grid).
+    w, thin, ach = calibrate.solve_weight_and_thin(
+        dens,
+        0.10,
+        weight_iters_options=(0, 1, 2, 3),
+        thins=(0.0, 0.1, 0.2, 0.3),
+    )
+    assert w == 0
+    assert thin == pytest.approx(0.3)
+    assert ach == pytest.approx(0.15)
+
+
+def test_solve_weight_and_thin_raises_without_measurable_density():
+    with pytest.raises(ValueError):
+        calibrate.solve_weight_and_thin(lambda w, t: None, 0.3)
+
+
+def test_weight_density_fn_solves_toward_target(font):
+    words = ["B0", "AB0"]
+    density_at = calibrate.weight_density_fn(font, words, 40)
+    # A target between the un-eroded density and a lightly-eroded one is
+    # reachable; the solve should land close and return valid knobs.
+    target = calibrate.median_word_density(
+        font, words, 40, 0.1, weight_iters=1
+    )
+    w, thin, ach = calibrate.solve_weight_and_thin(
+        density_at, target, weight_iters_options=(0, 1, 2)
+    )
+    assert w in (0, 1, 2)
+    assert 0.0 <= thin <= calibrate.SATURATION_THIN
+    assert ach == pytest.approx(target, abs=0.05)
+
+
 # --- M2: cap height ---
 
 

--- a/tools/glyph-studio/py/tests/test_calibrate.py
+++ b/tools/glyph-studio/py/tests/test_calibrate.py
@@ -89,6 +89,21 @@ def test_solve_is_robust_to_non_monotone_plateaus(font):
         )
 
 
+def test_effective_condense_gates_on_flag():
+    # condense_glyphs OFF -> mask not narrowed (factor 1.0), even if condense<1;
+    # ON -> the profile's condense passes through.
+    assert calibrate.effective_condense(0.7, False) == 1.0
+    assert calibrate.effective_condense(0.7, True) == pytest.approx(0.7)
+    assert calibrate.effective_condense(1.0, True) == pytest.approx(1.0)
+
+
+def test_solve_thins_reach_slight_erosion():
+    # The plateau grid must reach well below 0.05 so a merchant needing a hair
+    # of erosion isn't forced onto 0.0 or a coarse plateau.
+    assert min(t for t in calibrate._SOLVE_THINS if t > 0) < 0.02
+    assert 0.0 in calibrate._SOLVE_THINS
+
+
 def test_condense_narrows_the_measured_mask(font):
     # condense_glyphs resizes the mask narrower along x (NEAREST) after
     # thinning, exactly as the renderer does before pasting -- the measurer

--- a/tools/glyph-studio/py/tests/test_calibrate.py
+++ b/tools/glyph-studio/py/tests/test_calibrate.py
@@ -360,3 +360,68 @@ def test_solve_cap_ratio_max_font_ceiling_binds(font):
         max_font_px=24.0,
     )
     assert h_ratio == pytest.approx(24.0 / 30.0, abs=1e-3)
+
+
+def test_renderer_cap_px_floor_and_ceiling():
+    # round(0.75*40)=30 unclamped.
+    assert calibrate.renderer_cap_px(0.75, 40.0) == 30
+    # floor: base_cap round(50*0.8)=40 -> round(40*0.9)=36 > 30
+    assert (
+        calibrate.renderer_cap_px(
+            0.75, 40.0, font_px=50.0, bitmap_cap_ratio=0.8
+        )
+        == 36
+    )
+    # ceiling: max_font_px 24 < 30
+    assert calibrate.renderer_cap_px(0.75, 40.0, max_font_px=24.0) == 24
+
+
+# --- M4: calibrate_merchant (one-call orchestration) ---
+
+
+def test_calibrate_merchant_emits_full_block(font):
+    # Words built only from atlas glyphs (A,B,0) so coverage is 1.0; plus a
+    # sub-2-char word and a numeric caption the scorecard filter must drop.
+    receipts = [
+        {"words": [{"text": "AB0"}, {"text": "BA"}, {"text": "A"}]},
+        {"words": [{"text": "0123456789012345"}, {"text": "AAB0"}]},
+    ]
+    words = calibrate.scorecard_words(
+        [w for r in receipts for w in r["words"]]
+    )
+    # Target the un-weighted un-eroded density -> reachable at weight 0.
+    target = calibrate.median_word_density(font, words, 30, 0.0)
+    out = calibrate.calibrate_merchant(
+        font,
+        receipts,
+        real_cap_height_px=30.0,
+        median_ocr_word_height_px=40.0,
+        target_density=target,
+    )
+    assert set(out) >= {
+        "ocr_cap_height_ratio",
+        "weight_iters",
+        "bitmap_thin",
+        "cap_px",
+        "projected",
+        "coverage",
+        "provenance",
+    }
+    assert out["ocr_cap_height_ratio"] == pytest.approx(0.75, abs=1e-3)
+    assert out["cap_px"] == 30  # round(0.75 * 40)
+    assert out["coverage"] == 1.0
+    assert 0.0 <= out["bitmap_thin"] <= calibrate.SATURATION_THIN
+    assert out["weight_iters"] == 0  # target = un-weighted density
+    assert out["projected"]["density"] == pytest.approx(target, abs=1e-6)
+    assert out["provenance"].endswith("2 receipts")
+
+
+def test_calibrate_merchant_rejects_empty_corpus(font):
+    with pytest.raises(ValueError):
+        calibrate.calibrate_merchant(
+            font,
+            [{"words": [{"text": "A"}]}],  # only sub-2-char -> filtered out
+            real_cap_height_px=30.0,
+            median_ocr_word_height_px=40.0,
+            target_density=0.3,
+        )

--- a/tools/glyph-studio/py/tests/test_calibrate.py
+++ b/tools/glyph-studio/py/tests/test_calibrate.py
@@ -6,6 +6,7 @@ density math is checked against glyphs whose ink is known by construction.
 
 import numpy as np
 import pytest
+
 from glyphstudio import calibrate
 
 
@@ -49,34 +50,59 @@ def test_saturation_flat_beyond_bound(font):
     assert d_sat == pytest.approx(d_beyond, abs=1e-9)
 
 
-def test_solve_recovers_on_curve_target(font):
-    # A density achievable mid-curve must be solved to within tol.
-    target = calibrate.text_ink_density(font, "AB0", 40, 0.22)
-    thin, achieved = calibrate.solve_thin_for_density(
-        font, "AB0", 40, target, tol=1e-3
-    )
+def test_solve_recovers_an_achievable_target(font):
+    # A density that a plateau achieves must be recovered exactly (argmin over
+    # period plateaus; the returned thin lands on that plateau).
+    target = calibrate.text_ink_density(font, "AB0", 40, 0.2)
+    thin, achieved = calibrate.solve_thin_for_density(font, "AB0", 40, target)
     assert 0.0 <= thin <= calibrate.SATURATION_THIN
-    assert achieved == pytest.approx(target, abs=2e-3)
+    assert achieved == pytest.approx(target, abs=1e-6)
 
 
-def test_solve_clamps_low(font):
-    # Target denser than the un-eroded font -> can't add ink -> return lo.
+def test_solve_denser_than_font_returns_least_erosion(font):
+    # Target denser than the un-eroded font -> closest is thin 0.0.
     d0 = calibrate.text_ink_density(font, "AB", 40, 0.0)
     thin, achieved = calibrate.solve_thin_for_density(font, "AB", 40, d0 + 0.5)
     assert thin == 0.0
     assert achieved == pytest.approx(d0)
 
 
-def test_solve_clamps_high(font):
-    # Target sparser than max erosion -> can't erode more -> return hi.
-    d_hi = calibrate.text_ink_density(
-        font, "AB", 40, calibrate.SATURATION_THIN
+def test_solve_sparser_than_font_returns_max_erosion(font):
+    # Target sparser than max erosion -> closest is the most-eroded plateau.
+    d_max = min(d for _, d in calibrate.thin_response_curve(font, "AB", 40))
+    thin, achieved = calibrate.solve_thin_for_density(font, "AB", 40, 0.0)
+    assert achieved == pytest.approx(d_max)
+    assert thin >= 0.4  # a period-2 plateau (saturated erosion)
+
+
+def test_solve_is_robust_to_non_monotone_plateaus(font):
+    # Any target -> the returned density is genuinely the closest achievable
+    # over the enumerated plateaus (no monotonicity assumption).
+    curve = calibrate.thin_response_curve(
+        font, "AB0", 40, thins=calibrate._SOLVE_THINS
     )
-    thin, achieved = calibrate.solve_thin_for_density(
-        font, "AB", 40, d_hi - 0.5
-    )
-    assert thin == calibrate.SATURATION_THIN
-    assert achieved == pytest.approx(d_hi)
+    achievable = [d for _, d in curve]
+    for target in (0.15, 0.3, 0.45):
+        _, achieved = calibrate.solve_thin_for_density(font, "AB0", 40, target)
+        assert achieved == pytest.approx(
+            min(achievable, key=lambda d: abs(d - target))
+        )
+
+
+def test_condense_narrows_the_measured_mask(font):
+    # condense_glyphs resizes the mask narrower along x (NEAREST) after
+    # thinning, exactly as the renderer does before pasting -- the measurer
+    # must count those pixels, so the mask width shrinks by ~condense.
+    full = calibrate._rendered_glyph(font, "A", 40, 0.0, condense=1.0)
+    cond = calibrate._rendered_glyph(font, "A", 40, 0.0, condense=0.7)
+    assert cond.shape[1] == max(1, round(full.shape[1] * 0.7))
+    assert cond.shape[0] == full.shape[0]  # height unchanged (x-only)
+
+
+def test_glyph_coverage(font):
+    assert calibrate.text_glyph_coverage(font, "AB0") == 1.0
+    assert calibrate.text_glyph_coverage(font, "ABz") == pytest.approx(2 / 3)
+    assert calibrate.text_glyph_coverage(font, "   ") == 1.0
 
 
 def test_frequency_weighting(font):

--- a/tools/glyph-studio/py/tests/test_calibrate.py
+++ b/tools/glyph-studio/py/tests/test_calibrate.py
@@ -93,3 +93,50 @@ def test_missing_glyphs_return_none(font):
 def test_corpus_text_concatenates():
     words = [{"text": "AB"}, {"text": "0"}, {"text": None}]
     assert calibrate.corpus_text(words) == "AB0"
+
+
+# --- M2: cap height ---
+
+
+def test_cap_glyph_height_linear_in_cap_px(font):
+    h40 = calibrate.cap_glyph_height(font, 40, 0.0)
+    h80 = calibrate.cap_glyph_height(font, 80, 0.0)
+    assert h40 is not None and h80 is not None
+    assert h80 == pytest.approx(2 * h40, rel=0.05)
+
+
+def test_cap_glyph_height_none_without_cap_refs(tmp_path):
+    from receipt_agent.agents.label_evaluator.rendering.bitmap_font import (
+        BitmapFont,
+    )
+
+    digit = np.ones((20, 20), np.uint8)
+    p = tmp_path / "digits.glyphs.npz"
+    np.savez_compressed(p, c48=digit, o48=0)  # only '0', no cap refs
+    f = BitmapFont(str(p))
+    assert calibrate.cap_glyph_height(f, 20, 0.0) is None
+
+
+def test_solve_cap_ratio_hits_unit_h_ratio_when_unclamped(font):
+    # slope=1 (40px cap glyphs, cap_h=40); real cap 30, ocr word box 40
+    # -> ratio 0.75 (in band), projected h_ratio 1.0.
+    ratio, h_ratio = calibrate.solve_cap_ratio(
+        font, real_cap_height_px=30.0, median_ocr_word_height_px=40.0
+    )
+    assert ratio == pytest.approx(0.75, abs=1e-3)
+    assert h_ratio == pytest.approx(1.0, abs=1e-3)
+
+
+def test_solve_cap_ratio_clamps_to_band(font):
+    # real cap == ocr word box -> unclamped ratio 1.0 -> clamped to 0.95,
+    # so the projected h_ratio can no longer reach 1.0.
+    ratio, h_ratio = calibrate.solve_cap_ratio(
+        font, real_cap_height_px=40.0, median_ocr_word_height_px=40.0
+    )
+    assert ratio == pytest.approx(calibrate.CAP_RATIO_MAX)
+    assert h_ratio == pytest.approx(0.95, abs=1e-3)
+
+
+def test_solve_cap_ratio_rejects_bad_inputs(font):
+    with pytest.raises(ValueError):
+        calibrate.solve_cap_ratio(font, 30.0, 0.0)

--- a/tools/glyph-studio/py/tests/test_calibrate.py
+++ b/tools/glyph-studio/py/tests/test_calibrate.py
@@ -160,6 +160,15 @@ def test_is_long_numeric_caption():
     )  # 14 digits but only 14/19 < 0.75 non-space -> not a caption
 
 
+def test_is_long_numeric_caption_matches_scorecard_space_handling():
+    # The scorecard's whitespace strip is a no-op, so it keeps internal spaces
+    # in the length/digit-ratio count. A space-heavy 14-digit token is NOT a
+    # caption there (14 digits / 20 chars < 0.75), so we must keep it too --
+    # stripping spaces would wrongly flag and drop it.
+    spaced = "12 34 56 78 90 12 34"  # 14 digits, len 20 with spaces
+    assert not calibrate.is_long_numeric_caption(spaced)
+
+
 def test_median_word_density_is_not_dominated_by_one_long_token(font):
     # A char-weighted corpus mean lets one long dense token dominate; the
     # per-word median does not. 'A' (solid) is dense, '0' (sparse cross) light.
@@ -265,6 +274,21 @@ def test_solve_weight_and_thin_lightest_already_dense_erodes_down():
     assert w == 0
     assert thin == pytest.approx(0.3)
     assert ach == pytest.approx(0.15)
+
+
+def test_solve_weight_and_thin_prefers_closest_over_least_reachable():
+    # Discrete grid where the "least weight that reaches target" (w1) can only
+    # land far, while a lighter weight just under target (w0) lands much closer.
+    # A least-reachable-then-thin strategy would pick w1; the global argmin must
+    # pick w0 as it is genuinely closest.
+    table = {(0, 0.0): 0.48, (0, 0.3): 0.20, (1, 0.0): 0.90, (1, 0.3): 0.30}
+    dens = lambda w, t: table[(w, round(t, 1))]  # noqa: E731
+    w, thin, ach = calibrate.solve_weight_and_thin(
+        dens, 0.50, weight_iters_options=(0, 1), thins=(0.0, 0.3)
+    )
+    assert w == 0
+    assert thin == pytest.approx(0.0)
+    assert ach == pytest.approx(0.48)  # |0.48-0.50| < |0.30-0.50|
 
 
 def test_solve_weight_and_thin_raises_without_measurable_density():
@@ -397,12 +421,14 @@ def test_calibrate_merchant_emits_full_block(font):
         real_cap_height_px=30.0,
         median_ocr_word_height_px=40.0,
         target_density=target,
+        min_words=3,  # tiny hermetic corpus (3 eligible words)
     )
     assert set(out) >= {
         "ocr_cap_height_ratio",
         "weight_iters",
         "bitmap_thin",
         "cap_px",
+        "measured_words",
         "projected",
         "coverage",
         "provenance",
@@ -410,6 +436,7 @@ def test_calibrate_merchant_emits_full_block(font):
     assert out["ocr_cap_height_ratio"] == pytest.approx(0.75, abs=1e-3)
     assert out["cap_px"] == 30  # round(0.75 * 40)
     assert out["coverage"] == 1.0
+    assert out["measured_words"] == 3
     assert 0.0 <= out["bitmap_thin"] <= calibrate.SATURATION_THIN
     assert out["weight_iters"] == 0  # target = un-weighted density
     assert out["projected"]["density"] == pytest.approx(target, abs=1e-6)
@@ -421,6 +448,19 @@ def test_calibrate_merchant_rejects_empty_corpus(font):
         calibrate.calibrate_merchant(
             font,
             [{"words": [{"text": "A"}]}],  # only sub-2-char -> filtered out
+            real_cap_height_px=30.0,
+            median_ocr_word_height_px=40.0,
+            target_density=0.3,
+        )
+
+
+def test_calibrate_merchant_rejects_tiny_corpus_below_min_words(font):
+    # 3 eligible words but the default min_words=15 floor refuses it.
+    receipts = [{"words": [{"text": "AB0"}, {"text": "BA"}, {"text": "AAB0"}]}]
+    with pytest.raises(ValueError, match="min_words"):
+        calibrate.calibrate_merchant(
+            font,
+            receipts,
             real_cap_height_px=30.0,
             median_ocr_word_height_px=40.0,
             target_density=0.3,

--- a/tools/glyph-studio/py/tests/test_calibrate.py
+++ b/tools/glyph-studio/py/tests/test_calibrate.py
@@ -1,0 +1,95 @@
+"""Unit tests for glyphstudio.calibrate -- the render-free ink measurer.
+
+Hermetic: builds a tiny synthetic atlas npz (no vault, no receipts) so the
+density math is checked against glyphs whose ink is known by construction.
+"""
+
+import numpy as np
+import pytest
+from glyphstudio import calibrate
+
+
+@pytest.fixture()
+def font(tmp_path):
+    """A 3-glyph atlas: a solid cap block, a ringed cap, and a sparse digit."""
+    from receipt_agent.agents.label_evaluator.rendering.bitmap_font import (
+        BitmapFont,
+    )
+
+    # 40x40 cap glyphs (cap-ref letters so cap_h resolves), 1 digit.
+    solid = np.ones((40, 40), np.uint8)  # 'A' - fully solid
+    ring = np.ones((40, 40), np.uint8)  # 'B' - hollow center
+    ring[10:30, 10:30] = 0
+    sparse = np.zeros((40, 40), np.uint8)  # '0' - thin cross
+    sparse[18:22, :] = 1
+    sparse[:, 18:22] = 1
+    arrays = {"c65": solid, "c66": ring, "c48": sparse}
+    offsets = {"o65": 0, "o66": 0, "o48": 0}
+    p = tmp_path / "syn.glyphs.npz"
+    np.savez_compressed(p, **{k: v for k, v in {**arrays, **offsets}.items()})
+    return BitmapFont(str(p))
+
+
+def test_density_monotonic_non_increasing(font):
+    curve = calibrate.thin_response_curve(
+        font, "AB0", cap_px=40, thins=(0.0, 0.1, 0.2, 0.3, 0.4, 0.5)
+    )
+    densities = [d for _, d in curve]
+    assert len(densities) == 6
+    for a, b in zip(densities, densities[1:]):
+        assert b <= a + 1e-9, f"density rose with thin: {densities}"
+    assert densities[-1] < densities[0], "erosion had no effect at all"
+
+
+def test_saturation_flat_beyond_bound(font):
+    d_sat = calibrate.text_ink_density(
+        font, "AB", 40, calibrate.SATURATION_THIN
+    )
+    d_beyond = calibrate.text_ink_density(font, "AB", 40, 0.9)
+    assert d_sat == pytest.approx(d_beyond, abs=1e-9)
+
+
+def test_solve_recovers_on_curve_target(font):
+    # A density achievable mid-curve must be solved to within tol.
+    target = calibrate.text_ink_density(font, "AB0", 40, 0.22)
+    thin, achieved = calibrate.solve_thin_for_density(
+        font, "AB0", 40, target, tol=1e-3
+    )
+    assert 0.0 <= thin <= calibrate.SATURATION_THIN
+    assert achieved == pytest.approx(target, abs=2e-3)
+
+
+def test_solve_clamps_low(font):
+    # Target denser than the un-eroded font -> can't add ink -> return lo.
+    d0 = calibrate.text_ink_density(font, "AB", 40, 0.0)
+    thin, achieved = calibrate.solve_thin_for_density(font, "AB", 40, d0 + 0.5)
+    assert thin == 0.0
+    assert achieved == pytest.approx(d0)
+
+
+def test_solve_clamps_high(font):
+    # Target sparser than max erosion -> can't erode more -> return hi.
+    d_hi = calibrate.text_ink_density(
+        font, "AB", 40, calibrate.SATURATION_THIN
+    )
+    thin, achieved = calibrate.solve_thin_for_density(
+        font, "AB", 40, d_hi - 0.5
+    )
+    assert thin == calibrate.SATURATION_THIN
+    assert achieved == pytest.approx(d_hi)
+
+
+def test_frequency_weighting(font):
+    # Mostly-solid text is denser than mostly-sparse text at the same thin.
+    dense = calibrate.text_ink_density(font, "AAAAA0", 40, 0.0)
+    sparse = calibrate.text_ink_density(font, "0000A", 40, 0.0)
+    assert dense > sparse
+
+
+def test_missing_glyphs_return_none(font):
+    assert calibrate.text_ink_density(font, "zzz", 40, 0.0) is None
+
+
+def test_corpus_text_concatenates():
+    words = [{"text": "AB"}, {"text": "0"}, {"text": None}]
+    assert calibrate.corpus_text(words) == "AB0"

--- a/tools/glyph-studio/py/tests/test_validate.py
+++ b/tools/glyph-studio/py/tests/test_validate.py
@@ -1,0 +1,64 @@
+"""Unit tests for glyphstudio.validate -- the render-free claim checker.
+
+Hermetic: reuses a tiny synthetic atlas so the saturation / monotonicity /
+linearity checks run without the vault or a receipt render.
+"""
+
+import numpy as np
+import pytest
+
+from glyphstudio import validate
+
+
+@pytest.fixture()
+def font(tmp_path):
+    """Solid cap 'A', ringed cap 'B', sparse digit '0' (all erodable)."""
+    from receipt_agent.agents.label_evaluator.rendering.bitmap_font import (
+        BitmapFont,
+    )
+
+    solid = np.ones((40, 40), np.uint8)
+    ring = np.ones((40, 40), np.uint8)
+    ring[10:30, 10:30] = 0
+    sparse = np.zeros((40, 40), np.uint8)
+    sparse[18:22, :] = 1
+    sparse[:, 18:22] = 1
+    p = tmp_path / "syn.glyphs.npz"
+    np.savez_compressed(
+        p, c65=solid, c66=ring, c48=sparse, o65=0, o66=0, o48=0
+    )
+    return BitmapFont(str(p))
+
+
+def test_atlas_corpus_text_is_every_glyph_once(font):
+    # keys are chars; sorted -> '0','A','B'
+    assert validate.atlas_corpus_text(font) == "0AB"
+
+
+def test_saturation_thin_finds_the_plateau():
+    # falls 0.5 -> 0.4 -> 0.3, then flat: saturates at thin 0.3.
+    curve = [(0.0, 0.5), (0.1, 0.4), (0.2, 0.3), (0.3, 0.3), (0.4, 0.3)]
+    assert validate.saturation_thin(curve, tol=1e-3) == 0.2
+    # never flattens -> last thin
+    falling = [(0.0, 0.5), (0.1, 0.4), (0.2, 0.3)]
+    assert validate.saturation_thin(falling) == 0.2
+
+
+def test_validate_atlas_passes_all_claims(font):
+    report = validate.validate_atlas(font, cap_px=34)
+    assert report["coverage"] == 1.0
+    assert report["monotone_thin"] is True
+    assert report["monotone_weight"] is True
+    assert report["eroded"] is True
+    assert report["thickened"] is True
+    assert report["cap_linear"] is True
+    assert report["ok"] is True
+    # cap height doubles with cap_px (M2 linearity)
+    assert report["cap_height_2x"] == pytest.approx(
+        2 * report["cap_height_px"], rel=0.06
+    )
+
+
+def test_validate_atlas_reports_saturation_within_range(font):
+    report = validate.validate_atlas(font, cap_px=34)
+    assert 0.0 <= report["saturation_thin"] <= 0.6


### PR DESCRIPTION
First execution PR for the font-calibration derivation epic (#1057). Starts with **M1**: a cheap, render-free ink-density measurer that the mint-time solver will stand on.

**Why:** the current `bitmap_thin` derivation (`ink_calibration.derive_bitmap_thin`) bisects by re-rendering the WHOLE receipt 5-8 times to find one scalar — the dominant cost of calibrating, and of *rendering* the 5 merchants that leave it unpinned (HD's calibration render was ~10 min for exactly this). This module measures the same synth-side density directly from the atlas glyphs — scaled to `cap_px` and eroded EXACTLY as `BitmapFont` does (NEAREST then `thin_ink_mask`), frequency-weighted over the receipt text. A full thin response curve is **milliseconds** vs minutes, and it exposes the erosion **saturation** (~thin 0.4, where the drop-period floors at 2) that the blind bisection wastes probes on.

`glyphstudio.calibrate`: `text_ink_density`, `thin_response_curve`, `solve_thin_for_density` (monotone solve with endpoint clamps). 8 hermetic unit tests on a synthetic atlas (monotonicity, saturation, solve recovery + clamps, frequency weighting).

Next on this branch: validate the cheap measurer against the real scorecard density on shipped merchants (fit the paper-texture factor), then the cap-height measurer (M2) and the unified `calibrate_merchant`. M0 (pin the 5 deriving merchants) is a separate parallel PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HTrJ8omKZfEHQhZVTW5qYV

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bitmap font calibration helpers for measuring glyph coverage and ink density without full renders.
  * Added solvers to tune thinness, weight, and cap-height settings toward target visual density.
  * Improved handling for word-based measurements, including filtering, frequency weighting, and numeric-caption detection.

* **Bug Fixes**
  * Better handles edge cases such as missing glyphs, empty inputs, saturation plateaus, and out-of-range calibration targets.
  * Added safeguards for clamping, flooring, and ceiling behavior in cap-height calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->