### PR TITLE
[scripts] agent preflight + MCP auth healthcheck (W1)

### DIFF
--- a/scripts/agent_preflight.sh
+++ b/scripts/agent_preflight.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# Agent preflight for headless runs (plan humble-skipping-quilt W1).
+#
+# Composes read-only health checks a headless agent session depends on:
+#   1. MCP auth healthcheck        scripts/check_mcp_auth.py
+#   2. AWS dev-table readability   aws dynamodb describe-table (READ-ONLY)
+#      table = $DYNAMODB_TABLE_NAME, default dev ReceiptsTable-dc5be22.
+#      Never touches prod: default is the dev table and the only call made
+#      is describe-table.
+#   3. Git state                   branch, clean/dirty, origin reachability
+#   4. Disk free                   >= 10 GB required on the repo volume
+#
+# Output: one JSON document on stdout, human summary on stderr.
+# Exit:   0 healthy / 1 degraded / 2 red.
+# Safe to run anywhere (laptop or mini); mutates nothing.
+
+set -u -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# AGENT_PREFLIGHT_REPO_ROOT lets the preflight be staged outside the repo
+# (e.g. copied to /tmp on a remote host) while still checking the real repo.
+REPO_ROOT="${AGENT_PREFLIGHT_REPO_ROOT:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+TABLE_NAME="${DYNAMODB_TABLE_NAME:-ReceiptsTable-dc5be22}"
+DISK_MIN_GB=10
+
+# ---- 1. MCP auth healthcheck ---------------------------------------------
+MCP_JSON="$(python3 "$SCRIPT_DIR/check_mcp_auth.py" --repo-root "$REPO_ROOT" 2>/dev/null)"
+MCP_EXIT=$?
+if [ -z "$MCP_JSON" ]; then
+  MCP_JSON='{"overall":"red","checks":[],"error":"check_mcp_auth.py produced no output"}'
+  MCP_EXIT=2
+fi
+
+# ---- 2. AWS dev-table readability (describe-table is read-only) ----------
+AWS_STATUS="red"
+AWS_DETAIL=""
+if command -v aws >/dev/null 2>&1; then
+  AWS_OUT="$(aws dynamodb describe-table \
+      --table-name "$TABLE_NAME" \
+      --cli-connect-timeout 10 --cli-read-timeout 15 \
+      --query 'Table.{name:TableName,status:TableStatus,items:ItemCount}' \
+      --output json 2>&1)"
+  if [ $? -eq 0 ]; then
+    AWS_STATUS="ok"
+    AWS_DETAIL="$(printf '%s' "$AWS_OUT" | tr -d '\n' | tr -s ' ')"
+  else
+    AWS_DETAIL="describe-table failed: $(printf '%s' "$AWS_OUT" | head -2 | tr '\n' ' ')"
+  fi
+else
+  AWS_DETAIL="aws CLI not installed"
+fi
+
+# ---- 3. Git state (all read-only; ls-remote makes no changes) ------------
+GIT_BRANCH="$(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)"
+GIT_DIRTY_COUNT="$(git -C "$REPO_ROOT" status --porcelain 2>/dev/null | wc -l | tr -d ' ')"
+if [ "${GIT_DIRTY_COUNT:-0}" -eq 0 ]; then GIT_TREE="clean"; else GIT_TREE="dirty(${GIT_DIRTY_COUNT})"; fi
+if GIT_TERMINAL_PROMPT=0 GIT_SSH_COMMAND="ssh -o BatchMode=yes -o ConnectTimeout=10" \
+   git -C "$REPO_ROOT" -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=15 \
+   ls-remote --exit-code --heads origin >/dev/null 2>&1; then
+  GIT_ORIGIN="reachable"
+  GIT_STATUS="ok"
+else
+  GIT_ORIGIN="unreachable"
+  GIT_STATUS="degraded"
+fi
+GIT_DETAIL="branch=$GIT_BRANCH tree=$GIT_TREE origin=$GIT_ORIGIN"
+
+# ---- 4. Disk free --------------------------------------------------------
+# >= 10 GB ok; below that degraded; below 2 GB red (a render/eval night
+# cannot run and even logs/artifacts may fail to write).
+DISK_AVAIL_KB="$(df -k "$REPO_ROOT" | awk 'NR==2 {print $4}')"
+DISK_AVAIL_GB=$(( ${DISK_AVAIL_KB:-0} / 1048576 ))
+if [ "$DISK_AVAIL_GB" -ge "$DISK_MIN_GB" ]; then
+  DISK_STATUS="ok"
+elif [ "$DISK_AVAIL_GB" -ge 2 ]; then
+  DISK_STATUS="degraded"
+else
+  DISK_STATUS="red"
+fi
+DISK_DETAIL="${DISK_AVAIL_GB}GB free (need >= ${DISK_MIN_GB}GB, red < 2GB)"
+
+# ---- Compose -------------------------------------------------------------
+export MCP_JSON MCP_EXIT AWS_STATUS AWS_DETAIL TABLE_NAME \
+       GIT_STATUS GIT_DETAIL DISK_STATUS DISK_DETAIL DISK_AVAIL_GB
+
+REPORT="$(python3 - <<'PYEOF'
+import json, os, socket
+from datetime import datetime, timezone
+
+sev = {"ok": 0, "healthy": 0, "degraded": 1, "red": 2}
+
+try:
+    mcp = json.loads(os.environ["MCP_JSON"])
+except json.JSONDecodeError:
+    mcp = {"overall": "red", "error": "unparseable check_mcp_auth output"}
+
+checks = {
+    "mcp_auth": {"status": mcp.get("overall", "red"), "report": mcp},
+    "aws_dev_table": {
+        "status": os.environ["AWS_STATUS"],
+        "table": os.environ["TABLE_NAME"],
+        "detail": os.environ["AWS_DETAIL"],
+    },
+    "git": {"status": os.environ["GIT_STATUS"], "detail": os.environ["GIT_DETAIL"]},
+    "disk": {"status": os.environ["DISK_STATUS"], "detail": os.environ["DISK_DETAIL"]},
+}
+worst = max(sev.get(c["status"], 2) for c in checks.values())
+overall = ["healthy", "degraded", "red"][worst]
+doc = {
+    "overall": overall,
+    "host": socket.gethostname(),
+    "checked_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+    "checks": checks,
+}
+print(json.dumps(doc, indent=2))
+PYEOF
+)"
+
+OVERALL="$(printf '%s' "$REPORT" | python3 -c 'import json,sys; print(json.load(sys.stdin)["overall"])')"
+
+# JSON to stdout, human summary to stderr.
+printf '%s\n' "$REPORT"
+{
+  echo "== agent preflight: $OVERALL =="
+  echo "  mcp_auth : $(printf '%s' "$MCP_JSON" | python3 -c 'import json,sys
+d=json.load(sys.stdin)
+parts = "; ".join("%s=%s" % (c["name"], c["status"]) for c in d.get("checks", []))
+print(d.get("overall", "red"), "|", parts)')"
+  echo "  aws      : $AWS_STATUS | table=$TABLE_NAME $AWS_DETAIL"
+  echo "  git      : $GIT_STATUS | $GIT_DETAIL"
+  echo "  disk     : $DISK_STATUS | $DISK_DETAIL"
+} >&2
+
+case "$OVERALL" in
+  healthy)  exit 0 ;;
+  degraded) exit 1 ;;
+  *)        exit 2 ;;
+esac

--- a/scripts/check_mcp_auth.py
+++ b/scripts/check_mcp_auth.py
@@ -1,0 +1,399 @@
+#!/usr/bin/env python3
+"""Non-interactive MCP auth/connectivity healthcheck for headless agent runs.
+
+Probes each MCP dependency a headless (``claude -p``) run relies on and
+reports auth/connectivity state as one JSON document on stdout:
+
+    {"overall": "healthy|degraded|red", "checks": [{name, status, detail}...]}
+
+Checks
+------
+claude_oauth   ~/.claude/.credentials.json (the FILE credential store that
+               headless runs use -- macOS interactive sessions may use the
+               Keychain instead, which headless runs cannot read).  Validates
+               ``claudeAiOauth.expiresAt`` against now.  Never prints token
+               material: only validity + expiry.
+glyph_studio   stdio MCP (node tools/glyph-studio/server/mcp.mjs).  Verifies
+               the entry point exists, ``node`` is on PATH, and node_modules
+               is installed (tools/glyph-studio/node_modules or
+               server/node_modules).  No spawn: cheap and side-effect free.
+receipt_tools  Discovered from ~/.claude.json (project entry for the repo
+               first, then global) or the repo's .mcp.json.  For an HTTP
+               server: one authed POST to its URL if a stored OAuth token
+               exists in the file credential store, else an unauthenticated
+               probe to distinguish needs_auth (server answered 401/403)
+               from unreachable.  For a stdio server: script existence only
+               (no OAuth involved).
+
+Exit codes: 0 healthy, 1 degraded, 2 red.  Read-only: never mutates state,
+never triggers an interactive auth flow.
+
+Plan: ~/.claude/plans/humble-skipping-quilt.md (W1).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sys
+import time
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+OK_STATUSES = {"ok", "authenticated", "configured_stdio"}
+RED_STATUSES = {"missing", "expired", "malformed"}
+# Anything else (needs_auth, unreachable, unknown-needs-interactive-check,
+# missing_deps, misconfigured, not_configured, ...) degrades the run but a
+# headless session can still start.
+
+PROBE_TIMEOUT_S = 10
+
+
+# --------------------------------------------------------------------------
+# Pure logic (unit-tested; no filesystem, no network)
+# --------------------------------------------------------------------------
+
+
+def check_claude_oauth(creds: dict | None, now_ms: int) -> dict:
+    """Classify the Claude OAuth file credential. ``creds`` is the parsed
+    ~/.claude/.credentials.json content, or None if the file is absent or
+    unparseable.  Never surfaces token material."""
+    name = "claude_oauth"
+    if creds is None:
+        return {
+            "name": name,
+            "status": "missing",
+            "detail": (
+                "~/.claude/.credentials.json not found or unreadable; "
+                "headless runs need the file credential store "
+                "(interactive macOS sessions may be using the Keychain)"
+            ),
+        }
+    oauth = creds.get("claudeAiOauth")
+    if not isinstance(oauth, dict):
+        return {
+            "name": name,
+            "status": "malformed",
+            "detail": "credentials file has no claudeAiOauth section",
+        }
+    expires_at = oauth.get("expiresAt")
+    if not isinstance(expires_at, (int, float)):
+        return {
+            "name": name,
+            "status": "malformed",
+            "detail": "claudeAiOauth.expiresAt missing or non-numeric",
+        }
+    expires_iso = datetime.fromtimestamp(
+        expires_at / 1000, tz=timezone.utc
+    ).strftime("%Y-%m-%d %H:%M UTC")
+    if expires_at <= now_ms:
+        return {
+            "name": name,
+            "status": "expired",
+            "detail": f"OAuth expired at {expires_iso}",
+        }
+    days_left = (expires_at - now_ms) / 86_400_000
+    sub = oauth.get("subscriptionType", "unknown")
+    return {
+        "name": name,
+        "status": "ok",
+        "detail": (
+            f"OAuth valid, expires {expires_iso} "
+            f"({days_left:.1f} days; subscription={sub})"
+        ),
+    }
+
+
+def find_mcp_oauth_token(creds: dict | None, server_name: str) -> dict | None:
+    """Find a stored MCP OAuth entry for ``server_name`` in the file
+    credential store (``mcpOAuth`` section, keys contain the server name).
+    Returns the entry dict or None."""
+    if not isinstance(creds, dict):
+        return None
+    section = creds.get("mcpOAuth")
+    if not isinstance(section, dict):
+        return None
+    for key, entry in section.items():
+        if server_name in key and isinstance(entry, dict):
+            return entry
+    return None
+
+
+def classify_receipt_tools_http(
+    http_status: int | None, has_token: bool
+) -> tuple[str, str]:
+    """Map an HTTP probe outcome to (status, detail fragment).
+
+    ``http_status`` is the response code, or None when the request failed at
+    the network layer (DNS/conn/timeout)."""
+    if http_status is None:
+        return "unreachable", "network error probing MCP endpoint"
+    if http_status in (401, 403):
+        if has_token:
+            return (
+                "needs_auth",
+                f"stored token rejected (HTTP {http_status}); "
+                "interactive re-auth required",
+            )
+        return (
+            "needs_auth",
+            f"server reachable but no stored OAuth token "
+            f"(HTTP {http_status}); interactive auth required",
+        )
+    if 200 <= http_status < 300:
+        if has_token:
+            return "authenticated", f"authed probe OK (HTTP {http_status})"
+        # Endpoint answered 2xx without auth -- unexpected for a protected
+        # gateway; report honestly rather than claiming authenticated.
+        return (
+            "unknown-needs-interactive-check",
+            f"unauthenticated probe returned HTTP {http_status}; "
+            "cannot confirm auth state non-interactively",
+        )
+    return (
+        "unknown-needs-interactive-check",
+        f"unexpected HTTP {http_status} from MCP endpoint",
+    )
+
+
+def aggregate(checks: list[dict]) -> str:
+    """healthy | degraded | red from individual check statuses."""
+    statuses = {c.get("status") for c in checks}
+    if statuses & RED_STATUSES:
+        return "red"
+    if statuses - OK_STATUSES:
+        return "degraded"
+    return "healthy"
+
+
+def overall_exit_code(overall: str) -> int:
+    return {"healthy": 0, "degraded": 1}.get(overall, 2)
+
+
+def discover_mcp_server(
+    claude_config: dict | None, server_name: str, repo_root: Path
+) -> dict | None:
+    """Find ``server_name`` in parsed ~/.claude.json: the project entry whose
+    path contains the repo root wins, then any Portfolio-ish project entry,
+    then the global mcpServers section."""
+    if not isinstance(claude_config, dict):
+        return None
+    projects = claude_config.get("projects", {})
+    repo_str = str(repo_root)
+    candidates: list[dict] = []
+    if isinstance(projects, dict):
+        for path, proj in projects.items():
+            cfg = (proj or {}).get("mcpServers", {}).get(server_name)
+            if isinstance(cfg, dict):
+                if path == repo_str:
+                    return cfg
+                candidates.append(cfg)
+    global_cfg = (claude_config.get("mcpServers") or {}).get(server_name)
+    if isinstance(global_cfg, dict):
+        return global_cfg
+    return candidates[0] if candidates else None
+
+
+# --------------------------------------------------------------------------
+# IO wrappers
+# --------------------------------------------------------------------------
+
+
+def load_json(path: Path) -> dict | None:
+    try:
+        with open(path, encoding="utf-8") as f:
+            data = json.load(f)
+        return data if isinstance(data, dict) else None
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def probe_http(url: str, token: str | None, timeout: int) -> int | None:
+    """One POST to an MCP endpoint (JSON-RPC initialize). Returns the HTTP
+    status code, or None on a network-layer failure.  Read-only from the
+    server's perspective and never opens an interactive flow."""
+    body = json.dumps(
+        {
+            "jsonrpc": "2.0",
+            "id": 0,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-03-26",
+                "capabilities": {},
+                "clientInfo": {"name": "check_mcp_auth", "version": "1.0"},
+            },
+        }
+    ).encode()
+    headers = {
+        "Content-Type": "application/json",
+        "Accept": "application/json, text/event-stream",
+    }
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    req = urllib.request.Request(url, data=body, headers=headers)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return resp.status
+    except urllib.error.HTTPError as e:
+        return e.code
+    except (urllib.error.URLError, OSError, TimeoutError):
+        return None
+
+
+def check_glyph_studio(
+    claude_config: dict | None, repo_root: Path
+) -> dict:
+    name = "glyph_studio"
+    cfg = discover_mcp_server(claude_config, "glyph-studio", repo_root)
+    entry = None
+    if cfg and cfg.get("type") == "stdio":
+        for a in cfg.get("args", []):
+            if str(a).endswith("mcp.mjs"):
+                entry = Path(a)
+                break
+    if entry is None or not entry.exists():
+        entry = repo_root / "tools" / "glyph-studio" / "server" / "mcp.mjs"
+    if not entry.exists():
+        return {
+            "name": name,
+            "status": "missing",
+            "detail": f"server entry point not found: {entry}",
+        }
+    problems = []
+    if shutil.which("node") is None:
+        problems.append("node not on PATH")
+    pkg_root = entry.parent.parent  # tools/glyph-studio
+    if not (
+        (pkg_root / "node_modules").is_dir()
+        or (entry.parent / "node_modules").is_dir()
+    ):
+        problems.append(
+            f"node_modules not installed (run npm install in {pkg_root})"
+        )
+    if problems:
+        return {
+            "name": name,
+            "status": "missing_deps",
+            "detail": f"{entry}: " + "; ".join(problems),
+        }
+    return {
+        "name": name,
+        "status": "ok",
+        "detail": f"stdio server ready: node {entry}",
+    }
+
+
+def check_receipt_tools(
+    claude_config: dict | None,
+    creds: dict | None,
+    repo_root: Path,
+    timeout: int,
+) -> dict:
+    name = "receipt_tools"
+    cfg = discover_mcp_server(claude_config, "receipt-tools", repo_root)
+    if cfg is None:
+        mcp_json = load_json(repo_root / ".mcp.json")
+        if mcp_json:
+            cfg = (mcp_json.get("mcpServers") or {}).get("receipt-tools")
+    if not isinstance(cfg, dict):
+        return {
+            "name": name,
+            "status": "not_configured",
+            "detail": "no receipt-tools entry in ~/.claude.json or .mcp.json",
+        }
+    ctype = cfg.get("type", "stdio")
+    if ctype == "stdio":
+        script = next(
+            (a for a in cfg.get("args", []) if str(a).endswith(".py")), None
+        )
+        if script and Path(script).exists():
+            return {
+                "name": name,
+                "status": "configured_stdio",
+                "detail": (
+                    f"stdio server (no OAuth): {script} present; "
+                    "auth = local AWS credentials"
+                ),
+            }
+        return {
+            "name": name,
+            "status": "misconfigured",
+            "detail": f"stdio server script not found: {script}",
+        }
+    if ctype in ("http", "sse"):
+        url = cfg.get("url")
+        if not url:
+            return {
+                "name": name,
+                "status": "misconfigured",
+                "detail": f"{ctype} server has no url",
+            }
+        entry = find_mcp_oauth_token(creds, "receipt-tools")
+        token = entry.get("accessToken") if entry else None
+        http_status = probe_http(url, token, timeout)
+        status, detail = classify_receipt_tools_http(
+            http_status, has_token=bool(token)
+        )
+        return {"name": name, "status": status, "detail": f"{url}: {detail}"}
+    return {
+        "name": name,
+        "status": "unknown-needs-interactive-check",
+        "detail": f"unhandled server type {ctype!r}; probe it interactively",
+    }
+
+
+# --------------------------------------------------------------------------
+# CLI
+# --------------------------------------------------------------------------
+
+
+def run(home: Path, repo_root: Path, timeout: int) -> dict:
+    creds = load_json(home / ".claude" / ".credentials.json")
+    claude_config = load_json(home / ".claude.json")
+    now_ms = int(time.time() * 1000)
+    checks = [
+        check_claude_oauth(creds, now_ms),
+        check_glyph_studio(claude_config, repo_root),
+        check_receipt_tools(claude_config, creds, repo_root, timeout),
+    ]
+    return {
+        "overall": aggregate(checks),
+        "checks": checks,
+        "checked_at": datetime.now(timezone.utc).isoformat(
+            timespec="seconds"
+        ),
+        "home": str(home),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--home",
+        type=Path,
+        default=Path.home(),
+        help="credential-store home (default: $HOME; override for testing)",
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path(__file__).resolve().parent.parent,
+        help="Portfolio repo root (default: parent of scripts/)",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=PROBE_TIMEOUT_S,
+        help="HTTP probe timeout, seconds",
+    )
+    args = parser.parse_args(argv)
+    report = run(args.home, args.repo_root, args.timeout)
+    print(json.dumps(report, indent=2))
+    return overall_exit_code(report["overall"])
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/fixtures/mcp_auth/claude_config.json
+++ b/tests/fixtures/mcp_auth/claude_config.json
@@ -1,0 +1,32 @@
+{
+  "mcpServers": {
+    "receipt-tools": {
+      "type": "http",
+      "url": "https://global.example.lambda-url.us-east-1.on.aws"
+    },
+    "glyph-studio": {
+      "type": "stdio",
+      "command": "node",
+      "args": ["/somewhere/tools/glyph-studio/server/mcp.mjs"]
+    }
+  },
+  "projects": {
+    "/repo/root": {
+      "mcpServers": {
+        "receipt-tools": {
+          "type": "stdio",
+          "command": "python3",
+          "args": ["scripts/receipt_mcp_server.py"]
+        }
+      }
+    },
+    "/other/project": {
+      "mcpServers": {
+        "receipt-tools": {
+          "type": "http",
+          "url": "https://other.example.on.aws"
+        }
+      }
+    }
+  }
+}

--- a/tests/fixtures/mcp_auth/creds_malformed.json
+++ b/tests/fixtures/mcp_auth/creds_malformed.json
@@ -1,0 +1,3 @@
+{
+  "somethingElse": {"expiresAt": 1810363482067}
+}

--- a/tests/fixtures/mcp_auth/creds_valid.json
+++ b/tests/fixtures/mcp_auth/creds_valid.json
@@ -1,0 +1,8 @@
+{
+  "claudeAiOauth": {
+    "accessToken": "fixture-not-a-real-token",
+    "expiresAt": 1810363482067,
+    "scopes": ["user:inference", "user:profile"],
+    "subscriptionType": "max"
+  }
+}

--- a/tests/fixtures/mcp_auth/creds_with_mcp_token.json
+++ b/tests/fixtures/mcp_auth/creds_with_mcp_token.json
@@ -1,0 +1,15 @@
+{
+  "claudeAiOauth": {
+    "accessToken": "fixture-not-a-real-token",
+    "expiresAt": 1810363482067,
+    "scopes": ["user:inference", "user:profile"],
+    "subscriptionType": "max"
+  },
+  "mcpOAuth": {
+    "receipt-tools|https://example.execute-api.us-east-1.amazonaws.com/receipt/mcp": {
+      "accessToken": "fixture-mcp-access-token",
+      "refreshToken": "fixture-mcp-refresh-token",
+      "expiresAt": 1810363482067
+    }
+  }
+}

--- a/tests/test_check_mcp_auth.py
+++ b/tests/test_check_mcp_auth.py
@@ -1,0 +1,195 @@
+"""Unit tests for check_mcp_auth's pure logic (W1, plan
+humble-skipping-quilt): credential-expiry parsing, HTTP-probe
+classification, config discovery, and status aggregation.
+
+No network, no real credential files: fixtures live in
+tests/fixtures/mcp_auth/ and every value fed to the functions under test is
+loaded from there or built inline.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts import check_mcp_auth as cma
+
+FIXTURES = Path(__file__).parent / "fixtures" / "mcp_auth"
+
+# One millisecond epoch on each side of the fixture expiry (1810363482067).
+FIXTURE_EXPIRY_MS = 1810363482067
+BEFORE_EXPIRY_MS = FIXTURE_EXPIRY_MS - 86_400_000  # one day earlier
+AFTER_EXPIRY_MS = FIXTURE_EXPIRY_MS + 1
+
+
+def load_fixture(name: str) -> dict:
+    return json.loads((FIXTURES / name).read_text())
+
+
+# --------------------------------------------------------------------------
+# claude_oauth expiry parsing
+# --------------------------------------------------------------------------
+
+
+def test_valid_credentials_before_expiry():
+    creds = load_fixture("creds_valid.json")
+    check = cma.check_claude_oauth(creds, now_ms=BEFORE_EXPIRY_MS)
+    assert check["name"] == "claude_oauth"
+    assert check["status"] == "ok"
+    assert "expires" in check["detail"]
+
+
+def test_expired_credentials():
+    creds = load_fixture("creds_valid.json")
+    check = cma.check_claude_oauth(creds, now_ms=AFTER_EXPIRY_MS)
+    assert check["status"] == "expired"
+
+
+def test_missing_credentials_file():
+    check = cma.check_claude_oauth(None, now_ms=BEFORE_EXPIRY_MS)
+    assert check["status"] == "missing"
+    assert "headless" in check["detail"]
+
+
+def test_malformed_credentials():
+    creds = load_fixture("creds_malformed.json")
+    check = cma.check_claude_oauth(creds, now_ms=BEFORE_EXPIRY_MS)
+    assert check["status"] == "malformed"
+
+
+def test_non_numeric_expiry_is_malformed():
+    creds = {"claudeAiOauth": {"expiresAt": "tomorrow"}}
+    check = cma.check_claude_oauth(creds, now_ms=BEFORE_EXPIRY_MS)
+    assert check["status"] == "malformed"
+
+
+def test_no_token_material_in_output():
+    """The check must never surface token material, only validity+expiry."""
+    creds = load_fixture("creds_valid.json")
+    for now in (BEFORE_EXPIRY_MS, AFTER_EXPIRY_MS):
+        check = cma.check_claude_oauth(creds, now_ms=now)
+        dumped = json.dumps(check)
+        assert "fixture-not-a-real-token" not in dumped
+        assert "accessToken" not in dumped
+
+
+# --------------------------------------------------------------------------
+# stored MCP OAuth token lookup
+# --------------------------------------------------------------------------
+
+
+def test_find_mcp_token_present():
+    creds = load_fixture("creds_with_mcp_token.json")
+    entry = cma.find_mcp_oauth_token(creds, "receipt-tools")
+    assert entry is not None
+    assert entry["accessToken"] == "fixture-mcp-access-token"
+
+
+def test_find_mcp_token_absent():
+    creds = load_fixture("creds_valid.json")
+    assert cma.find_mcp_oauth_token(creds, "receipt-tools") is None
+    assert cma.find_mcp_oauth_token(None, "receipt-tools") is None
+
+
+# --------------------------------------------------------------------------
+# HTTP probe classification (pure: takes status code, never the network)
+# --------------------------------------------------------------------------
+
+
+def test_probe_200_with_token_is_authenticated():
+    status, _ = cma.classify_receipt_tools_http(200, has_token=True)
+    assert status == "authenticated"
+
+
+def test_probe_401_without_token_is_needs_auth():
+    status, detail = cma.classify_receipt_tools_http(401, has_token=False)
+    assert status == "needs_auth"
+    assert "no stored OAuth token" in detail
+
+
+def test_probe_403_with_token_is_needs_auth():
+    status, detail = cma.classify_receipt_tools_http(403, has_token=True)
+    assert status == "needs_auth"
+    assert "rejected" in detail
+
+
+def test_probe_network_error_is_unreachable():
+    status, _ = cma.classify_receipt_tools_http(None, has_token=True)
+    assert status == "unreachable"
+
+
+def test_probe_200_without_token_is_honest_unknown():
+    # A protected gateway should never 200 an anonymous call; if it does we
+    # refuse to claim "authenticated".
+    status, _ = cma.classify_receipt_tools_http(200, has_token=False)
+    assert status == "unknown-needs-interactive-check"
+
+
+def test_probe_weird_status_is_unknown():
+    status, _ = cma.classify_receipt_tools_http(500, has_token=True)
+    assert status == "unknown-needs-interactive-check"
+
+
+# --------------------------------------------------------------------------
+# config discovery precedence
+# --------------------------------------------------------------------------
+
+
+def test_discovery_prefers_exact_project_entry():
+    cfg = load_fixture("claude_config.json")
+    found = cma.discover_mcp_server(cfg, "receipt-tools", Path("/repo/root"))
+    assert found["type"] == "stdio"
+
+
+def test_discovery_falls_back_to_global():
+    cfg = load_fixture("claude_config.json")
+    found = cma.discover_mcp_server(
+        cfg, "receipt-tools", Path("/unrelated/repo")
+    )
+    assert found["type"] == "http"
+    assert "global.example" in found["url"]
+
+
+def test_discovery_handles_missing_config():
+    assert cma.discover_mcp_server(None, "receipt-tools", Path("/x")) is None
+    assert cma.discover_mcp_server({}, "receipt-tools", Path("/x")) is None
+
+
+# --------------------------------------------------------------------------
+# status aggregation + exit codes
+# --------------------------------------------------------------------------
+
+
+def mk(status: str) -> dict:
+    return {"name": "c", "status": status, "detail": ""}
+
+
+def test_all_ok_is_healthy():
+    checks = [mk("ok"), mk("authenticated"), mk("configured_stdio")]
+    assert cma.aggregate(checks) == "healthy"
+
+
+def test_needs_auth_degrades():
+    assert cma.aggregate([mk("ok"), mk("needs_auth")]) == "degraded"
+
+
+def test_unreachable_and_unknown_degrade():
+    assert cma.aggregate([mk("unreachable")]) == "degraded"
+    assert (
+        cma.aggregate([mk("unknown-needs-interactive-check")]) == "degraded"
+    )
+
+
+def test_missing_oauth_is_red_even_with_other_oks():
+    assert cma.aggregate([mk("missing"), mk("ok"), mk("ok")]) == "red"
+
+
+def test_expired_is_red_and_beats_degraded():
+    assert cma.aggregate([mk("expired"), mk("needs_auth")]) == "red"
+
+
+def test_exit_codes():
+    assert cma.overall_exit_code("healthy") == 0
+    assert cma.overall_exit_code("degraded") == 1
+    assert cma.overall_exit_code("red") == 2
+    assert cma.overall_exit_code("garbage") == 2


### PR DESCRIPTION
Implements **W1** of the approved plan `~/.claude/plans/humble-skipping-quilt.md` (agent preflight + MCP auth healthcheck): the read-only gate every future headless run (W2 nightly loop) executes before doing anything.

## What

- **`scripts/check_mcp_auth.py`** — probes each MCP dependency non-interactively, emits one JSON doc (`{overall, checks:[{name,status,detail}]}`), exit 0 healthy / 1 degraded / 2 red. Checks:
  - `claude_oauth`: `~/.claude/.credentials.json` (the FILE store headless runs use; macOS interactive sessions may be on Keychain) — validity + expiry only, **never token material**.
  - `glyph_studio`: stdio entry point exists + `node` on PATH + node_modules installed (`tools/glyph-studio/node_modules` — that's where `package.json` lives — or `server/node_modules`).
  - `receipt_tools`: config discovered from `~/.claude.json` (exact project entry → global → `.mcp.json`). HTTP servers get one JSON-RPC `initialize` probe — authed if a stored `mcpOAuth` token exists, else unauthenticated to distinguish `needs_auth` (401/403) from `unreachable`; anything else honestly reports `unknown-needs-interactive-check`. Stdio servers: script presence (no OAuth involved).
- **`scripts/agent_preflight.sh`** — composes check_mcp_auth + AWS dev-table readability (`aws dynamodb describe-table` on `$DYNAMODB_TABLE_NAME`, default dev `ReceiptsTable-dc5be22`; describe-table only — **never touches prod, never mutates**) + git state (branch, clean/dirty, `git ls-remote` origin reachability, no-prompt/BatchMode) + disk free (≥10GB; <2GB = red). JSON to stdout, human summary to stderr, exit 0/1/2. `AGENT_PREFLIGHT_REPO_ROOT` lets it be staged outside the repo on a remote host.
- **`tests/test_check_mcp_auth.py`** + `tests/fixtures/mcp_auth/` — 23 tests over the pure logic (expiry parsing incl. malformed/missing, token-material never leaked, probe classification, config-discovery precedence, aggregation, exit codes). No network, no real credential files.

## Evidence

### Laptop (Tylers-MacBook-Pro)

```
== agent preflight: red ==
  mcp_auth : red | claude_oauth=missing; glyph_studio=ok; receipt_tools=configured_stdio
  aws      : ok | table=ReceiptsTable-dc5be22 { "name": "ReceiptsTable-dc5be22", "status": "ACTIVE", "items": 2002813}
  git      : ok | branch=feat/agent-preflight tree=clean origin=reachable
  disk     : ok | 830GB free (need >= 10GB, red < 2GB)
EXIT=2
```

Honest red: this laptop keeps Claude credentials in the macOS **Keychain** — there is no `~/.claude/.credentials.json`, so a headless run here would have no file-store OAuth. `receipt-tools` on the laptop is a **stdio** server (`/Users/tnorlund/portfolio_worktree/scripts/receipt_mcp_server.py`, auth = local AWS creds), so no OAuth applies.

### Mini (`ssh tnorlund@Tylers-Mac-mini.local`, scripts staged read-only in /tmp)

```
== agent preflight: red ==
  mcp_auth : degraded | claude_oauth=ok; glyph_studio=ok; receipt_tools=needs_auth
  aws      : ok | table=ReceiptsTable-dc5be22 { "name": "ReceiptsTable-dc5be22", "status": "ACTIVE", "items": 2002813}
  git      : ok | branch=main tree=dirty(13) origin=reachable
  disk     : red | 0GB free (need >= 10GB, red < 2GB)
EXIT=2
```

`check_mcp_auth.py` alone on the mini (exit 1, degraded):

```json
{
  "overall": "degraded",
  "checks": [
    {"name": "claude_oauth", "status": "ok",
     "detail": "OAuth valid, expires 2027-05-15 06:44 UTC (297.6 days; subscription=max)"},
    {"name": "glyph_studio", "status": "ok",
     "detail": "stdio server ready: node /Users/tnorlund/Portfolio/tools/glyph-studio/server/mcp.mjs"},
    {"name": "receipt_tools", "status": "needs_auth",
     "detail": "https://tvkzgp64q7ddjtcudrn5ytsl3q0njppl.lambda-url.us-east-1.on.aws: server reachable but no stored OAuth token (HTTP 403); interactive auth required"}
  ]
}
```

- **`receipt_tools=needs_auth` on the mini — the known fact the plan wanted surfaced**, now machine-detected. Bonus finding: the mini's config still points at the **old Lambda Function URL** (flipped to AWS_IAM by #1105), so the W1 op item "re-auth receipt-tools on the mini" also needs the config moved to the Cognito gateway (`https://gk35oy04tf.execute-api.us-east-1.amazonaws.com/receipt/mcp`).
- **New operational finding: the mini's data volume is 100% full (207 MB free)** — preflight correctly goes red; needs cleanup before any nightly run (W2).

### RED path (HOME → empty temp dir)

```
$ HOME=$(mktemp -d) bash scripts/agent_preflight.sh
== agent preflight: red ==
  mcp_auth : red | claude_oauth=missing; glyph_studio=missing_deps; receipt_tools=not_configured
  aws      : red | table=ReceiptsTable-dc5be22 describe-table failed:  You must specify a region. ...
  git      : ok | branch=feat/agent-preflight tree=clean origin=reachable
  disk     : ok | 830GB free (need >= 10GB, red < 2GB)
EXIT=2
```

### Tests

```
$ .venv/bin/python -m pytest tests/test_check_mcp_auth.py -q
23 passed in 0.07s
```

## Safety

Read-only everywhere: file reads, `describe-table`, `git ls-remote`, `df`, and one HTTP POST (`initialize`) to an MCP endpoint. No writes, no prod access, no interactive auth flows triggered, no token material ever printed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BeLcSviHL5vDgS3zTSMbsq


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added non-interactive health checks for authentication, MCP connectivity, cloud database access, Git state, and available disk space.
  * Added structured JSON reports with human-readable status summaries.
  * Added overall health classifications and exit codes for healthy, degraded, and critical results.

* **Tests**
  * Added coverage for credential validation, configuration discovery, connectivity outcomes, status aggregation, and sensitive-token protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->