### PR TITLE
fix(m3_acceptance)+docs: OCR vetting + M3 findings correction (WF was never broken)

### DIFF
--- a/tools/glyph-studio/FONT_INTELLIGENCE_EPIC.md
+++ b/tools/glyph-studio/FONT_INTELLIGENCE_EPIC.md
@@ -204,14 +204,14 @@ unchanged — family fonts are *fitted skeletons*, never copied crops).
   (b) diagonals via **family-level handcraft** (one skeleton set per family,
   reused across members). *Exit (unchanged in spirit):* the railed merchants
   come off the rails on the standing harness `py/m3_acceptance.py`; anti-copy
-  + coverage gates hold. **Validated same day** (M3_FINDINGS.md addendum):
-  skeleton-protected stroke normalization un-rails BOTH railed merchants (WF
-  interior thin 0.333, density 0.137 vs 0.135; Costco interior 0.333, 0.200
-  vs 0.187; full coverage), and the derived parametric weight (WF `1.4 →
-  0.60`, closed-form from stylescan stroke/cap) lands 0.99× target in one
-  step. Root causes differ (WF stroke-width, Costco shape-driven) — the
-  density-targeted bisection is the general form. Visual A/B still required
-  before adoption.
+  + coverage gates hold. **CORRECTED 2026-07-10** (M3_FINDINGS.md): the
+  "railing" itself was a measurement artifact — one pathological receipt
+  (44 x-overlapping OCR pairs, 2× cap scale) contaminated first-N sampling in
+  v1's calibration and this epic's harness. On a vetted corpus the shipped WF
+  font scores median 0.87 (never broken); the derived-weight candidate is a
+  regression (median 0.66) and is withdrawn. The diagnostic toolchain +
+  now-vetted harness stand; RETROFIT's WF/Costco figures need re-derivation
+  on vetted corpora.
 - **M4 — Multi-face rendering.** Renderer reads the map; per-word face
   stamping. *Exit:* a Costco receipt renders bold totals + regular body from
   family fonts and the production scorecard is in-gate (h/wpc/density within

--- a/tools/glyph-studio/M3_FINDINGS.md
+++ b/tools/glyph-studio/M3_FINDINGS.md
@@ -206,3 +206,30 @@ duplicates overprint and inflate measured synth density. Clean receipts score
 
 *Lesson for every measurement in this epic: vet the corpus before trusting
 first-N samples; one bad receipt at the top of an index shaped two epics.*
+
+## Fleet-wide vetted pin audit (2026-07-10) — no pin needs changing
+
+Current shipped fonts + pins, vetted receipts only (OCR x-overlap ≤ 2),
+render scorecard:
+
+| merchant (pin) | vetted density_ratios | median | verdict |
+|---|---|--:|---|
+| Wild Fork (thin 0.6) | 0.92 / 0.94 / 0.94 / 0.99 | **0.94** | fine — tightest in the fleet |
+| Sprouts (0.225) | 0.75 / 0.97 / 0.97 / 1.09 | **0.97** | fine |
+| CVS (0.15) | 0.75 / 0.81 / 1.00 / 1.02 | **0.91** | fine |
+| Home Depot (0.6) | 0.98 (only one vetted receipt exists) | **0.98** | fine (n=1) |
+| Costco (0.0) | 0.53 / 0.74 / 0.76 / 1.12 | **0.75** | runs LIGHT + high variance — monitor, no change |
+
+Every "railed merchant" narrative dissolves on vetted data. Costco — which
+the epic doc says "rails at the 0.0 floor" (too dense) — actually runs
+*light*, the opposite direction, with too much variance for a confident
+correction. **The epic's M3/M5 acceptance criterion ("the railed merchants
+come off the rails") was chasing measurement artifacts.** The epic's real
+remaining objectives are diagonals (family-level handcraft), multi-face
+rendering (M4, consumes the M2 map), and new-merchant cold start (M6).
+Density calibration is CLOSED: current pins stand.
+
+(Note: Home Depot has exactly one vetted receipt in dev — 17 of its 18
+receipts flag the x-overlap detector. Whether that is genuinely pathological
+OCR corpus-wide or partly detector over-flagging on HD's dense column layout
+deserves a look before trusting any HD-specific conclusion.)

--- a/tools/glyph-studio/M3_FINDINGS.md
+++ b/tools/glyph-studio/M3_FINDINGS.md
@@ -165,3 +165,44 @@ python -m glyphstudio.compile /tmp/wf_font_copy /tmp/wf_derived.glyphs.npz
 python tools/glyph-studio/py/m3_acceptance.py /tmp/wf_derived.glyphs.npz \
   --merchant "Wild Fork:wildfork"
 ```
+
+## Correction (2026-07-10) — the Wild Fork "railing" was a measurement artifact
+
+Tyler's visual review of the render A/B caught broken layout in the synth;
+tracing it invalidated the addendum's ship recommendation.
+
+**Root cause:** receipt `058b662d#1` — used by the render A/B, by this
+harness's first-N `gather()`, and plausibly by v1's original calibration —
+has **44 same-row x-overlapping OCR word pairs** (doubled/fragmented OCR) and
+~2× the corpus's cap scale. The renderer stamps every OCR word faithfully, so
+duplicates overprint and inflate measured synth density. Clean receipts score
+0–2 on this metric.
+
+**Vetted 6-receipt distribution (dup-free, render scorecard):**
+
+| | shipped font | derived w=0.60 candidate |
+|---|--:|--:|
+| range | 0.831 – 0.991 | 0.616 – 0.788 |
+| median | **0.87 — in/near gate** | **0.66 — regression** |
+
+**Conclusions:**
+1. **The shipped Wild Fork font was never density-broken** on real receipts
+   (slightly *light* if anything). No weight change ships. The derived-weight
+   candidate is permanently withdrawn.
+2. The "rails at bitmap_thin 0.6, ~48% too dense" narrative — the epic's
+   flagship motivation — was the pathological receipt, not the font. v1's
+   RETROFIT figures for Wild Fork (and possibly Costco, whose acceptance
+   `gather()` shared the contaminated sampling) should be re-derived on a
+   vetted corpus.
+3. **What stands:** the pooling refutation (relative, same corpus both
+   sides), the diagnostic toolchain (stroke/cap measurement, skeleton-
+   protected erosion, the closed-form weight↔stroke mapping), and this
+   harness — now with OCR vetting (`ocr_overlap_score`, receipts above
+   `--max-overlaps` excluded) so first-N sampling can't poison future
+   measurements.
+4. Optional derived win, properly measured this time: the shipped font's
+   vetted median 0.87 suggests reducing the `bitmap_thin` pin (0.6 → ~0.3)
+   would center density at ~1.0 — needs a vetted-corpus derivation + A/B.
+
+*Lesson for every measurement in this epic: vet the corpus before trusting
+first-N samples; one bad receipt at the top of an index shaped two epics.*

--- a/tools/glyph-studio/py/m3_acceptance.py
+++ b/tools/glyph-studio/py/m3_acceptance.py
@@ -43,8 +43,42 @@ for _p in (
 SATURATION = 0.40  # erosion saturates here on all real atlases (VALIDATION.md)
 
 
-def gather(client, merchant_name: str, n_receipts: int) -> dict:
-    """Real-side scalars + scorecard corpus from the merchant's own scans."""
+def ocr_overlap_score(words) -> int:
+    """Count same-row word pairs whose x-intervals overlap >30%.
+
+    Pathological OCR (doubled passes, fragmented tokens) stamps words on top
+    of each other; the renderer reproduces that faithfully, inflating measured
+    density. Same TEXT repeating on a row is legitimate (price + total
+    columns) — only geometric x-overlap flags. Receipt 058b662d (Wild Fork)
+    scores 44 on this metric and single-handedly created the 'WF rails ~48%
+    too dense' artifact; clean receipts score 0-2.
+    """
+    rows: dict[float, list[tuple[float, float]]] = {}
+    for w in words:
+        bb = w.get("bbox") or ()
+        if len(bb) != 4:
+            continue
+        y_center = round((bb[1] + bb[3]) / 2000.0, 2)
+        x0, x1 = sorted((bb[0], bb[2]))
+        rows.setdefault(y_center, []).append((x0, x1))
+    bad = 0
+    for spans in rows.values():
+        spans.sort()
+        for (a0, a1), (b0, b1) in zip(spans, spans[1:]):
+            inter = min(a1, b1) - max(a0, b0)
+            if inter > 0.3 * min(a1 - a0, b1 - b0):
+                bad += 1
+    return bad
+
+
+def gather(client, merchant_name: str, n_receipts: int, max_overlaps: int = 2) -> dict:
+    """Real-side scalars + scorecard corpus from the merchant's own scans.
+
+    Receipts whose OCR is pathological (``ocr_overlap_score`` >
+    ``max_overlaps``) are excluded — unvetted first-N sampling is how the
+    Wild Fork density artifact contaminated both v1's and this epic's
+    measurements.
+    """
     from glyph_review import _ink_metrics
     from receipt_line_scorecard import _load_words_and_real
 
@@ -58,6 +92,14 @@ def gather(client, merchant_name: str, n_receipts: int) -> dict:
         try:
             real, words = _load_words_and_real(merchant_name, p.image_id, p.receipt_id)
         except Exception:  # noqa: BLE001 - missing image/receipt: skip
+            continue
+        overlaps = ocr_overlap_score(words)
+        if overlaps > max_overlaps:
+            print(
+                f"  [vet] skipping {p.image_id[:8]}#{p.receipt_id}: "
+                f"{overlaps} x-overlapping OCR pairs",
+                file=sys.stderr,
+            )
             continue
         m = _ink_metrics(real, words)
         if not m:


### PR DESCRIPTION
## The correction PR — closing the Wild Fork density saga

Tyler's visual review of the render A/B caught broken synth layout; tracing it exposed a **measurement artifact that shaped two epics**.

### Root cause
Receipt `058b662d#1` has **dozens of same-row x-overlapping OCR word pairs** (doubled/fragmented OCR) + 2× cap scale. The renderer stamps every OCR word faithfully → duplicates overprint → measured density inflates. It sits **first in the merchant index**, poisoning every first-N sample: the render A/B, this harness's `gather()`, and plausibly **v1's original "WF rails ~48% too dense" calibration**.

### Vetted 6-receipt distribution (dup-free, render scorecard)
| | shipped font | derived w=0.60 candidate |
|---|--:|--:|
| range | 0.831–0.991 | 0.616–0.788 |
| median | **0.87 — never broken** | **0.66 — regression, withdrawn** |

### Ships
- **`ocr_overlap_score()` + vetting in `gather()`** — receipts above `--max-overlaps` x-overlapping pairs are excluded (same-text-same-row = legit price/total columns, not flagged). Verified live: the pathological receipt is now auto-skipped.
- **`M3_FINDINGS.md` correction section** — what stands (pooling refutation, diagnostic toolchain, this harness) and what's withdrawn (the WF weight change; the "railing" narrative). Flags RETROFIT's WF/Costco figures for vetted re-derivation.
- Epic M3 blurb corrected.

Credit: caught by eyeball, not by any metric — which is itself the lesson the findings now record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)