### PR TITLE
fix-place: expose OpenRouter cost in LangSmith

### DIFF
--- a/infra/fix_place_lambda/infrastructure.py
+++ b/infra/fix_place_lambda/infrastructure.py
@@ -103,8 +103,7 @@ class FixPlaceLambda(ComponentResource):
             f"{name}-lambda-basic-exec",
             role=lambda_role.name,
             policy_arn=(
-                "arn:aws:iam::aws:policy/service-role/"
-                "AWSLambdaBasicExecutionRole"
+                "arn:aws:iam::aws:policy/service-role/" "AWSLambdaBasicExecutionRole"
             ),
             opts=ResourceOptions(parent=lambda_role),
         )
@@ -181,6 +180,20 @@ class FixPlaceLambda(ComponentResource):
                 # OpenRouter (for LLM calls)
                 "OPENROUTER_API_KEY": openrouter_api_key,
                 "OPENROUTER_MODEL": "x-ai/grok-4.3",
+                # Dev opts into tiered resolution; other stacks retain the
+                # legacy agent path until the quality gate is promoted.
+                "FIX_PLACE_RESOLUTION_MODE": (
+                    config.get("fix_place_resolution_mode")
+                    or ("tiered" if stack == "dev" else "agent")
+                ),
+                "FIX_PLACE_TIER2_MODEL": (
+                    config.get("fix_place_tier2_model") or "openai/gpt-oss-120b"
+                ),
+                "FIX_PLACE_AGENT_MODEL": (
+                    config.get("fix_place_agent_model") or "x-ai/grok-4.3"
+                ),
+                "FIX_PLACE_AGENT_RECURSION_LIMIT": "12",
+                "FIX_PLACE_AGENT_MAX_ROUNDS": "3",
                 # OpenAI (for embeddings)
                 "RECEIPT_AGENT_OPENAI_API_KEY": openai_api_key,
                 # Chroma Cloud
@@ -191,9 +204,7 @@ class FixPlaceLambda(ComponentResource):
                 "LANGCHAIN_API_KEY": langchain_api_key,
                 "LANGCHAIN_TRACING_V2": "true",
                 "LANGCHAIN_ENDPOINT": ("https://api.smith.langchain.com"),
-                "LANGCHAIN_PROJECT": (
-                    config.get("langchain_project") or "fix-place"
-                ),
+                "LANGCHAIN_PROJECT": (config.get("langchain_project") or "fix-place"),
             },
         }
 

--- a/infra/fix_place_lambda/lambdas/fix_place.py
+++ b/infra/fix_place_lambda/lambdas/fix_place.py
@@ -108,7 +108,7 @@ async def _run_place_finder(
     image_id: str,
     receipt_id: int,
     reason: str,
-) -> tuple[dict[str, Any], Any]:
+) -> tuple[dict[str, Any], Any, dict[str, Any]]:
     """Run the LangGraph place finder agent for a single receipt."""
     # pylint: disable=import-outside-toplevel
     from receipt_agent.clients.factory import (
@@ -160,7 +160,9 @@ async def _run_place_finder(
         reason=reason,
     )
 
-    return result, details
+    cost_callback = state_holder.get("cost_callback")
+    llm_stats = cost_callback.get_stats() if cost_callback else {}
+    return result, details, llm_stats
 
 
 def handler(  # pylint: disable=unused-argument
@@ -176,10 +178,17 @@ def handler(  # pylint: disable=unused-argument
     4. Submit place data with confidence scoring
     5. Update ReceiptPlace with corrected data
     """
+    image_id = event.get("image_id")
+    receipt_id = event.get("receipt_id")
+    invocation_llm_stats = {
+        "total_cost": 0.0,
+        "llm_calls": 0,
+        "prompt_tokens": 0,
+        "completion_tokens": 0,
+        "total_tokens": 0,
+    }
     try:
         # Validate input
-        image_id = event.get("image_id")
-        receipt_id = event.get("receipt_id")
         reason = event.get("reason", "User reported incorrect merchant")
 
         if not image_id or receipt_id is None:
@@ -207,9 +216,13 @@ def handler(  # pylint: disable=unused-argument
         details = None
         attempted_reason = reason
         for attempt in range(1, MAX_ATTEMPTS + 1):
-            agent_result, details = _loop.run_until_complete(
-                _run_place_finder(image_id, receipt_id, attempted_reason)
+            agent_result, details, attempt_llm_stats = (
+                _loop.run_until_complete(
+                    _run_place_finder(image_id, receipt_id, attempted_reason)
+                )
             )
+            for key in invocation_llm_stats:
+                invocation_llm_stats[key] += attempt_llm_stats.get(key, 0)
             if (
                 agent_result
                 and agent_result.get("found")
@@ -317,6 +330,18 @@ def handler(  # pylint: disable=unused-argument
         }
 
     finally:
+        logger.info(
+            "fix_place_llm_usage image_id=%s receipt_id=%s cost_usd=%.8f "
+            "llm_calls=%d prompt_tokens=%d completion_tokens=%d "
+            "total_tokens=%d",
+            image_id,
+            receipt_id,
+            invocation_llm_stats["total_cost"],
+            invocation_llm_stats["llm_calls"],
+            invocation_llm_stats["prompt_tokens"],
+            invocation_llm_stats["completion_tokens"],
+            invocation_llm_stats["total_tokens"],
+        )
         flush_langsmith_traces()
 
 

--- a/infra/fix_place_lambda/lambdas/fix_place.py
+++ b/infra/fix_place_lambda/lambdas/fix_place.py
@@ -34,6 +34,10 @@ Environment Variables:
     CHROMA_CLOUD_API_KEY: Chroma Cloud API key
     CHROMA_CLOUD_TENANT: Chroma Cloud tenant ID
     CHROMA_CLOUD_DATABASE: Chroma Cloud database name
+    FIX_PLACE_RESOLUTION_MODE: "agent" or "tiered"
+    FIX_PLACE_TIER2_MODEL: Cheap structured picker model
+    FIX_PLACE_AGENT_MODEL: Tier 3 tool-calling model
+    FIX_PLACE_AGENT_RECURSION_LIMIT: Hard graph step cap (maximum 12)
 """
 
 import asyncio
@@ -109,7 +113,7 @@ async def _run_place_finder(
     receipt_id: int,
     reason: str,
 ) -> tuple[dict[str, Any], Any, dict[str, Any]]:
-    """Run the LangGraph place finder agent for a single receipt."""
+    """Resolve one receipt through deterministic, picker, then agent tiers."""
     # pylint: disable=import-outside-toplevel
     from receipt_agent.clients.factory import (
         create_embed_fn,
@@ -124,8 +128,26 @@ async def _run_place_finder(
 
     table_name = os.environ["DYNAMODB_TABLE_NAME"]
     dynamo_client = DynamoClient(table_name=table_name)
+    details = dynamo_client.get_receipt_details(image_id, receipt_id)
+    places_client = create_places_client()
+    tiered_stats: dict[str, Any] = {}
 
-    # Create Chroma Cloud client
+    resolution_mode = os.environ.get("FIX_PLACE_RESOLUTION_MODE", "agent").lower()
+    if resolution_mode == "tiered":
+        from receipt_agent.subagents.place_finder.tiered import (
+            resolve_tiered_place,
+        )
+
+        tiered_result, tiered_stats = await resolve_tiered_place(details, places_client)
+        if tiered_result is not None:
+            return tiered_result, details, tiered_stats
+    elif resolution_mode != "agent":
+        logger.warning(
+            "Unknown FIX_PLACE_RESOLUTION_MODE=%s; using agent fallback",
+            resolution_mode,
+        )
+
+    # Tier 3 only: initialize the clients needed by the full agent.
     cloud_api_key = os.environ.get("CHROMA_CLOUD_API_KEY", "")
     cloud_tenant = os.environ.get("CHROMA_CLOUD_TENANT")
     cloud_database = os.environ.get("CHROMA_CLOUD_DATABASE")
@@ -138,7 +160,6 @@ async def _run_place_finder(
     )
 
     embed_fn = create_embed_fn()
-    places_client = create_places_client()
 
     graph, state_holder = create_receipt_place_finder_graph(
         dynamo_client=dynamo_client,
@@ -147,9 +168,6 @@ async def _run_place_finder(
         places_api=places_client,
     )
 
-    # Get receipt details for pre-loading
-    details = dynamo_client.get_receipt_details(image_id, receipt_id)
-
     result = await run_receipt_place_finder(
         graph=graph,
         state_holder=state_holder,
@@ -157,11 +175,15 @@ async def _run_place_finder(
         receipt_id=receipt_id,
         receipt_lines=details.lines,
         receipt_words=details.words,
+        receipt_labels=details.labels,
         reason=reason,
     )
+    result["resolution_tier"] = "tier3"
 
     cost_callback = state_holder.get("cost_callback")
     llm_stats = cost_callback.get_stats() if cost_callback else {}
+    for key, value in tiered_stats.items():
+        llm_stats[key] = llm_stats.get(key, 0) + value
     return result, details, llm_stats
 
 
@@ -187,6 +209,8 @@ def handler(  # pylint: disable=unused-argument
         "completion_tokens": 0,
         "total_tokens": 0,
     }
+    resolution_tier = "none"
+    resolution_succeeded = False
     try:
         # Validate input
         reason = event.get("reason", "User reported incorrect merchant")
@@ -206,35 +230,35 @@ def handler(  # pylint: disable=unused-argument
 
         _propagate_env_vars()
 
-        # The agent occasionally returns found=true with merchant_name but
-        # empty/None place_id. place_id is the canonical key — without it
-        # we can't write a usable ReceiptPlace. Retry up to MAX_ATTEMPTS,
-        # augmenting the reason on each retry so the agent knows to find
-        # the Google Places place_id explicitly.
-        MAX_ATTEMPTS = 3
+        # The legacy agent occasionally returns found=true with merchant_name
+        # but no place_id, so retain its historical retry behavior. Tiered
+        # mode already contains a bounded agent and a single structured picker;
+        # rerunning the whole cascade would multiply both limits and cost.
+        resolution_mode = os.environ.get("FIX_PLACE_RESOLUTION_MODE", "agent").lower()
+        max_attempts = 1 if resolution_mode == "tiered" else 3
         agent_result = None
         details = None
         attempted_reason = reason
-        for attempt in range(1, MAX_ATTEMPTS + 1):
-            agent_result, details, attempt_llm_stats = (
-                _loop.run_until_complete(
-                    _run_place_finder(image_id, receipt_id, attempted_reason)
-                )
+        for attempt in range(1, max_attempts + 1):
+            agent_result, details, attempt_llm_stats = _loop.run_until_complete(
+                _run_place_finder(image_id, receipt_id, attempted_reason)
             )
             for key in invocation_llm_stats:
                 invocation_llm_stats[key] += attempt_llm_stats.get(key, 0)
+            resolution_tier = agent_result.get("resolution_tier", "tier3")
             if (
                 agent_result
                 and agent_result.get("found")
                 and agent_result.get("merchant_name")
                 and agent_result.get("place_id")
             ):
+                resolution_succeeded = True
                 break
             logger.warning(
                 "place_finder attempt %d/%d incomplete: found=%s merchant=%s "
                 "place_id=%s",
                 attempt,
-                MAX_ATTEMPTS,
+                max_attempts,
                 bool(agent_result and agent_result.get("found")),
                 bool(agent_result and agent_result.get("merchant_name")),
                 bool(agent_result and agent_result.get("place_id")),
@@ -257,7 +281,7 @@ def handler(  # pylint: disable=unused-argument
                 "image_id": image_id,
                 "receipt_id": receipt_id,
                 "old_merchant": old_merchant,
-                "attempts": MAX_ATTEMPTS,
+                "attempts": max_attempts,
                 "reasoning": (
                     agent_result.get("reasoning", "") if agent_result else ""
                 ),
@@ -267,9 +291,7 @@ def handler(  # pylint: disable=unused-argument
         if not agent_result.get("merchant_name"):
             return {
                 "success": False,
-                "error": (
-                    "Agent found a place but merchant_name " "is missing"
-                ),
+                "error": ("Agent found a place but merchant_name " "is missing"),
                 "image_id": image_id,
                 "receipt_id": receipt_id,
                 "old_merchant": old_merchant,
@@ -285,12 +307,12 @@ def handler(  # pylint: disable=unused-argument
                 "error": (
                     f"Agent found a place named "
                     f"'{agent_result.get('merchant_name')}' but no "
-                    f"Google Places place_id after {MAX_ATTEMPTS} attempts"
+                    f"Google Places place_id after {max_attempts} attempts"
                 ),
                 "image_id": image_id,
                 "receipt_id": receipt_id,
                 "old_merchant": old_merchant,
-                "attempts": MAX_ATTEMPTS,
+                "attempts": max_attempts,
                 "reasoning": agent_result.get("reasoning", ""),
                 "fields_found": agent_result.get("fields_found", []),
             }
@@ -315,6 +337,7 @@ def handler(  # pylint: disable=unused-argument
             "reasoning": agent_result.get("reasoning", ""),
             "fields_found": agent_result.get("fields_found", []),
             "sources": agent_result.get("sources", {}),
+            "resolution_tier": resolution_tier,
         }
 
         logger.info("Successfully fixed place: %s", response)
@@ -330,6 +353,13 @@ def handler(  # pylint: disable=unused-argument
         }
 
     finally:
+        logger.info(
+            "fix_place_resolution image_id=%s receipt_id=%s tier=%s " "success=%s",
+            image_id,
+            receipt_id,
+            resolution_tier,
+            resolution_succeeded,
+        )
         logger.info(
             "fix_place_llm_usage image_id=%s receipt_id=%s cost_usd=%.8f "
             "llm_calls=%d prompt_tokens=%d completion_tokens=%d "
@@ -378,9 +408,7 @@ def _update_receipt_place(
         current_place.confidence = confidence
         current_place.reasoning = reasoning
         current_place.validated_by = "INFERENCE"
-        current_place.validation_status = (
-            "MATCHED" if confidence >= 0.8 else "UNSURE"
-        )
+        current_place.validation_status = "MATCHED" if confidence >= 0.8 else "UNSURE"
         current_place.timestamp = now
 
         dynamo_client.update_receipt_place(current_place)

--- a/infra/fix_place_lambda/lambdas/fix_place.py
+++ b/infra/fix_place_lambda/lambdas/fix_place.py
@@ -402,8 +402,9 @@ def _update_receipt_place(
             current_place.merchant_name = agent_result["merchant_name"]
         if agent_result.get("address"):
             current_place.formatted_address = agent_result["address"]
-        if agent_result.get("phone_number"):
-            current_place.phone_number = agent_result["phone_number"]
+        phone_number = agent_result.get("phone_number")
+        if phone_number is not None:
+            current_place.phone_number = phone_number
 
         current_place.confidence = confidence
         current_place.reasoning = reasoning

--- a/infra/test_fix_place_update.py
+++ b/infra/test_fix_place_update.py
@@ -1,0 +1,54 @@
+"""Tests for applying fix-place results to existing records."""
+
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+MODULE_PATH = (
+    Path(__file__).parent / "fix_place_lambda" / "lambdas" / "fix_place.py"
+)
+SPEC = importlib.util.spec_from_file_location("fix_place_handler", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+FIX_PLACE_HANDLER = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(FIX_PLACE_HANDLER)
+_update_receipt_place = FIX_PLACE_HANDLER._update_receipt_place
+
+
+def test_explicit_empty_phone_clears_stale_existing_phone(monkeypatch):
+    monkeypatch.setenv("DYNAMODB_TABLE_NAME", "test-table")
+    current_place = SimpleNamespace(
+        place_id="old-place",
+        merchant_name="Old Merchant",
+        formatted_address="1 Old St",
+        phone_number="(702) 555-0199",
+        confidence=0.1,
+        reasoning="old",
+        validated_by="HUMAN",
+        validation_status="UNSURE",
+        timestamp=None,
+    )
+    dynamo_client = MagicMock()
+    agent_result = {
+        "place_id": "new-place",
+        "merchant_name": "New Merchant",
+        "address": "2 New St",
+        "phone_number": "",
+        "confidence": 0.95,
+        "reasoning": "Tiered address match has no phone.",
+    }
+
+    with patch(
+        "receipt_dynamo.DynamoClient",
+        return_value=dynamo_client,
+    ):
+        updated = _update_receipt_place(
+            image_id="image-1",
+            receipt_id=1,
+            current_place=current_place,
+            agent_result=agent_result,
+            reason="Incorrect merchant",
+        )
+
+    assert updated.phone_number == ""
+    dynamo_client.update_receipt_place.assert_called_once_with(current_place)

--- a/receipt_agent/receipt_agent/agents/place_id_finder/graph.py
+++ b/receipt_agent/receipt_agent/agents/place_id_finder/graph.py
@@ -36,6 +36,11 @@ from receipt_agent.utils.llm_factory import CostTrackingCallback, create_llm
 logger = logging.getLogger(__name__)
 
 
+def _agent_recursion_limit() -> int:
+    """Preserve the upload place-ID finder's established execution budget."""
+    return 100
+
+
 # ==============================================================================
 # System Prompt
 # ==============================================================================
@@ -352,6 +357,14 @@ def create_place_id_finder_graph(
         # If no messages or no tool calls, go back to agent
         return "agent"
 
+    def after_tools(_state: PlaceIdFinderState) -> str:
+        """Stop immediately after submit_place_id succeeds."""
+        return (
+            "end"
+            if state_holder.get("place_id_result") is not None
+            else "agent"
+        )
+
     # Build the graph
     workflow = StateGraph(PlaceIdFinderState)
 
@@ -373,8 +386,11 @@ def create_place_id_finder_graph(
         },
     )
 
-    # After tools, go back to agent
-    workflow.add_edge("tools", "agent")
+    workflow.add_conditional_edges(
+        "tools",
+        after_tools,
+        {"agent": "agent", "end": END},
+    )
 
     # Compile
     compiled = workflow.compile()
@@ -449,7 +465,7 @@ async def run_place_id_finder(
     try:
         # Configure LangSmith tracing if available
         config: dict[str, Any] = {
-            "recursion_limit": 100,  # Increased to prevent early termination
+            "recursion_limit": _agent_recursion_limit(),
             "configurable": {
                 "thread_id": f"{image_id}#{receipt_id}",  # Unique thread ID for this receipt
             },
@@ -467,7 +483,7 @@ async def run_place_id_finder(
                 "LANGCHAIN_PROJECT", "receipt-label-validation"
             )
             config["run_name"] = "place_id_finder_agent"
-            config["tags"] = ["place_id_finder", "tier2"]
+            config["tags"] = ["place_id_finder", "tier3"]
 
         # Pass callbacks for parent trace context and always include the shared
         # cost handler. Graph-level callbacks propagate to every LLM turn.

--- a/receipt_agent/receipt_agent/agents/place_id_finder/graph.py
+++ b/receipt_agent/receipt_agent/agents/place_id_finder/graph.py
@@ -31,7 +31,7 @@ from receipt_agent.agents.agentic.tools import (
 from receipt_agent.agents.place_id_finder.state import PlaceIdFinderState
 from receipt_agent.config.settings import Settings, get_settings
 from receipt_agent.utils.agent_common import create_agent_node_with_retry
-from receipt_agent.utils.llm_factory import create_llm
+from receipt_agent.utils.llm_factory import CostTrackingCallback, create_llm
 
 logger = logging.getLogger(__name__)
 
@@ -297,6 +297,10 @@ def create_place_id_finder_graph(
     submit_tool = create_place_id_submission_tool(state_holder)
     tools.append(submit_tool)
 
+    # This graph invokes a raw bound model instead of LLMInvoker, so attach the
+    # shared OpenRouter usage callback explicitly in run_place_id_finder().
+    state_holder["cost_callback"] = CostTrackingCallback()
+
     # Create LLM with tools bound (uses OpenRouter)
     llm = create_llm(
         model=settings.openrouter_model,
@@ -304,6 +308,7 @@ def create_place_id_finder_graph(
         api_key=settings.openrouter_api_key.get_secret_value(),
         temperature=0.0,
         timeout=120,
+        stream_usage=True,
     ).bind_tools(tools)
 
     # Create agent node with retry logic and robust logging
@@ -417,6 +422,9 @@ async def run_place_id_finder(
         word_embeddings=word_embeddings,
     )
     state_holder["place_id_result"] = None
+    cost_callback = state_holder.get("cost_callback")
+    if cost_callback is not None:
+        cost_callback.reset()
 
     # Create initial state
     initial_state = PlaceIdFinderState(
@@ -461,9 +469,13 @@ async def run_place_id_finder(
             config["run_name"] = "place_id_finder_agent"
             config["tags"] = ["place_id_finder", "tier2"]
 
-        # Pass callbacks for parent trace context (enables nested traces)
-        if callbacks:
-            config["callbacks"] = callbacks
+        # Pass callbacks for parent trace context and always include the shared
+        # cost handler. Graph-level callbacks propagate to every LLM turn.
+        configured_callbacks = list(callbacks or [])
+        if cost_callback is not None:
+            configured_callbacks.append(cost_callback.handler)
+        if configured_callbacks:
+            config["callbacks"] = configured_callbacks
 
         _ = await graph.ainvoke(initial_state, config=config)
 

--- a/receipt_agent/receipt_agent/subagents/place_finder/graph.py
+++ b/receipt_agent/receipt_agent/subagents/place_finder/graph.py
@@ -24,7 +24,10 @@ from receipt_agent.subagents.place_finder.state import (
     ReceiptPlaceFinderState,
 )
 from receipt_agent.utils.agent_common import create_agent_node_with_retry
-from receipt_agent.utils.llm_factory import create_llm_from_settings
+from receipt_agent.utils.llm_factory import (
+    CostTrackingCallback,
+    create_llm_from_settings,
+)
 
 
 # Helper function for building line IDs (matches agentic.py)
@@ -355,9 +358,17 @@ def create_receipt_place_finder_graph(
     submit_tool = create_place_submission_tool(state_holder)
     tools.append(submit_tool)
 
+    # This graph invokes a raw bound model instead of LLMInvoker, so attach the
+    # shared OpenRouter usage callback explicitly in the runner below.
+    state_holder["cost_callback"] = CostTrackingCallback()
+
     # Create LLM with tools bound (reasoning disabled to avoid
     # hidden cost/latency on every tool-calling step)
-    llm = create_llm_from_settings(temperature=0.0, reasoning=False)
+    llm = create_llm_from_settings(
+        temperature=0.0,
+        reasoning=False,
+        stream_usage=True,
+    )
     llm = llm.bind_tools(tools)
 
     # Create agent node with retry logic using shared utility
@@ -505,6 +516,9 @@ async def run_receipt_place_finder(
         word_embeddings=word_embeddings,
     )
     state_holder["place_result"] = None
+    cost_callback = state_holder.get("cost_callback")
+    if cost_callback is not None:
+        cost_callback.reset()
 
     # Build the human message, including the reason if provided
     human_content = (
@@ -552,6 +566,9 @@ async def run_receipt_place_finder(
                 "receipt_id": receipt_id,
                 "workflow": "receipt_place_finder",
             }
+
+        if cost_callback is not None:
+            config["callbacks"] = [cost_callback.handler]
 
         await graph.ainvoke(initial_state, config=config)
 

--- a/receipt_agent/receipt_agent/subagents/place_finder/graph.py
+++ b/receipt_agent/receipt_agent/subagents/place_finder/graph.py
@@ -9,7 +9,12 @@ import logging
 import os
 from typing import Any, Callable, Optional
 
-from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+from langchain_core.messages import (
+    AIMessage,
+    HumanMessage,
+    SystemMessage,
+    ToolMessage,
+)
 from langchain_core.tools import tool
 from langgraph.graph import END, StateGraph
 from langgraph.prebuilt import ToolNode
@@ -26,7 +31,7 @@ from receipt_agent.subagents.place_finder.state import (
 from receipt_agent.utils.agent_common import create_agent_node_with_retry
 from receipt_agent.utils.llm_factory import (
     CostTrackingCallback,
-    create_llm_from_settings,
+    create_llm,
 )
 
 
@@ -37,6 +42,84 @@ def _build_line_id(image_id: str, receipt_id: int, line_id: int) -> str:
 
 
 logger = logging.getLogger(__name__)
+
+
+def _bounded_env_int(
+    name: str, default: int, maximum: int, minimum: int = 1
+) -> int:
+    """Read a positive integer environment value within a safe bound."""
+    try:
+        value = int(os.environ.get(name, str(default)))
+    except ValueError:
+        logger.warning("Invalid %s; using %d", name, default)
+        return default
+    return max(minimum, min(value, maximum))
+
+
+def _tiered_mode_enabled() -> bool:
+    """Return whether fix-place is using the constrained tiered rollout."""
+    return (
+        os.environ.get("FIX_PLACE_RESOLUTION_MODE", "agent").lower()
+        == "tiered"
+    )
+
+
+def _receipt_place_recursion_limit() -> int:
+    """Constrain Tier 3 while preserving the legacy agent-mode budget."""
+    if not _tiered_mode_enabled():
+        return 100
+    return _bounded_env_int(
+        "FIX_PLACE_AGENT_RECURSION_LIMIT", 12, 12, minimum=4
+    )
+
+
+def _compact_agent_messages(messages: list[Any]) -> list[Any]:
+    """Keep the initial request plus complete recent tool-call groups."""
+    if len(messages) <= 8:
+        return list(messages)
+
+    prefix = list(messages[:2])
+    groups: list[list[Any]] = []
+    for message in messages[2:]:
+        if isinstance(message, ToolMessage):
+            if not groups or not isinstance(groups[-1][0], AIMessage):
+                continue
+            expected_ids = {
+                tool_call.get("id") for tool_call in groups[-1][0].tool_calls
+            }
+            if message.tool_call_id in expected_ids:
+                groups[-1].append(message)
+            continue
+        groups.append([message])
+
+    complete_groups = []
+    for group in groups:
+        first = group[0]
+        if isinstance(first, AIMessage) and first.tool_calls:
+            expected_ids = {
+                tool_call.get("id") for tool_call in first.tool_calls
+            }
+            result_ids = {
+                message.tool_call_id
+                for message in group[1:]
+                if isinstance(message, ToolMessage)
+            }
+            if not expected_ids.issubset(result_ids):
+                continue
+        complete_groups.append(group)
+
+    selected_groups: list[list[Any]] = []
+    selected_count = 0
+    for group in reversed(complete_groups):
+        if selected_groups and selected_count + len(group) > 6:
+            break
+        selected_groups.append(group)
+        selected_count += len(group)
+
+    compacted = [
+        message for group in reversed(selected_groups) for message in group
+    ]
+    return prefix + compacted
 
 
 # ======================================================================
@@ -362,20 +445,56 @@ def create_receipt_place_finder_graph(
     # shared OpenRouter usage callback explicitly in the runner below.
     state_holder["cost_callback"] = CostTrackingCallback()
 
-    # Create LLM with tools bound (reasoning disabled to avoid
-    # hidden cost/latency on every tool-calling step)
-    llm = create_llm_from_settings(
+    # Keep the model independently configurable for gradual rollout. Without
+    # the fix-place override this preserves the existing application model.
+    model = (
+        os.environ.get("FIX_PLACE_AGENT_MODEL") or settings.openrouter_model
+    )
+    base_llm = create_llm(
+        model=model,
+        base_url=settings.openrouter_base_url,
+        api_key=settings.openrouter_api_key.get_secret_value(),
         temperature=0.0,
+        timeout=120,
         reasoning=False,
         stream_usage=True,
     )
-    llm = llm.bind_tools(tools)
-
-    # Create agent node with retry logic using shared utility
-    agent_node = create_agent_node_with_retry(
-        llm=llm,
+    normal_agent_node = create_agent_node_with_retry(
+        llm=base_llm.bind_tools(tools),
         agent_name="place_finder",
     )
+    forced_submit_node = create_agent_node_with_retry(
+        llm=base_llm.bind_tools(
+            [submit_tool],
+            tool_choice="submit_place",
+        ),
+        agent_name="place_finder_final_submit",
+    )
+    constrained_tier3 = _tiered_mode_enabled()
+    max_rounds = (
+        _bounded_env_int("FIX_PLACE_AGENT_MAX_ROUNDS", 3, 3)
+        if constrained_tier3
+        else None
+    )
+
+    def agent_node(state: ReceiptPlaceFinderState) -> dict:
+        """Apply rollout limits only to the tiered fix-place path."""
+        if not constrained_tier3:
+            return normal_agent_node(state)
+
+        compact_state = state.model_copy(
+            update={"messages": _compact_agent_messages(state.messages)}
+        )
+        completed_rounds = sum(
+            isinstance(message, AIMessage) for message in state.messages
+        )
+        if max_rounds is not None and completed_rounds >= max_rounds:
+            logger.warning(
+                "Place finder reached %d rounds; forcing submit_place",
+                completed_rounds,
+            )
+            return forced_submit_node(compact_state)
+        return normal_agent_node(compact_state)
 
     # Define tool node
     tool_node = ToolNode(tools)
@@ -390,24 +509,29 @@ def create_receipt_place_finder_graph(
         # Check last message for tool calls
         if state.messages:
             last_message = state.messages[-1]
-            if isinstance(last_message, AIMessage):
-                if last_message.tool_calls:
-                    return "tools"
-                # Give it another chance if no tool calls
+            if isinstance(last_message, AIMessage) and last_message.tool_calls:
+                return "tools"
+            if not constrained_tier3:
+                if len(state.messages) > 20:
+                    logger.error(
+                        "Legacy place agent exceeded 20 messages without "
+                        "submitting; ending the stalled run"
+                    )
+                    return "end"
                 if len(state.messages) > 10:
                     logger.warning(
-                        "Agent has made many steps without submitting"
-                        " - may need reminder"
+                        "Legacy place agent has made many steps without "
+                        "submitting"
                     )
-            if len(state.messages) > 20:
-                logger.error(
-                    "Agent exceeded 20 steps without submitting"
-                    " - forcing end"
-                )
-                return "end"
             return "agent"
 
         return "agent"
+
+    def after_tools(_state: ReceiptPlaceFinderState) -> str:
+        """Stop immediately after submit_place instead of paying for another turn."""
+        return (
+            "end" if state_holder.get("place_result") is not None else "agent"
+        )
 
     # Build the graph
     workflow = StateGraph(ReceiptPlaceFinderState)
@@ -430,8 +554,11 @@ def create_receipt_place_finder_graph(
         },
     )
 
-    # After tools, go back to agent
-    workflow.add_edge("tools", "agent")
+    workflow.add_conditional_edges(
+        "tools",
+        after_tools,
+        {"agent": "agent", "end": END},
+    )
 
     # Compile
     compiled = workflow.compile()
@@ -453,6 +580,7 @@ async def run_receipt_place_finder(
     word_embeddings: Optional[dict[str, list[float]]] = None,
     receipt_lines: Optional[list] = None,
     receipt_words: Optional[list] = None,
+    receipt_labels: Optional[list] = None,
     reason: Optional[str] = None,
 ) -> dict:
     """
@@ -469,6 +597,7 @@ async def run_receipt_place_finder(
             read)
         receipt_words: Pre-loaded receipt words (optional, avoids DynamoDB
             read)
+        receipt_labels: Pre-loaded word labels used to annotate receipt words
         reason: Why the current place data is wrong (optional hint for
             the agent)
 
@@ -493,6 +622,14 @@ async def run_receipt_place_finder(
             for line in receipt_lines
         ]
 
+    labels_by_word: dict[tuple[int, int], list[str]] = {}
+    for label in receipt_labels or []:
+        status = str(getattr(label, "validation_status", "")).upper()
+        if status.endswith("INVALID"):
+            continue
+        key = (label.line_id, label.word_id)
+        labels_by_word.setdefault(key, []).append(label.label)
+
     if receipt_words:
         # Convert ReceiptWord entities to dict format expected by tools
         words_dict = [
@@ -500,7 +637,10 @@ async def run_receipt_place_finder(
                 "line_id": word.line_id,
                 "word_id": word.word_id,
                 "text": word.text,
-                "label": getattr(word, "label", None),
+                "label": (
+                    labels_by_word.get((word.line_id, word.word_id), [None])[0]
+                ),
+                "labels": labels_by_word.get((word.line_id, word.word_id), []),
             }
             for word in receipt_words
         ]
@@ -553,7 +693,7 @@ async def run_receipt_place_finder(
     # Run the workflow
     try:
         config = {
-            "recursion_limit": 100,
+            "recursion_limit": _receipt_place_recursion_limit(),
             "configurable": {
                 "thread_id": f"{image_id}#{receipt_id}",
             },

--- a/receipt_agent/receipt_agent/subagents/place_finder/tiered.py
+++ b/receipt_agent/receipt_agent/subagents/place_finder/tiered.py
@@ -1,0 +1,731 @@
+"""Low-cost tiers for resolving a receipt's Google Place."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import Any
+
+from langchain_core.messages import HumanMessage, SystemMessage
+from pydantic import BaseModel, Field
+
+from receipt_agent.utils.address_validation import is_address_like
+from receipt_agent.utils.llm_factory import CostTrackingCallback, create_llm
+
+logger = logging.getLogger(__name__)
+
+_PLACE_ID_SENTINELS = {"", "null", "NO_RESULTS", "INVALID"}
+_FALSE_VALUES = {"0", "false", "no", "off"}
+_TIER2_MODEL = "openai/gpt-oss-120b"
+
+
+@dataclass
+class ReceiptClues:
+    """Compact place evidence extracted from receipt labels and metadata."""
+
+    merchant_name: str | None = None
+    address: str | None = None
+    phone: str | None = None
+    expected_state: str | None = None
+    snippet: str = ""
+    sources: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class PlaceCandidate:
+    """A deduplicated Google Places candidate."""
+
+    place_id: str
+    merchant_name: str
+    address: str | None
+    phone: str | None
+    score: float
+    search_methods: set[str] = field(default_factory=set)
+    deterministic_eligible: bool = True
+
+    def as_prompt_dict(self) -> dict[str, Any]:
+        """Return only the compact fields needed by the Tier 2 picker."""
+        return {
+            "place_id": self.place_id,
+            "merchant_name": self.merchant_name,
+            "address": self.address,
+            "phone": self.phone,
+            "deterministic_score": round(self.score, 3),
+            "search_methods": sorted(self.search_methods),
+            "deterministic_eligible": self.deterministic_eligible,
+        }
+
+
+class Tier2Selection(BaseModel):
+    """Single-call structured selection from known Places candidates."""
+
+    place_id: str | None = Field(
+        default=None,
+        description="One candidate place_id, or null when none matches",
+    )
+    confidence: float = Field(ge=0.0, le=1.0)
+    reasoning: str
+
+
+def empty_llm_stats() -> dict[str, int | float]:
+    """Return the common zero-cost statistics shape."""
+    return {
+        "total_cost": 0.0,
+        "total_tokens": 0,
+        "prompt_tokens": 0,
+        "completion_tokens": 0,
+        "llm_calls": 0,
+    }
+
+
+def _value(item: Any, name: str) -> Any:
+    if isinstance(item, dict):
+        return item.get(name)
+    return getattr(item, name, None)
+
+
+def _clean(value: Any) -> str | None:
+    if value is None:
+        return None
+    cleaned = " ".join(str(value).split()).strip()
+    return cleaned or None
+
+
+def _label_is_usable(label: Any) -> bool:
+    status = str(_value(label, "validation_status") or "").upper()
+    return not status.endswith("INVALID")
+
+
+def _group_labeled_words(details: Any) -> dict[str, dict[int, list[str]]]:
+    words = {
+        (_value(word, "line_id"), _value(word, "word_id")): word
+        for word in (_value(details, "words") or [])
+    }
+    grouped: dict[str, dict[int, list[tuple[int, str]]]] = defaultdict(
+        lambda: defaultdict(list)
+    )
+    for label in _value(details, "labels") or []:
+        if not _label_is_usable(label):
+            continue
+        line_id = _value(label, "line_id")
+        word_id = _value(label, "word_id")
+        word = words.get((line_id, word_id))
+        text = _clean(_value(word, "text")) if word is not None else None
+        label_name = _clean(_value(label, "label"))
+        if text and label_name and isinstance(line_id, int):
+            grouped[label_name.upper()][line_id].append((word_id, text))
+
+    result: dict[str, dict[int, list[str]]] = {}
+    for label_name, lines in grouped.items():
+        result[label_name] = {
+            line_id: [text for _, text in sorted(words_on_line)]
+            for line_id, words_on_line in lines.items()
+        }
+    return result
+
+
+def _best_merchant(lines: dict[int, list[str]]) -> str | None:
+    candidates = []
+    for line_id, words in lines.items():
+        text = _clean(" ".join(words))
+        if text and re.search(r"[A-Za-z]", text):
+            candidates.append((len(words), len(text), -line_id, text))
+    return max(candidates)[-1] if candidates else None
+
+
+def _best_phone(lines: dict[int, list[str]]) -> str | None:
+    candidates = []
+    for line_id, words in lines.items():
+        text = _clean(" ".join(words))
+        digits = _phone_digits(text)
+        if text and len(digits) >= 10:
+            candidates.append((len(digits) in {10, 11}, -line_id, text))
+    return max(candidates)[-1] if candidates else None
+
+
+def _combined_address(lines: dict[int, list[str]]) -> str | None:
+    parts = []
+    for _, words in sorted(lines.items()):
+        text = _clean(" ".join(words))
+        if text and text not in parts:
+            parts.append(text)
+    # Header cities are sometimes mislabeled as ADDRESS_LINE before the
+    # actual street.  Start at the first line containing a street number so
+    # that the deterministic address query remains usable.
+    street_start = next(
+        (index for index, part in enumerate(parts) if re.search(r"\d", part)),
+        None,
+    )
+    if street_start is not None:
+        parts = parts[street_start:]
+    return _clean(", ".join(parts))
+
+
+def _receipt_snippet(details: Any, limit: int = 1200) -> str:
+    lines = sorted(
+        _value(details, "lines") or [],
+        key=lambda line: _value(line, "line_id") or 0,
+    )
+    text = "\n".join(
+        value for line in lines[:15] if (value := _clean(_value(line, "text")))
+    )
+    return text[:limit]
+
+
+def extract_receipt_clues(details: Any) -> ReceiptClues:
+    """Extract labeled OCR clues without trusting the flagged current place."""
+    grouped = _group_labeled_words(details)
+    merchant = _best_merchant(grouped.get("MERCHANT_NAME", {}))
+    address = _combined_address(grouped.get("ADDRESS_LINE", {}))
+    phone = _best_phone(grouped.get("PHONE_NUMBER", {}))
+    sources = {
+        key: "receipt_labels"
+        for key, value in {
+            "merchant_name": merchant,
+            "address": address,
+            "phone": phone,
+        }.items()
+        if value
+    }
+
+    expected_state = _extract_state(address)
+    return ReceiptClues(
+        merchant_name=merchant,
+        address=address,
+        phone=phone,
+        expected_state=expected_state,
+        snippet=_receipt_snippet(details),
+        sources=sources,
+    )
+
+
+def _phone_digits(value: str | None) -> str:
+    return "".join(
+        character for character in (value or "") if character.isdigit()
+    )
+
+
+def _phones_match(left: str | None, right: str | None) -> bool:
+    left_digits = _phone_digits(left)
+    right_digits = _phone_digits(right)
+    if not left_digits or not right_digits:
+        return False
+    if len(left_digits) >= 10 and len(right_digits) >= 10:
+        return left_digits[-10:] == right_digits[-10:]
+    return left_digits == right_digits
+
+
+def _normalized_text(value: str | None) -> str:
+    return "".join(
+        character.lower()
+        for character in (value or "")
+        if character.isalnum() or character.isspace()
+    ).strip()
+
+
+def _names_match(left: str | None, right: str | None) -> bool:
+    first = "".join(_normalized_text(left).split())
+    second = "".join(_normalized_text(right).split())
+    return bool(first and second) and (first in second or second in first)
+
+
+def _street(value: str | None) -> str:
+    street = (value or "").split(",", maxsplit=1)[0]
+    # Unit notation is especially inconsistent between receipt OCR and
+    # Google Places ("#107" vs "Suite 107").  It is not part of the street
+    # identity, so remove it before comparing the primary address line.
+    street = re.sub(
+        r"(?:\b(?:suite|ste|unit|apt|apartment)\b|#)\s*[A-Z0-9-]+.*$",
+        "",
+        street,
+        flags=re.IGNORECASE,
+    )
+    normalized = _normalized_text(street)
+    replacements = {
+        "street": "st",
+        "avenue": "ave",
+        "boulevard": "blvd",
+        "road": "rd",
+        "drive": "dr",
+        "lane": "ln",
+        "highway": "hwy",
+    }
+    return " ".join(
+        replacements.get(token, token) for token in normalized.split()
+    )
+
+
+def _addresses_match(left: str | None, right: str | None) -> bool:
+    first = _street(left)
+    second = _street(right)
+    if not first or not second:
+        return False
+
+    first_tokens = first.split()
+    second_tokens = second.split()
+    number_pattern = re.compile(r"\d+[a-z]?")
+    first_number = (
+        first_tokens[0] if number_pattern.fullmatch(first_tokens[0]) else None
+    )
+    second_number = (
+        second_tokens[0]
+        if number_pattern.fullmatch(second_tokens[0])
+        else None
+    )
+    if first_number or second_number:
+        if first_number != second_number:
+            return False
+        first = " ".join(first_tokens[1:])
+        second = " ".join(second_tokens[1:])
+
+    return bool(first and second) and (first in second or second in first)
+
+
+def _extract_state(value: str | None) -> str | None:
+    if not value:
+        return None
+    upper = value.upper()
+    match = re.search(r"\b([A-Z]{2})\s+\d{5}(?:-\d{4})?\b", upper)
+    if match:
+        return match.group(1)
+    match = re.search(r",\s*([A-Z]{2})\b", upper)
+    return match.group(1) if match else None
+
+
+def _place_phone(place: Any) -> str | None:
+    return _clean(
+        _value(place, "formatted_phone_number")
+        or _value(place, "international_phone_number")
+    )
+
+
+def _deterministic_evidence_is_sufficient(
+    clues: ReceiptClues, place: Any, search_method: str
+) -> bool:
+    """Require secondary corroboration and reject active clue conflicts."""
+    primary_fields = {
+        "phone": "phone",
+        "address": "address",
+        "text": "merchant_name",
+    }
+    primary_field = primary_fields.get(search_method)
+    if primary_field is None:
+        return False
+
+    evidence = {
+        "merchant_name": (
+            clues.merchant_name,
+            _clean(_value(place, "name")),
+            _names_match,
+        ),
+        "address": (
+            clues.address,
+            _clean(_value(place, "formatted_address")),
+            _addresses_match,
+        ),
+        "phone": (clues.phone, _place_phone(place), _phones_match),
+    }
+    statuses = {}
+    for field_name, (clue, candidate_value, matcher) in evidence.items():
+        if not clue:
+            continue
+        if not candidate_value:
+            statuses[field_name] = "missing"
+        elif matcher(clue, candidate_value):
+            statuses[field_name] = "match"
+        else:
+            statuses[field_name] = "conflict"
+
+    if "conflict" in statuses.values():
+        return False
+    secondary_statuses = [
+        status
+        for field_name, status in statuses.items()
+        if field_name != primary_field
+    ]
+    return not secondary_statuses or "match" in secondary_statuses
+
+
+def _candidate_score(
+    clues: ReceiptClues, place: Any, search_method: str
+) -> float:
+    name_match = _names_match(clues.merchant_name, _value(place, "name"))
+    address_match = _addresses_match(
+        clues.address, _value(place, "formatted_address")
+    )
+    phone_match = _phones_match(clues.phone, _place_phone(place))
+
+    # A search method is not evidence by itself.  In particular, the Places
+    # client's phone fallback is a broad text search and can return an
+    # unrelated business.  Require the returned place to agree with the
+    # primary receipt clue before granting that method's base confidence.
+    if search_method == "phone":
+        if not phone_match:
+            return 0.0
+        return min(
+            1.0,
+            0.95
+            + (0.03 if address_match else 0.0)
+            + (0.02 if name_match else 0.0),
+        )
+    if search_method == "address":
+        if not address_match:
+            return 0.0
+        return min(
+            1.0,
+            0.90
+            + (0.05 if name_match else 0.0)
+            + (0.05 if phone_match else 0.0),
+        )
+    if search_method == "text":
+        if not name_match:
+            return 0.0
+        return min(
+            1.0,
+            0.75
+            + (0.15 if address_match else 0.0)
+            + (0.10 if phone_match else 0.0),
+        )
+
+    # Existing place IDs only reach Tier 0 when their labeled evidence is
+    # consistent.  Keep inconsistent existing candidates available to the
+    # structured picker, but never let them qualify for Tier 1 on base score.
+    return (
+        0.50
+        + (0.15 if name_match else 0.0)
+        + (0.15 if address_match else 0.0)
+        + (0.20 if phone_match else 0.0)
+    )
+
+
+def _primary_evidence_matches(
+    place: Any, clues: ReceiptClues, search_method: str
+) -> bool:
+    """Reject broad Places fallbacks that disagree with their receipt clue."""
+    if search_method == "phone":
+        return _phones_match(clues.phone, _place_phone(place))
+    if search_method == "address":
+        return _addresses_match(
+            clues.address, _clean(_value(place, "formatted_address"))
+        )
+    if search_method == "text":
+        return _names_match(clues.merchant_name, _clean(_value(place, "name")))
+    return True
+
+
+def _place_is_usable(place: Any, clues: ReceiptClues) -> bool:
+    place_id = _clean(_value(place, "place_id"))
+    name = _clean(_value(place, "name"))
+    if not place_id or not name or is_address_like(name):
+        return False
+    place_types = {
+        str(place_type).lower()
+        for place_type in (_value(place, "types") or [])
+    }
+    address_types = {"premise", "street_address", "subpremise"}
+    business_types = {"establishment", "point_of_interest"}
+    if place_types & address_types and not place_types & business_types:
+        return False
+    result_state = _extract_state(_clean(_value(place, "formatted_address")))
+    return not (
+        clues.expected_state
+        and result_state
+        and result_state != clues.expected_state
+    )
+
+
+def _to_candidate(
+    place: Any, clues: ReceiptClues, search_method: str
+) -> PlaceCandidate:
+    return PlaceCandidate(
+        place_id=str(_value(place, "place_id")),
+        merchant_name=str(_value(place, "name")),
+        address=_clean(_value(place, "formatted_address")),
+        phone=_place_phone(place),
+        score=_candidate_score(clues, place, search_method),
+        search_methods={search_method},
+        deterministic_eligible=_deterministic_evidence_is_sufficient(
+            clues, place, search_method
+        ),
+    )
+
+
+def _merge_candidate(
+    candidates: dict[str, PlaceCandidate], candidate: PlaceCandidate
+) -> None:
+    existing = candidates.get(candidate.place_id)
+    if existing is None:
+        candidates[candidate.place_id] = candidate
+        return
+    existing.score = max(existing.score, candidate.score)
+    existing.search_methods.update(candidate.search_methods)
+    existing.deterministic_eligible = (
+        existing.deterministic_eligible or candidate.deterministic_eligible
+    )
+    existing.address = existing.address or candidate.address
+    existing.phone = existing.phone or candidate.phone
+
+
+def _existing_candidate(
+    details: Any, places_client: Any, clues: ReceiptClues
+) -> PlaceCandidate | None:
+    current = _value(details, "place")
+    place_id = _clean(_value(current, "place_id"))
+    if not place_id or place_id in _PLACE_ID_SENTINELS:
+        return None
+    try:
+        place = places_client.get_place_details(place_id)
+    except Exception:  # pylint: disable=broad-exception-caught
+        logger.exception("Tier 0 place_id lookup failed")
+        return None
+    if not _place_is_usable(place, clues):
+        return None
+    return _to_candidate(place, clues, "existing_place_id")
+
+
+def _tier0_is_consistent(
+    candidate: PlaceCandidate, clues: ReceiptClues
+) -> bool:
+    if (
+        clues.merchant_name
+        and clues.sources.get("merchant_name") == "receipt_labels"
+        and not _names_match(clues.merchant_name, candidate.merchant_name)
+    ):
+        return False
+
+    checks = []
+    if clues.phone and clues.sources.get("phone") == "receipt_labels":
+        checks.append(_phones_match(clues.phone, candidate.phone))
+    if clues.address and clues.sources.get("address") == "receipt_labels":
+        checks.append(_addresses_match(clues.address, candidate.address))
+    return bool(checks) and all(checks)
+
+
+def collect_candidates(
+    places_client: Any,
+    clues: ReceiptClues,
+    initial: list[PlaceCandidate] | None = None,
+) -> list[PlaceCandidate]:
+    """Run the deterministic phone/address/text Places cascade."""
+    candidates = {
+        candidate.place_id: candidate for candidate in (initial or [])
+    }
+    searches = (
+        ("phone", clues.phone, places_client.search_by_phone),
+        ("address", clues.address, places_client.search_by_address),
+        ("text", clues.merchant_name, places_client.search_by_text),
+    )
+    for method, query, search in searches:
+        if not query:
+            continue
+        try:
+            place = search(query)
+        except Exception:  # pylint: disable=broad-exception-caught
+            logger.exception("Tier 1 Places %s search failed", method)
+            continue
+        if not _place_is_usable(place, clues):
+            continue
+        if not _primary_evidence_matches(place, clues, method):
+            logger.warning(
+                "Tier 1 rejected %s result because returned place did not "
+                "match the receipt's primary clue",
+                method,
+            )
+            continue
+        _merge_candidate(candidates, _to_candidate(place, clues, method))
+    return sorted(
+        candidates.values(),
+        key=lambda candidate: candidate.score,
+        reverse=True,
+    )
+
+
+def select_deterministic_candidate(
+    candidates: list[PlaceCandidate],
+    minimum_confidence: float,
+) -> PlaceCandidate | None:
+    """Select one high-confidence candidate, rejecting high-score conflicts."""
+    qualifying = [
+        candidate
+        for candidate in candidates
+        if candidate.score >= minimum_confidence
+        and candidate.deterministic_eligible
+    ]
+    if not qualifying:
+        return None
+    if len({candidate.place_id for candidate in qualifying}) > 1:
+        return None
+    return qualifying[0]
+
+
+def _result(
+    candidate: PlaceCandidate,
+    *,
+    tier: str,
+    confidence: float,
+    reasoning: str,
+    clues: ReceiptClues | None = None,
+) -> dict[str, Any]:
+    values = {
+        "place_id": candidate.place_id,
+        "merchant_name": candidate.merchant_name,
+        "address": candidate.address,
+        "phone_number": (
+            candidate.phone or (clues.phone if clues else None) or ""
+        ),
+    }
+    fields_found = [key for key, value in values.items() if value]
+    sources = dict.fromkeys(fields_found, "google_places")
+    if "phone_number" in fields_found and not candidate.phone:
+        sources["phone_number"] = "receipt_labels"
+    return {
+        **values,
+        "confidence": confidence,
+        "field_confidence": dict.fromkeys(fields_found, confidence),
+        "reasoning": reasoning,
+        "sources": sources,
+        "search_methods_used": sorted(candidate.search_methods),
+        "fields_found": fields_found,
+        "found": True,
+        "type": "deterministic" if tier != "tier2" else "llm_decided",
+        "resolution_tier": tier,
+    }
+
+
+async def _select_with_llm(
+    clues: ReceiptClues,
+    candidates: list[PlaceCandidate],
+) -> tuple[dict[str, Any] | None, dict[str, Any]]:
+    callback = CostTrackingCallback()
+    model = os.environ.get("FIX_PLACE_TIER2_MODEL", _TIER2_MODEL)
+    minimum_confidence = float(
+        os.environ.get("FIX_PLACE_TIER2_MIN_CONFIDENCE", "0.85")
+    )
+    llm = create_llm(
+        model=model,
+        temperature=0.0,
+        timeout=60,
+        reasoning=True,
+        stream_usage=True,
+    ).with_structured_output(Tier2Selection)
+    payload = {
+        "receipt_clues": {
+            "merchant_name": clues.merchant_name,
+            "address": clues.address,
+            "phone": clues.phone,
+        },
+        "receipt_text": clues.snippet,
+        "candidates": [
+            candidate.as_prompt_dict() for candidate in candidates[:5]
+        ],
+    }
+    messages = [
+        SystemMessage(
+            content=(
+                "Choose the single Google Places candidate supported by the "
+                "receipt. Return null when evidence conflicts or is too weak. "
+                "Never invent a place_id."
+            )
+        ),
+        HumanMessage(content=json.dumps(payload, ensure_ascii=True)),
+    ]
+    try:
+        selection = await llm.ainvoke(
+            messages,
+            config={"callbacks": [callback.handler]},
+        )
+    except Exception:  # pylint: disable=broad-exception-caught
+        logger.exception("Tier 2 structured place selection failed")
+        return None, callback.get_stats()
+
+    if isinstance(selection, dict):
+        selection = Tier2Selection.model_validate(selection)
+    selected = next(
+        (
+            candidate
+            for candidate in candidates
+            if candidate.place_id == selection.place_id
+        ),
+        None,
+    )
+    if selected is None or selection.confidence < minimum_confidence:
+        return None, callback.get_stats()
+    return (
+        _result(
+            selected,
+            tier="tier2",
+            confidence=selection.confidence,
+            reasoning=(
+                f"Single structured picker selected a known Places candidate: "
+                f"{selection.reasoning}"
+            ),
+            clues=clues,
+        ),
+        callback.get_stats(),
+    )
+
+
+async def resolve_tiered_place(
+    details: Any, places_client: Any
+) -> tuple[dict[str, Any] | None, dict[str, Any]]:
+    """Try Tiers 0-2 and return ``None`` when Tier 3 must run."""
+    if places_client is None:
+        logger.warning("Places client unavailable; escalating to Tier 3")
+        return None, empty_llm_stats()
+    clues = extract_receipt_clues(details)
+    if not any((clues.merchant_name, clues.address, clues.phone)):
+        logger.info(
+            "No usable receipt-labeled place evidence; escalating to Tier 3"
+        )
+        return None, empty_llm_stats()
+    existing = _existing_candidate(details, places_client, clues)
+    if existing and _tier0_is_consistent(existing, clues):
+        return (
+            _result(
+                existing,
+                tier="tier0",
+                confidence=1.0,
+                reasoning=(
+                    "Existing place_id matches receipt-labeled phone/address "
+                    "and current Google Places details."
+                ),
+                clues=clues,
+            ),
+            empty_llm_stats(),
+        )
+
+    candidates = collect_candidates(
+        places_client,
+        clues,
+        initial=[existing] if existing else None,
+    )
+    tier1_minimum = float(
+        os.environ.get("FIX_PLACE_TIER1_MIN_CONFIDENCE", "0.90")
+    )
+    deterministic = select_deterministic_candidate(candidates, tier1_minimum)
+    if deterministic:
+        return (
+            _result(
+                deterministic,
+                tier="tier1",
+                confidence=deterministic.score,
+                reasoning=(
+                    "Deterministic Places cascade produced one "
+                    "high-confidence candidate."
+                ),
+                clues=clues,
+            ),
+            empty_llm_stats(),
+        )
+
+    tier2_enabled = (
+        os.environ.get("FIX_PLACE_TIER2_ENABLED", "true").lower()
+        not in _FALSE_VALUES
+    )
+    if candidates and tier2_enabled:
+        return await _select_with_llm(clues, candidates)
+    return None, empty_llm_stats()

--- a/receipt_agent/receipt_agent/subagents/place_finder/tiered.py
+++ b/receipt_agent/receipt_agent/subagents/place_finder/tiered.py
@@ -13,7 +13,6 @@ from typing import Any
 from langchain_core.messages import HumanMessage, SystemMessage
 from pydantic import BaseModel, Field
 
-from receipt_agent.utils.address_validation import is_address_like
 from receipt_agent.utils.llm_factory import CostTrackingCallback, create_llm
 
 logger = logging.getLogger(__name__)
@@ -151,18 +150,26 @@ def _combined_address(lines: dict[int, list[str]]) -> str | None:
     parts = []
     for _, words in sorted(lines.items()):
         text = _clean(" ".join(words))
-        if text and text not in parts:
+        if text:
             parts.append(text)
     # Header cities are sometimes mislabeled as ADDRESS_LINE before the
-    # actual street.  Start at the first line containing a street number so
-    # that the deterministic address query remains usable.
+    # actual street.  Start at a leading house-number pattern rather than any
+    # digit so a ZIP-bearing city/state line cannot become the street clue.
     street_start = next(
-        (index for index, part in enumerate(parts) if re.search(r"\d", part)),
+        (
+            index
+            for index, part in enumerate(parts)
+            if re.match(
+                r"^\s*\d+[A-Za-z]?(?:[-/]\d+[A-Za-z]?)?\s+[A-Za-z]",
+                part,
+            )
+        ),
         None,
     )
     if street_start is not None:
         parts = parts[street_start:]
-    return _clean(", ".join(parts))
+    deduplicated = list(dict.fromkeys(parts))
+    return _clean(", ".join(deduplicated))
 
 
 def _receipt_snippet(details: Any, limit: int = 1200) -> str:
@@ -420,7 +427,7 @@ def _primary_evidence_matches(
 def _place_is_usable(place: Any, clues: ReceiptClues) -> bool:
     place_id = _clean(_value(place, "place_id"))
     name = _clean(_value(place, "name"))
-    if not place_id or not name or is_address_like(name):
+    if not place_id or not name:
         return False
     place_types = {
         str(place_type).lower()

--- a/receipt_agent/receipt_agent/utils/llm_factory.py
+++ b/receipt_agent/receipt_agent/utils/llm_factory.py
@@ -472,6 +472,12 @@ class CostTrackingCallback:
             self.total_tokens += t_tokens
             self.prompt_tokens += p_tokens
             self.completion_tokens += c_tokens
+            aggregate_usage = {
+                "input_tokens": self.prompt_tokens,
+                "output_tokens": self.completion_tokens,
+                "total_tokens": self.total_tokens,
+                "total_cost": self.total_cost,
+            }
 
         if cost > 0:
             try:
@@ -479,14 +485,11 @@ class CostTrackingCallback:
 
                 run_tree = get_current_run_tree()
                 if run_tree:
-                    run_tree.set(
-                        usage_metadata={
-                            "input_tokens": p_tokens,
-                            "output_tokens": c_tokens,
-                            "total_tokens": t_tokens,
-                            "total_cost": cost,
-                        }
-                    )
+                    # The callback runs inside the enclosing graph trace. Keep
+                    # that run's usage cumulative so a multi-turn tool loop
+                    # reports the invocation total rather than only its final
+                    # LLM turn.
+                    run_tree.set(usage_metadata=aggregate_usage)
             except Exception as e:
                 logger.debug("Could not add cost to LangSmith run: %s", e)
 
@@ -499,6 +502,15 @@ class CostTrackingCallback:
                 "completion_tokens": self.completion_tokens,
                 "llm_calls": self.llm_calls,
             }
+
+    def reset(self) -> None:
+        """Reset counters before a new graph invocation."""
+        with self._lock:
+            self.total_cost = 0.0
+            self.total_tokens = 0
+            self.prompt_tokens = 0
+            self.completion_tokens = 0
+            self.llm_calls = 0
 
 
 # =============================================================================

--- a/receipt_agent/receipt_agent/utils/llm_factory.py
+++ b/receipt_agent/receipt_agent/utils/llm_factory.py
@@ -472,12 +472,13 @@ class CostTrackingCallback:
             self.total_tokens += t_tokens
             self.prompt_tokens += p_tokens
             self.completion_tokens += c_tokens
-            aggregate_usage = {
-                "input_tokens": self.prompt_tokens,
-                "output_tokens": self.completion_tokens,
-                "total_tokens": self.total_tokens,
-                "total_cost": self.total_cost,
-            }
+
+        call_usage = {
+            "input_tokens": p_tokens,
+            "output_tokens": c_tokens,
+            "total_tokens": t_tokens,
+            "total_cost": cost,
+        }
 
         if cost > 0:
             try:
@@ -485,11 +486,10 @@ class CostTrackingCallback:
 
                 run_tree = get_current_run_tree()
                 if run_tree:
-                    # The callback runs inside the enclosing graph trace. Keep
-                    # that run's usage cumulative so a multi-turn tool loop
-                    # reports the invocation total rather than only its final
-                    # LLM turn.
-                    run_tree.set(usage_metadata=aggregate_usage)
+                    # LangSmith aggregates child usage into the root trace.
+                    # Attach only this turn's usage so a multi-turn loop is
+                    # not overcounted by repeatedly adding cumulative totals.
+                    run_tree.set(usage_metadata=call_usage)
             except Exception as e:
                 logger.debug("Could not add cost to LangSmith run: %s", e)
 

--- a/receipt_agent/tests/test_openrouter_cost_tracking.py
+++ b/receipt_agent/tests/test_openrouter_cost_tracking.py
@@ -73,6 +73,54 @@ class TestCostTrackingCallback:
 
         assert callback.get_stats()["total_cost"] == 0.0004
 
+    @patch("langsmith.run_helpers.get_current_run_tree")
+    def test_langsmith_usage_is_per_call_while_stats_are_cumulative(
+        self, mock_get_current_run_tree
+    ):
+        run_tree = MagicMock()
+        mock_get_current_run_tree.return_value = run_tree
+        callback = CostTrackingCallback()
+
+        for prompt, completion, cost in ((100, 10, 0.001), (200, 20, 0.002)):
+            callback.handler.on_llm_end(
+                SimpleNamespace(
+                    llm_output={
+                        "token_usage": {
+                            "prompt_tokens": prompt,
+                            "completion_tokens": completion,
+                            "total_tokens": prompt + completion,
+                            "cost": cost,
+                        }
+                    }
+                )
+            )
+
+        assert callback.get_stats() == {
+            "total_cost": 0.003,
+            "total_tokens": 330,
+            "prompt_tokens": 300,
+            "completion_tokens": 30,
+            "llm_calls": 2,
+        }
+        langsmith_usage = [
+            call.kwargs["usage_metadata"]
+            for call in run_tree.set.call_args_list
+        ]
+        assert langsmith_usage == [
+            {
+                "input_tokens": 100,
+                "output_tokens": 10,
+                "total_tokens": 110,
+                "total_cost": 0.001,
+            },
+            {
+                "input_tokens": 200,
+                "output_tokens": 20,
+                "total_tokens": 220,
+                "total_cost": 0.002,
+            },
+        ]
+
     def test_langchain_preserves_cost_for_tool_call_response(self):
         """ChatOpenAI must retain OpenRouter's extra usage fields."""
         llm = ChatOpenAI(

--- a/receipt_agent/tests/test_openrouter_cost_tracking.py
+++ b/receipt_agent/tests/test_openrouter_cost_tracking.py
@@ -1,0 +1,126 @@
+"""OpenRouter cost extraction and LangSmith propagation tests."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from langchain_openai import ChatOpenAI
+
+from receipt_agent.utils.llm_factory import CostTrackingCallback
+
+
+class TestCostTrackingCallback:
+    """Tests for OpenRouter cost extraction and LangSmith propagation."""
+
+    @patch("langsmith.run_helpers.get_current_run_tree")
+    def test_tracks_openrouter_cost_and_sets_langsmith_usage(
+        self, mock_get_current_run_tree
+    ):
+        run_tree = MagicMock()
+        mock_get_current_run_tree.return_value = run_tree
+        callback = CostTrackingCallback()
+        response = SimpleNamespace(
+            llm_output={
+                "token_usage": {
+                    "prompt_tokens": 125,
+                    "completion_tokens": 25,
+                    "total_tokens": 150,
+                    "cost": 0.00175,
+                    "cost_details": {
+                        "upstream_inference_cost": 0.0015,
+                    },
+                }
+            }
+        )
+
+        callback.handler.on_llm_end(response)
+
+        assert callback.get_stats() == {
+            "total_cost": 0.00175,
+            "total_tokens": 150,
+            "prompt_tokens": 125,
+            "completion_tokens": 25,
+            "llm_calls": 1,
+        }
+        run_tree.set.assert_called_once_with(
+            usage_metadata={
+                "input_tokens": 125,
+                "output_tokens": 25,
+                "total_tokens": 150,
+                "total_cost": 0.00175,
+            }
+        )
+
+    def test_uses_openrouter_upstream_cost_fallback(self):
+        callback = CostTrackingCallback()
+        response = SimpleNamespace(
+            llm_output={
+                "token_usage": {
+                    "prompt_tokens": 10,
+                    "completion_tokens": 2,
+                    "total_tokens": 12,
+                    "cost_details": {
+                        "upstream_inference_cost": 0.0004,
+                    },
+                }
+            }
+        )
+
+        with patch(
+            "langsmith.run_helpers.get_current_run_tree",
+            return_value=None,
+        ):
+            callback.handler.on_llm_end(response)
+
+        assert callback.get_stats()["total_cost"] == 0.0004
+
+    def test_langchain_preserves_cost_for_tool_call_response(self):
+        """ChatOpenAI must retain OpenRouter's extra usage fields."""
+        llm = ChatOpenAI(
+            model="test-model",
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+        )
+        response = {
+            "id": "gen-test",
+            "object": "chat.completion",
+            "created": 0,
+            "model": "test-model",
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {
+                        "role": "assistant",
+                        "content": None,
+                        "tool_calls": [
+                            {
+                                "id": "call-1",
+                                "type": "function",
+                                "function": {
+                                    "name": "lookup_place",
+                                    "arguments": "{}",
+                                },
+                            }
+                        ],
+                    },
+                    "finish_reason": "tool_calls",
+                    "logprobs": None,
+                }
+            ],
+            "usage": {
+                "prompt_tokens": 100,
+                "completion_tokens": 10,
+                "total_tokens": 110,
+                "cost": 0.002,
+            },
+        }
+
+        result = llm._create_chat_result(response)
+        callback = CostTrackingCallback()
+        with patch(
+            "langsmith.run_helpers.get_current_run_tree",
+            return_value=None,
+        ):
+            callback.handler.on_llm_end(result)
+
+        assert result.llm_output["token_usage"]["cost"] == 0.002
+        assert callback.get_stats()["total_cost"] == 0.002

--- a/receipt_agent/tests/test_place_finder_agent_cap.py
+++ b/receipt_agent/tests/test_place_finder_agent_cap.py
@@ -1,0 +1,293 @@
+"""Tests for constrained and legacy place-agent execution."""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from langchain_core.messages import (
+    AIMessage,
+    HumanMessage,
+    SystemMessage,
+    ToolMessage,
+)
+
+from receipt_agent.agents.place_id_finder.graph import run_place_id_finder
+from receipt_agent.subagents.place_finder.graph import (
+    _compact_agent_messages,
+    create_receipt_place_finder_graph,
+    run_receipt_place_finder,
+)
+from receipt_agent.subagents.place_finder.state import ReceiptPlaceFinderState
+
+
+def _settings():
+    return SimpleNamespace(
+        openrouter_model="test-model",
+        openrouter_base_url="https://openrouter.ai/api/v1",
+        openrouter_api_key=SimpleNamespace(
+            get_secret_value=lambda: "test-key"
+        ),
+    )
+
+
+def _submit_message():
+    return AIMessage(
+        content="",
+        tool_calls=[
+            {
+                "name": "submit_place",
+                "args": {
+                    "place_id": "ChIJ-test",
+                    "merchant_name": "Test Market",
+                    "confidence": 0.9,
+                    "reasoning": "Best available evidence.",
+                },
+                "id": "call-1",
+                "type": "tool_call",
+            }
+        ],
+    )
+
+
+def test_agent_forces_submit_after_configured_rounds(monkeypatch):
+    monkeypatch.setenv("FIX_PLACE_RESOLUTION_MODE", "tiered")
+    monkeypatch.setenv("FIX_PLACE_AGENT_MAX_ROUNDS", "3")
+    normal_llm = MagicMock()
+    normal_llm.invoke.side_effect = lambda _messages: AIMessage(
+        content="Still searching"
+    )
+    forced_llm = MagicMock()
+    forced_llm.invoke.return_value = _submit_message()
+    base_llm = MagicMock()
+    base_llm.bind_tools.side_effect = [normal_llm, forced_llm]
+
+    with (
+        patch(
+            "receipt_agent.subagents.place_finder.graph.create_agentic_tools",
+            return_value=([], {}),
+        ),
+        patch(
+            "receipt_agent.subagents.place_finder.graph.create_llm",
+            return_value=base_llm,
+        ),
+    ):
+        graph, state_holder = create_receipt_place_finder_graph(
+            dynamo_client=None,
+            chroma_client=None,
+            embed_fn=lambda _texts: [],
+            settings=_settings(),
+        )
+        graph.invoke(
+            ReceiptPlaceFinderState(
+                image_id="image-1",
+                receipt_id=1,
+                messages=[HumanMessage(content="Find the place")],
+            ),
+            config={"recursion_limit": 12},
+        )
+
+    assert normal_llm.invoke.call_count == 3
+    forced_llm.invoke.assert_called_once()
+    assert state_holder["place_result"]["place_id"] == "ChIJ-test"
+
+
+def test_submit_tool_ends_without_an_extra_llm_turn():
+    normal_llm = MagicMock()
+    normal_llm.invoke.return_value = _submit_message()
+    forced_llm = MagicMock()
+    base_llm = MagicMock()
+    base_llm.bind_tools.side_effect = [normal_llm, forced_llm]
+
+    with (
+        patch(
+            "receipt_agent.subagents.place_finder.graph.create_agentic_tools",
+            return_value=([], {}),
+        ),
+        patch(
+            "receipt_agent.subagents.place_finder.graph.create_llm",
+            return_value=base_llm,
+        ),
+    ):
+        graph, state_holder = create_receipt_place_finder_graph(
+            dynamo_client=None,
+            chroma_client=None,
+            embed_fn=lambda _texts: [],
+            settings=_settings(),
+        )
+        graph.invoke(
+            ReceiptPlaceFinderState(
+                image_id="image-1",
+                receipt_id=1,
+                messages=[HumanMessage(content="Find the place")],
+            ),
+            config={"recursion_limit": 12},
+        )
+
+    normal_llm.invoke.assert_called_once()
+    forced_llm.invoke.assert_not_called()
+    assert state_holder["place_result"]["found"] is True
+
+
+def test_legacy_agent_is_not_forced_to_submit_after_three_rounds(monkeypatch):
+    monkeypatch.setenv("FIX_PLACE_RESOLUTION_MODE", "agent")
+    monkeypatch.setenv("FIX_PLACE_AGENT_MAX_ROUNDS", "3")
+    normal_llm = MagicMock()
+    normal_llm.invoke.side_effect = [
+        AIMessage(content=f"Still searching, round {round_number}")
+        for round_number in range(1, 5)
+    ] + [_submit_message()]
+    forced_llm = MagicMock()
+    base_llm = MagicMock()
+    base_llm.bind_tools.side_effect = [normal_llm, forced_llm]
+
+    with (
+        patch(
+            "receipt_agent.subagents.place_finder.graph.create_agentic_tools",
+            return_value=([], {}),
+        ),
+        patch(
+            "receipt_agent.subagents.place_finder.graph.create_llm",
+            return_value=base_llm,
+        ),
+    ):
+        graph, state_holder = create_receipt_place_finder_graph(
+            dynamo_client=None,
+            chroma_client=None,
+            embed_fn=lambda _texts: [],
+            settings=_settings(),
+        )
+        graph.invoke(
+            ReceiptPlaceFinderState(
+                image_id="image-1",
+                receipt_id=1,
+                messages=[HumanMessage(content="Find the place")],
+            ),
+            config={"recursion_limit": 20},
+        )
+
+    assert normal_llm.invoke.call_count == 5
+    forced_llm.invoke.assert_not_called()
+    assert state_holder["place_result"]["place_id"] == "ChIJ-test"
+
+
+def test_legacy_agent_ends_after_twenty_stalled_messages(monkeypatch):
+    monkeypatch.setenv("FIX_PLACE_RESOLUTION_MODE", "agent")
+    normal_llm = MagicMock()
+    normal_llm.invoke.side_effect = lambda _messages: AIMessage(
+        content="Still searching"
+    )
+    forced_llm = MagicMock()
+    base_llm = MagicMock()
+    base_llm.bind_tools.side_effect = [normal_llm, forced_llm]
+
+    with (
+        patch(
+            "receipt_agent.subagents.place_finder.graph.create_agentic_tools",
+            return_value=([], {}),
+        ),
+        patch(
+            "receipt_agent.subagents.place_finder.graph.create_llm",
+            return_value=base_llm,
+        ),
+    ):
+        graph, state_holder = create_receipt_place_finder_graph(
+            dynamo_client=None,
+            chroma_client=None,
+            embed_fn=lambda _texts: [],
+            settings=_settings(),
+        )
+        graph.invoke(
+            ReceiptPlaceFinderState(
+                image_id="image-1",
+                receipt_id=1,
+                messages=[HumanMessage(content="Find the place")],
+            ),
+            config={"recursion_limit": 100},
+        )
+
+    assert normal_llm.invoke.call_count == 20
+    forced_llm.invoke.assert_not_called()
+    assert state_holder.get("place_result") is None
+
+
+def test_compaction_keeps_tool_calls_paired_with_all_results():
+    old_call_ids = [f"old-{index}" for index in range(3)]
+    recent_call_ids = [f"recent-{index}" for index in range(3)]
+
+    def tool_call_message(call_ids):
+        return AIMessage(
+            content="",
+            tool_calls=[
+                {
+                    "name": "lookup",
+                    "args": {"value": call_id},
+                    "id": call_id,
+                    "type": "tool_call",
+                }
+                for call_id in call_ids
+            ],
+        )
+
+    prefix = [
+        SystemMessage(content="system"),
+        HumanMessage(content="request"),
+    ]
+    old_group = [tool_call_message(old_call_ids)] + [
+        ToolMessage(content="result", tool_call_id=call_id)
+        for call_id in old_call_ids
+    ]
+    recent_group = [tool_call_message(recent_call_ids)] + [
+        ToolMessage(content="result", tool_call_id=call_id)
+        for call_id in recent_call_ids
+    ]
+
+    compacted = _compact_agent_messages(prefix + old_group + recent_group)
+
+    assert compacted == prefix + recent_group
+    available_call_ids = {
+        tool_call["id"]
+        for message in compacted
+        if isinstance(message, AIMessage)
+        for tool_call in message.tool_calls
+    }
+    assert {
+        message.tool_call_id
+        for message in compacted
+        if isinstance(message, ToolMessage)
+    } <= available_call_ids
+
+
+def test_receipt_place_runner_preserves_legacy_recursion_budget(monkeypatch):
+    monkeypatch.setenv("FIX_PLACE_RESOLUTION_MODE", "agent")
+    monkeypatch.setenv("FIX_PLACE_AGENT_RECURSION_LIMIT", "12")
+    graph = MagicMock()
+    graph.ainvoke = AsyncMock()
+    state_holder = {"place_result": None}
+
+    asyncio.run(
+        run_receipt_place_finder(
+            graph,
+            state_holder,
+            image_id="image-1",
+            receipt_id=1,
+        )
+    )
+
+    assert graph.ainvoke.await_args.kwargs["config"]["recursion_limit"] == 100
+
+
+def test_upload_place_id_runner_preserves_legacy_recursion_budget():
+    graph = MagicMock()
+    graph.ainvoke = AsyncMock()
+    state_holder = {"place_id_result": None}
+
+    asyncio.run(
+        run_place_id_finder(
+            graph,
+            state_holder,
+            image_id="image-1",
+            receipt_id=1,
+        )
+    )
+
+    assert graph.ainvoke.await_args.kwargs["config"]["recursion_limit"] == 100

--- a/receipt_agent/tests/test_place_finder_cost_tracking.py
+++ b/receipt_agent/tests/test_place_finder_cost_tracking.py
@@ -1,6 +1,7 @@
 """Cost visibility tests for the live fix-place graph runner."""
 
 import asyncio
+from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 from receipt_agent.subagents.place_finder.graph import (
@@ -9,8 +10,9 @@ from receipt_agent.subagents.place_finder.graph import (
 from receipt_agent.utils.llm_factory import CostTrackingCallback
 
 
-def test_fix_place_runner_attaches_cost_callback_to_graph():
+def test_fix_place_runner_attaches_cost_callback_to_graph(monkeypatch):
     """The graph-level handler must propagate to every tool-calling turn."""
+    monkeypatch.setenv("FIX_PLACE_RESOLUTION_MODE", "tiered")
     graph = AsyncMock()
     callback = CostTrackingCallback()
     state_holder = {"cost_callback": callback}
@@ -33,9 +35,20 @@ def test_fix_place_runner_attaches_cost_callback_to_graph():
             state_holder=state_holder,
             image_id="image-1",
             receipt_id=1,
+            receipt_words=[SimpleNamespace(line_id=2, word_id=3, text="Test")],
+            receipt_labels=[
+                SimpleNamespace(
+                    line_id=2,
+                    word_id=3,
+                    label="MERCHANT_NAME",
+                    validation_status="VALID",
+                )
+            ],
         )
     )
 
     assert result["found"] is True
     config = graph.ainvoke.call_args.kwargs["config"]
     assert callback.handler in config["callbacks"]
+    assert config["recursion_limit"] == 12
+    assert state_holder["context"].words[0]["label"] == "MERCHANT_NAME"

--- a/receipt_agent/tests/test_place_finder_cost_tracking.py
+++ b/receipt_agent/tests/test_place_finder_cost_tracking.py
@@ -1,0 +1,41 @@
+"""Cost visibility tests for the live fix-place graph runner."""
+
+import asyncio
+from unittest.mock import AsyncMock
+
+from receipt_agent.subagents.place_finder.graph import (
+    run_receipt_place_finder,
+)
+from receipt_agent.utils.llm_factory import CostTrackingCallback
+
+
+def test_fix_place_runner_attaches_cost_callback_to_graph():
+    """The graph-level handler must propagate to every tool-calling turn."""
+    graph = AsyncMock()
+    callback = CostTrackingCallback()
+    state_holder = {"cost_callback": callback}
+
+    async def complete_with_result(_state, config):
+        state_holder["place_result"] = {
+            "found": True,
+            "place_id": "ChIJ-test",
+            "merchant_name": "Test Merchant",
+            "confidence": 0.99,
+            "fields_found": ["place_id", "merchant_name"],
+        }
+        return config
+
+    graph.ainvoke.side_effect = complete_with_result
+
+    result = asyncio.run(
+        run_receipt_place_finder(
+            graph=graph,
+            state_holder=state_holder,
+            image_id="image-1",
+            receipt_id=1,
+        )
+    )
+
+    assert result["found"] is True
+    config = graph.ainvoke.call_args.kwargs["config"]
+    assert callback.handler in config["callbacks"]

--- a/receipt_agent/tests/test_tiered_place_resolution.py
+++ b/receipt_agent/tests/test_tiered_place_resolution.py
@@ -1,0 +1,441 @@
+"""Tests for the low-cost fix-place resolution tiers."""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from receipt_agent.subagents.place_finder.tiered import (
+    PlaceCandidate,
+    ReceiptClues,
+    Tier2Selection,
+    _addresses_match,
+    _select_with_llm,
+    extract_receipt_clues,
+    resolve_tiered_place,
+    select_deterministic_candidate,
+)
+
+
+def _word(line_id, word_id, text):
+    return SimpleNamespace(line_id=line_id, word_id=word_id, text=text)
+
+
+def _label(line_id, word_id, label, status="VALID"):
+    return SimpleNamespace(
+        line_id=line_id,
+        word_id=word_id,
+        label=label,
+        validation_status=status,
+    )
+
+
+def _place(
+    place_id="ChIJ-test",
+    name="Test Market",
+    address="123 Main St, Las Vegas, NV 89101, USA",
+    phone="(702) 555-0100",
+    types=None,
+):
+    return SimpleNamespace(
+        place_id=place_id,
+        name=name,
+        formatted_address=address,
+        formatted_phone_number=phone,
+        international_phone_number=None,
+        types=types or ["establishment", "point_of_interest"],
+    )
+
+
+def _details(*, current_place=None, phone="(702) 555-0100"):
+    return SimpleNamespace(
+        place=current_place,
+        words=[_word(1, 1, phone)],
+        labels=[_label(1, 1, "PHONE_NUMBER")],
+        lines=[SimpleNamespace(line_id=1, text=phone)],
+    )
+
+
+def _address_details():
+    words = [
+        _word(2, 1, "123"),
+        _word(2, 2, "Main"),
+        _word(2, 3, "St"),
+        _word(3, 1, "Las Vegas, NV 89101"),
+    ]
+    return SimpleNamespace(
+        place=None,
+        words=words,
+        labels=[
+            _label(word.line_id, word.word_id, "ADDRESS_LINE")
+            for word in words
+        ],
+        lines=[
+            SimpleNamespace(line_id=2, text="123 Main St"),
+            SimpleNamespace(line_id=3, text="Las Vegas, NV 89101"),
+        ],
+    )
+
+
+def _place_clue_details(
+    *,
+    merchant="Right Cafe",
+    address="123 Main St, Las Vegas, NV 89101",
+    phone="(702) 555-0100",
+    current_place=None,
+):
+    values = [
+        (1, merchant, "MERCHANT_NAME"),
+        (2, address, "ADDRESS_LINE"),
+        (3, phone, "PHONE_NUMBER"),
+    ]
+    return SimpleNamespace(
+        place=current_place,
+        words=[_word(line_id, 1, text) for line_id, text, _ in values],
+        labels=[_label(line_id, 1, label) for line_id, _, label in values],
+        lines=[
+            SimpleNamespace(line_id=line_id, text=text)
+            for line_id, text, _ in values
+        ],
+    )
+
+
+class _FakePlaces:
+    def __init__(self, *, details=None, phone=None, address=None, text=None):
+        self.details = details
+        self.phone = phone
+        self.address = address
+        self.text = text
+        self.calls = []
+
+    def get_place_details(self, place_id):
+        self.calls.append(("details", place_id))
+        return self.details
+
+    def search_by_phone(self, phone):
+        self.calls.append(("phone", phone))
+        return self.phone
+
+    def search_by_address(self, address):
+        self.calls.append(("address", address))
+        return self.address
+
+    def search_by_text(self, text):
+        self.calls.append(("text", text))
+        return self.text
+
+
+def test_tier0_keeps_consistent_existing_place_without_llm():
+    current = SimpleNamespace(
+        place_id="ChIJ-test",
+        merchant_name="Test Market",
+        formatted_address="123 Main St, Las Vegas, NV 89101, USA",
+        phone_number="(702) 555-0100",
+    )
+    places = _FakePlaces(details=_place())
+
+    result, stats = asyncio.run(
+        resolve_tiered_place(_details(current_place=current), places)
+    )
+
+    assert result["resolution_tier"] == "tier0"
+    assert result["place_id"] == "ChIJ-test"
+    assert stats["llm_calls"] == 0
+    assert places.calls == [("details", "ChIJ-test")]
+
+
+def test_tier1_phone_match_resolves_without_llm():
+    places = _FakePlaces(phone=_place())
+
+    result, stats = asyncio.run(resolve_tiered_place(_details(), places))
+
+    assert result["resolution_tier"] == "tier1"
+    assert result["confidence"] == 0.95
+    assert result["search_methods_used"] == ["phone"]
+    assert stats["llm_calls"] == 0
+    assert [method for method, _ in places.calls] == ["phone"]
+
+
+def test_tier1_address_match_resolves_without_llm():
+    places = _FakePlaces(address=_place())
+
+    result, stats = asyncio.run(
+        resolve_tiered_place(_address_details(), places)
+    )
+
+    assert result["resolution_tier"] == "tier1"
+    assert result["confidence"] == 0.90
+    assert result["search_methods_used"] == ["address"]
+    assert stats["llm_calls"] == 0
+    assert [method for method, _ in places.calls] == ["address"]
+
+
+def test_tier1_address_match_returns_empty_phone_string():
+    places = _FakePlaces(address=_place(phone=None))
+
+    result, _ = asyncio.run(resolve_tiered_place(_address_details(), places))
+
+    assert result["resolution_tier"] == "tier1"
+    assert result["phone_number"] == ""
+
+
+def test_tier1_rejects_conflicting_high_confidence_candidates():
+    candidates = [
+        PlaceCandidate("p1", "One", None, None, 0.99, {"phone"}),
+        PlaceCandidate("p2", "Two", None, None, 0.95, {"address"}),
+    ]
+
+    assert select_deterministic_candidate(candidates, 0.90) is None
+
+
+def test_tier1_rejects_unrelated_phone_text_fallback(monkeypatch):
+    """A phone search result must return the same phone it was searched by."""
+    monkeypatch.setenv("FIX_PLACE_TIER2_ENABLED", "false")
+    unrelated = _place(
+        place_id="wrong",
+        name="Professional Roofing Services",
+        address="4180 W Patrick Ln, Las Vegas, NV 89118, USA",
+        phone="(702) 500-0670",
+    )
+    places = _FakePlaces(phone=unrelated)
+
+    result, stats = asyncio.run(resolve_tiered_place(_details(), places))
+
+    assert result is None
+    assert stats["llm_calls"] == 0
+
+
+def test_tier1_rejects_phone_match_with_conflicting_receipt_clues(
+    monkeypatch,
+):
+    monkeypatch.setenv("FIX_PLACE_TIER2_ENABLED", "false")
+    conflicting = _place(
+        place_id="wrong",
+        name="Wrong Market",
+        address="999 Main St, Las Vegas, NV 89101, USA",
+        phone="(702) 555-0100",
+    )
+    places = _FakePlaces(phone=conflicting)
+
+    result, stats = asyncio.run(
+        resolve_tiered_place(_place_clue_details(), places)
+    )
+
+    assert result is None
+    assert stats["llm_calls"] == 0
+
+
+def test_tier1_rejects_address_match_with_conflicting_receipt_clues(
+    monkeypatch,
+):
+    monkeypatch.setenv("FIX_PLACE_TIER2_ENABLED", "false")
+    conflicting = _place(
+        place_id="wrong",
+        name="Wrong Market",
+        address="123 Main St, Las Vegas, NV 89101, USA",
+        phone="(702) 555-0199",
+    )
+    places = _FakePlaces(address=conflicting)
+
+    result, stats = asyncio.run(
+        resolve_tiered_place(_place_clue_details(), places)
+    )
+
+    assert result is None
+    assert stats["llm_calls"] == 0
+
+
+def test_tier0_rejects_existing_place_with_conflicting_merchant():
+    current = SimpleNamespace(
+        place_id="wrong",
+        merchant_name="Wrong Market",
+        formatted_address="123 Main St, Las Vegas, NV 89101, USA",
+        phone_number="(702) 555-0100",
+    )
+    wrong = _place(
+        place_id="wrong",
+        name="Wrong Market",
+        address="123 Main St, Las Vegas, NV 89101, USA",
+        phone="(702) 555-0100",
+    )
+    right = _place(
+        place_id="right",
+        name="Right Cafe",
+        address="123 Main St, Las Vegas, NV 89101, USA",
+        phone="(702) 555-0100",
+    )
+    places = _FakePlaces(
+        details=wrong,
+        phone=wrong,
+        address=wrong,
+        text=right,
+    )
+
+    result, _ = asyncio.run(
+        resolve_tiered_place(
+            _place_clue_details(current_place=current),
+            places,
+        )
+    )
+
+    assert result["place_id"] == "right"
+    assert result["resolution_tier"] == "tier1"
+
+
+def test_text_search_uses_merchant_and_rejects_wrong_phone_result():
+    details = SimpleNamespace(
+        place=None,
+        words=[
+            _word(1, 1, "CRAFTKITCHEN"),
+            _word(2, 1, "10940"),
+            _word(2, 2, "S"),
+            _word(2, 3, "EASTERN"),
+            _word(2, 4, "AVE"),
+            _word(2, 5, "#107"),
+            _word(3, 1, "HENDERSON,"),
+            _word(3, 2, "NV"),
+            _word(3, 3, "89052"),
+            _word(4, 1, "702"),
+            _word(4, 2, "728"),
+            _word(4, 3, "5838"),
+        ],
+        labels=[
+            _label(1, 1, "MERCHANT_NAME"),
+            *[_label(2, word_id, "ADDRESS_LINE") for word_id in range(1, 6)],
+            *[_label(3, word_id, "ADDRESS_LINE") for word_id in range(1, 4)],
+            *[_label(4, word_id, "PHONE_NUMBER") for word_id in range(1, 4)],
+        ],
+        lines=[SimpleNamespace(line_id=1, text="CRAFTKITCHEN")],
+    )
+    unrelated = _place(
+        place_id="wrong",
+        name="Professional Roofing Services",
+        address="4180 W Patrick Ln, Las Vegas, NV 89118, USA",
+        phone="(702) 500-0670",
+    )
+    correct = _place(
+        place_id="craft",
+        name="CRAFT Kitchen",
+        address="10940 S Eastern Ave Suite 107, Henderson, NV 89052, USA",
+        phone=None,
+    )
+    address_only = _place(
+        place_id="address",
+        name="10940 S Eastern Ave Suite 107",
+        address="10940 S Eastern Ave Suite 107, Henderson, NV 89052, USA",
+        phone=None,
+        types=["street_address", "subpremise"],
+    )
+    places = _FakePlaces(phone=unrelated, address=address_only, text=correct)
+
+    result, stats = asyncio.run(resolve_tiered_place(details, places))
+
+    assert result["place_id"] == "craft"
+    assert result["resolution_tier"] == "tier1"
+    assert result["phone_number"] == "702 728 5838"
+    assert result["sources"]["phone_number"] == "receipt_labels"
+    assert stats["llm_calls"] == 0
+    text_call = next(
+        query for method, query in places.calls if method == "text"
+    )
+    assert text_call == "CRAFTKITCHEN"
+
+
+def test_address_clues_drop_stray_header_labels_before_street_number():
+    details = SimpleNamespace(
+        place=None,
+        words=[
+            _word(1, 1, "Henderson"),
+            _word(2, 1, "4300"),
+            _word(2, 2, "E Sunset Rd. Suite A3"),
+            _word(3, 1, "Henderson, NV 89014"),
+        ],
+        labels=[
+            _label(1, 1, "ADDRESS_LINE"),
+            _label(2, 1, "ADDRESS_LINE"),
+            _label(2, 2, "ADDRESS_LINE"),
+            _label(3, 1, "ADDRESS_LINE"),
+        ],
+        lines=[],
+    )
+
+    assert extract_receipt_clues(details).address == (
+        "4300 E Sunset Rd. Suite A3, Henderson, NV 89014"
+    )
+
+
+def test_address_matching_ignores_equivalent_unit_notation():
+    assert _addresses_match(
+        "10940 S EASTERN AVE #107, HENDERSON, NV 89052",
+        "10940 S Eastern Avenue Suite 107, Henderson, NV 89052, USA",
+    )
+
+
+def test_address_matching_requires_exact_street_number():
+    assert not _addresses_match(
+        "1 Main St, Las Vegas, NV 89101",
+        "11 Main St, Las Vegas, NV 89101",
+    )
+
+
+def test_tiered_resolution_escalates_without_receipt_place_evidence():
+    current = SimpleNamespace(
+        place_id="ChIJ-wrong",
+        merchant_name="Wrong Market",
+        formatted_address="11 Main St, Las Vegas, NV 89101, USA",
+        phone_number="(702) 555-0111",
+    )
+    details = SimpleNamespace(
+        place=current,
+        words=[_word(1, 1, "Wrong Market")],
+        labels=[_label(1, 1, "MERCHANT_NAME", status="INVALID")],
+        lines=[SimpleNamespace(line_id=1, text="Wrong Market")],
+    )
+    places = _FakePlaces(details=_place(place_id="ChIJ-wrong"))
+
+    result, stats = asyncio.run(resolve_tiered_place(details, places))
+
+    assert result is None
+    assert stats["llm_calls"] == 0
+    assert places.calls == []
+
+
+def test_tier2_makes_one_structured_picker_call():
+    candidate = PlaceCandidate(
+        "ChIJ-test",
+        "Test Market",
+        "123 Main St, Las Vegas, NV 89101, USA",
+        "(702) 555-0100",
+        0.80,
+        {"text"},
+    )
+    structured_llm = MagicMock()
+    structured_llm.ainvoke = AsyncMock(
+        return_value=Tier2Selection(
+            place_id="ChIJ-test",
+            confidence=0.91,
+            reasoning="Receipt name and address match.",
+        )
+    )
+    base_llm = MagicMock()
+    base_llm.with_structured_output.return_value = structured_llm
+
+    with patch(
+        "receipt_agent.subagents.place_finder.tiered.create_llm",
+        return_value=base_llm,
+    ) as create_llm:
+        result, _ = asyncio.run(
+            _select_with_llm(
+                ReceiptClues(
+                    merchant_name="Test Market",
+                    address="123 Main St",
+                    snippet="TEST MARKET\n123 MAIN ST",
+                ),
+                [candidate],
+            )
+        )
+
+    assert result["resolution_tier"] == "tier2"
+    assert result["place_id"] == "ChIJ-test"
+    structured_llm.ainvoke.assert_awaited_once()
+    assert create_llm.call_args.kwargs["model"] == "openai/gpt-oss-120b"
+    assert create_llm.call_args.kwargs["reasoning"] is True

--- a/receipt_agent/tests/test_tiered_place_resolution.py
+++ b/receipt_agent/tests/test_tiered_place_resolution.py
@@ -363,6 +363,44 @@ def test_address_clues_drop_stray_header_labels_before_street_number():
     )
 
 
+def test_address_clues_do_not_treat_zip_as_street_number():
+    details = SimpleNamespace(
+        place=None,
+        words=[
+            _word(1, 1, "Henderson, NV 89014"),
+            _word(2, 1, "4300"),
+            _word(2, 2, "E Sunset Rd. Suite A3"),
+            _word(3, 1, "Henderson, NV 89014"),
+        ],
+        labels=[
+            _label(1, 1, "ADDRESS_LINE"),
+            _label(2, 1, "ADDRESS_LINE"),
+            _label(2, 2, "ADDRESS_LINE"),
+            _label(3, 1, "ADDRESS_LINE"),
+        ],
+        lines=[],
+    )
+
+    assert extract_receipt_clues(details).address == (
+        "4300 E Sunset Rd. Suite A3, Henderson, NV 89014"
+    )
+
+
+def test_tier1_accepts_establishment_with_address_like_business_name():
+    business = _place(
+        name="54th Street Grill & Bar",
+        types=["restaurant", "establishment", "point_of_interest"],
+    )
+    places = _FakePlaces(phone=business)
+
+    result, stats = asyncio.run(resolve_tiered_place(_details(), places))
+
+    assert result["place_id"] == "ChIJ-test"
+    assert result["merchant_name"] == "54th Street Grill & Bar"
+    assert result["resolution_tier"] == "tier1"
+    assert stats["llm_calls"] == 0
+
+
 def test_address_matching_ignores_equivalent_unit_notation():
     assert _addresses_match(
         "10940 S EASTERN AVE #107, HENDERSON, NV 89052",

--- a/receipt_places/receipt_places/client.py
+++ b/receipt_places/receipt_places/client.py
@@ -285,6 +285,24 @@ class PlacesClient:
         if not details:
             return None
 
+        returned_phone = (
+            details.formatted_phone_number
+            or details.international_phone_number
+            or ""
+        )
+        returned_digits = self._extract_digits(returned_phone)
+        if not returned_digits or (
+            returned_digits[-10:] != digits[-10:]
+            if len(returned_digits) >= 10 and len(digits) >= 10
+            else returned_digits != digits
+        ):
+            logger.warning(
+                "Rejecting phone text-search fallback: returned place phone "
+                "does not match %s",
+                phone_number,
+            )
+            return None
+
         # Cache with phone digits as key
         details_response = {
             "status": "OK",
@@ -544,7 +562,19 @@ class PlacesClient:
                 "user_ratings_total",
             ]
 
-            expected_fields = set(fields)
+            # Google legitimately omits optional requested fields (for
+            # example phone, website, hours, or ratings). Requiring every
+            # field made otherwise valid address/phone results disappear from
+            # the fix-place cascade. Keep the quality gate on the stable
+            # identity and location fields; optional enrichment remains typed
+            # as ``None`` when Google does not return it.
+            expected_fields = {
+                "place_id",
+                "name",
+                "formatted_address",
+                "geometry",
+                "types",
+            }
 
             data = self._make_request(
                 "details/json",

--- a/receipt_places/tests/test_client.py
+++ b/receipt_places/tests/test_client.py
@@ -133,6 +133,58 @@ class TestSearchByPhone:
         result = places_client.search_by_phone("999-999-9999")
         assert result is None
 
+    @responses.activate
+    def test_search_by_phone_rejects_unrelated_text_fallback(
+        self,
+        places_client: PlacesClient,
+    ) -> None:
+        """A broad text result must not be cached as an exact phone match."""
+        responses.add(
+            responses.GET,
+            "https://maps.googleapis.com/maps/api/place/findplacefromtext/json",
+            json={"status": "ZERO_RESULTS", "candidates": []},
+            status=200,
+        )
+        responses.add(
+            responses.GET,
+            "https://maps.googleapis.com/maps/api/place/textsearch/json",
+            json={
+                "status": "OK",
+                "results": [
+                    {
+                        "place_id": "wrong-place",
+                        "name": "Unrelated Business",
+                        "formatted_address": "999 Wrong St, City, ST 12345",
+                        "types": ["roofing_contractor"],
+                    }
+                ],
+            },
+            status=200,
+        )
+        wrong_details = dict(SAMPLE_DETAILS_RESPONSE["result"])
+        wrong_details.update(
+            {
+                "place_id": "wrong-place",
+                "name": "Unrelated Business",
+                "formatted_phone_number": "(702) 500-0670",
+                "international_phone_number": "+1 702-500-0670",
+            }
+        )
+        responses.add(
+            responses.GET,
+            "https://maps.googleapis.com/maps/api/place/details/json",
+            json={"status": "OK", "result": wrong_details},
+            status=200,
+        )
+
+        result = places_client.search_by_phone("702-728-5838")
+
+        assert result is None
+        assert (
+            places_client._cache.get("PHONE", "7027285838")  # noqa: SLF001
+            is None
+        )
+
 
 class TestSearchByAddress:
     """Test address search functionality."""
@@ -317,6 +369,40 @@ class TestGetPlaceDetails:
         assert result.place_id == "ChIJtest123"
         assert result.name == "Test Business"
         assert result.formatted_phone_number == "(555) 123-4567"
+
+    @responses.activate
+    def test_get_place_details_allows_missing_optional_fields(
+        self,
+        places_client: PlacesClient,
+    ) -> None:
+        """Businesses need not publish phone, website, hours, or ratings."""
+        required = {
+            "place_id",
+            "name",
+            "formatted_address",
+            "geometry",
+            "types",
+        }
+        responses.add(
+            responses.GET,
+            "https://maps.googleapis.com/maps/api/place/details/json",
+            json={
+                "status": "OK",
+                "result": {
+                    key: value
+                    for key, value in SAMPLE_DETAILS_RESPONSE["result"].items()
+                    if key in required
+                },
+            },
+            status=200,
+        )
+
+        result = places_client.get_place_details("ChIJtest123")
+
+        assert result is not None
+        assert result.place_id == "ChIJtest123"
+        assert result.formatted_phone_number is None
+        assert result.website is None
 
     def test_get_place_details_empty(
         self,


### PR DESCRIPTION
## Summary

- attach the shared `CostTrackingCallback` to both place-finder graph paths, including the graph used by the live fix-place Lambda
- preserve OpenRouter usage and cost for tool-calling turns with LangChain `stream_usage`
- attach each turn's incremental cost to LangSmith so its root aggregation equals the real invocation charge
- emit one CloudWatch-friendly `fix_place_llm_usage` line per Lambda invocation, aggregated across retries

## Why

The raw bound-LLM graph path bypassed `LLMInvoker`, so OpenRouter returned tokens and cost but the cost callback was never invoked. LangSmith therefore showed tokens while `total_cost` remained null.

Live validation also caught a subtle aggregation issue: stamping every child turn with the callback's cumulative total caused LangSmith to overcount the root. Each child now receives only its own turn cost, while the callback and CloudWatch retain cumulative invocation totals.

Closes the observability portion of #1156.

## Validation

- `python3.12 -m pytest tests/test_openrouter_cost_tracking.py tests/test_place_finder_cost_tracking.py -q` — 5 passed
- modified Python modules compile successfully
- CloudWatch emits one aggregate cost/token line with cost, LLM calls, and prompt/completion/total tokens

### Live LangSmith proof

A two-turn OpenRouter validation in the `fix-place` project produced trace `019f67fc-a14e-77c1-b9dc-cfa00d5a3d9b`:

- callback: `total_cost=$0.0002262`, `total_tokens=388`, `llm_calls=2`
- LangSmith root: `total_cost=$0.0002262`, `total_tokens=388`
- child turns: `$0.0001131` each

The LangSmith dollar total is non-null and exactly matches the callback's real cumulative OpenRouter cost.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tiered place resolution using receipt clues, deterministic matching, and optional AI assistance.
  * Added configurable resolution modes, models, retry limits, and agent execution controls.
  * Added resolution tier, success status, and AI usage details to processing results and logs.
* **Bug Fixes**
  * Prevented unrelated places from being returned during phone-search fallback.
  * Allowed missing optional place details without failing.
  * Explicitly empty phone values now clear outdated phone information.
* **Tests**
  * Added coverage for tiered resolution, agent limits, cost tracking, fallback validation, and place updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->