### PR TITLE
[receipt_dynamo] Hash-stable truth payload storage + G1 recovery (round-trip fix)

### DIFF
--- a/docs/architecture/MERCHANT_TRUTH_DYNAMO.md
+++ b/docs/architecture/MERCHANT_TRUTH_DYNAMO.md
@@ -98,6 +98,16 @@ of KB). The writer enforces: serialized payload > 300KB → store
 `payload_s3_key` + `payload_size` instead of inline `payload`;
 `content_hash` is always inline so gates and diffs never need S3.
 
+**Payload representation (hash stability, learned live in G1):** the inline
+`payload` attribute stores the component's **canonical JSON string** — the
+exact bytes `content_hash` was computed over — never a native
+AttributeValue tree. DynamoDB normalizes number representations (`0.0` is
+stored and returned as `0`), which silently changes the canonical JSON of a
+round-tripped native map and breaks read-back hash verification (the G1
+costco mint failed its seal on exactly this, via `bitmap_thin: 0.0`).
+Strings round-trip verbatim; readers `json.loads` the string and re-verify
+the hash, and reject legacy AttributeValue-encoded payloads outright.
+
 **The catalog inlines into the version** (revised in #1193 round-1 review).
 `C#catalog_snapshot` carries the full sorted, normalized product records
 plus `{item_count, catalog_hash, as_of}` — catalogs are tiny relative to

--- a/receipt_dynamo/receipt_dynamo/entities/merchant_truth.py
+++ b/receipt_dynamo/receipt_dynamo/entities/merchant_truth.py
@@ -128,6 +128,13 @@ class MerchantTruthComponent(DynamoDBEntity):
         }
 
     def to_item(self) -> dict[str, Any]:
+        # The payload is stored as its canonical JSON STRING — the exact
+        # bytes ``content_hash`` was computed over — never as a native
+        # AttributeValue tree. DynamoDB normalizes number representations
+        # (``0.0`` is stored and returned as ``0``), which silently changes
+        # the canonical JSON of a round-tripped native map and makes the
+        # read-back hash verification fail (observed live during the G1
+        # v1 mint on ``bitmap_thin: 0.0``). A string round-trips verbatim.
         item = {
             **self.key,
             "TYPE": {"S": "MERCHANT_TRUTH_COMPONENT"},
@@ -136,7 +143,9 @@ class MerchantTruthComponent(DynamoDBEntity):
             "component": {"S": self.name},
             "content_hash": {"S": self.content_hash},
             "provenance": to_dynamodb_value(self.provenance),
-            "payload": to_dynamodb_value(self.payload),
+            "payload": {
+                "S": canonical_json_bytes(self.payload).decode("utf-8")
+            },
         }
         if self.payload_s3_key is not None:
             item["payload_s3_key"] = {"S": self.payload_s3_key}
@@ -147,11 +156,20 @@ class MerchantTruthComponent(DynamoDBEntity):
     @classmethod
     def from_item(cls, item: dict[str, Any]) -> "MerchantTruthComponent":
         data = _item_to_python(item)
+        raw_payload = data["payload"]
+        if not isinstance(raw_payload, str):
+            raise ValueError(
+                "component payload must be stored as its canonical JSON "
+                "string; found a legacy AttributeValue-encoded payload, "
+                "whose number forms are not round-trip stable through "
+                "DynamoDB (numbers normalize, e.g. 0.0 -> 0) and can "
+                "never re-verify against content_hash"
+            )
         return cls(
             slug=data["slug"],
             version=int(data["version"]),
             name=data["component"],
-            payload=data["payload"],
+            payload=json.loads(raw_payload),
             provenance=data["provenance"],
             content_hash=data["content_hash"],
             payload_s3_key=data.get("payload_s3_key"),

--- a/receipt_dynamo/receipt_dynamo/migrations/merchant_truth_v1_live.py
+++ b/receipt_dynamo/receipt_dynamo/migrations/merchant_truth_v1_live.py
@@ -27,6 +27,7 @@ from pathlib import Path
 from typing import Any, Protocol, Sequence
 
 from receipt_dynamo.data.shared_exceptions import (
+    MerchantTruthConflictError,
     MerchantTruthIntegrityError,
     MerchantTruthTableMismatchError,
 )
@@ -35,6 +36,8 @@ from receipt_dynamo.entities.merchant_truth import (
     MerchantTruthComponent,
     MerchantTruthManifest,
     canonical_json_bytes,
+    merchant_truth_pk,
+    version_prefix,
 )
 from receipt_dynamo.merchant_truth_loader import (
     MerchantTruthLoader,
@@ -379,3 +382,121 @@ def _verify_one_bundle(
         bundle_hash=artifact.bundle_hash,
         mismatches=tuple(mismatches),
     )
+
+
+@dataclass(frozen=True)
+class OpenVersionCleanupResult:
+    """Outcome of an owner-gated unsealed-OPEN-version cleanup."""
+
+    slug: str
+    version: int
+    found_keys: tuple[str, ...]
+    deleted: bool
+
+    @property
+    def report_lines(self) -> list[str]:
+        verb = "DELETED" if self.deleted else "WOULD DELETE (dry run)"
+        lines = [
+            f"cleanup {self.slug} v{self.version}: {verb} "
+            f"{len(self.found_keys)} rows (AUDIT rows are preserved)"
+        ]
+        lines.extend(f"  {key}" for key in self.found_keys)
+        return lines
+
+
+def cleanup_unsealed_open_version(
+    dynamodb_client: Any,
+    *,
+    table_name: str,
+    slug: str,
+    version: int,
+    explicit_table: bool = False,
+    delete: bool = False,
+) -> OpenVersionCleanupResult:
+    """Owner-gated recovery: remove the rows of a FAILED, never-sealed mint.
+
+    This exists for exactly one situation: a migration mint wrote its OPEN
+    manifest + components but the seal failed (e.g. the G1 costco mint,
+    whose legacy AttributeValue-encoded payloads lost number-form fidelity
+    and can never re-verify). ``mint_version`` is create-only, so a re-mint
+    cannot proceed while those rows exist; the resume protocol cannot help
+    because the stored representation itself is unverifiable.
+
+    Guardrails: table pinning identical to the live mint (prod refused
+    unconditionally); refuses to touch anything unless the manifest exists
+    and is ``OPEN`` (a SEALED version is immutable truth and is never
+    deleted); deletion is a single conditional transaction; append-only
+    ``AUDIT#`` rows are outside the version key range and are always
+    preserved as the historical record of the failed attempt. Default is a
+    dry run that only lists the rows.
+    """
+    validate_live_table(table_name, explicit=explicit_table)
+    partition_key = merchant_truth_pk(slug)
+    sort_prefix = f"{version_prefix(version)}#"
+    items: list[dict[str, Any]] = []
+    exclusive_start_key = None
+    while True:
+        request: dict[str, Any] = {
+            "TableName": table_name,
+            "KeyConditionExpression": "PK = :pk AND begins_with(SK, :sk)",
+            "ExpressionAttributeValues": {
+                ":pk": {"S": partition_key},
+                ":sk": {"S": sort_prefix},
+            },
+            "ConsistentRead": True,
+        }
+        if exclusive_start_key is not None:
+            request["ExclusiveStartKey"] = exclusive_start_key
+        response = dynamodb_client.query(**request)
+        items.extend(response.get("Items", []))
+        exclusive_start_key = response.get("LastEvaluatedKey")
+        if not exclusive_start_key:
+            break
+    found_keys = tuple(item["SK"]["S"] for item in items)
+    if not items:
+        return OpenVersionCleanupResult(slug, version, (), deleted=False)
+    manifest_items = [
+        item
+        for item in items
+        if item["SK"]["S"] == f"{version_prefix(version)}#MANIFEST"
+    ]
+    if len(manifest_items) != 1:
+        raise MerchantTruthIntegrityError(
+            f"{slug} v{version} has {len(manifest_items)} manifest rows; "
+            "refusing cleanup of an unrecognized state"
+        )
+    status = manifest_items[0].get("status", {}).get("S")
+    if status != "OPEN":
+        raise MerchantTruthConflictError(
+            f"refusing cleanup: {slug} v{version} manifest status is "
+            f"{status!r}; only a never-sealed OPEN version may be removed"
+        )
+    if not delete:
+        return OpenVersionCleanupResult(slug, version, found_keys, False)
+    actions: list[dict[str, Any]] = []
+    for item in items:
+        key = {"PK": item["PK"], "SK": item["SK"]}
+        if item["SK"]["S"].endswith("#MANIFEST"):
+            actions.append(
+                {
+                    "Delete": {
+                        "TableName": table_name,
+                        "Key": key,
+                        "ConditionExpression": "#status = :open",
+                        "ExpressionAttributeNames": {"#status": "status"},
+                        "ExpressionAttributeValues": {":open": {"S": "OPEN"}},
+                    }
+                }
+            )
+        else:
+            actions.append(
+                {
+                    "Delete": {
+                        "TableName": table_name,
+                        "Key": key,
+                        "ConditionExpression": "attribute_exists(PK)",
+                    }
+                }
+            )
+    dynamodb_client.transact_write_items(TransactItems=actions)
+    return OpenVersionCleanupResult(slug, version, found_keys, True)

--- a/receipt_dynamo/tests/integration/test_merchant_truth_open_cleanup.py
+++ b/receipt_dynamo/tests/integration/test_merchant_truth_open_cleanup.py
@@ -1,0 +1,273 @@
+"""Owner-gated cleanup of a failed (never-sealed) OPEN mint + recovery.
+
+Simulates the orphaned G1 costco state — an OPEN manifest with legacy
+AttributeValue-encoded component payloads that can never re-verify — and
+proves the documented recovery path: cleanup deletes exactly the OPEN
+version rows (audits preserved), after which the fixed code re-mints and
+seals the same version successfully.
+"""
+
+from typing import Any
+
+import boto3
+import pytest
+
+from receipt_dynamo import DynamoClient
+from receipt_dynamo.data.shared_exceptions import (
+    MerchantTruthConflictError,
+    MerchantTruthTableMismatchError,
+)
+from receipt_dynamo.entities.dynamodb_utils import to_dynamodb_value
+from receipt_dynamo.entities.merchant_truth import (
+    COMPONENT_NAMES,
+    MerchantTruthAudit,
+    MerchantTruthComponent,
+    MerchantTruthManifest,
+    compute_bundle_hash,
+)
+from receipt_dynamo.migrations.merchant_truth_v1_live import (
+    PROD_TABLE_NAME,
+    cleanup_unsealed_open_version,
+)
+
+pytestmark = pytest.mark.integration
+SLUG = "costco_wholesale"
+NOW = "2026-07-21T16:00:00+00:00"
+LEGACY_PROVENANCE = {
+    "source_kind": "migration",
+    "provenance_completeness": "legacy",
+    "written_by": {
+        "kind": "migration",
+        "name": "merchant_truth_v1",
+        "version": "1",
+    },
+}
+# Real G1 culprit values: integral floats whose AttributeValue form
+# real DynamoDB normalizes (0.0 -> 0), breaking hash re-verification.
+PAYLOADS: dict[str, Any] = {
+    name: {"component": name, "bitmap_thin": 0.0, "scale": 1.0}
+    for name in sorted(COMPONENT_NAMES)
+}
+
+
+def build_components() -> list[MerchantTruthComponent]:
+    return [
+        MerchantTruthComponent(
+            slug=SLUG,
+            version=1,
+            name=name,
+            payload=PAYLOADS[name],
+            provenance=dict(LEGACY_PROVENANCE),
+        )
+        for name in sorted(COMPONENT_NAMES)
+    ]
+
+
+def seed_orphaned_open_mint(table: str) -> None:
+    """Write the failed-mint state exactly as the old code left it in dev:
+    OPEN manifest + legacy AttributeValue-encoded components + MINT audit.
+    """
+    dynamodb = boto3.client("dynamodb", region_name="us-east-1")
+    components = build_components()
+    hashes = {item.name: item.content_hash for item in components}
+    manifest = MerchantTruthManifest(
+        slug=SLUG,
+        version=1,
+        component_hashes=hashes,
+        bundle_hash=compute_bundle_hash(hashes),
+        status="OPEN",
+        provenance={"written_by": LEGACY_PROVENANCE["written_by"]},
+        mint_run_id="merchant-truth-v1-costco-orphan",
+    )
+    dynamodb.put_item(TableName=table, Item=manifest.to_item())
+    for component in components:
+        item = component.to_item()
+        # The pre-fix representation: a native AttributeValue tree.
+        item["payload"] = to_dynamodb_value(component.payload)
+        dynamodb.put_item(TableName=table, Item=item)
+    audit = MerchantTruthAudit(
+        slug=SLUG,
+        created_at=NOW,
+        audit_id="orphanedmintauditrecord001",
+        action="MINT",
+        version=1,
+        bundle_hash=manifest.bundle_hash,
+        details={"run_id": manifest.mint_run_id, "component_count": 7},
+    )
+    dynamodb.put_item(TableName=table, Item=audit.to_item())
+
+
+def version_row_keys(table: str) -> list[str]:
+    response = boto3.client("dynamodb", region_name="us-east-1").query(
+        TableName=table,
+        KeyConditionExpression="PK = :pk AND begins_with(SK, :sk)",
+        ExpressionAttributeValues={
+            ":pk": {"S": f"MERCHANT_TRUTH#{SLUG}"},
+            ":sk": {"S": "TRUTH#v0000000001#"},
+        },
+        ConsistentRead=True,
+    )
+    return sorted(item["SK"]["S"] for item in response["Items"])
+
+
+def audit_row_count(table: str) -> int:
+    response = boto3.client("dynamodb", region_name="us-east-1").query(
+        TableName=table,
+        KeyConditionExpression="PK = :pk AND begins_with(SK, :sk)",
+        ExpressionAttributeValues={
+            ":pk": {"S": f"MERCHANT_TRUTH#{SLUG}"},
+            ":sk": {"S": "AUDIT#"},
+        },
+        ConsistentRead=True,
+    )
+    return len(response["Items"])
+
+
+def cleanup(table: str, *, delete: bool):
+    return cleanup_unsealed_open_version(
+        boto3.client("dynamodb", region_name="us-east-1"),
+        table_name=table,
+        slug=SLUG,
+        version=1,
+        explicit_table=True,
+        delete=delete,
+    )
+
+
+def test_orphaned_legacy_rows_cannot_seal_even_after_the_fix(
+    dynamodb_table: str,
+) -> None:
+    """The stored representation is unverifiable: reject, do not resume."""
+    seed_orphaned_open_mint(dynamodb_table)
+    client = DynamoClient(dynamodb_table)
+
+    with pytest.raises(ValueError, match="legacy AttributeValue"):
+        client.seal_version(
+            SLUG,
+            1,
+            {"status": "PASS", "passed": True},
+            [],
+            dynamodb_table,
+            sealed_at=NOW,
+        )
+
+
+def test_cleanup_dry_run_lists_rows_and_deletes_nothing(
+    dynamodb_table: str,
+) -> None:
+    seed_orphaned_open_mint(dynamodb_table)
+
+    result = cleanup(dynamodb_table, delete=False)
+
+    assert not result.deleted
+    assert len(result.found_keys) == 8  # manifest + 7 components
+    assert len(version_row_keys(dynamodb_table)) == 8
+    assert audit_row_count(dynamodb_table) == 1
+
+
+def test_cleanup_deletes_open_rows_and_preserves_audits(
+    dynamodb_table: str,
+) -> None:
+    seed_orphaned_open_mint(dynamodb_table)
+
+    result = cleanup(dynamodb_table, delete=True)
+
+    assert result.deleted
+    assert len(result.found_keys) == 8
+    assert version_row_keys(dynamodb_table) == []
+    assert audit_row_count(dynamodb_table) == 1
+
+
+def test_cleanup_refuses_sealed_versions(dynamodb_table: str) -> None:
+    client = DynamoClient(dynamodb_table)
+    components = build_components()
+    client.mint_version(
+        SLUG,
+        1,
+        components,
+        {"written_by": LEGACY_PROVENANCE["written_by"]},
+        "run-sealed",
+        dynamodb_table,
+        created_at=NOW,
+    )
+    client.seal_version(
+        SLUG,
+        1,
+        {"status": "PASS", "passed": True},
+        [],
+        dynamodb_table,
+        sealed_at=NOW,
+    )
+
+    with pytest.raises(MerchantTruthConflictError, match="OPEN"):
+        cleanup(dynamodb_table, delete=True)
+    assert len(version_row_keys(dynamodb_table)) == 8
+
+
+def test_cleanup_refuses_prod_table_unconditionally() -> None:
+    class ExplodingDynamo:
+        def __getattr__(self, name: str) -> Any:
+            raise AssertionError("prod refusal must precede any call")
+
+    for explicit in (True, False):
+        with pytest.raises(
+            MerchantTruthTableMismatchError, match="unconditional"
+        ):
+            cleanup_unsealed_open_version(
+                ExplodingDynamo(),
+                table_name=PROD_TABLE_NAME,
+                slug=SLUG,
+                version=1,
+                explicit_table=explicit,
+                delete=True,
+            )
+
+
+def test_cleanup_is_a_noop_when_the_version_is_absent(
+    dynamodb_table: str,
+) -> None:
+    result = cleanup(dynamodb_table, delete=True)
+
+    assert not result.deleted
+    assert result.found_keys == ()
+
+
+def test_recovery_end_to_end_cleanup_then_remint_and_seal(
+    dynamodb_table: str,
+) -> None:
+    """The full G1 recovery: cleanup, re-mint with fixed code, seal, verify."""
+    seed_orphaned_open_mint(dynamodb_table)
+    cleanup(dynamodb_table, delete=True)
+
+    client = DynamoClient(dynamodb_table)
+    components = build_components()
+    client.mint_version(
+        SLUG,
+        1,
+        components,
+        {"written_by": LEGACY_PROVENANCE["written_by"]},
+        "merchant-truth-v1-costco-remint",
+        dynamodb_table,
+        created_at=NOW,
+    )
+    sealed = client.seal_version(
+        SLUG,
+        1,
+        {"status": "PASS", "passed": True},
+        [],
+        dynamodb_table,
+        sealed_at=NOW,
+    )
+
+    assert sealed.status == "SEALED"
+    read_back = {
+        component.name: component
+        for component in client.list_merchant_truth_components(
+            SLUG, 1, consistent_read=True
+        )
+    }
+    assert set(read_back) == COMPONENT_NAMES
+    for component in components:
+        assert read_back[component.name].payload == component.payload
+        assert read_back[component.name].content_hash == component.content_hash
+    assert audit_row_count(dynamodb_table) == 3  # orphan MINT + MINT + SEAL

--- a/receipt_dynamo/tests/unit/test_merchant_truth_component_roundtrip.py
+++ b/receipt_dynamo/tests/unit/test_merchant_truth_component_roundtrip.py
@@ -1,0 +1,189 @@
+"""Hash-stable payload round-trip through DynamoDB number normalization.
+
+Reproduces the G1 live-mint failure: real DynamoDB normalizes number
+representations (``0.0`` is stored and returned as ``0``), so a payload
+stored as a native AttributeValue tree changes its canonical JSON across
+the write/read round-trip and fails ``content_hash`` verification on
+read-back (seen live on costco_wholesale ``C#typography`` via
+``bitmap_thin: 0.0``). moto preserves the literal number string, which is
+why the original moto suite could not catch it — these tests simulate the
+real service's normalization explicitly.
+"""
+
+from decimal import Decimal
+from typing import Any
+
+import pytest
+
+from receipt_dynamo.entities.dynamodb_utils import to_dynamodb_value
+from receipt_dynamo.entities.merchant_truth import (
+    MerchantTruthComponent,
+    canonical_json_bytes,
+)
+
+pytestmark = pytest.mark.unit
+
+LEGACY_PROVENANCE = {
+    "source_kind": "migration",
+    "provenance_completeness": "legacy",
+    "written_by": {
+        "kind": "migration",
+        "name": "merchant_truth_v1",
+        "version": "1",
+    },
+}
+
+# The real Costco Wholesale profile slice that broke the G1 seal:
+# ``bitmap_thin: 0.0`` plus integral floats (display heading scales),
+# non-integral floats, nested maps, and lists — taken verbatim from
+# scripts/merchant_profiles.json at the time of the failure.
+COSTCO_TYPOGRAPHY_PAYLOAD: dict[str, Any] = {
+    "typography": {
+        "bitmap_thin": 0.0,
+        "bitmap_font": {
+            "regular": "bitMatrix-C2.glyphs.npz",
+            "heavy": "bitMatrix-C2-heavy.glyphs.npz",
+        },
+        "condense": 0.93,
+    },
+    "section_scale": {"FOOTER": 0.5},
+}
+COSTCO_FLAGS_PAYLOAD: dict[str, Any] = {
+    "typography": {
+        "display_headings": {
+            "SELF-CHECKOUT": 1.7,
+            "SELF CHECKOUT": 1.7,
+            "THANK YOU": 1.4,
+            "PLEASE COME AGAIN": 1.4,
+            "ITEMS SOLD:": 1.8,
+        },
+        "reverse_total": True,
+        "reverse_date_after_items": True,
+        "dashed_separators": True,
+        "heading_bleed_phrase": "ITEMS SOLD:",
+        "reverse_date_anchor": "NUMBER OF ITEMS SOLD",
+        "dash_after_amount_date": True,
+        "dash_around_phrases": ["SHOP CARD"],
+        "face_source": "stylemap",
+    }
+}
+COSTCO_LAYOUT_PAYLOAD: dict[str, Any] = {
+    "available": True,
+    "template": {
+        "version": 1,
+        "measured": {
+            "receipts": 12,
+            "tool_git_sha": "d9ce9cb82ecf",
+            "tool_dirty": False,
+        },
+        "columns": {
+            "barcode": [
+                {
+                    "role": "desc",
+                    "anchor": "left",
+                    "x": 0.2479,
+                    "spread": 0.007,
+                    "support": 7,
+                }
+            ],
+            "footer": [
+                {
+                    "role": "desc",
+                    "anchor": "left",
+                    "x": 0.0171,
+                    "spread": 0.0,
+                    "support": 12,
+                }
+            ],
+        },
+    },
+}
+
+
+def normalize_numbers(value: dict[str, Any]) -> dict[str, Any]:
+    """Simulate real DynamoDB's stored number representation.
+
+    DynamoDB treats ``0.0`` and ``0`` as the same number and returns the
+    normalized form without a trailing fractional part; moto returns the
+    literal string it was given.
+    """
+    if "N" in value:
+        number = Decimal(value["N"])
+        integral = number.to_integral_value()
+        if number == integral:
+            return {"N": str(integral)}
+        return {"N": str(number.normalize())}
+    if "M" in value:
+        return {
+            "M": {
+                key: normalize_numbers(item)
+                for key, item in value["M"].items()
+            }
+        }
+    if "L" in value:
+        return {"L": [normalize_numbers(item) for item in value["L"]]}
+    return value
+
+
+def component(name: str, payload: Any) -> MerchantTruthComponent:
+    return MerchantTruthComponent(
+        slug="costco_wholesale",
+        version=1,
+        name=name,
+        payload=payload,
+        provenance=dict(LEGACY_PROVENANCE),
+    )
+
+
+@pytest.mark.parametrize(
+    ("name", "payload"),
+    [
+        ("typography", COSTCO_TYPOGRAPHY_PAYLOAD),
+        ("flags", COSTCO_FLAGS_PAYLOAD),
+        ("layout", COSTCO_LAYOUT_PAYLOAD),
+    ],
+)
+def test_real_costco_payload_survives_dynamodb_number_normalization(
+    name: str, payload: Any
+) -> None:
+    """The exact G1 failure: fails on AttributeValue-encoded payloads."""
+    original = component(name, payload)
+
+    round_tripped = MerchantTruthComponent.from_item(
+        normalize_numbers({"M": original.to_item()})["M"]
+    )
+
+    assert round_tripped.payload == original.payload
+    assert round_tripped.content_hash == original.content_hash
+
+
+def test_payload_is_stored_as_the_exact_hashed_canonical_json_string() -> None:
+    original = component("typography", COSTCO_TYPOGRAPHY_PAYLOAD)
+
+    item = original.to_item()
+
+    assert item["payload"] == {
+        "S": canonical_json_bytes(COSTCO_TYPOGRAPHY_PAYLOAD).decode("utf-8")
+    }
+    assert '"bitmap_thin":0.0' in item["payload"]["S"]
+
+
+def test_zero_point_zero_float_form_is_preserved_verbatim() -> None:
+    original = component("typography", {"bitmap_thin": 0.0})
+
+    restored = MerchantTruthComponent.from_item(
+        normalize_numbers({"M": original.to_item()})["M"]
+    )
+
+    assert repr(restored.payload["bitmap_thin"]) == "0.0"
+    assert restored.content_hash == original.content_hash
+
+
+def test_legacy_attributevalue_payload_is_rejected_with_clear_error() -> None:
+    """The orphaned G1 costco rows must fail loudly, not with a hash riddle."""
+    original = component("typography", COSTCO_TYPOGRAPHY_PAYLOAD)
+    legacy_item = original.to_item()
+    legacy_item["payload"] = to_dynamodb_value(COSTCO_TYPOGRAPHY_PAYLOAD)
+
+    with pytest.raises(ValueError, match="legacy AttributeValue"):
+        MerchantTruthComponent.from_item(legacy_item)

--- a/receipt_dynamo/tests/unit/test_merchant_truth_v1_migration.py
+++ b/receipt_dynamo/tests/unit/test_merchant_truth_v1_migration.py
@@ -274,8 +274,11 @@ def test_dry_run_writer_outputs_payload_crosswalk_and_summary(
     )
 
 
+# Re-captured for the G1 round-trip fix: component payloads are now stored
+# as their canonical JSON string (hash-stable through DynamoDB number
+# normalization), which intentionally changed the payload-file bytes.
 DRY_RUN_GOLDEN_SHA256 = (
-    "0264778995a007e9f362800e9e971d881df748f9492cfcf04b4c43d96a9e4dc4"
+    "8d4fec8ca60deb16361391bfd499d4698cc6b49fe239c6e4c2eb2a3bb982c94f"
 )
 
 

--- a/scripts/cleanup_merchant_truth_open_version.py
+++ b/scripts/cleanup_merchant_truth_open_version.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Owner-gated cleanup of a FAILED (never-sealed) merchant-truth mint.
+
+Removes the OPEN manifest + component rows of one version so a fixed
+migration can re-mint it. Refuses SEALED versions unconditionally, refuses
+the prod table unconditionally, preserves append-only AUDIT rows, and is a
+dry run unless ``--delete`` is passed explicitly.
+
+Recovery context: the G1 v1 mint wrote costco_wholesale v1 with legacy
+AttributeValue-encoded payloads whose number forms DynamoDB normalized
+(``0.0`` -> ``0``); those rows can never re-verify against their content
+hashes, and mint_version is create-only, so they must be removed before the
+fixed migration re-mints.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+import boto3
+
+from receipt_dynamo.migrations.merchant_truth_v1 import DEV_TABLE_NAME
+from receipt_dynamo.migrations.merchant_truth_v1_live import (
+    cleanup_unsealed_open_version,
+)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--slug", required=True)
+    parser.add_argument("--version", type=int, default=1)
+    parser.add_argument(
+        "--table",
+        "--table-name",
+        dest="table_name",
+        default=None,
+        help=(
+            f"DynamoDB table (default: exact dev table {DEV_TABLE_NAME}). "
+            "Any other table must be passed explicitly; the prod table is "
+            "refused unconditionally."
+        ),
+    )
+    parser.add_argument("--region", default="us-east-1")
+    parser.add_argument(
+        "--delete",
+        action="store_true",
+        help=(
+            "Actually delete the OPEN rows (single conditional "
+            "transaction). Without this flag the script only lists them."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    explicit_table = args.table_name is not None
+    table_name = args.table_name or DEV_TABLE_NAME
+    result = cleanup_unsealed_open_version(
+        boto3.client("dynamodb", region_name=args.region),
+        table_name=table_name,
+        slug=args.slug,
+        version=args.version,
+        explicit_table=explicit_table,
+        delete=args.delete,
+    )
+    for line in result.report_lines:
+        print(line)
+    if not result.found_keys:
+        print("nothing to clean up")
+    elif not result.deleted:
+        print("dry run only — re-run with --delete to remove these rows")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Live failure (G1, 2026-07-21, dev table ReceiptsTable-dc5be22)

The first live v1 mint (owner gate G1, plan W4; #1197 / #1188 P4) minted `costco_wholesale` v1 (OPEN manifest + 7 components + MINT audit), then `seal_version`'s strong read-back raised `ValueError("content_hash does not match canonical payload")` in `MerchantTruthComponent.__post_init__`.

**Root cause (verified read-only against the live dev rows):** components stored their payload as a native AttributeValue tree, and real DynamoDB **normalizes number representations** — `bitmap_thin: 0.0` was written as `{"N": "0.0"}` and stored/returned as `0`. Read-back parsed it as int `0`, changing the canonical JSON (`0.0` → `0`), so the recomputed hash (`b8a61521…`) no longer matched the stored `content_hash` (`70947f1d…`). Leaf-diff of the live `C#typography` payload vs the dry-run file shows exactly one divergence:

```
DIFF .typography.bitmap_thin file= ('0.0', 'float') live= ('0', 'int')
```

moto preserves the literal number string, which is why the moto suite passed while real DynamoDB failed.

## Fix

`MerchantTruthComponent.to_item` now stores the payload as its **canonical JSON string** — the exact bytes `content_hash` was computed over — and `from_item` `json.loads` it. Strings round-trip verbatim through DynamoDB, so hash verification is representation-stable; JSON text → Python → canonical JSON text is a fixed point. Legacy AttributeValue-encoded payloads are rejected with an explicit error (they can never re-verify) instead of a confusing hash mismatch. All consumers (accessor, loader, promotion, migration, verify) go through the entity, so this is the single choke point. The contract doc gains a normative "Payload representation" paragraph. The dry-run golden digest was re-captured for this intentional representation change (the dry-run payload files now carry the payload as a JSON string attribute).

Why not fix number parsing instead: after DynamoDB normalization the distinction between `0.0` and `0` is *gone from the stored data* — no reader can recover it. Only storing the hashed bytes verbatim preserves the frozen hash contract.

## Recovery for the orphaned costco OPEN v1 (decision: cleanup-and-remint, not resume)

The orphan's stored representation is unverifiable forever (number-form fidelity lost), and `mint_version` is create-only, so the rows block any fresh mint (a re-mint under the fixed SHA has a different `run_id` ⇒ `MerchantTruthConflictError`). The resume protocol exists for oversized-mint continuation of *valid* rows, not representation migration — resuming would seal known-bad data. So: new owner-gated tool

```bash
# dry run (lists the 8 rows, deletes nothing)
python scripts/cleanup_merchant_truth_open_version.py --slug costco_wholesale --version 1
# actual cleanup
python scripts/cleanup_merchant_truth_open_version.py --slug costco_wholesale --version 1 --delete
```

Guardrails: same table pinning as the live mint (prod `ReceiptsTable-d7ff76a` refused unconditionally), refuses anything but a never-sealed `OPEN` manifest (SEALED versions are immutable and untouchable), single conditional transaction (manifest delete conditioned on `status = OPEN`), **append-only AUDIT rows preserved** as the historical record of the failed attempt, dry-run by default.

## G1 re-run instructions (owner-gated — not executed here)

On the mini, in a worktree at this branch (or main once merged), dev AWS creds:

```bash
python scripts/cleanup_merchant_truth_open_version.py --slug costco_wholesale --version 1 --delete
python scripts/migrate_merchant_truth_v1.py \
  --profiles scripts/merchant_profiles.json \
  --output-dir ~/section_label_kickoff/truth_v1_payloads \
  --live --verify
```

Expected: cleanup reports 8 deleted rows (audits preserved); then banner (table/13/SHA), 13 `MINTED+SEALED v1`, 3 `EXCLUDED (asset-blocked)`, `VERIFY OK: 13 live bundles byte-match the dry-run payloads`, exit 0.

## Tests

- **Unit reproducer with real costco data** (`test_merchant_truth_component_roundtrip.py`): the actual profile slice (`bitmap_thin: 0.0`, integral-float heading scales, nested maps/lists, layout column floats) pushed through a simulated DynamoDB number-normalization walk. Verified red on the old code (5/6 fail, including the exact typography culprit) and green on the fix; plus explicit `0.0`-preserved-verbatim and legacy-payload-rejection tests.
- **moto integration** (`test_merchant_truth_open_cleanup.py`): orphan state cannot seal even post-fix (explicit rejection); cleanup dry run/delete/sealed-refusal/unconditional prod refusal/absent-version noop; full recovery end-to-end (orphan → cleanup → re-mint → seal → hash-verified read-back, audits = orphan MINT + new MINT + SEAL).
- Full merchant-truth suite (component/loader/access/accessor/promotion/migration/live/cleanup): **69 passed**. black/isort clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BeLcSviHL5vDgS3zTSMbsq