### PR TITLE
fix-place: add tiered low-cost place resolution

### DIFF
--- a/infra/fix_place_lambda/infrastructure.py
+++ b/infra/fix_place_lambda/infrastructure.py
@@ -103,8 +103,7 @@ class FixPlaceLambda(ComponentResource):
             f"{name}-lambda-basic-exec",
             role=lambda_role.name,
             policy_arn=(
-                "arn:aws:iam::aws:policy/service-role/"
-                "AWSLambdaBasicExecutionRole"
+                "arn:aws:iam::aws:policy/service-role/" "AWSLambdaBasicExecutionRole"
             ),
             opts=ResourceOptions(parent=lambda_role),
         )
@@ -188,16 +187,10 @@ class FixPlaceLambda(ComponentResource):
                     or ("tiered" if stack == "dev" else "agent")
                 ),
                 "FIX_PLACE_TIER2_MODEL": (
-                    config.get("fix_place_tier2_model")
-                    or "openai/gpt-oss-120b"
+                    config.get("fix_place_tier2_model") or "openai/gpt-oss-120b"
                 ),
                 "FIX_PLACE_AGENT_MODEL": (
-                    config.get("fix_place_agent_model")
-                    or (
-                        "x-ai/grok-4.1-fast"
-                        if stack == "dev"
-                        else "x-ai/grok-4.3"
-                    )
+                    config.get("fix_place_agent_model") or "x-ai/grok-4.3"
                 ),
                 "FIX_PLACE_AGENT_RECURSION_LIMIT": "12",
                 "FIX_PLACE_AGENT_MAX_ROUNDS": "3",
@@ -211,9 +204,7 @@ class FixPlaceLambda(ComponentResource):
                 "LANGCHAIN_API_KEY": langchain_api_key,
                 "LANGCHAIN_TRACING_V2": "true",
                 "LANGCHAIN_ENDPOINT": ("https://api.smith.langchain.com"),
-                "LANGCHAIN_PROJECT": (
-                    config.get("langchain_project") or "fix-place"
-                ),
+                "LANGCHAIN_PROJECT": (config.get("langchain_project") or "fix-place"),
             },
         }
 

--- a/infra/fix_place_lambda/infrastructure.py
+++ b/infra/fix_place_lambda/infrastructure.py
@@ -181,6 +181,26 @@ class FixPlaceLambda(ComponentResource):
                 # OpenRouter (for LLM calls)
                 "OPENROUTER_API_KEY": openrouter_api_key,
                 "OPENROUTER_MODEL": "x-ai/grok-4.3",
+                # Dev opts into tiered resolution; other stacks retain the
+                # legacy agent path until the quality gate is promoted.
+                "FIX_PLACE_RESOLUTION_MODE": (
+                    config.get("fix_place_resolution_mode")
+                    or ("tiered" if stack == "dev" else "agent")
+                ),
+                "FIX_PLACE_TIER2_MODEL": (
+                    config.get("fix_place_tier2_model")
+                    or "openai/gpt-oss-120b"
+                ),
+                "FIX_PLACE_AGENT_MODEL": (
+                    config.get("fix_place_agent_model")
+                    or (
+                        "x-ai/grok-4.1-fast"
+                        if stack == "dev"
+                        else "x-ai/grok-4.3"
+                    )
+                ),
+                "FIX_PLACE_AGENT_RECURSION_LIMIT": "12",
+                "FIX_PLACE_AGENT_MAX_ROUNDS": "3",
                 # OpenAI (for embeddings)
                 "RECEIPT_AGENT_OPENAI_API_KEY": openai_api_key,
                 # Chroma Cloud

--- a/infra/fix_place_lambda/lambdas/fix_place.py
+++ b/infra/fix_place_lambda/lambdas/fix_place.py
@@ -34,6 +34,10 @@ Environment Variables:
     CHROMA_CLOUD_API_KEY: Chroma Cloud API key
     CHROMA_CLOUD_TENANT: Chroma Cloud tenant ID
     CHROMA_CLOUD_DATABASE: Chroma Cloud database name
+    FIX_PLACE_RESOLUTION_MODE: "agent" or "tiered"
+    FIX_PLACE_TIER2_MODEL: Cheap structured picker model
+    FIX_PLACE_AGENT_MODEL: Tier 3 tool-calling model
+    FIX_PLACE_AGENT_RECURSION_LIMIT: Hard graph step cap (maximum 12)
 """
 
 import asyncio
@@ -109,7 +113,7 @@ async def _run_place_finder(
     receipt_id: int,
     reason: str,
 ) -> tuple[dict[str, Any], Any, dict[str, Any]]:
-    """Run the LangGraph place finder agent for a single receipt."""
+    """Resolve one receipt through deterministic, picker, then agent tiers."""
     # pylint: disable=import-outside-toplevel
     from receipt_agent.clients.factory import (
         create_embed_fn,
@@ -124,8 +128,30 @@ async def _run_place_finder(
 
     table_name = os.environ["DYNAMODB_TABLE_NAME"]
     dynamo_client = DynamoClient(table_name=table_name)
+    details = dynamo_client.get_receipt_details(image_id, receipt_id)
+    places_client = create_places_client()
+    tiered_stats: dict[str, Any] = {}
 
-    # Create Chroma Cloud client
+    resolution_mode = os.environ.get(
+        "FIX_PLACE_RESOLUTION_MODE", "agent"
+    ).lower()
+    if resolution_mode == "tiered":
+        from receipt_agent.subagents.place_finder.tiered import (
+            resolve_tiered_place,
+        )
+
+        tiered_result, tiered_stats = await resolve_tiered_place(
+            details, places_client
+        )
+        if tiered_result is not None:
+            return tiered_result, details, tiered_stats
+    elif resolution_mode != "agent":
+        logger.warning(
+            "Unknown FIX_PLACE_RESOLUTION_MODE=%s; using agent fallback",
+            resolution_mode,
+        )
+
+    # Tier 3 only: initialize the clients needed by the full agent.
     cloud_api_key = os.environ.get("CHROMA_CLOUD_API_KEY", "")
     cloud_tenant = os.environ.get("CHROMA_CLOUD_TENANT")
     cloud_database = os.environ.get("CHROMA_CLOUD_DATABASE")
@@ -138,7 +164,6 @@ async def _run_place_finder(
     )
 
     embed_fn = create_embed_fn()
-    places_client = create_places_client()
 
     graph, state_holder = create_receipt_place_finder_graph(
         dynamo_client=dynamo_client,
@@ -147,9 +172,6 @@ async def _run_place_finder(
         places_api=places_client,
     )
 
-    # Get receipt details for pre-loading
-    details = dynamo_client.get_receipt_details(image_id, receipt_id)
-
     result = await run_receipt_place_finder(
         graph=graph,
         state_holder=state_holder,
@@ -157,11 +179,15 @@ async def _run_place_finder(
         receipt_id=receipt_id,
         receipt_lines=details.lines,
         receipt_words=details.words,
+        receipt_labels=details.labels,
         reason=reason,
     )
+    result["resolution_tier"] = "tier3"
 
     cost_callback = state_holder.get("cost_callback")
     llm_stats = cost_callback.get_stats() if cost_callback else {}
+    for key, value in tiered_stats.items():
+        llm_stats[key] = llm_stats.get(key, 0) + value
     return result, details, llm_stats
 
 
@@ -187,6 +213,8 @@ def handler(  # pylint: disable=unused-argument
         "completion_tokens": 0,
         "total_tokens": 0,
     }
+    resolution_tier = "none"
+    resolution_succeeded = False
     try:
         # Validate input
         reason = event.get("reason", "User reported incorrect merchant")
@@ -223,12 +251,14 @@ def handler(  # pylint: disable=unused-argument
             )
             for key in invocation_llm_stats:
                 invocation_llm_stats[key] += attempt_llm_stats.get(key, 0)
+            resolution_tier = agent_result.get("resolution_tier", "tier3")
             if (
                 agent_result
                 and agent_result.get("found")
                 and agent_result.get("merchant_name")
                 and agent_result.get("place_id")
             ):
+                resolution_succeeded = True
                 break
             logger.warning(
                 "place_finder attempt %d/%d incomplete: found=%s merchant=%s "
@@ -315,6 +345,7 @@ def handler(  # pylint: disable=unused-argument
             "reasoning": agent_result.get("reasoning", ""),
             "fields_found": agent_result.get("fields_found", []),
             "sources": agent_result.get("sources", {}),
+            "resolution_tier": resolution_tier,
         }
 
         logger.info("Successfully fixed place: %s", response)
@@ -330,6 +361,14 @@ def handler(  # pylint: disable=unused-argument
         }
 
     finally:
+        logger.info(
+            "fix_place_resolution image_id=%s receipt_id=%s tier=%s "
+            "success=%s",
+            image_id,
+            receipt_id,
+            resolution_tier,
+            resolution_succeeded,
+        )
         logger.info(
             "fix_place_llm_usage image_id=%s receipt_id=%s cost_usd=%.8f "
             "llm_calls=%d prompt_tokens=%d completion_tokens=%d "

--- a/infra/fix_place_lambda/lambdas/fix_place.py
+++ b/infra/fix_place_lambda/lambdas/fix_place.py
@@ -132,17 +132,13 @@ async def _run_place_finder(
     places_client = create_places_client()
     tiered_stats: dict[str, Any] = {}
 
-    resolution_mode = os.environ.get(
-        "FIX_PLACE_RESOLUTION_MODE", "agent"
-    ).lower()
+    resolution_mode = os.environ.get("FIX_PLACE_RESOLUTION_MODE", "agent").lower()
     if resolution_mode == "tiered":
         from receipt_agent.subagents.place_finder.tiered import (
             resolve_tiered_place,
         )
 
-        tiered_result, tiered_stats = await resolve_tiered_place(
-            details, places_client
-        )
+        tiered_result, tiered_stats = await resolve_tiered_place(details, places_client)
         if tiered_result is not None:
             return tiered_result, details, tiered_stats
     elif resolution_mode != "agent":
@@ -234,20 +230,18 @@ def handler(  # pylint: disable=unused-argument
 
         _propagate_env_vars()
 
-        # The agent occasionally returns found=true with merchant_name but
-        # empty/None place_id. place_id is the canonical key — without it
-        # we can't write a usable ReceiptPlace. Retry up to MAX_ATTEMPTS,
-        # augmenting the reason on each retry so the agent knows to find
-        # the Google Places place_id explicitly.
-        MAX_ATTEMPTS = 3
+        # The legacy agent occasionally returns found=true with merchant_name
+        # but no place_id, so retain its historical retry behavior. Tiered
+        # mode already contains a bounded agent and a single structured picker;
+        # rerunning the whole cascade would multiply both limits and cost.
+        resolution_mode = os.environ.get("FIX_PLACE_RESOLUTION_MODE", "agent").lower()
+        max_attempts = 1 if resolution_mode == "tiered" else 3
         agent_result = None
         details = None
         attempted_reason = reason
-        for attempt in range(1, MAX_ATTEMPTS + 1):
-            agent_result, details, attempt_llm_stats = (
-                _loop.run_until_complete(
-                    _run_place_finder(image_id, receipt_id, attempted_reason)
-                )
+        for attempt in range(1, max_attempts + 1):
+            agent_result, details, attempt_llm_stats = _loop.run_until_complete(
+                _run_place_finder(image_id, receipt_id, attempted_reason)
             )
             for key in invocation_llm_stats:
                 invocation_llm_stats[key] += attempt_llm_stats.get(key, 0)
@@ -264,7 +258,7 @@ def handler(  # pylint: disable=unused-argument
                 "place_finder attempt %d/%d incomplete: found=%s merchant=%s "
                 "place_id=%s",
                 attempt,
-                MAX_ATTEMPTS,
+                max_attempts,
                 bool(agent_result and agent_result.get("found")),
                 bool(agent_result and agent_result.get("merchant_name")),
                 bool(agent_result and agent_result.get("place_id")),
@@ -287,7 +281,7 @@ def handler(  # pylint: disable=unused-argument
                 "image_id": image_id,
                 "receipt_id": receipt_id,
                 "old_merchant": old_merchant,
-                "attempts": MAX_ATTEMPTS,
+                "attempts": max_attempts,
                 "reasoning": (
                     agent_result.get("reasoning", "") if agent_result else ""
                 ),
@@ -297,9 +291,7 @@ def handler(  # pylint: disable=unused-argument
         if not agent_result.get("merchant_name"):
             return {
                 "success": False,
-                "error": (
-                    "Agent found a place but merchant_name " "is missing"
-                ),
+                "error": ("Agent found a place but merchant_name " "is missing"),
                 "image_id": image_id,
                 "receipt_id": receipt_id,
                 "old_merchant": old_merchant,
@@ -315,12 +307,12 @@ def handler(  # pylint: disable=unused-argument
                 "error": (
                     f"Agent found a place named "
                     f"'{agent_result.get('merchant_name')}' but no "
-                    f"Google Places place_id after {MAX_ATTEMPTS} attempts"
+                    f"Google Places place_id after {max_attempts} attempts"
                 ),
                 "image_id": image_id,
                 "receipt_id": receipt_id,
                 "old_merchant": old_merchant,
-                "attempts": MAX_ATTEMPTS,
+                "attempts": max_attempts,
                 "reasoning": agent_result.get("reasoning", ""),
                 "fields_found": agent_result.get("fields_found", []),
             }
@@ -362,8 +354,7 @@ def handler(  # pylint: disable=unused-argument
 
     finally:
         logger.info(
-            "fix_place_resolution image_id=%s receipt_id=%s tier=%s "
-            "success=%s",
+            "fix_place_resolution image_id=%s receipt_id=%s tier=%s " "success=%s",
             image_id,
             receipt_id,
             resolution_tier,
@@ -417,9 +408,7 @@ def _update_receipt_place(
         current_place.confidence = confidence
         current_place.reasoning = reasoning
         current_place.validated_by = "INFERENCE"
-        current_place.validation_status = (
-            "MATCHED" if confidence >= 0.8 else "UNSURE"
-        )
+        current_place.validation_status = "MATCHED" if confidence >= 0.8 else "UNSURE"
         current_place.timestamp = now
 
         dynamo_client.update_receipt_place(current_place)

--- a/receipt_agent/receipt_agent/agents/place_id_finder/graph.py
+++ b/receipt_agent/receipt_agent/agents/place_id_finder/graph.py
@@ -36,6 +36,17 @@ from receipt_agent.utils.llm_factory import CostTrackingCallback, create_llm
 logger = logging.getLogger(__name__)
 
 
+def _agent_recursion_limit() -> int:
+    """Return the hard-capped place-agent recursion limit."""
+    try:
+        configured = int(
+            os.environ.get("FIX_PLACE_AGENT_RECURSION_LIMIT", "12")
+        )
+    except ValueError:
+        configured = 12
+    return max(4, min(configured, 12))
+
+
 # ==============================================================================
 # System Prompt
 # ==============================================================================
@@ -352,6 +363,14 @@ def create_place_id_finder_graph(
         # If no messages or no tool calls, go back to agent
         return "agent"
 
+    def after_tools(_state: PlaceIdFinderState) -> str:
+        """Stop immediately after submit_place_id succeeds."""
+        return (
+            "end"
+            if state_holder.get("place_id_result") is not None
+            else "agent"
+        )
+
     # Build the graph
     workflow = StateGraph(PlaceIdFinderState)
 
@@ -373,8 +392,11 @@ def create_place_id_finder_graph(
         },
     )
 
-    # After tools, go back to agent
-    workflow.add_edge("tools", "agent")
+    workflow.add_conditional_edges(
+        "tools",
+        after_tools,
+        {"agent": "agent", "end": END},
+    )
 
     # Compile
     compiled = workflow.compile()
@@ -449,7 +471,7 @@ async def run_place_id_finder(
     try:
         # Configure LangSmith tracing if available
         config: dict[str, Any] = {
-            "recursion_limit": 100,  # Increased to prevent early termination
+            "recursion_limit": _agent_recursion_limit(),
             "configurable": {
                 "thread_id": f"{image_id}#{receipt_id}",  # Unique thread ID for this receipt
             },
@@ -467,7 +489,7 @@ async def run_place_id_finder(
                 "LANGCHAIN_PROJECT", "receipt-label-validation"
             )
             config["run_name"] = "place_id_finder_agent"
-            config["tags"] = ["place_id_finder", "tier2"]
+            config["tags"] = ["place_id_finder", "tier3"]
 
         # Pass callbacks for parent trace context and always include the shared
         # cost handler. Graph-level callbacks propagate to every LLM turn.

--- a/receipt_agent/receipt_agent/agents/place_id_finder/graph.py
+++ b/receipt_agent/receipt_agent/agents/place_id_finder/graph.py
@@ -37,14 +37,8 @@ logger = logging.getLogger(__name__)
 
 
 def _agent_recursion_limit() -> int:
-    """Return the hard-capped place-agent recursion limit."""
-    try:
-        configured = int(
-            os.environ.get("FIX_PLACE_AGENT_RECURSION_LIMIT", "12")
-        )
-    except ValueError:
-        configured = 12
-    return max(4, min(configured, 12))
+    """Preserve the upload place-ID finder's established execution budget."""
+    return 100
 
 
 # ==============================================================================

--- a/receipt_agent/receipt_agent/subagents/place_finder/graph.py
+++ b/receipt_agent/receipt_agent/subagents/place_finder/graph.py
@@ -9,7 +9,12 @@ import logging
 import os
 from typing import Any, Callable, Optional
 
-from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+from langchain_core.messages import (
+    AIMessage,
+    HumanMessage,
+    SystemMessage,
+    ToolMessage,
+)
 from langchain_core.tools import tool
 from langgraph.graph import END, StateGraph
 from langgraph.prebuilt import ToolNode
@@ -51,14 +56,70 @@ def _bounded_env_int(
     return max(minimum, min(value, maximum))
 
 
+def _tiered_mode_enabled() -> bool:
+    """Return whether fix-place is using the constrained tiered rollout."""
+    return (
+        os.environ.get("FIX_PLACE_RESOLUTION_MODE", "agent").lower()
+        == "tiered"
+    )
+
+
+def _receipt_place_recursion_limit() -> int:
+    """Constrain Tier 3 while preserving the legacy agent-mode budget."""
+    if not _tiered_mode_enabled():
+        return 100
+    return _bounded_env_int(
+        "FIX_PLACE_AGENT_RECURSION_LIMIT", 12, 12, minimum=4
+    )
+
+
 def _compact_agent_messages(messages: list[Any]) -> list[Any]:
-    """Keep the initial request plus recent tool context for the next turn."""
+    """Keep the initial request plus complete recent tool-call groups."""
     if len(messages) <= 8:
         return list(messages)
+
     prefix = list(messages[:2])
-    return prefix + [
-        message for message in messages[-6:] if message not in prefix
+    groups: list[list[Any]] = []
+    for message in messages[2:]:
+        if isinstance(message, ToolMessage):
+            if not groups or not isinstance(groups[-1][0], AIMessage):
+                continue
+            expected_ids = {
+                tool_call.get("id") for tool_call in groups[-1][0].tool_calls
+            }
+            if message.tool_call_id in expected_ids:
+                groups[-1].append(message)
+            continue
+        groups.append([message])
+
+    complete_groups = []
+    for group in groups:
+        first = group[0]
+        if isinstance(first, AIMessage) and first.tool_calls:
+            expected_ids = {
+                tool_call.get("id") for tool_call in first.tool_calls
+            }
+            result_ids = {
+                message.tool_call_id
+                for message in group[1:]
+                if isinstance(message, ToolMessage)
+            }
+            if not expected_ids.issubset(result_ids):
+                continue
+        complete_groups.append(group)
+
+    selected_groups: list[list[Any]] = []
+    selected_count = 0
+    for group in reversed(complete_groups):
+        if selected_groups and selected_count + len(group) > 6:
+            break
+        selected_groups.append(group)
+        selected_count += len(group)
+
+    compacted = [
+        message for group in reversed(selected_groups) for message in group
     ]
+    return prefix + compacted
 
 
 # ======================================================================
@@ -409,17 +470,25 @@ def create_receipt_place_finder_graph(
         ),
         agent_name="place_finder_final_submit",
     )
-    max_rounds = _bounded_env_int("FIX_PLACE_AGENT_MAX_ROUNDS", 3, 3)
+    constrained_tier3 = _tiered_mode_enabled()
+    max_rounds = (
+        _bounded_env_int("FIX_PLACE_AGENT_MAX_ROUNDS", 3, 3)
+        if constrained_tier3
+        else None
+    )
 
     def agent_node(state: ReceiptPlaceFinderState) -> dict:
-        """Use compact history and force the final structured submission."""
+        """Apply rollout limits only to the tiered fix-place path."""
+        if not constrained_tier3:
+            return normal_agent_node(state)
+
         compact_state = state.model_copy(
             update={"messages": _compact_agent_messages(state.messages)}
         )
         completed_rounds = sum(
             isinstance(message, AIMessage) for message in state.messages
         )
-        if completed_rounds >= max_rounds:
+        if max_rounds is not None and completed_rounds >= max_rounds:
             logger.warning(
                 "Place finder reached %d rounds; forcing submit_place",
                 completed_rounds,
@@ -612,9 +681,7 @@ async def run_receipt_place_finder(
     # Run the workflow
     try:
         config = {
-            "recursion_limit": _bounded_env_int(
-                "FIX_PLACE_AGENT_RECURSION_LIMIT", 12, 12, minimum=4
-            ),
+            "recursion_limit": _receipt_place_recursion_limit(),
             "configurable": {
                 "thread_id": f"{image_id}#{receipt_id}",
             },

--- a/receipt_agent/receipt_agent/subagents/place_finder/graph.py
+++ b/receipt_agent/receipt_agent/subagents/place_finder/graph.py
@@ -511,6 +511,18 @@ def create_receipt_place_finder_graph(
             last_message = state.messages[-1]
             if isinstance(last_message, AIMessage) and last_message.tool_calls:
                 return "tools"
+            if not constrained_tier3:
+                if len(state.messages) > 20:
+                    logger.error(
+                        "Legacy place agent exceeded 20 messages without "
+                        "submitting; ending the stalled run"
+                    )
+                    return "end"
+                if len(state.messages) > 10:
+                    logger.warning(
+                        "Legacy place agent has made many steps without "
+                        "submitting"
+                    )
             return "agent"
 
         return "agent"

--- a/receipt_agent/receipt_agent/subagents/place_finder/graph.py
+++ b/receipt_agent/receipt_agent/subagents/place_finder/graph.py
@@ -26,7 +26,7 @@ from receipt_agent.subagents.place_finder.state import (
 from receipt_agent.utils.agent_common import create_agent_node_with_retry
 from receipt_agent.utils.llm_factory import (
     CostTrackingCallback,
-    create_llm_from_settings,
+    create_llm,
 )
 
 
@@ -37,6 +37,28 @@ def _build_line_id(image_id: str, receipt_id: int, line_id: int) -> str:
 
 
 logger = logging.getLogger(__name__)
+
+
+def _bounded_env_int(
+    name: str, default: int, maximum: int, minimum: int = 1
+) -> int:
+    """Read a positive integer environment value within a safe bound."""
+    try:
+        value = int(os.environ.get(name, str(default)))
+    except ValueError:
+        logger.warning("Invalid %s; using %d", name, default)
+        return default
+    return max(minimum, min(value, maximum))
+
+
+def _compact_agent_messages(messages: list[Any]) -> list[Any]:
+    """Keep the initial request plus recent tool context for the next turn."""
+    if len(messages) <= 8:
+        return list(messages)
+    prefix = list(messages[:2])
+    return prefix + [
+        message for message in messages[-6:] if message not in prefix
+    ]
 
 
 # ======================================================================
@@ -362,20 +384,48 @@ def create_receipt_place_finder_graph(
     # shared OpenRouter usage callback explicitly in the runner below.
     state_holder["cost_callback"] = CostTrackingCallback()
 
-    # Create LLM with tools bound (reasoning disabled to avoid
-    # hidden cost/latency on every tool-calling step)
-    llm = create_llm_from_settings(
+    # Keep the model independently configurable for gradual rollout. Without
+    # the fix-place override this preserves the existing application model.
+    model = (
+        os.environ.get("FIX_PLACE_AGENT_MODEL") or settings.openrouter_model
+    )
+    base_llm = create_llm(
+        model=model,
+        base_url=settings.openrouter_base_url,
+        api_key=settings.openrouter_api_key.get_secret_value(),
         temperature=0.0,
+        timeout=120,
         reasoning=False,
         stream_usage=True,
     )
-    llm = llm.bind_tools(tools)
-
-    # Create agent node with retry logic using shared utility
-    agent_node = create_agent_node_with_retry(
-        llm=llm,
+    normal_agent_node = create_agent_node_with_retry(
+        llm=base_llm.bind_tools(tools),
         agent_name="place_finder",
     )
+    forced_submit_node = create_agent_node_with_retry(
+        llm=base_llm.bind_tools(
+            [submit_tool],
+            tool_choice="submit_place",
+        ),
+        agent_name="place_finder_final_submit",
+    )
+    max_rounds = _bounded_env_int("FIX_PLACE_AGENT_MAX_ROUNDS", 3, 3)
+
+    def agent_node(state: ReceiptPlaceFinderState) -> dict:
+        """Use compact history and force the final structured submission."""
+        compact_state = state.model_copy(
+            update={"messages": _compact_agent_messages(state.messages)}
+        )
+        completed_rounds = sum(
+            isinstance(message, AIMessage) for message in state.messages
+        )
+        if completed_rounds >= max_rounds:
+            logger.warning(
+                "Place finder reached %d rounds; forcing submit_place",
+                completed_rounds,
+            )
+            return forced_submit_node(compact_state)
+        return normal_agent_node(compact_state)
 
     # Define tool node
     tool_node = ToolNode(tools)
@@ -390,24 +440,17 @@ def create_receipt_place_finder_graph(
         # Check last message for tool calls
         if state.messages:
             last_message = state.messages[-1]
-            if isinstance(last_message, AIMessage):
-                if last_message.tool_calls:
-                    return "tools"
-                # Give it another chance if no tool calls
-                if len(state.messages) > 10:
-                    logger.warning(
-                        "Agent has made many steps without submitting"
-                        " - may need reminder"
-                    )
-            if len(state.messages) > 20:
-                logger.error(
-                    "Agent exceeded 20 steps without submitting"
-                    " - forcing end"
-                )
-                return "end"
+            if isinstance(last_message, AIMessage) and last_message.tool_calls:
+                return "tools"
             return "agent"
 
         return "agent"
+
+    def after_tools(_state: ReceiptPlaceFinderState) -> str:
+        """Stop immediately after submit_place instead of paying for another turn."""
+        return (
+            "end" if state_holder.get("place_result") is not None else "agent"
+        )
 
     # Build the graph
     workflow = StateGraph(ReceiptPlaceFinderState)
@@ -430,8 +473,11 @@ def create_receipt_place_finder_graph(
         },
     )
 
-    # After tools, go back to agent
-    workflow.add_edge("tools", "agent")
+    workflow.add_conditional_edges(
+        "tools",
+        after_tools,
+        {"agent": "agent", "end": END},
+    )
 
     # Compile
     compiled = workflow.compile()
@@ -453,6 +499,7 @@ async def run_receipt_place_finder(
     word_embeddings: Optional[dict[str, list[float]]] = None,
     receipt_lines: Optional[list] = None,
     receipt_words: Optional[list] = None,
+    receipt_labels: Optional[list] = None,
     reason: Optional[str] = None,
 ) -> dict:
     """
@@ -469,6 +516,7 @@ async def run_receipt_place_finder(
             read)
         receipt_words: Pre-loaded receipt words (optional, avoids DynamoDB
             read)
+        receipt_labels: Pre-loaded word labels used to annotate receipt words
         reason: Why the current place data is wrong (optional hint for
             the agent)
 
@@ -493,6 +541,14 @@ async def run_receipt_place_finder(
             for line in receipt_lines
         ]
 
+    labels_by_word: dict[tuple[int, int], list[str]] = {}
+    for label in receipt_labels or []:
+        status = str(getattr(label, "validation_status", "")).upper()
+        if status.endswith("INVALID"):
+            continue
+        key = (label.line_id, label.word_id)
+        labels_by_word.setdefault(key, []).append(label.label)
+
     if receipt_words:
         # Convert ReceiptWord entities to dict format expected by tools
         words_dict = [
@@ -500,7 +556,10 @@ async def run_receipt_place_finder(
                 "line_id": word.line_id,
                 "word_id": word.word_id,
                 "text": word.text,
-                "label": getattr(word, "label", None),
+                "label": (
+                    labels_by_word.get((word.line_id, word.word_id), [None])[0]
+                ),
+                "labels": labels_by_word.get((word.line_id, word.word_id), []),
             }
             for word in receipt_words
         ]
@@ -553,7 +612,9 @@ async def run_receipt_place_finder(
     # Run the workflow
     try:
         config = {
-            "recursion_limit": 100,
+            "recursion_limit": _bounded_env_int(
+                "FIX_PLACE_AGENT_RECURSION_LIMIT", 12, 12, minimum=4
+            ),
             "configurable": {
                 "thread_id": f"{image_id}#{receipt_id}",
             },

--- a/receipt_agent/receipt_agent/subagents/place_finder/tiered.py
+++ b/receipt_agent/receipt_agent/subagents/place_finder/tiered.py
@@ -209,9 +209,7 @@ def extract_receipt_clues(details: Any) -> ReceiptClues:
 
 
 def _phone_digits(value: str | None) -> str:
-    return "".join(
-        character for character in (value or "") if character.isdigit()
-    )
+    return "".join(character for character in (value or "") if character.isdigit())
 
 
 def _phones_match(left: str | None, right: str | None) -> bool:
@@ -239,7 +237,27 @@ def _names_match(left: str | None, right: str | None) -> bool:
 
 
 def _street(value: str | None) -> str:
-    return _normalized_text((value or "").split(",", maxsplit=1)[0])
+    street = (value or "").split(",", maxsplit=1)[0]
+    # Unit notation is especially inconsistent between receipt OCR and
+    # Google Places ("#107" vs "Suite 107").  It is not part of the street
+    # identity, so remove it before comparing the primary address line.
+    street = re.sub(
+        r"(?:\b(?:suite|ste|unit|apt|apartment)\b|#)\s*[A-Z0-9-]+.*$",
+        "",
+        street,
+        flags=re.IGNORECASE,
+    )
+    normalized = _normalized_text(street)
+    replacements = {
+        "street": "st",
+        "avenue": "ave",
+        "boulevard": "blvd",
+        "road": "rd",
+        "drive": "dr",
+        "lane": "ln",
+        "highway": "hwy",
+    }
+    return " ".join(replacements.get(token, token) for token in normalized.split())
 
 
 def _addresses_match(left: str | None, right: str | None) -> bool:
@@ -266,26 +284,59 @@ def _place_phone(place: Any) -> str | None:
     )
 
 
-def _candidate_score(
-    clues: ReceiptClues, place: Any, search_method: str
-) -> float:
-    base = {"phone": 0.95, "address": 0.80, "text": 0.60}.get(
-        search_method, 0.50
+def _candidate_score(clues: ReceiptClues, place: Any, search_method: str) -> float:
+    name_match = _names_match(clues.merchant_name, _value(place, "name"))
+    address_match = _addresses_match(clues.address, _value(place, "formatted_address"))
+    phone_match = _phones_match(clues.phone, _place_phone(place))
+
+    # A search method is not evidence by itself.  In particular, the Places
+    # client's phone fallback is a broad text search and can return an
+    # unrelated business.  Require the returned place to agree with the
+    # primary receipt clue before granting that method's base confidence.
+    if search_method == "phone":
+        if not phone_match:
+            return 0.0
+        return min(
+            1.0, 0.95 + (0.03 if address_match else 0.0) + (0.02 if name_match else 0.0)
+        )
+    if search_method == "address":
+        if not address_match:
+            return 0.0
+        return min(
+            1.0, 0.90 + (0.05 if name_match else 0.0) + (0.05 if phone_match else 0.0)
+        )
+    if search_method == "text":
+        if not name_match:
+            return 0.0
+        return min(
+            1.0,
+            0.75 + (0.15 if address_match else 0.0) + (0.10 if phone_match else 0.0),
+        )
+
+    # Existing place IDs only reach Tier 0 when their labeled evidence is
+    # consistent.  Keep inconsistent existing candidates available to the
+    # structured picker, but never let them qualify for Tier 1 on base score.
+    return (
+        0.50
+        + (0.15 if name_match else 0.0)
+        + (0.15 if address_match else 0.0)
+        + (0.20 if phone_match else 0.0)
     )
-    comparisons = []
-    if clues.merchant_name and _value(place, "name"):
-        comparisons.append(
-            _names_match(clues.merchant_name, _value(place, "name"))
+
+
+def _primary_evidence_matches(
+    place: Any, clues: ReceiptClues, search_method: str
+) -> bool:
+    """Reject broad Places fallbacks that disagree with their receipt clue."""
+    if search_method == "phone":
+        return _phones_match(clues.phone, _place_phone(place))
+    if search_method == "address":
+        return _addresses_match(
+            clues.address, _clean(_value(place, "formatted_address"))
         )
-    if clues.address and _value(place, "formatted_address"):
-        comparisons.append(
-            _addresses_match(clues.address, _value(place, "formatted_address"))
-        )
-    if clues.phone and _place_phone(place):
-        comparisons.append(_phones_match(clues.phone, _place_phone(place)))
-    if comparisons:
-        base += 0.20 * (sum(comparisons) / len(comparisons))
-    return min(1.0, base)
+    if search_method == "text":
+        return _names_match(clues.merchant_name, _clean(_value(place, "name")))
+    return True
 
 
 def _place_is_usable(place: Any, clues: ReceiptClues) -> bool:
@@ -295,9 +346,7 @@ def _place_is_usable(place: Any, clues: ReceiptClues) -> bool:
         return False
     result_state = _extract_state(_clean(_value(place, "formatted_address")))
     return not (
-        clues.expected_state
-        and result_state
-        and result_state != clues.expected_state
+        clues.expected_state and result_state and result_state != clues.expected_state
     )
 
 
@@ -344,9 +393,7 @@ def _existing_candidate(
     return _to_candidate(place, clues, "existing_place_id")
 
 
-def _tier0_is_consistent(
-    candidate: PlaceCandidate, clues: ReceiptClues
-) -> bool:
+def _tier0_is_consistent(candidate: PlaceCandidate, clues: ReceiptClues) -> bool:
     checks = []
     if clues.phone and clues.sources.get("phone") == "receipt_labels":
         checks.append(_phones_match(clues.phone, candidate.phone))
@@ -361,13 +408,18 @@ def collect_candidates(
     initial: list[PlaceCandidate] | None = None,
 ) -> list[PlaceCandidate]:
     """Run the deterministic phone/address/text Places cascade."""
-    candidates = {
-        candidate.place_id: candidate for candidate in (initial or [])
-    }
+    candidates = {candidate.place_id: candidate for candidate in (initial or [])}
+    text_query = (
+        _clean(
+            " ".join(value for value in (clues.merchant_name, clues.address) if value)
+        )
+        if clues.merchant_name
+        else None
+    )
     searches = (
         ("phone", clues.phone, places_client.search_by_phone),
         ("address", clues.address, places_client.search_by_address),
-        ("text", clues.merchant_name, places_client.search_by_text),
+        ("text", text_query, places_client.search_by_text),
     )
     for method, query, search in searches:
         if not query:
@@ -377,8 +429,16 @@ def collect_candidates(
         except Exception:  # pylint: disable=broad-exception-caught
             logger.exception("Tier 1 Places %s search failed", method)
             continue
-        if _place_is_usable(place, clues):
-            _merge_candidate(candidates, _to_candidate(place, clues, method))
+        if not _place_is_usable(place, clues):
+            continue
+        if not _primary_evidence_matches(place, clues, method):
+            logger.warning(
+                "Tier 1 rejected %s result because returned place did not "
+                "match the receipt's primary clue",
+                method,
+            )
+            continue
+        _merge_candidate(candidates, _to_candidate(place, clues, method))
     return sorted(
         candidates.values(),
         key=lambda candidate: candidate.score,
@@ -392,9 +452,7 @@ def select_deterministic_candidate(
 ) -> PlaceCandidate | None:
     """Select one high-confidence candidate, rejecting high-score conflicts."""
     qualifying = [
-        candidate
-        for candidate in candidates
-        if candidate.score >= minimum_confidence
+        candidate for candidate in candidates if candidate.score >= minimum_confidence
     ]
     if not qualifying:
         return None
@@ -437,9 +495,7 @@ async def _select_with_llm(
 ) -> tuple[dict[str, Any] | None, dict[str, Any]]:
     callback = CostTrackingCallback()
     model = os.environ.get("FIX_PLACE_TIER2_MODEL", _TIER2_MODEL)
-    minimum_confidence = float(
-        os.environ.get("FIX_PLACE_TIER2_MIN_CONFIDENCE", "0.85")
-    )
+    minimum_confidence = float(os.environ.get("FIX_PLACE_TIER2_MIN_CONFIDENCE", "0.85"))
     llm = create_llm(
         model=model,
         temperature=0.0,
@@ -454,9 +510,7 @@ async def _select_with_llm(
             "phone": clues.phone,
         },
         "receipt_text": clues.snippet,
-        "candidates": [
-            candidate.as_prompt_dict() for candidate in candidates[:5]
-        ],
+        "candidates": [candidate.as_prompt_dict() for candidate in candidates[:5]],
     }
     messages = [
         SystemMessage(
@@ -531,9 +585,7 @@ async def resolve_tiered_place(
         clues,
         initial=[existing] if existing else None,
     )
-    tier1_minimum = float(
-        os.environ.get("FIX_PLACE_TIER1_MIN_CONFIDENCE", "0.90")
-    )
+    tier1_minimum = float(os.environ.get("FIX_PLACE_TIER1_MIN_CONFIDENCE", "0.90"))
     deterministic = select_deterministic_candidate(candidates, tier1_minimum)
     if deterministic:
         return (
@@ -550,8 +602,7 @@ async def resolve_tiered_place(
         )
 
     tier2_enabled = (
-        os.environ.get("FIX_PLACE_TIER2_ENABLED", "true").lower()
-        not in _FALSE_VALUES
+        os.environ.get("FIX_PLACE_TIER2_ENABLED", "true").lower() not in _FALSE_VALUES
     )
     if candidates and tier2_enabled:
         return await _select_with_llm(clues, candidates)

--- a/receipt_agent/receipt_agent/subagents/place_finder/tiered.py
+++ b/receipt_agent/receipt_agent/subagents/place_finder/tiered.py
@@ -175,7 +175,7 @@ def _receipt_snippet(details: Any, limit: int = 1200) -> str:
 
 
 def extract_receipt_clues(details: Any) -> ReceiptClues:
-    """Extract labeled OCR clues, with current place fields as fallbacks."""
+    """Extract labeled OCR clues without trusting the flagged current place."""
     grouped = _group_labeled_words(details)
     merchant = _best_merchant(grouped.get("MERCHANT_NAME", {}))
     address = _combined_address(grouped.get("ADDRESS_LINE", {}))
@@ -190,27 +190,11 @@ def extract_receipt_clues(details: Any) -> ReceiptClues:
         if value
     }
 
-    current = _value(details, "place")
-    fallbacks = {
-        "merchant_name": _clean(_value(current, "merchant_name")),
-        "address": _clean(_value(current, "formatted_address")),
-        "phone": _clean(_value(current, "phone_number")),
-    }
-    values = {
-        "merchant_name": merchant,
-        "address": address,
-        "phone": phone,
-    }
-    for key, value in fallbacks.items():
-        if not values[key] and value:
-            values[key] = value
-            sources[key] = "current_place"
-
     expected_state = _extract_state(address)
     return ReceiptClues(
-        merchant_name=values["merchant_name"],
-        address=values["address"],
-        phone=values["phone"],
+        merchant_name=merchant,
+        address=address,
+        phone=phone,
         expected_state=expected_state,
         snippet=_receipt_snippet(details),
         sources=sources,
@@ -218,7 +202,9 @@ def extract_receipt_clues(details: Any) -> ReceiptClues:
 
 
 def _phone_digits(value: str | None) -> str:
-    return "".join(character for character in (value or "") if character.isdigit())
+    return "".join(
+        character for character in (value or "") if character.isdigit()
+    )
 
 
 def _phones_match(left: str | None, right: str | None) -> bool:
@@ -266,12 +252,34 @@ def _street(value: str | None) -> str:
         "lane": "ln",
         "highway": "hwy",
     }
-    return " ".join(replacements.get(token, token) for token in normalized.split())
+    return " ".join(
+        replacements.get(token, token) for token in normalized.split()
+    )
 
 
 def _addresses_match(left: str | None, right: str | None) -> bool:
     first = _street(left)
     second = _street(right)
+    if not first or not second:
+        return False
+
+    first_tokens = first.split()
+    second_tokens = second.split()
+    number_pattern = re.compile(r"\d+[a-z]?")
+    first_number = (
+        first_tokens[0] if number_pattern.fullmatch(first_tokens[0]) else None
+    )
+    second_number = (
+        second_tokens[0]
+        if number_pattern.fullmatch(second_tokens[0])
+        else None
+    )
+    if first_number or second_number:
+        if first_number != second_number:
+            return False
+        first = " ".join(first_tokens[1:])
+        second = " ".join(second_tokens[1:])
+
     return bool(first and second) and (first in second or second in first)
 
 
@@ -293,9 +301,13 @@ def _place_phone(place: Any) -> str | None:
     )
 
 
-def _candidate_score(clues: ReceiptClues, place: Any, search_method: str) -> float:
+def _candidate_score(
+    clues: ReceiptClues, place: Any, search_method: str
+) -> float:
     name_match = _names_match(clues.merchant_name, _value(place, "name"))
-    address_match = _addresses_match(clues.address, _value(place, "formatted_address"))
+    address_match = _addresses_match(
+        clues.address, _value(place, "formatted_address")
+    )
     phone_match = _phones_match(clues.phone, _place_phone(place))
 
     # A search method is not evidence by itself.  In particular, the Places
@@ -306,20 +318,28 @@ def _candidate_score(clues: ReceiptClues, place: Any, search_method: str) -> flo
         if not phone_match:
             return 0.0
         return min(
-            1.0, 0.95 + (0.03 if address_match else 0.0) + (0.02 if name_match else 0.0)
+            1.0,
+            0.95
+            + (0.03 if address_match else 0.0)
+            + (0.02 if name_match else 0.0),
         )
     if search_method == "address":
         if not address_match:
             return 0.0
         return min(
-            1.0, 0.90 + (0.05 if name_match else 0.0) + (0.05 if phone_match else 0.0)
+            1.0,
+            0.90
+            + (0.05 if name_match else 0.0)
+            + (0.05 if phone_match else 0.0),
         )
     if search_method == "text":
         if not name_match:
             return 0.0
         return min(
             1.0,
-            0.75 + (0.15 if address_match else 0.0) + (0.10 if phone_match else 0.0),
+            0.75
+            + (0.15 if address_match else 0.0)
+            + (0.10 if phone_match else 0.0),
         )
 
     # Existing place IDs only reach Tier 0 when their labeled evidence is
@@ -354,7 +374,8 @@ def _place_is_usable(place: Any, clues: ReceiptClues) -> bool:
     if not place_id or not name or is_address_like(name):
         return False
     place_types = {
-        str(place_type).lower() for place_type in (_value(place, "types") or [])
+        str(place_type).lower()
+        for place_type in (_value(place, "types") or [])
     }
     address_types = {"premise", "street_address", "subpremise"}
     business_types = {"establishment", "point_of_interest"}
@@ -362,7 +383,9 @@ def _place_is_usable(place: Any, clues: ReceiptClues) -> bool:
         return False
     result_state = _extract_state(_clean(_value(place, "formatted_address")))
     return not (
-        clues.expected_state and result_state and result_state != clues.expected_state
+        clues.expected_state
+        and result_state
+        and result_state != clues.expected_state
     )
 
 
@@ -409,7 +432,9 @@ def _existing_candidate(
     return _to_candidate(place, clues, "existing_place_id")
 
 
-def _tier0_is_consistent(candidate: PlaceCandidate, clues: ReceiptClues) -> bool:
+def _tier0_is_consistent(
+    candidate: PlaceCandidate, clues: ReceiptClues
+) -> bool:
     checks = []
     if clues.phone and clues.sources.get("phone") == "receipt_labels":
         checks.append(_phones_match(clues.phone, candidate.phone))
@@ -424,7 +449,9 @@ def collect_candidates(
     initial: list[PlaceCandidate] | None = None,
 ) -> list[PlaceCandidate]:
     """Run the deterministic phone/address/text Places cascade."""
-    candidates = {candidate.place_id: candidate for candidate in (initial or [])}
+    candidates = {
+        candidate.place_id: candidate for candidate in (initial or [])
+    }
     searches = (
         ("phone", clues.phone, places_client.search_by_phone),
         ("address", clues.address, places_client.search_by_address),
@@ -461,7 +488,9 @@ def select_deterministic_candidate(
 ) -> PlaceCandidate | None:
     """Select one high-confidence candidate, rejecting high-score conflicts."""
     qualifying = [
-        candidate for candidate in candidates if candidate.score >= minimum_confidence
+        candidate
+        for candidate in candidates
+        if candidate.score >= minimum_confidence
     ]
     if not qualifying:
         return None
@@ -508,7 +537,9 @@ async def _select_with_llm(
 ) -> tuple[dict[str, Any] | None, dict[str, Any]]:
     callback = CostTrackingCallback()
     model = os.environ.get("FIX_PLACE_TIER2_MODEL", _TIER2_MODEL)
-    minimum_confidence = float(os.environ.get("FIX_PLACE_TIER2_MIN_CONFIDENCE", "0.85"))
+    minimum_confidence = float(
+        os.environ.get("FIX_PLACE_TIER2_MIN_CONFIDENCE", "0.85")
+    )
     llm = create_llm(
         model=model,
         temperature=0.0,
@@ -523,7 +554,9 @@ async def _select_with_llm(
             "phone": clues.phone,
         },
         "receipt_text": clues.snippet,
-        "candidates": [candidate.as_prompt_dict() for candidate in candidates[:5]],
+        "candidates": [
+            candidate.as_prompt_dict() for candidate in candidates[:5]
+        ],
     }
     messages = [
         SystemMessage(
@@ -579,6 +612,11 @@ async def resolve_tiered_place(
         logger.warning("Places client unavailable; escalating to Tier 3")
         return None, empty_llm_stats()
     clues = extract_receipt_clues(details)
+    if not any((clues.merchant_name, clues.address, clues.phone)):
+        logger.info(
+            "No usable receipt-labeled place evidence; escalating to Tier 3"
+        )
+        return None, empty_llm_stats()
     existing = _existing_candidate(details, places_client, clues)
     if existing and _tier0_is_consistent(existing, clues):
         return (
@@ -600,7 +638,9 @@ async def resolve_tiered_place(
         clues,
         initial=[existing] if existing else None,
     )
-    tier1_minimum = float(os.environ.get("FIX_PLACE_TIER1_MIN_CONFIDENCE", "0.90"))
+    tier1_minimum = float(
+        os.environ.get("FIX_PLACE_TIER1_MIN_CONFIDENCE", "0.90")
+    )
     deterministic = select_deterministic_candidate(candidates, tier1_minimum)
     if deterministic:
         return (
@@ -618,7 +658,8 @@ async def resolve_tiered_place(
         )
 
     tier2_enabled = (
-        os.environ.get("FIX_PLACE_TIER2_ENABLED", "true").lower() not in _FALSE_VALUES
+        os.environ.get("FIX_PLACE_TIER2_ENABLED", "true").lower()
+        not in _FALSE_VALUES
     )
     if candidates and tier2_enabled:
         return await _select_with_llm(clues, candidates)

--- a/receipt_agent/receipt_agent/subagents/place_finder/tiered.py
+++ b/receipt_agent/receipt_agent/subagents/place_finder/tiered.py
@@ -1,0 +1,558 @@
+"""Low-cost tiers for resolving a receipt's Google Place."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import Any
+
+from langchain_core.messages import HumanMessage, SystemMessage
+from pydantic import BaseModel, Field
+
+from receipt_agent.utils.address_validation import is_address_like
+from receipt_agent.utils.llm_factory import CostTrackingCallback, create_llm
+
+logger = logging.getLogger(__name__)
+
+_PLACE_ID_SENTINELS = {"", "null", "NO_RESULTS", "INVALID"}
+_FALSE_VALUES = {"0", "false", "no", "off"}
+_TIER2_MODEL = "openai/gpt-oss-120b"
+
+
+@dataclass
+class ReceiptClues:
+    """Compact place evidence extracted from receipt labels and metadata."""
+
+    merchant_name: str | None = None
+    address: str | None = None
+    phone: str | None = None
+    expected_state: str | None = None
+    snippet: str = ""
+    sources: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class PlaceCandidate:
+    """A deduplicated Google Places candidate."""
+
+    place_id: str
+    merchant_name: str
+    address: str | None
+    phone: str | None
+    score: float
+    search_methods: set[str] = field(default_factory=set)
+
+    def as_prompt_dict(self) -> dict[str, Any]:
+        """Return only the compact fields needed by the Tier 2 picker."""
+        return {
+            "place_id": self.place_id,
+            "merchant_name": self.merchant_name,
+            "address": self.address,
+            "phone": self.phone,
+            "deterministic_score": round(self.score, 3),
+            "search_methods": sorted(self.search_methods),
+        }
+
+
+class Tier2Selection(BaseModel):
+    """Single-call structured selection from known Places candidates."""
+
+    place_id: str | None = Field(
+        default=None,
+        description="One candidate place_id, or null when none matches",
+    )
+    confidence: float = Field(ge=0.0, le=1.0)
+    reasoning: str
+
+
+def empty_llm_stats() -> dict[str, int | float]:
+    """Return the common zero-cost statistics shape."""
+    return {
+        "total_cost": 0.0,
+        "total_tokens": 0,
+        "prompt_tokens": 0,
+        "completion_tokens": 0,
+        "llm_calls": 0,
+    }
+
+
+def _value(item: Any, name: str) -> Any:
+    if isinstance(item, dict):
+        return item.get(name)
+    return getattr(item, name, None)
+
+
+def _clean(value: Any) -> str | None:
+    if value is None:
+        return None
+    cleaned = " ".join(str(value).split()).strip()
+    return cleaned or None
+
+
+def _label_is_usable(label: Any) -> bool:
+    status = str(_value(label, "validation_status") or "").upper()
+    return not status.endswith("INVALID")
+
+
+def _group_labeled_words(details: Any) -> dict[str, dict[int, list[str]]]:
+    words = {
+        (_value(word, "line_id"), _value(word, "word_id")): word
+        for word in (_value(details, "words") or [])
+    }
+    grouped: dict[str, dict[int, list[tuple[int, str]]]] = defaultdict(
+        lambda: defaultdict(list)
+    )
+    for label in _value(details, "labels") or []:
+        if not _label_is_usable(label):
+            continue
+        line_id = _value(label, "line_id")
+        word_id = _value(label, "word_id")
+        word = words.get((line_id, word_id))
+        text = _clean(_value(word, "text")) if word is not None else None
+        label_name = _clean(_value(label, "label"))
+        if text and label_name and isinstance(line_id, int):
+            grouped[label_name.upper()][line_id].append((word_id, text))
+
+    result: dict[str, dict[int, list[str]]] = {}
+    for label_name, lines in grouped.items():
+        result[label_name] = {
+            line_id: [text for _, text in sorted(words_on_line)]
+            for line_id, words_on_line in lines.items()
+        }
+    return result
+
+
+def _best_merchant(lines: dict[int, list[str]]) -> str | None:
+    candidates = []
+    for line_id, words in lines.items():
+        text = _clean(" ".join(words))
+        if text and re.search(r"[A-Za-z]", text):
+            candidates.append((len(words), len(text), -line_id, text))
+    return max(candidates)[-1] if candidates else None
+
+
+def _best_phone(lines: dict[int, list[str]]) -> str | None:
+    candidates = []
+    for line_id, words in lines.items():
+        text = _clean(" ".join(words))
+        digits = _phone_digits(text)
+        if text and len(digits) >= 10:
+            candidates.append((len(digits) in {10, 11}, -line_id, text))
+    return max(candidates)[-1] if candidates else None
+
+
+def _combined_address(lines: dict[int, list[str]]) -> str | None:
+    parts = []
+    for _, words in sorted(lines.items()):
+        text = _clean(" ".join(words))
+        if text and text not in parts:
+            parts.append(text)
+    return _clean(", ".join(parts))
+
+
+def _receipt_snippet(details: Any, limit: int = 1200) -> str:
+    lines = sorted(
+        _value(details, "lines") or [],
+        key=lambda line: _value(line, "line_id") or 0,
+    )
+    text = "\n".join(
+        value for line in lines[:15] if (value := _clean(_value(line, "text")))
+    )
+    return text[:limit]
+
+
+def extract_receipt_clues(details: Any) -> ReceiptClues:
+    """Extract labeled OCR clues, with current place fields as fallbacks."""
+    grouped = _group_labeled_words(details)
+    merchant = _best_merchant(grouped.get("MERCHANT_NAME", {}))
+    address = _combined_address(grouped.get("ADDRESS_LINE", {}))
+    phone = _best_phone(grouped.get("PHONE_NUMBER", {}))
+    sources = {
+        key: "receipt_labels"
+        for key, value in {
+            "merchant_name": merchant,
+            "address": address,
+            "phone": phone,
+        }.items()
+        if value
+    }
+
+    current = _value(details, "place")
+    fallbacks = {
+        "merchant_name": _clean(_value(current, "merchant_name")),
+        "address": _clean(_value(current, "formatted_address")),
+        "phone": _clean(_value(current, "phone_number")),
+    }
+    values = {
+        "merchant_name": merchant,
+        "address": address,
+        "phone": phone,
+    }
+    for key, value in fallbacks.items():
+        if not values[key] and value:
+            values[key] = value
+            sources[key] = "current_place"
+
+    expected_state = _extract_state(address)
+    return ReceiptClues(
+        merchant_name=values["merchant_name"],
+        address=values["address"],
+        phone=values["phone"],
+        expected_state=expected_state,
+        snippet=_receipt_snippet(details),
+        sources=sources,
+    )
+
+
+def _phone_digits(value: str | None) -> str:
+    return "".join(
+        character for character in (value or "") if character.isdigit()
+    )
+
+
+def _phones_match(left: str | None, right: str | None) -> bool:
+    left_digits = _phone_digits(left)
+    right_digits = _phone_digits(right)
+    if not left_digits or not right_digits:
+        return False
+    if len(left_digits) >= 10 and len(right_digits) >= 10:
+        return left_digits[-10:] == right_digits[-10:]
+    return left_digits == right_digits
+
+
+def _normalized_text(value: str | None) -> str:
+    return "".join(
+        character.lower()
+        for character in (value or "")
+        if character.isalnum() or character.isspace()
+    ).strip()
+
+
+def _names_match(left: str | None, right: str | None) -> bool:
+    first = _normalized_text(left)
+    second = _normalized_text(right)
+    return bool(first and second) and (first in second or second in first)
+
+
+def _street(value: str | None) -> str:
+    return _normalized_text((value or "").split(",", maxsplit=1)[0])
+
+
+def _addresses_match(left: str | None, right: str | None) -> bool:
+    first = _street(left)
+    second = _street(right)
+    return bool(first and second) and (first in second or second in first)
+
+
+def _extract_state(value: str | None) -> str | None:
+    if not value:
+        return None
+    upper = value.upper()
+    match = re.search(r"\b([A-Z]{2})\s+\d{5}(?:-\d{4})?\b", upper)
+    if match:
+        return match.group(1)
+    match = re.search(r",\s*([A-Z]{2})\b", upper)
+    return match.group(1) if match else None
+
+
+def _place_phone(place: Any) -> str | None:
+    return _clean(
+        _value(place, "formatted_phone_number")
+        or _value(place, "international_phone_number")
+    )
+
+
+def _candidate_score(
+    clues: ReceiptClues, place: Any, search_method: str
+) -> float:
+    base = {"phone": 0.95, "address": 0.80, "text": 0.60}.get(
+        search_method, 0.50
+    )
+    comparisons = []
+    if clues.merchant_name and _value(place, "name"):
+        comparisons.append(
+            _names_match(clues.merchant_name, _value(place, "name"))
+        )
+    if clues.address and _value(place, "formatted_address"):
+        comparisons.append(
+            _addresses_match(clues.address, _value(place, "formatted_address"))
+        )
+    if clues.phone and _place_phone(place):
+        comparisons.append(_phones_match(clues.phone, _place_phone(place)))
+    if comparisons:
+        base += 0.20 * (sum(comparisons) / len(comparisons))
+    return min(1.0, base)
+
+
+def _place_is_usable(place: Any, clues: ReceiptClues) -> bool:
+    place_id = _clean(_value(place, "place_id"))
+    name = _clean(_value(place, "name"))
+    if not place_id or not name or is_address_like(name):
+        return False
+    result_state = _extract_state(_clean(_value(place, "formatted_address")))
+    return not (
+        clues.expected_state
+        and result_state
+        and result_state != clues.expected_state
+    )
+
+
+def _to_candidate(
+    place: Any, clues: ReceiptClues, search_method: str
+) -> PlaceCandidate:
+    return PlaceCandidate(
+        place_id=str(_value(place, "place_id")),
+        merchant_name=str(_value(place, "name")),
+        address=_clean(_value(place, "formatted_address")),
+        phone=_place_phone(place),
+        score=_candidate_score(clues, place, search_method),
+        search_methods={search_method},
+    )
+
+
+def _merge_candidate(
+    candidates: dict[str, PlaceCandidate], candidate: PlaceCandidate
+) -> None:
+    existing = candidates.get(candidate.place_id)
+    if existing is None:
+        candidates[candidate.place_id] = candidate
+        return
+    existing.score = max(existing.score, candidate.score)
+    existing.search_methods.update(candidate.search_methods)
+    existing.address = existing.address or candidate.address
+    existing.phone = existing.phone or candidate.phone
+
+
+def _existing_candidate(
+    details: Any, places_client: Any, clues: ReceiptClues
+) -> PlaceCandidate | None:
+    current = _value(details, "place")
+    place_id = _clean(_value(current, "place_id"))
+    if not place_id or place_id in _PLACE_ID_SENTINELS:
+        return None
+    try:
+        place = places_client.get_place_details(place_id)
+    except Exception:  # pylint: disable=broad-exception-caught
+        logger.exception("Tier 0 place_id lookup failed")
+        return None
+    if not _place_is_usable(place, clues):
+        return None
+    return _to_candidate(place, clues, "existing_place_id")
+
+
+def _tier0_is_consistent(
+    candidate: PlaceCandidate, clues: ReceiptClues
+) -> bool:
+    checks = []
+    if clues.phone and clues.sources.get("phone") == "receipt_labels":
+        checks.append(_phones_match(clues.phone, candidate.phone))
+    if clues.address and clues.sources.get("address") == "receipt_labels":
+        checks.append(_addresses_match(clues.address, candidate.address))
+    return bool(checks) and all(checks)
+
+
+def collect_candidates(
+    places_client: Any,
+    clues: ReceiptClues,
+    initial: list[PlaceCandidate] | None = None,
+) -> list[PlaceCandidate]:
+    """Run the deterministic phone/address/text Places cascade."""
+    candidates = {
+        candidate.place_id: candidate for candidate in (initial or [])
+    }
+    searches = (
+        ("phone", clues.phone, places_client.search_by_phone),
+        ("address", clues.address, places_client.search_by_address),
+        ("text", clues.merchant_name, places_client.search_by_text),
+    )
+    for method, query, search in searches:
+        if not query:
+            continue
+        try:
+            place = search(query)
+        except Exception:  # pylint: disable=broad-exception-caught
+            logger.exception("Tier 1 Places %s search failed", method)
+            continue
+        if _place_is_usable(place, clues):
+            _merge_candidate(candidates, _to_candidate(place, clues, method))
+    return sorted(
+        candidates.values(),
+        key=lambda candidate: candidate.score,
+        reverse=True,
+    )
+
+
+def select_deterministic_candidate(
+    candidates: list[PlaceCandidate],
+    minimum_confidence: float,
+) -> PlaceCandidate | None:
+    """Select one high-confidence candidate, rejecting high-score conflicts."""
+    qualifying = [
+        candidate
+        for candidate in candidates
+        if candidate.score >= minimum_confidence
+    ]
+    if not qualifying:
+        return None
+    if len({candidate.place_id for candidate in qualifying}) > 1:
+        return None
+    return qualifying[0]
+
+
+def _result(
+    candidate: PlaceCandidate,
+    *,
+    tier: str,
+    confidence: float,
+    reasoning: str,
+) -> dict[str, Any]:
+    values = {
+        "place_id": candidate.place_id,
+        "merchant_name": candidate.merchant_name,
+        "address": candidate.address,
+        "phone_number": candidate.phone,
+    }
+    fields_found = [key for key, value in values.items() if value]
+    return {
+        **values,
+        "confidence": confidence,
+        "field_confidence": dict.fromkeys(fields_found, confidence),
+        "reasoning": reasoning,
+        "sources": dict.fromkeys(fields_found, "google_places"),
+        "search_methods_used": sorted(candidate.search_methods),
+        "fields_found": fields_found,
+        "found": True,
+        "type": "deterministic" if tier != "tier2" else "llm_decided",
+        "resolution_tier": tier,
+    }
+
+
+async def _select_with_llm(
+    clues: ReceiptClues,
+    candidates: list[PlaceCandidate],
+) -> tuple[dict[str, Any] | None, dict[str, Any]]:
+    callback = CostTrackingCallback()
+    model = os.environ.get("FIX_PLACE_TIER2_MODEL", _TIER2_MODEL)
+    minimum_confidence = float(
+        os.environ.get("FIX_PLACE_TIER2_MIN_CONFIDENCE", "0.85")
+    )
+    llm = create_llm(
+        model=model,
+        temperature=0.0,
+        timeout=60,
+        reasoning=False,
+        stream_usage=True,
+    ).with_structured_output(Tier2Selection)
+    payload = {
+        "receipt_clues": {
+            "merchant_name": clues.merchant_name,
+            "address": clues.address,
+            "phone": clues.phone,
+        },
+        "receipt_text": clues.snippet,
+        "candidates": [
+            candidate.as_prompt_dict() for candidate in candidates[:5]
+        ],
+    }
+    messages = [
+        SystemMessage(
+            content=(
+                "Choose the single Google Places candidate supported by the "
+                "receipt. Return null when evidence conflicts or is too weak. "
+                "Never invent a place_id."
+            )
+        ),
+        HumanMessage(content=json.dumps(payload, ensure_ascii=True)),
+    ]
+    try:
+        selection = await llm.ainvoke(
+            messages,
+            config={"callbacks": [callback.handler]},
+        )
+    except Exception:  # pylint: disable=broad-exception-caught
+        logger.exception("Tier 2 structured place selection failed")
+        return None, callback.get_stats()
+
+    if isinstance(selection, dict):
+        selection = Tier2Selection.model_validate(selection)
+    selected = next(
+        (
+            candidate
+            for candidate in candidates
+            if candidate.place_id == selection.place_id
+        ),
+        None,
+    )
+    if selected is None or selection.confidence < minimum_confidence:
+        return None, callback.get_stats()
+    return (
+        _result(
+            selected,
+            tier="tier2",
+            confidence=selection.confidence,
+            reasoning=(
+                f"Single structured picker selected a known Places candidate: "
+                f"{selection.reasoning}"
+            ),
+        ),
+        callback.get_stats(),
+    )
+
+
+async def resolve_tiered_place(
+    details: Any, places_client: Any
+) -> tuple[dict[str, Any] | None, dict[str, Any]]:
+    """Try Tiers 0-2 and return ``None`` when Tier 3 must run."""
+    if places_client is None:
+        logger.warning("Places client unavailable; escalating to Tier 3")
+        return None, empty_llm_stats()
+    clues = extract_receipt_clues(details)
+    existing = _existing_candidate(details, places_client, clues)
+    if existing and _tier0_is_consistent(existing, clues):
+        return (
+            _result(
+                existing,
+                tier="tier0",
+                confidence=1.0,
+                reasoning=(
+                    "Existing place_id matches receipt-labeled phone/address "
+                    "and current Google Places details."
+                ),
+            ),
+            empty_llm_stats(),
+        )
+
+    candidates = collect_candidates(
+        places_client,
+        clues,
+        initial=[existing] if existing else None,
+    )
+    tier1_minimum = float(
+        os.environ.get("FIX_PLACE_TIER1_MIN_CONFIDENCE", "0.90")
+    )
+    deterministic = select_deterministic_candidate(candidates, tier1_minimum)
+    if deterministic:
+        return (
+            _result(
+                deterministic,
+                tier="tier1",
+                confidence=deterministic.score,
+                reasoning=(
+                    "Deterministic Places cascade produced one "
+                    "high-confidence candidate."
+                ),
+            ),
+            empty_llm_stats(),
+        )
+
+    tier2_enabled = (
+        os.environ.get("FIX_PLACE_TIER2_ENABLED", "true").lower()
+        not in _FALSE_VALUES
+    )
+    if candidates and tier2_enabled:
+        return await _select_with_llm(clues, candidates)
+    return None, empty_llm_stats()

--- a/receipt_agent/receipt_agent/subagents/place_finder/tiered.py
+++ b/receipt_agent/receipt_agent/subagents/place_finder/tiered.py
@@ -240,8 +240,8 @@ def _normalized_text(value: str | None) -> str:
 
 
 def _names_match(left: str | None, right: str | None) -> bool:
-    first = _normalized_text(left)
-    second = _normalized_text(right)
+    first = "".join(_normalized_text(left).split())
+    second = "".join(_normalized_text(right).split())
     return bool(first and second) and (first in second or second in first)
 
 
@@ -476,20 +476,24 @@ def _result(
     tier: str,
     confidence: float,
     reasoning: str,
+    clues: ReceiptClues | None = None,
 ) -> dict[str, Any]:
     values = {
         "place_id": candidate.place_id,
         "merchant_name": candidate.merchant_name,
         "address": candidate.address,
-        "phone_number": candidate.phone,
+        "phone_number": candidate.phone or (clues.phone if clues else None),
     }
     fields_found = [key for key, value in values.items() if value]
+    sources = dict.fromkeys(fields_found, "google_places")
+    if "phone_number" in fields_found and not candidate.phone:
+        sources["phone_number"] = "receipt_labels"
     return {
         **values,
         "confidence": confidence,
         "field_confidence": dict.fromkeys(fields_found, confidence),
         "reasoning": reasoning,
-        "sources": dict.fromkeys(fields_found, "google_places"),
+        "sources": sources,
         "search_methods_used": sorted(candidate.search_methods),
         "fields_found": fields_found,
         "found": True,
@@ -561,6 +565,7 @@ async def _select_with_llm(
                 f"Single structured picker selected a known Places candidate: "
                 f"{selection.reasoning}"
             ),
+            clues=clues,
         ),
         callback.get_stats(),
     )
@@ -585,6 +590,7 @@ async def resolve_tiered_place(
                     "Existing place_id matches receipt-labeled phone/address "
                     "and current Google Places details."
                 ),
+                clues=clues,
             ),
             empty_llm_stats(),
         )
@@ -606,6 +612,7 @@ async def resolve_tiered_place(
                     "Deterministic Places cascade produced one "
                     "high-confidence candidate."
                 ),
+                clues=clues,
             ),
             empty_llm_stats(),
         )

--- a/receipt_agent/receipt_agent/subagents/place_finder/tiered.py
+++ b/receipt_agent/receipt_agent/subagents/place_finder/tiered.py
@@ -45,6 +45,7 @@ class PlaceCandidate:
     phone: str | None
     score: float
     search_methods: set[str] = field(default_factory=set)
+    deterministic_eligible: bool = True
 
     def as_prompt_dict(self) -> dict[str, Any]:
         """Return only the compact fields needed by the Tier 2 picker."""
@@ -55,6 +56,7 @@ class PlaceCandidate:
             "phone": self.phone,
             "deterministic_score": round(self.score, 3),
             "search_methods": sorted(self.search_methods),
+            "deterministic_eligible": self.deterministic_eligible,
         }
 
 
@@ -301,6 +303,53 @@ def _place_phone(place: Any) -> str | None:
     )
 
 
+def _deterministic_evidence_is_sufficient(
+    clues: ReceiptClues, place: Any, search_method: str
+) -> bool:
+    """Require secondary corroboration and reject active clue conflicts."""
+    primary_fields = {
+        "phone": "phone",
+        "address": "address",
+        "text": "merchant_name",
+    }
+    primary_field = primary_fields.get(search_method)
+    if primary_field is None:
+        return False
+
+    evidence = {
+        "merchant_name": (
+            clues.merchant_name,
+            _clean(_value(place, "name")),
+            _names_match,
+        ),
+        "address": (
+            clues.address,
+            _clean(_value(place, "formatted_address")),
+            _addresses_match,
+        ),
+        "phone": (clues.phone, _place_phone(place), _phones_match),
+    }
+    statuses = {}
+    for field_name, (clue, candidate_value, matcher) in evidence.items():
+        if not clue:
+            continue
+        if not candidate_value:
+            statuses[field_name] = "missing"
+        elif matcher(clue, candidate_value):
+            statuses[field_name] = "match"
+        else:
+            statuses[field_name] = "conflict"
+
+    if "conflict" in statuses.values():
+        return False
+    secondary_statuses = [
+        status
+        for field_name, status in statuses.items()
+        if field_name != primary_field
+    ]
+    return not secondary_statuses or "match" in secondary_statuses
+
+
 def _candidate_score(
     clues: ReceiptClues, place: Any, search_method: str
 ) -> float:
@@ -399,6 +448,9 @@ def _to_candidate(
         phone=_place_phone(place),
         score=_candidate_score(clues, place, search_method),
         search_methods={search_method},
+        deterministic_eligible=_deterministic_evidence_is_sufficient(
+            clues, place, search_method
+        ),
     )
 
 
@@ -411,6 +463,9 @@ def _merge_candidate(
         return
     existing.score = max(existing.score, candidate.score)
     existing.search_methods.update(candidate.search_methods)
+    existing.deterministic_eligible = (
+        existing.deterministic_eligible or candidate.deterministic_eligible
+    )
     existing.address = existing.address or candidate.address
     existing.phone = existing.phone or candidate.phone
 
@@ -435,6 +490,13 @@ def _existing_candidate(
 def _tier0_is_consistent(
     candidate: PlaceCandidate, clues: ReceiptClues
 ) -> bool:
+    if (
+        clues.merchant_name
+        and clues.sources.get("merchant_name") == "receipt_labels"
+        and not _names_match(clues.merchant_name, candidate.merchant_name)
+    ):
+        return False
+
     checks = []
     if clues.phone and clues.sources.get("phone") == "receipt_labels":
         checks.append(_phones_match(clues.phone, candidate.phone))
@@ -491,6 +553,7 @@ def select_deterministic_candidate(
         candidate
         for candidate in candidates
         if candidate.score >= minimum_confidence
+        and candidate.deterministic_eligible
     ]
     if not qualifying:
         return None
@@ -511,7 +574,9 @@ def _result(
         "place_id": candidate.place_id,
         "merchant_name": candidate.merchant_name,
         "address": candidate.address,
-        "phone_number": candidate.phone or (clues.phone if clues else None),
+        "phone_number": (
+            candidate.phone or (clues.phone if clues else None) or ""
+        ),
     }
     fields_found = [key for key, value in values.items() if value]
     sources = dict.fromkeys(fields_found, "google_places")

--- a/receipt_agent/receipt_agent/subagents/place_finder/tiered.py
+++ b/receipt_agent/receipt_agent/subagents/place_finder/tiered.py
@@ -353,6 +353,13 @@ def _place_is_usable(place: Any, clues: ReceiptClues) -> bool:
     name = _clean(_value(place, "name"))
     if not place_id or not name or is_address_like(name):
         return False
+    place_types = {
+        str(place_type).lower() for place_type in (_value(place, "types") or [])
+    }
+    address_types = {"premise", "street_address", "subpremise"}
+    business_types = {"establishment", "point_of_interest"}
+    if place_types & address_types and not place_types & business_types:
+        return False
     result_state = _extract_state(_clean(_value(place, "formatted_address")))
     return not (
         clues.expected_state and result_state and result_state != clues.expected_state

--- a/receipt_agent/receipt_agent/subagents/place_finder/tiered.py
+++ b/receipt_agent/receipt_agent/subagents/place_finder/tiered.py
@@ -151,6 +151,15 @@ def _combined_address(lines: dict[int, list[str]]) -> str | None:
         text = _clean(" ".join(words))
         if text and text not in parts:
             parts.append(text)
+    # Header cities are sometimes mislabeled as ADDRESS_LINE before the
+    # actual street.  Start at the first line containing a street number so
+    # that the deterministic address query remains usable.
+    street_start = next(
+        (index for index, part in enumerate(parts) if re.search(r"\d", part)),
+        None,
+    )
+    if street_start is not None:
+        parts = parts[street_start:]
     return _clean(", ".join(parts))
 
 
@@ -409,17 +418,10 @@ def collect_candidates(
 ) -> list[PlaceCandidate]:
     """Run the deterministic phone/address/text Places cascade."""
     candidates = {candidate.place_id: candidate for candidate in (initial or [])}
-    text_query = (
-        _clean(
-            " ".join(value for value in (clues.merchant_name, clues.address) if value)
-        )
-        if clues.merchant_name
-        else None
-    )
     searches = (
         ("phone", clues.phone, places_client.search_by_phone),
         ("address", clues.address, places_client.search_by_address),
-        ("text", text_query, places_client.search_by_text),
+        ("text", clues.merchant_name, places_client.search_by_text),
     )
     for method, query, search in searches:
         if not query:
@@ -500,7 +502,7 @@ async def _select_with_llm(
         model=model,
         temperature=0.0,
         timeout=60,
-        reasoning=False,
+        reasoning=True,
         stream_usage=True,
     ).with_structured_output(Tier2Selection)
     payload = {

--- a/receipt_agent/tests/test_place_finder_agent_cap.py
+++ b/receipt_agent/tests/test_place_finder_agent_cap.py
@@ -1,0 +1,118 @@
+"""Tests for the constrained Tier 3 place agent."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from langchain_core.messages import AIMessage, HumanMessage
+
+from receipt_agent.subagents.place_finder.graph import (
+    create_receipt_place_finder_graph,
+)
+from receipt_agent.subagents.place_finder.state import ReceiptPlaceFinderState
+
+
+def _settings():
+    return SimpleNamespace(
+        openrouter_model="test-model",
+        openrouter_base_url="https://openrouter.ai/api/v1",
+        openrouter_api_key=SimpleNamespace(
+            get_secret_value=lambda: "test-key"
+        ),
+    )
+
+
+def _submit_message():
+    return AIMessage(
+        content="",
+        tool_calls=[
+            {
+                "name": "submit_place",
+                "args": {
+                    "place_id": "ChIJ-test",
+                    "merchant_name": "Test Market",
+                    "confidence": 0.9,
+                    "reasoning": "Best available evidence.",
+                },
+                "id": "call-1",
+                "type": "tool_call",
+            }
+        ],
+    )
+
+
+def test_agent_forces_submit_after_configured_rounds(monkeypatch):
+    monkeypatch.setenv("FIX_PLACE_AGENT_MAX_ROUNDS", "3")
+    normal_llm = MagicMock()
+    normal_llm.invoke.side_effect = lambda _messages: AIMessage(
+        content="Still searching"
+    )
+    forced_llm = MagicMock()
+    forced_llm.invoke.return_value = _submit_message()
+    base_llm = MagicMock()
+    base_llm.bind_tools.side_effect = [normal_llm, forced_llm]
+
+    with (
+        patch(
+            "receipt_agent.subagents.place_finder.graph.create_agentic_tools",
+            return_value=([], {}),
+        ),
+        patch(
+            "receipt_agent.subagents.place_finder.graph.create_llm",
+            return_value=base_llm,
+        ),
+    ):
+        graph, state_holder = create_receipt_place_finder_graph(
+            dynamo_client=None,
+            chroma_client=None,
+            embed_fn=lambda _texts: [],
+            settings=_settings(),
+        )
+        graph.invoke(
+            ReceiptPlaceFinderState(
+                image_id="image-1",
+                receipt_id=1,
+                messages=[HumanMessage(content="Find the place")],
+            ),
+            config={"recursion_limit": 12},
+        )
+
+    assert normal_llm.invoke.call_count == 3
+    forced_llm.invoke.assert_called_once()
+    assert state_holder["place_result"]["place_id"] == "ChIJ-test"
+
+
+def test_submit_tool_ends_without_an_extra_llm_turn():
+    normal_llm = MagicMock()
+    normal_llm.invoke.return_value = _submit_message()
+    forced_llm = MagicMock()
+    base_llm = MagicMock()
+    base_llm.bind_tools.side_effect = [normal_llm, forced_llm]
+
+    with (
+        patch(
+            "receipt_agent.subagents.place_finder.graph.create_agentic_tools",
+            return_value=([], {}),
+        ),
+        patch(
+            "receipt_agent.subagents.place_finder.graph.create_llm",
+            return_value=base_llm,
+        ),
+    ):
+        graph, state_holder = create_receipt_place_finder_graph(
+            dynamo_client=None,
+            chroma_client=None,
+            embed_fn=lambda _texts: [],
+            settings=_settings(),
+        )
+        graph.invoke(
+            ReceiptPlaceFinderState(
+                image_id="image-1",
+                receipt_id=1,
+                messages=[HumanMessage(content="Find the place")],
+            ),
+            config={"recursion_limit": 12},
+        )
+
+    normal_llm.invoke.assert_called_once()
+    forced_llm.invoke.assert_not_called()
+    assert state_holder["place_result"]["found"] is True

--- a/receipt_agent/tests/test_place_finder_agent_cap.py
+++ b/receipt_agent/tests/test_place_finder_agent_cap.py
@@ -170,6 +170,46 @@ def test_legacy_agent_is_not_forced_to_submit_after_three_rounds(monkeypatch):
     assert state_holder["place_result"]["place_id"] == "ChIJ-test"
 
 
+def test_legacy_agent_ends_after_twenty_stalled_messages(monkeypatch):
+    monkeypatch.setenv("FIX_PLACE_RESOLUTION_MODE", "agent")
+    normal_llm = MagicMock()
+    normal_llm.invoke.side_effect = lambda _messages: AIMessage(
+        content="Still searching"
+    )
+    forced_llm = MagicMock()
+    base_llm = MagicMock()
+    base_llm.bind_tools.side_effect = [normal_llm, forced_llm]
+
+    with (
+        patch(
+            "receipt_agent.subagents.place_finder.graph.create_agentic_tools",
+            return_value=([], {}),
+        ),
+        patch(
+            "receipt_agent.subagents.place_finder.graph.create_llm",
+            return_value=base_llm,
+        ),
+    ):
+        graph, state_holder = create_receipt_place_finder_graph(
+            dynamo_client=None,
+            chroma_client=None,
+            embed_fn=lambda _texts: [],
+            settings=_settings(),
+        )
+        graph.invoke(
+            ReceiptPlaceFinderState(
+                image_id="image-1",
+                receipt_id=1,
+                messages=[HumanMessage(content="Find the place")],
+            ),
+            config={"recursion_limit": 100},
+        )
+
+    assert normal_llm.invoke.call_count == 20
+    forced_llm.invoke.assert_not_called()
+    assert state_holder.get("place_result") is None
+
+
 def test_compaction_keeps_tool_calls_paired_with_all_results():
     old_call_ids = [f"old-{index}" for index in range(3)]
     recent_call_ids = [f"recent-{index}" for index in range(3)]

--- a/receipt_agent/tests/test_place_finder_agent_cap.py
+++ b/receipt_agent/tests/test_place_finder_agent_cap.py
@@ -1,12 +1,21 @@
-"""Tests for the constrained Tier 3 place agent."""
+"""Tests for constrained and legacy place-agent execution."""
 
+import asyncio
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
-from langchain_core.messages import AIMessage, HumanMessage
+from langchain_core.messages import (
+    AIMessage,
+    HumanMessage,
+    SystemMessage,
+    ToolMessage,
+)
 
+from receipt_agent.agents.place_id_finder.graph import run_place_id_finder
 from receipt_agent.subagents.place_finder.graph import (
+    _compact_agent_messages,
     create_receipt_place_finder_graph,
+    run_receipt_place_finder,
 )
 from receipt_agent.subagents.place_finder.state import ReceiptPlaceFinderState
 
@@ -41,6 +50,7 @@ def _submit_message():
 
 
 def test_agent_forces_submit_after_configured_rounds(monkeypatch):
+    monkeypatch.setenv("FIX_PLACE_RESOLUTION_MODE", "tiered")
     monkeypatch.setenv("FIX_PLACE_AGENT_MAX_ROUNDS", "3")
     normal_llm = MagicMock()
     normal_llm.invoke.side_effect = lambda _messages: AIMessage(
@@ -116,3 +126,128 @@ def test_submit_tool_ends_without_an_extra_llm_turn():
     normal_llm.invoke.assert_called_once()
     forced_llm.invoke.assert_not_called()
     assert state_holder["place_result"]["found"] is True
+
+
+def test_legacy_agent_is_not_forced_to_submit_after_three_rounds(monkeypatch):
+    monkeypatch.setenv("FIX_PLACE_RESOLUTION_MODE", "agent")
+    monkeypatch.setenv("FIX_PLACE_AGENT_MAX_ROUNDS", "3")
+    normal_llm = MagicMock()
+    normal_llm.invoke.side_effect = [
+        AIMessage(content=f"Still searching, round {round_number}")
+        for round_number in range(1, 5)
+    ] + [_submit_message()]
+    forced_llm = MagicMock()
+    base_llm = MagicMock()
+    base_llm.bind_tools.side_effect = [normal_llm, forced_llm]
+
+    with (
+        patch(
+            "receipt_agent.subagents.place_finder.graph.create_agentic_tools",
+            return_value=([], {}),
+        ),
+        patch(
+            "receipt_agent.subagents.place_finder.graph.create_llm",
+            return_value=base_llm,
+        ),
+    ):
+        graph, state_holder = create_receipt_place_finder_graph(
+            dynamo_client=None,
+            chroma_client=None,
+            embed_fn=lambda _texts: [],
+            settings=_settings(),
+        )
+        graph.invoke(
+            ReceiptPlaceFinderState(
+                image_id="image-1",
+                receipt_id=1,
+                messages=[HumanMessage(content="Find the place")],
+            ),
+            config={"recursion_limit": 20},
+        )
+
+    assert normal_llm.invoke.call_count == 5
+    forced_llm.invoke.assert_not_called()
+    assert state_holder["place_result"]["place_id"] == "ChIJ-test"
+
+
+def test_compaction_keeps_tool_calls_paired_with_all_results():
+    old_call_ids = [f"old-{index}" for index in range(3)]
+    recent_call_ids = [f"recent-{index}" for index in range(3)]
+
+    def tool_call_message(call_ids):
+        return AIMessage(
+            content="",
+            tool_calls=[
+                {
+                    "name": "lookup",
+                    "args": {"value": call_id},
+                    "id": call_id,
+                    "type": "tool_call",
+                }
+                for call_id in call_ids
+            ],
+        )
+
+    prefix = [
+        SystemMessage(content="system"),
+        HumanMessage(content="request"),
+    ]
+    old_group = [tool_call_message(old_call_ids)] + [
+        ToolMessage(content="result", tool_call_id=call_id)
+        for call_id in old_call_ids
+    ]
+    recent_group = [tool_call_message(recent_call_ids)] + [
+        ToolMessage(content="result", tool_call_id=call_id)
+        for call_id in recent_call_ids
+    ]
+
+    compacted = _compact_agent_messages(prefix + old_group + recent_group)
+
+    assert compacted == prefix + recent_group
+    available_call_ids = {
+        tool_call["id"]
+        for message in compacted
+        if isinstance(message, AIMessage)
+        for tool_call in message.tool_calls
+    }
+    assert {
+        message.tool_call_id
+        for message in compacted
+        if isinstance(message, ToolMessage)
+    } <= available_call_ids
+
+
+def test_receipt_place_runner_preserves_legacy_recursion_budget(monkeypatch):
+    monkeypatch.setenv("FIX_PLACE_RESOLUTION_MODE", "agent")
+    monkeypatch.setenv("FIX_PLACE_AGENT_RECURSION_LIMIT", "12")
+    graph = MagicMock()
+    graph.ainvoke = AsyncMock()
+    state_holder = {"place_result": None}
+
+    asyncio.run(
+        run_receipt_place_finder(
+            graph,
+            state_holder,
+            image_id="image-1",
+            receipt_id=1,
+        )
+    )
+
+    assert graph.ainvoke.await_args.kwargs["config"]["recursion_limit"] == 100
+
+
+def test_upload_place_id_runner_preserves_legacy_recursion_budget():
+    graph = MagicMock()
+    graph.ainvoke = AsyncMock()
+    state_holder = {"place_id_result": None}
+
+    asyncio.run(
+        run_place_id_finder(
+            graph,
+            state_holder,
+            image_id="image-1",
+            receipt_id=1,
+        )
+    )
+
+    assert graph.ainvoke.await_args.kwargs["config"]["recursion_limit"] == 100

--- a/receipt_agent/tests/test_place_finder_cost_tracking.py
+++ b/receipt_agent/tests/test_place_finder_cost_tracking.py
@@ -10,8 +10,9 @@ from receipt_agent.subagents.place_finder.graph import (
 from receipt_agent.utils.llm_factory import CostTrackingCallback
 
 
-def test_fix_place_runner_attaches_cost_callback_to_graph():
+def test_fix_place_runner_attaches_cost_callback_to_graph(monkeypatch):
     """The graph-level handler must propagate to every tool-calling turn."""
+    monkeypatch.setenv("FIX_PLACE_RESOLUTION_MODE", "tiered")
     graph = AsyncMock()
     callback = CostTrackingCallback()
     state_holder = {"cost_callback": callback}

--- a/receipt_agent/tests/test_place_finder_cost_tracking.py
+++ b/receipt_agent/tests/test_place_finder_cost_tracking.py
@@ -1,6 +1,7 @@
 """Cost visibility tests for the live fix-place graph runner."""
 
 import asyncio
+from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 from receipt_agent.subagents.place_finder.graph import (
@@ -33,9 +34,20 @@ def test_fix_place_runner_attaches_cost_callback_to_graph():
             state_holder=state_holder,
             image_id="image-1",
             receipt_id=1,
+            receipt_words=[SimpleNamespace(line_id=2, word_id=3, text="Test")],
+            receipt_labels=[
+                SimpleNamespace(
+                    line_id=2,
+                    word_id=3,
+                    label="MERCHANT_NAME",
+                    validation_status="VALID",
+                )
+            ],
         )
     )
 
     assert result["found"] is True
     config = graph.ainvoke.call_args.kwargs["config"]
     assert callback.handler in config["callbacks"]
+    assert config["recursion_limit"] == 12
+    assert state_holder["context"].words[0]["label"] == "MERCHANT_NAME"

--- a/receipt_agent/tests/test_tiered_place_resolution.py
+++ b/receipt_agent/tests/test_tiered_place_resolution.py
@@ -34,6 +34,7 @@ def _place(
     name="Test Market",
     address="123 Main St, Las Vegas, NV 89101, USA",
     phone="(702) 555-0100",
+    types=None,
 ):
     return SimpleNamespace(
         place_id=place_id,
@@ -41,6 +42,7 @@ def _place(
         formatted_address=address,
         formatted_phone_number=phone,
         international_phone_number=None,
+        types=types or ["establishment", "point_of_interest"],
     )
 
 
@@ -202,7 +204,14 @@ def test_text_search_uses_merchant_and_rejects_wrong_phone_result():
         address="10940 S Eastern Ave Suite 107, Henderson, NV 89052, USA",
         phone="(702) 728-5838",
     )
-    places = _FakePlaces(phone=unrelated, text=correct)
+    address_only = _place(
+        place_id="address",
+        name="10940 S Eastern Ave Suite 107",
+        address="10940 S Eastern Ave Suite 107, Henderson, NV 89052, USA",
+        phone=None,
+        types=["street_address", "subpremise"],
+    )
+    places = _FakePlaces(phone=unrelated, address=address_only, text=correct)
 
     result, stats = asyncio.run(resolve_tiered_place(details, places))
 

--- a/receipt_agent/tests/test_tiered_place_resolution.py
+++ b/receipt_agent/tests/test_tiered_place_resolution.py
@@ -76,6 +76,29 @@ def _address_details():
     )
 
 
+def _place_clue_details(
+    *,
+    merchant="Right Cafe",
+    address="123 Main St, Las Vegas, NV 89101",
+    phone="(702) 555-0100",
+    current_place=None,
+):
+    values = [
+        (1, merchant, "MERCHANT_NAME"),
+        (2, address, "ADDRESS_LINE"),
+        (3, phone, "PHONE_NUMBER"),
+    ]
+    return SimpleNamespace(
+        place=current_place,
+        words=[_word(line_id, 1, text) for line_id, text, _ in values],
+        labels=[_label(line_id, 1, label) for line_id, _, label in values],
+        lines=[
+            SimpleNamespace(line_id=line_id, text=text)
+            for line_id, text, _ in values
+        ],
+    )
+
+
 class _FakePlaces:
     def __init__(self, *, details=None, phone=None, address=None, text=None):
         self.details = details
@@ -146,6 +169,15 @@ def test_tier1_address_match_resolves_without_llm():
     assert [method for method, _ in places.calls] == ["address"]
 
 
+def test_tier1_address_match_returns_empty_phone_string():
+    places = _FakePlaces(address=_place(phone=None))
+
+    result, _ = asyncio.run(resolve_tiered_place(_address_details(), places))
+
+    assert result["resolution_tier"] == "tier1"
+    assert result["phone_number"] == ""
+
+
 def test_tier1_rejects_conflicting_high_confidence_candidates():
     candidates = [
         PlaceCandidate("p1", "One", None, None, 0.99, {"phone"}),
@@ -170,6 +202,83 @@ def test_tier1_rejects_unrelated_phone_text_fallback(monkeypatch):
 
     assert result is None
     assert stats["llm_calls"] == 0
+
+
+def test_tier1_rejects_phone_match_with_conflicting_receipt_clues(
+    monkeypatch,
+):
+    monkeypatch.setenv("FIX_PLACE_TIER2_ENABLED", "false")
+    conflicting = _place(
+        place_id="wrong",
+        name="Wrong Market",
+        address="999 Main St, Las Vegas, NV 89101, USA",
+        phone="(702) 555-0100",
+    )
+    places = _FakePlaces(phone=conflicting)
+
+    result, stats = asyncio.run(
+        resolve_tiered_place(_place_clue_details(), places)
+    )
+
+    assert result is None
+    assert stats["llm_calls"] == 0
+
+
+def test_tier1_rejects_address_match_with_conflicting_receipt_clues(
+    monkeypatch,
+):
+    monkeypatch.setenv("FIX_PLACE_TIER2_ENABLED", "false")
+    conflicting = _place(
+        place_id="wrong",
+        name="Wrong Market",
+        address="123 Main St, Las Vegas, NV 89101, USA",
+        phone="(702) 555-0199",
+    )
+    places = _FakePlaces(address=conflicting)
+
+    result, stats = asyncio.run(
+        resolve_tiered_place(_place_clue_details(), places)
+    )
+
+    assert result is None
+    assert stats["llm_calls"] == 0
+
+
+def test_tier0_rejects_existing_place_with_conflicting_merchant():
+    current = SimpleNamespace(
+        place_id="wrong",
+        merchant_name="Wrong Market",
+        formatted_address="123 Main St, Las Vegas, NV 89101, USA",
+        phone_number="(702) 555-0100",
+    )
+    wrong = _place(
+        place_id="wrong",
+        name="Wrong Market",
+        address="123 Main St, Las Vegas, NV 89101, USA",
+        phone="(702) 555-0100",
+    )
+    right = _place(
+        place_id="right",
+        name="Right Cafe",
+        address="123 Main St, Las Vegas, NV 89101, USA",
+        phone="(702) 555-0100",
+    )
+    places = _FakePlaces(
+        details=wrong,
+        phone=wrong,
+        address=wrong,
+        text=right,
+    )
+
+    result, _ = asyncio.run(
+        resolve_tiered_place(
+            _place_clue_details(current_place=current),
+            places,
+        )
+    )
+
+    assert result["place_id"] == "right"
+    assert result["resolution_tier"] == "tier1"
 
 
 def test_text_search_uses_merchant_and_rejects_wrong_phone_result():

--- a/receipt_agent/tests/test_tiered_place_resolution.py
+++ b/receipt_agent/tests/test_tiered_place_resolution.py
@@ -200,9 +200,9 @@ def test_text_search_uses_merchant_and_rejects_wrong_phone_result():
     )
     correct = _place(
         place_id="craft",
-        name="CRAFTkitchen",
+        name="CRAFT Kitchen",
         address="10940 S Eastern Ave Suite 107, Henderson, NV 89052, USA",
-        phone="(702) 728-5838",
+        phone=None,
     )
     address_only = _place(
         place_id="address",
@@ -217,6 +217,8 @@ def test_text_search_uses_merchant_and_rejects_wrong_phone_result():
 
     assert result["place_id"] == "craft"
     assert result["resolution_tier"] == "tier1"
+    assert result["phone_number"] == "702 728 5838"
+    assert result["sources"]["phone_number"] == "receipt_labels"
     assert stats["llm_calls"] == 0
     text_call = next(query for method, query in places.calls if method == "text")
     assert text_call == "CRAFTKITCHEN"

--- a/receipt_agent/tests/test_tiered_place_resolution.py
+++ b/receipt_agent/tests/test_tiered_place_resolution.py
@@ -1,0 +1,192 @@
+"""Tests for the low-cost fix-place resolution tiers."""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from receipt_agent.subagents.place_finder.tiered import (
+    PlaceCandidate,
+    ReceiptClues,
+    Tier2Selection,
+    _select_with_llm,
+    resolve_tiered_place,
+    select_deterministic_candidate,
+)
+
+
+def _word(line_id, word_id, text):
+    return SimpleNamespace(line_id=line_id, word_id=word_id, text=text)
+
+
+def _label(line_id, word_id, label, status="VALID"):
+    return SimpleNamespace(
+        line_id=line_id,
+        word_id=word_id,
+        label=label,
+        validation_status=status,
+    )
+
+
+def _place(
+    place_id="ChIJ-test",
+    name="Test Market",
+    address="123 Main St, Las Vegas, NV 89101, USA",
+    phone="(702) 555-0100",
+):
+    return SimpleNamespace(
+        place_id=place_id,
+        name=name,
+        formatted_address=address,
+        formatted_phone_number=phone,
+        international_phone_number=None,
+    )
+
+
+def _details(*, current_place=None, phone="(702) 555-0100"):
+    return SimpleNamespace(
+        place=current_place,
+        words=[_word(1, 1, phone)],
+        labels=[_label(1, 1, "PHONE_NUMBER")],
+        lines=[SimpleNamespace(line_id=1, text=phone)],
+    )
+
+
+def _address_details():
+    words = [
+        _word(2, 1, "123"),
+        _word(2, 2, "Main"),
+        _word(2, 3, "St"),
+        _word(3, 1, "Las Vegas, NV 89101"),
+    ]
+    return SimpleNamespace(
+        place=None,
+        words=words,
+        labels=[
+            _label(word.line_id, word.word_id, "ADDRESS_LINE")
+            for word in words
+        ],
+        lines=[
+            SimpleNamespace(line_id=2, text="123 Main St"),
+            SimpleNamespace(line_id=3, text="Las Vegas, NV 89101"),
+        ],
+    )
+
+
+class _FakePlaces:
+    def __init__(self, *, details=None, phone=None, address=None, text=None):
+        self.details = details
+        self.phone = phone
+        self.address = address
+        self.text = text
+        self.calls = []
+
+    def get_place_details(self, place_id):
+        self.calls.append(("details", place_id))
+        return self.details
+
+    def search_by_phone(self, phone):
+        self.calls.append(("phone", phone))
+        return self.phone
+
+    def search_by_address(self, address):
+        self.calls.append(("address", address))
+        return self.address
+
+    def search_by_text(self, text):
+        self.calls.append(("text", text))
+        return self.text
+
+
+def test_tier0_keeps_consistent_existing_place_without_llm():
+    current = SimpleNamespace(
+        place_id="ChIJ-test",
+        merchant_name="Test Market",
+        formatted_address="123 Main St, Las Vegas, NV 89101, USA",
+        phone_number="(702) 555-0100",
+    )
+    places = _FakePlaces(details=_place())
+
+    result, stats = asyncio.run(
+        resolve_tiered_place(_details(current_place=current), places)
+    )
+
+    assert result["resolution_tier"] == "tier0"
+    assert result["place_id"] == "ChIJ-test"
+    assert stats["llm_calls"] == 0
+    assert places.calls == [("details", "ChIJ-test")]
+
+
+def test_tier1_phone_match_resolves_without_llm():
+    places = _FakePlaces(phone=_place())
+
+    result, stats = asyncio.run(resolve_tiered_place(_details(), places))
+
+    assert result["resolution_tier"] == "tier1"
+    assert result["confidence"] == 1.0
+    assert result["search_methods_used"] == ["phone"]
+    assert stats["llm_calls"] == 0
+    assert [method for method, _ in places.calls] == ["phone"]
+
+
+def test_tier1_address_match_resolves_without_llm():
+    places = _FakePlaces(address=_place())
+
+    result, stats = asyncio.run(
+        resolve_tiered_place(_address_details(), places)
+    )
+
+    assert result["resolution_tier"] == "tier1"
+    assert result["confidence"] == 1.0
+    assert result["search_methods_used"] == ["address"]
+    assert stats["llm_calls"] == 0
+    assert [method for method, _ in places.calls] == ["address"]
+
+
+def test_tier1_rejects_conflicting_high_confidence_candidates():
+    candidates = [
+        PlaceCandidate("p1", "One", None, None, 0.99, {"phone"}),
+        PlaceCandidate("p2", "Two", None, None, 0.95, {"address"}),
+    ]
+
+    assert select_deterministic_candidate(candidates, 0.90) is None
+
+
+def test_tier2_makes_one_structured_picker_call():
+    candidate = PlaceCandidate(
+        "ChIJ-test",
+        "Test Market",
+        "123 Main St, Las Vegas, NV 89101, USA",
+        "(702) 555-0100",
+        0.80,
+        {"text"},
+    )
+    structured_llm = MagicMock()
+    structured_llm.ainvoke = AsyncMock(
+        return_value=Tier2Selection(
+            place_id="ChIJ-test",
+            confidence=0.91,
+            reasoning="Receipt name and address match.",
+        )
+    )
+    base_llm = MagicMock()
+    base_llm.with_structured_output.return_value = structured_llm
+
+    with patch(
+        "receipt_agent.subagents.place_finder.tiered.create_llm",
+        return_value=base_llm,
+    ) as create_llm:
+        result, _ = asyncio.run(
+            _select_with_llm(
+                ReceiptClues(
+                    merchant_name="Test Market",
+                    address="123 Main St",
+                    snippet="TEST MARKET\n123 MAIN ST",
+                ),
+                [candidate],
+            )
+        )
+
+    assert result["resolution_tier"] == "tier2"
+    assert result["place_id"] == "ChIJ-test"
+    structured_llm.ainvoke.assert_awaited_once()
+    assert create_llm.call_args.kwargs["model"] == "openai/gpt-oss-120b"

--- a/receipt_agent/tests/test_tiered_place_resolution.py
+++ b/receipt_agent/tests/test_tiered_place_resolution.py
@@ -65,7 +65,10 @@ def _address_details():
     return SimpleNamespace(
         place=None,
         words=words,
-        labels=[_label(word.line_id, word.word_id, "ADDRESS_LINE") for word in words],
+        labels=[
+            _label(word.line_id, word.word_id, "ADDRESS_LINE")
+            for word in words
+        ],
         lines=[
             SimpleNamespace(line_id=2, text="123 Main St"),
             SimpleNamespace(line_id=3, text="Las Vegas, NV 89101"),
@@ -132,7 +135,9 @@ def test_tier1_phone_match_resolves_without_llm():
 def test_tier1_address_match_resolves_without_llm():
     places = _FakePlaces(address=_place())
 
-    result, stats = asyncio.run(resolve_tiered_place(_address_details(), places))
+    result, stats = asyncio.run(
+        resolve_tiered_place(_address_details(), places)
+    )
 
     assert result["resolution_tier"] == "tier1"
     assert result["confidence"] == 0.90
@@ -220,7 +225,9 @@ def test_text_search_uses_merchant_and_rejects_wrong_phone_result():
     assert result["phone_number"] == "702 728 5838"
     assert result["sources"]["phone_number"] == "receipt_labels"
     assert stats["llm_calls"] == 0
-    text_call = next(query for method, query in places.calls if method == "text")
+    text_call = next(
+        query for method, query in places.calls if method == "text"
+    )
     assert text_call == "CRAFTKITCHEN"
 
 
@@ -252,6 +259,35 @@ def test_address_matching_ignores_equivalent_unit_notation():
         "10940 S EASTERN AVE #107, HENDERSON, NV 89052",
         "10940 S Eastern Avenue Suite 107, Henderson, NV 89052, USA",
     )
+
+
+def test_address_matching_requires_exact_street_number():
+    assert not _addresses_match(
+        "1 Main St, Las Vegas, NV 89101",
+        "11 Main St, Las Vegas, NV 89101",
+    )
+
+
+def test_tiered_resolution_escalates_without_receipt_place_evidence():
+    current = SimpleNamespace(
+        place_id="ChIJ-wrong",
+        merchant_name="Wrong Market",
+        formatted_address="11 Main St, Las Vegas, NV 89101, USA",
+        phone_number="(702) 555-0111",
+    )
+    details = SimpleNamespace(
+        place=current,
+        words=[_word(1, 1, "Wrong Market")],
+        labels=[_label(1, 1, "MERCHANT_NAME", status="INVALID")],
+        lines=[SimpleNamespace(line_id=1, text="Wrong Market")],
+    )
+    places = _FakePlaces(details=_place(place_id="ChIJ-wrong"))
+
+    result, stats = asyncio.run(resolve_tiered_place(details, places))
+
+    assert result is None
+    assert stats["llm_calls"] == 0
+    assert places.calls == []
 
 
 def test_tier2_makes_one_structured_picker_call():

--- a/receipt_agent/tests/test_tiered_place_resolution.py
+++ b/receipt_agent/tests/test_tiered_place_resolution.py
@@ -10,6 +10,7 @@ from receipt_agent.subagents.place_finder.tiered import (
     Tier2Selection,
     _addresses_match,
     _select_with_llm,
+    extract_receipt_clues,
     resolve_tiered_place,
     select_deterministic_candidate,
 )
@@ -164,7 +165,7 @@ def test_tier1_rejects_unrelated_phone_text_fallback(monkeypatch):
     assert stats["llm_calls"] == 0
 
 
-def test_text_search_uses_merchant_and_address_and_rejects_wrong_phone_result():
+def test_text_search_uses_merchant_and_rejects_wrong_phone_result():
     details = SimpleNamespace(
         place=None,
         words=[
@@ -209,7 +210,30 @@ def test_text_search_uses_merchant_and_address_and_rejects_wrong_phone_result():
     assert result["resolution_tier"] == "tier1"
     assert stats["llm_calls"] == 0
     text_call = next(query for method, query in places.calls if method == "text")
-    assert text_call == ("CRAFTKITCHEN 10940 S EASTERN AVE #107, HENDERSON, NV 89052")
+    assert text_call == "CRAFTKITCHEN"
+
+
+def test_address_clues_drop_stray_header_labels_before_street_number():
+    details = SimpleNamespace(
+        place=None,
+        words=[
+            _word(1, 1, "Henderson"),
+            _word(2, 1, "4300"),
+            _word(2, 2, "E Sunset Rd. Suite A3"),
+            _word(3, 1, "Henderson, NV 89014"),
+        ],
+        labels=[
+            _label(1, 1, "ADDRESS_LINE"),
+            _label(2, 1, "ADDRESS_LINE"),
+            _label(2, 2, "ADDRESS_LINE"),
+            _label(3, 1, "ADDRESS_LINE"),
+        ],
+        lines=[],
+    )
+
+    assert extract_receipt_clues(details).address == (
+        "4300 E Sunset Rd. Suite A3, Henderson, NV 89014"
+    )
 
 
 def test_address_matching_ignores_equivalent_unit_notation():
@@ -258,3 +282,4 @@ def test_tier2_makes_one_structured_picker_call():
     assert result["place_id"] == "ChIJ-test"
     structured_llm.ainvoke.assert_awaited_once()
     assert create_llm.call_args.kwargs["model"] == "openai/gpt-oss-120b"
+    assert create_llm.call_args.kwargs["reasoning"] is True

--- a/receipt_agent/tests/test_tiered_place_resolution.py
+++ b/receipt_agent/tests/test_tiered_place_resolution.py
@@ -8,6 +8,7 @@ from receipt_agent.subagents.place_finder.tiered import (
     PlaceCandidate,
     ReceiptClues,
     Tier2Selection,
+    _addresses_match,
     _select_with_llm,
     resolve_tiered_place,
     select_deterministic_candidate,
@@ -61,10 +62,7 @@ def _address_details():
     return SimpleNamespace(
         place=None,
         words=words,
-        labels=[
-            _label(word.line_id, word.word_id, "ADDRESS_LINE")
-            for word in words
-        ],
+        labels=[_label(word.line_id, word.word_id, "ADDRESS_LINE") for word in words],
         lines=[
             SimpleNamespace(line_id=2, text="123 Main St"),
             SimpleNamespace(line_id=3, text="Las Vegas, NV 89101"),
@@ -122,7 +120,7 @@ def test_tier1_phone_match_resolves_without_llm():
     result, stats = asyncio.run(resolve_tiered_place(_details(), places))
 
     assert result["resolution_tier"] == "tier1"
-    assert result["confidence"] == 1.0
+    assert result["confidence"] == 0.95
     assert result["search_methods_used"] == ["phone"]
     assert stats["llm_calls"] == 0
     assert [method for method, _ in places.calls] == ["phone"]
@@ -131,12 +129,10 @@ def test_tier1_phone_match_resolves_without_llm():
 def test_tier1_address_match_resolves_without_llm():
     places = _FakePlaces(address=_place())
 
-    result, stats = asyncio.run(
-        resolve_tiered_place(_address_details(), places)
-    )
+    result, stats = asyncio.run(resolve_tiered_place(_address_details(), places))
 
     assert result["resolution_tier"] == "tier1"
-    assert result["confidence"] == 1.0
+    assert result["confidence"] == 0.90
     assert result["search_methods_used"] == ["address"]
     assert stats["llm_calls"] == 0
     assert [method for method, _ in places.calls] == ["address"]
@@ -149,6 +145,78 @@ def test_tier1_rejects_conflicting_high_confidence_candidates():
     ]
 
     assert select_deterministic_candidate(candidates, 0.90) is None
+
+
+def test_tier1_rejects_unrelated_phone_text_fallback(monkeypatch):
+    """A phone search result must return the same phone it was searched by."""
+    monkeypatch.setenv("FIX_PLACE_TIER2_ENABLED", "false")
+    unrelated = _place(
+        place_id="wrong",
+        name="Professional Roofing Services",
+        address="4180 W Patrick Ln, Las Vegas, NV 89118, USA",
+        phone="(702) 500-0670",
+    )
+    places = _FakePlaces(phone=unrelated)
+
+    result, stats = asyncio.run(resolve_tiered_place(_details(), places))
+
+    assert result is None
+    assert stats["llm_calls"] == 0
+
+
+def test_text_search_uses_merchant_and_address_and_rejects_wrong_phone_result():
+    details = SimpleNamespace(
+        place=None,
+        words=[
+            _word(1, 1, "CRAFTKITCHEN"),
+            _word(2, 1, "10940"),
+            _word(2, 2, "S"),
+            _word(2, 3, "EASTERN"),
+            _word(2, 4, "AVE"),
+            _word(2, 5, "#107"),
+            _word(3, 1, "HENDERSON,"),
+            _word(3, 2, "NV"),
+            _word(3, 3, "89052"),
+            _word(4, 1, "702"),
+            _word(4, 2, "728"),
+            _word(4, 3, "5838"),
+        ],
+        labels=[
+            _label(1, 1, "MERCHANT_NAME"),
+            *[_label(2, word_id, "ADDRESS_LINE") for word_id in range(1, 6)],
+            *[_label(3, word_id, "ADDRESS_LINE") for word_id in range(1, 4)],
+            *[_label(4, word_id, "PHONE_NUMBER") for word_id in range(1, 4)],
+        ],
+        lines=[SimpleNamespace(line_id=1, text="CRAFTKITCHEN")],
+    )
+    unrelated = _place(
+        place_id="wrong",
+        name="Professional Roofing Services",
+        address="4180 W Patrick Ln, Las Vegas, NV 89118, USA",
+        phone="(702) 500-0670",
+    )
+    correct = _place(
+        place_id="craft",
+        name="CRAFTkitchen",
+        address="10940 S Eastern Ave Suite 107, Henderson, NV 89052, USA",
+        phone="(702) 728-5838",
+    )
+    places = _FakePlaces(phone=unrelated, text=correct)
+
+    result, stats = asyncio.run(resolve_tiered_place(details, places))
+
+    assert result["place_id"] == "craft"
+    assert result["resolution_tier"] == "tier1"
+    assert stats["llm_calls"] == 0
+    text_call = next(query for method, query in places.calls if method == "text")
+    assert text_call == ("CRAFTKITCHEN 10940 S EASTERN AVE #107, HENDERSON, NV 89052")
+
+
+def test_address_matching_ignores_equivalent_unit_notation():
+    assert _addresses_match(
+        "10940 S EASTERN AVE #107, HENDERSON, NV 89052",
+        "10940 S Eastern Avenue Suite 107, Henderson, NV 89052, USA",
+    )
 
 
 def test_tier2_makes_one_structured_picker_call():

--- a/receipt_places/receipt_places/client.py
+++ b/receipt_places/receipt_places/client.py
@@ -544,7 +544,19 @@ class PlacesClient:
                 "user_ratings_total",
             ]
 
-            expected_fields = set(fields)
+            # Google legitimately omits optional requested fields (for
+            # example phone, website, hours, or ratings). Requiring every
+            # field made otherwise valid address/phone results disappear from
+            # the fix-place cascade. Keep the quality gate on the stable
+            # identity and location fields; optional enrichment remains typed
+            # as ``None`` when Google does not return it.
+            expected_fields = {
+                "place_id",
+                "name",
+                "formatted_address",
+                "geometry",
+                "types",
+            }
 
             data = self._make_request(
                 "details/json",

--- a/receipt_places/receipt_places/client.py
+++ b/receipt_places/receipt_places/client.py
@@ -285,6 +285,24 @@ class PlacesClient:
         if not details:
             return None
 
+        returned_phone = (
+            details.formatted_phone_number
+            or details.international_phone_number
+            or ""
+        )
+        returned_digits = self._extract_digits(returned_phone)
+        if not returned_digits or (
+            returned_digits[-10:] != digits[-10:]
+            if len(returned_digits) >= 10 and len(digits) >= 10
+            else returned_digits != digits
+        ):
+            logger.warning(
+                "Rejecting phone text-search fallback: returned place phone "
+                "does not match %s",
+                phone_number,
+            )
+            return None
+
         # Cache with phone digits as key
         details_response = {
             "status": "OK",

--- a/receipt_places/tests/test_client.py
+++ b/receipt_places/tests/test_client.py
@@ -318,6 +318,40 @@ class TestGetPlaceDetails:
         assert result.name == "Test Business"
         assert result.formatted_phone_number == "(555) 123-4567"
 
+    @responses.activate
+    def test_get_place_details_allows_missing_optional_fields(
+        self,
+        places_client: PlacesClient,
+    ) -> None:
+        """Businesses need not publish phone, website, hours, or ratings."""
+        required = {
+            "place_id",
+            "name",
+            "formatted_address",
+            "geometry",
+            "types",
+        }
+        responses.add(
+            responses.GET,
+            "https://maps.googleapis.com/maps/api/place/details/json",
+            json={
+                "status": "OK",
+                "result": {
+                    key: value
+                    for key, value in SAMPLE_DETAILS_RESPONSE["result"].items()
+                    if key in required
+                },
+            },
+            status=200,
+        )
+
+        result = places_client.get_place_details("ChIJtest123")
+
+        assert result is not None
+        assert result.place_id == "ChIJtest123"
+        assert result.formatted_phone_number is None
+        assert result.website is None
+
     def test_get_place_details_empty(
         self,
         places_client: PlacesClient,

--- a/receipt_places/tests/test_client.py
+++ b/receipt_places/tests/test_client.py
@@ -133,6 +133,58 @@ class TestSearchByPhone:
         result = places_client.search_by_phone("999-999-9999")
         assert result is None
 
+    @responses.activate
+    def test_search_by_phone_rejects_unrelated_text_fallback(
+        self,
+        places_client: PlacesClient,
+    ) -> None:
+        """A broad text result must not be cached as an exact phone match."""
+        responses.add(
+            responses.GET,
+            "https://maps.googleapis.com/maps/api/place/findplacefromtext/json",
+            json={"status": "ZERO_RESULTS", "candidates": []},
+            status=200,
+        )
+        responses.add(
+            responses.GET,
+            "https://maps.googleapis.com/maps/api/place/textsearch/json",
+            json={
+                "status": "OK",
+                "results": [
+                    {
+                        "place_id": "wrong-place",
+                        "name": "Unrelated Business",
+                        "formatted_address": "999 Wrong St, City, ST 12345",
+                        "types": ["roofing_contractor"],
+                    }
+                ],
+            },
+            status=200,
+        )
+        wrong_details = dict(SAMPLE_DETAILS_RESPONSE["result"])
+        wrong_details.update(
+            {
+                "place_id": "wrong-place",
+                "name": "Unrelated Business",
+                "formatted_phone_number": "(702) 500-0670",
+                "international_phone_number": "+1 702-500-0670",
+            }
+        )
+        responses.add(
+            responses.GET,
+            "https://maps.googleapis.com/maps/api/place/details/json",
+            json={"status": "OK", "result": wrong_details},
+            status=200,
+        )
+
+        result = places_client.search_by_phone("702-728-5838")
+
+        assert result is None
+        assert (
+            places_client._cache.get("PHONE", "7027285838")  # noqa: SLF001
+            is None
+        )
+
 
 class TestSearchByAddress:
     """Test address search functionality."""


### PR DESCRIPTION
## Summary

- add Tier 0 validation for an existing place_id against receipt-labeled phone/address
- add a cached deterministic phone → address → merchant Places cascade for Tier 1
- add one structured cheap-model candidate picker for ambiguous Tier 2 cases
- defer Chroma and embedding client construction until the capped Tier 3 agent is actually needed
- cap Tier 3 at 12 graph steps, force `submit_place` after 3 rounds, compact history, and stop immediately after submission
- reject mismatched phone fallbacks and address-only Google records before they can become merchants
- normalize receipt addresses, unit notation, and merchant spacing; preserve receipt-labeled phone data when Google omits it
- enable tiered mode only on the dev stack by default; non-dev stacks retain the legacy path behind `FIX_PLACE_RESOLUTION_MODE`
- log and return the resolution tier for CloudWatch measurement

Stacked on #1157 so this PR shows only the tiered-resolution changes. Retarget to `main` after #1157 merges.

Addresses #1156.

## Model rollout

- Tier 2 default: `openai/gpt-oss-120b`, configurable with `FIX_PLACE_TIER2_MODEL`; required reasoning mode is enabled
- dev Tier 3 default: `x-ai/grok-4.3`, configurable with `FIX_PLACE_AGENT_MODEL` (`grok-4.1-fast` was rejected live because OpenRouter deprecated it)
- non-dev behavior is unchanged; no production model or resolution-mode flip

## Validation

- focused agent suite: 12 passed
- Places client suite: 28 passed
- Tier 0, phone/address/name Tier 1, and address-record rejection fixtures resolve without unnecessary LLM calls
- Tier 2 fixture makes exactly one structured picker call
- Tier 3 tests prove forced submission after 3 rounds and no extra LLM turn after submit
- malformed header labels, equivalent unit notation, optional Google fields, merchant spacing, and mismatched phone fallbacks have regression coverage
- modified modules compile successfully and diff checks pass

## Live dev E2E

Deployed isolated candidate image:

- tag: `fixplace1156-0ebcc3f01`
- digest: `sha256:f517db9c7b628d655e4673979ebc2eeac52720bc696df85ab01b08d110b5730b`

Both exported receipts completed successfully on that exact image:

| Receipt | Result | Tier | LLM calls | Cost |
| --- | --- | ---: | ---: | ---: |
| IMG_3197.png / Rise Henderson | `ChIJHSm8JxDQyIARf_nru6eda38` | Tier 0 | 0 | $0.00 |
| IMG_3201.png / CRAFT Kitchen | `ChIJ4fYsfv7NyIAR5ZWG31FHHzM` | Tier 1 | 0 | $0.00 |

CRAFT Kitchen was also tested from a conditionally deleted place row, proving the deterministic path reconstructs the correct merchant, address, and receipt phone. The bad phone cache entry is absent and both final DynamoDB rows contain the expected place IDs.

During hard-case diagnosis, capped Tier 3 invocations used 4 calls and cost $0.0225–$0.0337, about 52–68% below the ~$0.07 baseline.

The normal Pulumi preview is currently blocked by an unrelated pre-existing duplicate address-cache URN. The candidate was therefore built from the already-deployed source with only the reviewed runtime files overlaid through the dedicated dev image builder; production was not changed.