### PR TITLE
[infra] Reuse route Lambda resources

### DIFF
--- a/infra/components/route_lambda.py
+++ b/infra/components/route_lambda.py
@@ -1,0 +1,195 @@
+"""Reusable IAM, Lambda, and log wiring for API route handlers.
+
+Route modules pass every Pulumi logical name explicitly.  This module is a
+plain factory rather than a ``ComponentResource`` so migrating an existing
+route does not change its resource parent or URN.
+"""
+
+import json
+from dataclasses import dataclass, field
+from typing import Mapping, Sequence
+
+import pulumi
+import pulumi_aws as aws
+
+BASIC_EXECUTION_POLICY_ARN = (
+    "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+)
+
+LAMBDA_ASSUME_ROLE_POLICY = json.dumps(
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Action": "sts:AssumeRole",
+                "Principal": {"Service": "lambda.amazonaws.com"},
+                "Effect": "Allow",
+                "Sid": "",
+            }
+        ],
+    }
+)
+
+
+@dataclass(frozen=True)
+class ManagedPolicyDefinition:
+    """A customer-managed IAM policy attached to the route Lambda role."""
+
+    resource_name: str
+    attachment_name: str
+    document: pulumi.Input[str]
+    description: str | None = None
+
+
+@dataclass(frozen=True)
+class InlinePolicyDefinition:
+    """An inline IAM policy attached directly to the route Lambda role."""
+
+    resource_name: str
+    document: pulumi.Input[str]
+
+
+RoutePolicyDefinition = ManagedPolicyDefinition | InlinePolicyDefinition
+
+
+@dataclass(frozen=True)
+class RouteLambdaDefinition:
+    """Configuration for one file-archive Lambda used by an API route."""
+
+    role_name: str
+    basic_execution_attachment_name: str
+    function_name: str
+    log_group_name: str
+    handler_directory: str
+    policy: RoutePolicyDefinition | None = None
+    environment: Mapping[str, pulumi.Input[str]] = field(default_factory=dict)
+    layers: Sequence[pulumi.Input[str]] = field(default_factory=tuple)
+    memory_size: int | None = None
+    timeout: int | None = None
+    log_retention_in_days: int = 30
+    explicit_log_group_name: pulumi.Input[str] | None = None
+    use_function_log_group_name: bool = False
+    runtime: str = "python3.12"
+    architecture: str = "arm64"
+    handler: str = "index.handler"
+    reserved_concurrent_executions: int | None = None
+    function_options: pulumi.ResourceOptions | None = None
+
+    def __post_init__(self) -> None:
+        for field_name in (
+            "role_name",
+            "basic_execution_attachment_name",
+            "function_name",
+            "log_group_name",
+            "handler_directory",
+            "handler",
+        ):
+            if not getattr(self, field_name):
+                raise ValueError(f"{field_name} must not be empty")
+        if self.memory_size is not None and self.memory_size <= 0:
+            raise ValueError("memory_size must be positive")
+        if self.timeout is not None and self.timeout <= 0:
+            raise ValueError("timeout must be positive")
+        if self.log_retention_in_days <= 0:
+            raise ValueError("log_retention_in_days must be positive")
+        if (
+            self.explicit_log_group_name is not None
+            and self.use_function_log_group_name
+        ):
+            raise ValueError(
+                "choose either explicit_log_group_name or "
+                "use_function_log_group_name"
+            )
+
+
+@dataclass(frozen=True)
+class RouteLambdaResources:
+    """Pulumi resources created for a route Lambda."""
+
+    role: aws.iam.Role
+    basic_execution_attachment: aws.iam.RolePolicyAttachment
+    function: aws.lambda_.Function
+    log_group: aws.cloudwatch.LogGroup
+    policy: aws.iam.Policy | aws.iam.RolePolicy | None
+    policy_attachment: aws.iam.RolePolicyAttachment | None
+
+
+def create_route_lambda(
+    definition: RouteLambdaDefinition,
+) -> RouteLambdaResources:
+    """Create the common resources for a file-archive API Lambda."""
+    role = aws.iam.Role(
+        definition.role_name,
+        assume_role_policy=LAMBDA_ASSUME_ROLE_POLICY,
+    )
+
+    policy_resource: aws.iam.Policy | aws.iam.RolePolicy | None = None
+    policy_attachment: aws.iam.RolePolicyAttachment | None = None
+    if isinstance(definition.policy, ManagedPolicyDefinition):
+        managed_policy = aws.iam.Policy(
+            definition.policy.resource_name,
+            policy=definition.policy.document,
+            description=definition.policy.description,
+        )
+        policy_resource = managed_policy
+        policy_attachment = aws.iam.RolePolicyAttachment(
+            definition.policy.attachment_name,
+            role=role.name,
+            policy_arn=managed_policy.arn,
+        )
+    elif isinstance(definition.policy, InlinePolicyDefinition):
+        policy_resource = aws.iam.RolePolicy(
+            definition.policy.resource_name,
+            role=role.id,
+            policy=definition.policy.document,
+        )
+
+    basic_execution_attachment = aws.iam.RolePolicyAttachment(
+        definition.basic_execution_attachment_name,
+        role=role.name,
+        policy_arn=BASIC_EXECUTION_POLICY_ARN,
+    )
+
+    function = aws.lambda_.Function(
+        definition.function_name,
+        runtime=definition.runtime,
+        architectures=[definition.architecture],
+        role=role.arn,
+        code=pulumi.AssetArchive(
+            {".": pulumi.FileArchive(definition.handler_directory)}
+        ),
+        handler=definition.handler,
+        layers=list(definition.layers) if definition.layers else None,
+        environment=(
+            {"variables": dict(definition.environment)}
+            if definition.environment
+            else None
+        ),
+        memory_size=definition.memory_size,
+        timeout=definition.timeout,
+        reserved_concurrent_executions=(
+            definition.reserved_concurrent_executions
+        ),
+        tags={"environment": pulumi.get_stack()},
+        opts=definition.function_options,
+    )
+
+    physical_log_group_name = definition.explicit_log_group_name
+    if definition.use_function_log_group_name:
+        physical_log_group_name = pulumi.Output.concat(
+            "/aws/lambda/", function.name
+        )
+    log_group = aws.cloudwatch.LogGroup(
+        definition.log_group_name,
+        retention_in_days=definition.log_retention_in_days,
+        name=physical_log_group_name,
+    )
+
+    return RouteLambdaResources(
+        role=role,
+        basic_execution_attachment=basic_execution_attachment,
+        function=function,
+        log_group=log_group,
+        policy=policy_resource,
+        policy_attachment=policy_attachment,
+    )

--- a/infra/components/test_route_lambda.py
+++ b/infra/components/test_route_lambda.py
@@ -1,0 +1,216 @@
+"""Unit tests for shared API route Lambda resources."""
+
+# pylint: disable=redefined-outer-name
+
+from dataclasses import replace
+from types import SimpleNamespace
+from typing import Any, Callable, cast
+
+import pytest
+
+from infra.components import route_lambda
+
+CreatedResource = tuple[str, dict[str, Any], SimpleNamespace]
+CreatedResources = dict[str, list[CreatedResource]]
+
+
+@pytest.fixture
+def mocked_resources(
+    monkeypatch: pytest.MonkeyPatch,
+) -> CreatedResources:
+    created: CreatedResources = {
+        "roles": [],
+        "policies": [],
+        "inline_policies": [],
+        "attachments": [],
+        "functions": [],
+        "log_groups": [],
+    }
+
+    def resource(kind: str, **outputs: Any) -> Callable[..., SimpleNamespace]:
+        def create(resource_name: str, **kwargs: Any) -> SimpleNamespace:
+            value = SimpleNamespace(resource_name=resource_name, **outputs)
+            created[kind].append((resource_name, kwargs, value))
+            return value
+
+        return create
+
+    monkeypatch.setattr(
+        route_lambda.aws.iam,
+        "Role",
+        resource("roles", name="role-name", arn="role-arn", id="role-id"),
+    )
+    monkeypatch.setattr(
+        route_lambda.aws.iam,
+        "Policy",
+        resource("policies", arn="policy-arn"),
+    )
+    monkeypatch.setattr(
+        route_lambda.aws.iam,
+        "RolePolicy",
+        resource("inline_policies"),
+    )
+    monkeypatch.setattr(
+        route_lambda.aws.iam,
+        "RolePolicyAttachment",
+        resource("attachments"),
+    )
+    monkeypatch.setattr(
+        route_lambda.aws.lambda_,
+        "Function",
+        resource("functions", name="function-name", arn="function-arn"),
+    )
+    monkeypatch.setattr(
+        route_lambda.aws.cloudwatch,
+        "LogGroup",
+        resource("log_groups"),
+    )
+    monkeypatch.setattr(route_lambda.pulumi, "get_stack", lambda: "dev")
+    monkeypatch.setattr(
+        route_lambda.pulumi.Output,
+        "concat",
+        lambda *values: "".join(values),
+    )
+
+    return created
+
+
+def test_create_route_lambda_with_managed_policy(
+    mocked_resources: CreatedResources,
+) -> None:
+    function_options = route_lambda.pulumi.ResourceOptions(
+        ignore_changes=["layers"]
+    )
+    definition = route_lambda.RouteLambdaDefinition(
+        role_name="api_receipts_lambda_role",
+        basic_execution_attachment_name="api_receipts_lambda_basic_execution",
+        function_name="api_receipts_GET_lambda",
+        log_group_name="api_receipts_lambda_log_group",
+        handler_directory="/tmp/handler",
+        policy=route_lambda.ManagedPolicyDefinition(
+            resource_name="api_receipts_lambda_policy",
+            attachment_name="api_receipts_lambda_policy_attachment",
+            document="policy-json",
+            description="DynamoDB access",
+        ),
+        environment={"TABLE_NAME": "table-name"},
+        layers=("layer-arn",),
+        memory_size=1024,
+        timeout=120,
+        handler="index.lambda_handler",
+        reserved_concurrent_executions=100,
+        function_options=function_options,
+    )
+
+    resources = route_lambda.create_route_lambda(definition)
+
+    assert mocked_resources["roles"][0][:2] == (
+        "api_receipts_lambda_role",
+        {"assume_role_policy": route_lambda.LAMBDA_ASSUME_ROLE_POLICY},
+    )
+    assert mocked_resources["policies"][0][:2] == (
+        "api_receipts_lambda_policy",
+        {"policy": "policy-json", "description": "DynamoDB access"},
+    )
+    assert [item[:2] for item in mocked_resources["attachments"]] == [
+        (
+            "api_receipts_lambda_policy_attachment",
+            {"role": "role-name", "policy_arn": "policy-arn"},
+        ),
+        (
+            "api_receipts_lambda_basic_execution",
+            {
+                "role": "role-name",
+                "policy_arn": route_lambda.BASIC_EXECUTION_POLICY_ARN,
+            },
+        ),
+    ]
+    function_args = mocked_resources["functions"][0][1]
+    assert function_args["runtime"] == "python3.12"
+    assert function_args["architectures"] == ["arm64"]
+    assert function_args["role"] == "role-arn"
+    assert function_args["handler"] == "index.lambda_handler"
+    assert function_args["layers"] == ["layer-arn"]
+    assert function_args["environment"] == {
+        "variables": {"TABLE_NAME": "table-name"}
+    }
+    assert function_args["memory_size"] == 1024
+    assert function_args["timeout"] == 120
+    assert function_args["reserved_concurrent_executions"] == 100
+    assert function_args["opts"] is function_options
+    assert function_args["tags"] == {"environment": "dev"}
+    assert mocked_resources["log_groups"][0][:2] == (
+        "api_receipts_lambda_log_group",
+        {"retention_in_days": 30, "name": None},
+    )
+    assert cast(Any, resources.function) is mocked_resources["functions"][0][2]
+
+
+def test_create_route_lambda_with_inline_policy_and_named_log_group(
+    mocked_resources: CreatedResources,
+) -> None:
+    definition = route_lambda.RouteLambdaDefinition(
+        role_name="api_timeline_lambda_role",
+        basic_execution_attachment_name="api_timeline_basic_execution",
+        function_name="api_timeline_GET_lambda",
+        log_group_name="api_timeline_log_group",
+        handler_directory="/tmp/handler",
+        policy=route_lambda.InlinePolicyDefinition(
+            resource_name="api_timeline_s3_policy",
+            document="policy-json",
+        ),
+        use_function_log_group_name=True,
+        log_retention_in_days=7,
+    )
+
+    resources = route_lambda.create_route_lambda(definition)
+
+    assert mocked_resources["inline_policies"][0][:2] == (
+        "api_timeline_s3_policy",
+        {"role": "role-id", "policy": "policy-json"},
+    )
+    assert mocked_resources["log_groups"][0][:2] == (
+        "api_timeline_log_group",
+        {
+            "retention_in_days": 7,
+            "name": "/aws/lambda/function-name",
+        },
+    )
+    assert resources.policy_attachment is None
+
+
+@pytest.mark.parametrize(
+    ("changes", "message"),
+    [
+        ({"role_name": ""}, "role_name"),
+        ({"memory_size": 0}, "memory_size"),
+        ({"timeout": 0}, "timeout"),
+        ({"log_retention_in_days": 0}, "log_retention_in_days"),
+    ],
+)
+def test_route_lambda_definition_validates_inputs(
+    changes: dict[str, object], message: str
+) -> None:
+    definition = route_lambda.RouteLambdaDefinition(
+        role_name="role",
+        basic_execution_attachment_name="basic",
+        function_name="function",
+        log_group_name="logs",
+        handler_directory="/tmp/handler",
+    )
+
+    with pytest.raises(ValueError, match=message):
+        replace(definition, **cast(Any, changes))
+
+
+def test_route_lambda_definition_rejects_two_log_group_names() -> None:
+    with pytest.raises(ValueError, match="choose either"):
+        route_lambda.RouteLambdaDefinition(
+            role_name="role",
+            basic_execution_attachment_name="basic",
+            function_name="function",
+            log_group_name="logs",
+            handler_directory="/tmp/handler",
+            explicit_log_group_name="/aws/lambda/function",
+            use_function_log_group_name=True,
+        )

--- a/infra/routes/ai_usage/infra.py
+++ b/infra/routes/ai_usage/infra.py
@@ -1,118 +1,74 @@
-"""
-Infrastructure definition for AI usage metrics API endpoint.
-"""
+"""Pulumi resources for the AI-usage metrics API Lambda."""
 
 import json
 import os
 
 import pulumi
-import pulumi_aws as aws
-from pulumi import AssetArchive, FileArchive
 
-# Import the DynamoDB table name from the dynamo_db module
 from dynamo_db import dynamodb_table
-
-# Import the Lambda Layer from the lambda_layer module
 from infra.components.lambda_layer import dynamo_layer
+from infra.components.route_lambda import (
+    ManagedPolicyDefinition,
+    RouteLambdaDefinition,
+    create_route_lambda,
+)
 
-# Reference the directory containing index.py
 HANDLER_DIR = os.path.join(os.path.dirname(__file__), "handler")
-# Get the route name from the directory name
 ROUTE_NAME = os.path.basename(os.path.dirname(__file__))
-# Get the DynamoDB table name
 DYNAMODB_TABLE_NAME = dynamodb_table.name
 
-
-# Define the IAM role for the Lambda function
-lambda_role = aws.iam.Role(
-    f"api_{ROUTE_NAME}_lambda_role",
-    assume_role_policy="""{
-        "Version": "2012-10-17",
-        "Statement": [
-            {
-                "Action": "sts:AssumeRole",
-                "Principal": {
-                    "Service": "lambda.amazonaws.com"
-                },
-                "Effect": "Allow",
-                "Sid": ""
-            }
-        ]
-    }""",
-)
-
-# Define the IAM policy for DynamoDB access
-lambda_policy = aws.iam.Policy(
-    f"api_{ROUTE_NAME}_lambda_policy",
-    description="IAM policy for AI usage metrics Lambda to access DynamoDB",
-    policy=dynamodb_table.arn.apply(
-        lambda dynamo_arn: json.dumps(
-            {
-                "Version": "2012-10-17",
-                "Statement": [
+resources = create_route_lambda(
+    RouteLambdaDefinition(
+        role_name=f"api_{ROUTE_NAME}_lambda_role",
+        basic_execution_attachment_name=(
+            f"api_{ROUTE_NAME}_lambda_basic_execution"
+        ),
+        function_name=f"api_{ROUTE_NAME}_GET_lambda",
+        log_group_name=f"api_{ROUTE_NAME}_lambda_log_group",
+        handler_directory=HANDLER_DIR,
+        policy=ManagedPolicyDefinition(
+            resource_name=f"api_{ROUTE_NAME}_lambda_policy",
+            attachment_name=f"api_{ROUTE_NAME}_lambda_policy_attachment",
+            description=(
+                "IAM policy for AI usage metrics Lambda to access DynamoDB"
+            ),
+            document=dynamodb_table.arn.apply(
+                lambda dynamo_arn: json.dumps(
                     {
-                        "Effect": "Allow",
-                        "Action": [
-                            "dynamodb:Query",
-                            "dynamodb:GetItem",
-                            "dynamodb:DescribeTable",
+                        "Version": "2012-10-17",
+                        "Statement": [
+                            {
+                                "Effect": "Allow",
+                                "Action": [
+                                    "dynamodb:Query",
+                                    "dynamodb:GetItem",
+                                    "dynamodb:DescribeTable",
+                                ],
+                                "Resource": [
+                                    dynamo_arn,
+                                    f"{dynamo_arn}/index/GSI1",
+                                    f"{dynamo_arn}/index/GSI2",
+                                    f"{dynamo_arn}/index/GSI3",
+                                ],
+                            }
                         ],
-                        "Resource": [
-                            dynamo_arn,
-                            f"{dynamo_arn}/index/GSI1",
-                            f"{dynamo_arn}/index/GSI2",
-                            f"{dynamo_arn}/index/GSI3",
-                        ],
-                    },
-                ],
-            }
-        )
-    ),
+                    }
+                )
+            ),
+        ),
+        handler="index.lambda_handler",
+        environment={"DYNAMODB_TABLE_NAME": DYNAMODB_TABLE_NAME},
+        layers=(dynamo_layer.arn,),
+        memory_size=1024,
+        timeout=30,
+        use_function_log_group_name=True,
+    )
 )
 
-# Attach the custom policy to the role
-lambda_role_policy_attachment = aws.iam.RolePolicyAttachment(
-    f"api_{ROUTE_NAME}_lambda_policy_attachment",
-    role=lambda_role.name,
-    policy_arn=lambda_policy.arn,
-)
+lambda_role = resources.role
+lambda_policy = resources.policy
+lambda_role_policy_attachment = resources.policy_attachment
+ai_usage_lambda = resources.function
+log_group = resources.log_group
 
-# Attach the basic execution role
-aws.iam.RolePolicyAttachment(
-    f"api_{ROUTE_NAME}_lambda_basic_execution",
-    role=lambda_role.name,
-    policy_arn="arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
-)
-
-# Create the Lambda function
-ai_usage_lambda = aws.lambda_.Function(
-    f"api_{ROUTE_NAME}_GET_lambda",
-    runtime="python3.12",
-    architectures=["arm64"],
-    role=lambda_role.arn,
-    code=AssetArchive(
-        {
-            ".": FileArchive(HANDLER_DIR),
-        }
-    ),
-    handler="index.lambda_handler",
-    layers=[dynamo_layer.arn],
-    environment={
-        "variables": {
-            "DYNAMODB_TABLE_NAME": DYNAMODB_TABLE_NAME,
-        }
-    },
-    memory_size=1024,
-    timeout=30,
-    tags={"environment": pulumi.get_stack()},
-)
-
-# CloudWatch log group for the Lambda function
-log_group = aws.cloudwatch.LogGroup(
-    f"api_{ROUTE_NAME}_lambda_log_group",
-    name=pulumi.Output.concat("/aws/lambda/", ai_usage_lambda.name),
-    retention_in_days=30,
-)
-
-# Export the Lambda function ARN
 pulumi.export(f"{ROUTE_NAME}_lambda_arn", ai_usage_lambda.arn)

--- a/infra/routes/health_check/infra.py
+++ b/infra/routes/health_check/infra.py
@@ -1,58 +1,27 @@
-import json
+"""Pulumi resources for the health-check API Lambda."""
+
 import os
 
-import pulumi
-import pulumi_aws as aws
-from pulumi import AssetArchive, FileArchive
+from infra.components.route_lambda import (
+    RouteLambdaDefinition,
+    create_route_lambda,
+)
 
-# Reference the directory containing index.py
 HANDLER_DIR = os.path.join(os.path.dirname(__file__), "handler")
-# Get the route name from the directory name
 ROUTE_NAME = os.path.basename(os.path.dirname(__file__))
 
-
-# Define the IAM role for the Lambda function with permissions for the DynamoDB table
-lambda_role = aws.iam.Role(
-    f"api_{ROUTE_NAME}_lambda_role",
-    assume_role_policy="""{
-        "Version": "2012-10-17",
-        "Statement": [
-            {
-                "Action": "sts:AssumeRole",
-                "Principal": {
-                    "Service": "lambda.amazonaws.com"
-                },
-                "Effect": "Allow",
-                "Sid": ""
-            }
-        ]
-    }""",
+resources = create_route_lambda(
+    RouteLambdaDefinition(
+        role_name=f"api_{ROUTE_NAME}_lambda_role",
+        basic_execution_attachment_name=(
+            f"api_{ROUTE_NAME}_lambda_basic_execution"
+        ),
+        function_name=f"api_{ROUTE_NAME}_GET_lambda",
+        log_group_name=f"api_{ROUTE_NAME}_lambda_log_group",
+        handler_directory=HANDLER_DIR,
+    )
 )
 
-# Attach the necessary policies to the role
-aws.iam.RolePolicyAttachment(
-    f"api_{ROUTE_NAME}_lambda_basic_execution",
-    role=lambda_role.name,
-    policy_arn="arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
-)
-
-# Create the Lambda function for the "user" route
-health_check_lambda = aws.lambda_.Function(
-    f"api_{ROUTE_NAME}_GET_lambda",
-    runtime="python3.12",
-    architectures=["arm64"],
-    role=lambda_role.arn,
-    code=AssetArchive(
-        {
-            ".": FileArchive(HANDLER_DIR),
-        }
-    ),
-    handler="index.handler",
-    tags={"environment": pulumi.get_stack()},
-)
-
-# CloudWatch log group for the Lambda function
-log_group = aws.cloudwatch.LogGroup(
-    f"api_{ROUTE_NAME}_lambda_log_group",
-    retention_in_days=30,
-)
+lambda_role = resources.role
+health_check_lambda = resources.function
+log_group = resources.log_group

--- a/infra/routes/image_count/infra.py
+++ b/infra/routes/image_count/infra.py
@@ -1,100 +1,63 @@
+"""Pulumi resources for the image-count API Lambda."""
+
 import json
 import os
 
-import pulumi
-import pulumi_aws as aws
-from pulumi import AssetArchive, FileArchive
-
-# Import the DynamoDB table name from the dynamo_db module
 from dynamo_db import dynamodb_table
-
-# Import the Lambda Layer from the lambda_layer module
 from infra.components.lambda_layer import dynamo_layer
+from infra.components.route_lambda import (
+    ManagedPolicyDefinition,
+    RouteLambdaDefinition,
+    create_route_lambda,
+)
 
-# Reference the directory containing index.py
 HANDLER_DIR = os.path.join(os.path.dirname(__file__), "handler")
-# Get the route name from the directory name
 ROUTE_NAME = os.path.basename(os.path.dirname(__file__))
-# Get the DynamoDB table name
 DYNAMODB_TABLE_NAME = dynamodb_table.name
 
-
-# Define the IAM role for the Lambda function with permissions for the DynamoDB table
-lambda_role = aws.iam.Role(
-    f"api_{ROUTE_NAME}_lambda_role",
-    assume_role_policy="""{
-        "Version": "2012-10-17",
-        "Statement": [
-            {
-                "Action": "sts:AssumeRole",
-                "Principal": {
-                    "Service": "lambda.amazonaws.com"
-                },
-                "Effect": "Allow",
-                "Sid": ""
-            }
-        ]
-    }""",
-)
-
-# Attach the necessary policies to the role
-lambda_policy = aws.iam.Policy(
-    f"api_{ROUTE_NAME}_lambda_policy",
-    description="IAM policy for Lambda to access DynamoDB",
-    policy=dynamodb_table.arn.apply(
-        lambda arn: json.dumps(
-            {
-                "Version": "2012-10-17",
-                "Statement": [
+resources = create_route_lambda(
+    RouteLambdaDefinition(
+        role_name=f"api_{ROUTE_NAME}_lambda_role",
+        basic_execution_attachment_name=(
+            f"api_{ROUTE_NAME}_lambda_basic_execution"
+        ),
+        function_name=f"api_{ROUTE_NAME}_GET_lambda",
+        log_group_name=f"api_{ROUTE_NAME}_lambda_log_group",
+        handler_directory=HANDLER_DIR,
+        policy=ManagedPolicyDefinition(
+            resource_name=f"api_{ROUTE_NAME}_lambda_policy",
+            attachment_name=f"api_{ROUTE_NAME}_lambda_policy_attachment",
+            description="IAM policy for Lambda to access DynamoDB",
+            document=dynamodb_table.arn.apply(
+                lambda arn: json.dumps(
                     {
-                        "Effect": "Allow",
-                        "Action": ["dynamodb:Query", "dynamodb:DescribeTable"],
-                        "Resource": [arn, f"{arn}/index/GSITYPE"],
+                        "Version": "2012-10-17",
+                        "Statement": [
+                            {
+                                "Effect": "Allow",
+                                "Action": [
+                                    "dynamodb:Query",
+                                    "dynamodb:DescribeTable",
+                                ],
+                                "Resource": [
+                                    arn,
+                                    f"{arn}/index/GSITYPE",
+                                ],
+                            }
+                        ],
                     }
-                ],
-            }
-        )
-    ),
+                )
+            ),
+        ),
+        environment={"DYNAMODB_TABLE_NAME": DYNAMODB_TABLE_NAME},
+        layers=(dynamo_layer.arn,),
+        memory_size=1024,
+        timeout=300,
+    )
 )
 
-lambda_role_policy_attachment = aws.iam.RolePolicyAttachment(
-    f"api_{ROUTE_NAME}_lambda_policy_attachment",
-    role=lambda_role.name,
-    policy_arn=lambda_policy.arn,
-)
-
-# Attach the necessary policies to the role
-aws.iam.RolePolicyAttachment(
-    f"api_{ROUTE_NAME}_lambda_basic_execution",
-    role=lambda_role.name,
-    policy_arn="arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
-)
-
-# Create the Lambda function for the "user" route
-image_count_lambda = aws.lambda_.Function(
-    f"api_{ROUTE_NAME}_GET_lambda",
-    runtime="python3.12",
-    architectures=["arm64"],
-    role=lambda_role.arn,
-    code=AssetArchive(
-        {
-            ".": FileArchive(HANDLER_DIR),
-        }
-    ),
-    handler="index.handler",  # file_name.function_name
-    layers=[dynamo_layer.arn],
-    environment={
-        "variables": {
-            "DYNAMODB_TABLE_NAME": DYNAMODB_TABLE_NAME,
-        }
-    },
-    timeout=300,
-    memory_size=1024,  # Increase the RAM to 1024 MB
-    tags={"environment": pulumi.get_stack()},
-)
-
-# CloudWatch log group for the Lambda function
-log_group = aws.cloudwatch.LogGroup(
-    f"api_{ROUTE_NAME}_lambda_log_group",
-    retention_in_days=30,
-)
+lambda_role = resources.role
+lambda_policy = resources.policy
+lambda_role_policy_attachment = resources.policy_attachment
+image_count_lambda = resources.function
+log_group = resources.log_group

--- a/infra/routes/images/infra.py
+++ b/infra/routes/images/infra.py
@@ -1,80 +1,60 @@
+"""Pulumi resources for the images API Lambda."""
+
 import json
 import os
 
-import pulumi
-import pulumi_aws as aws
-from pulumi import AssetArchive, FileArchive
-
 from dynamo_db import dynamodb_table
 from infra.components.lambda_layer import dynamo_layer
+from infra.components.route_lambda import (
+    ManagedPolicyDefinition,
+    RouteLambdaDefinition,
+    create_route_lambda,
+)
 
 HANDLER_DIR = os.path.join(os.path.dirname(__file__), "handler")
 ROUTE_NAME = os.path.basename(os.path.dirname(__file__))
 DYNAMODB_TABLE_NAME = dynamodb_table.name
 
-lambda_role = aws.iam.Role(
-    f"api_{ROUTE_NAME}_lambda_role",
-    assume_role_policy="""{
-        "Version": "2012-10-17",
-        "Statement": [
-            {
-                "Action": "sts:AssumeRole",
-                "Principal": {"Service": "lambda.amazonaws.com"},
-                "Effect": "Allow",
-                "Sid": ""
-            }
-        ]
-    }""",
-)
-
-lambda_policy = aws.iam.Policy(
-    f"api_{ROUTE_NAME}_lambda_policy",
-    description="IAM policy for Lambda to access DynamoDB",
-    policy=dynamodb_table.arn.apply(
-        lambda arn: json.dumps(
-            {
-                "Version": "2012-10-17",
-                "Statement": [
+resources = create_route_lambda(
+    RouteLambdaDefinition(
+        role_name=f"api_{ROUTE_NAME}_lambda_role",
+        basic_execution_attachment_name=(
+            f"api_{ROUTE_NAME}_lambda_basic_execution"
+        ),
+        function_name=f"api_{ROUTE_NAME}_GET_lambda",
+        log_group_name=f"api_{ROUTE_NAME}_lambda_log_group",
+        handler_directory=HANDLER_DIR,
+        policy=ManagedPolicyDefinition(
+            resource_name=f"api_{ROUTE_NAME}_lambda_policy",
+            attachment_name=f"api_{ROUTE_NAME}_lambda_policy_attachment",
+            description="IAM policy for Lambda to access DynamoDB",
+            document=dynamodb_table.arn.apply(
+                lambda arn: json.dumps(
                     {
-                        "Effect": "Allow",
-                        "Action": ["dynamodb:Query", "dynamodb:DescribeTable"],
-                        "Resource": [arn, f"{arn}/index/GSI3"],
+                        "Version": "2012-10-17",
+                        "Statement": [
+                            {
+                                "Effect": "Allow",
+                                "Action": [
+                                    "dynamodb:Query",
+                                    "dynamodb:DescribeTable",
+                                ],
+                                "Resource": [arn, f"{arn}/index/GSI3"],
+                            }
+                        ],
                     }
-                ],
-            }
-        )
-    ),
+                )
+            ),
+        ),
+        environment={"DYNAMODB_TABLE_NAME": DYNAMODB_TABLE_NAME},
+        layers=(dynamo_layer.arn,),
+        memory_size=1024,
+        timeout=30,
+    )
 )
 
-lambda_role_policy_attachment = aws.iam.RolePolicyAttachment(
-    f"api_{ROUTE_NAME}_lambda_policy_attachment",
-    role=lambda_role.name,
-    policy_arn=lambda_policy.arn,
-)
-
-aws.iam.RolePolicyAttachment(
-    f"api_{ROUTE_NAME}_lambda_basic_execution",
-    role=lambda_role.name,
-    policy_arn=(
-        "arn:aws:iam::aws:policy/service-role/" "AWSLambdaBasicExecutionRole"
-    ),
-)
-
-images_lambda = aws.lambda_.Function(
-    f"api_{ROUTE_NAME}_GET_lambda",
-    runtime="python3.12",
-    architectures=["arm64"],
-    role=lambda_role.arn,
-    code=AssetArchive({".": FileArchive(HANDLER_DIR)}),
-    handler="index.handler",
-    layers=[dynamo_layer.arn],
-    environment={"variables": {"DYNAMODB_TABLE_NAME": DYNAMODB_TABLE_NAME}},
-    memory_size=1024,
-    timeout=30,
-    tags={"environment": pulumi.get_stack()},
-)
-
-log_group = aws.cloudwatch.LogGroup(
-    f"api_{ROUTE_NAME}_lambda_log_group",
-    retention_in_days=30,
-)
+lambda_role = resources.role
+lambda_policy = resources.policy
+lambda_role_policy_attachment = resources.policy_attachment
+images_lambda = resources.function
+log_group = resources.log_group

--- a/infra/routes/label_validation_count/infra.py
+++ b/infra/routes/label_validation_count/infra.py
@@ -1,122 +1,75 @@
+"""Pulumi resources for the label-validation-count API Lambda."""
+
 import json
 import os
 
 import pulumi
-import pulumi_aws as aws
-from pulumi import AssetArchive, FileArchive
 
-# Import the DynamoDB table name from the dynamo_db module
 from dynamo_db import dynamodb_table
-
-# Import the Lambda Layer from the lambda_layer module
 from infra.components.lambda_layer import dynamo_layer
-
-# Reference the directory containing index.py
-HANDLER_DIR = os.path.join(os.path.dirname(__file__), "handler")
-# Get the route name from the directory name
-ROUTE_NAME = os.path.basename(os.path.dirname(__file__))
-# Get the DynamoDB table name
-DYNAMODB_TABLE_NAME = dynamodb_table.name
-
-
-# Define the IAM role for the Lambda function with permissions for the DynamoDB table
-lambda_role = aws.iam.Role(
-    f"api_{ROUTE_NAME}_lambda_role",
-    assume_role_policy="""{
-        "Version": "2012-10-17",
-        "Statement": [
-            {
-                "Action": "sts:AssumeRole",
-                "Principal": {
-                    "Service": "lambda.amazonaws.com"
-                },
-                "Effect": "Allow",
-                "Sid": ""
-            }
-        ]
-    }""",
+from infra.components.route_lambda import (
+    ManagedPolicyDefinition,
+    RouteLambdaDefinition,
+    create_route_lambda,
 )
 
-# Get environment configuration
+HANDLER_DIR = os.path.join(os.path.dirname(__file__), "handler")
+ROUTE_NAME = os.path.basename(os.path.dirname(__file__))
+DYNAMODB_TABLE_NAME = dynamodb_table.name
 is_production = pulumi.get_stack() == "prod"
 
-lambda_policy = aws.iam.Policy(
-    f"api_{ROUTE_NAME}_lambda_policy",
-    description="IAM policy for label validation count Lambda to query DynamoDB",
-    policy=dynamodb_table.arn.apply(
-        lambda table_arn: json.dumps(
-            {
-                "Version": "2012-10-17",
-                "Statement": [
+resources = create_route_lambda(
+    RouteLambdaDefinition(
+        role_name=f"api_{ROUTE_NAME}_lambda_role",
+        basic_execution_attachment_name=(
+            f"api_{ROUTE_NAME}_lambda_basic_execution"
+        ),
+        function_name=f"api_{ROUTE_NAME}_GET_lambda",
+        log_group_name=f"api_{ROUTE_NAME}_lambda_log_group",
+        handler_directory=HANDLER_DIR,
+        policy=ManagedPolicyDefinition(
+            resource_name=f"api_{ROUTE_NAME}_lambda_policy",
+            attachment_name=f"api_{ROUTE_NAME}_lambda_policy_attachment",
+            description=(
+                "IAM policy for label validation count Lambda to query "
+                "DynamoDB"
+            ),
+            document=dynamodb_table.arn.apply(
+                lambda table_arn: json.dumps(
                     {
-                        "Effect": "Allow",
-                        "Action": ["dynamodb:Query", "dynamodb:DescribeTable"],
-                        "Resource": [
-                            table_arn,
-                            f"{table_arn}/index/GSI1",
-                            f"{table_arn}/index/GSITYPE",
+                        "Version": "2012-10-17",
+                        "Statement": [
+                            {
+                                "Effect": "Allow",
+                                "Action": [
+                                    "dynamodb:Query",
+                                    "dynamodb:DescribeTable",
+                                ],
+                                "Resource": [
+                                    table_arn,
+                                    f"{table_arn}/index/GSI1",
+                                    f"{table_arn}/index/GSITYPE",
+                                ],
+                            }
                         ],
                     }
-                ],
-            }
-        )
-    ),
+                )
+            ),
+        ),
+        environment={"DYNAMODB_TABLE_NAME": DYNAMODB_TABLE_NAME},
+        layers=(dynamo_layer.arn,),
+        memory_size=1536 if is_production else 512,
+        timeout=30,
+        reserved_concurrent_executions=100 if is_production else None,
+        log_retention_in_days=7 if is_production else 3,
+    )
 )
 
-lambda_role_policy_attachment = aws.iam.RolePolicyAttachment(
-    f"api_{ROUTE_NAME}_lambda_policy_attachment",
-    role=lambda_role.name,
-    policy_arn=lambda_policy.arn,
-)
+lambda_role = resources.role
+lambda_policy = resources.policy
+lambda_role_policy_attachment = resources.policy_attachment
+label_validation_count_lambda = resources.function
+log_group = resources.log_group
 
-# Attach the necessary policies to the role
-aws.iam.RolePolicyAttachment(
-    f"api_{ROUTE_NAME}_lambda_basic_execution",
-    role=lambda_role.name,
-    policy_arn="arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
-)
-
-# Create the Lambda function for the "user" route
-label_validation_count_lambda = aws.lambda_.Function(
-    f"api_{ROUTE_NAME}_GET_lambda",
-    runtime="python3.12",
-    architectures=["arm64"],
-    role=lambda_role.arn,
-    code=AssetArchive(
-        {
-            ".": FileArchive(HANDLER_DIR),
-        }
-    ),
-    handler="index.handler",
-    layers=[dynamo_layer.arn],
-    environment={
-        "variables": {
-            "DYNAMODB_TABLE_NAME": DYNAMODB_TABLE_NAME,
-        }
-    },
-    memory_size=1536 if is_production else 512,
-    timeout=30,  # Queries should complete quickly
-    reserved_concurrent_executions=100 if is_production else None,
-    tags={"environment": pulumi.get_stack()},
-)
-
-# CloudWatch log group for the Lambda function
-log_group = aws.cloudwatch.LogGroup(
-    f"api_{ROUTE_NAME}_lambda_log_group",
-    retention_in_days=7 if is_production else 3,  # Reduce log storage costs
-)
-
-# Provisioned concurrency disabled to save costs
-# Cold starts are acceptable for this internal API endpoint
-# Uncomment below if you need guaranteed low latency
-# if is_production:
-#     provisioned_config = aws.lambda_.ProvisionedConcurrencyConfig(
-#         f"api_{ROUTE_NAME}_provisioned_concurrency",
-#         function_name=label_validation_count_lambda.name,
-#         provisioned_concurrent_executions=2,
-#         qualifier=label_validation_count_lambda.version
-#     )
-
-# Export Lambda details
 pulumi.export(f"{ROUTE_NAME}_lambda_arn", label_validation_count_lambda.arn)
 pulumi.export(f"{ROUTE_NAME}_lambda_name", label_validation_count_lambda.name)

--- a/infra/routes/merchant_counts/infra.py
+++ b/infra/routes/merchant_counts/infra.py
@@ -1,150 +1,103 @@
+"""Pulumi resources for the merchant-counts API Lambda."""
+
+# pylint: disable=wrong-import-order
+
 import json
 import os
 
 import pulumi
-import pulumi_aws as aws
-from pulumi import AssetArchive, FileArchive
 
-# Import the DynamoDB table name from the dynamo_db module
 from dynamo_db import dynamodb_table
-
-# Import the Lambda Layer from the lambda_layer module
 from infra.components.lambda_layer import dynamo_layer
+from infra.components.route_lambda import (
+    ManagedPolicyDefinition,
+    RouteLambdaDefinition,
+    create_route_lambda,
+)
 from raw_bucket import raw_bucket
 from s3_website import site_bucket
 
-# Reference the directory containing index.py
 HANDLER_DIR = os.path.join(os.path.dirname(__file__), "handler")
-# Get the route name from the directory name
 ROUTE_NAME = os.path.basename(os.path.dirname(__file__))
-# Get the DynamoDB table name
 DYNAMODB_TABLE_NAME = dynamodb_table.name
 
-
-# Define the IAM role for the Lambda function with permissions for the DynamoDB table
-lambda_role = aws.iam.Role(
-    f"api_{ROUTE_NAME}_lambda_role",
-    assume_role_policy="""{
-        "Version": "2012-10-17",
-        "Statement": [
-            {
-                "Action": "sts:AssumeRole",
-                "Principal": {
-                    "Service": "lambda.amazonaws.com"
-                },
-                "Effect": "Allow",
-                "Sid": ""
-            }
-        ]
-    }""",
-)
-
-lambda_policy = aws.iam.Policy(
-    f"api_{ROUTE_NAME}_lambda_policy",
-    description="IAM policy for '/process' route Lambda to query DynamoDB",
-    policy=pulumi.Output.all(
-        dynamodb_table.arn,
-        raw_bucket.arn,
-        site_bucket.arn,
-    ).apply(
-        lambda arns: json.dumps(
-            {
-                "Version": "2012-10-17",
-                "Statement": [
+resources = create_route_lambda(
+    RouteLambdaDefinition(
+        role_name=f"api_{ROUTE_NAME}_lambda_role",
+        basic_execution_attachment_name=(
+            f"api_{ROUTE_NAME}_lambda_basic_execution"
+        ),
+        function_name=f"api_{ROUTE_NAME}_GET_lambda",
+        log_group_name=f"api_{ROUTE_NAME}_lambda_log_group",
+        handler_directory=HANDLER_DIR,
+        policy=ManagedPolicyDefinition(
+            resource_name=f"api_{ROUTE_NAME}_lambda_policy",
+            attachment_name=f"api_{ROUTE_NAME}_lambda_policy_attachment",
+            description=(
+                "IAM policy for '/process' route Lambda to query DynamoDB"
+            ),
+            document=pulumi.Output.all(
+                dynamodb_table.arn,
+                raw_bucket.arn,
+                site_bucket.arn,
+            ).apply(
+                lambda arns: json.dumps(
                     {
-                        # ---------- DynamoDB Permissions ----------
-                        "Effect": "Allow",
-                        "Action": [
-                            "dynamodb:Query",
-                            "dynamodb:DescribeTable",
-                            "dynamodb:PutItem",
-                            "dynamodb:BatchWriteItem",
+                        "Version": "2012-10-17",
+                        "Statement": [
+                            {
+                                "Effect": "Allow",
+                                "Action": [
+                                    "dynamodb:Query",
+                                    "dynamodb:DescribeTable",
+                                    "dynamodb:PutItem",
+                                    "dynamodb:BatchWriteItem",
+                                ],
+                                "Resource": [
+                                    arns[0],
+                                    f"{arns[0]}/index/GSI1",
+                                    f"{arns[0]}/index/GSI2",
+                                    f"{arns[0]}/index/GSI3",
+                                    f"{arns[0]}/index/GSITYPE",
+                                ],
+                            },
+                            {
+                                "Effect": "Allow",
+                                "Action": [
+                                    "s3:PutObject",
+                                    "s3:GetObject",
+                                    "s3:HeadObject",
+                                    "s3:ListBucket",
+                                ],
+                                "Resource": [arns[1], f"{arns[1]}/*"],
+                            },
+                            {
+                                "Effect": "Allow",
+                                "Action": [
+                                    "s3:PutObject",
+                                    "s3:GetObject",
+                                    "s3:HeadObject",
+                                    "s3:ListBucket",
+                                ],
+                                "Resource": [arns[2], f"{arns[2]}/*"],
+                            },
                         ],
-                        "Resource": [
-                            arns[0],  # dynamo_arn
-                            f"{arns[0]}/index/GSI1",
-                            f"{arns[0]}/index/GSI2",
-                            f"{arns[0]}/index/GSI3",
-                            f"{arns[0]}/index/GSITYPE",
-                        ],
-                    },
-                    {
-                        # ---------- S3 Permissions (Raw Bucket) ----------
-                        "Effect": "Allow",
-                        "Action": [
-                            "s3:PutObject",
-                            "s3:GetObject",
-                            "s3:HeadObject",
-                            "s3:ListBucket",
-                        ],
-                        "Resource": [
-                            arns[1],  # raw_arn
-                            f"{arns[1]}/*",
-                        ],
-                    },
-                    {
-                        # ---------- S3 Permissions (CDN Bucket) ----------
-                        "Effect": "Allow",
-                        "Action": [
-                            "s3:PutObject",
-                            "s3:GetObject",
-                            "s3:HeadObject",
-                            "s3:ListBucket",
-                        ],
-                        "Resource": [
-                            arns[2],  # cdn_arn
-                            f"{arns[2]}/*",
-                        ],
-                    },
-                ],
-            }
-        )
-    ),
+                    }
+                )
+            ),
+        ),
+        environment={"DYNAMODB_TABLE_NAME": DYNAMODB_TABLE_NAME},
+        layers=(dynamo_layer.arn,),
+        memory_size=3072,
+        timeout=300,
+        function_options=pulumi.ResourceOptions(
+            ignore_changes=["layers"],
+        ),
+    )
 )
 
-lambda_role_policy_attachment = aws.iam.RolePolicyAttachment(
-    f"api_{ROUTE_NAME}_lambda_policy_attachment",
-    role=lambda_role.name,
-    policy_arn=lambda_policy.arn,
-)
-
-# Attach the necessary policies to the role
-aws.iam.RolePolicyAttachment(
-    f"api_{ROUTE_NAME}_lambda_basic_execution",
-    role=lambda_role.name,
-    policy_arn="arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
-)
-
-# Create the Lambda function for the "user" route
-merchant_counts_lambda = aws.lambda_.Function(
-    f"api_{ROUTE_NAME}_GET_lambda",
-    runtime="python3.12",
-    architectures=["arm64"],
-    role=lambda_role.arn,
-    code=AssetArchive(
-        {
-            ".": FileArchive(HANDLER_DIR),
-        }
-    ),
-    handler="index.handler",
-    layers=[dynamo_layer.arn],
-    environment={
-        "variables": {
-            "DYNAMODB_TABLE_NAME": DYNAMODB_TABLE_NAME,
-        }
-    },
-    memory_size=3072,
-    timeout=300,
-    tags={"environment": pulumi.get_stack()},
-    opts=pulumi.ResourceOptions(
-        ignore_changes=["layers"],
-    ),
-)
-
-# CloudWatch log group for the Lambda function
-log_group = aws.cloudwatch.LogGroup(
-    f"api_{ROUTE_NAME}_lambda_log_group",
-    retention_in_days=30,
-)
-
-# Add a test for the Lambda Handler
+lambda_role = resources.role
+lambda_policy = resources.policy
+lambda_role_policy_attachment = resources.policy_attachment
+merchant_counts_lambda = resources.function
+log_group = resources.log_group

--- a/infra/routes/process/infra.py
+++ b/infra/routes/process/infra.py
@@ -1,144 +1,97 @@
+"""Pulumi resources for the process API Lambda."""
+
+# pylint: disable=wrong-import-order
+
 import json
 import os
 
 import pulumi
-import pulumi_aws as aws
-from pulumi import AssetArchive, FileArchive
 
-# Import the DynamoDB table name from the dynamo_db module
 from dynamo_db import dynamodb_table
-
-# Import the Lambda Layer from the lambda_layer module
 from infra.components.lambda_layer import dynamo_layer
+from infra.components.route_lambda import (
+    ManagedPolicyDefinition,
+    RouteLambdaDefinition,
+    create_route_lambda,
+)
 from raw_bucket import raw_bucket
 from s3_website import site_bucket
 
-# Reference the directory containing index.py
 HANDLER_DIR = os.path.join(os.path.dirname(__file__), "handler")
-# Get the route name from the directory name
 ROUTE_NAME = os.path.basename(os.path.dirname(__file__))
-# Get the DynamoDB table name
 DYNAMODB_TABLE_NAME = dynamodb_table.name
 
-
-# Define the IAM role for the Lambda function with permissions for the DynamoDB table
-lambda_role = aws.iam.Role(
-    f"api_{ROUTE_NAME}_lambda_role",
-    assume_role_policy="""{
-        "Version": "2012-10-17",
-        "Statement": [
-            {
-                "Action": "sts:AssumeRole",
-                "Principal": {
-                    "Service": "lambda.amazonaws.com"
-                },
-                "Effect": "Allow",
-                "Sid": ""
-            }
-        ]
-    }""",
-)
-
-lambda_policy = aws.iam.Policy(
-    f"api_{ROUTE_NAME}_lambda_policy",
-    description="IAM policy for '/process' route Lambda to query DynamoDB",
-    policy=pulumi.Output.all(
-        dynamodb_table.arn,
-        raw_bucket.arn,
-        site_bucket.arn,
-    ).apply(
-        lambda arns: json.dumps(
-            {
-                "Version": "2012-10-17",
-                "Statement": [
+resources = create_route_lambda(
+    RouteLambdaDefinition(
+        role_name=f"api_{ROUTE_NAME}_lambda_role",
+        basic_execution_attachment_name=(
+            f"api_{ROUTE_NAME}_lambda_basic_execution"
+        ),
+        function_name=f"api_{ROUTE_NAME}_GET_lambda",
+        log_group_name=f"api_{ROUTE_NAME}_lambda_log_group",
+        handler_directory=HANDLER_DIR,
+        policy=ManagedPolicyDefinition(
+            resource_name=f"api_{ROUTE_NAME}_lambda_policy",
+            attachment_name=f"api_{ROUTE_NAME}_lambda_policy_attachment",
+            description=(
+                "IAM policy for '/process' route Lambda to query DynamoDB"
+            ),
+            document=pulumi.Output.all(
+                dynamodb_table.arn,
+                raw_bucket.arn,
+                site_bucket.arn,
+            ).apply(
+                lambda arns: json.dumps(
                     {
-                        # ---------- DynamoDB Permissions ----------
-                        "Effect": "Allow",
-                        "Action": [
-                            "dynamodb:Query",
-                            "dynamodb:DescribeTable",
-                            "dynamodb:PutItem",
-                            "dynamodb:BatchWriteItem",
+                        "Version": "2012-10-17",
+                        "Statement": [
+                            {
+                                "Effect": "Allow",
+                                "Action": [
+                                    "dynamodb:Query",
+                                    "dynamodb:DescribeTable",
+                                    "dynamodb:PutItem",
+                                    "dynamodb:BatchWriteItem",
+                                ],
+                                "Resource": [
+                                    arns[0],
+                                    f"{arns[0]}/index/GSI1",
+                                ],
+                            },
+                            {
+                                "Effect": "Allow",
+                                "Action": [
+                                    "s3:PutObject",
+                                    "s3:GetObject",
+                                    "s3:HeadObject",
+                                    "s3:ListBucket",
+                                ],
+                                "Resource": [arns[1], f"{arns[1]}/*"],
+                            },
+                            {
+                                "Effect": "Allow",
+                                "Action": [
+                                    "s3:PutObject",
+                                    "s3:GetObject",
+                                    "s3:HeadObject",
+                                    "s3:ListBucket",
+                                ],
+                                "Resource": [arns[2], f"{arns[2]}/*"],
+                            },
                         ],
-                        "Resource": [
-                            arns[0],  # dynamo_arn
-                            f"{arns[0]}/index/GSI1",
-                        ],
-                    },
-                    {
-                        # ---------- S3 Permissions (Raw Bucket) ----------
-                        "Effect": "Allow",
-                        "Action": [
-                            "s3:PutObject",
-                            "s3:GetObject",
-                            "s3:HeadObject",
-                            "s3:ListBucket",
-                        ],
-                        "Resource": [
-                            arns[1],  # raw_arn
-                            f"{arns[1]}/*",
-                        ],
-                    },
-                    {
-                        # ---------- S3 Permissions (CDN Bucket) ----------
-                        "Effect": "Allow",
-                        "Action": [
-                            "s3:PutObject",
-                            "s3:GetObject",
-                            "s3:HeadObject",
-                            "s3:ListBucket",
-                        ],
-                        "Resource": [
-                            arns[2],  # cdn_arn
-                            f"{arns[2]}/*",
-                        ],
-                    },
-                ],
-            }
-        )
-    ),
+                    }
+                )
+            ),
+        ),
+        environment={"DYNAMODB_TABLE_NAME": DYNAMODB_TABLE_NAME},
+        layers=(dynamo_layer.arn,),
+        memory_size=3072,
+        timeout=300,
+    )
 )
 
-lambda_role_policy_attachment = aws.iam.RolePolicyAttachment(
-    f"api_{ROUTE_NAME}_lambda_policy_attachment",
-    role=lambda_role.name,
-    policy_arn=lambda_policy.arn,
-)
-
-# Attach the necessary policies to the role
-aws.iam.RolePolicyAttachment(
-    f"api_{ROUTE_NAME}_lambda_basic_execution",
-    role=lambda_role.name,
-    policy_arn="arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
-)
-
-# Create the Lambda function for the "user" route
-process_lambda = aws.lambda_.Function(
-    f"api_{ROUTE_NAME}_GET_lambda",
-    runtime="python3.12",
-    architectures=["arm64"],
-    role=lambda_role.arn,
-    code=AssetArchive(
-        {
-            ".": FileArchive(HANDLER_DIR),
-        }
-    ),
-    handler="index.handler",
-    layers=[dynamo_layer.arn],
-    environment={
-        "variables": {
-            "DYNAMODB_TABLE_NAME": DYNAMODB_TABLE_NAME,
-        }
-    },
-    memory_size=3072,
-    timeout=300,
-    tags={"environment": pulumi.get_stack()},
-)
-
-# CloudWatch log group for the Lambda function
-log_group = aws.cloudwatch.LogGroup(
-    f"api_{ROUTE_NAME}_lambda_log_group",
-    retention_in_days=30,
-)
-
-# Add a test for the Lambda Handler
+lambda_role = resources.role
+lambda_policy = resources.policy
+lambda_role_policy_attachment = resources.policy_attachment
+process_lambda = resources.function
+log_group = resources.log_group

--- a/infra/routes/random_image_details/infra.py
+++ b/infra/routes/random_image_details/infra.py
@@ -1,104 +1,64 @@
+"""Pulumi resources for the random-image-details API Lambda."""
+
 import json
 import os
 
-import pulumi
-import pulumi_aws as aws
-from pulumi import AssetArchive, FileArchive
-
-# Import the DynamoDB table name from the dynamo_db module
 from dynamo_db import dynamodb_table
-
-# Import the Lambda Layer from the lambda_layer module
 from infra.components.lambda_layer import dynamo_layer
+from infra.components.route_lambda import (
+    ManagedPolicyDefinition,
+    RouteLambdaDefinition,
+    create_route_lambda,
+)
 
-# Reference the directory containing index.py
 HANDLER_DIR = os.path.join(os.path.dirname(__file__), "handler")
-# Get the route name from the directory name
 ROUTE_NAME = os.path.basename(os.path.dirname(__file__))
-# Get the DynamoDB table name
 DYNAMODB_TABLE_NAME = dynamodb_table.name
 
-
-# Define the IAM role for the Lambda function with permissions for the DynamoDB table
-lambda_role = aws.iam.Role(
-    f"api_{ROUTE_NAME}_lambda_role",
-    assume_role_policy="""{
-        "Version": "2012-10-17",
-        "Statement": [
-            {
-                "Action": "sts:AssumeRole",
-                "Principal": {
-                    "Service": "lambda.amazonaws.com"
-                },
-                "Effect": "Allow",
-                "Sid": ""
-            }
-        ]
-    }""",
-)
-
-# Attach the necessary policies to the role
-lambda_policy = aws.iam.Policy(
-    f"api_{ROUTE_NAME}_lambda_policy",
-    description="IAM policy for Lambda to access DynamoDB",
-    policy=dynamodb_table.arn.apply(
-        lambda arn: json.dumps(
-            {
-                "Version": "2012-10-17",
-                "Statement": [
+resources = create_route_lambda(
+    RouteLambdaDefinition(
+        role_name=f"api_{ROUTE_NAME}_lambda_role",
+        basic_execution_attachment_name=(
+            f"api_{ROUTE_NAME}_lambda_basic_execution"
+        ),
+        function_name=f"api_{ROUTE_NAME}_GET_lambda",
+        log_group_name=f"api_{ROUTE_NAME}_lambda_log_group",
+        handler_directory=HANDLER_DIR,
+        policy=ManagedPolicyDefinition(
+            resource_name=f"api_{ROUTE_NAME}_lambda_policy",
+            attachment_name=f"api_{ROUTE_NAME}_lambda_policy_attachment",
+            description="IAM policy for Lambda to access DynamoDB",
+            document=dynamodb_table.arn.apply(
+                lambda arn: json.dumps(
                     {
-                        "Effect": "Allow",
-                        "Action": ["dynamodb:Query", "dynamodb:DescribeTable"],
-                        "Resource": [
-                            arn,
-                            f"{arn}/index/*",
-                            f"{arn}/index/GSITYPE",
+                        "Version": "2012-10-17",
+                        "Statement": [
+                            {
+                                "Effect": "Allow",
+                                "Action": [
+                                    "dynamodb:Query",
+                                    "dynamodb:DescribeTable",
+                                ],
+                                "Resource": [
+                                    arn,
+                                    f"{arn}/index/*",
+                                    f"{arn}/index/GSITYPE",
+                                ],
+                            }
                         ],
                     }
-                ],
-            }
-        )
-    ),
+                )
+            ),
+        ),
+        environment={"DYNAMODB_TABLE_NAME": DYNAMODB_TABLE_NAME},
+        layers=(dynamo_layer.arn,),
+        memory_size=1024,
+        timeout=30,
+    )
 )
 
-lambda_role_policy_attachment = aws.iam.RolePolicyAttachment(
-    f"api_{ROUTE_NAME}_lambda_policy_attachment",
-    role=lambda_role.name,
-    policy_arn=lambda_policy.arn,
-)
-
-# Attach the necessary policies to the role
-aws.iam.RolePolicyAttachment(
-    f"api_{ROUTE_NAME}_lambda_basic_execution",
-    role=lambda_role.name,
-    policy_arn="arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
-)
-
-# Create the Lambda function for the "user" route
-random_image_details_lambda = aws.lambda_.Function(
-    f"api_{ROUTE_NAME}_GET_lambda",
-    runtime="python3.12",
-    architectures=["arm64"],
-    role=lambda_role.arn,
-    code=AssetArchive(
-        {
-            ".": FileArchive(HANDLER_DIR),
-        }
-    ),
-    handler="index.handler",
-    layers=[dynamo_layer.arn],
-    environment={
-        "variables": {
-            "DYNAMODB_TABLE_NAME": DYNAMODB_TABLE_NAME,
-        }
-    },
-    memory_size=1024,
-    timeout=30,
-    tags={"environment": pulumi.get_stack()},
-)
-
-# CloudWatch log group for the Lambda function
-log_group = aws.cloudwatch.LogGroup(
-    f"api_{ROUTE_NAME}_lambda_log_group",
-    retention_in_days=30,
-)
+lambda_role = resources.role
+lambda_policy = resources.policy
+lambda_role_policy_attachment = resources.policy_attachment
+random_image_details_lambda = resources.function
+log_group = resources.log_group

--- a/infra/routes/random_receipt_details/infra.py
+++ b/infra/routes/random_receipt_details/infra.py
@@ -1,114 +1,66 @@
+"""Pulumi resources for the random-receipt-details API Lambda."""
+
 import json
 import os
 
-import pulumi
-import pulumi_aws as aws
-from pulumi import AssetArchive, FileArchive
-
-# Import the DynamoDB table name from the dynamo_db module
 from dynamo_db import dynamodb_table
-
-# Import the Lambda Layer from the lambda_layer module
 from infra.components.lambda_layer import dynamo_layer
+from infra.components.route_lambda import (
+    ManagedPolicyDefinition,
+    RouteLambdaDefinition,
+    create_route_lambda,
+)
 
-# Reference the directory containing index.py
 HANDLER_DIR = os.path.join(os.path.dirname(__file__), "handler")
-# Get the route name from the directory name
 ROUTE_NAME = os.path.basename(os.path.dirname(__file__))
-# Get the DynamoDB table name
 DYNAMODB_TABLE_NAME = dynamodb_table.name
 
-
-# Define the IAM role for the Lambda function with permissions for the DynamoDB table
-lambda_role = aws.iam.Role(
-    f"api_{ROUTE_NAME}_lambda_role",
-    assume_role_policy="""{
-        "Version": "2012-10-17",
-        "Statement": [
-            {
-                "Action": "sts:AssumeRole",
-                "Principal": {
-                    "Service": "lambda.amazonaws.com"
-                },
-                "Effect": "Allow",
-                "Sid": ""
-            }
-        ]
-    }""",
-)
-
-# Attach the necessary policies to the role
-lambda_policy = aws.iam.Policy(
-    f"api_{ROUTE_NAME}_lambda_policy",
-    description="IAM policy for Lambda to access DynamoDB",
-    policy=dynamodb_table.arn.apply(
-        lambda arn: json.dumps(
-            {
-                "Version": "2012-10-17",
-                "Statement": [
+resources = create_route_lambda(
+    RouteLambdaDefinition(
+        role_name=f"api_{ROUTE_NAME}_lambda_role",
+        basic_execution_attachment_name=(
+            f"api_{ROUTE_NAME}_lambda_basic_execution"
+        ),
+        function_name=f"api_{ROUTE_NAME}_GET_lambda",
+        log_group_name=f"api_{ROUTE_NAME}_lambda_log_group",
+        handler_directory=HANDLER_DIR,
+        policy=ManagedPolicyDefinition(
+            resource_name=f"api_{ROUTE_NAME}_lambda_policy",
+            attachment_name=f"api_{ROUTE_NAME}_lambda_policy_attachment",
+            description="IAM policy for Lambda to access DynamoDB",
+            document=dynamodb_table.arn.apply(
+                lambda arn: json.dumps(
                     {
-                        "Effect": "Allow",
-                        "Action": [
-                            "dynamodb:Query",
-                            "dynamodb:GetItem",
-                            "dynamodb:DescribeTable",
-                        ],
-                        "Resource": [
-                            arn,
-                            f"{arn}/index/*",
-                            f"{arn}/index/GSITYPE",
+                        "Version": "2012-10-17",
+                        "Statement": [
+                            {
+                                "Effect": "Allow",
+                                "Action": [
+                                    "dynamodb:Query",
+                                    "dynamodb:GetItem",
+                                    "dynamodb:DescribeTable",
+                                ],
+                                "Resource": [
+                                    arn,
+                                    f"{arn}/index/*",
+                                    f"{arn}/index/GSITYPE",
+                                ],
+                            }
                         ],
                     }
-                ],
-            }
-        )
-    ),
+                )
+            ),
+        ),
+        environment={"DYNAMODB_TABLE_NAME": DYNAMODB_TABLE_NAME},
+        layers=(dynamo_layer.arn,),
+        memory_size=1024,
+        timeout=60,
+        use_function_log_group_name=True,
+    )
 )
 
-lambda_role_policy_attachment = aws.iam.RolePolicyAttachment(
-    f"api_{ROUTE_NAME}_lambda_policy_attachment",
-    role=lambda_role.name,
-    policy_arn=lambda_policy.arn,
-)
-
-# Attach the necessary policies to the role
-aws.iam.RolePolicyAttachment(
-    f"api_{ROUTE_NAME}_lambda_basic_execution",
-    role=lambda_role.name,
-    policy_arn="arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
-)
-
-# Create the Lambda function for the route
-random_receipt_details_lambda = aws.lambda_.Function(
-    f"api_{ROUTE_NAME}_GET_lambda",
-    runtime="python3.12",
-    architectures=["arm64"],
-    role=lambda_role.arn,
-    code=AssetArchive(
-        {
-            ".": FileArchive(HANDLER_DIR),
-        }
-    ),
-    handler="index.handler",
-    layers=[dynamo_layer.arn],
-    environment={
-        "variables": {
-            "DYNAMODB_TABLE_NAME": DYNAMODB_TABLE_NAME,
-        }
-    },
-    memory_size=1024,
-    timeout=60,  # 1 minute should be enough for receipt details
-    tags={"environment": pulumi.get_stack()},
-)
-
-# CloudWatch log group for the Lambda function
-# Use the exact Lambda log group name format: /aws/lambda/<function-name>
-# Note: If deployment fails with "log group already exists", import it:
-#   pulumi import aws:cloudwatch/logGroup:LogGroup api_random_receipt_details_lambda_log_group /aws/lambda/api_random_receipt_details_GET_lambda-<hash>
-log_group = aws.cloudwatch.LogGroup(
-    f"api_{ROUTE_NAME}_lambda_log_group",
-    name=random_receipt_details_lambda.name.apply(
-        lambda function_name: f"/aws/lambda/{function_name}"
-    ),
-    retention_in_days=30,
-)
+lambda_role = resources.role
+lambda_policy = resources.policy
+lambda_role_policy_attachment = resources.policy_attachment
+random_receipt_details_lambda = resources.function
+log_group = resources.log_group

--- a/infra/routes/reader_summary/infra.py
+++ b/infra/routes/reader_summary/infra.py
@@ -1,11 +1,16 @@
+"""Pulumi resources for the reader-summary API Lambda."""
+
 import json
 import os
 
 import pulumi
-import pulumi_aws as aws
-from pulumi import AssetArchive, FileArchive
 
 from dynamo_db import dynamodb_table
+from infra.components.route_lambda import (
+    ManagedPolicyDefinition,
+    RouteLambdaDefinition,
+    create_route_lambda,
+)
 
 HANDLER_DIR = os.path.join(os.path.dirname(__file__), "handler")
 ROUTE_NAME = os.path.basename(os.path.dirname(__file__))
@@ -16,98 +21,68 @@ ALLOWED_ORIGINS = [
     "https://dev.tylernorlund.com",
 ]
 
-lambda_role = aws.iam.Role(
-    f"api_{ROUTE_NAME}_lambda_role",
-    assume_role_policy="""{
-        "Version": "2012-10-17",
-        "Statement": [
-            {
-                "Action": "sts:AssumeRole",
-                "Principal": {
-                    "Service": "lambda.amazonaws.com"
-                },
-                "Effect": "Allow",
-                "Sid": ""
-            }
-        ]
-    }""",
-)
-
-lambda_policy = aws.iam.Policy(
-    f"api_{ROUTE_NAME}_lambda_policy",
-    description="IAM policy for reader summary Lambda to aggregate reads",
-    policy=dynamodb_table.arn.apply(
-        lambda arn: json.dumps(
-            {
-                "Version": "2012-10-17",
-                "Statement": [
+resources = create_route_lambda(
+    RouteLambdaDefinition(
+        role_name=f"api_{ROUTE_NAME}_lambda_role",
+        basic_execution_attachment_name=(
+            f"api_{ROUTE_NAME}_lambda_basic_execution"
+        ),
+        function_name=f"api_{ROUTE_NAME}_POST_lambda",
+        log_group_name=f"api_{ROUTE_NAME}_lambda_log_group",
+        handler_directory=HANDLER_DIR,
+        policy=ManagedPolicyDefinition(
+            resource_name=f"api_{ROUTE_NAME}_lambda_policy",
+            attachment_name=f"api_{ROUTE_NAME}_lambda_policy_attachment",
+            description=(
+                "IAM policy for reader summary Lambda to aggregate reads"
+            ),
+            document=dynamodb_table.arn.apply(
+                lambda arn: json.dumps(
                     {
-                        "Effect": "Allow",
-                        "Action": "dynamodb:DescribeTable",
-                        "Resource": arn,
-                    },
-                    {
-                        "Effect": "Allow",
-                        "Action": [
-                            "dynamodb:DeleteItem",
-                            "dynamodb:GetItem",
-                            "dynamodb:PutItem",
-                            "dynamodb:UpdateItem",
+                        "Version": "2012-10-17",
+                        "Statement": [
+                            {
+                                "Effect": "Allow",
+                                "Action": "dynamodb:DescribeTable",
+                                "Resource": arn,
+                            },
+                            {
+                                "Effect": "Allow",
+                                "Action": [
+                                    "dynamodb:DeleteItem",
+                                    "dynamodb:GetItem",
+                                    "dynamodb:PutItem",
+                                    "dynamodb:UpdateItem",
+                                ],
+                                "Resource": arn,
+                                "Condition": {
+                                    "ForAllValues:StringLike": {
+                                        "dynamodb:LeadingKeys": [
+                                            "READER_SUMMARY#*"
+                                        ]
+                                    }
+                                },
+                            },
                         ],
-                        "Resource": arn,
-                        "Condition": {
-                            "ForAllValues:StringLike": {
-                                "dynamodb:LeadingKeys": [
-                                    "READER_SUMMARY#*"
-                                ]
-                            }
-                        },
                     }
-                ],
-            }
-        )
-    ),
-)
-
-aws.iam.RolePolicyAttachment(
-    f"api_{ROUTE_NAME}_lambda_policy_attachment",
-    role=lambda_role.name,
-    policy_arn=lambda_policy.arn,
-)
-
-aws.iam.RolePolicyAttachment(
-    f"api_{ROUTE_NAME}_lambda_basic_execution",
-    role=lambda_role.name,
-    policy_arn="arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
-)
-
-reader_summary_lambda = aws.lambda_.Function(
-    f"api_{ROUTE_NAME}_POST_lambda",
-    runtime="python3.12",
-    architectures=["arm64"],
-    role=lambda_role.arn,
-    code=AssetArchive(
-        {
-            ".": FileArchive(HANDLER_DIR),
-        }
-    ),
-    handler="index.handler",
-    environment={
-        "variables": {
+                )
+            ),
+        ),
+        environment={
             "READER_SUMMARY_TABLE_NAME": dynamodb_table.name,
             "MINIMUM_SAMPLE_SIZE": "5",
             "ALLOWED_ORIGINS": ",".join(ALLOWED_ORIGINS),
-        }
-    },
-    memory_size=256,
-    timeout=10,
-    tags={"environment": pulumi.get_stack()},
+        },
+        memory_size=256,
+        timeout=10,
+        log_retention_in_days=14,
+        use_function_log_group_name=True,
+    )
 )
 
-log_group = aws.cloudwatch.LogGroup(
-    f"api_{ROUTE_NAME}_lambda_log_group",
-    name=pulumi.Output.concat("/aws/lambda/", reader_summary_lambda.name),
-    retention_in_days=14,
-)
+lambda_role = resources.role
+lambda_policy = resources.policy
+reader_summary_lambda = resources.function
+log_group = resources.log_group
 
 pulumi.export(f"{ROUTE_NAME}_lambda_arn", reader_summary_lambda.arn)

--- a/infra/routes/receipt_count/infra.py
+++ b/infra/routes/receipt_count/infra.py
@@ -1,99 +1,63 @@
+"""Pulumi resources for the receipt-count API Lambda."""
+
 import json
 import os
 
-import pulumi
-import pulumi_aws as aws
-from pulumi import AssetArchive, FileArchive
-
-# Import the DynamoDB table name from the dynamo_db module
 from dynamo_db import dynamodb_table
-
-# Import the Lambda Layer from the lambda_layer module
 from infra.components.lambda_layer import dynamo_layer
+from infra.components.route_lambda import (
+    ManagedPolicyDefinition,
+    RouteLambdaDefinition,
+    create_route_lambda,
+)
 
-# Reference the directory containing index.py
 HANDLER_DIR = os.path.join(os.path.dirname(__file__), "handler")
-# Get the route name from the directory name
 ROUTE_NAME = os.path.basename(os.path.dirname(__file__))
-# Get the DynamoDB table name
 DYNAMODB_TABLE_NAME = dynamodb_table.name
 
-
-# Define the IAM role for the Lambda function with permissions for the DynamoDB table
-lambda_role = aws.iam.Role(
-    f"api_{ROUTE_NAME}_lambda_role",
-    assume_role_policy="""{
-        "Version": "2012-10-17",
-        "Statement": [
-            {
-                "Action": "sts:AssumeRole",
-                "Principal": {
-                    "Service": "lambda.amazonaws.com"
-                },
-                "Effect": "Allow",
-                "Sid": ""
-            }
-        ]
-    }""",
-)
-
-# Attach the necessary policies to the role
-lambda_policy = aws.iam.Policy(
-    f"api_{ROUTE_NAME}_lambda_policy",
-    description="IAM policy for Lambda to access DynamoDB",
-    policy=dynamodb_table.arn.apply(
-        lambda arn: json.dumps(
-            {
-                "Version": "2012-10-17",
-                "Statement": [
+resources = create_route_lambda(
+    RouteLambdaDefinition(
+        role_name=f"api_{ROUTE_NAME}_lambda_role",
+        basic_execution_attachment_name=(
+            f"api_{ROUTE_NAME}_lambda_basic_execution"
+        ),
+        function_name=f"api_{ROUTE_NAME}_GET_lambda",
+        log_group_name=f"api_{ROUTE_NAME}_lambda_log_group",
+        handler_directory=HANDLER_DIR,
+        policy=ManagedPolicyDefinition(
+            resource_name=f"api_{ROUTE_NAME}_lambda_policy",
+            attachment_name=f"api_{ROUTE_NAME}_lambda_policy_attachment",
+            description="IAM policy for Lambda to access DynamoDB",
+            document=dynamodb_table.arn.apply(
+                lambda arn: json.dumps(
                     {
-                        "Effect": "Allow",
-                        "Action": ["dynamodb:Query", "dynamodb:DescribeTable"],
-                        "Resource": [arn, f"{arn}/index/GSITYPE"],
+                        "Version": "2012-10-17",
+                        "Statement": [
+                            {
+                                "Effect": "Allow",
+                                "Action": [
+                                    "dynamodb:Query",
+                                    "dynamodb:DescribeTable",
+                                ],
+                                "Resource": [
+                                    arn,
+                                    f"{arn}/index/GSITYPE",
+                                ],
+                            }
+                        ],
                     }
-                ],
-            }
-        )
-    ),
+                )
+            ),
+        ),
+        environment={"DYNAMODB_TABLE_NAME": DYNAMODB_TABLE_NAME},
+        layers=(dynamo_layer.arn,),
+        memory_size=1024,
+    )
 )
 
-lambda_role_policy_attachment = aws.iam.RolePolicyAttachment(
-    f"api_{ROUTE_NAME}_lambda_policy_attachment",
-    role=lambda_role.name,
-    policy_arn=lambda_policy.arn,
-)
-
-# Attach the necessary policies to the role
-aws.iam.RolePolicyAttachment(
-    f"api_{ROUTE_NAME}_lambda_basic_execution",
-    role=lambda_role.name,
-    policy_arn="arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
-)
-
-# Create the Lambda function for the "user" route
-receipt_count_lambda = aws.lambda_.Function(
-    f"api_{ROUTE_NAME}_GET_lambda",
-    runtime="python3.12",
-    architectures=["arm64"],
-    role=lambda_role.arn,
-    code=AssetArchive(
-        {
-            ".": FileArchive(HANDLER_DIR),
-        }
-    ),
-    handler="index.handler",
-    layers=[dynamo_layer.arn],
-    environment={
-        "variables": {
-            "DYNAMODB_TABLE_NAME": DYNAMODB_TABLE_NAME,
-        }
-    },
-    memory_size=1024,
-    tags={"environment": pulumi.get_stack()},
-)
-
-# CloudWatch log group for the Lambda function
-log_group = aws.cloudwatch.LogGroup(
-    f"api_{ROUTE_NAME}_lambda_log_group",
-    retention_in_days=30,
-)
+# Keep the established module API used by the gateway and any stack imports.
+lambda_role = resources.role
+lambda_policy = resources.policy
+lambda_role_policy_attachment = resources.policy_attachment
+receipt_count_lambda = resources.function
+log_group = resources.log_group

--- a/infra/routes/receipts/infra.py
+++ b/infra/routes/receipts/infra.py
@@ -1,102 +1,65 @@
+"""Pulumi resources for the receipts API Lambda."""
+
 import json
 import os
 
-import pulumi
-import pulumi_aws as aws
-from pulumi import AssetArchive, FileArchive
-
-# Import the DynamoDB table name from the dynamo_db module
 from dynamo_db import dynamodb_table
-
-# Import the Lambda Layer from the lambda_layer module
 from infra.components.lambda_layer import dynamo_layer
+from infra.components.route_lambda import (
+    ManagedPolicyDefinition,
+    RouteLambdaDefinition,
+    create_route_lambda,
+)
 
-# Reference the directory containing index.py
 HANDLER_DIR = os.path.join(os.path.dirname(__file__), "handler")
-# Get the route name from the directory name
 ROUTE_NAME = os.path.basename(os.path.dirname(__file__))
-# Get the DynamoDB table name
 DYNAMODB_TABLE_NAME = dynamodb_table.name
 
-
-# Define the IAM role for the Lambda function with permissions for the DynamoDB table
-lambda_role = aws.iam.Role(
-    f"api_{ROUTE_NAME}_lambda_role",
-    assume_role_policy="""{
-        "Version": "2012-10-17",
-        "Statement": [
-            {
-                "Action": "sts:AssumeRole",
-                "Principal": {
-                    "Service": "lambda.amazonaws.com"
-                },
-                "Effect": "Allow",
-                "Sid": ""
-            }
-        ]
-    }""",
-)
-
-# Attach the necessary policies to the role
-lambda_policy = aws.iam.Policy(
-    f"api_{ROUTE_NAME}_lambda_policy",
-    description="IAM policy for '/images' route Lambda to query DynamoDB",
-    policy=dynamodb_table.arn.apply(
-        lambda arn: json.dumps(
-            {
-                "Version": "2012-10-17",
-                "Statement": [
+resources = create_route_lambda(
+    RouteLambdaDefinition(
+        role_name=f"api_{ROUTE_NAME}_lambda_role",
+        basic_execution_attachment_name=(
+            f"api_{ROUTE_NAME}_lambda_basic_execution"
+        ),
+        function_name=f"api_{ROUTE_NAME}_GET_lambda",
+        log_group_name=f"api_{ROUTE_NAME}_lambda_log_group",
+        handler_directory=HANDLER_DIR,
+        policy=ManagedPolicyDefinition(
+            resource_name=f"api_{ROUTE_NAME}_lambda_policy",
+            attachment_name=f"api_{ROUTE_NAME}_lambda_policy_attachment",
+            description=(
+                "IAM policy for '/images' route Lambda to query DynamoDB"
+            ),
+            document=dynamodb_table.arn.apply(
+                lambda arn: json.dumps(
                     {
-                        "Effect": "Allow",
-                        "Action": ["dynamodb:Query", "dynamodb:DescribeTable"],
-                        "Resource": [arn, f"{arn}/index/GSITYPE"],
+                        "Version": "2012-10-17",
+                        "Statement": [
+                            {
+                                "Effect": "Allow",
+                                "Action": [
+                                    "dynamodb:Query",
+                                    "dynamodb:DescribeTable",
+                                ],
+                                "Resource": [
+                                    arn,
+                                    f"{arn}/index/GSITYPE",
+                                ],
+                            }
+                        ],
                     }
-                ],
-            }
-        )
-    ),
+                )
+            ),
+        ),
+        environment={"DYNAMODB_TABLE_NAME": DYNAMODB_TABLE_NAME},
+        layers=(dynamo_layer.arn,),
+        memory_size=1024,
+        timeout=120,
+    )
 )
 
-lambda_role_policy_attachment = aws.iam.RolePolicyAttachment(
-    f"api_{ROUTE_NAME}_lambda_policy_attachment",
-    role=lambda_role.name,
-    policy_arn=lambda_policy.arn,
-)
-
-# Attach the necessary policies to the role
-aws.iam.RolePolicyAttachment(
-    f"api_{ROUTE_NAME}_lambda_basic_execution",
-    role=lambda_role.name,
-    policy_arn="arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
-)
-
-# Create the Lambda function for the "user" route
-receipts_lambda = aws.lambda_.Function(
-    f"api_{ROUTE_NAME}_GET_lambda",
-    runtime="python3.12",
-    architectures=["arm64"],
-    role=lambda_role.arn,
-    code=AssetArchive(
-        {
-            ".": FileArchive(HANDLER_DIR),
-        }
-    ),
-    handler="index.handler",
-    layers=[dynamo_layer.arn],
-    environment={
-        "variables": {
-            "DYNAMODB_TABLE_NAME": DYNAMODB_TABLE_NAME,
-        }
-    },
-    memory_size=1024,
-    timeout=60 * 2,
-    tags={"environment": pulumi.get_stack()},
-)
-
-# CloudWatch log group for the Lambda function
-log_group = aws.cloudwatch.LogGroup(
-    f"api_{ROUTE_NAME}_lambda_log_group",
-    retention_in_days=30,
-)
-
-# Add a test for the Lambda Handler
+lambda_role = resources.role
+lambda_policy = resources.policy
+lambda_role_policy_attachment = resources.policy_attachment
+receipts_lambda = resources.function
+log_group = resources.log_group


### PR DESCRIPTION
## Summary

- add a typed, plain Pulumi factory for the IAM role, optional route policy, Lambda archive, basic execution attachment, and CloudWatch log group shared by API handlers
- migrate 12 static API Lambda modules while preserving their existing logical resource names, parents, handler settings, policies, environment variables, timeouts, concurrency, exports, and module-level Lambda variables
- cover managed and inline IAM policy variants, custom handlers, named log groups, concurrency, and resource options with focused unit tests

## Why

The route modules repeated the same IAM → Lambda → log wiring, which made small configuration differences hard to review. The helper keeps those differences explicit in route-local definitions without introducing a `ComponentResource`, so existing resources are not reparented and Pulumi URNs remain stable.

## Collision audit

Open PRs, remote branches, and all local worktrees were checked before implementation and again before commit. This PR intentionally avoids the actively changing `infra/__main__.py`, Chroma, CodeBuild, upload pipeline, web analytics, S3 website, Step Functions, SageMaker, training metrics, and cache-generator files. The final path-level audit found no overlap with another active branch or uncommitted worktree.

## Validation

- `python3 -m pytest -q infra/components/test_route_lambda.py infra/components/test_http_api_route.py` — 12 passed
- Black and isort checks — passed
- mypy on the new helper and tests — passed
- pylint on the helper/tests and each migrated route — passed
- compileall and `git diff --check` — passed
- `pulumi preview --stack dev --diff --non-interactive` — completed successfully; the stack has unrelated async-build/worktree-path drift, but filtering the preview to every migrated route logical-name prefix produced no route creates, updates, deletes, or replacements


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Standardized deployment configuration across API Lambda routes.
  * Consistent runtime settings, environment variables, permissions, concurrency controls, and CloudWatch log retention are now applied across supported routes.
  * Existing route functionality and exported infrastructure resources remain available.

* **Tests**
  * Added coverage for Lambda resource creation, policy configuration, logging options, and invalid configuration handling.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->