### PR TITLE
fix(embedding): stop silent data loss + unblock stuck ingest pipeline

### DIFF
--- a/infra/embedding_step_functions/components/line_workflow.py
+++ b/infra/embedding_step_functions/components/line_workflow.py
@@ -217,6 +217,10 @@ class LineEmbeddingWorkflow(ComponentResource):
                     "Parameters": {
                         "batch_type": "line",
                         "execution_id.$": "$$.Execution.Name",
+                        # Cap batches per run so the PollBatches Map aggregate
+                        # result stays under the SFN 256KB state limit. Remaining
+                        # PENDING batches drain on the next run.
+                        "max_batches": 250,
                     },
                     "ResultPath": "$.list_result",
                     "Next": "CheckPendingBatches",
@@ -254,7 +258,7 @@ class LineEmbeddingWorkflow(ComponentResource):
                     "OpenAI file-download rate limits / circuit breaker on "
                     "large backlogs",
                     "ItemsPath": "$.poll_batches_data.batch_indices",
-                    "MaxConcurrency": 5,
+                    "MaxConcurrency": 50,
                     "Parameters": {
                         "batch_index.$": "$$.Map.Item.Value",
                         "manifest_s3_key.$": "$.poll_batches_data.manifest_s3_key",
@@ -289,6 +293,22 @@ class LineEmbeddingWorkflow(ComponentResource):
                                         "IntervalSeconds": 10,
                                         "MaxAttempts": 5,
                                         "BackoffRate": 2.0,
+                                    },
+                                    {
+                                        # OpenAI circuit breaker opened under
+                                        # burst load. The poll handler surfaces
+                                        # this as a RuntimeError (States.TaskFailed
+                                        # to SFN), NOT a CircuitBreakerOpenError
+                                        # name. Wait out the breaker's 60s
+                                        # recovery window (+ jitter) instead of
+                                        # failing the whole poll Map.
+                                        "ErrorEquals": [
+                                            "States.TaskFailed"
+                                        ],
+                                        "IntervalSeconds": 60,
+                                        "MaxAttempts": 6,
+                                        "BackoffRate": 1.5,
+                                        "JitterStrategy": "FULL",
                                     },
                                 ],
                             },

--- a/infra/embedding_step_functions/components/line_workflow.py
+++ b/infra/embedding_step_functions/components/line_workflow.py
@@ -250,9 +250,11 @@ class LineEmbeddingWorkflow(ComponentResource):
                 },
                 "PollBatches": {
                     "Type": "Map",
-                    "Comment": "Poll batches in parallel (100 concurrent)",
+                    "Comment": "Poll batches in parallel — bounded to avoid "
+                    "OpenAI file-download rate limits / circuit breaker on "
+                    "large backlogs",
                     "ItemsPath": "$.poll_batches_data.batch_indices",
-                    "MaxConcurrency": 100,
+                    "MaxConcurrency": 5,
                     "Parameters": {
                         "batch_index.$": "$$.Map.Item.Value",
                         "manifest_s3_key.$": "$.poll_batches_data.manifest_s3_key",

--- a/infra/embedding_step_functions/components/word_workflow.py
+++ b/infra/embedding_step_functions/components/word_workflow.py
@@ -217,6 +217,11 @@ class WordEmbeddingWorkflow(ComponentResource):
                         "Parameters": {
                             "batch_type": "word",
                             "execution_id.$": "$$.Execution.Name",
+                            # Cap batches per run so the PollWordBatches Map
+                            # aggregate result stays under the SFN 256KB state
+                            # limit. Remaining PENDING batches drain on the next
+                            # run. (Long-term: offload poll results to S3.)
+                            "max_batches": 250,
                         },
                         "ResultPath": "$.list_result",
                         "Next": "CheckPendingWordBatches",
@@ -254,7 +259,7 @@ class WordEmbeddingWorkflow(ComponentResource):
                         "OpenAI file-download rate limits / circuit breaker on "
                         "large backlogs",
                         "ItemsPath": "$.poll_batches_data.batch_indices",
-                        "MaxConcurrency": 5,
+                        "MaxConcurrency": 50,
                         "Parameters": {
                             "batch_index.$": "$$.Map.Item.Value",
                             "manifest_s3_key.$": "$.poll_batches_data.manifest_s3_key",
@@ -289,6 +294,26 @@ class WordEmbeddingWorkflow(ComponentResource):
                                             "IntervalSeconds": 10,
                                             "MaxAttempts": 5,
                                             "BackoffRate": 2.0,
+                                        },
+                                        {
+                                            # OpenAI circuit breaker opened under
+                                            # burst load (higher MaxConcurrency).
+                                            # The poll handler surfaces this as a
+                                            # RuntimeError ("Circuit breaker
+                                            # openai_api is open"), i.e.
+                                            # States.TaskFailed to SFN (NOT a
+                                            # CircuitBreakerOpenError name). Wait
+                                            # out the breaker's 60s recovery
+                                            # window (+ jitter so retries don't
+                                            # re-burst in lockstep) instead of
+                                            # failing the whole poll Map.
+                                            "ErrorEquals": [
+                                                "States.TaskFailed"
+                                            ],
+                                            "IntervalSeconds": 60,
+                                            "MaxAttempts": 6,
+                                            "BackoffRate": 1.5,
+                                            "JitterStrategy": "FULL",
                                         },
                                     ],
                                 },

--- a/infra/embedding_step_functions/components/word_workflow.py
+++ b/infra/embedding_step_functions/components/word_workflow.py
@@ -250,9 +250,11 @@ class WordEmbeddingWorkflow(ComponentResource):
                     },
                     "PollWordBatches": {
                         "Type": "Map",
-                        "Comment": "Poll batches in parallel (100 concurrent)",
+                        "Comment": "Poll batches in parallel — bounded to avoid "
+                        "OpenAI file-download rate limits / circuit breaker on "
+                        "large backlogs",
                         "ItemsPath": "$.poll_batches_data.batch_indices",
-                        "MaxConcurrency": 100,
+                        "MaxConcurrency": 5,
                         "Parameters": {
                             "batch_index.$": "$$.Map.Item.Value",
                             "manifest_s3_key.$": "$.poll_batches_data.manifest_s3_key",

--- a/infra/embedding_step_functions/simple_lambdas/list_pending/handler.py
+++ b/infra/embedding_step_functions/simple_lambdas/list_pending/handler.py
@@ -10,6 +10,7 @@ payload size limits.
 import json
 import logging
 import os
+import random
 import tempfile
 import uuid
 from datetime import datetime
@@ -144,9 +145,17 @@ def lambda_handler(
         except (TypeError, ValueError):
             max_batches = 0
         if max_batches and total_pending > max_batches:
+            # Randomly sample the slice instead of always taking the first
+            # `max_batches` from the status GSI. A fixed prefix would let a few
+            # permanently-stuck batches (e.g. orphaned batches referencing
+            # deleted words, which poll but never mark COMPLETE) sit at the
+            # front and starve every later batch forever. Random sampling lets
+            # the healthy batches drain (they get marked COMPLETE and leave the
+            # PENDING set), so the backlog actually converges.
+            random.shuffle(pending_batches)
             pending_batches = pending_batches[:max_batches]
             logger.info(
-                "Capping this run to %d of %d pending batches "
+                "Capping this run to a random %d of %d pending batches "
                 "(remaining %d will be handled by subsequent runs)",
                 max_batches,
                 total_pending,

--- a/infra/embedding_step_functions/simple_lambdas/list_pending/handler.py
+++ b/infra/embedding_step_functions/simple_lambdas/list_pending/handler.py
@@ -123,11 +123,35 @@ def lambda_handler(
                 dynamo_client, BatchType.LINE_EMBEDDING
             )
 
+        total_pending = len(pending_batches)
         logger.info(
             "Found %d pending %s embedding batches",
-            len(pending_batches),
+            total_pending,
             batch_type,
         )
+
+        # Cap the number of batches processed per run so the PollBatches Map's
+        # aggregate result stays under the Step Functions 256KB state-payload
+        # limit. The remaining PENDING batches are picked up by the next run.
+        # Controlled by event["max_batches"] or MAX_BATCHES_PER_RUN env var
+        # (0/unset = no cap). See infra/embedding_step_functions for the
+        # long-term fix (offload poll results to S3 instead of inline).
+        try:
+            max_batches = int(
+                event.get("max_batches")
+                or os.environ.get("MAX_BATCHES_PER_RUN", 0)
+            )
+        except (TypeError, ValueError):
+            max_batches = 0
+        if max_batches and total_pending > max_batches:
+            pending_batches = pending_batches[:max_batches]
+            logger.info(
+                "Capping this run to %d of %d pending batches "
+                "(remaining %d will be handled by subsequent runs)",
+                max_batches,
+                total_pending,
+                total_pending - max_batches,
+            )
 
         # Format response for Step Function
         batch_list = [

--- a/infra/embedding_step_functions/unified_embedding/handlers/compaction.py
+++ b/infra/embedding_step_functions/unified_embedding/handlers/compaction.py
@@ -9,6 +9,7 @@ import os
 import shutil
 import tempfile
 import time
+import traceback
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -1341,14 +1342,10 @@ def final_merge_handler(event: Dict[str, Any]) -> Dict[str, Any]:
             total_chunks=original_count,
             database=database_name,
         )
-        return {
-            "statusCode": 500,
-            "error": error_msg,
-            "batch_id": batch_id,
-            "message": "Final merge failed - no valid intermediate snapshots to merge",
-            "poll_results_s3_key": poll_results_s3_key,  # Pass through for MarkBatchesComplete
-            "poll_results_s3_bucket": poll_results_s3_bucket,  # Pass through for MarkBatchesComplete
-        }
+        # RAISE instead of returning statusCode 500: returning here (while
+        # passing poll_results through) previously let MarkBatchesComplete mark
+        # the batches COMPLETE even though nothing merged -> silent data loss.
+        raise RuntimeError(error_msg)
 
     # Use filtered results
     chunk_results = valid_chunk_results
@@ -1742,26 +1739,27 @@ def final_merge_handler(event: Dict[str, Any]) -> Dict[str, Any]:
             )
             raise  # Re-raise so Step Functions treats it as a task failure and retries
 
-        # For other RuntimeErrors, log and return error response
-        logger.error("Final merge failed with RuntimeError", error=error_msg)
-        return {
-            "statusCode": 500,
-            "error": error_msg,
-            "batch_id": batch_id,
-            "message": "Final merge failed",
-            "poll_results_s3_key": poll_results_s3_key,  # Pass through for MarkBatchesComplete
-            "poll_results_s3_bucket": poll_results_s3_bucket,  # Pass through for MarkBatchesComplete
-        }
+        # For other RuntimeErrors: RE-RAISE so Step Functions treats this as a
+        # task failure (triggers the FinalMerge Retry, and on exhaustion the
+        # Catch -> Fail). Previously this returned statusCode 500 while passing
+        # poll_results through, which let MarkBatchesComplete run anyway and
+        # marked batches COMPLETE despite an empty/failed merge -> silent data
+        # loss. Never mark batches complete when the merge did not succeed.
+        logger.error(
+            "Final merge failed with RuntimeError",
+            error=error_msg,
+            traceback=traceback.format_exc(),
+        )
+        raise
     except Exception as e:  # pylint: disable=broad-exception-caught
-        logger.error("Final merge failed", error=str(e))
-        return {
-            "statusCode": 500,
-            "error": str(e),
-            "batch_id": batch_id,
-            "message": "Final merge failed",
-            "poll_results_s3_key": poll_results_s3_key,  # Pass through for MarkBatchesComplete
-            "poll_results_s3_bucket": poll_results_s3_bucket,  # Pass through for MarkBatchesComplete
-        }
+        # RE-RAISE (see note above): a failed merge must NOT be reported as a
+        # success, or batches get marked COMPLETE with no vectors landed.
+        logger.error(
+            "Final merge failed",
+            error=str(e),
+            traceback=traceback.format_exc(),
+        )
+        raise
     finally:
         # Stop heartbeat and release lock
         lock_manager.stop_heartbeat()
@@ -2883,42 +2881,54 @@ def perform_final_merge(
                 if not use_predownloaded:
                     shutil.rmtree(chunk_temp, ignore_errors=True)
 
-        # Sync to Chroma Cloud (if enabled)
-        cloud_config = CloudConfig.from_env()
+        # Sync to Chroma Cloud (if enabled). This is INTENTIONALLY non-blocking:
+        # the local S3 snapshot is the source of truth, and a cloud outage (or a
+        # deleted/absent cloud collection) must never fail the merge. The whole
+        # block is wrapped so that even an exception at cloud-client construction
+        # (e.g. tenant/database validation) is swallowed here rather than
+        # propagating up to final_merge_handler, which now re-raises on error.
         cloud_sync_result = None
+        try:
+            cloud_config = CloudConfig.from_env()
 
-        if cloud_config:
-            sync_collection_name = database_name or "words"
-            logger.info(
-                "Syncing collection to Chroma Cloud",
-                collection=sync_collection_name,
-                total_embeddings=total_embeddings,
-            )
-
-            cloud_sync_result = sync_collection_to_cloud(
-                local_client=chroma_client,
-                collection_name=sync_collection_name,
-                cloud_config=cloud_config,
-                batch_size=250,  # Within Chroma Cloud quota limit (300)
-                max_workers=4,
-                logger=logger,
-            )
-
-            if cloud_sync_result.success:
+            if cloud_config:
+                sync_collection_name = database_name or "words"
                 logger.info(
-                    "Cloud sync completed",
+                    "Syncing collection to Chroma Cloud",
                     collection=sync_collection_name,
-                    uploaded=cloud_sync_result.uploaded,
-                    cloud_count=cloud_sync_result.cloud_count,
-                    duration_seconds=cloud_sync_result.duration_seconds,
+                    total_embeddings=total_embeddings,
                 )
-            else:
-                logger.error(
-                    "Cloud sync failed (non-blocking)",
-                    collection=sync_collection_name,
-                    error=cloud_sync_result.error,
-                    failed_batches=cloud_sync_result.failed_batches,
+
+                cloud_sync_result = sync_collection_to_cloud(
+                    local_client=chroma_client,
+                    collection_name=sync_collection_name,
+                    cloud_config=cloud_config,
+                    batch_size=250,  # Within Chroma Cloud quota limit (300)
+                    max_workers=4,
+                    logger=logger,
                 )
+
+                if cloud_sync_result.success:
+                    logger.info(
+                        "Cloud sync completed",
+                        collection=sync_collection_name,
+                        uploaded=cloud_sync_result.uploaded,
+                        cloud_count=cloud_sync_result.cloud_count,
+                        duration_seconds=cloud_sync_result.duration_seconds,
+                    )
+                else:
+                    logger.error(
+                        "Cloud sync failed (non-blocking)",
+                        collection=sync_collection_name,
+                        error=cloud_sync_result.error,
+                        failed_batches=cloud_sync_result.failed_batches,
+                    )
+        except Exception as cloud_err:  # pylint: disable=broad-exception-caught
+            logger.error(
+                "Cloud sync raised (non-blocking) - continuing with local snapshot",
+                error=str(cloud_err),
+                traceback=traceback.format_exc(),
+            )
 
         # CRITICAL: Close ChromaDB client BEFORE uploading to ensure SQLite files are flushed and unlocked
         close_chromadb_client(chroma_client, collection_name="final_merge")

--- a/receipt_chroma/pyproject.toml
+++ b/receipt_chroma/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 ]
 dependencies = [
     "boto3>=1.43.32,<1.44.0",
-    "chromadb>=1.5.0",
+    "chromadb>=1.5.0,<1.6.0",  # pin to tested 1.5.x line; 1.6+ untested for snapshot/tenant compat
     "openai>=2.8.1,<3.0.0",
     "receipt-dynamo",
     "receipt-dynamo-stream",


### PR DESCRIPTION
## Summary
Fixes found while re-embedding dev+prod after a full embedding reset. The ingest pipeline had been stuck since Jun 15 and was silently losing data.

### 1. 256KB Step Functions limit (the stuck pipeline)
The poll Map returned every batch result inline, so on a large backlog the aggregate exceeded SFN's 256KB state-payload cap and **every run died before marking anything**. Added a per-run cap (`list_pending` `max_batches`, wired through the ingest SM `ListPending` params, default 250) so the Map output stays bounded; the rest drains on later runs.

### 2. Silent data loss in FinalMerge (the important one)
`final_merge_handler` caught merge failures and **returned** a `statusCode: 500` body that still passed `poll_results` through — so the state machine ran `MarkBatchesComplete` and marked batches **COMPLETE with an empty snapshot**. Now it **re-raises** on every failure path, so the existing Retry/Catch handles it and batches stay PENDING. Added full `traceback` logging.

### 3. Cloud sync could crash the merge
Now that FinalMerge re-raises, the Chroma Cloud dual-write is wrapped in its own try/except so a cloud outage / missing collection stays genuinely non-blocking (local S3 snapshot is source of truth).

### Also
- Poll Map `MaxConcurrency` 100→50 + a **breaker-aware Retry**. The OpenAI circuit breaker surfaces as a `RuntimeError` (`States.TaskFailed`), **not** a `CircuitBreakerOpenError` name — so match `States.TaskFailed` with a 60s jittered backoff to outlast the breaker's 60s recovery.
- Pin `chromadb>=1.5.0,<1.6.0` (was unpinned).

## Validation
Proven end-to-end on **dev and prod**: capped runs SUCCEED, batches mark COMPLETE, and vectors land in both the S3 snapshot and Chroma Cloud (dev 49k+ words, prod 44k+ words and climbing). A prod arch-mismatch failure during rollout failed **loudly** (batches stayed PENDING) — confirming the re-raise fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)