### PR TITLE
[scripts] merchant_truth_diff CLI + fleet sealed-pending section (W5)

### DIFF
--- a/receipt_dynamo/receipt_dynamo/data/_merchant_truth.py
+++ b/receipt_dynamo/receipt_dynamo/data/_merchant_truth.py
@@ -887,6 +887,26 @@ class _MerchantTruth(FlattenedStandardMixin):
         )
         return [MerchantTruthActive.from_item(item) for item in items]
 
+    def list_merchant_truth_manifests(self) -> list[MerchantTruthManifest]:
+        """Read every version manifest fleet-wide through GSITYPE.
+
+        One query on ``TYPE = MERCHANT_TRUTH_MANIFEST`` (projection ALL),
+        mirroring ``list_active_merchant_truth``. This is the read that
+        makes SEALED-but-not-ACTIVE versions visible to fleet tooling —
+        during G1 the fleet view showed "0 ACTIVE" while 13 sealed bundles
+        existed invisibly.
+        """
+        items = self._query_all(
+            TableName=self.table_name,
+            IndexName="GSITYPE",
+            KeyConditionExpression="#type = :type",
+            ExpressionAttributeNames={"#type": "TYPE"},
+            ExpressionAttributeValues={
+                ":type": {"S": "MERCHANT_TRUTH_MANIFEST"}
+            },
+        )
+        return [MerchantTruthManifest.from_item(item) for item in items]
+
     def list_merchant_truth_proposals(
         self, slug: str
     ) -> list[MerchantTruthProposal]:

--- a/receipt_dynamo/receipt_dynamo/merchant_truth_loader.py
+++ b/receipt_dynamo/receipt_dynamo/merchant_truth_loader.py
@@ -34,6 +34,26 @@ class MerchantTruthReader(Protocol):
 
     def list_active_merchant_truth(self) -> list[MerchantTruthActive]: ...
 
+    def list_merchant_truth_manifests(
+        self,
+    ) -> list["MerchantTruthManifest"]: ...
+
+    def get_merchant_truth_manifest(
+        self,
+        slug: str,
+        version: int,
+        *,
+        consistent_read: bool = False,
+    ) -> "MerchantTruthManifest | None": ...
+
+    def list_merchant_truth_components(
+        self,
+        slug: str,
+        version: int,
+        *,
+        consistent_read: bool = False,
+    ) -> list[MerchantTruthComponent]: ...
+
     def get_active_merchant_truth(
         self, slug: str, *, consistent_read: bool = False
     ) -> MerchantTruthActive | None: ...

--- a/receipt_dynamo/tests/unit/test_merchant_truth_loader.py
+++ b/receipt_dynamo/tests/unit/test_merchant_truth_loader.py
@@ -131,6 +131,9 @@ class FakeReader:
             (item for item in self.active_records if item.slug == slug), None
         )
 
+    def list_merchant_truth_manifests(self) -> list[MerchantTruthManifest]:
+        raise AssertionError("the loader never lists fleet manifests")
+
     def read_merchant_truth_bundle_items(
         self,
         slug: str,

--- a/scripts/merchant_truth_diff.py
+++ b/scripts/merchant_truth_diff.py
@@ -1,0 +1,1128 @@
+#!/usr/bin/env python3
+"""Flip-review artifact for versioned merchant truth (W5, #1188 P4).
+
+Three read-only modes over SEALED merchant-truth bundles, plus a fleet
+sweep:
+
+  Mode A (version diff):
+      merchant_truth_diff.py --slug vons --from v1 --to v2
+      Semantic per-component diff of two sealed versions. Components with
+      identical content_hash collapse to one line. Layout diffs express
+      column moves in paper-width units (the layout payload's column ``x``
+      values are paper-width fractions); typography/flags/stylemap diff at
+      leaf level (dotted paths, old -> new); assets diff per artifact
+      (hash + pointer); catalog snapshots diff items added/removed/
+      price-changed. Provenance deltas (pipeline, git SHA, measured_at)
+      are shown per changed component.
+
+  Mode B (first activation review):
+      merchant_truth_diff.py --slug costco_wholesale --to v1
+      An activation decision document: component hashes + payload sizes,
+      key measured values, gate status + gate provenance, bundle_hash,
+      and what the flip will do. This is what the owner reads before the
+      FIRST ACTIVE flip (owner gate G2).
+
+  Mode C (legacy comparison):
+      merchant_truth_diff.py --slug costco_wholesale --to v1 \
+          --legacy scripts/merchant_profiles.json
+      Diff the minted bundle against the legacy profile source per the
+      migration crosswalk. G1 bundles were minted from that file, so the
+      expected result is byte-equivalence on every profile-derived
+      component; any deviation renders as a Mode-A style diff.
+
+  --all-sealed:
+      Emit a Mode B summary for every SEALED-but-not-ACTIVE version in
+      the table — the owner's G2 review packet in one command.
+
+Read-only always: this tool holds no writer surface and never flips.
+Env/table convention matches synthesis_loop/fleet_status.py: default dev
+table ReceiptsTable-dc5be22 via DYNAMODB_TABLE_NAME; the prod table
+(ReceiptsTable-d7ff76a) is refused unconditionally.
+
+Exit codes: 0 rendered; 1 data/integrity error; 2 refused configuration.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Iterable
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.dirname(HERE)
+for _p in (os.path.join(REPO, "receipt_dynamo"),):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from receipt_dynamo.entities.merchant_truth import (  # noqa: E402
+    COMPONENT_NAMES,
+    canonical_json_bytes,
+    compute_bundle_hash,
+    hash_payload,
+)
+from receipt_dynamo.merchant_truth_loader import (  # noqa: E402
+    normalize_merchant_alias,
+)
+from receipt_dynamo.migrations.merchant_truth_v1 import (  # noqa: E402
+    DECIDED_TYPOGRAPHY_FIELDS,
+    MEASURED_TYPOGRAPHY_FIELDS,
+    slugify_merchant,
+)
+
+if TYPE_CHECKING:
+    from receipt_dynamo.entities.merchant_truth import (
+        MerchantTruthActive,
+        MerchantTruthComponent,
+        MerchantTruthManifest,
+    )
+    from receipt_dynamo.merchant_truth_loader import MerchantTruthReader
+
+DEV_TABLE_NAME = "ReceiptsTable-dc5be22"
+PROD_TABLE_NAME = "ReceiptsTable-d7ff76a"
+PROD_TABLE_MARKER = "d7ff76a"
+SHORT_HASH_LEN = 12
+
+# Fixed review order: identity first, decided flags and catalog last.
+COMPONENT_ORDER = (
+    "identity",
+    "typography",
+    "stylemap",
+    "layout",
+    "assets",
+    "flags",
+    "catalog_snapshot",
+)
+assert set(COMPONENT_ORDER) == COMPONENT_NAMES
+
+# Flag groups copied verbatim into C#flags by the v1 migration writer.
+PROFILE_FLAG_GROUPS = (
+    "header",
+    "graphics",
+    "compose",
+    "logo_subtitle",
+    "logo_reserve_subtitle",
+)
+# Profile keys copied into the assets component's "profile" sub-object.
+PROFILE_ASSET_KEYS = ("logo", "logo_anchor")
+
+
+class DiffError(Exception):
+    """A data or integrity problem that must stop the review render."""
+
+
+def resolve_table(cli_table: str | None) -> str:
+    """Resolve the target table and refuse prod explicitly."""
+    table = (
+        cli_table or os.environ.get("DYNAMODB_TABLE_NAME") or DEV_TABLE_NAME
+    )
+    if table == PROD_TABLE_NAME or PROD_TABLE_MARKER in table:
+        raise ValueError(
+            f"merchant_truth_diff never reads prod; refusing table "
+            f"{table!r} (prod = {PROD_TABLE_NAME!r})"
+        )
+    return table
+
+
+def parse_version(text: str) -> int:
+    """Accept ``v1``, ``1``, or the padded ``v0000000001`` key form."""
+    match = re.fullmatch(r"v?(\d+)", text.strip().lower())
+    if match is None:
+        raise ValueError(f"invalid version {text!r}; expected e.g. v1")
+    version = int(match.group(1))
+    if version < 1:
+        raise ValueError(f"invalid version {text!r}; versions start at v1")
+    return version
+
+
+def short_hash(digest: str) -> str:
+    return digest[:SHORT_HASH_LEN]
+
+
+def format_value(value: Any) -> str:
+    """Render one leaf value compactly and deterministically."""
+    return json.dumps(
+        value, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+    )
+
+
+def format_paper_x(value: float) -> str:
+    """Render a column x position (a paper-width fraction) at 4 decimals."""
+    return f"{value:.4f}"
+
+
+def format_paper_move(old_x: float, new_x: float) -> str:
+    """Render a column move in paper-width units.
+
+    Layout column ``x`` values are fractions of the paper width, so the
+    signed delta IS the move expressed in paper-width units.
+    """
+    delta = new_x - old_x
+    return (
+        f"x {format_paper_x(old_x)} -> {format_paper_x(new_x)} "
+        f"(moved {delta:+.4f} paper-width)"
+    )
+
+
+def flatten_leaves(value: Any, prefix: str = "") -> dict[str, Any]:
+    """Flatten to dotted leaf paths; list elements use ``[i]``."""
+    leaves: dict[str, Any] = {}
+    if isinstance(value, dict):
+        if not value:
+            leaves[prefix or "(root)"] = {}
+            return leaves
+        for key in sorted(value):
+            path = f"{prefix}.{key}" if prefix else str(key)
+            leaves.update(flatten_leaves(value[key], path))
+        return leaves
+    if isinstance(value, list):
+        if not value:
+            leaves[prefix or "(root)"] = []
+            return leaves
+        for index, item in enumerate(value):
+            leaves.update(flatten_leaves(item, f"{prefix}[{index}]"))
+        return leaves
+    leaves[prefix or "(root)"] = value
+    return leaves
+
+
+def diff_leaves(old: Any, new: Any, *, prefix: str = "") -> list[str]:
+    """Leaf-level value diff: added / removed / changed dotted paths."""
+    old_leaves = flatten_leaves(old, prefix)
+    new_leaves = flatten_leaves(new, prefix)
+    lines: list[str] = []
+    for path in sorted(set(old_leaves) | set(new_leaves)):
+        if path not in new_leaves:
+            lines.append(
+                f"- {path} (removed): {format_value(old_leaves[path])}"
+            )
+        elif path not in old_leaves:
+            lines.append(f"- {path} (added): {format_value(new_leaves[path])}")
+        elif old_leaves[path] != new_leaves[path]:
+            lines.append(
+                f"- {path}: {format_value(old_leaves[path])} -> "
+                f"{format_value(new_leaves[path])}"
+            )
+    return lines
+
+
+# --------------------------------------------------------------------------
+# Bundle loading + integrity
+# --------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Bundle:
+    """A verified SEALED version: manifest plus its component payloads."""
+
+    manifest: "MerchantTruthManifest"
+    components: dict[str, "MerchantTruthComponent"]
+
+    def payload(self, name: str) -> Any:
+        return self.components[name].payload
+
+    def payload_size(self, name: str) -> int:
+        return len(canonical_json_bytes(self.components[name].payload))
+
+
+def load_bundle(
+    reader: "MerchantTruthReader", slug: str, version: int
+) -> Bundle:
+    """Read one version and fail closed on any integrity mismatch."""
+    manifest = reader.get_merchant_truth_manifest(slug, version)
+    if manifest is None:
+        raise DiffError(f"no manifest for {slug} v{version}")
+    if manifest.status != "SEALED":
+        raise DiffError(
+            f"{slug} v{version} is {manifest.status}; only SEALED "
+            "versions are reviewable"
+        )
+    components = {
+        item.name: item
+        for item in reader.list_merchant_truth_components(slug, version)
+    }
+    if set(components) != COMPONENT_NAMES:
+        raise DiffError(
+            f"{slug} v{version} components do not match the contract: "
+            f"loaded {sorted(components)}"
+        )
+    actual_hashes = {
+        name: components[name].content_hash for name in sorted(components)
+    }
+    if actual_hashes != manifest.component_hashes:
+        raise DiffError(
+            f"{slug} v{version} component hashes do not match the manifest"
+        )
+    if compute_bundle_hash(actual_hashes) != manifest.bundle_hash:
+        raise DiffError(f"{slug} v{version} bundle hash verification failed")
+    return Bundle(manifest=manifest, components=components)
+
+
+# --------------------------------------------------------------------------
+# Mode A: semantic per-component version diff
+# --------------------------------------------------------------------------
+
+
+def _column_key(column: dict[str, Any]) -> tuple[str, str]:
+    return (str(column.get("role")), str(column.get("anchor")))
+
+
+def _describe_column(column: dict[str, Any]) -> str:
+    extras = ", ".join(
+        f"{key} {format_value(column[key])}"
+        for key in sorted(column)
+        if key not in {"role", "anchor", "x"}
+    )
+    suffix = f" ({extras})" if extras else ""
+    return f"at x {format_paper_x(float(column.get('x', 0.0)))}{suffix}"
+
+
+def diff_layout(old_payload: Any, new_payload: Any) -> list[str]:
+    """Layout diff: column moves in paper-width units + leaf changes."""
+    lines: list[str] = []
+    old_payload = old_payload if isinstance(old_payload, dict) else {}
+    new_payload = new_payload if isinstance(new_payload, dict) else {}
+    if old_payload.get("available") != new_payload.get("available"):
+        lines.append(
+            f"- available: {format_value(old_payload.get('available'))} -> "
+            f"{format_value(new_payload.get('available'))}"
+        )
+    old_template = old_payload.get("template") or {}
+    new_template = new_payload.get("template") or {}
+    old_columns = old_template.get("columns") or {}
+    new_columns = new_template.get("columns") or {}
+    for section in sorted(set(old_columns) | set(new_columns)):
+        lines.extend(
+            _diff_section_columns(
+                section,
+                old_columns.get(section) or [],
+                new_columns.get(section) or [],
+            )
+        )
+    old_rest = {k: v for k, v in old_template.items() if k != "columns"}
+    new_rest = {k: v for k, v in new_template.items() if k != "columns"}
+    lines.extend(diff_leaves(old_rest, new_rest, prefix="template"))
+    return lines
+
+
+def _diff_section_columns(
+    section: str,
+    old_cols: list[dict[str, Any]],
+    new_cols: list[dict[str, Any]],
+) -> list[str]:
+    """Pair columns by (role, anchor) in x order; report moves/add/remove."""
+    lines: list[str] = []
+    keys = sorted({_column_key(col) for col in [*old_cols, *new_cols]})
+    for key in keys:
+        role, anchor = key
+        olds = sorted(
+            (c for c in old_cols if _column_key(c) == key),
+            key=lambda c: float(c.get("x", 0.0)),
+        )
+        news = sorted(
+            (c for c in new_cols if _column_key(c) == key),
+            key=lambda c: float(c.get("x", 0.0)),
+        )
+        label = f"{section}: {role}/{anchor} column"
+        for old_col, new_col in zip(olds, news):
+            old_x = float(old_col.get("x", 0.0))
+            new_x = float(new_col.get("x", 0.0))
+            if old_x != new_x:
+                lines.append(f"- {label} {format_paper_move(old_x, new_x)}")
+            for field_name in sorted(
+                (set(old_col) | set(new_col)) - {"x", "role", "anchor"}
+            ):
+                if old_col.get(field_name) != new_col.get(field_name):
+                    lines.append(
+                        f"- {label} {field_name}: "
+                        f"{format_value(old_col.get(field_name))} -> "
+                        f"{format_value(new_col.get(field_name))}"
+                    )
+        for new_col in news[len(olds) :]:
+            lines.append(f"- {label} added {_describe_column(new_col)}")
+        for old_col in olds[len(news) :]:
+            lines.append(f"- {label} removed {_describe_column(old_col)}")
+    return lines
+
+
+def _artifact_fields(artifact: Any) -> dict[str, Any]:
+    return artifact if isinstance(artifact, dict) else {"value": artifact}
+
+
+def _diff_artifact(name: str, old: Any, new: Any) -> list[str]:
+    """Per-artifact diff: hash + pointer first, then remaining fields."""
+    lines: list[str] = []
+    old_fields = _artifact_fields(old)
+    new_fields = _artifact_fields(new)
+    if old is None and new is not None:
+        lines.append(f"- {name} added: {format_value(new)}")
+        return lines
+    if old is not None and new is None:
+        lines.append(f"- {name} removed: {format_value(old)}")
+        return lines
+    for field_name, label in (
+        ("content_hash", "hash"),
+        ("s3_key", "pointer"),
+    ):
+        if old_fields.get(field_name) != new_fields.get(field_name):
+            lines.append(
+                f"- {name} {label}: "
+                f"{format_value(old_fields.get(field_name))} -> "
+                f"{format_value(new_fields.get(field_name))}"
+            )
+    rest_old = {
+        k: v
+        for k, v in old_fields.items()
+        if k not in {"content_hash", "s3_key"}
+    }
+    rest_new = {
+        k: v
+        for k, v in new_fields.items()
+        if k not in {"content_hash", "s3_key"}
+    }
+    lines.extend(diff_leaves(rest_old, rest_new, prefix=name))
+    return lines
+
+
+def diff_assets(old_payload: Any, new_payload: Any) -> list[str]:
+    """Asset diff: per font face, logo, and the profile sub-object."""
+    lines: list[str] = []
+    old_payload = old_payload if isinstance(old_payload, dict) else {}
+    new_payload = new_payload if isinstance(new_payload, dict) else {}
+    old_fonts = old_payload.get("fonts") or {}
+    new_fonts = new_payload.get("fonts") or {}
+    for face in sorted(set(old_fonts) | set(new_fonts)):
+        lines.extend(
+            _diff_artifact(
+                f"font[{face}]", old_fonts.get(face), new_fonts.get(face)
+            )
+        )
+    lines.extend(
+        _diff_artifact(
+            "logo", old_payload.get("logo"), new_payload.get("logo")
+        )
+    )
+    lines.extend(
+        diff_leaves(
+            old_payload.get("profile") or {},
+            new_payload.get("profile") or {},
+            prefix="profile",
+        )
+    )
+    if old_payload.get("missing_merchant_font") != new_payload.get(
+        "missing_merchant_font"
+    ):
+        lines.append(
+            "- missing_merchant_font: "
+            f"{format_value(old_payload.get('missing_merchant_font'))} -> "
+            f"{format_value(new_payload.get('missing_merchant_font'))}"
+        )
+    return lines
+
+
+def _catalog_items_by_key(
+    payload: Any,
+) -> dict[tuple[str, str, int], dict[str, Any]]:
+    items = (payload or {}).get("items") or []
+    keyed: dict[tuple[str, str, int], dict[str, Any]] = {}
+    occurrence: dict[tuple[str, str], int] = {}
+    for item in items:
+        base = (
+            str(item.get("category", "")),
+            str(item.get("product_text", "")),
+        )
+        index = occurrence.get(base, 0)
+        occurrence[base] = index + 1
+        keyed[(*base, index)] = item
+    return keyed
+
+
+def _catalog_label(key: tuple[str, str, int]) -> str:
+    category, product_text, index = key
+    suffix = f" #{index + 1}" if index else ""
+    prefix = f"{category}/" if category else ""
+    return f"{prefix}{product_text}{suffix}"
+
+
+def diff_catalog(old_payload: Any, new_payload: Any) -> list[str]:
+    """Catalog diff: items added/removed/price-changed + summary fields."""
+    lines: list[str] = []
+    old_items = _catalog_items_by_key(old_payload)
+    new_items = _catalog_items_by_key(new_payload)
+    for key in sorted(set(old_items) | set(new_items)):
+        label = _catalog_label(key)
+        if key not in new_items:
+            lines.append(
+                f"- item removed: {label} "
+                f"(price {format_value(old_items[key].get('price'))})"
+            )
+            continue
+        if key not in old_items:
+            lines.append(
+                f"- item added: {label} "
+                f"(price {format_value(new_items[key].get('price'))})"
+            )
+            continue
+        old_item, new_item = old_items[key], new_items[key]
+        if old_item.get("price") != new_item.get("price"):
+            lines.append(
+                f"- price changed: {label} "
+                f"{format_value(old_item.get('price'))} -> "
+                f"{format_value(new_item.get('price'))}"
+            )
+        other = diff_leaves(
+            {k: v for k, v in old_item.items() if k != "price"},
+            {k: v for k, v in new_item.items() if k != "price"},
+            prefix=f"item[{label}]",
+        )
+        lines.extend(other)
+    for field_name in ("item_count", "catalog_hash", "as_of"):
+        old_value = (old_payload or {}).get(field_name)
+        new_value = (new_payload or {}).get(field_name)
+        if old_value != new_value:
+            lines.append(
+                f"- {field_name}: {format_value(old_value)} -> "
+                f"{format_value(new_value)}"
+            )
+    return lines
+
+
+def diff_component_payload(name: str, old: Any, new: Any) -> list[str]:
+    """Dispatch to the semantic differ for one component."""
+    if name == "layout":
+        return diff_layout(old, new)
+    if name == "assets":
+        return diff_assets(old, new)
+    if name == "catalog_snapshot":
+        return diff_catalog(old, new)
+    # identity, typography, stylemap, flags: leaf-level value diff.
+    return diff_leaves(old, new)
+
+
+def provenance_delta_lines(
+    old_prov: dict[str, Any], new_prov: dict[str, Any]
+) -> list[str]:
+    """Pipeline / git SHA / measured_at deltas for a changed component."""
+    lines: list[str] = []
+    old_pipeline = (
+        f"{old_prov.get('pipeline')}@{old_prov.get('pipeline_version')}"
+    )
+    new_pipeline = (
+        f"{new_prov.get('pipeline')}@{new_prov.get('pipeline_version')}"
+    )
+    for label, old_value, new_value in (
+        ("pipeline", old_pipeline, new_pipeline),
+        ("git_sha", old_prov.get("git_sha"), new_prov.get("git_sha")),
+        (
+            "measured_at",
+            old_prov.get("measured_at"),
+            new_prov.get("measured_at"),
+        ),
+    ):
+        if old_value != new_value:
+            lines.append(
+                f"  provenance {label}: {format_value(old_value)} -> "
+                f"{format_value(new_value)}"
+            )
+        else:
+            lines.append(
+                f"  provenance {label}: {format_value(new_value)} "
+                "(unchanged)"
+            )
+    return lines
+
+
+def render_version_diff(old: Bundle, new: Bundle, *, table: str) -> list[str]:
+    """Mode A: the reviewed semantic diff between two sealed versions."""
+    slug = new.manifest.slug
+    lines = [
+        f"# Merchant-truth diff: {slug} "
+        f"v{old.manifest.version} -> v{new.manifest.version}",
+        "",
+        f"Table: `{table}`",
+        "",
+        f"- bundle_hash: `{old.manifest.bundle_hash}` ->",
+        f"  `{new.manifest.bundle_hash}`",
+        f"- gate: {old.manifest.gate_status} -> {new.manifest.gate_status}"
+        f" | sealed_at: {old.manifest.sealed_at} -> "
+        f"{new.manifest.sealed_at}",
+    ]
+    identical = [
+        name
+        for name in COMPONENT_ORDER
+        if old.components[name].content_hash
+        == new.components[name].content_hash
+    ]
+    changed = [name for name in COMPONENT_ORDER if name not in set(identical)]
+    lines += ["", "## Components", ""]
+    for name in identical:
+        lines.append(
+            f"- {name}: identical "
+            f"(content_hash `{short_hash(old.components[name].content_hash)}`)"
+        )
+    for name in changed:
+        old_component = old.components[name]
+        new_component = new.components[name]
+        lines += [
+            "",
+            f"### {name} — CHANGED "
+            f"(`{short_hash(old_component.content_hash)}` -> "
+            f"`{short_hash(new_component.content_hash)}`)",
+            "",
+        ]
+        body = diff_component_payload(
+            name, old_component.payload, new_component.payload
+        )
+        if body:
+            lines.extend(body)
+        else:
+            # Hash changed but leaf diff is empty: only possible when
+            # canonicalization-invisible details moved; still show it.
+            lines.append(
+                "- (payload leaf diff is empty despite a hash change)"
+            )
+        lines.extend(
+            provenance_delta_lines(
+                old_component.provenance, new_component.provenance
+            )
+        )
+    if not changed:
+        lines += ["", "No component content changed between the versions."]
+    return lines
+
+
+# --------------------------------------------------------------------------
+# Mode B: first-activation summary (the G2 decision document)
+# --------------------------------------------------------------------------
+
+
+def _numeric_leaf_lines(payload: Any) -> list[str]:
+    return [
+        f"- {path}: {format_value(value)}"
+        for path, value in sorted(flatten_leaves(payload).items())
+    ]
+
+
+def _layout_summary_lines(payload: Any) -> list[str]:
+    payload = payload if isinstance(payload, dict) else {}
+    lines = [f"- available: {format_value(payload.get('available'))}"]
+    template = payload.get("template") or {}
+    measured = template.get("measured") or {}
+    if measured:
+        lines.append(
+            f"- measured: {format_value(measured.get('receipts'))} receipts"
+            f" (tool {measured.get('tool_git_sha')}, "
+            f"dirty {format_value(measured.get('tool_dirty'))})"
+        )
+    columns = template.get("columns") or {}
+    if columns:
+        per_section = ", ".join(
+            f"{section}={len(columns[section])}" for section in sorted(columns)
+        )
+        lines.append(f"- columns per section: {per_section}")
+    return lines
+
+
+def _artifact_summary(name: str, artifact: Any) -> str:
+    if not isinstance(artifact, dict):
+        return f"- {name}: {format_value(artifact)}"
+    pointer = artifact.get("s3_key") or artifact.get("local_path")
+    digest = artifact.get("content_hash")
+    digest_text = f"`{short_hash(digest)}`" if digest else "(no hash)"
+    return f"- {name}: {pointer} hash {digest_text}"
+
+
+def _assets_summary_lines(payload: Any) -> list[str]:
+    payload = payload if isinstance(payload, dict) else {}
+    lines: list[str] = []
+    fonts = payload.get("fonts") or {}
+    for face in sorted(fonts):
+        lines.append(_artifact_summary(f"font[{face}]", fonts[face]))
+    logo = payload.get("logo")
+    if logo is not None:
+        lines.append(_artifact_summary("logo", logo))
+    else:
+        lines.append("- logo: none published")
+    profile = payload.get("profile") or {}
+    if profile:
+        lines.append(
+            "- profile assets: "
+            + ", ".join(
+                f"{key}={format_value(profile[key])}"
+                for key in sorted(profile)
+            )
+        )
+    if payload.get("missing_merchant_font"):
+        lines.append("- WARNING: missing MerchantFont row for this merchant")
+    return lines
+
+
+def _stylemap_summary_lines(payload: Any) -> list[str]:
+    payload = payload if isinstance(payload, dict) else {}
+    lines = [f"- available: {format_value(payload.get('available'))}"]
+    source = payload.get("source")
+    if source:
+        lines.append(_artifact_summary("source", source))
+    document = payload.get("document")
+    if isinstance(document, dict):
+        sections = document.get("sections")
+        if isinstance(sections, (dict, list)):
+            lines.append(f"- document sections: {len(sections)}")
+    return lines
+
+
+def _catalog_summary_lines(payload: Any) -> list[str]:
+    payload = payload if isinstance(payload, dict) else {}
+    catalog_hash = payload.get("catalog_hash") or ""
+    return [
+        f"- items: {format_value(payload.get('item_count'))} "
+        f"(catalog_hash `{short_hash(catalog_hash)}`, "
+        f"as_of {payload.get('as_of')})"
+    ]
+
+
+def _identity_summary_lines(payload: Any) -> list[str]:
+    payload = payload if isinstance(payload, dict) else {}
+    aliases = payload.get("normalized_aliases") or []
+    return [
+        f"- merchant_name: {format_value(payload.get('merchant_name'))}",
+        f"- slug: {payload.get('slug')} "
+        f"(upper {payload.get('upper_slug')})",
+        f"- normalized aliases: {len(aliases)}",
+    ]
+
+
+def _flags_summary_lines(payload: Any) -> list[str]:
+    payload = payload if isinstance(payload, dict) else {}
+    leaves = flatten_leaves(payload)
+    groups = ", ".join(sorted(payload)) if payload else "(none)"
+    return [
+        f"- {len(leaves)} decided leaves across groups: {groups}",
+        "- flags are git-sourced engine config "
+        "(truth = measured; flags = decided)",
+    ]
+
+
+def _gate_lines(manifest: "MerchantTruthManifest") -> list[str]:
+    gate = manifest.gate_results or {}
+    lines = [
+        f"- gate_status: {manifest.gate_status}"
+        + (
+            f" — {gate.get('gate')} ({gate.get('kind')})"
+            if gate.get("gate")
+            else ""
+        )
+    ]
+    if gate.get("note"):
+        lines.append(f"  - note: {gate['note']}")
+    evidence = gate.get("evidence") or {}
+    if evidence:
+        detail = ", ".join(
+            f"{key}={format_value(evidence[key])}" for key in sorted(evidence)
+        )
+        lines.append(f"  - evidence: {detail}")
+    written_by = gate.get("written_by") or {}
+    if written_by:
+        lines.append(
+            f"  - gate written_by: {written_by.get('kind')}/"
+            f"{written_by.get('name')}@{written_by.get('version')}"
+        )
+    return lines
+
+
+def render_activation_summary(
+    bundle: Bundle,
+    active: "MerchantTruthActive | None",
+    *,
+    table: str,
+) -> list[str]:
+    """Mode B: the decision document read before an ACTIVE flip."""
+    manifest = bundle.manifest
+    slug = manifest.slug
+    lines = [
+        f"# Merchant-truth activation review: {slug} v{manifest.version}",
+        "",
+        f"Table: `{table}`",
+        "",
+    ]
+    if active is None:
+        lines.append(
+            "FIRST ACTIVATION: no ACTIVE pointer exists for this merchant. "
+            "Flipping creates the initial pointer (conditional Put; "
+            "owner gate G2)."
+        )
+    elif active.version >= manifest.version:
+        lines.append(
+            f"NOTE: ACTIVE already points at v{active.version} "
+            f"(`{short_hash(active.bundle_hash)}`); this version is not "
+            "pending activation."
+        )
+    else:
+        lines.append(
+            f"UPGRADE: ACTIVE currently points at v{active.version} "
+            f"(`{short_hash(active.bundle_hash)}`); flipping moves it to "
+            f"v{manifest.version}."
+        )
+    provenance = manifest.provenance or {}
+    written_by = provenance.get("written_by") or {}
+    lines += [
+        "",
+        "## Decision summary",
+        "",
+        f"- bundle_hash: `{manifest.bundle_hash}`",
+        f"- manifest: {manifest.status}, sealed_at {manifest.sealed_at}",
+        *_gate_lines(manifest),
+        f"- mint: run `{manifest.mint_run_id}`, written_by "
+        f"{written_by.get('kind')}/{written_by.get('name')}"
+        f"@{written_by.get('version')}, git_sha "
+        f"{format_value(provenance.get('git_sha'))}",
+    ]
+    blockers = provenance.get("migration_blockers") or []
+    if blockers:
+        lines.append(f"- migration blockers at mint: {format_value(blockers)}")
+    lines += [
+        "",
+        "## Components",
+        "",
+        "| component | content_hash | payload bytes |",
+        "|---|---|---|",
+    ]
+    for name in COMPONENT_ORDER:
+        component = bundle.components[name]
+        lines.append(
+            f"| {name} | `{short_hash(component.content_hash)}` "
+            f"| {bundle.payload_size(name)} |"
+        )
+    lines += ["", "## Key measured values", ""]
+    sections: list[tuple[str, list[str]]] = [
+        ("identity", _identity_summary_lines(bundle.payload("identity"))),
+        ("typography", _numeric_leaf_lines(bundle.payload("typography"))),
+        ("layout", _layout_summary_lines(bundle.payload("layout"))),
+        ("assets", _assets_summary_lines(bundle.payload("assets"))),
+        ("stylemap", _stylemap_summary_lines(bundle.payload("stylemap"))),
+        (
+            "catalog_snapshot",
+            _catalog_summary_lines(bundle.payload("catalog_snapshot")),
+        ),
+        ("flags", _flags_summary_lines(bundle.payload("flags"))),
+    ]
+    for title, body in sections:
+        lines.append(f"### {title}")
+        lines.append("")
+        lines.extend(body)
+        lines.append("")
+    lines += [
+        "## Flip",
+        "",
+        "This tool never flips. The owner runs the flip "
+        "(DynamoClient.initial_activate for a first activation, "
+        "flip_active thereafter) after reading this review — owner "
+        "gate G2.",
+    ]
+    return lines
+
+
+# --------------------------------------------------------------------------
+# Mode C: legacy profile comparison (crosswalk sanity)
+# --------------------------------------------------------------------------
+
+LEGACY_SKIP_REASONS = {
+    "stylemap": "sourced from MerchantFont/S3 stylemap object, "
+    "not merchant_profiles.json",
+    "catalog_snapshot": "sourced from the MERCHANT_CATALOG partition, "
+    "not merchant_profiles.json",
+}
+
+
+def _select_keys(
+    source: dict[str, Any], names: Iterable[str]
+) -> dict[str, Any]:
+    allowed = set(names)
+    return {key: value for key, value in source.items() if key in allowed}
+
+
+def build_legacy_expectations(
+    document: dict[str, Any], slug: str
+) -> tuple[str, dict[str, Any]]:
+    """Rebuild the profile-derived component payloads for one merchant.
+
+    Mirrors the v1 migration writer's profile-derived construction
+    (``merchant_truth_v1._build_merchant_payload``) using the same
+    imported measured/decided field sets, so byte-equivalence here means
+    the sealed bundle faithfully carries the legacy source per the
+    crosswalk.
+    """
+    profiles = document.get("profiles")
+    if not isinstance(profiles, dict):
+        raise DiffError("legacy document must contain a profiles map")
+    merchant_name = next(
+        (name for name in profiles if slugify_merchant(name) == slug), None
+    )
+    if merchant_name is None:
+        raise DiffError(f"no legacy profile maps to slug {slug!r}")
+    profile = profiles[merchant_name]
+    aliases = [merchant_name, *profile.get("aliases", [])]
+    identity = {
+        "merchant_name": merchant_name,
+        "slug": slug,
+        "aliases": profile.get("aliases", []),
+        "upper_slug": slug.upper(),
+        "normalized_aliases": sorted(
+            {normalize_merchant_alias(alias) for alias in [slug, *aliases]}
+        ),
+    }
+    typography_source = profile.get("typography", {})
+    typography = {
+        "typography": _select_keys(
+            typography_source, MEASURED_TYPOGRAPHY_FIELDS
+        ),
+        "section_scale": profile.get("section_scale", {}),
+    }
+    flags: dict[str, Any] = {
+        "typography": _select_keys(
+            typography_source, DECIDED_TYPOGRAPHY_FIELDS
+        )
+    }
+    for key in PROFILE_FLAG_GROUPS:
+        if key in profile:
+            flags[key] = profile[key]
+    layout_template = profile.get("layout_template")
+    if isinstance(layout_template, dict):
+        layout_template = {
+            key: value
+            for key, value in layout_template.items()
+            if key != "_comment"
+        }
+    layout = {
+        "available": layout_template is not None,
+        "template": layout_template,
+    }
+    assets_profile = {
+        key: profile[key] for key in PROFILE_ASSET_KEYS if key in profile
+    }
+    if "stylemap" in typography_source:
+        assets_profile["stylemap_filename"] = typography_source["stylemap"]
+    return merchant_name, {
+        "identity": identity,
+        "typography": typography,
+        "flags": flags,
+        "layout": layout,
+        "assets.profile": assets_profile,
+    }
+
+
+def render_legacy_comparison(
+    bundle: Bundle, legacy_path: str, *, table: str
+) -> list[str]:
+    """Mode C: byte-equivalence report vs the legacy profile source."""
+    with open(legacy_path, encoding="utf-8") as handle:
+        document = json.load(handle)
+    slug = bundle.manifest.slug
+    merchant_name, expectations = build_legacy_expectations(document, slug)
+    lines = [
+        f"# Legacy comparison: {slug} v{bundle.manifest.version} "
+        f"vs {os.path.basename(legacy_path)}",
+        "",
+        f"Table: `{table}` | Legacy profile: {format_value(merchant_name)}",
+        "",
+        "| component | crosswalk coverage | result |",
+        "|---|---|---|",
+    ]
+    diff_sections: list[tuple[str, list[str]]] = []
+    for name in COMPONENT_ORDER:
+        if name in LEGACY_SKIP_REASONS:
+            lines.append(
+                f"| {name} | none — {LEGACY_SKIP_REASONS[name]} | SKIPPED |"
+            )
+            continue
+        if name == "assets":
+            expected = expectations["assets.profile"]
+            actual = (bundle.payload("assets") or {}).get("profile") or {}
+            coverage = "partial: profile sub-object only"
+            label = "assets.profile"
+        else:
+            expected = expectations[name]
+            actual = bundle.payload(name)
+            coverage = "full (profile-derived)"
+            label = name
+        if canonical_json_bytes(expected) == canonical_json_bytes(actual):
+            lines.append(
+                f"| {name} | {coverage} | BYTE-EQUIVALENT "
+                f"(`{short_hash(hash_payload(actual))}`) |"
+            )
+        else:
+            lines.append(f"| {name} | {coverage} | DIFFERS (see below) |")
+            if name == "assets":
+                body = diff_leaves(expected, actual)
+            else:
+                body = diff_component_payload(name, expected, actual)
+            diff_sections.append((label, body))
+    if diff_sections:
+        for label, body in diff_sections:
+            lines += [
+                "",
+                f"## {label} — legacy -> stored",
+                "",
+                *(body or ["- (no leaf-level differences found)"]),
+            ]
+    else:
+        lines += [
+            "",
+            "All profile-derived content is byte-equivalent to the sealed "
+            "bundle (expected for G1 v1 bundles minted from this file).",
+        ]
+    return lines
+
+
+# --------------------------------------------------------------------------
+# --all-sealed: the G2 review packet
+# --------------------------------------------------------------------------
+
+
+def render_all_sealed(
+    reader: "MerchantTruthReader", *, table: str
+) -> list[str]:
+    """Mode B summaries for every SEALED-but-not-ACTIVE version."""
+    manifests = reader.list_merchant_truth_manifests()
+    active_by_slug = {
+        record.slug: record for record in reader.list_active_merchant_truth()
+    }
+    pending = sorted(
+        (
+            manifest
+            for manifest in manifests
+            if manifest.status == "SEALED"
+            and manifest.version
+            > getattr(active_by_slug.get(manifest.slug), "version", 0)
+        ),
+        key=lambda manifest: (manifest.slug, manifest.version),
+    )
+    lines = [
+        "# Merchant-truth G2 review packet: SEALED pending activation",
+        "",
+        f"Table: `{table}` | {len(pending)} sealed version(s) awaiting an "
+        "ACTIVE flip",
+    ]
+    for manifest in pending:
+        bundle = load_bundle(reader, manifest.slug, manifest.version)
+        lines += [
+            "",
+            "---",
+            "",
+            *render_activation_summary(
+                bundle, active_by_slug.get(manifest.slug), table=table
+            ),
+        ]
+    if not pending:
+        lines += ["", "No sealed version is waiting on an ACTIVE flip."]
+    return lines
+
+
+# --------------------------------------------------------------------------
+# CLI
+# --------------------------------------------------------------------------
+
+
+def main(
+    argv: list[str] | None = None,
+    *,
+    reader: "MerchantTruthReader | None" = None,
+) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__.splitlines()[0],
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--slug", help="merchant slug, e.g. costco_wholesale")
+    parser.add_argument(
+        "--from",
+        dest="from_version",
+        metavar="vM",
+        help="older sealed version for Mode A (e.g. v1)",
+    )
+    parser.add_argument(
+        "--to",
+        dest="to_version",
+        metavar="vN",
+        help="sealed version under review (e.g. v1)",
+    )
+    parser.add_argument(
+        "--legacy",
+        metavar="PATH",
+        help="Mode C: legacy merchant_profiles.json to compare against",
+    )
+    parser.add_argument(
+        "--all-sealed",
+        action="store_true",
+        help="emit Mode B summaries for every SEALED-but-not-ACTIVE version",
+    )
+    parser.add_argument(
+        "--table",
+        default=None,
+        help="DynamoDB table (default: DYNAMODB_TABLE_NAME env or "
+        f"{DEV_TABLE_NAME}); prod is refused unconditionally",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        table = resolve_table(args.table)
+        if args.all_sealed:
+            if (
+                args.slug
+                or args.to_version
+                or args.from_version
+                or args.legacy
+            ):
+                raise ValueError(
+                    "--all-sealed takes no --slug/--from/--to/--legacy"
+                )
+        else:
+            if not args.slug or not args.to_version:
+                raise ValueError(
+                    "--slug and --to are required (or use --all-sealed)"
+                )
+            if args.from_version and args.legacy:
+                raise ValueError(
+                    "--from and --legacy are mutually exclusive modes"
+                )
+    except ValueError as error:
+        print(f"REFUSED: {error}", file=sys.stderr)
+        return 2
+
+    if reader is None:
+        from receipt_dynamo.data.dynamo_client import (  # noqa: PLC0415
+            DynamoClient,
+        )
+
+        region = os.environ.get("AWS_REGION", "us-east-1")
+        reader = DynamoClient(table_name=table, region=region)
+
+    try:
+        if args.all_sealed:
+            lines = render_all_sealed(reader, table=table)
+        else:
+            to_version = parse_version(args.to_version)
+            bundle = load_bundle(reader, args.slug, to_version)
+            if args.from_version:
+                from_version = parse_version(args.from_version)
+                old_bundle = load_bundle(reader, args.slug, from_version)
+                lines = render_version_diff(old_bundle, bundle, table=table)
+            elif args.legacy:
+                lines = render_legacy_comparison(
+                    bundle, args.legacy, table=table
+                )
+            else:
+                active = reader.get_active_merchant_truth(args.slug)
+                lines = render_activation_summary(bundle, active, table=table)
+    except (DiffError, ValueError, OSError) as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+
+    print("\n".join(lines))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/synthesis_loop/fleet_status.py
+++ b/synthesis_loop/fleet_status.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python3
 """Fleet status v1: ACTIVE merchant-truth rows vs legacy enumerations.
 
-One GSITYPE query (TYPE=MERCHANT_TRUTH_ACTIVE) through the DynamoClient
-``_MerchantTruth`` reader surface (``list_active_merchant_truth``), then a
+Two GSITYPE queries through the DynamoClient ``_MerchantTruth`` reader
+surface: TYPE=MERCHANT_TRUTH_ACTIVE (``list_active_merchant_truth``) for
+the fleet table, and TYPE=MERCHANT_TRUTH_MANIFEST
+(``list_merchant_truth_manifests``) for the "SEALED (pending activation)"
+section — sealed versions with no (or an older) ACTIVE pointer. Then a
 cross-check against the two legacy merchant enumerations:
 
   * ``scripts/merchant_profiles.json`` profile keys
@@ -44,7 +47,10 @@ from receipt_dynamo.migrations.merchant_truth_v1 import (  # noqa: E402
 )
 
 if TYPE_CHECKING:
-    from receipt_dynamo.entities.merchant_truth import MerchantTruthActive
+    from receipt_dynamo.entities.merchant_truth import (
+        MerchantTruthActive,
+        MerchantTruthManifest,
+    )
     from receipt_dynamo.merchant_truth_loader import MerchantTruthReader
 
 DEV_TABLE_NAME = "ReceiptsTable-dc5be22"
@@ -118,12 +124,40 @@ def _staleness_days(activated_at: str, now: datetime) -> int:
     return int((now - activated).total_seconds() // 86400)
 
 
+def build_sealed_pending(
+    manifests: list["MerchantTruthManifest"],
+    active_records: list["MerchantTruthActive"],
+) -> list[dict[str, Any]]:
+    """SEALED versions not (or no longer) covered by an ACTIVE pointer.
+
+    A version is pending activation when its manifest is SEALED and the
+    merchant either has no ACTIVE pointer at all or the ACTIVE pointer
+    names an older version. This is the G1 evidence gap: 13 sealed
+    bundles were invisible behind a "0 ACTIVE" fleet view.
+    """
+    active_version = {record.slug: record.version for record in active_records}
+    pending = [
+        {
+            "slug": manifest.slug,
+            "version": manifest.version,
+            "gate_status": manifest.gate_status,
+            "sealed_at": manifest.sealed_at,
+            "bundle_hash_short": manifest.bundle_hash[:SHORT_HASH_LEN],
+        }
+        for manifest in manifests
+        if manifest.status == "SEALED"
+        and manifest.version > active_version.get(manifest.slug, 0)
+    ]
+    return sorted(pending, key=lambda row: (row["slug"], row["version"]))
+
+
 def build_report(
     active_records: list["MerchantTruthActive"],
     legacy: dict[str, dict[str, Any]],
     *,
     table: str,
     now: datetime,
+    manifests: list["MerchantTruthManifest"] | None = None,
 ) -> dict[str, Any]:
     """Assemble the full status document (source of both outputs)."""
     active_rows = [
@@ -148,14 +182,17 @@ def build_report(
         for slug, entry in sorted(legacy.items())
         if slug not in active_slugs
     ]
+    sealed_pending = build_sealed_pending(manifests or [], active_records)
     return {
         "table": table,
         "generated_at": now.isoformat(),
         "active_count": len(active_rows),
         "legacy_count": len(legacy),
         "missing_count": len(missing),
+        "sealed_pending_count": len(sealed_pending),
         "active": active_rows,
         "missing": missing,
+        "sealed_pending": sealed_pending,
         "unlisted_in_legacy": sorted(active_slugs - set(legacy)),
         "check_failures": [
             row["slug"] for row in active_rows if row["gate_status"] != "PASS"
@@ -171,6 +208,7 @@ def render_markdown(report: dict[str, Any]) -> str:
         f"Table: `{report['table']}` | Generated: {report['generated_at']}",
         "",
         f"**{report['active_count']} ACTIVE / "
+        f"{report['sealed_pending_count']} SEALED pending activation / "
         f"{report['missing_count']} missing** "
         f"(legacy enumerations: {report['legacy_count']} merchants)",
         "",
@@ -187,6 +225,29 @@ def render_markdown(report: dict[str, Any]) -> str:
             )
     else:
         lines.append("| (no ACTIVE merchant-truth rows) | | | | | |")
+    lines += [
+        "",
+        "## SEALED (pending activation)",
+        "",
+    ]
+    if report["sealed_pending"]:
+        lines += [
+            "| merchant | version | gate | sealed_at | bundle_hash |",
+            "|---|---|---|---|---|",
+        ]
+        for row in report["sealed_pending"]:
+            lines.append(
+                f"| {row['slug']} | {row['version']} "
+                f"| {row['gate_status']} | {row['sealed_at']} "
+                f"| `{row['bundle_hash_short']}` |"
+            )
+        lines += [
+            "",
+            "Review each with scripts/merchant_truth_diff.py before "
+            "flipping ACTIVE (owner gate G2).",
+        ]
+    else:
+        lines.append("None: no sealed version is waiting on an ACTIVE flip.")
     lines += [
         "",
         "## Missing from truth store (present in legacy enumerations)",
@@ -252,12 +313,14 @@ def main(
         region = os.environ.get("AWS_REGION", "us-east-1")
         reader = DynamoClient(table_name=table, region=region)
     active_records = reader.list_active_merchant_truth()
+    manifests = reader.list_merchant_truth_manifests()
 
     report = build_report(
         active_records,
         legacy,
         table=table,
         now=now or datetime.now(timezone.utc),
+        manifests=manifests,
     )
     if args.json:
         print(json.dumps(report, indent=2, sort_keys=True))

--- a/tests/fixtures/merchant_truth_diff/all_sealed_packet.md
+++ b/tests/fixtures/merchant_truth_diff/all_sealed_packet.md
@@ -1,0 +1,80 @@
+# Merchant-truth G2 review packet: SEALED pending activation
+
+Table: `ReceiptsTable-dc5be22` | 1 sealed version(s) awaiting an ACTIVE flip
+
+---
+
+# Merchant-truth activation review: vons v2
+
+Table: `ReceiptsTable-dc5be22`
+
+UPGRADE: ACTIVE currently points at v1 (`b9aa8cab58e6`); flipping moves it to v2.
+
+## Decision summary
+
+- bundle_hash: `5862c420875ffe385ae3f7c1625d4bfe82cb2084b9809d76916adce19d9d873d`
+- manifest: SEALED, sealed_at 2026-07-22T05:00:00+00:00
+- gate_status: PASS — full_fidelity_eval (fidelity-eval)
+  - note: metrics PASS on truth-loaded renders
+  - evidence: git_sha="feedbeef00112233445566778899aabbccddeeff", report="docs/reports/nightly/2026-07-22.md"
+  - gate written_by: measurement_pipeline/glyphstudio@1
+- mint: run `merchant-truth-v2-vons-feedbeef0011`, written_by measurement_pipeline/glyphstudio@1, git_sha "feedbeef00112233445566778899aabbccddeeff"
+
+## Components
+
+| component | content_hash | payload bytes |
+|---|---|---|
+| identity | `34a3b352fe75` | 125 |
+| typography | `a76daf97b9b4` | 136 |
+| stylemap | `68095ec717bc` | 292 |
+| layout | `7ad5b76b8605` | 454 |
+| assets | `1692b3841032` | 730 |
+| flags | `b5152efc3a5f` | 108 |
+| catalog_snapshot | `90ee0edf45ae` | 331 |
+
+## Key measured values
+
+### identity
+
+- merchant_name: "Vons"
+- slug: vons (upper VONS)
+- normalized aliases: 2
+
+### typography
+
+- section_scale.FOOTER: 0.5
+- typography.bitmap_font.regular: "vons.glyphs.npz"
+- typography.bitmap_thin: 0.0
+- typography.condense: 0.95
+- typography.ink: 0.82
+
+### layout
+
+- available: true
+- measured: 15 receipts (tool bbbb33334444, dirty false)
+- columns per section: footer=1, items=2, payment=1
+
+### assets
+
+- font[regular]: fonts/vons/vons-3333.glyphs.npz hash `333333333333`
+- logo: fonts/vons/logo-2222.png hash `222222222222`
+- profile assets: logo="vons_logo.png", logo_anchor={"center":true,"phrases":["VONS"]}, stylemap_filename="vons_stylemap.json"
+
+### stylemap
+
+- available: true
+- source: fonts/vons/stylemap-5f5f.json hash `5f5f5f5f5f5f`
+- document sections: 1
+
+### catalog_snapshot
+
+- items: 3 (catalog_hash `018be2b531a6`, as_of 2026-07-22T00:00:00+00:00)
+
+### flags
+
+- 4 decided leaves across groups: header, typography
+- flags are git-sourced engine config (truth = measured; flags = decided)
+
+## Flip
+
+This tool never flips. The owner runs the flip (DynamoClient.initial_activate for a first activation, flip_active thereafter) after reading this review — owner gate G2.

--- a/tests/fixtures/merchant_truth_diff/mode_a_version_diff.md
+++ b/tests/fixtures/merchant_truth_diff/mode_a_version_diff.md
@@ -1,0 +1,60 @@
+# Merchant-truth diff: vons v1 -> v2
+
+Table: `ReceiptsTable-dc5be22`
+
+- bundle_hash: `b9aa8cab58e6fb0ec67fbd497626a395b9c6657b33fa6255e1f7724de9dacdb8` ->
+  `5862c420875ffe385ae3f7c1625d4bfe82cb2084b9809d76916adce19d9d873d`
+- gate: PASS -> PASS | sealed_at: 2026-07-21T05:00:00+00:00 -> 2026-07-22T05:00:00+00:00
+
+## Components
+
+- identity: identical (content_hash `34a3b352fe75`)
+- stylemap: identical (content_hash `68095ec717bc`)
+
+### typography — CHANGED (`ec190e78a501` -> `a76daf97b9b4`)
+
+- typography.condense: 0.93 -> 0.95
+- typography.ink (added): 0.82
+  provenance pipeline: "merchant_truth_v1@1" -> "glyphstudio.layout_template@1"
+  provenance git_sha: "1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b" -> "feedbeef00112233445566778899aabbccddeeff"
+  provenance measured_at: null -> "2026-07-22T04:00:00+00:00"
+
+### layout — CHANGED (`bdc1c2034dd8` -> `7ad5b76b8605`)
+
+- footer: desc/left column added at x 0.0171 (spread 0.0186, support 8)
+- items: amount/right column x 0.9439 -> 0.9502 (moved +0.0063 paper-width)
+- items: amount/right column support: 8 -> 11
+- payment: label/left column removed at x 0.0063 (spread 0.0124, support 8)
+- template.measured.receipts: 12 -> 15
+- template.measured.tool_git_sha: "aaaa11112222" -> "bbbb33334444"
+  provenance pipeline: "merchant_truth_v1@1" -> "glyphstudio.layout_template@1"
+  provenance git_sha: "1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b" -> "feedbeef00112233445566778899aabbccddeeff"
+  provenance measured_at: null -> "2026-07-22T04:00:00+00:00"
+
+### assets — CHANGED (`8a5ddebe9602` -> `1692b3841032`)
+
+- font[regular] hash: "1111111111111111111111111111111111111111111111111111111111111111" -> "3333333333333333333333333333333333333333333333333333333333333333"
+- font[regular] pointer: "fonts/vons/vons-1111.glyphs.npz" -> "fonts/vons/vons-3333.glyphs.npz"
+- font[regular].compiled_at: "2026-07-01T00:00:00+00:00" -> "2026-07-22T00:00:00+00:00"
+- font[regular].source_commit: "1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b" -> "feedbeef00112233445566778899aabbccddeeff"
+  provenance pipeline: "merchant_truth_v1@1" -> "glyphstudio.layout_template@1"
+  provenance git_sha: "1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b" -> "feedbeef00112233445566778899aabbccddeeff"
+  provenance measured_at: null -> "2026-07-22T04:00:00+00:00"
+
+### flags — CHANGED (`c2c16d31005b` -> `b5152efc3a5f`)
+
+- typography.reverse_total: true -> false
+  provenance pipeline: "merchant_truth_v1@1" -> "glyphstudio.layout_template@1"
+  provenance git_sha: "1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b" -> "feedbeef00112233445566778899aabbccddeeff"
+  provenance measured_at: null -> "2026-07-22T04:00:00+00:00"
+
+### catalog_snapshot — CHANGED (`add723d20556` -> `90ee0edf45ae`)
+
+- price changed: dairy/MILK 2% "3.99" -> "4.19"
+- item removed: produce/FUJI APPLES (price "2.49")
+- item added: produce/ORANGES (price "3.49")
+- catalog_hash: "7d3929ba57911730d1e60f3f0ce81d02f5d0c82f7cfe8426469e98bea4d1f4b6" -> "018be2b531a6a604baea56787a7d6c23b9af4df5ad1385ddac7050c548cc1ff9"
+- as_of: "2026-07-20T00:00:00+00:00" -> "2026-07-22T00:00:00+00:00"
+  provenance pipeline: "merchant_truth_v1@1" -> "glyphstudio.layout_template@1"
+  provenance git_sha: "1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b" -> "feedbeef00112233445566778899aabbccddeeff"
+  provenance measured_at: null -> "2026-07-22T04:00:00+00:00"

--- a/tests/fixtures/merchant_truth_diff/mode_b_first_activation.md
+++ b/tests/fixtures/merchant_truth_diff/mode_b_first_activation.md
@@ -1,0 +1,73 @@
+# Merchant-truth activation review: vons v1
+
+Table: `ReceiptsTable-dc5be22`
+
+FIRST ACTIVATION: no ACTIVE pointer exists for this merchant. Flipping creates the initial pointer (conditional Put; owner gate G2).
+
+## Decision summary
+
+- bundle_hash: `b9aa8cab58e6fb0ec67fbd497626a395b9c6657b33fa6255e1f7724de9dacdb8`
+- manifest: SEALED, sealed_at 2026-07-21T05:00:00+00:00
+- gate_status: PASS — merchant_truth_v1_bootstrap (migration-bootstrap-seal)
+  - note: bootstrap seal: gate passes on dry-run<->live source parity only; no fidelity eval has run against truth-loaded renders yet
+  - evidence: generated_at="2026-07-21T04:00:00+00:00", git_sha="1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b"
+  - gate written_by: migration/merchant_truth_v1@1
+- mint: run `merchant-truth-v1-vons-1a2b3c4d5e6f`, written_by migration/merchant_truth_v1@1, git_sha "1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b"
+
+## Components
+
+| component | content_hash | payload bytes |
+|---|---|---|
+| identity | `34a3b352fe75` | 125 |
+| typography | `ec190e78a501` | 125 |
+| stylemap | `68095ec717bc` | 292 |
+| layout | `bdc1c2034dd8` | 443 |
+| assets | `8a5ddebe9602` | 730 |
+| flags | `c2c16d31005b` | 107 |
+| catalog_snapshot | `add723d20556` | 335 |
+
+## Key measured values
+
+### identity
+
+- merchant_name: "Vons"
+- slug: vons (upper VONS)
+- normalized aliases: 2
+
+### typography
+
+- section_scale.FOOTER: 0.5
+- typography.bitmap_font.regular: "vons.glyphs.npz"
+- typography.bitmap_thin: 0.0
+- typography.condense: 0.93
+
+### layout
+
+- available: true
+- measured: 12 receipts (tool aaaa11112222, dirty false)
+- columns per section: items=2, payment=2
+
+### assets
+
+- font[regular]: fonts/vons/vons-1111.glyphs.npz hash `111111111111`
+- logo: fonts/vons/logo-2222.png hash `222222222222`
+- profile assets: logo="vons_logo.png", logo_anchor={"center":true,"phrases":["VONS"]}, stylemap_filename="vons_stylemap.json"
+
+### stylemap
+
+- available: true
+- source: fonts/vons/stylemap-5f5f.json hash `5f5f5f5f5f5f`
+- document sections: 1
+
+### catalog_snapshot
+
+- items: 3 (catalog_hash `7d3929ba5791`, as_of 2026-07-20T00:00:00+00:00)
+
+### flags
+
+- 4 decided leaves across groups: header, typography
+- flags are git-sourced engine config (truth = measured; flags = decided)
+
+## Flip
+
+This tool never flips. The owner runs the flip (DynamoClient.initial_activate for a first activation, flip_active thereafter) after reading this review — owner gate G2.

--- a/tests/fixtures/merchant_truth_diff/mode_c_legacy_comparison.md
+++ b/tests/fixtures/merchant_truth_diff/mode_c_legacy_comparison.md
@@ -1,0 +1,15 @@
+# Legacy comparison: vons v1 vs merchant_profiles.json
+
+Table: `ReceiptsTable-dc5be22` | Legacy profile: "Vons"
+
+| component | crosswalk coverage | result |
+|---|---|---|
+| identity | full (profile-derived) | BYTE-EQUIVALENT (`34a3b352fe75`) |
+| typography | full (profile-derived) | BYTE-EQUIVALENT (`ec190e78a501`) |
+| stylemap | none — sourced from MerchantFont/S3 stylemap object, not merchant_profiles.json | SKIPPED |
+| layout | full (profile-derived) | BYTE-EQUIVALENT (`bdc1c2034dd8`) |
+| assets | partial: profile sub-object only | BYTE-EQUIVALENT (`f761ba880548`) |
+| flags | full (profile-derived) | BYTE-EQUIVALENT (`c2c16d31005b`) |
+| catalog_snapshot | none — sourced from the MERCHANT_CATALOG partition, not merchant_profiles.json | SKIPPED |
+
+All profile-derived content is byte-equivalent to the sealed bundle (expected for G1 v1 bundles minted from this file).

--- a/tests/test_fleet_status.py
+++ b/tests/test_fleet_status.py
@@ -8,7 +8,12 @@ from typing import Any
 
 import pytest
 
-from receipt_dynamo.entities.merchant_truth import MerchantTruthActive
+from receipt_dynamo.entities.merchant_truth import (
+    COMPONENT_NAMES,
+    MerchantTruthActive,
+    MerchantTruthManifest,
+    compute_bundle_hash,
+)
 from synthesis_loop import fleet_status
 
 NOW = datetime(2026, 7, 21, 12, 0, 0, tzinfo=timezone.utc)
@@ -20,14 +25,22 @@ class StubReader:
     """MerchantTruthReader protocol stub (same shape as loader FakeReader)."""
 
     def __init__(
-        self, active_records: list[MerchantTruthActive] | None = None
+        self,
+        active_records: list[MerchantTruthActive] | None = None,
+        manifests: list[MerchantTruthManifest] | None = None,
     ) -> None:
         self.active_records = active_records or []
+        self.manifests = manifests or []
         self.fleet_calls = 0
+        self.manifest_calls = 0
 
     def list_active_merchant_truth(self) -> list[MerchantTruthActive]:
         self.fleet_calls += 1
         return self.active_records
+
+    def list_merchant_truth_manifests(self) -> list[MerchantTruthManifest]:
+        self.manifest_calls += 1
+        return self.manifests
 
     def get_active_merchant_truth(
         self, slug: str, *, consistent_read: bool = False
@@ -63,6 +76,28 @@ def make_active(
     )
 
 
+def make_manifest(
+    slug: str = "vons",
+    *,
+    version: int = 1,
+    status: str = "SEALED",
+    gate_status: str = "PASS",
+    sealed_at: str | None = "2026-07-21T05:00:00+00:00",
+) -> MerchantTruthManifest:
+    component_hashes = {name: "c" * 64 for name in COMPONENT_NAMES}
+    return MerchantTruthManifest(
+        slug=slug,
+        version=version,
+        component_hashes=component_hashes,
+        bundle_hash=compute_bundle_hash(component_hashes),
+        status=status,
+        provenance={"written_by": "test"},
+        mint_run_id=f"run-{slug}-{version}",
+        gate_status=gate_status,
+        sealed_at=sealed_at if status == "SEALED" else None,
+    )
+
+
 def test_legacy_enumerations_union_to_sixteen_merchants() -> None:
     legacy = fleet_status.load_legacy_merchants()
     assert len(legacy) == 16
@@ -88,7 +123,7 @@ def test_empty_fleet_renders_zero_active_sixteen_missing_exit_zero(
     assert exit_code == 0
     assert reader.fleet_calls == 1
     output = capsys.readouterr().out
-    assert "**0 ACTIVE / 16 missing**" in output
+    assert "**0 ACTIVE / 0 SEALED pending activation / 16 missing**" in output
     assert "(no ACTIVE merchant-truth rows)" in output
     assert "| vons | Vons |" in output
     assert "| sprouts_farmers_market | Sprouts Farmers Market |" in output
@@ -105,7 +140,7 @@ def test_populated_fleet_renders_row_with_short_hash_and_staleness(
 
     assert exit_code == 0
     output = capsys.readouterr().out
-    assert "**1 ACTIVE / 15 missing**" in output
+    assert "**1 ACTIVE / 0 SEALED pending activation / 15 missing**" in output
     assert f"| vons | 1 | `{'a' * 12}` | PASS " in output
     assert "| 2026-07-18T12:00:00+00:00 | 3 |" in output
     # vons moved out of the missing list
@@ -196,6 +231,7 @@ def test_prod_table_flag_is_refused_before_any_read(
 
     assert exit_code == 2
     assert reader.fleet_calls == 0
+    assert reader.manifest_calls == 0
     captured = capsys.readouterr()
     assert "REFUSED" in captured.err
     assert captured.out == ""
@@ -219,3 +255,82 @@ def test_default_table_is_dev(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_prod_marker_variants_are_refused() -> None:
     with pytest.raises(ValueError, match="refusing"):
         fleet_status.resolve_table("ReceiptsTable-d7ff76a-copy")
+
+
+# ---------------------------------------------------------------------------
+# SEALED (pending activation) — the G1 evidence gap
+# ---------------------------------------------------------------------------
+
+
+def test_sealed_without_active_is_listed_pending(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    reader = StubReader(manifests=[make_manifest("vons", version=1)])
+
+    exit_code = fleet_status.main([], reader=reader, now=NOW)
+
+    assert exit_code == 0
+    assert reader.manifest_calls == 1
+    output = capsys.readouterr().out
+    assert "**0 ACTIVE / 1 SEALED pending activation / 16 missing**" in output
+    assert "## SEALED (pending activation)" in output
+    assert "| vons | 1 | PASS | 2026-07-21T05:00:00+00:00 |" in output
+
+
+def test_sealed_covered_by_equal_active_is_not_pending() -> None:
+    pending = fleet_status.build_sealed_pending(
+        [make_manifest("vons", version=1)], [make_active("vons", version=1)]
+    )
+    assert pending == []
+
+
+def test_sealed_newer_than_active_is_pending() -> None:
+    pending = fleet_status.build_sealed_pending(
+        [
+            make_manifest("vons", version=1),
+            make_manifest("vons", version=2),
+        ],
+        [make_active("vons", version=1)],
+    )
+    assert [(row["slug"], row["version"]) for row in pending] == [("vons", 2)]
+
+
+def test_open_manifest_is_never_pending() -> None:
+    pending = fleet_status.build_sealed_pending(
+        [make_manifest("vons", version=1, status="OPEN")], []
+    )
+    assert pending == []
+
+
+def test_sealed_pending_sorted_and_in_json_report(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    reader = StubReader(
+        manifests=[
+            make_manifest("vons", version=2),
+            make_manifest("cvs", version=1, gate_status="FAIL"),
+            make_manifest("vons", version=1),
+        ]
+    )
+
+    exit_code = fleet_status.main(["--json"], reader=reader, now=NOW)
+
+    assert exit_code == 0
+    report = json.loads(capsys.readouterr().out)
+    assert report["sealed_pending_count"] == 3
+    assert [
+        (row["slug"], row["version"], row["gate_status"])
+        for row in report["sealed_pending"]
+    ] == [("cvs", 1, "FAIL"), ("vons", 1, "PASS"), ("vons", 2, "PASS")]
+
+
+def test_no_sealed_pending_renders_none_line(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    reader = StubReader([make_active("vons")], [make_manifest("vons")])
+
+    exit_code = fleet_status.main([], reader=reader, now=NOW)
+
+    assert exit_code == 0
+    output = capsys.readouterr().out
+    assert "None: no sealed version is waiting on an ACTIVE flip." in output

--- a/tests/test_merchant_truth_diff.py
+++ b/tests/test_merchant_truth_diff.py
@@ -1,0 +1,780 @@
+"""Golden-snapshot + unit tests for scripts/merchant_truth_diff.py (W5).
+
+Fixture bundles are built through the real MerchantTruth entities, so every
+content_hash / bundle_hash in the golden files is computed by the same
+canonical-JSON hashing the live table uses. Regenerate goldens with:
+
+    UPDATE_GOLDEN=1 pytest tests/test_merchant_truth_diff.py
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from receipt_dynamo.entities.merchant_truth import (
+    COMPONENT_NAMES,
+    MerchantTruthActive,
+    MerchantTruthComponent,
+    MerchantTruthManifest,
+    compute_bundle_hash,
+    hash_payload,
+)
+from scripts import merchant_truth_diff as mtd
+
+GOLDEN_DIR = Path(__file__).parent / "fixtures" / "merchant_truth_diff"
+SLUG = "vons"
+GIT_SHA_V1 = "1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b"
+GIT_SHA_V2 = "feedbeef00112233445566778899aabbccddeeff"
+SEALED_AT_V1 = "2026-07-21T05:00:00+00:00"
+SEALED_AT_V2 = "2026-07-22T05:00:00+00:00"
+
+# ---------------------------------------------------------------------------
+# Fixture payloads (v1 mirrors the migration writer's profile-derived shape)
+# ---------------------------------------------------------------------------
+
+LEGACY_DOC: dict[str, Any] = {
+    "profiles": {
+        "Vons": {
+            "aliases": ["VONS #2011"],
+            "section_scale": {"FOOTER": 0.5},
+            "typography": {
+                "bitmap_font": {"regular": "vons.glyphs.npz"},
+                "bitmap_thin": 0.0,
+                "condense": 0.93,
+                "stylemap": "vons_stylemap.json",
+                "reverse_total": True,
+                "face_source": "stylemap",
+                "_face_source_comment": "legacy comment (discarded)",
+            },
+            "logo": "vons_logo.png",
+            "logo_anchor": {"phrases": ["VONS"], "center": True},
+            "layout_template": {
+                "version": 1,
+                "_comment": "migration note (discarded)",
+                "measured": {
+                    "receipts": 12,
+                    "tool_git_sha": "aaaa11112222",
+                    "tool_dirty": False,
+                },
+                "columns": {
+                    "items": [
+                        {
+                            "role": "desc",
+                            "anchor": "left",
+                            "x": 0.007,
+                            "spread": 0.0078,
+                            "support": 6,
+                        },
+                        {
+                            "role": "amount",
+                            "anchor": "right",
+                            "x": 0.9439,
+                            "spread": 0.0096,
+                            "support": 8,
+                        },
+                    ],
+                    "payment": [
+                        {
+                            "role": "label",
+                            "anchor": "left",
+                            "x": 0.0063,
+                            "spread": 0.0124,
+                            "support": 8,
+                        },
+                        {
+                            "role": "amount",
+                            "anchor": "right",
+                            "x": 0.9417,
+                            "spread": 0.0124,
+                            "support": 9,
+                        },
+                    ],
+                },
+            },
+            "header": {"lines": ["VONS", "(555) 555-0134"]},
+        }
+    }
+}
+
+CATALOG_ITEMS_V1 = [
+    {"category": "dairy", "product_text": "MILK 2%", "price": "3.99"},
+    {"category": "produce", "product_text": "BANANAS", "price": "0.99"},
+    {"category": "produce", "product_text": "FUJI APPLES", "price": "2.49"},
+]
+CATALOG_ITEMS_V2 = [
+    {"category": "dairy", "product_text": "MILK 2%", "price": "4.19"},
+    {"category": "produce", "product_text": "BANANAS", "price": "0.99"},
+    {"category": "produce", "product_text": "ORANGES", "price": "3.49"},
+]
+
+STYLEMAP_PAYLOAD = {
+    "available": True,
+    "document": {
+        "version": 1,
+        "source": "stylescan",
+        "sections": {"ITEMS": [{"face": "regular"}]},
+    },
+    "source": {
+        "bucket_alias": "merchant-font-artifacts",
+        "s3_key": "fonts/vons/stylemap-5f5f.json",
+        "content_hash": "5f" * 32,
+        "size": 812,
+    },
+}
+
+
+def _v1_payloads() -> dict[str, Any]:
+    profile = LEGACY_DOC["profiles"]["Vons"]
+    template = copy.deepcopy(profile["layout_template"])
+    template.pop("_comment")
+    return {
+        "identity": {
+            "merchant_name": "Vons",
+            "slug": SLUG,
+            "aliases": ["VONS #2011"],
+            "upper_slug": "VONS",
+            "normalized_aliases": ["vons", "vons 2011"],
+        },
+        "typography": {
+            "typography": {
+                "bitmap_font": {"regular": "vons.glyphs.npz"},
+                "bitmap_thin": 0.0,
+                "condense": 0.93,
+            },
+            "section_scale": {"FOOTER": 0.5},
+        },
+        "stylemap": copy.deepcopy(STYLEMAP_PAYLOAD),
+        "layout": {"available": True, "template": template},
+        "assets": {
+            "fonts": {
+                "regular": {
+                    "bucket_alias": "merchant-font-artifacts",
+                    "s3_key": "fonts/vons/vons-1111.glyphs.npz",
+                    "content_hash": "11" * 32,
+                    "source_commit": GIT_SHA_V1,
+                    "compiled_at": "2026-07-01T00:00:00+00:00",
+                    "cap_h": 34.0,
+                    "advance_ratio": 0.61,
+                    "pitch_check": "ok",
+                    "glyph_count": 96,
+                    "cache_filename": "vons.glyphs.npz",
+                }
+            },
+            "profile": {
+                "logo": "vons_logo.png",
+                "logo_anchor": {"phrases": ["VONS"], "center": True},
+                "stylemap_filename": "vons_stylemap.json",
+            },
+            "logo": {
+                "bucket_alias": "merchant-font-artifacts",
+                "s3_key": "fonts/vons/logo-2222.png",
+                "content_hash": "22" * 32,
+                "size": 4096,
+            },
+            "missing_merchant_font": False,
+        },
+        "flags": {
+            "typography": {"reverse_total": True, "face_source": "stylemap"},
+            "header": {"lines": ["VONS", "(555) 555-0134"]},
+        },
+        "catalog_snapshot": {
+            "items": copy.deepcopy(CATALOG_ITEMS_V1),
+            "item_count": len(CATALOG_ITEMS_V1),
+            "catalog_hash": hash_payload(CATALOG_ITEMS_V1),
+            "as_of": "2026-07-20T00:00:00+00:00",
+        },
+    }
+
+
+def _v2_payloads() -> dict[str, Any]:
+    payloads = _v1_payloads()
+    typography = payloads["typography"]["typography"]
+    typography["condense"] = 0.95
+    typography["ink"] = 0.82
+    template = payloads["layout"]["template"]
+    template["measured"] = {
+        "receipts": 15,
+        "tool_git_sha": "bbbb33334444",
+        "tool_dirty": False,
+    }
+    template["columns"]["items"][1]["x"] = 0.9502
+    template["columns"]["items"][1]["support"] = 11
+    template["columns"]["payment"] = [template["columns"]["payment"][1]]
+    template["columns"]["footer"] = [
+        {
+            "role": "desc",
+            "anchor": "left",
+            "x": 0.0171,
+            "spread": 0.0186,
+            "support": 8,
+        }
+    ]
+    font = payloads["assets"]["fonts"]["regular"]
+    font["s3_key"] = "fonts/vons/vons-3333.glyphs.npz"
+    font["content_hash"] = "33" * 32
+    font["source_commit"] = GIT_SHA_V2
+    font["compiled_at"] = "2026-07-22T00:00:00+00:00"
+    payloads["flags"]["typography"]["reverse_total"] = False
+    payloads["catalog_snapshot"] = {
+        "items": copy.deepcopy(CATALOG_ITEMS_V2),
+        "item_count": len(CATALOG_ITEMS_V2),
+        "catalog_hash": hash_payload(CATALOG_ITEMS_V2),
+        "as_of": "2026-07-22T00:00:00+00:00",
+    }
+    return payloads
+
+
+def _component_provenance(version: int) -> dict[str, Any]:
+    if version == 1:
+        return {
+            "source_kind": "migration",
+            "written_by": {
+                "kind": "migration",
+                "name": "merchant_truth_v1",
+                "version": "1",
+            },
+            "source_path": "scripts/merchant_profiles.json",
+            "git_sha": GIT_SHA_V1,
+            "pipeline": "merchant_truth_v1",
+            "pipeline_version": "1",
+            "measured_at": None,
+            "provenance_completeness": "legacy",
+        }
+    return {
+        "source_kind": "measurement",
+        "written_by": {
+            "kind": "measurement_pipeline",
+            "name": "glyphstudio",
+            "version": "1",
+        },
+        "source_path": "glyphstudio/layout_template.py",
+        "git_sha": GIT_SHA_V2,
+        "pipeline": "glyphstudio.layout_template",
+        "pipeline_version": "1",
+        "measured_at": "2026-07-22T04:00:00+00:00",
+    }
+
+
+def _gate_results(version: int) -> dict[str, Any]:
+    if version == 1:
+        return {
+            "status": "PASS",
+            "passed": True,
+            "gate": "merchant_truth_v1_bootstrap",
+            "kind": "migration-bootstrap-seal",
+            "note": (
+                "bootstrap seal: gate passes on dry-run<->live source "
+                "parity only; no fidelity eval has run against "
+                "truth-loaded renders yet"
+            ),
+            "evidence": {
+                "git_sha": GIT_SHA_V1,
+                "generated_at": "2026-07-21T04:00:00+00:00",
+            },
+            "written_by": {
+                "kind": "migration",
+                "name": "merchant_truth_v1",
+                "version": "1",
+            },
+        }
+    return {
+        "status": "PASS",
+        "passed": True,
+        "gate": "full_fidelity_eval",
+        "kind": "fidelity-eval",
+        "note": "metrics PASS on truth-loaded renders",
+        "evidence": {
+            "git_sha": GIT_SHA_V2,
+            "report": "docs/reports/nightly/2026-07-22.md",
+        },
+        "written_by": {
+            "kind": "measurement_pipeline",
+            "name": "glyphstudio",
+            "version": "1",
+        },
+    }
+
+
+def build_bundle(
+    version: int,
+    payloads: dict[str, Any],
+    *,
+    slug: str = SLUG,
+    status: str = "SEALED",
+    sealed_at: str | None = None,
+) -> tuple[MerchantTruthManifest, list[MerchantTruthComponent]]:
+    components = [
+        MerchantTruthComponent(
+            slug=slug,
+            version=version,
+            name=name,
+            payload=payloads[name],
+            provenance=_component_provenance(version),
+        )
+        for name in sorted(COMPONENT_NAMES)
+    ]
+    hashes = {item.name: item.content_hash for item in components}
+    git_sha = GIT_SHA_V1 if version == 1 else GIT_SHA_V2
+    run_id = f"merchant-truth-v{version}-{slug}-{git_sha[:12]}"
+    manifest = MerchantTruthManifest(
+        slug=slug,
+        version=version,
+        component_hashes=hashes,
+        bundle_hash=compute_bundle_hash(hashes),
+        status=status,
+        provenance={
+            "written_by": (
+                {
+                    "kind": "migration",
+                    "name": "merchant_truth_v1",
+                    "version": "1",
+                }
+                if version == 1
+                else {
+                    "kind": "measurement_pipeline",
+                    "name": "glyphstudio",
+                    "version": "1",
+                }
+            ),
+            "minted_at": sealed_at or SEALED_AT_V1,
+            "run_id": run_id,
+            "git_sha": git_sha,
+            "migration_blockers": [],
+        },
+        mint_run_id=run_id,
+        gate_status="PASS" if status == "SEALED" else "PENDING",
+        gate_results=_gate_results(version) if status == "SEALED" else {},
+        sealed_at=sealed_at if status == "SEALED" else None,
+    )
+    return manifest, components
+
+
+class StubReader:
+    """MerchantTruthReader stub (mirrors the loader FakeReader shape)."""
+
+    def __init__(
+        self,
+        bundles: list[
+            tuple[MerchantTruthManifest, list[MerchantTruthComponent]]
+        ],
+        active_records: list[MerchantTruthActive] | None = None,
+    ) -> None:
+        self.manifests = {
+            (manifest.slug, manifest.version): manifest
+            for manifest, _ in bundles
+        }
+        self.components = {
+            (manifest.slug, manifest.version): components
+            for manifest, components in bundles
+        }
+        self.active_records = active_records or []
+        self.calls = 0
+
+    def get_merchant_truth_manifest(
+        self, slug: str, version: int, *, consistent_read: bool = False
+    ) -> MerchantTruthManifest | None:
+        del consistent_read
+        self.calls += 1
+        return self.manifests.get((slug, version))
+
+    def list_merchant_truth_components(
+        self, slug: str, version: int, *, consistent_read: bool = False
+    ) -> list[MerchantTruthComponent]:
+        del consistent_read
+        self.calls += 1
+        return list(self.components.get((slug, version), []))
+
+    def list_merchant_truth_manifests(self) -> list[MerchantTruthManifest]:
+        self.calls += 1
+        return list(self.manifests.values())
+
+    def list_active_merchant_truth(self) -> list[MerchantTruthActive]:
+        self.calls += 1
+        return list(self.active_records)
+
+    def get_active_merchant_truth(
+        self, slug: str, *, consistent_read: bool = False
+    ) -> MerchantTruthActive | None:
+        del consistent_read
+        self.calls += 1
+        return next(
+            (item for item in self.active_records if item.slug == slug),
+            None,
+        )
+
+    def read_merchant_truth_bundle_items(
+        self, slug: str, version: int, *, consistent_read: bool = False
+    ) -> list[dict[str, Any]]:
+        raise AssertionError(
+            "merchant_truth_diff reads manifests/components, not raw items"
+        )
+
+
+def make_active(
+    slug: str, version: int, bundle_hash: str
+) -> MerchantTruthActive:
+    return MerchantTruthActive(
+        slug=slug,
+        version=version,
+        bundle_hash=bundle_hash,
+        normalized_aliases=[slug],
+        activated_at="2026-07-21T12:00:00+00:00",
+        activated_by="owner",
+    )
+
+
+def assert_matches_golden(name: str, output: str) -> None:
+    path = GOLDEN_DIR / name
+    if os.environ.get("UPDATE_GOLDEN") == "1":
+        GOLDEN_DIR.mkdir(parents=True, exist_ok=True)
+        path.write_text(output, encoding="utf-8")
+    assert path.exists(), (
+        f"missing golden {path}; regenerate with "
+        "UPDATE_GOLDEN=1 pytest tests/test_merchant_truth_diff.py"
+    )
+    assert output == path.read_text(encoding="utf-8"), (
+        f"output drifted from golden {path.name}; review, then regenerate "
+        "with UPDATE_GOLDEN=1 pytest tests/test_merchant_truth_diff.py"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Golden snapshots: the three modes + the fleet sweep
+# ---------------------------------------------------------------------------
+
+
+def test_mode_a_version_diff_matches_golden(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    reader = StubReader(
+        [
+            build_bundle(1, _v1_payloads(), sealed_at=SEALED_AT_V1),
+            build_bundle(2, _v2_payloads(), sealed_at=SEALED_AT_V2),
+        ]
+    )
+
+    exit_code = mtd.main(
+        ["--slug", SLUG, "--from", "v1", "--to", "v2"], reader=reader
+    )
+
+    assert exit_code == 0
+    assert_matches_golden("mode_a_version_diff.md", capsys.readouterr().out)
+
+
+def test_mode_b_first_activation_matches_golden(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    reader = StubReader(
+        [build_bundle(1, _v1_payloads(), sealed_at=SEALED_AT_V1)]
+    )
+
+    exit_code = mtd.main(["--slug", SLUG, "--to", "v1"], reader=reader)
+
+    assert exit_code == 0
+    output = capsys.readouterr().out
+    assert "FIRST ACTIVATION" in output
+    assert_matches_golden("mode_b_first_activation.md", output)
+
+
+def test_mode_c_legacy_comparison_is_byte_equivalent(
+    capsys: pytest.CaptureFixture[str], tmp_path: Path
+) -> None:
+    legacy_path = tmp_path / "merchant_profiles.json"
+    legacy_path.write_text(json.dumps(LEGACY_DOC), encoding="utf-8")
+    reader = StubReader(
+        [build_bundle(1, _v1_payloads(), sealed_at=SEALED_AT_V1)]
+    )
+
+    exit_code = mtd.main(
+        ["--slug", SLUG, "--to", "v1", "--legacy", str(legacy_path)],
+        reader=reader,
+    )
+
+    assert exit_code == 0
+    output = capsys.readouterr().out
+    assert output.count("BYTE-EQUIVALENT") == 5
+    assert output.count("SKIPPED") == 2
+    assert "DIFFERS" not in output
+    # Stabilize the golden against tmp_path: only the basename is printed.
+    assert_matches_golden("mode_c_legacy_comparison.md", output)
+
+
+def test_all_sealed_review_packet_matches_golden(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    v1_manifest, v1_components = build_bundle(
+        1, _v1_payloads(), sealed_at=SEALED_AT_V1
+    )
+    v2_manifest, v2_components = build_bundle(
+        2, _v2_payloads(), sealed_at=SEALED_AT_V2
+    )
+    reader = StubReader(
+        [(v1_manifest, v1_components), (v2_manifest, v2_components)],
+        active_records=[make_active(SLUG, 1, v1_manifest.bundle_hash)],
+    )
+
+    exit_code = mtd.main(["--all-sealed"], reader=reader)
+
+    assert exit_code == 0
+    output = capsys.readouterr().out
+    # v1 is covered by ACTIVE v1; only v2 is pending.
+    assert "1 sealed version(s) awaiting" in output
+    assert "UPGRADE: ACTIVE currently points at v1" in output
+    assert_matches_golden("all_sealed_packet.md", output)
+
+
+# ---------------------------------------------------------------------------
+# Mode C: a legacy drift must render as a diff, not pass silently
+# ---------------------------------------------------------------------------
+
+
+def test_mode_c_reports_leaf_diff_on_legacy_drift(
+    capsys: pytest.CaptureFixture[str], tmp_path: Path
+) -> None:
+    drifted = copy.deepcopy(LEGACY_DOC)
+    drifted["profiles"]["Vons"]["typography"]["condense"] = 0.97
+    legacy_path = tmp_path / "merchant_profiles.json"
+    legacy_path.write_text(json.dumps(drifted), encoding="utf-8")
+    reader = StubReader(
+        [build_bundle(1, _v1_payloads(), sealed_at=SEALED_AT_V1)]
+    )
+
+    exit_code = mtd.main(
+        ["--slug", SLUG, "--to", "v1", "--legacy", str(legacy_path)],
+        reader=reader,
+    )
+
+    assert exit_code == 0
+    output = capsys.readouterr().out
+    assert "| typography | full (profile-derived) | DIFFERS" in output
+    assert "- typography.condense: 0.97 -> 0.93" in output
+
+
+def test_mode_c_unknown_slug_fails_with_error(
+    capsys: pytest.CaptureFixture[str], tmp_path: Path
+) -> None:
+    legacy_path = tmp_path / "merchant_profiles.json"
+    legacy_path.write_text(json.dumps(LEGACY_DOC), encoding="utf-8")
+    manifest, components = build_bundle(
+        1, _v1_payloads(), slug="mystery_mart", sealed_at=SEALED_AT_V1
+    )
+    reader = StubReader([(manifest, components)])
+
+    exit_code = mtd.main(
+        [
+            "--slug",
+            "mystery_mart",
+            "--to",
+            "v1",
+            "--legacy",
+            str(legacy_path),
+        ],
+        reader=reader,
+    )
+
+    assert exit_code == 1
+    assert "no legacy profile maps to slug" in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# Integrity + argument contract
+# ---------------------------------------------------------------------------
+
+
+def test_open_manifest_is_not_reviewable(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    reader = StubReader([build_bundle(1, _v1_payloads(), status="OPEN")])
+
+    exit_code = mtd.main(["--slug", SLUG, "--to", "v1"], reader=reader)
+
+    assert exit_code == 1
+    assert "only SEALED versions are reviewable" in capsys.readouterr().err
+
+
+def test_tampered_component_fails_closed(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    manifest, components = build_bundle(
+        1, _v1_payloads(), sealed_at=SEALED_AT_V1
+    )
+    tampered_payloads = _v1_payloads()
+    tampered_payloads["typography"]["typography"]["condense"] = 0.5
+    tampered = [
+        (
+            MerchantTruthComponent(
+                slug=SLUG,
+                version=1,
+                name=item.name,
+                payload=tampered_payloads[item.name],
+                provenance=item.provenance,
+            )
+            if item.name == "typography"
+            else item
+        )
+        for item in components
+    ]
+    reader = StubReader([(manifest, tampered)])
+
+    exit_code = mtd.main(["--slug", SLUG, "--to", "v1"], reader=reader)
+
+    assert exit_code == 1
+    assert "component hashes do not match" in capsys.readouterr().err
+
+
+def test_missing_manifest_errors(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    reader = StubReader([])
+
+    exit_code = mtd.main(["--slug", SLUG, "--to", "v3"], reader=reader)
+
+    assert exit_code == 1
+    assert "no manifest for vons v3" in capsys.readouterr().err
+
+
+def test_prod_table_is_refused_before_any_read(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    reader = StubReader([build_bundle(1, _v1_payloads())])
+
+    exit_code = mtd.main(
+        ["--slug", SLUG, "--to", "v1", "--table", "ReceiptsTable-d7ff76a"],
+        reader=reader,
+    )
+
+    assert exit_code == 2
+    assert reader.calls == 0
+    captured = capsys.readouterr()
+    assert "REFUSED" in captured.err
+    assert captured.out == ""
+
+
+def test_prod_table_env_var_is_refused(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("DYNAMODB_TABLE_NAME", "ReceiptsTable-d7ff76a")
+    reader = StubReader([])
+
+    assert mtd.main(["--slug", SLUG, "--to", "v1"], reader=reader) == 2
+    assert reader.calls == 0
+
+
+def test_default_table_is_dev(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("DYNAMODB_TABLE_NAME", raising=False)
+    assert mtd.resolve_table(None) == "ReceiptsTable-dc5be22"
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["--slug", SLUG],  # --to missing
+        ["--to", "v1"],  # --slug missing
+        ["--slug", SLUG, "--from", "v1", "--to", "v2", "--legacy", "x.json"],
+        ["--all-sealed", "--slug", SLUG],
+    ],
+)
+def test_invalid_argument_combinations_are_refused(
+    argv: list[str], capsys: pytest.CaptureFixture[str]
+) -> None:
+    reader = StubReader([])
+
+    assert mtd.main(argv, reader=reader) == 2
+    assert reader.calls == 0
+    assert "REFUSED" in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# Unit: version parsing + paper-width formatting
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [("v1", 1), ("1", 1), ("V2", 2), ("v0000000042", 42)],
+)
+def test_parse_version_accepts_common_forms(text: str, expected: int) -> None:
+    assert mtd.parse_version(text) == expected
+
+
+@pytest.mark.parametrize("text", ["", "v", "v0", "0", "vv1", "v1.2", "one"])
+def test_parse_version_rejects_invalid_forms(text: str) -> None:
+    with pytest.raises(ValueError):
+        mtd.parse_version(text)
+
+
+def test_paper_width_move_formats_signed_fraction() -> None:
+    assert mtd.format_paper_move(0.2479, 0.2510) == (
+        "x 0.2479 -> 0.2510 (moved +0.0031 paper-width)"
+    )
+    assert mtd.format_paper_move(0.9439, 0.9502) == (
+        "x 0.9439 -> 0.9502 (moved +0.0063 paper-width)"
+    )
+    assert mtd.format_paper_move(0.5, 0.4821) == (
+        "x 0.5000 -> 0.4821 (moved -0.0179 paper-width)"
+    )
+
+
+def test_layout_diff_expresses_moves_in_paper_width_units() -> None:
+    old = _v1_payloads()["layout"]
+    new = _v2_payloads()["layout"]
+
+    lines = mtd.diff_layout(old, new)
+
+    assert (
+        "- items: amount/right column x 0.9439 -> 0.9502 "
+        "(moved +0.0063 paper-width)" in lines
+    )
+    assert any(
+        line.startswith("- footer: desc/left column added at x 0.0171")
+        for line in lines
+    )
+    assert any(
+        line.startswith("- payment: label/left column removed at x 0.0063")
+        for line in lines
+    )
+    assert "- template.measured.receipts: 12 -> 15" in lines
+
+
+def test_catalog_diff_reports_added_removed_and_price_changes() -> None:
+    old = _v1_payloads()["catalog_snapshot"]
+    new = _v2_payloads()["catalog_snapshot"]
+
+    lines = mtd.diff_catalog(old, new)
+
+    assert '- price changed: dairy/MILK 2% "3.99" -> "4.19"' in lines
+    assert '- item added: produce/ORANGES (price "3.49")' in lines
+    assert '- item removed: produce/FUJI APPLES (price "2.49")' in lines
+
+
+def test_identical_components_collapse_to_one_line(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    reader = StubReader(
+        [
+            build_bundle(1, _v1_payloads(), sealed_at=SEALED_AT_V1),
+            build_bundle(2, _v2_payloads(), sealed_at=SEALED_AT_V2),
+        ]
+    )
+
+    assert (
+        mtd.main(["--slug", SLUG, "--from", "v1", "--to", "v2"], reader=reader)
+        == 0
+    )
+    output = capsys.readouterr().out
+    for name in ("identity", "stylemap"):
+        assert f"- {name}: identical (content_hash `" in output
+    for name in (
+        "typography",
+        "layout",
+        "assets",
+        "flags",
+        "catalog_snapshot",
+    ):
+        assert f"### {name} — CHANGED" in output


### PR DESCRIPTION
Implements **W5** of the approved plan (`.claude/plans/humble-skipping-quilt.md`) for #1188 P4: the contract-required flip review artifact (docs/architecture/MERCHANT_TRUTH_DYNAMO.md §3, "ACTIVE flip = the merge", step 2), ahead of owner gate **G2**.

## What's here

**`scripts/merchant_truth_diff.py`** — read-only, never flips, dev-table default with unconditional prod refusal (same pattern as `synthesis_loop/fleet_status.py`):

- **Mode A** `--slug X --from vM --to vN`: semantic per-component diff of two sealed versions. Identical `content_hash` collapses to one line. Layout column moves are expressed in **paper-width units** (the layout payload's column `x` values are paper-width fractions); typography/flags/stylemap diff at leaf level (dotted paths, old -> new); assets diff per artifact (hash + pointer); catalog_snapshot diffs items added/removed/price-changed. Provenance deltas (pipeline, git SHA, measured_at) shown per changed component.
- **Mode B** `--slug X --to v1` (no `--from`): first-activation decision document — component hashes + payload sizes, key measured values, gate status + gate provenance, `bundle_hash`, and what the flip will do.
- **Mode C** `--slug X --to v1 --legacy scripts/merchant_profiles.json`: diff vs the legacy profile source per the migration crosswalk. Profile-derived components (identity/typography/flags/layout + the assets `profile` sub-object) are checked for byte-equivalence; stylemap/catalog_snapshot are skipped with reason (not derivable from that file).
- **`--all-sealed`**: Mode B summaries for every SEALED-but-not-ACTIVE version — the owner's G2 review packet in one command.
- Bundle loads fail closed: manifest must be SEALED; component set, per-component hashes, and `bundle_hash` are re-verified (payload hash re-verification comes free from the #1200 canonical-string entities).

**`synthesis_loop/fleet_status.py`** — new **"SEALED (pending activation)"** section from one GSITYPE query on `MERCHANT_TRUTH_MANIFEST` (sealed versions with no, or an older, ACTIVE pointer). Closes the G1 evidence gap where the tool showed "0 ACTIVE / 16 missing" while 13 sealed bundles existed invisibly.

**`receipt_dynamo`** — adds read-only `list_merchant_truth_manifests()` to the `_MerchantTruth` accessor (GSITYPE, projection ALL, mirrors `list_active_merchant_truth`) and widens the `MerchantTruthReader` protocol to the manifest/component readers these tools use. No write-path changes.

## Tests

- `tests/test_merchant_truth_diff.py`: **31 tests** — golden snapshots for Modes A/B/C + the `--all-sealed` packet (`tests/fixtures/merchant_truth_diff/*.md`, regenerate with `UPDATE_GOLDEN=1`), fixture bundles built through the real entities so every hash in the goldens is computed by the canonical-JSON path; unit tests for paper-width formatting, version parsing, integrity fail-closed (OPEN manifest, tampered component, missing manifest), prod refusal, and argument-contract refusals.
- `tests/test_fleet_status.py`: **19 tests** (7 new/updated) covering the sealed-pending section (no-active, equal-active, older-active, OPEN excluded, sort + JSON fields) and prod refusal before any read.
- `receipt_dynamo` merchant-truth unit tests: **43 passed** (accessor/loader/migration/roundtrip).
- Full root suite: **262 passed, 1 skipped** (3 pre-existing collection errors in unrelated files from a local venv missing `receipt_chroma.s3`; untouched by this diff).

## Live verification (read-only, dev table `ReceiptsTable-dc5be22`)

### 1. `fleet_status` now shows the 13 sealed bundles

```
**0 ACTIVE / 13 SEALED pending activation / 16 missing** (legacy enumerations: 16 merchants)

## SEALED (pending activation)

| merchant | version | gate | sealed_at | bundle_hash |
|---|---|---|---|---|
| costco_wholesale | 1 | PASS | 2026-07-21T17:06:49.844567+00:00 | `c5cd31202f7a` |
| cvs | 1 | PASS | 2026-07-21T17:06:49.844567+00:00 | `9a2aee9fc39e` |
| gelson_s_westlake_village | 1 | PASS | 2026-07-21T17:06:49.844567+00:00 | `9486f47c16ee` |
| in_n_out_burger | 1 | PASS | 2026-07-21T17:06:49.844567+00:00 | `36a82f4e2ae8` |
| italia_deli___bakery | 1 | PASS | 2026-07-21T17:06:49.844567+00:00 | `84726353150b` |
| neighborly | 1 | PASS | 2026-07-21T17:06:49.844567+00:00 | `1efafa7688fe` |
| sprouts_farmers_market | 1 | PASS | 2026-07-21T17:06:49.844567+00:00 | `18dc387fbfd9` |
| target | 1 | PASS | 2026-07-21T17:06:49.844567+00:00 | `98db85a38da5` |
| the_home_depot | 1 | PASS | 2026-07-21T17:06:49.844567+00:00 | `89807363837e` |
| the_stand___american_classics_redefined | 1 | PASS | 2026-07-21T17:06:49.844567+00:00 | `c9d40358fc16` |
| trader_joe_s | 1 | PASS | 2026-07-21T17:06:49.844567+00:00 | `557c433fcc1e` |
| vons | 1 | PASS | 2026-07-21T17:06:49.844567+00:00 | `63775db497ae` |
| wild_fork | 1 | PASS | 2026-07-21T17:06:49.844567+00:00 | `a9de285daf99` |
```

### 2. Mode B: `--slug costco_wholesale --to v1`

```
# Merchant-truth activation review: costco_wholesale v1

Table: `ReceiptsTable-dc5be22`

FIRST ACTIVATION: no ACTIVE pointer exists for this merchant. Flipping creates the initial pointer (conditional Put; owner gate G2).

## Decision summary

- bundle_hash: `c5cd31202f7a52cee5f5b492c675ae4ed1d94241529bdc3d16d85b18bf7fd064`
- manifest: SEALED, sealed_at 2026-07-21T17:06:49.844567+00:00
- gate_status: PASS — merchant_truth_v1_bootstrap (migration-bootstrap-seal)
  - note: bootstrap seal: gate passes on dry-run<->live source parity only; no fidelity eval has run against truth-loaded renders yet
  - evidence: dry_run_payload_dir="/Users/tnorlund/section_label_kickoff/truth_v1_payloads", generated_at="2026-07-21T17:06:49.844567+00:00", git_sha="eb9d3617122be21d0e0e956e04f3208aec701c29"
  - gate written_by: migration/merchant_truth_v1@1
- mint: run `merchant-truth-v1-costco_wholesale-eb9d3617122b`, written_by migration/merchant_truth_v1@1, git_sha "eb9d3617122be21d0e0e956e04f3208aec701c29"

## Components

| component | content_hash | payload bytes |
|---|---|---|
| identity | `175c84d2a749` | 149 |
| typography | `70947f1d6ca6` | 173 |
| stylemap | `86e085f27327` | 8016 |
| layout | `7e6a7a3232a1` | 2054 |
| assets | `f7e32df3005b` | 1255 |
| flags | `4359b2e0a16b` | 386 |
| catalog_snapshot | `835af79b29ea` | 152 |

## Key measured values

### identity

- merchant_name: "Costco Wholesale"
- slug: costco_wholesale (upper COSTCO_WHOLESALE)
- normalized aliases: 1

### typography

- section_scale.FOOTER: 0.5
- typography.bitmap_font.heavy: "bitMatrix-C2-heavy.glyphs.npz"
- typography.bitmap_font.regular: "bitMatrix-C2.glyphs.npz"
- typography.bitmap_thin: 0.0
- typography.condense: 0.93

### layout

- available: true
- measured: 12 receipts (tool d9ce9cb82ecf, dirty false)
- columns per section: barcode=1, footer=3, items=2, payment=4, storefront=4, summary=5, total_line=1

### assets

- font[heavy]: merchant_fonts/costco_wholesale/heavy-2672820ca596.npz hash `2672820ca596`
- font[regular]: merchant_fonts/costco_wholesale/regular-bc14ace8711a.npz hash `bc14ace8711a`
- logo: merchant_fonts/costco_wholesale/logo-105ad531.png hash `105ad5310b94`
- profile assets: logo="bitMatrix-C2_logo.png", logo_anchor={"center":true,"extend_left":false,"phrases":["COSTCO","EWHOLESALE","WHOLESALE"]}

### stylemap

- available: true
- source: merchant_fonts/costco_wholesale/stylemap-a56efa58.json hash `a56efa587a6d`
- document sections: 13

### catalog_snapshot

- items: 0 (catalog_hash `4f53cda18c2b`, as_of 2026-07-21T17:06:49.844567+00:00)

### flags

- 13 decided leaves across groups: typography
- flags are git-sourced engine config (truth = measured; flags = decided)

## Flip

This tool never flips. The owner runs the flip (DynamoClient.initial_activate for a first activation, flip_active thereafter) after reading this review — owner gate G2.
```

### 3. `--all-sealed | head -30`

```
# Merchant-truth G2 review packet: SEALED pending activation

Table: `ReceiptsTable-dc5be22` | 13 sealed version(s) awaiting an ACTIVE flip

---

# Merchant-truth activation review: costco_wholesale v1

Table: `ReceiptsTable-dc5be22`

FIRST ACTIVATION: no ACTIVE pointer exists for this merchant. Flipping creates the initial pointer (conditional Put; owner gate G2).

## Decision summary

- bundle_hash: `c5cd31202f7a52cee5f5b492c675ae4ed1d94241529bdc3d16d85b18bf7fd064`
- manifest: SEALED, sealed_at 2026-07-21T17:06:49.844567+00:00
- gate_status: PASS — merchant_truth_v1_bootstrap (migration-bootstrap-seal)
  - note: bootstrap seal: gate passes on dry-run<->live source parity only; no fidelity eval has run against truth-loaded renders yet
  - evidence: dry_run_payload_dir="/Users/tnorlund/section_label_kickoff/truth_v1_payloads", generated_at="2026-07-21T17:06:49.844567+00:00", git_sha="eb9d3617122be21d0e0e956e04f3208aec701c29"
  - gate written_by: migration/merchant_truth_v1@1
- mint: run `merchant-truth-v1-costco_wholesale-eb9d3617122b`, written_by migration/merchant_truth_v1@1, git_sha "eb9d3617122be21d0e0e956e04f3208aec701c29"

## Components

| component | content_hash | payload bytes |
|---|---|---|
| identity | `175c84d2a749` | 149 |
| typography | `70947f1d6ca6` | 173 |
| stylemap | `86e085f27327` | 8016 |
| layout | `7e6a7a3232a1` | 2054 |
```

### 4. Mode C crosswalk sanity, all 13 sealed merchants

Every G1 bundle is byte-equivalent to its legacy profile source on every profile-derived component (identity, typography, flags, layout, assets.profile):

```
costco_wholesale: all profile-derived BYTE-EQUIVALENT
cvs: all profile-derived BYTE-EQUIVALENT
gelson_s_westlake_village: all profile-derived BYTE-EQUIVALENT
in_n_out_burger: all profile-derived BYTE-EQUIVALENT
italia_deli___bakery: all profile-derived BYTE-EQUIVALENT
neighborly: all profile-derived BYTE-EQUIVALENT
sprouts_farmers_market: all profile-derived BYTE-EQUIVALENT
target: all profile-derived BYTE-EQUIVALENT
the_home_depot: all profile-derived BYTE-EQUIVALENT
the_stand___american_classics_redefined: all profile-derived BYTE-EQUIVALENT
trader_joe_s: all profile-derived BYTE-EQUIVALENT
vons: all profile-derived BYTE-EQUIVALENT
wild_fork: all profile-derived BYTE-EQUIVALENT
```

## Contract interpretations (settled at implementation time per the design's stated policy)

- "Column moves in paper-width units" is rendered as the signed delta of the column `x` fraction (e.g. `moved +0.0063 paper-width`); columns are paired within a section by `(role, anchor)` in x-order, with unpaired columns reported as added/removed.
- Mode C byte-equivalence covers the crosswalk's profile-derived leaves; `stylemap` and `catalog_snapshot` payloads are not derivable from `merchant_profiles.json` (they came from MerchantFont/S3 and the catalog partition) and are reported as SKIPPED with reason rather than silently passed.
- Review requires `status=SEALED` but not `gate=PASS` — a FAIL/PENDING gate is displayed, since the review document is exactly where the owner should see it (the flip transaction itself enforces gate PASS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BeLcSviHL5vDgS3zTSMbsq


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a read-only merchant-truth review tool for comparing sealed versions, reviewing activations, and validating legacy equivalence.
  * Added fleet-status reporting for sealed versions pending activation, including gate status and bundle details.
  * Added APIs to list manifests, retrieve specific manifests, and list their components.

* **Bug Fixes**
  * Added validation that detects missing or tampered bundle data and prevents unsafe production-table access.

* **Tests**
  * Added comprehensive coverage for comparisons, activation reviews, pending statuses, validation failures, and report output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->