### PR TITLE
docs(font-intel): integrate M1 consistency audit into pipeline/risks/decision-log

### DIFF
--- a/tools/glyph-studio/FONT_INTELLIGENCE_EPIC.md
+++ b/tools/glyph-studio/FONT_INTELLIGENCE_EPIC.md
@@ -139,6 +139,9 @@ S0 seed        CORE_LABELS → section projection (GRAND_TOTAL ⇒ total_line, P
                + stylescan rules where they exist (Costco/Vons/TJ)
 S1 propagate   word-context Chroma NN → section posterior for every word
                → write SECTION_* labels as PENDING → MCP QA sample → VALID
+S1' audit      cross-tab CORE label × consensus section → flag inconsistent
+               word labels NEEDS_REVIEW (update_word_label); report per-label
+               violation rate
 S2 cluster     glyph-crop Chroma collection → family/face clustering
                → the (merchant, section) → (family, face) map, with confidence
 S3 fit         pooled stroke-skeleton fit per (family, face):
@@ -202,7 +205,11 @@ unchanged — family fonts are *fitted skeletons*, never copied crops).
 
 - **Section propagation accuracy.** Wrong sections poison face grouping.
   → Labels land `PENDING` until QA'd; M1 has a hard measured-accuracy gate;
-  clustering (M2) weights by section confidence.
+  clustering (M2) weights by section confidence. The M1 label↔section
+  consistency audit is the reverse check — it uses the propagated sections to
+  surface mislabeled words (flagged `NEEDS_REVIEW`), and the per-label
+  violation rate is a standing quality metric for both the labels and the
+  sections.
 - **Families don't separate cleanly** (continuum instead of clusters).
   → The IoU probe already shows separation at atlas level; if crops are
   messier, fall back to fewer/coarser families — even 2 families beat 9
@@ -228,3 +235,4 @@ unchanged — family fonts are *fitted skeletons*, never copied crops).
 | Crop embedding | deterministic pixel+geometry features first | no new API deps, reproducible; upgrade only if clusters demand |
 | Font model | family skeleton + face transform + merchant offset | stroke-space pooling is the diagonal fix; offsets keep printer character |
 | Calibration | v1 `calibrate_merchant` unchanged, downstream | v1 composes; railed-pin disappearance is the epic's acceptance test |
+| Label↔section co-QA | M1 consistency audit flags inconsistent labels `NEEDS_REVIEW`; per-label violation rate is an exit metric | sections and labels are shared ground truth — each QAs the other; propagated sections catch mislabels the original pass missed |


### PR DESCRIPTION
Follow-up to #1066, which added the **M1 label-section consistency audit** deliverable to the M1 milestone bullet. This threads that already-agreed deliverable through the three other places in the epic doc that still described M1 without it:

- **Pipeline** — adds the `S1' audit` stage (cross-tab CORE label × consensus section → flag inconsistent labels `NEEDS_REVIEW` → per-label violation rate).
- **Risks** — frames the audit as the *reverse check* on "section propagation accuracy": propagated sections surface mislabels, and the per-label violation rate is a standing quality metric for both the labels and the sections.
- **Decision log** — a `Label↔section co-QA` row.

No change to the M1 milestone text itself (already covered by #1066). Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)