### PR TITLE
feat(mcp): PENDING support on create_word_label (font-intel M0.1)

### DIFF
--- a/infra/mcp_server_lambda/lambdas/receipt_mcp_server_server.py
+++ b/infra/mcp_server_lambda/lambdas/receipt_mcp_server_server.py
@@ -2521,13 +2521,15 @@ async def create_word_label_impl(
     """
     from datetime import datetime, timezone
 
-    from receipt_dynamo.constants import ValidationStatus
     from receipt_dynamo.entities.receipt_word_label import ReceiptWordLabel
 
     try:
         normalized_label = label.upper()
-        normalized_status = str(validation_status).upper()
-        allowed = {s.value for s in ValidationStatus}
+        # Only the four workflow statuses are valid on create; a null/omitted
+        # arg falls back to VALID. NONE is deliberately excluded so a stray
+        # null can't silently persist a non-ground-truth row.
+        normalized_status = str(validation_status or "VALID").upper()
+        allowed = {"PENDING", "VALID", "INVALID", "NEEDS_REVIEW"}
         if normalized_status not in allowed:
             return {
                 "error": (

--- a/infra/mcp_server_lambda/lambdas/receipt_mcp_server_server.py
+++ b/infra/mcp_server_lambda/lambdas/receipt_mcp_server_server.py
@@ -538,7 +538,9 @@ WARNING: This WRITES to DynamoDB. Double-check the word context before calling."
 Use this to add a label to a word that doesn't have one yet. For example,
 labeling a "40.00" word as CASH_BACK when no CASH_BACK label exists for it.
 
-The validation_status is set to VALID and label_proposed_by to "mcp-claude-review".
+By default validation_status is VALID and label_proposed_by is "mcp-claude-review".
+Pass validation_status="PENDING" for machine-propagated rows (e.g. SECTION_*
+sections) that still need QA before they count as ground truth.
 
 consolidated_from: Use this when the new label is a CORRECTION of an existing
 wrong label on the same word. Set it to the old label name so we have an audit
@@ -578,6 +580,11 @@ image_id/receipt_id/line_id/word_id/label already exists.""",
                     "consolidated_from": {
                         "type": "string",
                         "description": "The old label name this corrects. Set when replacing a wrong label (e.g., 'PRODUCT_NAME' if that was the incorrect label). Omit when adding a brand new label with no predecessor.",
+                    },
+                    "validation_status": {
+                        "type": "string",
+                        "enum": ["PENDING", "VALID", "INVALID", "NEEDS_REVIEW"],
+                        "description": "Validation status for the new row. Defaults to VALID (human-reviewed). Use PENDING for machine-propagated rows (e.g. SECTION_* sections) that still need QA.",
                     },
                 },
                 "required": ["image_id", "receipt_id", "line_id", "word_id", "label", "reasoning"],
@@ -1249,6 +1256,9 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent]:
                 label=arguments["label"],
                 reasoning=arguments["reasoning"],
                 consolidated_from=arguments.get("consolidated_from"),
+                validation_status=arguments.get(
+                    "validation_status", "VALID"
+                ),
             )
         elif name == "compute_reocr_region":
             result = await compute_reocr_region_impl(
@@ -2501,14 +2511,30 @@ async def create_word_label_impl(
     label: str,
     reasoning: str,
     consolidated_from: Optional[str] = None,
+    validation_status: str = "VALID",
 ) -> dict:
-    """Create a new ReceiptWordLabel record in DynamoDB."""
+    """Create a new ReceiptWordLabel record in DynamoDB.
+
+    validation_status defaults to VALID (a human-reviewed label via MCP). Pass
+    PENDING for machine-propagated rows (e.g. SECTION_* sections) that still
+    need QA before they count as ground truth.
+    """
     from datetime import datetime, timezone
 
+    from receipt_dynamo.constants import ValidationStatus
     from receipt_dynamo.entities.receipt_word_label import ReceiptWordLabel
 
     try:
         normalized_label = label.upper()
+        normalized_status = str(validation_status).upper()
+        allowed = {s.value for s in ValidationStatus}
+        if normalized_status not in allowed:
+            return {
+                "error": (
+                    f"Invalid validation_status {validation_status!r}; "
+                    f"expected one of {sorted(allowed)}"
+                )
+            }
         new_label = ReceiptWordLabel(
             image_id=image_id,
             receipt_id=receipt_id,
@@ -2517,7 +2543,7 @@ async def create_word_label_impl(
             label=normalized_label,
             reasoning=reasoning,
             timestamp_added=datetime.now(timezone.utc).isoformat(),
-            validation_status="VALID",
+            validation_status=normalized_status,
             label_proposed_by="mcp-claude-review",
             label_consolidated_from=consolidated_from,
         )
@@ -2531,7 +2557,7 @@ async def create_word_label_impl(
             "line_id": line_id,
             "word_id": word_id,
             "label": normalized_label,
-            "validation_status": "VALID",
+            "validation_status": normalized_status,
             "reasoning": reasoning,
             "label_proposed_by": "mcp-claude-review",
         }

--- a/scripts/receipt_mcp_server.py
+++ b/scripts/receipt_mcp_server.py
@@ -2507,13 +2507,15 @@ async def create_word_label_impl(
     """
     from datetime import datetime, timezone
 
-    from receipt_dynamo.constants import ValidationStatus
     from receipt_dynamo.entities.receipt_word_label import ReceiptWordLabel
 
     try:
         normalized_label = label.upper()
-        normalized_status = str(validation_status).upper()
-        allowed = {s.value for s in ValidationStatus}
+        # Only the four workflow statuses are valid on create; a null/omitted
+        # arg falls back to VALID. NONE is deliberately excluded so a stray
+        # null can't silently persist a non-ground-truth row.
+        normalized_status = str(validation_status or "VALID").upper()
+        allowed = {"PENDING", "VALID", "INVALID", "NEEDS_REVIEW"}
         if normalized_status not in allowed:
             return {
                 "error": (

--- a/scripts/receipt_mcp_server.py
+++ b/scripts/receipt_mcp_server.py
@@ -524,7 +524,9 @@ WARNING: This WRITES to DynamoDB. Double-check the word context before calling."
 Use this to add a label to a word that doesn't have one yet. For example,
 labeling a "40.00" word as CASH_BACK when no CASH_BACK label exists for it.
 
-The validation_status is set to VALID and label_proposed_by to "mcp-claude-review".
+By default validation_status is VALID and label_proposed_by is "mcp-claude-review".
+Pass validation_status="PENDING" for machine-propagated rows (e.g. SECTION_*
+sections) that still need QA before they count as ground truth.
 
 consolidated_from: Use this when the new label is a CORRECTION of an existing
 wrong label on the same word. Set it to the old label name so we have an audit
@@ -564,6 +566,11 @@ image_id/receipt_id/line_id/word_id/label already exists.""",
                     "consolidated_from": {
                         "type": "string",
                         "description": "The old label name this corrects. Set when replacing a wrong label (e.g., 'PRODUCT_NAME' if that was the incorrect label). Omit when adding a brand new label with no predecessor.",
+                    },
+                    "validation_status": {
+                        "type": "string",
+                        "enum": ["PENDING", "VALID", "INVALID", "NEEDS_REVIEW"],
+                        "description": "Validation status for the new row. Defaults to VALID (human-reviewed). Use PENDING for machine-propagated rows (e.g. SECTION_* sections) that still need QA.",
                     },
                 },
                 "required": ["image_id", "receipt_id", "line_id", "word_id", "label", "reasoning"],
@@ -1235,6 +1242,9 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent]:
                 label=arguments["label"],
                 reasoning=arguments["reasoning"],
                 consolidated_from=arguments.get("consolidated_from"),
+                validation_status=arguments.get(
+                    "validation_status", "VALID"
+                ),
             )
         elif name == "compute_reocr_region":
             result = await compute_reocr_region_impl(
@@ -2487,14 +2497,30 @@ async def create_word_label_impl(
     label: str,
     reasoning: str,
     consolidated_from: Optional[str] = None,
+    validation_status: str = "VALID",
 ) -> dict:
-    """Create a new ReceiptWordLabel record in DynamoDB."""
+    """Create a new ReceiptWordLabel record in DynamoDB.
+
+    validation_status defaults to VALID (a human-reviewed label via MCP). Pass
+    PENDING for machine-propagated rows (e.g. SECTION_* sections) that still
+    need QA before they count as ground truth.
+    """
     from datetime import datetime, timezone
 
+    from receipt_dynamo.constants import ValidationStatus
     from receipt_dynamo.entities.receipt_word_label import ReceiptWordLabel
 
     try:
         normalized_label = label.upper()
+        normalized_status = str(validation_status).upper()
+        allowed = {s.value for s in ValidationStatus}
+        if normalized_status not in allowed:
+            return {
+                "error": (
+                    f"Invalid validation_status {validation_status!r}; "
+                    f"expected one of {sorted(allowed)}"
+                )
+            }
         new_label = ReceiptWordLabel(
             image_id=image_id,
             receipt_id=receipt_id,
@@ -2503,7 +2529,7 @@ async def create_word_label_impl(
             label=normalized_label,
             reasoning=reasoning,
             timestamp_added=datetime.now(timezone.utc).isoformat(),
-            validation_status="VALID",
+            validation_status=normalized_status,
             label_proposed_by="mcp-claude-review",
             label_consolidated_from=consolidated_from,
         )
@@ -2517,7 +2543,7 @@ async def create_word_label_impl(
             "line_id": line_id,
             "word_id": word_id,
             "label": normalized_label,
-            "validation_status": "VALID",
+            "validation_status": normalized_status,
             "reasoning": reasoning,
             "label_proposed_by": "mcp-claude-review",
         }


### PR DESCRIPTION
## M0.1 — font-intelligence epic

First slice of the [font-intelligence epic](../blob/main/tools/glyph-studio/FONT_INTELLIGENCE_EPIC.md). The epic persists per-word receipt **sections** as `SECTION_*` `ReceiptWordLabel` rows. Machine-propagated section rows must land **PENDING** (promoted to VALID by QA), but both MCP `create_word_label` paths hardcoded `validation_status="VALID"`.

### Change
- Add an optional `validation_status` parameter to `create_word_label_impl` (default `VALID`, so existing human-review behavior is byte-identical).
- Validate against the four advertised workflow statuses (`PENDING`/`VALID`/`INVALID`/`NEEDS_REVIEW`); coerce a null/omitted arg to `VALID`; `NONE` is deliberately excluded so a stray null can't silently persist a non-ground-truth row (codex P2 fix).
- Thread it through the row, the response, the call site, and the tool `inputSchema`.
- Mirrored across both copies: the stdio server (`scripts/receipt_mcp_server.py`) and the Lambda (`infra/mcp_server_lambda/lambdas/receipt_mcp_server_server.py`).

### Verification
This module imports `mcp` and instantiates `Server()` at import time (neither available in CI), so there's no existing test harness for it. Exercised locally with `mcp` stubbed and a fake Dynamo client: default→VALID; explicit `PENDING` and lowercase `pending` pass through to the row; invalid/`NONE`/`null` handled per above. Confirms the `SECTION_*` namespace is writable (create path does not gate on `CORE_LABELS`).

No Dynamo writes here — this only unlocks the write *path*. The first actual `SECTION_*` bulk write is gated on explicit approval (dev table, additive-only) per the epic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Word labels can now be created with a selectable validation status.
  * Supported statuses include Pending, Valid, Invalid, and Needs Review.

* **Bug Fixes**
  * New word labels now preserve the chosen validation status instead of always using the same default.
  * Invalid status values are rejected to prevent inconsistent records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->