### PR TITLE
[scripts] activate_merchant_truth CLI (G2 flip tool)

### DIFF
--- a/scripts/activate_merchant_truth.py
+++ b/scripts/activate_merchant_truth.py
@@ -1,0 +1,513 @@
+#!/usr/bin/env python3
+"""Owner-facing G2 activation CLI for versioned merchant truth (#1188 P4).
+
+The write-side companion to scripts/merchant_truth_diff.py (the read-only
+review artifact). Where the diff tool renders the G2 decision document,
+this tool performs the decision — and only when the owner explicitly says
+so:
+
+  DRY-RUN (default):
+      activate_merchant_truth.py --slug costco_wholesale --version 1
+      Loads the SEALED bundle fail-closed (same verification path as the
+      diff tool), prints a condensed decision summary (gate, bundle_hash,
+      component hashes) plus the exact mutation a flip WOULD perform,
+      and stops. Zero writes.
+
+  FLIP (explicit):
+      activate_merchant_truth.py --slug costco_wholesale --version 1 --flip
+      Performs the activation: ``DynamoClient.initial_activate`` when no
+      ACTIVE pointer exists (conditional Put, converges idempotently), or
+      ``DynamoClient.flip_active`` conditioned on the CURRENT active
+      {version, bundle_hash} as expected-prev otherwise. Prints the
+      resulting ACTIVE pointer and audit confirmation.
+
+  FLEET:
+      activate_merchant_truth.py --all-sealed [--flip]
+      One activation per SEALED-pending version (the same pending set
+      synthesis_loop/fleet_status.py reports), continuing past
+      per-merchant failures with a summary table at the end. Still a
+      dry-run without --flip.
+
+Safety, matching the sibling scripts' conventions exactly: the dev table
+(ReceiptsTable-dc5be22) is the default via DYNAMODB_TABLE_NAME; the prod
+table (ReceiptsTable-d7ff76a, or any name carrying the d7ff76a marker) is
+refused unconditionally BEFORE any client construction. ``--flip``
+additionally prints a banner (table, slug(s), versions) before writing.
+
+Exit codes: 0 success (including dry-run and idempotent convergence);
+1 data/integrity error (or any per-merchant failure under --all-sealed);
+2 refused configuration; 3 lost activation race
+(MerchantTruthConflictError).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.dirname(HERE)
+for _p in (REPO, os.path.join(REPO, "receipt_dynamo")):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from receipt_dynamo.data.shared_exceptions import (  # noqa: E402
+    MerchantTruthConflictError,
+)
+from receipt_dynamo.entities.merchant_truth import (  # noqa: E402
+    MerchantTruthActive,
+)
+
+# The loading/verification helpers are the diff tool's: import, don't copy.
+from scripts.merchant_truth_diff import (  # noqa: E402
+    COMPONENT_ORDER,
+    DEV_TABLE_NAME,
+    PROD_TABLE_MARKER,
+    PROD_TABLE_NAME,
+    Bundle,
+    DiffError,
+    load_bundle,
+    parse_version,
+    short_hash,
+)
+from synthesis_loop.fleet_status import build_sealed_pending  # noqa: E402
+
+if TYPE_CHECKING:
+    from receipt_dynamo.data.dynamo_client import DynamoClient
+
+DEFAULT_ACTIVATED_BY = "owner-cli"
+
+
+class ActivationError(Exception):
+    """A data or integrity problem that must stop the activation."""
+
+
+def resolve_table(cli_table: str | None) -> str:
+    """Resolve the target table and refuse prod explicitly.
+
+    Same stance as merchant_truth_diff.resolve_table / fleet_status:
+    default dev via DYNAMODB_TABLE_NAME, and the prod table name or any
+    name carrying the prod marker substring is refused unconditionally —
+    before any DynamoDB client is constructed.
+    """
+    table = (
+        cli_table or os.environ.get("DYNAMODB_TABLE_NAME") or DEV_TABLE_NAME
+    )
+    if table == PROD_TABLE_NAME or PROD_TABLE_MARKER in table:
+        raise ValueError(
+            f"activate_merchant_truth never touches prod; refusing table "
+            f"{table!r} (prod = {PROD_TABLE_NAME!r})"
+        )
+    return table
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+# --------------------------------------------------------------------------
+# Plan: what one activation would do (shared by dry-run and --flip)
+# --------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ActivationPlan:
+    """A verified bundle plus the exact mutation a flip would perform."""
+
+    slug: str
+    version: int
+    bundle: Bundle
+    current: MerchantTruthActive | None
+    action: str  # "initial" | "flip" | "noop"
+
+    @property
+    def bundle_hash(self) -> str:
+        return self.bundle.manifest.bundle_hash
+
+    @property
+    def normalized_aliases(self) -> list[str]:
+        payload = self.bundle.payload("identity")
+        aliases = (payload or {}).get("normalized_aliases")
+        if not isinstance(aliases, list) or not aliases:
+            raise ActivationError(
+                f"{self.slug} v{self.version} identity component carries no "
+                "normalized_aliases; ACTIVE cannot be built"
+            )
+        return [str(alias) for alias in aliases]
+
+
+def build_plan(
+    client: "DynamoClient", slug: str, version: int
+) -> ActivationPlan:
+    """Load the bundle fail-closed and decide the mutation."""
+    bundle = load_bundle(client, slug, version)
+    manifest = bundle.manifest
+    if manifest.gate_status != "PASS":
+        raise ActivationError(
+            f"{slug} v{version} gate_status is {manifest.gate_status!r}; "
+            "only gate-PASS bundles are activatable"
+        )
+    current = client.get_active_merchant_truth(slug)
+    if current is None:
+        action = "initial"
+    elif (
+        current.version == version
+        and current.bundle_hash == manifest.bundle_hash
+    ):
+        action = "noop"
+    else:
+        action = "flip"
+    plan = ActivationPlan(
+        slug=slug,
+        version=version,
+        bundle=bundle,
+        current=current,
+        action=action,
+    )
+    # Fail closed on a malformed identity component before any write plan
+    # is shown, not at flip time.
+    plan.normalized_aliases  # noqa: B018  (validation side effect)
+    return plan
+
+
+def _mutation_lines(plan: ActivationPlan) -> list[str]:
+    if plan.action == "initial":
+        return [
+            "- INITIAL ACTIVATION: no ACTIVE pointer exists for "
+            f"{plan.slug}.",
+            f"- Mutation: initial_activate -> ACTIVE = v{plan.version} "
+            f"(`{short_hash(plan.bundle_hash)}`) via conditional Put "
+            "(ACTIVE absent; converges idempotently).",
+        ]
+    if plan.action == "noop":
+        assert plan.current is not None
+        return [
+            f"- ALREADY ACTIVE: the pointer is v{plan.current.version} "
+            f"(`{short_hash(plan.current.bundle_hash)}`), activated_at "
+            f"{plan.current.activated_at} by {plan.current.activated_by}.",
+            "- Mutation: none — activation has already converged.",
+        ]
+    assert plan.current is not None
+    return [
+        f"- FLIP: ACTIVE currently points at v{plan.current.version} "
+        f"(`{short_hash(plan.current.bundle_hash)}`).",
+        f"- Mutation: flip_active -> ACTIVE = v{plan.version} "
+        f"(`{short_hash(plan.bundle_hash)}`), conditioned on exact "
+        f"expected {{version: {plan.current.version}, bundle_hash: "
+        f"`{short_hash(plan.current.bundle_hash)}`}}.",
+    ]
+
+
+def render_plan(plan: ActivationPlan, *, table: str) -> list[str]:
+    """The condensed decision summary + the exact mutation."""
+    manifest = plan.bundle.manifest
+    lines = [
+        f"# Activation: {plan.slug} v{plan.version}",
+        "",
+        f"Table: `{table}`",
+        "",
+        f"- gate_status: {manifest.gate_status}",
+        f"- bundle_hash: `{manifest.bundle_hash}`",
+        f"- manifest: {manifest.status}, sealed_at {manifest.sealed_at}",
+        "- components: "
+        + ", ".join(
+            f"{name} `{short_hash(plan.bundle.components[name].content_hash)}`"
+            for name in COMPONENT_ORDER
+        ),
+        "",
+        "## Mutation",
+        "",
+        *_mutation_lines(plan),
+    ]
+    return lines
+
+
+# --------------------------------------------------------------------------
+# Execution (--flip only)
+# --------------------------------------------------------------------------
+
+
+def execute_plan(
+    client: "DynamoClient",
+    plan: ActivationPlan,
+    *,
+    table: str,
+    activated_by: str,
+) -> tuple[str, MerchantTruthActive]:
+    """Perform the planned mutation and return (verb, resulting ACTIVE)."""
+    if plan.action == "noop":
+        assert plan.current is not None
+        return "ALREADY-ACTIVE", plan.current
+    target = MerchantTruthActive(
+        slug=plan.slug,
+        version=plan.version,
+        bundle_hash=plan.bundle_hash,
+        normalized_aliases=plan.normalized_aliases,
+        activated_at=_utc_now(),
+        activated_by=activated_by,
+        gate_status="PASS",
+        prev_version=(plan.current.version if plan.action == "flip" else None),
+    )
+    if plan.action == "initial":
+        result = client.initial_activate(target, table)
+        return "ACTIVATED", result
+    assert plan.current is not None
+    result = client.flip_active(
+        target, plan.current.version, plan.current.bundle_hash, table
+    )
+    return "FLIPPED", result
+
+
+def render_result(verb: str, active: MerchantTruthActive) -> list[str]:
+    lines = [
+        "",
+        f"## Result: {verb}",
+        "",
+        f"- ACTIVE: {active.slug} -> v{active.version} "
+        f"(`{active.bundle_hash}`)",
+        f"- activated_at: {active.activated_at} by {active.activated_by}",
+    ]
+    if active.prev_version is not None:
+        lines.append(f"- prev_version: {active.prev_version}")
+    if verb == "ALREADY-ACTIVE":
+        lines.append(
+            "- No write performed: the pointer already matched this "
+            "version and bundle_hash (idempotent convergence)."
+        )
+    else:
+        action = "INITIAL_ACTIVATE" if verb == "ACTIVATED" else "FLIP_ACTIVE"
+        lines.append(
+            f"- Audit: {action} audit row written in the same "
+            "transaction as the pointer."
+        )
+    return lines
+
+
+def render_conflict(
+    error: MerchantTruthConflictError,
+    client: "DynamoClient",
+    slug: str,
+) -> list[str]:
+    """Explain the lost race and show what ACTIVE points at now."""
+    current = client.get_active_merchant_truth(slug, consistent_read=True)
+    lines = [
+        "",
+        f"CONFLICT: {error}",
+        "",
+        "Another writer changed the ACTIVE pointer between this tool's "
+        "read and its conditional write (the expected {version, "
+        "bundle_hash} no longer matched). Nothing was written by this "
+        "run.",
+    ]
+    if current is None:
+        lines.append(f"Current ACTIVE for {slug}: (none)")
+    else:
+        lines.append(
+            f"Current ACTIVE for {slug}: v{current.version} "
+            f"(`{short_hash(current.bundle_hash)}`), activated_at "
+            f"{current.activated_at} by {current.activated_by}"
+        )
+    lines.append("Re-run the dry-run to review the new state before retrying.")
+    return lines
+
+
+def print_flip_banner(table: str, targets: list[tuple[str, int]]) -> None:
+    """The pre-write banner: table + every slug/version about to move."""
+    print("=" * 62)
+    print("FLIP: about to write ACTIVE pointer(s)")
+    print(f"  table: {table}")
+    for slug, version in targets:
+        print(f"  {slug} -> v{version}")
+    print("=" * 62)
+
+
+# --------------------------------------------------------------------------
+# CLI
+# --------------------------------------------------------------------------
+
+
+def _run_single(
+    client: "DynamoClient",
+    slug: str,
+    version: int,
+    *,
+    table: str,
+    flip: bool,
+    activated_by: str,
+) -> int:
+    try:
+        plan = build_plan(client, slug, version)
+    except (DiffError, ActivationError) as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+    print("\n".join(render_plan(plan, table=table)))
+    if not flip:
+        print(
+            "\nDRY-RUN: no writes performed. Re-run with --flip to "
+            "perform this activation (owner gate G2)."
+        )
+        return 0
+    if plan.action != "noop":
+        print_flip_banner(table, [(slug, version)])
+    try:
+        verb, active = execute_plan(
+            client, plan, table=table, activated_by=activated_by
+        )
+    except MerchantTruthConflictError as error:
+        print("\n".join(render_conflict(error, client, slug)))
+        return 3
+    print("\n".join(render_result(verb, active)))
+    return 0
+
+
+def _run_all_sealed(
+    client: "DynamoClient",
+    *,
+    table: str,
+    flip: bool,
+    activated_by: str,
+) -> int:
+    manifests = client.list_merchant_truth_manifests()
+    active_records = client.list_active_merchant_truth()
+    pending = build_sealed_pending(manifests, active_records)
+    print(
+        f"# Merchant-truth activation sweep: {len(pending)} SEALED "
+        f"pending version(s) on `{table}`"
+    )
+    if not pending:
+        print("\nNothing to do: no sealed version is pending activation.")
+        return 0
+    targets = [(row["slug"], row["version"]) for row in pending]
+    if flip:
+        print_flip_banner(table, targets)
+    results: list[tuple[str, int, str]] = []
+    for slug, version in targets:
+        print()
+        try:
+            plan = build_plan(client, slug, version)
+        except (DiffError, ActivationError) as error:
+            print(f"ERROR: {slug} v{version}: {error}", file=sys.stderr)
+            results.append((slug, version, f"ERROR: {error}"))
+            continue
+        print("\n".join(render_plan(plan, table=table)))
+        if not flip:
+            results.append((slug, version, "DRY-RUN"))
+            continue
+        try:
+            verb, active = execute_plan(
+                client, plan, table=table, activated_by=activated_by
+            )
+        except MerchantTruthConflictError as error:
+            print("\n".join(render_conflict(error, client, slug)))
+            results.append((slug, version, f"CONFLICT: {error}"))
+            continue
+        print("\n".join(render_result(verb, active)))
+        results.append((slug, version, verb))
+    print("\n## Sweep summary\n")
+    print("| merchant | version | result |")
+    print("|---|---|---|")
+    for slug, version, outcome in results:
+        print(f"| {slug} | {version} | {outcome} |")
+    if not flip:
+        print(
+            "\nDRY-RUN: no writes performed. Re-run with --flip to "
+            "perform these activations (owner gate G2)."
+        )
+        return 0
+    failed = [
+        outcome
+        for _, _, outcome in results
+        if outcome.startswith(("ERROR", "CONFLICT"))
+    ]
+    return 1 if failed else 0
+
+
+def main(
+    argv: list[str] | None = None,
+    *,
+    client: "DynamoClient | None" = None,
+) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__.splitlines()[0],
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--slug", help="merchant slug, e.g. costco_wholesale")
+    parser.add_argument(
+        "--version",
+        metavar="vN",
+        help="SEALED version to activate (e.g. v1 or 1)",
+    )
+    parser.add_argument(
+        "--flip",
+        action="store_true",
+        help="actually perform the activation (default is DRY-RUN)",
+    )
+    parser.add_argument(
+        "--all-sealed",
+        action="store_true",
+        help="one activation per SEALED-pending version, fleet-wide",
+    )
+    parser.add_argument(
+        "--activated-by",
+        default=DEFAULT_ACTIVATED_BY,
+        help=f"audit identity for the flip (default: {DEFAULT_ACTIVATED_BY})",
+    )
+    parser.add_argument(
+        "--table",
+        default=None,
+        help="DynamoDB table (default: DYNAMODB_TABLE_NAME env or "
+        f"{DEV_TABLE_NAME}); prod is refused unconditionally",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        # Prod refusal happens here — before any client construction.
+        table = resolve_table(args.table)
+        if args.all_sealed:
+            if args.slug or args.version:
+                raise ValueError("--all-sealed takes no --slug/--version")
+        else:
+            if not args.slug or not args.version:
+                raise ValueError(
+                    "--slug and --version are required (or use --all-sealed)"
+                )
+    except ValueError as error:
+        print(f"REFUSED: {error}", file=sys.stderr)
+        return 2
+
+    if client is None:
+        from receipt_dynamo.data.dynamo_client import (  # noqa: PLC0415
+            DynamoClient,
+        )
+
+        region = os.environ.get("AWS_REGION", "us-east-1")
+        client = DynamoClient(table_name=table, region=region)
+
+    if args.all_sealed:
+        return _run_all_sealed(
+            client,
+            table=table,
+            flip=args.flip,
+            activated_by=args.activated_by,
+        )
+    try:
+        version = parse_version(args.version)
+    except ValueError as error:
+        print(f"REFUSED: {error}", file=sys.stderr)
+        return 2
+    return _run_single(
+        client,
+        args.slug,
+        version,
+        table=table,
+        flip=args.flip,
+        activated_by=args.activated_by,
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/activate_merchant_truth.py
+++ b/scripts/activate_merchant_truth.py
@@ -151,7 +151,10 @@ def build_plan(
             f"{slug} v{version} gate_status is {manifest.gate_status!r}; "
             "only gate-PASS bundles are activatable"
         )
-    current = client.get_active_merchant_truth(slug)
+    # Consistent read: the accessor's expected-prev condition already
+    # guarantees safety, but planning from a lagging replica could either
+    # raise a spurious conflict or report a stale "already converged".
+    current = client.get_active_merchant_truth(slug, consistent_read=True)
     if current is None:
         action = "initial"
     elif (
@@ -393,6 +396,20 @@ def _run_all_sealed(
             print(f"ERROR: {slug} v{version}: {error}", file=sys.stderr)
             results.append((slug, version, f"ERROR: {error}"))
             continue
+        except Exception as error:  # noqa: BLE001 — sweep must not abort
+            # Unexpected per-merchant faults (e.g. botocore ClientError
+            # throttling) are recorded and the sweep continues, so one
+            # transient failure cannot skip the remaining merchants or
+            # the summary table.
+            print(
+                f"ERROR: {slug} v{version}: "
+                f"{type(error).__name__}: {error}",
+                file=sys.stderr,
+            )
+            results.append(
+                (slug, version, f"ERROR: {type(error).__name__}: {error}")
+            )
+            continue
         print("\n".join(render_plan(plan, table=table)))
         if not flip:
             results.append((slug, version, "DRY-RUN"))
@@ -404,6 +421,16 @@ def _run_all_sealed(
         except MerchantTruthConflictError as error:
             print("\n".join(render_conflict(error, client, slug)))
             results.append((slug, version, f"CONFLICT: {error}"))
+            continue
+        except Exception as error:  # noqa: BLE001 — sweep must not abort
+            print(
+                f"ERROR: {slug} v{version}: "
+                f"{type(error).__name__}: {error}",
+                file=sys.stderr,
+            )
+            results.append(
+                (slug, version, f"ERROR: {type(error).__name__}: {error}")
+            )
             continue
         print("\n".join(render_result(verb, active)))
         results.append((slug, version, verb))

--- a/tests/test_activate_merchant_truth.py
+++ b/tests/test_activate_merchant_truth.py
@@ -23,6 +23,7 @@ from typing import Any
 
 import boto3
 import pytest
+from botocore.exceptions import ClientError
 from moto import mock_aws
 
 from receipt_dynamo import DynamoClient
@@ -671,6 +672,46 @@ def test_all_sealed_flip_all_success_exits_zero(
     ]
     output = capsys.readouterr().out
     assert "| alpha | 1 | ACTIVATED |" in output
+    assert "| beta | 1 | ACTIVATED |" in output
+
+
+class ThrottledInitialClient(StubClient):
+    """A writer whose initial activation hits a transient AWS fault."""
+
+    def initial_activate(self, active, expected_table_name):
+        if active.slug == "alpha":
+            raise ClientError(
+                {
+                    "Error": {
+                        "Code": "ThrottlingException",
+                        "Message": "Rate exceeded",
+                    }
+                },
+                "TransactWriteItems",
+            )
+        return super().initial_activate(active, expected_table_name)
+
+
+def test_all_sealed_flip_continues_past_transient_client_error(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    alpha, alpha_components = build_sealed("alpha", 1)
+    beta, beta_components = build_sealed("beta", 1)
+    client = ThrottledInitialClient(
+        [(alpha, alpha_components), (beta, beta_components)],
+        allow_writes=True,
+    )
+
+    exit_code = amt.main(["--all-sealed", "--flip"], client=client)
+
+    # alpha's throttle is recorded as an ERROR, beta still activates,
+    # and the summary table renders (the sweep never aborts mid-fleet).
+    assert exit_code == 1
+    assert client.write_calls == [("initial", "beta", "1")]
+    output = capsys.readouterr().out
+    assert "## Sweep summary" in output
+    assert "| alpha | 1 | ERROR: ClientError:" in output
+    assert "ThrottlingException" in output
     assert "| beta | 1 | ACTIVATED |" in output
 
 

--- a/tests/test_activate_merchant_truth.py
+++ b/tests/test_activate_merchant_truth.py
@@ -1,0 +1,695 @@
+"""Contract tests for scripts/activate_merchant_truth.py (G2 flip tool).
+
+Two layers, matching the sibling suites:
+
+* Stub-client tests (pattern: tests/test_fleet_status.py) prove the
+  read-only dry-run contract and the prod refusal — including the two
+  mutation-honesty guards:
+
+  - ``test_dry_run_performs_zero_writes`` goes red if the ``--flip`` gate
+    is removed (the stub raises on any write in dry-run).
+  - ``test_prod_table_refused_before_any_read_or_write`` goes red if the
+    prod guard is removed (the poisoned DynamoClient constructor and the
+    poisoned stub both raise the moment the guard stops short-circuiting).
+
+* moto tests (pattern: receipt_dynamo/tests/integration) drive the real
+  write path end-to-end: initial activation, idempotent convergence,
+  flip with correct expected state, and a stale-expected conflict.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import boto3
+import pytest
+from moto import mock_aws
+
+from receipt_dynamo import DynamoClient
+from receipt_dynamo.data.shared_exceptions import MerchantTruthConflictError
+from receipt_dynamo.entities.merchant_truth import (
+    COMPONENT_NAMES,
+    MerchantTruthActive,
+    MerchantTruthComponent,
+    MerchantTruthManifest,
+    compute_bundle_hash,
+)
+from scripts import activate_merchant_truth as amt
+
+NOW = "2026-07-21T12:00:00+00:00"
+SEALED_AT = "2026-07-21T05:00:00+00:00"
+TABLE = "MyMockedTable"
+
+LEGACY_PROVENANCE = {
+    "source_kind": "migration",
+    "provenance_completeness": "legacy",
+    "written_by": {
+        "kind": "migration",
+        "name": "merchant_truth_v1",
+        "version": "1",
+    },
+}
+MINT_PROVENANCE = {
+    "written_by": {
+        "kind": "migration",
+        "name": "merchant_truth_v1",
+        "version": "1",
+    }
+}
+
+
+@pytest.fixture(autouse=True)
+def mock_aws_services():
+    """Override the root infrastructure stub so moto owns boto3 here."""
+    yield
+
+
+# ---------------------------------------------------------------------------
+# Entity builders (real entities, so every hash is the canonical one)
+# ---------------------------------------------------------------------------
+
+
+def component_payload(slug: str, name: str, version: int) -> Any:
+    if name == "identity":
+        return {
+            "merchant_name": slug.title(),
+            "slug": slug,
+            "normalized_aliases": [slug, f"{slug} store"],
+        }
+    return {"component": name, "v": version}
+
+
+def build_components(slug: str, version: int) -> list[MerchantTruthComponent]:
+    return [
+        MerchantTruthComponent(
+            slug=slug,
+            version=version,
+            name=name,
+            payload=component_payload(slug, name, version),
+            provenance=LEGACY_PROVENANCE,
+        )
+        for name in sorted(COMPONENT_NAMES)
+    ]
+
+
+def build_sealed(
+    slug: str,
+    version: int,
+    *,
+    gate_status: str = "PASS",
+) -> tuple[MerchantTruthManifest, list[MerchantTruthComponent]]:
+    components = build_components(slug, version)
+    hashes = {item.name: item.content_hash for item in components}
+    manifest = MerchantTruthManifest(
+        slug=slug,
+        version=version,
+        component_hashes=hashes,
+        bundle_hash=compute_bundle_hash(hashes),
+        status="SEALED",
+        provenance=MINT_PROVENANCE,
+        mint_run_id=f"run-{slug}-{version}",
+        gate_status=gate_status,
+        gate_results={"status": gate_status},
+        sealed_at=SEALED_AT,
+    )
+    return manifest, components
+
+
+def make_active(
+    slug: str, version: int, bundle_hash: str, *, activated_by: str = "owner"
+) -> MerchantTruthActive:
+    return MerchantTruthActive(
+        slug=slug,
+        version=version,
+        bundle_hash=bundle_hash,
+        normalized_aliases=[slug],
+        activated_at=NOW,
+        activated_by=activated_by,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Stub client (reader shape mirrors tests/test_fleet_status.py; writes are
+# poisoned unless a test explicitly allows them)
+# ---------------------------------------------------------------------------
+
+
+class StubClient:
+    def __init__(
+        self,
+        bundles: list[
+            tuple[MerchantTruthManifest, list[MerchantTruthComponent]]
+        ],
+        active_records: list[MerchantTruthActive] | None = None,
+        *,
+        allow_writes: bool = False,
+    ) -> None:
+        self.manifests = {
+            (manifest.slug, manifest.version): manifest
+            for manifest, _ in bundles
+        }
+        self.components = {
+            (manifest.slug, manifest.version): components
+            for manifest, components in bundles
+        }
+        self.active_records = list(active_records or [])
+        self.allow_writes = allow_writes
+        self.read_calls = 0
+        self.write_calls: list[tuple[str, ...]] = []
+
+    # -- reads ------------------------------------------------------------
+    def get_merchant_truth_manifest(
+        self, slug: str, version: int, *, consistent_read: bool = False
+    ) -> MerchantTruthManifest | None:
+        del consistent_read
+        self.read_calls += 1
+        return self.manifests.get((slug, version))
+
+    def list_merchant_truth_components(
+        self, slug: str, version: int, *, consistent_read: bool = False
+    ) -> list[MerchantTruthComponent]:
+        del consistent_read
+        self.read_calls += 1
+        return list(self.components.get((slug, version), []))
+
+    def list_merchant_truth_manifests(self) -> list[MerchantTruthManifest]:
+        self.read_calls += 1
+        return list(self.manifests.values())
+
+    def list_active_merchant_truth(self) -> list[MerchantTruthActive]:
+        self.read_calls += 1
+        return list(self.active_records)
+
+    def get_active_merchant_truth(
+        self, slug: str, *, consistent_read: bool = False
+    ) -> MerchantTruthActive | None:
+        del consistent_read
+        self.read_calls += 1
+        return next(
+            (item for item in self.active_records if item.slug == slug),
+            None,
+        )
+
+    # -- writes -----------------------------------------------------------
+    def initial_activate(
+        self, active: MerchantTruthActive, expected_table_name: str
+    ) -> MerchantTruthActive:
+        if not self.allow_writes:
+            raise AssertionError("dry-run must never call initial_activate")
+        self.write_calls.append(("initial", active.slug, str(active.version)))
+        self.active_records = [
+            a for a in self.active_records if a.slug != active.slug
+        ] + [active]
+        return active
+
+    def flip_active(
+        self,
+        active: MerchantTruthActive,
+        expected_version: int,
+        expected_bundle_hash: str,
+        expected_table_name: str,
+    ) -> MerchantTruthActive:
+        if not self.allow_writes:
+            raise AssertionError("dry-run must never call flip_active")
+        self.write_calls.append(
+            (
+                "flip",
+                active.slug,
+                str(active.version),
+                str(expected_version),
+                expected_bundle_hash,
+            )
+        )
+        self.active_records = [
+            a for a in self.active_records if a.slug != active.slug
+        ] + [active]
+        return active
+
+
+class BrokenFlipClient(StubClient):
+    """A writer whose flip always loses the race."""
+
+    def flip_active(self, *args: Any, **kwargs: Any) -> MerchantTruthActive:
+        raise MerchantTruthConflictError(
+            "ACTIVE no longer matches the expected prior state"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Dry-run: zero writes (mutation-honesty guard for the --flip gate)
+# ---------------------------------------------------------------------------
+
+
+def test_dry_run_performs_zero_writes(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    manifest, components = build_sealed("vons", 1)
+    client = StubClient([(manifest, components)], allow_writes=False)
+
+    exit_code = amt.main(["--slug", "vons", "--version", "v1"], client=client)
+
+    assert exit_code == 0
+    assert client.write_calls == []
+    output = capsys.readouterr().out
+    assert "DRY-RUN: no writes performed" in output
+    assert "--flip" in output
+    assert "INITIAL ACTIVATION" in output
+    assert f"bundle_hash: `{manifest.bundle_hash}`" in output
+    assert "gate_status: PASS" in output
+    # Component hashes are part of the condensed decision summary.
+    assert manifest.component_hashes["identity"][:12] in output
+
+
+def test_dry_run_for_upgrade_names_flip_expected_state(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    v1, c1 = build_sealed("vons", 1)
+    v2, c2 = build_sealed("vons", 2)
+    client = StubClient(
+        [(v1, c1), (v2, c2)],
+        [make_active("vons", 1, v1.bundle_hash)],
+        allow_writes=False,
+    )
+
+    exit_code = amt.main(["--slug", "vons", "--version", "2"], client=client)
+
+    assert exit_code == 0
+    assert client.write_calls == []
+    output = capsys.readouterr().out
+    assert "FLIP: ACTIVE currently points at v1" in output
+    assert "flip_active" in output
+    assert f"{{version: 1, bundle_hash: `{v1.bundle_hash[:12]}`}}" in output
+
+
+def test_all_sealed_dry_run_performs_zero_writes(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    alpha, alpha_components = build_sealed("alpha", 1)
+    beta, beta_components = build_sealed("beta", 1)
+    client = StubClient(
+        [(alpha, alpha_components), (beta, beta_components)],
+        allow_writes=False,
+    )
+
+    exit_code = amt.main(["--all-sealed"], client=client)
+
+    assert exit_code == 0
+    assert client.write_calls == []
+    output = capsys.readouterr().out
+    assert "2 SEALED pending version(s)" in output
+    assert "| alpha | 1 | DRY-RUN |" in output
+    assert "| beta | 1 | DRY-RUN |" in output
+    assert "DRY-RUN: no writes performed" in output
+
+
+def test_gate_fail_bundle_is_not_activatable() -> None:
+    manifest, components = build_sealed("vons", 1, gate_status="FAIL")
+    client = StubClient([(manifest, components)], allow_writes=True)
+
+    exit_code = amt.main(
+        ["--slug", "vons", "--version", "1", "--flip"], client=client
+    )
+
+    assert exit_code == 1
+    assert client.write_calls == []
+
+
+# ---------------------------------------------------------------------------
+# Prod refusal (mutation-honesty guard for the prod table guard)
+# ---------------------------------------------------------------------------
+
+
+def test_prod_table_refused_before_any_read_or_write(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A poisoned constructor: if the guard is removed, main() constructs a
+    # client (client=None path) and this blows up before any AWS call.
+    import receipt_dynamo.data.dynamo_client as dynamo_client_module
+
+    def poisoned(*args: Any, **kwargs: Any) -> None:
+        raise AssertionError(
+            "prod guard must refuse before any client construction"
+        )
+
+    monkeypatch.setattr(dynamo_client_module, "DynamoClient", poisoned)
+    monkeypatch.setenv("DYNAMODB_TABLE_NAME", "ReceiptsTable-d7ff76a")
+
+    exit_code = amt.main(
+        ["--slug", "vons", "--version", "1", "--flip"], client=None
+    )
+
+    assert exit_code == 2
+    captured = capsys.readouterr()
+    assert "REFUSED" in captured.err
+    assert captured.out == ""
+
+    # Explicit --table with the exact prod name and with the marker
+    # substring are both refused before a single read or write.
+    manifest, components = build_sealed("vons", 1)
+    stub = StubClient([(manifest, components)], allow_writes=False)
+    for prod_name in ("ReceiptsTable-d7ff76a", "ReceiptsTable-d7ff76a-copy"):
+        assert (
+            amt.main(
+                [
+                    "--slug",
+                    "vons",
+                    "--version",
+                    "1",
+                    "--flip",
+                    "--table",
+                    prod_name,
+                ],
+                client=stub,
+            )
+            == 2
+        )
+    assert stub.read_calls == 0
+    assert stub.write_calls == []
+
+
+def test_default_table_is_dev(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("DYNAMODB_TABLE_NAME", raising=False)
+    assert amt.resolve_table(None) == "ReceiptsTable-dc5be22"
+
+
+# ---------------------------------------------------------------------------
+# moto write path (pattern: receipt_dynamo integration tests)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def dynamodb_table():
+    with mock_aws():
+        client = boto3.client("dynamodb", region_name="us-east-1")
+        client.create_table(
+            TableName=TABLE,
+            KeySchema=[
+                {"AttributeName": "PK", "KeyType": "HASH"},
+                {"AttributeName": "SK", "KeyType": "RANGE"},
+            ],
+            AttributeDefinitions=[
+                {"AttributeName": "PK", "AttributeType": "S"},
+                {"AttributeName": "SK", "AttributeType": "S"},
+                {"AttributeName": "TYPE", "AttributeType": "S"},
+            ],
+            GlobalSecondaryIndexes=[
+                {
+                    "IndexName": "GSITYPE",
+                    "KeySchema": [
+                        {"AttributeName": "TYPE", "KeyType": "HASH"}
+                    ],
+                    "Projection": {"ProjectionType": "ALL"},
+                }
+            ],
+            BillingMode="PAY_PER_REQUEST",
+        )
+        yield TABLE
+
+
+def seal_live(
+    client: DynamoClient, table: str, slug: str, version: int
+) -> str:
+    """Mint + seal one version through the real accessor; return its hash."""
+    client.mint_version(
+        slug,
+        version,
+        build_components(slug, version),
+        MINT_PROVENANCE,
+        f"run-{slug}-{version}",
+        table,
+        created_at=NOW,
+    )
+    sealed = client.seal_version(
+        slug,
+        version,
+        {"status": "PASS", "report": f"s3://eval/{slug}-v{version}.json"},
+        [],
+        table,
+        sealed_at=NOW,
+    )
+    return sealed.bundle_hash
+
+
+def activation_audits(table: str, slug: str) -> list[str]:
+    """Actions of every activation audit row for a merchant, oldest first."""
+    response = boto3.client("dynamodb", region_name="us-east-1").query(
+        TableName=table,
+        KeyConditionExpression="PK = :pk AND begins_with(SK, :sk)",
+        ExpressionAttributeValues={
+            ":pk": {"S": f"MERCHANT_TRUTH#{slug}"},
+            ":sk": {"S": "AUDIT#"},
+        },
+    )
+    return [
+        item["action"]["S"]
+        for item in response["Items"]
+        if item["action"]["S"] in {"INITIAL_ACTIVATE", "FLIP_ACTIVE"}
+    ]
+
+
+def test_initial_activation_creates_active_pointer_and_audit(
+    dynamodb_table: str, capsys: pytest.CaptureFixture[str]
+) -> None:
+    client = DynamoClient(dynamodb_table)
+    bundle_hash = seal_live(client, dynamodb_table, "vons", 1)
+
+    exit_code = amt.main(
+        [
+            "--slug",
+            "vons",
+            "--version",
+            "1",
+            "--flip",
+            "--table",
+            dynamodb_table,
+        ],
+        client=client,
+    )
+
+    assert exit_code == 0
+    active = client.get_active_merchant_truth("vons", consistent_read=True)
+    assert active is not None
+    assert (active.version, active.bundle_hash) == (1, bundle_hash)
+    assert active.activated_by == "owner-cli"  # the default identity
+    assert active.normalized_aliases == ["vons", "vons store"]
+    assert activation_audits(dynamodb_table, "vons") == ["INITIAL_ACTIVATE"]
+    output = capsys.readouterr().out
+    # The banner precedes the write and names table + slug + version.
+    assert "FLIP: about to write ACTIVE pointer(s)" in output
+    assert f"table: {dynamodb_table}" in output
+    assert "vons -> v1" in output
+    assert "Result: ACTIVATED" in output
+    assert f"ACTIVE: vons -> v1 (`{bundle_hash}`)" in output
+    assert "audit row written in the same" in output
+
+
+def test_second_activation_converges_idempotently(
+    dynamodb_table: str, capsys: pytest.CaptureFixture[str]
+) -> None:
+    client = DynamoClient(dynamodb_table)
+    bundle_hash = seal_live(client, dynamodb_table, "vons", 1)
+    argv = [
+        "--slug",
+        "vons",
+        "--version",
+        "1",
+        "--flip",
+        "--table",
+        dynamodb_table,
+    ]
+
+    assert amt.main(argv, client=client) == 0
+    capsys.readouterr()
+    assert amt.main(argv, client=client) == 0
+
+    output = capsys.readouterr().out
+    assert "ALREADY ACTIVE" in output
+    assert "Result: ALREADY-ACTIVE" in output
+    active = client.get_active_merchant_truth("vons", consistent_read=True)
+    assert active is not None
+    assert (active.version, active.bundle_hash) == (1, bundle_hash)
+    # Convergence writes nothing: still exactly one activation audit.
+    assert activation_audits(dynamodb_table, "vons") == ["INITIAL_ACTIVATE"]
+
+
+def test_flip_with_correct_expected_moves_pointer(
+    dynamodb_table: str, capsys: pytest.CaptureFixture[str]
+) -> None:
+    client = DynamoClient(dynamodb_table)
+    seal_live(client, dynamodb_table, "vons", 1)
+    hash_v2 = seal_live(client, dynamodb_table, "vons", 2)
+    assert (
+        amt.main(
+            [
+                "--slug",
+                "vons",
+                "--version",
+                "1",
+                "--flip",
+                "--table",
+                dynamodb_table,
+            ],
+            client=client,
+        )
+        == 0
+    )
+    capsys.readouterr()
+
+    exit_code = amt.main(
+        [
+            "--slug",
+            "vons",
+            "--version",
+            "2",
+            "--flip",
+            "--table",
+            dynamodb_table,
+            "--activated-by",
+            "tyler",
+        ],
+        client=client,
+    )
+
+    assert exit_code == 0
+    active = client.get_active_merchant_truth("vons", consistent_read=True)
+    assert active is not None
+    assert (active.version, active.bundle_hash) == (2, hash_v2)
+    assert active.prev_version == 1
+    assert active.activated_by == "tyler"
+    assert activation_audits(dynamodb_table, "vons") == [
+        "INITIAL_ACTIVATE",
+        "FLIP_ACTIVE",
+    ]
+    output = capsys.readouterr().out
+    assert "Result: FLIPPED" in output
+
+
+class StaleReadClient(DynamoClient):
+    """Reads a frozen (stale) ACTIVE pointer; writes hit the real table."""
+
+    stale_active: MerchantTruthActive | None = None
+
+    def get_active_merchant_truth(
+        self, slug: str, *, consistent_read: bool = False
+    ) -> MerchantTruthActive | None:
+        del slug, consistent_read
+        return self.stale_active
+
+
+def test_flip_with_stale_expected_conflicts_exit_3(
+    dynamodb_table: str, capsys: pytest.CaptureFixture[str]
+) -> None:
+    client = DynamoClient(dynamodb_table)
+    hash_v1 = seal_live(client, dynamodb_table, "vons", 1)
+    hash_v2 = seal_live(client, dynamodb_table, "vons", 2)
+    seal_live(client, dynamodb_table, "vons", 3)
+    client.initial_activate(make_active("vons", 1, hash_v1), dynamodb_table)
+    client.flip_active(
+        make_active("vons", 2, hash_v2), 1, hash_v1, dynamodb_table
+    )
+    # A racer that still believes ACTIVE is v1 attempts the flip to v3
+    # with that stale expected state — the conditional write must lose.
+    stale = StaleReadClient(dynamodb_table)
+    stale.stale_active = make_active("vons", 1, hash_v1)
+
+    exit_code = amt.main(
+        [
+            "--slug",
+            "vons",
+            "--version",
+            "3",
+            "--flip",
+            "--table",
+            dynamodb_table,
+        ],
+        client=stale,
+    )
+
+    assert exit_code == 3
+    output = capsys.readouterr().out
+    assert "CONFLICT" in output
+    assert "Another writer changed the ACTIVE pointer" in output
+    # The winner's pointer is untouched.
+    active = client.get_active_merchant_truth("vons", consistent_read=True)
+    assert active is not None
+    assert (active.version, active.bundle_hash) == (2, hash_v2)
+    # Both pre-seeded audits share activated_at, so compare unordered:
+    # the failed racer must not have added a third activation audit.
+    assert sorted(activation_audits(dynamodb_table, "vons")) == [
+        "FLIP_ACTIVE",
+        "INITIAL_ACTIVATE",
+    ]
+
+
+# ---------------------------------------------------------------------------
+# --all-sealed --flip: continue past per-merchant failures
+# ---------------------------------------------------------------------------
+
+
+def test_all_sealed_flip_continues_past_failure(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    alpha, alpha_components = build_sealed("alpha", 1)
+    beta, beta_components = build_sealed("beta", 1)
+    # Tamper with alpha: a missing component makes the fail-closed loader
+    # raise, and the sweep must still activate beta afterward. (alpha
+    # sorts first, so the failure precedes the success.)
+    client = StubClient(
+        [(alpha, alpha_components[:-1]), (beta, beta_components)],
+        allow_writes=True,
+    )
+
+    exit_code = amt.main(["--all-sealed", "--flip"], client=client)
+
+    assert exit_code == 1
+    assert client.write_calls == [("initial", "beta", "1")]
+    output = capsys.readouterr().out
+    assert "FLIP: about to write ACTIVE pointer(s)" in output
+    assert "alpha -> v1" in output
+    assert "beta -> v1" in output
+    assert "| alpha | 1 | ERROR:" in output
+    assert "| beta | 1 | ACTIVATED |" in output
+
+
+def test_all_sealed_flip_all_success_exits_zero(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    alpha, alpha_components = build_sealed("alpha", 1)
+    beta, beta_components = build_sealed("beta", 1)
+    client = StubClient(
+        [(alpha, alpha_components), (beta, beta_components)],
+        allow_writes=True,
+    )
+
+    exit_code = amt.main(["--all-sealed", "--flip"], client=client)
+
+    assert exit_code == 0
+    assert client.write_calls == [
+        ("initial", "alpha", "1"),
+        ("initial", "beta", "1"),
+    ]
+    output = capsys.readouterr().out
+    assert "| alpha | 1 | ACTIVATED |" in output
+    assert "| beta | 1 | ACTIVATED |" in output
+
+
+def test_single_conflict_exits_three_with_current_active(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    v1, c1 = build_sealed("vons", 1)
+    v2, c2 = build_sealed("vons", 2)
+    client = BrokenFlipClient(
+        [(v1, c1), (v2, c2)],
+        [make_active("vons", 1, v1.bundle_hash)],
+        allow_writes=True,
+    )
+
+    exit_code = amt.main(
+        ["--slug", "vons", "--version", "2", "--flip"], client=client
+    )
+
+    assert exit_code == 3
+    output = capsys.readouterr().out
+    assert "CONFLICT" in output
+    assert "Current ACTIVE for vons: v1" in output


### PR DESCRIPTION
## Summary

Owner-facing G2 activation CLI for versioned merchant truth (#1188 P4). Follows the plan: 13 merchants sit SEALED at v0000000001 in dev with 0 ACTIVE; `scripts/merchant_truth_diff.py` (Mode B, W5) is the review artifact, and this tool is the flip that follows the review.

- **DRY-RUN by default** (`--slug X --version N`): loads the bundle fail-closed by importing the diff tool's `load_bundle` verification path (manifest exists, SEALED, component set matches the contract, component hashes match the manifest, bundle_hash recomputes) plus a gate-PASS check and an identity `normalized_aliases` check. Prints the condensed decision summary (gate, bundle_hash, per-component hashes) and the exact mutation a flip WOULD perform (initial activation vs flip-from-{version, hash}), then tells the owner to add `--flip`.
- **`--flip`**: `DynamoClient.initial_activate` when no ACTIVE exists (conditional Put; converges idempotently), `flip_active` with the CURRENT active `{version, bundle_hash}` as expected-prev otherwise. Prints the resulting ACTIVE pointer + audit confirmation. `MerchantTruthConflictError` renders the race explanation and current ACTIVE, exit 3.
- **`--all-sealed [--flip]`**: iterates every SEALED-pending version via `fleet_status.build_sealed_pending`, one activation per merchant, continuing past per-merchant failures with a summary table. Dry-run without `--flip`.
- **Safety** (copied from the sibling scripts' conventions): dev table default via `DYNAMODB_TABLE_NAME`; unconditional prod refusal (exact `ReceiptsTable-d7ff76a` name and any `d7ff76a` marker substring) BEFORE any client construction, exit 2; `--flip` prints a banner (table, slug(s), versions) before writing; `activated_by` defaults to `owner-cli` (`--activated-by` overrides).

Exit codes: 0 success/dry-run/converged; 1 data-integrity or per-merchant sweep failure; 2 refused configuration; 3 lost activation race.

## Tests (13, all green)

`tests/test_activate_merchant_truth.py` — stub-client pattern from `tests/test_fleet_status.py` for the read-only/dry-run contract, moto (receipt_dynamo integration-test pattern, real `mint_version`/`seal_version` through the accessor) for the write path:

- dry-run performs zero writes (single + `--all-sealed`; write methods poisoned)
- initial activation creates the ACTIVE pointer + one INITIAL_ACTIVATE audit, default `activated_by=owner-cli`, banner before write
- second activation converges idempotently (no second audit)
- flip with correct expected state moves the pointer (prev_version, FLIP_ACTIVE audit, `--activated-by` override)
- flip with stale expected state loses the conditional write, exit 3, winner's pointer untouched
- prod refusal before any read/write/client construction (poisoned `DynamoClient` constructor + poisoned stub; env var, exact name, and marker-substring variants)
- gate-FAIL bundle is not activatable
- `--all-sealed --flip` continues past a per-merchant failure (tampered bundle) and activates the rest, exit 1 with summary table

### Mutation-honesty (verified by hand, both mutations reverted)

- Removing the prod guard (`resolve_table` refusal) turns **`test_prod_table_refused_before_any_read_or_write`** red (1 failed / 12 passed).
- Removing the `--flip` gate (dry-run early-returns) turns **`test_dry_run_performs_zero_writes`** red (also `test_dry_run_for_upgrade_names_flip_expected_state` and `test_all_sealed_dry_run_performs_zero_writes`; 3 failed / 10 passed).

## Live DRY-RUN against dev (read-only; no live --flip — first activation is the owner's moment)

```
$ python scripts/activate_merchant_truth.py --slug costco_wholesale --version 1
# Activation: costco_wholesale v1

Table: `ReceiptsTable-dc5be22`

- gate_status: PASS
- bundle_hash: `c5cd31202f7a52cee5f5b492c675ae4ed1d94241529bdc3d16d85b18bf7fd064`
- manifest: SEALED, sealed_at 2026-07-21T17:06:49.844567+00:00
- components: identity `175c84d2a749`, typography `70947f1d6ca6`, stylemap `86e085f27327`, layout `7e6a7a3232a1`, assets `f7e32df3005b`, flags `4359b2e0a16b`, catalog_snapshot `835af79b29ea`

## Mutation

- INITIAL ACTIVATION: no ACTIVE pointer exists for costco_wholesale.
- Mutation: initial_activate -> ACTIVE = v1 (`c5cd31202f7a`) via conditional Put (ACTIVE absent; converges idempotently).

DRY-RUN: no writes performed. Re-run with --flip to perform this activation (owner gate G2).
```

Contract: `docs/architecture/MERCHANT_TRUTH_DYNAMO.md`. Cites #1188 P4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BeLcSviHL5vDgS3zTSMbsq