### PR TITLE
[synthesis_loop] fleet_status v1 (W0)

### DIFF
--- a/synthesis_loop/fleet_status.py
+++ b/synthesis_loop/fleet_status.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+"""Fleet status v1: ACTIVE merchant-truth rows vs legacy enumerations.
+
+One GSITYPE query (TYPE=MERCHANT_TRUTH_ACTIVE) through the DynamoClient
+``_MerchantTruth`` reader surface (``list_active_merchant_truth``), then a
+cross-check against the two legacy merchant enumerations:
+
+  * ``scripts/merchant_profiles.json`` profile keys
+  * ``tools/glyph-studio/server/env.mjs`` FONT_MERCHANTS values
+
+Merchants present in the legacy stores but with NO ACTIVE truth row are
+listed as missing. Pre-mint, "0 ACTIVE / 16 missing" is the truthful
+steady state, not an error.
+
+Usage:
+    python synthesis_loop/fleet_status.py [--json] [--check] [--table NAME]
+
+Exit codes: 0 always for status display; with ``--check``, 1 if any
+ACTIVE merchant has gate_status != PASS; 2 for refused configuration.
+
+Read-only against DynamoDB. Env: DYNAMODB_TABLE_NAME (default
+ReceiptsTable-dc5be22), AWS_REGION. The prod table (ReceiptsTable-d7ff76a)
+is refused explicitly, matching the migration writer's stance.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.dirname(HERE)
+for _p in (os.path.join(REPO, "receipt_dynamo"),):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from receipt_dynamo.migrations.merchant_truth_v1 import (  # noqa: E402
+    slugify_merchant,
+)
+
+if TYPE_CHECKING:
+    from receipt_dynamo.entities.merchant_truth import MerchantTruthActive
+    from receipt_dynamo.merchant_truth_loader import MerchantTruthReader
+
+DEV_TABLE_NAME = "ReceiptsTable-dc5be22"
+PROD_TABLE_NAME = "ReceiptsTable-d7ff76a"
+PROD_TABLE_MARKER = "d7ff76a"
+PROFILES_PATH = os.path.join(REPO, "scripts", "merchant_profiles.json")
+ENV_MJS_PATH = os.path.join(REPO, "tools", "glyph-studio", "server", "env.mjs")
+SHORT_HASH_LEN = 12
+
+PROFILES_SOURCE = "merchant_profiles.json"
+FONT_MERCHANTS_SOURCE = "env.mjs FONT_MERCHANTS"
+
+
+def resolve_table(cli_table: str | None) -> str:
+    """Resolve the target table and refuse prod explicitly."""
+    table = (
+        cli_table or os.environ.get("DYNAMODB_TABLE_NAME") or DEV_TABLE_NAME
+    )
+    if table == PROD_TABLE_NAME or PROD_TABLE_MARKER in table:
+        raise ValueError(
+            f"fleet_status never reads prod; refusing table {table!r} "
+            f"(prod = {PROD_TABLE_NAME!r})"
+        )
+    return table
+
+
+def parse_font_merchants(env_mjs_text: str) -> dict[str, str]:
+    """Extract the FONT_MERCHANTS font-dir -> merchant-name map."""
+    match = re.search(
+        r"export const FONT_MERCHANTS = \{(.*?)^\};",
+        env_mjs_text,
+        re.DOTALL | re.MULTILINE,
+    )
+    if match is None:
+        raise ValueError("FONT_MERCHANTS block not found in env.mjs")
+    entries = re.findall(r'(\w+):\s*"([^"]+)"', match.group(1))
+    if not entries:
+        raise ValueError("FONT_MERCHANTS block parsed to zero entries")
+    return dict(entries)
+
+
+def load_legacy_merchants(
+    profiles_path: str = PROFILES_PATH,
+    env_mjs_path: str = ENV_MJS_PATH,
+) -> dict[str, dict[str, Any]]:
+    """Union both legacy enumerations, keyed by canonical slug."""
+    with open(profiles_path, encoding="utf-8") as handle:
+        profiles = json.load(handle)["profiles"]
+    with open(env_mjs_path, encoding="utf-8") as handle:
+        font_merchants = parse_font_merchants(handle.read())
+
+    legacy: dict[str, dict[str, Any]] = {}
+    for source, names in (
+        (PROFILES_SOURCE, sorted(profiles)),
+        (FONT_MERCHANTS_SOURCE, sorted(font_merchants.values())),
+    ):
+        for name in names:
+            slug = slugify_merchant(name)
+            entry = legacy.setdefault(
+                slug, {"merchant_name": name, "sources": []}
+            )
+            if source not in entry["sources"]:
+                entry["sources"].append(source)
+    return legacy
+
+
+def _staleness_days(activated_at: str, now: datetime) -> int:
+    activated = datetime.fromisoformat(activated_at)
+    if activated.tzinfo is None:
+        activated = activated.replace(tzinfo=timezone.utc)
+    return int((now - activated).total_seconds() // 86400)
+
+
+def build_report(
+    active_records: list["MerchantTruthActive"],
+    legacy: dict[str, dict[str, Any]],
+    *,
+    table: str,
+    now: datetime,
+) -> dict[str, Any]:
+    """Assemble the full status document (source of both outputs)."""
+    active_rows = [
+        {
+            "slug": record.slug,
+            "version": record.version,
+            "bundle_hash": record.bundle_hash,
+            "bundle_hash_short": record.bundle_hash[:SHORT_HASH_LEN],
+            "gate_status": record.gate_status,
+            "activated_at": record.activated_at,
+            "staleness_days": _staleness_days(record.activated_at, now),
+        }
+        for record in sorted(active_records, key=lambda item: item.slug)
+    ]
+    active_slugs = {row["slug"] for row in active_rows}
+    missing = [
+        {
+            "slug": slug,
+            "merchant_name": entry["merchant_name"],
+            "sources": entry["sources"],
+        }
+        for slug, entry in sorted(legacy.items())
+        if slug not in active_slugs
+    ]
+    return {
+        "table": table,
+        "generated_at": now.isoformat(),
+        "active_count": len(active_rows),
+        "legacy_count": len(legacy),
+        "missing_count": len(missing),
+        "active": active_rows,
+        "missing": missing,
+        "unlisted_in_legacy": sorted(active_slugs - set(legacy)),
+        "check_failures": [
+            row["slug"] for row in active_rows if row["gate_status"] != "PASS"
+        ],
+    }
+
+
+def render_markdown(report: dict[str, Any]) -> str:
+    """Render the report as a markdown fleet table + missing list."""
+    lines = [
+        "# Merchant-truth fleet status",
+        "",
+        f"Table: `{report['table']}` | Generated: {report['generated_at']}",
+        "",
+        f"**{report['active_count']} ACTIVE / "
+        f"{report['missing_count']} missing** "
+        f"(legacy enumerations: {report['legacy_count']} merchants)",
+        "",
+        "| merchant | version | bundle_hash | gate | activated_at "
+        "| staleness (days) |",
+        "|---|---|---|---|---|---|",
+    ]
+    if report["active"]:
+        for row in report["active"]:
+            lines.append(
+                f"| {row['slug']} | {row['version']} "
+                f"| `{row['bundle_hash_short']}` | {row['gate_status']} "
+                f"| {row['activated_at']} | {row['staleness_days']} |"
+            )
+    else:
+        lines.append("| (no ACTIVE merchant-truth rows) | | | | | |")
+    lines += [
+        "",
+        "## Missing from truth store (present in legacy enumerations)",
+        "",
+    ]
+    if report["missing"]:
+        lines += [
+            "| slug | merchant_name | legacy sources |",
+            "|---|---|---|",
+        ]
+        for row in report["missing"]:
+            lines.append(
+                f"| {row['slug']} | {row['merchant_name']} "
+                f"| {', '.join(row['sources'])} |"
+            )
+    else:
+        lines.append("None: every legacy merchant has an ACTIVE truth row.")
+    if report["unlisted_in_legacy"]:
+        lines += [
+            "",
+            "## ACTIVE but absent from legacy enumerations",
+            "",
+        ]
+        lines += [f"- {slug}" for slug in report["unlisted_in_legacy"]]
+    return "\n".join(lines) + "\n"
+
+
+def main(
+    argv: list[str] | None = None,
+    *,
+    reader: "MerchantTruthReader | None" = None,
+    now: datetime | None = None,
+) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--json", action="store_true", help="emit JSON instead of markdown"
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="exit 1 if any ACTIVE merchant has gate_status != PASS",
+    )
+    parser.add_argument(
+        "--table",
+        default=None,
+        help="DynamoDB table (default: DYNAMODB_TABLE_NAME env or "
+        f"{DEV_TABLE_NAME})",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        table = resolve_table(args.table)
+    except ValueError as error:
+        print(f"REFUSED: {error}", file=sys.stderr)
+        return 2
+
+    legacy = load_legacy_merchants()
+    if reader is None:
+        from receipt_dynamo.data.dynamo_client import (  # noqa: PLC0415
+            DynamoClient,
+        )
+
+        region = os.environ.get("AWS_REGION", "us-east-1")
+        reader = DynamoClient(table_name=table, region=region)
+    active_records = reader.list_active_merchant_truth()
+
+    report = build_report(
+        active_records,
+        legacy,
+        table=table,
+        now=now or datetime.now(timezone.utc),
+    )
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(render_markdown(report), end="")
+
+    if args.check and report["check_failures"]:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_fleet_status.py
+++ b/tests/test_fleet_status.py
@@ -1,0 +1,221 @@
+"""Fleet-status v1 contract: truthful table, cross-check, exit codes."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+
+from receipt_dynamo.entities.merchant_truth import MerchantTruthActive
+from synthesis_loop import fleet_status
+
+NOW = datetime(2026, 7, 21, 12, 0, 0, tzinfo=timezone.utc)
+HASH_A = "a" * 64
+HASH_B = "b" * 64
+
+
+class StubReader:
+    """MerchantTruthReader protocol stub (same shape as loader FakeReader)."""
+
+    def __init__(
+        self, active_records: list[MerchantTruthActive] | None = None
+    ) -> None:
+        self.active_records = active_records or []
+        self.fleet_calls = 0
+
+    def list_active_merchant_truth(self) -> list[MerchantTruthActive]:
+        self.fleet_calls += 1
+        return self.active_records
+
+    def get_active_merchant_truth(
+        self, slug: str, *, consistent_read: bool = False
+    ) -> MerchantTruthActive | None:
+        raise AssertionError("fleet_status must not read per-slug pointers")
+
+    def read_merchant_truth_bundle_items(
+        self,
+        slug: str,
+        version: int,
+        *,
+        consistent_read: bool = False,
+    ) -> list[dict[str, Any]]:
+        raise AssertionError("fleet_status must not read bundle items")
+
+
+def make_active(
+    slug: str = "vons",
+    *,
+    version: int = 1,
+    bundle_hash: str = HASH_A,
+    gate_status: str = "PASS",
+    activated_at: str = "2026-07-18T12:00:00+00:00",
+) -> MerchantTruthActive:
+    return MerchantTruthActive(
+        slug=slug,
+        version=version,
+        bundle_hash=bundle_hash,
+        normalized_aliases=[slug],
+        activated_at=activated_at,
+        activated_by="owner",
+        gate_status=gate_status,
+    )
+
+
+def test_legacy_enumerations_union_to_sixteen_merchants() -> None:
+    legacy = fleet_status.load_legacy_merchants()
+    assert len(legacy) == 16
+    assert "vons" in legacy
+    assert "sprouts_farmers_market" in legacy
+    # env.mjs-only presence never adds merchants beyond the profile keys,
+    # but every FONT_MERCHANTS value must resolve into the union.
+    dual = [
+        slug
+        for slug, entry in legacy.items()
+        if fleet_status.FONT_MERCHANTS_SOURCE in entry["sources"]
+    ]
+    assert len(dual) == 11
+
+
+def test_empty_fleet_renders_zero_active_sixteen_missing_exit_zero(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    reader = StubReader([])
+
+    exit_code = fleet_status.main([], reader=reader, now=NOW)
+
+    assert exit_code == 0
+    assert reader.fleet_calls == 1
+    output = capsys.readouterr().out
+    assert "**0 ACTIVE / 16 missing**" in output
+    assert "(no ACTIVE merchant-truth rows)" in output
+    assert "| vons | Vons |" in output
+    assert "| sprouts_farmers_market | Sprouts Farmers Market |" in output
+
+
+def test_populated_fleet_renders_row_with_short_hash_and_staleness(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    reader = StubReader(
+        [make_active("vons", activated_at="2026-07-18T12:00:00+00:00")]
+    )
+
+    exit_code = fleet_status.main([], reader=reader, now=NOW)
+
+    assert exit_code == 0
+    output = capsys.readouterr().out
+    assert "**1 ACTIVE / 15 missing**" in output
+    assert f"| vons | 1 | `{'a' * 12}` | PASS " in output
+    assert "| 2026-07-18T12:00:00+00:00 | 3 |" in output
+    # vons moved out of the missing list
+    assert "| vons | Vons |" not in output
+
+
+def test_json_output_is_machine_readable(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    reader = StubReader([make_active("vons"), make_active("cvs")])
+
+    exit_code = fleet_status.main(["--json"], reader=reader, now=NOW)
+
+    assert exit_code == 0
+    report = json.loads(capsys.readouterr().out)
+    assert report["active_count"] == 2
+    assert report["missing_count"] == 14
+    assert report["legacy_count"] == 16
+    assert [row["slug"] for row in report["active"]] == ["cvs", "vons"]
+    row = report["active"][1]
+    assert row["bundle_hash"] == HASH_A
+    assert row["bundle_hash_short"] == "a" * 12
+    assert row["gate_status"] == "PASS"
+    assert row["staleness_days"] == 3
+    assert report["check_failures"] == []
+    assert report["unlisted_in_legacy"] == []
+
+
+def test_active_slug_outside_legacy_is_surfaced_not_fatal(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    reader = StubReader([make_active("mystery_mart")])
+
+    exit_code = fleet_status.main(["--json"], reader=reader, now=NOW)
+
+    assert exit_code == 0
+    report = json.loads(capsys.readouterr().out)
+    assert report["missing_count"] == 16
+    assert report["unlisted_in_legacy"] == ["mystery_mart"]
+
+
+def test_mixed_gate_statuses_display_without_check_exits_zero(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    reader = StubReader(
+        [
+            make_active("vons"),
+            make_active("cvs", bundle_hash=HASH_B, gate_status="FAIL"),
+        ]
+    )
+
+    exit_code = fleet_status.main(["--json"], reader=reader, now=NOW)
+
+    assert exit_code == 0
+    report = json.loads(capsys.readouterr().out)
+    assert report["check_failures"] == ["cvs"]
+
+
+def test_check_flag_exits_nonzero_on_non_pass_gate() -> None:
+    reader = StubReader(
+        [
+            make_active("vons"),
+            make_active("cvs", bundle_hash=HASH_B, gate_status="FAIL"),
+        ]
+    )
+
+    assert fleet_status.main(["--check"], reader=reader, now=NOW) == 1
+
+
+def test_check_flag_exits_zero_when_all_active_pass() -> None:
+    reader = StubReader([make_active("vons")])
+
+    assert fleet_status.main(["--check"], reader=reader, now=NOW) == 0
+
+
+def test_check_flag_exits_zero_on_empty_fleet() -> None:
+    assert fleet_status.main(["--check"], reader=StubReader()) == 0
+
+
+def test_prod_table_flag_is_refused_before_any_read(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    reader = StubReader([make_active("vons")])
+
+    exit_code = fleet_status.main(
+        ["--table", "ReceiptsTable-d7ff76a"], reader=reader, now=NOW
+    )
+
+    assert exit_code == 2
+    assert reader.fleet_calls == 0
+    captured = capsys.readouterr()
+    assert "REFUSED" in captured.err
+    assert captured.out == ""
+
+
+def test_prod_table_env_var_is_refused(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("DYNAMODB_TABLE_NAME", "ReceiptsTable-d7ff76a")
+    reader = StubReader()
+
+    assert fleet_status.main([], reader=reader) == 2
+    assert reader.fleet_calls == 0
+
+
+def test_default_table_is_dev(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("DYNAMODB_TABLE_NAME", raising=False)
+    assert fleet_status.resolve_table(None) == "ReceiptsTable-dc5be22"
+
+
+def test_prod_marker_variants_are_refused() -> None:
+    with pytest.raises(ValueError, match="refusing"):
+        fleet_status.resolve_table("ReceiptsTable-d7ff76a-copy")


### PR DESCRIPTION
Implements **W0** of the merchant-truth loop plan (Phase 0) and the `fleet_status` leftover from #1188 P4.

## What

`synthesis_loop/fleet_status.py` — fleet status v1:

- **One GSITYPE query** (`TYPE=MERCHANT_TRUTH_ACTIVE`) through the existing `DynamoClient`/`_MerchantTruth` reader surface (`list_active_merchant_truth`) — no re-implemented queries.
- **Output**: markdown fleet table (default) or `--json` — slug, version, short bundle_hash (12 chars), gate_status, activated_at, staleness (days since activation).
- **Legacy cross-check**: unions `scripts/merchant_profiles.json` profile keys with `tools/glyph-studio/server/env.mjs` `FONT_MERCHANTS` values (slugified via the migration's `slugify_merchant`) and lists merchants that have **no** ACTIVE truth row. Pre-mint, "0 ACTIVE / 16 missing" renders truthfully with exit 0 — it is the targeting input for the nightly loop, not an error.
- **Exit codes**: 0 always for status display; `--check` exits 1 if any ACTIVE merchant has `gate_status != PASS` (future loop use); 2 for refused configuration.
- **Read-only, never prod**: table from `--table` / `DYNAMODB_TABLE_NAME`, defaulting to the dev table (`ReceiptsTable-dc5be22`); the prod table (`ReceiptsTable-d7ff76a`, or any name carrying its suffix) is refused before any client is constructed, matching the migration writer's dev-only stance.

`tests/test_fleet_status.py` — 13 tests using the `MerchantTruthReader` protocol-stub pattern from `receipt_dynamo/tests/unit/test_merchant_truth_loader.py`: populated fleet, empty fleet (16 missing), mixed gate statuses, `--check` exit codes, prod-table refusal (flag + env var + suffix variant), legacy-enumeration union invariants.

## Verification

`pytest tests/test_fleet_status.py` → **13 passed**. black/isort (79) clean.

**Live read-only run** against dev (`ReceiptsTable-dc5be22`, us-east-1), captured 2026-07-21:

```
# Merchant-truth fleet status

Table: `ReceiptsTable-dc5be22` | Generated: 2026-07-21T15:26:49.605703+00:00

**0 ACTIVE / 16 missing** (legacy enumerations: 16 merchants)

| merchant | version | bundle_hash | gate | activated_at | staleness (days) |
|---|---|---|---|---|---|
| (no ACTIVE merchant-truth rows) | | | | | |

## Missing from truth store (present in legacy enumerations)

| slug | merchant_name | legacy sources |
|---|---|---|
| amazon_fresh | Amazon Fresh | merchant_profiles.json |
| costco_wholesale | Costco Wholesale | merchant_profiles.json, env.mjs FONT_MERCHANTS |
| cvs | CVS | merchant_profiles.json, env.mjs FONT_MERCHANTS |
| dollar_tree | Dollar Tree | merchant_profiles.json, env.mjs FONT_MERCHANTS |
| gelson_s_westlake_village | Gelson's Westlake Village | merchant_profiles.json, env.mjs FONT_MERCHANTS |
| in_n_out_burger | In-N-Out Burger | merchant_profiles.json, env.mjs FONT_MERCHANTS |
| italia_deli___bakery | Italia Deli & Bakery | merchant_profiles.json |
| neighborly | Neighborly | merchant_profiles.json |
| smith_s | Smith's | merchant_profiles.json |
| sprouts_farmers_market | Sprouts Farmers Market | merchant_profiles.json, env.mjs FONT_MERCHANTS |
| target | Target | merchant_profiles.json |
| the_home_depot | The Home Depot | merchant_profiles.json, env.mjs FONT_MERCHANTS |
| the_stand___american_classics_redefined | The Stand - American Classics Redefined | merchant_profiles.json, env.mjs FONT_MERCHANTS |
| trader_joe_s | Trader Joe's | merchant_profiles.json, env.mjs FONT_MERCHANTS |
| vons | Vons | merchant_profiles.json, env.mjs FONT_MERCHANTS |
| wild_fork | Wild Fork | merchant_profiles.json, env.mjs FONT_MERCHANTS |
```

Exit code 0. Prod refusal verified live: `--table ReceiptsTable-d7ff76a` → `REFUSED: fleet_status never reads prod; …` exit 2, no AWS client constructed.

The table is empty because the v1 migration has only run dry-run (mint happens at W3/W4 = owner gate G1) — this output is the expected truthful baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BeLcSviHL5vDgS3zTSMbsq
