### PR TITLE
[migrations] merchant-truth v1 --live mint mode (W3)

### DIFF
--- a/receipt_dynamo/receipt_dynamo/migrations/merchant_truth_v1_live.py
+++ b/receipt_dynamo/receipt_dynamo/migrations/merchant_truth_v1_live.py
@@ -1,0 +1,381 @@
+"""Live mint/seal driver and dry-run parity verifier for MerchantTruth v1.
+
+The migration's read side stays in ``merchant_truth_v1`` and remains
+structurally read-only. This module owns the *write* side of the one-shot
+v1 bootstrap and never talks to DynamoDB directly: every write goes
+exclusively through the mutation-tested ``_MerchantTruth`` accessor surface
+on ``DynamoClient`` (``mint_version`` / ``seal_version`` — conditional
+creates, atomic 9-action mint). It adds three safety layers on top:
+
+1. Table pinning: the dev table ``ReceiptsTable-dc5be22`` is the only
+   implicit target; any other table must be passed explicitly, and the prod
+   table ``ReceiptsTable-d7ff76a`` is refused unconditionally.
+2. Blocked-merchant exclusion: any payload carrying migration blockers
+   (the asset-blocked merchants per ``_summary.json``) is excluded from
+   minting with an owner-visible report line, so v1 never seals an asset
+   closure it cannot satisfy (#1194 review trail).
+3. Dry-run <-> live parity: every minted bundle is read back and pushed
+   through ``MerchantTruthLoader``'s fail-closed fixture verification, then
+   byte-compared component-by-component against the dry-run payload files.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Protocol, Sequence
+
+from receipt_dynamo.data.shared_exceptions import (
+    MerchantTruthIntegrityError,
+    MerchantTruthTableMismatchError,
+)
+from receipt_dynamo.entities.merchant_truth import (
+    COMPONENT_NAMES,
+    MerchantTruthComponent,
+    MerchantTruthManifest,
+    canonical_json_bytes,
+)
+from receipt_dynamo.merchant_truth_loader import (
+    MerchantTruthLoader,
+    TruthResolutionMode,
+)
+from receipt_dynamo.migrations.merchant_truth_v1 import (
+    DEV_TABLE_NAME,
+    MerchantV1Payload,
+)
+
+PROD_TABLE_NAME = "ReceiptsTable-d7ff76a"
+
+
+class MerchantTruthWriter(Protocol):
+    """The exact accessor surface the live migration is allowed to use."""
+
+    def mint_version(
+        self,
+        slug: str,
+        version: int,
+        components: Sequence[MerchantTruthComponent],
+        provenance: dict[str, Any],
+        run_id: str,
+        expected_table_name: str,
+        *,
+        created_at: str | None = None,
+    ) -> MerchantTruthManifest: ...
+
+    def seal_version(
+        self,
+        slug: str,
+        version: int,
+        gate_results: dict[str, Any],
+        confirmed_proposals: list[str],
+        expected_table_name: str,
+        *,
+        sealed_at: str | None = None,
+        actor: str = "merchant-truth-writer",
+    ) -> MerchantTruthManifest: ...
+
+    def read_merchant_truth_bundle_items(
+        self,
+        slug: str,
+        version: int,
+        *,
+        consistent_read: bool = False,
+    ) -> list[dict[str, Any]]: ...
+
+
+def validate_live_table(table_name: str, *, explicit: bool) -> None:
+    """Refuse every live target except the pinned dev table.
+
+    The prod table is refused unconditionally. Any other non-dev table is
+    allowed only when the operator passed it explicitly on the command line
+    (``explicit=True``), which supports test tables without ever making a
+    non-dev write reachable by default.
+    """
+    if table_name == PROD_TABLE_NAME:
+        raise MerchantTruthTableMismatchError(
+            "refusing live merchant-truth migration against prod table "
+            f"{PROD_TABLE_NAME!r}; prod promotion is a separate owner-gated "
+            "manual step and this refusal is unconditional"
+        )
+    if table_name == DEV_TABLE_NAME:
+        return
+    if not table_name or not explicit:
+        raise MerchantTruthTableMismatchError(
+            f"live migration writes only to exact dev table "
+            f"{DEV_TABLE_NAME!r} by default; pass --table explicitly to "
+            f"target {table_name!r}"
+        )
+
+
+def format_live_banner(
+    table_name: str, merchant_count: int, git_sha: str
+) -> str:
+    """The loud pre-write banner: exact table, mint count, and code SHA."""
+    bar = "=" * 72
+    return "\n".join(
+        [
+            bar,
+            "LIVE MERCHANT-TRUTH V1 MINT — DynamoDB WRITES WILL OCCUR",
+            f"  table:     {table_name}",
+            f"  merchants: {merchant_count} (mint + seal v1 each)",
+            f"  git SHA:   {git_sha}",
+            bar,
+        ]
+    )
+
+
+def bootstrap_gate_results(
+    *, git_sha: str, generated_at: str, payload_dir: Path
+) -> dict[str, Any]:
+    """Explicit gate_results for the one-shot bootstrap seal.
+
+    ``seal_version`` derives gate status from an explicit signal and fails
+    closed on ambiguity; this block passes via ``status``/``passed`` while
+    its provenance records that no fidelity eval has run against
+    truth-loaded renders yet — the passing signal is source-fidelity parity
+    (dry-run payloads vs live read-back), covered by the accessor's
+    ``migration`` writer-kind allowance.
+    """
+    return {
+        "status": "PASS",
+        "passed": True,
+        "gate": "merchant_truth_v1_bootstrap",
+        "kind": "migration-bootstrap-seal",
+        "note": (
+            "bootstrap seal: gate passes on dry-run<->live source parity "
+            "only; no fidelity eval has run against truth-loaded renders "
+            "yet"
+        ),
+        "evidence": {
+            "dry_run_payload_dir": str(payload_dir),
+            "git_sha": git_sha,
+            "generated_at": generated_at,
+        },
+        "written_by": {
+            "kind": "migration",
+            "name": "merchant_truth_v1",
+            "version": "1",
+        },
+    }
+
+
+@dataclass(frozen=True)
+class LiveMintResult:
+    """Owner-visible outcome for one merchant in a live run."""
+
+    merchant_name: str
+    slug: str
+    action: str  # "MINTED_SEALED" | "EXCLUDED"
+    version: int
+    bundle_hash: str | None = None
+    blockers: tuple[str, ...] = ()
+
+    @property
+    def report_line(self) -> str:
+        if self.action == "EXCLUDED":
+            return (
+                f"EXCLUDED (asset-blocked) {self.slug}: "
+                f"{'; '.join(self.blockers)}"
+            )
+        digest = (self.bundle_hash or "")[:12]
+        return f"MINTED+SEALED v{self.version} {self.slug} bundle={digest}"
+
+
+def _payload_entities(
+    payload: MerchantV1Payload,
+) -> tuple[MerchantTruthManifest, list[MerchantTruthComponent]]:
+    """Rebuild the exact dry-run entities from a payload's low-level items."""
+    manifests: list[MerchantTruthManifest] = []
+    components: list[MerchantTruthComponent] = []
+    for item in payload.items:
+        item_type = item.get("TYPE", {}).get("S")
+        if item_type == "MERCHANT_TRUTH_MANIFEST":
+            manifests.append(MerchantTruthManifest.from_item(item))
+        elif item_type == "MERCHANT_TRUTH_COMPONENT":
+            components.append(MerchantTruthComponent.from_item(item))
+    if len(manifests) != 1:
+        raise MerchantTruthIntegrityError(
+            f"payload for {payload.slug} must carry exactly one manifest"
+        )
+    if {component.name for component in components} != COMPONENT_NAMES:
+        raise MerchantTruthIntegrityError(
+            f"payload for {payload.slug} does not carry the exact "
+            "component set"
+        )
+    return manifests[0], components
+
+
+def run_live_mint(
+    client: MerchantTruthWriter,
+    payloads: Sequence[MerchantV1Payload],
+    *,
+    table_name: str,
+    gate_results: dict[str, Any],
+    generated_at: str,
+    explicit_table: bool = False,
+) -> list[LiveMintResult]:
+    """Mint + seal v1 for every unblocked merchant through the accessor.
+
+    Blocked merchants (any non-empty ``blockers``) are excluded, never
+    minted, and reported. The dry-run payload items are replayed verbatim:
+    the accessor re-derives hashes, re-validates governance, and writes its
+    own MINT/SEAL audit rows.
+    """
+    validate_live_table(table_name, explicit=explicit_table)
+    results: list[LiveMintResult] = []
+    for payload in sorted(payloads, key=lambda entry: entry.slug):
+        if payload.blockers:
+            results.append(
+                LiveMintResult(
+                    merchant_name=payload.merchant_name,
+                    slug=payload.slug,
+                    action="EXCLUDED",
+                    version=1,
+                    blockers=tuple(payload.blockers),
+                )
+            )
+            continue
+        manifest, components = _payload_entities(payload)
+        client.mint_version(
+            payload.slug,
+            manifest.version,
+            components,
+            manifest.provenance,
+            manifest.mint_run_id,
+            table_name,
+            created_at=generated_at,
+        )
+        sealed = client.seal_version(
+            payload.slug,
+            manifest.version,
+            gate_results,
+            [],
+            table_name,
+            sealed_at=generated_at,
+            actor="merchant_truth_v1_migration",
+        )
+        results.append(
+            LiveMintResult(
+                merchant_name=payload.merchant_name,
+                slug=payload.slug,
+                action="MINTED_SEALED",
+                version=sealed.version,
+                bundle_hash=sealed.bundle_hash,
+            )
+        )
+    return results
+
+
+@dataclass(frozen=True)
+class LiveVerifyResult:
+    """Per-merchant dry-run <-> live parity outcome."""
+
+    slug: str
+    ok: bool
+    bundle_hash: str | None = None
+    mismatches: tuple[str, ...] = field(default_factory=tuple)
+
+    @property
+    def report_line(self) -> str:
+        if self.ok:
+            digest = (self.bundle_hash or "")[:12]
+            return f"VERIFY OK {self.slug} bundle={digest}"
+        return f"VERIFY MISMATCH {self.slug}: {'; '.join(self.mismatches)}"
+
+
+def verify_live_against_dry_run(
+    client: MerchantTruthWriter,
+    payload_dir: Path,
+    slugs: Sequence[str],
+    *,
+    work_dir: Path,
+) -> list[LiveVerifyResult]:
+    """Read every minted bundle back and byte-compare it to the dry run.
+
+    Each bundle is read with strong consistency, verified through
+    ``MerchantTruthLoader``'s fail-closed fixture path (SEALED/PASS status,
+    component set, content hashes, bundle hash), and then every canonical
+    component payload is byte-compared against the dry-run payload file.
+    """
+    work_dir.mkdir(parents=True, exist_ok=True)
+    loader = MerchantTruthLoader(None, work_dir / "loader-cache")
+    results: list[LiveVerifyResult] = []
+    for slug in sorted(slugs):
+        results.append(
+            _verify_one_bundle(client, loader, payload_dir, slug, work_dir)
+        )
+    return results
+
+
+def _verify_one_bundle(
+    client: MerchantTruthWriter,
+    loader: MerchantTruthLoader,
+    payload_dir: Path,
+    slug: str,
+    work_dir: Path,
+) -> LiveVerifyResult:
+    mismatches: list[str] = []
+    payload_path = payload_dir / f"{slug}.json"
+    document = json.loads(payload_path.read_text(encoding="utf-8"))
+    expected_manifest, expected_components = _payload_entities(
+        MerchantV1Payload(
+            merchant_name=document["merchant_name"],
+            slug=slug,
+            items=document["items"],
+            blockers=document.get("migration_blockers", []),
+        )
+    )
+    expected_bytes = {
+        component.name: canonical_json_bytes(component.payload)
+        for component in expected_components
+    }
+
+    items = client.read_merchant_truth_bundle_items(
+        slug, expected_manifest.version, consistent_read=True
+    )
+    fixture_path = work_dir / f"{slug}.bundle.json"
+    fixture_path.write_text(
+        json.dumps({"items": items}, sort_keys=True), encoding="utf-8"
+    )
+    try:
+        artifact = loader.load(
+            slug,
+            TruthResolutionMode.FIXTURE,
+            fixture_path=fixture_path,
+        )
+    except MerchantTruthIntegrityError as error:
+        return LiveVerifyResult(
+            slug=slug,
+            ok=False,
+            mismatches=(f"loader rejected live bundle: {error}",),
+        )
+    if artifact.slug != slug:
+        mismatches.append(
+            f"loader resolved slug {artifact.slug!r}, expected {slug!r}"
+        )
+    if artifact.bundle_hash != expected_manifest.bundle_hash:
+        mismatches.append(
+            f"bundle hash {artifact.bundle_hash} != dry-run "
+            f"{expected_manifest.bundle_hash}"
+        )
+    live_names = set(artifact.components)
+    expected_names = set(expected_bytes)
+    for name in sorted(expected_names - live_names):
+        mismatches.append(f"component {name} missing from live bundle")
+    for name in sorted(live_names - expected_names):
+        mismatches.append(f"unexpected live component {name}")
+    for name in sorted(expected_names & live_names):
+        if (
+            canonical_json_bytes(artifact.components[name])
+            != expected_bytes[name]
+        ):
+            mismatches.append(
+                f"component {name} canonical payload bytes differ"
+            )
+    return LiveVerifyResult(
+        slug=slug,
+        ok=not mismatches,
+        bundle_hash=artifact.bundle_hash,
+        mismatches=tuple(mismatches),
+    )

--- a/receipt_dynamo/tests/integration/test_merchant_truth_v1_live.py
+++ b/receipt_dynamo/tests/integration/test_merchant_truth_v1_live.py
@@ -454,9 +454,23 @@ def test_script_default_stays_dry_run_and_write_free(
     assert truth_rows["Items"] == []
 
 
+@pytest.mark.parametrize(
+    "mode_flags",
+    [
+        pytest.param([], id="dry-run-default"),
+        pytest.param(["--live"], id="live"),
+        pytest.param(["--verify"], id="verify"),
+    ],
+)
 def test_script_refuses_prod_table_before_reading_anything(
-    tmp_path: Path,
+    tmp_path: Path, mode_flags: list[str]
 ) -> None:
+    """Prod refusal precedes profile reads on every path.
+
+    The profiles path does not exist, so reaching json.load (or boto3
+    client construction) would raise FileNotFoundError instead of the
+    table-mismatch error asserted here.
+    """
     with pytest.raises(MerchantTruthTableMismatchError, match="prod table"):
         _script_main(
             [
@@ -466,6 +480,6 @@ def test_script_refuses_prod_table_before_reading_anything(
                 str(tmp_path / "payloads"),
                 "--table",
                 PROD_TABLE_NAME,
-                "--live",
+                *mode_flags,
             ]
         )

--- a/receipt_dynamo/tests/integration/test_merchant_truth_v1_live.py
+++ b/receipt_dynamo/tests/integration/test_merchant_truth_v1_live.py
@@ -1,0 +1,471 @@
+"""Live-mint mode of the MerchantTruth v1 migration (moto only).
+
+Covers: live mint+seal with read-back verification, unconditional prod-table
+refusal, blocked-merchant exclusion, unmapped-leaf failure before any write,
+and the dry-run default remaining write-free.
+"""
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import boto3
+import pytest
+from moto import mock_aws
+
+from receipt_dynamo import DynamoClient
+from receipt_dynamo.data.shared_exceptions import (
+    MerchantTruthTableMismatchError,
+)
+from receipt_dynamo.entities.merchant_font import MerchantFont
+from receipt_dynamo.entities.merchant_truth import MerchantTruthComponent
+from receipt_dynamo.migrations.merchant_truth_v1 import (
+    DEV_TABLE_NAME,
+    EXPECTED_MISSING_FONT_SLUGS,
+    UnmappedMerchantTruthLeafError,
+    build_v1_payloads,
+    slugify_merchant,
+    write_dry_run_payloads,
+)
+from receipt_dynamo.migrations.merchant_truth_v1_live import (
+    PROD_TABLE_NAME,
+    bootstrap_gate_results,
+    run_live_mint,
+    validate_live_table,
+    verify_live_against_dry_run,
+)
+
+pytestmark = pytest.mark.integration
+NOW = "2026-07-20T16:00:00+00:00"
+GIT_SHA = "a" * 40
+MERCHANTS = [
+    "Amazon Fresh",
+    "CVS",
+    "Costco Wholesale",
+    "Dollar Tree",
+    "Gelson's Westlake Village",
+    "In-N-Out Burger",
+    "Italia Deli & Bakery",
+    "Neighborly",
+    "Smith's",
+    "Sprouts Farmers Market",
+    "Target",
+    "The Home Depot",
+    "The Stand - American Classics Redefined",
+    "Trader Joe's",
+    "Vons",
+    "Wild Fork",
+]
+STYLEMAP_BYTES = b'{"version":1,"sections":{}}'
+LOGO_BYTES = b"logo-bytes"
+
+
+def profile_document() -> dict[str, Any]:
+    profiles: dict[str, Any] = {
+        merchant: {
+            "_comment": "legacy note",
+            "aliases": [merchant.upper()],
+            "typography": {"condense": 0.9},
+        }
+        for merchant in MERCHANTS
+    }
+    profiles["Sprouts Farmers Market"]["typography"].update(
+        {
+            "bitmap_font": {"regular": "sprouts.npz"},
+            "stylemap": "sprouts.stylemap.json",
+            "font": "OCRB",
+        }
+    )
+    profiles["Sprouts Farmers Market"]["section_scale"] = {"HEADER": 1.1}
+    profiles["Sprouts Farmers Market"]["layout_template"] = {
+        "version": 1,
+        "columns": {"items": [{"x": 0.5}]},
+    }
+    return {
+        "_comment": "registry",
+        "_section_scale_note": "calibration",
+        "profiles": profiles,
+    }
+
+
+def merchant_font(merchant_name: str) -> MerchantFont:
+    token = slugify_merchant(merchant_name)
+    return MerchantFont(
+        merchant_name=merchant_name,
+        face="regular",
+        s3_bucket="font-bucket",
+        s3_key=f"merchant_fonts/{token}/regular-{'1' * 8}.npz",
+        content_hash="1" * 64,
+        source_commit="abc123",
+        compiled_at=datetime(2026, 7, 20, tzinfo=timezone.utc),
+        cap_h=0.7,
+        advance_ratio=0.54,
+        pitch_check="OK",
+        glyph_count=96,
+        stylemap_s3_key=f"merchant_fonts/{token}/stylemap.json",
+        logo_s3_key=f"merchant_fonts/{token}/logo.png",
+        cache_filename=f"{token}.npz",
+    )
+
+
+class FakeSource:
+    """Read-only source stand-in matching the dry-run unit fixtures."""
+
+    def __init__(self) -> None:
+        self.fonts = [
+            merchant_font(name)
+            for name in MERCHANTS
+            if slugify_merchant(name) not in EXPECTED_MISSING_FONT_SLUGS
+        ]
+
+    def list_merchant_font_items(self) -> list[dict[str, Any]]:
+        return [font.to_item() for font in self.fonts]
+
+    def list_catalog_items(self, slug: str) -> list[dict[str, Any]]:
+        return [catalog_item(slug)]
+
+    def read_object(self, _bucket: str, key: str) -> bytes:
+        return STYLEMAP_BYTES if key.endswith("stylemap.json") else LOGO_BYTES
+
+
+def catalog_item(slug: str) -> dict[str, Any]:
+    return {
+        "PK": {"S": f"MERCHANT_CATALOG#{slug}"},
+        "SK": {"S": "ITEM#GROCERY#MILK"},
+        "TYPE": {"S": "MERCHANT_CATALOG_ITEM"},
+        "product_text": {"S": "MILK"},
+        "price": {"S": "3.99"},
+        "category": {"S": "GROCERY"},
+        "taxable": {"BOOL": False},
+    }
+
+
+def built_payloads():
+    return build_v1_payloads(
+        profile_document(),
+        FakeSource(),  # type: ignore[arg-type]
+        profiles_source_path="scripts/merchant_profiles.json",
+        git_sha=GIT_SHA,
+        generated_at=NOW,
+    )
+
+
+def gate_results(payload_dir: Path) -> dict[str, Any]:
+    return bootstrap_gate_results(
+        git_sha=GIT_SHA, generated_at=NOW, payload_dir=payload_dir
+    )
+
+
+def mint_all(client: DynamoClient, table: str, payload_dir: Path):
+    payloads, crosswalk = built_payloads()
+    write_dry_run_payloads(
+        payload_dir, payloads, crosswalk, generated_at=NOW, git_sha=GIT_SHA
+    )
+    results = run_live_mint(
+        client,
+        payloads,
+        table_name=table,
+        gate_results=gate_results(payload_dir),
+        generated_at=NOW,
+        explicit_table=True,
+    )
+    return payloads, results
+
+
+def audit_actions(table: str, slug: str) -> list[str]:
+    response = boto3.client("dynamodb", region_name="us-east-1").query(
+        TableName=table,
+        KeyConditionExpression="PK = :pk AND begins_with(SK, :sk)",
+        ExpressionAttributeValues={
+            ":pk": {"S": f"MERCHANT_TRUTH#{slug}"},
+            ":sk": {"S": "AUDIT#"},
+        },
+    )
+    return sorted(item["action"]["S"] for item in response["Items"])
+
+
+def test_live_mint_seals_unblocked_and_excludes_blocked(
+    dynamodb_table: str, tmp_path: Path
+) -> None:
+    client = DynamoClient(dynamodb_table)
+
+    _, results = mint_all(client, dynamodb_table, tmp_path)
+
+    minted = [r for r in results if r.action == "MINTED_SEALED"]
+    excluded = [r for r in results if r.action == "EXCLUDED"]
+    assert len(minted) == 13
+    assert {r.slug for r in excluded} == EXPECTED_MISSING_FONT_SLUGS
+    for result in excluded:
+        assert result.blockers
+        assert "asset-blocked" in result.report_line
+        assert client.get_merchant_truth_manifest(result.slug, 1) is None
+    for result in minted:
+        manifest = client.get_merchant_truth_manifest(
+            result.slug, 1, consistent_read=True
+        )
+        assert manifest is not None
+        assert manifest.status == "SEALED"
+        assert manifest.gate_status == "PASS"
+        assert manifest.bundle_hash == result.bundle_hash
+        assert manifest.gate_results["kind"] == "migration-bootstrap-seal"
+        assert audit_actions(dynamodb_table, result.slug) == ["MINT", "SEAL"]
+
+
+def test_live_bundles_byte_match_dry_run_payloads(
+    dynamodb_table: str, tmp_path: Path
+) -> None:
+    client = DynamoClient(dynamodb_table)
+    _, results = mint_all(client, dynamodb_table, tmp_path)
+    minted_slugs = [r.slug for r in results if r.action == "MINTED_SEALED"]
+
+    verify_results = verify_live_against_dry_run(
+        client, tmp_path, minted_slugs, work_dir=tmp_path / "_live_verify"
+    )
+
+    assert len(verify_results) == 13
+    assert all(result.ok for result in verify_results)
+    by_slug = {result.slug: result for result in verify_results}
+    for result in results:
+        if result.action == "MINTED_SEALED":
+            assert by_slug[result.slug].bundle_hash == result.bundle_hash
+
+
+def test_verify_reports_mismatch_and_stays_fail_closed_on_tamper(
+    dynamodb_table: str, tmp_path: Path
+) -> None:
+    client = DynamoClient(dynamodb_table)
+    _, results = mint_all(client, dynamodb_table, tmp_path)
+    minted_slugs = sorted(
+        r.slug for r in results if r.action == "MINTED_SEALED"
+    )
+    victim = minted_slugs[0]
+    tampered = MerchantTruthComponent(
+        slug=victim,
+        version=1,
+        name="flags",
+        payload={"tampered": True},
+        provenance={"source_kind": "migration"},
+    )
+    boto3.client("dynamodb", region_name="us-east-1").put_item(
+        TableName=dynamodb_table, Item=tampered.to_item()
+    )
+
+    verify_results = verify_live_against_dry_run(
+        client, tmp_path, minted_slugs, work_dir=tmp_path / "_live_verify"
+    )
+
+    by_slug = {result.slug: result for result in verify_results}
+    assert not by_slug[victim].ok
+    assert "loader rejected live bundle" in by_slug[victim].report_line
+    assert all(result.ok for slug, result in by_slug.items() if slug != victim)
+
+
+def test_prod_table_is_refused_unconditionally(tmp_path: Path) -> None:
+    for explicit in (True, False):
+        with pytest.raises(
+            MerchantTruthTableMismatchError, match="unconditional"
+        ):
+            validate_live_table(PROD_TABLE_NAME, explicit=explicit)
+
+    payloads, _ = built_payloads()
+
+    class ExplodingClient:
+        def __getattr__(self, name: str) -> Any:
+            raise AssertionError("prod refusal must precede any client call")
+
+    with pytest.raises(MerchantTruthTableMismatchError, match="prod table"):
+        run_live_mint(
+            ExplodingClient(),  # type: ignore[arg-type]
+            payloads,
+            table_name=PROD_TABLE_NAME,
+            gate_results=gate_results(tmp_path),
+            generated_at=NOW,
+            explicit_table=True,
+        )
+
+
+def test_non_dev_table_requires_explicit_opt_in() -> None:
+    validate_live_table(DEV_TABLE_NAME, explicit=False)
+    validate_live_table("SomeTestTable", explicit=True)
+    with pytest.raises(MerchantTruthTableMismatchError, match="--table"):
+        validate_live_table("SomeTestTable", explicit=False)
+    with pytest.raises(MerchantTruthTableMismatchError):
+        validate_live_table("", explicit=True)
+
+
+def test_unmapped_leaf_fails_before_any_payload_is_built() -> None:
+    document = profile_document()
+    document["profiles"]["CVS"]["unknown_runtime_knob"] = True
+
+    with pytest.raises(UnmappedMerchantTruthLeafError, match="unmapped"):
+        build_v1_payloads(
+            document,
+            FakeSource(),  # type: ignore[arg-type]
+            profiles_source_path="scripts/merchant_profiles.json",
+            git_sha=GIT_SHA,
+            generated_at=NOW,
+        )
+
+
+def _create_dev_named_table() -> None:
+    boto3.client("dynamodb", region_name="us-east-1").create_table(
+        TableName=DEV_TABLE_NAME,
+        KeySchema=[
+            {"AttributeName": "PK", "KeyType": "HASH"},
+            {"AttributeName": "SK", "KeyType": "RANGE"},
+        ],
+        AttributeDefinitions=[
+            {"AttributeName": "PK", "AttributeType": "S"},
+            {"AttributeName": "SK", "AttributeType": "S"},
+            {"AttributeName": "TYPE", "AttributeType": "S"},
+        ],
+        BillingMode="PAY_PER_REQUEST",
+        GlobalSecondaryIndexes=[
+            {
+                "IndexName": "GSITYPE",
+                "KeySchema": [{"AttributeName": "TYPE", "KeyType": "HASH"}],
+                "Projection": {"ProjectionType": "ALL"},
+            }
+        ],
+    )
+
+
+def _seed_dev_sources() -> None:
+    dynamodb = boto3.client("dynamodb", region_name="us-east-1")
+    s3 = boto3.client("s3", region_name="us-east-1")
+    s3.create_bucket(Bucket="font-bucket")
+    for merchant in MERCHANTS:
+        slug = slugify_merchant(merchant)
+        dynamodb.put_item(TableName=DEV_TABLE_NAME, Item=catalog_item(slug))
+        if slug in EXPECTED_MISSING_FONT_SLUGS:
+            continue
+        font = merchant_font(merchant)
+        dynamodb.put_item(TableName=DEV_TABLE_NAME, Item=font.to_item())
+        s3.put_object(
+            Bucket="font-bucket",
+            Key=font.stylemap_s3_key,
+            Body=STYLEMAP_BYTES,
+        )
+        s3.put_object(
+            Bucket="font-bucket", Key=font.logo_s3_key, Body=LOGO_BYTES
+        )
+
+
+@pytest.fixture
+def seeded_dev_environment(tmp_path: Path):
+    with mock_aws():
+        _create_dev_named_table()
+        _seed_dev_sources()
+        profiles_path = tmp_path / "profiles.json"
+        profiles_path.write_text(
+            json.dumps(profile_document()), encoding="utf-8"
+        )
+        yield profiles_path
+
+
+def _script_main(argv: list[str]) -> int:
+    import importlib.util
+    import sys
+
+    script_path = (
+        Path(__file__).resolve().parents[3]
+        / "scripts"
+        / "migrate_merchant_truth_v1.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "migrate_merchant_truth_v1", script_path
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module.main(argv)
+
+
+def test_script_live_verify_end_to_end(
+    seeded_dev_environment: Path, tmp_path: Path, capsys
+) -> None:
+    output_dir = tmp_path / "payloads"
+
+    exit_code = _script_main(
+        [
+            "--profiles",
+            str(seeded_dev_environment),
+            "--output-dir",
+            str(output_dir),
+            "--git-sha",
+            GIT_SHA,
+            "--generated-at",
+            NOW,
+            "--live",
+            "--verify",
+        ]
+    )
+
+    captured = capsys.readouterr().out
+    assert exit_code == 0
+    assert "LIVE MERCHANT-TRUTH V1 MINT" in captured
+    assert DEV_TABLE_NAME in captured
+    assert "merchants: 13" in captured
+    assert GIT_SHA in captured
+    assert captured.count("MINTED+SEALED v1") == 13
+    assert captured.count("EXCLUDED (asset-blocked)") == 3
+    assert "VERIFY OK: 13 live bundles byte-match" in captured
+    assert len(list(output_dir.glob("*.json"))) == 18
+    client = DynamoClient(DEV_TABLE_NAME)
+    manifest = client.get_merchant_truth_manifest(
+        "sprouts_farmers_market", 1, consistent_read=True
+    )
+    assert manifest is not None and manifest.status == "SEALED"
+
+
+def test_script_default_stays_dry_run_and_write_free(
+    seeded_dev_environment: Path, tmp_path: Path, capsys
+) -> None:
+    output_dir = tmp_path / "payloads"
+
+    exit_code = _script_main(
+        [
+            "--profiles",
+            str(seeded_dev_environment),
+            "--output-dir",
+            str(output_dir),
+            "--git-sha",
+            GIT_SHA,
+            "--generated-at",
+            NOW,
+        ]
+    )
+
+    captured = capsys.readouterr().out
+    assert exit_code == 0
+    assert "DRY RUN: wrote 16 merchant payloads" in captured
+    assert "No DynamoDB or S3 writes were performed." in captured
+    assert "LIVE" not in captured
+    assert len(list(output_dir.glob("*.json"))) == 18
+    truth_rows = boto3.client("dynamodb", region_name="us-east-1").query(
+        TableName=DEV_TABLE_NAME,
+        IndexName="GSITYPE",
+        KeyConditionExpression="#type = :type",
+        ExpressionAttributeNames={"#type": "TYPE"},
+        ExpressionAttributeValues={":type": {"S": "MERCHANT_TRUTH_MANIFEST"}},
+    )
+    assert truth_rows["Items"] == []
+
+
+def test_script_refuses_prod_table_before_reading_anything(
+    tmp_path: Path,
+) -> None:
+    with pytest.raises(MerchantTruthTableMismatchError, match="prod table"):
+        _script_main(
+            [
+                "--profiles",
+                str(tmp_path / "missing.json"),
+                "--output-dir",
+                str(tmp_path / "payloads"),
+                "--table",
+                PROD_TABLE_NAME,
+                "--live",
+            ]
+        )

--- a/receipt_dynamo/tests/unit/test_merchant_truth_v1_migration.py
+++ b/receipt_dynamo/tests/unit/test_merchant_truth_v1_migration.py
@@ -274,6 +274,40 @@ def test_dry_run_writer_outputs_payload_crosswalk_and_summary(
     )
 
 
+DRY_RUN_GOLDEN_SHA256 = (
+    "0264778995a007e9f362800e9e971d881df748f9492cfcf04b4c43d96a9e4dc4"
+)
+
+
+def test_dry_run_payload_bytes_are_stable_for_fixture_input(
+    tmp_path: Path,
+) -> None:
+    """Pin the exact dry-run output bytes for a fixed fixture input.
+
+    The --live mode must never change what the default dry run writes; this
+    golden digest was captured from the pre-live implementation and any
+    byte-level drift in the payload files fails here.
+    """
+    payloads, crosswalk = build_v1_payloads(
+        profile_document(),
+        FakeSource(),  # type: ignore[arg-type]
+        profiles_source_path="scripts/merchant_profiles.json",
+        git_sha=GIT_SHA,
+        generated_at=NOW,
+    )
+    write_dry_run_payloads(
+        tmp_path, payloads, crosswalk, generated_at=NOW, git_sha=GIT_SHA
+    )
+
+    digest = hashlib.sha256()
+    for path in sorted(tmp_path.glob("*.json")):
+        digest.update(path.name.encode("utf-8"))
+        digest.update(b"\x00")
+        digest.update(path.read_bytes())
+        digest.update(b"\x00")
+    assert digest.hexdigest() == DRY_RUN_GOLDEN_SHA256
+
+
 class QueryOnlyDynamo:
     def query(self, **_kwargs: Any) -> dict[str, Any]:
         return {"Items": []}

--- a/scripts/migrate_merchant_truth_v1.py
+++ b/scripts/migrate_merchant_truth_v1.py
@@ -1,5 +1,14 @@
 #!/usr/bin/env python3
-"""Emit MerchantTruth v1 DynamoDB payloads without making any writes."""
+"""Emit MerchantTruth v1 DynamoDB payloads; optionally mint+seal with --live.
+
+Default behavior is unchanged and DRY-RUN ONLY: build payloads through the
+structurally read-only source adapter and write inspection files. With an
+explicit ``--live`` flag the same payloads are minted and sealed through the
+mutation-tested ``DynamoClient`` accessor (never through the read adapter),
+excluding asset-blocked merchants. ``--verify`` reads every minted bundle
+back through ``MerchantTruthLoader`` and byte-compares canonical component
+payloads against the dry-run files, exiting nonzero on any mismatch.
+"""
 
 from __future__ import annotations
 
@@ -11,11 +20,19 @@ from pathlib import Path
 
 import boto3
 
+from receipt_dynamo import DynamoClient
 from receipt_dynamo.migrations.merchant_truth_v1 import (
     DEV_TABLE_NAME,
     ReadOnlyMerchantTruthSource,
     build_v1_payloads,
     write_dry_run_payloads,
+)
+from receipt_dynamo.migrations.merchant_truth_v1_live import (
+    bootstrap_gate_results,
+    format_live_banner,
+    run_live_mint,
+    validate_live_table,
+    verify_live_against_dry_run,
 )
 
 
@@ -29,7 +46,7 @@ def _git_sha(repo_root: Path) -> str:
     ).stdout.strip()
 
 
-def main() -> int:
+def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--profiles", type=Path, required=True)
     parser.add_argument("--stylemap-root", type=Path)
@@ -38,11 +55,44 @@ def main() -> int:
         type=Path,
         default=Path.home() / "section_label_kickoff" / "truth_v1_payloads",
     )
-    parser.add_argument("--table-name", default=DEV_TABLE_NAME)
+    parser.add_argument(
+        "--table",
+        "--table-name",
+        dest="table_name",
+        default=None,
+        help=(
+            f"DynamoDB table (default: exact dev table {DEV_TABLE_NAME}). "
+            "Live mode refuses any other table unless passed explicitly; "
+            "the prod table is refused unconditionally."
+        ),
+    )
     parser.add_argument("--region", default="us-east-1")
     parser.add_argument("--git-sha")
     parser.add_argument("--generated-at")
-    args = parser.parse_args()
+    parser.add_argument(
+        "--live",
+        action="store_true",
+        help=(
+            "Mint + seal v1 for every unblocked merchant through the "
+            "DynamoClient accessor. Without this flag no DynamoDB write "
+            "ever happens."
+        ),
+    )
+    parser.add_argument(
+        "--verify",
+        action="store_true",
+        help=(
+            "Read minted bundles back through MerchantTruthLoader and "
+            "byte-compare canonical component payloads against the dry-run "
+            "payload files; exit nonzero on any mismatch."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    explicit_table = args.table_name is not None
+    table_name = args.table_name or DEV_TABLE_NAME
+    if args.live or args.verify:
+        validate_live_table(table_name, explicit=explicit_table)
 
     repo_root = Path(__file__).resolve().parents[1]
     generated_at = args.generated_at or datetime.now(timezone.utc).isoformat()
@@ -52,7 +102,7 @@ def main() -> int:
     source = ReadOnlyMerchantTruthSource(
         boto3.client("dynamodb", region_name=args.region),
         boto3.client("s3", region_name=args.region),
-        args.table_name,
+        table_name,
     )
     payloads, crosswalk = build_v1_payloads(
         document,
@@ -69,11 +119,67 @@ def main() -> int:
         generated_at=generated_at,
         git_sha=git_sha,
     )
-    print(
-        f"DRY RUN: wrote {len(payloads)} merchant payloads to "
-        f"{args.output_dir}"
+    minted_slugs = sorted(
+        payload.slug for payload in payloads if not payload.blockers
     )
-    print("No DynamoDB or S3 writes were performed.")
+
+    client: DynamoClient | None = None
+    if args.live:
+        print(
+            format_live_banner(table_name, len(minted_slugs), git_sha),
+            flush=True,
+        )
+        client = DynamoClient(table_name, region=args.region)
+        results = run_live_mint(
+            client,
+            payloads,
+            table_name=table_name,
+            gate_results=bootstrap_gate_results(
+                git_sha=git_sha,
+                generated_at=generated_at,
+                payload_dir=args.output_dir,
+            ),
+            generated_at=generated_at,
+            explicit_table=explicit_table,
+        )
+        for result in results:
+            print(result.report_line)
+        minted = [r for r in results if r.action == "MINTED_SEALED"]
+        excluded = [r for r in results if r.action == "EXCLUDED"]
+        print(
+            f"LIVE: minted+sealed {len(minted)} merchants on {table_name}; "
+            f"excluded {len(excluded)} asset-blocked merchants; dry-run "
+            f"payloads written to {args.output_dir}"
+        )
+    else:
+        print(
+            f"DRY RUN: wrote {len(payloads)} merchant payloads to "
+            f"{args.output_dir}"
+        )
+        print("No DynamoDB or S3 writes were performed.")
+
+    if args.verify:
+        if client is None:
+            client = DynamoClient(table_name, region=args.region)
+        verify_results = verify_live_against_dry_run(
+            client,
+            args.output_dir,
+            minted_slugs,
+            work_dir=args.output_dir / "_live_verify",
+        )
+        for verify_result in verify_results:
+            print(verify_result.report_line)
+        failures = [entry for entry in verify_results if not entry.ok]
+        if failures:
+            print(
+                f"VERIFY FAILED: {len(failures)}/{len(verify_results)} live "
+                "bundles do not match the dry-run payloads"
+            )
+            return 1
+        print(
+            f"VERIFY OK: {len(verify_results)} live bundles byte-match the "
+            "dry-run payloads"
+        )
     return 0
 
 

--- a/scripts/migrate_merchant_truth_v1.py
+++ b/scripts/migrate_merchant_truth_v1.py
@@ -91,8 +91,9 @@ def main(argv: list[str] | None = None) -> int:
 
     explicit_table = args.table_name is not None
     table_name = args.table_name or DEV_TABLE_NAME
-    if args.live or args.verify:
-        validate_live_table(table_name, explicit=explicit_table)
+    # Unconditional on every path (including the plain dry run): prod
+    # refusal must precede profile reads and boto3 client construction.
+    validate_live_table(table_name, explicit=explicit_table)
 
     repo_root = Path(__file__).resolve().parents[1]
     generated_at = args.generated_at or datetime.now(timezone.utc).isoformat()


### PR DESCRIPTION
## What

Work item **W3** of the approved plan (`.claude/plans/humble-skipping-quilt.md`, Phase 1) and part of the #1188 P4 (merchant-truth) follow-through: the v1 migration gains an explicit `--live` mode that drives `DynamoClient.mint_version` + `seal_version` per unblocked merchant, plus a `--verify` mode producing the dry-run<->live parity evidence for owner gate **G1** (W4). **This PR performs no live run** — implementation + moto tests only.

## Design

- **Default unchanged: DRY-RUN ONLY.** Without `--live` the script writes the same inspection files as before — pinned byte-identical by a golden-digest test (`test_dry_run_payload_bytes_are_stable_for_fixture_input`, digest captured from the pre-change code).
- **Read side stays structurally read-only.** `ReadOnlyMerchantTruthSource` is untouched (still only `dynamodb.query` + `s3.get_object`, still dev-pinned). All writes live in a new module, `receipt_dynamo/migrations/merchant_truth_v1_live.py`, that talks exclusively to the mutation-tested `_MerchantTruth` accessor surface (`MerchantTruthWriter` protocol = `mint_version`/`seal_version`/`read_merchant_truth_bundle_items`). It replays the dry-run payload items verbatim; the accessor re-derives hashes, re-validates governance, and writes its own MINT/SEAL audit rows.
- **Table safety.** Implicit target is exactly `ReceiptsTable-dc5be22`; any other table must be passed explicitly via `--table`; prod `ReceiptsTable-d7ff76a` is refused **unconditionally** (tested to fail before any client call). Validation runs before profiles are even opened.
- **Loud banner** of `{table, merchant count, git SHA}` printed before the first write.
- **Blocked-merchant exclusion.** Any payload with migration blockers (the 3 asset-blocked merchants per `_summary.json`: `amazon_fresh`, `dollar_tree`, `smith_s`) is excluded from minting with a per-merchant `EXCLUDED (asset-blocked)` report line — v1 never seals an asset closure it cannot satisfy (addresses the #1194 review comment "Block sealing migration bundles with missing artifacts" for the migration path).
- **Bootstrap seal gate_results.** `seal_version` derives gate status fail-closed, so the migration seals with an explicit block: `status: PASS` + `passed: true`, `gate: merchant_truth_v1_bootstrap`, `kind: migration-bootstrap-seal`, written_by kind `migration` (the accessor's migration writer-kind allowance), and a note/evidence block recording that **no fidelity eval has run against truth-loaded renders yet** — the passing signal is dry-run<->live source parity.
- **`--verify`.** Reads every minted bundle back with strong consistency, pushes it through `MerchantTruthLoader`'s fail-closed FIXTURE verification (SEALED/PASS, exact component set, content hashes, bundle hash), then byte-compares each canonical component payload and the bundle hash against the dry-run payload files. Per-merchant `VERIFY OK` / `VERIFY MISMATCH` lines; exits nonzero on any mismatch. (The loader's online modes require an ACTIVE pointer, which does not exist until owner gate G2 — hence read-back verification goes through the loader's fixture path rather than `ONLINE_ACTIVE`.)
- **Crosswalk fail-closed** on unmapped leaves is unchanged and covered both by the existing unit test and a new live-ordering test asserting the failure occurs before any payload/mint.

## Tests (moto only — no real AWS touched)

`receipt_dynamo`: 15 passed in the touched files (6 unit + 9 integration), plus the full merchant-truth suite (loader/access/accessor-integration/promotion: 39 passed) green.

- live mint+seal: 13 minted+sealed (`SEALED`/`PASS`, MINT+SEAL audit rows), 3 excluded, no rows for blocked slugs
- read-back parity: all 13 bundles byte-match dry-run payloads; tampered live component ⇒ loader rejects ⇒ `MISMATCH` (fail-closed)
- prod-table refusal: unconditional, precedes any client call; script-level refusal precedes reading profiles
- non-dev table requires explicit `--table`
- unmapped source leaf fails before anything is built or minted
- script e2e under moto (dev-named table + seeded fonts/catalog/S3): `--live --verify` exits 0, banner shows table/13/SHA, `VERIFY OK: 13`
- dry-run default: unchanged output (18 files), zero MERCHANT_TRUTH rows written, golden byte digest pinned

## Owner gate G1 (W4) — exact command

Run on a machine with dev AWS credentials, from the repo root on this branch (or main after merge):

```bash
python scripts/migrate_merchant_truth_v1.py \
  --profiles scripts/merchant_profiles.json \
  --output-dir ~/section_label_kickoff/truth_v1_payloads \
  --live --verify
```

Expected: banner `table: ReceiptsTable-dc5be22 / merchants: 13 / git SHA`, 13 `MINTED+SEALED v1` lines, 3 `EXCLUDED (asset-blocked)` lines, `VERIFY OK: 13 live bundles byte-match the dry-run payloads`, exit 0. Then `fleet_status` should report 13 SEALED (W0) with AUDIT rows per merchant. No ACTIVE flips happen here — G2 remains separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BeLcSviHL5vDgS3zTSMbsq