### PR TITLE
[analytics] Make web_events partition rebuild atomic

### DIFF
--- a/infra/components/web_analytics/README.md
+++ b/infra/components/web_analytics/README.md
@@ -11,9 +11,10 @@ No new data pipeline — it's a thin query layer over logs that already exist.
 ```
 INGEST     CloudFront → s3://<logs-bucket>/cloudfront/prod/   (already exists)
               │
-TRANSFORM   transform Lambda (scheduled daily + backfillable), Athena INSERT:
+TRANSFORM   transform Lambda (scheduled hourly + backfillable), Athena UNLOAD:
               parse beacon · dedup(request_id) · classify warp/bot · PT-ready
-              → web_events  (Parquet, partitioned by UTC `dt`)   [single source of truth]
+              → per-run Parquet staging → atomic `dt` location swap
+              → web_events                                  [single source of truth]
               │
 SERVE       analytics_* MCP tools SELECT from web_events (partition-pruned)
 ```
@@ -27,7 +28,7 @@ SERVE       analytics_* MCP tools SELECT from web_events (partition-pruned)
 - **Curated table** `web_events` — Parquet, **partitioned by UTC `dt`**, parsed
   + de-duplicated + WARP/bot-classified; what the MCP tools read
 - **Transform Lambda** (`transform_lambda/handler.py`) — incremental, idempotent
-  per-day partition rebuild; scheduled daily, and invokable with
+  per-day partition rebuild; scheduled hourly, and invokable with
   `{"start":"YYYY-MM-DD","end":"YYYY-MM-DD"}` to backfill
 - **Athena workgroup** `portfolio_analytics` + a **results bucket** (30-day expiry)
 - A **curated bucket** for the Parquet output
@@ -38,8 +39,11 @@ SERVE       analytics_* MCP tools SELECT from web_events (partition-pruned)
 
 - Reads **only the target day's** raw files via the Athena `$path` pseudo-column
   (`WHERE "$path" LIKE '%.<dt>-%'`), so scan cost stays flat as history grows.
-- **Idempotent:** drops the `dt` partition + deletes its S3 objects, then
-  re-`INSERT`s — safe to re-run / backfill.
+- **Gap-free and idempotent:** writes each rebuilt day to a unique
+  `staging/web_events/dt=<dt>/run=<uuid>/` Parquet location, atomically repoints
+  the existing Glue partition with `SET LOCATION`, then removes the superseded
+  partition objects and abandoned staging runs. First-time partitions are
+  registered only after their staged output is complete.
 - **Dedups** on `request_id` (CloudFront can re-deliver lines).
 - Partition is the **UTC** log date; the serve layer buckets to PT and widens
   the scan ±1 day so PT-day edges are correct.

--- a/infra/components/web_analytics/__init__.py
+++ b/infra/components/web_analytics/__init__.py
@@ -269,7 +269,7 @@ class WebAnalytics(ComponentResource):
             opts=child,
         )
 
-        # --- Transform Lambda (incremental, idempotent per-day rebuild) ---
+        # --- Transform Lambda (atomic, idempotent per-day rebuild) ---
         transform_role = aws.iam.Role(
             f"{name}-transform-role",
             assume_role_policy=json.dumps(
@@ -313,9 +313,8 @@ class WebAnalytics(ComponentResource):
             role=transform_role.arn,
             timeout=600,
             memory_size=256,
-            # Serialize runs: the per-day drop/delete/INSERT rebuild is not
-            # atomic, so a backfill overlapping the scheduled run must not
-            # interleave on the same partition.
+            # Serialize runs so staging cleanup and partition-location swaps
+            # cannot interleave when a backfill overlaps the scheduled run.
             reserved_concurrent_executions=1,
             environment=aws.lambda_.FunctionEnvironmentArgs(
                 variables={
@@ -323,6 +322,7 @@ class WebAnalytics(ComponentResource):
                     "ANALYTICS_WORKGROUP": database_name,
                     "CURATED_BUCKET": self.curated_bucket.bucket,
                     "CURATED_PREFIX": "web_events/",
+                    "STAGING_PREFIX": "staging/web_events/",
                 },
             ),
             opts=child,
@@ -330,12 +330,11 @@ class WebAnalytics(ComponentResource):
         # Hourly schedule: the no-payload run idempotently rebuilds today +
         # yesterday (UTC), so web_events -- and every analytics_* tool that reads
         # it -- stays at most ~1h behind instead of ~24h, for negligible added
-        # Athena cost at this traffic. Known limitation: _rebuild_partition is a
-        # non-atomic drop+reinsert, so a query landing during the sub-minute
-        # rebuild of a live partition can momentarily see partial data; on a
-        # personal-scale tool that window is ~seconds/hour and self-heals on
-        # re-query. A gap-free (staging-swap / Iceberg) rebuild is the proper
-        # follow-up. Off-minute (:17) dodges the top-of-hour scheduler crowd.
+        # Athena cost at this traffic. Each partition is written to a unique
+        # staging prefix and exposed with one metadata-location swap, so
+        # readers continue seeing a complete prior generation while the
+        # rebuild runs. Off-minute (:17) dodges the top-of-hour scheduler
+        # crowd.
         schedule = aws.cloudwatch.EventRule(
             f"{name}-transform-schedule",
             schedule_expression="cron(17 * * * ? *)",  # hourly at :17 UTC

--- a/infra/components/web_analytics/transform_lambda/handler.py
+++ b/infra/components/web_analytics/transform_lambda/handler.py
@@ -356,9 +356,10 @@ def _rebuild_partition(dt: str, deadline: float) -> str:
     run_id = uuid.uuid4().hex
     staging_prefix = f"{STAGING_PREFIX.rstrip('/')}/dt={dt}/run={run_id}/"
     staging_location = f"s3://{CURATED_BUCKET}/{staging_prefix}"
-    swapped = False
+    unload_complete = False
     try:
         _run(_unload_sql(dt, staging_location), deadline)
+        unload_complete = True
         if previous_location:
             swap_sql = (
                 f"ALTER TABLE {DB}.web_events PARTITION (dt='{dt}') "
@@ -370,12 +371,15 @@ def _rebuild_partition(dt: str, deadline: float) -> str:
                 f"LOCATION '{staging_location}'"
             )
         _run(swap_sql, deadline)
-        swapped = True
     finally:
-        if not swapped:
+        if not unload_complete:
             # Athena can leave partial UNLOAD output on failure. It is never
             # visible through web_events, and is safe to remove immediately.
             _delete_prefix(staging_prefix)
+        # Once UNLOAD succeeds, preserve staging on any swap error. Athena may
+        # have committed ADD/SET LOCATION just before a timeout was observed;
+        # deleting here could remove the newly active partition. The next run
+        # safely reconciles any genuinely orphaned staging prefix.
 
     # The metadata swap above is the only visibility boundary. Once it
     # succeeds, remove the previous location and any older abandoned runs.

--- a/infra/components/web_analytics/transform_lambda/handler.py
+++ b/infra/components/web_analytics/transform_lambda/handler.py
@@ -3,10 +3,13 @@
 A light, Spark-free transform run by a scheduled Lambda (and backfillable on
 demand). For each target UTC date it rebuilds that partition idempotently:
 
-1. ``ALTER TABLE ... DROP PARTITION`` + delete the partition's S3 objects, then
-2. ``INSERT INTO web_events`` a parsed / de-duplicated / classified projection
-   of *only that day's* raw CloudFront files (pruned via the Athena ``$path``
-   pseudo-column, so the scan stays cheap as history grows).
+1. ``UNLOAD`` a parsed / de-duplicated / classified projection to a unique
+   per-run Parquet staging location, then
+2. atomically repoint the Glue partition to the complete staging location and
+   delete objects from superseded runs.
+
+The source query reads *only that day's* raw CloudFront files (pruned via the
+Athena ``$path`` pseudo-column), so the scan stays cheap as history grows.
 
 All beacon parsing, WARP/bot classification and dedup live here, so the curated
 table is the single source of truth; the MCP ``analytics_*`` tools just SELECT.
@@ -20,7 +23,9 @@ import json
 import os
 import time
 import urllib.request
+import uuid
 from datetime import datetime, timedelta, timezone
+from typing import Any
 
 import boto3
 
@@ -28,6 +33,7 @@ DB = os.environ.get("ANALYTICS_DB", "portfolio_analytics")
 WORKGROUP = os.environ.get("ANALYTICS_WORKGROUP", "portfolio_analytics")
 CURATED_BUCKET = os.environ["CURATED_BUCKET"]
 CURATED_PREFIX = os.environ.get("CURATED_PREFIX", "web_events/")
+STAGING_PREFIX = os.environ.get("STAGING_PREFIX", "staging/web_events/")
 IP_GEO_KEY = os.environ.get("IP_GEO_KEY", "ip_geo/data.json")
 REGION = os.environ.get("AWS_REGION", "us-east-1")
 _WARP_RE = "^(104\\.28\\.|2a09:bac)"
@@ -58,6 +64,7 @@ _DC_RE = (
 )
 
 _athena = boto3.client("athena", region_name=REGION)
+_glue = boto3.client("glue", region_name=REGION)
 _s3 = boto3.client("s3", region_name=REGION)
 
 
@@ -67,6 +74,8 @@ def _run(sql: str, deadline: float) -> str:
         QueryExecutionContext={"Database": DB},
         WorkGroup=WORKGROUP,
     )["QueryExecutionId"]
+    if not isinstance(qid, str):
+        raise RuntimeError("Athena did not return a query execution ID")
     while True:
         status = _athena.get_query_execution(QueryExecutionId=qid)[
             "QueryExecution"
@@ -102,7 +111,7 @@ def _query_rows(sql: str, deadline: float) -> list:
     return rows[1:]  # drop header row
 
 
-def _enrich_ips(dts: list, deadline: float) -> int:
+def _enrich_ips(dts: list[str], deadline: float) -> tuple[int, bool]:
     """Resolve org/geo/hosting for newly-seen (non-WARP) IPs and upsert the
     ip_geo NDJSON. Each IP is looked up once and cached; web_events joins it.
     """
@@ -144,7 +153,7 @@ def _enrich_ips(dts: list, deadline: float) -> int:
         if time.time() >= deadline:
             complete = False
             break
-        batch = new_ips[i:i + 100]
+        batch = new_ips[i : i + 100]
         payload = json.dumps(
             [{"query": ip, "fields": fields} for ip in batch]
         ).encode()
@@ -194,7 +203,7 @@ def _enrich_ips(dts: list, deadline: float) -> int:
     return len(new_ips), complete
 
 
-def _insert_sql(dt: str) -> str:
+def _projection_sql(dt: str) -> str:
     # CloudFront percent-encodes each log field ONCE. The beacon query string's
     # nested param values were additionally url-encoded by the client, so we
     # single-decode the field and decode only each extracted beacon value —
@@ -215,9 +224,7 @@ def _insert_sql(dt: str) -> str:
         f" coalesce(g.asn, ''))), '{_DC_RE}'))"
     )
 
-    return f"""
-INSERT INTO {DB}.web_events
-WITH src AS (
+    return f"""WITH src AS (
   SELECT *, {beacon_param('eid')} AS _eid
   FROM {DB}.cloudfront_logs_prod WHERE "$path" LIKE '%.{dt}-%'
 ),
@@ -252,19 +259,59 @@ SELECT
   g.city AS city,
   g.org AS org,
   g.asn AS asn,
-  {dc} AS is_hosting,
-  cast(date as varchar) AS dt
+  {dc} AS is_hosting
 FROM dedup
 LEFT JOIN {DB}.ip_geo g ON dedup.request_ip = g.ip
 """
 
 
-def _delete_partition_objects(dt: str) -> None:
-    prefix = f"{CURATED_PREFIX}dt={dt}/"
+def _unload_sql(dt: str, location: str) -> str:
+    # ``dt`` is intentionally absent from the Parquet payload: it is the Glue
+    # partition key, supplied by the partition metadata after the swap. The
+    # remaining SELECT order exactly matches ``web_events``' non-partition
+    # columns in ``__init__.py``.
+    return f"""UNLOAD (
+{_projection_sql(dt)}
+)
+TO '{location}'
+WITH (format = 'PARQUET', compression = 'SNAPPY')
+"""
+
+
+def _partition_location(dt: str) -> str | None:
+    try:
+        partition = _glue.get_partition(
+            DatabaseName=DB,
+            TableName="web_events",
+            PartitionValues=[dt],
+        )["Partition"]
+    except _glue.exceptions.EntityNotFoundException:
+        return None
+    location = partition["StorageDescriptor"].get("Location")
+    return location if isinstance(location, str) else None
+
+
+def _location_prefix(location: str, dt: str) -> str:
+    root = f"s3://{CURATED_BUCKET}/"
+    if not location.startswith(root):
+        raise ValueError(
+            f"Refusing to clean partition outside curated bucket: {location}"
+        )
+    prefix = location[len(root) :].lstrip("/").rstrip("/") + "/"
+    if f"dt={dt}/" not in prefix:
+        raise ValueError(
+            f"Refusing to clean location without dt={dt}: {location}"
+        )
+    return prefix
+
+
+def _delete_prefix(prefix: str, keep_prefix: str | None = None) -> None:
     paginator = _s3.get_paginator("list_objects_v2")
     batch = []
     for page in paginator.paginate(Bucket=CURATED_BUCKET, Prefix=prefix):
         for obj in page.get("Contents", []):
+            if keep_prefix and obj["Key"].startswith(keep_prefix):
+                continue
             batch.append({"Key": obj["Key"]})
             if len(batch) == 1000:
                 _s3.delete_objects(
@@ -275,17 +322,72 @@ def _delete_partition_objects(dt: str) -> None:
         _s3.delete_objects(Bucket=CURATED_BUCKET, Delete={"Objects": batch})
 
 
+def _cleanup_partition_objects(
+    dt: str,
+    active_location: str,
+    retired_location: str | None = None,
+) -> None:
+    """Delete every known layout for ``dt`` except the active partition.
+
+    Sweeping both the legacy INSERT path and all inactive staging runs makes
+    cleanup retry-safe after a Lambda timeout between the metadata swap and
+    object deletion.
+    """
+    active_prefix = _location_prefix(active_location, dt)
+    roots = [
+        f"{CURATED_PREFIX.rstrip('/')}/dt={dt}/",
+        f"{STAGING_PREFIX.rstrip('/')}/dt={dt}/",
+    ]
+    if retired_location:
+        retired_prefix = _location_prefix(retired_location, dt)
+        if not any(retired_prefix.startswith(root) for root in roots):
+            roots.append(retired_prefix)
+    for prefix in roots:
+        _delete_prefix(prefix, keep_prefix=active_prefix)
+
+
 def _rebuild_partition(dt: str, deadline: float) -> str:
-    _run(
-        f"ALTER TABLE {DB}.web_events DROP IF EXISTS PARTITION (dt='{dt}')",
-        deadline,
+    previous_location = _partition_location(dt)
+    if previous_location:
+        # Clear objects orphaned by an earlier interrupted run, while retaining
+        # the complete location that queries currently read.
+        _cleanup_partition_objects(dt, previous_location)
+
+    run_id = uuid.uuid4().hex
+    staging_prefix = f"{STAGING_PREFIX.rstrip('/')}/dt={dt}/run={run_id}/"
+    staging_location = f"s3://{CURATED_BUCKET}/{staging_prefix}"
+    swapped = False
+    try:
+        _run(_unload_sql(dt, staging_location), deadline)
+        if previous_location:
+            swap_sql = (
+                f"ALTER TABLE {DB}.web_events PARTITION (dt='{dt}') "
+                f"SET LOCATION '{staging_location}'"
+            )
+        else:
+            swap_sql = (
+                f"ALTER TABLE {DB}.web_events ADD PARTITION (dt='{dt}') "
+                f"LOCATION '{staging_location}'"
+            )
+        _run(swap_sql, deadline)
+        swapped = True
+    finally:
+        if not swapped:
+            # Athena can leave partial UNLOAD output on failure. It is never
+            # visible through web_events, and is safe to remove immediately.
+            _delete_prefix(staging_prefix)
+
+    # The metadata swap above is the only visibility boundary. Once it
+    # succeeds, remove the previous location and any older abandoned runs.
+    _cleanup_partition_objects(
+        dt,
+        staging_location,
+        retired_location=previous_location,
     )
-    _delete_partition_objects(dt)
-    _run(_insert_sql(dt), deadline)
     return dt
 
 
-def _target_dates(event: dict) -> list:
+def _target_dates(event: dict) -> list[str]:
     if event.get("start") and event.get("end"):
         start = datetime.strptime(event["start"], "%Y-%m-%d").date()
         end = datetime.strptime(event["end"], "%Y-%m-%d").date()
@@ -303,7 +405,7 @@ def _target_dates(event: dict) -> list:
     return [(today - timedelta(days=n)).isoformat() for n in (1, 0)]
 
 
-def handler(event, context):
+def handler(event: dict | None, context: Any) -> dict:
     event = event or {}
     # Bound all Athena polling to the Lambda's own deadline (minus a buffer) so
     # a slow/queued query is stopped rather than orphaned when we're killed.

--- a/tests/test_web_analytics_transform.py
+++ b/tests/test_web_analytics_transform.py
@@ -154,6 +154,47 @@ def test_failed_unload_never_changes_partition(transform_module, monkeypatch):
     assert deleted == [f"staging/web_events/dt={dt}/run={'c' * 32}/"]
 
 
+def test_uncertain_swap_result_preserves_staging(
+    transform_module, monkeypatch
+):
+    """A swap timeout cannot delete a prefix Athena may have made active."""
+    transform = transform_module
+    dt = "2026-07-14"
+    previous = f"s3://curated-bucket/web_events/dt={dt}/"
+    sql_calls = []
+    deleted = []
+    monkeypatch.setattr(transform, "_partition_location", lambda _dt: previous)
+    monkeypatch.setattr(
+        transform.uuid,
+        "uuid4",
+        lambda: SimpleNamespace(hex="d" * 32),
+    )
+    monkeypatch.setattr(
+        transform,
+        "_cleanup_partition_objects",
+        lambda _dt, _active, retired_location=None: None,
+    )
+
+    def timeout_during_swap(sql, _deadline):
+        sql_calls.append(sql)
+        if len(sql_calls) == 2:
+            raise TimeoutError("swap result unknown")
+
+    monkeypatch.setattr(transform, "_run", timeout_during_swap)
+    monkeypatch.setattr(
+        transform,
+        "_delete_prefix",
+        lambda prefix, keep_prefix=None: deleted.append(prefix),
+    )
+
+    with pytest.raises(TimeoutError, match="swap result unknown"):
+        transform._rebuild_partition(dt, 123.0)
+
+    assert sql_calls[0].startswith("UNLOAD (")
+    assert " SET LOCATION " in sql_calls[1]
+    assert not deleted
+
+
 def test_unload_schema_matches_non_partition_columns(transform_module):
     """The partition key is metadata-only; enrichment and dedup stay intact."""
     sql = transform_module._unload_sql(

--- a/tests/test_web_analytics_transform.py
+++ b/tests/test_web_analytics_transform.py
@@ -1,0 +1,227 @@
+"""Tests for the atomic web_events partition rebuild."""
+
+# Pytest injects fixtures through arguments with the fixture's declared name.
+# pylint: disable=redefined-outer-name
+
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import boto3
+import pytest
+
+
+@pytest.fixture
+def transform_module(monkeypatch):
+    """Load the Lambda handler without constructing real AWS clients."""
+    clients = {
+        "athena": Mock(),
+        "glue": Mock(),
+        "s3": Mock(),
+    }
+    monkeypatch.setenv("CURATED_BUCKET", "curated-bucket")
+    monkeypatch.setattr(
+        boto3,
+        "client",
+        lambda service, **_kwargs: clients[service],
+    )
+    path = (
+        Path(__file__).parents[1]
+        / "infra/components/web_analytics/transform_lambda/handler.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "web_analytics_transform_handler_test", path
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_existing_partition_swaps_only_after_unload(
+    transform_module, monkeypatch
+):
+    """An existing complete partition remains registered until staging ends."""
+    dt = "2026-07-14"
+    previous = f"s3://curated-bucket/web_events/dt={dt}/"
+    staged_prefix = f"staging/web_events/dt={dt}/run={'a' * 32}/"
+    staged = f"s3://curated-bucket/{staged_prefix}"
+    calls = []
+
+    transform = transform_module
+    monkeypatch.setattr(transform, "_partition_location", lambda _dt: previous)
+    monkeypatch.setattr(
+        transform.uuid,
+        "uuid4",
+        lambda: SimpleNamespace(hex="a" * 32),
+    )
+    monkeypatch.setattr(
+        transform,
+        "_cleanup_partition_objects",
+        lambda _dt, active, retired_location=None: calls.append(
+            ("cleanup", active, retired_location)
+        ),
+    )
+    monkeypatch.setattr(
+        transform,
+        "_run",
+        lambda sql, _deadline: calls.append(("sql", sql)),
+    )
+
+    assert transform._rebuild_partition(dt, 123.0) == dt
+
+    assert calls[0] == ("cleanup", previous, None)
+    assert calls[1][0] == "sql"
+    assert calls[1][1].startswith("UNLOAD (")
+    assert staged in calls[1][1]
+    assert calls[2] == (
+        "sql",
+        f"ALTER TABLE portfolio_analytics.web_events PARTITION (dt='{dt}') "
+        f"SET LOCATION '{staged}'",
+    )
+    assert calls[3] == ("cleanup", staged, previous)
+    assert "DROP" not in calls[2][1]
+
+
+def test_first_partition_is_added_only_after_unload(
+    transform_module, monkeypatch
+):
+    """A missing partition is registered only after its files are complete."""
+    dt = "2026-07-14"
+    transform = transform_module
+    calls = []
+    monkeypatch.setattr(transform, "_partition_location", lambda _dt: None)
+    monkeypatch.setattr(
+        transform.uuid,
+        "uuid4",
+        lambda: SimpleNamespace(hex="b" * 32),
+    )
+    monkeypatch.setattr(
+        transform,
+        "_cleanup_partition_objects",
+        lambda _dt, active, retired_location=None: calls.append(
+            ("cleanup", active, retired_location)
+        ),
+    )
+    monkeypatch.setattr(
+        transform,
+        "_run",
+        lambda sql, _deadline: calls.append(("sql", sql)),
+    )
+
+    transform._rebuild_partition(dt, 123.0)
+
+    assert calls[0][1].startswith("UNLOAD (")
+    assert " ADD PARTITION " in calls[1][1]
+    assert calls[2][0] == "cleanup"
+
+
+def test_failed_unload_never_changes_partition(transform_module, monkeypatch):
+    """Partial staging files are deleted while the old partition stays live."""
+    transform = transform_module
+    dt = "2026-07-14"
+    previous = f"s3://curated-bucket/web_events/dt={dt}/"
+    sql_calls = []
+    deleted = []
+    monkeypatch.setattr(transform, "_partition_location", lambda _dt: previous)
+    monkeypatch.setattr(
+        transform.uuid,
+        "uuid4",
+        lambda: SimpleNamespace(hex="c" * 32),
+    )
+    monkeypatch.setattr(
+        transform,
+        "_cleanup_partition_objects",
+        lambda _dt, _active, retired_location=None: None,
+    )
+
+    def fail_unload(sql, _deadline):
+        sql_calls.append(sql)
+        raise RuntimeError("UNLOAD failed")
+
+    monkeypatch.setattr(transform, "_run", fail_unload)
+    monkeypatch.setattr(
+        transform,
+        "_delete_prefix",
+        lambda prefix, keep_prefix=None: deleted.append(prefix),
+    )
+
+    with pytest.raises(RuntimeError, match="UNLOAD failed"):
+        transform._rebuild_partition(dt, 123.0)
+
+    assert len(sql_calls) == 1
+    assert sql_calls[0].startswith("UNLOAD (")
+    assert deleted == [f"staging/web_events/dt={dt}/run={'c' * 32}/"]
+
+
+def test_unload_schema_matches_non_partition_columns(transform_module):
+    """The partition key is metadata-only; enrichment and dedup stay intact."""
+    sql = transform_module._unload_sql(
+        "2026-07-14",
+        "s3://curated-bucket/staging/web_events/dt=2026-07-14/run=x/",
+    )
+
+    assert "cast(date as varchar) AS dt" not in sql
+    assert "g.country AS country" in sql
+    assert "g.city AS city" in sql
+    assert "g.org AS org" in sql
+    assert "g.asn AS asn" in sql
+    assert "AS is_hosting" in sql
+    assert "ELSE request_id END" in sql
+    assert "LEFT JOIN portfolio_analytics.ip_geo" in sql
+    assert "format = 'PARQUET', compression = 'SNAPPY'" in sql
+
+
+def test_delete_prefix_preserves_active_staging_run(transform_module):
+    """Cleanup removes superseded runs without touching the active files."""
+    transform = transform_module
+    root = "staging/web_events/dt=2026-07-14/"
+    active = f"{root}run=active/"
+    paginator = transform._s3.get_paginator.return_value
+    paginator.paginate.return_value = [
+        {
+            "Contents": [
+                {"Key": f"{active}data.parquet"},
+                {"Key": f"{root}run=old/data.parquet"},
+            ]
+        }
+    ]
+
+    transform._delete_prefix(root, keep_prefix=active)
+
+    transform._s3.delete_objects.assert_called_once_with(
+        Bucket="curated-bucket",
+        Delete={"Objects": [{"Key": f"{root}run=old/data.parquet"}]},
+    )
+
+
+def test_cleanup_includes_previous_custom_partition_location(
+    transform_module, monkeypatch
+):
+    """Cleanup includes a prior location outside the known layouts."""
+    dt = "2026-07-14"
+    active_prefix = f"staging/web_events/dt={dt}/run=active/"
+    active = f"s3://curated-bucket/{active_prefix}"
+    retired = f"s3://curated-bucket/older-layout/dt={dt}/run=old/"
+    calls = []
+    monkeypatch.setattr(
+        transform_module,
+        "_delete_prefix",
+        lambda prefix, keep_prefix=None: calls.append((prefix, keep_prefix)),
+    )
+
+    transform_module._cleanup_partition_objects(
+        dt,
+        active,
+        retired_location=retired,
+    )
+
+    assert (f"older-layout/dt={dt}/run=old/", active_prefix) in calls
+    assert all(keep == active_prefix for _prefix, keep in calls)
+
+
+def test_backfill_range_still_expands_inclusively(transform_module):
+    """Atomic writes do not change the explicit backfill event contract."""
+    assert transform_module._target_dates(
+        {"start": "2026-07-12", "end": "2026-07-14"}
+    ) == ["2026-07-12", "2026-07-13", "2026-07-14"]


### PR DESCRIPTION
# Pull Request

## Summary

- Rebuild each `web_events` day into a unique Parquet staging prefix before changing live partition metadata.
- Repoint existing partitions with one `ALTER TABLE ... PARTITION ... SET LOCATION` operation, then clean the retired location and stale staging runs.
- Preserve the existing projection, IP geo enrichment, request/eid deduplication, yesterday+today default window, and explicit backfill range.

The implementation uses Athena `UNLOAD` rather than CTAS because the analytics workgroup enforces its query-results location, and Athena rejects CTAS statements that also specify `external_location` under that configuration. `UNLOAD` writes the same typed projection directly to the per-run Parquet staging location without adding a temporary Glue table.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that resolves an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [x] 🧪 Test changes or improved coverage

## Which Package(s) are Affected?

- [ ] receipt_dynamo
- [ ] receipt_dynamo_stream
- [ ] receipt_chroma
- [ ] receipt_upload
- [ ] receipt_places
- [ ] receipt_agent
- [ ] Portfolio (TypeScript/Next.js)
- [x] Infrastructure (Pulumi)
- [ ] CI/CD Workflows
- [ ] Other: _______________

## Testing

- [x] Unit tests pass locally (`pytest` or `npm test`)
- [ ] Integration tests pass locally (if applicable)
- [x] Added or updated tests for new functionality
- [x] All existing tests still pass with these changes
- [ ] Manual testing completed (if applicable)

Results:

- `python -m pytest tests -q --maxfail=5` — 116 passed
- `infra/.venv/bin/pytest tests/test_web_analytics_transform.py -q` — 7 passed
- Black and isort checks on the changed handler/test — passed
- Pylint on the changed handler/test — 10.00/10
- Mypy on the transform handler — passed
- `pulumi preview --stack dev --diff --non-interactive` — completed; no apply performed. The dev stack currently reports substantial unrelated provider/worktree-path and image/layer hash drift (117 planned changes), so that preview should not be used as a deploy plan without reconciling the unrelated drift.

## Documentation & Code Quality

- [x] Documentation or comments updated for complex logic
- [x] README updated (if introducing new feature/dependency)
- [ ] TypeDoc/JSDoc comments added where needed
- [x] No new warnings or linting issues introduced
- [x] Code follows project style guidelines

## Related Issues

Closes #1138

## Impact Analysis

Queries continue reading the complete prior partition while the replacement is written. Existing partitions switch to the complete staged generation through one metadata update; first-time partitions are registered only after their staged output succeeds. Failed writes remove partial staging output without touching the live partition. Successful runs remove the exact retired location, the legacy `web_events/dt=<dt>/` layout, and inactive `staging/web_events/dt=<dt>/run=<uuid>/` generations.

The default rebuild window remains yesterday + today, and `{"start","end"}` backfills remain inclusive. The Parquet payload contains the 21 non-partition `web_events` columns in table order; `dt` remains a Glue partition key rather than a duplicate file column.

## Deployment Notes

- New S3 layout: `s3://<curated-bucket>/staging/web_events/dt=<dt>/run=<uuid>/`.
- No IAM policy expansion is required: the transform role already has curated-bucket Put/Delete/List and Glue Get/Create/UpdatePartition permissions. `UNLOAD` avoids temporary Glue table permissions.
- Pulumi now sets `STAGING_PREFIX=staging/web_events/` on the transform Lambda.
- Deploy manually through the normal prod-gated Pulumi workflow. No `pulumi up` was run for this PR.
- On the first successful rebuild of an existing day, the live partition moves from the legacy location to staging and the legacy objects are deleted after the metadata swap.
