### PR TITLE
Add line-first receipt re-segmentation review workflow

### DIFF
--- a/infra/__main__.py
+++ b/infra/__main__.py
@@ -50,6 +50,7 @@ from fix_place_lambda import create_fix_place_lambda
 from label_evaluator_step_functions import LabelEvaluatorStepFunction
 from label_refresh_lambda import create_label_refresh_lambda
 from merge_receipt_lambda import create_merge_receipt_lambda
+from resegment_receipt_lambda import create_resegment_receipt_lambda
 
 # Using the optimized docker-build based base images with scoped contexts
 from networking import PublicVpc
@@ -1256,6 +1257,22 @@ merge_receipt_lambda = create_merge_receipt_lambda(
 pulumi.export("merge_receipt_lambda_arn", merge_receipt_lambda.lambda_arn)
 pulumi.export(
     "merge_receipt_lambda_name", merge_receipt_lambda.lambda_function.name
+)
+
+# Receipt Re-segmentation Lambda (one source receipt -> N guarded outputs)
+resegment_receipt_lambda = create_resegment_receipt_lambda(
+    dynamodb_table_name=dynamodb_table.name,
+    dynamodb_table_arn=dynamodb_table.arn,
+    raw_bucket_name=raw_bucket.bucket,
+    site_bucket_name=site_bucket.bucket,
+    image_bucket_name=upload_images.image_bucket.bucket,
+    chromadb_bucket_name=embedding_infrastructure.chromadb_buckets.bucket_name,
+    chromadb_bucket_arn=embedding_infrastructure.chromadb_buckets.bucket_arn,
+)
+pulumi.export("resegment_receipt_lambda_arn", resegment_receipt_lambda.lambda_arn)
+pulumi.export(
+    "resegment_receipt_lambda_name",
+    resegment_receipt_lambda.lambda_function.name,
 )
 
 # Trigger Re-OCR Lambda (for manually triggering regional re-OCR)

--- a/infra/mcp_server_lambda/lambdas/receipt_mcp_server_server.py
+++ b/infra/mcp_server_lambda/lambdas/receipt_mcp_server_server.py
@@ -18,10 +18,12 @@ Environment:
 """
 
 import asyncio
+import base64
 import json
 import logging
 import os
 import sys
+import urllib.request
 from collections import defaultdict
 from typing import Any, Optional
 
@@ -36,7 +38,7 @@ sys.path.insert(0, os.path.join(parent_dir, "receipt_chroma"))
 
 from mcp.server import Server
 from mcp.server.stdio import stdio_server
-from mcp.types import TextContent, Tool
+from mcp.types import ImageContent, TextContent, Tool
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -79,6 +81,7 @@ def get_clients():
             }
         else:
             from receipt_dynamo.data._pulumi import load_env, load_secrets
+
             config = load_env(env=env)
             secrets = load_secrets(env=env)
             for key, value in secrets.items():
@@ -119,6 +122,165 @@ def get_clients():
 
 # Create MCP server
 server = Server("receipt-tools")
+
+
+def _resegment_word_ref_schema() -> dict:
+    return {
+        "type": "object",
+        "properties": {
+            "line_id": {"type": "integer"},
+            "word_id": {"type": "integer"},
+            "word_ids": {"type": "array", "items": {"type": "integer"}},
+        },
+        "required": ["line_id"],
+        "oneOf": [{"required": ["word_id"]}, {"required": ["word_ids"]}],
+    }
+
+
+def _resegment_visible_region_schema() -> dict:
+    return {
+        "type": "object",
+        "description": (
+            "A visible PHOTO region in normalized IMAGE coordinates (x left-to-right, "
+            "y bottom-to-top). Disconnected receipts may provide multiple regions."
+        ),
+        "properties": {
+            "region_id": {"type": "string"},
+            "line_ids": {
+                "type": "array",
+                "items": {"type": "integer"},
+                "description": "Optional lines expected in this visible component.",
+            },
+            "points": {
+                "type": "array",
+                "minItems": 3,
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "x": {"type": "number", "minimum": 0, "maximum": 1},
+                        "y": {"type": "number", "minimum": 0, "maximum": 1},
+                    },
+                    "required": ["x", "y"],
+                },
+            },
+        },
+        "required": ["points"],
+    }
+
+
+def _resegment_segment_schema(*, legacy_selectors: bool = True) -> dict:
+    properties = {
+        "segment_key": {"type": "string"},
+        "place_policy": {
+            "type": "string",
+            "enum": ["inherit", "none"],
+            "default": "none",
+        },
+        "z_index": {
+            "type": "integer",
+            "default": 0,
+            "description": "PHOTO layer order; larger values are in front.",
+        },
+        "occluded_by": {
+            "type": "array",
+            "items": {"type": "string"},
+        },
+        "visible_regions": {
+            "type": "array",
+            "items": _resegment_visible_region_schema(),
+        },
+    }
+    if legacy_selectors:
+        properties.update(
+            {
+                "include_line_ids": {
+                    "type": "array",
+                    "items": {"type": "integer"},
+                },
+                "include_word_refs": {
+                    "type": "array",
+                    "items": _resegment_word_ref_schema(),
+                },
+            }
+        )
+    return {
+        "type": "object",
+        "properties": properties,
+        "required": ["segment_key"],
+    }
+
+
+def _resegment_assignments_schema() -> dict:
+    return {
+        "type": "object",
+        "description": (
+            "Schema v2 line-first ownership. Every line must appear exactly once in "
+            "lines or discard_lines; words are sparse contiguous overrides."
+        ),
+        "properties": {
+            "lines": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "line_id": {"type": "integer"},
+                        "segment_key": {"type": "string"},
+                    },
+                    "required": ["line_id", "segment_key"],
+                },
+            },
+            "words": {
+                "type": "array",
+                "items": {
+                    **_resegment_word_ref_schema(),
+                    "properties": {
+                        **_resegment_word_ref_schema()["properties"],
+                        "segment_key": {"type": "string"},
+                        "reason": {"type": "string"},
+                    },
+                    "required": ["line_id", "segment_key", "reason"],
+                },
+            },
+            "discard_lines": {
+                "type": "array",
+                "items": {"type": "integer"},
+            },
+            "discard_words": {
+                "type": "array",
+                "items": _resegment_word_ref_schema(),
+            },
+            "discard_reason": {"type": "string"},
+            "allow_labeled_discard": {"type": "boolean", "default": False},
+        },
+        "required": ["lines"],
+    }
+
+
+def _resegment_visualization_schema() -> dict:
+    return {
+        "type": "object",
+        "properties": {
+            "strategy": {
+                "type": "string",
+                "enum": ["AUTO", "RECTANGULAR", "LAYERED_MULTI_REGION"],
+                "default": "AUTO",
+            },
+            "padding_px": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 256,
+                "default": 12,
+            },
+            "confirm_stacked_scan": {
+                "type": "boolean",
+                "default": False,
+                "description": (
+                    "Required before using layered geometry on a stored SCAN. "
+                    "The stored image_type cannot be overridden by the caller."
+                ),
+            },
+        },
+    }
 
 
 @server.list_tools()
@@ -528,7 +690,14 @@ WARNING: This WRITES to DynamoDB. Double-check the word context before calling."
                         "description": "Why this status was chosen (e.g., 'tax flag indicator, not a product name'). Overwrites existing reasoning.",
                     },
                 },
-                "required": ["image_id", "receipt_id", "line_id", "word_id", "label", "new_status"],
+                "required": [
+                    "image_id",
+                    "receipt_id",
+                    "line_id",
+                    "word_id",
+                    "label",
+                    "new_status",
+                ],
             },
         ),
         Tool(
@@ -587,7 +756,14 @@ image_id/receipt_id/line_id/word_id/label already exists.""",
                         "description": "Validation status for the new row. Defaults to VALID (human-reviewed). Use PENDING for machine-propagated rows (e.g. SECTION_* sections) that still need QA.",
                     },
                 },
-                "required": ["image_id", "receipt_id", "line_id", "word_id", "label", "reasoning"],
+                "required": [
+                    "image_id",
+                    "receipt_id",
+                    "line_id",
+                    "word_id",
+                    "label",
+                    "reasoning",
+                ],
             },
         ),
         Tool(
@@ -634,6 +810,134 @@ and DELETES the original receipts. Only proceed after verifying with dry_run."""
                     },
                 },
                 "required": ["image_id", "receipt_ids"],
+            },
+        ),
+        Tool(
+            name="plan_receipt_resegmentation",
+            description="""Plan a safe split of one receipt into one or more outputs.
+
+Use schema_version=2 for line-first ownership. Every source line receives one
+default destination; sparse contiguous word overrides handle mixed OCR lines.
+The stored image_type selects PHOTO/SCAN behavior and cannot be overridden.
+The tool creates an assignment overlay, contact sheet, masks, visible crops,
+metrics, and one-hour signed URLs without changing receipt data.
+
+Review the returned image, findings, metrics, totals, and label counts. Revise
+the plan until clean before applying. Layered PHOTO plans are review-only until
+masked output rendering is explicitly enabled.""",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "image_id": {"type": "string"},
+                    "source_receipt_id": {"type": "integer"},
+                    "schema_version": {
+                        "type": "integer",
+                        "enum": [1, 2],
+                        "default": 1,
+                        "description": (
+                            "Use 2 with assignments for line-first planning. "
+                            "Version 1 remains available for legacy word selectors."
+                        ),
+                    },
+                    "segments": {
+                        "type": "array",
+                        "minItems": 1,
+                        "maxItems": 23,
+                        "items": _resegment_segment_schema(),
+                    },
+                    "assignments": _resegment_assignments_schema(),
+                    "visualization": _resegment_visualization_schema(),
+                    "discard_line_ids": {
+                        "type": "array",
+                        "items": {"type": "integer"},
+                    },
+                    "discard_word_refs": {
+                        "type": "array",
+                        "items": _resegment_word_ref_schema(),
+                    },
+                    "discard_reason": {"type": "string"},
+                    "allow_labeled_discard": {
+                        "type": "boolean",
+                        "default": False,
+                    },
+                    "padding_px": {
+                        "type": "number",
+                        "minimum": 0,
+                        "maximum": 256,
+                        "default": 12,
+                    },
+                },
+                "required": ["image_id", "source_receipt_id", "segments"],
+            },
+        ),
+        Tool(
+            name="get_receipt_resegmentation_plan",
+            description="""Retrieve a receipt re-segmentation plan revision.
+
+Returns the immutable assignment evidence, metrics, findings, artifact hashes,
+and freshly signed visualization URLs. Use this whenever preview URLs expire or
+before revising/applying to verify that a revision is still latest and applicable.""",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "plan_id": {"type": "string"},
+                    "revision": {"type": "integer", "minimum": 1},
+                },
+                "required": ["plan_id"],
+            },
+        ),
+        Tool(
+            name="revise_receipt_resegmentation_plan",
+            description="""Create an immutable replacement plan revision.
+
+Submit complete segment definitions and line-first assignments. base_revision
+and base_plan_hash provide optimistic concurrency protection; stale revisions
+are rejected. The new revision receives new overlay, mask, crop, and contact-
+sheet artifacts while the previous revision remains reviewable.""",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "plan_id": {"type": "string"},
+                    "base_revision": {"type": "integer", "minimum": 1},
+                    "base_plan_hash": {"type": "string"},
+                    "segments": {
+                        "type": "array",
+                        "minItems": 1,
+                        "maxItems": 23,
+                        "items": _resegment_segment_schema(legacy_selectors=False),
+                    },
+                    "assignments": _resegment_assignments_schema(),
+                    "visualization": _resegment_visualization_schema(),
+                    "revision_reason": {"type": "string", "minLength": 1},
+                },
+                "required": [
+                    "plan_id",
+                    "base_revision",
+                    "base_plan_hash",
+                    "segments",
+                    "assignments",
+                    "revision_reason",
+                ],
+            },
+        ),
+        Tool(
+            name="apply_receipt_resegmentation",
+            description="""Apply a previously reviewed receipt re-segmentation plan.
+
+The apply is guarded by the plan hash and source fingerprint. New receipt IDs
+are reserved invisibly, children and embeddings are staged and verified, and
+the output parents replace the source parent atomically. Cleanup is resumable.
+
+WARNING: This creates new receipt records and deletes the source receipt after
+the staged outputs are ready. Superseded revisions and plans with blocking
+findings—including layered PHOTO plans—are rejected.""",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "plan_id": {"type": "string"},
+                    "plan_hash": {"type": "string"},
+                },
+                "required": ["plan_id", "plan_hash"],
             },
         ),
         Tool(
@@ -926,8 +1230,14 @@ YYYY-MM-DD, inclusive, in America/Los_Angeles.""",
             inputSchema={
                 "type": "object",
                 "properties": {
-                    "start_date": {"type": "string", "description": "Start date YYYY-MM-DD (PT, inclusive)"},
-                    "end_date": {"type": "string", "description": "End date YYYY-MM-DD (PT, inclusive)"},
+                    "start_date": {
+                        "type": "string",
+                        "description": "Start date YYYY-MM-DD (PT, inclusive)",
+                    },
+                    "end_date": {
+                        "type": "string",
+                        "description": "End date YYYY-MM-DD (PT, inclusive)",
+                    },
                 },
                 "required": ["start_date", "end_date"],
             },
@@ -943,10 +1253,24 @@ real outside humans. Ordered by activity.""",
             inputSchema={
                 "type": "object",
                 "properties": {
-                    "start_date": {"type": "string", "description": "Start date YYYY-MM-DD (PT)"},
-                    "end_date": {"type": "string", "description": "End date YYYY-MM-DD (PT)"},
-                    "humans_only": {"type": "boolean", "default": True, "description": "Exclude bots + WARP (default true)"},
-                    "limit": {"type": "integer", "default": 50, "description": "Max sessions to return"},
+                    "start_date": {
+                        "type": "string",
+                        "description": "Start date YYYY-MM-DD (PT)",
+                    },
+                    "end_date": {
+                        "type": "string",
+                        "description": "End date YYYY-MM-DD (PT)",
+                    },
+                    "humans_only": {
+                        "type": "boolean",
+                        "default": True,
+                        "description": "Exclude bots + WARP (default true)",
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "default": 50,
+                        "description": "Max sessions to return",
+                    },
                 },
                 "required": ["start_date", "end_date"],
             },
@@ -962,9 +1286,21 @@ Use to answer "who just visited" without hand-writing SQL against raw logs.""",
             inputSchema={
                 "type": "object",
                 "properties": {
-                    "hours": {"type": "integer", "default": 6, "description": "Look-back window in hours (default 6, max 48)"},
-                    "humans_only": {"type": "boolean", "default": True, "description": "Exclude bots + WARP (default true)"},
-                    "limit": {"type": "integer", "default": 50, "description": "Max rows (default 50, max 200)"},
+                    "hours": {
+                        "type": "integer",
+                        "default": 6,
+                        "description": "Look-back window in hours (default 6, max 48)",
+                    },
+                    "humans_only": {
+                        "type": "boolean",
+                        "default": True,
+                        "description": "Exclude bots + WARP (default true)",
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "default": 50,
+                        "description": "Max rows (default 50, max 200)",
+                    },
                 },
                 "required": [],
             },
@@ -979,11 +1315,29 @@ Returns value + hit count + distinct sessions. Bots + WARP excluded by default."
             inputSchema={
                 "type": "object",
                 "properties": {
-                    "dimension": {"type": "string", "enum": ["page", "referrer", "ip", "country", "org"], "description": "What to rank"},
-                    "start_date": {"type": "string", "description": "Start date YYYY-MM-DD (PT)"},
-                    "end_date": {"type": "string", "description": "End date YYYY-MM-DD (PT)"},
-                    "limit": {"type": "integer", "default": 15, "description": "Max rows"},
-                    "humans_only": {"type": "boolean", "default": True, "description": "Exclude bots + WARP (default true)"},
+                    "dimension": {
+                        "type": "string",
+                        "enum": ["page", "referrer", "ip", "country", "org"],
+                        "description": "What to rank",
+                    },
+                    "start_date": {
+                        "type": "string",
+                        "description": "Start date YYYY-MM-DD (PT)",
+                    },
+                    "end_date": {
+                        "type": "string",
+                        "description": "End date YYYY-MM-DD (PT)",
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "default": 15,
+                        "description": "Max rows",
+                    },
+                    "humans_only": {
+                        "type": "boolean",
+                        "default": True,
+                        "description": "Exclude bots + WARP (default true)",
+                    },
                 },
                 "required": ["dimension", "start_date", "end_date"],
             },
@@ -1000,8 +1354,14 @@ that up separately (e.g. an IP-info service).""",
                 "type": "object",
                 "properties": {
                     "ip": {"type": "string", "description": "Client IP (v4 or v6)"},
-                    "start_date": {"type": "string", "description": "Start date YYYY-MM-DD (PT)"},
-                    "end_date": {"type": "string", "description": "End date YYYY-MM-DD (PT)"},
+                    "start_date": {
+                        "type": "string",
+                        "description": "Start date YYYY-MM-DD (PT)",
+                    },
+                    "end_date": {
+                        "type": "string",
+                        "description": "End date YYYY-MM-DD (PT)",
+                    },
                 },
                 "required": ["ip", "start_date", "end_date"],
             },
@@ -1018,7 +1378,10 @@ analytics_* tools; use this only when they don't fit.""",
             inputSchema={
                 "type": "object",
                 "properties": {
-                    "sql": {"type": "string", "description": "A single read-only SELECT/WITH query"},
+                    "sql": {
+                        "type": "string",
+                        "description": "A single read-only SELECT/WITH query",
+                    },
                 },
                 "required": ["sql"],
             },
@@ -1035,8 +1398,14 @@ via analytics_reconcile. Dates YYYY-MM-DD, inclusive.""",
             inputSchema={
                 "type": "object",
                 "properties": {
-                    "start_date": {"type": "string", "description": "Start date YYYY-MM-DD"},
-                    "end_date": {"type": "string", "description": "End date YYYY-MM-DD"},
+                    "start_date": {
+                        "type": "string",
+                        "description": "Start date YYYY-MM-DD",
+                    },
+                    "end_date": {
+                        "type": "string",
+                        "description": "End date YYYY-MM-DD",
+                    },
                 },
                 "required": ["start_date", "end_date"],
             },
@@ -1053,8 +1422,14 @@ can mean bot leakage. Dates YYYY-MM-DD, inclusive (Pacific).""",
             inputSchema={
                 "type": "object",
                 "properties": {
-                    "start_date": {"type": "string", "description": "Start date YYYY-MM-DD"},
-                    "end_date": {"type": "string", "description": "End date YYYY-MM-DD"},
+                    "start_date": {
+                        "type": "string",
+                        "description": "Start date YYYY-MM-DD",
+                    },
+                    "end_date": {
+                        "type": "string",
+                        "description": "End date YYYY-MM-DD",
+                    },
                 },
                 "required": ["start_date", "end_date"],
             },
@@ -1071,8 +1446,14 @@ Referrers/paths reflect the most recent 14-day snapshot. Dates YYYY-MM-DD.""",
             inputSchema={
                 "type": "object",
                 "properties": {
-                    "start_date": {"type": "string", "description": "Start date YYYY-MM-DD"},
-                    "end_date": {"type": "string", "description": "End date YYYY-MM-DD"},
+                    "start_date": {
+                        "type": "string",
+                        "description": "Start date YYYY-MM-DD",
+                    },
+                    "end_date": {
+                        "type": "string",
+                        "description": "End date YYYY-MM-DD",
+                    },
                 },
                 "required": ["start_date", "end_date"],
             },
@@ -1098,7 +1479,14 @@ Use status_filter to narrow results (e.g., "succeeded", "running", "failed")."""
                     },
                     "status_filter": {
                         "type": "string",
-                        "enum": ["succeeded", "running", "failed", "pending", "cancelled", "interrupted"],
+                        "enum": [
+                            "succeeded",
+                            "running",
+                            "failed",
+                            "pending",
+                            "cancelled",
+                            "interrupted",
+                        ],
                         "description": "Filter jobs by status (optional)",
                     },
                 },
@@ -1318,8 +1706,26 @@ WARNING: This WRITES to DynamoDB and is irreversible for that row.""",
     ]
 
 
+def _resegment_contact_sheet(result: Any) -> tuple[str, str] | None:
+    if not isinstance(result, dict):
+        return None
+    url = (result.get("preview_urls") or {}).get("contact_sheet")
+    artifact = (result.get("visualizations") or {}).get("contact_sheet") or {}
+    if not url:
+        return None
+    return url, artifact.get("mime_type", "image/jpeg")
+
+
+def _fetch_mcp_preview(url: str) -> bytes:
+    with urllib.request.urlopen(url, timeout=15) as response:  # nosec B310
+        data = response.read(2_500_001)
+    if len(data) > 2_500_000:
+        raise ValueError("MCP contact sheet exceeds 2.5 MB")
+    return data
+
+
 @server.call_tool()
-async def call_tool(name: str, arguments: dict) -> list[TextContent]:
+async def call_tool(name: str, arguments: dict) -> list[TextContent | ImageContent]:
     """Handle tool calls."""
     try:
         dynamo_client, chroma_client, embed_fn = get_clients()
@@ -1404,6 +1810,20 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent]:
                 receipt_ids=arguments["receipt_ids"],
                 dry_run=arguments.get("dry_run", True),
             )
+        elif name == "plan_receipt_resegmentation":
+            result = await plan_receipt_resegmentation_impl(arguments)
+        elif name == "get_receipt_resegmentation_plan":
+            result = await get_receipt_resegmentation_plan_impl(
+                plan_id=arguments["plan_id"],
+                revision=arguments.get("revision"),
+            )
+        elif name == "revise_receipt_resegmentation_plan":
+            result = await revise_receipt_resegmentation_plan_impl(arguments)
+        elif name == "apply_receipt_resegmentation":
+            result = await apply_receipt_resegmentation_impl(
+                plan_id=arguments["plan_id"],
+                plan_hash=arguments["plan_hash"],
+            )
         elif name == "get_receipt_words":
             result = await get_receipt_words_impl(
                 dynamo_client,
@@ -1427,9 +1847,7 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent]:
                 label=arguments["label"],
                 reasoning=arguments["reasoning"],
                 consolidated_from=arguments.get("consolidated_from"),
-                validation_status=arguments.get(
-                    "validation_status", "VALID"
-                ),
+                validation_status=arguments.get("validation_status", "VALID"),
             )
         elif name == "compute_reocr_region":
             result = await compute_reocr_region_impl(
@@ -1492,9 +1910,7 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent]:
                 section_type=arguments["section_type"],
                 line_ids=arguments["line_ids"],
                 validation_status=arguments.get("validation_status", "VALID"),
-                model_source=arguments.get(
-                    "model_source", "mcp-claude-review"
-                ),
+                model_source=arguments.get("model_source", "mcp-claude-review"),
             )
         elif name == "delete_receipt_section":
             result = await delete_receipt_section_impl(
@@ -1575,7 +1991,33 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent]:
         else:
             result = {"error": f"Unknown tool: {name}"}
 
-        return [TextContent(type="text", text=json.dumps(result, indent=2))]
+        content: list[TextContent | ImageContent] = [
+            TextContent(type="text", text=json.dumps(result, indent=2))
+        ]
+        if name in {
+            "plan_receipt_resegmentation",
+            "get_receipt_resegmentation_plan",
+            "revise_receipt_resegmentation_plan",
+        }:
+            contact_sheet = _resegment_contact_sheet(result)
+            if contact_sheet:
+                try:
+                    image_bytes = await asyncio.to_thread(
+                        _fetch_mcp_preview, contact_sheet[0]
+                    )
+                    content.append(
+                        ImageContent(
+                            type="image",
+                            data=base64.b64encode(image_bytes).decode("ascii"),
+                            mimeType=contact_sheet[1],
+                        )
+                    )
+                except Exception:
+                    logger.warning(
+                        "Unable to attach re-segmentation contact sheet",
+                        exc_info=True,
+                    )
+        return content
 
     except Exception as e:
         logger.exception("Tool error")
@@ -2348,15 +2790,18 @@ async def list_words_by_label_impl(
 
         words = []
         for record in sample:
-            words.append({
-                "text": getattr(record, "text", ""),
-                "validation_status": getattr(record, "validation_status", None) or "NONE",
-                "image_id": record.image_id,
-                "receipt_id": record.receipt_id,
-                "line_id": record.line_id,
-                "word_id": record.word_id,
-                "label_proposed_by": getattr(record, "label_proposed_by", None),
-            })
+            words.append(
+                {
+                    "text": getattr(record, "text", ""),
+                    "validation_status": getattr(record, "validation_status", None)
+                    or "NONE",
+                    "image_id": record.image_id,
+                    "receipt_id": record.receipt_id,
+                    "line_id": record.line_id,
+                    "word_id": record.word_id,
+                    "label_proposed_by": getattr(record, "label_proposed_by", None),
+                }
+            )
 
         return {
             "label": label,
@@ -2451,7 +2896,12 @@ async def validate_word_similarity_impl(
         evidence_for = []
         evidence_against = []
 
-        for metas, dists in [(positive_results.get("metadatas", [[]]), positive_results.get("distances", [[]]))]:
+        for metas, dists in [
+            (
+                positive_results.get("metadatas", [[]]),
+                positive_results.get("distances", [[]]),
+            )
+        ]:
             for meta, dist in zip(metas[0] if metas else [], dists[0] if dists else []):
                 sim = dist_to_sim(dist)
                 if sim < MIN_SIMILARITY:
@@ -2460,14 +2910,21 @@ async def validate_word_similarity_impl(
                 rid = f"IMAGE#{meta.get('image_id', '')}#RECEIPT#{meta.get('receipt_id', 0):05d}#LINE#{meta.get('line_id', 0):05d}#WORD#{meta.get('word_id', 0):05d}"
                 if rid == chroma_id:
                     continue
-                evidence_for.append({
-                    "text": meta.get("text", ""),
-                    "similarity": round(sim, 3),
-                    "merchant": meta.get("merchant_name", ""),
-                    "same_merchant": meta.get("merchant_name", "") == merchant_name,
-                })
+                evidence_for.append(
+                    {
+                        "text": meta.get("text", ""),
+                        "similarity": round(sim, 3),
+                        "merchant": meta.get("merchant_name", ""),
+                        "same_merchant": meta.get("merchant_name", "") == merchant_name,
+                    }
+                )
 
-        for metas, dists in [(negative_results.get("metadatas", [[]]), negative_results.get("distances", [[]]))]:
+        for metas, dists in [
+            (
+                negative_results.get("metadatas", [[]]),
+                negative_results.get("distances", [[]]),
+            )
+        ]:
             for meta, dist in zip(metas[0] if metas else [], dists[0] if dists else []):
                 sim = dist_to_sim(dist)
                 if sim < MIN_SIMILARITY:
@@ -2475,12 +2932,14 @@ async def validate_word_similarity_impl(
                 rid = f"IMAGE#{meta.get('image_id', '')}#RECEIPT#{meta.get('receipt_id', 0):05d}#LINE#{meta.get('line_id', 0):05d}#WORD#{meta.get('word_id', 0):05d}"
                 if rid == chroma_id:
                     continue
-                evidence_against.append({
-                    "text": meta.get("text", ""),
-                    "similarity": round(sim, 3),
-                    "merchant": meta.get("merchant_name", ""),
-                    "same_merchant": meta.get("merchant_name", "") == merchant_name,
-                })
+                evidence_against.append(
+                    {
+                        "text": meta.get("text", ""),
+                        "similarity": round(sim, 3),
+                        "merchant": meta.get("merchant_name", ""),
+                        "same_merchant": meta.get("merchant_name", "") == merchant_name,
+                    }
+                )
 
         total_matches = len(evidence_for) + len(evidence_against)
 
@@ -2537,7 +2996,9 @@ async def validate_word_similarity_impl(
             reason = f"{1.0 - confidence:.0%} of similar words rejected {label}"
         else:
             recommended_status = "NEEDS_REVIEW"
-            reason = f"Mixed evidence: {confidence:.0%} for, {1.0 - confidence:.0%} against"
+            reason = (
+                f"Mixed evidence: {confidence:.0%} for, {1.0 - confidence:.0%} against"
+            )
 
         # Find suggested labels if invalid or uncertain
         suggested_labels = []
@@ -2558,19 +3019,34 @@ async def validate_word_similarity_impl(
                         },
                         include=["distances"],
                     )
-                    cand_dists = cand_results.get("distances", [[]])[0] if cand_results.get("distances") else []
-                    cand_sims = [dist_to_sim(d) for d in cand_dists if dist_to_sim(d) >= MIN_SIMILARITY]
+                    cand_dists = (
+                        cand_results.get("distances", [[]])[0]
+                        if cand_results.get("distances")
+                        else []
+                    )
+                    cand_sims = [
+                        dist_to_sim(d)
+                        for d in cand_dists
+                        if dist_to_sim(d) >= MIN_SIMILARITY
+                    ]
                     if cand_sims:
                         avg_sim = sum(cand_sims) / len(cand_sims)
                         score = len(cand_sims) * avg_sim
-                        suggested_labels.append({
-                            "label": candidate_label,
-                            "match_count": len(cand_sims),
-                            "avg_similarity": round(avg_sim, 3),
-                            "score": round(score, 3),
-                        })
+                        suggested_labels.append(
+                            {
+                                "label": candidate_label,
+                                "match_count": len(cand_sims),
+                                "avg_similarity": round(avg_sim, 3),
+                                "score": round(score, 3),
+                            }
+                        )
                 except Exception as e:
-                    logger.warning("Error querying label %s (%s): %s", candidate_label, cand_field, e)
+                    logger.warning(
+                        "Error querying label %s (%s): %s",
+                        candidate_label,
+                        cand_field,
+                        e,
+                    )
                     continue
 
             suggested_labels.sort(key=lambda x: x["score"], reverse=True)
@@ -2679,7 +3155,8 @@ async def get_receipt_words_impl(
             labels_by_word[(label.line_id, label.word_id)].append(
                 {
                     "label": label.label,
-                    "validation_status": getattr(label, "validation_status", None) or "NONE",
+                    "validation_status": getattr(label, "validation_status", None)
+                    or "NONE",
                     "label_proposed_by": getattr(label, "label_proposed_by", None),
                 }
             )
@@ -2842,22 +3319,26 @@ async def list_recent_uploads_impl(dynamo_client, limit: int = 10) -> dict:
             receipts_info = []
             for rid in receipt_ids:
                 key = f"{img.image_id}_{rid}"
-                receipts_info.append({
-                    "receipt_id": rid,
-                    "merchant_name": places_by_key.get(key),
-                })
+                receipts_info.append(
+                    {
+                        "receipt_id": rid,
+                        "merchant_name": places_by_key.get(key),
+                    }
+                )
 
-            results.append({
-                "image_id": img.image_id,
-                "timestamp_added": _to_utc_dt(img.timestamp_added).isoformat(
-                    timespec="milliseconds"
-                ),
-                "image_type": img.image_type,
-                "receipt_count": len(receipts_info),
-                "width": img.width,
-                "height": img.height,
-                "receipts": receipts_info,
-            })
+            results.append(
+                {
+                    "image_id": img.image_id,
+                    "timestamp_added": _to_utc_dt(img.timestamp_added).isoformat(
+                        timespec="milliseconds"
+                    ),
+                    "image_type": img.image_type,
+                    "receipt_count": len(receipts_info),
+                    "width": img.width,
+                    "height": img.height,
+                    "receipts": receipts_info,
+                }
+            )
 
         return {
             "total_images": len(all_images),
@@ -2935,11 +3416,70 @@ async def merge_receipts_impl(
         return {"error": str(e)}
 
 
+async def plan_receipt_resegmentation_impl(arguments: dict) -> dict:
+    """Invoke the receipt re-segmentation Lambda in planning mode."""
+    try:
+        env = os.environ.get("PORTFOLIO_ENV", "dev")
+        return await _invoke_lambda(
+            f"resegment-receipt-{env}-resegment-receipt",
+            {"mode": "plan", **arguments},
+        )
+    except Exception as e:
+        logger.exception("Error planning receipt re-segmentation")
+        return {"error": str(e)}
+
+
+async def get_receipt_resegmentation_plan_impl(
+    plan_id: str, revision: int | None = None
+) -> dict:
+    """Retrieve a plan and refresh its signed visualization URLs."""
+    try:
+        env = os.environ.get("PORTFOLIO_ENV", "dev")
+        payload = {"mode": "get", "plan_id": plan_id}
+        if revision is not None:
+            payload["revision"] = revision
+        return await _invoke_lambda(
+            f"resegment-receipt-{env}-resegment-receipt", payload
+        )
+    except Exception as e:
+        logger.exception("Error retrieving receipt re-segmentation plan")
+        return {"error": str(e)}
+
+
+async def revise_receipt_resegmentation_plan_impl(arguments: dict) -> dict:
+    """Create a replacement receipt re-segmentation plan revision."""
+    try:
+        env = os.environ.get("PORTFOLIO_ENV", "dev")
+        return await _invoke_lambda(
+            f"resegment-receipt-{env}-resegment-receipt",
+            {"mode": "revise", **arguments},
+        )
+    except Exception as e:
+        logger.exception("Error revising receipt re-segmentation plan")
+        return {"error": str(e)}
+
+
+async def apply_receipt_resegmentation_impl(plan_id: str, plan_hash: str) -> dict:
+    """Invoke the receipt re-segmentation Lambda in apply mode."""
+    try:
+        env = os.environ.get("PORTFOLIO_ENV", "dev")
+        return await _invoke_lambda(
+            f"resegment-receipt-{env}-resegment-receipt",
+            {"mode": "apply", "plan_id": plan_id, "plan_hash": plan_hash},
+        )
+    except Exception as e:
+        logger.exception("Error applying receipt re-segmentation")
+        return {"error": str(e)}
+
+
 def _receipt_point_to_image(
-    rx: float, ry: float,
+    rx: float,
+    ry: float,
     coeffs: list[float],
-    receipt_width: int, receipt_height: int,
-    image_width: int, image_height: int,
+    receipt_width: int,
+    receipt_height: int,
+    image_width: int,
+    image_height: int,
 ) -> tuple[float, float]:
     """Projective forward transform: receipt-relative → full-image Vision.
 
@@ -2987,9 +3527,7 @@ async def compute_reocr_region_impl(
 
         # Filter words to only those on the requested lines
         target_line_ids = set(line_ids)
-        words_in_region = [
-            w for w in details.words if w.line_id in target_line_ids
-        ]
+        words_in_region = [w for w in details.words if w.line_id in target_line_ids]
 
         if not words_in_region:
             return {
@@ -3001,12 +3539,10 @@ async def compute_reocr_region_impl(
         min_x = min(w.bounding_box["x"] for w in words_in_region)
         min_y = min(w.bounding_box["y"] for w in words_in_region)
         max_x = max(
-            w.bounding_box["x"] + w.bounding_box["width"]
-            for w in words_in_region
+            w.bounding_box["x"] + w.bounding_box["width"] for w in words_in_region
         )
         max_y = max(
-            w.bounding_box["y"] + w.bounding_box["height"]
-            for w in words_in_region
+            w.bounding_box["y"] + w.bounding_box["height"] for w in words_in_region
         )
 
         # Always use full width — Vision OCR produces better results with
@@ -3020,20 +3556,30 @@ async def compute_reocr_region_impl(
         # receipt-relative space to full-image Vision coordinates using
         # the same projective (homography) transform that the FIRST_PASS
         # warp used.
-        from receipt_upload.geometry.transformations import find_perspective_coeffs
+        from receipt_upload.geometry.transformations import (
+            find_perspective_coeffs,
+        )
 
         receipt = details.receipt
         image = dynamo_client.get_image(image_id)
 
         src_points = [
-            (receipt.top_left["x"] * image.width,
-             (1.0 - receipt.top_left["y"]) * image.height),
-            (receipt.top_right["x"] * image.width,
-             (1.0 - receipt.top_right["y"]) * image.height),
-            (receipt.bottom_right["x"] * image.width,
-             (1.0 - receipt.bottom_right["y"]) * image.height),
-            (receipt.bottom_left["x"] * image.width,
-             (1.0 - receipt.bottom_left["y"]) * image.height),
+            (
+                receipt.top_left["x"] * image.width,
+                (1.0 - receipt.top_left["y"]) * image.height,
+            ),
+            (
+                receipt.top_right["x"] * image.width,
+                (1.0 - receipt.top_right["y"]) * image.height,
+            ),
+            (
+                receipt.bottom_right["x"] * image.width,
+                (1.0 - receipt.bottom_right["y"]) * image.height,
+            ),
+            (
+                receipt.bottom_left["x"] * image.width,
+                (1.0 - receipt.bottom_left["y"]) * image.height,
+            ),
         ]
         dst_points = [
             (0.0, 0.0),
@@ -3045,14 +3591,42 @@ async def compute_reocr_region_impl(
 
         _pt = _receipt_point_to_image
         img_corners = [
-            _pt(padded_x, padded_y, coeffs,
-                receipt.width, receipt.height, image.width, image.height),
-            _pt(padded_right, padded_y, coeffs,
-                receipt.width, receipt.height, image.width, image.height),
-            _pt(padded_x, padded_top, coeffs,
-                receipt.width, receipt.height, image.width, image.height),
-            _pt(padded_right, padded_top, coeffs,
-                receipt.width, receipt.height, image.width, image.height),
+            _pt(
+                padded_x,
+                padded_y,
+                coeffs,
+                receipt.width,
+                receipt.height,
+                image.width,
+                image.height,
+            ),
+            _pt(
+                padded_right,
+                padded_y,
+                coeffs,
+                receipt.width,
+                receipt.height,
+                image.width,
+                image.height,
+            ),
+            _pt(
+                padded_x,
+                padded_top,
+                coeffs,
+                receipt.width,
+                receipt.height,
+                image.width,
+                image.height,
+            ),
+            _pt(
+                padded_right,
+                padded_top,
+                coeffs,
+                receipt.width,
+                receipt.height,
+                image.width,
+                image.height,
+            ),
         ]
 
         img_min_x = max(0.0, min(c[0] for c in img_corners))
@@ -3075,12 +3649,8 @@ async def compute_reocr_region_impl(
         }
 
         # Include context: which lines were found, word count
-        found_line_ids = sorted(
-            target_line_ids & {w.line_id for w in details.words}
-        )
-        missing_line_ids = sorted(
-            target_line_ids - {w.line_id for w in details.words}
-        )
+        found_line_ids = sorted(target_line_ids & {w.line_id for w in details.words})
+        missing_line_ids = sorted(target_line_ids - {w.line_id for w in details.words})
 
         return {
             "image_id": image_id,
@@ -3162,9 +3732,7 @@ async def get_receipt_image_url_impl(
         return {"error": str(e)}
 
 
-async def delete_image_impl(
-    dynamo_client, image_id: str, dry_run: bool = True
-) -> dict:
+async def delete_image_impl(dynamo_client, image_id: str, dry_run: bool = True) -> dict:
     """Delete all DynamoDB records under an image partition key."""
     try:
         details = dynamo_client.get_image_details(image_id)
@@ -3245,16 +3813,10 @@ async def delete_receipt_impl(
         try:
             details = dynamo_client.get_receipt_details(image_id, receipt_id)
         except EntityNotFoundError:
-            return {
-                "error": (
-                    f"Receipt {receipt_id} not found for image {image_id}"
-                )
-            }
+            return {"error": (f"Receipt {receipt_id} not found for image {image_id}")}
 
         place = getattr(details, "place", None)
-        merchant_name = (
-            getattr(place, "merchant_name", None) if place else None
-        )
+        merchant_name = getattr(place, "merchant_name", None) if place else None
 
         # Note: ReceiptLetters are excluded from the GSI4 query that backs
         # get_receipt_details, so they are not counted here. The compactor
@@ -3322,18 +3884,12 @@ async def get_receipt_sections_impl(
         try:
             details = dynamo_client.get_receipt_details(image_id, receipt_id)
         except EntityNotFoundError:
-            return {
-                "error": (
-                    f"Receipt {receipt_id} not found for image {image_id}"
-                )
-            }
+            return {"error": (f"Receipt {receipt_id} not found for image {image_id}")}
 
         # line_id -> text so a reviewer can QA sections without a second call
         line_text = {line.line_id: line.text for line in details.lines or []}
 
-        sections = dynamo_client.get_receipt_sections_from_receipt(
-            image_id, receipt_id
-        )
+        sections = dynamo_client.get_receipt_sections_from_receipt(image_id, receipt_id)
 
         section_dicts = []
         for section in sorted(
@@ -3537,9 +4093,7 @@ async def create_receipt_section_impl(
                 )
             }
         receipt_line_ids = {line.line_id for line in details.lines or []}
-        unknown_line_ids = sorted(
-            set(normalized_line_ids) - receipt_line_ids
-        )
+        unknown_line_ids = sorted(set(normalized_line_ids) - receipt_line_ids)
         if unknown_line_ids:
             return {
                 "error": (
@@ -3635,7 +4189,6 @@ ANALYTICS_WORKGROUP = "portfolio_analytics"
 ANALYTICS_REGION = "us-east-1"
 
 
-
 def _analytics_check_date(d: str) -> str:
     # Athena's ExecutionParameters bind predicate placeholders as integer
     # (varchar/date params fail), so the structured tools validate inputs
@@ -3662,9 +4215,9 @@ def _athena_run(sql: str, max_wait: int = 90, max_rows: int = 5000) -> list:
     )["QueryExecutionId"]
     waited = 0.0
     while True:
-        status = ath.get_query_execution(QueryExecutionId=qid)[
-            "QueryExecution"
-        ]["Status"]
+        status = ath.get_query_execution(QueryExecutionId=qid)["QueryExecution"][
+            "Status"
+        ]
         state = status["State"]
         if state in ("SUCCEEDED", "FAILED", "CANCELLED"):
             break
@@ -4059,20 +4612,22 @@ async def list_training_jobs_impl(
             config = job.job_config or {}
             if isinstance(config, str):
                 config = json.loads(config)
-            results.append({
-                "name": job.name,
-                "status": job.status,
-                "created_at": str(job.created_at) if job.created_at else None,
-                "best_f1": r.get("best_f1"),
-                "best_epoch": r.get("best_epoch"),
-                "num_train_samples": r.get("num_train_samples"),
-                "num_val_samples": r.get("num_val_samples"),
-                "learning_rate": config.get("learning_rate"),
-                "epochs": config.get("epochs"),
-                "batch_size": config.get("batch_size"),
-                "merge_amounts": config.get("merge_amounts"),
-                "early_stopping_patience": config.get("early_stopping_patience"),
-            })
+            results.append(
+                {
+                    "name": job.name,
+                    "status": job.status,
+                    "created_at": str(job.created_at) if job.created_at else None,
+                    "best_f1": r.get("best_f1"),
+                    "best_epoch": r.get("best_epoch"),
+                    "num_train_samples": r.get("num_train_samples"),
+                    "num_val_samples": r.get("num_val_samples"),
+                    "learning_rate": config.get("learning_rate"),
+                    "epochs": config.get("epochs"),
+                    "batch_size": config.get("batch_size"),
+                    "merge_amounts": config.get("merge_amounts"),
+                    "early_stopping_patience": config.get("early_stopping_patience"),
+                }
+            )
 
         return {
             "total": len(results),
@@ -4100,9 +4655,9 @@ async def get_training_metrics_impl(
         # Group by epoch, filter to eval and training metrics
         by_epoch: dict[int, dict[str, Any]] = {}
         for m in metrics:
-            if (
-                m.metric_name.startswith("eval_")
-                or m.metric_name in ("loss", "learning_rate")
+            if m.metric_name.startswith("eval_") or m.metric_name in (
+                "loss",
+                "learning_rate",
             ):
                 epoch = m.epoch if m.epoch is not None else 0
                 if epoch not in by_epoch:
@@ -4161,9 +4716,7 @@ async def set_active_model_impl(
         old_active = dynamo_client.get_active_model_job()
         if old_active:
             old_active.tags = {
-                k: v
-                for k, v in (old_active.tags or {}).items()
-                if k != "active_model"
+                k: v for k, v in (old_active.tags or {}).items() if k != "active_model"
             }
             dynamo_client.update_job(old_active)
 

--- a/infra/mcp_server_lambda/lambdas/receipt_mcp_server_server.py
+++ b/infra/mcp_server_lambda/lambdas/receipt_mcp_server_server.py
@@ -3422,7 +3422,7 @@ async def plan_receipt_resegmentation_impl(arguments: dict) -> dict:
         env = os.environ.get("PORTFOLIO_ENV", "dev")
         return await _invoke_lambda(
             f"resegment-receipt-{env}-resegment-receipt",
-            {"mode": "plan", **arguments},
+            {**arguments, "mode": "plan"},
         )
     except Exception as e:
         logger.exception("Error planning receipt re-segmentation")
@@ -3452,7 +3452,7 @@ async def revise_receipt_resegmentation_plan_impl(arguments: dict) -> dict:
         env = os.environ.get("PORTFOLIO_ENV", "dev")
         return await _invoke_lambda(
             f"resegment-receipt-{env}-resegment-receipt",
-            {"mode": "revise", **arguments},
+            {**arguments, "mode": "revise"},
         )
     except Exception as e:
         logger.exception("Error revising receipt re-segmentation plan")

--- a/infra/resegment_receipt_lambda/__init__.py
+++ b/infra/resegment_receipt_lambda/__init__.py
@@ -1,0 +1,20 @@
+"""Receipt re-segmentation Lambda infrastructure."""
+
+from typing import Any
+
+__all__ = ["ResegmentReceiptLambda", "create_resegment_receipt_lambda"]
+
+
+def __getattr__(name: str) -> Any:
+    """Load Pulumi-only objects lazily so handler tests stay lightweight."""
+    if name not in __all__:
+        raise AttributeError(name)
+    from .infrastructure import (
+        ResegmentReceiptLambda,
+        create_resegment_receipt_lambda,
+    )
+
+    return {
+        "ResegmentReceiptLambda": ResegmentReceiptLambda,
+        "create_resegment_receipt_lambda": create_resegment_receipt_lambda,
+    }[name]

--- a/infra/resegment_receipt_lambda/infrastructure.py
+++ b/infra/resegment_receipt_lambda/infrastructure.py
@@ -1,0 +1,212 @@
+"""Pulumi infrastructure for the receipt re-segmentation Lambda."""
+
+import json
+from typing import Optional
+
+import pulumi
+from pulumi import ComponentResource, Config, Output, ResourceOptions
+from pulumi_aws.iam import Role, RolePolicy, RolePolicyAttachment
+
+from codebuild_docker_image import CodeBuildDockerImage
+
+config = Config("portfolio")
+openai_api_key = config.require_secret("OPENAI_API_KEY")
+
+
+class ResegmentReceiptLambda(ComponentResource):
+    """Container Lambda for planning and applying receipt splits."""
+
+    def __init__(
+        self,
+        name: str,
+        *,
+        dynamodb_table_name: pulumi.Input[str],
+        dynamodb_table_arn: pulumi.Input[str],
+        raw_bucket_name: pulumi.Input[str],
+        site_bucket_name: pulumi.Input[str],
+        image_bucket_name: pulumi.Input[str],
+        chromadb_bucket_name: pulumi.Input[str],
+        chromadb_bucket_arn: pulumi.Input[str],
+        opts: Optional[ResourceOptions] = None,
+    ):
+        super().__init__(f"{__name__}-{name}", name, None, opts)
+        stack = pulumi.get_stack()
+
+        role = Role(
+            f"{name}-lambda-role",
+            assume_role_policy=json.dumps(
+                {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Principal": {"Service": "lambda.amazonaws.com"},
+                            "Action": "sts:AssumeRole",
+                        }
+                    ],
+                }
+            ),
+            opts=ResourceOptions(parent=self),
+        )
+        RolePolicyAttachment(
+            f"{name}-lambda-basic-exec",
+            role=role.name,
+            policy_arn=(
+                "arn:aws:iam::aws:policy/service-role/" "AWSLambdaBasicExecutionRole"
+            ),
+            opts=ResourceOptions(parent=role),
+        )
+        RolePolicy(
+            f"{name}-lambda-ecr-policy",
+            role=role.id,
+            policy=json.dumps(
+                {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Action": [
+                                "ecr:GetAuthorizationToken",
+                                "ecr:BatchGetImage",
+                                "ecr:GetDownloadUrlForLayer",
+                            ],
+                            "Resource": "*",
+                        }
+                    ],
+                }
+            ),
+            opts=ResourceOptions(parent=role),
+        )
+
+        dynamodb_policy = RolePolicy(
+            f"{name}-lambda-dynamo-policy",
+            role=role.id,
+            policy=Output.from_input(dynamodb_table_arn).apply(
+                lambda arn: json.dumps(
+                    {
+                        "Version": "2012-10-17",
+                        "Statement": [
+                            {
+                                "Effect": "Allow",
+                                "Action": [
+                                    "dynamodb:DescribeTable",
+                                    "dynamodb:GetItem",
+                                    "dynamodb:PutItem",
+                                    "dynamodb:UpdateItem",
+                                    "dynamodb:DeleteItem",
+                                    "dynamodb:Query",
+                                    "dynamodb:BatchGetItem",
+                                    "dynamodb:BatchWriteItem",
+                                    "dynamodb:TransactWriteItems",
+                                ],
+                                "Resource": [arn, f"{arn}/index/*"],
+                            }
+                        ],
+                    }
+                )
+            ),
+            opts=ResourceOptions(parent=role),
+        )
+
+        s3_policy = RolePolicy(
+            f"{name}-lambda-s3-policy",
+            role=role.id,
+            policy=Output.all(
+                raw_bucket_name,
+                site_bucket_name,
+                image_bucket_name,
+                chromadb_bucket_arn,
+            ).apply(
+                lambda args: json.dumps(
+                    {
+                        "Version": "2012-10-17",
+                        "Statement": [
+                            {
+                                "Effect": "Allow",
+                                "Action": [
+                                    "s3:GetObject",
+                                    "s3:PutObject",
+                                    "s3:DeleteObject",
+                                    "s3:ListBucket",
+                                ],
+                                "Resource": [
+                                    f"arn:aws:s3:::{args[0]}",
+                                    f"arn:aws:s3:::{args[0]}/*",
+                                    f"arn:aws:s3:::{args[1]}",
+                                    f"arn:aws:s3:::{args[1]}/*",
+                                    f"arn:aws:s3:::{args[2]}",
+                                    f"arn:aws:s3:::{args[2]}/*",
+                                    args[3],
+                                    f"{args[3]}/*",
+                                ],
+                            }
+                        ],
+                    }
+                )
+            ),
+            opts=ResourceOptions(parent=role),
+        )
+
+        docker_image = CodeBuildDockerImage(
+            f"{name}-img",
+            dockerfile_path=("infra/resegment_receipt_lambda/lambdas/Dockerfile"),
+            build_context_path=".",
+            source_paths=[
+                "receipt_dynamo",
+                "receipt_dynamo_stream",
+                "receipt_chroma",
+                "receipt_upload",
+                "receipt_places",
+            ],
+            lambda_function_name=f"{name}-{stack}-resegment-receipt",
+            lambda_config={
+                "role_arn": role.arn,
+                "timeout": 900,
+                "memory_size": 3072,
+                "ephemeral_storage": 10240,
+                "tags": {"environment": stack},
+                "environment": {
+                    "DYNAMODB_TABLE_NAME": dynamodb_table_name,
+                    "RAW_BUCKET": raw_bucket_name,
+                    "SITE_BUCKET": site_bucket_name,
+                    "CHROMADB_BUCKET": chromadb_bucket_name,
+                    "OPENAI_API_KEY": openai_api_key,
+                },
+            },
+            platform="linux/arm64",
+            opts=ResourceOptions(
+                parent=self,
+                depends_on=[role, dynamodb_policy, s3_policy],
+            ),
+        )
+
+        self.lambda_function = docker_image.lambda_function
+        self.lambda_arn = self.lambda_function.arn
+        self.register_outputs(
+            {
+                "lambda_arn": self.lambda_arn,
+                "lambda_name": self.lambda_function.name,
+            }
+        )
+
+
+def create_resegment_receipt_lambda(
+    dynamodb_table_name: pulumi.Input[str],
+    dynamodb_table_arn: pulumi.Input[str],
+    raw_bucket_name: pulumi.Input[str],
+    site_bucket_name: pulumi.Input[str],
+    image_bucket_name: pulumi.Input[str],
+    chromadb_bucket_name: pulumi.Input[str],
+    chromadb_bucket_arn: pulumi.Input[str],
+) -> ResegmentReceiptLambda:
+    """Create the receipt re-segmentation component."""
+    return ResegmentReceiptLambda(
+        "resegment-receipt",
+        dynamodb_table_name=dynamodb_table_name,
+        dynamodb_table_arn=dynamodb_table_arn,
+        raw_bucket_name=raw_bucket_name,
+        site_bucket_name=site_bucket_name,
+        image_bucket_name=image_bucket_name,
+        chromadb_bucket_name=chromadb_bucket_name,
+        chromadb_bucket_arn=chromadb_bucket_arn,
+    )

--- a/infra/resegment_receipt_lambda/lambdas/Dockerfile
+++ b/infra/resegment_receipt_lambda/lambdas/Dockerfile
@@ -1,0 +1,24 @@
+FROM public.ecr.aws/lambda/python:3.12 AS dependencies
+
+ENV HNSWLIB_NO_NATIVE=1
+
+COPY receipt_dynamo/ /tmp/receipt_dynamo/
+COPY receipt_dynamo_stream/ /tmp/receipt_dynamo_stream/
+COPY receipt_chroma/ /tmp/receipt_chroma/
+COPY receipt_upload/ /tmp/receipt_upload/
+COPY receipt_places/ /tmp/receipt_places/
+
+RUN pip install --no-cache-dir /tmp/receipt_dynamo && \
+    pip install --no-cache-dir /tmp/receipt_dynamo_stream && \
+    pip install --no-cache-dir /tmp/receipt_chroma && \
+    pip install --no-cache-dir /tmp/receipt_places && \
+    pip install --no-cache-dir /tmp/receipt_upload && \
+    rm -rf /tmp/receipt_dynamo /tmp/receipt_dynamo_stream \
+        /tmp/receipt_chroma /tmp/receipt_upload /tmp/receipt_places
+
+FROM dependencies
+
+COPY infra/resegment_receipt_lambda/lambdas/resegment_receipt.py \
+    ${LAMBDA_TASK_ROOT}/handler.py
+
+CMD ["handler.handler"]

--- a/infra/resegment_receipt_lambda/lambdas/__init__.py
+++ b/infra/resegment_receipt_lambda/lambdas/__init__.py
@@ -1,0 +1,1 @@
+"""Receipt re-segmentation Lambda handlers."""

--- a/infra/resegment_receipt_lambda/lambdas/resegment_receipt.py
+++ b/infra/resegment_receipt_lambda/lambdas/resegment_receipt.py
@@ -973,7 +973,7 @@ def _embed_outputs(
     chromadb_bucket: str,
     wait_for_embeddings: bool,
 ) -> list[str]:
-    from receipt_chroma.embedding.orchestration import (
+    from receipt_chroma.embedding import (
         EmbeddingConfig,
         create_embeddings_and_compaction_run,
     )

--- a/infra/resegment_receipt_lambda/lambdas/resegment_receipt.py
+++ b/infra/resegment_receipt_lambda/lambdas/resegment_receipt.py
@@ -9,6 +9,7 @@ import json
 import logging
 import math
 import os
+import re
 import uuid
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any, Mapping
@@ -34,16 +35,34 @@ SUPPORTED_SOURCE_TYPES = {
 }
 
 
+_PLAN_ID_PATTERN = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,63}")
+
+
+def _validate_plan_id(plan_id: str) -> str:
+    """Reject plan IDs that could escape the plan S3 key namespace."""
+    if not _PLAN_ID_PATTERN.fullmatch(plan_id):
+        raise ValueError(
+            "plan_id must be 1-64 URL-safe characters and start with a "
+            "letter or number"
+        )
+    return plan_id
+
+
 def _plan_key(plan_id: str) -> str:
-    return f"{PLAN_PREFIX}/{plan_id}.json"
+    return f"{PLAN_PREFIX}/{_validate_plan_id(plan_id)}.json"
 
 
 def _revision_key(plan_id: str, revision: int) -> str:
-    return f"{PLAN_PREFIX}/{plan_id}/revisions/{revision:04d}.json"
+    return (
+        f"{PLAN_PREFIX}/{_validate_plan_id(plan_id)}/revisions/" f"{revision:04d}.json"
+    )
 
 
 def _artifact_prefix(plan_id: str, revision: int) -> str:
-    return f"{PLAN_PREFIX}/{plan_id}/revisions/{revision:04d}/preview"
+    return (
+        f"{PLAN_PREFIX}/{_validate_plan_id(plan_id)}/revisions/"
+        f"{revision:04d}/preview"
+    )
 
 
 def _png_bytes(image: PILImage.Image) -> bytes:
@@ -900,7 +919,10 @@ def apply_plan(
     chromadb_bucket: str,
 ) -> dict[str, Any]:
     """Apply a persisted plan with staging, guarded commit, and cleanup."""
-    from receipt_dynamo.data.shared_exceptions import EntityNotFoundError
+    from receipt_dynamo.data.shared_exceptions import (
+        EntityNotFoundError,
+        OperationError,
+    )
     from receipt_upload.combine import combine_receipt_words_to_image_coords
     from receipt_upload.resegment import (
         build_source_fingerprint,
@@ -948,6 +970,11 @@ def apply_plan(
                 dynamo_client.get_receipt(plan["image_id"], output_id)
                 visible_output_ids.add(output_id)
             except EntityNotFoundError:
+                pass
+            except OperationError:
+                # A row that exists but cannot parse as a Receipt is a
+                # leftover RESEGMENT_RESERVATION, so the output is not
+                # visible yet.
                 pass
         if not source_exists and visible_output_ids == set(output_ids):
             result = _finish_cleanup(
@@ -1076,6 +1103,17 @@ def apply_plan(
         return {"status": "APPLIED", **result}
     except Exception:
         if not committed:
+            if plan["status"] == "COMMITTING":
+                # The COMMITTING marker was persisted before the commit
+                # transaction; revert it so a retry re-runs the full
+                # plan validation instead of the resume path.
+                plan["status"] = "PLANNED"
+                try:
+                    _save_plan(s3_client, raw_bucket, plan)
+                except Exception:  # pylint: disable=broad-except
+                    logger.exception(
+                        "Failed to revert plan %s to PLANNED", plan["plan_id"]
+                    )
             try:
                 dynamo_client.release_receipt_id_reservations(
                     plan["image_id"], output_ids, plan["plan_id"]

--- a/infra/resegment_receipt_lambda/lambdas/resegment_receipt.py
+++ b/infra/resegment_receipt_lambda/lambdas/resegment_receipt.py
@@ -407,6 +407,14 @@ def create_plan(
         and not visualization.get("confirm_stacked_scan", False)
     ):
         raise ValueError("SCAN layered segmentation requires confirm_stacked_scan=true")
+    if effective_strategy == "RECTANGULAR" and any(
+        segment.get("visible_regions") for segment in plan_segments
+    ):
+        raise ValueError(
+            "visible_regions require the LAYERED_MULTI_REGION strategy; a "
+            "RECTANGULAR apply writes the min-area crop and would ignore "
+            "them, so the preview would not match the applied output"
+        )
 
     plan = {
         "version": schema_version,
@@ -909,6 +917,35 @@ def _finish_cleanup(
     }
 
 
+def _commit_landed(
+    dynamo_client: Any, plan: dict[str, Any], output_ids: list[int]
+) -> bool:
+    """Return True when the commit transaction actually took effect.
+
+    The commit atomically deletes the source parent and activates every
+    output, so it landed exactly when the source is gone and each output
+    parses as a real Receipt (a reservation row raises OperationError).
+    """
+    from receipt_dynamo.data.shared_exceptions import (
+        EntityNotFoundError,
+        OperationError,
+    )
+
+    try:
+        dynamo_client.get_receipt(plan["image_id"], int(plan["source_receipt_id"]))
+        return False
+    except EntityNotFoundError:
+        pass
+    except OperationError:
+        return False
+    for output_id in output_ids:
+        try:
+            dynamo_client.get_receipt(plan["image_id"], output_id)
+        except (EntityNotFoundError, OperationError):
+            return False
+    return True
+
+
 def apply_plan(
     event: dict[str, Any],
     *,
@@ -1074,11 +1111,24 @@ def apply_plan(
 
         plan["status"] = "COMMITTING"
         _save_plan(s3_client, raw_bucket, plan)
-        dynamo_client.commit_receipt_resegmentation(
-            details.receipt,
-            [output["receipt"] for output in outputs],
-            plan["plan_id"],
-        )
+        try:
+            dynamo_client.commit_receipt_resegmentation(
+                details.receipt,
+                [output["receipt"] for output in outputs],
+                plan["plan_id"],
+            )
+        except Exception:
+            # A commit exception is not proof the transaction failed: the
+            # response can be lost after DynamoDB committed, and a
+            # concurrent apply of the same plan may have won the race.
+            # Rolling back in either case would destroy committed data.
+            if not _commit_landed(dynamo_client, plan, output_ids):
+                raise
+            logger.warning(
+                "Commit for plan %s raised but the transaction landed; "
+                "continuing to cleanup",
+                plan["plan_id"],
+            )
         committed = True
         try:
             result = _finish_cleanup(

--- a/infra/resegment_receipt_lambda/lambdas/resegment_receipt.py
+++ b/infra/resegment_receipt_lambda/lambdas/resegment_receipt.py
@@ -1,4 +1,29 @@
-"""Plan and apply safe, word-level receipt re-segmentation."""
+"""Plan and apply safe, line-first receipt re-segmentation.
+
+Concurrency and durability model
+---------------------------------
+The persisted plan document in S3 is the single source of truth for a
+re-segmentation's lifecycle. Every mutation of the head plan object is a
+conditional write (``If-Match`` on the last-read ETag, or ``If-None-Match:*``
+for creates); a lost precondition surfaces a "plan changed underneath you"
+error instead of silently clobbering a concurrent writer.
+
+``apply_plan`` treats the ``PLANNED`` -> ``COMMITTING`` transition as an
+execution lock: it is a compare-and-swap on the plan ETag performed *before*
+any DynamoDB row is reserved, deleted, or committed. A second concurrent apply
+of the same plan loses that swap and bails out before it can touch data, which
+(together with the guarded ``release_receipt_id_reservations`` and the
+``_commit_landed`` recovery) closes the concurrent-apply data-loss window.
+
+Residual race (documented, not eliminated): the child rows that become the
+output receipts are snapshotted into ``outputs`` early in apply. The source
+fingerprint is re-verified immediately before the commit transaction to shrink
+the window, but an external writer that edits a source word or label *after*
+that final check and *before* the commit lands would have its edit dropped
+from the committed outputs. Eliminating this fully requires the commit
+transaction to guard each source child row's snapshot, which the current
+single-parent commit condition does not do.
+"""
 
 from __future__ import annotations
 
@@ -15,6 +40,7 @@ from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any, Mapping
 
 import boto3
+from botocore.exceptions import ClientError
 from PIL import Image as PILImage
 
 if TYPE_CHECKING:
@@ -22,6 +48,19 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
+
+
+class PlanPreconditionError(RuntimeError):
+    """A conditional plan write lost to a concurrent writer.
+
+    Raised when an ``If-Match`` / ``If-None-Match`` precondition fails, i.e.
+    the stored plan object changed (or already exists) since it was read.
+    """
+
+
+# S3 returns PreconditionFailed for a failed If-Match/If-None-Match; some
+# stacks report the 409 ConditionalRequestConflict for racing writers.
+_PRECONDITION_CODES = {"PreconditionFailed", "ConditionalRequestConflict"}
 
 PLAN_PREFIX = "resegment-plans"
 SUPPORTED_SOURCE_TYPES = {
@@ -104,27 +143,100 @@ def _artifact_record(
     }
 
 
-def _save_plan(s3_client: "S3Client", bucket: str, plan: dict) -> None:
-    s3_client.put_object(
-        Bucket=bucket,
-        Key=_plan_key(plan["plan_id"]),
-        Body=json.dumps(plan, sort_keys=True, default=str).encode("utf-8"),
-        ContentType="application/json",
+def _put_plan_json(
+    s3_client: "S3Client",
+    bucket: str,
+    key: str,
+    payload: Mapping[str, Any],
+    *,
+    if_match: str | None = None,
+    if_none_match: bool = False,
+) -> str:
+    """Write a plan document, optionally guarded by an S3 precondition.
+
+    Returns the new object ETag (unquoted). Raises ``PlanPreconditionError``
+    when a supplied precondition fails so callers can report a clear
+    "plan changed underneath you" error instead of overwriting a racing
+    writer.
+    """
+    kwargs: dict[str, Any] = {
+        "Bucket": bucket,
+        "Key": key,
+        "Body": json.dumps(payload, sort_keys=True, default=str).encode(
+            "utf-8"
+        ),
+        "ContentType": "application/json",
+    }
+    if if_match is not None:
+        kwargs["IfMatch"] = if_match
+    if if_none_match:
+        kwargs["IfNoneMatch"] = "*"
+    try:
+        response = s3_client.put_object(**kwargs)
+    except ClientError as error:
+        code = error.response.get("Error", {}).get("Code", "")
+        status = error.response.get("ResponseMetadata", {}).get(
+            "HTTPStatusCode"
+        )
+        if code in _PRECONDITION_CODES or status in (409, 412):
+            raise PlanPreconditionError(
+                "The plan changed underneath this write; retrieve the latest "
+                "plan and try again"
+            ) from error
+        raise
+    return str(response.get("ETag", "")).strip('"')
+
+
+def _save_plan(
+    s3_client: "S3Client",
+    bucket: str,
+    plan: dict,
+    *,
+    if_match: str | None = None,
+    if_none_match: bool = False,
+) -> str:
+    return _put_plan_json(
+        s3_client,
+        bucket,
+        _plan_key(plan["plan_id"]),
+        plan,
+        if_match=if_match,
+        if_none_match=if_none_match,
     )
 
 
-def _save_revision(s3_client: "S3Client", bucket: str, plan: dict) -> None:
-    s3_client.put_object(
-        Bucket=bucket,
-        Key=_revision_key(plan["plan_id"], int(plan.get("revision", 1))),
-        Body=json.dumps(plan, sort_keys=True, default=str).encode("utf-8"),
-        ContentType="application/json",
+def _save_revision(
+    s3_client: "S3Client",
+    bucket: str,
+    plan: dict,
+    *,
+    if_none_match: bool = False,
+) -> str:
+    # Revision keys are immutable and unique per revision number, so a
+    # revision write is always a create guarded by If-None-Match:* to stop
+    # two concurrent revisions from clobbering the same revision object.
+    return _put_plan_json(
+        s3_client,
+        bucket,
+        _revision_key(plan["plan_id"], int(plan.get("revision", 1))),
+        plan,
+        if_none_match=if_none_match,
     )
 
 
-def _load_plan(s3_client: "S3Client", bucket: str, plan_id: str) -> dict[str, Any]:
+def _load_plan(
+    s3_client: "S3Client", bucket: str, plan_id: str
+) -> dict[str, Any]:
+    plan, _ = _load_plan_with_etag(s3_client, bucket, plan_id)
+    return plan
+
+
+def _load_plan_with_etag(
+    s3_client: "S3Client", bucket: str, plan_id: str
+) -> tuple[dict[str, Any], str]:
     response = s3_client.get_object(Bucket=bucket, Key=_plan_key(plan_id))
-    return json.loads(response["Body"].read())
+    etag = str(response.get("ETag", "")).strip('"')
+    return json.loads(response["Body"].read()), etag
 
 
 def _load_revision(
@@ -245,8 +357,15 @@ def create_plan(
     revision: int = 1,
     supersedes_plan_hash: str | None = None,
     expected_source_fingerprint: str | None = None,
+    head_if_match: str | None = None,
 ) -> dict[str, Any]:
-    """Create and optionally persist a visual, immutable split plan."""
+    """Create and optionally persist a visual, immutable split plan.
+
+    ``head_if_match`` guards the head-plan write: pass the ETag read from the
+    existing head when superseding it with a new revision (revise), or leave
+    it ``None`` for a brand-new plan (the head is then written with
+    ``If-None-Match:*`` so it cannot clobber an existing plan_id).
+    """
     from receipt_upload.combine import (
         combine_receipt_words_to_image_coords,
         create_warped_receipt_image,
@@ -333,8 +452,11 @@ def create_plan(
         image=image_entity if schema_version == 2 else None,
         lines=details.lines if schema_version == 2 else (),
         letters=letters,
-        source_object=source_object if schema_version == 2 else None,
-        source_type_counts=type_counts if schema_version == 2 else None,
+        # Bind the source image object identity for v1 plans too (M4): a v1
+        # fingerprint that omitted it could not detect a same-key overwrite
+        # of the underlying image between plan and apply.
+        source_object=source_object,
+        source_type_counts=type_counts,
     )
     if (
         expected_source_fingerprint is not None
@@ -542,8 +664,11 @@ def create_plan(
 
     plan["plan_hash"] = compute_plan_hash(plan)
     if persist_plan:
-        _save_revision(s3_client, raw_bucket, plan)
-        _save_plan(s3_client, raw_bucket, plan)
+        _save_revision(s3_client, raw_bucket, plan, if_none_match=True)
+        if head_if_match is None:
+            _save_plan(s3_client, raw_bucket, plan, if_none_match=True)
+        else:
+            _save_plan(s3_client, raw_bucket, plan, if_match=head_if_match)
         preview_urls = _preview_delivery(s3_client, raw_bucket, plan)
 
     return {
@@ -595,7 +720,7 @@ def revise_plan(
 ) -> dict[str, Any]:
     """Create an immutable replacement revision with optimistic concurrency."""
     plan_id = str(event["plan_id"])
-    head = _load_plan(s3_client, raw_bucket, plan_id)
+    head, head_etag = _load_plan_with_etag(s3_client, raw_bucket, plan_id)
     if head.get("status") != "PLANNED":
         raise ValueError("Only a PLANNED re-segmentation can be revised")
     if int(event["base_revision"]) != int(head.get("revision", 1)):
@@ -631,6 +756,7 @@ def revise_plan(
         revision=int(head.get("revision", 1)) + 1,
         supersedes_plan_hash=head["plan_hash"],
         expected_source_fingerprint=head["source_fingerprint"],
+        head_if_match=head_etag,
     )
 
 
@@ -946,6 +1072,47 @@ def _commit_landed(
     return True
 
 
+def _current_source_fingerprint(
+    *,
+    dynamo_client: Any,
+    plan: dict[str, Any],
+    image_entity: Any,
+    source_object: dict[str, Any] | None,
+    schema_version: int,
+) -> str:
+    """Recompute the source fingerprint from the live source rows.
+
+    Used both for the up-front plan/apply consistency check and for the
+    re-verification immediately before the commit transaction (M2).
+    """
+    from receipt_upload.resegment import build_source_fingerprint
+
+    image_id = plan["image_id"]
+    source_receipt_id = int(plan["source_receipt_id"])
+    details = dynamo_client.get_receipt_details(image_id, source_receipt_id)
+    type_counts = dynamo_client.get_receipt_item_type_counts(
+        image_id, source_receipt_id
+    )
+    letters = (
+        dynamo_client.list_receipt_letters_from_receipt(
+            image_id, source_receipt_id
+        )
+        if schema_version == 2
+        else []
+    )
+    return build_source_fingerprint(
+        receipt=details.receipt,
+        words=details.words,
+        labels=details.labels,
+        place=details.place,
+        image=image_entity if schema_version == 2 else None,
+        lines=details.lines if schema_version == 2 else (),
+        letters=letters,
+        source_object=source_object,
+        source_type_counts=type_counts,
+    )
+
+
 def apply_plan(
     event: dict[str, Any],
     *,
@@ -966,7 +1133,9 @@ def apply_plan(
         compute_plan_hash,
     )
 
-    plan = _load_plan(s3_client, raw_bucket, str(event["plan_id"]))
+    plan, plan_etag = _load_plan_with_etag(
+        s3_client, raw_bucket, str(event["plan_id"])
+    )
     if event.get("plan_hash") != plan["plan_hash"]:
         raise ValueError("plan_hash does not match the stored plan")
     if compute_plan_hash(plan) != plan["plan_hash"]:
@@ -990,6 +1159,19 @@ def apply_plan(
         raise ValueError(
             "LAYERED_MULTI_REGION plans cannot be applied until masked output "
             "rendering is enabled"
+        )
+    # Defense-in-depth (M3): a RECTANGULAR apply writes the min-area crop and
+    # ignores visible_regions, so a stored plan that pairs them would apply an
+    # artifact its preview never showed. create_plan already rejects this, but
+    # re-checking here keeps a hand-edited or legacy plan from diverging.
+    if plan.get("visualization", {}).get(
+        "effective_strategy"
+    ) != "LAYERED_MULTI_REGION" and any(
+        segment.get("visible_regions") for segment in plan["segments"]
+    ):
+        raise ValueError(
+            "visible_regions require the LAYERED_MULTI_REGION strategy; this "
+            "plan pairs them with a RECTANGULAR apply and cannot be applied"
         )
 
     image_entity = dynamo_client.get_image(plan["image_id"])
@@ -1021,14 +1203,26 @@ def apply_plan(
             )
             plan["status"] = "APPLIED"
             plan["result"] = result
-            _save_plan(s3_client, raw_bucket, plan)
+            _save_plan(s3_client, raw_bucket, plan, if_match=plan_etag)
             return {"status": "APPLIED", **result}
         if source_exists:
+            # Claim the recovery exclusively before touching DynamoDB: the
+            # conditional reset is a compare-and-swap, so a second worker that
+            # also loaded this COMMITTING plan loses here and bails before it
+            # could release the winning worker's freshly-reserved rows.
+            plan["status"] = "PLANNED"
+            try:
+                plan_etag = _save_plan(
+                    s3_client, raw_bucket, plan, if_match=plan_etag
+                )
+            except PlanPreconditionError as error:
+                raise ValueError(
+                    "Another apply of this plan is already recovering it; "
+                    "retrieve the latest plan and retry"
+                ) from error
             dynamo_client.release_receipt_id_reservations(
                 plan["image_id"], output_ids, plan["plan_id"]
             )
-            plan["status"] = "PLANNED"
-            _save_plan(s3_client, raw_bucket, plan)
 
     details = dynamo_client.get_receipt_details(
         plan["image_id"], int(plan["source_receipt_id"])
@@ -1057,8 +1251,9 @@ def apply_plan(
         image=image_entity if schema_version == 2 else None,
         lines=details.lines if schema_version == 2 else (),
         letters=current_letters,
-        source_object=current_source_object if schema_version == 2 else None,
-        source_type_counts=current_type_counts if schema_version == 2 else None,
+        # Bind the source image object identity for v1 plans too (M4).
+        source_object=current_source_object,
+        source_type_counts=current_type_counts,
     )
     if current_fingerprint != plan["source_fingerprint"]:
         raise ValueError("The source receipt changed; create a new plan")
@@ -1085,14 +1280,31 @@ def apply_plan(
     if migrated_label_count != plan["totals"]["preserved_labels"]:
         raise RuntimeError("Label preservation invariant failed before staging")
 
-    dynamo_client.reserve_receipt_ids(plan["image_id"], output_ids, plan["plan_id"])
-    for output_id in output_ids:
-        dynamo_client.delete_receipt_items(
-            plan["image_id"], output_id, include_parent=False
-        )
+    # Execution lock (C2): transition PLANNED -> COMMITTING with a conditional
+    # S3 write BEFORE any destructive DynamoDB operation. This compare-and-swap
+    # is the single serialization point for a plan's apply: a second concurrent
+    # apply that also read the PLANNED head loses the swap and bails here,
+    # so it can never reserve IDs, delete staged child rows, race the commit,
+    # destroy the winner's committed outputs.
+    plan["status"] = "COMMITTING"
+    try:
+        plan_etag = _save_plan(s3_client, raw_bucket, plan, if_match=plan_etag)
+    except PlanPreconditionError as error:
+        raise ValueError(
+            "Another apply of this plan is already in progress; retry after "
+            "it finishes"
+        ) from error
+
     uploaded_keys: list[str] = []
     committed = False
     try:
+        dynamo_client.reserve_receipt_ids(
+            plan["image_id"], output_ids, plan["plan_id"]
+        )
+        for output_id in output_ids:
+            dynamo_client.delete_receipt_items(
+                plan["image_id"], output_id, include_parent=False
+            )
         _stage_outputs(
             outputs=outputs,
             dynamo_client=dynamo_client,
@@ -1109,8 +1321,23 @@ def apply_plan(
                 wait_for_embeddings=bool(event.get("wait_for_embeddings", True)),
             )
 
-        plan["status"] = "COMMITTING"
-        _save_plan(s3_client, raw_bucket, plan)
+        # Re-verify the source fingerprint immediately before the commit (M2):
+        # staging and embedding above widen the window in which an external
+        # writer could edit a source word or label after the initial check.
+        # This shrinks that window to the commit transaction itself; the
+        # residual child-snapshot race is documented in the module docstring.
+        if (
+            _current_source_fingerprint(
+                dynamo_client=dynamo_client,
+                plan=plan,
+                image_entity=image_entity,
+                source_object=current_source_object,
+                schema_version=schema_version,
+            )
+            != plan["source_fingerprint"]
+        ):
+            raise ValueError("The source receipt changed; create a new plan")
+
         try:
             dynamo_client.commit_receipt_resegmentation(
                 details.receipt,
@@ -1139,7 +1366,17 @@ def apply_plan(
         except Exception:  # pylint: disable=broad-except
             logger.exception("Re-segmentation committed; cleanup is pending")
             plan["status"] = "CLEANUP_PENDING"
-            _save_plan(s3_client, raw_bucket, plan)
+            # The data is already durably committed; the status write is
+            # bookkeeping, so a lost precondition is logged but not fatal.
+            try:
+                plan_etag = _save_plan(
+                    s3_client, raw_bucket, plan, if_match=plan_etag
+                )
+            except PlanPreconditionError:
+                logger.exception(
+                    "Failed to persist CLEANUP_PENDING for plan %s",
+                    plan["plan_id"],
+                )
             return {
                 "status": "CLEANUP_PENDING",
                 "plan_id": plan["plan_id"],
@@ -1149,17 +1386,28 @@ def apply_plan(
         result["compaction_run_ids"] = run_ids
         plan["status"] = "APPLIED"
         plan["result"] = result
-        _save_plan(s3_client, raw_bucket, plan)
+        try:
+            plan_etag = _save_plan(
+                s3_client, raw_bucket, plan, if_match=plan_etag
+            )
+        except PlanPreconditionError:
+            logger.exception(
+                "Failed to persist APPLIED status for plan %s",
+                plan["plan_id"],
+            )
         return {"status": "APPLIED", **result}
     except Exception:
         if not committed:
             if plan["status"] == "COMMITTING":
-                # The COMMITTING marker was persisted before the commit
-                # transaction; revert it so a retry re-runs the full
-                # plan validation instead of the resume path.
+                # The COMMITTING lock was acquired before staging; revert it so
+                # a retry re-runs the full plan validation instead of the
+                # resume path. The conditional write keeps this worker from
+                # stamping over a status another worker has since advanced.
                 plan["status"] = "PLANNED"
                 try:
-                    _save_plan(s3_client, raw_bucket, plan)
+                    plan_etag = _save_plan(
+                        s3_client, raw_bucket, plan, if_match=plan_etag
+                    )
                 except Exception:  # pylint: disable=broad-except
                     logger.exception(
                         "Failed to revert plan %s to PLANNED", plan["plan_id"]

--- a/infra/resegment_receipt_lambda/lambdas/resegment_receipt.py
+++ b/infra/resegment_receipt_lambda/lambdas/resegment_receipt.py
@@ -1,0 +1,1157 @@
+"""Plan and apply safe, word-level receipt re-segmentation."""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import io
+import json
+import logging
+import math
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import TYPE_CHECKING, Any, Mapping
+
+import boto3
+from PIL import Image as PILImage
+
+if TYPE_CHECKING:
+    from mypy_boto3_s3 import S3Client
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+PLAN_PREFIX = "resegment-plans"
+SUPPORTED_SOURCE_TYPES = {
+    "COMPACTION_RUN",
+    "RECEIPT",
+    "RECEIPT_LETTER",
+    "RECEIPT_LINE",
+    "RECEIPT_PLACE",
+    "RECEIPT_WORD",
+    "RECEIPT_WORD_LABEL",
+}
+
+
+def _plan_key(plan_id: str) -> str:
+    return f"{PLAN_PREFIX}/{plan_id}.json"
+
+
+def _revision_key(plan_id: str, revision: int) -> str:
+    return f"{PLAN_PREFIX}/{plan_id}/revisions/{revision:04d}.json"
+
+
+def _artifact_prefix(plan_id: str, revision: int) -> str:
+    return f"{PLAN_PREFIX}/{plan_id}/revisions/{revision:04d}/preview"
+
+
+def _png_bytes(image: PILImage.Image) -> bytes:
+    output = io.BytesIO()
+    image.save(output, format="PNG")
+    return output.getvalue()
+
+
+def _jpeg_bytes(image: PILImage.Image) -> bytes:
+    output = io.BytesIO()
+    image.convert("RGB").save(output, format="JPEG", quality=82, optimize=True)
+    return output.getvalue()
+
+
+def _artifact_record(
+    *,
+    s3_client: "S3Client",
+    bucket: str,
+    key: str,
+    image: PILImage.Image,
+    kind: str,
+    mime_type: str = "image/png",
+) -> dict[str, Any]:
+    body = _jpeg_bytes(image) if mime_type == "image/jpeg" else _png_bytes(image)
+    s3_client.put_object(
+        Bucket=bucket,
+        Key=key,
+        Body=body,
+        ContentType=mime_type,
+    )
+    return {
+        "kind": kind,
+        "s3_key": key,
+        "mime_type": mime_type,
+        "sha256": hashlib.sha256(body).hexdigest(),
+        "byte_size": len(body),
+        "width": image.width,
+        "height": image.height,
+    }
+
+
+def _save_plan(s3_client: "S3Client", bucket: str, plan: dict) -> None:
+    s3_client.put_object(
+        Bucket=bucket,
+        Key=_plan_key(plan["plan_id"]),
+        Body=json.dumps(plan, sort_keys=True, default=str).encode("utf-8"),
+        ContentType="application/json",
+    )
+
+
+def _save_revision(s3_client: "S3Client", bucket: str, plan: dict) -> None:
+    s3_client.put_object(
+        Bucket=bucket,
+        Key=_revision_key(plan["plan_id"], int(plan.get("revision", 1))),
+        Body=json.dumps(plan, sort_keys=True, default=str).encode("utf-8"),
+        ContentType="application/json",
+    )
+
+
+def _load_plan(s3_client: "S3Client", bucket: str, plan_id: str) -> dict[str, Any]:
+    response = s3_client.get_object(Bucket=bucket, Key=_plan_key(plan_id))
+    return json.loads(response["Body"].read())
+
+
+def _load_revision(
+    s3_client: "S3Client", bucket: str, plan_id: str, revision: int
+) -> dict[str, Any]:
+    response = s3_client.get_object(Bucket=bucket, Key=_revision_key(plan_id, revision))
+    return json.loads(response["Body"].read())
+
+
+def _word_ref_set(segment: dict[str, Any]) -> set[tuple[int, int]]:
+    return {(int(ref["line_id"]), int(ref["word_id"])) for ref in segment["word_refs"]}
+
+
+def _combined_words_by_ref(
+    combined_words: list[dict[str, Any]], source_receipt_id: int
+) -> dict[tuple[int, int], dict[str, Any]]:
+    return {
+        (int(word["line_id"]), int(word["word_id"])): word
+        for word in combined_words
+        if int(word["receipt_id"]) == source_receipt_id
+    }
+
+
+def _download_original_image(
+    s3_client: "S3Client", image_entity: Any
+) -> PILImage.Image:
+    image, _ = _download_original_image_with_identity(s3_client, image_entity)
+    return image
+
+
+def _download_original_image_with_identity(
+    s3_client: "S3Client", image_entity: Any
+) -> tuple[PILImage.Image, dict[str, Any]]:
+    response = s3_client.get_object(
+        Bucket=image_entity.raw_s3_bucket, Key=image_entity.raw_s3_key
+    )
+    body = response["Body"].read()
+    identity = {
+        "bucket": image_entity.raw_s3_bucket,
+        "key": image_entity.raw_s3_key,
+        "version_id": response.get("VersionId"),
+        "etag": str(response.get("ETag", "")).strip('"') or None,
+        "content_length": len(body),
+        "content_sha256": hashlib.sha256(body).hexdigest(),
+    }
+    return PILImage.open(io.BytesIO(body)).convert("RGB"), identity
+
+
+def _segment_geometry(
+    segment_words: list[dict[str, Any]],
+    image_width: int,
+    image_height: int,
+    padding_px: float,
+) -> dict[str, Any]:
+    from receipt_upload.combine import calculate_min_area_rect
+
+    geometry = calculate_min_area_rect(
+        segment_words,
+        image_width,
+        image_height,
+        padding_px=padding_px,
+    )
+
+    return {
+        "bounds": geometry["bounds"],
+        "src_corners": [list(point) for point in geometry["src_corners"]],
+        "warped_width": geometry["warped_width"],
+        "warped_height": geometry["warped_height"],
+        "requested_padding_px": padding_px,
+        "applied_padding_px": padding_px,
+    }
+
+
+def _plan_preview_url(s3_client: "S3Client", bucket: str, key: str) -> str:
+    return s3_client.generate_presigned_url(
+        "get_object",
+        Params={"Bucket": bucket, "Key": key},
+        ExpiresIn=3600,
+    )
+
+
+def _preview_delivery(
+    s3_client: "S3Client", bucket: str, plan: Mapping[str, Any]
+) -> dict[str, Any]:
+    manifest = plan.get("visualizations") or {}
+    if not manifest:
+        return {
+            segment["segment_key"]: _plan_preview_url(
+                s3_client, bucket, segment["preview_s3_key"]
+            )
+            for segment in plan.get("segments", ())
+            if segment.get("preview_s3_key")
+        }
+    delivery: dict[str, Any] = {
+        "expires_at": (datetime.now(timezone.utc) + timedelta(hours=1)).isoformat(),
+        "segments": {},
+    }
+    for name in ("overlay", "contact_sheet"):
+        artifact = manifest.get(name)
+        if artifact:
+            delivery[name] = _plan_preview_url(s3_client, bucket, artifact["s3_key"])
+    for segment_key, artifacts in manifest.get("segments", {}).items():
+        delivery["segments"][segment_key] = {
+            name: _plan_preview_url(s3_client, bucket, artifact["s3_key"])
+            for name, artifact in artifacts.items()
+            if isinstance(artifact, Mapping) and artifact.get("s3_key")
+        }
+    return delivery
+
+
+def create_plan(
+    event: dict[str, Any],
+    *,
+    dynamo_client: Any,
+    s3_client: "S3Client",
+    raw_bucket: str,
+    plan_id: str | None = None,
+    revision: int = 1,
+    supersedes_plan_hash: str | None = None,
+    expected_source_fingerprint: str | None = None,
+) -> dict[str, Any]:
+    """Create and optionally persist a visual, immutable split plan."""
+    from receipt_upload.combine import (
+        combine_receipt_words_to_image_coords,
+        create_warped_receipt_image,
+    )
+    from receipt_upload.resegment import (
+        build_preview_bundle,
+        build_source_fingerprint,
+        compute_plan_hash,
+        normalize_line_resegmentation_plan,
+        normalize_resegmentation_plan,
+    )
+
+    image_id = str(event["image_id"])
+    source_receipt_id = int(event["source_receipt_id"])
+    schema_version = int(
+        event.get("schema_version", 2 if event.get("assignments") else 1)
+    )
+    if schema_version not in {1, 2}:
+        raise ValueError("schema_version must be 1 or 2")
+    if schema_version == 2 and not event.get("assignments"):
+        raise ValueError("schema_version=2 requires line-first assignments")
+    if schema_version == 1 and event.get("assignments"):
+        raise ValueError("assignments require schema_version=2")
+
+    visualization = dict(event.get("visualization") or {})
+    padding_px = float(visualization.get("padding_px", event.get("padding_px", 12.0)))
+    if not math.isfinite(padding_px) or not 0 <= padding_px <= 256:
+        raise ValueError("padding_px must be a finite number between 0 and 256")
+    persist_plan = bool(event.get("persist_plan", True))
+    if event.get("rerun_ocr", False):
+        raise ValueError("rerun_ocr is not supported in the first release")
+
+    details = dynamo_client.get_receipt_details(image_id, source_receipt_id)
+    image_entity = dynamo_client.get_image(image_id)
+    image_type = str(image_entity.image_type)
+    letters = (
+        dynamo_client.list_receipt_letters_from_receipt(image_id, source_receipt_id)
+        if schema_version == 2
+        else []
+    )
+    type_counts = dynamo_client.get_receipt_item_type_counts(
+        image_id, source_receipt_id
+    )
+    unsupported = sorted(set(type_counts) - SUPPORTED_SOURCE_TYPES)
+    if unsupported:
+        raise ValueError(
+            "This receipt has unsupported dependent entity types: "
+            f"{unsupported}. Add an explicit migration policy before splitting."
+        )
+    if details.barcodes:
+        raise ValueError("Receipt barcodes need an explicit segment assignment policy")
+
+    if schema_version == 2:
+        normalized = normalize_line_resegmentation_plan(
+            lines=details.lines,
+            words=details.words,
+            letters=letters,
+            labels=details.labels,
+            segments=event["segments"],
+            assignments=event["assignments"],
+        )
+    else:
+        normalized = normalize_resegmentation_plan(
+            words=details.words,
+            labels=details.labels,
+            segments=event["segments"],
+            discard_line_ids=event.get("discard_line_ids", ()),
+            discard_word_refs=event.get("discard_word_refs", ()),
+            discard_reason=event.get("discard_reason"),
+            allow_labeled_discard=bool(event.get("allow_labeled_discard", False)),
+        )
+
+    original_image = None
+    source_object = None
+    if schema_version == 2 or persist_plan:
+        original_image, source_object = _download_original_image_with_identity(
+            s3_client, image_entity
+        )
+    source_fingerprint = build_source_fingerprint(
+        receipt=details.receipt,
+        words=details.words,
+        labels=details.labels,
+        place=details.place,
+        image=image_entity if schema_version == 2 else None,
+        lines=details.lines if schema_version == 2 else (),
+        letters=letters,
+        source_object=source_object if schema_version == 2 else None,
+        source_type_counts=type_counts if schema_version == 2 else None,
+    )
+    if (
+        expected_source_fingerprint is not None
+        and source_fingerprint != expected_source_fingerprint
+    ):
+        raise ValueError("The source receipt changed; create a new plan")
+    all_receipts = dynamo_client.get_receipts_from_image(image_id)
+    next_receipt_id = (
+        max((receipt.receipt_id for receipt in all_receipts), default=0) + 1
+    )
+
+    combined_words = combine_receipt_words_to_image_coords(
+        dynamo_client,
+        image_id,
+        [source_receipt_id],
+        image_entity.width,
+        image_entity.height,
+        deduplicate=False,
+    )
+    words_by_ref = _combined_words_by_ref(combined_words, source_receipt_id)
+    if len(words_by_ref) != normalized["totals"]["source_words"]:
+        raise ValueError("Not every source word could be transformed to image space")
+
+    plan_id = plan_id or str(uuid.uuid4())
+    plan_segments = []
+    for offset, segment in enumerate(normalized["segments"]):
+        refs = _word_ref_set(segment)
+        segment_words = [words_by_ref[ref] for ref in sorted(refs)]
+        geometry = _segment_geometry(
+            segment_words,
+            image_entity.width,
+            image_entity.height,
+            padding_px,
+        )
+        plan_segment = {
+            **segment,
+            "output_receipt_id": next_receipt_id + offset,
+            "geometry": geometry,
+        }
+        plan_segments.append(plan_segment)
+
+    requested_strategy = str(visualization.get("strategy", "AUTO")).upper()
+    if requested_strategy not in {"AUTO", "RECTANGULAR", "LAYERED_MULTI_REGION"}:
+        raise ValueError(
+            "visualization.strategy must be AUTO, RECTANGULAR, or "
+            "LAYERED_MULTI_REGION"
+        )
+    if requested_strategy == "AUTO":
+        layered_evidence = schema_version == 2 and (
+            normalized["totals"].get("mixed_lines", 0) > 0
+            or any(
+                segment.get("visible_regions")
+                or segment.get("occluded_by")
+                or int(segment.get("z_index", 0)) != 0
+                for segment in plan_segments
+            )
+        )
+        effective_strategy = (
+            "LAYERED_MULTI_REGION"
+            if image_type == "PHOTO" and layered_evidence
+            else "RECTANGULAR"
+        )
+    else:
+        effective_strategy = requested_strategy
+    if image_type == "NATIVE" and effective_strategy == "LAYERED_MULTI_REGION":
+        raise ValueError("NATIVE images do not support layered re-segmentation")
+    if (
+        image_type == "SCAN"
+        and effective_strategy == "LAYERED_MULTI_REGION"
+        and not visualization.get("confirm_stacked_scan", False)
+    ):
+        raise ValueError("SCAN layered segmentation requires confirm_stacked_scan=true")
+
+    plan = {
+        "version": schema_version,
+        "schema_version": schema_version,
+        "plan_id": plan_id,
+        "revision": revision,
+        "supersedes_plan_hash": supersedes_plan_hash,
+        "revision_reason": event.get("revision_reason"),
+        "status": "PLANNED",
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "image_id": image_id,
+        "source_receipt_id": source_receipt_id,
+        "image": {
+            "entity_type": "IMAGE",
+            "image_id": image_id,
+            "image_type": image_type,
+            "width": image_entity.width,
+            "height": image_entity.height,
+        },
+        "source_object": source_object if schema_version == 2 else None,
+        "source_fingerprint": source_fingerprint,
+        "source_type_counts": type_counts,
+        "padding_px": padding_px,
+        "visualization": {
+            "requested_strategy": requested_strategy,
+            "effective_strategy": effective_strategy,
+            "padding_px": padding_px,
+            "confirm_stacked_scan": bool(
+                visualization.get("confirm_stacked_scan", False)
+            ),
+        },
+        "segments": plan_segments,
+        "assignments": normalized.get("assignments"),
+        "discard": normalized["discard"],
+        "totals": normalized["totals"],
+    }
+
+    preview_urls: dict[str, Any] = {}
+    if persist_plan:
+        if original_image is None:
+            original_image = _download_original_image(s3_client, image_entity)
+        if schema_version == 2:
+            discard_refs = {
+                (int(ref["line_id"]), int(ref["word_id"]))
+                for ref in normalized["discard"]["word_refs"]
+            }
+            bundle = build_preview_bundle(
+                original_image,
+                image_type=image_type,
+                strategy=effective_strategy,
+                lines=details.lines,
+                words_by_ref=words_by_ref,
+                segments=plan_segments,
+                discard_refs=discard_refs,
+                letters=letters,
+                padding_px=int(round(padding_px)),
+            )
+            prefix = _artifact_prefix(plan_id, revision)
+            visualizations: dict[str, Any] = {
+                "schema_version": 1,
+                "source": {"entity_type": "IMAGE", "image_type": image_type},
+                "coordinate_space": {
+                    "space": "SOURCE_IMAGE_PIXELS",
+                    "origin": "TOP_LEFT",
+                    "width": image_entity.width,
+                    "height": image_entity.height,
+                },
+                "segments": {},
+            }
+            visualizations["overlay"] = _artifact_record(
+                s3_client=s3_client,
+                bucket=raw_bucket,
+                key=f"{prefix}/overlay.png",
+                image=bundle["images"]["overlay"],
+                kind="ASSIGNMENT_OVERLAY",
+            )
+            visualizations["contact_sheet"] = _artifact_record(
+                s3_client=s3_client,
+                bucket=raw_bucket,
+                key=f"{prefix}/contact-sheet.jpg",
+                image=bundle["images"]["contact_sheet"],
+                kind="MCP_CONTACT_SHEET",
+                mime_type="image/jpeg",
+            )
+            for segment_key, images in bundle["images"]["segments"].items():
+                visualizations["segments"][segment_key] = {
+                    "mask": _artifact_record(
+                        s3_client=s3_client,
+                        bucket=raw_bucket,
+                        key=f"{prefix}/segments/{segment_key}/mask.png",
+                        image=images["mask"],
+                        kind="VISIBLE_MASK",
+                    ),
+                    "visible_crop": _artifact_record(
+                        s3_client=s3_client,
+                        bucket=raw_bucket,
+                        key=f"{prefix}/segments/{segment_key}/visible.png",
+                        image=images["visible_crop"],
+                        kind="MASKED_RGBA_CROP",
+                    ),
+                }
+            plan["visualizations"] = visualizations
+            plan["metrics"] = bundle["metrics"]
+            plan["findings"] = bundle["findings"]
+            plan["evidence"] = bundle["evidence"]
+        else:
+            for segment, plan_segment in zip(normalized["segments"], plan_segments):
+                geometry = plan_segment["geometry"]
+                preview = create_warped_receipt_image(
+                    original_image,
+                    [tuple(point) for point in geometry["src_corners"]],
+                    geometry["warped_width"],
+                    geometry["warped_height"],
+                )
+                preview_key = (
+                    f"{PLAN_PREFIX}/{plan_id}/" f"{segment['segment_key']}.png"
+                )
+                s3_client.put_object(
+                    Bucket=raw_bucket,
+                    Key=preview_key,
+                    Body=_png_bytes(preview),
+                    ContentType="image/png",
+                )
+                plan_segment["preview_s3_key"] = preview_key
+
+    plan["plan_hash"] = compute_plan_hash(plan)
+    if persist_plan:
+        _save_revision(s3_client, raw_bucket, plan)
+        _save_plan(s3_client, raw_bucket, plan)
+        preview_urls = _preview_delivery(s3_client, raw_bucket, plan)
+
+    return {
+        **plan,
+        "applicable": not any(
+            finding.get("severity") == "BLOCKER" for finding in plan.get("findings", ())
+        ),
+        "preview_urls": preview_urls,
+    }
+
+
+def get_plan(
+    event: dict[str, Any],
+    *,
+    s3_client: "S3Client",
+    raw_bucket: str,
+) -> dict[str, Any]:
+    """Retrieve a plan revision and refresh all expiring preview URLs."""
+    plan_id = str(event["plan_id"])
+    head = _load_plan(s3_client, raw_bucket, plan_id)
+    requested_revision = event.get("revision")
+    if requested_revision is None or int(requested_revision) == int(
+        head.get("revision", 1)
+    ):
+        plan = head
+    else:
+        plan = _load_revision(s3_client, raw_bucket, plan_id, int(requested_revision))
+    blockers = [
+        finding
+        for finding in plan.get("findings", ())
+        if finding.get("severity") == "BLOCKER"
+    ]
+    return {
+        **plan,
+        "is_latest": int(plan.get("revision", 1)) == int(head.get("revision", 1)),
+        "applicable": not blockers
+        and int(plan.get("revision", 1)) == int(head.get("revision", 1))
+        and plan.get("status") == "PLANNED",
+        "preview_urls": _preview_delivery(s3_client, raw_bucket, plan),
+    }
+
+
+def revise_plan(
+    event: dict[str, Any],
+    *,
+    dynamo_client: Any,
+    s3_client: "S3Client",
+    raw_bucket: str,
+) -> dict[str, Any]:
+    """Create an immutable replacement revision with optimistic concurrency."""
+    plan_id = str(event["plan_id"])
+    head = _load_plan(s3_client, raw_bucket, plan_id)
+    if head.get("status") != "PLANNED":
+        raise ValueError("Only a PLANNED re-segmentation can be revised")
+    if int(event["base_revision"]) != int(head.get("revision", 1)):
+        raise ValueError("base_revision is stale; retrieve the latest plan")
+    if str(event["base_plan_hash"]) != str(head["plan_hash"]):
+        raise ValueError("base_plan_hash is stale; retrieve the latest plan")
+    if int(head.get("schema_version", head.get("version", 1))) != 2:
+        raise ValueError("Only schema_version=2 plans support revision")
+
+    previous_visualization = head.get("visualization", {})
+    replacement_event = {
+        "schema_version": 2,
+        "image_id": head["image_id"],
+        "source_receipt_id": head["source_receipt_id"],
+        "segments": event["segments"],
+        "assignments": event["assignments"],
+        "visualization": event.get("visualization")
+        or {
+            "strategy": previous_visualization.get("requested_strategy", "AUTO"),
+            "padding_px": previous_visualization.get("padding_px", 12),
+            "confirm_stacked_scan": previous_visualization.get(
+                "confirm_stacked_scan", False
+            ),
+        },
+        "revision_reason": event["revision_reason"],
+    }
+    return create_plan(
+        replacement_event,
+        dynamo_client=dynamo_client,
+        s3_client=s3_client,
+        raw_bucket=raw_bucket,
+        plan_id=plan_id,
+        revision=int(head.get("revision", 1)) + 1,
+        supersedes_plan_hash=head["plan_hash"],
+        expected_source_fingerprint=head["source_fingerprint"],
+    )
+
+
+def _migrate_labels(
+    source_labels: list[Any],
+    source_receipt_id: int,
+    output_receipt_id: int,
+    line_id_map: dict,
+    word_id_map: dict,
+) -> list[Any]:
+    from receipt_dynamo.entities import ReceiptWordLabel
+
+    migrated = []
+    for label in source_labels:
+        source_key = (label.word_id, label.line_id, source_receipt_id)
+        new_word_id = word_id_map.get(source_key)
+        new_line_id = line_id_map.get((label.line_id, source_receipt_id))
+        if new_word_id is None or new_line_id is None:
+            continue
+        migrated.append(
+            ReceiptWordLabel(
+                image_id=label.image_id,
+                receipt_id=output_receipt_id,
+                line_id=new_line_id,
+                word_id=new_word_id,
+                label=label.label,
+                reasoning=label.reasoning,
+                timestamp_added=label.timestamp_added,
+                validation_status=label.validation_status,
+                label_proposed_by=label.label_proposed_by,
+                label_consolidated_from=label.label_consolidated_from,
+            )
+        )
+    return migrated
+
+
+def _set_cdn_fields(receipt: Any, cdn_keys: dict[str, str]) -> None:
+    mappings = {
+        "cdn_s3_key": "jpeg",
+        "cdn_webp_s3_key": "webp",
+        "cdn_avif_s3_key": "avif",
+        "cdn_thumbnail_s3_key": "jpeg_thumbnail",
+        "cdn_thumbnail_webp_s3_key": "webp_thumbnail",
+        "cdn_thumbnail_avif_s3_key": "avif_thumbnail",
+        "cdn_small_s3_key": "jpeg_small",
+        "cdn_small_webp_s3_key": "webp_small",
+        "cdn_small_avif_s3_key": "avif_small",
+        "cdn_medium_s3_key": "jpeg_medium",
+        "cdn_medium_webp_s3_key": "webp_medium",
+        "cdn_medium_avif_s3_key": "avif_medium",
+    }
+    for attribute, key in mappings.items():
+        setattr(receipt, attribute, cdn_keys.get(key))
+
+
+def _expected_cdn_keys(base_key: str) -> list[str]:
+    return [
+        f"{base_key}{suffix}.{extension}"
+        for suffix in ("_thumbnail", "_small", "_medium", "")
+        for extension in ("jpg", "webp", "avif")
+    ]
+
+
+def _build_outputs(
+    *,
+    plan: dict[str, Any],
+    details: Any,
+    image_entity: Any,
+    original_image: PILImage.Image,
+    combined_words: list[dict[str, Any]],
+    dynamo_client: Any,
+    raw_bucket: str,
+    site_bucket: str,
+) -> list[dict[str, Any]]:
+    from receipt_upload.combine import (
+        combine_receipt_letters_to_image_coords,
+        create_combined_receipt_records,
+        create_receipt_letters_from_combined,
+        create_warped_receipt_image,
+    )
+    from receipt_upload.utils import calculate_sha256_from_bytes
+
+    source_receipt_id = int(plan["source_receipt_id"])
+    words_by_ref = _combined_words_by_ref(combined_words, source_receipt_id)
+    outputs = []
+    for segment in plan["segments"]:
+        output_receipt_id = int(segment["output_receipt_id"])
+        segment_words = [words_by_ref[ref] for ref in sorted(_word_ref_set(segment))]
+        geometry = _segment_geometry(
+            segment_words,
+            image_entity.width,
+            image_entity.height,
+            float(plan["padding_px"]),
+        )
+        if geometry != segment["geometry"]:
+            raise ValueError(f"Geometry changed for segment {segment['segment_key']}")
+        src_corners = [tuple(point) for point in geometry["src_corners"]]
+        warped_image = create_warped_receipt_image(
+            original_image,
+            src_corners,
+            geometry["warped_width"],
+            geometry["warped_height"],
+        )
+        records = create_combined_receipt_records(
+            image_id=plan["image_id"],
+            new_receipt_id=output_receipt_id,
+            combined_words=segment_words,
+            bounds=geometry["bounds"],
+            raw_bucket=raw_bucket,
+            site_bucket=site_bucket,
+            image_width=image_entity.width,
+            image_height=image_entity.height,
+            warped_width=geometry["warped_width"],
+            warped_height=geometry["warped_height"],
+            src_corners=src_corners,
+        )
+        combined_letters = combine_receipt_letters_to_image_coords(
+            dynamo_client,
+            plan["image_id"],
+            [source_receipt_id],
+            image_entity.width,
+            image_entity.height,
+            records["word_id_map"],
+            records["line_id_map"],
+        )
+        letters = create_receipt_letters_from_combined(
+            combined_letters=combined_letters,
+            new_receipt_id=output_receipt_id,
+            image_id=plan["image_id"],
+            receipt_width=geometry["warped_width"],
+            receipt_height=geometry["warped_height"],
+            image_height=image_entity.height,
+            warped_height=geometry["warped_height"],
+            src_corners=src_corners,
+            warped_width=geometry["warped_width"],
+        )
+        labels = _migrate_labels(
+            details.labels,
+            source_receipt_id,
+            output_receipt_id,
+            records["line_id_map"],
+            records["word_id_map"],
+        )
+        place = None
+        if segment.get("place_policy", "none") == "inherit" and details.place:
+            place = copy.deepcopy(details.place)
+            place.receipt_id = output_receipt_id
+        elif segment.get("place_policy") not in {"inherit", "none"}:
+            raise ValueError(f"Unsupported place_policy: {segment.get('place_policy')}")
+
+        raw_key = (
+            f"receipts/{plan['image_id']}/"
+            f"{plan['image_id']}_RECEIPT_{output_receipt_id:05d}.png"
+        )
+        receipt = records["receipt"]
+        receipt.raw_s3_key = raw_key
+        receipt.sha256 = calculate_sha256_from_bytes(_png_bytes(warped_image))
+        outputs.append(
+            {
+                "segment_key": segment["segment_key"],
+                "image": warped_image,
+                "receipt": receipt,
+                "lines": records["receipt_lines"],
+                "words": records["receipt_words"],
+                "letters": letters,
+                "labels": labels,
+                "place": place,
+                "raw_key": raw_key,
+            }
+        )
+    return outputs
+
+
+def _stage_outputs(
+    *,
+    outputs: list[dict[str, Any]],
+    dynamo_client: Any,
+    raw_bucket: str,
+    site_bucket: str,
+    uploaded_keys: list[str],
+) -> None:
+    from receipt_upload.utils import upload_all_cdn_formats, upload_png_to_s3
+
+    for output in outputs:
+        uploaded_keys.append(output["raw_key"])
+        upload_png_to_s3(output["image"], raw_bucket, output["raw_key"])
+        receipt_id = output["receipt"].receipt_id
+        cdn_base_key = f"assets/{output['receipt'].image_id}/{receipt_id}"
+        # Record every possible CDN key before the multi-format uploader runs,
+        # so a mid-upload exception can still roll back partial objects.
+        uploaded_keys.extend(_expected_cdn_keys(cdn_base_key))
+        cdn_keys = upload_all_cdn_formats(
+            output["image"],
+            site_bucket,
+            cdn_base_key,
+            generate_thumbnails=True,
+        )
+        _set_cdn_fields(output["receipt"], cdn_keys)
+
+        dynamo_client.add_receipt_lines(output["lines"])
+        dynamo_client.add_receipt_words(output["words"])
+        if output["letters"]:
+            dynamo_client.add_receipt_letters(output["letters"])
+        if output["labels"]:
+            dynamo_client.add_receipt_word_labels(output["labels"])
+        if output["place"]:
+            dynamo_client.add_receipt_place(output["place"])
+
+
+def _embed_outputs(
+    *,
+    outputs: list[dict[str, Any]],
+    dynamo_client: Any,
+    chromadb_bucket: str,
+    wait_for_embeddings: bool,
+) -> list[str]:
+    from receipt_chroma.embedding.orchestration import (
+        EmbeddingConfig,
+        create_embeddings_and_compaction_run,
+    )
+
+    run_ids = []
+    for output in outputs:
+        receipt = output["receipt"]
+        config = EmbeddingConfig(
+            image_id=receipt.image_id,
+            receipt_id=receipt.receipt_id,
+            chromadb_bucket=chromadb_bucket,
+            dynamo_client=dynamo_client,
+            receipt_place=output["place"],
+            receipt_word_labels=output["labels"] or None,
+        )
+        result = create_embeddings_and_compaction_run(
+            receipt_lines=output["lines"],
+            receipt_words=[word for word in output["words"] if not word.is_noise]
+            or output["words"],
+            config=config,
+        )
+        try:
+            run_ids.append(result.compaction_run.run_id)
+            if wait_for_embeddings and not result.wait_for_compaction_to_finish(
+                dynamo_client, max_wait_seconds=300
+            ):
+                raise RuntimeError(
+                    f"Embedding compaction failed for receipt {receipt.receipt_id}"
+                )
+        finally:
+            result.close()
+    return run_ids
+
+
+def _delete_uploaded_objects(
+    s3_client: "S3Client",
+    raw_bucket: str,
+    site_bucket: str,
+    keys: list[str],
+) -> None:
+    for key in keys:
+        bucket = site_bucket if key.startswith("assets/") else raw_bucket
+        try:
+            s3_client.delete_object(Bucket=bucket, Key=key)
+        except Exception:  # pylint: disable=broad-except
+            logger.warning("Failed to delete staged s3://%s/%s", bucket, key)
+
+
+def _finish_cleanup(
+    *, plan: dict[str, Any], dynamo_client: Any, image_entity: Any
+) -> dict[str, Any]:
+    deleted_items = dynamo_client.delete_receipt_items(
+        plan["image_id"], int(plan["source_receipt_id"]), include_parent=True
+    )
+    output_ids = [int(segment["output_receipt_id"]) for segment in plan["segments"]]
+    remaining_receipts = dynamo_client.get_receipts_from_image(plan["image_id"])
+    visible_ids = {receipt.receipt_id for receipt in remaining_receipts}
+    if not set(output_ids).issubset(visible_ids):
+        raise RuntimeError("Committed output receipts are not visible")
+    image_entity.receipt_count = len(remaining_receipts)
+    dynamo_client.update_image(image_entity)
+    return {
+        "image_id": plan["image_id"],
+        "source_receipt_id": plan["source_receipt_id"],
+        "output_receipt_ids": output_ids,
+        "deleted_source_items": deleted_items,
+    }
+
+
+def apply_plan(
+    event: dict[str, Any],
+    *,
+    dynamo_client: Any,
+    s3_client: "S3Client",
+    raw_bucket: str,
+    site_bucket: str,
+    chromadb_bucket: str,
+) -> dict[str, Any]:
+    """Apply a persisted plan with staging, guarded commit, and cleanup."""
+    from receipt_dynamo.data.shared_exceptions import EntityNotFoundError
+    from receipt_upload.combine import combine_receipt_words_to_image_coords
+    from receipt_upload.resegment import (
+        build_source_fingerprint,
+        compute_plan_hash,
+    )
+
+    plan = _load_plan(s3_client, raw_bucket, str(event["plan_id"]))
+    if event.get("plan_hash") != plan["plan_hash"]:
+        raise ValueError("plan_hash does not match the stored plan")
+    if compute_plan_hash(plan) != plan["plan_hash"]:
+        raise ValueError("Stored plan contents failed integrity validation")
+    if plan["status"] == "APPLIED":
+        return {"status": "APPLIED", **plan["result"]}
+    blockers = [
+        finding.get("code", "UNKNOWN_BLOCKER")
+        for finding in plan.get("findings", ())
+        if finding.get("severity") == "BLOCKER"
+    ]
+    if blockers:
+        raise ValueError(
+            "The reviewed plan has blocking findings and cannot be applied: "
+            f"{sorted(blockers)}"
+        )
+    if (
+        plan.get("visualization", {}).get("effective_strategy")
+        == "LAYERED_MULTI_REGION"
+    ):
+        raise ValueError(
+            "LAYERED_MULTI_REGION plans cannot be applied until masked output "
+            "rendering is enabled"
+        )
+
+    image_entity = dynamo_client.get_image(plan["image_id"])
+    output_ids = [int(segment["output_receipt_id"]) for segment in plan["segments"]]
+
+    if plan["status"] in {"COMMITTING", "CLEANUP_PENDING"}:
+        try:
+            dynamo_client.get_receipt(plan["image_id"], int(plan["source_receipt_id"]))
+            source_exists = True
+        except EntityNotFoundError:
+            source_exists = False
+        visible_output_ids = set()
+        for output_id in output_ids:
+            try:
+                dynamo_client.get_receipt(plan["image_id"], output_id)
+                visible_output_ids.add(output_id)
+            except EntityNotFoundError:
+                pass
+        if not source_exists and visible_output_ids == set(output_ids):
+            result = _finish_cleanup(
+                plan=plan,
+                dynamo_client=dynamo_client,
+                image_entity=image_entity,
+            )
+            plan["status"] = "APPLIED"
+            plan["result"] = result
+            _save_plan(s3_client, raw_bucket, plan)
+            return {"status": "APPLIED", **result}
+        if source_exists:
+            dynamo_client.release_receipt_id_reservations(
+                plan["image_id"], output_ids, plan["plan_id"]
+            )
+            plan["status"] = "PLANNED"
+            _save_plan(s3_client, raw_bucket, plan)
+
+    details = dynamo_client.get_receipt_details(
+        plan["image_id"], int(plan["source_receipt_id"])
+    )
+    current_type_counts = dynamo_client.get_receipt_item_type_counts(
+        plan["image_id"], int(plan["source_receipt_id"])
+    )
+    if current_type_counts != plan["source_type_counts"]:
+        raise ValueError("The source receipt dependents changed; create a new plan")
+    schema_version = int(plan.get("schema_version", plan.get("version", 1)))
+    current_letters = (
+        dynamo_client.list_receipt_letters_from_receipt(
+            plan["image_id"], int(plan["source_receipt_id"])
+        )
+        if schema_version == 2
+        else []
+    )
+    original_image, current_source_object = _download_original_image_with_identity(
+        s3_client, image_entity
+    )
+    current_fingerprint = build_source_fingerprint(
+        receipt=details.receipt,
+        words=details.words,
+        labels=details.labels,
+        place=details.place,
+        image=image_entity if schema_version == 2 else None,
+        lines=details.lines if schema_version == 2 else (),
+        letters=current_letters,
+        source_object=current_source_object if schema_version == 2 else None,
+        source_type_counts=current_type_counts if schema_version == 2 else None,
+    )
+    if current_fingerprint != plan["source_fingerprint"]:
+        raise ValueError("The source receipt changed; create a new plan")
+
+    combined_words = combine_receipt_words_to_image_coords(
+        dynamo_client,
+        plan["image_id"],
+        [int(plan["source_receipt_id"])],
+        image_entity.width,
+        image_entity.height,
+        deduplicate=False,
+    )
+    outputs = _build_outputs(
+        plan=plan,
+        details=details,
+        image_entity=image_entity,
+        original_image=original_image,
+        combined_words=combined_words,
+        dynamo_client=dynamo_client,
+        raw_bucket=raw_bucket,
+        site_bucket=site_bucket,
+    )
+    migrated_label_count = sum(len(output["labels"]) for output in outputs)
+    if migrated_label_count != plan["totals"]["preserved_labels"]:
+        raise RuntimeError("Label preservation invariant failed before staging")
+
+    dynamo_client.reserve_receipt_ids(plan["image_id"], output_ids, plan["plan_id"])
+    for output_id in output_ids:
+        dynamo_client.delete_receipt_items(
+            plan["image_id"], output_id, include_parent=False
+        )
+    uploaded_keys: list[str] = []
+    committed = False
+    try:
+        _stage_outputs(
+            outputs=outputs,
+            dynamo_client=dynamo_client,
+            raw_bucket=raw_bucket,
+            site_bucket=site_bucket,
+            uploaded_keys=uploaded_keys,
+        )
+        run_ids = []
+        if event.get("create_embeddings", True):
+            run_ids = _embed_outputs(
+                outputs=outputs,
+                dynamo_client=dynamo_client,
+                chromadb_bucket=chromadb_bucket,
+                wait_for_embeddings=bool(event.get("wait_for_embeddings", True)),
+            )
+
+        plan["status"] = "COMMITTING"
+        _save_plan(s3_client, raw_bucket, plan)
+        dynamo_client.commit_receipt_resegmentation(
+            details.receipt,
+            [output["receipt"] for output in outputs],
+            plan["plan_id"],
+        )
+        committed = True
+        try:
+            result = _finish_cleanup(
+                plan=plan,
+                dynamo_client=dynamo_client,
+                image_entity=image_entity,
+            )
+        except Exception:  # pylint: disable=broad-except
+            logger.exception("Re-segmentation committed; cleanup is pending")
+            plan["status"] = "CLEANUP_PENDING"
+            _save_plan(s3_client, raw_bucket, plan)
+            return {
+                "status": "CLEANUP_PENDING",
+                "plan_id": plan["plan_id"],
+                "output_receipt_ids": output_ids,
+            }
+
+        result["compaction_run_ids"] = run_ids
+        plan["status"] = "APPLIED"
+        plan["result"] = result
+        _save_plan(s3_client, raw_bucket, plan)
+        return {"status": "APPLIED", **result}
+    except Exception:
+        if not committed:
+            try:
+                dynamo_client.release_receipt_id_reservations(
+                    plan["image_id"], output_ids, plan["plan_id"]
+                )
+            finally:
+                _delete_uploaded_objects(
+                    s3_client,
+                    raw_bucket,
+                    site_bucket,
+                    uploaded_keys,
+                )
+        raise
+
+
+def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
+    """Dispatch plan or apply operations."""
+    del context
+    try:
+        mode = event.get("mode")
+        if mode not in {"plan", "get", "revise", "apply"}:
+            return {
+                "status": "error",
+                "error": "mode must be plan, get, revise, or apply",
+            }
+
+        table_name = os.environ["DYNAMODB_TABLE_NAME"]
+        raw_bucket = os.environ["RAW_BUCKET"]
+        site_bucket = os.environ["SITE_BUCKET"]
+        chromadb_bucket = os.environ["CHROMADB_BUCKET"]
+
+        from receipt_dynamo import DynamoClient
+
+        dynamo_client = DynamoClient(table_name=table_name)
+        s3_client = boto3.client("s3")
+        if mode == "plan":
+            return create_plan(
+                event,
+                dynamo_client=dynamo_client,
+                s3_client=s3_client,
+                raw_bucket=raw_bucket,
+            )
+        if mode == "get":
+            return get_plan(
+                {
+                    "plan_id": event.get("plan_id"),
+                    "revision": event.get("revision"),
+                },
+                s3_client=s3_client,
+                raw_bucket=raw_bucket,
+            )
+        if mode == "revise":
+            return revise_plan(
+                {
+                    "plan_id": event.get("plan_id"),
+                    "base_revision": event.get("base_revision"),
+                    "base_plan_hash": event.get("base_plan_hash"),
+                    "segments": event.get("segments"),
+                    "assignments": event.get("assignments"),
+                    "visualization": event.get("visualization"),
+                    "revision_reason": event.get("revision_reason"),
+                },
+                dynamo_client=dynamo_client,
+                s3_client=s3_client,
+                raw_bucket=raw_bucket,
+            )
+        return apply_plan(
+            {
+                "plan_id": event.get("plan_id"),
+                "plan_hash": event.get("plan_hash"),
+            },
+            dynamo_client=dynamo_client,
+            s3_client=s3_client,
+            raw_bucket=raw_bucket,
+            site_bucket=site_bucket,
+            chromadb_bucket=chromadb_bucket,
+        )
+    except Exception as exc:  # pylint: disable=broad-except
+        logger.exception("Receipt re-segmentation failed")
+        return {"status": "error", "error": str(exc)}

--- a/receipt_dynamo/receipt_dynamo/data/_receipt.py
+++ b/receipt_dynamo/receipt_dynamo/data/_receipt.py
@@ -1,7 +1,9 @@
 # infra/lambda_layer/python/dynamo/data/_receipt.py
+from collections import Counter
 from typing import Any
 
 from receipt_dynamo.data.base_operations import (
+    DeleteRequestTypeDef,
     DeleteTypeDef,
     FlattenedStandardMixin,
     PutRequestTypeDef,
@@ -152,6 +154,230 @@ class _Receipt(FlattenedStandardMixin):
         ]
         # type: ignore[arg-type]
         self._transact_write_with_chunking(transact_items)
+
+    @handle_dynamodb_errors("reserve_receipt_ids")
+    def reserve_receipt_ids(
+        self,
+        image_id: str,
+        receipt_ids: list[int],
+        operation_id: str,
+    ) -> None:
+        """Atomically reserve receipt IDs without exposing partial receipts.
+
+        Reservation rows deliberately omit every GSI key. Normal receipt
+        listing therefore ignores them, while the shared receipt primary key
+        prevents another writer from claiming the same numeric ID.
+        """
+        self._validate_image_id(image_id)
+        if not receipt_ids or len(receipt_ids) > 23:
+            raise EntityValidationError(
+                "receipt_ids must contain between 1 and 23 IDs"
+            )
+        if len(set(receipt_ids)) != len(receipt_ids):
+            raise EntityValidationError("receipt_ids must be distinct")
+        if not operation_id:
+            raise EntityValidationError("operation_id is required")
+
+        transact_items = []
+        for receipt_id in receipt_ids:
+            self._validate_receipt_id(receipt_id)
+            transact_items.append(
+                {
+                    "Put": {
+                        "TableName": self.table_name,
+                        "Item": {
+                            "PK": {"S": f"IMAGE#{image_id}"},
+                            "SK": {"S": f"RECEIPT#{receipt_id:05d}"},
+                            "TYPE": {"S": "RESEGMENT_RESERVATION"},
+                            "operation_id": {"S": operation_id},
+                        },
+                        "ConditionExpression": (
+                            "attribute_not_exists(PK) OR "
+                            "(#type = :reservation AND operation_id = :operation_id)"
+                        ),
+                        "ExpressionAttributeNames": {"#type": "TYPE"},
+                        "ExpressionAttributeValues": {
+                            ":reservation": {"S": "RESEGMENT_RESERVATION"},
+                            ":operation_id": {"S": operation_id},
+                        },
+                    }
+                }
+            )
+        self._client.transact_write_items(TransactItems=transact_items)
+
+    @handle_dynamodb_errors("commit_receipt_resegmentation")
+    def commit_receipt_resegmentation(
+        self,
+        source_receipt: Receipt,
+        output_receipts: list[Receipt],
+        operation_id: str,
+    ) -> None:
+        """Atomically activate reserved outputs and remove the source parent."""
+        self._validate_entity(source_receipt, Receipt, "source_receipt")
+        self._validate_entity_list(output_receipts, Receipt, "output_receipts")
+        if len(output_receipts) > 23:
+            raise EntityValidationError(
+                "A re-segmentation can create at most 23 receipts"
+            )
+        if not operation_id:
+            raise EntityValidationError("operation_id is required")
+
+        transact_items = []
+        for receipt in output_receipts:
+            transact_items.append(
+                {
+                    "Put": {
+                        "TableName": self.table_name,
+                        "Item": receipt.to_item(),
+                        "ConditionExpression": (
+                            "#type = :reservation AND "
+                            "operation_id = :operation_id"
+                        ),
+                        "ExpressionAttributeNames": {"#type": "TYPE"},
+                        "ExpressionAttributeValues": {
+                            ":reservation": {"S": "RESEGMENT_RESERVATION"},
+                            ":operation_id": {"S": operation_id},
+                        },
+                    }
+                }
+            )
+        transact_items.append(
+            {
+                "Delete": {
+                    "TableName": self.table_name,
+                    "Key": source_receipt.key,
+                    "ConditionExpression": "timestamp_added = :timestamp",
+                    "ExpressionAttributeValues": {
+                        ":timestamp": {"S": source_receipt.timestamp_added}
+                    },
+                }
+            }
+        )
+        self._client.transact_write_items(TransactItems=transact_items)
+
+    @handle_dynamodb_errors("delete_receipt_items")
+    def delete_receipt_items(
+        self,
+        image_id: str,
+        receipt_id: int,
+        *,
+        include_parent: bool = True,
+    ) -> int:
+        """Delete every row beneath a receipt primary-key prefix.
+
+        This intentionally deletes concrete child rows so DynamoDB stream
+        consumers receive word and line removal events for vector cleanup.
+        The operation is idempotent and paginates the full partition prefix.
+        """
+        self._validate_image_id(image_id)
+        self._validate_receipt_id(receipt_id)
+        parent_sk = f"RECEIPT#{receipt_id:05d}"
+        items: list[dict[str, Any]] = []
+        exclusive_start_key = None
+
+        while True:
+            params: dict[str, Any] = {
+                "TableName": self.table_name,
+                "KeyConditionExpression": (
+                    "PK = :pk AND begins_with(SK, :receipt_prefix)"
+                ),
+                "ExpressionAttributeValues": {
+                    ":pk": {"S": f"IMAGE#{image_id}"},
+                    ":receipt_prefix": {"S": parent_sk},
+                },
+                "ProjectionExpression": "PK, SK",
+            }
+            if exclusive_start_key:
+                params["ExclusiveStartKey"] = exclusive_start_key
+            response = self._client.query(**params)
+            items.extend(response.get("Items", []))
+            exclusive_start_key = response.get("LastEvaluatedKey")
+            if not exclusive_start_key:
+                break
+
+        requests = []
+        for item in items:
+            if not include_parent and item["SK"]["S"] == parent_sk:
+                continue
+            requests.append(
+                WriteRequestTypeDef(
+                    DeleteRequest=DeleteRequestTypeDef(
+                        Key={"PK": item["PK"], "SK": item["SK"]}
+                    )
+                )
+            )
+        if requests:
+            self._batch_write_with_retry(requests)
+        return len(requests)
+
+    @handle_dynamodb_errors("get_receipt_item_type_counts")
+    def get_receipt_item_type_counts(
+        self, image_id: str, receipt_id: int
+    ) -> dict[str, int]:
+        """Count all entity types stored below a receipt key prefix."""
+        self._validate_image_id(image_id)
+        self._validate_receipt_id(receipt_id)
+        counts: Counter[str] = Counter()
+        exclusive_start_key = None
+        while True:
+            params: dict[str, Any] = {
+                "TableName": self.table_name,
+                "KeyConditionExpression": (
+                    "PK = :pk AND begins_with(SK, :receipt_prefix)"
+                ),
+                "ExpressionAttributeValues": {
+                    ":pk": {"S": f"IMAGE#{image_id}"},
+                    ":receipt_prefix": {"S": f"RECEIPT#{receipt_id:05d}"},
+                },
+                "ProjectionExpression": "#type",
+                "ExpressionAttributeNames": {"#type": "TYPE"},
+            }
+            if exclusive_start_key:
+                params["ExclusiveStartKey"] = exclusive_start_key
+            response = self._client.query(**params)
+            for item in response.get("Items", []):
+                counts[item.get("TYPE", {}).get("S", "UNKNOWN")] += 1
+            exclusive_start_key = response.get("LastEvaluatedKey")
+            if not exclusive_start_key:
+                break
+        return dict(sorted(counts.items()))
+
+    @handle_dynamodb_errors("release_receipt_id_reservations")
+    def release_receipt_id_reservations(
+        self,
+        image_id: str,
+        receipt_ids: list[int],
+        operation_id: str,
+    ) -> None:
+        """Remove staged children and reservations owned by an operation."""
+        for receipt_id in receipt_ids:
+            self.delete_receipt_items(
+                image_id, receipt_id, include_parent=False
+            )
+
+        transact_items = [
+            {
+                "Delete": {
+                    "TableName": self.table_name,
+                    "Key": {
+                        "PK": {"S": f"IMAGE#{image_id}"},
+                        "SK": {"S": f"RECEIPT#{receipt_id:05d}"},
+                    },
+                    "ConditionExpression": (
+                        "#type = :reservation AND "
+                        "operation_id = :operation_id"
+                    ),
+                    "ExpressionAttributeNames": {"#type": "TYPE"},
+                    "ExpressionAttributeValues": {
+                        ":reservation": {"S": "RESEGMENT_RESERVATION"},
+                        ":operation_id": {"S": operation_id},
+                    },
+                }
+            }
+            for receipt_id in receipt_ids
+        ]
+        if transact_items:
+            self._client.transact_write_items(TransactItems=transact_items)
 
     @handle_dynamodb_errors("get_receipt")
     def get_receipt(self, image_id: str, receipt_id: int) -> Receipt:

--- a/receipt_dynamo/receipt_dynamo/data/_receipt.py
+++ b/receipt_dynamo/receipt_dynamo/data/_receipt.py
@@ -364,8 +364,9 @@ class _Receipt(FlattenedStandardMixin):
                         "SK": {"S": f"RECEIPT#{receipt_id:05d}"},
                     },
                     "ConditionExpression": (
-                        "#type = :reservation AND "
-                        "operation_id = :operation_id"
+                        "attribute_not_exists(PK) OR "
+                        "(#type = :reservation AND "
+                        "operation_id = :operation_id)"
                     ),
                     "ExpressionAttributeNames": {"#type": "TYPE"},
                     "ExpressionAttributeValues": {

--- a/receipt_dynamo/receipt_dynamo/data/_receipt.py
+++ b/receipt_dynamo/receipt_dynamo/data/_receipt.py
@@ -349,12 +349,13 @@ class _Receipt(FlattenedStandardMixin):
         receipt_ids: list[int],
         operation_id: str,
     ) -> None:
-        """Remove staged children and reservations owned by an operation."""
-        for receipt_id in receipt_ids:
-            self.delete_receipt_items(
-                image_id, receipt_id, include_parent=False
-            )
+        """Remove staged children and reservations owned by an operation.
 
+        The guarded reservation delete runs FIRST: if any parent row is a
+        committed receipt (the commit transaction actually landed, or a
+        concurrent apply won), the whole release fails before any child
+        rows are touched, so a rollback can never destroy committed data.
+        """
         transact_items = [
             {
                 "Delete": {
@@ -379,6 +380,10 @@ class _Receipt(FlattenedStandardMixin):
         ]
         if transact_items:
             self._client.transact_write_items(TransactItems=transact_items)
+        for receipt_id in receipt_ids:
+            self.delete_receipt_items(
+                image_id, receipt_id, include_parent=False
+            )
 
     @handle_dynamodb_errors("get_receipt")
     def get_receipt(self, image_id: str, receipt_id: int) -> Receipt:

--- a/receipt_dynamo/receipt_dynamo/data/_receipt_letter.py
+++ b/receipt_dynamo/receipt_dynamo/data/_receipt_letter.py
@@ -52,6 +52,8 @@ class _ReceiptLetter(FlattenedStandardMixin):
         Returns ReceiptLetters and the last evaluated key.
     list_receipt_letters_from_word(...) -> list[ReceiptLetter]:
         Returns all ReceiptLetters for a given word.
+    list_receipt_letters_from_receipt(...) -> list[ReceiptLetter]:
+        Returns all ReceiptLetters for a receipt in one consistent query.
     """
 
     @handle_dynamodb_errors("add_receipt_letter")
@@ -476,3 +478,39 @@ class _ReceiptLetter(FlattenedStandardMixin):
             ),
             converter_func=item_to_receipt_letter,
         )
+
+    @handle_dynamodb_errors("list_receipt_letters_from_receipt")
+    def list_receipt_letters_from_receipt(
+        self, image_id: str, receipt_id: int
+    ) -> list[ReceiptLetter]:
+        """Return all receipt letters with one strongly consistent PK query.
+
+        ``get_receipt_details`` intentionally excludes letters. Re-segmentation
+        needs the complete hierarchy for evidence and source fingerprinting,
+        so querying each word separately would be both expensive and prone to
+        observing different snapshots.
+        """
+        self._validate_image_id(image_id)
+        self._validate_positive_int_id(receipt_id, "receipt_id")
+        letters: list[ReceiptLetter] = []
+        last_key = None
+        while True:
+            params = {
+                "TableName": self.table_name,
+                "KeyConditionExpression": "PK = :pk AND begins_with(SK, :sk)",
+                "ExpressionAttributeValues": {
+                    ":pk": {"S": f"IMAGE#{image_id}"},
+                    ":sk": {"S": f"RECEIPT#{receipt_id:05d}#LINE#"},
+                },
+                "ConsistentRead": True,
+            }
+            if last_key:
+                params["ExclusiveStartKey"] = last_key
+            response = self._client.query(**params)
+            for item in response.get("Items", []):
+                if item.get("TYPE", {}).get("S") == "RECEIPT_LETTER":
+                    letters.append(item_to_receipt_letter(item))
+            last_key = response.get("LastEvaluatedKey")
+            if not last_key:
+                break
+        return letters

--- a/receipt_dynamo/tests/integration/test__receipt_resegment.py
+++ b/receipt_dynamo/tests/integration/test__receipt_resegment.py
@@ -1,0 +1,129 @@
+"""Integration tests for receipt ID reservation and atomic activation."""
+
+from datetime import datetime, timezone
+from uuid import uuid4
+
+import boto3
+import pytest
+
+from receipt_dynamo import DynamoClient, Receipt, ReceiptLetter, ReceiptWord
+from receipt_dynamo.data.shared_exceptions import (
+    DynamoDBError,
+    EntityNotFoundError,
+)
+
+
+def _receipt(image_id: str, receipt_id: int) -> Receipt:
+    return Receipt(
+        image_id=image_id,
+        receipt_id=receipt_id,
+        width=100,
+        height=200,
+        timestamp_added=datetime.now(timezone.utc),
+        raw_s3_bucket="raw-bucket",
+        raw_s3_key=f"receipts/{image_id}/{receipt_id}.png",
+        top_left={"x": 0.0, "y": 1.0},
+        top_right={"x": 1.0, "y": 1.0},
+        bottom_left={"x": 0.0, "y": 0.0},
+        bottom_right={"x": 1.0, "y": 0.0},
+    )
+
+
+@pytest.mark.integration
+def test_reservations_are_hidden_and_commit_is_atomic(dynamodb_table):
+    image_id = str(uuid4())
+    operation_id = str(uuid4())
+    client = DynamoClient(dynamodb_table)
+    source = _receipt(image_id, 1)
+    outputs = [_receipt(image_id, 2), _receipt(image_id, 3)]
+    client.add_receipt(source)
+
+    client.reserve_receipt_ids(image_id, [2, 3], operation_id)
+    client.reserve_receipt_ids(image_id, [2, 3], operation_id)
+    with pytest.raises(DynamoDBError):
+        client.reserve_receipt_ids(image_id, [2, 3], str(uuid4()))
+    assert [
+        receipt.receipt_id
+        for receipt in client.get_receipts_from_image(image_id)
+    ] == [1]
+
+    client.commit_receipt_resegmentation(source, outputs, operation_id)
+    assert sorted(
+        receipt.receipt_id
+        for receipt in client.get_receipts_from_image(image_id)
+    ) == [2, 3]
+    with pytest.raises(EntityNotFoundError):
+        client.get_receipt(image_id, 1)
+
+
+@pytest.mark.integration
+def test_release_removes_staged_children_and_reservation(dynamodb_table):
+    image_id = str(uuid4())
+    operation_id = str(uuid4())
+    client = DynamoClient(dynamodb_table)
+    client.reserve_receipt_ids(image_id, [2], operation_id)
+    client.add_receipt_word(
+        ReceiptWord(
+            image_id=image_id,
+            receipt_id=2,
+            line_id=1,
+            word_id=1,
+            text="staged",
+            bounding_box={"x": 0.1, "y": 0.1, "width": 0.1, "height": 0.1},
+            top_left={"x": 0.1, "y": 0.2},
+            top_right={"x": 0.2, "y": 0.2},
+            bottom_left={"x": 0.1, "y": 0.1},
+            bottom_right={"x": 0.2, "y": 0.1},
+            angle_degrees=0.0,
+            angle_radians=0.0,
+            confidence=1.0,
+        )
+    )
+
+    client.release_receipt_id_reservations(image_id, [2], operation_id)
+
+    raw_client = boto3.client("dynamodb", region_name="us-east-1")
+    response = raw_client.query(
+        TableName=dynamodb_table,
+        KeyConditionExpression="PK = :pk AND begins_with(SK, :prefix)",
+        ExpressionAttributeValues={
+            ":pk": {"S": f"IMAGE#{image_id}"},
+            ":prefix": {"S": "RECEIPT#00002"},
+        },
+    )
+    assert response["Items"] == []
+
+
+@pytest.mark.integration
+def test_bulk_receipt_letter_snapshot_filters_one_receipt(dynamodb_table):
+    image_id = str(uuid4())
+    client = DynamoClient(dynamodb_table)
+    geometry = {
+        "bounding_box": {"x": 0.1, "y": 0.1, "width": 0.05, "height": 0.1},
+        "top_left": {"x": 0.1, "y": 0.2},
+        "top_right": {"x": 0.15, "y": 0.2},
+        "bottom_left": {"x": 0.1, "y": 0.1},
+        "bottom_right": {"x": 0.15, "y": 0.1},
+        "angle_degrees": 0.0,
+        "angle_radians": 0.0,
+        "confidence": 1.0,
+    }
+    letters = [
+        ReceiptLetter(
+            image_id=image_id,
+            receipt_id=receipt_id,
+            line_id=1,
+            word_id=1,
+            letter_id=1,
+            text=text,
+            **geometry,
+        )
+        for receipt_id, text in ((1, "A"), (2, "B"))
+    ]
+    client.add_receipt_letters(letters)
+
+    result = client.list_receipt_letters_from_receipt(image_id, 1)
+
+    assert [(letter.receipt_id, letter.text) for letter in result] == [
+        (1, "A")
+    ]

--- a/receipt_dynamo/tests/integration/test__receipt_resegment.py
+++ b/receipt_dynamo/tests/integration/test__receipt_resegment.py
@@ -107,14 +107,34 @@ def test_release_is_idempotent_but_never_deletes_receipts(dynamodb_table):
     client.release_receipt_id_reservations(image_id, [2], operation_id)
     client.release_receipt_id_reservations(image_id, [2], operation_id)
 
-    # A committed receipt occupying the same key must never be deleted.
+    # A committed receipt occupying the same key must never be deleted,
+    # and the guarded parent delete must fail BEFORE any child rows are
+    # touched (a rollback racing a landed commit must not destroy data).
     client.add_receipt(_receipt(image_id, 2))
+    client.add_receipt_word(
+        ReceiptWord(
+            image_id=image_id,
+            receipt_id=2,
+            line_id=1,
+            word_id=1,
+            text="committed",
+            bounding_box={"x": 0.1, "y": 0.1, "width": 0.1, "height": 0.1},
+            top_left={"x": 0.1, "y": 0.2},
+            top_right={"x": 0.2, "y": 0.2},
+            bottom_left={"x": 0.1, "y": 0.1},
+            bottom_right={"x": 0.2, "y": 0.1},
+            angle_degrees=0.0,
+            angle_radians=0.0,
+            confidence=1.0,
+        )
+    )
     with pytest.raises(DynamoDBError):
         client.release_receipt_id_reservations(image_id, [2], operation_id)
     assert [
         receipt.receipt_id
         for receipt in client.get_receipts_from_image(image_id)
     ] == [2]
+    assert len(client.get_receipt_details(image_id, 2).words) == 1
 
 
 @pytest.mark.integration

--- a/receipt_dynamo/tests/integration/test__receipt_resegment.py
+++ b/receipt_dynamo/tests/integration/test__receipt_resegment.py
@@ -95,6 +95,29 @@ def test_release_removes_staged_children_and_reservation(dynamodb_table):
 
 
 @pytest.mark.integration
+def test_release_is_idempotent_but_never_deletes_receipts(dynamodb_table):
+    image_id = str(uuid4())
+    operation_id = str(uuid4())
+    client = DynamoClient(dynamodb_table)
+
+    # Releasing reservations that never existed (or were already released)
+    # must succeed so a crashed apply can always be retried.
+    client.release_receipt_id_reservations(image_id, [2, 3], operation_id)
+    client.reserve_receipt_ids(image_id, [2], operation_id)
+    client.release_receipt_id_reservations(image_id, [2], operation_id)
+    client.release_receipt_id_reservations(image_id, [2], operation_id)
+
+    # A committed receipt occupying the same key must never be deleted.
+    client.add_receipt(_receipt(image_id, 2))
+    with pytest.raises(DynamoDBError):
+        client.release_receipt_id_reservations(image_id, [2], operation_id)
+    assert [
+        receipt.receipt_id
+        for receipt in client.get_receipts_from_image(image_id)
+    ] == [2]
+
+
+@pytest.mark.integration
 def test_bulk_receipt_letter_snapshot_filters_one_receipt(dynamodb_table):
     image_id = str(uuid4())
     client = DynamoClient(dynamodb_table)

--- a/receipt_upload/receipt_upload/combine/geometry_utils.py
+++ b/receipt_upload/receipt_upload/combine/geometry_utils.py
@@ -17,7 +17,10 @@ IMAGE_PROCESSING_AVAILABLE = True
 
 
 def calculate_min_area_rect(
-    words: List[Dict[str, Any]], image_width: int, image_height: int
+    words: List[Dict[str, Any]],
+    image_width: int,
+    image_height: int,
+    padding_px: float = 0.0,
 ) -> Dict[str, Any]:
     """
     Calculate the minimum-area rectangle covering all words and return bounds + warping info.
@@ -64,6 +67,11 @@ def calculate_min_area_rect(
     if rw > rh:
         angle_deg -= 90.0
         rw, rh = rh, rw
+
+    if padding_px < 0:
+        raise ValueError("padding_px cannot be negative")
+    rw += 2.0 * padding_px
+    rh += 2.0 * padding_px
 
     # Get the 4 corners of the min-area rect
     box_4 = box_points((cx, cy), (rw, rh), angle_deg)

--- a/receipt_upload/receipt_upload/combine/records_builder.py
+++ b/receipt_upload/receipt_upload/combine/records_builder.py
@@ -82,6 +82,7 @@ def combine_receipt_words_to_image_coords(
     receipt_ids: List[int],
     image_width: int,
     image_height: int,
+    deduplicate: bool = True,
 ) -> List[Dict[str, Any]]:
     """
     Combine words from multiple receipts and transform to image coordinates.
@@ -186,6 +187,9 @@ def combine_receipt_words_to_image_coords(
             )
 
     all_words.sort(key=lambda w: (-w["centroid_y"], w["centroid_x"]))
+
+    if not deduplicate:
+        return all_words
 
     # Deduplicate words with identical coordinates (OCR duplicates)
     # This handles cases where the same word was detected on multiple lines
@@ -402,57 +406,9 @@ def create_combined_receipt_records(
     receipt_width = warped_width
     receipt_height = warped_height
 
-    # Transform receipt corners from original image space to warped space
-    # Convert OCR space bounds to PIL space for transformation
-    top_left_ocr = bounds["top_left"]
-    top_right_ocr = bounds["top_right"]
-    bottom_left_ocr = bounds["bottom_left"]
-    bottom_right_ocr = bounds["bottom_right"]
-
-    # Convert to PIL space (y=0 at top)
-    top_left_pil = (top_left_ocr["x"], image_height - top_left_ocr["y"])
-    top_right_pil = (top_right_ocr["x"], image_height - top_right_ocr["y"])
-    bottom_left_pil = (
-        bottom_left_ocr["x"],
-        image_height - bottom_left_ocr["y"],
-    )
-    bottom_right_pil = (
-        bottom_right_ocr["x"],
-        image_height - bottom_right_ocr["y"],
-    )
-
-    # Transform to warped space
-    top_left_warped = transform_point_to_warped_space(
-        top_left_pil[0],
-        top_left_pil[1],
-        src_corners,
-        warped_width,
-        warped_height,
-    )
-    top_right_warped = transform_point_to_warped_space(
-        top_right_pil[0],
-        top_right_pil[1],
-        src_corners,
-        warped_width,
-        warped_height,
-    )
-    bottom_left_warped = transform_point_to_warped_space(
-        bottom_left_pil[0],
-        bottom_left_pil[1],
-        src_corners,
-        warped_width,
-        warped_height,
-    )
-    bottom_right_warped = transform_point_to_warped_space(
-        bottom_right_pil[0],
-        bottom_right_pil[1],
-        src_corners,
-        warped_width,
-        warped_height,
-    )
-
-    # Create Receipt entity with corners in warped space, normalized (0-1)
-    # Receipt coordinates use OCR space (y=0 at bottom), so convert back
+    # Receipt corners locate the crop on the original image. Keep the
+    # min-area rectangle in original-image OCR coordinates; normalizing it to
+    # the warped crop would make any later receipt->image transform incorrect.
     receipt = Receipt(
         image_id=image_id,
         receipt_id=new_receipt_id,
@@ -464,48 +420,20 @@ def create_combined_receipt_records(
         # Receipt corners in normalized warped space (0-1),
         # OCR coordinate system (y=0 at bottom)
         top_left={
-            "x": (
-                top_left_warped[0] / warped_width if warped_width > 0 else 0.0
-            ),
-            "y": (
-                (warped_height - top_left_warped[1]) / warped_height
-                if warped_height > 0
-                else 0.0
-            ),  # Convert to OCR space
+            "x": bounds["top_left"]["x"] / image_width,
+            "y": bounds["top_left"]["y"] / image_height,
         },
         top_right={
-            "x": (
-                top_right_warped[0] / warped_width if warped_width > 0 else 1.0
-            ),
-            "y": (
-                (warped_height - top_right_warped[1]) / warped_height
-                if warped_height > 0
-                else 0.0
-            ),
+            "x": bounds["top_right"]["x"] / image_width,
+            "y": bounds["top_right"]["y"] / image_height,
         },
         bottom_left={
-            "x": (
-                bottom_left_warped[0] / warped_width
-                if warped_width > 0
-                else 0.0
-            ),
-            "y": (
-                (warped_height - bottom_left_warped[1]) / warped_height
-                if warped_height > 0
-                else 1.0
-            ),
+            "x": bounds["bottom_left"]["x"] / image_width,
+            "y": bounds["bottom_left"]["y"] / image_height,
         },
         bottom_right={
-            "x": (
-                bottom_right_warped[0] / warped_width
-                if warped_width > 0
-                else 1.0
-            ),
-            "y": (
-                (warped_height - bottom_right_warped[1]) / warped_height
-                if warped_height > 0
-                else 1.0
-            ),
+            "x": bounds["bottom_right"]["x"] / image_width,
+            "y": bounds["bottom_right"]["y"] / image_height,
         },
         sha256=None,  # Will be calculated and set when image is uploaded
         cdn_s3_bucket=site_bucket,

--- a/receipt_upload/receipt_upload/resegment/__init__.py
+++ b/receipt_upload/receipt_upload/resegment/__init__.py
@@ -1,0 +1,19 @@
+"""Safe, line-first receipt re-segmentation planning and previews."""
+
+from receipt_upload.resegment.planner import (
+    ResegmentPlanError,
+    build_source_fingerprint,
+    compute_plan_hash,
+    normalize_line_resegmentation_plan,
+    normalize_resegmentation_plan,
+)
+from receipt_upload.resegment.preview import build_preview_bundle
+
+__all__ = [
+    "ResegmentPlanError",
+    "build_source_fingerprint",
+    "build_preview_bundle",
+    "compute_plan_hash",
+    "normalize_line_resegmentation_plan",
+    "normalize_resegmentation_plan",
+]

--- a/receipt_upload/receipt_upload/resegment/planner.py
+++ b/receipt_upload/receipt_upload/resegment/planner.py
@@ -460,6 +460,18 @@ def normalize_line_resegmentation_plan(
             "Every line must have one default destination; unassigned lines: "
             f"{unassigned_lines}"
         )
+    wordless_assigned = sorted(
+        line_id
+        for line_id in default_owner_by_line
+        if not refs_by_line.get(line_id)
+    )
+    if wordless_assigned:
+        raise ResegmentPlanError(
+            "Lines without words cannot be assigned to a segment because "
+            "apply rebuilds outputs from words and would silently drop "
+            "them; discard these lines explicitly: "
+            f"{wordless_assigned}"
+        )
 
     owners: dict[WordRef, str | None] = {}
     for ref in known_refs:

--- a/receipt_upload/receipt_upload/resegment/planner.py
+++ b/receipt_upload/receipt_upload/resegment/planner.py
@@ -1,0 +1,797 @@
+"""Pure planning utilities for splitting one receipt into new segments."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections import Counter, defaultdict
+from collections.abc import Iterable, Mapping
+from copy import deepcopy
+from typing import Any
+
+WordRef = tuple[int, int]
+LetterRef = tuple[int, int, int]
+
+
+class ResegmentPlanError(ValueError):
+    """Raised when a re-segmentation request is ambiguous or unsafe."""
+
+
+def _value(entity: Any, name: str, default: Any = None) -> Any:
+    if isinstance(entity, Mapping):
+        return entity.get(name, default)
+    return getattr(entity, name, default)
+
+
+def _word_ref(entity: Any) -> WordRef:
+    return int(_value(entity, "line_id")), int(_value(entity, "word_id"))
+
+
+def _line_id(entity: Any) -> int:
+    return int(_value(entity, "line_id"))
+
+
+def _letter_ref(entity: Any) -> LetterRef:
+    line_id, word_id = _word_ref(entity)
+    return line_id, word_id, int(_value(entity, "letter_id"))
+
+
+def _ref_dict(ref: WordRef) -> dict[str, int]:
+    return {"line_id": ref[0], "word_id": ref[1]}
+
+
+def _parse_word_refs(raw_refs: Iterable[Mapping[str, Any]]) -> set[WordRef]:
+    refs: set[WordRef] = set()
+    for raw_ref in raw_refs:
+        line_id = int(raw_ref["line_id"])
+        word_ids = raw_ref.get("word_ids")
+        has_word_id = "word_id" in raw_ref
+        if word_ids is not None and has_word_id:
+            raise ResegmentPlanError(
+                "A word reference must use word_id or word_ids, not both"
+            )
+        if word_ids is None and not has_word_id:
+            raise ResegmentPlanError(
+                "A word reference requires either word_id or word_ids"
+            )
+        if word_ids is None:
+            word_ids = [raw_ref["word_id"]]
+        refs.update((line_id, int(word_id)) for word_id in word_ids)
+    return refs
+
+
+def _expand_selection(
+    *,
+    line_ids: Iterable[int],
+    raw_word_refs: Iterable[Mapping[str, Any]],
+    refs_by_line: Mapping[int, set[WordRef]],
+    known_refs: set[WordRef],
+    destination: str,
+) -> set[WordRef]:
+    selected: set[WordRef] = set()
+    requested_lines = {int(line_id) for line_id in line_ids}
+    unknown_lines = sorted(requested_lines - set(refs_by_line))
+    if unknown_lines:
+        raise ResegmentPlanError(
+            f"{destination} references unknown line_ids: {unknown_lines}"
+        )
+    for line_id in requested_lines:
+        selected.update(refs_by_line[line_id])
+
+    explicit_refs = _parse_word_refs(raw_word_refs)
+    unknown_refs = sorted(explicit_refs - known_refs)
+    if unknown_refs:
+        rendered = [_ref_dict(ref) for ref in unknown_refs]
+        raise ResegmentPlanError(
+            f"{destination} references unknown words: {rendered}"
+        )
+    selected.update(explicit_refs)
+    return selected
+
+
+def _labels_by_ref(labels: Iterable[Any]) -> dict[WordRef, list[Any]]:
+    grouped: dict[WordRef, list[Any]] = defaultdict(list)
+    for label in labels:
+        grouped[_word_ref(label)].append(label)
+    return grouped
+
+
+def normalize_resegmentation_plan(
+    *,
+    words: Iterable[Any],
+    labels: Iterable[Any],
+    segments: Iterable[Mapping[str, Any]],
+    discard_line_ids: Iterable[int] = (),
+    discard_word_refs: Iterable[Mapping[str, Any]] = (),
+    discard_reason: str | None = None,
+    allow_labeled_discard: bool = False,
+) -> dict[str, Any]:
+    """Expand line shorthands into a complete, validated word assignment.
+
+    Every source word must land in exactly one output segment or in the
+    explicit discard bucket. The returned word references are canonical and
+    suitable for hashing and later apply-time verification.
+    """
+    source_words = list(words)
+    source_labels = list(labels)
+    if not source_words:
+        raise ResegmentPlanError("The source receipt has no words")
+
+    known_refs = {_word_ref(word) for word in source_words}
+    if len(known_refs) != len(source_words):
+        raise ResegmentPlanError(
+            "The source receipt contains duplicate word keys"
+        )
+
+    refs_by_line: dict[int, set[WordRef]] = defaultdict(set)
+    for ref in known_refs:
+        refs_by_line[ref[0]].add(ref)
+
+    labels_by_ref = _labels_by_ref(source_labels)
+    orphan_label_refs = sorted(set(labels_by_ref) - known_refs)
+    if orphan_label_refs:
+        raise ResegmentPlanError(
+            "The source receipt contains labels without matching words: "
+            f"{[_ref_dict(ref) for ref in orphan_label_refs]}"
+        )
+    normalized_segments: list[dict[str, Any]] = []
+    owners: dict[WordRef, str] = {}
+    segment_keys: set[str] = set()
+
+    for raw_segment in segments:
+        segment_key = str(raw_segment.get("segment_key", "")).strip()
+        if not segment_key:
+            raise ResegmentPlanError("Every segment requires a segment_key")
+        if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]{0,63}", segment_key):
+            raise ResegmentPlanError(
+                "segment_key must be 1-64 URL-safe characters and start "
+                "with a letter or number"
+            )
+        if segment_key in segment_keys:
+            raise ResegmentPlanError(f"Duplicate segment_key: {segment_key}")
+        segment_keys.add(segment_key)
+
+        selected = _expand_selection(
+            line_ids=raw_segment.get("include_line_ids", ()),
+            raw_word_refs=raw_segment.get("include_word_refs", ()),
+            refs_by_line=refs_by_line,
+            known_refs=known_refs,
+            destination=f"segment {segment_key}",
+        )
+        if not selected:
+            raise ResegmentPlanError(
+                f"Segment {segment_key} does not select any words"
+            )
+
+        duplicates = sorted(ref for ref in selected if ref in owners)
+        if duplicates:
+            rendered = [
+                {**_ref_dict(ref), "already_assigned_to": owners[ref]}
+                for ref in duplicates
+            ]
+            raise ResegmentPlanError(
+                f"Segment {segment_key} duplicates assignments: {rendered}"
+            )
+        for ref in selected:
+            owners[ref] = segment_key
+
+        status_counts = Counter(
+            str(_value(label, "validation_status", "NONE") or "NONE")
+            for ref in selected
+            for label in labels_by_ref.get(ref, ())
+        )
+        place_policy = (
+            str(raw_segment.get("place_policy", "none")).strip().lower()
+        )
+        if place_policy not in {"inherit", "none"}:
+            raise ResegmentPlanError(
+                f"Unsupported place_policy for segment {segment_key}: {place_policy}"
+            )
+        normalized_segments.append(
+            {
+                "segment_key": segment_key,
+                "word_refs": [_ref_dict(ref) for ref in sorted(selected)],
+                "word_count": len(selected),
+                "label_count": sum(status_counts.values()),
+                "label_status_counts": dict(sorted(status_counts.items())),
+                "place_policy": place_policy,
+            }
+        )
+
+    if not normalized_segments:
+        raise ResegmentPlanError("At least one output segment is required")
+    if len(normalized_segments) > 23:
+        raise ResegmentPlanError(
+            "A re-segmentation can create at most 23 segments"
+        )
+
+    discarded = _expand_selection(
+        line_ids=discard_line_ids,
+        raw_word_refs=discard_word_refs,
+        refs_by_line=refs_by_line,
+        known_refs=known_refs,
+        destination="discard bucket",
+    )
+    duplicate_discards = sorted(ref for ref in discarded if ref in owners)
+    if duplicate_discards:
+        rendered = [
+            {**_ref_dict(ref), "already_assigned_to": owners[ref]}
+            for ref in duplicate_discards
+        ]
+        raise ResegmentPlanError(
+            f"Discard bucket duplicates assignments: {rendered}"
+        )
+
+    unassigned = sorted(known_refs - set(owners) - discarded)
+    if unassigned:
+        raise ResegmentPlanError(
+            "Every word must be assigned or explicitly discarded; "
+            f"unassigned words: {[_ref_dict(ref) for ref in unassigned]}"
+        )
+
+    discarded_labels = [
+        label for ref in discarded for label in labels_by_ref.get(ref, ())
+    ]
+    protected_discarded_labels = [
+        label
+        for label in discarded_labels
+        if str(_value(label, "validation_status", "NONE") or "NONE").upper()
+        != "INVALID"
+    ]
+    if protected_discarded_labels and not allow_labeled_discard:
+        refs = sorted(
+            {_word_ref(label) for label in protected_discarded_labels}
+        )
+        raise ResegmentPlanError(
+            "Discarding labeled words requires allow_labeled_discard=true; "
+            f"labeled words: {[_ref_dict(ref) for ref in refs]}"
+        )
+    if discarded and not str(discard_reason or "").strip():
+        raise ResegmentPlanError(
+            "discard_reason is required when words are discarded"
+        )
+
+    return {
+        "segments": normalized_segments,
+        "discard": {
+            "word_refs": [_ref_dict(ref) for ref in sorted(discarded)],
+            "word_count": len(discarded),
+            "label_count": len(discarded_labels),
+            "reason": discard_reason,
+        },
+        "totals": {
+            "source_words": len(source_words),
+            "assigned_words": len(owners),
+            "discarded_words": len(discarded),
+            "source_labels": len(source_labels),
+            "preserved_labels": len(source_labels) - len(discarded_labels),
+            "discarded_labels": len(discarded_labels),
+        },
+    }
+
+
+def _validate_segment_definitions(
+    segments: Iterable[Mapping[str, Any]],
+) -> tuple[list[dict[str, Any]], set[str]]:
+    normalized = []
+    segment_keys: set[str] = set()
+    for raw_segment in segments:
+        segment_key = str(raw_segment.get("segment_key", "")).strip()
+        if not segment_key:
+            raise ResegmentPlanError("Every segment requires a segment_key")
+        if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]{0,63}", segment_key):
+            raise ResegmentPlanError(
+                "segment_key must be 1-64 URL-safe characters and start "
+                "with a letter or number"
+            )
+        if segment_key in segment_keys:
+            raise ResegmentPlanError(f"Duplicate segment_key: {segment_key}")
+        segment_keys.add(segment_key)
+
+        place_policy = (
+            str(raw_segment.get("place_policy", "none")).strip().lower()
+        )
+        if place_policy not in {"inherit", "none"}:
+            raise ResegmentPlanError(
+                f"Unsupported place_policy for segment {segment_key}: {place_policy}"
+            )
+        normalized.append(
+            {
+                "segment_key": segment_key,
+                "place_policy": place_policy,
+                "z_index": int(raw_segment.get("z_index", 0)),
+                "occluded_by": sorted(
+                    {
+                        str(value)
+                        for value in raw_segment.get("occluded_by", ())
+                    }
+                ),
+                "visible_regions": deepcopy(
+                    raw_segment.get("visible_regions", [])
+                ),
+            }
+        )
+    if not normalized:
+        raise ResegmentPlanError("At least one output segment is required")
+    if len(normalized) > 23:
+        raise ResegmentPlanError(
+            "A re-segmentation can create at most 23 segments"
+        )
+    for segment in normalized:
+        unknown = sorted(set(segment["occluded_by"]) - segment_keys)
+        if unknown:
+            raise ResegmentPlanError(
+                f"Segment {segment['segment_key']} has unknown occluded_by values: "
+                f"{unknown}"
+            )
+        if segment["segment_key"] in segment["occluded_by"]:
+            raise ResegmentPlanError(
+                f"Segment {segment['segment_key']} cannot occlude itself"
+            )
+    return normalized, segment_keys
+
+
+def _ensure_contiguous_word_span(
+    refs: set[WordRef],
+    refs_by_line: Mapping[int, set[WordRef]],
+    destination: str,
+) -> None:
+    by_line: dict[int, list[int]] = defaultdict(list)
+    for line_id, word_id in refs:
+        by_line[line_id].append(word_id)
+    for line_id, word_ids in by_line.items():
+        ordered_source = sorted(
+            word_id for _, word_id in refs_by_line[line_id]
+        )
+        positions = sorted(
+            ordered_source.index(word_id) for word_id in word_ids
+        )
+        if positions != list(range(positions[0], positions[-1] + 1)):
+            raise ResegmentPlanError(
+                f"{destination} must be a contiguous word span on line {line_id}"
+            )
+
+
+def normalize_line_resegmentation_plan(
+    *,
+    lines: Iterable[Any],
+    words: Iterable[Any],
+    labels: Iterable[Any],
+    segments: Iterable[Mapping[str, Any]],
+    assignments: Mapping[str, Any],
+    letters: Iterable[Any] = (),
+) -> dict[str, Any]:
+    """Normalize a v2 line-first plan with sparse mixed-line word overrides.
+
+    Every source line receives one default destination (an output segment or
+    discard). Words inherit that destination unless explicitly moved by a
+    contiguous word override. Letters are intentionally not assignable: they
+    always follow their parent word during apply.
+    """
+    source_lines = list(lines)
+    source_words = list(words)
+    source_letters = list(letters)
+    source_labels = list(labels)
+    if not source_lines:
+        raise ResegmentPlanError("The source receipt has no lines")
+    if not source_words:
+        raise ResegmentPlanError("The source receipt has no words")
+
+    known_line_ids = {_line_id(line) for line in source_lines}
+    if len(known_line_ids) != len(source_lines):
+        raise ResegmentPlanError(
+            "The source receipt contains duplicate line keys"
+        )
+    known_refs = {_word_ref(word) for word in source_words}
+    if len(known_refs) != len(source_words):
+        raise ResegmentPlanError(
+            "The source receipt contains duplicate word keys"
+        )
+
+    refs_by_line: dict[int, set[WordRef]] = defaultdict(set)
+    for ref in known_refs:
+        if ref[0] not in known_line_ids:
+            raise ResegmentPlanError(
+                f"The source receipt contains a word for unknown line {ref[0]}"
+            )
+        refs_by_line[ref[0]].add(ref)
+
+    known_letter_refs = {_letter_ref(letter) for letter in source_letters}
+    if len(known_letter_refs) != len(source_letters):
+        raise ResegmentPlanError(
+            "The source receipt contains duplicate letter keys"
+        )
+    orphan_letter_refs = sorted(
+        letter_ref
+        for letter_ref in known_letter_refs
+        if letter_ref[:2] not in known_refs
+    )
+    if orphan_letter_refs:
+        raise ResegmentPlanError(
+            "The source receipt contains letters without matching words: "
+            f"{orphan_letter_refs}"
+        )
+    letter_counts_by_ref = Counter(
+        letter_ref[:2] for letter_ref in known_letter_refs
+    )
+
+    normalized_segments, segment_keys = _validate_segment_definitions(segments)
+    default_owner_by_line: dict[int, str] = {}
+    canonical_line_assignments = []
+    for raw_assignment in assignments.get("lines", ()):
+        line_id = int(raw_assignment["line_id"])
+        segment_key = str(raw_assignment.get("segment_key", "")).strip()
+        if line_id not in known_line_ids:
+            raise ResegmentPlanError(
+                f"Line assignment references unknown line {line_id}"
+            )
+        if segment_key not in segment_keys:
+            raise ResegmentPlanError(
+                f"Line {line_id} references unknown segment {segment_key}"
+            )
+        if line_id in default_owner_by_line:
+            raise ResegmentPlanError(
+                f"Line {line_id} has duplicate assignments"
+            )
+        default_owner_by_line[line_id] = segment_key
+        canonical_line_assignments.append(
+            {"line_id": line_id, "segment_key": segment_key}
+        )
+
+    discarded_line_ids = {
+        int(value) for value in assignments.get("discard_lines", ())
+    }
+    unknown_discard_lines = sorted(discarded_line_ids - known_line_ids)
+    if unknown_discard_lines:
+        raise ResegmentPlanError(
+            f"Discard bucket references unknown line_ids: {unknown_discard_lines}"
+        )
+    duplicate_lines = sorted(discarded_line_ids & set(default_owner_by_line))
+    if duplicate_lines:
+        raise ResegmentPlanError(
+            f"Lines cannot be both assigned and discarded: {duplicate_lines}"
+        )
+    unassigned_lines = sorted(
+        known_line_ids - set(default_owner_by_line) - discarded_line_ids
+    )
+    if unassigned_lines:
+        raise ResegmentPlanError(
+            "Every line must have one default destination; unassigned lines: "
+            f"{unassigned_lines}"
+        )
+
+    owners: dict[WordRef, str | None] = {}
+    for ref in known_refs:
+        owners[ref] = default_owner_by_line.get(ref[0])
+
+    canonical_overrides = []
+    overridden: set[WordRef] = set()
+    for raw_override in assignments.get("words", ()):
+        segment_key = str(raw_override.get("segment_key", "")).strip()
+        if segment_key not in segment_keys:
+            raise ResegmentPlanError(
+                f"Word override references unknown segment {segment_key}"
+            )
+        reason = str(raw_override.get("reason", "")).strip()
+        if not reason:
+            raise ResegmentPlanError("Every word override requires a reason")
+        refs = _parse_word_refs([raw_override])
+        unknown_refs = sorted(refs - known_refs)
+        if unknown_refs:
+            raise ResegmentPlanError(
+                f"Word override references unknown words: "
+                f"{[_ref_dict(ref) for ref in unknown_refs]}"
+            )
+        _ensure_contiguous_word_span(refs, refs_by_line, "Word override")
+        duplicates = sorted(refs & overridden)
+        if duplicates:
+            raise ResegmentPlanError(
+                f"Words have duplicate overrides: "
+                f"{[_ref_dict(ref) for ref in duplicates]}"
+            )
+        redundant = sorted(ref for ref in refs if owners[ref] == segment_key)
+        if redundant:
+            raise ResegmentPlanError(
+                f"Word overrides must change the line default: "
+                f"{[_ref_dict(ref) for ref in redundant]}"
+            )
+        for ref in refs:
+            owners[ref] = segment_key
+        overridden.update(refs)
+        canonical_overrides.append(
+            {
+                "line_id": next(iter(refs))[0],
+                "word_ids": sorted(ref[1] for ref in refs),
+                "segment_key": segment_key,
+                "reason": reason,
+            }
+        )
+
+    discarded_word_refs = _parse_word_refs(
+        assignments.get("discard_words", ())
+    )
+    unknown_discard_refs = sorted(discarded_word_refs - known_refs)
+    if unknown_discard_refs:
+        raise ResegmentPlanError(
+            f"Discard bucket references unknown words: "
+            f"{[_ref_dict(ref) for ref in unknown_discard_refs]}"
+        )
+    _ensure_contiguous_word_span(
+        discarded_word_refs, refs_by_line, "Discard word override"
+    )
+    duplicate_discard_overrides = sorted(discarded_word_refs & overridden)
+    if duplicate_discard_overrides:
+        raise ResegmentPlanError(
+            f"Words cannot be both overridden and discarded: "
+            f"{[_ref_dict(ref) for ref in duplicate_discard_overrides]}"
+        )
+    redundant_discards = sorted(
+        ref for ref in discarded_word_refs if owners[ref] is None
+    )
+    if redundant_discards:
+        raise ResegmentPlanError(
+            f"Discard word overrides must change the line default: "
+            f"{[_ref_dict(ref) for ref in redundant_discards]}"
+        )
+    for ref in discarded_word_refs:
+        owners[ref] = None
+
+    labels_by_ref = _labels_by_ref(source_labels)
+    orphan_label_refs = sorted(set(labels_by_ref) - known_refs)
+    if orphan_label_refs:
+        raise ResegmentPlanError(
+            "The source receipt contains labels without matching words: "
+            f"{[_ref_dict(ref) for ref in orphan_label_refs]}"
+        )
+    discarded = {ref for ref, owner in owners.items() if owner is None}
+    discarded_labels = [
+        label for ref in discarded for label in labels_by_ref.get(ref, ())
+    ]
+    protected_discarded_labels = [
+        label
+        for label in discarded_labels
+        if str(_value(label, "validation_status", "NONE") or "NONE").upper()
+        != "INVALID"
+    ]
+    allow_labeled_discard = bool(
+        assignments.get("allow_labeled_discard", False)
+    )
+    if protected_discarded_labels and not allow_labeled_discard:
+        refs = sorted(
+            {_word_ref(label) for label in protected_discarded_labels}
+        )
+        raise ResegmentPlanError(
+            "Discarding labeled words requires allow_labeled_discard=true; "
+            f"labeled words: {[_ref_dict(ref) for ref in refs]}"
+        )
+    discard_reason = str(assignments.get("discard_reason", "")).strip() or None
+    if discarded and not discard_reason:
+        raise ResegmentPlanError(
+            "discard_reason is required when words are discarded"
+        )
+
+    destinations_by_line: dict[int, set[str | None]] = defaultdict(set)
+    for ref, owner in owners.items():
+        destinations_by_line[ref[0]].add(owner)
+    mixed_line_ids = sorted(
+        line_id
+        for line_id, destinations in destinations_by_line.items()
+        if len(destinations) > 1
+    )
+
+    segment_by_key = {
+        segment["segment_key"]: segment for segment in normalized_segments
+    }
+    for segment_key, segment in segment_by_key.items():
+        selected = {
+            ref for ref, owner in owners.items() if owner == segment_key
+        }
+        status_counts = Counter(
+            str(_value(label, "validation_status", "NONE") or "NONE")
+            for ref in selected
+            for label in labels_by_ref.get(ref, ())
+        )
+        segment.update(
+            {
+                "line_ids": sorted(
+                    line_id
+                    for line_id, owner in default_owner_by_line.items()
+                    if owner == segment_key
+                ),
+                "mixed_line_ids": sorted(
+                    set(mixed_line_ids) & {ref[0] for ref in selected}
+                ),
+                "word_refs": [_ref_dict(ref) for ref in sorted(selected)],
+                "word_count": len(selected),
+                "letter_count": sum(
+                    letter_counts_by_ref[ref] for ref in selected
+                ),
+                "label_count": sum(status_counts.values()),
+                "label_status_counts": dict(sorted(status_counts.items())),
+            }
+        )
+        if not selected:
+            raise ResegmentPlanError(
+                f"Segment {segment_key} does not select any words"
+            )
+
+    return {
+        "assignment_mode": "LINE_FIRST",
+        "segments": normalized_segments,
+        "assignments": {
+            "lines": sorted(
+                canonical_line_assignments, key=lambda item: item["line_id"]
+            ),
+            "words": sorted(
+                canonical_overrides,
+                key=lambda item: (item["line_id"], item["word_ids"]),
+            ),
+            "discard_lines": sorted(discarded_line_ids),
+            "discard_words": [
+                _ref_dict(ref) for ref in sorted(discarded_word_refs)
+            ],
+            "discard_reason": discard_reason,
+            "allow_labeled_discard": allow_labeled_discard,
+        },
+        "discard": {
+            "line_ids": sorted(discarded_line_ids),
+            "word_refs": [_ref_dict(ref) for ref in sorted(discarded)],
+            "word_count": len(discarded),
+            "letter_count": sum(
+                letter_counts_by_ref[ref] for ref in discarded
+            ),
+            "label_count": len(discarded_labels),
+            "reason": discard_reason,
+        },
+        "totals": {
+            "source_lines": len(source_lines),
+            "mixed_lines": len(mixed_line_ids),
+            "source_words": len(source_words),
+            "assigned_words": len(source_words) - len(discarded),
+            "discarded_words": len(discarded),
+            "source_letters": len(source_letters),
+            "assigned_letters": sum(
+                letter_counts_by_ref[ref]
+                for ref, owner in owners.items()
+                if owner
+            ),
+            "discarded_letters": sum(
+                letter_counts_by_ref[ref] for ref in discarded
+            ),
+            "source_labels": len(source_labels),
+            "preserved_labels": len(source_labels) - len(discarded_labels),
+            "discarded_labels": len(discarded_labels),
+        },
+    }
+
+
+def _point(entity: Any, name: str) -> Any:
+    value = _value(entity, name)
+    if not isinstance(value, Mapping):
+        return value
+    return {key: float(value[key]) for key in sorted(value)}
+
+
+def _entity_payload(entity: Any) -> Any:
+    if entity is None:
+        return None
+    if isinstance(entity, Mapping):
+        return deepcopy(dict(entity))
+    to_item = getattr(entity, "to_item", None)
+    if callable(to_item):
+        return to_item()
+    return {
+        key: value
+        for key, value in vars(entity).items()
+        if not key.startswith("_")
+    }
+
+
+def build_source_fingerprint(
+    *,
+    receipt: Any,
+    words: Iterable[Any],
+    labels: Iterable[Any],
+    place: Any = None,
+    image: Any = None,
+    lines: Iterable[Any] = (),
+    letters: Iterable[Any] = (),
+    source_object: Mapping[str, Any] | None = None,
+    source_type_counts: Mapping[str, Any] | None = None,
+) -> str:
+    """Hash all source fields whose change could invalidate a plan."""
+    receipt_payload = {
+        name: _value(receipt, name)
+        for name in (
+            "image_id",
+            "receipt_id",
+            "width",
+            "height",
+            "timestamp_added",
+            "raw_s3_bucket",
+            "raw_s3_key",
+            "sha256",
+        )
+    }
+    for name in ("top_left", "top_right", "bottom_left", "bottom_right"):
+        receipt_payload[name] = _point(receipt, name)
+
+    word_payload = []
+    for word in sorted(words, key=_word_ref):
+        item = {
+            "line_id": _word_ref(word)[0],
+            "word_id": _word_ref(word)[1],
+            "text": _value(word, "text"),
+            "confidence": _value(word, "confidence"),
+            "is_noise": bool(_value(word, "is_noise", False)),
+        }
+        for name in (
+            "top_left",
+            "top_right",
+            "bottom_left",
+            "bottom_right",
+        ):
+            item[name] = _point(word, name)
+        word_payload.append(item)
+
+    label_payload = []
+    for label in sorted(
+        labels,
+        key=lambda item: (*_word_ref(item), str(_value(item, "label", ""))),
+    ):
+        label_payload.append(
+            {
+                "line_id": _word_ref(label)[0],
+                "word_id": _word_ref(label)[1],
+                "label": _value(label, "label"),
+                "validation_status": _value(label, "validation_status"),
+                "reasoning": _value(label, "reasoning"),
+                "timestamp_added": _value(label, "timestamp_added"),
+                "label_proposed_by": _value(label, "label_proposed_by"),
+                "label_consolidated_from": _value(
+                    label, "label_consolidated_from"
+                ),
+            }
+        )
+
+    payload = {
+        "receipt": receipt_payload,
+        "words": word_payload,
+        "labels": label_payload,
+        "place": _entity_payload(place),
+    }
+    if image is not None or source_object is not None:
+        payload.update(
+            {
+                "fingerprint_version": 2,
+                "image": _entity_payload(image),
+                "lines": [
+                    _entity_payload(line)
+                    for line in sorted(lines, key=_line_id)
+                ],
+                "letters": [
+                    _entity_payload(letter)
+                    for letter in sorted(letters, key=_letter_ref)
+                ],
+                "source_object": deepcopy(dict(source_object or {})),
+                "source_type_counts": dict(
+                    sorted((source_type_counts or {}).items())
+                ),
+            }
+        )
+    encoded = json.dumps(
+        payload, sort_keys=True, separators=(",", ":"), default=str
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def compute_plan_hash(plan: Mapping[str, Any]) -> str:
+    """Return a stable hash while excluding mutable delivery metadata."""
+    payload = deepcopy(dict(plan))
+    for key in ("plan_hash", "preview_urls", "delivery", "status", "result"):
+        payload.pop(key, None)
+    encoded = json.dumps(
+        payload, sort_keys=True, separators=(",", ":"), default=str
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()

--- a/receipt_upload/receipt_upload/resegment/planner.py
+++ b/receipt_upload/receipt_upload/resegment/planner.py
@@ -772,8 +772,17 @@ def build_source_fingerprint(
         "words": word_payload,
         "labels": label_payload,
         "place": _entity_payload(place),
+        # Source object identity is bound for every plan schema (v1 and v2):
+        # a same-key overwrite of the underlying image must invalidate the
+        # plan even when the receipt/word/label rows are unchanged.
+        "source_object": deepcopy(dict(source_object or {})),
+        "source_type_counts": dict(sorted((source_type_counts or {}).items())),
     }
-    if image is not None or source_object is not None:
+    # The layered (v2) block is keyed off the presence of the image entity,
+    # which only line-first plans supply. Moving source_object into the base
+    # payload above leaves the v2 hash unchanged (same keys and values) while
+    # extending v1 fingerprints to cover the source image bytes.
+    if image is not None:
         payload.update(
             {
                 "fingerprint_version": 2,
@@ -786,10 +795,6 @@ def build_source_fingerprint(
                     _entity_payload(letter)
                     for letter in sorted(letters, key=_letter_ref)
                 ],
-                "source_object": deepcopy(dict(source_object or {})),
-                "source_type_counts": dict(
-                    sorted((source_type_counts or {}).items())
-                ),
             }
         )
     encoded = json.dumps(

--- a/receipt_upload/receipt_upload/resegment/preview.py
+++ b/receipt_upload/receipt_upload/resegment/preview.py
@@ -528,9 +528,15 @@ def build_preview_bundle(
             findings.append(
                 {
                     "code": "DISCONNECTED_VISIBLE_REGIONS",
-                    "severity": "WARNING",
+                    "severity": (
+                        "BLOCKER" if strategy == "RECTANGULAR" else "WARNING"
+                    ),
                     "segment_key": key,
-                    "message": f"The segment has {len(component_lines[key])} visible components.",
+                    "message": (
+                        f"The segment has {len(component_lines[key])} visible "
+                        "components. A single rectangular output would include "
+                        "the pixels between them."
+                    ),
                 }
             )
         metrics[key] = {

--- a/receipt_upload/receipt_upload/resegment/preview.py
+++ b/receipt_upload/receipt_upload/resegment/preview.py
@@ -166,19 +166,16 @@ def _line_hulls(
     ]
 
 
-def _candidate_mask(
-    *,
-    size: tuple[int, int],
+def _cluster_line_hulls(
     line_hulls: Sequence[tuple[int, Sequence[tuple[float, float]]]],
-    padding_px: int,
-) -> tuple[Image.Image, list[list[int]]]:
-    mask = Image.new("L", size, 0)
-    draw = ImageDraw.Draw(mask)
+    size: tuple[int, int],
+) -> list[list[tuple[int, list[tuple[float, float]]]]]:
+    """Group line hulls into vertically contiguous components."""
     valid_hulls = [
         (line_id, list(hull)) for line_id, hull in line_hulls if len(hull) >= 3
     ]
     if not valid_hulls:
-        return mask, []
+        return []
 
     heights = [
         max(point[1] for point in hull) - min(point[1] for point in hull)
@@ -197,6 +194,20 @@ def _candidate_mask(
             components.append([item])
         else:
             components[-1].append(item)
+    return components
+
+
+def _candidate_mask(
+    *,
+    size: tuple[int, int],
+    line_hulls: Sequence[tuple[int, Sequence[tuple[float, float]]]],
+    padding_px: int,
+) -> tuple[Image.Image, list[list[int]]]:
+    mask = Image.new("L", size, 0)
+    draw = ImageDraw.Draw(mask)
+    components = _cluster_line_hulls(line_hulls, size)
+    if not components:
+        return mask, []
 
     for component in components:
         for _, hull in component:
@@ -403,8 +414,15 @@ def build_preview_bundle(
                 segment["geometry"]["src_corners"], fill=255
             )
             candidates[key] = mask
+            # The rectangle always covers every assigned line, so
+            # disconnection must be detected from the line geometry
+            # itself, not from the mask.
             component_lines[key] = [
-                sorted({ref[0] for ref in segment_refs[key]})
+                sorted(line_id for line_id, _ in component)
+                for component in _cluster_line_hulls(
+                    _line_hulls(segment_refs[key], words_by_ref, image.height),
+                    image.size,
+                )
             ]
         else:
             candidates[key], component_lines[key] = _candidate_mask(

--- a/receipt_upload/receipt_upload/resegment/preview.py
+++ b/receipt_upload/receipt_upload/resegment/preview.py
@@ -1,0 +1,576 @@
+"""Pillow-only visual evidence for receipt re-segmentation plans."""
+
+from __future__ import annotations
+
+import math
+import statistics
+from collections import defaultdict
+from collections.abc import Iterable, Mapping, Sequence
+from typing import Any
+
+from PIL import Image, ImageChops, ImageDraw, ImageFilter
+
+WordRef = tuple[int, int]
+
+_COLORS = (
+    (35, 131, 226),
+    (243, 143, 46),
+    (39, 174, 96),
+    (151, 84, 196),
+    (231, 76, 60),
+    (22, 160, 133),
+)
+_DISCARD_COLOR = (230, 61, 151)
+
+
+def _value(entity: Any, name: str, default: Any = None) -> Any:
+    if isinstance(entity, Mapping):
+        return entity.get(name, default)
+    return getattr(entity, name, default)
+
+
+def _word_ref(entity: Any) -> WordRef:
+    return int(_value(entity, "line_id")), int(_value(entity, "word_id"))
+
+
+def _polygon(entity: Any, image_height: int) -> list[tuple[float, float]]:
+    points = []
+    for name in ("top_left", "top_right", "bottom_right", "bottom_left"):
+        point = _value(entity, name, {}) or {}
+        points.append((float(point["x"]), image_height - float(point["y"])))
+    return points
+
+
+def _centroid(points: Sequence[tuple[float, float]]) -> tuple[float, float]:
+    return (
+        sum(point[0] for point in points) / len(points),
+        sum(point[1] for point in points) / len(points),
+    )
+
+
+def _cross(
+    origin: tuple[float, float],
+    first: tuple[float, float],
+    second: tuple[float, float],
+) -> float:
+    return (first[0] - origin[0]) * (second[1] - origin[1]) - (
+        first[1] - origin[1]
+    ) * (second[0] - origin[0])
+
+
+def _convex_hull(
+    points: Iterable[tuple[float, float]],
+) -> list[tuple[float, float]]:
+    unique = sorted(set(points))
+    if len(unique) <= 2:
+        return unique
+    lower: list[tuple[float, float]] = []
+    for point in unique:
+        while len(lower) >= 2 and _cross(lower[-2], lower[-1], point) <= 0:
+            lower.pop()
+        lower.append(point)
+    upper: list[tuple[float, float]] = []
+    for point in reversed(unique):
+        while len(upper) >= 2 and _cross(upper[-2], upper[-1], point) <= 0:
+            upper.pop()
+        upper.append(point)
+    return lower[:-1] + upper[:-1]
+
+
+def _point_in_mask(mask: Image.Image, point: tuple[float, float]) -> bool:
+    x = min(max(int(round(point[0])), 0), mask.width - 1)
+    y = min(max(int(round(point[1])), 0), mask.height - 1)
+    return bool(mask.getpixel((x, y)))
+
+
+def _mask_coverage(
+    mask: Image.Image, polygon: Sequence[tuple[float, float]]
+) -> float:
+    if len(polygon) < 3:
+        return 0.0
+    xs = [point[0] for point in polygon]
+    ys = [point[1] for point in polygon]
+    left = max(0, int(math.floor(min(xs))))
+    top = max(0, int(math.floor(min(ys))))
+    right = min(mask.width, int(math.ceil(max(xs))) + 1)
+    bottom = min(mask.height, int(math.ceil(max(ys))) + 1)
+    if left >= right or top >= bottom:
+        return 0.0
+    word_mask = Image.new("1", (right - left, bottom - top), 0)
+    ImageDraw.Draw(word_mask).polygon(
+        [(x - left, y - top) for x, y in polygon], fill=1
+    )
+    denominator = sum(word_mask.getdata())
+    if not denominator:
+        return 0.0
+    segment_crop = mask.crop((left, top, right, bottom)).convert("1")
+    numerator = sum(ImageChops.logical_and(word_mask, segment_crop).getdata())
+    return numerator / denominator
+
+
+def _dilate_and_smooth(mask: Image.Image, padding_px: int) -> Image.Image:
+    result = mask
+    remaining = max(0, int(padding_px))
+    while remaining:
+        radius = min(remaining, 15)
+        result = result.filter(ImageFilter.MaxFilter(radius * 2 + 1))
+        remaining -= radius
+    if padding_px:
+        result = result.filter(
+            ImageFilter.GaussianBlur(min(3.0, padding_px / 4))
+        )
+    return result.point(lambda value: 255 if value >= 96 else 0, mode="L")
+
+
+def _explicit_region_points(
+    region: Any, width: int, height: int
+) -> list[tuple[float, float]]:
+    raw_points = (
+        region.get("points", ()) if isinstance(region, Mapping) else region
+    )
+    points = []
+    for raw_point in raw_points:
+        if isinstance(raw_point, Mapping):
+            x = float(raw_point["x"])
+            y = float(raw_point["y"])
+        else:
+            x, y = (float(value) for value in raw_point)
+        if (
+            not math.isfinite(x)
+            or not math.isfinite(y)
+            or not 0 <= x <= 1
+            or not 0 <= y <= 1
+        ):
+            raise ValueError(
+                "visible region points must be finite normalized coordinates"
+            )
+        points.append((x * width, (1.0 - y) * height))
+    if len(points) < 3:
+        raise ValueError("visible regions require at least three points")
+    return points
+
+
+def _line_hulls(
+    refs: set[WordRef],
+    words_by_ref: Mapping[WordRef, Any],
+    image_height: int,
+) -> list[tuple[int, list[tuple[float, float]]]]:
+    polygons_by_line: dict[int, list[tuple[float, float]]] = defaultdict(list)
+    for ref in refs:
+        polygons_by_line[ref[0]].extend(
+            _polygon(words_by_ref[ref], image_height)
+        )
+    return [
+        (line_id, _convex_hull(points))
+        for line_id, points in sorted(polygons_by_line.items())
+    ]
+
+
+def _candidate_mask(
+    *,
+    size: tuple[int, int],
+    line_hulls: Sequence[tuple[int, Sequence[tuple[float, float]]]],
+    padding_px: int,
+) -> tuple[Image.Image, list[list[int]]]:
+    mask = Image.new("L", size, 0)
+    draw = ImageDraw.Draw(mask)
+    valid_hulls = [
+        (line_id, list(hull)) for line_id, hull in line_hulls if len(hull) >= 3
+    ]
+    if not valid_hulls:
+        return mask, []
+
+    heights = [
+        max(point[1] for point in hull) - min(point[1] for point in hull)
+        for _, hull in valid_hulls
+    ]
+    gap_limit = max(4 * statistics.median(heights), 0.06 * min(size))
+    ordered = sorted(valid_hulls, key=lambda item: _centroid(item[1])[1])
+    components: list[list[tuple[int, list[tuple[float, float]]]]] = []
+    for item in ordered:
+        if not components:
+            components.append([item])
+            continue
+        previous_y = _centroid(components[-1][-1][1])[1]
+        current_y = _centroid(item[1])[1]
+        if current_y - previous_y > gap_limit:
+            components.append([item])
+        else:
+            components[-1].append(item)
+
+    for component in components:
+        for _, hull in component:
+            draw.polygon(hull, fill=255)
+        for (_, first), (_, second) in zip(component, component[1:]):
+            bridge = _convex_hull([*first, *second])
+            if len(bridge) >= 3:
+                draw.polygon(bridge, fill=255)
+    return _dilate_and_smooth(mask, padding_px), [
+        [line_id for line_id, _ in component] for component in components
+    ]
+
+
+def _line_evidence(
+    lines: Sequence[Any],
+    words_by_ref: Mapping[WordRef, Any],
+    owner_by_ref: Mapping[WordRef, str | None],
+    image_height: int,
+    letters: Sequence[Any],
+) -> list[dict[str, Any]]:
+    words_by_line: dict[int, list[Any]] = defaultdict(list)
+    for ref, word in words_by_ref.items():
+        words_by_line[ref[0]].append(word)
+    letters_by_line: dict[int, list[Any]] = defaultdict(list)
+    for letter in letters:
+        letters_by_line[int(_value(letter, "line_id"))].append(letter)
+    evidence = []
+    for line in sorted(lines, key=lambda value: int(_value(value, "line_id"))):
+        line_id = int(_value(line, "line_id"))
+        words = words_by_line.get(line_id, [])
+        points = [
+            point for word in words for point in _polygon(word, image_height)
+        ]
+        word_angles = []
+        for word in words:
+            bottom_left = _value(word, "bottom_left")
+            bottom_right = _value(word, "bottom_right")
+            word_angles.append(
+                math.degrees(
+                    math.atan2(
+                        float(bottom_right["y"]) - float(bottom_left["y"]),
+                        float(bottom_right["x"]) - float(bottom_left["x"]),
+                    )
+                )
+            )
+        letter_angles = []
+        for letter in letters_by_line.get(line_id, ()):
+            bottom_left = _value(letter, "bottom_left")
+            bottom_right = _value(letter, "bottom_right")
+            letter_angles.append(
+                math.degrees(
+                    math.atan2(
+                        float(bottom_right["y"]) - float(bottom_left["y"]),
+                        float(bottom_right["x"]) - float(bottom_left["x"]),
+                    )
+                )
+            )
+        angles = letter_angles or word_angles
+        destinations = sorted(
+            {
+                owner_by_ref[_word_ref(word)] or "DISCARD"
+                for word in words
+                if _word_ref(word) in owner_by_ref
+            }
+        )
+        evidence.append(
+            {
+                "line_id": line_id,
+                "text": _value(line, "text", ""),
+                "confidence": _value(line, "confidence"),
+                "stored_angle_degrees": _value(line, "angle_degrees"),
+                "derived_baseline_degrees": (
+                    statistics.median(angles) if angles else None
+                ),
+                "derived_baseline_source": (
+                    "LETTER_CORNERS"
+                    if letter_angles
+                    else "WORD_CORNERS" if word_angles else None
+                ),
+                "assigned_to": destinations,
+                "letter_count": len(letters_by_line.get(line_id, ())),
+                "word_refs": [
+                    {
+                        "line_id": line_id,
+                        "word_id": int(_value(word, "word_id")),
+                    }
+                    for word in sorted(
+                        words, key=lambda value: int(_value(value, "word_id"))
+                    )
+                ],
+                "hull_px": [list(point) for point in _convex_hull(points)],
+            }
+        )
+    return evidence
+
+
+def _contact_sheet(
+    overlay: Image.Image, visible_crops: Mapping[str, Image.Image]
+) -> Image.Image:
+    cards: list[tuple[str, Image.Image]] = [("assignment overlay", overlay)]
+    cards.extend(
+        (segment_key, image) for segment_key, image in visible_crops.items()
+    )
+    card_width = 640
+    card_height = 460
+    columns = 2
+    rows = math.ceil(len(cards) / columns)
+    sheet = Image.new(
+        "RGB", (columns * card_width, rows * card_height), "white"
+    )
+    draw = ImageDraw.Draw(sheet)
+    for index, (label, image) in enumerate(cards):
+        column = index % columns
+        row = index // columns
+        x = column * card_width
+        y = row * card_height
+        draw.text((x + 12, y + 10), label, fill="black")
+        preview = image.copy()
+        preview.thumbnail((card_width - 24, card_height - 48))
+        if preview.mode == "RGBA":
+            background = Image.new("RGB", preview.size, "white")
+            background.paste(preview, mask=preview.getchannel("A"))
+            preview = background
+        elif preview.mode != "RGB":
+            preview = preview.convert("RGB")
+        paste_x = x + (card_width - preview.width) // 2
+        paste_y = y + 38 + (card_height - 48 - preview.height) // 2
+        sheet.paste(preview, (paste_x, paste_y))
+    sheet.thumbnail((1400, 1200))
+    return sheet
+
+
+def build_preview_bundle(
+    original_image: Image.Image,
+    *,
+    image_type: str,
+    strategy: str,
+    lines: Sequence[Any],
+    words_by_ref: Mapping[WordRef, Any],
+    segments: Sequence[Mapping[str, Any]],
+    discard_refs: set[WordRef],
+    letters: Sequence[Any] = (),
+    padding_px: int = 12,
+) -> dict[str, Any]:
+    """Render assignment evidence, masks, crops, metrics, and findings."""
+    image = original_image.convert("RGB")
+    owner_by_ref: dict[WordRef, str | None] = {
+        ref: None for ref in discard_refs
+    }
+    segment_refs: dict[str, set[WordRef]] = {}
+    for segment in segments:
+        key = str(segment["segment_key"])
+        refs = {
+            (int(ref["line_id"]), int(ref["word_id"]))
+            for ref in segment["word_refs"]
+        }
+        segment_refs[key] = refs
+        owner_by_ref.update({ref: key for ref in refs})
+
+    overlay_layer = Image.new("RGBA", image.size, (0, 0, 0, 0))
+    overlay_draw = ImageDraw.Draw(overlay_layer)
+    color_by_segment = {
+        str(segment["segment_key"]): _COLORS[index % len(_COLORS)]
+        for index, segment in enumerate(segments)
+    }
+    for ref, word in words_by_ref.items():
+        owner = owner_by_ref.get(ref)
+        color = _DISCARD_COLOR if owner is None else color_by_segment[owner]
+        polygon = _polygon(word, image.height)
+        overlay_draw.polygon(
+            polygon, fill=(*color, 105), outline=(*color, 255)
+        )
+    overlay = Image.alpha_composite(
+        image.convert("RGBA"), overlay_layer
+    ).convert("RGB")
+
+    candidates: dict[str, Image.Image] = {}
+    component_lines: dict[str, list[list[int]]] = {}
+    for segment in segments:
+        key = str(segment["segment_key"])
+        visible_regions = segment.get("visible_regions", ())
+        if visible_regions:
+            mask = Image.new("L", image.size, 0)
+            draw = ImageDraw.Draw(mask)
+            for region in visible_regions:
+                draw.polygon(
+                    _explicit_region_points(region, image.width, image.height),
+                    fill=255,
+                )
+            candidates[key] = mask
+            component_lines[key] = [
+                (
+                    sorted(
+                        int(line_id) for line_id in region.get("line_ids", ())
+                    )
+                    if isinstance(region, Mapping)
+                    else []
+                )
+                for region in visible_regions
+            ]
+        elif strategy == "RECTANGULAR" and segment.get("geometry"):
+            mask = Image.new("L", image.size, 0)
+            ImageDraw.Draw(mask).polygon(
+                segment["geometry"]["src_corners"], fill=255
+            )
+            candidates[key] = mask
+            component_lines[key] = [
+                sorted({ref[0] for ref in segment_refs[key]})
+            ]
+        else:
+            candidates[key], component_lines[key] = _candidate_mask(
+                size=image.size,
+                line_hulls=_line_hulls(
+                    segment_refs[key], words_by_ref, image.height
+                ),
+                padding_px=padding_px,
+            )
+
+    findings: list[dict[str, Any]] = []
+    masks: dict[str, Image.Image] = {}
+    foreground_union = Image.new("L", image.size, 0)
+    ordered_segments = sorted(
+        segments, key=lambda value: int(value.get("z_index", 0)), reverse=True
+    )
+    if strategy == "LAYERED_MULTI_REGION":
+        for index, first in enumerate(ordered_segments):
+            for second in ordered_segments[index + 1 :]:
+                if int(first.get("z_index", 0)) != int(
+                    second.get("z_index", 0)
+                ):
+                    continue
+                first_key = str(first["segment_key"])
+                second_key = str(second["segment_key"])
+                if ImageChops.multiply(
+                    candidates[first_key], candidates[second_key]
+                ).getbbox():
+                    findings.append(
+                        {
+                            "code": "AMBIGUOUS_LAYER_ORDER",
+                            "severity": "BLOCKER",
+                            "message": (
+                                f"Segments {first_key} and {second_key} overlap "
+                                "but have the same z_index."
+                            ),
+                        }
+                    )
+    for segment in ordered_segments:
+        key = str(segment["segment_key"])
+        candidate = candidates[key]
+        if image_type == "PHOTO" and strategy == "LAYERED_MULTI_REGION":
+            masks[key] = ImageChops.subtract(candidate, foreground_union)
+            foreground_union = ImageChops.lighter(foreground_union, masks[key])
+        else:
+            masks[key] = candidate
+
+    if strategy == "LAYERED_MULTI_REGION":
+        findings.append(
+            {
+                "code": "LAYERED_APPLY_NOT_SUPPORTED",
+                "severity": "BLOCKER",
+                "message": (
+                    "Layered PHOTO plans can be reviewed and revised, but apply "
+                    "is blocked until masked output rendering is enabled."
+                ),
+            }
+        )
+    if image_type == "NATIVE" and strategy == "LAYERED_MULTI_REGION":
+        findings.append(
+            {
+                "code": "NATIVE_LAYERING_UNSUPPORTED",
+                "severity": "BLOCKER",
+                "message": "NATIVE sources do not support layered segmentation.",
+            }
+        )
+
+    segment_images: dict[str, dict[str, Image.Image]] = {}
+    metrics: dict[str, Any] = {}
+    visible_crops: dict[str, Image.Image] = {}
+    letter_counts_by_ref = defaultdict(int)
+    for letter in letters:
+        letter_counts_by_ref[_word_ref(letter)] += 1
+    for segment in segments:
+        key = str(segment["segment_key"])
+        mask = masks[key]
+        rgba = image.convert("RGBA")
+        rgba.putalpha(mask)
+        bbox = mask.getbbox() or (0, 0, 1, 1)
+        visible_crop = rgba.crop(bbox)
+        visible_crops[key] = visible_crop
+        segment_images[key] = {"mask": mask, "visible_crop": visible_crop}
+
+        assigned_coverages = [
+            _mask_coverage(mask, _polygon(words_by_ref[ref], image.height))
+            for ref in sorted(segment_refs[key])
+        ]
+        retained = sum(
+            _point_in_mask(
+                mask, _centroid(_polygon(words_by_ref[ref], image.height))
+            )
+            for ref in segment_refs[key]
+        )
+        foreign_refs = set(words_by_ref) - segment_refs[key] - discard_refs
+        foreign_centroids = sum(
+            _point_in_mask(
+                mask, _centroid(_polygon(words_by_ref[ref], image.height))
+            )
+            for ref in foreign_refs
+        )
+        if retained != len(segment_refs[key]):
+            findings.append(
+                {
+                    "code": "ASSIGNED_WORD_CLIPPED",
+                    "severity": "BLOCKER",
+                    "segment_key": key,
+                    "message": "One or more assigned word centroids are outside the mask.",
+                }
+            )
+        if foreign_centroids:
+            severity = "BLOCKER" if image_type == "SCAN" else "WARNING"
+            findings.append(
+                {
+                    "code": "FOREIGN_WORD_CAPTURED",
+                    "severity": severity,
+                    "segment_key": key,
+                    "message": f"The mask contains {foreign_centroids} foreign word centroids.",
+                }
+            )
+        if len(component_lines[key]) > 1:
+            findings.append(
+                {
+                    "code": "DISCONNECTED_VISIBLE_REGIONS",
+                    "severity": "WARNING",
+                    "segment_key": key,
+                    "message": f"The segment has {len(component_lines[key])} visible components.",
+                }
+            )
+        metrics[key] = {
+            "assigned_word_count": len(segment_refs[key]),
+            "assigned_letter_count": sum(
+                letter_counts_by_ref[ref] for ref in segment_refs[key]
+            ),
+            "word_centroids_retained": retained,
+            "word_centroid_retention_ratio": (
+                retained / len(segment_refs[key]) if segment_refs[key] else 0.0
+            ),
+            "mean_word_quad_coverage": (
+                statistics.fmean(assigned_coverages)
+                if assigned_coverages
+                else 0.0
+            ),
+            "min_word_quad_coverage": min(assigned_coverages, default=0.0),
+            "foreign_word_centroids_in_mask": foreign_centroids,
+            "visible_region_count": len(component_lines[key]),
+            "visible_region_line_ids": component_lines[key],
+            "mask_area_px": sum(1 for value in mask.getdata() if value),
+            "source_bbox_px": {
+                "x": bbox[0],
+                "y": bbox[1],
+                "width": bbox[2] - bbox[0],
+                "height": bbox[3] - bbox[1],
+            },
+        }
+
+    return {
+        "images": {
+            "overlay": overlay,
+            "contact_sheet": _contact_sheet(overlay, visible_crops),
+            "segments": segment_images,
+        },
+        "metrics": metrics,
+        "findings": findings,
+        "evidence": {
+            "lines": _line_evidence(
+                lines, words_by_ref, owner_by_ref, image.height, letters
+            )
+        },
+    }

--- a/receipt_upload/receipt_upload/resegment/preview.py
+++ b/receipt_upload/receipt_upload/resegment/preview.py
@@ -389,7 +389,10 @@ def build_preview_bundle(
     for segment in segments:
         key = str(segment["segment_key"])
         visible_regions = segment.get("visible_regions", ())
-        if visible_regions:
+        # Explicit regions only shape the mask for layered plans; a
+        # RECTANGULAR apply writes the min-area crop, so honoring them
+        # here would preview an artifact apply never produces.
+        if strategy == "LAYERED_MULTI_REGION" and visible_regions:
             mask = Image.new("L", image.size, 0)
             draw = ImageDraw.Draw(mask)
             for region in visible_regions:

--- a/receipt_upload/tests/test_combine.py
+++ b/receipt_upload/tests/test_combine.py
@@ -352,6 +352,23 @@ def test_calculate_min_area_rect_returns_portrait_warp():
 
 
 @pytest.mark.unit
+def test_calculate_min_area_rect_padding_expands_dimensions():
+    words = [
+        {
+            "top_left": {"x": 10.0, "y": 90.0},
+            "top_right": {"x": 30.0, "y": 90.0},
+            "bottom_left": {"x": 10.0, "y": 20.0},
+            "bottom_right": {"x": 30.0, "y": 20.0},
+        }
+    ]
+    unpadded = calculate_min_area_rect(words, 100, 100)
+    padded = calculate_min_area_rect(words, 100, 100, padding_px=5)
+
+    assert padded["warped_width"] == unpadded["warped_width"] + 10
+    assert padded["warped_height"] == unpadded["warped_height"] + 10
+
+
+@pytest.mark.unit
 def test_create_combined_receipt_records_keeps_noise_and_mappings():
     combined_words = [
         {
@@ -429,6 +446,8 @@ def test_create_combined_receipt_records_keeps_noise_and_mappings():
     assert [w.is_noise for w in records["receipt_words"]] == [False, True]
     assert records["line_id_map"] == {(1, 2): 1}
     assert records["word_id_map"] == {(7, 1, 2): 1, (8, 1, 2): 2}
+    assert records["receipt"].top_left == {"x": 0.1, "y": 0.9}
+    assert records["receipt"].bottom_right == {"x": 0.35, "y": 0.8}
 
 
 @pytest.mark.unit

--- a/receipt_upload/tests/test_resegment_planner.py
+++ b/receipt_upload/tests/test_resegment_planner.py
@@ -527,3 +527,38 @@ def test_line_first_plan_rejects_missing_lines_and_noncontiguous_overrides():
                 ],
             },
         )
+
+
+def test_line_first_plan_rejects_wordless_line_assigned_to_segment():
+    """Apply rebuilds outputs from words, so a wordless line assigned to a
+    segment would be silently destroyed; it must be discarded explicitly."""
+    lines = [{"line_id": 1}, {"line_id": 2}]
+    words = [_word(1, 1)]
+    segments = [{"segment_key": "a"}]
+
+    with pytest.raises(ResegmentPlanError, match="Lines without words"):
+        normalize_line_resegmentation_plan(
+            lines=lines,
+            words=words,
+            labels=[],
+            segments=segments,
+            assignments={
+                "lines": [
+                    {"line_id": 1, "segment_key": "a"},
+                    {"line_id": 2, "segment_key": "a"},
+                ],
+            },
+        )
+
+    plan = normalize_line_resegmentation_plan(
+        lines=lines,
+        words=words,
+        labels=[],
+        segments=segments,
+        assignments={
+            "lines": [{"line_id": 1, "segment_key": "a"}],
+            "discard_lines": [2],
+            "discard_reason": "empty OCR line",
+        },
+    )
+    assert plan["totals"]["source_words"] == 1

--- a/receipt_upload/tests/test_resegment_planner.py
+++ b/receipt_upload/tests/test_resegment_planner.py
@@ -1,0 +1,529 @@
+"""Regression tests for safe receipt re-segmentation planning."""
+
+import pytest
+
+from receipt_upload.resegment import (
+    ResegmentPlanError,
+    build_source_fingerprint,
+    normalize_line_resegmentation_plan,
+    normalize_resegmentation_plan,
+)
+
+TWIN_PEAKS_WORD_COUNTS = {
+    1: 2,
+    2: 3,
+    3: 2,
+    4: 1,
+    5: 2,
+    6: 2,
+    7: 2,
+    8: 3,
+    9: 5,
+    10: 4,
+    11: 2,
+    12: 2,
+    13: 2,
+    14: 2,
+    15: 1,
+    16: 1,
+    17: 1,
+    18: 1,
+    19: 2,
+    20: 1,
+    21: 3,
+    22: 2,
+    23: 3,
+    24: 2,
+    25: 1,
+    26: 1,
+    27: 1,
+    28: 1,
+    29: 2,
+    30: 1,
+    31: 2,
+    32: 1,
+    33: 1,
+    34: 4,
+    35: 2,
+    36: 3,
+    37: 1,
+    38: 1,
+    39: 1,
+    40: 1,
+    41: 1,
+    42: 1,
+    43: 1,
+    44: 4,
+    45: 7,
+    46: 5,
+    47: 4,
+    48: 4,
+    49: 1,
+    50: 1,
+    51: 1,
+    52: 4,
+    53: 1,
+    54: 1,
+    55: 2,
+    56: 7,
+    57: 5,
+    58: 5,
+    59: 6,
+}
+
+
+def _word(line_id: int, word_id: int) -> dict:
+    text_overrides = {
+        (34, 1): "Appr'",
+        (34, 2): "CP",
+        (34, 3): "CREDIT",
+        (34, 4): "#",
+        (35, 1): "Entr",
+        (35, 2): "Authorizing...",
+        (36, 1): "Mod",
+        (36, 2): "Balance",
+        (36, 3): "Due",
+    }
+    return {
+        "line_id": line_id,
+        "word_id": word_id,
+        "text": text_overrides.get(
+            (line_id, word_id), f"w{line_id}-{word_id}"
+        ),
+        "top_left": {"x": 0.1, "y": 0.9},
+        "top_right": {"x": 0.2, "y": 0.9},
+        "bottom_left": {"x": 0.1, "y": 0.8},
+        "bottom_right": {"x": 0.2, "y": 0.8},
+        "confidence": 1.0,
+    }
+
+
+def _twin_peaks_words() -> list[dict]:
+    return [
+        _word(line_id, word_id)
+        for line_id, count in TWIN_PEAKS_WORD_COUNTS.items()
+        for word_id in range(1, count + 1)
+    ]
+
+
+def _letters_for_words(words: list[dict], total: int) -> list[dict]:
+    base, remainder = divmod(total, len(words))
+    letters = []
+    for index, word in enumerate(words):
+        count = base + (1 if index < remainder else 0)
+        letters.extend(
+            {
+                "line_id": word["line_id"],
+                "word_id": word["word_id"],
+                "letter_id": letter_id,
+                "text": "x",
+            }
+            for letter_id in range(1, count + 1)
+        )
+    return letters
+
+
+CARD_LINES = [
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    15,
+    16,
+    17,
+    29,
+    31,
+    32,
+    42,
+    43,
+    50,
+    54,
+    55,
+    56,
+    57,
+    58,
+    59,
+]
+GUEST_LINES = [
+    8,
+    9,
+    10,
+    11,
+    12,
+    13,
+    14,
+    18,
+    19,
+    20,
+    21,
+    22,
+    23,
+    24,
+    25,
+    26,
+    27,
+    28,
+    30,
+    33,
+    37,
+    38,
+    39,
+    40,
+    41,
+    44,
+    45,
+    46,
+    47,
+    48,
+    49,
+]
+
+
+def _segments() -> list[dict]:
+    return [
+        {
+            "segment_key": "card-slip",
+            "include_line_ids": CARD_LINES,
+            "include_word_refs": [
+                {"line_id": 34, "word_ids": [1]},
+                {"line_id": 35, "word_ids": [1]},
+                {"line_id": 36, "word_ids": [1]},
+            ],
+        },
+        {
+            "segment_key": "guest-check",
+            "include_line_ids": GUEST_LINES,
+            "include_word_refs": [
+                {"line_id": 34, "word_ids": [2, 3, 4]},
+                {"line_id": 35, "word_ids": [2]},
+                {"line_id": 36, "word_ids": [2, 3]},
+            ],
+        },
+    ]
+
+
+def test_twin_peaks_plan_partitions_every_word_once():
+    words = _twin_peaks_words()
+    card_refs = [
+        word
+        for word in words
+        if word["line_id"] in CARD_LINES
+        or (word["line_id"] in {34, 35, 36} and word["word_id"] == 1)
+    ]
+    guest_refs = [
+        word
+        for word in words
+        if word["line_id"] in GUEST_LINES
+        or (word["line_id"] == 34 and word["word_id"] in {2, 3, 4})
+        or (word["line_id"] == 35 and word["word_id"] == 2)
+        or (word["line_id"] == 36 and word["word_id"] in {2, 3})
+    ]
+    discard_refs = [word for word in words if word["line_id"] in {51, 52, 53}]
+    letters = [
+        *_letters_for_words(card_refs, 253),
+        *_letters_for_words(guest_refs, 361),
+        *_letters_for_words(discard_refs, 18),
+    ]
+    labels = [
+        {
+            "line_id": word["line_id"],
+            "word_id": word["word_id"],
+            "label": "TEST_LABEL",
+            "validation_status": "VALID",
+        }
+        for word in [*card_refs[:19], *guest_refs[:64]]
+    ]
+
+    lines = [
+        {
+            "line_id": line_id,
+            "text": f"line {line_id}",
+            "confidence": 1.0,
+            "angle_degrees": 0.0,
+        }
+        for line_id in TWIN_PEAKS_WORD_COUNTS
+    ]
+    assignments = {
+        "lines": [
+            *[
+                {"line_id": line_id, "segment_key": "card-slip"}
+                for line_id in CARD_LINES
+            ],
+            *[
+                {"line_id": line_id, "segment_key": "guest-check"}
+                for line_id in [*GUEST_LINES, 34, 35, 36]
+            ],
+        ],
+        "words": [
+            {
+                "line_id": line_id,
+                "word_ids": [1],
+                "segment_key": "card-slip",
+                "reason": "Mixed OCR bridge line",
+            }
+            for line_id in (34, 35, 36)
+        ],
+        "discard_lines": [51, 52, 53],
+        "discard_reason": "Unrelated menu text",
+    }
+    plan = normalize_line_resegmentation_plan(
+        lines=lines,
+        words=words,
+        letters=letters,
+        labels=labels,
+        segments=[
+            {
+                "segment_key": "card-slip",
+                "z_index": 0,
+                "occluded_by": ["guest-check"],
+            },
+            {
+                "segment_key": "guest-check",
+                "z_index": 1,
+                "occluded_by": [],
+            },
+        ],
+        assignments=assignments,
+    )
+
+    assert plan["totals"] == {
+        "source_lines": 59,
+        "mixed_lines": 3,
+        "source_words": 136,
+        "assigned_words": 130,
+        "discarded_words": 6,
+        "source_letters": 632,
+        "assigned_letters": 614,
+        "discarded_letters": 18,
+        "source_labels": 83,
+        "preserved_labels": 83,
+        "discarded_labels": 0,
+    }
+    assert [segment["word_count"] for segment in plan["segments"]] == [
+        54,
+        76,
+    ]
+    assert [segment["label_count"] for segment in plan["segments"]] == [19, 64]
+    assert [segment["letter_count"] for segment in plan["segments"]] == [
+        253,
+        361,
+    ]
+    assert plan["discard"]["letter_count"] == 18
+    assert plan["segments"][0]["mixed_line_ids"] == [34, 35, 36]
+
+
+def test_duplicate_assignment_is_rejected():
+    words = [_word(1, 1)]
+    with pytest.raises(ResegmentPlanError, match="duplicates assignments"):
+        normalize_resegmentation_plan(
+            words=words,
+            labels=[],
+            segments=[
+                {"segment_key": "a", "include_line_ids": [1]},
+                {
+                    "segment_key": "b",
+                    "include_word_refs": [{"line_id": 1, "word_id": 1}],
+                },
+            ],
+        )
+
+
+def test_unassigned_word_is_rejected():
+    with pytest.raises(ResegmentPlanError, match="unassigned words"):
+        normalize_resegmentation_plan(
+            words=[_word(1, 1), _word(2, 1)],
+            labels=[],
+            segments=[{"segment_key": "a", "include_line_ids": [1]}],
+        )
+
+
+def test_labeled_discard_requires_explicit_acknowledgement():
+    words = [_word(1, 1), _word(2, 1)]
+    labels = [
+        {
+            "line_id": 2,
+            "word_id": 1,
+            "label": "GRAND_TOTAL",
+            "validation_status": "VALID",
+        }
+    ]
+    with pytest.raises(ResegmentPlanError, match="labeled words"):
+        normalize_resegmentation_plan(
+            words=words,
+            labels=labels,
+            segments=[{"segment_key": "a", "include_line_ids": [1]}],
+            discard_line_ids=[2],
+            discard_reason="Not part of the receipt",
+        )
+
+
+def test_invalid_word_reference_and_place_policy_are_rejected():
+    words = [_word(1, 1)]
+    with pytest.raises(ResegmentPlanError, match="requires either"):
+        normalize_resegmentation_plan(
+            words=words,
+            labels=[],
+            segments=[
+                {
+                    "segment_key": "a",
+                    "include_word_refs": [{"line_id": 1}],
+                }
+            ],
+        )
+
+    with pytest.raises(ResegmentPlanError, match="place_policy"):
+        normalize_resegmentation_plan(
+            words=words,
+            labels=[],
+            segments=[
+                {
+                    "segment_key": "a",
+                    "include_line_ids": [1],
+                    "place_policy": "guess",
+                }
+            ],
+        )
+
+
+def test_orphan_label_is_rejected_before_planning():
+    with pytest.raises(ResegmentPlanError, match="without matching words"):
+        normalize_resegmentation_plan(
+            words=[_word(1, 1)],
+            labels=[
+                {
+                    "line_id": 2,
+                    "word_id": 1,
+                    "label": "GRAND_TOTAL",
+                    "validation_status": "VALID",
+                }
+            ],
+            segments=[{"segment_key": "a", "include_line_ids": [1]}],
+        )
+
+
+def test_source_fingerprint_changes_with_word_or_label_state():
+    receipt = {
+        "image_id": "img",
+        "receipt_id": 1,
+        "width": 100,
+        "height": 200,
+        "top_left": {"x": 0.0, "y": 1.0},
+        "top_right": {"x": 1.0, "y": 1.0},
+        "bottom_left": {"x": 0.0, "y": 0.0},
+        "bottom_right": {"x": 1.0, "y": 0.0},
+    }
+    words = [_word(1, 1)]
+    labels = [
+        {
+            "line_id": 1,
+            "word_id": 1,
+            "label": "ADDRESS_LINE",
+            "validation_status": "INVALID",
+        }
+    ]
+    original = build_source_fingerprint(
+        receipt=receipt, words=words, labels=labels
+    )
+    changed_words = [{**words[0], "text": "changed"}]
+    changed_labels = [{**labels[0], "validation_status": "VALID"}]
+
+    assert original != build_source_fingerprint(
+        receipt=receipt, words=changed_words, labels=labels
+    )
+    assert original != build_source_fingerprint(
+        receipt=receipt, words=words, labels=changed_labels
+    )
+    assert original != build_source_fingerprint(
+        receipt=receipt,
+        words=words,
+        labels=labels,
+        place={"place_id": "new-place"},
+    )
+
+
+def test_v2_source_fingerprint_covers_image_lines_letters_and_source_bytes():
+    receipt = {
+        "image_id": "img",
+        "receipt_id": 1,
+        "width": 100,
+        "height": 200,
+        "top_left": {"x": 0.0, "y": 1.0},
+        "top_right": {"x": 1.0, "y": 1.0},
+        "bottom_left": {"x": 0.0, "y": 0.0},
+        "bottom_right": {"x": 1.0, "y": 0.0},
+    }
+    kwargs = {
+        "receipt": receipt,
+        "words": [_word(1, 1)],
+        "labels": [],
+        "image": {
+            "image_id": "img",
+            "image_type": "PHOTO",
+            "width": 100,
+            "height": 200,
+        },
+        "lines": [{"line_id": 1, "text": "CARD", "angle_degrees": 0.0}],
+        "letters": [
+            {
+                "line_id": 1,
+                "word_id": 1,
+                "letter_id": 1,
+                "text": "C",
+            }
+        ],
+        "source_object": {"content_sha256": "abc", "version_id": "v1"},
+        "source_type_counts": {"RECEIPT_LINE": 1, "RECEIPT_WORD": 1},
+    }
+    original = build_source_fingerprint(**kwargs)
+
+    for field, replacement in (
+        ("image", {**kwargs["image"], "image_type": "SCAN"}),
+        ("lines", [{**kwargs["lines"][0], "text": "CHANGED"}]),
+        ("letters", [{**kwargs["letters"][0], "text": "X"}]),
+        ("source_object", {"content_sha256": "changed", "version_id": "v1"}),
+        ("source_type_counts", {"RECEIPT_LINE": 2, "RECEIPT_WORD": 1}),
+    ):
+        changed = {**kwargs, field: replacement}
+        assert build_source_fingerprint(**changed) != original
+
+
+def test_line_first_plan_rejects_missing_lines_and_noncontiguous_overrides():
+    lines = [{"line_id": 1}, {"line_id": 2}]
+    words = [_word(1, word_id) for word_id in (1, 2, 3)] + [_word(2, 1)]
+    segments = [{"segment_key": "a"}, {"segment_key": "b"}]
+
+    with pytest.raises(ResegmentPlanError, match="unassigned lines"):
+        normalize_line_resegmentation_plan(
+            lines=lines,
+            words=words,
+            labels=[],
+            segments=segments,
+            assignments={
+                "lines": [{"line_id": 1, "segment_key": "a"}],
+            },
+        )
+
+    with pytest.raises(ResegmentPlanError, match="contiguous word span"):
+        normalize_line_resegmentation_plan(
+            lines=lines,
+            words=words,
+            labels=[],
+            segments=segments,
+            assignments={
+                "lines": [
+                    {"line_id": 1, "segment_key": "a"},
+                    {"line_id": 2, "segment_key": "b"},
+                ],
+                "words": [
+                    {
+                        "line_id": 1,
+                        "word_ids": [1, 3],
+                        "segment_key": "b",
+                        "reason": "invalid split",
+                    }
+                ],
+            },
+        )

--- a/receipt_upload/tests/test_resegment_preview.py
+++ b/receipt_upload/tests/test_resegment_preview.py
@@ -165,3 +165,65 @@ def test_photo_rectangular_preview_blocks_disconnected_regions():
         if finding["code"] == "DISCONNECTED_VISIBLE_REGIONS"
     )
     assert finding["severity"] == "BLOCKER"
+
+
+def test_rectangular_preview_with_geometry_blocks_disconnected_regions():
+    """Production plans always carry geometry; the rectangle covers every
+    assigned line, so disconnection must still be detected from the line
+    clusters themselves."""
+    words = [_word(1, 1, 30, 70), _word(2, 1, 35, 530)]
+    words_by_ref = {(word["line_id"], word["word_id"]): word for word in words}
+
+    bundle = build_preview_bundle(
+        Image.new("RGB", (400, 600), "white"),
+        image_type="PHOTO",
+        strategy="RECTANGULAR",
+        lines=[_line(1), _line(2)],
+        words_by_ref=words_by_ref,
+        segments=[
+            {
+                **_segment("underlay", [(1, 1), (2, 1)], 0),
+                "geometry": {
+                    "src_corners": [[0, 40], [400, 40], [400, 560], [0, 560]]
+                },
+            }
+        ],
+        discard_refs=set(),
+        padding_px=0,
+    )
+
+    finding = next(
+        finding
+        for finding in bundle["findings"]
+        if finding["code"] == "DISCONNECTED_VISIBLE_REGIONS"
+    )
+    assert finding["severity"] == "BLOCKER"
+    assert bundle["metrics"]["underlay"]["visible_region_count"] == 2
+
+
+def test_rectangular_preview_with_geometry_allows_contiguous_lines():
+    words = [_word(1, 1, 30, 70), _word(2, 1, 35, 95)]
+    words_by_ref = {(word["line_id"], word["word_id"]): word for word in words}
+
+    bundle = build_preview_bundle(
+        Image.new("RGB", (400, 600), "white"),
+        image_type="PHOTO",
+        strategy="RECTANGULAR",
+        lines=[_line(1), _line(2)],
+        words_by_ref=words_by_ref,
+        segments=[
+            {
+                **_segment("receipt", [(1, 1), (2, 1)], 0),
+                "geometry": {
+                    "src_corners": [[0, 40], [400, 40], [400, 130], [0, 130]]
+                },
+            }
+        ],
+        discard_refs=set(),
+        padding_px=0,
+    )
+
+    assert not any(
+        finding["code"] == "DISCONNECTED_VISIBLE_REGIONS"
+        for finding in bundle["findings"]
+    )

--- a/receipt_upload/tests/test_resegment_preview.py
+++ b/receipt_upload/tests/test_resegment_preview.py
@@ -142,3 +142,26 @@ def test_scan_rectangular_preview_blocks_foreign_word_capture():
     }
     assert ("FOREIGN_WORD_CAPTURED", "first") in blockers
     assert ("FOREIGN_WORD_CAPTURED", "second") in blockers
+
+
+def test_photo_rectangular_preview_blocks_disconnected_regions():
+    words = [_word(1, 1, 30, 70), _word(2, 1, 35, 530)]
+    words_by_ref = {(word["line_id"], word["word_id"]): word for word in words}
+
+    bundle = build_preview_bundle(
+        Image.new("RGB", (400, 600), "white"),
+        image_type="PHOTO",
+        strategy="RECTANGULAR",
+        lines=[_line(1), _line(2)],
+        words_by_ref=words_by_ref,
+        segments=[_segment("underlay", [(1, 1), (2, 1)], 0)],
+        discard_refs=set(),
+        padding_px=0,
+    )
+
+    finding = next(
+        finding
+        for finding in bundle["findings"]
+        if finding["code"] == "DISCONNECTED_VISIBLE_REGIONS"
+    )
+    assert finding["severity"] == "BLOCKER"

--- a/receipt_upload/tests/test_resegment_preview.py
+++ b/receipt_upload/tests/test_resegment_preview.py
@@ -227,3 +227,54 @@ def test_rectangular_preview_with_geometry_allows_contiguous_lines():
         finding["code"] == "DISCONNECTED_VISIBLE_REGIONS"
         for finding in bundle["findings"]
     )
+
+
+def test_rectangular_preview_ignores_explicit_visible_regions():
+    """Apply writes the min-area crop for RECTANGULAR plans, so a tight
+    explicit region must not mask preview findings (here: a foreign word
+    inside the rectangle) that the applied crop would contain."""
+    words = [_word(1, 1, 30, 100), _word(2, 1, 80, 120)]
+    words_by_ref = {(word["line_id"], word["word_id"]): word for word in words}
+
+    bundle = build_preview_bundle(
+        Image.new("RGB", (400, 600), "white"),
+        image_type="SCAN",
+        strategy="RECTANGULAR",
+        lines=[_line(1), _line(2)],
+        words_by_ref=words_by_ref,
+        segments=[
+            {
+                **_segment("first", [(1, 1)], 0),
+                "geometry": {
+                    "src_corners": [[0, 50], [200, 50], [200, 200], [0, 200]]
+                },
+                # A tight region around only the assigned word; honoring it
+                # would hide the foreign-word capture below.
+                "visible_regions": [
+                    {
+                        "points": [
+                            {"x": 0.05, "y": 0.80},
+                            {"x": 0.30, "y": 0.80},
+                            {"x": 0.30, "y": 0.87},
+                            {"x": 0.05, "y": 0.87},
+                        ]
+                    }
+                ],
+            },
+            {
+                **_segment("second", [(2, 1)], 0),
+                "geometry": {
+                    "src_corners": [[0, 50], [200, 50], [200, 200], [0, 200]]
+                },
+            },
+        ],
+        discard_refs=set(),
+        padding_px=0,
+    )
+
+    blockers = {
+        (finding["code"], finding.get("segment_key"))
+        for finding in bundle["findings"]
+        if finding["severity"] == "BLOCKER"
+    }
+    assert ("FOREIGN_WORD_CAPTURED", "first") in blockers

--- a/receipt_upload/tests/test_resegment_preview.py
+++ b/receipt_upload/tests/test_resegment_preview.py
@@ -1,0 +1,144 @@
+"""Visual evidence tests for PHOTO and SCAN re-segmentation."""
+
+from PIL import Image
+
+from receipt_upload.resegment import build_preview_bundle
+
+
+def _word(line_id: int, word_id: int, x: float, pil_y: float) -> dict:
+    height = 600
+    width = 70
+    box_height = 18
+    return {
+        "line_id": line_id,
+        "word_id": word_id,
+        "text": f"w{line_id}-{word_id}",
+        "top_left": {"x": x, "y": height - pil_y},
+        "top_right": {"x": x + width, "y": height - pil_y},
+        "bottom_left": {"x": x, "y": height - pil_y - box_height},
+        "bottom_right": {
+            "x": x + width,
+            "y": height - pil_y - box_height,
+        },
+        "angle_degrees": 0.0,
+        "confidence": 0.95,
+    }
+
+
+def _line(line_id: int) -> dict:
+    return {
+        "line_id": line_id,
+        "text": f"line {line_id}",
+        "angle_degrees": 0.0,
+        "confidence": 0.95,
+    }
+
+
+def _letter(line_id: int, word_id: int, slope: float = 0.02) -> dict:
+    return {
+        "line_id": line_id,
+        "word_id": word_id,
+        "letter_id": 1,
+        "text": "x",
+        "bottom_left": {"x": 0.1, "y": 0.1},
+        "bottom_right": {"x": 0.2, "y": 0.1 + slope},
+    }
+
+
+def _segment(key: str, refs: list[tuple[int, int]], z_index: int) -> dict:
+    return {
+        "segment_key": key,
+        "word_refs": [
+            {"line_id": line_id, "word_id": word_id}
+            for line_id, word_id in refs
+        ],
+        "z_index": z_index,
+        "visible_regions": [],
+    }
+
+
+def test_photo_preview_preserves_disconnected_underlay_and_inline_sheet():
+    words = [
+        _word(1, 1, 20, 55),
+        _word(2, 1, 24, 90),
+        _word(3, 1, 35, 500),
+        _word(4, 1, 38, 535),
+        _word(10, 1, 190, 210),
+        _word(11, 1, 195, 250),
+        _word(12, 1, 200, 290),
+    ]
+    words_by_ref = {(word["line_id"], word["word_id"]): word for word in words}
+    card_refs = [(1, 1), (2, 1), (3, 1), (4, 1)]
+    guest_refs = [(10, 1), (11, 1), (12, 1)]
+
+    bundle = build_preview_bundle(
+        Image.new("RGB", (400, 600), "white"),
+        image_type="PHOTO",
+        strategy="LAYERED_MULTI_REGION",
+        lines=[_line(line_id) for line_id in (1, 2, 3, 4, 10, 11, 12)],
+        words_by_ref=words_by_ref,
+        segments=[
+            {
+                **_segment("card", card_refs, 0),
+                "occluded_by": ["guest"],
+            },
+            _segment("guest", guest_refs, 1),
+        ],
+        discard_refs=set(),
+        letters=[_letter(line_id, 1) for line_id in (1, 2, 3, 4, 10, 11, 12)],
+        padding_px=6,
+    )
+
+    assert bundle["metrics"]["card"]["visible_region_count"] == 2
+    assert bundle["metrics"]["guest"]["visible_region_count"] == 1
+    assert bundle["metrics"]["card"]["word_centroids_retained"] == 4
+    assert bundle["metrics"]["guest"]["word_centroids_retained"] == 3
+    assert bundle["metrics"]["card"]["assigned_letter_count"] == 4
+    assert bundle["metrics"]["guest"]["assigned_letter_count"] == 3
+    assert bundle["metrics"]["card"]["foreign_word_centroids_in_mask"] == 0
+    assert bundle["metrics"]["guest"]["foreign_word_centroids_in_mask"] == 0
+    assert bundle["images"]["segments"]["card"]["visible_crop"].mode == "RGBA"
+    assert bundle["images"]["contact_sheet"].width <= 1400
+    assert bundle["evidence"]["lines"][0]["derived_baseline_source"] == (
+        "LETTER_CORNERS"
+    )
+    assert {finding["code"] for finding in bundle["findings"]} >= {
+        "LAYERED_APPLY_NOT_SUPPORTED",
+        "DISCONNECTED_VISIBLE_REGIONS",
+    }
+
+
+def test_scan_rectangular_preview_blocks_foreign_word_capture():
+    words = [_word(1, 1, 30, 100), _word(2, 1, 80, 120)]
+    words_by_ref = {(word["line_id"], word["word_id"]): word for word in words}
+    overlapping_geometry = {
+        "src_corners": [[0, 50], [200, 50], [200, 200], [0, 200]]
+    }
+
+    bundle = build_preview_bundle(
+        Image.new("RGB", (400, 600), "white"),
+        image_type="SCAN",
+        strategy="RECTANGULAR",
+        lines=[_line(1), _line(2)],
+        words_by_ref=words_by_ref,
+        segments=[
+            {
+                **_segment("first", [(1, 1)], 0),
+                "geometry": overlapping_geometry,
+            },
+            {
+                **_segment("second", [(2, 1)], 0),
+                "geometry": overlapping_geometry,
+            },
+        ],
+        discard_refs=set(),
+        padding_px=0,
+    )
+
+    blockers = {
+        (finding["code"], finding.get("segment_key"))
+        for finding in bundle["findings"]
+        if finding["severity"] == "BLOCKER"
+    }
+    assert ("FOREIGN_WORD_CAPTURED", "first") in blockers
+    assert ("FOREIGN_WORD_CAPTURED", "second") in blockers

--- a/scripts/receipt_mcp_server.py
+++ b/scripts/receipt_mcp_server.py
@@ -18,10 +18,12 @@ Environment:
 """
 
 import asyncio
+import base64
 import json
 import logging
 import os
 import sys
+import urllib.request
 from collections import defaultdict
 from typing import Any, Optional
 
@@ -36,7 +38,7 @@ sys.path.insert(0, os.path.join(parent_dir, "receipt_chroma"))
 
 from mcp.server import Server
 from mcp.server.stdio import stdio_server
-from mcp.types import TextContent, Tool
+from mcp.types import ImageContent, TextContent, Tool
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -105,6 +107,165 @@ def get_clients():
 
 # Create MCP server
 server = Server("receipt-tools")
+
+
+def _resegment_word_ref_schema() -> dict:
+    return {
+        "type": "object",
+        "properties": {
+            "line_id": {"type": "integer"},
+            "word_id": {"type": "integer"},
+            "word_ids": {"type": "array", "items": {"type": "integer"}},
+        },
+        "required": ["line_id"],
+        "oneOf": [{"required": ["word_id"]}, {"required": ["word_ids"]}],
+    }
+
+
+def _resegment_visible_region_schema() -> dict:
+    return {
+        "type": "object",
+        "description": (
+            "A visible PHOTO region in normalized IMAGE coordinates (x left-to-right, "
+            "y bottom-to-top). Disconnected receipts may provide multiple regions."
+        ),
+        "properties": {
+            "region_id": {"type": "string"},
+            "line_ids": {
+                "type": "array",
+                "items": {"type": "integer"},
+                "description": "Optional lines expected in this visible component.",
+            },
+            "points": {
+                "type": "array",
+                "minItems": 3,
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "x": {"type": "number", "minimum": 0, "maximum": 1},
+                        "y": {"type": "number", "minimum": 0, "maximum": 1},
+                    },
+                    "required": ["x", "y"],
+                },
+            },
+        },
+        "required": ["points"],
+    }
+
+
+def _resegment_segment_schema(*, legacy_selectors: bool = True) -> dict:
+    properties = {
+        "segment_key": {"type": "string"},
+        "place_policy": {
+            "type": "string",
+            "enum": ["inherit", "none"],
+            "default": "none",
+        },
+        "z_index": {
+            "type": "integer",
+            "default": 0,
+            "description": "PHOTO layer order; larger values are in front.",
+        },
+        "occluded_by": {
+            "type": "array",
+            "items": {"type": "string"},
+        },
+        "visible_regions": {
+            "type": "array",
+            "items": _resegment_visible_region_schema(),
+        },
+    }
+    if legacy_selectors:
+        properties.update(
+            {
+                "include_line_ids": {
+                    "type": "array",
+                    "items": {"type": "integer"},
+                },
+                "include_word_refs": {
+                    "type": "array",
+                    "items": _resegment_word_ref_schema(),
+                },
+            }
+        )
+    return {
+        "type": "object",
+        "properties": properties,
+        "required": ["segment_key"],
+    }
+
+
+def _resegment_assignments_schema() -> dict:
+    return {
+        "type": "object",
+        "description": (
+            "Schema v2 line-first ownership. Every line must appear exactly once in "
+            "lines or discard_lines; words are sparse contiguous overrides."
+        ),
+        "properties": {
+            "lines": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "line_id": {"type": "integer"},
+                        "segment_key": {"type": "string"},
+                    },
+                    "required": ["line_id", "segment_key"],
+                },
+            },
+            "words": {
+                "type": "array",
+                "items": {
+                    **_resegment_word_ref_schema(),
+                    "properties": {
+                        **_resegment_word_ref_schema()["properties"],
+                        "segment_key": {"type": "string"},
+                        "reason": {"type": "string"},
+                    },
+                    "required": ["line_id", "segment_key", "reason"],
+                },
+            },
+            "discard_lines": {
+                "type": "array",
+                "items": {"type": "integer"},
+            },
+            "discard_words": {
+                "type": "array",
+                "items": _resegment_word_ref_schema(),
+            },
+            "discard_reason": {"type": "string"},
+            "allow_labeled_discard": {"type": "boolean", "default": False},
+        },
+        "required": ["lines"],
+    }
+
+
+def _resegment_visualization_schema() -> dict:
+    return {
+        "type": "object",
+        "properties": {
+            "strategy": {
+                "type": "string",
+                "enum": ["AUTO", "RECTANGULAR", "LAYERED_MULTI_REGION"],
+                "default": "AUTO",
+            },
+            "padding_px": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 256,
+                "default": 12,
+            },
+            "confirm_stacked_scan": {
+                "type": "boolean",
+                "default": False,
+                "description": (
+                    "Required before using layered geometry on a stored SCAN. "
+                    "The stored image_type cannot be overridden by the caller."
+                ),
+            },
+        },
+    }
 
 
 @server.list_tools()
@@ -514,7 +675,14 @@ WARNING: This WRITES to DynamoDB. Double-check the word context before calling."
                         "description": "Why this status was chosen (e.g., 'tax flag indicator, not a product name'). Overwrites existing reasoning.",
                     },
                 },
-                "required": ["image_id", "receipt_id", "line_id", "word_id", "label", "new_status"],
+                "required": [
+                    "image_id",
+                    "receipt_id",
+                    "line_id",
+                    "word_id",
+                    "label",
+                    "new_status",
+                ],
             },
         ),
         Tool(
@@ -573,7 +741,14 @@ image_id/receipt_id/line_id/word_id/label already exists.""",
                         "description": "Validation status for the new row. Defaults to VALID (human-reviewed). Use PENDING for machine-propagated rows (e.g. SECTION_* sections) that still need QA.",
                     },
                 },
-                "required": ["image_id", "receipt_id", "line_id", "word_id", "label", "reasoning"],
+                "required": [
+                    "image_id",
+                    "receipt_id",
+                    "line_id",
+                    "word_id",
+                    "label",
+                    "reasoning",
+                ],
             },
         ),
         Tool(
@@ -620,6 +795,134 @@ and DELETES the original receipts. Only proceed after verifying with dry_run."""
                     },
                 },
                 "required": ["image_id", "receipt_ids"],
+            },
+        ),
+        Tool(
+            name="plan_receipt_resegmentation",
+            description="""Plan a safe split of one receipt into one or more outputs.
+
+Use schema_version=2 for line-first ownership. Every source line receives one
+default destination; sparse contiguous word overrides handle mixed OCR lines.
+The stored image_type selects PHOTO/SCAN behavior and cannot be overridden.
+The tool creates an assignment overlay, contact sheet, masks, visible crops,
+metrics, and one-hour signed URLs without changing receipt data.
+
+Review the returned image, findings, metrics, totals, and label counts. Revise
+the plan until clean before applying. Layered PHOTO plans are review-only until
+masked output rendering is explicitly enabled.""",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "image_id": {"type": "string"},
+                    "source_receipt_id": {"type": "integer"},
+                    "schema_version": {
+                        "type": "integer",
+                        "enum": [1, 2],
+                        "default": 1,
+                        "description": (
+                            "Use 2 with assignments for line-first planning. "
+                            "Version 1 remains available for legacy word selectors."
+                        ),
+                    },
+                    "segments": {
+                        "type": "array",
+                        "minItems": 1,
+                        "maxItems": 23,
+                        "items": _resegment_segment_schema(),
+                    },
+                    "assignments": _resegment_assignments_schema(),
+                    "visualization": _resegment_visualization_schema(),
+                    "discard_line_ids": {
+                        "type": "array",
+                        "items": {"type": "integer"},
+                    },
+                    "discard_word_refs": {
+                        "type": "array",
+                        "items": _resegment_word_ref_schema(),
+                    },
+                    "discard_reason": {"type": "string"},
+                    "allow_labeled_discard": {
+                        "type": "boolean",
+                        "default": False,
+                    },
+                    "padding_px": {
+                        "type": "number",
+                        "minimum": 0,
+                        "maximum": 256,
+                        "default": 12,
+                    },
+                },
+                "required": ["image_id", "source_receipt_id", "segments"],
+            },
+        ),
+        Tool(
+            name="get_receipt_resegmentation_plan",
+            description="""Retrieve a receipt re-segmentation plan revision.
+
+Returns the immutable assignment evidence, metrics, findings, artifact hashes,
+and freshly signed visualization URLs. Use this whenever preview URLs expire or
+before revising/applying to verify that a revision is still latest and applicable.""",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "plan_id": {"type": "string"},
+                    "revision": {"type": "integer", "minimum": 1},
+                },
+                "required": ["plan_id"],
+            },
+        ),
+        Tool(
+            name="revise_receipt_resegmentation_plan",
+            description="""Create an immutable replacement plan revision.
+
+Submit complete segment definitions and line-first assignments. base_revision
+and base_plan_hash provide optimistic concurrency protection; stale revisions
+are rejected. The new revision receives new overlay, mask, crop, and contact-
+sheet artifacts while the previous revision remains reviewable.""",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "plan_id": {"type": "string"},
+                    "base_revision": {"type": "integer", "minimum": 1},
+                    "base_plan_hash": {"type": "string"},
+                    "segments": {
+                        "type": "array",
+                        "minItems": 1,
+                        "maxItems": 23,
+                        "items": _resegment_segment_schema(legacy_selectors=False),
+                    },
+                    "assignments": _resegment_assignments_schema(),
+                    "visualization": _resegment_visualization_schema(),
+                    "revision_reason": {"type": "string", "minLength": 1},
+                },
+                "required": [
+                    "plan_id",
+                    "base_revision",
+                    "base_plan_hash",
+                    "segments",
+                    "assignments",
+                    "revision_reason",
+                ],
+            },
+        ),
+        Tool(
+            name="apply_receipt_resegmentation",
+            description="""Apply a previously reviewed receipt re-segmentation plan.
+
+The apply is guarded by the plan hash and source fingerprint. New receipt IDs
+are reserved invisibly, children and embeddings are staged and verified, and
+the output parents replace the source parent atomically. Cleanup is resumable.
+
+WARNING: This creates new receipt records and deletes the source receipt after
+the staged outputs are ready. Superseded revisions and plans with blocking
+findings—including layered PHOTO plans—are rejected.""",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "plan_id": {"type": "string"},
+                    "plan_hash": {"type": "string"},
+                },
+                "required": ["plan_id", "plan_hash"],
             },
         ),
         Tool(
@@ -912,8 +1215,14 @@ YYYY-MM-DD, inclusive, in America/Los_Angeles.""",
             inputSchema={
                 "type": "object",
                 "properties": {
-                    "start_date": {"type": "string", "description": "Start date YYYY-MM-DD (PT, inclusive)"},
-                    "end_date": {"type": "string", "description": "End date YYYY-MM-DD (PT, inclusive)"},
+                    "start_date": {
+                        "type": "string",
+                        "description": "Start date YYYY-MM-DD (PT, inclusive)",
+                    },
+                    "end_date": {
+                        "type": "string",
+                        "description": "End date YYYY-MM-DD (PT, inclusive)",
+                    },
                 },
                 "required": ["start_date", "end_date"],
             },
@@ -929,10 +1238,24 @@ real outside humans. Ordered by activity.""",
             inputSchema={
                 "type": "object",
                 "properties": {
-                    "start_date": {"type": "string", "description": "Start date YYYY-MM-DD (PT)"},
-                    "end_date": {"type": "string", "description": "End date YYYY-MM-DD (PT)"},
-                    "humans_only": {"type": "boolean", "default": True, "description": "Exclude bots + WARP (default true)"},
-                    "limit": {"type": "integer", "default": 50, "description": "Max sessions to return"},
+                    "start_date": {
+                        "type": "string",
+                        "description": "Start date YYYY-MM-DD (PT)",
+                    },
+                    "end_date": {
+                        "type": "string",
+                        "description": "End date YYYY-MM-DD (PT)",
+                    },
+                    "humans_only": {
+                        "type": "boolean",
+                        "default": True,
+                        "description": "Exclude bots + WARP (default true)",
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "default": 50,
+                        "description": "Max sessions to return",
+                    },
                 },
                 "required": ["start_date", "end_date"],
             },
@@ -948,9 +1271,21 @@ Use to answer "who just visited" without hand-writing SQL against raw logs.""",
             inputSchema={
                 "type": "object",
                 "properties": {
-                    "hours": {"type": "integer", "default": 6, "description": "Look-back window in hours (default 6, max 48)"},
-                    "humans_only": {"type": "boolean", "default": True, "description": "Exclude bots + WARP (default true)"},
-                    "limit": {"type": "integer", "default": 50, "description": "Max rows (default 50, max 200)"},
+                    "hours": {
+                        "type": "integer",
+                        "default": 6,
+                        "description": "Look-back window in hours (default 6, max 48)",
+                    },
+                    "humans_only": {
+                        "type": "boolean",
+                        "default": True,
+                        "description": "Exclude bots + WARP (default true)",
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "default": 50,
+                        "description": "Max rows (default 50, max 200)",
+                    },
                 },
                 "required": [],
             },
@@ -965,11 +1300,29 @@ Returns value + hit count + distinct sessions. Bots + WARP excluded by default."
             inputSchema={
                 "type": "object",
                 "properties": {
-                    "dimension": {"type": "string", "enum": ["page", "referrer", "ip", "country", "org"], "description": "What to rank"},
-                    "start_date": {"type": "string", "description": "Start date YYYY-MM-DD (PT)"},
-                    "end_date": {"type": "string", "description": "End date YYYY-MM-DD (PT)"},
-                    "limit": {"type": "integer", "default": 15, "description": "Max rows"},
-                    "humans_only": {"type": "boolean", "default": True, "description": "Exclude bots + WARP (default true)"},
+                    "dimension": {
+                        "type": "string",
+                        "enum": ["page", "referrer", "ip", "country", "org"],
+                        "description": "What to rank",
+                    },
+                    "start_date": {
+                        "type": "string",
+                        "description": "Start date YYYY-MM-DD (PT)",
+                    },
+                    "end_date": {
+                        "type": "string",
+                        "description": "End date YYYY-MM-DD (PT)",
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "default": 15,
+                        "description": "Max rows",
+                    },
+                    "humans_only": {
+                        "type": "boolean",
+                        "default": True,
+                        "description": "Exclude bots + WARP (default true)",
+                    },
                 },
                 "required": ["dimension", "start_date", "end_date"],
             },
@@ -986,8 +1339,14 @@ that up separately (e.g. an IP-info service).""",
                 "type": "object",
                 "properties": {
                     "ip": {"type": "string", "description": "Client IP (v4 or v6)"},
-                    "start_date": {"type": "string", "description": "Start date YYYY-MM-DD (PT)"},
-                    "end_date": {"type": "string", "description": "End date YYYY-MM-DD (PT)"},
+                    "start_date": {
+                        "type": "string",
+                        "description": "Start date YYYY-MM-DD (PT)",
+                    },
+                    "end_date": {
+                        "type": "string",
+                        "description": "End date YYYY-MM-DD (PT)",
+                    },
                 },
                 "required": ["ip", "start_date", "end_date"],
             },
@@ -1004,7 +1363,10 @@ analytics_* tools; use this only when they don't fit.""",
             inputSchema={
                 "type": "object",
                 "properties": {
-                    "sql": {"type": "string", "description": "A single read-only SELECT/WITH query"},
+                    "sql": {
+                        "type": "string",
+                        "description": "A single read-only SELECT/WITH query",
+                    },
                 },
                 "required": ["sql"],
             },
@@ -1021,8 +1383,14 @@ via analytics_reconcile. Dates YYYY-MM-DD, inclusive.""",
             inputSchema={
                 "type": "object",
                 "properties": {
-                    "start_date": {"type": "string", "description": "Start date YYYY-MM-DD"},
-                    "end_date": {"type": "string", "description": "End date YYYY-MM-DD"},
+                    "start_date": {
+                        "type": "string",
+                        "description": "Start date YYYY-MM-DD",
+                    },
+                    "end_date": {
+                        "type": "string",
+                        "description": "End date YYYY-MM-DD",
+                    },
                 },
                 "required": ["start_date", "end_date"],
             },
@@ -1039,8 +1407,14 @@ can mean bot leakage. Dates YYYY-MM-DD, inclusive (Pacific).""",
             inputSchema={
                 "type": "object",
                 "properties": {
-                    "start_date": {"type": "string", "description": "Start date YYYY-MM-DD"},
-                    "end_date": {"type": "string", "description": "End date YYYY-MM-DD"},
+                    "start_date": {
+                        "type": "string",
+                        "description": "Start date YYYY-MM-DD",
+                    },
+                    "end_date": {
+                        "type": "string",
+                        "description": "End date YYYY-MM-DD",
+                    },
                 },
                 "required": ["start_date", "end_date"],
             },
@@ -1057,8 +1431,14 @@ Referrers/paths reflect the most recent 14-day snapshot. Dates YYYY-MM-DD.""",
             inputSchema={
                 "type": "object",
                 "properties": {
-                    "start_date": {"type": "string", "description": "Start date YYYY-MM-DD"},
-                    "end_date": {"type": "string", "description": "End date YYYY-MM-DD"},
+                    "start_date": {
+                        "type": "string",
+                        "description": "Start date YYYY-MM-DD",
+                    },
+                    "end_date": {
+                        "type": "string",
+                        "description": "End date YYYY-MM-DD",
+                    },
                 },
                 "required": ["start_date", "end_date"],
             },
@@ -1084,7 +1464,14 @@ Use status_filter to narrow results (e.g., "succeeded", "running", "failed")."""
                     },
                     "status_filter": {
                         "type": "string",
-                        "enum": ["succeeded", "running", "failed", "pending", "cancelled", "interrupted"],
+                        "enum": [
+                            "succeeded",
+                            "running",
+                            "failed",
+                            "pending",
+                            "cancelled",
+                            "interrupted",
+                        ],
                         "description": "Filter jobs by status (optional)",
                     },
                 },
@@ -1304,8 +1691,26 @@ WARNING: This WRITES to DynamoDB and is irreversible for that row.""",
     ]
 
 
+def _resegment_contact_sheet(result: Any) -> tuple[str, str] | None:
+    if not isinstance(result, dict):
+        return None
+    url = (result.get("preview_urls") or {}).get("contact_sheet")
+    artifact = (result.get("visualizations") or {}).get("contact_sheet") or {}
+    if not url:
+        return None
+    return url, artifact.get("mime_type", "image/jpeg")
+
+
+def _fetch_mcp_preview(url: str) -> bytes:
+    with urllib.request.urlopen(url, timeout=15) as response:  # nosec B310
+        data = response.read(2_500_001)
+    if len(data) > 2_500_000:
+        raise ValueError("MCP contact sheet exceeds 2.5 MB")
+    return data
+
+
 @server.call_tool()
-async def call_tool(name: str, arguments: dict) -> list[TextContent]:
+async def call_tool(name: str, arguments: dict) -> list[TextContent | ImageContent]:
     """Handle tool calls."""
     try:
         dynamo_client, chroma_client, embed_fn = get_clients()
@@ -1390,6 +1795,20 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent]:
                 receipt_ids=arguments["receipt_ids"],
                 dry_run=arguments.get("dry_run", True),
             )
+        elif name == "plan_receipt_resegmentation":
+            result = await plan_receipt_resegmentation_impl(arguments)
+        elif name == "get_receipt_resegmentation_plan":
+            result = await get_receipt_resegmentation_plan_impl(
+                plan_id=arguments["plan_id"],
+                revision=arguments.get("revision"),
+            )
+        elif name == "revise_receipt_resegmentation_plan":
+            result = await revise_receipt_resegmentation_plan_impl(arguments)
+        elif name == "apply_receipt_resegmentation":
+            result = await apply_receipt_resegmentation_impl(
+                plan_id=arguments["plan_id"],
+                plan_hash=arguments["plan_hash"],
+            )
         elif name == "get_receipt_words":
             result = await get_receipt_words_impl(
                 dynamo_client,
@@ -1413,9 +1832,7 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent]:
                 label=arguments["label"],
                 reasoning=arguments["reasoning"],
                 consolidated_from=arguments.get("consolidated_from"),
-                validation_status=arguments.get(
-                    "validation_status", "VALID"
-                ),
+                validation_status=arguments.get("validation_status", "VALID"),
             )
         elif name == "compute_reocr_region":
             result = await compute_reocr_region_impl(
@@ -1478,9 +1895,7 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent]:
                 section_type=arguments["section_type"],
                 line_ids=arguments["line_ids"],
                 validation_status=arguments.get("validation_status", "VALID"),
-                model_source=arguments.get(
-                    "model_source", "mcp-claude-review"
-                ),
+                model_source=arguments.get("model_source", "mcp-claude-review"),
             )
         elif name == "delete_receipt_section":
             result = await delete_receipt_section_impl(
@@ -1561,7 +1976,33 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent]:
         else:
             result = {"error": f"Unknown tool: {name}"}
 
-        return [TextContent(type="text", text=json.dumps(result, indent=2))]
+        content: list[TextContent | ImageContent] = [
+            TextContent(type="text", text=json.dumps(result, indent=2))
+        ]
+        if name in {
+            "plan_receipt_resegmentation",
+            "get_receipt_resegmentation_plan",
+            "revise_receipt_resegmentation_plan",
+        }:
+            contact_sheet = _resegment_contact_sheet(result)
+            if contact_sheet:
+                try:
+                    image_bytes = await asyncio.to_thread(
+                        _fetch_mcp_preview, contact_sheet[0]
+                    )
+                    content.append(
+                        ImageContent(
+                            type="image",
+                            data=base64.b64encode(image_bytes).decode("ascii"),
+                            mimeType=contact_sheet[1],
+                        )
+                    )
+                except Exception:
+                    logger.warning(
+                        "Unable to attach re-segmentation contact sheet",
+                        exc_info=True,
+                    )
+        return content
 
     except Exception as e:
         logger.exception("Tool error")
@@ -2334,15 +2775,18 @@ async def list_words_by_label_impl(
 
         words = []
         for record in sample:
-            words.append({
-                "text": getattr(record, "text", ""),
-                "validation_status": getattr(record, "validation_status", None) or "NONE",
-                "image_id": record.image_id,
-                "receipt_id": record.receipt_id,
-                "line_id": record.line_id,
-                "word_id": record.word_id,
-                "label_proposed_by": getattr(record, "label_proposed_by", None),
-            })
+            words.append(
+                {
+                    "text": getattr(record, "text", ""),
+                    "validation_status": getattr(record, "validation_status", None)
+                    or "NONE",
+                    "image_id": record.image_id,
+                    "receipt_id": record.receipt_id,
+                    "line_id": record.line_id,
+                    "word_id": record.word_id,
+                    "label_proposed_by": getattr(record, "label_proposed_by", None),
+                }
+            )
 
         return {
             "label": label,
@@ -2437,7 +2881,12 @@ async def validate_word_similarity_impl(
         evidence_for = []
         evidence_against = []
 
-        for metas, dists in [(positive_results.get("metadatas", [[]]), positive_results.get("distances", [[]]))]:
+        for metas, dists in [
+            (
+                positive_results.get("metadatas", [[]]),
+                positive_results.get("distances", [[]]),
+            )
+        ]:
             for meta, dist in zip(metas[0] if metas else [], dists[0] if dists else []):
                 sim = dist_to_sim(dist)
                 if sim < MIN_SIMILARITY:
@@ -2446,14 +2895,21 @@ async def validate_word_similarity_impl(
                 rid = f"IMAGE#{meta.get('image_id', '')}#RECEIPT#{meta.get('receipt_id', 0):05d}#LINE#{meta.get('line_id', 0):05d}#WORD#{meta.get('word_id', 0):05d}"
                 if rid == chroma_id:
                     continue
-                evidence_for.append({
-                    "text": meta.get("text", ""),
-                    "similarity": round(sim, 3),
-                    "merchant": meta.get("merchant_name", ""),
-                    "same_merchant": meta.get("merchant_name", "") == merchant_name,
-                })
+                evidence_for.append(
+                    {
+                        "text": meta.get("text", ""),
+                        "similarity": round(sim, 3),
+                        "merchant": meta.get("merchant_name", ""),
+                        "same_merchant": meta.get("merchant_name", "") == merchant_name,
+                    }
+                )
 
-        for metas, dists in [(negative_results.get("metadatas", [[]]), negative_results.get("distances", [[]]))]:
+        for metas, dists in [
+            (
+                negative_results.get("metadatas", [[]]),
+                negative_results.get("distances", [[]]),
+            )
+        ]:
             for meta, dist in zip(metas[0] if metas else [], dists[0] if dists else []):
                 sim = dist_to_sim(dist)
                 if sim < MIN_SIMILARITY:
@@ -2461,12 +2917,14 @@ async def validate_word_similarity_impl(
                 rid = f"IMAGE#{meta.get('image_id', '')}#RECEIPT#{meta.get('receipt_id', 0):05d}#LINE#{meta.get('line_id', 0):05d}#WORD#{meta.get('word_id', 0):05d}"
                 if rid == chroma_id:
                     continue
-                evidence_against.append({
-                    "text": meta.get("text", ""),
-                    "similarity": round(sim, 3),
-                    "merchant": meta.get("merchant_name", ""),
-                    "same_merchant": meta.get("merchant_name", "") == merchant_name,
-                })
+                evidence_against.append(
+                    {
+                        "text": meta.get("text", ""),
+                        "similarity": round(sim, 3),
+                        "merchant": meta.get("merchant_name", ""),
+                        "same_merchant": meta.get("merchant_name", "") == merchant_name,
+                    }
+                )
 
         total_matches = len(evidence_for) + len(evidence_against)
 
@@ -2523,7 +2981,9 @@ async def validate_word_similarity_impl(
             reason = f"{1.0 - confidence:.0%} of similar words rejected {label}"
         else:
             recommended_status = "NEEDS_REVIEW"
-            reason = f"Mixed evidence: {confidence:.0%} for, {1.0 - confidence:.0%} against"
+            reason = (
+                f"Mixed evidence: {confidence:.0%} for, {1.0 - confidence:.0%} against"
+            )
 
         # Find suggested labels if invalid or uncertain
         suggested_labels = []
@@ -2544,19 +3004,34 @@ async def validate_word_similarity_impl(
                         },
                         include=["distances"],
                     )
-                    cand_dists = cand_results.get("distances", [[]])[0] if cand_results.get("distances") else []
-                    cand_sims = [dist_to_sim(d) for d in cand_dists if dist_to_sim(d) >= MIN_SIMILARITY]
+                    cand_dists = (
+                        cand_results.get("distances", [[]])[0]
+                        if cand_results.get("distances")
+                        else []
+                    )
+                    cand_sims = [
+                        dist_to_sim(d)
+                        for d in cand_dists
+                        if dist_to_sim(d) >= MIN_SIMILARITY
+                    ]
                     if cand_sims:
                         avg_sim = sum(cand_sims) / len(cand_sims)
                         score = len(cand_sims) * avg_sim
-                        suggested_labels.append({
-                            "label": candidate_label,
-                            "match_count": len(cand_sims),
-                            "avg_similarity": round(avg_sim, 3),
-                            "score": round(score, 3),
-                        })
+                        suggested_labels.append(
+                            {
+                                "label": candidate_label,
+                                "match_count": len(cand_sims),
+                                "avg_similarity": round(avg_sim, 3),
+                                "score": round(score, 3),
+                            }
+                        )
                 except Exception as e:
-                    logger.warning("Error querying label %s (%s): %s", candidate_label, cand_field, e)
+                    logger.warning(
+                        "Error querying label %s (%s): %s",
+                        candidate_label,
+                        cand_field,
+                        e,
+                    )
                     continue
 
             suggested_labels.sort(key=lambda x: x["score"], reverse=True)
@@ -2665,7 +3140,8 @@ async def get_receipt_words_impl(
             labels_by_word[(label.line_id, label.word_id)].append(
                 {
                     "label": label.label,
-                    "validation_status": getattr(label, "validation_status", None) or "NONE",
+                    "validation_status": getattr(label, "validation_status", None)
+                    or "NONE",
                     "label_proposed_by": getattr(label, "label_proposed_by", None),
                 }
             )
@@ -2828,22 +3304,26 @@ async def list_recent_uploads_impl(dynamo_client, limit: int = 10) -> dict:
             receipts_info = []
             for rid in receipt_ids:
                 key = f"{img.image_id}_{rid}"
-                receipts_info.append({
-                    "receipt_id": rid,
-                    "merchant_name": places_by_key.get(key),
-                })
+                receipts_info.append(
+                    {
+                        "receipt_id": rid,
+                        "merchant_name": places_by_key.get(key),
+                    }
+                )
 
-            results.append({
-                "image_id": img.image_id,
-                "timestamp_added": _to_utc_dt(img.timestamp_added).isoformat(
-                    timespec="milliseconds"
-                ),
-                "image_type": img.image_type,
-                "receipt_count": len(receipts_info),
-                "width": img.width,
-                "height": img.height,
-                "receipts": receipts_info,
-            })
+            results.append(
+                {
+                    "image_id": img.image_id,
+                    "timestamp_added": _to_utc_dt(img.timestamp_added).isoformat(
+                        timespec="milliseconds"
+                    ),
+                    "image_type": img.image_type,
+                    "receipt_count": len(receipts_info),
+                    "width": img.width,
+                    "height": img.height,
+                    "receipts": receipts_info,
+                }
+            )
 
         return {
             "total_images": len(all_images),
@@ -2921,11 +3401,70 @@ async def merge_receipts_impl(
         return {"error": str(e)}
 
 
+async def plan_receipt_resegmentation_impl(arguments: dict) -> dict:
+    """Invoke the receipt re-segmentation Lambda in planning mode."""
+    try:
+        env = os.environ.get("PORTFOLIO_ENV", "dev")
+        return await _invoke_lambda(
+            f"resegment-receipt-{env}-resegment-receipt",
+            {"mode": "plan", **arguments},
+        )
+    except Exception as e:
+        logger.exception("Error planning receipt re-segmentation")
+        return {"error": str(e)}
+
+
+async def get_receipt_resegmentation_plan_impl(
+    plan_id: str, revision: int | None = None
+) -> dict:
+    """Retrieve a plan and refresh its signed visualization URLs."""
+    try:
+        env = os.environ.get("PORTFOLIO_ENV", "dev")
+        payload = {"mode": "get", "plan_id": plan_id}
+        if revision is not None:
+            payload["revision"] = revision
+        return await _invoke_lambda(
+            f"resegment-receipt-{env}-resegment-receipt", payload
+        )
+    except Exception as e:
+        logger.exception("Error retrieving receipt re-segmentation plan")
+        return {"error": str(e)}
+
+
+async def revise_receipt_resegmentation_plan_impl(arguments: dict) -> dict:
+    """Create a replacement receipt re-segmentation plan revision."""
+    try:
+        env = os.environ.get("PORTFOLIO_ENV", "dev")
+        return await _invoke_lambda(
+            f"resegment-receipt-{env}-resegment-receipt",
+            {"mode": "revise", **arguments},
+        )
+    except Exception as e:
+        logger.exception("Error revising receipt re-segmentation plan")
+        return {"error": str(e)}
+
+
+async def apply_receipt_resegmentation_impl(plan_id: str, plan_hash: str) -> dict:
+    """Invoke the receipt re-segmentation Lambda in apply mode."""
+    try:
+        env = os.environ.get("PORTFOLIO_ENV", "dev")
+        return await _invoke_lambda(
+            f"resegment-receipt-{env}-resegment-receipt",
+            {"mode": "apply", "plan_id": plan_id, "plan_hash": plan_hash},
+        )
+    except Exception as e:
+        logger.exception("Error applying receipt re-segmentation")
+        return {"error": str(e)}
+
+
 def _receipt_point_to_image(
-    rx: float, ry: float,
+    rx: float,
+    ry: float,
     coeffs: list[float],
-    receipt_width: int, receipt_height: int,
-    image_width: int, image_height: int,
+    receipt_width: int,
+    receipt_height: int,
+    image_width: int,
+    image_height: int,
 ) -> tuple[float, float]:
     """Projective forward transform: receipt-relative → full-image Vision.
 
@@ -2973,9 +3512,7 @@ async def compute_reocr_region_impl(
 
         # Filter words to only those on the requested lines
         target_line_ids = set(line_ids)
-        words_in_region = [
-            w for w in details.words if w.line_id in target_line_ids
-        ]
+        words_in_region = [w for w in details.words if w.line_id in target_line_ids]
 
         if not words_in_region:
             return {
@@ -2987,12 +3524,10 @@ async def compute_reocr_region_impl(
         min_x = min(w.bounding_box["x"] for w in words_in_region)
         min_y = min(w.bounding_box["y"] for w in words_in_region)
         max_x = max(
-            w.bounding_box["x"] + w.bounding_box["width"]
-            for w in words_in_region
+            w.bounding_box["x"] + w.bounding_box["width"] for w in words_in_region
         )
         max_y = max(
-            w.bounding_box["y"] + w.bounding_box["height"]
-            for w in words_in_region
+            w.bounding_box["y"] + w.bounding_box["height"] for w in words_in_region
         )
 
         # Always use full width — Vision OCR produces better results with
@@ -3006,20 +3541,30 @@ async def compute_reocr_region_impl(
         # receipt-relative space to full-image Vision coordinates using
         # the same projective (homography) transform that the FIRST_PASS
         # warp used.
-        from receipt_upload.geometry.transformations import find_perspective_coeffs
+        from receipt_upload.geometry.transformations import (
+            find_perspective_coeffs,
+        )
 
         receipt = details.receipt
         image = dynamo_client.get_image(image_id)
 
         src_points = [
-            (receipt.top_left["x"] * image.width,
-             (1.0 - receipt.top_left["y"]) * image.height),
-            (receipt.top_right["x"] * image.width,
-             (1.0 - receipt.top_right["y"]) * image.height),
-            (receipt.bottom_right["x"] * image.width,
-             (1.0 - receipt.bottom_right["y"]) * image.height),
-            (receipt.bottom_left["x"] * image.width,
-             (1.0 - receipt.bottom_left["y"]) * image.height),
+            (
+                receipt.top_left["x"] * image.width,
+                (1.0 - receipt.top_left["y"]) * image.height,
+            ),
+            (
+                receipt.top_right["x"] * image.width,
+                (1.0 - receipt.top_right["y"]) * image.height,
+            ),
+            (
+                receipt.bottom_right["x"] * image.width,
+                (1.0 - receipt.bottom_right["y"]) * image.height,
+            ),
+            (
+                receipt.bottom_left["x"] * image.width,
+                (1.0 - receipt.bottom_left["y"]) * image.height,
+            ),
         ]
         dst_points = [
             (0.0, 0.0),
@@ -3031,14 +3576,42 @@ async def compute_reocr_region_impl(
 
         _pt = _receipt_point_to_image
         img_corners = [
-            _pt(padded_x, padded_y, coeffs,
-                receipt.width, receipt.height, image.width, image.height),
-            _pt(padded_right, padded_y, coeffs,
-                receipt.width, receipt.height, image.width, image.height),
-            _pt(padded_x, padded_top, coeffs,
-                receipt.width, receipt.height, image.width, image.height),
-            _pt(padded_right, padded_top, coeffs,
-                receipt.width, receipt.height, image.width, image.height),
+            _pt(
+                padded_x,
+                padded_y,
+                coeffs,
+                receipt.width,
+                receipt.height,
+                image.width,
+                image.height,
+            ),
+            _pt(
+                padded_right,
+                padded_y,
+                coeffs,
+                receipt.width,
+                receipt.height,
+                image.width,
+                image.height,
+            ),
+            _pt(
+                padded_x,
+                padded_top,
+                coeffs,
+                receipt.width,
+                receipt.height,
+                image.width,
+                image.height,
+            ),
+            _pt(
+                padded_right,
+                padded_top,
+                coeffs,
+                receipt.width,
+                receipt.height,
+                image.width,
+                image.height,
+            ),
         ]
 
         img_min_x = max(0.0, min(c[0] for c in img_corners))
@@ -3061,12 +3634,8 @@ async def compute_reocr_region_impl(
         }
 
         # Include context: which lines were found, word count
-        found_line_ids = sorted(
-            target_line_ids & {w.line_id for w in details.words}
-        )
-        missing_line_ids = sorted(
-            target_line_ids - {w.line_id for w in details.words}
-        )
+        found_line_ids = sorted(target_line_ids & {w.line_id for w in details.words})
+        missing_line_ids = sorted(target_line_ids - {w.line_id for w in details.words})
 
         return {
             "image_id": image_id,
@@ -3148,9 +3717,7 @@ async def get_receipt_image_url_impl(
         return {"error": str(e)}
 
 
-async def delete_image_impl(
-    dynamo_client, image_id: str, dry_run: bool = True
-) -> dict:
+async def delete_image_impl(dynamo_client, image_id: str, dry_run: bool = True) -> dict:
     """Delete all DynamoDB records under an image partition key."""
     try:
         details = dynamo_client.get_image_details(image_id)
@@ -3231,16 +3798,10 @@ async def delete_receipt_impl(
         try:
             details = dynamo_client.get_receipt_details(image_id, receipt_id)
         except EntityNotFoundError:
-            return {
-                "error": (
-                    f"Receipt {receipt_id} not found for image {image_id}"
-                )
-            }
+            return {"error": (f"Receipt {receipt_id} not found for image {image_id}")}
 
         place = getattr(details, "place", None)
-        merchant_name = (
-            getattr(place, "merchant_name", None) if place else None
-        )
+        merchant_name = getattr(place, "merchant_name", None) if place else None
 
         # Note: ReceiptLetters are excluded from the GSI4 query that backs
         # get_receipt_details, so they are not counted here. The compactor
@@ -3308,18 +3869,12 @@ async def get_receipt_sections_impl(
         try:
             details = dynamo_client.get_receipt_details(image_id, receipt_id)
         except EntityNotFoundError:
-            return {
-                "error": (
-                    f"Receipt {receipt_id} not found for image {image_id}"
-                )
-            }
+            return {"error": (f"Receipt {receipt_id} not found for image {image_id}")}
 
         # line_id -> text so a reviewer can QA sections without a second call
         line_text = {line.line_id: line.text for line in details.lines or []}
 
-        sections = dynamo_client.get_receipt_sections_from_receipt(
-            image_id, receipt_id
-        )
+        sections = dynamo_client.get_receipt_sections_from_receipt(image_id, receipt_id)
 
         section_dicts = []
         for section in sorted(
@@ -3523,9 +4078,7 @@ async def create_receipt_section_impl(
                 )
             }
         receipt_line_ids = {line.line_id for line in details.lines or []}
-        unknown_line_ids = sorted(
-            set(normalized_line_ids) - receipt_line_ids
-        )
+        unknown_line_ids = sorted(set(normalized_line_ids) - receipt_line_ids)
         if unknown_line_ids:
             return {
                 "error": (
@@ -3621,7 +4174,6 @@ ANALYTICS_WORKGROUP = "portfolio_analytics"
 ANALYTICS_REGION = "us-east-1"
 
 
-
 def _analytics_check_date(d: str) -> str:
     # Athena's ExecutionParameters bind predicate placeholders as integer
     # (varchar/date params fail), so the structured tools validate inputs
@@ -3648,9 +4200,9 @@ def _athena_run(sql: str, max_wait: int = 90, max_rows: int = 5000) -> list:
     )["QueryExecutionId"]
     waited = 0.0
     while True:
-        status = ath.get_query_execution(QueryExecutionId=qid)[
-            "QueryExecution"
-        ]["Status"]
+        status = ath.get_query_execution(QueryExecutionId=qid)["QueryExecution"][
+            "Status"
+        ]
         state = status["State"]
         if state in ("SUCCEEDED", "FAILED", "CANCELLED"):
             break
@@ -4045,20 +4597,22 @@ async def list_training_jobs_impl(
             config = job.job_config or {}
             if isinstance(config, str):
                 config = json.loads(config)
-            results.append({
-                "name": job.name,
-                "status": job.status,
-                "created_at": str(job.created_at) if job.created_at else None,
-                "best_f1": r.get("best_f1"),
-                "best_epoch": r.get("best_epoch"),
-                "num_train_samples": r.get("num_train_samples"),
-                "num_val_samples": r.get("num_val_samples"),
-                "learning_rate": config.get("learning_rate"),
-                "epochs": config.get("epochs"),
-                "batch_size": config.get("batch_size"),
-                "merge_amounts": config.get("merge_amounts"),
-                "early_stopping_patience": config.get("early_stopping_patience"),
-            })
+            results.append(
+                {
+                    "name": job.name,
+                    "status": job.status,
+                    "created_at": str(job.created_at) if job.created_at else None,
+                    "best_f1": r.get("best_f1"),
+                    "best_epoch": r.get("best_epoch"),
+                    "num_train_samples": r.get("num_train_samples"),
+                    "num_val_samples": r.get("num_val_samples"),
+                    "learning_rate": config.get("learning_rate"),
+                    "epochs": config.get("epochs"),
+                    "batch_size": config.get("batch_size"),
+                    "merge_amounts": config.get("merge_amounts"),
+                    "early_stopping_patience": config.get("early_stopping_patience"),
+                }
+            )
 
         return {
             "total": len(results),
@@ -4086,9 +4640,9 @@ async def get_training_metrics_impl(
         # Group by epoch, filter to eval and training metrics
         by_epoch: dict[int, dict[str, Any]] = {}
         for m in metrics:
-            if (
-                m.metric_name.startswith("eval_")
-                or m.metric_name in ("loss", "learning_rate")
+            if m.metric_name.startswith("eval_") or m.metric_name in (
+                "loss",
+                "learning_rate",
             ):
                 epoch = m.epoch if m.epoch is not None else 0
                 if epoch not in by_epoch:
@@ -4147,9 +4701,7 @@ async def set_active_model_impl(
         old_active = dynamo_client.get_active_model_job()
         if old_active:
             old_active.tags = {
-                k: v
-                for k, v in (old_active.tags or {}).items()
-                if k != "active_model"
+                k: v for k, v in (old_active.tags or {}).items() if k != "active_model"
             }
             dynamo_client.update_job(old_active)
 

--- a/scripts/receipt_mcp_server.py
+++ b/scripts/receipt_mcp_server.py
@@ -3407,7 +3407,7 @@ async def plan_receipt_resegmentation_impl(arguments: dict) -> dict:
         env = os.environ.get("PORTFOLIO_ENV", "dev")
         return await _invoke_lambda(
             f"resegment-receipt-{env}-resegment-receipt",
-            {"mode": "plan", **arguments},
+            {**arguments, "mode": "plan"},
         )
     except Exception as e:
         logger.exception("Error planning receipt re-segmentation")
@@ -3437,7 +3437,7 @@ async def revise_receipt_resegmentation_plan_impl(arguments: dict) -> dict:
         env = os.environ.get("PORTFOLIO_ENV", "dev")
         return await _invoke_lambda(
             f"resegment-receipt-{env}-resegment-receipt",
-            {"mode": "revise", **arguments},
+            {**arguments, "mode": "revise"},
         )
     except Exception as e:
         logger.exception("Error revising receipt re-segmentation plan")

--- a/tests/test_receipt_mcp_section_tools.py
+++ b/tests/test_receipt_mcp_section_tools.py
@@ -227,6 +227,38 @@ def test_both_servers_expose_identical_resegment_tool_shape():
 
 
 @pytest.mark.parametrize("label", sorted(SERVER_FILES))
+def test_resegment_proxies_force_lambda_mode(label, monkeypatch):
+    """A caller-supplied `mode` key must never override the proxy's mode.
+
+    Otherwise the read-only-looking plan/revise tools could be smuggled
+    into invoking the destructive apply operation.
+    """
+    module = _load_module(label, SERVER_FILES[label])
+    calls = []
+
+    async def fake_invoke(function_name, payload):
+        calls.append((function_name, payload))
+        return {"ok": True}
+
+    monkeypatch.setattr(module, "_invoke_lambda", fake_invoke)
+
+    asyncio.run(
+        module.plan_receipt_resegmentation_impl(
+            {"image_id": "img", "mode": "apply", "plan_hash": "h"}
+        )
+    )
+    asyncio.run(
+        module.revise_receipt_resegmentation_plan_impl(
+            {"plan_id": "p", "mode": "apply"}
+        )
+    )
+
+    assert [payload["mode"] for _, payload in calls] == ["plan", "revise"]
+    for function_name, _ in calls:
+        assert function_name.endswith("-resegment-receipt")
+
+
+@pytest.mark.parametrize("label", sorted(SERVER_FILES))
 def test_resegment_plan_attaches_contact_sheet_as_image_content(label, monkeypatch):
     module = _load_module(label, SERVER_FILES[label])
     monkeypatch.setattr(module, "get_clients", lambda: (object(), object(), object()))

--- a/tests/test_receipt_mcp_section_tools.py
+++ b/tests/test_receipt_mcp_section_tools.py
@@ -36,6 +36,14 @@ EXPECTED_SECTION_TOOLS = {
 }
 
 
+EXPECTED_RESEGMENT_TOOLS = {
+    "plan_receipt_resegmentation",
+    "get_receipt_resegmentation_plan",
+    "revise_receipt_resegmentation_plan",
+    "apply_receipt_resegmentation",
+}
+
+
 class _FakeTool:
     """Stand-in for mcp.types.Tool that just records its fields."""
 
@@ -43,6 +51,12 @@ class _FakeTool:
         self.name = name
         self.description = description
         self.inputSchema = inputSchema
+
+
+class _FakeContent:
+    def __init__(self, **kwargs):
+        for key, value in kwargs.items():
+            setattr(self, key, value)
 
 
 def _install_mcp_stubs():
@@ -74,7 +88,8 @@ def _install_mcp_stubs():
     server_mod.Server = _FakeServer
     stdio_mod.stdio_server = _fake_stdio_server
     types_mod.Tool = _FakeTool
-    types_mod.TextContent = object
+    types_mod.TextContent = _FakeContent
+    types_mod.ImageContent = _FakeContent
 
     sys.modules["mcp"] = mcp_mod
     sys.modules["mcp.server"] = server_mod
@@ -84,9 +99,7 @@ def _install_mcp_stubs():
 
 def _load_module(label, path):
     _install_mcp_stubs()
-    spec = importlib.util.spec_from_file_location(
-        f"receipt_mcp_server_{label}", path
-    )
+    spec = importlib.util.spec_from_file_location(f"receipt_mcp_server_{label}", path)
     assert spec is not None and spec.loader is not None
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
@@ -156,6 +169,85 @@ def test_both_servers_expose_identical_section_tool_shape():
     assert shape(stdio) == shape(lam)
 
 
+@pytest.mark.parametrize("label", sorted(SERVER_FILES))
+def test_resegment_tools_present_with_valid_schema(label):
+    module = _load_module(label, SERVER_FILES[label])
+    tools = asyncio.run(module.list_tools())
+    by_name = {tool.name: tool for tool in tools}
+
+    assert EXPECTED_RESEGMENT_TOOLS <= set(by_name)
+    plan_schema = by_name["plan_receipt_resegmentation"].inputSchema
+    assert set(plan_schema["required"]) == {
+        "image_id",
+        "source_receipt_id",
+        "segments",
+    }
+    segment_schema = plan_schema["properties"]["segments"]["items"]
+    assert "include_word_refs" in segment_schema["properties"]
+    word_ref_schema = segment_schema["properties"]["include_word_refs"]["items"]
+    assert word_ref_schema["oneOf"] == [
+        {"required": ["word_id"]},
+        {"required": ["word_ids"]},
+    ]
+    assert plan_schema["properties"]["schema_version"]["enum"] == [1, 2]
+    assert "assignments" in plan_schema["properties"]
+    assert "visualization" in plan_schema["properties"]
+    assert "visible_regions" in segment_schema["properties"]
+    revise_schema = by_name["revise_receipt_resegmentation_plan"].inputSchema
+    assert set(revise_schema["required"]) == {
+        "plan_id",
+        "base_revision",
+        "base_plan_hash",
+        "segments",
+        "assignments",
+        "revision_reason",
+    }
+    get_schema = by_name["get_receipt_resegmentation_plan"].inputSchema
+    assert get_schema["required"] == ["plan_id"]
+    apply_schema = by_name["apply_receipt_resegmentation"].inputSchema
+    assert set(apply_schema["required"]) == {"plan_id", "plan_hash"}
+
+
+def test_both_servers_expose_identical_resegment_tool_shape():
+    stdio = _load_module("stdio-resegment", SERVER_FILES["stdio"])
+    lam = _load_module("lambda-resegment", SERVER_FILES["lambda"])
+
+    def shape(module):
+        tools = asyncio.run(module.list_tools())
+        return {
+            tool.name: (tool.description, tool.inputSchema)
+            for tool in tools
+            if tool.name in EXPECTED_RESEGMENT_TOOLS
+        }
+
+    assert shape(stdio) == shape(lam)
+    for module in (stdio, lam):
+        for name in EXPECTED_RESEGMENT_TOOLS:
+            assert callable(getattr(module, f"{name}_impl"))
+
+
+@pytest.mark.parametrize("label", sorted(SERVER_FILES))
+def test_resegment_plan_attaches_contact_sheet_as_image_content(label, monkeypatch):
+    module = _load_module(label, SERVER_FILES[label])
+    monkeypatch.setattr(module, "get_clients", lambda: (object(), object(), object()))
+
+    async def fake_plan(_arguments):
+        return {
+            "plan_id": "plan-1",
+            "preview_urls": {"contact_sheet": "https://example.test/sheet.jpg"},
+            "visualizations": {"contact_sheet": {"mime_type": "image/jpeg"}},
+        }
+
+    monkeypatch.setattr(module, "plan_receipt_resegmentation_impl", fake_plan)
+    monkeypatch.setattr(module, "_fetch_mcp_preview", lambda _url: b"jpeg-bytes")
+
+    content = asyncio.run(module.call_tool("plan_receipt_resegmentation", {}))
+
+    assert [item.type for item in content] == ["text", "image"]
+    assert content[1].mimeType == "image/jpeg"
+    assert content[1].data == "anBlZy1ieXRlcw=="
+
+
 # ---------------------------------------------------------------------------
 # Corruption-path tests: the impls must refuse writes that would persist bad
 # rows (noncanonical section_type SKs, orphan sections, invalid line refs).
@@ -204,9 +296,7 @@ def test_create_rejects_invalid_section_type(label):
     module = _load_module(label, SERVER_FILES[label])
     client = _StubDynamoClient()
     result = asyncio.run(
-        module.create_receipt_section_impl(
-            client, VALID_IMAGE_ID, 1, "ITMES", [1, 2]
-        )
+        module.create_receipt_section_impl(client, VALID_IMAGE_ID, 1, "ITMES", [1, 2])
     )
     assert "error" in result
     assert "Invalid section_type" in result["error"]
@@ -220,9 +310,7 @@ def test_create_rejects_line_ids_not_on_receipt(label):
     module = _load_module(label, SERVER_FILES[label])
     client = _StubDynamoClient(line_ids=(1, 2, 3))
     result = asyncio.run(
-        module.create_receipt_section_impl(
-            client, VALID_IMAGE_ID, 1, "ITEMS", [2, 99]
-        )
+        module.create_receipt_section_impl(client, VALID_IMAGE_ID, 1, "ITEMS", [2, 99])
     )
     assert "error" in result
     assert "99" in result["error"]
@@ -236,9 +324,7 @@ def test_create_rejects_nonexistent_receipt(label):
     module = _load_module(label, SERVER_FILES[label])
     client = _StubDynamoClient(receipt_exists=False)
     result = asyncio.run(
-        module.create_receipt_section_impl(
-            client, VALID_IMAGE_ID, 42, "ITEMS", [1]
-        )
+        module.create_receipt_section_impl(client, VALID_IMAGE_ID, 42, "ITEMS", [1])
     )
     assert "error" in result
     assert "not found" in result["error"]
@@ -251,9 +337,7 @@ def test_create_succeeds_for_valid_input(label):
     module = _load_module(label, SERVER_FILES[label])
     client = _StubDynamoClient(line_ids=(1, 2, 3))
     result = asyncio.run(
-        module.create_receipt_section_impl(
-            client, VALID_IMAGE_ID, 1, " items ", [1, 2]
-        )
+        module.create_receipt_section_impl(client, VALID_IMAGE_ID, 1, " items ", [1, 2])
     )
     assert result.get("success") is True
     assert result["section_type"] == "ITEMS"  # stripped + uppercased
@@ -287,17 +371,13 @@ def test_update_and_delete_reject_invalid_section_type(label, impl_name, args):
 
 
 @pytest.mark.parametrize("label", sorted(SERVER_FILES))
-@pytest.mark.parametrize(
-    "legacy_type", ["HEADER", "ITEMS_VALUE", "ITEMS_DESCRIPTION"]
-)
+@pytest.mark.parametrize("legacy_type", ["HEADER", "ITEMS_VALUE", "ITEMS_DESCRIPTION"])
 def test_create_rejects_deprecated_section_types(label, legacy_type):
     pytest.importorskip("receipt_dynamo")
     module = _load_module(label, SERVER_FILES[label])
     client = _StubDynamoClient(line_ids=(1, 2, 3))
     result = asyncio.run(
-        module.create_receipt_section_impl(
-            client, VALID_IMAGE_ID, 1, legacy_type, [1]
-        )
+        module.create_receipt_section_impl(client, VALID_IMAGE_ID, 1, legacy_type, [1])
     )
     assert "error" in result
     assert "deprecated" in result["error"]
@@ -318,9 +398,7 @@ def test_delete_still_accepts_deprecated_section_types(label):
             deleted.append((receipt_id, image_id, section_type))
 
     result = asyncio.run(
-        module.delete_receipt_section_impl(
-            _DeleteClient(), VALID_IMAGE_ID, 1, "HEADER"
-        )
+        module.delete_receipt_section_impl(_DeleteClient(), VALID_IMAGE_ID, 1, "HEADER")
     )
     assert result.get("success") is True
     assert deleted == [(1, VALID_IMAGE_ID, "HEADER")]

--- a/tests/test_resegment_receipt_lambda.py
+++ b/tests/test_resegment_receipt_lambda.py
@@ -1,0 +1,585 @@
+"""End-to-end local test for plan/apply receipt re-segmentation."""
+
+import io
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from uuid import uuid4
+
+import boto3
+import pytest
+import receipt_dynamo
+import receipt_upload.utils
+from moto import mock_aws
+from PIL import Image as PILImage
+from receipt_dynamo import (
+    DynamoClient,
+    Image,
+    Receipt,
+    ReceiptLine,
+    ReceiptWord,
+    ReceiptWordLabel,
+)
+
+from infra.resegment_receipt_lambda.lambdas import resegment_receipt
+from infra.resegment_receipt_lambda.lambdas.resegment_receipt import (
+    _segment_geometry,
+    _stage_outputs,
+    apply_plan,
+    create_plan,
+    get_plan,
+    revise_plan,
+)
+
+
+@pytest.fixture(autouse=True)
+def mock_aws_services():
+    """Override the root infrastructure stub so moto owns boto3 here."""
+    yield
+
+
+def _create_table(table_name: str) -> None:
+    client = boto3.client("dynamodb", region_name="us-east-1")
+    client.create_table(
+        TableName=table_name,
+        KeySchema=[
+            {"AttributeName": "PK", "KeyType": "HASH"},
+            {"AttributeName": "SK", "KeyType": "RANGE"},
+        ],
+        AttributeDefinitions=[
+            {"AttributeName": "PK", "AttributeType": "S"},
+            {"AttributeName": "SK", "AttributeType": "S"},
+            {"AttributeName": "GSI1PK", "AttributeType": "S"},
+            {"AttributeName": "GSI1SK", "AttributeType": "S"},
+            {"AttributeName": "GSI2PK", "AttributeType": "S"},
+            {"AttributeName": "GSI2SK", "AttributeType": "S"},
+            {"AttributeName": "GSI3PK", "AttributeType": "S"},
+            {"AttributeName": "GSI3SK", "AttributeType": "S"},
+            {"AttributeName": "GSI4PK", "AttributeType": "S"},
+            {"AttributeName": "GSI4SK", "AttributeType": "S"},
+            {"AttributeName": "TYPE", "AttributeType": "S"},
+        ],
+        BillingMode="PAY_PER_REQUEST",
+        GlobalSecondaryIndexes=[
+            {
+                "IndexName": name,
+                "KeySchema": [
+                    {"AttributeName": pk, "KeyType": "HASH"},
+                    {"AttributeName": sk, "KeyType": "RANGE"},
+                ],
+                "Projection": {"ProjectionType": "ALL"},
+            }
+            for name, pk, sk in (
+                ("GSI1", "GSI1PK", "GSI1SK"),
+                ("GSI2", "GSI2PK", "GSI2SK"),
+                ("GSI3", "GSI3PK", "GSI3SK"),
+                ("GSI4", "GSI4PK", "GSI4SK"),
+            )
+        ]
+        + [
+            {
+                "IndexName": "GSITYPE",
+                "KeySchema": [{"AttributeName": "TYPE", "KeyType": "HASH"}],
+                "Projection": {"ProjectionType": "ALL"},
+            }
+        ],
+    )
+
+
+def _geometry(x1: float, x2: float, y1: float, y2: float) -> dict:
+    return {
+        "bounding_box": {
+            "x": x1,
+            "y": y2,
+            "width": x2 - x1,
+            "height": y1 - y2,
+        },
+        "top_left": {"x": x1, "y": y1},
+        "top_right": {"x": x2, "y": y1},
+        "bottom_left": {"x": x1, "y": y2},
+        "bottom_right": {"x": x2, "y": y2},
+        "angle_degrees": 0.0,
+        "angle_radians": 0.0,
+        "confidence": 1.0,
+    }
+
+
+def test_handler_does_not_expose_test_only_apply_controls(monkeypatch):
+    captured = {}
+
+    monkeypatch.setenv("DYNAMODB_TABLE_NAME", "table")
+    monkeypatch.setenv("RAW_BUCKET", "raw")
+    monkeypatch.setenv("SITE_BUCKET", "site")
+    monkeypatch.setenv("CHROMADB_BUCKET", "chroma")
+    monkeypatch.setattr(receipt_dynamo, "DynamoClient", lambda table_name: object())
+    monkeypatch.setattr(resegment_receipt.boto3, "client", lambda service: object())
+
+    def fake_apply(event, **kwargs):
+        del kwargs
+        captured.update(event)
+        return {"status": "APPLIED"}
+
+    monkeypatch.setattr(resegment_receipt, "apply_plan", fake_apply)
+
+    result = resegment_receipt.handler(
+        {
+            "mode": "apply",
+            "plan_id": "plan-1",
+            "plan_hash": "hash-1",
+            "create_embeddings": False,
+            "wait_for_embeddings": False,
+        },
+        None,
+    )
+
+    assert result == {"status": "APPLIED"}
+    assert captured == {"plan_id": "plan-1", "plan_hash": "hash-1"}
+
+
+def test_segment_geometry_records_requested_padding_at_image_edge():
+    word = {
+        "top_left": {"x": 0.0, "y": 20.0},
+        "top_right": {"x": 10.0, "y": 20.0},
+        "bottom_left": {"x": 0.0, "y": 10.0},
+        "bottom_right": {"x": 10.0, "y": 10.0},
+    }
+
+    geometry = _segment_geometry([word], 100, 100, padding_px=2)
+
+    assert geometry["requested_padding_px"] == 2
+    assert geometry["applied_padding_px"] == 2
+    assert geometry["warped_width"] == 14
+    assert geometry["warped_height"] == 14
+
+
+def test_stage_outputs_tracks_partial_cdn_uploads_for_rollback(monkeypatch):
+    monkeypatch.setattr(receipt_upload.utils, "upload_png_to_s3", lambda *args: None)
+
+    def fail_mid_upload(*args, **kwargs):
+        del args, kwargs
+        raise RuntimeError("simulated CDN failure")
+
+    monkeypatch.setattr(
+        receipt_upload.utils,
+        "upload_all_cdn_formats",
+        fail_mid_upload,
+    )
+    uploaded_keys = []
+    output = {
+        "image": PILImage.new("RGB", (10, 10), "white"),
+        "raw_key": "receipts/img/img_RECEIPT_00002.png",
+        "receipt": SimpleNamespace(image_id="img", receipt_id=2),
+    }
+
+    with pytest.raises(RuntimeError, match="simulated CDN failure"):
+        _stage_outputs(
+            outputs=[output],
+            dynamo_client=object(),
+            raw_bucket="raw",
+            site_bucket="site",
+            uploaded_keys=uploaded_keys,
+        )
+
+    assert output["raw_key"] in uploaded_keys
+    assert "assets/img/2_thumbnail.jpg" in uploaded_keys
+    assert "assets/img/2.avif" in uploaded_keys
+    assert len(uploaded_keys) == 13
+
+
+@mock_aws
+def test_plan_and_apply_split_is_idempotent_and_preserves_labels():
+    table_name = "ReceiptResegmentTest"
+    raw_bucket = "resegment-raw"
+    site_bucket = "resegment-site"
+    image_bucket = "resegment-images"
+    chromadb_bucket = "resegment-chroma"
+    _create_table(table_name)
+    s3_client = boto3.client("s3", region_name="us-east-1")
+    for bucket in (raw_bucket, site_bucket, image_bucket, chromadb_bucket):
+        s3_client.create_bucket(Bucket=bucket)
+
+    image_id = str(uuid4())
+    timestamp = datetime.now(timezone.utc)
+    original = PILImage.new("RGB", (200, 300), "white")
+    buffer = io.BytesIO()
+    original.save(buffer, format="PNG")
+    s3_client.put_object(
+        Bucket=image_bucket,
+        Key="original.png",
+        Body=buffer.getvalue(),
+    )
+
+    client = DynamoClient(table_name)
+    client.add_image(
+        Image(
+            image_id=image_id,
+            width=200,
+            height=300,
+            timestamp_added=timestamp,
+            raw_s3_bucket=image_bucket,
+            raw_s3_key="original.png",
+            receipt_count=1,
+        )
+    )
+    client.add_receipt(
+        Receipt(
+            image_id=image_id,
+            receipt_id=1,
+            width=200,
+            height=300,
+            timestamp_added=timestamp,
+            raw_s3_bucket=image_bucket,
+            raw_s3_key="original.png",
+            top_left={"x": 0.0, "y": 1.0},
+            top_right={"x": 1.0, "y": 1.0},
+            bottom_left={"x": 0.0, "y": 0.0},
+            bottom_right={"x": 1.0, "y": 0.0},
+        )
+    )
+    line_geometry = [
+        _geometry(0.1, 0.35, 0.8, 0.7),
+        _geometry(0.6, 0.9, 0.4, 0.3),
+    ]
+    lines = [
+        ReceiptLine(
+            image_id=image_id,
+            receipt_id=1,
+            line_id=index,
+            text=text,
+            **geometry,
+        )
+        for index, (text, geometry) in enumerate(
+            zip(("LEFT", "RIGHT"), line_geometry), start=1
+        )
+    ]
+    words = [
+        ReceiptWord(
+            image_id=image_id,
+            receipt_id=1,
+            line_id=index,
+            word_id=1,
+            text=text,
+            **geometry,
+        )
+        for index, (text, geometry) in enumerate(
+            zip(("LEFT", "RIGHT"), line_geometry), start=1
+        )
+    ]
+    labels = [
+        ReceiptWordLabel(
+            image_id=image_id,
+            receipt_id=1,
+            line_id=index,
+            word_id=1,
+            label="MERCHANT_NAME" if index == 1 else "GRAND_TOTAL",
+            reasoning="test label",
+            timestamp_added=timestamp,
+            validation_status="VALID",
+            label_proposed_by="test",
+        )
+        for index in (1, 2)
+    ]
+    client.add_receipt_lines(lines)
+    client.add_receipt_words(words)
+    client.add_receipt_word_labels(labels)
+
+    plan = create_plan(
+        {
+            "image_id": image_id,
+            "source_receipt_id": 1,
+            "padding_px": 2,
+            "segments": [
+                {"segment_key": "left", "include_line_ids": [1]},
+                {"segment_key": "right", "include_line_ids": [2]},
+            ],
+        },
+        dynamo_client=client,
+        s3_client=s3_client,
+        raw_bucket=raw_bucket,
+    )
+    assert plan["totals"]["source_words"] == 2
+    assert plan["image"]["image_type"] == "SCAN"
+    assert plan["visualization"]["effective_strategy"] == "RECTANGULAR"
+    assert plan["applicable"] is True
+    assert set(plan["preview_urls"]) == {"left", "right"}
+
+    result = apply_plan(
+        {
+            "plan_id": plan["plan_id"],
+            "plan_hash": plan["plan_hash"],
+            "create_embeddings": False,
+        },
+        dynamo_client=client,
+        s3_client=s3_client,
+        raw_bucket=raw_bucket,
+        site_bucket=site_bucket,
+        chromadb_bucket=chromadb_bucket,
+    )
+
+    assert result["status"] == "APPLIED"
+    assert result["output_receipt_ids"] == [2, 3]
+    assert client.get_receipt_item_type_counts(image_id, 1) == {}
+    for receipt_id in (2, 3):
+        details = client.get_receipt_details(image_id, receipt_id)
+        assert len(details.words) == 1
+        assert len(details.labels) == 1
+        assert details.labels[0].validation_status == "VALID"
+        assert details.labels[0].label_proposed_by == "test"
+
+    repeated = apply_plan(
+        {"plan_id": plan["plan_id"], "plan_hash": plan["plan_hash"]},
+        dynamo_client=client,
+        s3_client=s3_client,
+        raw_bucket=raw_bucket,
+        site_bucket=site_bucket,
+        chromadb_bucket=chromadb_bucket,
+    )
+    assert repeated == result
+
+
+@mock_aws
+def test_photo_v2_plan_visualizes_revises_and_blocks_layered_apply():
+    table_name = "ReceiptResegmentV2Test"
+    raw_bucket = "resegment-v2-raw"
+    site_bucket = "resegment-v2-site"
+    image_bucket = "resegment-v2-images"
+    chromadb_bucket = "resegment-v2-chroma"
+    _create_table(table_name)
+    s3_client = boto3.client("s3", region_name="us-east-1")
+    for bucket in (raw_bucket, site_bucket, image_bucket, chromadb_bucket):
+        s3_client.create_bucket(Bucket=bucket)
+
+    image_id = str(uuid4())
+    timestamp = datetime.now(timezone.utc)
+    original = PILImage.new("RGB", (200, 300), "white")
+    buffer = io.BytesIO()
+    original.save(buffer, format="PNG")
+    s3_client.put_object(
+        Bucket=image_bucket,
+        Key="stacked-photo.png",
+        Body=buffer.getvalue(),
+    )
+
+    client = DynamoClient(table_name)
+    client.add_image(
+        Image(
+            image_id=image_id,
+            width=200,
+            height=300,
+            timestamp_added=timestamp,
+            raw_s3_bucket=image_bucket,
+            raw_s3_key="stacked-photo.png",
+            image_type="PHOTO",
+            receipt_count=1,
+        )
+    )
+    client.add_receipt(
+        Receipt(
+            image_id=image_id,
+            receipt_id=1,
+            width=200,
+            height=300,
+            timestamp_added=timestamp,
+            raw_s3_bucket=image_bucket,
+            raw_s3_key="stacked-photo.png",
+            top_left={"x": 0.0, "y": 1.0},
+            top_right={"x": 1.0, "y": 1.0},
+            bottom_left={"x": 0.0, "y": 0.0},
+            bottom_right={"x": 1.0, "y": 0.0},
+        )
+    )
+    geometries = [
+        _geometry(0.1, 0.35, 0.82, 0.72),
+        _geometry(0.6, 0.9, 0.42, 0.32),
+    ]
+    client.add_receipt_lines(
+        [
+            ReceiptLine(
+                image_id=image_id,
+                receipt_id=1,
+                line_id=index,
+                text=text,
+                **geometry,
+            )
+            for index, (text, geometry) in enumerate(
+                zip(("CARD", "GUEST"), geometries), start=1
+            )
+        ]
+    )
+    client.add_receipt_words(
+        [
+            ReceiptWord(
+                image_id=image_id,
+                receipt_id=1,
+                line_id=index,
+                word_id=1,
+                text=text,
+                **geometry,
+            )
+            for index, (text, geometry) in enumerate(
+                zip(("CARD", "GUEST"), geometries), start=1
+            )
+        ]
+    )
+
+    segments = [
+        {
+            "segment_key": "card",
+            "z_index": 0,
+            "occluded_by": ["guest"],
+            "visible_regions": [
+                {
+                    "region_id": "card-visible",
+                    "points": [
+                        {"x": 0.0, "y": 0.55},
+                        {"x": 0.48, "y": 0.55},
+                        {"x": 0.48, "y": 1.0},
+                        {"x": 0.0, "y": 1.0},
+                    ],
+                }
+            ],
+        },
+        {
+            "segment_key": "guest",
+            "z_index": 1,
+            "visible_regions": [
+                {
+                    "region_id": "guest-visible",
+                    "points": [
+                        {"x": 0.5, "y": 0.0},
+                        {"x": 1.0, "y": 0.0},
+                        {"x": 1.0, "y": 0.5},
+                        {"x": 0.5, "y": 0.5},
+                    ],
+                }
+            ],
+        },
+    ]
+    assignments = {
+        "lines": [
+            {"line_id": 1, "segment_key": "card"},
+            {"line_id": 2, "segment_key": "guest"},
+        ]
+    }
+    plan = create_plan(
+        {
+            "schema_version": 2,
+            "image_id": image_id,
+            "source_receipt_id": 1,
+            "segments": segments,
+            "assignments": assignments,
+            "visualization": {"strategy": "LAYERED_MULTI_REGION"},
+        },
+        dynamo_client=client,
+        s3_client=s3_client,
+        raw_bucket=raw_bucket,
+    )
+
+    assert plan["image"]["image_type"] == "PHOTO"
+    assert plan["revision"] == 1
+    assert plan["applicable"] is False
+    assert plan["preview_urls"]["contact_sheet"]
+    assert set(plan["visualizations"]["segments"]) == {"card", "guest"}
+    assert {finding["code"] for finding in plan["findings"]} >= {
+        "LAYERED_APPLY_NOT_SUPPORTED"
+    }
+    for artifact_name in ("overlay", "contact_sheet"):
+        artifact = plan["visualizations"][artifact_name]
+        stored = s3_client.get_object(Bucket=raw_bucket, Key=artifact["s3_key"])
+        assert stored["Body"].read()
+
+    fetched = get_plan(
+        {"plan_id": plan["plan_id"]},
+        s3_client=s3_client,
+        raw_bucket=raw_bucket,
+    )
+    assert fetched["is_latest"] is True
+    assert fetched["preview_urls"]["overlay"]
+
+    revised_segments = [{**segment} for segment in segments]
+    revised_segments[0]["visible_regions"] = [
+        {
+            "region_id": "card-visible-revised",
+            "points": [
+                {"x": 0.0, "y": 0.6},
+                {"x": 0.48, "y": 0.6},
+                {"x": 0.48, "y": 1.0},
+                {"x": 0.0, "y": 1.0},
+            ],
+        }
+    ]
+    revised = revise_plan(
+        {
+            "plan_id": plan["plan_id"],
+            "base_revision": 1,
+            "base_plan_hash": plan["plan_hash"],
+            "segments": revised_segments,
+            "assignments": assignments,
+            "visualization": {"strategy": "LAYERED_MULTI_REGION"},
+            "revision_reason": "Tighten the visible card region",
+        },
+        dynamo_client=client,
+        s3_client=s3_client,
+        raw_bucket=raw_bucket,
+    )
+    assert revised["revision"] == 2
+    assert revised["supersedes_plan_hash"] == plan["plan_hash"]
+    old = get_plan(
+        {"plan_id": plan["plan_id"], "revision": 1},
+        s3_client=s3_client,
+        raw_bucket=raw_bucket,
+    )
+    assert old["is_latest"] is False
+    assert old["applicable"] is False
+
+    with pytest.raises(ValueError, match="base_revision is stale"):
+        revise_plan(
+            {
+                "plan_id": plan["plan_id"],
+                "base_revision": 1,
+                "base_plan_hash": plan["plan_hash"],
+                "segments": segments,
+                "assignments": assignments,
+                "revision_reason": "Stale concurrent edit",
+            },
+            dynamo_client=client,
+            s3_client=s3_client,
+            raw_bucket=raw_bucket,
+        )
+
+    with pytest.raises(ValueError, match="plan_hash does not match"):
+        apply_plan(
+            {"plan_id": plan["plan_id"], "plan_hash": plan["plan_hash"]},
+            dynamo_client=client,
+            s3_client=s3_client,
+            raw_bucket=raw_bucket,
+            site_bucket=site_bucket,
+            chromadb_bucket=chromadb_bucket,
+        )
+
+    with pytest.raises(ValueError, match="blocking findings"):
+        apply_plan(
+            {"plan_id": revised["plan_id"], "plan_hash": revised["plan_hash"]},
+            dynamo_client=client,
+            s3_client=s3_client,
+            raw_bucket=raw_bucket,
+            site_bucket=site_bucket,
+            chromadb_bucket=chromadb_bucket,
+        )
+
+    scan_image = client.get_image(image_id)
+    scan_image.image_type = "SCAN"
+    client.update_image(scan_image)
+    with pytest.raises(ValueError, match="confirm_stacked_scan=true"):
+        create_plan(
+            {
+                "schema_version": 2,
+                "image_id": image_id,
+                "source_receipt_id": 1,
+                "segments": segments,
+                "assignments": assignments,
+                "visualization": {"strategy": "LAYERED_MULTI_REGION"},
+            },
+            dynamo_client=client,
+            s3_client=s3_client,
+            raw_bucket=raw_bucket,
+        )

--- a/tests/test_resegment_receipt_lambda.py
+++ b/tests/test_resegment_receipt_lambda.py
@@ -583,3 +583,192 @@ def test_photo_v2_plan_visualizes_revises_and_blocks_layered_apply():
             s3_client=s3_client,
             raw_bucket=raw_bucket,
         )
+
+
+def _seed_two_line_receipt(table_name, raw_bucket, image_bucket):
+    """Create the table, buckets, image, and a two-line source receipt."""
+    _create_table(table_name)
+    s3_client = boto3.client("s3", region_name="us-east-1")
+    for bucket in (raw_bucket, "resegment-site", image_bucket, "resegment-chroma"):
+        s3_client.create_bucket(Bucket=bucket)
+
+    image_id = str(uuid4())
+    timestamp = datetime.now(timezone.utc)
+    buffer = io.BytesIO()
+    PILImage.new("RGB", (200, 300), "white").save(buffer, format="PNG")
+    s3_client.put_object(
+        Bucket=image_bucket, Key="original.png", Body=buffer.getvalue()
+    )
+
+    client = DynamoClient(table_name)
+    client.add_image(
+        Image(
+            image_id=image_id,
+            width=200,
+            height=300,
+            timestamp_added=timestamp,
+            raw_s3_bucket=image_bucket,
+            raw_s3_key="original.png",
+            receipt_count=1,
+        )
+    )
+    client.add_receipt(
+        Receipt(
+            image_id=image_id,
+            receipt_id=1,
+            width=200,
+            height=300,
+            timestamp_added=timestamp,
+            raw_s3_bucket=image_bucket,
+            raw_s3_key="original.png",
+            top_left={"x": 0.0, "y": 1.0},
+            top_right={"x": 1.0, "y": 1.0},
+            bottom_left={"x": 0.0, "y": 0.0},
+            bottom_right={"x": 1.0, "y": 0.0},
+        )
+    )
+    line_geometry = [
+        _geometry(0.1, 0.35, 0.8, 0.7),
+        _geometry(0.6, 0.9, 0.4, 0.3),
+    ]
+    client.add_receipt_lines(
+        [
+            ReceiptLine(
+                image_id=image_id,
+                receipt_id=1,
+                line_id=index,
+                text=text,
+                **geometry,
+            )
+            for index, (text, geometry) in enumerate(
+                zip(("LEFT", "RIGHT"), line_geometry), start=1
+            )
+        ]
+    )
+    client.add_receipt_words(
+        [
+            ReceiptWord(
+                image_id=image_id,
+                receipt_id=1,
+                line_id=index,
+                word_id=1,
+                text=text,
+                **geometry,
+            )
+            for index, (text, geometry) in enumerate(
+                zip(("LEFT", "RIGHT"), line_geometry), start=1
+            )
+        ]
+    )
+    return client, s3_client, image_id
+
+
+@mock_aws
+def test_apply_retries_after_transient_commit_failure(monkeypatch):
+    """A failed commit transaction must not brick the plan: the status is
+    reverted to PLANNED, the reservations are released idempotently, and a
+    retry applies cleanly."""
+    raw_bucket = "resegment-raw"
+    client, s3_client, image_id = _seed_two_line_receipt(
+        "ReceiptResegmentRetry", raw_bucket, "resegment-images"
+    )
+
+    plan = create_plan(
+        {
+            "image_id": image_id,
+            "source_receipt_id": 1,
+            "segments": [
+                {"segment_key": "left", "include_line_ids": [1]},
+                {"segment_key": "right", "include_line_ids": [2]},
+            ],
+        },
+        dynamo_client=client,
+        s3_client=s3_client,
+        raw_bucket=raw_bucket,
+    )
+
+    real_commit = client.commit_receipt_resegmentation
+    calls = {"count": 0}
+
+    def flaky_commit(*args, **kwargs):
+        calls["count"] += 1
+        if calls["count"] == 1:
+            raise RuntimeError("simulated transient commit failure")
+        return real_commit(*args, **kwargs)
+
+    monkeypatch.setattr(client, "commit_receipt_resegmentation", flaky_commit)
+
+    apply_event = {
+        "plan_id": plan["plan_id"],
+        "plan_hash": plan["plan_hash"],
+        "create_embeddings": False,
+    }
+    apply_kwargs = {
+        "dynamo_client": client,
+        "s3_client": s3_client,
+        "raw_bucket": raw_bucket,
+        "site_bucket": "resegment-site",
+        "chromadb_bucket": "resegment-chroma",
+    }
+
+    with pytest.raises(RuntimeError, match="simulated transient commit failure"):
+        apply_plan(apply_event, **apply_kwargs)
+
+    stored = resegment_receipt._load_plan(s3_client, raw_bucket, plan["plan_id"])
+    assert stored["status"] == "PLANNED"
+    # The rollback released the reservations and staged children.
+    for output_id in (2, 3):
+        assert client.get_receipt_item_type_counts(image_id, output_id) == {}
+
+    result = apply_plan(apply_event, **apply_kwargs)
+    assert result["status"] == "APPLIED"
+    assert result["output_receipt_ids"] == [2, 3]
+
+
+@mock_aws
+def test_apply_recovers_from_crash_during_committing(monkeypatch):
+    """A crash after the COMMITTING marker is persisted but before the commit
+    transaction leaves reservation rows behind; the resume path must treat
+    them as not-yet-visible outputs and re-run the plan."""
+    raw_bucket = "resegment-raw"
+    client, s3_client, image_id = _seed_two_line_receipt(
+        "ReceiptResegmentCrash", raw_bucket, "resegment-images"
+    )
+
+    plan = create_plan(
+        {
+            "image_id": image_id,
+            "source_receipt_id": 1,
+            "segments": [
+                {"segment_key": "left", "include_line_ids": [1]},
+                {"segment_key": "right", "include_line_ids": [2]},
+            ],
+        },
+        dynamo_client=client,
+        s3_client=s3_client,
+        raw_bucket=raw_bucket,
+    )
+
+    # Simulate the crash: reservations exist and the stored plan says
+    # COMMITTING, but the commit transaction never ran.
+    client.reserve_receipt_ids(image_id, [2, 3], plan["plan_id"])
+    stored = resegment_receipt._load_plan(s3_client, raw_bucket, plan["plan_id"])
+    stored["status"] = "COMMITTING"
+    resegment_receipt._save_plan(s3_client, raw_bucket, stored)
+
+    result = apply_plan(
+        {
+            "plan_id": plan["plan_id"],
+            "plan_hash": plan["plan_hash"],
+            "create_embeddings": False,
+        },
+        dynamo_client=client,
+        s3_client=s3_client,
+        raw_bucket=raw_bucket,
+        site_bucket="resegment-site",
+        chromadb_bucket="resegment-chroma",
+    )
+
+    assert result["status"] == "APPLIED"
+    assert result["output_receipt_ids"] == [2, 3]
+    assert client.get_receipt_item_type_counts(image_id, 1) == {}

--- a/tests/test_resegment_receipt_lambda.py
+++ b/tests/test_resegment_receipt_lambda.py
@@ -660,6 +660,22 @@ def _seed_two_line_receipt(table_name, raw_bucket, image_bucket):
             )
         ]
     )
+    client.add_receipt_word_labels(
+        [
+            ReceiptWordLabel(
+                image_id=image_id,
+                receipt_id=1,
+                line_id=index,
+                word_id=1,
+                label="MERCHANT_NAME" if index == 1 else "GRAND_TOTAL",
+                reasoning="test label",
+                timestamp_added=timestamp,
+                validation_status="VALID",
+                label_proposed_by="test",
+            )
+            for index in (1, 2)
+        ]
+    )
     return client, s3_client, image_id
 
 
@@ -772,3 +788,98 @@ def test_apply_recovers_from_crash_during_committing(monkeypatch):
     assert result["status"] == "APPLIED"
     assert result["output_receipt_ids"] == [2, 3]
     assert client.get_receipt_item_type_counts(image_id, 1) == {}
+
+
+@mock_aws
+def test_apply_survives_commit_exception_after_transaction_landed(monkeypatch):
+    """A lost commit response (DynamoDB committed, then the call raised)
+    must not trigger a rollback that would destroy the committed outputs."""
+    raw_bucket = "resegment-raw"
+    client, s3_client, image_id = _seed_two_line_receipt(
+        "ReceiptResegmentLanded", raw_bucket, "resegment-images"
+    )
+
+    plan = create_plan(
+        {
+            "image_id": image_id,
+            "source_receipt_id": 1,
+            "segments": [
+                {"segment_key": "left", "include_line_ids": [1]},
+                {"segment_key": "right", "include_line_ids": [2]},
+            ],
+        },
+        dynamo_client=client,
+        s3_client=s3_client,
+        raw_bucket=raw_bucket,
+    )
+
+    real_commit = client.commit_receipt_resegmentation
+
+    def commit_then_raise(*args, **kwargs):
+        real_commit(*args, **kwargs)
+        raise RuntimeError("simulated lost commit response")
+
+    monkeypatch.setattr(client, "commit_receipt_resegmentation", commit_then_raise)
+
+    result = apply_plan(
+        {
+            "plan_id": plan["plan_id"],
+            "plan_hash": plan["plan_hash"],
+            "create_embeddings": False,
+        },
+        dynamo_client=client,
+        s3_client=s3_client,
+        raw_bucket=raw_bucket,
+        site_bucket="resegment-site",
+        chromadb_bucket="resegment-chroma",
+    )
+
+    assert result["status"] == "APPLIED"
+    assert result["output_receipt_ids"] == [2, 3]
+    for receipt_id in (2, 3):
+        details = client.get_receipt_details(image_id, receipt_id)
+        assert len(details.words) == 1
+        assert len(details.labels) == 1
+
+
+@mock_aws
+def test_create_plan_rejects_visible_regions_on_rectangular_strategy():
+    """Apply ignores visible_regions for RECTANGULAR plans, so accepting
+    them would preview an artifact apply never produces."""
+    raw_bucket = "resegment-raw"
+    client, s3_client, image_id = _seed_two_line_receipt(
+        "ReceiptResegmentRegions", raw_bucket, "resegment-images"
+    )
+
+    with pytest.raises(ValueError, match="visible_regions require"):
+        create_plan(
+            {
+                "schema_version": 2,
+                "image_id": image_id,
+                "source_receipt_id": 1,
+                "segments": [
+                    {
+                        "segment_key": "only",
+                        "visible_regions": [
+                            {
+                                "points": [
+                                    {"x": 0.1, "y": 0.1},
+                                    {"x": 0.9, "y": 0.1},
+                                    {"x": 0.9, "y": 0.9},
+                                ]
+                            }
+                        ],
+                    }
+                ],
+                "assignments": {
+                    "lines": [
+                        {"line_id": 1, "segment_key": "only"},
+                        {"line_id": 2, "segment_key": "only"},
+                    ]
+                },
+                "visualization": {"strategy": "RECTANGULAR"},
+            },
+            dynamo_client=client,
+            s3_client=s3_client,
+            raw_bucket=raw_bucket,
+        )

--- a/tests/test_resegment_receipt_lambda.py
+++ b/tests/test_resegment_receipt_lambda.py
@@ -19,6 +19,8 @@ from receipt_dynamo import (
     ReceiptWord,
     ReceiptWordLabel,
 )
+from receipt_dynamo.data.shared_exceptions import EntityNotFoundError
+from receipt_upload.resegment import compute_plan_hash
 
 from infra.resegment_receipt_lambda.lambdas import resegment_receipt
 from infra.resegment_receipt_lambda.lambdas.resegment_receipt import (
@@ -883,3 +885,316 @@ def test_create_plan_rejects_visible_regions_on_rectangular_strategy():
             s3_client=s3_client,
             raw_bucket=raw_bucket,
         )
+
+
+_V1_SEGMENTS = [
+    {"segment_key": "left", "include_line_ids": [1]},
+    {"segment_key": "right", "include_line_ids": [2]},
+]
+
+
+def _v1_plan_event(image_id: str) -> dict:
+    return {
+        "image_id": image_id,
+        "source_receipt_id": 1,
+        "segments": _V1_SEGMENTS,
+    }
+
+
+@mock_aws
+def test_conditional_plan_writes_enforce_preconditions():
+    """M1: head-plan writes are compare-and-swap. If-None-Match:* blocks a
+    clobbering create and a stale If-Match blocks a clobbering update."""
+    raw_bucket = "resegment-raw"
+    s3_client = boto3.client("s3", region_name="us-east-1")
+    s3_client.create_bucket(Bucket=raw_bucket)
+    plan = {"plan_id": "plan-cond", "revision": 1, "status": "PLANNED"}
+
+    etag = resegment_receipt._save_plan(
+        s3_client, raw_bucket, plan, if_none_match=True
+    )
+    assert etag
+
+    with pytest.raises(resegment_receipt.PlanPreconditionError):
+        resegment_receipt._save_plan(
+            s3_client, raw_bucket, plan, if_none_match=True
+        )
+
+    with pytest.raises(resegment_receipt.PlanPreconditionError):
+        resegment_receipt._save_plan(
+            s3_client, raw_bucket, plan, if_match="0" * 32
+        )
+
+    plan["status"] = "COMMITTING"
+    new_etag = resegment_receipt._save_plan(
+        s3_client, raw_bucket, plan, if_match=etag
+    )
+    assert new_etag and new_etag != etag
+    loaded, loaded_etag = resegment_receipt._load_plan_with_etag(
+        s3_client, raw_bucket, "plan-cond"
+    )
+    assert loaded_etag == new_etag
+    assert loaded["status"] == "COMMITTING"
+
+
+@mock_aws
+def test_create_plan_rejects_duplicate_plan_id():
+    """M1: creating a second plan with an existing plan_id must fail the
+    conditional revision/head writes rather than clobber the stored plan."""
+    raw_bucket = "resegment-raw"
+    client, s3_client, image_id = _seed_two_line_receipt(
+        "ReceiptResegmentDup", raw_bucket, "resegment-images"
+    )
+    kwargs = dict(
+        dynamo_client=client, s3_client=s3_client, raw_bucket=raw_bucket
+    )
+    create_plan(_v1_plan_event(image_id), plan_id="dup-plan", **kwargs)
+    with pytest.raises(resegment_receipt.PlanPreconditionError):
+        create_plan(_v1_plan_event(image_id), plan_id="dup-plan", **kwargs)
+
+
+def _stale_etag_loader(monkeypatch):
+    """Force apply_plan to read a valid plan body with a stale ETag so its
+    conditional writes lose the compare-and-swap, as a concurrent writer
+    would cause."""
+    real_load = resegment_receipt._load_plan_with_etag
+
+    def stale_load(s3_client, bucket, plan_id):
+        loaded, _etag = real_load(s3_client, bucket, plan_id)
+        return loaded, "0" * 32
+
+    monkeypatch.setattr(
+        resegment_receipt, "_load_plan_with_etag", stale_load
+    )
+
+
+@mock_aws
+def test_apply_bails_at_execution_lock_when_head_changed(monkeypatch):
+    """C2: a second concurrent apply loses the PLANNED->COMMITTING swap and
+    bails BEFORE reserving IDs or deleting rows, so it cannot destroy the
+    winner's data."""
+    raw_bucket = "resegment-raw"
+    client, s3_client, image_id = _seed_two_line_receipt(
+        "ReceiptResegmentLock", raw_bucket, "resegment-images"
+    )
+    plan = create_plan(
+        _v1_plan_event(image_id),
+        dynamo_client=client,
+        s3_client=s3_client,
+        raw_bucket=raw_bucket,
+    )
+
+    _stale_etag_loader(monkeypatch)
+
+    with pytest.raises(ValueError, match="already in progress"):
+        apply_plan(
+            {
+                "plan_id": plan["plan_id"],
+                "plan_hash": plan["plan_hash"],
+                "create_embeddings": False,
+            },
+            dynamo_client=client,
+            s3_client=s3_client,
+            raw_bucket=raw_bucket,
+            site_bucket="resegment-site",
+            chromadb_bucket="resegment-chroma",
+        )
+
+    # The source survived and no output rows were reserved or staged.
+    assert client.get_receipt(image_id, 1).receipt_id == 1
+    for output_id in (2, 3):
+        assert client.get_receipt_item_type_counts(image_id, output_id) == {}
+
+
+@mock_aws
+def test_apply_recovery_serializes_on_stale_etag(monkeypatch):
+    """C2: two workers recovering the same COMMITTING plan serialize on the
+    conditional reset; the loser bails without releasing the winner's
+    reservations."""
+    raw_bucket = "resegment-raw"
+    client, s3_client, image_id = _seed_two_line_receipt(
+        "ReceiptResegmentSerialize", raw_bucket, "resegment-images"
+    )
+    plan = create_plan(
+        _v1_plan_event(image_id),
+        dynamo_client=client,
+        s3_client=s3_client,
+        raw_bucket=raw_bucket,
+    )
+    # Simulate a crash mid-commit: reservations exist and status is COMMITTING.
+    client.reserve_receipt_ids(image_id, [2, 3], plan["plan_id"])
+    stored = resegment_receipt._load_plan(s3_client, raw_bucket, plan["plan_id"])
+    stored["status"] = "COMMITTING"
+    resegment_receipt._save_plan(s3_client, raw_bucket, stored)
+
+    _stale_etag_loader(monkeypatch)
+
+    with pytest.raises(ValueError, match="recovering it"):
+        apply_plan(
+            {
+                "plan_id": plan["plan_id"],
+                "plan_hash": plan["plan_hash"],
+                "create_embeddings": False,
+            },
+            dynamo_client=client,
+            s3_client=s3_client,
+            raw_bucket=raw_bucket,
+            site_bucket="resegment-site",
+            chromadb_bucket="resegment-chroma",
+        )
+
+    # The loser must not have released the (winner's) reservations.
+    for output_id in (2, 3):
+        assert client.get_receipt_item_type_counts(image_id, output_id) == {
+            "RESEGMENT_RESERVATION": 1
+        }
+
+
+@mock_aws
+def test_apply_reverifies_source_fingerprint_before_commit(monkeypatch):
+    """M2: an external edit to a source label after staging but before the
+    commit is caught by the pre-commit fingerprint re-verification, and the
+    apply rolls back instead of committing stale outputs."""
+    raw_bucket = "resegment-raw"
+    client, s3_client, image_id = _seed_two_line_receipt(
+        "ReceiptResegmentReverify", raw_bucket, "resegment-images"
+    )
+    plan = create_plan(
+        _v1_plan_event(image_id),
+        dynamo_client=client,
+        s3_client=s3_client,
+        raw_bucket=raw_bucket,
+    )
+
+    real_stage = resegment_receipt._stage_outputs
+
+    def stage_then_edit_source(**kwargs):
+        real_stage(**kwargs)
+        # A concurrent writer edits a source label between the up-front
+        # fingerprint check and the commit transaction.
+        client.add_receipt_word_labels(
+            [
+                ReceiptWordLabel(
+                    image_id=image_id,
+                    receipt_id=1,
+                    line_id=1,
+                    word_id=1,
+                    label="MERCHANT_NAME",
+                    reasoning="edited after the up-front check",
+                    timestamp_added=datetime.now(timezone.utc),
+                    validation_status="INVALID",
+                    label_proposed_by="test",
+                )
+            ]
+        )
+
+    monkeypatch.setattr(
+        resegment_receipt, "_stage_outputs", stage_then_edit_source
+    )
+
+    with pytest.raises(ValueError, match="source receipt changed"):
+        apply_plan(
+            {
+                "plan_id": plan["plan_id"],
+                "plan_hash": plan["plan_hash"],
+                "create_embeddings": False,
+            },
+            dynamo_client=client,
+            s3_client=s3_client,
+            raw_bucket=raw_bucket,
+            site_bucket="resegment-site",
+            chromadb_bucket="resegment-chroma",
+        )
+
+    # Nothing committed: the source is intact and the outputs were rolled back.
+    assert client.get_receipt(image_id, 1).receipt_id == 1
+    for output_id in (2, 3):
+        assert client.get_receipt_item_type_counts(image_id, output_id) == {}
+
+
+@mock_aws
+def test_apply_rejects_visible_regions_on_rectangular_stored_plan():
+    """M3: even a hand-edited stored plan that pairs visible_regions with a
+    RECTANGULAR apply is rejected before any destructive work."""
+    raw_bucket = "resegment-raw"
+    client, s3_client, image_id = _seed_two_line_receipt(
+        "ReceiptResegmentApplyRegions", raw_bucket, "resegment-images"
+    )
+    plan = create_plan(
+        _v1_plan_event(image_id),
+        dynamo_client=client,
+        s3_client=s3_client,
+        raw_bucket=raw_bucket,
+    )
+    assert plan["visualization"]["effective_strategy"] == "RECTANGULAR"
+
+    stored = resegment_receipt._load_plan(s3_client, raw_bucket, plan["plan_id"])
+    stored["segments"][0]["visible_regions"] = [
+        {
+            "region_id": "smuggled",
+            "points": [
+                {"x": 0.1, "y": 0.1},
+                {"x": 0.2, "y": 0.1},
+                {"x": 0.2, "y": 0.2},
+            ],
+        }
+    ]
+    stored["plan_hash"] = compute_plan_hash(stored)
+    resegment_receipt._save_plan(s3_client, raw_bucket, stored)
+
+    with pytest.raises(ValueError, match="visible_regions require"):
+        apply_plan(
+            {
+                "plan_id": plan["plan_id"],
+                "plan_hash": stored["plan_hash"],
+                "create_embeddings": False,
+            },
+            dynamo_client=client,
+            s3_client=s3_client,
+            raw_bucket=raw_bucket,
+            site_bucket="resegment-site",
+            chromadb_bucket="resegment-chroma",
+        )
+    # No destruction: the source still exists.
+    assert client.get_receipt(image_id, 1).receipt_id == 1
+
+
+@mock_aws
+def test_v1_plan_binds_source_image_identity():
+    """M4: a v1 plan's fingerprint now covers the source image bytes, so a
+    same-key overwrite of the image between plan and apply is detected."""
+    raw_bucket = "resegment-raw"
+    image_bucket = "resegment-images"
+    client, s3_client, image_id = _seed_two_line_receipt(
+        "ReceiptResegmentV1Bytes", raw_bucket, image_bucket
+    )
+    plan = create_plan(
+        _v1_plan_event(image_id),
+        dynamo_client=client,
+        s3_client=s3_client,
+        raw_bucket=raw_bucket,
+    )
+    assert int(plan["schema_version"]) == 1
+
+    # Overwrite the underlying image bytes without touching any DynamoDB rows.
+    buffer = io.BytesIO()
+    PILImage.new("RGB", (200, 300), "black").save(buffer, format="PNG")
+    s3_client.put_object(
+        Bucket=image_bucket, Key="original.png", Body=buffer.getvalue()
+    )
+
+    with pytest.raises(ValueError, match="source receipt changed"):
+        apply_plan(
+            {
+                "plan_id": plan["plan_id"],
+                "plan_hash": plan["plan_hash"],
+                "create_embeddings": False,
+            },
+            dynamo_client=client,
+            s3_client=s3_client,
+            raw_bucket=raw_bucket,
+            site_bucket="resegment-site",
+            chromadb_bucket="resegment-chroma",
+        )
+    # Rejected before any destructive work.
+    assert client.get_receipt(image_id, 1).receipt_id == 1


### PR DESCRIPTION
## Summary

- add schema-v2, line-first receipt assignments with sparse contiguous word overrides
- add immutable `plan`, `get`, `revise`, and guarded `apply` operations to both MCP surfaces
- add IMAGE/SCAN-aware review artifacts: overlay, inline contact sheet, masks, and transparent crops
- preserve the existing v1 rectangular workflow while adding hierarchy-complete source fingerprinting and stale-plan protection

## Why

The production Twin Peaks example contains two physical receipts stacked in one IMAGE. The earlier word-bounds result treated foreground fragments as rectangles and incorrectly assigned lower card-slip lines. Re-segmentation needs to reason from complete lines, letter-corner geometry, orientation, disconnected visible regions, labels, and image type—not just a word-level bounding box.

## Safety and behavior

- the stored `Image.image_type` is authoritative
- layered IMAGE plans are reviewable but intentionally blocked from apply with `LAYERED_APPLY_NOT_SUPPORTED` until the masked renderer is ready
- SCAN remains rectangular; layered SCAN plans require explicit confirmation
- plan hashes cover the source image bytes plus image, receipt, line, word, letter, label, and place state
- revisions are immutable and stale revisions cannot apply
- labels and the line → word → letter hierarchy follow their assigned destination transactionally

## Twin Peaks review case

The line-first golden plan assigns:

- card slip: 54 lines / 253 words / 19 labels
- guest receipt: 76 lines / 361 words / 64 labels
- discard: 6 lines / 18 words

The visualization bundle exposes the overlapping IMAGE geometry directly so a reviewer can revise line ownership before any mutation.

## Checks

- 50 focused planner, preview, Lambda, MCP, and Dynamo tests
- 12 combine/migration tests
- Black and isort checks using the repository/package configurations
- Ruff checks for the new and directly affected clean-scope modules
- Python compilation and `git diff --check`

## Headless Claude Code dry run

Claude Code reviewed the branch in a read-only, MCP-isolated session and found the
plan/get/revise/apply contract conditionally sufficient. Its one actionable
guardrail is included in the follow-up commit: disconnected visible regions are
now a blocker for rectangular output, preventing a PHOTO crop from bleeding
through the space between stacked receipt fragments.

## Follow-up

Implement masked/layered IMAGE rendering before enabling apply for this stacked-receipt edge case. This PR deliberately stops at a safe, reviewable plan.
