### PR TITLE
Refactor Pulumi API route wiring

### DIFF
--- a/infra/__main__.py
+++ b/infra/__main__.py
@@ -12,6 +12,11 @@ import pulumi_aws as aws
 from pulumi import Output
 
 import api_gateway
+from components.http_api_route import (
+    RouteDefinition,
+    create_lambda_route,
+    create_lambda_routes,
+)
 
 # Auto-enable Docker BuildKit based on Pulumi config
 config = pulumi.Config("portfolio")
@@ -383,33 +388,16 @@ word_similarity_lambda = create_word_similarity_lambda(
 pulumi.export("word_similarity_lambda_arn", word_similarity_lambda.arn)
 pulumi.export("word_similarity_lambda_name", word_similarity_lambda.name)
 
-# Create API Gateway route for word_similarity
-if hasattr(api_gateway, "api"):
-    integration_word_similarity = aws.apigatewayv2.Integration(
-        "word_similarity_lambda_integration",
-        api_id=api_gateway.api.id,
-        integration_type="AWS_PROXY",
-        integration_uri=word_similarity_lambda.invoke_arn,
-        integration_method="POST",
-        payload_format_version="2.0",
-    )
-    route_word_similarity = aws.apigatewayv2.Route(
-        "word_similarity_route",
-        api_id=api_gateway.api.id,
-        route_key="GET /word_similarity",
-        target=integration_word_similarity.id.apply(lambda id: f"integrations/{id}"),
-        opts=pulumi.ResourceOptions(
-            replace_on_changes=["route_key", "target"],
-            delete_before_replace=True,
-        ),
-    )
-    lambda_permission_word_similarity = aws.lambda_.Permission(
-        "word_similarity_lambda_permission",
-        action="lambda:InvokeFunction",
-        function=word_similarity_lambda.name,
-        principal="apigateway.amazonaws.com",
-        source_arn=api_gateway.api.execution_arn.apply(lambda arn: f"{arn}/*/*"),
-    )
+# This Lambda is created after the cache bucket, so its API route is registered
+# here rather than in api_gateway's static route manifest.
+create_lambda_route(
+    api=api_gateway.api,
+    integration_name="word_similarity_lambda_integration",
+    route_name="word_similarity_route",
+    route_key="GET /word_similarity",
+    lambda_function=word_similarity_lambda,
+    permission_name="word_similarity_lambda_permission",
+)
 
 # Recreate workers to use NAT private subnets for egress
 workers_nat = ChromaWorkers(
@@ -584,81 +572,31 @@ if layoutlm_training_bucket_name is not None:
     )
     epochs_module.layoutlm_epochs_lambda = layoutlm_epochs_lambda
 
-    # Create API Gateway route for layoutlm_inference
-    # This must be done here after Lambda is created, not in api_gateway.py
-    # because api_gateway.py is imported before the Lambda exists
-    import api_gateway
-
-    if hasattr(api_gateway, "api"):
-        integration_layoutlm_inference = aws.apigatewayv2.Integration(
-            "layoutlm_inference_lambda_integration",
-            api_id=api_gateway.api.id,
-            integration_type="AWS_PROXY",
-            integration_uri=layoutlm_inference_lambda.invoke_arn,
-            integration_method="POST",
-            payload_format_version="2.0",
-        )
-        route_layoutlm_inference = aws.apigatewayv2.Route(
-            "layoutlm_inference_route",
-            api_id=api_gateway.api.id,
-            route_key="GET /layoutlm_inference",
-            target=integration_layoutlm_inference.id.apply(
-                lambda id: f"integrations/{id}"
+    # These routes are late-bound because the model and cache buckets determine
+    # whether their Lambda functions exist for this stack.
+    create_lambda_routes(
+        api=api_gateway.api,
+        integration_name="layoutlm_inference_lambda_integration",
+        lambda_function=layoutlm_inference_lambda,
+        routes=(
+            RouteDefinition(
+                "layoutlm_inference_route", "GET /layoutlm_inference"
             ),
-            opts=pulumi.ResourceOptions(
-                replace_on_changes=["route_key", "target"],
-                delete_before_replace=True,
+            RouteDefinition(
+                "layoutlm_inference_cache_route",
+                "GET /layoutlm-inference-cache",
             ),
-        )
-        # Also add alias route with hyphens for convenience
-        route_layoutlm_inference_cache = aws.apigatewayv2.Route(
-            "layoutlm_inference_cache_route",
-            api_id=api_gateway.api.id,
-            route_key="GET /layoutlm-inference-cache",
-            target=integration_layoutlm_inference.id.apply(
-                lambda id: f"integrations/{id}"
-            ),
-            opts=pulumi.ResourceOptions(
-                replace_on_changes=["route_key", "target"],
-                delete_before_replace=True,
-            ),
-        )
-        lambda_permission_layoutlm_inference = aws.lambda_.Permission(
-            "layoutlm_inference_lambda_permission",
-            action="lambda:InvokeFunction",
-            function=layoutlm_inference_lambda.name,
-            principal="apigateway.amazonaws.com",
-            source_arn=api_gateway.api.execution_arn.apply(lambda arn: f"{arn}/*/*"),
-        )
-
-        # Route for the per-epoch evaluation API.
-        integration_layoutlm_epochs = aws.apigatewayv2.Integration(
-            "layoutlm_epochs_lambda_integration",
-            api_id=api_gateway.api.id,
-            integration_type="AWS_PROXY",
-            integration_uri=layoutlm_epochs_lambda.invoke_arn,
-            integration_method="POST",
-            payload_format_version="2.0",
-        )
-        route_layoutlm_epochs = aws.apigatewayv2.Route(
-            "layoutlm_epochs_route",
-            api_id=api_gateway.api.id,
-            route_key="GET /layoutlm_epochs",
-            target=integration_layoutlm_epochs.id.apply(
-                lambda id: f"integrations/{id}"
-            ),
-            opts=pulumi.ResourceOptions(
-                replace_on_changes=["route_key", "target"],
-                delete_before_replace=True,
-            ),
-        )
-        lambda_permission_layoutlm_epochs = aws.lambda_.Permission(
-            "layoutlm_epochs_lambda_permission",
-            action="lambda:InvokeFunction",
-            function=layoutlm_epochs_lambda.name,
-            principal="apigateway.amazonaws.com",
-            source_arn=api_gateway.api.execution_arn.apply(lambda arn: f"{arn}/*/*"),
-        )
+        ),
+        permission_name="layoutlm_inference_lambda_permission",
+    )
+    create_lambda_route(
+        api=api_gateway.api,
+        integration_name="layoutlm_epochs_lambda_integration",
+        route_name="layoutlm_epochs_route",
+        route_key="GET /layoutlm_epochs",
+        lambda_function=layoutlm_epochs_lambda,
+        permission_name="layoutlm_epochs_lambda_permission",
+    )
 
     pulumi.export(
         "layoutlm_inference_cache_bucket",
@@ -1589,35 +1527,14 @@ label_validation_timeline_lambda = create_label_validation_timeline_lambda(
     cache_bucket_name=timeline_cache_bucket.id,
 )
 
-# Create API Gateway route for label_validation_timeline
-if hasattr(api_gateway, "api"):
-    integration_label_validation_timeline = aws.apigatewayv2.Integration(
-        "label_validation_timeline_lambda_integration",
-        api_id=api_gateway.api.id,
-        integration_type="AWS_PROXY",
-        integration_uri=label_validation_timeline_lambda.invoke_arn,
-        integration_method="POST",
-        payload_format_version="2.0",
-    )
-    route_label_validation_timeline = aws.apigatewayv2.Route(
-        "label_validation_timeline_route",
-        api_id=api_gateway.api.id,
-        route_key="GET /label_validation_timeline",
-        target=integration_label_validation_timeline.id.apply(
-            lambda id: f"integrations/{id}"
-        ),
-        opts=pulumi.ResourceOptions(
-            replace_on_changes=["route_key", "target"],
-            delete_before_replace=True,
-        ),
-    )
-    lambda_permission_label_validation_timeline = aws.lambda_.Permission(
-        "label_validation_timeline_lambda_permission",
-        action="lambda:InvokeFunction",
-        function=label_validation_timeline_lambda.name,
-        principal="apigateway.amazonaws.com",
-        source_arn=api_gateway.api.execution_arn.apply(lambda arn: f"{arn}/*/*"),
-    )
+create_lambda_route(
+    api=api_gateway.api,
+    integration_name="label_validation_timeline_lambda_integration",
+    route_name="label_validation_timeline_route",
+    route_key="GET /label_validation_timeline",
+    lambda_function=label_validation_timeline_lambda,
+    permission_name="label_validation_timeline_lambda_permission",
+)
 
 pulumi.export("label_validation_timeline_cache_bucket", timeline_cache_bucket.id)
 pulumi.export(
@@ -1643,31 +1560,13 @@ if hasattr(api_gateway, "api"):
         label_evaluator_shared.viz_cache_bucket_name,
     )
 
-    # Label evaluator visualization endpoint
-    integration_viz = aws.apigatewayv2.Integration(
-        "label_evaluator_viz_cache_integration",
-        api_id=api_gateway.api.id,
-        integration_type="AWS_PROXY",
-        integration_uri=label_evaluator_viz_cache.api_lambda.invoke_arn,
-        integration_method="POST",
-        payload_format_version="2.0",
-    )
-    route_viz = aws.apigatewayv2.Route(
-        "label_evaluator_viz_cache_route",
-        api_id=api_gateway.api.id,
+    create_lambda_route(
+        api=api_gateway.api,
+        integration_name="label_evaluator_viz_cache_integration",
+        route_name="label_evaluator_viz_cache_route",
         route_key="GET /label_evaluator/visualization",
-        target=integration_viz.id.apply(lambda id: f"integrations/{id}"),
-        opts=pulumi.ResourceOptions(
-            replace_on_changes=["route_key", "target"],
-            delete_before_replace=True,
-        ),
-    )
-    aws.lambda_.Permission(
-        "label_evaluator_viz_lambda_permission",
-        action="lambda:InvokeFunction",
-        function=label_evaluator_viz_cache.api_lambda.name,
-        principal="apigateway.amazonaws.com",
-        source_arn=api_gateway.api.execution_arn.apply(lambda arn: f"{arn}/*/*"),
+        lambda_function=label_evaluator_viz_cache.api_lambda,
+        permission_name="label_evaluator_viz_lambda_permission",
     )
 
     # Additional label evaluator visualization endpoints (same Lambda, different paths)
@@ -1682,45 +1581,23 @@ if hasattr(api_gateway, "api"):
         "receipt_health",
         "receipt_health_issues",
     ]:
-        _integration = aws.apigatewayv2.Integration(
-            f"label_evaluator_{viz_name}_integration",
-            api_id=api_gateway.api.id,
-            integration_type="AWS_PROXY",
-            integration_uri=label_evaluator_viz_cache.api_lambda.invoke_arn,
-            integration_method="POST",
-            payload_format_version="2.0",
-        )
-        aws.apigatewayv2.Route(
-            f"label_evaluator_{viz_name}_route",
-            api_id=api_gateway.api.id,
+        create_lambda_route(
+            api=api_gateway.api,
+            integration_name=f"label_evaluator_{viz_name}_integration",
+            route_name=f"label_evaluator_{viz_name}_route",
             route_key=f"GET /label_evaluator/{viz_name}",
-            target=_integration.id.apply(lambda id: f"integrations/{id}"),
-            opts=pulumi.ResourceOptions(
-                replace_on_changes=["route_key", "target"],
-                delete_before_replace=True,
-            ),
+            lambda_function=label_evaluator_viz_cache.api_lambda,
         )
 
-    receipt_health_issues_post_integration = aws.apigatewayv2.Integration(
-        "label_evaluator_receipt_health_issues_post_integration",
-        api_id=api_gateway.api.id,
-        integration_type="AWS_PROXY",
-        integration_uri=label_evaluator_viz_cache.api_lambda.invoke_arn,
-        integration_method="POST",
-        payload_format_version="2.0",
-    )
-    aws.apigatewayv2.Route(
-        "label_evaluator_receipt_health_issues_post_route",
-        api_id=api_gateway.api.id,
+    create_lambda_route(
+        api=api_gateway.api,
+        integration_name=(
+            "label_evaluator_receipt_health_issues_post_integration"
+        ),
+        route_name="label_evaluator_receipt_health_issues_post_route",
         route_key="POST /label_evaluator/receipt_health_issues",
+        lambda_function=label_evaluator_viz_cache.api_lambda,
         authorization_type="AWS_IAM",
-        target=receipt_health_issues_post_integration.id.apply(
-            lambda id: f"integrations/{id}"
-        ),
-        opts=pulumi.ResourceOptions(
-            replace_on_changes=["route_key", "target"],
-            delete_before_replace=True,
-        ),
     )
 
     # Label Validation Visualization Cache (uses label_validation_project_name)
@@ -1751,33 +1628,13 @@ if hasattr(api_gateway, "api"):
         label_validation_viz_cache.step_function.arn,
     )
 
-    # Label validation visualization endpoint
-    integration_label_validation_viz = aws.apigatewayv2.Integration(
-        "label_validation_viz_cache_integration",
-        api_id=api_gateway.api.id,
-        integration_type="AWS_PROXY",
-        integration_uri=label_validation_viz_cache.api_lambda.invoke_arn,
-        integration_method="POST",
-        payload_format_version="2.0",
-    )
-    route_label_validation_viz = aws.apigatewayv2.Route(
-        "label_validation_viz_cache_route",
-        api_id=api_gateway.api.id,
+    create_lambda_route(
+        api=api_gateway.api,
+        integration_name="label_validation_viz_cache_integration",
+        route_name="label_validation_viz_cache_route",
         route_key="GET /label_validation/visualization",
-        target=integration_label_validation_viz.id.apply(
-            lambda id: f"integrations/{id}"
-        ),
-        opts=pulumi.ResourceOptions(
-            replace_on_changes=["route_key", "target"],
-            delete_before_replace=True,
-        ),
-    )
-    aws.lambda_.Permission(
-        "label_validation_viz_lambda_permission",
-        action="lambda:InvokeFunction",
-        function=label_validation_viz_cache.api_lambda.name,
-        principal="apigateway.amazonaws.com",
-        source_arn=api_gateway.api.execution_arn.apply(lambda arn: f"{arn}/*/*"),
+        lambda_function=label_validation_viz_cache.api_lambda,
+        permission_name="label_validation_viz_lambda_permission",
     )
 
 # QA Agent Step Function pipeline
@@ -1811,29 +1668,11 @@ if hasattr(api_gateway, "api"):
     )
     pulumi.export("qa_viz_cache_bucket", qa_agent_sf.batch_bucket_name)
 
-    # QA visualization endpoint
-    integration_qa_viz = aws.apigatewayv2.Integration(
-        "qa_viz_cache_integration",
-        api_id=api_gateway.api.id,
-        integration_type="AWS_PROXY",
-        integration_uri=qa_viz_cache.api_lambda.invoke_arn,
-        integration_method="POST",
-        payload_format_version="2.0",
-    )
-    route_qa_viz = aws.apigatewayv2.Route(
-        "qa_viz_cache_route",
-        api_id=api_gateway.api.id,
+    create_lambda_route(
+        api=api_gateway.api,
+        integration_name="qa_viz_cache_integration",
+        route_name="qa_viz_cache_route",
         route_key="GET /qa/visualization",
-        target=integration_qa_viz.id.apply(lambda id: f"integrations/{id}"),
-        opts=pulumi.ResourceOptions(
-            replace_on_changes=["route_key", "target"],
-            delete_before_replace=True,
-        ),
-    )
-    aws.lambda_.Permission(
-        "qa_viz_lambda_permission",
-        action="lambda:InvokeFunction",
-        function=qa_viz_cache.api_lambda.name,
-        principal="apigateway.amazonaws.com",
-        source_arn=api_gateway.api.execution_arn.apply(lambda arn: f"{arn}/*/*"),
+        lambda_function=qa_viz_cache.api_lambda,
+        permission_name="qa_viz_lambda_permission",
     )

--- a/infra/api_gateway.py
+++ b/infra/api_gateway.py
@@ -1,18 +1,15 @@
+"""Public HTTP API, static Lambda routes, logging, and custom domain."""
+
 import pulumi
 import pulumi_aws as aws
 
-# Import cache generator routes first (API routes depend on them)
+# Import cache generator routes first (API routes depend on them).
 import routes.address_similarity_cache_generator.infra  # noqa: F401
 import routes.image_details_cache_generator.infra  # noqa: F401
 import routes.layoutlm_inference_cache_generator.infra  # noqa: F401
-
-# word_similarity_cache_generator is now created in __main__.py with VPC config
+from components.http_api_route import create_lambda_route
 from routes.address_similarity.infra import address_similarity_lambda
-
-# word_similarity_lambda is created in __main__.py after cache generator
 from routes.ai_usage.infra import ai_usage_lambda
-
-# Import your Lambda/route definitions
 from routes.health_check.infra import health_check_lambda
 from routes.image_count.infra import image_count_lambda
 from routes.image_details_cache.infra import image_details_cache_lambda
@@ -27,35 +24,43 @@ from routes.reader_summary.infra import reader_summary_lambda
 from routes.receipt_count.infra import receipt_count_lambda
 from routes.receipts.infra import receipts_lambda
 
-# LayoutLM inference Lambda is created conditionally in __main__.py after cache bucket exists
-# Route creation is also done in __main__.py after Lambda is created
-
-# Detect the current Pulumi stack
-stack = pulumi.get_stack()
-
 BASE_DOMAIN = "tylernorlund.com"
-ALLOWED_API_ORIGINS = [
+ALLOWED_API_ORIGINS = (
     "http://localhost:3000",
     "https://tylernorlund.com",
     "https://www.tylernorlund.com",
     "https://dev.tylernorlund.com",
-]
+)
+ACCESS_LOG_FORMAT = (
+    "{"
+    '"requestId":"$context.requestId",'
+    '"ip":"$context.identity.sourceIp",'
+    '"caller":"$context.identity.caller",'
+    '"user":"$context.identity.user",'
+    '"requestTime":"$context.requestTime",'
+    '"httpMethod":"$context.httpMethod",'
+    '"resourcePath":"$context.resourcePath",'
+    '"status":"$context.status",'
+    '"protocol":"$context.protocol",'
+    '"responseLength":"$context.responseLength"'
+    "}"
+)
 
-# For "prod" => api.tylernorlund.com
-# otherwise   => dev-api.tylernorlund.com
-if stack == "prod":
-    api_domain_name = f"api.{BASE_DOMAIN}"
-else:
-    api_domain_name = f"{stack}-api.{BASE_DOMAIN}"
 
-# ─────────────────────────────────────────────────────────────────────────────────
-# 1. MAIN API DEFINITION
-# ─────────────────────────────────────────────────────────────────────────────────
+def _domain_name(stack_name: str) -> str:
+    """Return the stack-specific API hostname."""
+    subdomain = "api" if stack_name == "prod" else f"{stack_name}-api"
+    return f"{subdomain}.{BASE_DOMAIN}"
+
+
+stack = pulumi.get_stack()
+api_domain_name = _domain_name(stack)
+
 api = aws.apigatewayv2.Api(
     "my-api",
     protocol_type="HTTP",
     cors_configuration=aws.apigatewayv2.ApiCorsConfigurationArgs(
-        allow_origins=ALLOWED_API_ORIGINS,
+        allow_origins=list(ALLOWED_API_ORIGINS),
         allow_methods=["GET", "POST"],
         allow_headers=["Content-Type"],
         expose_headers=["Content-Type"],
@@ -64,451 +69,68 @@ api = aws.apigatewayv2.Api(
     ),
 )
 
-# Define your integrations and routes
-# ------------------------------------------------------------------------------
-# /health_check
-integration_health_check = aws.apigatewayv2.Integration(
-    "health_check_lambda_integration",
-    api_id=api.id,
-    integration_type="AWS_PROXY",
-    integration_uri=health_check_lambda.invoke_arn,
-    integration_method="POST",
-    payload_format_version="2.0",
-)
-route_health_check = aws.apigatewayv2.Route(
-    "health_check_route",
-    api_id=api.id,
-    route_key="GET /health_check",
-    target=integration_health_check.id.apply(lambda id: f"integrations/{id}"),
-    opts=pulumi.ResourceOptions(
-        replace_on_changes=["route_key", "target"],
-        delete_before_replace=True,
+# Routes whose Lambdas exist when this module is imported. Routes backed by
+# conditionally-created Lambdas are registered from __main__.py with the same
+# shared helper after those functions are available.
+_STATIC_ROUTES = (
+    ("health_check", "GET /health_check", health_check_lambda),
+    (
+        "random_image_details",
+        "GET /random_image_details",
+        random_image_details_lambda,
+    ),
+    ("image_count", "GET /image_count", image_count_lambda),
+    ("images", "GET /images", images_lambda),
+    (
+        "label_validation_count",
+        "GET /label_validation_count",
+        label_validation_count_lambda,
+    ),
+    ("merchant_counts", "GET /merchant_counts", merchant_counts_lambda),
+    ("receipt_count", "GET /receipt_count", receipt_count_lambda),
+    ("receipts", "GET /receipts", receipts_lambda),
+    (
+        "random_receipt_details",
+        "GET /random_receipt_details",
+        random_receipt_details_lambda,
+    ),
+    (
+        "address_similarity",
+        "GET /address_similarity",
+        address_similarity_lambda,
+    ),
+    (
+        "image_details_cache",
+        "GET /image_details_cache",
+        image_details_cache_lambda,
+    ),
+    ("process", "GET /process", process_lambda),
+    ("ai_usage", "GET /ai_usage", ai_usage_lambda),
+    ("reader_summary", "POST /reader_summary", reader_summary_lambda),
+    (
+        "job_training_metrics",
+        "GET /jobs/{job_id}/training-metrics",
+        job_training_metrics_lambda,
     ),
 )
-lambda_permission_health_check = aws.lambda_.Permission(
-    "health_check_lambda_permission",
-    action="lambda:InvokeFunction",
-    function=health_check_lambda.name,
-    principal="apigateway.amazonaws.com",
-    source_arn=api.execution_arn.apply(lambda arn: f"{arn}/*/*"),
-)
 
-# /random_image_details
-integration_random_image_details = aws.apigatewayv2.Integration(
-    "random_image_details_lambda_integration",
-    api_id=api.id,
-    integration_type="AWS_PROXY",
-    integration_uri=random_image_details_lambda.invoke_arn,
-    integration_method="POST",
-    payload_format_version="2.0",
-)
-route_random_image_details = aws.apigatewayv2.Route(
-    "random_image_details_route",
-    api_id=api.id,
-    route_key="GET /random_image_details",
-    target=integration_random_image_details.id.apply(
-        lambda id: f"integrations/{id}"
-    ),
-    opts=pulumi.ResourceOptions(
-        replace_on_changes=["route_key", "target"],
-        delete_before_replace=True,
-    ),
-)
-lambda_permission_random_image_details = aws.lambda_.Permission(
-    "random_image_details_lambda_permission",
-    action="lambda:InvokeFunction",
-    function=random_image_details_lambda.name,
-    principal="apigateway.amazonaws.com",
-    source_arn=api.execution_arn.apply(lambda arn: f"{arn}/*/*"),
-)
+static_route_resources = {
+    name: create_lambda_route(
+        api=api,
+        integration_name=f"{name}_lambda_integration",
+        route_name=f"{name}_route",
+        route_key=route_key,
+        lambda_function=lambda_function,
+        permission_name=f"{name}_lambda_permission",
+    )
+    for name, route_key, lambda_function in _STATIC_ROUTES
+}
 
-# /image_count
-integration_image_count = aws.apigatewayv2.Integration(
-    "image_count_lambda_integration",
-    api_id=api.id,
-    integration_type="AWS_PROXY",
-    integration_uri=image_count_lambda.invoke_arn,
-    integration_method="POST",
-    payload_format_version="2.0",
-)
-route_image_count = aws.apigatewayv2.Route(
-    "image_count_route",
-    api_id=api.id,
-    route_key="GET /image_count",
-    target=integration_image_count.id.apply(lambda id: f"integrations/{id}"),
-    opts=pulumi.ResourceOptions(
-        replace_on_changes=["route_key", "target"],
-        delete_before_replace=True,
-    ),
-)
-lambda_permission_image_count = aws.lambda_.Permission(
-    "image_count_lambda_permission",
-    action="lambda:InvokeFunction",
-    function=image_count_lambda.name,
-    principal="apigateway.amazonaws.com",
-    source_arn=api.execution_arn.apply(lambda arn: f"{arn}/*/*"),
-)
-
-# /images
-integration_images = aws.apigatewayv2.Integration(
-    "images_lambda_integration",
-    api_id=api.id,
-    integration_type="AWS_PROXY",
-    integration_uri=images_lambda.invoke_arn,
-    integration_method="POST",
-    payload_format_version="2.0",
-)
-route_images = aws.apigatewayv2.Route(
-    "images_route",
-    api_id=api.id,
-    route_key="GET /images",
-    target=integration_images.id.apply(lambda id: f"integrations/{id}"),
-    opts=pulumi.ResourceOptions(
-        replace_on_changes=["route_key", "target"],
-        delete_before_replace=True,
-    ),
-)
-lambda_permission_images = aws.lambda_.Permission(
-    "images_lambda_permission",
-    action="lambda:InvokeFunction",
-    function=images_lambda.name,
-    principal="apigateway.amazonaws.com",
-    source_arn=api.execution_arn.apply(lambda arn: f"{arn}/*/*"),
-)
-
-# /label_validation_count
-integration_label_validation_count = aws.apigatewayv2.Integration(
-    "label_validation_count_lambda_integration",
-    api_id=api.id,
-    integration_type="AWS_PROXY",
-    integration_uri=label_validation_count_lambda.invoke_arn,
-    integration_method="POST",
-    payload_format_version="2.0",
-)
-route_label_validation_count = aws.apigatewayv2.Route(
-    "label_validation_count_route",
-    api_id=api.id,
-    route_key="GET /label_validation_count",
-    target=integration_label_validation_count.id.apply(
-        lambda id: f"integrations/{id}"
-    ),  # noqa: E501
-    opts=pulumi.ResourceOptions(
-        replace_on_changes=["route_key", "target"],
-        delete_before_replace=True,
-    ),
-)
-lambda_permission_label_validation_count = aws.lambda_.Permission(
-    "label_validation_count_lambda_permission",
-    action="lambda:InvokeFunction",
-    function=label_validation_count_lambda.name,
-    principal="apigateway.amazonaws.com",
-    source_arn=api.execution_arn.apply(lambda arn: f"{arn}/*/*"),
-)
-
-# /merchant_counts
-integration_merchant_counts = aws.apigatewayv2.Integration(
-    "merchant_counts_lambda_integration",
-    api_id=api.id,
-    integration_type="AWS_PROXY",
-    integration_uri=merchant_counts_lambda.invoke_arn,
-    integration_method="POST",
-    payload_format_version="2.0",
-)
-route_merchant_counts = aws.apigatewayv2.Route(
-    "merchant_counts_route",
-    api_id=api.id,
-    route_key="GET /merchant_counts",
-    target=integration_merchant_counts.id.apply(
-        lambda id: f"integrations/{id}"
-    ),  # noqa: E501
-    opts=pulumi.ResourceOptions(
-        replace_on_changes=["route_key", "target"],
-        delete_before_replace=True,
-    ),
-)
-lambda_permission_merchant_counts = aws.lambda_.Permission(
-    "merchant_counts_lambda_permission",
-    action="lambda:InvokeFunction",
-    function=merchant_counts_lambda.name,
-    principal="apigateway.amazonaws.com",
-    source_arn=api.execution_arn.apply(lambda arn: f"{arn}/*/*"),
-)
-
-# /receipt_count
-integration_receipt_count = aws.apigatewayv2.Integration(
-    "receipt_count_lambda_integration",
-    api_id=api.id,
-    integration_type="AWS_PROXY",
-    integration_uri=receipt_count_lambda.invoke_arn,
-    integration_method="POST",
-    payload_format_version="2.0",
-)
-route_receipt_count = aws.apigatewayv2.Route(
-    "receipt_count_route",
-    api_id=api.id,
-    route_key="GET /receipt_count",
-    target=integration_receipt_count.id.apply(lambda id: f"integrations/{id}"),
-    opts=pulumi.ResourceOptions(
-        replace_on_changes=["route_key", "target"],
-        delete_before_replace=True,
-    ),
-)
-lambda_permission_receipt_count = aws.lambda_.Permission(
-    "receipt_count_lambda_permission",
-    action="lambda:InvokeFunction",
-    function=receipt_count_lambda.name,
-    principal="apigateway.amazonaws.com",
-    source_arn=api.execution_arn.apply(lambda arn: f"{arn}/*/*"),
-)
-
-# /receipts
-integration_receipts = aws.apigatewayv2.Integration(
-    "receipts_lambda_integration",
-    api_id=api.id,
-    integration_type="AWS_PROXY",
-    integration_uri=receipts_lambda.invoke_arn,
-    integration_method="POST",
-    payload_format_version="2.0",
-)
-route_receipts = aws.apigatewayv2.Route(
-    "receipts_route",
-    api_id=api.id,
-    route_key="GET /receipts",
-    target=integration_receipts.id.apply(lambda id: f"integrations/{id}"),
-    opts=pulumi.ResourceOptions(
-        replace_on_changes=["route_key", "target"],
-        delete_before_replace=True,
-    ),
-)
-lambda_permission_receipts = aws.lambda_.Permission(
-    "receipts_lambda_permission",
-    action="lambda:InvokeFunction",
-    function=receipts_lambda.name,
-    principal="apigateway.amazonaws.com",
-    source_arn=api.execution_arn.apply(lambda arn: f"{arn}/*/*"),
-)
-
-
-# /random_receipt_details
-integration_random_receipt_details = aws.apigatewayv2.Integration(
-    "random_receipt_details_lambda_integration",
-    api_id=api.id,
-    integration_type="AWS_PROXY",
-    integration_uri=random_receipt_details_lambda.invoke_arn,
-    integration_method="POST",
-    payload_format_version="2.0",
-)
-route_random_receipt_details = aws.apigatewayv2.Route(
-    "random_receipt_details_route",
-    api_id=api.id,
-    route_key="GET /random_receipt_details",
-    target=integration_random_receipt_details.id.apply(
-        lambda id: f"integrations/{id}"
-    ),
-    opts=pulumi.ResourceOptions(
-        replace_on_changes=["route_key", "target"],
-        delete_before_replace=True,
-    ),
-)
-lambda_permission_random_receipt_details = aws.lambda_.Permission(
-    "random_receipt_details_lambda_permission",
-    action="lambda:InvokeFunction",
-    function=random_receipt_details_lambda.name,
-    principal="apigateway.amazonaws.com",
-    source_arn=api.execution_arn.apply(lambda arn: f"{arn}/*/*"),
-)
-
-# /address_similarity
-integration_address_similarity = aws.apigatewayv2.Integration(
-    "address_similarity_lambda_integration",
-    api_id=api.id,
-    integration_type="AWS_PROXY",
-    integration_uri=address_similarity_lambda.invoke_arn,
-    integration_method="POST",
-    payload_format_version="2.0",
-)
-route_address_similarity = aws.apigatewayv2.Route(
-    "address_similarity_route",
-    api_id=api.id,
-    route_key="GET /address_similarity",
-    target=integration_address_similarity.id.apply(
-        lambda id: f"integrations/{id}"
-    ),
-    opts=pulumi.ResourceOptions(
-        replace_on_changes=["route_key", "target"],
-        delete_before_replace=True,
-    ),
-)
-lambda_permission_address_similarity = aws.lambda_.Permission(
-    "address_similarity_lambda_permission",
-    action="lambda:InvokeFunction",
-    function=address_similarity_lambda.name,
-    principal="apigateway.amazonaws.com",
-    source_arn=api.execution_arn.apply(lambda arn: f"{arn}/*/*"),
-)
-
-# /word_similarity - route created in __main__.py after cache generator with VPC config
-
-# /image_details_cache
-integration_image_details_cache = aws.apigatewayv2.Integration(
-    "image_details_cache_lambda_integration",
-    api_id=api.id,
-    integration_type="AWS_PROXY",
-    integration_uri=image_details_cache_lambda.invoke_arn,
-    integration_method="POST",
-    payload_format_version="2.0",
-)
-route_image_details_cache = aws.apigatewayv2.Route(
-    "image_details_cache_route",
-    api_id=api.id,
-    route_key="GET /image_details_cache",
-    target=integration_image_details_cache.id.apply(
-        lambda id: f"integrations/{id}"
-    ),
-    opts=pulumi.ResourceOptions(
-        replace_on_changes=["route_key", "target"],
-        delete_before_replace=True,
-    ),
-)
-lambda_permission_image_details_cache = aws.lambda_.Permission(
-    "image_details_cache_lambda_permission",
-    action="lambda:InvokeFunction",
-    function=image_details_cache_lambda.name,
-    principal="apigateway.amazonaws.com",
-    source_arn=api.execution_arn.apply(lambda arn: f"{arn}/*/*"),
-)
-
-
-# /layoutlm_inference
-# Route creation moved to __main__.py after Lambda is created
-# This ensures the Lambda exists before the route is created
-# (Lambda is created conditionally after cache bucket exists)
-
-
-# /process
-integration_process = aws.apigatewayv2.Integration(
-    "process_lambda_integration",
-    api_id=api.id,
-    integration_type="AWS_PROXY",
-    integration_uri=process_lambda.invoke_arn,
-    integration_method="POST",
-    payload_format_version="2.0",
-)
-route_process = aws.apigatewayv2.Route(
-    "process_route",
-    api_id=api.id,
-    route_key="GET /process",
-    target=integration_process.id.apply(lambda id: f"integrations/{id}"),
-    opts=pulumi.ResourceOptions(
-        replace_on_changes=["route_key", "target"],
-        delete_before_replace=True,
-    ),
-)
-lambda_permission_process = aws.lambda_.Permission(
-    "process_lambda_permission",
-    action="lambda:InvokeFunction",
-    function=process_lambda.name,
-    principal="apigateway.amazonaws.com",
-    source_arn=api.execution_arn.apply(lambda arn: f"{arn}/*/*"),
-)
-
-
-# /ai_usage
-integration_ai_usage = aws.apigatewayv2.Integration(
-    "ai_usage_lambda_integration",
-    api_id=api.id,
-    integration_type="AWS_PROXY",
-    integration_uri=ai_usage_lambda.invoke_arn,
-    integration_method="POST",
-    payload_format_version="2.0",
-)
-route_ai_usage = aws.apigatewayv2.Route(
-    "ai_usage_route",
-    api_id=api.id,
-    route_key="GET /ai_usage",
-    target=integration_ai_usage.id.apply(lambda id: f"integrations/{id}"),
-    opts=pulumi.ResourceOptions(
-        replace_on_changes=["route_key", "target"],
-        delete_before_replace=True,
-    ),
-)
-lambda_permission_ai_usage = aws.lambda_.Permission(
-    "ai_usage_lambda_permission",
-    action="lambda:InvokeFunction",
-    function=ai_usage_lambda.name,
-    principal="apigateway.amazonaws.com",
-    source_arn=api.execution_arn.apply(lambda arn: f"{arn}/*/*"),
-)
-
-
-# /reader_summary
-integration_reader_summary = aws.apigatewayv2.Integration(
-    "reader_summary_lambda_integration",
-    api_id=api.id,
-    integration_type="AWS_PROXY",
-    integration_uri=reader_summary_lambda.invoke_arn,
-    integration_method="POST",
-    payload_format_version="2.0",
-)
-route_reader_summary = aws.apigatewayv2.Route(
-    "reader_summary_route",
-    api_id=api.id,
-    route_key="POST /reader_summary",
-    target=integration_reader_summary.id.apply(
-        lambda id: f"integrations/{id}"
-    ),
-    opts=pulumi.ResourceOptions(
-        replace_on_changes=["route_key", "target"],
-        delete_before_replace=True,
-    ),
-)
-lambda_permission_reader_summary = aws.lambda_.Permission(
-    "reader_summary_lambda_permission",
-    action="lambda:InvokeFunction",
-    function=reader_summary_lambda.name,
-    principal="apigateway.amazonaws.com",
-    source_arn=api.execution_arn.apply(lambda arn: f"{arn}/*/*"),
-)
-
-
-# /jobs/{job_id}/training-metrics
-integration_job_training_metrics = aws.apigatewayv2.Integration(
-    "job_training_metrics_lambda_integration",
-    api_id=api.id,
-    integration_type="AWS_PROXY",
-    integration_uri=job_training_metrics_lambda.invoke_arn,
-    integration_method="POST",
-    payload_format_version="2.0",
-)
-route_job_training_metrics = aws.apigatewayv2.Route(
-    "job_training_metrics_route",
-    api_id=api.id,
-    route_key="GET /jobs/{job_id}/training-metrics",
-    target=integration_job_training_metrics.id.apply(
-        lambda id: f"integrations/{id}"
-    ),
-    opts=pulumi.ResourceOptions(
-        replace_on_changes=["route_key", "target"],
-        delete_before_replace=True,
-    ),
-)
-lambda_permission_job_training_metrics = aws.lambda_.Permission(
-    "job_training_metrics_lambda_permission",
-    action="lambda:InvokeFunction",
-    function=job_training_metrics_lambda.name,
-    principal="apigateway.amazonaws.com",
-    source_arn=api.execution_arn.apply(lambda arn: f"{arn}/*/*"),
-)
-
-
-# Replace the if stack == "dev" block with these unconditional declarations
-
-# ─────────────────────────────────────────────────────────────────────────────────
-# 2. DEPLOYMENT + LOGGING
-# ─────────────────────────────────────────────────────────────────────────────────
 log_group = aws.cloudwatch.LogGroup(
     "api_gateway_log_group",
-    name=api.id.apply(lambda id: f"API-Gateway-Execution-Logs_{id}_default"),
+    name=api.id.apply(
+        lambda api_id: f"API-Gateway-Execution-Logs_{api_id}_default"
+    ),
     retention_in_days=14,
 )
 
@@ -532,29 +154,15 @@ stage = aws.apigatewayv2.Stage(
     ],
     access_log_settings=aws.apigatewayv2.StageAccessLogSettingsArgs(
         destination_arn=log_group.arn,
-        format=(
-            "{"
-            '"requestId":"$context.requestId",'
-            '"ip":"$context.identity.sourceIp",'
-            '"caller":"$context.identity.caller",'
-            '"user":"$context.identity.user",'
-            '"requestTime":"$context.requestTime",'
-            '"httpMethod":"$context.httpMethod",'
-            '"resourcePath":"$context.resourcePath",'
-            '"status":"$context.status",'
-            '"protocol":"$context.protocol",'
-            '"responseLength":"$context.responseLength"'
-            "}"
-        ),
+        format=ACCESS_LOG_FORMAT,
     ),
-    opts=pulumi.ResourceOptions(depends_on=[route_reader_summary]),
+    opts=pulumi.ResourceOptions(
+        depends_on=[
+            resource.route for resource in static_route_resources.values()
+        ]
+    ),
 )
 
-# ─────────────────────────────────────────────────────────────────────────────────
-# 3. CUSTOM DOMAIN SETUP
-# ─────────────────────────────────────────────────────────────────────────────────
-
-# Lookup your existing Route 53 hosted zone for tylernorlund.com
 hosted_zone = aws.route53.get_zone(name=BASE_DOMAIN)
 
 api_certificate = aws.acm.Certificate(
@@ -563,7 +171,6 @@ api_certificate = aws.acm.Certificate(
     validation_method="DNS",
 )
 
-# Create a DNS validation record
 api_cert_validation_options = api_certificate.domain_validation_options[0]
 api_cert_validation_record = aws.route53.Record(
     "apiCertValidationRecord",
@@ -580,27 +187,26 @@ api_certificate_validation = aws.acm.CertificateValidation(
     validation_record_fqdns=[api_cert_validation_record.fqdn],
 )
 
-# Create the actual custom domain in API Gateway v2
 api_custom_domain = aws.apigatewayv2.DomainName(
     "apiCustomDomain",
     domain_name=api_domain_name,
-    domain_name_configuration=aws.apigatewayv2.DomainNameDomainNameConfigurationArgs(  # noqa: E501
-        certificate_arn=api_certificate_validation.certificate_arn,
-        endpoint_type="REGIONAL",  # HTTP APIs only support REGIONAL
-        security_policy="TLS_1_2",
+    domain_name_configuration=(
+        aws.apigatewayv2.DomainNameDomainNameConfigurationArgs(
+            certificate_arn=api_certificate_validation.certificate_arn,
+            endpoint_type="REGIONAL",
+            security_policy="TLS_1_2",
+        )
     ),
     opts=pulumi.ResourceOptions(depends_on=[api_certificate_validation]),
 )
 
-# Map your API and stage to this new domain
 api_mapping = aws.apigatewayv2.ApiMapping(
     "apiBasePathMapping",
     api_id=api.id,
     domain_name=api_custom_domain.id,
-    stage=stage.id,  # or "$default"
+    stage=stage.id,
 )
 
-# Create a Route 53 alias for the API domain
 api_alias_record = aws.route53.Record(
     "apiAliasRecord",
     zone_id=hosted_zone.zone_id,
@@ -610,14 +216,13 @@ api_alias_record = aws.route53.Record(
         {
             "name": (
                 api_custom_domain.domain_name_configuration.target_domain_name
-            ),  # noqa: E501
+            ),
             "zone_id": (
                 api_custom_domain.domain_name_configuration.hosted_zone_id
-            ),  # noqa: E501
+            ),
             "evaluateTargetHealth": True,
         }
     ],
 )
 
-# Finally, export your custom domain
 pulumi.export("api_domain", f"https://{api_domain_name}")

--- a/infra/components/http_api_route.py
+++ b/infra/components/http_api_route.py
@@ -1,0 +1,133 @@
+"""Reusable API Gateway HTTP API to Lambda route wiring.
+
+The Portfolio API has a mix of routes created at program import time and routes
+whose Lambda functions are created later in ``__main__.py``.  Keeping the
+three-resource wiring here gives both call sites the same behavior without
+forcing those Lambda functions into the same construction phase.
+"""
+
+from dataclasses import dataclass
+from typing import Sequence
+
+import pulumi
+import pulumi_aws as aws
+
+
+@dataclass(frozen=True)
+class RouteDefinition:
+    """Configuration for one route sharing a Lambda integration."""
+
+    resource_name: str
+    route_key: str
+    authorization_type: str | None = None
+
+    def __post_init__(self) -> None:
+        if not self.resource_name:
+            raise ValueError("route resource_name must not be empty")
+        if " " not in self.route_key:
+            raise ValueError(
+                "route_key must contain an HTTP method and path, for example "
+                "'GET /health_check'"
+            )
+
+
+@dataclass(frozen=True)
+class LambdaRouteResources:
+    """Pulumi resources created for one Lambda-backed route group."""
+
+    integration: aws.apigatewayv2.Integration
+    routes: tuple[aws.apigatewayv2.Route, ...]
+    permission: aws.lambda_.Permission | None
+
+    @property
+    def route(self) -> aws.apigatewayv2.Route:
+        """Return the only route in a single-route registration."""
+        if len(self.routes) != 1:
+            raise ValueError("route is only available for single-route groups")
+        return self.routes[0]
+
+
+def create_lambda_routes(
+    *,
+    api: aws.apigatewayv2.Api,
+    integration_name: str,
+    lambda_function: aws.lambda_.Function,
+    routes: Sequence[RouteDefinition],
+    permission_name: str | None = None,
+) -> LambdaRouteResources:
+    """Connect one Lambda to one or more HTTP API routes.
+
+    ``permission_name`` is optional because a Lambda needs only one broad
+    permission per API even when multiple integrations point to it.  All names
+    are explicit so adopting this helper never changes existing Pulumi URNs.
+    """
+    if not routes:
+        raise ValueError("at least one route is required")
+
+    integration = aws.apigatewayv2.Integration(
+        integration_name,
+        api_id=api.id,
+        integration_type="AWS_PROXY",
+        integration_uri=lambda_function.invoke_arn,
+        integration_method="POST",
+        payload_format_version="2.0",
+    )
+
+    route_resources = tuple(
+        aws.apigatewayv2.Route(
+            route.resource_name,
+            api_id=api.id,
+            route_key=route.route_key,
+            authorization_type=route.authorization_type,
+            target=integration.id.apply(
+                lambda integration_id: f"integrations/{integration_id}"
+            ),
+            opts=pulumi.ResourceOptions(
+                replace_on_changes=["route_key", "target"],
+                delete_before_replace=True,
+            ),
+        )
+        for route in routes
+    )
+
+    permission = None
+    if permission_name is not None:
+        permission = aws.lambda_.Permission(
+            permission_name,
+            action="lambda:InvokeFunction",
+            function=lambda_function.name,
+            principal="apigateway.amazonaws.com",
+            source_arn=api.execution_arn.apply(lambda arn: f"{arn}/*/*"),
+        )
+
+    return LambdaRouteResources(
+        integration=integration,
+        routes=route_resources,
+        permission=permission,
+    )
+
+
+def create_lambda_route(
+    *,
+    api: aws.apigatewayv2.Api,
+    integration_name: str,
+    route_name: str,
+    route_key: str,
+    lambda_function: aws.lambda_.Function,
+    permission_name: str | None = None,
+    authorization_type: str | None = None,
+) -> LambdaRouteResources:
+    """Convenience wrapper for the common one-integration, one-route case."""
+    return create_lambda_routes(
+        api=api,
+        integration_name=integration_name,
+        lambda_function=lambda_function,
+        routes=(
+            RouteDefinition(
+                resource_name=route_name,
+                route_key=route_key,
+                authorization_type=authorization_type,
+            ),
+        ),
+        permission_name=permission_name,
+    )

--- a/infra/components/http_api_route.py
+++ b/infra/components/http_api_route.py
@@ -1,9 +1,9 @@
 """Reusable API Gateway HTTP API to Lambda route wiring.
 
-The Portfolio API has a mix of routes created at program import time and routes
-whose Lambda functions are created later in ``__main__.py``.  Keeping the
-three-resource wiring here gives both call sites the same behavior without
-forcing those Lambda functions into the same construction phase.
+The Portfolio API has routes created at program import time and late-bound
+routes whose Lambda functions are created in ``__main__.py``. Keeping the
+integration, route, and permission wiring here gives both call sites the same
+behavior without forcing those Lambda functions into one construction phase.
 """
 
 from dataclasses import dataclass

--- a/infra/components/test_http_api_route.py
+++ b/infra/components/test_http_api_route.py
@@ -1,0 +1,147 @@
+"""Unit tests for the shared HTTP API route wiring."""
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from infra.components import http_api_route
+
+
+class FakeOutput:
+    """Minimal Output stand-in for checking apply transformations."""
+
+    def __init__(self, value: str) -> None:
+        self.value = value
+
+    def apply(self, callback):
+        return callback(self.value)
+
+
+@pytest.fixture
+def mocked_aws(monkeypatch):
+    integrations = []
+    routes = []
+    permissions = []
+
+    def integration(resource_name, **kwargs):
+        resource = SimpleNamespace(id=FakeOutput("integration-id"))
+        integrations.append((resource_name, kwargs, resource))
+        return resource
+
+    def route(resource_name, **kwargs):
+        resource = SimpleNamespace(resource_name=resource_name)
+        routes.append((resource_name, kwargs, resource))
+        return resource
+
+    def permission(resource_name, **kwargs):
+        resource = SimpleNamespace(resource_name=resource_name)
+        permissions.append((resource_name, kwargs, resource))
+        return resource
+
+    monkeypatch.setattr(
+        http_api_route.aws.apigatewayv2, "Integration", integration
+    )
+    monkeypatch.setattr(http_api_route.aws.apigatewayv2, "Route", route)
+    monkeypatch.setattr(http_api_route.aws.lambda_, "Permission", permission)
+    monkeypatch.setattr(http_api_route.pulumi, "ResourceOptions", Mock)
+
+    return integrations, routes, permissions
+
+
+def test_create_lambda_route_preserves_names_and_gateway_settings(mocked_aws):
+    integrations, routes, permissions = mocked_aws
+    api = SimpleNamespace(
+        id="api-id", execution_arn=FakeOutput("arn:aws:execute-api:api-id")
+    )
+    function = SimpleNamespace(
+        name="function-name", invoke_arn="function-invoke-arn"
+    )
+
+    resources = http_api_route.create_lambda_route(
+        api=api,
+        integration_name="health_check_lambda_integration",
+        route_name="health_check_route",
+        route_key="GET /health_check",
+        lambda_function=function,
+        permission_name="health_check_lambda_permission",
+    )
+
+    assert integrations[0][:2] == (
+        "health_check_lambda_integration",
+        {
+            "api_id": "api-id",
+            "integration_type": "AWS_PROXY",
+            "integration_uri": "function-invoke-arn",
+            "integration_method": "POST",
+            "payload_format_version": "2.0",
+        },
+    )
+    assert routes[0][0] == "health_check_route"
+    assert routes[0][1]["route_key"] == "GET /health_check"
+    assert routes[0][1]["target"] == "integrations/integration-id"
+    assert permissions[0][:2] == (
+        "health_check_lambda_permission",
+        {
+            "action": "lambda:InvokeFunction",
+            "function": "function-name",
+            "principal": "apigateway.amazonaws.com",
+            "source_arn": "arn:aws:execute-api:api-id/*/*",
+        },
+    )
+    assert resources.route is resources.routes[0]
+
+
+def test_create_lambda_routes_reuses_integration_and_permission(mocked_aws):
+    integrations, routes, permissions = mocked_aws
+    api = SimpleNamespace(id="api-id", execution_arn=FakeOutput("api-arn"))
+    function = SimpleNamespace(name="lambda-name", invoke_arn="invoke-arn")
+
+    resources = http_api_route.create_lambda_routes(
+        api=api,
+        integration_name="layoutlm_inference_lambda_integration",
+        lambda_function=function,
+        routes=(
+            http_api_route.RouteDefinition(
+                "layoutlm_inference_route", "GET /layoutlm_inference"
+            ),
+            http_api_route.RouteDefinition(
+                "layoutlm_inference_cache_route",
+                "GET /layoutlm-inference-cache",
+            ),
+        ),
+        permission_name="layoutlm_inference_lambda_permission",
+    )
+
+    assert len(integrations) == 1
+    assert [name for name, _, _ in routes] == [
+        "layoutlm_inference_route",
+        "layoutlm_inference_cache_route",
+    ]
+    assert len(permissions) == 1
+    assert len(resources.routes) == 2
+    with pytest.raises(ValueError, match="single-route"):
+        _ = resources.route
+
+
+def test_route_definition_requires_a_resource_name():
+    with pytest.raises(ValueError, match="resource_name"):
+        http_api_route.RouteDefinition("", "GET /health")
+
+
+def test_route_definition_requires_method_and_path():
+    with pytest.raises(ValueError, match="HTTP method and path"):
+        http_api_route.RouteDefinition("health_route", "/health")
+
+
+def test_create_lambda_routes_requires_at_least_one_route(mocked_aws):
+    api = SimpleNamespace(id="api-id", execution_arn=FakeOutput("api-arn"))
+    function = SimpleNamespace(name="lambda-name", invoke_arn="invoke-arn")
+
+    with pytest.raises(ValueError, match="at least one route"):
+        http_api_route.create_lambda_routes(
+            api=api,
+            integration_name="unused",
+            lambda_function=function,
+            routes=(),
+        )


### PR DESCRIPTION
## Summary

- add a reusable API Gateway HTTP API-to-Lambda route component
- replace the repetitive static API route declarations with a compact manifest
- migrate late-bound Word Similarity, LayoutLM, label visualization, and QA routes to the shared helper
- preserve existing Pulumi logical resource names to avoid infrastructure churn

## Why

The API infrastructure repeated the same integration, route, and Lambda permission wiring across `api_gateway.py` and several distant sections of `__main__.py`. This made route behavior harder to audit and increased the chance of inconsistent settings.

## Validation

- `python3 -m pytest components/test_http_api_route.py -q` (5 passed)
- `python3 -m black --check --config pyproject.toml api_gateway.py components/http_api_route.py components/test_http_api_route.py`
- `python3 -m py_compile api_gateway.py components/http_api_route.py components/test_http_api_route.py __main__.py`
- `python3 -m mypy components/http_api_route.py`
- `pulumi preview --stack dev --diff --refresh=false --non-interactive`

The Pulumi preview showed no changes to API Gateway routes, integrations, permissions, stage, custom domain, or DNS resources. It reported unrelated pre-existing worktree-path and image-hash drift elsewhere in the stack; no deployment was applied.

This replaces #1129 and #1131, whose mergeability calculations remained stuck at `UNKNOWN`. It uses the same validated commit on a fresh branch to bypass GitHub's stale head-branch cache.