### PR TITLE
Fix receipt loading skeleton transitions

### DIFF
--- a/portfolio/components/ui/Figures/LabelWordCloud/LabelWordCloud.tsx
+++ b/portfolio/components/ui/Figures/LabelWordCloud/LabelWordCloud.tsx
@@ -263,7 +263,9 @@ const LabelWordCloud: React.FC<LabelWordCloudProps> = ({
   });
 
   // Responsive sizing - use more square layout on mobile
-  const [isMobile, setIsMobile] = useState(false);
+  const [isMobile, setIsMobile] = useState(
+    () => typeof window !== "undefined" && window.innerWidth < 768,
+  );
 
   useEffect(() => {
     let timeoutId: ReturnType<typeof setTimeout>;

--- a/portfolio/components/ui/Figures/QuestionMarquee.tsx
+++ b/portfolio/components/ui/Figures/QuestionMarquee.tsx
@@ -59,7 +59,11 @@ const QuestionMarquee: React.FC<QuestionMarqueeProps> = ({
   onQuestionClick,
   activeQuestion,
 }) => {
-  const [isMobile, setIsMobile] = useState(false);
+  const [isMobile, setIsMobile] = useState(
+    () =>
+      typeof window !== "undefined" &&
+      window.matchMedia("(max-width: 639px)").matches,
+  );
   useEffect(() => {
     const mql = window.matchMedia("(max-width: 639px)");
     setIsMobile(mql.matches);

--- a/portfolio/components/ui/Figures/ReceiptFlow/ReceiptFlowLoadingShell.tsx
+++ b/portfolio/components/ui/Figures/ReceiptFlow/ReceiptFlowLoadingShell.tsx
@@ -107,18 +107,18 @@ function LegendSkeleton({ variant }: { variant: ReceiptFlowLoadingVariant }) {
     case "layoutlm":
       return (
         <div className={`${styles.legendSkeleton} ${styles.legendLayoutLM}`}>
-          {/* Desktop: 8 vertical rows matching ENTITY_TYPES */}
+          {/* Match the nine taxonomy families rendered by EntityLegend. */}
           <div className={styles.legendLayoutLMDesktop}>
-            {[1, 2, 3, 4, 5, 6, 7, 8].map((i) => (
+            {Array.from({ length: 9 }, (_, index) => index).map((i) => (
               <div key={i} className={styles.legendRowSkeleton}>
                 <div className={styles.legendDotSkeleton} />
                 <div className={styles.legendLabelSkeleton} />
               </div>
             ))}
           </div>
-          {/* Mobile: 6 items in 3-col grid matching MOBILE_LEGEND_GROUPS */}
+          {/* Mobile uses the same nine families in a 3-column grid. */}
           <div className={styles.legendLayoutLMMobile}>
-            {[1, 2, 3, 4, 5, 6].map((i) => (
+            {Array.from({ length: 9 }, (_, index) => index).map((i) => (
               <div key={i} className={styles.legendRowSkeleton}>
                 <div className={styles.legendDotSkeleton} />
                 <div className={styles.legendLabelSkeleton} />

--- a/portfolio/components/ui/Figures/TrainingMetricsAnimation/TrainingMetricsAnimation.module.css
+++ b/portfolio/components/ui/Figures/TrainingMetricsAnimation/TrainingMetricsAnimation.module.css
@@ -1,4 +1,5 @@
 .container {
+  position: relative;
   display: grid;
   grid-template-columns: 220px 1fr;
   gap: 1.5rem;
@@ -9,6 +10,18 @@
   max-width: 700px;
   margin: 0 auto;
   contain: paint;
+}
+
+.loadingError {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  margin: 0;
+  padding: 1rem;
+  text-align: center;
+  color: var(--text-color);
+  background: rgba(var(--background-color-rgb), 0.82);
 }
 
 /* Dataset Stats with segmented bars */
@@ -387,8 +400,11 @@
 .matrixContainer {
   display: flex;
   flex-direction: column;
+  align-items: center;
+  justify-content: center;
   gap: 0.5rem;
-  width: fit-content;
+  width: 366px;
+  min-height: 356px;
   /* The ~10-family matrix fits the figure on its own (no scroll); cap at the
      parent so it can never force the figure past the viewport. */
   max-width: 100%;
@@ -668,6 +684,8 @@
 
   .matrixContainer {
     margin: 0 auto;
+    width: min(100%, 306px);
+    min-height: 298px;
     --matrix-cell-size: 28px;
     --matrix-label-col: 36px;
     --matrix-header-row: 28px;

--- a/portfolio/components/ui/Figures/TrainingMetricsAnimation/TrainingMetricsLoadingShell.tsx
+++ b/portfolio/components/ui/Figures/TrainingMetricsAnimation/TrainingMetricsLoadingShell.tsx
@@ -1,0 +1,148 @@
+import React from "react";
+import styles from "./TrainingMetricsAnimation.module.css";
+
+const LABELS = [
+  "Address",
+  "Amount",
+  "Date",
+  "Merchant Name",
+  "Payment Method",
+  "Store Hours",
+  "Time",
+  "Website",
+];
+const MATRIX_LABELS = ["Addr", "Amt", "Date", "Merch", "Pay", "Hours", "Time", "Web", "O"];
+const SKELETON_BG = "rgba(var(--text-color-rgb, 0, 0, 0), 0.08)";
+const SVG_WIDTH = 600;
+const SVG_HEIGHT = 80;
+const SVG_PAD_X = 8;
+const SVG_PAD_BOTTOM = 14;
+
+const BarLegendSkeleton = () => (
+  <div className={styles.barLegend}>
+    <div className={styles.legendEntry}>
+      <span className={styles.legendSwatch} style={{ background: "var(--text-color)" }} />
+      <span className={styles.legendLabel}>F1 Score</span>
+    </div>
+    <div className={styles.legendEntry}>
+      <span className={styles.legendSwatch} style={{ background: "var(--color-blue)" }} />
+      <span className={styles.legendLabel}>Support</span>
+    </div>
+  </div>
+);
+
+/** Shared by the dynamic-import boundary and the API-loading state. */
+export const TrainingMetricsSkeleton: React.FC = () => {
+  const count = MATRIX_LABELS.length;
+  const gridTemplateColumns = `var(--matrix-label-col) repeat(${count}, var(--matrix-cell-size))`;
+  const gridTemplateRows = `var(--matrix-header-row) repeat(${count}, var(--matrix-cell-size))`;
+
+  return (
+    <>
+      <div className={styles.datasetStats}>
+        <div className={styles.statGroup}>
+          <span className={styles.statLabel}>Train/Val</span>
+          <div className={styles.segmentedBar}>
+            <div style={{ width: "90%", height: "100%", background: SKELETON_BG }} />
+            <div style={{ width: "10%", height: "100%", background: SKELETON_BG, opacity: 0.5 }} />
+          </div>
+          <span className={styles.statValues} style={{ background: SKELETON_BG, borderRadius: 3, width: 70, height: 10 }} />
+        </div>
+        <div className={styles.statGroup}>
+          <span className={styles.statLabel}>Labeled</span>
+          <div className={styles.segmentedBar}>
+            <div style={{ width: "33%", height: "100%", background: SKELETON_BG }} />
+            <div style={{ width: "67%", height: "100%", background: SKELETON_BG, opacity: 0.5 }} />
+          </div>
+          <span className={styles.statValues} style={{ background: SKELETON_BG, borderRadius: 3, width: 30, height: 10 }} />
+        </div>
+      </div>
+
+      <div className={styles.timeline}>
+        <svg
+          viewBox={`0 0 ${SVG_WIDTH} ${SVG_HEIGHT}`}
+          preserveAspectRatio="none"
+          className={styles.sparkline}
+          aria-hidden="true"
+        >
+          <line
+            x1={SVG_PAD_X}
+            x2={SVG_WIDTH - SVG_PAD_X}
+            y1={SVG_HEIGHT - SVG_PAD_BOTTOM}
+            y2={SVG_HEIGHT - SVG_PAD_BOTTOM}
+            stroke={SKELETON_BG}
+            strokeWidth={1.5}
+            vectorEffect="non-scaling-stroke"
+          />
+        </svg>
+      </div>
+
+      <div className={styles.timelineMobile}>
+        <div className={styles.timelineArrow} style={{ opacity: 0.25 }}>‹</div>
+        <div className={styles.timelineMobileCenter}>
+          <span className={styles.timelineMobileText} style={{ opacity: 0.3 }}>— / —</span>
+        </div>
+        <div className={styles.timelineArrow} style={{ opacity: 0.25 }}>›</div>
+      </div>
+
+      <div className={styles.leftPanel}>
+        <div className={styles.gaugeContainer}>
+          <div style={{ width: 80, height: 32, background: SKELETON_BG, borderRadius: 4 }} />
+          <div className={styles.gaugeBar} />
+        </div>
+        <div className={styles.perLabelContainer}>
+          {LABELS.map((label) => (
+            <div key={label} className={styles.labelRow}>
+              <span className={styles.labelName} style={{ opacity: 0.3 }}>{label}</span>
+              <div className={styles.labelBarStack}>
+                <div className={styles.labelBarSegmented}>
+                  <div className={styles.labelBarEmpty} style={{ width: "100%" }} />
+                </div>
+                <div className={styles.labelBarDistribution}>
+                  <div className={styles.labelBarDistEmpty} style={{ width: "100%" }} />
+                </div>
+              </div>
+              <span className={styles.labelBarValue} style={{ opacity: 0 }}>0.00</span>
+            </div>
+          ))}
+        </div>
+        <BarLegendSkeleton />
+      </div>
+
+      <div className={styles.rightPanel}>
+        <div className={styles.matrixContainer}>
+          <div className={styles.matrixGrid} style={{ gridTemplateColumns, gridTemplateRows }}>
+            <div className={styles.matrixCorner} />
+            {MATRIX_LABELS.map((label) => (
+              <div key={`x-${label}`} className={styles.matrixAxisLabel} style={{ opacity: 0.3 }}>
+                {label}
+              </div>
+            ))}
+            {MATRIX_LABELS.map((rowLabel, rowIndex) => (
+              <React.Fragment key={`row-${rowLabel}`}>
+                <div className={`${styles.matrixAxisLabel} ${styles.matrixAxisLabelY}`} style={{ opacity: 0.3 }}>
+                  {rowLabel}
+                </div>
+                {MATRIX_LABELS.map((_, columnIndex) => (
+                  <div
+                    key={`${rowIndex}-${columnIndex}`}
+                    className={styles.matrixCell}
+                    style={{ backgroundColor: rowIndex === columnIndex ? SKELETON_BG : "transparent" }}
+                  />
+                ))}
+              </React.Fragment>
+            ))}
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export const TrainingMetricsLoadingShell: React.FC = () => (
+  <div className={styles.container} aria-busy="true" aria-label="Loading training metrics">
+    <TrainingMetricsSkeleton />
+  </div>
+);
+
+export default TrainingMetricsLoadingShell;

--- a/portfolio/components/ui/Figures/TrainingMetricsAnimation/index.tsx
+++ b/portfolio/components/ui/Figures/TrainingMetricsAnimation/index.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useState, useMemo, useRef } from "react";
 import { animated, useSpring } from "@react-spring/web";
+import { useQuery } from "@tanstack/react-query";
 import { useInView } from "react-intersection-observer";
 import { api } from "../../../../services/api";
 import { DatasetMetrics, TrainingMetricsEpoch } from "../../../../types/api";
@@ -10,6 +11,9 @@ import {
   computeAxisLabels,
   computeScales,
 } from "./sparkline";
+import { TrainingMetricsSkeleton } from "./TrainingMetricsLoadingShell";
+
+const EMPTY_EPOCHS: TrainingMetricsEpoch[] = [];
 
 // Normalize ADDRESS_LINE to ADDRESS for display purposes
 const normalizeLabel = (label: string): string => {
@@ -716,135 +720,6 @@ const MatrixCell: React.FC<MatrixCellProps> = ({ value, rowSum, isDiagonal }) =>
   );
 };
 
-// Skeleton placeholder labels (match the 8 entity labels in the loaded state)
-const SKELETON_LABELS = [
-  "Address", "Amount", "Date", "Merchant Name",
-  "Payment Method", "Store Hours", "Time", "Website",
-];
-
-// 9 labels for the confusion matrix (8 entity + O)
-const SKELETON_MATRIX_LABELS = ["Addr", "Amt", "Date", "Merch", "Pay", "Hours", "Time", "Web", "O"];
-
-const SKELETON_BG = "rgba(var(--text-color-rgb, 0, 0, 0), 0.08)";
-
-// Skeleton that mirrors the loaded layout exactly
-const TrainingMetricsSkeleton: React.FC = () => {
-  const N = SKELETON_MATRIX_LABELS.length;
-  const gridTemplateColumns = `var(--matrix-label-col) repeat(${N}, var(--matrix-cell-size))`;
-  const gridTemplateRows = `var(--matrix-header-row) repeat(${N}, var(--matrix-cell-size))`;
-
-  return (
-    <>
-      {/* DatasetStats skeleton */}
-      <div className={styles.datasetStats}>
-        <div className={styles.statGroup}>
-          <span className={styles.statLabel}>Train/Val</span>
-          <div className={styles.segmentedBar}>
-            <div style={{ width: "90%", height: "100%", background: SKELETON_BG }} />
-            <div style={{ width: "10%", height: "100%", background: SKELETON_BG, opacity: 0.5 }} />
-          </div>
-          <span className={styles.statValues} style={{ background: SKELETON_BG, borderRadius: 3, width: 70, height: 10 }} />
-        </div>
-        <div className={styles.statGroup}>
-          <span className={styles.statLabel}>Labeled</span>
-          <div className={styles.segmentedBar}>
-            <div style={{ width: "33%", height: "100%", background: SKELETON_BG }} />
-            <div style={{ width: "67%", height: "100%", background: SKELETON_BG, opacity: 0.5 }} />
-          </div>
-          <span className={styles.statValues} style={{ background: SKELETON_BG, borderRadius: 3, width: 30, height: 10 }} />
-        </div>
-      </div>
-
-      {/* Desktop sparkline skeleton — flat baseline in the placeholder color */}
-      <div className={styles.timeline}>
-        <svg
-          viewBox={`0 0 ${SVG_W_FALLBACK} ${SVG_H}`}
-          preserveAspectRatio="none"
-          className={styles.sparkline}
-          aria-hidden="true"
-        >
-          <line
-            x1={SVG_PAD_X}
-            x2={SVG_W_FALLBACK - SVG_PAD_X}
-            y1={SVG_H - SVG_PAD_BOTTOM}
-            y2={SVG_H - SVG_PAD_BOTTOM}
-            stroke={SKELETON_BG}
-            strokeWidth={1.5}
-            vectorEffect="non-scaling-stroke"
-          />
-        </svg>
-      </div>
-
-      {/* Mobile timeline skeleton */}
-      <div className={styles.timelineMobile}>
-        <div className={styles.timelineArrow} style={{ opacity: 0.25 }}>‹</div>
-        <div className={styles.timelineMobileCenter}>
-          <span className={styles.timelineMobileText} style={{ opacity: 0.3 }}>— / —</span>
-        </div>
-        <div className={styles.timelineArrow} style={{ opacity: 0.25 }}>›</div>
-      </div>
-
-      {/* Left panel skeleton */}
-      <div className={styles.leftPanel}>
-        {/* F1 Gauge */}
-        <div className={styles.gaugeContainer}>
-          <div style={{ width: 80, height: 32, background: SKELETON_BG, borderRadius: 4 }} />
-          <div className={styles.gaugeBar} />
-        </div>
-
-        {/* Per-label bars */}
-        <div className={styles.perLabelContainer}>
-          {SKELETON_LABELS.map((label) => (
-            <div key={label} className={styles.labelRow}>
-              <span className={styles.labelName} style={{ opacity: 0.3 }}>{label}</span>
-              <div className={styles.labelBarStack}>
-                <div className={styles.labelBarSegmented}>
-                  <div className={styles.labelBarEmpty} style={{ width: "100%" }} />
-                </div>
-                <div className={styles.labelBarDistribution}>
-                  <div className={styles.labelBarDistEmpty} style={{ width: "100%" }} />
-                </div>
-              </div>
-              <span className={styles.labelBarValue} style={{ opacity: 0 }}>0.00</span>
-            </div>
-          ))}
-        </div>
-
-        {/* Bar legend */}
-        <BarLegend />
-      </div>
-
-      {/* Right panel — confusion matrix skeleton */}
-      <div className={styles.rightPanel}>
-        <div className={styles.matrixContainer}>
-          <div className={styles.matrixGrid} style={{ gridTemplateColumns, gridTemplateRows }}>
-            <div className={styles.matrixCorner} />
-            {SKELETON_MATRIX_LABELS.map((label) => (
-              <div key={`x-${label}`} className={styles.matrixAxisLabel} style={{ opacity: 0.3 }}>
-                {label}
-              </div>
-            ))}
-            {SKELETON_MATRIX_LABELS.map((rowLabel, i) => (
-              <React.Fragment key={`row-${i}`}>
-                <div className={`${styles.matrixAxisLabel} ${styles.matrixAxisLabelY}`} style={{ opacity: 0.3 }}>
-                  {rowLabel}
-                </div>
-                {SKELETON_MATRIX_LABELS.map((_, j) => (
-                  <div
-                    key={`${i}-${j}`}
-                    className={styles.matrixCell}
-                    style={{ backgroundColor: i === j ? SKELETON_BG : "transparent" }}
-                  />
-                ))}
-              </React.Fragment>
-            ))}
-          </div>
-        </div>
-      </div>
-    </>
-  );
-};
-
 // Main Component
 const TrainingMetricsAnimation: React.FC = () => {
   const { ref: lazyRef, inView: nearViewport } = useInView({
@@ -862,35 +737,24 @@ const TrainingMetricsAnimation: React.FC = () => {
     },
     [lazyRef, animRef],
   );
-  const [epochs, setEpochs] = useState<TrainingMetricsEpoch[]>([]);
-  const [datasetMetrics, setDatasetMetrics] = useState<DatasetMetrics | undefined>();
   const [currentEpochIndex, setCurrentEpochIndex] = useState(0);
-  const [isLoading, setIsLoading] = useState(true);
   const [showBestLabel, setShowBestLabel] = useState(false);
   const hasStartedAnimation = useRef(false);
-  const hasFetchedRef = useRef(false);
-
-  // Fetch data only when near viewport - defers work until section is close
-  useEffect(() => {
-    if (!nearViewport || hasFetchedRef.current) return;
-    hasFetchedRef.current = true;
-
-    api
-      .fetchFeaturedTrainingMetrics()
-      .then((data) => {
-        setEpochs(data.epochs);
-        setDatasetMetrics(data.dataset_metrics);
-        setIsLoading(false);
-      })
-      .catch((err) => {
-        console.error("Failed to fetch training metrics:", err);
-        setIsLoading(false);
-      });
-  }, [nearViewport]);
+  const {
+    data: trainingData,
+    error: queryError,
+    isPending,
+  } = useQuery({
+    queryKey: ["featured-training-metrics", { collapseBio: true }],
+    queryFn: ({ signal }) => api.fetchFeaturedTrainingMetrics(signal),
+    enabled: nearViewport,
+  });
+  const epochs = trainingData?.epochs ?? EMPTY_EPOCHS;
+  const datasetMetrics: DatasetMetrics | undefined = trainingData?.dataset_metrics;
 
   // Autoplay animation when in view and data is loaded
   useEffect(() => {
-    if (!inView || hasStartedAnimation.current || epochs.length === 0 || isLoading) {
+    if (!inView || hasStartedAnimation.current || epochs.length === 0 || isPending) {
       return;
     }
 
@@ -933,14 +797,25 @@ const TrainingMetricsAnimation: React.FC = () => {
     }, stepMs);
 
     return () => clearInterval(interval);
-  }, [inView, epochs, isLoading]);
+  }, [inView, epochs, isPending]);
 
   const currentEpoch = epochs[currentEpochIndex];
 
-  if (!nearViewport || isLoading) {
+  if (!nearViewport || isPending) {
     return (
       <div ref={setRefs} className={styles.container}>
         <TrainingMetricsSkeleton />
+      </div>
+    );
+  }
+
+  if (queryError) {
+    return (
+      <div ref={setRefs} className={styles.container}>
+        <TrainingMetricsSkeleton />
+        <p className={styles.loadingError} role="alert">
+          Training metrics are temporarily unavailable.
+        </p>
       </div>
     );
   }

--- a/portfolio/components/ui/Figures/WordSimilarity.module.css
+++ b/portfolio/components/ui/Figures/WordSimilarity.module.css
@@ -68,6 +68,19 @@
   border-bottom: 2px solid rgba(var(--text-color-rgb), 0.22);
 }
 
+.summaryTableFrame {
+  width: 100%;
+  height: 258px;
+  overflow: auto;
+  scrollbar-gutter: stable;
+}
+
+.summaryTableFrame table thead {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+
 .tableHeaderSkeleton {
   height: 44px;
   background: var(--code-background);
@@ -87,7 +100,9 @@
 }
 
 .tableRowSkeleton span,
-.timingLinesSkeleton span {
+.timingTitleSkeleton,
+.timingBarSkeleton,
+.timingLegendSkeleton span {
   height: 10px;
   border-radius: 999px;
   background: rgba(var(--text-color-rgb), 0.1);
@@ -100,32 +115,29 @@
 }
 
 .timingSkeleton {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 1.5rem;
-  min-height: 86px;
-}
-
-.timingRingSkeleton {
-  width: 68px;
-  height: 68px;
-  border: 8px solid rgba(var(--text-color-rgb), 0.08);
-  border-radius: 50%;
-}
-
-.timingLinesSkeleton {
   display: grid;
-  gap: 0.65rem;
-  width: min(280px, 45%);
+  gap: 1rem;
+  min-height: 124px;
+  padding: 1rem;
+  border-radius: 10px;
+  background: var(--code-background);
 }
 
-.timingLinesSkeleton span:nth-child(2) {
-  width: 78%;
+.timingTitleSkeleton {
+  width: min(260px, 45%);
+  height: 12px;
 }
 
-.timingLinesSkeleton span:nth-child(3) {
-  width: 58%;
+.timingBarSkeleton {
+  width: 100%;
+  height: 24px;
+  border-radius: 4px;
+}
+
+.timingLegendSkeleton {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 1rem;
 }
 
 @keyframes word-similarity-pulse {
@@ -157,15 +169,17 @@
     display: none;
   }
 
-  .timingSkeleton {
-    gap: 1rem;
+  .timingLegendSkeleton {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 
 @media (prefers-reduced-motion: reduce) {
   .receiptSkeleton,
   .tableRowSkeleton span,
-  .timingLinesSkeleton span {
+  .timingTitleSkeleton,
+  .timingBarSkeleton,
+  .timingLegendSkeleton span {
     animation: none;
   }
 }

--- a/portfolio/components/ui/Figures/WordSimilarity.tsx
+++ b/portfolio/components/ui/Figures/WordSimilarity.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
 import { getCdnBaseUrl } from "../../../utils/cdnBase";
 import { useInView } from "react-intersection-observer";
 import { api } from "../../../services/api";
@@ -8,6 +9,7 @@ import {
   getBestImageUrl,
 } from "../../../utils/imageFormat";
 import styles from "./WordSimilarity.module.css";
+import WordSimilarityLoadingShell from "./WordSimilarityLoadingShell";
 
 // Simple seeded random number generator for consistent randomness
 function seededRandom(seed: number): () => number {
@@ -35,48 +37,6 @@ interface CardPosition {
   y: number;
   rotation: number;
 }
-
-interface SafeZone {
-  minX: number;
-  maxX: number;
-  minY: number;
-  maxY: number;
-}
-
-const WordSimilaritySkeleton: React.FC = () => (
-  <div
-    className={styles.loadingShell}
-    data-testid="word-similarity"
-    aria-busy="true"
-    aria-label="Loading word similarity results"
-  >
-    <div className={styles.receiptStage} aria-hidden="true">
-      {Array.from({ length: 6 }).map((_, index) => (
-        <div key={index} className={styles.receiptSkeleton} />
-      ))}
-    </div>
-
-    <div className={styles.tableSkeleton} aria-hidden="true">
-      <div className={styles.tableHeaderSkeleton} />
-      {Array.from({ length: 5 }).map((_, index) => (
-        <div key={index} className={styles.tableRowSkeleton}>
-          <span />
-          <span />
-          <span />
-        </div>
-      ))}
-    </div>
-
-    <div className={styles.timingSkeleton} aria-hidden="true">
-      <div className={styles.timingRingSkeleton} />
-      <div className={styles.timingLinesSkeleton}>
-        <span />
-        <span />
-        <span />
-      </div>
-    </div>
-  </div>
-);
 
 // Constraint-based position solver that guarantees cards stay within bounds
 function solveCardPosition(
@@ -141,9 +101,6 @@ function solveCardPosition(
  * and a summary table below with merchant/product/price data.
  */
 const WordSimilarity: React.FC = () => {
-  const [data, setData] = useState<MilkSimilarityResponse | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
   const [formatSupport, setFormatSupport] = useState<{
     supportsAVIF: boolean;
     supportsWebP: boolean;
@@ -172,14 +129,17 @@ const WordSimilarity: React.FC = () => {
     triggerOnce: true,
     rootMargin: "200px",
   });
-  // Animation state - similar to ReceiptStack
-  const { ref: stackRef, inView } = useInView({
-    threshold: 0.1,
-    triggerOnce: true,
-  });
-  const [startAnimation, setStartAnimation] = useState(false);
   const [loadedImages, setLoadedImages] = useState<Set<string>>(new Set());
-  const fadeDelay = 25; // ms delay between each card animation
+
+  const {
+    data = null,
+    error: queryError,
+    isPending,
+  } = useQuery<MilkSimilarityResponse>({
+    queryKey: ["word-similarity"],
+    queryFn: ({ signal }) => api.fetchWordSimilarity(signal),
+    enabled: nearViewport,
+  });
 
   const measureContainer = useCallback(() => {
     if (containerRef.current) {
@@ -249,33 +209,6 @@ const WordSimilarity: React.FC = () => {
     detectImageFormatSupport().then(setFormatSupport);
   }, []);
 
-  useEffect(() => {
-    if (!nearViewport) return;
-    const fetchData = async () => {
-      try {
-        setLoading(true);
-        setError(null);
-        const response = await api.fetchWordSimilarity();
-        setData(response);
-      } catch (err) {
-        console.error("Failed to fetch word similarity:", err);
-        setError(err instanceof Error ? err.message : "Failed to load data");
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    fetchData();
-  }, [nearViewport]);
-
-  // Start animation when in view and data is loaded
-  useEffect(() => {
-    if (inView && data?.receipts && data.receipts.length > 0 && !startAnimation) {
-      setStartAnimation(true);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [inView, data?.receipts?.length]);
-
   const handleImageLoad = useCallback((receiptKey: string) => (e: React.SyntheticEvent<HTMLImageElement>) => {
     const img = e.currentTarget;
     if (img.naturalWidth && img.naturalHeight) {
@@ -291,15 +224,15 @@ const WordSimilarity: React.FC = () => {
     }
   }, []);
 
-  if (!nearViewport || loading) {
+  if (!nearViewport || isPending) {
     return (
       <div ref={lazyRef}>
-        <WordSimilaritySkeleton />
+        <WordSimilarityLoadingShell />
       </div>
     );
   }
 
-  if (error || !data) {
+  if (queryError || !data) {
     return (
       <div
         style={{
@@ -308,7 +241,9 @@ const WordSimilarity: React.FC = () => {
           color: "#999",
         }}
       >
-        {error || "No word similarity data available"}
+        {queryError instanceof Error
+          ? queryError.message
+          : "No word similarity data available"}
       </div>
     );
   }
@@ -364,7 +299,10 @@ const WordSimilarity: React.FC = () => {
   };
 
   // Render a single cropped receipt
-  const renderCroppedReceipt = (receiptData: MilkReceiptData) => {
+  const renderCroppedReceipt = (
+    receiptData: MilkReceiptData,
+    imageLoaded: boolean,
+  ) => {
     const cropRegion = calculateCropRegion(receiptData.bbox, receiptData.receipt);
     if (!cropRegion) {
       return null;
@@ -427,6 +365,8 @@ const WordSimilarity: React.FC = () => {
               width: `${imageWidthPercent}%`,
               height: "auto",
               transform: `translate(-${shiftLeftPercent}%, -${shiftTopPercent}%)`,
+              opacity: imageLoaded ? 1 : 0,
+              transition: "opacity 0.25s ease-out",
             }}
             onLoad={handleImageLoad(receiptKey)}
             onError={(e) => {
@@ -459,9 +399,8 @@ const WordSimilarity: React.FC = () => {
       {/* Receipt images stack */}
       <div
         ref={(el) => {
-          // Combine refs: lazyRef for lazy loading, stackRef for animation, containerRef for measurements
+          // Combine the lazy-loading and measurement refs.
           lazyRef(el);
-          stackRef(el);
           (containerRef as React.MutableRefObject<HTMLDivElement | null>).current = el;
         }}
         style={{
@@ -493,10 +432,6 @@ const WordSimilarity: React.FC = () => {
             cardDims = { width: cardWidth, height: cardWidth / estimatedAspectRatio };
           }
 
-          const receiptComponent = renderCroppedReceipt(receiptData);
-
-          if (!receiptComponent) return null;
-
           // Generate seed for consistent randomness
           const imageIdHash = receiptData.receipt.image_id
             ? receiptData.receipt.image_id.split('').reduce((acc: number, char: string) => acc + char.charCodeAt(0), 0)
@@ -515,9 +450,12 @@ const WordSimilarity: React.FC = () => {
 
           const zIndex = displayReceipts.length - index;
 
-          // Check if this image has loaded for animation
+          // Keep the positioned card visible as a placeholder until the image
+          // itself can cross-fade in after decode.
           const imageLoaded = loadedImages.has(receiptKey);
-          const shouldAnimate = startAnimation && imageLoaded;
+          const receiptComponent = renderCroppedReceipt(receiptData, imageLoaded);
+
+          if (!receiptComponent) return null;
 
           // Position card centered at (x, y) with rotation
           // Animation: start off-screen (translateY -50px) and fade in with staggered delay
@@ -538,11 +476,9 @@ const WordSimilarity: React.FC = () => {
                 left: `${x}px`,
                 width: `${cardWidth}px`,
                 zIndex,
-                transform: `translate(-50%, ${shouldAnimate ? '-50%' : 'calc(-50% - 50px)'}) rotate(${rotation}deg)`,
+                transform: `translate(-50%, -50%) rotate(${rotation}deg)`,
                 transformOrigin: "center center",
-                opacity: shouldAnimate ? 1 : 0,
-                transition: `transform 0.6s ease-out ${startAnimation ? index * fadeDelay : 0}ms, opacity 0.6s ease-out ${startAnimation ? index * fadeDelay : 0}ms`,
-                willChange: "transform, opacity",
+                opacity: 1,
               }}
             >
               {receiptComponent}
@@ -553,10 +489,7 @@ const WordSimilarity: React.FC = () => {
 
       {/* Summary table */}
       <div
-        style={{
-          width: "100%",
-          overflowX: "auto",
-        }}
+        className={styles.summaryTableFrame}
       >
         <table
           style={{

--- a/portfolio/components/ui/Figures/WordSimilarityLoadingShell.tsx
+++ b/portfolio/components/ui/Figures/WordSimilarityLoadingShell.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import styles from "./WordSimilarity.module.css";
+
+/**
+ * Stable first-paint shell for the word-similarity figure.
+ *
+ * This lives outside the dynamically imported figure so Next can render the
+ * same geometry while the component chunk and API payload are both loading.
+ */
+export const WordSimilarityLoadingShell: React.FC = () => (
+  <div
+    className={styles.loadingShell}
+    data-testid="word-similarity"
+    aria-busy="true"
+    aria-label="Loading word similarity results"
+  >
+    <div className={styles.receiptStage} aria-hidden="true">
+      {Array.from({ length: 6 }).map((_, index) => (
+        <div key={index} className={styles.receiptSkeleton} />
+      ))}
+    </div>
+
+    <div className={styles.tableSkeleton} aria-hidden="true">
+      <div className={styles.tableHeaderSkeleton} />
+      {Array.from({ length: 5 }).map((_, index) => (
+        <div key={index} className={styles.tableRowSkeleton}>
+          <span />
+          <span />
+          <span />
+        </div>
+      ))}
+    </div>
+
+    <div className={styles.timingSkeleton} aria-hidden="true">
+      <div className={styles.timingTitleSkeleton} />
+      <div className={styles.timingBarSkeleton} />
+      <div className={styles.timingLegendSkeleton}>
+        {Array.from({ length: 5 }).map((_, index) => (
+          <span key={index} />
+        ))}
+      </div>
+    </div>
+  </div>
+);
+
+export default WordSimilarityLoadingShell;

--- a/portfolio/components/ui/Figures/index.ts
+++ b/portfolio/components/ui/Figures/index.ts
@@ -1,6 +1,8 @@
 import dynamic from "next/dynamic";
 import React from "react";
 import { ReceiptFlowLoadingShell } from "./ReceiptFlow/ReceiptFlowLoadingShell";
+import TrainingMetricsLoadingShell from "./TrainingMetricsAnimation/TrainingMetricsLoadingShell";
+import WordSimilarityLoadingShell from "./WordSimilarityLoadingShell";
 
 type LoadingVariant = React.ComponentProps<typeof ReceiptFlowLoadingShell>["variant"];
 
@@ -77,7 +79,10 @@ export const PhotoReceiptDBSCAN = dynamic(
 );
 export { default as AddressSimilarity } from "./AddressSimilarity";
 export const AddressSimilaritySideBySide = dynamic(() => import("./AddressSimilaritySideBySide"), { ssr: false });
-export const WordSimilarity = dynamic(() => import("./WordSimilarity"), { ssr: false });
+export const WordSimilarity = dynamic(() => import("./WordSimilarity"), {
+  ssr: false,
+  loading: () => React.createElement(WordSimilarityLoadingShell),
+});
 export const CICDLoop = dynamic(() => import("./CICDLoop"), { ssr: false });
 export { default as CroppedAddressImage } from "./CroppedAddressImage";
 export const DynamoStreamAnimation = dynamic(() => import("./DynamoStreamAnimation"), { ssr: false });
@@ -96,7 +101,10 @@ export { default as RandomReceiptWithLabels } from "./RandomReceiptWithLabels";
 export const StreamBitsRoutingDiagram = dynamic(() => import("./StreamBitsRoutingDiagram"), { ssr: false });
 export const TrainingMetricsAnimation = dynamic(
   () => import("./TrainingMetricsAnimation"),
-  { ssr: false }
+  {
+    ssr: false,
+    loading: () => React.createElement(TrainingMetricsLoadingShell),
+  }
 );
 export const EpochEvaluation = dynamic(
   () => import("./EpochEvaluation"),

--- a/portfolio/e2e/skeleton-height-stability.spec.ts
+++ b/portfolio/e2e/skeleton-height-stability.spec.ts
@@ -281,6 +281,49 @@ test.describe("Skeleton height stability", () => {
     assertBoxStable(loadingBox!, loadedBox!, "WordSimilarity");
   });
 
+  test("WordSimilarity keeps a card placeholder while its image decodes", async ({
+    page,
+  }) => {
+    const pendingImages: Route[] = [];
+    await page.route("**/*.jpg", async (route) => {
+      pendingImages.push(route);
+    });
+    await page.route("**/word_similarity*", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(mockWordSimilarityResponse),
+      });
+    });
+    await stubOtherApis(page, ["word_similarity"]);
+    await navigateToReceipt(page);
+    await scrollToAnchor(
+      page,
+      "digs through the corpus, finds every mention of milk"
+    );
+
+    const table = page.locator("table").filter({ visible: true });
+    await expect(table).toHaveCount(1, { timeout: 15000 });
+    await expect.poll(() => pendingImages.length).toBeGreaterThan(0);
+
+    const card = page.locator("[data-receipt-key]").filter({ visible: true });
+    await expect(card).toHaveCount(1);
+    await expect(card).toHaveCSS("opacity", "1");
+    const image = card.locator("img");
+    await expect(image).toHaveCSS("opacity", "0");
+
+    for (const route of pendingImages) {
+      await route.fulfill({
+        status: 200,
+        contentType: "image/svg+xml",
+        body: Buffer.from(
+          '<svg xmlns="http://www.w3.org/2000/svg" width="300" height="400"><rect width="300" height="400" fill="#e8e8e8"/></svg>'
+        ),
+      });
+    }
+    await expect(image).toHaveCSS("opacity", "1");
+  });
+
   // ---------------------------------------------------------------------------
   // CICDLoop
   // ---------------------------------------------------------------------------

--- a/portfolio/pages/receipt.tsx
+++ b/portfolio/pages/receipt.tsx
@@ -45,6 +45,9 @@ import {
   PulumiLogo,
 } from "../components/ui/Logos";
 import QueryLabelTransform from "../components/ui/QueryLabelTransform";
+import { ReceiptFlowLoadingShell } from "../components/ui/Figures/ReceiptFlow/ReceiptFlowLoadingShell";
+import TrainingMetricsLoadingShell from "../components/ui/Figures/TrainingMetricsAnimation/TrainingMetricsLoadingShell";
+import WordSimilarityLoadingShell from "../components/ui/Figures/WordSimilarityLoadingShell";
 
 interface ReceiptPageProps {
   uploadDiagramChars: string[];
@@ -53,6 +56,7 @@ interface ReceiptPageProps {
 
 interface FigureBoundaryProps {
   children: React.ReactNode;
+  fallback?: React.ReactNode;
   name: string;
   intrinsicSize: string;
   mobileIntrinsicSize?: string;
@@ -60,8 +64,27 @@ interface FigureBoundaryProps {
 
 const FIGURE_LAZY_ROOT_MARGIN = "1000px 0px";
 
+const LayoutLMLoadingFallback = () => (
+  <div
+    style={{
+      width: "100%",
+      maxWidth: "1000px",
+      margin: "2rem auto",
+      padding: "1.5rem",
+      background: "var(--background-color)",
+      borderRadius: "12px",
+    }}
+  >
+    <ReceiptFlowLoadingShell
+      variant="layoutlm"
+      layoutVars={{ "--rf-align-items": "center" } as React.CSSProperties}
+    />
+  </div>
+);
+
 const FigureBoundary = ({
   children,
+  fallback = null,
   name,
   intrinsicSize,
   mobileIntrinsicSize = intrinsicSize,
@@ -92,7 +115,7 @@ const FigureBoundary = ({
         } as React.CSSProperties
       }
     >
-      {shouldRender ? children : null}
+      {shouldRender ? children : fallback}
     </div>
   );
 };
@@ -105,8 +128,12 @@ const QAAgentFigure = () => {
     selectQuestion: setSelectedQuestion,
   } = useQAQueue();
 
+  if (!qaData) {
+    return <ReceiptFlowLoadingShell variant="qa" />;
+  }
+
   return (
-    <QAAgentFlow autoPlay={true} questionData={qaData ?? undefined} onCycleComplete={advanceQuestion}>
+    <QAAgentFlow autoPlay={true} questionData={qaData} onCycleComplete={advanceQuestion}>
       <QuestionMarquee rows={4} speed={25} onQuestionClick={setSelectedQuestion} activeQuestion={selectedQuestion} />
     </QAAgentFlow>
   );
@@ -459,15 +486,20 @@ M1LK 2%           1    $4.4g`}</code>
       <FigureBoundary
         name="training-metrics"
         intrinsicSize="640px"
-        mobileIntrinsicSize="560px"
+        mobileIntrinsicSize="600px"
+        fallback={<TrainingMetricsLoadingShell />}
       >
-        <ClientOnly>
+        <ClientOnly fallback={<TrainingMetricsLoadingShell />}>
           <TrainingMetricsAnimation />
         </ClientOnly>
       </FigureBoundary>
 
-      <FigureBoundary name="layoutlm-inference" intrinsicSize="640px">
-        <ClientOnly>
+      <FigureBoundary
+        name="layoutlm-inference"
+        intrinsicSize="640px"
+        fallback={<LayoutLMLoadingFallback />}
+      >
+        <ClientOnly fallback={<LayoutLMLoadingFallback />}>
           <LayoutLMInferenceVisualization />
         </ClientOnly>
       </FigureBoundary>
@@ -540,10 +572,11 @@ M1LK 2%           1    $4.4g`}</code>
 
       <FigureBoundary
         name="word-similarity"
-        intrinsicSize="1080px"
-        mobileIntrinsicSize="980px"
+        intrinsicSize="1160px"
+        mobileIntrinsicSize="1160px"
+        fallback={<WordSimilarityLoadingShell />}
       >
-        <ClientOnly>
+        <ClientOnly fallback={<WordSimilarityLoadingShell />}>
           <WordSimilarity />
         </ClientOnly>
       </FigureBoundary>

--- a/portfolio/services/api/index.ts
+++ b/portfolio/services/api/index.ts
@@ -31,7 +31,9 @@ import { API_CONFIG } from "./config";
 const getAPIUrl = () => API_CONFIG.baseUrl;
 
 const fetchConfig = {
-  headers: API_CONFIG.headers,
+  // Bodyless GETs must not send Content-Type. In production these calls are
+  // cross-origin, and application/json would force an avoidable CORS preflight.
+  headers: { Accept: "application/json" },
 };
 
 // API calls that go directly to external APIs
@@ -256,11 +258,11 @@ const baseApi = {
     return response.json();
   },
 
-  async fetchWordSimilarity(): Promise<MilkSimilarityResponse> {
+  async fetchWordSimilarity(signal?: AbortSignal): Promise<MilkSimilarityResponse> {
     const apiUrl = getAPIUrl();
     const response = await fetch(
       `${apiUrl}/word_similarity`,
-      fetchConfig
+      { ...fetchConfig, signal }
     );
     if (!response.ok) {
       throw new Error(
@@ -284,11 +286,13 @@ const baseApi = {
     return response.json();
   },
 
-  async fetchFeaturedTrainingMetrics(): Promise<TrainingMetricsResponse> {
+  async fetchFeaturedTrainingMetrics(
+    signal?: AbortSignal
+  ): Promise<TrainingMetricsResponse> {
     const apiUrl = getAPIUrl();
     const response = await fetch(
       `${apiUrl}/jobs/featured/training-metrics?collapse_bio=true`,
-      fetchConfig
+      { ...fetchConfig, signal }
     );
     if (!response.ok) {
       throw new Error(


### PR DESCRIPTION
## What changed

- reuse matched loading shells across lazy boundaries, client hydration, dynamic imports, and API loading
- move Word Similarity and Training Metrics fetching to TanStack Query with cancellation
- remove unnecessary JSON content headers from GET requests to avoid CORS preflights
- preserve Word Similarity card placeholders until images decode and contain variable table height
- align Training Metrics and LayoutLM skeleton geometry with loaded content
- initialize responsive figure state correctly on the first mobile render
- keep the QA figure in a loading shell until real API data is available
- add desktop/mobile regression coverage for height stability and delayed image decoding

## Why

The previous loading path could pass through several unrelated or empty states: the viewport boundary, the client-only boundary, the dynamic chunk fallback, API loading, and image decoding. Those transitions caused blank frames, content swaps, or visible layout movement under slow connections.

This change gives the API-backed figures a single stable visual shape from the server-rendered first frame through loaded data.

## User impact

Receipt-page figures no longer pop into place while data or images load. The experience is stable on desktop and mobile, including large Word Similarity responses.

## Validation

- `npm run type-check`
- `npm run build`
- `npm test -- --runInBand services/api/index.test.ts` — 10 passed
- `CAPTURE_SKELETON_EVIDENCE=1 npx playwright test e2e/skeleton-height-stability.spec.ts --project=chromium --project='Mobile Chrome' --workers=1 --reporter=line` — 10 passed
- targeted ESLint — 0 errors
- `git diff --check`

Measured skeleton → loaded heights:

| Figure | Desktop | Mobile |
| --- | ---: | ---: |
| Training Metrics | 640 → 640 px | 600 → 600 px |
| LayoutLM | 640 → 640 px | 640 → 640 px |
| Word Similarity | 1160 → 1160 px | 1160 → 1160 px |
