### PR TITLE
config(dev): allow Codex desktop OAuth callback on MCP gateway

### DIFF
--- a/infra/Pulumi.dev.yaml
+++ b/infra/Pulumi.dev.yaml
@@ -51,3 +51,10 @@ config:
   portfolio:CHROMA_CLOUD_DATABASE: receipt_dev
   portfolio:CHROMA_CLOUD_ENABLED: "true"
   portfolio:LLM_VALIDATION_ASYNC: "true"
+  portfolio:mcpOAuthCallbackUrls:
+    - https://claude.ai/api/mcp/auth_callback
+    - https://claude.com/api/mcp/auth_callback
+    - http://localhost:8765/callback
+    - http://127.0.0.1:8765/callback
+    - http://localhost:6274/oauth/callback
+    - http://127.0.0.1:8765/callback/rzKPyJle2jYU


### PR DESCRIPTION
## Summary
- Sets `portfolio:mcpOAuthCallbackUrls` on the **dev stack only** to the five gateway defaults plus Codex's deterministic loopback callback (`http://127.0.0.1:8765/callback/rzKPyJle2jYU`)
- Unblocks `codex mcp login receipt-tools-hosted` against the dev MCP OAuth gateway (Cognito requires exact redirect-URI match; Codex appends a stable per-server hash to its callback path)
- Codex side is already configured: `mcp_oauth_callback_url` pins port 8765, per-server `scopes` request `portfolio-mcp/receipt`

No prod changes — `Pulumi.prod.yaml` untouched; prod deploy on merge is a no-op for this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FkMfkNVWCHJTVZr3YwixBj

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for additional MCP OAuth callback endpoints, including Claude web domains, localhost, and loopback addresses.
  * Improved OAuth compatibility for development and local testing environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->