### PR TITLE
Gold-standard benchmark harness (L0-L4 ladder) + Costco baseline record

### DIFF
--- a/tools/glyph-studio/py/baselines/costco_gold.baseline.2026-07-11.json
+++ b/tools/glyph-studio/py/baselines/costco_gold.baseline.2026-07-11.json
@@ -1,8 +1,9 @@
 {
   "merchant": "costco",
   "date": "2026-07-11",
-  "render": "/Users/tnorlund/Portfolio-gold-harness/portfolio/public/synthetic-receipts/pipeline/costco/final.webp",
-  "real": "/Users/tnorlund/Portfolio-gold-harness/portfolio/public/synthetic-receipts/pipeline/costco/real.webp",
+  "tool": "costco_gold.py",
+  "render": "portfolio/public/synthetic-receipts/pipeline/costco/final.webp",
+  "real": "portfolio/public/synthetic-receipts/pipeline/costco/real.webp",
   "canvas": [
     760,
     2999
@@ -221,7 +222,7 @@
       "dir": "p_min",
       "pass": false
     },
-    "kanungo_distance": 0.15853870431893693,
+    "kanungo_distance": 0.16562745098039217,
     "pass": false
   },
   "L4": {
@@ -251,8 +252,8 @@
       "render": 0.6447368421052632
     },
     "ocr_cer": {
-      "real": 0.20017597888253413,
-      "render": 0.2549019607843137
+      "real": 0.23330887747615553,
+      "render": 0.31988261188554656
     },
     "ocr_error_classes": {
       "shared": 32,
@@ -263,5 +264,5 @@
     "pass": false
   },
   "overall_rung_cleared": "L0-fail",
-  "elapsed_sec": 13.8
+  "elapsed_sec": 14.1
 }

--- a/tools/glyph-studio/py/baselines/costco_gold.baseline.2026-07-11.json
+++ b/tools/glyph-studio/py/baselines/costco_gold.baseline.2026-07-11.json
@@ -1,0 +1,267 @@
+{
+  "merchant": "costco",
+  "date": "2026-07-11",
+  "render": "/Users/tnorlund/Portfolio-gold-harness/portfolio/public/synthetic-receipts/pipeline/costco/final.webp",
+  "real": "/Users/tnorlund/Portfolio-gold-harness/portfolio/public/synthetic-receipts/pipeline/costco/real.webp",
+  "canvas": [
+    760,
+    2999
+  ],
+  "glyphscore_root": "/private/tmp/glyphscore",
+  "aligned": true,
+  "align_residual_px": 16.2,
+  "n_anchors": 51,
+  "L0": {
+    "ink_ratio": {
+      "value": 1.3672646480250314,
+      "target": 1.0,
+      "tol": 0.05,
+      "dir": "band",
+      "pass": false
+    },
+    "fill_render": {
+      "value": 0.220703125,
+      "target": 0.271,
+      "tol": 0.01,
+      "dir": "band",
+      "pass": false
+    },
+    "fill_real_ref": 0.25390625,
+    "cap_h_ratio": {
+      "value": 1.1674332573586204,
+      "target": 1.0,
+      "tol": 0.03,
+      "dir": "band",
+      "pass": false
+    },
+    "pitch_ratio": {
+      "value": 0.9928537885976523,
+      "target": 1.0,
+      "tol": 0.02,
+      "dir": "band",
+      "pass": true
+    },
+    "cap_h_px": {
+      "render": 35.81011040521652,
+      "real": 30.67422499701507
+    },
+    "pitch_px": {
+      "render": 44.3519716027911,
+      "real": 44.6712014519637
+    },
+    "interline_fill": {
+      "render": 0.8074074074074075,
+      "real": 0.6866666666666666
+    },
+    "pass": false
+  },
+  "L1": {
+    "gs_vs_crops": {
+      "value": 37.02350031445394,
+      "target": 50.0,
+      "tol": 5.0,
+      "dir": "min",
+      "pass": false
+    },
+    "gs_vs_chart": 76.9261078267169,
+    "iou_re": 0.5497502701985487,
+    "iou_rc": 0.6741329678763287,
+    "iou_ce": 0.6238213760723995,
+    "iou_rc_hygiene": {
+      "value": 0.6962139195545568,
+      "target": 0.536,
+      "tol": 0.05,
+      "dir": "band",
+      "pass": false
+    },
+    "iou_re_hygiene": 0.5596531184888861,
+    "self_agreement_ref": 0.87,
+    "worst_after_hygiene": [
+      {
+        "char": "L",
+        "rc": 0.077,
+        "ce": 0.744,
+        "n": 122
+      },
+      {
+        "char": "d",
+        "rc": 0.382,
+        "ce": 0.684,
+        "n": 37
+      },
+      {
+        "char": "H",
+        "rc": 0.417,
+        "ce": 0.713,
+        "n": 72
+      },
+      {
+        "char": "g",
+        "rc": 0.427,
+        "ce": 0.523,
+        "n": 22
+      },
+      {
+        "char": "o",
+        "rc": 0.427,
+        "ce": 0.432,
+        "n": 73
+      },
+      {
+        "char": "y",
+        "rc": 0.446,
+        "ce": 0.551,
+        "n": 10
+      },
+      {
+        "char": "U",
+        "rc": 0.448,
+        "ce": 0.578,
+        "n": 62
+      },
+      {
+        "char": "M",
+        "rc": 0.466,
+        "ce": 0.579,
+        "n": 77
+      }
+    ],
+    "segmentation": "212/219",
+    "pass": false
+  },
+  "L2": {
+    "chamfer_dots": 0.6768863136004138,
+    "boundary_iou": 0.36764586083465356,
+    "advance_ratio": {
+      "value": 1.022676142636168,
+      "target": 1.0,
+      "tol": 0.05,
+      "dir": "max",
+      "pass": true
+    },
+    "advance_px": {
+      "render": 20.46373630266952,
+      "real": 20.009986983679735
+    },
+    "price_std_px": {
+      "value": 5.582333649970399,
+      "target": 8.0,
+      "tol": 0.0,
+      "dir": "max",
+      "pass": true
+    },
+    "barcode_caption_ratio": {
+      "value": 0.9824611508940304,
+      "target": 1.0,
+      "tol": 0.05,
+      "dir": "band",
+      "pass": true
+    },
+    "cap_h_ratio": {
+      "value": 1.1674332573586204,
+      "target": 1.0,
+      "tol": 0.03,
+      "dir": "band",
+      "pass": false
+    },
+    "interline_fill": {
+      "render": 0.8074074074074075,
+      "real": 0.6866666666666666
+    },
+    "pass": false
+  },
+  "L3": {
+    "ink_darkness": {
+      "value": 10.806543450357367,
+      "target": 63.0,
+      "tol": 6.0,
+      "dir": "band",
+      "pass": false,
+      "real_measured": 63.0,
+      "spec_target": 69.0
+    },
+    "stroke_cov": {
+      "value": 0.04330392106820224,
+      "target": 0.1338306461501223,
+      "tol": 0.06,
+      "dir": "band",
+      "pass": false,
+      "real_measured": 0.1338306461501223,
+      "spec_target": 0.35
+    },
+    "edge_transition_frac": {
+      "value": 0.18303563846349818,
+      "target": 0.3540884074429982,
+      "tol": 0.05,
+      "dir": "band",
+      "pass": false,
+      "real_measured": 0.3540884074429982,
+      "spec_target": 0.16
+    },
+    "paper_clip_frac": {
+      "value": 0.01647953216374269,
+      "target": 0.4523040935672515,
+      "tol": 0.1,
+      "dir": "band",
+      "pass": false,
+      "real_measured": 0.4523040935672515,
+      "spec_target": 0.55
+    },
+    "ink_tone_emd": {
+      "value": 12.409867964181279,
+      "target": 0.0,
+      "tol": 3.0,
+      "dir": "max",
+      "pass": false
+    },
+    "kanungo_p": {
+      "value": 0.009900990099009901,
+      "target": 0.05,
+      "tol": 0.0,
+      "dir": "p_min",
+      "pass": false
+    },
+    "kanungo_distance": 0.15853870431893693,
+    "pass": false
+  },
+  "L4": {
+    "ms_ssim": {
+      "value": 0.44417112413474413,
+      "target": 0.75,
+      "tol": 0.0,
+      "dir": "min",
+      "pass": false
+    },
+    "ms_ssim_raw": 0.323284471894273,
+    "glcm_contrast": {
+      "real": 5.581989947787049,
+      "render": 8.276455375006101
+    },
+    "forgery_auc": "NOT_IMPLEMENTED",
+    "tstr_gap": "NOT_IMPLEMENTED",
+    "ocr_jaccard": {
+      "value": 0.6530612244897959,
+      "target": 1.0,
+      "tol": 0.1,
+      "dir": "min",
+      "pass": false
+    },
+    "ocr_recall": {
+      "real": 0.7412280701754386,
+      "render": 0.6447368421052632
+    },
+    "ocr_cer": {
+      "real": 0.20017597888253413,
+      "render": 0.2549019607843137
+    },
+    "ocr_error_classes": {
+      "shared": 32,
+      "render_only": 15,
+      "real_only": 2
+    },
+    "spacing_jitter_render": 0.5469899370554402,
+    "pass": false
+  },
+  "overall_rung_cleared": "L0-fail",
+  "elapsed_sec": 13.8
+}

--- a/tools/glyph-studio/py/costco.thresholds.json
+++ b/tools/glyph-studio/py/costco.thresholds.json
@@ -1,0 +1,44 @@
+{
+  "merchant": "costco",
+  "_doc": "Per-level pass bands = the 1:1 targets from GOLD_STANDARD.md Part 1. dir: band=|v-target|<=tol, min=v>=target-tol, max=v<=target+tol, p_min=v>=target (fail-to-reject). A render 'advances a rung' only when every live metric at that level passes. reg = regression threshold-width for the CI gate (no metric may worsen by more than reg vs the committed baseline).",
+  "dark_thresh": 160.0,
+  "regions": {
+    "header": [0.083, 0.153],
+    "body": [0.167, 0.617],
+    "footer": [0.727, 0.967]
+  },
+  "hygiene": {
+    "_doc": "I3 metric hygiene: drop logo-header lines (000-001, WHOLESALE contamination) and the dense payment-footer block (043-049, pitch mis-segmentation) so L1/L2 measure render defects, not measurement noise.",
+    "exclude_lines": [0, 1, 43, 44, 45, 46, 47, 48, 49]
+  },
+  "L0": {
+    "ink_ratio": {"target": 1.00, "tol": 0.05, "dir": "band", "reg": 0.05},
+    "fill": {"target": 0.271, "tol": 0.01, "dir": "band", "reg": 0.01},
+    "cap_h_ratio": {"target": 1.00, "tol": 0.03, "dir": "band", "reg": 0.03},
+    "pitch_ratio": {"target": 1.00, "tol": 0.02, "dir": "band", "reg": 0.02}
+  },
+  "L1": {
+    "gs_vs_crops": {"target": 50.0, "tol": 5.0, "dir": "min", "reg": 3.0},
+    "iou_rc": {"target": 0.536, "tol": 0.05, "dir": "band", "reg": 0.03},
+    "self_agreement_ref": 0.87
+  },
+  "L2": {
+    "cap_h_ratio": {"target": 1.00, "tol": 0.03, "dir": "band", "reg": 0.03},
+    "advance_ratio": {"target": 1.00, "tol": 0.05, "dir": "max", "reg": 0.03},
+    "price_std_px": {"target": 8.0, "tol": 0.0, "dir": "max", "reg": 2.0},
+    "barcode_caption_ratio": {"target": 1.00, "tol": 0.05, "dir": "band", "reg": 0.05}
+  },
+  "_L3_doc": "L3 channels are evaluated against the harness-measured real value (dynamic band = |render-real|<=tol), since texture 1:1 means matching real measured the SAME way. 'target' below is the documented Part-1 reference value, echoed as spec_target. tol is the dynamic band half-width. ink_tone_emd and kanungo_p are absolute (render-vs-real distances).",
+  "L3": {
+    "ink_darkness": {"target": 69.0, "tol": 6.0, "dir": "band", "reg": 5.0},
+    "stroke_cov": {"target": 0.35, "tol": 0.06, "dir": "band", "reg": 0.05},
+    "edge_transition_frac": {"target": 0.16, "tol": 0.05, "dir": "band", "reg": 0.03},
+    "paper_clip_frac": {"target": 0.55, "tol": 0.10, "dir": "band", "reg": 0.10},
+    "ink_tone_emd": {"target": 0.0, "tol": 3.0, "dir": "max", "reg": 3.0},
+    "kanungo_p": {"target": 0.05, "tol": 0.0, "dir": "p_min", "reg": 0.05}
+  },
+  "L4": {
+    "ms_ssim": {"target": 0.75, "tol": 0.0, "dir": "min", "reg": 0.03},
+    "ocr_jaccard": {"target": 1.00, "tol": 0.10, "dir": "min", "reg": 0.05}
+  }
+}

--- a/tools/glyph-studio/py/costco_gold.py
+++ b/tools/glyph-studio/py/costco_gold.py
@@ -18,6 +18,10 @@ existing machinery rather than reinventing it:
 Metrics that need a model we do not have (forgery-detector AUC, TSTR gap) are
 emitted as explicit ``NOT_IMPLEMENTED`` entries -- never a fabricated number.
 
+Pass/fail is vs the 1:1 target bands in ``--config``. Pass ``--baseline`` with a
+prior scorecard to additionally run the CI regression gate (no metric may
+worsen by more than its ``reg`` threshold-width); the run exits 2 on regression.
+
 Usage:
     costco_gold.py --render final.webp --real real.webp \\
         --labels final.labels.json --refpack costco.refpack.npz \\
@@ -69,6 +73,35 @@ def _load_gold_metrics():
 
 def _log(msg: str) -> None:
     print(f"[costco_gold {time.strftime('%H:%M:%S')}] {msg}", file=sys.stderr, flush=True)
+
+
+def _repo_rel(path: str) -> str:
+    """Path relative to the enclosing git repo root (portable in the committed
+    record), or the absolute path if not under a repo."""
+    ap = os.path.abspath(path)
+    d = os.path.dirname(ap)
+    while d and d != os.path.dirname(d):
+        if os.path.isdir(os.path.join(d, ".git")) or os.path.isfile(os.path.join(d, ".git")):
+            return os.path.relpath(ap, d)
+        d = os.path.dirname(d)
+    return ap
+
+
+def _sanitize(obj):
+    """Recursively replace non-finite floats with None so the scorecard is
+    strict-JSON valid (json.dumps allow_nan=False)."""
+    if isinstance(obj, dict):
+        return {k: _sanitize(v) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        return [_sanitize(v) for v in obj]
+    if isinstance(obj, float) and not np.isfinite(obj):
+        return None
+    if isinstance(obj, (np.floating,)):
+        f = float(obj)
+        return f if np.isfinite(f) else None
+    if isinstance(obj, (np.integer,)):
+        return int(obj)
+    return obj
 
 
 # --- GlyphScore machinery (imported from the glyphscore worktree) --------------
@@ -172,10 +205,21 @@ def _gate(value, spec: dict) -> dict:
     return out
 
 
-def _level_pass(gates: dict) -> bool:
-    passes = [g.get("pass") for g in gates.values() if isinstance(g, dict) and "pass" in g]
-    live = [p for p in passes if p is not None]
-    return bool(live) and all(live)
+def _level_pass(gates: dict):
+    """A level passes only when EVERY required gate passes. A required gate
+    that could not be evaluated (value nan/None -- e.g. OCR unavailable)
+    yields ``None`` (INCOMPLETE), never a silent pass on the survivors.
+
+    Only required gates are passed in here; intentionally-unsupported metrics
+    (forgery AUC, TSTR) are trained-model stubs kept OUT of the gate set.
+    """
+    passes = [g.get("pass") for g in gates.values()
+              if isinstance(g, dict) and "pass" in g]
+    if not passes:
+        return None
+    if any(p is None for p in passes):
+        return None  # required metric unavailable -> level incomplete
+    return all(passes)
 
 
 # --- L1 IoU decomposition (render vs design/real, with I3 hygiene) -------------
@@ -425,7 +469,10 @@ def _l3_texture(real_gray, render_warp, body, dark_thresh, GS, refpack_path,
         "render_paper_clip_frac": gm.paper_clip_frac(f_body),
         "ink_tone_emd": gm.tone_emd(r_body, f_body),
     }
-    # Kanungo two-sample: render glyph crops vs real refpack crops (binary)
+    # Kanungo two-sample: render glyph crops vs real refpack crops (binary).
+    # Stratified & character-MATCHED so the test measures texture, not glyph
+    # composition: for each char present on both sides (outside the hygiene
+    # mask) take an equal number of render and real crops, then pool.
     pack = GS["load_refpack"](refpack_path)
     gsc = GS["gsc"]
     words = gsc._words_from_json(labels_path)
@@ -437,16 +484,28 @@ def _l3_texture(real_gray, render_warp, body, dark_thresh, GS, refpack_path,
         except ValueError:
             return -1
 
-    render_crops = [np.asarray(m, bool) for ch, m, line in instances
-                    if line_idx(line) not in exclude_lines]
-    real_crops = []
-    for ch, stack in pack.items():
-        st = np.asarray(stack, bool)
-        for i in range(min(4, st.shape[0])):  # a few per char, keep it bounded
-            real_crops.append(st[i])
-    kg = gm.kanungo_two_sample(render_crops[:400], real_crops[:400], n_perm=100)
+    render_by_char = defaultdict(list)
+    for ch, m, line in instances:
+        if line_idx(line) in exclude_lines:
+            continue
+        render_by_char[ch].append(np.asarray(m, bool))
+    per_char_cap = 8  # bound total crops; equal counts per char both sides
+    render_crops, real_crops = [], []
+    for ch, r_list in render_by_char.items():
+        st = pack.get(ch)
+        if st is None:
+            continue
+        st = np.asarray(st, bool)
+        k = min(per_char_cap, len(r_list), st.shape[0])
+        if k < 1:
+            continue
+        idx = np.linspace(0, st.shape[0] - 1, k).round().astype(int)
+        render_crops.extend(r_list[:k])
+        real_crops.extend(st[i] for i in np.unique(idx))
+    kg = gm.kanungo_two_sample(render_crops, real_crops, n_perm=100)
     out["kanungo_distance"] = kg["distance"]
     out["kanungo_p"] = kg["p_value"]
+    out["kanungo_n"] = {"render": len(render_crops), "real": len(real_crops)}
     return out
 
 
@@ -465,6 +524,12 @@ def build_scorecard(args) -> dict:
     render_img = Image.open(args.render)
     real_gray = np.asarray(real_img.convert("L"), np.float64)
     render_gray = np.asarray(render_img.convert("L"), np.float64)
+    if real_gray.shape != render_gray.shape:
+        raise SystemExit(
+            f"render {render_gray.shape[::-1]} and real {real_gray.shape[::-1]} "
+            "must share one canvas (the pipeline composites both at the same "
+            "size); resize before scoring."
+        )
     H, W = real_gray.shape
     body = (int(regions["body"][0] * H), int(regions["body"][1] * H))
     dark_thresh = cfg.get("dark_thresh", 160.0)
@@ -472,8 +537,9 @@ def build_scorecard(args) -> dict:
     scorecard = {
         "merchant": cfg.get("merchant", "costco"),
         "date": time.strftime("%Y-%m-%d"),
-        "render": os.path.abspath(args.render),
-        "real": os.path.abspath(args.real),
+        "tool": "costco_gold.py",
+        "render": _repo_rel(args.render),
+        "real": _repo_rel(args.real),
         "canvas": [W, H],
         "glyphscore_root": args.glyphscore_root,
     }
@@ -525,7 +591,6 @@ def build_scorecard(args) -> dict:
     cap_real = duty_real * pitch_real if np.isfinite(pitch_real) else float("nan")
     cap_ratio = cap_render / cap_real if cap_real and np.isfinite(cap_real) else float("nan")
     pitch_ratio = pitch_render / pitch_real if pitch_real and np.isfinite(pitch_real) else float("nan")
-    interline_fill = duty_render  # duty cycle == glyph-height / pitch fill
     L0 = {
         "ink_ratio": _gate(ink_r, cfg["L0"]["ink_ratio"]),
         "fill_render": _gate(fill_render, cfg["L0"]["fill"]),
@@ -653,15 +718,58 @@ def build_scorecard(args) -> dict:
     scorecard["L3"] = L3
     scorecard["L4"] = L4
 
-    # overall rung cleared (first level that fails)
+    # overall rung cleared: first level that does not pass (fail vs incomplete)
     cleared = "L4-pass"
     for lvl in ("L0", "L1", "L2", "L3", "L4"):
-        if not scorecard[lvl].get("pass"):
-            cleared = f"{lvl}-fail"
-            break
+        p = scorecard[lvl].get("pass")
+        if p is True:
+            continue
+        cleared = f"{lvl}-{'incomplete' if p is None else 'fail'}"
+        break
     scorecard["overall_rung_cleared"] = cleared
     scorecard["elapsed_sec"] = round(time.time() - t_start, 1)
     return scorecard
+
+
+def _iter_gate_values(sc: dict):
+    """Yield (path, value) for every gated metric (dicts carrying a 'dir')."""
+    for lvl in ("L0", "L1", "L2", "L3", "L4"):
+        block = sc.get(lvl, {})
+        for name, g in block.items():
+            if isinstance(g, dict) and "dir" in g and isinstance(g.get("value"), (int, float)):
+                yield f"{lvl}.{name}", float(g["value"])
+
+
+def regression_report(current: dict, baseline: dict, cfg: dict) -> dict:
+    """CI gate: flag any metric that worsened by more than its ``reg``
+    threshold-width vs the committed baseline scorecard (GOLD_STANDARD Part 3).
+
+    "Worse" is direction-aware: for ``min`` gates a drop is worse, for ``max``
+    a rise is worse, for ``band`` any move away from target is worse.
+    """
+    base_vals = dict(_iter_gate_values(baseline))
+    regressions = []
+    for path, cur in _iter_gate_values(current):
+        if path not in base_vals:
+            continue
+        lvl, name = path.split(".", 1)
+        spec = cfg.get(lvl, {}).get(name, {})
+        reg = spec.get("reg")
+        if reg is None:
+            continue
+        d = spec.get("dir", "band")
+        base = base_vals[path]
+        if d == "min":
+            worse = base - cur
+        elif d == "max":
+            worse = cur - base
+        else:  # band: distance from target
+            t = spec.get("target", 0.0)
+            worse = abs(cur - t) - abs(base - t)
+        if worse > reg:
+            regressions.append({"metric": path, "baseline": base, "current": cur,
+                                "worsened_by": round(worse, 4), "reg_width": reg})
+    return {"regressions": regressions, "regressed": bool(regressions)}
 
 
 def main(argv=None) -> int:
@@ -678,17 +786,32 @@ def main(argv=None) -> int:
                     default=os.environ.get("GLYPHSCORE_ROOT", "/private/tmp/glyphscore"))
     ap.add_argument("--cache-dir",
                     default=os.path.join(tempfile.gettempdir(), "costco_gold_cache"))
+    ap.add_argument("--baseline",
+                    help="prior scorecard JSON; flag metrics that regressed by "
+                         "more than their reg threshold-width (CI gate). Exit 2 "
+                         "on regression.")
     args = ap.parse_args(argv)
 
     sc = build_scorecard(args)
-    text = json.dumps(sc, indent=2, sort_keys=False)
+    regressed = False
+    if args.baseline:
+        cfg = json.load(open(args.config))
+        baseline = json.load(open(args.baseline))
+        rep = regression_report(sc, baseline, cfg)
+        sc["regression"] = rep
+        regressed = rep["regressed"]
+        _log(f"regression check vs {args.baseline}: "
+             f"{len(rep['regressions'])} metric(s) regressed")
+
+    sc = _sanitize(sc)
+    text = json.dumps(sc, indent=2, sort_keys=False, allow_nan=False)
     if args.out:
         with open(args.out, "w") as fh:
             fh.write(text + "\n")
         _log(f"wrote {args.out}")
     print(text)
     _log(f"overall: {sc['overall_rung_cleared']} in {sc['elapsed_sec']}s")
-    return 0
+    return 2 if regressed else 0
 
 
 if __name__ == "__main__":

--- a/tools/glyph-studio/py/costco_gold.py
+++ b/tools/glyph-studio/py/costco_gold.py
@@ -659,8 +659,13 @@ def build_scorecard(args) -> dict:
     # each channel's pass band centers on the harness-measured real value
     # (dynamic target), not the reports' hand-crop numbers (a different method).
     # The documented Part-1 targets ride along as ``spec_target`` annotations.
+    # Texture channels are POPULATION statistics over the body band, so they
+    # are computed on the UNWARPED render: the piecewise row warp interpolates
+    # rows, manufacturing mid-tone pixels that inflate edge-transition frac
+    # (~+0.05) and tone EMD on the render side only -- an instrument bias, not
+    # a render property. (MS-SSIM, which IS spatially matched, keeps the warp.)
     _log("stage: L3 texture / degradation parity")
-    tex = _l3_texture(real_gray, render_warp, body, dark_thresh, GS, args.refpack,
+    tex = _l3_texture(real_gray, render_gray, body, dark_thresh, GS, args.refpack,
                       args.render, args.labels, exclude_lines)
 
     def _gate_dyn(value, real_value, key):

--- a/tools/glyph-studio/py/costco_gold.py
+++ b/tools/glyph-studio/py/costco_gold.py
@@ -590,9 +590,18 @@ def build_scorecard(args) -> dict:
     cap_real = duty_real * pitch_real if np.isfinite(pitch_real) else float("nan")
     cap_ratio = cap_render / cap_real if cap_real and np.isfinite(cap_real) else float("nan")
     pitch_ratio = pitch_render / pitch_real if pitch_real and np.isfinite(pitch_real) else float("nan")
+    # Fill is gated DYNAMICALLY against the refpack-measured real fill (same
+    # 32x32-normalized-mask method as the render side). The documented Part-1
+    # value (0.271, a different hand-crop method) rides along as spec_target;
+    # gating on it would fail the real reference itself (measures ~0.254).
+    fill_gate = _gate(fill_render, {"target": fill_real,
+                                    "tol": cfg["L0"]["fill"]["tol"],
+                                    "dir": "band"})
+    fill_gate["real_measured"] = fill_real
+    fill_gate["spec_target"] = cfg["L0"]["fill"].get("target")
     L0 = {
         "ink_ratio": _gate(ink_r, cfg["L0"]["ink_ratio"]),
-        "fill_render": _gate(fill_render, cfg["L0"]["fill"]),
+        "fill_render": fill_gate,
         "fill_real_ref": fill_real,
         "cap_h_ratio": _gate(cap_ratio, cfg["L0"]["cap_h_ratio"]),
         "pitch_ratio": _gate(pitch_ratio, cfg["L0"]["pitch_ratio"]),

--- a/tools/glyph-studio/py/costco_gold.py
+++ b/tools/glyph-studio/py/costco_gold.py
@@ -745,12 +745,16 @@ def build_scorecard(args) -> dict:
 
 
 def _iter_gate_values(sc: dict):
-    """Yield (path, value) for every gated metric (dicts carrying a 'dir')."""
+    """Yield (path, value, target) for every gated metric (dicts carrying a
+    'dir'). ``target`` is the gate's OWN recorded target -- for dynamic gates
+    (L3 channels, L0 fill) that is the real-measured value, which is what
+    pass/fail uses; the regression check must measure distance to the same
+    point or a move TOWARD the real value reads as a regression."""
     for lvl in ("L0", "L1", "L2", "L3", "L4"):
         block = sc.get(lvl, {})
         for name, g in block.items():
             if isinstance(g, dict) and "dir" in g and isinstance(g.get("value"), (int, float)):
-                yield f"{lvl}.{name}", float(g["value"])
+                yield f"{lvl}.{name}", float(g["value"]), g.get("target")
 
 
 def regression_report(current: dict, baseline: dict, cfg: dict) -> dict:
@@ -760,9 +764,9 @@ def regression_report(current: dict, baseline: dict, cfg: dict) -> dict:
     "Worse" is direction-aware: for ``min`` gates a drop is worse, for ``max``
     a rise is worse, for ``band`` any move away from target is worse.
     """
-    base_vals = dict(_iter_gate_values(baseline))
+    base_vals = {path: val for path, val, _t in _iter_gate_values(baseline)}
     regressions = []
-    for path, cur in _iter_gate_values(current):
+    for path, cur, gate_target in _iter_gate_values(current):
         if path not in base_vals:
             continue
         lvl, name = path.split(".", 1)
@@ -776,8 +780,9 @@ def regression_report(current: dict, baseline: dict, cfg: dict) -> dict:
             worse = base - cur
         elif d == "max":
             worse = cur - base
-        else:  # band: distance from target
-            t = spec.get("target", 0.0)
+        else:  # band: distance from the gate's own (possibly dynamic) target
+            t = gate_target if isinstance(gate_target, (int, float)) \
+                else spec.get("target", 0.0)
             worse = abs(cur - t) - abs(base - t)
         if worse > reg:
             regressions.append({"metric": path, "baseline": base, "current": cur,

--- a/tools/glyph-studio/py/costco_gold.py
+++ b/tools/glyph-studio/py/costco_gold.py
@@ -43,7 +43,6 @@ import sys
 import tempfile
 import time
 from collections import defaultdict
-from difflib import SequenceMatcher
 
 import numpy as np
 from PIL import Image

--- a/tools/glyph-studio/py/costco_gold.py
+++ b/tools/glyph-studio/py/costco_gold.py
@@ -1,0 +1,695 @@
+#!/usr/bin/env python3
+"""costco_gold.py -- the standing "how close to 1:1 are we" instrument.
+
+ONE command that takes a render + the Costco gold reference set and emits the
+full L0-L4 JSON scorecard (current values, 1:1 targets, pass/fail vs
+regression thresholds) defined by ``GOLD_STANDARD.md`` Part 3. It wires the
+existing machinery rather than reinventing it:
+
+- GlyphScore (worktree ``/private/tmp/glyphscore``, PR #1111) supplies L1
+  per-glyph fidelity and the render segmentation used by L0/L2. Its path is
+  configurable via ``--glyphscore-root`` / ``$GLYPHSCORE_ROOT``.
+- ``glyphstudio.gold_metrics`` supplies the analytic L0/L2/L3/L4 metrics
+  (chamfer, boundary-IoU, Kanungo two-sample texture test, MS-SSIM, OCR
+  error-set Jaccard, alignment warp).
+- Apple Vision (``ocr_vision.swift``, compiled on demand) supplies the OCR
+  used for alignment and the L4 OCR-parity metrics.
+
+Metrics that need a model we do not have (forgery-detector AUC, TSTR gap) are
+emitted as explicit ``NOT_IMPLEMENTED`` entries -- never a fabricated number.
+
+Usage:
+    costco_gold.py --render final.webp --real real.webp \\
+        --labels final.labels.json --refpack costco.refpack.npz \\
+        --chart bitMatrix-C2-chart.glyphs.npz --config costco.thresholds.json \\
+        --out costco_gold.scorecard.json
+
+Read-only vs dev/prod; deterministic; merchant-parameterized (Costco is the
+reference config).
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+from collections import defaultdict
+from difflib import SequenceMatcher
+
+import numpy as np
+from PIL import Image
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+
+NOT_IMPLEMENTED = "NOT_IMPLEMENTED"
+
+# gold_metrics is loaded standalone (by file path) so that the ``glyphstudio``
+# package name can resolve entirely to the glyphscore worktree (whose
+# family_cluster / typography / glyph_score are mutually consistent). Importing
+# our repo's glyphstudio would shadow it and hide glyph_score.py.
+gm = None
+
+
+def _load_gold_metrics():
+    global gm
+    if gm is not None:
+        return gm
+    path = os.path.join(_HERE, "glyphstudio", "gold_metrics.py")
+    spec = importlib.util.spec_from_file_location("gold_metrics", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    gm = mod
+    return gm
+
+
+def _log(msg: str) -> None:
+    print(f"[costco_gold {time.strftime('%H:%M:%S')}] {msg}", file=sys.stderr, flush=True)
+
+
+# --- GlyphScore machinery (imported from the glyphscore worktree) --------------
+
+
+def _import_glyphscore(root: str):
+    """Wire GlyphScore's CLI + scoring primitives from its worktree.
+
+    PR #1111 is not on origin/main, so -- like the gap analysts'
+    ``decompose.py`` -- we add the worktree to ``sys.path`` instead of
+    duplicating not-yet-merged code.
+    """
+    for p in (os.path.join(root, "tools/glyph-studio/py"),
+              os.path.join(root, "synthesis_loop")):
+        if os.path.isdir(p) and p not in sys.path:
+            sys.path.insert(0, p)
+    import glyph_score_cli as gsc  # noqa: E402
+    from glyphstudio.family_cluster import normalize_glyph  # noqa: E402
+    from glyphstudio.glyph_score import (  # noqa: E402
+        MIN_REF, MAX_REF, _cap_stack, crop_exemplar, load_refpack,
+        self_similarity, shifted_iou_stack,
+    )
+    return {
+        "gsc": gsc, "normalize_glyph": normalize_glyph, "MIN_REF": MIN_REF,
+        "MAX_REF": MAX_REF, "_cap_stack": _cap_stack,
+        "crop_exemplar": crop_exemplar, "load_refpack": load_refpack,
+        "self_similarity": self_similarity, "shifted_iou_stack": shifted_iou_stack,
+    }
+
+
+# --- OCR (Apple Vision via a compiled swift helper) ----------------------------
+
+
+def _ensure_ocr_binary(cache_dir: str):
+    """Compile ``ocr_vision.swift`` once into ``cache_dir``; return path or None.
+
+    Returns None (OCR-dependent metrics become NOT_IMPLEMENTED) when swiftc or
+    the Vision framework is unavailable, rather than faking OCR output.
+    """
+    src = os.path.join(_HERE, "ocr_vision.swift")
+    if not os.path.exists(src):
+        return None
+    os.makedirs(cache_dir, exist_ok=True)
+    binp = os.path.join(cache_dir, "ocr_vision")
+    if os.path.exists(binp) and os.path.getmtime(binp) >= os.path.getmtime(src):
+        return binp
+    swiftc = subprocess.run(["which", "swiftc"], capture_output=True, text=True)
+    if swiftc.returncode != 0:
+        _log("swiftc not found -> OCR metrics NOT_IMPLEMENTED")
+        return None
+    r = subprocess.run(["swiftc", "-O", src, "-o", binp],
+                       capture_output=True, text=True)
+    if r.returncode != 0:
+        _log(f"swiftc failed -> OCR NOT_IMPLEMENTED: {r.stderr[:200]}")
+        return None
+    return binp
+
+
+def _run_ocr(binp: str, img: Image.Image, cache_dir: str, tag: str):
+    """Run Vision OCR on a PIL image; return list of {text,x,y,w,h} lines."""
+    png = os.path.join(cache_dir, f"_ocr_{tag}.png")
+    img.convert("RGB").save(png)
+    r = subprocess.run([binp, png], capture_output=True, text=True)
+    if r.returncode != 0:
+        _log(f"ocr failed for {tag}: {r.stderr[:200]}")
+        return None
+    try:
+        return json.loads(r.stdout)["lines"]
+    except Exception as e:  # noqa: BLE001
+        _log(f"ocr parse failed for {tag}: {e}")
+        return None
+
+
+# --- gate evaluation -----------------------------------------------------------
+
+
+def _gate(value, spec: dict) -> dict:
+    """Evaluate one metric against its threshold spec.
+
+    spec: {target, tol, dir}  where dir in {band, min, max, p_min}. Returns a
+    dict with value, target, and pass (None when value is nan/None/not-live).
+    """
+    out = {"value": value, "target": spec.get("target"), "tol": spec.get("tol"),
+           "dir": spec.get("dir")}
+    if value is None or (isinstance(value, float) and not np.isfinite(value)):
+        out["pass"] = None
+        return out
+    t = spec.get("target")
+    tol = spec.get("tol", 0.0)
+    d = spec.get("dir", "band")
+    if d == "band":
+        out["pass"] = bool(abs(value - t) <= tol)
+    elif d == "min":
+        out["pass"] = bool(value >= t - tol)
+    elif d == "max":
+        out["pass"] = bool(value <= t + tol)
+    elif d == "p_min":  # fail-to-reject: p-value >= target
+        out["pass"] = bool(value >= t)
+    else:
+        out["pass"] = None
+    return out
+
+
+def _level_pass(gates: dict) -> bool:
+    passes = [g.get("pass") for g in gates.values() if isinstance(g, dict) and "pass" in g]
+    live = [p for p in passes if p is not None]
+    return bool(live) and all(live)
+
+
+# --- L1 IoU decomposition (render vs design/real, with I3 hygiene) -------------
+
+
+def _iou_decomposition(GS, render_path, labels_path, refpack_path, chart_path,
+                       exclude_lines):
+    """Usage-weighted IoU(render->design)=rc, IoU(render->real)=re, and
+    IoU(design->real)=ce, computed on the SAME normalized masks GlyphScore
+    uses -- both with and without the I3 metric-hygiene line mask.
+
+    Mirrors the gap analysts' ``decompose.py`` so the harness reproduces the
+    published rc/re/ce numbers.
+    """
+    gsc = GS["gsc"]
+    normalize_glyph = GS["normalize_glyph"]
+    shifted_iou_stack = GS["shifted_iou_stack"]
+    crop_exemplar = GS["crop_exemplar"]
+    _cap_stack = GS["_cap_stack"]
+    MIN_REF, MAX_REF = GS["MIN_REF"], GS["MAX_REF"]
+
+    pack = GS["load_refpack"](refpack_path)
+    atlas = gsc._load_atlas(chart_path)
+    chart = {c: normalize_glyph(g) for c, g in atlas.items()}
+
+    words = gsc._words_from_json(labels_path)
+    instances, seg = gsc.segment_render(render_path, words)
+
+    def line_idx(key):  # "line043" -> 43
+        try:
+            return int(str(key).replace("line", ""))
+        except ValueError:
+            return -1
+
+    r_by_char = defaultdict(list)
+    for ch, m, line in instances:
+        r_by_char[ch].append((np.asarray(m, bool), line_idx(line)))
+
+    def aggregate(drop_lines):
+        rows = []
+        for ch, stack in pack.items():
+            st = np.asarray(stack, bool)
+            if st.shape[0] < MIN_REF:
+                continue
+            ex = crop_exemplar(_cap_stack(st, MAX_REF))
+            g = chart.get(ch)
+            ce = (float(shifted_iou_stack(g, ex[None], 2)[0])
+                  if g is not None else float("nan"))
+            rins = [(m, li) for (m, li) in r_by_char.get(ch, [])
+                    if li not in drop_lines]
+            if not rins:
+                continue
+            re_vals, rc_vals = [], []
+            for m, _li in rins:
+                re_vals.append(float(shifted_iou_stack(m, ex[None], 2)[0]))
+                if g is not None:
+                    rc_vals.append(float(shifted_iou_stack(m, g[None], 2)[0]))
+            rows.append({
+                "char": ch, "n_real": int(st.shape[0]),
+                "re": float(np.median(re_vals)),
+                "rc": float(np.median(rc_vals)) if rc_vals else float("nan"),
+                "ce": ce,
+            })
+        return rows
+
+    def wmean(rows, key):
+        num = den = 0.0
+        for r in rows:
+            v = r[key]
+            if v != v:
+                continue
+            num += r["n_real"] * v
+            den += r["n_real"]
+        return num / den if den else float("nan")
+
+    rows_raw = aggregate(set())
+    rows_hyg = aggregate(set(exclude_lines))
+    worst = sorted(
+        [r for r in rows_hyg if r["rc"] == r["rc"]],
+        key=lambda r: r["rc"])[:8]
+    return {
+        "seg": seg,
+        "raw": {"iou_rc": wmean(rows_raw, "rc"), "iou_re": wmean(rows_raw, "re"),
+                "iou_ce": wmean(rows_raw, "ce")},
+        "hygiene": {"iou_rc": wmean(rows_hyg, "rc"), "iou_re": wmean(rows_hyg, "re"),
+                    "iou_ce": wmean(rows_hyg, "ce")},
+        "worst_after_hygiene": [
+            {"char": r["char"], "rc": round(r["rc"], 3), "ce": round(r["ce"], 3),
+             "n": r["n_real"]} for r in worst],
+    }
+
+
+# --- L2 chamfer / boundary-IoU per glyph (clean glyphs) ------------------------
+
+
+def _l2_shape_metrics(GS, render_path, labels_path, refpack_path, exclude_lines):
+    """Usage-weighted chamfer (dots on the 32-grid) + boundary-IoU of render
+    glyphs vs the real median-vote exemplar, hygiene applied."""
+    gsc = GS["gsc"]
+    crop_exemplar = GS["crop_exemplar"]
+    _cap_stack = GS["_cap_stack"]
+    MIN_REF, MAX_REF = GS["MIN_REF"], GS["MAX_REF"]
+    pack = GS["load_refpack"](refpack_path)
+    words = gsc._words_from_json(labels_path)
+    instances, _seg = gsc.segment_render(render_path, words)
+
+    exemplars = {}
+    counts = {}
+    for ch, stack in pack.items():
+        st = np.asarray(stack, bool)
+        if st.shape[0] < MIN_REF:
+            continue
+        exemplars[ch] = crop_exemplar(_cap_stack(st, MAX_REF))
+        counts[ch] = int(st.shape[0])
+
+    def line_idx(key):
+        try:
+            return int(str(key).replace("line", ""))
+        except ValueError:
+            return -1
+
+    ch_chamfer = defaultdict(list)
+    ch_biou = defaultdict(list)
+    for ch, m, line in instances:
+        if line_idx(line) in exclude_lines or ch not in exemplars:
+            continue
+        ex = exemplars[ch]
+        ch_chamfer[ch].append(gm.chamfer_distance(m, ex))
+        ch_biou[ch].append(gm.boundary_iou(m, ex, band=2))
+
+    def wmed(perchar):
+        num = den = 0.0
+        for ch, vals in perchar.items():
+            v = np.nanmedian(vals)
+            if not np.isfinite(v):
+                continue
+            num += counts[ch] * v
+            den += counts[ch]
+        return num / den if den else float("nan")
+
+    return {"chamfer_dots": wmed(ch_chamfer), "boundary_iou": wmed(ch_biou)}
+
+
+# --- geometry from OCR/labels (advance, price column, caption) -----------------
+
+
+def _render_word_boxes(labels_path, W, H):
+    """(width_px, text, x_right_px, y_center_px) for each render label token."""
+    with open(labels_path) as fh:
+        d = json.load(fh)
+    out = []
+    for t, b in zip(d["tokens"], d["bboxes"]):
+        x0, y0, x1, y1 = (float(v) for v in b[:4])
+        left = min(x0, x1) / 1000 * W
+        right = max(x0, x1) / 1000 * W
+        top = (1 - max(y0, y1) / 1000) * H
+        bottom = (1 - min(y0, y1) / 1000) * H
+        out.append((right - left, t, right, (top + bottom) / 2, bottom - top))
+    return out
+
+
+import re as _re
+
+PRICE_RE = _re.compile(r"^\d+\.\d\d-?$")
+
+
+def _clean(s):
+    return _re.sub(r"[^A-Za-z0-9]", "", s).upper()
+
+
+def _price_column_std_px(render_gray, render_boxes, dark_thresh):
+    """Std of rendered price-token right ink edges (column raggedness).
+
+    Measures the ACTUAL rightmost ink column per price token in the render
+    pixels (not the intended label box), reproducing the pixel raggedness the
+    gap report saw (label boxes are grid-perfect and hide it)."""
+    H, W = render_gray.shape
+    rights = []
+    for w, t, xr, yc, h in render_boxes:
+        if not PRICE_RE.match(t.strip()):
+            continue
+        y_lo = max(0, int(yc - h / 2) - 2)
+        y_hi = min(H, int(yc + h / 2) + 2)
+        # search a window around the intended right edge
+        x_lo = max(0, int(xr - w) - 4)
+        x_hi = min(W, int(xr) + 8)
+        band = render_gray[y_lo:y_hi, x_lo:x_hi]
+        ink_cols = np.where((band < dark_thresh).any(axis=0))[0]
+        if ink_cols.size:
+            rights.append(x_lo + int(ink_cols[-1]))
+    return gm.right_edge_std(rights)
+
+
+def _caption_ratio(render_boxes, real_lines, body):
+    """Barcode-caption height ratio: render footer numeric caption height vs
+    the real OCR footer numeric caption height (both below the body)."""
+    y1 = body[1]
+
+    def render_caption_h():
+        num = [(yc, h) for (_w, t, _xr, yc, h) in render_boxes
+               if t.strip().isdigit() and len(t.strip()) >= 2 and yc > y1]
+        if not num:
+            return float("nan")
+        num.sort()
+        return float(np.median([h for _yc, h in num[-4:]]))
+
+    def real_caption_h():
+        num = [(l["y"] + l["h"] / 2, l["h"]) for l in real_lines
+               if _clean(l["text"]).isdigit() and len(_clean(l["text"])) >= 2
+               and (l["y"] + l["h"] / 2) > y1]
+        if not num:
+            return float("nan")
+        num.sort()
+        return float(np.median([h for _yc, h in num[-4:]]))
+
+    return gm.caption_height_ratio(render_caption_h(), real_caption_h())
+
+
+# --- L3 texture (real vs render on aligned body region) ------------------------
+
+
+def _ink_mask(gray_region, dark_thresh):
+    return np.asarray(gray_region, np.float64) < dark_thresh
+
+
+def _l3_texture(real_gray, render_warp, body, dark_thresh, GS, refpack_path,
+                render_path, labels_path, exclude_lines):
+    y0, y1 = body
+    r_body = real_gray[y0:y1]
+    f_body = render_warp[y0:y1]
+    r_ink = _ink_mask(r_body, dark_thresh)
+    f_ink = _ink_mask(f_body, dark_thresh)
+    r_stats = gm.stroke_core_stats(r_body, r_ink, erode=1)
+    f_stats = gm.stroke_core_stats(f_body, f_ink, erode=1)
+    # edge transition fraction near ink (dilate ink to capture the ramp)
+    from scipy import ndimage
+    r_zone = ndimage.binary_dilation(r_ink, iterations=2)
+    f_zone = ndimage.binary_dilation(f_ink, iterations=2)
+    out = {
+        "real_stroke_core_L": r_stats["median_L"],
+        "render_stroke_core_L": f_stats["median_L"],
+        "real_stroke_cov": r_stats["cov"],
+        "render_stroke_cov": f_stats["cov"],
+        "real_edge_transition_frac": gm.edge_transition_frac(r_body, r_zone),
+        "render_edge_transition_frac": gm.edge_transition_frac(f_body, f_zone),
+        "real_paper_clip_frac": gm.paper_clip_frac(r_body),
+        "render_paper_clip_frac": gm.paper_clip_frac(f_body),
+        "ink_tone_emd": gm.tone_emd(r_body, f_body),
+    }
+    # Kanungo two-sample: render glyph crops vs real refpack crops (binary)
+    pack = GS["load_refpack"](refpack_path)
+    gsc = GS["gsc"]
+    words = gsc._words_from_json(labels_path)
+    instances, _ = gsc.segment_render(render_path, words)
+
+    def line_idx(key):
+        try:
+            return int(str(key).replace("line", ""))
+        except ValueError:
+            return -1
+
+    render_crops = [np.asarray(m, bool) for ch, m, line in instances
+                    if line_idx(line) not in exclude_lines]
+    real_crops = []
+    for ch, stack in pack.items():
+        st = np.asarray(stack, bool)
+        for i in range(min(4, st.shape[0])):  # a few per char, keep it bounded
+            real_crops.append(st[i])
+    kg = gm.kanungo_two_sample(render_crops[:400], real_crops[:400], n_perm=100)
+    out["kanungo_distance"] = kg["distance"]
+    out["kanungo_p"] = kg["p_value"]
+    return out
+
+
+# --- main ----------------------------------------------------------------------
+
+
+def build_scorecard(args) -> dict:
+    t_start = time.time()
+    GS = _import_glyphscore(args.glyphscore_root)
+    _load_gold_metrics()
+    cfg = json.load(open(args.config))
+    regions = cfg["regions"]
+    exclude_lines = set(cfg.get("hygiene", {}).get("exclude_lines", []))
+
+    real_img = Image.open(args.real)
+    render_img = Image.open(args.render)
+    real_gray = np.asarray(real_img.convert("L"), np.float64)
+    render_gray = np.asarray(render_img.convert("L"), np.float64)
+    H, W = real_gray.shape
+    body = (int(regions["body"][0] * H), int(regions["body"][1] * H))
+    dark_thresh = cfg.get("dark_thresh", 160.0)
+
+    scorecard = {
+        "merchant": cfg.get("merchant", "costco"),
+        "date": time.strftime("%Y-%m-%d"),
+        "render": os.path.abspath(args.render),
+        "real": os.path.abspath(args.real),
+        "canvas": [W, H],
+        "glyphscore_root": args.glyphscore_root,
+    }
+
+    # --- Alignment (OCR-anchored piecewise-linear warp) ---
+    _log("stage: OCR + alignment")
+    ocr_bin = _ensure_ocr_binary(args.cache_dir)
+    real_lines = render_lines = None
+    render_warp = render_gray
+    align_resid = None
+    if ocr_bin:
+        real_lines = _run_ocr(ocr_bin, real_img, args.cache_dir, "real")
+        render_lines = _run_ocr(ocr_bin, render_img, args.cache_dir, "render")
+    if real_lines and render_lines:
+        anchors = gm.ocr_anchors(real_lines, render_lines)
+        render_warp, align_resid = gm.piecewise_row_warp(render_gray, anchors, H)
+        scorecard["aligned"] = bool(align_resid is not None and align_resid <= 30)
+        scorecard["align_residual_px"] = round(align_resid, 1)
+        scorecard["n_anchors"] = len(anchors)
+    else:
+        scorecard["aligned"] = False
+        scorecard["align_residual_px"] = None
+        scorecard["align_note"] = "OCR unavailable; L2+ geometry raw-only, MS-SSIM raw"
+
+    # render token geometry (labels) + clustered rows, used by L0 and L2
+    render_boxes = _render_word_boxes(args.labels, W, H)
+
+    # --- L0 ---
+    _log("stage: L0 bulk gates")
+    gsc = GS["gsc"]
+    words = gsc._words_from_json(args.labels)
+    instances, seg = gsc.segment_render(args.render, words)
+    render_fills = [np.asarray(m, bool) for _c, m, _l in instances]
+    real_pack = GS["load_refpack"](args.refpack)
+    real_crop_masks = [st_i for st in real_pack.values()
+                       for st_i in np.asarray(st, bool)]
+    ink_r = gm.ink_ratio(real_gray, render_gray)
+    fill_render = gm.normalized_fill(render_fills)
+    fill_real = gm.normalized_fill(real_crop_masks)
+    # Vertical geometry from the body row-ink profile (pixel autocorrelation +
+    # duty cycle), measured identically on real and render so the ratio is
+    # method-fair and robust to the render's crammed leading (band-splitting
+    # merges adjacent crammed lines; autocorrelation reads the true period).
+    pitch_render = gm.line_pitch_autocorr(render_gray, *body)
+    pitch_real = gm.line_pitch_autocorr(real_gray, *body)
+    duty_render = gm.interline_duty(render_gray, *body)
+    duty_real = gm.interline_duty(real_gray, *body)
+    cap_render = duty_render * pitch_render if np.isfinite(pitch_render) else float("nan")
+    cap_real = duty_real * pitch_real if np.isfinite(pitch_real) else float("nan")
+    cap_ratio = cap_render / cap_real if cap_real and np.isfinite(cap_real) else float("nan")
+    pitch_ratio = pitch_render / pitch_real if pitch_real and np.isfinite(pitch_real) else float("nan")
+    interline_fill = duty_render  # duty cycle == glyph-height / pitch fill
+    L0 = {
+        "ink_ratio": _gate(ink_r, cfg["L0"]["ink_ratio"]),
+        "fill_render": _gate(fill_render, cfg["L0"]["fill"]),
+        "fill_real_ref": fill_real,
+        "cap_h_ratio": _gate(cap_ratio, cfg["L0"]["cap_h_ratio"]),
+        "pitch_ratio": _gate(pitch_ratio, cfg["L0"]["pitch_ratio"]),
+        "cap_h_px": {"render": cap_render, "real": cap_real},
+        "pitch_px": {"render": pitch_render, "real": pitch_real},
+        "interline_fill": {"render": duty_render, "real": duty_real},
+    }
+    L0["pass"] = _level_pass({k: v for k, v in L0.items()
+                              if k in ("ink_ratio", "fill_render", "cap_h_ratio", "pitch_ratio")})
+
+    # --- L1 GlyphScore ---
+    _log("stage: L1 GlyphScore (self + anchor) + IoU decomposition")
+    d_crops = gsc.score_render_report(args.render, words, args.refpack)
+    d_chart = gsc.score_render_report(args.render, words, args.refpack, anchor_path=args.chart)
+    iou = _iou_decomposition(GS, args.render, args.labels, args.refpack, args.chart,
+                             exclude_lines)
+    L1 = {
+        "gs_vs_crops": _gate(d_crops["glyphscore"], cfg["L1"]["gs_vs_crops"]),
+        "gs_vs_chart": d_chart["glyphscore"],
+        "iou_re": iou["raw"]["iou_re"],
+        "iou_rc": iou["raw"]["iou_rc"],
+        "iou_ce": iou["raw"]["iou_ce"],
+        "iou_rc_hygiene": _gate(iou["hygiene"]["iou_rc"], cfg["L1"]["iou_rc"]),
+        "iou_re_hygiene": iou["hygiene"]["iou_re"],
+        "self_agreement_ref": cfg["L1"].get("self_agreement_ref", 0.87),
+        "worst_after_hygiene": iou["worst_after_hygiene"],
+        "segmentation": f"{seg['n_words_segmented']}/{seg['n_words']}",
+    }
+    L1["pass"] = _level_pass({"gs": L1["gs_vs_crops"], "rc": L1["iou_rc_hygiene"]})
+
+    # --- L2 geometry ---
+    _log("stage: L2 chamfer + boundary-IoU + column geometry")
+    shape = _l2_shape_metrics(GS, args.render, args.labels, args.refpack, exclude_lines)
+    adv_render = gm.char_advance_autocorr(render_gray, *body)
+    adv_real = gm.char_advance_autocorr(real_gray, *body)
+    advance_ratio = adv_render / adv_real if adv_real and np.isfinite(adv_real) else float("nan")
+    price_std = _price_column_std_px(render_gray, render_boxes, dark_thresh)
+    caption_ratio = _caption_ratio(render_boxes, real_lines or [], body)
+    L2 = {
+        "chamfer_dots": shape["chamfer_dots"],
+        "boundary_iou": shape["boundary_iou"],
+        "advance_ratio": _gate(advance_ratio, cfg["L2"]["advance_ratio"]),
+        "advance_px": {"render": adv_render, "real": adv_real},
+        "price_std_px": _gate(price_std, cfg["L2"]["price_std_px"]),
+        "barcode_caption_ratio": _gate(caption_ratio, cfg["L2"]["barcode_caption_ratio"]),
+        "cap_h_ratio": _gate(cap_ratio, cfg["L2"]["cap_h_ratio"]),
+        "interline_fill": {"render": duty_render, "real": duty_real},
+    }
+    L2["pass"] = _level_pass({k: v for k, v in L2.items()
+                              if k in ("advance_ratio", "price_std_px",
+                                       "barcode_caption_ratio", "cap_h_ratio")})
+
+    # --- L3 texture ---
+    # 1:1 for texture = "indistinguishable from real measured the SAME way", so
+    # each channel's pass band centers on the harness-measured real value
+    # (dynamic target), not the reports' hand-crop numbers (a different method).
+    # The documented Part-1 targets ride along as ``spec_target`` annotations.
+    _log("stage: L3 texture / degradation parity")
+    tex = _l3_texture(real_gray, render_warp, body, dark_thresh, GS, args.refpack,
+                      args.render, args.labels, exclude_lines)
+
+    def _gate_dyn(value, real_value, key):
+        spec = cfg["L3"][key]
+        g = _gate(value, {"target": real_value, "tol": spec["tol"], "dir": "band"})
+        g["real_measured"] = real_value
+        g["spec_target"] = spec.get("target")
+        return g
+
+    L3 = {
+        "ink_darkness": _gate_dyn(tex["render_stroke_core_L"], tex["real_stroke_core_L"], "ink_darkness"),
+        "stroke_cov": _gate_dyn(tex["render_stroke_cov"], tex["real_stroke_cov"], "stroke_cov"),
+        "edge_transition_frac": _gate_dyn(tex["render_edge_transition_frac"],
+                                          tex["real_edge_transition_frac"], "edge_transition_frac"),
+        "paper_clip_frac": _gate_dyn(tex["render_paper_clip_frac"],
+                                     tex["real_paper_clip_frac"], "paper_clip_frac"),
+        "ink_tone_emd": _gate(tex["ink_tone_emd"], cfg["L3"]["ink_tone_emd"]),
+        "kanungo_p": _gate(tex["kanungo_p"], cfg["L3"]["kanungo_p"]),
+        "kanungo_distance": tex["kanungo_distance"],
+    }
+    L3["pass"] = _level_pass({k: v for k, v in L3.items()
+                              if k in ("ink_darkness", "stroke_cov",
+                                       "edge_transition_frac", "paper_clip_frac",
+                                       "ink_tone_emd", "kanungo_p")})
+
+    # --- L4 perceptual + task ---
+    _log("stage: L4 MS-SSIM + OCR parity (+ forgery/TSTR stubs)")
+    ms = gm.ms_ssim(real_gray, render_warp)
+    ms_raw = gm.ms_ssim(real_gray, render_gray)
+    L4 = {
+        "ms_ssim": _gate(ms, cfg["L4"]["ms_ssim"]),
+        "ms_ssim_raw": ms_raw,
+        "glcm_contrast": {"real": gm.glcm_contrast(real_gray[body[0]:body[1]]),
+                          "render": gm.glcm_contrast(render_warp[body[0]:body[1]])},
+        "forgery_auc": NOT_IMPLEMENTED,
+        "tstr_gap": NOT_IMPLEMENTED,
+    }
+    if real_lines and render_lines:
+        gt = json.load(open(args.labels))["tokens"]
+        ocr = gm.ocr_error_sets(gt, real_lines, render_lines)
+        L4["ocr_jaccard"] = _gate(ocr["jaccard"], cfg["L4"]["ocr_jaccard"])
+        L4["ocr_recall"] = {"real": ocr["real_recall"], "render": ocr["render_recall"]}
+        L4["ocr_cer"] = {"real": ocr["real_cer"], "render": ocr["render_cer"]}
+        L4["ocr_error_classes"] = {"shared": len(ocr["shared"]),
+                                   "render_only": len(ocr["render_only"]),
+                                   "real_only": len(ocr["real_only"])}
+        # spacing jitter needs render OCR line-grouped glyph centers -> approx
+        # from token x-centers per OCR line row
+        by_row = defaultdict(list)
+        for l in render_lines:
+            by_row[round(l["y"] / 25.0)].append(l["x"] + l["w"] / 2.0)
+        L4["spacing_jitter_render"] = gm.spacing_jitter(list(by_row.values()))
+    else:
+        L4["ocr_jaccard"] = {"value": None, "pass": None, "note": NOT_IMPLEMENTED}
+        L4["ocr_recall"] = NOT_IMPLEMENTED
+        L4["ocr_cer"] = NOT_IMPLEMENTED
+    L4["pass"] = _level_pass({k: v for k, v in L4.items()
+                              if k in ("ms_ssim", "ocr_jaccard")})
+
+    scorecard["L0"] = L0
+    scorecard["L1"] = L1
+    scorecard["L2"] = L2
+    scorecard["L3"] = L3
+    scorecard["L4"] = L4
+
+    # overall rung cleared (first level that fails)
+    cleared = "L4-pass"
+    for lvl in ("L0", "L1", "L2", "L3", "L4"):
+        if not scorecard[lvl].get("pass"):
+            cleared = f"{lvl}-fail"
+            break
+    scorecard["overall_rung_cleared"] = cleared
+    scorecard["elapsed_sec"] = round(time.time() - t_start, 1)
+    return scorecard
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--render", required=True)
+    ap.add_argument("--real", required=True)
+    ap.add_argument("--labels", required=True)
+    ap.add_argument("--refpack", required=True)
+    ap.add_argument("--chart", required=True)
+    ap.add_argument("--config", required=True)
+    ap.add_argument("--out")
+    ap.add_argument("--glyphscore-root",
+                    default=os.environ.get("GLYPHSCORE_ROOT", "/private/tmp/glyphscore"))
+    ap.add_argument("--cache-dir",
+                    default=os.path.join(tempfile.gettempdir(), "costco_gold_cache"))
+    args = ap.parse_args(argv)
+
+    sc = build_scorecard(args)
+    text = json.dumps(sc, indent=2, sort_keys=False)
+    if args.out:
+        with open(args.out, "w") as fh:
+            fh.write(text + "\n")
+        _log(f"wrote {args.out}")
+    print(text)
+    _log(f"overall: {sc['overall_rung_cleared']} in {sc['elapsed_sec']}s")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/glyph-studio/py/glyphstudio/gold_metrics.py
+++ b/tools/glyph-studio/py/glyphstudio/gold_metrics.py
@@ -1,0 +1,707 @@
+"""Analytic metric library for the Costco gold-standard benchmark harness.
+
+Pure numpy + scipy implementations of the L0-L4 measurement-ladder metrics
+described in ``GOLD_STANDARD.md`` (Part 1 / Part 3). Nothing here needs a
+trained model: every function is a deterministic pixel/geometry/texture
+statistic so the ladder is reproducible offline.
+
+Grouped by rung:
+
+- L0 bulk gates: :func:`ink_ratio`, :func:`normalized_fill`,
+  :func:`cap_height_px`, :func:`line_pitch_px`.
+- L2 geometry: :func:`chamfer_distance`, :func:`boundary_iou`,
+  :func:`advance_width_px`, :func:`right_edge_std`, :func:`caption_height_ratio`.
+- L3 texture/degradation: :func:`stroke_core_stats`,
+  :func:`edge_transition_frac`, :func:`paper_clip_frac`, :func:`tone_emd`,
+  :func:`kanungo_pattern_hist`, :func:`kanungo_two_sample`.
+- L4 perceptual/task: :func:`ssim_map`, :func:`ms_ssim`, :func:`ocr_error_sets`,
+  :func:`glcm_contrast`, :func:`spacing_jitter`.
+- Alignment: :func:`ocr_anchors`, :func:`piecewise_row_warp`.
+
+Conventions: images are 2-D float64 luminance arrays (0=black, 255=white);
+"ink" is darkness ``255 - L``; binary masks are bool ink==True. Physical
+units for chamfer are pixels on the array the masks live in (the CLI reports
+"dots" on the aspect-normalized 32x32 glyph grid).
+"""
+
+from __future__ import annotations
+
+import re
+from difflib import SequenceMatcher
+from typing import Iterable, Optional, Sequence
+
+import numpy as np
+from numpy.lib.stride_tricks import sliding_window_view
+from scipy import ndimage
+
+# ---------------------------------------------------------------------------
+# L0 -- bulk ink & geometry gates
+# ---------------------------------------------------------------------------
+
+
+def ink_ratio(real: np.ndarray, render: np.ndarray) -> float:
+    """Total-ink ratio Sigma(255-L)_render / Sigma(255-L)_real.
+
+    Single scalar for "too heavy/dark". Equivalent to the ratio of mean
+    darkness when both images share a canvas size.
+    """
+    real = np.asarray(real, dtype=np.float64)
+    render = np.asarray(render, dtype=np.float64)
+    denom = float((255.0 - real).sum())
+    if denom <= 0:
+        return float("nan")
+    return float((255.0 - render).sum()) / denom
+
+
+def normalized_fill(masks: Iterable[np.ndarray]) -> float:
+    """Median normalized fill fraction (ink px / box) over a set of masks.
+
+    Masks are the aspect-normalized glyph masks GlyphScore produces, so this
+    separates "more ink per glyph" (dot-gain) from "bigger glyphs" (scale).
+    """
+    fills = [float(np.asarray(m, bool).mean()) for m in masks if np.asarray(m).size]
+    if not fills:
+        return float("nan")
+    return float(np.median(fills))
+
+
+def _row_ink_bands(
+    gray: np.ndarray, y0: int, y1: int, ink_thresh: float = 0.06
+) -> list[tuple[int, int]]:
+    """Row bands (contiguous inked-row runs) inside [y0, y1).
+
+    A row is "inked" when its mean darkness exceeds ``ink_thresh`` of the
+    band's peak. Bands separated by >=2 blank rows are split.
+    """
+    band = np.asarray(gray, np.float64)[y0:y1]
+    prof = (255.0 - band).mean(axis=1)
+    if prof.max() <= 0:
+        return []
+    inked = prof > (prof.max() * ink_thresh)
+    rows = np.where(inked)[0]
+    if rows.size == 0:
+        return []
+    out: list[list[int]] = [[int(rows[0]), int(rows[0])]]
+    for r in rows[1:]:
+        if r - out[-1][1] - 1 < 2:
+            out[-1][1] = int(r)
+        else:
+            out.append([int(r), int(r)])
+    return [(a + y0, b + y0) for a, b in out]
+
+
+def cap_height_px(
+    gray: np.ndarray, y0: int, y1: int, ink_thresh: float = 0.06
+) -> float:
+    """Band-snapped cap height: median height of inked row-bands in a region.
+
+    The gap analysts' trustworthy figure (``gap_geometry.md`` Headline): band
+    heights snap to the true text line extent, avoiding the leaked-neighbour
+    error of a fixed window. Returns median band height in pixels.
+    """
+    bands = _row_ink_bands(gray, y0, y1, ink_thresh)
+    heights = [b - a + 1 for a, b in bands if (b - a + 1) >= 3]
+    if not heights:
+        return float("nan")
+    return float(np.median(heights))
+
+
+def line_pitch_px(
+    gray: np.ndarray, y0: int, y1: int, ink_thresh: float = 0.06
+) -> float:
+    """Median row-center spacing (line pitch) between inked bands in a region."""
+    bands = _row_ink_bands(gray, y0, y1, ink_thresh)
+    centers = [0.5 * (a + b) for a, b in bands if (b - a + 1) >= 3]
+    if len(centers) < 2:
+        return float("nan")
+    diffs = np.diff(sorted(centers))
+    # keep only plausible single-line steps (reject big gaps between blocks)
+    med = float(np.median(diffs))
+    keep = diffs[(diffs > 0.5 * med) & (diffs < 1.8 * med)]
+    return float(np.median(keep)) if keep.size else med
+
+
+def _autocorr_peak(sig: np.ndarray, lo: int, hi: int, min_rel: float = 0.2) -> float:
+    """First strong autocorrelation peak of ``sig`` in lag range [lo, hi).
+
+    Robust to a crammed layout (unlike band-splitting) because it reads the
+    dominant *period* of the ink profile. Returns nan if no lag clears
+    ``min_rel`` of the zero-lag energy.
+    """
+    x = np.asarray(sig, np.float64)
+    x = x - x.mean()
+    ac = np.correlate(x, x, "full")[len(x) - 1:]
+    if ac[0] <= 0:
+        return float("nan")
+    ac = ac / ac[0]
+    hi = min(hi, ac.size)
+    if hi <= lo:
+        return float("nan")
+    seg = ac[lo:hi]
+    if seg.size == 0 or seg.max() < min_rel:
+        return float("nan")
+    k = lo + int(np.argmax(seg))
+    # parabolic (sub-pixel) refinement around the peak -- a 1-px integer lag
+    # would wrongly fail a tight pitch band (real 44.8 vs render 45.0).
+    if 0 < k < ac.size - 1:
+        ym1, y0v, yp1 = ac[k - 1], ac[k], ac[k + 1]
+        denom = ym1 - 2 * y0v + yp1
+        if denom != 0:
+            offset = 0.5 * (ym1 - yp1) / denom
+            if -1.0 < offset < 1.0:
+                return float(k + offset)
+    return float(k)
+
+
+def line_pitch_autocorr(
+    gray: np.ndarray, y0: int, y1: int, lo: int = 20, hi: int = 80
+) -> float:
+    """Line pitch (px) = dominant period of the region's row-ink profile.
+
+    Reproduces the true line pitch on both a crammed render and an airy scan,
+    where band-splitting fails (adjacent crammed lines merge into one band).
+    """
+    prof = (255.0 - np.asarray(gray, np.float64)[y0:y1]).mean(axis=1)
+    return _autocorr_peak(prof, lo, hi)
+
+
+def interline_duty(
+    gray: np.ndarray, y0: int, y1: int, frac: float = 0.35
+) -> float:
+    """Duty cycle = fraction of region rows inked above ``frac`` of the p99
+    row-darkness -- the "leading crammed" tell (render ~0.80, real ~0.67).
+
+    cap_height ~= duty * pitch, so the ratio of duties (at equal pitch) is the
+    cap-height ratio the gap report names as the dominant vertical tell.
+    """
+    prof = (255.0 - np.asarray(gray, np.float64)[y0:y1]).mean(axis=1)
+    if prof.size == 0:
+        return float("nan")
+    peak = np.percentile(prof, 99)
+    if peak <= 0:
+        return float("nan")
+    return float((prof > frac * peak).mean())
+
+
+def char_advance_autocorr(
+    gray: np.ndarray, y0: int, y1: int, lo: int = 12, hi: int = 34,
+    min_ink: int = 8,
+) -> float:
+    """Character advance width (px) = median per-row horizontal ink period.
+
+    The horizontal analogue of :func:`line_pitch_autocorr`: for a monospace
+    receipt each inked row's autocorrelation peaks at the character pitch.
+    Measured identically on real and render, so the ratio is method-fair.
+    """
+    band = 255.0 - np.asarray(gray, np.float64)[y0:y1]
+    peaks = []
+    for row in band:
+        if int((row > 40).sum()) < min_ink:
+            continue
+        p = _autocorr_peak(row, lo, hi)
+        if np.isfinite(p):
+            peaks.append(p)
+    return float(np.median(peaks)) if peaks else float("nan")
+
+
+# ---------------------------------------------------------------------------
+# L2 -- geometry / pitch parity
+# ---------------------------------------------------------------------------
+
+
+def chamfer_distance(mask_a: np.ndarray, mask_b: np.ndarray) -> float:
+    """Symmetric mean chamfer distance (pixels) between two binary masks.
+
+    Mean over A's ink of the distance to the nearest B ink, symmetrized with
+    B->A. Robust to uniform printer thickening (edges stay close even when
+    area-IoU collapses), which is why the similarity research prefers it over
+    raw IoU for thin strokes. Empty masks -> nan.
+    """
+    a = np.asarray(mask_a, bool)
+    b = np.asarray(mask_b, bool)
+    if not a.any() or not b.any():
+        return float("nan")
+    # distance_transform_edt gives distance to nearest False; invert so we get
+    # distance to nearest ink.
+    dt_b = ndimage.distance_transform_edt(~b)
+    dt_a = ndimage.distance_transform_edt(~a)
+    ab = float(dt_b[a].mean())
+    ba = float(dt_a[b].mean())
+    return 0.5 * (ab + ba)
+
+
+def _boundary(mask: np.ndarray, band: int) -> np.ndarray:
+    """Pixels within ``band`` of the mask contour (Boundary-IoU band)."""
+    m = np.asarray(mask, bool)
+    if not m.any():
+        return np.zeros_like(m)
+    eroded = ndimage.binary_erosion(m, iterations=band, border_value=0)
+    return m & ~eroded
+
+
+def boundary_iou(mask_a: np.ndarray, mask_b: np.ndarray, band: int = 2) -> float:
+    """Boundary IoU (Cheng et al. CVPR21): IoU restricted to a contour band.
+
+    More sensitive to boundary/shape error than mask IoU and not biased by
+    uniform thickening of a filled interior. band ~ stroke width.
+    """
+    a = np.asarray(mask_a, bool)
+    b = np.asarray(mask_b, bool)
+    if not a.any() or not b.any():
+        return float("nan")
+    ba = _boundary(a, band)
+    bb = _boundary(b, band)
+    inter = float((ba & bb).sum())
+    union = float((ba | bb).sum())
+    return inter / union if union > 0 else float("nan")
+
+
+def advance_width_px(boxes: Sequence[tuple[float, str]]) -> float:
+    """Median advance width (px/char) over (width_px, text) tokens.
+
+    Only multi-char alphanumeric tokens (>=4 chars) count, matching the gap
+    report's definition; punctuation/short tokens are noisy.
+    """
+    vals = []
+    for width, text in boxes:
+        n = len([c for c in text if c.isalnum()])
+        if n >= 4 and width > 0:
+            vals.append(width / n)
+    return float(np.median(vals)) if vals else float("nan")
+
+
+def right_edge_std(x_rights: Sequence[float]) -> float:
+    """Std (px) of a set of right-edge x-coordinates (price-column raggedness)."""
+    xs = np.asarray(list(x_rights), float)
+    if xs.size < 2:
+        return float("nan")
+    return float(xs.std())
+
+
+def caption_height_ratio(render_h: float, real_h: float) -> float:
+    """Ratio render/real of a caption line height (barcode caption gate)."""
+    if not real_h:
+        return float("nan")
+    return float(render_h) / float(real_h)
+
+
+# ---------------------------------------------------------------------------
+# L3 -- texture / degradation parity
+# ---------------------------------------------------------------------------
+
+
+def stroke_core_stats(gray: np.ndarray, ink_mask: np.ndarray, erode: int = 1) -> dict:
+    """Median luminance, std and CoV of stroke *cores* (eroded ink interior).
+
+    Real thermal strokes are light and mottled (median L ~69, CoV ~0.35);
+    a too-clean render sits dark and uniform (median L ~12, CoV ~0.06).
+    """
+    g = np.asarray(gray, np.float64)
+    m = np.asarray(ink_mask, bool)
+    if erode > 0:
+        m = ndimage.binary_erosion(m, iterations=erode, border_value=0)
+    vals = g[m]
+    if vals.size < 8:
+        return {"median_L": float("nan"), "std": float("nan"), "cov": float("nan"),
+                "n": int(vals.size)}
+    med = float(np.median(vals))
+    std = float(vals.std())
+    ink = 255.0 - vals  # CoV on ink (darkness), the physically meaningful signal
+    cov = float(ink.std() / ink.mean()) if ink.mean() > 0 else float("nan")
+    return {"median_L": med, "std": std, "cov": cov, "n": int(vals.size)}
+
+
+def edge_transition_frac(
+    gray: np.ndarray, region: Optional[np.ndarray] = None,
+    lo: float = 64.0, hi: float = 192.0,
+) -> float:
+    """Fraction of (region) pixels in the mid-tone transition band [lo, hi].
+
+    Soft thermal/scan edges spread ink across many intermediate grays
+    (frac ~0.16); crisp vector edges jump black->white (frac ~0.04). A
+    scale-free proxy for edge softness.
+    """
+    g = np.asarray(gray, np.float64)
+    if region is not None:
+        g = g[np.asarray(region, bool)]
+    if g.size == 0:
+        return float("nan")
+    return float(((g >= lo) & (g <= hi)).mean())
+
+
+def paper_clip_frac(gray: np.ndarray, thresh: float = 254.5) -> float:
+    """Fraction of pixels clipped to white (>= thresh) -- the paper model.
+
+    A scanner auto-level crushes paper grain to featureless 255 (real ~0.55);
+    a textured render leaves it unclipped (render ~0.025).
+    """
+    g = np.asarray(gray, np.float64)
+    return float((g >= thresh).mean())
+
+
+def tone_emd(real: np.ndarray, render: np.ndarray, bins: int = 64) -> float:
+    """1-D Wasserstein (EMD) between the two luminance histograms, gray levels."""
+    r = np.asarray(real, np.float64).ravel()
+    f = np.asarray(render, np.float64).ravel()
+    hr, edges = np.histogram(r, bins=bins, range=(0, 255), density=True)
+    hf, _ = np.histogram(f, bins=bins, range=(0, 255), density=True)
+    cr = np.cumsum(hr) / hr.sum()
+    cf = np.cumsum(hf) / hf.sum()
+    return float(np.sum(np.abs(cr - cf)) * (255.0 / bins))
+
+
+def kanungo_pattern_hist(binary: np.ndarray) -> np.ndarray:
+    """Normalized 3x3 neighbourhood-pattern histogram (512 bins).
+
+    Each interior pixel maps its 3x3 binary neighbourhood to one of 512
+    codes; the histogram is the print-forensics texture signature Kanungo &
+    Zheng match to fit degradation params (``research_printer.md`` s1/s7).
+    """
+    b = np.asarray(binary, bool).astype(np.int32)
+    if b.shape[0] < 3 or b.shape[1] < 3:
+        return np.zeros(512, np.float64)
+    windows = sliding_window_view(b, (3, 3))  # (H-2, W-2, 3, 3)
+    weights = (1 << np.arange(9)).reshape(3, 3)
+    codes = np.tensordot(windows, weights, axes=([2, 3], [0, 1])).ravel()
+    hist = np.bincount(codes, minlength=512).astype(np.float64)
+    total = hist.sum()
+    return hist / total if total > 0 else hist
+
+
+def _pattern_hist_from_crops(crops: Sequence[np.ndarray]) -> np.ndarray:
+    """Pooled, normalized 3x3 pattern histogram over a stack of binary crops."""
+    acc = np.zeros(512, np.float64)
+    for c in crops:
+        b = np.asarray(c, bool).astype(np.int32)
+        if b.shape[0] < 3 or b.shape[1] < 3:
+            continue
+        windows = sliding_window_view(b, (3, 3))
+        weights = (1 << np.arange(9)).reshape(3, 3)
+        codes = np.tensordot(windows, weights, axes=([2, 3], [0, 1])).ravel()
+        acc += np.bincount(codes, minlength=512)
+    total = acc.sum()
+    return acc / total if total > 0 else acc
+
+
+def kanungo_two_sample(
+    crops_a: Sequence[np.ndarray],
+    crops_b: Sequence[np.ndarray],
+    n_perm: int = 200,
+    seed: int = 0,
+) -> dict:
+    """Two-sample test on 3x3 pattern histograms (render crops vs real crops).
+
+    Returns the L1 distance between the pooled pattern histograms and a
+    permutation p-value (fraction of label-shuffled splits whose distance is
+    >= the observed). p above the acceptance threshold => "fail to reject":
+    the two crop sets are texturally indistinguishable (the L3 accept gate,
+    analogous to GlyphScore). Small/degenerate inputs -> nan p.
+    """
+    a = [np.asarray(c, bool) for c in crops_a if np.asarray(c).size]
+    b = [np.asarray(c, bool) for c in crops_b if np.asarray(c).size]
+    if len(a) < 2 or len(b) < 2:
+        return {"distance": float("nan"), "p_value": float("nan"),
+                "n_a": len(a), "n_b": len(b)}
+    ha = _pattern_hist_from_crops(a)
+    hb = _pattern_hist_from_crops(b)
+    observed = float(np.abs(ha - hb).sum())
+    # permutation: pool, reshuffle labels, recompute distance
+    pooled = a + b
+    na = len(a)
+    rng = np.random.default_rng(seed)
+    ge = 0
+    for _ in range(n_perm):
+        idx = rng.permutation(len(pooled))
+        pa = [pooled[i] for i in idx[:na]]
+        pb = [pooled[i] for i in idx[na:]]
+        d = float(np.abs(_pattern_hist_from_crops(pa) - _pattern_hist_from_crops(pb)).sum())
+        if d >= observed:
+            ge += 1
+    p = (ge + 1) / (n_perm + 1)
+    return {"distance": observed, "p_value": float(p), "n_a": na, "n_b": len(b)}
+
+
+# ---------------------------------------------------------------------------
+# L4 -- perceptual + task parity
+# ---------------------------------------------------------------------------
+
+
+def _gauss_kernel(sigma: float = 1.5, radius: int = 5) -> np.ndarray:
+    x = np.arange(-radius, radius + 1)
+    k = np.exp(-x * x / (2 * sigma * sigma))
+    return k / k.sum()
+
+
+def _blur(im: np.ndarray, kernel: np.ndarray) -> np.ndarray:
+    r = (len(kernel) - 1) // 2
+    p = np.pad(im, ((r, r), (0, 0)), mode="reflect")
+    w = sliding_window_view(p, len(kernel), axis=0)
+    im = np.tensordot(w, kernel, axes=([2], [0]))
+    p = np.pad(im, ((0, 0), (r, r)), mode="reflect")
+    w = sliding_window_view(p, len(kernel), axis=1)
+    return np.tensordot(w, kernel, axes=([2], [0]))
+
+
+def ssim_map(a: np.ndarray, b: np.ndarray, L: float = 255.0) -> np.ndarray:
+    """Per-pixel SSIM map (Gaussian 11-tap, sigma 1.5) -- the metrics.py port."""
+    a = np.asarray(a, np.float64)
+    b = np.asarray(b, np.float64)
+    k = _gauss_kernel()
+    C1 = (0.01 * L) ** 2
+    C2 = (0.03 * L) ** 2
+    mu_a = _blur(a, k)
+    mu_b = _blur(b, k)
+    aa = _blur(a * a, k) - mu_a ** 2
+    bb = _blur(b * b, k) - mu_b ** 2
+    ab = _blur(a * b, k) - mu_a * mu_b
+    return ((2 * mu_a * mu_b + C1) * (2 * ab + C2)) / (
+        (mu_a ** 2 + mu_b ** 2 + C1) * (aa + bb + C2)
+    )
+
+
+def _downsample2(im: np.ndarray) -> np.ndarray:
+    h = im.shape[0] // 2 * 2
+    w = im.shape[1] // 2 * 2
+    return im[:h, :w].reshape(h // 2, 2, w // 2, 2).mean((1, 3))
+
+
+def ms_ssim(a: np.ndarray, b: np.ndarray, levels: int = 5) -> float:
+    """Multi-scale SSIM (standard 5-scale weights) -- the metrics.py port."""
+    weights = np.array([0.0448, 0.2856, 0.3001, 0.2363, 0.1333])
+    a = np.asarray(a, np.float64)
+    b = np.asarray(b, np.float64)
+    mcs = []
+    lssim = 1.0
+    for i in range(levels):
+        s = ssim_map(a, b)
+        if i < levels - 1:
+            mcs.append(max(s.mean(), 1e-6))
+            a = _downsample2(a)
+            b = _downsample2(b)
+        else:
+            lssim = s.mean()
+    mcs = np.array(mcs)
+    val = np.prod(mcs ** weights[: levels - 1]) * (lssim ** weights[levels - 1])
+    return float(val)
+
+
+def _tokens(lines: Sequence[dict], row_q: float = 25.0) -> list[str]:
+    """Reading-order token stream from OCR line dicts ({text,x,y})."""
+    ordered = sorted(lines, key=lambda l: (round(l["y"] / row_q), l["x"]))
+    joined = " ".join(l["text"] for l in ordered)
+    return re.findall(r"\S+", joined)
+
+
+def _align_subs(ref: Sequence[str], hyp: Sequence[str]):
+    sm = SequenceMatcher(None, list(ref), list(hyp))
+    nok = 0
+    subs: dict[str, str] = {}
+    for tag, i1, i2, j1, j2 in sm.get_opcodes():
+        if tag == "equal":
+            nok += i2 - i1
+        elif tag == "replace":
+            for k in range(max(i2 - i1, j2 - j1)):
+                r = ref[i1 + k] if i1 + k < i2 else ""
+                h = hyp[j1 + k] if j1 + k < j2 else ""
+                if r and r != h:
+                    subs.setdefault(r, h)
+        elif tag == "delete":
+            for x in range(i1, i2):
+                subs.setdefault(ref[x], "")
+    return nok, subs
+
+
+def ocr_error_sets(gt: Sequence[str], real_lines, render_lines) -> dict:
+    """OCR error-set parity: Jaccard of the mis-read GT-token sets, plus
+    per-image token recall and char-error-rate vs ground truth.
+
+    A realistic render makes the *same* OCR errors as the real scan
+    (Jaccard->1); a too-clean/artefact-laden render adds its own error class
+    (a superset). (``research_metrics.md`` axis-2 / ``gap_perceptual.md`` s6.)
+    """
+    gt = list(gt)
+    rt = _tokens(real_lines)
+    ft = _tokens(render_lines)
+    rok, rsubs = _align_subs(gt, rt)
+    fok, fsubs = _align_subs(gt, ft)
+
+    def cer(ref: Sequence[str], hyp: Sequence[str]) -> float:
+        a = "".join(ref)
+        b = "".join(hyp)
+        return 1.0 - SequenceMatcher(None, a, b).ratio()
+
+    shared = set(rsubs) & set(fsubs)
+    either = set(rsubs) | set(fsubs)
+    jacc = len(shared) / len(either) if either else float("nan")
+    return {
+        "jaccard": float(jacc),
+        "real_recall": rok / len(gt) if gt else float("nan"),
+        "render_recall": fok / len(gt) if gt else float("nan"),
+        "real_cer": cer(gt, rt),
+        "render_cer": cer(gt, ft),
+        "shared": sorted(shared),
+        "render_only": sorted(set(fsubs) - set(rsubs)),
+        "real_only": sorted(set(rsubs) - set(fsubs)),
+    }
+
+
+def glcm_contrast(gray: np.ndarray, levels: int = 16, dx: int = 1, dy: int = 0) -> float:
+    """GLCM contrast at one offset -- a scalar texture descriptor.
+
+    A cheap, model-free stand-in for the printer-source texture cluster
+    (``research_forgery.md`` 3.4): quantize to ``levels`` grays, build the
+    co-occurrence matrix at offset (dy,dx), return sum p*(i-j)^2. Compared
+    render-vs-real it flags "too smooth" (low contrast) fills.
+    """
+    g = np.asarray(gray, np.float64)
+    q = np.clip((g / 256.0 * levels).astype(int), 0, levels - 1)
+    a = q[: q.shape[0] - dy if dy else q.shape[0], : q.shape[1] - dx if dx else q.shape[1]]
+    b = q[dy:, dx:]
+    a = a[: b.shape[0], : b.shape[1]]
+    idx = a.ravel() * levels + b.ravel()
+    glcm = np.bincount(idx, minlength=levels * levels).astype(np.float64).reshape(levels, levels)
+    glcm = glcm + glcm.T
+    total = glcm.sum()
+    if total <= 0:
+        return float("nan")
+    glcm /= total
+    i = np.arange(levels)[:, None]
+    j = np.arange(levels)[None, :]
+    return float((glcm * (i - j) ** 2).sum())
+
+
+def spacing_jitter(centers_by_line: Sequence[Sequence[float]]) -> float:
+    """Sub-cell spacing-jitter statistic across text lines.
+
+    For each line, the std of successive glyph-center gaps normalized by the
+    line's median gap; averaged over lines. Mechanically-perfect grid spacing
+    -> ~0 (a named forensic tell, ``research_forgery.md`` 2.8); real print
+    carries micro-variation. Reported so a render can be checked for having
+    *some* jitter without inventing artificial drift.
+    """
+    per_line = []
+    for centers in centers_by_line:
+        c = np.asarray(sorted(centers), float)
+        if c.size < 3:
+            continue
+        gaps = np.diff(c)
+        med = np.median(gaps)
+        if med <= 0:
+            continue
+        per_line.append(float(gaps.std() / med))
+    if not per_line:
+        return float("nan")
+    return float(np.mean(per_line))
+
+
+# ---------------------------------------------------------------------------
+# Alignment (OCR-anchored piecewise-linear vertical warp)
+# ---------------------------------------------------------------------------
+
+
+def _clean_text(s: str) -> str:
+    return re.sub(r"[^A-Za-z0-9]", "", s).upper()
+
+
+def ocr_anchors(
+    real_lines: Sequence[dict],
+    render_lines: Sequence[dict],
+    min_sim: float = 0.85,
+    min_len: int = 4,
+) -> list[tuple[float, float, float]]:
+    """OCR line-box correspondences (real_cy, render_cy, similarity).
+
+    Matches real OCR lines to render OCR lines by cleaned-text similarity
+    (>= ``min_sim``), 1:1 greedily, then slope-outlier rejects to a monotone
+    anchor set (the ``match2.py`` recipe). Coordinates are line-center y.
+    """
+    def prep(lines):
+        out = []
+        for l in lines:
+            out.append({"cy": l["y"] + l["h"] / 2.0, "text": l["text"]})
+        out.sort(key=lambda x: x["cy"])
+        return out
+
+    R = prep(real_lines)
+    F = prep(render_lines)
+    used = [False] * len(F)
+    anchors: list[tuple[float, float, float]] = []
+    for r in R:
+        rc = _clean_text(r["text"])
+        if len(rc) < min_len:
+            continue
+        best = (-1.0, -1)
+        for j, f in enumerate(F):
+            if used[j]:
+                continue
+            fc = _clean_text(f["text"])
+            if len(fc) < min_len:
+                continue
+            s = SequenceMatcher(None, rc, fc).ratio()
+            if s > best[0]:
+                best = (s, j)
+        if best[1] >= 0 and best[0] >= min_sim:
+            used[best[1]] = True
+            anchors.append((r["cy"], F[best[1]]["cy"], best[0]))
+    anchors.sort()
+
+    # slope-outlier rejection (successive slope must be plausible)
+    def bad_indices(a):
+        bad = []
+        for i in range(1, len(a)):
+            dy_r = a[i][0] - a[i - 1][0]
+            dy_f = a[i][1] - a[i - 1][1]
+            if dy_r <= 0:
+                continue
+            s = dy_f / dy_r
+            if s < 0.55 or s > 1.8:
+                bad.append(i)
+        return bad
+
+    a = anchors[:]
+    for _ in range(200):
+        bad = bad_indices(a)
+        if not bad:
+            break
+        from collections import Counter
+
+        c: Counter = Counter()
+        for i in bad:
+            c[i] += 1
+            c[i - 1] += 1
+        worst = max(c, key=lambda k: c[k])
+        a.pop(worst)
+    return a
+
+
+def piecewise_row_warp(
+    render_gray: np.ndarray, anchors: Sequence[tuple[float, float, float]], H: int
+):
+    """Warp render into the real frame by vertical piecewise-linear map.
+
+    ``anchors`` are (real_cy, render_cy, sim). Returns (warped_render,
+    residual_std). residual_std is the std of the linear-fit residual of the
+    anchors -- the "geometry not matched" flag driver.
+    """
+    render_gray = np.asarray(render_gray, np.float64)
+    if len(anchors) < 2:
+        return render_gray.copy(), float("inf")
+    yr = np.array([a[0] for a in anchors], float)
+    yf = np.array([a[1] for a in anchors], float)
+    # linear-fit residual std (reported)
+    A = np.vstack([yr, np.ones_like(yr)]).T
+    coef, *_ = np.linalg.lstsq(A, yf, rcond=None)
+    resid = yf - A @ coef
+    resid_std = float(resid.std())
+    # extend anchors to the edges, then interpolate a source-row map
+    yr_e = np.concatenate([[0.0], yr, [H - 1.0]])
+    yf_e = np.concatenate(
+        [[max(0.0, yf[0] - yr[0])], yf, [min(H - 1.0, yf[-1] + (H - 1 - yr[-1]))]]
+    )
+    rows = np.arange(H)
+    srcf = np.interp(rows, yr_e, yf_e)
+    f0 = np.clip(np.floor(srcf).astype(int), 0, H - 1)
+    f1 = np.clip(f0 + 1, 0, H - 1)
+    w1 = (srcf - f0)[:, None]
+    warped = render_gray[f0] * (1 - w1) + render_gray[f1] * w1
+    return warped, resid_std

--- a/tools/glyph-studio/py/glyphstudio/gold_metrics.py
+++ b/tools/glyph-studio/py/glyphstudio/gold_metrics.py
@@ -466,7 +466,16 @@ def _downsample2(im: np.ndarray) -> np.ndarray:
 
 
 def ms_ssim(a: np.ndarray, b: np.ndarray, levels: int = 5) -> float:
-    """Multi-scale SSIM (standard 5-scale weights) -- the metrics.py port."""
+    """Multi-scale SSIM, 5-scale standard weights.
+
+    NOTE: this is the ``metrics.py`` port used to produce the committed Costco
+    reference (raw MS-SSIM 0.32328...), so it is kept bit-faithful to that
+    implementation on purpose -- it uses the full SSIM-map mean at each scale
+    as the contrast-structure proxy rather than the textbook CS-only term.
+    Changing the formula would break the required reproduction of the gap
+    report's numbers. All powered components are clamped non-negative so a
+    negative SSIM cannot produce NaN via a fractional power.
+    """
     weights = np.array([0.0448, 0.2856, 0.3001, 0.2363, 0.1333])
     a = np.asarray(a, np.float64)
     b = np.asarray(b, np.float64)
@@ -479,10 +488,35 @@ def ms_ssim(a: np.ndarray, b: np.ndarray, levels: int = 5) -> float:
             a = _downsample2(a)
             b = _downsample2(b)
         else:
-            lssim = s.mean()
+            lssim = max(s.mean(), 1e-6)  # clamp: no NaN from a negative base
     mcs = np.array(mcs)
     val = np.prod(mcs ** weights[: levels - 1]) * (lssim ** weights[levels - 1])
     return float(val)
+
+
+def _levenshtein(a: str, b: str) -> int:
+    """Edit distance (ins/del/sub) between two strings."""
+    if a == b:
+        return 0
+    if not a:
+        return len(b)
+    if not b:
+        return len(a)
+    prev = list(range(len(b) + 1))
+    for i, ca in enumerate(a, 1):
+        cur = [i]
+        for j, cb in enumerate(b, 1):
+            cur.append(min(prev[j] + 1, cur[j - 1] + 1,
+                           prev[j - 1] + (ca != cb)))
+        prev = cur
+    return prev[-1]
+
+
+def char_error_rate(ref: str, hyp: str) -> float:
+    """True character error rate: Levenshtein(ref, hyp) / len(ref)."""
+    if not ref:
+        return float("nan")
+    return _levenshtein(ref, hyp) / len(ref)
 
 
 def _tokens(lines: Sequence[dict], row_q: float = 25.0) -> list[str]:
@@ -526,9 +560,7 @@ def ocr_error_sets(gt: Sequence[str], real_lines, render_lines) -> dict:
     fok, fsubs = _align_subs(gt, ft)
 
     def cer(ref: Sequence[str], hyp: Sequence[str]) -> float:
-        a = "".join(ref)
-        b = "".join(hyp)
-        return 1.0 - SequenceMatcher(None, a, b).ratio()
+        return char_error_rate(" ".join(ref), " ".join(hyp))
 
     shared = set(rsubs) & set(fsubs)
     either = set(rsubs) | set(fsubs)
@@ -686,6 +718,7 @@ def piecewise_row_warp(
     render_gray = np.asarray(render_gray, np.float64)
     if len(anchors) < 2:
         return render_gray.copy(), float("inf")
+    Hr = render_gray.shape[0]  # clip source rows against the RENDER's height
     yr = np.array([a[0] for a in anchors], float)
     yf = np.array([a[1] for a in anchors], float)
     # linear-fit residual std (reported)
@@ -696,12 +729,12 @@ def piecewise_row_warp(
     # extend anchors to the edges, then interpolate a source-row map
     yr_e = np.concatenate([[0.0], yr, [H - 1.0]])
     yf_e = np.concatenate(
-        [[max(0.0, yf[0] - yr[0])], yf, [min(H - 1.0, yf[-1] + (H - 1 - yr[-1]))]]
+        [[max(0.0, yf[0] - yr[0])], yf, [min(Hr - 1.0, yf[-1] + (Hr - 1 - yr[-1]))]]
     )
     rows = np.arange(H)
     srcf = np.interp(rows, yr_e, yf_e)
-    f0 = np.clip(np.floor(srcf).astype(int), 0, H - 1)
-    f1 = np.clip(f0 + 1, 0, H - 1)
+    f0 = np.clip(np.floor(srcf).astype(int), 0, Hr - 1)
+    f1 = np.clip(f0 + 1, 0, Hr - 1)
     w1 = (srcf - f0)[:, None]
     warped = render_gray[f0] * (1 - w1) + render_gray[f1] * w1
     return warped, resid_std

--- a/tools/glyph-studio/py/ocr_vision.swift
+++ b/tools/glyph-studio/py/ocr_vision.swift
@@ -1,0 +1,34 @@
+import Foundation
+import Vision
+import AppKit
+
+let args = CommandLine.arguments
+guard args.count >= 2 else { fputs("usage: ocr <image>\n", stderr); exit(1) }
+let path = args[1]
+guard let img = NSImage(contentsOfFile: path),
+      let tiff = img.tiffRepresentation,
+      let bmp = NSBitmapImageRep(data: tiff),
+      let cg = bmp.cgImage else {
+    fputs("cannot load \(path)\n", stderr); exit(1)
+}
+let W = Double(cg.width), H = Double(cg.height)
+let req = VNRecognizeTextRequest()
+req.recognitionLevel = .accurate
+req.usesLanguageCorrection = false
+req.recognitionLanguages = ["en-US"]
+let handler = VNImageRequestHandler(cgImage: cg, options: [:])
+do { try handler.perform([req]) } catch { fputs("ocr err \(error)\n", stderr); exit(1) }
+var lines: [[String: Any]] = []
+for obs in (req.results ?? []) {
+    guard let cand = obs.topCandidates(1).first else { continue }
+    let bb = obs.boundingBox // normalized, origin bottom-left
+    let x = bb.origin.x * W
+    let y = (1.0 - bb.origin.y - bb.size.height) * H // convert to top-left
+    let w = bb.size.width * W
+    let h = bb.size.height * H
+    lines.append(["text": cand.string, "conf": cand.confidence,
+                  "x": x, "y": y, "w": w, "h": h])
+}
+let out: [String: Any] = ["path": path, "count": lines.count, "lines": lines]
+let data = try! JSONSerialization.data(withJSONObject: out, options: [.prettyPrinted])
+print(String(data: data, encoding: .utf8)!)

--- a/tools/glyph-studio/py/tests/test_gold_metrics.py
+++ b/tools/glyph-studio/py/tests/test_gold_metrics.py
@@ -196,6 +196,22 @@ def test_ocr_error_sets_parity():
     assert res["jaccard"] == pytest.approx(0.5)
 
 
+def test_char_error_rate():
+    assert gm.char_error_rate("HELLO", "HELLO") == pytest.approx(0.0)
+    # one substitution in a 5-char ref -> 0.2
+    assert gm.char_error_rate("HELLO", "HELLP") == pytest.approx(0.2)
+    # one deletion in a 4-char ref -> 0.25
+    assert gm.char_error_rate("ABCD", "ABD") == pytest.approx(0.25)
+
+
+def test_ms_ssim_no_nan_on_anticorrelated():
+    # anti-correlated images drive SSIM negative; must not return NaN
+    a = np.indices((32, 32)).sum(0) * 4.0
+    b = 255.0 - a
+    v = gm.ms_ssim(a, b)
+    assert np.isfinite(v)
+
+
 def test_glcm_contrast_flat_is_zero():
     g = np.full((20, 20), 100.0)
     assert gm.glcm_contrast(g) == pytest.approx(0.0)

--- a/tools/glyph-studio/py/tests/test_gold_metrics.py
+++ b/tools/glyph-studio/py/tests/test_gold_metrics.py
@@ -1,0 +1,234 @@
+"""Known-answer tests for the gold-standard metric library.
+
+Every metric is exercised on a synthetic fixture whose correct value is
+computable by hand, so a wiring regression in ``gold_metrics`` fails here
+before it corrupts a scorecard.
+"""
+
+import numpy as np
+import pytest
+
+from glyphstudio import gold_metrics as gm
+
+
+# --- L0 --------------------------------------------------------------------
+
+
+def test_ink_ratio_identical_is_one():
+    img = np.full((20, 20), 200.0)
+    img[5:10, 5:10] = 0.0
+    assert gm.ink_ratio(img, img) == pytest.approx(1.0)
+
+
+def test_ink_ratio_double_ink():
+    real = np.full((10, 10), 255.0)
+    real[0, 0] = 255.0 - 10.0  # ink sum 10
+    render = np.full((10, 10), 255.0)
+    render[0, 0] = 255.0 - 20.0  # ink sum 20
+    assert gm.ink_ratio(real, render) == pytest.approx(2.0)
+
+
+def test_normalized_fill_median():
+    m1 = np.zeros((4, 4), bool)
+    m1[:2] = True  # fill 0.5
+    m2 = np.zeros((4, 4), bool)
+    m2[0] = True  # fill 0.25
+    m3 = np.ones((4, 4), bool)  # fill 1.0
+    assert gm.normalized_fill([m1, m2, m3]) == pytest.approx(0.5)
+
+
+def test_cap_height_and_pitch_bands():
+    # three inked rows-bands of height 4, spaced 10 px center-to-center
+    g = np.full((40, 20), 255.0)
+    for top in (2, 12, 22):
+        g[top:top + 4, :] = 0.0
+    assert gm.cap_height_px(g, 0, 40) == pytest.approx(4.0)
+    assert gm.line_pitch_px(g, 0, 40) == pytest.approx(10.0)
+
+
+def test_line_pitch_autocorr_and_duty():
+    # periodic rows: pitch 10, each line 4 rows inked -> duty ~0.4
+    g = np.full((200, 20), 255.0)
+    for c in range(0, 200, 10):
+        g[c:c + 4, :] = 0.0
+    assert gm.line_pitch_autocorr(g, 0, 200, lo=5, hi=30) == pytest.approx(10.0, abs=0.2)
+    duty = gm.interline_duty(g, 0, 200, frac=0.5)
+    assert 0.3 < duty < 0.5
+
+
+def test_char_advance_autocorr():
+    # vertical ink stripes every 6 px across many rows -> advance 6
+    g = np.full((30, 120), 255.0)
+    for c in range(0, 120, 6):
+        g[:, c:c + 2] = 0.0
+    assert gm.char_advance_autocorr(g, 0, 30, lo=3, hi=15) == pytest.approx(6.0, abs=0.2)
+
+
+# --- L2 --------------------------------------------------------------------
+
+
+def test_chamfer_zero_on_identical():
+    m = np.zeros((10, 10), bool)
+    m[3:7, 3:7] = True
+    assert gm.chamfer_distance(m, m) == pytest.approx(0.0)
+
+
+def test_chamfer_shift_by_one():
+    a = np.zeros((10, 10), bool)
+    a[5, 3:7] = True
+    b = np.zeros((10, 10), bool)
+    b[6, 3:7] = True  # shifted down 1 row
+    # every A pixel is distance 1 from B and vice-versa
+    assert gm.chamfer_distance(a, b) == pytest.approx(1.0)
+
+
+def test_boundary_iou_identical_is_one():
+    m = np.zeros((16, 16), bool)
+    m[4:12, 4:12] = True
+    assert gm.boundary_iou(m, m, band=2) == pytest.approx(1.0)
+
+
+def test_boundary_iou_disjoint_is_zero():
+    a = np.zeros((16, 16), bool)
+    a[1:4, 1:4] = True
+    b = np.zeros((16, 16), bool)
+    b[12:15, 12:15] = True
+    assert gm.boundary_iou(a, b, band=1) == pytest.approx(0.0)
+
+
+def test_advance_width_px():
+    # only the >=4-char alnum token counts: 40px / 5 chars = 8
+    boxes = [(40.0, "HELLO"), (10.0, "hi"), (99.0, "a.b")]
+    assert gm.advance_width_px(boxes) == pytest.approx(8.0)
+
+
+def test_right_edge_std_and_caption_ratio():
+    assert gm.right_edge_std([100.0, 100.0, 100.0]) == pytest.approx(0.0)
+    assert gm.right_edge_std([98.0, 102.0]) == pytest.approx(2.0)
+    assert gm.caption_height_ratio(30.0, 50.0) == pytest.approx(0.6)
+
+
+# --- L3 --------------------------------------------------------------------
+
+
+def test_stroke_core_stats_uniform():
+    g = np.full((20, 20), 255.0)
+    g[5:15, 5:15] = 100.0  # a solid block, ink core
+    mask = g < 200
+    s = gm.stroke_core_stats(g, mask, erode=1)
+    assert s["median_L"] == pytest.approx(100.0)
+    assert s["std"] == pytest.approx(0.0)
+    assert s["cov"] == pytest.approx(0.0)
+
+
+def test_edge_transition_frac():
+    g = np.array([[0.0, 128.0, 255.0, 128.0]])
+    # two of four pixels lie in [64,192]
+    assert gm.edge_transition_frac(g) == pytest.approx(0.5)
+
+
+def test_paper_clip_frac():
+    g = np.array([[255.0, 255.0, 200.0, 100.0]])
+    assert gm.paper_clip_frac(g) == pytest.approx(0.5)
+
+
+def test_tone_emd_shift():
+    # two delta histograms 100 gray-levels apart -> EMD ~100
+    real = np.full((50, 50), 50.0)
+    render = np.full((50, 50), 150.0)
+    assert gm.tone_emd(real, render) == pytest.approx(100.0, abs=3.0)
+
+
+def test_kanungo_pattern_hist_all_background():
+    b = np.zeros((5, 5), bool)
+    h = gm.kanungo_pattern_hist(b)
+    assert h.sum() == pytest.approx(1.0)
+    assert h[0] == pytest.approx(1.0)  # code 0 = all-background 3x3
+
+
+def test_kanungo_two_sample_same_dist_fails_to_reject():
+    rng = np.random.default_rng(1)
+    crops = [rng.random((16, 16)) < 0.3 for _ in range(12)]
+    a = crops[:6]
+    b = crops[6:]
+    res = gm.kanungo_two_sample(a, b, n_perm=100)
+    # drawn from the same process -> should not reject (p not tiny)
+    assert res["p_value"] > 0.05
+
+
+def test_kanungo_two_sample_different_dist_rejects():
+    rng = np.random.default_rng(2)
+    a = [rng.random((16, 16)) < 0.1 for _ in range(8)]   # sparse
+    b = [rng.random((16, 16)) < 0.6 for _ in range(8)]   # dense
+    res = gm.kanungo_two_sample(a, b, n_perm=100)
+    assert res["distance"] > 0.2
+    assert res["p_value"] < 0.05
+
+
+# --- L4 --------------------------------------------------------------------
+
+
+def test_ms_ssim_identical_is_one():
+    rng = np.random.default_rng(3)
+    img = rng.random((64, 64)) * 255.0
+    assert gm.ms_ssim(img, img) == pytest.approx(1.0, abs=1e-6)
+
+
+def test_ms_ssim_ordering():
+    rng = np.random.default_rng(4)
+    img = rng.random((64, 64)) * 255.0
+    near = img + rng.normal(0, 5, img.shape)
+    far = rng.random((64, 64)) * 255.0
+    assert gm.ms_ssim(img, near) > gm.ms_ssim(img, far)
+
+
+def test_ocr_error_sets_parity():
+    gt = ["THE", "QUICK", "BROWN", "FOX"]
+    # real mis-reads QUICK; render mis-reads QUICK (shared) AND FOX (render-only)
+    def lines(tokens):
+        return [{"text": t, "x": 0.0, "y": float(i * 30), "h": 10.0}
+                for i, t in enumerate(tokens)]
+    real = lines(["THE", "QUISK", "BROWN", "FOX"])
+    render = lines(["THE", "QUISK", "BROWN", "F0X"])
+    res = gm.ocr_error_sets(gt, real, render)
+    assert "QUICK" in res["shared"]
+    assert "FOX" in res["render_only"]
+    assert res["jaccard"] == pytest.approx(0.5)
+
+
+def test_glcm_contrast_flat_is_zero():
+    g = np.full((20, 20), 100.0)
+    assert gm.glcm_contrast(g) == pytest.approx(0.0)
+
+
+def test_glcm_contrast_checkerboard_positive():
+    g = np.indices((20, 20)).sum(0) % 2 * 255.0
+    assert gm.glcm_contrast(g) > 0.0
+
+
+def test_spacing_jitter_uniform_is_zero():
+    lines = [[0.0, 10.0, 20.0, 30.0]]
+    assert gm.spacing_jitter(lines) == pytest.approx(0.0)
+
+
+def test_spacing_jitter_positive_on_variation():
+    lines = [[0.0, 10.0, 25.0, 30.0]]
+    assert gm.spacing_jitter(lines) > 0.0
+
+
+# --- alignment -------------------------------------------------------------
+
+
+def test_ocr_anchors_and_warp_identity():
+    lines = [{"text": f"WORD{i:02d}", "x": 0.0, "y": float(i * 50), "h": 10.0}
+             for i in range(6)]
+    anchors = gm.ocr_anchors(lines, lines)
+    assert len(anchors) == 6
+    # real_cy == render_cy on identical inputs
+    for rcy, fcy, sim in anchors:
+        assert rcy == pytest.approx(fcy)
+        assert sim == pytest.approx(1.0)
+    g = np.random.default_rng(5).random((300, 40)) * 255.0
+    warped, resid = gm.piecewise_row_warp(g, anchors, 300)
+    assert resid == pytest.approx(0.0, abs=1e-6)
+    assert np.allclose(warped, g, atol=1e-6)


### PR DESCRIPTION
## What

A single runnable suite `tools/glyph-studio/py/costco_gold.py` that consumes a render + the Costco gold reference set and emits the full **L0-L4 JSON scorecard** with current values, 1:1 targets, and pass/fail vs regression thresholds — the standing "how close to 1:1 are we" instrument specified in `GOLD_STANDARD.md` Part 3.

```
costco_gold.py --render final.webp --real real.webp --labels final.labels.json \
  --refpack costco.refpack.npz --chart bitMatrix-C2-chart.glyphs.npz \
  --config costco.thresholds.json --out scorecard.json
```

## How it wires existing machinery (doesn't reinvent)

- **GlyphScore** (imported from the `/private/tmp/glyphscore` worktree, PR #1111, via `--glyphscore-root`) supplies L1 per-glyph fidelity + the render segmentation used by L0/L2.
- **`glyphstudio/gold_metrics.py`** (new, pure numpy+scipy) supplies the analytic L0/L2/L3/L4 metrics, each with a known-answer test (27 pass).
- **Apple Vision** (`ocr_vision.swift`, compiled on demand) supplies alignment anchors + L4 OCR parity; gracefully degrades to `NOT_IMPLEMENTED` if swiftc/Vision is unavailable.

## Ladder: live vs NOT_IMPLEMENTED

| Rung | Live metrics | NOT_IMPLEMENTED |
|---|---|---|
| L0 | ink ratio, fill, cap-height ratio, line-pitch ratio (autocorrelation) | — |
| L1 | GlyphScore vs-crops / vs-chart, IoU rc/re/ce **with & without I3 hygiene** | — |
| L2 | chamfer (dots), Boundary-IoU, advance ratio, price-column std, barcode-caption ratio | — |
| L3 | stroke-core L/CoV, edge-transition frac, paper-clip frac, tone EMD, **Kanungo 3×3 two-sample test** | — |
| L4 | MS-SSIM (warped+raw), OCR error-set Jaccard/recall/CER, GLCM contrast, spacing-jitter | forgery-detector AUC, TSTR gap (need a model we don't have) |

## I3 metric hygiene

L1/L2 report both with and without the hygiene line-mask (drops the logo header + dense payment footer that the gap report identified as measurement artifacts, not render defects). Hygiene raises usage-weighted `iou_rc` 0.674 → 0.696, matching the report's clean-glyph regime.

## Baseline record (2026-07-11)

Committed as the first benchmark record: `tools/glyph-studio/py/baselines/costco_gold.baseline.2026-07-11.json`. Overall `L0-fail` — the render is too clean/heavy, exactly the diagnosis every gap report converges on.

### Reproduction check (vs known values, within tolerance)

| Metric | Known | Harness | |
|---|---|---|---|
| L0 ink ratio | ~1.37 | **1.367** | ✓ |
| L1 GlyphScore-vs-crops | ~36.7 | **37.0** | ✓ |
| L4 MS-SSIM (raw) | 0.323 | **0.32328** | exact match to metrics.json |
| L4 MS-SSIM (warped) | ~0.42 | **0.444** | within tol; better anchor set (51 vs 40 anchors, resid 16 vs 27 px) |
| L4 OCR Jaccard | 0.653 | **0.653** | exact |
| interline fill (render/real) | 0.80 / 0.67 | **0.807 / 0.687** | ✓ |
| OCR recall (real/render) | 0.741 / 0.645 | **0.741 / 0.645** | exact |

## Tests

`tools/glyph-studio/py/tests/test_gold_metrics.py` — 27 known-answer fixtures covering every analytic metric.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SRtFcxkcw1t3nZsVHstZGL