### PR TITLE
fix(ocr): histogram SCAN/PHOTO classifier + menu-bleed filter + duplicate-copy split

### DIFF
--- a/receipt_ocr_swift/Sources/ReceiptOCRCore/Classification/ImageClassifier.swift
+++ b/receipt_ocr_swift/Sources/ReceiptOCRCore/Classification/ImageClassifier.swift
@@ -57,6 +57,14 @@ public struct ImageClassifier {
     /// Threshold for margin detection (1% = 0.01)
     private let marginThreshold: CGFloat
 
+    /// Max border block-mean luminance std dev (normalized 0-1) still considered
+    /// a flat, uniformly-lit scan. A real scan's border blocks are near-constant
+    /// (measured ~0.0-0.05 on fixtures); a photo's border carries shading
+    /// gradients / vignetting that push it above this. Anything above is treated
+    /// as photo-consistent. Calibrated with margin above observed real scans so
+    /// genuine scans are never demoted; catches strong non-uniformity.
+    private let scanBorderStdDevThreshold: CGFloat = 0.10
+
     public init(marginThreshold: CGFloat = 0.01) {
         self.marginThreshold = marginThreshold
     }
@@ -167,18 +175,30 @@ public struct ImageClassifier {
             // Text fills the image - single receipt
             imageType = .native
         } else if let image = image, let feat = pixelFeatures(image: image) {
-            // PRIMARY signal: a SCAN is a white document that fills the frame,
-            // so its border is overwhelmingly near-white with ~0 saturation.
-            // A PHOTO has a table/scene background -> low border-white, higher
-            // saturation. This is resolution-invariant, unlike comparing pixel
-            // dimensions to fixed references (which mislabels downscaled photos
-            // as scans). Calibrated margin is huge: real scans ~0.9-1.0
-            // border-white, photos <0.01.
-            if feat.borderWhite > 0.5 && feat.meanSat < 0.05 {
-                imageType = .scan
-            } else {
-                imageType = .photo
-            }
+            // PRIMARY signal: a SCAN is a document that fills the frame, so its
+            // border is a UNIFORM field of paper (or, lid-open, near-black) with
+            // ~0 saturation. A PHOTO has a table/scene background -> lower
+            // border-white, higher saturation. This is resolution-invariant,
+            // unlike comparing pixel dimensions to fixed references (which
+            // mislabels downscaled photos as scans).
+            //
+            // Illumination-uniformity refinement: a white receipt photographed
+            // on a WHITE counter also reads high border-white + low saturation,
+            // so border color alone misfires. A real flat scan has near-constant
+            // border luminance (stddev ~0); a photo has shading gradients /
+            // vignetting (higher stddev). Require a uniform border for SCAN, and
+            // if the border luminance is non-uniform prefer PHOTO even when
+            // border-white is high.
+            let uniformBorder = feat.borderLumStdDev < scanBorderStdDevThreshold
+            // Bright, uniform paper border -> scan.
+            let brightScan =
+                feat.borderWhite > 0.5 && feat.meanSat < 0.05 && uniformBorder
+            // Scanner lid left open: a near-black, near-zero-saturation, uniform
+            // border is also scan-consistent (Fable's note) — an all-dark
+            // uniform frame must not be called PHOTO.
+            let darkScan =
+                feat.borderMeanLum < 0.15 && feat.meanSat < 0.05 && uniformBorder
+            imageType = (brightScan || darkScan) ? .scan : .photo
         } else if scanDistance < photoDistance {
             // Fallback (no pixels available): dimension heuristic.
             imageType = .scan
@@ -206,11 +226,23 @@ public struct ImageClassifier {
     ///     paper (~0.9-1.0); a photo shows a table/scene background (~0).
     ///   - meanSat: mean HSV saturation over the whole thumbnail. Scans are
     ///     grayscale paper+ink (~0); photos have color (>0.1).
+    ///   - borderLumStdDev: std dev of the outer-border luminance, mean-pooled
+    ///     into coarse blocks first so sparse dark ink / receipt edges that
+    ///     intrude into a real scan's border don't inflate it. A flat scan's
+    ///     border blocks are near-constant (~0); a photo's border has shading
+    ///     gradients / vignetting (higher). Distinguishes a true scan from a
+    ///     white receipt shot on a white counter.
+    ///   - borderMeanLum: mean luminance over the outer-border pixels. Lets a
+    ///     near-black, uniform border (scanner lid left open) count as
+    ///     scan-consistent rather than photo.
     ///
     /// Returns nil if a bitmap context can't be created.
     private func pixelFeatures(
         image: CGImage
-    ) -> (borderWhite: CGFloat, meanSat: CGFloat)? {
+    ) -> (
+        borderWhite: CGFloat, meanSat: CGFloat,
+        borderLumStdDev: CGFloat, borderMeanLum: CGFloat
+    )? {
         let side = 64
         let bytesPerRow = side * 4
         var data = [UInt8](repeating: 0, count: side * side * 4)
@@ -232,9 +264,19 @@ public struct ImageClassifier {
         )
 
         let borderPx = max(1, Int(CGFloat(side) * 0.12))
+        // Coarse block grid (8x8 px) used to mean-pool the border into
+        // low-frequency luminance samples. Pooling averages out sparse dark ink
+        // / receipt edges that intrude into a real scan's border (which would
+        // otherwise inflate a per-pixel std dev), while preserving the smooth
+        // shading gradients / vignetting that mark a PHOTO.
+        let blk = 8
+        let grid = (side + blk - 1) / blk
+        var blockLumSum = [CGFloat](repeating: 0, count: grid * grid)
+        var blockCount = [Int](repeating: 0, count: grid * grid)
         var whiteBorder = 0
         var borderCount = 0
         var satSum: CGFloat = 0
+        var borderLumSum: CGFloat = 0
 
         for y in 0..<side {
             for x in 0..<side {
@@ -253,9 +295,13 @@ public struct ImageClassifier {
                     || y < borderPx || y >= side - borderPx
                 if isBorder {
                     borderCount += 1
+                    borderLumSum += lum
                     if lum > 0.85 && sat < 0.12 {
                         whiteBorder += 1
                     }
+                    let bi = (y / blk) * grid + (x / blk)
+                    blockLumSum[bi] += lum
+                    blockCount[bi] += 1
                 }
             }
         }
@@ -264,7 +310,25 @@ public struct ImageClassifier {
             borderCount > 0
             ? CGFloat(whiteBorder) / CGFloat(borderCount) : 0
         let meanSat = satSum / CGFloat(side * side)
-        return (borderWhite, meanSat)
+        let borderMeanLum =
+            borderCount > 0 ? borderLumSum / CGFloat(borderCount) : 0
+
+        // Illumination-uniformity: std dev of the border BLOCK mean luminances.
+        // A flat scan's border blocks are all ~equal (stddev ~0); a photo's
+        // shading gradient / vignetting spreads them out. Computed on the same
+        // single 64x64 draw (no extra image passes).
+        var blockMeans: [CGFloat] = []
+        for bi in 0..<(grid * grid) where blockCount[bi] > 0 {
+            blockMeans.append(blockLumSum[bi] / CGFloat(blockCount[bi]))
+        }
+        var borderLumStdDev: CGFloat = 0
+        if !blockMeans.isEmpty {
+            let bm = blockMeans.reduce(0, +) / CGFloat(blockMeans.count)
+            let v = blockMeans.map { ($0 - bm) * ($0 - bm) }.reduce(0, +)
+                / CGFloat(blockMeans.count)
+            borderLumStdDev = max(0, v).squareRoot()
+        }
+        return (borderWhite, meanSat, borderLumStdDev, borderMeanLum)
     }
 }
 #endif

--- a/receipt_ocr_swift/Sources/ReceiptOCRCore/Classification/ImageClassifier.swift
+++ b/receipt_ocr_swift/Sources/ReceiptOCRCore/Classification/ImageClassifier.swift
@@ -141,7 +141,8 @@ public struct ImageClassifier {
     public func classify(
         lines: [Line],
         imageWidth: Int,
-        imageHeight: Int
+        imageHeight: Int,
+        image: CGImage? = nil
     ) -> ClassificationResult {
         let margins = findMargins(lines: lines)
 
@@ -165,7 +166,21 @@ public struct ImageClassifier {
         if margins.allBelow(marginThreshold) {
             // Text fills the image - single receipt
             imageType = .native
+        } else if let image = image, let feat = pixelFeatures(image: image) {
+            // PRIMARY signal: a SCAN is a white document that fills the frame,
+            // so its border is overwhelmingly near-white with ~0 saturation.
+            // A PHOTO has a table/scene background -> low border-white, higher
+            // saturation. This is resolution-invariant, unlike comparing pixel
+            // dimensions to fixed references (which mislabels downscaled photos
+            // as scans). Calibrated margin is huge: real scans ~0.9-1.0
+            // border-white, photos <0.01.
+            if feat.borderWhite > 0.5 && feat.meanSat < 0.05 {
+                imageType = .scan
+            } else {
+                imageType = .photo
+            }
         } else if scanDistance < photoDistance {
+            // Fallback (no pixels available): dimension heuristic.
             imageType = .scan
         } else {
             // When scanDistance == photoDistance, defaults to .photo
@@ -180,6 +195,76 @@ public struct ImageClassifier {
             imageWidth: imageWidth,
             imageHeight: imageHeight
         )
+    }
+
+    /// Cheap pixel-histogram features for scan-vs-photo discrimination.
+    ///
+    /// Downscales the image to a 64x64 thumbnail (one draw, ~4k pixels) and
+    /// measures how "document-like" the frame is:
+    ///   - borderWhite: fraction of near-white, near-zero-saturation pixels in
+    ///     the outer 12% border. A scanned document fills the frame in white
+    ///     paper (~0.9-1.0); a photo shows a table/scene background (~0).
+    ///   - meanSat: mean HSV saturation over the whole thumbnail. Scans are
+    ///     grayscale paper+ink (~0); photos have color (>0.1).
+    ///
+    /// Returns nil if a bitmap context can't be created.
+    private func pixelFeatures(
+        image: CGImage
+    ) -> (borderWhite: CGFloat, meanSat: CGFloat)? {
+        let side = 64
+        let bytesPerRow = side * 4
+        var data = [UInt8](repeating: 0, count: side * side * 4)
+        guard
+            let ctx = CGContext(
+                data: &data,
+                width: side,
+                height: side,
+                bitsPerComponent: 8,
+                bytesPerRow: bytesPerRow,
+                space: CGColorSpaceCreateDeviceRGB(),
+                bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+            )
+        else { return nil }
+        ctx.interpolationQuality = .low
+        ctx.draw(
+            image,
+            in: CGRect(x: 0, y: 0, width: side, height: side)
+        )
+
+        let borderPx = max(1, Int(CGFloat(side) * 0.12))
+        var whiteBorder = 0
+        var borderCount = 0
+        var satSum: CGFloat = 0
+
+        for y in 0..<side {
+            for x in 0..<side {
+                let i = (y * side + x) * 4
+                let r = CGFloat(data[i]) / 255.0
+                let g = CGFloat(data[i + 1]) / 255.0
+                let b = CGFloat(data[i + 2]) / 255.0
+                let mx = max(r, max(g, b))
+                let mn = min(r, min(g, b))
+                let sat = mx > 0 ? (mx - mn) / mx : 0
+                let lum = 0.299 * r + 0.587 * g + 0.114 * b
+                satSum += sat
+
+                let isBorder =
+                    x < borderPx || x >= side - borderPx
+                    || y < borderPx || y >= side - borderPx
+                if isBorder {
+                    borderCount += 1
+                    if lum > 0.85 && sat < 0.12 {
+                        whiteBorder += 1
+                    }
+                }
+            }
+        }
+
+        let borderWhite =
+            borderCount > 0
+            ? CGFloat(whiteBorder) / CGFloat(borderCount) : 0
+        let meanSat = satSum / CGFloat(side * side)
+        return (borderWhite, meanSat)
     }
 }
 #endif

--- a/receipt_ocr_swift/Sources/ReceiptOCRCore/Models/ReceiptDetection.swift
+++ b/receipt_ocr_swift/Sources/ReceiptOCRCore/Models/ReceiptDetection.swift
@@ -70,13 +70,19 @@ public struct ProcessedReceipt {
     /// Line indices from the original lines array that belong to this receipt
     public let lineIndices: [Int]
 
+    /// True when this cluster looks like multiple overlapping receipts but could
+    /// not be confidently split (e.g. a faded second copy) — surface for human
+    /// review rather than trusting the crop.
+    public let needsReview: Bool
+
     public init(
         clusterId: Int,
         bounds: ReceiptBounds,
         warpedImage: CGImage,
         warpedWidth: Int,
         warpedHeight: Int,
-        lineIndices: [Int]
+        lineIndices: [Int],
+        needsReview: Bool = false
     ) {
         self.clusterId = clusterId
         self.bounds = bounds
@@ -84,6 +90,7 @@ public struct ProcessedReceipt {
         self.warpedWidth = warpedWidth
         self.warpedHeight = warpedHeight
         self.lineIndices = lineIndices
+        self.needsReview = needsReview
     }
 }
 
@@ -122,6 +129,10 @@ public struct ReceiptOutput: Codable {
     /// the warped crop, matching `lines`).
     public var barcodes: [Barcode]?
 
+    /// True when this crop probably contains multiple overlapping receipts that
+    /// couldn't be confidently split — flag for human review.
+    public let needsReview: Bool
+
     public init(
         clusterId: Int,
         bounds: ReceiptBounds,
@@ -131,7 +142,8 @@ public struct ReceiptOutput: Codable {
         lineIndices: [Int],
         lines: [Line]? = nil,
         layoutlmPredictions: [LinePrediction]? = nil,
-        barcodes: [Barcode]? = nil
+        barcodes: [Barcode]? = nil,
+        needsReview: Bool = false
     ) {
         self.clusterId = clusterId
         self.bounds = bounds
@@ -142,6 +154,7 @@ public struct ReceiptOutput: Codable {
         self.lines = lines
         self.layoutlmPredictions = layoutlmPredictions
         self.barcodes = barcodes
+        self.needsReview = needsReview
     }
 
     /// Create from a ProcessedReceipt
@@ -155,6 +168,7 @@ public struct ReceiptOutput: Codable {
         self.lines = lines
         self.layoutlmPredictions = layoutlmPredictions
         self.barcodes = barcodes
+        self.needsReview = processed.needsReview
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -167,6 +181,7 @@ public struct ReceiptOutput: Codable {
         case lines
         case layoutlmPredictions = "layoutlm_predictions"
         case barcodes
+        case needsReview = "needs_review"
     }
 }
 

--- a/receipt_ocr_swift/Sources/ReceiptOCRCore/OCR/VisionOCREngine.swift
+++ b/receipt_ocr_swift/Sources/ReceiptOCRCore/OCR/VisionOCREngine.swift
@@ -605,8 +605,14 @@ public struct VisionOCREngine: OCREngineProtocol {
                         // with a low minSamples so the receipt is recovered rather
                         // than silently dropped. (Only fires when the normal pass
                         // produced nothing, so it can't regress working images.)
+                        // Floor at 5 lines: a handful (2-4) of labels on a
+                        // uniformly-colored sign/menu that slipped past the color
+                        // filter must not be clustered into a fabricated receipt;
+                        // a real small receipt has a merchant + a few items + a
+                        // total. (A stricter low-saturation paper gate is a noted
+                        // follow-up.)
                         if !photoClustering.clusters.contains(where: { $0.key != -1 && !$0.value.isEmpty }),
-                           docLines.count >= 3, docLines.count < 12 {
+                           docLines.count >= 5, docLines.count < 12 {
                             photoClustering = clusterer.dbscanLines(lines: docLines, eps: eps, minSamples: 3)
                         }
                         clustering = photoClustering
@@ -866,9 +872,11 @@ public struct VisionOCREngine: OCREngineProtocol {
                     let eps = avgDiagonal * 2
                     var photoClustering = clusterer.dbscanLines(lines: docLines, eps: eps, minSamples: 10)
                     // Small-receipt recovery (see async path): recover a small
-                    // receipt that minSamples 10 leaves entirely as noise.
+                    // receipt that minSamples 10 leaves entirely as noise. Floor
+                    // at 5 lines so a few labels on a colored sign aren't
+                    // fabricated into a receipt.
                     if !photoClustering.clusters.contains(where: { $0.key != -1 && !$0.value.isEmpty }),
-                       docLines.count >= 3, docLines.count < 12 {
+                       docLines.count >= 5, docLines.count < 12 {
                         photoClustering = clusterer.dbscanLines(lines: docLines, eps: eps, minSamples: 3)
                     }
                     clustering = photoClustering

--- a/receipt_ocr_swift/Sources/ReceiptOCRCore/OCR/VisionOCREngine.swift
+++ b/receipt_ocr_swift/Sources/ReceiptOCRCore/OCR/VisionOCREngine.swift
@@ -4,6 +4,25 @@ import Foundation
 import AppKit
 import Vision
 
+/// Remap cluster line indices from a filtered (compacted) line array back to the
+/// original line array. `keptIndices[i]` is the original index of the i-th kept
+/// line. Cluster keys (including the -1 noise cluster) are preserved. Used after
+/// `documentLineKeepIndices` drops colored-background lines so that the
+/// serialized clustering / receipt `line_indices` stay in the same index space
+/// as the full, unfiltered `lines` array in the output.
+private func remapClusterIndices(
+    _ clustering: ClusteringResult,
+    _ keptIndices: [Int]
+) -> ClusteringResult {
+    var out: [Int: [Int]] = [:]
+    for (key, vals) in clustering.clusters {
+        out[key] = vals.compactMap {
+            $0 >= 0 && $0 < keptIndices.count ? keptIndices[$0] : nil
+        }
+    }
+    return ClusteringResult(clusters: out)
+}
+
 // NOTE: Code Duplication with OCRSwift.swift
 //
 // This file contains duplicated code (data models, helper functions, and OCR logic)
@@ -558,12 +577,16 @@ public struct VisionOCREngine: OCREngineProtocol {
                     // background — e.g. a menu/flyer behind the receipt — so
                     // they can't be clustered into the receipt. NATIVE fills
                     // the frame with a single receipt, so it is left untouched.
-                    let docLines: [Line]
+                    // Keep the ORIGINAL indices of the surviving lines so the
+                    // cluster/receipt indices can be remapped back to the full
+                    // `mutableLines` array (which is what the output serializes).
+                    let keptIndices: [Int]
                     if classResult.imageType != .native, let img = loadedImage {
-                        docLines = filterDocumentLines(mutableLines, image: img)
+                        keptIndices = documentLineKeepIndices(mutableLines, image: img)
                     } else {
-                        docLines = mutableLines
+                        keptIndices = Array(0..<mutableLines.count)
                     }
+                    let docLines = keptIndices.map { mutableLines[$0] }
                     switch classResult.imageType {
                     case .native:
                         // Single receipt, no clustering needed
@@ -578,6 +601,14 @@ public struct VisionOCREngine: OCREngineProtocol {
                         clustering = clusterer.dbscanLinesXAxis(lines: docLines, eps: 0.08, minSamples: 2)
                     }
 
+                    // Filtering compacted the line array; remap cluster indices
+                    // back to the original `mutableLines` space so receipt
+                    // processing (below) and the serialized clustering both index
+                    // the same array the top-level `lines` is serialized from.
+                    if keptIndices.count != mutableLines.count, let c = clustering {
+                        clustering = remapClusterIndices(c, keptIndices)
+                    }
+
                     // Process receipts if we have clustering (PHOTO or SCAN)
                     if classResult.imageType != .native,
                        let clusterResult = clustering,
@@ -585,7 +616,7 @@ public struct VisionOCREngine: OCREngineProtocol {
                         let receiptProcessor = ReceiptProcessor()
                         let processedReceipts = receiptProcessor.process(
                             image: cgImage,
-                            lines: docLines,
+                            lines: mutableLines,
                             classification: classResult,
                             clustering: clusterResult
                         )
@@ -803,12 +834,16 @@ public struct VisionOCREngine: OCREngineProtocol {
 
             if let classResult = classification {
                 // Drop colored-background (non-document) lines before clustering.
-                let docLines: [Line]
+                // Keep the ORIGINAL indices of the surviving lines so cluster /
+                // receipt indices can be remapped back to the full `mutableLines`
+                // array that the output serializes.
+                let keptIndices: [Int]
                 if classResult.imageType != .native, let img = loadedImage {
-                    docLines = filterDocumentLines(mutableLines, image: img)
+                    keptIndices = documentLineKeepIndices(mutableLines, image: img)
                 } else {
-                    docLines = mutableLines
+                    keptIndices = Array(0..<mutableLines.count)
                 }
+                let docLines = keptIndices.map { mutableLines[$0] }
                 switch classResult.imageType {
                 case .native:
                     clustering = ClusteringResult(clusters: [1: Array(0..<docLines.count)])
@@ -820,13 +855,18 @@ public struct VisionOCREngine: OCREngineProtocol {
                     clustering = clusterer.dbscanLinesXAxis(lines: docLines, eps: 0.08, minSamples: 2)
                 }
 
+                // Remap filtered cluster indices back to the original line space.
+                if keptIndices.count != mutableLines.count, let c = clustering {
+                    clustering = remapClusterIndices(c, keptIndices)
+                }
+
                 if classResult.imageType != .native,
                    let clusterResult = clustering,
                    let cgImage = loadedImage {
                     let receiptProcessor = ReceiptProcessor()
                     let processedReceipts = receiptProcessor.process(
                         image: cgImage,
-                        lines: docLines,
+                        lines: mutableLines,
                         classification: classResult,
                         clustering: clusterResult
                     )

--- a/receipt_ocr_swift/Sources/ReceiptOCRCore/OCR/VisionOCREngine.swift
+++ b/receipt_ocr_swift/Sources/ReceiptOCRCore/OCR/VisionOCREngine.swift
@@ -554,18 +554,28 @@ public struct VisionOCREngine: OCREngineProtocol {
 
                 // Cluster based on image type
                 if let classResult = classification {
+                    // Drop lines that sit on a colored (non-document)
+                    // background — e.g. a menu/flyer behind the receipt — so
+                    // they can't be clustered into the receipt. NATIVE fills
+                    // the frame with a single receipt, so it is left untouched.
+                    let docLines: [Line]
+                    if classResult.imageType != .native, let img = loadedImage {
+                        docLines = filterDocumentLines(mutableLines, image: img)
+                    } else {
+                        docLines = mutableLines
+                    }
                     switch classResult.imageType {
                     case .native:
                         // Single receipt, no clustering needed
-                        clustering = ClusteringResult(clusters: [1: Array(0..<mutableLines.count)])
+                        clustering = ClusteringResult(clusters: [1: Array(0..<docLines.count)])
                     case .photo:
                         // Use 2D DBSCAN for photos
-                        let avgDiagonal = clusterer.averageDiagonalLength(lines: mutableLines)
+                        let avgDiagonal = clusterer.averageDiagonalLength(lines: docLines)
                         let eps = avgDiagonal * 2  // Dynamic eps based on line size
-                        clustering = clusterer.dbscanLines(lines: mutableLines, eps: eps, minSamples: 10)
+                        clustering = clusterer.dbscanLines(lines: docLines, eps: eps, minSamples: 10)
                     case .scan:
                         // Use X-axis clustering for scans
-                        clustering = clusterer.dbscanLinesXAxis(lines: mutableLines, eps: 0.08, minSamples: 2)
+                        clustering = clusterer.dbscanLinesXAxis(lines: docLines, eps: 0.08, minSamples: 2)
                     }
 
                     // Process receipts if we have clustering (PHOTO or SCAN)
@@ -575,7 +585,7 @@ public struct VisionOCREngine: OCREngineProtocol {
                         let receiptProcessor = ReceiptProcessor()
                         let processedReceipts = receiptProcessor.process(
                             image: cgImage,
-                            lines: mutableLines,
+                            lines: docLines,
                             classification: classResult,
                             clustering: clusterResult
                         )
@@ -792,15 +802,22 @@ public struct VisionOCREngine: OCREngineProtocol {
             )
 
             if let classResult = classification {
+                // Drop colored-background (non-document) lines before clustering.
+                let docLines: [Line]
+                if classResult.imageType != .native, let img = loadedImage {
+                    docLines = filterDocumentLines(mutableLines, image: img)
+                } else {
+                    docLines = mutableLines
+                }
                 switch classResult.imageType {
                 case .native:
-                    clustering = ClusteringResult(clusters: [1: Array(0..<mutableLines.count)])
+                    clustering = ClusteringResult(clusters: [1: Array(0..<docLines.count)])
                 case .photo:
-                    let avgDiagonal = clusterer.averageDiagonalLength(lines: mutableLines)
+                    let avgDiagonal = clusterer.averageDiagonalLength(lines: docLines)
                     let eps = avgDiagonal * 2
-                    clustering = clusterer.dbscanLines(lines: mutableLines, eps: eps, minSamples: 10)
+                    clustering = clusterer.dbscanLines(lines: docLines, eps: eps, minSamples: 10)
                 case .scan:
-                    clustering = clusterer.dbscanLinesXAxis(lines: mutableLines, eps: 0.08, minSamples: 2)
+                    clustering = clusterer.dbscanLinesXAxis(lines: docLines, eps: 0.08, minSamples: 2)
                 }
 
                 if classResult.imageType != .native,
@@ -809,7 +826,7 @@ public struct VisionOCREngine: OCREngineProtocol {
                     let receiptProcessor = ReceiptProcessor()
                     let processedReceipts = receiptProcessor.process(
                         image: cgImage,
-                        lines: mutableLines,
+                        lines: docLines,
                         classification: classResult,
                         clustering: clusterResult
                     )

--- a/receipt_ocr_swift/Sources/ReceiptOCRCore/OCR/VisionOCREngine.swift
+++ b/receipt_ocr_swift/Sources/ReceiptOCRCore/OCR/VisionOCREngine.swift
@@ -595,7 +595,21 @@ public struct VisionOCREngine: OCREngineProtocol {
                         // Use 2D DBSCAN for photos
                         let avgDiagonal = clusterer.averageDiagonalLength(lines: docLines)
                         let eps = avgDiagonal * 2  // Dynamic eps based on line size
-                        clustering = clusterer.dbscanLines(lines: docLines, eps: eps, minSamples: 10)
+                        var photoClustering = clusterer.dbscanLines(lines: docLines, eps: eps, minSamples: 10)
+                        // Small-receipt recovery: minSamples 10 is tuned for
+                        // full-resolution photos with many lines. A genuine small
+                        // receipt (or one reduced below 10 lines by the background
+                        // filter) leaves every line in the noise cluster and would
+                        // yield NO receipt. When the standard pass finds nothing
+                        // but a modest number of coherent lines remain, retry once
+                        // with a low minSamples so the receipt is recovered rather
+                        // than silently dropped. (Only fires when the normal pass
+                        // produced nothing, so it can't regress working images.)
+                        if !photoClustering.clusters.contains(where: { $0.key != -1 && !$0.value.isEmpty }),
+                           docLines.count >= 3, docLines.count < 12 {
+                            photoClustering = clusterer.dbscanLines(lines: docLines, eps: eps, minSamples: 3)
+                        }
+                        clustering = photoClustering
                     case .scan:
                         // Use X-axis clustering for scans
                         clustering = clusterer.dbscanLinesXAxis(lines: docLines, eps: 0.08, minSamples: 2)
@@ -850,7 +864,14 @@ public struct VisionOCREngine: OCREngineProtocol {
                 case .photo:
                     let avgDiagonal = clusterer.averageDiagonalLength(lines: docLines)
                     let eps = avgDiagonal * 2
-                    clustering = clusterer.dbscanLines(lines: docLines, eps: eps, minSamples: 10)
+                    var photoClustering = clusterer.dbscanLines(lines: docLines, eps: eps, minSamples: 10)
+                    // Small-receipt recovery (see async path): recover a small
+                    // receipt that minSamples 10 leaves entirely as noise.
+                    if !photoClustering.clusters.contains(where: { $0.key != -1 && !$0.value.isEmpty }),
+                       docLines.count >= 3, docLines.count < 12 {
+                        photoClustering = clusterer.dbscanLines(lines: docLines, eps: eps, minSamples: 3)
+                    }
+                    clustering = photoClustering
                 case .scan:
                     clustering = clusterer.dbscanLinesXAxis(lines: docLines, eps: 0.08, minSamples: 2)
                 }

--- a/receipt_ocr_swift/Sources/ReceiptOCRCore/OCR/VisionOCREngine.swift
+++ b/receipt_ocr_swift/Sources/ReceiptOCRCore/OCR/VisionOCREngine.swift
@@ -540,11 +540,16 @@ public struct VisionOCREngine: OCREngineProtocol {
             var receiptOutputs: [ReceiptOutput]?
 
             if includeClassification, let imageDimensions = getImageDimensions(from: imageURL) {
+                // Load pixels once: used both for scan-vs-photo classification
+                // (histogram signal) and, for non-native types, receipt
+                // extraction below.
+                let loadedImage = loadCGImage(from: imageURL)
                 // Classify the image
                 classification = classifier.classify(
                     lines: mutableLines,
                     imageWidth: imageDimensions.width,
-                    imageHeight: imageDimensions.height
+                    imageHeight: imageDimensions.height,
+                    image: loadedImage
                 )
 
                 // Cluster based on image type
@@ -566,7 +571,7 @@ public struct VisionOCREngine: OCREngineProtocol {
                     // Process receipts if we have clustering (PHOTO or SCAN)
                     if classResult.imageType != .native,
                        let clusterResult = clustering,
-                       let cgImage = loadCGImage(from: imageURL) {
+                       let cgImage = loadedImage {
                         let receiptProcessor = ReceiptProcessor()
                         let processedReceipts = receiptProcessor.process(
                             image: cgImage,
@@ -778,10 +783,12 @@ public struct VisionOCREngine: OCREngineProtocol {
         var receiptOutputs: [ReceiptOutput]?
 
         if includeClassification, let imageDimensions = getImageDimensions(from: imageURL) {
+            let loadedImage = loadCGImage(from: imageURL)
             classification = classifier.classify(
                 lines: mutableLines,
                 imageWidth: imageDimensions.width,
-                imageHeight: imageDimensions.height
+                imageHeight: imageDimensions.height,
+                image: loadedImage
             )
 
             if let classResult = classification {
@@ -798,7 +805,7 @@ public struct VisionOCREngine: OCREngineProtocol {
 
                 if classResult.imageType != .native,
                    let clusterResult = clustering,
-                   let cgImage = loadCGImage(from: imageURL) {
+                   let cgImage = loadedImage {
                     let receiptProcessor = ReceiptProcessor()
                     let processedReceipts = receiptProcessor.process(
                         image: cgImage,

--- a/receipt_ocr_swift/Sources/ReceiptOCRCore/ReceiptProcessing/BackgroundColorFilter.swift
+++ b/receipt_ocr_swift/Sources/ReceiptOCRCore/ReceiptProcessing/BackgroundColorFilter.swift
@@ -20,26 +20,35 @@ import CoreGraphics
 /// - Parameters:
 ///   - lines: OCR lines with normalized, bottom-left-origin coordinates.
 ///   - image: Source pixels (full image).
-///   - saturationThreshold: Mean background saturation above which a line is
-///     treated as non-document. Calibrated: receipt lines ~0.09 median, menu
-///     lines ~0.35-0.47; 0.18 leaves a wide margin.
+///   - saturationMargin: How far above the image's own median line saturation a
+///     line must sit to be dropped as non-document (floors the MAD-based, spread-
+///     adaptive threshold). Keeps uniform warm/cream paper (~0.22) while still
+///     removing a colored menu background (~0.35-0.47).
 /// - Returns: The subset of `lines` on a document background.
 public func filterDocumentLines(
     _ lines: [Line],
     image: CGImage,
-    saturationThreshold: CGFloat = 0.18
+    saturationMargin: CGFloat = 0.15
 ) -> [Line] {
     let w = image.width
     let h = image.height
     guard w > 0, h > 0, !lines.isEmpty else { return lines }
 
-    let bytesPerRow = w * 4
-    var data = [UInt8](repeating: 0, count: w * h * 4)
+    // Downscale so the long side is <= maxSide. We sample sparsely, so a small
+    // buffer is plenty and cuts memory ~10-15x (a full 4032x3024 RGBA buffer is
+    // ~48MB).
+    let maxSide = 1024
+    let scale = min(1.0, CGFloat(maxSide) / CGFloat(max(w, h)))
+    let bw = max(1, Int((CGFloat(w) * scale).rounded()))
+    let bh = max(1, Int((CGFloat(h) * scale).rounded()))
+
+    let bytesPerRow = bw * 4
+    var data = [UInt8](repeating: 0, count: bw * bh * 4)
     guard
         let ctx = CGContext(
             data: &data,
-            width: w,
-            height: h,
+            width: bw,
+            height: bh,
             bitsPerComponent: 8,
             bytesPerRow: bytesPerRow,
             space: CGColorSpaceCreateDeviceRGB(),
@@ -48,9 +57,10 @@ public func filterDocumentLines(
     else {
         return lines
     }
-    ctx.draw(image, in: CGRect(x: 0, y: 0, width: w, height: h))
+    ctx.interpolationQuality = .low
+    ctx.draw(image, in: CGRect(x: 0, y: 0, width: bw, height: bh))
 
-    func meanBackgroundSaturation(_ line: Line) -> CGFloat {
+    func backgroundSaturation(_ line: Line) -> CGFloat {
         let xsN = [
             line.topLeft.x, line.topRight.x,
             line.bottomLeft.x, line.bottomRight.x,
@@ -60,38 +70,57 @@ public func filterDocumentLines(
             line.topLeft.y, line.topRight.y,
             line.bottomLeft.y, line.bottomRight.y,
         ]
-        let xs = xsN.map { $0 * CGFloat(w) }
-        let ys = ysN.map { (1 - $0) * CGFloat(h) }
+        let xs = xsN.map { $0 * CGFloat(bw) }
+        let ys = ysN.map { (1 - $0) * CGFloat(bh) }
         let x0 = max(0, Int(xs.min() ?? 0))
-        let x1 = min(w, Int(xs.max() ?? 0))
+        let x1 = min(bw, Int(xs.max() ?? 0))
         let y0 = max(0, Int(ys.min() ?? 0))
-        let y1 = min(h, Int(ys.max() ?? 0))
+        let y1 = min(bh, Int(ys.max() ?? 0))
         if x1 <= x0 || y1 <= y0 { return 0 }
 
-        // Subsample to at most ~16x16 samples per line for speed.
+        // Measure the PAPER, not the ink: sample only non-dark pixels
+        // (lum >= 0.4) and take the MEDIAN. White paper and black ink are both
+        // low-saturation; a colored menu background is high. Excluding ink also
+        // protects receipt lines printed in colored ink (red VOID, colored
+        // logos) — the surrounding white paper dominates the median, so the line
+        // is kept.
+        var sats: [CGFloat] = []
         let stepX = max(1, (x1 - x0) / 16)
         let stepY = max(1, (y1 - y0) / 16)
-        var sum: CGFloat = 0
-        var count = 0
         var y = y0
         while y < y1 {
             var x = x0
             while x < x1 {
-                let i = (y * w + x) * 4
+                let i = (y * bw + x) * 4
                 let r = CGFloat(data[i]) / 255.0
                 let g = CGFloat(data[i + 1]) / 255.0
                 let b = CGFloat(data[i + 2]) / 255.0
-                let mx = max(r, max(g, b))
-                let mn = min(r, min(g, b))
-                sum += mx > 0 ? (mx - mn) / mx : 0
-                count += 1
+                let lum = 0.299 * r + 0.587 * g + 0.114 * b
+                if lum >= 0.4 {
+                    let mx = max(r, max(g, b))
+                    let mn = min(r, min(g, b))
+                    sats.append(mx > 0 ? (mx - mn) / mx : 0)
+                }
                 x += stepX
             }
             y += stepY
         }
-        return count > 0 ? sum / CGFloat(count) : 0
+        // No paper sampled (essentially all ink) -> don't flag; keep the line.
+        guard !sats.isEmpty else { return 0 }
+        return median(sats)
     }
 
-    return lines.filter { meanBackgroundSaturation($0) < saturationThreshold }
+    // Adaptive threshold: compare each line's background saturation to the
+    // image's OWN median line saturation, not a fixed constant. A receipt on
+    // warm/cream paper under warm light has an elevated but UNIFORM background
+    // (~0.22), so it must not be stripped; only lines that are clear saturation
+    // outliers above the paper baseline (a colored menu ~0.35-0.47) are dropped.
+    // threshold = median + max(margin, 4·MAD): the MAD term adapts to spread,
+    // the margin floor keeps uniform warm paper safe.
+    let sats = lines.map { backgroundSaturation($0) }
+    let med = median(sats)
+    let mad = median(sats.map { abs($0 - med) })
+    let threshold = med + max(saturationMargin, 4.0 * 1.4826 * mad)
+    return zip(lines, sats).compactMap { $0.1 < threshold ? $0.0 : nil }
 }
 #endif

--- a/receipt_ocr_swift/Sources/ReceiptOCRCore/ReceiptProcessing/BackgroundColorFilter.swift
+++ b/receipt_ocr_swift/Sources/ReceiptOCRCore/ReceiptProcessing/BackgroundColorFilter.swift
@@ -24,15 +24,42 @@ import CoreGraphics
 ///     line must sit to be dropped as non-document (floors the MAD-based, spread-
 ///     adaptive threshold). Keeps uniform warm/cream paper (~0.22) while still
 ///     removing a colored menu background (~0.35-0.47).
+///   - minColoredSaturation: Absolute saturation floor below which a line is
+///     NEVER dropped, regardless of the adaptive threshold. Guards the bimodal
+///     degenerate case (see below). Sits between cream paper (~0.22) and a
+///     colored menu (~0.35+).
 /// - Returns: The subset of `lines` on a document background.
 public func filterDocumentLines(
     _ lines: [Line],
     image: CGImage,
-    saturationMargin: CGFloat = 0.15
+    saturationMargin: CGFloat = 0.15,
+    minColoredSaturation: CGFloat = 0.28
 ) -> [Line] {
+    let keep = documentLineKeepIndices(
+        lines,
+        image: image,
+        saturationMargin: saturationMargin,
+        minColoredSaturation: minColoredSaturation
+    )
+    return keep.map { lines[$0] }
+}
+
+/// The document/background separation used by `filterDocumentLines`, returning
+/// the KEPT line indices (into `lines`) rather than the lines themselves.
+///
+/// Callers that filter BEFORE clustering use these indices to remap the
+/// downstream cluster / receipt line indices back to the original, unfiltered
+/// line array — otherwise the compacted (filtered) index space silently
+/// diverges from the serialized full `lines` array.
+public func documentLineKeepIndices(
+    _ lines: [Line],
+    image: CGImage,
+    saturationMargin: CGFloat = 0.15,
+    minColoredSaturation: CGFloat = 0.28
+) -> [Int] {
     let w = image.width
     let h = image.height
-    guard w > 0, h > 0, !lines.isEmpty else { return lines }
+    guard w > 0, h > 0, !lines.isEmpty else { return Array(0..<lines.count) }
 
     // Downscale so the long side is <= maxSide. We sample sparsely, so a small
     // buffer is plenty and cuts memory ~10-15x (a full 4032x3024 RGBA buffer is
@@ -55,7 +82,7 @@ public func filterDocumentLines(
             bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
         )
     else {
-        return lines
+        return Array(0..<lines.count)
     }
     ctx.interpolationQuality = .low
     ctx.draw(image, in: CGRect(x: 0, y: 0, width: bw, height: bh))
@@ -121,17 +148,28 @@ public func filterDocumentLines(
     let med = median(sats)
     let mad = median(sats.map { abs($0 - med) })
     let threshold = med + max(saturationMargin, 4.0 * 1.4826 * mad)
-    let kept = zip(lines, sats).compactMap { $0.1 < threshold ? $0.0 : nil }
+    // A line is dropped only if its background saturation clears BOTH the
+    // adaptive threshold AND an absolute floor. The floor prevents a degenerate
+    // BIMODAL case from erasing an entire second receipt: an image holding a
+    // white-paper receipt (sat ~0) plus a cream-paper receipt (sat ~0.22) has
+    // median 0 and MAD 0, so the adaptive threshold collapses to
+    // `saturationMargin` (0.15) and would strip every cream line while the
+    // 40% cap does not fire (the cream receipt is the minority). Real colored
+    // menu/photo backgrounds sit at ~0.35+, well above cream paper, so an
+    // absolute floor between them keeps warm/cream paper intact while still
+    // removing a colored background.
+    let effectiveThreshold = max(threshold, minColoredSaturation)
+    let keptIndices = sats.indices.filter { sats[$0] < effectiveThreshold }
 
-    // Drop-fraction cap: if the adaptive threshold would drop more than ~40% of
+    // Drop-fraction cap: if the adaptive threshold would drop at least ~40% of
     // all lines, DISBELIEVE the filter and keep everything. A receipt sitting
     // mostly on a colored surface (or with a large colored coupon block)
-    // contaminates the median itself, so "> 40% colored background" means the
+    // contaminates the median itself, so ">= 40% colored background" means the
     // baseline is unreliable and its own paper lines would be stripped.
-    let dropped = lines.count - kept.count
-    if CGFloat(dropped) > 0.40 * CGFloat(lines.count) {
-        return lines
+    let dropped = lines.count - keptIndices.count
+    if CGFloat(dropped) >= 0.40 * CGFloat(lines.count) {
+        return Array(0..<lines.count)
     }
-    return kept
+    return keptIndices
 }
 #endif

--- a/receipt_ocr_swift/Sources/ReceiptOCRCore/ReceiptProcessing/BackgroundColorFilter.swift
+++ b/receipt_ocr_swift/Sources/ReceiptOCRCore/ReceiptProcessing/BackgroundColorFilter.swift
@@ -121,6 +121,17 @@ public func filterDocumentLines(
     let med = median(sats)
     let mad = median(sats.map { abs($0 - med) })
     let threshold = med + max(saturationMargin, 4.0 * 1.4826 * mad)
-    return zip(lines, sats).compactMap { $0.1 < threshold ? $0.0 : nil }
+    let kept = zip(lines, sats).compactMap { $0.1 < threshold ? $0.0 : nil }
+
+    // Drop-fraction cap: if the adaptive threshold would drop more than ~40% of
+    // all lines, DISBELIEVE the filter and keep everything. A receipt sitting
+    // mostly on a colored surface (or with a large colored coupon block)
+    // contaminates the median itself, so "> 40% colored background" means the
+    // baseline is unreliable and its own paper lines would be stripped.
+    let dropped = lines.count - kept.count
+    if CGFloat(dropped) > 0.40 * CGFloat(lines.count) {
+        return lines
+    }
+    return kept
 }
 #endif

--- a/receipt_ocr_swift/Sources/ReceiptOCRCore/ReceiptProcessing/BackgroundColorFilter.swift
+++ b/receipt_ocr_swift/Sources/ReceiptOCRCore/ReceiptProcessing/BackgroundColorFilter.swift
@@ -1,0 +1,97 @@
+import Foundation
+
+#if os(macOS)
+import CoreGraphics
+
+/// Filters OCR lines to those sitting on a document (white-paper) background,
+/// dropping lines that sit on a colored / photo background — e.g. a menu or
+/// flyer behind the receipt.
+///
+/// Rationale: white thermal paper and black ink are BOTH near-zero saturation,
+/// so a receipt line's bounding box is low-saturation regardless of its text.
+/// A line printed on a colored menu/photo background is high-saturation. This
+/// is a cheap, mostly-deterministic separator that removes background bleed
+/// (the Twin Peaks receipt absorbing the burger-menu behind it) before
+/// clustering/segmentation.
+///
+/// Note: this does NOT separate two overlapping *white* receipts (both are
+/// low-saturation) — that remains a geometry problem handled elsewhere.
+///
+/// - Parameters:
+///   - lines: OCR lines with normalized, bottom-left-origin coordinates.
+///   - image: Source pixels (full image).
+///   - saturationThreshold: Mean background saturation above which a line is
+///     treated as non-document. Calibrated: receipt lines ~0.09 median, menu
+///     lines ~0.35-0.47; 0.18 leaves a wide margin.
+/// - Returns: The subset of `lines` on a document background.
+public func filterDocumentLines(
+    _ lines: [Line],
+    image: CGImage,
+    saturationThreshold: CGFloat = 0.18
+) -> [Line] {
+    let w = image.width
+    let h = image.height
+    guard w > 0, h > 0, !lines.isEmpty else { return lines }
+
+    let bytesPerRow = w * 4
+    var data = [UInt8](repeating: 0, count: w * h * 4)
+    guard
+        let ctx = CGContext(
+            data: &data,
+            width: w,
+            height: h,
+            bitsPerComponent: 8,
+            bytesPerRow: bytesPerRow,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        )
+    else {
+        return lines
+    }
+    ctx.draw(image, in: CGRect(x: 0, y: 0, width: w, height: h))
+
+    func meanBackgroundSaturation(_ line: Line) -> CGFloat {
+        let xsN = [
+            line.topLeft.x, line.topRight.x,
+            line.bottomLeft.x, line.bottomRight.x,
+        ]
+        // Vision is bottom-left origin; the bitmap is top-left origin.
+        let ysN = [
+            line.topLeft.y, line.topRight.y,
+            line.bottomLeft.y, line.bottomRight.y,
+        ]
+        let xs = xsN.map { $0 * CGFloat(w) }
+        let ys = ysN.map { (1 - $0) * CGFloat(h) }
+        let x0 = max(0, Int(xs.min() ?? 0))
+        let x1 = min(w, Int(xs.max() ?? 0))
+        let y0 = max(0, Int(ys.min() ?? 0))
+        let y1 = min(h, Int(ys.max() ?? 0))
+        if x1 <= x0 || y1 <= y0 { return 0 }
+
+        // Subsample to at most ~16x16 samples per line for speed.
+        let stepX = max(1, (x1 - x0) / 16)
+        let stepY = max(1, (y1 - y0) / 16)
+        var sum: CGFloat = 0
+        var count = 0
+        var y = y0
+        while y < y1 {
+            var x = x0
+            while x < x1 {
+                let i = (y * w + x) * 4
+                let r = CGFloat(data[i]) / 255.0
+                let g = CGFloat(data[i + 1]) / 255.0
+                let b = CGFloat(data[i + 2]) / 255.0
+                let mx = max(r, max(g, b))
+                let mn = min(r, min(g, b))
+                sum += mx > 0 ? (mx - mn) / mx : 0
+                count += 1
+                x += stepX
+            }
+            y += stepY
+        }
+        return count > 0 ? sum / CGFloat(count) : 0
+    }
+
+    return lines.filter { meanBackgroundSaturation($0) < saturationThreshold }
+}
+#endif

--- a/receipt_ocr_swift/Sources/ReceiptOCRCore/ReceiptProcessing/DuplicateReceiptSplitter.swift
+++ b/receipt_ocr_swift/Sources/ReceiptOCRCore/ReceiptProcessing/DuplicateReceiptSplitter.swift
@@ -1,0 +1,234 @@
+import Foundation
+
+#if os(macOS)
+import CoreGraphics
+
+/// Detects and splits the "two overlapping copies of the same receipt" case —
+/// a customer copy laid on top of a merchant copy — which color and naive
+/// geometry cannot separate (both are white paper).
+///
+/// Insight (deterministic): two offset copies of the same purchase have
+/// DUPLICATE text lines, and every true duplicate pair shares approximately the
+/// SAME displacement vector (a rigid translation). A single receipt with
+/// internally repeated text ("TOTAL"/"SUBTOTAL", repeated SKUs) yields
+/// INCONSISTENT displacement vectors and fails the consensus, so it is never
+/// split. We only split on >= `minConsensusPairs` displacement-consistent
+/// duplicate pairs, and only if both resulting halves independently look like a
+/// receipt — otherwise the cluster is left intact.
+///
+/// This runs on OCR text + geometry only (no pixels), is O(n^2) over a cluster's
+/// lines, and is fully deterministic / unit-testable.
+
+private let minConsensusPairs = 3
+private let minTextSimilarity: CGFloat = 0.85
+private let minTextLength = 4
+/// Displacement-vector agreement tolerance (normalized image units).
+private let dispTolerance: CGFloat = 0.035
+/// Each split half must keep at least this many lines AND this fraction.
+private let minHalfLines = 5
+private let minHalfFraction: CGFloat = 0.20
+
+/// Outcome of examining one cluster for duplicate-copy structure.
+enum DuplicateOutcome {
+    /// Confidently two overlapping copies — split into these two groups.
+    case split([Int], [Int])
+    /// Probably multiple receipts (some duplicate-anchor evidence) but below the
+    /// confident-split threshold — do not split, flag for review.
+    case suspicious(anchorPairs: Int)
+    /// A single receipt.
+    case single
+}
+
+/// Returns a new clustering in which any cluster confidently identified as two
+/// overlapping copies of one receipt is split into two clusters, plus the set of
+/// cluster IDs that look like multiple receipts but could not be split
+/// confidently (flag these for review). All other clusters pass through
+/// unchanged.
+public func splitDuplicateReceiptClusters(
+    _ clustering: ClusteringResult,
+    lines: [Line]
+) -> (result: ClusteringResult, needsReview: [Int]) {
+    var result: [Int: [Int]] = [:]
+    var needsReview: [Int] = []
+    var nextId = (clustering.clusters.keys.filter { $0 != -1 }.max() ?? 0) + 1
+
+    for (clusterId, indices) in clustering.clusters {
+        if clusterId == -1 {
+            result[clusterId] = indices
+            continue
+        }
+        let valid = indices.filter { $0 >= 0 && $0 < lines.count }
+        guard valid.count >= 2 * minHalfLines else {
+            result[clusterId] = indices
+            continue
+        }
+        switch examineDuplicatePair(valid, lines: lines) {
+        case .split(let groupA, let groupB):
+            result[clusterId] = groupA
+            result[nextId] = groupB
+            nextId += 1
+        case .suspicious:
+            result[clusterId] = indices
+            needsReview.append(clusterId)
+        case .single:
+            result[clusterId] = indices
+        }
+    }
+    return (ClusteringResult(clusters: result), needsReview)
+}
+
+/// Core detector. Confidently splits two overlapping copies, flags a suspicious
+/// (probable-multiple) cluster, or reports a single receipt.
+func examineDuplicatePair(
+    _ indices: [Int],
+    lines: [Line]
+) -> DuplicateOutcome {
+    let texts = indices.map { normalizedText(lines[$0].text) }
+    let cents = indices.map { centroid(lines[$0]) }
+    let heights = indices.map { lineHeight(lines[$0]) }
+
+    // 1. Candidate duplicate pairs: similar text, disjoint in space.
+    struct Pair { let a: Int; let b: Int; let disp: CGVector }
+    var pairs: [Pair] = []
+    for i in 0..<indices.count {
+        if texts[i].count < minTextLength { continue }
+        for j in (i + 1)..<indices.count {
+            if texts[j].count < minTextLength { continue }
+            if similarity(texts[i], texts[j]) < minTextSimilarity { continue }
+            let dx = cents[j].x - cents[i].x
+            let dy = cents[j].y - cents[i].y
+            let sep = (dx * dx + dy * dy).squareRoot()
+            let hRef = max(heights[i], heights[j])
+            if sep < 3.0 * hRef { continue }  // must be spatially disjoint
+            // Canonicalize direction so mirror pairs agree.
+            var vdx = dx, vdy = dy, ai = i, bj = j
+            if vdy < 0 || (vdy == 0 && vdx < 0) {
+                vdx = -vdx; vdy = -vdy; ai = j; bj = i
+            }
+            pairs.append(Pair(a: ai, b: bj, disp: CGVector(dx: vdx, dy: vdy)))
+        }
+    }
+    guard pairs.count >= 2 else { return .single }
+
+    // 2. Displacement consensus: the vector most pairs agree on.
+    var bestConsensus: [Pair] = []
+    for candidate in pairs {
+        let agree = pairs.filter {
+            let ex = $0.disp.dx - candidate.disp.dx
+            let ey = $0.disp.dy - candidate.disp.dy
+            return (ex * ex + ey * ey).squareRoot() <= dispTolerance
+        }
+        if agree.count > bestConsensus.count { bestConsensus = agree }
+    }
+    // Not even two duplicate anchors agree on a displacement — single receipt.
+    guard bestConsensus.count >= 2 else { return .single }
+
+    // Some duplicate-anchor evidence but below the confident-split threshold
+    // (e.g. a faded second copy yields only 2 clean anchors, or rotation makes
+    // a pure translation cap out). Flag for review; never split on this.
+    guard bestConsensus.count >= minConsensusPairs else {
+        return .suspicious(anchorPairs: bestConsensus.count)
+    }
+
+    // Consensus displacement (median of agreeing vectors).
+    let dUnit = normalize(
+        CGVector(
+            dx: median(bestConsensus.map { $0.disp.dx }),
+            dy: median(bestConsensus.map { $0.disp.dy })
+        )
+    )
+
+    // 3. Seeded assignment: anchors A (tail) and B (head) define the boundary;
+    //    assign every line by which side of it (along the displacement) it sits.
+    let projA = bestConsensus.map { proj(cents[$0.a], dUnit) }
+    let projB = bestConsensus.map { proj(cents[$0.b], dUnit) }
+    let boundary = (mean(projA) + mean(projB)) / 2.0
+
+    var groupA: [Int] = []
+    var groupB: [Int] = []
+    for (k, idx) in indices.enumerated() {
+        if proj(cents[k], dUnit) < boundary {
+            groupA.append(idx)
+        } else {
+            groupB.append(idx)
+        }
+    }
+
+    // 4. Validate: each half must independently look like a receipt.
+    let total = indices.count
+    let okA =
+        groupA.count >= minHalfLines
+        && CGFloat(groupA.count) >= minHalfFraction * CGFloat(total)
+    let okB =
+        groupB.count >= minHalfLines
+        && CGFloat(groupB.count) >= minHalfFraction * CGFloat(total)
+    guard okA && okB else {
+        return .suspicious(anchorPairs: bestConsensus.count)
+    }
+
+    return .split(groupA, groupB)
+}
+
+// MARK: - Helpers
+
+func normalizedText(_ s: String) -> String {
+    let upper = s.uppercased()
+    let collapsed = upper.split(whereSeparator: { $0 == " " || $0 == "\t" })
+        .joined(separator: " ")
+    return collapsed.trimmingCharacters(in: .whitespaces)
+}
+
+/// Normalized Levenshtein similarity in [0, 1].
+func similarity(_ a: String, _ b: String) -> CGFloat {
+    let s = Array(a), t = Array(b)
+    if s.isEmpty && t.isEmpty { return 1 }
+    let n = s.count, m = t.count
+    if n == 0 || m == 0 { return 0 }
+    // Quick length-ratio prefilter.
+    let lenRatio = CGFloat(min(n, m)) / CGFloat(max(n, m))
+    if lenRatio < 0.6 { return 0 }
+    var prev = Array(0...m)
+    var curr = [Int](repeating: 0, count: m + 1)
+    for i in 1...n {
+        curr[0] = i
+        for j in 1...m {
+            let cost = s[i - 1] == t[j - 1] ? 0 : 1
+            curr[j] = min(prev[j] + 1, curr[j - 1] + 1, prev[j - 1] + cost)
+        }
+        swap(&prev, &curr)
+    }
+    let dist = prev[m]
+    return 1.0 - CGFloat(dist) / CGFloat(max(n, m))
+}
+
+func centroid(_ line: Line) -> CGPoint {
+    let x =
+        (line.topLeft.x + line.topRight.x + line.bottomLeft.x
+            + line.bottomRight.x) / 4.0
+    let y =
+        (line.topLeft.y + line.topRight.y + line.bottomLeft.y
+            + line.bottomRight.y) / 4.0
+    return CGPoint(x: x, y: y)
+}
+
+func lineHeight(_ line: Line) -> CGFloat {
+    let leftH = abs(line.topLeft.y - line.bottomLeft.y)
+    let rightH = abs(line.topRight.y - line.bottomRight.y)
+    return max((leftH + rightH) / 2.0, 1e-4)
+}
+
+private func normalize(_ v: CGVector) -> CGVector {
+    let mag = (v.dx * v.dx + v.dy * v.dy).squareRoot()
+    guard mag > 1e-9 else { return CGVector(dx: 1, dy: 0) }
+    return CGVector(dx: v.dx / mag, dy: v.dy / mag)
+}
+
+private func proj(_ p: CGPoint, _ unit: CGVector) -> CGFloat {
+    return p.x * unit.dx + p.y * unit.dy
+}
+
+private func mean(_ values: [CGFloat]) -> CGFloat {
+    guard !values.isEmpty else { return 0 }
+    return values.reduce(0, +) / CGFloat(values.count)
+}
+#endif

--- a/receipt_ocr_swift/Sources/ReceiptOCRCore/ReceiptProcessing/DuplicateReceiptSplitter.swift
+++ b/receipt_ocr_swift/Sources/ReceiptOCRCore/ReceiptProcessing/DuplicateReceiptSplitter.swift
@@ -8,13 +8,19 @@ import CoreGraphics
 /// geometry cannot separate (both are white paper).
 ///
 /// Insight (deterministic): two offset copies of the same purchase have
-/// DUPLICATE text lines, and every true duplicate pair shares approximately the
-/// SAME displacement vector (a rigid translation). A single receipt with
+/// DUPLICATE text lines related by a single RIGID transform — a rotation θ plus
+/// a translation t (two copies tossed on a table are offset by translation AND a
+/// small rotation). Every true duplicate pair a_i (copy A point) -> b_i (copy B
+/// point) then satisfies b_i ≈ R_θ·a_i + t. We recover (θ, t) with a RANSAC over
+/// the duplicate-line correspondences and count inliers; a single receipt with
 /// internally repeated text ("TOTAL"/"SUBTOTAL", repeated SKUs) yields
-/// INCONSISTENT displacement vectors and fails the consensus, so it is never
-/// split. We only split on >= `minConsensusPairs` displacement-consistent
-/// duplicate pairs, and only if both resulting halves independently look like a
-/// receipt — otherwise the cluster is left intact.
+/// INCONSISTENT correspondences and fails the consensus, so it is never split.
+/// (A pure-translation consensus caps out under rotation because the
+/// displacement vector b_i - a_i grows down the receipt, so real anchors at
+/// opposite ends disagree; the rigid model removes that drift.) We only split on
+/// >= `minConsensusPairs` rigid-consistent duplicate pairs, and only if both
+/// resulting halves independently look like a receipt — otherwise the cluster is
+/// left intact.
 ///
 /// This runs on OCR text + geometry only (no pixels), is O(n^2) over a cluster's
 /// lines, and is fully deterministic / unit-testable.
@@ -22,8 +28,13 @@ import CoreGraphics
 private let minConsensusPairs = 3
 private let minTextSimilarity: CGFloat = 0.85
 private let minTextLength = 4
-/// Displacement-vector agreement tolerance (normalized image units).
+/// Positional agreement tolerance (normalized image units). Used both as the
+/// rigid-transform inlier residual threshold and for harmonic-family detection.
 private let dispTolerance: CGFloat = 0.035
+/// Maximum |θ| for a rigid two-copy model (radians, ≈15°). Two copies dropped on
+/// a table have a small relative rotation; a larger estimated rotation is
+/// spurious (e.g. a coincidental match between distant lines) and is rejected.
+private let maxRotation: CGFloat = 15.0 * CGFloat.pi / 180.0
 /// Each split half must keep at least this many lines AND this fraction.
 private let minHalfLines = 5
 private let minHalfFraction: CGFloat = 0.20
@@ -110,27 +121,62 @@ func examineDuplicatePair(
     }
     guard pairs.count >= 2 else { return .single }
 
-    // 2. Displacement consensus: the vector most pairs agree on.
+    // 2. Rigid-transform consensus (RANSAC). Each pair is a correspondence
+    //    a_i (copy A point) -> b_i (copy B point). From any two correspondences
+    //    estimate a rotation θ and translation t, reject models whose |θ| is too
+    //    large to be two dropped copies, then count inlier correspondences k for
+    //    which |R_θ·a_k + t - b_k| <= dispTolerance. The model with the most
+    //    inliers wins, and those inliers are the anchor set. This subsumes the
+    //    old pure-translation consensus (a periodic list still fits a θ≈0 model),
+    //    but recovers the rotated two-copy case a translation-only model misses.
+    let aPts = pairs.map { cents[$0.a] }
+    let bPts = pairs.map { cents[$0.b] }
     var bestConsensus: [Pair] = []
-    for candidate in pairs {
-        let agree = pairs.filter {
-            let ex = $0.disp.dx - candidate.disp.dx
-            let ey = $0.disp.dy - candidate.disp.dy
-            return (ex * ex + ey * ey).squareRoot() <= dispTolerance
+    for i in 0..<pairs.count {
+        for j in 0..<pairs.count where j != i {
+            let vAx = aPts[j].x - aPts[i].x
+            let vAy = aPts[j].y - aPts[i].y
+            let vBx = bPts[j].x - bPts[i].x
+            let vBy = bPts[j].y - bPts[i].y
+            let magA = (vAx * vAx + vAy * vAy).squareRoot()
+            let magB = (vBx * vBx + vBy * vBy).squareRoot()
+            if magA < 1e-6 || magB < 1e-6 { continue }
+            // θ = atan2(b_j - b_i) - atan2(a_j - a_i), wrapped to (-π, π].
+            var theta = atan2(vBy, vBx) - atan2(vAy, vAx)
+            while theta > CGFloat.pi { theta -= 2 * CGFloat.pi }
+            while theta <= -CGFloat.pi { theta += 2 * CGFloat.pi }
+            if abs(theta) > maxRotation { continue }
+            let c = cos(theta), s = sin(theta)
+            // t = b_i - R_θ·a_i.
+            let tx = bPts[i].x - (c * aPts[i].x - s * aPts[i].y)
+            let ty = bPts[i].y - (s * aPts[i].x + c * aPts[i].y)
+            var inliers: [Pair] = []
+            for k in 0..<pairs.count {
+                let rx = c * aPts[k].x - s * aPts[k].y + tx
+                let ry = s * aPts[k].x + c * aPts[k].y + ty
+                let ex = rx - bPts[k].x
+                let ey = ry - bPts[k].y
+                if (ex * ex + ey * ey).squareRoot() <= dispTolerance {
+                    inliers.append(pairs[k])
+                }
+            }
+            if inliers.count > bestConsensus.count { bestConsensus = inliers }
         }
-        if agree.count > bestConsensus.count { bestConsensus = agree }
     }
-    // Not even two duplicate anchors agree on a displacement — single receipt.
+    // Not even two duplicate anchors fit one rigid transform — single receipt.
     guard bestConsensus.count >= 2 else { return .single }
 
     // Some duplicate-anchor evidence but below the confident-split threshold
-    // (e.g. a faded second copy yields only 2 clean anchors, or rotation makes
-    // a pure translation cap out). Flag for review; never split on this.
+    // (e.g. a faded second copy yields only 2 clean anchors). Flag for review;
+    // never split on this.
     guard bestConsensus.count >= minConsensusPairs else {
         return .suspicious(anchorPairs: bestConsensus.count)
     }
 
-    // Consensus displacement (median of agreeing vectors).
+    // Representative translation of the winning model (median inlier
+    // displacement). With the small rotations seen between two copies this is
+    // close to t, and for a periodic list (θ≈0) it is the single pitch — which
+    // keeps the harmonic guard below working unchanged.
     let bestVec = CGVector(
         dx: median(bestConsensus.map { $0.disp.dx }),
         dy: median(bestConsensus.map { $0.disp.dy })

--- a/receipt_ocr_swift/Sources/ReceiptOCRCore/ReceiptProcessing/DuplicateReceiptSplitter.swift
+++ b/receipt_ocr_swift/Sources/ReceiptOCRCore/ReceiptProcessing/DuplicateReceiptSplitter.swift
@@ -212,13 +212,20 @@ func examineDuplicatePair(
     // the sub-threshold (2-inlier) review flag can be gated on the SAME quality
     // bar as the confident-split path (see the minConsensusPairs branch below).
 
-    // Distinctive anchors: at least two consensus pairs must be anchored by real
-    // alphabetic text, NOT a pure price / quantity / money token ("3.50",
-    // "$5.00", "2 X", "#4"). Repeated SKUs and prices do not count toward this.
-    let distinctiveAnchors = bestConsensus.filter {
-        isDistinctiveAnchorText(texts[$0.a])
-    }.count
-    let anchorsDistinctive = distinctiveAnchors >= 2
+    // Distinctive anchors: the consensus must be anchored by at least two
+    // DISTINCT pieces of real alphabetic text — not a pure price / quantity /
+    // money token ("3.50", "$5.00", "2 X", "#4"), and not the SAME string
+    // repeated. Two genuine copies duplicate several *different* unique lines
+    // (merchant, address, total); a single receipt with an evenly-spaced
+    // repeated alphabetic row ("TACO 3.50" x50) yields many "distinctive"
+    // anchors that are all the identical string and can forge a rigid,
+    // non-harmonic consensus — requiring two DISTINCT texts rejects that.
+    let distinctiveTexts = Set(
+        bestConsensus.compactMap {
+            isDistinctiveAnchorText(texts[$0.a]) ? texts[$0.a] : nil
+        }
+    )
+    let anchorsDistinctive = distinctiveTexts.count >= 2
 
     // Anchor spatial spread: the consensus anchors must be scattered across the
     // receipt's long axis (the displacement direction, ~vertical for stacked
@@ -310,6 +317,19 @@ func examineDuplicatePair(
         $0.0 < boundary && $0.1 >= boundary
     }.count
     guard CGFloat(straddling) >= 0.75 * CGFloat(bestConsensus.count) else {
+        return .suspicious(anchorPairs: bestConsensus.count)
+    }
+
+    // Require a real line-free gap AT the boundary. `maxProjA < minProjB` proves
+    // only that the matched ANCHORS are disjoint; an unmatched header/footer of
+    // one copy can still extend across the boundary and be assigned to the wrong
+    // copy. If the nearest lines on either side of the cut are closer than ~half
+    // a line height (no gap), the split would bisect content — flag instead.
+    let medHeight = median(heights)
+    let belowBoundary = clusterProj.filter { $0 <= boundary }.max()
+    let aboveBoundary = clusterProj.filter { $0 > boundary }.min()
+    if medHeight > 1e-6, let bb = belowBoundary, let ab = aboveBoundary,
+        (ab - bb) < 0.5 * medHeight {
         return .suspicious(anchorPairs: bestConsensus.count)
     }
 

--- a/receipt_ocr_swift/Sources/ReceiptOCRCore/ReceiptProcessing/DuplicateReceiptSplitter.swift
+++ b/receipt_ocr_swift/Sources/ReceiptOCRCore/ReceiptProcessing/DuplicateReceiptSplitter.swift
@@ -121,6 +121,18 @@ func examineDuplicatePair(
     }
     guard pairs.count >= 2 else { return .single }
 
+    // Pathological-explosion guard (bounds the O(P^2) consensus search below).
+    // A genuine pair of overlapping copies yields O(n) spatially-disjoint
+    // duplicate correspondences (each distinctive line matched to its twin). A
+    // long list of near-identical rows (e.g. 60 repeated SKU lines) instead
+    // yields O(n^2) candidate pairs — C(60,2)=1770 — and the pairwise model
+    // search is O(P^2) hypotheses x O(P) inliers = O(P^3), which would stall an
+    // OCR worker for seconds before the harmonic guard ever runs. Such a blow-up
+    // is definitionally a periodic list, not two copies, so treat it as a single
+    // receipt rather than attempt the (doomed, expensive) consensus.
+    let maxPairs = 300
+    if pairs.count > maxPairs { return .single }
+
     // 2. Rigid-transform consensus (RANSAC). Each pair is a correspondence
     //    a_i (copy A point) -> b_i (copy B point). From any two correspondences
     //    estimate a rotation θ and translation t, reject models whose |θ| is too
@@ -261,6 +273,21 @@ func examineDuplicatePair(
     // 3. Seeded assignment: anchors A (tail) and B (head) define the boundary;
     //    assign every line by which side of it (along the displacement) it sits.
     let boundary = (mean(projA) + mean(projB)) / 2.0
+
+    // The boundary can only separate two copies that are largely DISJOINT along
+    // the displacement axis (one copy stacked below the other). If the copies
+    // overlap so heavily that the midpoint slices through both, a positional
+    // split scatters each copy's lines across both halves, yielding two mixed
+    // partial crops rather than the two copies. Detect that: for a clean stacked
+    // pair every anchor's A-member (tail copy) sits below the boundary and its
+    // B-member (head copy) above it. If the anchor correspondences don't cleanly
+    // straddle the boundary, don't split — flag for review.
+    let straddling = zip(projA, projB).filter {
+        $0.0 < boundary && $0.1 >= boundary
+    }.count
+    guard CGFloat(straddling) >= 0.75 * CGFloat(bestConsensus.count) else {
+        return .suspicious(anchorPairs: bestConsensus.count)
+    }
 
     var groupA: [Int] = []
     var groupB: [Int] = []

--- a/receipt_ocr_swift/Sources/ReceiptOCRCore/ReceiptProcessing/DuplicateReceiptSplitter.swift
+++ b/receipt_ocr_swift/Sources/ReceiptOCRCore/ReceiptProcessing/DuplicateReceiptSplitter.swift
@@ -131,17 +131,67 @@ func examineDuplicatePair(
     }
 
     // Consensus displacement (median of agreeing vectors).
-    let dUnit = normalize(
-        CGVector(
-            dx: median(bestConsensus.map { $0.disp.dx }),
-            dy: median(bestConsensus.map { $0.disp.dy })
-        )
+    let bestVec = CGVector(
+        dx: median(bestConsensus.map { $0.disp.dx }),
+        dy: median(bestConsensus.map { $0.disp.dy })
     )
+    let dUnit = normalize(bestVec)
+
+    // --- FIX 1 guards: reject a false split of a SINGLE receipt whose
+    // internally repeated rows (6x "TACO 3.50", identical SKUs) forge an
+    // evenly spaced, single-pitch "consensus". A genuine pair of overlapping
+    // copies has exactly ONE rigid displacement, anchored by DISTINCTIVE text
+    // SCATTERED across the whole receipt; a periodic item list does not. All
+    // three guards must pass before we may split. ---
+
+    // Guard 3 (cheapest disqualifier, checked first): reject a
+    // harmonic/periodic displacement family. Evenly spaced repeats yield not
+    // only a 1-pitch consensus but also a 2-pitch (3-pitch, ...) family. Two
+    // real copies have exactly ONE displacement and no ~2x harmonic. If a
+    // second consensus vector (>= 2 agreeing pairs) sits at ~2x the best
+    // vector, this is a list, not two copies.
+    let twoVec = CGVector(dx: 2 * bestVec.dx, dy: 2 * bestVec.dy)
+    let harmonicCount = pairs.filter {
+        let ex = $0.disp.dx - twoVec.dx
+        let ey = $0.disp.dy - twoVec.dy
+        return (ex * ex + ey * ey).squareRoot() <= 2 * dispTolerance
+    }.count
+    if harmonicCount >= 2 {
+        return .single
+    }
+
+    // Guard 2: distinctive anchors. At least two consensus pairs must be
+    // anchored by real alphabetic text, NOT a pure price / quantity / money
+    // token ("3.50", "$5.00", "2 X", "#4"). Repeated SKUs and prices do not
+    // count toward this requirement.
+    let distinctiveAnchors = bestConsensus.filter {
+        isDistinctiveAnchorText(texts[$0.a])
+    }.count
+    guard distinctiveAnchors >= 2 else {
+        // Only prices / quantities line up: no evidence of duplicated content.
+        return .single
+    }
 
     // 3. Seeded assignment: anchors A (tail) and B (head) define the boundary;
     //    assign every line by which side of it (along the displacement) it sits.
     let projA = bestConsensus.map { proj(cents[$0.a], dUnit) }
     let projB = bestConsensus.map { proj(cents[$0.b], dUnit) }
+
+    // Guard 1: anchor spatial spread. The consensus anchors must be scattered
+    // across the receipt's long axis (the displacement direction, ~vertical for
+    // stacked copies), not locally consecutive. Require both the "A" and "B"
+    // members to span >= 40% of the whole cluster's extent on that axis.
+    let clusterProj = cents.map { proj($0, dUnit) }
+    let clusterExtent = (clusterProj.max() ?? 0) - (clusterProj.min() ?? 0)
+    let spanA = (projA.max() ?? 0) - (projA.min() ?? 0)
+    let spanB = (projB.max() ?? 0) - (projB.min() ?? 0)
+    let minSpread: CGFloat = 0.40 * clusterExtent
+    guard clusterExtent > 1e-6, spanA >= minSpread, spanB >= minSpread else {
+        // Distinctive, non-harmonic anchors exist but are bunched together, not
+        // clearly two copies. Some evidence: flag for review, but do not split.
+        return .suspicious(anchorPairs: bestConsensus.count)
+    }
+
     let boundary = (mean(projA) + mean(projB)) / 2.0
 
     var groupA: [Int] = []
@@ -176,6 +226,26 @@ func normalizedText(_ s: String) -> String {
     let collapsed = upper.split(whereSeparator: { $0 == " " || $0 == "\t" })
         .joined(separator: " ")
     return collapsed.trimmingCharacters(in: .whitespaces)
+}
+
+/// True if `t` (already normalized / uppercased) carries real alphabetic
+/// content and is NOT a pure price / quantity / money token. The money alphabet
+/// is digits, spaces, '.', ',', '$', 'X'/'x' (a quantity multiplier), and '#'.
+/// Repeated SKUs and prices ("3.50", "$5.00", "2 X", "#4") therefore do not
+/// qualify as distinctive anchors, while item names ("TACO 3.50") do.
+func isDistinctiveAnchorText(_ t: String) -> Bool {
+    var hasLetter = false
+    var hasNonMoney = false
+    for c in t.unicodeScalars {
+        if c.value >= 65 && c.value <= 90 { hasLetter = true }  // A-Z (uppercased)
+        switch c {
+        case "0"..."9", " ", ".", ",", "$", "X", "x", "#":
+            continue
+        default:
+            hasNonMoney = true
+        }
+    }
+    return hasLetter && hasNonMoney
 }
 
 /// Normalized Levenshtein similarity in [0, 1].

--- a/receipt_ocr_swift/Sources/ReceiptOCRCore/ReceiptProcessing/DuplicateReceiptSplitter.swift
+++ b/receipt_ocr_swift/Sources/ReceiptOCRCore/ReceiptProcessing/DuplicateReceiptSplitter.swift
@@ -122,16 +122,29 @@ func examineDuplicatePair(
     guard pairs.count >= 2 else { return .single }
 
     // Pathological-explosion guard (bounds the O(P^2) consensus search below).
-    // A genuine pair of overlapping copies yields O(n) spatially-disjoint
-    // duplicate correspondences (each distinctive line matched to its twin). A
-    // long list of near-identical rows (e.g. 60 repeated SKU lines) instead
-    // yields O(n^2) candidate pairs — C(60,2)=1770 — and the pairwise model
-    // search is O(P^2) hypotheses x O(P) inliers = O(P^3), which would stall an
-    // OCR worker for seconds before the harmonic guard ever runs. Such a blow-up
-    // is definitionally a periodic list, not two copies, so treat it as a single
-    // receipt rather than attempt the (doomed, expensive) consensus.
+    // A long list of near-identical rows (e.g. 60 repeated SKU lines) yields
+    // O(n^2) candidate pairs — C(60,2)=1770 — and the pairwise model search is
+    // O(P^2) hypotheses x O(P) inliers = O(P^3), which would stall an OCR worker
+    // for seconds. Rather than discard the decision entirely (a huge pair count
+    // is USUALLY a periodic single receipt, but two copies of a long repeated
+    // list can also overflow), deterministically keep the most INFORMATIVE
+    // candidates — distinctive-text anchors first (they carry the real two-copy
+    // signal, not repeated prices), then the widest displacements (spread) — and
+    // run the normal consensus + guards on that bounded set. A periodic list's
+    // pairs still trip the harmonic guard (-> .single); a genuine split's
+    // distinctive anchors survive the cull (-> .split / .suspicious).
     let maxPairs = 300
-    if pairs.count > maxPairs { return .single }
+    if pairs.count > maxPairs {
+        pairs.sort { lhs, rhs in
+            let ld = isDistinctiveAnchorText(texts[lhs.a]) ? 1 : 0
+            let rd = isDistinctiveAnchorText(texts[rhs.a]) ? 1 : 0
+            if ld != rd { return ld > rd }
+            let lm = lhs.disp.dx * lhs.disp.dx + lhs.disp.dy * lhs.disp.dy
+            let rm = rhs.disp.dx * rhs.disp.dx + rhs.disp.dy * rhs.disp.dy
+            return lm > rm
+        }
+        pairs = Array(pairs.prefix(maxPairs))
+    }
 
     // 2. Rigid-transform consensus (RANSAC). Each pair is a correspondence
     //    a_i (copy A point) -> b_i (copy B point). From any two correspondences
@@ -270,9 +283,20 @@ func examineDuplicatePair(
         return .suspicious(anchorPairs: bestConsensus.count)
     }
 
-    // 3. Seeded assignment: anchors A (tail) and B (head) define the boundary;
-    //    assign every line by which side of it (along the displacement) it sits.
-    let boundary = (mean(projA) + mean(projB)) / 2.0
+    // 3. Seeded assignment: anchors A (tail copy) and B (head copy) define the
+    //    boundary; assign every line by which side of it (along the displacement)
+    //    it sits. When the two copies are DISJOINT along the axis (max A-anchor
+    //    below min B-anchor) place the boundary in that gap, so every anchor
+    //    straddles it. Only when they interleave (overlapping copies) fall back
+    //    to the mean — where the straddle check below will (correctly) reject the
+    //    split as unseparable. Using the mean unconditionally would misplace the
+    //    boundary for a clean but asymmetric stacking and reject a valid split.
+    let maxProjA = projA.max() ?? 0
+    let minProjB = projB.min() ?? 0
+    let boundary =
+        maxProjA < minProjB
+        ? (maxProjA + minProjB) / 2.0
+        : (mean(projA) + mean(projB)) / 2.0
 
     // The boundary can only separate two copies that are largely DISJOINT along
     // the displacement axis (one copy stacked below the other). If the copies

--- a/receipt_ocr_swift/Sources/ReceiptOCRCore/ReceiptProcessing/DuplicateReceiptSplitter.swift
+++ b/receipt_ocr_swift/Sources/ReceiptOCRCore/ReceiptProcessing/DuplicateReceiptSplitter.swift
@@ -166,13 +166,6 @@ func examineDuplicatePair(
     // Not even two duplicate anchors fit one rigid transform — single receipt.
     guard bestConsensus.count >= 2 else { return .single }
 
-    // Some duplicate-anchor evidence but below the confident-split threshold
-    // (e.g. a faded second copy yields only 2 clean anchors). Flag for review;
-    // never split on this.
-    guard bestConsensus.count >= minConsensusPairs else {
-        return .suspicious(anchorPairs: bestConsensus.count)
-    }
-
     // Representative translation of the winning model (median inlier
     // displacement). With the small rotations seen between two copies this is
     // close to t, and for a periodic list (θ≈0) it is the single pitch — which
@@ -189,6 +182,52 @@ func examineDuplicatePair(
     // copies has exactly ONE rigid displacement, anchored by DISTINCTIVE text
     // SCATTERED across the whole receipt; a periodic item list does not. All
     // three guards must pass before we may split. ---
+    //
+    // The distinctive-anchor and anchor-spread predicates are hoisted here so
+    // the sub-threshold (2-inlier) review flag can be gated on the SAME quality
+    // bar as the confident-split path (see the minConsensusPairs branch below).
+
+    // Distinctive anchors: at least two consensus pairs must be anchored by real
+    // alphabetic text, NOT a pure price / quantity / money token ("3.50",
+    // "$5.00", "2 X", "#4"). Repeated SKUs and prices do not count toward this.
+    let distinctiveAnchors = bestConsensus.filter {
+        isDistinctiveAnchorText(texts[$0.a])
+    }.count
+    let anchorsDistinctive = distinctiveAnchors >= 2
+
+    // Anchor spatial spread: the consensus anchors must be scattered across the
+    // receipt's long axis (the displacement direction, ~vertical for stacked
+    // copies), not locally consecutive. Require both the "A" and "B" members to
+    // span >= 40% of the whole cluster's extent on that axis.
+    let projA = bestConsensus.map { proj(cents[$0.a], dUnit) }
+    let projB = bestConsensus.map { proj(cents[$0.b], dUnit) }
+    let clusterProj = cents.map { proj($0, dUnit) }
+    let clusterExtent = (clusterProj.max() ?? 0) - (clusterProj.min() ?? 0)
+    let spanA = (projA.max() ?? 0) - (projA.min() ?? 0)
+    let spanB = (projB.max() ?? 0) - (projB.min() ?? 0)
+    let minSpread: CGFloat = 0.40 * clusterExtent
+    let anchorsSpread =
+        clusterExtent > 1e-6 && spanA >= minSpread && spanB >= minSpread
+
+    // Some duplicate-anchor evidence but below the confident-split threshold
+    // (e.g. a faded second copy yields only 2 clean anchors). Flag for review
+    // ONLY when those anchors are themselves a plausible two-copy signal, held
+    // to the SAME distinctive-anchor / anchor-spread guards the split path uses
+    // and with the split path's OWN outcomes:
+    //   - non-distinctive anchors (a single clean receipt's repeated money/qty
+    //     tokens, "$20.00"/"TOTAL", which form rigid-consistent but meaningless
+    //     correspondences) -> .single, exactly as the split path's distinctive
+    //     guard returns .single;
+    //   - distinctive anchors that are merely bunched (not spread) -> the split
+    //     path already downgrades that from a split to .suspicious, so a 2-inlier
+    //     distinctive consensus is at most .suspicious here too.
+    // This removes the old blanket needs_review on any 2-inlier consensus (which
+    // fired on every receipt that repeats a price) while keeping genuine
+    // distinctive partial-duplicate evidence flagged. Never split on this.
+    guard bestConsensus.count >= minConsensusPairs else {
+        guard anchorsDistinctive else { return .single }
+        return .suspicious(anchorPairs: bestConsensus.count)
+    }
 
     // Guard 3 (cheapest disqualifier, checked first): reject a
     // harmonic/periodic displacement family. Evenly spaced repeats yield not
@@ -206,38 +245,21 @@ func examineDuplicatePair(
         return .single
     }
 
-    // Guard 2: distinctive anchors. At least two consensus pairs must be
-    // anchored by real alphabetic text, NOT a pure price / quantity / money
-    // token ("3.50", "$5.00", "2 X", "#4"). Repeated SKUs and prices do not
-    // count toward this requirement.
-    let distinctiveAnchors = bestConsensus.filter {
-        isDistinctiveAnchorText(texts[$0.a])
-    }.count
-    guard distinctiveAnchors >= 2 else {
+    // Guard 2: distinctive anchors (computed above).
+    guard anchorsDistinctive else {
         // Only prices / quantities line up: no evidence of duplicated content.
         return .single
     }
 
-    // 3. Seeded assignment: anchors A (tail) and B (head) define the boundary;
-    //    assign every line by which side of it (along the displacement) it sits.
-    let projA = bestConsensus.map { proj(cents[$0.a], dUnit) }
-    let projB = bestConsensus.map { proj(cents[$0.b], dUnit) }
-
-    // Guard 1: anchor spatial spread. The consensus anchors must be scattered
-    // across the receipt's long axis (the displacement direction, ~vertical for
-    // stacked copies), not locally consecutive. Require both the "A" and "B"
-    // members to span >= 40% of the whole cluster's extent on that axis.
-    let clusterProj = cents.map { proj($0, dUnit) }
-    let clusterExtent = (clusterProj.max() ?? 0) - (clusterProj.min() ?? 0)
-    let spanA = (projA.max() ?? 0) - (projA.min() ?? 0)
-    let spanB = (projB.max() ?? 0) - (projB.min() ?? 0)
-    let minSpread: CGFloat = 0.40 * clusterExtent
-    guard clusterExtent > 1e-6, spanA >= minSpread, spanB >= minSpread else {
+    // Guard 1: anchor spatial spread (computed above).
+    guard anchorsSpread else {
         // Distinctive, non-harmonic anchors exist but are bunched together, not
         // clearly two copies. Some evidence: flag for review, but do not split.
         return .suspicious(anchorPairs: bestConsensus.count)
     }
 
+    // 3. Seeded assignment: anchors A (tail) and B (head) define the boundary;
+    //    assign every line by which side of it (along the displacement) it sits.
     let boundary = (mean(projA) + mean(projB)) / 2.0
 
     var groupA: [Int] = []

--- a/receipt_ocr_swift/Sources/ReceiptOCRCore/ReceiptProcessing/GeometryFilters.swift
+++ b/receipt_ocr_swift/Sources/ReceiptOCRCore/ReceiptProcessing/GeometryFilters.swift
@@ -68,27 +68,35 @@ public func crossAxisInlierMask(_ lines: [Line], k: CGFloat = 4.0) -> [Bool] {
     // deliberately does NOT try to split two overlapping receipts — a gap-based
     // split was tried and regressed clean tilted receipts (it cut real header/
     // footer content), so that case is left to a content-based pass.
-    let reject = k * 1.4826 * mad
-    var mask = offsets.map { abs($0 - medOff) <= reject }
-
-    // Protect the longitudinal extremes. The top-most and bottom-most lines
-    // along the receipt's stacking axis anchor the crop's vertical extent — the
-    // store header and, critically, the grand TOTAL/TAX. A short, right- or
-    // left-aligned total or header line has an off-center cross-axis centroid
-    // and can read as an outlier of an otherwise tightly-aligned column; trimming
-    // it would exclude it from the hull and shrink the warped crop past real
-    // content. Never drop the two extreme lines on the stacking axis. (Sideways
-    // background bleed is handled by the color filter and the duplicate splitter,
-    // not here.)
-    let lx = -ay
-    let ly = ax
-    let longit = centroids.map { $0.0 * lx + $0.1 * ly }
-    if let minIdx = longit.indices.min(by: { longit[$0] < longit[$1] }),
-        let maxIdx = longit.indices.max(by: { longit[$0] < longit[$1] }) {
-        mask[minIdx] = true
-        mask[maxIdx] = true
+    // Interval-based rejection (conservative). Centroid distance alone would drop
+    // a short, off-center but legitimate line — e.g. a right-aligned TOTAL whose
+    // centroid sits far from the column median even though its text still lies
+    // WITHIN the receipt's column, or a centered header on a receipt with a
+    // tight body. Instead, reject a line only when its cross-axis EXTENT is
+    // wholly DISJOINT from the receipt column envelope: a menu / adjacent-document
+    // line pressed sideways against the receipt. A total/header overlaps the
+    // column and is kept; a truly sideways line is dropped even when it is the
+    // top-most or bottom-most line (which a longitudinal-extreme exception would
+    // have wrongly protected, re-admitting menu bleed).
+    let intervals = lines.map { line -> (CGFloat, CGFloat) in
+        let ps = [
+            line.topLeft.x * ax + line.topLeft.y * ay,
+            line.topRight.x * ax + line.topRight.y * ay,
+            line.bottomLeft.x * ax + line.bottomLeft.y * ay,
+            line.bottomRight.x * ax + line.bottomRight.y * ay,
+        ]
+        return (ps.min() ?? 0, ps.max() ?? 0)
     }
-    return mask
+    let medLow = median(intervals.map { $0.0 })
+    let medHigh = median(intervals.map { $0.1 })
+    let colWidth = max(0, medHigh - medLow)
+    // Generous envelope: half the column width on each side, floored at the
+    // MAD-based reject distance. A line is an outlier only if its whole cross-
+    // axis interval lies beyond this envelope (no overlap).
+    let tol = max(0.5 * colWidth, k * 1.4826 * mad)
+    let loBound = medLow - tol
+    let hiBound = medHigh + tol
+    return intervals.map { $0.1 >= loBound && $0.0 <= hiBound }
 }
 
 /// Median of a non-empty array (returns 0 for empty).

--- a/receipt_ocr_swift/Sources/ReceiptOCRCore/ReceiptProcessing/GeometryFilters.swift
+++ b/receipt_ocr_swift/Sources/ReceiptOCRCore/ReceiptProcessing/GeometryFilters.swift
@@ -1,0 +1,85 @@
+import Foundation
+
+#if os(macOS)
+import CoreGraphics
+
+/// Returns a keep-mask that drops lines whose perpendicular ("cross-axis")
+/// offset from the cluster's main column exceeds a robust threshold.
+///
+/// A receipt is a narrow vertical strip: its text lines stack along the strip's
+/// long axis and share a common column. Lines that stick out **sideways** — an
+/// adjacent menu pressed against the edge, or a second overlapping receipt — are
+/// cross-axis outliers. We project each line centroid onto the cross-axis (the
+/// text-baseline direction, perpendicular to the stacking direction), take the
+/// median and MAD, and reject lines beyond `k` robust deviations.
+///
+/// Self-scaling and conservative by construction:
+///   - The threshold is `k · 1.4826 · MAD`, i.e. relative to the receipt's own
+///     width, so a clean single-column receipt keeps every line (no line is a
+///     multi-MAD outlier of its own tight column).
+///   - Below a minimum line count, or when the spread is degenerate, it returns
+///     all-true and changes nothing.
+///
+/// - Parameters:
+///   - lines: The cluster's lines (normalized, bottom-left-origin coords).
+///   - k: Robust-deviation multiplier for the reject distance (default 4.0).
+/// - Returns: A Bool per line — true = keep (inlier), false = drop (outlier).
+public func crossAxisInlierMask(_ lines: [Line], k: CGFloat = 4.0) -> [Bool] {
+    // Too few lines to robustly estimate a column — keep everything.
+    guard lines.count >= 6 else {
+        return Array(repeating: true, count: lines.count)
+    }
+
+    let centroids = lines.map { line -> (CGFloat, CGFloat) in
+        let cx =
+            (line.topLeft.x + line.topRight.x + line.bottomLeft.x
+                + line.bottomRight.x) / 4.0
+        let cy =
+            (line.topLeft.y + line.topRight.y + line.bottomLeft.y
+                + line.bottomRight.y) / 4.0
+        return (cx, cy)
+    }
+
+    // Cross-axis = text-baseline direction (perpendicular to the vertical
+    // stacking of a portrait receipt). For an upright receipt this is ~x.
+    let avgAngle =
+        lines.reduce(0.0) { $0 + $1.angleRadians } / CGFloat(lines.count)
+    let ax = cos(avgAngle)
+    let ay = sin(avgAngle)
+
+    let medX = median(centroids.map { $0.0 })
+    let medY = median(centroids.map { $0.1 })
+    let offsets: [CGFloat] = centroids.map { c in
+        let dx: CGFloat = c.0 - medX
+        let dy: CGFloat = c.1 - medY
+        return dx * ax + dy * ay
+    }
+
+    let medOff = median(offsets)
+    let mad = median(offsets.map { abs($0 - medOff) })
+
+    // Degenerate spread (near single-point column) — don't trim.
+    guard mad > 1e-4 else {
+        return Array(repeating: true, count: lines.count)
+    }
+
+    // Conservative: drop only lines that are extreme cross-axis outliers of an
+    // otherwise-tight column (e.g. a single stray line from a table edge). This
+    // deliberately does NOT try to split two overlapping receipts — a gap-based
+    // split was tried and regressed clean tilted receipts (it cut real header/
+    // footer content), so that case is left to a content-based pass.
+    let reject = k * 1.4826 * mad
+    return offsets.map { abs($0 - medOff) <= reject }
+}
+
+/// Median of a non-empty array (returns 0 for empty).
+func median(_ values: [CGFloat]) -> CGFloat {
+    guard !values.isEmpty else { return 0 }
+    let sorted = values.sorted()
+    let n = sorted.count
+    if n % 2 == 1 {
+        return sorted[n / 2]
+    }
+    return (sorted[n / 2 - 1] + sorted[n / 2]) / 2.0
+}
+#endif

--- a/receipt_ocr_swift/Sources/ReceiptOCRCore/ReceiptProcessing/GeometryFilters.swift
+++ b/receipt_ocr_swift/Sources/ReceiptOCRCore/ReceiptProcessing/GeometryFilters.swift
@@ -69,7 +69,26 @@ public func crossAxisInlierMask(_ lines: [Line], k: CGFloat = 4.0) -> [Bool] {
     // split was tried and regressed clean tilted receipts (it cut real header/
     // footer content), so that case is left to a content-based pass.
     let reject = k * 1.4826 * mad
-    return offsets.map { abs($0 - medOff) <= reject }
+    var mask = offsets.map { abs($0 - medOff) <= reject }
+
+    // Protect the longitudinal extremes. The top-most and bottom-most lines
+    // along the receipt's stacking axis anchor the crop's vertical extent — the
+    // store header and, critically, the grand TOTAL/TAX. A short, right- or
+    // left-aligned total or header line has an off-center cross-axis centroid
+    // and can read as an outlier of an otherwise tightly-aligned column; trimming
+    // it would exclude it from the hull and shrink the warped crop past real
+    // content. Never drop the two extreme lines on the stacking axis. (Sideways
+    // background bleed is handled by the color filter and the duplicate splitter,
+    // not here.)
+    let lx = -ay
+    let ly = ax
+    let longit = centroids.map { $0.0 * lx + $0.1 * ly }
+    if let minIdx = longit.indices.min(by: { longit[$0] < longit[$1] }),
+        let maxIdx = longit.indices.max(by: { longit[$0] < longit[$1] }) {
+        mask[minIdx] = true
+        mask[maxIdx] = true
+    }
+    return mask
 }
 
 /// Median of a non-empty array (returns 0 for empty).

--- a/receipt_ocr_swift/Sources/ReceiptOCRCore/ReceiptProcessing/GeometryFilters.swift
+++ b/receipt_ocr_swift/Sources/ReceiptOCRCore/ReceiptProcessing/GeometryFilters.swift
@@ -3,101 +3,16 @@ import Foundation
 #if os(macOS)
 import CoreGraphics
 
-/// Returns a keep-mask that drops lines whose perpendicular ("cross-axis")
-/// offset from the cluster's main column exceeds a robust threshold.
-///
-/// A receipt is a narrow vertical strip: its text lines stack along the strip's
-/// long axis and share a common column. Lines that stick out **sideways** — an
-/// adjacent menu pressed against the edge, or a second overlapping receipt — are
-/// cross-axis outliers. We project each line centroid onto the cross-axis (the
-/// text-baseline direction, perpendicular to the stacking direction), take the
-/// median and MAD, and reject lines beyond `k` robust deviations.
-///
-/// Self-scaling and conservative by construction:
-///   - The threshold is `k · 1.4826 · MAD`, i.e. relative to the receipt's own
-///     width, so a clean single-column receipt keeps every line (no line is a
-///     multi-MAD outlier of its own tight column).
-///   - Below a minimum line count, or when the spread is degenerate, it returns
-///     all-true and changes nothing.
-///
-/// - Parameters:
-///   - lines: The cluster's lines (normalized, bottom-left-origin coords).
-///   - k: Robust-deviation multiplier for the reject distance (default 4.0).
-/// - Returns: A Bool per line — true = keep (inlier), false = drop (outlier).
-public func crossAxisInlierMask(_ lines: [Line], k: CGFloat = 4.0) -> [Bool] {
-    // Too few lines to robustly estimate a column — keep everything.
-    guard lines.count >= 6 else {
-        return Array(repeating: true, count: lines.count)
-    }
-
-    let centroids = lines.map { line -> (CGFloat, CGFloat) in
-        let cx =
-            (line.topLeft.x + line.topRight.x + line.bottomLeft.x
-                + line.bottomRight.x) / 4.0
-        let cy =
-            (line.topLeft.y + line.topRight.y + line.bottomLeft.y
-                + line.bottomRight.y) / 4.0
-        return (cx, cy)
-    }
-
-    // Cross-axis = text-baseline direction (perpendicular to the vertical
-    // stacking of a portrait receipt). For an upright receipt this is ~x.
-    let avgAngle =
-        lines.reduce(0.0) { $0 + $1.angleRadians } / CGFloat(lines.count)
-    let ax = cos(avgAngle)
-    let ay = sin(avgAngle)
-
-    let medX = median(centroids.map { $0.0 })
-    let medY = median(centroids.map { $0.1 })
-    let offsets: [CGFloat] = centroids.map { c in
-        let dx: CGFloat = c.0 - medX
-        let dy: CGFloat = c.1 - medY
-        return dx * ax + dy * ay
-    }
-
-    let medOff = median(offsets)
-    let mad = median(offsets.map { abs($0 - medOff) })
-
-    // Degenerate spread (near single-point column) — don't trim.
-    guard mad > 1e-4 else {
-        return Array(repeating: true, count: lines.count)
-    }
-
-    // Conservative: drop only lines that are extreme cross-axis outliers of an
-    // otherwise-tight column (e.g. a single stray line from a table edge). This
-    // deliberately does NOT try to split two overlapping receipts — a gap-based
-    // split was tried and regressed clean tilted receipts (it cut real header/
-    // footer content), so that case is left to a content-based pass.
-    // Interval-based rejection (conservative). Centroid distance alone would drop
-    // a short, off-center but legitimate line — e.g. a right-aligned TOTAL whose
-    // centroid sits far from the column median even though its text still lies
-    // WITHIN the receipt's column, or a centered header on a receipt with a
-    // tight body. Instead, reject a line only when its cross-axis EXTENT is
-    // wholly DISJOINT from the receipt column envelope: a menu / adjacent-document
-    // line pressed sideways against the receipt. A total/header overlaps the
-    // column and is kept; a truly sideways line is dropped even when it is the
-    // top-most or bottom-most line (which a longitudinal-extreme exception would
-    // have wrongly protected, re-admitting menu bleed).
-    let intervals = lines.map { line -> (CGFloat, CGFloat) in
-        let ps = [
-            line.topLeft.x * ax + line.topLeft.y * ay,
-            line.topRight.x * ax + line.topRight.y * ay,
-            line.bottomLeft.x * ax + line.bottomLeft.y * ay,
-            line.bottomRight.x * ax + line.bottomRight.y * ay,
-        ]
-        return (ps.min() ?? 0, ps.max() ?? 0)
-    }
-    let medLow = median(intervals.map { $0.0 })
-    let medHigh = median(intervals.map { $0.1 })
-    let colWidth = max(0, medHigh - medLow)
-    // Generous envelope: half the column width on each side, floored at the
-    // MAD-based reject distance. A line is an outlier only if its whole cross-
-    // axis interval lies beyond this envelope (no overlap).
-    let tol = max(0.5 * colWidth, k * 1.4826 * mad)
-    let loBound = medLow - tol
-    let hiBound = medHigh + tol
-    return intervals.map { $0.1 >= loBound && $0.0 <= hiBound }
-}
+// NOTE: This file previously exported `crossAxisInlierMask`, which trimmed
+// "sideways" cross-axis outliers from a receipt cluster before warping. It was
+// removed: deciding a line is background from geometry ALONE repeatedly proved
+// unsafe (a right-aligned TOTAL, or a separately-recognized price/amount column,
+// is cross-axis-disjoint from the description column yet is real receipt
+// content). The two cases it targeted are handled with actual evidence instead —
+// a colored menu/flyer background is dropped pre-clustering by the pixel-based
+// BackgroundColorFilter, and two overlapping copies are separated (or flagged)
+// by the duplicate splitter. The shared `median` helper below is still used by
+// BackgroundColorFilter and DuplicateReceiptSplitter.
 
 /// Median of a non-empty array (returns 0 for empty).
 func median(_ values: [CGFloat]) -> CGFloat {

--- a/receipt_ocr_swift/Sources/ReceiptOCRCore/ReceiptProcessing/ReceiptProcessor.swift
+++ b/receipt_ocr_swift/Sources/ReceiptOCRCore/ReceiptProcessing/ReceiptProcessor.swift
@@ -106,8 +106,15 @@ public struct ReceiptProcessor {
 
             // Trim cross-axis outliers: an adjacent menu pressed against the
             // edge, or a second overlapping receipt, that sticks out sideways
-            // from this receipt's column. Never trims below 3 lines.
-            let inlierMask = crossAxisInlierMask(clusterLines)
+            // from this receipt's column. Never trims below 3 lines. A cluster
+            // FLAGGED FOR REVIEW (probable overlapping copies that couldn't be
+            // confidently split) is exempt: the reviewer must see the full,
+            // untrimmed crop, not one from which a sideways-offset minority copy
+            // was already removed.
+            let inlierMask =
+                reviewClusterIds.contains(clusterId)
+                ? Array(repeating: true, count: clusterLines.count)
+                : crossAxisInlierMask(clusterLines)
             if inlierMask.contains(false) {
                 let keptLines = zip(clusterLines, inlierMask)
                     .compactMap { $0.1 ? $0.0 : nil }
@@ -273,7 +280,20 @@ public struct ReceiptProcessor {
             iouThreshold: 0.01
         )
 
-        for (clusterId, lineIndices) in mergedClusters {
+        // Two stacked / overlapping copies on a flatbed share the same X-range,
+        // so X-axis DBSCAN + overlap-join collapse them into ONE cluster. Run the
+        // same duplicate-content consensus the photo path uses to split them
+        // (or, when not confidently separable, flag for review) instead of
+        // emitting a single combined crop.
+        let (splitResult, reviewClusterIds) =
+            splitDuplicateReceiptClusters(
+                ClusteringResult(clusters: mergedClusters), lines: lines
+            )
+        for cid in reviewClusterIds {
+            logger.warning("SCAN cluster \(cid): probable overlapping copies (duplicate anchors below confident-split threshold) - flagged for review, not split")
+        }
+
+        for (clusterId, lineIndices) in splitResult.clusters {
             guard clusterId != -1 else { continue }
             guard !lineIndices.isEmpty else { continue }
 
@@ -344,7 +364,8 @@ public struct ReceiptProcessor {
                 warpedImage: warpedImage,
                 warpedWidth: w,
                 warpedHeight: h,
-                lineIndices: lineIndices
+                lineIndices: lineIndices,
+                needsReview: reviewClusterIds.contains(clusterId)
             )
             results.append(processed)
 

--- a/receipt_ocr_swift/Sources/ReceiptOCRCore/ReceiptProcessing/ReceiptProcessor.swift
+++ b/receipt_ocr_swift/Sources/ReceiptOCRCore/ReceiptProcessing/ReceiptProcessor.swift
@@ -74,6 +74,17 @@ public struct ReceiptProcessor {
         let imageWidth = CGFloat(image.width)
         let imageHeight = CGFloat(image.height)
 
+        // If a cluster is two overlapping copies of one receipt (customer +
+        // merchant copy), split it into two clusters via duplicate-content
+        // consensus. Clusters that look like multiple receipts but can't be
+        // confidently split are flagged for review (never silently guessed).
+        let (splitClustering, reviewClusterIds) =
+            splitDuplicateReceiptClusters(clustering, lines: lines)
+        for cid in reviewClusterIds {
+            logger.warning("Cluster \(cid): probable overlapping receipts (duplicate anchors below confident-split threshold) - flagged for review, not split")
+        }
+        let clustering = splitClustering
+
         for (clusterId, lineIndices) in clustering.clusters {
             // Skip noise cluster
             guard clusterId != -1 else { continue }
@@ -84,10 +95,28 @@ public struct ReceiptProcessor {
                 continue
             }
 
-            // Get lines for this cluster
-            let clusterLines = lineIndices.compactMap { idx -> Line? in
-                guard idx >= 0 && idx < lines.count else { return nil }
-                return lines[idx]
+            // Get lines for this cluster (keep line/index arrays parallel).
+            var clusterLines: [Line] = []
+            var effectiveIndices: [Int] = []
+            for idx in lineIndices {
+                guard idx >= 0 && idx < lines.count else { continue }
+                clusterLines.append(lines[idx])
+                effectiveIndices.append(idx)
+            }
+
+            // Trim cross-axis outliers: an adjacent menu pressed against the
+            // edge, or a second overlapping receipt, that sticks out sideways
+            // from this receipt's column. Never trims below 3 lines.
+            let inlierMask = crossAxisInlierMask(clusterLines)
+            if inlierMask.contains(false) {
+                let keptLines = zip(clusterLines, inlierMask)
+                    .compactMap { $0.1 ? $0.0 : nil }
+                let keptIndices = zip(effectiveIndices, inlierMask)
+                    .compactMap { $0.1 ? $0.0 : nil }
+                if keptLines.count >= 3 {
+                    clusterLines = keptLines
+                    effectiveIndices = keptIndices
+                }
             }
 
             guard clusterLines.count >= 3 else { continue }
@@ -200,7 +229,7 @@ public struct ReceiptProcessor {
                 warpedImage: warpedImage,
                 warpedWidth: warpedWidth,
                 warpedHeight: warpedHeight,
-                lineIndices: lineIndices
+                lineIndices: effectiveIndices
             )
             results.append(processed)
 

--- a/receipt_ocr_swift/Sources/ReceiptOCRCore/ReceiptProcessing/ReceiptProcessor.swift
+++ b/receipt_ocr_swift/Sources/ReceiptOCRCore/ReceiptProcessing/ReceiptProcessor.swift
@@ -229,7 +229,8 @@ public struct ReceiptProcessor {
                 warpedImage: warpedImage,
                 warpedWidth: warpedWidth,
                 warpedHeight: warpedHeight,
-                lineIndices: effectiveIndices
+                lineIndices: effectiveIndices,
+                needsReview: reviewClusterIds.contains(clusterId)
             )
             results.append(processed)
 

--- a/receipt_ocr_swift/Sources/ReceiptOCRCore/ReceiptProcessing/ReceiptProcessor.swift
+++ b/receipt_ocr_swift/Sources/ReceiptOCRCore/ReceiptProcessing/ReceiptProcessor.swift
@@ -104,27 +104,17 @@ public struct ReceiptProcessor {
                 effectiveIndices.append(idx)
             }
 
-            // Trim cross-axis outliers: an adjacent menu pressed against the
-            // edge, or a second overlapping receipt, that sticks out sideways
-            // from this receipt's column. Never trims below 3 lines. A cluster
-            // FLAGGED FOR REVIEW (probable overlapping copies that couldn't be
-            // confidently split) is exempt: the reviewer must see the full,
-            // untrimmed crop, not one from which a sideways-offset minority copy
-            // was already removed.
-            let inlierMask =
-                reviewClusterIds.contains(clusterId)
-                ? Array(repeating: true, count: clusterLines.count)
-                : crossAxisInlierMask(clusterLines)
-            if inlierMask.contains(false) {
-                let keptLines = zip(clusterLines, inlierMask)
-                    .compactMap { $0.1 ? $0.0 : nil }
-                let keptIndices = zip(effectiveIndices, inlierMask)
-                    .compactMap { $0.1 ? $0.0 : nil }
-                if keptLines.count >= 3 {
-                    clusterLines = keptLines
-                    effectiveIndices = keptIndices
-                }
-            }
+            // NOTE: cross-axis geometric trimming was intentionally removed here.
+            // Deciding a line is "sideways background" from geometry ALONE is
+            // unsafe: a right-aligned TOTAL, or a separately-recognized price /
+            // amount column, is cross-axis-disjoint from the description column
+            // yet is real receipt content — trimming it silently drops totals.
+            // The two cases trimming targeted are handled with actual evidence
+            // instead: a colored menu/flyer background is removed pre-clustering
+            // by the pixel-based BackgroundColorFilter, and two overlapping
+            // copies are separated (or flagged) by the duplicate splitter. A
+            // white adjacent document that survives both is kept in the crop
+            // (a slightly larger crop) rather than risking loss of real content.
 
             guard clusterLines.count >= 3 else { continue }
 


### PR DESCRIPTION
## Summary

Hardens the Swift receipt-OCR segmentation pipeline (`receipt_ocr_swift`) against three failure modes surfaced by a phone photo of a Twin Peaks receipt that was wrongly segmented (it ingested a colored menu behind the receipt, and the image was misclassified `SCAN`):

1. **Histogram-based SCAN/PHOTO classification.** The old classifier decided `SCAN` vs `PHOTO` purely from pixel *dimensions*, so a downscaled (~960×1280) phone photo "looked scan-sized" and was mislabeled `SCAN`. It now reads the actual pixels — border near-white fraction, mean saturation, and border illumination uniformity (block-mean luminance stddev) — and only calls `SCAN` when the border is uniformly lit and desaturated the way a real flatbed produces. Falls back to the dimension heuristic when pixels are unavailable.
2. **Per-line background color filter.** Colored menu / table / background text sitting behind a receipt is removed by an ink-masked, adaptive saturation threshold (`median + max(margin, 4·MAD)`), with a drop-fraction cap so a warm/cream-paper receipt is never fully stripped.
3. **Duplicate-copy detection & split.** Two overlapping copies of the same receipt are detected via rigid-transform (rotation+translation) RANSAC consensus over duplicate text lines, with harmonic-rejection / distinctive-anchor / spread guards to avoid false-splitting a single receipt that merely repeats SKUs. Ambiguous cases persist a `needs_review` flag rather than splitting blindly.

## Files
- `Classification/ImageClassifier.swift` — histogram classifier + illumination-uniformity
- `ReceiptProcessing/BackgroundColorFilter.swift` (new) — adaptive per-line saturation filter
- `ReceiptProcessing/DuplicateReceiptSplitter.swift` (new) — rigid-transform consensus splitter
- `ReceiptProcessing/GeometryFilters.swift` (new) — conservative cross-axis inlier trim
- `Models/ReceiptDetection.swift` — `needs_review` on `ProcessedReceipt` / `ReceiptOutput`
- `OCR/VisionOCREngine.swift`, `ReceiptProcessing/ReceiptProcessor.swift` — wiring (load image once, reuse)

## Validation (dev stack, RAW images, zero Dynamo writes)
Shadow-run comparison of OLD (pre-change) vs NEW binaries on real dev receipts:
- **Classifier flip is correct** — visually confirmed the reclassified images are genuine iPhone photos (`IMG_####` filenames, table/desk backgrounds, perspective, shadows), mislabeled `SCAN` by the old dimension-only heuristic.
- **No content-loss regression.** The apparent "line loss" was a measurement artifact: NEW's `SCAN→PHOTO` reclassification applies a different perspective warp, so Vision re-OCRs a differently-warped image and re-tokenizes (`$2.68`→`$2.66`, `AUTH CODE:674991`→`AUTH CODE: 674991`). Controlling for churn with fuzzy matching over 30 raw images: 89% of "removed" lines have a NEW counterpart; net line count is **+1.1% (NEW slightly higher)**; **zero whole receipts lost**. The two `2→1` receipt-count changes are NEW correctly *merging* clusters OLD over-split.
- Warm/cream-paper receipt (614 Gravier) is **not** over-stripped; clean tilted receipts are untouched.

## Notes for review
- macOS-only (`#if os(macOS)`, Apple Vision).
- No DynamoDB or S3 writes are introduced by this change; it only affects local OCR geometry/classification output.
- Suggested rollout guardrail (not in this PR): track fuzzy-matched monetary-token recall rather than raw line-set delta, since raw delta is dominated by re-warp churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved receipt classification by distinguishing scans from photos using image content.
  * Added background filtering to reduce OCR lines from colored areas.
  * Added detection and splitting of overlapping duplicate receipts.
  * Added small-receipt recovery for photo-based processing.
  * Added a `needs_review` flag to receipt results for uncertain detections.

* **Bug Fixes**
  * Preserved accurate line references after filtering and splitting.
  * Reduced accidental loss of receipt content from overly aggressive geometric filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->