### PR TITLE
Sync ReceiptSection changes to ChromaDB via stream processor

### DIFF
--- a/infra/chromadb_compaction/lambdas/enhanced_compaction_handler.py
+++ b/infra/chromadb_compaction/lambdas/enhanced_compaction_handler.py
@@ -260,8 +260,12 @@ def _collect_failed_message_ids(
     """
     failed_ids: list[str] = []
 
-    # Check metadata update failures
-    for meta_result in result.metadata_updates:
+    # Check metadata update failures (place updates + section recomputes
+    # both key results by image_id/receipt_id)
+    metadata_style_results = list(result.metadata_updates) + list(
+        result.section_updates or []
+    )
+    for meta_result in metadata_style_results:
         if meta_result.error:
             for msg in messages:
                 entity_data = msg.entity_data
@@ -424,6 +428,7 @@ def process_collection(  # pylint: disable=too-many-locals
                     "message_count": len(messages),
                     "metadata_updates": result.total_metadata_updated,
                     "label_updates": result.total_labels_updated,
+                    "section_updates": result.total_sections_updated,
                     "delta_merges": result.delta_merge_count,
                 },
             )

--- a/receipt_chroma/receipt_chroma/compaction/__init__.py
+++ b/receipt_chroma/receipt_chroma/compaction/__init__.py
@@ -21,12 +21,14 @@ from receipt_chroma.compaction.models import (
     ReceiptDeletionResult,
 )
 from receipt_chroma.compaction.processor import process_collection_updates
+from receipt_chroma.compaction.sections import apply_section_updates
 
 __all__ = [
     "apply_collection_updates",
     "apply_label_updates",
     "apply_place_updates",
     "apply_receipt_deletions",
+    "apply_section_updates",
     "BulkSyncResult",
     "CloudConfig",
     "CollectionUpdateResult",

--- a/receipt_chroma/receipt_chroma/compaction/message_ordering.py
+++ b/receipt_chroma/receipt_chroma/compaction/message_ordering.py
@@ -62,6 +62,19 @@ def _get_entity_key(msg: "StreamMessage") -> tuple[str, ...]:
             str(entity_data.get("word_id", "")),
         )
 
+    if entity_type == "RECEIPT_SECTION":
+        # Keyed per section (not per receipt) and namespaced by entity
+        # type so a section REMOVE never suppresses other entities'
+        # updates for the same receipt. The consumer recomputes from
+        # fresh DynamoDB state either way, so dropping a same-batch
+        # MODIFY after a REMOVE of the same section stays correct.
+        return (
+            "RECEIPT_SECTION",
+            str(entity_data.get("image_id", "")),
+            str(entity_data.get("receipt_id", "")),
+            str(entity_data.get("section_type", "")),
+        )
+
     # Fallback for other entity types
     return (entity_type, str(sorted(entity_data.items())))
 

--- a/receipt_chroma/receipt_chroma/compaction/models.py
+++ b/receipt_chroma/receipt_chroma/compaction/models.py
@@ -85,11 +85,14 @@ class CollectionUpdateResult:
     delta_merge_count: int
     delta_merge_results: List[Dict[str, Any]]
     receipt_deletions: List[ReceiptDeletionResult] = None  # type: ignore
+    section_updates: List[MetadataUpdateResult] = None  # type: ignore
 
     def __post_init__(self):
         """Initialize default values for mutable fields."""
         if self.receipt_deletions is None:
             object.__setattr__(self, "receipt_deletions", [])
+        if self.section_updates is None:
+            object.__setattr__(self, "section_updates", [])
 
     def to_dict(self) -> Dict[str, Any]:
         """Convert to dictionary format."""
@@ -101,6 +104,9 @@ class CollectionUpdateResult:
             "delta_merge_results": self.delta_merge_results,
             "receipt_deletions": [
                 r.to_dict() for r in (self.receipt_deletions or [])
+            ],
+            "section_updates": [
+                r.to_dict() for r in (self.section_updates or [])
             ],
         }
 
@@ -128,11 +134,21 @@ class CollectionUpdateResult:
         )
 
     @property
+    def total_sections_updated(self) -> int:
+        """Total rows restamped by section recompute (excluding errors)."""
+        return sum(
+            r.updated_count
+            for r in (self.section_updates or [])
+            if r.error is None
+        )
+
+    @property
     def has_errors(self) -> bool:
         """Whether any updates had errors."""
         all_results = (
             list(self.metadata_updates)
             + list(self.label_updates)
             + list(self.receipt_deletions or [])
+            + list(self.section_updates or [])
         )
         return any(r.error is not None for r in all_results)

--- a/receipt_chroma/receipt_chroma/compaction/processor.py
+++ b/receipt_chroma/receipt_chroma/compaction/processor.py
@@ -159,7 +159,16 @@ def process_collection_updates(
         )
 
     # 4. Apply section updates (after deltas so freshly-merged rows are
-    # restamped with current section state)
+    # restamped with current section state). Receipts touched by a delta
+    # merge are recomputed even without a section message: a delta whose
+    # metadata was captured before a section edit may merge after the
+    # section event was already processed, and no later event would fix
+    # the stale labels it carried.
+    delta_receipts = [
+        (r["image_id"], r["receipt_id"])
+        for r in delta_results
+        if r.get("image_id") is not None and r.get("receipt_id") is not None
+    ]
     section_results = apply_section_updates(
         chroma_client=chroma_client,
         section_messages=section_msgs,
@@ -167,6 +176,7 @@ def process_collection_updates(
         logger=logger,
         metrics=metrics,
         dynamo_client=dynamo_client,
+        extra_receipts=delta_receipts,
     )
 
     if section_results:

--- a/receipt_chroma/receipt_chroma/compaction/processor.py
+++ b/receipt_chroma/receipt_chroma/compaction/processor.py
@@ -8,6 +8,7 @@ from receipt_chroma.compaction.deltas import merge_compaction_deltas
 from receipt_chroma.compaction.labels import apply_label_updates
 from receipt_chroma.compaction.metadata import apply_place_updates
 from receipt_chroma.compaction.models import CollectionUpdateResult
+from receipt_chroma.compaction.sections import apply_section_updates
 from receipt_chroma.data.chroma_client import ChromaClient
 from receipt_dynamo.constants import ChromaDBCollection
 from receipt_dynamo.data.dynamo_client import DynamoClient
@@ -28,6 +29,7 @@ def process_collection_updates(
     1. Delta merges (COMPACTION_RUN) - must be applied first
     2. Place updates (RECEIPT_PLACE)
     3. Label updates (RECEIPT_WORD_LABEL)
+    4. Section updates (RECEIPT_SECTION, LINES collection only)
 
     The caller is responsible for:
     - Downloading the snapshot
@@ -53,6 +55,11 @@ def process_collection_updates(
     label_msgs = [
         m for m in stream_messages if m.entity_type == "RECEIPT_WORD_LABEL"
     ]
+    # Section changes trigger a per-receipt recompute of row
+    # section_label metadata; INSERT/MODIFY/REMOVE are all recomputes
+    section_msgs = [
+        m for m in stream_messages if m.entity_type == "RECEIPT_SECTION"
+    ]
     delta_msgs = [
         m for m in stream_messages if m.entity_type == "COMPACTION_RUN"
     ]
@@ -74,6 +81,7 @@ def process_collection_updates(
         total_messages=len(stream_messages),
         place_count=len(place_msgs),
         label_count=len(label_msgs),
+        section_count=len(section_msgs),
         delta_count=len(delta_msgs),
         entity_deletion_count=len(entity_deletion_msgs),
     )
@@ -150,7 +158,29 @@ def process_collection_updates(
             message_count=len(label_results),
         )
 
-    # 4. Apply entity deletions (receipts, words, lines)
+    # 4. Apply section updates (after deltas so freshly-merged rows are
+    # restamped with current section state)
+    section_results = apply_section_updates(
+        chroma_client=chroma_client,
+        section_messages=section_msgs,
+        collection=collection,
+        logger=logger,
+        metrics=metrics,
+        dynamo_client=dynamo_client,
+    )
+
+    if section_results:
+        total_sections = sum(
+            r.updated_count for r in section_results if r.error is None
+        )
+        logger.info(
+            "Applied section updates",
+            collection=collection.value,
+            total_updated=total_sections,
+            receipt_count=len(section_results),
+        )
+
+    # 5. Apply entity deletions (receipts, words, lines)
     deletion_results = apply_receipt_deletions(
         chroma_client=chroma_client,
         receipt_messages=entity_deletion_msgs,
@@ -179,6 +209,7 @@ def process_collection_updates(
         delta_merge_count=delta_count,
         delta_merge_results=delta_results,
         receipt_deletions=deletion_results,
+        section_updates=section_results,
     )
 
     # Log summary
@@ -187,6 +218,7 @@ def process_collection_updates(
         collection=collection.value,
         metadata_updated=result.total_metadata_updated,
         labels_updated=result.total_labels_updated,
+        sections_updated=result.total_sections_updated,
         deltas_merged=delta_count,
         embeddings_deleted=result.total_deletions,
         has_errors=result.has_errors,

--- a/receipt_chroma/receipt_chroma/compaction/sections.py
+++ b/receipt_chroma/receipt_chroma/compaction/sections.py
@@ -25,10 +25,17 @@ Design notes (race-condition driven):
 - STORM COLLAPSE: messages are grouped per (image_id, receipt_id) so a
   bulk-QA burst of N section events for one receipt costs one DynamoDB
   query + one recompute pass within a batch.
+
+- DELTA-DRIVEN RECOMPUTE: receipts touched by a delta merge in the same
+  compaction cycle are also recomputed (``extra_receipts``), so a delta
+  whose metadata was captured before a section edit — and merged after
+  the section event was already processed — cannot leave stale labels.
 """
 
 import json
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+from chromadb.errors import NotFoundError
 
 from receipt_chroma.compaction.models import MetadataUpdateResult
 from receipt_chroma.data.chroma_client import ChromaClient
@@ -49,6 +56,7 @@ def apply_section_updates(
     logger: Any,
     metrics: Any = None,
     dynamo_client: Optional[DynamoClient] = None,
+    extra_receipts: Optional[Iterable[Tuple[str, int]]] = None,
 ) -> List[MetadataUpdateResult]:
     """Recompute row ``section_label`` metadata for changed receipts.
 
@@ -67,12 +75,17 @@ def apply_section_updates(
         metrics: Optional metrics collector
         dynamo_client: DynamoDB client used to fetch the receipt's
             current sections; without it recompute is skipped
+        extra_receipts: Additional (image_id, receipt_id) pairs to
+            recompute even without a section message — the processor
+            passes receipts touched by delta merges so a delta whose
+            metadata was captured before a section edit cannot leave
+            stale labels behind
 
     Returns:
         List of MetadataUpdateResult objects (one per affected receipt)
     """
     results: List[MetadataUpdateResult] = []
-    if not section_messages:
+    if not section_messages and not extra_receipts:
         return results
 
     if collection != ChromaDBCollection.LINES:
@@ -83,6 +96,8 @@ def apply_section_updates(
         return results
 
     if dynamo_client is None:
+        # A missing client is a wiring bug, not a transient failure —
+        # retrying the messages cannot help, so warn loudly and skip.
         logger.warning(
             "No DynamoDB client; skipping section recompute",
             message_count=len(section_messages),
@@ -92,9 +107,11 @@ def apply_section_updates(
     database = collection.value
     try:
         collection_obj = chroma_client.get_collection(database)
-    except Exception:
-        # Collection may not exist yet (fresh environment) — safe no-op,
+    except (NotFoundError, ValueError):
+        # Collection genuinely absent (fresh environment) — safe no-op,
         # embeds will stamp fresh state when the collection is created.
+        # Any other failure (I/O, closed client, ...) propagates so the
+        # whole batch is retried instead of being silently acknowledged.
         logger.warning(
             "Collection not found for sections", collection=database
         )
@@ -113,6 +130,9 @@ def apply_section_updates(
                 entity_data=dict(entity_data),
             )
             continue
+        receipts[(image_id, receipt_id)] = None
+
+    for image_id, receipt_id in extra_receipts or []:
         receipts[(image_id, receipt_id)] = None
 
     for image_id, receipt_id in receipts:
@@ -212,6 +232,10 @@ def _recompute_receipt_section_labels(
         )
         return 0
 
+    # The base-table query is eventually consistent; by the time a
+    # stream event has traversed DynamoDB Streams -> Lambda -> SQS ->
+    # this handler (seconds), replication lag (sub-second) has passed —
+    # the same trade-off the label path makes.
     sections = dynamo_client.get_receipt_sections_from_receipt(
         image_id=image_id,
         receipt_id=receipt_id,
@@ -228,13 +252,10 @@ def _recompute_receipt_section_labels(
         if metadata.get(_SECTION_LABEL_KEY) == row_section:
             continue  # includes both-absent (None == None)
 
-        new_metadata = {
-            k: v for k, v in metadata.items() if k != _SECTION_LABEL_KEY
-        }
-        if row_section is not None:
-            new_metadata[_SECTION_LABEL_KEY] = row_section
+        # Chroma's update MERGES metadata (omitted keys survive), so
+        # send only the delta; None deletes the key.
         ids_to_update.append(chromadb_id)
-        new_metadatas.append(new_metadata)
+        new_metadatas.append({_SECTION_LABEL_KEY: row_section})
 
     if ids_to_update:
         collection_obj.update(ids=ids_to_update, metadatas=new_metadatas)

--- a/receipt_chroma/receipt_chroma/compaction/sections.py
+++ b/receipt_chroma/receipt_chroma/compaction/sections.py
@@ -1,0 +1,251 @@
+"""Section update processing for RECEIPT_SECTION entities.
+
+ReceiptSection rows classify a receipt's lines into sections (HEADER,
+LINE_ITEMS, ...). The LINES collection stores one embedding per visual
+row whose ``section_label`` metadata is the plurality of the row's
+lines' sections (INVALID sections skipped, higher-confidence section
+wins a contested line, ties leave the key unset).
+
+Design notes (race-condition driven):
+
+- RECOMPUTE, DON'T APPLY THE EVENT: a single section edit can change the
+  correct ``section_label`` for many rows, and the correct value depends
+  on ALL of the receipt's sections. Each message triggers a re-read of
+  the receipt's *current* section set from DynamoDB and a full label
+  recompute, reusing ``sections_to_line_map`` + ``row_section_from_map``
+  (the exact logic used at embed time). Duplicate or out-of-order stream
+  deliveries are therefore idempotent: last processing wins with fresh
+  state, and INSERT/MODIFY/REMOVE events are all handled identically.
+
+- MISSING ROWS ARE A CLEAN NO-OP: a section event can arrive before the
+  receipt's rows exist in ChromaDB (embedding batch still at OpenAI).
+  The embed itself stamps fresh section state when it lands, so there is
+  nothing to do here — no error, no retry.
+
+- STORM COLLAPSE: messages are grouped per (image_id, receipt_id) so a
+  bulk-QA burst of N section events for one receipt costs one DynamoDB
+  query + one recompute pass within a batch.
+"""
+
+import json
+from typing import Any, Dict, List, Optional
+
+from receipt_chroma.compaction.models import MetadataUpdateResult
+from receipt_chroma.data.chroma_client import ChromaClient
+from receipt_chroma.section_labels import (
+    row_section_from_map,
+    sections_to_line_map,
+)
+from receipt_dynamo.constants import ChromaDBCollection
+from receipt_dynamo.data.dynamo_client import DynamoClient
+
+_SECTION_LABEL_KEY = "section_label"
+
+
+def apply_section_updates(
+    chroma_client: ChromaClient,
+    section_messages: List[Any],
+    collection: ChromaDBCollection,
+    logger: Any,
+    metrics: Any = None,
+    dynamo_client: Optional[DynamoClient] = None,
+) -> List[MetadataUpdateResult]:
+    """Recompute row ``section_label`` metadata for changed receipts.
+
+    Processes RECEIPT_SECTION stream messages against an already-open
+    ChromaDB client (no S3 I/O — the caller owns snapshot download,
+    upload, and locking, exactly like the place/label paths).
+
+    Only the LINES collection carries section metadata; messages for any
+    other collection are a no-op.
+
+    Args:
+        chroma_client: Open ChromaDB client with snapshot loaded
+        section_messages: StreamMessage objects for section changes
+        collection: Target collection (only LINES is acted on)
+        logger: Logger instance for observability
+        metrics: Optional metrics collector
+        dynamo_client: DynamoDB client used to fetch the receipt's
+            current sections; without it recompute is skipped
+
+    Returns:
+        List of MetadataUpdateResult objects (one per affected receipt)
+    """
+    results: List[MetadataUpdateResult] = []
+    if not section_messages:
+        return results
+
+    if collection != ChromaDBCollection.LINES:
+        logger.debug(
+            "Section updates only apply to LINES collection",
+            collection=collection.value,
+        )
+        return results
+
+    if dynamo_client is None:
+        logger.warning(
+            "No DynamoDB client; skipping section recompute",
+            message_count=len(section_messages),
+        )
+        return results
+
+    database = collection.value
+    try:
+        collection_obj = chroma_client.get_collection(database)
+    except Exception:
+        # Collection may not exist yet (fresh environment) — safe no-op,
+        # embeds will stamp fresh state when the collection is created.
+        logger.warning(
+            "Collection not found for sections", collection=database
+        )
+        return results
+
+    # Collapse to one recompute per receipt: the recompute reads fresh
+    # state, so N events for one receipt need only one pass.
+    receipts: Dict[tuple, None] = {}
+    for update_msg in section_messages:
+        entity_data = update_msg.entity_data
+        image_id = entity_data.get("image_id")
+        receipt_id = entity_data.get("receipt_id")
+        if image_id is None or receipt_id is None:
+            logger.warning(
+                "Section message missing image_id/receipt_id",
+                entity_data=dict(entity_data),
+            )
+            continue
+        receipts[(image_id, receipt_id)] = None
+
+    for image_id, receipt_id in receipts:
+        try:
+            updated_count = _recompute_receipt_section_labels(
+                collection_obj=collection_obj,
+                image_id=image_id,
+                receipt_id=receipt_id,
+                dynamo_client=dynamo_client,
+                logger=logger,
+            )
+            results.append(
+                MetadataUpdateResult(
+                    database=database,
+                    collection=database,
+                    updated_count=updated_count,
+                    image_id=image_id,
+                    receipt_id=receipt_id,
+                )
+            )
+            if metrics:
+                metrics.count("SectionRecomputeProcessed", 1)
+
+        except Exception as e:
+            logger.exception(
+                "Error recomputing section labels",
+                image_id=image_id,
+                receipt_id=receipt_id,
+            )
+            results.append(
+                MetadataUpdateResult(
+                    database=database,
+                    collection=database,
+                    updated_count=0,
+                    image_id=image_id,
+                    receipt_id=receipt_id,
+                    error=str(e),
+                )
+            )
+
+    return results
+
+
+def _row_line_ids_from_metadata(metadata: dict) -> List[int]:
+    """Extract the visual row's line IDs from row metadata.
+
+    Mirrors the label path: ``row_line_ids`` is a JSON-encoded list;
+    legacy embeddings without it fall back to the single ``line_id``.
+    """
+    row_line_ids_str = metadata.get("row_line_ids", "[]")
+    try:
+        row_line_ids = json.loads(row_line_ids_str)
+    except (json.JSONDecodeError, TypeError):
+        row_line_ids = []
+    if not row_line_ids:
+        line_id = metadata.get("line_id")
+        if line_id is not None:
+            row_line_ids = [line_id]
+    return row_line_ids
+
+
+def _recompute_receipt_section_labels(
+    collection_obj: Any,
+    image_id: str,
+    receipt_id: int,
+    dynamo_client: DynamoClient,
+    logger: Any,
+) -> int:
+    """Recompute ``section_label`` for every row of one receipt.
+
+    Reads the receipt's current ReceiptSection rows from DynamoDB and
+    stamps each Chroma row with the plurality section of its lines,
+    removing the key where no clear plurality exists.
+
+    Returns the number of rows whose metadata changed. Raises on
+    DynamoDB/Chroma failures so the caller records an error result and
+    the message is retried (recomputing from a failed read could
+    otherwise wrongly strip labels).
+    """
+    existing_results = collection_obj.get(
+        where={
+            "$and": [
+                {"image_id": {"$eq": image_id}},
+                {"receipt_id": {"$eq": receipt_id}},
+            ]
+        },
+        include=["metadatas"],
+    )
+
+    if not existing_results["ids"]:
+        # Receipt not embedded yet (e.g. batch still at OpenAI). The
+        # embed stamps fresh section state when it lands — clean no-op.
+        logger.debug(
+            "No existing line embeddings for receipt; skipping sections",
+            image_id=image_id,
+            receipt_id=receipt_id,
+        )
+        return 0
+
+    sections = dynamo_client.get_receipt_sections_from_receipt(
+        image_id=image_id,
+        receipt_id=receipt_id,
+    )
+    section_by_line = sections_to_line_map(sections)
+
+    ids_to_update: List[str] = []
+    new_metadatas: List[dict] = []
+    for idx, chromadb_id in enumerate(existing_results["ids"]):
+        metadata = existing_results["metadatas"][idx] or {}
+        row_line_ids = _row_line_ids_from_metadata(metadata)
+        row_section = row_section_from_map(row_line_ids, section_by_line)
+
+        if metadata.get(_SECTION_LABEL_KEY) == row_section:
+            continue  # includes both-absent (None == None)
+
+        new_metadata = {
+            k: v for k, v in metadata.items() if k != _SECTION_LABEL_KEY
+        }
+        if row_section is not None:
+            new_metadata[_SECTION_LABEL_KEY] = row_section
+        ids_to_update.append(chromadb_id)
+        new_metadatas.append(new_metadata)
+
+    if ids_to_update:
+        collection_obj.update(ids=ids_to_update, metadatas=new_metadatas)
+
+    logger.debug(
+        "Recomputed section labels",
+        image_id=image_id,
+        receipt_id=receipt_id,
+        rows_total=len(existing_results["ids"]),
+        rows_updated=len(ids_to_update),
+        section_count=len(sections),
+    )
+
+    return len(ids_to_update)

--- a/receipt_chroma/receipt_chroma/compaction/sections.py
+++ b/receipt_chroma/receipt_chroma/compaction/sections.py
@@ -96,11 +96,18 @@ def apply_section_updates(
         return results
 
     if dynamo_client is None:
-        # A missing client is a wiring bug, not a transient failure —
-        # retrying the messages cannot help, so warn loudly and skip.
+        if section_messages:
+            # A missing client with real stream work is a wiring bug —
+            # raise so the batch retries/DLQs visibly instead of the
+            # messages being silently acknowledged and lost.
+            raise ValueError(
+                "dynamo_client is required to process RECEIPT_SECTION "
+                f"messages ({len(section_messages)} queued)"
+            )
+        # extra_receipts-only callers (e.g. delta merges run without a
+        # DynamoDB client in local tooling) degrade to a warned no-op.
         logger.warning(
-            "No DynamoDB client; skipping section recompute",
-            message_count=len(section_messages),
+            "No DynamoDB client; skipping delta-driven section recompute"
         )
         return results
 
@@ -232,10 +239,9 @@ def _recompute_receipt_section_labels(
         )
         return 0
 
-    # The base-table query is eventually consistent; by the time a
-    # stream event has traversed DynamoDB Streams -> Lambda -> SQS ->
-    # this handler (seconds), replication lag (sub-second) has passed —
-    # the same trade-off the label path makes.
+    # Strongly consistent read (ConsistentRead=True inside the client):
+    # this recompute acknowledges the event immediately afterwards, so a
+    # stale read could persist wrong metadata with nothing to fix it.
     sections = dynamo_client.get_receipt_sections_from_receipt(
         image_id=image_id,
         receipt_id=receipt_id,

--- a/receipt_chroma/receipt_chroma/embedding/delta/line_delta.py
+++ b/receipt_chroma/receipt_chroma/embedding/delta/line_delta.py
@@ -8,7 +8,6 @@ on the same visual row are grouped into a single embedding.
 """
 
 import logging
-from collections import Counter
 from typing import Dict, List, Optional, TypedDict
 
 from receipt_chroma.embedding.delta.producer import produce_embedding_delta
@@ -22,7 +21,10 @@ from receipt_chroma.embedding.metadata.line_metadata import (
     enrich_row_metadata_with_anchors,
     enrich_row_metadata_with_labels,
 )
-from receipt_chroma.embedding.records import sections_to_line_map
+from receipt_chroma.embedding.records import (
+    row_section_from_map,
+    sections_to_line_map,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -204,16 +206,9 @@ def save_line_embeddings_as_delta(
         section_by_line = get_section_map(
             image_id, receipt_id, receipt_details
         )
-        row_section = None
-        if section_by_line:
-            votes = Counter(
-                section_by_line[line.line_id]
-                for line in target_row
-                if line.line_id in section_by_line
-            )
-            top = votes.most_common(2)
-            if top and (len(top) == 1 or top[0][1] > top[1][1]):
-                row_section = top[0][0]
+        row_section = row_section_from_map(
+            (line.line_id for line in target_row), section_by_line
+        )
 
         # Build row metadata for ChromaDB
         row_metadata = create_row_metadata(

--- a/receipt_chroma/receipt_chroma/embedding/records.py
+++ b/receipt_chroma/receipt_chroma/embedding/records.py
@@ -28,6 +28,10 @@ from receipt_chroma.embedding.metadata.word_metadata import (
     enrich_word_metadata_with_anchors,
     enrich_word_metadata_with_labels,
 )
+from receipt_chroma.section_labels import (
+    row_section_from_map,
+    sections_to_line_map,
+)
 from receipt_dynamo.entities import ReceiptLine, ReceiptWord, ReceiptWordLabel
 
 
@@ -117,25 +121,9 @@ class RowEmbeddingRecord:
         return [line.line_id for line in self.row_lines]
 
 
-def sections_to_line_map(sections: Sequence[Any]) -> Dict[int, str]:
-    """Build a ``line_id -> section_type`` map from ReceiptSection rows.
-
-    Each section holds its ``line_ids``; sections partition a receipt's lines,
-    but if a line appears in more than one (e.g. overlapping seed generations)
-    the higher-confidence section wins.
-    """
-    out: Dict[int, str] = {}
-    best: Dict[int, float] = {}
-    for s in sections or []:
-        # skip QA-rejected rows — an INVALID section must not stamp a line
-        if str(getattr(s, "validation_status", "") or "").upper() == "INVALID":
-            continue
-        conf = getattr(s, "confidence", None) or 0.0
-        for line_id in getattr(s, "line_ids", []) or []:
-            if line_id not in out or conf > best.get(line_id, -1.0):
-                out[line_id] = s.section_type
-                best[line_id] = conf
-    return out
+# Section-label logic lives in receipt_chroma.section_labels (a
+# dependency leaf shared with the compaction consumer); re-exported here
+# for existing embed-time callers.
 
 
 def build_line_payload(
@@ -286,17 +274,7 @@ def build_row_payload(
 
         # Row section = majority section among the row's lines (a row can span
         # multiple ReceiptLines; sections are line-level).
-        row_section: Optional[str] = None
-        if section_by_line:
-            votes = Counter(
-                section_by_line[lid]
-                for lid in record.line_ids
-                if lid in section_by_line
-            )
-            top = votes.most_common(2)
-            # only stamp on a clear plurality; a tie is ambiguous -> leave unset
-            if top and (len(top) == 1 or top[0][1] > top[1][1]):
-                row_section = top[0][0]
+        row_section = row_section_from_map(record.line_ids, section_by_line)
 
         # Create row metadata
         row_metadata = create_row_metadata(

--- a/receipt_chroma/receipt_chroma/section_labels.py
+++ b/receipt_chroma/receipt_chroma/section_labels.py
@@ -1,0 +1,62 @@
+"""Shared section-label logic for embedding and compaction paths.
+
+ReceiptSection rows classify a receipt's lines into sections; the LINES
+collection stores one embedding per visual row whose ``section_label``
+metadata must reflect those sections. Embed-time stamping (records /
+line_delta) and stream-driven recompute (compaction.sections) MUST agree
+exactly, so both import these helpers rather than forking the logic.
+
+This module is a dependency leaf (stdlib only) so it is importable from
+``receipt_chroma.compaction`` during package init without triggering the
+embedding package's import chain (which cycles back to the top-level
+``receipt_chroma`` namespace).
+"""
+
+from collections import Counter
+from typing import Any, Dict, Iterable, Optional, Sequence
+
+
+def sections_to_line_map(sections: Sequence[Any]) -> Dict[int, str]:
+    """Build a ``line_id -> section_type`` map from ReceiptSection rows.
+
+    Each section holds its ``line_ids``; sections partition a receipt's
+    lines, but if a line appears in more than one (e.g. overlapping seed
+    generations) the higher-confidence section wins.
+    """
+    out: Dict[int, str] = {}
+    best: Dict[int, float] = {}
+    for s in sections or []:
+        # skip QA-rejected rows — an INVALID section must not stamp a line
+        if str(getattr(s, "validation_status", "") or "").upper() == "INVALID":
+            continue
+        conf = getattr(s, "confidence", None) or 0.0
+        for line_id in getattr(s, "line_ids", []) or []:
+            if line_id not in out or conf > best.get(line_id, -1.0):
+                out[line_id] = s.section_type
+                best[line_id] = conf
+    return out
+
+
+def row_section_from_map(
+    line_ids: Iterable[int],
+    section_by_line: Optional[Dict[int, str]],
+) -> Optional[str]:
+    """Plurality section for a visual row's lines.
+
+    A row can span multiple ReceiptLines while sections are line-level, so
+    the row's ``section_label`` is the majority section among its lines.
+    Ties or no mapped lines are ambiguous and return ``None`` (callers must
+    then leave the metadata key unset).
+    """
+    if not section_by_line:
+        return None
+    votes = Counter(
+        section_by_line[lid] for lid in line_ids if lid in section_by_line
+    )
+    top = votes.most_common(2)
+    if top and (len(top) == 1 or top[0][1] > top[1][1]):
+        return top[0][0]
+    return None
+
+
+__all__ = ["row_section_from_map", "sections_to_line_map"]

--- a/receipt_chroma/tests/unit/test_compaction_sections.py
+++ b/receipt_chroma/tests/unit/test_compaction_sections.py
@@ -98,11 +98,14 @@ def test_recompute_stamps_plurality_from_fresh_state():
     assert results[0].updated_count == 2
     kwargs = collection_obj.update.call_args.kwargs
     by_id = dict(zip(kwargs["ids"], kwargs["metadatas"]))
-    row1 = by_id["IMAGE#img#RECEIPT#00001#LINE#00001"]
-    row3 = by_id["IMAGE#img#RECEIPT#00001#LINE#00003"]
-    assert row1["section_label"] == "HEADER"
-    assert row3["section_label"] == "LINE_ITEMS"
-    assert row1["merchant_name"] == "Test"  # other metadata preserved
+    # Chroma update() MERGES metadata, so only the delta is sent —
+    # other keys (merchant_name, ...) survive untouched on the row.
+    assert by_id["IMAGE#img#RECEIPT#00001#LINE#00001"] == {
+        "section_label": "HEADER"
+    }
+    assert by_id["IMAGE#img#RECEIPT#00001#LINE#00003"] == {
+        "section_label": "LINE_ITEMS"
+    }
 
 
 @pytest.mark.unit
@@ -153,8 +156,8 @@ def test_invalid_section_demotion_removes_label():
 
     assert results[0].updated_count == 1
     new_metadata = collection_obj.update.call_args.kwargs["metadatas"][0]
-    assert "section_label" not in new_metadata
-    assert new_metadata["merchant_name"] == "Test"
+    # None deletes the key under Chroma's merge semantics
+    assert new_metadata == {"section_label": None}
 
 
 @pytest.mark.unit
@@ -180,7 +183,7 @@ def test_section_delete_removes_labels():
 
     assert results[0].updated_count == 1
     new_metadata = collection_obj.update.call_args.kwargs["metadatas"][0]
-    assert "section_label" not in new_metadata
+    assert new_metadata == {"section_label": None}
 
 
 @pytest.mark.unit
@@ -210,7 +213,7 @@ def test_tie_leaves_label_unset():
 
     assert results[0].updated_count == 1
     new_metadata = collection_obj.update.call_args.kwargs["metadatas"][0]
-    assert "section_label" not in new_metadata
+    assert new_metadata == {"section_label": None}
 
 
 @pytest.mark.unit
@@ -297,6 +300,51 @@ def test_missing_collection_is_noop():
 
 
 @pytest.mark.unit
+def test_unexpected_get_collection_error_propagates():
+    """Transient/unknown Chroma failures must NOT be acknowledged as a
+    missing collection; they propagate so the batch retries."""
+    chroma = Mock()
+    chroma.get_collection.side_effect = RuntimeError("client closed")
+    with pytest.raises(RuntimeError):
+        apply_section_updates(
+            chroma_client=chroma,
+            section_messages=[_message()],
+            collection=ChromaDBCollection.LINES,
+            logger=Mock(),
+            dynamo_client=Mock(),
+        )
+
+
+@pytest.mark.unit
+def test_extra_receipts_recomputed_without_section_messages():
+    """Receipts touched by a delta merge are restamped even when no
+    section message shares the batch (stale-delta-overwrite guard)."""
+    chroma, collection_obj = _chroma_with_rows(
+        {
+            "IMAGE#img#RECEIPT#00001#LINE#00001": {
+                "row_line_ids": json.dumps([1]),
+                "section_label": "STALE",
+            }
+        }
+    )
+    dynamo = _dynamo_with_sections([_section("HEADER", [1])])
+
+    results = apply_section_updates(
+        chroma_client=chroma,
+        section_messages=[],
+        collection=ChromaDBCollection.LINES,
+        logger=Mock(),
+        dynamo_client=dynamo,
+        extra_receipts=[(IMAGE_ID, 1)],
+    )
+
+    assert len(results) == 1
+    assert results[0].updated_count == 1
+    new_metadata = collection_obj.update.call_args.kwargs["metadatas"][0]
+    assert new_metadata == {"section_label": "HEADER"}
+
+
+@pytest.mark.unit
 def test_dynamo_failure_records_error_for_retry():
     """A failed section fetch must NOT strip labels; it must error so
     the SQS message is retried."""
@@ -324,6 +372,62 @@ def test_dynamo_failure_records_error_for_retry():
     assert len(results) == 1
     assert results[0].error is not None
     collection_obj.update.assert_not_called()
+
+
+@pytest.mark.unit
+def test_real_chroma_update_semantics_stamp_and_strip(tmp_path):
+    """Against a real ChromaDB collection: update() merges metadata, so
+    the delta-only payload preserves other keys, and None deletes the
+    key (a full-metadata payload minus the key would NOT delete it)."""
+    chromadb = pytest.importorskip("chromadb")
+    # PersistentClient with a unique path: chroma's shared-system cache
+    # keys by path, so this cannot collide with other tests' clients.
+    client = chromadb.PersistentClient(path=str(tmp_path / "chroma"))
+    collection_obj = client.create_collection("lines-test")
+    row_id = "IMAGE#img#RECEIPT#00001#LINE#00001"
+    collection_obj.add(
+        ids=[row_id],
+        embeddings=[[0.1, 0.2]],
+        metadatas=[
+            {
+                "image_id": IMAGE_ID,
+                "receipt_id": 1,
+                "row_line_ids": json.dumps([1]),
+                "merchant_name": "Test",
+                "section_label": "STALE",
+            }
+        ],
+    )
+    chroma = Mock()
+    chroma.get_collection.return_value = collection_obj
+
+    def run(sections):
+        dynamo = _dynamo_with_sections(sections)
+        return apply_section_updates(
+            chroma_client=chroma,
+            section_messages=[_message()],
+            collection=ChromaDBCollection.LINES,
+            logger=Mock(),
+            dynamo_client=dynamo,
+        )
+
+    # Restamp: STALE -> HEADER, other keys preserved
+    results = run([_section("HEADER", [1])])
+    assert results[0].updated_count == 1
+    metadata = collection_obj.get(ids=[row_id], include=["metadatas"])[
+        "metadatas"
+    ][0]
+    assert metadata["section_label"] == "HEADER"
+    assert metadata["merchant_name"] == "Test"
+
+    # Strip: all sections INVALID -> key actually deleted on the row
+    results = run([_section("HEADER", [1], validation_status="INVALID")])
+    assert results[0].updated_count == 1
+    metadata = collection_obj.get(ids=[row_id], include=["metadatas"])[
+        "metadatas"
+    ][0]
+    assert "section_label" not in metadata
+    assert metadata["merchant_name"] == "Test"
 
 
 @pytest.mark.unit

--- a/receipt_chroma/tests/unit/test_compaction_sections.py
+++ b/receipt_chroma/tests/unit/test_compaction_sections.py
@@ -300,6 +300,37 @@ def test_missing_collection_is_noop():
 
 
 @pytest.mark.unit
+def test_missing_dynamo_client_with_messages_raises():
+    """Section messages without a DynamoDB client is a wiring bug —
+    it must surface as a batch failure, not a silent ack."""
+    chroma = Mock()
+    with pytest.raises(ValueError):
+        apply_section_updates(
+            chroma_client=chroma,
+            section_messages=[_message()],
+            collection=ChromaDBCollection.LINES,
+            logger=Mock(),
+            dynamo_client=None,
+        )
+
+
+@pytest.mark.unit
+def test_missing_dynamo_client_extra_receipts_only_skips():
+    """Delta-driven recompute without a client degrades to a no-op
+    (local tooling may merge deltas without DynamoDB access)."""
+    chroma = Mock()
+    results = apply_section_updates(
+        chroma_client=chroma,
+        section_messages=[],
+        collection=ChromaDBCollection.LINES,
+        logger=Mock(),
+        dynamo_client=None,
+        extra_receipts=[(IMAGE_ID, 1)],
+    )
+    assert results == []
+
+
+@pytest.mark.unit
 def test_unexpected_get_collection_error_propagates():
     """Transient/unknown Chroma failures must NOT be acknowledged as a
     missing collection; they propagate so the batch retries."""

--- a/receipt_chroma/tests/unit/test_compaction_sections.py
+++ b/receipt_chroma/tests/unit/test_compaction_sections.py
@@ -1,0 +1,350 @@
+"""Unit tests for RECEIPT_SECTION compaction updates.
+
+The consumer recomputes each affected receipt's row ``section_label``
+metadata from the receipt's *current* ReceiptSection rows in DynamoDB
+(never from the stream event image), mirroring the row-label path.
+"""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from receipt_chroma.compaction.sections import apply_section_updates
+from receipt_dynamo.constants import ChromaDBCollection
+
+IMAGE_ID = "550e8400-e29b-41d4-a716-446655440000"
+
+
+def _message(image_id: str = IMAGE_ID, receipt_id: int = 1, **extra):
+    event_name = extra.pop("event_name", "MODIFY")
+    return SimpleNamespace(
+        entity_type="RECEIPT_SECTION",
+        entity_data={
+            "entity_type": "RECEIPT_SECTION",
+            "image_id": image_id,
+            "receipt_id": receipt_id,
+            **extra,
+        },
+        event_name=event_name,
+    )
+
+
+def _section(
+    section_type: str,
+    line_ids,
+    confidence: float = 0.9,
+    validation_status: str = "PENDING",
+):
+    return SimpleNamespace(
+        section_type=section_type,
+        line_ids=line_ids,
+        confidence=confidence,
+        validation_status=validation_status,
+    )
+
+
+def _chroma_with_rows(rows: dict[str, dict]):
+    """Mock ChromaClient whose LINES collection returns the given rows."""
+    collection_obj = Mock()
+    collection_obj.get.return_value = {
+        "ids": list(rows.keys()),
+        "metadatas": list(rows.values()),
+    }
+    chroma_client = Mock()
+    chroma_client.get_collection.return_value = collection_obj
+    return chroma_client, collection_obj
+
+
+def _dynamo_with_sections(sections):
+    dynamo = Mock()
+    dynamo.get_receipt_sections_from_receipt.return_value = sections
+    return dynamo
+
+
+@pytest.mark.unit
+def test_recompute_stamps_plurality_from_fresh_state():
+    """Labels come from DynamoDB's current sections, not the event."""
+    chroma, collection_obj = _chroma_with_rows(
+        {
+            "IMAGE#img#RECEIPT#00001#LINE#00001": {
+                "row_line_ids": json.dumps([1, 2]),
+                "merchant_name": "Test",
+            },
+            "IMAGE#img#RECEIPT#00001#LINE#00003": {
+                "row_line_ids": json.dumps([3]),
+                "merchant_name": "Test",
+            },
+        }
+    )
+    dynamo = _dynamo_with_sections(
+        [
+            _section("HEADER", [1, 2]),
+            _section("LINE_ITEMS", [3]),
+        ]
+    )
+
+    results = apply_section_updates(
+        chroma_client=chroma,
+        section_messages=[_message()],
+        collection=ChromaDBCollection.LINES,
+        logger=Mock(),
+        dynamo_client=dynamo,
+    )
+
+    assert len(results) == 1
+    assert results[0].error is None
+    assert results[0].updated_count == 2
+    kwargs = collection_obj.update.call_args.kwargs
+    by_id = dict(zip(kwargs["ids"], kwargs["metadatas"]))
+    row1 = by_id["IMAGE#img#RECEIPT#00001#LINE#00001"]
+    row3 = by_id["IMAGE#img#RECEIPT#00001#LINE#00003"]
+    assert row1["section_label"] == "HEADER"
+    assert row3["section_label"] == "LINE_ITEMS"
+    assert row1["merchant_name"] == "Test"  # other metadata preserved
+
+
+@pytest.mark.unit
+def test_missing_rows_is_clean_noop():
+    """Receipt not embedded yet (batch at OpenAI) -> no error, no update."""
+    chroma, collection_obj = _chroma_with_rows({})
+    dynamo = _dynamo_with_sections([_section("HEADER", [1])])
+
+    results = apply_section_updates(
+        chroma_client=chroma,
+        section_messages=[_message()],
+        collection=ChromaDBCollection.LINES,
+        logger=Mock(),
+        dynamo_client=dynamo,
+    )
+
+    assert len(results) == 1
+    assert results[0].error is None
+    assert results[0].updated_count == 0
+    collection_obj.update.assert_not_called()
+    # Dynamo isn't queried when there is nothing to stamp
+    dynamo.get_receipt_sections_from_receipt.assert_not_called()
+
+
+@pytest.mark.unit
+def test_invalid_section_demotion_removes_label():
+    """QA flipping a section INVALID must strip stale section_label."""
+    chroma, collection_obj = _chroma_with_rows(
+        {
+            "IMAGE#img#RECEIPT#00001#LINE#00001": {
+                "row_line_ids": json.dumps([1]),
+                "section_label": "HEADER",
+                "merchant_name": "Test",
+            }
+        }
+    )
+    dynamo = _dynamo_with_sections(
+        [_section("HEADER", [1], validation_status="INVALID")]
+    )
+
+    results = apply_section_updates(
+        chroma_client=chroma,
+        section_messages=[_message()],
+        collection=ChromaDBCollection.LINES,
+        logger=Mock(),
+        dynamo_client=dynamo,
+    )
+
+    assert results[0].updated_count == 1
+    new_metadata = collection_obj.update.call_args.kwargs["metadatas"][0]
+    assert "section_label" not in new_metadata
+    assert new_metadata["merchant_name"] == "Test"
+
+
+@pytest.mark.unit
+def test_section_delete_removes_labels():
+    """All sections deleted -> every stamped row loses section_label."""
+    chroma, collection_obj = _chroma_with_rows(
+        {
+            "IMAGE#img#RECEIPT#00001#LINE#00001": {
+                "row_line_ids": json.dumps([1]),
+                "section_label": "HEADER",
+            }
+        }
+    )
+    dynamo = _dynamo_with_sections([])
+
+    results = apply_section_updates(
+        chroma_client=chroma,
+        section_messages=[_message(event_name="REMOVE")],
+        collection=ChromaDBCollection.LINES,
+        logger=Mock(),
+        dynamo_client=dynamo,
+    )
+
+    assert results[0].updated_count == 1
+    new_metadata = collection_obj.update.call_args.kwargs["metadatas"][0]
+    assert "section_label" not in new_metadata
+
+
+@pytest.mark.unit
+def test_tie_leaves_label_unset():
+    chroma, collection_obj = _chroma_with_rows(
+        {
+            "IMAGE#img#RECEIPT#00001#LINE#00001": {
+                "row_line_ids": json.dumps([1, 2]),
+                "section_label": "HEADER",
+            }
+        }
+    )
+    dynamo = _dynamo_with_sections(
+        [
+            _section("HEADER", [1]),
+            _section("LINE_ITEMS", [2]),
+        ]
+    )
+
+    results = apply_section_updates(
+        chroma_client=chroma,
+        section_messages=[_message()],
+        collection=ChromaDBCollection.LINES,
+        logger=Mock(),
+        dynamo_client=dynamo,
+    )
+
+    assert results[0].updated_count == 1
+    new_metadata = collection_obj.update.call_args.kwargs["metadatas"][0]
+    assert "section_label" not in new_metadata
+
+
+@pytest.mark.unit
+def test_unchanged_rows_are_not_rewritten():
+    """Idempotent: reprocessing the same state writes nothing."""
+    chroma, collection_obj = _chroma_with_rows(
+        {
+            "IMAGE#img#RECEIPT#00001#LINE#00001": {
+                "row_line_ids": json.dumps([1]),
+                "section_label": "HEADER",
+            }
+        }
+    )
+    dynamo = _dynamo_with_sections([_section("HEADER", [1])])
+
+    results = apply_section_updates(
+        chroma_client=chroma,
+        section_messages=[_message()],
+        collection=ChromaDBCollection.LINES,
+        logger=Mock(),
+        dynamo_client=dynamo,
+    )
+
+    assert results[0].updated_count == 0
+    collection_obj.update.assert_not_called()
+
+
+@pytest.mark.unit
+def test_storm_collapses_to_one_recompute_per_receipt():
+    """N events for one receipt cost one Dynamo query + one pass."""
+    chroma, collection_obj = _chroma_with_rows(
+        {
+            "IMAGE#img#RECEIPT#00001#LINE#00001": {
+                "row_line_ids": json.dumps([1]),
+            }
+        }
+    )
+    dynamo = _dynamo_with_sections([_section("HEADER", [1])])
+
+    messages = [
+        _message(section_type=f"TYPE_{i}", event_name="MODIFY")
+        for i in range(25)
+    ]
+    results = apply_section_updates(
+        chroma_client=chroma,
+        section_messages=messages,
+        collection=ChromaDBCollection.LINES,
+        logger=Mock(),
+        dynamo_client=dynamo,
+    )
+
+    assert len(results) == 1
+    assert dynamo.get_receipt_sections_from_receipt.call_count == 1
+    assert collection_obj.get.call_count == 1
+
+
+@pytest.mark.unit
+def test_words_collection_is_noop():
+    chroma = Mock()
+    results = apply_section_updates(
+        chroma_client=chroma,
+        section_messages=[_message()],
+        collection=ChromaDBCollection.WORDS,
+        logger=Mock(),
+        dynamo_client=Mock(),
+    )
+    assert results == []
+    chroma.get_collection.assert_not_called()
+
+
+@pytest.mark.unit
+def test_missing_collection_is_noop():
+    """Fresh environment without a lines collection must not error."""
+    chroma = Mock()
+    chroma.get_collection.side_effect = ValueError("no such collection")
+    results = apply_section_updates(
+        chroma_client=chroma,
+        section_messages=[_message()],
+        collection=ChromaDBCollection.LINES,
+        logger=Mock(),
+        dynamo_client=Mock(),
+    )
+    assert results == []
+
+
+@pytest.mark.unit
+def test_dynamo_failure_records_error_for_retry():
+    """A failed section fetch must NOT strip labels; it must error so
+    the SQS message is retried."""
+    chroma, collection_obj = _chroma_with_rows(
+        {
+            "IMAGE#img#RECEIPT#00001#LINE#00001": {
+                "row_line_ids": json.dumps([1]),
+                "section_label": "HEADER",
+            }
+        }
+    )
+    dynamo = Mock()
+    dynamo.get_receipt_sections_from_receipt.side_effect = RuntimeError(
+        "dynamo down"
+    )
+
+    results = apply_section_updates(
+        chroma_client=chroma,
+        section_messages=[_message()],
+        collection=ChromaDBCollection.LINES,
+        logger=Mock(),
+        dynamo_client=dynamo,
+    )
+
+    assert len(results) == 1
+    assert results[0].error is not None
+    collection_obj.update.assert_not_called()
+
+
+@pytest.mark.unit
+def test_legacy_row_without_row_line_ids_uses_line_id():
+    chroma, collection_obj = _chroma_with_rows(
+        {
+            "IMAGE#img#RECEIPT#00001#LINE#00007": {
+                "line_id": 7,
+            }
+        }
+    )
+    dynamo = _dynamo_with_sections([_section("FOOTER", [7])])
+
+    results = apply_section_updates(
+        chroma_client=chroma,
+        section_messages=[_message()],
+        collection=ChromaDBCollection.LINES,
+        logger=Mock(),
+        dynamo_client=dynamo,
+    )
+
+    assert results[0].updated_count == 1
+    new_metadata = collection_obj.update.call_args.kwargs["metadatas"][0]
+    assert new_metadata["section_label"] == "FOOTER"

--- a/receipt_chroma/tests/unit/test_message_ordering.py
+++ b/receipt_chroma/tests/unit/test_message_ordering.py
@@ -108,6 +108,42 @@ class TestGetEntityKey:
         key = _get_entity_key(msg)
         assert key == ("img-5", "5", "8", "9")
 
+    def test_receipt_section_key(self):
+        """RECEIPT_SECTION keys are namespaced by entity type so a
+        section REMOVE never dedupes other entities for the receipt."""
+        msg = StreamMessage(
+            entity_type="RECEIPT_SECTION",
+            entity_data={
+                "image_id": "img-5",
+                "receipt_id": 5,
+                "section_type": "HEADER",
+            },
+            changes={},
+            event_name="REMOVE",
+            collections=(ChromaDBCollection.LINES,),
+            context=StreamRecordContext(
+                timestamp="2025-01-01T00:00:00Z",
+                record_id="msg-5b",
+                aws_region="us-east-1",
+            ),
+        )
+        key = _get_entity_key(msg)
+        assert key == ("RECEIPT_SECTION", "img-5", "5", "HEADER")
+
+        place_msg = StreamMessage(
+            entity_type="RECEIPT_PLACE",
+            entity_data={"image_id": "img-5", "receipt_id": 5},
+            changes={},
+            event_name="MODIFY",
+            collections=(ChromaDBCollection.LINES,),
+            context=StreamRecordContext(
+                timestamp="2025-01-01T00:00:00Z",
+                record_id="msg-5c",
+                aws_region="us-east-1",
+            ),
+        )
+        assert key != _get_entity_key(place_msg)
+
     def test_unknown_entity_type_key(self):
         """Test entity key extraction for unknown entity type."""
         msg = StreamMessage(

--- a/receipt_dynamo/receipt_dynamo/data/_receipt_section.py
+++ b/receipt_dynamo/receipt_dynamo/data/_receipt_section.py
@@ -327,6 +327,12 @@ class _ReceiptSection(FlattenedStandardMixin):
                     ":pk": {"S": expected_pk},
                     ":sk": {"S": start_of_sk},
                 },
+                # Strongly consistent: the ChromaDB stream consumer
+                # recomputes section_label from this read immediately
+                # after a section write and then acknowledges the event,
+                # so a stale eventually-consistent read could persist
+                # wrong metadata with no later event to correct it.
+                ConsistentRead=True,
             )
             return [
                 item_to_receipt_section(item) for item in response["Items"]

--- a/receipt_dynamo_stream/receipt_dynamo_stream/__init__.py
+++ b/receipt_dynamo_stream/receipt_dynamo_stream/__init__.py
@@ -11,6 +11,10 @@ so Lambdas can stay minimal while sharing business logic with other services.
 
 __version__ = "0.1.0"
 
+from receipt_dynamo_stream.backfill import (
+    build_section_backfill_messages,
+    publish_section_backfill,
+)
 from receipt_dynamo_stream.change_detection.detector import (
     CHROMADB_RELEVANT_FIELDS,
     get_chromadb_relevant_changes,
@@ -64,6 +68,7 @@ __all__ = [
     "StreamRecordContext",
     "TargetQueue",
     "build_messages_from_records",
+    "build_section_backfill_messages",
     "detect_entity_type",
     "get_chromadb_relevant_changes",
     "is_compaction_run",
@@ -72,6 +77,7 @@ __all__ = [
     "parse_entity",
     "parse_stream_record",
     "publish_messages",
+    "publish_section_backfill",
     "send_batch_to_queue",
     # Type definitions
     "APIGatewayResponse",

--- a/receipt_dynamo_stream/receipt_dynamo_stream/backfill.py
+++ b/receipt_dynamo_stream/receipt_dynamo_stream/backfill.py
@@ -1,0 +1,151 @@
+"""One-off section backfill through the stream pipeline.
+
+Receipts embedded before ReceiptSection rows existed (or before the
+section stream path deployed) have line rows in ChromaDB without
+``section_label`` metadata even though DynamoDB now holds their
+sections. This module publishes synthetic RECEIPT_SECTION messages
+through the SAME SQS -> enhanced-compaction path the DynamoDB stream
+uses, so the backfill:
+
+- serializes with concurrent delta ingestion under the compactor's
+  lock (no direct Chroma writer is introduced), and
+- reuses the consumer's recompute-from-current-DynamoDB-state logic,
+  making re-runs idempotent (rows already correct are not rewritten).
+
+Usage (one-off, from an environment with LINES_QUEUE_URL set to the
+lines compaction queue):
+
+    from receipt_dynamo.data.dynamo_client import DynamoClient
+    from receipt_dynamo_stream.backfill import publish_section_backfill
+
+    sent = publish_section_backfill(
+        dynamo_client=DynamoClient(table_name)
+    )
+
+or, for a known subset of receipts:
+
+    sent = publish_section_backfill(
+        receipts=[(image_id, receipt_id), ...]
+    )
+"""
+
+# pylint: disable=import-error
+# import-error: receipt_dynamo is a monorepo sibling installed at runtime
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Any, Iterable, Iterator, Optional
+from uuid import uuid4
+
+from receipt_dynamo_stream.models import (
+    ChromaDBCollection,
+    StreamMessage,
+    StreamRecordContext,
+)
+from receipt_dynamo_stream.sqs_publisher import publish_messages
+from receipt_dynamo_stream.stream_types import MetricsRecorder
+
+logger = logging.getLogger(__name__)
+
+_BACKFILL_SOURCE = "section_backfill"
+
+
+def iter_section_receipts(dynamo_client: Any) -> Iterator[tuple[str, int]]:
+    """Yield unique (image_id, receipt_id) pairs that have sections.
+
+    Paginates every ReceiptSection row via ``list_receipt_sections`` and
+    de-duplicates, so each receipt is recomputed exactly once.
+    """
+    seen: set[tuple[str, int]] = set()
+    last_evaluated_key: Optional[dict] = None
+    while True:
+        sections, last_evaluated_key = dynamo_client.list_receipt_sections(
+            last_evaluated_key=last_evaluated_key
+        )
+        for section in sections:
+            key = (section.image_id, section.receipt_id)
+            if key not in seen:
+                seen.add(key)
+                yield key
+        if not last_evaluated_key:
+            break
+
+
+def build_section_backfill_messages(
+    receipts: Iterable[tuple[str, int]],
+) -> list[StreamMessage]:
+    """Build one RECEIPT_SECTION recompute message per receipt.
+
+    The consumer ignores the event image entirely (it recomputes from
+    the receipt's current sections in DynamoDB), so the message only
+    needs (image_id, receipt_id) — identical in shape to stream-emitted
+    section messages, just tagged with a backfill source.
+    """
+    timestamp = datetime.now(timezone.utc).isoformat()
+    messages: list[StreamMessage] = []
+    for image_id, receipt_id in receipts:
+        messages.append(
+            StreamMessage(
+                entity_type="RECEIPT_SECTION",
+                entity_data={
+                    "entity_type": "RECEIPT_SECTION",
+                    "image_id": image_id,
+                    "receipt_id": receipt_id,
+                },
+                changes={},
+                event_name="MODIFY",
+                collections=(ChromaDBCollection.LINES,),
+                context=StreamRecordContext(
+                    source=_BACKFILL_SOURCE,
+                    timestamp=timestamp,
+                    record_id=f"{_BACKFILL_SOURCE}-{uuid4()}",
+                    aws_region="backfill",
+                ),
+            )
+        )
+    return messages
+
+
+def publish_section_backfill(
+    receipts: Optional[Iterable[tuple[str, int]]] = None,
+    dynamo_client: Any = None,
+    metrics: Optional[MetricsRecorder] = None,
+) -> int:
+    """Queue section recomputes for receipts via the lines SQS queue.
+
+    Args:
+        receipts: Explicit (image_id, receipt_id) pairs to recompute.
+            If omitted, every receipt owning at least one ReceiptSection
+            row is discovered via ``dynamo_client``.
+        dynamo_client: Required when ``receipts`` is omitted.
+        metrics: Optional metrics recorder.
+
+    Returns:
+        Number of SQS messages successfully published.
+    """
+    if receipts is None:
+        if dynamo_client is None:
+            raise ValueError(
+                "dynamo_client is required when receipts is not provided"
+            )
+        receipts = iter_section_receipts(dynamo_client)
+
+    messages = build_section_backfill_messages(receipts)
+    if not messages:
+        logger.info("Section backfill found no receipts to publish")
+        return 0
+
+    sent = publish_messages(messages, metrics)
+    logger.info(
+        "Section backfill published %s/%s messages", sent, len(messages)
+    )
+    return sent
+
+
+__all__ = [
+    "build_section_backfill_messages",
+    "iter_section_receipts",
+    "publish_section_backfill",
+]

--- a/receipt_dynamo_stream/receipt_dynamo_stream/backfill.py
+++ b/receipt_dynamo_stream/receipt_dynamo_stream/backfill.py
@@ -112,19 +112,30 @@ def publish_section_backfill(
     receipts: Optional[Iterable[tuple[str, int]]] = None,
     dynamo_client: Any = None,
     metrics: Optional[MetricsRecorder] = None,
+    chunk_size: int = 500,
 ) -> int:
     """Queue section recomputes for receipts via the lines SQS queue.
+
+    Publishes in chunks while iterating so the full receipt set is
+    never materialized in memory and progress survives a partial
+    failure (re-runs are idempotent — already-correct rows are not
+    rewritten by the consumer).
 
     Args:
         receipts: Explicit (image_id, receipt_id) pairs to recompute.
             If omitted, every receipt owning at least one ReceiptSection
-            row is discovered via ``dynamo_client``.
+            row is discovered via ``dynamo_client``. Receipts whose last
+            section was deleted (nothing left to discover) can be passed
+            explicitly here to strip their stale labels.
         dynamo_client: Required when ``receipts`` is omitted.
         metrics: Optional metrics recorder.
+        chunk_size: Receipts per publish call.
 
     Returns:
         Number of SQS messages successfully published.
     """
+    if chunk_size <= 0:
+        raise ValueError("chunk_size must be positive")
     if receipts is None:
         if dynamo_client is None:
             raise ValueError(
@@ -132,15 +143,29 @@ def publish_section_backfill(
             )
         receipts = iter_section_receipts(dynamo_client)
 
-    messages = build_section_backfill_messages(receipts)
-    if not messages:
-        logger.info("Section backfill found no receipts to publish")
-        return 0
+    sent = 0
+    total = 0
+    chunk: list[tuple[str, int]] = []
 
-    sent = publish_messages(messages, metrics)
-    logger.info(
-        "Section backfill published %s/%s messages", sent, len(messages)
-    )
+    def flush() -> None:
+        nonlocal sent, total
+        if not chunk:
+            return
+        messages = build_section_backfill_messages(chunk)
+        sent += publish_messages(messages, metrics)
+        total += len(messages)
+        chunk.clear()
+
+    for receipt in receipts:
+        chunk.append(receipt)
+        if len(chunk) >= chunk_size:
+            flush()
+    flush()
+
+    if total == 0:
+        logger.info("Section backfill found no receipts to publish")
+    else:
+        logger.info("Section backfill published %s/%s messages", sent, total)
     return sent
 
 

--- a/receipt_dynamo_stream/receipt_dynamo_stream/change_detection/detector.py
+++ b/receipt_dynamo_stream/receipt_dynamo_stream/change_detection/detector.py
@@ -21,6 +21,12 @@ CHROMADB_RELEVANT_FIELDS = {
         "label_proposed_by",
         "label_consolidated_from",
     ],
+    "RECEIPT_SECTION": [
+        "section_type",
+        "line_ids",
+        "confidence",
+        "validation_status",
+    ],
 }
 
 

--- a/receipt_dynamo_stream/receipt_dynamo_stream/message_builder.py
+++ b/receipt_dynamo_stream/receipt_dynamo_stream/message_builder.py
@@ -17,6 +17,7 @@ from typing import Callable, Iterable, Optional
 from receipt_dynamo.entities.receipt import Receipt
 from receipt_dynamo.entities.receipt_line import ReceiptLine
 from receipt_dynamo.entities.receipt_place import ReceiptPlace
+from receipt_dynamo.entities.receipt_section import ReceiptSection
 from receipt_dynamo.entities.receipt_word import ReceiptWord
 from receipt_dynamo.entities.receipt_word_label import ReceiptWordLabel
 from receipt_dynamo_stream.change_detection import (
@@ -40,6 +41,12 @@ from receipt_dynamo_stream.stream_types import (
 
 logger = logging.getLogger(__name__)
 
+# Entity types whose INSERT events must also produce change messages.
+# ReceiptSection INSERTs matter because creating a section changes the
+# correct ``section_label`` for the receipt's rows in ChromaDB; other
+# entity INSERTs are covered by the embedding pipeline itself.
+_INSERT_SYNCED_ENTITY_TYPES = frozenset({"RECEIPT_SECTION"})
+
 
 def build_messages_from_records(
     records: Iterable[DynamoDBStreamRecord],
@@ -54,6 +61,12 @@ def build_messages_from_records(
         event_name = record.get("eventName")
         if event_name == "INSERT":
             messages.extend(build_compaction_run_messages(record, metrics))
+            # Section INSERTs (e.g. QA creating a section) must trigger a
+            # section_label recompute; build_entity_change_message drops
+            # INSERTs for all other entity types.
+            entity_message = build_entity_change_message(record, metrics)
+            if entity_message:
+                messages.append(entity_message)
         elif event_name in {"MODIFY", "REMOVE"}:
             # Note: CompactionRun MODIFY events (embeddings completed) are
             # intentionally ignored.  The merge Lambda polls DynamoDB
@@ -147,6 +160,12 @@ def build_entity_change_message(
         entity_type = parsed_record.entity_type
         old_entity = parsed_record.old_entity
         new_entity = parsed_record.new_entity
+
+        if (
+            record.get("eventName") == "INSERT"
+            and entity_type not in _INSERT_SYNCED_ENTITY_TYPES
+        ):
+            return None
 
         changes = get_chromadb_relevant_changes(
             entity_type, old_entity, new_entity
@@ -247,6 +266,25 @@ def _extract_receipt_word_label(
     ]
 
 
+def _extract_receipt_section(
+    entity: ReceiptSection,
+) -> tuple[dict[str, object], list[ChromaDBCollection]]:
+    """Extract section data targeting the LINES collection only.
+
+    ``section_label`` lives on LINES (visual-row) metadata. The message
+    carries only (image_id, receipt_id): the consumer recomputes labels
+    from the receipt's *current* section set in DynamoDB, so the event
+    image is deliberately not trusted (see compaction sections module).
+    ``section_type`` is included only for within-batch deduplication.
+    """
+    return {
+        "entity_type": "RECEIPT_SECTION",
+        "image_id": entity.image_id,
+        "receipt_id": entity.receipt_id,
+        "section_type": str(entity.section_type),
+    }, [ChromaDBCollection.LINES]
+
+
 def _extract_receipt(
     entity: Receipt,
 ) -> tuple[dict[str, object], list[ChromaDBCollection]]:
@@ -282,7 +320,12 @@ def _extract_receipt_line(
 
 # Type alias for entity extractor functions
 _EntityType = (
-    Receipt | ReceiptLine | ReceiptPlace | ReceiptWord | ReceiptWordLabel
+    Receipt
+    | ReceiptLine
+    | ReceiptPlace
+    | ReceiptSection
+    | ReceiptWord
+    | ReceiptWordLabel
 )
 _ExtractorFunc = Callable[
     [_EntityType],
@@ -293,6 +336,7 @@ _ExtractorFunc = Callable[
 _ENTITY_EXTRACTORS: dict[str, tuple[type, _ExtractorFunc]] = {
     "RECEIPT_PLACE": (ReceiptPlace, _extract_receipt_place),
     "RECEIPT_WORD_LABEL": (ReceiptWordLabel, _extract_receipt_word_label),
+    "RECEIPT_SECTION": (ReceiptSection, _extract_receipt_section),
     "RECEIPT": (Receipt, _extract_receipt),
     "RECEIPT_WORD": (ReceiptWord, _extract_receipt_word),
     "RECEIPT_LINE": (ReceiptLine, _extract_receipt_line),
@@ -301,14 +345,7 @@ _ENTITY_EXTRACTORS: dict[str, tuple[type, _ExtractorFunc]] = {
 
 def _extract_entity_data(
     entity_type: str,
-    entity: (
-        Receipt
-        | ReceiptLine
-        | ReceiptPlace
-        | ReceiptWord
-        | ReceiptWordLabel
-        | None
-    ),
+    entity: _EntityType | None,
 ) -> tuple[dict[str, object], list[ChromaDBCollection | TargetQueue]]:
     """Extract entity data and determine target collections/queues."""
     if not entity:

--- a/receipt_dynamo_stream/receipt_dynamo_stream/models.py
+++ b/receipt_dynamo_stream/receipt_dynamo_stream/models.py
@@ -12,12 +12,18 @@ from typing import Mapping, Optional, TypeAlias
 from receipt_dynamo.entities.receipt import Receipt
 from receipt_dynamo.entities.receipt_line import ReceiptLine
 from receipt_dynamo.entities.receipt_place import ReceiptPlace
+from receipt_dynamo.entities.receipt_section import ReceiptSection
 from receipt_dynamo.entities.receipt_word import ReceiptWord
 from receipt_dynamo.entities.receipt_word_label import ReceiptWordLabel
 from receipt_dynamo_stream.stream_types import DynamoDBItem
 
 StreamEntity: TypeAlias = (
-    Receipt | ReceiptLine | ReceiptPlace | ReceiptWord | ReceiptWordLabel
+    Receipt
+    | ReceiptLine
+    | ReceiptPlace
+    | ReceiptSection
+    | ReceiptWord
+    | ReceiptWordLabel
 )
 
 

--- a/receipt_dynamo_stream/receipt_dynamo_stream/parsing/parsers.py
+++ b/receipt_dynamo_stream/receipt_dynamo_stream/parsing/parsers.py
@@ -14,6 +14,7 @@ from typing import Callable, Optional
 from receipt_dynamo.entities.receipt import item_to_receipt
 from receipt_dynamo.entities.receipt_line import item_to_receipt_line
 from receipt_dynamo.entities.receipt_place import item_to_receipt_place
+from receipt_dynamo.entities.receipt_section import item_to_receipt_section
 from receipt_dynamo.entities.receipt_word import item_to_receipt_word
 from receipt_dynamo.entities.receipt_word_label import (
     item_to_receipt_word_label,
@@ -32,6 +33,9 @@ logger = logging.getLogger(__name__)
 _SK_PATTERN_MATCHERS: list[tuple[Callable[[str], bool], str]] = [
     (lambda sk: "#PLACE" in sk, "RECEIPT_PLACE"),
     (lambda sk: "#LABEL#" in sk, "RECEIPT_WORD_LABEL"),
+    # RECEIPT#00001#SECTION#{TYPE}; "#SECTION#" appears in no other
+    # entity SK (receipt_section.py is the only entity emitting it)
+    (lambda sk: "#SECTION#" in sk, "RECEIPT_SECTION"),
     (lambda sk: "#COMPACTION_RUN#" in sk, "COMPACTION_RUN"),
     (lambda sk: "#WORD#" in sk and "#LINE#" in sk, "RECEIPT_WORD"),
     (lambda sk: "#LINE#" in sk, "RECEIPT_LINE"),
@@ -44,6 +48,7 @@ _ENTITY_PARSERS: dict[
 ] = {
     "RECEIPT_PLACE": item_to_receipt_place,
     "RECEIPT_WORD_LABEL": item_to_receipt_word_label,
+    "RECEIPT_SECTION": item_to_receipt_section,
     "RECEIPT": item_to_receipt,
     "RECEIPT_WORD": item_to_receipt_word,
     "RECEIPT_LINE": item_to_receipt_line,
@@ -55,6 +60,7 @@ def detect_entity_type(sk: str) -> Optional[str]:
 
     SK patterns (most specific first):
     - RECEIPT_WORD_LABEL: RECEIPT#00001#LINE#00001#WORD#00001#LABEL#...
+    - RECEIPT_SECTION: RECEIPT#00001#SECTION#HEADER
     - RECEIPT_WORD: RECEIPT#00001#LINE#00001#WORD#00001
     - RECEIPT_LINE: RECEIPT#00001#LINE#00001
     - RECEIPT_PLACE: IMAGE#...#RECEIPT#00001#PLACE

--- a/receipt_dynamo_stream/tests/unit/test_receipt_section_stream.py
+++ b/receipt_dynamo_stream/tests/unit/test_receipt_section_stream.py
@@ -1,0 +1,187 @@
+"""Unit tests for RECEIPT_SECTION stream support.
+
+Mirrors the RECEIPT_WORD_LABEL tests: SK detection, watched-field change
+detection, and message building for INSERT / MODIFY / REMOVE events.
+"""
+
+from datetime import datetime
+from typing import Any, Optional
+
+from receipt_dynamo.entities.receipt_section import ReceiptSection
+from receipt_dynamo_stream.change_detection import (
+    get_chromadb_relevant_changes,
+)
+from receipt_dynamo_stream.message_builder import (
+    _extract_entity_data,
+    build_entity_change_message,
+    build_messages_from_records,
+)
+from receipt_dynamo_stream.models import ChromaDBCollection
+from receipt_dynamo_stream.parsing import detect_entity_type
+
+IMAGE_ID = "550e8400-e29b-41d4-a716-446655440000"
+
+
+def _make_section(
+    section_type: str = "HEADER",
+    line_ids: Optional[list[int]] = None,
+    confidence: float = 0.9,
+    validation_status: str = "PENDING",
+) -> ReceiptSection:
+    return ReceiptSection(
+        image_id=IMAGE_ID,
+        receipt_id=1,
+        section_type=section_type,
+        line_ids=line_ids or [1, 2, 3],
+        created_at=datetime.fromisoformat("2024-01-01T00:00:00"),
+        confidence=confidence,
+        model_source="section-seed-v0",
+        validation_status=validation_status,
+    )
+
+
+def _record(
+    event_name: str,
+    old: Optional[ReceiptSection],
+    new: Optional[ReceiptSection],
+) -> dict[str, Any]:
+    entity = old or new
+    assert entity is not None
+    dynamodb: dict[str, Any] = {"Keys": entity.key}
+    if old is not None:
+        dynamodb["OldImage"] = old.to_item()
+    if new is not None:
+        dynamodb["NewImage"] = new.to_item()
+    return {
+        "eventName": event_name,
+        "eventID": "event-section-1",
+        "awsRegion": "us-east-1",
+        "dynamodb": dynamodb,
+    }
+
+
+# SK pattern detection
+
+
+def test_detect_entity_type_section_sk() -> None:
+    assert (
+        detect_entity_type("RECEIPT#00001#SECTION#HEADER") == "RECEIPT_SECTION"
+    )
+
+
+def test_detect_entity_type_section_does_not_shadow_others() -> None:
+    """Existing SK patterns must be unaffected by the SECTION matcher."""
+    assert (
+        detect_entity_type("RECEIPT#00001#LINE#00001#WORD#00001#LABEL#TOTAL")
+        == "RECEIPT_WORD_LABEL"
+    )
+    assert detect_entity_type("RECEIPT#00001#LINE#00001") == "RECEIPT_LINE"
+    assert (
+        detect_entity_type("RECEIPT#00001#COMPACTION_RUN#abc")
+        == "COMPACTION_RUN"
+    )
+
+
+# Watched-field change detection
+
+
+def test_section_validation_status_change_is_relevant() -> None:
+    old = _make_section(validation_status="PENDING")
+    new = _make_section(validation_status="VALID")
+    changes = get_chromadb_relevant_changes("RECEIPT_SECTION", old, new)
+    assert set(changes) == {"validation_status"}
+    assert changes["validation_status"].old == "PENDING"
+    assert changes["validation_status"].new == "VALID"
+
+
+def test_section_line_ids_and_confidence_changes_are_relevant() -> None:
+    old = _make_section(line_ids=[1, 2], confidence=0.5)
+    new = _make_section(line_ids=[1, 2, 3], confidence=0.9)
+    changes = get_chromadb_relevant_changes("RECEIPT_SECTION", old, new)
+    assert set(changes) == {"line_ids", "confidence"}
+
+
+def test_section_irrelevant_field_change_is_ignored() -> None:
+    old = _make_section()
+    new = _make_section()
+    new.model_source = "section-seed-v1"
+    changes = get_chromadb_relevant_changes("RECEIPT_SECTION", old, new)
+    assert changes == {}
+
+
+# Entity data extraction
+
+
+def test_extract_entity_data_receipt_section_targets_lines_only() -> None:
+    section = _make_section()
+    entity_data, collections = _extract_entity_data("RECEIPT_SECTION", section)
+    assert entity_data == {
+        "entity_type": "RECEIPT_SECTION",
+        "image_id": IMAGE_ID,
+        "receipt_id": 1,
+        "section_type": "HEADER",
+    }
+    assert collections == [ChromaDBCollection.LINES]
+
+
+# Message building
+
+
+def test_section_modify_builds_message() -> None:
+    record = _record(
+        "MODIFY",
+        _make_section(validation_status="PENDING"),
+        _make_section(validation_status="VALID"),
+    )
+    message = build_entity_change_message(record)
+    assert message is not None
+    assert message.entity_type == "RECEIPT_SECTION"
+    assert message.event_name == "MODIFY"
+    assert message.collections == (ChromaDBCollection.LINES,)
+    assert message.entity_data["image_id"] == IMAGE_ID
+    assert message.entity_data["receipt_id"] == 1
+
+
+def test_section_remove_builds_message_without_changes() -> None:
+    """REMOVE of a section must trigger recompute even with no field diff."""
+    record = _record("REMOVE", _make_section(), None)
+    message = build_entity_change_message(record)
+    assert message is not None
+    assert message.event_name == "REMOVE"
+    assert message.entity_type == "RECEIPT_SECTION"
+    assert message.collections == (ChromaDBCollection.LINES,)
+
+
+def test_section_insert_builds_message_via_records_pipeline() -> None:
+    """INSERT of a section (QA creating one) must produce a message."""
+    record = _record("INSERT", None, _make_section())
+    messages = build_messages_from_records([record])
+    assert len(messages) == 1
+    assert messages[0].entity_type == "RECEIPT_SECTION"
+    assert messages[0].event_name == "INSERT"
+
+
+def test_non_section_insert_still_ignored() -> None:
+    """INSERTs of other entity types must keep their existing behavior
+    (dropped — the embedding pipeline covers new entities)."""
+    from .test_message_builder import _make_word_label
+
+    label = _make_word_label()
+    record = {
+        "eventName": "INSERT",
+        "eventID": "event-label-insert",
+        "awsRegion": "us-east-1",
+        "dynamodb": {
+            "Keys": label.key,
+            "NewImage": label.to_item(),
+        },
+    }
+    assert build_messages_from_records([record]) == []
+
+
+def test_section_modify_without_relevant_changes_is_dropped() -> None:
+    old = _make_section()
+    new = _make_section()
+    new.model_source = "section-seed-v1"
+    record = _record("MODIFY", old, new)
+    assert build_entity_change_message(record) is None

--- a/receipt_dynamo_stream/tests/unit/test_section_backfill.py
+++ b/receipt_dynamo_stream/tests/unit/test_section_backfill.py
@@ -1,0 +1,82 @@
+"""Unit tests for the one-off section backfill entry point."""
+
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pytest
+
+from receipt_dynamo_stream.backfill import (
+    build_section_backfill_messages,
+    iter_section_receipts,
+    publish_section_backfill,
+)
+from receipt_dynamo_stream.models import ChromaDBCollection
+
+IMAGE_ID = "550e8400-e29b-41d4-a716-446655440000"
+
+
+def _section(image_id: str, receipt_id: int):
+    return SimpleNamespace(image_id=image_id, receipt_id=receipt_id)
+
+
+def test_build_messages_match_stream_message_shape() -> None:
+    messages = build_section_backfill_messages([(IMAGE_ID, 1), (IMAGE_ID, 2)])
+    assert len(messages) == 2
+    for msg, receipt_id in zip(messages, (1, 2)):
+        assert msg.entity_type == "RECEIPT_SECTION"
+        assert msg.collections == (ChromaDBCollection.LINES,)
+        assert msg.event_name == "MODIFY"
+        assert msg.entity_data["image_id"] == IMAGE_ID
+        assert msg.entity_data["receipt_id"] == receipt_id
+        assert msg.context.source == "section_backfill"
+    # record ids must be unique so SQS batching/failure tracking works
+    assert len({m.context.record_id for m in messages}) == 2
+
+
+def test_iter_section_receipts_paginates_and_dedupes() -> None:
+    dynamo = Mock()
+    dynamo.list_receipt_sections.side_effect = [
+        ([_section(IMAGE_ID, 1), _section(IMAGE_ID, 1)], {"k": "next"}),
+        ([_section(IMAGE_ID, 2)], None),
+    ]
+    receipts = list(iter_section_receipts(dynamo))
+    assert receipts == [(IMAGE_ID, 1), (IMAGE_ID, 2)]
+    assert dynamo.list_receipt_sections.call_count == 2
+
+
+def test_publish_with_explicit_receipts() -> None:
+    with patch(
+        "receipt_dynamo_stream.backfill.publish_messages", return_value=1
+    ) as publish:
+        sent = publish_section_backfill(receipts=[(IMAGE_ID, 1)])
+    assert sent == 1
+    (messages,) = publish.call_args.args[:1]
+    assert len(messages) == 1
+    assert messages[0].entity_data["receipt_id"] == 1
+
+
+def test_publish_discovers_receipts_from_dynamo() -> None:
+    dynamo = Mock()
+    dynamo.list_receipt_sections.return_value = (
+        [_section(IMAGE_ID, 3)],
+        None,
+    )
+    with patch(
+        "receipt_dynamo_stream.backfill.publish_messages", return_value=1
+    ) as publish:
+        sent = publish_section_backfill(dynamo_client=dynamo)
+    assert sent == 1
+    (messages,) = publish.call_args.args[:1]
+    assert messages[0].entity_data["receipt_id"] == 3
+
+
+def test_publish_requires_receipts_or_dynamo_client() -> None:
+    with pytest.raises(ValueError):
+        publish_section_backfill()
+
+
+def test_publish_no_receipts_is_noop() -> None:
+    with patch("receipt_dynamo_stream.backfill.publish_messages") as publish:
+        sent = publish_section_backfill(receipts=[])
+    assert sent == 0
+    publish.assert_not_called()

--- a/receipt_dynamo_stream/tests/unit/test_section_backfill.py
+++ b/receipt_dynamo_stream/tests/unit/test_section_backfill.py
@@ -80,3 +80,22 @@ def test_publish_no_receipts_is_noop() -> None:
         sent = publish_section_backfill(receipts=[])
     assert sent == 0
     publish.assert_not_called()
+
+
+def test_publish_chunks_large_receipt_sets() -> None:
+    """The full set is never materialized; publishes go out per chunk."""
+    receipts = [(IMAGE_ID, i) for i in range(1, 8)]
+    with patch(
+        "receipt_dynamo_stream.backfill.publish_messages",
+        side_effect=lambda msgs, metrics=None: len(msgs),
+    ) as publish:
+        sent = publish_section_backfill(receipts=iter(receipts), chunk_size=3)
+    assert sent == 7
+    assert publish.call_count == 3  # 3 + 3 + 1
+    chunk_sizes = [len(c.args[0]) for c in publish.call_args_list]
+    assert chunk_sizes == [3, 3, 1]
+
+
+def test_publish_rejects_invalid_chunk_size() -> None:
+    with pytest.raises(ValueError):
+        publish_section_backfill(receipts=[(IMAGE_ID, 1)], chunk_size=0)


### PR DESCRIPTION
## Summary

Closes the loop where a `ReceiptSection` edited **after** its receipt was embedded never reached ChromaDB. Today only `RECEIPT_WORD_LABEL` (and `RECEIPT_PLACE`) sync via the DynamoDB stream -> SQS -> enhanced-compaction pipeline; QA edits from the new section MCP tools (#1092) would silently leave stale `section_label` metadata on the `lines` collection. This PR adds `RECEIPT_SECTION` as a first-class stream entity, mirroring the label path end to end.

### Producer (`receipt_dynamo_stream`)
- SK matcher `"#SECTION#" in sk` -> `RECEIPT_SECTION` (verified: `receipt_section.py` is the only entity whose SK contains `#SECTION#`), parsed with the existing `item_to_receipt_section`.
- Watched fields: `section_type`, `line_ids`, `confidence`, `validation_status`.
- Messages target the **LINES queue only** (`section_label` lives on row metadata) and carry just `(image_id, receipt_id, section_type)` - the consumer recomputes from DynamoDB, so the event image is deliberately not trusted. `section_type` rides along only for within-batch dedup.
- Section **INSERTs** now produce messages (QA creates sections); INSERTs of every other entity type keep their existing dropped behavior via an explicit allowlist (`_INSERT_SYNCED_ENTITY_TYPES`).
- Section **REMOVEs** emit a message even with no field diff (existing REMOVE behavior).

### Shared logic (`receipt_chroma/section_labels.py`)
`sections_to_line_map` (INVALID skipped, higher-confidence section wins a contested line) and a new `row_section_from_map` (row plurality, tie -> unset) moved to a stdlib-only leaf module. The embed path (`embedding/records.py`, `embedding/delta/line_delta.py`) and the new consumer all import the same two functions - the voting logic previously existed as two inline copies and would have become three.

### Consumer (`receipt_chroma/compaction/sections.py`)
`apply_section_updates` runs inside `process_collection_updates`, i.e. inside the same lock-acquire -> snapshot-download -> in-memory update -> snapshot-upload cycle as place/label updates. For each affected receipt it re-reads the current section set (`get_receipt_sections_from_receipt`), recomputes every row's plurality label from `row_line_ids` metadata, and applies metadata-only `collection.update(ids=..., metadatas=...)` (full-metadata replace, preserving all other keys - same mechanism as `_update_row_labels`). Rows whose label is already correct are not rewritten.

### Lambda handler (`infra/.../enhanced_compaction_handler.py`)
Failed section recomputes are collected into `batchItemFailures` for SQS retry exactly like place-update failures (both result types key by `image_id`/`receipt_id`).

### One-off backfill (`receipt_dynamo_stream/backfill.py`)
`publish_section_backfill(receipts=... | dynamo_client=...)` publishes synthetic `RECEIPT_SECTION` recompute messages through the **same** lines SQS queue -> compactor path (no new writer, no new infra). Dev currently has ~419 receipts whose Dynamo sections landed after their rows were embedded; after this deploys, one call queues their recompute, and re-runs are idempotent (correct rows are never rewritten). Receipts are passed explicitly or discovered by paginating `ReceiptSection` rows; publishing is chunked (default 500) so the receipt set is never fully materialized and partial runs are safely resumable. Caveat (accepted): discovery only sees receipts that *currently* own sections - a receipt whose last section was deleted must be passed explicitly to strip stale labels.

### ChromaDB update semantics (verified empirically, was a codex P1)
Chroma 1.x `collection.update(ids, metadatas)` **merges** metadata - omitted keys survive - and a `None` value deletes a key. The consumer therefore sends a delta-only payload (`{"section_label": value-or-None}`); a full-metadata payload with the key omitted (the label path's removal idiom) would silently keep stale labels. A real-ChromaDB (non-mock) test asserts persisted stamp + strip behavior. Note: this same merge semantics means `_update_row_labels` in the label path likely never actually removes stale `label_*` keys - pre-existing, filed as follow-up material, not touched here.

## Race conditions

The five failure modes this design was built around, and the decision for each:

1. **Recompute, don't apply the event.** One section edit changes the correct `section_label` for potentially many visual rows, and the right value depends on *all* of the receipt's sections (plurality + INVALID-skip + confidence tie-break). The consumer re-reads the receipt's full current section set from DynamoDB at process time and recomputes every row, reusing the exact embed-time logic (`sections_to_line_map` + `row_section_from_map`, factored into `section_labels.py`, not forked). Duplicate and out-of-order stream deliveries are therefore idempotent - last processing wins with fresh state - and INSERT/MODIFY/REMOVE all reduce to the same recompute.

2. **Edit during in-flight embed.** If a section event arrives before the receipt's rows exist in Chroma (batch still at OpenAI), `collection.get(...)` returns no ids and the consumer returns a clean 0-update success - no error, no retry loop. The embed itself stamps fresh section state when it lands (PR #1089), so nothing is lost. The DynamoDB query is skipped entirely in this case. A missing `lines` collection (fresh environment) is likewise a warned no-op - but *only* a genuinely-missing collection (`NotFoundError`/`ValueError` from the client wrapper); any other Chroma failure propagates so the batch retries instead of being silently acknowledged.

   The mirror-image race - a **delta whose metadata was captured before the section edit merging after the section event was already processed** - is also closed: the processor passes every delta-merged receipt to `apply_section_updates` (`extra_receipts`), so each merge is followed by a fresh recompute inside the same locked cycle. This also incrementally self-heals pre-existing stale rows as receipts re-embed.

3. **Single writer.** No new Chroma writer is introduced. Section messages flow through the existing stream-processor -> LINES SQS queue -> enhanced-compaction Lambda path, and the recompute executes inside `process_collection_updates` under the same `LockManager` lock and atomic snapshot download/upload as delta merges, place updates, and label updates - so section writes serialize with concurrent delta ingestion by construction. Dual-write to Chroma Cloud comes for free via `apply_collection_updates`.

4. **Storm behavior.** Bulk QA (hundreds of `update_section_status` calls) produces one stream event per write - there is no producer-side batching to reuse (labels don't have one either). The amplification is bounded on the consumer: messages are grouped per `(image_id, receipt_id)`, so N same-receipt events in a batch cost **one** DynamoDB query + one recompute pass + at most one `collection.update`, and the Phase-2 greedy SQS fetch in the handler naturally widens batches during storms. Worst case (events spread across many batches) is one cheap recompute per batch per receipt, and unchanged rows are never rewritten. Within-batch dedup keys sections as `("RECEIPT_SECTION", image_id, receipt_id, section_type)` - namespaced by entity type so a section REMOVE can never suppress a `RECEIPT_PLACE`/`RECEIPT` update for the same receipt (their keys are un-namespaced `(image_id, receipt_id)`); dropping a same-batch MODIFY after a REMOVE of the same section stays correct because the surviving message triggers the same fresh-state recompute.

Two behaviors deliberately kept identical between embed and recompute rather than "improved" on one side: the equal-confidence contested-line rule in `sections_to_line_map` resolves by input order, which is deterministic in practice because both paths read sections from SK-ordered DynamoDB queries - changing it only on the consumer side would create embed/recompute drift, so it stays shared and unchanged.

Additional accepted trade-offs, documented in-code: the DynamoDB section read is now **strongly consistent** (`ConsistentRead=True` on the base-table query in `get_receipt_sections_from_receipt`) so an ack immediately after a section write cannot capture the pre-write state; and producer/consumer Lambdas deploy from the same CI run but not atomically - a section event landing in the minutes-wide window where the new stream processor runs against the old compactor image would be dropped by the consumer's entity-type filter. Sections currently change only via the QA MCP tools, any subsequent edit or delta merge self-heals, and the backfill entry point can force a full recompute after deploy.

5. **Prod exposure on merge.** Merging auto-deploys prod, whose table already contains ReceiptSection rows via the daily dev->prod mirror, so section events start flowing immediately. Safe-by-default: (a) the parser addition can't poison other entity types - `parse_stream_record`/`build_entity_change_message` already isolate per-record failures (unknown SKs return `None`, parse errors are logged + metered and the record is skipped, matching existing behavior verified in `test_parsers_edge_cases`); (b) the consumer no-ops on missing rows/collections (race 2); (c) a failed DynamoDB section read **raises** instead of recomputing from empty state, so a transient outage retries the SQS message rather than wrongly stripping labels; (d) prod rows embedded before section stamping simply gain correct labels on their first section event.

## Testing

- `receipt_dynamo_stream/tests/unit`: 133 passed (19 new, incl. chunked backfill: SK detection + non-shadowing, watched fields, LINES-only targeting, INSERT/MODIFY/REMOVE message building, other-entity INSERTs still dropped).
- `receipt_chroma/tests/unit`: 337 passed, 5 skipped (16 new consumer tests, incl. a real-ChromaDB persistence test for merge/None-delete semantics, extra_receipts delta recompute, and error-propagation: fresh-state recompute, missing-row no-op without a Dynamo call, INVALID demotion strips label, section delete strips label, tie unsets, idempotent no-rewrite, 25-message storm collapses to 1 query, WORDS/missing-collection no-ops, Dynamo failure -> error result, legacy `line_id` fallback; plus dedup-key test). Existing embed-time plurality tests now exercise the shared helper.
- `receipt_chroma/tests/integration`: identical pass/fail set to `origin/main` (pre-existing env-dependent failures only).
- `receipt_dynamo/tests` (section subset): 63 passed, integration-collection errors identical to `origin/main`.
- Handler + end-to-end smoke: producer record -> SQS dict -> `sort_and_deduplicate_messages` -> `process_collection_updates` verified INVALID demotion strips `section_label`; `_collect_failed_message_ids` returns section-failure record ids.
- `infra/chromadb_compaction/tests` cannot run locally (conftest requires a live Pulumi engine; identical failure on `origin/main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SRtFcxkcw1t3nZsVHstZGL
