### PR TITLE
[infra] Extract validation visualization handlers

### DIFF
--- a/infra/components/test_label_validation_viz_handlers.py
+++ b/infra/components/test_label_validation_viz_handlers.py
@@ -1,0 +1,112 @@
+"""Focused tests for extracted visualization workflow handlers."""
+
+import importlib.util
+import io
+import json
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from typing import Any
+
+import pytest
+
+
+def _load_handler(module_name: str) -> ModuleType:
+    """Load a handler without importing the eager Pulumi package."""
+    path = (
+        Path(__file__).parents[1]
+        / "routes"
+        / "label_validation_viz_cache"
+        / "handlers"
+        / f"{module_name}.py"
+    )
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load handler: {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+check_export = _load_handler("check_export")
+trigger_export = _load_handler("trigger_export")
+
+
+class FakeHttp:
+    """Return a configured response and record the outbound request."""
+
+    def __init__(self, response: SimpleNamespace) -> None:
+        self.response = response
+        self.requests: list[tuple[str, str, dict[str, Any]]] = []
+
+    def request(self, method: str, url: str, **kwargs: Any) -> SimpleNamespace:
+        self.requests.append((method, url, kwargs))
+        return self.response
+
+
+@pytest.mark.parametrize(
+    ("source_status", "expected_status"),
+    [
+        ("Complete", "completed"),
+        ("Completed", "completed"),
+        ("Failed", "failed"),
+        ("Cancelled", "failed"),
+        ("Pending", "pending"),
+        ("Running", "pending"),
+        ("InProgress", "pending"),
+        ("Unexpected", "Unexpected"),
+    ],
+)
+def test_check_export_normalizes_langsmith_status(
+    monkeypatch: pytest.MonkeyPatch,
+    source_status: str,
+    expected_status: str,
+) -> None:
+    response = SimpleNamespace(
+        status=200,
+        data=json.dumps({"status": source_status}).encode(),
+    )
+    http = FakeHttp(response)
+    monkeypatch.setenv("LANGCHAIN_API_KEY", "secret")
+    monkeypatch.setattr(check_export.urllib3, "PoolManager", lambda: http)
+
+    result = check_export.handler({"export_id": "export-1"}, None)
+
+    assert result == {
+        "export_id": "export-1",
+        "status": expected_status,
+    }
+    assert http.requests == [
+        (
+            "GET",
+            "https://api.smith.langchain.com/api/v1/bulk-exports/export-1",
+            {"headers": {"x-api-key": "secret"}},
+        )
+    ]
+
+
+def test_check_export_requires_an_export_id() -> None:
+    with pytest.raises(ValueError, match="export_id is required"):
+        check_export.handler({}, None)
+
+
+def test_trigger_export_reads_destination_from_setup_lambda(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = io.BytesIO(
+        json.dumps(
+            {"statusCode": 200, "destination_id": "destination-1"}
+        ).encode()
+    )
+    lambda_client = SimpleNamespace(
+        invoke=lambda **_kwargs: {"Payload": payload}
+    )
+    monkeypatch.setattr(
+        trigger_export.boto3,
+        "client",
+        lambda service: lambda_client if service == "lambda" else None,
+    )
+
+    assert (
+        trigger_export._ensure_destination_exists("setup-lambda")
+        == "destination-1"
+    )

--- a/infra/routes/label_validation_viz_cache/handlers/__init__.py
+++ b/infra/routes/label_validation_viz_cache/handlers/__init__.py
@@ -1,0 +1,1 @@
+"""Lambda handlers for the label-validation visualization workflow."""

--- a/infra/routes/label_validation_viz_cache/handlers/check_export.py
+++ b/infra/routes/label_validation_viz_cache/handlers/check_export.py
@@ -1,0 +1,51 @@
+import json
+import logging
+import os
+
+import urllib3
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+LANGSMITH_API_URL = "https://api.smith.langchain.com"
+
+
+def handler(event, context):
+    """Check LangSmith export status."""
+    logger.info("Received event: %s", json.dumps(event))
+
+    export_id = event.get("export_id")
+    if not export_id:
+        raise ValueError("export_id is required")
+
+    api_key = os.environ["LANGCHAIN_API_KEY"]
+
+    http = urllib3.PoolManager()
+
+    response = http.request(
+        "GET",
+        f"{LANGSMITH_API_URL}/api/v1/bulk-exports/{export_id}",
+        headers={"x-api-key": api_key},
+    )
+
+    if response.status != 200:
+        logger.error("Failed to check export: %s", response.data.decode())
+        return {"status": "error", "export_id": export_id}
+
+    result = json.loads(response.data.decode("utf-8"))
+    status = result.get("status", "unknown")
+
+    # Normalize status
+    if status in ("Complete", "Completed"):
+        status = "completed"
+    elif status in ("Failed", "Cancelled"):
+        status = "failed"
+    elif status in ("Pending", "Running", "InProgress"):
+        status = "pending"
+
+    logger.info("Export %s status: %s", export_id, status)
+
+    return {
+        "export_id": export_id,
+        "status": status,
+    }

--- a/infra/routes/label_validation_viz_cache/handlers/dynamo_query.py
+++ b/infra/routes/label_validation_viz_cache/handlers/dynamo_query.py
@@ -1,0 +1,167 @@
+import json
+import logging
+import os
+
+import boto3
+from botocore.exceptions import ClientError
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+# Limit receipts to prevent memory issues - visualization only needs a sample
+MAX_RECEIPTS = 500
+
+
+def handler(event, context):
+    """Query receipts, words, and labels from DynamoDB and write to S3.
+
+    The EMR job needs:
+    - Receipt CDN keys (for image display)
+    - Word bounding boxes (for overlays)
+    - Labels (for validation word filtering)
+
+    Limited to MAX_RECEIPTS to prevent memory exhaustion.
+    """
+    logger.info("Received event: %s", json.dumps(event))
+
+    table_name = os.environ["DYNAMODB_TABLE"]
+    cache_bucket = os.environ["CACHE_BUCKET"]
+
+    # Import receipt_dynamo (from layer)
+    from receipt_dynamo import DynamoClient
+
+    client = DynamoClient(table_name)
+
+    logger.info(
+        "Querying receipts from DynamoDB table: %s (limit: %d)",
+        table_name,
+        MAX_RECEIPTS,
+    )
+
+    receipt_lookup = {}
+    page_count = 0
+    last_key = None
+
+    # First page of receipts
+    receipts, last_key = client.list_receipts(limit=500)
+    page_count += 1
+
+    for r in receipts:
+        if len(receipt_lookup) >= MAX_RECEIPTS:
+            break
+
+        key = f"{r.image_id}_{r.receipt_id}"
+
+        words = client.list_receipt_words_from_receipt(
+            r.image_id, r.receipt_id
+        )
+        words_data = [
+            {
+                "line_id": w.line_id,
+                "word_id": w.word_id,
+                "text": w.text,
+                "bbox": w.bounding_box,
+            }
+            for w in words
+        ]
+
+        labels, _ = client.list_receipt_word_labels_for_receipt(
+            r.image_id, r.receipt_id
+        )
+        labels_data = {
+            f"{label.line_id}_{label.word_id}": label.label for label in labels
+        }
+
+        receipt_lookup[key] = {
+            "cdn_s3_key": r.cdn_s3_key or "",
+            "cdn_webp_s3_key": r.cdn_webp_s3_key,
+            "cdn_avif_s3_key": r.cdn_avif_s3_key,
+            "cdn_medium_s3_key": r.cdn_medium_s3_key,
+            "cdn_medium_webp_s3_key": r.cdn_medium_webp_s3_key,
+            "cdn_medium_avif_s3_key": r.cdn_medium_avif_s3_key,
+            "width": r.width or 0,
+            "height": r.height or 0,
+            "words": words_data,
+            "labels": labels_data,
+        }
+
+    # Paginate through remaining receipts until limit reached
+    while last_key and len(receipt_lookup) < MAX_RECEIPTS:
+        receipts, last_key = client.list_receipts(
+            limit=500, last_evaluated_key=last_key
+        )
+        page_count += 1
+
+        for r in receipts:
+            if len(receipt_lookup) >= MAX_RECEIPTS:
+                break
+
+            key = f"{r.image_id}_{r.receipt_id}"
+
+            words = client.list_receipt_words_from_receipt(
+                r.image_id, r.receipt_id
+            )
+            words_data = [
+                {
+                    "line_id": w.line_id,
+                    "word_id": w.word_id,
+                    "text": w.text,
+                    "bbox": w.bounding_box,
+                }
+                for w in words
+            ]
+
+            labels, _ = client.list_receipt_word_labels_for_receipt(
+                r.image_id, r.receipt_id
+            )
+            labels_data = {
+                f"{label.line_id}_{label.word_id}": label.label
+                for label in labels
+            }
+
+            receipt_lookup[key] = {
+                "cdn_s3_key": r.cdn_s3_key or "",
+                "cdn_webp_s3_key": r.cdn_webp_s3_key,
+                "cdn_avif_s3_key": r.cdn_avif_s3_key,
+                "cdn_medium_s3_key": r.cdn_medium_s3_key,
+                "cdn_medium_webp_s3_key": r.cdn_medium_webp_s3_key,
+                "cdn_medium_avif_s3_key": r.cdn_medium_avif_s3_key,
+                "width": r.width or 0,
+                "height": r.height or 0,
+                "words": words_data,
+                "labels": labels_data,
+            }
+
+        logger.info(
+            "Processed page %d, total receipts: %d",
+            page_count,
+            len(receipt_lookup),
+        )
+
+    logger.info(
+        "Collected %d receipts across %d pages (limit: %d)",
+        len(receipt_lookup),
+        page_count,
+        MAX_RECEIPTS,
+    )
+
+    # Write to S3
+    s3 = boto3.client("s3")
+    s3_key = "receipts-lookup.json"
+    try:
+        s3.put_object(
+            Bucket=cache_bucket,
+            Key=s3_key,
+            Body=json.dumps(receipt_lookup),
+            ContentType="application/json",
+        )
+    except ClientError:
+        logger.exception("Failed to write receipts lookup to S3")
+        raise
+
+    logger.info("Wrote %s to s3://%s/%s", s3_key, cache_bucket, s3_key)
+
+    return {
+        "receipt_count": len(receipt_lookup),
+        "receipts_s3_path": f"s3://{cache_bucket}/{s3_key}",
+    }

--- a/infra/routes/label_validation_viz_cache/handlers/trigger_export.py
+++ b/infra/routes/label_validation_viz_cache/handlers/trigger_export.py
@@ -1,0 +1,143 @@
+import json
+import logging
+import os
+from datetime import datetime, timedelta, timezone
+
+import boto3
+import urllib3
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+LANGSMITH_API_URL = "https://api.smith.langchain.com"
+
+
+def _ensure_destination_exists(setup_lambda_name):
+    """Get destination from setup Lambda (which handles SSM caching)."""
+    lambda_client = boto3.client("lambda")
+
+    # Just invoke the setup Lambda - it handles SSM caching internally
+    # with a unique parameter path per component
+    logger.info("Invoking setup lambda: %s", setup_lambda_name)
+    response = lambda_client.invoke(
+        FunctionName=setup_lambda_name,
+        InvocationType="RequestResponse",
+        Payload=json.dumps({"prefix": "traces"}),
+    )
+
+    result = json.loads(response["Payload"].read().decode())
+    if result.get("statusCode") != 200:
+        raise Exception(f"Setup lambda failed: {result}")
+
+    destination_id = result.get("destination_id")
+    if not destination_id:
+        raise Exception(f"No destination_id returned: {result}")
+
+    logger.info("Got destination from setup lambda: %s", destination_id)
+    return destination_id
+
+
+def handler(event, context):
+    """Trigger LangSmith bulk export for the configured project."""
+    logger.info("Received event: %s", json.dumps(event))
+
+    langchain_project = event.get("langchain_project") or os.environ.get(
+        "LANGSMITH_PROJECT_NAME"
+    )
+    if not langchain_project:
+        raise ValueError(
+            "langchain_project must be provided in event or LANGSMITH_PROJECT_NAME env var"
+        )
+    api_key = os.environ["LANGCHAIN_API_KEY"]
+    tenant_id = os.environ.get("LANGSMITH_TENANT_ID")
+    setup_lambda_name = os.environ.get("SETUP_LAMBDA_NAME")
+
+    http = urllib3.PoolManager()
+
+    headers = {"x-api-key": api_key}
+    if tenant_id:
+        headers["x-tenant-id"] = tenant_id
+
+    # Get destination from setup Lambda (handles SSM caching)
+    destination_id = _ensure_destination_exists(setup_lambda_name)
+
+    # Get project_id from LangSmith
+    response = http.request(
+        "GET",
+        f"{LANGSMITH_API_URL}/api/v1/sessions",
+        headers=headers,
+    )
+    if response.status != 200:
+        raise Exception(f"Failed to list projects: {response.data.decode()}")
+
+    projects = json.loads(response.data.decode("utf-8"))
+    project_id = None
+    for proj in projects:
+        if proj.get("name") == langchain_project:
+            project_id = proj.get("id")
+            break
+
+    if not project_id:
+        raise Exception(f"Project not found: {langchain_project}")
+
+    logger.info("Found project_id: %s for %s", project_id, langchain_project)
+
+    # Trigger bulk export.
+    # Event can override window; default remains a 7-day lookback.
+    days_back = event.get("days_back", 7)
+    end_time_value = event.get("end_time")
+    if end_time_value:
+        end_time = datetime.fromisoformat(
+            end_time_value.replace("Z", "+00:00")
+        )
+        if end_time.tzinfo is None:
+            end_time = end_time.replace(tzinfo=timezone.utc)
+    else:
+        end_time = datetime.now(timezone.utc)
+    end_time_iso = end_time.astimezone(timezone.utc).isoformat()
+    start_time_iso = event.get("start_time")
+    if not start_time_iso:
+        start_time_iso = (end_time - timedelta(days=days_back)).isoformat()
+
+    export_fields = event.get(
+        "export_fields",
+        [
+            "id",
+            "trace_id",
+            "name",
+            "outputs",
+            "extra",
+            "start_time",
+            "end_time",
+        ],
+    )
+
+    export_body = {
+        "bulk_export_destination_id": destination_id,
+        "session_id": project_id,
+        "start_time": start_time_iso,
+        "end_time": end_time_iso,
+        "export_fields": export_fields,
+    }
+
+    post_headers = dict(headers)
+    post_headers["Content-Type"] = "application/json"
+
+    response = http.request(
+        "POST",
+        f"{LANGSMITH_API_URL}/api/v1/bulk-exports",
+        headers=post_headers,
+        body=json.dumps(export_body),
+    )
+
+    if response.status not in (200, 201, 202):
+        raise Exception(f"Failed to trigger export: {response.data.decode()}")
+
+    result = json.loads(response.data.decode("utf-8"))
+    export_id = result.get("id")
+    logger.info("Triggered export: %s", export_id)
+
+    return {
+        "export_id": export_id,
+        "status": result.get("status", "pending"),
+    }

--- a/infra/routes/label_validation_viz_cache/infra.py
+++ b/infra/routes/label_validation_viz_cache/infra.py
@@ -25,10 +25,10 @@ from pulumi import (
     AssetArchive,
     ComponentResource,
     FileArchive,
+    FileAsset,
     Input,
     Output,
     ResourceOptions,
-    StringAsset,
 )
 
 from infra.components.lambda_layer import dynamo_layer
@@ -38,6 +38,7 @@ stack = pulumi.get_stack()
 
 # Reference the lambdas directory
 LAMBDAS_DIR = os.path.join(os.path.dirname(__file__), "lambdas")
+HANDLERS_DIR = os.path.join(os.path.dirname(__file__), "handlers")
 
 
 class LabelValidationVizCache(ComponentResource):
@@ -298,154 +299,6 @@ class LabelValidationVizCache(ComponentResource):
         )
 
         # DynamoDB query code - exports receipts, words, and labels
-        dynamo_query_code = '''
-import json
-import logging
-import os
-
-import boto3
-from botocore.exceptions import ClientError
-
-logger = logging.getLogger()
-logger.setLevel(logging.INFO)
-
-# Limit receipts to prevent memory issues - visualization only needs a sample
-MAX_RECEIPTS = 500
-
-
-def handler(event, context):
-    """Query receipts, words, and labels from DynamoDB and write to S3.
-
-    The EMR job needs:
-    - Receipt CDN keys (for image display)
-    - Word bounding boxes (for overlays)
-    - Labels (for validation word filtering)
-
-    Limited to MAX_RECEIPTS to prevent memory exhaustion.
-    """
-    logger.info("Received event: %s", json.dumps(event))
-
-    table_name = os.environ["DYNAMODB_TABLE"]
-    cache_bucket = os.environ["CACHE_BUCKET"]
-
-    # Import receipt_dynamo (from layer)
-    from receipt_dynamo import DynamoClient
-
-    client = DynamoClient(table_name)
-
-    logger.info("Querying receipts from DynamoDB table: %s (limit: %d)", table_name, MAX_RECEIPTS)
-
-    receipt_lookup = {}
-    page_count = 0
-    last_key = None
-
-    # First page of receipts
-    receipts, last_key = client.list_receipts(limit=500)
-    page_count += 1
-
-    for r in receipts:
-        if len(receipt_lookup) >= MAX_RECEIPTS:
-            break
-
-        key = f"{r.image_id}_{r.receipt_id}"
-
-        words = client.list_receipt_words_from_receipt(r.image_id, r.receipt_id)
-        words_data = [
-            {
-                "line_id": w.line_id,
-                "word_id": w.word_id,
-                "text": w.text,
-                "bbox": w.bounding_box,
-            }
-            for w in words
-        ]
-
-        labels, _ = client.list_receipt_word_labels_for_receipt(r.image_id, r.receipt_id)
-        labels_data = {
-            f"{label.line_id}_{label.word_id}": label.label
-            for label in labels
-        }
-
-        receipt_lookup[key] = {
-            "cdn_s3_key": r.cdn_s3_key or "",
-            "cdn_webp_s3_key": r.cdn_webp_s3_key,
-            "cdn_avif_s3_key": r.cdn_avif_s3_key,
-            "cdn_medium_s3_key": r.cdn_medium_s3_key,
-            "cdn_medium_webp_s3_key": r.cdn_medium_webp_s3_key,
-            "cdn_medium_avif_s3_key": r.cdn_medium_avif_s3_key,
-            "width": r.width or 0,
-            "height": r.height or 0,
-            "words": words_data,
-            "labels": labels_data,
-        }
-
-    # Paginate through remaining receipts until limit reached
-    while last_key and len(receipt_lookup) < MAX_RECEIPTS:
-        receipts, last_key = client.list_receipts(limit=500, last_evaluated_key=last_key)
-        page_count += 1
-
-        for r in receipts:
-            if len(receipt_lookup) >= MAX_RECEIPTS:
-                break
-
-            key = f"{r.image_id}_{r.receipt_id}"
-
-            words = client.list_receipt_words_from_receipt(r.image_id, r.receipt_id)
-            words_data = [
-                {
-                    "line_id": w.line_id,
-                    "word_id": w.word_id,
-                    "text": w.text,
-                    "bbox": w.bounding_box,
-                }
-                for w in words
-            ]
-
-            labels, _ = client.list_receipt_word_labels_for_receipt(r.image_id, r.receipt_id)
-            labels_data = {
-                f"{label.line_id}_{label.word_id}": label.label
-                for label in labels
-            }
-
-            receipt_lookup[key] = {
-                "cdn_s3_key": r.cdn_s3_key or "",
-                "cdn_webp_s3_key": r.cdn_webp_s3_key,
-                "cdn_avif_s3_key": r.cdn_avif_s3_key,
-                "cdn_medium_s3_key": r.cdn_medium_s3_key,
-                "cdn_medium_webp_s3_key": r.cdn_medium_webp_s3_key,
-                "cdn_medium_avif_s3_key": r.cdn_medium_avif_s3_key,
-                "width": r.width or 0,
-                "height": r.height or 0,
-                "words": words_data,
-                "labels": labels_data,
-            }
-
-        logger.info("Processed page %d, total receipts: %d", page_count, len(receipt_lookup))
-
-    logger.info("Collected %d receipts across %d pages (limit: %d)", len(receipt_lookup), page_count, MAX_RECEIPTS)
-
-    # Write to S3
-    s3 = boto3.client("s3")
-    s3_key = "receipts-lookup.json"
-    try:
-        s3.put_object(
-            Bucket=cache_bucket,
-            Key=s3_key,
-            Body=json.dumps(receipt_lookup),
-            ContentType="application/json",
-        )
-    except ClientError:
-        logger.exception("Failed to write receipts lookup to S3")
-        raise
-
-    logger.info("Wrote %s to s3://%s/%s", s3_key, cache_bucket, s3_key)
-
-    return {
-        "receipt_count": len(receipt_lookup),
-        "receipts_s3_path": f"s3://{cache_bucket}/{s3_key}",
-    }
-'''
-
         self.dynamo_query_lambda = aws.lambda_.Function(
             f"{name}-dynamo-query-lambda",
             runtime="python3.12",
@@ -453,7 +306,9 @@ def handler(event, context):
             role=self.dynamo_query_role.arn,
             code=AssetArchive(
                 {
-                    "index.py": StringAsset(dynamo_query_code),
+                    "index.py": FileAsset(
+                        os.path.join(HANDLERS_DIR, "dynamo_query.py")
+                    ),
                 }
             ),
             handler="index.handler",
@@ -527,146 +382,6 @@ def handler(event, context):
             opts=ResourceOptions(parent=self),
         )
 
-        trigger_export_code = f'''
-import json
-import logging
-import os
-from datetime import datetime, timedelta, timezone
-
-import boto3
-import urllib3
-
-logger = logging.getLogger()
-logger.setLevel(logging.INFO)
-
-LANGSMITH_API_URL = "https://api.smith.langchain.com"
-
-
-def _ensure_destination_exists(setup_lambda_name):
-    """Get destination from setup Lambda (which handles SSM caching)."""
-    lambda_client = boto3.client("lambda")
-
-    # Just invoke the setup Lambda - it handles SSM caching internally
-    # with a unique parameter path per component
-    logger.info("Invoking setup lambda: %s", setup_lambda_name)
-    response = lambda_client.invoke(
-        FunctionName=setup_lambda_name,
-        InvocationType="RequestResponse",
-        Payload=json.dumps({{"prefix": "traces"}}),
-    )
-
-    result = json.loads(response["Payload"].read().decode())
-    if result.get("statusCode") != 200:
-        raise Exception(f"Setup lambda failed: {{result}}")
-
-    destination_id = result.get("destination_id")
-    if not destination_id:
-        raise Exception(f"No destination_id returned: {{result}}")
-
-    logger.info("Got destination from setup lambda: %s", destination_id)
-    return destination_id
-
-
-def handler(event, context):
-    """Trigger LangSmith bulk export for the configured project."""
-    logger.info("Received event: %s", json.dumps(event))
-
-    langchain_project = event.get("langchain_project") or os.environ.get("LANGSMITH_PROJECT_NAME")
-    if not langchain_project:
-        raise ValueError("langchain_project must be provided in event or LANGSMITH_PROJECT_NAME env var")
-    api_key = os.environ["LANGCHAIN_API_KEY"]
-    tenant_id = os.environ.get("LANGSMITH_TENANT_ID")
-    setup_lambda_name = os.environ.get("SETUP_LAMBDA_NAME")
-
-    http = urllib3.PoolManager()
-
-    headers = {{"x-api-key": api_key}}
-    if tenant_id:
-        headers["x-tenant-id"] = tenant_id
-
-    # Get destination from setup Lambda (handles SSM caching)
-    destination_id = _ensure_destination_exists(setup_lambda_name)
-
-    # Get project_id from LangSmith
-    response = http.request(
-        "GET",
-        f"{{LANGSMITH_API_URL}}/api/v1/sessions",
-        headers=headers,
-    )
-    if response.status != 200:
-        raise Exception(f"Failed to list projects: {{response.data.decode()}}")
-
-    projects = json.loads(response.data.decode("utf-8"))
-    project_id = None
-    for proj in projects:
-        if proj.get("name") == langchain_project:
-            project_id = proj.get("id")
-            break
-
-    if not project_id:
-        raise Exception(f"Project not found: {{langchain_project}}")
-
-    logger.info("Found project_id: %s for %s", project_id, langchain_project)
-
-    # Trigger bulk export.
-    # Event can override window; default remains a 7-day lookback.
-    days_back = event.get("days_back", 7)
-    end_time_value = event.get("end_time")
-    if end_time_value:
-        end_time = datetime.fromisoformat(end_time_value.replace("Z", "+00:00"))
-        if end_time.tzinfo is None:
-            end_time = end_time.replace(tzinfo=timezone.utc)
-    else:
-        end_time = datetime.now(timezone.utc)
-    end_time_iso = end_time.astimezone(timezone.utc).isoformat()
-    start_time_iso = event.get("start_time")
-    if not start_time_iso:
-        start_time_iso = (end_time - timedelta(days=days_back)).isoformat()
-
-    export_fields = event.get(
-        "export_fields",
-        [
-            "id",
-            "trace_id",
-            "name",
-            "outputs",
-            "extra",
-            "start_time",
-            "end_time",
-        ],
-    )
-
-    export_body = {{
-        "bulk_export_destination_id": destination_id,
-        "session_id": project_id,
-        "start_time": start_time_iso,
-        "end_time": end_time_iso,
-        "export_fields": export_fields,
-    }}
-
-    post_headers = dict(headers)
-    post_headers["Content-Type"] = "application/json"
-
-    response = http.request(
-        "POST",
-        f"{{LANGSMITH_API_URL}}/api/v1/bulk-exports",
-        headers=post_headers,
-        body=json.dumps(export_body),
-    )
-
-    if response.status not in (200, 201, 202):
-        raise Exception(f"Failed to trigger export: {{response.data.decode()}}")
-
-    result = json.loads(response.data.decode("utf-8"))
-    export_id = result.get("id")
-    logger.info("Triggered export: %s", export_id)
-
-    return {{
-        "export_id": export_id,
-        "status": result.get("status", "pending"),
-    }}
-'''
-
         self.trigger_export_lambda = aws.lambda_.Function(
             f"{name}-trigger-export-lambda",
             runtime="python3.12",
@@ -674,7 +389,9 @@ def handler(event, context):
             role=self.trigger_export_role.arn,
             code=AssetArchive(
                 {
-                    "index.py": StringAsset(trigger_export_code),
+                    "index.py": FileAsset(
+                        os.path.join(HANDLERS_DIR, "trigger_export.py")
+                    ),
                 }
             ),
             handler="index.handler",
@@ -729,60 +446,6 @@ def handler(event, context):
             opts=ResourceOptions(parent=self.check_export_role),
         )
 
-        check_export_code = '''
-import json
-import logging
-import os
-
-import urllib3
-
-logger = logging.getLogger()
-logger.setLevel(logging.INFO)
-
-LANGSMITH_API_URL = "https://api.smith.langchain.com"
-
-
-def handler(event, context):
-    """Check LangSmith export status."""
-    logger.info("Received event: %s", json.dumps(event))
-
-    export_id = event.get("export_id")
-    if not export_id:
-        raise ValueError("export_id is required")
-
-    api_key = os.environ["LANGCHAIN_API_KEY"]
-
-    http = urllib3.PoolManager()
-
-    response = http.request(
-        "GET",
-        f"{LANGSMITH_API_URL}/api/v1/bulk-exports/{export_id}",
-        headers={"x-api-key": api_key},
-    )
-
-    if response.status != 200:
-        logger.error("Failed to check export: %s", response.data.decode())
-        return {"status": "error", "export_id": export_id}
-
-    result = json.loads(response.data.decode("utf-8"))
-    status = result.get("status", "unknown")
-
-    # Normalize status
-    if status in ("Complete", "Completed"):
-        status = "completed"
-    elif status in ("Failed", "Cancelled"):
-        status = "failed"
-    elif status in ("Pending", "Running", "InProgress"):
-        status = "pending"
-
-    logger.info("Export %s status: %s", export_id, status)
-
-    return {
-        "export_id": export_id,
-        "status": status,
-    }
-'''
-
         self.check_export_lambda = aws.lambda_.Function(
             f"{name}-check-export-lambda",
             runtime="python3.12",
@@ -790,7 +453,9 @@ def handler(event, context):
             role=self.check_export_role.arn,
             code=AssetArchive(
                 {
-                    "index.py": StringAsset(check_export_code),
+                    "index.py": FileAsset(
+                        os.path.join(HANDLERS_DIR, "check_export.py")
+                    ),
                 }
             ),
             handler="index.handler",


### PR DESCRIPTION
## Summary

- move the DynamoDB query, LangSmith export trigger, and export-status Lambda programs out of the 1,198-line Pulumi component and into normal handler source files
- keep every Pulumi logical name, parent, IAM policy, environment variable, handler entry point, and archive entry name unchanged
- add offline tests for status normalization, required inputs, setup-Lambda destination lookup, and outbound request construction

## Why

Three production Lambda programs were embedded as several hundred lines of Python string literals inside the Pulumi resource graph. That made the handlers difficult to format, test, lint, or review independently. The component is now focused on infrastructure wiring while the runtime programs are ordinary Python modules.

## Collision audit

This is independent of #1135. Open PRs, active branches, and uncommitted worktrees were checked before implementation and immediately before commit. The changed paths do not overlap any active work.

## Validation

- extracted handler ASTs match the evaluated embedded programs on `origin/main` for all three handlers
- `python3 -m pytest -q infra/components/test_label_validation_viz_handlers.py` — 10 passed
- Black, isort, mypy, pylint errors-only, compileall, and `git diff --check` — passed
- filtered dev Pulumi preview — exactly three in-place Lambda `code` updates from text assets to file assets; no replacements and no IAM, API, log-group, or state-machine changes
