### PR TITLE
Section-conditioned heavy-atlas mint pilot: Sprouts

### DIFF
--- a/synthesis_loop/anti_copy_npz.py
+++ b/synthesis_loop/anti_copy_npz.py
@@ -39,6 +39,10 @@ def main():
             print(f"ANTI-COPY FAIL: {len(same)}/{len(mine)} substantial glyphs byte-identical "
                   f"to {os.path.basename(other)} (e.g. {sorted(same)[:6]})")
             return 1
+    if worst is None:
+        # Fail closed: with no reference atlases the check proved nothing.
+        print(f"ANTI-COPY INCONCLUSIVE: no reference *.glyphs.npz in {args.fleet_dir}")
+        return 1
     print(f"anti-copy PASS: worst overlap {worst[1]:.0%} with {worst[0]} "
           f"({len(worst[2])}/{len(mine)} identical)")
     return 0

--- a/synthesis_loop/anti_copy_npz.py
+++ b/synthesis_loop/anti_copy_npz.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Anti-copy gate for npz atlases: refuse a mint whose glyph bitmaps duplicate
+another merchant's atlas (mirrors publish_merchant_font._reject_copied_letterforms,
+which checks parametric skeleton JSON; here we compare the binary bitmaps).
+
+Trivial glyphs (tiny ink) legitimately coincide; only substantial glyphs count.
+
+Usage: anti_copy_npz.py CANDIDATE.npz [--fleet-dir /tmp/bitmatrix]
+"""
+import argparse, glob, os, sys
+import numpy as np
+
+
+def load(p):
+    z = np.load(p)
+    return {k: z[k] for k in z.files if k.startswith("c")}
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("candidate")
+    ap.add_argument("--fleet-dir", default=os.environ.get("BITMATRIX_DIR", "/tmp/bitmatrix"))
+    args = ap.parse_args()
+    mine = {k: v for k, v in load(args.candidate).items() if v.sum() >= 40}
+    if not mine:
+        print("no substantial glyphs to check")
+        return 0
+    worst = None
+    for other in sorted(glob.glob(os.path.join(args.fleet_dir, "*.glyphs.npz"))):
+        if os.path.abspath(other) == os.path.abspath(args.candidate):
+            continue
+        theirs = load(other)
+        same = [k for k, v in mine.items()
+                if k in theirs and v.shape == theirs[k].shape and np.array_equal(v, theirs[k])]
+        frac = len(same) / len(mine)
+        if worst is None or frac > worst[1]:
+            worst = (os.path.basename(other), frac, same)
+        if len(same) > max(4, int(0.25 * len(mine))):
+            print(f"ANTI-COPY FAIL: {len(same)}/{len(mine)} substantial glyphs byte-identical "
+                  f"to {os.path.basename(other)} (e.g. {sorted(same)[:6]})")
+            return 1
+    print(f"anti-copy PASS: worst overlap {worst[1]:.0%} with {worst[0]} "
+          f"({len(worst[2])}/{len(mine)} identical)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/synthesis_loop/build_merchant_glyphs.py
+++ b/synthesis_loop/build_merchant_glyphs.py
@@ -344,7 +344,31 @@ def _collect(merchants, max_receipts):
     # poison the median-vote consensus) can drive the build. See
     # ADD_MERCHANT.md step 0.
     keys_json = os.environ.get("GLYPH_KEYS_JSON")
-    if keys_json:
+    # Section-conditioned pooling: GLYPH_LINE_KEYS_JSON points at a JSON dict
+    # {"<image_id>#<receipt_id>": [line_id, ...]} and RESTRICTS the corpus to
+    # exactly those printed lines (e.g. the bold-tier rows of a merchant's QA'd
+    # ReceiptSections), so a heavy atlas is minted from real bold letterforms
+    # rather than a uniform dilation of the body face. The receipt set is the
+    # keys of the map, so it also replaces the merchant query.
+    line_keys_json = os.environ.get("GLYPH_LINE_KEYS_JSON")
+    line_filter: dict[tuple[str, int], set[int]] | None = None
+    if line_keys_json:
+        import json  # noqa: PLC0415
+
+        with open(line_keys_json, encoding="utf-8") as fh:
+            raw = json.load(fh)
+        line_filter = {}
+        for k, lids in raw.items():
+            iid, _, rid = str(k).partition("#")
+            line_filter[(iid, int(rid))] = {int(x) for x in lids}
+        targets = sorted(line_filter.keys())
+        n_lines = sum(len(v) for v in line_filter.values())
+        print(
+            f"GLYPH_LINE_KEYS_JSON: {len(targets)} receipts, "
+            f"{n_lines} allowed lines",
+            flush=True,
+        )
+    elif keys_json:
         import json  # noqa: PLC0415
 
         with open(keys_json, encoding="utf-8") as fh:
@@ -379,7 +403,10 @@ def _collect(merchants, max_receipts):
         lines = defaultdict(list)
         for lt in letters:
             lines[lt.line_id].append(lt)
-        for _, lts in lines.items():
+        allowed = line_filter.get((iid, rid)) if line_filter else None
+        for line_id, lts in lines.items():
+            if allowed is not None and int(line_id) not in allowed:
+                continue
             glyphs = []  # (ch, mask, ink_bottom_abs, ink_h)
             for lt in lts:
                 ch = (lt.text or "").strip()

--- a/synthesis_loop/compose_heavy_npz.py
+++ b/synthesis_loop/compose_heavy_npz.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Compose a render-usable HEAVY atlas from a (partial) section-conditioned
+mint plus the merchant's regular atlas as backfill.
+
+The renderer's per-char fallback for an atlas miss is the TTF face, NOT the
+regular atlas -- so a sparse minted heavy face would draw bold rows in a mixed
+alien face. Overlaying the minted bold glyphs on the full regular atlas keeps
+every char in the merchant's own letterforms while the chars with real bold
+evidence use it.
+
+Writes ``OUT.npz`` plus ``OUT.manifest.json`` documenting the composition:
+which chars are minted (true bold), which are backfilled (regular weight), and
+which minted chars were dropped by ``--drop`` curation (e.g. a glyph the
+identity gate flagged as MISRENDER).
+
+Usage:
+  compose_heavy_npz.py MINTED_HEAVY.npz REGULAR.npz OUT.npz [--drop KX...]
+
+Nothing publishes; the compiled npz + manifest stay local (same policy as
+every other atlas: JSON sources in-repo, npz artifacts out).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+
+import numpy as np
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("minted")
+    ap.add_argument("regular")
+    ap.add_argument("out")
+    ap.add_argument(
+        "--drop",
+        default="",
+        help="chars to exclude from the minted overlay (curation), e.g. 'K'",
+    )
+    args = ap.parse_args(argv)
+
+    zm, zr = np.load(args.minted), np.load(args.regular)
+    dropped = set(args.drop)
+    payload: dict[str, np.ndarray] = {k: zr[k] for k in zr.files}
+    minted, backfilled = [], []
+    for k in zm.files:
+        if not k.startswith("c"):
+            continue
+        ch = chr(int(k[1:]))
+        if ch in dropped:
+            continue
+        payload[k] = zm[k]
+        ok = "o" + k[1:]
+        if ok in zm.files:
+            payload[ok] = zm[ok]
+        minted.append(ch)
+    minted_set = set(minted)
+    for k in zr.files:
+        if k.startswith("c") and chr(int(k[1:])) not in minted_set:
+            backfilled.append(chr(int(k[1:])))
+    np.savez_compressed(args.out, **payload)
+
+    manifest = {
+        "out": os.path.basename(args.out),
+        "minted_source": os.path.basename(args.minted),
+        "backfill_source": os.path.basename(args.regular),
+        "minted_chars": "".join(sorted(minted)),
+        "n_minted": len(minted),
+        "backfilled_chars": "".join(sorted(backfilled)),
+        "n_backfilled": len(backfilled),
+        "dropped_from_mint": "".join(sorted(dropped & {
+            chr(int(k[1:])) for k in zm.files if k.startswith("c")
+        })),
+        "note": (
+            "minted chars carry true bold letterforms from the merchant's "
+            "own bold rows (section-conditioned mint); backfilled chars are "
+            "the REGULAR face at body weight -- rows mixing both will show a "
+            "weight seam on backfilled chars."
+        ),
+    }
+    mpath = os.path.splitext(args.out)[0] + ".manifest.json"
+    # foo.glyphs.npz -> foo.glyphs.manifest.json (strip only the .npz)
+    with open(mpath, "w", encoding="utf-8") as fh:
+        json.dump(manifest, fh, indent=1)
+    print(
+        f"wrote {args.out}: {len(minted)} minted "
+        f"({manifest['minted_chars']}), {len(backfilled)} backfilled; "
+        f"manifest -> {mpath}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/synthesis_loop/compose_heavy_npz.py
+++ b/synthesis_loop/compose_heavy_npz.py
@@ -79,8 +79,9 @@ def main(argv=None) -> int:
             "weight seam on backfilled chars."
         ),
     }
+    # foo.glyphs.npz -> foo.glyphs.manifest.json (splitext strips the final
+    # extension, i.e. the .npz)
     mpath = os.path.splitext(args.out)[0] + ".manifest.json"
-    # foo.glyphs.npz -> foo.glyphs.manifest.json (strip only the .npz)
     with open(mpath, "w", encoding="utf-8") as fh:
         json.dump(manifest, fh, indent=1)
     print(

--- a/synthesis_loop/render_face_ab.py
+++ b/synthesis_loop/render_face_ab.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""A/B/C render harness for a candidate HEAVY atlas.
+
+Renders one real receipt through the standard profile/stylemap pipeline three
+times, differing only in the profile's ``bitmap_font.heavy`` slot:
+
+  A) heavy := regular       -> stylemap-bold rows fall back to 1px double-strike
+  B) heavy := CANDIDATE     -> bold rows draw the candidate face (chars the
+                               candidate lacks fall through to the TTF fallback)
+  C) heavy := $COMPOSITE_HEAVY_NPZ (optional env) -> e.g. candidate glyphs
+                               backfilled with the regular face for coverage
+
+Same canvas geometry for every variant. Writes the per-variant renders plus a
+REAL | A | B [| C] side-by-side composite, and prints the line-scorecard
+summary per variant (severity counts must not regress vs A).
+
+Usage:
+  render_face_ab.py <merchant> <slug> <image_id> <receipt_id> <heavy.npz> <outdir>
+
+Env: DYNAMODB_TABLE_NAME (default ReceiptsTable-dc5be22), AWS creds,
+COMPOSITE_HEAVY_NPZ (optional C variant), BITMATRIX_DIR for the atlases.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from io import BytesIO
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_ROOT = os.path.dirname(_HERE)
+for _p in (
+    _HERE,
+    os.path.join(_ROOT, "scripts"),
+    os.path.join(_ROOT, "receipt_agent"),
+    os.path.join(_ROOT, "receipt_dynamo"),
+    os.path.join(_ROOT, "receipt_upload"),
+):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+
+def main() -> int:
+    if len(sys.argv) < 7:
+        print(__doc__)
+        return 2
+    merchant, slug, iid, rid_s, heavy_npz, outdir = sys.argv[1:7]
+    rid = int(rid_s)
+    os.makedirs(outdir, exist_ok=True)
+
+    import boto3
+    from PIL import Image, ImageDraw, ImageFont
+
+    import render_synthetic_receipts as rsr
+    from receipt_line_scorecard import score_receipt_images
+
+    from receipt_dynamo.data.dynamo_client import DynamoClient
+
+    table = os.environ.get("DYNAMODB_TABLE_NAME", "ReceiptsTable-dc5be22")
+    region = os.environ.get("AWS_REGION", "us-east-1")
+    c = DynamoClient(table_name=table, region=region)
+    s3 = boto3.client("s3", region_name=region)
+    prof = rsr.cached_font_profile(table, merchant, region=region, max_receipts=12)
+    ss = rsr.section_scale_for_merchant(merchant)
+    typ = rsr.merchant_typography(merchant)
+    if "bitmap_font" not in typ:
+        raise SystemExit(f"{merchant}: no resolvable bitmap_font (atlases missing)")
+
+    d = c.get_image_details(iid)
+    rec = next((r for r in d.receipts if str(r.receipt_id) == str(rid)), None)
+    if rec is None:
+        raise SystemExit(f"receipt {rid} not found for {iid}")
+    lbl = {
+        (l.line_id, l.word_id): l.label
+        for l in d.receipt_word_labels
+        if l.receipt_id == rid
+    }
+    words = [
+        {
+            "text": w.text,
+            "line_id": w.line_id,
+            "word_id": w.word_id,
+            "bbox": [
+                w.top_left["x"] * 1000,
+                w.top_left["y"] * 1000,
+                w.bottom_right["x"] * 1000,
+                w.bottom_right["y"] * 1000,
+            ],
+            "labels": (
+                [lbl[(w.line_id, w.word_id)]]
+                if lbl.get((w.line_id, w.word_id)) not in (None, "O")
+                else []
+            ),
+        }
+        for w in d.receipt_words
+        if w.receipt_id == rid
+    ]
+    barcodes = []
+    if hasattr(c, "list_receipt_barcodes_from_receipt"):
+        try:
+            barcodes = [
+                {
+                    "text": getattr(b, "text", "") or "",
+                    "symbology": getattr(b, "symbology", ""),
+                    "top_left": getattr(b, "top_left", None),
+                    "bottom_right": getattr(b, "bottom_right", None),
+                    "confidence": getattr(b, "confidence", None),
+                }
+                for b in c.list_receipt_barcodes_from_receipt(iid, rid)
+            ]
+        except Exception:  # noqa: BLE001
+            barcodes = []
+
+    wt = 760
+    ht = int(round(wt * rec.height / rec.width))
+    reg = typ["bitmap_font"]["regular"]
+    variants = {
+        "A_regular_only": {"regular": reg, "heavy": reg},
+        "B_section_heavy": {"regular": reg, "heavy": heavy_npz},
+    }
+    comp = os.environ.get("COMPOSITE_HEAVY_NPZ")
+    if comp:
+        variants["C_composite_heavy"] = {"regular": reg, "heavy": comp}
+
+    synths = {}
+    for name, bf in variants.items():
+        t2 = dict(typ)
+        t2["bitmap_font"] = bf
+        path = os.path.join(outdir, f"{slug}_{iid[:8]}_{rid}_{name}.png")
+        rsr._render_cached_hybrid(
+            {"words": words, "barcodes": barcodes, "merchant_name": merchant},
+            None,
+            profile=prof,
+            width=wt,
+            height=ht,
+            path=path,
+            section_scale=ss,
+            **t2,
+        )
+        synths[name] = Image.open(path).convert("RGB")
+
+    real = None
+    for bkt, key in (
+        (rec.cdn_s3_bucket, rec.cdn_s3_key),
+        (rec.raw_s3_bucket, rec.raw_s3_key),
+    ):
+        if not bkt or not key:
+            continue
+        try:
+            real = Image.open(
+                BytesIO(s3.get_object(Bucket=bkt, Key=key)["Body"].read())
+            ).convert("RGB")
+            break
+        except Exception:  # noqa: BLE001
+            continue
+
+    scores = {}
+    if real is not None:
+        real_m = real.resize((wt, ht))
+        for name, syn in synths.items():
+            try:
+                sm = score_receipt_images(real_m, syn, words)["summary"]
+                scores[name] = {
+                    "severity_counts": sm["severity_counts"],
+                    "height_ratio_median": sm["height_ratio_median"],
+                    "density_ratio_median": sm["density_ratio_median"],
+                    "wpc_ratio_median": sm["wpc_ratio_median"],
+                }
+            except Exception as e:  # noqa: BLE001
+                scores[name] = {"error": str(e)[:80]}
+
+    wd = 380
+
+    def _byw(im):
+        w, h = im.size
+        return im.resize((wd, int(h * wd / w)))
+
+    panels = [("REAL", real)] if real is not None else []
+    panels += [(n.replace("_", " "), im) for n, im in synths.items()]
+    panels = [(t, _byw(im)) for t, im in panels]
+    hh = max(im.height for _, im in panels) + 40
+    cv = Image.new(
+        "RGB", (wd * len(panels) + 20 * (len(panels) + 1), hh), (235, 235, 235)
+    )
+    dd = ImageDraw.Draw(cv)
+    try:
+        lab = ImageFont.truetype(
+            "/System/Library/Fonts/Supplemental/Arial.ttf", 15
+        )
+    except OSError:
+        lab = ImageFont.load_default()
+    x = 20
+    for t, im in panels:
+        cv.paste(im, (x, 34))
+        dd.text((x, 12), t, fill=(200, 0, 0), font=lab)
+        x += wd + 20
+    out = os.path.join(outdir, f"ab_{slug}_{iid[:8]}_{rid}.png")
+    cv.save(out)
+    print(json.dumps({"out": out, "scores": scores}, indent=1))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/synthesis_loop/render_face_ab.py
+++ b/synthesis_loop/render_face_ab.py
@@ -5,6 +5,10 @@ Renders one real receipt through the standard profile/stylemap pipeline three
 times, differing only in the profile's ``bitmap_font.heavy`` slot:
 
   A) heavy := regular       -> stylemap-bold rows fall back to 1px double-strike
+                               (receipt_renderer only routes a bold row to the
+                               heavy face when bitmap_font["heavy"] differs from
+                               bitmap_font["regular"]; pointing both slots at
+                               the same file is exactly the double-strike path)
   B) heavy := CANDIDATE     -> bold rows draw the candidate face (chars the
                                candidate lacks fall through to the TTF fallback)
   C) heavy := $COMPOSITE_HEAVY_NPZ (optional env) -> e.g. candidate glyphs

--- a/synthesis_loop/section_bold_pool.py
+++ b/synthesis_loop/section_bold_pool.py
@@ -60,12 +60,25 @@ def valid_sections(table: str, region: str = "us-east-1"):
         for s in rows:
             if s.validation_status == "VALID":
                 key = (str(s.image_id), int(s.receipt_id))
-                out.setdefault(key, {})[s.section_type] = [
-                    int(x) for x in s.line_ids
-                ]
+                # Merge (don't overwrite) if a receipt somehow carries more
+                # than one row of the same section type.
+                bucket = out.setdefault(key, {}).setdefault(s.section_type, [])
+                bucket.extend(
+                    lid for lid in map(int, s.line_ids) if lid not in bucket
+                )
         if not lek:
             break
     return out
+
+
+def merchant_receipts(merchant: str, table: str, region: str = "us-east-1"):
+    """The merchant's (image_id, receipt_id) set, so a shared scan dir can't
+    leak another merchant's receipts into the pools."""
+    from receipt_dynamo.data.dynamo_client import DynamoClient
+
+    client = DynamoClient(table_name=table, region=region)
+    places, _ = client.get_receipt_places_by_merchant(merchant)
+    return {(str(p.image_id), int(p.receipt_id)) for p in places}
 
 
 def build(scan_dir, slug, valid, max_ocr_overlap=2):
@@ -139,6 +152,8 @@ def main(argv=None) -> int:
     os.makedirs(args.out_dir, exist_ok=True)
 
     valid = valid_sections(args.table, args.region)
+    mine = merchant_receipts(args.merchant, args.table, args.region)
+    valid = {k: v for k, v in valid.items() if k in mine}
     heavy, body, stats, sect, charhist = build(
         args.scan_dir, args.slug, valid, args.max_ocr_overlap
     )

--- a/synthesis_loop/section_bold_pool.py
+++ b/synthesis_loop/section_bold_pool.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Split a merchant's letter-crop pool into BODY vs HEAVY rows for a
+section-conditioned mint.
+
+Joins two sources per receipt:
+  * QA'd ``ReceiptSection`` rows (validation_status=VALID) -> the line_ids that
+    belong to a real section (~99% line purity), so pooling ignores OCR noise.
+  * ``glyphstudio.stylescan`` per-line measurements -> tier + stroke/cap, so a
+    row is judged BOLD relative to the receipt's own body median (scanner
+    exposure cancels out).
+
+A visual line is put in the HEAVY pool when it is inside a VALID section AND
+prints bold with the PR#1098 noise guard (stylescan tier=bold, i.e. stroke
+>=1.30x body_stroke and cap < 1.45x body_cap, AND stroke/cap ratio >=1.30x the
+body stroke/cap ratio -- a genuinely thicker stroke, not merely larger text).
+``normal``-tier VALID lines go to the BODY pool; ``large``-tier and
+bold-but-fails-guard rows are excluded from both (ambiguous).
+
+Reads pre-computed stylescan JSONs from ``--scan-dir`` (files named
+``<image_id>_<receipt_id>_<slug>.json`` as written by ``stylescan``); it does
+not hit S3 itself. Writes ``<slug>_heavy_pool.json`` / ``<slug>_body_pool.json``
+in ``--out-dir`` as ``{"<image_id>#<receipt_id>": [line_id, ...]}`` maps ready
+for ``build_merchant_glyphs.py``'s GLYPH_LINE_KEYS_JSON.
+
+Usage:
+  section_bold_pool.py "Sprouts Farmers Market" sprouts \\
+      --scan-dir SCANS --out-dir OUT [--max-ocr-overlap 2]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from collections import Counter
+
+
+def is_bold_guarded(line: dict, body_cap, body_stroke) -> bool:
+    if line.get("tier") != "bold":
+        return False
+    cap, stroke = line.get("cap_px"), line.get("stroke_med")
+    if not cap or not stroke or not body_cap or not body_stroke:
+        return False
+    return (stroke / cap) >= 1.30 * (body_stroke / body_cap)
+
+
+def valid_sections(table: str, region: str = "us-east-1"):
+    """Map (image_id, receipt_id) -> {section_type: [line_id,...]} for VALID."""
+    sys.path.insert(
+        0,
+        os.path.join(os.path.dirname(os.path.dirname(__file__)), "receipt_dynamo"),
+    )
+    from receipt_dynamo.data.dynamo_client import DynamoClient
+
+    client = DynamoClient(table_name=table, region=region)
+    out: dict[tuple[str, int], dict[str, list[int]]] = {}
+    lek = None
+    while True:
+        rows, lek = client.list_receipt_sections(limit=500, last_evaluated_key=lek)
+        for s in rows:
+            if s.validation_status == "VALID":
+                key = (str(s.image_id), int(s.receipt_id))
+                out.setdefault(key, {})[s.section_type] = [
+                    int(x) for x in s.line_ids
+                ]
+        if not lek:
+            break
+    return out
+
+
+def build(scan_dir, slug, valid, max_ocr_overlap=2):
+    heavy: dict[str, list[int]] = {}
+    body: dict[str, list[int]] = {}
+    stats = Counter()
+    sect = Counter()
+    charhist = Counter()
+    for (iid, rid), sections in valid.items():
+        fp = os.path.join(scan_dir, f"{iid}_{rid}_{slug}.json")
+        if not os.path.exists(fp):
+            continue
+        try:
+            res = json.load(open(fp, encoding="utf-8"))
+        except Exception:
+            continue
+        if res.get("error") or not res.get("lines"):
+            continue
+        if (res.get("_ocr_overlap") or 0) > max_ocr_overlap:
+            stats["ocr_rejected"] += 1
+            continue
+        valid_lineids: set[int] = set()
+        sect_of: dict[int, str] = {}
+        for stype, lids in sections.items():
+            for lid in lids:
+                valid_lineids.add(int(lid))
+                sect_of[int(lid)] = stype
+        bc, bs = res.get("body_cap_px"), res.get("body_stroke_px")
+        stats["receipts"] += 1
+        hl: list[int] = []
+        bl: list[int] = []
+        for line in res["lines"]:
+            inside = {int(x) for x in line.get("line_ids", [])} & valid_lineids
+            if not inside:
+                continue
+            if line.get("tier") == "large":
+                continue
+            if is_bold_guarded(line, bc, bs):
+                hl += list(inside)
+                stats["bold_lines"] += 1
+                for lid in sorted(inside):
+                    sect[sect_of.get(lid, "?")] += 1
+                    break
+                for chd in line.get("letters", []):
+                    ch = (chd.get("ch") or "").strip()
+                    if len(ch) == 1 and 33 <= ord(ch) < 127:
+                        charhist[ch] += 1
+            elif line.get("tier") == "normal":
+                bl += list(inside)
+                stats["body_lines"] += 1
+        if hl:
+            heavy[f"{iid}#{rid}"] = sorted(set(hl))
+        if bl:
+            body[f"{iid}#{rid}"] = sorted(set(bl))
+    return heavy, body, stats, sect, charhist
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("merchant")
+    ap.add_argument("slug")
+    ap.add_argument("--scan-dir", required=True)
+    ap.add_argument("--out-dir", required=True)
+    ap.add_argument("--max-ocr-overlap", type=int, default=2)
+    ap.add_argument(
+        "--table",
+        default=os.environ.get("DYNAMODB_TABLE_NAME", "ReceiptsTable-dc5be22"),
+    )
+    ap.add_argument("--region", default=os.environ.get("AWS_REGION", "us-east-1"))
+    args = ap.parse_args(argv)
+    os.makedirs(args.out_dir, exist_ok=True)
+
+    valid = valid_sections(args.table, args.region)
+    heavy, body, stats, sect, charhist = build(
+        args.scan_dir, args.slug, valid, args.max_ocr_overlap
+    )
+    hp = os.path.join(args.out_dir, f"{args.slug}_heavy_pool.json")
+    bp = os.path.join(args.out_dir, f"{args.slug}_body_pool.json")
+    json.dump(heavy, open(hp, "w", encoding="utf-8"), indent=1)
+    json.dump(body, open(bp, "w", encoding="utf-8"), indent=1)
+    ge10 = "".join(sorted(c for c in charhist if charhist[c] >= 10))
+    print(
+        json.dumps(
+            {
+                "heavy_pool": hp,
+                "body_pool": bp,
+                "heavy_receipts": len(heavy),
+                "body_receipts": len(body),
+                "stats": dict(stats),
+                "bold_sections": dict(sect.most_common()),
+                "chars_ge10_samples": ge10,
+                "n_chars_ge10": len(ge10),
+            },
+            indent=1,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/glyph-studio/py/e2e_section_heavy_demo.py
+++ b/tools/glyph-studio/py/e2e_section_heavy_demo.py
@@ -118,6 +118,12 @@ def main(argv=None) -> int:
     args = ap.parse_args(argv)
     os.makedirs(args.out_dir, exist_ok=True)
     merchant, _, slug = args.merchant.partition(":")
+    if not merchant.strip() or not slug.strip():
+        raise SystemExit(
+            f"--merchant must be 'Name:slug' (got {args.merchant!r})"
+        )
+    if not os.path.exists(args.heavy_npz):
+        raise SystemExit(f"--heavy-npz not found: {args.heavy_npz}")
 
     import boto3
     from PIL import Image, ImageDraw, ImageFont
@@ -181,6 +187,11 @@ def main(argv=None) -> int:
             k: v["source"] for k, v in row_faces.items() if v["face"] == "heavy"
         }
 
+        if not rec.width or not rec.height or rec.width <= 0 or rec.height <= 0:
+            raise SystemExit(
+                f"{iid}:{rid}: bad receipt dimensions "
+                f"{rec.width}x{rec.height}"
+            )
         wt = 760
         ht = int(round(wt * rec.height / rec.width))
         payload = {
@@ -242,7 +253,7 @@ def main(argv=None) -> int:
                     sm = score_receipt_images(real_m, syn, words)["summary"]
                     scores[mode] = sm["severity_counts"]
                 except Exception as e:  # noqa: BLE001
-                    scores[mode] = {"error": str(e)[:80]}
+                    scores[mode] = {"error": str(e)}
 
         # labeled side-by-side, shared canvas height
         wd = 380
@@ -286,7 +297,13 @@ def main(argv=None) -> int:
         os.path.join(args.out_dir, "e2e_report.json"), "w", encoding="utf-8"
     ) as fh:
         json.dump(report, fh, indent=1)
-    return 0
+    # A demo that could not score a render is not a completed comparison.
+    score_errors = any(
+        isinstance(v, dict) and "error" in v
+        for r in report
+        for v in (r.get("scorecard") or {}).values()
+    )
+    return 1 if score_errors else 0
 
 
 if __name__ == "__main__":

--- a/tools/glyph-studio/py/e2e_section_heavy_demo.py
+++ b/tools/glyph-studio/py/e2e_section_heavy_demo.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+"""End-to-end demo: QA'd sections -> section-conditioned heavy mint -> measured
+face selection -> render.
+
+Composes the whole pipeline on real receipts:
+
+  * the SECTIONS found the bold evidence (the heavy pool that minted the
+    candidate came from QA'd VALID ReceiptSection line_ids),
+  * the MINT made the true bold glyphs (composite heavy: minted bold chars
+    overlaid on the regular atlas -- see compose_heavy_npz.py's manifest),
+  * MEASURED FACE SELECTION places them (M4 ``face_source="measured"``:
+    per-row typography measured from the real scan routes bold rows to the
+    profile's ``bitmap_font.heavy`` slot).
+
+Per receipt this renders:
+  P) PRODUCTION -- stylemap text rules + the shipped heavy slot (today a
+     uniform dilation of the regular face), and
+  E) END-TO-END -- measured row faces + the composite TRUE-bold heavy,
+at identical canvas size, then writes a labeled REAL | PRODUCTION | E2E
+side-by-side, prints which rows routed to the heavy face and WHY (measured /
+box / prior ladder rung), and runs the line scorecard on both renders.
+
+MUST run inside a worktree with the M4 measured-face renderer
+(``RenderConfig.face_source``; branch feat/m4-measured-faces or a descendant)
+-- it exits with a clear message otherwise.
+
+Usage:
+  python e2e_section_heavy_demo.py --heavy-npz COMPOSITE.npz --out-dir OUT \\
+      --receipt IMAGE_ID:RECEIPT_ID [--receipt ...] \\
+      [--merchant "Sprouts Farmers Market:sprouts"]
+
+Env: DYNAMODB_TABLE_NAME (default dev), AWS creds, BITMATRIX_DIR.
+"""
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import os
+import sys
+from io import BytesIO
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_ROOT = os.path.abspath(os.path.join(_HERE, "..", "..", ".."))
+for _p in (
+    _HERE,
+    os.path.join(_ROOT, "receipt_agent"),
+    os.path.join(_ROOT, "receipt_dynamo"),
+    os.path.join(_ROOT, "receipt_upload"),
+    os.path.join(_ROOT, "synthesis_loop"),
+    os.path.join(_ROOT, "scripts"),
+):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+
+def _load_receipt(client, iid: str, rid: int):
+    d = client.get_image_details(iid)
+    rec = next(
+        (r for r in d.receipts if str(r.receipt_id) == str(rid)), None
+    )
+    if rec is None:
+        raise RuntimeError(f"receipt {rid} not found for {iid}")
+    lbl = {
+        (l.line_id, l.word_id): l.label
+        for l in d.receipt_word_labels
+        if l.receipt_id == rid
+    }
+    words = [
+        {
+            "text": w.text,
+            "line_id": w.line_id,
+            "word_id": w.word_id,
+            "bbox": [
+                w.top_left["x"] * 1000,
+                w.top_left["y"] * 1000,
+                w.bottom_right["x"] * 1000,
+                w.bottom_right["y"] * 1000,
+            ],
+            "labels": (
+                [lbl[(w.line_id, w.word_id)]]
+                if lbl.get((w.line_id, w.word_id)) not in (None, "O")
+                else []
+            ),
+        }
+        for w in d.receipt_words
+        if w.receipt_id == rid
+    ]
+    barcodes = []
+    if hasattr(client, "list_receipt_barcodes_from_receipt"):
+        try:
+            barcodes = [
+                {
+                    "text": getattr(b, "text", "") or "",
+                    "symbology": getattr(b, "symbology", ""),
+                    "top_left": getattr(b, "top_left", None),
+                    "bottom_right": getattr(b, "bottom_right", None),
+                    "confidence": getattr(b, "confidence", None),
+                }
+                for b in client.list_receipt_barcodes_from_receipt(iid, rid)
+            ]
+        except Exception:  # noqa: BLE001
+            barcodes = []
+    return rec, words, barcodes
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--heavy-npz", required=True, help="composite heavy atlas")
+    ap.add_argument("--out-dir", required=True)
+    ap.add_argument(
+        "--receipt",
+        action="append",
+        required=True,
+        metavar="IMAGE_ID:RECEIPT_ID",
+    )
+    ap.add_argument("--merchant", default="Sprouts Farmers Market:sprouts")
+    args = ap.parse_args(argv)
+    os.makedirs(args.out_dir, exist_ok=True)
+    merchant, _, slug = args.merchant.partition(":")
+
+    import boto3
+    from PIL import Image, ImageDraw, ImageFont
+
+    import render_synthetic_receipts as rsr
+    from receipt_line_scorecard import score_receipt_images
+
+    from receipt_agent.agents.label_evaluator.rendering.receipt_renderer import (
+        RenderConfig,
+    )
+    from receipt_dynamo.data.dynamo_client import DynamoClient
+
+    if not hasattr(RenderConfig(), "face_source"):
+        raise SystemExit(
+            "this worktree's renderer has no RenderConfig.face_source -- run "
+            "inside the M4 measured-faces branch (feat/m4-measured-faces)"
+        )
+    from glyphstudio.face_select import select_row_faces
+    from glyphstudio.section_face_map import load_merchant_faces
+    from glyphstudio.stylescan import measure
+
+    table = os.environ.get("DYNAMODB_TABLE_NAME", "ReceiptsTable-dc5be22")
+    region = os.environ.get("AWS_REGION", "us-east-1")
+    client = DynamoClient(table_name=table, region=region)
+    s3 = boto3.client("s3", region_name=region)
+
+    prof = rsr.cached_font_profile(
+        table, merchant, region=region, max_receipts=12
+    )
+    ss = rsr.section_scale_for_merchant(merchant)
+    typ = rsr.merchant_typography(merchant)
+    if "bitmap_font" not in typ:
+        raise SystemExit(f"{merchant}: bitmap_font atlases not resolvable")
+    priors = None
+    prior_dir = os.path.join(_ROOT, "tools", "glyph-studio", "fonts", slug)
+    if os.path.isdir(prior_dir):
+        try:
+            priors = load_merchant_faces(prior_dir)
+        except Exception:  # noqa: BLE001
+            priors = None
+
+    try:
+        lab = ImageFont.truetype(
+            "/System/Library/Fonts/Supplemental/Arial.ttf", 15
+        )
+    except OSError:
+        lab = ImageFont.load_default()
+
+    report = []
+    for spec_arg in args.receipt:
+        iid, _, rid_s = spec_arg.partition(":")
+        rid = int(rid_s)
+        tag = f"{slug}_{iid[:8]}_{rid}"
+        rec, words, barcodes = _load_receipt(client, iid, rid)
+
+        measurement = measure(iid, rid, merchant=slug)
+        row_faces, ladder = select_row_faces(
+            measurement, section_priors=priors
+        )
+        heavy_rows = {
+            k: v["source"] for k, v in row_faces.items() if v["face"] == "heavy"
+        }
+
+        wt = 760
+        ht = int(round(wt * rec.height / rec.width))
+        payload = {
+            "words": words,
+            "barcodes": barcodes,
+            "merchant_name": merchant,
+        }
+        variants = {
+            # P: today's pipeline exactly -- stylemap rules + shipped heavy.
+            "production": {},
+            # E: measured faces + the section-minted TRUE bold composite.
+            "e2e": {
+                "face_source": "measured",
+                "row_faces": row_faces,
+                "bitmap_font": {
+                    "regular": typ["bitmap_font"]["regular"],
+                    "heavy": args.heavy_npz,
+                },
+            },
+        }
+        paths, scores = {}, {}
+        for mode, extra in variants.items():
+            out = os.path.join(args.out_dir, f"{tag}.{mode}.png")
+            t = dict(typ)
+            t.update(extra)
+            rsr._render_cached_hybrid(
+                copy.deepcopy(payload),
+                None,
+                profile=prof,
+                width=wt,
+                height=ht,
+                path=out,
+                section_scale=ss,
+                **t,
+            )
+            paths[mode] = out
+
+        real = None
+        for bkt, key in (
+            (rec.cdn_s3_bucket, rec.cdn_s3_key),
+            (rec.raw_s3_bucket, rec.raw_s3_key),
+        ):
+            if not bkt or not key:
+                continue
+            try:
+                real = Image.open(
+                    BytesIO(
+                        s3.get_object(Bucket=bkt, Key=key)["Body"].read()
+                    )
+                ).convert("RGB")
+                break
+            except Exception:  # noqa: BLE001
+                continue
+        if real is not None:
+            real_m = real.resize((wt, ht))
+            for mode, p in paths.items():
+                syn = Image.open(p).convert("RGB")
+                try:
+                    sm = score_receipt_images(real_m, syn, words)["summary"]
+                    scores[mode] = sm["severity_counts"]
+                except Exception as e:  # noqa: BLE001
+                    scores[mode] = {"error": str(e)[:80]}
+
+        # labeled side-by-side, shared canvas height
+        wd = 380
+
+        def _byw(im):
+            w, h = im.size
+            return im.resize((wd, int(h * wd / w)))
+
+        panels = ([("REAL", real)] if real is not None else []) + [
+            ("PRODUCTION (stylemap+dilation)", Image.open(paths["production"])),
+            ("END-TO-END (measured+true bold)", Image.open(paths["e2e"])),
+        ]
+        panels = [(t_, _byw(im.convert("RGB"))) for t_, im in panels]
+        hh = max(im.height for _, im in panels) + 40
+        cv = Image.new(
+            "RGB",
+            (wd * len(panels) + 20 * (len(panels) + 1), hh),
+            (235, 235, 235),
+        )
+        dd = ImageDraw.Draw(cv)
+        x = 20
+        for t_, im in panels:
+            cv.paste(im, (x, 34))
+            dd.text((x, 12), t_, fill=(200, 0, 0), font=lab)
+            x += wd + 20
+        side = os.path.join(args.out_dir, f"e2e_{tag}.png")
+        cv.save(side)
+
+        report.append(
+            {
+                "receipt": f"{iid}:{rid}",
+                "side_by_side": side,
+                "heavy_rows": heavy_rows,
+                "ladder_stats": ladder,
+                "scorecard": scores,
+            }
+        )
+        print(json.dumps(report[-1], indent=1))
+
+    with open(
+        os.path.join(args.out_dir, "e2e_report.json"), "w", encoding="utf-8"
+    ) as fh:
+        json.dump(report, fh, indent=1)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/glyph-studio/py/glyph_gate_npz.py
+++ b/tools/glyph-studio/py/glyph_gate_npz.py
@@ -30,7 +30,8 @@ from collections import Counter
 import numpy as np
 
 _HERE = os.path.dirname(os.path.abspath(__file__))
-sys.path.insert(0, os.path.join(_HERE, "py"))
+if _HERE not in sys.path:
+    sys.path.insert(0, _HERE)
 
 from glyphstudio.family_cluster import normalize_glyph  # noqa: E402
 from glyphstudio.glyph_gate import GATE_CHARS, audit_normalized  # noqa: E402
@@ -50,12 +51,23 @@ def load_npz_normalized(path: str, size: int = 32) -> dict[int, np.ndarray]:
     return out
 
 
-def build_fleet(fleet_dir: str) -> dict[str, dict[int, np.ndarray]]:
+def build_fleet(
+    fleet_dir: str, exclude_paths: tuple[str, ...] = ()
+) -> dict[str, dict[int, np.ndarray]]:
+    """Regular faces in ``fleet_dir``, minus any path in ``exclude_paths``.
+
+    The candidate/baseline usually live in the same directory; loading them
+    both as a fleet member AND under their explicit name would double-count
+    identical glyphs in the consensus and mask identity defects.
+    """
+    skip = {os.path.realpath(p) for p in exclude_paths}
     fleet: dict[str, dict[int, np.ndarray]] = {}
     for p in sorted(glob.glob(os.path.join(fleet_dir, "*.glyphs.npz"))):
         base = os.path.basename(p)[: -len(".glyphs.npz")]
         if base.endswith("-heavy"):
             continue  # regular faces only in the reference fleet
+        if os.path.realpath(p) in skip:
+            continue
         fleet[base] = load_npz_normalized(p)
     return fleet
 
@@ -71,7 +83,8 @@ def main(argv=None) -> int:
     ap.add_argument("--baseline", nargs=2, metavar=("NPZ", "NAME"), default=None)
     args = ap.parse_args(argv)
 
-    normalized = build_fleet(args.fleet_dir)
+    exclude = [args.candidate] + ([args.baseline[0]] if args.baseline else [])
+    normalized = build_fleet(args.fleet_dir, exclude_paths=tuple(exclude))
     normalized[args.candidate_name] = load_npz_normalized(args.candidate)
     focus = {args.candidate_name}
     if args.baseline:
@@ -95,7 +108,28 @@ def main(argv=None) -> int:
     for f in findings:
         if f.merchant in focus:
             print(f"  [{f.merchant}] {f.char!r} {f.kind}: {f.detail}")
-    return 0
+
+    # Gate policy: MISSING is a coverage report, not a defect (a partial data
+    # mint legitimately lacks chars; the renderer falls back). QUALITY findings
+    # (MISRENDER + LOW_AGREEMENT) must not exceed the baseline's when one is
+    # given, and must include no MISRENDER when auditing without a baseline.
+    cand = by_m.get(args.candidate_name, Counter())
+    cand_quality = cand["MISRENDER"] + cand["LOW_AGREEMENT"]
+    if args.baseline:
+        base = by_m.get(args.baseline[1], Counter())
+        base_quality = base["MISRENDER"] + base["LOW_AGREEMENT"]
+        verdict = cand_quality <= base_quality
+        print(
+            f"\ngate: candidate quality findings {cand_quality} vs baseline "
+            f"{base_quality} -> {'PASS' if verdict else 'FAIL'}"
+        )
+    else:
+        verdict = cand["MISRENDER"] == 0
+        print(
+            f"\ngate: candidate MISRENDER {cand['MISRENDER']} "
+            f"-> {'PASS' if verdict else 'FAIL'}"
+        )
+    return 0 if verdict else 1
 
 
 if __name__ == "__main__":

--- a/tools/glyph-studio/py/glyph_gate_npz.py
+++ b/tools/glyph-studio/py/glyph_gate_npz.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Glyph identity gate for .npz atlases (data-mint fleet).
+
+``glyphstudio.glyph_gate`` audits *parametric* font dirs (font.json + glyph
+skeletons). The data mint (``synthesis_loop/build_merchant_glyphs.py``) emits
+binary ``.glyphs.npz`` atlases instead, so this thin adapter shape-normalizes
+npz glyphs the same way ``family_cluster.load_normalized_merchant`` normalizes
+rasterized parametric glyphs, then runs the SAME ``audit_normalized`` gate.
+
+Use it to check that a newly minted atlas (e.g. a section-conditioned HEAVY
+face) still renders each character as its own letter, referenced against the
+fleet of regular atlases — and to compare a candidate's finding count against a
+baseline atlas (usually the merchant's own regular face).
+
+Usage:
+  glyph_gate_npz.py CANDIDATE.npz CANDIDATE_NAME \\
+      [--fleet-dir DIR] [--baseline REG.npz REG_NAME]
+
+``--fleet-dir`` defaults to $BITMATRIX_DIR (or /tmp/bitmatrix): every
+``*.glyphs.npz`` there whose name has no ``-heavy`` suffix joins the fleet.
+"""
+from __future__ import annotations
+
+import argparse
+import glob
+import os
+import sys
+from collections import Counter
+
+import numpy as np
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(_HERE, "py"))
+
+from glyphstudio.family_cluster import normalize_glyph  # noqa: E402
+from glyphstudio.glyph_gate import GATE_CHARS, audit_normalized  # noqa: E402
+
+
+def load_npz_normalized(path: str, size: int = 32) -> dict[int, np.ndarray]:
+    """Shape-normalize the atlas's binary glyphs for the gate's char set."""
+    z = np.load(path)
+    out: dict[int, np.ndarray] = {}
+    for k in z.files:
+        if not k.startswith("c"):
+            continue
+        cp = int(k[1:])
+        if chr(cp) not in GATE_CHARS:
+            continue
+        out[cp] = normalize_glyph(z[k].astype(bool), size=size)
+    return out
+
+
+def build_fleet(fleet_dir: str) -> dict[str, dict[int, np.ndarray]]:
+    fleet: dict[str, dict[int, np.ndarray]] = {}
+    for p in sorted(glob.glob(os.path.join(fleet_dir, "*.glyphs.npz"))):
+        base = os.path.basename(p)[: -len(".glyphs.npz")]
+        if base.endswith("-heavy"):
+            continue  # regular faces only in the reference fleet
+        fleet[base] = load_npz_normalized(p)
+    return fleet
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("candidate")
+    ap.add_argument("candidate_name")
+    ap.add_argument(
+        "--fleet-dir",
+        default=os.environ.get("BITMATRIX_DIR", "/tmp/bitmatrix"),
+    )
+    ap.add_argument("--baseline", nargs=2, metavar=("NPZ", "NAME"), default=None)
+    args = ap.parse_args(argv)
+
+    normalized = build_fleet(args.fleet_dir)
+    normalized[args.candidate_name] = load_npz_normalized(args.candidate)
+    focus = {args.candidate_name}
+    if args.baseline:
+        normalized[args.baseline[1]] = load_npz_normalized(args.baseline[0])
+        focus.add(args.baseline[1])
+
+    findings = audit_normalized(normalized)
+    by_m: dict[str, Counter] = {}
+    for f in findings:
+        by_m.setdefault(f.merchant, Counter())[f.kind] += 1
+
+    print(f"{'merchant':22} MISRENDER LOW_AGREE MISSING  total")
+    for m in sorted(normalized):
+        c = by_m.get(m, Counter())
+        mark = "  <==" if m in focus else ""
+        print(
+            f"{m:22} {c['MISRENDER']:9} {c['LOW_AGREEMENT']:9} "
+            f"{c['MISSING']:7}  {sum(c.values()):5}{mark}"
+        )
+    print("\n--- candidate / baseline detail ---")
+    for f in findings:
+        if f.merchant in focus:
+            print(f"  [{f.merchant}] {f.char!r} {f.kind}: {f.detail}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/glyph-studio/py/glyphstudio/stylescan.py
+++ b/tools/glyph-studio/py/glyphstudio/stylescan.py
@@ -519,6 +519,13 @@ def measure(image_id: str, receipt_id: int, merchant: str = "sprouts") -> dict:
         text = " ".join(w["text"] for w in line)
         has_price = bool(price_re.search(line[-1]["text"]))
         section = _classify(text, has_price, merchant)
+        # OCR line_ids covered by this visual line (words carry line_id). Lets a
+        # caller join each measured row to a QA'd ReceiptSection (which stores
+        # line_ids), so tiers can be pooled per section -- see
+        # section-conditioned heavy-atlas mint.
+        line_ids = sorted(
+            {int(w["line_id"]) for w in line if w.get("line_id") is not None}
+        )
         lt = min(w["t"] for w in line)
         lb = max(w["b"] for w in line)
         ll = min(w["l"] for w in line)
@@ -596,6 +603,7 @@ def measure(image_id: str, receipt_id: int, merchant: str = "sprouts") -> dict:
             {
                 "reverse_video": reverse_video,
                 "text": text[:60],
+                "line_ids": line_ids,
                 "section": section,
                 "section_canonical": normalize_stylescan_section(section),
                 "cap_px": round(median(caps), 1) if caps else None,


### PR DESCRIPTION
## What

Pilot for minting a TRUE heavy face from a merchant's real bold rows, using the QA'd `ReceiptSection` rows (validation_status=VALID, ~99% line purity) to split the letter-crop pool into BODY vs BOLD lines. Today every shipped `-heavy.glyphs.npz` is a uniform ~2px dilation of the regular face (verified across the fleet: heavy bbox >= regular for 94/94 glyphs on every merchant, ink ratio 1.08-1.26x) — no merchant has a heavy face minted from bold print.

## Changes (all additive)

- `glyphstudio/stylescan.py`: each measured visual line now emits its OCR `line_ids`, so a measured row can be joined to a `ReceiptSection` (which stores line_ids).
- `synthesis_loop/build_merchant_glyphs.py`: new `GLYPH_LINE_KEYS_JSON` env — a `{"<image_id>#<receipt_id>": [line_id,...]}` map restricts the crop corpus to exactly those printed lines. Smallest change on top of the existing `GLYPH_KEYS_JSON` receipt-level curation; per-glyph gates unchanged.
- `synthesis_loop/section_bold_pool.py`: joins VALID sections to stylescan tiers and writes the heavy/body line-key pools (PR #1098 noise guard: tier=bold AND stroke/cap >= 1.3x body ratio; `large` and unguarded-bold excluded).
- `tools/glyph-studio/py/glyph_gate_npz.py`: identity-gate adapter for npz atlases (the data-mint fleet), so a minted face is audited with the SAME `audit_normalized` gate as parametric fonts.
- `synthesis_loop/anti_copy_npz.py`: bitmap-level anti-copy check for npz-only mints (parametric `_reject_copied_letterforms` stays untouched and mandatory in the publish path).
- `synthesis_loop/render_face_ab.py`: A/B/C render harness (A heavy=regular double-strike, B heavy=candidate, C composite) with per-variant scorecard summaries.

## Pilot results (Sprouts Farmers Market)

**STEP 1 — deterministic merchant ranking** (OCR-vetted receipts only, `ocr_overlap_score <= 2`; bold = stylescan tier=bold + 1.3x stroke/cap guard; lines restricted to VALID sections; 15-receipt sample per merchant):

| merchant | QA'd receipts | sampled/used | bold lines | bold crops | crops/receipt | projected total |
|---|---|---|---|---|---|---|
| **Sprouts** | **205** | 10 | 9 | 380 | 38.0 | **7,790** |
| Vons | 30 | 11 | 13 | 317 | 28.8 | 864 |
| Costco | 38 | 7 | 6 | 92 | 13.1 | 499 |
| In-N-Out | 16 | 13 | 7 | 160 | 12.3 | 196 |
| CVS | 12 | 5 | 1 | 78 | 15.6 | 187 |
| Trader Joe's / Target / Home Depot / Wild Fork | 21/20/18/11 | — | 0 | 0 | 0 | 0 |

Sprouts wins on volume by ~9x. (Wild Fork, Target, TJ, HD print no guarded-bold rows at all in their vetted QA'd samples.)

**STEP 2 — mint**: measured 131 QA'd Sprouts receipts; the pool builder kept 81 vetted ones -> 50 receipts with 85 bold lines (bold sections: ADDRESS 29, FOOTER 14, STOREFRONT 9, BARCODE 8, SECTION_HEADER 7, PAYMENT 5, TOTAL_LINE 4, SUMMARY 1). `GLYPH_LINE_KEYS_JSON` mint produced **19 glyphs**: `(-0124789ADIKLPRSTr` — a genuinely different letterform (serif-style emphasized print), visibly NOT a dilation of the regular face. Broken `K` dropped in curation -> 18. Anti-copy: PASS (0% overlap with every fleet atlas). Atlases/pools stay local (not committed).

**STEP 3 — gates + A/B + scorecard**:
- Identity gate (fleet-referenced): curated heavy = 2 MISRENDER + 0 LOW_AGREEMENT (+60 MISSING = coverage) vs regular-face baseline 5 MISRENDER + 3 LOW_AGREEMENT (fleet-dedup corrected in f2ea2dc; formal gate verdict: PASS, 2 vs 8). The glyphs that exist are cleaner than the regular face; coverage is the deficiency.
- A/B on 4 vetted bold-row receipts (`.out/ab_sprouts_*.png`, zooms `zoom_bold_*` / `zoom_balance_*`): the shipped stylemap marks only `balance_due` bold, and there B fixes A's double-strike artifact (A smears "DUE" into "DLE"; B renders it correctly with real emphasized digits).
- Scorecard non-regression: BLOCKER/MINOR counts identical across A/B/C on all 4 receipts (3/5, 5/5, 2/7, 6/3).

## Honest verdict

Section-conditioned pooling **works mechanically and produces real bold letterforms** (the minted digits+caps are legibly the emphasized face, and quality-per-glyph beats the regular atlas's own gate baseline). But it is **not yet a shippable replacement heavy face**:

1. **Coverage**: bold rows are rare (85 lines in 205 QA'd receipts) and skew numeric — 18/94 glyphs, missing most lowercase. A pure minted heavy face would render bold rows in a mixed atlas+TTF face; the composite (minted glyphs over regular backfill) is the usable middle today.
2. **Render-side mismatch**: the pool's dominant bold sections (ADDRESS/STOREFRONT/FOOTER) are not marked bold by the shipped stylemap (only `balance_due` is), so most of the harvest never draws. Full exploitation needs the measured face_source/stylemap alignment from the PR #1098 line of work.

Recommended next: keep the composite as the heavy slot for Sprouts once the stylemap learns the address/footer emphasis, and re-run the pool as more receipts get QA'd sections.

Do NOT merge yet — pilot for review. Dev reads only; no publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SRtFcxkcw1t3nZsVHstZGL


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added tools to compare glyph atlases and detect excessive overlap with existing references.
  - Added visual A/B receipt rendering with side-by-side image comparisons and scoring.
  - Added generation of separate body and bold glyph pools from validated receipt sections.

- **Improvements**
  - Added optional line-level corpus filtering for targeted glyph collection.
  - Enhanced style-scan output with line identifiers for more precise traceability.
  - Added normalized glyph quality auditing with baseline comparisons and clear pass/fail results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->