### PR TITLE
[receipt_upload] Evaluate upload determinism on dev

### DIFF
--- a/docs/UPLOAD_DETERMINISM_EVALUATION.md
+++ b/docs/UPLOAD_DETERMINISM_EVALUATION.md
@@ -1,0 +1,194 @@
+# Upload determinism evaluation
+
+Date: 2026-07-14
+
+Model source: `upload-determinism-v1`
+
+Environment: dev only
+
+## Decision
+
+The resolver is safe to continue behind review gating, but it is not ready to
+auto-validate uploads.  The strongest result is source/provenance safety: the
+20-receipt audit found no silent LayoutLM override, and every proposed D3
+change was preserved as a reviewable event.  The principal blocker is D2
+generalization.  Cross-fitted line accuracy is 62.35%, which causes excessive
+D3 conflicts and leaves every D4 artifact in `NEEDS_REVIEW`.
+
+## Snapshot and safeguards
+
+The evaluator read the DynamoDB table named by `DYNAMODB_TABLE_NAME` only after
+requiring `DEPLOYMENT_ENVIRONMENT=dev` and verifying the table's
+`Environment=dev` and `Pulumi_Stack=dev` tags.  It used the pure, non-persisting
+D2, D3, and D4 callables.  It did not call a write API and did not access prod.
+
+The captured snapshot contained:
+
+- 5,593 `ReceiptSection` entities: 5,126 `VALID`, 467 `PENDING`.
+- 842 processed receipts with sections; 841 had unique `VALID` gold usable for
+  scoring.
+- Section snapshot SHA-256:
+  `9a69c1c31141d97fc03a448fddb3af4c9fcebb7597fca53c3a7cecc577f313e7`.
+
+The plan's earlier 5,712-section count has therefore drifted.  This report uses
+the captured, hashed dev snapshot rather than silently mixing snapshots.
+Receipt images, OCR, IDs, and field values stayed in `/tmp`; only aggregate,
+redacted findings are recorded here.
+
+## Method
+
+D2 was evaluated with deterministic, merchant-stratified five-fold cross
+validation, grouped by source image so no source receipt appeared in both
+training and validation.  Merchant and global priors were relearned in each
+training fold.  The committed full-corpus prior is reported separately as
+in-sample apparent fit.
+
+D3 and D4 received the cross-fitted D2 sections.  Corpus-wide D3/D4 figures are
+section-consistency measurements, not field-value truth: `ReceiptSection`
+validates section membership but is not independent gold for word labels or
+structured values.
+
+The visual audit was preregistered before resolver output was viewed: five
+merchant sentinels (Sprouts, Costco, Vons, Smith's, and Italia Deli), plus five
+receipts each from common, mid-frequency, and long-tail merchant strata.  The
+sampling seed was `20260714`; all five sentinels were found.  The non-sentinel
+population sizes were 315 common, 249 mid-frequency, and 273 long-tail
+receipts.  Results from these 20 receipts are an audit sample, not a population
+estimate.
+
+## D2: row-to-section assignment
+
+| Metric | Cross-fitted result |
+| --- | ---: |
+| Eligible gold lines | 29,809 |
+| Prediction coverage | 100.00% |
+| Line micro accuracy | 62.35% |
+| Receipt-cluster bootstrap 95% CI | 60.78%-64.05% |
+| Receipt macro accuracy | 60.23% |
+| Row accuracy | 62.54% |
+| Macro F1 | 51.46% |
+| Boundary F1 | 39.16% |
+| Eligible-gold exact-receipt rate | 1.66% |
+| Confidence Brier score | 0.3024 |
+| 10-bin ECE | 0.3228 |
+
+The frozen committed model reaches 66.00% line accuracy, 65.61% row accuracy,
+and 55.22% macro F1 on its training corpus.  That gap is expected optimism from
+in-sample scoring and is not the deployment estimate.
+
+## D3: label reconciliation
+
+Against held-out `VALID` section footprints:
+
+| Metric | Result |
+| --- | ---: |
+| Footprint violations | 978 |
+| Violation action recall | 58.69% |
+| Footprint-consistent labels | 9,423 |
+| False-action rate | 34.67% |
+| Non-conflict correction section precision | 94.44% |
+
+The resolver emitted 5,166 `label-section-footprint` conflicts.  Other major
+review sources were arithmetic role cardinality (742), subtotal/tax/total
+reconciliation (195), line totals to subtotal (152), and direct-total checks
+(108).  Corpus-wide template rules added 26 Vons member-savings labels and 12
+Costco member-number labels.
+
+In the 20-receipt visual audit, D3 emitted 94 events: 72 section-footprint, 19
+arithmetic-cardinality, and three line-total/subtotal events.  All 94 were
+conflicts, all retained an event ID, rule, reason, provenance, and original
+proposer, and all routed to review; there were zero silent overrides.  The
+sentinel audit also exposed a coverage gap: the visible Costco member number,
+Vons savings evidence, and Smith's fuel-points evidence produced no template
+`ADD` event in their three sentinel artifacts (0/3 expected activations).
+Several visually valid total or tender labels were nevertheless flagged after
+D2 put their rows in the wrong section.  This is safe but substantially
+over-reviews.
+
+## D4: structured ReceiptDetails
+
+Across all 842 receipts, every artifact was `NEEDS_REVIEW`.  D4 emitted 6,050
+LayoutLM-provenance fields and six arithmetic-provenance fields.  Section
+conformance was high once a field was emitted: 97.71% over 3,492 assessable
+fields and 97.44% over 1,799 assessable item fields.  This measures placement,
+not value accuracy.
+
+The 20-receipt visual audit used exact normalized values for scalar fields and
+required the complete visible item-name/line-total set for the item result.
+Unreadable or genuinely absent slots were excluded rather than counted as true
+negatives.
+
+| Field | Exact | Visually legible support | Exact recall |
+| --- | ---: | ---: | ---: |
+| Merchant | 16 | 20 | 80.0% |
+| Date | 12 | 19 | 63.2% |
+| Time | 8 | 19 | 42.1% |
+| Complete item set | 6 | 18 | 33.3% |
+| Subtotal | 3 | 14 | 21.4% |
+| Tax | 6 | 13 | 46.2% |
+| Total | 3 | 19 | 15.8% |
+| Tender method | 1 | 17 | 5.9% |
+| **Micro** | **55** | **139** | **39.6%** |
+
+The dominant error mode was omission, not fabrication.  For example, the
+Shake Shack receipt had correct merchant, date, time, two items, subtotal, and
+tax, but omitted the visibly printed total and card tender.  Floor & Decor
+captured date, time, tax, and total but produced an extra/incomplete item.
+Hardwoods captured only the address despite a legible date, time, payment
+amount, and tender.  The upside-down Vons sentinel and damaged Marufuku receipt
+show why review gating remains necessary.
+
+Corpus-wide D4 review pressure was also high: 1,732 role-cardinality conflicts,
+1,193 required-field conflicts, 1,132 incomplete-item conflicts, and 115
+unverified-merchant conflicts.  These conflicts are exposed in the artifact;
+none is silently resolved.
+
+## Reproduction
+
+Run the unit checks without AWS access:
+
+```bash
+PYTHONPATH=receipt_upload:receipt_dynamo:receipt_chroma:receipt_places:\
+tools/glyph-studio/py \
+  python -m pytest -q \
+    receipt_upload/tests/test_upload_determinism_evaluation.py
+```
+
+Run the read-only corpus evaluation with an explicitly supplied dev table:
+
+```bash
+DEPLOYMENT_ENVIRONMENT=dev \
+  DYNAMODB_TABLE_NAME="$DEV_RECEIPTS_TABLE" \
+  PYTHONPATH=receipt_upload:receipt_dynamo:receipt_chroma:receipt_places:\
+tools/glyph-studio/py \
+  python scripts/evaluate_upload_determinism.py \
+    --output /tmp/upload-determinism-evaluation.json
+```
+
+Render the private, local audit sheets from that result:
+
+```bash
+DEPLOYMENT_ENVIRONMENT=dev \
+  DYNAMODB_TABLE_NAME="$DEV_RECEIPTS_TABLE" \
+  UPLOAD_DETERMINISM_AUDIT_S3_BUCKETS="$DEV_RECEIPT_BUCKETS" \
+  PYTHONPATH=receipt_upload:receipt_dynamo:receipt_chroma:receipt_places:\
+tools/glyph-studio/py \
+  python scripts/render_upload_determinism_audit.py \
+    --report /tmp/upload-determinism-evaluation.json \
+    --output-dir /tmp/upload-determinism-audit
+```
+
+Do not commit either `/tmp` artifact: both contain receipt evidence.
+
+## Follow-up gates
+
+Before enabling automatic validation:
+
+1. Improve cross-fitted D2 boundary F1 and calibrate confidence; the current
+   score makes section-based D3 rules too noisy.
+2. Re-run the three merchant-template sentinels until the expected template
+   actions are present and provenance-complete.
+3. Raise D4 recall for totals and tender methods while preserving the current
+   conflict and provenance behavior.
+4. Repeat the frozen snapshot and the preregistered audit after each change;
+   do not treat the in-sample D2 score as a release gate.

--- a/receipt_upload/tests/test_upload_determinism_evaluation.py
+++ b/receipt_upload/tests/test_upload_determinism_evaluation.py
@@ -1,0 +1,284 @@
+"""Unit tests for the read-only upload-determinism evaluator."""
+
+import stat
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pytest
+from PIL import Image
+
+_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_ROOT))
+
+from receipt_dynamo.constants import ValidationStatus
+from receipt_dynamo.entities import ReceiptWordLabel
+from receipt_upload.section_assignment import RowAssignment
+from scripts.evaluate_upload_determinism import (
+    CorpusReceipt,
+    _finalize_section_metrics,
+    _majority_row_label,
+    _new_section_metrics,
+    _score_sections,
+    assert_dev_table,
+    assert_private_destination,
+    assign_folds,
+    project_reconciled_labels,
+    select_manual_sample,
+    write_private_text,
+)
+from scripts.render_upload_determinism_audit import (
+    _bucket_allowlist,
+    _image,
+    _prepare_private_directory,
+    _save_private_png,
+)
+
+_UUID = "11111111-1111-4111-8111-111111111111"
+
+
+def _receipt(image_id: str, merchant: str = "Example") -> CorpusReceipt:
+    return CorpusReceipt(
+        image_id=image_id,
+        receipt_id=1,
+        merchant_name=merchant,
+        lines=(),
+        words=(),
+        labels=(),
+        rows=(),
+        gold_sections=(),
+        labeled_rows=(),
+    )
+
+
+def test_dev_table_guard_requires_both_dev_tags() -> None:
+    dynamodb = Mock()
+    dynamodb.describe_table.return_value = {
+        "Table": {"TableArn": "arn:example:table/dev"}
+    }
+    dynamodb.list_tags_of_resource.return_value = {
+        "Tags": [
+            {"Key": "Environment", "Value": "dev"},
+            {"Key": "Pulumi_Stack", "Value": "dev"},
+        ]
+    }
+    with patch(
+        "scripts.evaluate_upload_determinism.boto3.client",
+        return_value=dynamodb,
+    ):
+        assert assert_dev_table("dev", "table-from-env") == "table-from-env"
+        with pytest.raises(RuntimeError, match="exactly dev"):
+            assert_dev_table("prod", "table-from-env")
+
+
+@pytest.mark.parametrize(
+    "tags",
+    [
+        [{"Key": "Pulumi_Stack", "Value": "dev"}],
+        [{"Key": "Environment", "Value": "dev"}],
+        [
+            {"Key": "Environment", "Value": "prod"},
+            {"Key": "Pulumi_Stack", "Value": "dev"},
+        ],
+        [
+            {"Key": "Environment", "Value": "dev"},
+            {"Key": "Pulumi_Stack", "Value": "prod"},
+        ],
+    ],
+)
+def test_dev_table_guard_rejects_missing_or_wrong_tags(
+    tags: list[dict[str, str]],
+) -> None:
+    dynamodb = Mock()
+    dynamodb.describe_table.return_value = {
+        "Table": {"TableArn": "arn:example:table/not-dev"}
+    }
+    dynamodb.list_tags_of_resource.return_value = {"Tags": tags}
+    with patch(
+        "scripts.evaluate_upload_determinism.boto3.client",
+        return_value=dynamodb,
+    ), pytest.raises(RuntimeError, match="Environment=dev.*Pulumi_Stack=dev"):
+        assert_dev_table("dev", "table-from-env")
+
+
+def test_private_evaluation_output_stays_outside_repo_and_is_owner_only(
+    tmp_path: Path,
+) -> None:
+    with pytest.raises(RuntimeError, match="outside the repository"):
+        assert_private_destination(
+            Path(__file__).resolve().parent / "private-evaluation.json"
+        )
+
+    destination = tmp_path / "new-private-dir" / "evaluation.json"
+    written = write_private_text(destination, "private receipt data\n")
+
+    assert written.read_text(encoding="utf-8") == "private receipt data\n"
+    assert stat.S_IMODE(written.stat().st_mode) == 0o600
+    assert stat.S_IMODE(written.parent.stat().st_mode) == 0o700
+
+
+def test_audit_directory_and_png_are_owner_only(tmp_path: Path) -> None:
+    with pytest.raises(RuntimeError, match="outside the repository"):
+        _prepare_private_directory(
+            Path(__file__).resolve().parent / "private-audit"
+        )
+
+    output_dir = _prepare_private_directory(
+        tmp_path / "private-parent" / "private-audit"
+    )
+    output = output_dir / "01.png"
+    _save_private_png(Image.new("RGB", (2, 2), "white"), output)
+
+    assert stat.S_IMODE(output_dir.stat().st_mode) == 0o700
+    assert stat.S_IMODE(output_dir.parent.stat().st_mode) == 0o700
+    assert stat.S_IMODE(output.stat().st_mode) == 0o600
+
+
+def test_audit_s3_bucket_allowlist_is_required_and_fail_closed() -> None:
+    with pytest.raises(RuntimeError, match="AUDIT_S3_BUCKETS.*required"):
+        _bucket_allowlist(None)
+
+    receipt = SimpleNamespace(
+        cdn_s3_bucket="prod-cdn",
+        cdn_s3_key="receipt.png",
+        raw_s3_bucket="prod-raw",
+        raw_s3_key="receipt.png",
+        image_id=_UUID,
+        receipt_id=1,
+    )
+    s3 = Mock()
+    with patch(
+        "scripts.render_upload_determinism_audit.boto3.client",
+        return_value=s3,
+    ):
+        with pytest.raises(RuntimeError, match="image unavailable"):
+            _image(receipt, _bucket_allowlist("dev-cdn,dev-raw"))
+
+    s3.get_object.assert_not_called()
+
+
+def test_fold_assignment_keeps_source_image_together() -> None:
+    first = _receipt(_UUID)
+    second = CorpusReceipt(**{**first.__dict__, "receipt_id": 2})
+    other = _receipt("22222222-2222-4222-8222-222222222222")
+
+    folds = assign_folds([first, second, other])
+
+    assert folds[first.image_id] == folds[second.image_id]
+    assert set(folds.values()) <= set(range(5))
+
+
+def test_row_label_ties_match_production_primary_then_sorted_policy() -> None:
+    primary_wins = SimpleNamespace(row_id=2, line_ids=[1, 2])
+    sorted_fallback = SimpleNamespace(row_id=99, line_ids=[1, 2])
+    gold = {1: "ITEMS", 2: "HEADER"}
+
+    assert _majority_row_label(primary_wins, gold) == "HEADER"
+    assert _majority_row_label(sorted_fallback, gold) == "HEADER"
+
+
+def test_section_metrics_score_unique_valid_gold_only() -> None:
+    row = SimpleNamespace(row_id=1, line_ids=[1])
+    gold = SimpleNamespace(
+        validation_status=ValidationStatus.VALID.value,
+        section_type="ITEMS",
+        line_ids=[1],
+    )
+    receipt = CorpusReceipt(
+        **{
+            **_receipt(_UUID).__dict__,
+            "rows": (row,),
+            "gold_sections": (gold,),
+        }
+    )
+    metrics = _new_section_metrics()
+
+    _score_sections(
+        metrics,
+        receipt,
+        [RowAssignment(row=row, section_type="ITEMS", confidence=0.9)],
+    )
+    result = _finalize_section_metrics(metrics)
+
+    assert result["eligible_lines"] == 1
+    assert result["line_micro_accuracy"] == 1.0
+    assert result["row_accuracy"] == 1.0
+    assert result["eligible_gold_exact_receipt_rate"] == 1.0
+
+
+def test_reconciliation_projection_never_mutates_input() -> None:
+    original = ReceiptWordLabel(
+        image_id=_UUID,
+        receipt_id=1,
+        line_id=1,
+        word_id=1,
+        label="PRODUCT_NAME",
+        reasoning="layoutlm",
+        timestamp_added=datetime.now(timezone.utc),
+        validation_status=ValidationStatus.PENDING.value,
+        label_proposed_by="layoutlm",
+    )
+    plan = SimpleNamespace(
+        corrections=[
+            {
+                "line_id": 1,
+                "word_id": 1,
+                "original_label": "PRODUCT_NAME",
+                "original_new_status": "INVALID",
+                "corrected_label": "GRAND_TOTAL",
+                "corrected_status": "PENDING",
+                "reason": "test correction",
+                "provenance": "section-rule",
+            }
+        ]
+    )
+
+    projected = project_reconciled_labels([original], plan, _UUID, 1)
+
+    assert original.validation_status == ValidationStatus.PENDING.value
+    assert projected[0].validation_status == ValidationStatus.INVALID.value
+    assert projected[1].label == "GRAND_TOTAL"
+    assert projected[1].label_proposed_by.endswith(":section-rule")
+
+
+def test_manual_sample_has_sentinels_and_three_frequency_strata() -> None:
+    merchants = [
+        "Sprouts Farmers Market",
+        "Costco Wholesale",
+        "Vons",
+        "Smith's",
+        "Italia Deli",
+    ]
+    counts = {merchant.casefold(): 30 for merchant in merchants}
+    payloads = []
+    for index, merchant in enumerate(merchants):
+        payloads.append(
+            {
+                "image_id": f"{index + 1:08d}-0000-4000-8000-000000000000",
+                "receipt_id": 1,
+                "merchant": merchant,
+            }
+        )
+    for index in range(30):
+        merchant = f"Merchant {index}"
+        key = merchant.casefold()
+        counts[key] = 30 if index < 10 else 10 if index < 20 else 1
+        payloads.append(
+            {
+                "image_id": f"{index + 100:08d}-0000-4000-8000-000000000000",
+                "receipt_id": 1,
+                "merchant": merchant,
+            }
+        )
+
+    sample, design = select_manual_sample(payloads, counts)
+
+    assert len(sample) == 20
+    assert all(design["sentinels_found"].values())
+    assert {item["sample_stratum"] for item in sample} >= {
+        "common",
+        "mid_frequency",
+        "long_tail",
+    }

--- a/scripts/evaluate_upload_determinism.py
+++ b/scripts/evaluate_upload_determinism.py
@@ -1,0 +1,1087 @@
+#!/usr/bin/env python3
+"""Read-only, leakage-aware evaluation of the upload resolver on dev.
+
+The DynamoDB table is accepted only from ``DYNAMODB_TABLE_NAME``.  The
+command refuses any environment other than dev and verifies both the
+``Environment=dev`` and ``Pulumi_Stack=dev`` resource tags before reading.
+It never calls a write API.
+"""
+
+# pylint: disable=too-many-lines,too-many-locals,too-many-statements
+# pylint: disable=wrong-import-position
+# pylint: disable=broad-exception-caught
+
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import json
+import os
+import random
+import sys
+import threading
+from collections import Counter, defaultdict
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from statistics import fmean, median
+from typing import Any, Iterable, Mapping, Sequence
+
+import boto3
+
+_ROOT = Path(__file__).resolve().parent.parent
+for _package in ("receipt_dynamo", "receipt_chroma", "receipt_upload"):
+    sys.path.insert(0, str(_ROOT / _package))
+
+from receipt_chroma.embedding.formatting import build_receipt_rows
+from receipt_dynamo import DynamoClient
+from receipt_dynamo.constants import ValidationStatus
+from receipt_dynamo.data.shared_exceptions import (
+    EntityNotFoundError,
+    OperationError,
+)
+from receipt_dynamo.entities import (
+    ReceiptLabelReconciliation,
+    ReceiptWordLabel,
+)
+from receipt_upload.label_reconciliation import (
+    MODEL_SOURCE,
+    plan_label_reconciliation,
+)
+from receipt_upload.section_assignment import (
+    RowAssignment,
+    assign_row_sections,
+    extract_row_features,
+    learn_prior,
+    load_prior_model,
+    normalize_merchant_key,
+    sections_from_assignments,
+)
+from receipt_upload.structured_details import build_receipt_resolved_details
+
+_FOLDS = 5
+_BOOTSTRAP_SAMPLES = 1000
+_SEED = 20260714
+_LOCAL = threading.local()
+_AUDIT_FOOTPRINT = {
+    "PRODUCT_NAME": {"ITEMS"},
+    "QUANTITY": {"ITEMS"},
+    "UNIT_PRICE": {"ITEMS"},
+    "LINE_TOTAL": {"ITEMS"},
+    "SUBTOTAL": {"SUMMARY"},
+    "TAX": {"SUMMARY"},
+    "GRAND_TOTAL": {"SUMMARY", "TOTAL_LINE"},
+    "DISCOUNT": {"ITEMS", "SUMMARY"},
+    "CHANGE": {"PAYMENT"},
+    "CASH_BACK": {"PAYMENT"},
+    "REFUND": {"PAYMENT"},
+    "PAYMENT_METHOD": {"PAYMENT"},
+}
+
+
+@dataclass(frozen=True)
+class CorpusReceipt:
+    """One receipt and all read-only inputs needed by D2-D4."""
+
+    image_id: str
+    receipt_id: int
+    merchant_name: str | None
+    lines: tuple[Any, ...]
+    words: tuple[Any, ...]
+    labels: tuple[Any, ...]
+    rows: tuple[Any, ...]
+    gold_sections: tuple[Any, ...]
+    labeled_rows: tuple[tuple[Any, str], ...]
+
+    @property
+    def key(self) -> tuple[str, int]:
+        """Return the stable receipt key."""
+
+        return self.image_id, self.receipt_id
+
+
+def _args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--environment", default=os.environ.get("DEPLOYMENT_ENVIRONMENT")
+    )
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--workers", type=int, default=8)
+    return parser.parse_args()
+
+
+def assert_private_destination(path: Path) -> Path:
+    """Resolve a sensitive output path and reject the repository tree."""
+
+    resolved = path.expanduser().resolve(strict=False)
+    repository = _ROOT.resolve()
+    if resolved == repository or repository in resolved.parents:
+        raise RuntimeError(
+            "Sensitive evaluation output must stay outside the repository"
+        )
+    return resolved
+
+
+def _create_private_directories(path: Path) -> None:
+    """Create missing destination directories with owner-only permissions."""
+
+    missing = []
+    current = path
+    while not current.exists():
+        missing.append(current)
+        current = current.parent
+    path.mkdir(parents=True, mode=0o700, exist_ok=True)
+    for directory in missing:
+        directory.chmod(0o700)
+
+
+def write_private_text(path: Path, value: str) -> Path:
+    """Write a sensitive text artifact without following a final symlink."""
+
+    destination = assert_private_destination(path)
+    _create_private_directories(destination.parent)
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+    flags |= getattr(os, "O_NOFOLLOW", 0)
+    descriptor = os.open(destination, flags, 0o600)
+    try:
+        os.fchmod(descriptor, 0o600)
+        with os.fdopen(descriptor, "w", encoding="utf-8") as output:
+            descriptor = -1
+            output.write(value)
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+    return destination
+
+
+def assert_dev_table(environment: str | None, table_name: str | None) -> str:
+    """Fail closed unless the table is owned by the Pulumi dev stack."""
+
+    if environment != "dev":
+        raise RuntimeError("DEPLOYMENT_ENVIRONMENT must be exactly dev")
+    if not table_name:
+        raise RuntimeError("DYNAMODB_TABLE_NAME is required")
+    dynamodb = boto3.client("dynamodb")
+    table = dynamodb.describe_table(TableName=table_name)["Table"]
+    tags = {
+        item["Key"]: item["Value"]
+        for item in dynamodb.list_tags_of_resource(
+            ResourceArn=table["TableArn"]
+        )["Tags"]
+    }
+    if tags.get("Environment") != "dev" or tags.get("Pulumi_Stack") != "dev":
+        raise RuntimeError(
+            "Refusing table without Environment=dev and Pulumi_Stack=dev tags"
+        )
+    return table_name
+
+
+def _client(table_name: str) -> DynamoClient:
+    client = getattr(_LOCAL, "client", None)
+    if client is None or client.table_name != table_name:
+        client = DynamoClient(table_name)
+        _LOCAL.client = client
+    return client
+
+
+def _all_sections(client: DynamoClient) -> list[Any]:
+    sections: list[Any] = []
+    cursor = None
+    while True:
+        batch, cursor = client.list_receipt_sections(
+            limit=1000, last_evaluated_key=cursor
+        )
+        sections.extend(batch)
+        if cursor is None:
+            return sections
+
+
+def _merchant_name(
+    client: DynamoClient, image_id: str, receipt_id: int
+) -> str:
+    try:
+        merchant = client.get_receipt_place(image_id, receipt_id).merchant_name
+        return str(merchant) if merchant else ""
+    except EntityNotFoundError:
+        return ""
+    except OperationError as error:
+        if "does not match entity keys" not in str(error):
+            raise
+        response = client._client.get_item(  # pylint: disable=protected-access
+            TableName=client.table_name,
+            Key={
+                "PK": {"S": f"IMAGE#{image_id}"},
+                "SK": {"S": f"RECEIPT#{receipt_id:05d}#PLACE"},
+            },
+            ProjectionExpression="merchant_name",
+            ConsistentRead=True,
+        )
+        return response.get("Item", {}).get("merchant_name", {}).get("S", "")
+
+
+def _gold_by_line(
+    sections: Sequence[Any],
+) -> tuple[dict[int, str], set[int]]:
+    candidates: dict[int, set[str]] = defaultdict(set)
+    for section in sections:
+        if section.validation_status != ValidationStatus.VALID.value:
+            continue
+        for line_id in section.line_ids:
+            candidates[int(line_id)].add(str(section.section_type))
+    gold = {
+        line_id: next(iter(values))
+        for line_id, values in candidates.items()
+        if len(values) == 1
+    }
+    ambiguous = {
+        line_id for line_id, values in candidates.items() if len(values) > 1
+    }
+    return gold, ambiguous
+
+
+def _majority_row_label(row: Any, gold: Mapping[int, str]) -> str | None:
+    votes = Counter(
+        gold[line_id] for line_id in row.line_ids if line_id in gold
+    )
+    if not votes:
+        return None
+    maximum = max(votes.values())
+    leaders = sorted(
+        label for label, count in votes.items() if count == maximum
+    )
+    primary = gold.get(row.row_id)
+    return primary if primary in leaders else leaders[0]
+
+
+def _load_receipt(
+    table_name: str,
+    key: tuple[str, int],
+    sections: Sequence[Any],
+) -> CorpusReceipt:
+    client = _client(table_name)
+    image_id, receipt_id = key
+    lines = tuple(client.list_receipt_lines_from_receipt(image_id, receipt_id))
+    words = tuple(client.list_receipt_words_from_receipt(image_id, receipt_id))
+    labels, cursor = client.list_receipt_word_labels_for_receipt(
+        image_id, receipt_id
+    )
+    if cursor is not None:
+        raise RuntimeError(f"unexpected label pagination for {key}")
+    rows = tuple(build_receipt_rows(lines, words)) if lines else ()
+    gold, _ = _gold_by_line(sections)
+    labeled_rows = tuple(
+        (feature, label)
+        for feature in extract_row_features(rows, lines)
+        if (label := _majority_row_label(feature.row, gold)) is not None
+    )
+    return CorpusReceipt(
+        image_id=image_id,
+        receipt_id=receipt_id,
+        merchant_name=_merchant_name(client, image_id, receipt_id) or None,
+        lines=lines,
+        words=words,
+        labels=tuple(labels),
+        rows=rows,
+        gold_sections=tuple(sections),
+        labeled_rows=labeled_rows,
+    )
+
+
+def _stable_hash(*values: object) -> str:
+    return hashlib.sha256("|".join(map(str, values)).encode()).hexdigest()
+
+
+def assign_folds(receipts: Sequence[CorpusReceipt]) -> dict[str, int]:
+    """Assign image groups to deterministic merchant-stratified folds."""
+
+    by_image: dict[str, list[CorpusReceipt]] = defaultdict(list)
+    for receipt in receipts:
+        by_image[receipt.image_id].append(receipt)
+    strata: dict[str, list[str]] = defaultdict(list)
+    for image_id, group in by_image.items():
+        merchants = sorted(
+            normalize_merchant_key(receipt.merchant_name)
+            for receipt in group
+            if receipt.merchant_name
+        )
+        strata[merchants[0] if merchants else "<unknown>"].append(image_id)
+    folds = {}
+    for stratum, image_ids in sorted(strata.items()):
+        ordered = sorted(
+            image_ids, key=lambda value: _stable_hash(_SEED, value)
+        )
+        offset = int(_stable_hash(stratum)[:8], 16) % _FOLDS
+        for index, image_id in enumerate(ordered):
+            folds[image_id] = (index + offset) % _FOLDS
+    return folds
+
+
+def fit_model(receipts: Sequence[CorpusReceipt]) -> dict[str, Any]:
+    """Fit the same priors as the production builder on training receipts."""
+
+    labeled = [
+        list(receipt.labeled_rows)
+        for receipt in receipts
+        if receipt.labeled_rows
+    ]
+    by_merchant: dict[str, list[list[Any]]] = defaultdict(list)
+    for receipt in receipts:
+        if not receipt.labeled_rows:
+            continue
+        merchant = normalize_merchant_key(receipt.merchant_name)
+        if merchant:
+            by_merchant[merchant].append(list(receipt.labeled_rows))
+    counts = [len(items) for items in by_merchant.values()]
+    cutoff = int(median(counts)) + 1 if counts else 1
+    eligible = {
+        merchant: items
+        for merchant, items in by_merchant.items()
+        if len(items) >= cutoff
+    }
+    return {
+        "global": learn_prior(labeled),
+        "merchants": {
+            merchant: learn_prior(items, include_tokens=False)
+            for merchant, items in sorted(eligible.items())
+        },
+        "evaluation_training": {
+            "receipt_count": len(labeled),
+            "merchant_prior_min_receipts": cutoff,
+        },
+    }
+
+
+def _new_section_metrics() -> dict[str, Any]:
+    return {
+        "eligible_lines": 0,
+        "covered_lines": 0,
+        "correct_lines": 0,
+        "ambiguous_gold_lines": 0,
+        "unlabeled_predicted_lines": 0,
+        "eligible_rows": 0,
+        "correct_rows": 0,
+        "boundary_tp": 0,
+        "boundary_fp": 0,
+        "boundary_fn": 0,
+        "receipts_with_gold": 0,
+        "receipts_without_gold": 0,
+        "exact_receipts": 0,
+        "receipt_scores": [],
+        "receipt_line_counts": [],
+        "per_section": defaultdict(Counter),
+        "confusion": Counter(),
+        "confidence": [],
+    }
+
+
+def _score_sections(
+    metrics: dict[str, Any],
+    receipt: CorpusReceipt,
+    assignments: Sequence[RowAssignment],
+) -> None:
+    gold, ambiguous = _gold_by_line(receipt.gold_sections)
+    predicted = {
+        line_id: assignment.section_type
+        for assignment in assignments
+        for line_id in assignment.row.line_ids
+    }
+    confidence = {
+        line_id: assignment.confidence
+        for assignment in assignments
+        for line_id in assignment.row.line_ids
+    }
+    metrics["ambiguous_gold_lines"] += len(ambiguous)
+    if not gold:
+        metrics["receipts_without_gold"] += 1
+        return
+    metrics["receipts_with_gold"] += 1
+    correct = 0
+    for line_id, truth in gold.items():
+        prediction = predicted.get(line_id)
+        metrics["eligible_lines"] += 1
+        metrics["per_section"][truth]["support"] += 1
+        if prediction is None:
+            metrics["per_section"][truth]["fn"] += 1
+            metrics["confusion"][(truth, "<MISSING>")] += 1
+            continue
+        metrics["covered_lines"] += 1
+        is_correct = prediction == truth
+        metrics["confidence"].append((confidence[line_id], is_correct))
+        metrics["confusion"][(truth, prediction)] += 1
+        if is_correct:
+            correct += 1
+            metrics["correct_lines"] += 1
+            metrics["per_section"][truth]["tp"] += 1
+        else:
+            metrics["per_section"][truth]["fn"] += 1
+            metrics["per_section"][prediction]["fp"] += 1
+    metrics["unlabeled_predicted_lines"] += len(set(predicted) - set(gold))
+    support = len(gold)
+    metrics["receipt_scores"].append(correct / support)
+    metrics["receipt_line_counts"].append((correct, support))
+    if correct == support and all(line_id in predicted for line_id in gold):
+        metrics["exact_receipts"] += 1
+
+    ordered = list(assignments)
+    row_truth = [_majority_row_label(item.row, gold) for item in ordered]
+    for assignment, row_label in zip(ordered, row_truth, strict=True):
+        if row_label is None:
+            continue
+        metrics["eligible_rows"] += 1
+        metrics["correct_rows"] += int(assignment.section_type == row_label)
+    for index in range(1, len(ordered)):
+        if row_truth[index - 1] is None or row_truth[index] is None:
+            continue
+        gold_boundary = row_truth[index - 1] != row_truth[index]
+        pred_boundary = (
+            ordered[index - 1].section_type != ordered[index].section_type
+        )
+        metrics["boundary_tp"] += int(gold_boundary and pred_boundary)
+        metrics["boundary_fp"] += int(not gold_boundary and pred_boundary)
+        metrics["boundary_fn"] += int(gold_boundary and not pred_boundary)
+
+
+def _ratio(numerator: float, denominator: float) -> float | None:
+    return numerator / denominator if denominator else None
+
+
+def _bootstrap_ci(counts: Sequence[tuple[int, int]]) -> list[float] | None:
+    if not counts:
+        return None
+    rng = random.Random(_SEED)
+    samples = []
+    for _ in range(_BOOTSTRAP_SAMPLES):
+        picked = [counts[rng.randrange(len(counts))] for _ in counts]
+        samples.append(sum(x for x, _ in picked) / sum(n for _, n in picked))
+    samples.sort()
+    return [samples[24], samples[974]]
+
+
+def _finalize_section_metrics(metrics: dict[str, Any]) -> dict[str, Any]:
+    per_section = {}
+    f1_values = []
+    for section, counts in sorted(metrics["per_section"].items()):
+        precision = _ratio(counts["tp"], counts["tp"] + counts["fp"])
+        recall = _ratio(counts["tp"], counts["tp"] + counts["fn"])
+        f1 = (
+            2 * precision * recall / (precision + recall)
+            if precision is not None
+            and recall is not None
+            and precision + recall
+            else 0.0
+        )
+        if counts["support"]:
+            f1_values.append(f1)
+        per_section[section] = {
+            **dict(counts),
+            "precision": precision,
+            "recall": recall,
+            "f1": f1,
+        }
+    boundary_precision = _ratio(
+        metrics["boundary_tp"],
+        metrics["boundary_tp"] + metrics["boundary_fp"],
+    )
+    boundary_recall = _ratio(
+        metrics["boundary_tp"],
+        metrics["boundary_tp"] + metrics["boundary_fn"],
+    )
+    boundary_f1 = (
+        2
+        * boundary_precision
+        * boundary_recall
+        / (boundary_precision + boundary_recall)
+        if boundary_precision is not None
+        and boundary_recall is not None
+        and boundary_precision + boundary_recall
+        else 0.0
+    )
+    confidence = metrics["confidence"]
+    thresholds = {}
+    for threshold in (0.5, 0.7, 0.8, 0.9):
+        selected = [
+            correct for score, correct in confidence if score >= threshold
+        ]
+        thresholds[str(threshold)] = {
+            "coverage": _ratio(len(selected), len(confidence)),
+            "accuracy": _ratio(sum(selected), len(selected)),
+            "support": len(selected),
+        }
+    bins = []
+    ece = 0.0
+    for index in range(10):
+        low, high = index / 10, (index + 1) / 10
+        values = [
+            (score, correct)
+            for score, correct in confidence
+            if (low <= score <= high if index == 9 else low <= score < high)
+        ]
+        if not values:
+            continue
+        mean_confidence = fmean(score for score, _ in values)
+        accuracy = fmean(float(correct) for _, correct in values)
+        ece += (
+            len(values)
+            / max(len(confidence), 1)
+            * abs(mean_confidence - accuracy)
+        )
+        bins.append(
+            {
+                "low": low,
+                "high": high,
+                "support": len(values),
+                "mean_confidence": mean_confidence,
+                "accuracy": accuracy,
+            }
+        )
+    return {
+        "receipts_with_gold": metrics["receipts_with_gold"],
+        "receipts_without_valid_gold": metrics["receipts_without_gold"],
+        "eligible_lines": metrics["eligible_lines"],
+        "ambiguous_gold_lines": metrics["ambiguous_gold_lines"],
+        "prediction_coverage": _ratio(
+            metrics["covered_lines"], metrics["eligible_lines"]
+        ),
+        "line_micro_accuracy": _ratio(
+            metrics["correct_lines"], metrics["eligible_lines"]
+        ),
+        "line_micro_accuracy_cluster_bootstrap_95_ci": _bootstrap_ci(
+            metrics["receipt_line_counts"]
+        ),
+        "receipt_macro_accuracy": (
+            fmean(metrics["receipt_scores"])
+            if metrics["receipt_scores"]
+            else None
+        ),
+        "eligible_gold_exact_receipt_rate": _ratio(
+            metrics["exact_receipts"], metrics["receipts_with_gold"]
+        ),
+        "row_accuracy": _ratio(
+            metrics["correct_rows"], metrics["eligible_rows"]
+        ),
+        "boundary_precision": boundary_precision,
+        "boundary_recall": boundary_recall,
+        "boundary_f1": boundary_f1,
+        "macro_f1": fmean(f1_values) if f1_values else None,
+        "per_section": per_section,
+        "unlabeled_predicted_lines": metrics["unlabeled_predicted_lines"],
+        "confidence_brier": (
+            fmean(
+                (score - float(correct)) ** 2 for score, correct in confidence
+            )
+            if confidence
+            else None
+        ),
+        "confidence_ece_10_equal_width_bins": ece if confidence else None,
+        "confidence_bins": bins,
+        "selective_accuracy": thresholds,
+        "confusion": [
+            {"gold": gold, "predicted": pred, "count": count}
+            for (gold, pred), count in metrics["confusion"].most_common()
+        ],
+    }
+
+
+def _new_consistency_metrics() -> dict[str, Any]:
+    return {
+        "violations": 0,
+        "violations_acted": 0,
+        "consistent": 0,
+        "consistent_acted": 0,
+        "corrections_assessable": 0,
+        "corrections_conformant": 0,
+        "d3_actions": Counter(),
+        "d3_conflicts": Counter(),
+        "d4_status": Counter(),
+        "d4_conflicts": Counter(),
+        "d4_fields": Counter(),
+        "d4_provenance": Counter(),
+        "d4_assessable": 0,
+        "d4_conformant": 0,
+        "d4_item_assessable": 0,
+        "d4_item_conformant": 0,
+    }
+
+
+def project_reconciled_labels(
+    labels: Sequence[Any], plan: Any, image_id: str, receipt_id: int
+) -> list[Any]:
+    """Apply D3 events to copies only, mirroring the additive writer."""
+
+    projected = copy.deepcopy(list(labels))
+    index = {
+        (label.line_id, label.word_id, label.label): label
+        for label in projected
+    }
+    for event in plan.corrections:
+        line_id = int(event["line_id"])
+        word_id = int(event["word_id"])
+        original_label = event.get("original_label")
+        original = index.get((line_id, word_id, str(original_label)))
+        if original is not None and event.get("original_new_status"):
+            original.validation_status = str(event["original_new_status"])
+        corrected = event.get("corrected_label")
+        corrected_status = event.get("corrected_status")
+        if not corrected or not corrected_status:
+            continue
+        existing = index.get((line_id, word_id, str(corrected)))
+        if existing is not None:
+            existing.validation_status = str(corrected_status)
+            continue
+        created = ReceiptWordLabel(
+            image_id=image_id,
+            receipt_id=receipt_id,
+            line_id=line_id,
+            word_id=word_id,
+            label=str(corrected),
+            reasoning=str(event["reason"]),
+            timestamp_added=datetime.now(timezone.utc),
+            validation_status=str(corrected_status),
+            label_proposed_by=f"{MODEL_SOURCE}:{event['provenance']}",
+            label_consolidated_from=(
+                str(original_label) if original_label else None
+            ),
+        )
+        projected.append(created)
+        index[(line_id, word_id, str(corrected))] = created
+    return projected
+
+
+def _leaf_fields(value: Any, path: str = "") -> Iterable[tuple[str, dict]]:
+    if isinstance(value, list):
+        for item in value:
+            yield from _leaf_fields(item, path + "[]")
+        return
+    if not isinstance(value, dict):
+        return
+    if "value" in value:
+        yield path, value
+        return
+    for name, nested in value.items():
+        next_path = f"{path}.{name}" if path else name
+        yield from _leaf_fields(nested, next_path)
+
+
+def _score_d3_d4(
+    metrics: dict[str, Any],
+    receipt: CorpusReceipt,
+    plan: Any,
+    details: Any,
+) -> None:
+    gold, _ = _gold_by_line(receipt.gold_sections)
+    section_events = {
+        (
+            int(event["line_id"]),
+            int(event["word_id"]),
+            str(event.get("original_label")),
+        )
+        for event in plan.corrections
+        if str(event.get("rule_id", "")) == "label-section-footprint"
+    }
+    for label in receipt.labels:
+        if label.validation_status == ValidationStatus.INVALID.value:
+            continue
+        allowed = _AUDIT_FOOTPRINT.get(label.label)
+        truth = gold.get(label.line_id)
+        if allowed is None or truth is None:
+            continue
+        acted = (label.line_id, label.word_id, label.label) in section_events
+        if truth not in allowed:
+            metrics["violations"] += 1
+            metrics["violations_acted"] += int(acted)
+        else:
+            metrics["consistent"] += 1
+            metrics["consistent_acted"] += int(acted)
+    for event in plan.corrections:
+        rule = str(event.get("rule_id") or "<unknown>")
+        metrics["d3_actions"][(rule, str(event.get("action")))] += 1
+        if event.get("conflict"):
+            metrics["d3_conflicts"][rule] += 1
+        corrected = event.get("corrected_label")
+        truth = gold.get(int(event["line_id"]))
+        allowed = _AUDIT_FOOTPRINT.get(str(corrected))
+        if (
+            event.get("conflict")
+            or not corrected
+            or truth is None
+            or not allowed
+        ):
+            continue
+        metrics["corrections_assessable"] += 1
+        metrics["corrections_conformant"] += int(truth in allowed)
+
+    document = details.to_document()
+    metrics["d4_status"][details.validation_status] += 1
+    for conflict in details.conflicts:
+        metrics["d4_conflicts"][str(conflict.get("rule_id"))] += 1
+    for path, field in _leaf_fields(
+        {
+            "merchant": document["merchant"],
+            "transaction": document["transaction"],
+            "items": document["items"],
+            "totals": document["totals"],
+            "tender": document["tender"],
+        }
+    ):
+        if field.get("value") is None:
+            continue
+        metrics["d4_fields"][path] += 1
+        metrics["d4_provenance"][str(field.get("provenance"))] += 1
+        sources = field.get("source_words") or []
+        if not sources:
+            continue
+        truths = [gold.get(int(source["line_id"])) for source in sources]
+        if any(truth is None for truth in truths):
+            continue
+        metrics["d4_assessable"] += 1
+        labels = [str(source.get("label")) for source in sources]
+        conformant = all(
+            label not in _AUDIT_FOOTPRINT or truth in _AUDIT_FOOTPRINT[label]
+            for label, truth in zip(labels, truths, strict=True)
+        )
+        metrics["d4_conformant"] += int(conformant)
+        if path.startswith("items[]"):
+            metrics["d4_item_assessable"] += 1
+            metrics["d4_item_conformant"] += int(
+                all(truth == "ITEMS" for truth in truths)
+            )
+
+
+def _finalize_consistency(metrics: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "d3": {
+            "footprint_violation_support": metrics["violations"],
+            "footprint_violation_action_recall": _ratio(
+                metrics["violations_acted"], metrics["violations"]
+            ),
+            "footprint_consistent_support": metrics["consistent"],
+            "footprint_false_action_rate": _ratio(
+                metrics["consistent_acted"], metrics["consistent"]
+            ),
+            "correction_section_precision": _ratio(
+                metrics["corrections_conformant"],
+                metrics["corrections_assessable"],
+            ),
+            "actions_by_rule": [
+                {"rule": rule, "action": action, "count": count}
+                for (rule, action), count in metrics[
+                    "d3_actions"
+                ].most_common()
+            ],
+            "conflicts_by_rule": dict(metrics["d3_conflicts"].most_common()),
+        },
+        "d4": {
+            "status_counts": dict(metrics["d4_status"]),
+            "field_counts": dict(metrics["d4_fields"].most_common()),
+            "provenance_counts": dict(metrics["d4_provenance"].most_common()),
+            "field_section_conformance": _ratio(
+                metrics["d4_conformant"], metrics["d4_assessable"]
+            ),
+            "field_section_assessable_support": metrics["d4_assessable"],
+            "item_section_conformance": _ratio(
+                metrics["d4_item_conformant"],
+                metrics["d4_item_assessable"],
+            ),
+            "item_section_assessable_support": metrics["d4_item_assessable"],
+            "conflicts_by_rule": dict(metrics["d4_conflicts"].most_common()),
+        },
+    }
+
+
+def _manual_payload(receipt: CorpusReceipt, plan: Any, details: Any) -> dict:
+    return {
+        "image_id": receipt.image_id,
+        "receipt_id": receipt.receipt_id,
+        "merchant": receipt.merchant_name,
+        "sections": [
+            {
+                "section_type": section.section_type,
+                "line_ids": section.line_ids,
+                "validation_status": section.validation_status,
+            }
+            for section in receipt.gold_sections
+        ],
+        "ocr_lines": [
+            {"line_id": line.line_id, "text": line.text}
+            for line in sorted(receipt.lines, key=lambda item: item.line_id)
+        ],
+        "d3": {
+            "corrections": plan.corrections,
+            "checks": plan.checks,
+        },
+        "d4": details.to_document(),
+    }
+
+
+def select_manual_sample(
+    payloads: Sequence[dict], merchant_counts: Mapping[str, int]
+) -> tuple[list[dict], dict[str, Any]]:
+    """Pre-register five sentinels plus 5/5/5 frequency strata."""
+
+    ordered = sorted(
+        payloads,
+        key=lambda item: _stable_hash(
+            _SEED, item["image_id"], item["receipt_id"]
+        ),
+    )
+    sentinels = {
+        "Sprouts": lambda value: "sprouts" in value,
+        "Costco": lambda value: "costco" in value,
+        "Vons": lambda value: value == "vons",
+        "Smith's": lambda value: "smith" in value,
+        "Italia Deli": lambda value: "italia" in value and "deli" in value,
+    }
+    selected: list[dict] = []
+    sentinel_found = {}
+    for name, predicate in sentinels.items():
+        match = next(
+            (
+                item
+                for item in ordered
+                if predicate(normalize_merchant_key(item.get("merchant")))
+            ),
+            None,
+        )
+        sentinel_found[name] = bool(match)
+        if match and match not in selected:
+            tagged = dict(match)
+            tagged["sample_stratum"] = f"sentinel:{name}"
+            selected.append(tagged)
+    selected_keys = {
+        (item["image_id"], item["receipt_id"]) for item in selected
+    }
+    strata: dict[str, list[dict[str, Any]]] = {
+        "common": [],
+        "mid_frequency": [],
+        "long_tail": [],
+    }
+    for item in ordered:
+        if (item["image_id"], item["receipt_id"]) in selected_keys:
+            continue
+        merchant = normalize_merchant_key(item.get("merchant"))
+        count = merchant_counts.get(merchant, 0)
+        stratum = (
+            "common"
+            if count >= 20
+            else "mid_frequency" if count >= 5 else "long_tail"
+        )
+        strata[stratum].append(item)
+    for stratum, candidates in strata.items():
+        for item in candidates[:5]:
+            tagged = dict(item)
+            tagged["sample_stratum"] = stratum
+            selected.append(tagged)
+    return selected, {
+        "design": (
+            "5 merchant sentinels plus 5 common, 5 mid-frequency, and "
+            "5 long-tail receipts"
+        ),
+        "seed": _SEED,
+        "sentinels_found": sentinel_found,
+        "population_by_stratum": {
+            name: len(items) for name, items in strata.items()
+        },
+        "sample_count": len(selected),
+    }
+
+
+def _section_snapshot(sections: Sequence[Any]) -> str:
+    records = [
+        {
+            "image_id": section.image_id,
+            "receipt_id": section.receipt_id,
+            "section_type": str(section.section_type),
+            "line_ids": sorted(section.line_ids),
+            "validation_status": section.validation_status,
+        }
+        for section in sections
+    ]
+    payload = json.dumps(
+        sorted(
+            records,
+            key=lambda item: (
+                item["image_id"],
+                item["receipt_id"],
+                item["section_type"],
+            ),
+        ),
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode()
+    return hashlib.sha256(payload).hexdigest()
+
+
+def main() -> int:
+    args = _args()
+    output = assert_private_destination(args.output)
+    table_name = assert_dev_table(
+        args.environment, os.environ.get("DYNAMODB_TABLE_NAME")
+    )
+    sections = _all_sections(DynamoClient(table_name))
+    by_key: dict[tuple[str, int], list[Any]] = defaultdict(list)
+    for section in sections:
+        by_key[(section.image_id, section.receipt_id)].append(section)
+    keys = sorted(by_key)
+    receipts: list[CorpusReceipt] = []
+    failures = []
+    with ThreadPoolExecutor(max_workers=args.workers) as executor:
+        futures = {
+            executor.submit(_load_receipt, table_name, key, by_key[key]): key
+            for key in keys
+        }
+        for index, future in enumerate(as_completed(futures), start=1):
+            key = futures[future]
+            try:
+                receipts.append(future.result())
+            except Exception as error:  # noqa: BLE001 - reported, never hidden
+                failures.append({"key": key, "error": repr(error)})
+            if index % 50 == 0 or index == len(futures):
+                print(f"loaded {index}/{len(futures)} receipts", flush=True)
+    receipts.sort(key=lambda receipt: receipt.key)
+    if failures:
+        raise RuntimeError(
+            f"failed to load {len(failures)} receipts: {failures[:3]}"
+        )
+
+    folds = assign_folds(receipts)
+    crossfit = _new_section_metrics()
+    consistency = _new_consistency_metrics()
+    manual_payloads = []
+    fold_summaries = []
+    for fold in range(_FOLDS):
+        training = [
+            receipt for receipt in receipts if folds[receipt.image_id] != fold
+        ]
+        testing = [
+            receipt for receipt in receipts if folds[receipt.image_id] == fold
+        ]
+        model = fit_model(training)
+        fold_summaries.append(
+            {
+                "fold": fold,
+                "training_receipts": len(training),
+                "test_receipts": len(testing),
+                **model["evaluation_training"],
+            }
+        )
+        for receipt in testing:
+            assignments = assign_row_sections(
+                receipt.rows,
+                receipt.lines,
+                model,
+                receipt.merchant_name,
+            )
+            _score_sections(crossfit, receipt, assignments)
+            predicted_sections = sections_from_assignments(assignments)
+            plan = plan_label_reconciliation(
+                receipt.words,
+                receipt.labels,
+                receipt.rows,
+                predicted_sections,
+                receipt.merchant_name,
+            )
+            reconciliation = ReceiptLabelReconciliation(
+                image_id=receipt.image_id,
+                receipt_id=receipt.receipt_id,
+                corrections=plan.corrections,
+                checks=plan.checks,
+                validation_status=(
+                    ValidationStatus.NEEDS_REVIEW.value
+                    if plan.conflict_count
+                    else ValidationStatus.VALID.value
+                ),
+                model_source=MODEL_SOURCE,
+                created_at=datetime.now(timezone.utc),
+            )
+            projected_labels = project_reconciled_labels(
+                receipt.labels,
+                plan,
+                receipt.image_id,
+                receipt.receipt_id,
+            )
+            details = build_receipt_resolved_details(
+                image_id=receipt.image_id,
+                receipt_id=receipt.receipt_id,
+                words=receipt.words,
+                labels=projected_labels,
+                rows=receipt.rows,
+                sections=predicted_sections,
+                reconciliation=reconciliation,
+                merchant_name=receipt.merchant_name,
+                fingerprint=None,
+            )
+            _score_d3_d4(consistency, receipt, plan, details)
+            manual_payloads.append(_manual_payload(receipt, plan, details))
+        print(f"evaluated fold {fold + 1}/{_FOLDS}", flush=True)
+
+    frozen = _new_section_metrics()
+    frozen_model = load_prior_model()
+    for receipt in receipts:
+        _score_sections(
+            frozen,
+            receipt,
+            assign_row_sections(
+                receipt.rows,
+                receipt.lines,
+                frozen_model,
+                receipt.merchant_name,
+            ),
+        )
+
+    merchant_counts = Counter(
+        normalize_merchant_key(receipt.merchant_name) for receipt in receipts
+    )
+    manual_sample, sample_design = select_manual_sample(
+        manual_payloads, merchant_counts
+    )
+    report = {
+        "schema_version": 1,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "model_source": MODEL_SOURCE,
+        "source": {
+            "environment": "dev",
+            "section_count": len(sections),
+            "valid_section_count": sum(
+                section.validation_status == ValidationStatus.VALID.value
+                for section in sections
+            ),
+            "pending_section_count": sum(
+                section.validation_status == ValidationStatus.PENDING.value
+                for section in sections
+            ),
+            "sectioned_receipt_count": len(keys),
+            "processed_receipt_count": len(receipts),
+            "section_snapshot_sha256": _section_snapshot(sections),
+        },
+        "methodology": {
+            "cross_validation": (
+                "5-fold, grouped by source image and merchant-stratified"
+            ),
+            "fold_seed": _SEED,
+            "folds": fold_summaries,
+            "ground_truth": "unique VALID ReceiptSection membership only",
+            "d3_d4_scope": (
+                "section-consistency against held-out QA sections; current "
+                "VALID labels are inputs, not independent field-value truth"
+            ),
+        },
+        "d2_cross_fitted": _finalize_section_metrics(crossfit),
+        "d2_frozen_in_sample_apparent_fit": _finalize_section_metrics(frozen),
+        "d3_d4_cross_fitted_section_consistency": _finalize_consistency(
+            consistency
+        ),
+        "manual_sample_design": sample_design,
+        "manual_sample": manual_sample,
+    }
+    write_private_text(
+        output,
+        json.dumps(report, indent=2, sort_keys=True) + "\n",
+    )
+    print(f"wrote {output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/render_upload_determinism_audit.py
+++ b/scripts/render_upload_determinism_audit.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""Render private, local review sheets for the preregistered 20-receipt audit.
+
+The sheets can contain receipt PII and must stay outside the repository.  This
+helper reads only the environment-owned dev table and S3 objects named by its
+Receipt entities.  Every S3 bucket read must also be listed in the
+``UPLOAD_DETERMINISM_AUDIT_S3_BUCKETS`` environment variable.
+"""
+
+# pylint: disable=wrong-import-position,duplicate-code
+
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import os
+import sys
+import textwrap
+from pathlib import Path
+from typing import Any
+
+import boto3
+from PIL import Image, ImageDraw, ImageFont, ImageOps
+
+_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_ROOT))
+for _package in ("receipt_dynamo", "receipt_chroma", "receipt_upload"):
+    sys.path.insert(0, str(_ROOT / _package))
+
+from receipt_dynamo import DynamoClient
+from scripts.evaluate_upload_determinism import (
+    _create_private_directories,
+    _leaf_fields,
+    assert_dev_table,
+    assert_private_destination,
+)
+
+_BUCKET_ALLOWLIST_ENV = "UPLOAD_DETERMINISM_AUDIT_S3_BUCKETS"
+
+
+def _args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--report", type=Path, required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument(
+        "--environment", default=os.environ.get("DEPLOYMENT_ENVIRONMENT")
+    )
+    return parser.parse_args()
+
+
+def _bucket_allowlist(value: str | None) -> frozenset[str]:
+    """Parse the required, environment-owned S3 bucket allowlist."""
+
+    allowed = frozenset(
+        bucket.strip() for bucket in (value or "").split(",") if bucket.strip()
+    )
+    if not allowed:
+        raise RuntimeError(f"{_BUCKET_ALLOWLIST_ENV} is required")
+    return allowed
+
+
+def _prepare_private_directory(path: Path) -> Path:
+    """Create an owner-only audit directory outside the repository."""
+
+    destination = assert_private_destination(path)
+    _create_private_directories(destination)
+    destination.chmod(0o700)
+    return destination
+
+
+def _image(receipt: Any, allowed_buckets: frozenset[str]) -> Image.Image:
+    s3 = boto3.client("s3")
+    candidates = [
+        (receipt.cdn_s3_bucket, receipt.cdn_s3_key),
+        (receipt.raw_s3_bucket, receipt.raw_s3_key),
+    ]
+    for bucket, key in candidates:
+        if not bucket or not key:
+            continue
+        if bucket not in allowed_buckets:
+            continue
+        try:
+            body = s3.get_object(Bucket=bucket, Key=key)["Body"].read()
+            return Image.open(io.BytesIO(body)).convert("RGB")
+        except s3.exceptions.NoSuchKey:
+            continue
+    raise RuntimeError(
+        "receipt image unavailable for "
+        f"{receipt.image_id}#{receipt.receipt_id}"
+    )
+
+
+def _save_private_png(image: Image.Image, path: Path) -> None:
+    """Save an audit sheet owner-only without following a final symlink."""
+
+    destination = assert_private_destination(path)
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+    flags |= getattr(os, "O_NOFOLLOW", 0)
+    descriptor = os.open(destination, flags, 0o600)
+    try:
+        os.fchmod(descriptor, 0o600)
+        with os.fdopen(descriptor, "wb") as output:
+            descriptor = -1
+            image.save(output, format="PNG")
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+
+
+def _summary(sample: dict[str, Any]) -> list[str]:
+    lines = [
+        f"{sample['sample_stratum']} | {sample.get('merchant') or 'Unknown'}",
+        f"receipt {sample['image_id']}#{sample['receipt_id']}",
+        "",
+        "D4 fields",
+    ]
+    document = sample["d4"]
+    for path, field in _leaf_fields(
+        {
+            "merchant": document["merchant"],
+            "transaction": document["transaction"],
+            "items": document["items"],
+            "totals": document["totals"],
+            "tender": document["tender"],
+        }
+    ):
+        lines.append(
+            f"{path}: {field.get('value')!r} "
+            f"[{field.get('provenance')}, {field.get('validation_status')}]"
+        )
+    lines.extend(["", "D3 events"])
+    for event in sample["d3"]["corrections"]:
+        lines.append(
+            f"L{event.get('line_id')} W{event.get('word_id')} "
+            f"{event.get('action')} {event.get('original_label')} -> "
+            f"{event.get('corrected_label')} ({event.get('rule_id')})"
+        )
+    lines.extend(["", "Resolver conflicts"])
+    for conflict in document["conflicts"]:
+        lines.append(f"{conflict.get('field')}: {conflict.get('rule_id')}")
+    lines.extend(["", "OCR lines"])
+    for line in sample["ocr_lines"]:
+        lines.append(f"L{line['line_id']}: {line['text']}")
+    return lines
+
+
+def _sheet(image: Image.Image, sample: dict[str, Any]) -> Image.Image:
+    height = 1800
+    receipt_width = 800
+    panel_width = 1000
+    contained = ImageOps.contain(image, (receipt_width - 40, height - 40))
+    canvas = Image.new("RGB", (receipt_width + panel_width, height), "white")
+    canvas.paste(
+        contained,
+        ((receipt_width - contained.width) // 2, 20),
+    )
+    draw = ImageDraw.Draw(canvas)
+    draw.line((receipt_width, 0, receipt_width, height), fill="gray", width=2)
+    font = ImageFont.load_default(size=18)
+    y = 20
+    for raw_line in _summary(sample):
+        for line in textwrap.wrap(raw_line, width=88) or [""]:
+            draw.text((receipt_width + 20, y), line, fill="black", font=font)
+            y += 23
+            if y > height - 25:
+                draw.text(
+                    (receipt_width + 20, height - 25),
+                    "[truncated; inspect JSON for remaining evidence]",
+                    fill="red",
+                    font=font,
+                )
+                return canvas
+    return canvas
+
+
+def main() -> int:
+    args = _args()
+    report_path = assert_private_destination(args.report)
+    output_dir = _prepare_private_directory(args.output_dir)
+    allowed_buckets = _bucket_allowlist(os.environ.get(_BUCKET_ALLOWLIST_ENV))
+    table = assert_dev_table(
+        args.environment, os.environ.get("DYNAMODB_TABLE_NAME")
+    )
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    samples = report["manual_sample"]
+    client = DynamoClient(table)
+    for index, sample in enumerate(samples, start=1):
+        receipt = client.get_receipt(
+            sample["image_id"], int(sample["receipt_id"])
+        )
+        rendered = _sheet(_image(receipt, allowed_buckets), sample)
+        _save_private_png(rendered, output_dir / f"{index:02d}.png")
+    print(f"rendered {len(samples)} private audit sheets")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a read-only, dev-tag-gated 5-fold evaluator for D2-D4
- add a private audit renderer with repository-path rejection, owner-only permissions, and explicit dev S3 bucket allowlisting
- report the 842-receipt dev run and redacted 20-receipt visual audit

## Result
- D2 cross-fitted line accuracy: 62.35% (95% receipt-cluster CI 60.78%-64.05%)
- D3 correction section precision: 94.44%, with 34.67% false-action rate
- D4 field-section conformance: 97.71%; strict 20-receipt field recall: 39.6%
- all 842 artifacts remain NEEDS_REVIEW; report concludes auto-validation is not ready

## Safety
- dev Dynamo table comes only from the environment and must carry both dev tags
- evaluator calls pure/non-persisting D2-D4 APIs only
- private JSON/audit images are rejected inside the worktree and written 0600 under 0700 directories
- S3 reads require an explicit environment-owned bucket allowlist
- no raw receipt data, OCR, IDs, table/bucket names, or images are committed

## Validation
- 31 focused D2-D4/evaluator tests passed
- 9 receipt_chroma public API tests passed
- black/isort clean
- mypy clean
- pylint 10.00/10
- full read-only 842-receipt rerun completed against the tagged dev table