### PR TITLE
Restore QA receipt evidence and parallel tool timeline

### DIFF
--- a/portfolio/components/ui/Figures/QAAgentFlow.tsx
+++ b/portfolio/components/ui/Figures/QAAgentFlow.tsx
@@ -95,12 +95,16 @@ interface ReceiptEvidenceThumbnailProps {
   receipt: ReceiptEvidence;
   index: number;
   isVisible: boolean;
+  overlapRatio: number;
 }
+
+const EVIDENCE_THUMBNAIL_HEIGHT = 154;
 
 const ReceiptEvidenceThumbnail: React.FC<ReceiptEvidenceThumbnailProps> = ({
   receipt,
   index,
   isVisible,
+  overlapRatio,
 }) => {
   const initialUrl = getCdnUrl(receipt.thumbnailKey);
   const fallbackUrl = getReceiptJpegFallbackUrl(receipt.thumbnailKey);
@@ -122,6 +126,11 @@ const ReceiptEvidenceThumbnail: React.FC<ReceiptEvidenceThumbnailProps> = ({
 
   const rotation = ((index % 5) - 2) * 1.8;
   const merchant = receipt.merchant || "Unknown merchant";
+  const sourceWidth = receipt.width > 0 ? receipt.width : 300;
+  const sourceHeight = receipt.height > 0 ? receipt.height : 900;
+  const thumbnailWidth =
+    EVIDENCE_THUMBNAIL_HEIGHT * (sourceWidth / sourceHeight);
+  const overlap = Math.round(thumbnailWidth * overlapRatio);
   const evidenceDetail = [
     receipt.item,
     Number.isFinite(receipt.amount)
@@ -138,15 +147,15 @@ const ReceiptEvidenceThumbnail: React.FC<ReceiptEvidenceThumbnailProps> = ({
       style={
         {
           position: "relative",
-          width: "76px",
-          minWidth: "42px",
-          height: "154px",
-          flex: "0 1 76px",
-          marginLeft: index === 0 ? 0 : "-24px",
+          width: `${thumbnailWidth}px`,
+          minWidth: `${thumbnailWidth}px`,
+          height: `${EVIDENCE_THUMBNAIL_HEIGHT}px`,
+          flex: `0 0 ${thumbnailWidth}px`,
+          marginLeft: index === 0 ? 0 : `-${overlap}px`,
           zIndex: index + 1,
-          border: "1px solid rgba(var(--text-color-rgb, 0, 0, 0), 0.24)",
+          border: 0,
           borderRadius: "3px",
-          backgroundColor: "var(--background-color)",
+          backgroundColor: "transparent",
           boxShadow: "0 5px 16px rgba(0, 0, 0, 0.2)",
           overflow: "hidden",
           opacity: 0,
@@ -183,9 +192,9 @@ const ReceiptEvidenceThumbnail: React.FC<ReceiptEvidenceThumbnailProps> = ({
         <Image
           src={currentUrl}
           alt={`${merchant} receipt`}
-          width={receipt.width > 0 ? receipt.width : 300}
-          height={receipt.height > 0 ? receipt.height : 900}
-          sizes="76px"
+          width={sourceWidth}
+          height={sourceHeight}
+          sizes={`${Math.ceil(thumbnailWidth)}px`}
           loading={index < 3 ? "eager" : "lazy"}
           style={{
             width: "100%",
@@ -214,6 +223,7 @@ const ReceiptEvidenceStack: React.FC<ReceiptEvidenceStackProps> = ({
 
   const visibleReceipts = receipts.slice(0, MAX_EVIDENCE_THUMBNAILS);
   const hiddenCount = receipts.length - visibleReceipts.length;
+  const overlapRatio = visibleReceipts.length > 5 ? 0.48 : 0.28;
   const receiptLabel = `${receipts.length} ${
     receipts.length === 1 ? "receipt" : "receipts"
   }`;
@@ -274,6 +284,7 @@ const ReceiptEvidenceStack: React.FC<ReceiptEvidenceStackProps> = ({
             receipt={receipt}
             index={index}
             isVisible={isVisible}
+            overlapRatio={overlapRatio}
           />
         ))}
       </div>

--- a/portfolio/components/ui/Figures/QAAgentFlow.tsx
+++ b/portfolio/components/ui/Figures/QAAgentFlow.tsx
@@ -1,14 +1,19 @@
 import React from "react";
+import Image from "next/image";
 import ReactMarkdown from "react-markdown";
 import { useSpring, animated, config } from "@react-spring/web";
 import { getReceiptMotionScale } from "./ReceiptFlow/receiptFlowUtils";
 import type {
   QAQuestionData,
+  ReceiptEvidence,
   StepType,
   TraceStep,
   StructuredReceipt,
 } from "../../../hooks/qaTypes";
 import { useRevealInView } from "../../../hooks/useOptimizedInView";
+import { getCdnBaseUrl } from "../../../utils/cdnBase";
+import { getJpegFallbackUrl } from "../../../utils/imageFormat";
+import { buildTimelineLayout } from "./qaTimeline";
 
 interface QAAgentFlowProps {
   /** Whether to auto-play the animation */
@@ -21,12 +26,346 @@ interface QAAgentFlowProps {
   children?: React.ReactNode;
 }
 
+const CDN_BASE = getCdnBaseUrl();
+const MAX_EVIDENCE_THUMBNAILS = 8;
+const MAX_STRUCTURED_RECEIPTS = 4;
+const CURRENCY_FORMATTER = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+});
+
+const getCdnUrl = (key: string): string =>
+  `${CDN_BASE}/${key.replace(/^\/+/, "")}`;
+
+const getReceiptJpegFallbackUrl = (key: string): string => {
+  const jpegKey = key.replace(/\.(?:avif|webp)$/i, ".jpg");
+  return getJpegFallbackUrl({ cdn_s3_key: jpegKey.replace(/^\/+/, "") });
+};
+
+const deduplicateReceiptEvidence = (trace: TraceStep[]): ReceiptEvidence[] => {
+  const seenImageIds = new Set<string>();
+  const receipts: ReceiptEvidence[] = [];
+
+  for (const step of trace) {
+    for (const receipt of step.receipts ?? []) {
+      if (!receipt.imageId || !receipt.thumbnailKey) continue;
+      if (seenImageIds.has(receipt.imageId)) continue;
+
+      seenImageIds.add(receipt.imageId);
+      receipts.push(receipt);
+    }
+  }
+
+  return receipts;
+};
+
+interface ReceiptEvidenceThumbnailProps {
+  receipt: ReceiptEvidence;
+  index: number;
+  isVisible: boolean;
+}
+
+const ReceiptEvidenceThumbnail: React.FC<ReceiptEvidenceThumbnailProps> = ({
+  receipt,
+  index,
+  isVisible,
+}) => {
+  const initialUrl = getCdnUrl(receipt.thumbnailKey);
+  const fallbackUrl = getReceiptJpegFallbackUrl(receipt.thumbnailKey);
+  const [currentUrl, setCurrentUrl] = React.useState(initialUrl);
+  const [hasErrored, setHasErrored] = React.useState(false);
+
+  React.useEffect(() => {
+    setCurrentUrl(initialUrl);
+    setHasErrored(false);
+  }, [initialUrl]);
+
+  const handleError = React.useCallback(() => {
+    if (currentUrl !== fallbackUrl) {
+      setCurrentUrl(fallbackUrl);
+      return;
+    }
+    setHasErrored(true);
+  }, [currentUrl, fallbackUrl]);
+
+  const rotation = ((index % 5) - 2) * 1.8;
+  const merchant = receipt.merchant || "Unknown merchant";
+  const evidenceDetail = [
+    receipt.item,
+    Number.isFinite(receipt.amount)
+      ? CURRENCY_FORMATTER.format(receipt.amount)
+      : undefined,
+  ]
+    .filter(Boolean)
+    .join(" · ");
+
+  return (
+    <div
+      role="listitem"
+      title={evidenceDetail ? `${merchant}: ${evidenceDetail}` : merchant}
+      style={
+        {
+          position: "relative",
+          width: "76px",
+          minWidth: "42px",
+          height: "154px",
+          flex: "0 1 76px",
+          marginLeft: index === 0 ? 0 : "-24px",
+          zIndex: index + 1,
+          border: "1px solid rgba(var(--text-color-rgb, 0, 0, 0), 0.24)",
+          borderRadius: "3px",
+          backgroundColor: "var(--background-color)",
+          boxShadow: "0 5px 16px rgba(0, 0, 0, 0.2)",
+          overflow: "hidden",
+          opacity: 0,
+          "--receipt-evidence-rotation": `${rotation}deg`,
+          animation: `receiptEvidenceIn 320ms ease-out ${index * 55}ms forwards`,
+          animationPlayState: isVisible ? "running" : "paused",
+        } as React.CSSProperties
+      }
+    >
+      {hasErrored ? (
+        <div
+          aria-label={`${merchant} receipt unavailable`}
+          style={{
+            width: "100%",
+            height: "100%",
+            display: "grid",
+            placeItems: "center",
+            padding: "0.35rem",
+            boxSizing: "border-box",
+            color: "var(--text-color)",
+            fontSize: "0.62rem",
+            lineHeight: 1.25,
+            textAlign: "center",
+            opacity: 0.65,
+          }}
+        >
+          Receipt unavailable
+        </div>
+      ) : (
+        <Image
+          src={currentUrl}
+          alt={`${merchant} receipt`}
+          width={receipt.width > 0 ? receipt.width : 300}
+          height={receipt.height > 0 ? receipt.height : 900}
+          sizes="76px"
+          loading={index < 3 ? "eager" : "lazy"}
+          style={{
+            width: "100%",
+            height: "100%",
+            display: "block",
+            objectFit: "cover",
+            objectPosition: "top",
+          }}
+          onError={handleError}
+        />
+      )}
+    </div>
+  );
+};
+
+interface ReceiptEvidenceStackProps {
+  receipts: ReceiptEvidence[];
+  isVisible: boolean;
+}
+
+const ReceiptEvidenceStack: React.FC<ReceiptEvidenceStackProps> = ({
+  receipts,
+  isVisible,
+}) => {
+  if (receipts.length === 0) return null;
+
+  const visibleReceipts = receipts.slice(0, MAX_EVIDENCE_THUMBNAILS);
+  const hiddenCount = receipts.length - visibleReceipts.length;
+  const receiptLabel = `${receipts.length} ${
+    receipts.length === 1 ? "receipt" : "receipts"
+  }`;
+
+  return (
+    <section
+      role="region"
+      aria-label="Receipt evidence"
+      style={{
+        width: "100%",
+        paddingTop: "0.9rem",
+        borderTop: "1px solid rgba(var(--text-color-rgb, 0, 0, 0), 0.14)",
+        color: "var(--text-color)",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "baseline",
+          justifyContent: "space-between",
+          gap: "0.75rem",
+          marginBottom: "0.65rem",
+        }}
+      >
+        <strong style={{ fontSize: "0.78rem" }}>Evidence</strong>
+        <span
+          style={{
+            fontFamily: "var(--font-mono, monospace)",
+            fontSize: "0.68rem",
+            opacity: 0.65,
+          }}
+        >
+          <span>{receiptLabel}</span>
+          {hiddenCount > 0 ? ` · showing ${visibleReceipts.length}` : null}
+        </span>
+      </div>
+
+      <div
+        role="list"
+        aria-label={`${receiptLabel} used as evidence`}
+        style={{
+          display: "flex",
+          justifyContent: "center",
+          alignItems: "flex-start",
+          width: "100%",
+          maxWidth: "390px",
+          minHeight: "166px",
+          margin: "0 auto",
+          padding: "0.35rem 0.8rem 0.65rem",
+          boxSizing: "border-box",
+          overflow: "hidden",
+        }}
+      >
+        {visibleReceipts.map((receipt, index) => (
+          <ReceiptEvidenceThumbnail
+            key={receipt.imageId}
+            receipt={receipt}
+            index={index}
+            isVisible={isVisible}
+          />
+        ))}
+      </div>
+
+      <style>{`
+        @keyframes receiptEvidenceIn {
+          from {
+            opacity: 0;
+            transform: rotate(var(--receipt-evidence-rotation, 0deg)) translateY(-14px);
+          }
+          to {
+            opacity: 1;
+            transform: rotate(var(--receipt-evidence-rotation, 0deg)) translateY(0);
+          }
+        }
+
+        @media (prefers-reduced-motion: reduce) {
+          [aria-label="Receipt evidence"] [role="listitem"] {
+            animation-duration: 1ms !important;
+            animation-delay: 0ms !important;
+          }
+        }
+      `}</style>
+    </section>
+  );
+};
+
+interface StructuredReceiptSummaryProps {
+  receipts: StructuredReceipt[];
+}
+
+const StructuredReceiptSummary: React.FC<StructuredReceiptSummaryProps> = ({
+  receipts,
+}) => {
+  if (receipts.length === 0) return null;
+
+  const visibleReceipts = receipts.slice(0, MAX_STRUCTURED_RECEIPTS);
+  const hiddenCount = receipts.length - visibleReceipts.length;
+
+  return (
+    <section aria-label="Structured receipts" style={{ width: "100%" }}>
+      <strong
+        style={{
+          display: "block",
+          marginBottom: "0.5rem",
+          color: "var(--text-color)",
+          fontSize: "0.78rem",
+        }}
+      >
+        Structured receipts
+      </strong>
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(auto-fit, minmax(150px, 1fr))",
+          gap: "0.5rem",
+        }}
+      >
+        {visibleReceipts.map((receipt, receiptIndex) => (
+          <div
+            key={`${receipt.merchant}-${receiptIndex}`}
+            style={{
+              padding: "0.55rem 0.65rem",
+              border: "1px solid rgba(var(--text-color-rgb, 0, 0, 0), 0.14)",
+              borderRadius: "6px",
+              backgroundColor: "var(--background-color)",
+              color: "var(--text-color)",
+            }}
+          >
+            <div style={{ fontSize: "0.72rem", fontWeight: 700 }}>
+              {receipt.merchant || "Unknown merchant"}
+            </div>
+            {receipt.items.slice(0, 3).map((item, itemIndex) => (
+              <div
+                key={`${item.name}-${itemIndex}`}
+                style={{
+                  display: "flex",
+                  justifyContent: "space-between",
+                  gap: "0.5rem",
+                  marginTop: "0.25rem",
+                  fontSize: "0.68rem",
+                  opacity: 0.72,
+                }}
+              >
+                <span>{item.name}</span>
+                <span>{CURRENCY_FORMATTER.format(item.amount)}</span>
+              </div>
+            ))}
+          </div>
+        ))}
+      </div>
+      {hiddenCount > 0 ? (
+        <div
+          style={{
+            marginTop: "0.4rem",
+            color: "var(--text-color)",
+            fontSize: "0.65rem",
+            textAlign: "right",
+            opacity: 0.58,
+          }}
+        >
+          +{hiddenCount} more
+        </div>
+      ) : null}
+    </section>
+  );
+};
+
 // Structured receipt summaries (output of shape node)
 const STRUCTURED_RECEIPTS: StructuredReceipt[] = [
-  { merchant: "Neighborhood Market", items: [{ name: "WHOLE BEAN COFFEE", amount: 15.99 }] },
-  { merchant: "La La Land", items: [{ name: "Large Americano", amount: 4.70 }, { name: "Cappuccino", amount: 5.30 }] },
+  {
+    merchant: "Neighborhood Market",
+    items: [{ name: "WHOLE BEAN COFFEE", amount: 15.99 }],
+  },
+  {
+    merchant: "La La Land",
+    items: [
+      { name: "Large Americano", amount: 4.7 },
+      { name: "Cappuccino", amount: 5.3 },
+    ],
+  },
   { merchant: "Blue Bottle", items: [{ name: "Pour Over", amount: 5.25 }] },
-  { merchant: "Le Pain Quotidien", items: [{ name: "Iced Latte", amount: 6.25 }, { name: "Iced Americano", amount: 5.00 }] },
+  {
+    merchant: "Le Pain Quotidien",
+    items: [
+      { name: "Iced Latte", amount: 6.25 },
+      { name: "Iced Americano", amount: 5.0 },
+    ],
+  },
   { merchant: "Costco", items: [{ name: "KS ESPRESSO", amount: 15.89 }] },
 ];
 
@@ -83,14 +422,53 @@ const EXAMPLE_TRACE: TraceStep[] = [
   },
 ];
 
-const STEP_CONFIG: Record<StepType, { color: string; label: string; icon: string; node: string; description: string }> = {
-  plan: { color: "var(--color-purple)", label: "Plan", icon: "📋", node: "1", description: "Classifying the question and picking a retrieval strategy" },
-  agent: { color: "var(--color-blue)", label: "Agent", icon: "🤖", node: "2", description: "Reasoning about the question and deciding which tools to call" },
-  tools: { color: "var(--color-green)", label: "Tools", icon: "🔧", node: "3", description: "Searching DynamoDB and ChromaDB for relevant receipts" },
-  shape: { color: "var(--color-orange)", label: "Shape", icon: "📊", node: "4", description: "Filtering and structuring receipt summaries for synthesis" },
-  synthesize: { color: "var(--color-red)", label: "Synthesize", icon: "✓", node: "5", description: "Composing the final answer with evidence citations" },
+const STEP_CONFIG: Record<
+  StepType,
+  {
+    color: string;
+    label: string;
+    icon: string;
+    node: string;
+    description: string;
+  }
+> = {
+  plan: {
+    color: "var(--color-purple)",
+    label: "Plan",
+    icon: "📋",
+    node: "1",
+    description: "Classifying the question and picking a retrieval strategy",
+  },
+  agent: {
+    color: "var(--color-blue)",
+    label: "Agent",
+    icon: "🤖",
+    node: "2",
+    description:
+      "Reasoning about the question and deciding which tools to call",
+  },
+  tools: {
+    color: "var(--color-green)",
+    label: "Tools",
+    icon: "🔧",
+    node: "3",
+    description: "Searching DynamoDB and ChromaDB for relevant receipts",
+  },
+  shape: {
+    color: "var(--color-orange)",
+    label: "Shape",
+    icon: "📊",
+    node: "4",
+    description: "Filtering and structuring receipt summaries for synthesis",
+  },
+  synthesize: {
+    color: "var(--color-red)",
+    label: "Synthesize",
+    icon: "✓",
+    node: "5",
+    description: "Composing the final answer with evidence citations",
+  },
 };
-
 
 /** Default step duration (ms) when durationMs is not available */
 const DEFAULT_STEP_MS = 1500;
@@ -100,8 +478,14 @@ const TARGET_TOTAL_MS = 12000;
 const MIN_STEP_MS = 600;
 /** Maximum per-step duration to prevent a single slow step dominating */
 const MAX_STEP_MS = 3500;
+const TIMELINE_LANE_HEIGHT = 24;
 
-const QAAgentFlow: React.FC<QAAgentFlowProps> = ({ autoPlay = true, questionData, onCycleComplete, children }) => {
+const QAAgentFlow: React.FC<QAAgentFlowProps> = ({
+  autoPlay = true,
+  questionData,
+  onCycleComplete,
+  children,
+}) => {
   // threshold 0 (any pixel intersecting the rootMargin-expanded viewport),
   // NOT a fraction of the element: the tall intro stack makes a 10% area
   // threshold unreachable on mobile, which froze the flow on the intro and
@@ -118,6 +502,27 @@ const QAAgentFlow: React.FC<QAAgentFlowProps> = ({ autoPlay = true, questionData
 
   // Use real data when available, fall back to example trace
   const trace = questionData?.trace ?? EXAMPLE_TRACE;
+  const timelineLayout = React.useMemo(
+    () => buildTimelineLayout(trace, DEFAULT_STEP_MS),
+    [trace],
+  );
+  const synthesizeStep = trace.find((step) => step.type === "synthesize");
+  const rawAnswer = synthesizeStep?.content ?? "";
+  const answerText =
+    rawAnswer
+      .replace(/\n*#{0,3}\s*\*{0,2}Evidence\*{0,2}:?\**\s*[\s\S]*$/i, "")
+      .replace(/\n*```(?:json)?\s*\[\s*[\s\S]*$/, "")
+      .trim() || undefined;
+  const evidenceReceipts = React.useMemo(
+    () => deduplicateReceiptEvidence(trace),
+    [trace],
+  );
+  const structuredReceipts = React.useMemo(
+    () =>
+      trace.find((step) => (step.structuredData?.length ?? 0) > 0)
+        ?.structuredData ?? [],
+    [trace],
+  );
 
   // Reset animation when question changes (use index to avoid stale-data issues on mobile)
   const questionIndex = questionData?.questionIndex ?? -1;
@@ -132,7 +537,9 @@ const QAAgentFlow: React.FC<QAAgentFlowProps> = ({ autoPlay = true, questionData
 
   // Compute per-step animation durations from durationMs, scaled proportionally
   const stepDurations = React.useMemo(() => {
-    const hasTiming = trace.some((s) => s.durationMs != null && s.durationMs > 0);
+    const hasTiming = trace.some(
+      (s) => s.durationMs != null && s.durationMs > 0,
+    );
     if (!hasTiming) return trace.map(() => DEFAULT_STEP_MS * motionScale);
 
     const rawMs = trace.map((s) => s.durationMs ?? DEFAULT_STEP_MS);
@@ -143,8 +550,11 @@ const QAAgentFlow: React.FC<QAAgentFlowProps> = ({ autoPlay = true, questionData
     return rawMs.map((d) =>
       Math.max(
         MIN_STEP_MS * motionScale,
-        Math.min(MAX_STEP_MS * motionScale, Math.round(d * scale * motionScale)),
-      )
+        Math.min(
+          MAX_STEP_MS * motionScale,
+          Math.round(d * scale * motionScale),
+        ),
+      ),
     );
   }, [trace, motionScale]);
 
@@ -161,7 +571,10 @@ const QAAgentFlow: React.FC<QAAgentFlowProps> = ({ autoPlay = true, questionData
     if (activeStep >= trace.length - 1) {
       // Last step reached — reveal answer after its duration, then hold 5s
       if (!showAnswer) {
-        const id = setTimeout(() => setShowAnswer(true), stepDurations[trace.length - 1]);
+        const id = setTimeout(
+          () => setShowAnswer(true),
+          stepDurations[trace.length - 1],
+        );
         return () => clearTimeout(id);
       }
       const id = setTimeout(() => {
@@ -175,10 +588,19 @@ const QAAgentFlow: React.FC<QAAgentFlowProps> = ({ autoPlay = true, questionData
       return () => clearTimeout(id);
     }
 
-    const delay = activeStep < 0 ? 400 * motionScale : stepDurations[activeStep];
+    const delay =
+      activeStep < 0 ? 400 * motionScale : stepDurations[activeStep];
     const id = setTimeout(() => setActiveStep((prev) => prev + 1), delay);
     return () => clearTimeout(id);
-  }, [isPlaying, activeStep, trace.length, stepDurations, showAnswer, onCycleComplete, motionScale]);
+  }, [
+    isPlaying,
+    activeStep,
+    trace.length,
+    stepDurations,
+    showAnswer,
+    onCycleComplete,
+    motionScale,
+  ]);
 
   // Measure answer content height and spring the container open
   const answerRef = React.useRef<HTMLDivElement>(null);
@@ -215,23 +637,20 @@ const QAAgentFlow: React.FC<QAAgentFlowProps> = ({ autoPlay = true, questionData
     },
   });
 
-  // Compute flame-graph bar target (cumulative width% through the current step)
-  const barWidths = React.useMemo(() => {
-    const totalMs = trace.reduce(
-      (sum, s) => sum + (s.durationMs ?? DEFAULT_STEP_MS),
-      0,
-    );
-    return trace.map((s) => {
-      const duration = s.durationMs ?? DEFAULT_STEP_MS;
-      return totalMs > 0 ? (duration / totalMs) * 100 : 100 / trace.length;
-    });
-  }, [trace]);
-
+  // Reveal the wall-clock timeline through the furthest completed step.
+  // Overlapping steps share the same x-range and occupy separate lanes.
   const barTarget = React.useMemo(() => {
     if (activeStep < 0) return 0;
     if (activeStep >= trace.length - 1) return 100;
-    return barWidths.slice(0, activeStep + 1).reduce((a, b) => a + b, 0);
-  }, [activeStep, trace.length, barWidths]);
+    const revealedEndMs = timelineLayout.segments.reduce(
+      (furthestEnd, segment) =>
+        segment.stepIndex <= activeStep
+          ? Math.max(furthestEnd, segment.endMs)
+          : furthestEnd,
+      0,
+    );
+    return (revealedEndMs / timelineLayout.totalMs) * 100;
+  }, [activeStep, trace.length, timelineLayout]);
 
   const barSpring = useSpring({
     progress: barTarget,
@@ -249,21 +668,32 @@ const QAAgentFlow: React.FC<QAAgentFlowProps> = ({ autoPlay = true, questionData
   }, [activeStep, trace]);
 
   // Determine which node is currently active
-  const activeType: StepType | null = activeStep >= 0 && activeStep < trace.length ? trace[activeStep].type : null;
+  const activeType: StepType | null =
+    activeStep >= 0 && activeStep < trace.length
+      ? trace[activeStep].type
+      : null;
   // Determine the loop phase bounds dynamically based on trace content
-  const loopEndIdx = trace.length > 0 ? trace.reduce((last, s, i) => (s.type === "agent" || s.type === "tools" ? i : last), -1) : 5;
+  const loopEndIdx =
+    trace.length > 0
+      ? trace.reduce(
+          (last, s, i) => (s.type === "agent" || s.type === "tools" ? i : last),
+          -1,
+        )
+      : 5;
   const inLoopPhase = activeStep >= 1 && activeStep <= loopEndIdx;
 
   return (
     <div
       ref={flowRef}
-      style={{
-        fontSize: "0.85rem",
-        maxWidth: "1000px",
-        margin: "0 auto",
-        padding: "0.5rem",
-        "--marquee-play-state": isVisible ? "running" : "paused",
-      } as React.CSSProperties}
+      style={
+        {
+          fontSize: "0.85rem",
+          maxWidth: "1000px",
+          margin: "0 auto",
+          padding: "0.5rem",
+          "--marquee-play-state": isVisible ? "running" : "paused",
+        } as React.CSSProperties
+      }
     >
       {/* Flame Graph Timeline + Node Diagram */}
       {(() => {
@@ -282,7 +712,9 @@ const QAAgentFlow: React.FC<QAAgentFlowProps> = ({ autoPlay = true, questionData
           const stepIndices = trace
             .map((s, i) => (s.type === type ? i : -1))
             .filter((i) => i >= 0);
-          const visitedCount = stepIndices.filter((i) => i <= activeStep).length;
+          const visitedCount = stepIndices.filter(
+            (i) => i <= activeStep,
+          ).length;
           const fillPercent =
             stepIndices.length > 0
               ? (visitedCount / stepIndices.length) * 100
@@ -306,10 +738,15 @@ const QAAgentFlow: React.FC<QAAgentFlowProps> = ({ autoPlay = true, questionData
         const toolsX = agentX;
 
         const forwardArrows: [number, number][] = [
-          [0, 1], [1, 2], [2, 3],
+          [0, 1],
+          [1, 2],
+          [2, 3],
         ];
 
-        const isForwardArrowActive = (fromIdx: number, toIdx: number): boolean => {
+        const isForwardArrowActive = (
+          fromIdx: number,
+          toIdx: number,
+        ): boolean => {
           if (activeStep < 0) return false;
           const toType = mainNodes[toIdx];
           if (activeType !== toType) return false;
@@ -321,7 +758,7 @@ const QAAgentFlow: React.FC<QAAgentFlowProps> = ({ autoPlay = true, questionData
         const ahHalf = Math.round(4 * S);
         const edgeGap = Math.round(4 * S);
 
-        const angle = 40 * Math.PI / 180;
+        const angle = (40 * Math.PI) / 180;
         const edgeR = nodeR + edgeGap;
         const dx = Math.round(edgeR * Math.sin(angle));
         const dy = Math.round(edgeR * Math.cos(angle));
@@ -329,9 +766,12 @@ const QAAgentFlow: React.FC<QAAgentFlowProps> = ({ autoPlay = true, questionData
         const tx = Math.cos(angle);
         const ty = Math.sin(angle);
 
-        const rsx = agentX + dx, rsy = rowY + dy;
-        const rTipX = agentX + dx, rTipY = toolsY - dy;
-        const rex = rTipX + ahLen * tx, rey = rTipY - ahLen * ty;
+        const rsx = agentX + dx,
+          rsy = rowY + dy;
+        const rTipX = agentX + dx,
+          rTipY = toolsY - dy;
+        const rex = rTipX + ahLen * tx,
+          rey = rTipY - ahLen * ty;
         const downD = [
           `M ${rsx} ${rsy}`,
           `C ${rsx + armLen * tx} ${rsy + armLen * ty},`,
@@ -339,9 +779,12 @@ const QAAgentFlow: React.FC<QAAgentFlowProps> = ({ autoPlay = true, questionData
           `${rex} ${rey}`,
         ].join(" ");
 
-        const lsx = agentX - dx, lsy = toolsY - dy;
-        const lTipX = agentX - dx, lTipY = rowY + dy;
-        const lex = lTipX - ahLen * tx, ley = lTipY + ahLen * ty;
+        const lsx = agentX - dx,
+          lsy = toolsY - dy;
+        const lTipX = agentX - dx,
+          lTipY = rowY + dy;
+        const lex = lTipX - ahLen * tx,
+          ley = lTipY + ahLen * ty;
         const upD = [
           `M ${lsx} ${lsy}`,
           `C ${lsx - armLen * tx} ${lsy - armLen * ty},`,
@@ -350,7 +793,8 @@ const QAAgentFlow: React.FC<QAAgentFlowProps> = ({ autoPlay = true, questionData
         ].join(" ");
 
         const downActive = activeType === "tools" && inLoopPhase;
-        const upActive = activeType === "agent" && activeStep > 1 && inLoopPhase;
+        const upActive =
+          activeType === "agent" && activeStep > 1 && inLoopPhase;
         const loopVisible = inLoopPhase || activeStep === loopEndIdx + 1;
 
         const badgeX = agentX;
@@ -359,7 +803,12 @@ const QAAgentFlow: React.FC<QAAgentFlowProps> = ({ autoPlay = true, questionData
         const downArrowAngle = 180 - 40;
         const upArrowAngle = -40;
 
-        const renderArrowhead = (tipX: number, tipY: number, angleDeg: number, color: string) => (
+        const renderArrowhead = (
+          tipX: number,
+          tipY: number,
+          angleDeg: number,
+          color: string,
+        ) => (
           <polygon
             points={`0,0 ${-ahLen},${-ahHalf} ${-ahLen},${ahHalf}`}
             fill={color}
@@ -373,18 +822,32 @@ const QAAgentFlow: React.FC<QAAgentFlowProps> = ({ autoPlay = true, questionData
         const renderNode = (node: StepType, cx: number, cy: number) => {
           const cfg = STEP_CONFIG[node];
           const isNodeActive = activeType === node;
-          const wasVisited = activeStep >= 0 && trace.slice(0, activeStep + 1).some((s) => s.type === node);
+          const wasVisited =
+            activeStep >= 0 &&
+            trace.slice(0, activeStep + 1).some((s) => s.type === node);
           return (
-            <g key={node} style={{ transition: "opacity 0.3s ease" }} opacity={isNodeActive ? 1 : wasVisited ? 0.85 : 0.3}>
+            <g
+              key={node}
+              style={{ transition: "opacity 0.3s ease" }}
+              opacity={isNodeActive ? 1 : wasVisited ? 0.85 : 0.3}
+            >
               <circle
-                cx={cx} cy={cy} r={nodeR}
-                fill={wasVisited && !isNodeActive ? cfg.color : "var(--code-background)"}
-                stroke={cfg.color} strokeWidth={2 * S}
+                cx={cx}
+                cy={cy}
+                r={nodeR}
+                fill={
+                  wasVisited && !isNodeActive
+                    ? cfg.color
+                    : "var(--code-background)"
+                }
+                stroke={cfg.color}
+                strokeWidth={2 * S}
               />
               {isNodeActive && (
                 <circle
                   key={`clock-${node}-${activeStep}`}
-                  cx={cx} cy={cy}
+                  cx={cx}
+                  cy={cy}
                   r={nodeR / 2}
                   fill="none"
                   stroke={cfg.color}
@@ -438,54 +901,102 @@ const QAAgentFlow: React.FC<QAAgentFlowProps> = ({ autoPlay = true, questionData
                   const tipX = mainXs[toIdx] - nodeR - edgeGap;
                   const x2 = tipX - ahLen;
                   const active = isForwardArrowActive(fromIdx, toIdx);
-                  const color = active ? STEP_CONFIG[mainNodes[toIdx]].color : "var(--text-color)";
+                  const color = active
+                    ? STEP_CONFIG[mainNodes[toIdx]].color
+                    : "var(--text-color)";
                   return (
-                    <g key={`fwd-${fromIdx}-${toIdx}`} opacity={active ? 1 : 0.2} style={{ transition: "opacity 0.3s ease" }}>
+                    <g
+                      key={`fwd-${fromIdx}-${toIdx}`}
+                      opacity={active ? 1 : 0.2}
+                      style={{ transition: "opacity 0.3s ease" }}
+                    >
                       <line
-                        x1={x1} y1={rowY} x2={x2} y2={rowY}
-                        stroke={color} strokeWidth={active ? 2.5 * S : 2 * S}
+                        x1={x1}
+                        y1={rowY}
+                        x2={x2}
+                        y2={rowY}
+                        stroke={color}
+                        strokeWidth={active ? 2.5 * S : 2 * S}
                       />
                       {renderArrowhead(tipX, rowY, 0, color)}
                     </g>
                   );
                 })}
 
-                <g opacity={downActive ? 1 : loopVisible ? 0.35 : 0.15} style={{ transition: "opacity 0.3s ease" }}>
+                <g
+                  opacity={downActive ? 1 : loopVisible ? 0.35 : 0.15}
+                  style={{ transition: "opacity 0.3s ease" }}
+                >
                   <path
-                    d={downD} fill="none"
-                    stroke={downActive ? "var(--color-green)" : "var(--text-color)"}
+                    d={downD}
+                    fill="none"
+                    stroke={
+                      downActive ? "var(--color-green)" : "var(--text-color)"
+                    }
                     strokeWidth={downActive ? 2.5 * S : 2 * S}
                   />
-                  {renderArrowhead(rTipX, rTipY, downArrowAngle, downActive ? "var(--color-green)" : "var(--text-color)")}
+                  {renderArrowhead(
+                    rTipX,
+                    rTipY,
+                    downArrowAngle,
+                    downActive ? "var(--color-green)" : "var(--text-color)",
+                  )}
                 </g>
 
-                <g opacity={upActive ? 1 : loopVisible ? 0.35 : 0.15} style={{ transition: "opacity 0.3s ease" }}>
+                <g
+                  opacity={upActive ? 1 : loopVisible ? 0.35 : 0.15}
+                  style={{ transition: "opacity 0.3s ease" }}
+                >
                   <path
-                    d={upD} fill="none"
-                    stroke={upActive ? "var(--color-blue)" : "var(--text-color)"}
+                    d={upD}
+                    fill="none"
+                    stroke={
+                      upActive ? "var(--color-blue)" : "var(--text-color)"
+                    }
                     strokeWidth={upActive ? 2.5 * S : 2 * S}
                   />
-                  {renderArrowhead(lTipX, lTipY, upArrowAngle, upActive ? "var(--color-blue)" : "var(--text-color)")}
+                  {renderArrowhead(
+                    lTipX,
+                    lTipY,
+                    upArrowAngle,
+                    upActive ? "var(--color-blue)" : "var(--text-color)",
+                  )}
                 </g>
 
                 {loopCount > 0 && (
-                  <g style={{ transition: "opacity 0.3s ease" }} opacity={loopVisible ? 1 : 0}>
+                  <g
+                    style={{ transition: "opacity 0.3s ease" }}
+                    opacity={loopVisible ? 1 : 0}
+                  >
                     <rect
-                      x={badgeX - 14 * S} y={badgeY - 9 * S}
-                      width={28 * S} height={18 * S} rx={4 * S}
-                      fill="var(--code-background)" stroke="var(--color-green)" strokeWidth={1 * S} opacity={0.9}
+                      x={badgeX - 14 * S}
+                      y={badgeY - 9 * S}
+                      width={28 * S}
+                      height={18 * S}
+                      rx={4 * S}
+                      fill="var(--code-background)"
+                      stroke="var(--color-green)"
+                      strokeWidth={1 * S}
+                      opacity={0.9}
                     />
                     <text
-                      x={badgeX} y={badgeY}
-                      textAnchor="middle" dominantBaseline="central" fontSize={11 * S} fontWeight={700}
-                      fontFamily="var(--font-mono, monospace)" fill="var(--color-green)"
+                      x={badgeX}
+                      y={badgeY}
+                      textAnchor="middle"
+                      dominantBaseline="central"
+                      fontSize={11 * S}
+                      fontWeight={700}
+                      fontFamily="var(--font-mono, monospace)"
+                      fill="var(--color-green)"
                     >
                       {`×${loopCount}`}
                     </text>
                   </g>
                 )}
 
-                {mainNodes.map((node, idx) => renderNode(node, mainXs[idx], rowY))}
+                {mainNodes.map((node, idx) =>
+                  renderNode(node, mainXs[idx], rowY),
+                )}
                 {renderNode("tools", toolsX, toolsY)}
               </svg>
             </div>
@@ -505,7 +1016,9 @@ const QAAgentFlow: React.FC<QAAgentFlowProps> = ({ autoPlay = true, questionData
             >
               {activeStep >= 0 && trace[activeStep] ? (
                 <>
-                  <strong style={{ color: STEP_CONFIG[trace[activeStep].type].color }}>
+                  <strong
+                    style={{ color: STEP_CONFIG[trace[activeStep].type].color }}
+                  >
                     {STEP_CONFIG[trace[activeStep].type].label}:
                   </strong>{" "}
                   {STEP_CONFIG[trace[activeStep].type].description}
@@ -515,12 +1028,34 @@ const QAAgentFlow: React.FC<QAAgentFlowProps> = ({ autoPlay = true, questionData
               )}
             </div>
 
-            {/* Progress bar — animated with spring */}
+            {/* Wall-clock flame timeline — animated with spring */}
+            {timelineLayout.hasParallelTools ? (
+              <div
+                data-testid="parallel-tool-indicator"
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "flex-end",
+                  gap: "0.35rem",
+                  marginBottom: "0.35rem",
+                  color: "var(--color-green)",
+                  fontFamily: "var(--font-mono, monospace)",
+                  fontSize: "0.67rem",
+                  fontWeight: 650,
+                }}
+              >
+                <span aria-hidden="true">⇉</span>
+                <span>
+                  Parallel tool calls · {timelineLayout.laneCount} lanes
+                </span>
+              </div>
+            ) : null}
             <div
+              aria-label="QA trace wall-clock timeline"
               style={{
                 position: "relative",
                 width: "100%",
-                height: "24px",
+                height: `${timelineLayout.laneCount * TIMELINE_LANE_HEIGHT}px`,
                 marginBottom: "0.75rem",
                 borderRadius: "4px",
                 overflow: "hidden",
@@ -535,6 +1070,9 @@ const QAAgentFlow: React.FC<QAAgentFlowProps> = ({ autoPlay = true, questionData
                   height: "100%",
                   backgroundColor: "var(--background-color)",
                   borderRadius: "4px",
+                  backgroundImage:
+                    "linear-gradient(to bottom, transparent calc(100% - 1px), rgba(var(--text-color-rgb, 0, 0, 0), 0.1) calc(100% - 1px))",
+                  backgroundSize: `100% ${TIMELINE_LANE_HEIGHT}px`,
                 }}
               />
               <animated.div
@@ -542,26 +1080,42 @@ const QAAgentFlow: React.FC<QAAgentFlowProps> = ({ autoPlay = true, questionData
                   position: "absolute",
                   top: 0,
                   left: 0,
-                  display: "flex",
                   width: "100%",
                   height: "100%",
-                  clipPath: barSpring.progress.to((p) => `inset(0 ${100 - p}% 0 0)`),
+                  clipPath: barSpring.progress.to(
+                    (p) => `inset(0 ${100 - p}% 0 0)`,
+                  ),
                 }}
               >
-                {trace.map((step, idx) => {
+                {timelineLayout.segments.map((segment) => {
+                  const step = trace[segment.stepIndex];
                   const cfg = STEP_CONFIG[step.type];
-                  // Only render a duration label if the segment is wide enough to read it
-                  const widthPct = barWidths[idx];
-                  const showLabel = widthPct >= 6 && step.durationMs;
+                  const widthPct =
+                    (segment.durationMs / timelineLayout.totalMs) * 100;
+                  const leftPct =
+                    (segment.startMs / timelineLayout.totalMs) * 100;
+                  const durationLabel = formatMs(segment.durationMs);
+                  const showToolName = step.type === "tools" && widthPct >= 12;
+                  const showDuration = !showToolName && widthPct >= 6;
+                  const visibleLabel = showToolName
+                    ? step.content
+                    : showDuration
+                      ? durationLabel
+                      : "";
                   return (
                     <div
-                      key={`bar-${idx}-${step.type}`}
-                      title={`${cfg.label}: ${step.durationMs ? formatMs(step.durationMs) : "—"} (${widthPct.toFixed(1)}%)`}
+                      key={`bar-${segment.stepIndex}-${step.type}`}
+                      data-timeline-lane={segment.lane}
+                      aria-label={`${cfg.label}: ${step.content}; ${durationLabel}; starts at ${formatMs(segment.startMs)}`}
+                      title={`${cfg.label}: ${step.content} · ${durationLabel} · starts at ${formatMs(segment.startMs)}`}
                       style={{
+                        position: "absolute",
+                        top: `${segment.lane * TIMELINE_LANE_HEIGHT}px`,
+                        left: `${leftPct}%`,
                         width: `${widthPct}%`,
-                        height: "100%",
+                        minWidth: "2px",
+                        height: `${TIMELINE_LANE_HEIGHT - 2}px`,
                         backgroundColor: cfg.color,
-                        flexShrink: 0,
                         display: "flex",
                         alignItems: "center",
                         justifyContent: "center",
@@ -572,9 +1126,11 @@ const QAAgentFlow: React.FC<QAAgentFlowProps> = ({ autoPlay = true, questionData
                         textShadow: "0 0 2px rgba(0,0,0,0.4)",
                         overflow: "hidden",
                         whiteSpace: "nowrap",
+                        padding: visibleLabel ? "0 0.25rem" : 0,
+                        boxSizing: "border-box",
                       }}
                     >
-                      {showLabel && formatMs(step.durationMs!)}
+                      {visibleLabel}
                     </div>
                   );
                 })}
@@ -591,9 +1147,11 @@ const QAAgentFlow: React.FC<QAAgentFlowProps> = ({ autoPlay = true, questionData
               }}
             >
               {legendEntries.map((entry, index) => {
-                const prevComplete = index === 0 || legendEntries[index - 1].fillPercent >= 100;
+                const prevComplete =
+                  index === 0 || legendEntries[index - 1].fillPercent >= 100;
                 const isComplete = entry.fillPercent >= 100;
-                const isActive = entry.fillPercent > 0 && entry.fillPercent < 100;
+                const isActive =
+                  entry.fillPercent > 0 && entry.fillPercent < 100;
                 const circleSize = 14;
                 return (
                   <div
@@ -603,7 +1161,13 @@ const QAAgentFlow: React.FC<QAAgentFlowProps> = ({ autoPlay = true, questionData
                       alignItems: "center",
                       gap: "0.5rem",
                       color: "var(--text-color)",
-                      opacity: isComplete ? 1 : isActive ? 1 : prevComplete ? 0.6 : 0.3,
+                      opacity: isComplete
+                        ? 1
+                        : isActive
+                          ? 1
+                          : prevComplete
+                            ? 0.6
+                            : 0.3,
                       transition: "opacity 0.15s ease",
                     }}
                   >
@@ -632,56 +1196,48 @@ const QAAgentFlow: React.FC<QAAgentFlowProps> = ({ autoPlay = true, questionData
             </div>
 
             {/* Answer + Receipt stack (inside card) */}
-            {(() => {
-              const synthesizeStep = trace.find((s) => s.type === "synthesize");
-              const rawAnswer = synthesizeStep?.content ?? "";
-              const answerText = rawAnswer
-                .replace(/\n*#{0,3}\s*\*{0,2}Evidence\*{0,2}:?\**\s*[\s\S]*$/i, "")
-                .replace(/\n*```(?:json)?\s*\[\s*[\s\S]*$/, "")
-                .trim() || undefined;
-              return (
-                <animated.div
-                  ref={containerRef}
+            <animated.div
+              ref={containerRef}
+              style={{
+                ...answerHeightSpring,
+                overflow: "hidden",
+                display: "flex",
+                flexDirection: "column",
+                marginTop: "0.75rem",
+                marginBottom: "0.75rem",
+              }}
+            >
+              {showAnswer && answerText ? (
+                <div
+                  ref={answerRef}
                   style={{
-                    ...answerHeightSpring,
-                    overflow: "hidden",
                     display: "flex",
                     flexDirection: "column",
-                    marginTop: "0.75rem",
-                    marginBottom: "0.75rem",
+                    gap: "1rem",
+                    width: "100%",
+                    alignItems: "stretch",
                   }}
                 >
-                  {showAnswer && answerText ? (
-                    <div
-                      ref={answerRef}
-                      style={{
-                        display: "flex",
-                        flexWrap: "wrap",
-                        gap: "1rem",
-                        width: "100%",
-                        alignItems: "flex-start",
-                      }}
-                    >
-                      <div
-                        style={{
-                          flex: "1 1 250px",
-                          fontSize: "0.9rem",
-                          color: "var(--text-color)",
-                          minWidth: 0,
-                        }}
-                      >
-                        <ReactMarkdown>{answerText}</ReactMarkdown>
-                      </div>
-                    </div>
-                  ) : null}
-                </animated.div>
-              );
-            })()}
-
+                  <div
+                    style={{
+                      fontSize: "0.9rem",
+                      color: "var(--text-color)",
+                      minWidth: 0,
+                    }}
+                  >
+                    <ReactMarkdown>{answerText}</ReactMarkdown>
+                  </div>
+                  <StructuredReceiptSummary receipts={structuredReceipts} />
+                  <ReceiptEvidenceStack
+                    receipts={evidenceReceipts}
+                    isVisible={isVisible}
+                  />
+                </div>
+              ) : null}
+            </animated.div>
           </div>
         );
       })()}
-
     </div>
   );
 };

--- a/portfolio/components/ui/Figures/QAAgentFlow.tsx
+++ b/portfolio/components/ui/Figures/QAAgentFlow.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import Image from "next/image";
 import ReactMarkdown from "react-markdown";
-import { useSpring, animated, config } from "@react-spring/web";
+import { useSpring, animated } from "@react-spring/web";
 import { getReceiptMotionScale } from "./ReceiptFlow/receiptFlowUtils";
 import type {
   QAQuestionData,
@@ -119,7 +119,11 @@ const ReceiptEvidenceThumbnail: React.FC<ReceiptEvidenceThumbnailProps> = ({
           overflow: "hidden",
           opacity: 0,
           "--receipt-evidence-rotation": `${rotation}deg`,
-          animation: `receiptEvidenceIn 320ms ease-out ${index * 55}ms forwards`,
+          animationName: "receiptEvidenceIn",
+          animationDuration: "320ms",
+          animationTimingFunction: "ease-out",
+          animationDelay: `${index * 55}ms`,
+          animationFillMode: "forwards",
           animationPlayState: isVisible ? "running" : "paused",
         } as React.CSSProperties
       }
@@ -498,6 +502,7 @@ const QAAgentFlow: React.FC<QAAgentFlowProps> = ({
   const [activeStep, setActiveStep] = React.useState(-1);
   const [isPlaying, setIsPlaying] = React.useState(autoPlay);
   const [showAnswer, setShowAnswer] = React.useState(false);
+  const [showDetails, setShowDetails] = React.useState(false);
   const motionScale = getReceiptMotionScale();
 
   // Use real data when available, fall back to example trace
@@ -513,6 +518,7 @@ const QAAgentFlow: React.FC<QAAgentFlowProps> = ({
       .replace(/\n*#{0,3}\s*\*{0,2}Evidence\*{0,2}:?\**\s*[\s\S]*$/i, "")
       .replace(/\n*```(?:json)?\s*\[\s*[\s\S]*$/, "")
       .trim() || undefined;
+  const answerSummary = answerText?.split(/\n\s*\n/, 1)[0];
   const evidenceReceipts = React.useMemo(
     () => deduplicateReceiptEvidence(trace),
     [trace],
@@ -529,6 +535,7 @@ const QAAgentFlow: React.FC<QAAgentFlowProps> = ({
   React.useEffect(() => {
     setActiveStep(-1);
     setShowAnswer(false);
+    setShowDetails(false);
   }, [questionIndex]);
 
   React.useEffect(() => {
@@ -583,6 +590,7 @@ const QAAgentFlow: React.FC<QAAgentFlowProps> = ({
         // questionIndex (-1 → -1) and the questionIndex effect doesn't fire.
         setActiveStep(-1);
         setShowAnswer(false);
+        setShowDetails(false);
         onCycleComplete?.();
       }, 10000 * motionScale);
       return () => clearTimeout(id);
@@ -601,41 +609,6 @@ const QAAgentFlow: React.FC<QAAgentFlowProps> = ({
     onCycleComplete,
     motionScale,
   ]);
-
-  // Measure answer content height and spring the container open
-  const answerRef = React.useRef<HTMLDivElement>(null);
-  const [measuredHeight, setMeasuredHeight] = React.useState(0);
-
-  React.useEffect(() => {
-    if (showAnswer && answerRef.current) {
-      const raf = requestAnimationFrame(() => {
-        if (answerRef.current) {
-          setMeasuredHeight(answerRef.current.scrollHeight);
-        }
-      });
-      return () => cancelAnimationFrame(raf);
-    }
-    setMeasuredHeight(0);
-  }, [showAnswer, questionIndex]);
-
-  const containerRef = React.useRef<HTMLDivElement>(null);
-  const lastSpringHeight = React.useRef(0);
-
-  const answerHeightSpring = useSpring({
-    height: measuredHeight,
-    config: config.gentle,
-    onChange: (result: { value: { height: number } }) => {
-      const h = result.value.height;
-      const delta = h - lastSpringHeight.current;
-      lastSpringHeight.current = h;
-      if (delta !== 0 && containerRef.current) {
-        const rect = containerRef.current.getBoundingClientRect();
-        if (rect.bottom < 0) {
-          window.scrollBy(0, delta);
-        }
-      }
-    },
-  });
 
   // Reveal the wall-clock timeline through the furthest completed step.
   // Overlapping steps share the same x-range and occupy separate lanes.
@@ -856,7 +829,10 @@ const QAAgentFlow: React.FC<QAAgentFlowProps> = ({
                   strokeDashoffset={circumference}
                   transform={`rotate(-90 ${cx} ${cy})`}
                   style={{
-                    animation: `clockFill ${fillDurationSec}s linear forwards`,
+                    animationName: "clockFill",
+                    animationDuration: `${fillDurationSec}s`,
+                    animationTimingFunction: "linear",
+                    animationFillMode: "forwards",
                     animationPlayState: isVisible ? "running" : "paused",
                   }}
                 />
@@ -1195,46 +1171,173 @@ const QAAgentFlow: React.FC<QAAgentFlowProps> = ({
               })}
             </div>
 
-            {/* Answer + Receipt stack (inside card) */}
-            <animated.div
-              ref={containerRef}
+            {/* Stable answer frame: content changes never resize the page. */}
+            <section
+              data-testid="qa-result-frame"
+              role="region"
+              aria-label="QA answer result"
+              aria-busy={!showAnswer}
               style={{
-                ...answerHeightSpring,
+                height: "30rem",
                 overflow: "hidden",
+                overflowAnchor: "none",
                 display: "flex",
                 flexDirection: "column",
                 marginTop: "0.75rem",
                 marginBottom: "0.75rem",
+                border: "1px solid rgba(var(--text-color-rgb, 0, 0, 0), 0.14)",
+                borderRadius: "8px",
+                backgroundColor: "var(--background-color)",
+                color: "var(--text-color)",
+                boxSizing: "border-box",
               }}
             >
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "space-between",
+                  gap: "0.75rem",
+                  minHeight: "2.75rem",
+                  padding: "0.65rem 0.8rem",
+                  borderBottom:
+                    "1px solid rgba(var(--text-color-rgb, 0, 0, 0), 0.12)",
+                  boxSizing: "border-box",
+                }}
+              >
+                <strong style={{ fontSize: "0.78rem" }}>Result</strong>
+                <span
+                  style={{
+                    fontFamily: "var(--font-mono, monospace)",
+                    fontSize: "0.67rem",
+                    opacity: 0.62,
+                  }}
+                >
+                  {showAnswer ? "Answer ready" : "Answer pending"}
+                </span>
+              </div>
+
               {showAnswer && answerText ? (
                 <div
-                  ref={answerRef}
+                  key={`answer-${questionIndex}`}
+                  aria-live="polite"
                   style={{
                     display: "flex",
                     flexDirection: "column",
-                    gap: "1rem",
+                    flex: 1,
+                    minHeight: 0,
                     width: "100%",
-                    alignItems: "stretch",
+                    padding: "0.8rem",
+                    boxSizing: "border-box",
+                    animationName: "qaResultReveal",
+                    animationDuration: "220ms",
+                    animationTimingFunction: "ease-out",
+                    animationFillMode: "both",
                   }}
                 >
                   <div
+                    id="qa-result-content"
                     style={{
+                      display: "flex",
+                      flexDirection: "column",
+                      gap: "1rem",
+                      flex: 1,
+                      minHeight: 0,
+                      paddingRight: showDetails ? "0.35rem" : 0,
+                      overflowX: "hidden",
+                      overflowY: showDetails ? "auto" : "hidden",
+                      overscrollBehavior: "contain",
                       fontSize: "0.9rem",
                       color: "var(--text-color)",
-                      minWidth: 0,
                     }}
                   >
-                    <ReactMarkdown>{answerText}</ReactMarkdown>
+                    <div style={{ minWidth: 0 }}>
+                      <ReactMarkdown>
+                        {showDetails ? answerText : answerSummary}
+                      </ReactMarkdown>
+                    </div>
+                    {showDetails ? (
+                      <StructuredReceiptSummary receipts={structuredReceipts} />
+                    ) : null}
+                    <ReceiptEvidenceStack
+                      receipts={evidenceReceipts}
+                      isVisible={isVisible}
+                    />
                   </div>
-                  <StructuredReceiptSummary receipts={structuredReceipts} />
-                  <ReceiptEvidenceStack
-                    receipts={evidenceReceipts}
-                    isVisible={isVisible}
-                  />
+
+                  {answerText !== answerSummary ||
+                  structuredReceipts.length > 0 ? (
+                    <div
+                      style={{
+                        display: "flex",
+                        justifyContent: "flex-end",
+                        paddingTop: "0.65rem",
+                        flexShrink: 0,
+                      }}
+                    >
+                      <button
+                        type="button"
+                        data-testid="qa-result-details-toggle"
+                        aria-expanded={showDetails}
+                        aria-controls="qa-result-content"
+                        onClick={() => setShowDetails((current) => !current)}
+                        style={{
+                          padding: "0.4rem 0.65rem",
+                          border:
+                            "1px solid rgba(var(--text-color-rgb, 0, 0, 0), 0.24)",
+                          borderRadius: "999px",
+                          backgroundColor: "transparent",
+                          color: "var(--text-color)",
+                          fontFamily: "inherit",
+                          fontSize: "0.72rem",
+                          fontWeight: 650,
+                          cursor: "pointer",
+                        }}
+                      >
+                        {showDetails ? "Show summary" : "View full answer"}
+                      </button>
+                    </div>
+                  ) : null}
                 </div>
-              ) : null}
-            </animated.div>
+              ) : (
+                <div
+                  aria-live="polite"
+                  style={{
+                    display: "grid",
+                    flex: 1,
+                    placeItems: "center",
+                    minHeight: 0,
+                    padding: "1rem",
+                    textAlign: "center",
+                    opacity: 0.46,
+                  }}
+                >
+                  <div>
+                    <strong
+                      style={{ display: "block", marginBottom: "0.35rem" }}
+                    >
+                      Tracing your question
+                    </strong>
+                    <span style={{ fontSize: "0.76rem" }}>
+                      The completed answer and its receipt evidence will appear
+                      here.
+                    </span>
+                  </div>
+                </div>
+              )}
+              <style>{`
+                @keyframes qaResultReveal {
+                  from { opacity: 0; transform: translateY(4px); }
+                  to { opacity: 1; transform: translateY(0); }
+                }
+
+                @media (prefers-reduced-motion: reduce) {
+                  [data-testid="qa-result-frame"] > [aria-live="polite"] {
+                    animation-duration: 1ms !important;
+                  }
+                }
+              `}</style>
+            </section>
           </div>
         );
       })()}

--- a/portfolio/components/ui/Figures/QAAgentFlow.tsx
+++ b/portfolio/components/ui/Figures/QAAgentFlow.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import Image from "next/image";
-import ReactMarkdown from "react-markdown";
+import ReactMarkdown, { type Components } from "react-markdown";
+import remarkGfm from "remark-gfm";
 import { useSpring, animated } from "@react-spring/web";
 import { getReceiptMotionScale } from "./ReceiptFlow/receiptFlowUtils";
 import type {
@@ -35,6 +36,20 @@ const CDN_BASE = getCdnBaseUrl();
 const MAX_EVIDENCE_THUMBNAILS = 8;
 const MAX_STRUCTURED_RECEIPTS = 4;
 const MAX_ANSWER_SUMMARY_BODY_CHARS = 96;
+const QA_MARKDOWN_REMARK_PLUGINS = [remarkGfm];
+const QA_MARKDOWN_COMPONENTS: Components = {
+  table: ({ node: _node, ...tableProps }) => (
+    <div
+      className="qa-markdown-table-scroll"
+      data-testid="qa-markdown-table-scroll"
+      role="region"
+      aria-label="Scrollable answer table"
+      tabIndex={0}
+    >
+      <table {...tableProps} />
+    </div>
+  ),
+};
 const CURRENCY_FORMATTER = new Intl.NumberFormat("en-US", {
   style: "currency",
   currency: "USD",
@@ -1545,7 +1560,10 @@ const QAAgentFlow: React.FC<QAAgentFlowProps> = ({
                         overflow: "visible",
                       }}
                     >
-                      <ReactMarkdown>
+                      <ReactMarkdown
+                        remarkPlugins={QA_MARKDOWN_REMARK_PLUGINS}
+                        components={QA_MARKDOWN_COMPONENTS}
+                      >
                         {showDetails ? answerText : answerSummary}
                       </ReactMarkdown>
                     </div>
@@ -1641,6 +1659,58 @@ const QAAgentFlow: React.FC<QAAgentFlowProps> = ({
                   margin-top: 0;
                   font-size: 0.82rem;
                   line-height: 1.35;
+                }
+
+                .qa-markdown-table-scroll {
+                  width: 100%;
+                  margin: 0.65rem 0 1rem;
+                  overflow-x: auto;
+                  border: 1px solid rgba(var(--text-color-rgb, 0, 0, 0), 0.16);
+                  border-radius: 6px;
+                  overscroll-behavior-x: contain;
+                  scrollbar-width: thin;
+                  -webkit-overflow-scrolling: touch;
+                }
+
+                .qa-markdown-table-scroll:focus-visible {
+                  outline: 2px solid rgba(var(--text-color-rgb, 0, 0, 0), 0.5);
+                  outline-offset: 2px;
+                }
+
+                .qa-markdown-table-scroll table {
+                  width: 100%;
+                  min-width: 32rem;
+                  border-collapse: collapse;
+                  color: var(--text-color);
+                  font-size: 0.72rem;
+                  line-height: 1.4;
+                }
+
+                .qa-markdown-table-scroll :is(th, td) {
+                  padding: 0.5rem 0.6rem;
+                  border-right: 1px solid rgba(var(--text-color-rgb, 0, 0, 0), 0.12);
+                  border-bottom: 1px solid rgba(var(--text-color-rgb, 0, 0, 0), 0.12);
+                  text-align: left;
+                  vertical-align: top;
+                  overflow-wrap: anywhere;
+                }
+
+                .qa-markdown-table-scroll th {
+                  background: rgba(var(--text-color-rgb, 0, 0, 0), 0.07);
+                  font-weight: 700;
+                  white-space: nowrap;
+                }
+
+                .qa-markdown-table-scroll tbody tr:nth-child(even) {
+                  background: rgba(var(--text-color-rgb, 0, 0, 0), 0.025);
+                }
+
+                .qa-markdown-table-scroll :is(th, td):last-child {
+                  border-right: 0;
+                }
+
+                .qa-markdown-table-scroll tbody tr:last-child td {
+                  border-bottom: 0;
                 }
 
                 @media (prefers-reduced-motion: reduce) {

--- a/portfolio/components/ui/Figures/QAAgentFlow.tsx
+++ b/portfolio/components/ui/Figures/QAAgentFlow.tsx
@@ -13,7 +13,12 @@ import type {
 import { useRevealInView } from "../../../hooks/useOptimizedInView";
 import { getCdnBaseUrl } from "../../../utils/cdnBase";
 import { getJpegFallbackUrl } from "../../../utils/imageFormat";
-import { buildTimelineLayout } from "./qaTimeline";
+import {
+  buildTimelineLayout,
+  buildTimelinePlayback,
+  getActiveTimelineStepIndices,
+  getTimelineRevealPercent,
+} from "./qaTimeline";
 
 interface QAAgentFlowProps {
   /** Whether to auto-play the animation */
@@ -40,6 +45,24 @@ const getCdnUrl = (key: string): string =>
 const getReceiptJpegFallbackUrl = (key: string): string => {
   const jpegKey = key.replace(/\.(?:avif|webp)$/i, ".jpg");
   return getJpegFallbackUrl({ cdn_s3_key: jpegKey.replace(/^\/+/, "") });
+};
+
+const getAnswerSummaryMarkdown = (answer: string): string => {
+  const blocks = answer
+    .split(/\n\s*\n/)
+    .map((block) => block.trim())
+    .filter(Boolean);
+  const firstBlock = blocks[0] ?? answer;
+  const isHeading = (block: string): boolean => /^#{1,6}\s+\S/.test(block);
+
+  if (!isHeading(firstBlock)) return firstBlock;
+
+  const firstSubstantiveBlock = blocks
+    .slice(1)
+    .find((block) => !isHeading(block));
+  return firstSubstantiveBlock
+    ? `${firstBlock}\n\n${firstSubstantiveBlock}`
+    : firstBlock;
 };
 
 const deduplicateReceiptEvidence = (trace: TraceStep[]): ReceiptEvidence[] => {
@@ -499,7 +522,7 @@ const QAAgentFlow: React.FC<QAAgentFlowProps> = ({
     threshold: 0,
     rootMargin: "200px",
   });
-  const [activeStep, setActiveStep] = React.useState(-1);
+  const [playbackTimeMs, setPlaybackTimeMs] = React.useState(-1);
   const [isPlaying, setIsPlaying] = React.useState(autoPlay);
   const [showAnswer, setShowAnswer] = React.useState(false);
   const [showDetails, setShowDetails] = React.useState(false);
@@ -511,6 +534,16 @@ const QAAgentFlow: React.FC<QAAgentFlowProps> = ({
     () => buildTimelineLayout(trace, DEFAULT_STEP_MS),
     [trace],
   );
+  const playbackTimeline = React.useMemo(
+    () =>
+      buildTimelinePlayback(timelineLayout, {
+        targetTotalMs: TARGET_TOTAL_MS,
+        motionScale,
+        minStepMs: MIN_STEP_MS,
+        maxStepMs: MAX_STEP_MS,
+      }),
+    [timelineLayout, motionScale],
+  );
   const synthesizeStep = trace.find((step) => step.type === "synthesize");
   const rawAnswer = synthesizeStep?.content ?? "";
   const answerText =
@@ -518,7 +551,9 @@ const QAAgentFlow: React.FC<QAAgentFlowProps> = ({
       .replace(/\n*#{0,3}\s*\*{0,2}Evidence\*{0,2}:?\**\s*[\s\S]*$/i, "")
       .replace(/\n*```(?:json)?\s*\[\s*[\s\S]*$/, "")
       .trim() || undefined;
-  const answerSummary = answerText?.split(/\n\s*\n/, 1)[0];
+  const answerSummary = answerText
+    ? getAnswerSummaryMarkdown(answerText)
+    : undefined;
   const evidenceReceipts = React.useMemo(
     () => deduplicateReceiptEvidence(trace),
     [trace],
@@ -533,7 +568,7 @@ const QAAgentFlow: React.FC<QAAgentFlowProps> = ({
   // Reset animation when question changes (use index to avoid stale-data issues on mobile)
   const questionIndex = questionData?.questionIndex ?? -1;
   React.useEffect(() => {
-    setActiveStep(-1);
+    setPlaybackTimeMs(-1);
     setShowAnswer(false);
     setShowDetails(false);
   }, [questionIndex]);
@@ -542,53 +577,57 @@ const QAAgentFlow: React.FC<QAAgentFlowProps> = ({
     setIsPlaying(autoPlay && isVisible);
   }, [autoPlay, isVisible]);
 
-  // Compute per-step animation durations from durationMs, scaled proportionally
-  const stepDurations = React.useMemo(() => {
-    const hasTiming = trace.some(
-      (s) => s.durationMs != null && s.durationMs > 0,
-    );
-    if (!hasTiming) return trace.map(() => DEFAULT_STEP_MS * motionScale);
-
-    const rawMs = trace.map((s) => s.durationMs ?? DEFAULT_STEP_MS);
-    const rawTotal = rawMs.reduce((sum, d) => sum + d, 0);
-    if (rawTotal === 0) return trace.map(() => DEFAULT_STEP_MS);
-
-    const scale = TARGET_TOTAL_MS / rawTotal;
-    return rawMs.map((d) =>
-      Math.max(
-        MIN_STEP_MS * motionScale,
-        Math.min(
-          MAX_STEP_MS * motionScale,
-          Math.round(d * scale * motionScale),
-        ),
+  const nextBoundaryMs = React.useMemo(
+    () =>
+      playbackTimeMs < 0
+        ? 0
+        : playbackTimeline.boundariesMs.find(
+            (boundaryMs) => boundaryMs > playbackTimeMs,
+          ),
+    [playbackTimeMs, playbackTimeline.boundariesMs],
+  );
+  const activeStepIndices = React.useMemo(
+    () =>
+      playbackTimeMs < 0
+        ? []
+        : getActiveTimelineStepIndices(
+            playbackTimeline.segments,
+            playbackTimeMs,
+          ),
+    [playbackTimeMs, playbackTimeline.segments],
+  );
+  const activeStep = activeStepIndices[0] ?? -1;
+  const visitedStepIndices = React.useMemo(
+    () =>
+      new Set(
+        playbackTimeline.segments
+          .filter((segment) => segment.startMs <= playbackTimeMs)
+          .map((segment) => segment.stepIndex),
       ),
-    );
-  }, [trace, motionScale]);
-
-  // Current step's animation duration (for clock-fill sync)
+    [playbackTimeMs, playbackTimeline.segments],
+  );
+  const activePlaybackSegment = playbackTimeline.segments.find(
+    (segment) => segment.stepIndex === activeStep,
+  );
   const currentStepDuration =
-    activeStep >= 0 && activeStep < stepDurations.length
-      ? stepDurations[activeStep]
-      : DEFAULT_STEP_MS;
+    activePlaybackSegment?.durationMs ?? DEFAULT_STEP_MS;
+  const activeParallelToolSteps = activeStepIndices.filter(
+    (stepIndex) => trace[stepIndex]?.type === "tools",
+  );
 
-  // Auto-advance through steps using per-step durations
+  // Advance through actual wall-clock boundaries. Overlapping spans are active
+  // together, while legacy traces retain their clamped sequential playback.
   React.useEffect(() => {
     if (!isPlaying) return;
 
-    if (activeStep >= trace.length - 1) {
-      // Last step reached — reveal answer after its duration, then hold 5s
-      if (!showAnswer) {
-        const id = setTimeout(
-          () => setShowAnswer(true),
-          stepDurations[trace.length - 1],
-        );
-        return () => clearTimeout(id);
-      }
+    if (showAnswer) {
+      if (showDetails) return;
+
       const id = setTimeout(() => {
         // Reset animation before advancing so the next cycle always starts
         // fresh — even when consecutive null-data states produce the same
         // questionIndex (-1 → -1) and the questionIndex effect doesn't fire.
-        setActiveStep(-1);
+        setPlaybackTimeMs(-1);
         setShowAnswer(false);
         setShowDetails(false);
         onCycleComplete?.();
@@ -596,49 +635,61 @@ const QAAgentFlow: React.FC<QAAgentFlowProps> = ({
       return () => clearTimeout(id);
     }
 
-    const delay =
-      activeStep < 0 ? 400 * motionScale : stepDurations[activeStep];
-    const id = setTimeout(() => setActiveStep((prev) => prev + 1), delay);
+    if (playbackTimeMs < 0) {
+      const id = setTimeout(() => setPlaybackTimeMs(0), 400 * motionScale);
+      return () => clearTimeout(id);
+    }
+
+    if (nextBoundaryMs == null) {
+      setShowAnswer(true);
+      return;
+    }
+
+    const id = setTimeout(
+      () => setPlaybackTimeMs(nextBoundaryMs),
+      Math.max(0, nextBoundaryMs - playbackTimeMs),
+    );
     return () => clearTimeout(id);
   }, [
     isPlaying,
-    activeStep,
-    trace.length,
-    stepDurations,
+    playbackTimeMs,
+    nextBoundaryMs,
     showAnswer,
+    showDetails,
     onCycleComplete,
     motionScale,
   ]);
 
-  // Reveal the wall-clock timeline through the furthest completed step.
-  // Overlapping steps share the same x-range and occupy separate lanes.
-  const barTarget = React.useMemo(() => {
-    if (activeStep < 0) return 0;
-    if (activeStep >= trace.length - 1) return 100;
-    const revealedEndMs = timelineLayout.segments.reduce(
-      (furthestEnd, segment) =>
-        segment.stepIndex <= activeStep
-          ? Math.max(furthestEnd, segment.endMs)
-          : furthestEnd,
-      0,
-    );
-    return (revealedEndMs / timelineLayout.totalMs) * 100;
-  }, [activeStep, trace.length, timelineLayout]);
+  const barTarget =
+    playbackTimeMs < 0 || playbackTimeline.totalMs === 0
+      ? 0
+      : getTimelineRevealPercent(
+          timelineLayout,
+          playbackTimeline,
+          nextBoundaryMs ?? playbackTimeline.totalMs,
+        );
+  const barDuration =
+    playbackTimeMs < 0 || nextBoundaryMs == null
+      ? 0
+      : nextBoundaryMs - playbackTimeMs;
 
   const barSpring = useSpring({
     progress: barTarget,
-    config: { duration: activeStep < 0 ? 0 : currentStepDuration },
+    pause: !isPlaying,
+    config: { duration: barDuration },
   });
 
   // Compute loop count: increments each time an agent step appears
   const loopCount = React.useMemo(() => {
-    if (activeStep < 1) return 0;
-    let count = 0;
-    for (let i = 1; i <= Math.min(activeStep, trace.length - 1); i++) {
-      if (trace[i].type === "agent") count++;
-    }
-    return count;
-  }, [activeStep, trace]);
+    if (playbackTimeMs < 0) return 0;
+    return trace.reduce(
+      (count, step, stepIndex) =>
+        step.type === "agent" && visitedStepIndices.has(stepIndex)
+          ? count + 1
+          : count,
+      0,
+    );
+  }, [playbackTimeMs, trace, visitedStepIndices]);
 
   // Determine which node is currently active
   const activeType: StepType | null =
@@ -672,6 +723,9 @@ const QAAgentFlow: React.FC<QAAgentFlowProps> = ({
       {(() => {
         const formatMs = (ms: number): string =>
           ms >= 1000 ? `${(ms / 1000).toFixed(2)}s` : `${ms.toFixed(1)}ms`;
+        const parallelToolSegments = timelineLayout.segments.filter((segment) =>
+          timelineLayout.parallelStepIndices.includes(segment.stepIndex),
+        );
 
         // Deduplicate step types for the legend (e.g. multiple agent/tools steps)
         const uniqueTypes: StepType[] = [];
@@ -685,8 +739,8 @@ const QAAgentFlow: React.FC<QAAgentFlowProps> = ({
           const stepIndices = trace
             .map((s, i) => (s.type === type ? i : -1))
             .filter((i) => i >= 0);
-          const visitedCount = stepIndices.filter(
-            (i) => i <= activeStep,
+          const visitedCount = stepIndices.filter((i) =>
+            visitedStepIndices.has(i),
           ).length;
           const fillPercent =
             stepIndices.length > 0
@@ -790,14 +844,17 @@ const QAAgentFlow: React.FC<QAAgentFlowProps> = ({
         );
 
         const circumference = Math.PI * nodeR;
-        const fillDurationSec = ((currentStepDuration - 100) / 1000).toFixed(2);
+        const fillDurationSec = (
+          Math.max(1, currentStepDuration - 100) / 1000
+        ).toFixed(2);
 
         const renderNode = (node: StepType, cx: number, cy: number) => {
           const cfg = STEP_CONFIG[node];
           const isNodeActive = activeType === node;
-          const wasVisited =
-            activeStep >= 0 &&
-            trace.slice(0, activeStep + 1).some((s) => s.type === node);
+          const wasVisited = trace.some(
+            (step, stepIndex) =>
+              step.type === node && visitedStepIndices.has(stepIndex),
+          );
           return (
             <g
               key={node}
@@ -1006,24 +1063,87 @@ const QAAgentFlow: React.FC<QAAgentFlowProps> = ({
 
             {/* Wall-clock flame timeline — animated with spring */}
             {timelineLayout.hasParallelTools ? (
-              <div
-                data-testid="parallel-tool-indicator"
-                style={{
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "flex-end",
-                  gap: "0.35rem",
-                  marginBottom: "0.35rem",
-                  color: "var(--color-green)",
-                  fontFamily: "var(--font-mono, monospace)",
-                  fontSize: "0.67rem",
-                  fontWeight: 650,
-                }}
-              >
-                <span aria-hidden="true">⇉</span>
-                <span>
-                  Parallel tool calls · {timelineLayout.laneCount} lanes
-                </span>
+              <div style={{ marginBottom: "0.55rem" }}>
+                <div
+                  data-testid="parallel-tool-indicator"
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "space-between",
+                    flexWrap: "wrap",
+                    gap: "0.35rem 0.75rem",
+                    marginBottom: "0.4rem",
+                    color: "var(--color-green)",
+                    fontFamily: "var(--font-mono, monospace)",
+                    fontSize: "0.67rem",
+                    fontWeight: 650,
+                  }}
+                >
+                  <span>
+                    <span aria-hidden="true">⇉</span> Parallel tool calls ·{" "}
+                    {timelineLayout.laneCount} lanes
+                  </span>
+                  {activeParallelToolSteps.length > 1 ? (
+                    <span data-testid="active-parallel-tools" role="status">
+                      {activeParallelToolSteps.length} tools running together
+                    </span>
+                  ) : null}
+                </div>
+                <div
+                  role="list"
+                  aria-label="Parallel tool call details"
+                  style={{
+                    display: "grid",
+                    gridTemplateColumns:
+                      "repeat(auto-fit, minmax(min(100%, 220px), 1fr))",
+                    gap: "0.35rem",
+                  }}
+                >
+                  {parallelToolSegments.map((segment) => {
+                    const step = trace[segment.stepIndex];
+                    const isActive = activeStepIndices.includes(
+                      segment.stepIndex,
+                    );
+                    return (
+                      <div
+                        key={`parallel-detail-${segment.stepIndex}`}
+                        role="listitem"
+                        style={{
+                          display: "grid",
+                          gridTemplateColumns: "auto minmax(0, 1fr) auto",
+                          alignItems: "center",
+                          gap: "0.45rem",
+                          padding: "0.35rem 0.45rem",
+                          border:
+                            "1px solid rgba(var(--text-color-rgb, 0, 0, 0), 0.12)",
+                          borderRadius: "4px",
+                          color: "var(--text-color)",
+                          backgroundColor: isActive
+                            ? "rgba(var(--text-color-rgb, 0, 0, 0), 0.06)"
+                            : "transparent",
+                          fontFamily: "var(--font-mono, monospace)",
+                          fontSize: "0.67rem",
+                        }}
+                      >
+                        <span
+                          aria-hidden="true"
+                          style={{
+                            width: "0.45rem",
+                            height: "0.45rem",
+                            borderRadius: "50%",
+                            backgroundColor: STEP_CONFIG.tools.color,
+                          }}
+                        />
+                        <span style={{ overflowWrap: "anywhere" }}>
+                          {step.content}
+                        </span>
+                        <span style={{ opacity: 0.6 }}>
+                          {formatMs(segment.durationMs)}
+                        </span>
+                      </div>
+                    );
+                  })}
+                </div>
               </div>
             ) : null}
             <div
@@ -1082,6 +1202,11 @@ const QAAgentFlow: React.FC<QAAgentFlowProps> = ({
                     <div
                       key={`bar-${segment.stepIndex}-${step.type}`}
                       data-timeline-lane={segment.lane}
+                      data-active={
+                        activeStepIndices.includes(segment.stepIndex)
+                          ? "true"
+                          : "false"
+                      }
                       aria-label={`${cfg.label}: ${step.content}; ${durationLabel}; starts at ${formatMs(segment.startMs)}`}
                       title={`${cfg.label}: ${step.content} · ${durationLabel} · starts at ${formatMs(segment.startMs)}`}
                       style={{

--- a/portfolio/components/ui/Figures/QAAgentFlow.tsx
+++ b/portfolio/components/ui/Figures/QAAgentFlow.tsx
@@ -34,6 +34,7 @@ interface QAAgentFlowProps {
 const CDN_BASE = getCdnBaseUrl();
 const MAX_EVIDENCE_THUMBNAILS = 8;
 const MAX_STRUCTURED_RECEIPTS = 4;
+const MAX_ANSWER_SUMMARY_BODY_CHARS = 96;
 const CURRENCY_FORMATTER = new Intl.NumberFormat("en-US", {
   style: "currency",
   currency: "USD",
@@ -55,13 +56,29 @@ const getAnswerSummaryMarkdown = (answer: string): string => {
   const firstBlock = blocks[0] ?? answer;
   const isHeading = (block: string): boolean => /^#{1,6}\s+\S/.test(block);
 
-  if (!isHeading(firstBlock)) return firstBlock;
+  const summarizeBlock = (block: string): string => {
+    const normalized = block.replace(/\s+/g, " ").trim();
+    if (normalized.length <= MAX_ANSWER_SUMMARY_BODY_CHARS) return normalized;
+
+    const sentence = normalized.match(
+      new RegExp(`^.{1,${MAX_ANSWER_SUMMARY_BODY_CHARS}}?[.!?](?=\\s|$)`),
+    )?.[0];
+    if (sentence) return sentence;
+
+    const wordBoundary = normalized
+      .slice(0, MAX_ANSWER_SUMMARY_BODY_CHARS + 1)
+      .lastIndexOf(" ");
+    const cutoff = wordBoundary > 0 ? wordBoundary : MAX_ANSWER_SUMMARY_BODY_CHARS;
+    return `${normalized.slice(0, cutoff).trimEnd()}…`;
+  };
+
+  if (!isHeading(firstBlock)) return summarizeBlock(firstBlock);
 
   const firstSubstantiveBlock = blocks
     .slice(1)
     .find((block) => !isHeading(block));
   return firstSubstantiveBlock
-    ? `${firstBlock}\n\n${firstSubstantiveBlock}`
+    ? `${firstBlock}\n\n${summarizeBlock(firstSubstantiveBlock)}`
     : firstBlock;
 };
 
@@ -95,16 +112,20 @@ interface ReceiptEvidenceThumbnailProps {
   receipt: ReceiptEvidence;
   index: number;
   isVisible: boolean;
-  overlapRatio: number;
+  thumbnailHeight: number;
+  leftOffset: number;
 }
 
 const EVIDENCE_THUMBNAIL_HEIGHT = 154;
+const EVIDENCE_STACK_EDGE_SAFETY = 16;
+const MAX_EVIDENCE_OVERLAP_RATIO = 0.82;
 
 const ReceiptEvidenceThumbnail: React.FC<ReceiptEvidenceThumbnailProps> = ({
   receipt,
   index,
   isVisible,
-  overlapRatio,
+  thumbnailHeight,
+  leftOffset,
 }) => {
   const initialUrl = getCdnUrl(receipt.thumbnailKey);
   const fallbackUrl = getReceiptJpegFallbackUrl(receipt.thumbnailKey);
@@ -128,9 +149,8 @@ const ReceiptEvidenceThumbnail: React.FC<ReceiptEvidenceThumbnailProps> = ({
   const merchant = receipt.merchant || "Unknown merchant";
   const sourceWidth = receipt.width > 0 ? receipt.width : 300;
   const sourceHeight = receipt.height > 0 ? receipt.height : 900;
-  const thumbnailWidth =
-    EVIDENCE_THUMBNAIL_HEIGHT * (sourceWidth / sourceHeight);
-  const overlap = Math.round(thumbnailWidth * overlapRatio);
+  const sourceAspectRatio = sourceWidth / sourceHeight;
+  const thumbnailWidth = thumbnailHeight * sourceAspectRatio;
   const evidenceDetail = [
     receipt.item,
     Number.isFinite(receipt.amount)
@@ -143,21 +163,25 @@ const ReceiptEvidenceThumbnail: React.FC<ReceiptEvidenceThumbnailProps> = ({
   return (
     <div
       role="listitem"
+      data-testid="receipt-evidence-thumbnail"
+      data-source-aspect-ratio={sourceAspectRatio}
       title={evidenceDetail ? `${merchant}: ${evidenceDetail}` : merchant}
       style={
         {
-          position: "relative",
+          position: "absolute",
+          left: `${leftOffset}px`,
+          top: 0,
           width: `${thumbnailWidth}px`,
           minWidth: `${thumbnailWidth}px`,
-          height: `${EVIDENCE_THUMBNAIL_HEIGHT}px`,
+          height: `${thumbnailHeight}px`,
           flex: `0 0 ${thumbnailWidth}px`,
-          marginLeft: index === 0 ? 0 : `-${overlap}px`,
           zIndex: index + 1,
           border: 0,
-          borderRadius: "3px",
+          borderRadius: 0,
           backgroundColor: "transparent",
           boxShadow: "0 5px 16px rgba(0, 0, 0, 0.2)",
-          overflow: "hidden",
+          overflow: "visible",
+          transformOrigin: "center center",
           opacity: 0,
           "--receipt-evidence-rotation": `${rotation}deg`,
           animationName: "receiptEvidenceIn",
@@ -219,11 +243,97 @@ const ReceiptEvidenceStack: React.FC<ReceiptEvidenceStackProps> = ({
   receipts,
   isVisible,
 }) => {
+  const listRef = React.useRef<HTMLDivElement>(null);
+  const [availableWidth, setAvailableWidth] = React.useState(374);
+
+  React.useEffect(() => {
+    const list = listRef.current;
+    if (!list || typeof ResizeObserver === "undefined") return;
+
+    const updateAvailableWidth = (width: number) => {
+      setAvailableWidth((current) =>
+        Math.abs(current - width) >= 0.5 ? width : current,
+      );
+    };
+    updateAvailableWidth(list.getBoundingClientRect().width);
+
+    const observer = new ResizeObserver(([entry]) => {
+      if (entry) updateAvailableWidth(entry.contentRect.width);
+    });
+    observer.observe(list);
+    return () => observer.disconnect();
+  }, []);
+
   if (receipts.length === 0) return null;
 
   const visibleReceipts = receipts.slice(0, MAX_EVIDENCE_THUMBNAILS);
   const hiddenCount = receipts.length - visibleReceipts.length;
-  const overlapRatio = visibleReceipts.length > 5 ? 0.48 : 0.28;
+  const baseOverlapRatio = visibleReceipts.length > 5 ? 0.48 : 0.28;
+  const receiptWidthRatios = visibleReceipts.map((receipt) => {
+    const width = receipt.width > 0 ? receipt.width : 300;
+    const height = receipt.height > 0 ? receipt.height : 900;
+    return width / height;
+  });
+  const targetStackWidth = Math.max(
+    1,
+    availableWidth - EVIDENCE_STACK_EDGE_SAFETY,
+  );
+  const baseWidths = receiptWidthRatios.map(
+    (ratio) => ratio * EVIDENCE_THUMBNAIL_HEIGHT,
+  );
+  const getStackBounds = (overlapRatio: number) => {
+    if (baseWidths.length === 0) {
+      return { positions: [] as number[], span: 0, min: 0 };
+    }
+
+    const positions = [0];
+    let previousRight = baseWidths[0];
+    let min = 0;
+    let max = previousRight;
+    for (let index = 1; index < baseWidths.length; index += 1) {
+      const width = baseWidths[index];
+      const left = previousRight - width * overlapRatio;
+      const right = left + width;
+      positions.push(left);
+      min = Math.min(min, left);
+      max = Math.max(max, right);
+      previousRight = right;
+    }
+    return { positions, span: max - min, min };
+  };
+  let overlapRatio = baseOverlapRatio;
+  let stackBounds = getStackBounds(overlapRatio);
+  let smallestBounds = stackBounds;
+  let smallestBoundsOverlap = overlapRatio;
+  const OVERLAP_SEARCH_STEPS = 80;
+  for (let step = 1; step <= OVERLAP_SEARCH_STEPS; step += 1) {
+    const candidateOverlap =
+      baseOverlapRatio +
+      ((MAX_EVIDENCE_OVERLAP_RATIO - baseOverlapRatio) * step) /
+        OVERLAP_SEARCH_STEPS;
+    const candidateBounds = getStackBounds(candidateOverlap);
+    if (candidateBounds.span < smallestBounds.span) {
+      smallestBounds = candidateBounds;
+      smallestBoundsOverlap = candidateOverlap;
+    }
+    if (candidateBounds.span <= targetStackWidth) {
+      overlapRatio = candidateOverlap;
+      stackBounds = candidateBounds;
+      break;
+    }
+    if (step === OVERLAP_SEARCH_STEPS) {
+      overlapRatio = smallestBoundsOverlap;
+      stackBounds = smallestBounds;
+    }
+  }
+  const thumbnailHeight =
+    EVIDENCE_THUMBNAIL_HEIGHT *
+    Math.min(1, targetStackWidth / Math.max(1, stackBounds.span));
+  const stackScale = thumbnailHeight / EVIDENCE_THUMBNAIL_HEIGHT;
+  const thumbnailLeftOffsets = stackBounds.positions.map(
+    (position) => (position - stackBounds.min) * stackScale,
+  );
+  const stackWidth = stackBounds.span * stackScale;
   const receiptLabel = `${receipts.length} ${
     receipts.length === 1 ? "receipt" : "receipts"
   }`;
@@ -263,37 +373,53 @@ const ReceiptEvidenceStack: React.FC<ReceiptEvidenceStackProps> = ({
       </div>
 
       <div
+        ref={listRef}
         role="list"
+        data-testid="receipt-evidence-list"
+        data-available-width={availableWidth}
+        data-overlap-ratio={overlapRatio}
+        data-thumbnail-height={thumbnailHeight}
         aria-label={`${receiptLabel} used as evidence`}
         style={{
           display: "flex",
           justifyContent: "center",
-          alignItems: "flex-start",
+          alignItems: "center",
           width: "100%",
           maxWidth: "390px",
-          minHeight: "166px",
+          height: "166px",
           margin: "0 auto",
           padding: "0.35rem 0.8rem 0.65rem",
           boxSizing: "border-box",
-          overflow: "hidden",
+          overflow: "visible",
         }}
       >
-        {visibleReceipts.map((receipt, index) => (
-          <ReceiptEvidenceThumbnail
-            key={receipt.imageId}
-            receipt={receipt}
-            index={index}
-            isVisible={isVisible}
-            overlapRatio={overlapRatio}
-          />
-        ))}
+        <div
+          data-testid="receipt-evidence-stack"
+          style={{
+            position: "relative",
+            width: `${stackWidth}px`,
+            height: `${thumbnailHeight}px`,
+            flex: "0 0 auto",
+          }}
+        >
+          {visibleReceipts.map((receipt, index) => (
+            <ReceiptEvidenceThumbnail
+              key={receipt.imageId}
+              receipt={receipt}
+              index={index}
+              isVisible={isVisible}
+              thumbnailHeight={thumbnailHeight}
+              leftOffset={thumbnailLeftOffsets[index] ?? 0}
+            />
+          ))}
+        </div>
       </div>
 
       <style>{`
         @keyframes receiptEvidenceIn {
           from {
             opacity: 0;
-            transform: rotate(var(--receipt-evidence-rotation, 0deg)) translateY(-14px);
+            transform: rotate(var(--receipt-evidence-rotation, 0deg)) scale(0.98);
           }
           to {
             opacity: 1;
@@ -1416,22 +1542,7 @@ const QAAgentFlow: React.FC<QAAgentFlowProps> = ({
                       style={{
                         minWidth: 0,
                         flexShrink: 0,
-                        maxHeight:
-                          !showDetails && hasAnswerDetails
-                            ? "6.5rem"
-                            : undefined,
-                        overflow:
-                          !showDetails && hasAnswerDetails
-                            ? "hidden"
-                            : "visible",
-                        WebkitMaskImage:
-                          !showDetails && hasAnswerDetails
-                            ? "linear-gradient(to bottom, #000 78%, transparent 100%)"
-                            : undefined,
-                        maskImage:
-                          !showDetails && hasAnswerDetails
-                            ? "linear-gradient(to bottom, #000 78%, transparent 100%)"
-                            : undefined,
+                        overflow: "visible",
                       }}
                     >
                       <ReactMarkdown>
@@ -1510,6 +1621,26 @@ const QAAgentFlow: React.FC<QAAgentFlowProps> = ({
                 @keyframes qaResultReveal {
                   from { opacity: 0; transform: translateY(4px); }
                   to { opacity: 1; transform: translateY(0); }
+                }
+
+                [data-testid="qa-answer-summary"] > :first-child {
+                  margin-top: 0;
+                }
+
+                [data-testid="qa-answer-summary"] > :last-child {
+                  margin-bottom: 0;
+                }
+
+                [data-testid="qa-answer-summary"] > :is(h1, h2, h3) {
+                  margin-bottom: 0.35rem;
+                  font-size: 1.15rem;
+                  line-height: 1.25;
+                }
+
+                [data-testid="qa-answer-summary"] > p {
+                  margin-top: 0;
+                  font-size: 0.82rem;
+                  line-height: 1.35;
                 }
 
                 @media (prefers-reduced-motion: reduce) {

--- a/portfolio/components/ui/Figures/QAAgentFlow.tsx
+++ b/portfolio/components/ui/Figures/QAAgentFlow.tsx
@@ -191,8 +191,8 @@ const ReceiptEvidenceThumbnail: React.FC<ReceiptEvidenceThumbnailProps> = ({
             width: "100%",
             height: "100%",
             display: "block",
-            objectFit: "cover",
-            objectPosition: "top",
+            objectFit: "contain",
+            objectPosition: "top center",
           }}
           onError={handleError}
         />
@@ -227,6 +227,7 @@ const ReceiptEvidenceStack: React.FC<ReceiptEvidenceStackProps> = ({
         paddingTop: "0.9rem",
         borderTop: "1px solid rgba(var(--text-color-rgb, 0, 0, 0), 0.14)",
         color: "var(--text-color)",
+        flexShrink: 0,
       }}
     >
       <div
@@ -573,6 +574,8 @@ const QAAgentFlow: React.FC<QAAgentFlowProps> = ({
         ?.structuredData ?? [],
     [trace],
   );
+  const hasAnswerDetails =
+    answerText !== answerSummary || structuredReceipts.length > 0;
 
   // Reset animation when question changes (use index to avoid stale-data issues on mobile)
   const questionIndex = questionData?.questionIndex ?? -1;
@@ -1397,7 +1400,29 @@ const QAAgentFlow: React.FC<QAAgentFlowProps> = ({
                       color: "var(--text-color)",
                     }}
                   >
-                    <div style={{ minWidth: 0 }}>
+                    <div
+                      data-testid="qa-answer-summary"
+                      style={{
+                        minWidth: 0,
+                        flexShrink: 0,
+                        maxHeight:
+                          !showDetails && hasAnswerDetails
+                            ? "6.5rem"
+                            : undefined,
+                        overflow:
+                          !showDetails && hasAnswerDetails
+                            ? "hidden"
+                            : "visible",
+                        WebkitMaskImage:
+                          !showDetails && hasAnswerDetails
+                            ? "linear-gradient(to bottom, #000 78%, transparent 100%)"
+                            : undefined,
+                        maskImage:
+                          !showDetails && hasAnswerDetails
+                            ? "linear-gradient(to bottom, #000 78%, transparent 100%)"
+                            : undefined,
+                      }}
+                    >
                       <ReactMarkdown>
                         {showDetails ? answerText : answerSummary}
                       </ReactMarkdown>
@@ -1411,8 +1436,7 @@ const QAAgentFlow: React.FC<QAAgentFlowProps> = ({
                     />
                   </div>
 
-                  {answerText !== answerSummary ||
-                  structuredReceipts.length > 0 ? (
+                  {hasAnswerDetails ? (
                     <div
                       style={{
                         display: "flex",

--- a/portfolio/components/ui/Figures/QAAgentFlow.tsx
+++ b/portfolio/components/ui/Figures/QAAgentFlow.tsx
@@ -65,6 +65,15 @@ const getAnswerSummaryMarkdown = (answer: string): string => {
     : firstBlock;
 };
 
+const formatTimelineBarDuration = (ms: number): string => {
+  if (ms >= 1000) {
+    const seconds = ms / 1000;
+    return `${Number.isInteger(seconds) ? seconds.toFixed(0) : seconds.toFixed(1)}s`;
+  }
+
+  return `${Math.max(1, Math.round(ms))}ms`;
+};
+
 const deduplicateReceiptEvidence = (trace: TraceStep[]): ReceiptEvidence[] => {
   const seenImageIds = new Set<string>();
   const receipts: ReceiptEvidence[] = [];
@@ -1191,17 +1200,27 @@ const QAAgentFlow: React.FC<QAAgentFlowProps> = ({
                   const leftPct =
                     (segment.startMs / timelineLayout.totalMs) * 100;
                   const durationLabel = formatMs(segment.durationMs);
+                  const compactDurationLabel = formatTimelineBarDuration(
+                    segment.durationMs,
+                  );
                   const showToolName = step.type === "tools" && widthPct >= 12;
                   const showDuration = !showToolName && widthPct >= 6;
                   const visibleLabel = showToolName
                     ? step.content
                     : showDuration
-                      ? durationLabel
+                      ? compactDurationLabel
                       : "";
                   return (
                     <div
                       key={`bar-${segment.stepIndex}-${step.type}`}
                       data-timeline-lane={segment.lane}
+                      data-label-kind={
+                        showToolName
+                          ? "tool"
+                          : showDuration
+                            ? "duration"
+                            : "none"
+                      }
                       data-active={
                         activeStepIndices.includes(segment.stepIndex)
                           ? "true"
@@ -1221,13 +1240,15 @@ const QAAgentFlow: React.FC<QAAgentFlowProps> = ({
                         alignItems: "center",
                         justifyContent: "center",
                         color: "rgba(255,255,255,0.95)",
-                        fontSize: "0.7rem",
+                        fontSize: "clamp(0.58rem, 2.3vw, 0.7rem)",
                         fontFamily: "var(--font-mono, monospace)",
                         fontWeight: 600,
                         textShadow: "0 0 2px rgba(0,0,0,0.4)",
                         overflow: "hidden",
                         whiteSpace: "nowrap",
-                        padding: visibleLabel ? "0 0.25rem" : 0,
+                        padding: visibleLabel
+                          ? "0 clamp(0.125rem, 0.75vw, 0.25rem)"
+                          : 0,
                         boxSizing: "border-box",
                       }}
                     >

--- a/portfolio/components/ui/Figures/qaTimeline.test.ts
+++ b/portfolio/components/ui/Figures/qaTimeline.test.ts
@@ -1,0 +1,62 @@
+import type { TraceStep } from "../../../hooks/qaTypes";
+import { buildTimelineLayout } from "./qaTimeline";
+
+const makeStep = (step: Partial<TraceStep>): TraceStep => ({
+  type: "tools",
+  content: "Tool",
+  ...step,
+});
+
+describe("buildTimelineLayout", () => {
+  it("places overlapping tool calls on parallel lanes", () => {
+    const trace = [
+      makeStep({
+        type: "plan",
+        content: "Plan",
+        startOffsetMs: 0,
+        durationMs: 1000,
+      }),
+      makeStep({
+        content: "search_receipts",
+        startOffsetMs: 1000,
+        durationMs: 2000,
+      }),
+      makeStep({
+        content: "search_receipt_descriptions",
+        startOffsetMs: 1000,
+        durationMs: 1000,
+      }),
+      makeStep({
+        type: "synthesize",
+        content: "Answer",
+        startOffsetMs: 3000,
+        durationMs: 1000,
+      }),
+    ];
+
+    const layout = buildTimelineLayout(trace, 1000);
+
+    expect(layout.usesAbsoluteTiming).toBe(true);
+    expect(layout.laneCount).toBe(2);
+    expect(layout.hasParallelTools).toBe(true);
+    expect(layout.totalMs).toBe(4000);
+    expect(layout.segments.map((segment) => segment.lane)).toEqual([
+      0, 0, 1, 0,
+    ]);
+  });
+
+  it("keeps legacy traces on one sequential lane", () => {
+    const trace = [
+      makeStep({ type: "plan", content: "Plan", durationMs: 500 }),
+      makeStep({ content: "search_receipts", durationMs: 1500 }),
+    ];
+
+    const layout = buildTimelineLayout(trace, 1000);
+
+    expect(layout.usesAbsoluteTiming).toBe(false);
+    expect(layout.laneCount).toBe(1);
+    expect(layout.hasParallelTools).toBe(false);
+    expect(layout.totalMs).toBe(2000);
+    expect(layout.segments.map((segment) => segment.startMs)).toEqual([0, 500]);
+  });
+});

--- a/portfolio/components/ui/Figures/qaTimeline.test.ts
+++ b/portfolio/components/ui/Figures/qaTimeline.test.ts
@@ -1,5 +1,10 @@
 import type { TraceStep } from "../../../hooks/qaTypes";
-import { buildTimelineLayout } from "./qaTimeline";
+import {
+  buildTimelineLayout,
+  buildTimelinePlayback,
+  getActiveTimelineStepIndices,
+  getTimelineRevealPercent,
+} from "./qaTimeline";
 
 const makeStep = (step: Partial<TraceStep>): TraceStep => ({
   type: "tools",
@@ -39,6 +44,7 @@ describe("buildTimelineLayout", () => {
     expect(layout.usesAbsoluteTiming).toBe(true);
     expect(layout.laneCount).toBe(2);
     expect(layout.hasParallelTools).toBe(true);
+    expect(layout.parallelStepIndices).toEqual([1, 2]);
     expect(layout.totalMs).toBe(4000);
     expect(layout.segments.map((segment) => segment.lane)).toEqual([
       0, 0, 1, 0,
@@ -56,7 +62,74 @@ describe("buildTimelineLayout", () => {
     expect(layout.usesAbsoluteTiming).toBe(false);
     expect(layout.laneCount).toBe(1);
     expect(layout.hasParallelTools).toBe(false);
+    expect(layout.parallelStepIndices).toEqual([]);
     expect(layout.totalMs).toBe(2000);
     expect(layout.segments.map((segment) => segment.startMs)).toEqual([0, 500]);
+  });
+
+  it("preserves overlapping intervals when scaling absolute playback", () => {
+    const trace = [
+      makeStep({ type: "plan", startOffsetMs: 0, durationMs: 1000 }),
+      makeStep({
+        content: "search_receipts",
+        startOffsetMs: 1000,
+        durationMs: 2000,
+      }),
+      makeStep({
+        content: "search_receipt_descriptions",
+        startOffsetMs: 1000,
+        durationMs: 1000,
+      }),
+      makeStep({
+        type: "synthesize",
+        startOffsetMs: 3000,
+        durationMs: 1000,
+      }),
+    ];
+    const layout = buildTimelineLayout(trace, 1000);
+
+    const playback = buildTimelinePlayback(layout, {
+      targetTotalMs: 12000,
+      motionScale: 0.5,
+      minStepMs: 600,
+      maxStepMs: 3500,
+    });
+
+    expect(playback.totalMs).toBe(6000);
+    expect(playback.segments[1]).toMatchObject({
+      startMs: 1500,
+      durationMs: 3000,
+      endMs: 4500,
+    });
+    expect(playback.segments[2]).toMatchObject({
+      startMs: 1500,
+      durationMs: 1500,
+      endMs: 3000,
+    });
+    expect(getActiveTimelineStepIndices(playback.segments, 2000)).toEqual([
+      1, 2,
+    ]);
+  });
+
+  it("maps clamped sequential playback back to the raw timeline geometry", () => {
+    const trace = [
+      makeStep({ type: "plan", durationMs: 100 }),
+      makeStep({ type: "synthesize", durationMs: 10_000 }),
+    ];
+    const layout = buildTimelineLayout(trace, 1000);
+    const playback = buildTimelinePlayback(layout, {
+      targetTotalMs: 12_000,
+      motionScale: 1,
+      minStepMs: 600,
+      maxStepMs: 3500,
+    });
+
+    expect(playback.segments.map((segment) => segment.durationMs)).toEqual([
+      600, 3500,
+    ]);
+    expect(getTimelineRevealPercent(layout, playback, 600)).toBeCloseTo(
+      (100 / 10_100) * 100,
+    );
+    expect(getTimelineRevealPercent(layout, playback, 4100)).toBe(100);
   });
 });

--- a/portfolio/components/ui/Figures/qaTimeline.ts
+++ b/portfolio/components/ui/Figures/qaTimeline.ts
@@ -14,6 +14,20 @@ export interface TimelineLayout {
   laneCount: number;
   usesAbsoluteTiming: boolean;
   hasParallelTools: boolean;
+  parallelStepIndices: number[];
+}
+
+export interface TimelinePlaybackOptions {
+  targetTotalMs: number;
+  motionScale: number;
+  minStepMs: number;
+  maxStepMs: number;
+}
+
+export interface TimelinePlayback {
+  segments: TimelineSegment[];
+  totalMs: number;
+  boundariesMs: number[];
 }
 
 const getDuration = (step: TraceStep, defaultStepMs: number): number =>
@@ -78,20 +92,118 @@ export const buildTimelineLayout = (
   const toolSegments = segments.filter(
     (segment) => trace[segment.stepIndex]?.type === "tools",
   );
-  const hasParallelTools = toolSegments.some((segment, index) =>
-    toolSegments.some(
-      (candidate, candidateIndex) =>
-        candidateIndex !== index &&
-        candidate.startMs < segment.endMs &&
-        candidate.endMs > segment.startMs,
-    ),
-  );
+  const parallelStepIndices = toolSegments
+    .filter((segment, index) =>
+      toolSegments.some(
+        (candidate, candidateIndex) =>
+          candidateIndex !== index &&
+          candidate.startMs < segment.endMs &&
+          candidate.endMs > segment.startMs,
+      ),
+    )
+    .map((segment) => segment.stepIndex);
 
   return {
     segments,
     totalMs,
     laneCount: Math.max(1, laneEnds.length),
     usesAbsoluteTiming,
-    hasParallelTools,
+    hasParallelTools: parallelStepIndices.length > 0,
+    parallelStepIndices,
   };
+};
+
+export const buildTimelinePlayback = (
+  layout: TimelineLayout,
+  options: TimelinePlaybackOptions,
+): TimelinePlayback => {
+  const { targetTotalMs, motionScale, minStepMs, maxStepMs } = options;
+  let segments: TimelineSegment[];
+
+  if (layout.usesAbsoluteTiming) {
+    const scale = (targetTotalMs * motionScale) / layout.totalMs;
+    segments = layout.segments.map((segment) => {
+      const startMs = Math.round(segment.startMs * scale);
+      const durationMs = Math.round(segment.durationMs * scale);
+      return {
+        ...segment,
+        startMs,
+        durationMs,
+        endMs: startMs + durationMs,
+      };
+    });
+  } else {
+    const rawTotalMs = layout.segments.reduce(
+      (total, segment) => total + segment.durationMs,
+      0,
+    );
+    const durationScale = rawTotalMs > 0 ? targetTotalMs / rawTotalMs : 1;
+    let startMs = 0;
+
+    segments = layout.segments.map((segment) => {
+      const durationMs = Math.max(
+        minStepMs * motionScale,
+        Math.min(
+          maxStepMs * motionScale,
+          Math.round(segment.durationMs * durationScale * motionScale),
+        ),
+      );
+      const playbackSegment = {
+        ...segment,
+        startMs,
+        durationMs,
+        endMs: startMs + durationMs,
+      };
+      startMs += durationMs;
+      return playbackSegment;
+    });
+  }
+
+  const totalMs = Math.max(0, ...segments.map((segment) => segment.endMs));
+  const boundariesMs = Array.from(
+    new Set([
+      0,
+      totalMs,
+      ...segments.flatMap((segment) => [segment.startMs, segment.endMs]),
+    ]),
+  ).sort((a, b) => a - b);
+
+  return { segments, totalMs, boundariesMs };
+};
+
+export const getActiveTimelineStepIndices = (
+  segments: TimelineSegment[],
+  elapsedMs: number,
+): number[] =>
+  segments
+    .filter(
+      (segment) => segment.startMs <= elapsedMs && segment.endMs > elapsedMs,
+    )
+    .map((segment) => segment.stepIndex);
+
+export const getTimelineRevealPercent = (
+  layout: TimelineLayout,
+  playback: TimelinePlayback,
+  boundaryMs: number,
+): number => {
+  if (layout.totalMs <= 0 || playback.totalMs <= 0) return 0;
+
+  if (layout.usesAbsoluteTiming) {
+    return (boundaryMs / playback.totalMs) * 100;
+  }
+
+  const completedStepIndices = new Set(
+    playback.segments
+      .filter((segment) => segment.endMs <= boundaryMs)
+      .map((segment) => segment.stepIndex),
+  );
+  const revealedEndMs = layout.segments.reduce(
+    (furthestEndMs, segment) =>
+      completedStepIndices.has(segment.stepIndex)
+        ? Math.max(furthestEndMs, segment.endMs)
+        : furthestEndMs,
+    0,
+  );
+
+  return (revealedEndMs / layout.totalMs) * 100;
 };

--- a/portfolio/components/ui/Figures/qaTimeline.ts
+++ b/portfolio/components/ui/Figures/qaTimeline.ts
@@ -1,0 +1,97 @@
+import type { TraceStep } from "../../../hooks/qaTypes";
+
+export interface TimelineSegment {
+  stepIndex: number;
+  startMs: number;
+  durationMs: number;
+  endMs: number;
+  lane: number;
+}
+
+export interface TimelineLayout {
+  segments: TimelineSegment[];
+  totalMs: number;
+  laneCount: number;
+  usesAbsoluteTiming: boolean;
+  hasParallelTools: boolean;
+}
+
+const getDuration = (step: TraceStep, defaultStepMs: number): number =>
+  step.durationMs != null && step.durationMs > 0
+    ? step.durationMs
+    : defaultStepMs;
+
+export const buildTimelineLayout = (
+  trace: TraceStep[],
+  defaultStepMs: number,
+): TimelineLayout => {
+  const usesAbsoluteTiming =
+    trace.length > 0 &&
+    trace.every(
+      (step) =>
+        step.startOffsetMs != null && Number.isFinite(step.startOffsetMs),
+    );
+
+  const rawSegments: Omit<TimelineSegment, "lane">[] = [];
+  let sequentialStart = 0;
+
+  trace.forEach((step, stepIndex) => {
+    const durationMs = getDuration(step, defaultStepMs);
+    const startMs = usesAbsoluteTiming
+      ? Math.max(0, step.startOffsetMs ?? 0)
+      : sequentialStart;
+
+    rawSegments.push({
+      stepIndex,
+      startMs,
+      durationMs,
+      endMs: startMs + durationMs,
+    });
+    sequentialStart += durationMs;
+  });
+
+  const laneEnds: number[] = [];
+  const laneByStepIndex = new Map<number, number>();
+  const chronologicalSegments = [...rawSegments].sort(
+    (a, b) => a.startMs - b.startMs || a.stepIndex - b.stepIndex,
+  );
+
+  for (const segment of chronologicalSegments) {
+    let lane = laneEnds.findIndex((endMs) => endMs <= segment.startMs);
+    if (lane === -1) {
+      lane = laneEnds.length;
+      laneEnds.push(segment.endMs);
+    } else {
+      laneEnds[lane] = segment.endMs;
+    }
+    laneByStepIndex.set(segment.stepIndex, lane);
+  }
+
+  const segments = rawSegments.map((segment) => ({
+    ...segment,
+    lane: laneByStepIndex.get(segment.stepIndex) ?? 0,
+  }));
+  const totalMs = Math.max(
+    defaultStepMs,
+    ...segments.map((segment) => segment.endMs),
+  );
+  const toolSegments = segments.filter(
+    (segment) => trace[segment.stepIndex]?.type === "tools",
+  );
+  const hasParallelTools = toolSegments.some((segment, index) =>
+    toolSegments.some(
+      (candidate, candidateIndex) =>
+        candidateIndex !== index &&
+        candidate.startMs < segment.endMs &&
+        candidate.endMs > segment.startMs,
+    ),
+  );
+
+  return {
+    segments,
+    totalMs,
+    laneCount: Math.max(1, laneEnds.length),
+    usesAbsoluteTiming,
+    hasParallelTools,
+  };
+};

--- a/portfolio/e2e/fixtures/qa-agent-flow.ts
+++ b/portfolio/e2e/fixtures/qa-agent-flow.ts
@@ -34,7 +34,11 @@ const question0 = {
     },
     {
       type: "synthesize" as const,
-      content: "You spent $42.00 on groceries",
+      content: [
+        "# Grocery spending",
+        "",
+        "You spent $42.00 on groceries across receipts with valid dates and reasonable totals, excluding extreme OCR outliers so the summary reflects typical spending.",
+      ].join("\n"),
       detail: "3 receipts with grocery items identified",
       durationMs: 0,
       receipts: [

--- a/portfolio/e2e/fixtures/qa-agent-flow.ts
+++ b/portfolio/e2e/fixtures/qa-agent-flow.ts
@@ -37,6 +37,41 @@ const question0 = {
       content: "You spent $42.00 on groceries",
       detail: "3 receipts with grocery items identified",
       durationMs: 0,
+      receipts: [
+        {
+          imageId: "evidence-receipt-a",
+          merchant: "Neighborhood Market",
+          item: "Organic Milk",
+          amount: 6.49,
+          thumbnailKey: "assets/evidence-receipt-a.webp",
+          width: 300,
+          height: 900,
+        },
+        {
+          imageId: "evidence-receipt-a",
+          merchant: "Neighborhood Market",
+          item: "Greek Yogurt",
+          amount: 5.29,
+          thumbnailKey: "assets/evidence-receipt-a-duplicate.webp",
+          width: 300,
+          height: 900,
+        },
+        {
+          imageId: "evidence-receipt-b",
+          merchant: "Corner Grocer",
+          item: "Coffee",
+          amount: 12.99,
+          thumbnailKey: "assets/evidence-receipt-b.webp",
+          width: 320,
+          height: 960,
+        },
+      ],
+      structuredData: [
+        {
+          merchant: "Neighborhood Market",
+          items: [{ name: "Organic Milk", amount: 6.49 }],
+        },
+      ],
     },
   ],
   stats: {
@@ -115,6 +150,51 @@ const question2 = {
 
 /** All 3 mock questions indexed by questionIndex */
 export const mockQAQuestions = [question0, question1, question2];
+
+/** A trace with two tool calls sharing the same wall-clock interval. */
+export const mockParallelQAQuestion = {
+  question: "Which grocery searches ran together?",
+  questionIndex: 0,
+  traceId: "trace-parallel-tools",
+  trace: [
+    {
+      type: "plan" as const,
+      content: "comparison → parallel_search",
+      durationMs: 1000,
+      startOffsetMs: 0,
+    },
+    {
+      type: "agent" as const,
+      content: "Run complementary grocery searches",
+      durationMs: 1000,
+      startOffsetMs: 1000,
+    },
+    {
+      type: "tools" as const,
+      content: "search_receipts",
+      durationMs: 2000,
+      startOffsetMs: 2000,
+    },
+    {
+      type: "tools" as const,
+      content: "search_receipt_descriptions",
+      durationMs: 1200,
+      startOffsetMs: 2000,
+    },
+    {
+      type: "synthesize" as const,
+      content: "Both searches completed in parallel",
+      durationMs: 1000,
+      startOffsetMs: 4000,
+    },
+  ],
+  stats: {
+    llmCalls: 2,
+    toolInvocations: 2,
+    receiptsProcessed: 4,
+    cost: 0.004,
+  },
+};
 
 /** All distinct answer texts — useful for assertions */
 export const MOCK_ANSWERS = [

--- a/portfolio/e2e/qa-agent-flow.spec.ts
+++ b/portfolio/e2e/qa-agent-flow.spec.ts
@@ -308,6 +308,16 @@ test.describe("QAAgentFlow", () => {
       { timeout: 15_000 },
     );
     await expect(timeline.locator('[data-active="true"]')).toHaveCount(2);
+
+    const qaBoundary = page.locator('[data-figure-boundary="qa-agent"]');
+    const renderedHeights = await qaBoundary.evaluate((boundary) => ({
+      boundary: boundary.getBoundingClientRect().height,
+      component:
+        boundary.firstElementChild?.getBoundingClientRect().height ?? 0,
+    }));
+    expect(
+      Math.abs(renderedHeights.boundary - renderedHeights.component),
+    ).toBeLessThan(2);
   });
 
   test("answer updates when auto-advancing between questions", async ({

--- a/portfolio/e2e/qa-agent-flow.spec.ts
+++ b/portfolio/e2e/qa-agent-flow.spec.ts
@@ -336,9 +336,11 @@ test.describe("QAAgentFlow", () => {
                 "",
                 "## Breakdown",
                 "",
-                "- Neighborhood Market: $18.25",
-                "- Corner Grocer: $13.75",
-                "- Farmers Market: $10.00",
+                "| Store | Example item | Price range |",
+                "| --- | --- | ---: |",
+                "| Neighborhood Market | Organic Milk | $6.49–$8.99 |",
+                "| Corner Grocer | Coffee | $12.99–$15.99 |",
+                "| Farmers Market | Produce | $10.00–$18.25 |",
                 "",
                 "This longer explanation verifies that result content does not resize the outer visualization when it appears.",
               ].join("\n"),
@@ -401,6 +403,22 @@ test.describe("QAAgentFlow", () => {
     });
     await expect(detailsButton).toHaveAttribute("aria-expanded", "true");
     await expect(resultFrame.getByText("Structured receipts")).toBeVisible();
+    const markdownTable = resultFrame.getByRole("table");
+    await expect(markdownTable).toBeVisible();
+    await expect(
+      markdownTable.getByRole("columnheader", { name: "Store" }),
+    ).toBeVisible();
+    await expect(markdownTable.getByText("Neighborhood Market")).toBeVisible();
+    const tableScroller = resultFrame.getByTestId("qa-markdown-table-scroll");
+    const tableGeometry = await tableScroller.evaluate((element) => ({
+      overflowX: getComputedStyle(element).overflowX,
+      clientWidth: element.clientWidth,
+      scrollWidth: element.scrollWidth,
+    }));
+    expect(tableGeometry.overflowX).toBe("auto");
+    expect(tableGeometry.scrollWidth).toBeGreaterThanOrEqual(
+      tableGeometry.clientWidth,
+    );
     await page.waitForTimeout(2200);
     await expect(detailsButton).toHaveAttribute("aria-expanded", "true");
     await expect(

--- a/portfolio/e2e/qa-agent-flow.spec.ts
+++ b/portfolio/e2e/qa-agent-flow.spec.ts
@@ -159,6 +159,36 @@ test.describe("QAAgentFlow", () => {
     await expect(
       evidence.getByAltText("Neighborhood Market receipt"),
     ).toHaveAttribute("src", /evidence-receipt-a\.jpg$/);
+    await expect(
+      evidence.getByAltText("Neighborhood Market receipt"),
+    ).toHaveCSS("object-fit", "contain");
+
+    const evidenceGeometry = await evidence.evaluate((region) => {
+      const content = document.querySelector("#qa-result-content");
+      const list = region.querySelector('[role="list"]');
+      const thumbnails = Array.from(
+        region.querySelectorAll('[role="listitem"]'),
+      );
+      if (!content || !list || thumbnails.length === 0) return null;
+
+      const contentBottom = content.getBoundingClientRect().bottom;
+      return {
+        contentBottom,
+        listBottom: list.getBoundingClientRect().bottom,
+        receiptBottom: Math.max(
+          ...thumbnails.map(
+            (thumbnail) => thumbnail.getBoundingClientRect().bottom,
+          ),
+        ),
+      };
+    });
+    expect(evidenceGeometry).not.toBeNull();
+    expect(evidenceGeometry!.listBottom).toBeLessThanOrEqual(
+      evidenceGeometry!.contentBottom + 1,
+    );
+    expect(evidenceGeometry!.receiptBottom).toBeLessThanOrEqual(
+      evidenceGeometry!.contentBottom + 1,
+    );
 
     await page.getByRole("button", { name: "View full answer" }).click();
     await expect(page.getByText("Structured receipts")).toBeVisible();

--- a/portfolio/e2e/qa-agent-flow.spec.ts
+++ b/portfolio/e2e/qa-agent-flow.spec.ts
@@ -2,6 +2,7 @@ import { expect, test, devices } from "@playwright/test";
 
 import {
   mockQAMetadata,
+  mockParallelQAQuestion,
   mockQAQuestions,
   MOCK_ANSWERS,
   EXAMPLE_TRACE_ANSWER,
@@ -31,7 +32,7 @@ test.describe("QAAgentFlow", () => {
           `<svg xmlns="http://www.w3.org/2000/svg" width="300" height="400" viewBox="0 0 300 400">
             <rect width="300" height="400" fill="#e8e8e8"/>
             <text x="150" y="200" text-anchor="middle" fill="#666" font-family="sans-serif" font-size="12">Mock</text>
-          </svg>`
+          </svg>`,
         ),
       });
     });
@@ -43,7 +44,7 @@ test.describe("QAAgentFlow", () => {
         body: Buffer.from(
           `<svg xmlns="http://www.w3.org/2000/svg" width="300" height="400" viewBox="0 0 300 400">
             <rect width="300" height="400" fill="#e8e8e8"/>
-          </svg>`
+          </svg>`,
         ),
       });
     });
@@ -91,27 +92,112 @@ test.describe("QAAgentFlow", () => {
 
     // Wait for page to be ready
     await expect(
-      page.locator("h1", { hasText: "Introduction" })
-    ).toBeVisible({ timeout: 15_000 });
+      page.locator("h1:visible", { hasText: "Introduction" }),
+    ).toBeVisible({
+      timeout: 15_000,
+    });
 
     // Scroll to the QA section
-    const qaHeading = page.locator("h1", { hasText: "So Now What?" });
+    const qaHeading = page.locator("h1:visible", { hasText: "So Now What?" });
     await qaHeading.scrollIntoViewIfNeeded();
 
     // Wait for one of the real mock answers to appear (not the EXAMPLE_TRACE)
     const anyMockAnswer = page.locator("p").filter({
       hasText: new RegExp(
         MOCK_ANSWERS.map((a) => a.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")).join(
-          "|"
-        )
+          "|",
+        ),
       ),
     });
     await expect(anyMockAnswer.first()).toBeVisible({ timeout: 30_000 });
 
     // The EXAMPLE_TRACE answer should NOT be visible
     await expect(
-      page.getByText(EXAMPLE_TRACE_ANSWER, { exact: false })
+      page.getByText(EXAMPLE_TRACE_ANSWER, { exact: false }),
     ).not.toBeVisible();
+  });
+
+  test("renders deduplicated receipt evidence with image fallback", async ({
+    page,
+  }) => {
+    await page.route("**/assets/evidence-receipt-a.webp", async (route) => {
+      await route.fulfill({ status: 404 });
+    });
+
+    await page.route("**/qa/visualization*", async (route) => {
+      const url = new URL(route.request().url());
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(
+          url.searchParams.has("index")
+            ? { questions: [mockQAQuestions[0]] }
+            : { metadata: { total_questions: 1 }, questions: [] },
+        ),
+      });
+    });
+
+    await page.goto("/receipt");
+    await expect(
+      page.locator("h1:visible", { hasText: "Introduction" }),
+    ).toBeVisible({ timeout: 15_000 });
+
+    const qaHeading = page.locator("h1:visible", { hasText: "So Now What?" });
+    await qaHeading.scrollIntoViewIfNeeded();
+    await expect(page.getByText(MOCK_ANSWERS[0], { exact: false })).toBeVisible(
+      { timeout: 30_000 },
+    );
+
+    const evidence = page.getByRole("region", {
+      name: "Receipt evidence",
+    });
+    await expect(evidence).toBeVisible();
+    await expect(
+      evidence.getByText("2 receipts", { exact: true }),
+    ).toBeVisible();
+    await expect(evidence.locator("img")).toHaveCount(2);
+    await expect(
+      evidence.getByAltText("Neighborhood Market receipt"),
+    ).toHaveAttribute("src", /evidence-receipt-a\.jpg$/);
+
+    await expect(page.getByText("Structured receipts")).toBeVisible();
+    await expect(page.getByText("Organic Milk")).toBeVisible();
+    await expect(page.getByText("$6.49")).toBeVisible();
+  });
+
+  test("renders concurrent tool calls on parallel timeline lanes", async ({
+    page,
+  }) => {
+    await page.route("**/qa/visualization*", async (route) => {
+      const url = new URL(route.request().url());
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(
+          url.searchParams.has("index")
+            ? { questions: [mockParallelQAQuestion] }
+            : { metadata: { total_questions: 1 }, questions: [] },
+        ),
+      });
+    });
+
+    await page.goto("/receipt?receiptMotionScale=0.1");
+    await expect(
+      page.locator("h1:visible", { hasText: "Introduction" }),
+    ).toBeVisible({ timeout: 15_000 });
+
+    const qaHeading = page.locator("h1:visible", { hasText: "So Now What?" });
+    await qaHeading.scrollIntoViewIfNeeded();
+
+    await expect(page.getByTestId("parallel-tool-indicator")).toContainText(
+      "Parallel tool calls · 2 lanes",
+      { timeout: 15_000 },
+    );
+    const timeline = page.getByLabel("QA trace wall-clock timeline");
+    await expect(timeline.locator('[data-timeline-lane="1"]')).toHaveCount(1);
+    await expect(
+      timeline.getByLabel(/search_receipt_descriptions/),
+    ).toBeAttached();
   });
 
   test("answer updates when auto-advancing between questions", async ({
@@ -141,18 +227,20 @@ test.describe("QAAgentFlow", () => {
 
     await page.goto("/receipt");
     await expect(
-      page.locator("h1", { hasText: "Introduction" })
-    ).toBeVisible({ timeout: 15_000 });
+      page.locator("h1:visible", { hasText: "Introduction" }),
+    ).toBeVisible({
+      timeout: 15_000,
+    });
 
-    const qaHeading = page.locator("h1", { hasText: "So Now What?" });
+    const qaHeading = page.locator("h1:visible", { hasText: "So Now What?" });
     await qaHeading.scrollIntoViewIfNeeded();
 
     // Wait for the first answer to appear
     const anyMockAnswer = page.locator("p").filter({
       hasText: new RegExp(
         MOCK_ANSWERS.map((a) => a.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")).join(
-          "|"
-        )
+          "|",
+        ),
       ),
     });
     await expect(anyMockAnswer.first()).toBeVisible({ timeout: 30_000 });
@@ -164,7 +252,7 @@ test.describe("QAAgentFlow", () => {
 
     // Wait for that first answer to disappear (cycle reset)
     await expect(
-      page.getByText(firstAnswer!, { exact: false })
+      page.getByText(firstAnswer!, { exact: false }),
     ).not.toBeVisible({ timeout: 30_000 });
 
     // Wait for a different answer to appear
@@ -173,7 +261,7 @@ test.describe("QAAgentFlow", () => {
       hasText: new RegExp(
         otherAnswers
           .map((a) => a.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
-          .join("|")
+          .join("|"),
       ),
     });
     await expect(otherAnswerLocator.first()).toBeVisible({ timeout: 60_000 });
@@ -253,10 +341,12 @@ test.describe("QAAgentFlow", () => {
 
     await page.goto("/receipt");
     await expect(
-      page.locator("h1", { hasText: "Introduction" })
-    ).toBeVisible({ timeout: 15_000 });
+      page.locator("h1:visible", { hasText: "Introduction" }),
+    ).toBeVisible({
+      timeout: 15_000,
+    });
 
-    const qaHeading = page.locator("h1", { hasText: "So Now What?" });
+    const qaHeading = page.locator("h1:visible", { hasText: "So Now What?" });
     await qaHeading.scrollIntoViewIfNeeded();
 
     // Phase 1: Wait for the real answer from mock data to appear.
@@ -264,8 +354,8 @@ test.describe("QAAgentFlow", () => {
     const anyMockAnswer = page.locator("p").filter({
       hasText: new RegExp(
         MOCK_ANSWERS.map((a) => a.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")).join(
-          "|"
-        )
+          "|",
+        ),
       ),
     });
     await expect(anyMockAnswer.first()).toBeVisible({ timeout: 30_000 });
@@ -280,7 +370,7 @@ test.describe("QAAgentFlow", () => {
     // The other 2 indices returned empty → not cached.
     // After first cycle, advance() hits an uncached index → null data.
     await expect(
-      page.getByText(EXAMPLE_TRACE_ANSWER, { exact: false })
+      page.getByText(EXAMPLE_TRACE_ANSWER, { exact: false }),
     ).toBeVisible({ timeout: 60_000 });
 
     // Phase 3: Wait for the EXAMPLE_TRACE cycle to complete (~26s for
@@ -299,7 +389,7 @@ test.describe("QAAgentFlow", () => {
     // If the bug is present, this assertion FAILS (answer stays stuck).
     // If the bug is fixed, the reset fires and the answer disappears.
     await expect(
-      page.getByText(EXAMPLE_TRACE_ANSWER, { exact: false })
+      page.getByText(EXAMPLE_TRACE_ANSWER, { exact: false }),
     ).not.toBeVisible({ timeout: 15_000 });
   });
 
@@ -331,18 +421,20 @@ test.describe("QAAgentFlow", () => {
 
     await page.goto("/receipt");
     await expect(
-      page.locator("h1", { hasText: "Introduction" })
-    ).toBeVisible({ timeout: 15_000 });
+      page.locator("h1:visible", { hasText: "Introduction" }),
+    ).toBeVisible({
+      timeout: 15_000,
+    });
 
-    const qaHeading = page.locator("h1", { hasText: "So Now What?" });
+    const qaHeading = page.locator("h1:visible", { hasText: "So Now What?" });
     await qaHeading.scrollIntoViewIfNeeded();
 
     // Wait for the component to render and animate through one cycle
     const anyMockAnswer = page.locator("p").filter({
       hasText: new RegExp(
         MOCK_ANSWERS.map((a) => a.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")).join(
-          "|"
-        )
+          "|",
+        ),
       ),
     });
     await expect(anyMockAnswer.first()).toBeVisible({ timeout: 30_000 });

--- a/portfolio/e2e/qa-agent-flow.spec.ts
+++ b/portfolio/e2e/qa-agent-flow.spec.ts
@@ -176,6 +176,8 @@ test.describe("QAAgentFlow", () => {
           ? {
               ...step,
               content: [
+                "# Grocery spending",
+                "",
                 "You spent $42.00 on groceries.",
                 "",
                 "## Breakdown",
@@ -204,7 +206,7 @@ test.describe("QAAgentFlow", () => {
       });
     });
 
-    await page.goto("/receipt?receiptMotionScale=0.5");
+    await page.goto("/receipt?receiptMotionScale=0.2");
     await expect(
       page.locator("h1:visible", { hasText: "Introduction" }),
     ).toBeVisible({ timeout: 15_000 });
@@ -245,15 +247,20 @@ test.describe("QAAgentFlow", () => {
     });
     await expect(detailsButton).toHaveAttribute("aria-expanded", "true");
     await expect(resultFrame.getByText("Structured receipts")).toBeVisible();
+    await page.waitForTimeout(2200);
+    await expect(detailsButton).toHaveAttribute("aria-expanded", "true");
+    await expect(
+      resultFrame.getByText("You spent $42.00 on groceries.", {
+        exact: false,
+      }),
+    ).toBeVisible();
 
     const afterExpand = await resultFrame.evaluate((element) => ({
       height: element.getBoundingClientRect().height,
       scrollY: window.scrollY,
     }));
     expect(Math.abs(afterExpand.height - beforeReveal.height)).toBeLessThan(1);
-    expect(Math.abs(afterExpand.scrollY - beforeExpandScrollY)).toBeLessThan(
-      2,
-    );
+    expect(Math.abs(afterExpand.scrollY - beforeExpandScrollY)).toBeLessThan(2);
   });
 
   test("renders concurrent tool calls on parallel timeline lanes", async ({
@@ -272,7 +279,7 @@ test.describe("QAAgentFlow", () => {
       });
     });
 
-    await page.goto("/receipt?receiptMotionScale=0.1");
+    await page.goto("/receipt?receiptMotionScale=0.5");
     await expect(
       page.locator("h1:visible", { hasText: "Introduction" }),
     ).toBeVisible({ timeout: 15_000 });
@@ -289,6 +296,18 @@ test.describe("QAAgentFlow", () => {
     await expect(
       timeline.getByLabel(/search_receipt_descriptions/),
     ).toBeAttached();
+    const parallelDetails = page.getByRole("list", {
+      name: "Parallel tool call details",
+    });
+    await expect(parallelDetails.getByText("search_receipts")).toBeVisible();
+    await expect(
+      parallelDetails.getByText("search_receipt_descriptions"),
+    ).toBeVisible();
+    await expect(page.getByTestId("active-parallel-tools")).toContainText(
+      "2 tools running together",
+      { timeout: 15_000 },
+    );
+    await expect(timeline.locator('[data-active="true"]')).toHaveCount(2);
   });
 
   test("answer updates when auto-advancing between questions", async ({

--- a/portfolio/e2e/qa-agent-flow.spec.ts
+++ b/portfolio/e2e/qa-agent-flow.spec.ts
@@ -163,6 +163,25 @@ test.describe("QAAgentFlow", () => {
       evidence.getByAltText("Neighborhood Market receipt"),
     ).toHaveCSS("object-fit", "contain");
 
+    const thumbnailFrames = await evidence
+      .getByRole("listitem")
+      .evaluateAll((frames) =>
+        frames.map((frame) => {
+          const style = getComputedStyle(frame);
+          return {
+            aspectRatio: frame.clientWidth / frame.clientHeight,
+            backgroundColor: style.backgroundColor,
+            borderWidth: style.borderTopWidth,
+          };
+        }),
+      );
+    expect(thumbnailFrames).toHaveLength(2);
+    for (const frame of thumbnailFrames) {
+      expect(frame.aspectRatio).toBeCloseTo(300 / 900, 2);
+      expect(frame.backgroundColor).toBe("rgba(0, 0, 0, 0)");
+      expect(frame.borderWidth).toBe("0px");
+    }
+
     const evidenceGeometry = await evidence.evaluate((region) => {
       const content = document.querySelector("#qa-result-content");
       const list = region.querySelector('[role="list"]');

--- a/portfolio/e2e/qa-agent-flow.spec.ts
+++ b/portfolio/e2e/qa-agent-flow.spec.ts
@@ -160,9 +160,100 @@ test.describe("QAAgentFlow", () => {
       evidence.getByAltText("Neighborhood Market receipt"),
     ).toHaveAttribute("src", /evidence-receipt-a\.jpg$/);
 
+    await page.getByRole("button", { name: "View full answer" }).click();
     await expect(page.getByText("Structured receipts")).toBeVisible();
     await expect(page.getByText("Organic Milk")).toBeVisible();
     await expect(page.getByText("$6.49")).toBeVisible();
+  });
+
+  test("keeps the result frame stable while revealing and expanding the answer", async ({
+    page,
+  }) => {
+    const longAnswerQuestion = {
+      ...mockQAQuestions[0],
+      trace: mockQAQuestions[0].trace.map((step) =>
+        step.type === "synthesize"
+          ? {
+              ...step,
+              content: [
+                "You spent $42.00 on groceries.",
+                "",
+                "## Breakdown",
+                "",
+                "- Neighborhood Market: $18.25",
+                "- Corner Grocer: $13.75",
+                "- Farmers Market: $10.00",
+                "",
+                "This longer explanation verifies that result content does not resize the outer visualization when it appears.",
+              ].join("\n"),
+            }
+          : step,
+      ),
+    };
+
+    await page.route("**/qa/visualization*", async (route) => {
+      const url = new URL(route.request().url());
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(
+          url.searchParams.has("index")
+            ? { questions: [longAnswerQuestion] }
+            : { metadata: { total_questions: 1 }, questions: [] },
+        ),
+      });
+    });
+
+    await page.goto("/receipt?receiptMotionScale=0.5");
+    await expect(
+      page.locator("h1:visible", { hasText: "Introduction" }),
+    ).toBeVisible({ timeout: 15_000 });
+
+    const qaHeading = page.locator("h1:visible", { hasText: "So Now What?" });
+    await qaHeading.scrollIntoViewIfNeeded();
+
+    const resultFrame = page.getByTestId("qa-result-frame");
+    await expect(resultFrame).toBeVisible();
+    await expect(resultFrame.getByText("Answer pending")).toBeVisible();
+    await resultFrame.scrollIntoViewIfNeeded();
+
+    const beforeReveal = await resultFrame.evaluate((element) => ({
+      height: element.getBoundingClientRect().height,
+      scrollY: window.scrollY,
+    }));
+
+    await expect(
+      resultFrame.getByText("You spent $42.00 on groceries.", {
+        exact: false,
+      }),
+    ).toBeVisible({ timeout: 15_000 });
+
+    const afterReveal = await resultFrame.evaluate((element) => ({
+      height: element.getBoundingClientRect().height,
+      scrollY: window.scrollY,
+    }));
+    expect(Math.abs(afterReveal.height - beforeReveal.height)).toBeLessThan(1);
+    expect(Math.abs(afterReveal.scrollY - beforeReveal.scrollY)).toBeLessThan(
+      2,
+    );
+
+    const detailsButton = resultFrame.getByTestId("qa-result-details-toggle");
+    await detailsButton.scrollIntoViewIfNeeded();
+    const beforeExpandScrollY = await page.evaluate(() => window.scrollY);
+    await detailsButton.evaluate((element) => {
+      (element as HTMLButtonElement).click();
+    });
+    await expect(detailsButton).toHaveAttribute("aria-expanded", "true");
+    await expect(resultFrame.getByText("Structured receipts")).toBeVisible();
+
+    const afterExpand = await resultFrame.evaluate((element) => ({
+      height: element.getBoundingClientRect().height,
+      scrollY: window.scrollY,
+    }));
+    expect(Math.abs(afterExpand.height - beforeReveal.height)).toBeLessThan(1);
+    expect(Math.abs(afterExpand.scrollY - beforeExpandScrollY)).toBeLessThan(
+      2,
+    );
   });
 
   test("renders concurrent tool calls on parallel timeline lanes", async ({

--- a/portfolio/e2e/qa-agent-flow.spec.ts
+++ b/portfolio/e2e/qa-agent-flow.spec.ts
@@ -120,6 +120,31 @@ test.describe("QAAgentFlow", () => {
   test("renders deduplicated receipt evidence with image fallback", async ({
     page,
   }) => {
+    const denseEvidenceQuestion = {
+      ...mockQAQuestions[0],
+      trace: mockQAQuestions[0].trace.map((step) =>
+        step.type === "synthesize"
+          ? {
+              ...step,
+              receipts: [
+                ...("receipts" in step && Array.isArray(step.receipts)
+                  ? step.receipts
+                  : []),
+                ...[900, 720, 640, 560, 480, 400].map((width, index) => ({
+                  imageId: `dense-evidence-${index}`,
+                  merchant: `Dense Merchant ${index + 1}`,
+                  item: `Item ${index + 1}`,
+                  amount: index + 1,
+                  thumbnailKey: `assets/dense-evidence-${index}.webp`,
+                  width,
+                  height: 900,
+                })),
+              ],
+            }
+          : step,
+      ),
+    };
+
     await page.route("**/assets/evidence-receipt-a.webp", async (route) => {
       await route.fulfill({ status: 404 });
     });
@@ -131,7 +156,7 @@ test.describe("QAAgentFlow", () => {
         contentType: "application/json",
         body: JSON.stringify(
           url.searchParams.has("index")
-            ? { questions: [mockQAQuestions[0]] }
+            ? { questions: [denseEvidenceQuestion] }
             : { metadata: { total_questions: 1 }, questions: [] },
         ),
       });
@@ -153,9 +178,9 @@ test.describe("QAAgentFlow", () => {
     });
     await expect(evidence).toBeVisible();
     await expect(
-      evidence.getByText("2 receipts", { exact: true }),
+      evidence.getByText("8 receipts", { exact: true }),
     ).toBeVisible();
-    await expect(evidence.locator("img")).toHaveCount(2);
+    await expect(evidence.locator("img")).toHaveCount(8);
     await expect(
       evidence.getByAltText("Neighborhood Market receipt"),
     ).toHaveAttribute("src", /evidence-receipt-a\.jpg$/);
@@ -170,44 +195,124 @@ test.describe("QAAgentFlow", () => {
           const style = getComputedStyle(frame);
           return {
             aspectRatio: frame.clientWidth / frame.clientHeight,
+            sourceAspectRatio: Number(
+              frame.getAttribute("data-source-aspect-ratio"),
+            ),
             backgroundColor: style.backgroundColor,
             borderWidth: style.borderTopWidth,
+            borderRadius: style.borderRadius,
+            overflow: style.overflow,
           };
         }),
       );
-    expect(thumbnailFrames).toHaveLength(2);
+    expect(thumbnailFrames).toHaveLength(8);
     for (const frame of thumbnailFrames) {
-      expect(frame.aspectRatio).toBeCloseTo(300 / 900, 2);
+      expect(frame.aspectRatio).toBeCloseTo(frame.sourceAspectRatio, 2);
       expect(frame.backgroundColor).toBe("rgba(0, 0, 0, 0)");
       expect(frame.borderWidth).toBe("0px");
+      expect(frame.borderRadius).toBe("0px");
+      expect(frame.overflow).toBe("visible");
     }
 
+    await page.waitForTimeout(500);
     const evidenceGeometry = await evidence.evaluate((region) => {
-      const content = document.querySelector("#qa-result-content");
       const list = region.querySelector('[role="list"]');
       const thumbnails = Array.from(
         region.querySelectorAll('[role="listitem"]'),
       );
-      if (!content || !list || thumbnails.length === 0) return null;
+      if (!list || thumbnails.length === 0) return null;
 
-      const contentBottom = content.getBoundingClientRect().bottom;
+      const getClipping = (thumbnail: Element) => {
+        const receiptRect = thumbnail.getBoundingClientRect();
+        const clippingAncestors: Array<{
+          label: string;
+          overflowX: string;
+          overflowY: string;
+          clipped: { left: number; top: number; right: number; bottom: number };
+        }> = [];
+        let ancestor = thumbnail.parentElement;
+
+        while (ancestor) {
+          const style = getComputedStyle(ancestor);
+          const clipsX = style.overflowX !== "visible";
+          const clipsY = style.overflowY !== "visible";
+          if (clipsX || clipsY) {
+            const ancestorRect = ancestor.getBoundingClientRect();
+            clippingAncestors.push({
+              label:
+                ancestor.id ||
+                ancestor.getAttribute("data-testid") ||
+                ancestor.getAttribute("role") ||
+                ancestor.tagName,
+              overflowX: style.overflowX,
+              overflowY: style.overflowY,
+              clipped: {
+                left: clipsX
+                  ? Math.max(0, ancestorRect.left - receiptRect.left)
+                  : 0,
+                top: clipsY
+                  ? Math.max(0, ancestorRect.top - receiptRect.top)
+                  : 0,
+                right: clipsX
+                  ? Math.max(0, receiptRect.right - ancestorRect.right)
+                  : 0,
+                bottom: clipsY
+                  ? Math.max(0, receiptRect.bottom - ancestorRect.bottom)
+                  : 0,
+              },
+            });
+          }
+          ancestor = ancestor.parentElement;
+        }
+
+        return clippingAncestors;
+      };
+
       return {
-        contentBottom,
-        listBottom: list.getBoundingClientRect().bottom,
-        receiptBottom: Math.max(
-          ...thumbnails.map(
-            (thumbnail) => thumbnail.getBoundingClientRect().bottom,
-          ),
-        ),
+        listOverflow: getComputedStyle(list).overflow,
+        layout: {
+          availableWidth: list.getAttribute("data-available-width"),
+          overlapRatio: list.getAttribute("data-overlap-ratio"),
+          thumbnailHeight: list.getAttribute("data-thumbnail-height"),
+          listRect: list.getBoundingClientRect().toJSON(),
+        },
+        receipts: thumbnails.map((thumbnail) => ({
+          clippingAncestors: getClipping(thumbnail),
+          image: (() => {
+            const image = thumbnail.querySelector("img");
+            if (!image) return null;
+            const frameRect = thumbnail.getBoundingClientRect();
+            const imageRect = image.getBoundingClientRect();
+            return {
+              left: Math.abs(imageRect.left - frameRect.left),
+              top: Math.abs(imageRect.top - frameRect.top),
+              right: Math.abs(imageRect.right - frameRect.right),
+              bottom: Math.abs(imageRect.bottom - frameRect.bottom),
+            };
+          })(),
+        })),
       };
     });
     expect(evidenceGeometry).not.toBeNull();
-    expect(evidenceGeometry!.listBottom).toBeLessThanOrEqual(
-      evidenceGeometry!.contentBottom + 1,
-    );
-    expect(evidenceGeometry!.receiptBottom).toBeLessThanOrEqual(
-      evidenceGeometry!.contentBottom + 1,
-    );
+    expect(evidenceGeometry!.listOverflow).toBe("visible");
+    for (const receipt of evidenceGeometry!.receipts) {
+      expect(receipt.image).not.toBeNull();
+      expect(receipt.image!.left).toBeLessThanOrEqual(1);
+      expect(receipt.image!.top).toBeLessThanOrEqual(1);
+      expect(receipt.image!.right).toBeLessThanOrEqual(1);
+      expect(receipt.image!.bottom).toBeLessThanOrEqual(1);
+
+      for (const ancestor of receipt.clippingAncestors) {
+        const edgeContext = JSON.stringify({
+          ancestor,
+          layout: evidenceGeometry!.layout,
+        });
+        expect(ancestor.clipped.left, edgeContext).toBeLessThanOrEqual(1);
+        expect(ancestor.clipped.top, edgeContext).toBeLessThanOrEqual(1);
+        expect(ancestor.clipped.right, edgeContext).toBeLessThanOrEqual(1);
+        expect(ancestor.clipped.bottom, edgeContext).toBeLessThanOrEqual(1);
+      }
+    }
 
     await page.getByRole("button", { name: "View full answer" }).click();
     await expect(page.getByText("Structured receipts")).toBeVisible();

--- a/portfolio/e2e/qa-agent-flow.spec.ts
+++ b/portfolio/e2e/qa-agent-flow.spec.ts
@@ -309,6 +309,15 @@ test.describe("QAAgentFlow", () => {
     );
     await expect(timeline.locator('[data-active="true"]')).toHaveCount(2);
 
+    const durationBars = timeline.locator('[data-label-kind="duration"]');
+    await expect(durationBars).toHaveText(["1s", "1s", "1s"]);
+    const overflowingDurationLabels = await durationBars.evaluateAll((bars) =>
+      bars
+        .filter((bar) => bar.scrollWidth > bar.clientWidth)
+        .map((bar) => bar.textContent),
+    );
+    expect(overflowingDurationLabels).toEqual([]);
+
     const qaBoundary = page.locator('[data-figure-boundary="qa-agent"]');
     const renderedHeights = await qaBoundary.evaluate((boundary) => ({
       boundary: boundary.getBoundingClientRect().height,

--- a/portfolio/hooks/qaTypes.ts
+++ b/portfolio/hooks/qaTypes.ts
@@ -22,6 +22,8 @@ export interface TraceStep {
   detail?: string;
   /** Step duration in milliseconds (from LangSmith trace timestamps) */
   durationMs?: number;
+  /** Milliseconds from the trace start; enables parallel timeline lanes. */
+  startOffsetMs?: number;
   receipts?: ReceiptEvidence[];
   structuredData?: StructuredReceipt[];
 }

--- a/portfolio/package-lock.json
+++ b/portfolio/package-lock.json
@@ -14,7 +14,8 @@
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
         "react-intersection-observer": "^10.0.3",
-        "react-markdown": "^10.1.0"
+        "react-markdown": "^10.1.0",
+        "remark-gfm": "^4.0.1"
       },
       "devDependencies": {
         "@babel/plugin-syntax-flow": "^7.26.0",
@@ -101,6 +102,7 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -680,6 +682,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -703,6 +706,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2867,6 +2871,7 @@
       "integrity": "sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "playwright": "1.61.0"
       },
@@ -3317,6 +3322,7 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -3626,6 +3632,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3636,6 +3643,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3733,6 +3741,7 @@
       "integrity": "sha512-npiaib8XzbjtzS2N4HlqPvlpxpmZ14FjSJrteZpPxGUaYPlvhzlzUZ4mZyABo0EFrOWnvyd0Xxroq//hKhtAWg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.53.0",
         "@typescript-eslint/types": "8.53.0",
@@ -4262,6 +4271,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5002,6 +5012,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.42",
         "caniuse-lite": "^1.0.30001803",
@@ -5975,7 +5986,8 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1467305.tgz",
       "integrity": "sha512-LxwMLqBoPPGpMdRL4NkLFRNy3QLp6Uqa7GNp1v6JaBheop2QrB9Q7q0A/q/CYYP9sBfZdHOyszVx4gc9zyk7ow==",
       "dev": true,
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/doctrine": {
       "version": "2.1.0",
@@ -6375,6 +6387,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6560,6 +6573,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -7863,6 +7877,7 @@
       "integrity": "sha512-emn+JoJjrN9YTpRDS5it/UI2SO9BAE37T6I3d963RxcZ81G9A4pr2SZTEiiaiKbzx+NKRg5BZ89fCL7gCJCUog==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -10069,6 +10084,7 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -10759,6 +10775,16 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/marky": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/marky/-/marky-1.3.0.tgz",
@@ -10774,6 +10800,34 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/mdast-util-from-markdown": {
@@ -10794,6 +10848,107 @@
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0",
         "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -11057,6 +11212,127 @@
         "micromark-util-subtokenize": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/micromark-factory-destination": {
@@ -12418,6 +12694,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -12754,6 +13031,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
       "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -12763,6 +13041,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
       "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -12893,6 +13172,24 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/remark-parse": {
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
@@ -12920,6 +13217,21 @@
         "mdast-util-to-hast": "^13.0.0",
         "unified": "^11.0.0",
         "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -14346,6 +14658,7 @@
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -14695,6 +15008,7 @@
       "integrity": "sha512-ZkJ2G7mZrbxrKxinTQMjFqsCoYY6a5Luwv2GKbTnBCEgV2ihYm5CflA9JnJAwH0pZWavqfYxmDkFHPt4yx2oDQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@gerrit0/mini-shiki": "^3.17.0",
         "lunr": "^2.3.9",
@@ -14785,6 +15099,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -15820,6 +16135,7 @@
       "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/portfolio/package.json
+++ b/portfolio/package.json
@@ -9,7 +9,8 @@
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "react-intersection-observer": "^10.0.3",
-    "react-markdown": "^10.1.0"
+    "react-markdown": "^10.1.0",
+    "remark-gfm": "^4.0.1"
   },
   "scripts": {
     "dev": "next dev --turbopack",

--- a/portfolio/styles/Receipt.module.css
+++ b/portfolio/styles/Receipt.module.css
@@ -46,6 +46,13 @@
   overflow: visible;
 }
 
+/* Keep the QA estimate while lazy, then let its responsive content own height. */
+.figureBoundary[data-figure-boundary="qa-agent"]:not(
+    [data-lazy-pending="true"]
+  ) {
+  min-height: 0;
+}
+
 @media (max-width: 768px) {
   .figureBoundary {
     min-height: var(

--- a/receipt_langsmith/receipt_langsmith/spark/qa_viz_cache_helpers.py
+++ b/receipt_langsmith/receipt_langsmith/spark/qa_viz_cache_helpers.py
@@ -297,10 +297,13 @@ def derive_trace_steps(
 ) -> list[dict]:
     """Derive trace steps from child runs for the React component.
 
-    Maps each child run to a TraceStep with type, content, detail, and
-    durationMs based on the node name, outputs, and timestamps.
+    Maps each child run to a TraceStep with type, content, detail,
+    durationMs, and startOffsetMs based on the node name, outputs, and
+    timestamps.
     """
     steps: list[dict] = []
+    timing_runs = all_runs if all_runs is not None else child_runs
+    trace_start = _get_trace_start_seconds(timing_runs)
 
     for run in child_runs:
         name = run.get("name", "").lower()
@@ -310,7 +313,8 @@ def derive_trace_steps(
         step_type = _classify_run(name, run_type)
 
         # Expand ToolNode wrappers: depth-1 "tools" node has run_type="chain",
-        # but its depth-2 children have run_type="tool" with individual details.
+        # Its depth-2 children have run_type="tool" with individual
+        # details.
         if step_type is None and "tool" in name and all_runs is not None:
             wrapper_id = run.get("id", "")
             tool_children = sorted(
@@ -329,7 +333,7 @@ def derive_trace_steps(
                                 if child_inputs
                                 else ""
                             ),
-                            "durationMs": _compute_duration_ms(child),
+                            **_build_timing_fields(child, trace_start),
                         }
                     )
             if tool_children:
@@ -340,7 +344,7 @@ def derive_trace_steps(
 
         content = ""
         detail = ""
-        duration_ms = _compute_duration_ms(run)
+        timing_fields = _build_timing_fields(run, trace_start)
 
         if step_type == "plan":
             content = outputs.get("query", "") or outputs.get("question", "")
@@ -372,7 +376,7 @@ def derive_trace_steps(
                     "type": "synthesize",
                     "content": content,
                     "detail": detail,
-                    "durationMs": duration_ms,
+                    **timing_fields,
                     "receipts": receipts,
                 }
             )
@@ -383,7 +387,7 @@ def derive_trace_steps(
                 "type": step_type,
                 "content": content,
                 "detail": detail,
-                "durationMs": duration_ms,
+                **timing_fields,
             }
         )
 
@@ -407,29 +411,56 @@ def _classify_run(name: str, run_type: str) -> Optional[str]:
     return None
 
 
-def _compute_duration_ms(run: dict) -> Optional[int]:
-    """Compute step duration in milliseconds from start_time and end_time."""
-    start = run.get("start_time")
-    end = run.get("end_time")
-    if start is None or end is None:
+def _timestamp_seconds(value: Any) -> Optional[float]:
+    """Convert a supported trace timestamp value to epoch seconds."""
+    if value is None:
         return None
 
     try:
-        if isinstance(start, str) and isinstance(end, str):
-            fmt = "%Y-%m-%d %H:%M:%S"
-            s = datetime.strptime(start[:19], fmt)
-            e = datetime.strptime(end[:19], fmt)
-            return max(int((e - s).total_seconds() * 1000), 0)
-
-        if hasattr(start, "timestamp") and hasattr(end, "timestamp"):
-            return max(int((end.timestamp() - start.timestamp()) * 1000), 0)
-
-        if isinstance(start, (int, float)) and isinstance(end, (int, float)):
-            return max(int((end - start) * 1000), 0)
+        if isinstance(value, str):
+            normalized = value.strip().replace("Z", "+00:00")
+            return datetime.fromisoformat(normalized).timestamp()
+        if hasattr(value, "timestamp"):
+            return float(value.timestamp())
+        if isinstance(value, (int, float)):
+            return float(value)
     except (ValueError, TypeError, AttributeError, OverflowError):
         return None
-
     return None
+
+
+def _compute_duration_ms(run: dict) -> Optional[int]:
+    """Compute step duration in milliseconds from start_time and end_time."""
+    start = _timestamp_seconds(run.get("start_time"))
+    end = _timestamp_seconds(run.get("end_time"))
+    if start is None or end is None:
+        return None
+    return max(int(round((end - start) * 1000)), 0)
+
+
+def _get_trace_start_seconds(runs: list[dict]) -> Optional[float]:
+    """Return the earliest start time in a trace."""
+    start_times = [
+        timestamp
+        for run in runs
+        if (timestamp := _timestamp_seconds(run.get("start_time"))) is not None
+    ]
+    return min(start_times) if start_times else None
+
+
+def _build_timing_fields(
+    run: dict, trace_start: Optional[float]
+) -> dict[str, Optional[int]]:
+    """Build the frontend timing fields for a trace step."""
+    fields: dict[str, Optional[int]] = {
+        "durationMs": _compute_duration_ms(run)
+    }
+    start = _timestamp_seconds(run.get("start_time"))
+    if start is not None and trace_start is not None:
+        fields["startOffsetMs"] = max(
+            int(round((start - trace_start) * 1000)), 0
+        )
+    return fields
 
 
 def _extract_agent_content(outputs: dict) -> str:

--- a/receipt_langsmith/tests/spark/test_qa_viz_cache_helpers.py
+++ b/receipt_langsmith/tests/spark/test_qa_viz_cache_helpers.py
@@ -135,6 +135,43 @@ class TestDeriveTraceStepsExpandsToolChildren:
         assert steps[0]["durationMs"] == 2000
         assert steps[1]["durationMs"] == 1000
 
+    def test_parallel_tool_steps_include_relative_start_offsets(self):
+        wrapper = _make_run(
+            id="parallel-wrapper",
+            name="tools",
+            run_type="chain",
+            start_time="2025-01-01 00:00:00",
+            end_time="2025-01-01 00:00:04",
+        )
+        tool_a = _make_run(
+            id="parallel-tool-a",
+            name="search_receipts",
+            run_type="tool",
+            parent_run_id="parallel-wrapper",
+            dotted_order="1.1.1",
+            start_time="2025-01-01 00:00:01",
+            end_time="2025-01-01 00:00:03",
+        )
+        tool_b = _make_run(
+            id="parallel-tool-b",
+            name="search_receipt_descriptions",
+            run_type="tool",
+            parent_run_id="parallel-wrapper",
+            dotted_order="1.1.2",
+            start_time="2025-01-01 00:00:01.500",
+            end_time="2025-01-01 00:00:02.500",
+        )
+
+        steps = derive_trace_steps(
+            child_runs=[wrapper],
+            question_result={},
+            receipts_lookup={},
+            all_runs=[wrapper, tool_a, tool_b],
+        )
+
+        assert [step["startOffsetMs"] for step in steps] == [1000, 1500]
+        assert [step["durationMs"] for step in steps] == [2000, 1000]
+
 
 # ---------------------------------------------------------------------------
 # Test: derive_trace_steps with all_runs=None skips wrapper (backward compat)


### PR DESCRIPTION
## Summary

- restore receipt evidence rendering in `QAAgentFlow` from `TraceStep.receipts`
- deduplicate evidence by `imageId`, cap the visible responsive deck at eight thumbnails, and fall back from WebP/AVIF to JPEG
- render compact `structuredData` summaries when the cache provides them
- preserve LangSmith `startOffsetMs` timing and render overlapping tool calls on parallel wall-clock lanes
- harden the QA Playwright spec against duplicate responsive article headings

## Root cause

Commit `f4e60c226` removed the receipt-stack renderer while the cache/API evidence contract remained intact. The cache builder also discarded trace start offsets, so concurrent tool calls could only be displayed as a serial timeline.

## Impact

Answers on `/receipt` once again show the receipt thumbnails that support them. Large evidence sets remain bounded in the DOM, image failures degrade cleanly, and regenerated caches can show concurrent tool execution without breaking older sequential cache payloads.

## Validation

- `cd portfolio && npm test -- --runInBand` — 305 passed
- `cd portfolio && npm run lint` — 0 errors (existing warnings only)
- `cd portfolio && npm run type-check` — passed
- `cd portfolio && npx playwright test e2e/qa-agent-flow.spec.ts --project=chromium --workers=1` — 6 passed
- `pytest -q receipt_langsmith/tests/spark/test_qa_viz_cache_helpers.py` — 25 passed
- Black/isort checks — passed
- live local render against dev API — evidence deck rendered with no console errors

Closes #1123