### PR TITLE
Add ReceiptSection QA tools to MCP servers

### DIFF
--- a/infra/mcp_server_lambda/lambdas/receipt_mcp_server_server.py
+++ b/infra/mcp_server_lambda/lambdas/receipt_mcp_server_server.py
@@ -3346,17 +3346,36 @@ async def get_receipt_sections_impl(
         return {"error": str(e)}
 
 
-def _normalize_section_type(section_type):
+# Legacy SectionType values from the superseded 2025-05 experiment. Kept in
+# the enum so old rows still parse, but new MCP-created sections must use the
+# canonical vocabulary. update/delete still accept them so QA can demote or
+# remove stray legacy rows.
+_DEPRECATED_SECTION_TYPES = {"HEADER", "ITEMS_VALUE", "ITEMS_DESCRIPTION"}
+
+
+def _normalize_section_type(section_type, canonical_only=False):
     """Strip/uppercase a section_type and validate it against SectionType.
 
     Returns (normalized_type, None) on success, or (None, error_dict) when
     the value is not in the SectionType enum — catching typos like "ITMES"
     before they become noncanonical SKs or misleading "not found" errors.
+    With canonical_only=True the deprecated legacy values are also rejected,
+    so new rows can't be created with a superseded vocabulary.
     """
     from receipt_dynamo.constants import SectionType
 
     normalized = str(section_type or "").strip().upper()
     valid_types = {t.value for t in SectionType}
+    if canonical_only:
+        valid_types -= _DEPRECATED_SECTION_TYPES
+        if normalized in _DEPRECATED_SECTION_TYPES:
+            return None, {
+                "error": (
+                    f"section_type {normalized!r} is deprecated (superseded "
+                    "2025-05 experiment); use one of "
+                    f"{sorted(valid_types)}"
+                )
+            }
     if normalized not in valid_types:
         return None, {
             "error": (
@@ -3455,7 +3474,9 @@ async def create_receipt_section_impl(
     from receipt_dynamo.entities.receipt_section import ReceiptSection
 
     try:
-        normalized_type, type_error = _normalize_section_type(section_type)
+        normalized_type, type_error = _normalize_section_type(
+            section_type, canonical_only=True
+        )
         if type_error:
             return type_error
         normalized_status = str(validation_status or "VALID").upper()

--- a/infra/mcp_server_lambda/lambdas/receipt_mcp_server_server.py
+++ b/infra/mcp_server_lambda/lambdas/receipt_mcp_server_server.py
@@ -1231,7 +1231,8 @@ By default validation_status is VALID (human-reviewed) and model_source is
 
 WARNING: This WRITES to DynamoDB. Will FAIL if a section with the same
 section_type already exists on the receipt — use update_section_status to
-change an existing section instead.""",
+change an existing section instead. Also fails if the receipt does not exist
+or any line_id is not on the receipt.""",
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -3345,6 +3346,27 @@ async def get_receipt_sections_impl(
         return {"error": str(e)}
 
 
+def _normalize_section_type(section_type):
+    """Strip/uppercase a section_type and validate it against SectionType.
+
+    Returns (normalized_type, None) on success, or (None, error_dict) when
+    the value is not in the SectionType enum — catching typos like "ITMES"
+    before they become noncanonical SKs or misleading "not found" errors.
+    """
+    from receipt_dynamo.constants import SectionType
+
+    normalized = str(section_type or "").strip().upper()
+    valid_types = {t.value for t in SectionType}
+    if normalized not in valid_types:
+        return None, {
+            "error": (
+                f"Invalid section_type {section_type!r}; "
+                f"expected one of {sorted(valid_types)}"
+            )
+        }
+    return normalized, None
+
+
 async def update_section_status_impl(
     dynamo_client,
     image_id: str,
@@ -3358,7 +3380,9 @@ async def update_section_status_impl(
     from receipt_dynamo.entities.receipt_section import ReceiptSection
 
     try:
-        normalized_type = str(section_type or "").upper()
+        normalized_type, type_error = _normalize_section_type(section_type)
+        if type_error:
+            return type_error
         normalized_status = str(validation_status or "").upper()
         allowed = {s.value for s in ValidationStatus}
         if normalized_status not in allowed:
@@ -3426,11 +3450,14 @@ async def create_receipt_section_impl(
     from receipt_dynamo.constants import ValidationStatus
     from receipt_dynamo.data.shared_exceptions import (
         EntityAlreadyExistsError,
+        EntityNotFoundError,
     )
     from receipt_dynamo.entities.receipt_section import ReceiptSection
 
     try:
-        normalized_type = str(section_type or "").upper()
+        normalized_type, type_error = _normalize_section_type(section_type)
+        if type_error:
+            return type_error
         normalized_status = str(validation_status or "VALID").upper()
         allowed = {s.value for s in ValidationStatus}
         if normalized_status not in allowed:
@@ -3447,6 +3474,31 @@ async def create_receipt_section_impl(
             return {"error": "line_ids must be a list of integers"}
         if not normalized_line_ids:
             return {"error": "line_ids must be a non-empty list of integers"}
+
+        # Verify the receipt exists and every line_id belongs to it, so a
+        # typo'd image_id/receipt_id/line_id can't persist an orphan section
+        # or a section pointing at lines the receipt doesn't have.
+        try:
+            details = dynamo_client.get_receipt_details(image_id, receipt_id)
+        except EntityNotFoundError:
+            return {
+                "error": (
+                    f"Receipt {receipt_id} not found for image {image_id}; "
+                    "refusing to create a section for a nonexistent receipt"
+                )
+            }
+        receipt_line_ids = {line.line_id for line in details.lines or []}
+        unknown_line_ids = sorted(
+            set(normalized_line_ids) - receipt_line_ids
+        )
+        if unknown_line_ids:
+            return {
+                "error": (
+                    f"line_ids {unknown_line_ids} do not exist on receipt "
+                    f"{receipt_id} (image {image_id}). Valid line_ids: "
+                    f"{sorted(receipt_line_ids)}"
+                )
+            }
 
         new_section = ReceiptSection(
             receipt_id=receipt_id,
@@ -3492,7 +3544,9 @@ async def delete_receipt_section_impl(
     from receipt_dynamo.data.shared_exceptions import EntityNotFoundError
 
     try:
-        normalized_type = str(section_type or "").upper()
+        normalized_type, type_error = _normalize_section_type(section_type)
+        if type_error:
+            return type_error
         try:
             dynamo_client.delete_receipt_section(
                 receipt_id=receipt_id,

--- a/infra/mcp_server_lambda/lambdas/receipt_mcp_server_server.py
+++ b/infra/mcp_server_lambda/lambdas/receipt_mcp_server_server.py
@@ -1144,6 +1144,158 @@ broken down by validation status (VALID, INVALID, PENDING, NEEDS_REVIEW, NONE).
 Use this to understand training data balance and identify under-represented labels.""",
             inputSchema={"type": "object", "properties": {}},
         ),
+        Tool(
+            name="get_receipt_sections",
+            description="""List a receipt's classified sections for QA review.
+
+Returns every ReceiptSection on the receipt with its section_type, line_ids,
+confidence, model_source, and validation_status. For each section it also
+includes the text of every line it covers, so you can QA a section without a
+second get_receipt call.
+
+model_source distinguishes generations of rows (e.g. "section-seed-v0" for
+hand/heuristic seeds, "section-knn-v1" for KNN-propagated rows). KNN-propagated
+rows land with validation_status=PENDING and need review before they count as
+ground truth.
+
+Use this to inspect sections, then update_section_status to mark each one
+VALID / INVALID / NEEDS_REVIEW.""",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "image_id": {
+                        "type": "string",
+                        "description": "Image ID of the receipt",
+                    },
+                    "receipt_id": {
+                        "type": "integer",
+                        "description": "Receipt ID",
+                    },
+                },
+                "required": ["image_id", "receipt_id"],
+            },
+        ),
+        Tool(
+            name="update_section_status",
+            description="""Update the validation_status of an existing ReceiptSection.
+
+Sets validation_status on a section already present on the receipt. The
+ValidationStatus enum enforces only valid values: NONE, PENDING, VALID,
+INVALID, NEEDS_REVIEW. Errors clearly if the section does not exist.
+
+Use this AFTER reviewing a section with get_receipt_sections. This is the QA
+loop for machine-propagated (e.g. section-knn-v1) PENDING rows: promote correct
+ones to VALID and reject wrong ones as INVALID.
+
+WARNING: This WRITES to DynamoDB.""",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "image_id": {
+                        "type": "string",
+                        "description": "Image ID of the receipt",
+                    },
+                    "receipt_id": {
+                        "type": "integer",
+                        "description": "Receipt ID",
+                    },
+                    "section_type": {
+                        "type": "string",
+                        "description": "The section_type to update (e.g. ITEMS, TOTAL_LINE, PAYMENT)",
+                    },
+                    "validation_status": {
+                        "type": "string",
+                        "enum": ["VALID", "INVALID", "NEEDS_REVIEW", "PENDING", "NONE"],
+                        "description": "The new validation status to set",
+                    },
+                },
+                "required": [
+                    "image_id",
+                    "receipt_id",
+                    "section_type",
+                    "validation_status",
+                ],
+            },
+        ),
+        Tool(
+            name="create_receipt_section",
+            description="""Create a NEW ReceiptSection on a receipt.
+
+Use this to add a section that a reviewer identified but no model seeded, e.g.
+marking lines 20-24 as PAYMENT. section_type must be one of the canonical
+SectionType values (STOREFRONT, ADDRESS, ITEMS, SECTION_HEADER, SUMMARY,
+TOTAL_LINE, PAYMENT, SURVEY, FOOTER, BARCODE).
+
+By default validation_status is VALID (human-reviewed) and model_source is
+"mcp-claude-review".
+
+WARNING: This WRITES to DynamoDB. Will FAIL if a section with the same
+section_type already exists on the receipt — use update_section_status to
+change an existing section instead.""",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "image_id": {
+                        "type": "string",
+                        "description": "Image ID of the receipt",
+                    },
+                    "receipt_id": {
+                        "type": "integer",
+                        "description": "Receipt ID",
+                    },
+                    "section_type": {
+                        "type": "string",
+                        "description": "The canonical section type (e.g. ITEMS, PAYMENT, FOOTER)",
+                    },
+                    "line_ids": {
+                        "type": "array",
+                        "items": {"type": "integer"},
+                        "minItems": 1,
+                        "description": "The line IDs that make up this section",
+                    },
+                    "validation_status": {
+                        "type": "string",
+                        "enum": ["VALID", "INVALID", "NEEDS_REVIEW", "PENDING", "NONE"],
+                        "description": "Validation status for the new section. Defaults to VALID.",
+                    },
+                    "model_source": {
+                        "type": "string",
+                        "description": "Source tag for the row. Defaults to 'mcp-claude-review'.",
+                    },
+                },
+                "required": ["image_id", "receipt_id", "section_type", "line_ids"],
+            },
+        ),
+        Tool(
+            name="delete_receipt_section",
+            description="""Delete a single ReceiptSection row from a receipt.
+
+Removes one section (identified by section_type) from the receipt, leaving the
+rest of the receipt and its other sections intact. Use this to drop a spurious
+or mis-typed section.
+
+Errors clearly if the section does not exist.
+
+WARNING: This WRITES to DynamoDB and is irreversible for that row.""",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "image_id": {
+                        "type": "string",
+                        "description": "Image ID of the receipt",
+                    },
+                    "receipt_id": {
+                        "type": "integer",
+                        "description": "Receipt ID",
+                    },
+                    "section_type": {
+                        "type": "string",
+                        "description": "The section_type to delete (e.g. BARCODE, SURVEY)",
+                    },
+                },
+                "required": ["image_id", "receipt_id", "section_type"],
+            },
+        ),
     ]
 
 
@@ -1298,6 +1450,39 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent]:
                 image_id=arguments["image_id"],
                 receipt_id=arguments["receipt_id"],
                 dry_run=arguments.get("dry_run", True),
+            )
+        elif name == "get_receipt_sections":
+            result = await get_receipt_sections_impl(
+                dynamo_client,
+                image_id=arguments["image_id"],
+                receipt_id=arguments["receipt_id"],
+            )
+        elif name == "update_section_status":
+            result = await update_section_status_impl(
+                dynamo_client,
+                image_id=arguments["image_id"],
+                receipt_id=arguments["receipt_id"],
+                section_type=arguments["section_type"],
+                validation_status=arguments["validation_status"],
+            )
+        elif name == "create_receipt_section":
+            result = await create_receipt_section_impl(
+                dynamo_client,
+                image_id=arguments["image_id"],
+                receipt_id=arguments["receipt_id"],
+                section_type=arguments["section_type"],
+                line_ids=arguments["line_ids"],
+                validation_status=arguments.get("validation_status", "VALID"),
+                model_source=arguments.get(
+                    "model_source", "mcp-claude-review"
+                ),
+            )
+        elif name == "delete_receipt_section":
+            result = await delete_receipt_section_impl(
+                dynamo_client,
+                image_id=arguments["image_id"],
+                receipt_id=arguments["receipt_id"],
+                section_type=arguments["section_type"],
             )
         elif name == "list_training_jobs":
             result = await list_training_jobs_impl(
@@ -3099,6 +3284,240 @@ async def delete_receipt_impl(
 
     except Exception as e:
         logger.exception("Error deleting receipt")
+        return {"error": str(e)}
+
+
+async def get_receipt_sections_impl(
+    dynamo_client, image_id: str, receipt_id: int
+) -> dict:
+    """List a receipt's sections with the text of each section's lines."""
+    from receipt_dynamo.data.shared_exceptions import EntityNotFoundError
+
+    try:
+        try:
+            details = dynamo_client.get_receipt_details(image_id, receipt_id)
+        except EntityNotFoundError:
+            return {
+                "error": (
+                    f"Receipt {receipt_id} not found for image {image_id}"
+                )
+            }
+
+        # line_id -> text so a reviewer can QA sections without a second call
+        line_text = {line.line_id: line.text for line in details.lines or []}
+
+        sections = dynamo_client.get_receipt_sections_from_receipt(
+            image_id, receipt_id
+        )
+
+        section_dicts = []
+        for section in sorted(
+            sections,
+            key=lambda s: (
+                min(s.line_ids) if s.line_ids else 0,
+                s.section_type,
+            ),
+        ):
+            lines = [
+                {"line_id": lid, "text": line_text.get(lid, "")}
+                for lid in section.line_ids
+            ]
+            section_dicts.append(
+                {
+                    "section_type": section.section_type,
+                    "line_ids": section.line_ids,
+                    "confidence": section.confidence,
+                    "model_source": section.model_source,
+                    "validation_status": section.validation_status or "NONE",
+                    "lines": lines,
+                }
+            )
+
+        return {
+            "image_id": image_id,
+            "receipt_id": receipt_id,
+            "section_count": len(section_dicts),
+            "sections": section_dicts,
+        }
+
+    except Exception as e:
+        logger.exception("Error getting receipt sections")
+        return {"error": str(e)}
+
+
+async def update_section_status_impl(
+    dynamo_client,
+    image_id: str,
+    receipt_id: int,
+    section_type: str,
+    validation_status: str,
+) -> dict:
+    """Set the validation_status of an existing ReceiptSection."""
+    from receipt_dynamo.constants import ValidationStatus
+    from receipt_dynamo.data.shared_exceptions import EntityNotFoundError
+    from receipt_dynamo.entities.receipt_section import ReceiptSection
+
+    try:
+        normalized_type = str(section_type or "").upper()
+        normalized_status = str(validation_status or "").upper()
+        allowed = {s.value for s in ValidationStatus}
+        if normalized_status not in allowed:
+            return {
+                "error": (
+                    f"Invalid validation_status {validation_status!r}; "
+                    f"expected one of {sorted(allowed)}"
+                )
+            }
+
+        try:
+            existing = dynamo_client.get_receipt_section(
+                receipt_id=receipt_id,
+                image_id=image_id,
+                section_type=normalized_type,
+            )
+        except EntityNotFoundError:
+            return {
+                "error": (
+                    f"Section {normalized_type!r} not found on receipt "
+                    f"{receipt_id} (image {image_id}). Use "
+                    "get_receipt_sections to list existing sections."
+                )
+            }
+
+        old_status = existing.validation_status or "NONE"
+        updated = ReceiptSection(
+            receipt_id=existing.receipt_id,
+            image_id=existing.image_id,
+            section_type=existing.section_type,
+            line_ids=existing.line_ids,
+            created_at=existing.created_at,
+            confidence=existing.confidence,
+            model_source=existing.model_source,
+            validation_status=normalized_status,
+        )
+        dynamo_client.update_receipt_section(updated)
+
+        return {
+            "success": True,
+            "image_id": image_id,
+            "receipt_id": receipt_id,
+            "section_type": normalized_type,
+            "old_status": old_status,
+            "new_status": normalized_status,
+        }
+
+    except Exception as e:
+        logger.exception("Error updating section status")
+        return {"error": str(e)}
+
+
+async def create_receipt_section_impl(
+    dynamo_client,
+    image_id: str,
+    receipt_id: int,
+    section_type: str,
+    line_ids: list,
+    validation_status: str = "VALID",
+    model_source: str = "mcp-claude-review",
+) -> dict:
+    """Create a new ReceiptSection; fail if the section_type already exists."""
+    from datetime import datetime, timezone
+
+    from receipt_dynamo.constants import ValidationStatus
+    from receipt_dynamo.data.shared_exceptions import (
+        EntityAlreadyExistsError,
+    )
+    from receipt_dynamo.entities.receipt_section import ReceiptSection
+
+    try:
+        normalized_type = str(section_type or "").upper()
+        normalized_status = str(validation_status or "VALID").upper()
+        allowed = {s.value for s in ValidationStatus}
+        if normalized_status not in allowed:
+            return {
+                "error": (
+                    f"Invalid validation_status {validation_status!r}; "
+                    f"expected one of {sorted(allowed)}"
+                )
+            }
+
+        try:
+            normalized_line_ids = [int(lid) for lid in (line_ids or [])]
+        except (TypeError, ValueError):
+            return {"error": "line_ids must be a list of integers"}
+        if not normalized_line_ids:
+            return {"error": "line_ids must be a non-empty list of integers"}
+
+        new_section = ReceiptSection(
+            receipt_id=receipt_id,
+            image_id=image_id,
+            section_type=normalized_type,
+            line_ids=normalized_line_ids,
+            created_at=datetime.now(timezone.utc),
+            model_source=model_source,
+            validation_status=normalized_status,
+        )
+
+        try:
+            dynamo_client.add_receipt_section(new_section)
+        except EntityAlreadyExistsError:
+            return {
+                "error": (
+                    f"Section {normalized_type!r} already exists on receipt "
+                    f"{receipt_id} (image {image_id}). Use "
+                    "update_section_status to change it, or "
+                    "delete_receipt_section first."
+                )
+            }
+
+        return {
+            "success": True,
+            "image_id": image_id,
+            "receipt_id": receipt_id,
+            "section_type": normalized_type,
+            "line_ids": normalized_line_ids,
+            "validation_status": normalized_status,
+            "model_source": model_source,
+        }
+
+    except Exception as e:
+        logger.exception("Error creating receipt section")
+        return {"error": str(e)}
+
+
+async def delete_receipt_section_impl(
+    dynamo_client, image_id: str, receipt_id: int, section_type: str
+) -> dict:
+    """Delete a single ReceiptSection row from a receipt."""
+    from receipt_dynamo.data.shared_exceptions import EntityNotFoundError
+
+    try:
+        normalized_type = str(section_type or "").upper()
+        try:
+            dynamo_client.delete_receipt_section(
+                receipt_id=receipt_id,
+                image_id=image_id,
+                section_type=normalized_type,
+            )
+        except EntityNotFoundError:
+            return {
+                "error": (
+                    f"Section {normalized_type!r} not found on receipt "
+                    f"{receipt_id} (image {image_id}). Use "
+                    "get_receipt_sections to list existing sections."
+                )
+            }
+
+        return {
+            "success": True,
+            "image_id": image_id,
+            "receipt_id": receipt_id,
+            "section_type": normalized_type,
+            "deleted": True,
+        }
+
+    except Exception as e:
+        logger.exception("Error deleting receipt section")
         return {"error": str(e)}
 
 

--- a/scripts/receipt_mcp_server.py
+++ b/scripts/receipt_mcp_server.py
@@ -1130,6 +1130,158 @@ broken down by validation status (VALID, INVALID, PENDING, NEEDS_REVIEW, NONE).
 Use this to understand training data balance and identify under-represented labels.""",
             inputSchema={"type": "object", "properties": {}},
         ),
+        Tool(
+            name="get_receipt_sections",
+            description="""List a receipt's classified sections for QA review.
+
+Returns every ReceiptSection on the receipt with its section_type, line_ids,
+confidence, model_source, and validation_status. For each section it also
+includes the text of every line it covers, so you can QA a section without a
+second get_receipt call.
+
+model_source distinguishes generations of rows (e.g. "section-seed-v0" for
+hand/heuristic seeds, "section-knn-v1" for KNN-propagated rows). KNN-propagated
+rows land with validation_status=PENDING and need review before they count as
+ground truth.
+
+Use this to inspect sections, then update_section_status to mark each one
+VALID / INVALID / NEEDS_REVIEW.""",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "image_id": {
+                        "type": "string",
+                        "description": "Image ID of the receipt",
+                    },
+                    "receipt_id": {
+                        "type": "integer",
+                        "description": "Receipt ID",
+                    },
+                },
+                "required": ["image_id", "receipt_id"],
+            },
+        ),
+        Tool(
+            name="update_section_status",
+            description="""Update the validation_status of an existing ReceiptSection.
+
+Sets validation_status on a section already present on the receipt. The
+ValidationStatus enum enforces only valid values: NONE, PENDING, VALID,
+INVALID, NEEDS_REVIEW. Errors clearly if the section does not exist.
+
+Use this AFTER reviewing a section with get_receipt_sections. This is the QA
+loop for machine-propagated (e.g. section-knn-v1) PENDING rows: promote correct
+ones to VALID and reject wrong ones as INVALID.
+
+WARNING: This WRITES to DynamoDB.""",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "image_id": {
+                        "type": "string",
+                        "description": "Image ID of the receipt",
+                    },
+                    "receipt_id": {
+                        "type": "integer",
+                        "description": "Receipt ID",
+                    },
+                    "section_type": {
+                        "type": "string",
+                        "description": "The section_type to update (e.g. ITEMS, TOTAL_LINE, PAYMENT)",
+                    },
+                    "validation_status": {
+                        "type": "string",
+                        "enum": ["VALID", "INVALID", "NEEDS_REVIEW", "PENDING", "NONE"],
+                        "description": "The new validation status to set",
+                    },
+                },
+                "required": [
+                    "image_id",
+                    "receipt_id",
+                    "section_type",
+                    "validation_status",
+                ],
+            },
+        ),
+        Tool(
+            name="create_receipt_section",
+            description="""Create a NEW ReceiptSection on a receipt.
+
+Use this to add a section that a reviewer identified but no model seeded, e.g.
+marking lines 20-24 as PAYMENT. section_type must be one of the canonical
+SectionType values (STOREFRONT, ADDRESS, ITEMS, SECTION_HEADER, SUMMARY,
+TOTAL_LINE, PAYMENT, SURVEY, FOOTER, BARCODE).
+
+By default validation_status is VALID (human-reviewed) and model_source is
+"mcp-claude-review".
+
+WARNING: This WRITES to DynamoDB. Will FAIL if a section with the same
+section_type already exists on the receipt — use update_section_status to
+change an existing section instead.""",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "image_id": {
+                        "type": "string",
+                        "description": "Image ID of the receipt",
+                    },
+                    "receipt_id": {
+                        "type": "integer",
+                        "description": "Receipt ID",
+                    },
+                    "section_type": {
+                        "type": "string",
+                        "description": "The canonical section type (e.g. ITEMS, PAYMENT, FOOTER)",
+                    },
+                    "line_ids": {
+                        "type": "array",
+                        "items": {"type": "integer"},
+                        "minItems": 1,
+                        "description": "The line IDs that make up this section",
+                    },
+                    "validation_status": {
+                        "type": "string",
+                        "enum": ["VALID", "INVALID", "NEEDS_REVIEW", "PENDING", "NONE"],
+                        "description": "Validation status for the new section. Defaults to VALID.",
+                    },
+                    "model_source": {
+                        "type": "string",
+                        "description": "Source tag for the row. Defaults to 'mcp-claude-review'.",
+                    },
+                },
+                "required": ["image_id", "receipt_id", "section_type", "line_ids"],
+            },
+        ),
+        Tool(
+            name="delete_receipt_section",
+            description="""Delete a single ReceiptSection row from a receipt.
+
+Removes one section (identified by section_type) from the receipt, leaving the
+rest of the receipt and its other sections intact. Use this to drop a spurious
+or mis-typed section.
+
+Errors clearly if the section does not exist.
+
+WARNING: This WRITES to DynamoDB and is irreversible for that row.""",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "image_id": {
+                        "type": "string",
+                        "description": "Image ID of the receipt",
+                    },
+                    "receipt_id": {
+                        "type": "integer",
+                        "description": "Receipt ID",
+                    },
+                    "section_type": {
+                        "type": "string",
+                        "description": "The section_type to delete (e.g. BARCODE, SURVEY)",
+                    },
+                },
+                "required": ["image_id", "receipt_id", "section_type"],
+            },
+        ),
     ]
 
 
@@ -1284,6 +1436,39 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent]:
                 image_id=arguments["image_id"],
                 receipt_id=arguments["receipt_id"],
                 dry_run=arguments.get("dry_run", True),
+            )
+        elif name == "get_receipt_sections":
+            result = await get_receipt_sections_impl(
+                dynamo_client,
+                image_id=arguments["image_id"],
+                receipt_id=arguments["receipt_id"],
+            )
+        elif name == "update_section_status":
+            result = await update_section_status_impl(
+                dynamo_client,
+                image_id=arguments["image_id"],
+                receipt_id=arguments["receipt_id"],
+                section_type=arguments["section_type"],
+                validation_status=arguments["validation_status"],
+            )
+        elif name == "create_receipt_section":
+            result = await create_receipt_section_impl(
+                dynamo_client,
+                image_id=arguments["image_id"],
+                receipt_id=arguments["receipt_id"],
+                section_type=arguments["section_type"],
+                line_ids=arguments["line_ids"],
+                validation_status=arguments.get("validation_status", "VALID"),
+                model_source=arguments.get(
+                    "model_source", "mcp-claude-review"
+                ),
+            )
+        elif name == "delete_receipt_section":
+            result = await delete_receipt_section_impl(
+                dynamo_client,
+                image_id=arguments["image_id"],
+                receipt_id=arguments["receipt_id"],
+                section_type=arguments["section_type"],
             )
         elif name == "list_training_jobs":
             result = await list_training_jobs_impl(
@@ -3085,6 +3270,240 @@ async def delete_receipt_impl(
 
     except Exception as e:
         logger.exception("Error deleting receipt")
+        return {"error": str(e)}
+
+
+async def get_receipt_sections_impl(
+    dynamo_client, image_id: str, receipt_id: int
+) -> dict:
+    """List a receipt's sections with the text of each section's lines."""
+    from receipt_dynamo.data.shared_exceptions import EntityNotFoundError
+
+    try:
+        try:
+            details = dynamo_client.get_receipt_details(image_id, receipt_id)
+        except EntityNotFoundError:
+            return {
+                "error": (
+                    f"Receipt {receipt_id} not found for image {image_id}"
+                )
+            }
+
+        # line_id -> text so a reviewer can QA sections without a second call
+        line_text = {line.line_id: line.text for line in details.lines or []}
+
+        sections = dynamo_client.get_receipt_sections_from_receipt(
+            image_id, receipt_id
+        )
+
+        section_dicts = []
+        for section in sorted(
+            sections,
+            key=lambda s: (
+                min(s.line_ids) if s.line_ids else 0,
+                s.section_type,
+            ),
+        ):
+            lines = [
+                {"line_id": lid, "text": line_text.get(lid, "")}
+                for lid in section.line_ids
+            ]
+            section_dicts.append(
+                {
+                    "section_type": section.section_type,
+                    "line_ids": section.line_ids,
+                    "confidence": section.confidence,
+                    "model_source": section.model_source,
+                    "validation_status": section.validation_status or "NONE",
+                    "lines": lines,
+                }
+            )
+
+        return {
+            "image_id": image_id,
+            "receipt_id": receipt_id,
+            "section_count": len(section_dicts),
+            "sections": section_dicts,
+        }
+
+    except Exception as e:
+        logger.exception("Error getting receipt sections")
+        return {"error": str(e)}
+
+
+async def update_section_status_impl(
+    dynamo_client,
+    image_id: str,
+    receipt_id: int,
+    section_type: str,
+    validation_status: str,
+) -> dict:
+    """Set the validation_status of an existing ReceiptSection."""
+    from receipt_dynamo.constants import ValidationStatus
+    from receipt_dynamo.data.shared_exceptions import EntityNotFoundError
+    from receipt_dynamo.entities.receipt_section import ReceiptSection
+
+    try:
+        normalized_type = str(section_type or "").upper()
+        normalized_status = str(validation_status or "").upper()
+        allowed = {s.value for s in ValidationStatus}
+        if normalized_status not in allowed:
+            return {
+                "error": (
+                    f"Invalid validation_status {validation_status!r}; "
+                    f"expected one of {sorted(allowed)}"
+                )
+            }
+
+        try:
+            existing = dynamo_client.get_receipt_section(
+                receipt_id=receipt_id,
+                image_id=image_id,
+                section_type=normalized_type,
+            )
+        except EntityNotFoundError:
+            return {
+                "error": (
+                    f"Section {normalized_type!r} not found on receipt "
+                    f"{receipt_id} (image {image_id}). Use "
+                    "get_receipt_sections to list existing sections."
+                )
+            }
+
+        old_status = existing.validation_status or "NONE"
+        updated = ReceiptSection(
+            receipt_id=existing.receipt_id,
+            image_id=existing.image_id,
+            section_type=existing.section_type,
+            line_ids=existing.line_ids,
+            created_at=existing.created_at,
+            confidence=existing.confidence,
+            model_source=existing.model_source,
+            validation_status=normalized_status,
+        )
+        dynamo_client.update_receipt_section(updated)
+
+        return {
+            "success": True,
+            "image_id": image_id,
+            "receipt_id": receipt_id,
+            "section_type": normalized_type,
+            "old_status": old_status,
+            "new_status": normalized_status,
+        }
+
+    except Exception as e:
+        logger.exception("Error updating section status")
+        return {"error": str(e)}
+
+
+async def create_receipt_section_impl(
+    dynamo_client,
+    image_id: str,
+    receipt_id: int,
+    section_type: str,
+    line_ids: list,
+    validation_status: str = "VALID",
+    model_source: str = "mcp-claude-review",
+) -> dict:
+    """Create a new ReceiptSection; fail if the section_type already exists."""
+    from datetime import datetime, timezone
+
+    from receipt_dynamo.constants import ValidationStatus
+    from receipt_dynamo.data.shared_exceptions import (
+        EntityAlreadyExistsError,
+    )
+    from receipt_dynamo.entities.receipt_section import ReceiptSection
+
+    try:
+        normalized_type = str(section_type or "").upper()
+        normalized_status = str(validation_status or "VALID").upper()
+        allowed = {s.value for s in ValidationStatus}
+        if normalized_status not in allowed:
+            return {
+                "error": (
+                    f"Invalid validation_status {validation_status!r}; "
+                    f"expected one of {sorted(allowed)}"
+                )
+            }
+
+        try:
+            normalized_line_ids = [int(lid) for lid in (line_ids or [])]
+        except (TypeError, ValueError):
+            return {"error": "line_ids must be a list of integers"}
+        if not normalized_line_ids:
+            return {"error": "line_ids must be a non-empty list of integers"}
+
+        new_section = ReceiptSection(
+            receipt_id=receipt_id,
+            image_id=image_id,
+            section_type=normalized_type,
+            line_ids=normalized_line_ids,
+            created_at=datetime.now(timezone.utc),
+            model_source=model_source,
+            validation_status=normalized_status,
+        )
+
+        try:
+            dynamo_client.add_receipt_section(new_section)
+        except EntityAlreadyExistsError:
+            return {
+                "error": (
+                    f"Section {normalized_type!r} already exists on receipt "
+                    f"{receipt_id} (image {image_id}). Use "
+                    "update_section_status to change it, or "
+                    "delete_receipt_section first."
+                )
+            }
+
+        return {
+            "success": True,
+            "image_id": image_id,
+            "receipt_id": receipt_id,
+            "section_type": normalized_type,
+            "line_ids": normalized_line_ids,
+            "validation_status": normalized_status,
+            "model_source": model_source,
+        }
+
+    except Exception as e:
+        logger.exception("Error creating receipt section")
+        return {"error": str(e)}
+
+
+async def delete_receipt_section_impl(
+    dynamo_client, image_id: str, receipt_id: int, section_type: str
+) -> dict:
+    """Delete a single ReceiptSection row from a receipt."""
+    from receipt_dynamo.data.shared_exceptions import EntityNotFoundError
+
+    try:
+        normalized_type = str(section_type or "").upper()
+        try:
+            dynamo_client.delete_receipt_section(
+                receipt_id=receipt_id,
+                image_id=image_id,
+                section_type=normalized_type,
+            )
+        except EntityNotFoundError:
+            return {
+                "error": (
+                    f"Section {normalized_type!r} not found on receipt "
+                    f"{receipt_id} (image {image_id}). Use "
+                    "get_receipt_sections to list existing sections."
+                )
+            }
+
+        return {
+            "success": True,
+            "image_id": image_id,
+            "receipt_id": receipt_id,
+            "section_type": normalized_type,
+            "deleted": True,
+        }
+
+    except Exception as e:
+        logger.exception("Error deleting receipt section")
         return {"error": str(e)}
 
 

--- a/scripts/receipt_mcp_server.py
+++ b/scripts/receipt_mcp_server.py
@@ -1217,7 +1217,8 @@ By default validation_status is VALID (human-reviewed) and model_source is
 
 WARNING: This WRITES to DynamoDB. Will FAIL if a section with the same
 section_type already exists on the receipt — use update_section_status to
-change an existing section instead.""",
+change an existing section instead. Also fails if the receipt does not exist
+or any line_id is not on the receipt.""",
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -3331,6 +3332,27 @@ async def get_receipt_sections_impl(
         return {"error": str(e)}
 
 
+def _normalize_section_type(section_type):
+    """Strip/uppercase a section_type and validate it against SectionType.
+
+    Returns (normalized_type, None) on success, or (None, error_dict) when
+    the value is not in the SectionType enum — catching typos like "ITMES"
+    before they become noncanonical SKs or misleading "not found" errors.
+    """
+    from receipt_dynamo.constants import SectionType
+
+    normalized = str(section_type or "").strip().upper()
+    valid_types = {t.value for t in SectionType}
+    if normalized not in valid_types:
+        return None, {
+            "error": (
+                f"Invalid section_type {section_type!r}; "
+                f"expected one of {sorted(valid_types)}"
+            )
+        }
+    return normalized, None
+
+
 async def update_section_status_impl(
     dynamo_client,
     image_id: str,
@@ -3344,7 +3366,9 @@ async def update_section_status_impl(
     from receipt_dynamo.entities.receipt_section import ReceiptSection
 
     try:
-        normalized_type = str(section_type or "").upper()
+        normalized_type, type_error = _normalize_section_type(section_type)
+        if type_error:
+            return type_error
         normalized_status = str(validation_status or "").upper()
         allowed = {s.value for s in ValidationStatus}
         if normalized_status not in allowed:
@@ -3412,11 +3436,14 @@ async def create_receipt_section_impl(
     from receipt_dynamo.constants import ValidationStatus
     from receipt_dynamo.data.shared_exceptions import (
         EntityAlreadyExistsError,
+        EntityNotFoundError,
     )
     from receipt_dynamo.entities.receipt_section import ReceiptSection
 
     try:
-        normalized_type = str(section_type or "").upper()
+        normalized_type, type_error = _normalize_section_type(section_type)
+        if type_error:
+            return type_error
         normalized_status = str(validation_status or "VALID").upper()
         allowed = {s.value for s in ValidationStatus}
         if normalized_status not in allowed:
@@ -3433,6 +3460,31 @@ async def create_receipt_section_impl(
             return {"error": "line_ids must be a list of integers"}
         if not normalized_line_ids:
             return {"error": "line_ids must be a non-empty list of integers"}
+
+        # Verify the receipt exists and every line_id belongs to it, so a
+        # typo'd image_id/receipt_id/line_id can't persist an orphan section
+        # or a section pointing at lines the receipt doesn't have.
+        try:
+            details = dynamo_client.get_receipt_details(image_id, receipt_id)
+        except EntityNotFoundError:
+            return {
+                "error": (
+                    f"Receipt {receipt_id} not found for image {image_id}; "
+                    "refusing to create a section for a nonexistent receipt"
+                )
+            }
+        receipt_line_ids = {line.line_id for line in details.lines or []}
+        unknown_line_ids = sorted(
+            set(normalized_line_ids) - receipt_line_ids
+        )
+        if unknown_line_ids:
+            return {
+                "error": (
+                    f"line_ids {unknown_line_ids} do not exist on receipt "
+                    f"{receipt_id} (image {image_id}). Valid line_ids: "
+                    f"{sorted(receipt_line_ids)}"
+                )
+            }
 
         new_section = ReceiptSection(
             receipt_id=receipt_id,
@@ -3478,7 +3530,9 @@ async def delete_receipt_section_impl(
     from receipt_dynamo.data.shared_exceptions import EntityNotFoundError
 
     try:
-        normalized_type = str(section_type or "").upper()
+        normalized_type, type_error = _normalize_section_type(section_type)
+        if type_error:
+            return type_error
         try:
             dynamo_client.delete_receipt_section(
                 receipt_id=receipt_id,

--- a/scripts/receipt_mcp_server.py
+++ b/scripts/receipt_mcp_server.py
@@ -3332,17 +3332,36 @@ async def get_receipt_sections_impl(
         return {"error": str(e)}
 
 
-def _normalize_section_type(section_type):
+# Legacy SectionType values from the superseded 2025-05 experiment. Kept in
+# the enum so old rows still parse, but new MCP-created sections must use the
+# canonical vocabulary. update/delete still accept them so QA can demote or
+# remove stray legacy rows.
+_DEPRECATED_SECTION_TYPES = {"HEADER", "ITEMS_VALUE", "ITEMS_DESCRIPTION"}
+
+
+def _normalize_section_type(section_type, canonical_only=False):
     """Strip/uppercase a section_type and validate it against SectionType.
 
     Returns (normalized_type, None) on success, or (None, error_dict) when
     the value is not in the SectionType enum — catching typos like "ITMES"
     before they become noncanonical SKs or misleading "not found" errors.
+    With canonical_only=True the deprecated legacy values are also rejected,
+    so new rows can't be created with a superseded vocabulary.
     """
     from receipt_dynamo.constants import SectionType
 
     normalized = str(section_type or "").strip().upper()
     valid_types = {t.value for t in SectionType}
+    if canonical_only:
+        valid_types -= _DEPRECATED_SECTION_TYPES
+        if normalized in _DEPRECATED_SECTION_TYPES:
+            return None, {
+                "error": (
+                    f"section_type {normalized!r} is deprecated (superseded "
+                    "2025-05 experiment); use one of "
+                    f"{sorted(valid_types)}"
+                )
+            }
     if normalized not in valid_types:
         return None, {
             "error": (
@@ -3441,7 +3460,9 @@ async def create_receipt_section_impl(
     from receipt_dynamo.entities.receipt_section import ReceiptSection
 
     try:
-        normalized_type, type_error = _normalize_section_type(section_type)
+        normalized_type, type_error = _normalize_section_type(
+            section_type, canonical_only=True
+        )
         if type_error:
             return type_error
         normalized_status = str(validation_status or "VALID").upper()

--- a/tests/test_receipt_mcp_section_tools.py
+++ b/tests/test_receipt_mcp_section_tools.py
@@ -284,3 +284,43 @@ def test_update_and_delete_reject_invalid_section_type(label, impl_name, args):
     assert "error" in result
     assert "Invalid section_type" in result["error"]
     assert "ITEMS" in result["error"]
+
+
+@pytest.mark.parametrize("label", sorted(SERVER_FILES))
+@pytest.mark.parametrize(
+    "legacy_type", ["HEADER", "ITEMS_VALUE", "ITEMS_DESCRIPTION"]
+)
+def test_create_rejects_deprecated_section_types(label, legacy_type):
+    pytest.importorskip("receipt_dynamo")
+    module = _load_module(label, SERVER_FILES[label])
+    client = _StubDynamoClient(line_ids=(1, 2, 3))
+    result = asyncio.run(
+        module.create_receipt_section_impl(
+            client, VALID_IMAGE_ID, 1, legacy_type, [1]
+        )
+    )
+    assert "error" in result
+    assert "deprecated" in result["error"]
+    assert client.added_sections == []
+
+
+@pytest.mark.parametrize("label", sorted(SERVER_FILES))
+def test_delete_still_accepts_deprecated_section_types(label):
+    """QA must be able to remove stray legacy rows even though create can't
+    mint new ones."""
+    pytest.importorskip("receipt_dynamo")
+    module = _load_module(label, SERVER_FILES[label])
+
+    deleted = []
+
+    class _DeleteClient:
+        def delete_receipt_section(self, receipt_id, image_id, section_type):
+            deleted.append((receipt_id, image_id, section_type))
+
+    result = asyncio.run(
+        module.delete_receipt_section_impl(
+            _DeleteClient(), VALID_IMAGE_ID, 1, "HEADER"
+        )
+    )
+    assert result.get("success") is True
+    assert deleted == [(1, VALID_IMAGE_ID, "HEADER")]

--- a/tests/test_receipt_mcp_section_tools.py
+++ b/tests/test_receipt_mcp_section_tools.py
@@ -1,0 +1,156 @@
+"""Tests for the ReceiptSection QA tools on both MCP server implementations.
+
+The two servers (stdio `scripts/receipt_mcp_server.py` and the Lambda
+`infra/mcp_server_lambda/lambdas/receipt_mcp_server_server.py`) must expose the
+same tool surface. These tests import each module with a minimal fake `mcp`
+package (the real dependency is not installed in CI) and assert the four
+section tools are registered with valid input schemas and matching impls.
+"""
+
+import asyncio
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+SERVER_FILES = {
+    "stdio": REPO_ROOT / "scripts" / "receipt_mcp_server.py",
+    "lambda": (
+        REPO_ROOT
+        / "infra"
+        / "mcp_server_lambda"
+        / "lambdas"
+        / "receipt_mcp_server_server.py"
+    ),
+}
+
+EXPECTED_SECTION_TOOLS = {
+    "get_receipt_sections",
+    "update_section_status",
+    "create_receipt_section",
+    "delete_receipt_section",
+}
+
+
+class _FakeTool:
+    """Stand-in for mcp.types.Tool that just records its fields."""
+
+    def __init__(self, name, description, inputSchema):
+        self.name = name
+        self.description = description
+        self.inputSchema = inputSchema
+
+
+def _install_mcp_stubs():
+    """Register a minimal fake `mcp` package so the servers import cleanly."""
+    mcp_mod = types.ModuleType("mcp")
+    server_mod = types.ModuleType("mcp.server")
+    stdio_mod = types.ModuleType("mcp.server.stdio")
+    types_mod = types.ModuleType("mcp.types")
+
+    class _FakeServer:
+        def __init__(self, name):
+            self.name = name
+
+        def list_tools(self):
+            def decorator(func):
+                return func
+
+            return decorator
+
+        def call_tool(self):
+            def decorator(func):
+                return func
+
+            return decorator
+
+    def _fake_stdio_server(*args, **kwargs):  # pragma: no cover - unused
+        raise RuntimeError("stdio_server is not exercised in tests")
+
+    server_mod.Server = _FakeServer
+    stdio_mod.stdio_server = _fake_stdio_server
+    types_mod.Tool = _FakeTool
+    types_mod.TextContent = object
+
+    sys.modules["mcp"] = mcp_mod
+    sys.modules["mcp.server"] = server_mod
+    sys.modules["mcp.server.stdio"] = stdio_mod
+    sys.modules["mcp.types"] = types_mod
+
+
+def _load_module(label, path):
+    _install_mcp_stubs()
+    spec = importlib.util.spec_from_file_location(
+        f"receipt_mcp_server_{label}", path
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.parametrize("label", sorted(SERVER_FILES))
+def test_section_tools_present_with_valid_schema(label):
+    module = _load_module(label, SERVER_FILES[label])
+    tools = asyncio.run(module.list_tools())
+    by_name = {t.name: t for t in tools}
+
+    missing = EXPECTED_SECTION_TOOLS - set(by_name)
+    assert not missing, f"missing section tools in {label}: {missing}"
+
+    for name in EXPECTED_SECTION_TOOLS:
+        tool = by_name[name]
+        schema = tool.inputSchema
+        assert isinstance(schema, dict)
+        assert schema.get("type") == "object"
+        assert isinstance(schema.get("properties"), dict)
+        assert "image_id" in schema["properties"]
+        assert "receipt_id" in schema["properties"]
+        assert isinstance(schema.get("required"), list)
+        assert "image_id" in schema["required"]
+        assert "receipt_id" in schema["required"]
+        assert isinstance(tool.description, str) and tool.description.strip()
+
+    # get_receipt_sections is read-only: exactly the two identity keys.
+    assert set(by_name["get_receipt_sections"].inputSchema["required"]) == {
+        "image_id",
+        "receipt_id",
+    }
+
+    # create/update/delete carry the section payload.
+    assert {"section_type", "line_ids"} <= set(
+        by_name["create_receipt_section"].inputSchema["required"]
+    )
+    assert {"section_type", "validation_status"} <= set(
+        by_name["update_section_status"].inputSchema["required"]
+    )
+    assert "section_type" in set(
+        by_name["delete_receipt_section"].inputSchema["required"]
+    )
+
+
+@pytest.mark.parametrize("label", sorted(SERVER_FILES))
+def test_section_tool_impls_exist(label):
+    module = _load_module(label, SERVER_FILES[label])
+    for name in EXPECTED_SECTION_TOOLS:
+        impl = getattr(module, f"{name}_impl", None)
+        assert callable(impl), f"missing {name}_impl in {label} server"
+
+
+def test_both_servers_expose_identical_section_tool_shape():
+    stdio = _load_module("stdio", SERVER_FILES["stdio"])
+    lam = _load_module("lambda", SERVER_FILES["lambda"])
+
+    def shape(module):
+        tools = asyncio.run(module.list_tools())
+        return {
+            t.name: (t.description, t.inputSchema)
+            for t in tools
+            if t.name in EXPECTED_SECTION_TOOLS
+        }
+
+    assert shape(stdio) == shape(lam)

--- a/tests/test_receipt_mcp_section_tools.py
+++ b/tests/test_receipt_mcp_section_tools.py
@@ -154,3 +154,133 @@ def test_both_servers_expose_identical_section_tool_shape():
         }
 
     assert shape(stdio) == shape(lam)
+
+
+# ---------------------------------------------------------------------------
+# Corruption-path tests: the impls must refuse writes that would persist bad
+# rows (noncanonical section_type SKs, orphan sections, invalid line refs).
+# These exercise the impl functions with a stub dynamo client and need the
+# real receipt_dynamo package for its enums/exceptions.
+# ---------------------------------------------------------------------------
+
+VALID_IMAGE_ID = "3f2a1b0c-4d5e-4f70-8192-a3b4c5d6e7f8"
+
+
+class _StubLine:
+    def __init__(self, line_id):
+        self.line_id = line_id
+        self.text = f"line {line_id}"
+
+
+class _StubDetails:
+    def __init__(self, line_ids):
+        self.lines = [_StubLine(i) for i in line_ids]
+
+
+class _StubDynamoClient:
+    """Stub client recording writes; configurable receipt lines."""
+
+    def __init__(self, line_ids=(1, 2, 3), receipt_exists=True):
+        self._line_ids = line_ids
+        self._receipt_exists = receipt_exists
+        self.added_sections = []
+
+    def get_receipt_details(self, image_id, receipt_id):
+        if not self._receipt_exists:
+            from receipt_dynamo.data.shared_exceptions import (
+                EntityNotFoundError,
+            )
+
+            raise EntityNotFoundError("receipt not found")
+        return _StubDetails(self._line_ids)
+
+    def add_receipt_section(self, section):
+        self.added_sections.append(section)
+
+
+@pytest.mark.parametrize("label", sorted(SERVER_FILES))
+def test_create_rejects_invalid_section_type(label):
+    pytest.importorskip("receipt_dynamo")
+    module = _load_module(label, SERVER_FILES[label])
+    client = _StubDynamoClient()
+    result = asyncio.run(
+        module.create_receipt_section_impl(
+            client, VALID_IMAGE_ID, 1, "ITMES", [1, 2]
+        )
+    )
+    assert "error" in result
+    assert "Invalid section_type" in result["error"]
+    assert "ITEMS" in result["error"]  # lists the valid values
+    assert client.added_sections == []
+
+
+@pytest.mark.parametrize("label", sorted(SERVER_FILES))
+def test_create_rejects_line_ids_not_on_receipt(label):
+    pytest.importorskip("receipt_dynamo")
+    module = _load_module(label, SERVER_FILES[label])
+    client = _StubDynamoClient(line_ids=(1, 2, 3))
+    result = asyncio.run(
+        module.create_receipt_section_impl(
+            client, VALID_IMAGE_ID, 1, "ITEMS", [2, 99]
+        )
+    )
+    assert "error" in result
+    assert "99" in result["error"]
+    assert "do not exist on receipt" in result["error"]
+    assert client.added_sections == []
+
+
+@pytest.mark.parametrize("label", sorted(SERVER_FILES))
+def test_create_rejects_nonexistent_receipt(label):
+    pytest.importorskip("receipt_dynamo")
+    module = _load_module(label, SERVER_FILES[label])
+    client = _StubDynamoClient(receipt_exists=False)
+    result = asyncio.run(
+        module.create_receipt_section_impl(
+            client, VALID_IMAGE_ID, 42, "ITEMS", [1]
+        )
+    )
+    assert "error" in result
+    assert "not found" in result["error"]
+    assert client.added_sections == []
+
+
+@pytest.mark.parametrize("label", sorted(SERVER_FILES))
+def test_create_succeeds_for_valid_input(label):
+    pytest.importorskip("receipt_dynamo")
+    module = _load_module(label, SERVER_FILES[label])
+    client = _StubDynamoClient(line_ids=(1, 2, 3))
+    result = asyncio.run(
+        module.create_receipt_section_impl(
+            client, VALID_IMAGE_ID, 1, " items ", [1, 2]
+        )
+    )
+    assert result.get("success") is True
+    assert result["section_type"] == "ITEMS"  # stripped + uppercased
+    assert len(client.added_sections) == 1
+    assert client.added_sections[0].section_type == "ITEMS"
+
+
+@pytest.mark.parametrize("label", sorted(SERVER_FILES))
+@pytest.mark.parametrize(
+    "impl_name,args",
+    [
+        ("update_section_status_impl", ("ITMES", "VALID")),
+        ("delete_receipt_section_impl", ("ITMES",)),
+    ],
+)
+def test_update_and_delete_reject_invalid_section_type(label, impl_name, args):
+    pytest.importorskip("receipt_dynamo")
+    module = _load_module(label, SERVER_FILES[label])
+    impl = getattr(module, impl_name)
+
+    class _ExplodingClient:
+        def __getattr__(self, name):  # any client call means we validated late
+            raise AssertionError(
+                "client must not be called for an invalid section_type"
+            )
+
+    result = asyncio.run(impl(_ExplodingClient(), VALID_IMAGE_ID, 1, *args))
+    assert "error" in result
+    assert "Invalid section_type" in result["error"]
+    assert "ITEMS" in result["error"]


### PR DESCRIPTION
## What

Adds four `ReceiptSection` tools to **both** MCP server implementations, kept in sync (identical tool shape in each):

- **`get_receipt_sections(image_id, receipt_id)`** — list a receipt's sections (`section_type`, `line_ids`, `confidence`, `model_source`, `validation_status`), and for each section the text of its lines so a reviewer can QA without a second call.
- **`update_section_status(image_id, receipt_id, section_type, validation_status)`** — set `validation_status` (VALID / INVALID / NEEDS_REVIEW / PENDING / NONE) on an existing section; errors clearly if the section doesn't exist. Mirrors `update_word_label` (status change only).
- **`create_receipt_section(image_id, receipt_id, section_type, line_ids, validation_status=VALID, model_source='mcp-claude-review')`** — conditional put; **fails if that `section_type` already exists** on the receipt.
- **`delete_receipt_section(image_id, receipt_id, section_type)`** — remove one section row.

Both servers updated in lockstep:
- `scripts/receipt_mcp_server.py` (stdio)
- `infra/mcp_server_lambda/lambdas/receipt_mcp_server_server.py` (Lambda)

## Why

Dev has ~5,300 `ReceiptSection` rows: 3,128 seeds plus **2,163 KNN-propagated rows landing as `PENDING`** (`model_source=section-knn-v1`). Those PENDING rows need the same human-in-the-loop QA loop the word-label tools already provide before they count as ground truth. These tools let a reviewer inspect a receipt's sections (with line text inline), then promote correct ones to VALID / reject wrong ones as INVALID, or hand-add/remove a section.

## Notes

- Dev-only mindset: the DynamoDB table is resolved from env exactly like the existing tools — never hardcoded.
- All CRUD is backed by existing `receipt_dynamo` methods (`get_receipt_sections_from_receipt`, `get_receipt_section`, `add_receipt_section` conditional put, `update_receipt_section`, `delete_receipt_section`).
- Did **not** add section counts to `get_receipt` (the per-receipt summary) — it would add a DynamoDB query to the most-used QA tool; `get_receipt_sections` covers this cleanly instead.

## Tests

`tests/test_receipt_mcp_section_tools.py` imports **both** server modules (with a minimal fake `mcp` package, since the real dep isn't in CI) and asserts the four section tools appear in `list_tools` with valid input schemas, have matching `*_impl` functions, and expose an identical tool shape across the stdio and Lambda servers. 5 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added receipt section QA tools to view, create, update, and delete classified sections.
  * Section details now include covered line text, confidence, source, and validation status.
  * Added validation for section types, statuses, receipt lines, and duplicate or missing sections.

* **Tests**
  * Added coverage for tool availability, schemas, input validation, normalization, and section operations across server implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->