### PR TITLE
fix: make merge place migration clone + upsert-safe

### DIFF
--- a/infra/combine_receipts_step_functions/lambdas/combine_receipts_logic.py
+++ b/infra/combine_receipts_step_functions/lambdas/combine_receipts_logic.py
@@ -6,12 +6,9 @@ It can be used by both the dev script and the Lambda handler.
 """
 
 import logging
-from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
 from receipt_dynamo import DynamoClient
-from receipt_dynamo.constants import MerchantValidationStatus, ValidationMethod
-from receipt_dynamo.entities import ReceiptPlace
 
 # Import image processing (optional)
 try:
@@ -34,6 +31,7 @@ except ImportError as e:
 from embedding_utils import create_embeddings_and_compaction_run
 from receipt_upload.combine import (
     calculate_min_area_rect,
+    clone_receipt_place_for_receipt,
     combine_receipt_letters_to_image_coords,
     combine_receipt_words_to_image_coords,
     create_combined_receipt_records,
@@ -41,6 +39,7 @@ from receipt_upload.combine import (
     create_warped_receipt_image,
     get_best_receipt_place,
     migrate_receipt_word_labels,
+    upsert_receipt_place,
 )
 from s3_io import save_records_json_to_s3
 
@@ -244,32 +243,16 @@ def combine_receipts(
                     combined_image.tobytes()
                 )
 
-        # Get best ReceiptPlace
+        # Get best ReceiptPlace (full clone — do not drop geo/hours/etc.)
         best_place = get_best_receipt_place(client, image_id, receipt_ids)
         receipt_place = None
         if best_place:
-            receipt_place = ReceiptPlace(
-                image_id=image_id,
-                receipt_id=new_receipt_id,
-                place_id=best_place.place_id or "",
-                merchant_name=best_place.merchant_name or "",
-                merchant_category=best_place.merchant_category or "",
-                formatted_address=best_place.formatted_address or "",
-                phone_number=best_place.phone_number or "",
-                matched_fields=(
-                    best_place.matched_fields.copy()
-                    if best_place.matched_fields
-                    else []
+            receipt_place = clone_receipt_place_for_receipt(
+                best_place,
+                new_receipt_id=new_receipt_id,
+                reasoning_prefix=(
+                    f"Combined from receipts {receipt_ids}. Original: "
                 ),
-                validated_by=best_place.validated_by
-                or ValidationMethod.TEXT_SEARCH.value,
-                timestamp=datetime.now(timezone.utc),
-                reasoning=(
-                    f"Combined from receipts {receipt_ids}. "
-                    f"Original: {best_place.reasoning or 'N/A'}"
-                ),
-                validation_status=best_place.validation_status
-                or MerchantValidationStatus.MATCHED.value,
             )
 
         # Migrate labels
@@ -352,37 +335,15 @@ def combine_receipts(
                     # Re-raise if it's a different error
                     raise
 
-            # Try to add place data, but if it already exists (from a previous failed attempt),
-            # delete it first and try again
+            # Idempotent place write (retries after partial Dynamo writes)
             if receipt_place:
-                try:
-                    client.add_receipt_place(receipt_place)
-                except Exception as e:  # pylint: disable=broad-except
-                    error_str = str(e)
-                    if (
-                        "ConditionalCheckFailed" in error_str
-                        or "already exists" in error_str.lower()
-                    ):
-                        logger.warning(
-                            "Receipt place data already exists for receipt %s/%s (likely from previous failed attempt), deleting and retrying",
-                            image_id,
-                            new_receipt_id,
-                        )
-                        # Delete the existing place data (pass the ReceiptPlace object)
-                        try:
-                            client.delete_receipt_place(receipt_place)
-                        except (
-                            Exception
-                        ) as delete_err:  # pylint: disable=broad-except
-                            logger.warning(
-                                "Error deleting existing place data (may not exist): %s",
-                                delete_err,
-                            )
-                        # Try adding again
-                        client.add_receipt_place(receipt_place)
-                    else:
-                        # Re-raise if it's a different error
-                        raise
+                place_action = upsert_receipt_place(client, receipt_place)
+                logger.info(
+                    "Receipt place %s for receipt %s/%s",
+                    place_action,
+                    image_id,
+                    new_receipt_id,
+                )
             for label in migrated_labels:
                 client.add_receipt_word_label(label)
             if compaction_run:

--- a/infra/combine_receipts_step_functions/lambdas/combine_receipts_logic.py
+++ b/infra/combine_receipts_step_functions/lambdas/combine_receipts_logic.py
@@ -13,6 +13,7 @@ from receipt_dynamo import DynamoClient
 # Import image processing (optional)
 try:
     from PIL import Image as PIL_Image
+
     from receipt_upload.utils import (
         calculate_sha256_from_bytes,
         upload_all_cdn_formats,
@@ -29,6 +30,8 @@ except ImportError as e:
 # Import helper modules
 # Use local embedding_utils instead of package version to ensure we use upload_bundled_delta_to_s3
 from embedding_utils import create_embeddings_and_compaction_run
+from s3_io import save_records_json_to_s3
+
 from receipt_upload.combine import (
     calculate_min_area_rect,
     clone_receipt_place_for_receipt,
@@ -41,7 +44,6 @@ from receipt_upload.combine import (
     migrate_receipt_word_labels,
     upsert_receipt_place,
 )
-from s3_io import save_records_json_to_s3
 
 logger = logging.getLogger()
 

--- a/infra/merge_receipt_lambda/lambdas/merge_receipt.py
+++ b/infra/merge_receipt_lambda/lambdas/merge_receipt.py
@@ -70,14 +70,24 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
         dry_run = event.get("dry_run", False)
 
         if not image_id:
-            return {"status": "error", "error": "Missing required field: image_id"}
-        if not receipt_ids or not isinstance(receipt_ids, list) or len(receipt_ids) != 2:
+            return {
+                "status": "error",
+                "error": "Missing required field: image_id",
+            }
+        if (
+            not receipt_ids
+            or not isinstance(receipt_ids, list)
+            or len(receipt_ids) != 2
+        ):
             return {
                 "status": "error",
                 "error": "receipt_ids must be a list of exactly 2 receipt IDs",
             }
         if not all(isinstance(rid, int) for rid in receipt_ids):
-            return {"status": "error", "error": "receipt_ids must contain integers"}
+            return {
+                "status": "error",
+                "error": "receipt_ids must contain integers",
+            }
         if receipt_ids[0] == receipt_ids[1]:
             return {"status": "error", "error": "receipt_ids must be distinct"}
 
@@ -95,14 +105,15 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
             create_embeddings_and_compaction_run,
         )
         from receipt_dynamo import DynamoClient
+
         from receipt_upload.combine import (
             calculate_min_area_rect,
+            clone_receipt_place_for_receipt,
             combine_receipt_letters_to_image_coords,
             combine_receipt_words_to_image_coords,
             create_combined_receipt_records,
             create_receipt_letters_from_combined,
             create_warped_receipt_image,
-            clone_receipt_place_for_receipt,
             get_best_receipt_place,
             migrate_receipt_word_labels,
             upsert_receipt_place,
@@ -187,9 +198,7 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
         src_corners = rect_info["src_corners"]
         warped_width = rect_info["warped_width"]
         warped_height = rect_info["warped_height"]
-        logger.info(
-            "Warped dimensions: %dx%d", warped_width, warped_height
-        )
+        logger.info("Warped dimensions: %dx%d", warped_width, warped_height)
 
         # ============================================================
         # Step 4: Download original image and create warped image
@@ -215,7 +224,11 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
                 "image_id": image_id,
                 "receipt_ids": receipt_ids,
             }
-        logger.info("Created warped image: %dx%d", warped_image.width, warped_image.height)
+        logger.info(
+            "Created warped image: %dx%d",
+            warped_image.width,
+            warped_image.height,
+        )
 
         # ============================================================
         # Step 5: Create DynamoDB entities in warped space
@@ -252,8 +265,13 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
         # ============================================================
         logger.info("Transforming letters to image coordinates...")
         combined_letters = combine_receipt_letters_to_image_coords(
-            client, image_id, receipt_ids, image_width, image_height,
-            word_id_map, line_id_map,
+            client,
+            image_id,
+            receipt_ids,
+            image_width,
+            image_height,
+            word_id_map,
+            line_id_map,
         )
         logger.info("Combined %d letters", len(combined_letters))
 
@@ -277,7 +295,11 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
         # ============================================================
         logger.info("Migrating receipt word labels...")
         new_labels = migrate_receipt_word_labels(
-            client, image_id, receipt_ids, word_id_map, line_id_map,
+            client,
+            image_id,
+            receipt_ids,
+            word_id_map,
+            line_id_map,
             new_receipt_id,
         )
         logger.info("Migrated %d labels", len(new_labels))
@@ -326,13 +348,17 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
         # Step 9: Upload warped image to S3 and set CDN metadata
         # ============================================================
         raw_s3_key = f"raw/{image_id}_RECEIPT_{new_receipt_id:05d}.png"
-        logger.info("Uploading raw image to s3://%s/%s", raw_bucket, raw_s3_key)
+        logger.info(
+            "Uploading raw image to s3://%s/%s", raw_bucket, raw_s3_key
+        )
         upload_png_to_s3(warped_image, raw_bucket, raw_s3_key)
         receipt.raw_s3_key = raw_s3_key
 
         # Upload CDN variants and persist keys on the Receipt entity
         cdn_base_key = f"assets/{image_id}_RECEIPT_{new_receipt_id:05d}"
-        logger.info("Uploading CDN formats to s3://%s/%s.*", site_bucket, cdn_base_key)
+        logger.info(
+            "Uploading CDN formats to s3://%s/%s.*", site_bucket, cdn_base_key
+        )
         cdn_keys = upload_all_cdn_formats(
             warped_image, site_bucket, cdn_base_key, generate_thumbnails=True
         )
@@ -399,7 +425,9 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
         )
 
         # Filter out noise words for embedding (non-noise words only)
-        non_noise_words = [w for w in receipt_words if not getattr(w, "is_noise", False)]
+        non_noise_words = [
+            w for w in receipt_words if not getattr(w, "is_noise", False)
+        ]
         if not non_noise_words:
             non_noise_words = receipt_words  # Fallback: use all words
 
@@ -424,7 +452,9 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
                 compaction_run_id,
                 exc_info=True,
             )
-        logger.info("Compaction will complete asynchronously: %s", compaction_run_id)
+        logger.info(
+            "Compaction will complete asynchronously: %s", compaction_run_id
+        )
 
         # ============================================================
         # Step 13: Delete original receipts (highest ID first)
@@ -449,9 +479,7 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
         remaining_receipts = client.get_receipts_from_image(image_id)
         image_entity.receipt_count = len(remaining_receipts)
         client.update_image(image_entity)
-        logger.info(
-            "Updated image receipt_count=%d", len(remaining_receipts)
-        )
+        logger.info("Updated image receipt_count=%d", len(remaining_receipts))
 
         result["status"] = "success"
         result["compaction_run_id"] = compaction_run_id

--- a/infra/merge_receipt_lambda/lambdas/merge_receipt.py
+++ b/infra/merge_receipt_lambda/lambdas/merge_receipt.py
@@ -102,8 +102,10 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
             create_combined_receipt_records,
             create_receipt_letters_from_combined,
             create_warped_receipt_image,
+            clone_receipt_place_for_receipt,
             get_best_receipt_place,
             migrate_receipt_word_labels,
+            upsert_receipt_place,
         )
         from receipt_upload.utils import (
             calculate_sha256_from_bytes,
@@ -281,14 +283,22 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
         logger.info("Migrated %d labels", len(new_labels))
 
         # ============================================================
-        # Step 8: Select best place
+        # Step 8: Select best place (clone onto new receipt_id)
         # ============================================================
         logger.info("Selecting best receipt place...")
-        best_place = get_best_receipt_place(client, image_id, receipt_ids)
-        if best_place:
-            # Update place to point to new receipt
-            best_place.receipt_id = new_receipt_id
-            logger.info("Best place: %s", best_place.merchant_name)
+        source_place = get_best_receipt_place(client, image_id, receipt_ids)
+        receipt_place = None
+        if source_place:
+            # Clone so we never mutate the source entity or share mutable
+            # containers; full field copy preserves geo/hours/confidence.
+            receipt_place = clone_receipt_place_for_receipt(
+                source_place,
+                new_receipt_id=new_receipt_id,
+                reasoning_prefix=(
+                    f"Merged from receipts {receipt_ids}. Original: "
+                ),
+            )
+            logger.info("Best place: %s", receipt_place.merchant_name)
         else:
             logger.info("No place data found")
 
@@ -304,7 +314,7 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
             "labels_merged": len(new_labels),
             "lines_created": len(receipt_lines),
             "warped_dimensions": f"{warped_width}x{warped_height}",
-            "place": best_place.merchant_name if best_place else None,
+            "place": receipt_place.merchant_name if receipt_place else None,
         }
 
         if dry_run:
@@ -365,9 +375,15 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
             client.add_receipt_word_labels(new_labels)
             logger.info("  Added %d labels", len(new_labels))
 
-        if best_place:
-            client.add_receipt_place(best_place)
-            logger.info("  Added place: %s", best_place.merchant_name)
+        if receipt_place:
+            # Idempotent: retries after partial write must not abort before
+            # embeddings (step 11) and source deletion (step 13).
+            place_action = upsert_receipt_place(client, receipt_place)
+            logger.info(
+                "  %s place: %s",
+                "Added" if place_action == "added" else "Updated",
+                receipt_place.merchant_name,
+            )
 
         # ============================================================
         # Step 11: Create embeddings and compaction run
@@ -378,7 +394,7 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
             receipt_id=new_receipt_id,
             chromadb_bucket=chromadb_bucket,
             dynamo_client=client,
-            receipt_place=best_place,
+            receipt_place=receipt_place,
             receipt_word_labels=new_labels if new_labels else None,
         )
 

--- a/receipt_dynamo/receipt_dynamo/data/base_operations/flattened_mixin.py
+++ b/receipt_dynamo/receipt_dynamo/data/base_operations/flattened_mixin.py
@@ -14,6 +14,7 @@ from typing import (
 )
 
 from botocore.exceptions import ClientError
+
 from receipt_dynamo.data.shared_exceptions import (
     EntityAlreadyExistsError,
     EntityNotFoundError,

--- a/receipt_dynamo/receipt_dynamo/data/base_operations/flattened_mixin.py
+++ b/receipt_dynamo/receipt_dynamo/data/base_operations/flattened_mixin.py
@@ -14,7 +14,6 @@ from typing import (
 )
 
 from botocore.exceptions import ClientError
-
 from receipt_dynamo.data.shared_exceptions import (
     EntityAlreadyExistsError,
     EntityNotFoundError,

--- a/receipt_dynamo/receipt_dynamo/data/base_operations/flattened_mixin.py
+++ b/receipt_dynamo/receipt_dynamo/data/base_operations/flattened_mixin.py
@@ -44,6 +44,25 @@ if TYPE_CHECKING:
     from mypy_boto3_dynamodb import DynamoDBClient
 
 
+def _entity_display_id(entity: Any) -> str:
+    """Human-readable id for entity error messages.
+
+    Many entities (e.g. ReceiptPlace) have no ``id`` attribute and key on
+    ``image_id`` + ``receipt_id`` instead. Prefer those over the opaque
+    fallback ``\"unknown\"``.
+    """
+    entity_id = getattr(entity, "id", None)
+    if entity_id is not None:
+        return str(entity_id)
+    image_id = getattr(entity, "image_id", None)
+    if image_id is not None:
+        receipt_id = getattr(entity, "receipt_id", None)
+        if receipt_id is not None:
+            return f"{image_id}#{receipt_id}"
+        return str(image_id)
+    return "unknown"
+
+
 class FlattenedStandardMixin:
     """
     A flattened mixin that provides all standard DynamoDB operations.
@@ -261,7 +280,7 @@ class FlattenedStandardMixin:
                 == "ConditionalCheckFailedException"
             ):
                 entity_name = entity.__class__.__name__
-                entity_id = getattr(entity, "id", "unknown")
+                entity_id = _entity_display_id(entity)
                 raise EntityAlreadyExistsError(
                     f"{entity_name} with ID {entity_id} already exists"
                 ) from e
@@ -314,7 +333,7 @@ class FlattenedStandardMixin:
                 == "ConditionalCheckFailedException"
             ):
                 entity_name = entity.__class__.__name__
-                entity_id = getattr(entity, "id", "unknown")
+                entity_id = _entity_display_id(entity)
                 raise EntityNotFoundError(
                     f"{entity_name} with ID {entity_id} does not exist"
                 ) from e
@@ -340,7 +359,7 @@ class FlattenedStandardMixin:
                 == "ConditionalCheckFailedException"
             ):
                 entity_name = entity.__class__.__name__
-                entity_id = getattr(entity, "id", "unknown")
+                entity_id = _entity_display_id(entity)
                 raise EntityNotFoundError(
                     f"{entity_name} with ID {entity_id} does not exist"
                 ) from e

--- a/receipt_dynamo/receipt_dynamo/entities/receipt_place.py
+++ b/receipt_dynamo/receipt_dynamo/entities/receipt_place.py
@@ -74,7 +74,8 @@ _GSI3SK_CONFIDENCE_PREFIX_RE = re.compile(
 
 def _is_wellformed_place_partition(value: str) -> bool:
     """GSI2PK is "PLACE#" + place_id. The entity accepts any non-whitespace-only
-    place_id (Google place ids are opaque), so mirror that rather than a charset."""
+    place_id (Google place ids are opaque), so mirror that rather than a charset.
+    """
     prefix = "PLACE#"
     return value.startswith(prefix) and bool(value[len(prefix) :].strip())
 
@@ -88,6 +89,7 @@ def _is_wellformed_validation_sk(value: str, image_id: str) -> bool:
         return False
     head = value[: -len(suffix)]
     return _GSI3SK_CONFIDENCE_PREFIX_RE.match(head) is not None
+
 
 # Fields that are computed (GSI keys) and should not be passed to
 # constructor. Includes GSI4 and geohash for backward compatibility
@@ -655,9 +657,7 @@ class ReceiptPlace(  # pylint: disable=too-many-instance-attributes
         # GSI2PK is only present in expected_keys when place_id is set, so the
         # empty-place_id legacy handling below is unaffected.
         business_key_validators = {
-            "GSI1PK": lambda value: bool(
-                _MERCHANT_GSI1PK_RE.fullmatch(value)
-            ),
+            "GSI1PK": lambda value: bool(_MERCHANT_GSI1PK_RE.fullmatch(value)),
             "GSI2PK": _is_wellformed_place_partition,
             "GSI3SK": lambda value: _is_wellformed_validation_sk(
                 value, result.image_id
@@ -678,9 +678,7 @@ class ReceiptPlace(  # pylint: disable=too-many-instance-attributes
                 if not isinstance(stored, dict) or not validator(
                     stored.get("S") or ""
                 ):
-                    raise ValueError(
-                        f"{key_name} does not match entity keys"
-                    )
+                    raise ValueError(f"{key_name} does not match entity keys")
                 continue
             if key_name in item and item[key_name] != expected_value:
                 raise ValueError(f"{key_name} does not match entity keys")

--- a/receipt_dynamo/tests/integration/test__receipt_validation_summary.py
+++ b/receipt_dynamo/tests/integration/test__receipt_validation_summary.py
@@ -4,6 +4,7 @@ from typing import Any, Literal
 import pytest
 from botocore.exceptions import ClientError
 from pytest_mock import MockerFixture
+
 from receipt_dynamo import DynamoClient, ReceiptValidationSummary
 from receipt_dynamo.data.shared_exceptions import (
     DynamoDBError,

--- a/receipt_dynamo/tests/integration/test__receipt_validation_summary.py
+++ b/receipt_dynamo/tests/integration/test__receipt_validation_summary.py
@@ -20,8 +20,9 @@ from receipt_dynamo.data.shared_exceptions import (
 pytestmark = [pytest.mark.integration, pytest.mark.unused_in_production]
 
 IMAGE_ID = "3f52804b-2fad-4e00-92c8-b593da3a8ed3"
+RECEIPT_ID = 12345
 MISSING_ENTITY_ERROR = (
-    "ReceiptValidationSummary with ID unknown does not exist"
+    f"ReceiptValidationSummary with ID {IMAGE_ID}#{RECEIPT_ID} does not exist"
 )
 
 COMMON_ERROR_SCENARIOS = [
@@ -81,7 +82,7 @@ def _summary() -> ReceiptValidationSummary:
     """Return a representative validation summary with nested data."""
     return ReceiptValidationSummary(
         image_id=IMAGE_ID,
-        receipt_id=12345,
+        receipt_id=RECEIPT_ID,
         overall_status="valid",
         overall_reasoning="All fields validated successfully",
         validation_timestamp=datetime.now().isoformat(),

--- a/receipt_dynamo/tests/integration/test__receipt_validation_summary.py
+++ b/receipt_dynamo/tests/integration/test__receipt_validation_summary.py
@@ -4,7 +4,6 @@ from typing import Any, Literal
 import pytest
 from botocore.exceptions import ClientError
 from pytest_mock import MockerFixture
-
 from receipt_dynamo import DynamoClient, ReceiptValidationSummary
 from receipt_dynamo.data.shared_exceptions import (
     DynamoDBError,

--- a/receipt_upload/receipt_upload/combine/__init__.py
+++ b/receipt_upload/receipt_upload/combine/__init__.py
@@ -11,8 +11,10 @@ from receipt_upload.combine.geometry_utils import (
     transform_point_to_warped_space,
 )
 from receipt_upload.combine.metadata_utils import (
+    clone_receipt_place_for_receipt,
     get_best_receipt_place,
     migrate_receipt_word_labels,
+    upsert_receipt_place,
 )
 from receipt_upload.combine.records_builder import (
     combine_receipt_letters_to_image_coords,
@@ -25,8 +27,10 @@ __all__ = [
     "calculate_min_area_rect",
     "create_warped_receipt_image",
     "transform_point_to_warped_space",
+    "clone_receipt_place_for_receipt",
     "get_best_receipt_place",
     "migrate_receipt_word_labels",
+    "upsert_receipt_place",
     "combine_receipt_letters_to_image_coords",
     "combine_receipt_words_to_image_coords",
     "create_combined_receipt_records",

--- a/receipt_upload/receipt_upload/combine/metadata_utils.py
+++ b/receipt_upload/receipt_upload/combine/metadata_utils.py
@@ -108,7 +108,8 @@ def clone_receipt_place_for_receipt(
     kwargs = {f.name: getattr(source, f.name) for f in fields(source)}
     kwargs["receipt_id"] = new_receipt_id
     for name in _MUTABLE_PLACE_FIELDS:
-        kwargs[name] = deepcopy(kwargs[name])
+        if name in kwargs:
+            kwargs[name] = deepcopy(kwargs[name])
     if refresh_timestamp:
         kwargs["timestamp"] = datetime.now(timezone.utc)
     if reasoning_prefix:

--- a/receipt_upload/receipt_upload/combine/metadata_utils.py
+++ b/receipt_upload/receipt_upload/combine/metadata_utils.py
@@ -5,15 +5,31 @@ This module contains functions for selecting and migrating place data and labels
 when combining receipts.
 """
 
+from __future__ import annotations
+
 import logging
+from copy import deepcopy
+from dataclasses import fields
 from datetime import datetime, timezone
 from typing import Dict, List, Optional, Tuple
 
 from receipt_dynamo import DynamoClient
 from receipt_dynamo.constants import MerchantValidationStatus
+from receipt_dynamo.data.shared_exceptions import EntityAlreadyExistsError
 from receipt_dynamo.entities import ReceiptPlace, ReceiptWordLabel
 
 logger = logging.getLogger(__name__)
+
+# Mutable container fields that must be deep-copied when cloning a place so
+# the source entity and the merged entity cannot share list/dict identity.
+_MUTABLE_PLACE_FIELDS = (
+    "merchant_types",
+    "matched_fields",
+    "hours_summary",
+    "photo_references",
+    "address_components",
+    "hours_data",
+)
 
 
 def get_best_receipt_place(
@@ -23,6 +39,10 @@ def get_best_receipt_place(
 ) -> Optional[ReceiptPlace]:
     """
     Get the best ReceiptPlace from the original receipts.
+
+    Returns the live Dynamo entity for the winning source receipt. Callers that
+    need to re-key the place onto a new receipt_id must clone via
+    ``clone_receipt_place_for_receipt`` — never mutate ``receipt_id`` in place.
 
     Args:
         client: DynamoDB client
@@ -70,6 +90,56 @@ def get_best_receipt_place(
 
     places.sort(key=lambda p: (score_place(p), p.timestamp), reverse=True)
     return places[0]
+
+
+def clone_receipt_place_for_receipt(
+    source: ReceiptPlace,
+    *,
+    new_receipt_id: int,
+    reasoning_prefix: str | None = None,
+    refresh_timestamp: bool = True,
+) -> ReceiptPlace:
+    """
+    Deep-copy a ReceiptPlace onto a new receipt_id without mutating ``source``.
+
+    Preserves all Google Places fields (geo, hours, confidence, media, etc.)
+    that partial field-by-field constructors historically dropped.
+    """
+    kwargs = {f.name: getattr(source, f.name) for f in fields(source)}
+    kwargs["receipt_id"] = new_receipt_id
+    for name in _MUTABLE_PLACE_FIELDS:
+        kwargs[name] = deepcopy(kwargs[name])
+    if refresh_timestamp:
+        kwargs["timestamp"] = datetime.now(timezone.utc)
+    if reasoning_prefix:
+        original = kwargs.get("reasoning") or "N/A"
+        kwargs["reasoning"] = f"{reasoning_prefix}{original}"
+    return ReceiptPlace(**kwargs)
+
+
+def upsert_receipt_place(client: DynamoClient, place: ReceiptPlace) -> str:
+    """
+    Persist a ReceiptPlace, treating an existing key as an overwrite.
+
+    Merge/combine retries can leave a place row for ``new_receipt_id`` after a
+    partial write. ``add_receipt_place`` is create-only and would otherwise
+    abort the pipeline before embeddings and source deletion.
+
+    Returns:
+        ``"added"`` if the place was created, ``"updated"`` if it already existed.
+    """
+    try:
+        client.add_receipt_place(place)
+        return "added"
+    except EntityAlreadyExistsError:
+        logger.warning(
+            "ReceiptPlace already exists for image_id=%s receipt_id=%s; "
+            "updating in place (merge/combine retry)",
+            place.image_id,
+            place.receipt_id,
+        )
+        client.update_receipt_place(place)
+        return "updated"
 
 
 def migrate_receipt_word_labels(

--- a/receipt_upload/tests/test_combine.py
+++ b/receipt_upload/tests/test_combine.py
@@ -2,14 +2,13 @@ from datetime import datetime, timedelta, timezone
 
 import pytest
 from receipt_dynamo.constants import MerchantValidationStatus, ValidationStatus
+from receipt_dynamo.data.shared_exceptions import EntityAlreadyExistsError
 from receipt_dynamo.entities import (
     Receipt,
     ReceiptPlace,
     ReceiptWord,
     ReceiptWordLabel,
 )
-
-from receipt_dynamo.data.shared_exceptions import EntityAlreadyExistsError
 
 from receipt_upload.combine import (
     calculate_min_area_rect,

--- a/receipt_upload/tests/test_combine.py
+++ b/receipt_upload/tests/test_combine.py
@@ -9,13 +9,17 @@ from receipt_dynamo.entities import (
     ReceiptWordLabel,
 )
 
+from receipt_dynamo.data.shared_exceptions import EntityAlreadyExistsError
+
 from receipt_upload.combine import (
     calculate_min_area_rect,
+    clone_receipt_place_for_receipt,
     combine_receipt_words_to_image_coords,
     create_combined_receipt_records,
     get_best_receipt_place,
     migrate_receipt_word_labels,
     transform_point_to_warped_space,
+    upsert_receipt_place,
 )
 from receipt_upload.combine.records_builder import (
     _get_receipt_to_image_transform,
@@ -93,6 +97,107 @@ def _make_label(
         validation_status=validation_status,
         label_proposed_by=label_proposed_by,
     )
+
+
+@pytest.mark.unit
+def test_clone_receipt_place_for_receipt_preserves_fields_and_does_not_mutate_source():
+    source = _make_place(
+        receipt_id=1,
+        place_id="ChIJabc",
+        merchant_name="Roosterfish",
+        formatted_address="1302 Abbot Kinney Blvd",
+        phone_number="(424) 387-8221",
+        validation_status=MerchantValidationStatus.MATCHED.value,
+    )
+    source.latitude = 33.990
+    source.longitude = -118.466
+    source.confidence = 0.91
+    source.hours_data = {"periods": [{"open": {"day": 1}}]}
+    source.merchant_types = ["bar", "restaurant"]
+    source.matched_fields = ["name", "phone"]
+    source.reasoning = "text search"
+
+    cloned = clone_receipt_place_for_receipt(
+        source,
+        new_receipt_id=3,
+        reasoning_prefix="Merged from receipts [1, 2]. Original: ",
+    )
+
+    assert cloned.receipt_id == 3
+    assert source.receipt_id == 1  # source not re-keyed
+    assert cloned.place_id == "ChIJabc"
+    assert cloned.merchant_name == "Roosterfish"
+    assert cloned.latitude == 33.990
+    assert cloned.longitude == -118.466
+    assert cloned.confidence == 0.91
+    assert cloned.hours_data == {"periods": [{"open": {"day": 1}}]}
+    assert cloned.merchant_types == ["bar", "restaurant"]
+    assert "Merged from receipts [1, 2]" in cloned.reasoning
+    assert "text search" in cloned.reasoning
+
+    # Deep copy: mutating clone containers must not touch source
+    cloned.merchant_types.append("night_club")
+    cloned.hours_data["periods"].append({"open": {"day": 2}})
+    assert source.merchant_types == ["bar", "restaurant"]
+    assert source.hours_data == {"periods": [{"open": {"day": 1}}]}
+
+
+@pytest.mark.unit
+def test_upsert_receipt_place_adds_when_missing():
+    place = _make_place(
+        receipt_id=3,
+        place_id="p1",
+        merchant_name="Cafe",
+    )
+
+    class _Client:
+        def __init__(self):
+            self.added = []
+            self.updated = []
+
+        def add_receipt_place(self, receipt_place):
+            self.added.append(receipt_place)
+
+        def update_receipt_place(self, receipt_place):
+            self.updated.append(receipt_place)
+
+    client = _Client()
+    action = upsert_receipt_place(client, place)
+
+    assert action == "added"
+    assert client.added == [place]
+    assert client.updated == []
+
+
+@pytest.mark.unit
+def test_upsert_receipt_place_updates_on_already_exists():
+    place = _make_place(
+        receipt_id=3,
+        place_id="p1",
+        merchant_name="Cafe",
+    )
+
+    class _Client:
+        def __init__(self):
+            self.added = []
+            self.updated = []
+
+        def add_receipt_place(self, receipt_place):
+            self.added.append(receipt_place)
+            raise EntityAlreadyExistsError(
+                f"ReceiptPlace with ID {receipt_place.image_id}#"
+                f"{receipt_place.receipt_id} already exists"
+            )
+
+        def update_receipt_place(self, receipt_place):
+            self.updated.append(receipt_place)
+
+    client = _Client()
+    action = upsert_receipt_place(client, place)
+
+    assert action == "updated"
+    assert len(client.added) == 1
+    assert client.updated == [place]
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

Merge-receipt Lambda was aborting at place write with `ReceiptPlace with ID unknown already exists` after a partial Dynamo write of the new receipt. That blocked steps that create embeddings/compaction (Chroma) and delete the original fragments.

- **Clone** the best source `ReceiptPlace` onto `new_receipt_id` (no in-place mutation; full field copy including geo/hours/confidence)
- **Upsert** place (`add` → on `EntityAlreadyExistsError` → `update`) so retries do not die before embeddings and source deletion
- Align **combine_receipts** with the same helpers (replaces partial place ctor + delete-then-readd)
- Improve Dynamo entity error IDs for composite-key entities (`image_id#receipt_id` instead of `unknown`)

### Follow-ups (not in this PR)

Place upsert unblocks the reported failure mode. Full merge retry safety still needs idempotent `add_receipt` / lines / words / labels and a more stable `new_receipt_id` allocation than blind `max(existing)+1` — track as bulk-merge TODOs after this lands.

## Test plan

- [x] `pytest receipt_upload/tests/test_combine.py` (clone + upsert unit tests)
- [x] Updated integration expectation for composite entity IDs in `test__receipt_validation_summary.py`
- [ ] Deploy merge-receipt Lambda (and combine if shared package deploy differs)
- [ ] Dry-run then apply merge on a classic over-segment candidate; confirm response includes `compaction_run_id` and `deleted_receipts`
- [ ] Confirm merged words leave `embedding_status=NONE` via compaction path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Receipt place information is now safely copied to newly combined receipts without modifying the original receipt.
  * Receipt place saves now handle existing records automatically, improving reliability during repeated processing.
  * Error messages now provide clearer receipt and image identifiers when records are missing or duplicated.

* **Tests**
  * Added coverage for receipt place copying and add-or-update persistence behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->