### PR TITLE
Stabilize hydrated figure layouts

### DIFF
--- a/portfolio/components/analytics/ReaderInsight.module.css
+++ b/portfolio/components/analytics/ReaderInsight.module.css
@@ -14,6 +14,7 @@
 
 .summary {
   max-width: 720px;
+  min-height: calc(1.45em * 2);
   margin: 0;
   font-size: 1.1rem;
   font-weight: 650;
@@ -24,5 +25,9 @@
   .readerInsight {
     margin-top: 2rem;
     padding: 1rem 1rem 0;
+  }
+
+  .summary {
+    min-height: calc(1.45em * 3);
   }
 }

--- a/portfolio/components/ui/Figures/WordSimilarity.module.css
+++ b/portfolio/components/ui/Figures/WordSimilarity.module.css
@@ -1,0 +1,171 @@
+.loadingShell {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  width: 100%;
+  max-width: 1000px;
+  min-height: 100%;
+  margin: 0 auto;
+}
+
+.receiptStage {
+  position: relative;
+  width: 100%;
+  height: 600px;
+  overflow: hidden;
+}
+
+.receiptSkeleton {
+  position: absolute;
+  width: min(35%, 340px);
+  height: 92px;
+  border: 2px solid rgba(var(--text-color-rgb), 0.12);
+  border-radius: 8px;
+  background: rgba(var(--text-color-rgb), 0.06);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.08);
+  animation: word-similarity-pulse 1.6s ease-in-out infinite;
+}
+
+.receiptSkeleton:nth-child(1) {
+  top: 8%;
+  left: 7%;
+  transform: rotate(-7deg);
+}
+
+.receiptSkeleton:nth-child(2) {
+  top: 21%;
+  right: 5%;
+  transform: rotate(5deg);
+}
+
+.receiptSkeleton:nth-child(3) {
+  top: 39%;
+  left: 28%;
+  transform: rotate(-2deg);
+}
+
+.receiptSkeleton:nth-child(4) {
+  top: 57%;
+  right: 19%;
+  transform: rotate(8deg);
+}
+
+.receiptSkeleton:nth-child(5) {
+  top: 72%;
+  left: 4%;
+  transform: rotate(4deg);
+}
+
+.receiptSkeleton:nth-child(6) {
+  top: 80%;
+  right: 2%;
+  transform: rotate(-6deg);
+}
+
+.tableSkeleton {
+  overflow: hidden;
+  border-top: 2px solid rgba(var(--text-color-rgb), 0.22);
+  border-bottom: 2px solid rgba(var(--text-color-rgb), 0.22);
+}
+
+.tableHeaderSkeleton {
+  height: 44px;
+  background: var(--code-background);
+}
+
+.tableRowSkeleton {
+  display: grid;
+  grid-template-columns: 1.2fr 1.8fr 0.7fr;
+  gap: 1.5rem;
+  align-items: center;
+  min-height: 42px;
+  padding: 0 0.5rem;
+}
+
+.tableRowSkeleton:nth-child(odd) {
+  background: var(--code-background);
+}
+
+.tableRowSkeleton span,
+.timingLinesSkeleton span {
+  height: 10px;
+  border-radius: 999px;
+  background: rgba(var(--text-color-rgb), 0.1);
+  animation: word-similarity-pulse 1.6s ease-in-out infinite;
+}
+
+.tableRowSkeleton span:last-child {
+  justify-self: end;
+  width: 65%;
+}
+
+.timingSkeleton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1.5rem;
+  min-height: 86px;
+}
+
+.timingRingSkeleton {
+  width: 68px;
+  height: 68px;
+  border: 8px solid rgba(var(--text-color-rgb), 0.08);
+  border-radius: 50%;
+}
+
+.timingLinesSkeleton {
+  display: grid;
+  gap: 0.65rem;
+  width: min(280px, 45%);
+}
+
+.timingLinesSkeleton span:nth-child(2) {
+  width: 78%;
+}
+
+.timingLinesSkeleton span:nth-child(3) {
+  width: 58%;
+}
+
+@keyframes word-similarity-pulse {
+  0%,
+  100% {
+    opacity: 0.58;
+  }
+
+  50% {
+    opacity: 1;
+  }
+}
+
+@media (max-width: 768px) {
+  .receiptStage {
+    height: 400px;
+  }
+
+  .receiptSkeleton {
+    width: min(58%, 210px);
+    height: 72px;
+  }
+
+  .tableRowSkeleton {
+    grid-template-columns: 1fr 0.45fr;
+  }
+
+  .tableRowSkeleton span:nth-child(2) {
+    display: none;
+  }
+
+  .timingSkeleton {
+    gap: 1rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .receiptSkeleton,
+  .tableRowSkeleton span,
+  .timingLinesSkeleton span {
+    animation: none;
+  }
+}

--- a/portfolio/components/ui/Figures/WordSimilarity.tsx
+++ b/portfolio/components/ui/Figures/WordSimilarity.tsx
@@ -7,6 +7,7 @@ import {
   detectImageFormatSupport,
   getBestImageUrl,
 } from "../../../utils/imageFormat";
+import styles from "./WordSimilarity.module.css";
 
 // Simple seeded random number generator for consistent randomness
 function seededRandom(seed: number): () => number {
@@ -41,6 +42,41 @@ interface SafeZone {
   minY: number;
   maxY: number;
 }
+
+const WordSimilaritySkeleton: React.FC = () => (
+  <div
+    className={styles.loadingShell}
+    data-testid="word-similarity"
+    aria-busy="true"
+    aria-label="Loading word similarity results"
+  >
+    <div className={styles.receiptStage} aria-hidden="true">
+      {Array.from({ length: 6 }).map((_, index) => (
+        <div key={index} className={styles.receiptSkeleton} />
+      ))}
+    </div>
+
+    <div className={styles.tableSkeleton} aria-hidden="true">
+      <div className={styles.tableHeaderSkeleton} />
+      {Array.from({ length: 5 }).map((_, index) => (
+        <div key={index} className={styles.tableRowSkeleton}>
+          <span />
+          <span />
+          <span />
+        </div>
+      ))}
+    </div>
+
+    <div className={styles.timingSkeleton} aria-hidden="true">
+      <div className={styles.timingRingSkeleton} />
+      <div className={styles.timingLinesSkeleton}>
+        <span />
+        <span />
+        <span />
+      </div>
+    </div>
+  </div>
+);
 
 // Constraint-based position solver that guarantees cards stay within bounds
 function solveCardPosition(
@@ -256,22 +292,9 @@ const WordSimilarity: React.FC = () => {
   }, []);
 
   if (!nearViewport || loading) {
-    const reservedHeight = windowWidth <= 768 ? 100 : 120;
     return (
-      <div
-        ref={lazyRef}
-        data-testid="word-similarity"
-        style={{
-          padding: "2rem",
-          textAlign: "center",
-          color: "#666",
-          minHeight: `${reservedHeight}px`,
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
-        }}
-      >
-        Loading...
+      <div ref={lazyRef}>
+        <WordSimilaritySkeleton />
       </div>
     );
   }

--- a/portfolio/e2e/skeleton-height-stability.spec.ts
+++ b/portfolio/e2e/skeleton-height-stability.spec.ts
@@ -8,22 +8,19 @@ import { mockWordSimilarityResponse } from "./fixtures/word-similarity";
  *
  * For each lazy-loaded component on /receipt, we:
  *   1. Block its API so it renders the skeleton/loading placeholder.
- *   2. Scroll to it and measure the skeleton container height.
+ *   2. Scroll to it and measure the page-level figure boundary.
  *   3. Fulfill the blocked API request with mock data.
  *   4. Wait for the loaded state to render.
- *   5. Measure the loaded container height and assert they match (within tolerance).
+ *   5. Measure the settled boundary and assert that its full box is unchanged.
  *
- * A tolerance of 10 % is used because minor differences (a few px from borders,
- * dynamic content like epoch counts) are acceptable — the goal is to prevent
- * large layout shifts (e.g. 300 px → 900 px).
- *
- * Currently scoped to chromium (desktop). Mobile has known height-shift issues
- * in LayoutLM (~42%) and WordSimilarity (~28%) that should be fixed separately.
+ * A one-pixel tolerance only covers subpixel rounding. The outer boundary is
+ * the layout contract, so dynamic differences inside a figure must not move the
+ * surrounding article on either desktop or mobile.
  */
 
-test.use({ viewport: { width: 1280, height: 900 } });
+const BOX_TOLERANCE_PX = 1;
 
-const HEIGHT_TOLERANCE = 0.1; // 10%
+type LayoutBox = { x: number; y: number; width: number; height: number };
 
 /** Mock CDN image requests with an SVG placeholder */
 async function mockImages(page: Page) {
@@ -64,9 +61,10 @@ async function stubOtherApis(page: Page, except: string[]) {
 /** Navigate to the receipt page and wait for it to be ready */
 async function navigateToReceipt(page: Page) {
   await page.goto("/receipt");
-  await expect(
-    page.locator("h1", { hasText: "Introduction" })
-  ).toBeVisible({ timeout: 15000 });
+  const introduction = page
+    .getByRole("heading", { name: "Introduction", exact: true })
+    .filter({ visible: true });
+  await expect(introduction).toHaveCount(1, { timeout: 15000 });
 }
 
 /** Scroll a text anchor into view, then nudge slightly to reveal the component */
@@ -81,16 +79,34 @@ async function scrollToAnchor(page: Page, text: string, scrollUp?: number) {
   await page.waitForTimeout(500);
 }
 
-function assertHeightStable(
-  skeletonHeight: number,
-  loadedHeight: number,
+function assertBoxStable(
+  loadingBox: LayoutBox,
+  loadedBox: LayoutBox,
   componentName: string
 ) {
-  const ratio = Math.abs(loadedHeight - skeletonHeight) / skeletonHeight;
-  expect(
-    ratio,
-    `${componentName}: skeleton height (${skeletonHeight}px) vs loaded height (${loadedHeight}px) — ${(ratio * 100).toFixed(1)}% shift exceeds ${HEIGHT_TOLERANCE * 100}% tolerance`
-  ).toBeLessThanOrEqual(HEIGHT_TOLERANCE);
+  for (const key of ["x", "y", "width", "height"] as const) {
+    const delta = Math.abs(loadedBox[key] - loadingBox[key]);
+    expect(
+      delta,
+      `${componentName}: ${key} shifted by ${delta.toFixed(2)}px (loading ${loadingBox[key].toFixed(2)}px → loaded ${loadedBox[key].toFixed(2)}px)`
+    ).toBeLessThanOrEqual(BOX_TOLERANCE_PX);
+  }
+}
+
+function figureBoundary(page: Page, name: string) {
+  return page
+    .locator(`[data-figure-boundary="${name}"]`)
+    .filter({ visible: true });
+}
+
+async function measureDocumentBox(
+  page: Page,
+  locator: ReturnType<Page["locator"]>
+): Promise<LayoutBox | null> {
+  const box = await locator.boundingBox();
+  if (!box) return null;
+  const scroll = await page.evaluate(() => ({ x: window.scrollX, y: window.scrollY }));
+  return { ...box, x: box.x + scroll.x, y: box.y + scroll.y };
 }
 
 // ---------------------------------------------------------------------------
@@ -118,10 +134,10 @@ test.describe("Skeleton height stability", () => {
     // Measure skeleton height
     const container = page.locator('[class*="TrainingMetricsAnimation"]').first();
     await expect(container).toBeVisible({ timeout: 10000 });
-    const skeletonBox = await container.boundingBox();
+    const boundary = figureBoundary(page, "training-metrics");
+    const skeletonBox = await measureDocumentBox(page, boundary);
     expect(skeletonBox).not.toBeNull();
-    const skeletonHeight = skeletonBox!.height;
-    console.log(`  TrainingMetrics skeleton height: ${skeletonHeight}px`);
+    console.log(`  TrainingMetrics loading boundary: ${JSON.stringify(skeletonBox)}`);
 
     // Fulfill the blocked API request
     for (const route of pendingRoutes) {
@@ -134,12 +150,11 @@ test.describe("Skeleton height stability", () => {
 
     // Wait for loaded state — the epoch timeline appears when loaded
     await page.waitForTimeout(3000);
-    const loadedBox = await container.boundingBox();
+    const loadedBox = await measureDocumentBox(page, boundary);
     expect(loadedBox).not.toBeNull();
-    const loadedHeight = loadedBox!.height;
-    console.log(`  TrainingMetrics loaded height: ${loadedHeight}px`);
+    console.log(`  TrainingMetrics loaded boundary: ${JSON.stringify(loadedBox)}`);
 
-    assertHeightStable(skeletonHeight, loadedHeight, "TrainingMetricsAnimation");
+    assertBoxStable(skeletonBox!, loadedBox!, "TrainingMetricsAnimation");
   });
 
   // ---------------------------------------------------------------------------
@@ -165,10 +180,10 @@ test.describe("Skeleton height stability", () => {
     // Measure skeleton height — uses ReceiptFlowLoadingShell
     const container = page.locator('[class*="LayoutLMBatch"]').first();
     await expect(container).toBeVisible({ timeout: 10000 });
-    const skeletonBox = await container.boundingBox();
+    const boundary = figureBoundary(page, "layoutlm-inference");
+    const skeletonBox = await measureDocumentBox(page, boundary);
     expect(skeletonBox).not.toBeNull();
-    const skeletonHeight = skeletonBox!.height;
-    console.log(`  LayoutLM skeleton height: ${skeletonHeight}px`);
+    console.log(`  LayoutLM loading boundary: ${JSON.stringify(skeletonBox)}`);
 
     // Fulfill the blocked API requests (component fetches 3 times: initial + 2 prefetch)
     for (const route of pendingRoutes) {
@@ -189,12 +204,11 @@ test.describe("Skeleton height stability", () => {
     });
 
     await page.waitForTimeout(3000);
-    const loadedBox = await container.boundingBox();
+    const loadedBox = await measureDocumentBox(page, boundary);
     expect(loadedBox).not.toBeNull();
-    const loadedHeight = loadedBox!.height;
-    console.log(`  LayoutLM loaded height: ${loadedHeight}px`);
+    console.log(`  LayoutLM loaded boundary: ${JSON.stringify(loadedBox)}`);
 
-    assertHeightStable(skeletonHeight, loadedHeight, "LayoutLMBatchVisualization");
+    assertBoxStable(skeletonBox!, loadedBox!, "LayoutLMBatchVisualization");
   });
 
   // ---------------------------------------------------------------------------
@@ -223,16 +237,23 @@ test.describe("Skeleton height stability", () => {
     // Measure loading state height — the container has data-testid and minHeight: 900px
     const container = page.locator('[data-testid="word-similarity"]').first();
     await expect(container).toBeVisible({ timeout: 10000 });
-    const loadingBox = await container.boundingBox();
+    const boundary = figureBoundary(page, "word-similarity");
+    const loadingBox = await measureDocumentBox(page, boundary);
     expect(loadingBox).not.toBeNull();
-    const loadingHeight = loadingBox!.height;
-    console.log(`  WordSimilarity loading height: ${loadingHeight}px`);
+    console.log(`  WordSimilarity loading boundary: ${JSON.stringify(loadingBox)}`);
 
-    // Verify the loading placeholder reserves reasonable space
-    expect(
-      loadingHeight,
-      "WordSimilarity loading placeholder should reserve at least 400px"
-    ).toBeGreaterThanOrEqual(400);
+    const evidenceSuffix = (page.viewportSize()?.width ?? 1280) <= 768
+      ? "mobile"
+      : "desktop";
+    if (process.env.CAPTURE_SKELETON_EVIDENCE === "1") {
+      const performanceToggle = page.getByText("⚡ Performance", { exact: true });
+      if (await performanceToggle.count() === 1) {
+        await performanceToggle.click();
+      }
+      await boundary.screenshot({
+        path: `/tmp/portfolio-word-similarity-skeleton-${evidenceSuffix}.png`,
+      });
+    }
 
     // Fulfill the blocked API request
     for (const route of pendingRoutes) {
@@ -249,12 +270,15 @@ test.describe("Skeleton height stability", () => {
     await page.waitForTimeout(1000);
 
     // Measure the loaded component — same data-testid, now on the loaded wrapper
-    const loadedContainer = page.locator('[data-testid="word-similarity"]').first();
-    const loadedBox = await loadedContainer.boundingBox();
+    const loadedBox = await measureDocumentBox(page, boundary);
     expect(loadedBox).not.toBeNull();
-    const loadedHeight = loadedBox!.height;
-    console.log(`  WordSimilarity loaded height: ${loadedHeight}px`);
-    assertHeightStable(loadingHeight, loadedHeight, "WordSimilarity");
+    console.log(`  WordSimilarity loaded boundary: ${JSON.stringify(loadedBox)}`);
+    if (process.env.CAPTURE_SKELETON_EVIDENCE === "1") {
+      await boundary.screenshot({
+        path: `/tmp/portfolio-word-similarity-loaded-${evidenceSuffix}.png`,
+      });
+    }
+    assertBoxStable(loadingBox!, loadedBox!, "WordSimilarity");
   });
 
   // ---------------------------------------------------------------------------
@@ -268,7 +292,11 @@ test.describe("Skeleton height stability", () => {
     await navigateToReceipt(page);
 
     // CICDLoop has no API — it renders as soon as it enters the viewport.
-    // The placeholder has minHeight matching the SVG height prop.
+    // Measure the reserved boundary before bringing it into view.
+    const boundary = figureBoundary(page, "cicd-loop");
+    const placeholderBox = await measureDocumentBox(page, boundary);
+    expect(placeholderBox).not.toBeNull();
+
     // Scroll to just before the component to see the placeholder first.
     const anchor = page.getByText("LangSmith records what happened", {
       exact: false,
@@ -301,5 +329,9 @@ test.describe("Skeleton height stability", () => {
       // height prop, there should be no shift. Just verify it rendered.
       expect(svgBox!.height).toBeGreaterThan(100);
     }
+
+    const renderedBox = await measureDocumentBox(page, boundary);
+    expect(renderedBox).not.toBeNull();
+    assertBoxStable(placeholderBox!, renderedBox!, "CICDLoop");
   });
 });

--- a/portfolio/pages/receipt.tsx
+++ b/portfolio/pages/receipt.tsx
@@ -53,14 +53,18 @@ interface ReceiptPageProps {
 
 interface FigureBoundaryProps {
   children: React.ReactNode;
-  intrinsicSize?: string;
+  name: string;
+  intrinsicSize: string;
+  mobileIntrinsicSize?: string;
 }
 
 const FIGURE_LAZY_ROOT_MARGIN = "1000px 0px";
 
 const FigureBoundary = ({
   children,
-  intrinsicSize = "600px",
+  name,
+  intrinsicSize,
+  mobileIntrinsicSize = intrinsicSize,
 }: FigureBoundaryProps) => {
   const { ref, inView } = useInView({
     rootMargin: FIGURE_LAZY_ROOT_MARGIN,
@@ -79,11 +83,12 @@ const FigureBoundary = ({
     <div
       ref={ref}
       className={styles.figureBoundary}
+      data-figure-boundary={name}
       data-lazy-pending={shouldRender ? undefined : "true"}
       style={
         {
           "--figure-intrinsic-size": intrinsicSize,
-          minHeight: shouldRender ? undefined : intrinsicSize,
+          "--figure-mobile-intrinsic-size": mobileIntrinsicSize,
         } as React.CSSProperties
       }
     >
@@ -283,7 +288,7 @@ M1LK 2%           1    $4.4g`}</code>
         piece of paper with words on it.
       </p>
 
-      <FigureBoundary intrinsicSize="520px">
+      <FigureBoundary name="page-curl" intrinsicSize="160px">
         <ClientOnly>
           <PageCurlLetter />
         </ClientOnly>
@@ -294,7 +299,11 @@ M1LK 2%           1    $4.4g`}</code>
         paper with words on it out of the image.
       </p>
 
-      <FigureBoundary intrinsicSize="760px">
+      <FigureBoundary
+        name="receipt-bounding-box-grid"
+        intrinsicSize="960px"
+        mobileIntrinsicSize="440px"
+      >
         <ReceiptBoundingBoxGrid />
       </FigureBoundary>
 
@@ -302,7 +311,7 @@ M1LK 2%           1    $4.4g`}</code>
         This flattened receipt is now as clean as it can be.
       </p>
 
-      <FigureBoundary intrinsicSize="760px">
+      <FigureBoundary name="receipt-stack" intrinsicSize="800px">
         <ReceiptStack />
       </FigureBoundary>
 
@@ -317,11 +326,13 @@ M1LK 2%           1    $4.4g`}</code>
         receipt came from.
       </p>
 
-      <ClientOnly>
-        <AnimatedInView>
-          <GoogleMapsLogo />
-        </AnimatedInView>
-      </ClientOnly>
+      <FigureBoundary name="google-maps-logo" intrinsicSize="150px">
+        <ClientOnly>
+          <AnimatedInView>
+            <GoogleMapsLogo />
+          </AnimatedInView>
+        </ClientOnly>
+      </FigureBoundary>
 
       <p>
         First idea: Google Maps. Feed it an address, phone number, website,
@@ -330,11 +341,13 @@ M1LK 2%           1    $4.4g`}</code>
         a better way to group the receipts by store without wasting another $8.
       </p>
 
-      <ClientOnly>
-        <AnimatedInView>
-          <ChromaLogo />
-        </AnimatedInView>
-      </ClientOnly>
+      <FigureBoundary name="chroma-logo" intrinsicSize="150px">
+        <ClientOnly>
+          <AnimatedInView>
+            <ChromaLogo />
+          </AnimatedInView>
+        </ClientOnly>
+      </FigureBoundary>
 
       <p>
         So I added Chroma, a vector database. Great, another database. But
@@ -343,7 +356,11 @@ M1LK 2%           1    $4.4g`}</code>
         this address before?"
       </p>
 
-      <FigureBoundary intrinsicSize="520px">
+      <FigureBoundary
+        name="address-similarity"
+        intrinsicSize="460px"
+        mobileIntrinsicSize="360px"
+      >
         <ClientOnly>
           <AddressSimilaritySideBySide />
         </ClientOnly>
@@ -364,7 +381,11 @@ M1LK 2%           1    $4.4g`}</code>
         formats it differently. I needed a shared vocabulary.
       </p>
 
-      <FigureBoundary intrinsicSize="560px">
+      <FigureBoundary
+        name="label-word-cloud"
+        intrinsicSize="580px"
+        mobileIntrinsicSize="400px"
+      >
         <ClientOnly>
           <LabelWordCloud />
         </ClientOnly>
@@ -377,7 +398,7 @@ M1LK 2%           1    $4.4g`}</code>
         and the arithmetic on the totals.
       </p>
 
-      <FigureBoundary intrinsicSize="780px">
+      <FigureBoundary name="receipt-health" intrinsicSize="660px">
         <ClientOnly>
           <ReceiptHealthExplorer />
         </ClientOnly>
@@ -388,7 +409,11 @@ M1LK 2%           1    $4.4g`}</code>
         results by asking AI to verify them. And again. And again.
       </p>
 
-      <FigureBoundary intrinsicSize="420px">
+      <FigureBoundary
+        name="label-validation"
+        intrinsicSize="900px"
+        mobileIntrinsicSize="900px"
+      >
         <ClientOnly>
           <LabelValidationTimeline />
         </ClientOnly>
@@ -421,7 +446,7 @@ M1LK 2%           1    $4.4g`}</code>
         MILKs" You can't crank both to 100%.
       </p>
 
-      <FigureBoundary intrinsicSize="500px">
+      <FigureBoundary name="precision-recall" intrinsicSize="440px">
         <PrecisionRecallDartboard />
       </FigureBoundary>
 
@@ -431,13 +456,17 @@ M1LK 2%           1    $4.4g`}</code>
         is called hyper-parameter tuning.
       </p>
 
-      <FigureBoundary intrinsicSize="640px">
+      <FigureBoundary
+        name="training-metrics"
+        intrinsicSize="640px"
+        mobileIntrinsicSize="560px"
+      >
         <ClientOnly>
           <TrainingMetricsAnimation />
         </ClientOnly>
       </FigureBoundary>
 
-      <FigureBoundary intrinsicSize="720px">
+      <FigureBoundary name="layoutlm-inference" intrinsicSize="640px">
         <ClientOnly>
           <LayoutLMInferenceVisualization />
         </ClientOnly>
@@ -452,7 +481,7 @@ M1LK 2%           1    $4.4g`}</code>
         failure case. Free labels.
       </p>
 
-      <FigureBoundary intrinsicSize="720px">
+      <FigureBoundary name="synthesis-pipeline" intrinsicSize="640px">
         <ClientOnly>
           <SynthesisPipeline />
         </ClientOnly>
@@ -473,7 +502,7 @@ M1LK 2%           1    $4.4g`}</code>
         afford to find out about the milk.
       </p>
 
-      <FigureBoundary intrinsicSize="260px">
+      <FigureBoundary name="aws-flow" intrinsicSize="240px">
         <ClientOnly>
           <AWSFlowDiagram />
         </ClientOnly>
@@ -491,7 +520,11 @@ M1LK 2%           1    $4.4g`}</code>
       </p>
 
 
-      <FigureBoundary intrinsicSize="280px">
+      <FigureBoundary
+        name="query-transform"
+        intrinsicSize="160px"
+        mobileIntrinsicSize="120px"
+      >
         <ClientOnly>
           <QueryLabelTransform
             query="How much did I spend on milk?"
@@ -505,7 +538,11 @@ M1LK 2%           1    $4.4g`}</code>
         them up.
       </p>
 
-      <FigureBoundary intrinsicSize="900px">
+      <FigureBoundary
+        name="word-similarity"
+        intrinsicSize="1080px"
+        mobileIntrinsicSize="980px"
+      >
         <ClientOnly>
           <WordSimilarity />
         </ClientOnly>
@@ -524,11 +561,13 @@ M1LK 2%           1    $4.4g`}</code>
         doesn't exist? I need to find out.
       </p>
 
-      <ClientOnly>
-        <AnimatedInView>
-          <LangChainLogo />
-        </AnimatedInView>
-      </ClientOnly>
+      <FigureBoundary name="langchain-logo" intrinsicSize="150px">
+        <ClientOnly>
+          <AnimatedInView>
+            <LangChainLogo />
+          </AnimatedInView>
+        </ClientOnly>
+      </FigureBoundary>
 
       <p>
         LangChain lets me wire up the whole pipeline: question in, answer out.
@@ -536,7 +575,11 @@ M1LK 2%           1    $4.4g`}</code>
         the system to see what breaks.
       </p>
 
-      <FigureBoundary intrinsicSize="760px">
+      <FigureBoundary
+        name="qa-agent"
+        intrinsicSize="1040px"
+        mobileIntrinsicSize="1280px"
+      >
         <ClientOnly>
           <QAAgentFigure />
         </ClientOnly>
@@ -546,11 +589,13 @@ M1LK 2%           1    $4.4g`}</code>
         Some work. Some don't. That's the point.
       </p>
 
-      <ClientOnly>
-        <AnimatedInView>
-          <LangSmithLogo />
-        </AnimatedInView>
-      </ClientOnly>
+      <FigureBoundary name="langsmith-logo" intrinsicSize="150px">
+        <ClientOnly>
+          <AnimatedInView>
+            <LangSmithLogo />
+          </AnimatedInView>
+        </ClientOnly>
+      </FigureBoundary>
 
       <p>
         LangSmith records what happened: which questions worked, which failed,
@@ -558,7 +603,7 @@ M1LK 2%           1    $4.4g`}</code>
         it went wrong, and plan a new experiment.
       </p>
 
-      <FigureBoundary intrinsicSize="360px">
+      <FigureBoundary name="cicd-loop" intrinsicSize="320px">
         <ClientOnly>
           <CICDLoop />
         </ClientOnly>
@@ -589,48 +634,60 @@ M1LK 2%           1    $4.4g`}</code>
         spend more time reviewing changes than writing code.
       </p>
 
-      <ClientOnly>
-        <AnimatedInView>
-          <div
-            style={{
-              display: "flex",
-              flexDirection: "row",
-              justifyContent: "center",
-              alignItems: "center",
-              gap: "2rem",
-              flexWrap: "wrap",
-              margin: "2rem 0",
-            }}
-          >
-            <CursorLogo />
-            <ClaudeLogo />
-          </div>
-        </AnimatedInView>
-      </ClientOnly>
+      <FigureBoundary
+        name="cursor-claude-logos"
+        intrinsicSize="220px"
+        mobileIntrinsicSize="400px"
+      >
+        <ClientOnly>
+          <AnimatedInView>
+            <div
+              style={{
+                display: "flex",
+                flexDirection: "row",
+                justifyContent: "center",
+                alignItems: "center",
+                gap: "2rem",
+                flexWrap: "wrap",
+                margin: "2rem 0",
+              }}
+            >
+              <CursorLogo />
+              <ClaudeLogo />
+            </div>
+          </AnimatedInView>
+        </ClientOnly>
+      </FigureBoundary>
 
       <p>
         GitHub Actions let me experiment fast: push a change, watch it break,
         fix it, repeat. Cheap iteration without breaking production.
       </p>
 
-      <ClientOnly>
-        <AnimatedInView>
-          <div
-            style={{
-              display: "flex",
-              flexDirection: "row",
-              justifyContent: "center",
-              alignItems: "center",
-              gap: "2rem",
-              flexWrap: "wrap",
-              margin: "2rem 0",
-            }}
-          >
-            <GithubLogo />
-            <GithubActionsLogo />
-          </div>
-        </AnimatedInView>
-      </ClientOnly>
+      <FigureBoundary
+        name="github-logos"
+        intrinsicSize="220px"
+        mobileIntrinsicSize="400px"
+      >
+        <ClientOnly>
+          <AnimatedInView>
+            <div
+              style={{
+                display: "flex",
+                flexDirection: "row",
+                justifyContent: "center",
+                alignItems: "center",
+                gap: "2rem",
+                flexWrap: "wrap",
+                margin: "2rem 0",
+              }}
+            >
+              <GithubLogo />
+              <GithubActionsLogo />
+            </div>
+          </AnimatedInView>
+        </ClientOnly>
+      </FigureBoundary>
 
       <p>
         I've used Terraform before, but this time I tried Pulumi. It lets me
@@ -638,11 +695,13 @@ M1LK 2%           1    $4.4g`}</code>
         tools I already know.
       </p>
 
-      <ClientOnly>
-        <AnimatedInView>
-          <PulumiLogo />
-        </AnimatedInView>
-      </ClientOnly>
+      <FigureBoundary name="pulumi-logo" intrinsicSize="150px">
+        <ClientOnly>
+          <AnimatedInView>
+            <PulumiLogo />
+          </AnimatedInView>
+        </ClientOnly>
+      </FigureBoundary>
 
       <p>
         This project has a lot of docker containers. My Pulumi hack bundles and
@@ -650,13 +709,19 @@ M1LK 2%           1    $4.4g`}</code>
         melting my laptop.
       </p>
 
-      <ClientOnly>
-        <AnimatedInView>
-          <DockerLogo />
-        </AnimatedInView>
-      </ClientOnly>
+      <FigureBoundary name="docker-logo" intrinsicSize="150px">
+        <ClientOnly>
+          <AnimatedInView>
+            <DockerLogo />
+          </AnimatedInView>
+        </ClientOnly>
+      </FigureBoundary>
 
-      <FigureBoundary intrinsicSize="460px">
+      <FigureBoundary
+        name="codebuild-diagram"
+        intrinsicSize="260px"
+        mobileIntrinsicSize="460px"
+      >
         <ClientOnly>
           <CodeBuildDiagram chars={codeBuildDiagramChars} />
         </ClientOnly>
@@ -668,7 +733,7 @@ M1LK 2%           1    $4.4g`}</code>
         to it.
       </p>
 
-      <FigureBoundary intrinsicSize="240px">
+      <FigureBoundary name="dynamo-stream" intrinsicSize="160px">
         <ClientOnly>
           <DynamoStreamAnimation />
         </ClientOnly>
@@ -679,7 +744,7 @@ M1LK 2%           1    $4.4g`}</code>
         a Lambda picks it up, Chroma gets updated. No polling, no cron jobs.
       </p>
 
-      <FigureBoundary intrinsicSize="360px">
+      <FigureBoundary name="stream-bits-routing" intrinsicSize="360px">
         <ClientOnly>
           <StreamBitsRoutingDiagram />
         </ClientOnly>
@@ -690,7 +755,7 @@ M1LK 2%           1    $4.4g`}</code>
         Things fail, things retry, nothing gets lost.
       </p>
 
-      <FigureBoundary intrinsicSize="360px">
+      <FigureBoundary name="upload-diagram" intrinsicSize="360px">
         <ClientOnly>
           <UploadDiagram chars={uploadDiagramChars} />
         </ClientOnly>

--- a/portfolio/styles/Receipt.module.css
+++ b/portfolio/styles/Receipt.module.css
@@ -40,9 +40,23 @@
 }
 
 .figureBoundary {
+  min-height: var(--figure-intrinsic-size, 600px);
   content-visibility: auto;
   contain-intrinsic-size: auto var(--figure-intrinsic-size, 600px);
   overflow: visible;
+}
+
+@media (max-width: 768px) {
+  .figureBoundary {
+    min-height: var(
+      --figure-mobile-intrinsic-size,
+      var(--figure-intrinsic-size, 600px)
+    );
+    contain-intrinsic-size: auto var(
+      --figure-mobile-intrinsic-size,
+      var(--figure-intrinsic-size, 600px)
+    );
+  }
 }
 
 @supports not (content-visibility: auto) {


### PR DESCRIPTION
## Summary
- keep lazy figure and client-only logo boundaries at stable responsive dimensions through hydration
- replace Word Similarity's text loader with a geometry-matched receipt/table/timing skeleton
- reserve late reader/QA/label content and tighten layout-shift regression coverage to a 1px box tolerance

## Root cause
`FigureBoundary` removed its intrinsic min-height as soon as React mounted, before async children settled. `ClientOnly` logo blocks also had no server-rendered reservation, which WebKit/Safari exposed as a 600px hydration shift.

## Impact
The receipt article now preserves its document geometry while figures hydrate, APIs resolve, and late summaries render on desktop and mobile.

## Validation
- `npm run type-check`
- `npm run lint -- --quiet`
- `npm test -- --runInBand components/analytics/ReaderInsight.test.tsx` (3 passed)
- `npm run build`
- skeleton stability suite across Chromium, Mobile Chrome, Firefox, WebKit, and Mobile Safari (20 project/check combinations)
- production browser smoke test: correct page identity, meaningful content, no framework overlay, clean console