### PR TITLE
Add Dependabot maintainer automation skill

### DIFF
--- a/.codex/skills/dependabot-maintainer/SKILL.md
+++ b/.codex/skills/dependabot-maintainer/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: dependabot-maintainer
+description: Review, verify, rebase, and merge Dependabot pull requests in the Portfolio repo. Use when the user asks Codex to handle Dependabot PRs, automate dependency update review, run dependency-update guardrails, set up recurring Dependabot maintenance, or merge safe bot-authored dependency updates.
+---
+
+# Dependabot Maintainer
+
+## Overview
+
+Use this skill to turn Dependabot PR handling into a repeatable workflow. Prefer the bundled script for deterministic checks, then use GitHub tooling only after the script and CI agree the PR is safe.
+
+## Workflow
+
+1. Start with a clean view of open Dependabot PRs:
+
+   ```bash
+   python .codex/skills/dependabot-maintainer/scripts/dependabot_maintainer.py report
+   ```
+
+2. For each PR, inspect the changed files and risk class from the report.
+   - `ready`: bot-authored, dependency-manifest-only, mergeable, and CI green.
+   - `wait`: CI or mergeability is still settling.
+   - `manual`: changed files or version movement need human review before merge.
+
+3. Run local verification for dependency manifests when the update is not obviously docs-only or workflow-only:
+
+   ```bash
+   python .codex/skills/dependabot-maintainer/scripts/dependabot_maintainer.py verify <PR_NUMBER>
+   ```
+
+4. If a PR is dirty or conflicting after another Dependabot PR merges, ask Dependabot to rebase it:
+
+   ```bash
+   python .codex/skills/dependabot-maintainer/scripts/dependabot_maintainer.py rebase <PR_NUMBER>
+   ```
+
+   Wait for the head SHA to change and for post-rebase CI to complete before merging.
+
+5. Merge only after the PR is `ready`, local verification passed when relevant, and the head SHA is stable:
+
+   ```bash
+   python .codex/skills/dependabot-maintainer/scripts/dependabot_maintainer.py merge <PR_NUMBER> --yes
+   ```
+
+   Major-version updates are blocked by default. Use `--allow-major` only when the user explicitly approves the specific major update or local/manual review has already covered the risk.
+
+6. After merging, poll `main` CI until it completes. Report merged PR numbers, merge commits, checks run, and any remaining open Dependabot PRs.
+
+## Guardrails
+
+- Do not merge PRs unless the author is a Dependabot bot identity.
+- Do not merge PRs with source changes outside known dependency manifests, lockfiles, or GitHub workflow files.
+- Do not merge while checks are queued, in progress, failed, cancelled, timed out, or missing.
+- Do not merge when GitHub reports conflicts. Use `rebase`, then wait for the new head SHA and checks.
+- Do not batch unrelated PRs into one local commit. Dependabot PRs should remain individually mergeable and auditable.
+- Keep local work in scratch worktrees so unfinished user work in the main checkout is untouched.
+
+## Scheduled Automation
+
+For recurring Codex runs, read `references/scheduled-task.md` and use its prompt. Scheduled runs should use a new worktree, run the report first, and leave a summary when anything is blocked.

--- a/.codex/skills/dependabot-maintainer/SKILL.md
+++ b/.codex/skills/dependabot-maintainer/SKILL.md
@@ -18,7 +18,7 @@ Use this skill to turn Dependabot PR handling into a repeatable workflow. Prefer
    ```
 
 2. For each PR, inspect the changed files and risk class from the report.
-   - `ready`: bot-authored, dependency-manifest-only, mergeable, and CI green.
+   - `ready`: Dependabot-authored PR and head commits, dependency-manifest-only, `MERGEABLE/CLEAN`, non-major or explicitly approved, and CI green.
    - `wait`: CI or mergeability is still settling.
    - `manual`: changed files or version movement need human review before merge.
 
@@ -49,9 +49,11 @@ Use this skill to turn Dependabot PR handling into a repeatable workflow. Prefer
 ## Guardrails
 
 - Do not merge PRs unless the author is a Dependabot bot identity.
+- Do not merge PRs unless every head commit is also authored by a Dependabot bot identity.
 - Do not merge PRs with source changes outside known dependency manifests, lockfiles, or GitHub workflow files.
 - Do not merge while checks are queued, in progress, failed, cancelled, timed out, or missing.
-- Do not merge when GitHub reports conflicts. Use `rebase`, then wait for the new head SHA and checks.
+- Do not merge unless GitHub reports `MERGEABLE/CLEAN`. Use `rebase`, then wait for the new head SHA and checks.
+- Do not run local dependency installs until the same author, state, file, commit-provenance, and major-version guards pass.
 - Do not batch unrelated PRs into one local commit. Dependabot PRs should remain individually mergeable and auditable.
 - Keep local work in scratch worktrees so unfinished user work in the main checkout is untouched.
 

--- a/.codex/skills/dependabot-maintainer/SKILL.md
+++ b/.codex/skills/dependabot-maintainer/SKILL.md
@@ -18,7 +18,7 @@ Use this skill to turn Dependabot PR handling into a repeatable workflow. Prefer
    ```
 
 2. For each PR, inspect the changed files and risk class from the report.
-   - `ready`: Dependabot-authored PR and head commits, dependency-manifest-only, `MERGEABLE/CLEAN`, non-major or explicitly approved, and CI green.
+   - `ready`: Dependabot-authored PR and verified Dependabot head commits, dependency-manifest-only, `MERGEABLE/CLEAN`, non-major or explicitly approved, and CI green.
    - `wait`: CI or mergeability is still settling.
    - `manual`: changed files or version movement need human review before merge.
 
@@ -49,11 +49,13 @@ Use this skill to turn Dependabot PR handling into a repeatable workflow. Prefer
 ## Guardrails
 
 - Do not merge PRs unless the author is a Dependabot bot identity.
-- Do not merge PRs unless every head commit is also authored by a Dependabot bot identity.
+- Do not merge PRs unless every head commit is authored by Dependabot and either committed by Dependabot or has GitHub's verified Dependabot signature shape.
 - Do not merge PRs with source changes outside known dependency manifests, lockfiles, or GitHub workflow files.
 - Do not merge while checks are queued, in progress, failed, cancelled, timed out, or missing.
 - Do not merge unless GitHub reports `MERGEABLE/CLEAN`. Use `rebase`, then wait for the new head SHA and checks.
-- Do not run local dependency installs until the same author, state, file, commit-provenance, and major-version guards pass.
+- Do not run local dependency installs until the same author, state, file, commit-provenance, and major-version guards pass, then re-check that the fetched PR head is still the guarded SHA.
+- Do not execute npm verification scripts from a PR that changes those script definitions; route those PRs to manual review.
+- Do not treat unclear lockfile version movement as safe. Unknown dependency version diffs require manual review.
 - Do not batch unrelated PRs into one local commit. Dependabot PRs should remain individually mergeable and auditable.
 - Keep local work in scratch worktrees so unfinished user work in the main checkout is untouched.
 

--- a/.codex/skills/dependabot-maintainer/SKILL.md
+++ b/.codex/skills/dependabot-maintainer/SKILL.md
@@ -49,13 +49,13 @@ Use this skill to turn Dependabot PR handling into a repeatable workflow. Prefer
 ## Guardrails
 
 - Do not merge PRs unless the author is a Dependabot bot identity.
-- Do not merge PRs unless every head commit is authored by Dependabot and either committed by Dependabot or has GitHub's verified Dependabot signature shape.
+- Do not merge PRs unless every head commit has a GitHub-mapped Dependabot author and either a GitHub-mapped Dependabot committer or GitHub's verified Dependabot signature shape.
 - Do not merge PRs with source changes outside known dependency manifests, lockfiles, or GitHub workflow files.
 - Do not merge while checks are queued, in progress, failed, cancelled, timed out, or missing.
 - Do not merge unless GitHub reports `MERGEABLE/CLEAN`. Use `rebase`, then wait for the new head SHA and checks.
 - Do not run local dependency installs until the same author, state, file, commit-provenance, and major-version guards pass, then re-check that the fetched PR head is still the guarded SHA.
 - Do not execute npm verification scripts from a PR that changes those script definitions; route those PRs to manual review.
-- Do not treat unclear lockfile version movement as safe. Unknown dependency version diffs require manual review.
+- Do not treat unclear lockfile version movement, opaque non-JSON lockfile edits, or SHA-only action ref updates as safe. Unknown dependency version diffs require manual review.
 - Do not batch unrelated PRs into one local commit. Dependabot PRs should remain individually mergeable and auditable.
 - Keep local work in scratch worktrees so unfinished user work in the main checkout is untouched.
 

--- a/.codex/skills/dependabot-maintainer/agents/openai.yaml
+++ b/.codex/skills/dependabot-maintainer/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Dependabot Maintainer"
+  short_description: "Review and merge safe Dependabot PRs"
+  default_prompt: "Use $dependabot-maintainer to review open Dependabot PRs, run the guardrails, and merge the safe ones."

--- a/.codex/skills/dependabot-maintainer/references/scheduled-task.md
+++ b/.codex/skills/dependabot-maintainer/references/scheduled-task.md
@@ -1,0 +1,49 @@
+# Scheduled Dependabot Maintenance
+
+Use this reference when creating a recurring Codex scheduled task or a Claude routine for Portfolio Dependabot maintenance.
+
+## Recommended Codex Scheduled Task
+
+Cadence: weekly, 30 to 60 minutes after Dependabot's weekly run.
+
+Project: Portfolio.
+
+Worktree mode: new worktree.
+
+Prompt:
+
+```text
+Use $dependabot-maintainer in the Portfolio repo.
+
+Review all open Dependabot PRs. For each PR:
+1. Run the Dependabot maintainer report.
+2. Inspect the diff and changed files.
+3. Run local verification for changed dependency manifests when appropriate.
+4. If a PR is conflicting, ask Dependabot to rebase it and wait for the new checks.
+5. Merge only bot-authored, manifest-only PRs with green CI and stable head SHAs.
+6. Do not merge major-version updates unless the skill's guardrails say they are explicitly allowed by the prompt or prior user approval.
+7. After any merge, wait for the resulting main-branch CI run and summarize the outcome.
+
+Leave blocked PRs open with a short explanation in the final message.
+```
+
+Use the narrowest permissions that still allow GitHub reads, GitHub PR comments, GitHub merge actions, local shell, and network access for dependency installation. Keep the scheduled task in a dedicated worktree so it cannot overwrite unfinished local work.
+
+## Hook Guardrail
+
+Use the script's `guard` command as the deterministic pre-merge hook for either Codex or Claude:
+
+```bash
+python .codex/skills/dependabot-maintainer/scripts/dependabot_maintainer.py guard <PR_NUMBER>
+```
+
+The hook should run immediately before any merge action. A non-zero exit means the agent must stop and report the reason instead of merging. Keep this guard in the prompt or hook configuration rather than relying on model judgment alone.
+
+## Optional Claude Routine
+
+Use the same workflow prompt with Claude Code if you want a second reviewer. Keep Claude in review/comment mode unless you explicitly want it to merge. A good split is:
+
+- Codex: deterministic report, local verification, rebase requests, merge gate.
+- Claude: release-note risk summary and manual review for major-version or broad lockfile updates.
+
+Do not let both agents merge the same PR family concurrently. One agent should own the merge lane for a given Dependabot batch.

--- a/.codex/skills/dependabot-maintainer/references/scheduled-task.md
+++ b/.codex/skills/dependabot-maintainer/references/scheduled-task.md
@@ -20,7 +20,7 @@ Review all open Dependabot PRs. For each PR:
 2. Inspect the diff and changed files.
 3. Run local verification for changed dependency manifests when appropriate.
 4. If a PR is conflicting, ask Dependabot to rebase it and wait for the new checks.
-5. Merge only Dependabot-authored, Dependabot-committed, manifest-only PRs with green CI, stable head SHAs, and `MERGEABLE/CLEAN` merge state.
+5. Merge only Dependabot-authored, verified Dependabot-committed, manifest-only PRs with green CI, stable head SHAs, and `MERGEABLE/CLEAN` merge state.
 6. Do not merge major-version updates unless the skill's guardrails say they are explicitly allowed by the prompt or prior user approval.
 7. After any merge, wait for the resulting main-branch CI run and summarize the outcome.
 
@@ -39,7 +39,7 @@ python .codex/skills/dependabot-maintainer/scripts/dependabot_maintainer.py guar
 
 The hook should run immediately before any merge action. A non-zero exit means the agent must stop and report the reason instead of merging. Keep this guard in the prompt or hook configuration rather than relying on model judgment alone.
 
-Local verification also has a guard before any PR code is fetched into a worktree and installed. The npm verification path uses `npm ci --ignore-scripts` before running trusted project test commands.
+Local verification also has a guard before any PR code is fetched into a worktree and installed. After fetching, the resolved ref must still match the guarded head SHA. The npm verification path uses `npm ci --ignore-scripts` and refuses PRs that change the npm script definitions it would run. `receipt_upload` verification installs the same local sibling package stack used by CI.
 
 ## Optional Claude Routine
 

--- a/.codex/skills/dependabot-maintainer/references/scheduled-task.md
+++ b/.codex/skills/dependabot-maintainer/references/scheduled-task.md
@@ -20,7 +20,7 @@ Review all open Dependabot PRs. For each PR:
 2. Inspect the diff and changed files.
 3. Run local verification for changed dependency manifests when appropriate.
 4. If a PR is conflicting, ask Dependabot to rebase it and wait for the new checks.
-5. Merge only Dependabot-authored, verified Dependabot-committed, manifest-only PRs with green CI, stable head SHAs, and `MERGEABLE/CLEAN` merge state.
+5. Merge only Dependabot-authored, GitHub-mapped and verified Dependabot-committed, manifest-only PRs with green CI, stable head SHAs, and `MERGEABLE/CLEAN` merge state.
 6. Do not merge major-version updates unless the skill's guardrails say they are explicitly allowed by the prompt or prior user approval.
 7. After any merge, wait for the resulting main-branch CI run and summarize the outcome.
 
@@ -39,7 +39,7 @@ python .codex/skills/dependabot-maintainer/scripts/dependabot_maintainer.py guar
 
 The hook should run immediately before any merge action. A non-zero exit means the agent must stop and report the reason instead of merging. Keep this guard in the prompt or hook configuration rather than relying on model judgment alone.
 
-Local verification also has a guard before any PR code is fetched into a worktree and installed. After fetching, the resolved ref must still match the guarded head SHA. The npm verification path uses `npm ci --ignore-scripts` and refuses PRs that change the npm script definitions it would run. `receipt_upload` verification installs the same local sibling package stack used by CI.
+Local verification also has a guard before any PR code is fetched into a worktree and installed. After fetching, the resolved ref must still match the guarded head SHA. The npm verification path uses `npm ci --ignore-scripts` and refuses PRs that change the npm script definitions it would run. Opaque non-JSON lockfile edits and SHA-only action ref updates stay manual. `receipt_upload` verification installs the same local sibling package stack used by CI.
 
 ## Optional Claude Routine
 

--- a/.codex/skills/dependabot-maintainer/references/scheduled-task.md
+++ b/.codex/skills/dependabot-maintainer/references/scheduled-task.md
@@ -20,7 +20,7 @@ Review all open Dependabot PRs. For each PR:
 2. Inspect the diff and changed files.
 3. Run local verification for changed dependency manifests when appropriate.
 4. If a PR is conflicting, ask Dependabot to rebase it and wait for the new checks.
-5. Merge only bot-authored, manifest-only PRs with green CI and stable head SHAs.
+5. Merge only Dependabot-authored, Dependabot-committed, manifest-only PRs with green CI, stable head SHAs, and `MERGEABLE/CLEAN` merge state.
 6. Do not merge major-version updates unless the skill's guardrails say they are explicitly allowed by the prompt or prior user approval.
 7. After any merge, wait for the resulting main-branch CI run and summarize the outcome.
 
@@ -38,6 +38,8 @@ python .codex/skills/dependabot-maintainer/scripts/dependabot_maintainer.py guar
 ```
 
 The hook should run immediately before any merge action. A non-zero exit means the agent must stop and report the reason instead of merging. Keep this guard in the prompt or hook configuration rather than relying on model judgment alone.
+
+Local verification also has a guard before any PR code is fetched into a worktree and installed. The npm verification path uses `npm ci --ignore-scripts` before running trusted project test commands.
 
 ## Optional Claude Routine
 

--- a/.codex/skills/dependabot-maintainer/scripts/dependabot_maintainer.py
+++ b/.codex/skills/dependabot-maintainer/scripts/dependabot_maintainer.py
@@ -40,6 +40,11 @@ LOCK_FILE_NAMES = {
     "poetry.lock",
     "Pipfile.lock",
 }
+JSON_LOCK_FILE_NAMES = {
+    "package-lock.json",
+    "npm-shrinkwrap.json",
+    "Pipfile.lock",
+}
 GITHUB_VERIFIED_COMMITTERS = {"web-flow"}
 NPM_VERIFICATION_SCRIPTS = {"lint", "type-check", "test:ci"}
 RECEIPT_UPLOAD_LOCAL_STACK = (
@@ -63,6 +68,8 @@ RECEIPT_UPLOAD_EXTERNAL_DEPS = (
     "httpx",
     "pydantic",
     "pydantic-settings",
+    "python-barcode>=0.15.0",
+    "segno>=1.6.0",
     "structlog",
     "requests",
     "tenacity",
@@ -91,18 +98,12 @@ def is_lockfile_path(path: str | None) -> bool:
     return bool(path) and Path(path).name in LOCK_FILE_NAMES
 
 
-def is_dependabot_identity(
-    login: str | None,
-    *,
-    email: str = "",
-    name: str = "",
-) -> bool:
-    return (
-        login in DEPENDABOT_AUTHORS
-        or login == "dependabot[bot]"
-        or "dependabot[bot]" in email
-        or name == "dependabot[bot]"
-    )
+def is_json_lockfile_path(path: str | None) -> bool:
+    return bool(path) and Path(path).name in JSON_LOCK_FILE_NAMES
+
+
+def is_dependabot_identity(login: str | None) -> bool:
+    return login in DEPENDABOT_AUTHORS
 
 
 def run(
@@ -240,10 +241,12 @@ def parse_version_pairs(text: str | None) -> list[tuple[str, str]]:
 def version_major_set(version: str | None) -> set[int] | None:
     if not version:
         return None
+    if re.fullmatch(r"[0-9a-fA-F]{40}", version.strip()):
+        return None
     majors = {
         int(match.group(1))
         for match in re.finditer(
-            r"(?<![A-Za-z])v?(\d+)(?:\.\d+)?(?:\.\d+)?",
+            r"(?<![A-Za-z0-9])v?(\d+)(?:\.\d+){0,2}(?![A-Za-z0-9])",
             version,
         )
     }
@@ -314,7 +317,21 @@ def dependency_spec_from_line(
 
 
 def is_version_metadata_line(line: str) -> bool:
-    return bool(re.match(r'\s*"version":\s*"[^"]+"', line))
+    stripped = line.strip()
+    return bool(
+        re.match(r'"version":\s*"[^"]+"', stripped)
+        or re.match(r"version:\s*\S+", stripped)
+        or re.match(r"version\s*=\s*['\"]?[^'\"]+", stripped)
+        or re.match(r"[^\s:]+@\S+:", stripped)
+    )
+
+
+def is_opaque_lockfile_line(path: str | None, line: str) -> bool:
+    if not is_lockfile_path(path) or is_json_lockfile_path(path):
+        return False
+
+    stripped = line.strip()
+    return bool(stripped and not stripped.startswith(("#", "//")))
 
 
 def version_pairs_from_diff(
@@ -372,6 +389,8 @@ def version_pairs_from_diff(
                 unknown_changes.append(
                     f"{current_path}: unparsed removed version line"
                 )
+            elif is_opaque_lockfile_line(current_path, line[1:]):
+                unknown_changes.append(f"{current_path}: opaque removed lockfile line")
             continue
 
         if line.startswith("+"):
@@ -392,6 +411,8 @@ def version_pairs_from_diff(
                 line[1:]
             ):
                 unknown_changes.append(f"{current_path}: unparsed added version line")
+            elif is_opaque_lockfile_line(current_path, line[1:]):
+                unknown_changes.append(f"{current_path}: opaque added lockfile line")
 
     flush_removed()
     return pairs, unknown_changes
@@ -426,6 +447,7 @@ def major_update_reasons(
 
     diff_pairs, unknown_changes = version_pairs_from_diff(diff_text)
     known_non_major = False
+    unknown_pairs: list[str] = []
     for name, before, after in diff_pairs:
         result = pair_is_major(before, after)
         if result is True:
@@ -434,8 +456,10 @@ def major_update_reasons(
             ]
         if result is False:
             known_non_major = True
+        if result is None:
+            unknown_pairs.append(f"{name}: {before} -> {after}")
 
-    if unknown_changes:
+    if unknown_changes or unknown_pairs:
         return ["could not determine update level from every dependency diff"]
 
     if known_non_major:
@@ -453,9 +477,11 @@ def npm_script_change_reasons(diff_text: str | None) -> list[str]:
 
     reasons: list[str] = []
     current_path: str | None = None
+    scripts_depth: int | None = None
     for line in diff_text.splitlines():
         if line.startswith("diff --git "):
             current_path = None
+            scripts_depth = None
             parts = line.split()
             if len(parts) >= 4:
                 current_path = parts[3].removeprefix("b/")
@@ -464,21 +490,47 @@ def npm_script_change_reasons(diff_text: str | None) -> list[str]:
         if not current_path or Path(current_path).name != "package.json":
             continue
 
-        if not line.startswith(("+", "-")) or line.startswith(("+++", "---")):
+        if line.startswith("---") or line.startswith("+++"):
             continue
 
-        match = re.match(r'\s*"([^"]+)":', line[1:].strip())
+        line_body = line[1:] if line[:1] in {" ", "+", "-"} else line
+        stripped = line_body.strip()
+        entered_scripts = False
+        if scripts_depth is None and re.match(r'"scripts":\s*\{', stripped):
+            scripts_depth = stripped.count("{") - stripped.count("}")
+            entered_scripts = True
+
+        if not line.startswith(("+", "-")) or line.startswith(("+++", "---")):
+            if scripts_depth is not None and not entered_scripts:
+                scripts_depth += stripped.count("{") - stripped.count("}")
+                if scripts_depth <= 0:
+                    scripts_depth = None
+            continue
+
+        match = re.match(r'\s*"([^"]+)":', stripped)
         if not match:
+            if scripts_depth is not None and not entered_scripts:
+                scripts_depth += stripped.count("{") - stripped.count("}")
+                if scripts_depth <= 0:
+                    scripts_depth = None
             continue
 
         key = match.group(1)
-        if (
-            key == "scripts"
-            or key in NPM_VERIFICATION_SCRIPTS
-            or key.startswith("pre")
-            or key.startswith("post")
+        inside_scripts = scripts_depth is not None
+        if key == "scripts" or (
+            inside_scripts
+            and (
+                key in NPM_VERIFICATION_SCRIPTS
+                or key.startswith("pre")
+                or key.startswith("post")
+            )
         ):
             reasons.append(f"npm script changed in {current_path}: {key}")
+
+        if scripts_depth is not None and not entered_scripts:
+            scripts_depth += stripped.count("{") - stripped.count("}")
+            if scripts_depth <= 0:
+                scripts_depth = None
 
     return sorted(set(reasons))
 
@@ -526,11 +578,7 @@ def commit_provenance_reasons(
         github_author = data.get("author") or {}
         github_committer = data.get("committer") or {}
 
-        if not is_dependabot_identity(
-            github_author.get("login"),
-            email=raw_author.get("email") or "",
-            name=raw_author.get("name") or "",
-        ):
+        if not is_dependabot_identity(github_author.get("login")):
             author_label = (
                 github_author.get("login")
                 or raw_author.get("email")
@@ -541,11 +589,7 @@ def commit_provenance_reasons(
             )
 
         if not (
-            is_dependabot_identity(
-                github_committer.get("login"),
-                email=raw_committer.get("email") or "",
-                name=raw_committer.get("name") or "",
-            )
+            is_dependabot_identity(github_committer.get("login"))
             or has_verified_dependabot_signature(data)
         ):
             committer_label = (

--- a/.codex/skills/dependabot-maintainer/scripts/dependabot_maintainer.py
+++ b/.codex/skills/dependabot-maintainer/scripts/dependabot_maintainer.py
@@ -15,6 +15,7 @@ from typing import Any
 
 
 PASSING_CONCLUSIONS = {"SUCCESS", "SKIPPED", "NEUTRAL"}
+PASSING_STATES = {"SUCCESS"}
 DEPENDABOT_AUTHORS = {"dependabot[bot]", "app/dependabot"}
 DEPENDENCY_FILE_PATTERNS = (
     re.compile(r"(^|/)pyproject\.toml$"),
@@ -30,6 +31,52 @@ DEPENDENCY_FILE_PATTERNS = (
     re.compile(r"^\.github/workflows/[^/]+\.(ya?ml)$"),
     re.compile(r"^\.github/dependabot\.yml$"),
 )
+LOCK_FILE_NAMES = {
+    "package-lock.json",
+    "npm-shrinkwrap.json",
+    "pnpm-lock.yaml",
+    "yarn.lock",
+    "uv.lock",
+    "poetry.lock",
+    "Pipfile.lock",
+}
+GITHUB_VERIFIED_COMMITTERS = {"web-flow"}
+NPM_VERIFICATION_SCRIPTS = {"lint", "type-check", "test:ci"}
+RECEIPT_UPLOAD_LOCAL_STACK = (
+    "receipt_dynamo",
+    "receipt_dynamo_stream",
+    "receipt_chroma",
+    "receipt_places",
+    "receipt_agent",
+    "receipt_upload",
+)
+RECEIPT_UPLOAD_EXTERNAL_DEPS = (
+    "boto3",
+    "chromadb",
+    "openai>=2.8.1,<3.0.0",
+    "Pillow",
+    "pillow-avif-plugin",
+    "langsmith",
+    "langgraph",
+    "langchain-core>=0.3.0",
+    "langchain-openai>=0.2.0",
+    "httpx",
+    "pydantic",
+    "pydantic-settings",
+    "structlog",
+    "requests",
+    "tenacity",
+)
+PYTHON_TEST_DEPS = (
+    "pytest",
+    "pytest-mock",
+    "pytest-cov",
+    "pytest-xdist",
+    "pytest-timeout",
+    "pytest-rerunfailures",
+    "moto",
+    "responses",
+)
 VERSION_PAIR_RE = re.compile(
     r"\bfrom\s+`?([^`\s]+)`?\s+to\s+`?([^`\s]+)`?",
     re.IGNORECASE,
@@ -38,6 +85,24 @@ VERSION_PAIR_RE = re.compile(
 
 def is_dependency_path(path: str | None) -> bool:
     return bool(path) and is_dependency_file(path)
+
+
+def is_lockfile_path(path: str | None) -> bool:
+    return bool(path) and Path(path).name in LOCK_FILE_NAMES
+
+
+def is_dependabot_identity(
+    login: str | None,
+    *,
+    email: str = "",
+    name: str = "",
+) -> bool:
+    return (
+        login in DEPENDABOT_AUTHORS
+        or login == "dependabot[bot]"
+        or "dependabot[bot]" in email
+        or name == "dependabot[bot]"
+    )
 
 
 def run(
@@ -144,9 +209,20 @@ def checks_green(pr: dict[str, Any]) -> tuple[bool, list[str]]:
 
     blockers: list[str] = []
     for check in checks:
+        name = (
+            check.get("name")
+            or check.get("workflowName")
+            or check.get("context")
+            or "unknown"
+        )
+        if check.get("__typename") == "StatusContext":
+            state = check.get("state")
+            if state not in PASSING_STATES:
+                blockers.append(f"{name}: {state or 'pending'}")
+            continue
+
         status = check.get("status")
         conclusion = check.get("conclusion") or ""
-        name = check.get("name") or check.get("workflowName") or "unknown"
         if status != "COMPLETED" or conclusion not in PASSING_CONCLUSIONS:
             blockers.append(f"{name}: {status}/{conclusion or 'pending'}")
     return not blockers, blockers
@@ -161,32 +237,53 @@ def parse_version_pairs(text: str | None) -> list[tuple[str, str]]:
     ]
 
 
-def leading_major(version: str | None) -> int | None:
+def version_major_set(version: str | None) -> set[int] | None:
     if not version:
         return None
-    for token in re.split(r"[, ]+", version):
-        token = token.strip()
-        if not token or token.startswith("<"):
-            continue
-        match = re.search(r"(?:[>=~^=]*\s*v?)(\d+)(?:\.\d+)?", token)
-        if match:
-            return int(match.group(1))
+    majors = {
+        int(match.group(1))
+        for match in re.finditer(
+            r"(?<![A-Za-z])v?(\d+)(?:\.\d+)?(?:\.\d+)?",
+            version,
+        )
+    }
+    return majors or None
 
-    match = re.search(r"v?(\d+)(?:\.\d+)?(?:\.\d+)?", version)
-    if not match:
+
+def leading_major(version: str | None) -> int | None:
+    majors = version_major_set(version)
+    if not majors:
         return None
-    return int(match.group(1))
+    return min(majors)
 
 
 def pair_is_major(before: str, after: str) -> bool | None:
-    before_major = leading_major(before)
-    after_major = leading_major(after)
-    if before_major is None or after_major is None:
+    before_majors = version_major_set(before)
+    after_majors = version_major_set(after)
+    if before_majors is None or after_majors is None:
         return None
-    return before_major != after_major
+    return before_majors != after_majors
 
 
-def dependency_spec_from_line(line: str) -> tuple[str, str] | None:
+def lockfile_package_name_from_line(line: str) -> str | None:
+    stripped = line.strip().rstrip(",")
+    match = re.match(r'"([^"]+)":\s*\{$', stripped)
+    if not match:
+        return None
+
+    key = match.group(1)
+    if not key or key in {"dependencies", "devDependencies", "packages"}:
+        return None
+    if key.startswith("node_modules/"):
+        return key.removeprefix("node_modules/")
+    return key
+
+
+def dependency_spec_from_line(
+    line: str,
+    *,
+    current_lock_name: str | None = None,
+) -> tuple[str, str] | None:
     stripped = line.strip().rstrip(",")
     if not stripped:
         return None
@@ -196,6 +293,9 @@ def dependency_spec_from_line(line: str) -> tuple[str, str] | None:
         return uses_match.group(1), uses_match.group(2)
 
     json_match = re.match(r'"([^"]+)":\s*"([^"]+)"$', stripped)
+    if json_match and json_match.group(1) == "version" and current_lock_name:
+        return current_lock_name, json_match.group(2)
+
     metadata_keys = {"integrity", "license", "name", "resolved", "version"}
     if json_match and json_match.group(1) not in metadata_keys:
         return json_match.group(1), json_match.group(2)
@@ -213,14 +313,32 @@ def dependency_spec_from_line(line: str) -> tuple[str, str] | None:
     return None
 
 
-def version_pairs_from_diff(diff_text: str) -> list[tuple[str, str, str]]:
+def is_version_metadata_line(line: str) -> bool:
+    return bool(re.match(r'\s*"version":\s*"[^"]+"', line))
+
+
+def version_pairs_from_diff(
+    diff_text: str,
+) -> tuple[list[tuple[str, str, str]], list[str]]:
     pairs: list[tuple[str, str, str]] = []
+    unknown_changes: list[str] = []
     current_path: str | None = None
+    current_lock_name: str | None = None
     removed_specs: dict[str, str] = {}
+
+    def flush_removed() -> None:
+        for name in sorted(removed_specs):
+            unknown_changes.append(
+                f"{current_path}: removed dependency spec for {name} "
+                "without matching addition"
+            )
+        removed_specs.clear()
 
     for line in diff_text.splitlines():
         if line.startswith("diff --git "):
+            flush_removed()
             current_path = None
+            current_lock_name = None
             removed_specs = {}
             parts = line.split()
             if len(parts) >= 4:
@@ -233,18 +351,50 @@ def version_pairs_from_diff(diff_text: str) -> list[tuple[str, str, str]]:
         if line.startswith("---") or line.startswith("+++"):
             continue
 
+        line_body = line[1:] if line[:1] in {" ", "+", "-"} else line
+        if is_lockfile_path(current_path):
+            lock_name = lockfile_package_name_from_line(line_body)
+            if lock_name:
+                current_lock_name = lock_name
+
         if line.startswith("-"):
-            parsed = dependency_spec_from_line(line[1:])
+            parsed = dependency_spec_from_line(
+                line[1:],
+                current_lock_name=current_lock_name
+                if is_lockfile_path(current_path)
+                else None,
+            )
             if parsed:
                 removed_specs[parsed[0]] = parsed[1]
+            elif is_lockfile_path(current_path) and is_version_metadata_line(
+                line[1:]
+            ):
+                unknown_changes.append(
+                    f"{current_path}: unparsed removed version line"
+                )
             continue
 
         if line.startswith("+"):
-            parsed = dependency_spec_from_line(line[1:])
+            parsed = dependency_spec_from_line(
+                line[1:],
+                current_lock_name=current_lock_name
+                if is_lockfile_path(current_path)
+                else None,
+            )
             if parsed and parsed[0] in removed_specs:
                 pairs.append((parsed[0], removed_specs[parsed[0]], parsed[1]))
+                del removed_specs[parsed[0]]
+            elif parsed:
+                unknown_changes.append(
+                    f"{current_path}: added dependency spec for {parsed[0]} without matching removal"
+                )
+            elif is_lockfile_path(current_path) and is_version_metadata_line(
+                line[1:]
+            ):
+                unknown_changes.append(f"{current_path}: unparsed added version line")
 
-    return pairs
+    flush_removed()
+    return pairs, unknown_changes
 
 
 def pr_diff(root: Path, repo: str, number: int) -> str:
@@ -274,7 +424,7 @@ def major_update_reasons(
             return ["could not prove update is non-major without dependency diff"]
         return ["could not prove update is non-major without dependency diff"]
 
-    diff_pairs = version_pairs_from_diff(diff_text)
+    diff_pairs, unknown_changes = version_pairs_from_diff(diff_text)
     known_non_major = False
     for name, before, after in diff_pairs:
         result = pair_is_major(before, after)
@@ -285,6 +435,9 @@ def major_update_reasons(
         if result is False:
             known_non_major = True
 
+    if unknown_changes:
+        return ["could not determine update level from every dependency diff"]
+
     if known_non_major:
         return []
 
@@ -294,35 +447,120 @@ def major_update_reasons(
     return []
 
 
-def commit_authors_are_dependabot(pr: dict[str, Any]) -> tuple[bool, list[str]]:
+def npm_script_change_reasons(diff_text: str | None) -> list[str]:
+    if not diff_text:
+        return []
+
+    reasons: list[str] = []
+    current_path: str | None = None
+    for line in diff_text.splitlines():
+        if line.startswith("diff --git "):
+            current_path = None
+            parts = line.split()
+            if len(parts) >= 4:
+                current_path = parts[3].removeprefix("b/")
+            continue
+
+        if not current_path or Path(current_path).name != "package.json":
+            continue
+
+        if not line.startswith(("+", "-")) or line.startswith(("+++", "---")):
+            continue
+
+        match = re.match(r'\s*"([^"]+)":', line[1:].strip())
+        if not match:
+            continue
+
+        key = match.group(1)
+        if (
+            key == "scripts"
+            or key in NPM_VERIFICATION_SCRIPTS
+            or key.startswith("pre")
+            or key.startswith("post")
+        ):
+            reasons.append(f"npm script changed in {current_path}: {key}")
+
+    return sorted(set(reasons))
+
+
+def commit_view(root: Path, repo: str, oid: str) -> dict[str, Any]:
+    return run_json(["gh", "api", f"repos/{repo}/commits/{oid}"], cwd=root)
+
+
+def has_verified_dependabot_signature(commit_data: dict[str, Any]) -> bool:
+    commit = commit_data.get("commit") or {}
+    raw_committer = commit.get("committer") or {}
+    verification = commit.get("verification") or {}
+    payload = verification.get("payload") or ""
+    github_committer = commit_data.get("committer") or {}
+    return (
+        github_committer.get("login") in GITHUB_VERIFIED_COMMITTERS
+        and raw_committer.get("name") == "GitHub"
+        and raw_committer.get("email") == "noreply@github.com"
+        and verification.get("verified") is True
+        and "Signed-off-by: dependabot[bot]" in payload
+    )
+
+
+def commit_provenance_reasons(
+    root: Path,
+    repo: str,
+    pr: dict[str, Any],
+) -> list[str]:
     commits = pr.get("commits") or []
     if not commits:
-        return False, ["missing head commit metadata"]
+        return ["missing head commit metadata"]
 
     reasons: list[str] = []
     for commit in commits:
         oid = (commit.get("oid") or "unknown")[:12]
-        authors = commit.get("authors") or []
-        if not authors:
-            reasons.append(f"commit {oid} has no author metadata")
+        full_oid = commit.get("oid")
+        if not full_oid:
+            reasons.append("commit has no oid")
             continue
-        for author in authors:
-            login = author.get("login")
-            email = author.get("email") or ""
-            name = author.get("name") or ""
-            if (
-                login not in DEPENDABOT_AUTHORS
-                and "dependabot[bot]" not in email
-                and name != "dependabot[bot]"
-            ):
-                reasons.append(
-                    f"commit {oid} author is {login or email or name!r}"
-                )
 
-    return not reasons, reasons
+        data = commit_view(root, repo, full_oid)
+        commit_payload = data.get("commit") or {}
+        raw_author = commit_payload.get("author") or {}
+        raw_committer = commit_payload.get("committer") or {}
+        github_author = data.get("author") or {}
+        github_committer = data.get("committer") or {}
+
+        if not is_dependabot_identity(
+            github_author.get("login"),
+            email=raw_author.get("email") or "",
+            name=raw_author.get("name") or "",
+        ):
+            author_label = (
+                github_author.get("login")
+                or raw_author.get("email")
+                or raw_author.get("name")
+            )
+            reasons.append(
+                f"commit {oid} author is {author_label!r}"
+            )
+
+        if not (
+            is_dependabot_identity(
+                github_committer.get("login"),
+                email=raw_committer.get("email") or "",
+                name=raw_committer.get("name") or "",
+            )
+            or has_verified_dependabot_signature(data)
+        ):
+            committer_label = (
+                github_committer.get("login")
+                or raw_committer.get("email")
+                or raw_committer.get("name")
+            )
+            reasons.append(
+                f"commit {oid} committer is {committer_label!r}"
+            )
+
+    return reasons
 
 
-def base_guard_reasons(pr: dict[str, Any]) -> list[str]:
+def base_guard_reasons(root: Path, repo: str, pr: dict[str, Any]) -> list[str]:
     reasons: list[str] = []
 
     author = (pr.get("author") or {}).get("login")
@@ -340,20 +578,20 @@ def base_guard_reasons(pr: dict[str, Any]) -> list[str]:
     if disallowed:
         reasons.append("non-dependency files changed: " + ", ".join(disallowed))
 
-    commits_ok, commit_reasons = commit_authors_are_dependabot(pr)
-    if not commits_ok:
-        reasons.extend(commit_reasons)
+    reasons.extend(commit_provenance_reasons(root, repo, pr))
 
     return reasons
 
 
 def classify(
+    root: Path,
+    repo: str,
     pr: dict[str, Any],
     *,
     allow_major: bool = False,
     diff_text: str | None = None,
 ) -> tuple[str, list[str]]:
-    reasons = base_guard_reasons(pr)
+    reasons = base_guard_reasons(root, repo, pr)
 
     mergeable = pr.get("mergeable")
     merge_state = pr.get("mergeStateStatus")
@@ -369,6 +607,8 @@ def classify(
 
     if not allow_major:
         reasons.extend(major_update_reasons(pr, diff_text=diff_text))
+
+    reasons.extend(npm_script_change_reasons(diff_text))
 
     if not reasons:
         return "ready", []
@@ -441,6 +681,37 @@ def python_bin() -> str:
     return shutil.which("python3.12") or shutil.which("python3") or sys.executable
 
 
+def verify_receipt_upload_dir(worktree: Path, venv_python: Path) -> None:
+    run(
+        [str(venv_python), "-m", "pip", "install", "-e", "receipt_dynamo"],
+        cwd=worktree,
+    )
+    for package in RECEIPT_UPLOAD_LOCAL_STACK[1:]:
+        run(
+            [str(venv_python), "-m", "pip", "install", "--no-deps", "-e", package],
+            cwd=worktree,
+        )
+    run(
+        [str(venv_python), "-m", "pip", "install", *RECEIPT_UPLOAD_EXTERNAL_DEPS],
+        cwd=worktree,
+    )
+    run(
+        [str(venv_python), "-m", "pip", "install", *PYTHON_TEST_DEPS],
+        cwd=worktree,
+    )
+    run(
+        [
+            str(venv_python),
+            "-m",
+            "pip",
+            "install",
+            "black==26.5.1",
+            "isort==8.0.1",
+        ],
+        cwd=worktree,
+    )
+
+
 def verify_python_dir(worktree: Path, rel_dir: Path) -> None:
     package_dir = worktree / rel_dir
     venv = package_dir / ".venv-depbot"
@@ -455,8 +726,10 @@ def verify_python_dir(worktree: Path, rel_dir: Path) -> None:
 
     run([str(venv_python), "-m", "pip", "install", "--upgrade", "pip", "wheel"], cwd=package_dir)
 
-    pyproject = package_dir / "pyproject.toml"
-    if pyproject.exists():
+    if rel_dir == Path("receipt_upload"):
+        verify_receipt_upload_dir(worktree, venv_python)
+    elif (package_dir / "pyproject.toml").exists():
+        pyproject = package_dir / "pyproject.toml"
         extras = pyproject_extras(pyproject)
         target = f".[{extras}]" if extras else "."
         run([str(venv_python), "-m", "pip", "install", "-e", target], cwd=package_dir)
@@ -486,7 +759,7 @@ def verify_npm_dir(worktree: Path, rel_dir: Path) -> None:
             run(["npm", "run", script], cwd=package_dir)
 
 
-def fetch_pr_ref(root: Path, repo: str, number: int) -> str:
+def fetch_pr_ref(root: Path, repo: str, number: int, expected_oid: str) -> str:
     ref = f"refs/remotes/origin/dependabot-maintainer-pr-{number}"
     run(
         [
@@ -497,7 +770,14 @@ def fetch_pr_ref(root: Path, repo: str, number: int) -> str:
         ],
         cwd=root,
     )
-    return ref
+    completed = run(["git", "rev-parse", ref], cwd=root, capture=True)
+    fetched_oid = completed.stdout.strip()
+    if fetched_oid != expected_oid:
+        raise RuntimeError(
+            "fetched PR head does not match guarded head: "
+            f"expected {expected_oid}, got {fetched_oid}"
+        )
+    return fetched_oid
 
 
 def create_pr_worktree(root: Path, ref: str) -> Path:
@@ -518,6 +798,8 @@ def command_report(args: argparse.Namespace) -> int:
         pr = pr_view(root, repo, listed["number"])
         diff_text = pr_diff(root, repo, pr["number"])
         status, reasons = classify(
+            root,
+            repo,
             pr,
             allow_major=args.allow_major,
             diff_text=diff_text,
@@ -544,6 +826,8 @@ def command_guard(args: argparse.Namespace) -> int:
     pr = pr_view(root, repo, args.pr_number)
     diff_text = pr_diff(root, repo, args.pr_number)
     status, reasons = classify(
+        root,
+        repo,
         pr,
         allow_major=args.allow_major,
         diff_text=diff_text,
@@ -558,7 +842,7 @@ def command_rebase(args: argparse.Namespace) -> int:
     root = repo_root()
     repo = args.repo or repo_full_name(root)
     pr = pr_view(root, repo, args.pr_number)
-    reasons = base_guard_reasons(pr)
+    reasons = base_guard_reasons(root, repo, pr)
     if reasons:
         print(f"Refusing to rebase PR #{args.pr_number}", file=sys.stderr)
         for reason in reasons:
@@ -585,9 +869,10 @@ def command_verify(args: argparse.Namespace) -> int:
     repo = args.repo or repo_full_name(root)
     pr = pr_view(root, repo, args.pr_number)
     diff_text = pr_diff(root, repo, args.pr_number)
-    reasons = base_guard_reasons(pr)
+    reasons = base_guard_reasons(root, repo, pr)
     if not args.allow_major:
         reasons.extend(major_update_reasons(pr, diff_text=diff_text))
+    reasons.extend(npm_script_change_reasons(diff_text))
     if reasons:
         print(f"Refusing to verify PR #{args.pr_number}", file=sys.stderr)
         for reason in reasons:
@@ -601,7 +886,12 @@ def command_verify(args: argparse.Namespace) -> int:
         print("No local dependency directories detected. Rely on CI for this PR.")
         return 0
 
-    ref = fetch_pr_ref(root, repo, args.pr_number)
+    try:
+        ref = fetch_pr_ref(root, repo, args.pr_number, pr["headRefOid"])
+    except RuntimeError as exc:
+        print(f"Refusing to verify PR #{args.pr_number}: {exc}", file=sys.stderr)
+        return 1
+
     worktree = create_pr_worktree(root, ref)
     print(f"Created verification worktree: {worktree}")
     try:
@@ -628,6 +918,8 @@ def command_merge(args: argparse.Namespace) -> int:
     pr = pr_view(root, repo, args.pr_number)
     diff_text = pr_diff(root, repo, args.pr_number)
     status, reasons = classify(
+        root,
+        repo,
         pr,
         allow_major=args.allow_major,
         diff_text=diff_text,

--- a/.codex/skills/dependabot-maintainer/scripts/dependabot_maintainer.py
+++ b/.codex/skills/dependabot-maintainer/scripts/dependabot_maintainer.py
@@ -1,0 +1,509 @@
+#!/usr/bin/env python3
+"""Guardrails and local checks for Portfolio Dependabot PR maintenance."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+PASSING_CONCLUSIONS = {"SUCCESS", "SKIPPED", "NEUTRAL"}
+DEPENDABOT_AUTHORS = {"dependabot[bot]", "app/dependabot"}
+DEPENDENCY_FILE_PATTERNS = (
+    re.compile(r"(^|/)pyproject\.toml$"),
+    re.compile(r"(^|/)requirements[^/]*\.txt$"),
+    re.compile(r"(^|/)package\.json$"),
+    re.compile(r"(^|/)package-lock\.json$"),
+    re.compile(r"(^|/)npm-shrinkwrap\.json$"),
+    re.compile(r"(^|/)pnpm-lock\.yaml$"),
+    re.compile(r"(^|/)yarn\.lock$"),
+    re.compile(r"(^|/)uv\.lock$"),
+    re.compile(r"(^|/)poetry\.lock$"),
+    re.compile(r"(^|/)Pipfile\.lock$"),
+    re.compile(r"^\.github/workflows/[^/]+\.(ya?ml)$"),
+    re.compile(r"^\.github/dependabot\.yml$"),
+)
+
+
+def run(
+    cmd: list[str],
+    *,
+    cwd: Path,
+    check: bool = True,
+    capture: bool = False,
+) -> subprocess.CompletedProcess[str]:
+    kwargs: dict[str, Any] = {
+        "cwd": str(cwd),
+        "text": True,
+        "check": check,
+    }
+    if capture:
+        kwargs["stdout"] = subprocess.PIPE
+        kwargs["stderr"] = subprocess.PIPE
+    print(f"+ {' '.join(cmd)}", file=sys.stderr)
+    return subprocess.run(cmd, **kwargs)
+
+
+def run_json(cmd: list[str], *, cwd: Path) -> Any:
+    completed = run(cmd, cwd=cwd, capture=True)
+    return json.loads(completed.stdout)
+
+
+def repo_root() -> Path:
+    completed = run(["git", "rev-parse", "--show-toplevel"], cwd=Path.cwd(), capture=True)
+    return Path(completed.stdout.strip())
+
+
+def repo_full_name(root: Path) -> str:
+    data = run_json(["gh", "repo", "view", "--json", "nameWithOwner"], cwd=root)
+    return data["nameWithOwner"]
+
+
+def pr_list(root: Path, repo: str, limit: int) -> list[dict[str, Any]]:
+    return run_json(
+        [
+            "gh",
+            "pr",
+            "list",
+            "--repo",
+            repo,
+            "--author",
+            "app/dependabot",
+            "--state",
+            "open",
+            "--limit",
+            str(limit),
+            "--json",
+            "number,title,url,headRefOid,mergeable,mergeStateStatus",
+        ],
+        cwd=root,
+    )
+
+
+def pr_view(root: Path, repo: str, number: int) -> dict[str, Any]:
+    return run_json(
+        [
+            "gh",
+            "pr",
+            "view",
+            str(number),
+            "--repo",
+            repo,
+            "--json",
+            ",".join(
+                [
+                    "author",
+                    "baseRefName",
+                    "files",
+                    "headRefName",
+                    "headRefOid",
+                    "isDraft",
+                    "mergeStateStatus",
+                    "mergeable",
+                    "number",
+                    "state",
+                    "statusCheckRollup",
+                    "title",
+                    "url",
+                ]
+            ),
+        ],
+        cwd=root,
+    )
+
+
+def changed_paths(pr: dict[str, Any]) -> list[str]:
+    return sorted(item["path"] for item in pr.get("files", []))
+
+
+def is_dependency_file(path: str) -> bool:
+    return any(pattern.search(path) for pattern in DEPENDENCY_FILE_PATTERNS)
+
+
+def checks_green(pr: dict[str, Any]) -> tuple[bool, list[str]]:
+    checks = pr.get("statusCheckRollup") or []
+    if not checks:
+        return False, ["missing checks"]
+
+    blockers: list[str] = []
+    for check in checks:
+        status = check.get("status")
+        conclusion = check.get("conclusion") or ""
+        name = check.get("name") or check.get("workflowName") or "unknown"
+        if status != "COMPLETED" or conclusion not in PASSING_CONCLUSIONS:
+            blockers.append(f"{name}: {status}/{conclusion or 'pending'}")
+    return not blockers, blockers
+
+
+def parse_versions(title: str) -> tuple[str | None, str | None]:
+    match = re.search(r"\bfrom\s+([^ ]+)\s+to\s+([^ ]+)", title)
+    if not match:
+        return None, None
+    return match.group(1).strip("`., "), match.group(2).strip("`., ")
+
+
+def leading_major(version: str | None) -> int | None:
+    if not version:
+        return None
+    match = re.search(r"(\d+)(?:\.\d+)?(?:\.\d+)?", version)
+    if not match:
+        return None
+    return int(match.group(1))
+
+
+def is_major_update(title: str) -> bool:
+    before, after = parse_versions(title)
+    before_major = leading_major(before)
+    after_major = leading_major(after)
+    return (
+        before_major is not None
+        and after_major is not None
+        and before_major != after_major
+    )
+
+
+def classify(pr: dict[str, Any], *, allow_major: bool = False) -> tuple[str, list[str]]:
+    reasons: list[str] = []
+
+    author = (pr.get("author") or {}).get("login")
+    if author not in DEPENDABOT_AUTHORS:
+        reasons.append(f"author is {author!r}, not Dependabot")
+
+    if pr.get("state") != "OPEN":
+        reasons.append(f"PR state is {pr.get('state')!r}, not OPEN")
+
+    if pr.get("isDraft"):
+        reasons.append("PR is draft")
+
+    paths = changed_paths(pr)
+    disallowed = [path for path in paths if not is_dependency_file(path)]
+    if disallowed:
+        reasons.append("non-dependency files changed: " + ", ".join(disallowed))
+
+    mergeable = pr.get("mergeable")
+    merge_state = pr.get("mergeStateStatus")
+    if mergeable == "CONFLICTING" or merge_state == "DIRTY":
+        reasons.append(f"PR has merge conflicts: {mergeable}/{merge_state}")
+    elif mergeable not in ("MERGEABLE", "UNKNOWN"):
+        reasons.append(f"mergeability is {mergeable}/{merge_state}")
+
+    green, blockers = checks_green(pr)
+    if not green:
+        reasons.extend(blockers)
+
+    if is_major_update(pr.get("title", "")) and not allow_major:
+        reasons.append("major-version update requires manual approval")
+
+    if not reasons:
+        return "ready", []
+
+    if any("pending" in reason or "QUEUED" in reason or "IN_PROGRESS" in reason for reason in reasons):
+        return "wait", reasons
+
+    if any("missing checks" in reason for reason in reasons):
+        return "wait", reasons
+
+    return "manual", reasons
+
+
+def dependency_dirs(paths: list[str]) -> set[Path]:
+    dirs: set[Path] = set()
+    for path in paths:
+        p = Path(path)
+        if p.name in {
+            "pyproject.toml",
+            "package.json",
+            "package-lock.json",
+            "requirements.txt",
+        } or p.name.startswith("requirements"):
+            dirs.add(p.parent if str(p.parent) != "." else Path("."))
+    return dirs
+
+
+def pyproject_extras(pyproject: Path) -> str:
+    try:
+        import tomllib
+    except ModuleNotFoundError:
+        text = pyproject.read_text(errors="ignore")
+        in_optional = False
+        found: list[str] = []
+        for raw_line in text.splitlines():
+            line = raw_line.strip()
+            if line == "[project.optional-dependencies]":
+                in_optional = True
+                continue
+            if in_optional and line.startswith("["):
+                break
+            if in_optional and "=" in line:
+                found.append(line.split("=", 1)[0].strip())
+        if "dev" in found:
+            return "dev"
+        return ",".join(name for name in ("test", "lint") if name in found)
+
+    try:
+        with pyproject.open("rb") as handle:
+            data = tomllib.load(handle)
+    except Exception:
+        return ""
+
+    optional = (data.get("project") or {}).get("optional-dependencies") or {}
+    if "dev" in optional:
+        return "dev"
+
+    extras = [name for name in ("test", "lint") if name in optional]
+    return ",".join(extras)
+
+
+def python_bin() -> str:
+    return shutil.which("python3.12") or shutil.which("python3") or sys.executable
+
+
+def verify_python_dir(worktree: Path, rel_dir: Path) -> None:
+    package_dir = worktree / rel_dir
+    venv = package_dir / ".venv-depbot"
+    if venv.exists():
+        shutil.rmtree(venv)
+
+    py = python_bin()
+    run([py, "-m", "venv", ".venv-depbot"], cwd=package_dir)
+    venv_python = venv / "bin" / "python"
+    if not venv_python.exists():
+        venv_python = venv / "Scripts" / "python.exe"
+
+    run([str(venv_python), "-m", "pip", "install", "--upgrade", "pip", "wheel"], cwd=package_dir)
+
+    pyproject = package_dir / "pyproject.toml"
+    if pyproject.exists():
+        extras = pyproject_extras(pyproject)
+        target = f".[{extras}]" if extras else "."
+        run([str(venv_python), "-m", "pip", "install", "-e", target], cwd=package_dir)
+    else:
+        reqs = sorted(package_dir.glob("requirements*.txt"))
+        for req in reqs:
+            run([str(venv_python), "-m", "pip", "install", "-r", req.name], cwd=package_dir)
+
+    run([str(venv_python), "-m", "pip", "check"], cwd=package_dir)
+    run([str(venv_python), "-m", "compileall", "-q", "."], cwd=package_dir)
+
+
+def npm_scripts(package_json: Path) -> dict[str, str]:
+    try:
+        data = json.loads(package_json.read_text())
+    except Exception:
+        return {}
+    return data.get("scripts") or {}
+
+
+def verify_npm_dir(worktree: Path, rel_dir: Path) -> None:
+    package_dir = worktree / rel_dir
+    run(["npm", "ci", "--prefer-offline"], cwd=package_dir)
+    scripts = npm_scripts(package_dir / "package.json")
+    for script in ("lint", "type-check", "test:ci"):
+        if script in scripts:
+            run(["npm", "run", script], cwd=package_dir)
+
+
+def fetch_pr_ref(root: Path, repo: str, number: int) -> str:
+    ref = f"refs/remotes/origin/dependabot-maintainer-pr-{number}"
+    run(
+        [
+            "git",
+            "fetch",
+            "origin",
+            f"+pull/{number}/head:{ref}",
+        ],
+        cwd=root,
+    )
+    return ref
+
+
+def create_pr_worktree(root: Path, ref: str) -> Path:
+    tempdir = Path(tempfile.mkdtemp(prefix="portfolio-depbot-verify-"))
+    run(["git", "worktree", "add", "--detach", str(tempdir), ref], cwd=root)
+    return tempdir
+
+
+def command_report(args: argparse.Namespace) -> int:
+    root = repo_root()
+    repo = args.repo or repo_full_name(root)
+    prs = pr_list(root, repo, args.limit)
+    if not prs:
+        print("No open Dependabot PRs.")
+        return 0
+
+    for listed in prs:
+        pr = pr_view(root, repo, listed["number"])
+        status, reasons = classify(pr, allow_major=args.allow_major)
+        paths = changed_paths(pr)
+        print(f"## PR #{pr['number']}: {pr['title']}")
+        print(f"URL: {pr['url']}")
+        print(f"Head: {pr['headRefOid']}")
+        print(f"Status: {status}")
+        print("Files:")
+        for path in paths:
+            print(f"- {path}")
+        if reasons:
+            print("Reasons:")
+            for reason in reasons:
+                print(f"- {reason}")
+        print()
+    return 0
+
+
+def command_guard(args: argparse.Namespace) -> int:
+    root = repo_root()
+    repo = args.repo or repo_full_name(root)
+    pr = pr_view(root, repo, args.pr_number)
+    status, reasons = classify(pr, allow_major=args.allow_major)
+    print(f"PR #{pr['number']} status: {status}")
+    for reason in reasons:
+        print(f"- {reason}")
+    return 0 if status == "ready" else 1
+
+
+def command_rebase(args: argparse.Namespace) -> int:
+    root = repo_root()
+    repo = args.repo or repo_full_name(root)
+    pr = pr_view(root, repo, args.pr_number)
+    author = (pr.get("author") or {}).get("login")
+    if author not in DEPENDABOT_AUTHORS:
+        print(f"Refusing to comment: author is {author!r}", file=sys.stderr)
+        return 1
+    run(
+        [
+            "gh",
+            "pr",
+            "comment",
+            str(args.pr_number),
+            "--repo",
+            repo,
+            "--body",
+            "@dependabot rebase",
+        ],
+        cwd=root,
+    )
+    return 0
+
+
+def command_verify(args: argparse.Namespace) -> int:
+    root = repo_root()
+    repo = args.repo or repo_full_name(root)
+    pr = pr_view(root, repo, args.pr_number)
+    paths = changed_paths(pr)
+    dirs = dependency_dirs(paths)
+
+    if not dirs:
+        print("No local dependency directories detected. Rely on CI for this PR.")
+        return 0
+
+    ref = fetch_pr_ref(root, repo, args.pr_number)
+    worktree = create_pr_worktree(root, ref)
+    print(f"Created verification worktree: {worktree}")
+    try:
+        for rel_dir in sorted(dirs):
+            full_dir = worktree / rel_dir
+            if (full_dir / "package.json").exists():
+                verify_npm_dir(worktree, rel_dir)
+            elif (full_dir / "pyproject.toml").exists() or list(full_dir.glob("requirements*.txt")):
+                verify_python_dir(worktree, rel_dir)
+            else:
+                print(f"Skipping {rel_dir}: no supported dependency manifest")
+    finally:
+        if args.keep_worktree:
+            print(f"Kept verification worktree: {worktree}")
+        else:
+            run(["git", "worktree", "remove", "--force", str(worktree)], cwd=root, check=False)
+            shutil.rmtree(worktree, ignore_errors=True)
+    return 0
+
+
+def command_merge(args: argparse.Namespace) -> int:
+    root = repo_root()
+    repo = args.repo or repo_full_name(root)
+    pr = pr_view(root, repo, args.pr_number)
+    status, reasons = classify(pr, allow_major=args.allow_major)
+    if status != "ready":
+        print(f"Refusing to merge PR #{args.pr_number}: {status}", file=sys.stderr)
+        for reason in reasons:
+            print(f"- {reason}", file=sys.stderr)
+        return 1
+
+    if not args.yes:
+        print("Refusing to merge without --yes.", file=sys.stderr)
+        return 1
+
+    subject = args.subject or pr["title"].split(" from ", 1)[0]
+    body = args.body or "Merged by Dependabot Maintainer after guardrails and CI passed."
+    run(
+        [
+            "gh",
+            "pr",
+            "merge",
+            str(args.pr_number),
+            "--repo",
+            repo,
+            "--squash",
+            "--delete-branch",
+            "--match-head-commit",
+            pr["headRefOid"],
+            "--subject",
+            subject,
+            "--body",
+            body,
+        ],
+        cwd=root,
+    )
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", help="GitHub repo in owner/name form")
+
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    report = subparsers.add_parser("report", help="List open Dependabot PRs and guardrail status")
+    report.add_argument("--limit", type=int, default=30)
+    report.add_argument("--allow-major", action="store_true")
+    report.set_defaults(func=command_report)
+
+    guard = subparsers.add_parser("guard", help="Return success only when a PR is safe to merge")
+    guard.add_argument("pr_number", type=int)
+    guard.add_argument("--allow-major", action="store_true")
+    guard.set_defaults(func=command_guard)
+
+    verify = subparsers.add_parser("verify", help="Run local dependency checks for a PR")
+    verify.add_argument("pr_number", type=int)
+    verify.add_argument("--keep-worktree", action="store_true")
+    verify.set_defaults(func=command_verify)
+
+    rebase = subparsers.add_parser("rebase", help="Ask Dependabot to rebase a PR")
+    rebase.add_argument("pr_number", type=int)
+    rebase.set_defaults(func=command_rebase)
+
+    merge = subparsers.add_parser("merge", help="Squash merge a ready Dependabot PR")
+    merge.add_argument("pr_number", type=int)
+    merge.add_argument("--allow-major", action="store_true")
+    merge.add_argument("--yes", action="store_true")
+    merge.add_argument("--subject")
+    merge.add_argument("--body")
+    merge.set_defaults(func=command_merge)
+
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.codex/skills/dependabot-maintainer/scripts/dependabot_maintainer.py
+++ b/.codex/skills/dependabot-maintainer/scripts/dependabot_maintainer.py
@@ -30,6 +30,14 @@ DEPENDENCY_FILE_PATTERNS = (
     re.compile(r"^\.github/workflows/[^/]+\.(ya?ml)$"),
     re.compile(r"^\.github/dependabot\.yml$"),
 )
+VERSION_PAIR_RE = re.compile(
+    r"\bfrom\s+`?([^`\s]+)`?\s+to\s+`?([^`\s]+)`?",
+    re.IGNORECASE,
+)
+
+
+def is_dependency_path(path: str | None) -> bool:
+    return bool(path) and is_dependency_file(path)
 
 
 def run(
@@ -101,6 +109,8 @@ def pr_view(root: Path, repo: str, number: int) -> dict[str, Any]:
                 [
                     "author",
                     "baseRefName",
+                    "body",
+                    "commits",
                     "files",
                     "headRefName",
                     "headRefOid",
@@ -142,34 +152,177 @@ def checks_green(pr: dict[str, Any]) -> tuple[bool, list[str]]:
     return not blockers, blockers
 
 
-def parse_versions(title: str) -> tuple[str | None, str | None]:
-    match = re.search(r"\bfrom\s+([^ ]+)\s+to\s+([^ ]+)", title)
-    if not match:
-        return None, None
-    return match.group(1).strip("`., "), match.group(2).strip("`., ")
+def parse_version_pairs(text: str | None) -> list[tuple[str, str]]:
+    if not text:
+        return []
+    return [
+        (before.strip("`., "), after.strip("`., "))
+        for before, after in VERSION_PAIR_RE.findall(text)
+    ]
 
 
 def leading_major(version: str | None) -> int | None:
     if not version:
         return None
-    match = re.search(r"(\d+)(?:\.\d+)?(?:\.\d+)?", version)
+    for token in re.split(r"[, ]+", version):
+        token = token.strip()
+        if not token or token.startswith("<"):
+            continue
+        match = re.search(r"(?:[>=~^=]*\s*v?)(\d+)(?:\.\d+)?", token)
+        if match:
+            return int(match.group(1))
+
+    match = re.search(r"v?(\d+)(?:\.\d+)?(?:\.\d+)?", version)
     if not match:
         return None
     return int(match.group(1))
 
 
-def is_major_update(title: str) -> bool:
-    before, after = parse_versions(title)
+def pair_is_major(before: str, after: str) -> bool | None:
     before_major = leading_major(before)
     after_major = leading_major(after)
-    return (
-        before_major is not None
-        and after_major is not None
-        and before_major != after_major
+    if before_major is None or after_major is None:
+        return None
+    return before_major != after_major
+
+
+def dependency_spec_from_line(line: str) -> tuple[str, str] | None:
+    stripped = line.strip().rstrip(",")
+    if not stripped:
+        return None
+
+    uses_match = re.search(r"\buses:\s+([^@\s]+)@([^\s#]+)", stripped)
+    if uses_match:
+        return uses_match.group(1), uses_match.group(2)
+
+    json_match = re.match(r'"([^"]+)":\s*"([^"]+)"$', stripped)
+    metadata_keys = {"integrity", "license", "name", "resolved", "version"}
+    if json_match and json_match.group(1) not in metadata_keys:
+        return json_match.group(1), json_match.group(2)
+
+    quoted_match = re.match(r'"([^"<>=~!,\s\[]+)([^"]*)"$', stripped)
+    if quoted_match:
+        name = quoted_match.group(1)
+        spec = quoted_match.group(2).strip()
+        return name, spec or name
+
+    req_match = re.match(r"([A-Za-z0-9_.-]+)\s*([<>=!~].*)$", stripped)
+    if req_match:
+        return req_match.group(1), req_match.group(2)
+
+    return None
+
+
+def version_pairs_from_diff(diff_text: str) -> list[tuple[str, str, str]]:
+    pairs: list[tuple[str, str, str]] = []
+    current_path: str | None = None
+    removed_specs: dict[str, str] = {}
+
+    for line in diff_text.splitlines():
+        if line.startswith("diff --git "):
+            current_path = None
+            removed_specs = {}
+            parts = line.split()
+            if len(parts) >= 4:
+                current_path = parts[3].removeprefix("b/")
+            continue
+
+        if not is_dependency_path(current_path):
+            continue
+
+        if line.startswith("---") or line.startswith("+++"):
+            continue
+
+        if line.startswith("-"):
+            parsed = dependency_spec_from_line(line[1:])
+            if parsed:
+                removed_specs[parsed[0]] = parsed[1]
+            continue
+
+        if line.startswith("+"):
+            parsed = dependency_spec_from_line(line[1:])
+            if parsed and parsed[0] in removed_specs:
+                pairs.append((parsed[0], removed_specs[parsed[0]], parsed[1]))
+
+    return pairs
+
+
+def pr_diff(root: Path, repo: str, number: int) -> str:
+    completed = run(
+        ["gh", "pr", "diff", str(number), "--repo", repo, "--patch"],
+        cwd=root,
+        capture=True,
     )
+    return completed.stdout
 
 
-def classify(pr: dict[str, Any], *, allow_major: bool = False) -> tuple[str, list[str]]:
+def major_update_reasons(
+    pr: dict[str, Any],
+    *,
+    diff_text: str | None,
+) -> list[str]:
+    text_pairs = parse_version_pairs(pr.get("title")) + parse_version_pairs(
+        pr.get("body")
+    )
+    for before, after in text_pairs:
+        result = pair_is_major(before, after)
+        if result is True:
+            return [f"major-version update detected: {before} -> {after}"]
+
+    if diff_text is None:
+        if any(is_dependency_file(path) for path in changed_paths(pr)):
+            return ["could not prove update is non-major without dependency diff"]
+        return ["could not prove update is non-major without dependency diff"]
+
+    diff_pairs = version_pairs_from_diff(diff_text)
+    known_non_major = False
+    for name, before, after in diff_pairs:
+        result = pair_is_major(before, after)
+        if result is True:
+            return [
+                f"major-version update detected for {name}: {before} -> {after}"
+            ]
+        if result is False:
+            known_non_major = True
+
+    if known_non_major:
+        return []
+
+    if any(is_dependency_file(path) for path in changed_paths(pr)):
+        return ["could not determine update level from dependency diff"]
+
+    return []
+
+
+def commit_authors_are_dependabot(pr: dict[str, Any]) -> tuple[bool, list[str]]:
+    commits = pr.get("commits") or []
+    if not commits:
+        return False, ["missing head commit metadata"]
+
+    reasons: list[str] = []
+    for commit in commits:
+        oid = (commit.get("oid") or "unknown")[:12]
+        authors = commit.get("authors") or []
+        if not authors:
+            reasons.append(f"commit {oid} has no author metadata")
+            continue
+        for author in authors:
+            login = author.get("login")
+            email = author.get("email") or ""
+            name = author.get("name") or ""
+            if (
+                login not in DEPENDABOT_AUTHORS
+                and "dependabot[bot]" not in email
+                and name != "dependabot[bot]"
+            ):
+                reasons.append(
+                    f"commit {oid} author is {login or email or name!r}"
+                )
+
+    return not reasons, reasons
+
+
+def base_guard_reasons(pr: dict[str, Any]) -> list[str]:
     reasons: list[str] = []
 
     author = (pr.get("author") or {}).get("login")
@@ -187,24 +340,47 @@ def classify(pr: dict[str, Any], *, allow_major: bool = False) -> tuple[str, lis
     if disallowed:
         reasons.append("non-dependency files changed: " + ", ".join(disallowed))
 
+    commits_ok, commit_reasons = commit_authors_are_dependabot(pr)
+    if not commits_ok:
+        reasons.extend(commit_reasons)
+
+    return reasons
+
+
+def classify(
+    pr: dict[str, Any],
+    *,
+    allow_major: bool = False,
+    diff_text: str | None = None,
+) -> tuple[str, list[str]]:
+    reasons = base_guard_reasons(pr)
+
     mergeable = pr.get("mergeable")
     merge_state = pr.get("mergeStateStatus")
-    if mergeable == "CONFLICTING" or merge_state == "DIRTY":
-        reasons.append(f"PR has merge conflicts: {mergeable}/{merge_state}")
-    elif mergeable not in ("MERGEABLE", "UNKNOWN"):
-        reasons.append(f"mergeability is {mergeable}/{merge_state}")
+    if mergeable != "MERGEABLE" or merge_state != "CLEAN":
+        reasons.append(
+            "mergeability must be MERGEABLE/CLEAN; "
+            f"got {mergeable}/{merge_state}"
+        )
 
     green, blockers = checks_green(pr)
     if not green:
         reasons.extend(blockers)
 
-    if is_major_update(pr.get("title", "")) and not allow_major:
-        reasons.append("major-version update requires manual approval")
+    if not allow_major:
+        reasons.extend(major_update_reasons(pr, diff_text=diff_text))
 
     if not reasons:
         return "ready", []
 
-    if any("pending" in reason or "QUEUED" in reason or "IN_PROGRESS" in reason for reason in reasons):
+    if any(
+        "pending" in reason
+        or "QUEUED" in reason
+        or "IN_PROGRESS" in reason
+        or "UNKNOWN" in reason
+        or "UNSTABLE" in reason
+        for reason in reasons
+    ):
         return "wait", reasons
 
     if any("missing checks" in reason for reason in reasons):
@@ -303,7 +479,7 @@ def npm_scripts(package_json: Path) -> dict[str, str]:
 
 def verify_npm_dir(worktree: Path, rel_dir: Path) -> None:
     package_dir = worktree / rel_dir
-    run(["npm", "ci", "--prefer-offline"], cwd=package_dir)
+    run(["npm", "ci", "--ignore-scripts", "--prefer-offline"], cwd=package_dir)
     scripts = npm_scripts(package_dir / "package.json")
     for script in ("lint", "type-check", "test:ci"):
         if script in scripts:
@@ -340,7 +516,12 @@ def command_report(args: argparse.Namespace) -> int:
 
     for listed in prs:
         pr = pr_view(root, repo, listed["number"])
-        status, reasons = classify(pr, allow_major=args.allow_major)
+        diff_text = pr_diff(root, repo, pr["number"])
+        status, reasons = classify(
+            pr,
+            allow_major=args.allow_major,
+            diff_text=diff_text,
+        )
         paths = changed_paths(pr)
         print(f"## PR #{pr['number']}: {pr['title']}")
         print(f"URL: {pr['url']}")
@@ -361,7 +542,12 @@ def command_guard(args: argparse.Namespace) -> int:
     root = repo_root()
     repo = args.repo or repo_full_name(root)
     pr = pr_view(root, repo, args.pr_number)
-    status, reasons = classify(pr, allow_major=args.allow_major)
+    diff_text = pr_diff(root, repo, args.pr_number)
+    status, reasons = classify(
+        pr,
+        allow_major=args.allow_major,
+        diff_text=diff_text,
+    )
     print(f"PR #{pr['number']} status: {status}")
     for reason in reasons:
         print(f"- {reason}")
@@ -372,9 +558,11 @@ def command_rebase(args: argparse.Namespace) -> int:
     root = repo_root()
     repo = args.repo or repo_full_name(root)
     pr = pr_view(root, repo, args.pr_number)
-    author = (pr.get("author") or {}).get("login")
-    if author not in DEPENDABOT_AUTHORS:
-        print(f"Refusing to comment: author is {author!r}", file=sys.stderr)
+    reasons = base_guard_reasons(pr)
+    if reasons:
+        print(f"Refusing to rebase PR #{args.pr_number}", file=sys.stderr)
+        for reason in reasons:
+            print(f"- {reason}", file=sys.stderr)
         return 1
     run(
         [
@@ -396,6 +584,16 @@ def command_verify(args: argparse.Namespace) -> int:
     root = repo_root()
     repo = args.repo or repo_full_name(root)
     pr = pr_view(root, repo, args.pr_number)
+    diff_text = pr_diff(root, repo, args.pr_number)
+    reasons = base_guard_reasons(pr)
+    if not args.allow_major:
+        reasons.extend(major_update_reasons(pr, diff_text=diff_text))
+    if reasons:
+        print(f"Refusing to verify PR #{args.pr_number}", file=sys.stderr)
+        for reason in reasons:
+            print(f"- {reason}", file=sys.stderr)
+        return 1
+
     paths = changed_paths(pr)
     dirs = dependency_dirs(paths)
 
@@ -428,7 +626,12 @@ def command_merge(args: argparse.Namespace) -> int:
     root = repo_root()
     repo = args.repo or repo_full_name(root)
     pr = pr_view(root, repo, args.pr_number)
-    status, reasons = classify(pr, allow_major=args.allow_major)
+    diff_text = pr_diff(root, repo, args.pr_number)
+    status, reasons = classify(
+        pr,
+        allow_major=args.allow_major,
+        diff_text=diff_text,
+    )
     if status != "ready":
         print(f"Refusing to merge PR #{args.pr_number}: {status}", file=sys.stderr)
         for reason in reasons:
@@ -482,6 +685,7 @@ def build_parser() -> argparse.ArgumentParser:
     verify = subparsers.add_parser("verify", help="Run local dependency checks for a PR")
     verify.add_argument("pr_number", type=int)
     verify.add_argument("--keep-worktree", action="store_true")
+    verify.add_argument("--allow-major", action="store_true")
     verify.set_defaults(func=command_verify)
 
     rebase = subparsers.add_parser("rebase", help="Ask Dependabot to rebase a PR")


### PR DESCRIPTION
## Summary

Adds a repo-local Codex skill for repeatable Dependabot PR maintenance.

- Adds `.codex/skills/dependabot-maintainer/SKILL.md` with the review, rebase, verify, and merge workflow.
- Adds a deterministic `dependabot_maintainer.py` helper that can report open Dependabot PRs, guard merge readiness, request Dependabot rebases, run local dependency checks in scratch worktrees, and squash-merge only when explicit guardrails pass.
- Adds `references/scheduled-task.md` with the recommended Codex scheduled task prompt plus Claude routine split and pre-merge hook guardrail.

## Validation

- `python3 -m py_compile .codex/skills/dependabot-maintainer/scripts/dependabot_maintainer.py`
- `python3 /Users/tnorlund/.codex/skills/.system/skill-creator/scripts/quick_validate.py .codex/skills/dependabot-maintainer`
- `python3 .codex/skills/dependabot-maintainer/scripts/dependabot_maintainer.py report`
- `python3 .codex/skills/dependabot-maintainer/scripts/dependabot_maintainer.py guard 1075 || true` to confirm stale/merged PRs are refused

## Notes

The actual recurring Codex scheduled task is app-side state, so this PR adds the reviewed repo machinery and the exact prompt to use after merge.