### PR TITLE
M1a-2: wire receipt sections into line embedding metadata at ingest

### DIFF
--- a/receipt_chroma/receipt_chroma/embedding/delta/line_delta.py
+++ b/receipt_chroma/receipt_chroma/embedding/delta/line_delta.py
@@ -8,6 +8,7 @@ on the same visual row are grouped into a single embedding.
 """
 
 import logging
+from collections import Counter
 from typing import Dict, List, Optional, TypedDict
 
 from receipt_chroma.embedding.delta.producer import produce_embedding_delta
@@ -21,6 +22,7 @@ from receipt_chroma.embedding.metadata.line_metadata import (
     enrich_row_metadata_with_anchors,
     enrich_row_metadata_with_labels,
 )
+from receipt_chroma.embedding.records import sections_to_line_map
 
 logger = logging.getLogger(__name__)
 
@@ -111,8 +113,19 @@ def save_line_embeddings_as_delta(
     metadatas = []
     documents = []
 
-    # Cache visual rows per receipt to avoid recomputing
+    # Cache visual rows + section maps per receipt to avoid recomputing
     visual_rows_cache: Dict[tuple, Dict[int, list]] = {}
+    section_map_cache: Dict[tuple, Dict[int, str]] = {}
+
+    def get_section_map(
+        image_id: str, receipt_id: int, receipt_details: dict
+    ) -> Dict[int, str]:
+        key = (image_id, receipt_id)
+        if key not in section_map_cache:
+            section_map_cache[key] = sections_to_line_map(
+                receipt_details.get("sections") or []
+            )
+        return section_map_cache[key]
 
     def get_visual_rows_map(
         image_id: str, receipt_id: int, lines: list
@@ -186,11 +199,28 @@ def save_line_embeddings_as_delta(
             )
         merchant_name = place.merchant_name
 
+        # Row section from the receipt's ReceiptSection rows (M1a-2):
+        # majority section across the row's line_ids; ties/unknown stay unset.
+        section_by_line = get_section_map(
+            image_id, receipt_id, receipt_details
+        )
+        row_section = None
+        if section_by_line:
+            votes = Counter(
+                section_by_line[line.line_id]
+                for line in target_row
+                if line.line_id in section_by_line
+            )
+            top = votes.most_common(2)
+            if top and (len(top) == 1 or top[0][1] > top[1][1]):
+                row_section = top[0][0]
+
         # Build row metadata for ChromaDB
         row_metadata = create_row_metadata(
             row_lines=target_row,
             merchant_name=merchant_name,
             source="openai_embedding_batch",
+            section_label=row_section,
         )
 
         # Anchor-only enrichment: attach anchor fields from all words in row

--- a/receipt_chroma/tests/unit/test_delta_parsing.py
+++ b/receipt_chroma/tests/unit/test_delta_parsing.py
@@ -128,3 +128,74 @@ class TestStaleResultSkip:
         assert out["stale_receipts"] == [
             ["3f52804b-2fad-4e00-92c8-b593da3a8ed3", 1]
         ]
+
+
+class TestSectionWiring:
+    """M1a-2: ReceiptSection rows flow into row metadata as section_label."""
+
+    def test_section_label_lands_in_delta_metadata(self):
+        from unittest.mock import Mock, patch
+
+        from receipt_chroma.embedding.delta import line_delta
+
+        line = Mock()
+        line.line_id = 1
+        line.image_id = "3f52804b-2fad-4e00-92c8-b593da3a8ed3"
+        line.receipt_id = 1
+        line.text = "TOTAL 20.94"
+        line.confidence = 0.99
+        line.bounding_box = {"x": 0.1, "y": 0.5, "width": 0.8, "height": 0.02}
+        place = Mock()
+        place.merchant_name = "Test Mart"
+        section = Mock(
+            line_ids=[1],
+            section_type="TOTAL_LINE",
+            confidence=0.9,
+            validation_status="PENDING",
+        )
+        descriptions = {
+            line.image_id: {
+                1: {
+                    "lines": [line],
+                    "words": [],
+                    "labels": [],
+                    "place": place,
+                    "sections": [section],
+                }
+            }
+        }
+        results = [
+            {
+                "custom_id": f"IMAGE#{line.image_id}#RECEIPT#00001#LINE#00001",
+                "embedding": [0.1, 0.2],
+            }
+        ]
+        captured = {}
+
+        def fake_produce(**kwargs):
+            captured.update(kwargs)
+            return {
+                "delta_id": "d",
+                "delta_key": "k",
+                "embedding_count": len(kwargs["ids"]),
+            }
+
+        with (
+            patch.object(
+                line_delta, "produce_embedding_delta", side_effect=fake_produce
+            ),
+            patch.object(
+                line_delta,
+                "group_lines_into_visual_rows",
+                return_value=[[line]],
+            ),
+            patch.object(line_delta, "get_primary_line_id", return_value=1),
+        ):
+            line_delta.save_line_embeddings_as_delta(
+                results=results,
+                descriptions=descriptions,
+                batch_id="b1",
+                bucket_name="bucket",
+                sqs_queue_url=None,
+            )
+        assert captured["metadatas"][0].get("section_label") == "TOTAL_LINE"


### PR DESCRIPTION
## What

Completes M1a (font-intelligence epic): #1074 taught `create_row_metadata`/`build_row_payload` to accept `section_label`, but no caller passed it — the plumbing was inert. This wires the **ingest path** (`save_line_embeddings_as_delta`), which already carries each receipt's `ReceiptSection` rows in `descriptions[...]['sections']` unused.

- Build `line_id → section` map once per receipt via `sections_to_line_map` (cached alongside the visual-rows cache)
- Row's section = plurality vote across the row's `line_ids`; ties/no-sections leave `section_label` unset (same semantics as `build_row_payload`)
- Pass into `create_row_metadata(section_label=...)`

## Why now

The dev line drain (1,676 batches) is held until this merges — landing it first means first-pass ingest stamps `section_label` on rows from the 381 section-seeded receipts, instead of requiring a Chroma metadata re-sweep afterwards.

## Test

`TestSectionWiring::test_section_label_lands_in_delta_metadata` — a delta built from a receipt with a TOTAL_LINE section carries `section_label='TOTAL_LINE'` in row metadata.

Dev-only rollout via the standing targeted deploy. No prod deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SRtFcxkcw1t3nZsVHstZGL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Receipt line metadata now includes section labels when a visual row’s lines clearly belong to the same section.
  * Section labels are propagated into generated receipt embedding data.

* **Tests**
  * Added coverage to verify section labels appear correctly in receipt metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->