### PR TITLE
docs+eval(glyphstudio): M3 findings — pixel-space family pooling refuted (epic amendment)

### DIFF
--- a/tools/glyph-studio/FONT_INTELLIGENCE_EPIC.md
+++ b/tools/glyph-studio/FONT_INTELLIGENCE_EPIC.md
@@ -190,10 +190,21 @@ unchanged — family fonts are *fitted skeletons*, never copied crops).
   the `(merchant, section) → (family, face)` map with confidence scores;
   cluster count and IoU-style separation reported; Costco isolates as its own
   family (known-answer check).
-- **M3 — Pooled family font (Font A pilot).** Hierarchical skeleton fit for
-  the largest family; compile regular + bold faces. *Exit:* diagonal-glyph A/B
-  beats every constituent merchant's current atlas; passes the anti-copy gate
-  and the 94/94 coverage gate.
+- **M3 — Pooled family font (Font A pilot). ⚠ AMENDED — see M3_FINDINGS.md.**
+  Measured 2026-07-09: pixel-space cross-merchant pooling **fails both epic
+  criteria** — the pooled railed-family atlas is *denser* than the solo
+  atlases (WF 0.335→0.404, Costco 0.308→0.402 vs targets 0.135/0.187; both
+  still ceiling-railed) and every hard diagonal's consensus *blurs* (W −0.163
+  … M −0.043) despite 2–17× the samples. Root cause: the merchant printer
+  offset is signal, not noise — median-voting across letterforms adds edge
+  ink. Pooling survives only for **coverage** (+5 glyphs, rare-glyph recovery,
+  M6 cold start). Revised M3: (a) **density-calibrated minting per merchant**
+  (derive the mint's vote/erosion against the measured real density with the
+  v1 cheap measurer — "re-mint lighter", derived instead of eyeballed);
+  (b) diagonals via **family-level handcraft** (one skeleton set per family,
+  reused across members). *Exit (unchanged in spirit):* the railed merchants
+  come off the rails on the standing harness `py/m3_acceptance.py`; anti-copy
+  + coverage gates hold.
 - **M4 — Multi-face rendering.** Renderer reads the map; per-word face
   stamping. *Exit:* a Costco receipt renders bold totals + regular body from
   family fonts and the production scorecard is in-gate (h/wpc/density within

--- a/tools/glyph-studio/FONT_INTELLIGENCE_EPIC.md
+++ b/tools/glyph-studio/FONT_INTELLIGENCE_EPIC.md
@@ -204,7 +204,14 @@ unchanged — family fonts are *fitted skeletons*, never copied crops).
   (b) diagonals via **family-level handcraft** (one skeleton set per family,
   reused across members). *Exit (unchanged in spirit):* the railed merchants
   come off the rails on the standing harness `py/m3_acceptance.py`; anti-copy
-  + coverage gates hold.
+  + coverage gates hold. **Validated same day** (M3_FINDINGS.md addendum):
+  skeleton-protected stroke normalization un-rails BOTH railed merchants (WF
+  interior thin 0.333, density 0.137 vs 0.135; Costco interior 0.333, 0.200
+  vs 0.187; full coverage), and the derived parametric weight (WF `1.4 →
+  0.60`, closed-form from stylescan stroke/cap) lands 0.99× target in one
+  step. Root causes differ (WF stroke-width, Costco shape-driven) — the
+  density-targeted bisection is the general form. Visual A/B still required
+  before adoption.
 - **M4 — Multi-face rendering.** Renderer reads the map; per-word face
   stamping. *Exit:* a Costco receipt renders bold totals + regular body from
   family fonts and the production scorecard is in-gate (h/wpc/density within

--- a/tools/glyph-studio/M3_FINDINGS.md
+++ b/tools/glyph-studio/M3_FINDINGS.md
@@ -119,11 +119,13 @@ epic-mandated visual A/B before any profile adoption).
 The shipped fonts are parametric stroke skeletons whose raster ink is exactly
 `stroke_px ≈ dot.size × weight × cap/1000` — Wild Fork's hand-set
 `weight: 1.4` reproduces the measured 6px atlas stroke, and the derived value
-is `weight = stroke_ratio × 1000 / dot.size ≈ 0.60`. **Validated:** compiling
+is `weight = stroke_ratio × 1000 / dot.size ≈ 0.60`. **Validated end-to-end:** compiling
 `fonts/wildfork` at the derived `weight 0.60` lands projected density
-**0.134 vs target 0.135** (0.99×, from 2.5× over — one closed-form step),
-though at erosion saturation; the production loop adds one bisection step on
-weight for interior headroom. Because Costco shows the excess can be
+**0.134 vs target 0.135** (0.99×, from 2.5× over — one closed-form step) at
+erosion saturation, and one bisection step lower (`weight 0.50`) gives
+**thin 0.333 interior, density 0.135 — exactly on target — coverage 0.999**.
+The production fix for Wild Fork is a one-line `font.json` change, fully
+derived from measurements. Because Costco shows the excess can be
 shape-driven rather than stroke-driven, the **general derivation targets
 density, not stroke**: bisect the mint-side ink parameter (`weight`, or
 skeleton-protected erosion for crop-minted atlases) against the measured

--- a/tools/glyph-studio/M3_FINDINGS.md
+++ b/tools/glyph-studio/M3_FINDINGS.md
@@ -82,6 +82,64 @@ evidence" treated the offset as removable noise; it is signal.
    `(merchant, section) → (family, face)` map (M2, shipped) and does not
    depend on pooled atlases.
 
+## Addendum (same day) — the replacement mechanism VALIDATED: acceptance PASS
+
+Following the refutation, the density mechanism was isolated and the fix
+passes the standing harness on **both** railed merchants.
+
+### Diagnosis: two root causes, one cure
+
+| merchant | real stroke/cap | shipped atlas stroke/cap | root cause |
+|---|--:|--:|---|
+| Wild Fork | **0.044** (4.1px @ 92px caps) | 0.100 | strokes **2.25× too wide** — mint-pipeline fattening (±3px jitter + VOTE 0.45 on the soft consensus skirts every edge; the crops themselves carry the true width) |
+| Costco | **0.106** | 0.100 (already correct) | shape/coverage-driven excess (blocky chart-derived letterforms; renders tall) — **not** stroke width |
+
+The chessboard effect explains why nothing else worked: hard-threshold
+thinning (the VOTE sweep) fragments strokes before reaching target
+(coverage 0.999→0.597), and render-time `bitmap_thin` saturates. The fix
+thins in **distance space**: peel boundary pixels but never remove the
+`zhang_suen` skeleton — strokes thin without ever fragmenting.
+
+### Result — skeleton-protected stroke normalization, scored by the harness
+
+| merchant | candidate | thin | verdict | density vs target | coverage |
+|---|---|--:|---|---|--:|
+| Wild Fork | solo shipped | 0.5 | CEILING-RAILED | 0.335 / 0.135 | 0.999 |
+| Wild Fork | **erode2 (2px)** | **0.333** | **interior** | **0.137 / 0.135** | **0.999** |
+| Costco | solo shipped | 0.5 | CEILING-RAILED | 0.308 / 0.187 | 1.000 |
+| Costco | **erode1 (4px)** | **0.333** | **interior** | **0.200 / 0.187** | **1.000** |
+
+Coarse mint-side normalization brings density in range; v1's `bitmap_thin`
+then fine-tunes from the interior — the compose-with-v1 design working as
+intended. **This is the epic's acceptance criterion, met** (pending the
+epic-mandated visual A/B before any profile adoption).
+
+### Production form
+
+The shipped fonts are parametric stroke skeletons whose raster ink is exactly
+`stroke_px ≈ dot.size × weight × cap/1000` — Wild Fork's hand-set
+`weight: 1.4` reproduces the measured 6px atlas stroke, and the derived value
+is `weight = stroke_ratio × 1000 / dot.size ≈ 0.60`. **Validated:** compiling
+`fonts/wildfork` at the derived `weight 0.60` lands projected density
+**0.134 vs target 0.135** (0.99×, from 2.5× over — one closed-form step),
+though at erosion saturation; the production loop adds one bisection step on
+weight for interior headroom. Because Costco shows the excess can be
+shape-driven rather than stroke-driven, the **general derivation targets
+density, not stroke**: bisect the mint-side ink parameter (`weight`, or
+skeleton-protected erosion for crop-minted atlases) against the measured
+per-word density target using v1's render-free cheap measurer. Stroke/cap
+(stylescan `stroke_med`) is the *diagnostic* that says which root cause you
+have.
+
+### SDF-consensus mint (continuous-space idea): promising, not yet fairly tested
+
+A first prototype (chamfer SDFs, sub-pixel alignment, derived threshold)
+scored poorly (density 0.842) — but it averaged **raw, unfiltered** sample
+stacks, skipping the production mint's inlier selection (IoU-ranked top-32).
+That confounds the comparison; the concept (fixes fattening at the source,
+plausibly recovers diagonals and crisp cross-merchant intermediates) needs a
+re-run behind the mint's inlier filter before any verdict.
+
 ## Repro
 
 ```
@@ -96,4 +154,12 @@ python tools/glyph-studio/py/m3_acceptance.py /tmp/m3/railed_family.glyphs.npz
 # diagonal crispness: solo vs pooled stacks
 python tools/glyph-studio/py/m3_crispness.py /tmp/m3/cvs_solo.samples.npz \
   /tmp/m3/vons_solo.samples.npz /tmp/m3/cvs_vons_pooled.samples.npz
+
+# validated fix (addendum): derived parametric weight, scored per merchant
+#   weight = (stylescan stroke_med / cap_px) * 1000 / font.json dot.size
+#   e.g. Wild Fork: 0.044 * 1000 / 73.5 ≈ 0.60  (hand value was 1.4)
+# edit a copy of fonts/wildfork/font.json to the derived weight, then:
+python -m glyphstudio.compile /tmp/wf_font_copy /tmp/wf_derived.glyphs.npz
+python tools/glyph-studio/py/m3_acceptance.py /tmp/wf_derived.glyphs.npz \
+  --merchant "Wild Fork:wildfork"
 ```

--- a/tools/glyph-studio/M3_FINDINGS.md
+++ b/tools/glyph-studio/M3_FINDINGS.md
@@ -1,0 +1,99 @@
+# M3 findings — pixel-space family pooling refuted on both epic criteria
+
+**Status:** measured result, 2026-07-09. Three independent measurements, all
+local (dev Dynamo + S3 scans; no cloud compute). This amends the epic's M3
+design *before* M4/M5 build on it.
+
+## Setup
+
+- Family under test: `{costco, innout, sprouts, wildfork}` — the M2 IoU
+  cluster containing **both density-railed merchants** (Wild Fork
+  ceiling-railed at effective thin 0.40; Costco likewise rail-bound).
+- Pooled atlas: `build_merchant_glyphs.py "Costco Wholesale;Sprouts Farmers
+  Market;In-N-Out Burger;Wild Fork;Wild Fork Foods"` over 140 receipts
+  (native `;`-pooling, same mint pipeline as production).
+- Solo baselines: the shipped v1-refined fonts (`fonts/wildfork`,
+  `fonts/costco`) compiled via `glyphstudio.compile`.
+- Instruments: v1's render-free `calibrate_merchant` (`py/m3_acceptance.py`)
+  with real-side scalars measured from dev scans by the scorecard's own
+  `_ink_metrics`; consensus decisiveness by `py/m3_crispness.py`.
+
+## Finding 1 — acceptance test FAILS: pooled is *denser*, still railed
+
+Same corpus, same real-side targets; only the font changes.
+
+| merchant | target density | solo shipped | pooled family | verdict |
+|---|--:|--:|--:|---|
+| Wild Fork | 0.135 | 0.335 · thin railed | **0.404 · thin railed** | pooled **worse** |
+| Costco | 0.187 | 0.308 · thin railed | **0.402 · thin railed** | pooled **worse** |
+| scorecard glyph coverage | | 0.999 / 1.000 | **0.735 / 0.755** | pooled loses ¼ |
+
+(The cheap measurer inflates absolute density by a stable per-merchant factor
+— v1 measured Sprouts at 1.967 — which cancels in the solo-vs-pooled
+comparison. The solo rows reproduce v1's railing, validating the harness.)
+
+## Finding 2 — diagonals get *blurrier* when pooled (cvs+vons probe)
+
+Consensus decisiveness (2·|consensus−0.5| over ink, centroid-aligned), solo vs
+pooled at ~2× samples:
+
+| glyph | best solo | pooled | Δ |
+|---|--:|--:|--:|
+| W | 0.565 (n=25) | 0.402 (n=69) | **−0.163** |
+| A | 0.448 | 0.375 | −0.074 |
+| K | 0.397 | 0.335 | −0.062 |
+| X | 0.550 | 0.498 | −0.052 |
+| M | 0.444 | 0.401 | −0.043 |
+
+Every hard diagonal degrades despite 2–17× more samples. Within-merchant
+accumulation *does* help (cvs `W` n=4 → 0.349 vs vons n=25 → 0.565): the
+problem is letterform mixing, not evidence scarcity.
+
+## Finding 3 — pooling *does* help coverage
+
+cvs solo 46 glyphs / vons solo 46 → pooled 51–54 built, dropped 9→6. Pooling
+recovers rare glyphs (`Z k z $ ( )`). This is real and survives.
+
+## Root cause
+
+The two same-family merchants overlap at IoU 0.62 **after** shape
+normalization — the residual 38% is genuine letterform difference (the epic's
+own `merchant_printer_offset`). Median-voting crops across that offset blurs
+the consensus; blur at the vote threshold **adds ink at stroke edges** —
+simultaneously fattening the atlas (Finding 1) and shredding diagonals
+(Finding 2). The epic's premise that cross-merchant pooling buys "~10×
+evidence" treated the offset as removable noise; it is signal.
+
+## What this means for the epic
+
+1. **Density railing → density-calibrated minting (per merchant).** The fix
+   the data supports is deriving the mint's vote/erosion parameter against the
+   measured real density using v1's cheap measurer (render-free loop) — the
+   "re-mint lighter" v1 already prescribed, derived instead of eyeballed.
+2. **Diagonals → family-level handcraft.** Averaging can't produce them in any
+   space when letterforms differ; `handcraft.py` skeletons authored **once per
+   family** and reused across members is the legitimate exploitation of
+   cross-merchant similarity (amortizes ~20 hard glyphs × 5 families instead
+   of × 9 merchants).
+3. **Family pooling survives for coverage + cold start (M6).** Rare-glyph
+   recovery and new-merchant bootstrap are where pooled evidence genuinely
+   pays.
+4. **M4 (multi-face rendering) is unaffected** — it consumes the
+   `(merchant, section) → (family, face)` map (M2, shipped) and does not
+   depend on pooled atlases.
+
+## Repro
+
+```
+# pooled family mint (dev data)
+python synthesis_loop/build_merchant_glyphs.py \
+  "Costco Wholesale;Sprouts Farmers Market;In-N-Out Burger;Wild Fork;Wild Fork Foods" \
+  /tmp/m3 railed_family 80
+
+# acceptance: solo vs pooled on the railed merchants
+python tools/glyph-studio/py/m3_acceptance.py /tmp/m3/railed_family.glyphs.npz
+
+# diagonal crispness: solo vs pooled stacks
+python tools/glyph-studio/py/m3_crispness.py /tmp/m3/cvs_solo.samples.npz \
+  /tmp/m3/vons_solo.samples.npz /tmp/m3/cvs_vons_pooled.samples.npz
+```

--- a/tools/glyph-studio/py/m3_acceptance.py
+++ b/tools/glyph-studio/py/m3_acceptance.py
@@ -126,6 +126,12 @@ def main(argv=None) -> int:
     )
     ap.add_argument("--receipts", type=int, default=4)
     ap.add_argument(
+        "--min-coverage",
+        type=float,
+        default=0.90,
+        help="PASS also requires candidate scorecard glyph coverage >= this",
+    )
+    ap.add_argument(
         "--table",
         default=os.environ.get("DYNAMODB_TABLE_NAME", "ReceiptsTable-dc5be22"),
     )
@@ -160,10 +166,14 @@ def main(argv=None) -> int:
                 f"projected={proj_s} coverage={cov and round(cov, 3)}"
             )
             if label == "CANDIDATE":
-                verdicts[name] = railed
-    # The epic's exit criterion is ALL railed merchants off the rails, not any.
-    all_pass = bool(verdicts) and all(v == "interior" for v in verdicts.values())
-    summary = ", ".join(f"{n}={v}" for n, v in verdicts.items())
+                verdicts[name] = (railed, cov or 0.0)
+    # The epic's exit criterion is ALL railed merchants off the rails, not
+    # any — and a candidate can't buy density by dropping glyphs, so PASS also
+    # requires scorecard coverage >= --min-coverage per merchant.
+    all_pass = bool(verdicts) and all(
+        v == "interior" and c >= args.min_coverage for v, c in verdicts.values()
+    )
+    summary = ", ".join(f"{n}={v}(cov={c:.2f})" for n, (v, c) in verdicts.items())
     print(
         f"\nacceptance: {'PASS (all merchants un-railed)' if all_pass else 'FAIL'}"
         f" [{summary}]"

--- a/tools/glyph-studio/py/m3_acceptance.py
+++ b/tools/glyph-studio/py/m3_acceptance.py
@@ -84,8 +84,7 @@ def gather(client, merchant_name: str, n_receipts: int) -> dict:
 def solve(font_path: str, g: dict):
     from glyphstudio.calibrate import calibrate_merchant
 
-    from receipt_agent.agents.label_evaluator.rendering.bitmap_font import \
-        BitmapFont
+    from receipt_agent.agents.label_evaluator.rendering.bitmap_font import BitmapFont
 
     result = calibrate_merchant(
         BitmapFont(font_path),
@@ -138,7 +137,7 @@ def main(argv=None) -> int:
     from receipt_dynamo.data.dynamo_client import DynamoClient
 
     client = DynamoClient(args.table)
-    any_pass = False
+    verdicts: dict[str, str] = {}
     for pair in pairs:
         name, _, slug = pair.partition(":")
         solo = _compile_solo(slug or name.lower().replace(" ", ""))
@@ -160,12 +159,16 @@ def main(argv=None) -> int:
                 f"  {label:13s} thin={thin} [{railed}] "
                 f"projected={proj_s} coverage={cov and round(cov, 3)}"
             )
-            if label == "CANDIDATE" and railed == "interior":
-                any_pass = True
+            if label == "CANDIDATE":
+                verdicts[name] = railed
+    # The epic's exit criterion is ALL railed merchants off the rails, not any.
+    all_pass = bool(verdicts) and all(v == "interior" for v in verdicts.values())
+    summary = ", ".join(f"{n}={v}" for n, v in verdicts.items())
     print(
-        f"\nacceptance: {'PASS (candidate un-rails)' if any_pass else 'FAIL (still railed)'}"
+        f"\nacceptance: {'PASS (all merchants un-railed)' if all_pass else 'FAIL'}"
+        f" [{summary}]"
     )
-    return 0
+    return 0 if all_pass else 1
 
 
 if __name__ == "__main__":

--- a/tools/glyph-studio/py/m3_acceptance.py
+++ b/tools/glyph-studio/py/m3_acceptance.py
@@ -14,9 +14,9 @@ candidates (e.g. density-calibrated mints).
 
 Usage:
   python m3_acceptance.py CANDIDATE.glyphs.npz \
-      [--merchant "Wild Fork" --solo wildfork_shipped.glyphs.npz] ...
-  (default: Wild Fork + Costco Wholesale against fonts/{wildfork,costco},
-   compiling the solo baselines to a temp dir if needed)
+      [--merchant "Wild Fork:wildfork"] [--merchant "Costco Wholesale:costco"]
+  (default merchants: Wild Fork + Costco Wholesale; each solo baseline is
+   compiled fresh from fonts/<slug> into a temp dir)
 """
 
 from __future__ import annotations

--- a/tools/glyph-studio/py/m3_acceptance.py
+++ b/tools/glyph-studio/py/m3_acceptance.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""M3 acceptance test: does a candidate atlas un-rail a density-railed merchant?
+
+For each merchant: measure real-side scalars from its own dev scans (the
+scorecard's `_ink_metrics` path), then run v1's render-free
+`calibrate_merchant` with (a) the shipped solo atlas and (b) the candidate
+atlas. Same corpus, same targets — only the font changes. A PASS is a derived
+`bitmap_thin` in the interior (off the 0.0 floor / 0.40 saturation ceiling)
+with projected density ≈ target.
+
+Findings from the first run are in ../M3_FINDINGS.md (pooled family atlas
+FAILED — denser than solo). Kept as the standing harness for future mint
+candidates (e.g. density-calibrated mints).
+
+Usage:
+  python m3_acceptance.py CANDIDATE.glyphs.npz \
+      [--merchant "Wild Fork" --solo wildfork_shipped.glyphs.npz] ...
+  (default: Wild Fork + Costco Wholesale against fonts/{wildfork,costco},
+   compiling the solo baselines to a temp dir if needed)
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import tempfile
+
+import numpy as np
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_ROOT = os.path.abspath(os.path.join(_HERE, "..", "..", ".."))
+for _p in (
+    _HERE,
+    os.path.join(_ROOT, "receipt_dynamo"),
+    os.path.join(_ROOT, "synthesis_loop"),
+    os.path.join(_ROOT, "receipt_agent"),
+    os.path.join(_ROOT, "receipt_upload"),
+):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+SATURATION = 0.40  # erosion saturates here on all real atlases (VALIDATION.md)
+
+
+def gather(client, merchant_name: str, n_receipts: int) -> dict:
+    """Real-side scalars + scorecard corpus from the merchant's own scans."""
+    from glyph_review import _ink_metrics
+    from receipt_line_scorecard import _load_words_and_real
+
+    places, _ = client.get_receipt_places_by_merchant(
+        merchant_name=merchant_name, limit=50
+    )
+    receipts, h_meds, d_meds, word_h_px = [], [], [], []
+    for p in places:
+        if len(receipts) >= n_receipts:
+            break
+        try:
+            real, words = _load_words_and_real(merchant_name, p.image_id, p.receipt_id)
+        except Exception:  # noqa: BLE001 - missing image/receipt: skip
+            continue
+        m = _ink_metrics(real, words)
+        if not m:
+            continue
+        h_meds.append(m["h_med"])
+        d_meds.append(m["density_med"])
+        height = real.size[1]
+        for w in words:
+            bb = w.get("bbox") or ()
+            if len(bb) == 4:
+                word_h_px.append(abs(bb[3] - bb[1]) / 1000.0 * height)
+        receipts.append({"words": [{"text": w.get("text", "")} for w in words]})
+    if not receipts:
+        raise RuntimeError(f"no usable receipts for {merchant_name}")
+    return {
+        "receipts": receipts,
+        "real_cap_height_px": float(np.median(h_meds)),
+        "target_density": float(np.median(d_meds)),
+        "median_ocr_word_height_px": float(np.median(word_h_px)),
+        "n": len(receipts),
+    }
+
+
+def solve(font_path: str, g: dict):
+    from glyphstudio.calibrate import calibrate_merchant
+
+    from receipt_agent.agents.label_evaluator.rendering.bitmap_font import \
+        BitmapFont
+
+    result = calibrate_merchant(
+        BitmapFont(font_path),
+        g["receipts"],
+        real_cap_height_px=g["real_cap_height_px"],
+        median_ocr_word_height_px=g["median_ocr_word_height_px"],
+        target_density=g["target_density"],
+    )
+    thin = result.get("bitmap_thin")
+    if thin is None:
+        railed = "no-solve"
+    elif thin >= SATURATION - 1e-6:
+        railed = "CEILING-RAILED"
+    elif thin <= 1e-6:
+        railed = "FLOOR-RAILED"
+    else:
+        railed = "interior"
+    return thin, result.get("projected") or {}, result.get("coverage"), railed
+
+
+def _compile_solo(slug: str) -> str:
+    """Compile fonts/<slug> to a temp npz (the shipped v1-refined baseline)."""
+    from glyphstudio.compile import main as compile_main
+
+    out = os.path.join(tempfile.gettempdir(), f"m3_acceptance_{slug}.glyphs.npz")
+    compile_main([os.path.join(_ROOT, "tools", "glyph-studio", "fonts", slug), out])
+    return out
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("candidate", help="candidate .glyphs.npz to test")
+    ap.add_argument(
+        "--merchant",
+        action="append",
+        default=None,
+        help='"Merchant Name:slug" pair; repeatable '
+        "(default: 'Wild Fork:wildfork' and 'Costco Wholesale:costco')",
+    )
+    ap.add_argument("--receipts", type=int, default=4)
+    ap.add_argument(
+        "--table",
+        default=os.environ.get("DYNAMODB_TABLE_NAME", "ReceiptsTable-dc5be22"),
+    )
+    args = ap.parse_args(argv)
+    os.environ["DYNAMODB_TABLE_NAME"] = args.table
+
+    pairs = args.merchant or ["Wild Fork:wildfork", "Costco Wholesale:costco"]
+
+    from receipt_dynamo.data.dynamo_client import DynamoClient
+
+    client = DynamoClient(args.table)
+    any_pass = False
+    for pair in pairs:
+        name, _, slug = pair.partition(":")
+        solo = _compile_solo(slug or name.lower().replace(" ", ""))
+        print(f"\n===== {name} =====")
+        g = gather(client, name, args.receipts)
+        print(
+            f"  real-side (n={g['n']}): cap={g['real_cap_height_px']:.1f}px "
+            f"word_h={g['median_ocr_word_height_px']:.1f}px "
+            f"target_density={g['target_density']:.4f}"
+        )
+        for label, path in (("SOLO shipped", solo), ("CANDIDATE", args.candidate)):
+            thin, proj, cov, railed = solve(path, g)
+            proj_s = (
+                {k: round(v, 3) for k, v in proj.items()}
+                if isinstance(proj, dict)
+                else proj
+            )
+            print(
+                f"  {label:13s} thin={thin} [{railed}] "
+                f"projected={proj_s} coverage={cov and round(cov, 3)}"
+            )
+            if label == "CANDIDATE" and railed == "interior":
+                any_pass = True
+    print(
+        f"\nacceptance: {'PASS (candidate un-rails)' if any_pass else 'FAIL (still railed)'}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/glyph-studio/py/m3_crispness.py
+++ b/tools/glyph-studio/py/m3_crispness.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Consensus-crispness comparison: do pooled crops sharpen or blur glyphs?
+
+crispness = mean over ink-ish pixels of 2*|consensus - 0.5| (0 = fuzzy,
+1 = crisp). Each sample is centroid-aligned before averaging, so the metric
+measures consensus decisiveness rather than misregistration. See
+../M3_FINDINGS.md: cross-merchant pooling BLURRED every hard diagonal.
+
+Usage:
+  python m3_crispness.py SOLO_A.samples.npz [SOLO_B.samples.npz ...] POOLED.samples.npz \
+      [--chars MWKVXYNAZ] [--controls OICL0]
+The last path is treated as the pooled stack; the rest are solo baselines.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+import numpy as np
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+if _HERE not in sys.path:
+    sys.path.insert(0, _HERE)
+
+
+def _center(mask: np.ndarray) -> np.ndarray:
+    ys, xs = np.where(mask)
+    if len(ys) == 0:
+        return mask
+    h, w = mask.shape
+    dy = h // 2 - int(round(ys.mean()))
+    dx = w // 2 - int(round(xs.mean()))
+    return np.roll(np.roll(mask, dy, 0), dx, 1)
+
+
+def consensus_crispness(path: str, cp: int):
+    from glyphstudio.samples import load_stack
+
+    stack = load_stack(path, cp)
+    if stack is None or len(stack) == 0:
+        return None, 0
+    aligned = np.stack([_center(s) for s in stack]).astype(np.float32)
+    cons = aligned.mean(0)
+    ink = cons > 0.10
+    if not ink.any():
+        return 0.0, len(stack)
+    return float((2 * np.abs(cons[ink] - 0.5)).mean()), len(stack)
+
+
+def report(label: str, chars: str, solos: list[str], pooled: str) -> None:
+    names = [os.path.basename(s).split(".")[0] for s in solos]
+    header = " ".join(f"{n[:12]:>14s}" for n in names)
+    print(f"\n=== {label} ===")
+    print(f"  ch {header} {'pooled':>14s}   pooled_vs_best")
+    for ch in chars:
+        cp = ord(ch)
+        solo_vals = [consensus_crispness(s, cp) for s in solos]
+        pv, pn = consensus_crispness(pooled, cp)
+        best = max((v for v, _ in solo_vals if v is not None), default=None)
+        delta = f"{pv - best:+.3f}" if pv is not None and best is not None else "-"
+
+        def fmt(v, n):
+            return f"{v:.3f}(n={n})" if v is not None else f"  -  (n={n})"
+
+        cols = " ".join(f"{fmt(v, n):>14s}" for v, n in solo_vals)
+        print(f"  {ch:2s} {cols} {fmt(pv, pn):>14s}   {delta}")
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("stacks", nargs="+", help="solo .samples.npz ..., pooled last")
+    ap.add_argument("--chars", default="MWKVXYNAZ")
+    ap.add_argument("--controls", default="OICL0")
+    args = ap.parse_args(argv)
+    if len(args.stacks) < 2:
+        ap.error("need at least one solo stack and the pooled stack")
+    *solos, pooled = args.stacks
+    report("HARD DIAGONALS", args.chars, solos, pooled)
+    if args.controls:
+        report("EASY CONTROLS", args.controls, solos, pooled)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## The epic's M3 mechanism, tested — and refuted

Three local measurements (dev scans, v1's render-free instruments; zero cloud compute) show pixel-space cross-merchant pooling **fails both of the epic's own criteria**:

### 1. Acceptance test FAIL — pooled atlas is *denser*, still railed
Pooled railed-family atlas (`costco+innout+sprouts+wildfork`, 140 receipts, production mint path) vs shipped solo atlases, same corpus + real-side targets:

| merchant | target | solo | pooled |
|---|--:|--:|--:|
| Wild Fork | 0.135 | 0.335 · railed | **0.404 · railed** |
| Costco | 0.187 | 0.308 · railed | **0.402 · railed** |
| glyph coverage | | ~1.00 | **0.73–0.76** |

Solo rows reproduce v1's railing exactly (harness validated against the known answer).

### 2. Diagonals *blur* when pooled
Consensus decisiveness, best-solo vs pooled (2–17× samples): `W −0.163, A −0.074, K −0.062, X −0.052, M −0.043` — every hard diagonal degrades. Within-merchant accumulation helps (cvs `W` n=4→0.349 vs vons n=25→0.565); cross-merchant mixing hurts.

### 3. Coverage genuinely improves (+5 glyphs, rare-glyph recovery) — the part that survives (and M6 cold-start value).

**Root cause:** the merchant printer offset is signal, not noise — the same-family pair overlaps at IoU 0.62 *after* shape normalization, and median-voting across that residual adds edge ink: fatter *and* fuzzier.

## What ships
- `M3_FINDINGS.md` — full analysis + repro commands.
- `py/m3_acceptance.py` — **standing harness for the epic's exit test** (solo-vs-candidate `calibrate_merchant` on the railed merchants); runnable against any future mint.
- `py/m3_crispness.py` — consensus-decisiveness comparison.
- Epic doc M3 milestone amended: **(a) density-calibrated minting per merchant** (derive the mint's vote/erosion against measured real density — "re-mint lighter," derived not eyeballed), **(b) family-level handcraft for diagonals**. M4 unaffected (consumes the M2 map, not pooled atlases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new M3 validation tools for checking font density, coverage, and crispness across merchant samples.
  * Introduced support for comparing pooled results against solo baselines with clear pass/fail reporting.

* **Documentation**
  * Updated M3 milestone notes with the latest measurements, acceptance findings, and recommended next steps for font generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->