### PR TITLE
fix: get_image_details rejects legacy OCRJob keys (merge-day regression)

### DIFF
--- a/receipt_dynamo/receipt_dynamo/entities/ocr_job.py
+++ b/receipt_dynamo/receipt_dynamo/entities/ocr_job.py
@@ -328,16 +328,28 @@ class OCRJob:
             custom_extractors=custom_extractors,
         )
         expected = job.to_item()
-        for key in (
-            "PK",
-            "SK",
-            "TYPE",
-            "GSI1PK",
-            "GSI1SK",
-            "GSI2PK",
-            "GSI2SK",
-        ):
+        # Identity keys must round-trip exactly. GSI *SK* values derive from the
+        # immutable job_id, so legacy rows match them too.
+        for key in ("PK", "SK", "TYPE", "GSI1SK", "GSI2SK"):
             if item.get(key) != expected.get(key):
+                raise ValueError("Invalid OCRJob keys")
+        # GSI1PK/GSI2PK encode the mutable status. Legacy OCRJob rows in dev and
+        # prod were written at status=PENDING and never had their GSI status
+        # partitions rewritten on status transitions, so real rows carry e.g.
+        # status=COMPLETED with GSI1PK/GSI2PK=OCR_JOB_STATUS#PENDING (48 of 49
+        # Costco rows sampled in dev ReceiptsTable-dc5be22). The status field is
+        # authoritative on read, so tolerate a stale-but-well-formed partition
+        # here rather than hard-failing a read of pre-existing data; only reject
+        # partitions that are not a valid OCR_JOB_STATUS#<status> value.
+        valid_status_partitions = {
+            f"OCR_JOB_STATUS#{status.value}" for status in OCRStatus
+        }
+        for key in ("GSI1PK", "GSI2PK"):
+            partition = item.get(key, {})
+            if (
+                not isinstance(partition, dict)
+                or partition.get("S") not in valid_status_partitions
+            ):
                 raise ValueError("Invalid OCRJob keys")
         return job
 

--- a/receipt_dynamo/receipt_dynamo/entities/ocr_job.py
+++ b/receipt_dynamo/receipt_dynamo/entities/ocr_job.py
@@ -344,6 +344,7 @@ class OCRJob:
         valid_status_partitions = {
             f"OCR_JOB_STATUS#{status.value}" for status in OCRStatus
         }
+        partitions = []
         for key in ("GSI1PK", "GSI2PK"):
             partition = item.get(key, {})
             if (
@@ -351,6 +352,12 @@ class OCRJob:
                 or partition.get("S") not in valid_status_partitions
             ):
                 raise ValueError("Invalid OCRJob keys")
+            partitions.append(partition["S"])
+        # GSI1PK and GSI2PK are always written together from the same status, so
+        # legitimate legacy rows keep them equal even when both are stale.
+        # Divergent partitions indicate corruption, not a benign status drift.
+        if partitions[0] != partitions[1]:
+            raise ValueError("Invalid OCRJob keys")
         return job
 
 

--- a/receipt_dynamo/tests/unit/test_misc_record_contracts.py
+++ b/receipt_dynamo/tests/unit/test_misc_record_contracts.py
@@ -458,6 +458,18 @@ def test_ocr_job_from_item_rejects_malformed_gsi_status_partition(key):
         OCRJob.from_item(item)
 
 
+def test_ocr_job_from_item_rejects_divergent_gsi_status_partitions():
+    """GSI1PK and GSI2PK are written together from the same status, so a row
+    where they carry different (individually valid) statuses is corruption, not
+    a benign legacy drift, and must be rejected."""
+    item = make_ocr_job(status=OCRStatus.COMPLETED).to_item()
+    item["GSI1PK"] = {"S": "OCR_JOB_STATUS#PENDING"}
+    item["GSI2PK"] = {"S": "OCR_JOB_STATUS#COMPLETED"}
+
+    with pytest.raises(ValueError, match="keys"):
+        OCRJob.from_item(item)
+
+
 def test_ocr_job_revalidates_nested_map_after_mutation():
     job = make_ocr_job()
     job.reocr_region["height"] = float("inf")

--- a/receipt_dynamo/tests/unit/test_misc_record_contracts.py
+++ b/receipt_dynamo/tests/unit/test_misc_record_contracts.py
@@ -426,6 +426,38 @@ def test_ocr_job_optional_fields_roundtrip_as_null():
     assert OCRJob.from_item(item) == job
 
 
+def test_ocr_job_from_item_tolerates_stale_gsi_status_partition():
+    """Legacy rows keep the GSI status partition they were written with.
+
+    Real OCRJob rows in dev/prod were persisted at status=PENDING and never had
+    their GSI status partitions rewritten when the status advanced, so a row can
+    carry status=COMPLETED while GSI1PK/GSI2PK still read OCR_JOB_STATUS#PENDING.
+    from_item must read these rows (the status field is authoritative), not
+    hard-fail them with "Invalid OCRJob keys".
+    """
+    job = make_ocr_job(status=OCRStatus.COMPLETED)
+    item = job.to_item()
+    # Reproduce the legacy shape: stale-but-valid PENDING partitions.
+    item["GSI1PK"] = {"S": "OCR_JOB_STATUS#PENDING"}
+    item["GSI2PK"] = {"S": "OCR_JOB_STATUS#PENDING"}
+
+    restored = OCRJob.from_item(item)
+
+    assert restored == job
+    assert restored.status == OCRStatus.COMPLETED.value
+
+
+@pytest.mark.parametrize("key", ["GSI1PK", "GSI2PK"])
+def test_ocr_job_from_item_rejects_malformed_gsi_status_partition(key):
+    """A GSI status partition that is not a valid OCR_JOB_STATUS#<status> is
+    still rejected, so genuine corruption is not silently accepted."""
+    item = make_ocr_job().to_item()
+    item[key] = {"S": "OCR_JOB_STATUS#NOT_A_STATUS"}
+
+    with pytest.raises(ValueError, match="keys"):
+        OCRJob.from_item(item)
+
+
 def test_ocr_job_revalidates_nested_map_after_mutation():
     job = make_ocr_job()
     job.reocr_region["height"] = float("inf")


### PR DESCRIPTION
## Problem

PR #1116 hardened `OCRJob.from_item` with a round-trip integrity check that regenerates `GSI1PK`/`GSI2PK` from the current `status` field and hard-fails with `Invalid OCRJob keys` when they differ from the stored item.

Real OCRJob rows in dev (`ReceiptsTable-dc5be22`), and prod which mirrors it, were written at `status=PENDING` and never had their GSI status partitions rewritten when the status advanced. So a row legitimately carries e.g. `status=COMPLETED` with `GSI1PK/GSI2PK=OCR_JOB_STATUS#PENDING`.

This broke `get_image_details` fleet-wide (crop/refpack tooling):
- **Before:** 1/15 Costco dev images readable (14 raise `Invalid OCRJob keys`)
- 48 of 49 sampled OCRJob rows have the stale-partition shape; the **only** mismatching keys are `GSI1PK`/`GSI2PK` (never PK/SK/TYPE/GSI1SK/GSI2SK)

## Fix

Validate-on-write, tolerate-on-read. Keep exact round-trip checks on identity keys (`PK`/`SK`/`TYPE` and the immutable-job_id-derived `GSI1SK`/`GSI2SK`), but for the status-derived `GSI1PK`/`GSI2PK` require only that they are a **well-formed** `OCR_JOB_STATUS#<valid status>` value rather than matching the current status. Genuine corruption (a non-status partition) is still rejected — #1116's `GSI1PK: "WRONG"` test still passes. `to_item` is unchanged, so writes still regenerate correct partitions.

## Verification

- **After:** 15/15 Costco dev images read
- Full `receipt_dynamo` unit suite: **2122 passed** (including #1116's hardened contract tests)
- Added regression tests: tolerant read of stale-but-valid partition; rejection of malformed status partition

Dev reads only; no data written. A data migration to refresh stale GSI partitions is possible but intentionally not included here (prod mirrors this data) — flagged for separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OCR job record loading to support legacy records with stale but valid status indexes.
  * Continued rejecting malformed status index values to protect data integrity.

* **Tests**
  * Added coverage for valid stale index partitions and invalid status formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->