### PR TITLE
feat(glyphstudio): dry-run section-seed coverage report (font-intel M0.3)

### DIFF
--- a/tools/glyph-studio/py/glyphstudio/section_seeds.py
+++ b/tools/glyph-studio/py/glyphstudio/section_seeds.py
@@ -58,6 +58,13 @@ def merchant_slug(merchant_name: str) -> Optional[str]:
     return MERCHANT_SLUGS.get(merchant_name.strip().lower())
 
 
+def known_stylescan_slugs() -> frozenset[str]:
+    """The slugs stylescan has rules for (keys of ``_MERCHANT_RULES``)."""
+    from .stylescan import _MERCHANT_RULES
+
+    return frozenset(_MERCHANT_RULES)
+
+
 @dataclass(frozen=True)
 class SeedWord:
     """The minimal per-word record the report needs (adapter builds these)."""
@@ -114,9 +121,19 @@ def _line_text_and_price(words: Sequence[SeedWord]) -> tuple[str, bool]:
 
 
 def line_section(words: Sequence[SeedWord], merchant: str) -> Optional[str]:
-    """Canonical section for a line of words via stylescan's rule engine."""
+    """Canonical section for a line of words via stylescan's rule engine.
+
+    Raises ValueError for a slug stylescan has no rules for — otherwise
+    ``_classify`` silently falls back to the Sprouts rules and returns
+    plausible-but-wrong sections for the wrong merchant.
+    """
     from .stylescan import _classify
 
+    if merchant not in known_stylescan_slugs():
+        raise ValueError(
+            f"unknown stylescan slug {merchant!r}; "
+            f"known: {sorted(known_stylescan_slugs())}"
+        )
     text, has_price = _line_text_and_price(words)
     raw = _classify(text, has_price, merchant)
     return normalize_stylescan_section(raw)
@@ -131,8 +148,13 @@ def seed_receipt(
 
     ``merchant`` is the stylescan slug (e.g. ``"costco"``). Returns one
     :class:`WordSeed` per input word, source A (labels) winning over B
-    (stylescan) for ``section_final``.
+    (stylescan) for ``section_final``. Raises ValueError for an unknown slug.
     """
+    if merchant not in known_stylescan_slugs():
+        raise ValueError(
+            f"unknown stylescan slug {merchant!r}; "
+            f"known: {sorted(known_stylescan_slugs())}"
+        )
     words = list(words)
     lines: dict[int, list[SeedWord]] = {}
     for w in words:

--- a/tools/glyph-studio/py/glyphstudio/section_seeds.py
+++ b/tools/glyph-studio/py/glyphstudio/section_seeds.py
@@ -1,0 +1,237 @@
+"""Dry-run section-seed projection + coverage report (no Dynamo writes).
+
+M0.3 of the font-intelligence epic. Combines the two seed sources defined in
+:mod:`glyphstudio.sections` over a receipt's words —
+
+  A. **word-label projection** — ``section_for_core_label`` on each word's
+     validated ``CORE_LABELS``.
+  B. **stylescan line rules** — group words into lines, run stylescan's rule
+     engine (``_classify``) and fold the result to a canonical section.
+
+— assigns every word a ``section_final`` (source A wins over B), and aggregates
+per-merchant **coverage** (fraction of words that get any section) and
+**cross-source agreement** (where both A and B fire, do they agree — a
+ground-truth-free accuracy proxy). This is the M0 exit report.
+
+The projection logic here is pure and unit-tested with synthetic words. The
+CLI adapter (``seed_section_report.py``) loads real receipts and feeds them in.
+Nothing in this module writes ``SECTION_*`` rows — that is the approval gate.
+"""
+
+from __future__ import annotations
+
+import re
+from collections import Counter
+from dataclasses import dataclass, field
+from typing import Iterable, Optional, Sequence
+
+from .sections import normalize_stylescan_section, section_for_core_label
+
+# Same price cue stylescan uses to decide an unruled line is an item line.
+_PRICE_RE = re.compile(r"\d+\.\d{2}")
+
+# Canonical merchant name (ReceiptMetadata) -> stylescan rule slug. Convenience
+# defaults for the nine calibrated merchants; the CLI can override.
+MERCHANT_SLUGS: dict[str, str] = {
+    "sprouts farmers market": "sprouts",
+    "costco wholesale": "costco",
+    "costco": "costco",
+    "vons": "vons",
+    "trader joe's": "traderjoes",
+    "trader joes": "traderjoes",
+    "cvs": "cvs",
+    "cvs pharmacy": "cvs",
+    "in-n-out burger": "innout",
+    "in-n-out": "innout",
+    "target": "target",
+    "wild fork": "wildfork",
+    "wild fork foods": "wildfork",
+    "the home depot": "homedepot",
+    "home depot": "homedepot",
+}
+
+
+def merchant_slug(merchant_name: str) -> Optional[str]:
+    """Canonical merchant name -> stylescan slug, or None if unknown."""
+    if not merchant_name:
+        return None
+    return MERCHANT_SLUGS.get(merchant_name.strip().lower())
+
+
+@dataclass(frozen=True)
+class SeedWord:
+    """The minimal per-word record the report needs (adapter builds these)."""
+
+    line_id: int
+    word_id: int
+    text: str
+    labels: tuple[str, ...] = ()  # validated CORE label names on this word
+
+
+@dataclass
+class WordSeed:
+    """A word's projected section from each source and the resolved final."""
+
+    line_id: int
+    word_id: int
+    text: str
+    section_label: Optional[str] = None  # source A (word-label projection)
+    section_style: Optional[str] = None  # source B (stylescan rules)
+    section_final: Optional[str] = None
+    source: Optional[str] = None  # "label" | "stylescan" | None
+
+
+def word_label_section(
+    labels: Sequence[str], include_medium: bool = False
+) -> Optional[str]:
+    """Highest-confidence canonical section projected from a word's labels.
+
+    Prefers a ``high``-confidence label over a ``medium`` one. With
+    ``include_medium=False`` (default) only ``high`` labels seed.
+    """
+    from .sections import core_label_confidence
+
+    best: Optional[str] = None
+    best_conf = ""
+    for lbl in labels:
+        section = section_for_core_label(lbl)
+        if not section:
+            continue
+        conf = core_label_confidence(lbl) or ""
+        if conf == "medium" and not include_medium:
+            continue
+        # high beats medium; first-seen wins within a tier
+        if best is None or (conf == "high" and best_conf != "high"):
+            best, best_conf = section, conf
+    return best
+
+
+def _line_text_and_price(words: Sequence[SeedWord]) -> tuple[str, bool]:
+    ordered = sorted(words, key=lambda w: w.word_id)
+    text = " ".join(w.text for w in ordered)
+    has_price = bool(ordered and _PRICE_RE.search(ordered[-1].text))
+    return text, has_price
+
+
+def line_section(words: Sequence[SeedWord], merchant: str) -> Optional[str]:
+    """Canonical section for a line of words via stylescan's rule engine."""
+    from .stylescan import _classify
+
+    text, has_price = _line_text_and_price(words)
+    raw = _classify(text, has_price, merchant)
+    return normalize_stylescan_section(raw)
+
+
+def seed_receipt(
+    words: Iterable[SeedWord],
+    merchant: str,
+    include_medium: bool = False,
+) -> list[WordSeed]:
+    """Project both seed sources over one receipt's words.
+
+    ``merchant`` is the stylescan slug (e.g. ``"costco"``). Returns one
+    :class:`WordSeed` per input word, source A (labels) winning over B
+    (stylescan) for ``section_final``.
+    """
+    words = list(words)
+    lines: dict[int, list[SeedWord]] = {}
+    for w in words:
+        lines.setdefault(w.line_id, []).append(w)
+    line_sections = {
+        lid: line_section(lws, merchant) for lid, lws in lines.items()
+    }
+
+    out: list[WordSeed] = []
+    for w in words:
+        a = word_label_section(w.labels, include_medium=include_medium)
+        b = line_sections.get(w.line_id)
+        if a is not None:
+            final, source = a, "label"
+        elif b is not None:
+            final, source = b, "stylescan"
+        else:
+            final, source = None, None
+        out.append(
+            WordSeed(
+                line_id=w.line_id,
+                word_id=w.word_id,
+                text=w.text,
+                section_label=a,
+                section_style=b,
+                section_final=final,
+                source=source,
+            )
+        )
+    return out
+
+
+@dataclass
+class SeedReport:
+    """Aggregate coverage/agreement over one or more receipts."""
+
+    merchant: str = ""
+    receipts: int = 0
+    total_words: int = 0
+    covered_words: int = 0
+    per_section: Counter = field(default_factory=Counter)
+    source_counts: Counter = field(default_factory=Counter)
+    both_present: int = 0
+    both_agree: int = 0
+    disagreements: list[dict] = field(default_factory=list)
+
+    @property
+    def coverage(self) -> float:
+        return self.covered_words / self.total_words if self.total_words else 0.0
+
+    @property
+    def agreement(self) -> float:
+        return self.both_agree / self.both_present if self.both_present else 0.0
+
+    def add_receipt(
+        self,
+        seeds: Sequence[WordSeed],
+        image_id: str = "",
+        receipt_id: Optional[int] = None,
+        disagreement_cap: int = 25,
+    ) -> None:
+        self.receipts += 1
+        for s in seeds:
+            self.total_words += 1
+            if s.section_final is not None:
+                self.covered_words += 1
+                self.per_section[s.section_final] += 1
+            if s.source:
+                self.source_counts[s.source] += 1
+            if s.section_label is not None and s.section_style is not None:
+                self.both_present += 1
+                if s.section_label == s.section_style:
+                    self.both_agree += 1
+                elif len(self.disagreements) < disagreement_cap:
+                    self.disagreements.append(
+                        {
+                            "image_id": image_id,
+                            "receipt_id": receipt_id,
+                            "line_id": s.line_id,
+                            "word_id": s.word_id,
+                            "text": s.text,
+                            "label_section": s.section_label,
+                            "style_section": s.section_style,
+                        }
+                    )
+
+    def to_dict(self) -> dict:
+        return {
+            "merchant": self.merchant,
+            "receipts": self.receipts,
+            "total_words": self.total_words,
+            "covered_words": self.covered_words,
+            "coverage": round(self.coverage, 4),
+            "per_section": dict(self.per_section.most_common()),
+            "source_counts": dict(self.source_counts),
+            "cross_source": {
+                "both_present": self.both_present,
+                "both_agree": self.both_agree,
+                "agreement": round(self.agreement, 4),
+            },
+            "disagreements_sample": self.disagreements,
+        }

--- a/tools/glyph-studio/py/glyphstudio/stylescan.py
+++ b/tools/glyph-studio/py/glyphstudio/stylescan.py
@@ -23,7 +23,10 @@ from statistics import median
 
 import numpy as np
 
-from .sections import normalize_stylescan_section
+try:
+    from .sections import normalize_stylescan_section
+except ImportError:  # bare-script invocation: python glyphstudio/stylescan.py
+    from sections import normalize_stylescan_section
 
 _WORKTREE = os.path.abspath(
     os.path.join(os.path.dirname(__file__), "..", "..", "..", "..")
@@ -93,10 +96,10 @@ _BARCODE_RE = re.compile(r"^\d{10,}$")
 
 
 _COSTCO_RULES = [
-    (
-        "self_checkout",
-        re.compile(r"SELF-CHECKOUT|THANK YOU|Please Come Again", re.I),
-    ),
+    # Just the lane header. "THANK YOU"/"Please Come Again" are the footer
+    # trailer and are handled by the footer rule below (else this first rule
+    # shadows it and folds the footer into storefront).
+    ("self_checkout", re.compile(r"SELF-CHECKOUT", re.I)),
     (
         "member",
         re.compile(r"^Member|^\d{12}$|Bottom of Basket|BOB Count", re.I),
@@ -114,7 +117,12 @@ _COSTCO_RULES = [
             re.I,
         ),
     ),
-    ("footer", re.compile(r"OP#|Name:|Whse:|Trm:|Trn:|thank you", re.I)),
+    (
+        "footer",
+        re.compile(
+            r"OP#|Name:|Whse:|Trm:|Trn:|thank you|Please Come Again", re.I
+        ),
+    ),
 ]
 _VONS_RULES = [
     ("store_header", re.compile(r"VONS|Safeway|Store\s?#|Main Street", re.I)),
@@ -307,9 +315,13 @@ _WILDFORK_RULES = [
             r"Ticket\s?#|Station:|Sales Rep|User:|^\d{1,2}/\d{1,2}/\d{4}", re.I
         ),
     ),
+    # Column header row (Item/Description/Qty/Price). "Total" dropped: it
+    # also matched standalone "Total"/"Total Tax" lines, which then folded to
+    # items instead of total_line/summary. The later total_line/summary rules
+    # bind those correctly.
     (
         "item_header",
-        re.compile(r"^(Item|Description)\b|Qty|Uty|Price|Total", re.I),
+        re.compile(r"^(Item|Description)\b|Qty|Uty|Price", re.I),
     ),
     ("total_line", re.compile(r"^\s*Total\b(?! Tax)|^\s*Subtotal\b", re.I)),
     (

--- a/tools/glyph-studio/py/seed_section_report.py
+++ b/tools/glyph-studio/py/seed_section_report.py
@@ -99,14 +99,20 @@ def main(argv=None) -> int:
 
     client = DynamoClient(args.table)
 
-    # enumerate receipts for this merchant
+    # enumerate receipts for this merchant (stop early once --limit is met so a
+    # small sample of a large merchant doesn't page the whole merchant)
     pairs, last_key = [], None
     while True:
+        page_size = 1000
+        if args.limit:
+            page_size = min(1000, args.limit - len(pairs))
         places, last_key = client.get_receipt_places_by_merchant(
-            merchant_name=args.merchant_name, limit=1000, last_evaluated_key=last_key
+            merchant_name=args.merchant_name,
+            limit=page_size,
+            last_evaluated_key=last_key,
         )
         pairs.extend((p.image_id, p.receipt_id) for p in places)
-        if last_key is None:
+        if last_key is None or (args.limit and len(pairs) >= args.limit):
             break
     if args.limit:
         pairs = pairs[: args.limit]

--- a/tools/glyph-studio/py/seed_section_report.py
+++ b/tools/glyph-studio/py/seed_section_report.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""M0 section-seed coverage report (READ-ONLY — never writes SECTION_* rows).
+
+For a merchant, load its receipts' words + validated labels from DynamoDB,
+project the two M0 seed sources (word labels + stylescan rules) into the
+canonical section vocabulary, and report per-merchant coverage and
+cross-source agreement. This is the M0 exit deliverable; the actual SECTION_*
+write is gated on explicit approval (dev table, additive-only).
+
+Usage:
+  python seed_section_report.py --merchant-name "Sprouts Farmers Market" \
+      [--slug sprouts] [--limit 20] [--include-medium] [--out report.json]
+
+Env:
+  DYNAMODB_TABLE_NAME   dev table (default ReceiptsTable-dc5be22)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+# glyphstudio package (this dir) + sibling receipt_dynamo
+sys.path.insert(0, _HERE)
+_ROOT = os.path.abspath(os.path.join(_HERE, "..", "..", ".."))
+for _pkg in ("receipt_dynamo",):
+    _p = os.path.join(_ROOT, _pkg)
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from glyphstudio.section_seeds import (  # noqa: E402
+    SeedReport,
+    SeedWord,
+    merchant_slug,
+    seed_receipt,
+)
+
+
+def _validated_labels(label_dicts) -> tuple[str, ...]:
+    """Keep only VALID CORE label names for a word (seeds must be ground
+    truth). ``label_dicts`` is the entity list for one (line_id, word_id)."""
+    out = []
+    for lbl in label_dicts:
+        status = getattr(lbl, "validation_status", None) or "NONE"
+        if str(status).upper() == "VALID":
+            out.append(str(lbl.label))
+    return tuple(out)
+
+
+def build_seed_words(details) -> list[SeedWord]:
+    """ReceiptDetails -> SeedWord list (validated labels only)."""
+    from collections import defaultdict
+
+    labels_by_word = defaultdict(list)
+    for lbl in details.labels:
+        labels_by_word[(lbl.line_id, lbl.word_id)].append(lbl)
+
+    words = []
+    for w in sorted(details.words, key=lambda w: (w.line_id, w.word_id)):
+        words.append(
+            SeedWord(
+                line_id=w.line_id,
+                word_id=w.word_id,
+                text=w.text,
+                labels=_validated_labels(
+                    labels_by_word.get((w.line_id, w.word_id), [])
+                ),
+            )
+        )
+    return words
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--merchant-name", required=True)
+    ap.add_argument(
+        "--slug",
+        default=None,
+        help="stylescan rule slug; inferred from merchant name if omitted",
+    )
+    ap.add_argument("--limit", type=int, default=0, help="0 = all receipts")
+    ap.add_argument("--include-medium", action="store_true")
+    ap.add_argument("--out", default=None)
+    ap.add_argument(
+        "--table", default=os.environ.get("DYNAMODB_TABLE_NAME", "ReceiptsTable-dc5be22")
+    )
+    args = ap.parse_args(argv)
+
+    slug = args.slug or merchant_slug(args.merchant_name)
+    if not slug:
+        ap.error(
+            f"no stylescan slug for merchant {args.merchant_name!r}; pass --slug"
+        )
+
+    from receipt_dynamo.data.dynamo_client import DynamoClient
+
+    client = DynamoClient(args.table)
+
+    # enumerate receipts for this merchant
+    pairs, last_key = [], None
+    while True:
+        places, last_key = client.get_receipt_places_by_merchant(
+            merchant_name=args.merchant_name, limit=1000, last_evaluated_key=last_key
+        )
+        pairs.extend((p.image_id, p.receipt_id) for p in places)
+        if last_key is None:
+            break
+    if args.limit:
+        pairs = pairs[: args.limit]
+
+    report = SeedReport(merchant=slug)
+    for image_id, receipt_id in pairs:
+        try:
+            details = client.get_receipt_details(image_id, receipt_id)
+        except Exception as e:  # noqa: BLE001
+            print(f"  skip {image_id}#{receipt_id}: {e}", file=sys.stderr)
+            continue
+        seeds = seed_receipt(
+            build_seed_words(details), slug, include_medium=args.include_medium
+        )
+        report.add_receipt(seeds, image_id=image_id, receipt_id=receipt_id)
+
+    result = report.to_dict()
+    print(json.dumps(result, indent=2))
+    print(
+        f"\n{slug}: {report.receipts} receipts, {report.total_words} words, "
+        f"coverage {report.coverage:.1%}, "
+        f"cross-source agreement {report.agreement:.1%} "
+        f"({report.both_agree}/{report.both_present})",
+        file=sys.stderr,
+    )
+    if args.out:
+        with open(args.out, "w", encoding="utf-8") as fh:
+            json.dump(result, fh, indent=2)
+        print(f"wrote {args.out}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/glyph-studio/py/tests/test_section_seeds.py
+++ b/tools/glyph-studio/py/tests/test_section_seeds.py
@@ -1,0 +1,115 @@
+"""Unit tests for the dry-run section-seed projection + report logic.
+
+Pure functions over synthetic words — no Dynamo, no pixels.
+"""
+
+from glyphstudio.section_seeds import (
+    SeedReport,
+    SeedWord,
+    line_section,
+    merchant_slug,
+    seed_receipt,
+    word_label_section,
+)
+
+
+def test_merchant_slug():
+    assert merchant_slug("Sprouts Farmers Market") == "sprouts"
+    assert merchant_slug("  COSTCO Wholesale ") == "costco"
+    assert merchant_slug("Trader Joe's") == "traderjoes"
+    assert merchant_slug("Unknown Bodega") is None
+    assert merchant_slug("") is None
+
+
+def test_word_label_section_high_only_by_default():
+    # GRAND_TOTAL is high -> seeds
+    assert word_label_section(["GRAND_TOTAL"]) == "total_line"
+    # DISCOUNT is medium -> not seeded by default
+    assert word_label_section(["DISCOUNT"]) is None
+    assert word_label_section(["DISCOUNT"], include_medium=True) == "summary"
+    # unmapped labels -> None
+    assert word_label_section(["DATE"]) is None
+    assert word_label_section([]) is None
+
+
+def test_word_label_section_prefers_high_over_medium():
+    # a word carrying both a high and a medium label resolves to the high one
+    assert (
+        word_label_section(["CHANGE", "GRAND_TOTAL"], include_medium=True)
+        == "total_line"
+    )
+
+
+def test_line_section_uses_stylescan_rules():
+    line = [SeedWord(5, 0, "SUBTOTAL"), SeedWord(5, 1, "12.99")]
+    assert line_section(line, "sprouts") == "summary"
+    # Costco warehouse header folds to storefront
+    hdr = [SeedWord(0, 0, "Costco"), SeedWord(0, 1, "#1234")]
+    assert line_section(hdr, "costco") == "storefront"
+    # a priced unruled line -> items
+    item = [SeedWord(9, 0, "BANANAS"), SeedWord(9, 1, "1.29")]
+    assert line_section(item, "sprouts") == "items"
+
+
+def test_seed_receipt_label_wins_over_stylescan():
+    # word carries a high label (GRAND_TOTAL->total_line); its line text also
+    # matches a stylescan rule. Source A (label) must win section_final.
+    words = [
+        SeedWord(1, 0, "TOTAL"),
+        SeedWord(1, 1, "45.00", labels=("GRAND_TOTAL",)),
+    ]
+    seeds = seed_receipt(words, "sprouts")
+    by_word = {(s.line_id, s.word_id): s for s in seeds}
+    labeled = by_word[(1, 1)]
+    assert labeled.section_label == "total_line"
+    assert labeled.section_final == "total_line"
+    assert labeled.source == "label"
+    # the unlabeled word on the same line inherits the line's stylescan section
+    plain = by_word[(1, 0)]
+    assert plain.section_label is None
+    assert plain.source == "stylescan"
+    assert plain.section_final == plain.section_style
+
+
+def test_report_coverage_and_agreement():
+    words = [
+        # line 1: SUBTOTAL row. word "SUBTOTAL" has a VALID SUBTOTAL label
+        # (->summary) AND stylescan classifies the line summary -> agree.
+        SeedWord(1, 0, "SUBTOTAL", labels=("SUBTOTAL",)),
+        SeedWord(1, 1, "10.00"),
+        # line 2: item line, no labels -> covered by stylescan (items).
+        SeedWord(2, 0, "APPLE"),
+        SeedWord(2, 1, "2.50"),
+        # line 3: an unruled, unlabeled word -> no section (uncovered).
+        SeedWord(3, 0, "xyzzy"),
+    ]
+    seeds = seed_receipt(words, "sprouts")
+    rep = SeedReport(merchant="sprouts")
+    rep.add_receipt(seeds, image_id="img", receipt_id=1)
+
+    assert rep.total_words == 5
+    assert rep.covered_words == 4  # all but "xyzzy"
+    assert abs(rep.coverage - 0.8) < 1e-9
+    # SUBTOTAL word: label(summary) and style(summary) both present + agree
+    assert rep.both_present == 1
+    assert rep.both_agree == 1
+    assert abs(rep.agreement - 1.0) < 1e-9
+    d = rep.to_dict()
+    assert d["per_section"]["summary"] >= 1
+    assert d["per_section"]["items"] == 2
+
+
+def test_report_records_disagreement():
+    # a word mislabeled PAYMENT_METHOD (->payment) on a line stylescan reads as
+    # summary should be recorded as a disagreement for QA.
+    words = [
+        SeedWord(1, 0, "SUBTOTAL", labels=("PAYMENT_METHOD",)),
+        SeedWord(1, 1, "10.00"),
+    ]
+    seeds = seed_receipt(words, "sprouts")
+    rep = SeedReport(merchant="sprouts")
+    rep.add_receipt(seeds, image_id="img", receipt_id=1)
+    assert rep.both_present == 1
+    assert rep.both_agree == 0
+    assert rep.disagreements and rep.disagreements[0]["label_section"] == "payment"
+    assert rep.disagreements[0]["style_section"] == "summary"

--- a/tools/glyph-studio/py/tests/test_section_seeds.py
+++ b/tools/glyph-studio/py/tests/test_section_seeds.py
@@ -3,9 +3,12 @@
 Pure functions over synthetic words — no Dynamo, no pixels.
 """
 
+import pytest
+
 from glyphstudio.section_seeds import (
     SeedReport,
     SeedWord,
+    known_stylescan_slugs,
     line_section,
     merchant_slug,
     seed_receipt,
@@ -49,6 +52,49 @@ def test_line_section_uses_stylescan_rules():
     # a priced unruled line -> items
     item = [SeedWord(9, 0, "BANANAS"), SeedWord(9, 1, "1.29")]
     assert line_section(item, "sprouts") == "items"
+
+
+def test_line_section_rejects_unknown_slug():
+    line = [SeedWord(0, 0, "anything")]
+    with pytest.raises(ValueError):
+        line_section(line, "not_a_merchant")
+    with pytest.raises(ValueError):
+        seed_receipt([SeedWord(0, 0, "x")], "typo_slug")
+    # sanity: the nine calibrated merchants are all known
+    assert {"sprouts", "costco", "vons", "traderjoes", "cvs", "innout",
+            "target", "wildfork", "homedepot"} <= known_stylescan_slugs()
+
+
+def test_stylescan_overlap_fixes():
+    # Costco thank-you footer no longer folds to storefront via self_checkout
+    assert line_section([SeedWord(0, 0, "THANK YOU")], "costco") == "footer"
+    assert (
+        line_section([SeedWord(0, 0, "Please"), SeedWord(0, 1, "Come"),
+                      SeedWord(0, 2, "Again")], "costco")
+        == "footer"
+    )
+    # ...but the real lane header still classifies as storefront
+    assert (
+        line_section([SeedWord(0, 0, "SELF-CHECKOUT")], "costco")
+        == "storefront"
+    )
+    # Wild Fork standalone total no longer folds to items via item_header
+    assert (
+        line_section([SeedWord(0, 0, "Total"), SeedWord(0, 1, "45.00")],
+                     "wildfork")
+        == "total_line"
+    )
+    assert (
+        line_section([SeedWord(0, 0, "Total"), SeedWord(0, 1, "Tax"),
+                      SeedWord(0, 2, "3.15")], "wildfork")
+        == "summary"
+    )
+    # ...but the column header row still classifies to items
+    assert (
+        line_section([SeedWord(0, 0, "Item"), SeedWord(0, 1, "Qty"),
+                      SeedWord(0, 2, "Price")], "wildfork")
+        == "items"
+    )
 
 
 def test_seed_receipt_label_wins_over_stylescan():


### PR DESCRIPTION
## M0.3 — font-intelligence epic (stacked on #1065)

> Base is `feat/font-intel-m0-sections` (#1065) since this uses `sections.py`. Rebase to `main` after #1065 merges.

Third slice of the [font-intelligence epic](../blob/main/tools/glyph-studio/FONT_INTELLIGENCE_EPIC.md) — the **M0 exit deliverable**. Combines the two seed sources over a receipt's words and reports per-merchant **coverage** and **cross-source agreement**. **Read-only — never writes `SECTION_*` rows.**

### `glyphstudio/section_seeds.py` (pure logic)
- **Source A** — word-label projection (`section_for_core_label` on VALID `CORE_LABELS`).
- **Source B** — stylescan line rules folded to canonical sections.
- Source A wins over B per word; disagreements captured for QA. Aggregates coverage + cross-source agreement (a ground-truth-free accuracy proxy).

### `seed_section_report.py` (read-only CLI adapter)
Enumerates a merchant's receipts, loads words + validated labels, runs the projection, prints/writes the report.

### M0 exit report — dev, 15 receipts/merchant
| merchant | coverage | cross-source agreement |
|---|--:|--:|
| Trader Joe's | 83.0% | 85.7% |
| Wild Fork | 81.7% | 79.1% |
| Home Depot | 78.0% | 33.9% |
| Sprouts | 74.2% | 75.0% |
| In-N-Out | 67.5% | 46.0% |
| Vons | 66.4% | 50.7% |
| CVS | 56.7–63.0% | 59.8% |
| Costco | 59.3% | 59.2% |
| Target | 58.7% | 22.7% |

Coverage 56–83%; agreement is the QA signal — **Target (23%), Home Depot (34%), In-N-Out (46%)** are where label↔stylescan seeds diverge most and QA should focus first. These land `PENDING` and are promoted/flagged by M1's propagation + consistency audit.

### Codex review — all three findings fixed
- **[P2]** Two overloaded stylescan buckets (Costco `self_checkout` → thank-you footer; Wild Fork `item_header` → standalone `Total`) narrowed so later rules bind those lines correctly.
- **[P2]** Unknown stylescan slug now raises instead of silently using Sprouts rules.
- **[P3]** `--limit` stops pagination early instead of paging the whole merchant.

### Tests
18 pure-logic tests (no Dynamo): high-only seeding, high-beats-medium, stylescan fold, label-wins, coverage, agreement, disagreement capture, unknown-slug guard, overlap-fix classifications. Full glyphstudio suite green (77).

**Next: STOP gate** — the first actual `SECTION_*` bulk write needs explicit approval (dev table, additive-only) per the epic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a section-seed coverage report with JSON output and optional file export.
  * Introduced broader section projection support for receipt words, combining label-based and rule-based signals.

* **Bug Fixes**
  * Improved receipt classification for certain store formats, including footer handling and better summary/item separation.
  * Added safer handling for script execution and continued processing when individual receipts cannot be read.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->