### PR TITLE
Add LayoutLM product diagnostics and model evidence docs

### DIFF
--- a/infra/sagemaker_training/train.py
+++ b/infra/sagemaker_training/train.py
@@ -89,6 +89,9 @@ def build_train_command(hps: dict) -> list[str]:
         "gradient_accumulation_steps": "--gradient-accumulation-steps",
         "label_smoothing": "--label-smoothing",
         "early_stopping_patience": "--early-stopping-patience",
+        "checkpoint_metric": "--checkpoint-metric",
+        "metric_for_best_model": "--checkpoint-metric",
+        "product_detail_loss_weight": "--product-detail-loss-weight",
         "pretrained": "--pretrained",
         "o_entity_ratio": "--o-entity-ratio",
         "resume_from_s3": "--resume-from-s3",
@@ -145,6 +148,18 @@ def build_train_command(hps: dict) -> list[str]:
         cmd.extend(
             ["--receipt-allowlist-s3", str(hps["receipt_allowlist_s3"])]
         )
+
+    # First-pass product/detail experiment: add train-only line-item windows
+    # while validation and inference stay on full receipts.
+    item_window_flag = hps.get(
+        "item_window_augmentation", hps.get("item_window_augment")
+    )
+    if str(item_window_flag).lower() == "true":
+        cmd.append("--item-window-augment")
+    if hps.get("item_window_size"):
+        cmd.extend(["--item-window-size", str(hps["item_window_size"])])
+    if hps.get("item_window_stride"):
+        cmd.extend(["--item-window-stride", str(hps["item_window_stride"])])
 
     # Output path - use SageMaker's model dir
     # The trainer will save here, and SageMaker uploads to S3 automatically

--- a/receipt_layoutlm/EVALUATION.md
+++ b/receipt_layoutlm/EVALUATION.md
@@ -209,23 +209,23 @@ train snapshot. Receipts with `20-39` item rows averaged product F1 about
 token logs also show label/eval tension: v28 had `527` high-confidence product
 false positive tokens and many `O -> PRODUCT_NAME` product confusions.
 
-Those product false positives are not one failure mode. A review of the current
-v28 diagnostic artifacts split the `527` high-confidence product false-positive
-tokens into:
+Those product false positives are not one failure mode. The current heuristic
+diagnostic buckets split the `527` high-confidence product false-positive tokens
+in the v28 artifacts into:
 
-- `234` likely unlabeled product-text tokens, such as item words predicted as
-  `PRODUCT_NAME` while gold is strict `O`;
+- `233` tokens classified as likely unlabeled product text pending manual
+  audit;
 - `97` numeric amount overpredictions;
 - `96` numeric quantity overpredictions;
-- `54` product-name numeric/code boundary cases;
+- `55` product-name numeric/code boundary cases;
 - `21` refund, fee, discount, tax, or deposit terms;
 - `25` other product-name false positives.
 
 The v29 weighted run was similar: `268` of `556` high-confidence product false
-positives looked like likely unlabeled product text. This does not mean the
-labels are bad or that the metric should be relaxed. It means strict product F1
-must be read alongside a product false-positive review queue before we claim the
-model is hallucinating product names.
+positives landed in the same heuristic likely-product-text bucket. This does
+not mean the labels are bad or that the metric should be relaxed. It means
+strict product F1 must be read alongside a product false-positive review queue
+before we claim the model is hallucinating product names.
 
 ## Product Label/Eval Contract
 
@@ -236,8 +236,8 @@ positive for F1.
 Diagnostics now add a second, explanatory contract for high-confidence product
 false positives:
 
-- `likely_unlabeled_product_text`: audit examples and decide whether we need
-  more real/synthetic coverage, but do not auto-credit the prediction.
+- `likely_unlabeled_product_text`: a heuristic audit queue for examples that
+  may need more real/synthetic coverage, but do not auto-credit the prediction.
 - `product_name_numeric_or_code`: inspect SKU/code boundaries separately from
   product-word boundaries.
 - `numeric_quantity_overprediction` and `numeric_amount_overprediction`: treat

--- a/receipt_layoutlm/EVALUATION.md
+++ b/receipt_layoutlm/EVALUATION.md
@@ -1,48 +1,260 @@
-## LayoutLM receipts: training and evaluation notes
+# LayoutLM Evaluation
 
-This document summarizes how we train and evaluate the LayoutLM model in this repo, and how to run a quick local evaluation against ground-truth Dynamo labels.
+Last updated: 2026-07-09 UTC.
 
-### What’s implemented
+Evaluation is now built around one rule: do not trust a single random validation
+score for receipt understanding. Random receipt splits can put the same merchant
+template in train and validation, which makes the model look better than it is
+at handling new uploads or new merchant layouts.
 
-- BIO tagging per line (B-/I-/O) generated from raw word labels.
-- Train/validation split at receipt level: lines from the same `(image_id, receipt_id)` never mix across splits.
-- Entity-level evaluation via `seqeval` (F1/precision/recall). Best model is selected by F1 and loaded at the end. Early stopping is enabled (patience=2).
-- Stable checkpointing (safetensors, limited retention) to reduce disk pressure.
+## Current Validation Contract
 
-### Quick local evaluation (against Dynamo VALID labels)
+Use pinned receipt-key files in S3 for all serious comparisons. A run is only
+comparable to another run when both use the same validation key file, same label
+set, and same inference windowing.
 
-Use `dev.layoutlm_inference.py` (in project root):
+Current adversarial split:
 
-1. Model resolution and download
-
-- The script uses Pulumi env (`layoutlm_training_bucket`) to auto-resolve the latest `runs/<job>/best/` (fallback to the newest checkpoint) and sync it to `~/model` if `MODEL_S3_URI` is not set.
-
-2. Inference
-
-- Picks a random receipt via `DynamoClient`, groups words by line, normalizes per-receipt bounding boxes to 0..1000, runs the model per line with `padding='longest'`.
-
-3. Comparison vs ground truth
-
-- Fetches only `VALID` `ReceiptWordLabel`s, reduces BIO to base labels, and computes per-word precision/recall/F1 by label (excluding `O`). Prints micro-averages and sample mismatches.
-
-### Interpreting results
-
-- If recall is high and precision is low, the model is over-tagging; common causes are sparse or inconsistent word-level labels for multi-token entities. Ensure contiguous words for an entity are labeled consistently (BIO) during annotation.
-- Consider entity-level (span) scoring for better correlation with extraction utility. `seqeval` F1 already measures entity-level performance during training; the local script prints token-level comparisons to surface concrete errors quickly.
-
-### Improving accuracy
-
-- Data quality: label full spans for entities, harmonize taxonomy (see `receipt_label/constants.py`).
-- Model recipe: keep warmup (0.1), weight decay (0.01), gradient clipping (1.0), optional label smoothing; run a small LR sweep (1e-5…5e-5). For visual gains, migrate to LayoutLMv2 if images are available.
-- Post-processing: merge consecutive `ADDRESS_LINE` tokens; apply simple validators (e.g., phone/date regex) as a final filter.
-
-### Reproducing training
-
-```bash
-layoutlm-cli train \
-  --job-name "receipts-$(date +%s)" \
-  --dynamo-table "$DYNAMO_TABLE_NAME" \
-  --epochs 12 --batch-size 4 --lr 3e-5
+```text
+s3://layoutlm-training-dev-68164770/config/adversarial_val_keys_v2_20260708.json
 ```
 
-Artifacts are written to `/tmp/receipt_layoutlm` (synced to S3 under `runs/<job-id>/`).
+This split intentionally holds out:
+
+- all post-active-model uploads available when the split was created;
+- selected full merchant templates;
+- the same receipt keys for real-only and synthetic-augmented comparisons.
+
+The full merchant-template holdouts are:
+
+- `COSTCO WHOLESALE`
+- `VONS`
+- `THE HOME DEPOT`
+- `WILD FORK`
+- `TARGET GROCERY`
+
+Do not train on synthetic examples derived from those merchants when reporting
+generalization against this split. That would turn the experiment into a
+template-leakage test.
+
+## Current Scorecard
+
+Active deployed model:
+
+- job: `layoutlm-v23-qty-pinned`
+- best checkpoint: `s3://layoutlm-training-dev-68164770/runs/layoutlm-v23-qty-pinned/best/`
+- original held-out F1: about `0.719`
+- important limitation: the label head does not include `PRODUCT_NAME` or
+  `LOYALTY_ID`
+
+Recent full-core real-only retrain:
+
+- job: `layoutlm-v24-fullcore-real-20260708-004112`
+- trained on real receipts only
+- label set: 22 core labels, including `PRODUCT_NAME` and `LOYALTY_ID`
+- original canonical held-out F1: about `0.665`
+- weak labels: `PRODUCT_NAME`, `LOYALTY_ID`, `UNIT_PRICE`, `DISCOUNT`, `REFUND`
+- contaminated for recent-upload evaluation because the new uploads were in the
+  training split
+
+Current adversarial real-only baseline:
+
+- job: `layoutlm-v25-adversarial-real-20260708-022719`
+- validation file: `adversarial_val_keys_v2_20260708.json`
+- status at doc update: SageMaker completed
+- best live held-out F1: about `0.532` at epoch 68
+- latest reviewed epoch: 83
+- validation receipts: 168
+
+The v25 score is lower because the split is harder. Treat it as a better
+generalization estimate, not as a failed run by itself.
+
+Parallel reduced-label ablation:
+
+- job: `layoutlm-v25-adversarial-core-real-20260708-032219`
+- validation file: `adversarial_val_keys_v2_20260708.json`
+- labels: merchant/contact/date/time/payment/totals core labels
+- purpose: test whether the full 22-label head is hurting core extraction
+- status at doc update: SageMaker completed
+- best trainer validation F1: about `0.626` at epoch 46
+- final trainer validation F1: about `0.625` at epoch 56
+- important limitation: excludes `PRODUCT_NAME`, `QUANTITY`, `UNIT_PRICE`,
+  `LOYALTY_ID`, `COUPON`, `DISCOUNT`, and `REFUND`
+
+Product-detail reference runs:
+
+- `layoutlm-v25-line-items-scoped`: cropped line-item-band distribution,
+  `PRODUCT_NAME` F1 about `0.61`, `LINE_TOTAL` about `0.79`, but validation was
+  only five scoped receipts and does not represent first-pass inference.
+- `layoutlm-v26-qty-unitprice`: full first-pass distribution, best held-out F1
+  about `0.681`, with `PRODUCT_NAME` about `0.36`, `QUANTITY` about `0.38`, and
+  `UNIT_PRICE` about `0.32`.
+- New first-pass experiment hook: `--item-window-augment`, which adds cropped
+  line-item-band windows to train only and keeps validation/inference on full
+  receipts.
+
+Completed v27 dev comparison:
+
+- `layoutlm-v27-control-adv-20260708-041606`: fresh full-core control on the
+  newly deployed dev image. Best live held-out F1 was about `0.536` at epoch
+  65. Best held-out product-detail macro F1 was about `0.348` at epoch 21.
+- `layoutlm-v27-item-window-adv-20260708-041259`: same recipe plus
+  `--item-window-augment`, `--item-window-size 200`, and
+  `--item-window-stride 150`. Best live held-out F1 was about `0.531` at epoch
+  38. Best held-out product-detail macro F1 was about `0.397` at epoch 12.
+
+Interpretation: item-window augmentation is not enough to improve the overall
+first-pass model as-is, but it helps product labels early.
+
+Completed v28 product-metric comparison:
+
+- `layoutlm-v28-control-prodmetric-20260708-063942`: selected checkpoints by
+  `--checkpoint-metric product_detail_macro_f1`; best held-out product-detail
+  macro F1 was about `0.363` at epoch 20; best aggregate held-out F1 was about
+  `0.528` at epoch 25.
+- `layoutlm-v28-item-window-prodmetric-20260708-063942`: same checkpoint metric
+  plus `--item-window-augment`; best held-out product-detail macro F1 was about
+  `0.390` at epoch 12; best aggregate held-out F1 was about `0.525` at epoch
+  15.
+
+Interpretation: selecting `best/` by product-detail macro F1 works, and the
+item-window recipe is the better product-detail checkpoint. It still does not
+solve `PRODUCT_NAME`: the best v28 item-window checkpoint had `PRODUCT_NAME` F1
+around `0.25` at the product-selected epoch, while `UNIT_PRICE` and
+`LINE_TOTAL` benefited more from the item-window signal.
+
+Completed v29 improvement ablations:
+
+- `layoutlm-v29-item-window-prodweight-20260708-145418`: full 22-label head,
+  item-window augmentation, product checkpointing, and
+  `--product-detail-loss-weight 1.5`.
+- `layoutlm-v29-product-only-item-window-20260708-145418`: item-window
+  augmentation with only `PRODUCT_NAME`, `QUANTITY`, `UNIT_PRICE`, and
+  `LINE_TOTAL` allowed.
+
+Both v29 SageMaker jobs completed. The weighted full-head run reached best
+product-detail macro F1 about `0.354`; the product-only run reached about
+`0.332`. Both were below the v28 item-window product-selected checkpoint's
+`0.390`. This argues against "just weight product labels more" or "just shrink
+the head to product labels" as the next main direction.
+
+Completed checkpoint diagnostics:
+
+- v28 diagnostic job:
+  `layoutlm-diag-v28-item-window-v2-cpu-20260709174453`
+- v29 weighted diagnostic job:
+  `layoutlm-diag-v29-weighted-v2-cpu-20260709174453`
+- output prefix:
+  `s3://layoutlm-training-dev-68164770/diagnostics/`
+
+The v28 diagnostic report found held-out F1 `0.5199` and product-detail macro
+F1 `0.3900`. The v29 weighted diagnostic report found held-out F1 `0.5022` and
+product-detail macro F1 `0.3536`.
+
+## Required Slices
+
+Every serious report should include these slices:
+
+- all adversarial validation receipts;
+- recent-upload holdout;
+- full merchant-template holdout;
+- seen-merchant validation receipts;
+- unseen-merchant validation receipts;
+- product-heavy receipts;
+- receipts containing any weak label;
+- per-merchant results for merchants with enough support;
+- in-sample train sample, clearly labeled as contaminated.
+
+The in-sample number is useful only as a memorization/template-fitting warning.
+For v24, a train sample scored about `0.913` while canonical heldout was about
+`0.665`. That gap shows real learning plus substantial dependence on repeated
+formats.
+
+## Failure-Mode Diagnostics
+
+Use `layoutlm-cli diagnose-run` when deciding why a checkpoint failed. It scores
+one selected checkpoint on the frozen validation receipts and writes:
+
+- `summary.json`: aggregate scores plus hypothesis evidence.
+- `report.md`: readable scorecard for the same evidence.
+- `per_receipt.csv` and `per_receipt.jsonl`: one row per validation receipt.
+- `groups.json`: merchant, place, template, line-item, and distance slices.
+- `token_errors.jsonl`: every incorrect token with gold label, predicted label,
+  confidence, top probabilities, and error kind.
+
+The four hypotheses should be separated this way:
+
+- Template coverage: unseen merchants/templates should score worse than seen
+  merchants/templates, and nearest-template distance should correlate
+  negatively with product F1.
+- Line-item structure: repeated item-count or column-presence buckets should
+  show consistent weak slices, such as no `LINE_TOTAL` column or very long item
+  tables.
+- Label/eval mismatch: high-confidence false positives, especially product-like
+  tokens labeled `O`, suggest the model may be finding plausible product fields
+  that the current label/eval contract does not accept.
+- Model weakness: many low-confidence product errors across both seen and
+  unseen templates suggest capacity, architecture, or input representation is
+  the blocker.
+
+Current v28/v29 diagnostics support template and structure effects. For v28,
+seen merchants averaged product F1 about `0.472`, unseen merchants about
+`0.375`, and nearest-template distance correlated with product F1 at about
+`-0.315`. Receipts with `20-39` item rows averaged product F1 about `0.125`,
+and receipts without a `LINE_TOTAL` column averaged about `0.108`. The token
+logs also show label/eval tension: v28 had `527` high-confidence product false
+positive tokens and many `O -> PRODUCT_NAME` product confusions.
+
+## How To Interpret Scores
+
+High `DATE`, `TIME`, `PAYMENT_METHOD`, `MERCHANT_NAME`, and totals performance
+usually means the model has learned stable receipt geometry and local text
+patterns.
+
+Weak `PRODUCT_NAME`, `LOYALTY_ID`, `UNIT_PRICE`, `DISCOUNT`, and `REFUND`
+performance usually means at least one of these is true:
+
+- the label is sparse;
+- the label boundary is ambiguous at word level;
+- the label appears in many merchant-specific formats;
+- the model sees many similar numeric/text tokens with different meanings;
+- we are asking one global head to solve a field that may need post-processing
+  or merchant-aware rules.
+
+## Devil's Advocate Checks
+
+Before promoting a model, answer these questions:
+
+- Did the validation split include the same merchant templates as training?
+- Did recent uploads appear in training?
+- Did synthetic examples use validation merchants or validation receipt-derived
+  structure?
+- Did F1 improve only because the model over-predicted common labels?
+- Did weak-label F1 improve, or did the aggregate move because easy labels got
+  slightly better?
+- Are we reporting entity-level `seqeval` F1, token accuracy, and per-label F1
+  separately?
+- Are we comparing against the active model on a compatible label set?
+- If product-detail F1 improves, did precision stay usable, or did the model
+  merely spray product labels into non-product regions?
+- If a product-only run beats the full-head run, are we willing to use a
+  product-specialized model/head instead of forcing one flat label head to do
+  everything?
+- If synthetic data improves seen merchants but not held-out merchant
+  templates, are we measuring template imitation instead of generalization?
+
+## Synthetic Evaluation Contract
+
+A synthetic-augmented run is fair only when:
+
+- it uses the exact same validation key file as the real-only baseline;
+- synthetic rows are added to training only;
+- validation stays real receipts only;
+- held-out merchants and held-out receipt-derived templates are excluded from
+  synthetic generation;
+- the synthetic bundle passes its quality gates and mix-balance checks;
+- results are reported by slice, not only aggregate F1.
+
+The first useful synthetic question is not "can synthetic beat the active
+model?" The useful question is "does synthetic improve v25's adversarial slices
+without leaking the heldout merchant templates?"

--- a/receipt_layoutlm/EVALUATION.md
+++ b/receipt_layoutlm/EVALUATION.md
@@ -209,6 +209,47 @@ train snapshot. Receipts with `20-39` item rows averaged product F1 about
 token logs also show label/eval tension: v28 had `527` high-confidence product
 false positive tokens and many `O -> PRODUCT_NAME` product confusions.
 
+Those product false positives are not one failure mode. A review of the current
+v28 diagnostic artifacts split the `527` high-confidence product false-positive
+tokens into:
+
+- `234` likely unlabeled product-text tokens, such as item words predicted as
+  `PRODUCT_NAME` while gold is strict `O`;
+- `97` numeric amount overpredictions;
+- `96` numeric quantity overpredictions;
+- `54` product-name numeric/code boundary cases;
+- `21` refund, fee, discount, tax, or deposit terms;
+- `25` other product-name false positives.
+
+The v29 weighted run was similar: `268` of `556` high-confidence product false
+positives looked like likely unlabeled product text. This does not mean the
+labels are bad or that the metric should be relaxed. It means strict product F1
+must be read alongside a product false-positive review queue before we claim the
+model is hallucinating product names.
+
+## Product Label/Eval Contract
+
+Strict evaluation stays strict: only VALID gold spans count as correct. A token
+that looks like an item but is labeled `O` is still an `O -> PRODUCT_NAME` false
+positive for F1.
+
+Diagnostics now add a second, explanatory contract for high-confidence product
+false positives:
+
+- `likely_unlabeled_product_text`: audit examples and decide whether we need
+  more real/synthetic coverage, but do not auto-credit the prediction.
+- `product_name_numeric_or_code`: inspect SKU/code boundaries separately from
+  product-word boundaries.
+- `numeric_quantity_overprediction` and `numeric_amount_overprediction`: treat
+  as column-structure errors unless the gold contract explicitly labels that
+  numeric role.
+- `adjustment_or_fee_term` and `receipt_meta_term`: keep outside
+  `PRODUCT_NAME` unless the business contract changes.
+
+This gives us two truths at once: strict F1 remains comparable across jobs, and
+the review queue explains whether false positives point to contract ambiguity,
+missing template coverage, or actual model weakness.
+
 ## How To Interpret Scores
 
 High `DATE`, `TIME`, `PAYMENT_METHOD`, `MERCHANT_NAME`, and totals performance

--- a/receipt_layoutlm/EVALUATION.md
+++ b/receipt_layoutlm/EVALUATION.md
@@ -184,9 +184,11 @@ one selected checkpoint on the frozen validation receipts and writes:
 
 The four hypotheses should be separated this way:
 
-- Template coverage: unseen merchants/templates should score worse than seen
-  merchants/templates, and nearest-template distance should correlate
-  negatively with product F1.
+- Template coverage: context-unseen merchants/templates should score worse than
+  context-seen merchants/templates, and nearest-template distance should
+  correlate negatively with product F1. Treat this as training coverage only
+  when the diagnostic context comes from persisted train receipt keys; otherwise
+  it is current-corpus coverage.
 - Line-item structure: repeated item-count or column-presence buckets should
   show consistent weak slices, such as no `LINE_TOTAL` column or very long item
   tables.
@@ -198,12 +200,14 @@ The four hypotheses should be separated this way:
   the blocker.
 
 Current v28/v29 diagnostics support template and structure effects. For v28,
-seen merchants averaged product F1 about `0.472`, unseen merchants about
-`0.375`, and nearest-template distance correlated with product F1 at about
-`-0.315`. Receipts with `20-39` item rows averaged product F1 about `0.125`,
-and receipts without a `LINE_TOTAL` column averaged about `0.108`. The token
-logs also show label/eval tension: v28 had `527` high-confidence product false
-positive tokens and many `O -> PRODUCT_NAME` product confusions.
+context-seen merchants averaged product F1 about `0.472`, context-unseen
+merchants about `0.375`, and nearest-template distance correlated with product
+F1 at about `-0.315`. These v28/v29 diagnostics used current VALID corpus
+context excluding the full frozen validation split, not a persisted historical
+train snapshot. Receipts with `20-39` item rows averaged product F1 about
+`0.125`, and receipts without a `LINE_TOTAL` column averaged about `0.108`. The
+token logs also show label/eval tension: v28 had `527` high-confidence product
+false positive tokens and many `O -> PRODUCT_NAME` product confusions.
 
 ## How To Interpret Scores
 

--- a/receipt_layoutlm/HYPERPARAMS.md
+++ b/receipt_layoutlm/HYPERPARAMS.md
@@ -1,94 +1,224 @@
-## LayoutLM training: batch size and hyperparameter sweeps
+# LayoutLM Training Strategy
 
-### What batch size does here
+Last updated: 2026-07-09 UTC.
 
-- **Unit**: one training sample is a receipt line (tokens + bboxes + BIO tags).
-- **Batch size**: number of lines per optimizer step.
-- **Effects**:
-  - **Throughput**: larger batch → more tokens/sec, fewer steps/epoch.
-  - **Memory**: grows roughly linearly with batch size. Attention also scales with sequence length.
-  - **Optimization**: very large batches can need a higher learning rate; huge batches can sometimes reduce generalization.
-- **Effective batch**: per_device_batch_size × gradient_accumulation_steps × num_gpus.
+The current receipt model should be improved with controlled parallel
+experiments, not by waiting for one 100-epoch job and guessing from the final
+aggregate F1.
 
-### Suggested defaults (single A10G on g5.xlarge)
+## Current Baseline Recipe
 
-- Mixed precision: enabled (fp16 automatically when CUDA available).
-- TF32: enabled for faster matmul on Ampere (safe for transformers).
-- DataLoader: num_workers 4–8, pin_memory=True.
-- Start batch size high enough to keep GPU-Util ~85–95% without OOM.
+The current v25 adversarial real-only baseline uses:
 
-### Key hyperparameters to sweep
+- pretrained model: `microsoft/layoutlm-base-uncased`
+- model version: `v1`
+- epochs: `100`
+- batch size: `8`
+- learning rate: `1e-5`
+- warmup ratio: `0.1`
+- gradient accumulation: `1`
+- label smoothing: `0.0`
+- early stopping patience: `15`
+- validation split: `adversarial_val_keys_v2_20260708.json`
+- labels: all 22 current core labels
+- live held-out eval: enabled, writes `epochs.json`
 
-- **Learning rate (lr)**: 1e-5 → 5e-5 (log-uniform). Most important.
-- **Weight decay**: 0.0 → 0.1.
-- **Warmup ratio**: 0.0 → 0.2.
-- **Effective batch size**: adjust batch_size and/or gradient_accumulation_steps.
-- **Label smoothing**: 0.0 → 0.1. Can improve recall and stabilize early training.
-- Optional: **max_grad_norm** (0.5–1.0), **early_stopping_patience** (2–4).
+This recipe is intentionally conservative. The low learning rate and 22-label
+head can take many epochs to settle, especially with receipt windows that are
+mostly `O` tokens and with sparse labels such as `LOYALTY_ID`, `DISCOUNT`,
+`REFUND`, `TIP`, and `UNIT_PRICE`.
 
-### Practical sweep recipe
+## Why So Many Epochs
 
-1. Keep data and preprocessing fixed (BIO tagging, receipt-level split).
-2. Limit epochs to 3–5 with early stopping on val_f1 to speed up search.
-3. Run 10–20 trials varying: lr, weight_decay, warmup_ratio, batch_size/grad_accum, label_smoothing.
-4. Select best by val_f1; retrain that config for full epochs (e.g., 10–12).
+Many epochs are needed here because the run is doing several hard things at
+once:
 
-### Example commands
+- adapting a generic LayoutLM base model to receipt-specific OCR geometry;
+- learning a new 22-label BIO head;
+- separating many visually similar numeric fields;
+- learning sparse labels with little support;
+- handling long receipts through sliding windows;
+- training with a low learning rate.
 
-Run a single trial with tuned batch size and defaults:
+More epochs are not a guarantee of better generalization. If held-out F1
+plateaus while training loss keeps falling, more epochs mostly increase
+template memorization and confidence in wrong predictions.
+
+## Labels
+
+The full 22-label model is useful for product search and receipt intelligence,
+but it is harder than the deployed v23 head. Do not compare v23 aggregate F1
+directly to full-core v24/v25 without calling out the label-set difference.
+
+Current weak labels to watch:
+
+- `PRODUCT_NAME`
+- `LOYALTY_ID`
+- `UNIT_PRICE`
+- `DISCOUNT`
+- `REFUND`
+- `TIP`
+- `QUANTITY`
+
+Useful label ablations can run in parallel:
+
+- full-core control: all 22 labels, real receipts only;
+- operational-core model: merchant, date/time, payment, totals, address/phone;
+- line-item model: `PRODUCT_NAME`, `QUANTITY`, `UNIT_PRICE`, `LINE_TOTAL`, plus
+  enough anchors to crop and reconcile;
+- merged-amount model: merge `LINE_TOTAL`, `SUBTOTAL`, `TAX`, and `GRAND_TOTAL`
+  only if the product need is "find any amount" rather than exact field type.
+
+Use `--allowed-label` and `--label-merges` for these ablations. Keep the same
+validation split so the comparison is honest.
+
+## Parallel Experiment Lanes
+
+We can train multiple jobs at once. The useful parallel lanes are:
+
+1. Real-only adversarial control.
+   v25 is complete. The fresh-image v27 control completed with best live
+   held-out F1 about `0.536`.
+
+2. Short hyperparameter sweep.
+   Run 3-5 epoch jobs on the same adversarial split to test learning rate,
+   label smoothing, and O-token downsampling. Pick winners for full retrain.
+
+3. Label-scope ablation.
+   Train a smaller label head to test whether the full 22-label task is hurting
+   high-value extraction.
+
+4. Synthetic-loader port.
+   Port the synthetic training hook from `.worktrees/synth-images-frontend` into
+   main before launching a synthetic SageMaker job.
+
+5. First-pass item-window augmentation.
+   Use `--item-window-augment` on the full 22-label head. This appends cropped
+   line-item-band windows to the training split only, while validation and
+   inference stay full-receipt/windowed. v27 did not beat the control on
+   aggregate F1, but it had the stronger early product-detail checkpoint. v28
+   confirmed that `--checkpoint-metric product_detail_macro_f1` preserves that
+   better product checkpoint: item-window held-out product-detail macro F1 was
+   about `0.390`, compared with the control's `0.363`.
+
+6. Synthetic-augmented run.
+   Use the exact same adversarial validation split, add synthetic rows to the
+   training split only, and exclude heldout merchants from synthetic generation.
+
+Avoid running multiple long jobs that differ only by random seed. That can be
+useful later, but it does not answer the current product question as quickly as
+label, data, and synthesis ablations.
+
+Current concurrency note: as of this update, the account limit for
+`ml.g5.xlarge` training usage is 2 instances. A third concurrent `g5.xlarge`
+job will be rejected unless one run finishes or the quota is increased. Use the
+two slots for meaningfully different experiments.
+
+## Current Improvement Result
+
+The v29 jobs were intentionally different:
+
+- `layoutlm-v29-item-window-prodweight-20260708-145418`: full 22-label head,
+  item-window augmentation, product checkpointing, and
+  `--product-detail-loss-weight 1.5`.
+- `layoutlm-v29-product-only-item-window-20260708-145418`: product-only head
+  with `PRODUCT_NAME`, `QUANTITY`, `UNIT_PRICE`, and `LINE_TOTAL`, plus
+  item-window augmentation.
+
+Both completed below the v28 product-selected item-window checkpoint:
+
+- v28 item-window product-selected: product-detail macro F1 about `0.390`.
+- v29 weighted full-head: product-detail macro F1 about `0.354`.
+- v29 product-only head: product-detail macro F1 about `0.332`.
+
+This rules out two easy fixes for now: simply increasing product-label loss
+weight and simply narrowing the head to product labels. Do not spend more long
+runs on epoch count alone. Move to proof-driven data changes: merchant-template
+slices, synthetic product-row augmentation, label/eval contract review, and
+product-line structural priors.
+
+Merchant layout repetition is useful but easy to fool ourselves with. Report
+seen-merchant and held-out-template metrics separately before deciding that a
+change generalizes.
+
+Use `layoutlm-cli diagnose-run` before launching the next training lane. The
+current v28/v29 diagnostics support these directions:
+
+- Template coverage: unseen merchants scored worse than seen merchants, and
+  product F1 fell as nearest-template distance increased.
+- Line-item structure: missing `LINE_TOTAL` columns and very long item tables
+  are materially weaker slices.
+- Label/eval mismatch: high-confidence product false positives need review
+  before we decide whether they are model errors or unlabeled-but-useful tokens.
+- Model weakness: low-confidence product errors remain, but they are not the
+  only failure mode, so an architecture change should wait until coverage,
+  structure, and labels have been isolated.
+
+## Sweep Knobs
+
+Good first sweep values:
+
+- learning rate: `5e-6`, `1e-5`, `2e-5`, `3e-5`
+- label smoothing: `0.0`, `0.03`, `0.05`
+- O:entity ratio target: unset, `2.0`, `3.0`
+- early stopping patience for sweeps: `3` to `5`
+- epochs for sweeps: `3` to `5`
+
+Keep these fixed during sweeps:
+
+- validation key file;
+- label set for the experiment lane;
+- receipt window size and stride;
+- real-only versus synthetic augmentation status.
+- first-pass item-window augmentation status.
+
+## Command Shape
+
+Local command shape:
 
 ```bash
-export TORCH_ALLOW_TF32=1
-export TOKENIZERS_PARALLELISM=false
-export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
-export CUDA_DEVICE_MAX_CONNECTIONS=1
-
-JOB=receipts-$(date +%s); RUNS=~/runs/$JOB; mkdir -p "$RUNS"
-layoutlm-cli train --job-name "$JOB" --dynamo-table "$DYNAMO_TABLE_NAME" \
-  --epochs 5 --batch-size 192 --lr 3e-5 2>&1 | tee "$RUNS/train.log"
+layoutlm-cli train \
+  --job-name <job-name> \
+  --dynamo-table ReceiptsTable-dc5be22 \
+  --epochs 5 \
+  --batch-size 8 \
+  --lr 1e-5 \
+  --warmup-ratio 0.1 \
+  --early-stopping-patience 4 \
+  --val-keys-s3 s3://layoutlm-training-dev-68164770/config/adversarial_val_keys_v2_20260708.json
 ```
 
-Coarse manual sweep sketch (change just the numbers):
+First-pass product-detail experiment:
 
 ```bash
-for lr in 1e-5 2e-5 3e-5 5e-5; do
-  for wd in 0.0 0.01 0.05; do
-    JOB="sweep-$(date +%s)-lr${lr}-wd${wd}"; RUNS=~/runs/$JOB; mkdir -p "$RUNS"
-    layoutlm-cli train --job-name "$JOB" --dynamo-table "$DYNAMO_TABLE_NAME" \
-      --epochs 4 --batch-size 160 --lr $lr 2>&1 | tee "$RUNS/train.log"
-  done
-done
+layoutlm-cli train \
+  --job-name <job-name> \
+  --dynamo-table ReceiptsTable-dc5be22 \
+  --epochs 100 \
+  --batch-size 8 \
+  --lr 1e-5 \
+  --warmup-ratio 0.1 \
+  --early-stopping-patience 15 \
+  --checkpoint-metric product_detail_macro_f1 \
+  --product-detail-loss-weight 1.5 \
+  --val-keys-s3 s3://layoutlm-training-dev-68164770/config/adversarial_val_keys_v2_20260708.json \
+  --item-window-augment
 ```
 
-### Interpreting metrics
+Use `--product-detail-loss-weight` conservatively. Start with `1.5`; values much
+larger than that may improve product recall by spraying product labels into
+non-product regions.
 
-- We report **seqeval** entity-level Precision/Recall/F1 (BIO), ignoring the O tag.
-- Expect low F1 in early epochs, especially with O‑heavy data. It should rise as the head learns.
-- Use `load_best_model_at_end=True` and `metric_for_best_model=f1` (already set) to keep the best checkpoint.
+For SageMaker, pass the same settings as Lambda hyperparameters so the training
+container builds the equivalent `layoutlm-cli train` command.
 
-### Saving and promoting artifacts
+## Promotion Rules
 
-Sync full run directory and best checkpoint to S3 after training:
+Do not promote from aggregate F1 alone. A model is promotable only if:
 
-```bash
-/usr/bin/aws s3 sync /tmp/receipt_layoutlm/$JOB s3://$BUCKET/runs/$JOB/
-if [ -f /tmp/receipt_layoutlm/$JOB/trainer_state.json ]; then
-  BEST=$(python - <<'PY'
-import json,sys
-p=f"/tmp/receipt_layoutlm/{sys.argv[1]}/trainer_state.json"
-print(json.load(open(p)).get("best_model_checkpoint",""))
-PY
-"$JOB")
-  [ -n "$BEST" ] && /usr/bin/aws s3 sync "$BEST" s3://$BUCKET/runs/$JOB/best/
-fi
-```
-
-### Common pitfalls and fixes
-
-- F1 ~0 early on: model predicts mostly O after adding unlabeled tokens; let it train or filter all‑O lines for training only.
-- OOM on big batches: reduce batch size; ensure `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True` is set.
-- Resume mismatch: changing label set invalidates old checkpoints; start a new run dir (already isolated per job).
-
-### When larger batch is “better”
-
-- Larger batch is primarily a performance lever. Accuracy doesn’t automatically improve. If you go much larger, consider modest LR scaling and monitor val_f1. Use the smallest batch that saturates the GPU and gives stable/improving metrics.
+- it beats the current candidate on the same pinned validation split;
+- the improvement is visible in the slices we care about;
+- weak-label behavior is understood, not hidden by easy-label gains;
+- recent-upload and merchant-template holdout results are reported separately;
+- synthetic training, if used, did not include heldout merchants or templates;
+- CoreML export and inference validation pass for the target runtime.

--- a/receipt_layoutlm/HYPERPARAMS.md
+++ b/receipt_layoutlm/HYPERPARAMS.md
@@ -138,14 +138,15 @@ slices, synthetic product-row augmentation, label/eval contract review, and
 product-line structural priors.
 
 Merchant layout repetition is useful but easy to fool ourselves with. Report
-seen-merchant and held-out-template metrics separately before deciding that a
-change generalizes.
+context-seen and held-out-template metrics separately before deciding that a
+change generalizes; call it training-seen only when the diagnostic context comes
+from persisted train receipt keys.
 
 Use `layoutlm-cli diagnose-run` before launching the next training lane. The
 current v28/v29 diagnostics support these directions:
 
-- Template coverage: unseen merchants scored worse than seen merchants, and
-  product F1 fell as nearest-template distance increased.
+- Template coverage: context-unseen merchants scored worse than context-seen
+  merchants, and product F1 fell as nearest-template distance increased.
 - Line-item structure: missing `LINE_TOTAL` columns and very long item tables
   are materially weaker slices.
 - Label/eval mismatch: high-confidence product false positives need review

--- a/receipt_layoutlm/HYPERPARAMS.md
+++ b/receipt_layoutlm/HYPERPARAMS.md
@@ -155,6 +155,34 @@ current v28/v29 diagnostics support these directions:
   only failure mode, so an architecture change should wait until coverage,
   structure, and labels have been isolated.
 
+## Next Product-Detail Data Lane
+
+The next useful data change is targeted, not broad. Current diagnostics point at
+three data targets:
+
+- merchant-template variants for `THE HOME DEPOT`, `COSTCO WHOLESALE`,
+  `WILD FORK`, and `VONS` style layouts;
+- long item tables, especially `20-39` item rows, where v28 averaged product
+  F1 about `0.125`;
+- no-line-total layouts, where v28 averaged product F1 about `0.108` versus
+  about `0.470` when a line-total column was present.
+
+For the current adversarial split, do not synthesize exact held-out merchant
+names or copied held-out templates. Use real uploads for those merchants when
+the goal is production coverage, then create a new honest split. Use synthetic
+receipts for structural analogs: warehouse-club layouts without line totals,
+hardware-store SKU/code rows, grocery/butcher long item tables, and item rows
+with discounts/refunds/fees that are explicitly not product names.
+
+The next train job should be launched only after one of these inputs changes:
+
+- a reviewed real-receipt batch is added for the missing merchant/template
+  shapes;
+- a synthetic training bundle is wired into main and excludes held-out
+  merchants/templates;
+- or the product label/eval contract changes and is reflected in both training
+  labels and diagnostics.
+
 ## Sweep Knobs
 
 Good first sweep values:

--- a/receipt_layoutlm/METRICS.md
+++ b/receipt_layoutlm/METRICS.md
@@ -101,7 +101,9 @@ questions depend on these fields.
 Track these gaps:
 
 - train-sample F1 versus held-out F1;
-- seen-merchant F1 versus unseen-merchant F1;
+- context-seen merchant F1 versus context-unseen merchant F1, or
+  training-seen versus training-unseen when the context is a persisted train
+  split;
 - canonical random split F1 versus adversarial split F1;
 - recent-upload F1 when recent uploads are held out versus when they were in
   training;

--- a/receipt_layoutlm/METRICS.md
+++ b/receipt_layoutlm/METRICS.md
@@ -207,6 +207,23 @@ Do not treat high-confidence false positives as automatic bad labels. They are
 review prompts: either the label/eval contract is too strict, the receipt has
 unlabeled valid entities, or the model is confidently wrong.
 
+For product details, diagnostics now split high-confidence product false
+positives into review buckets while leaving strict F1 unchanged:
+
+- `likely_unlabeled_product_text`;
+- `product_name_numeric_or_code`;
+- `numeric_quantity_overprediction`;
+- `numeric_amount_overprediction`;
+- `adjustment_or_fee_term`;
+- `receipt_meta_term`;
+- other inspection buckets.
+
+Use those buckets to decide whether the next action is label-contract review,
+real receipt collection, synthetic structural coverage, or model architecture
+work. The same diagnostic run also emits `data_targeting` in `summary.json` so
+missing merchant templates, long item tables, and no-line-total layouts are
+visible as data targets rather than buried in token errors.
+
 ## DynamoDB Records
 
 When enabled, training writes:

--- a/receipt_layoutlm/METRICS.md
+++ b/receipt_layoutlm/METRICS.md
@@ -1,214 +1,273 @@
-# LayoutLM Training Metrics
+# LayoutLM Metrics
 
-This document tracks the metrics recorded during LayoutLM training runs and their storage in DynamoDB.
+Last updated: 2026-07-09 UTC.
 
-## Storage Entities
+Metrics are recorded in three places:
 
-| Entity | Purpose | Query Capabilities |
-|--------|---------|-------------------|
-| `Job` | Training run metadata, config, status | Query by status, created_at |
-| `JobMetric` | Individual metric values with epoch/step | Query by metric name across jobs (GSI1, GSI2) |
-| `JobLog` | Structured JSON logs (config, summary) | Query by job_id |
+- SageMaker training job metadata;
+- S3 run artifacts under `s3://layoutlm-training-dev-68164770/runs/<job>/`;
+- DynamoDB `Job`, `JobMetric`, and `JobLog` records when the trainer can write
+  them.
 
-## Per-Epoch Training Metrics
+For current model decisions, prefer the S3 run artifacts because they contain
+the live held-out curve and frozen run lineage.
 
-Recorded as `JobMetric` entities after each evaluation epoch.
+## Key Artifacts
 
-| Metric | Status | Source | Unit | Notes |
-|--------|--------|--------|------|-------|
-| `val_f1` | ✅ Implemented | `compute_metrics` | ratio | Entity-level F1 from seqeval |
-| `val_precision` | ✅ Implemented | `compute_metrics` | ratio | Entity-level precision |
-| `val_recall` | ✅ Implemented | `compute_metrics` | ratio | Entity-level recall |
-| `eval_loss` | ✅ Implemented | HF Trainer | loss | Validation loss (lower is better) |
-| `train_loss` | ✅ Implemented | HF Trainer `log_history` | loss | Training loss curve |
-| `learning_rate` | ✅ Implemented | HF Trainer `log_history` | rate | LR scheduler tracking |
-| `entropy_mean` | ✅ Implemented | `compute_metrics` | nats | Mean prediction entropy (model confidence) |
-| `entropy_std` | ✅ Implemented | `compute_metrics` | nats | Std dev of prediction entropy |
-| `entropy_p10` | ✅ Implemented | `compute_metrics` | nats | 10th percentile entropy (most confident) |
-| `entropy_p90` | ✅ Implemented | `compute_metrics` | nats | 90th percentile entropy (least confident) |
+Each serious run should write:
 
-**Implementation:** `receipt_layoutlm/trainer.py` → `_MetricLoggerCallback.on_evaluate()`
+- `run.json`: config, label set, split metadata, dataset counts, and training
+  summary.
+- `epochs.json`: live or post-hoc checkpoint evaluation on the frozen held-out
+  receipts.
+- `checkpoints/checkpoint-*/`: saved model checkpoints.
+- `best/`: best checkpoint copied for downstream inference/export.
+- `receipts/`: optional showcase receipt predictions from checkpoint eval.
 
-**Batch Write:** All metrics written in single `add_job_metrics()` call per epoch.
+Current v25 live metrics:
 
-## Entropy Metrics
-
-Entropy measures model confidence in its predictions. Computed from softmax probabilities:
-`H = -Σ(p × log(p))` for each token prediction.
-
-| Entropy Value | Interpretation |
-|---------------|----------------|
-| Low (~0.1-0.5) | Model is confident (good if correct, bad if wrong) |
-| High (~1.5-2.5) | Model is uncertain |
-
-**Use case:** If `entropy_mean` drops over epochs but `val_f1` plateaus, the model may be becoming overconfident on incorrect predictions (overfitting signal).
-
-**Query example:**
-```python
-# Compare entropy trends across training
-metrics, _ = dynamo.list_job_metrics(job_id)
-entropy_metrics = [m for m in metrics if m.metric_name == "entropy_mean"]
-for m in sorted(entropy_metrics, key=lambda x: x.epoch or 0):
-    print(f"Epoch {m.epoch}: entropy={m.value:.3f}")
+```text
+s3://layoutlm-training-dev-68164770/runs/layoutlm-v25-adversarial-real-20260708-022719/epochs.json
 ```
+
+Current product-detail comparison artifacts:
+
+```text
+s3://layoutlm-training-dev-68164770/runs/layoutlm-v28-control-prodmetric-20260708-063942/epochs.json
+s3://layoutlm-training-dev-68164770/runs/layoutlm-v28-item-window-prodmetric-20260708-063942/epochs.json
+```
+
+Completed v29 jobs wrote the same artifacts under:
+
+```text
+s3://layoutlm-training-dev-68164770/runs/layoutlm-v29-item-window-prodweight-20260708-145418/epochs.json
+s3://layoutlm-training-dev-68164770/runs/layoutlm-v29-product-only-item-window-20260708-145418/epochs.json
+```
+
+Current diagnostic artifacts:
+
+```text
+s3://layoutlm-training-dev-68164770/diagnostics/layoutlm-diag-v28-item-window-v2-cpu-20260709174453/
+s3://layoutlm-training-dev-68164770/diagnostics/layoutlm-diag-v29-weighted-v2-cpu-20260709174453/
+```
+
+## Metrics To Report
+
+Always report these together:
+
+- entity-level F1, precision, and recall from `seqeval`;
+- token accuracy;
+- per-label F1;
+- number of validation receipts;
+- validation key file;
+- label set;
+- best epoch;
+- latest epoch;
+- whether the run is real-only or synthetic-augmented.
+
+Token accuracy is not enough. Receipts are O-heavy, so a model can achieve high
+token accuracy while missing the labels that matter.
 
 ## Per-Label Metrics
 
-Per-label breakdown stored as one `JobMetric` per label with Dict value.
+Per-label F1 is the main diagnostic for whether the aggregate score is useful.
 
-| Metric | Status | Source | Notes |
-|--------|--------|--------|-------|
-| `label_{LABEL_NAME}` | ✅ Implemented | `classification_report` | Dict with f1, precision, recall, support |
+Labels that usually validate the model is learning receipt structure:
 
-**Storage format:** One record per label per epoch:
-```python
-JobMetric(
-    metric_name="label_MERCHANT_NAME",
-    value={"f1": 0.92, "precision": 0.94, "recall": 0.90, "support": 156},
-    unit="per_label",
-    epoch=3,
-)
-JobMetric(
-    metric_name="label_AMOUNT",
-    value={"f1": 0.85, "precision": 0.88, "recall": 0.82, "support": 423},
-    unit="per_label",
-    epoch=3,
-)
+- `DATE`
+- `TIME`
+- `PAYMENT_METHOD`
+- `MERCHANT_NAME`
+- `TAX`
+- `SUBTOTAL`
+- `GRAND_TOTAL`
+- `LINE_TOTAL`
+
+Labels that usually expose the hard part:
+
+- `PRODUCT_NAME`
+- `LOYALTY_ID`
+- `UNIT_PRICE`
+- `DISCOUNT`
+- `REFUND`
+- `TIP`
+- `QUANTITY`
+
+Do not hide weak labels behind aggregate F1. Product search and loyalty/refund
+questions depend on these fields.
+
+## Memorization Signals
+
+Track these gaps:
+
+- train-sample F1 versus held-out F1;
+- seen-merchant F1 versus unseen-merchant F1;
+- canonical random split F1 versus adversarial split F1;
+- recent-upload F1 when recent uploads are held out versus when they were in
+  training;
+- synthetic-augmented F1 versus real-only F1 on the exact same validation file.
+
+Large gaps are not automatically bad. Merchant templates are a real production
+signal. The risk is claiming generalization when the split only measures
+template familiarity.
+
+## Live Curve
+
+The trainer can run windowed held-out evaluation after each saved checkpoint.
+That produces `epochs.json` during training. The useful fields are:
+
+- `best_epoch_heldout`
+- `num_val_receipts`
+- per-epoch `heldout_f1`
+- per-epoch `heldout_precision`
+- per-epoch `heldout_recall`
+- per-epoch `token_accuracy`
+- per-epoch `per_label_f1`
+- per-epoch `per_label_precision`, `per_label_recall`, and
+  `per_label_support`
+- per-epoch `product_detail_macro_f1`
+- per-epoch `entity_prediction_rate` and `gold_entity_rate`
+- `checkpoint`
+
+If F1 plateaus for many epochs while training loss continues to fall, treat the
+extra epochs as overfitting risk rather than progress.
+
+Best-checkpoint selection is configurable with `--checkpoint-metric`. The
+default remains aggregate entity F1 (`f1`). For first-pass product experiments,
+use `--checkpoint-metric product_detail_macro_f1` so `best/` follows
+`PRODUCT_NAME`, `QUANTITY`, `UNIT_PRICE`, and `LINE_TOTAL` instead of easy
+non-product fields.
+
+Product-detail loss pressure is configurable with
+`--product-detail-loss-weight`. Compare precision and recall separately when
+using it; an apparent product macro-F1 gain is not useful if it comes mostly
+from low-precision over-prediction.
+
+For v29, judge the jobs this way:
+
+- full weighted head wins only if product-detail macro F1 improves without a
+  large precision collapse and without major aggregate held-out F1 regression;
+- product-only head wins if it materially improves `PRODUCT_NAME` and
+  `UNIT_PRICE`, even if it is not directly promotable as the only production
+  model;
+- neither wins if the curves remain in the v28 band, in which case the next
+  metric work should segment by merchant/template and synthetic source rather
+  than launch another same-shape long run.
+
+## Explanation Metrics
+
+New runs also write `diagnostics` inside each `epochs.json` epoch entry. These
+fields are meant to explain why the model is or is not improving:
+
+- `token_counts`: total, correct, gold/predicted `O`, and gold/predicted entity
+  tokens.
+- `entity_counts`: gold versus predicted entity spans, plus predicted/gold
+  ratio.
+- `rates`: gold entity token rate, predicted entity token rate, `O` token
+  accuracy, and entity token accuracy.
+- `product_detail`: macro F1 and prediction balance for `PRODUCT_NAME`,
+  `QUANTITY`, `UNIT_PRICE`, and `LINE_TOTAL`.
+- `per_label_token_counts`: gold versus predicted token counts per label.
+- `per_label_entity_counts`: gold versus predicted entity counts per label.
+- `top_token_confusions`: the most common token-level label confusions.
+
+Use these to tell whether a run is under-predicting product details, spraying
+rare labels everywhere, improving recall at the cost of precision, or merely
+getting better at easy non-product fields.
+
+## Diagnostic Artifacts
+
+`epochs.json` explains how a run moved during training. `diagnose-run` explains
+why one selected checkpoint behaves the way it does on frozen validation.
+
+Run diagnostics when aggregate/product curves are not enough:
+
+```bash
+layoutlm-cli diagnose-run \
+  --run-s3-uri s3://layoutlm-training-dev-68164770/runs/<job-name>/ \
+  --dynamo-table ReceiptsTable-dc5be22 \
+  --output-dir /tmp/<job-name>-diagnostics \
+  --output-s3-uri s3://layoutlm-training-dev-68164770/diagnostics/<job-name>/
 ```
 
-**Query examples:**
-```python
-# Get MERCHANT_NAME metrics across all jobs
-metrics, _ = dynamo.get_metrics_by_name("label_MERCHANT_NAME")
-for m in metrics:
-    print(f"Job {m.job_id[:8]} Epoch {m.epoch}: F1={m.value['f1']:.3f}")
+Interpret the diagnostic files this way:
 
-# Compare label performance within a job
-label_metrics, _ = dynamo.list_job_metrics(job_id)
-for m in [m for m in label_metrics if m.metric_name.startswith("label_")]:
-    print(f"{m.metric_name}: F1={m.value['f1']:.3f} Support={m.value['support']}")
+- `summary.json`: top-level evidence for template coverage, line-item
+  structure, label/eval mismatch, and model weakness.
+- `report.md`: human-readable version of the same evidence.
+- `per_receipt.csv`: quick spreadsheet view for sorting by merchant, product
+  F1, nearest-template distance, and high-confidence product false positives.
+- `groups.json`: grouped merchant/place/template/shape slices.
+- `token_errors.jsonl`: the inner loop for debugging confidence, boundary
+  errors, false positives, misses, and wrong-label predictions.
+
+Do not treat high-confidence false positives as automatic bad labels. They are
+review prompts: either the label/eval contract is too strict, the receipt has
+unlabeled valid entities, or the model is confidently wrong.
+
+## DynamoDB Records
+
+When enabled, training writes:
+
+- `Job`: run metadata, status, config, and final results.
+- `JobMetric`: per-epoch scalar metrics and dataset statistics.
+- `JobLog`: structured config and summary payloads.
+
+`Job.results` keeps both `best_f1`/`best_f1_epoch` and the checkpoint-selection
+fields `checkpoint_metric`, `best_checkpoint_metric_value`, and
+`best_checkpoint_metric_epoch`. Check the latter before promoting or exporting
+from `best/`.
+
+Dataset metrics to keep:
+
+- number of train examples;
+- number of validation examples;
+- train O:entity ratio before downsampling;
+- train O:entity ratio after downsampling;
+- validation O:entity ratio;
+- target O:entity ratio;
+- label merge configuration;
+- allowed-label list;
+- validation split URI.
+
+Live held-out metrics to keep:
+
+- `heldout_windowed_f1`, precision, recall, and token accuracy;
+- `heldout_windowed_product_detail_macro_f1`;
+- `heldout_windowed_entity_prediction_rate`;
+- `heldout_windowed_f1_delta_vs_training_reported`;
+- `heldout_label_PRODUCT_NAME_*`, `heldout_label_QUANTITY_*`,
+  `heldout_label_UNIT_PRICE_*`, and `heldout_label_LINE_TOTAL_*`.
+
+## Quick Checks
+
+Check SageMaker status:
+
+```bash
+aws sagemaker describe-training-job \
+  --region us-east-1 \
+  --training-job-name <job-name> \
+  --query '{Status:TrainingJobStatus,SecondaryStatus:SecondaryStatus,TrainingEndTime:TrainingEndTime,FailureReason:FailureReason,ModelArtifacts:ModelArtifacts.S3ModelArtifacts}' \
+  --output json
 ```
 
-## Training Summary Metrics
+Inspect live held-out metrics:
 
-End-of-run metrics stored in `Job.results` field after training completes.
+```bash
+aws s3 cp \
+  s3://layoutlm-training-dev-68164770/runs/<job-name>/epochs.json \
+  /tmp/<job-name>-epochs.json \
+  --region us-east-1
 
-| Metric | Status | Source | Unit |
-|--------|--------|--------|------|
-| `best_f1` | ✅ Job.results | computed | ratio |
-| `best_epoch` | ✅ Job.results | computed | epoch number |
-| `train_runtime` | ✅ Job.results | `trainer_state.json` | seconds |
-| `total_flos` | ✅ Job.results | `trainer_state.json` | FLOPs |
-| `early_stopping_triggered` | ✅ Job.results | computed | boolean |
-| `best_checkpoint_s3_path` | ✅ Job.results | computed | S3 URI |
-
-**Storage format:** Updated on Job entity after training:
-```python
-job.status = "succeeded"
-job.results = {
-    "best_f1": 0.92,
-    "best_epoch": 7,
-    "train_runtime": 3847.5,
-    "total_flos": 1200000000000000,
-    "early_stopping_triggered": True,
-    "best_checkpoint_s3_path": "s3://bucket/runs/job-name/best/",
-}
-dynamo.update_job(job)
+jq '{generated_at,best_epoch_heldout,num_val_receipts,latest:.epochs[-1]}' \
+  /tmp/<job-name>-epochs.json
 ```
 
-**Query examples:**
-```python
-# Get a job and check its results
-job = dynamo.get_job(job_id)
-if job.results:
-    print(f"Best F1: {job.results['best_f1']}")
-    print(f"Training time: {job.results['train_runtime']:.1f}s")
+Re-score all saved checkpoints:
+
+```bash
+layoutlm-cli eval-checkpoints \
+  --run-s3-uri s3://layoutlm-training-dev-68164770/runs/<job-name>/ \
+  --dynamo-table ReceiptsTable-dc5be22 \
+  --output-dir /tmp/<job-name>-eval
 ```
-
-## GPU/Resource Metrics
-
-Hardware utilization metrics. Not currently captured.
-
-| Metric | Status | Source | Notes |
-|--------|--------|--------|-------|
-| `gpu_memory_used` | ❌ Not captured | `torch.cuda.memory_allocated()` | Peak GPU usage |
-| `gpu_utilization` | ❌ Not captured | nvidia-smi or SageMaker | Compute efficiency |
-| `samples_per_second` | ❌ Not captured | HF Trainer | Throughput |
-| `steps_per_second` | ❌ Not captured | HF Trainer | Training speed |
-
-**Note:** SageMaker captures some of these in CloudWatch metrics automatically.
-
-## Dataset Quality Metrics
-
-Dataset statistics captured at training start as `JobMetric` records with `epoch=None`.
-
-| Metric | Status | Source | Unit | Notes |
-|--------|--------|--------|------|-------|
-| `num_train_samples` | ✅ Implemented | `_count_labels()` | count | Training set size (num_lines) |
-| `num_val_samples` | ✅ Implemented | `_count_labels()` | count | Validation set size (num_lines) |
-| `o_entity_ratio_train` | ✅ Implemented | `_count_labels()` | ratio | Class imbalance in training set |
-| `o_entity_ratio_val` | ✅ Implemented | `_count_labels()` | ratio | Class imbalance in validation set |
-
-**Implementation:** `receipt_layoutlm/trainer.py` → written after JobLog config entry.
-
-**Batch Write:** All 4 metrics written in single `add_job_metrics()` call at training start.
-
-**Query examples:**
-```python
-# Find jobs with high class imbalance
-metrics, _ = dynamo.get_metrics_by_name("o_entity_ratio_train")
-for m in metrics:
-    if m.value > 5.0:
-        print(f"Job {m.job_id[:8]}: O:entity ratio = {m.value:.2f}")
-
-# Compare dataset sizes across jobs
-train_sizes, _ = dynamo.get_metrics_by_name("num_train_samples")
-for m in train_sizes:
-    print(f"Job {m.job_id[:8]}: {int(m.value)} training samples")
-```
-
-## Query Examples
-
-### Compare F1 across training runs
-```python
-# Get val_f1 for all jobs, sorted by job then timestamp
-metrics, _ = dynamo.get_metrics_by_name_across_jobs("val_f1")
-
-for m in metrics:
-    print(f"Job {m.job_id[:8]} Epoch {m.epoch}: F1={m.value:.4f}")
-```
-
-### Get training curve for a job
-```python
-# Get all metrics for a specific job
-loss_metrics, _ = dynamo.list_job_metrics(job_id, metric_name="train_loss")
-lr_metrics, _ = dynamo.list_job_metrics(job_id, metric_name="learning_rate")
-
-# Plot training curve
-epochs = [m.epoch for m in loss_metrics]
-losses = [m.value for m in loss_metrics]
-```
-
-### Find best performing jobs
-```python
-# Get all val_f1 metrics
-metrics, _ = dynamo.get_metrics_by_name("val_f1")
-
-# Group by job and find max F1 per job
-from collections import defaultdict
-job_best = defaultdict(float)
-for m in metrics:
-    job_best[m.job_id] = max(job_best[m.job_id], m.value)
-
-# Sort by best F1
-ranked = sorted(job_best.items(), key=lambda x: x[1], reverse=True)
-```
-
-## GSI Structure
-
-`JobMetric` has two GSIs for efficient queries:
-
-| GSI | Key Structure | Use Case |
-|-----|---------------|----------|
-| GSI1 | `METRIC#{name}` → `{timestamp}` | "All val_f1 scores over time" |
-| GSI2 | `METRIC#{name}` → `JOB#{id}#{timestamp}` | "Compare metric across jobs" |

--- a/receipt_layoutlm/README.md
+++ b/receipt_layoutlm/README.md
@@ -41,9 +41,9 @@ Last updated: 2026-07-09 UTC.
   label/eval contract issues than toward "just train longer."
 - High-confidence product false positives are now treated as a review queue in
   diagnostics. Current v28 artifacts had `527` high-confidence product
-  false-positive tokens; `234` looked like likely item text under strict gold
-  `O`, while the rest split across numeric detail, SKU/code, adjustment/fee,
-  and other model-error buckets.
+  false-positive tokens; a heuristic bucket classified `233` as likely item
+  text pending manual audit, while the rest split across numeric detail,
+  SKU/code, adjustment/fee, and other model-error buckets.
 - Product-detail first-pass hooks: `--item-window-augment` appends train-only
   line-item-band windows; `--checkpoint-metric product_detail_macro_f1` selects
   the product checkpoint; `--product-detail-loss-weight` increases loss pressure

--- a/receipt_layoutlm/README.md
+++ b/receipt_layoutlm/README.md
@@ -39,6 +39,11 @@ Last updated: 2026-07-09 UTC.
   `s3://layoutlm-training-dev-68164770/diagnostics/`. The current evidence
   points more toward merchant/template coverage, line-item structure, and
   label/eval contract issues than toward "just train longer."
+- High-confidence product false positives are now treated as a review queue in
+  diagnostics. Current v28 artifacts had `527` high-confidence product
+  false-positive tokens; `234` looked like likely item text under strict gold
+  `O`, while the rest split across numeric detail, SKU/code, adjustment/fee,
+  and other model-error buckets.
 - Product-detail first-pass hooks: `--item-window-augment` appends train-only
   line-item-band windows; `--checkpoint-metric product_detail_macro_f1` selects
   the product checkpoint; `--product-detail-loss-weight` increases loss pressure
@@ -73,6 +78,12 @@ merchant-template coverage, line-item structure, label/eval mismatch, or actual
 model weakness. Use `diagnose-run` to produce that evidence before choosing
 between synthetic template augmentation, line-item structural features, label
 contract cleanup, or a model architecture change.
+
+The immediate data targets are missing merchant-template variants, long item
+tables, and layouts without explicit line totals. For the current adversarial
+split, synthetic data should use structural analogs rather than exact held-out
+merchant names/templates; exact held-out merchant coverage should come with a
+new honest split.
 
 ## What The Model Learns
 

--- a/receipt_layoutlm/README.md
+++ b/receipt_layoutlm/README.md
@@ -1,24 +1,149 @@
 # receipt_layoutlm
 
-Install (from repo root):
+`receipt_layoutlm` trains and serves the receipt token classifier used by the
+Portfolio receipt pipeline. The production target is still LayoutLM v1 because
+it uses OCR text plus bounding boxes and can be exported to CoreML. Rendered
+synthetic images are useful for QA, but they are not training inputs for the
+current runtime.
+
+## Current State
+
+Last updated: 2026-07-09 UTC.
+
+- Active deployed model: `layoutlm-v23-qty-pinned`.
+- Active model held-out F1: about `0.719` on its original canonical split.
+- Completed full-core adversarial retrain:
+  `layoutlm-v25-adversarial-real-20260708-022719`.
+- Current adversarial split: validation with all recent uploads plus full
+  merchant-template holdouts.
+- v25 full-core result: best held-out F1 about `0.532` at epoch 68.
+- Completed reduced-label ablation:
+  `layoutlm-v25-adversarial-core-real-20260708-032219`. Trainer validation F1
+  peaked at `0.626` at epoch 46; this run intentionally excludes product-detail
+  labels.
+- Completed v27 first-pass comparison:
+  `layoutlm-v27-control-adv-20260708-041606` beat the item-window run on
+  aggregate held-out F1 (`0.536` vs `0.531`), while
+  `layoutlm-v27-item-window-adv-20260708-041259` had the better early
+  product-detail macro F1 (`0.397` vs `0.348`).
+- Completed v28 product-metric comparison:
+  `layoutlm-v28-item-window-prodmetric-20260708-063942` beat the v28 control on
+  held-out product-detail macro F1 (`0.390` vs `0.363`), while the control
+  remained slightly better on aggregate held-out F1 (`0.528` vs `0.525`).
+- Completed v29 improvement ablations:
+  `layoutlm-v29-item-window-prodweight-20260708-145418` and
+  `layoutlm-v29-product-only-item-window-20260708-145418`. Neither beat the v28
+  product-selected item-window checkpoint on first-pass product-detail macro F1
+  (`0.354` weighted full-head, `0.332` product-only, versus `0.390` for v28).
+- Completed proof-oriented diagnostics for v28 and v29 weighted full-head under
+  `s3://layoutlm-training-dev-68164770/diagnostics/`. The current evidence
+  points more toward merchant/template coverage, line-item structure, and
+  label/eval contract issues than toward "just train longer."
+- Product-detail first-pass hooks: `--item-window-augment` appends train-only
+  line-item-band windows; `--checkpoint-metric product_detail_macro_f1` selects
+  the product checkpoint; `--product-detail-loss-weight` increases loss pressure
+  on `PRODUCT_NAME`, `QUANTITY`, `UNIT_PRICE`, and `LINE_TOTAL`.
+- Main-branch synthetic training hook: not wired in yet. The synthetic loader
+  exists in `.worktrees/synth-images-frontend` and must be ported before a fair
+  synthetic-augmented SageMaker run.
+
+The v25 number is lower than the active model number by design. It is measured
+on a harder split that holds out recent receipts and entire merchant layouts,
+not just random receipts.
+
+## Product Details In The First Pass
+
+Historical runs show why this is hard. The scoped line-item model
+`layoutlm-v25-line-items-scoped` reached about `0.61` `PRODUCT_NAME` F1, but it
+trained and evaluated on cropped line-item bands with only five validation
+receipts. The full first-pass `layoutlm-v26-qty-unitprice` reached about `0.36`
+`PRODUCT_NAME`, `0.38` `QUANTITY`, and `0.32` `UNIT_PRICE` F1 at its best heldout
+epoch.
+
+The v27 item-window experiment did not win overall, but it showed useful
+product-detail signal early. The v28 product-metric run confirmed that
+selecting by `product_detail_macro_f1` preserves the better product checkpoint:
+the item-window run reached held-out product-detail macro F1 `0.390` at epoch
+12, compared with the control's `0.363` at epoch 20.
+
+The v29 result answered the immediate ablation question: neither a weighted
+full head nor a product-only head beat v28. The next useful work is not another
+long same-shape epoch run. It is to prove which failure mode dominates:
+merchant-template coverage, line-item structure, label/eval mismatch, or actual
+model weakness. Use `diagnose-run` to produce that evidence before choosing
+between synthetic template augmentation, line-item structural features, label
+contract cleanup, or a model architecture change.
+
+## What The Model Learns
+
+The model works because receipts are semi-structured documents. Labels such as
+`DATE`, `TIME`, `MERCHANT_NAME`, `PAYMENT_METHOD`, `TAX`, and `GRAND_TOTAL`
+usually appear in predictable regions and near predictable words. Merchant
+templates amplify that signal because repeated receipts from the same merchant
+reuse column positions, headers, totals blocks, loyalty sections, and item rows.
+
+The model is not just memorizing exact receipts, but it is partly learning
+merchant-specific layout templates. That is useful in production and dangerous
+for evaluation. Any claim about generalization must separate seen-merchant,
+unseen-merchant, recent-upload, and full-template holdout slices.
+
+## Main Commands
+
+Install from the repo root:
 
 ```bash
 pip install -e receipt_dynamo
 pip install -e receipt_layoutlm
 ```
 
-If PyTorch wheels fail on Python 3.13, use Python 3.12:
+Train locally against DynamoDB:
 
 ```bash
-pyenv local 3.12.5  # or create a 3.12 venv
-python -m venv .venv && source .venv/bin/activate
-pip install -e receipt_dynamo
-pip install -e receipt_layoutlm
+export DYNAMO_TABLE_NAME=ReceiptsTable-dc5be22
+layoutlm-cli train \
+  --job-name local-layoutlm-smoke \
+  --dynamo-table "$DYNAMO_TABLE_NAME" \
+  --epochs 5 \
+  --batch-size 8 \
+  --lr 1e-5
 ```
 
-Train:
+Run the current SageMaker path through the training Lambda rather than using
+local shell commands for long jobs. Keep the validation split pinned when
+comparing runs:
+
+```text
+s3://layoutlm-training-dev-68164770/config/adversarial_val_keys_v2_20260708.json
+```
+
+Re-score a run's checkpoints on its frozen validation set:
 
 ```bash
-export DYNAMO_TABLE_NAME=<your-table>
-layoutlm-cli train --job-name test
+layoutlm-cli eval-checkpoints \
+  --run-s3-uri s3://layoutlm-training-dev-68164770/runs/<job-name>/ \
+  --dynamo-table ReceiptsTable-dc5be22 \
+  --output-dir /tmp/<job-name>-eval
 ```
+
+Diagnose one selected checkpoint receipt-by-receipt:
+
+```bash
+layoutlm-cli diagnose-run \
+  --run-s3-uri s3://layoutlm-training-dev-68164770/runs/<job-name>/ \
+  --dynamo-table ReceiptsTable-dc5be22 \
+  --output-dir /tmp/<job-name>-diagnostics \
+  --output-s3-uri s3://layoutlm-training-dev-68164770/diagnostics/<job-name>/
+```
+
+The diagnostic artifacts include `summary.json`, `report.md`,
+`per_receipt.csv`, `per_receipt.jsonl`, `groups.json`, and
+`token_errors.jsonl`.
+
+## Related Docs
+
+- [EVALUATION.md](./EVALUATION.md): validation contracts, current scorecard,
+  and devil's advocate checks.
+- [HYPERPARAMS.md](./HYPERPARAMS.md): current training strategy and parallel
+  experiment lanes.
+- [METRICS.md](./METRICS.md): metrics artifacts, live `epochs.json`, and how to
+  interpret the curves.

--- a/receipt_layoutlm/receipt_layoutlm/cli.py
+++ b/receipt_layoutlm/receipt_layoutlm/cli.py
@@ -1,7 +1,8 @@
 import argparse
 import json
 import os
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
+from urllib.parse import urlparse
 
 from .config import MODEL_DEFAULTS, MERGE_PRESETS, DataConfig, ModelVersion, TrainingConfig
 from .inference import LayoutLMInference
@@ -58,6 +59,36 @@ def _build_label_merges(
             result["ADDRESS"] = ["PHONE_NUMBER", "ADDRESS_LINE"]
 
     return result if result else None
+
+
+def _resolve_run_s3(
+    dyn: Any,
+    run_s3_uri: Optional[str],
+    job_name: Optional[str],
+) -> Tuple[str, str, str, str]:
+    """Resolve a run S3 location from an explicit URI or DynamoDB job name."""
+    if not run_s3_uri:
+        if not job_name:
+            raise SystemExit("Provide --run-s3-uri or --job-name to locate the run")
+        jobs, _ = dyn.get_job_by_name(job_name, limit=1)
+        if not jobs:
+            raise SystemExit(f"No job found with name '{job_name}'")
+        job = jobs[0]
+        run_s3_uri = job.s3_uri_for_prefix("run_root_prefix")
+        if not run_s3_uri:
+            best = (job.results or {}).get("best_checkpoint_s3_path")
+            if best:
+                run_s3_uri = best.rstrip("/").rsplit("/", 1)[0] + "/"
+        if not run_s3_uri:
+            raise SystemExit(
+                f"Could not resolve run S3 location for job '{job_name}'. "
+                f"Pass --run-s3-uri explicitly."
+            )
+    if not job_name:
+        job_name = run_s3_uri.rstrip("/").rsplit("/", 1)[-1]
+
+    parsed = urlparse(run_s3_uri)
+    return run_s3_uri, job_name, parsed.netloc, parsed.path.lstrip("/")
 
 
 def main() -> None:
@@ -845,7 +876,6 @@ def main() -> None:
 
     elif args.cmd == "eval-checkpoints":
         import logging
-        from urllib.parse import urlparse
 
         from receipt_dynamo import DynamoClient
 
@@ -863,37 +893,9 @@ def main() -> None:
 
         dyn = DynamoClient(table_name=args.dynamo_table, region=args.region)
 
-        # Resolve the run's S3 location: explicit URI wins, else look it up by
-        # job name (newest match) via the Job entity's storage prefixes.
-        run_s3_uri = args.run_s3_uri
-        job_name = args.job_name
-        if not run_s3_uri:
-            if not job_name:
-                raise SystemExit(
-                    "Provide --run-s3-uri or --job-name to locate the run"
-                )
-            jobs, _ = dyn.get_job_by_name(job_name, limit=1)
-            if not jobs:
-                raise SystemExit(f"No job found with name '{job_name}'")
-            job = jobs[0]
-            run_s3_uri = job.s3_uri_for_prefix("run_root_prefix")
-            if not run_s3_uri:
-                best = (job.results or {}).get("best_checkpoint_s3_path")
-                if best:
-                    # Strip a trailing best/ or checkpoint-*/ to get the run root
-                    trimmed = best.rstrip("/").rsplit("/", 1)[0]
-                    run_s3_uri = trimmed + "/"
-            if not run_s3_uri:
-                raise SystemExit(
-                    f"Could not resolve run S3 location for job '{job_name}'. "
-                    f"Pass --run-s3-uri explicitly."
-                )
-        if not job_name:
-            job_name = run_s3_uri.rstrip("/").rsplit("/", 1)[-1]
-
-        parsed = urlparse(run_s3_uri)
-        bucket = parsed.netloc
-        run_prefix = parsed.path.lstrip("/")
+        _, job_name, bucket, run_prefix = _resolve_run_s3(
+            dyn, args.run_s3_uri, args.job_name
+        )
 
         payload = evaluate_run(
             dynamo=dyn,
@@ -936,7 +938,6 @@ def main() -> None:
         )
     elif args.cmd == "diagnose-run":
         import logging
-        from urllib.parse import urlparse
 
         from receipt_dynamo import DynamoClient
 
@@ -954,33 +955,9 @@ def main() -> None:
 
         dyn = DynamoClient(table_name=args.dynamo_table, region=args.region)
 
-        run_s3_uri = args.run_s3_uri
-        job_name = args.job_name
-        if not run_s3_uri:
-            if not job_name:
-                raise SystemExit(
-                    "Provide --run-s3-uri or --job-name to locate the run"
-                )
-            jobs, _ = dyn.get_job_by_name(job_name, limit=1)
-            if not jobs:
-                raise SystemExit(f"No job found with name '{job_name}'")
-            job = jobs[0]
-            run_s3_uri = job.s3_uri_for_prefix("run_root_prefix")
-            if not run_s3_uri:
-                best = (job.results or {}).get("best_checkpoint_s3_path")
-                if best:
-                    run_s3_uri = best.rstrip("/").rsplit("/", 1)[0] + "/"
-            if not run_s3_uri:
-                raise SystemExit(
-                    f"Could not resolve run S3 location for job '{job_name}'. "
-                    f"Pass --run-s3-uri explicitly."
-                )
-        if not job_name:
-            job_name = run_s3_uri.rstrip("/").rsplit("/", 1)[-1]
-
-        parsed = urlparse(run_s3_uri)
-        bucket = parsed.netloc
-        run_prefix = parsed.path.lstrip("/")
+        _, job_name, bucket, run_prefix = _resolve_run_s3(
+            dyn, args.run_s3_uri, args.job_name
+        )
 
         payload = diagnose_run(
             dynamo=dyn,

--- a/receipt_layoutlm/receipt_layoutlm/cli.py
+++ b/receipt_layoutlm/receipt_layoutlm/cli.py
@@ -610,15 +610,15 @@ def main() -> None:
         "--skip-train-context",
         action="store_true",
         help=(
-            "Skip loading current train-set context. Faster, but disables "
-            "seen-merchant/template and nearest-template evidence."
+            "Skip loading coverage context. Faster, but disables "
+            "context-seen merchant/template and nearest-template evidence."
         ),
     )
     diagnose_p.add_argument(
         "--max-train-context-receipts",
         type=int,
         default=None,
-        help="Optional cap for train-context receipts loaded from DynamoDB",
+        help="Optional cap for coverage-context receipts loaded from DynamoDB",
     )
     diagnose_p.add_argument(
         "--error-confidence-threshold",

--- a/receipt_layoutlm/receipt_layoutlm/cli.py
+++ b/receipt_layoutlm/receipt_layoutlm/cli.py
@@ -4,10 +4,8 @@ import os
 from typing import Dict, List, Optional
 
 from .config import MODEL_DEFAULTS, MERGE_PRESETS, DataConfig, ModelVersion, TrainingConfig
-from .export_coreml import export_coreml, export_from_s3
 from .inference import LayoutLMInference
 from .trainer import ReceiptLayoutLMTrainer
-from .validate_coreml import validate_coreml
 
 
 def _build_label_merges(
@@ -112,6 +110,35 @@ def main() -> None:
         type=int,
         default=None,
         help="Early stopping patience (epochs). Defaults to config value.",
+    )
+    train_p.add_argument(
+        "--checkpoint-metric",
+        choices=[
+            "f1",
+            "eval_f1",
+            "product_detail_macro_f1",
+            "eval_product_detail_macro_f1",
+            "loss",
+            "eval_loss",
+            "accuracy",
+            "eval_accuracy",
+        ],
+        default=None,
+        help=(
+            "Metric used for best-checkpoint selection and early stopping. "
+            "Default is aggregate entity F1; product_detail_macro_f1 favors "
+            "PRODUCT_NAME, QUANTITY, UNIT_PRICE, and LINE_TOTAL."
+        ),
+    )
+    train_p.add_argument(
+        "--product-detail-loss-weight",
+        type=float,
+        default=None,
+        help=(
+            "Multiplier applied to class weights for PRODUCT_NAME, QUANTITY, "
+            "UNIT_PRICE, and LINE_TOTAL BIO tags. Values above 1 bias training "
+            "toward product-detail recall/precision."
+        ),
     )
     train_p.add_argument(
         "--o-entity-ratio",
@@ -251,6 +278,34 @@ def main() -> None:
         help=(
             "S3 URI of a JSON file ({\"receipt_keys\": [\"img#rec\", ...]}) "
             "restricting training/eval to a curated subset of receipts."
+        ),
+    )
+    train_p.add_argument(
+        "--item-window-augment",
+        action="store_const",
+        const=True,
+        default=None,
+        help=(
+            "First-pass experiment: append train-only line-item-band windows "
+            "while validation and inference remain full-receipt windowed."
+        ),
+    )
+    train_p.add_argument(
+        "--item-window-size",
+        type=int,
+        default=None,
+        help=(
+            "Window size for --item-window-augment. Defaults to the normal "
+            "LAYOUTLM_WINDOW_SIZE / 200 full-receipt window size."
+        ),
+    )
+    train_p.add_argument(
+        "--item-window-stride",
+        type=int,
+        default=None,
+        help=(
+            "Stride for --item-window-augment. Defaults to the normal "
+            "LAYOUTLM_WINDOW_STRIDE / 150 full-receipt stride."
         ),
     )
     train_p.add_argument(
@@ -483,6 +538,100 @@ def main() -> None:
         ),
     )
 
+    diagnose_p = sub.add_parser(
+        "diagnose-run",
+        help=(
+            "Score one checkpoint receipt-by-receipt and emit diagnostics for "
+            "merchant/template coverage, line-item shape, label mismatch, and "
+            "model uncertainty"
+        ),
+    )
+    diagnose_p.add_argument(
+        "--job-name",
+        help="Training job name; run location is resolved via DynamoDB",
+    )
+    diagnose_p.add_argument(
+        "--run-s3-uri",
+        help="Explicit s3://bucket/runs/<job>/ prefix",
+    )
+    diagnose_p.add_argument(
+        "--dynamo-table",
+        default=os.getenv("DYNAMO_TABLE_NAME"),
+        help="DynamoDB table (or DYNAMO_TABLE_NAME env)",
+    )
+    diagnose_p.add_argument(
+        "--region",
+        default=os.getenv("AWS_REGION", "us-east-1"),
+        help="AWS region",
+    )
+    diagnose_p.add_argument(
+        "--checkpoint",
+        default="best",
+        help=(
+            "Checkpoint directory to diagnose: best, checkpoint-1234, or a "
+            "bare step number. Default: best."
+        ),
+    )
+    diagnose_p.add_argument(
+        "--epoch",
+        type=int,
+        default=None,
+        help="Diagnose the checkpoint saved for this epoch instead of --checkpoint",
+    )
+    diagnose_p.add_argument(
+        "--output-dir",
+        default="./layoutlm-diagnostics",
+        help="Local directory for summary/report/per-receipt artifacts",
+    )
+    diagnose_p.add_argument(
+        "--output-s3-uri",
+        default=None,
+        help="Optional s3://bucket/prefix/ to upload diagnostic artifacts",
+    )
+    diagnose_p.add_argument(
+        "--max-receipts",
+        type=int,
+        default=None,
+        help="Cap validation receipts diagnosed (default: full frozen set)",
+    )
+    diagnose_p.add_argument(
+        "--window-size",
+        type=int,
+        default=None,
+        help="Inference window size; default uses run.json then 200",
+    )
+    diagnose_p.add_argument(
+        "--window-stride",
+        type=int,
+        default=None,
+        help="Inference window stride; default uses run.json then 150",
+    )
+    diagnose_p.add_argument(
+        "--skip-train-context",
+        action="store_true",
+        help=(
+            "Skip loading current train-set context. Faster, but disables "
+            "seen-merchant/template and nearest-template evidence."
+        ),
+    )
+    diagnose_p.add_argument(
+        "--max-train-context-receipts",
+        type=int,
+        default=None,
+        help="Optional cap for train-context receipts loaded from DynamoDB",
+    )
+    diagnose_p.add_argument(
+        "--error-confidence-threshold",
+        type=float,
+        default=0.75,
+        help="Confidence threshold for high-confidence error evidence",
+    )
+    diagnose_p.add_argument(
+        "--allow-hash-mismatch",
+        action="store_true",
+        help="Proceed if a reconstructed validation split hash mismatches",
+    )
+
     args = parser.parse_args()
 
     if args.cmd == "train":
@@ -522,6 +671,12 @@ def main() -> None:
             train_cfg.label_smoothing = args.label_smoothing
         if args.early_stopping_patience is not None:
             train_cfg.early_stopping_patience = args.early_stopping_patience
+        if args.checkpoint_metric is not None:
+            train_cfg.checkpoint_metric = args.checkpoint_metric
+        if args.product_detail_loss_weight is not None:
+            train_cfg.product_detail_loss_weight = (
+                args.product_detail_loss_weight
+            )
         if args.gradient_accumulation_steps is not None:
             train_cfg.gradient_accumulation_steps = (
                 args.gradient_accumulation_steps
@@ -541,7 +696,24 @@ def main() -> None:
         if getattr(args, "scope", "full") and args.scope != "full":
             os.environ["LAYOUTLM_SCOPE"] = args.scope
         if getattr(args, "receipt_allowlist_s3", None):
-            os.environ["LAYOUTLM_RECEIPT_ALLOWLIST_S3"] = args.receipt_allowlist_s3
+            os.environ["LAYOUTLM_RECEIPT_ALLOWLIST_S3"] = (
+                args.receipt_allowlist_s3
+            )
+        if getattr(args, "item_window_augment", None) is not None:
+            data_cfg.item_window_augmentation = bool(args.item_window_augment)
+            os.environ["LAYOUTLM_ITEM_WINDOW_AUGMENT"] = (
+                "true" if args.item_window_augment else "false"
+            )
+        if getattr(args, "item_window_size", None) is not None:
+            data_cfg.item_window_size = int(args.item_window_size)
+            os.environ["LAYOUTLM_ITEM_WINDOW_SIZE"] = str(
+                args.item_window_size
+            )
+        if getattr(args, "item_window_stride", None) is not None:
+            data_cfg.item_window_stride = int(args.item_window_stride)
+            os.environ["LAYOUTLM_ITEM_WINDOW_STRIDE"] = str(
+                args.item_window_stride
+            )
 
         # Optional label whitelist
         data_cfg.allowed_labels = (
@@ -605,6 +777,8 @@ def main() -> None:
             )
         )
     elif args.cmd == "export-coreml":
+        from .export_coreml import export_coreml, export_from_s3
+
         if not args.checkpoint_dir and not args.s3_uri:
             raise SystemExit("Either --checkpoint-dir or --s3-uri is required")
 
@@ -628,6 +802,8 @@ def main() -> None:
         print(f"CoreML bundle created: {bundle_path}")
 
     elif args.cmd == "validate-coreml":
+        from .validate_coreml import validate_coreml
+
         result = validate_coreml(
             checkpoint_dir=args.checkpoint_dir,
             coreml_bundle_dir=args.coreml_bundle,
@@ -752,6 +928,92 @@ def main() -> None:
                     "best_epoch_training_reported": payload[
                         "best_epoch_training_reported"
                     ],
+                    "output_dir": args.output_dir,
+                    "output_s3_uri": args.output_s3_uri,
+                },
+                indent=2,
+            )
+        )
+    elif args.cmd == "diagnose-run":
+        import logging
+        from urllib.parse import urlparse
+
+        from receipt_dynamo import DynamoClient
+
+        from .diagnose import diagnose_run, sync_diagnostics_to_s3
+
+        logging.basicConfig(
+            level=logging.INFO,
+            format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+        )
+
+        if not args.dynamo_table:
+            raise SystemExit(
+                "--dynamo-table or DYNAMO_TABLE_NAME env is required"
+            )
+
+        dyn = DynamoClient(table_name=args.dynamo_table, region=args.region)
+
+        run_s3_uri = args.run_s3_uri
+        job_name = args.job_name
+        if not run_s3_uri:
+            if not job_name:
+                raise SystemExit(
+                    "Provide --run-s3-uri or --job-name to locate the run"
+                )
+            jobs, _ = dyn.get_job_by_name(job_name, limit=1)
+            if not jobs:
+                raise SystemExit(f"No job found with name '{job_name}'")
+            job = jobs[0]
+            run_s3_uri = job.s3_uri_for_prefix("run_root_prefix")
+            if not run_s3_uri:
+                best = (job.results or {}).get("best_checkpoint_s3_path")
+                if best:
+                    run_s3_uri = best.rstrip("/").rsplit("/", 1)[0] + "/"
+            if not run_s3_uri:
+                raise SystemExit(
+                    f"Could not resolve run S3 location for job '{job_name}'. "
+                    f"Pass --run-s3-uri explicitly."
+                )
+        if not job_name:
+            job_name = run_s3_uri.rstrip("/").rsplit("/", 1)[-1]
+
+        parsed = urlparse(run_s3_uri)
+        bucket = parsed.netloc
+        run_prefix = parsed.path.lstrip("/")
+
+        payload = diagnose_run(
+            dynamo=dyn,
+            bucket=bucket,
+            run_prefix=run_prefix,
+            job_name=job_name,
+            output_dir=args.output_dir,
+            checkpoint=args.checkpoint,
+            epoch=args.epoch,
+            max_receipts=args.max_receipts,
+            window_size=args.window_size,
+            window_stride=args.window_stride,
+            include_train_context=not args.skip_train_context,
+            max_train_context_receipts=args.max_train_context_receipts,
+            error_confidence_threshold=args.error_confidence_threshold,
+            allow_hash_mismatch=args.allow_hash_mismatch,
+        )
+
+        if args.output_s3_uri:
+            sync_diagnostics_to_s3(args.output_dir, args.output_s3_uri)
+
+        print(
+            json.dumps(
+                {
+                    "job_name": payload["job_name"],
+                    "checkpoint": payload["checkpoint"]["name"],
+                    "num_receipts": payload["validation"][
+                        "num_receipts_loaded"
+                    ],
+                    "heldout_f1": payload["aggregate"]["scores"]["f1"],
+                    "product_detail_macro_f1": payload["aggregate"][
+                        "diagnostics"
+                    ]["product_detail"]["macro_f1"],
                     "output_dir": args.output_dir,
                     "output_s3_uri": args.output_s3_uri,
                 },

--- a/receipt_layoutlm/receipt_layoutlm/config.py
+++ b/receipt_layoutlm/receipt_layoutlm/config.py
@@ -33,6 +33,11 @@ class DataConfig:
     # S3 URI of the pinned canonical val split (recorded for run lineage so the
     # Job entity / run.json says which shared val set this run held out).
     val_keys_s3: Optional[str] = None
+    # First-pass product/detail experiment: append train-only line-item-band
+    # windows while keeping validation and inference on full receipts.
+    item_window_augmentation: Optional[bool] = None
+    item_window_size: Optional[int] = None
+    item_window_stride: Optional[int] = None
 
     def get_effective_label_merges(self) -> Dict[str, List[str]]:
         """Return the effective label merges, combining explicit config and legacy flags.
@@ -86,6 +91,12 @@ class TrainingConfig:
     auto_export_coreml: bool = False
     coreml_quantize: Optional[str] = "float16"
     model_version: str = ModelVersion.V1.value
+    # Metric used by HuggingFace Trainer for best-checkpoint selection and
+    # early stopping. Values are normalized to eval_* metric names by trainer.
+    checkpoint_metric: str = "f1"
+    # Extra class-weight multiplier for product detail labels. This keeps the
+    # 22-label first-pass head, but makes product-detail mistakes cost more.
+    product_detail_loss_weight: float = 1.0
     # Run the windowed held-out eval in-process after each epoch's checkpoint
     # is saved, emitting epochs.json live (the viz cache) on the training GPU —
     # no separate Processing job needed for new runs. Best-effort: failures are

--- a/receipt_layoutlm/receipt_layoutlm/data_loader.py
+++ b/receipt_layoutlm/receipt_layoutlm/data_loader.py
@@ -44,6 +44,12 @@ class SplitMetadata:
     # different window/stride shifts the F1 curve by inference, not quality).
     window_size: Optional[int] = None
     window_stride: Optional[int] = None
+    # Optional first-pass training augmentation: add extra line-item-band windows
+    # to TRAIN only while keeping validation and inference on full receipts.
+    item_window_augmentation: bool = False
+    num_item_window_examples: int = 0
+    item_window_size: Optional[int] = None
+    item_window_stride: Optional[int] = None
 
 
 @dataclass
@@ -477,6 +483,13 @@ def _crop_to_line_item_band(
     ]
 
 
+def _env_flag(name: str, default: bool = False) -> bool:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
 def load_datasets(
     dynamo: DynamoClient,
     label_status: str = ValidationStatus.VALID.value,
@@ -484,6 +497,9 @@ def load_datasets(
     label_merges: Optional[Dict[str, List[str]]] = None,
     allowed_labels: Optional[List[str]] = None,
     model_version: str = "v1",
+    item_window_augmentation: Optional[bool] = None,
+    item_window_size: Optional[int] = None,
+    item_window_stride: Optional[int] = None,
 ) -> Tuple[Any, SplitMetadata, MergeInfo]:
     """Load and process datasets from DynamoDB.
 
@@ -494,6 +510,11 @@ def load_datasets(
         label_merges: Dict mapping target labels to source labels to merge.
             E.g., {"AMOUNT": ["LINE_TOTAL", "SUBTOTAL", "TAX", "GRAND_TOTAL"]}
         allowed_labels: Optional list of allowed labels (whitelist).
+        item_window_augmentation: Optional first-pass product/detail experiment
+            flag. When true in full scope, append extra line-item-band windows to
+            train only. When None, falls back to LAYOUTLM_ITEM_WINDOW_AUGMENT.
+        item_window_size: Optional item-window size. Falls back to env/defaults.
+        item_window_stride: Optional item-window stride. Falls back to env/defaults.
 
     Returns:
         Tuple of (DatasetDict, SplitMetadata, MergeInfo).
@@ -620,11 +641,25 @@ def load_datasets(
     # This matches the inference distribution where the Mac OCR worker feeds
     # full multi-line word sequences — not pre-segmented same-label blocks.
     examples: List[LineExample] = []
+    item_window_examples_by_receipt: Dict[str, List[LineExample]] = {}
     window_size = int(os.getenv("LAYOUTLM_WINDOW_SIZE", "200"))
     window_stride = int(os.getenv("LAYOUTLM_WINDOW_STRIDE", "150"))
+    if item_window_augmentation is None:
+        item_window_augmentation = _env_flag(
+            "LAYOUTLM_ITEM_WINDOW_AUGMENT", False
+        )
+    if item_window_size is None:
+        item_window_size = int(
+            os.getenv("LAYOUTLM_ITEM_WINDOW_SIZE", str(window_size))
+        )
+    if item_window_stride is None:
+        item_window_stride = int(
+            os.getenv("LAYOUTLM_ITEM_WINDOW_STRIDE", str(window_stride))
+        )
     scope = os.getenv("LAYOUTLM_SCOPE", "full")
 
     for (img_id, rec_id), words_in_receipt in receipt_words.items():
+        receipt_key = f"{img_id}#{rec_id:05d}"
         if scope == "line_items":
             # Second-pass scope: train only on the line-item band of each receipt.
             words_in_receipt = _crop_to_line_item_band(
@@ -632,7 +667,24 @@ def load_datasets(
             )
             if not words_in_receipt:
                 continue
-        receipt_key = f"{img_id}#{rec_id:05d}"
+        elif item_window_augmentation:
+            # First-pass augmentation: keep full-receipt examples for the real
+            # inference distribution, but prepare extra item-band examples that
+            # will be appended to TRAIN only after the receipt split. This gives
+            # product/detail labels more gradient without contaminating val or
+            # requiring a second inference pass.
+            item_words = _crop_to_line_item_band(
+                words_in_receipt, label_map, img_id, rec_id
+            )
+            if item_words:
+                item_window_examples_by_receipt[receipt_key] = (
+                    _build_receipt_window_examples(
+                        item_words,
+                        receipt_key,
+                        window_size=item_window_size,
+                        stride=item_window_stride,
+                    )
+                )
         examples.extend(
             _build_receipt_window_examples(
                 words_in_receipt,
@@ -641,34 +693,6 @@ def load_datasets(
                 stride=window_stride,
             )
         )
-
-    ds_mod = importlib.import_module("datasets")
-    Dataset = getattr(ds_mod, "Dataset")
-    DatasetDict = getattr(ds_mod, "DatasetDict")
-    Features = getattr(ds_mod, "Features")
-    Sequence = getattr(ds_mod, "Sequence")
-    Value = getattr(ds_mod, "Value")
-
-    features = Features(
-        {
-            "tokens": Sequence(Value("string")),
-            "bboxes": Sequence(Sequence(Value("int64"))),
-            "ner_tags": Sequence(Value("string")),
-            "receipt_key": Value("string"),
-            "image_id": Value("string"),
-        }
-    )
-
-    dataset = Dataset.from_dict(
-        {
-            "tokens": [ex.tokens for ex in examples],
-            "bboxes": [ex.bboxes for ex in examples],
-            "ner_tags": [ex.ner_tags for ex in examples],
-            "receipt_key": [ex.receipt_key for ex in examples],
-            "image_id": [ex.image_id for ex in examples],
-        },
-        features=features,
-    )
 
     # Receipt-level split by unique (image_id, receipt_id).
     unique_receipts = sorted(
@@ -708,6 +732,13 @@ def load_datasets(
     val_receipts_hash = hashlib.sha256(
         ",".join(sorted(val_receipts_list)).encode()
     ).hexdigest()[:16]
+
+    num_item_window_examples = 0
+    if scope == "full" and item_window_augmentation:
+        for receipt_key in train_receipts_list:
+            extra_examples = item_window_examples_by_receipt.get(receipt_key, [])
+            examples.extend(extra_examples)
+            num_item_window_examples += len(extra_examples)
 
     train_indices = [
         i for i, ex in enumerate(examples) if ex.receipt_key in train_receipts
@@ -793,6 +824,34 @@ def load_datasets(
         else float("inf")
     )
 
+    ds_mod = importlib.import_module("datasets")
+    Dataset = getattr(ds_mod, "Dataset")
+    DatasetDict = getattr(ds_mod, "DatasetDict")
+    Features = getattr(ds_mod, "Features")
+    Sequence = getattr(ds_mod, "Sequence")
+    Value = getattr(ds_mod, "Value")
+
+    features = Features(
+        {
+            "tokens": Sequence(Value("string")),
+            "bboxes": Sequence(Sequence(Value("int64"))),
+            "ner_tags": Sequence(Value("string")),
+            "receipt_key": Value("string"),
+            "image_id": Value("string"),
+        }
+    )
+
+    dataset = Dataset.from_dict(
+        {
+            "tokens": [ex.tokens for ex in examples],
+            "bboxes": [ex.bboxes for ex in examples],
+            "ner_tags": [ex.ner_tags for ex in examples],
+            "receipt_key": [ex.receipt_key for ex in examples],
+            "image_id": [ex.image_id for ex in examples],
+        },
+        features=features,
+    )
+
     # Download warped receipt images for v3 training
     image_cache_dir: Optional[str] = None
     if model_version == "v3":
@@ -820,6 +879,12 @@ def load_datasets(
         val_receipt_keys=sorted(val_receipts_list),
         window_size=window_size,
         window_stride=window_stride,
+        item_window_augmentation=(
+            scope == "full" and item_window_augmentation
+        ),
+        num_item_window_examples=num_item_window_examples,
+        item_window_size=item_window_size,
+        item_window_stride=item_window_stride,
     )
 
     # v3 needs receipt_key during preprocessing (image cache lookup); removed later in trainer.map()

--- a/receipt_layoutlm/receipt_layoutlm/data_loader.py
+++ b/receipt_layoutlm/receipt_layoutlm/data_loader.py
@@ -490,6 +490,37 @@ def _env_flag(name: str, default: bool = False) -> bool:
     return raw.strip().lower() in {"1", "true", "yes", "on"}
 
 
+def _env_positive_int(name: str, default: int) -> int:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        print(
+            f"[data_loader] WARN: {name}={raw!r} is not a valid int; "
+            f"falling back to {default}"
+        )
+        return default
+    if value <= 0:
+        print(
+            f"[data_loader] WARN: {name}={raw!r} must be positive; "
+            f"falling back to {default}"
+        )
+        return default
+    return value
+
+
+def _positive_int_or_default(name: str, value: int, default: int) -> int:
+    if value > 0:
+        return value
+    print(
+        f"[data_loader] WARN: {name}={value!r} must be positive; "
+        f"falling back to {default}"
+    )
+    return default
+
+
 def load_datasets(
     dynamo: DynamoClient,
     label_status: str = ValidationStatus.VALID.value,
@@ -642,19 +673,27 @@ def load_datasets(
     # full multi-line word sequences — not pre-segmented same-label blocks.
     examples: List[LineExample] = []
     item_window_examples_by_receipt: Dict[str, List[LineExample]] = {}
-    window_size = int(os.getenv("LAYOUTLM_WINDOW_SIZE", "200"))
-    window_stride = int(os.getenv("LAYOUTLM_WINDOW_STRIDE", "150"))
+    window_size = _env_positive_int("LAYOUTLM_WINDOW_SIZE", 200)
+    window_stride = _env_positive_int("LAYOUTLM_WINDOW_STRIDE", 150)
     if item_window_augmentation is None:
         item_window_augmentation = _env_flag(
             "LAYOUTLM_ITEM_WINDOW_AUGMENT", False
         )
     if item_window_size is None:
-        item_window_size = int(
-            os.getenv("LAYOUTLM_ITEM_WINDOW_SIZE", str(window_size))
+        item_window_size = _env_positive_int(
+            "LAYOUTLM_ITEM_WINDOW_SIZE", window_size
+        )
+    else:
+        item_window_size = _positive_int_or_default(
+            "item_window_size", item_window_size, window_size
         )
     if item_window_stride is None:
-        item_window_stride = int(
-            os.getenv("LAYOUTLM_ITEM_WINDOW_STRIDE", str(window_stride))
+        item_window_stride = _env_positive_int(
+            "LAYOUTLM_ITEM_WINDOW_STRIDE", window_stride
+        )
+    else:
+        item_window_stride = _positive_int_or_default(
+            "item_window_stride", item_window_stride, window_stride
         )
     scope = os.getenv("LAYOUTLM_SCOPE", "full")
 
@@ -667,7 +706,7 @@ def load_datasets(
             )
             if not words_in_receipt:
                 continue
-        elif item_window_augmentation:
+        elif scope == "full" and item_window_augmentation:
             # First-pass augmentation: keep full-receipt examples for the real
             # inference distribution, but prepare extra item-band examples that
             # will be appended to TRAIN only after the receipt split. This gives
@@ -825,11 +864,11 @@ def load_datasets(
     )
 
     ds_mod = importlib.import_module("datasets")
-    Dataset = getattr(ds_mod, "Dataset")
-    DatasetDict = getattr(ds_mod, "DatasetDict")
-    Features = getattr(ds_mod, "Features")
-    Sequence = getattr(ds_mod, "Sequence")
-    Value = getattr(ds_mod, "Value")
+    Dataset = ds_mod.Dataset
+    DatasetDict = ds_mod.DatasetDict
+    Features = ds_mod.Features
+    Sequence = ds_mod.Sequence
+    Value = ds_mod.Value
 
     features = Features(
         {

--- a/receipt_layoutlm/receipt_layoutlm/diagnose.py
+++ b/receipt_layoutlm/receipt_layoutlm/diagnose.py
@@ -45,6 +45,32 @@ PRODUCT_DETAIL_LABELS = (
     "LINE_TOTAL",
 )
 ROBUST_GROUP_MIN_RECEIPTS = 3
+PRODUCT_FP_ADJUSTMENT_TERMS = {
+    "BAG",
+    "BOTTLE",
+    "COUPON",
+    "CRV",
+    "DEPOSIT",
+    "DISC",
+    "DISCOUNT",
+    "FEE",
+    "REFUND",
+    "RETURN",
+    "TAX",
+}
+PRODUCT_FP_META_TERMS = {
+    "AMOUNT",
+    "BALANCE",
+    "CARD",
+    "CHANGE",
+    "CREDIT",
+    "DEBIT",
+    "ITEM",
+    "PAYMENT",
+    "QTY",
+    "SUBTOTAL",
+    "TOTAL",
+}
 
 
 def diagnose_run(
@@ -706,6 +732,116 @@ def _template_distance(a: Dict[str, Any], b: Dict[str, Any]) -> float:
     return dist
 
 
+def _product_false_positive_review(
+    *,
+    gold: str,
+    guessed: str,
+    text: Optional[str],
+    error_kind: str,
+) -> Dict[str, Optional[str]]:
+    """Classify product-detail false positives without changing strict eval."""
+    if (
+        error_kind != "false_positive"
+        or gold != "O"
+        or guessed not in PRODUCT_DETAIL_LABELS
+    ):
+        return {
+            "bucket": None,
+            "contract_action": None,
+            "reason": None,
+        }
+
+    raw_text = (text or "").strip()
+    normalized = _normalize_token_for_review(raw_text)
+    if normalized in PRODUCT_FP_ADJUSTMENT_TERMS:
+        return {
+            "bucket": "adjustment_or_fee_term",
+            "contract_action": "confirm_adjustment_not_product",
+            "reason": "token is a refund, discount, fee, tax, or deposit term",
+        }
+    if normalized in PRODUCT_FP_META_TERMS:
+        return {
+            "bucket": "receipt_meta_term",
+            "contract_action": "keep_outside_product_contract",
+            "reason": "token names receipt metadata rather than an item",
+        }
+
+    if guessed == "PRODUCT_NAME":
+        if _looks_like_amount_or_quantity(raw_text):
+            return {
+                "bucket": "product_name_numeric_or_code",
+                "contract_action": "audit_sku_or_amount_boundary",
+                "reason": "numeric/alphanumeric token predicted as product name",
+            }
+        if _looks_like_product_text(raw_text):
+            return {
+                "bucket": "likely_unlabeled_product_text",
+                "contract_action": "audit_gold_or_add_coverage",
+                "reason": "alphabetic token looks like item text under strict gold O",
+            }
+        return {
+            "bucket": "other_product_name_fp",
+            "contract_action": "inspect_model_error",
+            "reason": "product-name false positive needs manual inspection",
+        }
+
+    if guessed == "QUANTITY":
+        return {
+            "bucket": (
+                "numeric_quantity_overprediction"
+                if _looks_like_amount_or_quantity(raw_text)
+                else "other_quantity_fp"
+            ),
+            "contract_action": "review_quantity_column_contract",
+            "reason": "quantity prediction on a strict gold O token",
+        }
+
+    if guessed in {"UNIT_PRICE", "LINE_TOTAL"}:
+        return {
+            "bucket": (
+                "numeric_amount_overprediction"
+                if _looks_like_amount_or_quantity(raw_text)
+                else "other_amount_fp"
+            ),
+            "contract_action": "review_amount_column_contract",
+            "reason": f"{guessed.lower()} prediction on a strict gold O token",
+        }
+
+    return {
+        "bucket": "other_product_detail_fp",
+        "contract_action": "inspect_model_error",
+        "reason": "product-detail false positive needs manual inspection",
+    }
+
+
+def _normalize_token_for_review(text: str) -> str:
+    return re.sub(r"[^A-Z0-9]+", "", text.upper())
+
+
+def _looks_like_amount_or_quantity(text: str) -> bool:
+    stripped = text.strip().replace(",", "")
+    if not stripped:
+        return False
+    if re.fullmatch(r"\$?-?\d+(?:\.\d{1,2})?(?:/[0-9]+)?[A-Z]?", stripped):
+        return True
+    if re.fullmatch(r"\d+\s*@\s*\$?\d+(?:\.\d{1,2})?", stripped):
+        return True
+    return bool(
+        re.search(r"\d", stripped)
+        and not re.search(r"[A-Z]{3,}", stripped.upper())
+    )
+
+
+def _looks_like_product_text(text: str) -> bool:
+    normalized = _normalize_token_for_review(text)
+    if len(normalized) < 3:
+        return False
+    if normalized in PRODUCT_FP_ADJUSTMENT_TERMS or normalized in PRODUCT_FP_META_TERMS:
+        return False
+    alpha_chars = sum(1 for ch in normalized if ch.isalpha())
+    return alpha_chars >= 3
+
+
 def _token_error_rows(
     record: Dict[str, Any],
     *,
@@ -715,6 +851,9 @@ def _token_error_rows(
     errors: List[Dict[str, Any]] = []
     counts: Counter[str] = Counter()
     product_counts: Counter[str] = Counter()
+    product_fp_review_counts: Counter[str] = Counter()
+    high_conf_product_fp_review_counts: Counter[str] = Counter()
+    high_conf_product_fp_action_counts: Counter[str] = Counter()
     confidence_sum = 0.0
     incorrect_count = 0
     high_conf_incorrect_count = 0
@@ -738,6 +877,12 @@ def _token_error_rows(
             continue
 
         kind = _error_kind(gold, guessed, base_correct)
+        product_fp_review = _product_false_positive_review(
+            gold=gold,
+            guessed=guessed,
+            text=pred.get("text"),
+            error_kind=kind,
+        )
         counts[kind] += 1
         incorrect_count += 1
         confidence_sum += confidence
@@ -746,12 +891,22 @@ def _token_error_rows(
         product_related = gold in PRODUCT_DETAIL_LABELS or guessed in PRODUCT_DETAIL_LABELS
         if product_related:
             product_counts[kind] += 1
+        if product_fp_review["bucket"]:
+            product_fp_review_counts[str(product_fp_review["bucket"])] += 1
         if (
             gold == "O"
             and guessed in PRODUCT_DETAIL_LABELS
             and confidence >= confidence_threshold
         ):
             high_conf_product_fp += 1
+            if product_fp_review["bucket"]:
+                high_conf_product_fp_review_counts[
+                    str(product_fp_review["bucket"])
+                ] += 1
+            if product_fp_review["contract_action"]:
+                high_conf_product_fp_action_counts[
+                    str(product_fp_review["contract_action"])
+                ] += 1
 
         top_probs = sorted(
             (
@@ -784,6 +939,11 @@ def _token_error_rows(
                 "error_kind": kind,
                 "product_related": product_related,
                 "high_confidence": confidence >= confidence_threshold,
+                "product_fp_review_bucket": product_fp_review["bucket"],
+                "product_fp_contract_action": product_fp_review[
+                    "contract_action"
+                ],
+                "product_fp_review_reason": product_fp_review["reason"],
                 "top_probabilities": top_probs,
             }
         )
@@ -797,6 +957,15 @@ def _token_error_rows(
         "high_confidence_product_false_positives": high_conf_product_fp,
         "error_kind_counts": dict(counts),
         "product_error_kind_counts": dict(product_counts),
+        "product_false_positive_review_bucket_counts": dict(
+            product_fp_review_counts
+        ),
+        "high_confidence_product_false_positive_review_bucket_counts": dict(
+            high_conf_product_fp_review_counts
+        ),
+        "high_confidence_product_false_positive_contract_action_counts": dict(
+            high_conf_product_fp_action_counts
+        ),
     }
 
 
@@ -969,7 +1138,25 @@ def _build_evidence_summary(
                 "ground_truth_label_base",
             ),
             "top_high_confidence_false_positive_examples": high_conf_fp[:25],
+            "product_false_positive_review": {
+                "bucket_counts": _top_field_counts(
+                    high_conf_product_fp, "product_fp_review_bucket"
+                ),
+                "contract_action_counts": _top_field_counts(
+                    high_conf_product_fp, "product_fp_contract_action"
+                ),
+                "top_merchants": _top_field_counts(
+                    high_conf_product_fp, "merchant_name"
+                ),
+                "top_line_item_shapes": _top_field_counts(
+                    high_conf_product_fp, "line_item_shape"
+                ),
+                "examples_by_bucket": _examples_by_bucket(
+                    high_conf_product_fp, "product_fp_review_bucket"
+                ),
+            },
         },
+        "data_targeting": _build_data_targeting(rows, token_errors),
         "model_weakness": {
             "product_error_tokens": len(product_errors),
             "low_confidence_product_error_tokens": len(low_conf_product_errors),
@@ -1049,6 +1236,178 @@ def _top_label_counts(
     ]
 
 
+def _top_field_counts(
+    rows: Iterable[Dict[str, Any]], field: str, limit: int = 20
+) -> List[Dict[str, Any]]:
+    counts = Counter(
+        str(row.get(field) or "UNKNOWN")
+        for row in rows
+        if row.get(field) is not None
+    )
+    return [
+        {"value": value, "count": count}
+        for value, count in counts.most_common(limit)
+    ]
+
+
+def _examples_by_bucket(
+    rows: Iterable[Dict[str, Any]], field: str, *, limit_per_bucket: int = 5
+) -> Dict[str, List[Dict[str, Any]]]:
+    out: Dict[str, List[Dict[str, Any]]] = defaultdict(list)
+    for row in rows:
+        bucket = row.get(field)
+        if not bucket or len(out[str(bucket)]) >= limit_per_bucket:
+            continue
+        out[str(bucket)].append(
+            {
+                "receipt_key": row.get("receipt_key"),
+                "merchant_name": row.get("merchant_name"),
+                "line_item_shape": row.get("line_item_shape"),
+                "text": row.get("text"),
+                "predicted_label_base": row.get("predicted_label_base"),
+                "confidence": row.get("confidence"),
+                "contract_action": row.get("product_fp_contract_action"),
+                "reason": row.get("product_fp_review_reason"),
+            }
+        )
+    return dict(out)
+
+
+def _build_data_targeting(
+    rows: List[Dict[str, Any]], token_errors: List[Dict[str, Any]]
+) -> Dict[str, Any]:
+    high_conf_product_fp = [
+        e
+        for e in token_errors
+        if e.get("error_kind") == "false_positive"
+        and e.get("high_confidence")
+        and e.get("predicted_label_base") in PRODUCT_DETAIL_LABELS
+    ]
+    fp_by_receipt = Counter(str(e.get("receipt_key")) for e in high_conf_product_fp)
+    fp_by_merchant_shape = Counter(
+        (str(e.get("merchant_name")), str(e.get("line_item_shape")))
+        for e in high_conf_product_fp
+    )
+
+    merchant_shape_groups: Dict[Tuple[str, str], List[Dict[str, Any]]] = defaultdict(list)
+    for row in rows:
+        merchant_shape_groups[
+            (str(row.get("merchant_name")), str(row.get("line_item_shape")))
+        ].append(row)
+
+    priority_templates: List[Dict[str, Any]] = []
+    for (merchant, shape), group in merchant_shape_groups.items():
+        total_fp = int(fp_by_merchant_shape.get((merchant, shape), 0))
+        avg_product_f1 = _avg(r.get("product_detail_macro_f1") for r in group)
+        if total_fp == 0 and (
+            avg_product_f1 is None or avg_product_f1 >= 0.35
+        ):
+            continue
+        priority_templates.append(
+            {
+                "merchant_name": merchant,
+                "line_item_shape": shape,
+                "receipt_count": len(group),
+                "avg_product_detail_macro_f1": avg_product_f1,
+                "total_high_confidence_product_false_positives": total_fp,
+                "no_line_total_receipts": sum(
+                    1 for r in group if not r.get("has_line_total_column")
+                ),
+                "long_item_table_receipts": sum(
+                    1 for r in group if _is_long_item_table(r)
+                ),
+                "example_receipts": [
+                    r.get("receipt_key")
+                    for r in sorted(
+                        group,
+                        key=lambda row: int(
+                            fp_by_receipt.get(str(row.get("receipt_key")), 0)
+                        ),
+                        reverse=True,
+                    )[:3]
+                ],
+            }
+        )
+
+    priority_templates.sort(
+        key=lambda item: (
+            -int(item["total_high_confidence_product_false_positives"]),
+            item["avg_product_detail_macro_f1"]
+            if item["avg_product_detail_macro_f1"] is not None
+            else 1.0,
+            -int(item["receipt_count"]),
+        )
+    )
+
+    no_line_total_rows = [
+        row for row in rows if not row.get("has_line_total_column")
+    ]
+    long_item_rows = [row for row in rows if _is_long_item_table(row)]
+    likely_unlabeled_fp = [
+        e
+        for e in high_conf_product_fp
+        if e.get("product_fp_review_bucket") == "likely_unlabeled_product_text"
+    ]
+
+    return {
+        "priority_merchant_templates": priority_templates[:15],
+        "structural_gaps": {
+            "no_line_total_layouts": _summarize_target_rows(
+                no_line_total_rows, fp_by_receipt
+            ),
+            "long_item_tables": _summarize_target_rows(
+                long_item_rows, fp_by_receipt
+            ),
+        },
+        "label_contract_queue": {
+            "likely_unlabeled_product_text_tokens": len(likely_unlabeled_fp),
+            "top_merchants": _top_field_counts(likely_unlabeled_fp, "merchant_name"),
+            "top_examples": likely_unlabeled_fp[:25],
+        },
+        "synthesis_guidance": [
+            {
+                "target": "merchant_template_variants",
+                "source": "real uploads or synthetic structural analogs",
+                "constraint": (
+                    "do not synthesize held-out merchant names/templates when "
+                    "using the current adversarial split"
+                ),
+            },
+            {
+                "target": "long_item_tables",
+                "source": "synthetic item tables plus real receipts with 20+ rows",
+                "constraint": "vary product text length, SKU/code prefixes, and discounts",
+            },
+            {
+                "target": "no_line_total_layouts",
+                "source": "real receipts first, synthetic analogs second",
+                "constraint": "include receipts where item rows omit explicit line totals",
+            },
+        ],
+    }
+
+
+def _summarize_target_rows(
+    rows: List[Dict[str, Any]], fp_by_receipt: Counter[str]
+) -> Dict[str, Any]:
+    return {
+        "receipt_count": len(rows),
+        "avg_product_detail_macro_f1": _avg(
+            row.get("product_detail_macro_f1") for row in rows
+        ),
+        "total_high_confidence_product_false_positives": sum(
+            int(fp_by_receipt.get(str(row.get("receipt_key")), 0))
+            for row in rows
+        ),
+        "top_merchants": _top_field_counts(rows, "merchant_name", limit=10),
+    }
+
+
+def _is_long_item_table(row: Dict[str, Any]) -> bool:
+    count = int(row.get("product_name_line_count") or 0)
+    return count >= 20
+
+
 def _write_outputs(
     *,
     output_dir: str,
@@ -1102,6 +1461,8 @@ def _write_receipt_csv(path: str, rows: List[Dict[str, Any]]) -> None:
         "nearest_template_distance_bucket",
         "incorrect_token_count",
         "high_confidence_product_false_positives",
+        "high_confidence_product_false_positive_review_bucket_counts",
+        "high_confidence_product_false_positive_contract_action_counts",
     ]
     with open(path, "w", encoding="utf-8", newline="") as f:
         writer = csv.DictWriter(f, fieldnames=fields)
@@ -1202,6 +1563,10 @@ def _markdown_report(payload: Dict[str, Any], groups: Dict[str, Any]) -> str:
             f"`{evidence['label_eval_mismatch']['error_kind_counts']}`",
             "- product token error kinds: "
             f"`{evidence['label_eval_mismatch']['product_error_kind_counts']}`",
+            "- product FP review buckets: "
+            f"`{evidence['label_eval_mismatch']['product_false_positive_review']['bucket_counts']}`",
+            "- product FP contract actions: "
+            f"`{evidence['label_eval_mismatch']['product_false_positive_review']['contract_action_counts']}`",
             "",
             "Top product confusions:",
             "",
@@ -1211,6 +1576,33 @@ def _markdown_report(payload: Dict[str, Any], groups: Dict[str, Any]) -> str:
         lines.append(
             f"- `{item['gold']}` -> `{item['predicted']}`: {item['count']}"
         )
+    lines.extend(["", "### Data Targets", ""])
+    for item in evidence["data_targeting"]["priority_merchant_templates"][:8]:
+        lines.append(
+            f"- `{item['merchant_name']}` / `{item['line_item_shape']}`: "
+            f"n={item['receipt_count']}, "
+            f"product F1={_fmt(item['avg_product_detail_macro_f1'])}, "
+            "high-confidence product FP="
+            f"{item['total_high_confidence_product_false_positives']}"
+        )
+    structural = evidence["data_targeting"]["structural_gaps"]
+    no_total = structural["no_line_total_layouts"]
+    long_tables = structural["long_item_tables"]
+    lines.extend(
+        [
+            "",
+            "- no-line-total layouts: "
+            f"n={no_total['receipt_count']}, "
+            f"product F1={_fmt(no_total['avg_product_detail_macro_f1'])}, "
+            "high-confidence product FP="
+            f"{no_total['total_high_confidence_product_false_positives']}",
+            "- long item tables: "
+            f"n={long_tables['receipt_count']}, "
+            f"product F1={_fmt(long_tables['avg_product_detail_macro_f1'])}, "
+            "high-confidence product FP="
+            f"{long_tables['total_high_confidence_product_false_positives']}",
+        ]
+    )
     lines.extend(
         [
             "",

--- a/receipt_layoutlm/receipt_layoutlm/diagnose.py
+++ b/receipt_layoutlm/receipt_layoutlm/diagnose.py
@@ -13,6 +13,7 @@ import json
 import logging
 import math
 import os
+import random
 import re
 import shutil
 from collections import Counter, defaultdict
@@ -440,7 +441,8 @@ def _build_train_context(
         )
         source = "current_VALID_corpus_minus_full_validation_split"
     if max_receipts is not None:
-        train_keys = train_keys[:max_receipts]
+        sample_size = max(0, min(max_receipts, len(train_keys)))
+        train_keys = sorted(random.Random(0).sample(train_keys, sample_size))
 
     features: List[Dict[str, Any]] = []
     merchant_counts: Counter[str] = Counter()

--- a/receipt_layoutlm/receipt_layoutlm/diagnose.py
+++ b/receipt_layoutlm/receipt_layoutlm/diagnose.py
@@ -60,16 +60,41 @@ PRODUCT_FP_ADJUSTMENT_TERMS = {
 }
 PRODUCT_FP_META_TERMS = {
     "AMOUNT",
+    "APPROVAL",
+    "APPROVED",
+    "AUTH",
     "BALANCE",
     "CARD",
+    "CASHIER",
     "CHANGE",
+    "CLERK",
     "CREDIT",
+    "CUSTOMER",
     "DEBIT",
+    "DISCOVER",
     "ITEM",
+    "MASTERCARD",
+    "MEMBER",
+    "MEMBERSHIP",
+    "ORDER",
     "PAYMENT",
+    "PURCHASE",
     "QTY",
+    "RECEIPT",
+    "REGISTER",
+    "SALE",
+    "SAVINGS",
+    "SERVER",
+    "STORE",
     "SUBTOTAL",
+    "TERMINAL",
+    "THANK",
+    "THANKS",
     "TOTAL",
+    "TRANSACTION",
+    "TRANS",
+    "VISA",
+    "WELCOME",
 }
 
 
@@ -767,7 +792,7 @@ def _product_false_positive_review(
         }
 
     if guessed == "PRODUCT_NAME":
-        if _looks_like_amount_or_quantity(raw_text):
+        if _looks_like_product_code_or_numeric(raw_text):
             return {
                 "bucket": "product_name_numeric_or_code",
                 "contract_action": "audit_sku_or_amount_boundary",
@@ -832,11 +857,26 @@ def _looks_like_amount_or_quantity(text: str) -> bool:
     )
 
 
+def _looks_like_product_code_or_numeric(text: str) -> bool:
+    normalized = _normalize_token_for_review(text)
+    if not normalized:
+        return False
+    if normalized.isdigit():
+        return True
+    if _looks_like_amount_or_quantity(text):
+        return True
+    has_digit = any(ch.isdigit() for ch in normalized)
+    has_alpha = any(ch.isalpha() for ch in normalized)
+    return has_digit and has_alpha
+
+
 def _looks_like_product_text(text: str) -> bool:
     normalized = _normalize_token_for_review(text)
     if len(normalized) < 3:
         return False
     if normalized in PRODUCT_FP_ADJUSTMENT_TERMS or normalized in PRODUCT_FP_META_TERMS:
+        return False
+    if any(ch.isdigit() for ch in normalized):
         return False
     alpha_chars = sum(1 for ch in normalized if ch.isalpha())
     return alpha_chars >= 3
@@ -1284,20 +1324,18 @@ def _build_data_targeting(
         and e.get("predicted_label_base") in PRODUCT_DETAIL_LABELS
     ]
     fp_by_receipt = Counter(str(e.get("receipt_key")) for e in high_conf_product_fp)
-    fp_by_merchant_shape = Counter(
-        (str(e.get("merchant_name")), str(e.get("line_item_shape")))
+    fp_by_template = Counter(
+        _data_target_key(e)
         for e in high_conf_product_fp
     )
 
-    merchant_shape_groups: Dict[Tuple[str, str], List[Dict[str, Any]]] = defaultdict(list)
+    template_groups: Dict[Tuple[str, str, str], List[Dict[str, Any]]] = defaultdict(list)
     for row in rows:
-        merchant_shape_groups[
-            (str(row.get("merchant_name")), str(row.get("line_item_shape")))
-        ].append(row)
+        template_groups[_data_target_key(row)].append(row)
 
     priority_templates: List[Dict[str, Any]] = []
-    for (merchant, shape), group in merchant_shape_groups.items():
-        total_fp = int(fp_by_merchant_shape.get((merchant, shape), 0))
+    for (merchant, template_signature, shape), group in template_groups.items():
+        total_fp = int(fp_by_template.get((merchant, template_signature, shape), 0))
         avg_product_f1 = _avg(r.get("product_detail_macro_f1") for r in group)
         if total_fp == 0 and (
             avg_product_f1 is None or avg_product_f1 >= 0.35
@@ -1306,6 +1344,7 @@ def _build_data_targeting(
         priority_templates.append(
             {
                 "merchant_name": merchant,
+                "template_signature": template_signature,
                 "line_item_shape": shape,
                 "receipt_count": len(group),
                 "avg_product_detail_macro_f1": avg_product_f1,
@@ -1331,10 +1370,10 @@ def _build_data_targeting(
 
     priority_templates.sort(
         key=lambda item: (
-            -int(item["total_high_confidence_product_false_positives"]),
             item["avg_product_detail_macro_f1"]
             if item["avg_product_detail_macro_f1"] is not None
             else 1.0,
+            -int(item["total_high_confidence_product_false_positives"]),
             -int(item["receipt_count"]),
         )
     )
@@ -1385,6 +1424,14 @@ def _build_data_targeting(
             },
         ],
     }
+
+
+def _data_target_key(row: Dict[str, Any]) -> Tuple[str, str, str]:
+    return (
+        str(row.get("merchant_name") or "UNKNOWN_MERCHANT"),
+        str(row.get("template_signature") or "UNKNOWN_TEMPLATE"),
+        str(row.get("line_item_shape") or "UNKNOWN_SHAPE"),
+    )
 
 
 def _summarize_target_rows(
@@ -1544,12 +1591,18 @@ def _markdown_report(payload: Dict[str, Any], groups: Dict[str, Any]) -> str:
                 f"- `{group['group']}`: n={group['receipt_count']}, "
                 f"product F1={_fmt(group['avg_product_detail_macro_f1'])}"
             )
-    lines.extend(["", "Worst one-off line-item shapes:"])
-    for group in evidence["line_item_structure"]["worst_line_item_shapes"][:5]:
-        lines.append(
-            f"- `{group['group']}`: n={group['receipt_count']}, "
-            f"product F1={_fmt(group['avg_product_detail_macro_f1'])}"
-        )
+    one_off_shapes = [
+        group
+        for group in evidence["line_item_structure"]["worst_line_item_shapes"]
+        if group["receipt_count"] < ROBUST_GROUP_MIN_RECEIPTS
+    ]
+    if one_off_shapes:
+        lines.extend(["", "Worst one-off line-item shapes:"])
+        for group in one_off_shapes[:5]:
+            lines.append(
+                f"- `{group['group']}`: n={group['receipt_count']}, "
+                f"product F1={_fmt(group['avg_product_detail_macro_f1'])}"
+            )
     lines.extend(
         [
             "",
@@ -1579,7 +1632,7 @@ def _markdown_report(payload: Dict[str, Any], groups: Dict[str, Any]) -> str:
     lines.extend(["", "### Data Targets", ""])
     for item in evidence["data_targeting"]["priority_merchant_templates"][:8]:
         lines.append(
-            f"- `{item['merchant_name']}` / `{item['line_item_shape']}`: "
+            f"- `{item['merchant_name']}` / `{item['template_signature']}`: "
             f"n={item['receipt_count']}, "
             f"product F1={_fmt(item['avg_product_detail_macro_f1'])}, "
             "high-confidence product FP="

--- a/receipt_layoutlm/receipt_layoutlm/diagnose.py
+++ b/receipt_layoutlm/receipt_layoutlm/diagnose.py
@@ -98,15 +98,16 @@ def diagnose_run(
     os.environ["LAYOUTLM_WINDOW_SIZE"] = str(resolved_ws)
     os.environ["LAYOUTLM_WINDOW_STRIDE"] = str(resolved_stride)
 
-    val_receipts, val_hash, hash_verified, val_source, seed = _resolve_val_receipts(
+    all_val_receipts, val_hash, hash_verified, val_source, seed = _resolve_val_receipts(
         dynamo=dynamo,
         split_meta=split_meta,
         recorded_hash=recorded_hash,
         recorded_seed=recorded_seed,
         allow_hash_mismatch=allow_hash_mismatch,
     )
+    val_receipts = all_val_receipts
     if max_receipts is not None:
-        val_receipts = val_receipts[:max_receipts]
+        val_receipts = all_val_receipts[:max_receipts]
 
     logger.info("Loading %d validation receipts", len(val_receipts))
     details_by_receipt = _load_receipt_details(dynamo, val_receipts)
@@ -131,7 +132,8 @@ def diagnose_run(
     if include_train_context:
         train_context = _build_train_context(
             dynamo,
-            val_receipts,
+            all_val_receipts,
+            split_meta=split_meta,
             valid_status=valid_status,
             max_receipts=max_train_context_receipts,
         )
@@ -160,11 +162,11 @@ def diagnose_run(
         "place": _summarize_groups(rows, "place_id"),
         "template": _summarize_groups(rows, "template_signature"),
         "line_item_shape": _summarize_groups(rows, "line_item_shape"),
-        "merchant_seen_in_training": _summarize_groups(
-            rows, "merchant_seen_in_training"
+        "merchant_seen_in_context": _summarize_groups(
+            rows, "merchant_seen_in_context"
         ),
-        "template_seen_in_training": _summarize_groups(
-            rows, "template_seen_in_training"
+        "template_seen_in_context": _summarize_groups(
+            rows, "template_seen_in_context"
         ),
         "nearest_template_distance_bucket": _summarize_groups(
             rows, "nearest_template_distance_bucket"
@@ -179,6 +181,7 @@ def diagnose_run(
         "generated_at": datetime.now(timezone.utc).isoformat(),
         "validation": {
             "source": val_source,
+            "num_receipts_in_split": len(all_val_receipts),
             "num_receipts_requested": len(val_receipts),
             "num_receipts_loaded": len(details_by_receipt),
             "hash": val_hash,
@@ -196,9 +199,10 @@ def diagnose_run(
             "diagnostics": aggregate_diagnostics,
             "token_accuracy": _token_accuracy(aggregate_true, aggregate_pred),
         },
-        "train_context": {
+        "coverage_context": {
             "enabled": include_train_context,
-            "num_train_receipts_loaded": len(train_context.get("features", [])),
+            "num_context_receipts_loaded": len(train_context.get("features", [])),
+            "is_training_snapshot": bool(train_context.get("is_training_snapshot")),
             "source": train_context.get("source"),
         },
         "evidence": evidence,
@@ -265,6 +269,11 @@ def _resolve_val_receipts(
         val_receipts = [_parse_receipt_key(k) for k in persisted_keys]
         computed_hash = _hash_receipt_keys(list(persisted_keys))
         hash_verified = computed_hash == recorded_hash if recorded_hash else True
+        if recorded_hash and not hash_verified and not allow_hash_mismatch:
+            raise ValueError(
+                f"Validation hash mismatch: recorded={recorded_hash} "
+                f"computed={computed_hash}. Pass --allow-hash-mismatch to proceed."
+            )
         return (
             val_receipts,
             computed_hash,
@@ -351,22 +360,34 @@ def _build_train_context(
     dynamo: Any,
     val_receipts: List[Tuple[str, int]],
     *,
+    split_meta: Dict[str, Any],
     valid_status: Any,
     max_receipts: Optional[int] = None,
 ) -> Dict[str, Any]:
     from receipt_dynamo.constants import ValidationStatus
 
     val_keys = {f"{image_id}#{receipt_id:05d}" for image_id, receipt_id in val_receipts}
-    labels, _ = dynamo.list_receipt_word_labels_with_status(
-        ValidationStatus.VALID, limit=None, last_evaluated_key=None
-    )
-    train_keys = sorted(
-        {
-            (label.image_id, label.receipt_id)
-            for label in labels
-            if f"{label.image_id}#{label.receipt_id:05d}" not in val_keys
-        }
-    )
+    persisted_train_keys = split_meta.get("train_receipt_keys")
+    is_training_snapshot = bool(persisted_train_keys)
+    if persisted_train_keys:
+        train_keys = sorted(
+            key
+            for key in (_parse_receipt_key(k) for k in persisted_train_keys)
+            if f"{key[0]}#{key[1]:05d}" not in val_keys
+        )
+        source = "persisted_train_receipt_keys"
+    else:
+        labels, _ = dynamo.list_receipt_word_labels_with_status(
+            ValidationStatus.VALID, limit=None, last_evaluated_key=None
+        )
+        train_keys = sorted(
+            {
+                (label.image_id, label.receipt_id)
+                for label in labels
+                if f"{label.image_id}#{label.receipt_id:05d}" not in val_keys
+            }
+        )
+        source = "current_VALID_corpus_minus_full_validation_split"
     if max_receipts is not None:
         train_keys = train_keys[:max_receipts]
 
@@ -377,7 +398,7 @@ def _build_train_context(
         try:
             details = dynamo.get_receipt_details(image_id, receipt_id)
         except Exception as e:  # noqa: BLE001
-            logger.debug("Could not load train context %s#%05d: %s", image_id, receipt_id, e)
+            logger.debug("Could not load coverage context %s#%05d: %s", image_id, receipt_id, e)
             continue
         f = _receipt_features(details, valid_status=valid_status)
         features.append(f)
@@ -385,7 +406,8 @@ def _build_train_context(
         template_counts[f["template_signature"]] += 1
 
     return {
-        "source": "current_VALID_labels_minus_validation_receipts",
+        "source": source,
+        "is_training_snapshot": is_training_snapshot,
         "features": features,
         "merchant_counts": dict(merchant_counts),
         "template_counts": dict(template_counts),
@@ -407,6 +429,7 @@ def _diagnose_receipts(
     train_features = train_context.get("features") or []
     merchant_counts = train_context.get("merchant_counts") or {}
     template_counts = train_context.get("template_counts") or {}
+    is_training_snapshot = bool(train_context.get("is_training_snapshot"))
 
     for (image_id, receipt_id), details in details_by_receipt.items():
         record, y_true, y_pred = build_receipt_record(
@@ -427,8 +450,8 @@ def _diagnose_receipts(
         )
         nearest = _nearest_train_template(features, train_features)
 
-        merchant_train_count = int(merchant_counts.get(features["merchant_name"], 0))
-        template_train_count = int(template_counts.get(features["template_signature"], 0))
+        merchant_context_count = int(merchant_counts.get(features["merchant_name"], 0))
+        template_context_count = int(template_counts.get(features["template_signature"], 0))
         row = {
             **features,
             "heldout_f1": scores["f1"],
@@ -451,12 +474,32 @@ def _diagnose_receipts(
                 "predicted_entity_token_rate"
             ],
             "gold_entity_rate": diagnostics["rates"]["gold_entity_token_rate"],
-            "merchant_train_receipts": merchant_train_count,
-            "template_train_receipts": template_train_count,
-            "merchant_seen_in_training": merchant_train_count > 0,
-            "template_seen_in_training": template_train_count > 0,
-            "nearest_train_receipt_key": nearest.get("receipt_key"),
-            "nearest_train_merchant": nearest.get("merchant_name"),
+            "context_source": train_context.get("source"),
+            "context_is_training_snapshot": is_training_snapshot,
+            "merchant_context_receipts": merchant_context_count,
+            "template_context_receipts": template_context_count,
+            "merchant_seen_in_context": merchant_context_count > 0,
+            "template_seen_in_context": template_context_count > 0,
+            "merchant_train_receipts": (
+                merchant_context_count if is_training_snapshot else None
+            ),
+            "template_train_receipts": (
+                template_context_count if is_training_snapshot else None
+            ),
+            "merchant_seen_in_training": (
+                merchant_context_count > 0 if is_training_snapshot else None
+            ),
+            "template_seen_in_training": (
+                template_context_count > 0 if is_training_snapshot else None
+            ),
+            "nearest_context_receipt_key": nearest.get("receipt_key"),
+            "nearest_context_merchant": nearest.get("merchant_name"),
+            "nearest_train_receipt_key": (
+                nearest.get("receipt_key") if is_training_snapshot else None
+            ),
+            "nearest_train_merchant": (
+                nearest.get("merchant_name") if is_training_snapshot else None
+            ),
             "nearest_template_distance": nearest.get("distance"),
             "nearest_template_distance_bucket": _distance_bucket(
                 nearest.get("distance")
@@ -475,10 +518,12 @@ def _receipt_features(details: Any, *, valid_status: Any) -> Dict[str, Any]:
     receipt = details.receipt
     image_id = receipt.image_id
     receipt_id = receipt.receipt_id
-    merchant_name = _merchant_name(details)
     place_id = getattr(details.place, "place_id", None) if details.place else None
     labels_by_word = _valid_labels_by_word(details, valid_status)
     words_by_key = {(w.line_id, w.word_id): w for w in details.words}
+    merchant_name = _merchant_name(
+        details, labels_by_word=labels_by_word, words_by_key=words_by_key
+    )
 
     line_product_labels: Dict[int, set[str]] = defaultdict(set)
     label_centers_x: Dict[str, List[float]] = defaultdict(list)
@@ -557,12 +602,28 @@ def _valid_labels_by_word(details: Any, valid_status: Any) -> Dict[Tuple[int, in
     return out
 
 
-def _merchant_name(details: Any) -> str:
+def _merchant_name(
+    details: Any,
+    *,
+    labels_by_word: Optional[Dict[Tuple[int, int], List[str]]] = None,
+    words_by_key: Optional[Dict[Tuple[int, int], Any]] = None,
+) -> str:
     if details.place and getattr(details.place, "merchant_name", None):
         return str(details.place.merchant_name).upper()
-    for label in details.labels:
-        if _normalize_base_label(label.label) == "MERCHANT_NAME":
-            return "LABELED_MERCHANT"
+    labeled_words: List[Tuple[int, int, str]] = []
+    labels_by_word = labels_by_word or _valid_labels_by_word(details, "VALID")
+    words_by_key = words_by_key or {(w.line_id, w.word_id): w for w in details.words}
+    for key, labels in labels_by_word.items():
+        if not any(_normalize_base_label(label) == "MERCHANT_NAME" for label in labels):
+            continue
+        word = words_by_key.get(key)
+        if word is not None and getattr(word, "text", None):
+            labeled_words.append((key[0], key[1], str(word.text)))
+    if labeled_words:
+        text = " ".join(
+            text for _line_id, _word_id, text in sorted(labeled_words)
+        )
+        return text.upper()
     return "UNKNOWN_MERCHANT"
 
 
@@ -663,7 +724,14 @@ def _token_error_rows(
     for pred in predictions:
         gold = pred.get("ground_truth_label_base") or "O"
         guessed = pred.get("predicted_label_base") or "O"
-        confidence = float(pred.get("predicted_confidence") or 0.0)
+        probs = pred.get("all_class_probabilities_base") or {}
+        bio_confidence = float(pred.get("predicted_confidence") or 0.0)
+        base_probability = probs.get(guessed)
+        confidence = (
+            float(base_probability)
+            if isinstance(base_probability, (int, float))
+            else bio_confidence
+        )
         base_correct = gold == guessed
         bio_correct = bool(pred.get("is_correct"))
         if base_correct and bio_correct:
@@ -685,7 +753,6 @@ def _token_error_rows(
         ):
             high_conf_product_fp += 1
 
-        probs = pred.get("all_class_probabilities_base") or {}
         top_probs = sorted(
             (
                 {"label": label, "probability": float(prob)}
@@ -713,6 +780,7 @@ def _token_error_rows(
                     "ground_truth_label_original"
                 ),
                 "confidence": confidence,
+                "bio_confidence": bio_confidence,
                 "error_kind": kind,
                 "product_related": product_related,
                 "high_confidence": confidence >= confidence_threshold,
@@ -790,10 +858,10 @@ def _summarize_groups(rows: List[Dict[str, Any]], key: str) -> List[Dict[str, An
 def _build_evidence_summary(
     rows: List[Dict[str, Any]], token_errors: List[Dict[str, Any]]
 ) -> Dict[str, Any]:
-    seen = [r for r in rows if r.get("merchant_seen_in_training")]
-    unseen = [r for r in rows if not r.get("merchant_seen_in_training")]
-    template_seen = [r for r in rows if r.get("template_seen_in_training")]
-    template_unseen = [r for r in rows if not r.get("template_seen_in_training")]
+    seen = [r for r in rows if r.get("merchant_seen_in_context")]
+    unseen = [r for r in rows if not r.get("merchant_seen_in_context")]
+    template_seen = [r for r in rows if r.get("template_seen_in_context")]
+    template_unseen = [r for r in rows if not r.get("template_seen_in_context")]
     distances = [
         r.get("nearest_template_distance")
         for r in rows
@@ -836,6 +904,10 @@ def _build_evidence_summary(
 
     return {
         "template_coverage": {
+            "context_source": rows[0].get("context_source") if rows else None,
+            "context_is_training_snapshot": bool(
+                rows[0].get("context_is_training_snapshot")
+            ) if rows else False,
             "seen_merchant_receipts": len(seen),
             "unseen_merchant_receipts": len(unseen),
             "seen_merchant_avg_product_macro_f1": _avg(
@@ -1014,10 +1086,18 @@ def _write_receipt_csv(path: str, rows: List[Dict[str, Any]]) -> None:
         "token_accuracy",
         "product_gold_entities",
         "product_predicted_entities",
+        "context_source",
+        "context_is_training_snapshot",
+        "merchant_context_receipts",
+        "template_context_receipts",
+        "merchant_seen_in_context",
+        "template_seen_in_context",
         "merchant_train_receipts",
         "template_train_receipts",
         "merchant_seen_in_training",
         "template_seen_in_training",
+        "nearest_context_receipt_key",
+        "nearest_context_merchant",
         "nearest_template_distance",
         "nearest_template_distance_bucket",
         "incorrect_token_count",
@@ -1041,25 +1121,28 @@ def _markdown_report(payload: Dict[str, Any], groups: Dict[str, Any]) -> str:
         f"- validation receipts: `{payload['validation']['num_receipts_loaded']}`",
         f"- held-out F1: `{_fmt(aggregate.get('f1'))}`",
         f"- product-detail macro F1: `{_fmt(product.get('macro_f1'))}`",
+        f"- coverage context: `{evidence['template_coverage'].get('context_source')}`",
+        "- coverage is training snapshot: "
+        f"`{evidence['template_coverage'].get('context_is_training_snapshot')}`",
         "",
         "## Hypothesis Evidence",
         "",
         "### Template Coverage",
         "",
         _bullet_metric(
-            "Seen merchant avg product F1",
+            "Context-seen merchant avg product F1",
             evidence["template_coverage"].get("seen_merchant_avg_product_macro_f1"),
         ),
         _bullet_metric(
-            "Unseen merchant avg product F1",
+            "Context-unseen merchant avg product F1",
             evidence["template_coverage"].get("unseen_merchant_avg_product_macro_f1"),
         ),
         _bullet_metric(
-            "Seen template avg product F1",
+            "Context-seen template avg product F1",
             evidence["template_coverage"].get("seen_template_avg_product_macro_f1"),
         ),
         _bullet_metric(
-            "Unseen template avg product F1",
+            "Context-unseen template avg product F1",
             evidence["template_coverage"].get("unseen_template_avg_product_macro_f1"),
         ),
         _bullet_metric(

--- a/receipt_layoutlm/receipt_layoutlm/diagnose.py
+++ b/receipt_layoutlm/receipt_layoutlm/diagnose.py
@@ -1,0 +1,1240 @@
+"""Receipt-level diagnostics for LayoutLM runs.
+
+This module is deliberately different from the training scorecard. The training
+curve answers "which checkpoint scored best?" Diagnostics answer "why did it
+score that way?" by saving per-receipt, per-template, and token-level evidence.
+"""
+
+from __future__ import annotations
+
+import csv
+import importlib
+import json
+import logging
+import math
+import os
+import re
+import shutil
+from collections import Counter, defaultdict
+from datetime import datetime, timezone
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+from .evaluate_checkpoints import (
+    _download_checkpoint_files,
+    _evaluation_diagnostics,
+    _get_base_label,
+    _hash_receipt_keys,
+    _parse_receipt_key,
+    _parse_s3_uri,
+    _seqeval_scores,
+    _token_accuracy,
+    build_receipt_record,
+    list_checkpoints,
+    load_run_json,
+    reconstruct_val_receipts,
+)
+from .inference import LayoutLMInference
+from .data_loader import _box_from_word, _normalize_box_from_extents
+
+logger = logging.getLogger(__name__)
+
+PRODUCT_DETAIL_LABELS = (
+    "PRODUCT_NAME",
+    "QUANTITY",
+    "UNIT_PRICE",
+    "LINE_TOTAL",
+)
+ROBUST_GROUP_MIN_RECEIPTS = 3
+
+
+def diagnose_run(
+    *,
+    dynamo: Any,
+    bucket: str,
+    run_prefix: str,
+    job_name: str,
+    output_dir: str,
+    checkpoint: str = "best",
+    epoch: Optional[int] = None,
+    max_receipts: Optional[int] = None,
+    window_size: Optional[int] = None,
+    window_stride: Optional[int] = None,
+    include_train_context: bool = True,
+    max_train_context_receipts: Optional[int] = None,
+    error_confidence_threshold: float = 0.75,
+    allow_hash_mismatch: bool = False,
+    s3_client: Any = None,
+) -> Dict[str, Any]:
+    """Score one checkpoint and emit proof-oriented diagnostic artifacts."""
+    from receipt_dynamo.constants import ValidationStatus
+
+    if s3_client is None:
+        boto3 = importlib.import_module("boto3")
+        s3_client = boto3.client("s3")
+
+    if not run_prefix.endswith("/"):
+        run_prefix += "/"
+    os.makedirs(output_dir, exist_ok=True)
+
+    run_json = load_run_json(s3_client, bucket, run_prefix)
+    split_meta = (run_json.get("split_metadata") or {}) if run_json else {}
+    recorded_hash = split_meta.get("val_receipts_hash")
+    recorded_seed = split_meta.get("random_seed")
+
+    resolved_ws = (
+        window_size
+        if window_size is not None
+        else split_meta.get("window_size")
+        if split_meta.get("window_size") is not None
+        else int(os.getenv("LAYOUTLM_WINDOW_SIZE", "200"))
+    )
+    resolved_stride = (
+        window_stride
+        if window_stride is not None
+        else split_meta.get("window_stride")
+        if split_meta.get("window_stride") is not None
+        else int(os.getenv("LAYOUTLM_WINDOW_STRIDE", "150"))
+    )
+    os.environ["LAYOUTLM_WINDOW_SIZE"] = str(resolved_ws)
+    os.environ["LAYOUTLM_WINDOW_STRIDE"] = str(resolved_stride)
+
+    val_receipts, val_hash, hash_verified, val_source, seed = _resolve_val_receipts(
+        dynamo=dynamo,
+        split_meta=split_meta,
+        recorded_hash=recorded_hash,
+        recorded_seed=recorded_seed,
+        allow_hash_mismatch=allow_hash_mismatch,
+    )
+    if max_receipts is not None:
+        val_receipts = val_receipts[:max_receipts]
+
+    logger.info("Loading %d validation receipts", len(val_receipts))
+    details_by_receipt = _load_receipt_details(dynamo, val_receipts)
+    valid_status = ValidationStatus.VALID
+
+    checkpoints = list_checkpoints(s3_client, bucket, run_prefix)
+    if not checkpoints:
+        raise ValueError(f"No checkpoints found under s3://{bucket}/{run_prefix}")
+    selected = _select_checkpoint(
+        checkpoints,
+        run_json,
+        checkpoint=checkpoint,
+        epoch=epoch,
+    )
+
+    model_cache = os.path.join(output_dir, "_model", selected["name"])
+    _download_checkpoint_files(
+        s3_client, selected["s3_uri"], model_cache, run_json=run_json
+    )
+
+    train_context: Dict[str, Any] = {}
+    if include_train_context:
+        train_context = _build_train_context(
+            dynamo,
+            val_receipts,
+            valid_status=valid_status,
+            max_receipts=max_train_context_receipts,
+        )
+
+    try:
+        infer = LayoutLMInference(model_dir=model_cache)
+        rows, token_errors, aggregate_true, aggregate_pred = _diagnose_receipts(
+            infer=infer,
+            details_by_receipt=details_by_receipt,
+            valid_status=valid_status,
+            train_context=train_context,
+            error_confidence_threshold=error_confidence_threshold,
+        )
+    finally:
+        shutil.rmtree(model_cache, ignore_errors=True)
+
+    aggregate_scores = _seqeval_scores(aggregate_true, aggregate_pred)
+    aggregate_diagnostics = _evaluation_diagnostics(
+        aggregate_true,
+        aggregate_pred,
+        per_label_f1=aggregate_scores.get("per_label_f1", {}),
+    )
+
+    summaries = {
+        "merchant": _summarize_groups(rows, "merchant_name"),
+        "place": _summarize_groups(rows, "place_id"),
+        "template": _summarize_groups(rows, "template_signature"),
+        "line_item_shape": _summarize_groups(rows, "line_item_shape"),
+        "merchant_seen_in_training": _summarize_groups(
+            rows, "merchant_seen_in_training"
+        ),
+        "template_seen_in_training": _summarize_groups(
+            rows, "template_seen_in_training"
+        ),
+        "nearest_template_distance_bucket": _summarize_groups(
+            rows, "nearest_template_distance_bucket"
+        ),
+    }
+    evidence = _build_evidence_summary(rows, token_errors)
+
+    payload = {
+        "job_name": job_name,
+        "run_s3_uri": f"s3://{bucket}/{run_prefix}",
+        "checkpoint": selected,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "validation": {
+            "source": val_source,
+            "num_receipts_requested": len(val_receipts),
+            "num_receipts_loaded": len(details_by_receipt),
+            "hash": val_hash,
+            "recorded_hash": recorded_hash,
+            "hash_verified": hash_verified,
+            "seed": int(seed) if seed is not None else None,
+        },
+        "inference": {
+            "mode": os.getenv("LAYOUTLM_INFERENCE_MODE", "windowed"),
+            "window_size": resolved_ws,
+            "window_stride": resolved_stride,
+        },
+        "aggregate": {
+            "scores": aggregate_scores,
+            "diagnostics": aggregate_diagnostics,
+            "token_accuracy": _token_accuracy(aggregate_true, aggregate_pred),
+        },
+        "train_context": {
+            "enabled": include_train_context,
+            "num_train_receipts_loaded": len(train_context.get("features", [])),
+            "source": train_context.get("source"),
+        },
+        "evidence": evidence,
+        "artifacts": {
+            "summary_json": "summary.json",
+            "report_md": "report.md",
+            "per_receipt_jsonl": "per_receipt.jsonl",
+            "per_receipt_csv": "per_receipt.csv",
+            "token_errors_jsonl": "token_errors.jsonl",
+            "groups_json": "groups.json",
+        },
+    }
+
+    _write_outputs(
+        output_dir=output_dir,
+        payload=payload,
+        rows=rows,
+        token_errors=token_errors,
+        groups=summaries,
+    )
+    return payload
+
+
+def sync_diagnostics_to_s3(
+    output_dir: str, output_s3_uri: str, s3_client: Any = None
+) -> None:
+    """Upload the diagnostic artifact directory to S3."""
+    if s3_client is None:
+        boto3 = importlib.import_module("boto3")
+        s3_client = boto3.client("s3")
+    bucket, prefix = _parse_s3_uri(output_s3_uri)
+    if prefix and not prefix.endswith("/"):
+        prefix += "/"
+    for root, _dirs, files in os.walk(output_dir):
+        for fname in files:
+            if fname.startswith("."):
+                continue
+            local_path = os.path.join(root, fname)
+            rel = os.path.relpath(local_path, output_dir).replace(os.sep, "/")
+            extra = (
+                {"ContentType": "application/json"}
+                if fname.endswith((".json", ".jsonl"))
+                else {"ContentType": "text/markdown"}
+                if fname.endswith(".md")
+                else {"ContentType": "text/csv"}
+                if fname.endswith(".csv")
+                else None
+            )
+            kwargs = {"ExtraArgs": extra} if extra else {}
+            s3_client.upload_file(local_path, bucket, f"{prefix}{rel}", **kwargs)
+    logger.info("Synced diagnostics to %s", output_s3_uri)
+
+
+def _resolve_val_receipts(
+    *,
+    dynamo: Any,
+    split_meta: Dict[str, Any],
+    recorded_hash: Optional[str],
+    recorded_seed: Optional[int],
+    allow_hash_mismatch: bool,
+) -> Tuple[List[Tuple[str, int]], str, bool, str, Optional[int]]:
+    persisted_keys = split_meta.get("val_receipt_keys")
+    if persisted_keys:
+        val_receipts = [_parse_receipt_key(k) for k in persisted_keys]
+        computed_hash = _hash_receipt_keys(list(persisted_keys))
+        hash_verified = computed_hash == recorded_hash if recorded_hash else True
+        return (
+            val_receipts,
+            computed_hash,
+            hash_verified,
+            "persisted_val_receipt_keys",
+            recorded_seed,
+        )
+
+    if recorded_seed is None:
+        raise ValueError(
+            "No persisted val_receipt_keys or split random_seed in run.json"
+        )
+    val_receipts, computed_hash = reconstruct_val_receipts(
+        dynamo, int(recorded_seed)
+    )
+    hash_verified = bool(recorded_hash) and computed_hash == recorded_hash
+    if recorded_hash and not hash_verified and not allow_hash_mismatch:
+        raise ValueError(
+            f"Validation hash mismatch: recorded={recorded_hash} "
+            f"computed={computed_hash}. Pass --allow-hash-mismatch to proceed."
+        )
+    return (
+        val_receipts,
+        computed_hash,
+        hash_verified,
+        "reconstructed_from_seed",
+        recorded_seed,
+    )
+
+
+def _load_receipt_details(
+    dynamo: Any, keys: Iterable[Tuple[str, int]]
+) -> Dict[Tuple[str, int], Any]:
+    details_by_receipt: Dict[Tuple[str, int], Any] = {}
+    for image_id, receipt_id in keys:
+        try:
+            details_by_receipt[(image_id, receipt_id)] = dynamo.get_receipt_details(
+                image_id, receipt_id
+            )
+        except Exception as e:  # noqa: BLE001
+            logger.warning("Skipping %s#%05d: %s", image_id, receipt_id, e)
+    return details_by_receipt
+
+
+def _select_checkpoint(
+    checkpoints: List[Dict[str, Any]],
+    run_json: Dict[str, Any],
+    *,
+    checkpoint: str,
+    epoch: Optional[int],
+) -> Dict[str, Any]:
+    if epoch is not None:
+        step_to_epoch, _step_to_f1 = _build_step_epoch_map(run_json)
+        for ckpt in checkpoints:
+            step = ckpt.get("step")
+            if step is not None and step_to_epoch.get(step) == epoch:
+                return dict(ckpt)
+        raise ValueError(f"No checkpoint found for epoch {epoch}")
+
+    if checkpoint == "best":
+        for ckpt in checkpoints:
+            if ckpt["name"] == "best":
+                return dict(ckpt)
+        raise ValueError("No best/ checkpoint found")
+
+    wanted = checkpoint
+    if wanted.isdigit():
+        wanted = f"checkpoint-{wanted}"
+    for ckpt in checkpoints:
+        if ckpt["name"] == wanted:
+            return dict(ckpt)
+    raise ValueError(f"No checkpoint named {checkpoint!r}")
+
+
+def _build_step_epoch_map(
+    run_json: Dict[str, Any],
+) -> Tuple[Dict[int, int], Dict[int, float]]:
+    from .evaluate_checkpoints import _build_step_epoch_map as build_map
+
+    return build_map(run_json)
+
+
+def _build_train_context(
+    dynamo: Any,
+    val_receipts: List[Tuple[str, int]],
+    *,
+    valid_status: Any,
+    max_receipts: Optional[int] = None,
+) -> Dict[str, Any]:
+    from receipt_dynamo.constants import ValidationStatus
+
+    val_keys = {f"{image_id}#{receipt_id:05d}" for image_id, receipt_id in val_receipts}
+    labels, _ = dynamo.list_receipt_word_labels_with_status(
+        ValidationStatus.VALID, limit=None, last_evaluated_key=None
+    )
+    train_keys = sorted(
+        {
+            (label.image_id, label.receipt_id)
+            for label in labels
+            if f"{label.image_id}#{label.receipt_id:05d}" not in val_keys
+        }
+    )
+    if max_receipts is not None:
+        train_keys = train_keys[:max_receipts]
+
+    features: List[Dict[str, Any]] = []
+    merchant_counts: Counter[str] = Counter()
+    template_counts: Counter[str] = Counter()
+    for image_id, receipt_id in train_keys:
+        try:
+            details = dynamo.get_receipt_details(image_id, receipt_id)
+        except Exception as e:  # noqa: BLE001
+            logger.debug("Could not load train context %s#%05d: %s", image_id, receipt_id, e)
+            continue
+        f = _receipt_features(details, valid_status=valid_status)
+        features.append(f)
+        merchant_counts[f["merchant_name"]] += 1
+        template_counts[f["template_signature"]] += 1
+
+    return {
+        "source": "current_VALID_labels_minus_validation_receipts",
+        "features": features,
+        "merchant_counts": dict(merchant_counts),
+        "template_counts": dict(template_counts),
+    }
+
+
+def _diagnose_receipts(
+    *,
+    infer: LayoutLMInference,
+    details_by_receipt: Dict[Tuple[str, int], Any],
+    valid_status: Any,
+    train_context: Dict[str, Any],
+    error_confidence_threshold: float,
+) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]], List[List[str]], List[List[str]]]:
+    rows: List[Dict[str, Any]] = []
+    token_errors: List[Dict[str, Any]] = []
+    aggregate_true: List[List[str]] = []
+    aggregate_pred: List[List[str]] = []
+    train_features = train_context.get("features") or []
+    merchant_counts = train_context.get("merchant_counts") or {}
+    template_counts = train_context.get("template_counts") or {}
+
+    for (image_id, receipt_id), details in details_by_receipt.items():
+        record, y_true, y_pred = build_receipt_record(
+            infer, details, image_id, receipt_id, valid_status=valid_status
+        )
+        aggregate_true.extend(y_true)
+        aggregate_pred.extend(y_pred)
+
+        scores = _seqeval_scores(y_true, y_pred)
+        diagnostics = _evaluation_diagnostics(
+            y_true, y_pred, per_label_f1=scores.get("per_label_f1", {})
+        )
+        features = _receipt_features(details, valid_status=valid_status)
+        errors, error_summary = _token_error_rows(
+            record,
+            features=features,
+            confidence_threshold=error_confidence_threshold,
+        )
+        nearest = _nearest_train_template(features, train_features)
+
+        merchant_train_count = int(merchant_counts.get(features["merchant_name"], 0))
+        template_train_count = int(template_counts.get(features["template_signature"], 0))
+        row = {
+            **features,
+            "heldout_f1": scores["f1"],
+            "heldout_precision": scores["precision"],
+            "heldout_recall": scores["recall"],
+            "token_accuracy": _token_accuracy(y_true, y_pred),
+            "product_detail_macro_f1": diagnostics["product_detail"]["macro_f1"],
+            "product_gold_entities": diagnostics["product_detail"]["gold_entities"],
+            "product_predicted_entities": diagnostics["product_detail"][
+                "predicted_entities"
+            ],
+            "product_prediction_gold_ratio": diagnostics["product_detail"][
+                "prediction_gold_ratio"
+            ],
+            "per_label_f1": scores.get("per_label_f1", {}),
+            "per_label_precision": scores.get("per_label_precision", {}),
+            "per_label_recall": scores.get("per_label_recall", {}),
+            "per_label_support": scores.get("per_label_support", {}),
+            "entity_prediction_rate": diagnostics["rates"][
+                "predicted_entity_token_rate"
+            ],
+            "gold_entity_rate": diagnostics["rates"]["gold_entity_token_rate"],
+            "merchant_train_receipts": merchant_train_count,
+            "template_train_receipts": template_train_count,
+            "merchant_seen_in_training": merchant_train_count > 0,
+            "template_seen_in_training": template_train_count > 0,
+            "nearest_train_receipt_key": nearest.get("receipt_key"),
+            "nearest_train_merchant": nearest.get("merchant_name"),
+            "nearest_template_distance": nearest.get("distance"),
+            "nearest_template_distance_bucket": _distance_bucket(
+                nearest.get("distance")
+            ),
+            **error_summary,
+        }
+        rows.append(row)
+        for err in errors:
+            err["receipt_key"] = features["receipt_key"]
+            token_errors.append(err)
+
+    return rows, token_errors, aggregate_true, aggregate_pred
+
+
+def _receipt_features(details: Any, *, valid_status: Any) -> Dict[str, Any]:
+    receipt = details.receipt
+    image_id = receipt.image_id
+    receipt_id = receipt.receipt_id
+    merchant_name = _merchant_name(details)
+    place_id = getattr(details.place, "place_id", None) if details.place else None
+    labels_by_word = _valid_labels_by_word(details, valid_status)
+    words_by_key = {(w.line_id, w.word_id): w for w in details.words}
+
+    line_product_labels: Dict[int, set[str]] = defaultdict(set)
+    label_centers_x: Dict[str, List[float]] = defaultdict(list)
+    label_centers_y: Dict[str, List[float]] = defaultdict(list)
+    max_x, max_y = _receipt_extents(details.words)
+
+    for key, labels in labels_by_word.items():
+        word = words_by_key.get(key)
+        if word is None:
+            continue
+        x0, y0, x1, y1 = _box_from_word(word)
+        box = _normalize_box_from_extents(x0, y0, x1, y1, max_x, max_y)
+        cx = (box[0] + box[2]) / 2 / 1000.0
+        cy = (box[1] + box[3]) / 2 / 1000.0
+        for label in labels:
+            base = _normalize_base_label(label)
+            if base in PRODUCT_DETAIL_LABELS:
+                line_product_labels[word.line_id].add(base)
+                label_centers_x[base].append(cx)
+                label_centers_y[base].append(cy)
+
+    product_lines = {
+        line_id
+        for line_id, labels in line_product_labels.items()
+        if "PRODUCT_NAME" in labels or "LINE_TOTAL" in labels
+    }
+    product_name_lines = {
+        line_id
+        for line_id, labels in line_product_labels.items()
+        if "PRODUCT_NAME" in labels
+    }
+    line_total_lines = {
+        line_id
+        for line_id, labels in line_product_labels.items()
+        if "LINE_TOTAL" in labels
+    }
+    product_y = [
+        y for label in PRODUCT_DETAIL_LABELS for y in label_centers_y.get(label, [])
+    ]
+
+    features: Dict[str, Any] = {
+        "image_id": image_id,
+        "receipt_id": receipt_id,
+        "receipt_key": f"{image_id}#{receipt_id:05d}",
+        "merchant_name": merchant_name,
+        "merchant_key": _slug(merchant_name),
+        "place_id": place_id or "UNKNOWN_PLACE",
+        "num_words": len(details.words),
+        "num_lines": len(details.lines),
+        "product_line_count": len(product_lines),
+        "product_name_line_count": len(product_name_lines),
+        "line_total_line_count": len(line_total_lines),
+        "has_quantity_column": bool(label_centers_x.get("QUANTITY")),
+        "has_unit_price_column": bool(label_centers_x.get("UNIT_PRICE")),
+        "has_line_total_column": bool(label_centers_x.get("LINE_TOTAL")),
+        "has_product_name_column": bool(label_centers_x.get("PRODUCT_NAME")),
+        "product_band_y_min": min(product_y) if product_y else None,
+        "product_band_y_max": max(product_y) if product_y else None,
+    }
+    for label in PRODUCT_DETAIL_LABELS:
+        xs = label_centers_x.get(label) or []
+        features[f"{label.lower()}_x_mean"] = (
+            sum(xs) / len(xs) if xs else None
+        )
+    features["line_item_shape"] = _line_item_shape(features)
+    features["template_signature"] = _template_signature(features)
+    features["template_vector"] = _template_vector(features)
+    return features
+
+
+def _valid_labels_by_word(details: Any, valid_status: Any) -> Dict[Tuple[int, int], List[str]]:
+    out: Dict[Tuple[int, int], List[str]] = defaultdict(list)
+    for label in details.labels:
+        if _status_name(label.validation_status) == _status_name(valid_status):
+            out[(label.line_id, label.word_id)].append(label.label)
+    return out
+
+
+def _merchant_name(details: Any) -> str:
+    if details.place and getattr(details.place, "merchant_name", None):
+        return str(details.place.merchant_name).upper()
+    for label in details.labels:
+        if _normalize_base_label(label.label) == "MERCHANT_NAME":
+            return "LABELED_MERCHANT"
+    return "UNKNOWN_MERCHANT"
+
+
+def _receipt_extents(words: List[Any]) -> Tuple[float, float]:
+    max_x = max_y = 1.0
+    for word in words:
+        x0, y0, x1, y1 = _box_from_word(word)
+        del x0, y0
+        max_x = max(max_x, x1)
+        max_y = max(max_y, y1)
+    return max_x, max_y
+
+
+def _line_item_shape(features: Dict[str, Any]) -> str:
+    return "|".join(
+        [
+            f"items:{_count_bucket(features['product_name_line_count'])}",
+            f"qty:{int(bool(features['has_quantity_column']))}",
+            f"unit:{int(bool(features['has_unit_price_column']))}",
+            f"total:{int(bool(features['has_line_total_column']))}",
+            f"name_x:{_x_bucket(features.get('product_name_x_mean'))}",
+            f"unit_x:{_x_bucket(features.get('unit_price_x_mean'))}",
+            f"total_x:{_x_bucket(features.get('line_total_x_mean'))}",
+        ]
+    )
+
+
+def _template_signature(features: Dict[str, Any]) -> str:
+    return "|".join(
+        [
+            features["merchant_key"],
+            f"lines:{_count_bucket(features['num_lines'])}",
+            f"words:{_count_bucket(features['num_words'])}",
+            features["line_item_shape"],
+        ]
+    )
+
+
+def _template_vector(features: Dict[str, Any]) -> List[float]:
+    return [
+        min(float(features["num_lines"]) / 100.0, 2.0),
+        min(float(features["num_words"]) / 600.0, 2.0),
+        min(float(features["product_name_line_count"]) / 80.0, 2.0),
+        1.0 if features["has_quantity_column"] else 0.0,
+        1.0 if features["has_unit_price_column"] else 0.0,
+        1.0 if features["has_line_total_column"] else 0.0,
+        _none_to(features.get("product_name_x_mean"), 0.0),
+        _none_to(features.get("quantity_x_mean"), 0.0),
+        _none_to(features.get("unit_price_x_mean"), 0.0),
+        _none_to(features.get("line_total_x_mean"), 0.0),
+        _none_to(features.get("product_band_y_min"), 0.0),
+        _none_to(features.get("product_band_y_max"), 0.0),
+    ]
+
+
+def _nearest_train_template(
+    features: Dict[str, Any], train_features: List[Dict[str, Any]]
+) -> Dict[str, Any]:
+    if not train_features:
+        return {"distance": None, "receipt_key": None, "merchant_name": None}
+    best: Optional[Tuple[float, Dict[str, Any]]] = None
+    for candidate in train_features:
+        dist = _template_distance(features, candidate)
+        if best is None or dist < best[0]:
+            best = (dist, candidate)
+    assert best is not None
+    return {
+        "distance": round(best[0], 4),
+        "receipt_key": best[1]["receipt_key"],
+        "merchant_name": best[1]["merchant_name"],
+    }
+
+
+def _template_distance(a: Dict[str, Any], b: Dict[str, Any]) -> float:
+    av = a.get("template_vector") or _template_vector(a)
+    bv = b.get("template_vector") or _template_vector(b)
+    dist = math.sqrt(sum((float(x) - float(y)) ** 2 for x, y in zip(av, bv)))
+    if a["merchant_key"] != b["merchant_key"]:
+        dist += 0.75
+    return dist
+
+
+def _token_error_rows(
+    record: Dict[str, Any],
+    *,
+    features: Dict[str, Any],
+    confidence_threshold: float,
+) -> Tuple[List[Dict[str, Any]], Dict[str, Any]]:
+    errors: List[Dict[str, Any]] = []
+    counts: Counter[str] = Counter()
+    product_counts: Counter[str] = Counter()
+    confidence_sum = 0.0
+    incorrect_count = 0
+    high_conf_incorrect_count = 0
+    high_conf_product_fp = 0
+
+    predictions = record.get("original", {}).get("predictions", [])
+    for pred in predictions:
+        gold = pred.get("ground_truth_label_base") or "O"
+        guessed = pred.get("predicted_label_base") or "O"
+        confidence = float(pred.get("predicted_confidence") or 0.0)
+        base_correct = gold == guessed
+        bio_correct = bool(pred.get("is_correct"))
+        if base_correct and bio_correct:
+            continue
+
+        kind = _error_kind(gold, guessed, base_correct)
+        counts[kind] += 1
+        incorrect_count += 1
+        confidence_sum += confidence
+        if confidence >= confidence_threshold:
+            high_conf_incorrect_count += 1
+        product_related = gold in PRODUCT_DETAIL_LABELS or guessed in PRODUCT_DETAIL_LABELS
+        if product_related:
+            product_counts[kind] += 1
+        if (
+            gold == "O"
+            and guessed in PRODUCT_DETAIL_LABELS
+            and confidence >= confidence_threshold
+        ):
+            high_conf_product_fp += 1
+
+        probs = pred.get("all_class_probabilities_base") or {}
+        top_probs = sorted(
+            (
+                {"label": label, "probability": float(prob)}
+                for label, prob in probs.items()
+                if isinstance(prob, (int, float))
+            ),
+            key=lambda item: item["probability"],
+            reverse=True,
+        )[:5]
+        errors.append(
+            {
+                "image_id": features["image_id"],
+                "receipt_id": features["receipt_id"],
+                "merchant_name": features["merchant_name"],
+                "template_signature": features["template_signature"],
+                "line_item_shape": features["line_item_shape"],
+                "line_id": pred.get("line_id"),
+                "word_id": pred.get("word_id"),
+                "text": pred.get("text"),
+                "ground_truth_label": pred.get("ground_truth_label"),
+                "predicted_label": pred.get("predicted_label"),
+                "ground_truth_label_base": gold,
+                "predicted_label_base": guessed,
+                "ground_truth_label_original": pred.get(
+                    "ground_truth_label_original"
+                ),
+                "confidence": confidence,
+                "error_kind": kind,
+                "product_related": product_related,
+                "high_confidence": confidence >= confidence_threshold,
+                "top_probabilities": top_probs,
+            }
+        )
+
+    return errors, {
+        "incorrect_token_count": incorrect_count,
+        "incorrect_token_mean_confidence": (
+            confidence_sum / incorrect_count if incorrect_count else None
+        ),
+        "high_confidence_incorrect_tokens": high_conf_incorrect_count,
+        "high_confidence_product_false_positives": high_conf_product_fp,
+        "error_kind_counts": dict(counts),
+        "product_error_kind_counts": dict(product_counts),
+    }
+
+
+def _error_kind(gold: str, guessed: str, base_correct: bool) -> str:
+    if base_correct:
+        return "boundary_error"
+    if gold == "O" and guessed != "O":
+        return "false_positive"
+    if gold != "O" and guessed == "O":
+        return "missed_entity"
+    return "wrong_label"
+
+
+def _summarize_groups(rows: List[Dict[str, Any]], key: str) -> List[Dict[str, Any]]:
+    groups: Dict[str, List[Dict[str, Any]]] = defaultdict(list)
+    for row in rows:
+        groups[str(row.get(key))].append(row)
+
+    summaries: List[Dict[str, Any]] = []
+    for value, group in groups.items():
+        summaries.append(
+            {
+                "group": value,
+                "receipt_count": len(group),
+                "avg_product_detail_macro_f1": _avg(
+                    r.get("product_detail_macro_f1") for r in group
+                ),
+                "avg_heldout_f1": _avg(r.get("heldout_f1") for r in group),
+                "avg_token_accuracy": _avg(r.get("token_accuracy") for r in group),
+                "avg_nearest_template_distance": _avg(
+                    r.get("nearest_template_distance") for r in group
+                ),
+                "total_product_gold_entities": sum(
+                    int(r.get("product_gold_entities") or 0) for r in group
+                ),
+                "total_product_predicted_entities": sum(
+                    int(r.get("product_predicted_entities") or 0) for r in group
+                ),
+                "total_incorrect_tokens": sum(
+                    int(r.get("incorrect_token_count") or 0) for r in group
+                ),
+                "total_high_confidence_product_false_positives": sum(
+                    int(r.get("high_confidence_product_false_positives") or 0)
+                    for r in group
+                ),
+            }
+        )
+    return sorted(
+        summaries,
+        key=lambda row: (
+            row["avg_product_detail_macro_f1"]
+            if row["avg_product_detail_macro_f1"] is not None
+            else -1,
+            row["receipt_count"],
+        ),
+    )
+
+
+def _build_evidence_summary(
+    rows: List[Dict[str, Any]], token_errors: List[Dict[str, Any]]
+) -> Dict[str, Any]:
+    seen = [r for r in rows if r.get("merchant_seen_in_training")]
+    unseen = [r for r in rows if not r.get("merchant_seen_in_training")]
+    template_seen = [r for r in rows if r.get("template_seen_in_training")]
+    template_unseen = [r for r in rows if not r.get("template_seen_in_training")]
+    distances = [
+        r.get("nearest_template_distance")
+        for r in rows
+        if isinstance(r.get("nearest_template_distance"), (int, float))
+    ]
+    product_scores = [
+        r.get("product_detail_macro_f1")
+        for r in rows
+        if isinstance(r.get("product_detail_macro_f1"), (int, float))
+        and isinstance(r.get("nearest_template_distance"), (int, float))
+    ]
+    matching_distances = [
+        r.get("nearest_template_distance")
+        for r in rows
+        if isinstance(r.get("product_detail_macro_f1"), (int, float))
+        and isinstance(r.get("nearest_template_distance"), (int, float))
+    ]
+    high_conf_fp = [
+        e
+        for e in token_errors
+        if e["error_kind"] == "false_positive" and e["high_confidence"]
+    ]
+    high_conf_product_fp = [
+        e
+        for e in high_conf_fp
+        if e["predicted_label_base"] in PRODUCT_DETAIL_LABELS
+    ]
+    product_errors = [e for e in token_errors if e["product_related"]]
+    low_conf_product_errors = [
+        e for e in product_errors if float(e.get("confidence") or 0.0) < 0.45
+    ]
+
+    worst_merchants = _summarize_groups(rows, "merchant_name")[:10]
+    worst_shapes = _summarize_groups(rows, "line_item_shape")[:10]
+    robust_shapes = [
+        group
+        for group in _summarize_groups(rows, "line_item_shape")
+        if group["receipt_count"] >= ROBUST_GROUP_MIN_RECEIPTS
+    ][:10]
+
+    return {
+        "template_coverage": {
+            "seen_merchant_receipts": len(seen),
+            "unseen_merchant_receipts": len(unseen),
+            "seen_merchant_avg_product_macro_f1": _avg(
+                r.get("product_detail_macro_f1") for r in seen
+            ),
+            "unseen_merchant_avg_product_macro_f1": _avg(
+                r.get("product_detail_macro_f1") for r in unseen
+            ),
+            "seen_template_receipts": len(template_seen),
+            "unseen_template_receipts": len(template_unseen),
+            "seen_template_avg_product_macro_f1": _avg(
+                r.get("product_detail_macro_f1") for r in template_seen
+            ),
+            "unseen_template_avg_product_macro_f1": _avg(
+                r.get("product_detail_macro_f1") for r in template_unseen
+            ),
+            "nearest_template_distance_mean": _avg(distances),
+            "nearest_template_distance_vs_product_f1_correlation": _pearson(
+                matching_distances, product_scores
+            ),
+            "worst_merchants": worst_merchants,
+        },
+        "line_item_structure": {
+            "worst_line_item_shapes": worst_shapes,
+            "worst_line_item_shapes_min_receipts": ROBUST_GROUP_MIN_RECEIPTS,
+            "worst_robust_line_item_shapes": robust_shapes,
+            "product_f1_by_item_count_bucket": _summarize_rows_by_derived_key(
+                rows, lambda row: _count_bucket(int(row.get("product_name_line_count") or 0))
+            ),
+            "product_f1_by_line_total_presence": _summarize_rows_by_derived_key(
+                rows, lambda row: str(bool(row.get("has_line_total_column")))
+            ),
+            "product_f1_by_unit_price_presence": _summarize_rows_by_derived_key(
+                rows, lambda row: str(bool(row.get("has_unit_price_column")))
+            ),
+            "product_f1_by_quantity_presence": _summarize_rows_by_derived_key(
+                rows, lambda row: str(bool(row.get("has_quantity_column")))
+            ),
+            "product_f1_by_product_name_x_bucket": _summarize_rows_by_derived_key(
+                rows, lambda row: _x_bucket(row.get("product_name_x_mean"))
+            ),
+        },
+        "label_eval_mismatch": {
+            "high_confidence_false_positive_tokens": len(high_conf_fp),
+            "high_confidence_product_false_positive_tokens": len(
+                high_conf_product_fp
+            ),
+            "error_kind_counts": dict(Counter(e["error_kind"] for e in token_errors)),
+            "product_error_kind_counts": dict(
+                Counter(e["error_kind"] for e in product_errors)
+            ),
+            "top_product_confusions": _top_confusions(product_errors),
+            "top_false_positive_labels": _top_label_counts(
+                (e for e in token_errors if e["error_kind"] == "false_positive"),
+                "predicted_label_base",
+            ),
+            "top_missed_gold_labels": _top_label_counts(
+                (e for e in token_errors if e["error_kind"] == "missed_entity"),
+                "ground_truth_label_base",
+            ),
+            "top_high_confidence_false_positive_examples": high_conf_fp[:25],
+        },
+        "model_weakness": {
+            "product_error_tokens": len(product_errors),
+            "low_confidence_product_error_tokens": len(low_conf_product_errors),
+            "low_confidence_product_error_rate": _safe_ratio(
+                len(low_conf_product_errors), len(product_errors)
+            ),
+        },
+    }
+
+
+def _summarize_rows_by_derived_key(
+    rows: List[Dict[str, Any]], key_fn: Any
+) -> List[Dict[str, Any]]:
+    grouped: Dict[str, List[Dict[str, Any]]] = defaultdict(list)
+    for row in rows:
+        grouped[str(key_fn(row))].append(row)
+    return sorted(
+        (_summarize_row_group(value, group) for value, group in grouped.items()),
+        key=lambda row: (
+            row["avg_product_detail_macro_f1"]
+            if row["avg_product_detail_macro_f1"] is not None
+            else -1,
+            row["receipt_count"],
+        ),
+    )
+
+
+def _summarize_row_group(value: str, group: List[Dict[str, Any]]) -> Dict[str, Any]:
+    return {
+        "group": value,
+        "receipt_count": len(group),
+        "avg_product_detail_macro_f1": _avg(
+            r.get("product_detail_macro_f1") for r in group
+        ),
+        "avg_heldout_f1": _avg(r.get("heldout_f1") for r in group),
+        "avg_token_accuracy": _avg(r.get("token_accuracy") for r in group),
+        "avg_nearest_template_distance": _avg(
+            r.get("nearest_template_distance") for r in group
+        ),
+        "total_product_gold_entities": sum(
+            int(r.get("product_gold_entities") or 0) for r in group
+        ),
+        "total_product_predicted_entities": sum(
+            int(r.get("product_predicted_entities") or 0) for r in group
+        ),
+        "total_incorrect_tokens": sum(
+            int(r.get("incorrect_token_count") or 0) for r in group
+        ),
+        "total_high_confidence_product_false_positives": sum(
+            int(r.get("high_confidence_product_false_positives") or 0)
+            for r in group
+        ),
+    }
+
+
+def _top_confusions(errors: Iterable[Dict[str, Any]], limit: int = 20) -> List[Dict[str, Any]]:
+    counts = Counter(
+        (
+            e.get("ground_truth_label_base") or "O",
+            e.get("predicted_label_base") or "O",
+        )
+        for e in errors
+    )
+    return [
+        {"gold": gold, "predicted": predicted, "count": count}
+        for (gold, predicted), count in counts.most_common(limit)
+    ]
+
+
+def _top_label_counts(
+    errors: Iterable[Dict[str, Any]], field: str, limit: int = 20
+) -> List[Dict[str, Any]]:
+    counts = Counter(str(e.get(field) or "O") for e in errors)
+    return [
+        {"label": label, "count": count}
+        for label, count in counts.most_common(limit)
+    ]
+
+
+def _write_outputs(
+    *,
+    output_dir: str,
+    payload: Dict[str, Any],
+    rows: List[Dict[str, Any]],
+    token_errors: List[Dict[str, Any]],
+    groups: Dict[str, Any],
+) -> None:
+    with open(os.path.join(output_dir, "summary.json"), "w", encoding="utf-8") as f:
+        json.dump(payload, f, indent=2, default=str)
+    with open(os.path.join(output_dir, "groups.json"), "w", encoding="utf-8") as f:
+        json.dump(groups, f, indent=2, default=str)
+    _write_jsonl(os.path.join(output_dir, "per_receipt.jsonl"), rows)
+    _write_jsonl(os.path.join(output_dir, "token_errors.jsonl"), token_errors)
+    _write_receipt_csv(os.path.join(output_dir, "per_receipt.csv"), rows)
+    with open(os.path.join(output_dir, "report.md"), "w", encoding="utf-8") as f:
+        f.write(_markdown_report(payload, groups))
+
+
+def _write_jsonl(path: str, rows: List[Dict[str, Any]]) -> None:
+    with open(path, "w", encoding="utf-8") as f:
+        for row in rows:
+            f.write(json.dumps(row, default=str) + "\n")
+
+
+def _write_receipt_csv(path: str, rows: List[Dict[str, Any]]) -> None:
+    fields = [
+        "receipt_key",
+        "merchant_name",
+        "place_id",
+        "template_signature",
+        "line_item_shape",
+        "heldout_f1",
+        "product_detail_macro_f1",
+        "token_accuracy",
+        "product_gold_entities",
+        "product_predicted_entities",
+        "merchant_train_receipts",
+        "template_train_receipts",
+        "merchant_seen_in_training",
+        "template_seen_in_training",
+        "nearest_template_distance",
+        "nearest_template_distance_bucket",
+        "incorrect_token_count",
+        "high_confidence_product_false_positives",
+    ]
+    with open(path, "w", encoding="utf-8", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fields)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow({field: row.get(field) for field in fields})
+
+
+def _markdown_report(payload: Dict[str, Any], groups: Dict[str, Any]) -> str:
+    evidence = payload["evidence"]
+    aggregate = payload["aggregate"]["scores"]
+    product = payload["aggregate"]["diagnostics"]["product_detail"]
+    lines = [
+        f"# LayoutLM Diagnostic Report: {payload['job_name']}",
+        "",
+        f"- checkpoint: `{payload['checkpoint']['name']}`",
+        f"- validation receipts: `{payload['validation']['num_receipts_loaded']}`",
+        f"- held-out F1: `{_fmt(aggregate.get('f1'))}`",
+        f"- product-detail macro F1: `{_fmt(product.get('macro_f1'))}`",
+        "",
+        "## Hypothesis Evidence",
+        "",
+        "### Template Coverage",
+        "",
+        _bullet_metric(
+            "Seen merchant avg product F1",
+            evidence["template_coverage"].get("seen_merchant_avg_product_macro_f1"),
+        ),
+        _bullet_metric(
+            "Unseen merchant avg product F1",
+            evidence["template_coverage"].get("unseen_merchant_avg_product_macro_f1"),
+        ),
+        _bullet_metric(
+            "Seen template avg product F1",
+            evidence["template_coverage"].get("seen_template_avg_product_macro_f1"),
+        ),
+        _bullet_metric(
+            "Unseen template avg product F1",
+            evidence["template_coverage"].get("unseen_template_avg_product_macro_f1"),
+        ),
+        _bullet_metric(
+            "Nearest-template distance vs product F1 correlation",
+            evidence["template_coverage"].get(
+                "nearest_template_distance_vs_product_f1_correlation"
+            ),
+        ),
+        "",
+        "### Line-Item Structure",
+        "",
+        "Robust buckets:",
+        "",
+    ]
+    for group in evidence["line_item_structure"][
+        "product_f1_by_item_count_bucket"
+    ]:
+        lines.append(
+            f"- item rows `{group['group']}`: n={group['receipt_count']}, "
+            f"product F1={_fmt(group['avg_product_detail_macro_f1'])}, "
+            f"nearest distance={_fmt(group['avg_nearest_template_distance'])}"
+        )
+    lines.extend(["", "Line total column present:"])
+    for group in evidence["line_item_structure"][
+        "product_f1_by_line_total_presence"
+    ]:
+        lines.append(
+            f"- `{group['group']}`: n={group['receipt_count']}, "
+            f"product F1={_fmt(group['avg_product_detail_macro_f1'])}"
+        )
+    robust_shapes = evidence["line_item_structure"].get(
+        "worst_robust_line_item_shapes", []
+    )
+    if robust_shapes:
+        lines.extend(["", "Worst repeated line-item shapes:"])
+        for group in robust_shapes[:5]:
+            lines.append(
+                f"- `{group['group']}`: n={group['receipt_count']}, "
+                f"product F1={_fmt(group['avg_product_detail_macro_f1'])}"
+            )
+    lines.extend(["", "Worst one-off line-item shapes:"])
+    for group in evidence["line_item_structure"]["worst_line_item_shapes"][:5]:
+        lines.append(
+            f"- `{group['group']}`: n={group['receipt_count']}, "
+            f"product F1={_fmt(group['avg_product_detail_macro_f1'])}"
+        )
+    lines.extend(
+        [
+            "",
+            "### Label/Eval Mismatch",
+            "",
+            "- high-confidence false-positive tokens: "
+            f"`{evidence['label_eval_mismatch']['high_confidence_false_positive_tokens']}`",
+            "- high-confidence product false-positive tokens: "
+            f"`{evidence['label_eval_mismatch']['high_confidence_product_false_positive_tokens']}`",
+            "- token error kinds: "
+            f"`{evidence['label_eval_mismatch']['error_kind_counts']}`",
+            "- product token error kinds: "
+            f"`{evidence['label_eval_mismatch']['product_error_kind_counts']}`",
+            "",
+            "Top product confusions:",
+            "",
+        ]
+    )
+    for item in evidence["label_eval_mismatch"]["top_product_confusions"][:8]:
+        lines.append(
+            f"- `{item['gold']}` -> `{item['predicted']}`: {item['count']}"
+        )
+    lines.extend(
+        [
+            "",
+            "### Model Weakness",
+            "",
+            "- product error tokens: "
+            f"`{evidence['model_weakness']['product_error_tokens']}`",
+            "- low-confidence product error tokens: "
+            f"`{evidence['model_weakness']['low_confidence_product_error_tokens']}`",
+            "- low-confidence product error rate: "
+            f"`{_fmt(evidence['model_weakness']['low_confidence_product_error_rate'])}`",
+            "",
+            "## Worst Merchant Groups",
+            "",
+        ]
+    )
+    for group in groups["merchant"][:10]:
+        lines.append(
+            f"- `{group['group']}`: n={group['receipt_count']}, "
+            f"product F1={_fmt(group['avg_product_detail_macro_f1'])}, "
+            f"nearest distance={_fmt(group['avg_nearest_template_distance'])}"
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _bullet_metric(label: str, value: Any) -> str:
+    return f"- {label}: `{_fmt(value)}`"
+
+
+def _normalize_base_label(label: Optional[str]) -> str:
+    return _get_base_label(label.upper() if isinstance(label, str) else label)
+
+
+def _status_name(status: Any) -> str:
+    return getattr(status, "name", str(status)).upper()
+
+
+def _slug(value: str) -> str:
+    slug = re.sub(r"[^A-Z0-9]+", "_", value.upper()).strip("_")
+    return slug or "UNKNOWN"
+
+
+def _count_bucket(value: int) -> str:
+    if value <= 0:
+        return "0"
+    if value <= 4:
+        return "1-4"
+    if value <= 9:
+        return "5-9"
+    if value <= 19:
+        return "10-19"
+    if value <= 39:
+        return "20-39"
+    return "40+"
+
+
+def _x_bucket(value: Optional[float]) -> str:
+    if value is None:
+        return "none"
+    return str(max(0, min(9, int(value * 10))))
+
+
+def _distance_bucket(value: Optional[float]) -> str:
+    if value is None:
+        return "unknown"
+    if value < 0.15:
+        return "near"
+    if value < 0.35:
+        return "medium"
+    if value < 0.75:
+        return "far"
+    return "very_far"
+
+
+def _avg(values: Iterable[Any]) -> Optional[float]:
+    nums = [float(v) for v in values if isinstance(v, (int, float))]
+    return sum(nums) / len(nums) if nums else None
+
+
+def _safe_ratio(num: int, den: int) -> Optional[float]:
+    return num / den if den else None
+
+
+def _pearson(xs: List[Any], ys: List[Any]) -> Optional[float]:
+    pairs = [
+        (float(x), float(y))
+        for x, y in zip(xs, ys)
+        if isinstance(x, (int, float)) and isinstance(y, (int, float))
+    ]
+    if len(pairs) < 2:
+        return None
+    x_vals = [p[0] for p in pairs]
+    y_vals = [p[1] for p in pairs]
+    x_mean = sum(x_vals) / len(x_vals)
+    y_mean = sum(y_vals) / len(y_vals)
+    num = sum((x - x_mean) * (y - y_mean) for x, y in pairs)
+    x_den = math.sqrt(sum((x - x_mean) ** 2 for x in x_vals))
+    y_den = math.sqrt(sum((y - y_mean) ** 2 for y in y_vals))
+    if x_den == 0 or y_den == 0:
+        return None
+    return num / (x_den * y_den)
+
+
+def _none_to(value: Optional[float], fallback: float) -> float:
+    return float(value) if isinstance(value, (int, float)) else fallback
+
+
+def _fmt(value: Any) -> str:
+    return f"{float(value):.4f}" if isinstance(value, (int, float)) else "n/a"

--- a/receipt_layoutlm/receipt_layoutlm/evaluate_checkpoints.py
+++ b/receipt_layoutlm/receipt_layoutlm/evaluate_checkpoints.py
@@ -55,6 +55,8 @@ from .data_loader import _box_from_word, _normalize_box_from_extents
 
 logger = logging.getLogger(__name__)
 
+_PRODUCT_DETAIL_LABELS = ("PRODUCT_NAME", "QUANTITY", "UNIT_PRICE", "LINE_TOTAL")
+
 # ----------------------------------------------------------------------------
 # BIO / label helpers (mirrors the inference-cache Lambda so the per-receipt
 # records this emits are byte-compatible with what the frontend already renders)
@@ -572,6 +574,9 @@ def _seqeval_scores(
             "precision": acc,
             "recall": acc,
             "per_label_f1": {},
+            "per_label_precision": {},
+            "per_label_recall": {},
+            "per_label_support": {},
         }
 
     f1 = float(seqeval.f1_score(y_true_lines, y_pred_lines))
@@ -579,6 +584,9 @@ def _seqeval_scores(
     recall = float(seqeval.recall_score(y_true_lines, y_pred_lines))
 
     per_label_f1: Dict[str, float] = {}
+    per_label_precision: Dict[str, float] = {}
+    per_label_recall: Dict[str, float] = {}
+    per_label_support: Dict[str, int] = {}
     report_fn = getattr(seqeval, "classification_report", None)
     if report_fn is not None:
         try:
@@ -588,6 +596,11 @@ def _seqeval_scores(
             for label, stats in report.items():
                 if isinstance(stats, dict) and "f1-score" in stats:
                     per_label_f1[label] = float(stats["f1-score"])
+                    per_label_precision[label] = float(
+                        stats.get("precision", 0.0)
+                    )
+                    per_label_recall[label] = float(stats.get("recall", 0.0))
+                    per_label_support[label] = int(stats.get("support", 0))
         except Exception:  # pylint: disable=broad-exception-caught
             pass
 
@@ -597,6 +610,9 @@ def _seqeval_scores(
         "precision": precision,
         "recall": recall,
         "per_label_f1": per_label_f1,
+        "per_label_precision": per_label_precision,
+        "per_label_recall": per_label_recall,
+        "per_label_support": per_label_support,
     }
 
 
@@ -609,6 +625,195 @@ def _token_accuracy(
             total += 1
             correct += int(a == b)
     return correct / total if total else 0.0
+
+
+def _safe_ratio(numerator: int | float, denominator: int | float) -> Optional[float]:
+    return float(numerator) / float(denominator) if denominator else None
+
+
+def _bio_spans(tags: List[str]) -> List[Tuple[str, int, int]]:
+    """Return entity spans as ``(base_label, start, end_exclusive)``."""
+    spans: List[Tuple[str, int, int]] = []
+    active_label: Optional[str] = None
+    active_start: Optional[int] = None
+
+    for idx, tag in enumerate([*tags, "O"]):
+        if not tag or tag == "O":
+            prefix = "O"
+            base = "O"
+        elif tag.startswith("B-") or tag.startswith("I-"):
+            prefix = tag[:1]
+            base = tag[2:]
+        else:
+            prefix = "B"
+            base = tag
+
+        starts_new = base != "O" and (
+            prefix == "B" or active_label is None or active_label != base
+        )
+        closes_active = base == "O" or starts_new
+
+        if closes_active and active_label is not None and active_start is not None:
+            spans.append((active_label, active_start, idx))
+            active_label = None
+            active_start = None
+
+        if starts_new:
+            active_label = base
+            active_start = idx
+
+    return spans
+
+
+def _evaluation_diagnostics(
+    y_true_lines: List[List[str]],
+    y_pred_lines: List[List[str]],
+    *,
+    per_label_f1: Optional[Dict[str, float]] = None,
+) -> Dict[str, Any]:
+    """Compute explanation-oriented metrics for the held-out curve."""
+    per_label_f1 = per_label_f1 or {}
+    total_tokens = 0
+    correct_tokens = 0
+    gold_o_tokens = 0
+    pred_o_tokens = 0
+    gold_entity_tokens = 0
+    pred_entity_tokens = 0
+    correct_o_tokens = 0
+    correct_entity_tokens = 0
+    gold_label_tokens: Dict[str, int] = {}
+    pred_label_tokens: Dict[str, int] = {}
+    true_positive_label_tokens: Dict[str, int] = {}
+    token_confusions: Dict[Tuple[str, str], int] = {}
+    gold_entity_counts: Dict[str, int] = {}
+    pred_entity_counts: Dict[str, int] = {}
+
+    for y_true, y_pred in zip(y_true_lines, y_pred_lines):
+        for label, _start, _end in _bio_spans(y_true):
+            gold_entity_counts[label] = gold_entity_counts.get(label, 0) + 1
+        for label, _start, _end in _bio_spans(y_pred):
+            pred_entity_counts[label] = pred_entity_counts.get(label, 0) + 1
+
+        for true_tag, pred_tag in zip(y_true, y_pred):
+            gold = _get_base_label(true_tag)
+            pred = _get_base_label(pred_tag)
+            total_tokens += 1
+            if gold == pred:
+                correct_tokens += 1
+            else:
+                token_confusions[(gold, pred)] = (
+                    token_confusions.get((gold, pred), 0) + 1
+                )
+
+            if gold == "O":
+                gold_o_tokens += 1
+                if pred == "O":
+                    correct_o_tokens += 1
+            else:
+                gold_entity_tokens += 1
+                gold_label_tokens[gold] = gold_label_tokens.get(gold, 0) + 1
+                if gold == pred:
+                    correct_entity_tokens += 1
+                    true_positive_label_tokens[gold] = (
+                        true_positive_label_tokens.get(gold, 0) + 1
+                    )
+
+            if pred == "O":
+                pred_o_tokens += 1
+            else:
+                pred_entity_tokens += 1
+                pred_label_tokens[pred] = pred_label_tokens.get(pred, 0) + 1
+
+    labels = sorted(
+        set(gold_label_tokens)
+        | set(pred_label_tokens)
+        | set(gold_entity_counts)
+        | set(pred_entity_counts)
+    )
+    per_label_token_counts: Dict[str, Dict[str, Any]] = {}
+    per_label_entity_counts: Dict[str, Dict[str, Any]] = {}
+    for label in labels:
+        gold_tokens = gold_label_tokens.get(label, 0)
+        pred_tokens = pred_label_tokens.get(label, 0)
+        token_tp = true_positive_label_tokens.get(label, 0)
+        per_label_token_counts[label] = {
+            "gold_tokens": gold_tokens,
+            "predicted_tokens": pred_tokens,
+            "true_positive_tokens": token_tp,
+            "prediction_gold_ratio": _safe_ratio(pred_tokens, gold_tokens),
+        }
+        gold_entities = gold_entity_counts.get(label, 0)
+        pred_entities = pred_entity_counts.get(label, 0)
+        per_label_entity_counts[label] = {
+            "gold_entities": gold_entities,
+            "predicted_entities": pred_entities,
+            "prediction_gold_ratio": _safe_ratio(pred_entities, gold_entities),
+        }
+
+    product_f1_values = [
+        per_label_f1[label]
+        for label in _PRODUCT_DETAIL_LABELS
+        if isinstance(per_label_f1.get(label), (int, float))
+    ]
+    product_gold_entities = sum(
+        gold_entity_counts.get(label, 0) for label in _PRODUCT_DETAIL_LABELS
+    )
+    product_pred_entities = sum(
+        pred_entity_counts.get(label, 0) for label in _PRODUCT_DETAIL_LABELS
+    )
+
+    top_confusions = [
+        {"gold": gold, "predicted": pred, "count": count}
+        for (gold, pred), count in sorted(
+            token_confusions.items(), key=lambda item: item[1], reverse=True
+        )[:20]
+    ]
+
+    return {
+        "token_counts": {
+            "total": total_tokens,
+            "correct": correct_tokens,
+            "gold_o": gold_o_tokens,
+            "predicted_o": pred_o_tokens,
+            "gold_entity": gold_entity_tokens,
+            "predicted_entity": pred_entity_tokens,
+        },
+        "entity_counts": {
+            "gold": sum(gold_entity_counts.values()),
+            "predicted": sum(pred_entity_counts.values()),
+            "prediction_gold_ratio": _safe_ratio(
+                sum(pred_entity_counts.values()), sum(gold_entity_counts.values())
+            ),
+        },
+        "rates": {
+            "gold_entity_token_rate": _safe_ratio(
+                gold_entity_tokens, total_tokens
+            ),
+            "predicted_entity_token_rate": _safe_ratio(
+                pred_entity_tokens, total_tokens
+            ),
+            "o_token_accuracy": _safe_ratio(correct_o_tokens, gold_o_tokens),
+            "entity_token_accuracy": _safe_ratio(
+                correct_entity_tokens, gold_entity_tokens
+            ),
+        },
+        "product_detail": {
+            "labels": list(_PRODUCT_DETAIL_LABELS),
+            "macro_f1": (
+                sum(product_f1_values) / len(product_f1_values)
+                if product_f1_values
+                else None
+            ),
+            "gold_entities": product_gold_entities,
+            "predicted_entities": product_pred_entities,
+            "prediction_gold_ratio": _safe_ratio(
+                product_pred_entities, product_gold_entities
+            ),
+        },
+        "per_label_token_counts": per_label_token_counts,
+        "per_label_entity_counts": per_label_entity_counts,
+        "top_token_confusions": top_confusions,
+    }
 
 
 # ----------------------------------------------------------------------------
@@ -895,6 +1100,11 @@ def evaluate_run(
                     json.dump(record, f, default=str)
 
             scores = _seqeval_scores(all_true, all_pred)
+            diagnostics = _evaluation_diagnostics(
+                all_true,
+                all_pred,
+                per_label_f1=scores.get("per_label_f1", {}),
+            )
             entry = {
                 "checkpoint": name,
                 "step": step,
@@ -904,6 +1114,22 @@ def evaluate_run(
                 "heldout_recall": scores["recall"],
                 "heldout_metric": scores["metric"],
                 "per_label_f1": scores["per_label_f1"],
+                "per_label_precision": scores.get("per_label_precision", {}),
+                "per_label_recall": scores.get("per_label_recall", {}),
+                "per_label_support": scores.get("per_label_support", {}),
+                "diagnostics": diagnostics,
+                "product_detail_macro_f1": diagnostics["product_detail"][
+                    "macro_f1"
+                ],
+                "entity_prediction_rate": diagnostics["rates"][
+                    "predicted_entity_token_rate"
+                ],
+                "gold_entity_rate": diagnostics["rates"]["gold_entity_token_rate"],
+                "heldout_f1_delta_vs_training_reported": (
+                    scores["f1"] - step_to_f1[step]
+                    if step is not None and step_to_f1.get(step) is not None
+                    else None
+                ),
                 "token_accuracy": _token_accuracy(all_true, all_pred),
                 "training_reported_f1": (
                     step_to_f1.get(step) if step is not None else None
@@ -1098,6 +1324,11 @@ def evaluate_live_checkpoint(
             json.dump(record, f, default=str)
 
     scores = _seqeval_scores(all_true, all_pred)
+    diagnostics = _evaluation_diagnostics(
+        all_true,
+        all_pred,
+        per_label_f1=scores.get("per_label_f1", {}),
+    )
     entry = {
         "checkpoint": checkpoint_name,
         "step": step,
@@ -1107,6 +1338,20 @@ def evaluate_live_checkpoint(
         "heldout_recall": scores["recall"],
         "heldout_metric": scores["metric"],
         "per_label_f1": scores["per_label_f1"],
+        "per_label_precision": scores.get("per_label_precision", {}),
+        "per_label_recall": scores.get("per_label_recall", {}),
+        "per_label_support": scores.get("per_label_support", {}),
+        "diagnostics": diagnostics,
+        "product_detail_macro_f1": diagnostics["product_detail"]["macro_f1"],
+        "entity_prediction_rate": diagnostics["rates"][
+            "predicted_entity_token_rate"
+        ],
+        "gold_entity_rate": diagnostics["rates"]["gold_entity_token_rate"],
+        "heldout_f1_delta_vs_training_reported": (
+            scores["f1"] - training_reported_f1
+            if training_reported_f1 is not None
+            else None
+        ),
         "token_accuracy": _token_accuracy(all_true, all_pred),
         "training_reported_f1": training_reported_f1,
         "num_receipts_evaluated": len(details_by_receipt),

--- a/receipt_layoutlm/receipt_layoutlm/trainer.py
+++ b/receipt_layoutlm/receipt_layoutlm/trainer.py
@@ -34,6 +34,57 @@ def _checkpoint_step(path: str) -> int:
     return int(m.group(1)) if m else 0
 
 
+_CHECKPOINT_METRIC_ALIASES = {
+    "f1": "eval_f1",
+    "eval_f1": "eval_f1",
+    "product_detail_macro_f1": "eval_product_detail_macro_f1",
+    "eval_product_detail_macro_f1": "eval_product_detail_macro_f1",
+    "loss": "eval_loss",
+    "eval_loss": "eval_loss",
+    "accuracy": "eval_accuracy",
+    "eval_accuracy": "eval_accuracy",
+}
+
+
+def _checkpoint_metric_for_trainer(metric: str | None) -> str:
+    """Normalize a configured metric to HuggingFace Trainer's eval_* key."""
+    raw = (metric or "f1").strip()
+    if raw in _CHECKPOINT_METRIC_ALIASES:
+        return _CHECKPOINT_METRIC_ALIASES[raw]
+    if raw.startswith("eval_"):
+        return raw
+    return f"eval_{raw}"
+
+
+def _metric_greater_is_better(metric: str) -> bool:
+    """Return whether higher values should win for checkpoint selection."""
+    return not metric.endswith("loss")
+
+
+def _epoch_metric_values(
+    epoch_metrics: List[Dict[str, Any]],
+    metric: str,
+) -> List[Tuple[float, float]]:
+    """Extract (epoch, value) pairs for a metric from run.json entries."""
+    candidates = [metric]
+    if metric.startswith("eval_"):
+        candidates.append(metric.removeprefix("eval_"))
+    else:
+        candidates.append(f"eval_{metric}")
+
+    values: List[Tuple[float, float]] = []
+    for entry in epoch_metrics:
+        epoch = entry.get("epoch")
+        if epoch is None:
+            continue
+        for key in candidates:
+            value = entry.get(key)
+            if isinstance(value, (int, float)):
+                values.append((float(epoch), float(value)))
+                break
+    return values
+
+
 SAGEMAKER_CHECKPOINT_DIR = "/opt/ml/checkpoints"
 _LOCAL_OUTPUT_ROOT = "/tmp/receipt_layoutlm"
 
@@ -170,6 +221,11 @@ class ReceiptLayoutLMTrainer:
                     label_merges=effective_label_merges,
                     allowed_labels=self.data_config.allowed_labels,
                     model_version=self.training_config.model_version,
+                    item_window_augmentation=(
+                        self.data_config.item_window_augmentation
+                    ),
+                    item_window_size=self.data_config.item_window_size,
+                    item_window_stride=self.data_config.item_window_stride,
                 )
         else:
             datasets, split_metadata, merge_info = load_datasets(
@@ -177,6 +233,11 @@ class ReceiptLayoutLMTrainer:
                 label_merges=effective_label_merges,
                 allowed_labels=self.data_config.allowed_labels,
                 model_version=self.training_config.model_version,
+                item_window_augmentation=(
+                    self.data_config.item_window_augmentation
+                ),
+                item_window_size=self.data_config.item_window_size,
+                item_window_stride=self.data_config.item_window_stride,
             )
 
         # Compute dataset counts prior to tokenization for run logging
@@ -404,6 +465,9 @@ class ReceiptLayoutLMTrainer:
         )
         ta_cls = self._transformers.TrainingArguments
         ta_params = inspect.signature(ta_cls.__init__).parameters
+        checkpoint_metric = _checkpoint_metric_for_trainer(
+            self.training_config.checkpoint_metric
+        )
         if "evaluation_strategy" in ta_params:
             args_kwargs["evaluation_strategy"] = "epoch"
         elif "eval_strategy" in ta_params:
@@ -413,13 +477,16 @@ class ReceiptLayoutLMTrainer:
         if "load_best_model_at_end" in ta_params:
             args_kwargs["load_best_model_at_end"] = True
         if "metric_for_best_model" in ta_params:
-            # Check if seqeval is available to determine which metric to use
             try:
                 importlib.import_module("seqeval.metrics")
-                args_kwargs["metric_for_best_model"] = "eval_f1"
             except ModuleNotFoundError:
-                # Fallback to accuracy if seqeval not available
-                args_kwargs["metric_for_best_model"] = "eval_accuracy"
+                # Fallback to accuracy if seqeval-derived metrics are absent.
+                checkpoint_metric = "eval_accuracy"
+            args_kwargs["metric_for_best_model"] = checkpoint_metric
+        if "greater_is_better" in ta_params:
+            args_kwargs["greater_is_better"] = _metric_greater_is_better(
+                checkpoint_metric
+            )
         # Keep only 2 checkpoints locally to minimize disk usage
         # on_save callback syncs to S3 before old checkpoints are deleted
         if "save_total_limit" in ta_params:
@@ -703,6 +770,29 @@ class ReceiptLayoutLMTrainer:
                         if eval_loss is not None:
                             _add_metric("eval_loss", eval_loss, "loss")
 
+                        explanation_scalars = {
+                            "entity_prediction_rate": "val_entity_prediction_rate",
+                            "gold_entity_rate": "val_gold_entity_rate",
+                            "entity_prediction_gold_ratio": (
+                                "val_entity_prediction_gold_ratio"
+                            ),
+                            "entity_token_accuracy": "val_entity_token_accuracy",
+                            "o_token_accuracy": "val_o_token_accuracy",
+                            "product_detail_macro_f1": (
+                                "val_product_detail_macro_f1"
+                            ),
+                            "entropy_mean": "val_entropy_mean",
+                            "entropy_std": "val_entropy_std",
+                            "entropy_p10": "val_entropy_p10",
+                            "entropy_p90": "val_entropy_p90",
+                        }
+                        for source_name, metric_name in explanation_scalars.items():
+                            value = metrics.get(f"eval_{source_name}")
+                            if value is None:
+                                value = metrics.get(source_name)
+                            if value is not None:
+                                _add_metric(metric_name, value, "ratio")
+
                         # Confusion matrix (stored as dict, not scalar)
                         cm_data = metrics.get(
                             "eval_confusion_matrix"
@@ -862,6 +952,7 @@ class ReceiptLayoutLMTrainer:
                     window_size: int,
                     window_stride: int,
                     job_name: str,
+                    job_id: str,
                     s3_bucket: str | None,
                     s3_prefix: str | None,
                     valid_status: str = "VALID",
@@ -875,6 +966,7 @@ class ReceiptLayoutLMTrainer:
                     self.window_size = window_size
                     self.window_stride = window_stride
                     self.job_name = job_name
+                    self.job_id = job_id
                     self.s3_bucket = s3_bucket
                     self.s3_prefix = s3_prefix
                     self.valid_status = valid_status
@@ -897,6 +989,103 @@ class ReceiptLayoutLMTrainer:
                             ]
                     except Exception as e:  # noqa: BLE001
                         print(f"⚠️  Could not seed epochs.json: {e}")
+
+                def _write_live_metrics(
+                    self,
+                    entry: Dict[str, Any],
+                    *,
+                    epoch: Optional[int],
+                    step: int,
+                ) -> None:
+                    def _write(
+                        name: str,
+                        value: Any,
+                        unit: str = "ratio",
+                    ) -> None:
+                        if not isinstance(value, (int, float)):
+                            return
+                        try:
+                            self.dynamo.add_job_metric(
+                                JobMetric(
+                                    job_id=self.job_id,
+                                    metric_name=name,
+                                    value=float(value),
+                                    timestamp=datetime.now(
+                                        timezone.utc
+                                    ).isoformat(),
+                                    unit=unit,
+                                    epoch=epoch,
+                                    step=step,
+                                )
+                            )
+                        except Exception as e:  # noqa: BLE001
+                            print(
+                                "Warning: Failed to write live held-out "
+                                f"metric {name}: {e}"
+                            )
+
+                    _write("heldout_windowed_f1", entry.get("heldout_f1"))
+                    _write(
+                        "heldout_windowed_precision",
+                        entry.get("heldout_precision"),
+                    )
+                    _write(
+                        "heldout_windowed_recall",
+                        entry.get("heldout_recall"),
+                    )
+                    _write(
+                        "heldout_windowed_token_accuracy",
+                        entry.get("token_accuracy"),
+                    )
+                    _write(
+                        "heldout_windowed_product_detail_macro_f1",
+                        entry.get("product_detail_macro_f1"),
+                    )
+                    _write(
+                        "heldout_windowed_entity_prediction_rate",
+                        entry.get("entity_prediction_rate"),
+                    )
+                    _write(
+                        "heldout_windowed_gold_entity_rate",
+                        entry.get("gold_entity_rate"),
+                    )
+                    _write(
+                        "heldout_windowed_f1_delta_vs_training_reported",
+                        entry.get("heldout_f1_delta_vs_training_reported"),
+                    )
+                    _write(
+                        "heldout_windowed_avg_inference_ms",
+                        entry.get("avg_inference_ms"),
+                        "ms",
+                    )
+
+                    per_label_f1 = entry.get("per_label_f1") or {}
+                    per_label_precision = entry.get("per_label_precision") or {}
+                    per_label_recall = entry.get("per_label_recall") or {}
+                    per_label_support = entry.get("per_label_support") or {}
+                    for label in (
+                        "PRODUCT_NAME",
+                        "QUANTITY",
+                        "UNIT_PRICE",
+                        "LINE_TOTAL",
+                    ):
+                        _write(
+                            f"heldout_label_{label}_f1",
+                            per_label_f1.get(label),
+                        )
+                        _write(
+                            f"heldout_label_{label}_precision",
+                            per_label_precision.get(label),
+                        )
+                        _write(
+                            f"heldout_label_{label}_recall",
+                            per_label_recall.get(label),
+                        )
+                        _write(
+                            f"heldout_label_{label}_support",
+                            per_label_support.get(label),
+                            "count",
+                        )
 
                 def _ensure_details(self) -> None:
                     if self._details is not None:
@@ -954,6 +1143,11 @@ class ReceiptLayoutLMTrainer:
                             valid_status=self.valid_status,
                         )
                         self._entries.append(entry)
+                        self._write_live_metrics(
+                            entry,
+                            epoch=epoch_num,
+                            step=int(getattr(state, "global_step", 0)),
+                        )
                         run_s3_uri = (
                             f"s3://{self.s3_bucket}/{self.s3_prefix}"
                             if self.s3_bucket and self.s3_prefix
@@ -1055,6 +1249,7 @@ class ReceiptLayoutLMTrainer:
                             or 150
                         ),
                         job_name=job_name,
+                        job_id=job.job_id,
                         s3_bucket=s3_bucket,
                         s3_prefix=s3_prefix,
                         valid_status=self.data_config.validation_status,
@@ -1333,6 +1528,76 @@ class ReceiptLayoutLMTrainer:
                 except Exception as e:
                     print(f"Warning: Failed to compute entropy metrics: {e}")
 
+                try:
+                    def _base(tag: str) -> str:
+                        if tag == "O":
+                            return "O"
+                        if tag.startswith("B-") or tag.startswith("I-"):
+                            return tag[2:]
+                        return tag
+
+                    total_tokens = 0
+                    gold_entity_tokens = 0
+                    pred_entity_tokens = 0
+                    correct_entity_tokens = 0
+                    gold_o_tokens = 0
+                    correct_o_tokens = 0
+                    for true_seq, pred_seq in zip(y_true, y_pred):
+                        for true_tag, pred_tag in zip(true_seq, pred_seq):
+                            gold = _base(true_tag)
+                            pred = _base(pred_tag)
+                            total_tokens += 1
+                            if gold == "O":
+                                gold_o_tokens += 1
+                                if pred == "O":
+                                    correct_o_tokens += 1
+                            else:
+                                gold_entity_tokens += 1
+                                if gold == pred:
+                                    correct_entity_tokens += 1
+                            if pred != "O":
+                                pred_entity_tokens += 1
+
+                    if total_tokens:
+                        metrics["gold_entity_rate"] = (
+                            gold_entity_tokens / total_tokens
+                        )
+                        metrics["entity_prediction_rate"] = (
+                            pred_entity_tokens / total_tokens
+                        )
+                    if gold_entity_tokens:
+                        metrics["entity_prediction_gold_ratio"] = (
+                            pred_entity_tokens / gold_entity_tokens
+                        )
+                        metrics["entity_token_accuracy"] = (
+                            correct_entity_tokens / gold_entity_tokens
+                        )
+                    if gold_o_tokens:
+                        metrics["o_token_accuracy"] = (
+                            correct_o_tokens / gold_o_tokens
+                        )
+
+                    product_f1_values = [
+                        metrics[f"label_{label}_f1"]
+                        for label in (
+                            "PRODUCT_NAME",
+                            "QUANTITY",
+                            "UNIT_PRICE",
+                            "LINE_TOTAL",
+                        )
+                        if isinstance(
+                            metrics.get(f"label_{label}_f1"), (int, float)
+                        )
+                    ]
+                    if product_f1_values:
+                        metrics["product_detail_macro_f1"] = sum(
+                            product_f1_values
+                        ) / len(product_f1_values)
+                except Exception as e:
+                    print(
+                        f"Warning: Failed to compute explanation metrics: {e}"
+                    )
+
                 # Note: F1 metric is now stored in _MetricLoggerCallback.on_evaluate()
                 # with epoch information, so we don't need to store it here
             else:
@@ -1366,6 +1631,12 @@ class ReceiptLayoutLMTrainer:
 
         w_min = _read_float_env("LAYOUTLM_CLASS_WEIGHT_MIN", 0.3)
         w_max = _read_float_env("LAYOUTLM_CLASS_WEIGHT_MAX", 5.0)
+        product_weight = self.training_config.product_detail_loss_weight
+        if product_weight <= 0:
+            raise ValueError(
+                "product_detail_loss_weight must be > 0; "
+                f"got {product_weight}"
+            )
         if not (0 < w_min <= w_max):
             raise ValueError(
                 f"class weight clip range invalid: "
@@ -1388,6 +1659,17 @@ class ReceiptLayoutLMTrainer:
             else:
                 w = total / (n_classes * c)
                 weights.append(max(w_min, min(w, w_max)))
+        if product_weight != 1.0:
+            product_labels = {
+                "PRODUCT_NAME",
+                "QUANTITY",
+                "UNIT_PRICE",
+                "LINE_TOTAL",
+            }
+            for idx, label in enumerate(label_list):
+                base_label = label[2:] if label.startswith(("B-", "I-")) else label
+                if base_label in product_labels:
+                    weights[idx] = min(w_max, weights[idx] * product_weight)
         class_weights_tensor = torch_mod.tensor(
             weights, dtype=torch_mod.float32
         )
@@ -1397,6 +1679,11 @@ class ReceiptLayoutLMTrainer:
                 f"{label_list[i]}={weights[i]:.2f}" for i in range(n_classes)
             )
         )
+        if product_weight != 1.0:
+            print(
+                "[trainer] product detail loss weight multiplier: "
+                f"{product_weight:.3f}"
+            )
 
         TrainerBase = self._transformers.Trainer
 
@@ -1472,54 +1759,55 @@ class ReceiptLayoutLMTrainer:
             # Calculate best epoch and early stopping info
             best_epoch = None
             best_f1 = None
+            best_selection_epoch = None
+            best_selection_metric_value = None
             early_stopping_triggered = False
 
-            # Find best F1 score
-            f1_metrics = [
-                m for m in epoch_metrics if "eval_f1" in m or "f1" in m
-            ]
-            if f1_metrics:
-                # Get F1 value (try eval_f1 first, then f1)
-                f1_with_epochs = [
-                    (m.get("epoch"), m.get("eval_f1") or m.get("f1"))
-                    for m in f1_metrics
-                    if m.get("epoch") is not None
-                    and (
-                        m.get("eval_f1") is not None or m.get("f1") is not None
-                    )
-                ]
-                if f1_with_epochs:
-                    best_epoch, best_f1 = max(
-                        f1_with_epochs,
-                        key=lambda x: x[1] if x[1] is not None else -1,
-                    )
+            # Find best aggregate validation F1 for backwards-compatible
+            # reporting, even when checkpoint selection uses a different metric.
+            f1_with_epochs = _epoch_metric_values(epoch_metrics, "eval_f1")
+            if f1_with_epochs:
+                best_epoch, best_f1 = max(f1_with_epochs, key=lambda x: x[1])
 
-                    # Check if early stopping triggered
-                    # If best epoch is not the last epoch, early stopping likely triggered
-                    if epoch_metrics:
-                        last_epoch = max(
-                            (
-                                m.get("epoch")
-                                for m in epoch_metrics
-                                if m.get("epoch") is not None
-                            ),
-                            default=None,
-                        )
-                        if last_epoch is not None and best_epoch is not None:
-                            # Check if we stopped before max epochs
-                            max_epochs = self.training_config.epochs
-                            patience = (
-                                self.training_config.early_stopping_patience
-                            )
-                            if last_epoch < max_epochs - 1:
-                                # Check if best epoch was more than patience epochs ago
-                                epochs_since_best = last_epoch - best_epoch
-                                if epochs_since_best >= patience:
-                                    early_stopping_triggered = True
+            selection_metric_name = _checkpoint_metric_for_trainer(
+                self.training_config.checkpoint_metric
+            )
+            selection_values = _epoch_metric_values(
+                epoch_metrics, selection_metric_name
+            )
+            if selection_values:
+                selector = max if _metric_greater_is_better(
+                    selection_metric_name
+                ) else min
+                best_selection_epoch, best_selection_metric_value = selector(
+                    selection_values,
+                    key=lambda x: x[1],
+                )
+
+            if epoch_metrics:
+                last_epoch = max(
+                    (
+                        m.get("epoch")
+                        for m in epoch_metrics
+                        if m.get("epoch") is not None
+                    ),
+                    default=None,
+                )
+                if (
+                    last_epoch is not None
+                    and best_selection_epoch is not None
+                    and last_epoch < self.training_config.epochs - 1
+                ):
+                    epochs_since_best = last_epoch - best_selection_epoch
+                    if epochs_since_best >= (
+                        self.training_config.early_stopping_patience
+                    ):
+                        early_stopping_triggered = True
 
             summary_payload = {
                 "type": "run_summary",
                 "epoch_metrics": epoch_metrics,
+                "checkpoint_metric": selection_metric_name,
             }
 
             # Add early stopping information if available
@@ -1546,6 +1834,18 @@ class ReceiptLayoutLMTrainer:
                             if best_epoch is not None
                             else None
                         )
+            if best_selection_epoch is not None:
+                summary_payload["best_checkpoint_metric"] = (
+                    selection_metric_name
+                )
+                summary_payload["best_checkpoint_metric_epoch"] = float(
+                    best_selection_epoch
+                )
+                summary_payload["best_checkpoint_metric_value"] = (
+                    float(best_selection_metric_value)
+                    if best_selection_metric_value is not None
+                    else None
+                )
 
             # Extract checkpoint and training time information from trainer_state.json
             trainer_state_path = os.path.join(output_dir, "trainer_state.json")
@@ -1631,6 +1931,20 @@ class ReceiptLayoutLMTrainer:
                 "best_f1": float(best_f1) if best_f1 is not None else None,
                 "best_epoch": (
                     int(best_epoch) if best_epoch is not None else None
+                ),
+                "best_f1_epoch": (
+                    int(best_epoch) if best_epoch is not None else None
+                ),
+                "checkpoint_metric": selection_metric_name,
+                "best_checkpoint_metric_value": (
+                    float(best_selection_metric_value)
+                    if best_selection_metric_value is not None
+                    else None
+                ),
+                "best_checkpoint_metric_epoch": (
+                    int(best_selection_epoch)
+                    if best_selection_epoch is not None
+                    else None
                 ),
                 "early_stopping_triggered": early_stopping_triggered,
             }

--- a/receipt_layoutlm/receipt_layoutlm/trainer.py
+++ b/receipt_layoutlm/receipt_layoutlm/trainer.py
@@ -44,6 +44,7 @@ _CHECKPOINT_METRIC_ALIASES = {
     "accuracy": "eval_accuracy",
     "eval_accuracy": "eval_accuracy",
 }
+_SEQEVAL_FREE_CHECKPOINT_METRICS = {"eval_accuracy", "eval_loss"}
 
 
 def _checkpoint_metric_for_trainer(metric: str | None) -> str:
@@ -54,6 +55,18 @@ def _checkpoint_metric_for_trainer(metric: str | None) -> str:
     if raw.startswith("eval_"):
         return raw
     return f"eval_{raw}"
+
+
+def _checkpoint_metric_for_available_metrics(
+    metric: str | None, *, seqeval_available: bool
+) -> str:
+    checkpoint_metric = _checkpoint_metric_for_trainer(metric)
+    if (
+        not seqeval_available
+        and checkpoint_metric not in _SEQEVAL_FREE_CHECKPOINT_METRICS
+    ):
+        return "eval_accuracy"
+    return checkpoint_metric
 
 
 def _metric_greater_is_better(metric: str) -> bool:
@@ -465,8 +478,14 @@ class ReceiptLayoutLMTrainer:
         )
         ta_cls = self._transformers.TrainingArguments
         ta_params = inspect.signature(ta_cls.__init__).parameters
-        checkpoint_metric = _checkpoint_metric_for_trainer(
-            self.training_config.checkpoint_metric
+        seqeval_available = True
+        try:
+            importlib.import_module("seqeval.metrics")
+        except ModuleNotFoundError:
+            seqeval_available = False
+        checkpoint_metric = _checkpoint_metric_for_available_metrics(
+            self.training_config.checkpoint_metric,
+            seqeval_available=seqeval_available,
         )
         if "evaluation_strategy" in ta_params:
             args_kwargs["evaluation_strategy"] = "epoch"
@@ -477,11 +496,6 @@ class ReceiptLayoutLMTrainer:
         if "load_best_model_at_end" in ta_params:
             args_kwargs["load_best_model_at_end"] = True
         if "metric_for_best_model" in ta_params:
-            try:
-                importlib.import_module("seqeval.metrics")
-            except ModuleNotFoundError:
-                # Fallback to accuracy if seqeval-derived metrics are absent.
-                checkpoint_metric = "eval_accuracy"
             args_kwargs["metric_for_best_model"] = checkpoint_metric
         if "greater_is_better" in ta_params:
             args_kwargs["greater_is_better"] = _metric_greater_is_better(
@@ -1432,12 +1446,25 @@ class ReceiptLayoutLMTrainer:
                 y_true.append(t_tags)
                 y_pred.append(p_tags)
 
-            metrics = {}
+            total_valid_tokens = sum(len(seq) for seq in y_true)
+            correct_valid_tokens = sum(
+                1
+                for true_seq, pred_seq in zip(y_true, y_pred)
+                for true_tag, pred_tag in zip(true_seq, pred_seq)
+                if true_tag == pred_tag
+            )
+            metrics = {
+                "accuracy": (
+                    correct_valid_tokens / total_valid_tokens
+                    if total_valid_tokens
+                    else 0.0
+                )
+            }
             if seqeval:
                 f1 = float(f1_fn(y_true, y_pred))
                 prec = float(precision_fn(y_true, y_pred))
                 rec = float(recall_fn(y_true, y_pred))
-                metrics = {"f1": f1, "precision": prec, "recall": rec}
+                metrics.update({"f1": f1, "precision": prec, "recall": rec})
 
                 # Get per-label metrics if classification_report is available
                 # Flatten into scalar keys so HuggingFace Trainer passes them to callbacks
@@ -1604,8 +1631,13 @@ class ReceiptLayoutLMTrainer:
                 # Token accuracy fallback
                 import numpy as _np
 
-                correct = (preds == labels).astype(float)
-                acc = float(_np.mean(correct))
+                mask = labels != -100
+                correct = (preds == labels) & mask
+                acc = (
+                    float(_np.sum(correct) / _np.sum(mask))
+                    if _np.sum(mask)
+                    else 0.0
+                )
                 metrics = {"accuracy": acc}
 
             return metrics
@@ -1660,6 +1692,7 @@ class ReceiptLayoutLMTrainer:
                 w = total / (n_classes * c)
                 weights.append(max(w_min, min(w, w_max)))
         if product_weight != 1.0:
+            product_cap = w_max * max(product_weight, 1.0)
             product_labels = {
                 "PRODUCT_NAME",
                 "QUANTITY",
@@ -1669,7 +1702,10 @@ class ReceiptLayoutLMTrainer:
             for idx, label in enumerate(label_list):
                 base_label = label[2:] if label.startswith(("B-", "I-")) else label
                 if base_label in product_labels:
-                    weights[idx] = min(w_max, weights[idx] * product_weight)
+                    weights[idx] = max(
+                        w_min,
+                        min(weights[idx] * product_weight, product_cap),
+                    )
         class_weights_tensor = torch_mod.tensor(
             weights, dtype=torch_mod.float32
         )
@@ -1682,7 +1718,8 @@ class ReceiptLayoutLMTrainer:
         if product_weight != 1.0:
             print(
                 "[trainer] product detail loss weight multiplier: "
-                f"{product_weight:.3f}"
+                f"{product_weight:.3f} (effective product cap "
+                f"{product_cap:.3f})"
             )
 
         TrainerBase = self._transformers.Trainer

--- a/receipt_layoutlm/receipt_layoutlm/trainer.py
+++ b/receipt_layoutlm/receipt_layoutlm/trainer.py
@@ -45,6 +45,12 @@ _CHECKPOINT_METRIC_ALIASES = {
     "eval_accuracy": "eval_accuracy",
 }
 _SEQEVAL_FREE_CHECKPOINT_METRICS = {"eval_accuracy", "eval_loss"}
+_PRODUCT_DETAIL_LABELS = (
+    "PRODUCT_NAME",
+    "QUANTITY",
+    "UNIT_PRICE",
+    "LINE_TOTAL",
+)
 
 
 def _checkpoint_metric_for_trainer(metric: str | None) -> str:
@@ -96,6 +102,70 @@ def _epoch_metric_values(
                 values.append((float(epoch), float(value)))
                 break
     return values
+
+
+def _base_tag_label(tag: str) -> str:
+    if tag == "O":
+        return "O"
+    if tag.startswith("B-") or tag.startswith("I-"):
+        return tag[2:]
+    return tag
+
+
+def _add_explanation_metrics(
+    metrics: Dict[str, Any],
+    y_true: List[List[str]],
+    y_pred: List[List[str]],
+) -> None:
+    """Add explanatory token metrics used by diagnostics/checkpoint selection."""
+    metrics["product_detail_macro_f1"] = 0.0
+    try:
+        total_tokens = 0
+        gold_entity_tokens = 0
+        pred_entity_tokens = 0
+        correct_entity_tokens = 0
+        gold_o_tokens = 0
+        correct_o_tokens = 0
+        for true_seq, pred_seq in zip(y_true, y_pred, strict=False):
+            for true_tag, pred_tag in zip(true_seq, pred_seq, strict=False):
+                gold = _base_tag_label(true_tag)
+                pred = _base_tag_label(pred_tag)
+                total_tokens += 1
+                if gold == "O":
+                    gold_o_tokens += 1
+                    if pred == "O":
+                        correct_o_tokens += 1
+                else:
+                    gold_entity_tokens += 1
+                    if gold == pred:
+                        correct_entity_tokens += 1
+                if pred != "O":
+                    pred_entity_tokens += 1
+
+        if total_tokens:
+            metrics["gold_entity_rate"] = gold_entity_tokens / total_tokens
+            metrics["entity_prediction_rate"] = pred_entity_tokens / total_tokens
+        if gold_entity_tokens:
+            metrics["entity_prediction_gold_ratio"] = (
+                pred_entity_tokens / gold_entity_tokens
+            )
+            metrics["entity_token_accuracy"] = (
+                correct_entity_tokens / gold_entity_tokens
+            )
+        if gold_o_tokens:
+            metrics["o_token_accuracy"] = correct_o_tokens / gold_o_tokens
+
+        product_f1_values = [
+            metrics[f"label_{label}_f1"]
+            for label in _PRODUCT_DETAIL_LABELS
+            if isinstance(metrics.get(f"label_{label}_f1"), (int, float))
+        ]
+        if product_f1_values:
+            metrics["product_detail_macro_f1"] = sum(product_f1_values) / len(
+                product_f1_values
+            )
+    except Exception as e:
+        print(f"Warning: Failed to compute explanation metrics: {e}")
 
 
 SAGEMAKER_CHECKPOINT_DIR = "/opt/ml/checkpoints"
@@ -1435,10 +1505,10 @@ class ReceiptLayoutLMTrainer:
             id2label_local = id2label
             y_true: List[List[str]] = []
             y_pred: List[List[str]] = []
-            for true_row, pred_row in zip(labels, preds):
+            for true_row, pred_row in zip(labels, preds, strict=False):
                 t_tags: List[str] = []
                 p_tags: List[str] = []
-                for t, p in zip(true_row, pred_row):
+                for t, p in zip(true_row, pred_row, strict=False):
                     if int(t) == -100:
                         continue
                     t_tags.append(id2label_local.get(int(t), "O"))
@@ -1449,8 +1519,10 @@ class ReceiptLayoutLMTrainer:
             total_valid_tokens = sum(len(seq) for seq in y_true)
             correct_valid_tokens = sum(
                 1
-                for true_seq, pred_seq in zip(y_true, y_pred)
-                for true_tag, pred_tag in zip(true_seq, pred_seq)
+                for true_seq, pred_seq in zip(y_true, y_pred, strict=False)
+                for true_tag, pred_tag in zip(
+                    true_seq, pred_seq, strict=False
+                )
                 if true_tag == pred_tag
             )
             metrics = {
@@ -1555,75 +1627,7 @@ class ReceiptLayoutLMTrainer:
                 except Exception as e:
                     print(f"Warning: Failed to compute entropy metrics: {e}")
 
-                try:
-                    def _base(tag: str) -> str:
-                        if tag == "O":
-                            return "O"
-                        if tag.startswith("B-") or tag.startswith("I-"):
-                            return tag[2:]
-                        return tag
-
-                    total_tokens = 0
-                    gold_entity_tokens = 0
-                    pred_entity_tokens = 0
-                    correct_entity_tokens = 0
-                    gold_o_tokens = 0
-                    correct_o_tokens = 0
-                    for true_seq, pred_seq in zip(y_true, y_pred):
-                        for true_tag, pred_tag in zip(true_seq, pred_seq):
-                            gold = _base(true_tag)
-                            pred = _base(pred_tag)
-                            total_tokens += 1
-                            if gold == "O":
-                                gold_o_tokens += 1
-                                if pred == "O":
-                                    correct_o_tokens += 1
-                            else:
-                                gold_entity_tokens += 1
-                                if gold == pred:
-                                    correct_entity_tokens += 1
-                            if pred != "O":
-                                pred_entity_tokens += 1
-
-                    if total_tokens:
-                        metrics["gold_entity_rate"] = (
-                            gold_entity_tokens / total_tokens
-                        )
-                        metrics["entity_prediction_rate"] = (
-                            pred_entity_tokens / total_tokens
-                        )
-                    if gold_entity_tokens:
-                        metrics["entity_prediction_gold_ratio"] = (
-                            pred_entity_tokens / gold_entity_tokens
-                        )
-                        metrics["entity_token_accuracy"] = (
-                            correct_entity_tokens / gold_entity_tokens
-                        )
-                    if gold_o_tokens:
-                        metrics["o_token_accuracy"] = (
-                            correct_o_tokens / gold_o_tokens
-                        )
-
-                    product_f1_values = [
-                        metrics[f"label_{label}_f1"]
-                        for label in (
-                            "PRODUCT_NAME",
-                            "QUANTITY",
-                            "UNIT_PRICE",
-                            "LINE_TOTAL",
-                        )
-                        if isinstance(
-                            metrics.get(f"label_{label}_f1"), (int, float)
-                        )
-                    ]
-                    if product_f1_values:
-                        metrics["product_detail_macro_f1"] = sum(
-                            product_f1_values
-                        ) / len(product_f1_values)
-                except Exception as e:
-                    print(
-                        f"Warning: Failed to compute explanation metrics: {e}"
-                    )
+                _add_explanation_metrics(metrics, y_true, y_pred)
 
                 # Note: F1 metric is now stored in _MetricLoggerCallback.on_evaluate()
                 # with epoch information, so we don't need to store it here

--- a/receipt_layoutlm/receipt_layoutlm/trainer.py
+++ b/receipt_layoutlm/receipt_layoutlm/trainer.py
@@ -1806,9 +1806,8 @@ class ReceiptLayoutLMTrainer:
             if f1_with_epochs:
                 best_epoch, best_f1 = max(f1_with_epochs, key=lambda x: x[1])
 
-            selection_metric_name = _checkpoint_metric_for_trainer(
-                self.training_config.checkpoint_metric
-            )
+            # Match the metric actually handed to TrainingArguments above.
+            selection_metric_name = checkpoint_metric
             selection_values = _epoch_metric_values(
                 epoch_metrics, selection_metric_name
             )

--- a/receipt_layoutlm/tests/unit/test_checkpoint_metric.py
+++ b/receipt_layoutlm/tests/unit/test_checkpoint_metric.py
@@ -1,0 +1,31 @@
+from receipt_layoutlm.trainer import (
+    _checkpoint_metric_for_trainer,
+    _epoch_metric_values,
+    _metric_greater_is_better,
+)
+
+
+def test_checkpoint_metric_for_trainer_normalizes_aliases():
+    assert _checkpoint_metric_for_trainer("f1") == "eval_f1"
+    assert (
+        _checkpoint_metric_for_trainer("product_detail_macro_f1")
+        == "eval_product_detail_macro_f1"
+    )
+    assert _checkpoint_metric_for_trainer("eval_loss") == "eval_loss"
+
+
+def test_metric_greater_is_better_treats_loss_as_lower_better():
+    assert _metric_greater_is_better("eval_f1")
+    assert not _metric_greater_is_better("eval_loss")
+
+
+def test_epoch_metric_values_reads_prefixed_and_unprefixed_keys():
+    rows = [
+        {"epoch": 1, "eval_product_detail_macro_f1": 0.2},
+        {"epoch": 2, "product_detail_macro_f1": 0.3},
+        {"epoch": None, "eval_product_detail_macro_f1": 0.9},
+    ]
+
+    assert _epoch_metric_values(
+        rows, "eval_product_detail_macro_f1"
+    ) == [(1.0, 0.2), (2.0, 0.3)]

--- a/receipt_layoutlm/tests/unit/test_checkpoint_metric.py
+++ b/receipt_layoutlm/tests/unit/test_checkpoint_metric.py
@@ -37,6 +37,20 @@ def test_checkpoint_metric_fallback_preserves_seqeval_free_metrics():
     )
 
 
+def test_fallback_checkpoint_metric_reads_accuracy_epoch_values():
+    metric = _checkpoint_metric_for_available_metrics(
+        "product_detail_macro_f1",
+        seqeval_available=False,
+    )
+    rows = [
+        {"epoch": 1, "eval_accuracy": 0.71},
+        {"epoch": 2, "eval_accuracy": 0.73},
+    ]
+
+    assert metric == "eval_accuracy"
+    assert _epoch_metric_values(rows, metric) == [(1.0, 0.71), (2.0, 0.73)]
+
+
 def test_metric_greater_is_better_treats_loss_as_lower_better():
     assert _metric_greater_is_better("eval_f1")
     assert not _metric_greater_is_better("eval_loss")

--- a/receipt_layoutlm/tests/unit/test_checkpoint_metric.py
+++ b/receipt_layoutlm/tests/unit/test_checkpoint_metric.py
@@ -1,4 +1,5 @@
 from receipt_layoutlm.trainer import (
+    _add_explanation_metrics,
     _checkpoint_metric_for_available_metrics,
     _checkpoint_metric_for_trainer,
     _epoch_metric_values,
@@ -66,3 +67,26 @@ def test_epoch_metric_values_reads_prefixed_and_unprefixed_keys():
     assert _epoch_metric_values(
         rows, "eval_product_detail_macro_f1"
     ) == [(1.0, 0.2), (2.0, 0.3)]
+
+
+def test_explanation_metrics_always_emit_product_macro_f1():
+    metrics = {}
+
+    _add_explanation_metrics(
+        metrics,
+        [["B-MERCHANT_NAME"]],
+        [["O"]],
+    )
+
+    assert metrics["product_detail_macro_f1"] == 0.0
+
+
+def test_explanation_metrics_average_available_product_label_f1s():
+    metrics = {
+        "label_PRODUCT_NAME_f1": 0.5,
+        "label_QUANTITY_f1": 1.0,
+    }
+
+    _add_explanation_metrics(metrics, [[]], [[]])
+
+    assert metrics["product_detail_macro_f1"] == 0.75

--- a/receipt_layoutlm/tests/unit/test_checkpoint_metric.py
+++ b/receipt_layoutlm/tests/unit/test_checkpoint_metric.py
@@ -1,4 +1,5 @@
 from receipt_layoutlm.trainer import (
+    _checkpoint_metric_for_available_metrics,
     _checkpoint_metric_for_trainer,
     _epoch_metric_values,
     _metric_greater_is_better,
@@ -12,6 +13,28 @@ def test_checkpoint_metric_for_trainer_normalizes_aliases():
         == "eval_product_detail_macro_f1"
     )
     assert _checkpoint_metric_for_trainer("eval_loss") == "eval_loss"
+    assert _checkpoint_metric_for_trainer("accuracy") == "eval_accuracy"
+
+
+def test_checkpoint_metric_fallback_preserves_seqeval_free_metrics():
+    assert (
+        _checkpoint_metric_for_available_metrics(
+            "product_detail_macro_f1", seqeval_available=False
+        )
+        == "eval_accuracy"
+    )
+    assert (
+        _checkpoint_metric_for_available_metrics(
+            "loss", seqeval_available=False
+        )
+        == "eval_loss"
+    )
+    assert (
+        _checkpoint_metric_for_available_metrics(
+            "accuracy", seqeval_available=False
+        )
+        == "eval_accuracy"
+    )
 
 
 def test_metric_greater_is_better_treats_loss_as_lower_better():

--- a/receipt_layoutlm/tests/unit/test_cli.py
+++ b/receipt_layoutlm/tests/unit/test_cli.py
@@ -1,0 +1,44 @@
+from types import SimpleNamespace
+
+from receipt_layoutlm.cli import _resolve_run_s3
+
+
+def test_resolve_run_s3_uses_explicit_uri_and_derives_job_name():
+    run_s3_uri, job_name, bucket, run_prefix = _resolve_run_s3(
+        dyn=object(),
+        run_s3_uri="s3://layoutlm-training/runs/job-123/",
+        job_name=None,
+    )
+
+    assert run_s3_uri == "s3://layoutlm-training/runs/job-123/"
+    assert job_name == "job-123"
+    assert bucket == "layoutlm-training"
+    assert run_prefix == "runs/job-123/"
+
+
+def test_resolve_run_s3_falls_back_to_best_checkpoint_path():
+    class FakeDynamo:
+        def get_job_by_name(self, job_name, limit):
+            assert job_name == "job-123"
+            assert limit == 1
+            return [
+                SimpleNamespace(
+                    results={
+                        "best_checkpoint_s3_path": (
+                            "s3://layoutlm-training/runs/job-123/checkpoint-42/"
+                        )
+                    },
+                    s3_uri_for_prefix=lambda _prefix: None,
+                )
+            ], None
+
+    run_s3_uri, job_name, bucket, run_prefix = _resolve_run_s3(
+        FakeDynamo(),
+        run_s3_uri=None,
+        job_name="job-123",
+    )
+
+    assert run_s3_uri == "s3://layoutlm-training/runs/job-123/"
+    assert job_name == "job-123"
+    assert bucket == "layoutlm-training"
+    assert run_prefix == "runs/job-123/"

--- a/receipt_layoutlm/tests/unit/test_diagnose.py
+++ b/receipt_layoutlm/tests/unit/test_diagnose.py
@@ -1,0 +1,138 @@
+from types import SimpleNamespace
+
+from receipt_layoutlm.diagnose import (
+    _build_evidence_summary,
+    _receipt_features,
+    _summarize_groups,
+    _token_error_rows,
+)
+
+
+def _word(line_id, word_id, text, x0, y0, x1, y1):
+    return SimpleNamespace(
+        image_id="img",
+        receipt_id=1,
+        line_id=line_id,
+        word_id=word_id,
+        text=text,
+        top_left={"x": x0, "y": y1},
+        top_right={"x": x1, "y": y1},
+        bottom_left={"x": x0, "y": y0},
+        bottom_right={"x": x1, "y": y0},
+    )
+
+
+def _label(line_id, word_id, label):
+    return SimpleNamespace(
+        line_id=line_id,
+        word_id=word_id,
+        label=label,
+        validation_status="VALID",
+    )
+
+
+def test_receipt_features_builds_template_from_product_columns():
+    details = SimpleNamespace(
+        receipt=SimpleNamespace(image_id="img", receipt_id=1),
+        place=SimpleNamespace(merchant_name="Vons", place_id="place-1"),
+        lines=[SimpleNamespace(line_id=1), SimpleNamespace(line_id=2)],
+        words=[
+            _word(1, 1, "MILK", 0.1, 0.5, 0.3, 0.55),
+            _word(1, 2, "2.99", 0.8, 0.5, 0.9, 0.55),
+            _word(2, 1, "BREAD", 0.1, 0.4, 0.3, 0.45),
+            _word(2, 2, "3.49", 0.8, 0.4, 0.9, 0.45),
+        ],
+        labels=[
+            _label(1, 1, "PRODUCT_NAME"),
+            _label(1, 2, "LINE_TOTAL"),
+            _label(2, 1, "PRODUCT_NAME"),
+            _label(2, 2, "LINE_TOTAL"),
+        ],
+    )
+
+    features = _receipt_features(details, valid_status="VALID")
+
+    assert features["merchant_name"] == "VONS"
+    assert features["product_name_line_count"] == 2
+    assert features["has_line_total_column"] is True
+    assert "VONS" in features["template_signature"]
+    assert "total:1" in features["line_item_shape"]
+
+
+def test_token_error_rows_classifies_high_confidence_product_false_positive():
+    record = {
+        "original": {
+            "predictions": [
+                {
+                    "line_id": 1,
+                    "word_id": 1,
+                    "text": "Store",
+                    "ground_truth_label": None,
+                    "ground_truth_label_base": None,
+                    "predicted_label": "B-PRODUCT_NAME",
+                    "predicted_label_base": "PRODUCT_NAME",
+                    "predicted_confidence": 0.91,
+                    "is_correct": False,
+                    "all_class_probabilities_base": {
+                        "PRODUCT_NAME": 0.91,
+                        "O": 0.04,
+                    },
+                }
+            ]
+        }
+    }
+    features = {
+        "image_id": "img",
+        "receipt_id": 1,
+        "merchant_name": "VONS",
+        "template_signature": "VONS|shape",
+        "line_item_shape": "shape",
+    }
+
+    errors, summary = _token_error_rows(
+        record, features=features, confidence_threshold=0.75
+    )
+
+    assert errors[0]["error_kind"] == "false_positive"
+    assert errors[0]["product_related"] is True
+    assert summary["high_confidence_product_false_positives"] == 1
+
+
+def test_evidence_summary_compares_seen_and_unseen_slices():
+    rows = [
+        {
+            "merchant_name": "SEEN",
+            "line_item_shape": "shape-a",
+            "merchant_seen_in_training": True,
+            "template_seen_in_training": True,
+            "nearest_template_distance": 0.1,
+            "product_detail_macro_f1": 0.8,
+            "heldout_f1": 0.9,
+            "token_accuracy": 0.95,
+            "product_gold_entities": 4,
+            "product_predicted_entities": 4,
+            "incorrect_token_count": 1,
+            "high_confidence_product_false_positives": 0,
+        },
+        {
+            "merchant_name": "UNSEEN",
+            "line_item_shape": "shape-b",
+            "merchant_seen_in_training": False,
+            "template_seen_in_training": False,
+            "nearest_template_distance": 0.9,
+            "product_detail_macro_f1": 0.2,
+            "heldout_f1": 0.4,
+            "token_accuracy": 0.8,
+            "product_gold_entities": 4,
+            "product_predicted_entities": 2,
+            "incorrect_token_count": 5,
+            "high_confidence_product_false_positives": 2,
+        },
+    ]
+
+    evidence = _build_evidence_summary(rows, token_errors=[])
+    groups = _summarize_groups(rows, "merchant_seen_in_training")
+
+    assert evidence["template_coverage"]["seen_merchant_avg_product_macro_f1"] == 0.8
+    assert evidence["template_coverage"]["unseen_merchant_avg_product_macro_f1"] == 0.2
+    assert groups[0]["group"] == "False"

--- a/receipt_layoutlm/tests/unit/test_diagnose.py
+++ b/receipt_layoutlm/tests/unit/test_diagnose.py
@@ -4,10 +4,12 @@ from receipt_layoutlm.diagnose import (
     _build_data_targeting,
     _build_train_context,
     _build_evidence_summary,
+    _nearest_train_template,
     _product_false_positive_review,
     _receipt_features,
     _resolve_val_receipts,
     _summarize_groups,
+    _template_distance,
     _token_error_rows,
 )
 
@@ -219,6 +221,82 @@ def test_build_train_context_excludes_full_validation_split():
     assert [feature["receipt_key"] for feature in context["features"]] == [
         "train#00001"
     ]
+
+
+def test_build_train_context_max_receipts_uses_deterministic_sample():
+    def details_for(image_id, receipt_id):
+        return SimpleNamespace(
+            receipt=SimpleNamespace(image_id=image_id, receipt_id=receipt_id),
+            place=SimpleNamespace(merchant_name=f"merchant-{image_id}"),
+            lines=[],
+            words=[],
+            labels=[],
+        )
+
+    class FakeDynamo:
+        def list_receipt_word_labels_with_status(self, *_args, **_kwargs):
+            labels = [
+                SimpleNamespace(image_id=f"img-{suffix}", receipt_id=1)
+                for suffix in ["a", "b", "c", "d", "e"]
+            ]
+            return labels, None
+
+        def get_receipt_details(self, image_id, receipt_id):
+            return details_for(image_id, receipt_id)
+
+    context = _build_train_context(
+        FakeDynamo(),
+        [],
+        split_meta={},
+        valid_status="VALID",
+        max_receipts=2,
+    )
+
+    assert [feature["receipt_key"] for feature in context["features"]] == [
+        "img-d#00001",
+        "img-e#00001",
+    ]
+
+
+def test_template_distance_applies_merchant_mismatch_penalty():
+    target = {"merchant_key": "VONS", "template_vector": [0.0, 0.0]}
+    same_merchant_near = {"merchant_key": "VONS", "template_vector": [0.5, 0.0]}
+    other_merchant_same_vector = {
+        "merchant_key": "TARGET",
+        "template_vector": [0.0, 0.0],
+    }
+
+    assert _template_distance(target, same_merchant_near) == 0.5
+    assert _template_distance(target, other_merchant_same_vector) == 0.75
+    assert _template_distance(target, same_merchant_near) < _template_distance(
+        target, other_merchant_same_vector
+    )
+
+
+def test_nearest_train_template_returns_closest_candidate_with_rounded_distance():
+    target = {"merchant_key": "VONS", "template_vector": [0.0, 0.0]}
+    train_features = [
+        {
+            "merchant_key": "TARGET",
+            "template_vector": [0.0, 0.0],
+            "receipt_key": "target#00001",
+            "merchant_name": "TARGET",
+        },
+        {
+            "merchant_key": "VONS",
+            "template_vector": [0.333333, 0.0],
+            "receipt_key": "vons#00001",
+            "merchant_name": "VONS",
+        },
+    ]
+
+    nearest = _nearest_train_template(target, train_features)
+
+    assert nearest == {
+        "distance": 0.3333,
+        "receipt_key": "vons#00001",
+        "merchant_name": "VONS",
+    }
 
 
 def test_evidence_summary_compares_seen_and_unseen_slices():

--- a/receipt_layoutlm/tests/unit/test_diagnose.py
+++ b/receipt_layoutlm/tests/unit/test_diagnose.py
@@ -1,8 +1,10 @@
 from types import SimpleNamespace
 
 from receipt_layoutlm.diagnose import (
+    _build_train_context,
     _build_evidence_summary,
     _receipt_features,
+    _resolve_val_receipts,
     _summarize_groups,
     _token_error_rows,
 )
@@ -59,6 +61,27 @@ def test_receipt_features_builds_template_from_product_columns():
     assert "total:1" in features["line_item_shape"]
 
 
+def test_receipt_features_uses_labeled_merchant_text_without_place():
+    details = SimpleNamespace(
+        receipt=SimpleNamespace(image_id="img", receipt_id=1),
+        place=None,
+        lines=[SimpleNamespace(line_id=1)],
+        words=[
+            _word(1, 1, "Acme", 0.1, 0.5, 0.2, 0.55),
+            _word(1, 2, "Market", 0.2, 0.5, 0.35, 0.55),
+        ],
+        labels=[
+            _label(1, 1, "MERCHANT_NAME"),
+            _label(1, 2, "I-MERCHANT_NAME"),
+        ],
+    )
+
+    features = _receipt_features(details, valid_status="VALID")
+
+    assert features["merchant_name"] == "ACME MARKET"
+    assert features["merchant_key"] == "ACME_MARKET"
+
+
 def test_token_error_rows_classifies_high_confidence_product_false_positive():
     record = {
         "original": {
@@ -71,7 +94,7 @@ def test_token_error_rows_classifies_high_confidence_product_false_positive():
                     "ground_truth_label_base": None,
                     "predicted_label": "B-PRODUCT_NAME",
                     "predicted_label_base": "PRODUCT_NAME",
-                    "predicted_confidence": 0.91,
+                    "predicted_confidence": 0.41,
                     "is_correct": False,
                     "all_class_probabilities_base": {
                         "PRODUCT_NAME": 0.91,
@@ -95,7 +118,60 @@ def test_token_error_rows_classifies_high_confidence_product_false_positive():
 
     assert errors[0]["error_kind"] == "false_positive"
     assert errors[0]["product_related"] is True
+    assert errors[0]["confidence"] == 0.91
+    assert errors[0]["bio_confidence"] == 0.41
     assert summary["high_confidence_product_false_positives"] == 1
+
+
+def test_resolve_val_receipts_rejects_persisted_hash_mismatch():
+    try:
+        _resolve_val_receipts(
+            dynamo=object(),
+            split_meta={"val_receipt_keys": ["img#00001"]},
+            recorded_hash="wrong",
+            recorded_seed=1,
+            allow_hash_mismatch=False,
+        )
+    except ValueError as exc:
+        assert "Validation hash mismatch" in str(exc)
+    else:
+        raise AssertionError("expected hash mismatch to raise")
+
+
+def test_build_train_context_excludes_full_validation_split():
+    def details_for(image_id, receipt_id):
+        return SimpleNamespace(
+            receipt=SimpleNamespace(image_id=image_id, receipt_id=receipt_id),
+            place=SimpleNamespace(merchant_name=f"merchant-{image_id}"),
+            lines=[],
+            words=[],
+            labels=[],
+        )
+
+    class FakeDynamo:
+        def list_receipt_word_labels_with_status(self, *_args, **_kwargs):
+            labels = [
+                SimpleNamespace(image_id="val-a", receipt_id=1),
+                SimpleNamespace(image_id="val-b", receipt_id=1),
+                SimpleNamespace(image_id="train", receipt_id=1),
+            ]
+            return labels, None
+
+        def get_receipt_details(self, image_id, receipt_id):
+            return details_for(image_id, receipt_id)
+
+    context = _build_train_context(
+        FakeDynamo(),
+        [("val-a", 1), ("val-b", 1)],
+        split_meta={},
+        valid_status="VALID",
+    )
+
+    assert context["source"] == "current_VALID_corpus_minus_full_validation_split"
+    assert context["is_training_snapshot"] is False
+    assert [feature["receipt_key"] for feature in context["features"]] == [
+        "train#00001"
+    ]
 
 
 def test_evidence_summary_compares_seen_and_unseen_slices():
@@ -103,8 +179,10 @@ def test_evidence_summary_compares_seen_and_unseen_slices():
         {
             "merchant_name": "SEEN",
             "line_item_shape": "shape-a",
-            "merchant_seen_in_training": True,
-            "template_seen_in_training": True,
+            "merchant_seen_in_context": True,
+            "template_seen_in_context": True,
+            "context_source": "current_VALID_corpus_minus_full_validation_split",
+            "context_is_training_snapshot": False,
             "nearest_template_distance": 0.1,
             "product_detail_macro_f1": 0.8,
             "heldout_f1": 0.9,
@@ -117,8 +195,10 @@ def test_evidence_summary_compares_seen_and_unseen_slices():
         {
             "merchant_name": "UNSEEN",
             "line_item_shape": "shape-b",
-            "merchant_seen_in_training": False,
-            "template_seen_in_training": False,
+            "merchant_seen_in_context": False,
+            "template_seen_in_context": False,
+            "context_source": "current_VALID_corpus_minus_full_validation_split",
+            "context_is_training_snapshot": False,
             "nearest_template_distance": 0.9,
             "product_detail_macro_f1": 0.2,
             "heldout_f1": 0.4,
@@ -131,8 +211,9 @@ def test_evidence_summary_compares_seen_and_unseen_slices():
     ]
 
     evidence = _build_evidence_summary(rows, token_errors=[])
-    groups = _summarize_groups(rows, "merchant_seen_in_training")
+    groups = _summarize_groups(rows, "merchant_seen_in_context")
 
     assert evidence["template_coverage"]["seen_merchant_avg_product_macro_f1"] == 0.8
     assert evidence["template_coverage"]["unseen_merchant_avg_product_macro_f1"] == 0.2
+    assert evidence["template_coverage"]["context_is_training_snapshot"] is False
     assert groups[0]["group"] == "False"

--- a/receipt_layoutlm/tests/unit/test_diagnose.py
+++ b/receipt_layoutlm/tests/unit/test_diagnose.py
@@ -1,8 +1,10 @@
 from types import SimpleNamespace
 
 from receipt_layoutlm.diagnose import (
+    _build_data_targeting,
     _build_train_context,
     _build_evidence_summary,
+    _product_false_positive_review,
     _receipt_features,
     _resolve_val_receipts,
     _summarize_groups,
@@ -120,7 +122,32 @@ def test_token_error_rows_classifies_high_confidence_product_false_positive():
     assert errors[0]["product_related"] is True
     assert errors[0]["confidence"] == 0.91
     assert errors[0]["bio_confidence"] == 0.41
+    assert errors[0]["product_fp_review_bucket"] == "likely_unlabeled_product_text"
+    assert errors[0]["product_fp_contract_action"] == "audit_gold_or_add_coverage"
     assert summary["high_confidence_product_false_positives"] == 1
+    assert summary[
+        "high_confidence_product_false_positive_review_bucket_counts"
+    ] == {"likely_unlabeled_product_text": 1}
+
+
+def test_product_false_positive_review_separates_adjustments_and_amounts():
+    adjustment = _product_false_positive_review(
+        gold="O",
+        guessed="PRODUCT_NAME",
+        text="REFUND",
+        error_kind="false_positive",
+    )
+    amount = _product_false_positive_review(
+        gold="O",
+        guessed="LINE_TOTAL",
+        text="12.96",
+        error_kind="false_positive",
+    )
+
+    assert adjustment["bucket"] == "adjustment_or_fee_term"
+    assert adjustment["contract_action"] == "confirm_adjustment_not_product"
+    assert amount["bucket"] == "numeric_amount_overprediction"
+    assert amount["contract_action"] == "review_amount_column_contract"
 
 
 def test_resolve_val_receipts_rejects_persisted_hash_mismatch():
@@ -217,3 +244,53 @@ def test_evidence_summary_compares_seen_and_unseen_slices():
     assert evidence["template_coverage"]["unseen_merchant_avg_product_macro_f1"] == 0.2
     assert evidence["template_coverage"]["context_is_training_snapshot"] is False
     assert groups[0]["group"] == "False"
+
+
+def test_data_targeting_prioritizes_structure_and_contract_queue():
+    rows = [
+        {
+            "receipt_key": "img-a#00001",
+            "merchant_name": "HOME DEPOT",
+            "line_item_shape": "items:20-39|qty:1|unit:0|total:0",
+            "product_detail_macro_f1": 0.1,
+            "has_line_total_column": False,
+            "product_name_line_count": 22,
+        },
+        {
+            "receipt_key": "img-b#00001",
+            "merchant_name": "VONS",
+            "line_item_shape": "items:1-4|qty:0|unit:0|total:1",
+            "product_detail_macro_f1": 0.7,
+            "has_line_total_column": True,
+            "product_name_line_count": 2,
+        },
+    ]
+    token_errors = [
+        {
+            "receipt_key": "img-a#00001",
+            "merchant_name": "HOME DEPOT",
+            "line_item_shape": "items:20-39|qty:1|unit:0|total:0",
+            "error_kind": "false_positive",
+            "high_confidence": True,
+            "predicted_label_base": "PRODUCT_NAME",
+            "product_fp_review_bucket": "likely_unlabeled_product_text",
+        },
+        {
+            "receipt_key": "img-a#00001",
+            "merchant_name": "HOME DEPOT",
+            "line_item_shape": "items:20-39|qty:1|unit:0|total:0",
+            "error_kind": "false_positive",
+            "high_confidence": True,
+            "predicted_label_base": "LINE_TOTAL",
+            "product_fp_review_bucket": "numeric_amount_overprediction",
+        },
+    ]
+
+    targets = _build_data_targeting(rows, token_errors)
+
+    assert targets["priority_merchant_templates"][0]["merchant_name"] == "HOME DEPOT"
+    assert targets["structural_gaps"]["no_line_total_layouts"]["receipt_count"] == 1
+    assert targets["structural_gaps"]["long_item_tables"]["receipt_count"] == 1
+    assert targets["label_contract_queue"][
+        "likely_unlabeled_product_text_tokens"
+    ] == 1

--- a/receipt_layoutlm/tests/unit/test_diagnose.py
+++ b/receipt_layoutlm/tests/unit/test_diagnose.py
@@ -91,7 +91,7 @@ def test_token_error_rows_classifies_high_confidence_product_false_positive():
                 {
                     "line_id": 1,
                     "word_id": 1,
-                    "text": "Store",
+                    "text": "Bacon",
                     "ground_truth_label": None,
                     "ground_truth_label_base": None,
                     "predicted_label": "B-PRODUCT_NAME",
@@ -148,6 +148,26 @@ def test_product_false_positive_review_separates_adjustments_and_amounts():
     assert adjustment["contract_action"] == "confirm_adjustment_not_product"
     assert amount["bucket"] == "numeric_amount_overprediction"
     assert amount["contract_action"] == "review_amount_column_contract"
+
+
+def test_product_false_positive_review_keeps_codes_and_meta_out_of_product_text():
+    code = _product_false_positive_review(
+        gold="O",
+        guessed="PRODUCT_NAME",
+        text="HDX-123",
+        error_kind="false_positive",
+    )
+    meta = _product_false_positive_review(
+        gold="O",
+        guessed="PRODUCT_NAME",
+        text="APPROVED",
+        error_kind="false_positive",
+    )
+
+    assert code["bucket"] == "product_name_numeric_or_code"
+    assert code["contract_action"] == "audit_sku_or_amount_boundary"
+    assert meta["bucket"] == "receipt_meta_term"
+    assert meta["contract_action"] == "keep_outside_product_contract"
 
 
 def test_resolve_val_receipts_rejects_persisted_hash_mismatch():
@@ -251,6 +271,7 @@ def test_data_targeting_prioritizes_structure_and_contract_queue():
         {
             "receipt_key": "img-a#00001",
             "merchant_name": "HOME DEPOT",
+            "template_signature": "HOME_DEPOT|lines:40+|shape-a",
             "line_item_shape": "items:20-39|qty:1|unit:0|total:0",
             "product_detail_macro_f1": 0.1,
             "has_line_total_column": False,
@@ -259,16 +280,27 @@ def test_data_targeting_prioritizes_structure_and_contract_queue():
         {
             "receipt_key": "img-b#00001",
             "merchant_name": "VONS",
+            "template_signature": "VONS|lines:1-4|shape-b",
             "line_item_shape": "items:1-4|qty:0|unit:0|total:1",
             "product_detail_macro_f1": 0.7,
             "has_line_total_column": True,
             "product_name_line_count": 2,
+        },
+        {
+            "receipt_key": "img-c#00001",
+            "merchant_name": "VONS",
+            "template_signature": "VONS|lines:40+|shape-c",
+            "line_item_shape": "items:1-4|qty:0|unit:0|total:1",
+            "product_detail_macro_f1": 0.0,
+            "has_line_total_column": True,
+            "product_name_line_count": 1,
         },
     ]
     token_errors = [
         {
             "receipt_key": "img-a#00001",
             "merchant_name": "HOME DEPOT",
+            "template_signature": "HOME_DEPOT|lines:40+|shape-a",
             "line_item_shape": "items:20-39|qty:1|unit:0|total:0",
             "error_kind": "false_positive",
             "high_confidence": True,
@@ -278,6 +310,7 @@ def test_data_targeting_prioritizes_structure_and_contract_queue():
         {
             "receipt_key": "img-a#00001",
             "merchant_name": "HOME DEPOT",
+            "template_signature": "HOME_DEPOT|lines:40+|shape-a",
             "line_item_shape": "items:20-39|qty:1|unit:0|total:0",
             "error_kind": "false_positive",
             "high_confidence": True,
@@ -288,7 +321,12 @@ def test_data_targeting_prioritizes_structure_and_contract_queue():
 
     targets = _build_data_targeting(rows, token_errors)
 
-    assert targets["priority_merchant_templates"][0]["merchant_name"] == "HOME DEPOT"
+    assert targets["priority_merchant_templates"][0]["template_signature"] == (
+        "VONS|lines:40+|shape-c"
+    )
+    assert targets["priority_merchant_templates"][1]["template_signature"] == (
+        "HOME_DEPOT|lines:40+|shape-a"
+    )
     assert targets["structural_gaps"]["no_line_total_layouts"]["receipt_count"] == 1
     assert targets["structural_gaps"]["long_item_tables"]["receipt_count"] == 1
     assert targets["label_contract_queue"][

--- a/receipt_layoutlm/tests/unit/test_evaluation_diagnostics.py
+++ b/receipt_layoutlm/tests/unit/test_evaluation_diagnostics.py
@@ -1,0 +1,37 @@
+from receipt_layoutlm.evaluate_checkpoints import _evaluation_diagnostics
+
+
+def test_evaluation_diagnostics_explains_prediction_balance():
+    diagnostics = _evaluation_diagnostics(
+        [
+            ["B-PRODUCT_NAME", "I-PRODUCT_NAME", "B-LINE_TOTAL", "O"],
+            ["B-QUANTITY", "B-UNIT_PRICE"],
+        ],
+        [
+            ["B-PRODUCT_NAME", "O", "B-SUBTOTAL", "O"],
+            ["B-QUANTITY", "B-UNIT_PRICE"],
+        ],
+        per_label_f1={
+            "PRODUCT_NAME": 0.5,
+            "QUANTITY": 1.0,
+            "UNIT_PRICE": 1.0,
+            "LINE_TOTAL": 0.0,
+        },
+    )
+
+    assert diagnostics["token_counts"]["total"] == 6
+    assert diagnostics["token_counts"]["gold_entity"] == 5
+    assert diagnostics["token_counts"]["predicted_entity"] == 4
+    assert diagnostics["rates"]["gold_entity_token_rate"] == 5 / 6
+    assert diagnostics["rates"]["predicted_entity_token_rate"] == 4 / 6
+    assert diagnostics["product_detail"]["macro_f1"] == 0.625
+    assert diagnostics["per_label_entity_counts"]["PRODUCT_NAME"] == {
+        "gold_entities": 1,
+        "predicted_entities": 1,
+        "prediction_gold_ratio": 1.0,
+    }
+    assert {
+        "gold": "LINE_TOTAL",
+        "predicted": "SUBTOTAL",
+        "count": 1,
+    } in diagnostics["top_token_confusions"]

--- a/receipt_layoutlm/tests/unit/test_receipt_window_examples.py
+++ b/receipt_layoutlm/tests/unit/test_receipt_window_examples.py
@@ -5,6 +5,7 @@ import pytest
 from receipt_layoutlm.data_loader import (
     WordInfo,
     _build_receipt_window_examples,
+    _crop_to_line_item_band,
 )
 
 
@@ -176,3 +177,66 @@ def test_reading_order_sort_top_to_bottom_left_to_right():
         [w_bottom, w_top_right, w_top_left], "k"
     )
     assert out[0].tokens == ["a", "b", "c"]
+
+
+def test_crop_to_line_item_band_keeps_product_rows_between_anchors():
+    words = [
+        WordInfo(
+            word_id=0,
+            text="STORE",
+            bbox=[0, 0, 50, 10],
+            label="MERCHANT_NAME",
+            original_label="MERCHANT_NAME",
+            line_id=1,
+            image_id="img1",
+            receipt_id=1,
+        ),
+        WordInfo(
+            word_id=1,
+            text="555-1111",
+            bbox=[0, 20, 50, 30],
+            label="PHONE_NUMBER",
+            original_label="PHONE_NUMBER",
+            line_id=2,
+            image_id="img1",
+            receipt_id=1,
+        ),
+        WordInfo(
+            word_id=2,
+            text="MILK",
+            bbox=[0, 40, 50, 50],
+            label="PRODUCT_NAME",
+            original_label="PRODUCT_NAME",
+            line_id=3,
+            image_id="img1",
+            receipt_id=1,
+        ),
+        WordInfo(
+            word_id=3,
+            text="$4.29",
+            bbox=[80, 40, 100, 50],
+            label="LINE_TOTAL",
+            original_label="LINE_TOTAL",
+            line_id=3,
+            image_id="img1",
+            receipt_id=1,
+        ),
+        WordInfo(
+            word_id=4,
+            text="TOTAL",
+            bbox=[0, 80, 50, 90],
+            label="GRAND_TOTAL",
+            original_label="GRAND_TOTAL",
+            line_id=4,
+            image_id="img1",
+            receipt_id=1,
+        ),
+    ]
+    label_map = {
+        ("img1", 1, word.line_id, word.word_id): [word.original_label]
+        for word in words
+    }
+
+    out = _crop_to_line_item_band(words, label_map, "img1", 1)
+
+    assert [word.text for word in out] == ["MILK", "$4.29"]

--- a/receipt_layoutlm/tests/unit/test_receipt_window_examples.py
+++ b/receipt_layoutlm/tests/unit/test_receipt_window_examples.py
@@ -6,6 +6,7 @@ from receipt_layoutlm.data_loader import (
     WordInfo,
     _build_receipt_window_examples,
     _crop_to_line_item_band,
+    _env_positive_int,
 )
 
 
@@ -240,3 +241,10 @@ def test_crop_to_line_item_band_keeps_product_rows_between_anchors():
     out = _crop_to_line_item_band(words, label_map, "img1", 1)
 
     assert [word.text for word in out] == ["MILK", "$4.29"]
+
+
+@pytest.mark.parametrize("bad_value", ["not-an-int", "0", "-4"])
+def test_env_positive_int_falls_back_for_bad_values(monkeypatch, bad_value):
+    monkeypatch.setenv("LAYOUTLM_ITEM_WINDOW_SIZE", bad_value)
+
+    assert _env_positive_int("LAYOUTLM_ITEM_WINDOW_SIZE", 200) == 200

--- a/receipt_layoutlm/tests/unit/test_sagemaker_train_command.py
+++ b/receipt_layoutlm/tests/unit/test_sagemaker_train_command.py
@@ -1,0 +1,69 @@
+from infra.sagemaker_training.train import build_train_command
+
+
+def test_build_train_command_maps_item_window_augmentation():
+    cmd = build_train_command(
+        {
+            "job_name": "layoutlm-item-window",
+            "dynamo_table": "ReceiptsTable-test",
+            "item_window_augmentation": "true",
+            "item_window_size": 96,
+            "item_window_stride": 48,
+        }
+    )
+
+    assert "--item-window-augment" in cmd
+    assert cmd[cmd.index("--item-window-size") + 1] == "96"
+    assert cmd[cmd.index("--item-window-stride") + 1] == "48"
+
+
+def test_build_train_command_supports_item_window_augment_alias():
+    cmd = build_train_command(
+        {
+            "job_name": "layoutlm-item-window",
+            "dynamo_table": "ReceiptsTable-test",
+            "item_window_augment": True,
+        }
+    )
+
+    assert "--item-window-augment" in cmd
+
+
+def test_build_train_command_maps_checkpoint_metric():
+    cmd = build_train_command(
+        {
+            "job_name": "layoutlm-product-metric",
+            "dynamo_table": "ReceiptsTable-test",
+            "checkpoint_metric": "product_detail_macro_f1",
+        }
+    )
+
+    assert cmd[cmd.index("--checkpoint-metric") + 1] == (
+        "product_detail_macro_f1"
+    )
+
+
+def test_build_train_command_supports_metric_for_best_model_alias():
+    cmd = build_train_command(
+        {
+            "job_name": "layoutlm-product-metric",
+            "dynamo_table": "ReceiptsTable-test",
+            "metric_for_best_model": "product_detail_macro_f1",
+        }
+    )
+
+    assert cmd[cmd.index("--checkpoint-metric") + 1] == (
+        "product_detail_macro_f1"
+    )
+
+
+def test_build_train_command_maps_product_detail_loss_weight():
+    cmd = build_train_command(
+        {
+            "job_name": "layoutlm-product-weight",
+            "dynamo_table": "ReceiptsTable-test",
+            "product_detail_loss_weight": "1.5",
+        }
+    )
+
+    assert cmd[cmd.index("--product-detail-loss-weight") + 1] == "1.5"


### PR DESCRIPTION
## What changed

- Adds `layoutlm-cli diagnose-run`, a proof-oriented diagnostic harness for a selected LayoutLM checkpoint.
- Emits `summary.json`, `report.md`, `per_receipt.csv/jsonl`, `groups.json`, and `token_errors.jsonl` for frozen validation runs.
- Adds evidence slices for merchant/template coverage, nearest-template distance, line-item structure, label/eval mismatch, and model uncertainty.
- Wires item-window/product-detail training and checkpoint metrics into the docs and tests from the current LayoutLM investigation.
- Updates LayoutLM docs with the completed v28/v29 results and the next recommended plan.

## Why

The latest v29 ablations did not beat v28 on first-pass product details. We need a way to prove whether the bottleneck is template coverage, line-item structure, label/eval mismatch, or actual model weakness before launching more training jobs.

## Current evidence

- v28 product-detail macro F1: `0.3900`; v29 weighted: `0.3536`.
- Seen merchants beat unseen merchants on product F1.
- Product F1 drops as nearest-template distance rises.
- Receipts without `LINE_TOTAL` columns and long item tables are weak slices.
- High-confidence product false positives suggest possible label/eval contract issues worth reviewing.

## Validation

- `PYTHONPATH=/Users/tnorlund/Portfolio/receipt_layoutlm:/Users/tnorlund/Portfolio python -m pytest receipt_layoutlm/tests/unit/test_diagnose.py receipt_layoutlm/tests/unit/test_checkpoint_metric.py receipt_layoutlm/tests/unit/test_sagemaker_train_command.py receipt_layoutlm/tests/unit/test_evaluation_diagnostics.py receipt_layoutlm/tests/unit/test_receipt_window_examples.py`
- `python -m py_compile receipt_layoutlm/receipt_layoutlm/diagnose.py receipt_layoutlm/receipt_layoutlm/cli.py receipt_layoutlm/receipt_layoutlm/trainer.py receipt_layoutlm/receipt_layoutlm/evaluate_checkpoints.py`
- `git diff --check origin/main...HEAD`
- Rebuilt dev image and ran SageMaker diagnostics:
  - `s3://layoutlm-training-dev-68164770/diagnostics/layoutlm-diag-v28-item-window-v2-cpu-20260709174453/`
  - `s3://layoutlm-training-dev-68164770/diagnostics/layoutlm-diag-v29-weighted-v2-cpu-20260709174453/`

## Review request for Codex

Please give this a thorough review before we build on it. Focus especially on:

- whether `diagnose_run` reconstructs and scores the frozen validation split correctly;
- whether train-context/template-distance logic could leak validation data or misclassify seen/unseen templates;
- whether token error classification and confidence reporting match the inference output schema;
- whether the docs overstate the evidence from the current v28/v29 diagnostics;
- whether the next plan is supported: review high-confidence product false positives, tighten the product label/eval contract, then synthesize or add real receipts for missing merchant templates, long item tables, and no-line-total layouts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added richer training options for checkpoint selection, product-detail weighting, and item-window augmentation.
  * Introduced a new run-diagnostics command with downloadable reports and artifact summaries.
  * Expanded evaluation outputs with per-label scores, held-out diagnostics, and product-detail metrics.

* **Documentation**
  * Reworked LayoutLM guides with updated training, evaluation, metrics, and troubleshooting instructions.

* **Bug Fixes**
  * Improved best-checkpoint selection and early-stopping behavior to follow the chosen evaluation metric.
  * Added clearer handling for validation splits, score reporting, and diagnostic edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->