### PR TITLE
M4 pilot: measured-typography face selection (Wild Fork)

### DIFF
--- a/receipt_agent/receipt_agent/agents/label_evaluator/rendering/receipt_renderer.py
+++ b/receipt_agent/receipt_agent/agents/label_evaluator/rendering/receipt_renderer.py
@@ -54,6 +54,7 @@ from receipt_agent.agents.label_evaluator.rendering.receipt_grid import (
     section_for_labels,
 )
 from receipt_agent.agents.label_evaluator.rendering.receipt_stylemap import (
+    measured_row_style,
     row_style,
 )
 
@@ -203,6 +204,15 @@ class RenderConfig:
     # BINDS for fonts with lower bitmap_cap_ratio (Vons: floor 0.73x cap vs
     # true 0.538x cap -> cells ~35% wide -> truncated item names).
     pitch_ratio: float | None = None
+    # M4 pilot (opt-in): per-ROW typography MEASURED from the real receipt
+    # being mimicked, instead of the stylemap's text rules. ``face_source``
+    # stays "stylemap" by default (production behavior byte-identical);
+    # "measured" consumes ``row_faces`` -- a {normalize_face_key(row_text):
+    # {"face": "regular"|"heavy", "scale": float, "underline": bool}} map
+    # built by glyphstudio.face_select from stylescan measurements. Rows
+    # without a measured entry fall back to the stylemap rules.
+    face_source: str = "stylemap"
+    row_faces: Mapping[str, Any] | None = None
 
 
 def render_receipt(
@@ -280,9 +290,7 @@ def render_receipt(
         # fusing it into the neighbour or clipping it off the paper margin).
         eff_condense = _fit_condense(draw, text, font, box_w, condense)
         # Vertically center the glyph in its box; left-align horizontally.
-        _draw_text(
-            image, draw, (left, top + box_h / 2), text, font, ink, eff_condense
-        )
+        _draw_text(image, draw, (left, top + box_h / 2), text, font, ink, eff_condense)
 
     return image
 
@@ -398,9 +406,7 @@ def _ocr_grid_metrics(
         return None, None
 
     cap_ratio = max(0.65, min(0.95, float(config.ocr_cap_height_ratio)))
-    base_cap = max(
-        6, int(round(sizing.font_px * float(config.bitmap_cap_ratio)))
-    )
+    base_cap = max(6, int(round(sizing.font_px * float(config.bitmap_cap_ratio))))
     measured_cap = int(round(median(heights) * cap_ratio))
     cap_px = max(int(round(base_cap * 0.9)), measured_cap)
     cap_px = min(max(6, int(config.max_font_px)), cap_px)
@@ -490,9 +496,7 @@ def _render_grid(
 
         bitmap_thin = max(0.0, min(0.9, float(config.bitmap_thin or 0.0)))
         bmf = BitmapFont(config.bitmap_font["regular"], thin=bitmap_thin)
-        heavy_path = config.bitmap_font.get(
-            "heavy", config.bitmap_font["regular"]
-        )
+        heavy_path = config.bitmap_font.get("heavy", config.bitmap_font["regular"])
         bmf_heavy = BitmapFont(heavy_path, thin=bitmap_thin)
         cap_ratio = max(0.5, min(1.0, float(config.bitmap_cap_ratio)))
         cap_px = max(6, int(round(sizing.font_px * cap_ratio)))
@@ -505,9 +509,7 @@ def _render_grid(
         advance = bmf.advance(cap_px) * float(config.condense)
         if ocr_advance is not None:
             advance = ocr_advance
-    spec = build_grid_spec(
-        profile, inner_w, inner_h, config, char_advance_px=advance
-    )
+    spec = build_grid_spec(profile, inner_w, inner_h, config, char_advance_px=advance)
     # "1" => 1-bit (no anti-aliasing): glyphs render as hard on/off dots, which
     # is what a thermal/dot-matrix head actually lays down.
     draw.fontmode = "1"
@@ -541,8 +543,7 @@ def _render_grid(
         heading_rules = [(k.upper(), float(v)) for k, v in raw_head.items()]
     else:
         heading_rules = [
-            (str(h).upper(), float(config.heading_scale or 1.0))
-            for h in raw_head
+            (str(h).upper(), float(config.heading_scale or 1.0)) for h in raw_head
         ]
     # The big bottom item-count date line inherits its heading phrase's scale
     # (Costco's "ITEMS SOLD:"); the anchor phrase comes from the merchant profile.
@@ -675,9 +676,7 @@ def _render_grid(
             if is_total_row or is_amount_date:
                 dash_after_rows.add(k)
             for phrase in config.dash_around_phrases or ():
-                if t.startswith(phrase.upper()) and any(
-                    ch.isdigit() for ch in t
-                ):
+                if t.startswith(phrase.upper()) and any(ch.isdigit() for ch in t):
                     dash_after_rows.add(k)
                     if k > 0:
                         dash_after_rows.add(k - 1)
@@ -702,9 +701,7 @@ def _render_grid(
         # heavy + enlarged; the heavy face is NOT applied to the whole TOTALS zone
         # (real Costco totals are body weight -- only headings, the reverse-video
         # total, and the bottom block stand out).
-        hscale = next(
-            (sc for pat, sc in heading_rules if pat in row_text), None
-        )
+        hscale = next((sc for pat, sc in heading_rules if pat in row_text), None)
         # Bottom date line: the big date right after "Items Sold:" (distinct from
         # the reverse-video date after "TOTAL NUMBER OF ITEMS SOLD").
         if (
@@ -737,10 +734,16 @@ def _render_grid(
         # Measured stylemap pass (no-op when config.stylemap is None): size
         # scale multiplies the row cap; bold double-strikes; underline draws
         # a rule under the row. Headings keep their own treatment.
+        # M4 opt-in (face_source="measured"): a per-row style measured from
+        # the real receipt overrides the text rules for the rows it covers;
+        # uncovered rows keep the stylemap fallback.
         sm_style = None
-        if config.stylemap is not None and not is_heading:
-            sm_style = row_style(config.stylemap, row_text, seed=str(baseline))
-            if sm_style["scale"] != 1.0:
+        if not is_heading:
+            if config.face_source == "measured" and config.row_faces:
+                sm_style = measured_row_style(config.row_faces, row_text)
+            if sm_style is None and config.stylemap is not None:
+                sm_style = row_style(config.stylemap, row_text, seed=str(baseline))
+            if sm_style is not None and sm_style["scale"] != 1.0:
                 sc = sc * sm_style["scale"]
         if _is_asterisk_rule(row_text):
             n = int(content_cw / spec.cell_w)
@@ -760,9 +763,7 @@ def _render_grid(
                 bitmap_thin=config.bitmap_thin,
             )
             continue
-        sm_extra = bool(
-            sm_style and (sm_style["bold"] or sm_style["underline"])
-        )
+        sm_extra = bool(sm_style and (sm_style["bold"] or sm_style["underline"]))
         if sc == 1.0 and not fpath and not sm_extra:
             run = _run_layout(line, center_to)
             if run is not None:
@@ -821,9 +822,7 @@ def _render_grid(
                 row_adv = bf_row.advance(row_cap) * float(config.condense)
             else:
                 row_cap = None
-                row_adv = glyph_advance(draw, row_font) * float(
-                    config.condense
-                )
+                row_adv = glyph_advance(draw, row_font) * float(config.condense)
             row_spec = GridSpec(
                 cell_w=row_adv,
                 cell_h=spec.cell_h,
@@ -835,21 +834,13 @@ def _render_grid(
         row_spec, row_font, row_cap = cached
         # Lane only applies when the row shares the base cell grid (scale 1.0).
         lane = amount_lane if sc == 1.0 else None
-        cp = (
-            row_cap
-            if row_cap
-            else (int(round(cap_px * sc)) if cap_px else None)
-        )
+        cp = row_cap if row_cap else (int(round(cap_px * sc)) if cap_px else None)
         sm_bold = bool(sm_style and sm_style["bold"])
         sm_underline = bool(sm_style and sm_style["underline"])
         # A genuinely-compiled heavy face beats a 1px double-strike; fall back
         # to double-strike only when the profile's heavy is the regular file.
         bfp = config.bitmap_font or {}
-        if (
-            sm_bold
-            and bmf_heavy is not None
-            and bfp.get("heavy") != bfp.get("regular")
-        ):
+        if sm_bold and bmf_heavy is not None and bfp.get("heavy") != bfp.get("regular"):
             bf_row = bmf_heavy
             sm_bold = False
         run = _run_layout(line, center_to)
@@ -905,9 +896,7 @@ def _render_grid(
             ul_right = int(round(max(w.right for w in line)))
             ul_h = max(1, int(round((cp or spec.font_px) * 0.07)))
             ul_y = int(round(baseline + max(2, ul_h)))
-            draw.rectangle(
-                [ul_left, ul_y, ul_right, ul_y + ul_h - 1], fill=line[0].ink
-            )
+            draw.rectangle([ul_left, ul_y, ul_right, ul_y + ul_h - 1], fill=line[0].ink)
 
     # Dashed section rules, printed as a run of real ``-`` glyphs in the reserved
     # gap below each anchor row. Use the merchant's bitmap face when it carries a
@@ -981,9 +970,7 @@ def save_receipt_png(
     coord_max: float | None = None,
 ) -> str:
     """Render ``receipt`` and write it to ``path`` (PNG). Returns ``path``."""
-    image = render_receipt(
-        receipt, profile=profile, config=config, coord_max=coord_max
-    )
+    image = render_receipt(receipt, profile=profile, config=config, coord_max=coord_max)
     os.makedirs(os.path.dirname(os.path.abspath(path)), exist_ok=True)
     image.save(path, format="PNG")
     return path
@@ -1159,9 +1146,7 @@ def _draw_text(
     image.paste(layer, (int(left), paste_y), layer)
 
 
-def _ink_for(
-    word: Mapping[str, Any], config: RenderConfig
-) -> tuple[int, int, int]:
+def _ink_for(word: Mapping[str, Any], config: RenderConfig) -> tuple[int, int, int]:
     if not config.color_by_label:
         custom = getattr(config, "ink", None)
         if custom is not None:

--- a/receipt_agent/receipt_agent/agents/label_evaluator/rendering/receipt_renderer.py
+++ b/receipt_agent/receipt_agent/agents/label_evaluator/rendering/receipt_renderer.py
@@ -290,7 +290,9 @@ def render_receipt(
         # fusing it into the neighbour or clipping it off the paper margin).
         eff_condense = _fit_condense(draw, text, font, box_w, condense)
         # Vertically center the glyph in its box; left-align horizontally.
-        _draw_text(image, draw, (left, top + box_h / 2), text, font, ink, eff_condense)
+        _draw_text(
+            image, draw, (left, top + box_h / 2), text, font, ink, eff_condense
+        )
 
     return image
 
@@ -406,7 +408,9 @@ def _ocr_grid_metrics(
         return None, None
 
     cap_ratio = max(0.65, min(0.95, float(config.ocr_cap_height_ratio)))
-    base_cap = max(6, int(round(sizing.font_px * float(config.bitmap_cap_ratio))))
+    base_cap = max(
+        6, int(round(sizing.font_px * float(config.bitmap_cap_ratio)))
+    )
     measured_cap = int(round(median(heights) * cap_ratio))
     cap_px = max(int(round(base_cap * 0.9)), measured_cap)
     cap_px = min(max(6, int(config.max_font_px)), cap_px)
@@ -496,7 +500,9 @@ def _render_grid(
 
         bitmap_thin = max(0.0, min(0.9, float(config.bitmap_thin or 0.0)))
         bmf = BitmapFont(config.bitmap_font["regular"], thin=bitmap_thin)
-        heavy_path = config.bitmap_font.get("heavy", config.bitmap_font["regular"])
+        heavy_path = config.bitmap_font.get(
+            "heavy", config.bitmap_font["regular"]
+        )
         bmf_heavy = BitmapFont(heavy_path, thin=bitmap_thin)
         cap_ratio = max(0.5, min(1.0, float(config.bitmap_cap_ratio)))
         cap_px = max(6, int(round(sizing.font_px * cap_ratio)))
@@ -509,7 +515,9 @@ def _render_grid(
         advance = bmf.advance(cap_px) * float(config.condense)
         if ocr_advance is not None:
             advance = ocr_advance
-    spec = build_grid_spec(profile, inner_w, inner_h, config, char_advance_px=advance)
+    spec = build_grid_spec(
+        profile, inner_w, inner_h, config, char_advance_px=advance
+    )
     # "1" => 1-bit (no anti-aliasing): glyphs render as hard on/off dots, which
     # is what a thermal/dot-matrix head actually lays down.
     draw.fontmode = "1"
@@ -543,7 +551,8 @@ def _render_grid(
         heading_rules = [(k.upper(), float(v)) for k, v in raw_head.items()]
     else:
         heading_rules = [
-            (str(h).upper(), float(config.heading_scale or 1.0)) for h in raw_head
+            (str(h).upper(), float(config.heading_scale or 1.0))
+            for h in raw_head
         ]
     # The big bottom item-count date line inherits its heading phrase's scale
     # (Costco's "ITEMS SOLD:"); the anchor phrase comes from the merchant profile.
@@ -676,7 +685,9 @@ def _render_grid(
             if is_total_row or is_amount_date:
                 dash_after_rows.add(k)
             for phrase in config.dash_around_phrases or ():
-                if t.startswith(phrase.upper()) and any(ch.isdigit() for ch in t):
+                if t.startswith(phrase.upper()) and any(
+                    ch.isdigit() for ch in t
+                ):
                     dash_after_rows.add(k)
                     if k > 0:
                         dash_after_rows.add(k - 1)
@@ -701,7 +712,9 @@ def _render_grid(
         # heavy + enlarged; the heavy face is NOT applied to the whole TOTALS zone
         # (real Costco totals are body weight -- only headings, the reverse-video
         # total, and the bottom block stand out).
-        hscale = next((sc for pat, sc in heading_rules if pat in row_text), None)
+        hscale = next(
+            (sc for pat, sc in heading_rules if pat in row_text), None
+        )
         # Bottom date line: the big date right after "Items Sold:" (distinct from
         # the reverse-video date after "TOTAL NUMBER OF ITEMS SOLD").
         if (
@@ -742,7 +755,9 @@ def _render_grid(
             if config.face_source == "measured" and config.row_faces:
                 sm_style = measured_row_style(config.row_faces, row_text)
             if sm_style is None and config.stylemap is not None:
-                sm_style = row_style(config.stylemap, row_text, seed=str(baseline))
+                sm_style = row_style(
+                    config.stylemap, row_text, seed=str(baseline)
+                )
             if sm_style is not None and sm_style["scale"] != 1.0:
                 sc = sc * sm_style["scale"]
         if _is_asterisk_rule(row_text):
@@ -763,7 +778,9 @@ def _render_grid(
                 bitmap_thin=config.bitmap_thin,
             )
             continue
-        sm_extra = bool(sm_style and (sm_style["bold"] or sm_style["underline"]))
+        sm_extra = bool(
+            sm_style and (sm_style["bold"] or sm_style["underline"])
+        )
         if sc == 1.0 and not fpath and not sm_extra:
             run = _run_layout(line, center_to)
             if run is not None:
@@ -822,7 +839,9 @@ def _render_grid(
                 row_adv = bf_row.advance(row_cap) * float(config.condense)
             else:
                 row_cap = None
-                row_adv = glyph_advance(draw, row_font) * float(config.condense)
+                row_adv = glyph_advance(draw, row_font) * float(
+                    config.condense
+                )
             row_spec = GridSpec(
                 cell_w=row_adv,
                 cell_h=spec.cell_h,
@@ -834,13 +853,21 @@ def _render_grid(
         row_spec, row_font, row_cap = cached
         # Lane only applies when the row shares the base cell grid (scale 1.0).
         lane = amount_lane if sc == 1.0 else None
-        cp = row_cap if row_cap else (int(round(cap_px * sc)) if cap_px else None)
+        cp = (
+            row_cap
+            if row_cap
+            else (int(round(cap_px * sc)) if cap_px else None)
+        )
         sm_bold = bool(sm_style and sm_style["bold"])
         sm_underline = bool(sm_style and sm_style["underline"])
         # A genuinely-compiled heavy face beats a 1px double-strike; fall back
         # to double-strike only when the profile's heavy is the regular file.
         bfp = config.bitmap_font or {}
-        if sm_bold and bmf_heavy is not None and bfp.get("heavy") != bfp.get("regular"):
+        if (
+            sm_bold
+            and bmf_heavy is not None
+            and bfp.get("heavy") != bfp.get("regular")
+        ):
             bf_row = bmf_heavy
             sm_bold = False
         run = _run_layout(line, center_to)
@@ -896,7 +923,9 @@ def _render_grid(
             ul_right = int(round(max(w.right for w in line)))
             ul_h = max(1, int(round((cp or spec.font_px) * 0.07)))
             ul_y = int(round(baseline + max(2, ul_h)))
-            draw.rectangle([ul_left, ul_y, ul_right, ul_y + ul_h - 1], fill=line[0].ink)
+            draw.rectangle(
+                [ul_left, ul_y, ul_right, ul_y + ul_h - 1], fill=line[0].ink
+            )
 
     # Dashed section rules, printed as a run of real ``-`` glyphs in the reserved
     # gap below each anchor row. Use the merchant's bitmap face when it carries a
@@ -970,7 +999,9 @@ def save_receipt_png(
     coord_max: float | None = None,
 ) -> str:
     """Render ``receipt`` and write it to ``path`` (PNG). Returns ``path``."""
-    image = render_receipt(receipt, profile=profile, config=config, coord_max=coord_max)
+    image = render_receipt(
+        receipt, profile=profile, config=config, coord_max=coord_max
+    )
     os.makedirs(os.path.dirname(os.path.abspath(path)), exist_ok=True)
     image.save(path, format="PNG")
     return path
@@ -1146,7 +1177,9 @@ def _draw_text(
     image.paste(layer, (int(left), paste_y), layer)
 
 
-def _ink_for(word: Mapping[str, Any], config: RenderConfig) -> tuple[int, int, int]:
+def _ink_for(
+    word: Mapping[str, Any], config: RenderConfig
+) -> tuple[int, int, int]:
     if not config.color_by_label:
         custom = getattr(config, "ink", None)
         if custom is not None:

--- a/receipt_agent/receipt_agent/agents/label_evaluator/rendering/receipt_stylemap.py
+++ b/receipt_agent/receipt_agent/agents/label_evaluator/rendering/receipt_stylemap.py
@@ -93,8 +93,7 @@ _RULES: list[tuple[str, re.Pattern]] = [
     (
         "transaction",
         re.compile(
-            r"Ticket\s?#|Station:|Sales Rep|User:|"
-            r"^\d{1,2}/\d{1,2}/\d{4}",
+            r"Ticket\s?#|Station:|Sales Rep|User:|" r"^\d{1,2}/\d{1,2}/\d{4}",
             re.I,
         ),
     ),
@@ -160,6 +159,39 @@ def classify_row(text: str, merchant: str | None = None) -> str:
         if rx.search(compact):
             return name
     return "other"
+
+
+def normalize_face_key(text: str) -> str:
+    """Canonical row key shared by the renderer and the M4 face selector.
+
+    Uppercase, whitespace-collapsed, truncated to 60 chars (stylescan stores
+    measured line text truncated to 60). Both sides MUST use this exact
+    function or measured rows silently miss and fall back to text rules.
+    """
+    return " ".join(str(text).upper().split())[:60]
+
+
+def measured_row_style(
+    row_faces: Mapping[str, Any],
+    row_text: str,
+) -> dict[str, Any] | None:
+    """Resolve one row's MEASURED style from an M4 ``row_faces`` map.
+
+    ``row_faces`` maps :func:`normalize_face_key` keys to entries built by
+    ``glyphstudio.face_select`` from stylescan measurements of the real
+    receipt being mimicked: ``{"face": "regular"|"heavy", "scale": float,
+    "underline": bool}``. Returns the same shape as :func:`row_style`
+    (``{"scale", "bold", "underline"}``) or ``None`` when the row has no
+    measurement (caller falls back to the stylemap text rules).
+    """
+    entry = row_faces.get(normalize_face_key(row_text))
+    if entry is None:
+        return None
+    return {
+        "scale": float(entry.get("scale", 1.0)),
+        "bold": str(entry.get("face", "regular")).lower() == "heavy",
+        "underline": bool(entry.get("underline", False)),
+    }
 
 
 def row_style(

--- a/receipt_agent/receipt_agent/agents/label_evaluator/rendering/receipt_stylemap.py
+++ b/receipt_agent/receipt_agent/agents/label_evaluator/rendering/receipt_stylemap.py
@@ -16,6 +16,7 @@ barcode captions are smaller/lighter; everything else is single-weight.
 from __future__ import annotations
 
 import hashlib
+import math
 import re
 from typing import Any, Mapping
 
@@ -93,7 +94,8 @@ _RULES: list[tuple[str, re.Pattern]] = [
     (
         "transaction",
         re.compile(
-            r"Ticket\s?#|Station:|Sales Rep|User:|" r"^\d{1,2}/\d{1,2}/\d{4}",
+            r"Ticket\s?#|Station:|Sales Rep|User:|"
+            r"^\d{1,2}/\d{1,2}/\d{4}",
             re.I,
         ),
     ),
@@ -171,6 +173,17 @@ def normalize_face_key(text: str) -> str:
     return " ".join(str(text).upper().split())[:60]
 
 
+def _safe_scale(value: Any) -> float:
+    """row_faces is an external API boundary: clamp scale to sane, finite."""
+    try:
+        scale = float(value)
+    except (TypeError, ValueError):
+        return 1.0
+    if not math.isfinite(scale):
+        return 1.0
+    return max(0.25, min(4.0, scale))
+
+
 def measured_row_style(
     row_faces: Mapping[str, Any],
     row_text: str,
@@ -188,7 +201,7 @@ def measured_row_style(
     if entry is None:
         return None
     return {
-        "scale": float(entry.get("scale", 1.0)),
+        "scale": _safe_scale(entry.get("scale", 1.0)),
         "bold": str(entry.get("face", "regular")).lower() == "heavy",
         "underline": bool(entry.get("underline", False)),
     }

--- a/receipt_agent/tests/test_receipt_stylemap.py
+++ b/receipt_agent/tests/test_receipt_stylemap.py
@@ -1,13 +1,13 @@
 from receipt_agent.agents.label_evaluator.rendering.receipt_stylemap import (
     classify_row,
+    measured_row_style,
+    normalize_face_key,
     row_style,
 )
 
 
 def test_innout_row_classification_sections():
-    assert (
-        classify_row("IN-N-OUT WESTLAKE VILLAGE", "innout") == "store_header"
-    )
+    assert classify_row("IN-N-OUT WESTLAKE VILLAGE", "innout") == "store_header"
     assert classify_row("Cashier: ORDERTAKER 1", "innout") == "transaction"
     assert classify_row("Amount Due $27.71", "innout") == "total_line"
     assert classify_row("AUTH AMT: $27.71", "innout") == "total_line"
@@ -57,3 +57,37 @@ def test_target_department_headers_use_section_header_style():
         "bold": True,
         "underline": False,
     }
+
+
+def test_normalize_face_key_collapses_case_space_and_truncates():
+    assert normalize_face_key("  Thousand  Oaks CA ") == "THOUSAND OAKS CA"
+    assert len(normalize_face_key("x" * 90)) == 60
+
+
+def test_measured_row_style_hit_maps_face_to_bold():
+    row_faces = {
+        normalize_face_key("Thousand Oaks CA"): {
+            "face": "regular",
+            "scale": 1.7,
+            "underline": False,
+        },
+        normalize_face_key("BALANCE DUE 12.34"): {
+            "face": "heavy",
+            "scale": 1.0,
+            "underline": True,
+        },
+    }
+    assert measured_row_style(row_faces, "THOUSAND OAKS CA") == {
+        "scale": 1.7,
+        "bold": False,
+        "underline": False,
+    }
+    assert measured_row_style(row_faces, "BALANCE DUE 12.34") == {
+        "scale": 1.0,
+        "bold": True,
+        "underline": True,
+    }
+
+
+def test_measured_row_style_miss_returns_none_for_stylemap_fallback():
+    assert measured_row_style({}, "ANY ROW") is None

--- a/receipt_agent/tests/test_receipt_stylemap.py
+++ b/receipt_agent/tests/test_receipt_stylemap.py
@@ -91,3 +91,18 @@ def test_measured_row_style_hit_maps_face_to_bold():
 
 def test_measured_row_style_miss_returns_none_for_stylemap_fallback():
     assert measured_row_style({}, "ANY ROW") is None
+
+
+def test_measured_row_style_clamps_malformed_scale():
+    for bad, expect in (
+        (float("nan"), 1.0),
+        (float("inf"), 1.0),
+        (-1.0, 0.25),
+        (99.0, 4.0),
+        ("junk", 1.0),
+    ):
+        style = measured_row_style(
+            {normalize_face_key("ROW"): {"face": "regular", "scale": bad}},
+            "ROW",
+        )
+        assert style["scale"] == expect

--- a/scripts/merchant_profiles.json
+++ b/scripts/merchant_profiles.json
@@ -350,7 +350,9 @@
         "ocr_font_sizing": true,
         "ocr_cap_height_ratio": 0.79,
         "stylemap": "wildfork.stylemap.json",
-        "pitch_ratio": 0.538
+        "pitch_ratio": 0.538,
+        "_face_source_comment": "M4 pilot flag. 'stylemap' (default, no-op) = text-rule faces; 'measured' consumes a per-row row_faces map built by glyphstudio.face_select from stylescan measurements of the mimicked receipt.",
+        "face_source": "stylemap"
       },
       "logo_anchor": {
         "phrases": [

--- a/scripts/render_synthetic_receipts.py
+++ b/scripts/render_synthetic_receipts.py
@@ -102,19 +102,13 @@ def _resolve_tag(tag, id_to_label: dict[int, str]):
     return None
 
 
-def _synthetic_receipt_dict(
-    example: dict, id_to_label: dict[int, str]
-) -> dict:
+def _synthetic_receipt_dict(example: dict, id_to_label: dict[int, str]) -> dict:
     words = []
     tokens = example.get("tokens") or []
     bboxes = example.get("bboxes") or []
     tags = example.get("ner_tags") or []
     for index, (token, bbox) in enumerate(zip(tokens, bboxes)):
-        label = (
-            _resolve_tag(tags[index], id_to_label)
-            if index < len(tags)
-            else None
-        )
+        label = _resolve_tag(tags[index], id_to_label) if index < len(tags) else None
         # Keep the raw (possibly BIO-prefixed) label; the renderer normalizes it.
         words.append(
             {
@@ -215,9 +209,7 @@ def _is_price_token(token: str) -> bool:
 def _cached_line_receipt_dict(example: dict) -> dict:
     hp = _header_profile_for(example.get("merchant_name"))
     lines = []
-    source_lines = _order_cached_lines(
-        _drop_duplicate_header_lines(example, hp), hp
-    )
+    source_lines = _order_cached_lines(_drop_duplicate_header_lines(example, hp), hp)
     for index, line in enumerate(source_lines):
         text = str(line.get("text") or "").strip()
         if not text:
@@ -225,20 +217,14 @@ def _cached_line_receipt_dict(example: dict) -> dict:
         words = text.split()
         y = float(line.get("y") or (940 - index * _LINE_ROW_PITCH))
         labels = list(line.get("labels") or [])
-        is_logo_line = any(
-            _label_name(label) == "MERCHANT_NAME" for label in labels
-        )
+        is_logo_line = any(_label_name(label) == "MERCHANT_NAME" for label in labels)
         # Cached line-only examples do not carry OCR word widths, so give the
         # renderer enough horizontal room to avoid shrinking every line to the
         # minimum font size.
-        width_units = [
-            max(18.0, len(word) * _LINE_CHAR_WIDTH) for word in words
-        ]
+        width_units = [max(18.0, len(word) * _LINE_CHAR_WIDTH) for word in words]
         if is_logo_line and len(words) == 1:
             width_units = [max(width_units[0], _LINE_LOGO_MIN_WIDTH)]
-        total_width = (
-            sum(width_units) + max(0, len(words) - 1) * _LINE_WORD_GAP
-        )
+        total_width = sum(width_units) + max(0, len(words) - 1) * _LINE_WORD_GAP
         if total_width > _LINE_MAX_WIDTH:
             factor = _LINE_MAX_WIDTH / total_width
             width_units = [width * factor for width in width_units]
@@ -315,10 +301,7 @@ def _order_cached_lines(lines: list[dict], hp: dict) -> list[dict]:
     if not (
         hp["reflow"]
         and hp["brand"]
-        and any(
-            hp["brand"] in _compact_text(line.get("text") or "")
-            for line in lines
-        )
+        and any(hp["brand"] in _compact_text(line.get("text") or "") for line in lines)
     ):
         return lines
 
@@ -329,9 +312,7 @@ def _order_cached_lines(lines: list[dict], hp: dict) -> list[dict]:
         "footer": [],
     }
     for line in lines:
-        sections[
-            _text_section(_compact_text(line.get("text") or ""), hp)
-        ].append(line)
+        sections[_text_section(_compact_text(line.get("text") or ""), hp)].append(line)
 
     ordered = []
     for name in ("header", "body", "payment", "footer"):
@@ -339,9 +320,7 @@ def _order_cached_lines(lines: list[dict], hp: dict) -> list[dict]:
             ordered.append({"text": "", "y": None, "labels": []})
         ordered.extend(sections[name])
 
-    real_count = sum(
-        1 for line in ordered if str(line.get("text") or "").strip()
-    )
+    real_count = sum(1 for line in ordered if str(line.get("text") or "").strip())
     break_count = len(ordered) - real_count
     section_gap = 18.0 if real_count < 70 else 10.0
     spacing = (930.0 - break_count * section_gap) / max(1, real_count - 1)
@@ -433,9 +412,7 @@ def _repair_missing_top_header_lines(receipt: dict) -> dict:
         return receipt
 
     top_end = first_header
-    while (
-        top_end + 1 < len(line_infos) and line_infos[top_end + 1]["is_header"]
-    ):
+    while top_end + 1 < len(line_infos) and line_infos[top_end + 1]["is_header"]:
         top_end += 1
     top_block = line_infos[first_header : top_end + 1]
     top_texts = {info["text"] for info in top_block}
@@ -453,9 +430,7 @@ def _repair_missing_top_header_lines(receipt: dict) -> dict:
     for marker in missing:
         source_index = next(
             index
-            for index, info in enumerate(
-                line_infos[top_end + 1 :], top_end + 1
-            )
+            for index, info in enumerate(line_infos[top_end + 1 :], top_end + 1)
             if info["text"] == marker
         )
         source = line_infos[source_index]
@@ -508,11 +483,7 @@ def _repair_missing_top_header_lines(receipt: dict) -> dict:
                 [word["bbox"] for word in anchor["words"] if word.get("bbox")]
             )
             target_anchor_box = _union_bbox(
-                [
-                    word["bbox"]
-                    for word in target_anchor["words"]
-                    if word.get("bbox")
-                ]
+                [word["bbox"] for word in target_anchor["words"] if word.get("bbox")]
             )
             if source_anchor_box is not None and target_anchor_box is not None:
                 source_anchor_span = max(
@@ -626,16 +597,10 @@ def _top_band_logo_placement(
 ) -> tuple[dict, list[float]]:
     band = max(0.0, min(350.0, float(anchor_cfg.get("top_band", 0.0))))
     words = [
-        word
-        for line in _receipt_lines(receipt)
-        for word in line
-        if word.get("bbox")
+        word for line in _receipt_lines(receipt) for word in line if word.get("bbox")
     ]
     top_y = max(
-        (
-            max(float(word["bbox"][1]), float(word["bbox"][3]))
-            for word in words
-        ),
+        (max(float(word["bbox"][1]), float(word["bbox"][3])) for word in words),
         default=0.0,
     )
     required_room = band * float(anchor_cfg.get("reserve_threshold", 0.70))
@@ -656,9 +621,7 @@ def _top_band_logo_placement(
     band_h = max(1.0, band_top - band_bottom)
     box_w = coord_max * width_frac
     aspect = logo.width / max(1, logo.height)
-    h_from_width = (
-        (box_w / coord_max * inner_w / aspect) / max(1, inner_h) * coord_max
-    )
+    h_from_width = (box_w / coord_max * inner_w / aspect) / max(1, inner_h) * coord_max
     box_h = min(band_h, h_from_width)
     cx = coord_max / 2.0
     cy = (band_top + band_bottom) / 2.0
@@ -723,25 +686,16 @@ def _line_receipt_from_cached_token_words(
             y -= section_gap
             continue
         labels = sorted(
-            {
-                label
-                for word in line
-                for label in (word.get("labels") or [])
-                if label
-            }
+            {label for word in line for label in (word.get("labels") or []) if label}
         )
         text = _line_text_from_cached_words(line)
         if text:
             lines.append({"y": y, "text": text, "labels": labels})
             y -= spacing
-    return _cached_line_receipt_dict(
-        {"lines": lines, "merchant_name": merchant}
-    )
+    return _cached_line_receipt_dict({"lines": lines, "merchant_name": merchant})
 
 
-def _ordered_token_lines(
-    words: list[dict], hp: dict
-) -> list[tuple[list[dict], bool]]:
+def _ordered_token_lines(words: list[dict], hp: dict) -> list[tuple[list[dict], bool]]:
     lines = _group_cached_words_by_line(words)
     if not lines:
         return []
@@ -867,9 +821,7 @@ def _text_section(text: str, hp: dict) -> str:
         )
     ):
         return "payment"
-    if text.startswith(
-        ("AID", "TVR", "IAD", "TSI", "ARC", "TC", "MID", "SEQ")
-    ):
+    if text.startswith(("AID", "TVR", "IAD", "TSI", "ARC", "TC", "MID", "SEQ")):
         return "payment"
     return "body"
 
@@ -956,9 +908,7 @@ def _composite_paper_texture(
         rgb *= lum[:, :, None]
 
     # Fine grain (neutral: same delta on R/G/B).
-    grain = rng.normal(0.0, 4.5 * s, size=(height, width, 1)).astype(
-        np.float32
-    )
+    grain = rng.normal(0.0, 4.5 * s, size=(height, width, 1)).astype(np.float32)
     rgb += grain
 
     # Edge vignette: darker toward the paper edges/corners.
@@ -975,9 +925,7 @@ def _composite_paper_texture(
         bar_w, soft = 0.06, 0.025
         xn = np.linspace(0.0, 1.0, width, dtype=np.float32)
         d = np.minimum(xn, 1.0 - xn)  # 0 at edges -> 0.5 center
-        ew = np.clip((bar_w + soft - d) / soft, 0.0, 1.0)[
-            None, :
-        ]  # flat 1 in bar
+        ew = np.clip((bar_w + soft - d) / soft, 0.0, 1.0)[None, :]  # flat 1 in bar
         rgb[..., 0] -= 24.0 * s * ew
         rgb[..., 1] -= 2.0 * s * ew
         rgb[..., 2] -= 4.0 * s * ew
@@ -989,9 +937,7 @@ def _composite_paper_texture(
     if s > 0:
         angle = float(rng.uniform(-0.8, 0.8)) * min(s, 1.5)
         fill = tuple(int(v) for v in np.asarray(image.convert("RGB"))[0, 0])
-        textured = textured.rotate(
-            angle, resample=Image.BICUBIC, fillcolor=fill
-        )
+        textured = textured.rotate(angle, resample=Image.BICUBIC, fillcolor=fill)
 
     if source_mode == "RGB":
         return textured
@@ -1029,12 +975,8 @@ _VENDORED_FONTS_DIR = os.path.join(
     "rendering",
     "fonts",
 )
-_VT323 = os.path.join(
-    _VENDORED_FONTS_DIR, "VT323-Regular.ttf"
-)  # OFL pixel/dot-matrix
-_B612 = os.path.join(
-    _VENDORED_FONTS_DIR, "B612Mono-Regular.ttf"
-)  # OFL clean sans mono
+_VT323 = os.path.join(_VENDORED_FONTS_DIR, "VT323-Regular.ttf")  # OFL pixel/dot-matrix
+_B612 = os.path.join(_VENDORED_FONTS_DIR, "B612Mono-Regular.ttf")  # OFL clean sans mono
 _FONT_TOKENS = {"PTMONO": _PTMONO, "VT323": _VT323, "B612": _B612}
 # Glyph atlases + logo PNGs (bitMatrix-C2 chart derived / logo_master medians),
 # kept local (paid-font derived). Relocate via $BITMATRIX_DIR.
@@ -1132,7 +1074,6 @@ def _ensure_font_cached(filename: str, merchant: str, face: str) -> str:
         import hashlib
 
         import boto3
-
         from receipt_dynamo import DynamoClient
 
         table = os.environ.get("DYNAMODB_TABLE_NAME", "ReceiptsTable-dc5be22")
@@ -1203,8 +1144,7 @@ def merchant_typography(merchant: str | None) -> dict:
                 cfg["font_path"] = path
         elif key == "bitmap_font":
             cfg["bitmap_font"] = {
-                k: _ensure_font_cached(v, merchant, face=k)
-                for k, v in val.items()
+                k: _ensure_font_cached(v, merchant, face=k) for k, v in val.items()
             }
         elif key == "stylemap":
             # Measured per-section style rules (Glyph Studio fleet); the JSON
@@ -1255,9 +1195,7 @@ def _cached_build(kind, build, table, merchant, region, max_receipts, refresh):
     return obj
 
 
-def cached_glyph_atlas(
-    table, merchant, *, region, max_receipts=8, refresh=False
-):
+def cached_glyph_atlas(table, merchant, *, region, max_receipts=8, refresh=False):
     """Disk-cached :func:`build_glyph_atlas_from_dynamo` (per merchant)."""
     return _cached_build(
         "atlas",
@@ -1270,9 +1208,7 @@ def cached_glyph_atlas(
     )
 
 
-def cached_font_profile(
-    table, merchant, *, region, max_receipts=12, refresh=False
-):
+def cached_font_profile(table, merchant, *, region, max_receipts=12, refresh=False):
     """Disk-cached :func:`build_merchant_font_profile_from_dynamo` (per merchant)."""
     return _cached_build(
         "profile",
@@ -1333,9 +1269,8 @@ def resolve_bitmap_thin(
     from statistics import median
 
     from ink_calibration import derive_bitmap_thin  # noqa: E402
-    from receipt_line_scorecard import _load_words_and_real  # noqa: E402
-
     from receipt_dynamo.data.dynamo_client import DynamoClient  # noqa: E402
+    from receipt_line_scorecard import _load_words_and_real  # noqa: E402
 
     client = DynamoClient(table_name=table, region=region)
     places, _ = client.get_receipt_places_by_merchant(merchant)
@@ -1431,16 +1366,8 @@ def _content_texture_seed(receipt: dict) -> int:
         # ints and strings are not mutually orderable; rank ints before strings
         # so the sort is total and deterministic across mixed id types.
         return (
-            (
-                (0, line_id, "")
-                if isinstance(line_id, int)
-                else (1, 0, str(line_id))
-            ),
-            (
-                (0, word_id, "")
-                if isinstance(word_id, int)
-                else (1, 0, str(word_id))
-            ),
+            ((0, line_id, "") if isinstance(line_id, int) else (1, 0, str(line_id))),
+            ((0, word_id, "") if isinstance(word_id, int) else (1, 0, str(word_id))),
         )
 
     for word in sorted(words, key=_key):
@@ -1486,6 +1413,8 @@ def _render_cached_hybrid(
     ocr_font_sizing: bool = False,
     ocr_cap_height_ratio: float = 0.72,
     ink: tuple[int, int, int] | list[int] | None = None,
+    face_source: str = "stylemap",
+    row_faces: dict | None = None,
 ) -> str:
     receipt = _repair_missing_top_header_lines(receipt)
     # Render-time content repair (EMV/auth strings, totals) on the synthetic
@@ -1523,6 +1452,10 @@ def _render_cached_hybrid(
         ocr_font_sizing=ocr_font_sizing,
         ocr_cap_height_ratio=ocr_cap_height_ratio,
         ink=ink,
+        # M4 pilot: measured per-row typography. Defaults are a no-op; the
+        # profile flag face_source="stylemap" keeps production byte-identical.
+        face_source=face_source,
+        row_faces=row_faces,
         # Grid typography (fixed character grid, one body size per receipt, hard
         # non-anti-aliased glyphs on a shared baseline). The merchant profile
         # geometry is the realism control; min/max_font_px are only sanity clamps.
@@ -1564,10 +1497,7 @@ def _render_cached_hybrid(
         # Merchants whose wordmark is a pure graphic (no MERCHANT_NAME OCR text,
         # e.g. The Home Depot) anchor the logo off a configured slogan phrase.
         anchor_cfg = (
-            get_merchant_profile(receipt.get("merchant_name")).get(
-                "logo_anchor"
-            )
-            or {}
+            get_merchant_profile(receipt.get("merchant_name")).get("logo_anchor") or {}
         )
         placed = None
         top_band_placed = False
@@ -1605,17 +1535,11 @@ def _render_cached_hybrid(
                     wordmark = _logo_wordmark_words(receipt)
                     if wordmark:
                         wordmark_words, logo_bbox = wordmark
-                        if get_merchant_profile(
-                            receipt.get("merchant_name")
-                        ).get("logo_reserve_subtitle") and len(
-                            wordmark_words
-                        ) == len(
-                            logo_line
-                        ):
+                        if get_merchant_profile(receipt.get("merchant_name")).get(
+                            "logo_reserve_subtitle"
+                        ) and len(wordmark_words) == len(logo_line):
                             logo_bbox = _reserve_logo_subtitle_bbox(logo_bbox)
-                        render_input = _receipt_drop_words(
-                            receipt, wordmark_words
-                        )
+                        render_input = _receipt_drop_words(receipt, wordmark_words)
                 else:
                     # Logo shows only the brand line. For merchants whose
                     # subtitle is part of the wordmark (Sprouts' FARMERS
@@ -1633,22 +1557,14 @@ def _render_cached_hybrid(
                             else (
                                 logo_line,
                                 _union_bbox(
-                                    [
-                                        w["bbox"]
-                                        for w in logo_line
-                                        if w.get("bbox")
-                                    ]
+                                    [w["bbox"] for w in logo_line if w.get("bbox")]
                                 ),
                             )
                         )
-                        if wordmark is None or len(wordmark_words) == len(
-                            logo_line
-                        ):
+                        if wordmark is None or len(wordmark_words) == len(logo_line):
                             logo_bbox = _reserve_logo_subtitle_bbox(logo_bbox)
                         logo_subtitle = str(subtitle)
-                        render_input = _receipt_drop_words(
-                            receipt, wordmark_words
-                        )
+                        render_input = _receipt_drop_words(receipt, wordmark_words)
                     else:
                         logo_bbox = _union_bbox(
                             [w["bbox"] for w in logo_line if w.get("bbox")]
@@ -1716,9 +1632,7 @@ def _overlay_cached_logo(
 ) -> None:
     # ``logo_image`` (e.g. a clipped-subtitle-trimmed copy) overrides the atlas
     # bitmap when supplied.
-    logo = (
-        logo_image if logo_image is not None else getattr(atlas, "logo", None)
-    )
+    logo = logo_image if logo_image is not None else getattr(atlas, "logo", None)
     if logo is None:
         return
     # ``bbox`` (the full wordmark region, including any reserved subtitle row)
@@ -1727,9 +1641,7 @@ def _overlay_cached_logo(
         logo_line = _cached_logo_line(receipt)
         if not logo_line:
             return
-        bbox = _union_bbox(
-            [word["bbox"] for word in logo_line if word.get("bbox")]
-        )
+        bbox = _union_bbox([word["bbox"] for word in logo_line if word.get("bbox")])
     if bbox is None:
         return
     inner_w = config.width - 2 * config.margin
@@ -2177,9 +2089,7 @@ def _overlay_inbody_barcodes(
     inner_w = config.width - 2 * config.margin
     inner_h = config.height - 2 * config.margin
     all_words = receipt.get("words") or [
-        w
-        for line in (receipt.get("lines") or [])
-        for w in (line.get("words") or [])
+        w for line in (receipt.get("lines") or []) for w in (line.get("words") or [])
     ]
     words = [w for w in all_words if w.get("bbox")]
     if not words:
@@ -2187,9 +2097,7 @@ def _overlay_inbody_barcodes(
     ib = {
         **_INBODY_BARCODE_DEFAULTS,
         **(
-            graphics_for_merchant(receipt.get("merchant_name")).get(
-                "inbody_barcode"
-            )
+            graphics_for_merchant(receipt.get("merchant_name")).get("inbody_barcode")
             or {}
         ),
     }
@@ -2219,9 +2127,7 @@ def _overlay_inbody_barcodes(
     ]
     by_line: dict = {}
     for w, top, bot, left, right in px:
-        by_line.setdefault(w.get("line_id"), []).append(
-            (w, top, bot, left, right)
-        )
+        by_line.setdefault(w.get("line_id"), []).append((w, top, bot, left, right))
     for line_id, group in sorted(by_line.items(), key=lambda kv: str(kv[0])):
         if line_id is None or len(group) < 2:
             continue
@@ -2246,9 +2152,7 @@ def _overlay_inbody_barcodes(
             continue
         # nearest content bottom strictly above this line
         above = [
-            pb
-            for j, (_, pt, pb, _, _) in enumerate(px)
-            if j != i and pb <= top + 2
+            pb for j, (_, pt, pb, _, _) in enumerate(px) if j != i and pb <= top + 2
         ]
         nearest = max(above) if above else float(config.margin)
         space = top - nearest
@@ -2262,9 +2166,7 @@ def _overlay_inbody_barcodes(
             )
         )
         cx = (left + right) / 2.0
-        payload = _visual_barcode_payload(
-            digits[: ib["max_digits"]], ib["symbology"]
-        )
+        payload = _visual_barcode_payload(digits[: ib["max_digits"]], ib["symbology"])
         tile = receipt_graphics.render_barcode_tile(
             payload, ib["symbology"], bar_w, bar_h, with_hri=False
         )
@@ -2393,13 +2295,9 @@ def _overlay_qr_and_barcode(
         qs = min(qr_size, int(avail_h - gap - bar_h))
         block = qs + gap + bar_h
         y0 = int(gtop + (avail_h - block) / 2)
-        qr_tile = receipt_graphics.render_qr_tile(
-            _qr_payload(receipt, seed), qs, seed
-        )
+        qr_tile = receipt_graphics.render_qr_tile(_qr_payload(receipt, seed), qs, seed)
         _paste_graphic_tile(image, qr_tile, int(cx - qs / 2), y0)
-        _paste_graphic_tile(
-            image, barcode_tile, int(cx - bar_w / 2), y0 + qs + gap
-        )
+        _paste_graphic_tile(image, barcode_tile, int(cx - bar_w / 2), y0 + qs + gap)
     elif avail_h >= bar_h + 6:
         y0 = int(gtop + (avail_h - bar_h) / 2)
         _paste_graphic_tile(image, barcode_tile, int(cx - bar_w / 2), y0)
@@ -2420,9 +2318,7 @@ def _cached_logo_line(receipt: dict) -> list[dict] | None:
 
     candidates = []
     for line in lines:
-        line_words = [
-            word for word in line.get("words", []) if word.get("bbox")
-        ]
+        line_words = [word for word in line.get("words", []) if word.get("bbox")]
         if not line_words:
             continue
         labels = {
@@ -2453,10 +2349,7 @@ def _receipt_lines(receipt: dict) -> list[list[dict]]:
     detection): use explicit ``lines`` if present, else band words by y."""
     lines = receipt.get("lines")
     if lines:
-        return [
-            [w for w in line.get("words", []) if w.get("bbox")]
-            for line in lines
-        ]
+        return [[w for w in line.get("words", []) if w.get("bbox")] for line in lines]
     grouped: dict[int, list[dict]] = {}
     for word in receipt.get("words") or []:
         bbox = word.get("bbox")
@@ -2494,20 +2387,13 @@ def _phrase_logo_placement(
         return None
     drop, boxes = [], []
     for words in _receipt_lines(receipt):
-        text = _normalize_phrase(
-            " ".join(str(w.get("text") or "") for w in words)
-        )
+        text = _normalize_phrase(" ".join(str(w.get("text") or "") for w in words))
         if not text or not any(p in text for p in norm):
             continue
         # This anchors a TOP-of-receipt lockup; short brand phrases ("VONS")
         # also match footer URLs / body mentions, which unions a bogus
         # mid-receipt band and drops body words. Only accept header lines.
-        ys = [
-            v
-            for w in words
-            if w.get("bbox")
-            for v in (w["bbox"][1], w["bbox"][3])
-        ]
+        ys = [v for w in words if w.get("bbox") for v in (w["bbox"][1], w["bbox"][3])]
         if ys and (sum(ys) / len(ys)) < 780.0:
             continue
         drop.extend(words)
@@ -2575,9 +2461,7 @@ def _logo_wordmark_words(
     logo_line = _cached_logo_line(receipt)
     if not logo_line:
         return None
-    band = _union_bbox(
-        [word["bbox"] for word in logo_line if word.get("bbox")]
-    )
+    band = _union_bbox([word["bbox"] for word in logo_line if word.get("bbox")])
     if band is None:
         return None
     cluster = list(logo_line)
@@ -2641,17 +2525,13 @@ def _receipt_drop_words(receipt: dict, drop: list[dict]) -> dict:
     drop_ids = {id(word) for word in drop}
     new = dict(receipt)
     if receipt.get("words") is not None:
-        new["words"] = [
-            word for word in receipt["words"] if id(word) not in drop_ids
-        ]
+        new["words"] = [word for word in receipt["words"] if id(word) not in drop_ids]
     if receipt.get("lines") is not None:
         new_lines = []
         for line in receipt["lines"]:
             new_line = dict(line)
             new_line["words"] = [
-                word
-                for word in (line.get("words") or [])
-                if id(word) not in drop_ids
+                word for word in (line.get("words") or []) if id(word) not in drop_ids
             ]
             new_lines.append(new_line)
         new["lines"] = new_lines
@@ -2733,9 +2613,7 @@ def _render_cached_synthetic_examples(args: argparse.Namespace) -> int:
 
     rendered = 0
     for path in sorted(
-        name
-        for name in os.listdir(args.cached_synthetic_dir)
-        if name.endswith(".json")
+        name for name in os.listdir(args.cached_synthetic_dir) if name.endswith(".json")
     ):
         source_path = os.path.join(args.cached_synthetic_dir, path)
         example = json.load(open(source_path, encoding="utf-8"))
@@ -2826,9 +2704,7 @@ def _profile_from_export_dir(merchant: str, receipt_dir: str):
         for line in export.get("receipt_lines", []) or []:
             lines_by_rid.setdefault(line.get("receipt_id"), []).append(line)
         for letter in export.get("receipt_letters", []) or []:
-            letters_by_rid.setdefault(letter.get("receipt_id"), []).append(
-                letter
-            )
+            letters_by_rid.setdefault(letter.get("receipt_id"), []).append(letter)
         for rid, words in words_by_rid.items():
             profile = extract_receipt_font_profile(
                 words,
@@ -2883,9 +2759,7 @@ def main() -> int:
     if args.cached_synthetic_dir:
         return _render_cached_synthetic_examples(args)
     if not args.bundle or not args.receipt_dir:
-        parser.error(
-            "--bundle and --receipt-dir are required outside cached mode"
-        )
+        parser.error("--bundle and --receipt-dir are required outside cached mode")
 
     bundle = json.load(open(args.bundle))
     examples = bundle.get("synthetic_training_examples", []) or []
@@ -2909,14 +2783,10 @@ def main() -> int:
     exports: dict[str, dict] = {}
     for name in os.listdir(args.receipt_dir):
         if name.endswith(".json"):
-            exports[name[:-5]] = json.load(
-                open(os.path.join(args.receipt_dir, name))
-            )
+            exports[name[:-5]] = json.load(open(os.path.join(args.receipt_dir, name)))
 
     profile = _profile_from_export_dir(args.merchant, args.receipt_dir)
-    print(
-        "Merchant profile:", json.dumps(profile.to_dict() if profile else None)
-    )
+    print("Merchant profile:", json.dumps(profile.to_dict() if profile else None))
 
     os.makedirs(args.out_dir, exist_ok=True)
     config = RenderConfig(
@@ -2934,9 +2804,7 @@ def main() -> int:
             base_receipt_id = None
 
         synthetic = _synthetic_receipt_dict(example, id_to_label)
-        synth_path = os.path.join(
-            args.out_dir, f"{candidate_id}.synthetic.png"
-        )
+        synth_path = os.path.join(args.out_dir, f"{candidate_id}.synthetic.png")
         save_receipt_png(synthetic, synth_path, profile=profile, config=config)
 
         if image_id in exports and base_receipt_id is not None:

--- a/scripts/render_synthetic_receipts.py
+++ b/scripts/render_synthetic_receipts.py
@@ -102,13 +102,19 @@ def _resolve_tag(tag, id_to_label: dict[int, str]):
     return None
 
 
-def _synthetic_receipt_dict(example: dict, id_to_label: dict[int, str]) -> dict:
+def _synthetic_receipt_dict(
+    example: dict, id_to_label: dict[int, str]
+) -> dict:
     words = []
     tokens = example.get("tokens") or []
     bboxes = example.get("bboxes") or []
     tags = example.get("ner_tags") or []
     for index, (token, bbox) in enumerate(zip(tokens, bboxes)):
-        label = _resolve_tag(tags[index], id_to_label) if index < len(tags) else None
+        label = (
+            _resolve_tag(tags[index], id_to_label)
+            if index < len(tags)
+            else None
+        )
         # Keep the raw (possibly BIO-prefixed) label; the renderer normalizes it.
         words.append(
             {
@@ -209,7 +215,9 @@ def _is_price_token(token: str) -> bool:
 def _cached_line_receipt_dict(example: dict) -> dict:
     hp = _header_profile_for(example.get("merchant_name"))
     lines = []
-    source_lines = _order_cached_lines(_drop_duplicate_header_lines(example, hp), hp)
+    source_lines = _order_cached_lines(
+        _drop_duplicate_header_lines(example, hp), hp
+    )
     for index, line in enumerate(source_lines):
         text = str(line.get("text") or "").strip()
         if not text:
@@ -217,14 +225,20 @@ def _cached_line_receipt_dict(example: dict) -> dict:
         words = text.split()
         y = float(line.get("y") or (940 - index * _LINE_ROW_PITCH))
         labels = list(line.get("labels") or [])
-        is_logo_line = any(_label_name(label) == "MERCHANT_NAME" for label in labels)
+        is_logo_line = any(
+            _label_name(label) == "MERCHANT_NAME" for label in labels
+        )
         # Cached line-only examples do not carry OCR word widths, so give the
         # renderer enough horizontal room to avoid shrinking every line to the
         # minimum font size.
-        width_units = [max(18.0, len(word) * _LINE_CHAR_WIDTH) for word in words]
+        width_units = [
+            max(18.0, len(word) * _LINE_CHAR_WIDTH) for word in words
+        ]
         if is_logo_line and len(words) == 1:
             width_units = [max(width_units[0], _LINE_LOGO_MIN_WIDTH)]
-        total_width = sum(width_units) + max(0, len(words) - 1) * _LINE_WORD_GAP
+        total_width = (
+            sum(width_units) + max(0, len(words) - 1) * _LINE_WORD_GAP
+        )
         if total_width > _LINE_MAX_WIDTH:
             factor = _LINE_MAX_WIDTH / total_width
             width_units = [width * factor for width in width_units]
@@ -301,7 +315,10 @@ def _order_cached_lines(lines: list[dict], hp: dict) -> list[dict]:
     if not (
         hp["reflow"]
         and hp["brand"]
-        and any(hp["brand"] in _compact_text(line.get("text") or "") for line in lines)
+        and any(
+            hp["brand"] in _compact_text(line.get("text") or "")
+            for line in lines
+        )
     ):
         return lines
 
@@ -312,7 +329,9 @@ def _order_cached_lines(lines: list[dict], hp: dict) -> list[dict]:
         "footer": [],
     }
     for line in lines:
-        sections[_text_section(_compact_text(line.get("text") or ""), hp)].append(line)
+        sections[
+            _text_section(_compact_text(line.get("text") or ""), hp)
+        ].append(line)
 
     ordered = []
     for name in ("header", "body", "payment", "footer"):
@@ -320,7 +339,9 @@ def _order_cached_lines(lines: list[dict], hp: dict) -> list[dict]:
             ordered.append({"text": "", "y": None, "labels": []})
         ordered.extend(sections[name])
 
-    real_count = sum(1 for line in ordered if str(line.get("text") or "").strip())
+    real_count = sum(
+        1 for line in ordered if str(line.get("text") or "").strip()
+    )
     break_count = len(ordered) - real_count
     section_gap = 18.0 if real_count < 70 else 10.0
     spacing = (930.0 - break_count * section_gap) / max(1, real_count - 1)
@@ -412,7 +433,9 @@ def _repair_missing_top_header_lines(receipt: dict) -> dict:
         return receipt
 
     top_end = first_header
-    while top_end + 1 < len(line_infos) and line_infos[top_end + 1]["is_header"]:
+    while (
+        top_end + 1 < len(line_infos) and line_infos[top_end + 1]["is_header"]
+    ):
         top_end += 1
     top_block = line_infos[first_header : top_end + 1]
     top_texts = {info["text"] for info in top_block}
@@ -430,7 +453,9 @@ def _repair_missing_top_header_lines(receipt: dict) -> dict:
     for marker in missing:
         source_index = next(
             index
-            for index, info in enumerate(line_infos[top_end + 1 :], top_end + 1)
+            for index, info in enumerate(
+                line_infos[top_end + 1 :], top_end + 1
+            )
             if info["text"] == marker
         )
         source = line_infos[source_index]
@@ -483,7 +508,11 @@ def _repair_missing_top_header_lines(receipt: dict) -> dict:
                 [word["bbox"] for word in anchor["words"] if word.get("bbox")]
             )
             target_anchor_box = _union_bbox(
-                [word["bbox"] for word in target_anchor["words"] if word.get("bbox")]
+                [
+                    word["bbox"]
+                    for word in target_anchor["words"]
+                    if word.get("bbox")
+                ]
             )
             if source_anchor_box is not None and target_anchor_box is not None:
                 source_anchor_span = max(
@@ -597,10 +626,16 @@ def _top_band_logo_placement(
 ) -> tuple[dict, list[float]]:
     band = max(0.0, min(350.0, float(anchor_cfg.get("top_band", 0.0))))
     words = [
-        word for line in _receipt_lines(receipt) for word in line if word.get("bbox")
+        word
+        for line in _receipt_lines(receipt)
+        for word in line
+        if word.get("bbox")
     ]
     top_y = max(
-        (max(float(word["bbox"][1]), float(word["bbox"][3])) for word in words),
+        (
+            max(float(word["bbox"][1]), float(word["bbox"][3]))
+            for word in words
+        ),
         default=0.0,
     )
     required_room = band * float(anchor_cfg.get("reserve_threshold", 0.70))
@@ -621,7 +656,9 @@ def _top_band_logo_placement(
     band_h = max(1.0, band_top - band_bottom)
     box_w = coord_max * width_frac
     aspect = logo.width / max(1, logo.height)
-    h_from_width = (box_w / coord_max * inner_w / aspect) / max(1, inner_h) * coord_max
+    h_from_width = (
+        (box_w / coord_max * inner_w / aspect) / max(1, inner_h) * coord_max
+    )
     box_h = min(band_h, h_from_width)
     cx = coord_max / 2.0
     cy = (band_top + band_bottom) / 2.0
@@ -686,16 +723,25 @@ def _line_receipt_from_cached_token_words(
             y -= section_gap
             continue
         labels = sorted(
-            {label for word in line for label in (word.get("labels") or []) if label}
+            {
+                label
+                for word in line
+                for label in (word.get("labels") or [])
+                if label
+            }
         )
         text = _line_text_from_cached_words(line)
         if text:
             lines.append({"y": y, "text": text, "labels": labels})
             y -= spacing
-    return _cached_line_receipt_dict({"lines": lines, "merchant_name": merchant})
+    return _cached_line_receipt_dict(
+        {"lines": lines, "merchant_name": merchant}
+    )
 
 
-def _ordered_token_lines(words: list[dict], hp: dict) -> list[tuple[list[dict], bool]]:
+def _ordered_token_lines(
+    words: list[dict], hp: dict
+) -> list[tuple[list[dict], bool]]:
     lines = _group_cached_words_by_line(words)
     if not lines:
         return []
@@ -821,7 +867,9 @@ def _text_section(text: str, hp: dict) -> str:
         )
     ):
         return "payment"
-    if text.startswith(("AID", "TVR", "IAD", "TSI", "ARC", "TC", "MID", "SEQ")):
+    if text.startswith(
+        ("AID", "TVR", "IAD", "TSI", "ARC", "TC", "MID", "SEQ")
+    ):
         return "payment"
     return "body"
 
@@ -908,7 +956,9 @@ def _composite_paper_texture(
         rgb *= lum[:, :, None]
 
     # Fine grain (neutral: same delta on R/G/B).
-    grain = rng.normal(0.0, 4.5 * s, size=(height, width, 1)).astype(np.float32)
+    grain = rng.normal(0.0, 4.5 * s, size=(height, width, 1)).astype(
+        np.float32
+    )
     rgb += grain
 
     # Edge vignette: darker toward the paper edges/corners.
@@ -925,7 +975,9 @@ def _composite_paper_texture(
         bar_w, soft = 0.06, 0.025
         xn = np.linspace(0.0, 1.0, width, dtype=np.float32)
         d = np.minimum(xn, 1.0 - xn)  # 0 at edges -> 0.5 center
-        ew = np.clip((bar_w + soft - d) / soft, 0.0, 1.0)[None, :]  # flat 1 in bar
+        ew = np.clip((bar_w + soft - d) / soft, 0.0, 1.0)[
+            None, :
+        ]  # flat 1 in bar
         rgb[..., 0] -= 24.0 * s * ew
         rgb[..., 1] -= 2.0 * s * ew
         rgb[..., 2] -= 4.0 * s * ew
@@ -937,7 +989,9 @@ def _composite_paper_texture(
     if s > 0:
         angle = float(rng.uniform(-0.8, 0.8)) * min(s, 1.5)
         fill = tuple(int(v) for v in np.asarray(image.convert("RGB"))[0, 0])
-        textured = textured.rotate(angle, resample=Image.BICUBIC, fillcolor=fill)
+        textured = textured.rotate(
+            angle, resample=Image.BICUBIC, fillcolor=fill
+        )
 
     if source_mode == "RGB":
         return textured
@@ -975,8 +1029,12 @@ _VENDORED_FONTS_DIR = os.path.join(
     "rendering",
     "fonts",
 )
-_VT323 = os.path.join(_VENDORED_FONTS_DIR, "VT323-Regular.ttf")  # OFL pixel/dot-matrix
-_B612 = os.path.join(_VENDORED_FONTS_DIR, "B612Mono-Regular.ttf")  # OFL clean sans mono
+_VT323 = os.path.join(
+    _VENDORED_FONTS_DIR, "VT323-Regular.ttf"
+)  # OFL pixel/dot-matrix
+_B612 = os.path.join(
+    _VENDORED_FONTS_DIR, "B612Mono-Regular.ttf"
+)  # OFL clean sans mono
 _FONT_TOKENS = {"PTMONO": _PTMONO, "VT323": _VT323, "B612": _B612}
 # Glyph atlases + logo PNGs (bitMatrix-C2 chart derived / logo_master medians),
 # kept local (paid-font derived). Relocate via $BITMATRIX_DIR.
@@ -1074,6 +1132,7 @@ def _ensure_font_cached(filename: str, merchant: str, face: str) -> str:
         import hashlib
 
         import boto3
+
         from receipt_dynamo import DynamoClient
 
         table = os.environ.get("DYNAMODB_TABLE_NAME", "ReceiptsTable-dc5be22")
@@ -1144,7 +1203,8 @@ def merchant_typography(merchant: str | None) -> dict:
                 cfg["font_path"] = path
         elif key == "bitmap_font":
             cfg["bitmap_font"] = {
-                k: _ensure_font_cached(v, merchant, face=k) for k, v in val.items()
+                k: _ensure_font_cached(v, merchant, face=k)
+                for k, v in val.items()
             }
         elif key == "stylemap":
             # Measured per-section style rules (Glyph Studio fleet); the JSON
@@ -1195,7 +1255,9 @@ def _cached_build(kind, build, table, merchant, region, max_receipts, refresh):
     return obj
 
 
-def cached_glyph_atlas(table, merchant, *, region, max_receipts=8, refresh=False):
+def cached_glyph_atlas(
+    table, merchant, *, region, max_receipts=8, refresh=False
+):
     """Disk-cached :func:`build_glyph_atlas_from_dynamo` (per merchant)."""
     return _cached_build(
         "atlas",
@@ -1208,7 +1270,9 @@ def cached_glyph_atlas(table, merchant, *, region, max_receipts=8, refresh=False
     )
 
 
-def cached_font_profile(table, merchant, *, region, max_receipts=12, refresh=False):
+def cached_font_profile(
+    table, merchant, *, region, max_receipts=12, refresh=False
+):
     """Disk-cached :func:`build_merchant_font_profile_from_dynamo` (per merchant)."""
     return _cached_build(
         "profile",
@@ -1269,8 +1333,9 @@ def resolve_bitmap_thin(
     from statistics import median
 
     from ink_calibration import derive_bitmap_thin  # noqa: E402
-    from receipt_dynamo.data.dynamo_client import DynamoClient  # noqa: E402
     from receipt_line_scorecard import _load_words_and_real  # noqa: E402
+
+    from receipt_dynamo.data.dynamo_client import DynamoClient  # noqa: E402
 
     client = DynamoClient(table_name=table, region=region)
     places, _ = client.get_receipt_places_by_merchant(merchant)
@@ -1366,8 +1431,16 @@ def _content_texture_seed(receipt: dict) -> int:
         # ints and strings are not mutually orderable; rank ints before strings
         # so the sort is total and deterministic across mixed id types.
         return (
-            ((0, line_id, "") if isinstance(line_id, int) else (1, 0, str(line_id))),
-            ((0, word_id, "") if isinstance(word_id, int) else (1, 0, str(word_id))),
+            (
+                (0, line_id, "")
+                if isinstance(line_id, int)
+                else (1, 0, str(line_id))
+            ),
+            (
+                (0, word_id, "")
+                if isinstance(word_id, int)
+                else (1, 0, str(word_id))
+            ),
         )
 
     for word in sorted(words, key=_key):
@@ -1497,7 +1570,10 @@ def _render_cached_hybrid(
         # Merchants whose wordmark is a pure graphic (no MERCHANT_NAME OCR text,
         # e.g. The Home Depot) anchor the logo off a configured slogan phrase.
         anchor_cfg = (
-            get_merchant_profile(receipt.get("merchant_name")).get("logo_anchor") or {}
+            get_merchant_profile(receipt.get("merchant_name")).get(
+                "logo_anchor"
+            )
+            or {}
         )
         placed = None
         top_band_placed = False
@@ -1535,11 +1611,17 @@ def _render_cached_hybrid(
                     wordmark = _logo_wordmark_words(receipt)
                     if wordmark:
                         wordmark_words, logo_bbox = wordmark
-                        if get_merchant_profile(receipt.get("merchant_name")).get(
-                            "logo_reserve_subtitle"
-                        ) and len(wordmark_words) == len(logo_line):
+                        if get_merchant_profile(
+                            receipt.get("merchant_name")
+                        ).get("logo_reserve_subtitle") and len(
+                            wordmark_words
+                        ) == len(
+                            logo_line
+                        ):
                             logo_bbox = _reserve_logo_subtitle_bbox(logo_bbox)
-                        render_input = _receipt_drop_words(receipt, wordmark_words)
+                        render_input = _receipt_drop_words(
+                            receipt, wordmark_words
+                        )
                 else:
                     # Logo shows only the brand line. For merchants whose
                     # subtitle is part of the wordmark (Sprouts' FARMERS
@@ -1557,14 +1639,22 @@ def _render_cached_hybrid(
                             else (
                                 logo_line,
                                 _union_bbox(
-                                    [w["bbox"] for w in logo_line if w.get("bbox")]
+                                    [
+                                        w["bbox"]
+                                        for w in logo_line
+                                        if w.get("bbox")
+                                    ]
                                 ),
                             )
                         )
-                        if wordmark is None or len(wordmark_words) == len(logo_line):
+                        if wordmark is None or len(wordmark_words) == len(
+                            logo_line
+                        ):
                             logo_bbox = _reserve_logo_subtitle_bbox(logo_bbox)
                         logo_subtitle = str(subtitle)
-                        render_input = _receipt_drop_words(receipt, wordmark_words)
+                        render_input = _receipt_drop_words(
+                            receipt, wordmark_words
+                        )
                     else:
                         logo_bbox = _union_bbox(
                             [w["bbox"] for w in logo_line if w.get("bbox")]
@@ -1632,7 +1722,9 @@ def _overlay_cached_logo(
 ) -> None:
     # ``logo_image`` (e.g. a clipped-subtitle-trimmed copy) overrides the atlas
     # bitmap when supplied.
-    logo = logo_image if logo_image is not None else getattr(atlas, "logo", None)
+    logo = (
+        logo_image if logo_image is not None else getattr(atlas, "logo", None)
+    )
     if logo is None:
         return
     # ``bbox`` (the full wordmark region, including any reserved subtitle row)
@@ -1641,7 +1733,9 @@ def _overlay_cached_logo(
         logo_line = _cached_logo_line(receipt)
         if not logo_line:
             return
-        bbox = _union_bbox([word["bbox"] for word in logo_line if word.get("bbox")])
+        bbox = _union_bbox(
+            [word["bbox"] for word in logo_line if word.get("bbox")]
+        )
     if bbox is None:
         return
     inner_w = config.width - 2 * config.margin
@@ -2089,7 +2183,9 @@ def _overlay_inbody_barcodes(
     inner_w = config.width - 2 * config.margin
     inner_h = config.height - 2 * config.margin
     all_words = receipt.get("words") or [
-        w for line in (receipt.get("lines") or []) for w in (line.get("words") or [])
+        w
+        for line in (receipt.get("lines") or [])
+        for w in (line.get("words") or [])
     ]
     words = [w for w in all_words if w.get("bbox")]
     if not words:
@@ -2097,7 +2193,9 @@ def _overlay_inbody_barcodes(
     ib = {
         **_INBODY_BARCODE_DEFAULTS,
         **(
-            graphics_for_merchant(receipt.get("merchant_name")).get("inbody_barcode")
+            graphics_for_merchant(receipt.get("merchant_name")).get(
+                "inbody_barcode"
+            )
             or {}
         ),
     }
@@ -2127,7 +2225,9 @@ def _overlay_inbody_barcodes(
     ]
     by_line: dict = {}
     for w, top, bot, left, right in px:
-        by_line.setdefault(w.get("line_id"), []).append((w, top, bot, left, right))
+        by_line.setdefault(w.get("line_id"), []).append(
+            (w, top, bot, left, right)
+        )
     for line_id, group in sorted(by_line.items(), key=lambda kv: str(kv[0])):
         if line_id is None or len(group) < 2:
             continue
@@ -2152,7 +2252,9 @@ def _overlay_inbody_barcodes(
             continue
         # nearest content bottom strictly above this line
         above = [
-            pb for j, (_, pt, pb, _, _) in enumerate(px) if j != i and pb <= top + 2
+            pb
+            for j, (_, pt, pb, _, _) in enumerate(px)
+            if j != i and pb <= top + 2
         ]
         nearest = max(above) if above else float(config.margin)
         space = top - nearest
@@ -2166,7 +2268,9 @@ def _overlay_inbody_barcodes(
             )
         )
         cx = (left + right) / 2.0
-        payload = _visual_barcode_payload(digits[: ib["max_digits"]], ib["symbology"])
+        payload = _visual_barcode_payload(
+            digits[: ib["max_digits"]], ib["symbology"]
+        )
         tile = receipt_graphics.render_barcode_tile(
             payload, ib["symbology"], bar_w, bar_h, with_hri=False
         )
@@ -2295,9 +2399,13 @@ def _overlay_qr_and_barcode(
         qs = min(qr_size, int(avail_h - gap - bar_h))
         block = qs + gap + bar_h
         y0 = int(gtop + (avail_h - block) / 2)
-        qr_tile = receipt_graphics.render_qr_tile(_qr_payload(receipt, seed), qs, seed)
+        qr_tile = receipt_graphics.render_qr_tile(
+            _qr_payload(receipt, seed), qs, seed
+        )
         _paste_graphic_tile(image, qr_tile, int(cx - qs / 2), y0)
-        _paste_graphic_tile(image, barcode_tile, int(cx - bar_w / 2), y0 + qs + gap)
+        _paste_graphic_tile(
+            image, barcode_tile, int(cx - bar_w / 2), y0 + qs + gap
+        )
     elif avail_h >= bar_h + 6:
         y0 = int(gtop + (avail_h - bar_h) / 2)
         _paste_graphic_tile(image, barcode_tile, int(cx - bar_w / 2), y0)
@@ -2318,7 +2426,9 @@ def _cached_logo_line(receipt: dict) -> list[dict] | None:
 
     candidates = []
     for line in lines:
-        line_words = [word for word in line.get("words", []) if word.get("bbox")]
+        line_words = [
+            word for word in line.get("words", []) if word.get("bbox")
+        ]
         if not line_words:
             continue
         labels = {
@@ -2349,7 +2459,10 @@ def _receipt_lines(receipt: dict) -> list[list[dict]]:
     detection): use explicit ``lines`` if present, else band words by y."""
     lines = receipt.get("lines")
     if lines:
-        return [[w for w in line.get("words", []) if w.get("bbox")] for line in lines]
+        return [
+            [w for w in line.get("words", []) if w.get("bbox")]
+            for line in lines
+        ]
     grouped: dict[int, list[dict]] = {}
     for word in receipt.get("words") or []:
         bbox = word.get("bbox")
@@ -2387,13 +2500,20 @@ def _phrase_logo_placement(
         return None
     drop, boxes = [], []
     for words in _receipt_lines(receipt):
-        text = _normalize_phrase(" ".join(str(w.get("text") or "") for w in words))
+        text = _normalize_phrase(
+            " ".join(str(w.get("text") or "") for w in words)
+        )
         if not text or not any(p in text for p in norm):
             continue
         # This anchors a TOP-of-receipt lockup; short brand phrases ("VONS")
         # also match footer URLs / body mentions, which unions a bogus
         # mid-receipt band and drops body words. Only accept header lines.
-        ys = [v for w in words if w.get("bbox") for v in (w["bbox"][1], w["bbox"][3])]
+        ys = [
+            v
+            for w in words
+            if w.get("bbox")
+            for v in (w["bbox"][1], w["bbox"][3])
+        ]
         if ys and (sum(ys) / len(ys)) < 780.0:
             continue
         drop.extend(words)
@@ -2461,7 +2581,9 @@ def _logo_wordmark_words(
     logo_line = _cached_logo_line(receipt)
     if not logo_line:
         return None
-    band = _union_bbox([word["bbox"] for word in logo_line if word.get("bbox")])
+    band = _union_bbox(
+        [word["bbox"] for word in logo_line if word.get("bbox")]
+    )
     if band is None:
         return None
     cluster = list(logo_line)
@@ -2525,13 +2647,17 @@ def _receipt_drop_words(receipt: dict, drop: list[dict]) -> dict:
     drop_ids = {id(word) for word in drop}
     new = dict(receipt)
     if receipt.get("words") is not None:
-        new["words"] = [word for word in receipt["words"] if id(word) not in drop_ids]
+        new["words"] = [
+            word for word in receipt["words"] if id(word) not in drop_ids
+        ]
     if receipt.get("lines") is not None:
         new_lines = []
         for line in receipt["lines"]:
             new_line = dict(line)
             new_line["words"] = [
-                word for word in (line.get("words") or []) if id(word) not in drop_ids
+                word
+                for word in (line.get("words") or [])
+                if id(word) not in drop_ids
             ]
             new_lines.append(new_line)
         new["lines"] = new_lines
@@ -2613,7 +2739,9 @@ def _render_cached_synthetic_examples(args: argparse.Namespace) -> int:
 
     rendered = 0
     for path in sorted(
-        name for name in os.listdir(args.cached_synthetic_dir) if name.endswith(".json")
+        name
+        for name in os.listdir(args.cached_synthetic_dir)
+        if name.endswith(".json")
     ):
         source_path = os.path.join(args.cached_synthetic_dir, path)
         example = json.load(open(source_path, encoding="utf-8"))
@@ -2704,7 +2832,9 @@ def _profile_from_export_dir(merchant: str, receipt_dir: str):
         for line in export.get("receipt_lines", []) or []:
             lines_by_rid.setdefault(line.get("receipt_id"), []).append(line)
         for letter in export.get("receipt_letters", []) or []:
-            letters_by_rid.setdefault(letter.get("receipt_id"), []).append(letter)
+            letters_by_rid.setdefault(letter.get("receipt_id"), []).append(
+                letter
+            )
         for rid, words in words_by_rid.items():
             profile = extract_receipt_font_profile(
                 words,
@@ -2759,7 +2889,9 @@ def main() -> int:
     if args.cached_synthetic_dir:
         return _render_cached_synthetic_examples(args)
     if not args.bundle or not args.receipt_dir:
-        parser.error("--bundle and --receipt-dir are required outside cached mode")
+        parser.error(
+            "--bundle and --receipt-dir are required outside cached mode"
+        )
 
     bundle = json.load(open(args.bundle))
     examples = bundle.get("synthetic_training_examples", []) or []
@@ -2783,10 +2915,14 @@ def main() -> int:
     exports: dict[str, dict] = {}
     for name in os.listdir(args.receipt_dir):
         if name.endswith(".json"):
-            exports[name[:-5]] = json.load(open(os.path.join(args.receipt_dir, name)))
+            exports[name[:-5]] = json.load(
+                open(os.path.join(args.receipt_dir, name))
+            )
 
     profile = _profile_from_export_dir(args.merchant, args.receipt_dir)
-    print("Merchant profile:", json.dumps(profile.to_dict() if profile else None))
+    print(
+        "Merchant profile:", json.dumps(profile.to_dict() if profile else None)
+    )
 
     os.makedirs(args.out_dir, exist_ok=True)
     config = RenderConfig(
@@ -2804,7 +2940,9 @@ def main() -> int:
             base_receipt_id = None
 
         synthetic = _synthetic_receipt_dict(example, id_to_label)
-        synth_path = os.path.join(args.out_dir, f"{candidate_id}.synthetic.png")
+        synth_path = os.path.join(
+            args.out_dir, f"{candidate_id}.synthetic.png"
+        )
         save_receipt_png(synthetic, synth_path, profile=profile, config=config)
 
         if image_id in exports and base_receipt_id is not None:

--- a/tools/glyph-studio/py/glyphstudio/face_select.py
+++ b/tools/glyph-studio/py/glyphstudio/face_select.py
@@ -180,6 +180,10 @@ def select_row_faces(
     normalized text collides with a DIFFERENT style are dropped entirely
     (both fall back to the stylemap rules) -- a text key must be unambiguous
     to be trusted.
+
+    Stats are KEY-level over the returned map (``measured``/``measured_box``
+    /``prior`` count retained keys; ``conflicts`` counts dropped keys), plus
+    line-level ``skipped`` for lines no rung could style.
     """
     body_cap = measurement.get("body_cap_px")
     body_stroke = measurement.get("body_stroke_px")
@@ -207,12 +211,14 @@ def select_row_faces(
         if style is None:
             stats["skipped"] += 1
             continue
-        stats[style["source"]] += 1
         if key in out:
             prev = out[key]
             if prev is not None and not _same_style(prev, style):
                 out[key] = None  # ambiguous key -> stylemap fallback
-                stats["conflicts"] += 1
         else:
             out[key] = style
-    return {k: v for k, v in out.items() if v is not None}, stats
+    kept = {k: v for k, v in out.items() if v is not None}
+    for style in kept.values():
+        stats[style["source"]] += 1
+    stats["conflicts"] = len(out) - len(kept)
+    return kept, stats

--- a/tools/glyph-studio/py/glyphstudio/face_select.py
+++ b/tools/glyph-studio/py/glyphstudio/face_select.py
@@ -55,6 +55,16 @@ MIN_LETTERS = 4
 # (WF's "Tender:" has ONE cap sample, an OCR smear read as 1.34x body --
 # hand-checked as plain body height).
 MIN_CAP_SAMPLES = 3
+# A single printed row has ONE cap height, so its cap samples must agree:
+# when p75/p25 of the samples reaches this ratio, the letter set mixes
+# physical rows (OCR leakage from a neighboring line) and the median sizes
+# a row that does not exist. In-N-Out 9afeb902#2's small footer
+# "Questions/Comments: ... Call" measured cap 65px = 1.51x body because
+# leaked 83-84px digits sat beside its true 46-47px caps -- hand-checked
+# as plain small print. Sizing is suppressed on such rows; face/underline
+# keep their own guards. (Clean enlarged headers measure tight: WF's
+# "Thousand Oaks CA" disperses < 1.1; body-row OCR noise reaches ~1.3.)
+CAP_DISPERSION_MAX = 1.4
 
 
 def normalize_face_key(text: str) -> str:
@@ -67,12 +77,28 @@ def normalize_face_key(text: str) -> str:
     return " ".join(str(text).upper().split())[:60]
 
 
-def _cap_samples(line: Mapping[str, Any]) -> int:
-    return sum(
-        1
+def _cap_heights(line: Mapping[str, Any]) -> list[float]:
+    return sorted(
+        float(c["h"])
         for c in line.get("letters") or ()
-        if str(c.get("ch", ""))[:1].isupper() or str(c.get("ch", ""))[:1].isdigit()
+        if (str(c.get("ch", ""))[:1].isupper() or str(c.get("ch", ""))[:1].isdigit())
+        and c.get("h")
     )
+
+
+def _caps_consistent(line: Mapping[str, Any]) -> bool:
+    """True when the row's cap samples describe ONE letter size.
+
+    Enough samples (>= MIN_CAP_SAMPLES) and unimodal heights
+    (p75/p25 < CAP_DISPERSION_MAX) -- see the constants' rationale.
+    """
+    heights = _cap_heights(line)
+    n = len(heights)
+    if n < MIN_CAP_SAMPLES:
+        return False
+    p25 = heights[n // 4]
+    p75 = heights[(3 * n) // 4]
+    return p75 / max(p25, 1e-6) < CAP_DISPERSION_MAX
 
 
 def measured_style_for_line(
@@ -98,7 +124,7 @@ def measured_style_for_line(
         and stroke_rel / max(cap_rel, 1e-6) >= BOLD_STROKE_TO_CAP
     )
     scale = 1.0
-    if cap_rel >= LARGE_CAP and _cap_samples(line) >= MIN_CAP_SAMPLES:
+    if cap_rel >= LARGE_CAP and _caps_consistent(line):
         scale = round(min(cap_rel, SCALE_MAX), 2)
     underline = bool(line.get("underline"))
     reverse = bool(line.get("reverse_video"))

--- a/tools/glyph-studio/py/glyphstudio/face_select.py
+++ b/tools/glyph-studio/py/glyphstudio/face_select.py
@@ -1,0 +1,218 @@
+"""M4 pilot: measured-typography face selection.
+
+Replaces text-rule face guessing with MEASUREMENT: for a receipt being
+mimicked, derive each row's face (regular/heavy), scale tier, and underline
+from :mod:`glyphstudio.stylescan` measurements of the REAL receipt (primary
+signal), with weaker rungs below it. The full ladder, strongest first:
+
+1. **letters** -- per-letter cap/stroke statistics (stylescan);
+2. **box** -- the OCR line-box height, when letter stats are missing;
+3. **section prior** -- the M2 (merchant, section) -> face map
+   (:mod:`glyphstudio.section_face_map`), when the line has no usable
+   geometry at all;
+4. **stylemap rules** -- rows absent from the output map fall through to the
+   renderer's existing text rules (the production default).
+
+Output shape (consumed by the renderer's opt-in ``face_source="measured"``
+path via ``RenderConfig.row_faces``)::
+
+    {normalize_face_key(row_text): {
+        "face": "regular" | "heavy",
+        "scale": float,          # row cap multiplier vs body (1.0 = body)
+        "underline": bool,
+        "reverse_video": bool,   # carried for audit; renderer ignores today
+        "source": "measured" | "measured_box" | "prior",
+    }}
+
+Face rule: a row is HEAVY when its strokes are both absolutely thicker than
+body AND disproportionate to its cap height. A large row whose strokes scale
+WITH its caps (Wild Fork's "Thousand Oaks CA" header: cap_rel ~1.7,
+stroke_rel ~1.6) is the SAME face enlarged, not a bold face -- using
+stylescan's raw ``tier`` alone would misread every enlarged header as
+needing the heavy atlas.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Optional
+
+# A row is heavy when its strokes are BOTH absolutely thicker than body
+# (>= 1.30x) AND disproportionate to its cap height (>= 1.30x the cap
+# ratio). Each alone false-positives: proportional growth = same face
+# enlarged (WF header), and small-cap rows inflate stroke/cap (WF's phone
+# line, stroke_rel 1.17 at cap_rel 0.88 -- hand-checked as plain body).
+BOLD_STROKE_REL = 1.30
+BOLD_STROKE_TO_CAP = 1.30
+# Per-row scale is applied only above this cap ratio; body-scale jitter
+# (OCR boxes wobble ~+/-10%) stays at 1.0 so the receipt keeps one body size.
+LARGE_CAP = 1.30
+# Sanity clamp for measured scales (the WF logo measures ~4.2x but is drawn
+# by the logo overlay, not text).
+SCALE_MAX = 2.5
+# Fewer measured letters than this = unreliable stats -> next rung.
+MIN_LETTERS = 4
+# Cap height needs >= this many upper/digit letter samples to size a row
+# (WF's "Tender:" has ONE cap sample, an OCR smear read as 1.34x body --
+# hand-checked as plain body height).
+MIN_CAP_SAMPLES = 3
+
+
+def normalize_face_key(text: str) -> str:
+    """Canonical row key: MUST match the renderer's ``normalize_face_key``.
+
+    (receipt_agent...rendering.receipt_stylemap.normalize_face_key; the
+    parity is pinned by a test. Duplicated so glyphstudio has no import-time
+    dependency on receipt_agent.)
+    """
+    return " ".join(str(text).upper().split())[:60]
+
+
+def _cap_samples(line: Mapping[str, Any]) -> int:
+    return sum(
+        1
+        for c in line.get("letters") or ()
+        if str(c.get("ch", ""))[:1].isupper() or str(c.get("ch", ""))[:1].isdigit()
+    )
+
+
+def measured_style_for_line(
+    line: Mapping[str, Any],
+    body_cap: Optional[float],
+    body_stroke: Optional[float],
+) -> Optional[dict[str, Any]]:
+    """The letters rung: per-letter cap/stroke measurements -> row style.
+
+    Returns None when the line's letter statistics are too thin to trust
+    (callers fall to the box rung / section prior / stylemap rules). Also
+    the pilot's ground-truth extractor, so truth and selector cannot drift.
+    """
+    cap = line.get("cap_px")
+    if not cap or not body_cap or (line.get("n_letters") or 0) < MIN_LETTERS:
+        return None
+    cap_rel = float(cap) / float(body_cap)
+    stroke = line.get("stroke_med")
+    stroke_rel = float(stroke) / float(body_stroke) if stroke and body_stroke else None
+    heavy = bool(
+        stroke_rel is not None
+        and stroke_rel >= BOLD_STROKE_REL
+        and stroke_rel / max(cap_rel, 1e-6) >= BOLD_STROKE_TO_CAP
+    )
+    scale = 1.0
+    if cap_rel >= LARGE_CAP and _cap_samples(line) >= MIN_CAP_SAMPLES:
+        scale = round(min(cap_rel, SCALE_MAX), 2)
+    underline = bool(line.get("underline"))
+    reverse = bool(line.get("reverse_video"))
+    # A dark scan band (shadow/fold) trips BOTH the underline and the
+    # reverse-video probes on an otherwise body-weight line (hand-checked on
+    # ccc09736's payment block). A printed underline never coexists with
+    # reverse video, so treat the pair as one artifact.
+    if underline and reverse and not heavy:
+        underline = reverse = False
+    return {
+        "face": "heavy" if heavy else "regular",
+        "scale": scale,
+        "underline": underline,
+        "reverse_video": reverse,
+        "source": "measured",
+    }
+
+
+def _style_from_box(
+    line: Mapping[str, Any],
+    body_box_h: Optional[float],
+) -> Optional[dict[str, Any]]:
+    """The box rung: OCR line-box height when letter stats are missing.
+
+    Weaker than the letters rung (boxes include descenders and OCR padding)
+    but still a MEASUREMENT of this receipt -- it beats the section prior,
+    which inherits text-rule misclassification (stylescan's WF store_header
+    regex matches the footer URL; the prior then blew the URL row up 1.7x
+    while the real print is body-size).
+    """
+    box = line.get("box_h")
+    if not box or not body_box_h:
+        return None
+    rel = float(box) / float(body_box_h)
+    scale = round(min(rel, SCALE_MAX), 2) if rel >= LARGE_CAP else 1.0
+    return {
+        "face": "regular",
+        "scale": scale,
+        "underline": False,
+        "reverse_video": bool(line.get("reverse_video")),
+        "source": "measured_box",
+    }
+
+
+def _style_from_prior(prior: Any) -> dict[str, Any]:
+    """Map an M2 ``section_face_map.Face`` (or dict alike) to a row style."""
+    get = (
+        prior.get
+        if isinstance(prior, Mapping)
+        else lambda k, d=None: getattr(prior, k, d)
+    )
+    weight = str(get("weight", "normal") or "normal").lower()
+    return {
+        "face": "heavy" if weight == "bold" else "regular",
+        "scale": float(get("scale", 1.0) or 1.0),
+        "underline": float(get("underline_rate", 0.0) or 0.0) >= 0.5,
+        "reverse_video": False,
+        "source": "prior",
+    }
+
+
+def _same_style(a: Mapping[str, Any], b: Mapping[str, Any]) -> bool:
+    return (
+        a["face"] == b["face"]
+        and abs(a["scale"] - b["scale"]) < 0.11
+        and a["underline"] == b["underline"]
+    )
+
+
+def select_row_faces(
+    measurement: Mapping[str, Any],
+    *,
+    section_priors: Mapping[str, Any] | None = None,
+) -> tuple[dict[str, dict[str, Any]], dict[str, int]]:
+    """stylescan ``measure()`` output -> (row_faces map, ladder stats).
+
+    ``section_priors`` maps canonical section names to M2 ``Face`` priors
+    (e.g. ``section_face_map.load_merchant_faces(font_dir)``). Lines whose
+    normalized text collides with a DIFFERENT style are dropped entirely
+    (both fall back to the stylemap rules) -- a text key must be unambiguous
+    to be trusted.
+    """
+    body_cap = measurement.get("body_cap_px")
+    body_stroke = measurement.get("body_stroke_px")
+    body_box_h = measurement.get("body_box_h")
+    stats = {
+        "measured": 0,
+        "measured_box": 0,
+        "prior": 0,
+        "skipped": 0,
+        "conflicts": 0,
+    }
+    out: dict[str, dict[str, Any] | None] = {}
+    for line in measurement.get("lines") or ():
+        key = normalize_face_key(line.get("text") or "")
+        if not key:
+            stats["skipped"] += 1
+            continue
+        style = measured_style_for_line(line, body_cap, body_stroke)
+        if style is None:
+            style = _style_from_box(line, body_box_h)
+        if style is None and section_priors:
+            prior = section_priors.get(line.get("section_canonical"))
+            if prior is not None:
+                style = _style_from_prior(prior)
+        if style is None:
+            stats["skipped"] += 1
+            continue
+        stats[style["source"]] += 1
+        if key in out:
+            prev = out[key]
+            if prev is not None and not _same_style(prev, style):
+                out[key] = None  # ambiguous key -> stylemap fallback
+                stats["conflicts"] += 1
+        else:
+            out[key] = style
+    return {k: v for k, v in out.items() if v is not None}, stats

--- a/tools/glyph-studio/py/glyphstudio/stylescan.py
+++ b/tools/glyph-studio/py/glyphstudio/stylescan.py
@@ -69,7 +69,9 @@ _RULES = [
     ("total_line", re.compile(r"^Total:", re.I)),
     (
         "summary",
-        re.compile(r"BALANCE DUE|CHANGE\b|CREDIT\b|SUBTOTAL|^TAX\b|DEBIT\s*$", re.I),
+        re.compile(
+            r"BALANCE DUE|CHANGE\b|CREDIT\b|SUBTOTAL|^TAX\b|DEBIT\s*$", re.I
+        ),
     ),
     (
         "payment",
@@ -117,14 +119,18 @@ _COSTCO_RULES = [
     ),
     (
         "footer",
-        re.compile(r"OP#|Name:|Whse:|Trm:|Trn:|thank you|Please Come Again", re.I),
+        re.compile(
+            r"OP#|Name:|Whse:|Trm:|Trn:|thank you|Please Come Again", re.I
+        ),
     ),
 ]
 _VONS_RULES = [
     ("store_header", re.compile(r"VONS|Safeway|Store\s?#|Main Street", re.I)),
     (
         "savings",
-        re.compile(r"SAVINGS|Club Savings|YOU PAY|Price You Pay|Member Savings", re.I),
+        re.compile(
+            r"SAVINGS|Club Savings|YOU PAY|Price You Pay|Member Savings", re.I
+        ),
     ),
     (
         "section_header",
@@ -220,7 +226,9 @@ _INNOUT_RULES = [
     ),
     (
         "transaction",
-        re.compile(r"Cashier|ORDERTAKER|Check\s*:|TRANS\s*#|Ticket|Station", re.I),
+        re.compile(
+            r"Cashier|ORDERTAKER|Check\s*:|TRANS\s*#|Ticket|Station", re.I
+        ),
     ),
     ("note", re.compile(r"^NOTE\b|^tes$", re.I)),
     (
@@ -295,14 +303,17 @@ _WILDFORK_RULES = [
     (
         "address",
         re.compile(
-            r"(Westlake|Blvd\.?|,\s*CA\s+\d{5}|^\d{3}\s*S\.|" r"1-833-300-9453)",
+            r"(Westlake|Blvd\.?|,\s*CA\s+\d{5}|^\d{3}\s*S\.|"
+            r"1-833-300-9453)",
             re.I,
         ),
     ),
     ("policy", re.compile(r"FEFO|returns|refunds|exchanges", re.I)),
     (
         "transaction",
-        re.compile(r"Ticket\s?#|Station:|Sales Rep|User:|^\d{1,2}/\d{1,2}/\d{4}", re.I),
+        re.compile(
+            r"Ticket\s?#|Station:|Sales Rep|User:|^\d{1,2}/\d{1,2}/\d{4}", re.I
+        ),
     ),
     # Column header row (Item/Description/Qty/Price). "Total" dropped: it
     # also matched standalone "Total"/"Total Tax" lines, which then folded to
@@ -429,15 +440,20 @@ def _run_widths(mask: np.ndarray) -> list[int]:
         padded = np.concatenate([[0], row.view(np.uint8), [0]])
         starts = np.where(np.diff(padded) == 1)[0]
         ends = np.where(np.diff(padded) == -1)[0]
-        out.extend(int(e - s) for s, e in zip(starts, ends) if 1 <= e - s <= 20)
+        out.extend(
+            int(e - s) for s, e in zip(starts, ends) if 1 <= e - s <= 20
+        )
     return out
 
 
 def measure(image_id: str, receipt_id: int, merchant: str = "sprouts") -> dict:
-    from receipt_dynamo.data.dynamo_client import DynamoClient
     from receipt_line_scorecard import _load_words_and_real
 
-    real, words = _load_words_and_real("Sprouts Farmers Market", image_id, receipt_id)
+    from receipt_dynamo.data.dynamo_client import DynamoClient
+
+    # _load_words_and_real ignores its merchant arg (loads purely by
+    # image/receipt id); pass the caller's merchant through for clarity.
+    real, words = _load_words_and_real(merchant, image_id, receipt_id)
     gray = np.asarray(real.convert("L"))
     H, W = gray.shape
 
@@ -446,7 +462,9 @@ def measure(image_id: str, receipt_id: int, merchant: str = "sprouts") -> dict:
     )
     details = client.get_image_details(image_id)
     letters = [
-        l for l in details.receipt_letters if str(l.receipt_id) == str(receipt_id)
+        l
+        for l in details.receipt_letters
+        if str(l.receipt_id) == str(receipt_id)
     ]
 
     def box_px(obj):
@@ -480,7 +498,11 @@ def measure(image_id: str, receipt_id: int, merchant: str = "sprouts") -> dict:
     ws.sort(key=lambda w: w["cy"])
     lines: list[list[dict]] = []
     for w in ws:
-        if lines and abs(w["cy"] - median(x["cy"] for x in lines[-1])) < w["h"] * 0.6:
+        if (
+            lines
+            and abs(w["cy"] - median(x["cy"] for x in lines[-1]))
+            < w["h"] * 0.6
+        ):
             lines[-1].append(w)
         else:
             lines.append([w])
@@ -540,7 +562,9 @@ def measure(image_id: str, receipt_id: int, merchant: str = "sprouts") -> dict:
                     {
                         "ch": ch,
                         "density": round(float(mask.mean()), 4),
-                        "stroke": (round(float(np.mean(runs)), 2) if runs else None),
+                        "stroke": (
+                            round(float(np.mean(runs)), 2) if runs else None
+                        ),
                         "h": int(yi1 - yi0),
                     }
                 )
@@ -591,26 +615,33 @@ def measure(image_id: str, receipt_id: int, merchant: str = "sprouts") -> dict:
     body_caps = [
         l["cap_px"]
         for l in out_lines
-        if l["section"] in ("item", "other", "footer", "survey") and l["cap_px"]
+        if l["section"] in ("item", "other", "footer", "survey")
+        and l["cap_px"]
     ]
     body_strokes = [
         l["stroke_med"]
         for l in out_lines
-        if l["section"] in ("item", "other", "footer", "survey") and l["stroke_med"]
+        if l["section"] in ("item", "other", "footer", "survey")
+        and l["stroke_med"]
     ]
     body_cap = median(body_caps) if body_caps else None
     body_stroke = median(body_strokes) if body_strokes else None
     body_boxes = [
         l["box_h"]
         for l in out_lines
-        if l["section"] in ("item", "other", "footer", "survey") and l["box_h"] > 0
+        if l["section"] in ("item", "other", "footer", "survey")
+        and l["box_h"] > 0
     ]
     body_box_h = median(body_boxes) if body_boxes else None
     for l in out_lines:
         tier = "normal"
         if body_cap and l["cap_px"] and l["cap_px"] >= 1.45 * body_cap:
             tier = "large"
-        elif body_stroke and l["stroke_med"] and l["stroke_med"] >= 1.30 * body_stroke:
+        elif (
+            body_stroke
+            and l["stroke_med"]
+            and l["stroke_med"] >= 1.30 * body_stroke
+        ):
             tier = "bold"
         l["tier"] = tier
 

--- a/tools/glyph-studio/py/glyphstudio/stylescan.py
+++ b/tools/glyph-studio/py/glyphstudio/stylescan.py
@@ -69,9 +69,7 @@ _RULES = [
     ("total_line", re.compile(r"^Total:", re.I)),
     (
         "summary",
-        re.compile(
-            r"BALANCE DUE|CHANGE\b|CREDIT\b|SUBTOTAL|^TAX\b|DEBIT\s*$", re.I
-        ),
+        re.compile(r"BALANCE DUE|CHANGE\b|CREDIT\b|SUBTOTAL|^TAX\b|DEBIT\s*$", re.I),
     ),
     (
         "payment",
@@ -119,18 +117,14 @@ _COSTCO_RULES = [
     ),
     (
         "footer",
-        re.compile(
-            r"OP#|Name:|Whse:|Trm:|Trn:|thank you|Please Come Again", re.I
-        ),
+        re.compile(r"OP#|Name:|Whse:|Trm:|Trn:|thank you|Please Come Again", re.I),
     ),
 ]
 _VONS_RULES = [
     ("store_header", re.compile(r"VONS|Safeway|Store\s?#|Main Street", re.I)),
     (
         "savings",
-        re.compile(
-            r"SAVINGS|Club Savings|YOU PAY|Price You Pay|Member Savings", re.I
-        ),
+        re.compile(r"SAVINGS|Club Savings|YOU PAY|Price You Pay|Member Savings", re.I),
     ),
     (
         "section_header",
@@ -226,9 +220,7 @@ _INNOUT_RULES = [
     ),
     (
         "transaction",
-        re.compile(
-            r"Cashier|ORDERTAKER|Check\s*:|TRANS\s*#|Ticket|Station", re.I
-        ),
+        re.compile(r"Cashier|ORDERTAKER|Check\s*:|TRANS\s*#|Ticket|Station", re.I),
     ),
     ("note", re.compile(r"^NOTE\b|^tes$", re.I)),
     (
@@ -303,17 +295,14 @@ _WILDFORK_RULES = [
     (
         "address",
         re.compile(
-            r"(Westlake|Blvd\.?|,\s*CA\s+\d{5}|^\d{3}\s*S\.|"
-            r"1-833-300-9453)",
+            r"(Westlake|Blvd\.?|,\s*CA\s+\d{5}|^\d{3}\s*S\.|" r"1-833-300-9453)",
             re.I,
         ),
     ),
     ("policy", re.compile(r"FEFO|returns|refunds|exchanges", re.I)),
     (
         "transaction",
-        re.compile(
-            r"Ticket\s?#|Station:|Sales Rep|User:|^\d{1,2}/\d{1,2}/\d{4}", re.I
-        ),
+        re.compile(r"Ticket\s?#|Station:|Sales Rep|User:|^\d{1,2}/\d{1,2}/\d{4}", re.I),
     ),
     # Column header row (Item/Description/Qty/Price). "Total" dropped: it
     # also matched standalone "Total"/"Total Tax" lines, which then folded to
@@ -440,20 +429,15 @@ def _run_widths(mask: np.ndarray) -> list[int]:
         padded = np.concatenate([[0], row.view(np.uint8), [0]])
         starts = np.where(np.diff(padded) == 1)[0]
         ends = np.where(np.diff(padded) == -1)[0]
-        out.extend(
-            int(e - s) for s, e in zip(starts, ends) if 1 <= e - s <= 20
-        )
+        out.extend(int(e - s) for s, e in zip(starts, ends) if 1 <= e - s <= 20)
     return out
 
 
 def measure(image_id: str, receipt_id: int, merchant: str = "sprouts") -> dict:
+    from receipt_dynamo.data.dynamo_client import DynamoClient
     from receipt_line_scorecard import _load_words_and_real
 
-    from receipt_dynamo.data.dynamo_client import DynamoClient
-
-    real, words = _load_words_and_real(
-        "Sprouts Farmers Market", image_id, receipt_id
-    )
+    real, words = _load_words_and_real("Sprouts Farmers Market", image_id, receipt_id)
     gray = np.asarray(real.convert("L"))
     H, W = gray.shape
 
@@ -462,9 +446,7 @@ def measure(image_id: str, receipt_id: int, merchant: str = "sprouts") -> dict:
     )
     details = client.get_image_details(image_id)
     letters = [
-        l
-        for l in details.receipt_letters
-        if str(l.receipt_id) == str(receipt_id)
+        l for l in details.receipt_letters if str(l.receipt_id) == str(receipt_id)
     ]
 
     def box_px(obj):
@@ -498,11 +480,7 @@ def measure(image_id: str, receipt_id: int, merchant: str = "sprouts") -> dict:
     ws.sort(key=lambda w: w["cy"])
     lines: list[list[dict]] = []
     for w in ws:
-        if (
-            lines
-            and abs(w["cy"] - median(x["cy"] for x in lines[-1]))
-            < w["h"] * 0.6
-        ):
+        if lines and abs(w["cy"] - median(x["cy"] for x in lines[-1])) < w["h"] * 0.6:
             lines[-1].append(w)
         else:
             lines.append([w])
@@ -562,9 +540,7 @@ def measure(image_id: str, receipt_id: int, merchant: str = "sprouts") -> dict:
                     {
                         "ch": ch,
                         "density": round(float(mask.mean()), 4),
-                        "stroke": (
-                            round(float(np.mean(runs)), 2) if runs else None
-                        ),
+                        "stroke": (round(float(np.mean(runs)), 2) if runs else None),
                         "h": int(yi1 - yi0),
                     }
                 )
@@ -603,6 +579,10 @@ def measure(image_id: str, receipt_id: int, merchant: str = "sprouts") -> dict:
                 "stroke_med": round(median(strokes), 2) if strokes else None,
                 "underline": underline,
                 "n_letters": len(chars),
+                # OCR line-box height: a weaker size signal than per-letter
+                # caps, but present even when letters are missing (URL rows,
+                # dropped letter records) -- the M4 selector's middle rung.
+                "box_h": round(lb - lt, 1),
                 "letters": chars,
             }
         )
@@ -611,26 +591,26 @@ def measure(image_id: str, receipt_id: int, merchant: str = "sprouts") -> dict:
     body_caps = [
         l["cap_px"]
         for l in out_lines
-        if l["section"] in ("item", "other", "footer", "survey")
-        and l["cap_px"]
+        if l["section"] in ("item", "other", "footer", "survey") and l["cap_px"]
     ]
     body_strokes = [
         l["stroke_med"]
         for l in out_lines
-        if l["section"] in ("item", "other", "footer", "survey")
-        and l["stroke_med"]
+        if l["section"] in ("item", "other", "footer", "survey") and l["stroke_med"]
     ]
     body_cap = median(body_caps) if body_caps else None
     body_stroke = median(body_strokes) if body_strokes else None
+    body_boxes = [
+        l["box_h"]
+        for l in out_lines
+        if l["section"] in ("item", "other", "footer", "survey") and l["box_h"] > 0
+    ]
+    body_box_h = median(body_boxes) if body_boxes else None
     for l in out_lines:
         tier = "normal"
         if body_cap and l["cap_px"] and l["cap_px"] >= 1.45 * body_cap:
             tier = "large"
-        elif (
-            body_stroke
-            and l["stroke_med"]
-            and l["stroke_med"] >= 1.30 * body_stroke
-        ):
+        elif body_stroke and l["stroke_med"] and l["stroke_med"] >= 1.30 * body_stroke:
             tier = "bold"
         l["tier"] = tier
 
@@ -640,6 +620,7 @@ def measure(image_id: str, receipt_id: int, merchant: str = "sprouts") -> dict:
         "image_size": [W, H],
         "body_cap_px": body_cap,
         "body_stroke_px": body_stroke,
+        "body_box_h": body_box_h,
         "lines": out_lines,
     }
 

--- a/tools/glyph-studio/py/m4_face_pilot.py
+++ b/tools/glyph-studio/py/m4_face_pilot.py
@@ -1,0 +1,378 @@
+#!/usr/bin/env python3
+"""M4 pilot driver: A/B stylemap text rules vs MEASURED typography (Wild Fork).
+
+For every vetted receipt of the merchant (OCR x-overlap score <= 2, the M3
+vetting rule), this:
+
+1. measures per-line typography from the REAL scan (glyphstudio.stylescan),
+2. builds the measured row->face map (glyphstudio.face_select; fallback
+   ladder measurement -> M2 section prior -> renderer stylemap rules),
+3. renders the receipt twice at identical canvas size -- face_source
+   "stylemap" (production default) vs "measured" (opt-in path),
+4. scores per-line FACE AGREEMENT of each path against the measured truth,
+5. runs the production scorecard (receipt_line_scorecard) on both renders,
+6. saves one labeled side-by-side per receipt: real | stylemap | measured.
+
+Usage:
+  python m4_face_pilot.py --out-dir /tmp/m4_pilot \
+      [--merchant "Wild Fork:wildfork"] [--limit 10]
+
+Env: PYTHONPATH=receipt_agent:receipt_dynamo:receipt_upload:synthesis_loop:
+scripts, DYNAMODB_TABLE_NAME, AWS_REGION, PORTFOLIO_ENV=dev,
+RECEIPT_PAPER_STRENGTH=0.3 (render calibration), optional BITMATRIX_DIR.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import os
+import sys
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_ROOT = os.path.abspath(os.path.join(_HERE, "..", "..", ".."))
+for _p in (
+    _HERE,
+    os.path.join(_ROOT, "receipt_agent"),
+    os.path.join(_ROOT, "receipt_dynamo"),
+    os.path.join(_ROOT, "receipt_upload"),
+    os.path.join(_ROOT, "synthesis_loop"),
+    os.path.join(_ROOT, "scripts"),
+):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+MAX_OVERLAPS = 2  # M3 vetting threshold
+LARGE = 1.30  # scale bucket boundary (matches face_select.LARGE_CAP)
+
+
+def _truth_from_line(line, body_cap, body_stroke):
+    """Measured (large, heavy, underline) truth triple, or None.
+
+    Truth comes from the selector's LETTERS rung only (the strongest
+    evidence, noise-guarded and hand-checked); lines it cannot measure are
+    excluded from agreement scoring rather than judged against weak rungs.
+    """
+    from glyphstudio.face_select import measured_style_for_line
+
+    style = measured_style_for_line(line, body_cap, body_stroke)
+    if style is None:
+        return None
+    return (
+        float(style["scale"]) >= LARGE,
+        style["face"] == "heavy",
+        bool(style["underline"]),
+    )
+
+
+def _pred_from_style(style):
+    return (
+        float(style["scale"]) >= LARGE,
+        bool(style["bold"]),
+        bool(style["underline"]),
+    )
+
+
+def _agreement(measurement, row_faces, stylemap_json):
+    """Per-line agreement of both paths against the measured truth."""
+    from glyphstudio.face_select import normalize_face_key
+
+    from receipt_agent.agents.label_evaluator.rendering.receipt_stylemap import (  # noqa: E501
+        measured_row_style,
+        row_style,
+    )
+
+    body_cap = measurement.get("body_cap_px")
+    body_stroke = measurement.get("body_stroke_px")
+    rows = []
+    for line in measurement.get("lines") or ():
+        truth = _truth_from_line(line, body_cap, body_stroke)
+        if truth is None:
+            continue
+        text = line.get("text") or ""
+        rule = row_style(stylemap_json, text.upper())
+        # The measured render's effective style: covered row -> measured
+        # entry; uncovered (conflict-dropped/skipped) -> stylemap fallback,
+        # exactly what the renderer does.
+        key = normalize_face_key(text)
+        entry = row_faces.get(key)
+        meas = measured_row_style({key: entry}, text) if entry else None
+        rows.append(
+            {
+                "text": text,
+                "truth": truth,
+                "stylemap": _pred_from_style(rule),
+                "measured": _pred_from_style(meas if meas else rule),
+                "measured_source": "measured" if meas else "fallback",
+            }
+        )
+    return rows
+
+
+def _summarize(rows):
+    out = {}
+    for path in ("stylemap", "measured"):
+        n = len(rows)
+        attr_hits = [0, 0, 0]
+        full = 0
+        for r in rows:
+            hits = [int(a == b) for a, b in zip(r[path], r["truth"])]
+            attr_hits = [x + y for x, y in zip(attr_hits, hits)]
+            full += int(all(hits))
+        out[path] = {
+            "n": n,
+            "scale_tier": attr_hits[0] / n if n else None,
+            "face": attr_hits[1] / n if n else None,
+            "underline": attr_hits[2] / n if n else None,
+            "all_three": full / n if n else None,
+        }
+    return out
+
+
+def _load_receipt_payload(client, merchant, image_id, receipt_id):
+    """Words + barcodes + geometry, matching glyph_review.receipt."""
+    details = client.get_image_details(image_id)
+    rec = next(
+        (r for r in details.receipts if str(r.receipt_id) == str(receipt_id)),
+        None,
+    )
+    if rec is None:
+        raise RuntimeError(f"receipt {receipt_id} not found for {image_id}")
+    lbl = {
+        (l.line_id, l.word_id): l.label
+        for l in details.receipt_word_labels
+        if l.receipt_id == receipt_id
+    }
+    words = [
+        {
+            "text": w.text,
+            "line_id": w.line_id,
+            "word_id": w.word_id,
+            "bbox": [
+                w.top_left["x"] * 1000,
+                w.top_left["y"] * 1000,
+                w.bottom_right["x"] * 1000,
+                w.bottom_right["y"] * 1000,
+            ],
+            "labels": (
+                [lbl[(w.line_id, w.word_id)]]
+                if lbl.get((w.line_id, w.word_id)) not in (None, "O")
+                else []
+            ),
+        }
+        for w in details.receipt_words
+        if w.receipt_id == receipt_id
+    ]
+    barcodes = []
+    if hasattr(client, "list_receipt_barcodes_from_receipt"):
+        try:
+            for b in client.list_receipt_barcodes_from_receipt(image_id, receipt_id):
+                barcodes.append(
+                    {
+                        "text": getattr(b, "text", "") or "",
+                        "symbology": getattr(b, "symbology", ""),
+                        "top_left": getattr(b, "top_left", None),
+                        "bottom_right": getattr(b, "bottom_right", None),
+                        "confidence": getattr(b, "confidence", None),
+                    }
+                )
+        except Exception:  # noqa: BLE001
+            barcodes = []
+    return rec, words, barcodes
+
+
+def _panelize(images, labels, out_png, panel_w=400):
+    from PIL import Image, ImageDraw, ImageFont
+
+    try:
+        lab = ImageFont.truetype("/System/Library/Fonts/Supplemental/Arial.ttf", 16)
+    except OSError:
+        lab = ImageFont.load_default()
+    resized = [
+        im.resize((panel_w, int(im.height * panel_w / im.width))) for im in images
+    ]
+    hh = max(im.height for im in resized) + 40
+    cv = Image.new(
+        "RGB",
+        (panel_w * len(resized) + 20 * (len(resized) + 1), hh),
+        (235, 235, 235),
+    )
+    dd = ImageDraw.Draw(cv)
+    x = 20
+    for t, im in zip(labels, resized):
+        cv.paste(im, (x, 34))
+        dd.text((x, 12), t, fill=(200, 0, 0), font=lab)
+        x += panel_w + 20
+    cv.save(out_png)
+    # header zoom (the region where WF's face differences live)
+    crop = cv.crop((0, 0, cv.width, 34 + int((hh - 34) * 0.22)))
+    crop = crop.resize((crop.width * 2, crop.height * 2))
+    crop.save(os.path.splitext(out_png)[0] + ".zoom_header.png")
+
+
+def _scorecard(real, syn, words):
+    from glyph_review import _ink_metrics
+    from receipt_line_scorecard import score_receipt_images
+
+    report = score_receipt_images(real, syn, words)
+    counts = report["summary"]["severity_counts"]
+    rm, sm = _ink_metrics(real, words), _ink_metrics(syn, words)
+    gates = {}
+    if rm and sm:
+        gates = {
+            "h_ratio": round(sm["h_med"] / max(1.0, rm["h_med"]), 3),
+            "wpc_ratio": round(sm["wpc_med"] / max(1.0, rm["wpc_med"]), 3),
+            "density_ratio": round(sm["density_med"] / max(1e-6, rm["density_med"]), 3),
+        }
+    return {
+        "blockers": counts.get("BLOCKER", 0),
+        "minors": counts.get("MINOR", 0),
+        **gates,
+    }
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--out-dir", required=True)
+    ap.add_argument("--merchant", default="Wild Fork:wildfork")
+    ap.add_argument("--limit", type=int, default=10)
+    args = ap.parse_args(argv)
+    os.makedirs(args.out_dir, exist_ok=True)
+    merchant, _, slug = args.merchant.partition(":")
+
+    from io import BytesIO
+
+    import boto3
+    import render_synthetic_receipts as rsr
+    from glyph_review import _ink_metrics  # noqa: F401  (path check)
+    from glyphstudio.face_select import select_row_faces
+    from glyphstudio.section_face_map import load_merchant_faces
+    from glyphstudio.stylescan import measure
+    from m3_acceptance import ocr_overlap_score
+    from PIL import Image
+    from receipt_dynamo.data.dynamo_client import DynamoClient
+
+    table = os.environ.get("DYNAMODB_TABLE_NAME", "ReceiptsTable-dc5be22")
+    region = os.environ.get("AWS_REGION", "us-east-1")
+    client = DynamoClient(table_name=table, region=region)
+    s3 = boto3.client("s3", region_name=region)
+
+    prof = rsr.cached_font_profile(table, merchant, region=region, max_receipts=12)
+    ss = rsr.section_scale_for_merchant(merchant)
+    typ = rsr.merchant_typography(merchant)
+    priors = load_merchant_faces(
+        os.path.join(_ROOT, "tools", "glyph-studio", "fonts", slug)
+    )
+
+    places, _ = client.get_receipt_places_by_merchant(merchant_name=merchant, limit=50)
+    all_rows, per_receipt = [], {}
+    for p in places:
+        if len(per_receipt) >= args.limit:
+            break
+        iid, rid = p.image_id, p.receipt_id
+        tag = f"{iid[:8]}_{rid}"
+        try:
+            rec, words, barcodes = _load_receipt_payload(client, merchant, iid, rid)
+        except Exception as exc:  # noqa: BLE001
+            print(f"[skip] {tag}: load failed ({exc})")
+            continue
+        overlaps = ocr_overlap_score(words)
+        if overlaps > MAX_OVERLAPS:
+            print(f"[vet] {tag}: rejected ({overlaps} x-overlap pairs)")
+            continue
+
+        measurement = measure(iid, rid, merchant=slug)
+        row_faces, stats = select_row_faces(measurement, section_priors=priors)
+        rows = _agreement(measurement, row_faces, typ.get("stylemap"))
+        all_rows.extend(rows)
+
+        # A/B renders at identical canvas size (locked rule: same heights).
+        wt = 760
+        ht = int(round(wt * rec.height / rec.width))
+        payload = {
+            "words": words,
+            "barcodes": barcodes,
+            "merchant_name": merchant,
+        }
+        paths = {}
+        for mode, extra in (
+            ("stylemap", {}),
+            (
+                "measured",
+                {"face_source": "measured", "row_faces": row_faces},
+            ),
+        ):
+            out = os.path.join(args.out_dir, f"{tag}.{mode}.png")
+            t = dict(typ)
+            t.update(extra)
+            rsr._render_cached_hybrid(
+                copy.deepcopy(payload),
+                None,
+                profile=prof,
+                width=wt,
+                height=ht,
+                path=out,
+                section_scale=ss,
+                **t,
+            )
+            paths[mode] = out
+
+        real = None
+        for bkt, key in (
+            (rec.cdn_s3_bucket, rec.cdn_s3_key),
+            (rec.raw_s3_bucket, rec.raw_s3_key),
+        ):
+            if not bkt or not key:
+                continue
+            try:
+                real = Image.open(
+                    BytesIO(s3.get_object(Bucket=bkt, Key=key)["Body"].read())
+                ).convert("RGB")
+                break
+            except Exception:  # noqa: BLE001
+                continue
+        if real is None:
+            print(f"[skip] {tag}: no loadable real image")
+            continue
+
+        syn_a = Image.open(paths["stylemap"]).convert("RGB")
+        syn_b = Image.open(paths["measured"]).convert("RGB")
+        side = os.path.join(args.out_dir, f"{tag}.side_by_side.png")
+        _panelize([real, syn_a, syn_b], ["REAL", "STYLEMAP", "MEASURED"], side)
+
+        real_m = real.resize((wt, ht))
+        cards = {
+            m: _scorecard(real_m, im, words)
+            for m, im in (("stylemap", syn_a), ("measured", syn_b))
+        }
+        per_receipt[tag] = {
+            "image_id": iid,
+            "receipt_id": rid,
+            "selector_stats": stats,
+            "agreement": _summarize(rows),
+            "scorecard": cards,
+            "side_by_side": side,
+        }
+        print(
+            f"[ok] {tag}: rows={len(rows)} selector={stats} "
+            f"scorecard stylemap={cards['stylemap']} "
+            f"measured={cards['measured']}"
+        )
+
+    summary = {
+        "merchant": args.merchant,
+        "receipts": per_receipt,
+        "pooled_agreement": _summarize(all_rows),
+        "pooled_rows": len(all_rows),
+    }
+    out_json = os.path.join(args.out_dir, "m4_pilot_summary.json")
+    with open(out_json, "w", encoding="utf-8") as fh:
+        json.dump(summary, fh, indent=1, sort_keys=True)
+    print(json.dumps(summary["pooled_agreement"], indent=1))
+    print(f"-> {out_json}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/glyph-studio/py/m4_face_pilot.py
+++ b/tools/glyph-studio/py/m4_face_pilot.py
@@ -285,7 +285,6 @@ def main(argv=None) -> int:
         measurement = measure(iid, rid, merchant=slug)
         row_faces, stats = select_row_faces(measurement, section_priors=priors)
         rows = _agreement(measurement, row_faces, typ.get("stylemap"))
-        all_rows.extend(rows)
 
         # A/B renders at identical canvas size (locked rule: same heights).
         wt = 760
@@ -346,6 +345,9 @@ def main(argv=None) -> int:
             m: _scorecard(real_m, im, words)
             for m, im in (("stylemap", syn_a), ("measured", syn_b))
         }
+        # Pool agreement rows only for receipts that made it all the way
+        # (else pooled vs per-receipt describe different populations).
+        all_rows.extend(rows)
         per_receipt[tag] = {
             "image_id": iid,
             "receipt_id": rid,

--- a/tools/glyph-studio/py/tests/test_face_select.py
+++ b/tools/glyph-studio/py/tests/test_face_select.py
@@ -4,11 +4,8 @@ import os
 import sys
 
 import pytest
-from glyphstudio.face_select import (
-    measured_style_for_line,
-    normalize_face_key,
-    select_row_faces,
-)
+from glyphstudio.face_select import (measured_style_for_line,
+                                     normalize_face_key, select_row_faces)
 from glyphstudio.section_face_map import Face
 
 
@@ -223,9 +220,8 @@ def test_normalize_key_parity_with_renderer():
     )
     sys.path.insert(0, os.path.join(root, "receipt_agent"))
     try:
-        from receipt_agent.agents.label_evaluator.rendering.receipt_stylemap import (  # noqa: E501
-            normalize_face_key as renderer_key,
-        )
+        from receipt_agent.agents.label_evaluator.rendering.receipt_stylemap import \
+            normalize_face_key as renderer_key  # noqa: E501
     except ImportError:
         pytest.skip("receipt_agent not importable in this environment")
     for text in (
@@ -236,3 +232,61 @@ def test_normalize_key_parity_with_renderer():
         "Total Tax 0. 00",
     ):
         assert normalize_face_key(text) == renderer_key(text)
+
+
+def test_bimodal_cap_samples_cannot_size_a_row():
+    # In-N-Out 9afeb902#2 "Questions/Comments: ... Call": true caps at
+    # 46-47px with 83-84px digits leaked from a neighboring line; the
+    # median (65px = 1.51x body) sized a row that does not exist on the
+    # print (hand-checked as plain small text). Bimodal caps -> no sizing.
+    letters = [
+        {"ch": c, "h": h}
+        for c, h in [
+            ("C", 46),
+            ("C", 46),
+            ("C", 46),
+            ("Q", 47),
+            ("C", 47),
+            ("Q", 47),
+            ("C", 47),
+            ("Q", 47),
+            ("C", 47),
+            ("0", 83),
+            ("5", 83),
+            ("0", 83),
+            ("5", 83),
+            ("0", 83),
+            ("5", 83),
+            ("3", 84),
+            ("3", 84),
+            ("3", 84),
+        ]
+    ]
+    faces, _ = select_row_faces(
+        _measurement(
+            [
+                _line(
+                    "Questions/Comments: ad0a-53e24d Call",
+                    cap=65.0,
+                    stroke=3.02,
+                    n=90,
+                    letters=letters,
+                )
+            ],
+            body_cap=43.0,
+            body_stroke=3.0,
+        )
+    )
+    key = normalize_face_key("Questions/Comments: ad0a-53e24d Call")
+    assert faces[key]["scale"] == 1.0
+    assert faces[key]["face"] == "regular"
+
+
+def test_unimodal_cap_samples_still_size_an_enlarged_header():
+    # A genuine enlarged header disperses tight (WF "Thousand Oaks CA"
+    # letters all ~85px) and must keep its measured scale.
+    letters = [{"ch": c, "h": 85} for c in "THOUSANDOAKSCA"]
+    faces, _ = select_row_faces(
+        _measurement([_line("Thousand Oaks CA", cap=85.0, stroke=6.2, letters=letters)])
+    )
+    assert faces[normalize_face_key("Thousand Oaks CA")]["scale"] == 1.7

--- a/tools/glyph-studio/py/tests/test_face_select.py
+++ b/tools/glyph-studio/py/tests/test_face_select.py
@@ -1,0 +1,238 @@
+"""Unit tests for the M4 measured-typography face selector."""
+
+import os
+import sys
+
+import pytest
+from glyphstudio.face_select import (
+    measured_style_for_line,
+    normalize_face_key,
+    select_row_faces,
+)
+from glyphstudio.section_face_map import Face
+
+
+def _line(text, cap=50.0, stroke=3.8, n=20, section="item", **kw):
+    letters = kw.pop(
+        "letters",
+        ([{"ch": c, "h": cap} for c in text if not c.isspace()] if cap else []),
+    )
+    out = {
+        "text": text,
+        "cap_px": cap,
+        "stroke_med": stroke,
+        "n_letters": n,
+        "section": section,
+        "section_canonical": kw.pop("section_canonical", section),
+        "underline": False,
+        "reverse_video": 0,
+        "tier": "normal",
+        "letters": letters,
+    }
+    out.update(kw)
+    return out
+
+
+def _measurement(lines, body_cap=50.0, body_stroke=3.8, body_box_h=None):
+    return {
+        "body_cap_px": body_cap,
+        "body_stroke_px": body_stroke,
+        "body_box_h": body_box_h,
+        "lines": lines,
+    }
+
+
+def test_body_line_is_regular_scale_one():
+    faces, stats = select_row_faces(
+        _measurement([_line("8304 1 5.00 5.00", cap=53.0, stroke=3.9)])
+    )
+    style = faces[normalize_face_key("8304 1 5.00 5.00")]
+    assert style == {
+        "face": "regular",
+        "scale": 1.0,
+        "underline": False,
+        "reverse_video": False,
+        "source": "measured",
+    }
+    assert stats["measured"] == 1
+
+
+def test_enlarged_header_scales_but_stays_regular():
+    # WF's "Thousand Oaks CA": cap_rel ~1.7 with strokes growing WITH the
+    # caps -> same face enlarged, NOT the heavy face.
+    faces, _ = select_row_faces(
+        _measurement([_line("Thousand Oaks CA", cap=85.0, stroke=6.2)])
+    )
+    style = faces[normalize_face_key("Thousand Oaks CA")]
+    assert style["face"] == "regular"
+    assert style["scale"] == 1.7
+
+
+def test_disproportionate_stroke_selects_heavy():
+    # body-cap row printed with ~1.6x strokes = a genuinely bolder face
+    faces, _ = select_row_faces(
+        _measurement([_line("BALANCE DUE 12.34", cap=51.0, stroke=6.2)])
+    )
+    assert faces[normalize_face_key("BALANCE DUE 12.34")]["face"] == "heavy"
+
+
+def test_mild_stroke_on_small_caps_is_not_heavy():
+    # WF's phone line: stroke_rel 1.17 at cap_rel 0.88 inflates the
+    # stroke/cap ratio past 1.3, but absolute stroke is body-like ->
+    # regular (hand-checked real crop is plain body).
+    faces, _ = select_row_faces(
+        _measurement([_line("1-833-300-9453", cap=44.0, stroke=4.45)])
+    )
+    assert faces[normalize_face_key("1-833-300-9453")]["face"] == "regular"
+
+
+def test_single_cap_sample_cannot_size_a_row():
+    # WF's "Tender:": one cap sample ('T'), an OCR smear read as 1.34x
+    # body -> scale stays 1.0 (hand-checked as plain body height).
+    letters = [{"ch": c, "h": 50.0} for c in "Tender:"]
+    faces, _ = select_row_faces(
+        _measurement([_line("Tender:", cap=67.0, letters=letters)])
+    )
+    assert faces[normalize_face_key("Tender:")]["scale"] == 1.0
+
+
+def test_underline_plus_reverse_is_scan_artifact():
+    # A dark scan band trips both probes on a body-weight line -> both
+    # cleared (hand-checked on ccc09736's payment block).
+    faces, _ = select_row_faces(
+        _measurement(
+            [
+                _line(
+                    "Entry Method: EMV Contactless",
+                    underline=True,
+                    reverse_video=1,
+                )
+            ]
+        )
+    )
+    style = faces[normalize_face_key("Entry Method: EMV Contactless")]
+    assert style["underline"] is False
+    assert style["reverse_video"] is False
+
+
+def test_real_underline_without_reverse_is_kept():
+    faces, _ = select_row_faces(_measurement([_line("SECTION HEADER", underline=True)]))
+    assert faces[normalize_face_key("SECTION HEADER")]["underline"] is True
+
+
+def test_scale_clamped_below_logo_sizes():
+    faces, _ = select_row_faces(
+        _measurement([_line("W F 4 5", cap=211.0, stroke=10.5, n=4)])
+    )
+    assert faces[normalize_face_key("W F 4 5")]["scale"] == 2.5
+
+
+def test_missing_letters_falls_back_to_box_rung():
+    # URL rows lose their letter records; the OCR box height still sizes
+    # them (and correctly keeps a body-height row at 1.0 even when the
+    # section prior says 1.7 -- the f008ea77 footer-URL regression).
+    priors = {"storefront": Face(scale=1.7, weight="normal", underline_rate=0.0)}
+    faces, stats = select_row_faces(
+        _measurement(
+            [
+                _line(
+                    "wildforkfoods.com/pages/careers",
+                    cap=None,
+                    n=31,
+                    box_h=60.0,
+                    section_canonical="storefront",
+                )
+            ],
+            body_box_h=58.0,
+        ),
+        section_priors=priors,
+    )
+    style = faces[normalize_face_key("wildforkfoods.com/pages/careers")]
+    assert style["source"] == "measured_box"
+    assert style["scale"] == 1.0
+    assert stats["measured_box"] == 1 and stats["prior"] == 0
+
+
+def test_no_geometry_falls_back_to_section_prior():
+    priors = {"storefront": Face(scale=1.7, weight="normal", underline_rate=0.0)}
+    faces, stats = select_row_faces(
+        _measurement([_line("WF*", cap=None, n=2, section_canonical="storefront")]),
+        section_priors=priors,
+    )
+    style = faces[normalize_face_key("WF*")]
+    assert style["source"] == "prior"
+    assert style["scale"] == 1.7
+    assert style["face"] == "regular"
+    assert stats["prior"] == 1
+
+
+def test_bold_prior_maps_to_heavy_and_underline_rate_threshold():
+    priors = {"section_header": Face(scale=1.0, weight="bold", underline_rate=0.6)}
+    faces, _ = select_row_faces(
+        _measurement(
+            [
+                _line(
+                    "PRODUCE",
+                    cap=None,
+                    n=0,
+                    section_canonical="section_header",
+                )
+            ]
+        ),
+        section_priors=priors,
+    )
+    style = faces[normalize_face_key("PRODUCE")]
+    assert style["face"] == "heavy"
+    assert style["underline"] is True
+
+
+def test_no_measurement_no_prior_is_skipped():
+    faces, stats = select_row_faces(_measurement([_line("mystery row", cap=None, n=0)]))
+    assert faces == {}
+    assert stats["skipped"] == 1
+
+
+def test_conflicting_duplicate_text_is_dropped():
+    lines = [
+        _line("MASTERCARD", cap=50.0, stroke=3.8),
+        _line("MASTERCARD", cap=85.0, stroke=6.4),  # same text, large
+    ]
+    faces, stats = select_row_faces(_measurement(lines))
+    assert normalize_face_key("MASTERCARD") not in faces
+    assert stats["conflicts"] == 1
+
+
+def test_agreeing_duplicate_text_is_kept():
+    lines = [
+        _line("MASTERCARD", cap=50.0, stroke=3.8),
+        _line("MASTERCARD", cap=52.0, stroke=3.9),
+    ]
+    faces, _ = select_row_faces(_measurement(lines))
+    assert faces[normalize_face_key("MASTERCARD")]["face"] == "regular"
+
+
+def test_measured_style_for_line_thin_stats_return_none():
+    assert measured_style_for_line(_line("ab", cap=50.0, n=2), 50.0, 3.8) is None
+    assert measured_style_for_line(_line("abcdef", cap=None), 50.0, 3.8) is None
+
+
+def test_normalize_key_parity_with_renderer():
+    """The selector's key MUST equal the renderer's or every row misses."""
+    root = os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "..", "..", "..", "..")
+    )
+    sys.path.insert(0, os.path.join(root, "receipt_agent"))
+    try:
+        from receipt_agent.agents.label_evaluator.rendering.receipt_stylemap import (  # noqa: E501
+            normalize_face_key as renderer_key,
+        )
+    except ImportError:
+        pytest.skip("receipt_agent not importable in this environment")
+    for text in (
+        "Thousand Oaks CA",
+        "  double  spaced   text ",
+        "lower case row",
+        "x" * 80,
+        "Total Tax 0. 00",
+    ):
+        assert normalize_face_key(text) == renderer_key(text)


### PR DESCRIPTION
## What

M4 pilot: replace text-rule face guessing with MEASURED typography in synthetic receipt rendering, piloted on Wild Fork. Production render behavior stays **byte-identical by default** (verified: SHA of a default WF render is unchanged before/after this branch).

### The selector (`glyphstudio/face_select.py`)

For a receipt being mimicked, each row's face (regular/heavy), scale tier, and underline come from stylescan measurements of the REAL receipt, through a rung ladder (strongest first):

1. **letters** — per-letter cap/stroke statistics (`measured_style_for_line`)
2. **box** — OCR line-box height when letter stats are missing (`stylescan` now emits `box_h`/`body_box_h`)
3. **M2 section prior** — `section_face_map` face for the line's canonical section, only when the line has no usable geometry
4. **stylemap rules** — rows absent from the map fall through to the existing production text rules

Noise guards were hand-checked against real WF crops (each guard exists because the unguarded rule misfired on a real line):
- **heavy** requires strokes BOTH >=1.30x body AND >=1.30x the cap ratio (WF's enlarged header has proportional strokes = same face scaled; WF's phone line inflates stroke/cap at small caps)
- **sizing** requires >=3 cap-letter samples ("Tender:" has one smeared 'T' that reads 1.34x)
- **underline + reverse-video together** on a body-weight line = one dark scan band, both cleared (ccc09736's payment block)

### The renderer opt-in (`receipt_agent` + `scripts`)

`RenderConfig.face_source` (default `"stylemap"`, no-op) + `RenderConfig.row_faces`. When `face_source="measured"`, a covered row uses its measured style (heavy maps to the profile's compiled heavy atlas, scale multiplies the row cap, underline draws the measured rule); uncovered rows keep the stylemap rules. The WF profile carries the flag at its no-op default.

## A/B results (10 vetted WF receipts, OCR x-overlap <= 2; 058b662d correctly rejected)

Per-line agreement with letters-rung measured truth, 359 lines (`m4_face_pilot.py`):

| path | scale tier | face | underline | all three |
|---|---|---|---|---|
| stylemap rules | 99.7% | 100% | 100% | 99.7% |
| measured | 100%* | 100%* | 100%* | 100%* |

*measured agreement is partially by construction (the selector is derived from the same measurements); the meaningful evidence is the stylemap column, the visual side-by-sides, and the scorecards.

The one stylemap miss is real and visible: `Thousand Oaks CA•` (OCR trailing bullet) fails the `^Thousand Oaks CA$` anchor, so the rules print the store header at body size; measured renders it at its measured 1.66x (see `19a032ac` side-by-side). Measured also tracks the header's true per-receipt scale (1.58–2.0x across the corpus vs the fixed 1.7).

**Scorecard (production `receipt_line_scorecard`) on all 10 pairs: measured never regresses** — identical BLOCKER/MINOR counts on every receipt, h/wpc/density ratios within noise of the stylemap render (e.g. worst h_ratio delta 0.000, worst density delta 0.018).

### Honest read

On Wild Fork the text rules were already ~99.7% right per line: this corpus is body-single-face + one enlarged header, and after noise-guarding, no genuinely bold/underlined/reverse body rows exist in the 10 vetted receipts (the WF heavy atlas goes unused by BOTH paths). Measured wins where OCR text breaks regex anchors and on per-receipt header scale, and it removes the need to hand-write per-merchant regexes — but on this merchant it is a small, real improvement, not a step change. The pilot's more valuable output may be the guarded measurement rules themselves: the raw stylescan tiers misfired on 8/359 lines (false heavy x3, false large x4, scan-shadow underline x1), all caught by hand-checking crops.

## Files

- `tools/glyph-studio/py/glyphstudio/face_select.py` — selector + ladder (new)
- `tools/glyph-studio/py/glyphstudio/stylescan.py` — emit `box_h`/`body_box_h`
- `receipt_agent/.../receipt_stylemap.py` — `normalize_face_key` + `measured_row_style`
- `receipt_agent/.../receipt_renderer.py` — opt-in `face_source`/`row_faces` (default path untouched)
- `scripts/render_synthetic_receipts.py` — plumb both through `_render_cached_hybrid`
- `scripts/merchant_profiles.json` — WF `face_source: "stylemap"` (no-op flag)
- `tools/glyph-studio/py/m4_face_pilot.py` — A/B driver (new)
- tests: `test_face_select.py` (16, incl. renderer key-parity pin), `test_receipt_stylemap.py` (+3)

No `.npz`/sample artifacts committed; JSON sources only; dev-only reads, no AWS writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SRtFcxkcw1t3nZsVHstZGL


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional measured typography rendering for individual receipt rows.
  * Improved row styling with measured font weight, scale, and underline detection.
  * Added fallback handling using OCR measurements and merchant-specific typography guidance.
  * Added a pilot workflow to compare measured and default rendering results.

* **Bug Fixes**
  * Corrected merchant-specific measurement handling.
  * Improved safeguards for invalid or extreme typography measurements.

* **Tests**
  * Added coverage for measured styling, fallback behavior, normalization, conflicts, and scaling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->