### PR TITLE
Fix two synthetic-render crashes (dash-row kwarg, non-int line_id seed)

### DIFF
--- a/receipt_agent/receipt_agent/agents/label_evaluator/rendering/receipt_renderer.py
+++ b/receipt_agent/receipt_agent/agents/label_evaluator/rendering/receipt_renderer.py
@@ -318,6 +318,7 @@ def _draw_dash_row(
     bitmap_font=None,
     cap_px=None,
     bitmap_thin: float = 0.0,
+    condense_glyphs: bool = False,
 ) -> None:
     """A thermal separator rule printed as a run of actual ``-`` glyphs.
 
@@ -325,7 +326,9 @@ def _draw_dash_row(
     character in the same monospace face as the body (dropped by OCR). Rendering
     them through :func:`draw_token_chars` -- rather than a drawn line -- gives the
     real letterform (bitmap atlas), condense, stroke and ink of the body text, so
-    the rule reads as printed dashes instead of a clean vector line."""
+    the rule reads as printed dashes instead of a clean vector line. ``condense_glyphs``
+    mirrors the body text's per-glyph x-resize so the dashes track the same width.
+    """
     start_col = int(round((x0 - spec.grid_left) / spec.cell_w))
     n = int((x1 - x0) / spec.cell_w)
     if n <= 0:
@@ -343,6 +346,7 @@ def _draw_dash_row(
         bitmap_font=bitmap_font,
         cap_px=cap_px,
         bitmap_thin=bitmap_thin,
+        condense_glyphs=condense_glyphs,
     )
 
 

--- a/scripts/render_synthetic_receipts.py
+++ b/scripts/render_synthetic_receipts.py
@@ -1132,6 +1132,7 @@ def _ensure_font_cached(filename: str, merchant: str, face: str) -> str:
         import hashlib
 
         import boto3
+
         from receipt_dynamo import DynamoClient
 
         table = os.environ.get("DYNAMODB_TABLE_NAME", "ReceiptsTable-dc5be22")
@@ -1332,8 +1333,9 @@ def resolve_bitmap_thin(
     from statistics import median
 
     from ink_calibration import derive_bitmap_thin  # noqa: E402
-    from receipt_dynamo.data.dynamo_client import DynamoClient  # noqa: E402
     from receipt_line_scorecard import _load_words_and_real  # noqa: E402
+
+    from receipt_dynamo.data.dynamo_client import DynamoClient  # noqa: E402
 
     client = DynamoClient(table_name=table, region=region)
     places, _ = client.get_receipt_places_by_merchant(merchant)
@@ -1414,14 +1416,36 @@ def _content_texture_seed(receipt: dict) -> int:
     parts = [str(receipt.get("merchant_name") or "")]
     words = receipt.get("words") or []
 
+    def _coerce_id(value):
+        # OCR ids are ints, but synthetic augmentation can carry string ids
+        # (e.g. 'header-clone-40'); keep the int fast-path byte-identical and
+        # fall back to the raw value rather than crashing on the cast.
+        try:
+            return int(value or 0)
+        except (TypeError, ValueError):
+            return value
+
     def _key(word: dict):
+        line_id = _coerce_id(word.get("line_id"))
+        word_id = _coerce_id(word.get("word_id"))
+        # ints and strings are not mutually orderable; rank ints before strings
+        # so the sort is total and deterministic across mixed id types.
         return (
-            int(word.get("line_id") or 0),
-            int(word.get("word_id") or 0),
+            (
+                (0, line_id, "")
+                if isinstance(line_id, int)
+                else (1, 0, str(line_id))
+            ),
+            (
+                (0, word_id, "")
+                if isinstance(word_id, int)
+                else (1, 0, str(word_id))
+            ),
         )
 
     for word in sorted(words, key=_key):
-        line_id, word_id = _key(word)
+        line_id = _coerce_id(word.get("line_id"))
+        word_id = _coerce_id(word.get("word_id"))
         bbox = word.get("bbox") or []
         bbox_str = ",".join(f"{float(v):.2f}" for v in bbox)
         text = word.get("text", "")


### PR DESCRIPTION
## Two real render-path crashes on `main`

Both were uncovered while deriving `bitmap_thin` for merchants whose receipts hit these paths, and both crash the render outright.

### 1. `_draw_dash_row()` unexpected keyword `condense_glyphs`
`receipt_renderer._render_grid` draws dashed section rules via `_draw_dash_row(..., condense_glyphs=config.condense_glyphs)`, but `_draw_dash_row` neither accepted nor forwarded that keyword — so every render with `dashed_separators` **and** `condense_glyphs` (e.g. **Costco**) raised `TypeError`. Fix: accept `condense_glyphs` and thread it into `draw_token_chars` (which already supports it), so the dash rule tracks the body text's per-glyph x-resize.

### 2. `int(line_id)` crash on synthetic string ids
`_content_texture_seed._key` did `int(word.get("line_id") or 0)`, which raised `ValueError: invalid literal for int() with base 10: 'header-clone-40'` on synthetic **header-clone augmentation** words (e.g. **Sprouts**). Fix: coerce ids through an int fast-path that falls back to the raw value, and rank ints before strings so the sort stays total and deterministic.

## Determinism preserved
The int-id path is **byte-identical** to before (verified via crc32), preserving the #1049 content-keyed paper-texture seed. String-id receipts now seed deterministically instead of crashing.

## Verification
- `int`-id receipts → identical crc32 seed to the previous implementation.
- string-id receipts → no longer raise; stable seed across calls.
- Both files parse; lint clean (black/isort @ line-length 79).

🤖 Generated with [Claude Code](https://claude.com/claude-code)