### PR TITLE
Deprecate legacy RECEIPT_METADATA; route merchant reads through RECEIPT_PLACE

### DIFF
--- a/docs/architecture/CANONICAL_FIELDS_DEPRECATION.md
+++ b/docs/architecture/CANONICAL_FIELDS_DEPRECATION.md
@@ -6,6 +6,37 @@ cluster of receipts. That bulk harmonizer is retired. New code should treat the
 base receipt place fields as the source of truth and should correct them through
 the current place workflows.
 
+## Entity Source Of Truth
+
+`RECEIPT_PLACE` is the source of truth for a receipt's merchant and location.
+Active merchant lookup, census, rendering, and analytics code must use
+`ReceiptPlace` data:
+
+- Use `get_receipt_places_by_merchant` for merchant-specific lookups.
+- For a table-wide census, query the `GSITYPE` index with
+  `TYPE = RECEIPT_PLACE` and parse the scalar `merchant_name` field.
+- Do not add new reads of `RECEIPT_METADATA` or `ReceiptMetadata` for current
+  merchant state.
+
+`RECEIPT_METADATA` is legacy. Its model and data APIs remain only for workflows
+that must preserve or transform historical rows: the dev-to-prod mirror,
+reconciliation, cleanup/repair, and the metadata-to-place backfill. Those
+exceptions do not make metadata authoritative.
+
+### Drifted Legacy Rows
+
+Historical `RECEIPT_METADATA` rows can contain stale secondary-index values
+derived from an older merchant name, place ID, or validation status. The legacy
+converter tolerates those drifted GSI projections so a migration or backfill
+page does not crash, while still validating primary identity (`PK`, `SK`, and
+`TYPE`) and field shapes. Consumers must not interpret a tolerated metadata row
+as fresher than its corresponding `RECEIPT_PLACE` row.
+
+`RECEIPT_PLACE` rows can also retain old secondary-index projections after a
+scalar repair. This is why table-wide census tooling uses the raw `GSITYPE`
+query described above instead of requiring every historical row to satisfy the
+current entity converter.
+
 ## Fields
 
 - `canonical_merchant_name`
@@ -16,7 +47,8 @@ the current place workflows.
 ## Current Source Of Truth
 
 - Missing place IDs are filled by `receipt_agent.agents.place_id_finder`.
-- Incorrect `ReceiptPlace` records are corrected through the fix-place workflow.
+- Incorrect `RECEIPT_PLACE` records are corrected through the fix-place
+  workflow.
 - Corrections use receipt text, Google Places, ChromaDB context, and explicit MCP
   update tools.
 - Label quality and financial consistency are validated by the label evaluator

--- a/infra/qa_agent_step_functions/infrastructure.py
+++ b/infra/qa_agent_step_functions/infrastructure.py
@@ -3,7 +3,7 @@ Pulumi infrastructure for QA Agent Step Function pipeline.
 
 This component creates a Step Function that:
 1. Runs all 32 marquee questions through the 5-node QA graph (single container Lambda)
-2. Queries DynamoDB for receipt metadata (zip Lambda)
+2. Queries DynamoDB for receipt rendering data (zip Lambda)
 3. Triggers LangSmith bulk export (reuses existing Lambda)
 4. Polls export status with retry loop (reuses existing Lambda)
 5. Starts EMR Spark job to build per-question viz cache
@@ -21,6 +21,10 @@ from typing import Optional
 
 import pulumi
 import pulumi_aws as aws
+
+# Import shared components
+from codebuild_docker_image import CodeBuildDockerImage
+from lambda_layer import dynamo_layer
 from pulumi import (
     AssetArchive,
     ComponentResource,
@@ -29,10 +33,6 @@ from pulumi import (
     Output,
     ResourceOptions,
 )
-
-# Import shared components
-from codebuild_docker_image import CodeBuildDockerImage
-from lambda_layer import dynamo_layer
 
 # Load secrets
 config = Config("portfolio")
@@ -56,7 +56,7 @@ class QAAgentStepFunction(ComponentResource):
 
     Workflow:
     1. RunAllQuestions → run 32 questions, write NDJSON, extract receipt keys
-    2. QueryReceiptMetadata → receipts-lookup.json to S3
+    2. QueryReceiptData → receipts-lookup.json to S3
     3. TriggerLangSmithExport → start bulk export
     4. WaitForExport → 60s wait
     5. CheckExportStatus → poll loop (max 30 retries)
@@ -534,7 +534,7 @@ def _build_state_machine_definition(
     """Build the Step Function ASL definition.
 
     Pipeline:
-    Initialize → RunAllQuestions → QueryReceiptMetadata →
+    Initialize → RunAllQuestions → QueryReceiptData →
     TriggerLangSmithExport → WaitForExport ⟷ CheckExportStatus →
     PrepareEMRArgs → StartEMRJob → Done
     """
@@ -580,9 +580,9 @@ def _build_state_machine_definition(
                         "BackoffRate": 1,
                     }
                 ],
-                "Next": "QueryReceiptMetadata",
+                "Next": "QueryReceiptData",
             },
-            "QueryReceiptMetadata": {
+            "QueryReceiptData": {
                 "Type": "Task",
                 "Resource": "arn:aws:states:::lambda:invoke",
                 "Parameters": {

--- a/receipt_agent/receipt_agent/agents/label_evaluator/rendering/font_profile.py
+++ b/receipt_agent/receipt_agent/agents/label_evaluator/rendering/font_profile.py
@@ -328,11 +328,11 @@ def build_merchant_font_profile_from_dynamo(
 ) -> MerchantFontProfile | None:
     """Build a merchant profile from real receipts in Dynamo/S3.
 
-    Resolves the merchant's receipts via :class:`ReceiptPlace`
-    (``get_receipt_places_by_merchant`` — ``ReceiptMetadata`` is deprecated),
-    loads each receipt's OCR lines/words/letters, and builds a per-receipt
-    profile with :func:`extract_receipt_font_profile` (which runs #994's
-    clustering on the letters). Profiles are then aggregated.
+    Resolves the merchant's receipts from the canonical ``RECEIPT_PLACE`` rows
+    via ``get_receipt_places_by_merchant``, loads each receipt's OCR
+    lines/words/letters, and builds a per-receipt profile with
+    :func:`extract_receipt_font_profile` (which runs #994's clustering on the
+    letters). Profiles are then aggregated.
 
     ``eps=3.0`` matches the receipt-level recommendation from the font pilot
     (``docs/receipt-font-analysis-pilot.md``). When ``use_raw_image`` is set the

--- a/receipt_agent/receipt_agent/agents/label_evaluator/rendering/glyph_atlas.py
+++ b/receipt_agent/receipt_agent/agents/label_evaluator/rendering/glyph_atlas.py
@@ -743,9 +743,9 @@ def build_glyph_atlas_from_dynamo(
 ) -> GlyphAtlas | None:
     """Build a merchant glyph atlas from real receipts in Dynamo/S3.
 
-    Resolves receipts via :class:`ReceiptPlace` (``ReceiptMetadata`` is
-    deprecated), loads letters + the raw receipt crop per receipt, and delegates
-    to :func:`build_glyph_atlas`. ``max_receipts`` bounds the S3 image pulls.
+    Resolves receipts from the canonical ``RECEIPT_PLACE`` rows, loads letters
+    plus the raw receipt crop per receipt, and delegates to
+    :func:`build_glyph_atlas`. ``max_receipts`` bounds the S3 image pulls.
     """
     from receipt_dynamo.data.dynamo_client import DynamoClient
     from receipt_upload.font_analysis import load_raw_image_from_s3

--- a/receipt_agent/receipt_agent/subagents/place_finder/backfill_receipt_place.py
+++ b/receipt_agent/receipt_agent/subagents/place_finder/backfill_receipt_place.py
@@ -1,9 +1,10 @@
 """
 Backfill script: Migrate ReceiptMetadata to ReceiptPlace entities.
 
-DEPRECATED: This migration script has been run and the backfill is complete.
-The ReceiptMetadata entity is being removed. This file is retained for
-historical reference only.
+DEPRECATED FOR NORMAL READS: The broad migration has run, but this operational
+backfill remains functional for targeted or resumed repairs. It intentionally
+reads legacy ReceiptMetadata only as source material for missing ReceiptPlace
+rows; all current merchant reads use ReceiptPlace.
 
 This script creates ReceiptPlace records for all existing ReceiptMetadata
 records in DynamoDB, enriching them with data from Google Places API v1.

--- a/receipt_agent/tests/test_font_profile.py
+++ b/receipt_agent/tests/test_font_profile.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+from receipt_agent.agents.label_evaluator.rendering import font_profile
 from receipt_agent.agents.label_evaluator.rendering.font_profile import (
     MerchantFontProfile,
     ReceiptFontProfile,
     build_merchant_font_profile,
+    build_merchant_font_profile_from_dynamo,
     extract_receipt_font_profile,
 )
 
@@ -323,6 +325,51 @@ def test_to_geometry_params_scales_to_canvas():
 
 def test_build_merchant_profile_none_for_empty():
     assert build_merchant_font_profile("M", []) is None
+
+
+def test_dynamo_profile_resolves_receipts_through_receipt_place(monkeypatch):
+    words, lines = _simple_receipt()
+    for line in lines:
+        line.receipt_id = 1
+
+    class PlaceOnlyClient:
+        def __init__(self):
+            self.merchant_queries = []
+            self.image_queries = []
+
+        def get_receipt_places_by_merchant(self, merchant_name):
+            self.merchant_queries.append(merchant_name)
+            place = SimpleNamespace(image_id="image-1", receipt_id=1)
+            return [place, place], None
+
+        def get_image_details(self, image_id):
+            self.image_queries.append(image_id)
+            return SimpleNamespace(
+                receipt_lines=lines,
+                receipt_words=words,
+                receipt_letters=[],
+                receipts=[],
+            )
+
+    client = PlaceOnlyClient()
+    monkeypatch.setattr(
+        "receipt_dynamo.data.dynamo_client.DynamoClient",
+        lambda **_kwargs: client,
+    )
+    monkeypatch.setattr(
+        font_profile,
+        "analyze_receipt_fonts",
+        lambda *_args, **_kwargs: None,
+    )
+
+    profile = build_merchant_font_profile_from_dynamo(
+        "ReceiptsTable-dc5be22", "Test Merchant"
+    )
+
+    assert isinstance(profile, MerchantFontProfile)
+    assert profile.receipt_count == 1
+    assert client.merchant_queries == ["Test Merchant"]
+    assert client.image_queries == ["image-1"]
 
 
 def test_extract_uses_dominant_cluster_when_letters_present():

--- a/receipt_agent/tests/test_glyph_atlas.py
+++ b/receipt_agent/tests/test_glyph_atlas.py
@@ -10,11 +10,13 @@ from __future__ import annotations
 
 from PIL import Image, ImageDraw
 
+from receipt_agent.agents.label_evaluator.rendering import glyph_atlas
 from receipt_agent.agents.label_evaluator.rendering.glyph_atlas import (
     GlyphAtlas,
     _is_promo_text,
     _logo_match_score,
     build_glyph_atlas,
+    build_glyph_atlas_from_dynamo,
     extract_glyph_image,
     load_atlas,
     save_atlas,
@@ -402,3 +404,56 @@ def test_build_returns_none_without_usable_receipts():
         )
         is None
     )
+
+
+def test_dynamo_atlas_resolves_receipts_through_receipt_place(monkeypatch):
+    source = _build_inputs()[0]
+
+    class PlaceOnlyClient:
+        def __init__(self):
+            self.merchant_queries = []
+
+        def get_receipt_places_by_merchant(self, merchant_name):
+            self.merchant_queries.append(merchant_name)
+            place = type("Place", (), {"image_id": "img-1", "receipt_id": 1})()
+            return [place, place], None
+
+        def get_image_details(self, image_id):
+            assert image_id == "img-1"
+            receipt = type("Receipt", (), {"receipt_id": 1})()
+            letters = [
+                type("Letter", (), {**letter, "receipt_id": 1})()
+                for letter in source["letters"]
+            ]
+            return type(
+                "Details",
+                (),
+                {"receipt_letters": letters, "receipts": [receipt]},
+            )()
+
+    client = PlaceOnlyClient()
+    monkeypatch.setattr(
+        "receipt_dynamo.data.dynamo_client.DynamoClient",
+        lambda **_kwargs: client,
+    )
+    monkeypatch.setattr(
+        "receipt_upload.font_analysis.load_raw_image_from_s3",
+        lambda _receipt: source["raw_image"],
+    )
+    captured = {}
+    expected = object()
+
+    def capture_build(receipts, merchant_name, **kwargs):
+        captured["receipts"] = receipts
+        captured["merchant_name"] = merchant_name
+        captured["kwargs"] = kwargs
+        return expected
+
+    monkeypatch.setattr(glyph_atlas, "build_glyph_atlas", capture_build)
+
+    result = build_glyph_atlas_from_dynamo("ReceiptsTable-dc5be22", "TestMart")
+
+    assert result is expected
+    assert client.merchant_queries == ["TestMart"]
+    assert len(captured["receipts"]) == 1
+    assert captured["merchant_name"] == "TestMart"

--- a/receipt_dynamo/receipt_dynamo/data/_receipt_metadata.py
+++ b/receipt_dynamo/receipt_dynamo/data/_receipt_metadata.py
@@ -1,4 +1,9 @@
-# infra/lambda_layer/python/dynamo/data/_receipt_metadata.py
+"""Legacy metadata operations retained for migration and repair workflows.
+
+New merchant lookup and census code must use ``ReceiptPlace`` operations.
+These methods remain functional because the dev-to-prod mirror, historical
+cleanup, and place backfill still need to read or preserve old rows.
+"""
 
 from receipt_dynamo.data.base_operations import (
     DeleteTypeDef,
@@ -20,9 +25,10 @@ class _ReceiptMetadata(
     FlattenedStandardMixin,
 ):
     """
-    A class providing methods to interact with "ReceiptMetadata" entities in
-    DynamoDB. This class is typically used within a DynamoClient to access and
-    manage receipt metadata records.
+    Compatibility operations for legacy ``ReceiptMetadata`` rows in DynamoDB.
+
+    ``ReceiptPlace`` is authoritative for active merchant reads. This mixin is
+    retained for migrations, reconciliation, repair, and cleanup only.
 
     Attributes
     ----------
@@ -354,7 +360,11 @@ class _ReceiptMetadata(
         last_evaluated_key: dict | None = None,
     ) -> tuple[list[ReceiptMetadata], dict | None]:
         """
-        Lists ReceiptMetadata records from DynamoDB with optional pagination.
+        Lists legacy ReceiptMetadata records with optional pagination.
+
+        Deprecated for census work: query ``RECEIPT_PLACE`` through
+        ``list_receipt_places`` or the raw ``GSITYPE`` index. This API remains
+        available for migration, repair, and backfill tools.
 
         Parameters
         ----------
@@ -391,7 +401,11 @@ class _ReceiptMetadata(
         last_evaluated_key: dict | None = None,
     ) -> tuple[list[ReceiptMetadata], dict | None]:
         """
-        Retrieves ReceiptMetadata records from DynamoDB by merchant name.
+        Retrieves legacy ReceiptMetadata records by merchant name.
+
+        Deprecated for merchant lookup: use
+        ``get_receipt_places_by_merchant``. This API remains available only for
+        migration and repair workflows.
 
         Parameters
         ----------

--- a/receipt_dynamo/receipt_dynamo/data/_receipt_place.py
+++ b/receipt_dynamo/receipt_dynamo/data/_receipt_place.py
@@ -405,6 +405,53 @@ class _ReceiptPlace(FlattenedStandardMixin):
             last_evaluated_key=last_evaluated_key,
         )
 
+    @handle_dynamodb_errors("list_receipt_places_raw")
+    def list_receipt_places_raw(
+        self,
+        limit: int | None = None,
+        last_evaluated_key: dict | None = None,
+    ) -> tuple[list[dict], dict | None]:
+        """Census read: raw ``RECEIPT_PLACE`` rows WITHOUT entity conversion.
+
+        Table-wide census work (dedup dossiers, place-census scripts) cannot
+        rely on strict entity conversion because historical place rows may
+        carry drifted secondary-index projections while their scalar
+        identity/merchant fields remain authoritative. This is the ONLY
+        sanctioned raw read; callers must never reach into ``_client``.
+
+        Parameters
+        ----------
+        limit : int, optional
+            Maximum number of items for this page (defaults to the query's
+            natural page size, capped at 1000).
+        last_evaluated_key : dict, optional
+            The key to start pagination from.
+
+        Returns
+        -------
+        tuple[list[dict], dict | None]
+            Low-level DynamoDB items (attribute-value maps) and the last
+            evaluated key for pagination.
+        """
+        self._validate_pagination_params(limit, last_evaluated_key)
+        query: dict = {
+            "TableName": self.table_name,
+            "IndexName": "GSITYPE",
+            "KeyConditionExpression": "#entity_type = :entity_type",
+            "ExpressionAttributeNames": {"#entity_type": "TYPE"},
+            "ExpressionAttributeValues": {
+                ":entity_type": {"S": "RECEIPT_PLACE"}
+            },
+            "Limit": min(limit, 1000) if limit is not None else 1000,
+        }
+        if last_evaluated_key is not None:
+            query["ExclusiveStartKey"] = last_evaluated_key
+        response = self._client.query(**query)
+        return (
+            list(response.get("Items", [])),
+            response.get("LastEvaluatedKey"),
+        )
+
     @handle_dynamodb_errors("get_receipt_places_by_merchant")
     def get_receipt_places_by_merchant(
         self,

--- a/receipt_dynamo/receipt_dynamo/entities/receipt_metadata.py
+++ b/receipt_dynamo/receipt_dynamo/entities/receipt_metadata.py
@@ -37,14 +37,12 @@ MIN_ADDRESS_TOKENS = 3  # Minimum meaningful tokens for valid address
 class ReceiptMetadata(  # pylint: disable=too-many-instance-attributes
     SerializationMixin
 ):
-    """
-    Represents validated metadata for a receipt, specifically merchant-related
-    information derived from Google Places API and optionally validated by GPT.
+    """Legacy merchant metadata retained for migration compatibility.
 
-    This entity is used to:
-    - Anchor a receipt to a verified merchant (name, address, phone)
-    - Support merchant-specific labeling strategies
-    - Enable clustering and quality control across receipts
+    ``ReceiptPlace`` is the canonical merchant/location source of truth.
+    ``ReceiptMetadata`` remains readable for historical reconciliation,
+    repair, cleanup, and place-backfill workflows; active merchant lookup,
+    clustering, and quality-control paths must use ``ReceiptPlace`` instead.
 
     Each ReceiptMetadata record is stored in DynamoDB using the image_id and
     receipt_id, and indexed by merchant name via GSIs.
@@ -557,14 +555,16 @@ class ReceiptMetadata(  # pylint: disable=too-many-instance-attributes
             custom_extractors=custom_extractors,
         )
 
-        # Secondary indexes are projections, not identity, for this legacy
-        # entity. Historical rows can retain GSI values derived from an older
+        # PK and SK are identity, so preserve their canonical encoding after
+        # parsing. Secondary indexes are only projections for this legacy
+        # entity: historical rows can retain GSI values derived from an older
         # merchant name, place ID, or validation status after their scalar
         # fields were repaired. ReceiptPlace owns current merchant reads, while
         # migration/backfill readers need to consume these old rows without a
-        # stale projection crashing the entire page. PK, SK, TYPE, and field
-        # shapes remain validated above; only regenerated GSI equality is
-        # deliberately not enforced.
+        # stale projection crashing the page.
+        for key_name, expected_value in result.key.items():
+            if item[key_name] != expected_value:
+                raise ValueError(f"{key_name} does not match entity keys")
         return result
 
 

--- a/receipt_dynamo/receipt_dynamo/entities/receipt_metadata.py
+++ b/receipt_dynamo/receipt_dynamo/entities/receipt_metadata.py
@@ -1,4 +1,9 @@
-"""DynamoDB entity for validated receipt merchant metadata."""
+"""Legacy receipt metadata entity retained for migration compatibility.
+
+``ReceiptPlace`` is the merchant/location source of truth. This entity remains
+readable so historical reconciliation, repair, and place-backfill tools can
+process rows created before that migration.
+"""
 
 import os
 from dataclasses import dataclass
@@ -551,14 +556,15 @@ class ReceiptMetadata(  # pylint: disable=too-many-instance-attributes
             },
             custom_extractors=custom_extractors,
         )
-        for key_name, expected_value in {
-            **result.key,
-            **result.gsi1_key(),
-            **result.gsi2_key(),
-            **result.gsi3_key(),
-        }.items():
-            if key_name in item and item[key_name] != expected_value:
-                raise ValueError(f"{key_name} does not match entity keys")
+
+        # Secondary indexes are projections, not identity, for this legacy
+        # entity. Historical rows can retain GSI values derived from an older
+        # merchant name, place ID, or validation status after their scalar
+        # fields were repaired. ReceiptPlace owns current merchant reads, while
+        # migration/backfill readers need to consume these old rows without a
+        # stale projection crashing the entire page. PK, SK, TYPE, and field
+        # shapes remain validated above; only regenerated GSI equality is
+        # deliberately not enforced.
         return result
 
 

--- a/receipt_dynamo/tests/integration/test__receipt_place_raw_census.py
+++ b/receipt_dynamo/tests/integration/test__receipt_place_raw_census.py
@@ -1,0 +1,69 @@
+"""Raw ReceiptPlace census operation (PR #1183 codex P2).
+
+A table-wide census cannot rely on strict entity conversion because
+historical place rows can carry drifted secondary-index projections. The
+data layer must expose a raw, non-converting read so callers
+(receipt_upload dedup, census scripts) never reach into ``_client``.
+"""
+
+import pytest
+
+from receipt_dynamo import DynamoClient
+
+
+@pytest.fixture
+def client(dynamodb_table):
+    return DynamoClient(table_name=dynamodb_table)
+
+
+def _put_raw_place(client, image_id, receipt_id, merchant, drifted=False):
+    item = {
+        "PK": {"S": f"IMAGE#{image_id}"},
+        "SK": {"S": f"RECEIPT#{receipt_id:05d}#PLACE"},
+        "TYPE": {"S": "RECEIPT_PLACE"},
+        "image_id": {"S": image_id},
+        "receipt_id": {"N": str(receipt_id)},
+        "merchant_name": {"S": merchant},
+        "GSITYPE": {"S": "RECEIPT_PLACE"},
+    }
+    if drifted:
+        # stale projection: entity conversion would reject this row, the
+        # raw census must still return it
+        item.pop("image_id")
+        item["place_id"] = {"NULL": True}
+    client._client.put_item(TableName=client.table_name, Item=item)
+
+
+@pytest.mark.integration
+def test_raw_census_returns_all_rows_including_drifted(client):
+    _put_raw_place(
+        client, "3f52804b-2fad-4e00-92c8-b593da3a8ed3", 1, "Clean Mart"
+    )
+    _put_raw_place(
+        client,
+        "3f52804b-2fad-4e00-92c8-b593da3a8ed4",
+        2,
+        "Drifted Mart",
+        drifted=True,
+    )
+    items, lek = client.list_receipt_places_raw()
+    assert lek is None
+    merchants = sorted(i.get("merchant_name", {}).get("S", "") for i in items)
+    assert merchants == ["Clean Mart", "Drifted Mart"]
+    # raw means raw: low-level attribute maps, no entity conversion
+    assert all(isinstance(i.get("TYPE"), dict) for i in items)
+
+
+@pytest.mark.integration
+def test_raw_census_pagination(client):
+    for n in range(1, 5):
+        _put_raw_place(
+            client,
+            f"3f52804b-2fad-4e00-92c8-b593da3a8e{n:02d}",
+            n,
+            f"M{n}",
+        )
+    items, lek = client.list_receipt_places_raw(limit=2)
+    assert len(items) == 2 and lek is not None
+    rest, lek2 = client.list_receipt_places_raw(last_evaluated_key=lek)
+    assert len(rest) == 2 and lek2 is None

--- a/receipt_dynamo/tests/unit/test_receipt_metadata.py
+++ b/receipt_dynamo/tests/unit/test_receipt_metadata.py
@@ -557,3 +557,15 @@ def test_receipt_metadata_from_item_rejects_type_but_tolerates_gsi_drift(
     assert restored.merchant_name == example_receipt_metadata.merchant_name
     assert restored.place_id == example_receipt_metadata.place_id
     assert restored.validation_status == MerchantValidationStatus.MATCHED
+
+
+@pytest.mark.unit
+def test_receipt_metadata_from_item_rejects_noncanonical_primary_key(
+    example_receipt_metadata,
+):
+    item = example_receipt_metadata.to_item()
+    item["SK"] = {
+        "S": f"RECEIPT#{example_receipt_metadata.receipt_id}#METADATA"
+    }
+    with pytest.raises(ValueError, match="SK does not match entity keys"):
+        item_to_receipt_metadata(item)

--- a/receipt_dynamo/tests/unit/test_receipt_metadata.py
+++ b/receipt_dynamo/tests/unit/test_receipt_metadata.py
@@ -539,7 +539,7 @@ def test_receipt_metadata_revalidates_mutated_state(example_receipt_metadata):
 
 
 @pytest.mark.unit
-def test_receipt_metadata_from_item_rejects_type_and_gsi_mismatches(
+def test_receipt_metadata_from_item_rejects_type_but_tolerates_gsi_drift(
     example_receipt_metadata,
 ):
     item = example_receipt_metadata.to_item()
@@ -548,6 +548,12 @@ def test_receipt_metadata_from_item_rejects_type_and_gsi_mismatches(
         item_to_receipt_metadata(item)
 
     item = example_receipt_metadata.to_item()
+    item["GSI1PK"] = {"S": "MERCHANT#OLD_NAME"}
     item["GSI2PK"] = {"S": "PLACE#wrong"}
-    with pytest.raises(ValueError, match="GSI2PK does not match"):
-        item_to_receipt_metadata(item)
+    item["GSI3SK"] = {"S": "STATUS#NO_MATCH"}
+
+    restored = item_to_receipt_metadata(item)
+
+    assert restored.merchant_name == example_receipt_metadata.merchant_name
+    assert restored.place_id == example_receipt_metadata.place_id
+    assert restored.validation_status == MerchantValidationStatus.MATCHED

--- a/receipt_places/monitoring.py
+++ b/receipt_places/monitoring.py
@@ -221,7 +221,7 @@ class MetricsCollector:
         print("\nDual-Write Metrics:")
         dw = summary["dual_write"]
         print(
-            f"  ReceiptMetadata: {dw['metadata_writes']} writes, "
+            f"  Legacy metadata: {dw['metadata_writes']} writes, "
             f"{dw['metadata_errors']} errors "
             f"({dw['metadata_success_rate']:.1%} success)"
         )

--- a/receipt_upload/receipt_upload/dedup/dossiers.py
+++ b/receipt_upload/receipt_upload/dedup/dossiers.py
@@ -17,6 +17,65 @@ from receipt_upload.dedup.context import LabelObs
 ENV_TABLE = {"dev": "ReceiptsTable-dc5be22", "prod": "ReceiptsTable-d7ff76a"}
 
 
+def _receipt_place_merchants(
+    dc: DynamoClient,
+) -> dict[tuple[str, int], str | None]:
+    """Load merchant names from raw ``RECEIPT_PLACE`` rows.
+
+    A table-wide dedup census cannot rely on strict entity conversion because
+    historical place rows may retain stale secondary-index projections. Query
+    ``GSITYPE`` directly and read only scalar identity/name fields instead.
+    """
+    merchants: dict[tuple[str, int], str | None] = {}
+    last_evaluated_key = None
+
+    while True:
+        query = {
+            "TableName": dc.table_name,
+            "IndexName": "GSITYPE",
+            "KeyConditionExpression": "#entity_type = :entity_type",
+            "ExpressionAttributeNames": {"#entity_type": "TYPE"},
+            "ExpressionAttributeValues": {
+                ":entity_type": {"S": "RECEIPT_PLACE"}
+            },
+        }
+        if last_evaluated_key is not None:
+            query["ExclusiveStartKey"] = last_evaluated_key
+
+        response = dc._client.query(**query)
+        for item in response.get("Items", []):
+            image_id = item.get("image_id", {}).get("S")
+            if not image_id:
+                image_id = (
+                    item.get("PK", {}).get("S", "").removeprefix("IMAGE#")
+                )
+
+            raw_receipt_id = item.get("receipt_id", {}).get("N")
+            if raw_receipt_id is None:
+                sk_parts = item.get("SK", {}).get("S", "").split("#")
+                raw_receipt_id = (
+                    sk_parts[1]
+                    if len(sk_parts) == 3
+                    and sk_parts[0] == "RECEIPT"
+                    and sk_parts[2] == "PLACE"
+                    else None
+                )
+            try:
+                receipt_id = int(raw_receipt_id)
+            except (TypeError, ValueError):
+                continue
+            if not image_id:
+                continue
+
+            merchants[(image_id, receipt_id)] = item.get(
+                "merchant_name", {}
+            ).get("S")
+
+        last_evaluated_key = response.get("LastEvaluatedKey")
+        if last_evaluated_key is None:
+            return merchants
+
+
 def load_inputs(table: str, *, with_summaries: bool = False):
     """Return ``(receipts, words_by_receipt, labels_by_receipt)``.
 
@@ -61,9 +120,5 @@ def load_inputs(table: str, *, with_summaries: bool = False):
         g = getattr(su, "grand_total", None)
         if g is not None:
             totals[(su.image_id, su.receipt_id)] = float(g)
-    merchants = {}
-    for m in dc.list_receipt_metadatas()[0]:
-        merchants[(m.image_id, m.receipt_id)] = getattr(
-            m, "canonical_merchant_name", None
-        ) or getattr(m, "merchant_name", None)
+    merchants = _receipt_place_merchants(dc)
     return receipts, words_by_receipt, labels_by_receipt, totals, merchants

--- a/receipt_upload/receipt_upload/dedup/dossiers.py
+++ b/receipt_upload/receipt_upload/dedup/dossiers.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 from collections import defaultdict
 
 from receipt_dynamo import DynamoClient
-
 from receipt_upload.dedup.context import LabelObs
 
 ENV_TABLE = {"dev": "ReceiptsTable-dc5be22", "prod": "ReceiptsTable-d7ff76a"}
@@ -30,20 +29,14 @@ def _receipt_place_merchants(
     last_evaluated_key = None
 
     while True:
-        query = {
-            "TableName": dc.table_name,
-            "IndexName": "GSITYPE",
-            "KeyConditionExpression": "#entity_type = :entity_type",
-            "ExpressionAttributeNames": {"#entity_type": "TYPE"},
-            "ExpressionAttributeValues": {
-                ":entity_type": {"S": "RECEIPT_PLACE"}
-            },
-        }
-        if last_evaluated_key is not None:
-            query["ExclusiveStartKey"] = last_evaluated_key
-
-        response = dc._client.query(**query)
-        for item in response.get("Items", []):
+        # All DynamoDB operations live in receipt_dynamo: the data layer's
+        # raw census read returns low-level items without entity conversion
+        # (drifted projections stay readable) while keeping this module off
+        # the private _client.
+        items, last_evaluated_key = dc.list_receipt_places_raw(
+            last_evaluated_key=last_evaluated_key
+        )
+        for item in items:
             image_id = item.get("image_id", {}).get("S")
             if not image_id:
                 image_id = (
@@ -71,7 +64,6 @@ def _receipt_place_merchants(
                 "merchant_name", {}
             ).get("S")
 
-        last_evaluated_key = response.get("LastEvaluatedKey")
         if last_evaluated_key is None:
             return merchants
 

--- a/receipt_upload/receipt_upload/dedup/dossiers.py
+++ b/receipt_upload/receipt_upload/dedup/dossiers.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from collections import defaultdict
 
 from receipt_dynamo import DynamoClient
+
 from receipt_upload.dedup.context import LabelObs
 
 ENV_TABLE = {"dev": "ReceiptsTable-dc5be22", "prod": "ReceiptsTable-d7ff76a"}
@@ -39,8 +40,13 @@ def _receipt_place_merchants(
         for item in items:
             image_id = item.get("image_id", {}).get("S")
             if not image_id:
+                raw_pk = item.get("PK", {}).get("S")
                 image_id = (
-                    item.get("PK", {}).get("S", "").removeprefix("IMAGE#")
+                    raw_pk.removeprefix("IMAGE#")
+                    if isinstance(raw_pk, str)
+                    and raw_pk.startswith("IMAGE#")
+                    and raw_pk != "IMAGE#"
+                    else None
                 )
 
             raw_receipt_id = item.get("receipt_id", {}).get("N")

--- a/receipt_upload/tests/test_dedup_dossiers.py
+++ b/receipt_upload/tests/test_dedup_dossiers.py
@@ -1,0 +1,70 @@
+"""Tests for canonical merchant census loading in dedup dossiers."""
+
+from receipt_upload.dedup import dossiers
+
+
+def test_load_inputs_reads_merchants_from_raw_receipt_places(monkeypatch):
+    class RawClient:
+        def __init__(self):
+            self.calls = []
+
+        def query(self, **kwargs):
+            self.calls.append(kwargs)
+            if "ExclusiveStartKey" not in kwargs:
+                return {
+                    "Items": [
+                        {
+                            "image_id": {"S": "image-1"},
+                            "receipt_id": {"N": "1"},
+                            "merchant_name": {"S": "First Merchant"},
+                        }
+                    ],
+                    "LastEvaluatedKey": {"PK": {"S": "next"}},
+                }
+            return {
+                "Items": [
+                    {
+                        "PK": {"S": "IMAGE#image-2"},
+                        "SK": {"S": "RECEIPT#00002#PLACE"},
+                        "merchant_name": {"S": "Second Merchant"},
+                    }
+                ]
+            }
+
+    class PlaceOnlyDynamo:
+        table_name = "ReceiptsTable-dc5be22"
+
+        def __init__(self):
+            self._client = RawClient()
+
+        def list_receipts(self):
+            return ["receipt"], None
+
+        def list_receipt_words(self):
+            return [], None
+
+        def list_receipt_word_labels(self):
+            return [], None
+
+        def list_receipt_summaries(self):
+            return [], None
+
+    dc = PlaceOnlyDynamo()
+    monkeypatch.setattr(dossiers, "DynamoClient", lambda _table: dc)
+
+    receipts, words, labels, totals, merchants = dossiers.load_inputs(
+        dc.table_name, with_summaries=True
+    )
+
+    assert receipts == ["receipt"]
+    assert not words and not labels and not totals
+    assert merchants == {
+        ("image-1", 1): "First Merchant",
+        ("image-2", 2): "Second Merchant",
+    }
+    assert all(call["IndexName"] == "GSITYPE" for call in dc._client.calls)
+    assert all(
+        call["ExpressionAttributeValues"][":entity_type"]
+        == {"S": "RECEIPT_PLACE"}
+        for call in dc._client.calls
+    )

--- a/receipt_upload/tests/test_dedup_dossiers.py
+++ b/receipt_upload/tests/test_dedup_dossiers.py
@@ -4,38 +4,41 @@ from receipt_upload.dedup import dossiers
 
 
 def test_load_inputs_reads_merchants_from_raw_receipt_places(monkeypatch):
-    class RawClient:
-        def __init__(self):
-            self.calls = []
+    class PlaceOnlyDynamo:
+        table_name = "ReceiptsTable-dc5be22"
 
-        def query(self, **kwargs):
-            self.calls.append(kwargs)
-            if "ExclusiveStartKey" not in kwargs:
-                return {
-                    "Items": [
+        def __init__(self):
+            self.place_calls = []
+
+        def list_receipt_places_raw(self, limit=None, last_evaluated_key=None):
+            self.place_calls.append((limit, last_evaluated_key))
+            if last_evaluated_key is None:
+                return (
+                    [
                         {
                             "image_id": {"S": "image-1"},
                             "receipt_id": {"N": "1"},
                             "merchant_name": {"S": "First Merchant"},
                         }
                     ],
-                    "LastEvaluatedKey": {"PK": {"S": "next"}},
-                }
-            return {
-                "Items": [
+                    {"PK": {"S": "next"}},
+                )
+            return (
+                [
                     {
                         "PK": {"S": "IMAGE#image-2"},
                         "SK": {"S": "RECEIPT#00002#PLACE"},
                         "merchant_name": {"S": "Second Merchant"},
-                    }
-                ]
-            }
-
-    class PlaceOnlyDynamo:
-        table_name = "ReceiptsTable-dc5be22"
-
-        def __init__(self):
-            self._client = RawClient()
+                    },
+                    {
+                        # A malformed primary key must not become an image ID.
+                        "PK": {"S": "image-3"},
+                        "SK": {"S": "RECEIPT#00003#PLACE"},
+                        "merchant_name": {"S": "Ignored Merchant"},
+                    },
+                ],
+                None,
+            )
 
         def list_receipts(self):
             return ["receipt"], None
@@ -62,9 +65,7 @@ def test_load_inputs_reads_merchants_from_raw_receipt_places(monkeypatch):
         ("image-1", 1): "First Merchant",
         ("image-2", 2): "Second Merchant",
     }
-    assert all(call["IndexName"] == "GSITYPE" for call in dc._client.calls)
-    assert all(
-        call["ExpressionAttributeValues"][":entity_type"]
-        == {"S": "RECEIPT_PLACE"}
-        for call in dc._client.calls
-    )
+    assert dc.place_calls == [
+        (None, None),
+        (None, {"PK": {"S": "next"}}),
+    ]

--- a/receipt_upload/tests/test_dedup_dossiers_layering.py
+++ b/receipt_upload/tests/test_dedup_dossiers_layering.py
@@ -36,7 +36,13 @@ class _FakeClient:
                     "PK": {"S": "IMAGE#img-2"},
                     "SK": {"S": "RECEIPT#00002#PLACE"},
                     "merchant_name": {"S": "Mart Two"},
-                }
+                },
+                {
+                    # malformed fallback keys are ignored, not reinterpreted
+                    "PK": {"S": "img-3"},
+                    "SK": {"S": "RECEIPT#00003#PLACE"},
+                    "merchant_name": {"S": "Ignored Mart"},
+                },
             ],
             None,
         )

--- a/receipt_upload/tests/test_dedup_dossiers_layering.py
+++ b/receipt_upload/tests/test_dedup_dossiers_layering.py
@@ -1,0 +1,52 @@
+"""Dedup dossiers must use the receipt_dynamo public API (PR #1183 P2).
+
+All DynamoDB operations belong in receipt_dynamo; reaching into
+``DynamoClient._client`` from receipt_upload breaks that layering and
+silently detaches this census from centralized query/error handling.
+"""
+
+from receipt_upload.dedup.dossiers import _receipt_place_merchants
+
+
+class _FakeClient:
+    """Public-API-only stand-in: no _client attribute at all."""
+
+    table_name = "TestTable"
+
+    def __init__(self):
+        self.calls = []
+
+    def list_receipt_places_raw(self, limit=None, last_evaluated_key=None):
+        self.calls.append(last_evaluated_key)
+        if last_evaluated_key is None:
+            return (
+                [
+                    {
+                        "image_id": {"S": "img-1"},
+                        "receipt_id": {"N": "1"},
+                        "merchant_name": {"S": "Mart One"},
+                    }
+                ],
+                {"cursor": {"S": "next"}},
+            )
+        return (
+            [
+                {
+                    # drifted row: identity only via PK/SK
+                    "PK": {"S": "IMAGE#img-2"},
+                    "SK": {"S": "RECEIPT#00002#PLACE"},
+                    "merchant_name": {"S": "Mart Two"},
+                }
+            ],
+            None,
+        )
+
+
+def test_merchants_load_through_public_raw_census_api():
+    fake = _FakeClient()
+    merchants = _receipt_place_merchants(fake)
+    assert merchants == {
+        ("img-1", 1): "Mart One",
+        ("img-2", 2): "Mart Two",
+    }
+    assert fake.calls == [None, {"cursor": {"S": "next"}}]

--- a/scripts/backfill_receipt_place.py
+++ b/scripts/backfill_receipt_place.py
@@ -3,6 +3,8 @@
 Executable wrapper for ReceiptPlace backfill.
 
 Initializes clients from Pulumi stack and runs the backfill operation.
+This is an intentional legacy exception: it must read ReceiptMetadata as the
+source material for receipts that still need a ReceiptPlace row.
 
 Usage:
     python scripts/backfill_receipt_place.py --stack main --dry-run

--- a/scripts/cleanup_receipt_records.py
+++ b/scripts/cleanup_receipt_records.py
@@ -7,7 +7,7 @@ This removes, per receipt ID:
 - ReceiptWords
 - ReceiptLines
 - ReceiptLetters (best effort)
-- ReceiptMetadata (best effort)
+- ReceiptMetadata (intentional legacy cleanup, best effort, to avoid orphans)
 - CompactionRuns (best effort)
 - The Receipt itself (last)
 

--- a/scripts/copy_dynamodb_dev_to_prod.py
+++ b/scripts/copy_dynamodb_dev_to_prod.py
@@ -10,6 +10,11 @@ This script:
 5. Copies all related entities (lines, words, labels, metadata, OCR jobs, etc.)
 6. Uses batch writes for efficiency
 
+Legacy ReceiptMetadata rows are intentionally replayed when present. A mirror
+REPLACE deletes the complete image partition, so omitting exported legacy rows
+would silently make prod differ from dev even though ReceiptPlace is the active
+merchant source of truth.
+
 Usage:
     # Dry run first
     python scripts/copy_dynamodb_dev_to_prod.py --dry-run
@@ -296,7 +301,8 @@ def copy_image_entities(
                     prod_client.add_receipt_word_labels(batch)
             stats["receipt_word_labels"] = len(receipt_word_labels)
 
-        # Process ReceiptMetadatas
+        # Preserve legacy ReceiptMetadata rows during whole-image mirroring.
+        # Active merchant reads use ReceiptPlace, processed immediately below.
         if export_data.get("receipt_metadatas"):
             receipt_metadatas = [
                 ReceiptMetadata(**metadata)

--- a/scripts/fix_null_place_id_metadata.py
+++ b/scripts/fix_null_place_id_metadata.py
@@ -4,6 +4,10 @@
 This script identifies and updates ReceiptMetadata records in DynamoDB that have
 NULL or missing place_id values, setting them to empty strings to comply with
 the ReceiptMetadata validation requirements.
+
+This repair tool intentionally targets legacy rows so migration and backfill
+readers can still deserialize them. It does not make metadata authoritative;
+current merchant/place state lives in ReceiptPlace.
 """
 
 import logging

--- a/scripts/list_receipt_places.py
+++ b/scripts/list_receipt_places.py
@@ -21,8 +21,8 @@ parent_dir = os.path.dirname(script_dir)
 sys.path.insert(0, parent_dir)
 sys.path.insert(0, os.path.join(parent_dir, "receipt_dynamo"))
 
-from receipt_dynamo import DynamoClient
-from receipt_dynamo.data._pulumi import load_env
+from receipt_dynamo import DynamoClient  # noqa: E402
+from receipt_dynamo.data._pulumi import load_env  # noqa: E402
 
 logging.basicConfig(
     level=logging.INFO,
@@ -52,8 +52,7 @@ def list_all_places(
     census work.
 
     Args:
-        dynamodb_client: Low-level boto3 DynamoDB client.
-        table_name: DynamoDB table to query.
+        client: Public DynamoDB client exposing the raw ReceiptPlace census.
         limit: Maximum number of records to retrieve (None for all)
         output_file: Optional file path to save results as JSON
 
@@ -128,7 +127,7 @@ def print_summary(places: list[dict[str, Any]]) -> None:
         return
 
     print(f"\n{'='*60}")
-    print(f"SUMMARY")
+    print("SUMMARY")
     print(f"{'='*60}")
     print(f"Total records: {len(places)}")
 
@@ -138,7 +137,7 @@ def print_summary(places: list[dict[str, Any]]) -> None:
         status = place.get("validation_status") or "UNKNOWN"
         status_counts[status] = status_counts.get(status, 0) + 1
 
-    print(f"\nBy validation status:")
+    print("\nBy validation status:")
     for status, count in sorted(status_counts.items()):
         print(f"  {status}: {count}")
 
@@ -164,7 +163,7 @@ def print_summary(places: list[dict[str, Any]]) -> None:
 
     # Show some examples
     print(f"\n{'='*60}")
-    print(f"SAMPLE RECORDS (first 5)")
+    print("SAMPLE RECORDS (first 5)")
     print(f"{'='*60}")
     for i, place in enumerate(places[:5], 1):
         print(
@@ -269,7 +268,7 @@ def main():
 
     if not args.summary_only:
         print(f"\n{'='*60}")
-        print(f"ALL RECORDS")
+        print("ALL RECORDS")
         print(f"{'='*60}")
         for i, place in enumerate(places, 1):
             print(

--- a/scripts/list_receipt_places.py
+++ b/scripts/list_receipt_places.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
-"""List all ReceiptMetadata records from DynamoDB.
+"""List all ReceiptPlace records from DynamoDB.
 
-This script lists all ReceiptMetadata records from the specified DynamoDB table,
-with options to filter, paginate, and export the results.
+ReceiptPlace is the merchant/location source of truth. This read-only census
+script lists those records with options to paginate and export the results.
 """
 
 import argparse
@@ -10,8 +10,10 @@ import json
 import logging
 import os
 import sys
-from datetime import datetime
-from typing import List, Optional
+from typing import Any, Optional
+
+import boto3
+from boto3.dynamodb.types import TypeDeserializer
 
 # Add parent directories to path for imports
 script_dir = os.path.dirname(os.path.abspath(__file__))
@@ -21,33 +23,46 @@ sys.path.insert(0, parent_dir)
 sys.path.insert(0, os.path.join(parent_dir, "receipt_dynamo"))
 
 from receipt_dynamo.data._pulumi import load_env
-from receipt_dynamo.data.dynamo_client import DynamoClient
-from receipt_dynamo.entities.receipt_metadata import ReceiptMetadata
 
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s - %(levelname)s - %(message)s",
 )
 logger = logging.getLogger(__name__)
+_DESERIALIZER = TypeDeserializer()
 
 
-def list_all_metadatas(
-    dynamo_client: DynamoClient,
+def _deserialize_item(item: dict[str, Any]) -> dict[str, Any]:
+    """Convert one low-level DynamoDB item to ordinary Python values."""
+    return {
+        key: _DESERIALIZER.deserialize(value) for key, value in item.items()
+    }
+
+
+def list_all_places(
+    dynamodb_client: Any,
+    table_name: str,
     limit: Optional[int] = None,
     output_file: Optional[str] = None,
-) -> List[ReceiptMetadata]:
-    """List all ReceiptMetadata records from DynamoDB.
+) -> list[dict[str, Any]]:
+    """List canonical place rows through the raw ``GSITYPE`` index.
+
+    This census intentionally avoids entity conversion. Historical place rows
+    can carry drifted secondary-index projections, while their scalar
+    ``merchant_name`` and place fields remain authoritative for read-only
+    census work.
 
     Args:
-        dynamo_client: DynamoDB client instance
+        dynamodb_client: Low-level boto3 DynamoDB client.
+        table_name: DynamoDB table to query.
         limit: Maximum number of records to retrieve (None for all)
         output_file: Optional file path to save results as JSON
 
     Returns:
-        List of ReceiptMetadata records
+        Deserialized ``RECEIPT_PLACE`` rows.
     """
-    logger.info("Starting to list all ReceiptMetadata records...")
-    all_metadatas = []
+    logger.info("Starting to list all ReceiptPlace records...")
+    all_places = []
     last_evaluated_key = None
     page_count = 0
 
@@ -56,21 +71,35 @@ def list_all_metadatas(
             page_count += 1
             logger.info(f"Fetching page {page_count}...")
 
-            metadatas, last_evaluated_key = (
-                dynamo_client.list_receipt_metadatas(
-                    limit=1000, last_evaluated_key=last_evaluated_key
-                )
-            )
+            remaining = None if limit is None else limit - len(all_places)
+            query: dict[str, Any] = {
+                "TableName": table_name,
+                "IndexName": "GSITYPE",
+                "KeyConditionExpression": "#entity_type = :entity_type",
+                "ExpressionAttributeNames": {"#entity_type": "TYPE"},
+                "ExpressionAttributeValues": {
+                    ":entity_type": {"S": "RECEIPT_PLACE"}
+                },
+                "Limit": min(remaining, 1000) if remaining else 1000,
+            }
+            if last_evaluated_key is not None:
+                query["ExclusiveStartKey"] = last_evaluated_key
 
-            all_metadatas.extend(metadatas)
+            response = dynamodb_client.query(**query)
+            places = [
+                _deserialize_item(item) for item in response.get("Items", [])
+            ]
+            last_evaluated_key = response.get("LastEvaluatedKey")
+
+            all_places.extend(places)
             logger.info(
-                f"Page {page_count}: Retrieved {len(metadatas)} records "
-                f"(total so far: {len(all_metadatas)})"
+                f"Page {page_count}: Retrieved {len(places)} records "
+                f"(total so far: {len(all_places)})"
             )
 
             # Check if we've hit the limit
-            if limit and len(all_metadatas) >= limit:
-                all_metadatas = all_metadatas[:limit]
+            if limit and len(all_places) >= limit:
+                all_places = all_places[:limit]
                 logger.info(f"Reached limit of {limit} records")
                 break
 
@@ -80,69 +109,45 @@ def list_all_metadatas(
                 break
 
     except Exception as e:
-        logger.error(f"Error listing metadatas: {e}", exc_info=True)
+        logger.error(f"Error listing places: {e}", exc_info=True)
         raise
 
-    logger.info(
-        f"Total ReceiptMetadata records retrieved: {len(all_metadatas)}"
-    )
+    logger.info(f"Total ReceiptPlace records retrieved: {len(all_places)}")
 
     # Save to file if requested
     if output_file:
         logger.info(f"Saving results to {output_file}...")
         with open(output_file, "w", encoding="utf-8") as f:
             json.dump(
-                [
-                    {
-                        "image_id": m.image_id,
-                        "receipt_id": m.receipt_id,
-                        "place_id": m.place_id,
-                        "merchant_name": m.merchant_name,
-                        "merchant_category": m.merchant_category,
-                        "address": m.address,
-                        "phone_number": m.phone_number,
-                        "matched_fields": m.matched_fields,
-                        "validated_by": m.validated_by,
-                        "reasoning": m.reasoning,
-                        "timestamp": (
-                            m.timestamp.isoformat() if m.timestamp else None
-                        ),
-                        "validation_status": m.validation_status,
-                        "canonical_place_id": m.canonical_place_id,
-                        "canonical_merchant_name": m.canonical_merchant_name,
-                        "canonical_address": m.canonical_address,
-                        "canonical_phone_number": m.canonical_phone_number,
-                    }
-                    for m in all_metadatas
-                ],
+                all_places,
                 f,
                 indent=2,
                 default=str,
             )
         logger.info(f"Results saved to {output_file}")
 
-    return all_metadatas
+    return all_places
 
 
-def print_summary(metadatas: List[ReceiptMetadata]) -> None:
-    """Print a summary of the metadata records.
+def print_summary(places: list[dict[str, Any]]) -> None:
+    """Print a summary of the receipt-place records.
 
     Args:
-        metadatas: List of ReceiptMetadata records
+        places: List of ReceiptPlace records
     """
-    if not metadatas:
-        print("No metadata records found.")
+    if not places:
+        print("No receipt-place records found.")
         return
 
     print(f"\n{'='*60}")
     print(f"SUMMARY")
     print(f"{'='*60}")
-    print(f"Total records: {len(metadatas)}")
+    print(f"Total records: {len(places)}")
 
     # Count by validation status
     status_counts = {}
-    for m in metadatas:
-        status = m.validation_status or "UNKNOWN"
+    for place in places:
+        status = place.get("validation_status") or "UNKNOWN"
         status_counts[status] = status_counts.get(status, 0) + 1
 
     print(f"\nBy validation status:")
@@ -151,17 +156,20 @@ def print_summary(metadatas: List[ReceiptMetadata]) -> None:
 
     # Count unique merchants
     unique_merchants = set()
-    for m in metadatas:
-        if m.merchant_name and m.merchant_name.strip():
-            unique_merchants.add(m.merchant_name.strip())
+    for place in places:
+        merchant_name = place.get("merchant_name")
+        if isinstance(merchant_name, str) and merchant_name.strip():
+            unique_merchants.add(merchant_name.strip())
 
     print(f"\nUnique merchants: {len(unique_merchants)}")
 
     # Count records with/without place_id
     with_place_id = sum(
-        1 for m in metadatas if m.place_id and m.place_id.strip()
+        1
+        for place in places
+        if isinstance(place.get("place_id"), str) and place["place_id"].strip()
     )
-    without_place_id = len(metadatas) - with_place_id
+    without_place_id = len(places) - with_place_id
 
     print(f"\nRecords with place_id: {with_place_id}")
     print(f"Records without place_id: {without_place_id}")
@@ -170,18 +178,21 @@ def print_summary(metadatas: List[ReceiptMetadata]) -> None:
     print(f"\n{'='*60}")
     print(f"SAMPLE RECORDS (first 5)")
     print(f"{'='*60}")
-    for i, m in enumerate(metadatas[:5], 1):
-        print(f"\n{i}. Image: {m.image_id}, Receipt: {m.receipt_id}")
-        print(f"   Merchant: {m.merchant_name or '(empty)'}")
-        print(f"   Place ID: {m.place_id or '(empty)'}")
-        print(f"   Status: {m.validation_status or '(empty)'}")
-        print(f"   Matched fields: {m.matched_fields}")
+    for i, place in enumerate(places[:5], 1):
+        print(
+            f"\n{i}. Image: {place.get('image_id')}, "
+            f"Receipt: {place.get('receipt_id')}"
+        )
+        print(f"   Merchant: {place.get('merchant_name') or '(empty)'}")
+        print(f"   Place ID: {place.get('place_id') or '(empty)'}")
+        print(f"   Status: {place.get('validation_status') or '(empty)'}")
+        print(f"   Matched fields: {place.get('matched_fields', [])}")
 
 
 def main():
     """Main function."""
     parser = argparse.ArgumentParser(
-        description="List all ReceiptMetadata records from DynamoDB"
+        description="List all ReceiptPlace records from DynamoDB"
     )
     parser.add_argument(
         "--table",
@@ -243,34 +254,41 @@ def main():
 
     logger.info(f"Using DynamoDB table: {table_name}")
 
-    # Create DynamoDB client
+    # Create a low-level client so drifted index projections do not go through
+    # strict entity conversion during this read-only census.
     try:
-        dynamo_client = DynamoClient(table_name)
+        dynamodb_client = boto3.client("dynamodb")
     except Exception as e:
         logger.error(f"Failed to create DynamoDB client: {e}", exc_info=True)
         sys.exit(1)
 
-    # List all metadatas
+    # List all receipt places
     try:
-        metadatas = list_all_metadatas(
-            dynamo_client, limit=args.limit, output_file=args.output
+        places = list_all_places(
+            dynamodb_client,
+            table_name,
+            limit=args.limit,
+            output_file=args.output,
         )
     except Exception as e:
-        logger.error(f"Failed to list metadatas: {e}", exc_info=True)
+        logger.error(f"Failed to list places: {e}", exc_info=True)
         sys.exit(1)
 
     # Print summary
-    print_summary(metadatas)
+    print_summary(places)
 
     if not args.summary_only:
         print(f"\n{'='*60}")
         print(f"ALL RECORDS")
         print(f"{'='*60}")
-        for i, m in enumerate(metadatas, 1):
-            print(f"\n{i}. {m.image_id} / Receipt {m.receipt_id}")
-            print(f"   Merchant: {m.merchant_name or '(empty)'}")
-            print(f"   Place ID: {m.place_id or '(empty)'}")
-            print(f"   Status: {m.validation_status or '(empty)'}")
+        for i, place in enumerate(places, 1):
+            print(
+                f"\n{i}. {place.get('image_id')} / "
+                f"Receipt {place.get('receipt_id')}"
+            )
+            print(f"   Merchant: {place.get('merchant_name') or '(empty)'}")
+            print(f"   Place ID: {place.get('place_id') or '(empty)'}")
+            print(f"   Status: {place.get('validation_status') or '(empty)'}")
 
 
 if __name__ == "__main__":

--- a/scripts/list_receipt_places.py
+++ b/scripts/list_receipt_places.py
@@ -12,7 +12,6 @@ import os
 import sys
 from typing import Any, Optional
 
-import boto3
 from boto3.dynamodb.types import TypeDeserializer
 
 # Add parent directories to path for imports
@@ -22,6 +21,7 @@ parent_dir = os.path.dirname(script_dir)
 sys.path.insert(0, parent_dir)
 sys.path.insert(0, os.path.join(parent_dir, "receipt_dynamo"))
 
+from receipt_dynamo import DynamoClient
 from receipt_dynamo.data._pulumi import load_env
 
 logging.basicConfig(
@@ -40,8 +40,7 @@ def _deserialize_item(item: dict[str, Any]) -> dict[str, Any]:
 
 
 def list_all_places(
-    dynamodb_client: Any,
-    table_name: str,
+    client: DynamoClient,
     limit: Optional[int] = None,
     output_file: Optional[str] = None,
 ) -> list[dict[str, Any]]:
@@ -72,24 +71,13 @@ def list_all_places(
             logger.info(f"Fetching page {page_count}...")
 
             remaining = None if limit is None else limit - len(all_places)
-            query: dict[str, Any] = {
-                "TableName": table_name,
-                "IndexName": "GSITYPE",
-                "KeyConditionExpression": "#entity_type = :entity_type",
-                "ExpressionAttributeNames": {"#entity_type": "TYPE"},
-                "ExpressionAttributeValues": {
-                    ":entity_type": {"S": "RECEIPT_PLACE"}
-                },
-                "Limit": min(remaining, 1000) if remaining else 1000,
-            }
-            if last_evaluated_key is not None:
-                query["ExclusiveStartKey"] = last_evaluated_key
-
-            response = dynamodb_client.query(**query)
-            places = [
-                _deserialize_item(item) for item in response.get("Items", [])
-            ]
-            last_evaluated_key = response.get("LastEvaluatedKey")
+            # the data layer's raw census read: low-level items, no strict
+            # entity conversion (drifted projections stay readable)
+            items, last_evaluated_key = client.list_receipt_places_raw(
+                limit=remaining,
+                last_evaluated_key=last_evaluated_key,
+            )
+            places = [_deserialize_item(item) for item in items]
 
             all_places.extend(places)
             logger.info(
@@ -254,10 +242,13 @@ def main():
 
     logger.info(f"Using DynamoDB table: {table_name}")
 
-    # Create a low-level client so drifted index projections do not go through
-    # strict entity conversion during this read-only census.
+    # Standard client resolution: DynamoClient defaults the region
+    # (us-east-1) and honors DYNAMODB_ENDPOINT_URL, so the census works
+    # without AWS_REGION in the environment and against local endpoints.
+    # Raw reads still bypass strict entity conversion via
+    # list_receipt_places_raw (drifted index projections stay readable).
     try:
-        dynamodb_client = boto3.client("dynamodb")
+        client = DynamoClient(table_name)
     except Exception as e:
         logger.error(f"Failed to create DynamoDB client: {e}", exc_info=True)
         sys.exit(1)
@@ -265,8 +256,7 @@ def main():
     # List all receipt places
     try:
         places = list_all_places(
-            dynamodb_client,
-            table_name,
+            client,
             limit=args.limit,
             output_file=args.output,
         )

--- a/scripts/maintenance/fix_remaining_imports.py
+++ b/scripts/maintenance/fix_remaining_imports.py
@@ -49,6 +49,7 @@ def fix_imports_in_file(filepath: Path) -> int:
         "itemToQueue": "item_to_queue",
         "itemToJobResource": "item_to_job_resource",
         "itemToReceiptField": "item_to_receipt_field",
+        # Historical symbol migration only; active reads use receipt places.
         "itemToReceiptMetadata": "item_to_receipt_metadata",
         "itemToImage": "item_to_image",
         "itemToEmbeddingBatchResult": "item_to_embedding_batch_result",

--- a/scripts/reconcile_dev_to_prod.py
+++ b/scripts/reconcile_dev_to_prod.py
@@ -83,6 +83,8 @@ RESTORABLE_TYPES = {
     # restored by copy_image_entities
     "IMAGE", "RECEIPT", "LINE", "WORD", "LETTER",
     "RECEIPT_LINE", "RECEIPT_WORD", "RECEIPT_LETTER", "RECEIPT_WORD_LABEL",
+    # Legacy metadata is replayed by copy_image_entities after a whole-image
+    # REPLACE; keeping it restorable prevents the mirror from dropping dev rows.
     "RECEIPT_METADATA", "RECEIPT_PLACE", "RECEIPT_BARCODE",
     "OCR_ROUTING_DECISION",
     # restored by the filtered sync_ocr_jobs step

--- a/tests/test_list_receipt_places.py
+++ b/tests/test_list_receipt_places.py
@@ -1,0 +1,79 @@
+"""Tests for the raw ReceiptPlace census script."""
+
+import importlib.util
+from pathlib import Path
+
+SCRIPT_PATH = Path(__file__).parents[1] / "scripts" / "list_receipt_places.py"
+SPEC = importlib.util.spec_from_file_location(
+    "list_receipt_places", SCRIPT_PATH
+)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+list_all_places = MODULE.list_all_places
+
+
+def test_list_all_places_uses_canonical_place_pages():
+    first = {
+        "image_id": {"S": "image-1"},
+        "receipt_id": {"N": "1"},
+        "merchant_name": {"S": "First Merchant"},
+    }
+    second = {
+        "image_id": {"S": "image-2"},
+        "receipt_id": {"N": "1"},
+        "merchant_name": {"S": "Second Merchant"},
+    }
+
+    class PlaceOnlyClient:
+        def __init__(self):
+            self.calls = []
+
+        def query(self, **kwargs):
+            self.calls.append(kwargs)
+            if "ExclusiveStartKey" not in kwargs:
+                return {
+                    "Items": [first],
+                    "LastEvaluatedKey": {"PK": {"S": "next"}},
+                }
+            return {"Items": [second]}
+
+    client = PlaceOnlyClient()
+
+    places = list_all_places(client, "ReceiptsTable-dc5be22")
+
+    assert [place["merchant_name"] for place in places] == [
+        "First Merchant",
+        "Second Merchant",
+    ]
+    assert all(call["IndexName"] == "GSITYPE" for call in client.calls)
+    assert all(
+        call["ExpressionAttributeValues"][":entity_type"]
+        == {"S": "RECEIPT_PLACE"}
+        for call in client.calls
+    )
+    assert client.calls[1]["ExclusiveStartKey"] == {"PK": {"S": "next"}}
+
+
+def test_list_all_places_applies_limit_across_pages():
+    items = [
+        {
+            "image_id": {"S": f"image-{index}"},
+            "receipt_id": {"N": "1"},
+        }
+        for index in range(3)
+    ]
+
+    class PlaceOnlyClient:
+        def query(self, **kwargs):
+            assert kwargs["Limit"] == 2
+            return {
+                "Items": items,
+                "LastEvaluatedKey": {"PK": {"S": "unused"}},
+            }
+
+    places = list_all_places(
+        PlaceOnlyClient(), "ReceiptsTable-dc5be22", limit=2
+    )
+
+    assert [place["image_id"] for place in places] == ["image-0", "image-1"]

--- a/tests/test_list_receipt_places.py
+++ b/tests/test_list_receipt_places.py
@@ -29,30 +29,24 @@ def test_list_all_places_uses_canonical_place_pages():
         def __init__(self):
             self.calls = []
 
-        def query(self, **kwargs):
-            self.calls.append(kwargs)
-            if "ExclusiveStartKey" not in kwargs:
-                return {
-                    "Items": [first],
-                    "LastEvaluatedKey": {"PK": {"S": "next"}},
-                }
-            return {"Items": [second]}
+        def list_receipt_places_raw(self, limit=None, last_evaluated_key=None):
+            self.calls.append((limit, last_evaluated_key))
+            if last_evaluated_key is None:
+                return [first], {"PK": {"S": "next"}}
+            return [second], None
 
     client = PlaceOnlyClient()
 
-    places = list_all_places(client, "ReceiptsTable-dc5be22")
+    places = list_all_places(client)
 
     assert [place["merchant_name"] for place in places] == [
         "First Merchant",
         "Second Merchant",
     ]
-    assert all(call["IndexName"] == "GSITYPE" for call in client.calls)
-    assert all(
-        call["ExpressionAttributeValues"][":entity_type"]
-        == {"S": "RECEIPT_PLACE"}
-        for call in client.calls
-    )
-    assert client.calls[1]["ExclusiveStartKey"] == {"PK": {"S": "next"}}
+    assert client.calls == [
+        (None, None),
+        (None, {"PK": {"S": "next"}}),
+    ]
 
 
 def test_list_all_places_applies_limit_across_pages():
@@ -65,15 +59,15 @@ def test_list_all_places_applies_limit_across_pages():
     ]
 
     class PlaceOnlyClient:
-        def query(self, **kwargs):
-            assert kwargs["Limit"] == 2
-            return {
-                "Items": items,
-                "LastEvaluatedKey": {"PK": {"S": "unused"}},
-            }
+        def __init__(self):
+            self.calls = []
 
-    places = list_all_places(
-        PlaceOnlyClient(), "ReceiptsTable-dc5be22", limit=2
-    )
+        def list_receipt_places_raw(self, limit=None, last_evaluated_key=None):
+            self.calls.append((limit, last_evaluated_key))
+            return items, {"PK": {"S": "unused"}}
+
+    client = PlaceOnlyClient()
+    places = list_all_places(client, limit=2)
 
     assert [place["image_id"] for place in places] == ["image-0", "image-1"]
+    assert client.calls == [(2, None)]

--- a/tests/test_list_receipt_places_client.py
+++ b/tests/test_list_receipt_places_client.py
@@ -1,0 +1,43 @@
+"""list_receipt_places census uses the standard DynamoClient resolution
+(PR #1183 codex P2): region defaults + DYNAMODB_ENDPOINT_URL honored, and
+pagination flows through the data layer's raw census read."""
+
+from __future__ import annotations
+
+from scripts import list_receipt_places as lrp
+
+
+class _FakeClient:
+    table_name = "T"
+
+    def __init__(self, pages):
+        self.pages = pages
+        self.calls = []
+
+    def list_receipt_places_raw(self, limit=None, last_evaluated_key=None):
+        self.calls.append((limit, last_evaluated_key))
+        return self.pages[len(self.calls) - 1]
+
+
+def test_list_all_places_paginates_through_raw_census():
+    pages = [
+        ([{"merchant_name": {"S": "A"}}], {"k": {"S": "1"}}),
+        ([{"merchant_name": {"S": "B"}}], None),
+    ]
+    fake = _FakeClient(pages)
+    places = lrp.list_all_places(fake)
+    assert [p["merchant_name"] for p in places] == ["A", "B"]
+    assert fake.calls[0] == (None, None)
+    assert fake.calls[1] == (None, {"k": {"S": "1"}})
+
+
+def test_limit_short_circuits():
+    pages = [
+        (
+            [{"merchant_name": {"S": "A"}}, {"merchant_name": {"S": "B"}}],
+            {"k": {"S": "1"}},
+        )
+    ]
+    fake = _FakeClient(pages)
+    places = lrp.list_all_places(fake, limit=1)
+    assert len(places) == 1

--- a/tools/glyph-studio/py/glyphstudio/section_seeds.py
+++ b/tools/glyph-studio/py/glyphstudio/section_seeds.py
@@ -30,7 +30,7 @@ from .sections import normalize_stylescan_section, section_for_core_label
 # Same price cue stylescan uses to decide an unruled line is an item line.
 _PRICE_RE = re.compile(r"\d+\.\d{2}")
 
-# Canonical merchant name (ReceiptMetadata) -> stylescan rule slug. Convenience
+# Canonical ReceiptPlace merchant name -> stylescan rule slug. Convenience
 # defaults for the nine calibrated merchants; the CLI can override.
 MERCHANT_SLUGS: dict[str, str] = {
     "sprouts farmers market": "sprouts",
@@ -203,11 +203,15 @@ class SeedReport:
 
     @property
     def coverage(self) -> float:
-        return self.covered_words / self.total_words if self.total_words else 0.0
+        return (
+            self.covered_words / self.total_words if self.total_words else 0.0
+        )
 
     @property
     def agreement(self) -> float:
-        return self.both_agree / self.both_present if self.both_present else 0.0
+        return (
+            self.both_agree / self.both_present if self.both_present else 0.0
+        )
 
     def add_receipt(
         self,


### PR DESCRIPTION
## Summary

- Routes active merchant census, dedup, font-profile, glyph-atlas, and QA/rendering reads through `RECEIPT_PLACE`.
- Hardens legacy `ReceiptMetadata` conversion against stale secondary-index projections while keeping primary identity, type, and field validation strict.
- Documents `RECEIPT_PLACE` as the source of truth and preserves migration-only metadata workflows.

## Audit buckets

### (a) Re-pointed/removable reads

- Replaced the metadata listing script with a raw `GSITYPE` census using `TYPE = RECEIPT_PLACE`.
- Re-pointed the dedup dossier merchant census to raw place rows.
- Verified rendering paths use `get_receipt_places_by_merchant` and added place-only regression tests.
- Removed misleading legacy names from the QA state, monitoring output, and glyph seed comments.

### (b) Intentionally retained migration/reconcile paths

- Kept `reconcile_dev_to_prod.py`, `copy_dynamodb_dev_to_prod.py`, both place backfills, `fix_null_place_id_metadata.py`, cleanup, and symbol-migration compatibility functional.
- Annotated why each still touches legacy metadata. No mirror or backfill behavior was removed.

### (c) Legacy converter

- Allows stale GSI projections on historical metadata rows.
- Still validates `PK`, `SK`, `TYPE`, required fields, and field shapes.
- Deprecates active list and merchant read APIs in docstrings in favor of `ReceiptPlace`.

## Validation

- Black 26.5.1 and isort 8.0.1 checks pass for changed CI packages.
- 2,142 `receipt_dynamo` unit tests passed.
- 55 `ReceiptMetadata` integration tests passed.
- 163 `receipt_places` tests passed.
- 30 rendering, census, and backfill contract tests passed.
- The dedup dossier place-census regression test passed.
- Read-only dev verification against `ReceiptsTable-dc5be22`: 797 named `RECEIPT_PLACE` rows; merchant lookup and raw census succeeded. No production writes were performed.

Closes #1182


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Receipt-place listing now operates on canonical receipt-place records, with pagination, optional limits, summaries, and JSON export.
  - Deduplication dossiers now populate merchant names from raw receipt-place census data.

- **Bug Fixes**
  - Processing now tolerates drifted legacy secondary-index values without failing.
  - Improved handling of missing or inconsistent receipt identifiers during merchant lookups.

- **Documentation**
  - Expanded guidance on canonical fields, legacy exceptions, drifted legacy rows, and fix-place correction flow.
  - Updated script and monitoring wording to reflect “legacy metadata” vs current receipt-place state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->