### PR TITLE
ROM-font recreation from specimen charts + crop validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -251,8 +251,7 @@ infra/backups/
 .venv312/
 backups/
 
-# ROM-font recreation: never commit extracted atlases / heavy artifacts (local only)
-.out/rom-fonts/*.glyphs.npz
-.out/rom-fonts/*.verify.png
-.out/rom-fonts/_shipped_*.npz
-.out/rom-fonts/cache/
+# ROM-font recreation: extracted atlases / crop caches / render proofs stay
+# local (tracked copies of the per-font manifests + validation results live in
+# synthesis_loop/rom_font_manifests/)
+.out/rom-fonts/

--- a/.gitignore
+++ b/.gitignore
@@ -250,3 +250,9 @@ infra/backups/
 .github/pr-reviews/reports/*-review-tracking.md
 .venv312/
 backups/
+
+# ROM-font recreation: never commit extracted atlases / heavy artifacts (local only)
+.out/rom-fonts/*.glyphs.npz
+.out/rom-fonts/*.verify.png
+.out/rom-fonts/_shipped_*.npz
+.out/rom-fonts/cache/

--- a/synthesis_loop/extract_bitmatrix.py
+++ b/synthesis_loop/extract_bitmatrix.py
@@ -124,6 +124,7 @@ def extract(chart: str, cols: int = COLS):
     offsets: dict[str, float] = {}
     next_code = FIRST_CODE
     row_report = []
+    started = False  # first inked cell seen (the leading pad is over)
     for (y0, y1) in glyph_rows:
         if next_code > LAST_CODE:
             break
@@ -133,7 +134,21 @@ def extract(chart: str, cols: int = COLS):
                 break
             res = _extract_cell(black, y0, y1, c, W, cols)
             if res is None:
-                continue  # empty cell: skip WITHOUT consuming a codepoint
+                # Only the leading pad of the right-aligned partial top row
+                # may be empty. Every printable ASCII glyph carries ink, so an
+                # interior empty cell means the black-mask threshold missed a
+                # glyph -- and silently skipping it would shift every
+                # subsequent codepoint (the Latin-1 tail would then backfill
+                # the count to a plausible-looking 94). Fail loudly instead.
+                if started:
+                    raise RuntimeError(
+                        f"empty cell at row band ({y0},{y1}) col {c} while "
+                        f"expecting {chr(next_code)!r} (0x{next_code:02x}): "
+                        "codepoint mapping would shift; chart layout or "
+                        "threshold mismatch"
+                    )
+                continue  # leading pad: skip WITHOUT consuming a codepoint
+            started = True
             ch = chr(next_code)
             row[c] = (ch, res[0], res[1])
             next_code += 1
@@ -158,6 +173,13 @@ def extract(chart: str, cols: int = COLS):
             }
         )
 
+    expected = LAST_CODE - FIRST_CODE + 1
+    if len(glyphs) != expected:
+        raise RuntimeError(
+            f"incomplete extraction: {len(glyphs)}/{expected} glyphs "
+            f"(missing {''.join(chr(c) for c in range(FIRST_CODE, LAST_CODE + 1) if chr(c) not in glyphs)!r}); "
+            "refusing to emit a partial atlas"
+        )
     meta = {
         "chart": os.path.abspath(chart),
         "image_size": [W, H],
@@ -176,7 +198,11 @@ def extract(chart: str, cols: int = COLS):
 def write_outputs(glyphs, offsets, meta, out_dir, name):
     os.makedirs(out_dir, exist_ok=True)
     payload = {f"c{ord(k)}": v for k, v in glyphs.items()}
-    payload.update({f"o{ord(k)}": np.int16(v) for k, v in offsets.items()})
+    # round-half-away instead of int16 truncation: an even cap count medians
+    # to x.5 and truncation would bias those glyphs up a pixel
+    payload.update(
+        {f"o{ord(k)}": np.int16(round(v)) for k, v in offsets.items()}
+    )
     npz_path = os.path.join(out_dir, f"{name}.glyphs.npz")
     np.savez_compressed(npz_path, **payload)
 

--- a/synthesis_loop/extract_bitmatrix.py
+++ b/synthesis_loop/extract_bitmatrix.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""extract_bitmatrix.py -- build a clean glyph atlas from a receiptfont.com
+specimen chart PNG (the bitMatrix / bitArray / pixCrog family).
+
+The chart is a 17-column grid sweeping the printable ASCII table (`!` 0x21 ..
+`~` 0x7E) row-major, right-aligned into a partial top row, then full rows.
+Glyphs are pure black; per-cell labels are gray, and the grid/baseline guides
+are a saturated color (BLUE on bitMatrix-C2 / pixCrog, GREEN on
+bitMatrix-C1/D1/B2 and bitArray-A2). A black-only mask therefore isolates the
+letterform on every chart in the family regardless of guide color.
+
+Generalized from the Costco bitMatrix-C2 extractor (synthesis_loop history):
+the C2 version hard-coded the codepoint of each cell as ``34 + i*17 + c`` with
+a special case for `!`. That only holds for C2's left-aligned layout. The
+green-guide charts are RIGHT-aligned (a fuller partial top row) and continue
+past `~` into Latin-1 (`£ À Á ...`, even `€`). So this version assigns
+codepoints by *reading order*: the first inked cell is `!` (0x21) and every
+subsequent inked cell takes the next ASCII code, capping at `~` (0x7E). Empty
+cells (the leading pad of the partial top row, trailing cells) are skipped
+without consuming a codepoint; there are no interior gaps because every
+printable ASCII glyph carries ink. The Latin-1 tail is intentionally ignored
+-- receipt text is ASCII, so the atlas only needs 0x21..0x7E.
+
+Output: <out>/<name>.glyphs.npz (char -> binary glyph + per-char baseline
+offset), <out>/<name>.manifest.json (chart source, grid params, coverage), and
+<out>/<name>.verify.png (labeled contact sheet).
+
+Usage: extract_bitmatrix.py <chart.png> <out_dir> <atlas_name> [--cols 17]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+
+import numpy as np
+from PIL import Image, ImageDraw
+
+COLS = 17
+FIRST_CODE = 0x21  # '!'
+LAST_CODE = 0x7E  # '~'
+MIN_ROW_HEIGHT = 20  # a glyph row band is taller than this (label strips are
+#                      gray -> excluded from the black mask, so every black
+#                      band is a glyph row; the threshold only drops specks)
+
+
+def _row_bands(mask):
+    """Y-bands (row ranges) that contain glyph ink, top->bottom."""
+    proj = mask.sum(axis=1)
+    on = proj > proj.max() * 0.03
+    bands, i, n = [], 0, len(on)
+    while i < n:
+        if on[i]:
+            j = i
+            while j < n and on[j]:
+                j += 1
+            if j - i >= 4:
+                bands.append((i, j))
+            i = j
+        else:
+            i += 1
+    return bands
+
+
+def _trim_borders(g):
+    """Drop isolated full-height edge columns (cell-border slivers), keep '|'/'I'."""
+    h = g.shape[0]
+    full = lambda c: g[:, c].sum() >= 0.95 * h
+    empty = lambda c: g[:, c].sum() <= 0.1 * h
+    L, R = 0, g.shape[1]
+    while R - L > 3 and full(L) and empty(L + 1):
+        L += 1
+    while R - L > 3 and full(R - 1) and empty(R - 2):
+        R -= 1
+    g = g[:, L:R]
+    cols = np.where(g.sum(0) > 0)[0]
+    if cols.size:
+        g = g[:, cols.min():cols.max() + 1]
+    rows = np.where(g.sum(1) > 0)[0]
+    if rows.size:
+        g = g[rows.min():rows.max() + 1, :]
+    return g
+
+
+def _extract_cell(black, y0, y1, c, W, cols):
+    """Return (trimmed glyph, glyph_bottom_y_in_band) or None.
+
+    Removes any full-height vertical CELL BORDER (near either cell edge) BEFORE
+    measuring, so the glyph's real bottom -- not a border's -- sets the
+    baseline. (Colored guides are already dropped by the black mask; this only
+    fires on the rare chart that inks its rules.)
+    """
+    cell_w = W / cols
+    x0, x1 = int(round(c * cell_w)), int(round((c + 1) * cell_w))
+    cell = black[y0:y1, x0:x1].copy()
+    bh, bw = cell.shape
+    colsum = cell.sum(axis=0)
+    for x in range(bw):
+        if colsum[x] >= 0.9 * bh and (x < 4 or x > bw - 5):
+            cell[:, x] = 0  # drop edge border column
+    ys, xs = np.where(cell)
+    if ys.size < 3:
+        return None
+    g = cell[ys.min():ys.max() + 1, xs.min():xs.max() + 1].astype(np.uint8)
+    g = _trim_borders(g)
+    if g.size == 0 or g.sum() < 3:
+        return None
+    return g, int(ys.max())  # glyph bottom within the row band (baseline metric)
+
+
+def extract(chart: str, cols: int = COLS):
+    """Chart PNG -> (glyphs, offsets, meta). Pure; no disk writes."""
+    im = Image.open(chart).convert("RGB")
+    a = np.asarray(im).astype(int)
+    W, H = im.size
+    r, g, b = a[..., 0], a[..., 1], a[..., 2]
+    black = (r < 70) & (g < 70) & (b < 70)
+
+    bands = _row_bands(black)
+    glyph_rows = [(y0, y1) for (y0, y1) in bands if (y1 - y0) > MIN_ROW_HEIGHT]
+
+    glyphs: dict[str, np.ndarray] = {}
+    offsets: dict[str, float] = {}
+    next_code = FIRST_CODE
+    row_report = []
+    for (y0, y1) in glyph_rows:
+        if next_code > LAST_CODE:
+            break
+        row = {}  # col -> (char, glyph, bottom_y)
+        for c in range(cols):
+            if next_code > LAST_CODE:
+                break
+            res = _extract_cell(black, y0, y1, c, W, cols)
+            if res is None:
+                continue  # empty cell: skip WITHOUT consuming a codepoint
+            ch = chr(next_code)
+            row[c] = (ch, res[0], res[1])
+            next_code += 1
+        if not row:
+            continue
+        # baseline = median bottom of the CAP letters in this row; every glyph's
+        # offset = how far ITS bottom sits below the baseline (caps 0, hyphen
+        # negative=above, descenders positive=below).
+        cap_bottoms = [bt for (ch, _, bt) in row.values() if ch.isupper()]
+        baseline = (
+            float(np.median(cap_bottoms))
+            if cap_bottoms
+            else float(np.median([bt for (_, _, bt) in row.values()]))
+        )
+        for c, (ch, gl, bt) in sorted(row.items()):
+            glyphs[ch] = gl
+            offsets[ch] = bt - baseline
+        row_report.append(
+            {
+                "y_band": [int(y0), int(y1)],
+                "chars": "".join(ch for (ch, _, _) in (row[c] for c in sorted(row))),
+            }
+        )
+
+    meta = {
+        "chart": os.path.abspath(chart),
+        "image_size": [W, H],
+        "cols": cols,
+        "n_bands": len(bands),
+        "n_glyph_rows": len(glyph_rows),
+        "first_code": FIRST_CODE,
+        "last_code": LAST_CODE,
+        "glyph_count": len(glyphs),
+        "coverage": "".join(sorted(glyphs, key=ord)),
+        "rows": row_report,
+    }
+    return glyphs, offsets, meta
+
+
+def write_outputs(glyphs, offsets, meta, out_dir, name):
+    os.makedirs(out_dir, exist_ok=True)
+    payload = {f"c{ord(k)}": v for k, v in glyphs.items()}
+    payload.update({f"o{ord(k)}": np.int16(v) for k, v in offsets.items()})
+    npz_path = os.path.join(out_dir, f"{name}.glyphs.npz")
+    np.savez_compressed(npz_path, **payload)
+
+    manifest = dict(meta)
+    manifest["name"] = name
+    manifest["npz"] = os.path.abspath(npz_path)
+    man_path = os.path.join(out_dir, f"{name}.manifest.json")
+    with open(man_path, "w", encoding="utf-8") as fh:
+        json.dump(manifest, fh, indent=2)
+
+    # verification contact sheet
+    order = sorted(glyphs, key=ord)
+    cw, chh, per = 30, 40, 24
+    rows = (len(order) + per - 1) // per
+    sheet = Image.new("RGB", (per * cw, rows * (chh + 12)), (240, 240, 240))
+    d = ImageDraw.Draw(sheet)
+    for i, ch in enumerate(order):
+        gl = glyphs[ch]
+        tile = Image.fromarray((1 - gl) * 255).resize(
+            (min(cw - 4, int(gl.shape[1] * chh / gl.shape[0]) or 1), chh - 4)
+        )
+        rr, cc = divmod(i, per)
+        sheet.paste(tile, (cc * cw + 2, rr * (chh + 12) + 2))
+        d.text((cc * cw + 2, rr * (chh + 12) + chh - 8), ch, fill=(180, 0, 0))
+    verify_path = os.path.join(out_dir, f"{name}.verify.png")
+    sheet.save(verify_path)
+    return npz_path, man_path, verify_path
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("chart")
+    ap.add_argument("out_dir")
+    ap.add_argument("name")
+    ap.add_argument("--cols", type=int, default=COLS)
+    args = ap.parse_args(argv)
+
+    glyphs, offsets, meta = extract(args.chart, args.cols)
+    npz_path, man_path, verify_path = write_outputs(
+        glyphs, offsets, meta, args.out_dir, args.name
+    )
+    print(
+        f"{args.name}: {meta['image_size']}, {meta['n_bands']} bands, "
+        f"{meta['n_glyph_rows']} glyph rows"
+    )
+    print(f"  extracted {meta['glyph_count']} glyphs: {meta['coverage']}")
+    print(f"  npz     -> {npz_path}")
+    print(f"  manifest-> {man_path}")
+    print(f"  verify  -> {verify_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/synthesis_loop/render_rom_proof.py
+++ b/synthesis_loop/render_rom_proof.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""render_rom_proof.py -- REAL | CURRENT | ROM-FONT side-by-side for one receipt.
+
+Renders a vetted golden receipt three ways at matched canvas height:
+  REAL     -- the scanned receipt (CDN S3).
+  CURRENT  -- the merchant's shipped render profile (its current atlas/font).
+  ROM-FONT -- the SAME profile with the winning recreated ROM atlas swapped in
+              for the bitmap_font faces (everything else -- condense, pitch,
+              bitmap_thin, stylemap, section scale -- held fixed, so only the
+              glyph SHAPES change).
+
+For a merchant that ships a vector font instead of a bitmap atlas (Smith's uses
+VT323), the ROM panel injects a bitmap_font block with borrowed grocery knobs so
+the ROM glyphs can be placed -- an approximate, eyeball-only config.
+
+Scratch render cache + RECEIPT_PAPER_STRENGTH honored from the environment.
+
+Usage:
+  RECEIPT_PAPER_STRENGTH=0.3 python render_rom_proof.py \
+      --merchant Vons --image <id> --receipt 1 \
+      --rom .out/rom-fonts/bitMatrix-C1-heavy.glyphs.npz \
+      --out .out/rom-fonts/proof_vons.png
+"""
+from __future__ import annotations
+
+import argparse
+import copy
+import os
+import sys
+from io import BytesIO
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_ROOT = os.path.abspath(os.path.join(_HERE, ".."))
+for _p in (_HERE, os.path.join(_ROOT, "scripts"), os.path.join(_ROOT, "receipt_dynamo")):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from PIL import Image, ImageDraw  # noqa: E402
+
+# Borrowed bitmap knobs for a vector-font merchant (Smith's): grocery defaults.
+_BITMAP_FALLBACK = dict(
+    bitmap_cap_ratio=0.66,
+    ocr_font_sizing=True,
+    ocr_cap_height_ratio=0.649,
+    mixed_layout=True,
+    bitmap_thin=0.3,
+    pitch_ratio=0.538,
+)
+
+
+def _render_synth(rsr, merchant, rec, words, barcodes, prof, ss, typ, wt, ht, path):
+    rsr._render_cached_hybrid(
+        {"words": words, "barcodes": barcodes, "merchant_name": merchant},
+        None if "bitmap_font" in typ else typ.get("_atlas"),
+        profile=prof,
+        width=wt,
+        height=ht,
+        path=path,
+        section_scale=ss,
+        **{k: v for k, v in typ.items() if not k.startswith("_")},
+    )
+    return Image.open(path).convert("RGB")
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--merchant", required=True)
+    ap.add_argument("--image", required=True)
+    ap.add_argument("--receipt", type=int, required=True)
+    ap.add_argument("--rom", required=True, help="winning ROM .glyphs.npz")
+    ap.add_argument("--rom-heavy", default=None, help="ROM heavy face (default: --rom)")
+    ap.add_argument("--out", required=True)
+    ap.add_argument(
+        "--table",
+        default=os.environ.get("DYNAMODB_TABLE_NAME", "ReceiptsTable-dc5be22"),
+    )
+    args = ap.parse_args(argv)
+    os.environ["DYNAMODB_TABLE_NAME"] = args.table
+    region = os.environ.get("AWS_REGION", "us-east-1")
+
+    import boto3
+
+    import render_synthetic_receipts as rsr
+    from receipt_dynamo.data.dynamo_client import DynamoClient
+
+    c = DynamoClient(table_name=args.table, region=region)
+    s3 = boto3.client("s3", region_name=region)
+
+    prof = rsr.cached_font_profile(args.table, args.merchant, region=region, max_receipts=12)
+    ss = rsr.section_scale_for_merchant(args.merchant)
+    typ_current = rsr.merchant_typography(args.merchant)
+
+    # atlas needed when the merchant has no bitmap_font (renders from cached glyphs)
+    atlas = None
+    if "bitmap_font" not in typ_current:
+        atlas = rsr.cached_glyph_atlas(args.table, args.merchant, region=region, max_receipts=8)
+        typ_current["_atlas"] = atlas
+
+    d = c.get_image_details(args.image)
+    rec = next((r for r in d.receipts if str(r.receipt_id) == str(args.receipt)), None)
+    if rec is None:
+        raise SystemExit(f"receipt {args.receipt} not in image {args.image}")
+    ws = [w for w in d.receipt_words if w.receipt_id == args.receipt]
+    words = [
+        {
+            "text": w.text,
+            "line_id": w.line_id,
+            "word_id": w.word_id,
+            "bbox": [
+                w.top_left["x"] * 1000,
+                w.top_left["y"] * 1000,
+                w.bottom_right["x"] * 1000,
+                w.bottom_right["y"] * 1000,
+            ],
+            "labels": [],
+        }
+        for w in ws
+    ]
+    barcodes = []
+
+    wt = 760
+    ht = int(round(wt * rec.height / rec.width))
+
+    # CURRENT panel
+    syn_cur = _render_synth(
+        rsr, args.merchant, rec, words, barcodes, prof, ss, typ_current, wt, ht,
+        args.out + ".current.png",
+    )
+
+    # ROM panel: swap bitmap_font faces to the ROM npz, hold everything else.
+    rom_heavy = args.rom_heavy or args.rom
+    typ_rom = copy.deepcopy({k: v for k, v in typ_current.items() if k != "_atlas"})
+    if "bitmap_font" in typ_rom:
+        typ_rom["bitmap_font"] = {"regular": args.rom, "heavy": rom_heavy}
+    else:
+        # vector-font merchant: inject a bitmap_font + borrowed knobs
+        typ_rom["bitmap_font"] = {"regular": args.rom, "heavy": rom_heavy}
+        for k, v in _BITMAP_FALLBACK.items():
+            typ_rom.setdefault(k, v)
+    syn_rom = _render_synth(
+        rsr, args.merchant, rec, words, barcodes, prof, ss, typ_rom, wt, ht,
+        args.out + ".rom.png",
+    )
+
+    # REAL panel
+    real = None
+    for bkt, key in [(rec.cdn_s3_bucket, rec.cdn_s3_key), (rec.raw_s3_bucket, rec.raw_s3_key)]:
+        if not bkt or not key:
+            continue
+        try:
+            real = Image.open(BytesIO(s3.get_object(Bucket=bkt, Key=key)["Body"].read())).convert("RGB")
+            break
+        except Exception:  # noqa: BLE001
+            continue
+
+    # compose at matched panel height
+    wd = 380
+    def byw(im):
+        w, h = im.size
+        return im.resize((wd, int(h * wd / w)))
+
+    panels = [("REAL", real), ("CURRENT", syn_cur), ("ROM-FONT", syn_rom)]
+    panels = [(t, byw(im)) for t, im in panels if im is not None]
+    hh = max(im.height for _, im in panels) + 40
+    cv = Image.new("RGB", (wd * len(panels) + 20 * (len(panels) + 1), hh), (235, 235, 235))
+    dd = ImageDraw.Draw(cv)
+    x = 20
+    for t, im in panels:
+        cv.paste(im, (x, 34))
+        dd.text((x, 12), t, fill=(200, 0, 0))
+        x += wd + 20
+    os.makedirs(os.path.dirname(args.out), exist_ok=True)
+    cv.save(args.out)
+    print(f"{args.merchant} {args.image}:{args.receipt} -> {args.out}")
+    for t, p in [("current", args.out + ".current.png"), ("rom", args.out + ".rom.png")]:
+        print(f"  {t}: {p}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/synthesis_loop/render_rom_proof.py
+++ b/synthesis_loop/render_rom_proof.py
@@ -100,7 +100,7 @@ def main(argv=None) -> int:
     rec = next((r for r in d.receipts if str(r.receipt_id) == str(args.receipt)), None)
     if rec is None:
         raise SystemExit(f"receipt {args.receipt} not in image {args.image}")
-    ws = [w for w in d.receipt_words if w.receipt_id == args.receipt]
+    ws = [w for w in d.receipt_words if str(w.receipt_id) == str(args.receipt)]
     words = [
         {
             "text": w.text,
@@ -144,14 +144,22 @@ def main(argv=None) -> int:
 
     # REAL panel
     real = None
+    last_err = None
     for bkt, key in [(rec.cdn_s3_bucket, rec.cdn_s3_key), (rec.raw_s3_bucket, rec.raw_s3_key)]:
         if not bkt or not key:
             continue
         try:
             real = Image.open(BytesIO(s3.get_object(Bucket=bkt, Key=key)["Body"].read())).convert("RGB")
             break
-        except Exception:  # noqa: BLE001
+        except Exception as e:  # noqa: BLE001
+            last_err = e
             continue
+    if real is None:
+        raise SystemExit(
+            f"could not fetch the REAL scan for {args.image}#{args.receipt} "
+            f"(last error: {last_err or 'no s3 keys on record'}); "
+            "refusing to emit a proof without the REAL panel"
+        )
 
     # compose at matched panel height
     wd = 380
@@ -169,7 +177,9 @@ def main(argv=None) -> int:
         cv.paste(im, (x, 34))
         dd.text((x, 12), t, fill=(200, 0, 0))
         x += wd + 20
-    os.makedirs(os.path.dirname(args.out), exist_ok=True)
+    parent = os.path.dirname(args.out)
+    if parent:
+        os.makedirs(parent, exist_ok=True)
     cv.save(args.out)
     print(f"{args.merchant} {args.image}:{args.receipt} -> {args.out}")
     for t, p in [("current", args.out + ".current.png"), ("rom", args.out + ".rom.png")]:

--- a/synthesis_loop/rom_font_manifests/bitArray-A2.manifest.json
+++ b/synthesis_loop/rom_font_manifests/bitArray-A2.manifest.json
@@ -1,0 +1,60 @@
+{
+  "chart": "/private/tmp/claude-501/-Users-tnorlund-vegas-26/8e37906b-7da3-4cc8-b685-505d5d59c685/scratchpad/font_charts/626436-bitArray-A2.png",
+  "image_size": [
+    626,
+    436
+  ],
+  "cols": 17,
+  "n_bands": 14,
+  "n_glyph_rows": 8,
+  "first_code": 33,
+  "last_code": 126,
+  "glyph_count": 94,
+  "coverage": "!\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~",
+  "rows": [
+    {
+      "y_band": [
+        16,
+        49
+      ],
+      "chars": "!\"#$%&'()*+,-."
+    },
+    {
+      "y_band": [
+        73,
+        104
+      ],
+      "chars": "/0123456789:;<=>?"
+    },
+    {
+      "y_band": [
+        128,
+        155
+      ],
+      "chars": "@ABCDEFGHIJKLMNOP"
+    },
+    {
+      "y_band": [
+        181,
+        214
+      ],
+      "chars": "QRSTUVWXYZ[\\]^_`a"
+    },
+    {
+      "y_band": [
+        236,
+        269
+      ],
+      "chars": "bcdefghijklmnopqr"
+    },
+    {
+      "y_band": [
+        291,
+        324
+      ],
+      "chars": "stuvwxyz{|}~"
+    }
+  ],
+  "name": "bitArray-A2",
+  "npz": "/Users/tnorlund/Portfolio_rom_font/.out/rom-fonts/bitArray-A2.glyphs.npz"
+}

--- a/synthesis_loop/rom_font_manifests/bitMatrix-B2.manifest.json
+++ b/synthesis_loop/rom_font_manifests/bitMatrix-B2.manifest.json
@@ -1,0 +1,60 @@
+{
+  "chart": "/private/tmp/claude-501/-Users-tnorlund-vegas-26/8e37906b-7da3-4cc8-b685-505d5d59c685/scratchpad/font_charts/626436-bitMatrix-B2.png",
+  "image_size": [
+    626,
+    436
+  ],
+  "cols": 17,
+  "n_bands": 8,
+  "n_glyph_rows": 7,
+  "first_code": 33,
+  "last_code": 126,
+  "glyph_count": 94,
+  "coverage": "!\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~",
+  "rows": [
+    {
+      "y_band": [
+        18,
+        44
+      ],
+      "chars": "!\"#$%&'()*+,-./0"
+    },
+    {
+      "y_band": [
+        73,
+        99
+      ],
+      "chars": "123456789:;<=>?@A"
+    },
+    {
+      "y_band": [
+        128,
+        151
+      ],
+      "chars": "BCDEFGHIJKLMNOPQR"
+    },
+    {
+      "y_band": [
+        183,
+        211
+      ],
+      "chars": "STUVWXYZ[\\]^_`abc"
+    },
+    {
+      "y_band": [
+        238,
+        264
+      ],
+      "chars": "defghijklmnopqrst"
+    },
+    {
+      "y_band": [
+        292,
+        318
+      ],
+      "chars": "uvwxyz{|}~"
+    }
+  ],
+  "name": "bitMatrix-B2",
+  "npz": "/Users/tnorlund/Portfolio_rom_font/.out/rom-fonts/bitMatrix-B2.glyphs.npz"
+}

--- a/synthesis_loop/rom_font_manifests/bitMatrix-C1-heavy.manifest.json
+++ b/synthesis_loop/rom_font_manifests/bitMatrix-C1-heavy.manifest.json
@@ -1,0 +1,60 @@
+{
+  "chart": "/private/tmp/claude-501/-Users-tnorlund-vegas-26/8e37906b-7da3-4cc8-b685-505d5d59c685/scratchpad/font_charts/626436-bitMatrix-C1-heavy.png",
+  "image_size": [
+    626,
+    436
+  ],
+  "cols": 17,
+  "n_bands": 11,
+  "n_glyph_rows": 7,
+  "first_code": 33,
+  "last_code": 126,
+  "glyph_count": 94,
+  "coverage": "!\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~",
+  "rows": [
+    {
+      "y_band": [
+        16,
+        47
+      ],
+      "chars": "!\"#$%&'()*+,-."
+    },
+    {
+      "y_band": [
+        71,
+        99
+      ],
+      "chars": "/0123456789:;<=>?"
+    },
+    {
+      "y_band": [
+        126,
+        154
+      ],
+      "chars": "@ABCDEFGHIJKLMNOP"
+    },
+    {
+      "y_band": [
+        180,
+        209
+      ],
+      "chars": "QRSTUVWXYZ[\\]^_`a"
+    },
+    {
+      "y_band": [
+        236,
+        267
+      ],
+      "chars": "bcdefghijklmnopqr"
+    },
+    {
+      "y_band": [
+        291,
+        322
+      ],
+      "chars": "stuvwxyz{|}~"
+    }
+  ],
+  "name": "bitMatrix-C1-heavy",
+  "npz": "/Users/tnorlund/Portfolio_rom_font/.out/rom-fonts/bitMatrix-C1-heavy.glyphs.npz"
+}

--- a/synthesis_loop/rom_font_manifests/bitMatrix-C1.manifest.json
+++ b/synthesis_loop/rom_font_manifests/bitMatrix-C1.manifest.json
@@ -1,0 +1,60 @@
+{
+  "chart": "/private/tmp/claude-501/-Users-tnorlund-vegas-26/8e37906b-7da3-4cc8-b685-505d5d59c685/scratchpad/font_charts/626436-bitMatrix-C1.png",
+  "image_size": [
+    626,
+    436
+  ],
+  "cols": 17,
+  "n_bands": 10,
+  "n_glyph_rows": 7,
+  "first_code": 33,
+  "last_code": 126,
+  "glyph_count": 94,
+  "coverage": "!\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~",
+  "rows": [
+    {
+      "y_band": [
+        16,
+        43
+      ],
+      "chars": "!\"#$%&'()*+,-."
+    },
+    {
+      "y_band": [
+        71,
+        98
+      ],
+      "chars": "/0123456789:;<=>?"
+    },
+    {
+      "y_band": [
+        126,
+        153
+      ],
+      "chars": "@ABCDEFGHIJKLMNOP"
+    },
+    {
+      "y_band": [
+        180,
+        208
+      ],
+      "chars": "QRSTUVWXYZ[\\]^_`a"
+    },
+    {
+      "y_band": [
+        236,
+        266
+      ],
+      "chars": "bcdefghijklmnopqr"
+    },
+    {
+      "y_band": [
+        291,
+        321
+      ],
+      "chars": "stuvwxyz{|}~"
+    }
+  ],
+  "name": "bitMatrix-C1",
+  "npz": "/Users/tnorlund/Portfolio_rom_font/.out/rom-fonts/bitMatrix-C1.glyphs.npz"
+}

--- a/synthesis_loop/rom_font_manifests/bitMatrix-D1.manifest.json
+++ b/synthesis_loop/rom_font_manifests/bitMatrix-D1.manifest.json
@@ -1,0 +1,60 @@
+{
+  "chart": "/private/tmp/claude-501/-Users-tnorlund-vegas-26/8e37906b-7da3-4cc8-b685-505d5d59c685/scratchpad/font_charts/626436-bitMatrix-D1.png",
+  "image_size": [
+    626,
+    436
+  ],
+  "cols": 17,
+  "n_bands": 12,
+  "n_glyph_rows": 8,
+  "first_code": 33,
+  "last_code": 126,
+  "glyph_count": 94,
+  "coverage": "!\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~",
+  "rows": [
+    {
+      "y_band": [
+        16,
+        47
+      ],
+      "chars": "!\"#$%&'()*+,-./0"
+    },
+    {
+      "y_band": [
+        71,
+        99
+      ],
+      "chars": "123456789:;<=>?@A"
+    },
+    {
+      "y_band": [
+        126,
+        154
+      ],
+      "chars": "BCDEFGHIJKLMNOPQR"
+    },
+    {
+      "y_band": [
+        181,
+        209
+      ],
+      "chars": "STUVWXYZ[\\]^_`abc"
+    },
+    {
+      "y_band": [
+        236,
+        270
+      ],
+      "chars": "defghijklmnopqrst"
+    },
+    {
+      "y_band": [
+        281,
+        325
+      ],
+      "chars": "uvwxyz{|}~"
+    }
+  ],
+  "name": "bitMatrix-D1",
+  "npz": "/Users/tnorlund/Portfolio_rom_font/.out/rom-fonts/bitMatrix-D1.glyphs.npz"
+}

--- a/synthesis_loop/rom_font_manifests/pixCrog.manifest.json
+++ b/synthesis_loop/rom_font_manifests/pixCrog.manifest.json
@@ -1,0 +1,60 @@
+{
+  "chart": "/private/tmp/claude-501/-Users-tnorlund-vegas-26/8e37906b-7da3-4cc8-b685-505d5d59c685/scratchpad/font_charts/626436-pixCrog.png",
+  "image_size": [
+    626,
+    436
+  ],
+  "cols": 17,
+  "n_bands": 12,
+  "n_glyph_rows": 6,
+  "first_code": 33,
+  "last_code": 126,
+  "glyph_count": 94,
+  "coverage": "!\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~",
+  "rows": [
+    {
+      "y_band": [
+        16,
+        45
+      ],
+      "chars": "!\"#$%&'()*+,-."
+    },
+    {
+      "y_band": [
+        72,
+        100
+      ],
+      "chars": "/0123456789:;<=>?"
+    },
+    {
+      "y_band": [
+        127,
+        154
+      ],
+      "chars": "@ABCDEFGHIJKLMNOP"
+    },
+    {
+      "y_band": [
+        181,
+        210
+      ],
+      "chars": "QRSTUVWXYZ[\\]^_`a"
+    },
+    {
+      "y_band": [
+        237,
+        265
+      ],
+      "chars": "bcdefghijklmnopqr"
+    },
+    {
+      "y_band": [
+        291,
+        320
+      ],
+      "chars": "stuvwxyz{|}~"
+    }
+  ],
+  "name": "pixCrog",
+  "npz": "/Users/tnorlund/Portfolio_rom_font/.out/rom-fonts/pixCrog.glyphs.npz"
+}

--- a/synthesis_loop/rom_font_manifests/validation_results.json
+++ b/synthesis_loop/rom_font_manifests/validation_results.json
@@ -1,0 +1,335 @@
+{
+  "table": "ReceiptsTable-dc5be22",
+  "roms": [
+    "bitMatrix-C1",
+    "bitMatrix-C1-heavy",
+    "bitMatrix-D1",
+    "pixCrog",
+    "bitMatrix-B2",
+    "bitArray-A2"
+  ],
+  "merchants": {
+    "Vons": {
+      "shipped_slug": "vons",
+      "n_receipts": 8,
+      "n_letters": 4814,
+      "median_cap_px": 27.0,
+      "receipts": [
+        "00ded398-af6f-4a49-86f7-c79ccb554e48#1",
+        "129ee4aa-2053-4cd7-8534-a9817f8a3402#1",
+        "129ee4aa-2053-4cd7-8534-a9817f8a3402#2",
+        "1828b9ba-6f91-4d06-a738-1a7a1539f35f#1",
+        "1b441d33-6434-449f-b4c7-c98e70861277#2",
+        "314ac65b-2b97-45d6-81c2-e48fb0b8cef4#2",
+        "3cd5a28e-f5ef-4fd9-8bc9-a44437a6353f#1",
+        "47283bc4-7540-4903-890e-87fdc9bcb480#1"
+      ],
+      "scores": {
+        "CURRENT:vons": {
+          "median_iou": 0.5958,
+          "mean_iou": 0.5624,
+          "n_letters": 4814
+        },
+        "ROM:bitMatrix-C1": {
+          "median_iou": 0.5529,
+          "mean_iou": 0.5209,
+          "n_letters": 4814
+        },
+        "ROM:bitMatrix-C1-heavy": {
+          "median_iou": 0.6202,
+          "mean_iou": 0.572,
+          "n_letters": 4814
+        },
+        "ROM:bitMatrix-D1": {
+          "median_iou": 0.4757,
+          "mean_iou": 0.4656,
+          "n_letters": 4814
+        },
+        "ROM:pixCrog": {
+          "median_iou": 0.5668,
+          "mean_iou": 0.5374,
+          "n_letters": 4814
+        },
+        "ROM:bitMatrix-B2": {
+          "median_iou": 0.5068,
+          "mean_iou": 0.4949,
+          "n_letters": 4814
+        },
+        "ROM:bitArray-A2": {
+          "median_iou": 0.4863,
+          "mean_iou": 0.4664,
+          "n_letters": 4814
+        }
+      },
+      "rom_winner": "bitMatrix-C1-heavy",
+      "rom_winner_iou": 0.6202,
+      "current_iou": 0.5958,
+      "rom_beats_current": true
+    },
+    "CVS": {
+      "shipped_slug": "cvs",
+      "n_receipts": 5,
+      "n_letters": 2848,
+      "median_cap_px": 13.0,
+      "receipts": [
+        "3be818da-3892-40ae-bf7a-e2d6fffd3f37#1",
+        "74221b69-0121-4047-a152-718007d00a39#1",
+        "86063568-36eb-4ab7-bf05-22f12a60a572#1",
+        "b81f388d-5c6d-459e-a5c5-d38007950ba5#1",
+        "dd30e914-df04-4d71-a359-3d84e386b897#1"
+      ],
+      "scores": {
+        "CURRENT:cvs": {
+          "median_iou": 0.5029,
+          "mean_iou": 0.4708,
+          "n_letters": 2848
+        },
+        "ROM:bitMatrix-C1": {
+          "median_iou": 0.446,
+          "mean_iou": 0.4232,
+          "n_letters": 2848
+        },
+        "ROM:bitMatrix-C1-heavy": {
+          "median_iou": 0.5429,
+          "mean_iou": 0.4967,
+          "n_letters": 2848
+        },
+        "ROM:bitMatrix-D1": {
+          "median_iou": 0.4234,
+          "mean_iou": 0.4139,
+          "n_letters": 2848
+        },
+        "ROM:pixCrog": {
+          "median_iou": 0.4855,
+          "mean_iou": 0.4582,
+          "n_letters": 2848
+        },
+        "ROM:bitMatrix-B2": {
+          "median_iou": 0.4364,
+          "mean_iou": 0.4225,
+          "n_letters": 2848
+        },
+        "ROM:bitArray-A2": {
+          "median_iou": 0.4012,
+          "mean_iou": 0.3899,
+          "n_letters": 2848
+        }
+      },
+      "rom_winner": "bitMatrix-C1-heavy",
+      "rom_winner_iou": 0.5429,
+      "current_iou": 0.5029,
+      "rom_beats_current": true
+    },
+    "Smith's": {
+      "shipped_slug": null,
+      "n_receipts": 6,
+      "n_letters": 4160,
+      "median_cap_px": 15.0,
+      "receipts": [
+        "153e7df4-0bc2-4995-98a1-8c8f6e8bad34#1",
+        "2173f96f-07ca-41cf-afbe-f8a055053d10#1",
+        "3b2cb4f3-6977-40e8-90d8-e7d3d1aac3c2#1",
+        "5884c115-c24e-41eb-ae9b-0e7ee225c45a#1",
+        "abb331f5-5fdb-4868-9e63-331a385dc012#1",
+        "c9b694f7-4112-4197-9a05-6b918c759c70#1"
+      ],
+      "scores": {
+        "ROM:bitMatrix-C1": {
+          "median_iou": 0.3518,
+          "mean_iou": 0.3533,
+          "n_letters": 4160
+        },
+        "ROM:bitMatrix-C1-heavy": {
+          "median_iou": 0.4125,
+          "mean_iou": 0.4068,
+          "n_letters": 4160
+        },
+        "ROM:bitMatrix-D1": {
+          "median_iou": 0.3648,
+          "mean_iou": 0.3579,
+          "n_letters": 4160
+        },
+        "ROM:pixCrog": {
+          "median_iou": 0.4713,
+          "mean_iou": 0.4409,
+          "n_letters": 4160
+        },
+        "ROM:bitMatrix-B2": {
+          "median_iou": 0.4585,
+          "mean_iou": 0.4382,
+          "n_letters": 4160
+        },
+        "ROM:bitArray-A2": {
+          "median_iou": 0.4172,
+          "mean_iou": 0.398,
+          "n_letters": 4160
+        }
+      },
+      "rom_winner": "pixCrog",
+      "rom_winner_iou": 0.4713,
+      "current_iou": null,
+      "rom_beats_current": false
+    },
+    "The Home Depot": {
+      "shipped_slug": "homedepot",
+      "n_receipts": 5,
+      "n_letters": 5487,
+      "median_cap_px": 29.0,
+      "receipts": [
+        "88c1e632-dea6-4331-a6ca-43894ebbd173#1",
+        "a893938d-146c-4381-a00a-88082627f353#1",
+        "d1953a02-b3ea-410d-8f63-4a1859da6b53#1",
+        "e1f519d5-a977-4916-bc2b-0f122564730d#2",
+        "ecfff604-b0af-473c-b3e9-3e22ca2940dd#1"
+      ],
+      "scores": {
+        "CURRENT:homedepot": {
+          "median_iou": 0.3805,
+          "mean_iou": 0.367,
+          "n_letters": 5487
+        },
+        "ROM:bitMatrix-C1": {
+          "median_iou": 0.3759,
+          "mean_iou": 0.3698,
+          "n_letters": 5487
+        },
+        "ROM:bitMatrix-C1-heavy": {
+          "median_iou": 0.399,
+          "mean_iou": 0.3839,
+          "n_letters": 5487
+        },
+        "ROM:bitMatrix-D1": {
+          "median_iou": 0.4263,
+          "mean_iou": 0.4175,
+          "n_letters": 5487
+        },
+        "ROM:pixCrog": {
+          "median_iou": 0.4262,
+          "mean_iou": 0.4043,
+          "n_letters": 5487
+        },
+        "ROM:bitMatrix-B2": {
+          "median_iou": 0.3769,
+          "mean_iou": 0.3644,
+          "n_letters": 5487
+        },
+        "ROM:bitArray-A2": {
+          "median_iou": 0.4075,
+          "mean_iou": 0.3791,
+          "n_letters": 5487
+        }
+      },
+      "rom_winner": "bitMatrix-D1",
+      "rom_winner_iou": 0.4263,
+      "current_iou": 0.3805,
+      "rom_beats_current": true
+    },
+    "Target": {
+      "shipped_slug": "target",
+      "n_receipts": 8,
+      "n_letters": 5483,
+      "median_cap_px": 15.0,
+      "receipts": [
+        "249e7199-d09a-436b-97fa-f226f527f8a0#1",
+        "24a192ed-ef9d-4719-b48b-5064dbedcf1c#1",
+        "2ca22098-11e8-48a3-93a1-5a1a1d07666f#1",
+        "3442685c-4f52-4bf2-879a-5597eee79e12#2",
+        "55423224-094b-48c5-93dd-f40b4d238d72#1",
+        "5925105a-e3e5-4bab-ac6b-d90b643d1994#1",
+        "6d7b9412-1286-48db-ab51-e276168dc110#1",
+        "7104f671-a9ea-4bcf-94fc-e3b631bd047b#1"
+      ],
+      "scores": {
+        "CURRENT:target": {
+          "median_iou": 0.5231,
+          "mean_iou": 0.4814,
+          "n_letters": 5483
+        },
+        "ROM:bitMatrix-C1": {
+          "median_iou": 0.428,
+          "mean_iou": 0.4157,
+          "n_letters": 5483
+        },
+        "ROM:bitMatrix-C1-heavy": {
+          "median_iou": 0.4925,
+          "mean_iou": 0.4669,
+          "n_letters": 5483
+        },
+        "ROM:bitMatrix-D1": {
+          "median_iou": 0.4986,
+          "mean_iou": 0.4614,
+          "n_letters": 5483
+        },
+        "ROM:pixCrog": {
+          "median_iou": 0.524,
+          "mean_iou": 0.4847,
+          "n_letters": 5483
+        },
+        "ROM:bitMatrix-B2": {
+          "median_iou": 0.4541,
+          "mean_iou": 0.4448,
+          "n_letters": 5483
+        },
+        "ROM:bitArray-A2": {
+          "median_iou": 0.4551,
+          "mean_iou": 0.4309,
+          "n_letters": 5483
+        }
+      },
+      "rom_winner": "pixCrog",
+      "rom_winner_iou": 0.524,
+      "current_iou": 0.5231,
+      "rom_beats_current": true
+    },
+    "Whole Foods Market": {
+      "shipped_slug": null,
+      "n_receipts": 6,
+      "n_letters": 3675,
+      "median_cap_px": 17.0,
+      "receipts": [
+        "51245ed8-9930-4e86-ad81-ff25079afe90#1",
+        "9f838ec2-483a-41d0-90bf-95076a6c0572#1",
+        "a1b7d98e-20f8-41cf-8d30-7c3c69e722c2#1",
+        "b77f9d00-8799-4e63-90fa-294def514a96#1",
+        "de60c6a8-3776-4440-9389-7b17df7e417e#1",
+        "e296ec27-4200-4880-a2c4-06ecb1b12290#3"
+      ],
+      "scores": {
+        "ROM:bitMatrix-C1": {
+          "median_iou": 0.4348,
+          "mean_iou": 0.423,
+          "n_letters": 3675
+        },
+        "ROM:bitMatrix-C1-heavy": {
+          "median_iou": 0.5131,
+          "mean_iou": 0.4775,
+          "n_letters": 3675
+        },
+        "ROM:bitMatrix-D1": {
+          "median_iou": 0.54,
+          "mean_iou": 0.4871,
+          "n_letters": 3675
+        },
+        "ROM:pixCrog": {
+          "median_iou": 0.5227,
+          "mean_iou": 0.4843,
+          "n_letters": 3675
+        },
+        "ROM:bitMatrix-B2": {
+          "median_iou": 0.4437,
+          "mean_iou": 0.4381,
+          "n_letters": 3675
+        },
+        "ROM:bitArray-A2": {
+          "median_iou": 0.4449,
+          "mean_iou": 0.4224,
+          "n_letters": 3675
+        }
+      },
+      "rom_winner": "bitMatrix-D1",
+      "rom_winner_iou": 0.54,
+      "current_iou": null,
+      "rom_beats_current": false
+    }
+  }
+}

--- a/synthesis_loop/validate_rom_fonts.py
+++ b/synthesis_loop/validate_rom_fonts.py
@@ -43,6 +43,11 @@ for _p in (
         sys.path.insert(0, _p)
 
 from glyphstudio.family_cluster import normalize_glyph  # noqa: E402
+
+# The M3-canonical vetting metric (identical semantics to every prior vetted
+# run: groups words by rounded geometric y-center, deliberately NOT by OCR
+# line_id, so numbers stay comparable across epics). Imported, not duplicated.
+from m3_acceptance import ocr_overlap_score  # noqa: E402
 from glyphstudio.typography import (  # noqa: E402
     attribution_ious,
     clean_letter_mask,
@@ -58,26 +63,6 @@ DEFAULT_ROMS = [
     "bitMatrix-B2",
     "bitArray-A2",
 ]
-
-
-def ocr_overlap_score(words) -> int:
-    """Same-row word pairs whose x-intervals overlap >30% (M3 vetting)."""
-    rows: dict[float, list[tuple[float, float]]] = {}
-    for w in words:
-        bb = w.get("bbox") or ()
-        if len(bb) != 4:
-            continue
-        y_center = round((bb[1] + bb[3]) / 2000.0, 2)
-        x0, x1 = sorted((bb[0], bb[2]))
-        rows.setdefault(y_center, []).append((x0, x1))
-    bad = 0
-    for spans in rows.values():
-        spans.sort()
-        for (a0, a1), (b0, b1) in zip(spans, spans[1:]):
-            inter = min(a1, b1) - max(a0, b0)
-            if inter > 0.3 * min(a1 - a0, b1 - b0):
-                bad += 1
-    return bad
 
 
 # --- per-receipt crop extraction (cached) ------------------------------------
@@ -187,11 +172,12 @@ def compile_shipped_atlas(slug, out_dir):
     """Compile fonts/<slug> to a temp npz and normalize (shipped baseline)."""
     from glyphstudio.compile import main as compile_main
 
+    # always recompile: it is cheap, and reusing an existing npz would
+    # silently score a stale revision of fonts/<slug>
     npz = os.path.join(out_dir, f"_shipped_{slug}.glyphs.npz")
-    if not os.path.exists(npz):
-        compile_main(
-            [os.path.join(_ROOT, "tools", "glyph-studio", "fonts", slug), npz]
-        )
+    compile_main(
+        [os.path.join(_ROOT, "tools", "glyph-studio", "fonts", slug), npz]
+    )
     data = np.load(npz)
     return {
         chr(int(k[1:])): normalize_glyph(data[k])
@@ -345,7 +331,9 @@ def main(argv=None) -> int:
         )
         report["merchants"][name] = entry
 
-    os.makedirs(os.path.dirname(args.out), exist_ok=True)
+    parent = os.path.dirname(args.out)
+    if parent:
+        os.makedirs(parent, exist_ok=True)
     with open(args.out, "w", encoding="utf-8") as fh:
         json.dump(report, fh, indent=2)
     print(f"\nreport -> {args.out}")

--- a/synthesis_loop/validate_rom_fonts.py
+++ b/synthesis_loop/validate_rom_fonts.py
@@ -1,0 +1,356 @@
+#!/usr/bin/env python3
+"""validate_rom_fonts.py -- match recreated ROM-font atlases against a
+merchant's REAL receipt letter crops, and compare to the merchant's currently
+shipped atlas on the same vetted crops.
+
+Machinery is the typography pilot's (PR #1106): per-letter crops are cleaned
+(``clean_letter_mask``), shape-normalized (``normalize_glyph``, the M2
+aspect-preserving 32x32 space -- which cancels cap-height / scanner-resolution
+differences), and scored by calibrated shifted IoU (``shifted_iou``, +-2 px).
+A font's score against a merchant is the MEDIAN per-letter shifted IoU over all
+that merchant's vetted crops (``ocr_overlap_score`` <= 2, the M3 vetting rule).
+
+Extraction is cached per receipt so network blips resume cheaply. Pure
+measurement: no Dynamo writes, no renders, no publishes.
+
+Usage:
+  python validate_rom_fonts.py \
+      --rom-dir ../.out/rom-fonts \
+      --merchant "Vons:vons" --merchant "CVS:cvs" \
+      --merchant "Smith's:" --merchant "The Home Depot:homedepot" \
+      --merchant "Target:target" --merchant "Whole Foods Market:" \
+      --receipts 8 --out ../.out/rom-fonts/validation.json
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from collections import defaultdict
+from statistics import median
+
+import numpy as np
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_ROOT = os.path.abspath(os.path.join(_HERE, ".."))
+for _p in (
+    _HERE,
+    os.path.join(_ROOT, "receipt_dynamo"),
+    os.path.join(_ROOT, "tools", "glyph-studio", "py"),
+):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from glyphstudio.family_cluster import normalize_glyph  # noqa: E402
+from glyphstudio.typography import (  # noqa: E402
+    attribution_ious,
+    clean_letter_mask,
+    shifted_iou,
+)
+
+CACHE_SCHEMA = 1
+DEFAULT_ROMS = [
+    "bitMatrix-C1",
+    "bitMatrix-C1-heavy",
+    "bitMatrix-D1",
+    "pixCrog",
+    "bitMatrix-B2",
+    "bitArray-A2",
+]
+
+
+def ocr_overlap_score(words) -> int:
+    """Same-row word pairs whose x-intervals overlap >30% (M3 vetting)."""
+    rows: dict[float, list[tuple[float, float]]] = {}
+    for w in words:
+        bb = w.get("bbox") or ()
+        if len(bb) != 4:
+            continue
+        y_center = round((bb[1] + bb[3]) / 2000.0, 2)
+        x0, x1 = sorted((bb[0], bb[2]))
+        rows.setdefault(y_center, []).append((x0, x1))
+    bad = 0
+    for spans in rows.values():
+        spans.sort()
+        for (a0, a1), (b0, b1) in zip(spans, spans[1:]):
+            inter = min(a1, b1) - max(a0, b0)
+            if inter > 0.3 * min(a1 - a0, b1 - b0):
+                bad += 1
+    return bad
+
+
+# --- per-receipt crop extraction (cached) ------------------------------------
+
+
+def _extract_receipt(client, merchant, image_id, receipt_id):
+    """Real receipt -> (chars, normalized bool masks, cap-height px, overlap)."""
+    from receipt_line_scorecard import _load_words_and_real
+
+    from glyph_segment import auto_polarity, sauvola_mask
+
+    real, words = _load_words_and_real(merchant, image_id, receipt_id)
+    overlaps = ocr_overlap_score(words)
+    gray = np.asarray(real.convert("L"))
+    H, W = gray.shape
+    details = client.get_image_details(image_id)
+    letters = [
+        l
+        for l in details.receipt_letters
+        if str(l.receipt_id) == str(receipt_id)
+    ]
+
+    def box_px(obj):
+        tl, br = obj.top_left, obj.bottom_right
+        return (
+            min(tl["x"], br["x"]) * W,
+            (1 - max(tl["y"], br["y"])) * H,
+            max(tl["x"], br["x"]) * W,
+            (1 - min(tl["y"], br["y"])) * H,
+        )
+
+    chars, masks, caps = [], [], []
+    for l in letters:
+        ch = str(l.text or "")[:1]
+        if not ch.strip() or not (33 <= ord(ch) <= 126):
+            continue
+        x0, y0, x1, y1 = box_px(l)
+        xi0, yi0 = max(0, int(x0)), max(0, int(y0))
+        xi1, yi1 = min(W, int(x1) + 1), min(H, int(y1) + 1)
+        if xi1 - xi0 < 3 or yi1 - yi0 < 3:
+            continue
+        crop, _ = auto_polarity(gray[yi0:yi1, xi0:xi1])
+        mask = clean_letter_mask(sauvola_mask(crop))
+        if mask.sum() < 8:
+            continue
+        ys, _xs = np.where(mask)
+        ink_h = float(ys.max() - ys.min() + 1)
+        chars.append(ch)
+        masks.append(normalize_glyph(mask))
+        if ch.isupper() or ch.isdigit():
+            caps.append(ink_h)
+    return chars, masks, caps, overlaps
+
+
+def load_or_extract(client, merchant, slug_key, image_id, receipt_id, cache_dir):
+    os.makedirs(cache_dir, exist_ok=True)
+    path = os.path.join(cache_dir, f"{slug_key}_{image_id}_{receipt_id}.npz")
+    if os.path.exists(path):
+        try:
+            d = np.load(path, allow_pickle=False)
+            if int(d["schema"]) == CACHE_SCHEMA:
+                return (
+                    [str(c) for c in d["chars"]],
+                    list(d["masks"].astype(bool)),
+                    d["caps"].tolist(),
+                    int(d["overlap"]),
+                )
+        except Exception:  # noqa: BLE001 - corrupt/old cache: re-extract
+            pass
+        os.remove(path)
+    chars, masks, caps, overlap = _extract_receipt(
+        client, merchant, image_id, receipt_id
+    )
+    tmp = path + ".tmp"
+    with open(tmp, "wb") as fh:
+        np.savez_compressed(
+            fh,
+            schema=np.int32(CACHE_SCHEMA),
+            chars=np.array(chars, dtype="U1"),
+            masks=(
+                np.stack(masks).astype(bool)
+                if masks
+                else np.zeros((0, 32, 32), bool)
+            ),
+            caps=np.array(caps, dtype=np.float32),
+            overlap=np.int32(overlap),
+        )
+        fh.flush()
+        os.fsync(fh.fileno())
+    os.replace(tmp, path)
+    return chars, masks, caps, overlap
+
+
+# --- atlases -----------------------------------------------------------------
+
+
+def load_rom_atlas(npz_path):
+    data = np.load(npz_path)
+    return {
+        chr(int(k[1:])): normalize_glyph(data[k])
+        for k in data.files
+        if k.startswith("c")
+    }
+
+
+def compile_shipped_atlas(slug, out_dir):
+    """Compile fonts/<slug> to a temp npz and normalize (shipped baseline)."""
+    from glyphstudio.compile import main as compile_main
+
+    npz = os.path.join(out_dir, f"_shipped_{slug}.glyphs.npz")
+    if not os.path.exists(npz):
+        compile_main(
+            [os.path.join(_ROOT, "tools", "glyph-studio", "fonts", slug), npz]
+        )
+    data = np.load(npz)
+    return {
+        chr(int(k[1:])): normalize_glyph(data[k])
+        for k in data.files
+        if k.startswith("c")
+    }
+
+
+# --- scoring -----------------------------------------------------------------
+
+
+def score_atlas(letters, atlas):
+    """Corpus (char, shifted-IoU) pairs + median/mean/n vs one atlas."""
+    ious = attribution_ious(letters, atlas)  # skips chars atlas lacks
+    vals = [v for _, v in ious]
+    per_char = defaultdict(list)
+    for ch, v in ious:
+        per_char[ch].append(v)
+    return {
+        "median_iou": round(float(median(vals)), 4) if vals else None,
+        "mean_iou": round(float(np.mean(vals)), 4) if vals else None,
+        "n_letters": len(vals),
+        "per_char_median": {
+            ch: round(float(median(vs)), 3) for ch, vs in sorted(per_char.items())
+        },
+    }, ious
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--rom-dir", default=os.path.join(_ROOT, ".out", "rom-fonts"))
+    ap.add_argument("--rom", action="append", default=None)
+    ap.add_argument("--merchant", action="append", required=True)
+    ap.add_argument("--receipts", type=int, default=8)
+    ap.add_argument("--max-overlaps", type=int, default=2)
+    ap.add_argument(
+        "--out", default=os.path.join(_ROOT, ".out", "rom-fonts", "validation.json")
+    )
+    ap.add_argument(
+        "--table",
+        default=os.environ.get("DYNAMODB_TABLE_NAME", "ReceiptsTable-dc5be22"),
+    )
+    args = ap.parse_args(argv)
+    os.environ["DYNAMODB_TABLE_NAME"] = args.table
+    cache_dir = os.path.join(args.rom_dir, "cache", args.table)
+
+    rom_names = args.rom or DEFAULT_ROMS
+    roms = {
+        r: load_rom_atlas(os.path.join(args.rom_dir, f"{r}.glyphs.npz"))
+        for r in rom_names
+    }
+    for r, a in roms.items():
+        print(f"ROM {r}: {len(a)} glyphs")
+
+    from receipt_dynamo.data.dynamo_client import DynamoClient
+
+    client = DynamoClient(args.table)
+    report = {"table": args.table, "roms": rom_names, "merchants": {}}
+
+    for pair in args.merchant:
+        name, _, slug = pair.partition(":")
+        slug = slug.strip() or None
+        slug_key = slug or name.lower().replace(" ", "").replace("'", "")
+        print(f"\n===== {name} (shipped slug={slug}) =====")
+        places, _ = client.get_receipt_places_by_merchant(
+            merchant_name=name, limit=80
+        )
+        letters, caps_all, used = [], [], []
+        for p in places:
+            if len(used) >= args.receipts:
+                break
+            try:
+                chars, masks, caps, overlap = load_or_extract(
+                    client, name, slug_key, str(p.image_id), int(p.receipt_id),
+                    cache_dir,
+                )
+            except Exception as e:  # noqa: BLE001
+                print(f"  [skip] {str(p.image_id)[:8]}#{p.receipt_id}: {e}")
+                continue
+            if overlap > args.max_overlaps:
+                print(
+                    f"  [vet] {str(p.image_id)[:8]}#{p.receipt_id}: "
+                    f"overlap={overlap} > {args.max_overlaps}"
+                )
+                continue
+            if not masks:
+                continue
+            letters.extend(zip(chars, masks))
+            caps_all.extend(caps)
+            used.append(f"{p.image_id}#{p.receipt_id}")
+            print(
+                f"  [ok] {str(p.image_id)[:8]}#{p.receipt_id}: "
+                f"{len(masks)} letters, cap~{np.median(caps):.1f}px"
+                if caps else f"  [ok] {str(p.image_id)[:8]}#{p.receipt_id}"
+            )
+        if not letters:
+            print("  no vetted crops; skipping")
+            report["merchants"][name] = {"error": "no vetted crops"}
+            continue
+
+        cap_med = float(np.median(caps_all)) if caps_all else None
+        entry = {
+            "shipped_slug": slug,
+            "n_receipts": len(used),
+            "n_letters": len(letters),
+            "median_cap_px": round(cap_med, 1) if cap_med else None,
+            "receipts": used,
+            "scores": {},
+        }
+        # shipped baseline
+        if slug:
+            try:
+                shipped = compile_shipped_atlas(slug, args.rom_dir)
+                s, _ = score_atlas(letters, shipped)
+                entry["scores"]["CURRENT:" + slug] = s
+                print(
+                    f"  CURRENT ({slug}): median_iou={s['median_iou']} "
+                    f"n={s['n_letters']}"
+                )
+            except Exception as e:  # noqa: BLE001
+                print(f"  CURRENT ({slug}) failed: {e}")
+                entry["scores"]["CURRENT:" + slug] = {"error": str(e)}
+        # ROM candidates
+        for r, atlas in roms.items():
+            s, _ = score_atlas(letters, atlas)
+            entry["scores"]["ROM:" + r] = s
+            print(f"  ROM {r:20s}: median_iou={s['median_iou']} n={s['n_letters']}")
+
+        rom_scores = {
+            r: entry["scores"]["ROM:" + r]["median_iou"]
+            for r in roms
+            if entry["scores"]["ROM:" + r]["median_iou"] is not None
+        }
+        winner = max(rom_scores, key=rom_scores.get) if rom_scores else None
+        entry["rom_winner"] = winner
+        entry["rom_winner_iou"] = rom_scores.get(winner) if winner else None
+        cur = (
+            entry["scores"].get("CURRENT:" + slug, {}).get("median_iou")
+            if slug
+            else None
+        )
+        entry["current_iou"] = cur
+        entry["rom_beats_current"] = (
+            (entry["rom_winner_iou"] is not None and cur is not None
+             and entry["rom_winner_iou"] > cur)
+        )
+        print(
+            f"  => winner ROM={winner} ({entry['rom_winner_iou']}) "
+            f"vs current={cur} "
+            f"beats={entry['rom_beats_current']}"
+        )
+        report["merchants"][name] = entry
+
+    os.makedirs(os.path.dirname(args.out), exist_ok=True)
+    with open(args.out, "w", encoding="utf-8") as fh:
+        json.dump(report, fh, indent=2)
+    print(f"\nreport -> {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/glyph-studio/py/glyphstudio/typography.py
+++ b/tools/glyph-studio/py/glyphstudio/typography.py
@@ -1,0 +1,561 @@
+"""Per-line typography: font attribution, typeface discovery, style runs.
+
+Pilot layer over the M2 shape toolchain (``family_cluster``): given per-letter
+crops of a receipt line, does the line's lettering match the merchant's known
+body atlas? Lines that match poorly are candidates for a *different* typeface
+within the same receipt (Wild Fork mixes faces in its body; Sprouts prints a
+serif display wordmark above a mono body). Poorly-attributed lines are then
+clustered in the same normalized shape space to *discover* the merchant's
+typeface set T1..Tk, and contiguous lines sharing (typeface, tier,
+underline, reverse-video) are grouped into STYLE RUNS — the orthogonal
+per-line typography layer that semantic sections correlate with but do not
+determine.
+
+Everything here is pure numpy on masks/records; network + pixels live in the
+CLI (``typography_runs.py``). Shape normalization and IoU come from
+``family_cluster`` (aspect-preserving, the M2 convention).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from statistics import median
+from typing import Optional, Sequence
+
+import numpy as np
+
+from glyphstudio.family_cluster import glyph_iou, normalize_glyph
+
+__all__ = [
+    "clean_letter_mask",
+    "shifted_iou",
+    "attribution_ious",
+    "line_attribution",
+    "per_char_medians",
+    "calibrated_deviation",
+    "estimate_slant",
+    "line_slant",
+    "DIAGONAL_CHARS",
+    "intra_line_overlap",
+    "LineShape",
+    "cluster_line_shapes",
+    "exemplar_glyphs",
+    "assign_tiers",
+    "build_style_runs",
+    "section_run_crosstab",
+]
+
+
+# --- per-crop cleaning -----------------------------------------------------
+
+
+def connected_components(mask: np.ndarray) -> list[np.ndarray]:
+    """4-connected components of a boolean mask, as boolean masks."""
+    from collections import deque
+
+    m = np.asarray(mask, dtype=bool)
+    h, w = m.shape
+    lbl = np.zeros((h, w), np.int32)
+    comps: list[np.ndarray] = []
+    for y in range(h):
+        for x in range(w):
+            if m[y, x] and not lbl[y, x]:
+                q = deque([(y, x)])
+                lbl[y, x] = len(comps) + 1
+                pix = [(y, x)]
+                while q:
+                    cy, cx = q.popleft()
+                    for ny, nx in (
+                        (cy - 1, cx),
+                        (cy + 1, cx),
+                        (cy, cx - 1),
+                        (cy, cx + 1),
+                    ):
+                        if (
+                            0 <= ny < h
+                            and 0 <= nx < w
+                            and m[ny, nx]
+                            and not lbl[ny, nx]
+                        ):
+                            lbl[ny, nx] = len(comps) + 1
+                            q.append((ny, nx))
+                            pix.append((ny, nx))
+                cm = np.zeros((h, w), bool)
+                ys, xs = zip(*pix)
+                cm[list(ys), list(xs)] = True
+                comps.append(cm)
+    return comps
+
+
+def clean_letter_mask(mask: np.ndarray) -> np.ndarray:
+    """Strip neighbor bleed, specks, and rule fragments from a letter crop.
+
+    OCR letter boxes span the full line height and routinely clip fragments of
+    the adjacent letters; ``normalize_glyph`` crops to the FULL ink bbox, so a
+    3-px neighbor fragment at the crop edge shreds the normalized shape (IoU
+    vs the atlas drops from ~0.55 to ~0.1 — measured on Wild Fork line 6).
+    Median-vote atlas builds absorb this across hundreds of samples; per-line
+    attribution cannot, so clean each crop:
+
+    - drop components with x-centroid in the outer 12% of the crop (neighbor
+      bleed hugs the left/right edges),
+    - drop specks (< max(3 px, 2% of ink)),
+    - drop flat full-width components (<=2 px tall, >=85% of crop width:
+      underline / separator-rule fragments).
+
+    Vertically stacked parts (i/j dots, colons) survive because their
+    x-centroid is central. If EVERY component is disqualified (a lone dash
+    filling the crop, a single letter hugging the edge of a tight box) the
+    largest is kept — an empty mask helps nobody — but a rule fragment that
+    happens to out-weigh the letter no longer gets a free pass.
+    """
+    m = np.asarray(mask, dtype=bool)
+    if not m.any():
+        return m
+    h, w = m.shape
+    comps = connected_components(m)
+    total = int(m.sum())
+    keep = np.zeros_like(m)
+    for c in comps:
+        n = int(c.sum())
+        ys, xs = np.where(c)
+        cx = float(xs.mean()) / max(1, w - 1)
+        ch = ys.max() - ys.min() + 1
+        cw = xs.max() - xs.min() + 1
+        if n < max(3, 0.02 * total):
+            continue
+        if cx < 0.12 or cx > 0.88:
+            continue
+        if ch <= 2 and cw >= 0.85 * w:
+            continue
+        keep |= c
+    if not keep.any():
+        keep = max(comps, key=lambda c: int(c.sum()))
+    return keep
+
+
+# --- attribution -----------------------------------------------------------
+
+
+def _shift(mask: np.ndarray, dy: int, dx: int) -> np.ndarray:
+    """Translate a boolean mask, zero-filling exposed pixels (no wrap:
+    normalized glyphs touch the canvas edges, so ``np.roll`` would smuggle
+    edge ink onto the opposite side and fake intersections)."""
+    out = np.zeros_like(mask)
+    h, w = mask.shape
+    ys0, ys1 = max(0, dy), min(h, h + dy)
+    xs0, xs1 = max(0, dx), min(w, w + dx)
+    out[ys0:ys1, xs0:xs1] = mask[
+        max(0, -dy) : min(h, h - dy), max(0, -dx) : min(w, w - dx)
+    ]
+    return out
+
+
+def shifted_iou(a: np.ndarray, b: np.ndarray, max_shift: int = 2) -> float:
+    """Max IoU of ``a`` over ``b`` across integer shifts of +-``max_shift``.
+
+    Segmentation jitter moves ink a pixel or two inside the normalized grid;
+    plain IoU punishes that as shape difference. Small-shift tolerance keeps
+    the metric about letterform, not box placement.
+    """
+    best = 0.0
+    bb = np.asarray(b, dtype=bool)
+    aa = np.asarray(a, dtype=bool)
+    for dy in range(-max_shift, max_shift + 1):
+        for dx in range(-max_shift, max_shift + 1):
+            best = max(best, glyph_iou(_shift(aa, dy, dx), bb))
+    return best
+
+
+def attribution_ious(
+    letters: Sequence[tuple[str, np.ndarray]],
+    atlas: dict[str, np.ndarray],
+    max_shift: int = 2,
+) -> list[tuple[str, float]]:
+    """Per-letter (char, shifted IoU vs atlas) for a line; skips chars the
+    atlas lacks."""
+    return [
+        (ch, shifted_iou(g, atlas[ch], max_shift))
+        for ch, g in letters
+        if ch in atlas
+    ]
+
+
+def line_attribution(
+    letters: Sequence[tuple[str, np.ndarray]],
+    atlas: dict[str, np.ndarray],
+    min_letters: int = 4,
+    max_shift: int = 2,
+) -> tuple[Optional[float], int]:
+    """Median per-letter shifted IoU of a line's normalized glyphs vs an atlas.
+
+    ``letters`` is (char, normalized 2D bool mask) pairs; chars missing from
+    the atlas are skipped. Returns (score, n_used); score None when fewer
+    than ``min_letters`` usable letters (distributions, not n=1).
+    """
+    vals = [v for _, v in attribution_ious(letters, atlas, max_shift)]
+    if len(vals) < min_letters:
+        return None, len(vals)
+    return float(median(vals)), len(vals)
+
+
+def per_char_medians(
+    ious: Sequence[tuple[str, float]], min_samples: int = 10
+) -> dict[str, float]:
+    """Median atlas-IoU per character over a merchant's whole vetted corpus.
+
+    The body face dominates every receipt, so this is each char's *body*
+    matching level — including the atlas's own per-char weaknesses (a traced
+    'e' that only ever hits 0.41, a '.' at 0.21). Raw line medians confuse
+    those weaknesses with typeface changes: 'Tender:' is built almost
+    entirely from weak chars and false-flagged as a second face until each
+    letter is judged against its own char's norm.
+    """
+    by_char: dict[str, list[float]] = {}
+    for ch, v in ious:
+        by_char.setdefault(ch, []).append(v)
+    return {
+        ch: float(median(vs))
+        for ch, vs in by_char.items()
+        if len(vs) >= min_samples
+    }
+
+
+def calibrated_deviation(
+    ious: Sequence[tuple[str, float]],
+    char_medians: dict[str, float],
+    min_letters: int = 4,
+) -> Optional[float]:
+    """Median per-letter deviation from each char's own corpus norm.
+
+    ~0 for body lines regardless of char mix; strongly negative when the
+    letterforms genuinely differ from the atlas. Chars without a corpus norm
+    are skipped. None when fewer than ``min_letters`` usable letters.
+    """
+    devs = [v - char_medians[ch] for ch, v in ious if ch in char_medians]
+    if len(devs) < min_letters:
+        return None
+    return float(median(devs))
+
+
+# --- slant / italic probe ---------------------------------------------------
+
+
+def estimate_slant(
+    mask: np.ndarray, max_deg: float = 30.0, step: float = 1.0
+) -> float:
+    """Dominant stroke slant of one glyph, in degrees (positive = italic
+    rightward lean), by shear search.
+
+    Shear the ink by candidate angles and score the sharpness of the column
+    projection (sum of squared column counts); vertical strokes concentrate
+    ink into few columns exactly when the shear cancels their lean. Upright
+    text peaks at 0; true italics peak at +8..+20.
+    """
+    m = np.asarray(mask, dtype=bool)
+    ys, xs = np.where(m)
+    if ys.size < 8:
+        return 0.0
+    h = ys.max() - ys.min() + 1
+    if h < 4:
+        return 0.0
+    yc = (ys.max() + ys.min()) / 2.0
+    best_deg, best_score = 0.0, -1.0
+    # candidates ordered by |deg|: on a tie (thin strokes quantize identically
+    # across small angles) the most-upright interpretation wins.
+    degs = sorted(np.arange(-max_deg, max_deg + 1e-6, step), key=abs)
+    for deg in degs:
+        t = np.tan(np.radians(deg))
+        sheared = np.round(xs + t * (ys - yc)).astype(int)
+        _, counts = np.unique(sheared, return_counts=True)
+        score = float((counts.astype(float) ** 2).sum())
+        if score > best_score:
+            best_score, best_deg = score, float(deg)
+    # Image y grows DOWNWARD, so a rightward (italic) lean has larger x at
+    # smaller y; the shear that straightens it (x + tan(deg)*(y - yc)) then
+    # has deg > 0. Positive result = rightward lean, as typographers expect.
+    return best_deg
+
+
+# Letterforms whose strokes are legitimately diagonal: a line of card-mask
+# X's "leans" ~14deg to the shear probe without any italic intent. Excluded
+# from line-level slant so the italic finding measures the typeface, not the
+# letter inventory.
+DIAGONAL_CHARS = set("AKMNRVWXYZkvwxyz/\\%*<>")
+
+
+def line_slant(
+    slants: Sequence[tuple[str, float]], min_glyphs: int = 3
+) -> Optional[float]:
+    """Median per-glyph slant over a line, from (char, slant_deg) pairs.
+
+    Skips ``DIAGONAL_CHARS`` and NaNs (glyphs too short to lean)."""
+    vals = [
+        s
+        for ch, s in slants
+        if ch not in DIAGONAL_CHARS and s == s  # NaN-safe
+    ]
+    if len(vals) < min_glyphs:
+        return None
+    return float(median(vals))
+
+
+# --- contamination (overlap-stamped OCR, e.g. Sprouts wordmark) -------------
+
+
+def intra_line_overlap(boxes: Sequence[tuple[float, float, float, float]]) -> float:
+    """Fraction of a line's letter boxes whose x-span overlaps ANY other
+    box on the line by >30% (of the smaller box).
+
+    Overlap-contaminated regions (the Sprouts wordmark double-strike) stamp
+    letter boxes on top of each other; their crops are unusable for shape
+    attribution and must be flagged EXPLICITLY, not silently misattributed.
+    Boxes are (x0, y0, x1, y1). All pairs are checked (double-strike passes
+    are not adjacent after sorting), and both members of a bad pair count.
+    """
+    if len(boxes) < 2:
+        return 0.0
+    spans = [(min(b[0], b[2]), max(b[0], b[2])) for b in boxes]
+    bad = [False] * len(spans)
+    for i in range(len(spans)):
+        for j in range(i + 1, len(spans)):
+            a0, a1 = spans[i]
+            b0, b1 = spans[j]
+            inter = min(a1, b1) - max(a0, b0)
+            smaller = min(a1 - a0, b1 - b0)
+            if smaller > 0 and inter > 0.3 * smaller:
+                bad[i] = bad[j] = True
+    return sum(bad) / len(spans)
+
+
+# --- within-merchant typeface discovery -------------------------------------
+
+
+@dataclass
+class LineShape:
+    """A line's letterforms in normalized shape space, for clustering."""
+
+    key: str  # e.g. "<image8>#<rid>:<visual line idx>"
+    glyphs: dict[str, np.ndarray]  # char -> normalized bool mask (median-voted)
+    text: str = ""
+
+
+def _median_vote(stack: list[np.ndarray]) -> np.ndarray:
+    return np.mean(np.stack(stack).astype(float), axis=0) >= 0.5
+
+
+def line_shape(
+    key: str, letters: Sequence[tuple[str, np.ndarray]], text: str = ""
+) -> LineShape:
+    """Collapse a line's (char, normalized mask) pairs into per-char votes."""
+    by_char: dict[str, list[np.ndarray]] = {}
+    for ch, g in letters:
+        by_char.setdefault(ch, []).append(np.asarray(g, dtype=bool))
+    return LineShape(
+        key=key,
+        glyphs={ch: _median_vote(gs) for ch, gs in by_char.items()},
+        text=text,
+    )
+
+
+def line_pair_iou(
+    a: LineShape, b: LineShape, max_shift: int = 2
+) -> tuple[float, int]:
+    """Mean shifted IoU over the chars two lines share."""
+    shared = sorted(set(a.glyphs) & set(b.glyphs))
+    if not shared:
+        return 0.0, 0
+    vals = [shifted_iou(a.glyphs[ch], b.glyphs[ch], max_shift) for ch in shared]
+    return float(np.mean(vals)), len(shared)
+
+
+def cluster_line_shapes(
+    lines: Sequence[LineShape],
+    threshold: float = 0.45,
+    min_shared: int = 3,
+    max_shift: int = 2,
+) -> list[list[int]]:
+    """Single-linkage clustering of lines by shared-letterform IoU.
+
+    Union-find over pairs with mean IoU >= ``threshold`` on >= ``min_shared``
+    shared chars (evidence gate, same rationale as M2's family clustering: a
+    single coincidental glyph must not merge typefaces). Returns clusters as
+    lists of indices into ``lines``, largest first; singletons included.
+    """
+    n = len(lines)
+    parent = list(range(n))
+
+    def find(x: int) -> int:
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = parent[x]
+        return x
+
+    for i in range(n):
+        for j in range(i + 1, n):
+            iou, shared = line_pair_iou(lines[i], lines[j], max_shift)
+            if shared >= min_shared and iou >= threshold:
+                parent[find(i)] = find(j)
+
+    groups: dict[int, list[int]] = {}
+    for i in range(n):
+        groups.setdefault(find(i), []).append(i)
+    return sorted(groups.values(), key=len, reverse=True)
+
+
+def exemplar_glyphs(
+    members: Sequence[LineShape], min_votes: int = 2
+) -> dict[str, np.ndarray]:
+    """Per-char median-voted exemplar over a cluster's lines.
+
+    Chars seen on fewer than ``min_votes`` member lines are skipped for
+    clusters of >=2 lines (a one-line vote is just that line back again).
+    """
+    by_char: dict[str, list[np.ndarray]] = {}
+    for ls in members:
+        for ch, g in ls.glyphs.items():
+            by_char.setdefault(ch, []).append(g)
+    need = min_votes if len(members) >= 2 else 1
+    return {
+        ch: _median_vote(gs) for ch, gs in by_char.items() if len(gs) >= need
+    }
+
+
+# --- tiers (receipt-relative, ported convention from stylescan) --------------
+
+
+def assign_tiers(
+    lines: Sequence[dict],
+    cap_key: str = "cap_px",
+    stroke_key: str = "stroke_med",
+    large_ratio: float = 1.45,
+    bold_ratio: float = 1.30,
+) -> tuple[Optional[float], Optional[float]]:
+    """Set ``line["tier"]`` in place: normal / bold / large.
+
+    stylescan's convention (receipt-relative so scanner exposure cancels),
+    with one pilot deviation: the body reference is the median over ALL
+    measured lines instead of section-classified body lines — this layer is
+    deliberately section-blind. Returns (body_cap, body_stroke).
+    """
+    caps = [l[cap_key] for l in lines if l.get(cap_key)]
+    strokes = [l[stroke_key] for l in lines if l.get(stroke_key)]
+    body_cap = median(caps) if caps else None
+    body_stroke = median(strokes) if strokes else None
+    for l in lines:
+        tier = "normal"
+        if body_cap and l.get(cap_key) and l[cap_key] >= large_ratio * body_cap:
+            tier = "large"
+        elif (
+            body_stroke
+            and l.get(stroke_key)
+            and l[stroke_key] >= bold_ratio * body_stroke
+        ):
+            tier = "bold"
+        l["tier"] = tier
+    return body_cap, body_stroke
+
+
+# --- style runs --------------------------------------------------------------
+
+
+@dataclass
+class StyleRun:
+    """A maximal contiguous block of lines sharing one typographic style."""
+
+    run_id: int
+    typeface: str
+    tier: str
+    underline: bool
+    reverse_video: bool
+    line_indices: list[int] = field(default_factory=list)
+    line_ids: list[int] = field(default_factory=list)
+
+    def style_key(self) -> tuple:
+        return (self.typeface, self.tier, self.underline, self.reverse_video)
+
+
+def build_style_runs(lines: Sequence[dict]) -> list[StyleRun]:
+    """Group contiguous measured lines sharing (typeface, tier, underline,
+    reverse_video) into runs.
+
+    ``lines`` are visual-line records in top-to-bottom order with keys
+    ``typeface``, ``tier``, ``underline``, ``reverse_video``, ``line_ids``.
+    Lines with typeface None (too few letters to attribute) or ``"X"``
+    (overlap-contaminated — excluded, never attributed) are transparent:
+    they don't break a run and belong to no run, so they can't fabricate
+    multi-style sections in the crosstab.
+    """
+    runs: list[StyleRun] = []
+    for idx, l in enumerate(lines):
+        if l.get("typeface") in (None, "X"):
+            continue
+        key = (
+            l["typeface"],
+            l.get("tier", "normal"),
+            bool(l.get("underline")),
+            bool(l.get("reverse_video")),
+        )
+        if runs and runs[-1].style_key() == key:
+            runs[-1].line_indices.append(idx)
+            runs[-1].line_ids.extend(l.get("line_ids", []))
+        else:
+            runs.append(
+                StyleRun(
+                    run_id=len(runs),
+                    typeface=key[0],
+                    tier=key[1],
+                    underline=key[2],
+                    reverse_video=key[3],
+                    line_indices=[idx],
+                    line_ids=list(l.get("line_ids", [])),
+                )
+            )
+    return runs
+
+
+def section_run_crosstab(
+    sections: Sequence[dict], runs: Sequence[StyleRun]
+) -> list[dict]:
+    """Cross-tab semantic sections vs style runs.
+
+    ``sections`` are dicts with ``section_type`` and ``line_ids`` (the QA'd
+    ReceiptSection rows). For each section: which runs its lines fall into,
+    over the lines that were typographically measured at all. A section
+    spanning >1 run is the quantified evidence that semantic sections do not
+    determine typography.
+    """
+    line_to_run: dict[int, int] = {}
+    for r in runs:
+        for lid in r.line_ids:
+            line_to_run[lid] = r.run_id
+    out = []
+    for s in sections:
+        run_ids = sorted(
+            {line_to_run[lid] for lid in s["line_ids"] if lid in line_to_run}
+        )
+        measured = [lid for lid in s["line_ids"] if lid in line_to_run]
+        styles = {runs[rid].style_key() for rid in run_ids}
+        out.append(
+            {
+                "section_type": s["section_type"],
+                "n_lines": len(s["line_ids"]),
+                "n_measured": len(measured),
+                "run_ids": run_ids,
+                "n_runs": len(run_ids),
+                "typefaces": sorted(
+                    {runs[rid].typeface for rid in run_ids}
+                ),
+                # multi_run: split across runs (includes being interrupted by
+                # a different-styled block). multi_style: the section itself
+                # contains >1 distinct (typeface, tier, underline, reverse)
+                # style — the direct "sections don't determine typography"
+                # evidence. multi_typeface: strongest form, >1 letterform set.
+                "multi_run": len(run_ids) > 1,
+                "n_styles": len(styles),
+                "multi_style": len(styles) > 1,
+                "multi_typeface": len({runs[rid].typeface for rid in run_ids})
+                > 1,
+            }
+        )
+    return out


### PR DESCRIPTION
## What

Recreates the six identified receipt-printer ROM fonts from their published specimen charts (the exact pipeline that produced our best atlas, Costco's bitMatrix-C2) and validates each against real receipt letter crops of the merchants hypothesized to use them (receiptfont.com's matched catalog).

### Extraction (`synthesis_loop/extract_bitmatrix.py`)

Generalizes the Costco bitMatrix-C2 chart extractor to the whole specimen family:
- **Guide color**: C2/pixCrog rule the grid in blue, C1/C1-heavy/D1/B2/A2 in green — the black-only glyph mask (r,g,b < 70) ignores both, no per-chart tuning.
- **Codepoint mapping**: C2's `34 + i*17 + c` formula only holds for its left-aligned layout. The green charts are right-aligned and continue past `~` into Latin-1. Replaced with reading-order assignment: first inked cell = `!` (0x21), each subsequent inked cell takes the next ASCII code, capped at `~` (0x7E). Latin-1 tail dropped (receipt text is ASCII).

All six charts extract the **full 94-glyph printable-ASCII set** (verified visually against the charts). `.glyphs.npz` atlases stay local (gitignored); per-font JSON manifests (chart source, grid params, coverage) are tracked in `synthesis_loop/rom_font_manifests/`.

### Validation (`synthesis_loop/validate_rom_fonts.py`)

The typography pilot's calibrated machinery (PR #1106, vendored `glyphstudio/typography.py`): per-letter crops cleaned (`clean_letter_mask`), shape-normalized (`normalize_glyph`, M2 aspect-preserving space — cancels cap-height differences), scored by shifted IoU (±2 px). Vetted receipts only (`ocr_overlap_score <= 2`). Per-receipt cached extraction.

**Merchant × font matrix** (median shifted-IoU; winner bold):

| merchant | crops (receipts) | CURRENT atlas | C1 | **C1-heavy** | D1 | pixCrog | B2 | A2 | verdict |
|---|---|---|---|---|---|---|---|---|---|
| Vons | 4,814 (8) | 0.596 | 0.553 | **0.620** | 0.476 | 0.567 | 0.507 | 0.486 | hypothesis CONFIRMED (heavy variant), beats current |
| CVS | 2,848 (5) | 0.503 | 0.446 | **0.543** | 0.423 | 0.486 | 0.436 | 0.401 | hypothesis CONFIRMED (heavy variant), beats current |
| Smith's | 4,160 (6) | — (VT323 vector) | 0.352 | 0.413 | 0.365 | **0.471** | 0.459 | 0.417 | **pixCrog wins, not C1** — the alternate Kroger hypothesis |
| The Home Depot | 5,487 (5) | 0.381 | 0.376 | 0.399 | **0.426** | 0.426 | 0.377 | 0.408 | D1 confirmed (pixCrog statistical tie), beats current |
| Target | 5,483 (8) | 0.523 | 0.428 | 0.493 | 0.499 | **0.524** | 0.454 | 0.455 | **D1 REFUTED** — pixCrog wins, ties current |
| Whole Foods | 3,675 (6) | — (no shipped atlas) | 0.435 | 0.513 | **0.540** | 0.523 | 0.444 | 0.445 | **Epson-default (B2/A2) REFUTED** — D1 wins |

**Cross-check reproduced**: CVS and Vons share the same winner (bitMatrix-C1-heavy) with the same runner-up ordering — the M2 family clustering's tightest pair (0.62–0.73), now confirmed from the font side.

### Render proof (`synthesis_loop/render_rom_proof.py`)

REAL | CURRENT | ROM-FONT side-by-side, one vetted golden receipt each (scratch profile, `RECEIPT_PAPER_STRENGTH=0.3`, dev table):
- **Vons** (`.out/rom-fonts/proof_vons.png`, bitMatrix-C1-heavy): letterforms track real closely; **scale defect (task #25) persists independent of glyphs** — REAL h_med 27.0px vs CURRENT 36.5px (×1.35) vs ROM 36.0px (×1.33). The oversize comes from the sizing knobs (`ocr_cap_height_ratio` path), not the atlas. ROM ink density 0.173 ≈ real 0.170 (current 0.156).
- **Smith's** (`.out/rom-fonts/proof_smiths.png`, pixCrog): dramatic improvement over the VT323 current render — pixCrog's blocky letterforms visibly match the real Kroger print.

No publishes; extraction/validation are pure measurement (no Dynamo writes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SRtFcxkcw1t3nZsVHstZGL