### PR TITLE
feat(glyphstudio): canonical section vocabulary + seed projections (font-intel M0.2)

### DIFF
--- a/tools/glyph-studio/py/glyphstudio/sections.py
+++ b/tools/glyph-studio/py/glyphstudio/sections.py
@@ -1,0 +1,183 @@
+"""Canonical receipt-section vocabulary and seed projections.
+
+The font-intelligence epic reframes the font model from ``merchant -> font`` to
+``(merchant, section) -> (family, face)``. Section is the strongest prior on
+face (header -> display, body -> regular, totals -> bold), so we need a single
+canonical section vocabulary and two ways to *seed* it from evidence we already
+have:
+
+1. **Word labels** (``CORE_LABELS``) -> section. A ``GRAND_TOTAL`` word sits in
+   the total line; a ``PRODUCT_NAME`` word sits in the items block. This turns
+   the existing hand-validated label corpus into free section seeds.
+2. **stylescan rules** -> section. ``stylescan.py`` already classifies each
+   visual line for all nine merchants, but with per-merchant ad-hoc names
+   (``warehouse_header``, ``extracare``, ``qty_line`` ...). This module folds
+   those into the canonical vocabulary so all nine speak one language.
+
+Both are *seeds*: they land as ``SECTION_*`` ``ReceiptWordLabel`` rows with
+``validation_status=PENDING`` and are promoted by QA (M1). Nothing here writes
+to Dynamo — this is pure projection logic.
+
+The canonical vocabulary is stylescan's ten sections (epic sec. 4.1).
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+# --- canonical section vocabulary (epic sec. 4.1) -------------------------
+
+CANONICAL_SECTIONS: tuple[str, ...] = (
+    "storefront",  # merchant name / logo / hours / self-checkout lane header
+    "address",  # street address + store phone
+    "items",  # purchased line items (name / qty / unit price / line total)
+    "section_header",  # department dividers ("PRODUCE", "GROCERY", ...)
+    "summary",  # subtotal / tax / discounts / item counts
+    "total_line",  # the grand-total line
+    "payment",  # tender: card / auth / change / cash back
+    "survey",  # post-purchase survey / sweepstakes invite
+    "footer",  # thank-you / policy / rewards trailers / register metadata
+    "barcode",  # numeric barcode captions
+)
+CANONICAL_SECTION_SET = frozenset(CANONICAL_SECTIONS)
+
+# The label namespace persisted in DynamoDB: SECTION_<CANONICAL>.
+SECTION_LABEL_PREFIX = "SECTION_"
+
+
+def is_canonical_section(section: Optional[str]) -> bool:
+    """True if ``section`` is one of the ten canonical section names."""
+    return section in CANONICAL_SECTION_SET
+
+
+def section_label(section: str) -> str:
+    """Canonical section -> its ``SECTION_*`` label string (e.g. total_line ->
+    ``SECTION_TOTAL_LINE``)."""
+    if not is_canonical_section(section):
+        raise ValueError(f"unknown canonical section {section!r}")
+    return SECTION_LABEL_PREFIX + section.upper()
+
+
+def parse_section_label(label: Optional[str]) -> Optional[str]:
+    """``SECTION_*`` label string -> canonical section, or None if ``label`` is
+    not a section label / not canonical."""
+    if not label or not label.upper().startswith(SECTION_LABEL_PREFIX):
+        return None
+    section = label[len(SECTION_LABEL_PREFIX):].lower()
+    return section if is_canonical_section(section) else None
+
+
+# --- CORE_LABELS -> section projection ------------------------------------
+#
+# confidence:
+#   "high"   -> the label has an unambiguous section home; safe to seed.
+#   "medium" -> defensible but placement varies by merchant/receipt; seed only
+#               when explicitly asked (the seed builder defaults to high-only).
+# Labels absent from this map (DATE, TIME) are too positionally scattered to
+# seed and are left to M1 propagation.
+
+CORE_LABEL_SECTION: dict[str, tuple[str, str]] = {
+    # storefront
+    "MERCHANT_NAME": ("storefront", "high"),
+    "STORE_HOURS": ("storefront", "high"),
+    # address block
+    "ADDRESS_LINE": ("address", "high"),
+    "PHONE_NUMBER": ("address", "high"),
+    # items
+    "PRODUCT_NAME": ("items", "high"),
+    "QUANTITY": ("items", "high"),
+    "UNIT_PRICE": ("items", "high"),
+    "LINE_TOTAL": ("items", "high"),
+    # summary block (subtotal/tax are anchors; the rest sit here but can also
+    # appear inline with items, hence medium)
+    "SUBTOTAL": ("summary", "high"),
+    "TAX": ("summary", "high"),
+    "DISCOUNT": ("summary", "medium"),
+    "COUPON": ("summary", "medium"),
+    "TIP": ("summary", "medium"),
+    "REFUND": ("summary", "medium"),
+    # the grand total
+    "GRAND_TOTAL": ("total_line", "high"),
+    # payment / tender exchange
+    "PAYMENT_METHOD": ("payment", "high"),
+    "CHANGE": ("payment", "medium"),
+    "CASH_BACK": ("payment", "medium"),
+    # loyalty id: near tender on most receipts, but Costco prints the member #
+    # in the header -> genuinely ambiguous, medium.
+    "LOYALTY_ID": ("payment", "medium"),
+    # website: usually the footer URL, occasionally the storefront header.
+    "WEBSITE": ("footer", "medium"),
+}
+
+
+def section_for_core_label(label: Optional[str]) -> Optional[str]:
+    """CORE label -> canonical section, or None if it has no confident seed."""
+    if not label:
+        return None
+    entry = CORE_LABEL_SECTION.get(label.upper())
+    return entry[0] if entry else None
+
+
+def core_label_confidence(label: Optional[str]) -> Optional[str]:
+    """CORE label -> seed confidence ("high"/"medium"), or None."""
+    if not label:
+        return None
+    entry = CORE_LABEL_SECTION.get(label.upper())
+    return entry[1] if entry else None
+
+
+# --- stylescan raw names -> canonical section -----------------------------
+#
+# stylescan.py emits per-merchant rule names plus a few generic ones. This
+# folds every raw name any merchant's rules can produce into the canonical
+# vocabulary. Non-obvious folds are commented; "->None" means "not a section"
+# (layout artifact / unclassified) and should not seed.
+
+STYLESCAN_TO_SECTION: dict[str, Optional[str]] = {
+    # --- generic _classify outputs ---
+    "section_header": "section_header",
+    "barcode_caption": "barcode",
+    "item": "items",
+    "separator": None,  # rule of dashes/asterisks, not a section
+    "other": None,  # unclassified
+    # --- storefront / header ---
+    "store_hours": "storefront",
+    "store_header": "storefront",
+    "warehouse_header": "storefront",  # Costco "WHOLESALE #123"
+    "self_checkout": "storefront",  # Costco SELF-CHECKOUT lane header
+    "member": "storefront",  # Costco member # printed in the header block
+    # --- address ---
+    "address": "address",
+    # --- items ---
+    "qty_line": "items",  # TJ "N @ $price" weigh/qty line
+    "item_header": "items",  # Wild Fork Item/Qty/Price column header
+    "pharmacy": "items",  # CVS RX#/vaccine -> the purchased service lines
+    # --- summary ---
+    "summary": "summary",
+    "savings": "summary",  # Costco/Vons money-off lines
+    "discount": "summary",  # Home Depot discount lines
+    "fsa": "summary",  # CVS "FSA Eligible Total" -> a financial subtotal
+    "items_sold": "summary",  # Costco "ITEMS SOLD" count line near totals
+    # --- total ---
+    "total_line": "total_line",
+    # --- payment ---
+    "payment": "payment",
+    # --- survey ---
+    "survey": "survey",
+    # --- footer / trailers / register metadata ---
+    "footer": "footer",
+    "points": "footer",  # Vons rewards-earned trailer
+    "extracare": "footer",  # CVS ExtraBucks reward coupons print at bottom
+    "policy": "footer",  # Wild Fork FEFO/returns policy blurb
+    "transaction": "footer",  # ticket#/station/cashier metadata trailer
+    "reg_line": "footer",  # CVS REG#/TRN#/CSHR# register metadata
+    "note": "footer",  # In-N-Out order note
+}
+
+
+def normalize_stylescan_section(raw: Optional[str]) -> Optional[str]:
+    """stylescan raw section name -> canonical section, or None if it maps to
+    no section (layout artifact / unclassified / unknown)."""
+    if not raw:
+        return None
+    return STYLESCAN_TO_SECTION.get(raw.lower())

--- a/tools/glyph-studio/py/glyphstudio/stylescan.py
+++ b/tools/glyph-studio/py/glyphstudio/stylescan.py
@@ -23,6 +23,8 @@ from statistics import median
 
 import numpy as np
 
+from .sections import normalize_stylescan_section
+
 _WORKTREE = os.path.abspath(
     os.path.join(os.path.dirname(__file__), "..", "..", "..", "..")
 )
@@ -583,6 +585,7 @@ def measure(image_id: str, receipt_id: int, merchant: str = "sprouts") -> dict:
                 "reverse_video": reverse_video,
                 "text": text[:60],
                 "section": section,
+                "section_canonical": normalize_stylescan_section(section),
                 "cap_px": round(median(caps), 1) if caps else None,
                 "density_med": round(median(dens), 4) if dens else None,
                 "stroke_med": round(median(strokes), 2) if strokes else None,

--- a/tools/glyph-studio/py/tests/test_sections.py
+++ b/tools/glyph-studio/py/tests/test_sections.py
@@ -1,0 +1,114 @@
+"""Contract tests for the canonical section vocabulary + seed projections.
+
+These are pure-function tests (no Dynamo, no pixels). They pin the two seed
+sources against drift: a new CORE label or a new stylescan rule name should
+force an explicit decision here rather than silently produce no section.
+"""
+
+import os
+import sys
+
+import pytest
+
+from glyphstudio import sections
+
+# receipt_dynamo lives as a sibling package, not pip-installed; add it so we can
+# assert the projection against the real CORE_LABELS (single source of truth).
+_ROOT = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "..", "..")
+)
+_RD = os.path.join(_ROOT, "receipt_dynamo")
+if _RD not in sys.path:
+    sys.path.insert(0, _RD)
+
+
+def test_canonical_section_set_is_ten():
+    assert len(sections.CANONICAL_SECTIONS) == 10
+    assert len(sections.CANONICAL_SECTION_SET) == 10
+
+
+def test_section_label_roundtrip():
+    for s in sections.CANONICAL_SECTIONS:
+        lbl = sections.section_label(s)
+        assert lbl == "SECTION_" + s.upper()
+        assert sections.parse_section_label(lbl) == s
+
+
+def test_parse_section_label_rejects_non_sections():
+    assert sections.parse_section_label("GRAND_TOTAL") is None
+    assert sections.parse_section_label("SECTION_BOGUS") is None
+    assert sections.parse_section_label("") is None
+    assert sections.parse_section_label(None) is None
+    # case-insensitive prefix
+    assert sections.parse_section_label("section_items") == "items"
+
+
+def test_section_label_rejects_unknown_section():
+    with pytest.raises(ValueError):
+        sections.section_label("nonsense")
+
+
+def test_core_label_map_targets_are_canonical():
+    for label, (section, conf) in sections.CORE_LABEL_SECTION.items():
+        assert label == label.upper()
+        assert sections.is_canonical_section(section), (label, section)
+        assert conf in ("high", "medium"), (label, conf)
+
+
+def test_stylescan_map_targets_are_canonical_or_none():
+    for raw, section in sections.STYLESCAN_TO_SECTION.items():
+        assert raw == raw.lower()
+        assert section is None or sections.is_canonical_section(section), (
+            raw,
+            section,
+        )
+
+
+def test_every_core_label_is_decided():
+    """Each CORE label is either projected or on the explicit no-seed list."""
+    from receipt_dynamo.constants import CORE_LABELS
+
+    no_seed = {"DATE", "TIME"}  # too positionally scattered to seed
+    decided = set(sections.CORE_LABEL_SECTION) | no_seed
+    missing = set(CORE_LABELS) - decided
+    assert not missing, f"CORE labels with no section decision: {missing}"
+    # and no stale entries referencing labels that no longer exist
+    stale = set(sections.CORE_LABEL_SECTION) - set(CORE_LABELS)
+    assert not stale, f"projection references unknown labels: {stale}"
+
+
+def test_every_stylescan_rule_name_is_mapped():
+    """Every section name any merchant's rules (or the generic classifier) can
+    emit must have an entry in STYLESCAN_TO_SECTION."""
+    from glyphstudio import stylescan
+
+    emitted = set()
+    for rules in stylescan._MERCHANT_RULES.values():
+        for name, _rx in rules:
+            emitted.add(name)
+    # generic hardcoded returns of _classify()
+    emitted |= {
+        "barcode_caption",
+        "section_header",
+        "item",
+        "separator",
+        "other",
+    }
+    missing = emitted - set(sections.STYLESCAN_TO_SECTION)
+    assert not missing, f"unmapped stylescan section names: {missing}"
+
+
+def test_projection_spot_checks():
+    assert sections.section_for_core_label("GRAND_TOTAL") == "total_line"
+    assert sections.section_for_core_label("product_name") == "items"
+    assert sections.section_for_core_label("DATE") is None
+    assert sections.core_label_confidence("SUBTOTAL") == "high"
+    assert sections.core_label_confidence("DISCOUNT") == "medium"
+
+    assert sections.normalize_stylescan_section("warehouse_header") == (
+        "storefront"
+    )
+    assert sections.normalize_stylescan_section("extracare") == "footer"
+    assert sections.normalize_stylescan_section("separator") is None
+    assert sections.normalize_stylescan_section("nope") is None
+    assert sections.normalize_stylescan_section(None) is None


### PR DESCRIPTION
## M0.2 — font-intelligence epic

Second slice of the [font-intelligence epic](../blob/main/tools/glyph-studio/FONT_INTELLIGENCE_EPIC.md). The epic organizes fonts around `(merchant, section) -> (family, face)`. This PR establishes the **canonical section vocabulary** and the two ways we seed it from evidence we already have. Pure projection logic — **no Dynamo, no pixels, no writes.**

### `glyphstudio/sections.py`
- **`CANONICAL_SECTIONS`** — the ten sections from epic §4.1 (`storefront / address / items / section_header / summary / total_line / payment / survey / footer / barcode`).
- **`CORE_LABEL_SECTION`** — projection from `CORE_LABELS` word labels to sections, tagged `high`/`medium` confidence (`GRAND_TOTAL → total_line`, `PRODUCT_NAME → items`, ...). `DATE`/`TIME` are deliberately left un-seeded (too positionally scattered — left to M1 propagation).
- **`STYLESCAN_TO_SECTION`** — folds every per-merchant stylescan rule name across all nine merchants (`warehouse_header`, `extracare`, `qty_line`, `items_sold`, ...) into the canonical vocabulary. Non-obvious folds are commented.
- **`SECTION_*` label helpers** — `section_label` / `parse_section_label` for the DynamoDB `SECTION_*` namespace.

### stylescan
Now additionally emits `section_canonical` per line (additive; the raw `section` field is byte-identical).

### Tests
`tests/test_sections.py` (9 tests) pins both maps against drift: a new `CORE_LABEL` or a new stylescan rule name forces an explicit decision here rather than silently producing no section; every projection target is asserted canonical. Full glyphstudio suite green (68 passed). Codex review: no regressions.

> Note: the renderer already has a coarser `CORE_LABELS`-grouping in `receipt_agent/.../rendering/receipt_grid.py` (`SECTION_LABELS`, `GridWord.section`). This canonical vocabulary is the richer superset the epic calls for; wiring the renderer to it is M4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)