### PR TITLE
feat(migration): label-preserving re-OCR toolkit — rehearsal harness, apply tool, rollback

### DIFF
--- a/docs/ocr-migration-runbook.md
+++ b/docs/ocr-migration-runbook.md
@@ -1,0 +1,106 @@
+# Re-OCR Migration Runbook (apply #1095 to existing labeled images)
+
+Status as of 2026-07-11: **G1 gate PASSED** on a full local rehearsal.
+New uploads already get the new segmentation (merged #1095 + rebuilt worker).
+This runbook covers migrating the ~633 EXISTING labeled dev images, then prod.
+
+## What's proven (G1, local DynamoDB Local rehearsal)
+
+616 images / 58,586 labels via `scripts/ocr_migration_apply.py`:
+
+| moved (audit trail verbatim) | parked NEEDS_REVIEW | pre-orphans preserved | absorbed dead rows | lost |
+|---|---|---|---|---|
+| 55,213 | 1,869 | 1,494 | 99 | **0** |
+
+Blast radius 0 · new orphans 0 · wiped 0 · rollback = `restore` (byte-exact
+verified). Toolkit lives in `scripts/ocr_migration_rehearsal.py` +
+`scripts/ocr_migration_apply.py` (43 tests). PR #1109.
+
+## Dev waves (~50 images each)
+
+Per wave, IN ORDER:
+
+1. **Backup** (rollback source, from live dev — full partitions, never
+   `--exclude-types`):
+   `ocr_migration_rehearsal.py backup --endpoint-url <real> --allow-aws --table-name ReceiptsTable-dc5be22 --images wave.txt --out waveN_backup.sqlite3`
+2. **Apply**: `ocr_migration_apply.py --allow-aws --endpoint-url https://dynamodb.us-east-1.amazonaws.com ... --backup waveN_backup.sqlite3`
+   — run on the SAME Mac as the rehearsal (Vision reads differ across macOS
+   builds). Raw images: fetch per image (17 of 633 have NO raw object — skip
+   list in the apply report).
+3. **Crops + CDN**: regenerate warped crops, upload raw `receipts/{image}/...`
+   + `upload_all_cdn_formats` (12 objects/receipt), update Receipt cdn keys.
+4. **CloudFront invalidation** (dev distribution) — `/assets/{image_id}/*` per
+   wave image. NOTE: minTtl=24h/defaultTtl=30d on `/assets/*` and NO
+   invalidation code exists anywhere in the repo outside prod-deploy CI
+   (`main.yml:274`). Also delete orphaned `assets/{image}/{old_receipt_id}*`
+   keys when receipt ids disappear.
+5. **Harness diff** vs the wave backup (`--expect-parked <apply_report>`).
+   Verdict must be PASS.
+6. **Streams drain, then RECEIPT_SUMMARY repair**: the updater fires on label
+   REMOVEs and will re-upsert EMPTY summaries for OLD receipt ids (and INSERTs
+   never create new-id summaries). Sweep orphaned summaries, then
+   `scripts/backfill_receipt_summaries.py --env dev`.
+7. **Chroma**: VERIFY FIRST (open question below) whether stream deletion
+   covers word/line vectors; delete old-id vectors explicitly if not. Kick
+   embedding SFs (`start_ingestion_dev.sh both` — they have NO schedule),
+   confirm NONE→SUCCESS drains, spot-check old ids gone / new present.
+   Wave 1 doubles as the embedding-pipeline canary (words leg has the #990
+   stuck-PENDING history).
+8. **Derived caches**: label-evaluator viz SF (manual, old-id-keyed);
+   force image_details/word+address-similarity generators AFTER Chroma is
+   consistent (else they bake stale vectors); LABEL_COUNT_CACHE self-heals.
+9. **Local cache re-sync**: `make analytics-cache ENV=dev`.
+
+### Before/after E2E check (wave 1 especially)
+Fixed set: Twin Peaks `01024cab`, cream `4e180507`, the 7 June22 uploads,
+2 untouched controls. Capture BEFORE and AFTER: API responses
+(`receipts`, `images`, counts, `label_validation_count`,
+`image_details_cache`) + frontend screenshots of receipt pages. Diff:
+counts/bounds/cdn keys change as expected, labels preserved (status+audit),
+no crop 404s, no stale crops post-invalidation, controls byte-identical.
+Sign-off before wave 2.
+
+## Prod (after dev soak, 2–7 days)
+
+Existing mirror: `reconcile_dev_to_prod.py` — fingerprints flip on every
+migrated image → REPLACE (delete-then-recopy; correct for re-keying), Chroma
+leg intra-env, embedding_status reset → `start_ingestion_prod.sh both`.
+- **Dry-run first**: `guard_replaces` SILENTLY SKIPS prod partitions holding
+  non-`RESTORABLE_TYPES` (sections/analyses) — inspect skips, extend the set
+  in a reviewed change if needed.
+- Promote in slices (`--protect` the rest); prod compaction DLQs empty + the
+  pre-apply-only health gate means the flood is on you between slices.
+- Nothing syncs raw `receipts/` crops to prod (known: prod raw 404s;
+  `cdn_s3_key` is the reliable surface). No prod CloudFront invalidation
+  outside deploy CI — invalidate `/assets/*` explicitly after slices.
+
+## Parked-label review (1,869)
+
+Every parked label is `validation_status=NEEDS_REVIEW` with a reasoning note:
+`[PARKED by re-OCR migration: no confident word match; original status=...;
+original word '...' @ (r,l,w)]` — they flow through the normal labeling
+workflow. Concentrated: 370/616 images parked ZERO; top ~20 images carry the
+bulk (duplicate-copy merges, garbage-OCR images). Review packet:
+`~/.claude/jobs/ce5f2402/tmp/review_packet.html` (worst-first).
+
+## Open questions / deferred
+
+- **Chroma stream deletion conflict**: one audit read
+  `receipt_dynamo_stream/parsing/parsers.py` as handling RECEIPT_WORD/LINE
+  REMOVEs; another read `chromadb_compaction/lambdas/stream_processor.py` as
+  PLACE+LABEL-only. Reconcile before wave 1 — decides explicit vector deletion.
+- **1,494 pre-orphaned labels** (pre-existing dev breakage; 586 on image
+  `13da1048`): separate cleanup pass, NOT part of migration diffs.
+- **RECEIPT_PLACE re-keying on splits** (apply preserves but doesn't re-key;
+  re-run `fix_place` for split receipts — dev Places key expired 2026-07-07,
+  renew first).
+- **Geometry tier for wrong-word relabeling** (same-text swaps invisible to
+  the harness; position scoring makes it rare).
+- **Crop uploads set no Cache-Control** → browsers heuristically cache old
+  crop bytes even after invalidation. Add `CacheControl` at upload later.
+- **Worker LayoutLM download crash** (`HTTPClientError.deadlineExceeded` on
+  the CoreML bundle) — auto-restart wrapper in place; fix Soto timeout if it
+  loops.
+- **Mini**: staging leftovers `~/ce5f2402_*` (~6 GB) can be deleted; rescue
+  patches from deleted worktrees in `~/worktree_rescue_patches/`; hosts the 4
+  GitHub Actions runners (mac2-runner-1..4) — that's its real job.

--- a/infra/embedding_step_functions/unified_embedding/handlers/word_polling.py
+++ b/infra/embedding_step_functions/unified_embedding/handlers/word_polling.py
@@ -23,6 +23,7 @@ from receipt_chroma.embedding.openai import (
     get_unique_receipt_and_image_ids,
     handle_batch_status,
     mark_items_for_retry,
+    mark_words_embedded,
 )
 from receipt_chroma.embedding.records import (
     WordEmbeddingRecord,
@@ -1020,6 +1021,19 @@ def _handle_internal_core(
         tracer.add_metadata("delta_result", delta_result)
         tracer.add_annotation("delta_id", delta_id)
 
+        # Flip word embedding_status now that the delta is durably in S3
+        # (#990: this was skipped, stranding words in PENDING forever)
+        with operation_with_timeout("mark_words_embedded", max_duration=120):
+            words_marked = mark_words_embedded(
+                results, descriptions, dynamo_client
+            )
+        collected_metrics["WordsMarkedSuccess"] = words_marked
+        logger.info(
+            "Marked words as embedded",
+            words_marked=words_marked,
+            batch_id=batch_id,
+        )
+
         # Mark batch complete only if NOT in step function mode
         # (skip_sqs=False means standalone mode)
         # In step function mode, batches will be marked complete after successful compaction
@@ -1218,10 +1232,13 @@ def _handle_internal_core(
                     sqs_queue_url,
                 )
 
-                # Skip writing to DynamoDB - we only store in ChromaDB now
+                words_marked_partial = mark_words_embedded(
+                    partial_results, descriptions, dynamo_client
+                )
                 logger.info(
                     "Processed partial embedding results",
                     count=len(partial_results),
+                    words_marked=words_marked_partial,
                 )
 
         # Mark failed items for retry

--- a/receipt_chroma/receipt_chroma/embedding/openai/__init__.py
+++ b/receipt_chroma/receipt_chroma/embedding/openai/__init__.py
@@ -8,6 +8,7 @@ from receipt_chroma.embedding.openai.batch_status import (
     handle_batch_status,
     map_openai_to_dynamo_status,
     mark_items_for_retry,
+    mark_words_embedded,
     process_error_file,
     process_partial_results,
     should_retry_batch,
@@ -32,6 +33,7 @@ from receipt_chroma.embedding.openai.submit import (
 __all__ = [
     "handle_batch_status",
     "mark_items_for_retry",
+    "mark_words_embedded",
     "map_openai_to_dynamo_status",
     "process_error_file",
     "process_partial_results",

--- a/receipt_chroma/receipt_chroma/embedding/openai/batch_status.py
+++ b/receipt_chroma/receipt_chroma/embedding/openai/batch_status.py
@@ -573,6 +573,76 @@ def mark_items_for_retry(
     return marked_count
 
 
+def mark_words_embedded(
+    embed_results: List[dict],
+    descriptions: Dict[str, Dict[int, dict]],
+    dynamo_client: DynamoClient,
+) -> int:
+    """
+    Flip embedding_status to SUCCESS for every word whose embedding was
+    saved to the delta.
+
+    Unlike lines (visual-row grouping with stale resets), words embed
+    one-per-custom_id, so a straight id match suffices. A word replaced
+    between submit and poll has no row to match and is skipped — its
+    receipt was already filtered out, or its word_id no longer exists.
+    Without this flip words stay PENDING forever: discovery only selects
+    NONE, so they are never resubmitted, and drains gated on PENDING never
+    finish.
+
+    Args:
+        embed_results: OpenAI batch result rows (each with a custom_id in
+            IMAGE#<id>#RECEIPT#<id>#LINE#<id>#WORD#<id> format)
+        descriptions: image_id -> receipt_id -> {"words": [ReceiptWord]}
+            as returned by get_receipt_details
+        dynamo_client: DynamoDB client instance
+
+    Returns:
+        Number of words marked SUCCESS
+    """
+    words_by_receipt: Dict[Tuple[str, int], Dict[Tuple[int, int], Any]] = {}
+    for image_id, receipts in descriptions.items():
+        for receipt_id, details in receipts.items():
+            words_by_receipt[(image_id, receipt_id)] = {
+                (w.line_id, w.word_id): w for w in details["words"]
+            }
+
+    to_update: Dict[Tuple[str, int], list] = {}
+    for result in embed_results:
+        try:
+            parts = result["custom_id"].split("#")
+            if len(parts) != 8 or parts[4] != "LINE" or parts[6] != "WORD":
+                raise ValueError("not a word custom_id")
+            image_id = parts[1]
+            receipt_id = int(parts[3])
+            line_id = int(parts[5])
+            word_id = int(parts[7])
+        except (KeyError, IndexError, ValueError, AttributeError) as e:
+            logger.warning(
+                "Skipping result with invalid custom_id: %s (%s)",
+                result.get("custom_id") if isinstance(result, dict) else None,
+                e,
+            )
+            continue
+        word = words_by_receipt.get((image_id, receipt_id), {}).get(
+            (line_id, word_id)
+        )
+        if (
+            word is not None
+            and word.embedding_status != EmbeddingStatus.SUCCESS.value
+        ):
+            word.embedding_status = EmbeddingStatus.SUCCESS.value
+            to_update.setdefault((image_id, receipt_id), []).append(word)
+
+    # Update per receipt to avoid transaction conflicts when multiple
+    # batches are processed concurrently (same pattern as line polling)
+    for words_to_update in to_update.values():
+        dynamo_client.update_receipt_words(words_to_update)
+    marked = sum(len(w) for w in to_update.values())
+    logger.info("Marked %d words as embedded (SUCCESS)", marked)
+    return marked
+
+
 def should_retry_batch(
     batch_summary: BatchSummary,
     max_retries: int = 3,  # pylint: disable=unused-argument

--- a/receipt_chroma/tests/unit/test_mark_words_embedded.py
+++ b/receipt_chroma/tests/unit/test_mark_words_embedded.py
@@ -17,7 +17,9 @@ class FakeWord:
 
 
 def _custom_id(image_id, receipt_id, line_id, word_id):
-    return f"IMAGE#{image_id}#RECEIPT#{receipt_id}#LINE#{line_id}#WORD#{word_id}"
+    return (
+        f"IMAGE#{image_id}#RECEIPT#{receipt_id}#LINE#{line_id}#WORD#{word_id}"
+    )
 
 
 IMG = "3f52ce10-0000-4000-8000-000000000001"

--- a/receipt_chroma/tests/unit/test_mark_words_embedded.py
+++ b/receipt_chroma/tests/unit/test_mark_words_embedded.py
@@ -1,0 +1,118 @@
+"""Tests for mark_words_embedded (#990: words stranded in PENDING because
+the word poller never flipped embedding_status after a successful delta
+save — only the line poller did)."""
+
+from dataclasses import dataclass
+from unittest.mock import MagicMock
+
+from receipt_chroma.embedding.openai import mark_words_embedded
+from receipt_dynamo.constants import EmbeddingStatus
+
+
+@dataclass
+class FakeWord:
+    line_id: int
+    word_id: int
+    embedding_status: str = EmbeddingStatus.PENDING.value
+
+
+def _custom_id(image_id, receipt_id, line_id, word_id):
+    return f"IMAGE#{image_id}#RECEIPT#{receipt_id}#LINE#{line_id}#WORD#{word_id}"
+
+
+IMG = "3f52ce10-0000-4000-8000-000000000001"
+
+
+def _descriptions(words):
+    return {IMG: {1: {"words": words}}}
+
+
+def test_marks_matched_words_success_and_updates_dynamo():
+    words = [FakeWord(1, 1), FakeWord(1, 2), FakeWord(2, 1)]
+    results = [
+        {"custom_id": _custom_id(IMG, 1, 1, 1)},
+        {"custom_id": _custom_id(IMG, 1, 2, 1)},
+    ]
+    client = MagicMock()
+
+    marked = mark_words_embedded(results, _descriptions(words), client)
+
+    assert marked == 2
+    assert words[0].embedding_status == EmbeddingStatus.SUCCESS.value
+    assert words[2].embedding_status == EmbeddingStatus.SUCCESS.value
+    # untouched word stays PENDING
+    assert words[1].embedding_status == EmbeddingStatus.PENDING.value
+    client.update_receipt_words.assert_called_once()
+    (updated,), _ = client.update_receipt_words.call_args
+    assert {(w.line_id, w.word_id) for w in updated} == {(1, 1), (2, 1)}
+
+
+def test_skips_words_missing_from_current_receipt():
+    """A word replaced between submit and poll has no row to match."""
+    words = [FakeWord(1, 1)]
+    results = [
+        {"custom_id": _custom_id(IMG, 1, 1, 1)},
+        {"custom_id": _custom_id(IMG, 1, 9, 9)},  # no longer exists
+        {"custom_id": _custom_id(IMG, 2, 1, 1)},  # receipt filtered out
+    ]
+    client = MagicMock()
+
+    marked = mark_words_embedded(results, _descriptions(words), client)
+
+    assert marked == 1
+    assert words[0].embedding_status == EmbeddingStatus.SUCCESS.value
+
+
+def test_already_success_words_not_rewritten():
+    words = [FakeWord(1, 1, EmbeddingStatus.SUCCESS.value)]
+    results = [{"custom_id": _custom_id(IMG, 1, 1, 1)}]
+    client = MagicMock()
+
+    marked = mark_words_embedded(results, _descriptions(words), client)
+
+    assert marked == 0
+    client.update_receipt_words.assert_not_called()
+
+
+def test_invalid_custom_ids_skipped():
+    words = [FakeWord(1, 1)]
+    results = [
+        {"custom_id": "GARBAGE"},
+        {"no_custom_id": True},
+        {"custom_id": _custom_id(IMG, 1, 1, 1) + "#LINE#extra"},
+        {"custom_id": _custom_id(IMG, 1, 1, 1)},
+    ]
+    client = MagicMock()
+
+    marked = mark_words_embedded(results, _descriptions(words), client)
+
+    assert marked == 1
+
+
+def test_line_custom_id_rejected():
+    """Line-format ids (no WORD component) must not match words."""
+    words = [FakeWord(1, 1)]
+    results = [{"custom_id": f"IMAGE#{IMG}#RECEIPT#1#LINE#1"}]
+    client = MagicMock()
+
+    marked = mark_words_embedded(results, _descriptions(words), client)
+
+    assert marked == 0
+    client.update_receipt_words.assert_not_called()
+
+
+def test_updates_are_per_receipt():
+    """One update_receipt_words call per receipt, never cross-receipt."""
+    img2 = "3f52ce10-0000-4000-8000-000000000002"
+    w1, w2 = FakeWord(1, 1), FakeWord(1, 1)
+    descriptions = {IMG: {1: {"words": [w1]}}, img2: {2: {"words": [w2]}}}
+    results = [
+        {"custom_id": _custom_id(IMG, 1, 1, 1)},
+        {"custom_id": _custom_id(img2, 2, 1, 1)},
+    ]
+    client = MagicMock()
+
+    marked = mark_words_embedded(results, descriptions, client)
+
+    assert marked == 2
+    assert client.update_receipt_words.call_count == 2

--- a/scripts/local_analytics_cache.py
+++ b/scripts/local_analytics_cache.py
@@ -244,7 +244,8 @@ class DynamoSQLiteWriter:
         self.connection.execute("PRAGMA journal_mode=OFF")
         self.connection.execute("PRAGMA synchronous=OFF")
         self.connection.execute("PRAGMA temp_store=MEMORY")
-        self.connection.executescript("""
+        self.connection.executescript(
+            """
             CREATE TABLE dynamo_items (
                 pk TEXT NOT NULL,
                 sk TEXT NOT NULL,
@@ -275,7 +276,8 @@ class DynamoSQLiteWriter:
                 key TEXT PRIMARY KEY,
                 value TEXT NOT NULL
             ) WITHOUT ROWID;
-            """)
+            """
+        )
         self.lock = threading.Lock()
         self.row_count = 0
 
@@ -349,15 +351,19 @@ class DynamoSQLiteWriter:
             self.connection.execute(
                 "CREATE INDEX dynamo_items_image_idx ON dynamo_items(image_id)"
             )
-            self.connection.execute("""CREATE INDEX dynamo_items_raw_s3_idx
-                ON dynamo_items(raw_s3_bucket, raw_s3_key)""")
-            self.connection.executescript("""
+            self.connection.execute(
+                """CREATE INDEX dynamo_items_raw_s3_idx
+                ON dynamo_items(raw_s3_bucket, raw_s3_key)"""
+            )
+            self.connection.executescript(
+                """
                 CREATE VIEW images AS
                 SELECT * FROM dynamo_items WHERE entity_type = 'IMAGE';
 
                 CREATE VIEW receipts AS
                 SELECT * FROM dynamo_items WHERE entity_type = 'RECEIPT';
-                """)
+                """
+            )
             self.connection.executemany(
                 "INSERT OR REPLACE INTO cache_metadata(key, value) VALUES (?, ?)",
                 [(key, _json_dump(value)) for key, value in metadata.items()],
@@ -981,6 +987,33 @@ def _local_dynamo_client(endpoint_url: str, region: str | None = None) -> Any:
     )
 
 
+def _robust_local_dynamo_client(
+    endpoint_url: str, region: str | None = None, workers: int = 4
+) -> Any:
+    """Local client for BULK work (hydration import, big scans).
+
+    ``_local_dynamo_client``'s aggressive timeouts (read_timeout=1s, zero
+    retries) are right for the is-the-server-there probe but fatal for a large
+    ``batch_write_item`` stream: a disk-backed DynamoDB Local occasionally
+    takes >1s per batch (JVM GC, bind-mount I/O), which killed hydration on a
+    Mac mini ~3k items in, on every attempt. Bulk paths get real timeouts,
+    retries, and a pool sized to the worker count.
+    """
+    return boto3.client(
+        "dynamodb",
+        endpoint_url=endpoint_url,
+        region_name=region or "us-east-1",
+        aws_access_key_id="local",
+        aws_secret_access_key="local",
+        config=Config(
+            connect_timeout=5,
+            read_timeout=60,
+            retries={"max_attempts": 8, "mode": "adaptive"},
+            max_pool_connections=max(10, workers * 2),
+        ),
+    )
+
+
 def _container_name(env: str, port: int) -> str:
     safe_env = re.sub(r"[^a-zA-Z0-9_.-]+", "-", env).strip("-") or "cache"
     return f"portfolio-dynamodb-local-{safe_env}-{port}"
@@ -1189,8 +1222,13 @@ def serve_dynamodb_cache(args: argparse.Namespace) -> dict[str, Any]:
         LOG.info("DynamoDB Local already matches the cache; skipping import")
     else:
         LOG.info("Importing the cache into DynamoDB Local at %s", endpoint_url)
+        # The probe client above uses 1s/no-retry timeouts on purpose; the bulk
+        # import needs a client that tolerates slow batches (see docstring).
+        import_client = _robust_local_dynamo_client(
+            endpoint_url, args.region, args.import_workers
+        )
         imported = _import_local_dynamo(
-            client,
+            import_client,
             table_name,
             db_path,
             state["table_schema"],

--- a/scripts/ocr_migration_apply.py
+++ b/scripts/ocr_migration_apply.py
@@ -219,13 +219,25 @@ def plan_label_moves(
     # images with repeated labels, e.g. many ADDRESS_LINE rows).
     taken: set[tuple[tuple[int, int, int], str]] = set()
 
+    # PASS 1 — finalize all MOVES first so their (word, label) slots are
+    # claimed before any park chooses a landing spot. (A park's all-consumed
+    # fallback may land on a move's word; if the park ran first it could claim
+    # the same (word, label) a later move needs -> duplicate PK/SK.)
+    for okey in labeled_keys:
+        if okey not in matched:
+            continue
+        rows = old_labels[okey]
+        for row in rows:
+            lab = str(row.get("label", ""))
+            plan.moves.append(LabelMove(okey, matched[okey], row, lab))
+            taken.add((matched[okey], lab))
+
+    # PASS 2 — parks.
     for okey in labeled_keys:
         rows = old_labels[okey]
         labels_here = [str(row.get("label", "")) for row in rows]
         if okey in matched:
-            for row, lab in zip(rows, labels_here):
-                plan.moves.append(LabelMove(okey, matched[okey], row, lab))
-                taken.add((matched[okey], lab))
+            pass  # handled in pass 1
         else:
             # PARK: nearest word (unconsumed first) whose (word, label) slots
             # are all free. Consume it so parked labels spread out instead of

--- a/scripts/ocr_migration_apply.py
+++ b/scripts/ocr_migration_apply.py
@@ -51,7 +51,7 @@ from collections import Counter, defaultdict
 from dataclasses import dataclass, field
 from difflib import SequenceMatcher
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterable
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "receipt_dynamo"))
@@ -213,40 +213,59 @@ def plan_label_moves(
             matched[okey] = best
             consumed.add(best)
 
+    # (new word key, label) pairs already claimed — a label row's PK/SK is
+    # unique per (word, label), so two labels landing on the same pair would be
+    # DUPLICATE KEYS in the batch write (this killed the first real apply on
+    # images with repeated labels, e.g. many ADDRESS_LINE rows).
+    taken: set[tuple[tuple[int, int, int], str]] = set()
+
     for okey in labeled_keys:
         rows = old_labels[okey]
+        labels_here = [str(row.get("label", "")) for row in rows]
         if okey in matched:
-            for row in rows:
-                plan.moves.append(
-                    LabelMove(okey, matched[okey], row, str(row.get("label", "")))
-                )
+            for row, lab in zip(rows, labels_here):
+                plan.moves.append(LabelMove(okey, matched[okey], row, lab))
+                taken.add((matched[okey], lab))
         else:
-            # PARK: nearest unconsumed word (any receipt), no score threshold —
-            # a parked label needs a live word to attach to, and NEEDS_REVIEW
-            # flags it for a human regardless of where it sits.
+            # PARK: nearest word (unconsumed first) whose (word, label) slots
+            # are all free. Consume it so parked labels spread out instead of
+            # piling onto one word.
             od = old_words[okey]
-            best, best_d = None, float("inf")
-            for nkey, nd in new_words.items():
-                if nkey in consumed:
-                    continue
-                d = math.hypot(od["c"][0] - nd["c"][0], od["c"][1] - nd["c"][1])
-                if d < best_d:
-                    best, best_d = nkey, d
-            if best is None:  # every new word consumed — attach to nearest overall
-                for nkey, nd in new_words.items():
+
+            def _nearest(pool: Iterable[tuple[int, int, int]]):
+                best, best_d = None, float("inf")
+                for nkey in pool:
+                    nd = new_words[nkey]
+                    if any((nkey, lab) in taken for lab in labels_here):
+                        continue
                     d = math.hypot(od["c"][0] - nd["c"][0], od["c"][1] - nd["c"][1])
                     if d < best_d:
                         best, best_d = nkey, d
-            for row in rows:
+                return best
+
+            best = _nearest(k for k in new_words if k not in consumed)
+            if best is None:  # all consumed — any word with free label slots
+                best = _nearest(new_words.keys())
+            if best is None:
+                # Pathological (labels with this name outnumber words). Refuse
+                # rather than lose or collide; the image errors out cleanly
+                # before any write happens.
+                raise RuntimeError(
+                    f"cannot place parked label(s) {labels_here} from {okey}: "
+                    "no (word, label) slot left"
+                )
+            consumed.add(best)
+            for row, lab in zip(rows, labels_here):
                 plan.parks.append(
                     LabelPark(
                         okey,
                         best,
                         row,
-                        str(row.get("label", "")),
+                        lab,
                         str(row.get("validation_status", "NONE")),
                     )
                 )
+                taken.add((best, lab))
     return plan
 
 
@@ -508,6 +527,11 @@ def apply_image(
         + [lb.to_item() for lb in label_entities]
     )
     new_keys = {(i["PK"]["S"], i["SK"]["S"]) for i in new_items}
+    if len(new_keys) != len(new_items):
+        raise RuntimeError(
+            f"duplicate keys in new items ({len(new_items) - len(new_keys)}); "
+            "refusing to write"
+        )
     pre_orphan_sks = {
         (
             f"IMAGE#{image_id}",

--- a/scripts/ocr_migration_apply.py
+++ b/scripts/ocr_migration_apply.py
@@ -81,9 +81,18 @@ def _norm(t: str | None) -> str:
 def _centroid(d: dict[str, Any]) -> tuple[float, float]:
     # float() everything: rows read live from DynamoDB deserialize numbers as
     # decimal.Decimal, and Decimal / float raises TypeError.
+    # Older-era word rows can lack corner attrs; fall back to bounding_box so
+    # their labels are MOVED/PARKED instead of mis-classed as pre-orphans while
+    # their words get deleted (live-dev wave-2 halt, image 1b441d33).
+    if "top_left" in d and "bottom_right" in d:
+        return (
+            (float(d["top_left"]["x"]) + float(d["bottom_right"]["x"])) / 2.0,
+            (float(d["top_left"]["y"]) + float(d["bottom_right"]["y"])) / 2.0,
+        )
+    bb = d["bounding_box"]
     return (
-        (float(d["top_left"]["x"]) + float(d["bottom_right"]["x"])) / 2.0,
-        (float(d["top_left"]["y"]) + float(d["bottom_right"]["y"])) / 2.0,
+        float(bb["x"]) + float(bb["width"]) / 2.0,
+        float(bb["y"]) + float(bb["height"]) / 2.0,
     )
 
 
@@ -471,7 +480,7 @@ def apply_image(
         etype = native.get("TYPE")
         wkey = reh.parse_word_sk(sk)
         if wkey and etype == "RECEIPT_WORD":
-            if "top_left" in native and "bottom_right" in native:
+            if "bounding_box" in native or ("top_left" in native and "bottom_right" in native):
                 old_words[wkey] = {
                     "text": _norm(native.get("text")),
                     "c": _centroid(native),

--- a/scripts/ocr_migration_apply.py
+++ b/scripts/ocr_migration_apply.py
@@ -1,0 +1,640 @@
+#!/usr/bin/env python3
+"""Label-preserving re-OCR migration: apply #1095 segmentation to existing images.
+
+Per image: run the new Swift OCR on the LOCAL raw image, build the new receipt
+hierarchy (same conventions as the ingestion lambda's
+``_parse_receipt_ocr_from_swift``: ids ``enumerate(start=1)``, empty-text /
+zero-confidence skip rules), MOVE every human label onto its matched new word,
+then delete the stale rows — children first, never ``delete_image_details``.
+
+Label policy (the point of this tool):
+  - MOVE, never regenerate: a matched label keeps ``label``,
+    ``validation_status``, ``label_proposed_by``, ``label_consolidated_from``,
+    ``reasoning`` and ``timestamp_added`` verbatim — the audit trail survives.
+  - Matching = old receipt -> new receipt correspondence (word-text Jaccard),
+    then per-receipt one-to-one word matching by combined TEXT similarity +
+    CENTROID proximity (measured 97.8% auto-preservation on 616 dev images).
+  - PARK, never drop: an unmatched label is attached to the nearest unconsumed
+    new word with ``validation_status=NEEDS_REVIEW`` and a reasoning note that
+    records the original status/word — zero labels are ever deleted.
+  - Labels already orphaned BEFORE the migration (their word row is missing in
+    dev) are left completely untouched and reported; they are pre-existing
+    breakage for the separate cleanup pass.
+  - No machine (LayoutLM) labels are written during migration: moved human
+    labels are the only labels this tool produces, so a human label can never
+    be shadowed by a machine proposal (the normal pipeline can re-propose
+    later).
+
+Safety:
+  - Local-first: refuses non-local endpoints unless ``--allow-aws``.
+  - Requires a rollback ``backup`` (from ocr_migration_rehearsal.py) covering
+    every target image, taken from the SAME endpoint, before it writes.
+  - ``--dry-run`` computes and reports everything, writes nothing.
+
+Out of scope here (dev-phase steps, by design): crop upload + CDN formats +
+CloudFront invalidation, OCRJob bookkeeping, embedding kick-off. The new
+RECEIPT_WORD/LINE rows default to ``embedding_status=NONE`` so the batch
+embedding step functions discover them.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import math
+import os
+import subprocess
+import sys
+import tempfile
+from collections import Counter, defaultdict
+from dataclasses import dataclass, field
+from difflib import SequenceMatcher
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "receipt_dynamo"))
+from receipt_dynamo.entities import (  # noqa: E402
+    Receipt,
+    ReceiptLetter,
+    ReceiptLine,
+    ReceiptWord,
+    ReceiptWordLabel,
+)
+from scripts import ocr_migration_rehearsal as reh  # noqa: E402
+
+LOG = logging.getLogger("ocr_migration_apply")
+
+MIN_SCORE, W_TEXT, W_POS, POS_SCALE = 0.55, 0.5, 0.5, 0.5
+
+# Old receipt-scoped SKs to delete after a successful re-OCR. Dead analysis
+# families are dropped on purpose (no producers/consumers; see game plan).
+STALE_SK_PREFIX = "RECEIPT#"
+PRESERVED_TYPES = {"RECEIPT_PLACE"}  # re-keyed, not deleted-and-lost
+
+
+def _norm(t: str | None) -> str:
+    return " ".join((t or "").strip().upper().split())
+
+
+def _centroid(d: dict[str, Any]) -> tuple[float, float]:
+    return (
+        (d["top_left"]["x"] + d["bottom_right"]["x"]) / 2.0,
+        (d["top_left"]["y"] + d["bottom_right"]["y"]) / 2.0,
+    )
+
+
+def _score(
+    text_a: str, ca: tuple[float, float], text_b: str, cb: tuple[float, float]
+) -> float:
+    ts = SequenceMatcher(None, text_a, text_b).ratio()
+    ps = max(0.0, 1.0 - math.hypot(ca[0] - cb[0], ca[1] - cb[1]) / POS_SCALE)
+    return W_TEXT * ts + W_POS * ps
+
+
+# --------------------------------------------------------------------------- #
+# Planning (pure, unit-testable)                                              #
+# --------------------------------------------------------------------------- #
+
+
+@dataclass
+class LabelMove:
+    old_key: tuple[int, int, int]  # (receipt_id, line_id, word_id)
+    new_key: tuple[int, int, int]
+    native: dict[str, Any]  # the old label row's native attributes
+    label: str
+
+
+@dataclass
+class LabelPark:
+    old_key: tuple[int, int, int]
+    new_key: tuple[int, int, int]  # best-guess word the parked label attaches to
+    native: dict[str, Any]
+    label: str
+    original_status: str
+
+
+@dataclass
+class MovePlan:
+    moves: list[LabelMove] = field(default_factory=list)
+    parks: list[LabelPark] = field(default_factory=list)
+    pre_orphaned: list[tuple[tuple[int, int, int], str]] = field(default_factory=list)
+
+
+def correspond_receipts(
+    old_words: dict[tuple[int, int, int], dict[str, Any]],
+    new_words: dict[tuple[int, int, int], dict[str, Any]],
+) -> dict[int, int]:
+    """old receipt_id -> new receipt_id by word-text Jaccard overlap."""
+    old_sets: dict[int, Counter] = defaultdict(Counter)
+    new_sets: dict[int, Counter] = defaultdict(Counter)
+    for (r, _l, _w), d in old_words.items():
+        old_sets[r][d["text"]] += 1
+    for (r, _l, _w), d in new_words.items():
+        new_sets[r][d["text"]] += 1
+    pairs = []
+    for orid, oset in old_sets.items():
+        for nrid, nset in new_sets.items():
+            inter = sum((oset & nset).values())
+            union = sum((oset | nset).values()) or 1
+            pairs.append((inter / union, orid, nrid))
+    pairs.sort(reverse=True)
+    used_new: set[int] = set()
+    corr: dict[int, int] = {}
+    for s, orid, nrid in pairs:
+        if orid in corr or nrid in used_new or s <= 0:
+            continue
+        corr[orid] = nrid
+        used_new.add(nrid)
+    return corr
+
+
+def plan_label_moves(
+    old_words: dict[tuple[int, int, int], dict[str, Any]],
+    old_labels: dict[tuple[int, int, int], list[dict[str, Any]]],
+    new_words: dict[tuple[int, int, int], dict[str, Any]],
+) -> MovePlan:
+    """Decide, for every old label, where it lands in the new hierarchy.
+
+    ``old_words``/``new_words``: key -> {"text": norm, "c": (x, y)}.
+    ``old_labels``: old word key -> [label-row native dicts].
+    One physical word may carry several labels; they all ride its match.
+    """
+    plan = MovePlan()
+    corr = correspond_receipts(old_words, new_words)
+    consumed: set[tuple[int, int, int]] = set()
+
+    # Pre-orphans: label rows whose word does not exist — leave untouched.
+    labeled_keys = []
+    for okey, rows in old_labels.items():
+        if okey not in old_words:
+            for row in rows:
+                plan.pre_orphaned.append((okey, str(row.get("label", ""))))
+        else:
+            labeled_keys.append(okey)
+
+    # Greedy best-score matching per corresponded receipt.
+    cands = []
+    for okey in labeled_keys:
+        od = old_words[okey]
+        nrid = corr.get(okey[0])
+        if nrid is None:
+            continue
+        for nkey, nd in new_words.items():
+            if nkey[0] != nrid:
+                continue
+            s = _score(od["text"], od["c"], nd["text"], nd["c"])
+            if s >= MIN_SCORE:
+                cands.append((s, okey, nkey))
+    cands.sort(key=lambda x: x[0], reverse=True)
+    matched: dict[tuple[int, int, int], tuple[int, int, int]] = {}
+    for s, okey, nkey in cands:
+        if okey in matched or nkey in consumed:
+            continue
+        matched[okey] = nkey
+        consumed.add(nkey)
+
+    # Fallback pass: unmatched labeled words try any unconsumed new word.
+    for okey in labeled_keys:
+        if okey in matched:
+            continue
+        od = old_words[okey]
+        best, best_s = None, 0.0
+        for nkey, nd in new_words.items():
+            if nkey in consumed:
+                continue
+            s = _score(od["text"], od["c"], nd["text"], nd["c"])
+            if s > best_s:
+                best, best_s = nkey, s
+        if best is not None and best_s >= MIN_SCORE:
+            matched[okey] = best
+            consumed.add(best)
+
+    for okey in labeled_keys:
+        rows = old_labels[okey]
+        if okey in matched:
+            for row in rows:
+                plan.moves.append(
+                    LabelMove(okey, matched[okey], row, str(row.get("label", "")))
+                )
+        else:
+            # PARK: nearest unconsumed word (any receipt), no score threshold —
+            # a parked label needs a live word to attach to, and NEEDS_REVIEW
+            # flags it for a human regardless of where it sits.
+            od = old_words[okey]
+            best, best_d = None, float("inf")
+            for nkey, nd in new_words.items():
+                if nkey in consumed:
+                    continue
+                d = math.hypot(od["c"][0] - nd["c"][0], od["c"][1] - nd["c"][1])
+                if d < best_d:
+                    best, best_d = nkey, d
+            if best is None:  # every new word consumed — attach to nearest overall
+                for nkey, nd in new_words.items():
+                    d = math.hypot(od["c"][0] - nd["c"][0], od["c"][1] - nd["c"][1])
+                    if d < best_d:
+                        best, best_d = nkey, d
+            for row in rows:
+                plan.parks.append(
+                    LabelPark(
+                        okey,
+                        best,
+                        row,
+                        str(row.get("label", "")),
+                        str(row.get("validation_status", "NONE")),
+                    )
+                )
+    return plan
+
+
+def moved_label_entity(
+    image_id: str, move: LabelMove, parked: bool = False, old_word_text: str = ""
+) -> ReceiptWordLabel:
+    """Build the re-keyed label entity, carrying the audit trail verbatim."""
+    n = move.native
+    rid, lid, wid = move.new_key
+    reasoning = n.get("reasoning")
+    status = n.get("validation_status")
+    if parked:
+        note = (
+            f"[PARKED by re-OCR migration: no confident word match; "
+            f"original status={status or 'NONE'}; original word "
+            f"'{old_word_text}' @ {move.old_key}]"
+        )
+        reasoning = f"{note} {reasoning}" if reasoning else note
+        status = "NEEDS_REVIEW"
+    return ReceiptWordLabel(
+        image_id=image_id,
+        receipt_id=rid,
+        line_id=lid,
+        word_id=wid,
+        label=move.label,
+        reasoning=reasoning,
+        timestamp_added=n.get("timestamp_added"),
+        validation_status=status,
+        label_proposed_by=n.get("label_proposed_by"),
+        label_consolidated_from=n.get("label_consolidated_from"),
+    )
+
+
+# --------------------------------------------------------------------------- #
+# OCR + entity construction (ingestion conventions)                            #
+# --------------------------------------------------------------------------- #
+
+
+def run_swift_ocr(binary: Path, image_path: Path) -> dict[str, Any] | None:
+    out = tempfile.mkdtemp()
+    subprocess.run(
+        [
+            str(binary),
+            "--process-local-image",
+            str(image_path),
+            "--output-dir",
+            out,
+            "--log-level",
+            "error",
+        ],
+        capture_output=True,
+        timeout=300,
+    )
+    js = [f for f in os.listdir(out) if f.endswith(".json") and "RECEIPT" not in f]
+    return json.load(open(os.path.join(out, js[0]))) if js else None
+
+
+def _valid_geometry(d: dict[str, Any]) -> bool:
+    bbox = d.get("bounding_box", {})
+    if not all(k in bbox for k in ("x", "y", "width", "height")):
+        return False
+    return all(
+        all(k in d.get(c, {}) for k in ("x", "y"))
+        for c in ("top_left", "top_right", "bottom_left", "bottom_right")
+    )
+
+
+def build_new_entities(
+    image_id: str, ocr: dict[str, Any], raw_bucket: str, timestamp: str
+) -> tuple[list[Receipt], list[ReceiptLine], list[ReceiptWord], list[ReceiptLetter]]:
+    """Swift OCR JSON -> entities, mirroring _parse_receipt_ocr_from_swift."""
+    receipts, lines, words, letters = [], [], [], []
+    for receipt_idx, rc in enumerate(ocr.get("receipts") or [], start=1):
+        bounds = rc.get("bounds") or {}
+        raw_key = f"receipts/{image_id}/{image_id}_RECEIPT_{receipt_idx:05d}.png"
+        receipts.append(
+            Receipt(
+                image_id=image_id,
+                receipt_id=receipt_idx,
+                width=int(rc.get("warped_width", 0)),
+                height=int(rc.get("warped_height", 0)),
+                timestamp_added=timestamp,
+                raw_s3_bucket=raw_bucket,
+                raw_s3_key=raw_key,
+                top_left=bounds.get("top_left"),
+                top_right=bounds.get("top_right"),
+                bottom_left=bounds.get("bottom_left"),
+                bottom_right=bounds.get("bottom_right"),
+            )
+        )
+        for line_idx, ld in enumerate(rc.get("lines") or [], start=1):
+            if not ld.get("text") or not _valid_geometry(ld):
+                continue
+            lines.append(
+                ReceiptLine(
+                    image_id=image_id,
+                    receipt_id=receipt_idx,
+                    line_id=line_idx,
+                    text=ld["text"],
+                    bounding_box=ld["bounding_box"],
+                    top_left=ld["top_left"],
+                    top_right=ld["top_right"],
+                    bottom_left=ld["bottom_left"],
+                    bottom_right=ld["bottom_right"],
+                    angle_degrees=ld.get("angle_degrees", 0.0),
+                    angle_radians=ld.get("angle_radians", 0.0),
+                    confidence=ld.get("confidence", 1.0),
+                )
+            )
+            for word_idx, wd in enumerate(ld.get("words") or [], start=1):
+                if (
+                    not wd.get("text")
+                    or wd.get("confidence", 0.0) <= 0.0
+                    or not _valid_geometry(wd)
+                ):
+                    continue
+                words.append(
+                    ReceiptWord(
+                        image_id=image_id,
+                        receipt_id=receipt_idx,
+                        line_id=line_idx,
+                        word_id=word_idx,
+                        text=wd["text"],
+                        bounding_box=wd["bounding_box"],
+                        top_left=wd["top_left"],
+                        top_right=wd["top_right"],
+                        bottom_left=wd["bottom_left"],
+                        bottom_right=wd["bottom_right"],
+                        angle_degrees=wd.get("angle_degrees", 0.0),
+                        angle_radians=wd.get("angle_radians", 0.0),
+                        confidence=wd["confidence"],
+                        extracted_data=wd.get("extracted_data"),
+                    )
+                )
+                for letter_idx, lt in enumerate(wd.get("letters") or [], start=1):
+                    if (
+                        len(lt.get("text", "")) != 1
+                        or lt.get("confidence", 0.0) <= 0.0
+                        or not _valid_geometry(lt)
+                    ):
+                        continue
+                    letters.append(
+                        ReceiptLetter(
+                            image_id=image_id,
+                            receipt_id=receipt_idx,
+                            line_id=line_idx,
+                            word_id=word_idx,
+                            letter_id=letter_idx,
+                            text=lt["text"],
+                            bounding_box=lt["bounding_box"],
+                            top_left=lt["top_left"],
+                            top_right=lt["top_right"],
+                            bottom_left=lt["bottom_left"],
+                            bottom_right=lt["bottom_right"],
+                            angle_degrees=lt.get("angle_degrees", 0.0),
+                            angle_radians=lt.get("angle_radians", 0.0),
+                            confidence=lt["confidence"],
+                        )
+                    )
+    return receipts, lines, words, letters
+
+
+# --------------------------------------------------------------------------- #
+# Apply (live)                                                                #
+# --------------------------------------------------------------------------- #
+
+
+def apply_image(
+    client: Any,
+    table_name: str,
+    image_id: str,
+    raw_dir: Path,
+    binary: Path,
+    dry_run: bool,
+) -> dict[str, Any]:
+    raw_path = raw_dir / f"{image_id}.png"
+    if not raw_path.exists():
+        return {"status": "no-raw"}
+
+    # 1. Current partition state.
+    items = reh._query_partition(client, table_name, f"IMAGE#{image_id}")
+    from scripts import local_analytics_cache as cache
+
+    old_words: dict[tuple[int, int, int], dict[str, Any]] = {}
+    old_labels: dict[tuple[int, int, int], list[dict[str, Any]]] = defaultdict(list)
+    old_receipt_sks: list[tuple[str, str]] = []  # stale candidates
+    place_rows: list[dict[str, Any]] = []
+    for it in items:
+        native = cache._native_item(it)
+        pk, sk = str(native.get("PK", "")), str(native.get("SK", ""))
+        etype = native.get("TYPE")
+        wkey = reh.parse_word_sk(sk)
+        if wkey and etype == "RECEIPT_WORD":
+            if "top_left" in native and "bottom_right" in native:
+                old_words[wkey] = {
+                    "text": _norm(native.get("text")),
+                    "c": _centroid(native),
+                }
+        lkey = reh.parse_label_sk(sk)
+        if lkey:
+            old_labels[(lkey[0], lkey[1], lkey[2])].append(native)
+        if etype == "RECEIPT_PLACE":
+            place_rows.append(native)
+        if sk.startswith(STALE_SK_PREFIX) and etype not in PRESERVED_TYPES:
+            old_receipt_sks.append((pk, sk))
+
+    n_old_labels = sum(len(v) for v in old_labels.values())
+
+    # 2. New OCR.
+    ocr = run_swift_ocr(binary, raw_path)
+    if not ocr or not (ocr.get("receipts") or []):
+        return {"status": "no-ocr", "labels": n_old_labels}
+    raw_bucket = next(
+        (
+            str(cache._native_item(it).get("raw_s3_bucket"))
+            for it in items
+            if cache._native_item(it).get("TYPE") == "IMAGE"
+        ),
+        "unknown",
+    )
+    timestamp = cache._utc_now()
+    receipts, lines, words, letters = build_new_entities(
+        image_id, ocr, raw_bucket, timestamp
+    )
+    new_words_map = {
+        (w.receipt_id, w.line_id, w.word_id): {
+            "text": _norm(w.text),
+            "c": (
+                (w.top_left["x"] + w.bottom_right["x"]) / 2.0,
+                (w.top_left["y"] + w.bottom_right["y"]) / 2.0,
+            ),
+        }
+        for w in words
+    }
+
+    # 3. Label plan.
+    plan = plan_label_moves(old_words, dict(old_labels), new_words_map)
+    label_entities = [moved_label_entity(image_id, m) for m in plan.moves] + [
+        moved_label_entity(
+            image_id,
+            LabelMove(p.old_key, p.new_key, p.native, p.label),
+            parked=True,
+            old_word_text=old_words.get(p.old_key, {}).get("text", ""),
+        )
+        for p in plan.parks
+    ]
+
+    # 4. Writes: puts first (overwrite semantics), then stale deletes.
+    new_items = (
+        [r.to_item() for r in receipts]
+        + [ln.to_item() for ln in lines]
+        + [w.to_item() for w in words]
+        + [lt.to_item() for lt in letters]
+        + [lb.to_item() for lb in label_entities]
+    )
+    new_keys = {(i["PK"]["S"], i["SK"]["S"]) for i in new_items}
+    pre_orphan_sks = {
+        (
+            f"IMAGE#{image_id}",
+            f"RECEIPT#{k[0]:05d}#LINE#{k[1]:05d}#WORD#{k[2]:05d}#LABEL#{lab}",
+        )
+        for (k, lab) in plan.pre_orphaned
+    }
+    stale = [
+        (pk, sk)
+        for (pk, sk) in old_receipt_sks
+        if (pk, sk) not in new_keys and (pk, sk) not in pre_orphan_sks
+    ]
+
+    result = {
+        "status": "ok",
+        "old_receipts": len({k[0] for k in old_words}),
+        "new_receipts": len(receipts),
+        "labels": n_old_labels,
+        "moved": len(plan.moves),
+        "parked": len(plan.parks),
+        "pre_orphaned_untouched": len(plan.pre_orphaned),
+        "puts": len(new_items),
+        "stale_deletes": len(stale),
+        "image_type": (ocr.get("classification") or {}).get("image_type"),
+    }
+    if dry_run:
+        result["dry_run"] = True
+        return result
+
+    reh._batch_write(
+        client,
+        table_name,
+        [{"PutRequest": {"Item": it}} for it in new_items],
+    )
+    reh._batch_write(
+        client,
+        table_name,
+        [
+            {"DeleteRequest": {"Key": {"PK": {"S": pk}, "SK": {"S": sk}}}}
+            for pk, sk in stale
+        ],
+    )
+    # 5. IMAGE row: new classification + receipt count.
+    itype = (ocr.get("classification") or {}).get("image_type")
+    if itype:
+        client.update_item(
+            TableName=table_name,
+            Key={"PK": {"S": f"IMAGE#{image_id}"}, "SK": {"S": f"IMAGE#{image_id}"}},
+            UpdateExpression="SET image_type = :t, receipt_count = :n",
+            ExpressionAttributeValues={
+                ":t": {"S": itype},
+                ":n": {"N": str(len(receipts))},
+            },
+        )
+    return result
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--endpoint-url", default="http://127.0.0.1:8000")
+    p.add_argument("--allow-aws", action="store_true")
+    p.add_argument("--table-name", required=True)
+    p.add_argument("--region", default=None)
+    p.add_argument("--images", type=Path, required=True)
+    p.add_argument("--raw-dir", type=Path, required=True)
+    p.add_argument("--binary", type=Path, required=True, help="receipt-ocr binary")
+    p.add_argument(
+        "--backup",
+        type=Path,
+        required=True,
+        help="rollback backup covering every target image (refused otherwise)",
+    )
+    p.add_argument("--report", type=Path, required=True)
+    p.add_argument("--dry-run", action="store_true")
+    p.add_argument("--limit", type=int, default=None)
+    p.add_argument("--log-level", default="INFO")
+    args = p.parse_args(argv)
+    logging.basicConfig(level=args.log_level.upper())
+
+    ids = reh._read_image_ids(args.images)
+    if args.limit:
+        ids = ids[: args.limit]
+
+    # Precondition: the rollback backup must cover every target image.
+    if not args.backup.exists():
+        raise SystemExit(f"REFUSING: backup {args.backup} does not exist")
+    backed_up = {
+        r.image_id or reh.image_id_from_pk(r.pk) for r in reh.load_rows(args.backup)
+    }
+    missing = [i for i in ids if i not in backed_up]
+    if missing:
+        raise SystemExit(
+            f"REFUSING: {len(missing)} target images missing from backup "
+            f"(first: {missing[:3]})"
+        )
+
+    client = reh._make_client(args.endpoint_url, args.region, args.allow_aws)
+    results: dict[str, Any] = {}
+    for n, image_id in enumerate(ids, 1):
+        try:
+            results[image_id] = apply_image(
+                client,
+                args.table_name,
+                image_id,
+                args.raw_dir,
+                args.binary,
+                args.dry_run,
+            )
+        except Exception as exc:  # keep going; the report shows the failure
+            LOG.exception("apply failed for %s", image_id)
+            results[image_id] = {"status": "error", "error": str(exc)}
+        LOG.info("[%d/%d] %s: %s", n, len(ids), image_id[:8], results[image_id])
+
+    args.report.write_text(json.dumps(results, indent=2))
+    ok = [r for r in results.values() if r["status"] == "ok"]
+    errs = [i for i, r in results.items() if r["status"] in ("error", "no-ocr")]
+    print(
+        json.dumps(
+            {
+                "images": len(results),
+                "ok": len(ok),
+                "errors": errs,
+                "labels": sum(r.get("labels", 0) for r in ok),
+                "moved": sum(r.get("moved", 0) for r in ok),
+                "parked": sum(r.get("parked", 0) for r in ok),
+                "pre_orphaned_untouched": sum(
+                    r.get("pre_orphaned_untouched", 0) for r in ok
+                ),
+            },
+            indent=2,
+        )
+    )
+    return 1 if errs else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ocr_migration_apply.py
+++ b/scripts/ocr_migration_apply.py
@@ -79,9 +79,11 @@ def _norm(t: str | None) -> str:
 
 
 def _centroid(d: dict[str, Any]) -> tuple[float, float]:
+    # float() everything: rows read live from DynamoDB deserialize numbers as
+    # decimal.Decimal, and Decimal / float raises TypeError.
     return (
-        (d["top_left"]["x"] + d["bottom_right"]["x"]) / 2.0,
-        (d["top_left"]["y"] + d["bottom_right"]["y"]) / 2.0,
+        (float(d["top_left"]["x"]) + float(d["bottom_right"]["x"])) / 2.0,
+        (float(d["top_left"]["y"]) + float(d["bottom_right"]["y"])) / 2.0,
     )
 
 

--- a/scripts/ocr_migration_apply.py
+++ b/scripts/ocr_migration_apply.py
@@ -447,6 +447,11 @@ def apply_image(
                 }
         lkey = reh.parse_label_sk(sk)
         if lkey:
+            # The label string lives ONLY in the SK — label rows carry no
+            # separate "label" attribute. Inject the parsed value so the
+            # planner and the rebuilt entity always have it.
+            native = dict(native)
+            native["label"] = lkey[3]
             old_labels[(lkey[0], lkey[1], lkey[2])].append(native)
         if etype == "RECEIPT_PLACE":
             place_rows.append(native)

--- a/scripts/ocr_migration_publish_crops.py
+++ b/scripts/ocr_migration_publish_crops.py
@@ -1,0 +1,547 @@
+#!/usr/bin/env python3
+"""Publish regenerated receipt crops after the re-OCR migration.
+
+``ocr_migration_apply.py`` rewrites the receipt hierarchy in dev DynamoDB but
+deliberately leaves the CDN work out of scope: the new Receipt rows carry the
+new bounds/dimensions and a conventional ``raw_s3_key`` while their ``cdn_*``
+fields are still null (or stale) and the site bucket still serves the OLD
+crops. This tool closes that gap, per migrated image:
+
+  1. Query the image's top-level RECEIPT rows from dev DynamoDB
+     (SK exactly ``RECEIPT#{id:05d}``, TYPE=RECEIPT).
+  2. Re-warp each crop from the LOCAL raw PNG using the receipt's corner
+     geometry — the exact PIL PERSPECTIVE transform the ingestion lambda's
+     in-process fallback uses (``ocr_processor._obtain_receipt_crop``), so the
+     published crop matches what ingestion would have produced.
+  3. Upload the raw crop PNG to the receipt's ``raw_s3_bucket`` and all 12 CDN
+     formats (full/thumbnail/small/medium x jpg/webp/avif) to the site bucket
+     under ``assets/{image_id}/{receipt_id}``.
+  4. ``update_item`` the Receipt row's ``cdn_*`` fields exactly as ingestion's
+     ``_apply_cdn_keys`` does (S for present keys, NULL for missing).
+  5. Detect ORPHANED old crops: ``assets/{image_id}/`` objects whose leading
+     receipt_id no longer exists (re-segmentation changed receipt counts) and
+     delete them.
+
+At the end, ONE CloudFront invalidation batches ``/assets/{image_id}/*`` for
+every touched image (chunked at the API's 3000-path limit).
+
+Safety (same philosophy as ``ocr_migration_rehearsal._make_client``): this
+tool targets REAL AWS by design, so any non-``--dry-run`` invocation is
+refused without an explicit ``--allow-aws``. ``--dry-run`` computes and
+reports everything — including which orphans WOULD be deleted — with zero
+writes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import re
+import subprocess
+import sys
+import uuid
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+import boto3
+from PIL import Image as PIL_Image
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "receipt_dynamo"))
+sys.path.insert(0, str(REPO_ROOT / "receipt_upload"))
+from receipt_dynamo.entities import Receipt  # noqa: E402
+from receipt_upload.geometry import find_perspective_coeffs  # noqa: E402
+from receipt_upload.utils import (  # noqa: E402
+    upload_all_cdn_formats,
+    upload_png_to_s3,
+)
+from scripts import ocr_migration_rehearsal as reh  # noqa: E402
+
+LOG = logging.getLogger("ocr_migration_publish_crops")
+
+DEFAULT_STACK = "tnorlund/portfolio/dev"
+INVALIDATION_MAX_PATHS = 3000  # CloudFront create-invalidation hard limit
+
+# Top-level receipt rows only (children are RECEIPT#..#LINE#.. etc.).
+_RECEIPT_SK = re.compile(r"^RECEIPT#\d{5}$")
+# A receipt CDN asset basename starts with the integer receipt_id followed by
+# a size/format suffix: "3.jpg", "3_thumbnail.webp", "12_medium.avif", ...
+_ASSET_RID = re.compile(r"^(\d+)[._]")
+
+# Maps a Receipt CDN entity field to the key returned by
+# upload_all_cdn_formats — identical to ocr_processor._CDN_KEY_FIELDS.
+CDN_KEY_FIELDS: tuple[tuple[str, str], ...] = (
+    ("cdn_s3_key", "jpeg_full"),
+    ("cdn_webp_s3_key", "webp_full"),
+    ("cdn_avif_s3_key", "avif_full"),
+    ("cdn_thumbnail_s3_key", "jpeg_thumbnail"),
+    ("cdn_thumbnail_webp_s3_key", "webp_thumbnail"),
+    ("cdn_thumbnail_avif_s3_key", "avif_thumbnail"),
+    ("cdn_small_s3_key", "jpeg_small"),
+    ("cdn_small_webp_s3_key", "webp_small"),
+    ("cdn_small_avif_s3_key", "avif_small"),
+    ("cdn_medium_s3_key", "jpeg_medium"),
+    ("cdn_medium_webp_s3_key", "webp_medium"),
+    ("cdn_medium_avif_s3_key", "avif_medium"),
+)
+
+
+# --------------------------------------------------------------------------- #
+# Guardrail                                                                    #
+# --------------------------------------------------------------------------- #
+
+
+def ensure_write_allowed(dry_run: bool, allow_aws: bool) -> None:
+    """Refuse any real write without an explicit --allow-aws opt-in.
+
+    This tool has no local-endpoint mode (S3 + CloudFront + the migrated dev
+    table ARE the target), so the rehearsal harness's local-first guardrail
+    degenerates to: writes require --allow-aws, always.
+    """
+    if dry_run or allow_aws:
+        return
+    raise SystemExit(
+        "REFUSING to write to real AWS without --allow-aws. This tool uploads "
+        "S3 crops, updates dev DynamoDB Receipt rows, and deletes orphaned "
+        "CDN objects. Pass --dry-run to preview everything, or add "
+        "--allow-aws to deliberately publish."
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Warp (pure): port of ocr_processor._get_perspective_coeffs / crop fallback   #
+# --------------------------------------------------------------------------- #
+
+
+def perspective_coeffs(
+    receipt: Any, image_width: int, image_height: int
+) -> list[float]:
+    """Coefficients mapping receipt-PIL -> image-PIL for PIL PERSPECTIVE.
+
+    Identical formulation to ocr_processor._get_perspective_coeffs: receipt
+    corners are normalized with a bottom-left origin (hence the ``1 - y``
+    flip into PIL's top-left pixel space); the destination is the receipt's
+    warped (width, height) rectangle.
+    """
+    src_points = [
+        (
+            receipt.top_left["x"] * image_width,
+            (1.0 - receipt.top_left["y"]) * image_height,
+        ),
+        (
+            receipt.top_right["x"] * image_width,
+            (1.0 - receipt.top_right["y"]) * image_height,
+        ),
+        (
+            receipt.bottom_right["x"] * image_width,
+            (1.0 - receipt.bottom_right["y"]) * image_height,
+        ),
+        (
+            receipt.bottom_left["x"] * image_width,
+            (1.0 - receipt.bottom_left["y"]) * image_height,
+        ),
+    ]
+    dst_points = [
+        (0.0, 0.0),
+        (float(receipt.width - 1), 0.0),
+        (float(receipt.width - 1), float(receipt.height - 1)),
+        (0.0, float(receipt.height - 1)),
+    ]
+    return find_perspective_coeffs(src_points, dst_points)
+
+
+def warp_receipt_crop(original: PIL_Image.Image, receipt: Any) -> PIL_Image.Image:
+    """Warp the ORIGINAL image to the receipt's bounds/dimensions.
+
+    Same call ingestion's in-process fallback makes, so the published crop is
+    pixel-for-pixel what a fresh ingestion would have generated.
+    """
+    coeffs = perspective_coeffs(receipt, original.width, original.height)
+    return original.transform(
+        (receipt.width, receipt.height),
+        PIL_Image.Transform.PERSPECTIVE,
+        coeffs,
+        resample=PIL_Image.Resampling.BICUBIC,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# CDN key mapping (pure)                                                       #
+# --------------------------------------------------------------------------- #
+
+
+def expected_cdn_keys(base_key: str) -> dict[str, str]:
+    """The keys upload_all_cdn_formats WOULD return for base_key (dry-run)."""
+    keys: dict[str, str] = {}
+    for size in ("full", "thumbnail", "small", "medium"):
+        size_key = base_key if size == "full" else f"{base_key}_{size}"
+        for fmt, ext in (("jpeg", "jpg"), ("webp", "webp"), ("avif", "avif")):
+            keys[f"{fmt}_{size}"] = f"{size_key}.{ext}"
+    return keys
+
+
+def build_cdn_update(
+    cdn_keys: Mapping[str, str | None], bucket: str
+) -> tuple[str, dict[str, Any]]:
+    """(UpdateExpression, ExpressionAttributeValues) for a Receipt row.
+
+    Field-for-field what ingestion persists: ``_apply_cdn_keys`` sets
+    ``cdn_s3_bucket`` plus the 12 mapped keys, and ``CDNFieldsMixin``
+    serializes a missing key as NULL (e.g. AVIF encode unavailable).
+    """
+    fields: dict[str, str | None] = {"cdn_s3_bucket": bucket}
+    for field_name, dict_key in CDN_KEY_FIELDS:
+        fields[field_name] = cdn_keys.get(dict_key)
+    expression = "SET " + ", ".join(f"{name} = :v{i}" for i, name in enumerate(fields))
+    values: dict[str, Any] = {
+        f":v{i}": ({"S": value} if value else {"NULL": True})
+        for i, value in enumerate(fields.values())
+    }
+    return expression, values
+
+
+# --------------------------------------------------------------------------- #
+# Orphan detection (pure)                                                      #
+# --------------------------------------------------------------------------- #
+
+
+def find_orphan_asset_keys(
+    listed_keys: Iterable[str],
+    image_id: str,
+    live_receipt_ids: set[int],
+) -> tuple[list[str], list[str]]:
+    """Split ``assets/{image_id}/`` listings into (orphans, unrecognized).
+
+    An orphan is an object whose leading integer receipt_id is not a live
+    receipt (re-segmentation changed the receipt count, stranding the old
+    crop). A key whose basename does not start with ``<digits>[._]`` is
+    reported as unrecognized and NEVER deleted.
+    """
+    prefix = f"assets/{image_id}/"
+    orphans: list[str] = []
+    unrecognized: list[str] = []
+    for key in listed_keys:
+        if not key.startswith(prefix):
+            continue
+        match = _ASSET_RID.match(key[len(prefix) :])
+        if not match:
+            unrecognized.append(key)
+        elif int(match.group(1)) not in live_receipt_ids:
+            orphans.append(key)
+    return sorted(orphans), sorted(unrecognized)
+
+
+def chunk_paths(paths: list[str], size: int = INVALIDATION_MAX_PATHS):
+    """Yield CloudFront-sized path batches (max 3000 paths per call)."""
+    for start in range(0, len(paths), size):
+        yield paths[start : start + size]
+
+
+# --------------------------------------------------------------------------- #
+# AWS plumbing                                                                 #
+# --------------------------------------------------------------------------- #
+
+
+def resolve_stack_output(name: str, stack: str) -> str:
+    """``pulumi stack output <name>`` from infra/ (explicit flags skip this)."""
+    proc = subprocess.run(
+        ["pulumi", "stack", "output", name, "--stack", stack],
+        cwd=REPO_ROOT / "infra",
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    value = proc.stdout.strip()
+    if not value:
+        raise SystemExit(f"pulumi stack output {name!r} is empty for {stack}")
+    return value
+
+
+def load_receipts(client: Any, table_name: str, image_id: str) -> list[Receipt]:
+    """Top-level Receipt rows for an image (SK RECEIPT#{id:05d}, TYPE=RECEIPT)."""
+    kwargs: dict[str, Any] = {
+        "TableName": table_name,
+        "KeyConditionExpression": "PK = :pk AND begins_with(SK, :sk)",
+        "ExpressionAttributeValues": {
+            ":pk": {"S": f"IMAGE#{image_id}"},
+            ":sk": {"S": "RECEIPT#"},
+        },
+        "ConsistentRead": True,
+    }
+    receipts: list[Receipt] = []
+    while True:
+        resp = client.query(**kwargs)
+        for item in resp.get("Items", []):
+            sk = item.get("SK", {}).get("S", "")
+            if _RECEIPT_SK.match(sk) and item.get("TYPE", {}).get("S") == ("RECEIPT"):
+                receipts.append(Receipt.from_item(item))
+        lek = resp.get("LastEvaluatedKey")
+        if not lek:
+            return sorted(receipts, key=lambda r: r.receipt_id)
+        kwargs["ExclusiveStartKey"] = lek
+
+
+def list_asset_keys(s3: Any, bucket: str, prefix: str) -> list[str]:
+    keys: list[str] = []
+    kwargs: dict[str, Any] = {"Bucket": bucket, "Prefix": prefix}
+    while True:
+        resp = s3.list_objects_v2(**kwargs)
+        keys.extend(obj["Key"] for obj in resp.get("Contents", []))
+        if not resp.get("IsTruncated"):
+            return keys
+        kwargs["ContinuationToken"] = resp["NextContinuationToken"]
+
+
+def delete_keys(s3: Any, bucket: str, keys: list[str]) -> None:
+    for start in range(0, len(keys), 1000):
+        chunk = keys[start : start + 1000]
+        resp = s3.delete_objects(
+            Bucket=bucket,
+            Delete={"Objects": [{"Key": k} for k in chunk], "Quiet": True},
+        )
+        errors = resp.get("Errors") or []
+        if errors:
+            raise RuntimeError(f"delete_objects failed: {errors[:5]}")
+
+
+def invalidate(cloudfront: Any, distribution_id: str, paths: list[str]) -> list[str]:
+    """One create-invalidation per <=3000-path chunk; returns invalidation ids."""
+    ids: list[str] = []
+    for batch in chunk_paths(sorted(set(paths))):
+        resp = cloudfront.create_invalidation(
+            DistributionId=distribution_id,
+            InvalidationBatch={
+                "Paths": {"Quantity": len(batch), "Items": batch},
+                "CallerReference": f"publish-crops-{uuid.uuid4()}",
+            },
+        )
+        ids.append(resp["Invalidation"]["Id"])
+    return ids
+
+
+# --------------------------------------------------------------------------- #
+# Per-image publish                                                            #
+# --------------------------------------------------------------------------- #
+
+
+def publish_image(
+    dynamo: Any,
+    s3: Any,
+    table_name: str,
+    image_id: str,
+    raw_dir: Path,
+    site_bucket: str,
+    dry_run: bool,
+) -> dict[str, Any]:
+    result: dict[str, Any] = {
+        "status": "ok",
+        "receipts_published": 0,
+        "raw_crops_uploaded": [],
+        "cdn_objects_uploaded": [],
+        "orphans_deleted": [],
+        "unrecognized_asset_keys": [],
+        "errors": [],
+    }
+    if dry_run:
+        result["dry_run"] = True
+
+    receipts = load_receipts(dynamo, table_name, image_id)
+    if not receipts:
+        result["status"] = "no-receipts"
+        result["errors"].append("no top-level RECEIPT rows in DynamoDB")
+        return result
+
+    raw_path = raw_dir / f"{image_id}.png"
+    if not raw_path.exists():
+        result["status"] = "no-raw"
+        result["errors"].append(f"missing local raw image {raw_path}")
+        return result
+    original = PIL_Image.open(raw_path)
+    original.load()
+
+    # Orphans first (independent of per-receipt failures): old crops whose
+    # receipt_id vanished when re-OCR re-segmented the image.
+    live_ids = {r.receipt_id for r in receipts}
+    existing = list_asset_keys(s3, site_bucket, f"assets/{image_id}/")
+    orphans, unrecognized = find_orphan_asset_keys(existing, image_id, live_ids)
+    result["unrecognized_asset_keys"] = unrecognized
+
+    for receipt in receipts:
+        rid = receipt.receipt_id
+        try:
+            crop = warp_receipt_crop(original, receipt)
+            raw_key = (
+                receipt.raw_s3_key
+                or f"receipts/{image_id}/{image_id}_RECEIPT_{rid:05d}.png"
+            )
+            base_key = f"assets/{image_id}/{rid}"
+            if dry_run:
+                cdn_keys: Mapping[str, str | None] = expected_cdn_keys(base_key)
+            else:
+                upload_png_to_s3(crop, receipt.raw_s3_bucket, raw_key)
+                cdn_keys = upload_all_cdn_formats(
+                    crop, site_bucket, base_key, generate_thumbnails=True
+                )
+                expression, values = build_cdn_update(cdn_keys, site_bucket)
+                dynamo.update_item(
+                    TableName=table_name,
+                    Key={
+                        "PK": {"S": f"IMAGE#{image_id}"},
+                        "SK": {"S": f"RECEIPT#{rid:05d}"},
+                    },
+                    UpdateExpression=expression,
+                    ExpressionAttributeValues=values,
+                )
+            result["raw_crops_uploaded"].append(raw_key)
+            result["cdn_objects_uploaded"].extend(
+                cdn_keys[f"{fmt}_{size}"]
+                for size in ("full", "thumbnail", "small", "medium")
+                for fmt in ("jpeg", "webp", "avif")
+                if cdn_keys.get(f"{fmt}_{size}")
+            )
+            result["receipts_published"] += 1
+        except Exception as exc:  # per-receipt: report, keep going
+            LOG.exception("publish failed for %s/%s", image_id, rid)
+            result["errors"].append(f"receipt {rid}: {exc}")
+
+    if orphans and not dry_run:
+        delete_keys(s3, site_bucket, orphans)
+    result["orphans_deleted"] = orphans
+
+    if result["errors"]:
+        result["status"] = "error"
+    return result
+
+
+# --------------------------------------------------------------------------- #
+# CLI                                                                          #
+# --------------------------------------------------------------------------- #
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--table-name", required=True)
+    p.add_argument(
+        "--images",
+        type=Path,
+        required=True,
+        help="file of migrated image_ids, one per line",
+    )
+    p.add_argument(
+        "--raw-dir",
+        type=Path,
+        required=True,
+        help="directory of local raw PNGs (<raw-dir>/<image_id>.png)",
+    )
+    p.add_argument("--report", type=Path, required=True)
+    p.add_argument("--dry-run", action="store_true")
+    p.add_argument(
+        "--allow-aws",
+        action="store_true",
+        help="required for any real write; refused otherwise",
+    )
+    p.add_argument("--region", default=None)
+    p.add_argument(
+        "--site-bucket",
+        default=None,
+        help="CDN site bucket (default: pulumi output cdn_bucket_name)",
+    )
+    p.add_argument(
+        "--invalidate",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="create ONE CloudFront invalidation for touched images",
+    )
+    p.add_argument(
+        "--distribution-id",
+        default=None,
+        help="CloudFront distribution (default: pulumi output " "cdn_distribution_id)",
+    )
+    p.add_argument("--stack", default=DEFAULT_STACK)
+    p.add_argument("--log-level", default="INFO")
+    args = p.parse_args(argv)
+    logging.basicConfig(level=args.log_level.upper())
+
+    ensure_write_allowed(args.dry_run, args.allow_aws)
+
+    image_ids = reh._read_image_ids(args.images)
+    site_bucket = args.site_bucket or resolve_stack_output(
+        "cdn_bucket_name", args.stack
+    )
+    session = boto3.Session(region_name=args.region)
+    dynamo = session.client("dynamodb")
+    s3 = session.client("s3")
+
+    results: dict[str, Any] = {}
+    touched: list[str] = []
+    for n, image_id in enumerate(image_ids, 1):
+        try:
+            results[image_id] = publish_image(
+                dynamo,
+                s3,
+                args.table_name,
+                image_id,
+                args.raw_dir,
+                site_bucket,
+                args.dry_run,
+            )
+        except Exception as exc:  # keep going; the report shows the failure
+            LOG.exception("publish failed for %s", image_id)
+            results[image_id] = {"status": "error", "errors": [str(exc)]}
+        r = results[image_id]
+        if r.get("receipts_published") or r.get("orphans_deleted"):
+            touched.append(image_id)
+        LOG.info(
+            "[%d/%d] %s: %s (%d receipts, %d orphans, %d errors)",
+            n,
+            len(image_ids),
+            image_id[:8],
+            r["status"],
+            r.get("receipts_published", 0),
+            len(r.get("orphans_deleted", [])),
+            len(r.get("errors", [])),
+        )
+
+    # ONE invalidation covering every touched image (chunked at 3000 paths).
+    paths = [f"/assets/{i}/*" for i in touched]
+    invalidation: dict[str, Any] = {
+        "requested": bool(args.invalidate and paths),
+        "paths": paths,
+    }
+    if args.invalidate and paths and not args.dry_run:
+        distribution_id = args.distribution_id or resolve_stack_output(
+            "cdn_distribution_id", args.stack
+        )
+        invalidation["distribution_id"] = distribution_id
+        invalidation["invalidation_ids"] = invalidate(
+            session.client("cloudfront"), distribution_id, paths
+        )
+
+    report = {"images": results, "invalidation": invalidation}
+    args.report.write_text(json.dumps(report, indent=2))
+
+    errors = {i: r["errors"] for i, r in results.items() if r.get("errors")}
+    summary = {
+        "images": len(results),
+        "ok": sum(1 for r in results.values() if r["status"] == "ok"),
+        "receipts_published": sum(
+            r.get("receipts_published", 0) for r in results.values()
+        ),
+        "cdn_objects_uploaded": sum(
+            len(r.get("cdn_objects_uploaded", [])) for r in results.values()
+        ),
+        "orphans_deleted": sum(
+            len(r.get("orphans_deleted", [])) for r in results.values()
+        ),
+        "invalidation_paths": len(paths),
+        "dry_run": args.dry_run,
+        "images_with_errors": sorted(errors),
+    }
+    print(json.dumps(summary, indent=2))
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ocr_migration_rehearsal.py
+++ b/scripts/ocr_migration_rehearsal.py
@@ -817,34 +817,101 @@ def reconcile_parked(
     is REAL loss/surplus and still fails the verdict.
     """
     reconciled: dict[str, int] = {}
-    for img in list(labels.lost_labels.keys()):
+    images = set(labels.lost_labels) | set(labels.surplus_labels)
+    for img in images:
         budget = expect_parked.get(img, 0)
         if budget <= 0:
             continue
-        lost = dict(labels.lost_labels[img])
+        lost = dict(labels.lost_labels.get(img, []))
         surplus = dict(labels.surplus_labels.get(img, []))
-        nr_avail = {lab: n for (lab, st), n in surplus.items() if st == "NEEDS_REVIEW"}
         used = 0
-        new_lost = {}
-        for (lab, st), n in lost.items():
-            take = min(n, nr_avail.get(lab, 0), budget - used)
-            if take > 0:
-                nr_avail[lab] -= take
-                surplus[(lab, "NEEDS_REVIEW")] -= take
-                used += take
-            if n - take > 0:
-                new_lost[(lab, st)] = n - take
+        # Each park provably creates exactly one (label, NEEDS_REVIEW) row, so
+        # the report's parked count vouches for NR surpluses DIRECTLY — the
+        # matching (label, orig_status) loss may already be explained elsewhere
+        # (e.g. an absorbed pre-orphan). Cancel NR surplus up to budget, and
+        # opportunistically cancel a same-label loss 1:1 for each. Non-NR
+        # surplus (real duplication) and unexplained loss still fail.
+        for key in list(surplus.keys()):
+            lab, st = key
+            if st != "NEEDS_REVIEW" or used >= budget:
+                continue
+            take = min(surplus[key], budget - used)
+            surplus[key] -= take
+            used += take
+            rem = take
+            for lkey in list(lost.keys()):
+                if lkey[0] != lab or rem <= 0:
+                    continue
+                c = min(lost[lkey], rem)
+                lost[lkey] -= c
+                rem -= c
+                if lost[lkey] <= 0:
+                    del lost[lkey]
         reconciled[img] = used
+        for target, src in (
+            (labels.lost_labels, {k: v for k, v in lost.items() if v > 0}),
+            (labels.surplus_labels, {k: v for k, v in surplus.items() if v > 0}),
+        ):
+            if src:
+                target[img] = sorted(src.items())
+            else:
+                target.pop(img, None)
+    return reconciled
+
+
+def absorbed_pre_orphans(
+    before: list[Row],
+    after: list[Row],
+    target_image_ids: Iterable[str] | None = None,
+) -> dict[str, Counter]:
+    """Per image: (label, status) counts of pre-orphan rows ABSORBED by a move.
+
+    A pre-orphan (label row whose word never existed) can have the same SK as a
+    legitimately moved label when re-OCR reassigns coinciding ids; the put then
+    overwrites the dead row. The real label survives; only the dead row's
+    contribution leaves the multiset. Detect exactly that: a BEFORE pre-orphan
+    SK that exists in AFTER with a LIVE word. Its BEFORE (label, status) is an
+    EXPECTED disappearance, not a loss.
+    """
+    targets = set(target_image_ids) if target_image_ids is not None else None
+    before_words = {(r.pk, r.sk) for r in before if parse_word_sk(r.sk)}
+    after_words = {(r.pk, r.sk) for r in after if parse_word_sk(r.sk)}
+    after_label_keys = {(r.pk, r.sk) for r in after if parse_label_sk(r.sk)}
+    out: dict[str, Counter] = {}
+    for r in before:
+        m = parse_label_sk(r.sk)
+        if not m:
+            continue
+        img = r.image_id or image_id_from_pk(r.pk)
+        if img is None or (targets is not None and img not in targets):
+            continue
+        word_sk = r.sk.rsplit("#LABEL#", 1)[0]
+        if (r.pk, word_sk) in before_words:
+            continue  # not a pre-orphan
+        if (r.pk, r.sk) in after_label_keys and (r.pk, word_sk) in after_words:
+            status = str(r.native.get("validation_status") or "").upper()
+            out.setdefault(img, Counter())[(m[3], status)] += 1
+    return out
+
+
+def _cancel_expected_losses(labels: LabelReport, expected: dict[str, Counter]) -> int:
+    """Remove expected (label, status) disappearances from lost_labels."""
+    cancelled = 0
+    for img, exp in expected.items():
+        if img not in labels.lost_labels:
+            continue
+        lost = dict(labels.lost_labels[img])
+        new_lost = {}
+        for key, n in lost.items():
+            take = min(n, exp.get(key, 0))
+            cancelled += take
+            if n - take > 0:
+                new_lost[key] = n - take
         if new_lost:
             labels.lost_labels[img] = sorted(new_lost.items())
         else:
             del labels.lost_labels[img]
-        remaining_surplus = {k: v for k, v in surplus.items() if v > 0}
-        if remaining_surplus:
-            labels.surplus_labels[img] = sorted(remaining_surplus.items())
-        else:
-            labels.surplus_labels.pop(img, None)
-    return reconciled
+    return cancelled
 
 
 def run_diff(
@@ -858,6 +925,13 @@ def run_diff(
     row_diff = diff_rows(before, after)
     violations = blast_radius_violations(row_diff.changed_pks, target_image_ids)
     labels = check_label_preservation(before, after, target_image_ids)
+    # Absorption FIRST (exact, key-deterministic), park reconciliation second
+    # (budgeted): otherwise the parked NEEDS_REVIEW budget gets spent cancelling
+    # losses that absorption would have explained exactly, leaving genuine
+    # parked transitions stranded as false "loss".
+    absorbed = _cancel_expected_losses(
+        labels, absorbed_pre_orphans(before, after, target_image_ids)
+    )
     reconciled = reconcile_parked(labels, expect_parked) if expect_parked else {}
     # Orphan DELTA: pre-existing dangling labels (word already missing BEFORE
     # the migration) must not fail the run — only orphans the migration CREATED.
@@ -907,6 +981,7 @@ def run_diff(
             "images_with_churn_only": len(labels.churn_only),
             "reconciled_parked": sum(reconciled.values()),
             "images_reconciled": len(reconciled),
+            "absorbed_pre_orphans": absorbed,
         },
         "invariants": {
             "orphan_labels": [

--- a/scripts/ocr_migration_rehearsal.py
+++ b/scripts/ocr_migration_rehearsal.py
@@ -781,17 +781,69 @@ def _read_image_ids(path: Path) -> list[str]:
     return ids
 
 
+def reconcile_parked(
+    labels: LabelReport, expect_parked: dict[str, int]
+) -> dict[str, Any]:
+    """Cancel loss/surplus pairs explained by PARKING, in place.
+
+    A parked label legitimately transitions (label, ORIG_STATUS) ->
+    (label, NEEDS_REVIEW) on its image, which the raw multiset check reads as
+    one loss plus one surplus. For each image, cancel each lost (label, S)
+    against available (label, NEEDS_REVIEW) surplus, capped by the apply
+    report's parked count for that image. Anything left after reconciliation
+    is REAL loss/surplus and still fails the verdict.
+    """
+    reconciled: dict[str, int] = {}
+    for img in list(labels.lost_labels.keys()):
+        budget = expect_parked.get(img, 0)
+        if budget <= 0:
+            continue
+        lost = dict(labels.lost_labels[img])
+        surplus = dict(labels.surplus_labels.get(img, []))
+        nr_avail = {lab: n for (lab, st), n in surplus.items() if st == "NEEDS_REVIEW"}
+        used = 0
+        new_lost = {}
+        for (lab, st), n in lost.items():
+            take = min(n, nr_avail.get(lab, 0), budget - used)
+            if take > 0:
+                nr_avail[lab] -= take
+                surplus[(lab, "NEEDS_REVIEW")] -= take
+                used += take
+            if n - take > 0:
+                new_lost[(lab, st)] = n - take
+        reconciled[img] = used
+        if new_lost:
+            labels.lost_labels[img] = sorted(new_lost.items())
+        else:
+            del labels.lost_labels[img]
+        remaining_surplus = {k: v for k, v in surplus.items() if v > 0}
+        if remaining_surplus:
+            labels.surplus_labels[img] = sorted(remaining_surplus.items())
+        else:
+            labels.surplus_labels.pop(img, None)
+    return reconciled
+
+
 def run_diff(
     before_path: Path,
     after_path: Path,
     target_image_ids: list[str],
+    expect_parked: dict[str, int] | None = None,
 ) -> dict[str, Any]:
     before = load_rows(before_path)
     after = load_rows(after_path)
     row_diff = diff_rows(before, after)
     violations = blast_radius_violations(row_diff.changed_pks, target_image_ids)
     labels = check_label_preservation(before, after, target_image_ids)
-    orphans = find_orphan_label_keys(after, target_image_ids)
+    reconciled = reconcile_parked(labels, expect_parked) if expect_parked else {}
+    # Orphan DELTA: pre-existing dangling labels (word already missing BEFORE
+    # the migration) must not fail the run — only orphans the migration CREATED.
+    before_orphans = set(find_orphan_label_keys(before, target_image_ids))
+    orphans = [
+        o
+        for o in find_orphan_label_keys(after, target_image_ids)
+        if o not in before_orphans
+    ]
     wiped = wiped_images(before, after, target_image_ids)
     unchanged = unchanged_targets(row_diff.changed_pks, target_image_ids)
     word_bypass = targets_without_word_changes(row_diff, target_image_ids)
@@ -830,12 +882,15 @@ def run_diff(
             "images_with_surplus_labels": len(labels.surplus_labels),
             "surplus": dict(labels.surplus_labels),
             "images_with_churn_only": len(labels.churn_only),
+            "reconciled_parked": sum(reconciled.values()),
+            "images_reconciled": len(reconciled),
         },
         "invariants": {
             "orphan_labels": [
                 f"{img}#{rid}#{lid}#{wid}#{label}"
                 for (img, rid, lid, wid, label) in orphans
             ],
+            "pre_existing_orphans": len(before_orphans),
             "wiped_images": wiped,
             "unchanged_targets": unchanged,
             "targets_without_word_changes": word_bypass,
@@ -865,7 +920,8 @@ def _print_report(report: dict[str, Any]) -> None:
     )
     print(
         f"  images_with_lost_labels={lb['images_with_lost_labels']} "
-        f"images_with_churn_only={lb['images_with_churn_only']}"
+        f"images_with_churn_only={lb['images_with_churn_only']} "
+        f"reconciled_parked={lb.get('reconciled_parked', 0)}"
     )
     for rk, items in list(lb["lost"].items())[:20]:
         print(f"    LOST {rk}: {items}")
@@ -914,6 +970,13 @@ def main(argv: list[str] | None = None) -> int:
         help="file of migration target image_ids (one per line)",
     )
     d.add_argument("--json", type=Path, default=None, help="write full report JSON")
+    d.add_argument(
+        "--expect-parked",
+        type=Path,
+        default=None,
+        help="apply-report JSON; reconciles (label,S)->(label,NEEDS_REVIEW) "
+        "transitions up to each image's reported parked count",
+    )
 
     pull = sub.add_parser(
         "pull", help="scoped BEFORE snapshot: Query only the listed images from dev"
@@ -1024,7 +1087,15 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.command == "diff":
         target_ids = _read_image_ids(args.images)
-        report = run_diff(args.before, args.after, target_ids)
+        expect_parked = None
+        if args.expect_parked:
+            apply_report = json.loads(args.expect_parked.read_text())
+            expect_parked = {
+                img: int(r.get("parked", 0))
+                for img, r in apply_report.items()
+                if isinstance(r, dict) and r.get("status") == "ok"
+            }
+        report = run_diff(args.before, args.after, target_ids, expect_parked)
         if args.json:
             args.json.write_text(json.dumps(report, indent=2))
         _print_report(report)

--- a/scripts/ocr_migration_rehearsal.py
+++ b/scripts/ocr_migration_rehearsal.py
@@ -692,13 +692,21 @@ def _query_partition(client: Any, table_name: str, pk: str) -> list[dict[str, An
 
 
 def _batch_write(client: Any, table_name: str, requests: list[dict[str, Any]]) -> None:
+    """Chunked batch_write_item with EXPONENTIAL BACKOFF on UnprocessedItems.
+
+    Under sustained load (a 370k-row restore) DynamoDB keeps shedding items;
+    immediate re-submits never let it drain — the retry loop must back off.
+    """
+    import time as _time
+
     for i in range(0, len(requests), 25):
         chunk = {table_name: requests[i : i + 25]}
-        for _ in range(8):
+        for attempt in range(12):
             resp = client.batch_write_item(RequestItems=chunk)
             chunk = resp.get("UnprocessedItems") or {}
             if not chunk:
                 break
+            _time.sleep(min(5.0, 0.1 * (2**attempt)))
         if chunk:
             raise RuntimeError("batch_write left unprocessed items after retries")
 

--- a/scripts/ocr_migration_rehearsal.py
+++ b/scripts/ocr_migration_rehearsal.py
@@ -17,11 +17,14 @@ workflow (built on top of ``scripts/local_analytics_cache.py`` / PR #1097):
 
 Why label-preservation is not simple key-equality: re-OCR reassigns line/word
 ids, so a label's PK/SK (``...#LINE#..#WORD#..#LABEL#..``) changes even when the
-label is faithfully re-applied. We therefore compare, per (image_id, receipt_id),
+label is faithfully re-applied. It can also RE-SEGMENT an image (split/merge
+receipts), moving labels between receipt_ids. We therefore compare per IMAGE
+(pooled across the image's receipts, so re-segmentation is not counted as loss)
 the MULTISET of (label, word_text, validation_status) - joining each label to its
 word's text - and separately the word-text-INSENSITIVE (label, validation_status)
 counts. A tuple that disappears only because a word was re-read to different text
-is churn; a drop in the word-text-insensitive count is a real lost label.
+is churn; a drop in the word-text-insensitive count is a real lost label, and an
+increase is a surplus (a duplicated/mis-attached label).
 
 The ``diff`` command is pure Python over two SQLite files and needs no Docker or
 AWS; only ``snapshot`` talks to the live local container.
@@ -196,8 +199,9 @@ def blast_radius_violations(
 # Label preservation                                                          #
 # --------------------------------------------------------------------------- #
 
-# Per (image_id, receipt_id): Counter over an identity tuple.
-LabelIndex = dict[tuple[str, int], Counter]
+# Per image_id: Counter over an identity tuple, pooled across the image's
+# receipts (robust to re-OCR re-segmentation reassigning receipt_ids).
+LabelIndex = dict[str, Counter]
 
 
 def build_word_text_map(rows: list[Row]) -> dict[tuple[str, int, int, int], str]:
@@ -217,7 +221,14 @@ def build_word_text_map(rows: list[Row]) -> dict[tuple[str, int, int, int], str]
 
 
 def build_label_index(rows: list[Row]) -> tuple[LabelIndex, LabelIndex]:
-    """Build two per-receipt label indexes.
+    """Build two per-IMAGE label indexes (aggregated across the image's receipts).
+
+    Keyed by image_id, NOT (image_id, receipt_id): re-OCR can RE-SEGMENT an image
+    (our splitter can turn one receipt into two, or merge two), which reassigns
+    words - and their labels - to different receipt_ids. A per-receipt invariant
+    would then read that legitimate movement as loss-in-one + surplus-in-another.
+    Pooling per image makes "no label was lost from this image" the invariant,
+    which is what actually matters, while still catching a genuine drop.
 
     Returns (tuple_index, count_index):
       - tuple_index counts (label, word_text, validation_status) - sensitive to a
@@ -241,29 +252,22 @@ def build_label_index(rows: list[Row]) -> tuple[LabelIndex, LabelIndex]:
         # already normalize via normalize_enum; this hardens against raw rows.
         status = "" if status is None else str(status).upper()
         word_text = words.get((image_id, rid, lid, wid), "")
-        key = (image_id, rid)
-        tuple_index.setdefault(key, Counter())[(label, word_text, status)] += 1
-        count_index.setdefault(key, Counter())[(label, status)] += 1
+        tuple_index.setdefault(image_id, Counter())[(label, word_text, status)] += 1
+        count_index.setdefault(image_id, Counter())[(label, status)] += 1
     return tuple_index, count_index
 
 
 @dataclass
 class LabelReport:
-    # (image_id, receipt_id) -> list of lost identity tuples with counts
-    lost_labels: dict[tuple[str, int], list[tuple[Any, int]]] = field(
-        default_factory=dict
-    )
-    churn_only: dict[tuple[str, int], list[tuple[Any, int]]] = field(
-        default_factory=dict
-    )
-    # (image_id, receipt_id) -> (label, status) counts that INCREASED. A clean
-    # re-apply preserves counts exactly; a surplus means the migration failed to
+    # image_id -> list of lost identity tuples with counts (pooled per image)
+    lost_labels: dict[str, list[tuple[Any, int]]] = field(default_factory=dict)
+    churn_only: dict[str, list[tuple[Any, int]]] = field(default_factory=dict)
+    # image_id -> (label, status) counts that INCREASED. A clean re-apply
+    # preserves per-image counts exactly; a surplus means the migration failed to
     # delete an old label row whose (line,word) id collided with a regenerated
     # word (so the orphan check can't see it) -> a duplicated, mis-attached label.
-    surplus_labels: dict[tuple[str, int], list[tuple[Any, int]]] = field(
-        default_factory=dict
-    )
-    receipts_checked: int = 0
+    surplus_labels: dict[str, list[tuple[Any, int]]] = field(default_factory=dict)
+    images_checked: int = 0
     labels_before: int = 0
     labels_after: int = 0
 
@@ -281,61 +285,61 @@ def check_label_preservation(
     after: list[Row],
     target_image_ids: Iterable[str] | None = None,
 ) -> LabelReport:
-    """Assert every pre-migration label survives (per receipt, multiset >=).
+    """Assert every pre-migration label survives (per IMAGE, multiset >=).
 
-    A real loss is a decrease in the word-text-INSENSITIVE (label,
-    validation_status) count for a receipt. A tuple that only disappears from the
-    word-text-SENSITIVE view (same label+status count preserved) is churn from a
-    re-read word and is reported separately, not as loss.
+    Labels are pooled per image (not per receipt) so a re-OCR that re-segments an
+    image and moves labels between receipt_ids reads as preserved. A real loss is
+    a decrease in the word-text-INSENSITIVE (label, validation_status) count for
+    an image; a surplus is an increase (duplicated/mis-attached label). A tuple
+    that only disappears from the word-text-SENSITIVE view (same (label,status)
+    count) is churn from a re-read word, reported separately, not as loss.
     """
     targets = set(target_image_ids) if target_image_ids is not None else None
     before_tuples, before_counts = build_label_index(before)
     after_tuples, after_counts = build_label_index(after)
 
-    def _in_scope(key: tuple[str, int]) -> bool:
-        return targets is None or key[0] in targets
+    def _in_scope(image_id: str) -> bool:
+        return targets is None or image_id in targets
 
     report = LabelReport()
-    for key, before_counter in before_counts.items():
-        if not _in_scope(key):
+    for image_id, before_counter in before_counts.items():
+        if not _in_scope(image_id):
             continue
-        report.receipts_checked += 1
+        report.images_checked += 1
         report.labels_before += sum(before_counter.values())
-        after_counter = after_counts.get(key, Counter())
+        after_counter = after_counts.get(image_id, Counter())
         report.labels_after += sum(after_counter.values())
 
         # Real loss: word-text-insensitive (label, status) count dropped.
         lost = before_counter - after_counter  # only positive residuals
         if lost:
-            report.lost_labels[key] = sorted(lost.items())
+            report.lost_labels[image_id] = sorted(lost.items())
 
-        # Surplus: (label, status) count INCREASED for a receipt present in both.
-        # A faithful re-apply keeps counts equal; a surplus is a duplicated label
-        # -- the stale-label id-collision case the orphan check can't see (the
-        # stale row lands on a regenerated word at the same id). Scoped to shared
-        # receipts so re-segmentation (labels moving to a new receipt_id) is not
-        # counted here -- that is handled per-image, see module notes.
+        # Surplus: (label, status) count INCREASED for an image present in both.
+        # A faithful re-apply keeps per-image counts equal; a surplus is a
+        # duplicated label -- the stale-label id-collision the orphan check can't
+        # see (the stale row lands on a regenerated word at the same id).
         surplus = after_counter - before_counter
         if surplus:
-            report.surplus_labels[key] = sorted(surplus.items())
+            report.surplus_labels[image_id] = sorted(surplus.items())
 
         # Churn (informational): a (label, word_text, status) tuple vanished but
         # its (label, status) count is preserved -> the label moved to a re-read
         # word. Test EACH tuple's (label, status) against the real-loss set, not
-        # the receipt-level truthiness of `lost`.
-        tuple_lost = before_tuples.get(key, Counter()) - after_tuples.get(
-            key, Counter()
+        # the image-level truthiness of `lost`.
+        tuple_lost = before_tuples.get(image_id, Counter()) - after_tuples.get(
+            image_id, Counter()
         )
         churn = [
             item for item in tuple_lost.items() if (item[0][0], item[0][2]) not in lost
         ]
         if churn:
-            report.churn_only[key] = sorted(churn)
+            report.churn_only[image_id] = sorted(churn)
 
-    # Count labels on receipts that exist only in AFTER (so labels_after is a true
-    # total, not just the before-receipts' contribution).
-    for key, after_counter in after_counts.items():
-        if _in_scope(key) and key not in before_counts:
+    # Count labels on images that exist only in AFTER (so labels_after is a true
+    # total, not just the before-images' contribution).
+    for image_id, after_counter in after_counts.items():
+        if _in_scope(image_id) and image_id not in before_counts:
             report.labels_after += sum(after_counter.values())
     return report
 
@@ -367,33 +371,37 @@ def find_orphan_label_keys(
 
 
 def _word_counts(rows: list[Row], targets: set[str] | None) -> Counter:
-    """(image_id, receipt_id) -> number of ReceiptWord rows."""
+    """image_id -> number of ReceiptWord rows (pooled across receipts).
+
+    Per image, not per receipt: re-OCR can re-segment (merge receipts), so a
+    single receipt_id dropping to zero words is legitimate movement, whereas an
+    IMAGE dropping to zero words is a genuine wipe.
+    """
     counts: Counter = Counter()
     for r in rows:
         image_id = r.image_id or image_id_from_pk(r.pk)
         if image_id is None or (targets is not None and image_id not in targets):
             continue
-        parsed = parse_word_sk(r.sk)
-        if parsed is not None:
-            counts[(image_id, parsed[0])] += 1
+        if parse_word_sk(r.sk) is not None:
+            counts[image_id] += 1
     return counts
 
 
-def wiped_receipts(
+def wiped_images(
     before: list[Row],
     after: list[Row],
     target_image_ids: Iterable[str] | None = None,
-) -> list[tuple[str, int]]:
-    """Target receipts that had words BEFORE but have zero AFTER.
+) -> list[str]:
+    """Target images that had words BEFORE but have zero AFTER.
 
-    Catches a wholesale nuke that the label check alone misses for receipts that
-    carried no labels (nothing to 'lose'), yet whose words all vanished.
+    Catches a wholesale nuke the label check misses for an image whose receipts
+    carried no labels (nothing to 'lose') yet whose words all vanished.
     """
     targets = set(target_image_ids) if target_image_ids is not None else None
     before_wc = _word_counts(before, targets)
     after_wc = _word_counts(after, targets)
     return sorted(
-        key for key, n in before_wc.items() if n > 0 and after_wc.get(key, 0) == 0
+        img for img, n in before_wc.items() if n > 0 and after_wc.get(img, 0) == 0
     )
 
 
@@ -611,7 +619,7 @@ def run_diff(
     violations = blast_radius_violations(row_diff.changed_pks, target_image_ids)
     labels = check_label_preservation(before, after, target_image_ids)
     orphans = find_orphan_label_keys(after, target_image_ids)
-    wiped = wiped_receipts(before, after, target_image_ids)
+    wiped = wiped_images(before, after, target_image_ids)
     unchanged = unchanged_targets(row_diff.changed_pks, target_image_ids)
     word_bypass = targets_without_word_changes(row_diff, target_image_ids)
 
@@ -641,27 +649,21 @@ def run_diff(
             "violations": violations,
         },
         "labels": {
-            "receipts_checked": labels.receipts_checked,
+            "images_checked": labels.images_checked,
             "labels_before": labels.labels_before,
             "labels_after": labels.labels_after,
-            "receipts_with_lost_labels": len(labels.lost_labels),
-            "lost": {
-                f"{img}#{rid}": items
-                for (img, rid), items in labels.lost_labels.items()
-            },
-            "receipts_with_surplus_labels": len(labels.surplus_labels),
-            "surplus": {
-                f"{img}#{rid}": items
-                for (img, rid), items in labels.surplus_labels.items()
-            },
-            "receipts_with_churn_only": len(labels.churn_only),
+            "images_with_lost_labels": len(labels.lost_labels),
+            "lost": dict(labels.lost_labels),
+            "images_with_surplus_labels": len(labels.surplus_labels),
+            "surplus": dict(labels.surplus_labels),
+            "images_with_churn_only": len(labels.churn_only),
         },
         "invariants": {
             "orphan_labels": [
                 f"{img}#{rid}#{lid}#{wid}#{label}"
                 for (img, rid, lid, wid, label) in orphans
             ],
-            "wiped_receipts": [f"{img}#{rid}" for (img, rid) in wiped],
+            "wiped_images": wiped,
             "unchanged_targets": unchanged,
             "targets_without_word_changes": word_bypass,
         },
@@ -683,14 +685,14 @@ def _print_report(report: dict[str, Any]) -> None:
     )
     for pk in br["violations"][:20]:
         print(f"    OUT-OF-SCOPE CHANGE: {pk}")
-    print("=== Label preservation ===")
+    print("=== Label preservation (per image) ===")
     print(
-        f"  receipts_checked={lb['receipts_checked']} "
+        f"  images_checked={lb['images_checked']} "
         f"labels_before={lb['labels_before']} labels_after={lb['labels_after']}"
     )
     print(
-        f"  receipts_with_lost_labels={lb['receipts_with_lost_labels']} "
-        f"receipts_with_churn_only={lb['receipts_with_churn_only']}"
+        f"  images_with_lost_labels={lb['images_with_lost_labels']} "
+        f"images_with_churn_only={lb['images_with_churn_only']}"
     )
     for rk, items in list(lb["lost"].items())[:20]:
         print(f"    LOST {rk}: {items}")
@@ -700,14 +702,14 @@ def _print_report(report: dict[str, Any]) -> None:
     print("=== Invariants ===")
     print(
         f"  orphan_labels={len(inv['orphan_labels'])} "
-        f"wiped_receipts={len(inv['wiped_receipts'])} "
+        f"wiped_images={len(inv['wiped_images'])} "
         f"unchanged_targets={len(inv['unchanged_targets'])} "
         f"targets_without_word_changes={len(inv['targets_without_word_changes'])}"
     )
     for o in inv["orphan_labels"][:10]:
         print(f"    ORPHAN LABEL (no word): {o}")
-    for w in inv["wiped_receipts"][:10]:
-        print(f"    WIPED RECEIPT (words->0): {w}")
+    for w in inv["wiped_images"][:10]:
+        print(f"    WIPED IMAGE (words->0): {w}")
     for u in inv["unchanged_targets"][:10]:
         print(f"    UNCHANGED TARGET (no writes — no-op/bypass?): {u}")
     for u in inv["targets_without_word_changes"][:10]:

--- a/scripts/ocr_migration_rehearsal.py
+++ b/scripts/ocr_migration_rehearsal.py
@@ -761,25 +761,45 @@ def restore_images(
     ] + [{"PutRequest": {"Item": json.loads(r.wire_json)}} for r in puts]
     _batch_write(client, table_name, requests)
 
-    # Verify: every partition must now match the backup byte-for-byte.
+    # Verify: every partition must match the backup — modulo LIVE-TABLE churn:
+    # background pipelines legitimately mutate embedding_status/updated_at and
+    # append COMPACTION_RUN rows between our write and read. Ignore exactly
+    # those; anything else is a real mismatch.
+    VOLATILE_ATTRS = ("embedding_status", "updated_at")
+    VOLATILE_TYPES = ("COMPACTION_RUN",)
+
+    def _stable(wire: str) -> str:
+        try:
+            it = json.loads(wire)
+        except (TypeError, json.JSONDecodeError):
+            return wire
+        for a in VOLATILE_ATTRS:
+            it.pop(a, None)
+        return _canonical(json.dumps(it))
+
     mismatches = []
     for img in ids:
         want = {
-            (r.pk, r.sk): _canonical(r.wire_json)
+            (r.pk, r.sk): _stable(r.wire_json)
             for r in backup_rows
             if r.pk == f"IMAGE#{img}"
         }
-        got = {}
+        got, got_types = {}, {}
         for it in _query_partition(client, table_name, f"IMAGE#{img}"):
             native = cache._native_item(it)
-            got[(str(native.get("PK", "")), str(native.get("SK", "")))] = _canonical(
-                json.dumps(it)
-            )
+            key = (str(native.get("PK", "")), str(native.get("SK", "")))
+            got[key] = _stable(json.dumps(it))
+            got_types[key] = native.get("TYPE")
         if want != got:
-            extra = set(got) - set(want)
+            extra = {
+                k
+                for k in set(got) - set(want)
+                if got_types.get(k) not in VOLATILE_TYPES
+            }
             missing = set(want) - set(got)
             changed = {k for k in set(want) & set(got) if want[k] != got[k]}
-            mismatches.append((img, len(missing), len(extra), len(changed)))
+            if missing or extra or changed:
+                mismatches.append((img, len(missing), len(extra), len(changed)))
     if mismatches:
         raise RuntimeError(f"RESTORE VERIFICATION FAILED: {mismatches[:5]}")
     return {

--- a/scripts/ocr_migration_rehearsal.py
+++ b/scripts/ocr_migration_rehearsal.py
@@ -498,6 +498,7 @@ def pull_scoped_images(
     table_name: str,
     image_ids: list[str],
     dest_path: Path,
+    exclude_types: set[str] | None = None,
 ) -> dict[str, Any]:
     """Query ALL rows for the given images into a serve-compatible cache SQLite.
 
@@ -507,6 +508,10 @@ def pull_scoped_images(
     output ``dynamodb.sqlite3`` + returned component dict match what the full
     ``local_analytics_cache`` sync produces, so ``serve`` can hydrate it and the
     diff can treat it as the exact BEFORE snapshot.
+
+    ``exclude_types`` skips entity TYPEs on disk-constrained hosts (e.g. LETTER /
+    RECEIPT_LETTER: 68% of rows, no labels, pure re-OCR regen). NEVER use it for
+    a rollback ``backup`` — a backup must be complete to be a backup.
     """
     table = client.describe_table(TableName=table_name)["Table"]
     writer = cache.DynamoSQLiteWriter(dest_path)
@@ -522,6 +527,12 @@ def pull_scoped_images(
             while True:
                 resp = client.query(**kwargs)
                 items = resp.get("Items", [])
+                if exclude_types:
+                    items = [
+                        it
+                        for it in items
+                        if it.get("TYPE", {}).get("S") not in exclude_types
+                    ]
                 writer.add(items)
                 scanned += len(items)
                 lek = resp.get("LastEvaluatedKey")
@@ -572,13 +583,18 @@ def run_pull(
     image_ids: list[str],
     region: str | None = None,
     profile: str | None = None,
+    exclude_types: set[str] | None = None,
 ) -> dict[str, Any]:
     """Scoped pull into ``<cache_dir>/<env>/dynamodb.sqlite3`` + a serve manifest."""
     cache_root = cache_dir.expanduser().resolve() / env
     cache_root.mkdir(parents=True, exist_ok=True)
     client = boto3.Session(profile_name=profile, region_name=region).client("dynamodb")
     component = pull_scoped_images(
-        client, table_name, image_ids, cache_root / "dynamodb.sqlite3"
+        client,
+        table_name,
+        image_ids,
+        cache_root / "dynamodb.sqlite3",
+        exclude_types=exclude_types,
     )
     manifest = cache._load_manifest(cache_root)
     manifest.setdefault("components", {})
@@ -910,6 +926,12 @@ def main(argv: list[str] | None = None) -> int:
     )
     pull.add_argument("--region", default=None)
     pull.add_argument("--profile", default=None)
+    pull.add_argument(
+        "--exclude-types",
+        default=None,
+        help="comma-separated entity TYPEs to skip (disk-constrained hosts); "
+        "never valid for rollback backups",
+    )
 
     bk = sub.add_parser(
         "backup",
@@ -965,6 +987,11 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.command == "pull":
         ids = _read_image_ids(args.images)
+        excl = (
+            {t.strip() for t in args.exclude_types.split(",") if t.strip()}
+            if args.exclude_types
+            else None
+        )
         result = run_pull(
             args.env,
             args.cache_dir,
@@ -972,6 +999,7 @@ def main(argv: list[str] | None = None) -> int:
             ids,
             args.region,
             args.profile,
+            exclude_types=excl,
         )
         comp = result["component"]
         print(

--- a/scripts/ocr_migration_rehearsal.py
+++ b/scripts/ocr_migration_rehearsal.py
@@ -1,0 +1,461 @@
+#!/usr/bin/env python3
+"""Rehearse the destructive re-OCR -> DynamoDB migration against a LOCAL table.
+
+This is the safety harness for the gated "re-OCR ~211 images, regenerating their
+words + word-labels" migration. It never touches real dev/prod DynamoDB. The
+workflow (built on top of ``scripts/local_analytics_cache.py`` / PR #1097):
+
+  1. ``local_analytics_cache.py serve --env dev``  -> DynamoDB Local hydrated from
+     the SQLite snapshot ``<cache>/dynamodb.sqlite3`` (this file is the exact
+     "BEFORE" image).
+  2. Run the real migration with ``DYNAMODB_ENDPOINT_URL`` pointed at the local
+     container (writes go through ``DynamoClient`` unmodified).
+  3. ``ocr_migration_rehearsal.py snapshot`` -> scan the post-migration local
+     table into an "AFTER" SQLite (same schema as the snapshot).
+  4. ``ocr_migration_rehearsal.py diff`` -> row-level diff, blast-radius check,
+     and label-preservation check, with a hard verdict.
+
+Why label-preservation is not simple key-equality: re-OCR reassigns line/word
+ids, so a label's PK/SK (``...#LINE#..#WORD#..#LABEL#..``) changes even when the
+label is faithfully re-applied. We therefore compare, per (image_id, receipt_id),
+the MULTISET of (label, word_text, validation_status) - joining each label to its
+word's text - and separately the word-text-INSENSITIVE (label, validation_status)
+counts. A tuple that disappears only because a word was re-read to different text
+is churn; a drop in the word-text-insensitive count is a real lost label.
+
+The ``diff`` command is pure Python over two SQLite files and needs no Docker or
+AWS; only ``snapshot`` talks to the live local container.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import re
+import sqlite3
+import sys
+from collections import Counter
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable
+
+# Reuse the cache tooling from PR #1097 for an identical SQLite schema/normalization.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from scripts import local_analytics_cache as cache  # noqa: E402
+
+LOG = logging.getLogger("ocr_migration_rehearsal")
+
+# SK grammars (see receipt_dynamo entities receipt_word.py / receipt_word_label.py).
+# Word:  RECEIPT#<rid>#LINE#<lid>#WORD#<wid>
+# Label: RECEIPT#<rid>#LINE#<lid>#WORD#<wid>#LABEL#<label>
+_WORD_SK = re.compile(r"^RECEIPT#(\d+)#LINE#(\d+)#WORD#(\d+)$")
+_LABEL_SK = re.compile(r"^RECEIPT#(\d+)#LINE#(\d+)#WORD#(\d+)#LABEL#(.+)$")
+
+
+def parse_word_sk(sk: str) -> tuple[int, int, int] | None:
+    """Return (receipt_id, line_id, word_id) for a ReceiptWord SK, else None."""
+    m = _WORD_SK.match(sk or "")
+    if not m:
+        return None
+    return int(m.group(1)), int(m.group(2)), int(m.group(3))
+
+
+def parse_label_sk(sk: str) -> tuple[int, int, int, str] | None:
+    """Return (receipt_id, line_id, word_id, label) for a label SK, else None."""
+    m = _LABEL_SK.match(sk or "")
+    if not m:
+        return None
+    return int(m.group(1)), int(m.group(2)), int(m.group(3)), m.group(4)
+
+
+def image_id_from_pk(pk: str) -> str | None:
+    return pk.split("#", 1)[1] if pk.startswith("IMAGE#") else None
+
+
+# --------------------------------------------------------------------------- #
+# Loading                                                                     #
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class Row:
+    pk: str
+    sk: str
+    entity_type: str | None
+    image_id: str | None
+    receipt_id: int | None
+    native: dict[str, Any]
+    wire_json: str
+
+
+def load_rows(sqlite_path: Path) -> list[Row]:
+    """Read every dynamo_items row from a snapshot/after SQLite file."""
+    with sqlite3.connect(f"file:{sqlite_path}?mode=ro", uri=True) as conn:
+        cur = conn.execute(
+            "SELECT pk, sk, entity_type, image_id, receipt_id, item_json, "
+            "dynamodb_json FROM dynamo_items"
+        )
+        rows: list[Row] = []
+        for pk, sk, etype, image_id, receipt_id, item_json, wire_json in cur:
+            try:
+                native = json.loads(item_json)
+            except (TypeError, json.JSONDecodeError):
+                native = {}
+            rows.append(
+                Row(
+                    pk=pk,
+                    sk=sk,
+                    entity_type=etype,
+                    image_id=image_id,
+                    receipt_id=receipt_id,
+                    native=native,
+                    wire_json=wire_json,
+                )
+            )
+    return rows
+
+
+# --------------------------------------------------------------------------- #
+# Row-level diff + blast radius                                               #
+# --------------------------------------------------------------------------- #
+
+
+@dataclass
+class RowDiff:
+    added: list[tuple[str, str]] = field(default_factory=list)
+    deleted: list[tuple[str, str]] = field(default_factory=list)
+    mutated: list[tuple[str, str]] = field(default_factory=list)
+    by_entity: Counter = field(default_factory=Counter)  # (op, entity_type) -> n
+
+    @property
+    def changed_pks(self) -> set[str]:
+        return {pk for pk, _ in self.added + self.deleted + self.mutated}
+
+
+def diff_rows(before: list[Row], after: list[Row]) -> RowDiff:
+    """Diff two snapshots on (pk, sk) using the exact wire JSON for mutation."""
+    before_map = {(r.pk, r.sk): r for r in before}
+    after_map = {(r.pk, r.sk): r for r in after}
+    diff = RowDiff()
+    for key, r in after_map.items():
+        if key not in before_map:
+            diff.added.append(key)
+            diff.by_entity[("added", r.entity_type)] += 1
+    for key, r in before_map.items():
+        if key not in after_map:
+            diff.deleted.append(key)
+            diff.by_entity[("deleted", r.entity_type)] += 1
+        else:
+            other = after_map[key]
+            if _canonical(r.wire_json) != _canonical(other.wire_json):
+                diff.mutated.append(key)
+                diff.by_entity[("mutated", r.entity_type)] += 1
+    return diff
+
+
+def _canonical(wire_json: str) -> str:
+    """Order-insensitive canonical form of a wire-JSON item for comparison."""
+    try:
+        return json.dumps(json.loads(wire_json), sort_keys=True)
+    except (TypeError, json.JSONDecodeError):
+        return wire_json
+
+
+def blast_radius_violations(
+    changed_pks: Iterable[str], target_image_ids: Iterable[str]
+) -> list[str]:
+    """Changed PKs that are NOT one of the migration's target images.
+
+    A clean migration only mutates rows under IMAGE#<id> for the images it
+    re-OCRs; anything else changing is an unexpected, out-of-scope write.
+    """
+    allowed = {f"IMAGE#{i}" for i in target_image_ids}
+    return sorted({pk for pk in changed_pks if pk not in allowed})
+
+
+# --------------------------------------------------------------------------- #
+# Label preservation                                                          #
+# --------------------------------------------------------------------------- #
+
+# Per (image_id, receipt_id): Counter over an identity tuple.
+LabelIndex = dict[tuple[str, int], Counter]
+
+
+def build_word_text_map(rows: list[Row]) -> dict[tuple[str, int, int, int], str]:
+    """(image_id, receipt_id, line_id, word_id) -> word text."""
+    out: dict[tuple[str, int, int, int], str] = {}
+    for r in rows:
+        image_id = r.image_id or image_id_from_pk(r.pk)
+        if image_id is None:
+            continue
+        parsed = parse_word_sk(r.sk)
+        if parsed is None:
+            continue
+        rid, lid, wid = parsed
+        text = r.native.get("text")
+        out[(image_id, rid, lid, wid)] = "" if text is None else str(text)
+    return out
+
+
+def build_label_index(rows: list[Row]) -> tuple[LabelIndex, LabelIndex]:
+    """Build two per-receipt label indexes.
+
+    Returns (tuple_index, count_index):
+      - tuple_index counts (label, word_text, validation_status) - sensitive to a
+        word being re-read to different text (churn shows here);
+      - count_index counts (label, validation_status) - word-text-INSENSITIVE, so
+        a decrease is a genuinely lost label, not churn.
+    """
+    words = build_word_text_map(rows)
+    tuple_index: LabelIndex = {}
+    count_index: LabelIndex = {}
+    for r in rows:
+        image_id = r.image_id or image_id_from_pk(r.pk)
+        if image_id is None:
+            continue
+        parsed = parse_label_sk(r.sk)
+        if parsed is None:
+            continue
+        rid, lid, wid, label = parsed
+        status = r.native.get("validation_status")
+        status = "" if status is None else str(status)
+        word_text = words.get((image_id, rid, lid, wid), "")
+        key = (image_id, rid)
+        tuple_index.setdefault(key, Counter())[(label, word_text, status)] += 1
+        count_index.setdefault(key, Counter())[(label, status)] += 1
+    return tuple_index, count_index
+
+
+@dataclass
+class LabelReport:
+    # (image_id, receipt_id) -> list of lost identity tuples with counts
+    lost_labels: dict[tuple[str, int], list[tuple[Any, int]]] = field(
+        default_factory=dict
+    )
+    churn_only: dict[tuple[str, int], list[tuple[Any, int]]] = field(
+        default_factory=dict
+    )
+    receipts_checked: int = 0
+    labels_before: int = 0
+    labels_after: int = 0
+
+    @property
+    def has_real_loss(self) -> bool:
+        return bool(self.lost_labels)
+
+
+def check_label_preservation(
+    before: list[Row],
+    after: list[Row],
+    target_image_ids: Iterable[str] | None = None,
+) -> LabelReport:
+    """Assert every pre-migration label survives (per receipt, multiset >=).
+
+    A real loss is a decrease in the word-text-INSENSITIVE (label,
+    validation_status) count for a receipt. A tuple that only disappears from the
+    word-text-SENSITIVE view (same label+status count preserved) is churn from a
+    re-read word and is reported separately, not as loss.
+    """
+    targets = set(target_image_ids) if target_image_ids is not None else None
+    before_tuples, before_counts = build_label_index(before)
+    _, after_counts = build_label_index(after)
+    after_tuples, _ = build_label_index(after)
+
+    report = LabelReport()
+    for key, before_counter in before_counts.items():
+        image_id, _rid = key
+        if targets is not None and image_id not in targets:
+            continue
+        report.receipts_checked += 1
+        report.labels_before += sum(before_counter.values())
+        after_counter = after_counts.get(key, Counter())
+        report.labels_after += sum(after_counter.values())
+
+        # Real loss: word-text-insensitive (label, status) count dropped.
+        lost = before_counter - after_counter  # only positive residuals
+        if lost:
+            report.lost_labels[key] = sorted(lost.items())
+
+        # Churn (informational): a (label, text, status) tuple vanished but the
+        # (label, status) count was preserved -> the label moved to a re-read word.
+        tuple_lost = before_tuples.get(key, Counter()) - after_tuples.get(
+            key, Counter()
+        )
+        churn = [item for item in tuple_lost.items() if not lost]
+        if churn:
+            report.churn_only[key] = sorted(churn)
+    return report
+
+
+# --------------------------------------------------------------------------- #
+# Snapshot (live: talks to DynamoDB Local)                                     #
+# --------------------------------------------------------------------------- #
+
+
+def snapshot_local_table(
+    endpoint_url: str,
+    table_name: str,
+    out_path: Path,
+    region: str | None = None,
+) -> dict[str, Any]:
+    """Scan the running DynamoDB Local table into an 'after' SQLite file.
+
+    Reuses the cache's DynamoSQLiteWriter so the schema/normalization exactly
+    matches the pre-migration snapshot, making them directly diffable.
+    """
+    client = cache._local_dynamo_client(endpoint_url, region)
+    writer = cache.DynamoSQLiteWriter(out_path)
+    stats = cache._scan_segment(
+        client=client,
+        table_name=table_name,
+        segment=0,
+        total_segments=1,
+        consistent_read=True,
+        writer=writer,
+    )
+    writer.finalize(
+        {
+            "source": "dynamodb-local",
+            "endpoint_url": endpoint_url,
+            "table_name": table_name,
+            "scan": stats,
+        }
+    )
+    LOG.info("Snapshotted %s -> %s (%d items)", table_name, out_path, writer.row_count)
+    return {"path": str(out_path), "items": writer.row_count, "scan": stats}
+
+
+# --------------------------------------------------------------------------- #
+# Reporting / CLI                                                             #
+# --------------------------------------------------------------------------- #
+
+
+def _read_image_ids(path: Path) -> list[str]:
+    ids: list[str] = []
+    for line in path.read_text().splitlines():
+        s = line.strip()
+        if s and not s.startswith("#"):
+            ids.append(s)
+    return ids
+
+
+def run_diff(
+    before_path: Path,
+    after_path: Path,
+    target_image_ids: list[str],
+) -> dict[str, Any]:
+    before = load_rows(before_path)
+    after = load_rows(after_path)
+    row_diff = diff_rows(before, after)
+    violations = blast_radius_violations(row_diff.changed_pks, target_image_ids)
+    labels = check_label_preservation(before, after, target_image_ids)
+
+    ok = not violations and not labels.has_real_loss
+    return {
+        "ok": ok,
+        "row_diff": {
+            "added": len(row_diff.added),
+            "deleted": len(row_diff.deleted),
+            "mutated": len(row_diff.mutated),
+            "by_entity": {
+                f"{op}:{etype}": n
+                for (op, etype), n in sorted(row_diff.by_entity.items())
+            },
+        },
+        "blast_radius": {
+            "target_images": len(target_image_ids),
+            "changed_pks": len(row_diff.changed_pks),
+            "violations": violations,
+        },
+        "labels": {
+            "receipts_checked": labels.receipts_checked,
+            "labels_before": labels.labels_before,
+            "labels_after": labels.labels_after,
+            "receipts_with_lost_labels": len(labels.lost_labels),
+            "lost": {
+                f"{img}#{rid}": items
+                for (img, rid), items in labels.lost_labels.items()
+            },
+            "receipts_with_churn_only": len(labels.churn_only),
+        },
+    }
+
+
+def _print_report(report: dict[str, Any]) -> None:
+    rd = report["row_diff"]
+    br = report["blast_radius"]
+    lb = report["labels"]
+    print("=== Row diff ===")
+    print(f"  added={rd['added']} deleted={rd['deleted']} mutated={rd['mutated']}")
+    for k, n in rd["by_entity"].items():
+        print(f"    {k}: {n}")
+    print("=== Blast radius ===")
+    print(
+        f"  target_images={br['target_images']} changed_pks={br['changed_pks']} "
+        f"violations={len(br['violations'])}"
+    )
+    for pk in br["violations"][:20]:
+        print(f"    OUT-OF-SCOPE CHANGE: {pk}")
+    print("=== Label preservation ===")
+    print(
+        f"  receipts_checked={lb['receipts_checked']} "
+        f"labels_before={lb['labels_before']} labels_after={lb['labels_after']}"
+    )
+    print(
+        f"  receipts_with_lost_labels={lb['receipts_with_lost_labels']} "
+        f"receipts_with_churn_only={lb['receipts_with_churn_only']}"
+    )
+    for rk, items in list(lb["lost"].items())[:20]:
+        print(f"    LOST {rk}: {items}")
+    print("=== VERDICT ===")
+    print("  PASS" if report["ok"] else "  FAIL")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--log-level", default="INFO")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    snap = sub.add_parser("snapshot", help="scan the local table into an AFTER sqlite")
+    snap.add_argument("--endpoint-url", default="http://127.0.0.1:8000")
+    snap.add_argument("--table-name", required=True)
+    snap.add_argument("--region", default=None)
+    snap.add_argument("--out", type=Path, required=True)
+
+    d = sub.add_parser("diff", help="diff BEFORE vs AFTER, verdict on labels/radius")
+    d.add_argument(
+        "--before", type=Path, required=True, help="dynamodb.sqlite3 snapshot"
+    )
+    d.add_argument("--after", type=Path, required=True, help="snapshot of local table")
+    d.add_argument(
+        "--images",
+        type=Path,
+        required=True,
+        help="file of migration target image_ids (one per line)",
+    )
+    d.add_argument("--json", type=Path, default=None, help="write full report JSON")
+
+    args = parser.parse_args(argv)
+    logging.basicConfig(level=args.log_level.upper())
+
+    if args.command == "snapshot":
+        result = snapshot_local_table(
+            args.endpoint_url, args.table_name, args.out, args.region
+        )
+        print(json.dumps(result, indent=2))
+        return 0
+
+    if args.command == "diff":
+        target_ids = _read_image_ids(args.images)
+        report = run_diff(args.before, args.after, target_ids)
+        if args.json:
+            args.json.write_text(json.dumps(report, indent=2))
+        _print_report(report)
+        return 0 if report["ok"] else 1
+
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ocr_migration_rehearsal.py
+++ b/scripts/ocr_migration_rehearsal.py
@@ -458,7 +458,7 @@ def snapshot_local_table(
     Reuses the cache's DynamoSQLiteWriter so the schema/normalization exactly
     matches the pre-migration snapshot, making them directly diffable.
     """
-    client = cache._local_dynamo_client(endpoint_url, region)
+    client = cache._robust_local_dynamo_client(endpoint_url, region)
     writer = cache.DynamoSQLiteWriter(out_path)
     stats = cache._scan_segment(
         client=client,
@@ -622,9 +622,13 @@ def _is_local_endpoint(endpoint_url: str | None) -> bool:
 
 
 def _make_client(endpoint_url: str | None, region: str | None, allow_aws: bool):
-    """Local-first guardrail: a real-AWS client requires an explicit opt-in."""
+    """Local-first guardrail: a real-AWS client requires an explicit opt-in.
+
+    Uses the ROBUST local client (60s read timeout, retries): backup/restore/
+    snapshot are bulk scan/write paths, and the 1s probe client dies mid-run.
+    """
     if _is_local_endpoint(endpoint_url):
-        return cache._local_dynamo_client(endpoint_url, region)
+        return cache._robust_local_dynamo_client(endpoint_url, region)
     if not allow_aws:
         raise SystemExit(
             "REFUSING to touch a non-local endpoint without --allow-aws. "

--- a/scripts/ocr_migration_rehearsal.py
+++ b/scripts/ocr_migration_rehearsal.py
@@ -156,10 +156,26 @@ def diff_rows(before: list[Row], after: list[Row]) -> RowDiff:
     return diff
 
 
+def _canonicalize(obj: Any) -> Any:
+    """Recursively sort DynamoDB set members (SS/NS/BS are unordered) so an
+    otherwise-identical item does not read as 'mutated' from set reordering."""
+    if isinstance(obj, dict):
+        out: dict[str, Any] = {}
+        for k, v in obj.items():
+            if k in ("SS", "NS", "BS") and isinstance(v, list):
+                out[k] = sorted(v)
+            else:
+                out[k] = _canonicalize(v)
+        return out
+    if isinstance(obj, list):
+        return [_canonicalize(v) for v in obj]
+    return obj
+
+
 def _canonical(wire_json: str) -> str:
     """Order-insensitive canonical form of a wire-JSON item for comparison."""
     try:
-        return json.dumps(json.loads(wire_json), sort_keys=True)
+        return json.dumps(_canonicalize(json.loads(wire_json)), sort_keys=True)
     except (TypeError, json.JSONDecodeError):
         return wire_json
 
@@ -221,7 +237,9 @@ def build_label_index(rows: list[Row]) -> tuple[LabelIndex, LabelIndex]:
             continue
         rid, lid, wid, label = parsed
         status = r.native.get("validation_status")
-        status = "" if status is None else str(status)
+        # Normalize case so an off-cased legacy row can't false-FAIL. Entities
+        # already normalize via normalize_enum; this hardens against raw rows.
+        status = "" if status is None else str(status).upper()
         word_text = words.get((image_id, rid, lid, wid), "")
         key = (image_id, rid)
         tuple_index.setdefault(key, Counter())[(label, word_text, status)] += 1
@@ -261,13 +279,14 @@ def check_label_preservation(
     """
     targets = set(target_image_ids) if target_image_ids is not None else None
     before_tuples, before_counts = build_label_index(before)
-    _, after_counts = build_label_index(after)
-    after_tuples, _ = build_label_index(after)
+    after_tuples, after_counts = build_label_index(after)
+
+    def _in_scope(key: tuple[str, int]) -> bool:
+        return targets is None or key[0] in targets
 
     report = LabelReport()
     for key, before_counter in before_counts.items():
-        image_id, _rid = key
-        if targets is not None and image_id not in targets:
+        if not _in_scope(key):
             continue
         report.receipts_checked += 1
         report.labels_before += sum(before_counter.values())
@@ -279,15 +298,98 @@ def check_label_preservation(
         if lost:
             report.lost_labels[key] = sorted(lost.items())
 
-        # Churn (informational): a (label, text, status) tuple vanished but the
-        # (label, status) count was preserved -> the label moved to a re-read word.
+        # Churn (informational): a (label, word_text, status) tuple vanished but
+        # its (label, status) count is preserved -> the label moved to a re-read
+        # word. Test EACH tuple's (label, status) against the real-loss set, not
+        # the receipt-level truthiness of `lost`.
         tuple_lost = before_tuples.get(key, Counter()) - after_tuples.get(
             key, Counter()
         )
-        churn = [item for item in tuple_lost.items() if not lost]
+        churn = [
+            item for item in tuple_lost.items() if (item[0][0], item[0][2]) not in lost
+        ]
         if churn:
             report.churn_only[key] = sorted(churn)
+
+    # Count labels on receipts that exist only in AFTER (so labels_after is a true
+    # total, not just the before-receipts' contribution).
+    for key, after_counter in after_counts.items():
+        if _in_scope(key) and key not in before_counts:
+            report.labels_after += sum(after_counter.values())
     return report
+
+
+def find_orphan_label_keys(
+    rows: list[Row], target_image_ids: Iterable[str] | None = None
+) -> list[tuple[str, int, int, int, str]]:
+    """AFTER label rows whose (image, receipt, line, word) has no word row.
+
+    A migration that regenerates words under new ids but fails to delete the OLD
+    label rows leaves dangling labels: they still parse and would be counted as
+    'preserved' by the multiset check even though they point at a word that no
+    longer exists. Every label must have its word.
+    """
+    targets = set(target_image_ids) if target_image_ids is not None else None
+    words = build_word_text_map(rows)
+    orphans: list[tuple[str, int, int, int, str]] = []
+    for r in rows:
+        image_id = r.image_id or image_id_from_pk(r.pk)
+        if image_id is None or (targets is not None and image_id not in targets):
+            continue
+        parsed = parse_label_sk(r.sk)
+        if parsed is None:
+            continue
+        rid, lid, wid, label = parsed
+        if (image_id, rid, lid, wid) not in words:
+            orphans.append((image_id, rid, lid, wid, label))
+    return sorted(orphans)
+
+
+def _word_counts(rows: list[Row], targets: set[str] | None) -> Counter:
+    """(image_id, receipt_id) -> number of ReceiptWord rows."""
+    counts: Counter = Counter()
+    for r in rows:
+        image_id = r.image_id or image_id_from_pk(r.pk)
+        if image_id is None or (targets is not None and image_id not in targets):
+            continue
+        parsed = parse_word_sk(r.sk)
+        if parsed is not None:
+            counts[(image_id, parsed[0])] += 1
+    return counts
+
+
+def wiped_receipts(
+    before: list[Row],
+    after: list[Row],
+    target_image_ids: Iterable[str] | None = None,
+) -> list[tuple[str, int]]:
+    """Target receipts that had words BEFORE but have zero AFTER.
+
+    Catches a wholesale nuke that the label check alone misses for receipts that
+    carried no labels (nothing to 'lose'), yet whose words all vanished.
+    """
+    targets = set(target_image_ids) if target_image_ids is not None else None
+    before_wc = _word_counts(before, targets)
+    after_wc = _word_counts(after, targets)
+    return sorted(
+        key for key, n in before_wc.items() if n > 0 and after_wc.get(key, 0) == 0
+    )
+
+
+def unchanged_targets(
+    changed_pks: Iterable[str], target_image_ids: Iterable[str]
+) -> list[str]:
+    """Target images with NO changed row at all.
+
+    A silent no-op, a migration that crashed before writing, or a driver that
+    bypassed DYNAMODB_ENDPOINT_URL (writing to REAL dev instead) all leave the
+    local table untouched -> an empty diff that would otherwise print PASS. A
+    genuine re-OCR of every target must touch every target.
+    """
+    changed_images = {
+        pk.split("#", 1)[1] for pk in changed_pks if pk.startswith("IMAGE#")
+    }
+    return sorted(i for i in target_image_ids if i not in changed_images)
 
 
 # --------------------------------------------------------------------------- #
@@ -466,8 +568,17 @@ def run_diff(
     row_diff = diff_rows(before, after)
     violations = blast_radius_violations(row_diff.changed_pks, target_image_ids)
     labels = check_label_preservation(before, after, target_image_ids)
+    orphans = find_orphan_label_keys(after, target_image_ids)
+    wiped = wiped_receipts(before, after, target_image_ids)
+    unchanged = unchanged_targets(row_diff.changed_pks, target_image_ids)
 
-    ok = not violations and not labels.has_real_loss
+    ok = (
+        not violations
+        and not labels.has_real_loss
+        and not orphans
+        and not wiped
+        and not unchanged
+    )
     return {
         "ok": ok,
         "row_diff": {
@@ -494,6 +605,14 @@ def run_diff(
                 for (img, rid), items in labels.lost_labels.items()
             },
             "receipts_with_churn_only": len(labels.churn_only),
+        },
+        "invariants": {
+            "orphan_labels": [
+                f"{img}#{rid}#{lid}#{wid}#{label}"
+                for (img, rid, lid, wid, label) in orphans
+            ],
+            "wiped_receipts": [f"{img}#{rid}" for (img, rid) in wiped],
+            "unchanged_targets": unchanged,
         },
     }
 
@@ -524,6 +643,19 @@ def _print_report(report: dict[str, Any]) -> None:
     )
     for rk, items in list(lb["lost"].items())[:20]:
         print(f"    LOST {rk}: {items}")
+    inv = report["invariants"]
+    print("=== Invariants ===")
+    print(
+        f"  orphan_labels={len(inv['orphan_labels'])} "
+        f"wiped_receipts={len(inv['wiped_receipts'])} "
+        f"unchanged_targets={len(inv['unchanged_targets'])}"
+    )
+    for o in inv["orphan_labels"][:10]:
+        print(f"    ORPHAN LABEL (no word): {o}")
+    for w in inv["wiped_receipts"][:10]:
+        print(f"    WIPED RECEIPT (words->0): {w}")
+    for u in inv["unchanged_targets"][:10]:
+        print(f"    UNCHANGED TARGET (no writes — no-op/bypass?): {u}")
     print("=== VERDICT ===")
     print("  PASS" if report["ok"] else "  FAIL")
 

--- a/scripts/ocr_migration_rehearsal.py
+++ b/scripts/ocr_migration_rehearsal.py
@@ -800,13 +800,21 @@ def restore_images(
             changed = {k for k in set(want) & set(got) if want[k] != got[k]}
             if missing or extra or changed:
                 mismatches.append((img, len(missing), len(extra), len(changed)))
+    # Missing/extra rows = a real restore failure. Mutation-only mismatches on
+    # a LIVE table are background-pipeline churn (status flips, place updates)
+    # racing the verify read — warn and let the wave diff (churn-tolerant by
+    # design) be the actual gate.
+    fatal = [m for m in mismatches if m[1] > 0 or m[2] > 0]
+    if fatal:
+        raise RuntimeError(f"RESTORE VERIFICATION FAILED: {fatal[:5]}")
     if mismatches:
-        raise RuntimeError(f"RESTORE VERIFICATION FAILED: {mismatches[:5]}")
+        LOG.warning("restore verify: mutation-only churn on %s", mismatches[:5])
     return {
         "images": len(ids),
         "puts": len(puts),
         "deletes": len(deletes),
         "verified": True,
+        "mutation_churn_images": len(mismatches),
     }
 
 

--- a/scripts/ocr_migration_rehearsal.py
+++ b/scripts/ocr_migration_rehearsal.py
@@ -256,6 +256,13 @@ class LabelReport:
     churn_only: dict[tuple[str, int], list[tuple[Any, int]]] = field(
         default_factory=dict
     )
+    # (image_id, receipt_id) -> (label, status) counts that INCREASED. A clean
+    # re-apply preserves counts exactly; a surplus means the migration failed to
+    # delete an old label row whose (line,word) id collided with a regenerated
+    # word (so the orphan check can't see it) -> a duplicated, mis-attached label.
+    surplus_labels: dict[tuple[str, int], list[tuple[Any, int]]] = field(
+        default_factory=dict
+    )
     receipts_checked: int = 0
     labels_before: int = 0
     labels_after: int = 0
@@ -263,6 +270,10 @@ class LabelReport:
     @property
     def has_real_loss(self) -> bool:
         return bool(self.lost_labels)
+
+    @property
+    def has_surplus(self) -> bool:
+        return bool(self.surplus_labels)
 
 
 def check_label_preservation(
@@ -297,6 +308,16 @@ def check_label_preservation(
         lost = before_counter - after_counter  # only positive residuals
         if lost:
             report.lost_labels[key] = sorted(lost.items())
+
+        # Surplus: (label, status) count INCREASED for a receipt present in both.
+        # A faithful re-apply keeps counts equal; a surplus is a duplicated label
+        # -- the stale-label id-collision case the orphan check can't see (the
+        # stale row lands on a regenerated word at the same id). Scoped to shared
+        # receipts so re-segmentation (labels moving to a new receipt_id) is not
+        # counted here -- that is handled per-image, see module notes.
+        surplus = after_counter - before_counter
+        if surplus:
+            report.surplus_labels[key] = sorted(surplus.items())
 
         # Churn (informational): a (label, word_text, status) tuple vanished but
         # its (label, status) count is preserved -> the label moved to a re-read
@@ -390,6 +411,27 @@ def unchanged_targets(
         pk.split("#", 1)[1] for pk in changed_pks if pk.startswith("IMAGE#")
     }
     return sorted(i for i in target_image_ids if i not in changed_images)
+
+
+def targets_without_word_changes(
+    row_diff: "RowDiff", target_image_ids: Iterable[str]
+) -> list[str]:
+    """Target images with no changed WORD/LABEL row.
+
+    Stronger than ``unchanged_targets``: a mixed-endpoint bypass (benign
+    receipt-metadata writes hit the local table while word/label writes go to
+    real dev) mutates one row per image and defeats the any-change check, yet
+    leaves words/labels locally untouched. A genuine re-OCR deletes+recreates
+    words and re-applies labels for every target, so every target must have at
+    least one changed word/label-shaped (pk, sk).
+    """
+    changed = set()
+    for pk, sk in row_diff.added + row_diff.deleted + row_diff.mutated:
+        if not pk.startswith("IMAGE#"):
+            continue
+        if parse_word_sk(sk) is not None or parse_label_sk(sk) is not None:
+            changed.add(pk.split("#", 1)[1])
+    return sorted(i for i in target_image_ids if i not in changed)
 
 
 # --------------------------------------------------------------------------- #
@@ -571,13 +613,16 @@ def run_diff(
     orphans = find_orphan_label_keys(after, target_image_ids)
     wiped = wiped_receipts(before, after, target_image_ids)
     unchanged = unchanged_targets(row_diff.changed_pks, target_image_ids)
+    word_bypass = targets_without_word_changes(row_diff, target_image_ids)
 
     ok = (
         not violations
         and not labels.has_real_loss
+        and not labels.has_surplus
         and not orphans
         and not wiped
         and not unchanged
+        and not word_bypass
     )
     return {
         "ok": ok,
@@ -604,6 +649,11 @@ def run_diff(
                 f"{img}#{rid}": items
                 for (img, rid), items in labels.lost_labels.items()
             },
+            "receipts_with_surplus_labels": len(labels.surplus_labels),
+            "surplus": {
+                f"{img}#{rid}": items
+                for (img, rid), items in labels.surplus_labels.items()
+            },
             "receipts_with_churn_only": len(labels.churn_only),
         },
         "invariants": {
@@ -613,6 +663,7 @@ def run_diff(
             ],
             "wiped_receipts": [f"{img}#{rid}" for (img, rid) in wiped],
             "unchanged_targets": unchanged,
+            "targets_without_word_changes": word_bypass,
         },
     }
 
@@ -643,12 +694,15 @@ def _print_report(report: dict[str, Any]) -> None:
     )
     for rk, items in list(lb["lost"].items())[:20]:
         print(f"    LOST {rk}: {items}")
+    for rk, items in list(lb.get("surplus", {}).items())[:20]:
+        print(f"    SURPLUS {rk}: {items}")
     inv = report["invariants"]
     print("=== Invariants ===")
     print(
         f"  orphan_labels={len(inv['orphan_labels'])} "
         f"wiped_receipts={len(inv['wiped_receipts'])} "
-        f"unchanged_targets={len(inv['unchanged_targets'])}"
+        f"unchanged_targets={len(inv['unchanged_targets'])} "
+        f"targets_without_word_changes={len(inv['targets_without_word_changes'])}"
     )
     for o in inv["orphan_labels"][:10]:
         print(f"    ORPHAN LABEL (no word): {o}")
@@ -656,6 +710,8 @@ def _print_report(report: dict[str, Any]) -> None:
         print(f"    WIPED RECEIPT (words->0): {w}")
     for u in inv["unchanged_targets"][:10]:
         print(f"    UNCHANGED TARGET (no writes — no-op/bypass?): {u}")
+    for u in inv["targets_without_word_changes"][:10]:
+        print(f"    NO WORD/LABEL CHANGE (mixed-endpoint bypass?): {u}")
     print("=== VERDICT ===")
     print("  PASS" if report["ok"] else "  FAIL")
 

--- a/scripts/ocr_migration_rehearsal.py
+++ b/scripts/ocr_migration_rehearsal.py
@@ -595,6 +595,163 @@ def run_pull(
 
 
 # --------------------------------------------------------------------------- #
+# Backup / restore (rollback)                                                  #
+# --------------------------------------------------------------------------- #
+
+LOCAL_ENDPOINT_HINTS = ("127.0.0.1", "localhost", "http://192.168.")
+
+
+def _is_local_endpoint(endpoint_url: str | None) -> bool:
+    return bool(endpoint_url) and any(h in endpoint_url for h in LOCAL_ENDPOINT_HINTS)
+
+
+def _make_client(endpoint_url: str | None, region: str | None, allow_aws: bool):
+    """Local-first guardrail: a real-AWS client requires an explicit opt-in."""
+    if _is_local_endpoint(endpoint_url):
+        return cache._local_dynamo_client(endpoint_url, region)
+    if not allow_aws:
+        raise SystemExit(
+            "REFUSING to touch a non-local endpoint without --allow-aws. "
+            f"(endpoint_url={endpoint_url!r}) Pass --endpoint-url http://127.0.0.1:8000 "
+            "for the local table, or add --allow-aws to deliberately target real AWS."
+        )
+    return boto3.Session(region_name=region).client("dynamodb")
+
+
+def backup_images(
+    client: Any,
+    table_name: str,
+    image_ids: list[str],
+    out_path: Path,
+) -> dict[str, Any]:
+    """Wire-exact snapshot of the given IMAGE partitions (rollback source)."""
+    component = pull_scoped_images(client, table_name, image_ids, out_path)
+    return {
+        "path": str(out_path),
+        "rows": component["row_count"],
+        "images": len(image_ids),
+    }
+
+
+def compute_restore_plan(
+    backup_rows: list[Row],
+    current_rows: list[Row],
+    image_ids: list[str],
+) -> tuple[list[Row], list[tuple[str, str]]]:
+    """(puts, deletes) that return the target partitions to the backup state.
+
+    puts    = every backup row (wire-exact overwrite; unchanged rows are no-ops)
+    deletes = (pk, sk) present now but absent from the backup (rows the
+              migration added), scoped to the target images only.
+    """
+    targets = {f"IMAGE#{i}" for i in image_ids}
+    backup_keys = {(r.pk, r.sk) for r in backup_rows if r.pk in targets}
+    puts = [r for r in backup_rows if r.pk in targets]
+    deletes = [
+        (r.pk, r.sk)
+        for r in current_rows
+        if r.pk in targets and (r.pk, r.sk) not in backup_keys
+    ]
+    return puts, deletes
+
+
+def _query_partition(client: Any, table_name: str, pk: str) -> list[dict[str, Any]]:
+    items, kwargs = [], {
+        "TableName": table_name,
+        "KeyConditionExpression": "PK = :pk",
+        "ExpressionAttributeValues": {":pk": {"S": pk}},
+        "ConsistentRead": True,
+    }
+    while True:
+        resp = client.query(**kwargs)
+        items.extend(resp.get("Items", []))
+        lek = resp.get("LastEvaluatedKey")
+        if not lek:
+            return items
+        kwargs["ExclusiveStartKey"] = lek
+
+
+def _batch_write(client: Any, table_name: str, requests: list[dict[str, Any]]) -> None:
+    for i in range(0, len(requests), 25):
+        chunk = {table_name: requests[i : i + 25]}
+        for _ in range(8):
+            resp = client.batch_write_item(RequestItems=chunk)
+            chunk = resp.get("UnprocessedItems") or {}
+            if not chunk:
+                break
+        if chunk:
+            raise RuntimeError("batch_write left unprocessed items after retries")
+
+
+def restore_images(
+    client: Any,
+    table_name: str,
+    backup_path: Path,
+    image_ids: list[str] | None = None,
+) -> dict[str, Any]:
+    """Roll the target partitions back to the backup, then VERIFY byte-exact.
+
+    Deletes rows the migration added, rewrites every backed-up row from its
+    exact wire JSON, then re-reads each partition and compares canonical wire
+    forms. Raises if verification fails — a rollback you can't verify is not a
+    rollback.
+    """
+    backup_rows = load_rows(backup_path)
+    ids = image_ids or sorted(
+        {r.image_id or image_id_from_pk(r.pk) for r in backup_rows} - {None}
+    )
+    current: list[Row] = []
+    for img in ids:
+        for it in _query_partition(client, table_name, f"IMAGE#{img}"):
+            native = cache._native_item(it)
+            current.append(
+                Row(
+                    pk=str(native.get("PK", "")),
+                    sk=str(native.get("SK", "")),
+                    entity_type=None,
+                    image_id=img,
+                    receipt_id=None,
+                    native=native,
+                    wire_json=json.dumps(it),
+                )
+            )
+    puts, deletes = compute_restore_plan(backup_rows, current, ids)
+    requests = [
+        {"DeleteRequest": {"Key": {"PK": {"S": pk}, "SK": {"S": sk}}}}
+        for pk, sk in deletes
+    ] + [{"PutRequest": {"Item": json.loads(r.wire_json)}} for r in puts]
+    _batch_write(client, table_name, requests)
+
+    # Verify: every partition must now match the backup byte-for-byte.
+    mismatches = []
+    for img in ids:
+        want = {
+            (r.pk, r.sk): _canonical(r.wire_json)
+            for r in backup_rows
+            if r.pk == f"IMAGE#{img}"
+        }
+        got = {}
+        for it in _query_partition(client, table_name, f"IMAGE#{img}"):
+            native = cache._native_item(it)
+            got[(str(native.get("PK", "")), str(native.get("SK", "")))] = _canonical(
+                json.dumps(it)
+            )
+        if want != got:
+            extra = set(got) - set(want)
+            missing = set(want) - set(got)
+            changed = {k for k in set(want) & set(got) if want[k] != got[k]}
+            mismatches.append((img, len(missing), len(extra), len(changed)))
+    if mismatches:
+        raise RuntimeError(f"RESTORE VERIFICATION FAILED: {mismatches[:5]}")
+    return {
+        "images": len(ids),
+        "puts": len(puts),
+        "deletes": len(deletes),
+        "verified": True,
+    }
+
+
+# --------------------------------------------------------------------------- #
 # Reporting / CLI                                                             #
 # --------------------------------------------------------------------------- #
 
@@ -754,8 +911,57 @@ def main(argv: list[str] | None = None) -> int:
     pull.add_argument("--region", default=None)
     pull.add_argument("--profile", default=None)
 
+    bk = sub.add_parser(
+        "backup",
+        help="wire-exact snapshot of target image partitions (rollback source)",
+    )
+    bk.add_argument("--endpoint-url", default="http://127.0.0.1:8000")
+    bk.add_argument(
+        "--allow-aws",
+        action="store_true",
+        help="required to back up from a non-local endpoint",
+    )
+    bk.add_argument("--table-name", required=True)
+    bk.add_argument("--region", default=None)
+    bk.add_argument("--images", type=Path, required=True)
+    bk.add_argument("--out", type=Path, required=True)
+
+    rs = sub.add_parser(
+        "restore", help="roll target partitions back to a backup + verify byte-exact"
+    )
+    rs.add_argument("--endpoint-url", default="http://127.0.0.1:8000")
+    rs.add_argument(
+        "--allow-aws",
+        action="store_true",
+        help="required to restore into a non-local endpoint",
+    )
+    rs.add_argument("--table-name", required=True)
+    rs.add_argument("--region", default=None)
+    rs.add_argument("--backup", type=Path, required=True)
+    rs.add_argument(
+        "--images",
+        type=Path,
+        default=None,
+        help="optional subset; default = every image in the backup",
+    )
+
     args = parser.parse_args(argv)
     logging.basicConfig(level=args.log_level.upper())
+
+    if args.command == "backup":
+        client = _make_client(args.endpoint_url, args.region, args.allow_aws)
+        result = backup_images(
+            client, args.table_name, _read_image_ids(args.images), args.out
+        )
+        print(json.dumps(result, indent=2))
+        return 0
+
+    if args.command == "restore":
+        client = _make_client(args.endpoint_url, args.region, args.allow_aws)
+        ids = _read_image_ids(args.images) if args.images else None
+        result = restore_images(client, args.table_name, args.backup, ids)
+        print(json.dumps(result, indent=2))
+        return 0
 
     if args.command == "pull":
         ids = _read_image_ids(args.images)

--- a/scripts/ocr_migration_rehearsal.py
+++ b/scripts/ocr_migration_rehearsal.py
@@ -40,6 +40,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Iterable
 
+import boto3
+
 # Reuse the cache tooling from PR #1097 for an identical SQLite schema/normalization.
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from scripts import local_analytics_cache as cache  # noqa: E402
@@ -327,6 +329,120 @@ def snapshot_local_table(
 
 
 # --------------------------------------------------------------------------- #
+# Scoped pull (live: Query real dev for a handful of images -> BEFORE snapshot) #
+# --------------------------------------------------------------------------- #
+
+
+def _index_summary(index: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "IndexName": index["IndexName"],
+        "KeySchema": index["KeySchema"],
+        "Projection": index["Projection"],
+    }
+
+
+def pull_scoped_images(
+    client: Any,
+    table_name: str,
+    image_ids: list[str],
+    dest_path: Path,
+) -> dict[str, Any]:
+    """Query ALL rows for the given images into a serve-compatible cache SQLite.
+
+    Instead of scanning the full ~2M-item table, Query PK=IMAGE#<id> per image.
+    Every entity of a receipt hierarchy (image, receipts, lines, words, letters,
+    labels) shares PK=IMAGE#<id>, so one Query per image captures it whole. The
+    output ``dynamodb.sqlite3`` + returned component dict match what the full
+    ``local_analytics_cache`` sync produces, so ``serve`` can hydrate it and the
+    diff can treat it as the exact BEFORE snapshot.
+    """
+    table = client.describe_table(TableName=table_name)["Table"]
+    writer = cache.DynamoSQLiteWriter(dest_path)
+    scanned = 0
+    try:
+        for image_id in image_ids:
+            kwargs: dict[str, Any] = {
+                "TableName": table_name,
+                "KeyConditionExpression": "PK = :pk",
+                "ExpressionAttributeValues": {":pk": {"S": f"IMAGE#{image_id}"}},
+                "ConsistentRead": True,
+            }
+            while True:
+                resp = client.query(**kwargs)
+                items = resp.get("Items", [])
+                writer.add(items)
+                scanned += len(items)
+                lek = resp.get("LastEvaluatedKey")
+                if not lek:
+                    break
+                kwargs["ExclusiveStartKey"] = lek
+        synced_at = cache._utc_now()
+        entity_counts = writer.finalize(
+            {
+                "table_name": table_name,
+                "table_arn": table.get("TableArn"),
+                "synced_at": synced_at,
+                "scan": {"scanned": scanned},
+                "scoped_image_ids": image_ids,
+            }
+        )
+    except Exception:
+        writer.abort()
+        raise
+    return {
+        "valid": True,
+        "path": "dynamodb.sqlite3",
+        "table_name": table_name,
+        "table_arn": table.get("TableArn"),
+        "row_count": writer.row_count,
+        "entity_counts": entity_counts,
+        "scoped_image_ids": image_ids,
+        "scan": {"scanned": scanned},
+        "consistent_read": True,
+        "table_schema": {
+            "KeySchema": table["KeySchema"],
+            "AttributeDefinitions": table["AttributeDefinitions"],
+            "GlobalSecondaryIndexes": [
+                _index_summary(i) for i in table.get("GlobalSecondaryIndexes", [])
+            ],
+            "LocalSecondaryIndexes": [
+                _index_summary(i) for i in table.get("LocalSecondaryIndexes", [])
+            ],
+        },
+        "synced_at": synced_at,
+    }
+
+
+def run_pull(
+    env: str,
+    cache_dir: Path,
+    table_name: str,
+    image_ids: list[str],
+    region: str | None = None,
+    profile: str | None = None,
+) -> dict[str, Any]:
+    """Scoped pull into ``<cache_dir>/<env>/dynamodb.sqlite3`` + a serve manifest."""
+    cache_root = cache_dir.expanduser().resolve() / env
+    cache_root.mkdir(parents=True, exist_ok=True)
+    client = boto3.Session(profile_name=profile, region_name=region).client("dynamodb")
+    component = pull_scoped_images(
+        client, table_name, image_ids, cache_root / "dynamodb.sqlite3"
+    )
+    manifest = cache._load_manifest(cache_root)
+    manifest.setdefault("components", {})
+    manifest["components"]["dynamodb"] = component
+    manifest["schema_version"] = cache.SCHEMA_VERSION
+    manifest["environment"] = env
+    manifest["cache_root"] = str(cache_root)
+    manifest["scoped"] = True
+    now = cache._utc_now()
+    manifest["updated_at"] = now
+    manifest.setdefault("created_at", now)
+    cache._write_manifest(cache_root, manifest)
+    return {"cache_root": str(cache_root), "component": component}
+
+
+# --------------------------------------------------------------------------- #
 # Reporting / CLI                                                             #
 # --------------------------------------------------------------------------- #
 
@@ -436,8 +552,44 @@ def main(argv: list[str] | None = None) -> int:
     )
     d.add_argument("--json", type=Path, default=None, help="write full report JSON")
 
+    pull = sub.add_parser(
+        "pull", help="scoped BEFORE snapshot: Query only the listed images from dev"
+    )
+    pull.add_argument("--env", default="dev")
+    pull.add_argument("--cache-dir", type=Path, default=cache.DEFAULT_CACHE_DIR)
+    pull.add_argument("--table-name", required=True)
+    pull.add_argument(
+        "--images", type=Path, required=True, help="image_ids to pull, one per line"
+    )
+    pull.add_argument("--region", default=None)
+    pull.add_argument("--profile", default=None)
+
     args = parser.parse_args(argv)
     logging.basicConfig(level=args.log_level.upper())
+
+    if args.command == "pull":
+        ids = _read_image_ids(args.images)
+        result = run_pull(
+            args.env,
+            args.cache_dir,
+            args.table_name,
+            ids,
+            args.region,
+            args.profile,
+        )
+        comp = result["component"]
+        print(
+            json.dumps(
+                {
+                    "cache_root": result["cache_root"],
+                    "images": len(ids),
+                    "row_count": comp["row_count"],
+                    "entity_counts": comp["entity_counts"],
+                },
+                indent=2,
+            )
+        )
+        return 0
 
     if args.command == "snapshot":
         result = snapshot_local_table(

--- a/scripts/ocr_migration_rehearsal.py
+++ b/scripts/ocr_migration_rehearsal.py
@@ -460,14 +460,25 @@ def snapshot_local_table(
     """
     client = cache._robust_local_dynamo_client(endpoint_url, region)
     writer = cache.DynamoSQLiteWriter(out_path)
-    stats = cache._scan_segment(
-        client=client,
-        table_name=table_name,
-        segment=0,
-        total_segments=1,
-        consistent_read=True,
-        writer=writer,
-    )
+    # Own scan loop with a modest page Limit: DynamoDB Local's Scan can throw
+    # InternalFailure on large pages after heavy write churn; small pages are
+    # reliable (per-partition Queries never exhibited the failure).
+    kwargs: dict[str, Any] = {
+        "TableName": table_name,
+        "ConsistentRead": True,
+        "Limit": 250,
+    }
+    pages = scanned = 0
+    while True:
+        resp = client.scan(**kwargs)
+        writer.add(resp.get("Items", []))
+        pages += 1
+        scanned += int(resp.get("ScannedCount", 0))
+        lek = resp.get("LastEvaluatedKey")
+        if not lek:
+            break
+        kwargs["ExclusiveStartKey"] = lek
+    stats = {"pages": pages, "scanned": scanned}
     writer.finalize(
         {
             "source": "dynamodb-local",

--- a/tests/test_ocr_migration_apply.py
+++ b/tests/test_ocr_migration_apply.py
@@ -144,3 +144,26 @@ def test_centroid_handles_dynamodb_decimals():
     new_words = {(1, 1, 1): {"text": "TOTAL", "c": (0.3, 0.85)}}
     plan = app.plan_label_moves(old_words, old_labels, new_words)
     assert len(plan.moves) == 1
+
+
+def test_parked_same_label_lands_on_distinct_words():
+    # Two different old words both carry ADDRESS_LINE and both fail to match.
+    # They must park on DISTINCT words (same (word,label) twice = duplicate
+    # PK/SK = the BatchWriteItem failure from the first real apply).
+    old_words = {
+        (1, 1, 1): w("AAAA", 0.2, 0.9),
+        (1, 2, 1): w("BBBB", 0.2, 0.8),
+    }
+    old_labels = {
+        (1, 1, 1): [label_row("ADDRESS_LINE")],
+        (1, 2, 1): [label_row("ADDRESS_LINE")],
+    }
+    new_words = {
+        (1, 1, 1): w("XXXX", 0.2, 0.9),
+        (1, 2, 1): w("YYYY", 0.2, 0.8),
+        (1, 3, 1): w("ZZZZ", 0.2, 0.7),
+    }
+    plan = app.plan_label_moves(old_words, old_labels, new_words)
+    assert len(plan.parks) == 2
+    landing = {(p.new_key, p.label) for p in plan.parks}
+    assert len(landing) == 2  # distinct (word, label) slots

--- a/tests/test_ocr_migration_apply.py
+++ b/tests/test_ocr_migration_apply.py
@@ -167,3 +167,9 @@ def test_parked_same_label_lands_on_distinct_words():
     assert len(plan.parks) == 2
     landing = {(p.new_key, p.label) for p in plan.parks}
     assert len(landing) == 2  # distinct (word, label) slots
+
+
+def test_centroid_falls_back_to_bounding_box():
+    d = {"bounding_box": {"x": 0.2, "y": 0.6, "width": 0.2, "height": 0.1}}
+    cx, cy = app._centroid(d)
+    assert abs(cx - 0.3) < 1e-9 and abs(cy - 0.65) < 1e-9

--- a/tests/test_ocr_migration_apply.py
+++ b/tests/test_ocr_migration_apply.py
@@ -1,0 +1,127 @@
+"""Unit tests for the label-move planner in the re-OCR apply tool.
+
+Pure planning logic: no Docker, no AWS, no Swift. Exercises the policies that
+matter: audit-trail carry, park-not-drop (NEEDS_REVIEW), pre-orphans untouched,
+and repeated-word disambiguation by position.
+"""
+
+from __future__ import annotations
+
+from scripts import ocr_migration_apply as app
+
+IMG = "0e2f8a2c-1111-4222-8333-944445555666"
+
+
+def w(text: str, x: float, y: float) -> dict:
+    return {"text": text, "c": (x, y)}
+
+
+def label_row(label: str, status: str = "VALID", **extra) -> dict:
+    row = {
+        "label": label,
+        "validation_status": status,
+        "label_proposed_by": "human_review",
+        "reasoning": "looked right",
+        "timestamp_added": "2026-01-01T00:00:00+00:00",
+    }
+    row.update(extra)
+    return row
+
+
+def test_exact_move_carries_everything():
+    old_words = {(1, 1, 1): w("TOTAL", 0.5, 0.1)}
+    old_labels = {(1, 1, 1): [label_row("GRAND_TOTAL")]}
+    new_words = {(1, 3, 2): w("TOTAL", 0.5, 0.1)}
+    plan = app.plan_label_moves(old_words, old_labels, new_words)
+    assert len(plan.moves) == 1 and not plan.parks and not plan.pre_orphaned
+    mv = plan.moves[0]
+    assert mv.new_key == (1, 3, 2)
+    ent = app.moved_label_entity(IMG, mv)
+    assert ent.receipt_id == 1 and ent.line_id == 3 and ent.word_id == 2
+    assert ent.label == "GRAND_TOTAL"
+    assert ent.validation_status == "VALID"
+    assert ent.label_proposed_by == "human_review"
+    assert ent.reasoning == "looked right"
+    assert ent.timestamp_added == "2026-01-01T00:00:00+00:00"
+
+
+def test_repeated_word_disambiguated_by_position():
+    # Two identical "9.99" words; the labeled one is at the bottom. It must
+    # match the bottom one in the new OCR, not the top.
+    old_words = {
+        (1, 2, 1): w("9.99", 0.8, 0.7),
+        (1, 9, 1): w("9.99", 0.8, 0.1),  # labeled, near bottom
+    }
+    old_labels = {(1, 9, 1): [label_row("GRAND_TOTAL")]}
+    new_words = {
+        (1, 2, 1): w("9.99", 0.8, 0.7),
+        (1, 10, 1): w("9.99", 0.8, 0.1),
+    }
+    plan = app.plan_label_moves(old_words, old_labels, new_words)
+    assert plan.moves[0].new_key == (1, 10, 1)
+
+
+def test_reread_text_still_moves_by_position():
+    old_words = {(1, 1, 1): w("$2.68", 0.5, 0.2)}
+    old_labels = {(1, 1, 1): [label_row("LINE_TOTAL")]}
+    new_words = {(1, 7, 2): w("$2.66", 0.5, 0.2)}  # re-read, same place
+    plan = app.plan_label_moves(old_words, old_labels, new_words)
+    assert len(plan.moves) == 1 and plan.moves[0].new_key == (1, 7, 2)
+
+
+def test_unmatched_label_parked_needs_review_never_dropped():
+    old_words = {(1, 1, 1): w("SMOKESTACK", 0.5, 0.9)}
+    old_labels = {(1, 1, 1): [label_row("PRODUCT_NAME", status="VALID")]}
+    # New OCR read something totally different everywhere.
+    new_words = {(1, 1, 1): w("ZZZZ", 0.1, 0.1)}
+    plan = app.plan_label_moves(old_words, old_labels, new_words)
+    assert not plan.moves and len(plan.parks) == 1
+    pk = plan.parks[0]
+    assert pk.original_status == "VALID"
+    ent = app.moved_label_entity(
+        IMG,
+        app.LabelMove(pk.old_key, pk.new_key, pk.native, pk.label),
+        parked=True,
+        old_word_text="SMOKESTACK",
+    )
+    assert ent.validation_status == "NEEDS_REVIEW"
+    assert "PARKED by re-OCR migration" in ent.reasoning
+    assert "SMOKESTACK" in ent.reasoning
+    assert "VALID" in ent.reasoning  # original status recorded
+
+
+def test_pre_orphaned_labels_left_untouched():
+    old_words = {(1, 1, 1): w("A", 0.5, 0.5)}
+    old_labels = {
+        (1, 1, 1): [label_row("MERCHANT_NAME")],
+        (1, 9, 9): [label_row("GRAND_TOTAL")],  # word (1,9,9) missing -> pre-orphan
+    }
+    new_words = {(1, 1, 1): w("A", 0.5, 0.5)}
+    plan = app.plan_label_moves(old_words, old_labels, new_words)
+    assert len(plan.moves) == 1
+    assert plan.pre_orphaned == [((1, 9, 9), "GRAND_TOTAL")]
+    assert not plan.parks  # a pre-orphan is not parked, it is left alone
+
+
+def test_multi_label_word_rides_together_and_split_receipts_correspond():
+    # One word carries two labels; the image was re-segmented 1 receipt -> 2.
+    old_words = {
+        (1, 1, 1): w("COSTCO", 0.5, 0.95),
+        (1, 8, 1): w("VISA", 0.5, 0.15),
+    }
+    old_labels = {
+        (1, 1, 1): [label_row("MERCHANT_NAME"), label_row("BUSINESS_NAME")],
+        (1, 8, 1): [label_row("PAYMENT_METHOD")],
+    }
+    new_words = {
+        (1, 1, 1): w("COSTCO", 0.5, 0.95),  # new receipt 1
+        (2, 1, 1): w("VISA", 0.5, 0.15),  # new receipt 2 (split)
+    }
+    plan = app.plan_label_moves(old_words, old_labels, new_words)
+    moved = {(m.label, m.new_key) for m in plan.moves}
+    assert ("MERCHANT_NAME", (1, 1, 1)) in moved
+    assert ("BUSINESS_NAME", (1, 1, 1)) in moved
+    # old receipt 1 corresponds to ONE new receipt; VISA's label lands via the
+    # fallback pass on the split receipt rather than being dropped.
+    assert ("PAYMENT_METHOD", (2, 1, 1)) in moved
+    assert not plan.parks

--- a/tests/test_ocr_migration_apply.py
+++ b/tests/test_ocr_migration_apply.py
@@ -125,3 +125,22 @@ def test_multi_label_word_rides_together_and_split_receipts_correspond():
     # fallback pass on the split receipt rather than being dropped.
     assert ("PAYMENT_METHOD", (2, 1, 1)) in moved
     assert not plan.parks
+
+
+def test_centroid_handles_dynamodb_decimals():
+    # Live Dynamo reads deserialize numbers as decimal.Decimal; the planner
+    # must not blow up on Decimal / float (the first dry-run failed on this).
+    from decimal import Decimal
+
+    d = {
+        "top_left": {"x": Decimal("0.2"), "y": Decimal("0.9")},
+        "bottom_right": {"x": Decimal("0.4"), "y": Decimal("0.8")},
+    }
+    cx, cy = app._centroid(d)
+    assert isinstance(cx, float) and isinstance(cy, float)
+    assert abs(cx - 0.3) < 1e-9
+    old_words = {(1, 1, 1): {"text": "TOTAL", "c": app._centroid(d)}}
+    old_labels = {(1, 1, 1): [label_row("GRAND_TOTAL")]}
+    new_words = {(1, 1, 1): {"text": "TOTAL", "c": (0.3, 0.85)}}
+    plan = app.plan_label_moves(old_words, old_labels, new_words)
+    assert len(plan.moves) == 1

--- a/tests/test_ocr_migration_publish_crops.py
+++ b/tests/test_ocr_migration_publish_crops.py
@@ -1,0 +1,157 @@
+"""Unit tests for the post-migration crop publisher (pure parts only).
+
+No AWS, no network: warp-coefficient math against a known square, the CDN
+key -> Receipt field mapping, orphan detection from S3 listings, the
+--allow-aws guardrail, and invalidation chunking.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from PIL import Image as PIL_Image
+
+from scripts import ocr_migration_publish_crops as pub
+
+IMG = "0e2f8a2c-1111-4222-8333-944445555666"
+
+
+def make_receipt(width: int, height: int, corners: dict) -> SimpleNamespace:
+    """Duck-typed receipt: normalized corners (bottom-left origin) + dims."""
+    return SimpleNamespace(width=width, height=height, **corners)
+
+
+def apply_coeffs(coeffs, x: float, y: float) -> tuple[float, float]:
+    """PIL PERSPECTIVE forward map: receipt (dst) pixel -> image (src) pixel."""
+    a, b, c, d, e, f, g, h = coeffs
+    den = 1.0 + g * x + h * y
+    return (a * x + b * y + c) / den, (d * x + e * y + f) / den
+
+
+def test_perspective_coeffs_known_square():
+    # A receipt occupying the axis-aligned square x in [0.25, 0.75],
+    # y in [0.25, 0.75] (normalized, bottom-left origin) of a 200x400 image.
+    receipt = make_receipt(
+        101,
+        201,
+        {
+            "top_left": {"x": 0.25, "y": 0.75},
+            "top_right": {"x": 0.75, "y": 0.75},
+            "bottom_left": {"x": 0.25, "y": 0.25},
+            "bottom_right": {"x": 0.75, "y": 0.25},
+        },
+    )
+    coeffs = pub.perspective_coeffs(receipt, 200, 400)
+    # Receipt corners (PIL pixel space) must land on the square's corners in
+    # image PIL space; note the y-flip: normalized y=0.75 -> pixel y=100.
+    assert apply_coeffs(coeffs, 0, 0) == pytest.approx((50.0, 100.0))
+    assert apply_coeffs(coeffs, 100, 0) == pytest.approx((150.0, 100.0))
+    assert apply_coeffs(coeffs, 100, 200) == pytest.approx((150.0, 300.0))
+    assert apply_coeffs(coeffs, 0, 200) == pytest.approx((50.0, 300.0))
+
+
+def test_warp_receipt_crop_extracts_known_region():
+    # White image with a solid red rectangle covering the receipt region
+    # (with margin, since the crop's edge pixels sample AT the receipt
+    # corners); the warped crop must be entirely red (and the right size).
+    image = PIL_Image.new("RGB", (100, 100), "white")
+    image.paste((255, 0, 0), (15, 5, 90, 95))  # PIL box, top-left origin
+    receipt = make_receipt(
+        60,
+        80,
+        {
+            # bottom-left-origin normalized: pixel y=10 -> 0.9, y=90 -> 0.1
+            "top_left": {"x": 0.20, "y": 0.90},
+            "top_right": {"x": 0.80, "y": 0.90},
+            "bottom_left": {"x": 0.20, "y": 0.10},
+            "bottom_right": {"x": 0.80, "y": 0.10},
+        },
+    )
+    crop = pub.warp_receipt_crop(image, receipt)
+    assert crop.size == (60, 80)
+    for xy in ((0, 0), (59, 0), (59, 79), (0, 79), (30, 40)):
+        assert crop.getpixel(xy) == (255, 0, 0)
+
+
+def test_cdn_key_field_mapping_matches_ingestion():
+    base = f"assets/{IMG}/3"
+    keys = pub.expected_cdn_keys(base)
+    assert len(keys) == 12
+    expression, values = pub.build_cdn_update(keys, "site-bucket")
+    field_to_value = {
+        name.strip(): values[placeholder.strip()]
+        for name, placeholder in (
+            part.split("=") for part in expression.removeprefix("SET ").split(",")
+        )
+    }
+    assert field_to_value["cdn_s3_bucket"] == {"S": "site-bucket"}
+    assert field_to_value["cdn_s3_key"] == {"S": f"{base}.jpg"}
+    assert field_to_value["cdn_webp_s3_key"] == {"S": f"{base}.webp"}
+    assert field_to_value["cdn_avif_s3_key"] == {"S": f"{base}.avif"}
+    assert field_to_value["cdn_thumbnail_s3_key"] == {"S": f"{base}_thumbnail.jpg"}
+    assert field_to_value["cdn_small_webp_s3_key"] == {"S": f"{base}_small.webp"}
+    assert field_to_value["cdn_medium_avif_s3_key"] == {"S": f"{base}_medium.avif"}
+    assert len(field_to_value) == 13  # bucket + 12 keys, nothing else
+
+    # A missing format (e.g. AVIF encoder unavailable) serializes as NULL,
+    # exactly like CDNFieldsMixin.cdn_fields_to_dynamodb_item.
+    partial = dict(keys)
+    partial["avif_full"] = None
+    _, null_values = pub.build_cdn_update(partial, "site-bucket")
+    assert {"NULL": True} in null_values.values()
+
+
+def test_orphan_detection_from_listing():
+    listed = [
+        f"assets/{IMG}/1.jpg",
+        f"assets/{IMG}/1_thumbnail.webp",
+        f"assets/{IMG}/2.avif",  # receipt 2 no longer exists -> orphan
+        f"assets/{IMG}/2_medium.jpg",  # orphan
+        f"assets/{IMG}/12.jpg",  # receipt 12 gone; must not match "1"
+        f"assets/{IMG}/notes.txt",  # unrecognized: reported, never deleted
+        "assets/other-image/2.jpg",  # different image: ignored entirely
+    ]
+    orphans, unrecognized = pub.find_orphan_asset_keys(listed, IMG, {1})
+    assert orphans == sorted(
+        [
+            f"assets/{IMG}/2.avif",
+            f"assets/{IMG}/2_medium.jpg",
+            f"assets/{IMG}/12.jpg",
+        ]
+    )
+    assert unrecognized == [f"assets/{IMG}/notes.txt"]
+
+
+def test_guardrail_refuses_real_write_without_allow_aws(tmp_path):
+    with pytest.raises(SystemExit, match="REFUSING"):
+        pub.ensure_write_allowed(dry_run=False, allow_aws=False)
+    # Dry-run and explicit opt-in are both fine.
+    pub.ensure_write_allowed(dry_run=True, allow_aws=False)
+    pub.ensure_write_allowed(dry_run=False, allow_aws=True)
+
+    # The CLI refuses BEFORE touching AWS or pulumi.
+    images = tmp_path / "images.txt"
+    images.write_text(f"{IMG}\n")
+    with pytest.raises(SystemExit, match="REFUSING"):
+        pub.main(
+            [
+                "--table-name",
+                "ReceiptsTable-dev",
+                "--images",
+                str(images),
+                "--raw-dir",
+                str(tmp_path),
+                "--report",
+                str(tmp_path / "report.json"),
+                "--site-bucket",
+                "site-bucket",
+            ]
+        )
+
+
+def test_invalidation_paths_chunked_at_cloudfront_limit():
+    paths = [f"/assets/img-{i}/*" for i in range(6500)]
+    chunks = list(pub.chunk_paths(paths))
+    assert [len(c) for c in chunks] == [3000, 3000, 500]
+    assert [p for c in chunks for p in c] == paths

--- a/tests/test_ocr_migration_rehearsal.py
+++ b/tests/test_ocr_migration_rehearsal.py
@@ -344,3 +344,59 @@ def test_set_member_reorder_not_mutated(tmp_path: Path):
     after = write_snapshot(tmp_path / "after.sqlite3", [word_with_tags(["x", "y"])])
     diff = reh.diff_rows(reh.load_rows(before), reh.load_rows(after))
     assert len(diff.mutated) == 0
+
+
+def test_surplus_label_detected_id_collision(tmp_path: Path):
+    # forgot-to-delete: the OLD label survives on a re-read word (so NO orphan),
+    # and the label is ALSO re-applied to a new word -> 2 copies where 1 existed.
+    # The orphan check is blind to this; the surplus check must catch it.
+    before = write_snapshot(
+        tmp_path / "before.sqlite3",
+        [word_item("img1", 1, 1, 1, "A"), label_item("img1", 1, 1, 1, "GT")],
+    )
+    after = write_snapshot(
+        tmp_path / "after.sqlite3",
+        [
+            word_item("img1", 1, 1, 1, "A2"),  # re-read; stale label still valid
+            label_item("img1", 1, 1, 1, "GT"),  # stale label NOT deleted
+            word_item("img1", 1, 2, 2, "B"),  # regenerated word
+            label_item("img1", 1, 2, 2, "GT"),  # re-applied here too
+        ],
+    )
+    report = reh.check_label_preservation(
+        reh.load_rows(before), reh.load_rows(after), ["img1"]
+    )
+    assert report.has_surplus
+    assert not report.has_real_loss
+    assert reh.find_orphan_label_keys(reh.load_rows(after), ["img1"]) == []
+    diff = reh.run_diff(before, after, ["img1"])
+    assert diff["ok"] is False
+    assert diff["labels"]["receipts_with_surplus_labels"] == 1
+
+
+def test_targets_without_word_changes_flags_mixed_endpoint(tmp_path: Path):
+    # Only a benign receipt-metadata row changed locally; the word/label writes
+    # went to real dev (endpoint bypass). unchanged_targets is satisfied (a row
+    # changed) but the stronger word-level check must flag the bypass.
+    before = write_snapshot(
+        tmp_path / "before.sqlite3",
+        [
+            word_item("img1", 1, 1, 1, "A"),
+            label_item("img1", 1, 1, 1, "GT"),
+            other_item("IMAGE#img1", "RECEIPT#00001", "v1"),
+        ],
+    )
+    after = write_snapshot(
+        tmp_path / "after.sqlite3",
+        [
+            word_item("img1", 1, 1, 1, "A"),
+            label_item("img1", 1, 1, 1, "GT"),
+            other_item("IMAGE#img1", "RECEIPT#00001", "v2"),  # only meta changed
+        ],
+    )
+    diff = reh.diff_rows(reh.load_rows(before), reh.load_rows(after))
+    assert reh.unchanged_targets(diff.changed_pks, ["img1"]) == []  # a row changed
+    assert reh.targets_without_word_changes(diff, ["img1"]) == ["img1"]
+    report = reh.run_diff(before, after, ["img1"])
+    assert report["ok"] is False
+    assert report["invariants"]["targets_without_word_changes"] == ["img1"]

--- a/tests/test_ocr_migration_rehearsal.py
+++ b/tests/test_ocr_migration_rehearsal.py
@@ -233,3 +233,114 @@ def test_run_diff_verdict_passes_on_clean_reocr(tmp_path: Path):
     report = reh.run_diff(before, after, ["img1"])
     assert report["ok"] is True
     assert report["blast_radius"]["violations"] == []
+    assert report["invariants"]["unchanged_targets"] == []
+
+
+# --------------------------------------------------------------------------- #
+# Fable review must-fixes                                                       #
+# --------------------------------------------------------------------------- #
+
+
+def test_churn_reported_even_with_other_real_loss(tmp_path: Path):
+    # Label A is truly dropped; label B is re-applied on a re-read word. The
+    # per-item churn filter must still report B (the old whole-receipt `if not
+    # lost` test suppressed all churn whenever any loss existed).
+    before = write_snapshot(
+        tmp_path / "before.sqlite3",
+        [
+            word_item("img1", 1, 1, 1, "X"),
+            label_item("img1", 1, 1, 1, "A"),
+            word_item("img1", 1, 2, 2, "$1"),
+            label_item("img1", 1, 2, 2, "B"),
+        ],
+    )
+    after = write_snapshot(
+        tmp_path / "after.sqlite3",
+        [
+            word_item("img1", 1, 5, 5, "$2"),  # B's word re-read, new ids
+            label_item("img1", 1, 5, 5, "B"),
+        ],
+    )
+    report = reh.check_label_preservation(
+        reh.load_rows(before), reh.load_rows(after), ["img1"]
+    )
+    assert report.has_real_loss  # A
+    churn_labels = {t[0][0] for t in report.churn_only[("img1", 1)]}
+    assert "B" in churn_labels  # churn still surfaced despite A's loss
+    assert "A" not in churn_labels  # A is real loss, not churn
+
+
+def test_orphan_label_detected(tmp_path: Path):
+    after = write_snapshot(
+        tmp_path / "after.sqlite3",
+        [
+            word_item("img1", 1, 1, 1, "TOTAL"),  # a real word (not wiped)
+            label_item("img1", 1, 9, 9, "GRAND_TOTAL"),  # points at absent word
+        ],
+    )
+    orphans = reh.find_orphan_label_keys(reh.load_rows(after), ["img1"])
+    assert ("img1", 1, 9, 9, "GRAND_TOTAL") in orphans
+
+
+def test_run_diff_fails_on_orphan_label(tmp_path: Path):
+    # Migration regenerated the word under new ids but left the OLD label row.
+    before = write_snapshot(
+        tmp_path / "before.sqlite3",
+        [word_item("img1", 1, 1, 1, "T"), label_item("img1", 1, 1, 1, "GT")],
+    )
+    after = write_snapshot(
+        tmp_path / "after.sqlite3",
+        [
+            word_item("img1", 1, 2, 2, "T"),  # new word
+            label_item("img1", 1, 2, 2, "GT"),  # re-applied
+            label_item("img1", 1, 1, 1, "GT"),  # stale orphan (word 1,1,1 gone)
+        ],
+    )
+    report = reh.run_diff(before, after, ["img1"])
+    assert report["ok"] is False
+    assert report["invariants"]["orphan_labels"]
+
+
+def test_wiped_receipt_detected(tmp_path: Path):
+    # Receipt with words but NO labels, all words nuked -> label check is blind,
+    # words-survive invariant catches it.
+    before = write_snapshot(
+        tmp_path / "before.sqlite3",
+        [word_item("img1", 1, 1, 1, "A"), word_item("img1", 1, 1, 2, "B")],
+    )
+    after = write_snapshot(
+        tmp_path / "after.sqlite3",
+        [other_item("IMAGE#img1", "RECEIPT#00001", "meta-only")],  # words gone
+    )
+    assert ("img1", 1) in reh.wiped_receipts(
+        reh.load_rows(before), reh.load_rows(after), ["img1"]
+    )
+    report = reh.run_diff(before, after, ["img1"])
+    assert report["ok"] is False
+
+
+def test_unchanged_target_flags_noop(tmp_path: Path):
+    # Identical BEFORE/AFTER -> migration silently did nothing (or bypassed the
+    # local endpoint and wrote to real dev). Empty diff must NOT pass.
+    items = [word_item("img1", 1, 1, 1, "A"), label_item("img1", 1, 1, 1, "GT")]
+    before = write_snapshot(tmp_path / "before.sqlite3", items)
+    after = write_snapshot(tmp_path / "after.sqlite3", items)
+    report = reh.run_diff(before, after, ["img1"])
+    assert report["ok"] is False
+    assert report["invariants"]["unchanged_targets"] == ["img1"]
+
+
+def test_set_member_reorder_not_mutated(tmp_path: Path):
+    def word_with_tags(order):
+        return {
+            "PK": {"S": "IMAGE#img1"},
+            "SK": {"S": "RECEIPT#00001#LINE#00001#WORD#00001"},
+            "TYPE": {"S": "RECEIPT_WORD"},
+            "text": {"S": "A"},
+            "tags": {"SS": order},
+        }
+
+    before = write_snapshot(tmp_path / "before.sqlite3", [word_with_tags(["y", "x"])])
+    after = write_snapshot(tmp_path / "after.sqlite3", [word_with_tags(["x", "y"])])
+    diff = reh.diff_rows(reh.load_rows(before), reh.load_rows(after))
+    assert len(diff.mutated) == 0

--- a/tests/test_ocr_migration_rehearsal.py
+++ b/tests/test_ocr_migration_rehearsal.py
@@ -1,0 +1,235 @@
+"""Unit tests for the OCR->DynamoDB migration rehearsal harness.
+
+Pure Python: no Docker, no AWS. Synthetic BEFORE/AFTER snapshots are built with
+the same DynamoSQLiteWriter the live path uses, so the schema matches exactly.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from scripts import local_analytics_cache as cache
+from scripts import ocr_migration_rehearsal as reh
+
+# --------------------------------------------------------------------------- #
+# Wire-item builders (DynamoDB typed JSON)                                     #
+# --------------------------------------------------------------------------- #
+
+
+def word_item(image_id: str, rid: int, lid: int, wid: int, text: str) -> dict[str, Any]:
+    return {
+        "PK": {"S": f"IMAGE#{image_id}"},
+        "SK": {"S": f"RECEIPT#{rid:05d}#LINE#{lid:05d}#WORD#{wid:05d}"},
+        "TYPE": {"S": "RECEIPT_WORD"},
+        "text": {"S": text},
+    }
+
+
+def label_item(
+    image_id: str,
+    rid: int,
+    lid: int,
+    wid: int,
+    label: str,
+    status: str = "VALID",
+) -> dict[str, Any]:
+    return {
+        "PK": {"S": f"IMAGE#{image_id}"},
+        "SK": {"S": (f"RECEIPT#{rid:05d}#LINE#{lid:05d}#WORD#{wid:05d}#LABEL#{label}")},
+        "TYPE": {"S": "RECEIPT_WORD_LABEL"},
+        "label": {"S": label},
+        "validation_status": {"S": status},
+    }
+
+
+def other_item(pk: str, sk: str, payload: str = "x") -> dict[str, Any]:
+    return {
+        "PK": {"S": pk},
+        "SK": {"S": sk},
+        "TYPE": {"S": "OTHER"},
+        "payload": {"S": payload},
+    }
+
+
+def write_snapshot(path: Path, items: list[dict[str, Any]]) -> Path:
+    writer = cache.DynamoSQLiteWriter(path)
+    writer.add(items)
+    writer.finalize({"test": True})
+    writer.connection.close()
+    return path
+
+
+# --------------------------------------------------------------------------- #
+# SK parsing                                                                   #
+# --------------------------------------------------------------------------- #
+
+
+def test_parse_word_sk():
+    assert reh.parse_word_sk("RECEIPT#00001#LINE#00002#WORD#00003") == (1, 2, 3)
+    # A label SK is NOT a word SK.
+    assert reh.parse_word_sk("RECEIPT#00001#LINE#00002#WORD#00003#LABEL#TOTAL") is None
+    assert reh.parse_word_sk("RECEIPT#00001#LINE#00002") is None
+
+
+def test_parse_label_sk():
+    assert reh.parse_label_sk(
+        "RECEIPT#00001#LINE#00002#WORD#00003#LABEL#GRAND_TOTAL"
+    ) == (1, 2, 3, "GRAND_TOTAL")
+    assert reh.parse_label_sk("RECEIPT#00001#LINE#00002#WORD#00003") is None
+
+
+# --------------------------------------------------------------------------- #
+# Row diff + blast radius                                                      #
+# --------------------------------------------------------------------------- #
+
+
+def test_diff_rows_detects_add_delete_mutate(tmp_path: Path):
+    before = write_snapshot(
+        tmp_path / "before.sqlite3",
+        [
+            word_item("img1", 1, 1, 1, "COFFEE"),  # will mutate (text re-read)
+            word_item("img1", 1, 1, 2, "MILK"),  # will be deleted
+        ],
+    )
+    after = write_snapshot(
+        tmp_path / "after.sqlite3",
+        [
+            word_item("img1", 1, 1, 1, "COFEE"),  # mutated text
+            word_item("img1", 1, 1, 3, "SUGAR"),  # added
+        ],
+    )
+    diff = reh.diff_rows(reh.load_rows(before), reh.load_rows(after))
+    assert len(diff.added) == 1
+    assert len(diff.deleted) == 1
+    assert len(diff.mutated) == 1
+    assert diff.changed_pks == {"IMAGE#img1"}
+
+
+def test_blast_radius_flags_out_of_scope(tmp_path: Path):
+    before = write_snapshot(
+        tmp_path / "before.sqlite3",
+        [word_item("img1", 1, 1, 1, "A"), other_item("IMAGE#img2", "META", "v1")],
+    )
+    after = write_snapshot(
+        tmp_path / "after.sqlite3",
+        [word_item("img1", 1, 1, 1, "B"), other_item("IMAGE#img2", "META", "v2")],
+    )
+    diff = reh.diff_rows(reh.load_rows(before), reh.load_rows(after))
+    # Only img1 is a migration target; img2 changed too -> violation.
+    violations = reh.blast_radius_violations(diff.changed_pks, ["img1"])
+    assert violations == ["IMAGE#img2"]
+    # With both in scope, no violation.
+    assert reh.blast_radius_violations(diff.changed_pks, ["img1", "img2"]) == []
+
+
+# --------------------------------------------------------------------------- #
+# Label preservation                                                           #
+# --------------------------------------------------------------------------- #
+
+
+def test_label_preservation_detects_dropped_label(tmp_path: Path):
+    before = write_snapshot(
+        tmp_path / "before.sqlite3",
+        [
+            word_item("img1", 1, 1, 1, "TOTAL"),
+            label_item("img1", 1, 1, 1, "GRAND_TOTAL"),
+        ],
+    )
+    # Re-OCR regenerated the word but did NOT re-apply the label.
+    after = write_snapshot(
+        tmp_path / "after.sqlite3",
+        [word_item("img1", 1, 2, 5, "TOTAL")],
+    )
+    report = reh.check_label_preservation(
+        reh.load_rows(before), reh.load_rows(after), ["img1"]
+    )
+    assert report.has_real_loss
+    assert ("img1", 1) in report.lost_labels
+    assert report.labels_before == 1
+    assert report.labels_after == 0
+
+
+def test_text_reread_is_churn_not_loss(tmp_path: Path):
+    # Label preserved but on a word re-read to different text and new line/word id.
+    before = write_snapshot(
+        tmp_path / "before.sqlite3",
+        [
+            word_item("img1", 1, 1, 1, "$2.68"),
+            label_item("img1", 1, 1, 1, "LINE_TOTAL"),
+        ],
+    )
+    after = write_snapshot(
+        tmp_path / "after.sqlite3",
+        [
+            word_item("img1", 1, 7, 9, "$2.66"),  # re-read text, new ids
+            label_item("img1", 1, 7, 9, "LINE_TOTAL"),  # label re-applied
+        ],
+    )
+    report = reh.check_label_preservation(
+        reh.load_rows(before), reh.load_rows(after), ["img1"]
+    )
+    # No REAL loss (label+status count preserved) ...
+    assert not report.has_real_loss
+    # ... but the word-text-sensitive tuple changed -> reported as churn.
+    assert ("img1", 1) in report.churn_only
+
+
+def test_reassigned_ids_same_text_preserved(tmp_path: Path):
+    # Same label + same word text, only line/word ids changed -> fully preserved.
+    before = write_snapshot(
+        tmp_path / "before.sqlite3",
+        [
+            word_item("img1", 1, 1, 1, "VISA"),
+            label_item("img1", 1, 1, 1, "PAYMENT_METHOD"),
+        ],
+    )
+    after = write_snapshot(
+        tmp_path / "after.sqlite3",
+        [
+            word_item("img1", 1, 4, 2, "VISA"),
+            label_item("img1", 1, 4, 2, "PAYMENT_METHOD"),
+        ],
+    )
+    report = reh.check_label_preservation(
+        reh.load_rows(before), reh.load_rows(after), ["img1"]
+    )
+    assert not report.has_real_loss
+    assert not report.churn_only
+
+
+def test_run_diff_verdict_fails_on_loss(tmp_path: Path):
+    before = write_snapshot(
+        tmp_path / "before.sqlite3",
+        [
+            word_item("img1", 1, 1, 1, "TOTAL"),
+            label_item("img1", 1, 1, 1, "GRAND_TOTAL"),
+        ],
+    )
+    after = write_snapshot(
+        tmp_path / "after.sqlite3",
+        [word_item("img1", 1, 1, 1, "TOTAL")],  # label dropped
+    )
+    report = reh.run_diff(before, after, ["img1"])
+    assert report["ok"] is False
+    assert report["labels"]["receipts_with_lost_labels"] == 1
+
+
+def test_run_diff_verdict_passes_on_clean_reocr(tmp_path: Path):
+    before = write_snapshot(
+        tmp_path / "before.sqlite3",
+        [
+            word_item("img1", 1, 1, 1, "TOTAL"),
+            label_item("img1", 1, 1, 1, "GRAND_TOTAL"),
+        ],
+    )
+    after = write_snapshot(
+        tmp_path / "after.sqlite3",
+        [
+            word_item("img1", 1, 3, 8, "TOTAL"),
+            label_item("img1", 1, 3, 8, "GRAND_TOTAL"),
+        ],
+    )
+    report = reh.run_diff(before, after, ["img1"])
+    assert report["ok"] is True
+    assert report["blast_radius"]["violations"] == []

--- a/tests/test_ocr_migration_rehearsal.py
+++ b/tests/test_ocr_migration_rehearsal.py
@@ -145,7 +145,7 @@ def test_label_preservation_detects_dropped_label(tmp_path: Path):
         reh.load_rows(before), reh.load_rows(after), ["img1"]
     )
     assert report.has_real_loss
-    assert ("img1", 1) in report.lost_labels
+    assert "img1" in report.lost_labels
     assert report.labels_before == 1
     assert report.labels_after == 0
 
@@ -172,7 +172,7 @@ def test_text_reread_is_churn_not_loss(tmp_path: Path):
     # No REAL loss (label+status count preserved) ...
     assert not report.has_real_loss
     # ... but the word-text-sensitive tuple changed -> reported as churn.
-    assert ("img1", 1) in report.churn_only
+    assert "img1" in report.churn_only
 
 
 def test_reassigned_ids_same_text_preserved(tmp_path: Path):
@@ -212,7 +212,7 @@ def test_run_diff_verdict_fails_on_loss(tmp_path: Path):
     )
     report = reh.run_diff(before, after, ["img1"])
     assert report["ok"] is False
-    assert report["labels"]["receipts_with_lost_labels"] == 1
+    assert report["labels"]["images_with_lost_labels"] == 1
 
 
 def test_run_diff_verdict_passes_on_clean_reocr(tmp_path: Path):
@@ -265,7 +265,7 @@ def test_churn_reported_even_with_other_real_loss(tmp_path: Path):
         reh.load_rows(before), reh.load_rows(after), ["img1"]
     )
     assert report.has_real_loss  # A
-    churn_labels = {t[0][0] for t in report.churn_only[("img1", 1)]}
+    churn_labels = {t[0][0] for t in report.churn_only["img1"]}
     assert "B" in churn_labels  # churn still surfaced despite A's loss
     assert "A" not in churn_labels  # A is real loss, not churn
 
@@ -312,7 +312,7 @@ def test_wiped_receipt_detected(tmp_path: Path):
         tmp_path / "after.sqlite3",
         [other_item("IMAGE#img1", "RECEIPT#00001", "meta-only")],  # words gone
     )
-    assert ("img1", 1) in reh.wiped_receipts(
+    assert "img1" in reh.wiped_images(
         reh.load_rows(before), reh.load_rows(after), ["img1"]
     )
     report = reh.run_diff(before, after, ["img1"])
@@ -371,7 +371,7 @@ def test_surplus_label_detected_id_collision(tmp_path: Path):
     assert reh.find_orphan_label_keys(reh.load_rows(after), ["img1"]) == []
     diff = reh.run_diff(before, after, ["img1"])
     assert diff["ok"] is False
-    assert diff["labels"]["receipts_with_surplus_labels"] == 1
+    assert diff["labels"]["images_with_surplus_labels"] == 1
 
 
 def test_targets_without_word_changes_flags_mixed_endpoint(tmp_path: Path):
@@ -400,3 +400,34 @@ def test_targets_without_word_changes_flags_mixed_endpoint(tmp_path: Path):
     report = reh.run_diff(before, after, ["img1"])
     assert report["ok"] is False
     assert report["invariants"]["targets_without_word_changes"] == ["img1"]
+
+
+# --------------------------------------------------------------------------- #
+# Per-image aggregation (re-segmentation robustness)                           #
+# --------------------------------------------------------------------------- #
+
+
+def test_resegmentation_label_moved_between_receipts_preserved(tmp_path: Path):
+    # Re-OCR re-segments the image: a label that was on receipt 1 is now on
+    # receipt 2 (same word text). A per-receipt check would see loss-in-1 +
+    # surplus-in-2; per-image pooling must read it as fully preserved.
+    before = write_snapshot(
+        tmp_path / "before.sqlite3",
+        [
+            word_item("img1", 1, 1, 1, "VISA"),
+            label_item("img1", 1, 1, 1, "PAYMENT_METHOD"),
+        ],
+    )
+    after = write_snapshot(
+        tmp_path / "after.sqlite3",
+        [
+            word_item("img1", 2, 1, 1, "VISA"),  # now under receipt 2
+            label_item("img1", 2, 1, 1, "PAYMENT_METHOD"),
+        ],
+    )
+    report = reh.check_label_preservation(
+        reh.load_rows(before), reh.load_rows(after), ["img1"]
+    )
+    assert not report.has_real_loss
+    assert not report.has_surplus
+    assert reh.run_diff(before, after, ["img1"])["ok"] is True

--- a/tests/test_ocr_migration_rehearsal.py
+++ b/tests/test_ocr_migration_rehearsal.py
@@ -431,3 +431,48 @@ def test_resegmentation_label_moved_between_receipts_preserved(tmp_path: Path):
     assert not report.has_real_loss
     assert not report.has_surplus
     assert reh.run_diff(before, after, ["img1"])["ok"] is True
+
+
+# --------------------------------------------------------------------------- #
+# Backup / restore (rollback)                                                  #
+# --------------------------------------------------------------------------- #
+
+
+def test_compute_restore_plan(tmp_path: Path):
+    backup = write_snapshot(
+        tmp_path / "backup.sqlite3",
+        [
+            word_item("img1", 1, 1, 1, "OLD"),
+            label_item("img1", 1, 1, 1, "GT"),
+            word_item("img2", 1, 1, 1, "KEEP"),  # not a restore target
+        ],
+    )
+    current = write_snapshot(
+        tmp_path / "current.sqlite3",
+        [
+            word_item("img1", 1, 2, 2, "NEW"),  # migration-added -> delete
+            word_item("img1", 1, 1, 1, "MUTATED"),  # same key -> overwritten by put
+        ],
+    )
+    puts, deletes = reh.compute_restore_plan(
+        reh.load_rows(backup), reh.load_rows(current), ["img1"]
+    )
+    put_keys = {(r.pk, r.sk) for r in puts}
+    # every img1 backup row is re-put; img2 is out of scope
+    assert ("IMAGE#img1", "RECEIPT#00001#LINE#00001#WORD#00001") in put_keys
+    assert all(pk == "IMAGE#img1" for pk, _ in put_keys)
+    # the migration-added row is deleted; the mutated same-key row is not
+    assert deletes == [("IMAGE#img1", "RECEIPT#00001#LINE#00002#WORD#00002")]
+
+
+def test_local_endpoint_guardrail():
+    assert reh._is_local_endpoint("http://127.0.0.1:8000")
+    assert reh._is_local_endpoint("http://localhost:8000")
+    assert not reh._is_local_endpoint(None)
+    assert not reh._is_local_endpoint("https://dynamodb.us-east-1.amazonaws.com")
+    import pytest
+
+    with pytest.raises(SystemExit):
+        reh._make_client("https://dynamodb.us-east-1.amazonaws.com", None, False)
+    with pytest.raises(SystemExit):
+        reh._make_client(None, None, False)

--- a/tests/test_ocr_migration_rehearsal.py
+++ b/tests/test_ocr_migration_rehearsal.py
@@ -548,3 +548,27 @@ def test_orphan_delta_ignores_pre_existing(tmp_path: Path):
     report = reh.run_diff(before, after, ["img1"])
     assert report["invariants"]["orphan_labels"] == []
     assert report["invariants"]["pre_existing_orphans"] == 1
+
+
+def test_absorbed_pre_orphan_not_counted_as_loss(tmp_path: Path):
+    # BEFORE: a real labeled word + a PRE-ORPHAN label at (1,2,2) (no word).
+    # Migration moves the real label to (1,2,2) — same SK as the pre-orphan —
+    # overwriting the dead row. Net count drops by 1 but nothing real was lost.
+    before = write_snapshot(
+        tmp_path / "b.sqlite3",
+        [
+            word_item("img1", 1, 1, 1, "TOTAL"),
+            label_item("img1", 1, 1, 1, "GT", status="VALID"),
+            label_item("img1", 1, 2, 2, "GT", status="VALID"),  # pre-orphan
+        ],
+    )
+    after = write_snapshot(
+        tmp_path / "a.sqlite3",
+        [
+            word_item("img1", 1, 2, 2, "TOTAL"),  # new word at colliding ids
+            label_item("img1", 1, 2, 2, "GT", status="VALID"),  # moved label
+        ],
+    )
+    report = reh.run_diff(before, after, ["img1"])
+    assert report["labels"]["absorbed_pre_orphans"] == 1
+    assert report["ok"] is True

--- a/tests/test_ocr_migration_rehearsal.py
+++ b/tests/test_ocr_migration_rehearsal.py
@@ -476,3 +476,75 @@ def test_local_endpoint_guardrail():
         reh._make_client("https://dynamodb.us-east-1.amazonaws.com", None, False)
     with pytest.raises(SystemExit):
         reh._make_client(None, None, False)
+
+
+# --------------------------------------------------------------------------- #
+# Parked reconciliation + orphan delta                                         #
+# --------------------------------------------------------------------------- #
+
+
+def test_parked_reconciliation_clears_verdict(tmp_path: Path):
+    # One label parked: (GT, VALID) -> (GT, NEEDS_REVIEW) on a re-read word.
+    before = write_snapshot(
+        tmp_path / "b.sqlite3",
+        [
+            word_item("img1", 1, 1, 1, "TOTAL"),
+            label_item("img1", 1, 1, 1, "GT", status="VALID"),
+        ],
+    )
+    after = write_snapshot(
+        tmp_path / "a.sqlite3",
+        [
+            word_item("img1", 1, 2, 2, "TOTAI"),  # re-read word
+            label_item("img1", 1, 2, 2, "GT", status="NEEDS_REVIEW"),  # parked
+        ],
+    )
+    # Without reconciliation: loss + surplus -> FAIL.
+    assert reh.run_diff(before, after, ["img1"])["ok"] is False
+    # With the apply report vouching for 1 parked label -> PASS.
+    report = reh.run_diff(before, after, ["img1"], expect_parked={"img1": 1})
+    assert report["ok"] is True
+    assert report["labels"]["reconciled_parked"] == 1
+
+
+def test_parked_reconciliation_never_hides_real_loss(tmp_path: Path):
+    # Two labels: one parked, one genuinely dropped. Reconciliation may cancel
+    # only the parked pair; the drop must still FAIL.
+    before = write_snapshot(
+        tmp_path / "b.sqlite3",
+        [
+            word_item("img1", 1, 1, 1, "TOTAL"),
+            label_item("img1", 1, 1, 1, "GT", status="VALID"),
+            word_item("img1", 1, 2, 1, "VISA"),
+            label_item("img1", 1, 2, 1, "PAYMENT", status="VALID"),  # dropped
+        ],
+    )
+    after = write_snapshot(
+        tmp_path / "a.sqlite3",
+        [
+            word_item("img1", 1, 3, 3, "TOTAI"),
+            label_item("img1", 1, 3, 3, "GT", status="NEEDS_REVIEW"),  # parked
+            word_item("img1", 1, 4, 1, "VISA"),  # word survives, label gone
+        ],
+    )
+    report = reh.run_diff(before, after, ["img1"], expect_parked={"img1": 1})
+    assert report["ok"] is False
+    lost = report["labels"]["lost"]["img1"]
+    assert any(lab == "PAYMENT" for ((lab, _st), _n) in lost)
+
+
+def test_orphan_delta_ignores_pre_existing(tmp_path: Path):
+    # img1 already has a dangling label BEFORE the migration. If the migration
+    # neither fixes nor worsens it, the orphan invariant must not fail.
+    pre_orphan = label_item("img1", 1, 9, 9, "GT")  # word (1,9,9) never exists
+    before = write_snapshot(
+        tmp_path / "b.sqlite3",
+        [word_item("img1", 1, 1, 1, "A"), pre_orphan],
+    )
+    after = write_snapshot(
+        tmp_path / "a.sqlite3",
+        [word_item("img1", 1, 2, 2, "A"), pre_orphan],  # word re-keyed; orphan kept
+    )
+    report = reh.run_diff(before, after, ["img1"])
+    assert report["invariants"]["orphan_labels"] == []
+    assert report["invariants"]["pre_existing_orphans"] == 1


### PR DESCRIPTION
## Summary

The complete toolkit for applying #1095's segmentation to EXISTING labeled images without losing labels, plus the local rehearsal infrastructure it was proven on (built atop #1097's cache/DynamoDB Local).

- **`scripts/ocr_migration_rehearsal.py`** — scoped `pull` (serve-compatible cache from target image partitions), `backup`/`restore` (wire-exact rollback with byte-exact verification), paged `snapshot`, and `diff`: per-IMAGE label preservation (re-segmentation-safe), parked-label reconciliation (budget-vouched NEEDS_REVIEW), absorbed-pre-orphan accounting, orphan-delta, blast radius, wiped/no-op/bypass invariants. Local-first endpoint guardrail (`--allow-aws` required for real AWS).
- **`scripts/ocr_migration_apply.py`** — per image: new Swift OCR on the local raw → rebuild hierarchy (ingestion-lambda conventions) → **MOVE labels** (text+centroid matching; audit trail carried verbatim) → **PARK unmatched as NEEDS_REVIEW** with reasoning notes (never dropped) → children-first stale deletes. Refuses to run without a rollback backup. No machine labels written during migration.
- Fixes to `local_analytics_cache.py`: robust bulk client (the 1s probe client killed hydration/scan under load), exponential backoff in batch writes.

## Proven: G1 gate PASSED on a full local rehearsal
616 images / 58,586 labels against DynamoDB Local hydrated with real dev data:
**55,213 moved (audit intact) · 1,869 parked · 1,494 pre-orphans preserved · 0 lost · 0 new orphans · 0 blast-radius violations.**

32 unit tests; every bug found during rehearsal (Decimal coords, SK-only labels, park key collisions, backoff, paged scans) has a regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KQbKFQckzW2p4iiyK7iwu6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added CLI tool to re-run OCR while preserving and relocating human-applied labels, including dry-run reporting and rollback-ready backups.
  - Added OCR migration rehearsal workflow to snapshot, diff, validate label preservation, and enforce blast-radius guardrails against DynamoDB Local.
  - Added crop publisher tool to regenerate and publish receipt crops/derivatives with orphan asset cleanup and optional CloudFront invalidations.
- **Reliability**
  - Improved local DynamoDB cache hydration using a more robust bulk/batch DynamoDB Local client.
  - Marked receipt words as embedded immediately after successfully saving OpenAI batch results.
- **Documentation**
  - Added an OCR migration runbook covering dev and production wave procedures.
- **Tests**
  - Added unit tests for centroid fallback, rehearsal safety/diff invariants, crop publisher helpers/guardrails, and embedded-status marking behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->