### PR TITLE
Fix black formatting in deflaked race tests (unbreak main)

### DIFF
--- a/receipt_dynamo/tests/integration/test__merchant_truth.py
+++ b/receipt_dynamo/tests/integration/test__merchant_truth.py
@@ -1,6 +1,5 @@
 """Integration coverage for MerchantTruth activation races."""
 
-
 import pytest
 
 from receipt_dynamo import DynamoClient


### PR DESCRIPTION
Main CI runs `black --check`; the #1198 deflake left a double blank line after the module docstring in `test__merchant_truth.py`. One-line reformat with CI's exact black (26.5.1). Root-cause note: the earlier "No python3 found" diagnosis was an artifact of grepping the step's echoed script text in the logs — the real failure was this formatting check all along.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BeLcSviHL5vDgS3zTSMbsq