### PR TITLE
Align synthesis legend with LayoutLM

### DIFF
--- a/portfolio/components/ui/Figures/SynthesisPipeline/SynthesisPipeline.module.css
+++ b/portfolio/components/ui/Figures/SynthesisPipeline/SynthesisPipeline.module.css
@@ -559,9 +559,11 @@
 .assembleSide {
   display: flex;
   flex-direction: column;
-  align-items: center;
+  align-items: flex-start;
   gap: 0.6rem;
-  max-width: min(300px, 42%);
+  width: 180px;
+  max-width: 42%;
+  flex-shrink: 0;
   animation: side-in 0.5s ease both;
 }
 
@@ -866,6 +868,7 @@
   .assembleSide {
     max-width: 100%;
     width: 100%;
+    align-items: center;
   }
 
   /* Finale: swap the two corner badges (which collide on narrow cards) for a

--- a/portfolio/components/ui/Figures/SynthesisPipeline/SynthesisPipeline.test.tsx
+++ b/portfolio/components/ui/Figures/SynthesisPipeline/SynthesisPipeline.test.tsx
@@ -382,6 +382,10 @@ describe("SynthesisPipeline (reduced motion)", () => {
     );
     // The caption was dropped — the boxes + legend carry the act.
     expect(screen.queryByTestId("labels-counter")).not.toBeInTheDocument();
+    const legend = screen.getByLabelText("Label families");
+    expect(legend).toHaveTextContent("Date / Time");
+    expect(legend).toHaveTextContent("Charges");
+    expect(legend).toHaveTextContent("Hours / Pay");
   });
 
   test("assemble label boxes use the LayoutLM LABEL_COLORS + stroke styling", async () => {

--- a/portfolio/components/ui/Figures/SynthesisPipeline/SynthesisPipeline.test.tsx
+++ b/portfolio/components/ui/Figures/SynthesisPipeline/SynthesisPipeline.test.tsx
@@ -4,6 +4,7 @@ import path from "path";
 import SynthesisPipeline, { advanceAutoplay } from ".";
 import { ACT_COUNT, ACTS } from "./pipelineData";
 import { LABEL_COLORS } from "../labelStyles";
+import { LabelLegend } from "../labelBoxOverlay";
 
 jest.mock("react-intersection-observer", () => ({
   useInView: () => ({ ref: jest.fn(), inView: true }),
@@ -386,6 +387,24 @@ describe("SynthesisPipeline (reduced motion)", () => {
     expect(legend).toHaveTextContent("Date / Time");
     expect(legend).toHaveTextContent("Charges");
     expect(legend).toHaveTextContent("Hours / Pay");
+  });
+
+  test("the legend groups merchant aliases and preserves unknown families", () => {
+    render(
+      <LabelLegend
+        families={[
+          "MERCHANT_NAME",
+          "BUSINESS_NAME",
+          "LOYALTY_ID",
+          "CUSTOM_FIELD",
+        ]}
+      />,
+    );
+
+    const legend = screen.getByLabelText("Label families");
+    expect(legend).toHaveTextContent("Merchant");
+    expect(legend).toHaveTextContent("Custom field");
+    expect(legend.children).toHaveLength(2);
   });
 
   test("assemble label boxes use the LayoutLM LABEL_COLORS + stroke styling", async () => {

--- a/portfolio/components/ui/Figures/labelBoxOverlay.module.css
+++ b/portfolio/components/ui/Figures/labelBoxOverlay.module.css
@@ -12,10 +12,12 @@
    figures' legends read identically (dot + label per family). */
 
 .legend {
+  width: 180px;
   display: flex;
   flex-direction: column;
-  gap: 0.6rem;
+  gap: 1rem;
   flex-shrink: 0;
+  padding: 1rem 0;
 }
 
 .legendItem {
@@ -42,10 +44,12 @@
    without clipping at the stage edge. */
 @media (max-width: 700px) {
   .legend {
+    width: 100%;
     flex-direction: row;
     flex-wrap: wrap;
     justify-content: center;
     gap: 0.3rem 0.7rem;
+    padding: 0;
   }
   .legendItem {
     gap: 0.4rem;

--- a/portfolio/components/ui/Figures/labelBoxOverlay.tsx
+++ b/portfolio/components/ui/Figures/labelBoxOverlay.tsx
@@ -1,13 +1,17 @@
 import React from "react";
-import { CHARGE_GREEN } from "./labelStyles";
+import {
+  CHARGE_GREEN,
+  ENTITY_DISPLAY_NAMES,
+  LABEL_COLORS,
+} from "./labelStyles";
 import styles from "./labelBoxOverlay.module.css";
 
 const LEGEND_GROUPS = [
   {
     color: "var(--color-yellow)",
     label: "Merchant",
-    title: "Merchant name",
-    types: ["MERCHANT_NAME"],
+    title: "Merchant name · Business name · Loyalty ID",
+    types: ["MERCHANT_NAME", "BUSINESS_NAME", "LOYALTY_ID"],
   },
   {
     color: "var(--color-blue)",
@@ -71,6 +75,17 @@ const LEGEND_GROUPS = [
     types: ["STORE_HOURS", "PAYMENT_METHOD"],
   },
 ] as const;
+
+const groupedFamilies: Set<string> = new Set(
+  LEGEND_GROUPS.flatMap((group) => [...group.types]),
+);
+
+const fallbackLabel = (family: string): string =>
+  ENTITY_DISPLAY_NAMES[family] ??
+  family
+    .toLowerCase()
+    .replaceAll("_", " ")
+    .replace(/^./, (character) => character.toUpperCase());
 
 /**
  * The ground-truth label box layer, extracted verbatim from
@@ -136,6 +151,9 @@ export const LabelLegend: React.FC<{
   const visibleGroups = LEGEND_GROUPS.filter((group) =>
     group.types.some((type) => presentFamilies.has(type)),
   );
+  const unmatchedFamilies = Array.from(presentFamilies).filter(
+    (family) => family !== "O" && !groupedFamilies.has(family),
+  );
 
   return (
     <div
@@ -149,6 +167,17 @@ export const LabelLegend: React.FC<{
             style={{ backgroundColor: group.color }}
           />
           <span className={styles.legendLabel}>{group.label}</span>
+        </div>
+      ))}
+      {unmatchedFamilies.map((family) => (
+        <div key={family} title={family} className={styles.legendItem}>
+          <div
+            className={styles.legendDot}
+            style={{
+              backgroundColor: LABEL_COLORS[family] || LABEL_COLORS.O,
+            }}
+          />
+          <span className={styles.legendLabel}>{fallbackLabel(family)}</span>
         </div>
       ))}
     </div>

--- a/portfolio/components/ui/Figures/labelBoxOverlay.tsx
+++ b/portfolio/components/ui/Figures/labelBoxOverlay.tsx
@@ -1,6 +1,76 @@
 import React from "react";
-import { ENTITY_DISPLAY_NAMES, LABEL_COLORS } from "./labelStyles";
+import { CHARGE_GREEN } from "./labelStyles";
 import styles from "./labelBoxOverlay.module.css";
+
+const LEGEND_GROUPS = [
+  {
+    color: "var(--color-yellow)",
+    label: "Merchant",
+    title: "Merchant name",
+    types: ["MERCHANT_NAME"],
+  },
+  {
+    color: "var(--color-blue)",
+    label: "Date / Time",
+    title: "Date · Time",
+    types: ["DATE", "TIME"],
+  },
+  {
+    color: CHARGE_GREEN,
+    label: "Charges",
+    title: "Total · Subtotal · Tax · Line total · Unit price",
+    types: [
+      "GRAND_TOTAL",
+      "SUBTOTAL",
+      "TAX",
+      "LINE_TOTAL",
+      "UNIT_PRICE",
+      "AMOUNT",
+    ],
+  },
+  {
+    color: "var(--color-teal)",
+    label: "Credits",
+    title: "Discount · Coupon · Tip · Change · Cash back · Refund",
+    types: ["DISCOUNT", "COUPON", "TIP", "CHANGE", "CASH_BACK", "REFUND"],
+  },
+  {
+    color: "var(--color-cyan)",
+    label: "Quantity",
+    title: "Quantity",
+    types: ["QUANTITY"],
+  },
+  {
+    color: "var(--color-red)",
+    label: "Address",
+    title: "Address line",
+    types: ["ADDRESS", "ADDRESS_LINE"],
+  },
+  {
+    color: "var(--color-pink)",
+    label: "Phone",
+    title: "Phone number",
+    types: ["PHONE_NUMBER"],
+  },
+  {
+    color: "var(--color-purple)",
+    label: "Product",
+    title: "Product name",
+    types: ["PRODUCT_NAME"],
+  },
+  {
+    color: "var(--color-purple)",
+    label: "Website",
+    title: "Website",
+    types: ["WEBSITE"],
+  },
+  {
+    color: "var(--color-orange)",
+    label: "Hours / Pay",
+    title: "Store hours · Payment method",
+    types: ["STORE_HOURS", "PAYMENT_METHOD"],
+  },
+] as const;
 
 /**
  * The ground-truth label box layer, extracted verbatim from
@@ -54,27 +124,33 @@ export const LabelBoxOverlay: React.FC<{
 );
 
 /**
- * The label legend, matching LayoutLMBatchVisualization's legend markup/classes
- * (a colored dot + display name per family) so both figures read the same.
+ * The label legend, matching LayoutLMBatchVisualization's compact taxonomy
+ * groups and dot/label styling so both figures read the same without letting a
+ * granular receipt-specific label list outgrow the fixed carousel stage.
  */
 export const LabelLegend: React.FC<{
   families: string[];
   className?: string;
-}> = ({ families, className }) => (
-  <div
-    className={className ? `${styles.legend} ${className}` : styles.legend}
-    aria-label="Label families"
-  >
-    {families.map((family) => (
-      <div key={family} className={styles.legendItem}>
-        <div
-          className={styles.legendDot}
-          style={{ backgroundColor: LABEL_COLORS[family] || LABEL_COLORS.O }}
-        />
-        <span className={styles.legendLabel}>
-          {ENTITY_DISPLAY_NAMES[family] ?? family}
-        </span>
-      </div>
-    ))}
-  </div>
-);
+}> = ({ families, className }) => {
+  const presentFamilies = new Set(families);
+  const visibleGroups = LEGEND_GROUPS.filter((group) =>
+    group.types.some((type) => presentFamilies.has(type)),
+  );
+
+  return (
+    <div
+      className={className ? `${styles.legend} ${className}` : styles.legend}
+      aria-label="Label families"
+    >
+      {visibleGroups.map((group) => (
+        <div key={group.label} title={group.title} className={styles.legendItem}>
+          <div
+            className={styles.legendDot}
+            style={{ backgroundColor: group.color }}
+          />
+          <span className={styles.legendLabel}>{group.label}</span>
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/portfolio/components/ui/Figures/labelStyles.ts
+++ b/portfolio/components/ui/Figures/labelStyles.ts
@@ -12,6 +12,8 @@ const CHARGE_GREEN_LIGHT = "color-mix(in srgb, var(--color-green) 48%, white)";
 // family) vs credits (teal), plus QUANTITY (cyan) and ADDRESS_LINE.
 export const LABEL_COLORS: Record<string, string> = {
   MERCHANT_NAME: "var(--color-yellow)",
+  BUSINESS_NAME: "var(--color-yellow)",
+  LOYALTY_ID: "var(--color-yellow)",
   DATE: "var(--color-blue)",
   TIME: "var(--color-blue)",
   PRODUCT_NAME: "var(--color-purple)",
@@ -44,6 +46,8 @@ export const LABEL_COLORS: Record<string, string> = {
 // Entity type display names
 export const ENTITY_DISPLAY_NAMES: Record<string, string> = {
   MERCHANT_NAME: "Merchant",
+  BUSINESS_NAME: "Business name",
+  LOYALTY_ID: "Loyalty ID",
   DATE: "Date",
   TIME: "Time",
   PRODUCT_NAME: "Product",


### PR DESCRIPTION
## Summary

- group granular synthesis labels into the same compact taxonomy used by the LayoutLM inference visualization
- match the LayoutLM legend width, spacing, padding, dot sizing, and alignment
- preserve a dedicated Product row and the wrapped mobile layout
- add regression coverage for the grouped legend labels

## Why

The synthesis legend had drifted from the LayoutLM component: it used a narrower, tighter column and rendered every granular label separately. Copying LayoutLM's spacing directly made that 12-row list taller than the fixed carousel stage. Grouping related labels keeps the LayoutLM visual rhythm while ensuring the full legend fits without clipping.

## Validation

- `npm test -- --runInBand components/ui/Figures/SynthesisPipeline/SynthesisPipeline.test.tsx` — 19 tests passed
- `npm run type-check`
- `npx eslint components/ui/Figures/labelBoxOverlay.tsx components/ui/Figures/SynthesisPipeline/SynthesisPipeline.test.tsx`
- `git diff --check`
- browser QA at 1280×720 confirmed all nine legend rows fit within the synthesis stage
