### PR TITLE
M0: pin bitmap_thin on 6 bitmap-font merchants (kill slow re-derive)

### DIFF
--- a/scripts/merchant_profiles.json
+++ b/scripts/merchant_profiles.json
@@ -6,6 +6,7 @@
       "_comment": "Real font extracted from the bitMatrix-C2 chart: bitMatrix-C2 body + bitMatrix-C2-heavy heading. SELF-CHECKOUT prints as a large bold heading; the grand TOTAL prints reverse-video. condense 0.93: bitMatrix's widest-letter advance reads ~6% too airy vs the real char pitch (cell aspect 0.61 vs 0.57). Header measured ~= body (uniform).",
       "section_scale": {},
       "typography": {
+        "bitmap_thin": 0.0,
         "bitmap_font": {
           "regular": "bitMatrix-C2.glyphs.npz",
           "heavy": "bitMatrix-C2-heavy.glyphs.npz"
@@ -165,6 +166,7 @@
       "_comment": "First studio-native merchant: font+logo mined entirely from its 31 receipts (no chart, no pre-existing atlas). Pointers in Dynamo (MerchantFont).",
       "logo": "vons_logo.png",
       "typography": {
+        "bitmap_thin": 0.3,
         "font": "PTMONO",
         "bitmap_font": {
           "regular": "vons.glyphs.npz",
@@ -191,6 +193,7 @@
       "_comment": "Dense natural-grocer format: the cached OCR repeats the store header/address block and interleaves department sections, so the line renderer de-dups the header and reflows lines into header/body/payment/footer order. header_markers are the non-brand header lines (address city, phone, hours); body_section_anchors mark where the item body starts.",
       "section_scale": {},
       "typography": {
+        "bitmap_thin": 0.225,
         "font": "PTMONO",
         "stylemap": "sprouts.stylemap.json",
         "bitmap_font": {
@@ -262,6 +265,7 @@
       ],
       "logo": "traderjoes_logo.png",
       "typography": {
+        "bitmap_thin": 0.0,
         "font": "PTMONO",
         "bitmap_font": {
           "regular": "traderjoes.glyphs.npz",
@@ -298,6 +302,7 @@
       ],
       "logo": "cvs_logo.png",
       "typography": {
+        "bitmap_thin": 0.15,
         "font": "PTMONO",
         "bitmap_font": {
           "regular": "cvs.glyphs.npz",
@@ -333,6 +338,7 @@
       "_comment": "Studio-minted from 12 merchant-index receipts / 11 production-loadable receipts. Mixed old/new POS structures share the same Wild Fork thermal body font; newer receipts may crop off the logo and include a footer barcode. Logo is the black/white outline WF mark derived from receipt scans, not the filled color web asset.",
       "logo": "wildfork_logo.png",
       "typography": {
+        "bitmap_thin": 0.6,
         "font": "PTMONO",
         "bitmap_font": {
           "regular": "wildfork.glyphs.npz",


### PR DESCRIPTION
## What & why

Six merchants with a bitmap font left `bitmap_thin` **unpinned**, so `resolve_bitmap_thin` re-derived it via a full-receipt render bisection **on every render** — the slow path that made Home Depot's cold render take ~10 minutes. This pins each merchant to the value its own canonical render-time derivation produces, so rendering reads a constant instead of re-solving it.

| merchant | bitmap_thin | scorecard (blockers/minors, density_ratio) |
|---|---|---|
| CVS | 0.15 | 0/3, 0.725 |
| Vons | 0.3 | 2/2, 0.875 |
| Trader Joe's | 0.0 | 0/9, 1.244 |
| Costco | 0.0 | 3/9, 1.119 |
| Sprouts | 0.225 | 2/4, 0.955 (cleanest new one, density near 1.0) |
| Wild Fork | 0.6 | 2/10, 1.479 |

## Notes

- **Additive config only** — one `"bitmap_thin"` key added to each merchant's `typography` block (6-line diff), no behavior change beyond skipping the re-derive.
- The values are the render-time derivation's **own output**; pinning only freezes it.
- **Two pins are railed at the clamp boundaries and are the least-confident:** Costco at the `0.0` floor (density_ratio 1.119 → still too dense even with zero erosion) and Wild Fork at the `0.6` ceiling (density_ratio 1.479 → ~48% denser than the real scan even at max erosion; its true optimum is beyond 0.6). These are still the **correct** pins — the derivation can't go past the clamp, and pinning only freezes what it computes — but the railing is a font-quality signal (the atlas is too heavy for those merchants), flagged for the font-quality / M5 follow-up, not a bad pin. Sprouts (0.225) is solid.
- Costco and Sprouts previously **crashed** mid-derive; their values here were obtained with the render-crash fixes in #1060. This PR is independent and merges on its own — #1060 is only needed to *render* those two, not to apply the config.
- The three already-pinned bitmap-font merchants (Target, In-N-Out, Home Depot) are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)