### PR TITLE
Move receipt-chroma to a glyphstudio 'sections' extra (fix prod deploy)

### DIFF
--- a/tools/glyph-studio/py/pyproject.toml
+++ b/tools/glyph-studio/py/pyproject.toml
@@ -10,8 +10,14 @@ requires-python = ">=3.10"
 dependencies = [
     "numpy",
     "pillow",
-    "receipt-chroma",
 ]
+
+[project.optional-dependencies]
+# receipt-chroma is a local monorepo package (not on PyPI). Only
+# section_propagate / section_propagate_eval need it; the glyph MCP Lambda
+# image installs the default (numpy + PIL only) package and must stay
+# resolvable without it.
+sections = ["receipt-chroma"]
 
 [tool.setuptools]
 packages = ["glyphstudio"]

--- a/tools/glyph-studio/py/tests/test_packaging.py
+++ b/tools/glyph-studio/py/tests/test_packaging.py
@@ -1,0 +1,27 @@
+"""Guard the glyph MCP Lambda image contract: the default glyphstudio
+install must stay resolvable without local monorepo packages.
+
+The Lambda Dockerfile (infra/glyph_mcp_lambda/lambdas/Dockerfile) runs
+``pip install tools/glyph-studio/py`` against PyPI only. A mandatory
+dependency on receipt-chroma (a local package, not on PyPI) breaks that
+build — it must stay behind the ``sections`` extra.
+"""
+
+import tomllib
+from pathlib import Path
+
+_PYPROJECT = Path(__file__).resolve().parents[1] / "pyproject.toml"
+
+
+def _project() -> dict:
+    return tomllib.loads(_PYPROJECT.read_text())["project"]
+
+
+def test_receipt_chroma_is_not_a_default_dependency():
+    default_deps = " ".join(_project()["dependencies"]).replace("_", "-")
+    assert "receipt-chroma" not in default_deps
+
+
+def test_receipt_chroma_stays_available_via_sections_extra():
+    extras = _project()["optional-dependencies"]["sections"]
+    assert any("receipt-chroma" in dep for dep in extras)


### PR DESCRIPTION
## Problem
The prod deploy for `ff3fab9f` (#1145) failed: the glyph-mcp Lambda image build died with `No matching distribution found for receipt-chroma`. #1145 added `receipt-chroma` (a local monorepo package, not on PyPI) as a mandatory glyphstudio dependency, but `infra/glyph_mcp_lambda/lambdas/Dockerfile` installs `tools/glyph-studio/py` against PyPI only (by design: "numpy + PIL only").

## Fix
Only `section_propagate.py` / `section_propagate_eval.py` import `receipt_chroma` — the MCP server never does. Move the dependency behind an optional `sections` extra. Environments running section propagation install `glyphstudio[sections]` (or already have the sibling package editable-installed).

## Verification
- Fresh venv: `pip install tools/glyph-studio/py` succeeds with **no receipt-chroma** installed; `import glyphstudio` works.
- The exact Lambda image builds: replicated the CodeBuild context assembly (source_paths rsync patterns + handler dir + extra context paths + root Dockerfile) and ran `docker build --platform linux/arm64` to completion; `import glyphstudio, handler` inside the image works.
- `tests/test_section_propagate.py` passes (6/6) with local receipt_chroma installed.
- New `tests/test_packaging.py` pins the contract (receipt-chroma absent from default deps, present in the `sections` extra).

Diff is packaging-only: `pyproject.toml` +8/−1, one new test file. No code or infrastructure changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)