### PR TITLE
M5: retrofit diff + CI regression lock (calibration epic complete)

### DIFF
--- a/receipt_dynamo/tests/unit/test_merchant_profiles_contract.py
+++ b/receipt_dynamo/tests/unit/test_merchant_profiles_contract.py
@@ -1,0 +1,76 @@
+"""Regression lock for the synthetic-render merchant-profile contract.
+
+The font-calibration epic (tools/glyph-studio/DERIVATION_EPIC.md) closed with
+every bitmap-font merchant's ``bitmap_thin`` PINNED in
+``scripts/merchant_profiles.json``. An unpinned value silently reverts the
+renderer to deriving it via a full-receipt render bisection on every cold
+render (~10 min for Home Depot) — a regression that is invisible until someone
+waits on it. This contract test makes that failure loud.
+
+It lives in receipt_dynamo's suite (rather than tools/glyph-studio) because CI
+runs only the receipt_* package suites; the profile file is a repo-level render
+contract, so the test skips gracefully when the repo root is not present
+(package-only installs).
+"""
+
+import json
+import os
+
+import pytest
+
+_PROFILES_PATH = os.path.abspath(
+    os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "..",
+        "..",
+        "scripts",
+        "merchant_profiles.json",
+    )
+)
+
+pytestmark = pytest.mark.skipif(
+    not os.path.exists(_PROFILES_PATH),
+    reason="repo-level scripts/merchant_profiles.json not present "
+    "(package-only install)",
+)
+
+
+def _profiles():
+    with open(_PROFILES_PATH) as f:
+        return json.load(f)["profiles"]
+
+
+def test_profiles_json_parses_with_profiles_map():
+    profiles = _profiles()
+    assert isinstance(profiles, dict) and profiles, "profiles map missing"
+
+
+def test_every_bitmap_font_merchant_pins_bitmap_thin():
+    """No bitmap-font merchant may leave bitmap_thin unpinned (slow re-derive)."""
+    unpinned = []
+    for name, prof in _profiles().items():
+        typo = prof.get("typography", {})
+        if "bitmap_font" in typo and "bitmap_thin" not in typo:
+            unpinned.append(name)
+    assert not unpinned, (
+        f"bitmap_thin unpinned for {unpinned}: rendering will re-derive it "
+        "via full-receipt bisection on every cold render. Pin the value "
+        "(see tools/glyph-studio/DERIVATION_EPIC.md M0)."
+    )
+
+
+def test_pinned_bitmap_thin_values_are_in_range():
+    """thin_ink_mask erosion saturates by 0.4-0.5; the derive path caps at 0.6.
+
+    A pin outside [0, 0.6] is either a typo or an attempt to erode past what
+    the renderer can express (VALIDATION.md: all real atlases saturate at 0.40).
+    """
+    bad = {}
+    for name, prof in _profiles().items():
+        typo = prof.get("typography", {})
+        if "bitmap_thin" in typo:
+            thin = typo["bitmap_thin"]
+            if not isinstance(thin, (int, float)) or not 0.0 <= thin <= 0.6:
+                bad[name] = thin
+    assert not bad, f"bitmap_thin out of [0, 0.6]: {bad}"

--- a/tools/glyph-studio/DERIVATION_EPIC.md
+++ b/tools/glyph-studio/DERIVATION_EPIC.md
@@ -1,5 +1,14 @@
 # Epic: Measured font calibration (derive the render knobs, once, at mint time)
 
+> **Status: COMPLETE** (2026-07-08). M0 pins shipped (#1061 + crash fixes
+> #1060); M1-M4 solvers + `calibrate_merchant` shipped (#1059); validation in
+> VALIDATION.md (all structural claims confirmed on real atlases; the cheap
+> measurer tracks the scorecard at CV 0.37 %); M5 retrofit diff + CI regression
+> lock in RETROFIT.md and
+> `receipt_dynamo/tests/unit/test_merchant_profiles_contract.py`.
+> Derived-correction adoption (A/B-gated) and the railed/floor-bound merchants
+> carry forward into FONT_INTELLIGENCE_EPIC.md.
+
 **Thesis.** Today a merchant font is minted by measurement (glyphs, pitch,
 stylemap) but *calibrated by hand* — a human or agent eyeballs `weight`,
 `ocr_cap_height_ratio`, and `bitmap_thin` across many slow renders until the

--- a/tools/glyph-studio/RETROFIT.md
+++ b/tools/glyph-studio/RETROFIT.md
@@ -1,0 +1,70 @@
+# M5 retrofit — derived knobs vs. hand-tuned, all bitmap-font merchants
+
+Closes the calibration-derivation epic (DERIVATION_EPIC.md M5): every
+hand-tuned render knob diffed against what the v1 solvers derive, using the M0
+production scorecard measurements (plus the Home Depot re-mint verify run) as
+the real-side inputs. **Report-only:** derived corrections are NOT adopted
+here — a profile change alters production renders, so each shift goes through
+a visual A/B first (the epic's own adoption rule). The regression lock that
+ships with this report is `receipt_dynamo/tests/unit/
+test_merchant_profiles_contract.py` (CI-enforced: pins present and in range).
+
+## Cap-height ratio (`ocr_cap_height_ratio`)
+
+Cap height is linear in the ratio (validated on all six atlases,
+VALIDATION.md), so the correction is algebraic:
+`derived = hand_ratio / measured_h_ratio`, clamped to the renderer's
+[0.65, 0.95] band.
+
+| merchant | hand ratio | measured h_ratio | derived | clamped | verdict |
+|---|---|---|---|---|---|
+| CVS | 0.858 | 1.000 | 0.858 | 0.858 | **already perfect** — hand value = derived value |
+| Home Depot | 0.860 | 0.976 | 0.881 | 0.881 | minor +0.021 available |
+| Sprouts | 0.760 | 1.100 | 0.691 | 0.691 | −0.069 correction available (renders 10 % tall) |
+| Wild Fork | 0.790 | 1.074 | 0.736 | 0.736 | −0.054 correction available |
+| Vons | 0.649 | 1.296 | 0.501 | **0.650 (floor)** | **floor-bound** — see below |
+| Trader Joe's | 0.720 | 1.565 | 0.460 | **0.650 (floor)** | **floor-bound** — see below |
+| Costco | (none pinned) | 1.174 | n/a | — | renders 17 % tall with no ratio knob set; needs a pinned ratio first |
+
+**Floor-bound merchants (Vons, Trader Joe's).** Their derived ratios fall below
+the renderer's 0.65 clamp, meaning the ratio knob *cannot* fix their height —
+even at the floor they still render ~30 % / ~57 % tall. The binding constraint
+is the base-cap floor (`round(font_px x bitmap_cap_ratio x 0.9)`), exactly the
+clamp `solve_cap_ratio(font_px=..., bitmap_cap_ratio=...)` models. Fixing them
+means revisiting `bitmap_cap_ratio` / pitch-derived sizing, not the ratio —
+flagged as follow-up work, out of scope for a report.
+
+This confirms the epic's hypothesis about the hand-tuned spread: CVS's
+eyeballed value was already optimal; four others carry derivable corrections;
+two were hand-tuned against a clamp that made the knob inert (which eyeballing
+could never reveal).
+
+## bitmap_thin pins vs. erosion saturation
+
+All real atlases saturate erosion at thin **0.40** (VALIDATION.md): every
+distinct render behavior lives in [0, 0.40].
+
+| merchant | pinned thin | effective thin | note |
+|---|---|---|---|
+| CVS | 0.15 | 0.15 | interior — headroom both ways |
+| Vons | 0.30 | 0.30 | interior |
+| Trader Joe's | 0.0 | 0.0 | floor — synth already sparser than real (density_ratio 1.24 is a height artifact, see above) |
+| Costco | 0.0 | 0.0 | floor-railed: too dense at zero erosion |
+| Sprouts | 0.225 | 0.225 | interior; cheap-solve cross-check says ~0.14 is the true density optimum (VALIDATION.md) |
+| Wild Fork | 0.6 | **0.40** | ceiling-railed: 0.6 ≡ 0.4 (saturated); atlas too heavy — re-mint, don't erode |
+| Target | 0.0 | 0.0 | hand-pinned previously |
+| In-N-Out | 0.0 | 0.0 | hand-pinned previously |
+| Home Depot | 0.6 | **0.40** | same saturation note as Wild Fork |
+
+## Adoption policy
+
+1. **Nothing in this report changes a profile.** Each derived correction
+   (Sprouts, Wild Fork, Home Depot ratios; the Sprouts thin refinement) gets a
+   render A/B against its review receipt before adoption.
+2. **Floor-bound and railed merchants are font/sizing work, not knob work:**
+   Vons + Trader Joe's height (base-cap floor), Wild Fork + Costco density
+   (atlas weight). These are inputs to the font-intelligence epic
+   (FONT_INTELLIGENCE_EPIC.md), whose acceptance test is that the railed pins
+   disappear on family-fitted fonts.
+3. The CI contract test keeps the epic's M0 win locked: no bitmap-font
+   merchant can silently return to render-time derivation.


### PR DESCRIPTION
## Closes the font-calibration derivation epic

**RETROFIT.md** — every hand-tuned knob diffed against the v1 solvers (M0 scorecard measurements as real-side inputs). Report-only; adoption is A/B-gated per the epic's own rule.

| finding | merchants |
|---|---|
| hand value already optimal | CVS (0.858 = derived exactly) |
| derivable correction available | Sprouts −0.069, Wild Fork −0.054, Home Depot +0.021 |
| **floor-bound** — ratio knob inert, base-cap floor binds | Vons (derived 0.501 < 0.65 clamp), Trader Joe's (0.460) |
| ceiling-railed thin ≡ saturation 0.40 | Wild Fork, Home Depot (0.6 pins) |

The floor-bound/railed merchants carry into FONT_INTELLIGENCE_EPIC.md, whose acceptance test is that they disappear on family-fitted fonts.

**CI regression lock** — `receipt_dynamo/tests/unit/test_merchant_profiles_contract.py`: every bitmap-font merchant must pin `bitmap_thin` in [0, 0.6]. Placed in receipt_dynamo because CI runs only the `receipt_*` suites; skips gracefully on package-only installs. 3 tests, passing.

**DERIVATION_EPIC.md** → status COMPLETE with artifact pointers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added regression coverage to catch missing or out-of-range bitmap-thin settings for bitmap-font merchant profiles, helping prevent rendering regressions.
* **Tests**
  * Introduced a contract test that validates merchant profile data is present, complete, and within expected numeric limits.
* **Documentation**
  * Updated project notes with current delivery status and a new retrofit report summarizing recent solver and validation progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->