### PR TITLE
fix: get_image_details rejects legacy ReceiptPlace keys (merge-day regression)

### DIFF
--- a/receipt_dynamo/receipt_dynamo/entities/receipt_place.py
+++ b/receipt_dynamo/receipt_dynamo/entities/receipt_place.py
@@ -662,9 +662,16 @@ class ReceiptPlace(  # pylint: disable=too-many-instance-attributes
             validator = business_key_validators.get(key_name)
             if validator is not None:
                 stored = item.get(key_name)
-                if stored is not None and (
-                    not isinstance(stored, dict)
-                    or not validator(stored.get("S") or "")
+                # Absent (sparse/tolerated) or the canonical current value: the
+                # exact-match short-circuit means a legitimately generated key
+                # is never rejected by the looser well-formed patterns below.
+                if stored is None or stored == expected_value:
+                    continue
+                # Stored value differs from the regenerated projection, i.e. it
+                # is stale: accept only if it is a shape the generator could
+                # have emitted for some earlier valid state, else it is corrupt.
+                if not isinstance(stored, dict) or not validator(
+                    stored.get("S") or ""
                 ):
                     raise ValueError(
                         f"{key_name} does not match entity keys"

--- a/receipt_dynamo/receipt_dynamo/entities/receipt_place.py
+++ b/receipt_dynamo/receipt_dynamo/entities/receipt_place.py
@@ -53,17 +53,29 @@ MIN_NAME_LENGTH = 2
 # update (merchant remap, place remap, confidence bump) while still rejecting
 # genuinely malformed values. See ReceiptPlace.from_item for the rationale.
 #
+# Each "well-formed" shape mirrors what gsi*_key could legitimately emit for a
+# valid entity, so a stale projection is accepted only if some earlier valid
+# state could have produced it; anything else is treated as corruption.
+#
 # GSI1PK: "MERCHANT#" + the slug merchant_name normalization emits (uppercase
 # alphanumeric groups joined by single underscores, no leading/trailing "_").
+# The entity guarantees this slug is non-empty.
 _MERCHANT_GSI1PK_RE = re.compile(r"MERCHANT#[A-Z0-9]+(?:_[A-Z0-9]+)*")
-# GSI2PK: "PLACE#" + a non-empty Google place id (base64url-ish charset).
-_PLACE_GSI2PK_RE = re.compile(r"PLACE#[A-Za-z0-9_-]+")
-# GSI3SK: CONFIDENCE#<number>#STATUS#<status>#IMAGE#<image_id>. Confidence and
-# status are mutable; the trailing image id is identity and is anchored to the
-# row in _is_wellformed_validation_sk.
+# GSI3SK: CONFIDENCE#<0.0000-1.0000>#STATUS#<status>#IMAGE#<image_id>.
+# gsi3_key formats confidence as a 4-decimal value the entity constrains to
+# [0.0, 1.0]; validation_status is a free-form string (empty is a valid
+# "needs review" state), so the status segment stays permissive. The trailing
+# image id is identity and is anchored to the row in _is_wellformed_validation_sk.
 _VALIDATION_GSI3SK_RE = re.compile(
-    r"CONFIDENCE#\d+(?:\.\d+)?#STATUS#[^#]*#IMAGE#(?P<image_id>[^#]+)"
+    r"CONFIDENCE#(?:0\.\d{4}|1\.0000)#STATUS#[^#]*#IMAGE#(?P<image_id>[^#]+)"
 )
+
+
+def _is_wellformed_place_partition(value: str) -> bool:
+    """GSI2PK is "PLACE#" + place_id. The entity accepts any non-whitespace-only
+    place_id (Google place ids are opaque), so mirror that rather than a charset."""
+    prefix = "PLACE#"
+    return value.startswith(prefix) and bool(value[len(prefix) :].strip())
 
 
 def _is_wellformed_validation_sk(value: str, image_id: str) -> bool:
@@ -641,7 +653,7 @@ class ReceiptPlace(  # pylint: disable=too-many-instance-attributes
             "GSI1PK": lambda value: bool(
                 _MERCHANT_GSI1PK_RE.fullmatch(value)
             ),
-            "GSI2PK": lambda value: bool(_PLACE_GSI2PK_RE.fullmatch(value)),
+            "GSI2PK": _is_wellformed_place_partition,
             "GSI3SK": lambda value: _is_wellformed_validation_sk(
                 value, result.image_id
             ),

--- a/receipt_dynamo/receipt_dynamo/entities/receipt_place.py
+++ b/receipt_dynamo/receipt_dynamo/entities/receipt_place.py
@@ -63,11 +63,12 @@ MIN_NAME_LENGTH = 2
 _MERCHANT_GSI1PK_RE = re.compile(r"MERCHANT#[A-Z0-9]+(?:_[A-Z0-9]+)*")
 # GSI3SK: CONFIDENCE#<0.0000-1.0000>#STATUS#<status>#IMAGE#<image_id>.
 # gsi3_key formats confidence as a 4-decimal value the entity constrains to
-# [0.0, 1.0]; validation_status is a free-form string (empty is a valid
-# "needs review" state), so the status segment stays permissive. The trailing
-# image id is identity and is anchored to the row in _is_wellformed_validation_sk.
-_VALIDATION_GSI3SK_RE = re.compile(
-    r"CONFIDENCE#(?:0\.\d{4}|1\.0000)#STATUS#[^#]*#IMAGE#(?P<image_id>[^#]+)"
+# [0.0, 1.0]. validation_status is a free-form string that may be empty or
+# even contain '#', so the status segment is not pattern-matched; instead the
+# CONFIDENCE# prefix and the identity #IMAGE#<image_id> suffix are anchored in
+# _is_wellformed_validation_sk and everything between is treated as the status.
+_GSI3SK_CONFIDENCE_PREFIX_RE = re.compile(
+    r"CONFIDENCE#(?:0\.\d{4}|1\.0000)#STATUS#"
 )
 
 
@@ -79,10 +80,14 @@ def _is_wellformed_place_partition(value: str) -> bool:
 
 
 def _is_wellformed_validation_sk(value: str, image_id: str) -> bool:
-    """A GSI3SK is well-formed if it matches the confidence/status/image shape
-    and its identity anchor (the trailing IMAGE#<id>) matches this row."""
-    match = _VALIDATION_GSI3SK_RE.fullmatch(value)
-    return bool(match) and match.group("image_id") == image_id
+    """A GSI3SK is well-formed if its identity anchor (the trailing
+    #IMAGE#<id>) matches this row and the head is CONFIDENCE#<0-1>#STATUS#
+    followed by a free-form status (which may be empty or contain '#')."""
+    suffix = f"#IMAGE#{image_id}"
+    if not value.endswith(suffix):
+        return False
+    head = value[: -len(suffix)]
+    return _GSI3SK_CONFIDENCE_PREFIX_RE.match(head) is not None
 
 # Fields that are computed (GSI keys) and should not be passed to
 # constructor. Includes GSI4 and geohash for backward compatibility

--- a/receipt_dynamo/receipt_dynamo/entities/receipt_place.py
+++ b/receipt_dynamo/receipt_dynamo/entities/receipt_place.py
@@ -48,6 +48,30 @@ logger = __import__("logging").getLogger(__name__)
 MIN_PHONE_DIGITS = 7
 MIN_NAME_LENGTH = 2
 
+# Well-formed shapes for the GSI keys that embed a mutable business field.
+# Used on read to accept a stale-but-well-formed projection left by a partial
+# update (merchant remap, place remap, confidence bump) while still rejecting
+# genuinely malformed values. See ReceiptPlace.from_item for the rationale.
+#
+# GSI1PK: "MERCHANT#" + the slug merchant_name normalization emits (uppercase
+# alphanumeric groups joined by single underscores, no leading/trailing "_").
+_MERCHANT_GSI1PK_RE = re.compile(r"MERCHANT#[A-Z0-9]+(?:_[A-Z0-9]+)*")
+# GSI2PK: "PLACE#" + a non-empty Google place id (base64url-ish charset).
+_PLACE_GSI2PK_RE = re.compile(r"PLACE#[A-Za-z0-9_-]+")
+# GSI3SK: CONFIDENCE#<number>#STATUS#<status>#IMAGE#<image_id>. Confidence and
+# status are mutable; the trailing image id is identity and is anchored to the
+# row in _is_wellformed_validation_sk.
+_VALIDATION_GSI3SK_RE = re.compile(
+    r"CONFIDENCE#\d+(?:\.\d+)?#STATUS#[^#]*#IMAGE#(?P<image_id>[^#]+)"
+)
+
+
+def _is_wellformed_validation_sk(value: str, image_id: str) -> bool:
+    """A GSI3SK is well-formed if it matches the confidence/status/image shape
+    and its identity anchor (the trailing IMAGE#<id>) matches this row."""
+    match = _VALIDATION_GSI3SK_RE.fullmatch(value)
+    return bool(match) and match.group("image_id") == image_id
+
 # Fields that are computed (GSI keys) and should not be passed to
 # constructor. Includes GSI4 and geohash for backward compatibility
 # with older records that had geospatial indexing.
@@ -598,7 +622,42 @@ class ReceiptPlace(  # pylint: disable=too-many-instance-attributes
             **result.gsi3_key,
             **result.gsi4_key,
         }
+        # Some GSI keys embed a *mutable* business field, so a partial update
+        # (e.g. a merchant remap or a confidence bump) can correct the scalar
+        # field without rewriting the projected GSI value. Real dev/prod rows
+        # carry that drift: the merchant-normalization migration fixed 144
+        # merchants but left 6 dev rows whose GSI1PK/GSI2PK/GSI3SK still encode
+        # the superseded merchant, place_id, and confidence (e.g.
+        # merchant_name="Wild Fork" with GSI1PK=MERCHANT#THOUSAND_OAKS and
+        # GSI2PK=PLACE#<old place id>; confidence bumped 0.80->0.95 without
+        # rewriting GSI3SK). The scalar fields are authoritative on read, so
+        # tolerate a stale-but-well-formed projection here rather than
+        # hard-failing a read of pre-existing data. Only these three keys carry
+        # a mutable field; every other key derives from identity
+        # (image_id/receipt_id) or a constant and stays a strict exact match.
+        # GSI2PK is only present in expected_keys when place_id is set, so the
+        # empty-place_id legacy handling below is unaffected.
+        business_key_validators = {
+            "GSI1PK": lambda value: bool(
+                _MERCHANT_GSI1PK_RE.fullmatch(value)
+            ),
+            "GSI2PK": lambda value: bool(_PLACE_GSI2PK_RE.fullmatch(value)),
+            "GSI3SK": lambda value: _is_wellformed_validation_sk(
+                value, result.image_id
+            ),
+        }
         for key_name, expected_value in expected_keys.items():
+            validator = business_key_validators.get(key_name)
+            if validator is not None:
+                stored = item.get(key_name)
+                if stored is not None and (
+                    not isinstance(stored, dict)
+                    or not validator(stored.get("S") or "")
+                ):
+                    raise ValueError(
+                        f"{key_name} does not match entity keys"
+                    )
+                continue
             if key_name in item and item[key_name] != expected_value:
                 raise ValueError(f"{key_name} does not match entity keys")
 

--- a/receipt_dynamo/tests/unit/test_receipt_place.py
+++ b/receipt_dynamo/tests/unit/test_receipt_place.py
@@ -747,3 +747,60 @@ def test_receipt_place_from_item_rejects_type_and_key_mismatches(
     item["GSI4SK"] = {"S": "OTHER"}
     with pytest.raises(ValueError, match="GSI4SK does not match"):
         ReceiptPlace.from_item(item)
+
+
+@pytest.mark.unit
+def test_receipt_place_from_item_tolerates_stale_business_gsi_projections(
+    example_receipt_place,
+):
+    """A merchant/place remap or confidence bump corrects the scalar field
+    without rewriting the projected GSI value, so legitimate dev/prod rows keep
+    superseded GSI1PK (merchant), GSI2PK (place_id), and GSI3SK (confidence)
+    projections. This reproduces the real dev shape of the 6 remapped rows
+    (e.g. merchant_name="Wild Fork" with GSI1PK=MERCHANT#THOUSAND_OAKS,
+    GSI2PK=PLACE#<old id>, and GSI3SK confidence 0.8000 while the field is
+    0.95). from_item must read these rows; the scalar fields are authoritative.
+    """
+    item = example_receipt_place.to_item()
+    image_id = example_receipt_place.image_id
+    item["GSI1PK"] = {"S": "MERCHANT#THOUSAND_OAKS"}
+    item["GSI2PK"] = {"S": "PLACE#ChIJkYgocFYl6IARJi7MRwF6Lo0"}
+    item["GSI3SK"] = {
+        "S": f"CONFIDENCE#0.8000#STATUS#MATCHED#IMAGE#{image_id}"
+    }
+
+    restored = ReceiptPlace.from_item(item)
+
+    assert restored == example_receipt_place
+    assert restored.merchant_name == "Starbucks Coffee"
+    assert restored.confidence == pytest.approx(0.85)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("key", "bad_value"),
+    [
+        ("GSI1PK", "WRONG"),
+        ("GSI1PK", "MERCHANT#"),
+        ("GSI1PK", "MERCHANT#lower case"),
+        ("GSI2PK", "WRONG"),
+        ("GSI2PK", "PLACE#"),
+        ("GSI3PK", "NOT_PLACE_VALIDATION"),
+        (
+            "GSI3SK",
+            "CONFIDENCE#0.8000#STATUS#MATCHED#IMAGE#00000000-0000-0000-0000-000000000000",
+        ),
+        ("GSI3SK", "garbage"),
+    ],
+)
+def test_receipt_place_from_item_rejects_malformed_gsi_projections(
+    example_receipt_place, key, bad_value
+):
+    """Malformed projections (wrong prefix, empty slug, or a GSI3SK whose
+    identity anchor does not match the row) are still rejected, so genuine
+    corruption is not silently accepted. GSI3PK is a constant and stays a
+    strict exact match."""
+    item = example_receipt_place.to_item()
+    item[key] = {"S": bad_value}
+    with pytest.raises(ValueError, match=f"{key} does not match"):
+        ReceiptPlace.from_item(item)

--- a/receipt_dynamo/tests/unit/test_receipt_place.py
+++ b/receipt_dynamo/tests/unit/test_receipt_place.py
@@ -804,6 +804,26 @@ def test_receipt_place_from_item_accepts_legitimate_stale_projections(
 
 
 @pytest.mark.unit
+def test_receipt_place_from_item_accepts_generated_gsi3sk_with_hash_status():
+    """validation_status is free-form and may contain '#', so a GSI3SK the
+    generator actually emits must round-trip even though '#' is the segment
+    separator. The exact-match short-circuit (not the looser pattern) covers
+    this canonical case."""
+    place = ReceiptPlace(
+        image_id="3f52804b-2fad-4e00-92c8-b593da3a8ed3",
+        receipt_id=1,
+        place_id="place",
+        merchant_name="Merchant",
+        validation_status="needs#review",
+        confidence=0.5,
+    )
+    item = place.to_item()
+    assert "#review#IMAGE#" in item["GSI3SK"]["S"]
+
+    assert ReceiptPlace.from_item(item) == place
+
+
+@pytest.mark.unit
 @pytest.mark.parametrize(
     ("key", "bad_value"),
     [

--- a/receipt_dynamo/tests/unit/test_receipt_place.py
+++ b/receipt_dynamo/tests/unit/test_receipt_place.py
@@ -790,6 +790,14 @@ def test_receipt_place_from_item_tolerates_stale_business_gsi_projections(
             "CONFIDENCE#0.0000#STATUS##IMAGE#"
             "3f52804b-2fad-4e00-92c8-b593da3a8ed3",
         ),
+        # A stale confidence (0.8000 vs the field's 0.85) with a free-form
+        # status containing '#'. Still well-formed: valid confidence, correct
+        # identity anchor, arbitrary status between.
+        (
+            "GSI3SK",
+            "CONFIDENCE#0.8000#STATUS#manual#review#IMAGE#"
+            "3f52804b-2fad-4e00-92c8-b593da3a8ed3",
+        ),
     ],
 )
 def test_receipt_place_from_item_accepts_legitimate_stale_projections(

--- a/receipt_dynamo/tests/unit/test_receipt_place.py
+++ b/receipt_dynamo/tests/unit/test_receipt_place.py
@@ -778,6 +778,33 @@ def test_receipt_place_from_item_tolerates_stale_business_gsi_projections(
 
 @pytest.mark.unit
 @pytest.mark.parametrize(
+    ("key", "good_value"),
+    [
+        # Google place ids are opaque; a stale id with a non-base64url char is
+        # still legitimate.
+        ("GSI2PK", "PLACE#abc.def"),
+        # Empty validation_status is a real "needs review" state, so an empty
+        # STATUS segment must be accepted.
+        (
+            "GSI3SK",
+            "CONFIDENCE#0.0000#STATUS##IMAGE#"
+            "3f52804b-2fad-4e00-92c8-b593da3a8ed3",
+        ),
+    ],
+)
+def test_receipt_place_from_item_accepts_legitimate_stale_projections(
+    example_receipt_place, key, good_value
+):
+    """Values the key generator could legitimately emit for some valid entity
+    state are accepted even when stale."""
+    item = example_receipt_place.to_item()
+    item[key] = {"S": good_value}
+
+    assert ReceiptPlace.from_item(item) == example_receipt_place
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
     ("key", "bad_value"),
     [
         ("GSI1PK", "WRONG"),
@@ -786,9 +813,19 @@ def test_receipt_place_from_item_tolerates_stale_business_gsi_projections(
         ("GSI2PK", "WRONG"),
         ("GSI2PK", "PLACE#"),
         ("GSI3PK", "NOT_PLACE_VALIDATION"),
+        # Identity anchor (trailing image id) does not match the row.
         (
             "GSI3SK",
             "CONFIDENCE#0.8000#STATUS#MATCHED#IMAGE#00000000-0000-0000-0000-000000000000",
+        ),
+        # Confidence the entity could never emit (out of [0,1] / non-canonical).
+        (
+            "GSI3SK",
+            "CONFIDENCE#999#STATUS#MATCHED#IMAGE#3f52804b-2fad-4e00-92c8-b593da3a8ed3",
+        ),
+        (
+            "GSI3SK",
+            "CONFIDENCE#1.5000#STATUS#MATCHED#IMAGE#3f52804b-2fad-4e00-92c8-b593da3a8ed3",
         ),
         ("GSI3SK", "garbage"),
     ],


### PR DESCRIPTION
## Problem

Sibling of #1142. PR #1116 hardened `ReceiptPlace.from_item` with a round-trip check that regenerates every GSI key from the parsed entity and hard-fails with `<KEY> does not match entity keys` when a stored key differs.

Several GSI keys embed a **mutable business field**, so a partial update (merchant remap, place remap, confidence bump) corrects the scalar field without rewriting the projected GSI value. The merchant-normalization migration fixed 144 merchants but left **6 dev rows** (mirrored to prod) with stale projections. Measured on dev `ReceiptsTable-dc5be22`:

| stale key | derives from | rows affected |
|---|---|---|
| `GSI1PK` (`MERCHANT#<slug>`) | `merchant_name` | 6 / 6 |
| `GSI2PK` (`PLACE#<id>`) | `place_id` | 6 / 6 |
| `GSI3SK` (`CONFIDENCE#..#STATUS#..#IMAGE#..`) | `confidence`, `validation_status` | 3 / 6 |

All identity keys (`PK`/`SK`/`GSI1SK`/`GSI2SK`/`GSI3PK`/`GSI4PK`/`GSI4SK`) still match. Example: `merchant_name="Wild Fork"` with `GSI1PK=MERCHANT#THOUSAND_OAKS`, `GSI2PK=PLACE#<old id>`, `GSI3SK` confidence `0.8000` while the field is `0.95`.

**Effect:** `get_image_details` AND `get_receipt_places_by_merchant` abort on any image containing one of these rows.
- Before: 0 / 6 affected images readable
- After: 6 / 6 read

## Fix

Validate-on-write, tolerate-on-read. Keep strict exact-match for every identity/constant-derived key. For the three keys that embed a mutable field, accept a **stale-but-well-formed** projection on read (the scalar field is authoritative):
- `GSI1PK` must be `MERCHANT#<slug>`
- `GSI2PK` must be `PLACE#<id>`
- `GSI3SK` must match `CONFIDENCE#<num>#STATUS#<status>#IMAGE#<id>` with its identity anchor equal to the row's `image_id`

Malformed projections (wrong prefix, empty slug, mismatched identity anchor) are still rejected — #1116's `GSI4SK`/`TYPE` mismatch test still passes. `to_item` is unchanged, so writes still emit correct projections. The empty-`place_id` sparse/legacy GSI2 handling is untouched (`GSI2PK` is only validated when `place_id` is set).

## Verification

- 6 / 6 affected dev images read via `get_image_details`; merchant queries parse
- Full `receipt_dynamo` unit suite: **2132 passed** (including #1116's hardened contracts)
- Added regression tests: tolerant read of all three stale projections; rejection of malformed variants

Dev reads only; no data written.

## Latent-GSI-visibility flag (not migrated, same as #1142)

These rows are **invisible under their current merchant/place to any GSI query** — they sit under the old partition (e.g. `get_receipt_places_by_merchant("Shake Shack")` returns 0 because that row is keyed `MERCHANT#SHAKE_SHACK_JENKINTOWN`). This read-tolerance fix unblocks parsing but does not correct the stale index entries. A backfill to rewrite the 6 rows' GSI projections is worth a separate decision — flagged, not migrated, because **prod mirrors this data**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)