### PR TITLE
Polish receipt glyph sizing and transparent rendering

### DIFF
--- a/portfolio/components/ui/Figures/SynthesisPipeline/Acts.tsx
+++ b/portfolio/components/ui/Figures/SynthesisPipeline/Acts.tsx
@@ -22,6 +22,7 @@ import {
   charPrintSrc,
   COMPOSE_GROUP_ORDER,
   FONT_CODEPOINTS,
+  FontGlyphMetric,
   fontGlyphSrc,
   finalSrc,
   logoSrc,
@@ -389,6 +390,25 @@ const CharacterAct: React.FC<ActProps> = ({
 
 const FONT_GRID_COLS = 12; // matches grid-template-columns on desktop
 const HERO_FLIGHT_SCALE = 5.2; // how big the hero rides in from stage center
+const FONT_GRID_CAP_PERCENT = 70;
+const FONT_GRID_BASELINE_PERCENT = 78.5;
+
+const normalizedGlyphStyle = (
+  metric: FontGlyphMetric | undefined,
+  capHeight: number | undefined,
+): React.CSSProperties | undefined => {
+  if (!metric || !capHeight || capHeight <= 0) {
+    return undefined;
+  }
+  const scale = FONT_GRID_CAP_PERCENT / capHeight;
+  return {
+    width: `${metric.width * scale}%`,
+    height: `${metric.height * scale}%`,
+    top: "auto",
+    bottom: `${100 - FONT_GRID_BASELINE_PERCENT - metric.offset * scale}%`,
+    transform: "translateX(-50%)",
+  };
+};
 
 /** Smoothstep ease for the flight. */
 const smooth = (t: number): number => t * t * (3 - 2 * t);
@@ -438,12 +458,18 @@ const WholeFontAct: React.FC<ActProps> = ({
             }
           : undefined;
         const maskUrl = `url(${fontGlyphSrc(merchant, cp)})`;
+        const glyphMetric = assets.fontMetrics?.glyphs[String(cp)];
+        const metricStyle = normalizedGlyphStyle(
+          glyphMetric,
+          assets.fontMetrics?.capHeight,
+        );
         return (
           <div
             key={cp}
             className={`${styles.fontCell}${isHero ? ` ${styles.fontCellHero}` : ""}`}
             data-shown={shown}
             data-hero={isHero || undefined}
+            data-codepoint={cp}
             data-testid="font-cell"
             style={heroStyle}
           >
@@ -452,7 +478,11 @@ const WholeFontAct: React.FC<ActProps> = ({
                 themes. */}
             <div
               className={styles.fontGlyph}
-              style={{ WebkitMaskImage: maskUrl, maskImage: maskUrl }}
+              style={{
+                WebkitMaskImage: maskUrl,
+                maskImage: maskUrl,
+                ...metricStyle,
+              }}
               aria-hidden="true"
             />
           </div>

--- a/portfolio/components/ui/Figures/SynthesisPipeline/Acts.tsx
+++ b/portfolio/components/ui/Figures/SynthesisPipeline/Acts.tsx
@@ -547,6 +547,7 @@ const WholeFontAct: React.FC<ActProps> = ({
           glyphMetric,
           assets.fontMetrics?.capHeight,
         );
+        const maskSize = metricStyle ? "100% 100%" : "contain";
         return (
           <div
             key={cp}
@@ -565,6 +566,8 @@ const WholeFontAct: React.FC<ActProps> = ({
               style={{
                 WebkitMaskImage: maskUrl,
                 maskImage: maskUrl,
+                WebkitMaskSize: maskSize,
+                maskSize,
                 ...metricStyle,
               }}
               aria-hidden="true"

--- a/portfolio/components/ui/Figures/SynthesisPipeline/Acts.tsx
+++ b/portfolio/components/ui/Figures/SynthesisPipeline/Acts.tsx
@@ -65,6 +65,94 @@ const AssetPending: React.FC<{ children: React.ReactNode }> = ({
   </div>
 );
 
+/**
+ * Turn opaque dark-ink-on-white receipt pixels into black ink with real alpha.
+ * The grayscale intensity is preserved as opacity, so antialiasing and the
+ * consensus cloud survive while the receipt-paper pixels disappear entirely.
+ */
+export const knockOutReceiptPaper = (pixels: Uint8ClampedArray): void => {
+  const paperLuminance = 220;
+  const solidInkLuminance = 70;
+  for (let i = 0; i < pixels.length; i += 4) {
+    const luminance = Math.round(
+      pixels[i] * 0.2126 + pixels[i + 1] * 0.7152 + pixels[i + 2] * 0.0722,
+    );
+    const normalizedInk = Math.min(
+      1,
+      Math.max(
+        0,
+        (paperLuminance - luminance) /
+          (paperLuminance - solidInkLuminance),
+      ),
+    );
+    const inkAlpha = normalizedInk ** 1.5;
+    pixels[i + 3] = Math.round(pixels[i + 3] * inkAlpha);
+    pixels[i] = 0;
+    pixels[i + 1] = 0;
+    pixels[i + 2] = 0;
+  }
+};
+
+interface ReceiptInkLayerProps {
+  src: string;
+  className: string;
+  style?: React.CSSProperties;
+  ariaLabel?: string;
+  testId?: string;
+}
+
+const ReceiptInkLayer: React.FC<ReceiptInkLayerProps> = ({
+  src,
+  className,
+  style,
+  ariaLabel,
+  testId,
+}) => {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) {
+      return;
+    }
+    let cancelled = false;
+    const source = new Image();
+    source.decoding = "async";
+    source.onload = () => {
+      if (cancelled) {
+        return;
+      }
+      const ctx = canvas.getContext("2d", { willReadFrequently: true });
+      if (!ctx) {
+        return;
+      }
+      canvas.width = source.naturalWidth;
+      canvas.height = source.naturalHeight;
+      ctx.drawImage(source, 0, 0);
+      const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
+      knockOutReceiptPaper(imageData.data);
+      ctx.putImageData(imageData, 0, 0);
+    };
+    source.src = src;
+    return () => {
+      cancelled = true;
+      source.onload = null;
+    };
+  }, [src]);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      className={className}
+      style={style}
+      role={ariaLabel ? "img" : undefined}
+      aria-label={ariaLabel}
+      aria-hidden={ariaLabel ? undefined : true}
+      data-testid={testId}
+    />
+  );
+};
+
 /* ==================================================================== */
 /* Act 1 — Raw material                                                  */
 /* ==================================================================== */
@@ -270,23 +358,19 @@ const CharacterAct: React.FC<ActProps> = ({
     <div className={styles.charStageWrap} data-testid="act-character">
       <div className={styles.charGlyphBox} style={{ aspectRatio: geom.aspect }}>
         {/* Consensus cloud (the shared frame everything maps into). */}
-        {/* eslint-disable-next-line @next/next/no-img-element */}
-        <img
+        <ReceiptInkLayer
           src={charCloudSrc(merchant)}
-          alt="Consensus letterform averaged from many prints"
+          ariaLabel="Consensus letterform averaged from many prints"
           className={styles.charCloudFill}
           style={{ opacity: cloudOpacity }}
-          data-testid="char-cloud"
+          testId="char-cloud"
         />
         {/* Real prints piling up, fading as the cloud resolves. */}
         {printsOpacity > 0.01
           ? printLayers.map((i, depth) => (
-              // eslint-disable-next-line @next/next/no-img-element
-              <img
+              <ReceiptInkLayer
                 key={i}
                 src={charPrintSrc(merchant, i)}
-                alt=""
-                aria-hidden="true"
                 className={styles.charPrintLayer}
                 style={{
                   opacity: printsOpacity * (1 - depth * 0.28),

--- a/portfolio/components/ui/Figures/SynthesisPipeline/SynthesisPipeline.module.css
+++ b/portfolio/components/ui/Figures/SynthesisPipeline/SynthesisPipeline.module.css
@@ -508,10 +508,10 @@
   mask-mode: alpha;
   mask-repeat: no-repeat;
   mask-position: center;
-  mask-size: 100% 100%;
+  mask-size: contain;
   -webkit-mask-repeat: no-repeat;
   -webkit-mask-position: center;
-  -webkit-mask-size: 100% 100%;
+  -webkit-mask-size: contain;
 }
 
 /* ==== Act 6: the receipt assembles (typing + LayoutLM boxes) ========= */

--- a/portfolio/components/ui/Figures/SynthesisPipeline/SynthesisPipeline.module.css
+++ b/portfolio/components/ui/Figures/SynthesisPipeline/SynthesisPipeline.module.css
@@ -332,9 +332,6 @@
   width: 100%;
   height: 100%;
   object-fit: fill;
-  /* White paper is neutral under multiply, leaving only the receipt ink
-     visible over the page instead of painting an opaque image rectangle. */
-  mix-blend-mode: multiply;
 }
 
 .charPrintLayer {
@@ -345,29 +342,24 @@
   width: auto;
   object-fit: contain;
   image-rendering: pixelated;
-  mix-blend-mode: multiply;
 }
 
-/* Dark mode: the consensus cloud + real prints are dark-ink-on-white PNGs, so
-   invert them to light-ink-on-black, then screen-blend them. Black is neutral
-   under screen, so the live glyph pixels remain while the page background
-   shows through the former receipt-paper pixels. */
+/* The source receipt paper is knocked out to real alpha in ReceiptInkLayer.
+   Dark mode only recolors the remaining black ink pixels to white; transparent
+   paper pixels stay transparent, even inside the act's animated layers. */
 @media (prefers-color-scheme: dark) {
   .charCloudFill,
   .charPrintLayer {
     filter: invert(1);
-    mix-blend-mode: screen;
   }
 }
 :root[data-theme="dark"] .charCloudFill,
 :root[data-theme="dark"] .charPrintLayer {
   filter: invert(1);
-  mix-blend-mode: screen;
 }
 :root[data-theme="light"] .charCloudFill,
 :root[data-theme="light"] .charPrintLayer {
   filter: none;
-  mix-blend-mode: multiply;
 }
 
 .penSvg {

--- a/portfolio/components/ui/Figures/SynthesisPipeline/SynthesisPipeline.module.css
+++ b/portfolio/components/ui/Figures/SynthesisPipeline/SynthesisPipeline.module.css
@@ -332,6 +332,9 @@
   width: 100%;
   height: 100%;
   object-fit: fill;
+  /* White paper is neutral under multiply, leaving only the receipt ink
+     visible over the page instead of painting an opaque image rectangle. */
+  mix-blend-mode: multiply;
 }
 
 .charPrintLayer {
@@ -342,25 +345,29 @@
   width: auto;
   object-fit: contain;
   image-rendering: pixelated;
+  mix-blend-mode: multiply;
 }
 
 /* Dark mode: the consensus cloud + real prints are dark-ink-on-white PNGs, so
-   invert them to read as light ink on the dark stage — no glaring white slab.
-   The blue pen path and the --text-color (white) thermal dots already contrast
-   on the dark stage. */
+   invert them to light-ink-on-black, then screen-blend them. Black is neutral
+   under screen, so the live glyph pixels remain while the page background
+   shows through the former receipt-paper pixels. */
 @media (prefers-color-scheme: dark) {
   .charCloudFill,
   .charPrintLayer {
     filter: invert(1);
+    mix-blend-mode: screen;
   }
 }
 :root[data-theme="dark"] .charCloudFill,
 :root[data-theme="dark"] .charPrintLayer {
   filter: invert(1);
+  mix-blend-mode: screen;
 }
 :root[data-theme="light"] .charCloudFill,
 :root[data-theme="light"] .charPrintLayer {
   filter: none;
+  mix-blend-mode: multiply;
 }
 
 .penSvg {
@@ -467,6 +474,7 @@
 
 /* No tile chrome: the glyphs sit directly on the page background like type. */
 .fontCell {
+  position: relative;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -498,16 +506,20 @@
 /* Alpha-mask glyph: painted in the page text color (currentColor) through the
    glyph's alpha, so it reads as type-on-page and is theme-aware. */
 .fontGlyph {
+  position: absolute;
+  left: 50%;
+  top: 50%;
   width: 78%;
   height: 78%;
+  transform: translate(-50%, -50%);
   background-color: currentColor;
   mask-mode: alpha;
   mask-repeat: no-repeat;
   mask-position: center;
-  mask-size: contain;
+  mask-size: 100% 100%;
   -webkit-mask-repeat: no-repeat;
   -webkit-mask-position: center;
-  -webkit-mask-size: contain;
+  -webkit-mask-size: 100% 100%;
 }
 
 /* ==== Act 6: the receipt assembles (typing + LayoutLM boxes) ========= */

--- a/portfolio/components/ui/Figures/SynthesisPipeline/SynthesisPipeline.test.tsx
+++ b/portfolio/components/ui/Figures/SynthesisPipeline/SynthesisPipeline.test.tsx
@@ -72,6 +72,28 @@ const flushAssets = async () => {
   });
 };
 
+test("font metrics cover every glyph and match the committed PNG dimensions", () => {
+  const metrics = JSON.parse(
+    fs.readFileSync(path.join(PIPELINE_DIR, "sprouts/font_metrics.json"), "utf-8"),
+  ) as {
+    capHeight: number;
+    glyphs: Record<string, { width: number; height: number; offset: number }>;
+  };
+
+  expect(metrics.capHeight).toBe(40);
+  expect(Object.keys(metrics.glyphs)).toHaveLength(94);
+  for (let codepoint = 33; codepoint <= 126; codepoint += 1) {
+    const metric = metrics.glyphs[String(codepoint)];
+    const png = fs.readFileSync(
+      path.join(PIPELINE_DIR, `sprouts/font_grid/${codepoint}.png`),
+    );
+    expect(metric).toBeDefined();
+    expect(metric.width).toBe(png.readUInt32BE(16));
+    expect(metric.height).toBe(png.readUInt32BE(20));
+    expect(Number.isFinite(metric.offset)).toBe(true);
+  }
+});
+
 describe("advanceAutoplay (pure timeline math)", () => {
   test("advancing within a dwell increments progress, same act", () => {
     const s = advanceAutoplay(2, 0.2, 1000, 5000, ACT_COUNT);
@@ -341,6 +363,25 @@ describe("SynthesisPipeline (reduced motion)", () => {
       .firstElementChild as HTMLElement;
     const style = glyph.getAttribute("style") || "";
     expect(style).toMatch(/mask-image:\s*url\([^)]*font_grid[^)]*\.png/);
+  });
+
+  test("atlas glyphs preserve receipt-relative cap height and baseline", async () => {
+    render(<SynthesisPipeline />);
+    await flushAssets();
+
+    const cellFor = (codepoint: number) =>
+      screen
+        .getAllByTestId("font-cell")
+        .find((cell) => cell.getAttribute("data-codepoint") === String(codepoint));
+    const uppercase = cellFor(65)?.firstElementChild as HTMLElement;
+    const lowercase = cellFor(97)?.firstElementChild as HTMLElement;
+
+    expect(uppercase).toBeInTheDocument();
+    expect(lowercase).toBeInTheDocument();
+    expect(Number.parseFloat(uppercase.style.height)).toBeCloseTo(70, 3);
+    expect(Number.parseFloat(lowercase.style.height)).toBeCloseTo(49, 3);
+    expect(Number.parseFloat(uppercase.style.bottom)).toBeCloseTo(23.25, 3);
+    expect(Number.parseFloat(lowercase.style.bottom)).toBeCloseTo(23.25, 3);
   });
 
   test("pen-path act draws SVG paths + anchor dots from the real skeleton", async () => {

--- a/portfolio/components/ui/Figures/SynthesisPipeline/SynthesisPipeline.test.tsx
+++ b/portfolio/components/ui/Figures/SynthesisPipeline/SynthesisPipeline.test.tsx
@@ -2,6 +2,7 @@ import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
 import fs from "fs";
 import path from "path";
 import SynthesisPipeline, { advanceAutoplay } from ".";
+import { knockOutReceiptPaper } from "./Acts";
 import { ACT_COUNT, ACTS } from "./pipelineData";
 import { LABEL_COLORS } from "../labelStyles";
 
@@ -71,6 +72,26 @@ const flushAssets = async () => {
     await Promise.resolve();
   });
 };
+
+test("receipt-paper knockout converts luminance to transparent ink alpha", () => {
+  const pixels = new Uint8ClampedArray([
+    255, 255, 255, 255, // white paper -> transparent
+    0, 0, 0, 255, // black ink -> opaque
+    127, 127, 127, 255, // gray antialiasing -> partial alpha
+    230, 230, 230, 255, // near-paper scan shading -> transparent
+    0, 0, 0, 0, // transparent source remains transparent
+  ]);
+
+  knockOutReceiptPaper(pixels);
+
+  expect(Array.from(pixels)).toEqual([
+    0, 0, 0, 0,
+    0, 0, 0, 255,
+    0, 0, 0, 124,
+    0, 0, 0, 0,
+    0, 0, 0, 0,
+  ]);
+});
 
 test("font metrics cover every glyph and match the committed PNG dimensions", () => {
   const metrics = JSON.parse(

--- a/portfolio/components/ui/Figures/SynthesisPipeline/SynthesisPipeline.test.tsx
+++ b/portfolio/components/ui/Figures/SynthesisPipeline/SynthesisPipeline.test.tsx
@@ -384,6 +384,21 @@ describe("SynthesisPipeline (reduced motion)", () => {
       .firstElementChild as HTMLElement;
     const style = glyph.getAttribute("style") || "";
     expect(style).toMatch(/mask-image:\s*url\([^)]*font_grid[^)]*\.png/);
+    expect(style).toMatch(/mask-size:\s*100% 100%/);
+  });
+
+  test("atlas fallback keeps glyph masks proportional while metrics load", () => {
+    global.fetch = jest.fn(
+      () => new Promise<Response>(() => {}),
+    ) as jest.Mock;
+
+    render(<SynthesisPipeline />);
+
+    const glyph = screen
+      .getAllByTestId("font-cell")[0]
+      .firstElementChild as HTMLElement;
+    const style = glyph.getAttribute("style") || "";
+    expect(style).toMatch(/mask-size:\s*contain/);
   });
 
   test("atlas glyphs preserve receipt-relative cap height and baseline", async () => {

--- a/portfolio/components/ui/Figures/SynthesisPipeline/index.tsx
+++ b/portfolio/components/ui/Figures/SynthesisPipeline/index.tsx
@@ -15,6 +15,8 @@ import {
   DotParams,
   EMPTY_ASSETS,
   finalLabelsSrc,
+  fontMetricsSrc,
+  FontMetrics,
   MerchantAssets,
   PIPELINE_MERCHANT,
   skeletonSrc,
@@ -128,14 +130,22 @@ const SynthesisPipeline: React.FC = () => {
     Promise.all([
       fetchJson<GlyphSkeleton>(skeletonSrc(PIPELINE_MERCHANT)),
       fetchJson<DotParams>(dotParamsSrc(PIPELINE_MERCHANT)),
+      fetchJson<FontMetrics>(fontMetricsSrc(PIPELINE_MERCHANT)),
       fetchJson<StyleAnnotated>(styleAnnotatedSrc(PIPELINE_MERCHANT)),
       fetchJson<ComposeSteps>(composeStepsSrc(PIPELINE_MERCHANT)),
       fetchJson<ShowcaseLabelFile>(finalLabelsSrc(PIPELINE_MERCHANT)),
-    ]).then(([skeleton, dotParams, style, compose, finalLabels]) => {
+    ]).then(([skeleton, dotParams, fontMetrics, style, compose, finalLabels]) => {
       if (cancelled) {
         return;
       }
-      setAssets({ skeleton, dotParams, style, compose, finalLabels });
+      setAssets({
+        skeleton,
+        dotParams,
+        fontMetrics,
+        style,
+        compose,
+        finalLabels,
+      });
     });
 
     return () => {

--- a/portfolio/components/ui/Figures/SynthesisPipeline/pipelineData.ts
+++ b/portfolio/components/ui/Figures/SynthesisPipeline/pipelineData.ts
@@ -76,6 +76,9 @@ export const dotParamsSrc = (merchant: Merchant): string =>
 export const fontGlyphSrc = (merchant: Merchant, codepoint: number): string =>
   `${assetRoot(merchant)}/font_grid/${codepoint}.png`;
 
+export const fontMetricsSrc = (merchant: Merchant): string =>
+  `${assetRoot(merchant)}/font_metrics.json`;
+
 export const styleAnnotatedSrc = (merchant: Merchant): string =>
   `${assetRoot(merchant)}/style_annotated.json`;
 
@@ -136,6 +139,19 @@ export interface DotParams {
   samples: number;
   /** Cloud PNG pixel geometry for act-3/4 alignment (added incrementally). */
   cloudGeom?: CloudGeom;
+}
+
+export interface FontGlyphMetric {
+  width: number;
+  height: number;
+  /** Ink-bottom row relative to the shared baseline. */
+  offset: number;
+}
+
+export interface FontMetrics {
+  /** Pixel cap height used when the tightly cropped glyph masks were exported. */
+  capHeight: number;
+  glyphs: Record<string, FontGlyphMetric>;
 }
 
 export const DEFAULT_DOT_PARAMS: DotParams = {
@@ -204,6 +220,7 @@ export interface ComposeSteps {
 export interface MerchantAssets {
   skeleton: GlyphSkeleton | null;
   dotParams: DotParams | null;
+  fontMetrics: FontMetrics | null;
   style: StyleAnnotated | null;
   compose: ComposeSteps | null;
   finalLabels: ShowcaseLabelFile | null;
@@ -212,6 +229,7 @@ export interface MerchantAssets {
 export const EMPTY_ASSETS: MerchantAssets = {
   skeleton: null,
   dotParams: null,
+  fontMetrics: null,
   style: null,
   compose: null,
   finalLabels: null,

--- a/portfolio/public/synthetic-receipts/pipeline/sprouts/font_metrics.json
+++ b/portfolio/public/synthetic-receipts/pipeline/sprouts/font_metrics.json
@@ -1,0 +1,475 @@
+{
+  "capHeight": 40,
+  "glyphs": {
+    "33": {
+      "width": 8,
+      "height": 28,
+      "offset": -8
+    },
+    "34": {
+      "width": 11,
+      "height": 8,
+      "offset": -33
+    },
+    "35": {
+      "width": 17,
+      "height": 35,
+      "offset": -3
+    },
+    "36": {
+      "width": 19,
+      "height": 43,
+      "offset": 1
+    },
+    "37": {
+      "width": 23,
+      "height": 37,
+      "offset": -2
+    },
+    "38": {
+      "width": 31,
+      "height": 40,
+      "offset": -1
+    },
+    "39": {
+      "width": 4,
+      "height": 8,
+      "offset": -33
+    },
+    "40": {
+      "width": 12,
+      "height": 37,
+      "offset": -3
+    },
+    "41": {
+      "width": 10,
+      "height": 37,
+      "offset": -3
+    },
+    "42": {
+      "width": 35,
+      "height": 37,
+      "offset": -2
+    },
+    "43": {
+      "width": 19,
+      "height": 19,
+      "offset": -9
+    },
+    "44": {
+      "width": 17,
+      "height": 30,
+      "offset": 3
+    },
+    "45": {
+      "width": 19,
+      "height": 4,
+      "offset": -18
+    },
+    "46": {
+      "width": 4,
+      "height": 4,
+      "offset": -3
+    },
+    "47": {
+      "width": 22,
+      "height": 35,
+      "offset": -3
+    },
+    "48": {
+      "width": 22,
+      "height": 38,
+      "offset": -3
+    },
+    "49": {
+      "width": 15,
+      "height": 38,
+      "offset": -2
+    },
+    "50": {
+      "width": 21,
+      "height": 40,
+      "offset": -1
+    },
+    "51": {
+      "width": 17,
+      "height": 37,
+      "offset": -3
+    },
+    "52": {
+      "width": 23,
+      "height": 37,
+      "offset": -2
+    },
+    "53": {
+      "width": 21,
+      "height": 37,
+      "offset": -3
+    },
+    "54": {
+      "width": 21,
+      "height": 37,
+      "offset": -3
+    },
+    "55": {
+      "width": 21,
+      "height": 39,
+      "offset": -2
+    },
+    "56": {
+      "width": 21,
+      "height": 39,
+      "offset": -2
+    },
+    "57": {
+      "width": 21,
+      "height": 38,
+      "offset": -2
+    },
+    "58": {
+      "width": 4,
+      "height": 23,
+      "offset": -3
+    },
+    "59": {
+      "width": 8,
+      "height": 33,
+      "offset": 6
+    },
+    "60": {
+      "width": 12,
+      "height": 41,
+      "offset": 0
+    },
+    "61": {
+      "width": 21,
+      "height": 15,
+      "offset": -16
+    },
+    "62": {
+      "width": 12,
+      "height": 41,
+      "offset": 0
+    },
+    "63": {
+      "width": 19,
+      "height": 41,
+      "offset": 0
+    },
+    "64": {
+      "width": 23,
+      "height": 33,
+      "offset": -1
+    },
+    "65": {
+      "width": 19,
+      "height": 40,
+      "offset": -1
+    },
+    "66": {
+      "width": 16,
+      "height": 39,
+      "offset": -2
+    },
+    "67": {
+      "width": 20,
+      "height": 37,
+      "offset": -3
+    },
+    "68": {
+      "width": 21,
+      "height": 39,
+      "offset": -2
+    },
+    "69": {
+      "width": 19,
+      "height": 40,
+      "offset": -1
+    },
+    "70": {
+      "width": 21,
+      "height": 39,
+      "offset": -2
+    },
+    "71": {
+      "width": 21,
+      "height": 37,
+      "offset": -3
+    },
+    "72": {
+      "width": 19,
+      "height": 32,
+      "offset": -5
+    },
+    "73": {
+      "width": 22,
+      "height": 39,
+      "offset": -2
+    },
+    "74": {
+      "width": 16,
+      "height": 38,
+      "offset": -2
+    },
+    "75": {
+      "width": 25,
+      "height": 40,
+      "offset": -1
+    },
+    "76": {
+      "width": 19,
+      "height": 33,
+      "offset": -3
+    },
+    "77": {
+      "width": 27,
+      "height": 40,
+      "offset": -1
+    },
+    "78": {
+      "width": 25,
+      "height": 40,
+      "offset": -1
+    },
+    "79": {
+      "width": 29,
+      "height": 40,
+      "offset": -1
+    },
+    "80": {
+      "width": 19,
+      "height": 37,
+      "offset": -3
+    },
+    "81": {
+      "width": 24,
+      "height": 45,
+      "offset": 4
+    },
+    "82": {
+      "width": 29,
+      "height": 40,
+      "offset": -1
+    },
+    "83": {
+      "width": 23,
+      "height": 40,
+      "offset": -1
+    },
+    "84": {
+      "width": 21,
+      "height": 40,
+      "offset": -1
+    },
+    "85": {
+      "width": 30,
+      "height": 40,
+      "offset": -1
+    },
+    "86": {
+      "width": 22,
+      "height": 40,
+      "offset": -1
+    },
+    "87": {
+      "width": 19,
+      "height": 40,
+      "offset": -1
+    },
+    "88": {
+      "width": 27,
+      "height": 40,
+      "offset": -1
+    },
+    "89": {
+      "width": 18,
+      "height": 40,
+      "offset": -1
+    },
+    "90": {
+      "width": 23,
+      "height": 39,
+      "offset": -2
+    },
+    "91": {
+      "width": 10,
+      "height": 39,
+      "offset": -2
+    },
+    "92": {
+      "width": 21,
+      "height": 39,
+      "offset": -2
+    },
+    "93": {
+      "width": 11,
+      "height": 40,
+      "offset": -1
+    },
+    "94": {
+      "width": 15,
+      "height": 17,
+      "offset": -25
+    },
+    "95": {
+      "width": 9,
+      "height": 4,
+      "offset": -2
+    },
+    "96": {
+      "width": 8,
+      "height": 12,
+      "offset": -29
+    },
+    "97": {
+      "width": 27,
+      "height": 28,
+      "offset": -1
+    },
+    "98": {
+      "width": 22,
+      "height": 39,
+      "offset": -1
+    },
+    "99": {
+      "width": 17,
+      "height": 26,
+      "offset": -3
+    },
+    "100": {
+      "width": 22,
+      "height": 39,
+      "offset": -1
+    },
+    "101": {
+      "width": 27,
+      "height": 28,
+      "offset": -1
+    },
+    "102": {
+      "width": 14,
+      "height": 34,
+      "offset": -6
+    },
+    "103": {
+      "width": 19,
+      "height": 34,
+      "offset": 4
+    },
+    "104": {
+      "width": 27,
+      "height": 41,
+      "offset": -1
+    },
+    "105": {
+      "width": 7,
+      "height": 37,
+      "offset": -1
+    },
+    "106": {
+      "width": 11,
+      "height": 49,
+      "offset": 12
+    },
+    "107": {
+      "width": 22,
+      "height": 41,
+      "offset": -1
+    },
+    "108": {
+      "width": 3,
+      "height": 40,
+      "offset": -1
+    },
+    "109": {
+      "width": 22,
+      "height": 28,
+      "offset": -1
+    },
+    "110": {
+      "width": 21,
+      "height": 28,
+      "offset": -1
+    },
+    "111": {
+      "width": 27,
+      "height": 28,
+      "offset": -1
+    },
+    "112": {
+      "width": 18,
+      "height": 34,
+      "offset": 5
+    },
+    "113": {
+      "width": 20,
+      "height": 34,
+      "offset": 5
+    },
+    "114": {
+      "width": 27,
+      "height": 28,
+      "offset": -1
+    },
+    "115": {
+      "width": 19,
+      "height": 26,
+      "offset": -3
+    },
+    "116": {
+      "width": 21,
+      "height": 30,
+      "offset": -3
+    },
+    "117": {
+      "width": 29,
+      "height": 28,
+      "offset": -1
+    },
+    "118": {
+      "width": 22,
+      "height": 28,
+      "offset": -1
+    },
+    "119": {
+      "width": 29,
+      "height": 28,
+      "offset": -1
+    },
+    "120": {
+      "width": 28,
+      "height": 28,
+      "offset": -1
+    },
+    "121": {
+      "width": 23,
+      "height": 41,
+      "offset": 12
+    },
+    "122": {
+      "width": 19,
+      "height": 28,
+      "offset": -1
+    },
+    "123": {
+      "width": 13,
+      "height": 40,
+      "offset": -1
+    },
+    "124": {
+      "width": 4,
+      "height": 38,
+      "offset": -3
+    },
+    "125": {
+      "width": 13,
+      "height": 40,
+      "offset": -1
+    },
+    "126": {
+      "width": 19,
+      "height": 6,
+      "offset": -18
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- add receipt-derived width, height, and baseline metrics for all 94 Sprouts glyph masks
- scale and baseline-align punctuation, uppercase, lowercase, and descenders from one shared 40 px cap-height reference
- replace opaque character-cloud and source-print images with a canvas layer that converts receipt-paper luminance into real transparency
- preserve grayscale antialiasing while removing near-paper scan shading
- render remaining ink through the existing light/dark theme treatment

## Root cause

The atlas placed tightly cropped PNG masks in equal square cells with `mask-size: contain`, so each glyph independently expanded to fill its cell and lost the receipt renderer's relative proportions.

The preceding character phase used opaque dark-ink-on-white PNGs. In dark mode, inverting those images also turned the white paper into a hard black rectangle. Blend modes could not reliably remove it because the animated act layers create isolated stacking contexts.

## Impact

The font atlas now preserves receipt-relative glyph size and baseline placement. The character phase now shows only live ink/cloud pixels over the actual page background: white ink in dark mode and black ink in light mode, without an opaque receipt slab. The following atlas phase continues to use RGBA alpha masks and transparent cells in both themes.

## Validation

- `npm test -- --runInBand components/ui/Figures/SynthesisPipeline/SynthesisPipeline.test.tsx` — 22 tests passed
- `npm run type-check` — passed
- `npx eslint components/ui/Figures/SynthesisPipeline/Acts.tsx components/ui/Figures/SynthesisPipeline/SynthesisPipeline.test.tsx` — passed
- `git diff --check` — passed
- dark-mode browser QA at 1280×720 — transparent character cloud, white ink, transparent atlas cells, no relevant console errors
- light-mode browser QA at 1280×720 — transparent character cloud, black ink, transparent atlas cells, no relevant console errors
