### PR TITLE
chore: enable email_receipt_inbox on dev stack config

### DIFF
--- a/infra/Pulumi.dev.yaml
+++ b/infra/Pulumi.dev.yaml
@@ -58,3 +58,4 @@ config:
     - http://127.0.0.1:8765/callback
     - http://localhost:6274/oauth/callback
     - http://127.0.0.1:8765/callback/rzKPyJle2jYU
+  portfolio:email_receipt_inbox_enabled: "true"


### PR DESCRIPTION
One-line config change recording the already-deployed dev enablement of PR #1175's inbox (deployed + self-tested end-to-end today). Prod remains gated off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)