### PR TITLE
[analytics] Add real-time visitor attribution layer

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -243,7 +243,7 @@ jobs:
           cd infra
           echo "NEXT_PUBLIC_GA_MEASUREMENT_ID=$(pulumi config get portfolio:googleAnalyticsMeasurementId --stack tnorlund/portfolio/prod)" >> "$GITHUB_ENV"
           echo "NEXT_PUBLIC_GTM_ID=$(pulumi config get portfolio:googleTagManagerId --stack tnorlund/portfolio/prod)" >> "$GITHUB_ENV"
-          echo "NEXT_PUBLIC_CLOUDFRONT_ANALYTICS_BEACON_PATH=/analytics/pixel.txt" >> "$GITHUB_ENV"
+          echo "NEXT_PUBLIC_CLOUDFRONT_ANALYTICS_BEACON_PATH=/analytics/collect" >> "$GITHUB_ENV"
         env:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,8 +8,10 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Keep a manually approved deploy isolated from validation runs. Otherwise a
+  # later push to main could cancel Pulumi or the S3 sync mid-deployment.
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
 
 env:
   PYTHONPATH: ${{ github.workspace }}
@@ -207,13 +209,13 @@ jobs:
           retention-days: 7
 
   # ============================================================================
-  # STAGE 2: Deploy (only after ALL tests pass, main branch only)
+  # STAGE 2: Deploy (manual dispatch from main after ALL tests pass)
   # ============================================================================
 
   deploy:
     name: Deploy
     needs: [lambda-syntax, python-tests, typescript-tests, browser-tests]
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    if: github.ref == 'refs/heads/main' && github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     environment: production
     steps:
@@ -228,6 +230,11 @@ jobs:
           node-version: "22"
           cache: "npm"
           cache-dependency-path: "portfolio/package-lock.json"
+
+      - name: Install pinned Pulumi CLI
+        uses: pulumi/actions@v6
+        with:
+          pulumi-version: 3.251.0
 
       - name: Configure AWS
         uses: aws-actions/configure-aws-credentials@v4
@@ -282,7 +289,7 @@ jobs:
   smoke-tests:
     name: Smoke Tests
     needs: deploy
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    if: github.ref == 'refs/heads/main' && github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -243,7 +243,7 @@ jobs:
           cd infra
           echo "NEXT_PUBLIC_GA_MEASUREMENT_ID=$(pulumi config get portfolio:googleAnalyticsMeasurementId --stack tnorlund/portfolio/prod)" >> "$GITHUB_ENV"
           echo "NEXT_PUBLIC_GTM_ID=$(pulumi config get portfolio:googleTagManagerId --stack tnorlund/portfolio/prod)" >> "$GITHUB_ENV"
-          echo "NEXT_PUBLIC_CLOUDFRONT_ANALYTICS_BEACON_PATH=/analytics/collect" >> "$GITHUB_ENV"
+          echo "NEXT_PUBLIC_CLOUDFRONT_ANALYTICS_BEACON_PATH=/analytics/pixel.txt" >> "$GITHUB_ENV"
         env:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
 

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -52,7 +52,7 @@ npm install
 # Build production bundle
 NEXT_PUBLIC_GA_MEASUREMENT_ID=G-7TT64C825N \
 NEXT_PUBLIC_GTM_ID=GTM-PBZWT6NS \
-NEXT_PUBLIC_CLOUDFRONT_ANALYTICS_BEACON_PATH=/analytics/pixel.txt \
+NEXT_PUBLIC_CLOUDFRONT_ANALYTICS_BEACON_PATH=/analytics/collect \
 npm run build
 
 # Deploy to S3
@@ -226,10 +226,12 @@ After deployment:
 ## Analytics Join Notes
 
 The portfolio sends pseudonymous `analytics_session_id` and
-`analytics_event_id` parameters to GA/GTM and to the static
-`/analytics/pixel.txt` beacon. CloudFront standard logs capture that
-beacon request and query string, which makes GA4 BigQuery events
-joinable to CloudFront request logs without adding a runtime API.
+`analytics_event_id` parameters to GA/GTM and to the real-time
+`/analytics/collect` beacon. Each event is also mirrored to the static
+`/analytics/pixel.txt` beacon so CloudFront standard logs remain the durable
+batch source if the collector is unavailable. The collector uses `live_eid`
+while the static mirror keeps canonical `eid`, preventing the unchanged batch
+dedup from racing the two request paths and preserving GA4 BigQuery joins.
 
 Reader-speed comparisons call `POST /reader_summary` after a visitor
 reaches the bottom of a long page. The Lambda writes per-page

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -229,7 +229,7 @@ The portfolio sends pseudonymous `analytics_session_id` and
 `analytics_event_id` parameters to GA/GTM and to the real-time
 `/analytics/collect` beacon. Each event is also mirrored to the static
 `/analytics/pixel.txt` beacon so CloudFront standard logs remain the durable
-batch source if the collector is unavailable. The collector uses `live_eid`
+batch source if the collector is unavailable. The collector uses `live_id`
 while the static mirror keeps canonical `eid`, preventing the unchanged batch
 dedup from racing the two request paths and preserving GA4 BigQuery joins.
 

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -52,7 +52,7 @@ npm install
 # Build production bundle
 NEXT_PUBLIC_GA_MEASUREMENT_ID=G-7TT64C825N \
 NEXT_PUBLIC_GTM_ID=GTM-PBZWT6NS \
-NEXT_PUBLIC_CLOUDFRONT_ANALYTICS_BEACON_PATH=/analytics/collect \
+NEXT_PUBLIC_CLOUDFRONT_ANALYTICS_BEACON_PATH=/analytics/pixel.txt \
 npm run build
 
 # Deploy to S3
@@ -226,12 +226,12 @@ After deployment:
 ## Analytics Join Notes
 
 The portfolio sends pseudonymous `analytics_session_id` and
-`analytics_event_id` parameters to GA/GTM and to the real-time
-`/analytics/collect` beacon. Each event is also mirrored to the static
-`/analytics/pixel.txt` beacon so CloudFront standard logs remain the durable
-batch source if the collector is unavailable. The collector uses `live_id`
-while the static mirror keeps canonical `eid`, preventing the unchanged batch
-dedup from racing the two request paths and preserving GA4 BigQuery joins.
+`analytics_event_id` parameters to GA/GTM and to the canonical
+`/analytics/pixel.txt` beacon. Its CloudFront behavior routes that single
+request to the real-time collector while standard access logging preserves the
+same canonical `eid` for the durable batch pipeline and GA4 BigQuery joins. An
+origin group uses the collector Lambda as primary and the static S3 pixel as
+secondary, so origin failure still returns the no-op pixel successfully.
 
 Reader-speed comparisons call `POST /reader_summary` after a visitor
 reaches the bottom of a long page. The Lambda writes per-page

--- a/infra/__main__.py
+++ b/infra/__main__.py
@@ -1330,16 +1330,20 @@ glyph_mcp_server = GlyphMcpLambda("glyph-mcp")
 pulumi.export("glyph_mcp_server_url", glyph_mcp_server.function_url)
 pulumi.export("glyph_mcp_server_lambda_arn", glyph_mcp_server.lambda_arn)
 
-# Web analytics query layer: Glue + Athena over the CloudFront access logs,
-# read by the analytics_* MCP tools. No new pipeline — just a queryable view
-# of logs that already exist.
+# Web analytics: the durable Glue + Athena layer over CloudFront access logs,
+# plus the request-time DynamoDB overlay read by the live analytics MCP tools.
 # Glue/Athena names are account-global, and the analytics source is the prod
 # CloudFront logs — so only build this on the prod stack to avoid dev/prod
 # collisions. The MCP tools use a fixed DB name and query via account-level
 # creds, so they work regardless of which stack the caller runs in.
 if pulumi.get_stack() == "prod":
     from components.web_analytics import WebAnalytics  # noqa: E402
-    from s3_website import cloudfront_logs_bucket  # noqa: E402
+    from s3_website import (  # noqa: E402
+        cloudfront_logs_bucket,
+        live_web_analytics,
+    )
+
+    assert live_web_analytics is not None
 
     # GA4 second source is optional: the extractor Lambda is only built when
     # both the service-account key (secret) and property id are configured.
@@ -1360,6 +1364,7 @@ if pulumi.get_stack() == "prod":
         ga_property_id=_analytics_cfg.get("gaPropertyId"),
         github_token=_analytics_cfg.get_secret("githubTrafficToken"),
         github_repos=_analytics_cfg.get("githubTrafficRepos"),
+        live_table_arn=live_web_analytics.table_arn,
     )
     # Let the MCP Lambda role run Athena/Glue/S3 reads for the analytics tools.
     aws.iam.RolePolicyAttachment(

--- a/infra/components/web_analytics/README.md
+++ b/infra/components/web_analytics/README.md
@@ -22,7 +22,7 @@ BROWSER     /analytics/pixel.txt (one canonical eid-bearing request)
               → CloudFront standard logs in S3
               → unchanged daily transform + ip_geo enrichment
               → web_events (Parquet) → existing analytics_* tools ─┤
-                                                                  └→ analytics_auto
+                                                                  └→ analytics
 ```
 
 ## What this creates
@@ -127,9 +127,9 @@ rather than spanning the intervening visit.
 Examples:
 
 ```
-analytics_auto(minutes=60)
-analytics_auto(since="2026-07-01T00:00:00Z")
-analytics_auto(campaign="arthur-babylist")
+analytics(minutes=60)
+analytics(since="2026-07-01T00:00:00Z")
+analytics(campaign="arthur-babylist")
 analytics_live(minutes=60, humans_only=true)
 analytics_attribution(campaign="arthur-babylist")
 analytics_attribution(since="2026-07-10T17:00:00Z")
@@ -141,7 +141,7 @@ durable analysis.
 
 ### Unified MCP routing
 
-`analytics_auto` is the default read surface when a visitor question may cross
+`analytics` is the default read surface when a visitor question may cross
 the live/durable boundary. It accepts a UTC `[since, until)` interval (or a
 minute lookback), then:
 
@@ -180,7 +180,7 @@ in lockstep in `scripts/receipt_mcp_server.py` and
 
 | Tool | Purpose |
 |---|---|
-| `analytics_auto(minutes, since, until, campaign, humans_only=true)` | default unified visitor/session query; routes and merges live DynamoDB with durable Athena data |
+| `analytics(minutes, since, until, campaign, humans_only=true)` | default unified visitor/session query; routes and merges live DynamoDB with durable Athena data |
 | `analytics_live(minutes=60, humans_only=true)` | request-time sessions from `web_events_live`, with edge geo, referrer, UTM fields, pages, and events |
 | `analytics_attribution(campaign, since, humans_only=true)` | exact live campaign/time-window attribution with full-session page timelines |
 | `analytics_traffic(start, end)` | per-PT-day requests, outside-human vs WARP vs bot, human sessions/pageviews |
@@ -290,7 +290,7 @@ can omit detailed geo fields for AWS viewers.
    country; assert region/city when CloudFront supplies them.
 3. Call `analytics_attribution(campaign="smoke-<UTC epoch>",
    humans_only=false)` and assert the same session, referrer, and campaign.
-4. Call `analytics_auto(campaign="smoke-<UTC epoch>", humans_only=false)` and
+4. Call `analytics(campaign="smoke-<UTC epoch>", humans_only=false)` and
    assert `source` includes `live`, no unexpected unqueried range is reported,
    and the same session is returned.
 5. Check the collector Lambda `Errors` metric and log group, then verify the

--- a/infra/components/web_analytics/README.md
+++ b/infra/components/web_analytics/README.md
@@ -1,26 +1,41 @@
-# Web Analytics (Glue + Athena over CloudFront logs)
+# Web Analytics (real-time DynamoDB + durable CloudFront batch)
 
-Makes the production CloudFront access logs **queryable** so Claude (via the
-`analytics_*` MCP tools) can answer "how much real traffic did the site get,
-who visited, from where" without hand-parsing gzip logs.
+Provides two complementary production analytics layers so the `analytics_*`
+MCP tools can answer both "who is here now?" and durable historical questions
+without hand-parsing CloudFront logs:
 
-No new data pipeline — it's a thin query layer over logs that already exist.
+- **Live overlay:** request-time collection into TTL'd DynamoDB, queryable in
+  seconds with edge geo and UTM/referrer attribution.
+- **Durable batch:** the existing daily CloudFront-log transform into curated
+  Parquet. This remains the source of truth and is not replaced by DynamoDB.
 
-## Architecture (ETL + serving)
+## Architecture
 
 ```
-INGEST     CloudFront → s3://<logs-bucket>/cloudfront/prod/   (already exists)
-              │
-TRANSFORM   transform Lambda (scheduled daily + backfillable), Athena INSERT:
-              parse beacon · dedup(request_id) · classify warp/bot · PT-ready
-              → web_events  (Parquet, partitioned by UTC `dt`)   [single source of truth]
-              │
-SERVE       analytics_* MCP tools SELECT from web_events (partition-pruned)
+BROWSER     /analytics/pixel.txt (one canonical eid-bearing request)
+              → CloudFront viewer headers + caching disabled
+              → origin group
+                   ├─ primary: signed Function URL → collector Lambda
+                   │    → web_events_live (DynamoDB, ~90-day TTL)
+                   │    → analytics_live / analytics_attribution
+                   └─ failover: existing static S3 pixel (always 200)
+              → CloudFront standard logs in S3
+              → unchanged daily transform + ip_geo enrichment
+              → web_events (Parquet) → existing analytics_* tools
 ```
 
 ## What this creates
 
 - **Glue database** `portfolio_analytics`
+- **Live DynamoDB table** `web_events_live` — on-demand capacity, UTC date
+  partition key (`dt`), time/session/event sort key (`sk`), `sid-index`, and
+  an `expires_at` TTL of approximately 90 days
+- **Collector Lambda + Function URL** — invoked only through a SigV4-signed
+  CloudFront origin access control; writes one request-time event to DynamoDB
+- **CloudFront `/analytics/pixel.txt` behavior + origin group** — caching
+  disabled; the Lambda URL is primary and the existing static S3 object is the
+  failover; query strings are forwarded without cookies and viewer geo/ASN
+  headers are added at the edge
 - **Raw external table** `cloudfront_logs_prod` over
   `s3://<cloudfront-logs-bucket>/cloudfront/prod/` (gzip TSV, 2 header lines
   skipped; AWS CloudFront standard log column order) — the transform's input
@@ -31,8 +46,10 @@ SERVE       analytics_* MCP tools SELECT from web_events (partition-pruned)
   `{"start":"YYYY-MM-DD","end":"YYYY-MM-DD"}` to backfill
 - **Athena workgroup** `portfolio_analytics` + a **results bucket** (30-day expiry)
 - A **curated bucket** for the Parquet output
-- **IAM policies** — read-only Athena/Glue/S3 for the MCP Lambda role; a
-  read-raw / write-curated / manage-partitions policy for the transform Lambda
+- **IAM policies** — Athena/Glue/S3 plus live-table `Query`/`GetItem` for the
+  MCP Lambda role; live-table `PutItem` only for the collector; and the
+  existing read-raw / write-curated / manage-partitions policy for the
+  transform Lambda
 
 ## Transform details
 
@@ -57,19 +74,75 @@ aws lambda invoke --function-name <web-analytics-transform> \
   --payload '{"start":"2026-06-19","end":"2026-06-30"}' /dev/stdout
 ```
 
-## Why the logic lives in the MCP tools, not a Glue view
+## Real-time collection and attribution
 
-Beacon parsing, bot/WARP classification, and PT-timezone bucketing are encoded
-as SQL **inside the `analytics_*` MCP tools** (`scripts/receipt_mcp_server.py`
-and `infra/mcp_server_lambda/lambdas/receipt_mcp_server_server.py`), not as a
-Glue/Athena view. That keeps the analytics logic version-controlled,
-diff-reviewable, and testable, and avoids managing Athena view definitions in
-IaC.
+Production builds keep
+`NEXT_PUBLIC_CLOUDFRONT_ANALYTICS_BEACON_PATH=/analytics/pixel.txt`. The browser
+automatically adds `utm_source`, `utm_medium`, `utm_campaign`, and
+`document.referrer` (`ref`) to each live beacon. Outreach links should use a
+stable campaign name, for example:
+
+```
+https://tylernorlund.com/receipt?utm_source=li&utm_medium=dm&utm_campaign=arthur-babylist
+```
+
+The canonical pixel path is intentional. A separate collector path would need
+a second pixel request to preserve the unchanged batch pipeline, inflating
+existing request/IP/top metrics. Origin failover keeps one request and retains
+the static object's non-breaking 200 response.
+
+CloudFront forwards the query string, user agent, viewer address/ASN, and the
+`CloudFront-Viewer-Country`, `-Country-Region`, `-City`, `-Latitude`,
+`-Longitude`, and `-Time-Zone` headers. The collector percent-decodes and
+persists those fields directly; it performs **no external geo lookup**. The
+edge ASN is also checked against a conservative set of the datacenter/cloud
+providers represented by the batch classifier.
+
+Each event makes one same-origin, fire-and-forget request. CloudFront first
+tries the signed collector Function URL; on configured 4xx/5xx failures it
+retries the same GET against the existing S3 origin, where the static pixel
+returns 200. The collector also treats writes as best-effort and returns a
+cache-disabled 1x1 GIF with status 200 after malformed input or a DynamoDB
+failure. CloudFront standard logging records that same canonical request for
+the unchanged batch pipeline, so the live overlay neither doubles nor steals
+events from existing metrics.
+
+Live items use `dt` (UTC) and
+`sk=<13-digit epoch_ms>#<sid>#<eid>`, plus a `sid-index` for session access.
+`analytics_live` queries only the intersecting UTC date partitions with
+strongly consistent DynamoDB reads. `analytics_attribution` rolls up the full
+session before campaign filtering, so pages visited after the landing URL
+drops its UTM parameters remain attributed.
+
+Examples:
+
+```
+analytics_live(minutes=60, humans_only=true)
+analytics_attribution(campaign="arthur-babylist")
+analytics_attribution(since="2026-07-10T17:00:00Z")
+```
+
+The live table is an operational overlay, not a historical replacement. TTL
+removes old items; use `web_events` and the existing Athena-backed tools for
+durable analysis.
+
+## Where classification and query logic live
+
+The durable transform owns batch beacon parsing, deduplication, geo enrichment,
+and bot/WARP/hosting classification. Existing Athena-backed MCP tools query the
+materialized `web_events` fields. The collector mirrors the same WARP, bot-UA,
+known-scanner, and datacenter-provider intent at request time using only edge
+data; the two live MCP tools explicitly exclude `is_bot`, `is_warp`, and
+`is_hosting` when `humans_only=true`. All tool definitions remain duplicated
+in lockstep in `scripts/receipt_mcp_server.py` and
+`infra/mcp_server_lambda/lambdas/receipt_mcp_server_server.py`.
 
 ## MCP tools
 
 | Tool | Purpose |
 |---|---|
+| `analytics_live(minutes=60, humans_only=true)` | request-time sessions from `web_events_live`, with edge geo, referrer, UTM fields, pages, and events |
+| `analytics_attribution(campaign, since, humans_only=true)` | exact live campaign/time-window attribution with full-session page timelines |
 | `analytics_traffic(start, end)` | per-PT-day requests, outside-human vs WARP vs bot, human sessions/pageviews |
 | `analytics_sessions(start, end, humans_only)` | reconstructed beacon sessions with **org / city / country / is_hosting** inline (pages, scroll, reader-summaries) |
 | `analytics_top(dimension, start, end)` | top `page` / `referrer` / `ip` / `country` / `org` |
@@ -117,13 +190,17 @@ GA applies Google's own bot filtering but is blocked by adblock/ITP (it
 under-counts); the beacon is complete but raw. `analytics_reconcile` puts them
 side by side per day — beacon > GA usually means adblock loss.
 
-## Classification rules (in the tool SQL)
+## Classification rules
 
 - **WARP / "us":** client IP in `104.28.0.0/16` or `2a09:bac…` (Cloudflare WARP egress)
 - **Bot:** user-agent matches a bot/crawler/scanner regex, or the known scanner
   subnet `185.177.72.0/24`
+- **Hosting:** batch uses the materialized `ip_geo` hosting/proxy/owner signal;
+  live collection uses `CloudFront-Viewer-ASN` and a conservative provider ASN
+  set because CloudFront does not expose org/ISP or a hosting flag
 - **Human session:** an analytics-beacon (`/analytics/pixel.txt`) session id,
-  excluding WARP + bots
+  excluding WARP + bots/hosting in batch; live tools explicitly exclude all
+  three flags
 
 > Note: IP org/geo/hosting is now a **materialized column** on `web_events`
 > (enriched once per IP into `ip_geo`), and both `is_hosting` and `is_bot` fold
@@ -148,6 +225,11 @@ side by side per day — beacon > GA usually means adblock loss.
 
 - **Dev** is deployed manually (`pulumi up` on the dev stack); **prod** deploys
   via CI on merge to `main`.
+- The live table, collector, and `/analytics/pixel.txt` origin-group behavior
+  are production only. The browser path does not change during rollout.
+- Keep `portfolio/public/analytics/pixel.txt`. It is both the no-op fallback
+  and the canonical path captured by durable logs; removing it breaks
+  non-breaking origin failover.
 - The Glue DB/table may already exist from validation — if `pulumi up` reports a
   conflict, `pulumi import` the two Glue resources (or delete them) so Pulumi
   can manage them.
@@ -157,5 +239,7 @@ side by side per day — beacon > GA usually means adblock loss.
 
 ## Cost
 
-Negligible. Athena bills per TB scanned; the logs are KB–MB/day. Results expire
+Negligible at portfolio traffic: DynamoDB uses on-demand capacity, the
+collector is one small Lambda invocation per event, and Athena scans
+KB–MB/day. Live items expire after approximately 90 days; Athena results expire
 after 30 days.

--- a/infra/components/web_analytics/README.md
+++ b/infra/components/web_analytics/README.md
@@ -28,10 +28,11 @@ BROWSER     /analytics/pixel.txt (one canonical eid-bearing request)
 
 - **Glue database** `portfolio_analytics`
 - **Live DynamoDB table** `web_events_live` — on-demand capacity, UTC date
-  partition key (`dt`), time/session/event sort key (`sk`), `sid-index`, and
-  an `expires_at` TTL of approximately 90 days
+  partition key (`dt`), time/session/event sort key (`sk`), keys-only
+  `sid-index`, and an `expires_at` TTL of approximately 90 days
 - **Collector Lambda + Function URL** — invoked only through a SigV4-signed
-  CloudFront origin access control; writes one request-time event to DynamoDB
+  CloudFront origin access control; writes one request-time event to DynamoDB;
+  its CloudWatch log group has 30-day retention
 - **CloudFront `/analytics/pixel.txt` behavior + origin group** — caching
   disabled; the Lambda URL is primary and the existing static S3 object is the
   failover; query strings are forwarded without cookies and viewer geo/ASN
@@ -57,7 +58,8 @@ BROWSER     /analytics/pixel.txt (one canonical eid-bearing request)
   (`WHERE "$path" LIKE '%.<dt>-%'`), so scan cost stays flat as history grows.
 - **Idempotent:** drops the `dt` partition + deletes its S3 objects, then
   re-`INSERT`s — safe to re-run / backfill.
-- **Dedups** on `request_id` (CloudFront can re-deliver lines).
+- **Dedups** on beacon `eid` when present, otherwise `request_id` (CloudFront
+  can re-deliver lines and browsers can retry a beacon).
 - Partition is the **UTC** log date; the serve layer buckets to PT and widens
   the scan ±1 day so PT-day edges are correct.
 - **IP enrichment:** before each rebuild the transform resolves any newly-seen
@@ -79,8 +81,9 @@ aws lambda invoke --function-name <web-analytics-transform> \
 Production builds keep
 `NEXT_PUBLIC_CLOUDFRONT_ANALYTICS_BEACON_PATH=/analytics/pixel.txt`. The browser
 automatically adds `utm_source`, `utm_medium`, `utm_campaign`, and
-`document.referrer` (`ref`) to each live beacon. Outreach links should use a
-stable campaign name, for example:
+`document.referrer` (`ref`) to each live beacon. Referrers are reduced to
+HTTP(S) origin + pathname so query tokens and fragments are not copied into
+the beacon URL. Outreach links should use a stable campaign name, for example:
 
 ```
 https://tylernorlund.com/receipt?utm_source=li&utm_medium=dm&utm_campaign=arthur-babylist
@@ -94,25 +97,31 @@ the static object's non-breaking 200 response.
 CloudFront forwards the query string, user agent, viewer address/ASN, and the
 `CloudFront-Viewer-Country`, `-Country-Region`, `-City`, `-Latitude`,
 `-Longitude`, and `-Time-Zone` headers. The collector percent-decodes and
-persists those fields directly; it performs **no external geo lookup**. The
-edge ASN is also checked against a conservative set of the datacenter/cloud
-providers represented by the batch classifier.
+persists available fields directly; it performs **no external geo lookup**.
+City can be unavailable for some IPs, and detailed location headers can be
+absent for AWS-network viewers, so those fields are nullable. The edge ASN is
+also checked against a conservative set of the datacenter/cloud providers
+represented by the batch classifier.
 
 Each event makes one same-origin, fire-and-forget request. CloudFront first
 tries the signed collector Function URL; on configured 4xx/5xx failures it
 retries the same GET against the existing S3 origin, where the static pixel
-returns 200. The collector also treats writes as best-effort and returns a
-cache-disabled 1x1 GIF with status 200 after malformed input or a DynamoDB
-failure. CloudFront standard logging records that same canonical request for
-the unchanged batch pipeline, so the live overlay neither doubles nor steals
-events from existing metrics.
+returns 200. Malformed/no-op requests receive a cache-disabled 1x1 GIF from the
+collector. Persistence errors are re-raised so Lambda's error metric records
+the failure and CloudFront exercises the static 200 fallback. CloudFront
+standard logging records that same canonical request for the unchanged batch
+pipeline, so the live overlay neither doubles nor steals events from existing
+metrics.
 
 Live items use `dt` (UTC) and
 `sk=<13-digit epoch_ms>#<sid>#<eid>`, plus a `sid-index` for session access.
 `analytics_live` queries only the intersecting UTC date partitions with
-strongly consistent DynamoDB reads. `analytics_attribution` rolls up the full
-session before campaign filtering, so pages visited after the landing URL
-drops its UTM parameters remain attributed.
+strongly consistent DynamoDB reads and deduplicates retries by `eid`, matching
+the durable transform. `analytics_attribution` starts a campaign segment at
+the matching tagged landing event and retains subsequent untagged pages until
+another tagged campaign begins. If a browser later returns to the requested
+campaign after a different campaign, the tool reports a separate segment
+rather than spanning the intervening visit.
 
 Examples:
 
@@ -223,8 +232,8 @@ side by side per day — beacon > GA usually means adblock loss.
 
 ## Deployment
 
-- **Dev** is deployed manually (`pulumi up` on the dev stack); **prod** deploys
-  via CI on merge to `main`.
+- **Dev** is deployed manually (`pulumi up` on the dev stack). **Prod** deploys
+  only from a manually dispatched CI run on `main`, after all test jobs pass.
 - The live table, collector, and `/analytics/pixel.txt` origin-group behavior
   are production only. The browser path does not change during rollout.
 - Keep `portfolio/public/analytics/pixel.txt`. It is both the no-op fallback
@@ -236,6 +245,44 @@ side by side per day — beacon > GA usually means adblock loss.
 - The `analytics_*` MCP tools require the MCP server to pick up the new code:
   redeploy the MCP Lambda, and for the local stdio server, reload it
   (`/mcp` reconnect).
+
+### Post-deploy smoke and rollback
+
+Runtime acceptance remains pending until the manual production deployment.
+Use a normal, non-AWS-network browser for the geo assertion because CloudFront
+can omit detailed geo fields for AWS viewers.
+
+1. Open a unique tagged URL such as
+   `/receipt?utm_source=smoke&utm_medium=manual&utm_campaign=smoke-<UTC epoch>`.
+2. Within five seconds, call `analytics_live(minutes=5, humans_only=false)` and
+   assert one deduplicated `page_view` with the expected path and nonempty
+   country; assert region/city when CloudFront supplies them.
+3. Call `analytics_attribution(campaign="smoke-<UTC epoch>",
+   humans_only=false)` and assert the same session, referrer, and campaign.
+4. Check the collector Lambda `Errors` metric and log group, then verify the
+   DynamoDB item has `expires_at`, edge geo, `sid`, and `eid`.
+5. In a controlled fallback test, temporarily set the collector's reserved
+   concurrency to zero, request `/analytics/pixel.txt?...`, and verify the
+   CloudFront response is still 200 from S3. Restore concurrency to 5
+   immediately afterward.
+
+For an emergency collector rollback, setting reserved concurrency to zero
+routes eligible beacon failures to the static pixel while the CloudFront
+behavior is reverted through the normal manual Pulumi review. Do not delete
+`portfolio/public/analytics/pixel.txt`.
+
+### Security and abuse boundary
+
+The beacon path is intentionally public. Reserved Lambda concurrency bounds
+simultaneous compute but is not a request-rate or DynamoDB cost ceiling; watch
+Lambda invocations/errors and DynamoDB consumed requests, and use a URI-scoped
+WAF rate rule if traffic stops matching portfolio-scale usage.
+
+The existing receipt MCP Function URL currently uses unauthenticated public
+access. Because the live tools expose visitor telemetry, authenticating or
+isolating that remote endpoint is a release decision before enabling its live
+table read policy. The local stdio MCP server continues to use local AWS
+credentials.
 
 ## Cost
 

--- a/infra/components/web_analytics/README.md
+++ b/infra/components/web_analytics/README.md
@@ -17,11 +17,12 @@ BROWSER     /analytics/pixel.txt (one canonical eid-bearing request)
               → origin group
                    ├─ primary: signed Function URL → collector Lambda
                    │    → web_events_live (DynamoDB, ~90-day TTL)
-                   │    → analytics_live / analytics_attribution
+                   │    → analytics_live / analytics_attribution ─┐
                    └─ failover: existing static S3 pixel (always 200)
               → CloudFront standard logs in S3
               → unchanged daily transform + ip_geo enrichment
-              → web_events (Parquet) → existing analytics_* tools
+              → web_events (Parquet) → existing analytics_* tools ─┤
+                                                                  └→ analytics_auto
 ```
 
 ## What this creates
@@ -126,6 +127,9 @@ rather than spanning the intervening visit.
 Examples:
 
 ```
+analytics_auto(minutes=60)
+analytics_auto(since="2026-07-01T00:00:00Z")
+analytics_auto(campaign="arthur-babylist")
 analytics_live(minutes=60, humans_only=true)
 analytics_attribution(campaign="arthur-babylist")
 analytics_attribution(since="2026-07-10T17:00:00Z")
@@ -134,6 +138,32 @@ analytics_attribution(since="2026-07-10T17:00:00Z")
 The live table is an operational overlay, not a historical replacement. TTL
 removes old items; use `web_events` and the existing Athena-backed tools for
 durable analysis.
+
+### Unified MCP routing
+
+`analytics_auto` is the default read surface when a visitor question may cross
+the live/durable boundary. It accepts a UTC `[since, until)` interval (or a
+minute lookback), then:
+
+1. Finds the latest materialized durable event using Glue partition metadata
+   plus a partition-pruned Athena `max(ts_utc)` query, cached for five minutes
+   on warm MCP processes.
+2. Reads the older interval from `web_events` and DynamoDB across a four-day
+   overlap matching the transform's trailing repair horizon.
+3. Reconstructs `ref`, UTM, and event metrics from the existing durable
+   `query_decoded` field. No batch schema or transform change is needed.
+4. Merges events before filtering/rollup and de-duplicates only nonempty
+   `eid`s. Durable classification/org data win, live millisecond ordering is
+   retained, and other live-only edge fields fill durable gaps.
+5. Returns `source` (`live`, `durable`, or `mixed`), freshness, truncation,
+   errors, and explicit queried/unqueried ranges. These describe which stores
+   were queried; they do not claim DynamoDB contained pre-rollout history.
+
+Campaign-only calls default to 24 hours, while other calls default to 60
+minutes. Explicit `since` values can reach beyond the live table's TTL because
+the older portion is served by Athena, with a one-year maximum interval to
+bound scan cost. Existing tools remain unchanged and available when a caller
+explicitly wants one source.
 
 ## Where classification and query logic live
 
@@ -150,6 +180,7 @@ in lockstep in `scripts/receipt_mcp_server.py` and
 
 | Tool | Purpose |
 |---|---|
+| `analytics_auto(minutes, since, until, campaign, humans_only=true)` | default unified visitor/session query; routes and merges live DynamoDB with durable Athena data |
 | `analytics_live(minutes=60, humans_only=true)` | request-time sessions from `web_events_live`, with edge geo, referrer, UTM fields, pages, and events |
 | `analytics_attribution(campaign, since, humans_only=true)` | exact live campaign/time-window attribution with full-session page timelines |
 | `analytics_traffic(start, end)` | per-PT-day requests, outside-human vs WARP vs bot, human sessions/pageviews |
@@ -259,9 +290,12 @@ can omit detailed geo fields for AWS viewers.
    country; assert region/city when CloudFront supplies them.
 3. Call `analytics_attribution(campaign="smoke-<UTC epoch>",
    humans_only=false)` and assert the same session, referrer, and campaign.
-4. Check the collector Lambda `Errors` metric and log group, then verify the
+4. Call `analytics_auto(campaign="smoke-<UTC epoch>", humans_only=false)` and
+   assert `source` includes `live`, no unexpected unqueried range is reported,
+   and the same session is returned.
+5. Check the collector Lambda `Errors` metric and log group, then verify the
    DynamoDB item has `expires_at`, edge geo, `sid`, and `eid`.
-5. In a controlled fallback test, temporarily set the collector's reserved
+6. In a controlled fallback test, temporarily set the collector's reserved
    concurrency to zero, request `/analytics/pixel.txt?...`, and verify the
    CloudFront response is still 200 from S3. Restore concurrency to 5
    immediately afterward.

--- a/infra/components/web_analytics/__init__.py
+++ b/infra/components/web_analytics/__init__.py
@@ -1,19 +1,18 @@
-"""
-Web Analytics query layer (Glue + Athena over CloudFront access logs).
+"""Portfolio web analytics infrastructure.
 
-Makes the raw CloudFront access logs queryable without any new data pipeline:
+Adds a request-time DynamoDB collector in front of the canonical beacon and
+keeps the existing Glue + Athena layer over CloudFront access logs:
 
 - Glue Catalog database + external table over the existing CloudFront log
   bucket (gzip TSV, 2 header lines skipped).
 - Athena workgroup with a dedicated results bucket (results expire on a
   lifecycle rule).
-- A managed IAM policy granting read-only Athena/Glue/S3 access, intended to be
-  attached to the MCP server's Lambda role so the ``analytics_*`` MCP tools can
-  run queries.
+- A managed IAM policy granting Athena/Glue/S3 plus live-table read access,
+  intended to be attached to the MCP server's Lambda role.
 
-All beacon-parsing / bot+WARP classification / timezone bucketing lives in the
-MCP tool SQL (see ``receipt_mcp_server`` ``analytics_*`` tools), not in a Glue
-view, so the logic stays version-controlled and reviewable.
+Durable beacon parsing and timezone bucketing remain in the existing transform
+and MCP SQL. The collector mirrors bot/WARP/hosting classification from edge
+data for the live tools.
 
 CloudFront standard log field order is fixed by AWS; the column list below
 matches it exactly.
@@ -22,6 +21,7 @@ matches it exactly.
 import json
 from pathlib import Path
 from typing import Optional
+from urllib.parse import urlsplit
 
 import pulumi
 import pulumi_aws as aws
@@ -30,6 +30,9 @@ from pulumi import ComponentResource, Input, Output, ResourceOptions
 _HANDLER_DIR = str(Path(__file__).resolve().parent / "transform_lambda")
 _GH_HANDLER_DIR = str(
     Path(__file__).resolve().parent / "github_extract_lambda"
+)
+_COLLECTOR_HANDLER_FILE = str(
+    Path(__file__).resolve().parent / "collector_lambda" / "handler.py"
 )
 
 # Short aliases for verbose pulumi_aws Args classes (keeps lines <= 79 cols).
@@ -75,6 +78,180 @@ _CLOUDFRONT_COLUMNS = [
 ]
 
 
+class LiveWebAnalytics(ComponentResource):
+    """Request-time analytics table and CloudFront-backed collector."""
+
+    def __init__(
+        self,
+        name: str,
+        *,
+        table_name: str = "web_events_live",
+        ttl_days: int = 90,
+        opts: Optional[ResourceOptions] = None,
+    ):
+        super().__init__(
+            "portfolio:analytics:LiveWebAnalytics", name, None, opts
+        )
+        child = ResourceOptions(parent=self)
+        stack = pulumi.get_stack()
+
+        self.table = aws.dynamodb.Table(
+            f"{name}-table",
+            name=table_name,
+            billing_mode="PAY_PER_REQUEST",
+            hash_key="dt",
+            range_key="sk",
+            attributes=[
+                aws.dynamodb.TableAttributeArgs(name="dt", type="S"),
+                aws.dynamodb.TableAttributeArgs(name="sk", type="S"),
+                aws.dynamodb.TableAttributeArgs(name="sid", type="S"),
+                aws.dynamodb.TableAttributeArgs(name="ts", type="S"),
+            ],
+            global_secondary_indexes=[
+                aws.dynamodb.TableGlobalSecondaryIndexArgs(
+                    name="sid-index",
+                    hash_key="sid",
+                    range_key="ts",
+                    projection_type="ALL",
+                )
+            ],
+            ttl=aws.dynamodb.TableTtlArgs(
+                attribute_name="expires_at",
+                enabled=True,
+            ),
+            tags={
+                "Environment": stack,
+                "Name": table_name,
+                "Purpose": "real-time web analytics",
+            },
+            opts=child,
+        )
+
+        collector_role = aws.iam.Role(
+            f"{name}-collector-role",
+            assume_role_policy=json.dumps(
+                {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Principal": {"Service": "lambda.amazonaws.com"},
+                            "Action": "sts:AssumeRole",
+                        }
+                    ],
+                }
+            ),
+            opts=child,
+        )
+        collector_basic = aws.iam.RolePolicyAttachment(
+            f"{name}-collector-basic",
+            role=collector_role.name,
+            policy_arn=(
+                "arn:aws:iam::aws:policy/service-role/"
+                "AWSLambdaBasicExecutionRole"
+            ),
+            opts=ResourceOptions(parent=collector_role),
+        )
+        collector_write = aws.iam.RolePolicy(
+            f"{name}-collector-write",
+            role=collector_role.id,
+            policy=self.table.arn.apply(_collector_policy_json),
+            opts=ResourceOptions(parent=collector_role),
+        )
+
+        self.collector_lambda = aws.lambda_.Function(
+            f"{name}-collector",
+            name=f"{name}-{stack}-collector",
+            runtime="python3.12",
+            handler="handler.handler",
+            code=pulumi.AssetArchive(
+                {"handler.py": pulumi.FileAsset(_COLLECTOR_HANDLER_FILE)}
+            ),
+            role=collector_role.arn,
+            timeout=5,
+            memory_size=128,
+            reserved_concurrent_executions=5,
+            environment=aws.lambda_.FunctionEnvironmentArgs(
+                variables={
+                    "WEB_EVENTS_LIVE_TABLE_NAME": self.table.name,
+                    "WEB_EVENTS_LIVE_TTL_DAYS": str(ttl_days),
+                }
+            ),
+            opts=ResourceOptions(
+                parent=self,
+                depends_on=[collector_basic, collector_write],
+            ),
+        )
+        self.function_url_resource = aws.lambda_.FunctionUrl(
+            f"{name}-collector-url",
+            function_name=self.collector_lambda.name,
+            authorization_type="AWS_IAM",
+            invoke_mode="BUFFERED",
+            opts=ResourceOptions(parent=self.collector_lambda),
+        )
+
+        # Sign CloudFront -> Function URL requests without making the Function
+        # URL public.  Distribution-scoped Lambda permissions are added after
+        # the distribution exists in s3_website.py.
+        self.origin_access_control = aws.cloudfront.OriginAccessControl(
+            f"{name}-collector-oac",
+            name=f"{name}-{stack}-collector-oac",
+            description="SigV4 access for the live analytics Lambda URL",
+            origin_access_control_origin_type="lambda",
+            signing_behavior="always",
+            signing_protocol="sigv4",
+            opts=child,
+        )
+        self.origin_request_policy = aws.cloudfront.OriginRequestPolicy(
+            f"{name}-collector-origin-request",
+            name=f"{name}-{stack}-collector-origin-request",
+            comment=(
+                "Forward analytics query parameters, viewer UA, and "
+                "CloudFront geo headers"
+            ),
+            cookies_config={"cookie_behavior": "none"},
+            headers_config={
+                "header_behavior": "whitelist",
+                "headers": {
+                    "items": [
+                        "User-Agent",
+                        "CloudFront-Viewer-Address",
+                        "CloudFront-Viewer-ASN",
+                        "CloudFront-Viewer-Country",
+                        "CloudFront-Viewer-Country-Region",
+                        "CloudFront-Viewer-City",
+                        "CloudFront-Viewer-Latitude",
+                        "CloudFront-Viewer-Longitude",
+                        "CloudFront-Viewer-Time-Zone",
+                    ]
+                },
+            },
+            query_strings_config={"query_string_behavior": "all"},
+            opts=child,
+        )
+
+        self.table_name = self.table.name
+        self.table_arn = self.table.arn
+        self.function_url = self.function_url_resource.function_url
+        self.function_url_domain = self.function_url.apply(
+            lambda url: urlsplit(url).netloc
+        )
+        self.origin_access_control_id = self.origin_access_control.id
+        self.origin_request_policy_id = self.origin_request_policy.id
+
+        self.register_outputs(
+            {
+                "table_name": self.table_name,
+                "table_arn": self.table_arn,
+                "collector_lambda_name": self.collector_lambda.name,
+                "function_url": self.function_url,
+                "function_url_domain": self.function_url_domain,
+                "origin_access_control_id": self.origin_access_control_id,
+                "origin_request_policy_id": self.origin_request_policy_id,
+            }
+        )
+
+
 class WebAnalytics(ComponentResource):
     """Glue + Athena query layer over CloudFront access logs."""
 
@@ -91,6 +268,7 @@ class WebAnalytics(ComponentResource):
         ga_property_id: Optional[str] = None,
         github_token: Optional[Input[str]] = None,
         github_repos: Optional[str] = None,
+        live_table_arn: Optional[Input[str]] = None,
         opts: Optional[ResourceOptions] = None,
     ):
         super().__init__("portfolio:analytics:WebAnalytics", name, None, opts)
@@ -658,9 +836,14 @@ class WebAnalytics(ComponentResource):
                 bucket_name,
                 self.results_bucket.arn,
                 self.curated_bucket.arn,
+                (
+                    Output.from_input(live_table_arn)
+                    if live_table_arn is not None
+                    else Output.from_input("")
+                ),
             ).apply(
                 lambda args: _policy_json(
-                    args[0], args[1], args[2], glue_resources
+                    args[0], args[1], args[2], glue_resources, args[3]
                 )
             ),
             opts=child,
@@ -684,69 +867,101 @@ def _policy_json(
     results_bucket_arn: str,
     curated_bucket_arn: str,
     glue_resources: list,
+    live_table_arn: str = "",
 ) -> str:
+    statements = [
+        {
+            "Sid": "Athena",
+            "Effect": "Allow",
+            "Action": [
+                "athena:StartQueryExecution",
+                "athena:StopQueryExecution",
+                "athena:GetQueryExecution",
+                "athena:GetQueryResults",
+                "athena:GetWorkGroup",
+            ],
+            "Resource": "*",
+        },
+        {
+            "Sid": "GlueCatalog",
+            "Effect": "Allow",
+            "Action": [
+                "glue:GetDatabase",
+                "glue:GetDatabases",
+                "glue:GetTable",
+                "glue:GetTables",
+                "glue:GetPartition",
+                "glue:GetPartitions",
+                "glue:BatchGetPartition",
+            ],
+            "Resource": glue_resources,
+        },
+        {
+            "Sid": "ReadLogsAndCurated",
+            "Effect": "Allow",
+            "Action": [
+                "s3:GetObject",
+                "s3:ListBucket",
+                "s3:GetBucketLocation",
+            ],
+            "Resource": [
+                f"arn:aws:s3:::{logs_bucket}",
+                f"arn:aws:s3:::{logs_bucket}/*",
+                curated_bucket_arn,
+                f"{curated_bucket_arn}/*",
+            ],
+        },
+        {
+            "Sid": "ReadWriteResults",
+            "Effect": "Allow",
+            "Action": [
+                "s3:GetObject",
+                "s3:PutObject",
+                "s3:ListBucket",
+                "s3:GetBucketLocation",
+                "s3:AbortMultipartUpload",
+                "s3:ListMultipartUploadParts",
+                "s3:ListBucketMultipartUploads",
+            ],
+            "Resource": [
+                results_bucket_arn,
+                f"{results_bucket_arn}/*",
+            ],
+        },
+    ]
+    if live_table_arn:
+        statements.append(
+            {
+                "Sid": "ReadLiveEvents",
+                "Effect": "Allow",
+                "Action": ["dynamodb:GetItem", "dynamodb:Query"],
+                "Resource": [
+                    live_table_arn,
+                    f"{live_table_arn}/index/*",
+                ],
+            }
+        )
+
+    return json.dumps(
+        {
+            "Version": "2012-10-17",
+            "Statement": statements,
+        }
+    )
+
+
+def _collector_policy_json(table_arn: str) -> str:
+    """Least-privilege collector permission: append events to one table."""
     return json.dumps(
         {
             "Version": "2012-10-17",
             "Statement": [
                 {
-                    "Sid": "Athena",
+                    "Sid": "WriteLiveEvents",
                     "Effect": "Allow",
-                    "Action": [
-                        "athena:StartQueryExecution",
-                        "athena:StopQueryExecution",
-                        "athena:GetQueryExecution",
-                        "athena:GetQueryResults",
-                        "athena:GetWorkGroup",
-                    ],
-                    "Resource": "*",
-                },
-                {
-                    "Sid": "GlueCatalog",
-                    "Effect": "Allow",
-                    "Action": [
-                        "glue:GetDatabase",
-                        "glue:GetDatabases",
-                        "glue:GetTable",
-                        "glue:GetTables",
-                        "glue:GetPartition",
-                        "glue:GetPartitions",
-                        "glue:BatchGetPartition",
-                    ],
-                    "Resource": glue_resources,
-                },
-                {
-                    "Sid": "ReadLogsAndCurated",
-                    "Effect": "Allow",
-                    "Action": [
-                        "s3:GetObject",
-                        "s3:ListBucket",
-                        "s3:GetBucketLocation",
-                    ],
-                    "Resource": [
-                        f"arn:aws:s3:::{logs_bucket}",
-                        f"arn:aws:s3:::{logs_bucket}/*",
-                        curated_bucket_arn,
-                        f"{curated_bucket_arn}/*",
-                    ],
-                },
-                {
-                    "Sid": "ReadWriteResults",
-                    "Effect": "Allow",
-                    "Action": [
-                        "s3:GetObject",
-                        "s3:PutObject",
-                        "s3:ListBucket",
-                        "s3:GetBucketLocation",
-                        "s3:AbortMultipartUpload",
-                        "s3:ListMultipartUploadParts",
-                        "s3:ListBucketMultipartUploads",
-                    ],
-                    "Resource": [
-                        results_bucket_arn,
-                        f"{results_bucket_arn}/*",
-                    ],
-                },
+                    "Action": "dynamodb:PutItem",
+                    "Resource": table_arn,
+                }
             ],
         }
     )

--- a/infra/components/web_analytics/__init__.py
+++ b/infra/components/web_analytics/__init__.py
@@ -112,7 +112,10 @@ class LiveWebAnalytics(ComponentResource):
                     name="sid-index",
                     hash_key="sid",
                     range_key="ts",
-                    projection_type="ALL",
+                    # Live tools query UTC date partitions today. Keep the
+                    # required session index cheap until a direct SID lookup
+                    # needs additional projected fields.
+                    projection_type="KEYS_ONLY",
                 )
             ],
             ttl=aws.dynamodb.TableTtlArgs(
@@ -159,9 +162,17 @@ class LiveWebAnalytics(ComponentResource):
             opts=ResourceOptions(parent=collector_role),
         )
 
+        collector_function_name = f"{name}-{stack}-collector"
+        self.collector_log_group = aws.cloudwatch.LogGroup(
+            f"{name}-collector-logs",
+            name=f"/aws/lambda/{collector_function_name}",
+            retention_in_days=30,
+            opts=child,
+        )
+
         self.collector_lambda = aws.lambda_.Function(
             f"{name}-collector",
-            name=f"{name}-{stack}-collector",
+            name=collector_function_name,
             runtime="python3.12",
             handler="handler.handler",
             code=pulumi.AssetArchive(
@@ -179,7 +190,11 @@ class LiveWebAnalytics(ComponentResource):
             ),
             opts=ResourceOptions(
                 parent=self,
-                depends_on=[collector_basic, collector_write],
+                depends_on=[
+                    collector_basic,
+                    collector_write,
+                    self.collector_log_group,
+                ],
             ),
         )
         self.function_url_resource = aws.lambda_.FunctionUrl(

--- a/infra/components/web_analytics/collector_lambda/handler.py
+++ b/infra/components/web_analytics/collector_lambda/handler.py
@@ -18,7 +18,7 @@ import re
 import uuid
 from datetime import datetime, timedelta, timezone
 from typing import Any
-from urllib.parse import parse_qs, unquote
+from urllib.parse import parse_qs, unquote, urlsplit, urlunsplit
 
 import boto3
 
@@ -167,6 +167,30 @@ def _clean_id(value: Any, limit: int) -> str:
     return cleaned if _ANALYTICS_ID_RE.fullmatch(cleaned) else ""
 
 
+def _clean_ref(value: Any, limit: int) -> str:
+    """Retain only an HTTP(S) referrer origin and path."""
+    try:
+        parsed = urlsplit(str(value or "").strip())
+        if (
+            parsed.scheme.lower() not in {"http", "https"}
+            or not parsed.hostname
+        ):
+            return ""
+
+        host = parsed.hostname
+        if ":" in host:
+            host = f"[{host}]"
+        if parsed.port is not None:
+            host = f"{host}:{parsed.port}"
+
+        sanitized = urlunsplit(
+            (parsed.scheme.lower(), host, parsed.path or "/", "", "")
+        )
+        return _clean(sanitized, limit)
+    except (TypeError, ValueError):
+        return ""
+
+
 def _viewer_ip(headers: dict[str, str]) -> str:
     address = headers.get("cloudfront-viewer-address", "").strip()
     if address:
@@ -237,7 +261,7 @@ def _build_item(event: dict[str, Any], now: datetime) -> dict[str, Any] | None:
     item: dict[str, Any] = {
         "dt": now.date().isoformat(),
         "sk": f"{epoch_ms:013d}#{sid}#{eid}",
-        "ts": now.isoformat(timespec="milliseconds").replace("+00:00", "Z"),
+        "ts": now.isoformat(timespec="milliseconds"),
         "epoch_ms": epoch_ms,
         "expires_at": int((now + timedelta(days=TTL_DAYS)).timestamp()),
         "sid": sid,
@@ -247,7 +271,7 @@ def _build_item(event: dict[str, Any], now: datetime) -> dict[str, Any] | None:
         "page_path": _clean(
             params.get("page_path"), _EVENT_PARAM_LIMITS["page_path"]
         ),
-        "ref": _clean(params.get("ref"), _EVENT_PARAM_LIMITS["ref"]),
+        "ref": _clean_ref(params.get("ref"), _EVENT_PARAM_LIMITS["ref"]),
         "utm_source": _clean(
             params.get("utm_source"), _EVENT_PARAM_LIMITS["utm_source"]
         ),

--- a/infra/components/web_analytics/collector_lambda/handler.py
+++ b/infra/components/web_analytics/collector_lambda/handler.py
@@ -4,9 +4,9 @@ CloudFront forwards the analytics beacon, viewer location headers, and the
 viewer user-agent to this Lambda Function URL.  The handler performs no network
 lookups: it classifies the request and writes the event directly to DynamoDB.
 
-The response is deliberately best-effort.  Analytics must never affect the
-page experience, so malformed requests and DynamoDB failures are logged and
-still receive a cache-disabled 1x1 GIF response.
+Malformed/no-op requests receive a cache-disabled 1x1 GIF response. Persistence
+failures are logged and re-raised so CloudFront marks the primary origin as
+failed and serves the static S3 pixel instead; visitors still receive a 200.
 """
 
 from __future__ import annotations
@@ -36,6 +36,7 @@ _BOT_RE = re.compile(
     re.IGNORECASE,
 )
 _SCANNER_PREFIX = "185.177.72."
+_ANALYTICS_ID_RE = re.compile(r"^[A-Za-z0-9_-]+$")
 
 # CloudFront supplies a numeric viewer ASN but not the network-owner string
 # consumed by the batch transform's _DC_RE.  This deliberately conservative
@@ -160,6 +161,12 @@ def _clean(value: Any, limit: int) -> str:
     return str(value).strip()[:limit]
 
 
+def _clean_id(value: Any, limit: int) -> str:
+    """Bound key material to the ASCII alphabet emitted by the frontend."""
+    cleaned = _clean(value, limit)
+    return cleaned if _ANALYTICS_ID_RE.fullmatch(cleaned) else ""
+
+
 def _viewer_ip(headers: dict[str, str]) -> str:
     address = headers.get("cloudfront-viewer-address", "").strip()
     if address:
@@ -206,17 +213,17 @@ def _build_item(event: dict[str, Any], now: datetime) -> dict[str, Any] | None:
     if not event_name:
         return None
 
-    request_id = _clean(
+    request_id = _clean_id(
         (event.get("requestContext") or {}).get("requestId"), 180
     )
     # The same canonical request is captured by DynamoDB now and CloudFront
     # standard logs for the durable batch, so both layers retain the same eid.
-    eid = _clean(params.get("eid"), _EVENT_PARAM_LIMITS["eid"])
+    eid = _clean_id(params.get("eid"), _EVENT_PARAM_LIMITS["eid"])
     if not eid:
         eid = request_id or f"evt_{uuid.uuid4().hex}"
-    sid = _clean(params.get("sid"), _EVENT_PARAM_LIMITS["sid"])
+    sid = _clean_id(params.get("sid"), _EVENT_PARAM_LIMITS["sid"])
     if not sid:
-        sid = f"anon_{eid}"
+        sid = _clean(f"anon_{eid}", _EVENT_PARAM_LIMITS["sid"])
 
     headers = _headers(event)
     ip = _viewer_ip(headers)
@@ -273,11 +280,12 @@ def _build_item(event: dict[str, Any], now: datetime) -> dict[str, Any] | None:
 
 
 def handler(event: dict[str, Any], _context: Any) -> dict[str, Any]:
-    """Persist one live beacon and always return a no-store 1x1 GIF."""
+    """Persist one live beacon or let CloudFront fail over to static S3."""
     try:
         item = _build_item(event, _utc_now())
         if item is not None:
             _get_table().put_item(Item=item)
-    except Exception:  # Analytics must never surface an error to the page.
+    except Exception:  # CloudFront converts this origin error to a static 200.
         LOGGER.exception("Failed to persist live web analytics event")
+        raise
     return _response()

--- a/infra/components/web_analytics/collector_lambda/handler.py
+++ b/infra/components/web_analytics/collector_lambda/handler.py
@@ -1,0 +1,283 @@
+"""Request-time web analytics collector.
+
+CloudFront forwards the analytics beacon, viewer location headers, and the
+viewer user-agent to this Lambda Function URL.  The handler performs no network
+lookups: it classifies the request and writes the event directly to DynamoDB.
+
+The response is deliberately best-effort.  Analytics must never affect the
+page experience, so malformed requests and DynamoDB failures are logged and
+still receive a cache-disabled 1x1 GIF response.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import logging
+import os
+import re
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Any
+from urllib.parse import parse_qs, unquote
+
+import boto3
+
+LOGGER = logging.getLogger(__name__)
+LOGGER.setLevel(logging.INFO)
+
+TABLE_NAME = os.environ.get("WEB_EVENTS_LIVE_TABLE_NAME", "web_events_live")
+TTL_DAYS = int(os.environ.get("WEB_EVENTS_LIVE_TTL_DAYS", "90"))
+
+_WARP_RE = re.compile(r"^(104\.28\.|2a09:bac)", re.IGNORECASE)
+_BOT_RE = re.compile(
+    r"bot|crawl|spider|slurp|curl|python-requests|go-http|headless|wget|"
+    r"monitor|preview|scan|http.?client|java/|okhttp|axios|node-fetch|libwww|"
+    r"facebookexternal|meta-external|petalbot|ahrefs|semrush|dataforseo",
+    re.IGNORECASE,
+)
+_SCANNER_PREFIX = "185.177.72."
+
+# CloudFront supplies a numeric viewer ASN but not the network-owner string
+# consumed by the batch transform's _DC_RE.  This deliberately conservative
+# set covers the well-known infrastructure networks named by that regex.  It
+# avoids residential/corporate access networks and can be extended as a new
+# provider is confirmed.  No request-time ASN or geo lookup is performed.
+_HOSTING_ASNS = frozenset(
+    {
+        7224,  # Amazon/AWS
+        8068,  # Microsoft
+        8075,  # Microsoft Azure
+        8100,  # QuadraNet
+        8987,  # Amazon/AWS
+        9009,  # M247
+        12876,  # Scaleway
+        13335,  # Cloudflare Workers/datacenter (WARP is also caught by IP)
+        14061,  # DigitalOcean
+        14618,  # Amazon/AWS
+        15169,  # Google
+        16276,  # OVH
+        16509,  # Amazon/AWS
+        20473,  # Choopa/Vultr
+        21859,  # Zenlayer
+        24940,  # Hetzner
+        28753,  # Leaseweb
+        31898,  # Oracle Cloud
+        37963,  # Alibaba Cloud
+        396982,  # Google Cloud
+        40676,  # Psychz Networks
+        45090,  # Tencent Cloud
+        45102,  # Alibaba Cloud
+        51167,  # Contabo
+        60781,  # Leaseweb
+        62567,  # DigitalOcean
+        62785,  # Amazon/AWS
+        63949,  # Linode/Akamai Connected Cloud
+        132203,  # Tencent Cloud
+        199524,  # Gcore
+        213230,  # Hetzner
+    }
+)
+
+_EVENT_PARAM_LIMITS = {
+    "event": 120,
+    "sid": 180,
+    "eid": 180,
+    "path": 1024,
+    "page_path": 1024,
+    "ref": 2048,
+    "utm_source": 256,
+    "utm_medium": 256,
+    "utm_campaign": 256,
+}
+_METRIC_PARAMS = (
+    "percent_scrolled",
+    "metric_name",
+    "metric_value",
+    "time_to_bottom_ms",
+    "active_scroll_ms",
+    "page_height",
+    "scrollable_pixels",
+    "screens_per_minute",
+    "reader_delta_percent",
+    "baseline_sample_size",
+    "session_page_views",
+    "quick_jump",
+)
+
+_PIXEL_BODY = "R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw=="
+
+_table: Any = None
+
+
+def _get_table() -> Any:
+    global _table  # pylint: disable=global-statement
+    if _table is None:
+        _table = boto3.resource("dynamodb").Table(TABLE_NAME)
+    return _table
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _response() -> dict[str, Any]:
+    return {
+        "statusCode": 200,
+        "headers": {
+            "Cache-Control": "no-store, no-cache, max-age=0, must-revalidate",
+            "Content-Type": "image/gif",
+            "Pragma": "no-cache",
+        },
+        "isBase64Encoded": True,
+        "body": _PIXEL_BODY,
+    }
+
+
+def _headers(event: dict[str, Any]) -> dict[str, str]:
+    return {
+        str(key).lower(): unquote(str(value))
+        for key, value in (event.get("headers") or {}).items()
+        if value is not None
+    }
+
+
+def _query_params(event: dict[str, Any]) -> dict[str, str]:
+    raw = event.get("rawQueryString")
+    if isinstance(raw, str):
+        parsed = parse_qs(raw, keep_blank_values=True)
+        return {key: values[-1] for key, values in parsed.items() if values}
+
+    return {
+        str(key): str(value)
+        for key, value in (event.get("queryStringParameters") or {}).items()
+        if value is not None
+    }
+
+
+def _clean(value: Any, limit: int) -> str:
+    if value is None:
+        return ""
+    return str(value).strip()[:limit]
+
+
+def _viewer_ip(headers: dict[str, str]) -> str:
+    address = headers.get("cloudfront-viewer-address", "").strip()
+    if address:
+        candidates = [address]
+        if address.startswith("[") and "]" in address:
+            candidates.insert(0, address[1 : address.index("]")])
+        elif address.count(":") == 1:
+            candidates.insert(0, address.rsplit(":", 1)[0])
+
+        for candidate in candidates:
+            try:
+                return str(ipaddress.ip_address(candidate))
+            except ValueError:
+                continue
+
+    # CloudFront appends the actual viewer address to any viewer-supplied XFF,
+    # so prefer the last valid address to avoid trusting a spoofed first hop.
+    forwarded = headers.get("x-forwarded-for", "")
+    for candidate in reversed(forwarded.split(",")):
+        try:
+            return str(ipaddress.ip_address(candidate.strip()))
+        except ValueError:
+            continue
+    return ""
+
+
+def _viewer_asn(headers: dict[str, str]) -> tuple[str, bool]:
+    value = _clean(headers.get("cloudfront-viewer-asn"), 20)
+    try:
+        return value, int(value) in _HOSTING_ASNS
+    except (TypeError, ValueError):
+        return value, False
+
+
+def _build_item(event: dict[str, Any], now: datetime) -> dict[str, Any] | None:
+    method = ((event.get("requestContext") or {}).get("http") or {}).get(
+        "method"
+    ) or "GET"
+    if method != "GET":
+        return None
+
+    params = _query_params(event)
+    event_name = _clean(params.get("event"), _EVENT_PARAM_LIMITS["event"])
+    if not event_name:
+        return None
+
+    request_id = _clean(
+        (event.get("requestContext") or {}).get("requestId"), 180
+    )
+    # The same canonical request is captured by DynamoDB now and CloudFront
+    # standard logs for the durable batch, so both layers retain the same eid.
+    eid = _clean(params.get("eid"), _EVENT_PARAM_LIMITS["eid"])
+    if not eid:
+        eid = request_id or f"evt_{uuid.uuid4().hex}"
+    sid = _clean(params.get("sid"), _EVENT_PARAM_LIMITS["sid"])
+    if not sid:
+        sid = f"anon_{eid}"
+
+    headers = _headers(event)
+    ip = _viewer_ip(headers)
+    ua = _clean(headers.get("user-agent"), 1024)
+    asn, is_hosting = _viewer_asn(headers)
+    is_warp = bool(_WARP_RE.match(ip))
+    is_bot = bool(_BOT_RE.search(ua)) or ip.startswith(_SCANNER_PREFIX)
+    is_bot = is_bot or is_hosting
+
+    epoch_ms = int(now.timestamp() * 1000)
+    item: dict[str, Any] = {
+        "dt": now.date().isoformat(),
+        "sk": f"{epoch_ms:013d}#{sid}#{eid}",
+        "ts": now.isoformat(timespec="milliseconds").replace("+00:00", "Z"),
+        "epoch_ms": epoch_ms,
+        "expires_at": int((now + timedelta(days=TTL_DAYS)).timestamp()),
+        "sid": sid,
+        "eid": eid,
+        "event": event_name,
+        "path": _clean(params.get("path"), _EVENT_PARAM_LIMITS["path"]),
+        "page_path": _clean(
+            params.get("page_path"), _EVENT_PARAM_LIMITS["page_path"]
+        ),
+        "ref": _clean(params.get("ref"), _EVENT_PARAM_LIMITS["ref"]),
+        "utm_source": _clean(
+            params.get("utm_source"), _EVENT_PARAM_LIMITS["utm_source"]
+        ),
+        "utm_medium": _clean(
+            params.get("utm_medium"), _EVENT_PARAM_LIMITS["utm_medium"]
+        ),
+        "utm_campaign": _clean(
+            params.get("utm_campaign"), _EVENT_PARAM_LIMITS["utm_campaign"]
+        ),
+        "ip": ip,
+        "ua": ua,
+        "country": _clean(headers.get("cloudfront-viewer-country"), 8),
+        "region": _clean(headers.get("cloudfront-viewer-country-region"), 32),
+        "city": _clean(headers.get("cloudfront-viewer-city"), 256),
+        "latitude": _clean(headers.get("cloudfront-viewer-latitude"), 32),
+        "longitude": _clean(headers.get("cloudfront-viewer-longitude"), 32),
+        "timezone": _clean(headers.get("cloudfront-viewer-time-zone"), 128),
+        "asn": asn,
+        "is_warp": is_warp,
+        "is_bot": is_bot,
+        "is_hosting": is_hosting,
+    }
+
+    for key in _METRIC_PARAMS:
+        value = _clean(params.get(key), 120)
+        if value:
+            item[key] = value
+
+    return item
+
+
+def handler(event: dict[str, Any], _context: Any) -> dict[str, Any]:
+    """Persist one live beacon and always return a no-store 1x1 GIF."""
+    try:
+        item = _build_item(event, _utc_now())
+        if item is not None:
+            _get_table().put_item(Item=item)
+    except Exception:  # Analytics must never surface an error to the page.
+        LOGGER.exception("Failed to persist live web analytics event")
+    return _response()

--- a/infra/components/web_analytics/tests/test_collector_handler.py
+++ b/infra/components/web_analytics/tests/test_collector_handler.py
@@ -8,6 +8,8 @@ from pathlib import Path
 from typing import Any
 from unittest.mock import Mock
 
+import pytest
+
 
 def _load_handler_module() -> Any:
     handler_path = (
@@ -177,6 +179,21 @@ def test_eid_is_shared_with_the_durable_batch_event() -> None:
     assert item["sk"].endswith("#ses_1#legacy_evt")
 
 
+def test_non_ascii_ids_cannot_overflow_the_dynamodb_sort_key() -> None:
+    item = collector._build_item(
+        _event(
+            "event=page_view&sid=%F0%9F%92%A5%F0%9F%92%A5&"
+            "eid=%F0%9F%92%A5%F0%9F%92%A5"
+        ),
+        NOW,
+    )
+
+    assert item is not None
+    assert item["eid"] == "request-1"
+    assert item["sid"] == "anon_request-1"
+    assert len(item["sk"].encode("utf-8")) < 1024
+
+
 def test_handler_writes_immediately_and_returns_gif() -> None:
     table = Mock()
     collector._table = table
@@ -192,15 +209,11 @@ def test_handler_writes_immediately_and_returns_gif() -> None:
     assert response["isBase64Encoded"] is True
 
 
-def test_handler_swallows_dynamodb_failure_and_still_returns_200() -> None:
+def test_handler_reraises_dynamodb_failure_for_cloudfront_failover() -> None:
     table = Mock()
     table.put_item.side_effect = RuntimeError("DynamoDB unavailable")
     collector._table = table
     collector._utc_now = lambda: NOW
 
-    response = collector.handler(
-        _event("event=page_view&sid=ses_1&eid=evt_1"), None
-    )
-
-    assert response["statusCode"] == 200
-    assert response["headers"]["Cache-Control"].startswith("no-store")
+    with pytest.raises(RuntimeError, match="DynamoDB unavailable"):
+        collector.handler(_event("event=page_view&sid=ses_1&eid=evt_1"), None)

--- a/infra/components/web_analytics/tests/test_collector_handler.py
+++ b/infra/components/web_analytics/tests/test_collector_handler.py
@@ -7,6 +7,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 from unittest.mock import Mock
+from urllib.parse import quote
 
 import pytest
 
@@ -43,7 +44,8 @@ def test_build_item_parses_attribution_geo_and_ttl() -> None:
     event = _event(
         "event=page_view&sid=ses_1&eid=evt_1&path=%2Freceipt&"
         "page_path=%2Freceipt%3Futm_campaign%3Dbabylist&"
-        "ref=https%3A%2F%2Fgithub.com%2Ftnorlund%2FPortfolio&"
+        "ref=https%3A%2F%2Fgithub.com%2Ftnorlund%2FPortfolio%3F"
+        "token%3Dprivate%23message&"
         "utm_source=li&utm_medium=dm&utm_campaign=arthur-babylist&"
         "percent_scrolled=90",
         **{
@@ -64,6 +66,7 @@ def test_build_item_parses_attribution_geo_and_ttl() -> None:
     assert item is not None
     assert item["dt"] == "2026-07-10"
     assert item["sk"] == "1783708200123#ses_1#evt_1"
+    assert item["ts"] == "2026-07-10T18:30:00.123+00:00"
     assert item["eid"] == "evt_1"
     assert item["expires_at"] == int(
         datetime(
@@ -80,6 +83,29 @@ def test_build_item_parses_attribution_geo_and_ttl() -> None:
     assert item["is_warp"] is False
     assert item["is_bot"] is False
     assert item["is_hosting"] is False
+
+
+def test_build_item_sanitizes_referrer_at_the_trust_boundary() -> None:
+    trusted = "https://user:secret@example.com:8443/path?token=private#message"
+    trusted_item = collector._build_item(
+        _event(
+            "event=page_view&sid=trusted&eid=1&ref="
+            f"{quote(trusted, safe='')}"
+        ),
+        NOW,
+    )
+    untrusted_item = collector._build_item(
+        _event(
+            "event=page_view&sid=untrusted&eid=2&ref="
+            "javascript%3Aalert(1)"
+        ),
+        NOW,
+    )
+
+    assert trusted_item is not None
+    assert trusted_item["ref"] == "https://example.com:8443/path"
+    assert untrusted_item is not None
+    assert untrusted_item["ref"] == ""
 
 
 def test_live_classification_covers_known_batch_signals() -> None:

--- a/infra/components/web_analytics/tests/test_collector_handler.py
+++ b/infra/components/web_analytics/tests/test_collector_handler.py
@@ -1,0 +1,206 @@
+"""Unit tests for the request-time web analytics collector."""
+
+from __future__ import annotations
+
+import importlib.util
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from unittest.mock import Mock
+
+
+def _load_handler_module() -> Any:
+    handler_path = (
+        Path(__file__).resolve().parents[1] / "collector_lambda" / "handler.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "web_analytics_collector_handler", handler_path
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+collector = _load_handler_module()
+NOW = datetime(2026, 7, 10, 18, 30, 0, 123000, tzinfo=timezone.utc)
+
+
+def _event(raw_query: str, **headers: str) -> dict[str, object]:
+    return {
+        "rawQueryString": raw_query,
+        "headers": headers,
+        "requestContext": {
+            "requestId": "request-1",
+            "http": {"method": "GET"},
+        },
+    }
+
+
+def test_build_item_parses_attribution_geo_and_ttl() -> None:
+    event = _event(
+        "event=page_view&sid=ses_1&eid=evt_1&path=%2Freceipt&"
+        "page_path=%2Freceipt%3Futm_campaign%3Dbabylist&"
+        "ref=https%3A%2F%2Fgithub.com%2Ftnorlund%2FPortfolio&"
+        "utm_source=li&utm_medium=dm&utm_campaign=arthur-babylist&"
+        "percent_scrolled=90",
+        **{
+            "CloudFront-Viewer-Address": "203.0.113.9:43120",
+            "CloudFront-Viewer-ASN": "7922",
+            "CloudFront-Viewer-Country": "US",
+            "CloudFront-Viewer-Country-Region": "WA",
+            "CloudFront-Viewer-City": "Vancouver%20Heights",
+            "CloudFront-Viewer-Latitude": "45.63",
+            "CloudFront-Viewer-Longitude": "-122.67",
+            "CloudFront-Viewer-Time-Zone": "America%2FLos_Angeles",
+            "User-Agent": "Mozilla/5.0",
+        },
+    )
+
+    item = collector._build_item(event, NOW)
+
+    assert item is not None
+    assert item["dt"] == "2026-07-10"
+    assert item["sk"] == "1783708200123#ses_1#evt_1"
+    assert item["eid"] == "evt_1"
+    assert item["expires_at"] == int(
+        datetime(
+            2026, 10, 8, 18, 30, 0, 123000, tzinfo=timezone.utc
+        ).timestamp()
+    )
+    assert item["path"] == "/receipt"
+    assert item["ref"] == "https://github.com/tnorlund/Portfolio"
+    assert item["utm_campaign"] == "arthur-babylist"
+    assert item["ip"] == "203.0.113.9"
+    assert item["city"] == "Vancouver Heights"
+    assert item["timezone"] == "America/Los_Angeles"
+    assert item["percent_scrolled"] == "90"
+    assert item["is_warp"] is False
+    assert item["is_bot"] is False
+    assert item["is_hosting"] is False
+
+
+def test_live_classification_covers_known_batch_signals() -> None:
+    warp = collector._build_item(
+        _event(
+            "event=page_view&sid=warp&eid=1",
+            **{
+                "CloudFront-Viewer-Address": "104.28.42.1:1234",
+                "User-Agent": "Mozilla/5.0",
+            },
+        ),
+        NOW,
+    )
+    bot = collector._build_item(
+        _event(
+            "event=page_view&sid=bot&eid=2",
+            **{
+                "CloudFront-Viewer-Address": "203.0.113.10:1234",
+                "User-Agent": "Mozilla/5.0 HeadlessChrome",
+            },
+        ),
+        NOW,
+    )
+    scanner = collector._build_item(
+        _event(
+            "event=page_view&sid=scanner&eid=3",
+            **{
+                "CloudFront-Viewer-Address": "185.177.72.44:1234",
+                "User-Agent": "Mozilla/5.0",
+            },
+        ),
+        NOW,
+    )
+    hosting = collector._build_item(
+        _event(
+            "event=page_view&sid=hosting&eid=4",
+            **{
+                "CloudFront-Viewer-Address": "198.51.100.4:1234",
+                "CloudFront-Viewer-ASN": "16509",
+                "User-Agent": "Mozilla/5.0",
+            },
+        ),
+        NOW,
+    )
+    cloudflare_worker = collector._build_item(
+        _event(
+            "event=page_view&sid=worker&eid=5",
+            **{
+                "CloudFront-Viewer-Address": "198.51.100.5:1234",
+                "CloudFront-Viewer-ASN": "13335",
+                "User-Agent": "Mozilla/5.0",
+            },
+        ),
+        NOW,
+    )
+
+    assert warp is not None and warp["is_warp"] is True
+    assert bot is not None and bot["is_bot"] is True
+    assert scanner is not None and scanner["is_bot"] is True
+    assert hosting is not None and hosting["is_hosting"] is True
+    assert hosting["is_bot"] is True
+    assert cloudflare_worker is not None
+    assert cloudflare_worker["is_hosting"] is True
+    assert cloudflare_worker["is_bot"] is True
+
+
+def test_viewer_address_wins_and_xff_fallback_uses_last_valid_ip() -> None:
+    preferred = collector._build_item(
+        _event(
+            "event=page_view&sid=a&eid=1",
+            **{
+                "CloudFront-Viewer-Address": "[2001:db8::9]:443",
+                "X-Forwarded-For": "192.0.2.1, 192.0.2.2",
+            },
+        ),
+        NOW,
+    )
+    fallback = collector._build_item(
+        _event(
+            "event=page_view&sid=b&eid=2",
+            **{"X-Forwarded-For": "spoofed, 198.51.100.8"},
+        ),
+        NOW,
+    )
+
+    assert preferred is not None and preferred["ip"] == "2001:db8::9"
+    assert fallback is not None and fallback["ip"] == "198.51.100.8"
+
+
+def test_eid_is_shared_with_the_durable_batch_event() -> None:
+    item = collector._build_item(
+        _event("event=page_view&sid=ses_1&eid=legacy_evt"), NOW
+    )
+
+    assert item is not None
+    assert item["eid"] == "legacy_evt"
+    assert item["sk"].endswith("#ses_1#legacy_evt")
+
+
+def test_handler_writes_immediately_and_returns_gif() -> None:
+    table = Mock()
+    collector._table = table
+    collector._utc_now = lambda: NOW
+
+    response = collector.handler(
+        _event("event=page_view&sid=ses_1&eid=evt_1"), None
+    )
+
+    table.put_item.assert_called_once()
+    assert response["statusCode"] == 200
+    assert response["headers"]["Content-Type"] == "image/gif"
+    assert response["isBase64Encoded"] is True
+
+
+def test_handler_swallows_dynamodb_failure_and_still_returns_200() -> None:
+    table = Mock()
+    table.put_item.side_effect = RuntimeError("DynamoDB unavailable")
+    collector._table = table
+    collector._utc_now = lambda: NOW
+
+    response = collector.handler(
+        _event("event=page_view&sid=ses_1&eid=evt_1"), None
+    )
+
+    assert response["statusCode"] == 200
+    assert response["headers"]["Cache-Control"].startswith("no-store")

--- a/infra/mcp_server_lambda/lambdas/receipt_mcp_server_server.py
+++ b/infra/mcp_server_lambda/lambdas/receipt_mcp_server_server.py
@@ -914,7 +914,7 @@ using get_receipt or get_receipt_image_url.""",
             },
         ),
         Tool(
-            name="analytics_auto",
+            name="analytics",
             description="""Unified production visitor analytics across live and durable data.
 
 Use this as the default tool when a question may span current and historical
@@ -969,7 +969,7 @@ event details, edge geo, referrer, and UTM attribution. By default excludes
 bots, Cloudflare WARP traffic, and datacenter-hosting traffic. `minutes` is
 clamped to the live table's 90-day retention window. Results contain at most
 the newest 5,000 events and 250 sessions; `truncated` reports omitted data.
-Prefer `analytics_auto` unless a Dynamo-only diagnostic is explicitly needed.""",
+Prefer `analytics` unless a Dynamo-only diagnostic is explicitly needed.""",
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -998,7 +998,7 @@ campaign result starts at its tagged landing event and continues until another
 tagged campaign begins. Returns pages/events, edge geo, referrer, and UTM
 fields. At least one of `campaign` or `since` is required. Results contain at
 most the newest 5,000 events and 250 sessions; `truncated` reports omitted
-data. Prefer `analytics_auto` when attribution may include durable history.""",
+data. Prefer `analytics` when attribution may include durable history.""",
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -1614,8 +1614,8 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent]:
             )
         elif name == "get_label_distribution":
             result = await get_label_distribution_impl(dynamo_client)
-        elif name == "analytics_auto":
-            result = await analytics_auto_impl(
+        elif name == "analytics":
+            result = await analytics_impl(
                 minutes=arguments.get("minutes"),
                 since=arguments.get("since"),
                 until=arguments.get("until"),
@@ -3740,8 +3740,8 @@ ANALYTICS_LIVE_TABLE = os.environ.get(
 ANALYTICS_LIVE_MAX_MINUTES = 90 * 24 * 60
 ANALYTICS_LIVE_MAX_EVENTS = 5000
 ANALYTICS_LIVE_MAX_SESSIONS = 250
-ANALYTICS_AUTO_MAX_MINUTES = 365 * 24 * 60
-ANALYTICS_AUTO_REPAIR_OVERLAP_DAYS = 4
+ANALYTICS_MAX_MINUTES = 365 * 24 * 60
+ANALYTICS_REPAIR_OVERLAP_DAYS = 4
 ANALYTICS_WATERMARK_CACHE_SECONDS = 300
 _analytics_watermark_cache = {"checked_at": 0.0, "value": None}
 
@@ -4253,7 +4253,7 @@ def _athena_run(sql: str, max_wait: int = 90, max_rows: int = 5000) -> list:
     return rows
 
 
-def _analytics_auto_window(
+def _analytics_window(
     minutes=None, since=None, until=None, campaign=None, now=None
 ):
     """Return a validated UTC [start, end) interval for routed analytics."""
@@ -4284,14 +4284,14 @@ def _analytics_auto_window(
         except (TypeError, ValueError) as exc:
             raise ValueError("minutes must be an integer") from exc
         effective_minutes = max(
-            1, min(effective_minutes, ANALYTICS_AUTO_MAX_MINUTES)
+            1, min(effective_minutes, ANALYTICS_MAX_MINUTES)
         )
         start = end - timedelta(minutes=effective_minutes)
 
     if start >= end:
         raise ValueError("since must be earlier than until")
-    if end - start > timedelta(minutes=ANALYTICS_AUTO_MAX_MINUTES):
-        raise ValueError("analytics_auto interval cannot exceed 365 days")
+    if end - start > timedelta(minutes=ANALYTICS_MAX_MINUTES):
+        raise ValueError("analytics interval cannot exceed 365 days")
     return start, end, current, effective_minutes
 
 
@@ -4436,7 +4436,7 @@ LIMIT {row_limit}
     return [_analytics_normalize_durable_event(row) for row in rows], truncated
 
 
-def _analytics_auto_merge_events(events: list[dict]):
+def _analytics_merge_events(events: list[dict]):
     """Deduplicate non-empty eids while retaining both sources' best fields."""
     durable_authoritative = {
         "dt",
@@ -4536,7 +4536,7 @@ def _analytics_auto_merge_events(events: list[dict]):
     return merged_events, deduplicated, len(without_eid)
 
 
-def _analytics_auto_unqueried_ranges(start, end, queried_ranges):
+def _analytics_unqueried_ranges(start, end, queried_ranges):
     """Return uncovered UTC intervals after merging successful source ranges."""
     cursor = start
     gaps = []
@@ -4555,7 +4555,7 @@ def _analytics_auto_unqueried_ranges(start, end, queried_ranges):
     return gaps
 
 
-async def analytics_auto_impl(
+async def analytics_impl(
     minutes=None,
     since=None,
     until=None,
@@ -4569,7 +4569,7 @@ async def analytics_auto_impl(
 
     try:
         campaign = str(campaign or "").strip()
-        start, end, current, effective_minutes = _analytics_auto_window(
+        start, end, current, effective_minutes = _analytics_window(
             minutes=minutes,
             since=since,
             until=until,
@@ -4587,7 +4587,7 @@ async def analytics_auto_impl(
         try:
             latest_durable = _analytics_latest_durable_event()
         except Exception as exc:
-            logger.exception("analytics_auto durable watermark failed")
+            logger.exception("analytics durable watermark failed")
             source_errors["watermark"] = str(exc)
 
         durable_range = None
@@ -4598,7 +4598,7 @@ async def analytics_auto_impl(
                 durable_range = (start, durable_end)
 
             overlap_start = latest_durable - timedelta(
-                days=ANALYTICS_AUTO_REPAIR_OVERLAP_DAYS
+                days=ANALYTICS_REPAIR_OVERLAP_DAYS
             )
             live_start = max(start, overlap_start, live_floor)
             if live_start < end:
@@ -4621,7 +4621,7 @@ async def analytics_auto_impl(
                 truncated = truncated or durable_truncated
                 queried_ranges.append(("durable", *durable_range))
             except Exception as exc:
-                logger.exception("analytics_auto durable query failed")
+                logger.exception("analytics durable query failed")
                 source_errors["durable"] = str(exc)
                 fallback_start = max(start, live_floor)
                 if fallback_start < end:
@@ -4645,10 +4645,10 @@ async def analytics_auto_impl(
                 truncated = truncated or live_truncated
                 queried_ranges.append(("live", *live_range))
             except Exception as exc:
-                logger.exception("analytics_auto live query failed")
+                logger.exception("analytics live query failed")
                 source_errors["live"] = str(exc)
 
-        events, deduplicated, undeduplicable = _analytics_auto_merge_events(
+        events, deduplicated, undeduplicable = _analytics_merge_events(
             all_events
         )
         if len(events) > ANALYTICS_LIVE_MAX_EVENTS:
@@ -4668,7 +4668,7 @@ async def analytics_auto_impl(
             truncated = True
         sessions = sessions[:limit]
 
-        unqueried_ranges = _analytics_auto_unqueried_ranges(
+        unqueried_ranges = _analytics_unqueried_ranges(
             start, end, queried_ranges
         )
         successful_sources = sorted({item[0] for item in queried_ranges})
@@ -4738,7 +4738,7 @@ async def analytics_auto_impl(
             "sessions": sessions,
         }
     except Exception as exc:
-        logger.exception("analytics_auto failed")
+        logger.exception("analytics failed")
         return {"error": str(exc)}
 
 

--- a/infra/mcp_server_lambda/lambdas/receipt_mcp_server_server.py
+++ b/infra/mcp_server_lambda/lambdas/receipt_mcp_server_server.py
@@ -914,6 +914,63 @@ using get_receipt or get_receipt_image_url.""",
             },
         ),
         Tool(
+            name="analytics_live",
+            description="""Recent production web visits from the real-time beacon collector.
+
+Reads DynamoDB directly and rolls beacon events into sessions with pages,
+event details, edge geo, referrer, and UTM attribution. By default excludes
+bots, Cloudflare WARP traffic, and datacenter-hosting traffic. `minutes` is
+clamped to the live table's 90-day retention window.""",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "minutes": {
+                        "type": "integer",
+                        "default": 60,
+                        "minimum": 1,
+                        "maximum": 129600,
+                        "description": "Lookback in minutes (default 60, max 129600)",
+                    },
+                    "humans_only": {
+                        "type": "boolean",
+                        "default": True,
+                        "description": "Exclude bots, WARP, and hosting traffic",
+                    },
+                },
+            },
+        ),
+        Tool(
+            name="analytics_attribution",
+            description="""Real-time campaign and outreach attribution.
+
+Filter live beacon events by exact `utm_campaign`, an ISO-8601 UTC `since`
+timestamp, or both. Campaign-only queries default to the last 24 hours. Returns
+session pages/events, first/last seen, edge geo, referrer, and UTM fields. At
+least one of `campaign` or `since` is required.""",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "campaign": {
+                        "type": "string",
+                        "description": "Exact utm_campaign value",
+                    },
+                    "since": {
+                        "type": "string",
+                        "description": "ISO-8601 timestamp (naive values are UTC)",
+                    },
+                    "humans_only": {
+                        "type": "boolean",
+                        "default": True,
+                        "description": "Exclude bots, WARP, and hosting traffic",
+                    },
+                },
+                "anyOf": [
+                    {"required": ["campaign"]},
+                    {"required": ["since"]},
+                ],
+            },
+        ),
+        Tool(
             name="analytics_traffic",
             description="""Per-day production web traffic (CloudFront logs via Athena).
 
@@ -1505,6 +1562,17 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent]:
             )
         elif name == "get_label_distribution":
             result = await get_label_distribution_impl(dynamo_client)
+        elif name == "analytics_live":
+            result = await analytics_live_impl(
+                minutes=arguments.get("minutes", 60),
+                humans_only=arguments.get("humans_only", True),
+            )
+        elif name == "analytics_attribution":
+            result = await analytics_attribution_impl(
+                campaign=arguments.get("campaign"),
+                since=arguments.get("since"),
+                humans_only=arguments.get("humans_only", True),
+            )
         elif name == "analytics_traffic":
             result = await analytics_traffic_impl(
                 start_date=arguments["start_date"],
@@ -3605,6 +3673,379 @@ async def delete_receipt_section_impl(
 ANALYTICS_DB = "portfolio_analytics"
 ANALYTICS_WORKGROUP = "portfolio_analytics"
 ANALYTICS_REGION = "us-east-1"
+ANALYTICS_LIVE_TABLE = os.environ.get(
+    "WEB_EVENTS_LIVE_TABLE_NAME", "web_events_live"
+)
+ANALYTICS_LIVE_MAX_MINUTES = 90 * 24 * 60
+
+
+def _analytics_normalize_dynamo(value):
+    """Return a JSON-safe copy of a value produced by boto3 DynamoDB."""
+    from decimal import Decimal
+
+    if isinstance(value, Decimal):
+        if value == value.to_integral_value():
+            return int(value)
+        return float(value)
+    if isinstance(value, dict):
+        return {
+            key: _analytics_normalize_dynamo(item)
+            for key, item in value.items()
+        }
+    if isinstance(value, (list, tuple)):
+        return [_analytics_normalize_dynamo(item) for item in value]
+    if isinstance(value, set):
+        return [
+            _analytics_normalize_dynamo(item)
+            for item in sorted(value, key=str)
+        ]
+    return value
+
+
+def _analytics_live_iso(dt) -> str:
+    return dt.isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+
+def _analytics_live_parse_since(value: str):
+    from datetime import datetime, timezone
+
+    text = (value or "").strip()
+    if not text:
+        raise ValueError("since must be a non-empty ISO-8601 timestamp")
+    if text.endswith(("Z", "z")):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError as exc:
+        raise ValueError(
+            f"since must be an ISO-8601 timestamp, got {value!r}"
+        ) from exc
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _analytics_live_window(minutes=60, since=None, now=None):
+    from datetime import datetime, timedelta, timezone
+
+    current = now or datetime.now(timezone.utc)
+    if current.tzinfo is None:
+        current = current.replace(tzinfo=timezone.utc)
+    current = current.astimezone(timezone.utc)
+    earliest = current - timedelta(minutes=ANALYTICS_LIVE_MAX_MINUTES)
+
+    if since is not None and str(since).strip():
+        start = _analytics_live_parse_since(str(since))
+        if start > current:
+            raise ValueError("since cannot be in the future")
+        return max(start, earliest), current
+
+    try:
+        lookback = int(minutes)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("minutes must be an integer") from exc
+    lookback = max(1, min(lookback, ANALYTICS_LIVE_MAX_MINUTES))
+    return current - timedelta(minutes=lookback), current
+
+
+def _analytics_live_epoch_ms(item: dict) -> int:
+    raw_epoch = item.get("epoch_ms")
+    if raw_epoch is not None:
+        try:
+            return int(raw_epoch)
+        except (TypeError, ValueError):
+            pass
+
+    sk_epoch = str(item.get("sk") or "").split("#", 1)[0]
+    if sk_epoch.isdigit():
+        return int(sk_epoch)
+
+    try:
+        return int(_analytics_live_parse_since(str(item.get("ts"))).timestamp() * 1000)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _analytics_live_query(start, end) -> list[dict]:
+    """Query each UTC date partition intersecting [start, end]; never scan."""
+    from datetime import datetime, timedelta, timezone
+
+    import boto3
+    from boto3.dynamodb.conditions import Key
+
+    table = boto3.resource("dynamodb", region_name=ANALYTICS_REGION).Table(
+        ANALYTICS_LIVE_TABLE
+    )
+    start_ms = int(start.timestamp() * 1000)
+    end_ms = int(end.timestamp() * 1000)
+    items = []
+    day = start.date()
+    while day <= end.date():
+        day_start = datetime.combine(day, datetime.min.time(), timezone.utc)
+        next_day = day_start + timedelta(days=1)
+        lower_ms = max(start_ms, int(day_start.timestamp() * 1000))
+        upper_ms = min(end_ms, int(next_day.timestamp() * 1000) - 1)
+        query_args = {
+            "KeyConditionExpression": (
+                Key("dt").eq(day.isoformat())
+                & Key("sk").between(
+                    f"{lower_ms:013d}#", f"{upper_ms:013d}#\uffff"
+                )
+            ),
+            # The real-time tool should observe a just-written beacon.
+            "ConsistentRead": True,
+        }
+        while True:
+            response = table.query(**query_args)
+            items.extend(response.get("Items", []))
+            last_key = response.get("LastEvaluatedKey")
+            if not last_key:
+                break
+            query_args["ExclusiveStartKey"] = last_key
+        day += timedelta(days=1)
+
+    normalized = [_analytics_normalize_dynamo(item) for item in items]
+    # The SK range is authoritative; the second check protects against malformed
+    # test/manual rows and keeps rollups deterministic.
+    normalized = [
+        item
+        for item in normalized
+        if start_ms <= _analytics_live_epoch_ms(item) <= end_ms
+    ]
+    return sorted(
+        normalized,
+        key=lambda item: (
+            _analytics_live_epoch_ms(item),
+            str(item.get("sk") or ""),
+        ),
+    )
+
+
+def _analytics_live_flag(item: dict, key: str) -> bool:
+    value = item.get(key, False)
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes"}
+    return bool(value)
+
+
+def _analytics_live_is_human(item: dict) -> bool:
+    # Batch `is_bot` already folds hosting into bots. Live checks all three
+    # explicitly so classification cannot drift if one stored flag is wrong.
+    return not any(
+        _analytics_live_flag(item, key)
+        for key in ("is_bot", "is_warp", "is_hosting")
+    )
+
+
+def _analytics_live_first(events: list[dict], key: str):
+    for event in events:
+        value = event.get(key)
+        if value is not None and value != "":
+            return value
+    return None
+
+
+def _analytics_live_referrer_parts(ref):
+    from urllib.parse import urlsplit
+
+    if not ref:
+        return None, None
+    text = str(ref)
+    try:
+        parsed = urlsplit(text)
+    except ValueError:
+        return None, text
+    path = parsed.path or "/"
+    if parsed.query:
+        path = f"{path}?{parsed.query}"
+    return parsed.netloc or None, path
+
+
+_ANALYTICS_LIVE_EVENT_METRICS = (
+    "page_path",
+    "percent_scrolled",
+    "metric_name",
+    "metric_value",
+    "time_to_bottom_ms",
+    "active_scroll_ms",
+    "page_height",
+    "scrollable_pixels",
+    "screens_per_minute",
+    "reader_delta_percent",
+    "baseline_sample_size",
+    "session_page_views",
+    "quick_jump",
+)
+
+
+def _analytics_live_event_summary(item: dict) -> dict:
+    summary = {
+        "ts": item.get("ts"),
+        "eid": item.get("eid"),
+        "event": item.get("event"),
+        "path": item.get("path") or item.get("page_path"),
+    }
+    for key in _ANALYTICS_LIVE_EVENT_METRICS:
+        value = item.get(key)
+        if value is not None and value != "":
+            summary[key] = value
+    return {key: value for key, value in summary.items() if value is not None}
+
+
+def _analytics_live_rollup(events: list[dict]) -> list[dict]:
+    grouped = defaultdict(list)
+    for event in events:
+        sid = str(event.get("sid") or "").strip()
+        if sid:
+            grouped[sid].append(event)
+
+    sessions = []
+    for sid, session_events in grouped.items():
+        session_events.sort(
+            key=lambda event: (
+                _analytics_live_epoch_ms(event),
+                str(event.get("sk") or ""),
+            )
+        )
+        first_epoch = _analytics_live_epoch_ms(session_events[0])
+        last_epoch = _analytics_live_epoch_ms(session_events[-1])
+        pages = []
+        event_counts = {}
+        for event in session_events:
+            page = event.get("path") or event.get("page_path")
+            if page and page not in pages:
+                pages.append(page)
+            event_name = str(event.get("event") or "unknown")
+            event_counts[event_name] = event_counts.get(event_name, 0) + 1
+
+        ref = _analytics_live_first(session_events, "ref")
+        referrer_host, referrer_path = _analytics_live_referrer_parts(ref)
+        session = {
+            "sid": sid,
+            "first_seen": session_events[0].get("ts"),
+            "last_seen": session_events[-1].get("ts"),
+            "duration_seconds": max(0, (last_epoch - first_epoch) // 1000),
+            "ip": _analytics_live_first(session_events, "ip"),
+            "ua": _analytics_live_first(session_events, "ua"),
+            "country": _analytics_live_first(session_events, "country"),
+            "region": _analytics_live_first(session_events, "region"),
+            "city": _analytics_live_first(session_events, "city"),
+            "latitude": _analytics_live_first(session_events, "latitude"),
+            "longitude": _analytics_live_first(session_events, "longitude"),
+            "timezone": _analytics_live_first(session_events, "timezone"),
+            "asn": _analytics_live_first(session_events, "asn"),
+            "ref": ref,
+            "referrer_host": referrer_host,
+            "referrer_path": referrer_path,
+            "utm_source": _analytics_live_first(session_events, "utm_source"),
+            "utm_medium": _analytics_live_first(session_events, "utm_medium"),
+            "utm_campaign": _analytics_live_first(
+                session_events, "utm_campaign"
+            ),
+            "is_warp": any(
+                _analytics_live_flag(event, "is_warp")
+                for event in session_events
+            ),
+            "is_bot": any(
+                _analytics_live_flag(event, "is_bot")
+                for event in session_events
+            ),
+            "is_hosting": any(
+                _analytics_live_flag(event, "is_hosting")
+                for event in session_events
+            ),
+            "pages": pages,
+            "pageviews": event_counts.get("page_view", 0),
+            "beacons": len(session_events),
+            "event_counts": event_counts,
+            "events": [
+                _analytics_live_event_summary(event)
+                for event in session_events
+            ],
+            "_last_epoch": last_epoch,
+        }
+        sessions.append(session)
+
+    sessions.sort(
+        key=lambda session: (session["_last_epoch"], session["sid"]),
+        reverse=True,
+    )
+    for session in sessions:
+        session.pop("_last_epoch", None)
+    return sessions
+
+
+async def analytics_live_impl(minutes=60, humans_only=True) -> dict:
+    try:
+        start, end = _analytics_live_window(minutes=minutes)
+        effective_minutes = max(
+            1, min(int(minutes), ANALYTICS_LIVE_MAX_MINUTES)
+        )
+        events = _analytics_live_query(start, end)
+        if humans_only:
+            events = [event for event in events if _analytics_live_is_human(event)]
+        sessions = _analytics_live_rollup(events)
+        return {
+            "since": _analytics_live_iso(start),
+            "as_of": _analytics_live_iso(end),
+            "minutes": effective_minutes,
+            "timezone": "UTC",
+            "humans_only": bool(humans_only),
+            "event_count": len(events),
+            "session_count": len(sessions),
+            "sessions": sessions,
+        }
+    except Exception as exc:
+        logger.exception("analytics_live failed")
+        return {"error": str(exc)}
+
+
+async def analytics_attribution_impl(
+    campaign=None, since=None, humans_only=True
+) -> dict:
+    try:
+        campaign = str(campaign or "").strip()
+        since = str(since or "").strip()
+        if not campaign and not since:
+            return {"error": "campaign or since is required"}
+
+        # Campaign-only is optimized for the outreach use case; explicit since
+        # can reach back as far as the live table's 90-day TTL.
+        start, end = _analytics_live_window(
+            minutes=24 * 60,
+            since=since or None,
+        )
+        events = _analytics_live_query(start, end)
+        if humans_only:
+            events = [event for event in events if _analytics_live_is_human(event)]
+        attributed_sids = {
+            str(event.get("sid") or "")
+            for event in events
+            if str(event.get("utm_campaign") or "") == campaign
+        }
+        sessions = _analytics_live_rollup(events)
+        if campaign:
+            sessions = [
+                session
+                for session in sessions
+                if session["sid"] in attributed_sids
+            ]
+        attributed_event_count = sum(
+            session["beacons"] for session in sessions
+        )
+        return {
+            "campaign": campaign or None,
+            "since": _analytics_live_iso(start),
+            "as_of": _analytics_live_iso(end),
+            "timezone": "UTC",
+            "humans_only": bool(humans_only),
+            "event_count": attributed_event_count,
+            "session_count": len(sessions),
+            "sessions": sessions,
+        }
+    except Exception as exc:
+        logger.exception("analytics_attribution failed")
+        return {"error": str(exc)}
 
 
 

--- a/infra/mcp_server_lambda/lambdas/receipt_mcp_server_server.py
+++ b/infra/mcp_server_lambda/lambdas/receipt_mcp_server_server.py
@@ -914,6 +914,53 @@ using get_receipt or get_receipt_image_url.""",
             },
         ),
         Tool(
+            name="analytics_auto",
+            description="""Unified production visitor analytics across live and durable data.
+
+Use this as the default tool when a question may span current and historical
+traffic. It routes the older range to Athena and queries DynamoDB across a
+four-day repair/tail overlap, then normalizes, merges, and de-duplicates events
+by `eid`. Optional exact `campaign` filtering preserves campaign segments
+across the source boundary. Returns source/freshness metadata, errors,
+queried/unqueried ranges, and at most 250 newest sessions without changing
+existing analytics tools.""",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "minutes": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 525600,
+                        "description": "Lookback ending at until; default 60, or 1440 for campaign-only",
+                    },
+                    "since": {
+                        "type": "string",
+                        "description": "Optional ISO-8601 UTC start (max 365-day interval)",
+                    },
+                    "until": {
+                        "type": "string",
+                        "description": "Optional ISO-8601 UTC exclusive end (default now)",
+                    },
+                    "campaign": {
+                        "type": "string",
+                        "description": "Optional exact utm_campaign value",
+                    },
+                    "humans_only": {
+                        "type": "boolean",
+                        "default": True,
+                        "description": "Exclude bots, WARP, and hosting traffic",
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "default": 250,
+                        "minimum": 1,
+                        "maximum": 250,
+                        "description": "Maximum newest sessions returned",
+                    },
+                },
+            },
+        ),
+        Tool(
             name="analytics_live",
             description="""Recent production web visits from the real-time beacon collector.
 
@@ -921,7 +968,8 @@ Reads DynamoDB directly and rolls beacon events into sessions with pages,
 event details, edge geo, referrer, and UTM attribution. By default excludes
 bots, Cloudflare WARP traffic, and datacenter-hosting traffic. `minutes` is
 clamped to the live table's 90-day retention window. Results contain at most
-the newest 5,000 events and 250 sessions; `truncated` reports omitted data.""",
+the newest 5,000 events and 250 sessions; `truncated` reports omitted data.
+Prefer `analytics_auto` unless a Dynamo-only diagnostic is explicitly needed.""",
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -950,7 +998,7 @@ campaign result starts at its tagged landing event and continues until another
 tagged campaign begins. Returns pages/events, edge geo, referrer, and UTM
 fields. At least one of `campaign` or `since` is required. Results contain at
 most the newest 5,000 events and 250 sessions; `truncated` reports omitted
-data.""",
+data. Prefer `analytics_auto` when attribution may include durable history.""",
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -1566,6 +1614,15 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent]:
             )
         elif name == "get_label_distribution":
             result = await get_label_distribution_impl(dynamo_client)
+        elif name == "analytics_auto":
+            result = await analytics_auto_impl(
+                minutes=arguments.get("minutes"),
+                since=arguments.get("since"),
+                until=arguments.get("until"),
+                campaign=arguments.get("campaign"),
+                humans_only=arguments.get("humans_only", True),
+                limit=arguments.get("limit", 250),
+            )
         elif name == "analytics_live":
             result = await analytics_live_impl(
                 minutes=arguments.get("minutes", 60),
@@ -3683,6 +3740,10 @@ ANALYTICS_LIVE_TABLE = os.environ.get(
 ANALYTICS_LIVE_MAX_MINUTES = 90 * 24 * 60
 ANALYTICS_LIVE_MAX_EVENTS = 5000
 ANALYTICS_LIVE_MAX_SESSIONS = 250
+ANALYTICS_AUTO_MAX_MINUTES = 365 * 24 * 60
+ANALYTICS_AUTO_REPAIR_OVERLAP_DAYS = 4
+ANALYTICS_WATERMARK_CACHE_SECONDS = 300
+_analytics_watermark_cache = {"checked_at": 0.0, "value": None}
 
 
 def _analytics_normalize_dynamo(value):
@@ -3953,6 +4014,7 @@ def _analytics_live_event_summary(item: dict) -> dict:
         "eid": item.get("eid"),
         "event": item.get("event"),
         "path": item.get("path") or item.get("page_path"),
+        "source": item.get("_source"),
     }
     for key in _ANALYTICS_LIVE_EVENT_METRICS:
         value = item.get(key)
@@ -4035,6 +4097,19 @@ def _analytics_live_rollup(events: list[dict]) -> list[dict]:
         }
         if campaign_segment is not None:
             session["campaign_segment"] = campaign_segment
+        org = _analytics_live_first(session_events, "org")
+        if org:
+            session["org"] = org
+        source_set = set()
+        for event in session_events:
+            event_sources = event.get("_sources") or []
+            if event_sources:
+                source_set.update(str(source) for source in event_sources)
+            elif event.get("_source"):
+                source_set.add(str(event["_source"]))
+        sources = sorted(source_set)
+        if sources:
+            session["sources"] = sources
         sessions.append(session)
 
     sessions.sort(
@@ -4176,6 +4251,495 @@ def _athena_run(sql: str, max_wait: int = 90, max_rows: int = 5000) -> list:
         if not token:
             break
     return rows
+
+
+def _analytics_auto_window(
+    minutes=None, since=None, until=None, campaign=None, now=None
+):
+    """Return a validated UTC [start, end) interval for routed analytics."""
+    from datetime import datetime, timedelta, timezone
+
+    current = now or datetime.now(timezone.utc)
+    if current.tzinfo is None:
+        current = current.replace(tzinfo=timezone.utc)
+    current = current.astimezone(timezone.utc)
+
+    end = (
+        _analytics_live_parse_since(str(until))
+        if until is not None and str(until).strip()
+        else current
+    )
+    if end > current:
+        raise ValueError("until cannot be in the future")
+
+    if since is not None and str(since).strip():
+        start = _analytics_live_parse_since(str(since))
+        effective_minutes = None
+    else:
+        default_minutes = 24 * 60 if str(campaign or "").strip() else 60
+        try:
+            effective_minutes = int(
+                default_minutes if minutes is None else minutes
+            )
+        except (TypeError, ValueError) as exc:
+            raise ValueError("minutes must be an integer") from exc
+        effective_minutes = max(
+            1, min(effective_minutes, ANALYTICS_AUTO_MAX_MINUTES)
+        )
+        start = end - timedelta(minutes=effective_minutes)
+
+    if start >= end:
+        raise ValueError("since must be earlier than until")
+    if end - start > timedelta(minutes=ANALYTICS_AUTO_MAX_MINUTES):
+        raise ValueError("analytics_auto interval cannot exceed 365 days")
+    return start, end, current, effective_minutes
+
+
+def _analytics_durable_param_sql(name: str) -> str:
+    """Extract one beacon parameter already retained in query_decoded."""
+    return (
+        "NULLIF(TRY(url_decode(regexp_extract(COALESCE(query_decoded, ''), "
+        f"'(?:^|&){name}=([^&]*)', 1))), '')"
+    )
+
+
+def _analytics_latest_durable_event(force=False):
+    """Return the newest materialized event timestamp, cached for warm calls."""
+    import time
+
+    checked_at = float(_analytics_watermark_cache.get("checked_at") or 0.0)
+    now_mono = time.monotonic()
+    if (
+        not force
+        and checked_at
+        and now_mono - checked_at < ANALYTICS_WATERMARK_CACHE_SECONDS
+    ):
+        return _analytics_watermark_cache.get("value")
+
+    import boto3
+
+    glue = boto3.client("glue", region_name=ANALYTICS_REGION)
+    partition_dates = []
+    paginator = glue.get_paginator("get_partitions")
+    for page in paginator.paginate(
+        DatabaseName=ANALYTICS_DB,
+        TableName="web_events",
+        ExcludeColumnSchema=True,
+    ):
+        for partition in page.get("Partitions", []):
+            values = partition.get("Values") or []
+            if values:
+                try:
+                    partition_dates.append(_analytics_check_date(values[0]))
+                except ValueError:
+                    continue
+
+    latest = None
+    if partition_dates:
+        repair_dates = sorted(set(partition_dates))[-4:]
+        dates_sql = ", ".join(f"'{dt}'" for dt in repair_dates)
+        rows = _athena_run(
+            f"""
+SELECT date_format(max(ts_utc), '%Y-%m-%dT%H:%i:%s.%fZ') AS latest
+FROM {ANALYTICS_DB}.web_events
+WHERE dt IN ({dates_sql})
+""",
+            max_rows=1,
+        )
+        raw = rows[0].get("latest") if rows else None
+        if raw:
+            latest = _analytics_live_parse_since(raw)
+
+    _analytics_watermark_cache["checked_at"] = now_mono
+    _analytics_watermark_cache["value"] = latest
+    return latest
+
+
+def _analytics_normalize_durable_event(row: dict) -> dict:
+    """Map an Athena web_events row to the live event contract."""
+    event = {
+        key: value
+        for key, value in row.items()
+        if value is not None and value != ""
+    }
+    try:
+        event["epoch_ms"] = int(event.get("epoch_ms", 0))
+    except (TypeError, ValueError):
+        event["epoch_ms"] = _analytics_live_epoch_ms(event)
+
+    sid = str(event.get("sid") or "")
+    eid = str(event.get("eid") or "")
+    request_id = str(event.get("request_id") or "")
+    event["sk"] = (
+        f"{event['epoch_ms']:013d}#{sid}#{eid or request_id}"
+    )
+    event["_source"] = "durable"
+    event["_sources"] = ["durable"]
+    return event
+
+
+def _analytics_durable_query(start, end) -> tuple[list[dict], bool]:
+    """Read normalized durable beacon events for UTC [start, end)."""
+    from datetime import timedelta
+
+    if start >= end:
+        return [], False
+
+    last_included = end - timedelta(microseconds=1)
+    start_dt = start.date().isoformat()
+    end_dt = last_included.date().isoformat()
+    start_sql = start.strftime("%Y-%m-%d %H:%M:%S.%f")
+    end_sql = end.strftime("%Y-%m-%d %H:%M:%S.%f")
+    param_fields = (
+        "ref",
+        "utm_source",
+        "utm_medium",
+        "utm_campaign",
+        *_ANALYTICS_LIVE_EVENT_METRICS,
+    )
+    param_select = ",\n  ".join(
+        f"{_analytics_durable_param_sql(name)} AS {name}"
+        for name in param_fields
+    )
+    row_limit = ANALYTICS_LIVE_MAX_EVENTS + 1
+    sql = f"""
+SELECT
+  dt,
+  request_id,
+  date_format(ts_utc, '%Y-%m-%dT%H:%i:%s.%fZ') AS ts,
+  CAST(to_unixtime(ts_utc) * 1000 AS bigint) AS epoch_ms,
+  sid,
+  eid,
+  event,
+  evt_path AS path,
+  {param_select},
+  request_ip AS ip,
+  user_agent AS ua,
+  country,
+  city,
+  org,
+  asn,
+  is_warp,
+  is_bot,
+  is_hosting
+FROM {ANALYTICS_DB}.web_events
+WHERE dt BETWEEN '{start_dt}' AND '{end_dt}'
+  AND is_beacon
+  AND ts_utc >= TIMESTAMP '{start_sql}'
+  AND ts_utc < TIMESTAMP '{end_sql}'
+ORDER BY ts_utc DESC, request_id DESC
+LIMIT {row_limit}
+"""
+    rows = _athena_run(sql, max_rows=row_limit)
+    truncated = len(rows) > ANALYTICS_LIVE_MAX_EVENTS
+    rows = rows[:ANALYTICS_LIVE_MAX_EVENTS]
+    return [_analytics_normalize_durable_event(row) for row in rows], truncated
+
+
+def _analytics_auto_merge_events(events: list[dict]):
+    """Deduplicate non-empty eids while retaining both sources' best fields."""
+    durable_authoritative = {
+        "dt",
+        "request_id",
+        "sid",
+        "eid",
+        "event",
+        "path",
+        "page_path",
+        "ip",
+        "ua",
+        "country",
+        "city",
+        "org",
+        "asn",
+        "is_warp",
+        "is_bot",
+        "is_hosting",
+    }
+    by_eid = {}
+    without_eid = []
+    deduplicated = 0
+
+    ordered = sorted(
+        events,
+        key=lambda event: (
+            _analytics_live_epoch_ms(event),
+            str(event.get("sk") or ""),
+        ),
+    )
+    for original in ordered:
+        event = dict(original)
+        source = str(event.get("_source") or "")
+        if source == "live":
+            event["_live_order"] = {
+                key: event.get(key)
+                for key in ("dt", "ts", "epoch_ms", "sk")
+            }
+        event["_sources"] = sorted(
+            set(event.get("_sources") or ([source] if source else []))
+        )
+        eid = str(event.get("eid") or "").strip()
+        if not eid:
+            without_eid.append(event)
+            continue
+
+        existing = by_eid.get(eid)
+        if existing is None:
+            by_eid[eid] = event
+            continue
+
+        deduplicated += 1
+        merged = dict(existing)
+        for key, value in event.items():
+            if (
+                value is not None
+                and value != ""
+                and (merged.get(key) is None or merged.get(key) == "")
+            ):
+                merged[key] = value
+
+        durable = None
+        if event.get("_source") == "durable":
+            durable = event
+        elif existing.get("_source") == "durable" or "durable" in (
+            existing.get("_sources") or []
+        ):
+            durable = existing
+        if durable is not None:
+            for key in durable_authoritative:
+                value = durable.get(key)
+                if value is not None and value != "":
+                    merged[key] = value
+
+        sources = sorted(
+            set(existing.get("_sources") or [])
+            | set(event.get("_sources") or [])
+        )
+        merged["_sources"] = sources
+        merged["_source"] = "mixed" if len(sources) > 1 else sources[0]
+        if "durable" in sources and "live" in sources:
+            live_order = merged.get("_live_order") or {}
+            for key in ("dt", "ts", "epoch_ms", "sk"):
+                value = live_order.get(key)
+                if value is not None and value != "":
+                    merged[key] = value
+        by_eid[eid] = merged
+
+    merged_events = list(by_eid.values()) + without_eid
+    merged_events.sort(
+        key=lambda event: (
+            _analytics_live_epoch_ms(event),
+            str(event.get("sk") or ""),
+        ),
+        reverse=True,
+    )
+    return merged_events, deduplicated, len(without_eid)
+
+
+def _analytics_auto_unqueried_ranges(start, end, queried_ranges):
+    """Return uncovered UTC intervals after merging successful source ranges."""
+    cursor = start
+    gaps = []
+    for _, covered_start, covered_end in sorted(
+        queried_ranges, key=lambda item: item[1]
+    ):
+        covered_start = max(start, covered_start)
+        covered_end = min(end, covered_end)
+        if covered_end <= cursor:
+            continue
+        if covered_start > cursor:
+            gaps.append((cursor, covered_start))
+        cursor = max(cursor, covered_end)
+    if cursor < end:
+        gaps.append((cursor, end))
+    return gaps
+
+
+async def analytics_auto_impl(
+    minutes=None,
+    since=None,
+    until=None,
+    campaign=None,
+    humans_only=True,
+    limit=ANALYTICS_LIVE_MAX_SESSIONS,
+    _now=None,
+) -> dict:
+    """Route one UTC interval across durable and live analytics sources."""
+    from datetime import timedelta
+
+    try:
+        campaign = str(campaign or "").strip()
+        start, end, current, effective_minutes = _analytics_auto_window(
+            minutes=minutes,
+            since=since,
+            until=until,
+            campaign=campaign,
+            now=_now,
+        )
+        limit = max(1, min(int(limit), ANALYTICS_LIVE_MAX_SESSIONS))
+        live_floor = current - timedelta(
+            minutes=ANALYTICS_LIVE_MAX_MINUTES
+        )
+        source_errors = {}
+        latest_durable = None
+        overlap_start = None
+
+        try:
+            latest_durable = _analytics_latest_durable_event()
+        except Exception as exc:
+            logger.exception("analytics_auto durable watermark failed")
+            source_errors["watermark"] = str(exc)
+
+        durable_range = None
+        live_range = None
+        if latest_durable is not None:
+            durable_end = min(end, latest_durable + timedelta(milliseconds=1))
+            if start < durable_end:
+                durable_range = (start, durable_end)
+
+            overlap_start = latest_durable - timedelta(
+                days=ANALYTICS_AUTO_REPAIR_OVERLAP_DAYS
+            )
+            live_start = max(start, overlap_start, live_floor)
+            if live_start < end:
+                live_range = (live_start, end)
+        else:
+            live_start = max(start, live_floor)
+            if live_start < end:
+                live_range = (live_start, end)
+
+        all_events = []
+        queried_ranges = []
+        truncated = False
+
+        if durable_range is not None:
+            try:
+                durable_events, durable_truncated = _analytics_durable_query(
+                    *durable_range
+                )
+                all_events.extend(durable_events)
+                truncated = truncated or durable_truncated
+                queried_ranges.append(("durable", *durable_range))
+            except Exception as exc:
+                logger.exception("analytics_auto durable query failed")
+                source_errors["durable"] = str(exc)
+                fallback_start = max(start, live_floor)
+                if fallback_start < end:
+                    live_range = (fallback_start, end)
+
+        if live_range is not None:
+            try:
+                live_events, live_truncated = _analytics_live_query(
+                    live_range[0],
+                    live_range[1] - timedelta(microseconds=1),
+                )
+                start_ms = live_range[0].timestamp() * 1000
+                end_ms = live_range[1].timestamp() * 1000
+                for live_event in live_events:
+                    epoch_ms = _analytics_live_epoch_ms(live_event)
+                    if start_ms <= epoch_ms < end_ms:
+                        normalized = dict(live_event)
+                        normalized["_source"] = "live"
+                        normalized["_sources"] = ["live"]
+                        all_events.append(normalized)
+                truncated = truncated or live_truncated
+                queried_ranges.append(("live", *live_range))
+            except Exception as exc:
+                logger.exception("analytics_auto live query failed")
+                source_errors["live"] = str(exc)
+
+        events, deduplicated, undeduplicable = _analytics_auto_merge_events(
+            all_events
+        )
+        if len(events) > ANALYTICS_LIVE_MAX_EVENTS:
+            events = events[:ANALYTICS_LIVE_MAX_EVENTS]
+            truncated = True
+        if humans_only:
+            events = [
+                event
+                for event in events
+                if _analytics_live_is_human(event)
+            ]
+        if campaign:
+            events = _analytics_live_campaign_events(events, campaign)
+
+        sessions = _analytics_live_rollup(events)
+        if len(sessions) > limit:
+            truncated = True
+        sessions = sessions[:limit]
+
+        unqueried_ranges = _analytics_auto_unqueried_ranges(
+            start, end, queried_ranges
+        )
+        successful_sources = sorted({item[0] for item in queried_ranges})
+        if len(successful_sources) > 1:
+            source = "mixed"
+        elif successful_sources:
+            source = successful_sources[0]
+        else:
+            source = "none"
+
+        if not successful_sources and source_errors:
+            return {
+                "error": "all analytics sources failed",
+                "source_errors": source_errors,
+                "since": _analytics_live_iso(start),
+                "until": _analytics_live_iso(end),
+            }
+
+        source_event_counts = {"durable": 0, "live": 0, "mixed": 0}
+        for event in events:
+            event_source = str(event.get("_source") or "")
+            if event_source in source_event_counts:
+                source_event_counts[event_source] += 1
+
+        return {
+            "source": source,
+            "since": _analytics_live_iso(start),
+            "until": _analytics_live_iso(end),
+            "as_of": _analytics_live_iso(current),
+            "minutes": effective_minutes,
+            "campaign": campaign or None,
+            "timezone": "UTC",
+            "humans_only": bool(humans_only),
+            "partial": bool(source_errors or unqueried_ranges),
+            "truncated": truncated,
+            "latest_durable_event": (
+                _analytics_live_iso(latest_durable)
+                if latest_durable is not None
+                else None
+            ),
+            "live_durable_overlap_start": (
+                _analytics_live_iso(overlap_start)
+                if overlap_start is not None
+                else None
+            ),
+            "queried_ranges": [
+                {
+                    "source": item_source,
+                    "since": _analytics_live_iso(item_start),
+                    "until": _analytics_live_iso(item_end),
+                }
+                for item_source, item_start, item_end in queried_ranges
+            ],
+            "unqueried_ranges": [
+                {
+                    "since": _analytics_live_iso(gap_start),
+                    "until": _analytics_live_iso(gap_end),
+                }
+                for gap_start, gap_end in unqueried_ranges
+            ],
+            "source_errors": source_errors,
+            "source_event_counts": source_event_counts,
+            "deduplicated_event_count": deduplicated,
+            "undeduplicable_event_count": undeduplicable,
+            "event_count": len(events),
+            "session_count": len(sessions),
+            "sessions": sessions,
+        }
+    except Exception as exc:
+        logger.exception("analytics_auto failed")
+        return {"error": str(exc)}
 
 
 def _analytics_base_cte(start_date: str, end_date: str) -> str:

--- a/infra/mcp_server_lambda/lambdas/receipt_mcp_server_server.py
+++ b/infra/mcp_server_lambda/lambdas/receipt_mcp_server_server.py
@@ -3770,7 +3770,7 @@ def _analytics_normalize_dynamo(value):
 
 
 def _analytics_live_iso(dt) -> str:
-    return dt.isoformat(timespec="milliseconds").replace("+00:00", "Z")
+    return dt.isoformat(timespec="milliseconds")
 
 
 def _analytics_live_parse_since(value: str):

--- a/infra/mcp_server_lambda/lambdas/receipt_mcp_server_server.py
+++ b/infra/mcp_server_lambda/lambdas/receipt_mcp_server_server.py
@@ -920,7 +920,8 @@ using get_receipt or get_receipt_image_url.""",
 Reads DynamoDB directly and rolls beacon events into sessions with pages,
 event details, edge geo, referrer, and UTM attribution. By default excludes
 bots, Cloudflare WARP traffic, and datacenter-hosting traffic. `minutes` is
-clamped to the live table's 90-day retention window.""",
+clamped to the live table's 90-day retention window. Results contain at most
+the newest 5,000 events and 250 sessions; `truncated` reports omitted data.""",
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -946,7 +947,8 @@ clamped to the live table's 90-day retention window.""",
 Filter live beacon events by exact `utm_campaign`, an ISO-8601 UTC `since`
 timestamp, or both. Campaign-only queries default to the last 24 hours. Returns
 session pages/events, first/last seen, edge geo, referrer, and UTM fields. At
-least one of `campaign` or `since` is required.""",
+least one of `campaign` or `since` is required. Results contain at most the
+newest 5,000 events and 250 sessions; `truncated` reports omitted data.""",
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -3665,10 +3667,10 @@ async def delete_receipt_section_impl(
 
 
 # ---------------------------------------------------------------------------
-# Web analytics — Athena over CloudFront access logs.
-# Glue table + workgroup are created by infra/components/web_analytics.
-# All beacon parsing / WARP+bot classification / PT bucketing lives here in
-# SQL so the logic stays version-controlled rather than in a Glue view.
+# Web analytics — live DynamoDB overlay + durable CloudFront/Athena batch.
+# infra/components/web_analytics creates both query surfaces. The batch
+# transform owns durable parsing/classification/materialization; the collector
+# owns request-time flags. This server only reads and rolls up those records.
 # ---------------------------------------------------------------------------
 ANALYTICS_DB = "portfolio_analytics"
 ANALYTICS_WORKGROUP = "portfolio_analytics"
@@ -3677,6 +3679,8 @@ ANALYTICS_LIVE_TABLE = os.environ.get(
     "WEB_EVENTS_LIVE_TABLE_NAME", "web_events_live"
 )
 ANALYTICS_LIVE_MAX_MINUTES = 90 * 24 * 60
+ANALYTICS_LIVE_MAX_EVENTS = 5000
+ANALYTICS_LIVE_MAX_SESSIONS = 250
 
 
 def _analytics_normalize_dynamo(value):
@@ -3766,8 +3770,8 @@ def _analytics_live_epoch_ms(item: dict) -> int:
         return 0
 
 
-def _analytics_live_query(start, end) -> list[dict]:
-    """Query each UTC date partition intersecting [start, end]; never scan."""
+def _analytics_live_query(start, end) -> tuple[list[dict], bool]:
+    """Return the newest bounded event suffix and whether data was unread."""
     from datetime import datetime, timedelta, timezone
 
     import boto3
@@ -3779,8 +3783,10 @@ def _analytics_live_query(start, end) -> list[dict]:
     start_ms = int(start.timestamp() * 1000)
     end_ms = int(end.timestamp() * 1000)
     items = []
-    day = start.date()
-    while day <= end.date():
+    first_day = start.date()
+    day = end.date()
+    truncated = False
+    while day >= first_day and len(items) < ANALYTICS_LIVE_MAX_EVENTS:
         day_start = datetime.combine(day, datetime.min.time(), timezone.utc)
         next_day = day_start + timedelta(days=1)
         lower_ms = max(start_ms, int(day_start.timestamp() * 1000))
@@ -3794,15 +3800,25 @@ def _analytics_live_query(start, end) -> list[dict]:
             ),
             # The real-time tool should observe a just-written beacon.
             "ConsistentRead": True,
+            "ScanIndexForward": False,
         }
         while True:
+            query_args["Limit"] = ANALYTICS_LIVE_MAX_EVENTS - len(items)
             response = table.query(**query_args)
             items.extend(response.get("Items", []))
             last_key = response.get("LastEvaluatedKey")
             if not last_key:
                 break
+            if len(items) >= ANALYTICS_LIVE_MAX_EVENTS:
+                truncated = True
+                break
             query_args["ExclusiveStartKey"] = last_key
-        day += timedelta(days=1)
+        if truncated:
+            break
+        day -= timedelta(days=1)
+        if len(items) >= ANALYTICS_LIVE_MAX_EVENTS and day >= first_day:
+            truncated = True
+            break
 
     normalized = [_analytics_normalize_dynamo(item) for item in items]
     # The SK range is authoritative; the second check protects against malformed
@@ -3812,12 +3828,16 @@ def _analytics_live_query(start, end) -> list[dict]:
         for item in normalized
         if start_ms <= _analytics_live_epoch_ms(item) <= end_ms
     ]
-    return sorted(
-        normalized,
-        key=lambda item: (
-            _analytics_live_epoch_ms(item),
-            str(item.get("sk") or ""),
+    return (
+        sorted(
+            normalized,
+            key=lambda item: (
+                _analytics_live_epoch_ms(item),
+                str(item.get("sk") or ""),
+            ),
+            reverse=True,
         ),
+        truncated,
     )
 
 
@@ -3981,16 +4001,20 @@ async def analytics_live_impl(minutes=60, humans_only=True) -> dict:
         effective_minutes = max(
             1, min(int(minutes), ANALYTICS_LIVE_MAX_MINUTES)
         )
-        events = _analytics_live_query(start, end)
+        events, truncated = _analytics_live_query(start, end)
         if humans_only:
             events = [event for event in events if _analytics_live_is_human(event)]
         sessions = _analytics_live_rollup(events)
+        if len(sessions) > ANALYTICS_LIVE_MAX_SESSIONS:
+            truncated = True
+        sessions = sessions[:ANALYTICS_LIVE_MAX_SESSIONS]
         return {
             "since": _analytics_live_iso(start),
             "as_of": _analytics_live_iso(end),
             "minutes": effective_minutes,
             "timezone": "UTC",
             "humans_only": bool(humans_only),
+            "truncated": truncated,
             "event_count": len(events),
             "session_count": len(sessions),
             "sessions": sessions,
@@ -4015,7 +4039,7 @@ async def analytics_attribution_impl(
             minutes=24 * 60,
             since=since or None,
         )
-        events = _analytics_live_query(start, end)
+        events, truncated = _analytics_live_query(start, end)
         if humans_only:
             events = [event for event in events if _analytics_live_is_human(event)]
         attributed_sids = {
@@ -4030,6 +4054,9 @@ async def analytics_attribution_impl(
                 for session in sessions
                 if session["sid"] in attributed_sids
             ]
+        if len(sessions) > ANALYTICS_LIVE_MAX_SESSIONS:
+            truncated = True
+        sessions = sessions[:ANALYTICS_LIVE_MAX_SESSIONS]
         attributed_event_count = sum(
             session["beacons"] for session in sessions
         )
@@ -4039,6 +4066,7 @@ async def analytics_attribution_impl(
             "as_of": _analytics_live_iso(end),
             "timezone": "UTC",
             "humans_only": bool(humans_only),
+            "truncated": truncated,
             "event_count": attributed_event_count,
             "session_count": len(sessions),
             "sessions": sessions,

--- a/infra/mcp_server_lambda/lambdas/receipt_mcp_server_server.py
+++ b/infra/mcp_server_lambda/lambdas/receipt_mcp_server_server.py
@@ -945,10 +945,12 @@ the newest 5,000 events and 250 sessions; `truncated` reports omitted data.""",
             description="""Real-time campaign and outreach attribution.
 
 Filter live beacon events by exact `utm_campaign`, an ISO-8601 UTC `since`
-timestamp, or both. Campaign-only queries default to the last 24 hours. Returns
-session pages/events, first/last seen, edge geo, referrer, and UTM fields. At
-least one of `campaign` or `since` is required. Results contain at most the
-newest 5,000 events and 250 sessions; `truncated` reports omitted data.""",
+timestamp, or both. Campaign-only queries default to the last 24 hours. A
+campaign result starts at its tagged landing event and continues until another
+tagged campaign begins. Returns pages/events, edge geo, referrer, and UTM
+fields. At least one of `campaign` or `since` is required. Results contain at
+most the newest 5,000 events and 250 sessions; `truncated` reports omitted
+data.""",
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -3770,6 +3772,22 @@ def _analytics_live_epoch_ms(item: dict) -> int:
         return 0
 
 
+def _analytics_live_dedupe(events: list[dict]) -> list[dict]:
+    """Match the durable transform by retaining the earliest row per eid."""
+    seen_eids = set()
+    deduped = []
+    # _analytics_live_query supplies newest-first rows, while the durable
+    # transform's row_number() uses ORDER BY time (ascending).
+    for event in reversed(events):
+        eid = str(event.get("eid") or "").strip()
+        if eid:
+            if eid in seen_eids:
+                continue
+            seen_eids.add(eid)
+        deduped.append(event)
+    return list(reversed(deduped))
+
+
 def _analytics_live_query(start, end) -> tuple[list[dict], bool]:
     """Return the newest bounded event suffix and whether data was unread."""
     from datetime import datetime, timedelta, timezone
@@ -3828,17 +3846,15 @@ def _analytics_live_query(start, end) -> tuple[list[dict], bool]:
         for item in normalized
         if start_ms <= _analytics_live_epoch_ms(item) <= end_ms
     ]
-    return (
-        sorted(
-            normalized,
-            key=lambda item: (
-                _analytics_live_epoch_ms(item),
-                str(item.get("sk") or ""),
-            ),
-            reverse=True,
+    ordered = sorted(
+        normalized,
+        key=lambda item: (
+            _analytics_live_epoch_ms(item),
+            str(item.get("sk") or ""),
         ),
-        truncated,
+        reverse=True,
     )
+    return _analytics_live_dedupe(ordered), truncated
 
 
 def _analytics_live_flag(item: dict, key: str) -> bool:
@@ -3855,6 +3871,39 @@ def _analytics_live_is_human(item: dict) -> bool:
         _analytics_live_flag(item, key)
         for key in ("is_bot", "is_warp", "is_hosting")
     )
+
+
+def _analytics_live_campaign_events(
+    events: list[dict], campaign: str
+) -> list[dict]:
+    """Return separately marked spans while the campaign is active."""
+    grouped = defaultdict(list)
+    for event in events:
+        sid = str(event.get("sid") or "").strip()
+        if sid:
+            grouped[sid].append(event)
+
+    attributed = []
+    for session_events in grouped.values():
+        session_events.sort(
+            key=lambda event: (
+                _analytics_live_epoch_ms(event),
+                str(event.get("sk") or ""),
+            )
+        )
+        active_campaign = None
+        campaign_segment = 0
+        for event in session_events:
+            tagged_campaign = str(event.get("utm_campaign") or "").strip()
+            if tagged_campaign and tagged_campaign != active_campaign:
+                active_campaign = tagged_campaign
+                if active_campaign == campaign:
+                    campaign_segment += 1
+            if active_campaign == campaign:
+                attributed_event = dict(event)
+                attributed_event["_campaign_segment"] = campaign_segment
+                attributed.append(attributed_event)
+    return attributed
 
 
 def _analytics_live_first(events: list[dict], key: str):
@@ -3917,10 +3966,10 @@ def _analytics_live_rollup(events: list[dict]) -> list[dict]:
     for event in events:
         sid = str(event.get("sid") or "").strip()
         if sid:
-            grouped[sid].append(event)
+            grouped[(sid, event.get("_campaign_segment"))].append(event)
 
     sessions = []
-    for sid, session_events in grouped.items():
+    for (sid, campaign_segment), session_events in grouped.items():
         session_events.sort(
             key=lambda event: (
                 _analytics_live_epoch_ms(event),
@@ -3984,6 +4033,8 @@ def _analytics_live_rollup(events: list[dict]) -> list[dict]:
             ],
             "_last_epoch": last_epoch,
         }
+        if campaign_segment is not None:
+            session["campaign_segment"] = campaign_segment
         sessions.append(session)
 
     sessions.sort(
@@ -4042,18 +4093,9 @@ async def analytics_attribution_impl(
         events, truncated = _analytics_live_query(start, end)
         if humans_only:
             events = [event for event in events if _analytics_live_is_human(event)]
-        attributed_sids = {
-            str(event.get("sid") or "")
-            for event in events
-            if str(event.get("utm_campaign") or "") == campaign
-        }
-        sessions = _analytics_live_rollup(events)
         if campaign:
-            sessions = [
-                session
-                for session in sessions
-                if session["sid"] in attributed_sids
-            ]
+            events = _analytics_live_campaign_events(events, campaign)
+        sessions = _analytics_live_rollup(events)
         if len(sessions) > ANALYTICS_LIVE_MAX_SESSIONS:
             truncated = True
         sessions = sessions[:ANALYTICS_LIVE_MAX_SESSIONS]

--- a/infra/pyproject.toml
+++ b/infra/pyproject.toml
@@ -7,8 +7,8 @@ name = "portfolio-infra"
 version = "0.1.0"
 requires-python = ">=3.12"
 dependencies = [
-    "pulumi>=3.251.0,<4.0.0",
-    "pulumi-aws>=7.35.0,<8.0.0",
+    "pulumi==3.251.0",
+    "pulumi-aws==7.36.0",
     "pulumi-command>=1.2.1,<2.0.0",  # Updated to allow 1.x versions
     "pulumi-docker-build>=0.0.12",  # Used for Docker image building
     # Lambda Layer Version Update Tool dependencies

--- a/infra/s3_website.py
+++ b/infra/s3_website.py
@@ -178,6 +178,15 @@ cloudfront_logs_lifecycle = aws.s3.BucketLifecycleConfiguration(
     ],
 )
 
+# The live collector must exist before the distribution is declared so its
+# Function URL can be wired as a custom origin. Fixed analytics names are kept
+# production-only, matching the durable WebAnalytics component.
+live_web_analytics = None
+if stack == "prod":
+    from components.web_analytics import LiveWebAnalytics
+
+    live_web_analytics = LiveWebAnalytics("web-analytics-live")
+
 ########################
 # 6) CloudFront Function (Enhanced for Performance)
 ########################
@@ -324,19 +333,82 @@ cors_response_headers_policy = aws.cloudfront.ResponseHeadersPolicy(
     },
 )
 
-cdn = aws.cloudfront.Distribution(
-    "cdn",
-    origins=[
+cdn_origins = [
+    {
+        # Use S3 REST API endpoint instead of website hosting for better AVIF support
+        "domainName": site_bucket.bucket_domain_name,
+        "originId": site_bucket.id,
+        "originAccessControlId": origin_access_control.id,
+        "s3OriginConfig": {
+            "originAccessIdentity": "",  # Required but empty when using OAC
+        },
+    }
+]
+live_cache_behaviors = []
+origin_groups = []
+if live_web_analytics is not None:
+    live_origin_id = "web-analytics-live-collector"
+    live_origin_group_id = "web-analytics-live-failover"
+    cdn_origins.append(
         {
-            # Use S3 REST API endpoint instead of website hosting for better AVIF support
-            "domainName": site_bucket.bucket_domain_name,
-            "originId": site_bucket.id,
-            "originAccessControlId": origin_access_control.id,
-            "s3OriginConfig": {
-                "originAccessIdentity": "",  # Required but empty when using OAC
+            "domainName": live_web_analytics.function_url_domain,
+            "originId": live_origin_id,
+            "connectionAttempts": 1,
+            "connectionTimeout": 2,
+            "originAccessControlId": (
+                live_web_analytics.origin_access_control_id
+            ),
+            "customOriginConfig": {
+                "httpPort": 80,
+                "httpsPort": 443,
+                "originProtocolPolicy": "https-only",
+                "originSslProtocols": ["TLSv1.2"],
+                "originReadTimeout": 6,
             },
         }
-    ],
+    )
+    origin_groups.append(
+        {
+            "originId": live_origin_group_id,
+            "failoverCriteria": {
+                "statusCodes": [
+                    400,
+                    403,
+                    404,
+                    429,
+                    500,
+                    502,
+                    503,
+                    504,
+                ]
+            },
+            "members": [
+                {"originId": live_origin_id},
+                {"originId": site_bucket.id},
+            ],
+        }
+    )
+    live_cache_behaviors.append(
+        {
+            "pathPattern": "/analytics/pixel.txt",
+            "targetOriginId": live_origin_group_id,
+            "viewerProtocolPolicy": "redirect-to-https",
+            "allowedMethods": ["GET", "HEAD"],
+            "cachedMethods": ["GET", "HEAD"],
+            # AWS-managed CachingDisabled policy. Query strings are forwarded
+            # separately by the narrow origin policy and are never cached.
+            "cachePolicyId": "4135ea2d-6df8-44a3-9df3-4b5a84be39ad",
+            "originRequestPolicyId": (
+                live_web_analytics.origin_request_policy_id
+            ),
+            "compress": False,
+        }
+    )
+
+cdn = aws.cloudfront.Distribution(
+    "cdn",
+    origins=cdn_origins,
+    origin_groups=origin_groups,
     enabled=True,
     default_root_object="index.html",
     logging_config=aws.cloudfront.DistributionLoggingConfigArgs(
@@ -348,6 +420,7 @@ cdn = aws.cloudfront.Distribution(
     http_version="http2and3",
     # Optimized cache behaviors for different content types
     ordered_cache_behaviors=[
+        *live_cache_behaviors,
         {
             # Cache behavior for receipt images (AVIF, WebP, JPEG) - With CORS support
             "pathPattern": "/assets/*",
@@ -479,6 +552,34 @@ cdn = aws.cloudfront.Distribution(
 
 pulumi.export("cdn_distribution_id", cdn.id)
 
+if live_web_analytics is not None:
+    # New Function URLs (October 2025 onward) require both resource-policy
+    # actions. Scope both to this distribution and URL-only invocation.
+    aws.lambda_.Permission(
+        "web-analytics-live-cloudfront-url-permission",
+        action="lambda:InvokeFunctionUrl",
+        function=live_web_analytics.collector_lambda.name,
+        principal="cloudfront.amazonaws.com",
+        source_arn=cdn.arn,
+        function_url_auth_type="AWS_IAM",
+        opts=pulumi.ResourceOptions(
+            parent=live_web_analytics.collector_lambda,
+            depends_on=[cdn],
+        ),
+    )
+    aws.lambda_.Permission(
+        "web-analytics-live-cloudfront-invoke-permission",
+        action="lambda:InvokeFunction",
+        function=live_web_analytics.collector_lambda.name,
+        principal="cloudfront.amazonaws.com",
+        source_arn=cdn.arn,
+        invoked_via_function_url=True,
+        opts=pulumi.ResourceOptions(
+            parent=live_web_analytics.collector_lambda,
+            depends_on=[cdn],
+        ),
+    )
+
 # S3 bucket policy for Origin Access Control (now that CDN is defined)
 bucket_policy = aws.s3.BucketPolicy(
     "bucketPolicy",
@@ -536,6 +637,13 @@ for domain in site_domains:
 ########################
 pulumi.export("cdn_bucket_name", site_bucket.bucket)
 pulumi.export("cloudfront_logs_bucket_name", cloudfront_logs_bucket.bucket)
+if live_web_analytics is not None:
+    pulumi.export("web_events_live_table_name", live_web_analytics.table_name)
+    pulumi.export(
+        "web_analytics_collector_lambda_name",
+        live_web_analytics.collector_lambda.name,
+    )
+    pulumi.export("web_analytics_collector_path", "/analytics/pixel.txt")
 pulumi.export(
     "cloudfront_log_retention_days", cloudfront_log_retention_days
 )

--- a/portfolio/utils/analytics.test.ts
+++ b/portfolio/utils/analytics.test.ts
@@ -194,10 +194,16 @@ describe("analytics utilities", () => {
 
   test("CloudFront beacons capture UTM attribution and referrer", () => {
     const imageRequests = mockImageRequests();
-    const longReferrerPath = `/in/${"recruiter-portfolio-".repeat(10)}`;
+    const longReferrerPath = `/in/${"recruiter-portfolio-".repeat(40)}`;
+    const longUtmSource = `li-${"source".repeat(60)}`;
+    const longUtmMedium = `dm-${"medium".repeat(60)}`;
+    const longUtmCampaign = `arthur-${"babylist".repeat(50)}`;
     setViewport({
-      search:
-        "?utm_source=li&utm_medium=dm&utm_campaign=arthur-babylist",
+      search: `?${new URLSearchParams({
+        utm_source: longUtmSource,
+        utm_medium: longUtmMedium,
+        utm_campaign: longUtmCampaign,
+      }).toString()}`,
     });
     setDocumentReferrer(
       `https://www.linkedin.com${longReferrerPath}?token=private#message`
@@ -213,16 +219,23 @@ describe("analytics utilities", () => {
     expect(beaconUrl.pathname).toBe("/analytics/pixel.txt");
     expect(beaconUrl.searchParams.get("eid")).toBe("evt_event-id");
     expect(beaconUrl.searchParams.get("path")).toBe("/receipt");
-    expect(beaconUrl.searchParams.get("utm_source")).toBe("li");
-    expect(beaconUrl.searchParams.get("utm_medium")).toBe("dm");
+    expect(beaconUrl.searchParams.get("utm_source")).toBe(
+      longUtmSource.slice(0, 256)
+    );
+    expect(beaconUrl.searchParams.get("utm_medium")).toBe(
+      longUtmMedium.slice(0, 256)
+    );
     expect(beaconUrl.searchParams.get("utm_campaign")).toBe(
-      "arthur-babylist"
+      longUtmCampaign.slice(0, 256)
     );
     expect(beaconUrl.searchParams.get("ref")).toBe(
-      `https://www.linkedin.com${longReferrerPath}`
+      `https://www.linkedin.com${longReferrerPath}`.slice(0, 512)
     );
     expect(beaconUrl.searchParams.get("ref")).not.toContain("token");
-    expect(beaconUrl.searchParams.get("ref")?.length).toBeGreaterThan(120);
+    expect(beaconUrl.searchParams.get("utm_source")).toHaveLength(256);
+    expect(beaconUrl.searchParams.get("utm_medium")).toHaveLength(256);
+    expect(beaconUrl.searchParams.get("utm_campaign")).toHaveLength(256);
+    expect(beaconUrl.searchParams.get("ref")).toHaveLength(512);
     expect(window.fetch).toHaveBeenCalledTimes(1);
     expect(imageRequests).toHaveLength(0);
     expect(window.dataLayer?.[0]).not.toHaveProperty("utm_campaign");

--- a/portfolio/utils/analytics.test.ts
+++ b/portfolio/utils/analytics.test.ts
@@ -2,6 +2,17 @@ type AnalyticsModule = typeof import("./analytics");
 
 const originalEnv = process.env;
 const originalCrypto = window.crypto;
+const originalFetch = window.fetch;
+const originalImage = window.Image;
+const originalReferrerDescriptor = Object.getOwnPropertyDescriptor(
+  document,
+  "referrer"
+);
+
+type MockImageInstance = {
+  decoding: string;
+  src: string;
+};
 
 function loadAnalytics(env: Record<string, string | undefined> = {}) {
   jest.resetModules();
@@ -30,6 +41,54 @@ function mockCryptoIds(...ids: string[]): jest.Mock {
   });
 
   return randomUUID;
+}
+
+function setDocumentReferrer(value: string): void {
+  Object.defineProperty(document, "referrer", {
+    configurable: true,
+    value,
+  });
+}
+
+function mockImageRequests(): MockImageInstance[] {
+  const instances: MockImageInstance[] = [];
+
+  Object.defineProperty(window, "Image", {
+    configurable: true,
+    value: jest.fn(() => {
+      const image: MockImageInstance = {
+        decoding: "",
+        src: "",
+      };
+      instances.push(image);
+      return image;
+    }),
+  });
+
+  return instances;
+}
+
+async function flushBeaconPromises(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+function expectCollectorAndMirrorIds(
+  collectorUrl: URL,
+  mirrorUrl: URL
+): void {
+  expect(collectorUrl.pathname).toBe("/analytics/collect");
+  expect(collectorUrl.searchParams.get("live_eid")).toBe("evt_event-id");
+  expect(collectorUrl.searchParams.has("eid")).toBe(false);
+  expect(mirrorUrl.pathname).toBe("/analytics/pixel.txt");
+  expect(mirrorUrl.searchParams.get("eid")).toBe("evt_event-id");
+  expect(mirrorUrl.searchParams.has("live_eid")).toBe(false);
+
+  const collectorParams = new URLSearchParams(collectorUrl.search);
+  const mirrorParams = new URLSearchParams(mirrorUrl.search);
+  collectorParams.delete("live_eid");
+  mirrorParams.delete("eid");
+  expect(collectorParams.toString()).toBe(mirrorParams.toString());
 }
 
 function setViewport({
@@ -71,6 +130,7 @@ describe("analytics utilities", () => {
     window.dataLayer = [];
     window.gtag = jest.fn();
     window.fetch = jest.fn().mockResolvedValue({ ok: true }) as jest.Mock;
+    setDocumentReferrer("");
     jest.spyOn(Date, "now").mockReturnValue(1781889000000);
     mockCryptoIds("session-id", "event-id", "second-event-id");
     setViewport();
@@ -84,6 +144,25 @@ describe("analytics utilities", () => {
       configurable: true,
       value: originalCrypto,
     });
+    Object.defineProperty(window, "fetch", {
+      configurable: true,
+      value: originalFetch,
+      writable: true,
+    });
+    Object.defineProperty(window, "Image", {
+      configurable: true,
+      value: originalImage,
+      writable: true,
+    });
+    if (originalReferrerDescriptor) {
+      Object.defineProperty(
+        document,
+        "referrer",
+        originalReferrerDescriptor
+      );
+    } else {
+      delete (document as unknown as { referrer?: string }).referrer;
+    }
     delete window.gtag;
     delete window.dataLayer;
   });
@@ -127,10 +206,50 @@ describe("analytics utilities", () => {
     expect(beaconUrl.searchParams.get("event")).toBe("reader_summary");
     expect(beaconUrl.searchParams.get("sid")).toBe("ses_session-id");
     expect(beaconUrl.searchParams.get("eid")).toBe("evt_event-id");
+    expect(beaconUrl.searchParams.has("live_eid")).toBe(false);
     expect(beaconUrl.searchParams.get("page_path")).toBe("/receipt");
     expect(beaconUrl.searchParams.get("quick_jump")).toBe("false");
     expect(beaconUrl.searchParams.has("metric_value")).toBe(false);
     expect(beaconUrl.searchParams.has("omitted")).toBe(false);
+    expect(beaconUrl.searchParams.has("utm_source")).toBe(false);
+    expect(beaconUrl.searchParams.has("utm_medium")).toBe(false);
+    expect(beaconUrl.searchParams.has("utm_campaign")).toBe(false);
+    expect(beaconUrl.searchParams.has("ref")).toBe(false);
+  });
+
+  test("CloudFront beacons capture UTM attribution and referrer", () => {
+    const imageRequests = mockImageRequests();
+    setViewport({
+      search:
+        "?utm_source=li&utm_medium=dm&utm_campaign=arthur-babylist",
+    });
+    setDocumentReferrer("https://www.linkedin.com/in/recruiter");
+    const analytics = loadAnalytics({
+      NEXT_PUBLIC_CLOUDFRONT_ANALYTICS_BEACON_PATH:
+        "/analytics/collect",
+    });
+
+    analytics.trackEvent("scroll_depth", {
+      page_path: "/receipt",
+      percent_scrolled: 25,
+    });
+
+    const beaconUrl = new URL((window.fetch as jest.Mock).mock.calls[0][0]);
+    expect(beaconUrl.pathname).toBe("/analytics/collect");
+    expect(beaconUrl.searchParams.get("path")).toBe("/receipt");
+    expect(beaconUrl.searchParams.get("utm_source")).toBe("li");
+    expect(beaconUrl.searchParams.get("utm_medium")).toBe("dm");
+    expect(beaconUrl.searchParams.get("utm_campaign")).toBe(
+      "arthur-babylist"
+    );
+    expect(beaconUrl.searchParams.get("ref")).toBe(
+      "https://www.linkedin.com/in/recruiter"
+    );
+    expect(imageRequests).toHaveLength(1);
+    const mirrorUrl = new URL(imageRequests[0].src);
+    expectCollectorAndMirrorIds(beaconUrl, mirrorUrl);
+    expect(window.dataLayer?.[0]).not.toHaveProperty("utm_campaign");
+    expect(window.dataLayer?.[0]).not.toHaveProperty("ref");
   });
 
   test("trackPageView increments the anonymous session page count", () => {
@@ -253,5 +372,102 @@ describe("analytics utilities", () => {
     expect(beaconUrl.origin).toBe(window.location.origin);
     expect(beaconUrl.pathname).toBe("/custom/pixel.txt");
     expect(beaconUrl.searchParams.get("source")).toBe("analytics");
+  });
+
+  test("collector network failures do not duplicate the static mirror", async () => {
+    const imageRequests = mockImageRequests();
+    (window.fetch as jest.Mock).mockRejectedValueOnce(
+      new TypeError("collector unavailable")
+    );
+    setViewport({
+      search:
+        "?utm_source=li&utm_medium=dm&utm_campaign=arthur-babylist",
+    });
+    setDocumentReferrer("https://www.linkedin.com/");
+    const analytics = loadAnalytics({
+      NEXT_PUBLIC_CLOUDFRONT_ANALYTICS_BEACON_PATH:
+        "/analytics/collect",
+    });
+
+    analytics.trackEvent("page_view", { page_path: "/receipt" });
+    await flushBeaconPromises();
+
+    expect(imageRequests).toHaveLength(1);
+    const collectorUrl = new URL(
+      (window.fetch as jest.Mock).mock.calls[0][0]
+    );
+    const mirrorUrl = new URL(imageRequests[0].src);
+    expectCollectorAndMirrorIds(collectorUrl, mirrorUrl);
+    expect(mirrorUrl.searchParams.get("event")).toBe("page_view");
+    expect(mirrorUrl.searchParams.get("sid")).toBe("ses_session-id");
+    expect(mirrorUrl.searchParams.get("eid")).toBe("evt_event-id");
+    expect(mirrorUrl.searchParams.get("utm_campaign")).toBe(
+      "arthur-babylist"
+    );
+    expect(mirrorUrl.searchParams.get("ref")).toBe(
+      "https://www.linkedin.com/"
+    );
+  });
+
+  test("non-ok collector responses keep exactly one static mirror", async () => {
+    const imageRequests = mockImageRequests();
+    (window.fetch as jest.Mock).mockResolvedValueOnce({ ok: false });
+    const analytics = loadAnalytics({
+      NEXT_PUBLIC_CLOUDFRONT_ANALYTICS_BEACON_PATH:
+        "/analytics/collect",
+    });
+
+    analytics.trackEvent("page_view", { page_path: "/receipt" });
+    await flushBeaconPromises();
+
+    expect(imageRequests).toHaveLength(1);
+    expectCollectorAndMirrorIds(
+      new URL((window.fetch as jest.Mock).mock.calls[0][0]),
+      new URL(imageRequests[0].src)
+    );
+  });
+
+  test("successful collector responses still preserve the static mirror", async () => {
+    const imageRequests = mockImageRequests();
+    const analytics = loadAnalytics({
+      NEXT_PUBLIC_CLOUDFRONT_ANALYTICS_BEACON_PATH:
+        "/analytics/collect",
+    });
+
+    analytics.trackEvent("page_view", { page_path: "/receipt" });
+    await flushBeaconPromises();
+
+    expect(imageRequests).toHaveLength(1);
+    expectCollectorAndMirrorIds(
+      new URL((window.fetch as jest.Mock).mock.calls[0][0]),
+      new URL(imageRequests[0].src)
+    );
+  });
+
+  test("image transport sends the collector and one static mirror", () => {
+    const imageRequests = mockImageRequests();
+    Object.defineProperty(window, "fetch", {
+      configurable: true,
+      value: undefined,
+      writable: true,
+    });
+    const analytics = loadAnalytics({
+      NEXT_PUBLIC_CLOUDFRONT_ANALYTICS_BEACON_PATH:
+        "/analytics/collect",
+    });
+
+    analytics.trackEvent("page_view", { page_path: "/receipt" });
+
+    expect(imageRequests).toHaveLength(2);
+    const requestUrls = imageRequests.map(({ src }) => new URL(src));
+    const collectorUrl = requestUrls.find(
+      ({ pathname }) => pathname === "/analytics/collect"
+    );
+    const mirrorUrl = requestUrls.find(
+      ({ pathname }) => pathname === "/analytics/pixel.txt"
+    );
+    expect(collectorUrl).toBeDefined();
+    expect(mirrorUrl).toBeDefined();
+    expectCollectorAndMirrorIds(collectorUrl!, mirrorUrl!);
   });
 });

--- a/portfolio/utils/analytics.test.ts
+++ b/portfolio/utils/analytics.test.ts
@@ -78,15 +78,16 @@ function expectCollectorAndMirrorIds(
   mirrorUrl: URL
 ): void {
   expect(collectorUrl.pathname).toBe("/analytics/collect");
-  expect(collectorUrl.searchParams.get("live_eid")).toBe("evt_event-id");
+  expect(collectorUrl.searchParams.get("live_id")).toBe("evt_event-id");
   expect(collectorUrl.searchParams.has("eid")).toBe(false);
+  expect(collectorUrl.search).not.toContain("eid=");
   expect(mirrorUrl.pathname).toBe("/analytics/pixel.txt");
   expect(mirrorUrl.searchParams.get("eid")).toBe("evt_event-id");
-  expect(mirrorUrl.searchParams.has("live_eid")).toBe(false);
+  expect(mirrorUrl.searchParams.has("live_id")).toBe(false);
 
   const collectorParams = new URLSearchParams(collectorUrl.search);
   const mirrorParams = new URLSearchParams(mirrorUrl.search);
-  collectorParams.delete("live_eid");
+  collectorParams.delete("live_id");
   mirrorParams.delete("eid");
   expect(collectorParams.toString()).toBe(mirrorParams.toString());
 }
@@ -206,7 +207,7 @@ describe("analytics utilities", () => {
     expect(beaconUrl.searchParams.get("event")).toBe("reader_summary");
     expect(beaconUrl.searchParams.get("sid")).toBe("ses_session-id");
     expect(beaconUrl.searchParams.get("eid")).toBe("evt_event-id");
-    expect(beaconUrl.searchParams.has("live_eid")).toBe(false);
+    expect(beaconUrl.searchParams.has("live_id")).toBe(false);
     expect(beaconUrl.searchParams.get("page_path")).toBe("/receipt");
     expect(beaconUrl.searchParams.get("quick_jump")).toBe("false");
     expect(beaconUrl.searchParams.has("metric_value")).toBe(false);

--- a/portfolio/utils/analytics.test.ts
+++ b/portfolio/utils/analytics.test.ts
@@ -194,11 +194,14 @@ describe("analytics utilities", () => {
 
   test("CloudFront beacons capture UTM attribution and referrer", () => {
     const imageRequests = mockImageRequests();
+    const longReferrerPath = `/in/${"recruiter-portfolio-".repeat(10)}`;
     setViewport({
       search:
         "?utm_source=li&utm_medium=dm&utm_campaign=arthur-babylist",
     });
-    setDocumentReferrer("https://www.linkedin.com/in/recruiter");
+    setDocumentReferrer(
+      `https://www.linkedin.com${longReferrerPath}?token=private#message`
+    );
     const analytics = loadAnalytics();
 
     analytics.trackEvent("scroll_depth", {
@@ -216,8 +219,10 @@ describe("analytics utilities", () => {
       "arthur-babylist"
     );
     expect(beaconUrl.searchParams.get("ref")).toBe(
-      "https://www.linkedin.com/in/recruiter"
+      `https://www.linkedin.com${longReferrerPath}`
     );
+    expect(beaconUrl.searchParams.get("ref")).not.toContain("token");
+    expect(beaconUrl.searchParams.get("ref")?.length).toBeGreaterThan(120);
     expect(window.fetch).toHaveBeenCalledTimes(1);
     expect(imageRequests).toHaveLength(0);
     expect(window.dataLayer?.[0]).not.toHaveProperty("utm_campaign");
@@ -357,7 +362,7 @@ describe("analytics utilities", () => {
       search:
         "?utm_source=li&utm_medium=dm&utm_campaign=arthur-babylist",
     });
-    setDocumentReferrer("https://www.linkedin.com/");
+    setDocumentReferrer("https://www.linkedin.com/?token=private");
     const analytics = loadAnalytics();
 
     analytics.trackEvent("page_view", { page_path: "/receipt" });

--- a/portfolio/utils/analytics.test.ts
+++ b/portfolio/utils/analytics.test.ts
@@ -2,7 +2,6 @@ type AnalyticsModule = typeof import("./analytics");
 
 const originalEnv = process.env;
 const originalCrypto = window.crypto;
-const originalFetch = window.fetch;
 const originalImage = window.Image;
 const originalReferrerDescriptor = Object.getOwnPropertyDescriptor(
   document,
@@ -73,25 +72,6 @@ async function flushBeaconPromises(): Promise<void> {
   await Promise.resolve();
 }
 
-function expectCollectorAndMirrorIds(
-  collectorUrl: URL,
-  mirrorUrl: URL
-): void {
-  expect(collectorUrl.pathname).toBe("/analytics/collect");
-  expect(collectorUrl.searchParams.get("live_id")).toBe("evt_event-id");
-  expect(collectorUrl.searchParams.has("eid")).toBe(false);
-  expect(collectorUrl.search).not.toContain("eid=");
-  expect(mirrorUrl.pathname).toBe("/analytics/pixel.txt");
-  expect(mirrorUrl.searchParams.get("eid")).toBe("evt_event-id");
-  expect(mirrorUrl.searchParams.has("live_id")).toBe(false);
-
-  const collectorParams = new URLSearchParams(collectorUrl.search);
-  const mirrorParams = new URLSearchParams(mirrorUrl.search);
-  collectorParams.delete("live_id");
-  mirrorParams.delete("eid");
-  expect(collectorParams.toString()).toBe(mirrorParams.toString());
-}
-
 function setViewport({
   path = "/receipt",
   search = "",
@@ -144,11 +124,6 @@ describe("analytics utilities", () => {
     Object.defineProperty(window, "crypto", {
       configurable: true,
       value: originalCrypto,
-    });
-    Object.defineProperty(window, "fetch", {
-      configurable: true,
-      value: originalFetch,
-      writable: true,
     });
     Object.defineProperty(window, "Image", {
       configurable: true,
@@ -207,7 +182,6 @@ describe("analytics utilities", () => {
     expect(beaconUrl.searchParams.get("event")).toBe("reader_summary");
     expect(beaconUrl.searchParams.get("sid")).toBe("ses_session-id");
     expect(beaconUrl.searchParams.get("eid")).toBe("evt_event-id");
-    expect(beaconUrl.searchParams.has("live_id")).toBe(false);
     expect(beaconUrl.searchParams.get("page_path")).toBe("/receipt");
     expect(beaconUrl.searchParams.get("quick_jump")).toBe("false");
     expect(beaconUrl.searchParams.has("metric_value")).toBe(false);
@@ -225,10 +199,7 @@ describe("analytics utilities", () => {
         "?utm_source=li&utm_medium=dm&utm_campaign=arthur-babylist",
     });
     setDocumentReferrer("https://www.linkedin.com/in/recruiter");
-    const analytics = loadAnalytics({
-      NEXT_PUBLIC_CLOUDFRONT_ANALYTICS_BEACON_PATH:
-        "/analytics/collect",
-    });
+    const analytics = loadAnalytics();
 
     analytics.trackEvent("scroll_depth", {
       page_path: "/receipt",
@@ -236,7 +207,8 @@ describe("analytics utilities", () => {
     });
 
     const beaconUrl = new URL((window.fetch as jest.Mock).mock.calls[0][0]);
-    expect(beaconUrl.pathname).toBe("/analytics/collect");
+    expect(beaconUrl.pathname).toBe("/analytics/pixel.txt");
+    expect(beaconUrl.searchParams.get("eid")).toBe("evt_event-id");
     expect(beaconUrl.searchParams.get("path")).toBe("/receipt");
     expect(beaconUrl.searchParams.get("utm_source")).toBe("li");
     expect(beaconUrl.searchParams.get("utm_medium")).toBe("dm");
@@ -246,9 +218,8 @@ describe("analytics utilities", () => {
     expect(beaconUrl.searchParams.get("ref")).toBe(
       "https://www.linkedin.com/in/recruiter"
     );
-    expect(imageRequests).toHaveLength(1);
-    const mirrorUrl = new URL(imageRequests[0].src);
-    expectCollectorAndMirrorIds(beaconUrl, mirrorUrl);
+    expect(window.fetch).toHaveBeenCalledTimes(1);
+    expect(imageRequests).toHaveLength(0);
     expect(window.dataLayer?.[0]).not.toHaveProperty("utm_campaign");
     expect(window.dataLayer?.[0]).not.toHaveProperty("ref");
   });
@@ -373,9 +344,11 @@ describe("analytics utilities", () => {
     expect(beaconUrl.origin).toBe(window.location.origin);
     expect(beaconUrl.pathname).toBe("/custom/pixel.txt");
     expect(beaconUrl.searchParams.get("source")).toBe("analytics");
+    expect(beaconUrl.searchParams.get("eid")).toBe("evt_event-id");
+    expect(window.fetch).toHaveBeenCalledTimes(1);
   });
 
-  test("collector network failures do not duplicate the static mirror", async () => {
+  test("fetch failures retry the same beacon once via Image", async () => {
     const imageRequests = mockImageRequests();
     (window.fetch as jest.Mock).mockRejectedValueOnce(
       new TypeError("collector unavailable")
@@ -385,90 +358,27 @@ describe("analytics utilities", () => {
         "?utm_source=li&utm_medium=dm&utm_campaign=arthur-babylist",
     });
     setDocumentReferrer("https://www.linkedin.com/");
-    const analytics = loadAnalytics({
-      NEXT_PUBLIC_CLOUDFRONT_ANALYTICS_BEACON_PATH:
-        "/analytics/collect",
-    });
+    const analytics = loadAnalytics();
 
     analytics.trackEvent("page_view", { page_path: "/receipt" });
     await flushBeaconPromises();
 
+    expect(window.fetch).toHaveBeenCalledTimes(1);
     expect(imageRequests).toHaveLength(1);
-    const collectorUrl = new URL(
+    const fetchUrl = new URL(
       (window.fetch as jest.Mock).mock.calls[0][0]
     );
-    const mirrorUrl = new URL(imageRequests[0].src);
-    expectCollectorAndMirrorIds(collectorUrl, mirrorUrl);
-    expect(mirrorUrl.searchParams.get("event")).toBe("page_view");
-    expect(mirrorUrl.searchParams.get("sid")).toBe("ses_session-id");
-    expect(mirrorUrl.searchParams.get("eid")).toBe("evt_event-id");
-    expect(mirrorUrl.searchParams.get("utm_campaign")).toBe(
+    const imageUrl = new URL(imageRequests[0].src);
+    expect(fetchUrl.pathname).toBe("/analytics/pixel.txt");
+    expect(imageUrl.toString()).toBe(fetchUrl.toString());
+    expect(imageUrl.searchParams.get("event")).toBe("page_view");
+    expect(imageUrl.searchParams.get("sid")).toBe("ses_session-id");
+    expect(imageUrl.searchParams.get("eid")).toBe("evt_event-id");
+    expect(imageUrl.searchParams.get("utm_campaign")).toBe(
       "arthur-babylist"
     );
-    expect(mirrorUrl.searchParams.get("ref")).toBe(
+    expect(imageUrl.searchParams.get("ref")).toBe(
       "https://www.linkedin.com/"
     );
-  });
-
-  test("non-ok collector responses keep exactly one static mirror", async () => {
-    const imageRequests = mockImageRequests();
-    (window.fetch as jest.Mock).mockResolvedValueOnce({ ok: false });
-    const analytics = loadAnalytics({
-      NEXT_PUBLIC_CLOUDFRONT_ANALYTICS_BEACON_PATH:
-        "/analytics/collect",
-    });
-
-    analytics.trackEvent("page_view", { page_path: "/receipt" });
-    await flushBeaconPromises();
-
-    expect(imageRequests).toHaveLength(1);
-    expectCollectorAndMirrorIds(
-      new URL((window.fetch as jest.Mock).mock.calls[0][0]),
-      new URL(imageRequests[0].src)
-    );
-  });
-
-  test("successful collector responses still preserve the static mirror", async () => {
-    const imageRequests = mockImageRequests();
-    const analytics = loadAnalytics({
-      NEXT_PUBLIC_CLOUDFRONT_ANALYTICS_BEACON_PATH:
-        "/analytics/collect",
-    });
-
-    analytics.trackEvent("page_view", { page_path: "/receipt" });
-    await flushBeaconPromises();
-
-    expect(imageRequests).toHaveLength(1);
-    expectCollectorAndMirrorIds(
-      new URL((window.fetch as jest.Mock).mock.calls[0][0]),
-      new URL(imageRequests[0].src)
-    );
-  });
-
-  test("image transport sends the collector and one static mirror", () => {
-    const imageRequests = mockImageRequests();
-    Object.defineProperty(window, "fetch", {
-      configurable: true,
-      value: undefined,
-      writable: true,
-    });
-    const analytics = loadAnalytics({
-      NEXT_PUBLIC_CLOUDFRONT_ANALYTICS_BEACON_PATH:
-        "/analytics/collect",
-    });
-
-    analytics.trackEvent("page_view", { page_path: "/receipt" });
-
-    expect(imageRequests).toHaveLength(2);
-    const requestUrls = imageRequests.map(({ src }) => new URL(src));
-    const collectorUrl = requestUrls.find(
-      ({ pathname }) => pathname === "/analytics/collect"
-    );
-    const mirrorUrl = requestUrls.find(
-      ({ pathname }) => pathname === "/analytics/pixel.txt"
-    );
-    expect(collectorUrl).toBeDefined();
-    expect(mirrorUrl).toBeDefined();
-    expectCollectorAndMirrorIds(collectorUrl!, mirrorUrl!);
   });
 });

--- a/portfolio/utils/analytics.ts
+++ b/portfolio/utils/analytics.ts
@@ -232,34 +232,6 @@ function appendBeaconParam(
   url.searchParams.set(key, stringValue.slice(0, 120));
 }
 
-function getStaticBeaconMirrorUrl(url: URL): URL | null {
-  const mirrorUrl = new URL(
-    DEFAULT_CLOUDFRONT_ANALYTICS_BEACON_PATH,
-    window.location.origin
-  );
-
-  if (
-    mirrorUrl.origin === url.origin &&
-    mirrorUrl.pathname === url.pathname
-  ) {
-    return null;
-  }
-
-  mirrorUrl.search = url.search;
-  mirrorUrl.searchParams.delete("live_id");
-  return mirrorUrl;
-}
-
-function sendImageBeacon(url: URL): void {
-  try {
-    const image = new Image();
-    image.decoding = "async";
-    image.src = url.toString();
-  } catch {
-    // Analytics should never affect the page experience.
-  }
-}
-
 function sendCloudFrontBeacon(
   event: string,
   params: AnalyticsParams,
@@ -298,13 +270,6 @@ function sendCloudFrontBeacon(
       appendBeaconParam(url, key, beaconParams[key]);
     });
 
-    const mirrorUrl = getStaticBeaconMirrorUrl(url);
-    if (mirrorUrl) {
-      url.searchParams.delete("eid");
-      appendBeaconParam(url, "live_id", meta.eventId);
-      sendImageBeacon(mirrorUrl);
-    }
-
     if (typeof window.fetch === "function") {
       window
         .fetch(url.toString(), {
@@ -313,12 +278,16 @@ function sendCloudFrontBeacon(
           cache: "no-store",
         })
         .catch(() => {
-          // The static mirror already preserves the durable event.
+          const image = new Image();
+          image.decoding = "async";
+          image.src = url.toString();
         });
       return;
     }
 
-    sendImageBeacon(url);
+    const image = new Image();
+    image.decoding = "async";
+    image.src = url.toString();
   } catch {
     // Analytics should never affect the page experience.
   }

--- a/portfolio/utils/analytics.ts
+++ b/portfolio/utils/analytics.ts
@@ -46,6 +46,11 @@ export const CLOUDFRONT_ANALYTICS_BEACON_PATH = getCloudFrontBeaconPath(
 const SCROLL_THRESHOLDS = [25, 50, 75, 90];
 const ANALYTICS_SESSION_ID_KEY = "tnor.analyticsSessionId";
 const ANALYTICS_PAGE_VIEW_COUNT_KEY = "tnor.analyticsPageViews";
+const BEACON_UTM_PARAM_KEYS = [
+  "utm_source",
+  "utm_medium",
+  "utm_campaign",
+] as const;
 
 const CLOUDFRONT_BEACON_PARAM_KEYS = [
   "page_path",
@@ -61,6 +66,8 @@ const CLOUDFRONT_BEACON_PARAM_KEYS = [
   "baseline_sample_size",
   "session_page_views",
   "quick_jump",
+  ...BEACON_UTM_PARAM_KEYS,
+  "ref",
 ];
 
 export type AnalyticsParams = Record<
@@ -94,6 +101,25 @@ function getSessionStorage(): Storage | null {
   } catch {
     return null;
   }
+}
+
+function getBeaconAttributionParams(): AnalyticsParams {
+  const attribution: AnalyticsParams = {};
+  const searchParams = new URLSearchParams(window.location.search);
+
+  BEACON_UTM_PARAM_KEYS.forEach((key) => {
+    const value = searchParams.get(key);
+
+    if (value) {
+      attribution[key] = value;
+    }
+  });
+
+  if (document.referrer) {
+    attribution.ref = document.referrer;
+  }
+
+  return attribution;
 }
 
 function createAnalyticsId(prefix: string): string {
@@ -206,6 +232,34 @@ function appendBeaconParam(
   url.searchParams.set(key, stringValue.slice(0, 120));
 }
 
+function getStaticBeaconMirrorUrl(url: URL): URL | null {
+  const mirrorUrl = new URL(
+    DEFAULT_CLOUDFRONT_ANALYTICS_BEACON_PATH,
+    window.location.origin
+  );
+
+  if (
+    mirrorUrl.origin === url.origin &&
+    mirrorUrl.pathname === url.pathname
+  ) {
+    return null;
+  }
+
+  mirrorUrl.search = url.search;
+  mirrorUrl.searchParams.delete("live_eid");
+  return mirrorUrl;
+}
+
+function sendImageBeacon(url: URL): void {
+  try {
+    const image = new Image();
+    image.decoding = "async";
+    image.src = url.toString();
+  } catch {
+    // Analytics should never affect the page experience.
+  }
+}
+
 function sendCloudFrontBeacon(
   event: string,
   params: AnalyticsParams,
@@ -235,9 +289,21 @@ function sendCloudFrontBeacon(
     appendBeaconParam(url, "path", getBeaconPagePath());
     appendBeaconParam(url, "ts", Date.now());
 
+    const beaconParams = {
+      ...params,
+      ...getBeaconAttributionParams(),
+    };
+
     CLOUDFRONT_BEACON_PARAM_KEYS.forEach((key) => {
-      appendBeaconParam(url, key, params[key]);
+      appendBeaconParam(url, key, beaconParams[key]);
     });
+
+    const mirrorUrl = getStaticBeaconMirrorUrl(url);
+    if (mirrorUrl) {
+      url.searchParams.delete("eid");
+      appendBeaconParam(url, "live_eid", meta.eventId);
+      sendImageBeacon(mirrorUrl);
+    }
 
     if (typeof window.fetch === "function") {
       window
@@ -247,16 +313,12 @@ function sendCloudFrontBeacon(
           cache: "no-store",
         })
         .catch(() => {
-          const image = new Image();
-          image.decoding = "async";
-          image.src = url.toString();
+          // The static mirror already preserves the durable event.
         });
       return;
     }
 
-    const image = new Image();
-    image.decoding = "async";
-    image.src = url.toString();
+    sendImageBeacon(url);
   } catch {
     // Analytics should never affect the page experience.
   }

--- a/portfolio/utils/analytics.ts
+++ b/portfolio/utils/analytics.ts
@@ -246,7 +246,7 @@ function getStaticBeaconMirrorUrl(url: URL): URL | null {
   }
 
   mirrorUrl.search = url.search;
-  mirrorUrl.searchParams.delete("live_eid");
+  mirrorUrl.searchParams.delete("live_id");
   return mirrorUrl;
 }
 
@@ -301,7 +301,7 @@ function sendCloudFrontBeacon(
     const mirrorUrl = getStaticBeaconMirrorUrl(url);
     if (mirrorUrl) {
       url.searchParams.delete("eid");
-      appendBeaconParam(url, "live_eid", meta.eventId);
+      appendBeaconParam(url, "live_id", meta.eventId);
       sendImageBeacon(mirrorUrl);
     }
 

--- a/portfolio/utils/analytics.ts
+++ b/portfolio/utils/analytics.ts
@@ -51,6 +51,13 @@ const BEACON_UTM_PARAM_KEYS = [
   "utm_medium",
   "utm_campaign",
 ] as const;
+const DEFAULT_BEACON_PARAM_LIMIT = 120;
+const BEACON_PARAM_LIMITS: Record<string, number> = {
+  ref: 512,
+  utm_source: 256,
+  utm_medium: 256,
+  utm_campaign: 256,
+};
 
 const CLOUDFRONT_BEACON_PARAM_KEYS = [
   "page_path",
@@ -116,7 +123,18 @@ function getBeaconAttributionParams(): AnalyticsParams {
   });
 
   if (document.referrer) {
-    attribution.ref = document.referrer;
+    try {
+      const referrer = new URL(document.referrer);
+
+      if (referrer.protocol === "http:" || referrer.protocol === "https:") {
+        // Query strings can contain tokens or other private values. Campaign
+        // attribution has dedicated UTM fields, so retain only origin + path.
+        attribution.ref = `${referrer.origin}${referrer.pathname}`;
+      }
+    } catch {
+      // Browsers normally expose an absolute URL, but malformed values should
+      // never interfere with analytics or the page experience.
+    }
   }
 
   return attribution;
@@ -213,7 +231,8 @@ function pushDataLayerEvent(
 function appendBeaconParam(
   url: URL,
   key: string,
-  value: string | number | boolean | undefined
+  value: string | number | boolean | undefined,
+  maxLength = BEACON_PARAM_LIMITS[key] ?? DEFAULT_BEACON_PARAM_LIMIT
 ): void {
   if (value === undefined) {
     return;
@@ -229,7 +248,7 @@ function appendBeaconParam(
     return;
   }
 
-  url.searchParams.set(key, stringValue.slice(0, 120));
+  url.searchParams.set(key, stringValue.slice(0, maxLength));
 }
 
 function sendCloudFrontBeacon(

--- a/scripts/receipt_mcp_server.py
+++ b/scripts/receipt_mcp_server.py
@@ -931,10 +931,12 @@ the newest 5,000 events and 250 sessions; `truncated` reports omitted data.""",
             description="""Real-time campaign and outreach attribution.
 
 Filter live beacon events by exact `utm_campaign`, an ISO-8601 UTC `since`
-timestamp, or both. Campaign-only queries default to the last 24 hours. Returns
-session pages/events, first/last seen, edge geo, referrer, and UTM fields. At
-least one of `campaign` or `since` is required. Results contain at most the
-newest 5,000 events and 250 sessions; `truncated` reports omitted data.""",
+timestamp, or both. Campaign-only queries default to the last 24 hours. A
+campaign result starts at its tagged landing event and continues until another
+tagged campaign begins. Returns pages/events, edge geo, referrer, and UTM
+fields. At least one of `campaign` or `since` is required. Results contain at
+most the newest 5,000 events and 250 sessions; `truncated` reports omitted
+data.""",
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -3756,6 +3758,22 @@ def _analytics_live_epoch_ms(item: dict) -> int:
         return 0
 
 
+def _analytics_live_dedupe(events: list[dict]) -> list[dict]:
+    """Match the durable transform by retaining the earliest row per eid."""
+    seen_eids = set()
+    deduped = []
+    # _analytics_live_query supplies newest-first rows, while the durable
+    # transform's row_number() uses ORDER BY time (ascending).
+    for event in reversed(events):
+        eid = str(event.get("eid") or "").strip()
+        if eid:
+            if eid in seen_eids:
+                continue
+            seen_eids.add(eid)
+        deduped.append(event)
+    return list(reversed(deduped))
+
+
 def _analytics_live_query(start, end) -> tuple[list[dict], bool]:
     """Return the newest bounded event suffix and whether data was unread."""
     from datetime import datetime, timedelta, timezone
@@ -3814,17 +3832,15 @@ def _analytics_live_query(start, end) -> tuple[list[dict], bool]:
         for item in normalized
         if start_ms <= _analytics_live_epoch_ms(item) <= end_ms
     ]
-    return (
-        sorted(
-            normalized,
-            key=lambda item: (
-                _analytics_live_epoch_ms(item),
-                str(item.get("sk") or ""),
-            ),
-            reverse=True,
+    ordered = sorted(
+        normalized,
+        key=lambda item: (
+            _analytics_live_epoch_ms(item),
+            str(item.get("sk") or ""),
         ),
-        truncated,
+        reverse=True,
     )
+    return _analytics_live_dedupe(ordered), truncated
 
 
 def _analytics_live_flag(item: dict, key: str) -> bool:
@@ -3841,6 +3857,39 @@ def _analytics_live_is_human(item: dict) -> bool:
         _analytics_live_flag(item, key)
         for key in ("is_bot", "is_warp", "is_hosting")
     )
+
+
+def _analytics_live_campaign_events(
+    events: list[dict], campaign: str
+) -> list[dict]:
+    """Return separately marked spans while the campaign is active."""
+    grouped = defaultdict(list)
+    for event in events:
+        sid = str(event.get("sid") or "").strip()
+        if sid:
+            grouped[sid].append(event)
+
+    attributed = []
+    for session_events in grouped.values():
+        session_events.sort(
+            key=lambda event: (
+                _analytics_live_epoch_ms(event),
+                str(event.get("sk") or ""),
+            )
+        )
+        active_campaign = None
+        campaign_segment = 0
+        for event in session_events:
+            tagged_campaign = str(event.get("utm_campaign") or "").strip()
+            if tagged_campaign and tagged_campaign != active_campaign:
+                active_campaign = tagged_campaign
+                if active_campaign == campaign:
+                    campaign_segment += 1
+            if active_campaign == campaign:
+                attributed_event = dict(event)
+                attributed_event["_campaign_segment"] = campaign_segment
+                attributed.append(attributed_event)
+    return attributed
 
 
 def _analytics_live_first(events: list[dict], key: str):
@@ -3903,10 +3952,10 @@ def _analytics_live_rollup(events: list[dict]) -> list[dict]:
     for event in events:
         sid = str(event.get("sid") or "").strip()
         if sid:
-            grouped[sid].append(event)
+            grouped[(sid, event.get("_campaign_segment"))].append(event)
 
     sessions = []
-    for sid, session_events in grouped.items():
+    for (sid, campaign_segment), session_events in grouped.items():
         session_events.sort(
             key=lambda event: (
                 _analytics_live_epoch_ms(event),
@@ -3970,6 +4019,8 @@ def _analytics_live_rollup(events: list[dict]) -> list[dict]:
             ],
             "_last_epoch": last_epoch,
         }
+        if campaign_segment is not None:
+            session["campaign_segment"] = campaign_segment
         sessions.append(session)
 
     sessions.sort(
@@ -4028,18 +4079,9 @@ async def analytics_attribution_impl(
         events, truncated = _analytics_live_query(start, end)
         if humans_only:
             events = [event for event in events if _analytics_live_is_human(event)]
-        attributed_sids = {
-            str(event.get("sid") or "")
-            for event in events
-            if str(event.get("utm_campaign") or "") == campaign
-        }
-        sessions = _analytics_live_rollup(events)
         if campaign:
-            sessions = [
-                session
-                for session in sessions
-                if session["sid"] in attributed_sids
-            ]
+            events = _analytics_live_campaign_events(events, campaign)
+        sessions = _analytics_live_rollup(events)
         if len(sessions) > ANALYTICS_LIVE_MAX_SESSIONS:
             truncated = True
         sessions = sessions[:ANALYTICS_LIVE_MAX_SESSIONS]

--- a/scripts/receipt_mcp_server.py
+++ b/scripts/receipt_mcp_server.py
@@ -3756,7 +3756,7 @@ def _analytics_normalize_dynamo(value):
 
 
 def _analytics_live_iso(dt) -> str:
-    return dt.isoformat(timespec="milliseconds").replace("+00:00", "Z")
+    return dt.isoformat(timespec="milliseconds")
 
 
 def _analytics_live_parse_since(value: str):

--- a/scripts/receipt_mcp_server.py
+++ b/scripts/receipt_mcp_server.py
@@ -900,6 +900,53 @@ using get_receipt or get_receipt_image_url.""",
             },
         ),
         Tool(
+            name="analytics_auto",
+            description="""Unified production visitor analytics across live and durable data.
+
+Use this as the default tool when a question may span current and historical
+traffic. It routes the older range to Athena and queries DynamoDB across a
+four-day repair/tail overlap, then normalizes, merges, and de-duplicates events
+by `eid`. Optional exact `campaign` filtering preserves campaign segments
+across the source boundary. Returns source/freshness metadata, errors,
+queried/unqueried ranges, and at most 250 newest sessions without changing
+existing analytics tools.""",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "minutes": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 525600,
+                        "description": "Lookback ending at until; default 60, or 1440 for campaign-only",
+                    },
+                    "since": {
+                        "type": "string",
+                        "description": "Optional ISO-8601 UTC start (max 365-day interval)",
+                    },
+                    "until": {
+                        "type": "string",
+                        "description": "Optional ISO-8601 UTC exclusive end (default now)",
+                    },
+                    "campaign": {
+                        "type": "string",
+                        "description": "Optional exact utm_campaign value",
+                    },
+                    "humans_only": {
+                        "type": "boolean",
+                        "default": True,
+                        "description": "Exclude bots, WARP, and hosting traffic",
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "default": 250,
+                        "minimum": 1,
+                        "maximum": 250,
+                        "description": "Maximum newest sessions returned",
+                    },
+                },
+            },
+        ),
+        Tool(
             name="analytics_live",
             description="""Recent production web visits from the real-time beacon collector.
 
@@ -907,7 +954,8 @@ Reads DynamoDB directly and rolls beacon events into sessions with pages,
 event details, edge geo, referrer, and UTM attribution. By default excludes
 bots, Cloudflare WARP traffic, and datacenter-hosting traffic. `minutes` is
 clamped to the live table's 90-day retention window. Results contain at most
-the newest 5,000 events and 250 sessions; `truncated` reports omitted data.""",
+the newest 5,000 events and 250 sessions; `truncated` reports omitted data.
+Prefer `analytics_auto` unless a Dynamo-only diagnostic is explicitly needed.""",
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -936,7 +984,7 @@ campaign result starts at its tagged landing event and continues until another
 tagged campaign begins. Returns pages/events, edge geo, referrer, and UTM
 fields. At least one of `campaign` or `since` is required. Results contain at
 most the newest 5,000 events and 250 sessions; `truncated` reports omitted
-data.""",
+data. Prefer `analytics_auto` when attribution may include durable history.""",
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -1552,6 +1600,15 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent]:
             )
         elif name == "get_label_distribution":
             result = await get_label_distribution_impl(dynamo_client)
+        elif name == "analytics_auto":
+            result = await analytics_auto_impl(
+                minutes=arguments.get("minutes"),
+                since=arguments.get("since"),
+                until=arguments.get("until"),
+                campaign=arguments.get("campaign"),
+                humans_only=arguments.get("humans_only", True),
+                limit=arguments.get("limit", 250),
+            )
         elif name == "analytics_live":
             result = await analytics_live_impl(
                 minutes=arguments.get("minutes", 60),
@@ -3669,6 +3726,10 @@ ANALYTICS_LIVE_TABLE = os.environ.get(
 ANALYTICS_LIVE_MAX_MINUTES = 90 * 24 * 60
 ANALYTICS_LIVE_MAX_EVENTS = 5000
 ANALYTICS_LIVE_MAX_SESSIONS = 250
+ANALYTICS_AUTO_MAX_MINUTES = 365 * 24 * 60
+ANALYTICS_AUTO_REPAIR_OVERLAP_DAYS = 4
+ANALYTICS_WATERMARK_CACHE_SECONDS = 300
+_analytics_watermark_cache = {"checked_at": 0.0, "value": None}
 
 
 def _analytics_normalize_dynamo(value):
@@ -3939,6 +4000,7 @@ def _analytics_live_event_summary(item: dict) -> dict:
         "eid": item.get("eid"),
         "event": item.get("event"),
         "path": item.get("path") or item.get("page_path"),
+        "source": item.get("_source"),
     }
     for key in _ANALYTICS_LIVE_EVENT_METRICS:
         value = item.get(key)
@@ -4021,6 +4083,19 @@ def _analytics_live_rollup(events: list[dict]) -> list[dict]:
         }
         if campaign_segment is not None:
             session["campaign_segment"] = campaign_segment
+        org = _analytics_live_first(session_events, "org")
+        if org:
+            session["org"] = org
+        source_set = set()
+        for event in session_events:
+            event_sources = event.get("_sources") or []
+            if event_sources:
+                source_set.update(str(source) for source in event_sources)
+            elif event.get("_source"):
+                source_set.add(str(event["_source"]))
+        sources = sorted(source_set)
+        if sources:
+            session["sources"] = sources
         sessions.append(session)
 
     sessions.sort(
@@ -4162,6 +4237,495 @@ def _athena_run(sql: str, max_wait: int = 90, max_rows: int = 5000) -> list:
         if not token:
             break
     return rows
+
+
+def _analytics_auto_window(
+    minutes=None, since=None, until=None, campaign=None, now=None
+):
+    """Return a validated UTC [start, end) interval for routed analytics."""
+    from datetime import datetime, timedelta, timezone
+
+    current = now or datetime.now(timezone.utc)
+    if current.tzinfo is None:
+        current = current.replace(tzinfo=timezone.utc)
+    current = current.astimezone(timezone.utc)
+
+    end = (
+        _analytics_live_parse_since(str(until))
+        if until is not None and str(until).strip()
+        else current
+    )
+    if end > current:
+        raise ValueError("until cannot be in the future")
+
+    if since is not None and str(since).strip():
+        start = _analytics_live_parse_since(str(since))
+        effective_minutes = None
+    else:
+        default_minutes = 24 * 60 if str(campaign or "").strip() else 60
+        try:
+            effective_minutes = int(
+                default_minutes if minutes is None else minutes
+            )
+        except (TypeError, ValueError) as exc:
+            raise ValueError("minutes must be an integer") from exc
+        effective_minutes = max(
+            1, min(effective_minutes, ANALYTICS_AUTO_MAX_MINUTES)
+        )
+        start = end - timedelta(minutes=effective_minutes)
+
+    if start >= end:
+        raise ValueError("since must be earlier than until")
+    if end - start > timedelta(minutes=ANALYTICS_AUTO_MAX_MINUTES):
+        raise ValueError("analytics_auto interval cannot exceed 365 days")
+    return start, end, current, effective_minutes
+
+
+def _analytics_durable_param_sql(name: str) -> str:
+    """Extract one beacon parameter already retained in query_decoded."""
+    return (
+        "NULLIF(TRY(url_decode(regexp_extract(COALESCE(query_decoded, ''), "
+        f"'(?:^|&){name}=([^&]*)', 1))), '')"
+    )
+
+
+def _analytics_latest_durable_event(force=False):
+    """Return the newest materialized event timestamp, cached for warm calls."""
+    import time
+
+    checked_at = float(_analytics_watermark_cache.get("checked_at") or 0.0)
+    now_mono = time.monotonic()
+    if (
+        not force
+        and checked_at
+        and now_mono - checked_at < ANALYTICS_WATERMARK_CACHE_SECONDS
+    ):
+        return _analytics_watermark_cache.get("value")
+
+    import boto3
+
+    glue = boto3.client("glue", region_name=ANALYTICS_REGION)
+    partition_dates = []
+    paginator = glue.get_paginator("get_partitions")
+    for page in paginator.paginate(
+        DatabaseName=ANALYTICS_DB,
+        TableName="web_events",
+        ExcludeColumnSchema=True,
+    ):
+        for partition in page.get("Partitions", []):
+            values = partition.get("Values") or []
+            if values:
+                try:
+                    partition_dates.append(_analytics_check_date(values[0]))
+                except ValueError:
+                    continue
+
+    latest = None
+    if partition_dates:
+        repair_dates = sorted(set(partition_dates))[-4:]
+        dates_sql = ", ".join(f"'{dt}'" for dt in repair_dates)
+        rows = _athena_run(
+            f"""
+SELECT date_format(max(ts_utc), '%Y-%m-%dT%H:%i:%s.%fZ') AS latest
+FROM {ANALYTICS_DB}.web_events
+WHERE dt IN ({dates_sql})
+""",
+            max_rows=1,
+        )
+        raw = rows[0].get("latest") if rows else None
+        if raw:
+            latest = _analytics_live_parse_since(raw)
+
+    _analytics_watermark_cache["checked_at"] = now_mono
+    _analytics_watermark_cache["value"] = latest
+    return latest
+
+
+def _analytics_normalize_durable_event(row: dict) -> dict:
+    """Map an Athena web_events row to the live event contract."""
+    event = {
+        key: value
+        for key, value in row.items()
+        if value is not None and value != ""
+    }
+    try:
+        event["epoch_ms"] = int(event.get("epoch_ms", 0))
+    except (TypeError, ValueError):
+        event["epoch_ms"] = _analytics_live_epoch_ms(event)
+
+    sid = str(event.get("sid") or "")
+    eid = str(event.get("eid") or "")
+    request_id = str(event.get("request_id") or "")
+    event["sk"] = (
+        f"{event['epoch_ms']:013d}#{sid}#{eid or request_id}"
+    )
+    event["_source"] = "durable"
+    event["_sources"] = ["durable"]
+    return event
+
+
+def _analytics_durable_query(start, end) -> tuple[list[dict], bool]:
+    """Read normalized durable beacon events for UTC [start, end)."""
+    from datetime import timedelta
+
+    if start >= end:
+        return [], False
+
+    last_included = end - timedelta(microseconds=1)
+    start_dt = start.date().isoformat()
+    end_dt = last_included.date().isoformat()
+    start_sql = start.strftime("%Y-%m-%d %H:%M:%S.%f")
+    end_sql = end.strftime("%Y-%m-%d %H:%M:%S.%f")
+    param_fields = (
+        "ref",
+        "utm_source",
+        "utm_medium",
+        "utm_campaign",
+        *_ANALYTICS_LIVE_EVENT_METRICS,
+    )
+    param_select = ",\n  ".join(
+        f"{_analytics_durable_param_sql(name)} AS {name}"
+        for name in param_fields
+    )
+    row_limit = ANALYTICS_LIVE_MAX_EVENTS + 1
+    sql = f"""
+SELECT
+  dt,
+  request_id,
+  date_format(ts_utc, '%Y-%m-%dT%H:%i:%s.%fZ') AS ts,
+  CAST(to_unixtime(ts_utc) * 1000 AS bigint) AS epoch_ms,
+  sid,
+  eid,
+  event,
+  evt_path AS path,
+  {param_select},
+  request_ip AS ip,
+  user_agent AS ua,
+  country,
+  city,
+  org,
+  asn,
+  is_warp,
+  is_bot,
+  is_hosting
+FROM {ANALYTICS_DB}.web_events
+WHERE dt BETWEEN '{start_dt}' AND '{end_dt}'
+  AND is_beacon
+  AND ts_utc >= TIMESTAMP '{start_sql}'
+  AND ts_utc < TIMESTAMP '{end_sql}'
+ORDER BY ts_utc DESC, request_id DESC
+LIMIT {row_limit}
+"""
+    rows = _athena_run(sql, max_rows=row_limit)
+    truncated = len(rows) > ANALYTICS_LIVE_MAX_EVENTS
+    rows = rows[:ANALYTICS_LIVE_MAX_EVENTS]
+    return [_analytics_normalize_durable_event(row) for row in rows], truncated
+
+
+def _analytics_auto_merge_events(events: list[dict]):
+    """Deduplicate non-empty eids while retaining both sources' best fields."""
+    durable_authoritative = {
+        "dt",
+        "request_id",
+        "sid",
+        "eid",
+        "event",
+        "path",
+        "page_path",
+        "ip",
+        "ua",
+        "country",
+        "city",
+        "org",
+        "asn",
+        "is_warp",
+        "is_bot",
+        "is_hosting",
+    }
+    by_eid = {}
+    without_eid = []
+    deduplicated = 0
+
+    ordered = sorted(
+        events,
+        key=lambda event: (
+            _analytics_live_epoch_ms(event),
+            str(event.get("sk") or ""),
+        ),
+    )
+    for original in ordered:
+        event = dict(original)
+        source = str(event.get("_source") or "")
+        if source == "live":
+            event["_live_order"] = {
+                key: event.get(key)
+                for key in ("dt", "ts", "epoch_ms", "sk")
+            }
+        event["_sources"] = sorted(
+            set(event.get("_sources") or ([source] if source else []))
+        )
+        eid = str(event.get("eid") or "").strip()
+        if not eid:
+            without_eid.append(event)
+            continue
+
+        existing = by_eid.get(eid)
+        if existing is None:
+            by_eid[eid] = event
+            continue
+
+        deduplicated += 1
+        merged = dict(existing)
+        for key, value in event.items():
+            if (
+                value is not None
+                and value != ""
+                and (merged.get(key) is None or merged.get(key) == "")
+            ):
+                merged[key] = value
+
+        durable = None
+        if event.get("_source") == "durable":
+            durable = event
+        elif existing.get("_source") == "durable" or "durable" in (
+            existing.get("_sources") or []
+        ):
+            durable = existing
+        if durable is not None:
+            for key in durable_authoritative:
+                value = durable.get(key)
+                if value is not None and value != "":
+                    merged[key] = value
+
+        sources = sorted(
+            set(existing.get("_sources") or [])
+            | set(event.get("_sources") or [])
+        )
+        merged["_sources"] = sources
+        merged["_source"] = "mixed" if len(sources) > 1 else sources[0]
+        if "durable" in sources and "live" in sources:
+            live_order = merged.get("_live_order") or {}
+            for key in ("dt", "ts", "epoch_ms", "sk"):
+                value = live_order.get(key)
+                if value is not None and value != "":
+                    merged[key] = value
+        by_eid[eid] = merged
+
+    merged_events = list(by_eid.values()) + without_eid
+    merged_events.sort(
+        key=lambda event: (
+            _analytics_live_epoch_ms(event),
+            str(event.get("sk") or ""),
+        ),
+        reverse=True,
+    )
+    return merged_events, deduplicated, len(without_eid)
+
+
+def _analytics_auto_unqueried_ranges(start, end, queried_ranges):
+    """Return uncovered UTC intervals after merging successful source ranges."""
+    cursor = start
+    gaps = []
+    for _, covered_start, covered_end in sorted(
+        queried_ranges, key=lambda item: item[1]
+    ):
+        covered_start = max(start, covered_start)
+        covered_end = min(end, covered_end)
+        if covered_end <= cursor:
+            continue
+        if covered_start > cursor:
+            gaps.append((cursor, covered_start))
+        cursor = max(cursor, covered_end)
+    if cursor < end:
+        gaps.append((cursor, end))
+    return gaps
+
+
+async def analytics_auto_impl(
+    minutes=None,
+    since=None,
+    until=None,
+    campaign=None,
+    humans_only=True,
+    limit=ANALYTICS_LIVE_MAX_SESSIONS,
+    _now=None,
+) -> dict:
+    """Route one UTC interval across durable and live analytics sources."""
+    from datetime import timedelta
+
+    try:
+        campaign = str(campaign or "").strip()
+        start, end, current, effective_minutes = _analytics_auto_window(
+            minutes=minutes,
+            since=since,
+            until=until,
+            campaign=campaign,
+            now=_now,
+        )
+        limit = max(1, min(int(limit), ANALYTICS_LIVE_MAX_SESSIONS))
+        live_floor = current - timedelta(
+            minutes=ANALYTICS_LIVE_MAX_MINUTES
+        )
+        source_errors = {}
+        latest_durable = None
+        overlap_start = None
+
+        try:
+            latest_durable = _analytics_latest_durable_event()
+        except Exception as exc:
+            logger.exception("analytics_auto durable watermark failed")
+            source_errors["watermark"] = str(exc)
+
+        durable_range = None
+        live_range = None
+        if latest_durable is not None:
+            durable_end = min(end, latest_durable + timedelta(milliseconds=1))
+            if start < durable_end:
+                durable_range = (start, durable_end)
+
+            overlap_start = latest_durable - timedelta(
+                days=ANALYTICS_AUTO_REPAIR_OVERLAP_DAYS
+            )
+            live_start = max(start, overlap_start, live_floor)
+            if live_start < end:
+                live_range = (live_start, end)
+        else:
+            live_start = max(start, live_floor)
+            if live_start < end:
+                live_range = (live_start, end)
+
+        all_events = []
+        queried_ranges = []
+        truncated = False
+
+        if durable_range is not None:
+            try:
+                durable_events, durable_truncated = _analytics_durable_query(
+                    *durable_range
+                )
+                all_events.extend(durable_events)
+                truncated = truncated or durable_truncated
+                queried_ranges.append(("durable", *durable_range))
+            except Exception as exc:
+                logger.exception("analytics_auto durable query failed")
+                source_errors["durable"] = str(exc)
+                fallback_start = max(start, live_floor)
+                if fallback_start < end:
+                    live_range = (fallback_start, end)
+
+        if live_range is not None:
+            try:
+                live_events, live_truncated = _analytics_live_query(
+                    live_range[0],
+                    live_range[1] - timedelta(microseconds=1),
+                )
+                start_ms = live_range[0].timestamp() * 1000
+                end_ms = live_range[1].timestamp() * 1000
+                for live_event in live_events:
+                    epoch_ms = _analytics_live_epoch_ms(live_event)
+                    if start_ms <= epoch_ms < end_ms:
+                        normalized = dict(live_event)
+                        normalized["_source"] = "live"
+                        normalized["_sources"] = ["live"]
+                        all_events.append(normalized)
+                truncated = truncated or live_truncated
+                queried_ranges.append(("live", *live_range))
+            except Exception as exc:
+                logger.exception("analytics_auto live query failed")
+                source_errors["live"] = str(exc)
+
+        events, deduplicated, undeduplicable = _analytics_auto_merge_events(
+            all_events
+        )
+        if len(events) > ANALYTICS_LIVE_MAX_EVENTS:
+            events = events[:ANALYTICS_LIVE_MAX_EVENTS]
+            truncated = True
+        if humans_only:
+            events = [
+                event
+                for event in events
+                if _analytics_live_is_human(event)
+            ]
+        if campaign:
+            events = _analytics_live_campaign_events(events, campaign)
+
+        sessions = _analytics_live_rollup(events)
+        if len(sessions) > limit:
+            truncated = True
+        sessions = sessions[:limit]
+
+        unqueried_ranges = _analytics_auto_unqueried_ranges(
+            start, end, queried_ranges
+        )
+        successful_sources = sorted({item[0] for item in queried_ranges})
+        if len(successful_sources) > 1:
+            source = "mixed"
+        elif successful_sources:
+            source = successful_sources[0]
+        else:
+            source = "none"
+
+        if not successful_sources and source_errors:
+            return {
+                "error": "all analytics sources failed",
+                "source_errors": source_errors,
+                "since": _analytics_live_iso(start),
+                "until": _analytics_live_iso(end),
+            }
+
+        source_event_counts = {"durable": 0, "live": 0, "mixed": 0}
+        for event in events:
+            event_source = str(event.get("_source") or "")
+            if event_source in source_event_counts:
+                source_event_counts[event_source] += 1
+
+        return {
+            "source": source,
+            "since": _analytics_live_iso(start),
+            "until": _analytics_live_iso(end),
+            "as_of": _analytics_live_iso(current),
+            "minutes": effective_minutes,
+            "campaign": campaign or None,
+            "timezone": "UTC",
+            "humans_only": bool(humans_only),
+            "partial": bool(source_errors or unqueried_ranges),
+            "truncated": truncated,
+            "latest_durable_event": (
+                _analytics_live_iso(latest_durable)
+                if latest_durable is not None
+                else None
+            ),
+            "live_durable_overlap_start": (
+                _analytics_live_iso(overlap_start)
+                if overlap_start is not None
+                else None
+            ),
+            "queried_ranges": [
+                {
+                    "source": item_source,
+                    "since": _analytics_live_iso(item_start),
+                    "until": _analytics_live_iso(item_end),
+                }
+                for item_source, item_start, item_end in queried_ranges
+            ],
+            "unqueried_ranges": [
+                {
+                    "since": _analytics_live_iso(gap_start),
+                    "until": _analytics_live_iso(gap_end),
+                }
+                for gap_start, gap_end in unqueried_ranges
+            ],
+            "source_errors": source_errors,
+            "source_event_counts": source_event_counts,
+            "deduplicated_event_count": deduplicated,
+            "undeduplicable_event_count": undeduplicable,
+            "event_count": len(events),
+            "session_count": len(sessions),
+            "sessions": sessions,
+        }
+    except Exception as exc:
+        logger.exception("analytics_auto failed")
+        return {"error": str(exc)}
 
 
 def _analytics_base_cte(start_date: str, end_date: str) -> str:

--- a/scripts/receipt_mcp_server.py
+++ b/scripts/receipt_mcp_server.py
@@ -900,7 +900,7 @@ using get_receipt or get_receipt_image_url.""",
             },
         ),
         Tool(
-            name="analytics_auto",
+            name="analytics",
             description="""Unified production visitor analytics across live and durable data.
 
 Use this as the default tool when a question may span current and historical
@@ -955,7 +955,7 @@ event details, edge geo, referrer, and UTM attribution. By default excludes
 bots, Cloudflare WARP traffic, and datacenter-hosting traffic. `minutes` is
 clamped to the live table's 90-day retention window. Results contain at most
 the newest 5,000 events and 250 sessions; `truncated` reports omitted data.
-Prefer `analytics_auto` unless a Dynamo-only diagnostic is explicitly needed.""",
+Prefer `analytics` unless a Dynamo-only diagnostic is explicitly needed.""",
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -984,7 +984,7 @@ campaign result starts at its tagged landing event and continues until another
 tagged campaign begins. Returns pages/events, edge geo, referrer, and UTM
 fields. At least one of `campaign` or `since` is required. Results contain at
 most the newest 5,000 events and 250 sessions; `truncated` reports omitted
-data. Prefer `analytics_auto` when attribution may include durable history.""",
+data. Prefer `analytics` when attribution may include durable history.""",
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -1600,8 +1600,8 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent]:
             )
         elif name == "get_label_distribution":
             result = await get_label_distribution_impl(dynamo_client)
-        elif name == "analytics_auto":
-            result = await analytics_auto_impl(
+        elif name == "analytics":
+            result = await analytics_impl(
                 minutes=arguments.get("minutes"),
                 since=arguments.get("since"),
                 until=arguments.get("until"),
@@ -3726,8 +3726,8 @@ ANALYTICS_LIVE_TABLE = os.environ.get(
 ANALYTICS_LIVE_MAX_MINUTES = 90 * 24 * 60
 ANALYTICS_LIVE_MAX_EVENTS = 5000
 ANALYTICS_LIVE_MAX_SESSIONS = 250
-ANALYTICS_AUTO_MAX_MINUTES = 365 * 24 * 60
-ANALYTICS_AUTO_REPAIR_OVERLAP_DAYS = 4
+ANALYTICS_MAX_MINUTES = 365 * 24 * 60
+ANALYTICS_REPAIR_OVERLAP_DAYS = 4
 ANALYTICS_WATERMARK_CACHE_SECONDS = 300
 _analytics_watermark_cache = {"checked_at": 0.0, "value": None}
 
@@ -4239,7 +4239,7 @@ def _athena_run(sql: str, max_wait: int = 90, max_rows: int = 5000) -> list:
     return rows
 
 
-def _analytics_auto_window(
+def _analytics_window(
     minutes=None, since=None, until=None, campaign=None, now=None
 ):
     """Return a validated UTC [start, end) interval for routed analytics."""
@@ -4270,14 +4270,14 @@ def _analytics_auto_window(
         except (TypeError, ValueError) as exc:
             raise ValueError("minutes must be an integer") from exc
         effective_minutes = max(
-            1, min(effective_minutes, ANALYTICS_AUTO_MAX_MINUTES)
+            1, min(effective_minutes, ANALYTICS_MAX_MINUTES)
         )
         start = end - timedelta(minutes=effective_minutes)
 
     if start >= end:
         raise ValueError("since must be earlier than until")
-    if end - start > timedelta(minutes=ANALYTICS_AUTO_MAX_MINUTES):
-        raise ValueError("analytics_auto interval cannot exceed 365 days")
+    if end - start > timedelta(minutes=ANALYTICS_MAX_MINUTES):
+        raise ValueError("analytics interval cannot exceed 365 days")
     return start, end, current, effective_minutes
 
 
@@ -4422,7 +4422,7 @@ LIMIT {row_limit}
     return [_analytics_normalize_durable_event(row) for row in rows], truncated
 
 
-def _analytics_auto_merge_events(events: list[dict]):
+def _analytics_merge_events(events: list[dict]):
     """Deduplicate non-empty eids while retaining both sources' best fields."""
     durable_authoritative = {
         "dt",
@@ -4522,7 +4522,7 @@ def _analytics_auto_merge_events(events: list[dict]):
     return merged_events, deduplicated, len(without_eid)
 
 
-def _analytics_auto_unqueried_ranges(start, end, queried_ranges):
+def _analytics_unqueried_ranges(start, end, queried_ranges):
     """Return uncovered UTC intervals after merging successful source ranges."""
     cursor = start
     gaps = []
@@ -4541,7 +4541,7 @@ def _analytics_auto_unqueried_ranges(start, end, queried_ranges):
     return gaps
 
 
-async def analytics_auto_impl(
+async def analytics_impl(
     minutes=None,
     since=None,
     until=None,
@@ -4555,7 +4555,7 @@ async def analytics_auto_impl(
 
     try:
         campaign = str(campaign or "").strip()
-        start, end, current, effective_minutes = _analytics_auto_window(
+        start, end, current, effective_minutes = _analytics_window(
             minutes=minutes,
             since=since,
             until=until,
@@ -4573,7 +4573,7 @@ async def analytics_auto_impl(
         try:
             latest_durable = _analytics_latest_durable_event()
         except Exception as exc:
-            logger.exception("analytics_auto durable watermark failed")
+            logger.exception("analytics durable watermark failed")
             source_errors["watermark"] = str(exc)
 
         durable_range = None
@@ -4584,7 +4584,7 @@ async def analytics_auto_impl(
                 durable_range = (start, durable_end)
 
             overlap_start = latest_durable - timedelta(
-                days=ANALYTICS_AUTO_REPAIR_OVERLAP_DAYS
+                days=ANALYTICS_REPAIR_OVERLAP_DAYS
             )
             live_start = max(start, overlap_start, live_floor)
             if live_start < end:
@@ -4607,7 +4607,7 @@ async def analytics_auto_impl(
                 truncated = truncated or durable_truncated
                 queried_ranges.append(("durable", *durable_range))
             except Exception as exc:
-                logger.exception("analytics_auto durable query failed")
+                logger.exception("analytics durable query failed")
                 source_errors["durable"] = str(exc)
                 fallback_start = max(start, live_floor)
                 if fallback_start < end:
@@ -4631,10 +4631,10 @@ async def analytics_auto_impl(
                 truncated = truncated or live_truncated
                 queried_ranges.append(("live", *live_range))
             except Exception as exc:
-                logger.exception("analytics_auto live query failed")
+                logger.exception("analytics live query failed")
                 source_errors["live"] = str(exc)
 
-        events, deduplicated, undeduplicable = _analytics_auto_merge_events(
+        events, deduplicated, undeduplicable = _analytics_merge_events(
             all_events
         )
         if len(events) > ANALYTICS_LIVE_MAX_EVENTS:
@@ -4654,7 +4654,7 @@ async def analytics_auto_impl(
             truncated = True
         sessions = sessions[:limit]
 
-        unqueried_ranges = _analytics_auto_unqueried_ranges(
+        unqueried_ranges = _analytics_unqueried_ranges(
             start, end, queried_ranges
         )
         successful_sources = sorted({item[0] for item in queried_ranges})
@@ -4724,7 +4724,7 @@ async def analytics_auto_impl(
             "sessions": sessions,
         }
     except Exception as exc:
-        logger.exception("analytics_auto failed")
+        logger.exception("analytics failed")
         return {"error": str(exc)}
 
 

--- a/scripts/receipt_mcp_server.py
+++ b/scripts/receipt_mcp_server.py
@@ -900,6 +900,63 @@ using get_receipt or get_receipt_image_url.""",
             },
         ),
         Tool(
+            name="analytics_live",
+            description="""Recent production web visits from the real-time beacon collector.
+
+Reads DynamoDB directly and rolls beacon events into sessions with pages,
+event details, edge geo, referrer, and UTM attribution. By default excludes
+bots, Cloudflare WARP traffic, and datacenter-hosting traffic. `minutes` is
+clamped to the live table's 90-day retention window.""",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "minutes": {
+                        "type": "integer",
+                        "default": 60,
+                        "minimum": 1,
+                        "maximum": 129600,
+                        "description": "Lookback in minutes (default 60, max 129600)",
+                    },
+                    "humans_only": {
+                        "type": "boolean",
+                        "default": True,
+                        "description": "Exclude bots, WARP, and hosting traffic",
+                    },
+                },
+            },
+        ),
+        Tool(
+            name="analytics_attribution",
+            description="""Real-time campaign and outreach attribution.
+
+Filter live beacon events by exact `utm_campaign`, an ISO-8601 UTC `since`
+timestamp, or both. Campaign-only queries default to the last 24 hours. Returns
+session pages/events, first/last seen, edge geo, referrer, and UTM fields. At
+least one of `campaign` or `since` is required.""",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "campaign": {
+                        "type": "string",
+                        "description": "Exact utm_campaign value",
+                    },
+                    "since": {
+                        "type": "string",
+                        "description": "ISO-8601 timestamp (naive values are UTC)",
+                    },
+                    "humans_only": {
+                        "type": "boolean",
+                        "default": True,
+                        "description": "Exclude bots, WARP, and hosting traffic",
+                    },
+                },
+                "anyOf": [
+                    {"required": ["campaign"]},
+                    {"required": ["since"]},
+                ],
+            },
+        ),
+        Tool(
             name="analytics_traffic",
             description="""Per-day production web traffic (CloudFront logs via Athena).
 
@@ -1491,6 +1548,17 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent]:
             )
         elif name == "get_label_distribution":
             result = await get_label_distribution_impl(dynamo_client)
+        elif name == "analytics_live":
+            result = await analytics_live_impl(
+                minutes=arguments.get("minutes", 60),
+                humans_only=arguments.get("humans_only", True),
+            )
+        elif name == "analytics_attribution":
+            result = await analytics_attribution_impl(
+                campaign=arguments.get("campaign"),
+                since=arguments.get("since"),
+                humans_only=arguments.get("humans_only", True),
+            )
         elif name == "analytics_traffic":
             result = await analytics_traffic_impl(
                 start_date=arguments["start_date"],
@@ -3591,6 +3659,379 @@ async def delete_receipt_section_impl(
 ANALYTICS_DB = "portfolio_analytics"
 ANALYTICS_WORKGROUP = "portfolio_analytics"
 ANALYTICS_REGION = "us-east-1"
+ANALYTICS_LIVE_TABLE = os.environ.get(
+    "WEB_EVENTS_LIVE_TABLE_NAME", "web_events_live"
+)
+ANALYTICS_LIVE_MAX_MINUTES = 90 * 24 * 60
+
+
+def _analytics_normalize_dynamo(value):
+    """Return a JSON-safe copy of a value produced by boto3 DynamoDB."""
+    from decimal import Decimal
+
+    if isinstance(value, Decimal):
+        if value == value.to_integral_value():
+            return int(value)
+        return float(value)
+    if isinstance(value, dict):
+        return {
+            key: _analytics_normalize_dynamo(item)
+            for key, item in value.items()
+        }
+    if isinstance(value, (list, tuple)):
+        return [_analytics_normalize_dynamo(item) for item in value]
+    if isinstance(value, set):
+        return [
+            _analytics_normalize_dynamo(item)
+            for item in sorted(value, key=str)
+        ]
+    return value
+
+
+def _analytics_live_iso(dt) -> str:
+    return dt.isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+
+def _analytics_live_parse_since(value: str):
+    from datetime import datetime, timezone
+
+    text = (value or "").strip()
+    if not text:
+        raise ValueError("since must be a non-empty ISO-8601 timestamp")
+    if text.endswith(("Z", "z")):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError as exc:
+        raise ValueError(
+            f"since must be an ISO-8601 timestamp, got {value!r}"
+        ) from exc
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _analytics_live_window(minutes=60, since=None, now=None):
+    from datetime import datetime, timedelta, timezone
+
+    current = now or datetime.now(timezone.utc)
+    if current.tzinfo is None:
+        current = current.replace(tzinfo=timezone.utc)
+    current = current.astimezone(timezone.utc)
+    earliest = current - timedelta(minutes=ANALYTICS_LIVE_MAX_MINUTES)
+
+    if since is not None and str(since).strip():
+        start = _analytics_live_parse_since(str(since))
+        if start > current:
+            raise ValueError("since cannot be in the future")
+        return max(start, earliest), current
+
+    try:
+        lookback = int(minutes)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("minutes must be an integer") from exc
+    lookback = max(1, min(lookback, ANALYTICS_LIVE_MAX_MINUTES))
+    return current - timedelta(minutes=lookback), current
+
+
+def _analytics_live_epoch_ms(item: dict) -> int:
+    raw_epoch = item.get("epoch_ms")
+    if raw_epoch is not None:
+        try:
+            return int(raw_epoch)
+        except (TypeError, ValueError):
+            pass
+
+    sk_epoch = str(item.get("sk") or "").split("#", 1)[0]
+    if sk_epoch.isdigit():
+        return int(sk_epoch)
+
+    try:
+        return int(_analytics_live_parse_since(str(item.get("ts"))).timestamp() * 1000)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _analytics_live_query(start, end) -> list[dict]:
+    """Query each UTC date partition intersecting [start, end]; never scan."""
+    from datetime import datetime, timedelta, timezone
+
+    import boto3
+    from boto3.dynamodb.conditions import Key
+
+    table = boto3.resource("dynamodb", region_name=ANALYTICS_REGION).Table(
+        ANALYTICS_LIVE_TABLE
+    )
+    start_ms = int(start.timestamp() * 1000)
+    end_ms = int(end.timestamp() * 1000)
+    items = []
+    day = start.date()
+    while day <= end.date():
+        day_start = datetime.combine(day, datetime.min.time(), timezone.utc)
+        next_day = day_start + timedelta(days=1)
+        lower_ms = max(start_ms, int(day_start.timestamp() * 1000))
+        upper_ms = min(end_ms, int(next_day.timestamp() * 1000) - 1)
+        query_args = {
+            "KeyConditionExpression": (
+                Key("dt").eq(day.isoformat())
+                & Key("sk").between(
+                    f"{lower_ms:013d}#", f"{upper_ms:013d}#\uffff"
+                )
+            ),
+            # The real-time tool should observe a just-written beacon.
+            "ConsistentRead": True,
+        }
+        while True:
+            response = table.query(**query_args)
+            items.extend(response.get("Items", []))
+            last_key = response.get("LastEvaluatedKey")
+            if not last_key:
+                break
+            query_args["ExclusiveStartKey"] = last_key
+        day += timedelta(days=1)
+
+    normalized = [_analytics_normalize_dynamo(item) for item in items]
+    # The SK range is authoritative; the second check protects against malformed
+    # test/manual rows and keeps rollups deterministic.
+    normalized = [
+        item
+        for item in normalized
+        if start_ms <= _analytics_live_epoch_ms(item) <= end_ms
+    ]
+    return sorted(
+        normalized,
+        key=lambda item: (
+            _analytics_live_epoch_ms(item),
+            str(item.get("sk") or ""),
+        ),
+    )
+
+
+def _analytics_live_flag(item: dict, key: str) -> bool:
+    value = item.get(key, False)
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes"}
+    return bool(value)
+
+
+def _analytics_live_is_human(item: dict) -> bool:
+    # Batch `is_bot` already folds hosting into bots. Live checks all three
+    # explicitly so classification cannot drift if one stored flag is wrong.
+    return not any(
+        _analytics_live_flag(item, key)
+        for key in ("is_bot", "is_warp", "is_hosting")
+    )
+
+
+def _analytics_live_first(events: list[dict], key: str):
+    for event in events:
+        value = event.get(key)
+        if value is not None and value != "":
+            return value
+    return None
+
+
+def _analytics_live_referrer_parts(ref):
+    from urllib.parse import urlsplit
+
+    if not ref:
+        return None, None
+    text = str(ref)
+    try:
+        parsed = urlsplit(text)
+    except ValueError:
+        return None, text
+    path = parsed.path or "/"
+    if parsed.query:
+        path = f"{path}?{parsed.query}"
+    return parsed.netloc or None, path
+
+
+_ANALYTICS_LIVE_EVENT_METRICS = (
+    "page_path",
+    "percent_scrolled",
+    "metric_name",
+    "metric_value",
+    "time_to_bottom_ms",
+    "active_scroll_ms",
+    "page_height",
+    "scrollable_pixels",
+    "screens_per_minute",
+    "reader_delta_percent",
+    "baseline_sample_size",
+    "session_page_views",
+    "quick_jump",
+)
+
+
+def _analytics_live_event_summary(item: dict) -> dict:
+    summary = {
+        "ts": item.get("ts"),
+        "eid": item.get("eid"),
+        "event": item.get("event"),
+        "path": item.get("path") or item.get("page_path"),
+    }
+    for key in _ANALYTICS_LIVE_EVENT_METRICS:
+        value = item.get(key)
+        if value is not None and value != "":
+            summary[key] = value
+    return {key: value for key, value in summary.items() if value is not None}
+
+
+def _analytics_live_rollup(events: list[dict]) -> list[dict]:
+    grouped = defaultdict(list)
+    for event in events:
+        sid = str(event.get("sid") or "").strip()
+        if sid:
+            grouped[sid].append(event)
+
+    sessions = []
+    for sid, session_events in grouped.items():
+        session_events.sort(
+            key=lambda event: (
+                _analytics_live_epoch_ms(event),
+                str(event.get("sk") or ""),
+            )
+        )
+        first_epoch = _analytics_live_epoch_ms(session_events[0])
+        last_epoch = _analytics_live_epoch_ms(session_events[-1])
+        pages = []
+        event_counts = {}
+        for event in session_events:
+            page = event.get("path") or event.get("page_path")
+            if page and page not in pages:
+                pages.append(page)
+            event_name = str(event.get("event") or "unknown")
+            event_counts[event_name] = event_counts.get(event_name, 0) + 1
+
+        ref = _analytics_live_first(session_events, "ref")
+        referrer_host, referrer_path = _analytics_live_referrer_parts(ref)
+        session = {
+            "sid": sid,
+            "first_seen": session_events[0].get("ts"),
+            "last_seen": session_events[-1].get("ts"),
+            "duration_seconds": max(0, (last_epoch - first_epoch) // 1000),
+            "ip": _analytics_live_first(session_events, "ip"),
+            "ua": _analytics_live_first(session_events, "ua"),
+            "country": _analytics_live_first(session_events, "country"),
+            "region": _analytics_live_first(session_events, "region"),
+            "city": _analytics_live_first(session_events, "city"),
+            "latitude": _analytics_live_first(session_events, "latitude"),
+            "longitude": _analytics_live_first(session_events, "longitude"),
+            "timezone": _analytics_live_first(session_events, "timezone"),
+            "asn": _analytics_live_first(session_events, "asn"),
+            "ref": ref,
+            "referrer_host": referrer_host,
+            "referrer_path": referrer_path,
+            "utm_source": _analytics_live_first(session_events, "utm_source"),
+            "utm_medium": _analytics_live_first(session_events, "utm_medium"),
+            "utm_campaign": _analytics_live_first(
+                session_events, "utm_campaign"
+            ),
+            "is_warp": any(
+                _analytics_live_flag(event, "is_warp")
+                for event in session_events
+            ),
+            "is_bot": any(
+                _analytics_live_flag(event, "is_bot")
+                for event in session_events
+            ),
+            "is_hosting": any(
+                _analytics_live_flag(event, "is_hosting")
+                for event in session_events
+            ),
+            "pages": pages,
+            "pageviews": event_counts.get("page_view", 0),
+            "beacons": len(session_events),
+            "event_counts": event_counts,
+            "events": [
+                _analytics_live_event_summary(event)
+                for event in session_events
+            ],
+            "_last_epoch": last_epoch,
+        }
+        sessions.append(session)
+
+    sessions.sort(
+        key=lambda session: (session["_last_epoch"], session["sid"]),
+        reverse=True,
+    )
+    for session in sessions:
+        session.pop("_last_epoch", None)
+    return sessions
+
+
+async def analytics_live_impl(minutes=60, humans_only=True) -> dict:
+    try:
+        start, end = _analytics_live_window(minutes=minutes)
+        effective_minutes = max(
+            1, min(int(minutes), ANALYTICS_LIVE_MAX_MINUTES)
+        )
+        events = _analytics_live_query(start, end)
+        if humans_only:
+            events = [event for event in events if _analytics_live_is_human(event)]
+        sessions = _analytics_live_rollup(events)
+        return {
+            "since": _analytics_live_iso(start),
+            "as_of": _analytics_live_iso(end),
+            "minutes": effective_minutes,
+            "timezone": "UTC",
+            "humans_only": bool(humans_only),
+            "event_count": len(events),
+            "session_count": len(sessions),
+            "sessions": sessions,
+        }
+    except Exception as exc:
+        logger.exception("analytics_live failed")
+        return {"error": str(exc)}
+
+
+async def analytics_attribution_impl(
+    campaign=None, since=None, humans_only=True
+) -> dict:
+    try:
+        campaign = str(campaign or "").strip()
+        since = str(since or "").strip()
+        if not campaign and not since:
+            return {"error": "campaign or since is required"}
+
+        # Campaign-only is optimized for the outreach use case; explicit since
+        # can reach back as far as the live table's 90-day TTL.
+        start, end = _analytics_live_window(
+            minutes=24 * 60,
+            since=since or None,
+        )
+        events = _analytics_live_query(start, end)
+        if humans_only:
+            events = [event for event in events if _analytics_live_is_human(event)]
+        attributed_sids = {
+            str(event.get("sid") or "")
+            for event in events
+            if str(event.get("utm_campaign") or "") == campaign
+        }
+        sessions = _analytics_live_rollup(events)
+        if campaign:
+            sessions = [
+                session
+                for session in sessions
+                if session["sid"] in attributed_sids
+            ]
+        attributed_event_count = sum(
+            session["beacons"] for session in sessions
+        )
+        return {
+            "campaign": campaign or None,
+            "since": _analytics_live_iso(start),
+            "as_of": _analytics_live_iso(end),
+            "timezone": "UTC",
+            "humans_only": bool(humans_only),
+            "event_count": attributed_event_count,
+            "session_count": len(sessions),
+            "sessions": sessions,
+        }
+    except Exception as exc:
+        logger.exception("analytics_attribution failed")
+        return {"error": str(exc)}
 
 
 

--- a/scripts/receipt_mcp_server.py
+++ b/scripts/receipt_mcp_server.py
@@ -906,7 +906,8 @@ using get_receipt or get_receipt_image_url.""",
 Reads DynamoDB directly and rolls beacon events into sessions with pages,
 event details, edge geo, referrer, and UTM attribution. By default excludes
 bots, Cloudflare WARP traffic, and datacenter-hosting traffic. `minutes` is
-clamped to the live table's 90-day retention window.""",
+clamped to the live table's 90-day retention window. Results contain at most
+the newest 5,000 events and 250 sessions; `truncated` reports omitted data.""",
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -932,7 +933,8 @@ clamped to the live table's 90-day retention window.""",
 Filter live beacon events by exact `utm_campaign`, an ISO-8601 UTC `since`
 timestamp, or both. Campaign-only queries default to the last 24 hours. Returns
 session pages/events, first/last seen, edge geo, referrer, and UTM fields. At
-least one of `campaign` or `since` is required.""",
+least one of `campaign` or `since` is required. Results contain at most the
+newest 5,000 events and 250 sessions; `truncated` reports omitted data.""",
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -3651,10 +3653,10 @@ async def delete_receipt_section_impl(
 
 
 # ---------------------------------------------------------------------------
-# Web analytics — Athena over CloudFront access logs.
-# Glue table + workgroup are created by infra/components/web_analytics.
-# All beacon parsing / WARP+bot classification / PT bucketing lives here in
-# SQL so the logic stays version-controlled rather than in a Glue view.
+# Web analytics — live DynamoDB overlay + durable CloudFront/Athena batch.
+# infra/components/web_analytics creates both query surfaces. The batch
+# transform owns durable parsing/classification/materialization; the collector
+# owns request-time flags. This server only reads and rolls up those records.
 # ---------------------------------------------------------------------------
 ANALYTICS_DB = "portfolio_analytics"
 ANALYTICS_WORKGROUP = "portfolio_analytics"
@@ -3663,6 +3665,8 @@ ANALYTICS_LIVE_TABLE = os.environ.get(
     "WEB_EVENTS_LIVE_TABLE_NAME", "web_events_live"
 )
 ANALYTICS_LIVE_MAX_MINUTES = 90 * 24 * 60
+ANALYTICS_LIVE_MAX_EVENTS = 5000
+ANALYTICS_LIVE_MAX_SESSIONS = 250
 
 
 def _analytics_normalize_dynamo(value):
@@ -3752,8 +3756,8 @@ def _analytics_live_epoch_ms(item: dict) -> int:
         return 0
 
 
-def _analytics_live_query(start, end) -> list[dict]:
-    """Query each UTC date partition intersecting [start, end]; never scan."""
+def _analytics_live_query(start, end) -> tuple[list[dict], bool]:
+    """Return the newest bounded event suffix and whether data was unread."""
     from datetime import datetime, timedelta, timezone
 
     import boto3
@@ -3765,8 +3769,10 @@ def _analytics_live_query(start, end) -> list[dict]:
     start_ms = int(start.timestamp() * 1000)
     end_ms = int(end.timestamp() * 1000)
     items = []
-    day = start.date()
-    while day <= end.date():
+    first_day = start.date()
+    day = end.date()
+    truncated = False
+    while day >= first_day and len(items) < ANALYTICS_LIVE_MAX_EVENTS:
         day_start = datetime.combine(day, datetime.min.time(), timezone.utc)
         next_day = day_start + timedelta(days=1)
         lower_ms = max(start_ms, int(day_start.timestamp() * 1000))
@@ -3780,15 +3786,25 @@ def _analytics_live_query(start, end) -> list[dict]:
             ),
             # The real-time tool should observe a just-written beacon.
             "ConsistentRead": True,
+            "ScanIndexForward": False,
         }
         while True:
+            query_args["Limit"] = ANALYTICS_LIVE_MAX_EVENTS - len(items)
             response = table.query(**query_args)
             items.extend(response.get("Items", []))
             last_key = response.get("LastEvaluatedKey")
             if not last_key:
                 break
+            if len(items) >= ANALYTICS_LIVE_MAX_EVENTS:
+                truncated = True
+                break
             query_args["ExclusiveStartKey"] = last_key
-        day += timedelta(days=1)
+        if truncated:
+            break
+        day -= timedelta(days=1)
+        if len(items) >= ANALYTICS_LIVE_MAX_EVENTS and day >= first_day:
+            truncated = True
+            break
 
     normalized = [_analytics_normalize_dynamo(item) for item in items]
     # The SK range is authoritative; the second check protects against malformed
@@ -3798,12 +3814,16 @@ def _analytics_live_query(start, end) -> list[dict]:
         for item in normalized
         if start_ms <= _analytics_live_epoch_ms(item) <= end_ms
     ]
-    return sorted(
-        normalized,
-        key=lambda item: (
-            _analytics_live_epoch_ms(item),
-            str(item.get("sk") or ""),
+    return (
+        sorted(
+            normalized,
+            key=lambda item: (
+                _analytics_live_epoch_ms(item),
+                str(item.get("sk") or ""),
+            ),
+            reverse=True,
         ),
+        truncated,
     )
 
 
@@ -3967,16 +3987,20 @@ async def analytics_live_impl(minutes=60, humans_only=True) -> dict:
         effective_minutes = max(
             1, min(int(minutes), ANALYTICS_LIVE_MAX_MINUTES)
         )
-        events = _analytics_live_query(start, end)
+        events, truncated = _analytics_live_query(start, end)
         if humans_only:
             events = [event for event in events if _analytics_live_is_human(event)]
         sessions = _analytics_live_rollup(events)
+        if len(sessions) > ANALYTICS_LIVE_MAX_SESSIONS:
+            truncated = True
+        sessions = sessions[:ANALYTICS_LIVE_MAX_SESSIONS]
         return {
             "since": _analytics_live_iso(start),
             "as_of": _analytics_live_iso(end),
             "minutes": effective_minutes,
             "timezone": "UTC",
             "humans_only": bool(humans_only),
+            "truncated": truncated,
             "event_count": len(events),
             "session_count": len(sessions),
             "sessions": sessions,
@@ -4001,7 +4025,7 @@ async def analytics_attribution_impl(
             minutes=24 * 60,
             since=since or None,
         )
-        events = _analytics_live_query(start, end)
+        events, truncated = _analytics_live_query(start, end)
         if humans_only:
             events = [event for event in events if _analytics_live_is_human(event)]
         attributed_sids = {
@@ -4016,6 +4040,9 @@ async def analytics_attribution_impl(
                 for session in sessions
                 if session["sid"] in attributed_sids
             ]
+        if len(sessions) > ANALYTICS_LIVE_MAX_SESSIONS:
+            truncated = True
+        sessions = sessions[:ANALYTICS_LIVE_MAX_SESSIONS]
         attributed_event_count = sum(
             session["beacons"] for session in sessions
         )
@@ -4025,6 +4052,7 @@ async def analytics_attribution_impl(
             "as_of": _analytics_live_iso(end),
             "timezone": "UTC",
             "humans_only": bool(humans_only),
+            "truncated": truncated,
             "event_count": attributed_event_count,
             "session_count": len(sessions),
             "sessions": sessions,

--- a/tests/test_receipt_mcp_section_tools.py
+++ b/tests/test_receipt_mcp_section_tools.py
@@ -37,7 +37,7 @@ EXPECTED_SECTION_TOOLS = {
 }
 
 EXPECTED_LIVE_ANALYTICS_TOOLS = {
-    "analytics_auto",
+    "analytics",
     "analytics_live",
     "analytics_attribution",
 }
@@ -172,8 +172,8 @@ def test_live_analytics_tools_present_with_valid_schema(label):
     missing = EXPECTED_LIVE_ANALYTICS_TOOLS - set(by_name)
     assert not missing, f"missing live analytics tools in {label}: {missing}"
 
-    auto_schema = by_name["analytics_auto"].inputSchema
-    assert auto_schema["type"] == "object"
+    analytics_schema = by_name["analytics"].inputSchema
+    assert analytics_schema["type"] == "object"
     assert {
         "minutes",
         "since",
@@ -181,10 +181,10 @@ def test_live_analytics_tools_present_with_valid_schema(label):
         "campaign",
         "humans_only",
         "limit",
-    } <= set(auto_schema["properties"])
-    assert auto_schema["properties"]["minutes"]["maximum"] == 525600
-    assert auto_schema["properties"]["humans_only"]["default"] is True
-    assert auto_schema["properties"]["limit"]["maximum"] == 250
+    } <= set(analytics_schema["properties"])
+    assert analytics_schema["properties"]["minutes"]["maximum"] == 525600
+    assert analytics_schema["properties"]["humans_only"]["default"] is True
+    assert analytics_schema["properties"]["limit"]["maximum"] == 250
 
     live_schema = by_name["analytics_live"].inputSchema
     assert live_schema["type"] == "object"
@@ -227,7 +227,7 @@ def test_live_analytics_tools_are_dispatched(label):
     dispatch = source.split("async def call_tool", 1)[1].split(
         "async def search_receipts_impl", 1
     )[0]
-    assert 'elif name == "analytics_auto"' in dispatch
+    assert 'elif name == "analytics"' in dispatch
     assert 'elif name == "analytics_live"' in dispatch
     assert 'elif name == "analytics_attribution"' in dispatch
 
@@ -470,11 +470,11 @@ def _live_test_event(ts, sid, campaign=None):
 
 
 @pytest.mark.parametrize("label", sorted(SERVER_FILES))
-def test_auto_window_is_exclusive_and_campaign_defaults_to_24h(label):
+def test_analytics_window_is_exclusive_and_campaign_defaults_to_24h(label):
     module = _load_module(label, SERVER_FILES[label])
     now = datetime(2026, 7, 10, 12, tzinfo=timezone.utc)
 
-    start, end, current, minutes = module._analytics_auto_window(
+    start, end, current, minutes = module._analytics_window(
         campaign="launch", now=now
     )
 
@@ -484,13 +484,13 @@ def test_auto_window_is_exclusive_and_campaign_defaults_to_24h(label):
     assert minutes == 24 * 60
 
     with pytest.raises(ValueError, match="earlier than until"):
-        module._analytics_auto_window(
+        module._analytics_window(
             since="2026-07-10T12:00:00Z",
             until="2026-07-10T12:00:00Z",
             now=now,
         )
     with pytest.raises(ValueError, match="cannot exceed 365 days"):
-        module._analytics_auto_window(
+        module._analytics_window(
             since=(now - timedelta(days=366)).isoformat(),
             until=now.isoformat(),
             now=now,
@@ -591,7 +591,7 @@ def test_durable_query_normalizes_existing_feed_without_schema_changes(
 
 
 @pytest.mark.parametrize("label", sorted(SERVER_FILES))
-def test_auto_merge_prefers_durable_classification_and_keeps_live_geo(label):
+def test_analytics_merge_prefers_durable_classification_and_keeps_live_geo(label):
     module = _load_module(label, SERVER_FILES[label])
     ts = datetime(2026, 7, 8, 12, tzinfo=timezone.utc)
     durable = _live_test_event(ts, "shared")
@@ -620,7 +620,7 @@ def test_auto_merge_prefers_durable_classification_and_keeps_live_geo(label):
     no_eid_b = _live_test_event(ts, "no-eid-b")
     no_eid_b.update({"eid": "", "_source": "live"})
 
-    events, deduplicated, undeduplicable = module._analytics_auto_merge_events(
+    events, deduplicated, undeduplicable = module._analytics_merge_events(
         [live, no_eid_a, durable, no_eid_b]
     )
 
@@ -637,7 +637,7 @@ def test_auto_merge_prefers_durable_classification_and_keeps_live_geo(label):
 
 
 @pytest.mark.parametrize("label", sorted(SERVER_FILES))
-def test_auto_merge_keeps_live_order_for_same_second_campaign_events(label):
+def test_analytics_merge_keeps_live_order_for_same_second_campaign_events(label):
     module = _load_module(label, SERVER_FILES[label])
     second = datetime(2026, 7, 8, 12, tzinfo=timezone.utc)
     landing_live_ts = second + timedelta(milliseconds=100)
@@ -680,7 +680,7 @@ def test_auto_merge_keeps_live_order_for_same_second_campaign_events(label):
         }
     )
 
-    merged, deduplicated, _ = module._analytics_auto_merge_events(
+    merged, deduplicated, _ = module._analytics_merge_events(
         [durable_follow, durable_landing, live_follow, live_landing]
     )
     attributed = module._analytics_live_campaign_events(merged, "launch")
@@ -693,7 +693,7 @@ def test_auto_merge_keeps_live_order_for_same_second_campaign_events(label):
 
 
 @pytest.mark.parametrize("label", sorted(SERVER_FILES))
-def test_analytics_auto_routes_recent_window_to_live_only(label, monkeypatch):
+def test_analytics_routes_recent_window_to_live_only(label, monkeypatch):
     module = _load_module(label, SERVER_FILES[label])
     now = datetime(2026, 7, 10, 12, tzinfo=timezone.utc)
     before_end = _live_test_event(
@@ -723,7 +723,7 @@ def test_analytics_auto_routes_recent_window_to_live_only(label, monkeypatch):
     )
 
     result = asyncio.run(
-        module.analytics_auto_impl(minutes=60, humans_only=False, _now=now)
+        module.analytics_impl(minutes=60, humans_only=False, _now=now)
     )
 
     assert result["source"] == "live"
@@ -739,7 +739,7 @@ def test_analytics_auto_routes_recent_window_to_live_only(label, monkeypatch):
 
 
 @pytest.mark.parametrize("label", sorted(SERVER_FILES))
-def test_analytics_auto_routes_old_window_to_durable_only(label, monkeypatch):
+def test_analytics_routes_old_window_to_durable_only(label, monkeypatch):
     module = _load_module(label, SERVER_FILES[label])
     now = datetime(2026, 7, 10, 12, tzinfo=timezone.utc)
     event = _live_test_event(
@@ -768,7 +768,7 @@ def test_analytics_auto_routes_old_window_to_durable_only(label, monkeypatch):
     )
 
     result = asyncio.run(
-        module.analytics_auto_impl(
+        module.analytics_impl(
             since="2026-06-01T00:00:00Z",
             until="2026-06-02T00:00:00Z",
             humans_only=False,
@@ -788,7 +788,7 @@ def test_analytics_auto_routes_old_window_to_durable_only(label, monkeypatch):
 
 
 @pytest.mark.parametrize("label", sorted(SERVER_FILES))
-def test_analytics_auto_merges_overlap_and_campaign_across_sources(
+def test_analytics_merges_overlap_and_campaign_across_sources(
     label, monkeypatch
 ):
     module = _load_module(label, SERVER_FILES[label])
@@ -835,7 +835,7 @@ def test_analytics_auto_merges_overlap_and_campaign_across_sources(
     monkeypatch.setattr(module, "_analytics_live_query", _live)
 
     result = asyncio.run(
-        module.analytics_auto_impl(
+        module.analytics_impl(
             since="2026-07-01T00:00:00Z",
             campaign="launch",
             humans_only=True,
@@ -867,7 +867,7 @@ def test_analytics_auto_merges_overlap_and_campaign_across_sources(
 
 
 @pytest.mark.parametrize("label", sorted(SERVER_FILES))
-def test_analytics_auto_marks_live_fallback_partial_on_durable_error(
+def test_analytics_marks_live_fallback_partial_on_durable_error(
     label, monkeypatch
 ):
     module = _load_module(label, SERVER_FILES[label])
@@ -894,7 +894,7 @@ def test_analytics_auto_marks_live_fallback_partial_on_durable_error(
     )
 
     result = asyncio.run(
-        module.analytics_auto_impl(
+        module.analytics_impl(
             since="2026-07-01T12:00:00Z",
             humans_only=False,
             _now=now,
@@ -909,7 +909,7 @@ def test_analytics_auto_marks_live_fallback_partial_on_durable_error(
 
 
 @pytest.mark.parametrize("label", sorted(SERVER_FILES))
-def test_analytics_auto_reports_retention_gap_without_durable_data(
+def test_analytics_reports_retention_gap_without_durable_data(
     label, monkeypatch
 ):
     module = _load_module(label, SERVER_FILES[label])
@@ -928,7 +928,7 @@ def test_analytics_auto_reports_retention_gap_without_durable_data(
     )
 
     result = asyncio.run(
-        module.analytics_auto_impl(
+        module.analytics_impl(
             since=start.isoformat(), humans_only=False, _now=now
         )
     )
@@ -947,7 +947,7 @@ def test_analytics_auto_reports_retention_gap_without_durable_data(
 
 
 @pytest.mark.parametrize("label", sorted(SERVER_FILES))
-def test_analytics_auto_caps_combined_sources_to_newest_events(
+def test_analytics_caps_combined_sources_to_newest_events(
     label, monkeypatch
 ):
     module = _load_module(label, SERVER_FILES[label])
@@ -985,7 +985,7 @@ def test_analytics_auto_caps_combined_sources_to_newest_events(
     )
 
     result = asyncio.run(
-        module.analytics_auto_impl(
+        module.analytics_impl(
             since="2026-07-08T00:00:00Z",
             humans_only=False,
             _now=now,
@@ -1001,7 +1001,7 @@ def test_analytics_auto_caps_combined_sources_to_newest_events(
 
 
 @pytest.mark.parametrize("label", sorted(SERVER_FILES))
-def test_analytics_auto_returns_error_when_both_sources_fail(label, monkeypatch):
+def test_analytics_returns_error_when_both_sources_fail(label, monkeypatch):
     module = _load_module(label, SERVER_FILES[label])
     now = datetime(2026, 7, 10, 12, tzinfo=timezone.utc)
     monkeypatch.setattr(
@@ -1015,7 +1015,7 @@ def test_analytics_auto_returns_error_when_both_sources_fail(label, monkeypatch)
         lambda *_args: (_ for _ in ()).throw(RuntimeError("Dynamo down")),
     )
 
-    result = asyncio.run(module.analytics_auto_impl(_now=now))
+    result = asyncio.run(module.analytics_impl(_now=now))
 
     assert result["error"] == "all analytics sources failed"
     assert result["source_errors"] == {

--- a/tests/test_receipt_mcp_section_tools.py
+++ b/tests/test_receipt_mcp_section_tools.py
@@ -11,6 +11,7 @@ import asyncio
 import importlib.util
 import sys
 import types
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
@@ -280,7 +281,7 @@ def test_attribution_keeps_full_session_after_campaign_landing(
     monkeypatch.setattr(
         module,
         "_analytics_live_query",
-        lambda _start, _end: events,
+        lambda _start, _end: (events, False),
     )
 
     result = asyncio.run(
@@ -289,6 +290,7 @@ def test_attribution_keeps_full_session_after_campaign_landing(
 
     assert result["session_count"] == 1
     assert result["event_count"] == 2
+    assert result["truncated"] is False
     session = result["sessions"][0]
     assert session["sid"] == "session-1"
     assert session["pages"] == ["/receipt", "/resume"]
@@ -306,8 +308,231 @@ def test_live_query_uses_partition_queries_not_scan(label):
     assert 'Key("dt").eq' in query_source
     assert 'Key("sk").between' in query_source
     assert '"ConsistentRead": True' in query_source
+    assert '"ScanIndexForward": False' in query_source
+    assert 'query_args["Limit"]' in query_source
     assert "table.query(" in query_source
     assert "scan(" not in query_source
+
+
+class _FakeDynamoCondition:
+    def __init__(self, parts):
+        self.parts = list(parts)
+
+    def __and__(self, other):
+        return _FakeDynamoCondition(self.parts + other.parts)
+
+
+def _install_fake_boto3_query(monkeypatch, table, queried_days):
+    class _FakeKey:
+        def __init__(self, name):
+            self.name = name
+
+        def eq(self, value):
+            if self.name == "dt":
+                queried_days.append(value)
+            return _FakeDynamoCondition([(self.name, "eq", value)])
+
+        def between(self, lower, upper):
+            return _FakeDynamoCondition(
+                [(self.name, "between", lower, upper)]
+            )
+
+    boto3_module = types.ModuleType("boto3")
+    dynamodb_module = types.ModuleType("boto3.dynamodb")
+    conditions_module = types.ModuleType("boto3.dynamodb.conditions")
+    conditions_module.Key = _FakeKey
+    dynamodb_module.conditions = conditions_module
+    boto3_module.dynamodb = dynamodb_module
+    boto3_module.resource = lambda *_args, **_kwargs: types.SimpleNamespace(
+        Table=lambda _name: table
+    )
+    monkeypatch.setitem(sys.modules, "boto3", boto3_module)
+    monkeypatch.setitem(sys.modules, "boto3.dynamodb", dynamodb_module)
+    monkeypatch.setitem(
+        sys.modules, "boto3.dynamodb.conditions", conditions_module
+    )
+
+
+def _live_test_event(ts, sid, campaign=None):
+    epoch_ms = int(ts.timestamp() * 1000)
+    event = {
+        "dt": ts.date().isoformat(),
+        "sk": f"{epoch_ms:013d}#{sid}#event",
+        "epoch_ms": epoch_ms,
+        "ts": ts.isoformat(timespec="milliseconds").replace("+00:00", "Z"),
+        "sid": sid,
+        "eid": f"{sid}-event",
+        "event": "page_view",
+        "path": f"/{sid}",
+    }
+    if campaign is not None:
+        event["utm_campaign"] = campaign
+    return event
+
+
+@pytest.mark.parametrize("label", sorted(SERVER_FILES))
+def test_live_query_caps_newest_page_and_reports_unread_page(
+    label, monkeypatch
+):
+    module = _load_module(label, SERVER_FILES[label])
+    monkeypatch.setattr(module, "ANALYTICS_LIVE_MAX_EVENTS", 3)
+    queried_days = []
+    responses = [
+        {
+            "Items": [
+                _live_test_event(
+                    datetime(2026, 7, 10, 12, 3, tzinfo=timezone.utc),
+                    "newest",
+                ),
+                _live_test_event(
+                    datetime(2026, 7, 10, 12, 2, tzinfo=timezone.utc),
+                    "middle",
+                ),
+            ],
+            "LastEvaluatedKey": {"dt": "2026-07-10", "sk": "page-2"},
+        },
+        {
+            "Items": [
+                _live_test_event(
+                    datetime(2026, 7, 10, 12, 1, tzinfo=timezone.utc),
+                    "oldest-returned",
+                )
+            ],
+            "LastEvaluatedKey": {"dt": "2026-07-10", "sk": "unread"},
+        },
+    ]
+
+    class _FakeTable:
+        def __init__(self):
+            self.calls = []
+
+        def query(self, **kwargs):
+            self.calls.append(kwargs)
+            return responses.pop(0)
+
+    table = _FakeTable()
+    _install_fake_boto3_query(monkeypatch, table, queried_days)
+    start = datetime(2026, 7, 9, tzinfo=timezone.utc)
+    end = datetime(2026, 7, 10, 23, 59, tzinfo=timezone.utc)
+
+    events, truncated = module._analytics_live_query(start, end)
+
+    assert truncated is True
+    assert [event["sid"] for event in events] == [
+        "newest",
+        "middle",
+        "oldest-returned",
+    ]
+    assert queried_days == ["2026-07-10"]
+    assert [call["Limit"] for call in table.calls] == [3, 1]
+    assert all(call["ConsistentRead"] is True for call in table.calls)
+    assert all(call["ScanIndexForward"] is False for call in table.calls)
+
+
+@pytest.mark.parametrize("label", sorted(SERVER_FILES))
+def test_live_query_reports_unread_older_date_at_exact_cap(label, monkeypatch):
+    module = _load_module(label, SERVER_FILES[label])
+    monkeypatch.setattr(module, "ANALYTICS_LIVE_MAX_EVENTS", 2)
+    queried_days = []
+
+    class _FakeTable:
+        def __init__(self):
+            self.calls = []
+
+        def query(self, **kwargs):
+            self.calls.append(kwargs)
+            return {
+                "Items": [
+                    _live_test_event(
+                        datetime(2026, 7, 10, 12, 2, tzinfo=timezone.utc),
+                        "newest",
+                    ),
+                    _live_test_event(
+                        datetime(2026, 7, 10, 12, 1, tzinfo=timezone.utc),
+                        "next",
+                    ),
+                ]
+            }
+
+    table = _FakeTable()
+    _install_fake_boto3_query(monkeypatch, table, queried_days)
+    start = datetime(2026, 7, 9, tzinfo=timezone.utc)
+    end = datetime(2026, 7, 10, 23, 59, tzinfo=timezone.utc)
+
+    events, truncated = module._analytics_live_query(start, end)
+
+    assert len(events) == 2
+    assert truncated is True
+    assert queried_days == ["2026-07-10"]
+    assert len(table.calls) == 1
+
+
+@pytest.mark.parametrize("label", sorted(SERVER_FILES))
+def test_analytics_live_caps_to_newest_sessions(label, monkeypatch):
+    module = _load_module(label, SERVER_FILES[label])
+    monkeypatch.setattr(module, "ANALYTICS_LIVE_MAX_SESSIONS", 2)
+    events = [
+        _live_test_event(
+            datetime(2026, 7, 10, 12, minute, tzinfo=timezone.utc),
+            sid,
+        )
+        for minute, sid in [(1, "oldest"), (2, "middle"), (3, "newest")]
+    ]
+    monkeypatch.setattr(
+        module,
+        "_analytics_live_query",
+        lambda _start, _end: (events, False),
+    )
+
+    result = asyncio.run(module.analytics_live_impl(humans_only=False))
+
+    assert result["truncated"] is True
+    assert result["event_count"] == 3
+    assert result["session_count"] == 2
+    assert [session["sid"] for session in result["sessions"]] == [
+        "newest",
+        "middle",
+    ]
+
+
+@pytest.mark.parametrize("label", sorted(SERVER_FILES))
+def test_attribution_filters_then_caps_to_newest_campaign_sessions(
+    label, monkeypatch
+):
+    module = _load_module(label, SERVER_FILES[label])
+    monkeypatch.setattr(module, "ANALYTICS_LIVE_MAX_SESSIONS", 2)
+    events = [
+        _live_test_event(
+            datetime(2026, 7, 10, 12, minute, tzinfo=timezone.utc),
+            sid,
+            campaign,
+        )
+        for minute, sid, campaign in [
+            (1, "campaign-oldest", "launch"),
+            (2, "campaign-middle", "launch"),
+            (3, "campaign-newest", "launch"),
+            (4, "unrelated-newest", "other"),
+        ]
+    ]
+    monkeypatch.setattr(
+        module,
+        "_analytics_live_query",
+        lambda _start, _end: (events, False),
+    )
+
+    result = asyncio.run(
+        module.analytics_attribution_impl(
+            campaign="launch", humans_only=False
+        )
+    )
+
+    assert result["truncated"] is True
+    assert result["event_count"] == 2
+    assert result["session_count"] == 2
+    assert [session["sid"] for session in result["sessions"]] == [
+        "campaign-newest",
+        "campaign-middle",
+    ]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_receipt_mcp_section_tools.py
+++ b/tests/test_receipt_mcp_section_tools.py
@@ -458,7 +458,7 @@ def _live_test_event(ts, sid, campaign=None):
         "dt": ts.date().isoformat(),
         "sk": f"{epoch_ms:013d}#{sid}#event",
         "epoch_ms": epoch_ms,
-        "ts": ts.isoformat(timespec="milliseconds").replace("+00:00", "Z"),
+        "ts": ts.isoformat(timespec="milliseconds"),
         "sid": sid,
         "eid": f"{sid}-event",
         "event": "page_view",

--- a/tests/test_receipt_mcp_section_tools.py
+++ b/tests/test_receipt_mcp_section_tools.py
@@ -1,10 +1,10 @@
-"""Tests for the ReceiptSection QA tools on both MCP server implementations.
+"""Cross-server contract tests for duplicated Receipt MCP implementations.
 
 The two servers (stdio `scripts/receipt_mcp_server.py` and the Lambda
 `infra/mcp_server_lambda/lambdas/receipt_mcp_server_server.py`) must expose the
 same tool surface. These tests import each module with a minimal fake `mcp`
-package (the real dependency is not installed in CI) and assert the four
-section tools are registered with valid input schemas and matching impls.
+package (the real dependency is not installed in CI) and assert the section
+and real-time analytics tools have matching schemas, dispatch, and impls.
 """
 
 import asyncio
@@ -33,6 +33,11 @@ EXPECTED_SECTION_TOOLS = {
     "update_section_status",
     "create_receipt_section",
     "delete_receipt_section",
+}
+
+EXPECTED_LIVE_ANALYTICS_TOOLS = {
+    "analytics_live",
+    "analytics_attribution",
 }
 
 
@@ -154,6 +159,155 @@ def test_both_servers_expose_identical_section_tool_shape():
         }
 
     assert shape(stdio) == shape(lam)
+
+
+@pytest.mark.parametrize("label", sorted(SERVER_FILES))
+def test_live_analytics_tools_present_with_valid_schema(label):
+    module = _load_module(label, SERVER_FILES[label])
+    tools = asyncio.run(module.list_tools())
+    by_name = {tool.name: tool for tool in tools}
+
+    missing = EXPECTED_LIVE_ANALYTICS_TOOLS - set(by_name)
+    assert not missing, f"missing live analytics tools in {label}: {missing}"
+
+    live_schema = by_name["analytics_live"].inputSchema
+    assert live_schema["type"] == "object"
+    assert live_schema["properties"]["minutes"]["default"] == 60
+    assert live_schema["properties"]["minutes"]["minimum"] == 1
+    assert live_schema["properties"]["minutes"]["maximum"] == 129600
+    assert live_schema["properties"]["humans_only"]["default"] is True
+
+    attribution_schema = by_name["analytics_attribution"].inputSchema
+    assert attribution_schema["type"] == "object"
+    assert {"campaign", "since", "humans_only"} <= set(
+        attribution_schema["properties"]
+    )
+    assert attribution_schema["anyOf"] == [
+        {"required": ["campaign"]},
+        {"required": ["since"]},
+    ]
+
+    for name in EXPECTED_LIVE_ANALYTICS_TOOLS:
+        assert callable(getattr(module, f"{name}_impl", None))
+
+
+def test_both_servers_share_identical_tool_and_impl_suffix():
+    """Only get_clients differs; tool schemas/routes/impls must stay in sync."""
+
+    def common_suffix(path):
+        source = path.read_text(encoding="utf-8")
+        marker = "@server.list_tools()"
+        assert marker in source
+        return source[source.index(marker):]
+
+    assert common_suffix(SERVER_FILES["stdio"]) == common_suffix(
+        SERVER_FILES["lambda"]
+    )
+
+
+@pytest.mark.parametrize("label", sorted(SERVER_FILES))
+def test_live_analytics_tools_are_dispatched(label):
+    source = SERVER_FILES[label].read_text(encoding="utf-8")
+    dispatch = source.split("async def call_tool", 1)[1].split(
+        "async def search_receipts_impl", 1
+    )[0]
+    assert 'elif name == "analytics_live"' in dispatch
+    assert 'elif name == "analytics_attribution"' in dispatch
+
+
+@pytest.mark.parametrize("label", sorted(SERVER_FILES))
+def test_live_human_filter_and_dynamo_normalization(label):
+    from decimal import Decimal
+
+    module = _load_module(label, SERVER_FILES[label])
+    assert module._analytics_live_is_human({}) is True
+    assert module._analytics_live_is_human({"is_bot": True}) is False
+    assert module._analytics_live_is_human({"is_warp": "true"}) is False
+    assert module._analytics_live_is_human({"is_hosting": Decimal("1")}) is False
+
+    normalized = module._analytics_normalize_dynamo(
+        {"whole": Decimal("42"), "fraction": Decimal("1.25")}
+    )
+    assert normalized == {"whole": 42, "fraction": 1.25}
+
+
+@pytest.mark.parametrize("label", sorted(SERVER_FILES))
+def test_attribution_keeps_full_session_after_campaign_landing(
+    label, monkeypatch
+):
+    module = _load_module(label, SERVER_FILES[label])
+    events = [
+        {
+            "dt": "2026-07-10",
+            "sk": "1783700000000#session-1#landing",
+            "epoch_ms": 1783700000000,
+            "ts": "2026-07-10T00:13:20.000Z",
+            "sid": "session-1",
+            "eid": "landing",
+            "event": "page_view",
+            "path": "/receipt",
+            "ref": "https://www.linkedin.com/messaging/thread/123",
+            "utm_source": "li",
+            "utm_medium": "dm",
+            "utm_campaign": "arthur-babylist",
+            "country": "US",
+            "region": "WA",
+            "city": "Vancouver",
+        },
+        {
+            "dt": "2026-07-10",
+            "sk": "1783700060000#session-1#next-page",
+            "epoch_ms": 1783700060000,
+            "ts": "2026-07-10T00:14:20.000Z",
+            "sid": "session-1",
+            "eid": "next-page",
+            "event": "page_view",
+            "path": "/resume",
+        },
+        {
+            "dt": "2026-07-10",
+            "sk": "1783700070000#hosting-session#blocked",
+            "epoch_ms": 1783700070000,
+            "ts": "2026-07-10T00:14:30.000Z",
+            "sid": "hosting-session",
+            "eid": "blocked",
+            "event": "page_view",
+            "path": "/receipt",
+            "utm_campaign": "arthur-babylist",
+            "is_hosting": True,
+        },
+    ]
+    monkeypatch.setattr(
+        module,
+        "_analytics_live_query",
+        lambda _start, _end: events,
+    )
+
+    result = asyncio.run(
+        module.analytics_attribution_impl(campaign="arthur-babylist")
+    )
+
+    assert result["session_count"] == 1
+    assert result["event_count"] == 2
+    session = result["sessions"][0]
+    assert session["sid"] == "session-1"
+    assert session["pages"] == ["/receipt", "/resume"]
+    assert session["utm_campaign"] == "arthur-babylist"
+    assert session["referrer_host"] == "www.linkedin.com"
+    assert session["referrer_path"] == "/messaging/thread/123"
+
+
+@pytest.mark.parametrize("label", sorted(SERVER_FILES))
+def test_live_query_uses_partition_queries_not_scan(label):
+    source = SERVER_FILES[label].read_text(encoding="utf-8")
+    query_source = source.split("def _analytics_live_query", 1)[1].split(
+        "def _analytics_live_flag", 1
+    )[0]
+    assert 'Key("dt").eq' in query_source
+    assert 'Key("sk").between' in query_source
+    assert '"ConsistentRead": True' in query_source
+    assert "table.query(" in query_source
+    assert "scan(" not in query_source
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_receipt_mcp_section_tools.py
+++ b/tests/test_receipt_mcp_section_tools.py
@@ -300,6 +300,89 @@ def test_attribution_keeps_full_session_after_campaign_landing(
 
 
 @pytest.mark.parametrize("label", sorted(SERVER_FILES))
+def test_attribution_starts_at_requested_campaign_segment(label, monkeypatch):
+    module = _load_module(label, SERVER_FILES[label])
+    events = []
+    for minute, eid, path, campaign in [
+        (1, "a-landing", "/first", "campaign-a"),
+        (2, "a-next", "/first-details", None),
+        (3, "b-landing", "/second", "campaign-b"),
+        (4, "b-next", "/second-details", None),
+    ]:
+        event = _live_test_event(
+            datetime(2026, 7, 10, 12, minute, tzinfo=timezone.utc),
+            "shared-session",
+            campaign,
+        )
+        event.update({"eid": eid, "path": path})
+        events.append(event)
+
+    monkeypatch.setattr(
+        module,
+        "_analytics_live_query",
+        lambda _start, _end: (events, False),
+    )
+
+    result = asyncio.run(
+        module.analytics_attribution_impl(
+            campaign="campaign-b", humans_only=False
+        )
+    )
+
+    assert result["event_count"] == 2
+    assert result["session_count"] == 1
+    session = result["sessions"][0]
+    assert session["pages"] == ["/second", "/second-details"]
+    assert session["utm_campaign"] == "campaign-b"
+    assert session["first_seen"] == events[2]["ts"]
+
+
+@pytest.mark.parametrize("label", sorted(SERVER_FILES))
+def test_attribution_keeps_repeated_campaign_segments_separate(
+    label, monkeypatch
+):
+    module = _load_module(label, SERVER_FILES[label])
+    events = []
+    for minute, eid, path, campaign in [
+        (1, "a-first", "/first", "campaign-a"),
+        (2, "a-first-next", "/first-details", None),
+        (3, "b-landing", "/second", "campaign-b"),
+        (4, "b-next", "/second-details", None),
+        (5, "a-return", "/third", "campaign-a"),
+        (6, "a-return-next", "/third-details", None),
+    ]:
+        event = _live_test_event(
+            datetime(2026, 7, 10, 12, minute, tzinfo=timezone.utc),
+            "shared-session",
+            campaign,
+        )
+        event.update({"eid": eid, "path": path})
+        events.append(event)
+
+    monkeypatch.setattr(
+        module,
+        "_analytics_live_query",
+        lambda _start, _end: (events, False),
+    )
+
+    result = asyncio.run(
+        module.analytics_attribution_impl(
+            campaign="campaign-a", humans_only=False
+        )
+    )
+
+    assert result["event_count"] == 4
+    assert result["session_count"] == 2
+    assert [session["pages"] for session in result["sessions"]] == [
+        ["/third", "/third-details"],
+        ["/first", "/first-details"],
+    ]
+    assert [
+        session["campaign_segment"] for session in result["sessions"]
+    ] == [2, 1]
+
+
+@pytest.mark.parametrize("label", sorted(SERVER_FILES))
 def test_live_query_uses_partition_queries_not_scan(label):
     source = SERVER_FILES[label].read_text(encoding="utf-8")
     query_source = source.split("def _analytics_live_query", 1)[1].split(
@@ -465,6 +548,43 @@ def test_live_query_reports_unread_older_date_at_exact_cap(label, monkeypatch):
     assert truncated is True
     assert queried_days == ["2026-07-10"]
     assert len(table.calls) == 1
+
+
+@pytest.mark.parametrize("label", sorted(SERVER_FILES))
+def test_live_query_deduplicates_retry_by_eid(label, monkeypatch):
+    module = _load_module(label, SERVER_FILES[label])
+    queried_days = []
+    newest = _live_test_event(
+        datetime(2026, 7, 10, 12, 3, tzinfo=timezone.utc),
+        "retried-session",
+    )
+    newest["path"] = "/newest-copy"
+    older = _live_test_event(
+        datetime(2026, 7, 10, 12, 2, tzinfo=timezone.utc),
+        "retried-session",
+    )
+    older["path"] = "/older-copy"
+    unique = _live_test_event(
+        datetime(2026, 7, 10, 12, 1, tzinfo=timezone.utc),
+        "unique-session",
+    )
+
+    class _FakeTable:
+        def query(self, **_kwargs):
+            return {"Items": [newest, older, unique]}
+
+    _install_fake_boto3_query(monkeypatch, _FakeTable(), queried_days)
+    start = datetime(2026, 7, 10, 12, tzinfo=timezone.utc)
+    end = datetime(2026, 7, 10, 13, tzinfo=timezone.utc)
+
+    events, truncated = module._analytics_live_query(start, end)
+
+    assert truncated is False
+    assert [event["path"] for event in events] == [
+        "/older-copy",
+        "/unique-session",
+    ]
+    assert queried_days == ["2026-07-10"]
 
 
 @pytest.mark.parametrize("label", sorted(SERVER_FILES))

--- a/tests/test_receipt_mcp_section_tools.py
+++ b/tests/test_receipt_mcp_section_tools.py
@@ -11,7 +11,7 @@ import asyncio
 import importlib.util
 import sys
 import types
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
@@ -37,6 +37,7 @@ EXPECTED_SECTION_TOOLS = {
 }
 
 EXPECTED_LIVE_ANALYTICS_TOOLS = {
+    "analytics_auto",
     "analytics_live",
     "analytics_attribution",
 }
@@ -171,6 +172,20 @@ def test_live_analytics_tools_present_with_valid_schema(label):
     missing = EXPECTED_LIVE_ANALYTICS_TOOLS - set(by_name)
     assert not missing, f"missing live analytics tools in {label}: {missing}"
 
+    auto_schema = by_name["analytics_auto"].inputSchema
+    assert auto_schema["type"] == "object"
+    assert {
+        "minutes",
+        "since",
+        "until",
+        "campaign",
+        "humans_only",
+        "limit",
+    } <= set(auto_schema["properties"])
+    assert auto_schema["properties"]["minutes"]["maximum"] == 525600
+    assert auto_schema["properties"]["humans_only"]["default"] is True
+    assert auto_schema["properties"]["limit"]["maximum"] == 250
+
     live_schema = by_name["analytics_live"].inputSchema
     assert live_schema["type"] == "object"
     assert live_schema["properties"]["minutes"]["default"] == 60
@@ -212,6 +227,7 @@ def test_live_analytics_tools_are_dispatched(label):
     dispatch = source.split("async def call_tool", 1)[1].split(
         "async def search_receipts_impl", 1
     )[0]
+    assert 'elif name == "analytics_auto"' in dispatch
     assert 'elif name == "analytics_live"' in dispatch
     assert 'elif name == "analytics_attribution"' in dispatch
 
@@ -451,6 +467,561 @@ def _live_test_event(ts, sid, campaign=None):
     if campaign is not None:
         event["utm_campaign"] = campaign
     return event
+
+
+@pytest.mark.parametrize("label", sorted(SERVER_FILES))
+def test_auto_window_is_exclusive_and_campaign_defaults_to_24h(label):
+    module = _load_module(label, SERVER_FILES[label])
+    now = datetime(2026, 7, 10, 12, tzinfo=timezone.utc)
+
+    start, end, current, minutes = module._analytics_auto_window(
+        campaign="launch", now=now
+    )
+
+    assert start == datetime(2026, 7, 9, 12, tzinfo=timezone.utc)
+    assert end == now
+    assert current == now
+    assert minutes == 24 * 60
+
+    with pytest.raises(ValueError, match="earlier than until"):
+        module._analytics_auto_window(
+            since="2026-07-10T12:00:00Z",
+            until="2026-07-10T12:00:00Z",
+            now=now,
+        )
+    with pytest.raises(ValueError, match="cannot exceed 365 days"):
+        module._analytics_auto_window(
+            since=(now - timedelta(days=366)).isoformat(),
+            until=now.isoformat(),
+            now=now,
+        )
+
+
+@pytest.mark.parametrize("label", sorted(SERVER_FILES))
+def test_latest_durable_event_uses_newest_glue_partition(label, monkeypatch):
+    module = _load_module(label, SERVER_FILES[label])
+    captured_sql = []
+
+    class _Paginator:
+        def paginate(self, **kwargs):
+            assert kwargs["DatabaseName"] == "portfolio_analytics"
+            assert kwargs["TableName"] == "web_events"
+            assert kwargs["ExcludeColumnSchema"] is True
+            return [
+                {
+                    "Partitions": [
+                        {"Values": ["2026-07-08"]},
+                        {"Values": ["not-a-date"]},
+                        {"Values": ["2026-07-10"]},
+                    ]
+                }
+            ]
+
+    class _Glue:
+        def get_paginator(self, operation):
+            assert operation == "get_partitions"
+            return _Paginator()
+
+    boto3_module = types.ModuleType("boto3")
+    boto3_module.client = lambda service, **_kwargs: (
+        _Glue() if service == "glue" else None
+    )
+    monkeypatch.setitem(sys.modules, "boto3", boto3_module)
+    monkeypatch.setattr(
+        module,
+        "_athena_run",
+        lambda sql, max_rows=5000: (
+            captured_sql.append((sql, max_rows))
+            or [{"latest": "2026-07-10T09:29:59.123000Z"}]
+        ),
+    )
+    module._analytics_watermark_cache = {"checked_at": 0.0, "value": None}
+
+    latest = module._analytics_latest_durable_event(force=True)
+
+    assert latest == datetime(
+        2026, 7, 10, 9, 29, 59, 123000, tzinfo=timezone.utc
+    )
+    assert "WHERE dt IN ('2026-07-08', '2026-07-10')" in captured_sql[0][0]
+    assert captured_sql[0][1] == 1
+
+
+@pytest.mark.parametrize("label", sorted(SERVER_FILES))
+def test_durable_query_normalizes_existing_feed_without_schema_changes(
+    label, monkeypatch
+):
+    module = _load_module(label, SERVER_FILES[label])
+    captured = {}
+
+    def _fake_athena(sql, max_rows=5000):
+        captured.update({"sql": sql, "max_rows": max_rows})
+        return [
+            {
+                "dt": "2026-07-08",
+                "request_id": "request-1",
+                "ts": "2026-07-08T12:00:00.000000Z",
+                "epoch_ms": "1783512000000",
+                "sid": "session-1",
+                "eid": "event-1",
+                "event": "page_view",
+                "path": "/receipt",
+                "utm_campaign": "launch",
+                "is_bot": "false",
+            }
+        ]
+
+    monkeypatch.setattr(module, "_athena_run", _fake_athena)
+    start = datetime(2026, 7, 8, 12, tzinfo=timezone.utc)
+    end = datetime(2026, 7, 9, 13, tzinfo=timezone.utc)
+
+    events, truncated = module._analytics_durable_query(start, end)
+
+    assert truncated is False
+    assert events[0]["epoch_ms"] == 1783512000000
+    assert events[0]["_source"] == "durable"
+    assert events[0]["sk"].endswith("#session-1#event-1")
+    sql = captured["sql"]
+    assert "dt BETWEEN '2026-07-08' AND '2026-07-09'" in sql
+    assert "ts_utc >= TIMESTAMP '2026-07-08 12:00:00.000000'" in sql
+    assert "ts_utc < TIMESTAMP '2026-07-09 13:00:00.000000'" in sql
+    assert "(?:^|&)utm_campaign=([^&]*)" in sql
+    assert "(?:^|&)ref=([^&]*)" in sql
+    assert "TRY(url_decode" in sql
+    assert "referrer AS ref" not in sql
+
+
+@pytest.mark.parametrize("label", sorted(SERVER_FILES))
+def test_auto_merge_prefers_durable_classification_and_keeps_live_geo(label):
+    module = _load_module(label, SERVER_FILES[label])
+    ts = datetime(2026, 7, 8, 12, tzinfo=timezone.utc)
+    durable = _live_test_event(ts, "shared")
+    durable.update(
+        {
+            "_source": "durable",
+            "_sources": ["durable"],
+            "is_bot": "true",
+            "country": "US",
+            "org": "Example Hosting",
+        }
+    )
+    live = _live_test_event(ts, "shared")
+    live.update(
+        {
+            "_source": "live",
+            "_sources": ["live"],
+            "is_bot": False,
+            "region": "WA",
+            "latitude": "45.6",
+            "utm_campaign": "launch",
+        }
+    )
+    no_eid_a = _live_test_event(ts, "no-eid-a")
+    no_eid_a.update({"eid": "", "_source": "durable"})
+    no_eid_b = _live_test_event(ts, "no-eid-b")
+    no_eid_b.update({"eid": "", "_source": "live"})
+
+    events, deduplicated, undeduplicable = module._analytics_auto_merge_events(
+        [live, no_eid_a, durable, no_eid_b]
+    )
+
+    merged = next(event for event in events if event.get("eid"))
+    assert deduplicated == 1
+    assert undeduplicable == 2
+    assert merged["_source"] == "mixed"
+    assert merged["_sources"] == ["durable", "live"]
+    assert merged["is_bot"] == "true"
+    assert merged["org"] == "Example Hosting"
+    assert merged["region"] == "WA"
+    assert merged["latitude"] == "45.6"
+    assert merged["utm_campaign"] == "launch"
+
+
+@pytest.mark.parametrize("label", sorted(SERVER_FILES))
+def test_auto_merge_keeps_live_order_for_same_second_campaign_events(label):
+    module = _load_module(label, SERVER_FILES[label])
+    second = datetime(2026, 7, 8, 12, tzinfo=timezone.utc)
+    landing_live_ts = second + timedelta(milliseconds=100)
+    follow_live_ts = second + timedelta(milliseconds=200)
+
+    durable_landing = _live_test_event(second, "shared", "launch")
+    durable_landing.update(
+        {
+            "eid": "z-landing",
+            "path": "/landing",
+            "_source": "durable",
+            "_sources": ["durable"],
+        }
+    )
+    durable_follow = _live_test_event(second, "shared")
+    durable_follow.update(
+        {
+            "eid": "a-follow",
+            "path": "/follow",
+            "_source": "durable",
+            "_sources": ["durable"],
+        }
+    )
+    live_landing = _live_test_event(landing_live_ts, "shared", "launch")
+    live_landing.update(
+        {
+            "eid": "z-landing",
+            "path": "/landing",
+            "_source": "live",
+            "_sources": ["live"],
+        }
+    )
+    live_follow = _live_test_event(follow_live_ts, "shared")
+    live_follow.update(
+        {
+            "eid": "a-follow",
+            "path": "/follow",
+            "_source": "live",
+            "_sources": ["live"],
+        }
+    )
+
+    merged, deduplicated, _ = module._analytics_auto_merge_events(
+        [durable_follow, durable_landing, live_follow, live_landing]
+    )
+    attributed = module._analytics_live_campaign_events(merged, "launch")
+    sessions = module._analytics_live_rollup(attributed)
+
+    assert deduplicated == 2
+    assert sessions[0]["pages"] == ["/landing", "/follow"]
+    assert sessions[0]["first_seen"] == live_landing["ts"]
+    assert sessions[0]["last_seen"] == live_follow["ts"]
+
+
+@pytest.mark.parametrize("label", sorted(SERVER_FILES))
+def test_analytics_auto_routes_recent_window_to_live_only(label, monkeypatch):
+    module = _load_module(label, SERVER_FILES[label])
+    now = datetime(2026, 7, 10, 12, tzinfo=timezone.utc)
+    before_end = _live_test_event(
+        datetime(2026, 7, 10, 11, 59, 59, tzinfo=timezone.utc),
+        "included",
+    )
+    at_end = _live_test_event(now, "excluded")
+    live_calls = []
+
+    monkeypatch.setattr(
+        module,
+        "_analytics_latest_durable_event",
+        lambda: datetime(2026, 7, 1, tzinfo=timezone.utc),
+    )
+    monkeypatch.setattr(
+        module,
+        "_analytics_durable_query",
+        lambda *_args: pytest.fail("durable query should not run"),
+    )
+    monkeypatch.setattr(
+        module,
+        "_analytics_live_query",
+        lambda start, end: (
+            live_calls.append((start, end)) or [before_end, at_end],
+            False,
+        ),
+    )
+
+    result = asyncio.run(
+        module.analytics_auto_impl(minutes=60, humans_only=False, _now=now)
+    )
+
+    assert result["source"] == "live"
+    assert result["partial"] is False
+    assert result["event_count"] == 1
+    assert result["sessions"][0]["sid"] == "included"
+    assert live_calls == [
+        (
+            datetime(2026, 7, 10, 11, tzinfo=timezone.utc),
+            now - timedelta(microseconds=1),
+        )
+    ]
+
+
+@pytest.mark.parametrize("label", sorted(SERVER_FILES))
+def test_analytics_auto_routes_old_window_to_durable_only(label, monkeypatch):
+    module = _load_module(label, SERVER_FILES[label])
+    now = datetime(2026, 7, 10, 12, tzinfo=timezone.utc)
+    event = _live_test_event(
+        datetime(2026, 6, 1, 12, tzinfo=timezone.utc), "historical"
+    )
+    event.update({"_source": "durable", "_sources": ["durable"]})
+    durable_calls = []
+
+    monkeypatch.setattr(
+        module,
+        "_analytics_latest_durable_event",
+        lambda: datetime(2026, 7, 9, 12, tzinfo=timezone.utc),
+    )
+    monkeypatch.setattr(
+        module,
+        "_analytics_durable_query",
+        lambda start, end: (
+            durable_calls.append((start, end)) or [event],
+            False,
+        ),
+    )
+    monkeypatch.setattr(
+        module,
+        "_analytics_live_query",
+        lambda *_args: pytest.fail("live query should not run"),
+    )
+
+    result = asyncio.run(
+        module.analytics_auto_impl(
+            since="2026-06-01T00:00:00Z",
+            until="2026-06-02T00:00:00Z",
+            humans_only=False,
+            _now=now,
+        )
+    )
+
+    assert result["source"] == "durable"
+    assert result["partial"] is False
+    assert result["event_count"] == 1
+    assert durable_calls == [
+        (
+            datetime(2026, 6, 1, tzinfo=timezone.utc),
+            datetime(2026, 6, 2, tzinfo=timezone.utc),
+        )
+    ]
+
+
+@pytest.mark.parametrize("label", sorted(SERVER_FILES))
+def test_analytics_auto_merges_overlap_and_campaign_across_sources(
+    label, monkeypatch
+):
+    module = _load_module(label, SERVER_FILES[label])
+    now = datetime(2026, 7, 10, 12, tzinfo=timezone.utc)
+    latest = datetime(2026, 7, 9, 12, tzinfo=timezone.utc)
+    landing_ts = datetime(2026, 7, 8, 12, tzinfo=timezone.utc)
+    durable_landing = _live_test_event(landing_ts, "shared", "launch")
+    durable_landing.update(
+        {
+            "eid": "shared-landing",
+            "path": "/landing",
+            "_source": "durable",
+            "_sources": ["durable"],
+            "is_bot": "false",
+            "org": "Residential ISP",
+        }
+    )
+    live_duplicate = dict(durable_landing)
+    live_duplicate.update(
+        {
+            "_source": "live",
+            "_sources": ["live"],
+            "region": "WA",
+            "is_bot": True,
+        }
+    )
+    follow = _live_test_event(
+        datetime(2026, 7, 9, 13, tzinfo=timezone.utc), "shared"
+    )
+    follow.update({"eid": "shared-follow", "path": "/follow"})
+    calls = {}
+
+    monkeypatch.setattr(module, "_analytics_latest_durable_event", lambda: latest)
+
+    def _durable(start, end):
+        calls["durable"] = (start, end)
+        return [durable_landing], False
+
+    def _live(start, end):
+        calls["live"] = (start, end)
+        return [live_duplicate, follow], False
+
+    monkeypatch.setattr(module, "_analytics_durable_query", _durable)
+    monkeypatch.setattr(module, "_analytics_live_query", _live)
+
+    result = asyncio.run(
+        module.analytics_auto_impl(
+            since="2026-07-01T00:00:00Z",
+            campaign="launch",
+            humans_only=True,
+            _now=now,
+        )
+    )
+
+    assert result["source"] == "mixed"
+    assert result["partial"] is False
+    assert result["deduplicated_event_count"] == 1
+    assert result["event_count"] == 2
+    assert result["source_event_counts"] == {
+        "durable": 0,
+        "live": 1,
+        "mixed": 1,
+    }
+    assert result["sessions"][0]["pages"] == ["/landing", "/follow"]
+    assert result["sessions"][0]["sources"] == ["durable", "live"]
+    assert result["sessions"][0]["org"] == "Residential ISP"
+    assert result["sessions"][0]["region"] == "WA"
+    assert calls["durable"] == (
+        datetime(2026, 7, 1, tzinfo=timezone.utc),
+        latest.replace(microsecond=1000),
+    )
+    assert calls["live"] == (
+        datetime(2026, 7, 5, 12, tzinfo=timezone.utc),
+        now - timedelta(microseconds=1),
+    )
+
+
+@pytest.mark.parametrize("label", sorted(SERVER_FILES))
+def test_analytics_auto_marks_live_fallback_partial_on_durable_error(
+    label, monkeypatch
+):
+    module = _load_module(label, SERVER_FILES[label])
+    now = datetime(2026, 7, 10, 12, tzinfo=timezone.utc)
+    start = datetime(2026, 7, 1, 12, tzinfo=timezone.utc)
+    live_calls = []
+    monkeypatch.setattr(
+        module,
+        "_analytics_latest_durable_event",
+        lambda: datetime(2026, 7, 9, 12, tzinfo=timezone.utc),
+    )
+    monkeypatch.setattr(
+        module,
+        "_analytics_durable_query",
+        lambda *_args: (_ for _ in ()).throw(RuntimeError("Athena down")),
+    )
+    monkeypatch.setattr(
+        module,
+        "_analytics_live_query",
+        lambda live_start, live_end: (
+            live_calls.append((live_start, live_end)) or [],
+            False,
+        ),
+    )
+
+    result = asyncio.run(
+        module.analytics_auto_impl(
+            since="2026-07-01T12:00:00Z",
+            humans_only=False,
+            _now=now,
+        )
+    )
+
+    assert result["source"] == "live"
+    assert result["partial"] is True
+    assert result["source_errors"] == {"durable": "Athena down"}
+    assert result["unqueried_ranges"] == []
+    assert live_calls == [(start, now - timedelta(microseconds=1))]
+
+
+@pytest.mark.parametrize("label", sorted(SERVER_FILES))
+def test_analytics_auto_reports_retention_gap_without_durable_data(
+    label, monkeypatch
+):
+    module = _load_module(label, SERVER_FILES[label])
+    now = datetime(2026, 7, 10, 12, tzinfo=timezone.utc)
+    start = now - timedelta(days=100)
+    live_floor = now - timedelta(days=90)
+    live_calls = []
+    monkeypatch.setattr(module, "_analytics_latest_durable_event", lambda: None)
+    monkeypatch.setattr(
+        module,
+        "_analytics_live_query",
+        lambda live_start, live_end: (
+            live_calls.append((live_start, live_end)) or [],
+            False,
+        ),
+    )
+
+    result = asyncio.run(
+        module.analytics_auto_impl(
+            since=start.isoformat(), humans_only=False, _now=now
+        )
+    )
+
+    assert result["source"] == "live"
+    assert result["partial"] is True
+    assert result["unqueried_ranges"] == [
+        {
+            "since": module._analytics_live_iso(start),
+            "until": module._analytics_live_iso(live_floor),
+        }
+    ]
+    assert live_calls == [
+        (live_floor, now - timedelta(microseconds=1))
+    ]
+
+
+@pytest.mark.parametrize("label", sorted(SERVER_FILES))
+def test_analytics_auto_caps_combined_sources_to_newest_events(
+    label, monkeypatch
+):
+    module = _load_module(label, SERVER_FILES[label])
+    monkeypatch.setattr(module, "ANALYTICS_LIVE_MAX_EVENTS", 2)
+    now = datetime(2026, 7, 10, 12, tzinfo=timezone.utc)
+    latest = datetime(2026, 7, 9, 12, tzinfo=timezone.utc)
+    durable_events = [
+        _live_test_event(
+            datetime(2026, 7, 8, 10, tzinfo=timezone.utc), "oldest"
+        ),
+        _live_test_event(
+            datetime(2026, 7, 9, 10, tzinfo=timezone.utc), "middle"
+        ),
+    ]
+    for event in durable_events:
+        event.update({"_source": "durable", "_sources": ["durable"]})
+    live_events = [
+        _live_test_event(
+            datetime(2026, 7, 9, 13, tzinfo=timezone.utc), "newer"
+        ),
+        _live_test_event(
+            datetime(2026, 7, 10, 11, tzinfo=timezone.utc), "newest"
+        ),
+    ]
+    monkeypatch.setattr(module, "_analytics_latest_durable_event", lambda: latest)
+    monkeypatch.setattr(
+        module,
+        "_analytics_durable_query",
+        lambda *_args: (durable_events, False),
+    )
+    monkeypatch.setattr(
+        module,
+        "_analytics_live_query",
+        lambda *_args: (live_events, False),
+    )
+
+    result = asyncio.run(
+        module.analytics_auto_impl(
+            since="2026-07-08T00:00:00Z",
+            humans_only=False,
+            _now=now,
+        )
+    )
+
+    assert result["truncated"] is True
+    assert result["event_count"] == 2
+    assert [session["sid"] for session in result["sessions"]] == [
+        "newest",
+        "newer",
+    ]
+
+
+@pytest.mark.parametrize("label", sorted(SERVER_FILES))
+def test_analytics_auto_returns_error_when_both_sources_fail(label, monkeypatch):
+    module = _load_module(label, SERVER_FILES[label])
+    now = datetime(2026, 7, 10, 12, tzinfo=timezone.utc)
+    monkeypatch.setattr(
+        module,
+        "_analytics_latest_durable_event",
+        lambda: (_ for _ in ()).throw(RuntimeError("watermark down")),
+    )
+    monkeypatch.setattr(
+        module,
+        "_analytics_live_query",
+        lambda *_args: (_ for _ in ()).throw(RuntimeError("Dynamo down")),
+    )
+
+    result = asyncio.run(module.analytics_auto_impl(_now=now))
+
+    assert result["error"] == "all analytics sources failed"
+    assert result["source_errors"] == {
+        "watermark": "watermark down",
+        "live": "Dynamo down",
+    }
 
 
 @pytest.mark.parametrize("label", sorted(SERVER_FILES))


### PR DESCRIPTION
Closes #1101

## Summary

- Adds a prod-only, on-demand `web_events_live` DynamoDB table with ~90-day TTL, UTC `dt`/`sk` keys, and a keys-only `sid-index`.
- Adds a request-time Python collector behind an AWS_IAM Lambda Function URL and CloudFront OAC. It persists UTM/referrer, viewer IP/UA, CloudFront edge geo/ASN, event metrics, and live bot/WARP/hosting flags.
- Routes the existing canonical `/analytics/pixel.txt` request through a Lambda-primary/S3-secondary CloudFront origin group with caching disabled and fast failover.
- Captures `utm_source`, `utm_medium`, `utm_campaign`, and a query/fragment-free referrer origin+path in the browser beacon.
- Adds `analytics_live` and `analytics_attribution` to both MCP server copies. Reads are strongly consistent, partition-bounded, retry-deduplicated, and capped with explicit `truncated` metadata.
- Adds `analytics` as the default MCP routing surface: it queries the older interval from durable Athena data, overlaps the repaired/tail interval with live DynamoDB, normalizes both event shapes, and deduplicates by `eid` before filtering and session rollup.
- Leaves the daily transform, its `cron(30 9 * * ? *)` schedule, `web_events`, `ip_geo`, and every existing `analytics_*` implementation unchanged.

## Design choices and deviations

- **Reused `/analytics/pixel.txt` instead of adding `/analytics/collect`.** Switching the configured browser path would stop the unchanged batch transform from recognizing beacon rows. One canonical request preserves the durable pipeline, and the origin group gives the existing static pixel a real fallback role.
- **Used an AWS_IAM Function URL plus CloudFront OAC.** The collector URL is not directly public; CloudFront receives narrowly scoped invoke permissions.
- **Extended the sort key to `<epoch_ms>#<sid>#<eid>`.** This prevents same-session events in the same millisecond from overwriting each other.
- **Reads DynamoDB directly.** This is the shortest request-to-query path; Athena remains the durable batch interface.
- **Names the unified MCP surface `analytics`.** Live-versus-durable routing is an implementation detail; `analytics_live` remains available only for explicit DynamoDB diagnostics, while the issue-required attribution tool remains focused on outreach queries.
- **Live hosting classification is edge-only.** CloudFront exposes ASN but not the batch `ip_geo` hosting/proxy/org signals. The collector uses the exact batch WARP and bot/scanner rules plus a conservative datacenter ASN set, with no request-time external lookup.
- Campaign-only attribution defaults to 24 hours. A tagged landing starts a segment that lasts until another tagged campaign; A→B→A returns two distinct A segments.
- **Reuses the existing durable feed.** `analytics` reconstructs referrer, UTM, and metric fields from `web_events.query_decoded`; it does not add another stream, change the batch schema, or copy DynamoDB rows into Parquet.
- The router uses the latest materialized durable event plus a four-day overlap matching the transform's trailing rebuild horizon. Durable classification/org data win on duplicates, while live millisecond ordering and edge-only fields are retained.

## Review fixes

- Deduplicates the fetch→Image retry path by `eid`, retaining the earliest row to match the durable transform.
- Prevents campaign changes inside one browser session from contaminating attribution timelines.
- Removes referrer query strings/fragments before beaconing and retains longer useful paths.
- Validates DynamoDB key IDs as bounded ASCII so Unicode input cannot exceed key byte limits.
- Re-raises persistence failures so Lambda errors are observable and CloudFront exercises the configured static-S3 200 fallback.
- Adds a 30-day collector log-group retention policy and reduces the currently unused GSI projection to keys only.
- Pins Pulumi CLI `3.251.0` and AWS provider SDK `7.36.0`; production deployment is manual-only, cannot be cancelled by validation pushes, and its smoke job is reachable.
- Adds a post-deploy latency/geo/fallback smoke checklist and rollback guidance.
- Adds source-aware MCP routing with UTC `[since, until)` semantics, queried/unqueried range metadata, partial-source degradation, guarded legacy URL decoding, a one-year interval cap, and combined event/session limits.
- Sanitizes caller-supplied referrers again at the collector boundary, preserves explicit UTC offsets in live timestamps, and tests the exact 512/256-character beacon limits.

## Validation

- `npm run lint` — pass, 0 errors (195 pre-existing warnings)
- `npm run type-check` — pass
- `npm run test:ci` — 50 suites / 300 tests passed
- `CI=true npm run build` — pass
- Hydration browser suite — 21 Chromium/Firefox/WebKit tests passed
- `python3.12 -m pytest tests -q` — 101 passed
- Collector tests — 8 passed
- Focused MCP/routing suite — 74 passed
- All Python files under `infra/` compile
- Both MCP analytics suffixes are byte-identical; workflow YAML parses; `git diff --check` passes
- Read-only production catalog probe — Glue watermark discovery and partition-pruned Athena normalization query passed, including `TRY(url_decode(...))`

Pinned-version production preview: https://app.pulumi.com/tnorlund/portfolio/prod/previews/8cb176d5-5327-4069-bb3e-d67d558beab1

The preview succeeded and includes the intended collector/table/OAC/CloudFront/IAM changes, but the full stack also reports unrelated drift (`12 create, 85 update, 3 replace`, including an unrelated Chroma service-discovery replacement). **Do not apply this preview as-is.** Reconcile or isolate that drift during the manual production review.

## Acceptance coverage

- [x] Request-time Lambda → DynamoDB write path and strongly consistent live reads are implemented and unit-tested.
- [x] CloudFront viewer geo headers are forwarded and persisted without an external lookup.
- [x] `utm_campaign` retrieval and multi-campaign attribution segments are tested.
- [x] Human-only live results exclude stored bot, WARP, and hosting flags; WARP/bot/scanner rules match the batch implementation.
- [x] Existing transform/table/tool code is unchanged and existing tests pass.
- [x] Collector failures propagate to the configured static S3 fallback; the browser path remains non-blocking.
- [x] `analytics` routes live-only, durable-only, and mixed windows; cross-source campaign boundaries, exclusive endpoints, deduplication, retention gaps, source failures, and scan/result caps are covered by tests.
- [ ] Verify a production row and `analytics_live()` result within ~5 seconds after the manual deployment.
- [ ] Verify production country/region/city availability with a normal non-AWS-network browser.
- [ ] Verify tagged production attribution and controlled collector-down fallback using the documented smoke checklist.

## Release decisions before deployment

1. **Remote MCP authentication/isolation:** the existing receipt MCP Function URL is anonymously invokable. Deploying the new read policy would expose live visitor telemetry, and `analytics` would make both live and durable visitor history directly accessible through that endpoint. Choose authentication or keep these tools local/isolated before production enablement.
2. **Exact hosting parity:** exact batch parity is impossible from CloudFront ASN alone because the batch also uses `ip_geo` hosting/proxy/org data. This PR documents and tests the edge-only conservative approximation required by the no-external-lookup constraint.
3. **Public beacon abuse controls:** reserved concurrency bounds simultaneous Lambda compute, not request/DynamoDB cost. Portfolio-scale cost is expected to be pennies, but a URI-scoped WAF rate rule remains optional hardening.

No deployment or `pulumi up` was performed. This PR remains draft until the release decisions and runtime smoke checks are resolved.
