### PR TITLE
Face-map v2: (merchant,section)->face priors from QA'd sections

### DIFF
--- a/tools/glyph-studio/maps/section_face_map_v2.json
+++ b/tools/glyph-studio/maps/section_face_map_v2.json
@@ -1,0 +1,14326 @@
+{
+  "version": 2,
+  "source": "receipt-sections-valid",
+  "table": "ReceiptsTable-dc5be22",
+  "families": [
+    [
+      "costco",
+      "innout",
+      "sprouts",
+      "wildfork"
+    ],
+    [
+      "cvs",
+      "vons"
+    ],
+    [
+      "homedepot"
+    ],
+    [
+      "target"
+    ],
+    [
+      "traderjoes"
+    ]
+  ],
+  "threshold": 0.6,
+  "map": [
+    {
+      "merchant": "101nwestlakeblvd",
+      "section": "footer",
+      "family": "101nwestlakeblvd",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "101nwestlakeblvd",
+      "section": "items",
+      "family": "101nwestlakeblvd",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 8,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "101nwestlakeblvd",
+      "section": "payment",
+      "family": "101nwestlakeblvd",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 9,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "14cannons",
+      "section": "address",
+      "family": "14cannons",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "14cannons",
+      "section": "footer",
+      "family": "14cannons",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "14cannons",
+      "section": "items",
+      "family": "14cannons",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "14cannons",
+      "section": "payment",
+      "family": "14cannons",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 11,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "14cannons",
+      "section": "storefront",
+      "family": "14cannons",
+      "face": {
+        "scale": 1.0,
+        "weight": "bold",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "14cannons",
+      "section": "summary",
+      "family": "14cannons",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "55fultonmarket",
+      "section": "footer",
+      "family": "55fultonmarket",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 9,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "55fultonmarket",
+      "section": "items",
+      "family": "55fultonmarket",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "55fultonmarket",
+      "section": "payment",
+      "family": "55fultonmarket",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 7,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "7eleven",
+      "section": "address",
+      "family": "7eleven",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 6,
+      "n_receipts": 2,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "7eleven",
+      "section": "footer",
+      "family": "7eleven",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "7eleven",
+      "section": "items",
+      "family": "7eleven",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "7eleven",
+      "section": "payment",
+      "family": "7eleven",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 14,
+      "n_receipts": 2,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "7eleven",
+      "section": "storefront",
+      "family": "7eleven",
+      "face": {
+        "scale": 1.0,
+        "weight": "bold",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "7eleven",
+      "section": "summary",
+      "family": "7eleven",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 5,
+      "n_receipts": 2,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "7eleven",
+      "section": "total_line",
+      "family": "7eleven",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "academyla",
+      "section": "address",
+      "family": "academyla",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "academyla",
+      "section": "payment",
+      "family": "academyla",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "academyla",
+      "section": "summary",
+      "family": "academyla",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "aimmailcenter",
+      "section": "address",
+      "family": "aimmailcenter",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 16,
+      "n_receipts": 4,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "aimmailcenter",
+      "section": "footer",
+      "family": "aimmailcenter",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 5,
+      "n_receipts": 4,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "aimmailcenter",
+      "section": "items",
+      "family": "aimmailcenter",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 6,
+      "n_receipts": 3,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "aimmailcenter",
+      "section": "payment",
+      "family": "aimmailcenter",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 2,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "aimmailcenter",
+      "section": "total_line",
+      "family": "aimmailcenter",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 3,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "aimmailcenter18",
+      "section": "address",
+      "family": "aimmailcenter18",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 16,
+      "n_receipts": 4,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "aimmailcenter18",
+      "section": "footer",
+      "family": "aimmailcenter18",
+      "face": {
+        "scale": 1.17,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 4,
+      "n_receipts": 4,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "aimmailcenter18",
+      "section": "items",
+      "family": "aimmailcenter18",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 2,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "aimmailcenter18",
+      "section": "payment",
+      "family": "aimmailcenter18",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 4,
+      "n_receipts": 4,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "aimmailcenter18",
+      "section": "summary",
+      "family": "aimmailcenter18",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 2,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "aimmailcenter18",
+      "section": "total_line",
+      "family": "aimmailcenter18",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 2,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "allanticovinaio",
+      "section": "address",
+      "family": "allanticovinaio",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 9,
+      "n_receipts": 3,
+      "low_confidence": false,
+      "reverse_video_rate": 0.3333
+    },
+    {
+      "merchant": "allanticovinaio",
+      "section": "items",
+      "family": "allanticovinaio",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 1.0
+    },
+    {
+      "merchant": "allanticovinaio",
+      "section": "payment",
+      "family": "allanticovinaio",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 28,
+      "n_receipts": 3,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "allanticovinaio",
+      "section": "storefront",
+      "family": "allanticovinaio",
+      "face": {
+        "scale": 1.38,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 5,
+      "n_receipts": 3,
+      "low_confidence": false,
+      "reverse_video_rate": 0.4
+    },
+    {
+      "merchant": "allanticovinaio",
+      "section": "summary",
+      "family": "allanticovinaio",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 2,
+      "low_confidence": false,
+      "reverse_video_rate": 0.3333
+    },
+    {
+      "merchant": "alohasunrisecafe",
+      "section": "address",
+      "family": "alohasunrisecafe",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "alohasunrisecafe",
+      "section": "footer",
+      "family": "alohasunrisecafe",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "alohasunrisecafe",
+      "section": "items",
+      "family": "alohasunrisecafe",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 4,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "alohasunrisecafe",
+      "section": "payment",
+      "family": "alohasunrisecafe",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 14,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "alohasunrisecafe",
+      "section": "summary",
+      "family": "alohasunrisecafe",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "amazonfresh",
+      "section": "address",
+      "family": "amazonfresh",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 12,
+      "n_receipts": 4,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "amazonfresh",
+      "section": "footer",
+      "family": "amazonfresh",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 14,
+      "n_receipts": 3,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "amazonfresh",
+      "section": "items",
+      "family": "amazonfresh",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 18,
+      "n_receipts": 3,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "amazonfresh",
+      "section": "payment",
+      "family": "amazonfresh",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 20,
+      "n_receipts": 4,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "amazonfresh",
+      "section": "summary",
+      "family": "amazonfresh",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 10,
+      "n_receipts": 2,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "amazonfresh",
+      "section": "survey",
+      "family": "amazonfresh",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 2,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "amazonfresh",
+      "section": "total_line",
+      "family": "amazonfresh",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 2,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "anawalttruevaluelumber",
+      "section": "address",
+      "family": "anawalttruevaluelumber",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "anawalttruevaluelumber",
+      "section": "footer",
+      "family": "anawalttruevaluelumber",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 4,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "anawalttruevaluelumber",
+      "section": "items",
+      "family": "anawalttruevaluelumber",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "anawalttruevaluelumber",
+      "section": "payment",
+      "family": "anawalttruevaluelumber",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 21,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "anawalttruevaluelumber",
+      "section": "summary",
+      "family": "anawalttruevaluelumber",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "arco47024",
+      "section": "address",
+      "family": "arco47024",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "arco47024",
+      "section": "barcode",
+      "family": "arco47024",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "arco47024",
+      "section": "footer",
+      "family": "arco47024",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 4,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "arco47024",
+      "section": "items",
+      "family": "arco47024",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "arco47024",
+      "section": "payment",
+      "family": "arco47024",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 14,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "arco47024",
+      "section": "storefront",
+      "family": "arco47024",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "arco47024",
+      "section": "summary",
+      "family": "arco47024",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "auberginekitchen",
+      "section": "address",
+      "family": "auberginekitchen",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "auberginekitchen",
+      "section": "items",
+      "family": "auberginekitchen",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "auberginekitchen",
+      "section": "payment",
+      "family": "auberginekitchen",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 12,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "auberginekitchen",
+      "section": "storefront",
+      "family": "auberginekitchen",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "auberginekitchen",
+      "section": "summary",
+      "family": "auberginekitchen",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "aycefortapache",
+      "section": "address",
+      "family": "aycefortapache",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 7,
+      "n_receipts": 2,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "aycefortapache",
+      "section": "footer",
+      "family": "aycefortapache",
+      "face": {
+        "scale": 1.5,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "aycefortapache",
+      "section": "items",
+      "family": "aycefortapache",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0417
+      },
+      "n_lines": 24,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.1667
+    },
+    {
+      "merchant": "aycefortapache",
+      "section": "payment",
+      "family": "aycefortapache",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0769
+      },
+      "n_lines": 13,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "aycesushi",
+      "section": "address",
+      "family": "aycesushi",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 4,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "aycesushi",
+      "section": "barcode",
+      "family": "aycesushi",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "aycesushi",
+      "section": "payment",
+      "family": "aycesushi",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 11,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "baciodilatte",
+      "section": "address",
+      "family": "baciodilatte",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 4,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "baciodilatte",
+      "section": "footer",
+      "family": "baciodilatte",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "baciodilatte",
+      "section": "items",
+      "family": "baciodilatte",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "baciodilatte",
+      "section": "payment",
+      "family": "baciodilatte",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 5,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "bestbuy1044",
+      "section": "address",
+      "family": "bestbuy1044",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "bestbuy1044",
+      "section": "footer",
+      "family": "bestbuy1044",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 5,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "bestbuy1044",
+      "section": "items",
+      "family": "bestbuy1044",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "bestbuy1044",
+      "section": "payment",
+      "family": "bestbuy1044",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 7,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "bestbuy1044",
+      "section": "summary",
+      "family": "bestbuy1044",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 5,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "bevmo",
+      "section": "address",
+      "family": "bevmo",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "bevmo",
+      "section": "barcode",
+      "family": "bevmo",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "bevmo",
+      "section": "footer",
+      "family": "bevmo",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "bevmo",
+      "section": "items",
+      "family": "bevmo",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "bevmo",
+      "section": "payment",
+      "family": "bevmo",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 4,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "bevmo",
+      "section": "summary",
+      "family": "bevmo",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "bevmo",
+      "section": "survey",
+      "family": "bevmo",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 5,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "bjswholesaleclub",
+      "section": "address",
+      "family": "bjswholesaleclub",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "bjswholesaleclub",
+      "section": "barcode",
+      "family": "bjswholesaleclub",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "bjswholesaleclub",
+      "section": "footer",
+      "family": "bjswholesaleclub",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 4,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "bjswholesaleclub",
+      "section": "items",
+      "family": "bjswholesaleclub",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 5,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "bjswholesaleclub",
+      "section": "payment",
+      "family": "bjswholesaleclub",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 6,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "bjswholesaleclub",
+      "section": "summary",
+      "family": "bjswholesaleclub",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 4,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "bjswholesaleclub",
+      "section": "total_line",
+      "family": "bjswholesaleclub",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "blacktapcraftburgersbeernashville",
+      "section": "address",
+      "family": "blacktapcraftburgersbeernashville",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 4,
+      "n_receipts": 2,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "blacktapcraftburgersbeernashville",
+      "section": "items",
+      "family": "blacktapcraftburgersbeernashville",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "blacktapcraftburgersbeernashville",
+      "section": "payment",
+      "family": "blacktapcraftburgersbeernashville",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 23,
+      "n_receipts": 2,
+      "low_confidence": false,
+      "reverse_video_rate": 0.087
+    },
+    {
+      "merchant": "blacktapcraftburgersbeernashville",
+      "section": "total_line",
+      "family": "blacktapcraftburgersbeernashville",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "bluebottlecoffee",
+      "section": "address",
+      "family": "bluebottlecoffee",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.375
+      },
+      "n_lines": 8,
+      "n_receipts": 3,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "bluebottlecoffee",
+      "section": "barcode",
+      "family": "bluebottlecoffee",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 5,
+      "n_receipts": 3,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "bluebottlecoffee",
+      "section": "footer",
+      "family": "bluebottlecoffee",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 6,
+      "n_receipts": 3,
+      "low_confidence": false,
+      "reverse_video_rate": 0.3333
+    },
+    {
+      "merchant": "bluebottlecoffee",
+      "section": "items",
+      "family": "bluebottlecoffee",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 6,
+      "n_receipts": 3,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "bluebottlecoffee",
+      "section": "payment",
+      "family": "bluebottlecoffee",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.25
+      },
+      "n_lines": 8,
+      "n_receipts": 3,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "bluebottlecoffee",
+      "section": "summary",
+      "family": "bluebottlecoffee",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 2,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "brentsdelicatessenrestaurant",
+      "section": "address",
+      "family": "brentsdelicatessenrestaurant",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 18,
+      "n_receipts": 5,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "brentsdelicatessenrestaurant",
+      "section": "barcode",
+      "family": "brentsdelicatessenrestaurant",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "brentsdelicatessenrestaurant",
+      "section": "footer",
+      "family": "brentsdelicatessenrestaurant",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 8,
+      "n_receipts": 4,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "brentsdelicatessenrestaurant",
+      "section": "items",
+      "family": "brentsdelicatessenrestaurant",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "brentsdelicatessenrestaurant",
+      "section": "payment",
+      "family": "brentsdelicatessenrestaurant",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 53,
+      "n_receipts": 4,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "brentsdelicatessenrestaurant",
+      "section": "storefront",
+      "family": "brentsdelicatessenrestaurant",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "brentsdelicatessenrestaurant",
+      "section": "total_line",
+      "family": "brentsdelicatessenrestaurant",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 2,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "bristolfarms",
+      "section": "address",
+      "family": "bristolfarms",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 6,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "bristolfarms",
+      "section": "footer",
+      "family": "bristolfarms",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "bristolfarms",
+      "section": "items",
+      "family": "bristolfarms",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "bristolfarms",
+      "section": "payment",
+      "family": "bristolfarms",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 11,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "bristolfarms",
+      "section": "storefront",
+      "family": "bristolfarms",
+      "face": {
+        "scale": 2.48,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "bristolfarms",
+      "section": "total_line",
+      "family": "bristolfarms",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "brooklynsbestpizzaandpasta",
+      "section": "address",
+      "family": "brooklynsbestpizzaandpasta",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "brooklynsbestpizzaandpasta",
+      "section": "items",
+      "family": "brooklynsbestpizzaandpasta",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "brooklynsbestpizzaandpasta",
+      "section": "payment",
+      "family": "brooklynsbestpizzaandpasta",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0769
+      },
+      "n_lines": 13,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "brooklynsbestpizzaandpasta",
+      "section": "storefront",
+      "family": "brooklynsbestpizzaandpasta",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 1.0
+    },
+    {
+      "merchant": "brooklynsbestpizzaandpasta",
+      "section": "summary",
+      "family": "brooklynsbestpizzaandpasta",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 1.0
+    },
+    {
+      "merchant": "califchickencafe",
+      "section": "address",
+      "family": "califchickencafe",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 4,
+      "n_receipts": 2,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "califchickencafe",
+      "section": "items",
+      "family": "califchickencafe",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 2,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "califchickencafe",
+      "section": "payment",
+      "family": "califchickencafe",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 21,
+      "n_receipts": 2,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "califchickencafe",
+      "section": "summary",
+      "family": "califchickencafe",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 2,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "californiapizzakitchen",
+      "section": "address",
+      "family": "californiapizzakitchen",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.25
+      },
+      "n_lines": 4,
+      "n_receipts": 2,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "californiapizzakitchen",
+      "section": "footer",
+      "family": "californiapizzakitchen",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.3333
+    },
+    {
+      "merchant": "californiapizzakitchen",
+      "section": "items",
+      "family": "californiapizzakitchen",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.1111
+      },
+      "n_lines": 9,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "californiapizzakitchen",
+      "section": "payment",
+      "family": "californiapizzakitchen",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 15,
+      "n_receipts": 2,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0667
+    },
+    {
+      "merchant": "californiapizzakitchen",
+      "section": "storefront",
+      "family": "californiapizzakitchen",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "californiapizzakitchen",
+      "section": "summary",
+      "family": "californiapizzakitchen",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "californiapizzakitchen",
+      "section": "total_line",
+      "family": "californiapizzakitchen",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "carouselcafeatplazahotelcasino",
+      "section": "address",
+      "family": "carouselcafeatplazahotelcasino",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "carouselcafeatplazahotelcasino",
+      "section": "payment",
+      "family": "carouselcafeatplazahotelcasino",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 10,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "carouselcafeatplazahotelcasino",
+      "section": "total_line",
+      "family": "carouselcafeatplazahotelcasino",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "chasebank",
+      "section": "address",
+      "family": "chasebank",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 9,
+      "n_receipts": 4,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "chasebank",
+      "section": "barcode",
+      "family": "chasebank",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "chasebank",
+      "section": "footer",
+      "family": "chasebank",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 19,
+      "n_receipts": 4,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "chasebank",
+      "section": "payment",
+      "family": "chasebank",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "chasebank",
+      "section": "storefront",
+      "family": "chasebank",
+      "face": {
+        "scale": 2.45,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 3,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "chasebank",
+      "section": "summary",
+      "family": "chasebank",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 2,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "chasebank",
+      "section": "survey",
+      "family": "chasebank",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "chickfilamoorparkroadfsu03175",
+      "section": "address",
+      "family": "chickfilamoorparkroadfsu03175",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "chickfilamoorparkroadfsu03175",
+      "section": "barcode",
+      "family": "chickfilamoorparkroadfsu03175",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "chickfilamoorparkroadfsu03175",
+      "section": "footer",
+      "family": "chickfilamoorparkroadfsu03175",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 4,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "chickfilamoorparkroadfsu03175",
+      "section": "items",
+      "family": "chickfilamoorparkroadfsu03175",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 9,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "chickfilamoorparkroadfsu03175",
+      "section": "payment",
+      "family": "chickfilamoorparkroadfsu03175",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 5,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "chickfilamoorparkroadfsu03175",
+      "section": "storefront",
+      "family": "chickfilamoorparkroadfsu03175",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "chickfilamoorparkroadfsu03175",
+      "section": "summary",
+      "family": "chickfilamoorparkroadfsu03175",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "chickfilawestlakevillagedio02508",
+      "section": "address",
+      "family": "chickfilawestlakevillagedio02508",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "chickfilawestlakevillagedio02508",
+      "section": "footer",
+      "family": "chickfilawestlakevillagedio02508",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "chickfilawestlakevillagedio02508",
+      "section": "items",
+      "family": "chickfilawestlakevillagedio02508",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 7,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "chickfilawestlakevillagedio02508",
+      "section": "payment",
+      "family": "chickfilawestlakevillagedio02508",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 7,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "chickfilawestlakevillagedio02508",
+      "section": "storefront",
+      "family": "chickfilawestlakevillagedio02508",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "chickfilawestlakevillagedio02508",
+      "section": "summary",
+      "family": "chickfilawestlakevillagedio02508",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "chipotlemexicangrill",
+      "section": "address",
+      "family": "chipotlemexicangrill",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "chipotlemexicangrill",
+      "section": "footer",
+      "family": "chipotlemexicangrill",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 1.0
+    },
+    {
+      "merchant": "chipotlemexicangrill",
+      "section": "items",
+      "family": "chipotlemexicangrill",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 4,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "chipotlemexicangrill",
+      "section": "payment",
+      "family": "chipotlemexicangrill",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "chipotlemexicangrill",
+      "section": "storefront",
+      "family": "chipotlemexicangrill",
+      "face": {
+        "scale": 2.19,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "chipotlemexicangrill",
+      "section": "survey",
+      "family": "chipotlemexicangrill",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.5
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "chipotlemexicangrill",
+      "section": "total_line",
+      "family": "chipotlemexicangrill",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "chubbyskewersauthenticchinesebbq",
+      "section": "address",
+      "family": "chubbyskewersauthenticchinesebbq",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.6667
+    },
+    {
+      "merchant": "chubbyskewersauthenticchinesebbq",
+      "section": "barcode",
+      "family": "chubbyskewersauthenticchinesebbq",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "chubbyskewersauthenticchinesebbq",
+      "section": "payment",
+      "family": "chubbyskewersauthenticchinesebbq",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "chubbyskewersauthenticchinesebbq",
+      "section": "storefront",
+      "family": "chubbyskewersauthenticchinesebbq",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "chubbyskewersauthenticchinesebbq",
+      "section": "summary",
+      "family": "chubbyskewersauthenticchinesebbq",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "cjsitalianicecustard",
+      "section": "address",
+      "family": "cjsitalianicecustard",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "cjsitalianicecustard",
+      "section": "items",
+      "family": "cjsitalianicecustard",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "cjsitalianicecustard",
+      "section": "payment",
+      "family": "cjsitalianicecustard",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "cjsitalianicecustard",
+      "section": "summary",
+      "family": "cjsitalianicecustard",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "corbinbowl",
+      "section": "address",
+      "family": "corbinbowl",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 4,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "corbinbowl",
+      "section": "payment",
+      "family": "corbinbowl",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 24,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "cornerbakerycafe207",
+      "section": "address",
+      "family": "cornerbakerycafe207",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "cornerbakerycafe207",
+      "section": "footer",
+      "family": "cornerbakerycafe207",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "cornerbakerycafe207",
+      "section": "items",
+      "family": "cornerbakerycafe207",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "cornerbakerycafe207",
+      "section": "payment",
+      "family": "cornerbakerycafe207",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "cornerbakerycafe207",
+      "section": "summary",
+      "family": "cornerbakerycafe207",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "cornerbakerycafe207",
+      "section": "total_line",
+      "family": "cornerbakerycafe207",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "costco",
+      "section": "address",
+      "family": "costco+innout+sprouts+wildfork",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 68,
+      "n_receipts": 21,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "costco",
+      "section": "barcode",
+      "family": "costco+innout+sprouts+wildfork",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 18,
+      "n_receipts": 18,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0556
+    },
+    {
+      "merchant": "costco",
+      "section": "footer",
+      "family": "costco+innout+sprouts+wildfork",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 44,
+      "n_receipts": 20,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "costco",
+      "section": "items",
+      "family": "costco+innout+sprouts+wildfork",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 107,
+      "n_receipts": 20,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "costco",
+      "section": "payment",
+      "family": "costco+innout+sprouts+wildfork",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 139,
+      "n_receipts": 22,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0144
+    },
+    {
+      "merchant": "costco",
+      "section": "storefront",
+      "family": "costco+innout+sprouts+wildfork",
+      "face": {
+        "scale": 1.505,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 56,
+      "n_receipts": 22,
+      "low_confidence": false,
+      "reverse_video_rate": 0.2321
+    },
+    {
+      "merchant": "costco",
+      "section": "summary",
+      "family": "costco+innout+sprouts+wildfork",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 48,
+      "n_receipts": 20,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0208
+    },
+    {
+      "merchant": "costco",
+      "section": "total_line",
+      "family": "costco+innout+sprouts+wildfork",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 25,
+      "n_receipts": 20,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "curryyacheongdamfoodhall",
+      "section": "address",
+      "family": "curryyacheongdamfoodhall",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "curryyacheongdamfoodhall",
+      "section": "footer",
+      "family": "curryyacheongdamfoodhall",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 1.0
+    },
+    {
+      "merchant": "curryyacheongdamfoodhall",
+      "section": "items",
+      "family": "curryyacheongdamfoodhall",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 4,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "curryyacheongdamfoodhall",
+      "section": "payment",
+      "family": "curryyacheongdamfoodhall",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 10,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.5
+    },
+    {
+      "merchant": "curryyacheongdamfoodhall",
+      "section": "summary",
+      "family": "curryyacheongdamfoodhall",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "curryyacheongdamfoodhall",
+      "section": "total_line",
+      "family": "curryyacheongdamfoodhall",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "cvs",
+      "section": "address",
+      "family": "cvs+vons",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 17,
+      "n_receipts": 10,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "cvs",
+      "section": "barcode",
+      "family": "cvs+vons",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 11,
+      "n_receipts": 8,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "cvs",
+      "section": "footer",
+      "family": "cvs+vons",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0164
+      },
+      "n_lines": 61,
+      "n_receipts": 9,
+      "low_confidence": false,
+      "reverse_video_rate": 0.1311
+    },
+    {
+      "merchant": "cvs",
+      "section": "items",
+      "family": "cvs+vons",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 12,
+      "n_receipts": 8,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "cvs",
+      "section": "payment",
+      "family": "cvs+vons",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.04
+      },
+      "n_lines": 50,
+      "n_receipts": 9,
+      "low_confidence": false,
+      "reverse_video_rate": 0.04
+    },
+    {
+      "merchant": "cvs",
+      "section": "storefront",
+      "family": "cvs+vons",
+      "face": {
+        "scale": 2.5,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 9,
+      "n_receipts": 9,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "cvs",
+      "section": "summary",
+      "family": "cvs+vons",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 13,
+      "n_receipts": 7,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "cvs",
+      "section": "total_line",
+      "family": "cvs+vons",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 9,
+      "n_receipts": 8,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "cvspharmacy",
+      "section": "address",
+      "family": "cvspharmacy",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "cvspharmacy",
+      "section": "barcode",
+      "family": "cvspharmacy",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "cvspharmacy",
+      "section": "footer",
+      "family": "cvspharmacy",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 7,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "cvspharmacy",
+      "section": "items",
+      "family": "cvspharmacy",
+      "face": {
+        "scale": 1.61,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "cvspharmacy",
+      "section": "payment",
+      "family": "cvspharmacy",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "cvspharmacy",
+      "section": "storefront",
+      "family": "cvspharmacy",
+      "face": {
+        "scale": 2.5,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "cvspharmacy",
+      "section": "survey",
+      "family": "cvspharmacy",
+      "face": {
+        "scale": 1.52,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "cvspharmacy",
+      "section": "total_line",
+      "family": "cvspharmacy",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "dickssportinggoods",
+      "section": "address",
+      "family": "dickssportinggoods",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "dickssportinggoods",
+      "section": "footer",
+      "family": "dickssportinggoods",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "dickssportinggoods",
+      "section": "items",
+      "family": "dickssportinggoods",
+      "face": {
+        "scale": 1.195,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "dickssportinggoods",
+      "section": "payment",
+      "family": "dickssportinggoods",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 5,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "diyhomecenter",
+      "section": "address",
+      "family": "diyhomecenter",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 15,
+      "n_receipts": 5,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "diyhomecenter",
+      "section": "barcode",
+      "family": "diyhomecenter",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "diyhomecenter",
+      "section": "footer",
+      "family": "diyhomecenter",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 7,
+      "n_receipts": 4,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "diyhomecenter",
+      "section": "items",
+      "family": "diyhomecenter",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 5,
+      "n_receipts": 3,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "diyhomecenter",
+      "section": "payment",
+      "family": "diyhomecenter",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 82,
+      "n_receipts": 5,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "diyhomecenter",
+      "section": "storefront",
+      "family": "diyhomecenter",
+      "face": {
+        "scale": 1.75,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 2,
+      "low_confidence": true,
+      "reverse_video_rate": 0.5
+    },
+    {
+      "merchant": "diyhomecenter",
+      "section": "summary",
+      "family": "diyhomecenter",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 4,
+      "n_receipts": 4,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "diyhomecenter",
+      "section": "survey",
+      "family": "diyhomecenter",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 4,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "diyhomecenter",
+      "section": "total_line",
+      "family": "diyhomecenter",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 2,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "dollartree",
+      "section": "address",
+      "family": "dollartree",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 21,
+      "n_receipts": 7,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "dollartree",
+      "section": "barcode",
+      "family": "dollartree",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 3,
+      "low_confidence": false,
+      "reverse_video_rate": 0.3333
+    },
+    {
+      "merchant": "dollartree",
+      "section": "footer",
+      "family": "dollartree",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 5,
+      "n_receipts": 4,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "dollartree",
+      "section": "items",
+      "family": "dollartree",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 34,
+      "n_receipts": 7,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "dollartree",
+      "section": "payment",
+      "family": "dollartree",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 23,
+      "n_receipts": 7,
+      "low_confidence": false,
+      "reverse_video_rate": 0.2174
+    },
+    {
+      "merchant": "dollartree",
+      "section": "storefront",
+      "family": "dollartree",
+      "face": {
+        "scale": 2.19,
+        "weight": "bold",
+        "underline_rate": 0.0
+      },
+      "n_lines": 5,
+      "n_receipts": 5,
+      "low_confidence": false,
+      "reverse_video_rate": 0.6
+    },
+    {
+      "merchant": "dollartree",
+      "section": "summary",
+      "family": "dollartree",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 9,
+      "n_receipts": 7,
+      "low_confidence": false,
+      "reverse_video_rate": 0.1111
+    },
+    {
+      "merchant": "dollartree",
+      "section": "survey",
+      "family": "dollartree",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 7,
+      "n_receipts": 7,
+      "low_confidence": false,
+      "reverse_video_rate": 0.1429
+    },
+    {
+      "merchant": "dollartree",
+      "section": "total_line",
+      "family": "dollartree",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "drlisawoolfmd",
+      "section": "address",
+      "family": "drlisawoolfmd",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "drlisawoolfmd",
+      "section": "footer",
+      "family": "drlisawoolfmd",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "drlisawoolfmd",
+      "section": "payment",
+      "family": "drlisawoolfmd",
+      "face": {
+        "scale": 1.69,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 8,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "drlisawoolfmd",
+      "section": "total_line",
+      "family": "drlisawoolfmd",
+      "face": {
+        "scale": 1.97,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "eastcoastbagelco",
+      "section": "address",
+      "family": "eastcoastbagelco",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 18,
+      "n_receipts": 6,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "eastcoastbagelco",
+      "section": "barcode",
+      "family": "eastcoastbagelco",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 8,
+      "n_receipts": 6,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "eastcoastbagelco",
+      "section": "footer",
+      "family": "eastcoastbagelco",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 9,
+      "n_receipts": 4,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "eastcoastbagelco",
+      "section": "items",
+      "family": "eastcoastbagelco",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 18,
+      "n_receipts": 5,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "eastcoastbagelco",
+      "section": "payment",
+      "family": "eastcoastbagelco",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 80,
+      "n_receipts": 6,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "eastcoastbagelco",
+      "section": "storefront",
+      "family": "eastcoastbagelco",
+      "face": {
+        "scale": 1.415,
+        "weight": "normal",
+        "underline_rate": 0.5
+      },
+      "n_lines": 2,
+      "n_receipts": 2,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "eastcoastbagelco",
+      "section": "summary",
+      "family": "eastcoastbagelco",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 5,
+      "n_receipts": 4,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "eastcoastbagelco",
+      "section": "total_line",
+      "family": "eastcoastbagelco",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "eastwood",
+      "section": "address",
+      "family": "eastwood",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 10,
+      "n_receipts": 4,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "eastwood",
+      "section": "payment",
+      "family": "eastwood",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 29,
+      "n_receipts": 4,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "eastwood",
+      "section": "storefront",
+      "family": "eastwood",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 2,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "eastwood",
+      "section": "summary",
+      "family": "eastwood",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 2,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "eastwood",
+      "section": "total_line",
+      "family": "eastwood",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "feychiropracticthousandoaksspine",
+      "section": "address",
+      "family": "feychiropracticthousandoaksspine",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 8,
+      "n_receipts": 3,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "feychiropracticthousandoaksspine",
+      "section": "payment",
+      "family": "feychiropracticthousandoaksspine",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 32,
+      "n_receipts": 3,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "five07coffeebar",
+      "section": "address",
+      "family": "five07coffeebar",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "five07coffeebar",
+      "section": "items",
+      "family": "five07coffeebar",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "five07coffeebar",
+      "section": "payment",
+      "family": "five07coffeebar",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 13,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "fivebelow",
+      "section": "address",
+      "family": "fivebelow",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 4,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "fivebelow",
+      "section": "barcode",
+      "family": "fivebelow",
+      "face": {
+        "scale": 1.0,
+        "weight": "bold",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "fivebelow",
+      "section": "footer",
+      "family": "fivebelow",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "fivebelow",
+      "section": "items",
+      "family": "fivebelow",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "fivebelow",
+      "section": "payment",
+      "family": "fivebelow",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 7,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "fivebelow",
+      "section": "summary",
+      "family": "fivebelow",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "floordecor",
+      "section": "address",
+      "family": "floordecor",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 6,
+      "n_receipts": 2,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "floordecor",
+      "section": "barcode",
+      "family": "floordecor",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 2,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "floordecor",
+      "section": "footer",
+      "family": "floordecor",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 2,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "floordecor",
+      "section": "items",
+      "family": "floordecor",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "floordecor",
+      "section": "payment",
+      "family": "floordecor",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 21,
+      "n_receipts": 2,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "floordecor",
+      "section": "total_line",
+      "family": "floordecor",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 2,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "formarestaurantcheesebarsantamonica",
+      "section": "address",
+      "family": "formarestaurantcheesebarsantamonica",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 4,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "formarestaurantcheesebarsantamonica",
+      "section": "items",
+      "family": "formarestaurantcheesebarsantamonica",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "formarestaurantcheesebarsantamonica",
+      "section": "summary",
+      "family": "formarestaurantcheesebarsantamonica",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "fremontstreetexperience",
+      "section": "barcode",
+      "family": "fremontstreetexperience",
+      "face": {
+        "scale": 1.96,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "fremontstreetexperience",
+      "section": "payment",
+      "family": "fremontstreetexperience",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "fremontstreetexperience",
+      "section": "storefront",
+      "family": "fremontstreetexperience",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 4,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "fridamexicancuisine",
+      "section": "address",
+      "family": "fridamexicancuisine",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "fridamexicancuisine",
+      "section": "items",
+      "family": "fridamexicancuisine",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "fridamexicancuisine",
+      "section": "storefront",
+      "family": "fridamexicancuisine",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "fridamexicancuisine",
+      "section": "summary",
+      "family": "fridamexicancuisine",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "fridamexicancuisine",
+      "section": "survey",
+      "family": "fridamexicancuisine",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "gelsonswestlakevillage",
+      "section": "address",
+      "family": "gelsonswestlakevillage",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 10,
+      "n_receipts": 3,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "gelsonswestlakevillage",
+      "section": "footer",
+      "family": "gelsonswestlakevillage",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 8,
+      "n_receipts": 2,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "gelsonswestlakevillage",
+      "section": "items",
+      "family": "gelsonswestlakevillage",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 22,
+      "n_receipts": 2,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "gelsonswestlakevillage",
+      "section": "payment",
+      "family": "gelsonswestlakevillage",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 37,
+      "n_receipts": 3,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "gelsonswestlakevillage",
+      "section": "section_header",
+      "family": "gelsonswestlakevillage",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "gelsonswestlakevillage",
+      "section": "storefront",
+      "family": "gelsonswestlakevillage",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 2,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "gelsonswestlakevillage",
+      "section": "summary",
+      "family": "gelsonswestlakevillage",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "gelsonswestlakevillage",
+      "section": "total_line",
+      "family": "gelsonswestlakevillage",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 2,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "generaladmissionlasvegas",
+      "section": "address",
+      "family": "generaladmissionlasvegas",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 11,
+      "n_receipts": 5,
+      "low_confidence": false,
+      "reverse_video_rate": 0.1818
+    },
+    {
+      "merchant": "generaladmissionlasvegas",
+      "section": "items",
+      "family": "generaladmissionlasvegas",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 5,
+      "n_receipts": 4,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "generaladmissionlasvegas",
+      "section": "payment",
+      "family": "generaladmissionlasvegas",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 57,
+      "n_receipts": 5,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0702
+    },
+    {
+      "merchant": "generaladmissionlasvegas",
+      "section": "storefront",
+      "family": "generaladmissionlasvegas",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 7,
+      "n_receipts": 4,
+      "low_confidence": false,
+      "reverse_video_rate": 0.2857
+    },
+    {
+      "merchant": "generaladmissionlasvegas",
+      "section": "summary",
+      "family": "generaladmissionlasvegas",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 2,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "generaladmissionlasvegas",
+      "section": "survey",
+      "family": "generaladmissionlasvegas",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 6,
+      "n_receipts": 4,
+      "low_confidence": false,
+      "reverse_video_rate": 0.3333
+    },
+    {
+      "merchant": "generaladmissionlasvegas",
+      "section": "total_line",
+      "family": "generaladmissionlasvegas",
+      "face": {
+        "scale": 2.41,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "gtpoke",
+      "section": "address",
+      "family": "gtpoke",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 4,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.25
+    },
+    {
+      "merchant": "gtpoke",
+      "section": "items",
+      "family": "gtpoke",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "gtpoke",
+      "section": "payment",
+      "family": "gtpoke",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.3333
+      },
+      "n_lines": 3,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "gtpoke",
+      "section": "summary",
+      "family": "gtpoke",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.5
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "hablamosescueladeespaolenmadrid",
+      "section": "address",
+      "family": "hablamosescueladeespaolenmadrid",
+      "face": {
+        "scale": 1.53,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "hablamosescueladeespaolenmadrid",
+      "section": "footer",
+      "family": "hablamosescueladeespaolenmadrid",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 7,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "hablamosescueladeespaolenmadrid",
+      "section": "payment",
+      "family": "hablamosescueladeespaolenmadrid",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.1111
+      },
+      "n_lines": 9,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "hablamosescueladeespaolenmadrid",
+      "section": "survey",
+      "family": "hablamosescueladeespaolenmadrid",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "handelsicecream",
+      "section": "address",
+      "family": "handelsicecream",
+      "face": {
+        "scale": 1.15,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "handelsicecream",
+      "section": "footer",
+      "family": "handelsicecream",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "handelsicecream",
+      "section": "payment",
+      "family": "handelsicecream",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 20,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "harborfreight",
+      "section": "address",
+      "family": "harborfreight",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 15,
+      "n_receipts": 3,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "harborfreight",
+      "section": "barcode",
+      "family": "harborfreight",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 2,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "harborfreight",
+      "section": "footer",
+      "family": "harborfreight",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 16,
+      "n_receipts": 3,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "harborfreight",
+      "section": "items",
+      "family": "harborfreight",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 14,
+      "n_receipts": 3,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "harborfreight",
+      "section": "payment",
+      "family": "harborfreight",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 39,
+      "n_receipts": 2,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "harborfreight",
+      "section": "storefront",
+      "family": "harborfreight",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 1.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "harborfreight",
+      "section": "summary",
+      "family": "harborfreight",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 2,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "hardwoodschatsworth",
+      "section": "address",
+      "family": "hardwoodschatsworth",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 4,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "hardwoodschatsworth",
+      "section": "payment",
+      "family": "hardwoodschatsworth",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 16,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "hardwoodschatsworth",
+      "section": "storefront",
+      "family": "hardwoodschatsworth",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "hedarysmediterranean",
+      "section": "address",
+      "family": "hedarysmediterranean",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 11,
+      "n_receipts": 5,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0909
+    },
+    {
+      "merchant": "hedarysmediterranean",
+      "section": "footer",
+      "family": "hedarysmediterranean",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 8,
+      "n_receipts": 4,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "hedarysmediterranean",
+      "section": "items",
+      "family": "hedarysmediterranean",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 9,
+      "n_receipts": 5,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "hedarysmediterranean",
+      "section": "payment",
+      "family": "hedarysmediterranean",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 24,
+      "n_receipts": 3,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "hedarysmediterranean",
+      "section": "storefront",
+      "family": "hedarysmediterranean",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 3,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "hedarysmediterranean",
+      "section": "summary",
+      "family": "hedarysmediterranean",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "hedarysmediterranean",
+      "section": "survey",
+      "family": "hedarysmediterranean",
+      "face": {
+        "scale": 1.3,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 1.0
+    },
+    {
+      "merchant": "hedarysmediterranean",
+      "section": "total_line",
+      "family": "hedarysmediterranean",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "hihocheeseburger",
+      "section": "address",
+      "family": "hihocheeseburger",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "hihocheeseburger",
+      "section": "footer",
+      "family": "hihocheeseburger",
+      "face": {
+        "scale": 1.36,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "hihocheeseburger",
+      "section": "items",
+      "family": "hihocheeseburger",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "hihocheeseburger",
+      "section": "payment",
+      "family": "hihocheeseburger",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "hihocheeseburgersantamonica",
+      "section": "address",
+      "family": "hihocheeseburgersantamonica",
+      "face": {
+        "scale": 1.175,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "hihocheeseburgersantamonica",
+      "section": "footer",
+      "family": "hihocheeseburgersantamonica",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "hihocheeseburgersantamonica",
+      "section": "items",
+      "family": "hihocheeseburgersantamonica",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 5,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "hihocheeseburgersantamonica",
+      "section": "payment",
+      "family": "hihocheeseburgersantamonica",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "hihocheeseburgersantamonica",
+      "section": "summary",
+      "family": "hihocheeseburgersantamonica",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "hollywoodimprov",
+      "section": "address",
+      "family": "hollywoodimprov",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 4,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "hollywoodimprov",
+      "section": "items",
+      "family": "hollywoodimprov",
+      "face": {
+        "scale": 1.235,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "hollywoodimprov",
+      "section": "payment",
+      "family": "hollywoodimprov",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 15,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "hollywoodimprov",
+      "section": "summary",
+      "family": "hollywoodimprov",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "homedepot",
+      "section": "address",
+      "family": "homedepot",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 9,
+      "n_receipts": 5,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "homedepot",
+      "section": "footer",
+      "family": "homedepot",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 10,
+      "n_receipts": 5,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "homedepot",
+      "section": "items",
+      "family": "homedepot",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 78,
+      "n_receipts": 5,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "homedepot",
+      "section": "payment",
+      "family": "homedepot",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 5,
+      "n_receipts": 3,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "homedepot",
+      "section": "summary",
+      "family": "homedepot",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 6,
+      "n_receipts": 3,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "homedepot",
+      "section": "total_line",
+      "family": "homedepot",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 2,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "honeypig",
+      "section": "footer",
+      "family": "honeypig",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 1.0
+    },
+    {
+      "merchant": "honeypig",
+      "section": "payment",
+      "family": "honeypig",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 10,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "honeypig",
+      "section": "total_line",
+      "family": "honeypig",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "hummuslali",
+      "section": "address",
+      "family": "hummuslali",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "hummuslali",
+      "section": "barcode",
+      "family": "hummuslali",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "hummuslali",
+      "section": "items",
+      "family": "hummuslali",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "hummuslali",
+      "section": "payment",
+      "family": "hummuslali",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 13,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "hummuslali",
+      "section": "storefront",
+      "family": "hummuslali",
+      "face": {
+        "scale": 1.0,
+        "weight": "bold",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "hummuslali",
+      "section": "summary",
+      "family": "hummuslali",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "humobarbecue",
+      "section": "address",
+      "family": "humobarbecue",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "humobarbecue",
+      "section": "barcode",
+      "family": "humobarbecue",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "humobarbecue",
+      "section": "payment",
+      "family": "humobarbecue",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 5,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "humobarbecue",
+      "section": "storefront",
+      "family": "humobarbecue",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "humobarbecue",
+      "section": "total_line",
+      "family": "humobarbecue",
+      "face": {
+        "scale": 1.61,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "ikesloveandsandwiches",
+      "section": "address",
+      "family": "ikesloveandsandwiches",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "ikesloveandsandwiches",
+      "section": "barcode",
+      "family": "ikesloveandsandwiches",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "ikesloveandsandwiches",
+      "section": "payment",
+      "family": "ikesloveandsandwiches",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 16,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "ikesloveandsandwiches",
+      "section": "storefront",
+      "family": "ikesloveandsandwiches",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "ikesloveandsandwiches",
+      "section": "summary",
+      "family": "ikesloveandsandwiches",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "imperialparking",
+      "section": "address",
+      "family": "imperialparking",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "imperialparking",
+      "section": "payment",
+      "family": "imperialparking",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "innout",
+      "section": "address",
+      "family": "costco+innout+sprouts+wildfork",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "innout",
+      "section": "footer",
+      "family": "costco+innout+sprouts+wildfork",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 17,
+      "n_receipts": 13,
+      "low_confidence": false,
+      "reverse_video_rate": 0.1765
+    },
+    {
+      "merchant": "innout",
+      "section": "items",
+      "family": "costco+innout+sprouts+wildfork",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 45,
+      "n_receipts": 14,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "innout",
+      "section": "payment",
+      "family": "costco+innout+sprouts+wildfork",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 63,
+      "n_receipts": 14,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0159
+    },
+    {
+      "merchant": "innout",
+      "section": "storefront",
+      "family": "costco+innout+sprouts+wildfork",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 13,
+      "n_receipts": 12,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "innout",
+      "section": "summary",
+      "family": "costco+innout+sprouts+wildfork",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 26,
+      "n_receipts": 14,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "innout",
+      "section": "total_line",
+      "family": "costco+innout+sprouts+wildfork",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 13,
+      "n_receipts": 10,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "italiadelibakery",
+      "section": "address",
+      "family": "italiadelibakery",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 16,
+      "n_receipts": 6,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "italiadelibakery",
+      "section": "footer",
+      "family": "italiadelibakery",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 11,
+      "n_receipts": 5,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "italiadelibakery",
+      "section": "items",
+      "family": "italiadelibakery",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 6,
+      "n_receipts": 4,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "italiadelibakery",
+      "section": "payment",
+      "family": "italiadelibakery",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 83,
+      "n_receipts": 6,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "italiadelibakery",
+      "section": "summary",
+      "family": "italiadelibakery",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "jamba",
+      "section": "address",
+      "family": "jamba",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 8,
+      "n_receipts": 2,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "jamba",
+      "section": "items",
+      "family": "jamba",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "jamba",
+      "section": "payment",
+      "family": "jamba",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 20,
+      "n_receipts": 2,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "jamba",
+      "section": "summary",
+      "family": "jamba",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "jasonsdeli216",
+      "section": "address",
+      "family": "jasonsdeli216",
+      "face": {
+        "scale": 1.175,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "jasonsdeli216",
+      "section": "items",
+      "family": "jasonsdeli216",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 7,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "jasonsdeli216",
+      "section": "survey",
+      "family": "jasonsdeli216",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "jetsetnews",
+      "section": "address",
+      "family": "jetsetnews",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 1.0
+    },
+    {
+      "merchant": "jetsetnews",
+      "section": "footer",
+      "family": "jetsetnews",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "jetsetnews",
+      "section": "items",
+      "family": "jetsetnews",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "jetsetnews",
+      "section": "storefront",
+      "family": "jetsetnews",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 1.0
+    },
+    {
+      "merchant": "jetsetnews",
+      "section": "summary",
+      "family": "jetsetnews",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "jinyaramenbarsantamonica",
+      "section": "footer",
+      "family": "jinyaramenbarsantamonica",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "jinyaramenbarsantamonica",
+      "section": "items",
+      "family": "jinyaramenbarsantamonica",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 5,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "joicaf",
+      "section": "address",
+      "family": "joicaf",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "joicaf",
+      "section": "barcode",
+      "family": "joicaf",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "joicaf",
+      "section": "footer",
+      "family": "joicaf",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "joicaf",
+      "section": "items",
+      "family": "joicaf",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "joicaf",
+      "section": "payment",
+      "family": "joicaf",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 4,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "joicaf",
+      "section": "storefront",
+      "family": "joicaf",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "joicaf",
+      "section": "summary",
+      "family": "joicaf",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "kansuiramenwestlakevillageca",
+      "section": "address",
+      "family": "kansuiramenwestlakevillageca",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 5,
+      "n_receipts": 2,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "kansuiramenwestlakevillageca",
+      "section": "barcode",
+      "family": "kansuiramenwestlakevillageca",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "kansuiramenwestlakevillageca",
+      "section": "items",
+      "family": "kansuiramenwestlakevillageca",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 9,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "kansuiramenwestlakevillageca",
+      "section": "payment",
+      "family": "kansuiramenwestlakevillageca",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "krusecompanybicycles",
+      "section": "address",
+      "family": "krusecompanybicycles",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 6,
+      "n_receipts": 2,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "krusecompanybicycles",
+      "section": "barcode",
+      "family": "krusecompanybicycles",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "krusecompanybicycles",
+      "section": "footer",
+      "family": "krusecompanybicycles",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 7,
+      "n_receipts": 2,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "krusecompanybicycles",
+      "section": "items",
+      "family": "krusecompanybicycles",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 5,
+      "n_receipts": 2,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "krusecompanybicycles",
+      "section": "payment",
+      "family": "krusecompanybicycles",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0909
+      },
+      "n_lines": 11,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "krusecompanybicycles",
+      "section": "storefront",
+      "family": "krusecompanybicycles",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "krusecompanybicycles",
+      "section": "summary",
+      "family": "krusecompanybicycles",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 4,
+      "n_receipts": 2,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "lalaland",
+      "section": "address",
+      "family": "lalaland",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 8,
+      "n_receipts": 4,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "lalaland",
+      "section": "barcode",
+      "family": "lalaland",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "lalaland",
+      "section": "footer",
+      "family": "lalaland",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 9,
+      "n_receipts": 4,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "lalaland",
+      "section": "items",
+      "family": "lalaland",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 14,
+      "n_receipts": 4,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "lalaland",
+      "section": "payment",
+      "family": "lalaland",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 48,
+      "n_receipts": 4,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "lalaland",
+      "section": "storefront",
+      "family": "lalaland",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 5,
+      "n_receipts": 4,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "lalaland",
+      "section": "summary",
+      "family": "lalaland",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 5,
+      "n_receipts": 3,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "lasvegassinusandentcenters",
+      "section": "address",
+      "family": "lasvegassinusandentcenters",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "lasvegassinusandentcenters",
+      "section": "footer",
+      "family": "lasvegassinusandentcenters",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "lasvegassinusandentcenters",
+      "section": "payment",
+      "family": "lasvegassinusandentcenters",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 21,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "laundryvalet",
+      "section": "address",
+      "family": "laundryvalet",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 6,
+      "n_receipts": 2,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "laundryvalet",
+      "section": "barcode",
+      "family": "laundryvalet",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "laundryvalet",
+      "section": "footer",
+      "family": "laundryvalet",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 5,
+      "n_receipts": 2,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "laundryvalet",
+      "section": "items",
+      "family": "laundryvalet",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 4,
+      "n_receipts": 2,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "laundryvalet",
+      "section": "payment",
+      "family": "laundryvalet",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 7,
+      "n_receipts": 2,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "laundryvalet",
+      "section": "section_header",
+      "family": "laundryvalet",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "laundryvalet",
+      "section": "summary",
+      "family": "laundryvalet",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 2,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "laundryvalet",
+      "section": "survey",
+      "family": "laundryvalet",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 9,
+      "n_receipts": 2,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "lazydogrestaurantbar",
+      "section": "footer",
+      "family": "lazydogrestaurantbar",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "lazydogrestaurantbar",
+      "section": "summary",
+      "family": "lazydogrestaurantbar",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "lazydogrestaurantbar",
+      "section": "total_line",
+      "family": "lazydogrestaurantbar",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "lepainquotidien",
+      "section": "address",
+      "family": "lepainquotidien",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 4,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "lepainquotidien",
+      "section": "footer",
+      "family": "lepainquotidien",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "lepainquotidien",
+      "section": "items",
+      "family": "lepainquotidien",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 6,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "lepainquotidien",
+      "section": "payment",
+      "family": "lepainquotidien",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 9,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "lepainquotidien",
+      "section": "storefront",
+      "family": "lepainquotidien",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "lepetitcafebakery",
+      "section": "address",
+      "family": "lepetitcafebakery",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "lepetitcafebakery",
+      "section": "payment",
+      "family": "lepetitcafebakery",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 9,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "lepetitcafebakery",
+      "section": "total_line",
+      "family": "lepetitcafebakery",
+      "face": {
+        "scale": 1.67,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "lexenhotelnorthhollywooduniversalstudios",
+      "section": "address",
+      "family": "lexenhotelnorthhollywooduniversalstudios",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "lexenhotelnorthhollywooduniversalstudios",
+      "section": "footer",
+      "family": "lexenhotelnorthhollywooduniversalstudios",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "lexenhotelnorthhollywooduniversalstudios",
+      "section": "items",
+      "family": "lexenhotelnorthhollywooduniversalstudios",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "lexenhotelnorthhollywooduniversalstudios",
+      "section": "summary",
+      "family": "lexenhotelnorthhollywooduniversalstudios",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "lexenhotelnorthhollywooduniversalstudios",
+      "section": "total_line",
+      "family": "lexenhotelnorthhollywooduniversalstudios",
+      "face": {
+        "scale": 1.0,
+        "weight": "bold",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "lifetime",
+      "section": "barcode",
+      "family": "lifetime",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "lifetime",
+      "section": "items",
+      "family": "lifetime",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "lifetime",
+      "section": "payment",
+      "family": "lifetime",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 8,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "lifetime",
+      "section": "storefront",
+      "family": "lifetime",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "lifetime",
+      "section": "summary",
+      "family": "lifetime",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 4,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "lifetime",
+      "section": "total_line",
+      "family": "lifetime",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "littlecalfscoopshop",
+      "section": "address",
+      "family": "littlecalfscoopshop",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 16,
+      "n_receipts": 4,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "littlecalfscoopshop",
+      "section": "barcode",
+      "family": "littlecalfscoopshop",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 2,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "littlecalfscoopshop",
+      "section": "payment",
+      "family": "littlecalfscoopshop",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 61,
+      "n_receipts": 4,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "littlecalfscoopshop",
+      "section": "storefront",
+      "family": "littlecalfscoopshop",
+      "face": {
+        "scale": 2.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 3,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "losagaves",
+      "section": "address",
+      "family": "losagaves",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "losagaves",
+      "section": "footer",
+      "family": "losagaves",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "losagaves",
+      "section": "items",
+      "family": "losagaves",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "losagaves",
+      "section": "payment",
+      "family": "losagaves",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 11,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "losagaves",
+      "section": "summary",
+      "family": "losagaves",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "losangelescountydepartmentofbeachesharbors",
+      "section": "address",
+      "family": "losangelescountydepartmentofbeachesharbors",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 5,
+      "n_receipts": 2,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "losangelescountydepartmentofbeachesharbors",
+      "section": "barcode",
+      "family": "losangelescountydepartmentofbeachesharbors",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "losangelescountydepartmentofbeachesharbors",
+      "section": "footer",
+      "family": "losangelescountydepartmentofbeachesharbors",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "losangelescountydepartmentofbeachesharbors",
+      "section": "items",
+      "family": "losangelescountydepartmentofbeachesharbors",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 2,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "losangelescountydepartmentofbeachesharbors",
+      "section": "payment",
+      "family": "losangelescountydepartmentofbeachesharbors",
+      "face": {
+        "scale": 1.45,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 2,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "loweshomeimprovement",
+      "section": "address",
+      "family": "loweshomeimprovement",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "loweshomeimprovement",
+      "section": "barcode",
+      "family": "loweshomeimprovement",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "loweshomeimprovement",
+      "section": "footer",
+      "family": "loweshomeimprovement",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 4,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "loweshomeimprovement",
+      "section": "items",
+      "family": "loweshomeimprovement",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 5,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "loweshomeimprovement",
+      "section": "payment",
+      "family": "loweshomeimprovement",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 9,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "loweshomeimprovement",
+      "section": "summary",
+      "family": "loweshomeimprovement",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "loweshomeimprovement",
+      "section": "survey",
+      "family": "loweshomeimprovement",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 6,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "lustigculvercity",
+      "section": "address",
+      "family": "lustigculvercity",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "lustigculvercity",
+      "section": "payment",
+      "family": "lustigculvercity",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 15,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "lustigculvercity",
+      "section": "summary",
+      "family": "lustigculvercity",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "mainstprovisions",
+      "section": "address",
+      "family": "mainstprovisions",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 5,
+      "n_receipts": 2,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "mainstprovisions",
+      "section": "items",
+      "family": "mainstprovisions",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "mainstprovisions",
+      "section": "payment",
+      "family": "mainstprovisions",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 9,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "mainstprovisions",
+      "section": "storefront",
+      "family": "mainstprovisions",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.5
+      },
+      "n_lines": 2,
+      "n_receipts": 2,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "mainstprovisions",
+      "section": "total_line",
+      "family": "mainstprovisions",
+      "face": {
+        "scale": 1.42,
+        "weight": "bold",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 2,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "marufukuramen",
+      "section": "address",
+      "family": "marufukuramen",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.5
+    },
+    {
+      "merchant": "marufukuramen",
+      "section": "items",
+      "family": "marufukuramen",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "mastrossteakhouse",
+      "section": "address",
+      "family": "mastrossteakhouse",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 6,
+      "n_receipts": 2,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "mastrossteakhouse",
+      "section": "footer",
+      "family": "mastrossteakhouse",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 2,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "mastrossteakhouse",
+      "section": "items",
+      "family": "mastrossteakhouse",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 11,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "mastrossteakhouse",
+      "section": "payment",
+      "family": "mastrossteakhouse",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 15,
+      "n_receipts": 2,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "mastrossteakhouse",
+      "section": "summary",
+      "family": "mastrossteakhouse",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "mastrossteakhouse",
+      "section": "total_line",
+      "family": "mastrossteakhouse",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "mendocinofarms",
+      "section": "address",
+      "family": "mendocinofarms",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 15,
+      "n_receipts": 5,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "mendocinofarms",
+      "section": "items",
+      "family": "mendocinofarms",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 17,
+      "n_receipts": 5,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "mendocinofarms",
+      "section": "payment",
+      "family": "mendocinofarms",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 55,
+      "n_receipts": 5,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "mendocinofarms",
+      "section": "storefront",
+      "family": "mendocinofarms",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 14,
+      "n_receipts": 5,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "mendocinofarms",
+      "section": "summary",
+      "family": "mendocinofarms",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 4,
+      "n_receipts": 4,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "methodofbeauty",
+      "section": "address",
+      "family": "methodofbeauty",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "methodofbeauty",
+      "section": "barcode",
+      "family": "methodofbeauty",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "methodofbeauty",
+      "section": "footer",
+      "family": "methodofbeauty",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "methodofbeauty",
+      "section": "payment",
+      "family": "methodofbeauty",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "methodofbeauty",
+      "section": "section_header",
+      "family": "methodofbeauty",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "methodofbeauty",
+      "section": "summary",
+      "family": "methodofbeauty",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "methodofbeauty",
+      "section": "survey",
+      "family": "methodofbeauty",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 4,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "methodofbeauty",
+      "section": "total_line",
+      "family": "methodofbeauty",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "michaels",
+      "section": "address",
+      "family": "michaels",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "michaels",
+      "section": "barcode",
+      "family": "michaels",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "michaels",
+      "section": "footer",
+      "family": "michaels",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 6,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "michaels",
+      "section": "items",
+      "family": "michaels",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "michaels",
+      "section": "payment",
+      "family": "michaels",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 5,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "michaels",
+      "section": "storefront",
+      "family": "michaels",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "michaels",
+      "section": "summary",
+      "family": "michaels",
+      "face": {
+        "scale": 1.0,
+        "weight": "bold",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "millenniummaxwellhouse",
+      "section": "address",
+      "family": "millenniummaxwellhouse",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 7,
+      "n_receipts": 3,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "millenniummaxwellhouse",
+      "section": "items",
+      "family": "millenniummaxwellhouse",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 5,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "millenniummaxwellhouse",
+      "section": "payment",
+      "family": "millenniummaxwellhouse",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 40,
+      "n_receipts": 2,
+      "low_confidence": false,
+      "reverse_video_rate": 0.075
+    },
+    {
+      "merchant": "millenniummaxwellhouse",
+      "section": "storefront",
+      "family": "millenniummaxwellhouse",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 4,
+      "n_receipts": 3,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "moodymarketprovisions",
+      "section": "address",
+      "family": "moodymarketprovisions",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 19,
+      "n_receipts": 6,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "moodymarketprovisions",
+      "section": "barcode",
+      "family": "moodymarketprovisions",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "moodymarketprovisions",
+      "section": "footer",
+      "family": "moodymarketprovisions",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "moodymarketprovisions",
+      "section": "items",
+      "family": "moodymarketprovisions",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 10,
+      "n_receipts": 4,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "moodymarketprovisions",
+      "section": "payment",
+      "family": "moodymarketprovisions",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 35,
+      "n_receipts": 5,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "moodymarketprovisions",
+      "section": "storefront",
+      "family": "moodymarketprovisions",
+      "face": {
+        "scale": 1.16,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 4,
+      "n_receipts": 2,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "moodymarketprovisions",
+      "section": "summary",
+      "family": "moodymarketprovisions",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 5,
+      "n_receipts": 3,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "moodymarketprovisions",
+      "section": "total_line",
+      "family": "moodymarketprovisions",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "moodyrooster",
+      "section": "address",
+      "family": "moodyrooster",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 10,
+      "n_receipts": 2,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "moodyrooster",
+      "section": "items",
+      "family": "moodyrooster",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 2,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "moodyrooster",
+      "section": "summary",
+      "family": "moodyrooster",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "moodyrooster",
+      "section": "total_line",
+      "family": "moodyrooster",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "mothershipcoffee",
+      "section": "address",
+      "family": "mothershipcoffee",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 6,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "mothershipcoffee",
+      "section": "footer",
+      "family": "mothershipcoffee",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.5
+    },
+    {
+      "merchant": "mothershipcoffee",
+      "section": "items",
+      "family": "mothershipcoffee",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.25
+      },
+      "n_lines": 4,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "mothershipcoffee",
+      "section": "payment",
+      "family": "mothershipcoffee",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.5
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "mothershipcoffee",
+      "section": "summary",
+      "family": "mothershipcoffee",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 1.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "mouthfuleatery",
+      "section": "address",
+      "family": "mouthfuleatery",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 13,
+      "n_receipts": 4,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "mouthfuleatery",
+      "section": "footer",
+      "family": "mouthfuleatery",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "mouthfuleatery",
+      "section": "items",
+      "family": "mouthfuleatery",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 7,
+      "n_receipts": 4,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "mouthfuleatery",
+      "section": "payment",
+      "family": "mouthfuleatery",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 39,
+      "n_receipts": 4,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "mouthfuleatery",
+      "section": "storefront",
+      "family": "mouthfuleatery",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 3,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "mouthfuleatery",
+      "section": "summary",
+      "family": "mouthfuleatery",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 2,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "neighborcarehomehealth",
+      "section": "address",
+      "family": "neighborcarehomehealth",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "neighborcarehomehealth",
+      "section": "barcode",
+      "family": "neighborcarehomehealth",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "neighborcarehomehealth",
+      "section": "items",
+      "family": "neighborcarehomehealth",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "neighborcarehomehealth",
+      "section": "payment",
+      "family": "neighborcarehomehealth",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 10,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "neighborcarehomehealth",
+      "section": "storefront",
+      "family": "neighborcarehomehealth",
+      "face": {
+        "scale": 2.08,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "neighborcarehomehealth",
+      "section": "summary",
+      "family": "neighborcarehomehealth",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "neighborly",
+      "section": "address",
+      "family": "neighborly",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 8,
+      "n_receipts": 4,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "neighborly",
+      "section": "barcode",
+      "family": "neighborly",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 3,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "neighborly",
+      "section": "footer",
+      "family": "neighborly",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 5,
+      "n_receipts": 3,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "neighborly",
+      "section": "items",
+      "family": "neighborly",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 7,
+      "n_receipts": 4,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "neighborly",
+      "section": "payment",
+      "family": "neighborly",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 32,
+      "n_receipts": 4,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "neighborly",
+      "section": "storefront",
+      "family": "neighborly",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 6,
+      "n_receipts": 3,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "neighborly",
+      "section": "total_line",
+      "family": "neighborly",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "nicoleskinstudio",
+      "section": "address",
+      "family": "nicoleskinstudio",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 12,
+      "n_receipts": 4,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "nicoleskinstudio",
+      "section": "payment",
+      "family": "nicoleskinstudio",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 44,
+      "n_receipts": 4,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "noahsnybagels",
+      "section": "address",
+      "family": "noahsnybagels",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "noahsnybagels",
+      "section": "footer",
+      "family": "noahsnybagels",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 5,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "noahsnybagels",
+      "section": "items",
+      "family": "noahsnybagels",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 5,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "noahsnybagels",
+      "section": "summary",
+      "family": "noahsnybagels",
+      "face": {
+        "scale": 1.0,
+        "weight": "bold",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "noahsnybagels",
+      "section": "total_line",
+      "family": "noahsnybagels",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "nordstrom",
+      "section": "address",
+      "family": "nordstrom",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 10,
+      "n_receipts": 2,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "nordstrom",
+      "section": "footer",
+      "family": "nordstrom",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 7,
+      "n_receipts": 2,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "nordstrom",
+      "section": "items",
+      "family": "nordstrom",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 4,
+      "n_receipts": 2,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "nordstrom",
+      "section": "storefront",
+      "family": "nordstrom",
+      "face": {
+        "scale": 2.27,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "nordstrom",
+      "section": "summary",
+      "family": "nordstrom",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 2,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "nordstrom",
+      "section": "survey",
+      "family": "nordstrom",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 2,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "nordstrom",
+      "section": "total_line",
+      "family": "nordstrom",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 2,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "nouveauteavietnamesebakerycaf",
+      "section": "address",
+      "family": "nouveauteavietnamesebakerycaf",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "nouveauteavietnamesebakerycaf",
+      "section": "payment",
+      "family": "nouveauteavietnamesebakerycaf",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 9,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "nouveauteavietnamesebakerycaf",
+      "section": "storefront",
+      "family": "nouveauteavietnamesebakerycaf",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "oceanperinatalmedicalgroupinc",
+      "section": "address",
+      "family": "oceanperinatalmedicalgroupinc",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "oceanperinatalmedicalgroupinc",
+      "section": "payment",
+      "family": "oceanperinatalmedicalgroupinc",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 10,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "oceanperinatalmedicalgroupinc",
+      "section": "total_line",
+      "family": "oceanperinatalmedicalgroupinc",
+      "face": {
+        "scale": 1.49,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "omahabar",
+      "section": "barcode",
+      "family": "omahabar",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "omahabar",
+      "section": "payment",
+      "family": "omahabar",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.2143
+      },
+      "n_lines": 14,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.2143
+    },
+    {
+      "merchant": "omahabar",
+      "section": "summary",
+      "family": "omahabar",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "pachipachi",
+      "section": "address",
+      "family": "pachipachi",
+      "face": {
+        "scale": 1.525,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 4,
+      "n_receipts": 2,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "pachipachi",
+      "section": "barcode",
+      "family": "pachipachi",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 1.0
+    },
+    {
+      "merchant": "pachipachi",
+      "section": "footer",
+      "family": "pachipachi",
+      "face": {
+        "scale": 1.33,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "pachipachi",
+      "section": "items",
+      "family": "pachipachi",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "pachipachi",
+      "section": "payment",
+      "family": "pachipachi",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.125
+      },
+      "n_lines": 16,
+      "n_receipts": 2,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "pastasisters",
+      "section": "address",
+      "family": "pastasisters",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "pastasisters",
+      "section": "footer",
+      "family": "pastasisters",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "pastasisters",
+      "section": "items",
+      "family": "pastasisters",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 5,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "pastasisters",
+      "section": "storefront",
+      "family": "pastasisters",
+      "face": {
+        "scale": 2.5,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "pastasisters",
+      "section": "summary",
+      "family": "pastasisters",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "pastasisters",
+      "section": "survey",
+      "family": "pastasisters",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "pastasisters",
+      "section": "total_line",
+      "family": "pastasisters",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "pinchestacosthegramercy",
+      "section": "address",
+      "family": "pinchestacosthegramercy",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 14,
+      "n_receipts": 3,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "pinchestacosthegramercy",
+      "section": "barcode",
+      "family": "pinchestacosthegramercy",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 4,
+      "n_receipts": 3,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "pinchestacosthegramercy",
+      "section": "items",
+      "family": "pinchestacosthegramercy",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 5,
+      "n_receipts": 2,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "pinchestacosthegramercy",
+      "section": "payment",
+      "family": "pinchestacosthegramercy",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 24,
+      "n_receipts": 3,
+      "low_confidence": false,
+      "reverse_video_rate": 0.375
+    },
+    {
+      "merchant": "pinchestacosthegramercy",
+      "section": "summary",
+      "family": "pinchestacosthegramercy",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 2,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "pinchestacosthegramercy",
+      "section": "total_line",
+      "family": "pinchestacosthegramercy",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 2,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "pitfirepizza",
+      "section": "address",
+      "family": "pitfirepizza",
+      "face": {
+        "scale": 1.39,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "pitfirepizza",
+      "section": "footer",
+      "family": "pitfirepizza",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "pitfirepizza",
+      "section": "payment",
+      "family": "pitfirepizza",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 9,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "pitfirepizza",
+      "section": "storefront",
+      "family": "pitfirepizza",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "pointdume",
+      "section": "address",
+      "family": "pointdume",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "pointdume",
+      "section": "barcode",
+      "family": "pointdume",
+      "face": {
+        "scale": 1.98,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "pointdume",
+      "section": "footer",
+      "family": "pointdume",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "pointdume",
+      "section": "payment",
+      "family": "pointdume",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "pokemarket",
+      "section": "address",
+      "family": "pokemarket",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "pokemarket",
+      "section": "items",
+      "family": "pokemarket",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "pokemarket",
+      "section": "payment",
+      "family": "pokemarket",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 11,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0909
+    },
+    {
+      "merchant": "pokemarket",
+      "section": "storefront",
+      "family": "pokemarket",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 4,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "pressedjuicery",
+      "section": "address",
+      "family": "pressedjuicery",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 4,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "pressedjuicery",
+      "section": "items",
+      "family": "pressedjuicery",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "proteinhousebluediamond",
+      "section": "address",
+      "family": "proteinhousebluediamond",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 4,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "proteinhousebluediamond",
+      "section": "footer",
+      "family": "proteinhousebluediamond",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "proteinhousebluediamond",
+      "section": "items",
+      "family": "proteinhousebluediamond",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 5,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "rachelskitchen",
+      "section": "address",
+      "family": "rachelskitchen",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "rachelskitchen",
+      "section": "footer",
+      "family": "rachelskitchen",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "rachelskitchen",
+      "section": "items",
+      "family": "rachelskitchen",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "rachelskitchen",
+      "section": "payment",
+      "family": "rachelskitchen",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 12,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "rachelskitchenatthedistrict",
+      "section": "address",
+      "family": "rachelskitchenatthedistrict",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "rachelskitchenatthedistrict",
+      "section": "footer",
+      "family": "rachelskitchenatthedistrict",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "rachelskitchenatthedistrict",
+      "section": "items",
+      "family": "rachelskitchenatthedistrict",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "rachelskitchenatthedistrict",
+      "section": "payment",
+      "family": "rachelskitchenatthedistrict",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0833
+      },
+      "n_lines": 12,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0833
+    },
+    {
+      "merchant": "raisingcaneschickenfingers",
+      "section": "address",
+      "family": "raisingcaneschickenfingers",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "raisingcaneschickenfingers",
+      "section": "footer",
+      "family": "raisingcaneschickenfingers",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "raisingcaneschickenfingers",
+      "section": "items",
+      "family": "raisingcaneschickenfingers",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "raisingcaneschickenfingers",
+      "section": "payment",
+      "family": "raisingcaneschickenfingers",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "ralphs",
+      "section": "address",
+      "family": "ralphs",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "ralphs",
+      "section": "footer",
+      "family": "ralphs",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "ralphs",
+      "section": "payment",
+      "family": "ralphs",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 7,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "ralphs",
+      "section": "storefront",
+      "family": "ralphs",
+      "face": {
+        "scale": 1.645,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "ralphs",
+      "section": "summary",
+      "family": "ralphs",
+      "face": {
+        "scale": 1.435,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 4,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "ralphsfreshfare",
+      "section": "address",
+      "family": "ralphsfreshfare",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 4,
+      "n_receipts": 2,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "ralphsfreshfare",
+      "section": "footer",
+      "family": "ralphsfreshfare",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 9,
+      "n_receipts": 2,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "ralphsfreshfare",
+      "section": "items",
+      "family": "ralphsfreshfare",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 7,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "ralphsfreshfare",
+      "section": "payment",
+      "family": "ralphsfreshfare",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 6,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "ralphsfreshfare",
+      "section": "storefront",
+      "family": "ralphsfreshfare",
+      "face": {
+        "scale": 1.655,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 4,
+      "n_receipts": 2,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "ralphsfreshfare",
+      "section": "total_line",
+      "family": "ralphsfreshfare",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "ranchhandbbq",
+      "section": "footer",
+      "family": "ranchhandbbq",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 4,
+      "n_receipts": 3,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "ranchhandbbq",
+      "section": "items",
+      "family": "ranchhandbbq",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 4,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "ranchhandbbq",
+      "section": "payment",
+      "family": "ranchhandbbq",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 29,
+      "n_receipts": 3,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "ranchhandbbq",
+      "section": "section_header",
+      "family": "ranchhandbbq",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "ranchhandbbq",
+      "section": "storefront",
+      "family": "ranchhandbbq",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "ranchhandbbq",
+      "section": "summary",
+      "family": "ranchhandbbq",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "ranchhandbbq",
+      "section": "survey",
+      "family": "ranchhandbbq",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "ranchhandbbq",
+      "section": "total_line",
+      "family": "ranchhandbbq",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "regalsunsetstation",
+      "section": "address",
+      "family": "regalsunsetstation",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "regalsunsetstation",
+      "section": "footer",
+      "family": "regalsunsetstation",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 4,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.5
+    },
+    {
+      "merchant": "regalsunsetstation",
+      "section": "items",
+      "family": "regalsunsetstation",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "regalsunsetstation",
+      "section": "summary",
+      "family": "regalsunsetstation",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "regalsunsetstation",
+      "section": "survey",
+      "family": "regalsunsetstation",
+      "face": {
+        "scale": 1.15,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "risedispensaries",
+      "section": "address",
+      "family": "risedispensaries",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "risedispensaries",
+      "section": "barcode",
+      "family": "risedispensaries",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "risedispensaries",
+      "section": "items",
+      "family": "risedispensaries",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.3333
+      },
+      "n_lines": 3,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "risedispensaries",
+      "section": "storefront",
+      "family": "risedispensaries",
+      "face": {
+        "scale": 1.62,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "risedispensaries",
+      "section": "summary",
+      "family": "risedispensaries",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 1.0
+    },
+    {
+      "merchant": "risedurango",
+      "section": "address",
+      "family": "risedurango",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "risedurango",
+      "section": "payment",
+      "family": "risedurango",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "risedurango",
+      "section": "summary",
+      "family": "risedurango",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "risehenderson",
+      "section": "address",
+      "family": "risehenderson",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 5,
+      "n_receipts": 2,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "risehenderson",
+      "section": "barcode",
+      "family": "risehenderson",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 8,
+      "n_receipts": 2,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "risehenderson",
+      "section": "footer",
+      "family": "risehenderson",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.3333
+      },
+      "n_lines": 3,
+      "n_receipts": 2,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "risehenderson",
+      "section": "items",
+      "family": "risehenderson",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 12,
+      "n_receipts": 2,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "risehenderson",
+      "section": "storefront",
+      "family": "risehenderson",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "risehenderson",
+      "section": "summary",
+      "family": "risehenderson",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "risehenderson",
+      "section": "survey",
+      "family": "risehenderson",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "riselasvegasdurango",
+      "section": "address",
+      "family": "riselasvegasdurango",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "riselasvegasdurango",
+      "section": "footer",
+      "family": "riselasvegasdurango",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 4,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "riselasvegasdurango",
+      "section": "items",
+      "family": "riselasvegasdurango",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "riselasvegasdurango",
+      "section": "storefront",
+      "family": "riselasvegasdurango",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "riselasvegasdurango",
+      "section": "summary",
+      "family": "riselasvegasdurango",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "riselasvegasdurengo",
+      "section": "address",
+      "family": "riselasvegasdurengo",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "riselasvegasdurengo",
+      "section": "barcode",
+      "family": "riselasvegasdurengo",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "riselasvegasdurengo",
+      "section": "footer",
+      "family": "riselasvegasdurengo",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "riselasvegasdurengo",
+      "section": "items",
+      "family": "riselasvegasdurengo",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "riselasvegasdurengo",
+      "section": "storefront",
+      "family": "riselasvegasdurengo",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "rivervalleysprouts",
+      "section": "address",
+      "family": "rivervalleysprouts",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "rivervalleysprouts",
+      "section": "barcode",
+      "family": "rivervalleysprouts",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "rivervalleysprouts",
+      "section": "footer",
+      "family": "rivervalleysprouts",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 7,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "rivervalleysprouts",
+      "section": "items",
+      "family": "rivervalleysprouts",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "rivervalleysprouts",
+      "section": "payment",
+      "family": "rivervalleysprouts",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 17,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "rivervalleysprouts",
+      "section": "storefront",
+      "family": "rivervalleysprouts",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 5,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "rivervalleysprouts",
+      "section": "survey",
+      "family": "rivervalleysprouts",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 4,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "rivervalleysprouts",
+      "section": "total_line",
+      "family": "rivervalleysprouts",
+      "face": {
+        "scale": 1.155,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "roastandricekitchen",
+      "section": "address",
+      "family": "roastandricekitchen",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "roastandricekitchen",
+      "section": "payment",
+      "family": "roastandricekitchen",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 19,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "roastandricekitchen",
+      "section": "storefront",
+      "family": "roastandricekitchen",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "roastriceasianfusion",
+      "section": "address",
+      "family": "roastriceasianfusion",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 23,
+      "n_receipts": 7,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "roastriceasianfusion",
+      "section": "barcode",
+      "family": "roastriceasianfusion",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "roastriceasianfusion",
+      "section": "footer",
+      "family": "roastriceasianfusion",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "roastriceasianfusion",
+      "section": "items",
+      "family": "roastriceasianfusion",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 14,
+      "n_receipts": 4,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "roastriceasianfusion",
+      "section": "payment",
+      "family": "roastriceasianfusion",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 58,
+      "n_receipts": 4,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "roastriceasianfusion",
+      "section": "storefront",
+      "family": "roastriceasianfusion",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 6,
+      "n_receipts": 6,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "roastriceasianfusion",
+      "section": "summary",
+      "family": "roastriceasianfusion",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 3,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "roastriceasianfusion",
+      "section": "total_line",
+      "family": "roastriceasianfusion",
+      "face": {
+        "scale": 1.0,
+        "weight": "bold",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 3,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "roccosnypizzeriaand",
+      "section": "address",
+      "family": "roccosnypizzeriaand",
+      "face": {
+        "scale": 1.165,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 4,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "roccosnypizzeriaand",
+      "section": "footer",
+      "family": "roccosnypizzeriaand",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 4,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "roccosnypizzeriaand",
+      "section": "items",
+      "family": "roccosnypizzeriaand",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 5,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "roccosnypizzeriaand",
+      "section": "payment",
+      "family": "roccosnypizzeriaand",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 11,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "roccosnypizzeriaand",
+      "section": "summary",
+      "family": "roccosnypizzeriaand",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.5
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "roosterfish",
+      "section": "address",
+      "family": "roosterfish",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "roosterfish",
+      "section": "items",
+      "family": "roosterfish",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "roosterfish",
+      "section": "payment",
+      "family": "roosterfish",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "sakuraramen",
+      "section": "address",
+      "family": "sakuraramen",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 2,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "sakuraramen",
+      "section": "footer",
+      "family": "sakuraramen",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 1.0
+    },
+    {
+      "merchant": "sakuraramen",
+      "section": "items",
+      "family": "sakuraramen",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "sakuraramen",
+      "section": "payment",
+      "family": "sakuraramen",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 14,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.1429
+    },
+    {
+      "merchant": "sakuraramen",
+      "section": "storefront",
+      "family": "sakuraramen",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "sallybeauty",
+      "section": "address",
+      "family": "sallybeauty",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 6,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "sallybeauty",
+      "section": "barcode",
+      "family": "sallybeauty",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "sallybeauty",
+      "section": "footer",
+      "family": "sallybeauty",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 1.0
+    },
+    {
+      "merchant": "sallybeauty",
+      "section": "items",
+      "family": "sallybeauty",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 11,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "sallybeauty",
+      "section": "payment",
+      "family": "sallybeauty",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 4,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "sallybeauty",
+      "section": "summary",
+      "family": "sallybeauty",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "saltandlimemodernmexicangrill",
+      "section": "address",
+      "family": "saltandlimemodernmexicangrill",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "saltandlimemodernmexicangrill",
+      "section": "items",
+      "family": "saltandlimemodernmexicangrill",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 9,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "saltandlimemodernmexicangrill",
+      "section": "storefront",
+      "family": "saltandlimemodernmexicangrill",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "saltandlimemodernmexicangrill",
+      "section": "summary",
+      "family": "saltandlimemodernmexicangrill",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "saltandlimemodernmexicangrill",
+      "section": "total_line",
+      "family": "saltandlimemodernmexicangrill",
+      "face": {
+        "scale": 1.0,
+        "weight": "bold",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "saltstraw",
+      "section": "address",
+      "family": "saltstraw",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "saltstraw",
+      "section": "items",
+      "family": "saltstraw",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 2,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "saltstraw",
+      "section": "payment",
+      "family": "saltstraw",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 22,
+      "n_receipts": 2,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "saltstraw",
+      "section": "storefront",
+      "family": "saltstraw",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 2,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "saltstraw",
+      "section": "summary",
+      "family": "saltstraw",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "shakeshack",
+      "section": "address",
+      "family": "shakeshack",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "shakeshack",
+      "section": "items",
+      "family": "shakeshack",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "shakeshack",
+      "section": "payment",
+      "family": "shakeshack",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "shakeshack",
+      "section": "storefront",
+      "family": "shakeshack",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "shakeshack",
+      "section": "summary",
+      "family": "shakeshack",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "shakeshack",
+      "section": "survey",
+      "family": "shakeshack",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "shakeshack",
+      "section": "total_line",
+      "family": "shakeshack",
+      "face": {
+        "scale": 1.0,
+        "weight": "bold",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "showgrow",
+      "section": "address",
+      "family": "showgrow",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "showgrow",
+      "section": "footer",
+      "family": "showgrow",
+      "face": {
+        "scale": 1.265,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "showgrow",
+      "section": "items",
+      "family": "showgrow",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 5,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "showgrow",
+      "section": "storefront",
+      "family": "showgrow",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "skullsrainbowroom",
+      "section": "address",
+      "family": "skullsrainbowroom",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.1667
+      },
+      "n_lines": 6,
+      "n_receipts": 4,
+      "low_confidence": false,
+      "reverse_video_rate": 0.3333
+    },
+    {
+      "merchant": "skullsrainbowroom",
+      "section": "barcode",
+      "family": "skullsrainbowroom",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "skullsrainbowroom",
+      "section": "footer",
+      "family": "skullsrainbowroom",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "skullsrainbowroom",
+      "section": "items",
+      "family": "skullsrainbowroom",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 1.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "skullsrainbowroom",
+      "section": "payment",
+      "family": "skullsrainbowroom",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 37,
+      "n_receipts": 3,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0541
+    },
+    {
+      "merchant": "skullsrainbowroom",
+      "section": "storefront",
+      "family": "skullsrainbowroom",
+      "face": {
+        "scale": 1.31,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 4,
+      "n_receipts": 2,
+      "low_confidence": false,
+      "reverse_video_rate": 0.75
+    },
+    {
+      "merchant": "skullsrainbowroom",
+      "section": "summary",
+      "family": "skullsrainbowroom",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "skullsrainbowroom",
+      "section": "total_line",
+      "family": "skullsrainbowroom",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 2,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "slicehousethousandoaks",
+      "section": "address",
+      "family": "slicehousethousandoaks",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 5,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "slicehousethousandoaks",
+      "section": "items",
+      "family": "slicehousethousandoaks",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "slicehousethousandoaks",
+      "section": "payment",
+      "family": "slicehousethousandoaks",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 14,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "sloans",
+      "section": "address",
+      "family": "sloans",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 5,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "sloans",
+      "section": "footer",
+      "family": "sloans",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 5,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "sloans",
+      "section": "items",
+      "family": "sloans",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "sloans",
+      "section": "payment",
+      "family": "sloans",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 12,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "sloans",
+      "section": "survey",
+      "family": "sloans",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "smartfinalextra",
+      "section": "address",
+      "family": "smartfinalextra",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 12,
+      "n_receipts": 3,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "smartfinalextra",
+      "section": "barcode",
+      "family": "smartfinalextra",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 3,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "smartfinalextra",
+      "section": "footer",
+      "family": "smartfinalextra",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 9,
+      "n_receipts": 3,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "smartfinalextra",
+      "section": "items",
+      "family": "smartfinalextra",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 6,
+      "n_receipts": 3,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "smartfinalextra",
+      "section": "payment",
+      "family": "smartfinalextra",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 21,
+      "n_receipts": 3,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "smartfinalextra",
+      "section": "section_header",
+      "family": "smartfinalextra",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "smartfinalextra",
+      "section": "storefront",
+      "family": "smartfinalextra",
+      "face": {
+        "scale": 1.0,
+        "weight": "bold",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 2,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "smartfinalextra",
+      "section": "summary",
+      "family": "smartfinalextra",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 3,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "smartfinalextra",
+      "section": "survey",
+      "family": "smartfinalextra",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 8,
+      "n_receipts": 3,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "smartfinalextra",
+      "section": "total_line",
+      "family": "smartfinalextra",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "smiths",
+      "section": "address",
+      "family": "smiths",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 8,
+      "n_receipts": 6,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "smiths",
+      "section": "footer",
+      "family": "smiths",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 15,
+      "n_receipts": 5,
+      "low_confidence": false,
+      "reverse_video_rate": 0.1333
+    },
+    {
+      "merchant": "smiths",
+      "section": "items",
+      "family": "smiths",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 43,
+      "n_receipts": 6,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "smiths",
+      "section": "payment",
+      "family": "smiths",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0488
+      },
+      "n_lines": 41,
+      "n_receipts": 6,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "smiths",
+      "section": "storefront",
+      "family": "smiths",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 9,
+      "n_receipts": 6,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "smiths",
+      "section": "summary",
+      "family": "smiths",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "smiths",
+      "section": "survey",
+      "family": "smiths",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "smiths",
+      "section": "total_line",
+      "family": "smiths",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 2,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "smithsfreshforeveryone",
+      "section": "address",
+      "family": "smithsfreshforeveryone",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "smithsfreshforeveryone",
+      "section": "items",
+      "family": "smithsfreshforeveryone",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 15,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "smithsfreshforeveryone",
+      "section": "payment",
+      "family": "smithsfreshforeveryone",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 6,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "smithsfreshforeveryone",
+      "section": "storefront",
+      "family": "smithsfreshforeveryone",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.3333
+      },
+      "n_lines": 3,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "smithsfreshforeveryone",
+      "section": "total_line",
+      "family": "smithsfreshforeveryone",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "smithsmarketplace",
+      "section": "address",
+      "family": "smithsmarketplace",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 7,
+      "n_receipts": 3,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "smithsmarketplace",
+      "section": "footer",
+      "family": "smithsmarketplace",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 21,
+      "n_receipts": 3,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "smithsmarketplace",
+      "section": "items",
+      "family": "smithsmarketplace",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 13,
+      "n_receipts": 3,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "smithsmarketplace",
+      "section": "payment",
+      "family": "smithsmarketplace",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 22,
+      "n_receipts": 3,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "smithsmarketplace",
+      "section": "storefront",
+      "family": "smithsmarketplace",
+      "face": {
+        "scale": 1.35,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 6,
+      "n_receipts": 3,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "smithsmarketplace",
+      "section": "summary",
+      "family": "smithsmarketplace",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 2,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "smithsmarketplace",
+      "section": "total_line",
+      "family": "smithsmarketplace",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 2,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "smokintsbbqbar",
+      "section": "address",
+      "family": "smokintsbbqbar",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "smokintsbbqbar",
+      "section": "footer",
+      "family": "smokintsbbqbar",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 4,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "smokintsbbqbar",
+      "section": "items",
+      "family": "smokintsbbqbar",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 4,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "smokintsbbqbar",
+      "section": "payment",
+      "family": "smokintsbbqbar",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 9,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "smokintsbbqbar",
+      "section": "storefront",
+      "family": "smokintsbbqbar",
+      "face": {
+        "scale": 1.47,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "smokintsbbqbar",
+      "section": "summary",
+      "family": "smokintsbbqbar",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "sparklingimagecarwash",
+      "section": "address",
+      "family": "sparklingimagecarwash",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 7,
+      "n_receipts": 2,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "sparklingimagecarwash",
+      "section": "barcode",
+      "family": "sparklingimagecarwash",
+      "face": {
+        "scale": 1.0,
+        "weight": "bold",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "sparklingimagecarwash",
+      "section": "footer",
+      "family": "sparklingimagecarwash",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 2,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "sparklingimagecarwash",
+      "section": "payment",
+      "family": "sparklingimagecarwash",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "sparklingimagecarwash",
+      "section": "storefront",
+      "family": "sparklingimagecarwash",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "sparklingimagecarwash",
+      "section": "summary",
+      "family": "sparklingimagecarwash",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 2,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "sparklingimagecarwash",
+      "section": "total_line",
+      "family": "sparklingimagecarwash",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 2,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "sprouts",
+      "section": "address",
+      "family": "costco+innout+sprouts+wildfork",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0018
+      },
+      "n_lines": 567,
+      "n_receipts": 138,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "sprouts",
+      "section": "barcode",
+      "family": "costco+innout+sprouts+wildfork",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0078
+      },
+      "n_lines": 129,
+      "n_receipts": 110,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "sprouts",
+      "section": "footer",
+      "family": "costco+innout+sprouts+wildfork",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0223
+      },
+      "n_lines": 806,
+      "n_receipts": 136,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0012
+    },
+    {
+      "merchant": "sprouts",
+      "section": "items",
+      "family": "costco+innout+sprouts+wildfork",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0071
+      },
+      "n_lines": 422,
+      "n_receipts": 138,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "sprouts",
+      "section": "payment",
+      "family": "costco+innout+sprouts+wildfork",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0053
+      },
+      "n_lines": 1710,
+      "n_receipts": 139,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0006
+    },
+    {
+      "merchant": "sprouts",
+      "section": "section_header",
+      "family": "costco+innout+sprouts+wildfork",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.3881
+      },
+      "n_lines": 201,
+      "n_receipts": 122,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "sprouts",
+      "section": "storefront",
+      "family": "costco+innout+sprouts+wildfork",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 448,
+      "n_receipts": 140,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "sprouts",
+      "section": "summary",
+      "family": "costco+innout+sprouts+wildfork",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 14,
+      "n_receipts": 10,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "sprouts",
+      "section": "survey",
+      "family": "costco+innout+sprouts+wildfork",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0017
+      },
+      "n_lines": 590,
+      "n_receipts": 132,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0034
+    },
+    {
+      "merchant": "sprouts",
+      "section": "total_line",
+      "family": "costco+innout+sprouts+wildfork",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 212,
+      "n_receipts": 133,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "stanleyofneworleans",
+      "section": "address",
+      "family": "stanleyofneworleans",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "stanleyofneworleans",
+      "section": "barcode",
+      "family": "stanleyofneworleans",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "stanleyofneworleans",
+      "section": "footer",
+      "family": "stanleyofneworleans",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 1.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "stanleyofneworleans",
+      "section": "items",
+      "family": "stanleyofneworleans",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "stanleyofneworleans",
+      "section": "payment",
+      "family": "stanleyofneworleans",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 4,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "stanleyofneworleans",
+      "section": "summary",
+      "family": "stanleyofneworleans",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "stanleyofneworleans",
+      "section": "total_line",
+      "family": "stanleyofneworleans",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "starbucks",
+      "section": "address",
+      "family": "starbucks",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "starbucks",
+      "section": "footer",
+      "family": "starbucks",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "starbucks",
+      "section": "items",
+      "family": "starbucks",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "starbucks",
+      "section": "payment",
+      "family": "starbucks",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 9,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "starbucks",
+      "section": "summary",
+      "family": "starbucks",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "stonearch",
+      "section": "footer",
+      "family": "stonearch",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "stonearch",
+      "section": "payment",
+      "family": "stonearch",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 14,
+      "n_receipts": 2,
+      "low_confidence": false,
+      "reverse_video_rate": 0.2143
+    },
+    {
+      "merchant": "stonearch",
+      "section": "summary",
+      "family": "stonearch",
+      "face": {
+        "scale": 1.5,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "stonearch",
+      "section": "total_line",
+      "family": "stonearch",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "sunrisecoffee",
+      "section": "address",
+      "family": "sunrisecoffee",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 4,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "sunrisecoffee",
+      "section": "footer",
+      "family": "sunrisecoffee",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 4,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "sunrisecoffee",
+      "section": "items",
+      "family": "sunrisecoffee",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 9,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "sunrisecoffee",
+      "section": "payment",
+      "family": "sunrisecoffee",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "sunrisecoffee",
+      "section": "summary",
+      "family": "sunrisecoffee",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "sunrosecaliforniaeatery",
+      "section": "address",
+      "family": "sunrosecaliforniaeatery",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "sunrosecaliforniaeatery",
+      "section": "items",
+      "family": "sunrosecaliforniaeatery",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "sushihero",
+      "section": "address",
+      "family": "sushihero",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.3333
+      },
+      "n_lines": 3,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "sushihero",
+      "section": "barcode",
+      "family": "sushihero",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "sushihero",
+      "section": "footer",
+      "family": "sushihero",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "sushihero",
+      "section": "payment",
+      "family": "sushihero",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.1111
+      },
+      "n_lines": 9,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.2222
+    },
+    {
+      "merchant": "sushihero",
+      "section": "storefront",
+      "family": "sushihero",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "sushiplanet",
+      "section": "address",
+      "family": "sushiplanet",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 11,
+      "n_receipts": 3,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "sushiplanet",
+      "section": "barcode",
+      "family": "sushiplanet",
+      "face": {
+        "scale": 1.0,
+        "weight": "bold",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 2,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "sushiplanet",
+      "section": "footer",
+      "family": "sushiplanet",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "sushiplanet",
+      "section": "items",
+      "family": "sushiplanet",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 4,
+      "n_receipts": 2,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "sushiplanet",
+      "section": "payment",
+      "family": "sushiplanet",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 12,
+      "n_receipts": 2,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "sushiplanet",
+      "section": "storefront",
+      "family": "sushiplanet",
+      "face": {
+        "scale": 1.0,
+        "weight": "bold",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "sushiplanet",
+      "section": "summary",
+      "family": "sushiplanet",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "sushiplanet",
+      "section": "total_line",
+      "family": "sushiplanet",
+      "face": {
+        "scale": 1.0,
+        "weight": "bold",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "sushiwasabi",
+      "section": "address",
+      "family": "sushiwasabi",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 4,
+      "n_receipts": 2,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "sushiwasabi",
+      "section": "items",
+      "family": "sushiwasabi",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 12,
+      "n_receipts": 3,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "sushiwasabi",
+      "section": "storefront",
+      "family": "sushiwasabi",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "sushiwasabi",
+      "section": "summary",
+      "family": "sushiwasabi",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 3,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "sushiwasabi",
+      "section": "total_line",
+      "family": "sushiwasabi",
+      "face": {
+        "scale": 1.0,
+        "weight": "bold",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "tabushabuthousandoaks",
+      "section": "barcode",
+      "family": "tabushabuthousandoaks",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "tabushabuthousandoaks",
+      "section": "footer",
+      "family": "tabushabuthousandoaks",
+      "face": {
+        "scale": 1.18,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "tabushabuthousandoaks",
+      "section": "items",
+      "family": "tabushabuthousandoaks",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 7,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "tabushabuthousandoaks",
+      "section": "payment",
+      "family": "tabushabuthousandoaks",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "tabushabuthousandoaks",
+      "section": "storefront",
+      "family": "tabushabuthousandoaks",
+      "face": {
+        "scale": 2.005,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "tanla",
+      "section": "address",
+      "family": "tanla",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 11,
+      "n_receipts": 3,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "tanla",
+      "section": "payment",
+      "family": "tanla",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 27,
+      "n_receipts": 3,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "tanla",
+      "section": "storefront",
+      "family": "tanla",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "target",
+      "section": "address",
+      "family": "target",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 51,
+      "n_receipts": 19,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "target",
+      "section": "footer",
+      "family": "target",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 4,
+      "n_receipts": 2,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "target",
+      "section": "items",
+      "family": "target",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 54,
+      "n_receipts": 16,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "target",
+      "section": "payment",
+      "family": "target",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 27,
+      "n_receipts": 19,
+      "low_confidence": false,
+      "reverse_video_rate": 0.1111
+    },
+    {
+      "merchant": "target",
+      "section": "section_header",
+      "family": "target",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "target",
+      "section": "summary",
+      "family": "target",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0303
+      },
+      "n_lines": 33,
+      "n_receipts": 19,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0606
+    },
+    {
+      "merchant": "target",
+      "section": "total_line",
+      "family": "target",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 14,
+      "n_receipts": 14,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0714
+    },
+    {
+      "merchant": "targetgrocery",
+      "section": "address",
+      "family": "targetgrocery",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 32,
+      "n_receipts": 10,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "targetgrocery",
+      "section": "barcode",
+      "family": "targetgrocery",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 2,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "targetgrocery",
+      "section": "footer",
+      "family": "targetgrocery",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 28,
+      "n_receipts": 10,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "targetgrocery",
+      "section": "items",
+      "family": "targetgrocery",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 22,
+      "n_receipts": 7,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "targetgrocery",
+      "section": "payment",
+      "family": "targetgrocery",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 29,
+      "n_receipts": 9,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "targetgrocery",
+      "section": "section_header",
+      "family": "targetgrocery",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 2,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "targetgrocery",
+      "section": "summary",
+      "family": "targetgrocery",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 14,
+      "n_receipts": 10,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "targetgrocery",
+      "section": "survey",
+      "family": "targetgrocery",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 48,
+      "n_receipts": 10,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "targetgrocery",
+      "section": "total_line",
+      "family": "targetgrocery",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "targetsummerlinsouth",
+      "section": "address",
+      "family": "targetsummerlinsouth",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 4,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "targetsummerlinsouth",
+      "section": "footer",
+      "family": "targetsummerlinsouth",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "targetsummerlinsouth",
+      "section": "items",
+      "family": "targetsummerlinsouth",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 8,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "targetsummerlinsouth",
+      "section": "payment",
+      "family": "targetsummerlinsouth",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 5,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "targetsummerlinsouth",
+      "section": "summary",
+      "family": "targetsummerlinsouth",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "targetsummerlinsouth",
+      "section": "survey",
+      "family": "targetsummerlinsouth",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 1.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "terribleherbst226",
+      "section": "address",
+      "family": "terribleherbst226",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 4,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "terribleherbst226",
+      "section": "items",
+      "family": "terribleherbst226",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "terribleherbst226",
+      "section": "payment",
+      "family": "terribleherbst226",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 10,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "terribleherbst226",
+      "section": "storefront",
+      "family": "terribleherbst226",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "terribleherbst226",
+      "section": "summary",
+      "family": "terribleherbst226",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "terribleherbst226",
+      "section": "survey",
+      "family": "terribleherbst226",
+      "face": {
+        "scale": 1.33,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "terribleherbst226",
+      "section": "total_line",
+      "family": "terribleherbst226",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "theboardandbrew",
+      "section": "items",
+      "family": "theboardandbrew",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "theboardandbrew",
+      "section": "payment",
+      "family": "theboardandbrew",
+      "face": {
+        "scale": 1.16,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "theboardandbrew",
+      "section": "storefront",
+      "family": "theboardandbrew",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "theboardandbrew",
+      "section": "total_line",
+      "family": "theboardandbrew",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "thecheesecakefactoryhd",
+      "section": "address",
+      "family": "thecheesecakefactoryhd",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "thecheesecakefactoryhd",
+      "section": "barcode",
+      "family": "thecheesecakefactoryhd",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "thecheesecakefactoryhd",
+      "section": "footer",
+      "family": "thecheesecakefactoryhd",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "thecheesecakefactoryhd",
+      "section": "payment",
+      "family": "thecheesecakefactoryhd",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 9,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "thecheesecakefactoryhd",
+      "section": "survey",
+      "family": "thecheesecakefactoryhd",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "thecheesecakefactoryhd",
+      "section": "total_line",
+      "family": "thecheesecakefactoryhd",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "thechickenshackhenderson",
+      "section": "address",
+      "family": "thechickenshackhenderson",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 4,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "thechickenshackhenderson",
+      "section": "footer",
+      "family": "thechickenshackhenderson",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "thechickenshackhenderson",
+      "section": "items",
+      "family": "thechickenshackhenderson",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 4,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "thechickenshackhenderson",
+      "section": "payment",
+      "family": "thechickenshackhenderson",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 5,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "thechickenshackhenderson",
+      "section": "summary",
+      "family": "thechickenshackhenderson",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "thehandlebarbarbershop",
+      "section": "address",
+      "family": "thehandlebarbarbershop",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 6,
+      "n_receipts": 2,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "thehandlebarbarbershop",
+      "section": "footer",
+      "family": "thehandlebarbarbershop",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 6,
+      "n_receipts": 2,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "thehandlebarbarbershop",
+      "section": "payment",
+      "family": "thehandlebarbarbershop",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 7,
+      "n_receipts": 2,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "thehandlebarbarbershop",
+      "section": "storefront",
+      "family": "thehandlebarbarbershop",
+      "face": {
+        "scale": 2.25,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "thehandlebarbarbershop",
+      "section": "summary",
+      "family": "thehandlebarbarbershop",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 2,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "thehuntingtonbeachhouse",
+      "section": "address",
+      "family": "thehuntingtonbeachhouse",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "thehuntingtonbeachhouse",
+      "section": "items",
+      "family": "thehuntingtonbeachhouse",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "thehuntingtonbeachhouse",
+      "section": "payment",
+      "family": "thehuntingtonbeachhouse",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 9,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "thehuntingtonbeachhouse",
+      "section": "storefront",
+      "family": "thehuntingtonbeachhouse",
+      "face": {
+        "scale": 1.45,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "thehuntingtonbeachhouse",
+      "section": "summary",
+      "family": "thehuntingtonbeachhouse",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "thelegacyelderlawcenter",
+      "section": "footer",
+      "family": "thelegacyelderlawcenter",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "thelegacyelderlawcenter",
+      "section": "payment",
+      "family": "thelegacyelderlawcenter",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "thenovo",
+      "section": "address",
+      "family": "thenovo",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 11,
+      "n_receipts": 4,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "thenovo",
+      "section": "barcode",
+      "family": "thenovo",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.1111
+      },
+      "n_lines": 9,
+      "n_receipts": 5,
+      "low_confidence": false,
+      "reverse_video_rate": 0.1111
+    },
+    {
+      "merchant": "thenovo",
+      "section": "footer",
+      "family": "thenovo",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 4,
+      "n_receipts": 2,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "thenovo",
+      "section": "items",
+      "family": "thenovo",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 10,
+      "n_receipts": 3,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "thenovo",
+      "section": "payment",
+      "family": "thenovo",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 6,
+      "n_receipts": 2,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "thenovo",
+      "section": "storefront",
+      "family": "thenovo",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.5
+      },
+      "n_lines": 2,
+      "n_receipts": 2,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "thenovo",
+      "section": "summary",
+      "family": "thenovo",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 4,
+      "n_receipts": 3,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "thenovo",
+      "section": "survey",
+      "family": "thenovo",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 10,
+      "n_receipts": 3,
+      "low_confidence": false,
+      "reverse_video_rate": 0.3
+    },
+    {
+      "merchant": "thestand",
+      "section": "footer",
+      "family": "thestand",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.3333
+      },
+      "n_lines": 3,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "thestandamericanclassicsredefined",
+      "section": "address",
+      "family": "thestandamericanclassicsredefined",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 26,
+      "n_receipts": 6,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "thestandamericanclassicsredefined",
+      "section": "footer",
+      "family": "thestandamericanclassicsredefined",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0667
+      },
+      "n_lines": 30,
+      "n_receipts": 6,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "thestandamericanclassicsredefined",
+      "section": "items",
+      "family": "thestandamericanclassicsredefined",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 23,
+      "n_receipts": 4,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "thestandamericanclassicsredefined",
+      "section": "payment",
+      "family": "thestandamericanclassicsredefined",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 22,
+      "n_receipts": 2,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "thestandamericanclassicsredefined",
+      "section": "storefront",
+      "family": "thestandamericanclassicsredefined",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 5,
+      "n_receipts": 3,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "thestandamericanclassicsredefined",
+      "section": "summary",
+      "family": "thestandamericanclassicsredefined",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 5,
+      "n_receipts": 4,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "thestandamericanclassicsredefined",
+      "section": "survey",
+      "family": "thestandamericanclassicsredefined",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.1818
+      },
+      "n_lines": 11,
+      "n_receipts": 4,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0909
+    },
+    {
+      "merchant": "thevitaminshoppe",
+      "section": "address",
+      "family": "thevitaminshoppe",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "thevitaminshoppe",
+      "section": "items",
+      "family": "thevitaminshoppe",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "thevitaminshoppe",
+      "section": "payment",
+      "family": "thevitaminshoppe",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 12,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "thevitaminshoppe",
+      "section": "summary",
+      "family": "thevitaminshoppe",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "tikino",
+      "section": "address",
+      "family": "tikino",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 4,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "tikino",
+      "section": "payment",
+      "family": "tikino",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 14,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "toasteatery",
+      "section": "address",
+      "family": "toasteatery",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "toasteatery",
+      "section": "barcode",
+      "family": "toasteatery",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 1.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "toasteatery",
+      "section": "items",
+      "family": "toasteatery",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 4,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "toasteatery",
+      "section": "storefront",
+      "family": "toasteatery",
+      "face": {
+        "scale": 1.0,
+        "weight": "bold",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "traderjoes",
+      "section": "address",
+      "family": "traderjoes",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 55,
+      "n_receipts": 19,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0545
+    },
+    {
+      "merchant": "traderjoes",
+      "section": "barcode",
+      "family": "traderjoes",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 8,
+      "n_receipts": 8,
+      "low_confidence": false,
+      "reverse_video_rate": 0.375
+    },
+    {
+      "merchant": "traderjoes",
+      "section": "footer",
+      "family": "traderjoes",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 56,
+      "n_receipts": 19,
+      "low_confidence": false,
+      "reverse_video_rate": 0.1429
+    },
+    {
+      "merchant": "traderjoes",
+      "section": "items",
+      "family": "traderjoes",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0172
+      },
+      "n_lines": 116,
+      "n_receipts": 19,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0172
+    },
+    {
+      "merchant": "traderjoes",
+      "section": "payment",
+      "family": "traderjoes",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0068
+      },
+      "n_lines": 146,
+      "n_receipts": 19,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0342
+    },
+    {
+      "merchant": "traderjoes",
+      "section": "storefront",
+      "family": "traderjoes",
+      "face": {
+        "scale": 2.04,
+        "weight": "normal",
+        "underline_rate": 0.0278
+      },
+      "n_lines": 36,
+      "n_receipts": 19,
+      "low_confidence": false,
+      "reverse_video_rate": 0.1389
+    },
+    {
+      "merchant": "traderjoes",
+      "section": "summary",
+      "family": "traderjoes",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "traderjoes",
+      "section": "total_line",
+      "family": "traderjoes",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 32,
+      "n_receipts": 19,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0625
+    },
+    {
+      "merchant": "traderjoesstore0058",
+      "section": "address",
+      "family": "traderjoesstore0058",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "traderjoesstore0058",
+      "section": "footer",
+      "family": "traderjoesstore0058",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "traderjoesstore0058",
+      "section": "items",
+      "family": "traderjoesstore0058",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 9,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "traderjoesstore0058",
+      "section": "payment",
+      "family": "traderjoesstore0058",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 11,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "traderjoesstore0058",
+      "section": "storefront",
+      "family": "traderjoesstore0058",
+      "face": {
+        "scale": 2.5,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "traderjoesstore0058",
+      "section": "total_line",
+      "family": "traderjoesstore0058",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "tsiinc",
+      "section": "address",
+      "family": "tsiinc",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "tsiinc",
+      "section": "footer",
+      "family": "tsiinc",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 5,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "tsiinc",
+      "section": "items",
+      "family": "tsiinc",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "tsiinc",
+      "section": "payment",
+      "family": "tsiinc",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 17,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "tsiinc",
+      "section": "storefront",
+      "family": "tsiinc",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "tsiinc",
+      "section": "total_line",
+      "family": "tsiinc",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "twistedoaktavern",
+      "section": "address",
+      "family": "twistedoaktavern",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 6,
+      "n_receipts": 4,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "twistedoaktavern",
+      "section": "footer",
+      "family": "twistedoaktavern",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 9,
+      "n_receipts": 4,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "twistedoaktavern",
+      "section": "items",
+      "family": "twistedoaktavern",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 6,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "twistedoaktavern",
+      "section": "payment",
+      "family": "twistedoaktavern",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 15,
+      "n_receipts": 2,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "twistedoaktavern",
+      "section": "storefront",
+      "family": "twistedoaktavern",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 2,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "twistedoaktavern",
+      "section": "summary",
+      "family": "twistedoaktavern",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 2,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "twistedoaktavern",
+      "section": "total_line",
+      "family": "twistedoaktavern",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 2,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "universalstudioshollywood",
+      "section": "barcode",
+      "family": "universalstudioshollywood",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "universalstudioshollywood",
+      "section": "items",
+      "family": "universalstudioshollywood",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "universalstudioshollywood",
+      "section": "payment",
+      "family": "universalstudioshollywood",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 16,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "urbanecafe",
+      "section": "address",
+      "family": "urbanecafe",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 8,
+      "n_receipts": 2,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "urbanecafe",
+      "section": "items",
+      "family": "urbanecafe",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 4,
+      "n_receipts": 2,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "urbanecafe",
+      "section": "payment",
+      "family": "urbanecafe",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 22,
+      "n_receipts": 2,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "urbanecafe",
+      "section": "summary",
+      "family": "urbanecafe",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 2,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "urthcaffe",
+      "section": "address",
+      "family": "urthcaffe",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 20,
+      "n_receipts": 6,
+      "low_confidence": false,
+      "reverse_video_rate": 0.05
+    },
+    {
+      "merchant": "urthcaffe",
+      "section": "barcode",
+      "family": "urthcaffe",
+      "face": {
+        "scale": 1.0,
+        "weight": "bold",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "urthcaffe",
+      "section": "footer",
+      "family": "urthcaffe",
+      "face": {
+        "scale": 1.0,
+        "weight": "bold",
+        "underline_rate": 0.0
+      },
+      "n_lines": 4,
+      "n_receipts": 4,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "urthcaffe",
+      "section": "items",
+      "family": "urthcaffe",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 10,
+      "n_receipts": 6,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "urthcaffe",
+      "section": "payment",
+      "family": "urthcaffe",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 20,
+      "n_receipts": 6,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "urthcaffe",
+      "section": "storefront",
+      "family": "urthcaffe",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 4,
+      "n_receipts": 2,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "urthcaffe",
+      "section": "summary",
+      "family": "urthcaffe",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 2,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "urthcaffe",
+      "section": "total_line",
+      "family": "urthcaffe",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 6,
+      "n_receipts": 4,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "vons",
+      "section": "address",
+      "family": "cvs+vons",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 65,
+      "n_receipts": 21,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "vons",
+      "section": "barcode",
+      "family": "cvs+vons",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 19,
+      "n_receipts": 19,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "vons",
+      "section": "footer",
+      "family": "cvs+vons",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 89,
+      "n_receipts": 20,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "vons",
+      "section": "items",
+      "family": "cvs+vons",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 101,
+      "n_receipts": 21,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "vons",
+      "section": "payment",
+      "family": "cvs+vons",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 130,
+      "n_receipts": 21,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "vons",
+      "section": "section_header",
+      "family": "cvs+vons",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 18,
+      "n_receipts": 11,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "vons",
+      "section": "storefront",
+      "family": "cvs+vons",
+      "face": {
+        "scale": 2.5,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 27,
+      "n_receipts": 20,
+      "low_confidence": false,
+      "reverse_video_rate": 0.4444
+    },
+    {
+      "merchant": "vons",
+      "section": "summary",
+      "family": "cvs+vons",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 32,
+      "n_receipts": 19,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "vons",
+      "section": "total_line",
+      "family": "cvs+vons",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 25,
+      "n_receipts": 18,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "walmartsupercenter",
+      "section": "address",
+      "family": "walmartsupercenter",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "walmartsupercenter",
+      "section": "footer",
+      "family": "walmartsupercenter",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.5
+    },
+    {
+      "merchant": "walmartsupercenter",
+      "section": "items",
+      "family": "walmartsupercenter",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "walmartsupercenter",
+      "section": "payment",
+      "family": "walmartsupercenter",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 11,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "walmartsupercenter",
+      "section": "summary",
+      "family": "walmartsupercenter",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "walmartsupercenter",
+      "section": "survey",
+      "family": "walmartsupercenter",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "westlakephysicaltherapyinc",
+      "section": "address",
+      "family": "westlakephysicaltherapyinc",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 8,
+      "n_receipts": 2,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "westlakephysicaltherapyinc",
+      "section": "payment",
+      "family": "westlakephysicaltherapyinc",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 21,
+      "n_receipts": 2,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "westlakevillagecleaners",
+      "section": "address",
+      "family": "westlakevillagecleaners",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "westlakevillagecleaners",
+      "section": "footer",
+      "family": "westlakevillagecleaners",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "westlakevillagecleaners",
+      "section": "payment",
+      "family": "westlakevillagecleaners",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 10,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "wholefoodsmarket",
+      "section": "address",
+      "family": "wholefoodsmarket",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 18,
+      "n_receipts": 6,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "wholefoodsmarket",
+      "section": "barcode",
+      "family": "wholefoodsmarket",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 16,
+      "n_receipts": 6,
+      "low_confidence": false,
+      "reverse_video_rate": 0.375
+    },
+    {
+      "merchant": "wholefoodsmarket",
+      "section": "footer",
+      "family": "wholefoodsmarket",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 26,
+      "n_receipts": 6,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "wholefoodsmarket",
+      "section": "items",
+      "family": "wholefoodsmarket",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 6,
+      "n_receipts": 6,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "wholefoodsmarket",
+      "section": "payment",
+      "family": "wholefoodsmarket",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 11,
+      "n_receipts": 6,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "wholefoodsmarket",
+      "section": "storefront",
+      "family": "wholefoodsmarket",
+      "face": {
+        "scale": 1.75,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "wholefoodsmarket",
+      "section": "summary",
+      "family": "wholefoodsmarket",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 4,
+      "n_receipts": 2,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "wildfork",
+      "section": "address",
+      "family": "costco+innout+sprouts+wildfork",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 46,
+      "n_receipts": 12,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "wildfork",
+      "section": "barcode",
+      "family": "costco+innout+sprouts+wildfork",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 12,
+      "n_receipts": 12,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "wildfork",
+      "section": "footer",
+      "family": "costco+innout+sprouts+wildfork",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 24,
+      "n_receipts": 12,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "wildfork",
+      "section": "items",
+      "family": "costco+innout+sprouts+wildfork",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 137,
+      "n_receipts": 12,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "wildfork",
+      "section": "payment",
+      "family": "costco+innout+sprouts+wildfork",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 103,
+      "n_receipts": 11,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "wildfork",
+      "section": "storefront",
+      "family": "costco+innout+sprouts+wildfork",
+      "face": {
+        "scale": 1.715,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 2,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "wildfork",
+      "section": "summary",
+      "family": "costco+innout+sprouts+wildfork",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 24,
+      "n_receipts": 12,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "wildfork",
+      "section": "total_line",
+      "family": "costco+innout+sprouts+wildfork",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 11,
+      "n_receipts": 11,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "yogurtlandhenderson",
+      "section": "address",
+      "family": "yogurtlandhenderson",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "yogurtlandhenderson",
+      "section": "barcode",
+      "family": "yogurtlandhenderson",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "yogurtlandhenderson",
+      "section": "items",
+      "family": "yogurtlandhenderson",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 4,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "yogurtlandhenderson",
+      "section": "payment",
+      "family": "yogurtlandhenderson",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 10,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.2
+    },
+    {
+      "merchant": "yogurtlandhenderson",
+      "section": "summary",
+      "family": "yogurtlandhenderson",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "yzenfrogurt",
+      "section": "address",
+      "family": "yzenfrogurt",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "yzenfrogurt",
+      "section": "items",
+      "family": "yzenfrogurt",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "yzenfrogurt",
+      "section": "payment",
+      "family": "yzenfrogurt",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 4,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "zenleafcannabisdispensary",
+      "section": "address",
+      "family": "zenleafcannabisdispensary",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 6,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "zenleafcannabisdispensary",
+      "section": "payment",
+      "family": "zenleafcannabisdispensary",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 8,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "zenleafcannabisdispensary",
+      "section": "summary",
+      "family": "zenleafcannabisdispensary",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "zenleaflasvegas",
+      "section": "address",
+      "family": "zenleaflasvegas",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 3,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "zenleaflasvegas",
+      "section": "items",
+      "family": "zenleaflasvegas",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.25
+      },
+      "n_lines": 4,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "zenleaflasvegas",
+      "section": "payment",
+      "family": "zenleaflasvegas",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "zenleaflasvegas",
+      "section": "storefront",
+      "family": "zenleaflasvegas",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "zenleaflasvegas",
+      "section": "summary",
+      "family": "zenleaflasvegas",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 2,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "zonacocina",
+      "section": "address",
+      "family": "zonacocina",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "zonacocina",
+      "section": "footer",
+      "family": "zonacocina",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "zonacocina",
+      "section": "payment",
+      "family": "zonacocina",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 8,
+      "n_receipts": 1,
+      "low_confidence": false,
+      "reverse_video_rate": 0.0
+    },
+    {
+      "merchant": "zonacocina",
+      "section": "total_line",
+      "family": "zonacocina",
+      "face": {
+        "scale": 1.0,
+        "weight": "normal",
+        "underline_rate": 0.0
+      },
+      "n_lines": 1,
+      "n_receipts": 1,
+      "low_confidence": true,
+      "reverse_video_rate": 0.0
+    }
+  ],
+  "meta": {
+    "receipts_with_valid_sections": 795,
+    "receipts_measured": 628,
+    "receipts_vetted_out": 166,
+    "receipts_load_failed": 0,
+    "receipts_without_merchant": 1,
+    "baseline_items": 235,
+    "baseline_stylescan": 393,
+    "lines_ambiguous": 372,
+    "lines_unmeasured": 673,
+    "max_overlaps": 2,
+    "model_sources": {
+      "section-knn-v1": 716,
+      "section-qa-v2": 3176,
+      "section-seed-v0": 973
+    }
+  }
+}

--- a/tools/glyph-studio/py/face_map_v2_cli.py
+++ b/tools/glyph-studio/py/face_map_v2_cli.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+"""Emit face-map v2: (merchant, section) -> face priors from QA'd sections.
+
+Where the M2 CLI (section_face_map_cli.py) read each merchant's committed
+stylemap.json (sections attributed by stylescan's RULE tables), this measures:
+it walks every receipt that has VALID ``ReceiptSection`` rows in Dynamo, vets
+its OCR (``ocr_overlap_score`` <= --max-overlaps, the locked M3 rule), runs
+stylescan's per-line typography measurement over the real scan (cdn image
+preferred by the loader), joins measured lines to the QA'd sections by OCR
+line id, and aggregates per (merchant, section) with M2's Face semantics.
+Pure join/aggregation logic lives in :mod:`glyphstudio.face_map_v2`.
+
+Reads Dynamo + S3 only; writes nothing but the output JSON.
+
+Usage:
+  python face_map_v2_cli.py --out ../maps/section_face_map_v2.json \
+      [--table ReceiptsTable-dc5be22] [--workers 8] [--limit N] \
+      [--merchant-slug sprouts ...]
+
+Env: AWS creds; DYNAMODB_TABLE_NAME (or --table).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import threading
+from collections import Counter, defaultdict
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import asdict
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_ROOT = os.path.abspath(os.path.join(_HERE, "..", "..", ".."))
+for _p in (
+    _HERE,
+    os.path.join(_ROOT, "receipt_dynamo"),
+    os.path.join(_ROOT, "receipt_agent"),
+    os.path.join(_ROOT, "receipt_upload"),
+    os.path.join(_ROOT, "synthesis_loop"),
+):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from m3_acceptance import ocr_overlap_score  # noqa: E402
+from glyphstudio.face_map_v2 import (  # noqa: E402
+    LineFace,
+    aggregate_cell,
+    assign_sections,
+    items_body_baseline,
+    line_face,
+)
+from glyphstudio.section_seeds import merchant_slug  # noqa: E402
+
+_LOCAL = threading.local()
+
+
+def _client(table: str):
+    if getattr(_LOCAL, "client", None) is None:
+        from receipt_dynamo.data.dynamo_client import DynamoClient
+
+        _LOCAL.client = DynamoClient(table)
+    return _LOCAL.client
+
+
+def generic_slug(name: str) -> str:
+    """Fallback merchant key for merchants outside MERCHANT_SLUGS.
+
+    Same squashed-lowercase style as the calibrated slugs so the map speaks
+    one naming convention ("Whole Foods Market" -> "wholefoodsmarket").
+    """
+    return re.sub(r"[^a-z0-9]+", "", name.lower()) or "unknown"
+
+
+def resolve_slug(merchant_name: str | None) -> str | None:
+    if not merchant_name or merchant_name.strip().lower() == "unknown":
+        return None
+    return merchant_slug(merchant_name) or generic_slug(merchant_name)
+
+
+def load_corpus(table: str):
+    """All VALID sections grouped per receipt + the merchant of each receipt."""
+    client = _client(table)
+    sections, lek = [], None
+    while True:
+        batch, lek = client.list_receipt_sections(
+            limit=1000, last_evaluated_key=lek
+        )
+        sections.extend(batch)
+        if lek is None:
+            break
+    valid = [s for s in sections if s.validation_status == "VALID"]
+
+    places, lek = [], None
+    while True:
+        batch, lek = client.list_receipt_places(
+            limit=1000, last_evaluated_key=lek
+        )
+        places.extend(batch)
+        if lek is None:
+            break
+    merchant_of = {(p.image_id, p.receipt_id): p.merchant_name for p in places}
+
+    by_receipt: dict[tuple[str, int], list] = defaultdict(list)
+    for s in valid:
+        by_receipt[(s.image_id, s.receipt_id)].append(s)
+    return by_receipt, merchant_of, Counter(s.model_source for s in valid)
+
+
+def process_receipt(table: str, image_id: str, receipt_id: int, slug: str, sections):
+    """Vet -> measure -> join -> per-line faces for ONE receipt."""
+    from glyphstudio.stylescan import _MERCHANT_RULES, measure
+
+    client = _client(table)
+    words = client.list_receipt_words_from_receipt(image_id, receipt_id)
+    word_dicts = [
+        {
+            "bbox": [
+                w.top_left["x"] * 1000,
+                w.top_left["y"] * 1000,
+                w.bottom_right["x"] * 1000,
+                w.bottom_right["y"] * 1000,
+            ]
+        }
+        for w in words
+    ]
+    overlaps = ocr_overlap_score(word_dicts)
+    if overlaps > process_receipt.max_overlaps:
+        return {"status": "vetted_out", "overlaps": overlaps}
+
+    # stylescan's rule slug only steers its own body fallback / section names
+    # (which v2 ignores in favor of the QA'd join); unknown merchants use the
+    # generic rules.
+    rule_slug = slug if slug in _MERCHANT_RULES else "sprouts"
+    measurement = measure(image_id, receipt_id, merchant=rule_slug)
+
+    sec_dicts = [
+        {"section_type": s.section_type, "line_ids": s.line_ids}
+        for s in sections
+    ]
+    assigned, ambiguous = assign_sections(measurement["lines"], sec_dicts)
+    body_cap, body_stroke, baseline = items_body_baseline(
+        assigned, measurement["body_cap_px"], measurement["body_stroke_px"]
+    )
+    faces: list[tuple[str, LineFace]] = []
+    unmeasured = 0
+    for line, section in assigned:
+        if section is None:
+            continue
+        lf = line_face(line, body_cap, body_stroke, (image_id, receipt_id))
+        if lf is None:
+            unmeasured += 1
+            continue
+        faces.append((section, lf))
+    return {
+        "status": "ok",
+        "faces": faces,
+        "ambiguous": ambiguous,
+        "unmeasured": unmeasured,
+        "baseline": baseline,
+    }
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--table",
+        default=os.environ.get("DYNAMODB_TABLE_NAME", "ReceiptsTable-dc5be22"),
+    )
+    ap.add_argument("--out", default=None)
+    ap.add_argument(
+        "--fonts", default=os.path.abspath(os.path.join(_HERE, "..", "fonts"))
+    )
+    ap.add_argument("--threshold", type=float, default=0.60)
+    ap.add_argument(
+        "--max-overlaps",
+        type=int,
+        default=2,
+        help="M3 OCR vetting: skip receipts with more x-overlapping pairs",
+    )
+    ap.add_argument("--workers", type=int, default=8)
+    ap.add_argument("--limit", type=int, default=None, help="debug: first N receipts")
+    ap.add_argument(
+        "--merchant-slug",
+        action="append",
+        default=None,
+        help="debug: restrict to these merchant slugs (repeatable)",
+    )
+    args = ap.parse_args(argv)
+    os.environ["DYNAMODB_TABLE_NAME"] = args.table
+    process_receipt.max_overlaps = args.max_overlaps
+
+    by_receipt, merchant_of, model_sources = load_corpus(args.table)
+    jobs = []
+    skipped_no_merchant = 0
+    for key, sections in sorted(by_receipt.items()):
+        slug = resolve_slug(merchant_of.get(key))
+        if slug is None:
+            skipped_no_merchant += 1
+            continue
+        if args.merchant_slug and slug not in args.merchant_slug:
+            continue
+        jobs.append((key, slug, sections))
+    if args.limit:
+        jobs = jobs[: args.limit]
+    print(
+        f"corpus: {len(by_receipt)} receipts with VALID sections; "
+        f"{len(jobs)} to measure ({skipped_no_merchant} without merchant)",
+        file=sys.stderr,
+    )
+
+    cells: dict[tuple[str, str], list[LineFace]] = defaultdict(list)
+    stats = Counter()
+    with ThreadPoolExecutor(max_workers=args.workers) as pool:
+        futures = {
+            pool.submit(
+                process_receipt, args.table, key[0], key[1], slug, sections
+            ): (key, slug)
+            for key, slug, sections in jobs
+        }
+        for i, fut in enumerate(as_completed(futures), 1):
+            (image_id, receipt_id), slug = futures[fut]
+            try:
+                res = fut.result()
+            except Exception as exc:  # noqa: BLE001 - missing image etc.
+                stats["load_failed"] += 1
+                print(
+                    f"  [{i}/{len(futures)}] {image_id[:8]}#{receipt_id} "
+                    f"({slug}): FAILED {exc}",
+                    file=sys.stderr,
+                )
+                continue
+            if res["status"] == "vetted_out":
+                stats["vetted_out"] += 1
+                print(
+                    f"  [{i}/{len(futures)}] {image_id[:8]}#{receipt_id} "
+                    f"({slug}): vetted out ({res['overlaps']} OCR overlaps)",
+                    file=sys.stderr,
+                )
+                continue
+            stats["measured"] += 1
+            stats["lines_ambiguous"] += res["ambiguous"]
+            stats["lines_unmeasured"] += res["unmeasured"]
+            stats[f"baseline_{res['baseline']}"] += 1
+            for section, lf in res["faces"]:
+                cells[(slug, section)].append(lf)
+            if i % 50 == 0:
+                print(f"  [{i}/{len(futures)}] ...", file=sys.stderr)
+
+    # families: same discovery the v1 CLI runs (glyph-atlas IoU over the
+    # merchants that HAVE committed fonts); everyone else is their own family.
+    from glyphstudio.family_cluster import discover_families
+    from glyphstudio.section_face_map import families_to_merchant_family
+
+    font_dirs = {
+        n: os.path.join(args.fonts, n)
+        for n in sorted(os.listdir(args.fonts))
+        if os.path.exists(os.path.join(args.fonts, n, "font.json"))
+    }
+    fam_res = discover_families(font_dirs, threshold=args.threshold)
+    merchant_family = families_to_merchant_family(fam_res.families)
+
+    entries = []
+    for (merchant, section), members in sorted(cells.items()):
+        agg = aggregate_cell(members)
+        entries.append(
+            {
+                "merchant": merchant,
+                "section": section,
+                "family": merchant_family.get(merchant, merchant),
+                "face": asdict(agg["face"]),
+                "n_lines": agg["n_lines"],
+                "n_receipts": agg["n_receipts"],
+                "low_confidence": agg["low_confidence"],
+                "reverse_video_rate": agg["reverse_video_rate"],
+            }
+        )
+
+    obj = {
+        "version": 2,
+        "source": "receipt-sections-valid",
+        "table": args.table,
+        "families": fam_res.families,
+        "threshold": fam_res.threshold,
+        "map": entries,
+        "meta": {
+            "receipts_with_valid_sections": len(by_receipt),
+            "receipts_measured": stats["measured"],
+            "receipts_vetted_out": stats["vetted_out"],
+            "receipts_load_failed": stats["load_failed"],
+            "receipts_without_merchant": skipped_no_merchant,
+            "baseline_items": stats["baseline_items"],
+            "baseline_stylescan": stats["baseline_stylescan"],
+            "lines_ambiguous": stats["lines_ambiguous"],
+            "lines_unmeasured": stats["lines_unmeasured"],
+            "max_overlaps": args.max_overlaps,
+            "model_sources": dict(sorted(model_sources.items())),
+        },
+    }
+    text = json.dumps(obj, indent=2)
+    if args.out:
+        with open(args.out, "w", encoding="utf-8") as fh:
+            fh.write(text + "\n")
+        n_ok = sum(1 for e in entries if not e["low_confidence"])
+        print(
+            f"wrote {args.out}: {len(entries)} cells "
+            f"({n_ok} confident, {len(entries) - n_ok} low-confidence) "
+            f"over {len({e['merchant'] for e in entries})} merchants",
+            file=sys.stderr,
+        )
+    else:
+        print(text)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/glyph-studio/py/glyphstudio/face_map_v2.py
+++ b/tools/glyph-studio/py/glyphstudio/face_map_v2.py
@@ -1,0 +1,265 @@
+"""Face-map v2: (merchant, section) -> face priors MEASURED over QA'd sections.
+
+The M2 map (:mod:`glyphstudio.section_face_map`) reads each merchant's
+``stylemap.json`` — faces measured once per merchant, sections attributed by
+stylescan's per-merchant RULE tables. v2 replaces the section attribution with
+the QA'd ``ReceiptSection`` ground truth (line-level, ``validation_status=
+VALID``) and replaces the one-shot stylemap faces with per-line MEASUREMENTS
+(:func:`glyphstudio.stylescan.measure`) aggregated across every vetted receipt
+of the merchant:
+
+1. **join** — stylescan's visual lines carry the OCR ``line_ids`` that formed
+   them; a ``ReceiptSection`` row is a set of ``line_ids``. A visual line
+   belongs to a section when its line_ids hit exactly ONE section type;
+   straddlers (line_ids claimed by two different section types) are dropped as
+   ambiguous rather than voting for either.
+2. **body baseline** — cap/stroke medians over the receipt's QA'd ITEMS lines
+   (>= :data:`MIN_BODY_LINES` measurable lines), falling back to stylescan's
+   own rule-based body when the receipt has too few measurable items. Using
+   the QA'd items block keeps the baseline honest for merchants stylescan has
+   no rule table for.
+3. **per-line face** — the LETTERS-rung rules from face_select (branch
+   ``feat/m4-measured-faces``), constants duplicated here and kept in sync by
+   comment: a line is BOLD only when its strokes are both absolutely thicker
+   than body and disproportionate to its cap height (an enlarged header whose
+   strokes scale with its caps is the same face enlarged, not bold); scale
+   engages only above ``LARGE_CAP`` with enough cap samples (OCR jitter stays
+   1.0); a joint underline+reverse-video hit on a non-bold line is one dark
+   scan band, not print.
+4. **aggregate** — M2's ``Face`` semantics per (merchant, section): scale =
+   median, weight = mode with the LIGHTER weight winning ties, and
+   underline_rate = the measured rate over lines (v1's max-over-subfaces was
+   a stylemap fold artifact; here the rate is observed directly).
+
+Cells with fewer than :data:`LOW_CONFIDENCE_LINES` measured lines are emitted
+with ``low_confidence: true`` — present for coverage accounting, but not a
+prior anyone should trust (the locked M3 lesson: distributions, not n=1).
+
+Everything in this module is pure (no Dynamo, no S3); the CLI adapter
+(``face_map_v2_cli.py``) feeds it.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+from statistics import median
+from typing import Any, Iterable, Mapping, Optional
+
+from glyphstudio.section_face_map import _WEIGHT_ORDER, Face
+from glyphstudio.sections import CANONICAL_SECTION_SET
+
+# --- per-line face rules -----------------------------------------------------
+# Constants mirror glyphstudio.face_select (branch feat/m4-measured-faces);
+# see that module's docstring for the hand-checked receipts behind each. If
+# face_select lands on main, import from it instead of redefining.
+BOLD_STROKE_REL = 1.30
+BOLD_STROKE_TO_CAP = 1.30
+LARGE_CAP = 1.30
+SCALE_MAX = 2.5
+MIN_LETTERS = 4
+MIN_CAP_SAMPLES = 3
+
+# --- aggregation thresholds --------------------------------------------------
+MIN_BODY_LINES = 3  # measurable ITEMS lines needed to trust the QA'd baseline
+LOW_CONFIDENCE_LINES = 3  # cells with fewer measured lines are low-confidence
+
+
+@dataclass(frozen=True)
+class LineFace:
+    """One measured line's face vote plus its receipt provenance."""
+
+    scale: float
+    weight: str  # "normal" | "bold"
+    underline: bool
+    reverse_video: bool
+    receipt: tuple[str, int]  # (image_id, receipt_id)
+
+
+def assign_sections(
+    lines: Iterable[Mapping[str, Any]],
+    sections: Iterable[Mapping[str, Any]],
+) -> tuple[list[tuple[Mapping[str, Any], Optional[str]]], int]:
+    """Join stylescan visual lines to QA'd sections by OCR line id.
+
+    ``sections`` are ``{"section_type": "TOTAL_LINE", "line_ids": [...]}``
+    mappings (already filtered to VALID). Returns ``([(line, canonical_section
+    | None), ...], n_ambiguous)`` — a line whose line_ids are claimed by MORE
+    than one section type is dropped from the pairs entirely and counted
+    (straddler; letting it vote for either section corrupts both cells).
+    """
+    claim: dict[int, set[str]] = {}
+    for sec in sections:
+        canon = str(sec["section_type"]).lower()
+        if canon not in CANONICAL_SECTION_SET:
+            continue
+        for lid in sec["line_ids"]:
+            claim.setdefault(int(lid), set()).add(canon)
+
+    out: list[tuple[Mapping[str, Any], Optional[str]]] = []
+    ambiguous = 0
+    for line in lines:
+        hit: set[str] = set()
+        for lid in line.get("line_ids") or ():
+            hit |= claim.get(int(lid), set())
+        if len(hit) > 1:
+            ambiguous += 1
+            continue
+        out.append((line, next(iter(hit)) if hit else None))
+    return out, ambiguous
+
+
+def _measurable(line: Mapping[str, Any]) -> bool:
+    return bool(line.get("cap_px")) and (line.get("n_letters") or 0) >= MIN_LETTERS
+
+
+def items_body_baseline(
+    assigned: Iterable[tuple[Mapping[str, Any], Optional[str]]],
+    fallback_cap: Optional[float],
+    fallback_stroke: Optional[float],
+) -> tuple[Optional[float], Optional[float], str]:
+    """Receipt body (cap, stroke) from the QA'd ITEMS lines.
+
+    Falls back to stylescan's rule-based body when fewer than
+    ``MIN_BODY_LINES`` items lines are measurable (returns which source was
+    used as the third element: ``"items"`` / ``"stylescan"``).
+    """
+    caps = [
+        float(l["cap_px"])
+        for l, sec in assigned
+        if sec == "items" and _measurable(l)
+    ]
+    strokes = [
+        float(l["stroke_med"])
+        for l, sec in assigned
+        if sec == "items" and _measurable(l) and l.get("stroke_med")
+    ]
+    if len(caps) >= MIN_BODY_LINES:
+        return (
+            median(caps),
+            median(strokes) if strokes else fallback_stroke,
+            "items",
+        )
+    return fallback_cap, fallback_stroke, "stylescan"
+
+
+def _cap_samples(line: Mapping[str, Any]) -> int:
+    return sum(
+        1
+        for c in line.get("letters") or ()
+        if str(c.get("ch", ""))[:1].isupper() or str(c.get("ch", ""))[:1].isdigit()
+    )
+
+
+def line_face(
+    line: Mapping[str, Any],
+    body_cap: Optional[float],
+    body_stroke: Optional[float],
+    receipt: tuple[str, int],
+) -> Optional[LineFace]:
+    """The LETTERS-rung face for one measured line, or None if too thin.
+
+    Same decision surface as face_select.measured_style_for_line (see module
+    docstring): thin letter statistics yield None rather than a noisy vote.
+    """
+    if not _measurable(line) or not body_cap:
+        return None
+    cap_rel = float(line["cap_px"]) / float(body_cap)
+    stroke = line.get("stroke_med")
+    stroke_rel = (
+        float(stroke) / float(body_stroke) if stroke and body_stroke else None
+    )
+    bold = bool(
+        stroke_rel is not None
+        and stroke_rel >= BOLD_STROKE_REL
+        and stroke_rel / max(cap_rel, 1e-6) >= BOLD_STROKE_TO_CAP
+    )
+    scale = 1.0
+    if cap_rel >= LARGE_CAP and _cap_samples(line) >= MIN_CAP_SAMPLES:
+        scale = round(min(cap_rel, SCALE_MAX), 2)
+    underline = bool(line.get("underline"))
+    reverse = bool(line.get("reverse_video"))
+    if underline and reverse and not bold:
+        # One dark scan band trips both probes on a body-weight line
+        # (hand-checked, see face_select); a printed underline never
+        # coexists with reverse video.
+        underline = reverse = False
+    return LineFace(
+        scale=scale,
+        weight="bold" if bold else "normal",
+        underline=underline,
+        reverse_video=reverse,
+        receipt=receipt,
+    )
+
+
+def aggregate_cell(members: list[LineFace]) -> dict[str, Any]:
+    """M2 Face aggregation over one (merchant, section) cell's line votes.
+
+    scale = median; weight = mode with the LIGHTER weight winning ties (a
+    rare emphasis line must not bold the whole section); underline_rate =
+    observed rate. Adds sample accounting: ``n_lines``, ``n_receipts``,
+    ``low_confidence`` (n_lines < LOW_CONFIDENCE_LINES) and the audit-only
+    ``reverse_video_rate``.
+    """
+    if not members:
+        raise ValueError("aggregate_cell needs at least one member line")
+    counts = Counter(m.weight for m in members)
+    top = max(counts.values())
+    weight = min(
+        (w for w, c in counts.items() if c == top),
+        key=lambda w: _WEIGHT_ORDER.get(w, 0),
+    )
+    face = Face(
+        scale=round(median(m.scale for m in members), 3),
+        weight=weight,
+        underline_rate=round(
+            sum(1 for m in members if m.underline) / len(members), 4
+        ),
+    )
+    return {
+        "face": face,
+        "n_lines": len(members),
+        "n_receipts": len({m.receipt for m in members}),
+        "low_confidence": len(members) < LOW_CONFIDENCE_LINES,
+        "reverse_video_rate": round(
+            sum(1 for m in members if m.reverse_video) / len(members), 4
+        ),
+    }
+
+
+def aggregate_map(
+    cells: Mapping[tuple[str, str], list[LineFace]],
+) -> list[dict[str, Any]]:
+    """All cells -> sorted v2 map entries (merchant, section, face, counts)."""
+    out = []
+    for (merchant, section), members in sorted(cells.items()):
+        if not members:
+            continue
+        agg = aggregate_cell(members)
+        out.append({"merchant": merchant, "section": section, **agg})
+    return out
+
+
+def merchant_section_priors(
+    map_obj: Mapping[str, Any],
+    merchant: str,
+    *,
+    include_low_confidence: bool = False,
+) -> dict[str, dict[str, Any]]:
+    """v2 map JSON -> {canonical_section: face dict} for one merchant.
+
+    The face dicts are Mapping-shaped priors accepted by face_select's
+    ``_style_from_prior`` (keys ``scale`` / ``weight`` / ``underline_rate``),
+    i.e. a drop-in replacement for M2's ``load_merchant_faces``. Low-
+    confidence cells are excluded by default — a prior measured from fewer
+    than LOW_CONFIDENCE_LINES lines misleads more than it helps.
+    """
+    out: dict[str, dict[str, Any]] = {}
+    for entry in map_obj.get("map") or ():
+        if entry.get("merchant") != merchant:
+            continue
+        if entry.get("low_confidence") and not include_low_confidence:
+            continue
+        out[str(entry["section"])] = dict(entry["face"])
+    return out

--- a/tools/glyph-studio/py/glyphstudio/stylescan.py
+++ b/tools/glyph-studio/py/glyphstudio/stylescan.py
@@ -595,6 +595,15 @@ def measure(image_id: str, receipt_id: int, merchant: str = "sprouts") -> dict:
         out_lines.append(
             {
                 "reverse_video": reverse_video,
+                # OCR line ids feeding this visual line -- the join key to
+                # ReceiptSection.line_ids (face-map v2).
+                "line_ids": sorted(
+                    {
+                        int(w["line_id"])
+                        for w in line
+                        if w["line_id"] is not None
+                    }
+                ),
                 "text": text[:60],
                 "section": section,
                 "section_canonical": normalize_stylescan_section(section),

--- a/tools/glyph-studio/py/tests/test_face_map_v2.py
+++ b/tools/glyph-studio/py/tests/test_face_map_v2.py
@@ -1,0 +1,232 @@
+"""Unit tests for face-map v2's section join + measured-face aggregation."""
+
+import pytest
+
+from glyphstudio.face_map_v2 import (
+    LineFace,
+    aggregate_cell,
+    aggregate_map,
+    assign_sections,
+    items_body_baseline,
+    line_face,
+    merchant_section_priors,
+)
+
+R = ("img-1", 1)
+
+
+def _line(line_ids, cap=10.0, stroke=2.0, n_letters=8, caps=6, **kw):
+    """A stylescan visual line with enough letter statistics to measure."""
+    letters = [{"ch": "A"}] * caps + [{"ch": "a"}] * (n_letters - caps)
+    d = {
+        "line_ids": line_ids,
+        "cap_px": cap,
+        "stroke_med": stroke,
+        "n_letters": n_letters,
+        "letters": letters,
+        "underline": False,
+        "reverse_video": 0,
+    }
+    d.update(kw)
+    return d
+
+
+# --- join -------------------------------------------------------------------
+
+
+def test_assign_sections_by_line_id():
+    lines = [_line([1]), _line([2]), _line([9])]
+    sections = [
+        {"section_type": "ITEMS", "line_ids": [1]},
+        {"section_type": "TOTAL_LINE", "line_ids": [2]},
+    ]
+    pairs, ambiguous = assign_sections(lines, sections)
+    assert ambiguous == 0
+    assert [sec for _, sec in pairs] == ["items", "total_line", None]
+
+
+def test_assign_sections_drops_straddlers():
+    # a visual line whose OCR lines are claimed by TWO section types must not
+    # vote for either cell
+    lines = [_line([1, 2])]
+    sections = [
+        {"section_type": "SUMMARY", "line_ids": [1]},
+        {"section_type": "TOTAL_LINE", "line_ids": [2]},
+    ]
+    pairs, ambiguous = assign_sections(lines, sections)
+    assert ambiguous == 1
+    assert pairs == []
+
+
+def test_assign_sections_multi_line_one_section_ok():
+    # merging two OCR lines of the SAME section is not a straddle
+    lines = [_line([1, 2])]
+    sections = [{"section_type": "ITEMS", "line_ids": [1, 2, 3]}]
+    pairs, ambiguous = assign_sections(lines, sections)
+    assert ambiguous == 0
+    assert pairs[0][1] == "items"
+
+
+def test_assign_sections_ignores_non_canonical():
+    lines = [_line([1])]
+    sections = [{"section_type": "HEADER", "line_ids": [1]}]  # legacy type
+    pairs, _ = assign_sections(lines, sections)
+    assert pairs[0][1] is None
+
+
+# --- body baseline ------------------------------------------------------------
+
+
+def test_body_baseline_from_items():
+    assigned = [
+        (_line([1], cap=10.0, stroke=2.0), "items"),
+        (_line([2], cap=12.0, stroke=2.2), "items"),
+        (_line([3], cap=11.0, stroke=2.1), "items"),
+        (_line([4], cap=30.0, stroke=6.0), "storefront"),  # must not skew body
+    ]
+    cap, stroke, src = items_body_baseline(assigned, 99.0, 9.0)
+    assert src == "items"
+    assert cap == 11.0
+    assert stroke == 2.1
+
+
+def test_body_baseline_falls_back_when_items_thin():
+    assigned = [(_line([1], cap=10.0), "items")]  # < MIN_BODY_LINES
+    cap, stroke, src = items_body_baseline(assigned, 9.5, 1.9)
+    assert (cap, stroke, src) == (9.5, 1.9, "stylescan")
+
+
+# --- per-line face -------------------------------------------------------------
+
+
+def test_line_face_body_line_is_plain():
+    lf = line_face(_line([1], cap=10.0, stroke=2.0), 10.0, 2.0, R)
+    assert (lf.scale, lf.weight, lf.underline) == (1.0, "normal", False)
+
+
+def test_line_face_bold_needs_disproportionate_stroke():
+    # 1.5x stroke at body cap -> bold
+    lf = line_face(_line([1], cap=10.0, stroke=3.0), 10.0, 2.0, R)
+    assert lf.weight == "bold"
+    # enlarged header whose strokes scale WITH caps (same face, bigger) ->
+    # NOT bold (the hand-won Wild Fork header rule)
+    lf = line_face(_line([1], cap=17.0, stroke=3.3), 10.0, 2.0, R)
+    assert lf.weight == "normal"
+    assert lf.scale == 1.7
+
+
+def test_line_face_scale_needs_cap_samples():
+    # a 1.5x cap read off <3 upper/digit samples is an OCR smear, not a size
+    lf = line_face(_line([1], cap=15.0, caps=2, n_letters=8), 10.0, 2.0, R)
+    assert lf.scale == 1.0
+
+
+def test_line_face_scale_clamped():
+    lf = line_face(_line([1], cap=50.0), 10.0, 2.0, R)
+    assert lf.scale == 2.5
+
+
+def test_line_face_thin_stats_yield_none():
+    assert line_face(_line([1], n_letters=2, caps=2), 10.0, 2.0, R) is None
+    assert line_face(_line([1], cap=None), 10.0, 2.0, R) is None
+    assert line_face(_line([1]), None, None, R) is None
+
+
+def test_line_face_underline_plus_reverse_is_scan_band():
+    # both probes firing on a non-bold line = one dark band artifact
+    lf = line_face(
+        _line([1], underline=True, reverse_video=1), 10.0, 2.0, R
+    )
+    assert lf.underline is False and lf.reverse_video is False
+    # on a BOLD line the pair is kept (Costco reverse-video TOTAL box)
+    lf = line_face(
+        _line([1], stroke=3.0, underline=True, reverse_video=1), 10.0, 2.0, R
+    )
+    assert lf.underline is True and lf.reverse_video is True
+
+
+# --- aggregation ---------------------------------------------------------------
+
+
+def _lf(scale=1.0, weight="normal", underline=False, reverse=False, receipt=R):
+    return LineFace(scale, weight, underline, reverse, receipt)
+
+
+def test_aggregate_cell_median_scale_mode_weight():
+    agg = aggregate_cell(
+        [
+            _lf(1.0),
+            _lf(1.5, "bold", underline=True, receipt=("img-2", 1)),
+            _lf(2.0, receipt=("img-3", 1)),
+        ]
+    )
+    assert agg["face"].scale == 1.5
+    assert agg["face"].weight == "normal"  # mode over lines
+    assert agg["face"].underline_rate == pytest.approx(1 / 3, abs=1e-4)
+    assert agg["n_lines"] == 3
+    assert agg["n_receipts"] == 3
+    assert agg["low_confidence"] is False
+
+
+def test_aggregate_cell_tie_prefers_lighter():
+    agg = aggregate_cell([_lf(weight="bold"), _lf(weight="normal")])
+    assert agg["face"].weight == "normal"
+
+
+def test_aggregate_cell_low_confidence_below_three_lines():
+    agg = aggregate_cell([_lf(), _lf()])
+    assert agg["low_confidence"] is True
+    assert agg["n_lines"] == 2
+
+
+def test_aggregate_cell_empty_raises():
+    with pytest.raises(ValueError):
+        aggregate_cell([])
+
+
+def test_aggregate_map_sorted_entries():
+    cells = {
+        ("vons", "items"): [_lf()],
+        ("costco", "total_line"): [_lf(weight="bold")],
+    }
+    entries = aggregate_map(cells)
+    assert [(e["merchant"], e["section"]) for e in entries] == [
+        ("costco", "total_line"),
+        ("vons", "items"),
+    ]
+
+
+# --- consumer adapter -----------------------------------------------------------
+
+
+def test_merchant_section_priors_shape_and_filtering():
+    map_obj = {
+        "map": [
+            {
+                "merchant": "costco",
+                "section": "total_line",
+                "face": {"scale": 1.4, "weight": "bold", "underline_rate": 0.8},
+                "low_confidence": False,
+            },
+            {
+                "merchant": "costco",
+                "section": "survey",
+                "face": {"scale": 1.0, "weight": "normal", "underline_rate": 0.0},
+                "low_confidence": True,
+            },
+            {
+                "merchant": "vons",
+                "section": "items",
+                "face": {"scale": 1.0, "weight": "normal", "underline_rate": 0.0},
+                "low_confidence": False,
+            },
+        ]
+    }
+    priors = merchant_section_priors(map_obj, "costco")
+    assert set(priors) == {"total_line"}  # low-confidence excluded by default
+    # Mapping-shaped prior with the face_select._style_from_prior keys
+    assert priors["total_line"]["weight"] == "bold"
+    assert priors["total_line"]["scale"] == 1.4
+    assert priors["total_line"]["underline_rate"] == 0.8
+    both = merchant_section_priors(map_obj, "costco", include_low_confidence=True)
+    assert set(both) == {"total_line", "survey"}


### PR DESCRIPTION
Regenerates the font-intelligence epic's (merchant, section) -> face map from the newly QA'd `ReceiptSection` ground truth, replacing v1's two weakest links:

- **v1 (PR #1079)**: sections attributed by stylescan's per-merchant RULE tables, faces read once per merchant from committed `stylemap.json` — 9 merchants, no sample accounting.
- **v2 (this PR)**: sections come from the QA'd corpus in dev Dynamo (4,865 VALID rows across 795 receipts, three-pass judge/repair/polish), and every face is MEASURED per line across all vetted receipts of the merchant, then aggregated with M2's Face semantics.

## How it's built

1. **Join** — `stylescan.measure` now emits the OCR `line_ids` behind each visual line; a visual line joins a section when its line_ids hit exactly one VALID section type. Straddlers (line_ids claimed by two types) are dropped as ambiguous rather than voting for either cell (372 lines corpus-wide).
2. **Vetting (locked M3 rule)** — receipts with `ocr_overlap_score > 2` are excluded: 166 of 795, including the notorious Wild Fork `058b662d` (17 overlaps) that single-handedly created v1's "WF rails ~48% too dense" artifact, and a Home Depot scan at 266. Pixels load via the loader's cdn-first path.
3. **Body baseline** — cap/stroke medians over the receipt's own QA'd ITEMS lines (>= 3 measurable), falling back to stylescan's rule-based body otherwise (235 items / 393 fallback). Keeps the baseline honest for the 186 merchants stylescan has no rule table for.
4. **Per-line face** — the LETTERS-rung rules from `face_select` (branch `feat/m4-measured-faces`, constants mirrored + comment-pinned): bold only on disproportionate stroke (an enlarged header whose strokes scale with its caps is the same face enlarged), scale gated on >= 3 cap samples, joint underline+reverse hits on non-bold lines treated as one dark scan band.
5. **Aggregation (M2 semantics)** — scale = median, weight = mode with the LIGHTER weight winning ties, underline_rate = observed rate over lines (v1's max-over-subfaces was a stylemap fold artifact; here the rate is measured directly). Same `families`/`threshold`/`map` JSON shape M4's `select_row_faces` consumes; `face_map_v2.merchant_section_priors` is a drop-in for `load_merchant_faces`.

## Coverage

| | v1 | v2 |
|---|---|---|
| merchants | 9 | **195** |
| (merchant, section) cells | 67 | **1,020** |
| cells with n_lines >= 3 (confident) | — (no sample accounting) | **573** |
| low-confidence cells (n < 3, flagged, excluded from priors by default) | — | 447 |
| receipts measured / vetted out | — | 628 / 166 |

## v1 -> v2 diff (64 shared cells: 55 same face, 9 changed)

### Cells that changed face

| merchant | section | v1 (scale/weight/ul) | v2 | n_lines | n_receipts | what changed |
|---|---|---|---|---|---|---|
| costco | barcode | 0.828/normal/ul=0.0 | 1.0/normal/ul=0.0 | 18 | 18 | scale |
| costco | storefront | 1.227/normal/ul=0.0 | 1.505/normal/ul=0.0 | 56 | 22 | scale |
| cvs | storefront | 1.0/normal/ul=0.06 | 2.5/normal/ul=0.0 | 9 | 9 | scale |
| innout | total_line | 1.0/**bold**/ul=0.034 | 1.0/**normal**/ul=0.0 | 13 | 10 | weight |
| sprouts | barcode | 0.85/normal/ul=0.041 | 1.0/normal/ul=0.0078 | 129 | 110 | scale |
| target | section_header | 0.95/**bold**/ul=0.0 | 1.0/**normal**/ul=0.0 | 2 (LOW-CONF) | 1 | weight |
| traderjoes | storefront | 1.05/normal/ul=0.01 | 2.04/normal/ul=0.0278 | 36 | 19 | scale |
| vons | section_header | 1.05/**bold**/ul=0.0 | 1.0/**normal**/ul=0.0 | 18 | 11 | weight |
| vons | storefront | 1.0/normal/ul=0.009 | 2.5/normal/ul=0.0 | 27 | 20 | scale |

The interesting ones:

- **Storefront scales jump (cvs/vons/traderjoes/costco)** — v1's stylemaps carried body-ish storefront scales because the big merchant name is usually drawn by the logo overlay, not text. v2 measures the print as-is, so large logotype lines read as 2.0–2.5x (clamped at `SCALE_MAX=2.5`). Callers that draw logos via overlay should keep doing so; the prior now describes what's actually printed.
- **Bold flips to normal (vons section_header, innout total_line)** — mode-over-measured-lines with the lighter tie-break disagrees with the hand-written stylemaps: most VONS department headers and In-N-Out amount-due lines measure body-weight. v1's bold came from one-shot eyeballing; v2 has 18/13 lines across 11/10 receipts behind the flip.
- **Barcode captions are body-size (sprouts n=129, costco n=18)** — v1 said 0.83–0.85x; measured caption digits are body-height.
- **target section_header flips too but is flagged LOW-CONF (n=2)** — exactly the misleading-prior class the n>=3 rule exists for; `merchant_section_priors` excludes it by default.

### v1-only cells (3) — rule-attributed sections v2 never measured

| merchant | section | v1 face |
|---|---|---|
| homedepot | storefront | 1.0/normal/ul=0.0 |
| innout | barcode | 0.98/normal/ul=0.0 |
| target | storefront | 1.0/normal/ul=0.023 |

(The QA'd corpus has no VALID storefront rows joinable to letter-measurable lines for these — Home Depot/Target storefronts are mostly logo pixels.)

### v2-only cells: 956 across 192 merchants (186 merchants new in v2; 513 confident)

The QA'd corpus reaches far beyond the 9 hand-ruled merchants. A sample of confident new cells with non-trivial faces:

| merchant | section | v2 face | n_lines | n_receipts | reverse_video_rate |
|---|---|---|---|---|---|
| dollartree | storefront | 2.19/bold/ul=0.0 | 5 | 5 | 0.60 |
| chasebank | storefront | 2.45/normal/ul=0.0 | 3 | 3 | 0.0 |
| ralphsfreshfare | storefront | 1.655/normal/ul=0.0 | 4 | 2 | 0.0 |
| smithsmarketplace | storefront | 1.35/normal/ul=0.0 | 6 | 3 | 0.0 |
| roastriceasianfusion | total_line | 1.0/bold/ul=0.0 | 3 | 3 | 0.0 |
| mainstprovisions | total_line | 1.42/bold/ul=0.0 | 3 | 2 | 0.0 |
| urthcaffe | footer | 1.0/bold/ul=0.0 | 4 | 4 | 0.0 |
| bluebottlecoffee | address | 1.0/normal/ul=0.375 | 8 | 3 | 0.0 |
| traderjoes | barcode (new cell) | 1.0/normal/ul=0.0 | 8 | 8 | 0.375 |

## Known limitations (deliberate scope cuts)

- **Merchant keys are name-derived slugs** — merchants outside the calibrated `MERCHANT_SLUGS` get squashed-lowercase names, so place-name noise splits cells (`aimmailcenter` vs `aimmailcenter18`, `target` vs `targetgrocery`). Canonical merchant naming is its own workstream; the 9 calibrated slugs are stable and v1-comparable.
- **`family` is merchant-self for the 186 new merchants** — family discovery needs glyph atlases, which only the 9 font-dir merchants have. Same fallback `build_section_face_map` uses.
- **Dev reads only** — the generator reads Dynamo + S3 and writes nothing but the JSON.

## Testing

- 18 new unit tests (join incl. straddler drop and legacy-type skip, items-baseline fallback, per-line bold/scale/underline rules incl. the enlarged-header and scan-band cases, aggregation tie-break and low-confidence marking, consumer-shaped priors adapter); full glyphstudio suite 129 passed.
- Full generation run end-to-end against dev (628 receipts, 0 load failures); output committed at `tools/glyph-studio/maps/section_face_map_v2.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SRtFcxkcw1t3nZsVHstZGL
