### PR TITLE
feat(dynamo): canonical section vocab + optional fields on ReceiptSection (font-intel)

### DIFF
--- a/receipt_dynamo/receipt_dynamo/constants.py
+++ b/receipt_dynamo/receipt_dynamo/constants.py
@@ -80,12 +80,31 @@ class EmbeddingStatus(str, Enum):
 
 
 class SectionType(str, Enum):
-    """Types of receipt sections for classification."""
+    """Types of receipt sections for classification.
 
-    HEADER = "HEADER"  # Contains merchant info, date, receipt number
-    FOOTER = "FOOTER"  # Contains totals, payment info, thank you notes
-    ITEMS_VALUE = "ITEMS_VALUE"  # The number that the item is worth
-    ITEMS_DESCRIPTION = "ITEMS_DESCRIPTION"  # The description of the item
+    The canonical vocabulary (font-intelligence epic, stylescan's ten
+    sections) is the lower block. The three LEGACY values are from a
+    superseded 2025-05 classifier experiment and are deprecated — kept only so
+    any stray legacy rows still parse. ``FOOTER`` is retained and reused as the
+    canonical footer.
+    """
+
+    # --- legacy (deprecated: superseded 2025-05 experiment) ---
+    HEADER = "HEADER"  # deprecated -> STOREFRONT / ADDRESS
+    ITEMS_VALUE = "ITEMS_VALUE"  # deprecated -> ITEMS
+    ITEMS_DESCRIPTION = "ITEMS_DESCRIPTION"  # deprecated -> ITEMS
+
+    # --- canonical vocabulary (epic sec. 4.1) ---
+    STOREFRONT = "STOREFRONT"  # merchant name / logo / hours / lane header
+    ADDRESS = "ADDRESS"  # street address + store phone
+    ITEMS = "ITEMS"  # purchased line items
+    SECTION_HEADER = "SECTION_HEADER"  # department dividers
+    SUMMARY = "SUMMARY"  # subtotal / tax / discounts / item counts
+    TOTAL_LINE = "TOTAL_LINE"  # the grand-total line
+    PAYMENT = "PAYMENT"  # tender: card / auth / change / cash back
+    SURVEY = "SURVEY"  # post-purchase survey / sweepstakes
+    FOOTER = "FOOTER"  # thank-you / policy / rewards / register metadata
+    BARCODE = "BARCODE"  # numeric barcode captions
 
 
 class MerchantValidationStatus(str, Enum):

--- a/receipt_dynamo/receipt_dynamo/entities/receipt_section.py
+++ b/receipt_dynamo/receipt_dynamo/entities/receipt_section.py
@@ -111,7 +111,10 @@ class ReceiptSection:
             raise ValueError("model_source must be a string or None")
 
         if self.validation_status is not None:
-            status = str(self.validation_status).upper()
+            status = self.validation_status
+            if isinstance(status, ValidationStatus):
+                status = status.value
+            status = str(status).upper()
             allowed = {s.value for s in ValidationStatus}
             if status not in allowed:
                 raise ValueError(

--- a/receipt_dynamo/receipt_dynamo/entities/receipt_section.py
+++ b/receipt_dynamo/receipt_dynamo/entities/receipt_section.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Generator
 
-from receipt_dynamo.constants import SectionType
+from receipt_dynamo.constants import SectionType, ValidationStatus
 from receipt_dynamo.entities.util import (
     _repr_str,
     assert_valid_uuid,
@@ -25,12 +25,17 @@ class ReceiptSection:
         section_type (str): The type of section (e.g., "HEADER", "FOOTER",
             "LINE_ITEMS", etc.)
         line_ids (list[int]): The line IDs in this section.
-        confidence (float): The model's confidence in this section
-            classification.
-        embedding_status (EmbeddingStatus): The status of the embedding for
-            this section.
         created_at (datetime): Timestamp when this section was created.
-        model_source (str): The model or pipeline that identified this section.
+        confidence (float | None): Optional model confidence in [0, 1].
+        model_source (str | None): Optional model / pipeline that produced this
+            section (e.g. "section-seed-v0"). Used to version writes and to
+            distinguish generations of rows.
+        validation_status (str | None): Optional QA status
+            (PENDING / VALID / INVALID / NEEDS_REVIEW) — machine-seeded rows
+            land PENDING and are promoted by QA.
+
+    The three optional fields are additive: rows written before they existed
+    (and readers that ignore them) remain valid.
     """
 
     REQUIRED_KEYS = {
@@ -46,6 +51,9 @@ class ReceiptSection:
     section_type: str | SectionType
     line_ids: list[int]
     created_at: datetime | str
+    confidence: float | None = None
+    model_source: str | None = None
+    validation_status: str | None = None
 
     def __post_init__(self):
         """Validate and initialize the ReceiptSection instance."""
@@ -87,6 +95,32 @@ class ReceiptSection:
         else:
             raise ValueError("created_at must be a datetime or ISO string")
 
+        # Optional fields (additive) --------------------------------------
+        if self.confidence is not None:
+            if isinstance(self.confidence, bool) or not isinstance(
+                self.confidence, (int, float)
+            ):
+                raise ValueError("confidence must be a number or None")
+            self.confidence = float(self.confidence)
+            if not 0.0 <= self.confidence <= 1.0:
+                raise ValueError("confidence must be in [0, 1]")
+
+        if self.model_source is not None and not isinstance(
+            self.model_source, str
+        ):
+            raise ValueError("model_source must be a string or None")
+
+        if self.validation_status is not None:
+            status = str(self.validation_status).upper()
+            allowed = {s.value for s in ValidationStatus}
+            if status not in allowed:
+                raise ValueError(
+                    "validation_status must be one of "
+                    f"{sorted(allowed)} or None; got "
+                    f"{self.validation_status!r}"
+                )
+            self.validation_status = status
+
     @property
     def key(self) -> dict[str, Any]:
         """Generate the primary key for the receipt section."""
@@ -101,8 +135,12 @@ class ReceiptSection:
         }
 
     def to_item(self) -> dict[str, Any]:
-        """Convert the ReceiptSection to a DynamoDB item."""
-        return {
+        """Convert the ReceiptSection to a DynamoDB item.
+
+        Optional fields are only emitted when set, so rows stay identical to
+        the pre-existing schema when the new fields are unused.
+        """
+        item = {
             **self.key,
             "TYPE": {"S": "RECEIPT_SECTION"},
             "section_type": {"S": self.section_type},
@@ -111,6 +149,13 @@ class ReceiptSection:
             },
             "created_at": {"S": self.created_at.isoformat()},
         }
+        if self.confidence is not None:
+            item["confidence"] = {"N": str(self.confidence)}
+        if self.model_source is not None:
+            item["model_source"] = {"S": self.model_source}
+        if self.validation_status is not None:
+            item["validation_status"] = {"S": self.validation_status}
+        return item
 
     def __repr__(self) -> str:
         """Returns a string representation of the ReceiptSection object."""
@@ -120,7 +165,10 @@ class ReceiptSection:
             f"image_id={_repr_str(self.image_id)}, "
             f"section_type='{self.section_type}', "
             f"line_ids={self.line_ids}, "
-            f"created_at={_repr_str(self.created_at.isoformat())}"
+            f"created_at={_repr_str(self.created_at.isoformat())}, "
+            f"confidence={self.confidence}, "
+            f"model_source={_repr_str(self.model_source)}, "
+            f"validation_status={_repr_str(self.validation_status)}"
             f")"
         )
 
@@ -132,6 +180,9 @@ class ReceiptSection:
         yield "section_type", self.section_type
         yield "line_ids", self.line_ids
         yield "created_at", self.created_at.isoformat()
+        yield "confidence", self.confidence
+        yield "model_source", self.model_source
+        yield "validation_status", self.validation_status
 
     def __hash__(self) -> int:
         """Return a hash of the ReceiptSection."""
@@ -142,6 +193,9 @@ class ReceiptSection:
                 self.section_type,
                 tuple(self.line_ids),
                 self.created_at.isoformat(),
+                self.confidence,
+                self.model_source,
+                self.validation_status,
             )
         )
 
@@ -172,12 +226,30 @@ class ReceiptSection:
             line_ids = [int(li["N"]) for li in item["line_ids"]["L"]]
             created_at = datetime.fromisoformat(item["created_at"]["S"])
 
+            # Optional fields (absent on legacy rows)
+            confidence = (
+                float(item["confidence"]["N"])
+                if "confidence" in item
+                else None
+            )
+            model_source = (
+                item["model_source"]["S"] if "model_source" in item else None
+            )
+            validation_status = (
+                item["validation_status"]["S"]
+                if "validation_status" in item
+                else None
+            )
+
             return cls(
                 receipt_id=receipt_id,
                 image_id=image_id,
                 section_type=section_type,
                 line_ids=line_ids,
                 created_at=created_at,
+                confidence=confidence,
+                model_source=model_source,
+                validation_status=validation_status,
             )
         except (KeyError, IndexError, ValueError) as e:
             raise ValueError(

--- a/receipt_dynamo/tests/unit/test_receipt_section.py
+++ b/receipt_dynamo/tests/unit/test_receipt_section.py
@@ -267,3 +267,121 @@ def test_item_to_receipt_section(example_receipt_section):
         ValueError, match="Error converting item to ReceiptSection"
     ):
         item_to_receipt_section(invalid_item)
+
+
+# --- canonical vocabulary + optional fields (font-intelligence epic) -------
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "canonical",
+    [
+        "STOREFRONT",
+        "ADDRESS",
+        "ITEMS",
+        "SECTION_HEADER",
+        "SUMMARY",
+        "TOTAL_LINE",
+        "PAYMENT",
+        "SURVEY",
+        "FOOTER",
+        "BARCODE",
+    ],
+)
+def test_canonical_section_types_accepted(canonical):
+    """All ten canonical section types are valid."""
+    s = ReceiptSection(
+        receipt_id=1,
+        image_id="3f52804b-2fad-4e00-92c8-b593da3a8ed3",
+        section_type=canonical,
+        line_ids=[1],
+        created_at=datetime(2023, 1, 1),
+    )
+    assert s.section_type == canonical
+
+
+@pytest.mark.unit
+def test_optional_fields_roundtrip():
+    """confidence / model_source / validation_status survive to_item/from_item."""
+    s = ReceiptSection(
+        receipt_id=2,
+        image_id="3f52804b-2fad-4e00-92c8-b593da3a8ed3",
+        section_type="TOTAL_LINE",
+        line_ids=[7, 8],
+        created_at=datetime(2026, 7, 8),
+        confidence=0.75,
+        model_source="section-seed-v0",
+        validation_status="pending",  # normalized to PENDING
+    )
+    assert s.validation_status == "PENDING"
+    item = s.to_item()
+    assert item["confidence"]["N"] == "0.75"
+    assert item["model_source"]["S"] == "section-seed-v0"
+    assert item["validation_status"]["S"] == "PENDING"
+    assert item_to_receipt_section(item) == s
+
+
+@pytest.mark.unit
+def test_optional_fields_omitted_when_none(example_receipt_section):
+    """to_item stays schema-identical to the legacy row when unset."""
+    item = example_receipt_section.to_item()
+    assert "confidence" not in item
+    assert "model_source" not in item
+    assert "validation_status" not in item
+
+
+@pytest.mark.unit
+def test_legacy_item_without_optionals_parses():
+    """A row written before the optional fields existed still deserializes."""
+    legacy = {
+        "PK": {"S": "IMAGE#3f52804b-2fad-4e00-92c8-b593da3a8ed3"},
+        "SK": {"S": "RECEIPT#00001#SECTION#HEADER"},
+        "TYPE": {"S": "RECEIPT_SECTION"},
+        "section_type": {"S": "HEADER"},
+        "line_ids": {"L": [{"N": "1"}, {"N": "2"}]},
+        "created_at": {"S": "2025-05-01T00:00:00"},
+    }
+    s = item_to_receipt_section(legacy)
+    assert s.confidence is None
+    assert s.model_source is None
+    assert s.validation_status is None
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("bad", [-0.1, 1.1, "high", True])
+def test_invalid_confidence_rejected(bad):
+    with pytest.raises(ValueError, match="confidence"):
+        ReceiptSection(
+            receipt_id=1,
+            image_id="3f52804b-2fad-4e00-92c8-b593da3a8ed3",
+            section_type="ITEMS",
+            line_ids=[1],
+            created_at=datetime(2023, 1, 1),
+            confidence=bad,
+        )
+
+
+@pytest.mark.unit
+def test_invalid_validation_status_rejected():
+    with pytest.raises(ValueError, match="validation_status"):
+        ReceiptSection(
+            receipt_id=1,
+            image_id="3f52804b-2fad-4e00-92c8-b593da3a8ed3",
+            section_type="ITEMS",
+            line_ids=[1],
+            created_at=datetime(2023, 1, 1),
+            validation_status="BOGUS",
+        )
+
+
+@pytest.mark.unit
+def test_invalid_model_source_rejected():
+    with pytest.raises(ValueError, match="model_source"):
+        ReceiptSection(
+            receipt_id=1,
+            image_id="3f52804b-2fad-4e00-92c8-b593da3a8ed3",
+            section_type="ITEMS",
+            line_ids=[1],
+            created_at=datetime(2023, 1, 1),
+            model_source=123,
+        )

--- a/receipt_dynamo/tests/unit/test_receipt_section.py
+++ b/receipt_dynamo/tests/unit/test_receipt_section.py
@@ -385,3 +385,19 @@ def test_invalid_model_source_rejected():
             created_at=datetime(2023, 1, 1),
             model_source=123,
         )
+
+
+@pytest.mark.unit
+def test_validation_status_accepts_enum_instance():
+    """Passing the ValidationStatus enum (not just its .value) is normalized."""
+    from receipt_dynamo.constants import ValidationStatus
+
+    s = ReceiptSection(
+        receipt_id=1,
+        image_id="3f52804b-2fad-4e00-92c8-b593da3a8ed3",
+        section_type="ITEMS",
+        line_ids=[1],
+        created_at=datetime(2023, 1, 1),
+        validation_status=ValidationStatus.PENDING,
+    )
+    assert s.validation_status == "PENDING"


### PR DESCRIPTION
## Storage pivot for the font-intelligence epic

The epic now persists per-receipt **sections** via the purpose-built **`ReceiptSection`** entity (line-level: one row per `(receipt, section_type)` holding its `line_ids`) rather than `SECTION_*` `ReceiptWordLabel` rows — keeping the label table a clean training corpus. This PR is the storage foundation.

### `SectionType`
Adds the ten canonical sections (`STOREFRONT / ADDRESS / ITEMS / SECTION_HEADER / SUMMARY / TOTAL_LINE / PAYMENT / SURVEY / FOOTER / BARCODE`). The three legacy values (`HEADER / ITEMS_VALUE / ITEMS_DESCRIPTION`) from the superseded 2025-05 classifier experiment are kept-but-deprecated so any stray rows still parse; `FOOTER` is retained and reused as the canonical footer.

### `ReceiptSection` — optional fields (additive)
- `confidence: float|None` (validated `[0,1]`), `model_source: str|None` (versions writes, e.g. `section-seed-v0`), `validation_status: str|None` (`PENDING`→QA).
- `to_item` emits them **only when set** → rows stay byte-identical to the old schema when unused; `from_item` reads them when present (legacy rows → `None`). The docstring previously advertised `confidence`/`model_source` that were never actually persisted — now the useful ones are real.

### Notes
- Fully back-compatible: legacy rows (no optional keys) deserialize with `None`.
- Codex P2 fixed: normalize a `ValidationStatus` enum instance to its `.value` before validating.
- **Not wired to Chroma here** — the embedding pipeline's `section_label` hook is currently inert (fetches sections but never maps them onto lines); completing that is a deferred M1 task.

### Tests
13 new + 33 total green in `test_receipt_section.py` (canonical types, optional round-trip, schema-identical-when-none, legacy-row parse, confidence/status/model_source validation, enum-instance normalization).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded receipt section labels to support a fuller set of canonical section types across receipts.
  * Added optional receipt section metadata for confidence, source, and validation state.

* **Bug Fixes**
  * Improved compatibility with older stored receipt data so existing records continue to load correctly.
  * Optional metadata is now saved only when present, avoiding unnecessary changes to existing output.

* **Tests**
  * Added coverage for the new section labels and metadata handling, including validation and round-trip behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->