### PR TITLE
feat(chroma): plumb section_label through embedding payloads (font-intel M1a-1)

### DIFF
--- a/receipt_chroma/receipt_chroma/embedding/metadata/line_metadata.py
+++ b/receipt_chroma/receipt_chroma/embedding/metadata/line_metadata.py
@@ -139,8 +139,13 @@ def create_row_metadata(
     row_lines: Sequence[ReceiptLine],
     merchant_name: Optional[str] = None,
     source: str = "openai_embedding_batch",
+    section_label: Optional[str] = None,
 ) -> LineMetadata:
-    """Create metadata for a visual row embedding."""
+    """Create metadata for a visual row embedding.
+
+    ``section_label`` (the row's receipt section, e.g. ``TOTAL_LINE``) is
+    emitted only when set — mirrors ``create_line_metadata``.
+    """
     if not row_lines:
         raise ValueError("Cannot create metadata for empty row")
 
@@ -183,6 +188,9 @@ def create_row_metadata(
 
     if merchant_name:
         metadata["merchant_name"] = merchant_name
+
+    if section_label:
+        metadata["section_label"] = section_label
 
     return metadata
 

--- a/receipt_chroma/receipt_chroma/embedding/records.py
+++ b/receipt_chroma/receipt_chroma/embedding/records.py
@@ -4,8 +4,9 @@ These lightweight dataclasses keep embedding payloads (id, document text,
 metadata) aligned with the same schema used for persisted snapshots/deltas.
 """
 
+from collections import Counter
 from dataclasses import dataclass
-from typing import Any, Dict, Iterable, List, Optional
+from typing import Any, Dict, Iterable, List, Optional, Sequence
 
 from receipt_chroma.embedding.formatting.line_format import (
     LineLike,
@@ -116,11 +117,30 @@ class RowEmbeddingRecord:
         return [line.line_id for line in self.row_lines]
 
 
+def sections_to_line_map(sections: Sequence[Any]) -> Dict[int, str]:
+    """Build a ``line_id -> section_type`` map from ReceiptSection rows.
+
+    Each section holds its ``line_ids``; sections partition a receipt's lines,
+    but if a line appears in more than one (e.g. overlapping seed generations)
+    the higher-confidence section wins.
+    """
+    out: Dict[int, str] = {}
+    best: Dict[int, float] = {}
+    for s in sections or []:
+        conf = getattr(s, "confidence", None) or 0.0
+        for line_id in getattr(s, "line_ids", []) or []:
+            if line_id not in out or conf > best.get(line_id, -1.0):
+                out[line_id] = s.section_type
+                best[line_id] = conf
+    return out
+
+
 def build_line_payload(
     records: Iterable[LineEmbeddingRecord],
     all_lines: List[ReceiptLine],
     all_words: List[ReceiptWord],
     merchant_name: Optional[str] = None,
+    section_by_line: Optional[Dict[int, str]] = None,
 ) -> Dict[str, List]:
     """Create Chroma-ready payloads (ids/embeddings/docs/metadatas) for lines.
 
@@ -144,7 +164,11 @@ def build_line_payload(
         embedding_input = format_line_context_embedding_input(line, all_lines)
         prev_line, next_line = parse_prev_next_from_formatted(embedding_input)
 
-        section_label = getattr(line, "section_label", None) or None
+        section_label = (
+            (section_by_line or {}).get(line.line_id)
+            or getattr(line, "section_label", None)
+            or None
+        )
         line_metadata = create_line_metadata(
             line=line,
             prev_line=prev_line,
@@ -230,6 +254,7 @@ def build_row_payload(
     all_words: List[ReceiptWord],
     all_labels: Optional[List[ReceiptWordLabel]] = None,
     merchant_name: Optional[str] = None,
+    section_by_line: Optional[Dict[int, str]] = None,
 ) -> Dict[str, List]:
     """Create Chroma-ready payloads for row-based line embeddings.
 
@@ -256,11 +281,24 @@ def build_row_payload(
         row_line_ids = set(record.line_ids)
         row_words = [w for w in all_words if w.line_id in row_line_ids]
 
+        # Row section = majority section among the row's lines (a row can span
+        # multiple ReceiptLines; sections are line-level).
+        row_section: Optional[str] = None
+        if section_by_line:
+            votes = Counter(
+                section_by_line[lid]
+                for lid in record.line_ids
+                if lid in section_by_line
+            )
+            if votes:
+                row_section = votes.most_common(1)[0][0]
+
         # Create row metadata
         row_metadata = create_row_metadata(
             row_lines=list(record.row_lines),
             merchant_name=merchant_name,
             source="openai_embedding_batch",
+            section_label=row_section,
         )
 
         # Enrich with anchors from all words in the row

--- a/receipt_chroma/receipt_chroma/embedding/records.py
+++ b/receipt_chroma/receipt_chroma/embedding/records.py
@@ -127,6 +127,9 @@ def sections_to_line_map(sections: Sequence[Any]) -> Dict[int, str]:
     out: Dict[int, str] = {}
     best: Dict[int, float] = {}
     for s in sections or []:
+        # skip QA-rejected rows — an INVALID section must not stamp a line
+        if str(getattr(s, "validation_status", "") or "").upper() == "INVALID":
+            continue
         conf = getattr(s, "confidence", None) or 0.0
         for line_id in getattr(s, "line_ids", []) or []:
             if line_id not in out or conf > best.get(line_id, -1.0):
@@ -290,8 +293,10 @@ def build_row_payload(
                 for lid in record.line_ids
                 if lid in section_by_line
             )
-            if votes:
-                row_section = votes.most_common(1)[0][0]
+            top = votes.most_common(2)
+            # only stamp on a clear plurality; a tie is ambiguous -> leave unset
+            if top and (len(top) == 1 or top[0][1] > top[1][1]):
+                row_section = top[0][0]
 
         # Create row metadata
         row_metadata = create_row_metadata(

--- a/receipt_chroma/tests/unit/test_embedding_records.py
+++ b/receipt_chroma/tests/unit/test_embedding_records.py
@@ -384,3 +384,27 @@ class TestSectionLabelWiring:
         s_high = Mock(line_ids=[2], section_type="TOTAL_LINE", confidence=0.95)
         m = sections_to_line_map([s_low, s_high])
         assert m == {1: "ITEMS", 2: "TOTAL_LINE"}  # line 2: higher conf wins
+
+
+class TestSectionGuards:
+    """Codex P2s: skip INVALID sections; don't stamp on a tie."""
+
+    def test_sections_to_line_map_skips_invalid(self):
+        from receipt_chroma.embedding.records import sections_to_line_map
+        good = Mock(line_ids=[1], section_type="ITEMS", confidence=0.9,
+                    validation_status="PENDING")
+        bad = Mock(line_ids=[2], section_type="PAYMENT", confidence=0.9,
+                   validation_status="INVALID")
+        m = sections_to_line_map([good, bad])
+        assert m == {1: "ITEMS"}          # line 2 (INVALID) omitted
+
+    def test_row_payload_no_stamp_on_tie(self):
+        l1 = create_mock_line("img1", 1, 1, "L1")
+        l2 = create_mock_line("img1", 1, 2, "L2")
+        record = RowEmbeddingRecord(row_lines=(l1, l2), embedding=[0.1, 0.2])
+        # 1 vote ITEMS, 1 vote SUMMARY -> tie -> no section_label
+        payload = build_row_payload(
+            records=[record], all_words=[],
+            section_by_line={1: "ITEMS", 2: "SUMMARY"},
+        )
+        assert "section_label" not in payload["metadatas"][0]

--- a/receipt_chroma/tests/unit/test_embedding_records.py
+++ b/receipt_chroma/tests/unit/test_embedding_records.py
@@ -391,12 +391,21 @@ class TestSectionGuards:
 
     def test_sections_to_line_map_skips_invalid(self):
         from receipt_chroma.embedding.records import sections_to_line_map
-        good = Mock(line_ids=[1], section_type="ITEMS", confidence=0.9,
-                    validation_status="PENDING")
-        bad = Mock(line_ids=[2], section_type="PAYMENT", confidence=0.9,
-                   validation_status="INVALID")
+
+        good = Mock(
+            line_ids=[1],
+            section_type="ITEMS",
+            confidence=0.9,
+            validation_status="PENDING",
+        )
+        bad = Mock(
+            line_ids=[2],
+            section_type="PAYMENT",
+            confidence=0.9,
+            validation_status="INVALID",
+        )
         m = sections_to_line_map([good, bad])
-        assert m == {1: "ITEMS"}          # line 2 (INVALID) omitted
+        assert m == {1: "ITEMS"}  # line 2 (INVALID) omitted
 
     def test_row_payload_no_stamp_on_tie(self):
         l1 = create_mock_line("img1", 1, 1, "L1")
@@ -404,7 +413,8 @@ class TestSectionGuards:
         record = RowEmbeddingRecord(row_lines=(l1, l2), embedding=[0.1, 0.2])
         # 1 vote ITEMS, 1 vote SUMMARY -> tie -> no section_label
         payload = build_row_payload(
-            records=[record], all_words=[],
+            records=[record],
+            all_words=[],
             section_by_line={1: "ITEMS", 2: "SUMMARY"},
         )
         assert "section_label" not in payload["metadatas"][0]

--- a/receipt_chroma/tests/unit/test_embedding_records.py
+++ b/receipt_chroma/tests/unit/test_embedding_records.py
@@ -341,3 +341,46 @@ class TestBuildWordPayload:
         metadata = payload["metadatas"][0]
         assert metadata["left"] == "<EDGE>"
         assert metadata["right"] == "<EDGE>"
+
+
+class TestSectionLabelWiring:
+    """section_label flows from a line_id->section map into row/line metadata."""
+
+    def test_row_payload_stamps_majority_section(self) -> None:
+        from receipt_chroma.embedding.records import sections_to_line_map
+
+        l1 = create_mock_line("img1", 1, 1, "Line 1")
+        l2 = create_mock_line("img1", 1, 2, "Line 2")
+        record = RowEmbeddingRecord(row_lines=(l1, l2), embedding=[0.1, 0.2])
+        # both lines in TOTAL_LINE -> majority TOTAL_LINE
+        payload = build_row_payload(
+            records=[record],
+            all_words=[],
+            section_by_line={1: "TOTAL_LINE", 2: "TOTAL_LINE"},
+        )
+        assert payload["metadatas"][0]["section_label"] == "TOTAL_LINE"
+
+    def test_row_payload_no_map_has_no_section(self) -> None:
+        line = create_mock_line("img1", 1, 1, "Line 1")
+        record = RowEmbeddingRecord(row_lines=(line,), embedding=[0.1, 0.2])
+        payload = build_row_payload(records=[record], all_words=[])
+        assert "section_label" not in payload["metadatas"][0]
+
+    def test_line_payload_stamps_section(self) -> None:
+        line = create_mock_line("img1", 1, 5, "Line 5")
+        record = LineEmbeddingRecord(line=line, embedding=[0.1, 0.2])
+        payload = build_line_payload(
+            records=[record],
+            all_lines=[line],
+            all_words=[],
+            section_by_line={5: "SUMMARY"},
+        )
+        assert payload["metadatas"][0]["section_label"] == "SUMMARY"
+
+    def test_sections_to_line_map_highest_confidence_wins(self) -> None:
+        from receipt_chroma.embedding.records import sections_to_line_map
+
+        s_low = Mock(line_ids=[1, 2], section_type="ITEMS", confidence=0.60)
+        s_high = Mock(line_ids=[2], section_type="TOTAL_LINE", confidence=0.95)
+        m = sections_to_line_map([s_low, s_high])
+        assert m == {1: "ITEMS", 2: "TOTAL_LINE"}  # line 2: higher conf wins


### PR DESCRIPTION
## M1a part 1 — wire section_label into the embedding record path

First M1 step. The `section_label` line-metadata hook was **inert**: the active backfill path (`orchestration → build_row_payload → create_row_metadata`) never set it, and `build_line_payload` only read `getattr(line, "section_label")` — always `None` (`ReceiptLine` has no such field). This plumbs section through the payload builders so the `ReceiptSection` seeds now in dev can enrich line/row embeddings.

- `create_row_metadata` gains `section_label` (emitted only when set; mirrors `create_line_metadata`).
- `build_row_payload` / `build_line_payload` gain an optional `section_by_line` map; `build_row_payload` stamps the row's **majority** section across its `line_ids`.
- `sections_to_line_map(sections)` builds `line_id → section_type` from `ReceiptSection` rows (higher-confidence section wins on overlap).

**Back-compatible:** all new params default `None` → existing callers unchanged, no metadata emitted until wired.

### Sequencing
Landing early: dev line embeddings are only ~33% done, so first-pass metadata beats a re-sweep (the ~664 already-embedded lines need a cheap metadata upsert later).

### Next (part 2)
Wire the callers (`orchestration` / `line_polling` / `embed_from_ndjson`) to fetch the receipt's `ReceiptSection` rows and pass `section_by_line`.

### Tests
4 new (`TestSectionLabelWiring`); 20 record + 78 metadata/record tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)