### PR TITLE
Systemic render fixes: INVALID-label hygiene, wordmark bounds, multi-word headers, per-section condense

### DIFF
--- a/receipt_agent/receipt_agent/agents/label_evaluator/rendering/receipt_grid.py
+++ b/receipt_agent/receipt_agent/agents/label_evaluator/rendering/receipt_grid.py
@@ -269,11 +269,19 @@ def section_for_labels(
         str(lbl)[2:] if str(lbl)[:2] in ("B-", "I-") else str(lbl)
         for lbl in labels
     }
-    if not in_header_zone:
-        clean -= _POSITIONAL_HEADER_LABELS
+    # A word carrying both DATE/TIME and another section's label is that
+    # OTHER section's word wherever it sits (a payment-block "Credit
+    # Purchase 02/03/25" row must not be header-scaled by its date token):
+    # match with the positional labels excluded first, and only fall back to
+    # them inside the header zone.
+    non_positional = clean - _POSITIONAL_HEADER_LABELS
     for section, names in SECTION_LABELS.items():
-        if clean & names:
+        if non_positional & names:
             return section
+    if in_header_zone:
+        for section, names in SECTION_LABELS.items():
+            if clean & names:
+                return section
     return None
 
 
@@ -326,6 +334,13 @@ def effective_row_sections(
     # digit-heavy row -- this captures the narration tail while never
     # touching the prominent digit rows just above it (the boxed reverse
     # date, the transaction line), which must stay at full size.
+    #
+    # Only when a body boundary exists: on a receipt with no labels and no
+    # price rows (every label INVALID-filtered), the walk would otherwise
+    # consume EVERY alphabetic row -- header included -- and shrink the
+    # whole receipt to footer scale.
+    if first_item is None:
+        return base
     for i in range(len(rows) - 1, -1, -1):
         if base[i] is not None or is_item_row(i):
             break

--- a/receipt_agent/receipt_agent/agents/label_evaluator/rendering/receipt_grid.py
+++ b/receipt_agent/receipt_agent/agents/label_evaluator/rendering/receipt_grid.py
@@ -245,14 +245,32 @@ SECTION_LABELS: dict[str, frozenset[str]] = {
 }
 
 
-def section_for_labels(labels: Sequence[str] | None) -> str | None:
-    """The receipt section for a word's labels (strips B-/I- NER prefixes)."""
+# HEADER labels that are POSITIONAL: a date/time is only header typography
+# when it sits in the top of the paper -- the same tokens reprint in the
+# payment/transaction block low on the receipt at body size, and letting them
+# vote HEADER there mis-scales whole payment rows (Vons' "Credit Purchase
+# 02/03/25 18:20" row shrank to header scale once an invalid label stopped
+# out-voting them).
+_POSITIONAL_HEADER_LABELS = frozenset({"DATE", "TIME"})
+
+
+def section_for_labels(
+    labels: Sequence[str] | None, *, in_header_zone: bool = True
+) -> str | None:
+    """The receipt section for a word's labels (strips B-/I- NER prefixes).
+
+    ``in_header_zone=False`` (word known to sit low on the paper) ignores the
+    positional HEADER labels; the default keeps the legacy label-only
+    behavior for callers without geometry.
+    """
     if not labels:
         return None
     clean = {
         str(lbl)[2:] if str(lbl)[:2] in ("B-", "I-") else str(lbl)
         for lbl in labels
     }
+    if not in_header_zone:
+        clean -= _POSITIONAL_HEADER_LABELS
     for section, names in SECTION_LABELS.items():
         if clean & names:
             return section

--- a/receipt_agent/receipt_agent/agents/label_evaluator/rendering/receipt_grid.py
+++ b/receipt_agent/receipt_agent/agents/label_evaluator/rendering/receipt_grid.py
@@ -298,6 +298,25 @@ def effective_row_sections(
         for i in range(first_item):
             if base[i] is None:
                 base[i] = "HEADER"
+
+    # Trailing FOOTER narration: the bottom legal / return-policy text
+    # ("Electronics Return", "Policy Information", survey blurbs) prints in
+    # a small condensed face on real receipts but renders at body size
+    # here. Mark that tail so a profile can size it down (section_scale
+    # FOOTER). Walk bottom-up over UNLABELED rows whose text is
+    # predominantly ALPHABETIC, stopping at the first labeled / price /
+    # digit-heavy row -- this captures the narration tail while never
+    # touching the prominent digit rows just above it (the boxed reverse
+    # date, the transaction line), which must stay at full size.
+    for i in range(len(rows) - 1, -1, -1):
+        if base[i] is not None or is_item_row(i):
+            break
+        text = "".join(w.text for w in rows[i])
+        letters = sum(ch.isalpha() for ch in text)
+        digits = sum(ch.isdigit() for ch in text)
+        if letters < 3 or letters <= digits:
+            break
+        base[i] = "FOOTER"
     return base
 
 

--- a/receipt_agent/receipt_agent/agents/label_evaluator/rendering/receipt_renderer.py
+++ b/receipt_agent/receipt_agent/agents/label_evaluator/rendering/receipt_renderer.py
@@ -123,11 +123,14 @@ class RenderConfig:
     # per-token box-fitting path is used (see ``render_receipt``).
     grid_mode: bool = False
     # Per-section typography (real thermal receipts switch Font A / Font B per
-    # region). ``section_scale`` multiplies the body font size for a section
-    # (e.g. {"HEADER": 0.8}); ``section_font`` overrides the face for a section.
-    # BODY/TOTALS stay at scale 1.0 so they share the amount column. None = the
-    # whole receipt uses one size/font.
-    section_scale: Mapping[str, float] | None = None
+    # region). A ``section_scale`` entry is either a bare float that multiplies
+    # the body font size (e.g. {"HEADER": 0.8}) or a mapping
+    # ``{"height_scale": float, "condense": float}`` whose condense multiplies
+    # the global glyph condense for that section only (real prints switch to a
+    # narrower face per region, not just a smaller one). ``section_font``
+    # overrides the face for a section. BODY/TOTALS stay at scale 1.0 so they
+    # share the amount column. None = the whole receipt uses one size/font.
+    section_scale: Mapping[str, Any] | None = None
     # Measured per-section style rules (Glyph Studio stylemap); None = off.
     stylemap: Mapping[str, Any] | None = None
     # When a list is supplied, every drawn word appends its EXACT placement
@@ -217,6 +220,21 @@ class RenderConfig:
     # without a measured entry fall back to the stylemap rules.
     face_source: str = "stylemap"
     row_faces: Mapping[str, Any] | None = None
+
+
+def section_style(value: Any) -> tuple[float, float]:
+    """``(height_scale, condense)`` from one ``section_scale`` entry.
+
+    A bare number is the legacy height-only scale (condense 1.0, so every
+    existing profile renders byte-identically); a mapping may add a
+    per-section ``condense`` that multiplies the global glyph condense.
+    """
+    if isinstance(value, Mapping):
+        return (
+            float(value.get("height_scale", 1.0)),
+            float(value.get("condense", 1.0)),
+        )
+    return float(value), 1.0
 
 
 def render_receipt(
@@ -480,6 +498,12 @@ def _render_grid(
         if px is None:
             continue
         left, top, right, bottom = px
+        # The top ~third of the paper is the only place DATE/TIME mean header
+        # typography; lower on the paper they are transaction-block reprints
+        # at body size (see _POSITIONAL_HEADER_LABELS).
+        in_header_zone = (top + bottom) / 2.0 < (
+            config.margin + 0.35 * inner_h
+        )
         grid_words.append(
             GridWord(
                 left=left,
@@ -490,7 +514,9 @@ def _render_grid(
                 ink=_ink_for(word, config),
                 word_index=word.get("_box_index"),
                 source_line=_source_line_id(word),
-                section=section_for_labels(word.get("labels")),
+                section=section_for_labels(
+                    word.get("labels"), in_header_zone=in_header_zone
+                ),
             )
         )
     # Bitmap (glyph-atlas) font: the merchant's actual letterforms. cap_px is the
@@ -750,10 +776,14 @@ def _render_grid(
         center_to = _center_target(line)
         fpath = section_font.get(sect) if sect else None
         if is_heading:
-            sc = float(hscale)
+            sc, sect_cond = float(hscale), 1.0
             bf_row = bmf_heavy if bmf else None
         else:
-            sc = float(section_scale.get(sect, 1.0)) if sect else 1.0
+            sc, sect_cond = (
+                section_style(section_scale.get(sect, 1.0))
+                if sect
+                else (1.0, 1.0)
+            )
             bf_row = bmf
         # Measured stylemap pass (no-op when config.stylemap is None): size
         # scale multiplies the row cap; bold double-strikes; underline draws
@@ -792,7 +822,7 @@ def _render_grid(
         sm_extra = bool(
             sm_style and (sm_style["bold"] or sm_style["underline"])
         )
-        if sc == 1.0 and not fpath and not sm_extra:
+        if sc == 1.0 and sect_cond == 1.0 and not fpath and not sm_extra:
             run = _run_layout(line, center_to)
             if run is not None:
                 text, anchor, x, target_w = run
@@ -837,7 +867,11 @@ def _render_grid(
                 box_sink=config.box_sink,
             )
             continue
-        key = (fpath, sc, bf_row is bmf_heavy)
+        # Per-section condense multiplies the global condense for this row
+        # only (sect_cond is 1.0 everywhere a profile uses the legacy float
+        # schema, so the effective condense equals config.condense exactly).
+        eff_cond = float(config.condense) * sect_cond
+        key = (fpath, sc, sect_cond, bf_row is bmf_heavy)
         cached = row_cache.get(key)
         if cached is None:
             row_font_px = max(6, int(round(sizing.font_px * sc)))
@@ -847,12 +881,10 @@ def _render_grid(
                 # Bitmap pitch comes from the atlas advance at the scaled cap, NOT
                 # the TTF advance (the two differ -> mis-spaced enlarged rows).
                 row_cap = max(6, int(round((cap_px or row_font_px) * sc)))
-                row_adv = bf_row.advance(row_cap) * float(config.condense)
+                row_adv = bf_row.advance(row_cap) * eff_cond
             else:
                 row_cap = None
-                row_adv = glyph_advance(draw, row_font) * float(
-                    config.condense
-                )
+                row_adv = glyph_advance(draw, row_font) * eff_cond
             row_spec = GridSpec(
                 cell_w=row_adv,
                 cell_h=spec.cell_h,
@@ -862,8 +894,9 @@ def _render_grid(
             row_cache[key] = (row_spec, row_font, row_cap)
             cached = row_cache[key]
         row_spec, row_font, row_cap = cached
-        # Lane only applies when the row shares the base cell grid (scale 1.0).
-        lane = amount_lane if sc == 1.0 else None
+        # Lane only applies when the row shares the base cell grid (scale 1.0
+        # AND base condense -- a per-section condense changes the cell width).
+        lane = amount_lane if sc == 1.0 and sect_cond == 1.0 else None
         cp = (
             row_cap
             if row_cap
@@ -895,7 +928,7 @@ def _render_grid(
                     line[0].ink,
                     anchor=anchor,
                     stroke=config.stroke,
-                    condense=config.condense,
+                    condense=eff_cond,
                     condense_glyphs=config.condense_glyphs,
                     bitmap_font=bf_row,
                     cap_px=cp,
@@ -914,7 +947,7 @@ def _render_grid(
                     row_font,
                     amount_lane=lane,
                     stroke=config.stroke,
-                    condense=config.condense,
+                    condense=eff_cond,
                     condense_glyphs=config.condense_glyphs,
                     bitmap_font=bf_row,
                     cap_px=cp,

--- a/receipt_agent/receipt_agent/agents/label_evaluator/rendering/receipt_renderer.py
+++ b/receipt_agent/receipt_agent/agents/label_evaluator/rendering/receipt_renderer.py
@@ -222,19 +222,33 @@ class RenderConfig:
     row_faces: Mapping[str, Any] | None = None
 
 
+def _clamped_scale(value: Any, lo: float, hi: float) -> float:
+    """Profile values are an external boundary: clamp to finite, sane range."""
+    try:
+        scale = float(value)
+    except (TypeError, ValueError):
+        return 1.0
+    if not math.isfinite(scale):
+        return 1.0
+    return max(lo, min(hi, scale))
+
+
 def section_style(value: Any) -> tuple[float, float]:
     """``(height_scale, condense)`` from one ``section_scale`` entry.
 
     A bare number is the legacy height-only scale (condense 1.0, so every
     existing profile renders byte-identically); a mapping may add a
     per-section ``condense`` that multiplies the global glyph condense.
+    Values are clamped to finite, positive ranges -- a zero/NaN condense
+    from a hand-edited profile must degrade to a no-op, not a
+    ZeroDivisionError deep in token placement.
     """
     if isinstance(value, Mapping):
         return (
-            float(value.get("height_scale", 1.0)),
-            float(value.get("condense", 1.0)),
+            _clamped_scale(value.get("height_scale", 1.0), 0.25, 4.0),
+            _clamped_scale(value.get("condense", 1.0), 0.2, 2.0),
         )
-    return float(value), 1.0
+    return _clamped_scale(value, 0.25, 4.0), 1.0
 
 
 def render_receipt(
@@ -775,14 +789,18 @@ def _render_grid(
         prev_text = row_text
         center_to = _center_target(line)
         fpath = section_font.get(sect) if sect else None
+        # A row's section condense applies whether or not the row is an
+        # enlarged display heading -- the heading scale overrides HEIGHT
+        # only, the section's face width stays in force.
+        sect_cond = (
+            section_style(section_scale.get(sect, 1.0))[1] if sect else 1.0
+        )
         if is_heading:
-            sc, sect_cond = float(hscale), 1.0
+            sc = float(hscale)
             bf_row = bmf_heavy if bmf else None
         else:
-            sc, sect_cond = (
-                section_style(section_scale.get(sect, 1.0))
-                if sect
-                else (1.0, 1.0)
+            sc = (
+                section_style(section_scale.get(sect, 1.0))[0] if sect else 1.0
             )
             bf_row = bmf
         # Measured stylemap pass (no-op when config.stylemap is None): size

--- a/receipt_agent/receipt_agent/agents/label_evaluator/rendering/receipt_stylemap.py
+++ b/receipt_agent/receipt_agent/agents/label_evaluator/rendering/receipt_stylemap.py
@@ -177,11 +177,37 @@ def _merchant_key(stylemap: Mapping[str, Any] | None) -> str | None:
     return None
 
 
+# Department qualifiers that prefix a section token on real category headers
+# ("REG DELI", "SERVICE DELI", "HOT BAKERY"). Kept to an explicit allowlist so
+# a product description that happens to END in a department word ("RED WINE",
+# "GROUND MEAT") never picks up header styling.
+_SECTION_QUALIFIERS = {"REG", "SERVICE", "SVC", "HOT", "FRESH", "DEPT"}
+
+
+def _is_section_header(compact: str) -> bool:
+    """True for a department/category header row.
+
+    Exact token match first ("GROCERY", "HEALTH AND BEAUTY"); then a
+    QUALIFIED header -- an allowlisted qualifier followed by a department
+    token ("REG DELI"), which real prints style like any other category
+    header.
+    """
+    text = " ".join(compact.upper().strip(" :").split())
+    if text in SECTION_TOKENS:
+        return True
+    words = text.split()
+    return (
+        len(words) == 2
+        and words[0] in _SECTION_QUALIFIERS
+        and words[1] in SECTION_TOKENS
+    )
+
+
 def classify_row(text: str, merchant: str | None = None) -> str:
     compact = text.strip()
     if _BARCODE_RE.match(compact.replace(" ", "")):
         return "barcode_caption"
-    if compact.upper().strip(":") in SECTION_TOKENS:
+    if _is_section_header(compact):
         return "section_header"
     rules = _MERCHANT_RULES.get((merchant or "").lower(), _RULES)
     for name, rx in rules:

--- a/receipt_agent/receipt_agent/agents/label_evaluator/rendering/receipt_stylemap.py
+++ b/receipt_agent/receipt_agent/agents/label_evaluator/rendering/receipt_stylemap.py
@@ -196,10 +196,12 @@ def _is_section_header(compact: str) -> bool:
     if text in SECTION_TOKENS:
         return True
     words = text.split()
+    # Multi-word departments keep working under a qualifier
+    # ("FRESH HEALTH AND BEAUTY"): compare the full remainder, not word[1].
     return (
-        len(words) == 2
+        len(words) >= 2
         and words[0] in _SECTION_QUALIFIERS
-        and words[1] in SECTION_TOKENS
+        and " ".join(words[1:]) in SECTION_TOKENS
     )
 
 

--- a/receipt_agent/tests/test_receipt_stylemap.py
+++ b/receipt_agent/tests/test_receipt_stylemap.py
@@ -7,7 +7,9 @@ from receipt_agent.agents.label_evaluator.rendering.receipt_stylemap import (
 
 
 def test_innout_row_classification_sections():
-    assert classify_row("IN-N-OUT WESTLAKE VILLAGE", "innout") == "store_header"
+    assert (
+        classify_row("IN-N-OUT WESTLAKE VILLAGE", "innout") == "store_header"
+    )
     assert classify_row("Cashier: ORDERTAKER 1", "innout") == "transaction"
     assert classify_row("Amount Due $27.71", "innout") == "total_line"
     assert classify_row("AUTH AMT: $27.71", "innout") == "total_line"
@@ -141,3 +143,25 @@ def test_measured_row_style_clamps_malformed_scale():
             "ROW",
         )
         assert style["scale"] == expect
+
+
+def test_multiword_category_headers_classify_as_section_header():
+    # Real prints qualify a department ("REG DELI", "SERVICE DELI") and style
+    # the row exactly like any other category header.
+    assert classify_row("REG DELI") == "section_header"
+    assert classify_row("SERVICE DELI") == "section_header"
+    assert classify_row("REG DELI:") == "section_header"
+    assert classify_row("  reg   deli  ") == "section_header"
+
+
+def test_qualified_header_never_fires_on_item_rows():
+    # Only an allowlisted qualifier + department token is a header; product
+    # descriptions ending in a department word must never pick up header
+    # styling, with or without a price on the row.
+    assert classify_row("TURKEY DELI SANDWICH") != "section_header"
+    assert classify_row("HOT DELI ITEM 2.99") != "section_header"
+    assert classify_row("DELI SLICED HAM 1LB") != "section_header"
+    assert classify_row("THE VERY BEST REG DELI") != "section_header"
+    assert classify_row("RED WINE") != "section_header"
+    assert classify_row("GROUND MEAT") != "section_header"
+    assert classify_row("ORGANIC BODY") != "section_header"

--- a/receipt_agent/tests/test_receipt_stylemap.py
+++ b/receipt_agent/tests/test_receipt_stylemap.py
@@ -165,3 +165,10 @@ def test_qualified_header_never_fires_on_item_rows():
     assert classify_row("RED WINE") != "section_header"
     assert classify_row("GROUND MEAT") != "section_header"
     assert classify_row("ORGANIC BODY") != "section_header"
+
+
+def test_qualified_multiword_department_tokens_match():
+    assert classify_row("FRESH HEALTH AND BEAUTY") == "section_header"
+    assert classify_row("DEPT PATIO & OUTDOOR DECOR") == "section_header"
+    # A non-token remainder still never matches.
+    assert classify_row("FRESH HEALTH AND WELLNESS") != "section_header"

--- a/receipt_agent/tests/test_section_style.py
+++ b/receipt_agent/tests/test_section_style.py
@@ -1,0 +1,43 @@
+"""section_scale schema: legacy float vs {height_scale, condense} mapping."""
+
+from receipt_agent.agents.label_evaluator.rendering.receipt_renderer import (
+    section_style,
+)
+
+
+def test_legacy_float_is_height_only():
+    assert section_style(0.8) == (0.8, 1.0)
+
+
+def test_mapping_carries_height_and_condense():
+    assert section_style({"height_scale": 0.9, "condense": 0.85}) == (
+        0.9,
+        0.85,
+    )
+
+
+def test_mapping_defaults_missing_keys_to_noop():
+    assert section_style({"condense": 0.85}) == (1.0, 0.85)
+    assert section_style({"height_scale": 0.9}) == (0.9, 1.0)
+    assert section_style({}) == (1.0, 1.0)
+
+
+def test_date_time_header_vote_is_positional():
+    from receipt_agent.agents.label_evaluator.rendering.receipt_grid import (
+        section_for_labels,
+    )
+
+    # In the header zone (default) DATE/TIME are header typography.
+    assert section_for_labels(["DATE", "TIME"]) == "HEADER"
+    # Low on the paper they are transaction-block reprints, not headers.
+    assert section_for_labels(["DATE"], in_header_zone=False) is None
+    assert section_for_labels(["TIME"], in_header_zone=False) is None
+    # Non-positional header labels still vote HEADER anywhere.
+    assert (
+        section_for_labels(["MERCHANT_NAME"], in_header_zone=False) == "HEADER"
+    )
+    # A word with another section's label keeps that section.
+    assert (
+        section_for_labels(["DATE", "PAYMENT_METHOD"], in_header_zone=False)
+        == "PAYMENT"
+    )

--- a/receipt_agent/tests/test_section_style.py
+++ b/receipt_agent/tests/test_section_style.py
@@ -41,3 +41,47 @@ def test_date_time_header_vote_is_positional():
         section_for_labels(["DATE", "PAYMENT_METHOD"], in_header_zone=False)
         == "PAYMENT"
     )
+
+
+def test_section_style_clamps_malformed_values():
+    for bad in (0, -1.0, float("nan"), float("inf"), None, "junk"):
+        h, c = section_style({"height_scale": bad, "condense": bad})
+        assert 0.25 <= h <= 4.0
+        assert 0.2 <= c <= 2.0
+    assert section_style({"condense": 0}) == (1.0, 0.2)
+    assert section_style(float("nan")) == (1.0, 1.0)
+
+
+def test_unlabeled_priceless_receipt_never_becomes_all_footer():
+    from receipt_agent.agents.label_evaluator.rendering.receipt_grid import (
+        GridWord,
+        effective_row_sections,
+    )
+
+    def row(text, top):
+        return [
+            GridWord(
+                left=10.0,
+                top=top,
+                right=200.0,
+                bottom=top + 20.0,
+                text=text,
+                ink=(0, 0, 0),
+            )
+        ]
+
+    rows = [row("GELSONS MARKET", 10.0), row("THANK YOU", 40.0)]
+    assert effective_row_sections(rows) == [None, None]
+
+
+def test_non_positional_label_beats_date_time_everywhere():
+    from receipt_agent.agents.label_evaluator.rendering.receipt_grid import (
+        section_for_labels,
+    )
+
+    # Even in the header zone, a payment label on the word wins.
+    assert section_for_labels(["DATE", "PAYMENT_METHOD"]) == "PAYMENT"
+    assert (
+        section_for_labels(["DATE", "PAYMENT_METHOD"], in_header_zone=False)
+        == "PAYMENT"
+    )

--- a/scripts/merchant_profiles.json
+++ b/scripts/merchant_profiles.json
@@ -1,10 +1,12 @@
 {
   "_comment": "Per-merchant synthetic-receipt render profile, keyed by exact merchant_name. Every field is optional; an absent field falls back to a generic default that reproduces pre-registry behavior. See docs/synthetic-receipt-rendering-generalization.md. typography.font is a token resolved to a bundled font path (PTMONO/VT323/B612); typography.bitmap_font and logo filenames resolve under $BITMATRIX_DIR. _comment keys are ignored by the loader.",
-  "_section_scale_note": "Per-merchant header size relative to body, from a measured + dual-reviewed (Claude pixel-measurement + codex) study of the real receipts. Real thermal printers shrink the header block (Epson Font A vs Font B); warehouse / natural-grocer formats print the header at body size. NONE use a different per-section typeface (size only). {} means uniform (no shrink). Default when unset: {\"HEADER\": 0.80}.",
+  "_section_scale_note": "Per-merchant header size relative to body, from a measured + dual-reviewed (Claude pixel-measurement + codex) study of the real receipts. Real thermal printers shrink the header block (Epson Font A vs Font B); warehouse / natural-grocer formats print the header at body size. NONE use a different per-section typeface (size only). {} means uniform (no shrink). Default when unset: {\"HEADER\": 0.80}. Keys map to the renderer's row sections (HEADER / BODY / TOTALS / PAYMENT / FOOTER); FOOTER targets the trailing alphabetic return-policy / legal narration.",
   "profiles": {
     "Costco Wholesale": {
-      "_comment": "Real font extracted from the bitMatrix-C2 chart: bitMatrix-C2 body + bitMatrix-C2-heavy heading. SELF-CHECKOUT prints as a large bold heading; the grand TOTAL prints reverse-video. condense 0.93: bitMatrix's widest-letter advance reads ~6% too airy vs the real char pitch (cell aspect 0.61 vs 0.57). Header measured ~= body (uniform).",
-      "section_scale": {},
+      "_comment": "Real font extracted from the bitMatrix-C2 chart: bitMatrix-C2 body + bitMatrix-C2-heavy heading. SELF-CHECKOUT prints as a large bold heading; the grand TOTAL prints reverse-video. condense 0.93: bitMatrix's widest-letter advance reads ~6% too airy vs the real char pitch (cell aspect 0.61 vs 0.57). Header measured ~= body (uniform). FOOTER 0.5: the bottom return-policy / legal narration (cap ~15.5px) prints at ~half body height (cap ~33px); STOREFRONT wordmark is the pasted logo, ADDRESS measures ~= body height.",
+      "section_scale": {
+        "FOOTER": 0.5
+      },
       "typography": {
         "bitmap_thin": 0.0,
         "bitmap_font": {
@@ -34,6 +36,7 @@
       "logo": "bitMatrix-C2_logo.png",
       "logo_anchor": {
         "phrases": [
+          "COSTCO",
           "EWHOLESALE",
           "WHOLESALE"
         ],

--- a/scripts/render_synthetic_receipts.py
+++ b/scripts/render_synthetic_receipts.py
@@ -70,6 +70,13 @@ def _real_receipt_dict(export: dict, receipt_id: int) -> dict:
     for lbl in export.get("receipt_word_labels", []) or []:
         if lbl.get("receipt_id") != receipt_id:
             continue
+        # A label judged INVALID is not on the printed receipt; feeding it to
+        # the renderer mis-sections real words (an INVALID MERCHANT_NAME on an
+        # address word lets the logo wordmark absorb the address line, whose
+        # band the logo overlay then background-erases). Unreviewed labels
+        # (no status / PENDING / NEEDS_REVIEW) stay.
+        if str(lbl.get("validation_status") or "").upper() == "INVALID":
+            continue
         key = (lbl.get("line_id"), lbl.get("word_id"))
         label_index.setdefault(key, []).append(str(lbl.get("label") or ""))
 
@@ -1691,6 +1698,7 @@ def _render_cached_hybrid(
         config=config,
         coord_max=1000.0,
         reserved=stamped_bands,
+        logo_bbox=logo_bbox,
     )
     # Content-derived seed so a given receipt renders the SAME paper texture
     # regardless of the output path. Keying on the filename made scorecard
@@ -2292,6 +2300,7 @@ def _overlay_qr_and_barcode(
     config: RenderConfig,
     coord_max: float,
     reserved: list[tuple[float, float]] | None = None,
+    logo_bbox: list[float] | None = None,
 ) -> None:
     """Stamp a REAL QR symbol and a REAL 1D barcode in the blank footer region.
 
@@ -2334,6 +2343,20 @@ def _overlay_qr_and_barcode(
             inner_h=inner_h,
         )
         intervals.append((min(t, b), max(t, b)))
+    # Treat the pasted logo footprint as occupied. Its wordmark/badge OCR
+    # tokens were dropped so the logo could depict them, which leaves that band
+    # looking blank here -- a blind "tallest band" stamp would drop a phantom
+    # QR/barcode right where the logo is (The Stand's header badge). The logo
+    # is real content; exclude its band.
+    if logo_bbox is not None:
+        _, lt, _, lb = _to_pixel_box(
+            logo_bbox,
+            coord_max=coord_max,
+            margin=config.margin,
+            inner_w=inner_w,
+            inner_h=inner_h,
+        )
+        intervals.append((min(lt, lb), max(lt, lb)))
     # Treat already-stamped in-body barcode bands as occupied so we don't stack a
     # redundant second barcode in the same gap.
     for r0, r1 in reserved or []:
@@ -2356,10 +2379,22 @@ def _overlay_qr_and_barcode(
     # a phantom QR+barcode ABOVE the wordmark. Footer codes belong
     # between/after printed content, so only interior and trailing
     # whitespace are eligible.
+    # Real receipts never print a QR/barcode in the header/upper region (that
+    # is the wordmark, date and first items); footer codes live in
+    # interior-payment or trailing whitespace. A tall header gap -- e.g. the
+    # whitespace between a "Dine-In" line and a pasted header badge (The
+    # Stand) -- must not win the "tallest band" pick, so drop any gap whose
+    # center sits in the top third of the paper. Costco's legitimate interior
+    # barcode (~0.80 of paper) is well below this cutoff and unaffected.
+    header_cutoff = paper_top + 0.33 * (paper_bottom - paper_top)
     gaps: list[tuple[float, float]] = []
     prev = paper_top
     for s, e in merged:
-        if s - prev > 0 and prev > paper_top:
+        if (
+            s - prev > 0
+            and prev > paper_top
+            and (prev + s) / 2.0 >= header_cutoff
+        ):
             gaps.append((prev, s))
         prev = max(prev, e)
     if paper_bottom - prev > 0:
@@ -2512,10 +2547,14 @@ def _phrase_logo_placement(
         return None
     drop, boxes = [], []
     for words in _receipt_lines(receipt):
-        text = _normalize_phrase(
-            " ".join(str(w.get("text") or "") for w in words)
-        )
-        if not text or not any(p in text for p in norm):
+        # Match a phrase only when it spans a CONTIGUOUS run of whole word
+        # tokens on the line -- so multi-word slogans still match
+        # ("HOWDOERS" = "HOW"+"DOERS") but a short brand phrase never fires on
+        # an unrelated word that merely contains it ("TREE" must not match
+        # "STREET"). A whole-line substring test conflates the two.
+        toks = [_normalize_phrase(w.get("text") or "") for w in words]
+        toks = [t for t in toks if t]
+        if not toks or not _phrase_run_match(toks, norm):
             continue
         # This anchors a TOP-of-receipt lockup; short brand phrases ("VONS")
         # also match footer URLs / body mentions, which unions a bogus
@@ -2562,6 +2601,31 @@ def _normalize_phrase(text: str) -> str:
     return "".join(ch for ch in str(text).upper() if ch.isalnum())
 
 
+def _phrase_run_match(tokens: list[str], norm_phrases: list[str]) -> bool:
+    """True when a normalized phrase equals a contiguous run of word tokens.
+
+    A phrase matches only if it can be assembled from whole, adjacent tokens
+    (``"HOWDOERS"`` == ``"HOW"`` + ``"DOERS"``); a phrase that is merely a
+    substring of one token (``"TREE"`` inside ``"STREET"``) does NOT match.
+    This keeps multi-word slogan anchors working while stopping short brand
+    phrases from firing on unrelated words.
+    """
+    n = len(tokens)
+    # Stop each run once it can no longer equal any phrase (longest phrase's
+    # length), so a configured phrase longer than any fixed cap still matches
+    # while runaway concatenation is still bounded.
+    max_len = max((len(p) for p in norm_phrases), default=0)
+    for i in range(n):
+        acc = ""
+        for j in range(i, n):
+            acc += tokens[j]
+            if acc in norm_phrases:
+                return True
+            if len(acc) > max_len:
+                break
+    return False
+
+
 def _flatten_receipt_words(receipt: dict) -> list[dict]:
     """Return the receipt's word dicts (originals, for identity matching)."""
     words = receipt.get("words")
@@ -2593,12 +2657,26 @@ def _logo_wordmark_words(
     logo_line = _cached_logo_line(receipt)
     if not logo_line:
         return None
-    band = _union_bbox(
-        [word["bbox"] for word in logo_line if word.get("bbox")]
-    )
+
+    def _foreign(word: dict) -> bool:
+        """True when the word carries any non-MERCHANT_NAME label.
+
+        Such a word is real printed content (an address line the OCR banded
+        onto the brand row, a phone number under it) -- suppressing it and
+        folding it into the logo bbox lets the logo overlay background-erase
+        it (the Gelson's address-eraser). Better to under-absorb than to
+        erase. Unlabeled words stay eligible: the brand-line detector matches
+        wordmark text without labels (e.g. Sprouts).
+        """
+        labels = {_label_name(label) for label in (word.get("labels") or [])}
+        return bool(labels - {"MERCHANT_NAME"})
+
+    # Seed only with the brand line's own wordmark words -- a foreign-labeled
+    # word sharing the detected line must keep rendering as text.
+    cluster = [word for word in logo_line if not _foreign(word)]
+    band = _union_bbox([word["bbox"] for word in cluster if word.get("bbox")])
     if band is None:
         return None
-    cluster = list(logo_line)
     cluster_ids = {id(word) for word in cluster}
 
     # OCR bboxes may be bottom-origin (y0 > y1), so read spans via min/max rather
@@ -2618,11 +2696,15 @@ def _logo_wordmark_words(
     # count as the logo's subtitle, so far-away MERCHANT_NAME tokens (e.g. a
     # footer ".com" wordmark) are not absorbed.
     gap = line_h
+
     candidates = [
         word
         for word in _flatten_receipt_words(receipt)
-        if id(word) not in cluster_ids
-        and word.get("bbox")
+        if id(word) not in cluster_ids and word.get("bbox")
+        # Off-line absorption additionally requires a MERCHANT_NAME label
+        # (subtitle words like WHOLESALE); pure-unlabeled words elsewhere on
+        # the receipt are unrelated.
+        and not _foreign(word)
         and any(
             _label_name(label) == "MERCHANT_NAME"
             for label in (word.get("labels") or [])

--- a/scripts/render_synthetic_receipts.py
+++ b/scripts/render_synthetic_receipts.py
@@ -2346,10 +2346,20 @@ def _overlay_qr_and_barcode(
         else:
             merged.append([s, e])
     # Blank vertical bands between printed content.
+    #
+    # Skip the LEADING gap (paper_top -> first printed content). Real
+    # receipts print the wordmark/logo at the very top and never a QR or
+    # barcode above it, but that band reads as blank here because the
+    # wordmark OCR tokens are dropped and depicted by the pasted logo
+    # instead. On a receipt whose tallest blank band is this header
+    # whitespace (e.g. Costco 0324604e), a blind "tallest band" stamp drops
+    # a phantom QR+barcode ABOVE the wordmark. Footer codes belong
+    # between/after printed content, so only interior and trailing
+    # whitespace are eligible.
     gaps: list[tuple[float, float]] = []
     prev = paper_top
     for s, e in merged:
-        if s - prev > 0:
+        if s - prev > 0 and prev > paper_top:
             gaps.append((prev, s))
         prev = max(prev, e)
     if paper_bottom - prev > 0:

--- a/scripts/render_synthetic_receipts.py
+++ b/scripts/render_synthetic_receipts.py
@@ -2665,15 +2665,45 @@ def _logo_wordmark_words(
         onto the brand row, a phone number under it) -- suppressing it and
         folding it into the logo bbox lets the logo overlay background-erase
         it (the Gelson's address-eraser). Better to under-absorb than to
-        erase. Unlabeled words stay eligible: the brand-line detector matches
-        wordmark text without labels (e.g. Sprouts).
+        erase.
         """
         labels = {_label_name(label) for label in (word.get("labels") or [])}
         return bool(labels - {"MERCHANT_NAME"})
 
-    # Seed only with the brand line's own wordmark words -- a foreign-labeled
-    # word sharing the detected line must keep rendering as text.
-    cluster = [word for word in logo_line if not _foreign(word)]
+    def _merchant_labeled(word: dict) -> bool:
+        return any(
+            _label_name(label) == "MERCHANT_NAME"
+            for label in (word.get("labels") or [])
+        )
+
+    # Seed only with the brand line's own WORDMARK words. An unlabeled word on
+    # the detected line is NOT automatically wordmark content: filtering an
+    # INVALID label turns an address token into exactly such an unlabeled
+    # word (GELSONS[MERCHANT_NAME] WESTLAKE[] on one OCR row), and seeding it
+    # re-opens the address-eraser the label filter closed. So: when the line
+    # carries MERCHANT_NAME labels, trust exactly those words; when it was
+    # detected purely by brand TEXT (no labels anywhere -- Sprouts), keep the
+    # words whose normalized text is part of the merchant name; only with no
+    # merchant name to check does the whole non-foreign line count.
+    labeled_seed = [
+        word
+        for word in logo_line
+        if _merchant_labeled(word) and not _foreign(word)
+    ]
+    if labeled_seed:
+        cluster = labeled_seed
+    else:
+        brand = _normalize_phrase(receipt.get("merchant_name") or "")
+        nonforeign = [word for word in logo_line if not _foreign(word)]
+        if brand:
+            cluster = [
+                word
+                for word in nonforeign
+                if _normalize_phrase(word.get("text") or "")
+                and _normalize_phrase(word.get("text") or "") in brand
+            ]
+        else:
+            cluster = nonforeign
     band = _union_bbox([word["bbox"] for word in cluster if word.get("bbox")])
     if band is None:
         return None

--- a/synthesis_loop/glyph_review.py
+++ b/synthesis_loop/glyph_review.py
@@ -148,6 +148,9 @@ def receipt(
         (l.line_id, l.word_id): l.label
         for l in d.receipt_word_labels
         if l.receipt_id == receipt_id
+        # INVALID labels are not on the printed receipt; keep unreviewed ones
+        # (same policy as _real_receipt_dict in render_synthetic_receipts).
+        and str(getattr(l, "validation_status", "") or "").upper() != "INVALID"
     }
     words = [
         {
@@ -302,7 +305,9 @@ def _maybe_glyphscore(syn, words) -> dict | None:
             f"{doc['n_words_segmented']}/{doc['n_words']} words)"
         )
         return doc
-    except Exception as e:  # noqa: BLE001 - opt-in axis must never break review
+    except (
+        Exception
+    ) as e:  # noqa: BLE001 - opt-in axis must never break review
         print(f"glyphscore skipped: {e}", file=sys.stderr)
         return None
 

--- a/synthesis_loop/render_regression_baseline.json
+++ b/synthesis_loop/render_regression_baseline.json
@@ -1,0 +1,6 @@
+{
+  "costco_golden": "966a680f614c30bf6116c33884b05f408c8cd772bda1239695c94fd327ed93bc",
+  "costco_new": "8c92670602cfcc62d47ce5e54c0469837c3a8ca7b7d7d5976cf74aa3b11ec43a",
+  "sprouts": "d19f03193d9b808e6e89e022ebdd5daba60e75ff4b526051321e146e2807028b",
+  "vons_golden": "52a7ffdf1951d5046e4aaf4aaef7caa7ea27a9ed0d7f5151c8ca5ee22fdd9b47"
+}

--- a/synthesis_loop/render_regression_guard.py
+++ b/synthesis_loop/render_regression_guard.py
@@ -17,6 +17,13 @@ renderer regressed.
 Usage:
   render_regression_guard.py capture <out_dir>
   render_regression_guard.py compare <baseline_dir> <out_dir>
+  render_regression_guard.py check <out_dir>
+
+``check`` compares against the COMMITTED baseline manifest
+(``render_regression_baseline.json`` beside this script) so a fresh checkout
+verifies the pinned hashes without first trusting a locally-captured
+baseline. Re-capture (and commit) that manifest only for an intended,
+reviewed render change.
 
 Env: same as glyph_review receipt mode (DYNAMODB_TABLE_NAME, AWS_REGION,
 BITMATRIX_DIR, AWS creds with read access to the dev table).
@@ -131,11 +138,36 @@ def compare(baseline_dir: str, out_dir: str) -> int:
     return 0
 
 
+COMMITTED_BASELINE = os.path.join(HERE, "render_regression_baseline.json")
+
+
+def check(out_dir: str) -> int:
+    """Compare fresh renders against the COMMITTED baseline hashes."""
+    with open(COMMITTED_BASELINE, encoding="utf-8") as fh:
+        baseline = json.load(fh)
+    manifest = _render_all(out_dir)
+    failures = [
+        slug
+        for slug, sha in sorted(manifest.items())
+        if baseline.get(slug) != sha
+    ]
+    for slug in sorted(manifest):
+        state = "CHANGED" if slug in failures else "byte-identical"
+        print(f"{slug}: {state}")
+    if failures:
+        print(f"REGRESSION vs committed baseline: {failures}")
+        return 1
+    print("all pinned renders match the committed baseline")
+    return 0
+
+
 def main() -> int:
     if len(sys.argv) >= 3 and sys.argv[1] == "capture":
         return capture(sys.argv[2])
     if len(sys.argv) >= 4 and sys.argv[1] == "compare":
         return compare(sys.argv[2], sys.argv[3])
+    if len(sys.argv) >= 3 and sys.argv[1] == "check":
+        return check(sys.argv[2])
     print(__doc__)
     return 2
 

--- a/synthesis_loop/render_regression_guard.py
+++ b/synthesis_loop/render_regression_guard.py
@@ -113,12 +113,33 @@ def capture(out_dir: str) -> int:
     return 0
 
 
+def _manifest_keys_match(
+    baseline: dict[str, str], manifest: dict[str, str]
+) -> bool:
+    """Report whether the rendered and baseline slug sets are identical."""
+    baseline_slugs = set(baseline)
+    rendered_slugs = set(manifest)
+    missing = sorted(baseline_slugs - rendered_slugs)
+    extra = sorted(rendered_slugs - baseline_slugs)
+    if not missing and not extra:
+        return True
+
+    print("render manifest key-set mismatch")
+    print(f"missing slugs: {missing}")
+    print(f"extra slugs: {extra}")
+    return False
+
+
 def compare(baseline_dir: str, out_dir: str) -> int:
     with open(
         os.path.join(baseline_dir, "manifest.json"), encoding="utf-8"
     ) as fh:
         baseline = json.load(fh)
     manifest = _render_all(out_dir)
+    if not _manifest_keys_match(baseline, manifest):
+        print("REGRESSION: rendered slug set differs from baseline")
+        return 1
+
     failures = []
     for slug, sha in sorted(manifest.items()):
         base_sha = baseline.get(slug)
@@ -146,6 +167,10 @@ def check(out_dir: str) -> int:
     with open(COMMITTED_BASELINE, encoding="utf-8") as fh:
         baseline = json.load(fh)
     manifest = _render_all(out_dir)
+    if not _manifest_keys_match(baseline, manifest):
+        print("REGRESSION: rendered slug set differs from committed baseline")
+        return 1
+
     failures = [
         slug
         for slug, sha in sorted(manifest.items())

--- a/synthesis_loop/render_regression_guard.py
+++ b/synthesis_loop/render_regression_guard.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3.12
+"""Byte-identical re-render gate for shipped merchants.
+
+Renders each pinned shipped receipt through the exact ``glyph_review.py
+receipt`` recipe and hashes the SYNTH panel PNG. ``capture`` writes a baseline
+manifest; ``compare`` re-renders and fails loudly on any hash change, reporting
+the pixel MAD of each mismatch so a reviewer can judge the drift. The paper
+texture is content-seeded, so an unchanged code path re-renders byte-identical
+(MAD 0.0000).
+
+The pinned set covers the shipped-atlas merchants a systemic renderer change
+must not disturb. Receipt keys in the dev table are NOT stable across re-OCR
+(the Vons golden moved from #1 to #2 once already), so a lookup failure or an
+obviously-wrong merchant render means the pin needs re-verifying, not that the
+renderer regressed.
+
+Usage:
+  render_regression_guard.py capture <out_dir>
+  render_regression_guard.py compare <baseline_dir> <out_dir>
+
+Env: same as glyph_review receipt mode (DYNAMODB_TABLE_NAME, AWS_REGION,
+BITMATRIX_DIR, AWS creds with read access to the dev table).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+for path in (HERE, os.path.join(os.path.dirname(HERE), "scripts")):
+    if path not in sys.path:
+        sys.path.insert(0, path)
+
+# (merchant profile key, image_id, receipt_id, slug)
+PINNED = [
+    (
+        "Costco Wholesale",
+        "57cb7f2c-7dcc-4974-9ef8-a460232f3b1d",
+        1,
+        "costco_golden",
+    ),
+    (
+        "Costco Wholesale",
+        "0324604e-e1f7-4021-b887-7ef7e012c563",
+        1,
+        "costco_new",
+    ),
+    (
+        "Vons",
+        "678a7c94-4948-4ebf-b8e9-9a17c13051ec",
+        2,
+        "vons_golden",
+    ),
+    (
+        "Sprouts Farmers Market",
+        "00ded398-af6f-4a49-86f7-c79ccb554e48",
+        1,
+        "sprouts",
+    ),
+]
+
+
+def _sha256(path: str) -> str:
+    digest = hashlib.sha256()
+    with open(path, "rb") as fh:
+        for chunk in iter(lambda: fh.read(1 << 20), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _render_all(out_dir: str) -> dict[str, str]:
+    import glyph_review
+
+    os.makedirs(out_dir, exist_ok=True)
+    manifest: dict[str, str] = {}
+    for merchant, image_id, receipt_id, slug in PINNED:
+        out_png = os.path.join(out_dir, f"{slug}.png")
+        glyph_review.receipt(merchant, image_id, receipt_id, out_png)
+        # glyph_review saves the raw synthetic render (the panel under test,
+        # before the REAL|SYNTH montage) alongside the montage.
+        manifest[slug] = _sha256(f"{out_png}.syn.png")
+    return manifest
+
+
+def _pixel_mad(path_a: str, path_b: str) -> float:
+    import numpy as np
+    from PIL import Image
+
+    a = np.asarray(Image.open(path_a).convert("RGB"), dtype=np.float64)
+    b = np.asarray(Image.open(path_b).convert("RGB"), dtype=np.float64)
+    if a.shape != b.shape:
+        return float("inf")
+    return float(np.abs(a - b).mean())
+
+
+def capture(out_dir: str) -> int:
+    manifest = _render_all(out_dir)
+    manifest_path = os.path.join(out_dir, "manifest.json")
+    with open(manifest_path, "w", encoding="utf-8") as fh:
+        json.dump(manifest, fh, indent=2, sort_keys=True)
+        fh.write("\n")
+    print(f"baseline captured: {manifest_path}")
+    return 0
+
+
+def compare(baseline_dir: str, out_dir: str) -> int:
+    with open(
+        os.path.join(baseline_dir, "manifest.json"), encoding="utf-8"
+    ) as fh:
+        baseline = json.load(fh)
+    manifest = _render_all(out_dir)
+    failures = []
+    for slug, sha in sorted(manifest.items()):
+        base_sha = baseline.get(slug)
+        if base_sha == sha:
+            print(f"{slug}: byte-identical (MAD 0.0000)")
+            continue
+        mad = _pixel_mad(
+            os.path.join(baseline_dir, f"{slug}.png.syn.png"),
+            os.path.join(out_dir, f"{slug}.png.syn.png"),
+        )
+        print(f"{slug}: CHANGED (MAD {mad:.4f})")
+        failures.append(slug)
+    if failures:
+        print(f"REGRESSION: {len(failures)} render(s) changed: {failures}")
+        return 1
+    print("all pinned renders byte-identical")
+    return 0
+
+
+def main() -> int:
+    if len(sys.argv) >= 3 and sys.argv[1] == "capture":
+        return capture(sys.argv[2])
+    if len(sys.argv) >= 4 and sys.argv[1] == "compare":
+        return compare(sys.argv[2], sys.argv[3])
+    print(__doc__)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_render_regression_guard.py
+++ b/tests/test_render_regression_guard.py
@@ -1,0 +1,75 @@
+"""Adversarial tests for the committed render regression gate."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from synthesis_loop import render_regression_guard as guard
+
+
+@pytest.mark.parametrize("gate", ["check", "compare"])
+def test_gate_rejects_omitted_pinned_slug(
+    gate: str,
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    baseline = {
+        "costco_golden": "costco-sha",
+        "vons_golden": "vons-sha",
+    }
+    rendered = {"costco_golden": "costco-sha"}
+    monkeypatch.setattr(guard, "_render_all", lambda _out_dir: rendered)
+
+    if gate == "check":
+        baseline_path = tmp_path / "committed-baseline.json"
+        baseline_path.write_text(json.dumps(baseline), encoding="utf-8")
+        monkeypatch.setattr(guard, "COMMITTED_BASELINE", str(baseline_path))
+        result = guard.check(str(tmp_path / "out"))
+    else:
+        baseline_dir = tmp_path / "baseline"
+        baseline_dir.mkdir()
+        (baseline_dir / "manifest.json").write_text(
+            json.dumps(baseline), encoding="utf-8"
+        )
+        result = guard.compare(str(baseline_dir), str(tmp_path / "out"))
+
+    assert result != 0
+    output = capsys.readouterr().out
+    assert "missing slugs: ['vons_golden']" in output
+    assert "extra slugs: []" in output
+
+
+@pytest.mark.parametrize("gate", ["check", "compare"])
+def test_gate_rejects_unexpected_rendered_slug(
+    gate: str,
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    baseline = {"costco_golden": "costco-sha"}
+    rendered = {
+        "costco_golden": "costco-sha",
+        "unexpected": "unexpected-sha",
+    }
+    monkeypatch.setattr(guard, "_render_all", lambda _out_dir: rendered)
+
+    if gate == "check":
+        baseline_path = tmp_path / "committed-baseline.json"
+        baseline_path.write_text(json.dumps(baseline), encoding="utf-8")
+        monkeypatch.setattr(guard, "COMMITTED_BASELINE", str(baseline_path))
+        result = guard.check(str(tmp_path / "out"))
+    else:
+        baseline_dir = tmp_path / "baseline"
+        baseline_dir.mkdir()
+        (baseline_dir / "manifest.json").write_text(
+            json.dumps(baseline), encoding="utf-8"
+        )
+        result = guard.compare(str(baseline_dir), str(tmp_path / "out"))
+
+    assert result != 0
+    output = capsys.readouterr().out
+    assert "missing slugs: []" in output
+    assert "extra slugs: ['unexpected']" in output

--- a/tests/test_render_systemic_fixes.py
+++ b/tests/test_render_systemic_fixes.py
@@ -1,0 +1,120 @@
+"""Unit tests for the systemic render fixes (fix/render-systemic).
+
+Covers the label-hygiene and logo-band rules that erased real content:
+INVALID labels feeding the renderer, the wordmark cluster absorbing
+address words, and phrase anchors firing on substrings of unrelated words
+("TREE" in "STREET").
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("PIL")
+
+from scripts import render_synthetic_receipts as rsr  # noqa: E402
+
+
+def _word(text, line_id, word_id, bbox):
+    return {
+        "receipt_id": 1,
+        "line_id": line_id,
+        "word_id": word_id,
+        "text": text,
+        "bounding_box": {
+            "x": bbox[0],
+            "y": bbox[1],
+            "width": bbox[2] - bbox[0],
+            "height": bbox[3] - bbox[1],
+        },
+    }
+
+
+def _label(label, line_id, word_id, status):
+    return {
+        "receipt_id": 1,
+        "line_id": line_id,
+        "word_id": word_id,
+        "label": label,
+        "validation_status": status,
+    }
+
+
+class TestRealReceiptDictLabelFilter:
+    def _export(self, status):
+        return {
+            "receipt_words": [_word("WESTLAKE", 2, 1, [0.1, 0.1, 0.4, 0.15])],
+            "receipt_word_labels": [_label("MERCHANT_NAME", 2, 1, status)],
+        }
+
+    def test_invalid_labels_are_excluded(self):
+        real = rsr._real_receipt_dict(self._export("INVALID"), 1)
+        assert real["words"][0]["labels"] == []
+
+    def test_valid_labels_are_kept(self):
+        real = rsr._real_receipt_dict(self._export("VALID"), 1)
+        assert real["words"][0]["labels"] == ["MERCHANT_NAME"]
+
+    def test_unreviewed_labels_are_kept(self):
+        for status in (None, "", "PENDING", "NEEDS_REVIEW"):
+            real = rsr._real_receipt_dict(self._export(status), 1)
+            assert real["words"][0]["labels"] == ["MERCHANT_NAME"], status
+
+
+class TestLogoWordmarkBounds:
+    """The wordmark cluster must never absorb non-MERCHANT_NAME content."""
+
+    def _receipt(self, extra_labels):
+        # Receipt coords are y-up (larger y = higher on the paper): the brand
+        # line sits at the very top with an adjacent word in the same column
+        # one line below -- exactly the geometry the greedy absorption accepts.
+        return {
+            "words": [
+                {
+                    "text": "GELSONS",
+                    "bbox": [100.0, 950.0, 500.0, 990.0],
+                    "labels": ["MERCHANT_NAME"],
+                },
+                {
+                    "text": "WESTLAKE",
+                    "bbox": [120.0, 900.0, 400.0, 940.0],
+                    "labels": extra_labels,
+                },
+            ]
+        }
+
+    def test_pure_merchant_name_word_is_absorbed(self):
+        cluster, bbox = rsr._logo_wordmark_words(
+            self._receipt(["MERCHANT_NAME"])
+        )
+        assert len(cluster) == 2
+        assert bbox[1] == 900.0
+
+    def test_word_with_address_label_is_not_absorbed(self):
+        cluster, bbox = rsr._logo_wordmark_words(
+            self._receipt(["MERCHANT_NAME", "ADDRESS_LINE"])
+        )
+        assert len(cluster) == 1
+        assert bbox[1] == 950.0
+
+    def test_word_with_only_address_label_is_not_absorbed(self):
+        cluster, _ = rsr._logo_wordmark_words(self._receipt(["ADDRESS_LINE"]))
+        assert len(cluster) == 1
+
+
+class TestPhraseRunMatch:
+    def test_multiword_slogan_assembles_from_adjacent_tokens(self):
+        assert rsr._phrase_run_match(
+            ["HOW", "DOERS", "GET", "MORE", "DONE"], ["HOWDOERSGETMOREDONE"]
+        )
+
+    def test_substring_of_one_token_does_not_match(self):
+        assert not rsr._phrase_run_match(
+            ["361", "WESTLAKE", "STREET"], ["TREE"]
+        )
+
+    def test_whole_token_matches(self):
+        assert rsr._phrase_run_match(["DOLLAR", "TREE"], ["TREE"])
+
+    def test_non_adjacent_tokens_do_not_match(self):
+        assert not rsr._phrase_run_match(["HOW", "X", "DOERS"], ["HOWDOERS"])

--- a/tests/test_render_systemic_fixes.py
+++ b/tests/test_render_systemic_fixes.py
@@ -118,3 +118,50 @@ class TestPhraseRunMatch:
 
     def test_non_adjacent_tokens_do_not_match(self):
         assert not rsr._phrase_run_match(["HOW", "X", "DOERS"], ["HOWDOERS"])
+
+
+class TestWordmarkSeedFilter:
+    """P1 review finding: an UNLABELED word on the brand line (e.g. its label
+    was INVALID-filtered) must not be seeded into the wordmark cluster."""
+
+    def test_unlabeled_same_row_address_word_is_not_seeded(self):
+        receipt = {
+            "merchant_name": "Gelson's Westlake Village",
+            "words": [
+                {
+                    "text": "GELSONS",
+                    "bbox": [100.0, 950.0, 400.0, 990.0],
+                    "labels": ["MERCHANT_NAME"],
+                },
+                # Same OCR row; its INVALID MERCHANT_NAME label was filtered.
+                {
+                    "text": "WESTLAKE",
+                    "bbox": [420.0, 950.0, 700.0, 990.0],
+                    "labels": [],
+                },
+            ],
+        }
+        cluster, bbox = rsr._logo_wordmark_words(receipt)
+        assert [w["text"] for w in cluster] == ["GELSONS"]
+        assert bbox[2] == 400.0
+
+    def test_text_detected_brand_line_still_seeds_brand_words(self):
+        # No labels at all: the Sprouts-style text-detected wordmark keeps
+        # words whose text is part of the merchant name.
+        receipt = {
+            "merchant_name": "Sprouts Farmers Market",
+            "words": [
+                {
+                    "text": "SPROUTS",
+                    "bbox": [100.0, 950.0, 400.0, 990.0],
+                    "labels": [],
+                },
+                {
+                    "text": "FARMERS",
+                    "bbox": [420.0, 950.0, 700.0, 990.0],
+                    "labels": [],
+                },
+            ],
+        }
+        cluster, _ = rsr._logo_wordmark_words(receipt)
+        assert {w["text"] for w in cluster} == {"SPROUTS", "FARMERS"}


### PR DESCRIPTION
## Summary

Phase 1 of the render-redo campaign: systemic fixes to the synthetic-receipt renderer, each addressing a failure class found in the forensic review of the prior polish pass (#1185, which stays unmerged).

- **INVALID-label hygiene (the Gelson's address-eraser fix):** `ReceiptWordLabel`s with `validation_status=INVALID` are excluded from render input in both label paths (`_real_receipt_dict`, `glyph_review.py`). Unreviewed labels are kept.
- **Wordmark bounds:** `_logo_wordmark_words` never absorbs — nor seeds its cluster with — words carrying a non-MERCHANT_NAME label, so real content beside the wordmark can't be background-erased by the logo overlay.
- **Multi-word category headers:** `classify_row` matches qualified department headers ("REG DELI", "SERVICE DELI") via an explicit qualifier allowlist; product rows ending in a department word ("RED WINE") never match.
- **Per-section width knob:** `section_scale` entries accept `{"height_scale", "condense"}` mappings alongside legacy bare floats (which stay byte-identical); per-section condense threads through the renderer row loop.
- **#1185 keepers cherry-picked:** `_phrase_run_match` contiguous-token phrase anchors ("TREE" ⊄ "STREET") and the `_overlay_qr_and_barcode` phantom-barcode fixes (logo-footprint occupancy, top-third header gap cutoff). The #1185 wordmark-band token sweep is deliberately **not** carried (it eats The Stand's "THE STAND" line; Phase 2 redoes it bounded).
- **Positional DATE/TIME guard:** below the top 35% of the paper, DATE/TIME labels no longer vote HEADER — payment-block date reprints are body-size on real prints.
- **New byte-identical gate:** `synthesis_loop/render_regression_guard.py` (capture/compare, SHA256 + pixel MAD) over pinned shipped renders.

## Verification

| pinned render | result |
|---|---|
| costco_golden `57cb7f2c#1` | byte-identical (MAD 0.0000) |
| costco_new `0324604e#1` | byte-identical (MAD 0.0000) |
| sprouts `00ded398#1` | byte-identical (MAD 0.0000) |
| vons_golden `678a7c94#2` | intended change (MAD 0.90), footer band only — see below |

The Vons golden carries 98 INVALID labels. Excluding them changes exactly one band: the footer "Thank you for shopping Vons!" block, which INVALID `MERCHANT_NAME` labels had been shrinking to header scale; it now renders at body size, **matching the real print** (crop-verified). A bisect proved every other fix is a no-op on all four pins.

- Unit tests: 10 (render fixes) + 4 (section_style) + positional-guard + stylemap additions, all green; full receipt_agent unit suite shows the same 13 pre-existing failures as the base commit, zero new.
- Codex review ran before this PR; both findings (wordmark seed-line filter, qualified-header over-match) fixed and re-gated.
- Black 26.5.1 / isort 8.0.1 (CI pins).

Draft for review — part of the overnight render-redo campaign; Phase 2 (Dollar Tree / Gelson's / The Stand redo) builds on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved receipt section detection so dates and times in transaction areas no longer receive header styling.
  * Prevented text-only receipts from being incorrectly rendered at footer scale.
  * Improved logo and footer code placement, avoiding overlaps and false logo matches.
  * Excluded invalid OCR labels from affecting receipt layout.

* **Enhancements**
  * Added section-specific text compression for more accurate receipt rendering.
  * Improved recognition of qualified, multiword section headers.

* **Quality**
  * Added automated rendering regression checks and expanded coverage for layout, logos, labels, and typography.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->