### PR TITLE
Fix Costco render fidelity: phantom barcode, duplicate wordmark, per-section sizing

### DIFF
--- a/receipt_agent/receipt_agent/agents/label_evaluator/rendering/receipt_grid.py
+++ b/receipt_agent/receipt_agent/agents/label_evaluator/rendering/receipt_grid.py
@@ -298,6 +298,25 @@ def effective_row_sections(
         for i in range(first_item):
             if base[i] is None:
                 base[i] = "HEADER"
+
+    # Trailing FOOTER narration: the bottom legal / return-policy text
+    # ("Electronics Return", "Policy Information", survey blurbs) prints in
+    # a small condensed face on real receipts but renders at body size
+    # here. Mark that tail so a profile can size it down (section_scale
+    # FOOTER). Walk bottom-up over UNLABELED rows whose text is
+    # predominantly ALPHABETIC, stopping at the first labeled / price /
+    # digit-heavy row -- this captures the narration tail while never
+    # touching the prominent digit rows just above it (the boxed reverse
+    # date, the transaction line), which must stay at full size.
+    for i in range(len(rows) - 1, -1, -1):
+        if base[i] is not None or is_item_row(i):
+            break
+        text = "".join(w.text for w in rows[i])
+        letters = sum(ch.isalpha() for ch in text)
+        digits = sum(ch.isdigit() for ch in text)
+        if letters < 3 or letters <= digits:
+            break
+        base[i] = "FOOTER"
     return base
 
 

--- a/scripts/merchant_profiles.json
+++ b/scripts/merchant_profiles.json
@@ -1,10 +1,12 @@
 {
   "_comment": "Per-merchant synthetic-receipt render profile, keyed by exact merchant_name. Every field is optional; an absent field falls back to a generic default that reproduces pre-registry behavior. See docs/synthetic-receipt-rendering-generalization.md. typography.font is a token resolved to a bundled font path (PTMONO/VT323/B612); typography.bitmap_font and logo filenames resolve under $BITMATRIX_DIR. _comment keys are ignored by the loader.",
-  "_section_scale_note": "Per-merchant header size relative to body, from a measured + dual-reviewed (Claude pixel-measurement + codex) study of the real receipts. Real thermal printers shrink the header block (Epson Font A vs Font B); warehouse / natural-grocer formats print the header at body size. NONE use a different per-section typeface (size only). {} means uniform (no shrink). Default when unset: {\"HEADER\": 0.80}.",
+  "_section_scale_note": "Per-merchant header size relative to body, from a measured + dual-reviewed (Claude pixel-measurement + codex) study of the real receipts. Real thermal printers shrink the header block (Epson Font A vs Font B); warehouse / natural-grocer formats print the header at body size. NONE use a different per-section typeface (size only). {} means uniform (no shrink). Default when unset: {\"HEADER\": 0.80}. Keys map to the renderer's row sections (HEADER / BODY / TOTALS / PAYMENT / FOOTER); FOOTER targets the trailing alphabetic return-policy / legal narration.",
   "profiles": {
     "Costco Wholesale": {
-      "_comment": "Real font extracted from the bitMatrix-C2 chart: bitMatrix-C2 body + bitMatrix-C2-heavy heading. SELF-CHECKOUT prints as a large bold heading; the grand TOTAL prints reverse-video. condense 0.93: bitMatrix's widest-letter advance reads ~6% too airy vs the real char pitch (cell aspect 0.61 vs 0.57). Header measured ~= body (uniform).",
-      "section_scale": {},
+      "_comment": "Real font extracted from the bitMatrix-C2 chart: bitMatrix-C2 body + bitMatrix-C2-heavy heading. SELF-CHECKOUT prints as a large bold heading; the grand TOTAL prints reverse-video. condense 0.93: bitMatrix's widest-letter advance reads ~6% too airy vs the real char pitch (cell aspect 0.61 vs 0.57). Header measured ~= body (uniform). FOOTER 0.5: the bottom return-policy / legal narration (cap ~15.5px) prints at ~half body height (cap ~33px); STOREFRONT wordmark is the pasted logo, ADDRESS measures ~= body height.",
+      "section_scale": {
+        "FOOTER": 0.5
+      },
       "typography": {
         "bitmap_thin": 0.0,
         "bitmap_font": {
@@ -34,6 +36,7 @@
       "logo": "bitMatrix-C2_logo.png",
       "logo_anchor": {
         "phrases": [
+          "COSTCO",
           "EWHOLESALE",
           "WHOLESALE"
         ],

--- a/scripts/render_synthetic_receipts.py
+++ b/scripts/render_synthetic_receipts.py
@@ -2346,10 +2346,20 @@ def _overlay_qr_and_barcode(
         else:
             merged.append([s, e])
     # Blank vertical bands between printed content.
+    #
+    # Skip the LEADING gap (paper_top -> first printed content). Real
+    # receipts print the wordmark/logo at the very top and never a QR or
+    # barcode above it, but that band reads as blank here because the
+    # wordmark OCR tokens are dropped and depicted by the pasted logo
+    # instead. On a receipt whose tallest blank band is this header
+    # whitespace (e.g. Costco 0324604e), a blind "tallest band" stamp drops
+    # a phantom QR+barcode ABOVE the wordmark. Footer codes belong
+    # between/after printed content, so only interior and trailing
+    # whitespace are eligible.
     gaps: list[tuple[float, float]] = []
     prev = paper_top
     for s, e in merged:
-        if s - prev > 0:
+        if s - prev > 0 and prev > paper_top:
             gaps.append((prev, s))
         prev = max(prev, e)
     if paper_bottom - prev > 0:


### PR DESCRIPTION
## Summary

Three receipt-data-triggered fidelity bugs in the synthetic **Costco** render path (`scripts/render_synthetic_receipts.py` + the shared grid renderer `receipt_grid.py`), surfaced by rendering receipt `0324604e` vs the golden `57cb7f2c`. Both are Costco with **zero** `RECEIPT_BARCODE` entities, yet the golden rendered clean while `0324604e` showed a phantom code block and a doubled wordmark — so the triggers are in the receipt data + placement heuristics, not universal.

### 1. Phantom QR + barcode at the top
`_overlay_qr_and_barcode` fabricates a footer QR/barcode in the *tallest blank band*. When the wordmark OCR tokens are dropped (depicted by the pasted logo), the leading whitespace above the first printed row becomes the tallest band, so the blind heuristic stamped a phantom **QR at y=30 + barcode at y=174** above the wordmark on `0324604e`. The golden's tallest band was interior (y=2407, a plausible payment-area location), so it looked fine.
**Fix:** exclude the leading header gap (`prev > paper_top`) — real receipts never print a code above the wordmark. Golden's interior barcode is preserved; the phantom is gone.

### 2. Duplicated COSTCO wordmark
The Costco wordmark is two OCR lines (`COSTCO` / `WHOLESALE`); `logo_anchor.phrases` only matched `WHOLESALE`, so the `COSTCO` brand line rendered as small text **under** a logo that already depicts "COSTCO WHOLESALE" (present on *both* receipts; `0324604e`'s COSTCO is unlabeled, golden's is `MERCHANT_NAME`, so a label-based drop wouldn't work).
**Fix:** add `COSTCO` to `logo_anchor.phrases` so the full two-line lockup is suppressed and the logo spans both lines. The `y>=780` header guard keeps body/footer mentions safe.

### 3. Per-section sizing (empty `section_scale`)
Costco `section_scale` was `{}`, so the trailing return-policy / legal narration ("Electronics Return", "Policy Information") rendered at body size instead of ~half height (measured cap ~15.5px vs body ~33px).
**Fix:** `effective_row_sections` now classifies the trailing **alphabetic** narration tail as a `FOOTER` section (bottom-up walk that stops at the first labeled/price/digit-heavy row, so the boxed reverse-date and transaction lines stay full size), and Costco `section_scale` sets `FOOTER: 0.5`.

The renderer supports per-section **height** scale only (no per-section width). STOREFRONT (cap ~57) is the pasted **logo**, already large; ADDRESS (cap ~32) measures ≈ body height — its *perceived* smallness is width/condensation, which the engine can only do globally (`condense`). Documented as a known gap.

## Verification
- Re-rendered golden `57cb7f2c#1` and `0324604e#1` with the fixes.
- **Before/after/real sheet:** `.out/costco_fidelity_fix.png` (also `~/section_label_kickoff/costco_fidelity_fix.png`) — proves: no phantom barcode, single wordmark, footer narration sized down.
- **Golden non-regressed:** scorecard `3 blockers / 9 minors` unchanged; GlyphScore `34.0 → 33.8` (−0.2, from removing the duplicate COSTCO text — an improvement).
- **Cross-merchant safety:** Vons render **byte-identical** before/after (MAD 0.0) — the FOOTER classification is a no-op for merchants without a FOOTER scale.
- Codex code review: clean, no correctness bugs or regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Receipt rendering now identifies trailing narration as footer content and applies appropriate sizing.
  * Added improved footer scaling and logo anchoring for Costco Wholesale receipts.
* **Bug Fixes**
  * Prevented QR codes and barcodes from being placed in the blank header area instead of the receipt footer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->