### PR TITLE
Section→label compatibility prior: deterministic artifact + gate + review queue

### DIFF
--- a/receipt_upload/pyproject.toml
+++ b/receipt_upload/pyproject.toml
@@ -95,6 +95,7 @@ include = ["receipt_upload/py.typed"]
 
 [tool.hatch.build.targets.wheel.force-include]
 "receipt_upload/assets/section_order_priors_v2.json" = "receipt_upload/assets/section_order_priors_v2.json"
+"receipt_upload/assets/section_label_priors_v1.json" = "receipt_upload/assets/section_label_priors_v1.json"
 
 [tool.black]
 line-length = 79

--- a/receipt_upload/pyproject.toml
+++ b/receipt_upload/pyproject.toml
@@ -97,6 +97,11 @@ include = ["receipt_upload/py.typed"]
 "receipt_upload/assets/section_order_priors_v2.json" = "receipt_upload/assets/section_order_priors_v2.json"
 "receipt_upload/assets/section_label_priors_v1.json" = "receipt_upload/assets/section_label_priors_v1.json"
 
+# The global exclude drops *.json, so sdists need the assets re-included too.
+[tool.hatch.build.targets.sdist.force-include]
+"receipt_upload/assets/section_order_priors_v2.json" = "receipt_upload/assets/section_order_priors_v2.json"
+"receipt_upload/assets/section_label_priors_v1.json" = "receipt_upload/assets/section_label_priors_v1.json"
+
 [tool.black]
 line-length = 79
 target-version = ["py312"]

--- a/receipt_upload/receipt_upload/assets/section_label_priors_v1.json
+++ b/receipt_upload/receipt_upload/assets/section_label_priors_v1.json
@@ -817,7 +817,7 @@
   ],
   "source": {
     "core_label_row_count": 28329,
-    "corpus_sha256": "94f12973bc6886c909f7b0d8d723d340f941e52ec4cd814a96d4163cd9549f41",
+    "corpus_sha256": "4597ea00a415520794283e06ab01f0eab0f259301e973a033ea758b969a19fe3",
     "legacy_valid_section_rows_excluded": 0,
     "receipts_with_valid_labels": 813,
     "receipts_with_valid_sections_and_labels": 794,

--- a/receipt_upload/receipt_upload/assets/section_label_priors_v1.json
+++ b/receipt_upload/receipt_upload/assets/section_label_priors_v1.json
@@ -1,8 +1,9 @@
 {
-  "denominator": "pairs of (VALID core-label row, VALID canonical section on the row's line); p = count / label pair total",
+  "denominator": "p = section pair count / label's sectioned row count (co-occurrence rate per sectioned row; cells on multi-section lines can sum above 1.0)",
   "labels": {
     "ADDRESS_LINE": {
       "sectioned": 5226,
+      "sectioned_lines": 1991,
       "sections": {
         "ADDRESS": {
           "count": 4825,
@@ -46,6 +47,7 @@
     },
     "CASH_BACK": {
       "sectioned": 19,
+      "sectioned_lines": 19,
       "sections": {
         "ITEMS": {
           "count": 2,
@@ -61,6 +63,7 @@
     },
     "CHANGE": {
       "sectioned": 50,
+      "sectioned_lines": 50,
       "sections": {
         "ITEMS": {
           "count": 1,
@@ -84,6 +87,7 @@
     },
     "COUPON": {
       "sectioned": 109,
+      "sectioned_lines": 66,
       "sections": {
         "ADDRESS": {
           "count": 9,
@@ -123,6 +127,7 @@
     },
     "DATE": {
       "sectioned": 337,
+      "sectioned_lines": 286,
       "sections": {
         "ADDRESS": {
           "count": 33,
@@ -166,6 +171,7 @@
     },
     "DISCOUNT": {
       "sectioned": 137,
+      "sectioned_lines": 97,
       "sections": {
         "ADDRESS": {
           "count": 1,
@@ -201,6 +207,7 @@
     },
     "GRAND_TOTAL": {
       "sectioned": 850,
+      "sectioned_lines": 849,
       "sections": {
         "ITEMS": {
           "count": 16,
@@ -228,6 +235,7 @@
     },
     "LINE_TOTAL": {
       "sectioned": 1451,
+      "sectioned_lines": 1447,
       "sections": {
         "ADDRESS": {
           "count": 2,
@@ -279,6 +287,7 @@
     },
     "LOYALTY_ID": {
       "sectioned": 91,
+      "sectioned_lines": 77,
       "sections": {
         "ADDRESS": {
           "count": 2,
@@ -322,6 +331,7 @@
     },
     "MERCHANT_NAME": {
       "sectioned": 1287,
+      "sectioned_lines": 856,
       "sections": {
         "ADDRESS": {
           "count": 140,
@@ -361,6 +371,7 @@
     },
     "PAYMENT_METHOD": {
       "sectioned": 3234,
+      "sectioned_lines": 2718,
       "sections": {
         "ADDRESS": {
           "count": 2,
@@ -408,6 +419,7 @@
     },
     "PHONE_NUMBER": {
       "sectioned": 938,
+      "sectioned_lines": 796,
       "sections": {
         "ADDRESS": {
           "count": 752,
@@ -447,6 +459,7 @@
     },
     "PRODUCT_NAME": {
       "sectioned": 4300,
+      "sectioned_lines": 1783,
       "sections": {
         "ADDRESS": {
           "count": 2,
@@ -498,6 +511,7 @@
     },
     "QUANTITY": {
       "sectioned": 407,
+      "sectioned_lines": 399,
       "sections": {
         "ADDRESS": {
           "count": 1,
@@ -533,6 +547,7 @@
     },
     "REFUND": {
       "sectioned": 10,
+      "sectioned_lines": 9,
       "sections": {
         "ITEMS": {
           "count": 6,
@@ -552,6 +567,7 @@
     },
     "STORE_HOURS": {
       "sectioned": 1186,
+      "sectioned_lines": 341,
       "sections": {
         "ADDRESS": {
           "count": 12,
@@ -587,6 +603,7 @@
     },
     "SUBTOTAL": {
       "sectioned": 393,
+      "sectioned_lines": 393,
       "sections": {
         "ADDRESS": {
           "count": 2,
@@ -626,6 +643,7 @@
     },
     "TAX": {
       "sectioned": 386,
+      "sectioned_lines": 385,
       "sections": {
         "ADDRESS": {
           "count": 1,
@@ -661,6 +679,7 @@
     },
     "TIME": {
       "sectioned": 349,
+      "sectioned_lines": 298,
       "sections": {
         "ADDRESS": {
           "count": 34,
@@ -700,6 +719,7 @@
     },
     "TIP": {
       "sectioned": 41,
+      "sectioned_lines": 41,
       "sections": {
         "ITEMS": {
           "count": 2,
@@ -723,6 +743,7 @@
     },
     "UNIT_PRICE": {
       "sectioned": 400,
+      "sectioned_lines": 399,
       "sections": {
         "ADDRESS": {
           "count": 3,
@@ -762,6 +783,7 @@
     },
     "WEBSITE": {
       "sectioned": 599,
+      "sectioned_lines": 589,
       "sections": {
         "ADDRESS": {
           "count": 26,

--- a/receipt_upload/receipt_upload/assets/section_label_priors_v1.json
+++ b/receipt_upload/receipt_upload/assets/section_label_priors_v1.json
@@ -1,0 +1,830 @@
+{
+  "denominator": "pairs of (VALID core-label row, VALID canonical section on the row's line); p = count / label pair total",
+  "labels": {
+    "ADDRESS_LINE": {
+      "sectioned": 5226,
+      "sections": {
+        "ADDRESS": {
+          "count": 4825,
+          "p": 0.923268
+        },
+        "FOOTER": {
+          "count": 152,
+          "p": 0.029085
+        },
+        "ITEMS": {
+          "count": 55,
+          "p": 0.010524
+        },
+        "PAYMENT": {
+          "count": 87,
+          "p": 0.016648
+        },
+        "STOREFRONT": {
+          "count": 44,
+          "p": 0.008419
+        },
+        "SUMMARY": {
+          "count": 30,
+          "p": 0.005741
+        },
+        "SURVEY": {
+          "count": 9,
+          "p": 0.001722
+        },
+        "TOTAL_LINE": {
+          "count": 4,
+          "p": 0.000765
+        },
+        "TRANSACTION_INFO": {
+          "count": 20,
+          "p": 0.003827
+        }
+      },
+      "total": 5839,
+      "unsectioned": 613
+    },
+    "CASH_BACK": {
+      "sectioned": 19,
+      "sections": {
+        "ITEMS": {
+          "count": 2,
+          "p": 0.105263
+        },
+        "PAYMENT": {
+          "count": 17,
+          "p": 0.894737
+        }
+      },
+      "total": 26,
+      "unsectioned": 7
+    },
+    "CHANGE": {
+      "sectioned": 50,
+      "sections": {
+        "ITEMS": {
+          "count": 1,
+          "p": 0.02
+        },
+        "PAYMENT": {
+          "count": 47,
+          "p": 0.94
+        },
+        "SUMMARY": {
+          "count": 1,
+          "p": 0.02
+        },
+        "TOTAL_LINE": {
+          "count": 1,
+          "p": 0.02
+        }
+      },
+      "total": 79,
+      "unsectioned": 29
+    },
+    "COUPON": {
+      "sectioned": 109,
+      "sections": {
+        "ADDRESS": {
+          "count": 9,
+          "p": 0.082569
+        },
+        "FOOTER": {
+          "count": 48,
+          "p": 0.440367
+        },
+        "ITEMS": {
+          "count": 15,
+          "p": 0.137615
+        },
+        "PAYMENT": {
+          "count": 11,
+          "p": 0.100917
+        },
+        "STOREFRONT": {
+          "count": 9,
+          "p": 0.082569
+        },
+        "SUMMARY": {
+          "count": 3,
+          "p": 0.027523
+        },
+        "SURVEY": {
+          "count": 12,
+          "p": 0.110092
+        },
+        "TRANSACTION_INFO": {
+          "count": 2,
+          "p": 0.018349
+        }
+      },
+      "total": 270,
+      "unsectioned": 161
+    },
+    "DATE": {
+      "sectioned": 337,
+      "sections": {
+        "ADDRESS": {
+          "count": 33,
+          "p": 0.097923
+        },
+        "BARCODE": {
+          "count": 1,
+          "p": 0.002967
+        },
+        "FOOTER": {
+          "count": 30,
+          "p": 0.089021
+        },
+        "ITEMS": {
+          "count": 6,
+          "p": 0.017804
+        },
+        "PAYMENT": {
+          "count": 97,
+          "p": 0.287834
+        },
+        "STOREFRONT": {
+          "count": 1,
+          "p": 0.002967
+        },
+        "SUMMARY": {
+          "count": 1,
+          "p": 0.002967
+        },
+        "TOTAL_LINE": {
+          "count": 4,
+          "p": 0.011869
+        },
+        "TRANSACTION_INFO": {
+          "count": 164,
+          "p": 0.486647
+        }
+      },
+      "total": 1162,
+      "unsectioned": 825
+    },
+    "DISCOUNT": {
+      "sectioned": 137,
+      "sections": {
+        "ADDRESS": {
+          "count": 1,
+          "p": 0.007299
+        },
+        "FOOTER": {
+          "count": 20,
+          "p": 0.145985
+        },
+        "ITEMS": {
+          "count": 100,
+          "p": 0.729927
+        },
+        "PAYMENT": {
+          "count": 4,
+          "p": 0.029197
+        },
+        "STOREFRONT": {
+          "count": 1,
+          "p": 0.007299
+        },
+        "SUMMARY": {
+          "count": 10,
+          "p": 0.072993
+        },
+        "TOTAL_LINE": {
+          "count": 1,
+          "p": 0.007299
+        }
+      },
+      "total": 340,
+      "unsectioned": 203
+    },
+    "GRAND_TOTAL": {
+      "sectioned": 850,
+      "sections": {
+        "ITEMS": {
+          "count": 16,
+          "p": 0.018824
+        },
+        "PAYMENT": {
+          "count": 260,
+          "p": 0.305882
+        },
+        "SUMMARY": {
+          "count": 55,
+          "p": 0.064706
+        },
+        "TOTAL_LINE": {
+          "count": 517,
+          "p": 0.608235
+        },
+        "TRANSACTION_INFO": {
+          "count": 2,
+          "p": 0.002353
+        }
+      },
+      "total": 1053,
+      "unsectioned": 203
+    },
+    "LINE_TOTAL": {
+      "sectioned": 1451,
+      "sections": {
+        "ADDRESS": {
+          "count": 2,
+          "p": 0.001378
+        },
+        "BARCODE": {
+          "count": 1,
+          "p": 0.000689
+        },
+        "FOOTER": {
+          "count": 3,
+          "p": 0.002068
+        },
+        "ITEMS": {
+          "count": 1365,
+          "p": 0.940731
+        },
+        "PAYMENT": {
+          "count": 23,
+          "p": 0.015851
+        },
+        "SECTION_HEADER": {
+          "count": 7,
+          "p": 0.004824
+        },
+        "STOREFRONT": {
+          "count": 3,
+          "p": 0.002068
+        },
+        "SUMMARY": {
+          "count": 27,
+          "p": 0.018608
+        },
+        "SURVEY": {
+          "count": 1,
+          "p": 0.000689
+        },
+        "TOTAL_LINE": {
+          "count": 16,
+          "p": 0.011027
+        },
+        "TRANSACTION_INFO": {
+          "count": 3,
+          "p": 0.002068
+        }
+      },
+      "total": 1693,
+      "unsectioned": 242
+    },
+    "LOYALTY_ID": {
+      "sectioned": 91,
+      "sections": {
+        "ADDRESS": {
+          "count": 2,
+          "p": 0.021978
+        },
+        "BARCODE": {
+          "count": 8,
+          "p": 0.087912
+        },
+        "FOOTER": {
+          "count": 8,
+          "p": 0.087912
+        },
+        "ITEMS": {
+          "count": 8,
+          "p": 0.087912
+        },
+        "PAYMENT": {
+          "count": 41,
+          "p": 0.450549
+        },
+        "STOREFRONT": {
+          "count": 1,
+          "p": 0.010989
+        },
+        "SUMMARY": {
+          "count": 1,
+          "p": 0.010989
+        },
+        "SURVEY": {
+          "count": 11,
+          "p": 0.120879
+        },
+        "TRANSACTION_INFO": {
+          "count": 11,
+          "p": 0.120879
+        }
+      },
+      "total": 173,
+      "unsectioned": 82
+    },
+    "MERCHANT_NAME": {
+      "sectioned": 1287,
+      "sections": {
+        "ADDRESS": {
+          "count": 140,
+          "p": 0.10878
+        },
+        "BARCODE": {
+          "count": 2,
+          "p": 0.001554
+        },
+        "FOOTER": {
+          "count": 25,
+          "p": 0.019425
+        },
+        "ITEMS": {
+          "count": 19,
+          "p": 0.014763
+        },
+        "PAYMENT": {
+          "count": 15,
+          "p": 0.011655
+        },
+        "STOREFRONT": {
+          "count": 1080,
+          "p": 0.839161
+        },
+        "SURVEY": {
+          "count": 4,
+          "p": 0.003108
+        },
+        "TRANSACTION_INFO": {
+          "count": 2,
+          "p": 0.001554
+        }
+      },
+      "total": 1817,
+      "unsectioned": 530
+    },
+    "PAYMENT_METHOD": {
+      "sectioned": 3234,
+      "sections": {
+        "ADDRESS": {
+          "count": 2,
+          "p": 0.000618
+        },
+        "FOOTER": {
+          "count": 120,
+          "p": 0.037106
+        },
+        "ITEMS": {
+          "count": 29,
+          "p": 0.008967
+        },
+        "PAYMENT": {
+          "count": 2889,
+          "p": 0.893321
+        },
+        "SECTION_HEADER": {
+          "count": 1,
+          "p": 0.000309
+        },
+        "STOREFRONT": {
+          "count": 1,
+          "p": 0.000309
+        },
+        "SUMMARY": {
+          "count": 5,
+          "p": 0.001546
+        },
+        "SURVEY": {
+          "count": 66,
+          "p": 0.020408
+        },
+        "TOTAL_LINE": {
+          "count": 62,
+          "p": 0.019171
+        },
+        "TRANSACTION_INFO": {
+          "count": 59,
+          "p": 0.018244
+        }
+      },
+      "total": 3870,
+      "unsectioned": 636
+    },
+    "PHONE_NUMBER": {
+      "sectioned": 938,
+      "sections": {
+        "ADDRESS": {
+          "count": 752,
+          "p": 0.801706
+        },
+        "BARCODE": {
+          "count": 2,
+          "p": 0.002132
+        },
+        "FOOTER": {
+          "count": 38,
+          "p": 0.040512
+        },
+        "ITEMS": {
+          "count": 25,
+          "p": 0.026652
+        },
+        "PAYMENT": {
+          "count": 100,
+          "p": 0.10661
+        },
+        "SECTION_HEADER": {
+          "count": 1,
+          "p": 0.001066
+        },
+        "STOREFRONT": {
+          "count": 9,
+          "p": 0.009595
+        },
+        "TRANSACTION_INFO": {
+          "count": 11,
+          "p": 0.011727
+        }
+      },
+      "total": 1083,
+      "unsectioned": 145
+    },
+    "PRODUCT_NAME": {
+      "sectioned": 4300,
+      "sections": {
+        "ADDRESS": {
+          "count": 2,
+          "p": 0.000465
+        },
+        "BARCODE": {
+          "count": 3,
+          "p": 0.000698
+        },
+        "FOOTER": {
+          "count": 23,
+          "p": 0.005349
+        },
+        "ITEMS": {
+          "count": 4197,
+          "p": 0.976047
+        },
+        "PAYMENT": {
+          "count": 20,
+          "p": 0.004651
+        },
+        "SECTION_HEADER": {
+          "count": 12,
+          "p": 0.002791
+        },
+        "STOREFRONT": {
+          "count": 4,
+          "p": 0.00093
+        },
+        "SUMMARY": {
+          "count": 22,
+          "p": 0.005116
+        },
+        "SURVEY": {
+          "count": 7,
+          "p": 0.001628
+        },
+        "TOTAL_LINE": {
+          "count": 5,
+          "p": 0.001163
+        },
+        "TRANSACTION_INFO": {
+          "count": 5,
+          "p": 0.001163
+        }
+      },
+      "total": 5464,
+      "unsectioned": 1164
+    },
+    "QUANTITY": {
+      "sectioned": 407,
+      "sections": {
+        "ADDRESS": {
+          "count": 1,
+          "p": 0.002457
+        },
+        "BARCODE": {
+          "count": 1,
+          "p": 0.002457
+        },
+        "FOOTER": {
+          "count": 6,
+          "p": 0.014742
+        },
+        "ITEMS": {
+          "count": 384,
+          "p": 0.943489
+        },
+        "PAYMENT": {
+          "count": 4,
+          "p": 0.009828
+        },
+        "SUMMARY": {
+          "count": 4,
+          "p": 0.009828
+        },
+        "TRANSACTION_INFO": {
+          "count": 7,
+          "p": 0.017199
+        }
+      },
+      "total": 552,
+      "unsectioned": 145
+    },
+    "REFUND": {
+      "sectioned": 10,
+      "sections": {
+        "ITEMS": {
+          "count": 6,
+          "p": 0.6
+        },
+        "PAYMENT": {
+          "count": 2,
+          "p": 0.2
+        },
+        "TOTAL_LINE": {
+          "count": 2,
+          "p": 0.2
+        }
+      },
+      "total": 16,
+      "unsectioned": 6
+    },
+    "STORE_HOURS": {
+      "sectioned": 1186,
+      "sections": {
+        "ADDRESS": {
+          "count": 12,
+          "p": 0.010118
+        },
+        "FOOTER": {
+          "count": 237,
+          "p": 0.199831
+        },
+        "ITEMS": {
+          "count": 2,
+          "p": 0.001686
+        },
+        "PAYMENT": {
+          "count": 2,
+          "p": 0.001686
+        },
+        "STOREFRONT": {
+          "count": 924,
+          "p": 0.779089
+        },
+        "SURVEY": {
+          "count": 2,
+          "p": 0.001686
+        },
+        "TRANSACTION_INFO": {
+          "count": 7,
+          "p": 0.005902
+        }
+      },
+      "total": 1266,
+      "unsectioned": 80
+    },
+    "SUBTOTAL": {
+      "sectioned": 393,
+      "sections": {
+        "ADDRESS": {
+          "count": 2,
+          "p": 0.005089
+        },
+        "FOOTER": {
+          "count": 2,
+          "p": 0.005089
+        },
+        "ITEMS": {
+          "count": 33,
+          "p": 0.083969
+        },
+        "PAYMENT": {
+          "count": 25,
+          "p": 0.063613
+        },
+        "SUMMARY": {
+          "count": 289,
+          "p": 0.735369
+        },
+        "SURVEY": {
+          "count": 1,
+          "p": 0.002545
+        },
+        "TOTAL_LINE": {
+          "count": 40,
+          "p": 0.101781
+        },
+        "TRANSACTION_INFO": {
+          "count": 1,
+          "p": 0.002545
+        }
+      },
+      "total": 485,
+      "unsectioned": 92
+    },
+    "TAX": {
+      "sectioned": 386,
+      "sections": {
+        "ADDRESS": {
+          "count": 1,
+          "p": 0.002591
+        },
+        "ITEMS": {
+          "count": 19,
+          "p": 0.049223
+        },
+        "PAYMENT": {
+          "count": 11,
+          "p": 0.028497
+        },
+        "STOREFRONT": {
+          "count": 1,
+          "p": 0.002591
+        },
+        "SUMMARY": {
+          "count": 345,
+          "p": 0.893782
+        },
+        "TOTAL_LINE": {
+          "count": 8,
+          "p": 0.020725
+        },
+        "TRANSACTION_INFO": {
+          "count": 1,
+          "p": 0.002591
+        }
+      },
+      "total": 485,
+      "unsectioned": 99
+    },
+    "TIME": {
+      "sectioned": 349,
+      "sections": {
+        "ADDRESS": {
+          "count": 34,
+          "p": 0.097421
+        },
+        "BARCODE": {
+          "count": 1,
+          "p": 0.002865
+        },
+        "FOOTER": {
+          "count": 6,
+          "p": 0.017192
+        },
+        "ITEMS": {
+          "count": 9,
+          "p": 0.025788
+        },
+        "PAYMENT": {
+          "count": 104,
+          "p": 0.297994
+        },
+        "SUMMARY": {
+          "count": 3,
+          "p": 0.008596
+        },
+        "TOTAL_LINE": {
+          "count": 3,
+          "p": 0.008596
+        },
+        "TRANSACTION_INFO": {
+          "count": 189,
+          "p": 0.541547
+        }
+      },
+      "total": 1265,
+      "unsectioned": 916
+    },
+    "TIP": {
+      "sectioned": 41,
+      "sections": {
+        "ITEMS": {
+          "count": 2,
+          "p": 0.04878
+        },
+        "PAYMENT": {
+          "count": 4,
+          "p": 0.097561
+        },
+        "SUMMARY": {
+          "count": 34,
+          "p": 0.829268
+        },
+        "TOTAL_LINE": {
+          "count": 1,
+          "p": 0.02439
+        }
+      },
+      "total": 72,
+      "unsectioned": 31
+    },
+    "UNIT_PRICE": {
+      "sectioned": 400,
+      "sections": {
+        "ADDRESS": {
+          "count": 3,
+          "p": 0.0075
+        },
+        "FOOTER": {
+          "count": 2,
+          "p": 0.005
+        },
+        "ITEMS": {
+          "count": 373,
+          "p": 0.9325
+        },
+        "PAYMENT": {
+          "count": 5,
+          "p": 0.0125
+        },
+        "SECTION_HEADER": {
+          "count": 5,
+          "p": 0.0125
+        },
+        "SUMMARY": {
+          "count": 8,
+          "p": 0.02
+        },
+        "SURVEY": {
+          "count": 1,
+          "p": 0.0025
+        },
+        "TRANSACTION_INFO": {
+          "count": 3,
+          "p": 0.0075
+        }
+      },
+      "total": 531,
+      "unsectioned": 131
+    },
+    "WEBSITE": {
+      "sectioned": 599,
+      "sections": {
+        "ADDRESS": {
+          "count": 26,
+          "p": 0.043406
+        },
+        "FOOTER": {
+          "count": 290,
+          "p": 0.48414
+        },
+        "ITEMS": {
+          "count": 5,
+          "p": 0.008347
+        },
+        "PAYMENT": {
+          "count": 16,
+          "p": 0.026711
+        },
+        "STOREFRONT": {
+          "count": 28,
+          "p": 0.046745
+        },
+        "SUMMARY": {
+          "count": 1,
+          "p": 0.001669
+        },
+        "SURVEY": {
+          "count": 219,
+          "p": 0.365609
+        },
+        "TRANSACTION_INFO": {
+          "count": 14,
+          "p": 0.023372
+        }
+      },
+      "total": 788,
+      "unsectioned": 189
+    }
+  },
+  "model_source": "section-label-prior-v1",
+  "schema_version": 1,
+  "sections": [
+    "ADDRESS",
+    "BARCODE",
+    "FOOTER",
+    "ITEMS",
+    "PAYMENT",
+    "SECTION_HEADER",
+    "STOREFRONT",
+    "SUMMARY",
+    "SURVEY",
+    "TOTAL_LINE",
+    "TRANSACTION_INFO"
+  ],
+  "source": {
+    "core_label_row_count": 28329,
+    "corpus_sha256": "94f12973bc6886c909f7b0d8d723d340f941e52ec4cd814a96d4163cd9549f41",
+    "legacy_valid_section_rows_excluded": 0,
+    "receipts_with_valid_labels": 813,
+    "receipts_with_valid_sections_and_labels": 794,
+    "section_row_count": 5768,
+    "sectioned_core_label_row_count": 21800,
+    "valid_label_row_count": 29015,
+    "valid_section_row_count": 5751
+  },
+  "source_environment": "dev"
+}

--- a/receipt_upload/receipt_upload/label_section_gate.py
+++ b/receipt_upload/receipt_upload/label_section_gate.py
@@ -17,6 +17,7 @@ an immutable prior artifact and caller-provided section values.
 from __future__ import annotations
 
 import json
+import math
 from dataclasses import dataclass
 from functools import lru_cache
 from importlib.resources import files
@@ -123,10 +124,19 @@ def evaluate_label_section(
         )
 
     section_priors = entry.get("sections", {})
-    prior = max(
+    cell_values = [
         float(section_priors.get(section_type, {}).get("p", 0.0))
         for section_type in line_sections
-    )
+    ]
+    # A malformed artifact (NaN/inf/out-of-range cells) must fail loudly:
+    # NaN compares False against the threshold and would silently pass as OK.
+    for value in cell_values:
+        if not math.isfinite(value) or not 0.0 <= value <= 1.0:
+            raise ValueError(
+                f"Malformed prior cell for label {label!r}: {value!r} is "
+                "not a finite probability in [0, 1]"
+            )
+    prior = max(cell_values)
     if prior < threshold:
         return GateResult(
             verdict=VERDICT_LOW_PRIOR,

--- a/receipt_upload/receipt_upload/label_section_gate.py
+++ b/receipt_upload/receipt_upload/label_section_gate.py
@@ -1,0 +1,155 @@
+"""Pure section-to-word-label compatibility gate.
+
+The gate evaluates a proposed label against the canonical sections assigned
+to its line. It is a dependency leaf and imports only the Python standard
+library, allowing callers to load it without triggering the wider upload
+package's numpy, Pillow, or embedding import chains.
+
+Abstaining on an unsectioned line is a hard rule: DATE was approximately 70%
+unsectioned and TIME approximately 72% unsectioned in the 2026-07-18 dev
+snapshot because the semi-Markov decoder does not yet emit TRANSACTION_INFO.
+Treating those lines as mismatches would therefore manufacture false flags.
+
+This module is not wired into any write path. It only computes a verdict from
+an immutable prior artifact and caller-provided section values.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from functools import lru_cache
+from importlib.resources import files
+from typing import Any, Iterable, Optional
+
+VERDICT_OK = "OK"
+VERDICT_LOW_PRIOR = "LOW_PRIOR"
+VERDICT_ABSTAIN = "ABSTAIN"
+
+# Measured bad/good flag rates and enrichment by threshold on 2026-07-18:
+# 0.01: 10.5%/1.6%/6.5x; 0.02: 18.0%/3.8%/4.8x;
+# 0.05: 26.3%/6.3%/4.2x; 0.07: 28.0%/6.7%/4.2x;
+# 0.10: 29.7%/7.5%/3.9x; 0.15: 33.0%/9.2%/3.6x;
+# 0.30: 33.3%/11.2%/3.0x.
+# False flags consume human review time, while misses are silent. A threshold
+# of 0.05 sits left of the flat Youden-J plateau (0.200 at 0.05 versus the
+# 0.238 maximum at 0.15), retains near-maximal enrichment, and lies on the
+# robust 0.05-0.07 shelf rather than at a knife-edge.
+DEFAULT_LOW_PRIOR_THRESHOLD = 0.05
+
+# ceil(ln(0.05) / ln(1 - 0.05)) = 59. This is the smallest sample size for
+# which a cell with a true rate equal to the threshold has less than a 5%
+# probability of producing zero observations.
+MIN_SECTIONED_SUPPORT = 59
+
+
+@dataclass(frozen=True)
+class GateResult:
+    """Result of evaluating one label against its line's sections."""
+
+    verdict: str
+    prior: Optional[float]
+    threshold: float
+    reason: str
+
+
+@lru_cache(maxsize=1)
+def _default_priors_text() -> str:
+    """Read and cache the packaged default prior artifact's text.
+
+    Caching the text rather than the parsed object means every caller gets
+    a fresh dict, so no caller can mutate another caller's priors.
+    """
+    path = files("receipt_upload").joinpath(
+        "assets",
+        "section_label_priors_v1.json",
+    )
+    return path.read_text(encoding="utf-8")
+
+
+def load_priors(path: Optional[str] = None) -> dict[str, Any]:
+    """Load priors, caching only reads of the packaged default artifact.
+
+    A caller-supplied path is always read afresh. Objects implementing the
+    standard path protocol, such as ``pathlib.Path``, are also accepted by
+    Python's built-in ``open`` despite the intentionally narrow annotation.
+    """
+    if path is None:
+        return json.loads(_default_priors_text())
+
+    with open(path, encoding="utf-8") as stream:
+        return json.load(stream)
+
+
+def evaluate_label_section(
+    label: str,
+    section_types: Optional[Iterable[str]],
+    priors: dict[str, Any],
+    *,
+    threshold: float = DEFAULT_LOW_PRIOR_THRESHOLD,
+    min_support: int = MIN_SECTIONED_SUPPORT,
+) -> GateResult:
+    """Evaluate one label against the canonical sections assigned to a line."""
+    canonical_sections = set(priors.get("sections", []))
+    line_sections = {
+        section_type
+        for section_type in section_types or ()
+        if section_type in canonical_sections
+    }
+    if not line_sections:
+        return GateResult(
+            verdict=VERDICT_ABSTAIN,
+            prior=None,
+            threshold=threshold,
+            reason="unsectioned-line",
+        )
+
+    labels = priors.get("labels", {})
+    if label not in labels:
+        return GateResult(
+            verdict=VERDICT_ABSTAIN,
+            prior=None,
+            threshold=threshold,
+            reason="unknown-label",
+        )
+
+    entry = labels[label]
+    if int(entry.get("sectioned", 0)) < min_support:
+        return GateResult(
+            verdict=VERDICT_ABSTAIN,
+            prior=None,
+            threshold=threshold,
+            reason="insufficient-support",
+        )
+
+    section_priors = entry.get("sections", {})
+    prior = max(
+        float(section_priors.get(section_type, {}).get("p", 0.0))
+        for section_type in line_sections
+    )
+    if prior < threshold:
+        return GateResult(
+            verdict=VERDICT_LOW_PRIOR,
+            prior=prior,
+            threshold=threshold,
+            reason="prior-below-threshold",
+        )
+
+    return GateResult(
+        verdict=VERDICT_OK,
+        prior=prior,
+        threshold=threshold,
+        reason="prior-at-or-above-threshold",
+    )
+
+
+__all__ = [
+    "DEFAULT_LOW_PRIOR_THRESHOLD",
+    "MIN_SECTIONED_SUPPORT",
+    "VERDICT_ABSTAIN",
+    "VERDICT_LOW_PRIOR",
+    "VERDICT_OK",
+    "GateResult",
+    "evaluate_label_section",
+    "load_priors",
+]

--- a/receipt_upload/receipt_upload/label_section_gate.py
+++ b/receipt_upload/receipt_upload/label_section_gate.py
@@ -40,7 +40,10 @@ DEFAULT_LOW_PRIOR_THRESHOLD = 0.05
 
 # ceil(ln(0.05) / ln(1 - 0.05)) = 59. This is the smallest sample size for
 # which a cell with a true rate equal to the threshold has less than a 5%
-# probability of producing zero observations.
+# probability of producing zero observations. Support is counted in DISTINCT
+# SECTIONED LINES (``sectioned_lines``), not word rows: all words on a line
+# share the same section assignment, so word rows are not independent trials
+# and counting them would overstate support (pseudo-replication).
 MIN_SECTIONED_SUPPORT = 59
 
 
@@ -91,6 +94,12 @@ def evaluate_label_section(
     min_support: int = MIN_SECTIONED_SUPPORT,
 ) -> GateResult:
     """Evaluate one label against the canonical sections assigned to a line."""
+    # NaN compares False everywhere, so an invalid threshold would silently
+    # pass every row as OK; fail loudly instead.
+    if not math.isfinite(threshold) or not 0.0 <= threshold <= 1.0:
+        raise ValueError(
+            f"threshold {threshold!r} must be a finite value in [0, 1]"
+        )
     canonical_sections = set(priors.get("sections", []))
     line_sections = {
         section_type
@@ -115,7 +124,8 @@ def evaluate_label_section(
         )
 
     entry = labels[label]
-    if int(entry.get("sectioned", 0)) < min_support:
+    support = int(entry.get("sectioned_lines", entry.get("sectioned", 0)))
+    if support < min_support:
         return GateResult(
             verdict=VERDICT_ABSTAIN,
             prior=None,

--- a/receipt_upload/tests/test_label_section_gate.py
+++ b/receipt_upload/tests/test_label_section_gate.py
@@ -228,6 +228,22 @@ def test_gate_result_carries_prior_and_threshold(
     assert result.threshold == pytest.approx(0.03)
 
 
+def test_malformed_prior_cell_raises(
+    synthetic_priors: dict[str, Any],
+) -> None:
+    """Fail loudly on NaN or out-of-range prior cells instead of passing OK."""
+    synthetic_priors["labels"]["PRODUCT_NAME"]["sections"]["ITEMS"]["p"] = (
+        float("nan")
+    )
+
+    with pytest.raises(ValueError, match="finite probability"):
+        evaluate_label_section(
+            "PRODUCT_NAME",
+            ["ITEMS"],
+            synthetic_priors,
+        )
+
+
 def test_packaged_prior_asset_has_loose_invariants() -> None:
     """Integration-lite: verify the packaged artifact is readable and sane."""
     artifact = load_priors()

--- a/receipt_upload/tests/test_label_section_gate.py
+++ b/receipt_upload/tests/test_label_section_gate.py
@@ -1,0 +1,242 @@
+"""Unit tests for the pure section-to-word-label compatibility gate."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from receipt_upload.label_section_gate import (
+    VERDICT_ABSTAIN,
+    VERDICT_LOW_PRIOR,
+    VERDICT_OK,
+    GateResult,
+    evaluate_label_section,
+    load_priors,
+)
+
+
+@pytest.fixture
+def synthetic_priors() -> dict[str, Any]:
+    """Return a compact synthetic prior artifact for deterministic tests."""
+    return {
+        "schema_version": 1,
+        "sections": [
+            "ADDRESS",
+            "ITEMS",
+            "PAYMENT",
+            "SUMMARY",
+            "TOTAL_LINE",
+            "TRANSACTION_INFO",
+        ],
+        "labels": {
+            "ADDRESS_LINE": {
+                "total": 100,
+                "sectioned": 90,
+                "unsectioned": 10,
+                "sections": {
+                    "ADDRESS": {"count": 83, "p": 0.923},
+                    "SUMMARY": {"count": 7, "p": 0.077},
+                },
+            },
+            "PRODUCT_NAME": {
+                "total": 100,
+                "sectioned": 100,
+                "unsectioned": 0,
+                "sections": {
+                    "ADDRESS": {"count": 2, "p": 0.02},
+                    "ITEMS": {"count": 98, "p": 0.98},
+                },
+            },
+            "DATE": {
+                "total": 100,
+                "sectioned": 58,
+                "unsectioned": 42,
+                "sections": {
+                    "TRANSACTION_INFO": {"count": 58, "p": 0.8},
+                },
+            },
+            "TAX": {
+                "total": 100,
+                "sectioned": 80,
+                "unsectioned": 20,
+                "sections": {
+                    "SUMMARY": {"count": 4, "p": 0.05},
+                },
+            },
+        },
+    }
+
+
+def test_high_prior_section_is_ok(
+    synthetic_priors: dict[str, Any],
+) -> None:
+    """Accept a label paired with its high-prior section."""
+    result = evaluate_label_section(
+        "ADDRESS_LINE",
+        ["ADDRESS"],
+        synthetic_priors,
+    )
+
+    assert result.verdict == VERDICT_OK
+    assert result.prior == pytest.approx(0.923)
+    assert result.reason == "prior-at-or-above-threshold"
+
+
+def test_absent_canonical_section_prior_is_low(
+    synthetic_priors: dict[str, Any],
+) -> None:
+    """Assign a zero prior when a canonical section cell is absent."""
+    result = evaluate_label_section(
+        "ADDRESS_LINE",
+        ["PAYMENT"],
+        synthetic_priors,
+    )
+
+    assert result.verdict == VERDICT_LOW_PRIOR
+    assert result.prior == 0.0
+    assert result.reason == "prior-below-threshold"
+
+
+@pytest.mark.parametrize(
+    "section_types",
+    [
+        None,
+        [],
+        ["HEADER"],
+    ],
+)
+def test_unsectioned_inputs_abstain(
+    synthetic_priors: dict[str, Any],
+    section_types: list[str] | None,
+) -> None:
+    """Abstain for missing, empty, or legacy-only line sections."""
+    result = evaluate_label_section(
+        "ADDRESS_LINE",
+        section_types,
+        synthetic_priors,
+    )
+
+    assert result.verdict == VERDICT_ABSTAIN
+    assert result.prior is None
+    assert result.reason == "unsectioned-line"
+
+
+def test_unknown_label_abstains(
+    synthetic_priors: dict[str, Any],
+) -> None:
+    """Abstain when the artifact does not contain the supplied label."""
+    result = evaluate_label_section(
+        "UNKNOWN_LABEL",
+        ["ADDRESS"],
+        synthetic_priors,
+    )
+
+    assert result.verdict == VERDICT_ABSTAIN
+    assert result.prior is None
+    assert result.reason == "unknown-label"
+
+
+def test_insufficient_support_abstains(
+    synthetic_priors: dict[str, Any],
+) -> None:
+    """Abstain when sectioned support is below the default floor of 59."""
+    result = evaluate_label_section(
+        "DATE",
+        ["TRANSACTION_INFO"],
+        synthetic_priors,
+    )
+
+    assert result.verdict == VERDICT_ABSTAIN
+    assert result.prior is None
+    assert result.reason == "insufficient-support"
+
+
+def test_multiple_sections_use_maximum_prior(
+    synthetic_priors: dict[str, Any],
+) -> None:
+    """Accept a multi-section line when any canonical section has high prior."""
+    result = evaluate_label_section(
+        "PRODUCT_NAME",
+        ["ADDRESS", "ITEMS"],
+        synthetic_priors,
+    )
+
+    assert result.verdict == VERDICT_OK
+    assert result.prior == pytest.approx(0.98)
+
+
+def test_prior_equal_to_threshold_is_ok(
+    synthetic_priors: dict[str, Any],
+) -> None:
+    """Accept a prior exactly equal to the threshold."""
+    result = evaluate_label_section(
+        "TAX",
+        ["SUMMARY"],
+        synthetic_priors,
+    )
+
+    assert result.verdict == VERDICT_OK
+    assert result.prior == pytest.approx(0.05)
+
+
+def test_custom_threshold_is_honored(
+    synthetic_priors: dict[str, Any],
+) -> None:
+    """Use a caller-supplied threshold instead of the default."""
+    result = evaluate_label_section(
+        "ADDRESS_LINE",
+        ["ADDRESS"],
+        synthetic_priors,
+        threshold=0.95,
+    )
+
+    assert result.verdict == VERDICT_LOW_PRIOR
+    assert result.threshold == pytest.approx(0.95)
+
+
+def test_custom_minimum_support_is_honored(
+    synthetic_priors: dict[str, Any],
+) -> None:
+    """Use a caller-supplied support floor instead of the default."""
+    result = evaluate_label_section(
+        "DATE",
+        ["TRANSACTION_INFO"],
+        synthetic_priors,
+        threshold=0.7,
+        min_support=1,
+    )
+
+    assert result.verdict == VERDICT_OK
+    assert result.prior == pytest.approx(0.8)
+
+
+def test_gate_result_carries_prior_and_threshold(
+    synthetic_priors: dict[str, Any],
+) -> None:
+    """Expose the evaluated prior and threshold in the immutable result."""
+    result = evaluate_label_section(
+        "PRODUCT_NAME",
+        ["ADDRESS"],
+        synthetic_priors,
+        threshold=0.03,
+    )
+
+    assert isinstance(result, GateResult)
+    assert result.verdict == VERDICT_LOW_PRIOR
+    assert result.prior == pytest.approx(0.02)
+    assert result.threshold == pytest.approx(0.03)
+
+
+def test_packaged_prior_asset_has_loose_invariants() -> None:
+    """Integration-lite: verify the packaged artifact is readable and sane."""
+    artifact = load_priors()
+
+    assert isinstance(artifact, dict)
+    assert "labels" in artifact
+    address_line = artifact["labels"]["ADDRESS_LINE"]
+    assert address_line["sections"]["ADDRESS"]["p"] > 0.5
+
+    for entry in artifact["labels"].values():
+        for section in entry.get("sections", {}).values():
+            assert 0.0 <= section["p"] <= 1.0

--- a/receipt_upload/tests/test_label_section_gate.py
+++ b/receipt_upload/tests/test_label_section_gate.py
@@ -33,6 +33,7 @@ def synthetic_priors() -> dict[str, Any]:
             "ADDRESS_LINE": {
                 "total": 100,
                 "sectioned": 90,
+                "sectioned_lines": 80,
                 "unsectioned": 10,
                 "sections": {
                     "ADDRESS": {"count": 83, "p": 0.923},
@@ -42,6 +43,7 @@ def synthetic_priors() -> dict[str, Any]:
             "PRODUCT_NAME": {
                 "total": 100,
                 "sectioned": 100,
+                "sectioned_lines": 95,
                 "unsectioned": 0,
                 "sections": {
                     "ADDRESS": {"count": 2, "p": 0.02},
@@ -51,6 +53,7 @@ def synthetic_priors() -> dict[str, Any]:
             "DATE": {
                 "total": 100,
                 "sectioned": 58,
+                "sectioned_lines": 58,
                 "unsectioned": 42,
                 "sections": {
                     "TRANSACTION_INFO": {"count": 58, "p": 0.8},
@@ -59,6 +62,7 @@ def synthetic_priors() -> dict[str, Any]:
             "TAX": {
                 "total": 100,
                 "sectioned": 80,
+                "sectioned_lines": 75,
                 "unsectioned": 20,
                 "sections": {
                     "SUMMARY": {"count": 4, "p": 0.05},
@@ -226,6 +230,38 @@ def test_gate_result_carries_prior_and_threshold(
     assert result.verdict == VERDICT_LOW_PRIOR
     assert result.prior == pytest.approx(0.02)
     assert result.threshold == pytest.approx(0.03)
+
+
+def test_support_floor_uses_distinct_lines(
+    synthetic_priors: dict[str, Any],
+) -> None:
+    """Abstain when line-level support is thin despite many word rows."""
+    entry = synthetic_priors["labels"]["PRODUCT_NAME"]
+    entry["sectioned"] = 200
+    entry["sectioned_lines"] = 10
+
+    result = evaluate_label_section(
+        "PRODUCT_NAME",
+        ["ITEMS"],
+        synthetic_priors,
+    )
+
+    assert result.verdict == VERDICT_ABSTAIN
+    assert result.reason == "insufficient-support"
+
+
+def test_invalid_threshold_raises(
+    synthetic_priors: dict[str, Any],
+) -> None:
+    """Reject NaN and out-of-range thresholds instead of passing rows OK."""
+    for bad in (float("nan"), -0.1, 1.5):
+        with pytest.raises(ValueError, match="threshold"):
+            evaluate_label_section(
+                "ADDRESS_LINE",
+                ["ADDRESS"],
+                synthetic_priors,
+                threshold=bad,
+            )
 
 
 def test_malformed_prior_cell_raises(

--- a/scripts/build_section_label_priors.py
+++ b/scripts/build_section_label_priors.py
@@ -221,14 +221,18 @@ def _build_model(
     }
     observations: list[list[Any]] = []
     receipts_with_valid_labels: set[tuple[str, int]] = set()
+    valid_label_row_count = 0
     core_label_row_count = 0
     sectioned_core_label_row_count = 0
 
     for item in label_items:
+        # The GSI3 VALID partition may hold other entity types; only items
+        # whose sort key parses as a word-label row are counted at all.
         identity = _label_identity(item)
         if identity is None:
             continue
 
+        valid_label_row_count += 1
         image_id, receipt_id, line_id, word_id, label = identity
         receipts_with_valid_labels.add((image_id, receipt_id))
         if label not in CORE_LABELS:
@@ -296,7 +300,7 @@ def _build_model(
         "section_row_count": len(section_items),
         "valid_section_row_count": valid_section_row_count,
         "legacy_valid_section_rows_excluded": (legacy_valid_section_rows_excluded),
-        "valid_label_row_count": len(label_items),
+        "valid_label_row_count": valid_label_row_count,
         "core_label_row_count": core_label_row_count,
         "sectioned_core_label_row_count": sectioned_core_label_row_count,
         "receipts_with_valid_labels": len(receipts_with_valid_labels),

--- a/scripts/build_section_label_priors.py
+++ b/scripts/build_section_label_priors.py
@@ -213,6 +213,7 @@ def _build_model(
     tallies: dict[str, dict[str, Any]] = {
         label: {
             "sectioned": 0,
+            "sectioned_line_keys": set(),
             "section_pairs": Counter(),
             "total": 0,
             "unsectioned": 0,
@@ -246,6 +247,7 @@ def _build_model(
 
         if line_sections:
             label_tally["sectioned"] += 1
+            label_tally["sectioned_line_keys"].add(line_key)
             sectioned_core_label_row_count += 1
             for section_type in sorted(line_sections):
                 label_tally["section_pairs"][section_type] += 1
@@ -278,17 +280,22 @@ def _build_model(
     for label in sorted(CORE_LABELS):
         tally = tallies[label]
         section_pairs: Counter[str] = tally["section_pairs"]
-        pair_total = sum(section_pairs.values())
+        sectioned_rows = tally["sectioned"]
+        # p is the co-occurrence rate per sectioned row (count / sectioned),
+        # matching the gate's max-over-sections decision rule. On lines with
+        # more than one section a row contributes to several cells, so the
+        # cells can sum above 1.0 — they are rates, not a partition.
         section_probabilities = {
             section_type: {
                 "count": count,
-                "p": round(count / pair_total, 6),
+                "p": round(count / sectioned_rows, 6),
             }
             for section_type, count in sorted(section_pairs.items())
         }
         labels[label] = {
             "total": tally["total"],
             "sectioned": tally["sectioned"],
+            "sectioned_lines": len(tally["sectioned_line_keys"]),
             "unsectioned": tally["unsectioned"],
             "sections": section_probabilities,
         }
@@ -315,8 +322,9 @@ def _build_model(
         "model_source": "section-label-prior-v1",
         "source_environment": "dev",
         "denominator": (
-            "pairs of (VALID core-label row, VALID canonical section on the "
-            "row's line); p = count / label pair total"
+            "p = section pair count / label's sectioned row count "
+            "(co-occurrence rate per sectioned row; cells on multi-section "
+            "lines can sum above 1.0)"
         ),
         "sections": canonical_sections,
         "source": source,

--- a/scripts/build_section_label_priors.py
+++ b/scripts/build_section_label_priors.py
@@ -151,8 +151,8 @@ def _line_ids(item: dict[str, Any]) -> set[int]:
 
 def _label_identity(
     item: dict[str, Any],
-) -> Optional[tuple[str, int, int, str]]:
-    """Parse image, receipt, line, and label from a GSI3 sort key."""
+) -> Optional[tuple[str, int, int, int, str]]:
+    """Parse image, receipt, line, word, and label from a GSI3 sort key."""
     sort_key = _string_attribute(item, "GSI3SK")
     match = _LABEL_SK_RE.match(sort_key)
     if match is None:
@@ -161,6 +161,7 @@ def _label_identity(
         match.group("image"),
         int(match.group("receipt")),
         int(match.group("line")),
+        int(match.group("word")),
         match.group("label"),
     )
 
@@ -228,7 +229,7 @@ def _build_model(
         if identity is None:
             continue
 
-        image_id, receipt_id, line_id, label = identity
+        image_id, receipt_id, line_id, word_id, label = identity
         receipts_with_valid_labels.add((image_id, receipt_id))
         if label not in CORE_LABELS:
             continue
@@ -249,6 +250,7 @@ def _build_model(
                         image_id,
                         receipt_id,
                         line_id,
+                        word_id,
                         label,
                         section_type,
                     ]
@@ -262,6 +264,7 @@ def _build_model(
                     image_id,
                     receipt_id,
                     line_id,
+                    word_id,
                     label,
                     "<line-unsectioned>",
                 ]

--- a/scripts/build_section_label_priors.py
+++ b/scripts/build_section_label_priors.py
@@ -1,0 +1,362 @@
+#!/usr/bin/env python3
+"""Build deterministic section-to-word-label priors from QA-valid dev data.
+
+This command is read-only. The DynamoDB table must be supplied through
+``DYNAMODB_TABLE_NAME`` and the environment must explicitly be ``dev``.
+
+The measured 2026-07-18 dev corpus contained 5,768 section rows, including
+5,751 VALID rows, and 29,015 VALID word-label rows. Of 813 receipts with
+VALID labels, 794 also had VALID sections (98%).
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any, Optional
+
+import boto3
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT / "receipt_dynamo"))
+
+# pylint: disable=wrong-import-position
+from receipt_dynamo.constants import CORE_LABELS, SectionType  # isort: skip
+
+# pylint: enable=wrong-import-position
+
+DEV_TABLE = "ReceiptsTable-dc5be22"
+PROD_TABLE = "ReceiptsTable-d7ff76a"
+AWS_REGION = "us-east-1"
+
+_DEFAULT_OUTPUT = (
+    _REPO_ROOT
+    / "receipt_upload"
+    / "receipt_upload"
+    / "assets"
+    / "section_label_priors_v1.json"
+)
+
+_LEGACY_SECTION_TYPES = {
+    "HEADER",
+    "ITEMS_DESCRIPTION",
+    "ITEMS_VALUE",
+}
+_SECTION_SK_RE = re.compile(r"^RECEIPT#(?P<receipt>\d+)#SECTION#")
+_LABEL_SK_RE = re.compile(
+    r"^IMAGE#(?P<image>.+?)"
+    r"#RECEIPT#(?P<receipt>\d+)"
+    r"#LINE#(?P<line>\d+)"
+    r"#WORD#(?P<word>\d+)"
+    r"#LABEL#(?P<label>.+)$"
+)
+
+
+def _arguments() -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(
+        description=("Build deterministic section-to-word-label priors from dev data.")
+    )
+    parser.add_argument(
+        "--environment",
+        default=os.environ.get("DEPLOYMENT_ENVIRONMENT"),
+        help="Deployment environment; must be dev.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=_DEFAULT_OUTPUT,
+        help="Destination JSON artifact.",
+    )
+    return parser.parse_args()
+
+
+def _query_all(
+    client: Any,
+    table_name: str,
+    index: str,
+    pk_attr: str,
+    pk_value: str,
+    projection: str,
+    names: Optional[dict[str, str]] = None,
+) -> list[dict[str, Any]]:
+    """Query every page for one exact GSI partition-key value."""
+    items: list[dict[str, Any]] = []
+    kwargs: dict[str, Any] = {
+        "TableName": table_name,
+        "IndexName": index,
+        "KeyConditionExpression": f"{pk_attr} = :p",
+        "ExpressionAttributeValues": {":p": {"S": pk_value}},
+        "ProjectionExpression": projection,
+    }
+    if names:
+        kwargs["ExpressionAttributeNames"] = names
+
+    while True:
+        response = client.query(**kwargs)
+        items.extend(response.get("Items", []))
+        if not response.get("LastEvaluatedKey"):
+            return items
+        kwargs["ExclusiveStartKey"] = response["LastEvaluatedKey"]
+
+
+def _string_attribute(item: dict[str, Any], name: str) -> str:
+    """Return a DynamoDB string attribute or an empty string."""
+    value = item.get(name, {}).get("S")
+    return value if isinstance(value, str) else ""
+
+
+def _canonical_sections() -> list[str]:
+    """Return sorted canonical section values from the shared enum."""
+    return sorted(
+        {
+            str(member.value)
+            for member in SectionType
+            if str(member.value) not in _LEGACY_SECTION_TYPES
+        }
+    )
+
+
+def _section_identity(
+    item: dict[str, Any],
+) -> Optional[tuple[str, int]]:
+    """Parse an image and receipt identity from a section item."""
+    partition_key = _string_attribute(item, "PK")
+    sort_key = _string_attribute(item, "SK")
+    match = _SECTION_SK_RE.match(sort_key)
+    if not partition_key.startswith("IMAGE#") or match is None:
+        return None
+    return partition_key.removeprefix("IMAGE#"), int(match.group("receipt"))
+
+
+def _line_ids(item: dict[str, Any]) -> set[int]:
+    """Parse numeric or string line IDs from a DynamoDB list attribute."""
+    output: set[int] = set()
+    for value in item.get("line_ids", {}).get("L", []):
+        raw_line_id = value.get("S") or value.get("N")
+        if raw_line_id is None:
+            continue
+        try:
+            output.add(int(raw_line_id))
+        except (TypeError, ValueError):
+            continue
+    return output
+
+
+def _label_identity(
+    item: dict[str, Any],
+) -> Optional[tuple[str, int, int, str]]:
+    """Parse image, receipt, line, and label from a GSI3 sort key."""
+    sort_key = _string_attribute(item, "GSI3SK")
+    match = _LABEL_SK_RE.match(sort_key)
+    if match is None:
+        return None
+    return (
+        match.group("image"),
+        int(match.group("receipt")),
+        int(match.group("line")),
+        match.group("label"),
+    )
+
+
+def _snapshot_sha256(observations: list[list[Any]]) -> str:
+    """Hash sorted observations using the deterministic corpus encoding."""
+    payload = json.dumps(
+        sorted(observations),
+        separators=(",", ":"),
+    ).encode()
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _build_model(
+    section_items: list[dict[str, Any]],
+    label_items: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Build the deterministic prior artifact from raw DynamoDB items."""
+    canonical_sections = _canonical_sections()
+    canonical_section_set = set(canonical_sections)
+
+    valid_section_row_count = 0
+    legacy_valid_section_rows_excluded = 0
+    sections_by_line: dict[tuple[str, int, int], set[str]] = {}
+    receipts_with_valid_sections: set[tuple[str, int]] = set()
+
+    for item in section_items:
+        if _string_attribute(item, "validation_status").upper() != "VALID":
+            continue
+
+        valid_section_row_count += 1
+        section_type = _string_attribute(item, "section_type")
+        if section_type in _LEGACY_SECTION_TYPES:
+            legacy_valid_section_rows_excluded += 1
+            continue
+        if section_type not in canonical_section_set:
+            continue
+
+        identity = _section_identity(item)
+        if identity is None:
+            continue
+
+        image_id, receipt_id = identity
+        receipts_with_valid_sections.add((image_id, receipt_id))
+        for line_id in _line_ids(item):
+            line_key = (image_id, receipt_id, line_id)
+            sections_by_line.setdefault(line_key, set()).add(section_type)
+
+    tallies: dict[str, dict[str, Any]] = {
+        label: {
+            "sectioned": 0,
+            "section_pairs": Counter(),
+            "total": 0,
+            "unsectioned": 0,
+        }
+        for label in CORE_LABELS
+    }
+    observations: list[list[Any]] = []
+    receipts_with_valid_labels: set[tuple[str, int]] = set()
+    core_label_row_count = 0
+    sectioned_core_label_row_count = 0
+
+    for item in label_items:
+        identity = _label_identity(item)
+        if identity is None:
+            continue
+
+        image_id, receipt_id, line_id, label = identity
+        receipts_with_valid_labels.add((image_id, receipt_id))
+        if label not in CORE_LABELS:
+            continue
+
+        core_label_row_count += 1
+        label_tally = tallies[label]
+        label_tally["total"] += 1
+        line_key = (image_id, receipt_id, line_id)
+        line_sections = sections_by_line.get(line_key, set())
+
+        if line_sections:
+            label_tally["sectioned"] += 1
+            sectioned_core_label_row_count += 1
+            for section_type in sorted(line_sections):
+                label_tally["section_pairs"][section_type] += 1
+                observations.append(
+                    [
+                        image_id,
+                        receipt_id,
+                        line_id,
+                        label,
+                        section_type,
+                    ]
+                )
+        else:
+            # Every core label row lands in the hashed corpus, sectioned or
+            # not, so any change to the artifact's inputs changes the hash.
+            label_tally["unsectioned"] += 1
+            observations.append(
+                [
+                    image_id,
+                    receipt_id,
+                    line_id,
+                    label,
+                    "<line-unsectioned>",
+                ]
+            )
+
+    labels: dict[str, Any] = {}
+    for label in sorted(CORE_LABELS):
+        tally = tallies[label]
+        section_pairs: Counter[str] = tally["section_pairs"]
+        pair_total = sum(section_pairs.values())
+        section_probabilities = {
+            section_type: {
+                "count": count,
+                "p": round(count / pair_total, 6),
+            }
+            for section_type, count in sorted(section_pairs.items())
+        }
+        labels[label] = {
+            "total": tally["total"],
+            "sectioned": tally["sectioned"],
+            "unsectioned": tally["unsectioned"],
+            "sections": section_probabilities,
+        }
+
+    receipts_with_sections_and_labels = (
+        receipts_with_valid_sections & receipts_with_valid_labels
+    )
+    source = {
+        "section_row_count": len(section_items),
+        "valid_section_row_count": valid_section_row_count,
+        "legacy_valid_section_rows_excluded": (legacy_valid_section_rows_excluded),
+        "valid_label_row_count": len(label_items),
+        "core_label_row_count": core_label_row_count,
+        "sectioned_core_label_row_count": sectioned_core_label_row_count,
+        "receipts_with_valid_labels": len(receipts_with_valid_labels),
+        "receipts_with_valid_sections_and_labels": len(
+            receipts_with_sections_and_labels
+        ),
+        "corpus_sha256": _snapshot_sha256(observations),
+    }
+
+    return {
+        "schema_version": 1,
+        "model_source": "section-label-prior-v1",
+        "source_environment": "dev",
+        "denominator": (
+            "pairs of (VALID core-label row, VALID canonical section on the "
+            "row's line); p = count / label pair total"
+        ),
+        "sections": canonical_sections,
+        "source": source,
+        "labels": labels,
+    }
+
+
+def main() -> int:
+    """Validate the dev guard, read DynamoDB, and write the prior artifact."""
+    args = _arguments()
+    table_name = os.environ.get("DYNAMODB_TABLE_NAME")
+    if args.environment != "dev":
+        raise SystemExit("Refusing to read anything except the dev environment")
+    if table_name != DEV_TABLE or table_name == PROD_TABLE:
+        raise SystemExit(
+            f"Refusing table {table_name!r}; expected exact dev table " f"{DEV_TABLE!r}"
+        )
+
+    client = boto3.client("dynamodb", region_name=AWS_REGION)
+    section_items = _query_all(
+        client,
+        table_name,
+        "GSITYPE",
+        "#T",
+        "RECEIPT_SECTION",
+        "PK, SK, section_type, line_ids, validation_status",
+        {"#T": "TYPE"},
+    )
+    label_items = _query_all(
+        client,
+        table_name,
+        "GSI3",
+        "GSI3PK",
+        "VALIDATION_STATUS#VALID",
+        "GSI3SK",
+    )
+
+    model = _build_model(section_items, label_items)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(
+        json.dumps(model, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+    print(json.dumps(model["source"], indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/section_label_review_queue.py
+++ b/scripts/section_label_review_queue.py
@@ -470,7 +470,13 @@ def main() -> int:
 
     priors_bytes = args.priors.read_bytes()
     priors_sha256 = hashlib.sha256(priors_bytes).hexdigest()
-    priors = gate.load_priors(args.priors)
+    # Parse the exact bytes just hashed so priors_sha256 always describes
+    # the priors actually evaluated, even if the file is replaced meanwhile.
+    priors = json.loads(priors_bytes)
+    if priors.get("source_environment") != "dev":
+        raise SystemExit(
+            "Refusing priors artifact whose source_environment is not 'dev'"
+        )
 
     client = boto3.client("dynamodb", region_name=AWS_REGION)
     section_items = _query_all(

--- a/scripts/section_label_review_queue.py
+++ b/scripts/section_label_review_queue.py
@@ -1,0 +1,532 @@
+#!/usr/bin/env python3
+"""Generate a read-only low-prior review queue from current VALID dev labels.
+
+This command is read-only. The DynamoDB table must be supplied through
+``DYNAMODB_TABLE_NAME`` and the environment must explicitly be ``dev``.
+
+At the selected 0.05 threshold, the 2026-07-18 validation study flagged
+26.3% of known-bad sectioned labels versus 6.3% of currently VALID core
+labels, a 4.2x enrichment. Outputs reflect mutable dev state and are intended
+for local review rather than source control.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import json
+import math
+import os
+import re
+import sys
+import time
+from collections import Counter
+from pathlib import Path
+from types import ModuleType
+from typing import Any, Iterator, Optional
+
+import boto3
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT / "receipt_dynamo"))
+
+# pylint: disable=wrong-import-position
+from receipt_dynamo.constants import CORE_LABELS  # isort: skip
+
+# pylint: enable=wrong-import-position
+
+DEV_TABLE = "ReceiptsTable-dc5be22"
+PROD_TABLE = "ReceiptsTable-d7ff76a"
+AWS_REGION = "us-east-1"
+_MAX_BATCH_RETRIES = 8
+
+_GATE_PATH = _REPO_ROOT / "receipt_upload" / "receipt_upload" / "label_section_gate.py"
+_DEFAULT_PRIORS = (
+    _REPO_ROOT
+    / "receipt_upload"
+    / "receipt_upload"
+    / "assets"
+    / "section_label_priors_v1.json"
+)
+_LEGACY_SECTION_TYPES = {
+    "HEADER",
+    "ITEMS_DESCRIPTION",
+    "ITEMS_VALUE",
+}
+_SECTION_SK_RE = re.compile(r"^RECEIPT#(?P<receipt>\d+)#SECTION#")
+_LABEL_SK_RE = re.compile(
+    r"^IMAGE#(?P<image>.+?)"
+    r"#RECEIPT#(?P<receipt>\d+)"
+    r"#LINE#(?P<line>\d+)"
+    r"#WORD#(?P<word>\d+)"
+    r"#LABEL#(?P<label>.+)$"
+)
+
+
+def _load_gate_module() -> ModuleType:
+    """Load the leaf gate module without importing receipt_upload itself."""
+    # receipt_upload.__init__ pulls numpy and Pillow. Loading this dependency
+    # leaf directly keeps the review script's runtime to stdlib plus boto3.
+    module_name = "_receipt_upload_label_section_gate"
+    spec = importlib.util.spec_from_file_location(module_name, _GATE_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load gate module from {_GATE_PATH}")
+
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _arguments(gate: ModuleType) -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Generate a read-only low-prior VALID-label review queue."
+    )
+    parser.add_argument(
+        "--environment",
+        default=os.environ.get("DEPLOYMENT_ENVIRONMENT"),
+        help="Deployment environment; must be dev.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path.cwd() / "section_label_review_queue_out",
+        help="Directory receiving the JSON and Markdown review queues.",
+    )
+    parser.add_argument(
+        "--threshold",
+        type=float,
+        default=gate.DEFAULT_LOW_PRIOR_THRESHOLD,
+        help="Prior values strictly below this threshold are queued.",
+    )
+    parser.add_argument(
+        "--priors",
+        type=Path,
+        default=_DEFAULT_PRIORS,
+        help="Section-label prior artifact.",
+    )
+    return parser.parse_args()
+
+
+def _query_all(
+    client: Any,
+    table_name: str,
+    index: str,
+    pk_attr: str,
+    pk_value: str,
+    projection: str,
+    names: Optional[dict[str, str]] = None,
+) -> list[dict[str, Any]]:
+    """Query every page for one exact GSI partition-key value."""
+    items: list[dict[str, Any]] = []
+    kwargs: dict[str, Any] = {
+        "TableName": table_name,
+        "IndexName": index,
+        "KeyConditionExpression": f"{pk_attr} = :p",
+        "ExpressionAttributeValues": {":p": {"S": pk_value}},
+        "ProjectionExpression": projection,
+    }
+    if names:
+        kwargs["ExpressionAttributeNames"] = names
+
+    while True:
+        response = client.query(**kwargs)
+        items.extend(response.get("Items", []))
+        if not response.get("LastEvaluatedKey"):
+            return items
+        kwargs["ExclusiveStartKey"] = response["LastEvaluatedKey"]
+
+
+def _string_attribute(item: dict[str, Any], name: str) -> str:
+    """Return a DynamoDB string attribute or an empty string."""
+    value = item.get(name, {}).get("S")
+    return value if isinstance(value, str) else ""
+
+
+def _optional_string_attribute(
+    item: dict[str, Any],
+    name: str,
+) -> Optional[str]:
+    """Return an optional DynamoDB string attribute."""
+    value = item.get(name, {}).get("S")
+    return value if isinstance(value, str) else None
+
+
+def _line_ids(item: dict[str, Any]) -> set[int]:
+    """Parse numeric or string line IDs from a DynamoDB list attribute."""
+    output: set[int] = set()
+    for value in item.get("line_ids", {}).get("L", []):
+        raw_line_id = value.get("S") or value.get("N")
+        if raw_line_id is None:
+            continue
+        try:
+            output.add(int(raw_line_id))
+        except (TypeError, ValueError):
+            continue
+    return output
+
+
+def _section_identity(
+    item: dict[str, Any],
+) -> Optional[tuple[str, int]]:
+    """Parse an image and receipt identity from a section item."""
+    partition_key = _string_attribute(item, "PK")
+    sort_key = _string_attribute(item, "SK")
+    match = _SECTION_SK_RE.match(sort_key)
+    if not partition_key.startswith("IMAGE#") or match is None:
+        return None
+    return partition_key.removeprefix("IMAGE#"), int(match.group("receipt"))
+
+
+def _label_identity(
+    item: dict[str, Any],
+) -> Optional[tuple[str, int, int, int, str]]:
+    """Parse word-label coordinates and label from a GSI3 sort key."""
+    sort_key = _string_attribute(item, "GSI3SK")
+    match = _LABEL_SK_RE.match(sort_key)
+    if match is None:
+        return None
+    return (
+        match.group("image"),
+        int(match.group("receipt")),
+        int(match.group("line")),
+        int(match.group("word")),
+        match.group("label"),
+    )
+
+
+def _build_section_map(
+    section_items: list[dict[str, Any]],
+    canonical_sections: set[str],
+) -> dict[tuple[str, int, int], set[str]]:
+    """Map each line to its set of VALID canonical section types."""
+    sections_by_line: dict[tuple[str, int, int], set[str]] = {}
+
+    for item in section_items:
+        if _string_attribute(item, "validation_status").upper() != "VALID":
+            continue
+
+        section_type = _string_attribute(item, "section_type")
+        if section_type in _LEGACY_SECTION_TYPES:
+            continue
+        if section_type not in canonical_sections:
+            continue
+
+        identity = _section_identity(item)
+        if identity is None:
+            continue
+
+        image_id, receipt_id = identity
+        for line_id in _line_ids(item):
+            line_key = (image_id, receipt_id, line_id)
+            sections_by_line.setdefault(line_key, set()).add(section_type)
+
+    return sections_by_line
+
+
+def _word_key(row: dict[str, Any]) -> tuple[str, str]:
+    """Return the base-table partition and sort keys for a queued word."""
+    partition_key = f"IMAGE#{row['image_id']}"
+    sort_key = (
+        f"RECEIPT#{row['receipt_id']:05d}"
+        f"#LINE#{row['line_id']:05d}"
+        f"#WORD#{row['word_id']:05d}"
+    )
+    return partition_key, sort_key
+
+
+def _chunks(
+    values: list[tuple[str, str]],
+    size: int,
+) -> Iterator[list[tuple[str, str]]]:
+    """Yield fixed-size slices of key tuples."""
+    for start in range(0, len(values), size):
+        yield values[start : start + size]
+
+
+def _fetch_word_texts(
+    client: Any,
+    table_name: str,
+    rows: list[dict[str, Any]],
+) -> dict[tuple[str, str], str]:
+    """Batch-fetch word text, retrying all DynamoDB unprocessed keys."""
+    unique_keys = sorted({_word_key(row) for row in rows})
+    output: dict[tuple[str, str], str] = {}
+
+    for key_chunk in _chunks(unique_keys, 100):
+        keys = [
+            {
+                "PK": {"S": partition_key},
+                "SK": {"S": sort_key},
+            }
+            for partition_key, sort_key in key_chunk
+        ]
+        pending: dict[str, Any] = {
+            table_name: {
+                "Keys": keys,
+                "ProjectionExpression": "PK, SK, #t",
+                "ExpressionAttributeNames": {"#t": "text"},
+            }
+        }
+
+        attempts = 0
+        while pending:
+            response = client.batch_get_item(RequestItems=pending)
+            for item in response.get("Responses", {}).get(table_name, []):
+                partition_key = _string_attribute(item, "PK")
+                sort_key = _string_attribute(item, "SK")
+                text = _string_attribute(item, "text")
+                output[(partition_key, sort_key)] = text
+            pending = response.get("UnprocessedKeys", {})
+            if not pending:
+                break
+            attempts += 1
+            if attempts > _MAX_BATCH_RETRIES:
+                remaining = len(pending.get(table_name, {}).get("Keys", []))
+                raise SystemExit(
+                    f"BatchGetItem left {remaining} unprocessed keys after "
+                    f"{_MAX_BATCH_RETRIES} retries"
+                )
+            time.sleep(min(2.0, 0.1 * (2**attempts)))
+
+    return output
+
+
+def _queue_rows(
+    label_items: list[dict[str, Any]],
+    sections_by_line: dict[tuple[str, int, int], set[str]],
+    priors: dict[str, Any],
+    gate: ModuleType,
+    threshold: float,
+) -> list[dict[str, Any]]:
+    """Evaluate VALID core labels and retain low-prior rows."""
+    rows: list[dict[str, Any]] = []
+
+    for item in label_items:
+        identity = _label_identity(item)
+        if identity is None:
+            continue
+
+        image_id, receipt_id, line_id, word_id, label = identity
+        if label not in CORE_LABELS:
+            continue
+
+        line_sections = sorted(
+            sections_by_line.get((image_id, receipt_id, line_id), set())
+        )
+        result = gate.evaluate_label_section(
+            label,
+            line_sections,
+            priors,
+            threshold=threshold,
+        )
+        if result.verdict != gate.VERDICT_LOW_PRIOR:
+            continue
+
+        rows.append(
+            {
+                "image_id": image_id,
+                "receipt_id": receipt_id,
+                "line_id": line_id,
+                "word_id": word_id,
+                "label": label,
+                "word_text": None,
+                "line_sections": line_sections,
+                "prior": result.prior,
+                "label_proposed_by": _optional_string_attribute(
+                    item,
+                    "label_proposed_by",
+                ),
+            }
+        )
+
+    rows.sort(
+        key=lambda row: (
+            row["label"],
+            row["image_id"],
+            row["receipt_id"],
+            row["line_id"],
+            row["word_id"],
+        )
+    )
+    return rows
+
+
+def _markdown_text(value: Optional[str]) -> str:
+    """Normalize, truncate, and escape word text for a Markdown table."""
+    normalized = " ".join((value or "").split())[:40]
+    escaped = (
+        normalized.replace("\\", "\\\\")
+        .replace("|", r"\|")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+    )
+    return escaped
+
+
+def _markdown_report(
+    threshold: float,
+    rows: list[dict[str, Any]],
+    by_label: dict[str, int],
+) -> str:
+    """Render the review queue as deterministic Markdown."""
+    ordered_counts = sorted(
+        by_label.items(),
+        key=lambda item: (-item[1], item[0]),
+    )
+    lines = [
+        "# Section-label review queue",
+        "",
+        f"- Threshold: `{threshold}`",
+        f"- Total rows: `{len(rows)}`",
+        "",
+        "## Counts by label",
+        "",
+        "| Label | Count |",
+        "| --- | ---: |",
+    ]
+    for label, count in ordered_counts:
+        lines.append(f"| {label} | {count} |")
+
+    for label, _count in ordered_counts:
+        lines.extend(
+            [
+                "",
+                f"## {label}",
+                "",
+                ("| image_id | receipt | line | word | text | sections | " "prior |"),
+                "| --- | ---: | ---: | ---: | --- | --- | ---: |",
+            ]
+        )
+        for row in rows:
+            if row["label"] != label:
+                continue
+            sections = ", ".join(row["line_sections"])
+            prior = float(row["prior"])
+            lines.append(
+                f"| {row['image_id']} "
+                f"| {row['receipt_id']} "
+                f"| {row['line_id']} "
+                f"| {row['word_id']} "
+                f"| {_markdown_text(row['word_text'])} "
+                f"| {sections} "
+                f"| {prior:.6f} |"
+            )
+
+    return "\n".join(lines) + "\n"
+
+
+def _write_outputs(
+    output_dir: Path,
+    threshold: float,
+    priors_sha256: str,
+    rows: list[dict[str, Any]],
+) -> dict[str, int]:
+    """Write deterministic JSON and Markdown queue files."""
+    counts = Counter(row["label"] for row in rows)
+    by_label = dict(sorted(counts.items()))
+    payload = {
+        "threshold": threshold,
+        "priors_sha256": priors_sha256,
+        "row_count": len(rows),
+        "by_label": by_label,
+        "rows": rows,
+    }
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    json_path = output_dir / "section_label_review_queue.json"
+    markdown_path = output_dir / "section_label_review_queue.md"
+    json_path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+    markdown_path.write_text(
+        _markdown_report(threshold, rows, by_label),
+        encoding="utf-8",
+        newline="\n",
+    )
+    return by_label
+
+
+def main() -> int:
+    """Validate the dev guard and generate the read-only review queue."""
+    gate = _load_gate_module()
+    args = _arguments(gate)
+    if not math.isfinite(args.threshold) or not 0.0 <= args.threshold <= 1.0:
+        raise SystemExit(
+            f"Refusing threshold {args.threshold!r}; must be finite and "
+            "within [0, 1]"
+        )
+    table_name = os.environ.get("DYNAMODB_TABLE_NAME")
+    if args.environment != "dev":
+        raise SystemExit("Refusing to read anything except the dev environment")
+    if table_name != DEV_TABLE or table_name == PROD_TABLE:
+        raise SystemExit(
+            f"Refusing table {table_name!r}; expected exact dev table " f"{DEV_TABLE!r}"
+        )
+
+    priors_bytes = args.priors.read_bytes()
+    priors_sha256 = hashlib.sha256(priors_bytes).hexdigest()
+    priors = gate.load_priors(args.priors)
+
+    client = boto3.client("dynamodb", region_name=AWS_REGION)
+    section_items = _query_all(
+        client,
+        table_name,
+        "GSITYPE",
+        "#T",
+        "RECEIPT_SECTION",
+        "PK, SK, section_type, line_ids, validation_status",
+        {"#T": "TYPE"},
+    )
+    label_items = _query_all(
+        client,
+        table_name,
+        "GSI3",
+        "GSI3PK",
+        "VALIDATION_STATUS#VALID",
+        "GSI3SK, label_proposed_by",
+    )
+
+    canonical_sections = set(priors.get("sections", []))
+    sections_by_line = _build_section_map(
+        section_items,
+        canonical_sections,
+    )
+    rows = _queue_rows(
+        label_items,
+        sections_by_line,
+        priors,
+        gate,
+        args.threshold,
+    )
+
+    word_texts = _fetch_word_texts(client, table_name, rows)
+    for row in rows:
+        row["word_text"] = word_texts.get(_word_key(row))
+
+    by_label = _write_outputs(
+        args.output_dir,
+        args.threshold,
+        priors_sha256,
+        rows,
+    )
+
+    print(f"Low-prior rows: {len(rows)}")
+    for label, count in sorted(
+        by_label.items(),
+        key=lambda item: (-item[1], item[0]),
+    )[:8]:
+        print(f"{label}: {count}")
+    print(
+        "Reminder: these outputs depend on current dev state and must NOT be "
+        "committed."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
# Section→label compatibility prior: deterministic artifact + gate + review queue

## The idea

Line-scoped `RECEIPT_SECTION` rows carry strong signal about which word labels are
plausible on a line, but nothing in the codebase links the two namespaces. This PR
creates the first linkage: an empirical `P(section_type | label)` prior built from
VALID word labels joined (by line membership) to VALID sections, a pure gate library
that scores a `(label, line-sections)` pair as `OK | LOW_PRIOR | ABSTAIN`, and a
read-only review-queue generator for currently-VALID low-prior labels.

**Nothing is wired into any write path.** Library + deterministic artifact +
evidence only. No labels were written, modified, or deleted; all scripts are
read-only against dev (`ReceiptsTable-dc5be22`) and hard-refuse any other table.

## Measured evidence (re-derived 2026-07-18 against dev, read-only)

Corpus: 5,768 `RECEIPT_SECTION` rows (5,751 VALID / 17 INVALID); 29,015 VALID
word-label rows; 794 of 813 receipts with VALID labels also have VALID sections (98%).

The prior is sharp (sectioned-only denominator):

| Label → Section | P(section \| label) |
|---|---|
| PRODUCT_NAME → ITEMS | 97.6% |
| LINE_TOTAL → ITEMS | 94.1% |
| ADDRESS_LINE → ADDRESS | 92.3% |
| TAX → SUMMARY | 89.4% |
| PAYMENT_METHOD → PAYMENT | 89.3% |
| MERCHANT_NAME → STOREFRONT | 83.9% |
| GRAND_TOTAL → TOTAL_LINE (+PAYMENT) | 60.8% (+30.6%) |

**Validation against known-bad labels:** of the 2,435 INVALID labels with
`label_proposed_by = "mcp-claude-review"` (human/LLM-rejected via MCP), 1,792 sit on
sectioned lines. At the 10% reference threshold the gate flags 532 of them —
**21.8% of all 2,435 (29.7% of the sectioned ones) vs a 7.5% base rate** (1,641 /
21,800) among currently-VALID core labels on sectioned lines → **~3.9× enrichment**
(kickoff measurement: 22.4% vs 7.5%, ~3×; the small drift is dev-state movement
between measurements).

## Threshold derivation (measured, not fit)

Flag-rate sweep, known-bad (sectioned) vs known-good (sectioned):

| threshold | bad flagged | good flagged | J = bad−good | enrichment |
|---|---|---|---|---|
| 0.01 | 10.5% | 1.6% | 0.089 | 6.5× |
| 0.02 | 18.0% | 3.8% | 0.142 | 4.8× |
| **0.05** | **26.3%** | **6.3%** | **0.200** | **4.2×** |
| 0.07 | 28.0% | 6.7% | 0.213 | 4.2× |
| 0.10 | 29.7% | 7.5% | 0.222 | 3.9× |
| 0.15 | 33.0% | 9.2% | 0.238 (max) | 3.6× |
| 0.30 | 33.3% | 11.2% | 0.221 | 3.0× |

Default `DEFAULT_LOW_PRIOR_THRESHOLD = 0.05`: Youden-J peaks at 0.15, but J weighs
false flags and misses equally — here false flags cost human review time while
misses are silent, so we sit on the left edge of the flat J plateau (J=0.200 vs max
0.238) where enrichment is near-max (4.2×). Marginal enrichment (Δbad/Δgood) for
cells added beyond 0.05 declines toward ~2×; 0.05–0.07 is a flat shelf, so the
choice is not a knife-edge. (Cross-checked independently by a second model; same
conclusion.) 59 known-bad labels sit on sections with prior exactly 0.0; zero
known-good do.

Support floor `MIN_SECTIONED_SUPPORT = 59 = ceil(ln 0.05 / ln 0.95)` — the smallest
n at which a cell whose true rate equals the threshold has <5% probability of zero
observations; below it the gate ABSTAINs rather than turn sampling noise into
false flags.

## Abstain rules (hard)

- **Unsectioned lines → ABSTAIN.** DATE is 70% unsectioned and TIME 72%, because the
  semi-Markov decoder does not emit `TRANSACTION_INFO` yet (section-order priors
  rebuild pending, #1173 note in `constants.py`). Until then, absence of a section
  is not evidence against a label.
- Unknown labels (outside `CORE_LABELS`) → ABSTAIN.
- Label with < 59 sectioned observations → ABSTAIN.
- Legacy section types (HEADER, ITEMS_VALUE, ITEMS_DESCRIPTION) are excluded from
  the prior and ignored by the gate.

## Deliverables

- `receipt_upload/receipt_upload/assets/section_label_priors_v1.json` — committed
  deterministic artifact (per-cell counts + p, corpus SHA-256, no wall-clock).
  Two independent builds are byte-identical (verified: cmp + shasum, SHA 6ed0e42b…).
- `scripts/build_section_label_priors.py` — read-only builder; refuses any table
  except dev `ReceiptsTable-dc5be22` and any environment except `dev`.
- `receipt_upload/receipt_upload/label_section_gate.py` — pure stdlib leaf module
  (mirrors `section_labels.py` discipline): `evaluate_label_section(label,
  section_types, priors)` → `GateResult(verdict, prior, threshold, reason)`.
- `receipt_upload/tests/test_label_section_gate.py` — unit tests on synthetic
  priors + one loose integration test against the committed artifact.
- `scripts/section_label_review_queue.py` — read-only queue generator; emits JSON +
  markdown for currently-VALID low-prior labels (output is dev-state-dependent and
  deliberately NOT committed).

### Artifact SHA-256s

- `section_label_priors_v1.json`: `6ed0e42b36f5e19be52b6435b985bf572b0690373767cc54c58cf975eefbcbfd`
- corpus SHA-256 (sorted (image, receipt, line, word, label, section) observation
  tuples): `4597ea00a415520794283e06ab01f0eab0f259301e973a033ea758b969a19fe3`

### Review queue summary (dev state 2026-07-18, threshold 0.05, not committed)

1,369 rows at the 0.05 default (support floor abstains CASH_BACK/CHANGE/REFUND/TIP). Top labels: ADDRESS_LINE 401, PAYMENT_METHOD 345, PRODUCT_NAME 103, WEBSITE 90, LINE_TOTAL 86, PHONE_NUMBER 86, MERCHANT_NAME 67, TAX 41. 14 rows have null word text (word row no longer present).

At the 10% reference threshold the queue matches the kickoff expectation
(~1,641 rows; top offenders ADDRESS_LINE 401, PAYMENT_METHOD 345, PRODUCT_NAME 103,
WEBSITE 90, PHONE_NUMBER 86, LINE_TOTAL 86).

## Intended (future) wire-in point — NOT in this PR

The LLM-refine label proposal step: a proposal whose gate verdict is `LOW_PRIOR`
should be demoted to `NEEDS_REVIEW` instead of landing as VALID/PENDING. The gate
API takes the line's section types straight from `sections_to_line_map`-style
precedence, so the call site is a few lines. Separately, per-line typography
attributes (ROW_SCHEMA.md §7 — e.g. bold tier → totals) could later join as an
independent feature next to the section prior; deliberately not built here since
typography is orthogonal to semantic sections (31% of VALID sections are
multi-style).

## Label-name hygiene (report only; nothing fixed here)

The VALID-label namespace contains 686 rows across 32 non-core names. Drift:
ADDRESS 425 (vs ADDRESS_LINE), OTHER 178, TENDER 24, UNLABELED 11, NULL 8, plus
PHONE, ITEM_NAME, BUSINESS_NAME, AMOUNT, TOTAL. Junk: bare amounts ("$3.15",
"59.12", "1249.36", "0.00") and free-text notes-as-labels (e.g. "SUBTOTAL SHOULD BE
$214.46 (OR THE $4014.97 ENTRY SHOULD BE REMOVED/RELABELED)", "LINE_TOTAL $10.89
(ADD TO LINE 5)"). These are excluded from the prior (CORE_LABELS-only) and left
untouched; a follow-up PR should normalize or invalidate them.

## Caveats

- TRANSACTION_INFO already carries some prior mass (17 label cells) from manually
  QA-promoted sections, but the semi-Markov decoder cannot emit it yet; once the
  section-order priors are rebuilt and it flows at scale, rebuild this artifact
  (v2) and DATE/TIME stop being ~70% unsectioned.
- The artifact is dev-corpus-derived; the builder embeds corpus counts + SHA so a
  rebuild against moved dev state is an explicit, reviewable diff.

## Final review loop (fresh-eyes, post-increment reviews)

After five incremental codex rounds converged, the complete final diff + full
file contents went to codex (fresh-eyes correctness pass) and grok
(adversarial statistics pass). Outcome:

**Fixed:**
- Priors are now co-occurrence rates: `p = count / sectioned-row-count`,
  matching the gate's max-over-sections decision rule (the previous
  pair-normalized share deflates every cell when a line carries >1 section).
  No p value changed on the current corpus — multi-section lines are absent
  today — but the estimator now matches the decision rule by construction.
- Support floor counts **distinct sectioned lines** (`sectioned_lines`, new
  artifact field) instead of word rows: words on a line share one section
  assignment, so word rows are not independent trials (pseudo-replication).
  Same four labels abstain (CASH_BACK, CHANGE, REFUND, TIP).
- Gate validates its `threshold` parameter (NaN/out-of-range previously
  compared False and silently passed rows as OK).

**Declined, with rationale:**
- "Report flag rates on a holdout": the 6.3% known-good rate is in-sample by
  construction (priors fit on VALID labels) and is labeled as such; the
  out-of-sample checks are the known-bad enrichment (INVALID labels are not
  in the training mass) and the 50-row precision sample (80% precision,
  Wilson 95% [67.0%, 88.8%], two independent judges). A receipt-level holdout
  fit is queued for the v2 artifact.
- "Make `receipt_upload.__init__` lazy so the gate imports stdlib-only via the
  package": out of scope — touches the whole package's import surface; the
  review-queue script documents the leaf-module load pattern instead.
- Claim-denominator symmetry: both the 26.3% (known-bad) and 6.3%
  (known-good) rates were already computed on the same predicate (sectioned
  lines, no support floor); wording clarified here rather than code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NhWBiuLexPBbapWJWeCB1K
