### PR TITLE
[nightly] Loop v0 harness: wrapper, brief, report contract, launchd (W2)

### DIFF
--- a/docs/nightly/BRIEF.md
+++ b/docs/nightly/BRIEF.md
@@ -1,0 +1,91 @@
+# Nightly Loop v0 Brief — eval-only, read-only
+
+You are the nightly receipt-synthesis agent (loop v0, plan
+humble-skipping-quilt W2). Tonight you MEASURE and REPORT. You change
+nothing.
+
+## Environment (exported by the wrapper)
+
+- `$NIGHTLY_DATE` — tonight's date (YYYY-MM-DD)
+- `$NIGHTLY_REPORT_PATH` — the EXACT file you must write the morning
+  report to (docs/reports/nightly/$NIGHTLY_DATE.md)
+- `$NIGHTLY_RUN_DIR` — scratch/log dir; `preflight.json` in it holds the
+  preflight result (read it; if any check is degraded, say so in
+  Failures & Anomalies and continue DEGRADED — do not abort)
+- `$NIGHTLY_REPO_ROOT` — the Portfolio checkout to work in
+- `DYNAMODB_TABLE_NAME` — the dev table. Dev only, reads only.
+
+If the receipt-tools MCP is unauthenticated, run DEGRADED: skip MCP-backed
+steps, note it in Failures & Anomalies, keep going with direct read-only
+AWS/scripts access.
+
+## Hard guardrails (violating any of these makes the night a failure)
+
+- READ-ONLY: never write to DynamoDB or S3. No put/update/delete/batch
+  writes, no uploads, no mint, no seal.
+- Never flip ACTIVE pointers. Never promote to prod. Never touch the prod
+  table (ReceiptsTable-d7ff76a).
+- Never merge, push, force-push, or delete branches. Do not commit; the
+  wrapper publishes your report.
+- Do not modify any repo file except writing `$NIGHTLY_REPORT_PATH`.
+  Eval artifacts go under `$NIGHTLY_RUN_DIR`.
+- At most 3 concurrent subagents. Stay within your turn budget; if time
+  runs short, write the report early with what you have.
+
+## Mission
+
+1. **Fleet status.** From `$NIGHTLY_REPO_ROOT` run:
+   `python3 synthesis_loop/fleet_status.py` (markdown) and
+   `python3 synthesis_loop/fleet_status.py --json > "$NIGHTLY_RUN_DIR/fleet.json"`.
+   The markdown output goes verbatim into the report's Fleet section. If
+   `docs/reports/nightly/` contains a previous report, add a one-line
+   delta vs its Fleet section; otherwise say "no prior report".
+
+2. **Pick 3 merchants** by date-hash rotation over the ACTIVE fleet
+   (deterministic per night, rotates across nights):
+
+   ```bash
+   python3 - <<'EOF'
+   import hashlib, json, os
+   run_dir = os.environ["NIGHTLY_RUN_DIR"]
+   fleet = json.load(open(os.path.join(run_dir, "fleet.json")))
+   slugs = sorted(r["slug"] for r in fleet.get("active", []))
+   date = os.environ["NIGHTLY_DATE"]
+   if slugs:
+       start = int(hashlib.sha256(date.encode()).hexdigest(), 16) % len(slugs)
+       picks = [slugs[(start + i) % len(slugs)] for i in range(min(3, len(slugs)))]
+   else:
+       picks = []
+   print("\n".join(picks))
+   EOF
+   ```
+
+   (`fleet.json` shape: top-level `active` list, each row has `slug` —
+   see `synthesis_loop/fleet_status.py build_report`. The intent is:
+   sorted ACTIVE slugs, start index = sha256(date) mod N, take 3
+   consecutive with wraparound.)
+
+3. **Eval sweep (current form, legacy path).** For each picked merchant,
+   run `synthesis_loop/full_fidelity_eval.py run <merchant> <image_id>
+   <receipt_id> <slug> --out-root "$NIGHTLY_RUN_DIR/eval"` against dev on
+   its golden receipt — the receipt its profile/truth bundle references
+   (look in the merchant's truth bundle GOLDEN component, else
+   `scripts/merchant_profiles.json`, else the merchant's most recent
+   receipt via read-only Dynamo queries). Run it only if cheap: if
+   finding the golden receipt or completing the render+eval would exceed
+   ~30 minutes for that merchant, or requires anything non-read-only,
+   record `SKIPPED` with a one-line reason instead. A failing eval is a
+   finding, not an error — record the per-metric verdicts.
+
+4. **Write the morning report** to `$NIGHTLY_REPORT_PATH`, following
+   `docs/nightly/REPORT_CONTRACT.md` section by section (all seven `##`
+   sections, exact headings, one verdict line). Verdict: GREEN if fleet
+   ran and all attempted evals completed (pass or fail is still GREEN —
+   red metrics are findings); YELLOW if anything was SKIPPED or DEGRADED;
+   RED only if you produced no usable work. Self-check before finishing:
+   `python3 scripts/nightly/check_contract.py "$NIGHTLY_REPORT_PATH"`
+   must exit 0.
+
+The report is your only deliverable. The wrapper validates it, publishes
+it to a `nightly/$NIGHTLY_DATE` branch, and logs the summary line — you
+do none of that.

--- a/docs/nightly/BRIEF.md
+++ b/docs/nightly/BRIEF.md
@@ -76,6 +76,8 @@ AWS/scripts access.
    ~30 minutes for that merchant, or requires anything non-read-only,
    record `SKIPPED` with a one-line reason instead. A failing eval is a
    finding, not an error — record the per-metric verdicts.
+   `full_fidelity_eval` must be invoked read-only; if any invocation
+   would write to DynamoDB or S3, SKIP that merchant and record why.
 
 4. **Write the morning report** to `$NIGHTLY_REPORT_PATH`, following
    `docs/nightly/REPORT_CONTRACT.md` section by section (all seven `##`

--- a/docs/nightly/REPORT_CONTRACT.md
+++ b/docs/nightly/REPORT_CONTRACT.md
@@ -14,6 +14,14 @@ is case-insensitive on the title text but must be a level-2 markdown heading
 (`## `). Extra sections are allowed after the required ones; extra prose
 inside sections is allowed.
 
+Two hardening rules:
+
+- Fenced code blocks (``` or ~~~) are stripped before scanning: a heading
+  or verdict line quoted inside a fence does not count.
+- Every required section needs a non-empty body: at least one
+  non-whitespace line (outside fences) before the next `#`/`##` heading.
+  Write `None.` rather than leaving a section blank.
+
 ### 1. `## Verdict`
 
 Must contain exactly one verdict line matching this grammar (first match

--- a/docs/nightly/REPORT_CONTRACT.md
+++ b/docs/nightly/REPORT_CONTRACT.md
@@ -1,0 +1,85 @@
+# Nightly Morning-Report Contract (v0)
+
+Every nightly run MUST end with one report file at
+`docs/reports/nightly/YYYY-MM-DD.md` (the wrapper exports the exact path as
+`$NIGHTLY_REPORT_PATH`). The wrapper validates the report with
+`scripts/nightly/check_contract.py`; a missing or invalid report is replaced
+by a RED stub. This file is the single source of truth for what "valid"
+means.
+
+## Required sections
+
+All seven `##` headings below must be present, in this order. Heading match
+is case-insensitive on the title text but must be a level-2 markdown heading
+(`## `). Extra sections are allowed after the required ones; extra prose
+inside sections is allowed.
+
+### 1. `## Verdict`
+
+Must contain exactly one verdict line matching this grammar (first match
+wins; the checker rejects reports with zero matches):
+
+```
+**Verdict: GREEN** - <one sentence>
+```
+
+- Color is one of `GREEN`, `YELLOW`, `RED` (uppercase).
+- The `**` bold markers are optional; the ` - ` separator may also be `: `.
+- The trailing sentence is required (why this color, one line).
+
+Meaning: `GREEN` = everything planned ran and passed; `YELLOW` = ran with
+skips/degradations worth reading; `RED` = the night did not produce usable
+work (preflight RED, watchdog kill, contract failure).
+
+### 2. `## Budget`
+
+Wall clock used, agent turns used (vs `--max-turns`), subagent count
+(vs the <=3 cap). A stub report states `n/a` where unknown.
+
+### 3. `## Fleet`
+
+The `fleet_status` markdown table (ACTIVE rows, sealed-pending, missing
+merchants) plus a one-line delta vs yesterday's report (or "no prior
+report" / "fleet unavailable" in a stub).
+
+### 4. `## Tonight's Work`
+
+Per merchant touched tonight: what ran and the result. For loop v0
+(eval-only) that is the full-fidelity eval verdict per metric, or
+`SKIPPED` with the reason. Later loop versions add minted
+version/hash, metric red->green deltas, evidence-sheet paths+SHAs, and the
+diff artifact here.
+
+### 5. `## Awaiting Owner`
+
+Everything that needs a human decision: staged flip commands each with a
+one-line diff summary (v1+; v0 stages nothing), merge FYIs and exceptions,
+PARKED items with the single decision needed. `None` is a valid body.
+
+### 6. `## Failures & Anomalies`
+
+Preflight degradations (e.g. receipt-tools MCP unauthenticated), contract
+or watchdog events, reaped screens, eval errors, anything surprising.
+`None` is a valid body.
+
+### 7. `## Tomorrow's Top 3`
+
+Three (or fewer, with a reason) concrete targets, each with the driving
+metric or proposal.
+
+## Checker behavior
+
+`scripts/nightly/check_contract.py REPORT.md`:
+
+- exit 0: all seven sections present in order + parseable verdict line.
+- exit 1: invalid (each problem printed, one per line).
+- exit 2: file missing/unreadable.
+- `--verdict` prints just the parsed color (GREEN/YELLOW/RED) for a valid
+  report; `--json` emits the machine-readable result.
+
+## Delivery
+
+The wrapper commits the report to a `nightly/YYYY-MM-DD` branch pushed to
+origin (never merged to main) and appends a one-line summary to
+`~/section_label_kickoff/CAMPAIGN_LOG.md`. A condensed comment on the
+pinned fleet issue is a later addition (v1).

--- a/infra/ops/README.md
+++ b/infra/ops/README.md
@@ -1,0 +1,29 @@
+# infra/ops — host-level operational units
+
+launchd units for the mini (loop host). These files are COMMITTED here but
+NOT installed by any PR or CI — installation is an owner op.
+
+## com.tnorlund.receipt-nightly
+
+Nightly receipt-synthesis loop v0 (02:00 daily, caffeinate-wrapped,
+`RunAtLoad` false). Wrapper: `scripts/nightly/run_nightly.sh`; mission:
+`docs/nightly/BRIEF.md`; report contract: `docs/nightly/REPORT_CONTRACT.md`.
+
+Install (owner op, on the mini):
+
+```sh
+launchctl bootstrap gui/$UID /Users/tnorlund/Portfolio/infra/ops/com.tnorlund.receipt-nightly.plist
+```
+
+Uninstall / trigger-now / status:
+
+```sh
+launchctl bootout gui/$UID/com.tnorlund.receipt-nightly
+launchctl kickstart gui/$UID/com.tnorlund.receipt-nightly
+launchctl print gui/$UID/com.tnorlund.receipt-nightly | head -30
+```
+
+Logs: `~/Library/Logs/receipt-nightly.{out,err}.log` plus per-run dirs in
+`~/.nightly-loop/YYYY-MM-DD/`. Reports land on `nightly/YYYY-MM-DD`
+branches (never merged to main) and at `docs/reports/nightly/` in the loop
+checkout.

--- a/infra/ops/com.tnorlund.receipt-nightly.plist
+++ b/infra/ops/com.tnorlund.receipt-nightly.plist
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <!-- Nightly receipt-synthesis loop v0 (plan humble-skipping-quilt W2).
+       Committed to the repo; installation is an OWNER OP (see
+       infra/ops/README.md). RunAtLoad is false: the loop only fires on
+       its 02:00 schedule, never on login/bootstrap. caffeinate -ims keeps
+       the mini awake for the run without lighting the display. -->
+  <key>Label</key>
+  <string>com.tnorlund.receipt-nightly</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>/usr/bin/caffeinate</string>
+    <string>-ims</string>
+    <string>/bin/bash</string>
+    <string>-lc</string>
+    <string>exec /Users/tnorlund/Portfolio/scripts/nightly/run_nightly.sh</string>
+  </array>
+
+  <key>StartCalendarInterval</key>
+  <dict>
+    <key>Hour</key>
+    <integer>2</integer>
+    <key>Minute</key>
+    <integer>0</integer>
+  </dict>
+
+  <key>RunAtLoad</key>
+  <false/>
+
+  <key>WorkingDirectory</key>
+  <string>/Users/tnorlund/Portfolio</string>
+
+  <key>StandardOutPath</key>
+  <string>/Users/tnorlund/Library/Logs/receipt-nightly.out.log</string>
+  <key>StandardErrorPath</key>
+  <string>/Users/tnorlund/Library/Logs/receipt-nightly.err.log</string>
+
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>/Users/tnorlund/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    <key>CLAUDE_BIN</key>
+    <string>/Users/tnorlund/.local/bin/claude</string>
+  </dict>
+</dict>
+</plist>

--- a/scripts/nightly/check_contract.py
+++ b/scripts/nightly/check_contract.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Morning-report contract checker (plan humble-skipping-quilt W2).
+
+Validates a nightly morning report against docs/nightly/REPORT_CONTRACT.md:
+all seven required ``##`` sections present in order, plus exactly one
+parseable verdict line. The nightly wrapper runs this on the agent's
+report; a nonzero exit makes the wrapper replace the report with a RED
+stub (which itself satisfies this contract).
+
+Usage:
+    check_contract.py REPORT.md [--json] [--verdict]
+
+Exit codes:
+    0  valid report
+    1  invalid report (problems printed one per line to stderr)
+    2  file missing or unreadable
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from typing import Any
+
+REQUIRED_SECTIONS: tuple[str, ...] = (
+    "Verdict",
+    "Budget",
+    "Fleet",
+    "Tonight's Work",
+    "Awaiting Owner",
+    "Failures & Anomalies",
+    "Tomorrow's Top 3",
+)
+
+# **Verdict: GREEN** - sentence   (bold optional, "-" or ":" separator,
+# nonempty trailing sentence required). Colors are uppercase-only.
+VERDICT_RE = re.compile(
+    r"^(?:\*\*)?Verdict:\s*(GREEN|YELLOW|RED)(?:\*\*)?\s*[-:]\s*(\S.*)$"
+)
+
+HEADING_RE = re.compile(r"^##\s+(.+?)\s*$")
+
+
+def _normalize_heading(title: str) -> str:
+    return title.strip().lower()
+
+
+def check_report_text(text: str) -> dict[str, Any]:
+    """Pure contract check; returns {valid, verdict, problems, sections}."""
+    problems: list[str] = []
+
+    headings: list[str] = [
+        _normalize_heading(m.group(1))
+        for line in text.splitlines()
+        if (m := HEADING_RE.match(line))
+    ]
+
+    # Presence + order: walk the found headings looking for each required
+    # section past the position of the previous one.
+    cursor = 0
+    out_of_order: list[str] = []
+    for section in REQUIRED_SECTIONS:
+        want = _normalize_heading(section)
+        try:
+            idx = headings.index(want, cursor)
+            cursor = idx + 1
+        except ValueError:
+            if want in headings:
+                out_of_order.append(section)
+            else:
+                problems.append(f"missing section: ## {section}")
+    for section in out_of_order:
+        problems.append(f"section out of order: ## {section}")
+
+    verdict_matches = [
+        m for line in text.splitlines() if (m := VERDICT_RE.match(line))
+    ]
+    verdict: str | None = None
+    if not verdict_matches:
+        problems.append(
+            "no parseable verdict line "
+            "(need: **Verdict: GREEN|YELLOW|RED** - <one sentence>)"
+        )
+    else:
+        verdict = verdict_matches[0].group(1)
+        if len(verdict_matches) > 1:
+            problems.append(
+                f"multiple verdict lines ({len(verdict_matches)}); "
+                "the contract requires exactly one"
+            )
+
+    return {
+        "valid": not problems,
+        "verdict": verdict,
+        "problems": problems,
+        "sections_found": headings,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate a nightly morning report against the contract."
+    )
+    parser.add_argument("report", help="path to the morning report .md")
+    parser.add_argument(
+        "--json", action="store_true", help="emit the machine-readable result"
+    )
+    parser.add_argument(
+        "--verdict",
+        action="store_true",
+        help="print only the parsed verdict color (valid reports only)",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        with open(args.report, encoding="utf-8") as handle:
+            text = handle.read()
+    except OSError as exc:
+        print(f"cannot read report: {exc}", file=sys.stderr)
+        return 2
+
+    result = check_report_text(text)
+
+    if args.json:
+        print(json.dumps(result, indent=2))
+    elif args.verdict:
+        if result["valid"]:
+            print(result["verdict"])
+    else:
+        status = "VALID" if result["valid"] else "INVALID"
+        print(f"contract: {status} verdict={result['verdict'] or 'n/a'}")
+
+    for problem in result["problems"]:
+        print(problem, file=sys.stderr)
+    return 0 if result["valid"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/nightly/check_contract.py
+++ b/scripts/nightly/check_contract.py
@@ -2,10 +2,12 @@
 """Morning-report contract checker (plan humble-skipping-quilt W2).
 
 Validates a nightly morning report against docs/nightly/REPORT_CONTRACT.md:
-all seven required ``##`` sections present in order, plus exactly one
-parseable verdict line. The nightly wrapper runs this on the agent's
-report; a nonzero exit makes the wrapper replace the report with a RED
-stub (which itself satisfies this contract).
+all seven required ``##`` sections present in order with non-empty bodies,
+plus exactly one parseable verdict line. Fenced code blocks (``` or ~~~)
+are stripped before scanning, so quoted headings/verdicts don't count.
+The nightly wrapper runs this on the agent's report; a nonzero exit makes
+the wrapper replace the report with a RED stub (which itself satisfies
+this contract).
 
 Usage:
     check_contract.py REPORT.md [--json] [--verdict]
@@ -41,19 +43,60 @@ VERDICT_RE = re.compile(
 )
 
 HEADING_RE = re.compile(r"^##\s+(.+?)\s*$")
+ANY_HEADING_RE = re.compile(r"^#{1,2}\s+\S")
+FENCE_RE = re.compile(r"^\s*(```|~~~)")
 
 
 def _normalize_heading(title: str) -> str:
     return title.strip().lower()
 
 
+def _strip_fences(text: str) -> list[str]:
+    """Drop fenced code blocks: headings/verdicts inside them don't count."""
+    lines: list[str] = []
+    in_fence = False
+    for line in text.splitlines():
+        if FENCE_RE.match(line):
+            in_fence = not in_fence
+            continue
+        if not in_fence:
+            lines.append(line)
+    return lines
+
+
+def _section_bodies(lines: list[str]) -> dict[str, list[str]]:
+    """Map each ## heading (first occurrence) to its body lines.
+
+    A body runs to the next level-1/2 heading; deeper headings count as
+    body content. Fenced blocks are already stripped, so a section whose
+    only content was a code fence counts as empty.
+    """
+    bodies: dict[str, list[str]] = {}
+    current: str | None = None
+    for line in lines:
+        match = HEADING_RE.match(line)
+        if match:
+            key = _normalize_heading(match.group(1))
+            current = key if key not in bodies else None
+            if current is not None:
+                bodies[current] = []
+            continue
+        if ANY_HEADING_RE.match(line):
+            current = None
+            continue
+        if current is not None:
+            bodies[current].append(line)
+    return bodies
+
+
 def check_report_text(text: str) -> dict[str, Any]:
     """Pure contract check; returns {valid, verdict, problems, sections}."""
     problems: list[str] = []
+    lines = _strip_fences(text)
 
     headings: list[str] = [
         _normalize_heading(m.group(1))
-        for line in text.splitlines()
+        for line in lines
         if (m := HEADING_RE.match(line))
     ]
 
@@ -74,9 +117,13 @@ def check_report_text(text: str) -> dict[str, Any]:
     for section in out_of_order:
         problems.append(f"section out of order: ## {section}")
 
-    verdict_matches = [
-        m for line in text.splitlines() if (m := VERDICT_RE.match(line))
-    ]
+    bodies = _section_bodies(lines)
+    for section in REQUIRED_SECTIONS:
+        want = _normalize_heading(section)
+        if want in bodies and not any(line.strip() for line in bodies[want]):
+            problems.append(f"empty section: ## {section}")
+
+    verdict_matches = [m for line in lines if (m := VERDICT_RE.match(line))]
     verdict: str | None = None
     if not verdict_matches:
         problems.append(

--- a/scripts/nightly/fixtures/canned_agent_report.md
+++ b/scripts/nightly/fixtures/canned_agent_report.md
@@ -1,0 +1,37 @@
+# Nightly Report {{DATE}} (dry-run canned output)
+
+This report was produced by `run_nightly.sh --dry-run`: the headless claude
+call was skipped and this canned agent output was substituted. It exists to
+exercise the wrapper end-to-end (preflight -> contract check -> publish)
+without spending an agent run.
+
+## Verdict
+**Verdict: YELLOW** - dry-run: wrapper path exercised end-to-end, no real eval work performed.
+
+## Budget
+- wall clock: 0s agent time (claude call skipped by --dry-run)
+- turns: 0 of 80
+- subagents: 0 of 3
+
+## Fleet
+Fleet table not collected (dry-run substitutes canned output for the agent).
+Delta vs yesterday: n/a (dry-run).
+
+| slug | version | gate | staleness |
+|------|---------|------|-----------|
+| (dry-run placeholder - real runs paste fleet_status markdown here) | - | - | - |
+
+## Tonight's Work
+- dry-run: SKIPPED - all 3 merchant evals skipped because --dry-run never
+  launches the agent.
+
+## Awaiting Owner
+None (dry-run).
+
+## Failures & Anomalies
+None (dry-run).
+
+## Tomorrow's Top 3
+1. Run a real supervised night (owner-gated first run) - driving item: W2 acceptance
+2. Verify preflight is GREEN on the mini (receipt-tools MCP auth) - driving item: W1 op
+3. Confirm nightly/YYYY-MM-DD branch publishing from the mini - driving item: W2 publish leg

--- a/scripts/nightly/run_nightly.sh
+++ b/scripts/nightly/run_nightly.sh
@@ -1,0 +1,234 @@
+#!/usr/bin/env bash
+# Nightly loop v0 wrapper (plan humble-skipping-quilt W2). Eval-only,
+# read-only. Sequence:
+#   1. scripts/agent_preflight.sh   exit 2 (RED)  -> RED stub report, no agent
+#   2. headless `claude -p` on docs/nightly/BRIEF.md, 4h watchdog
+#   3. scripts/nightly/check_contract.py           invalid -> RED stub
+#   4. publish: commit report on nightly/YYYY-MM-DD branch pushed to origin
+#      (NEVER merged to main) + one-line summary appended to CAMPAIGN_LOG
+#
+# The wrapper ALWAYS produces a report file, even if everything fails.
+#
+# Flags:
+#   --dry-run   skip the claude call (use the canned agent report) and skip
+#               all git mutations (branch/commit/push are logged, not run).
+#
+# Env overrides (all optional; defaults suit the mini):
+#   CLAUDE_BIN              headless claude binary (~/.local/bin/claude)
+#   NIGHTLY_REPO_ROOT       Portfolio checkout (default: this script's repo)
+#   NIGHTLY_DATE            YYYY-MM-DD (default: today)
+#   NIGHTLY_REPORT_DIR      default $REPO_ROOT/docs/reports/nightly
+#   NIGHTLY_LOG_DIR         default ~/.nightly-loop
+#   NIGHTLY_CAMPAIGN_LOG    default ~/section_label_kickoff/CAMPAIGN_LOG.md
+#   NIGHTLY_PREFLIGHT_BIN   default $REPO_ROOT/scripts/agent_preflight.sh
+#   NIGHTLY_TIMEOUT_SECS    default 14400 (4h)
+#   NIGHTLY_MAX_TURNS       default 80
+#
+# Exit: 0 report produced and published (any verdict); 1 only when even the
+# stub/publish path failed.
+
+set -u -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${NIGHTLY_REPO_ROOT:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
+RUN_DATE="${NIGHTLY_DATE:-$(date +%F)}"
+REPORT_DIR="${NIGHTLY_REPORT_DIR:-$REPO_ROOT/docs/reports/nightly}"
+REPORT_PATH="$REPORT_DIR/$RUN_DATE.md"
+RUN_DIR="${NIGHTLY_LOG_DIR:-$HOME/.nightly-loop}/$RUN_DATE"
+CAMPAIGN_LOG="${NIGHTLY_CAMPAIGN_LOG:-$HOME/section_label_kickoff/CAMPAIGN_LOG.md}"
+PREFLIGHT_BIN="${NIGHTLY_PREFLIGHT_BIN:-$REPO_ROOT/scripts/agent_preflight.sh}"
+TIMEOUT_SECS="${NIGHTLY_TIMEOUT_SECS:-14400}"
+MAX_TURNS="${NIGHTLY_MAX_TURNS:-80}"
+BRIEF="$REPO_ROOT/docs/nightly/BRIEF.md"
+CANNED_REPORT="$SCRIPT_DIR/fixtures/canned_agent_report.md"
+CHECKER="$SCRIPT_DIR/check_contract.py"
+# Dev table pin: never inherit a prod-pointing env into the loop.
+export DYNAMODB_TABLE_NAME="${DYNAMODB_TABLE_NAME:-ReceiptsTable-dc5be22}"
+export PORTFOLIO_ENV=dev
+
+# CLAUDE_BIN resolution: env override, then ~/.local/bin/claude, then PATH.
+if [ -z "${CLAUDE_BIN:-}" ]; then
+  if [ -x "$HOME/.local/bin/claude" ]; then
+    CLAUDE_BIN="$HOME/.local/bin/claude"
+  else
+    CLAUDE_BIN="claude"
+  fi
+fi
+
+DRY_RUN=0
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=1 ;;
+    *) echo "unknown argument: $arg" >&2; exit 64 ;;
+  esac
+done
+
+mkdir -p "$REPORT_DIR" "$RUN_DIR"
+START_EPOCH="$(date +%s)"
+
+log() {
+  printf '[%s] %s\n' "$(date -u +%FT%TZ)" "$*" | tee -a "$RUN_DIR/wrapper.log" >&2
+}
+
+elapsed() { echo "$(( $(date +%s) - START_EPOCH ))"; }
+
+# Portable 4h watchdog: coreutils timeout, gtimeout, else the perl
+# alarm+exec idiom (the alarm survives exec; SIGALRM kills the child).
+run_with_timeout() {
+  local secs="$1"; shift
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$secs" "$@"
+  elif command -v gtimeout >/dev/null 2>&1; then
+    gtimeout "$secs" "$@"
+  else
+    perl -e 'alarm shift @ARGV; exec @ARGV or die "exec: $!"' "$secs" "$@"
+  fi
+}
+
+PREFLIGHT_SUMMARY="not run"
+
+write_red_stub() {
+  local reason="$1"
+  log "writing RED stub report: $reason"
+  cat > "$REPORT_PATH" <<EOF
+# Nightly Report $RUN_DATE (RED stub)
+
+## Verdict
+**Verdict: RED** - $reason
+
+## Budget
+- wall clock: $(elapsed)s (wrapper); no completed agent run
+- turns: n/a
+- subagents: n/a
+
+## Fleet
+Fleet table unavailable (stub report). See the most recent prior report in
+docs/reports/nightly/ for the last known fleet state.
+
+## Tonight's Work
+None - $reason
+
+## Awaiting Owner
+- Investigate the RED cause: $reason
+- Logs: $RUN_DIR (wrapper.log, preflight.json, agent_stdout.log)
+
+## Failures & Anomalies
+- $reason
+- preflight: $PREFLIGHT_SUMMARY
+
+## Tomorrow's Top 3
+1. Restore the nightly loop to GREEN (root-cause: $reason)
+2. Re-run preflight manually: scripts/agent_preflight.sh
+3. Re-attempt the skipped eval sweep once preflight is healthy
+EOF
+}
+
+publish_report() {
+  local branch="nightly/$RUN_DATE"
+  local verdict summary_line
+  verdict="$(python3 "$CHECKER" --verdict "$REPORT_PATH" 2>/dev/null || echo RED)"
+  [ -n "$verdict" ] || verdict="RED"
+  summary_line="$(date -u +%FT%TZ) nightly-v0 $RUN_DATE verdict=$verdict report=docs/reports/nightly/$RUN_DATE.md branch=$branch elapsed=$(elapsed)s"
+
+  if [ "$DRY_RUN" -eq 1 ]; then
+    log "[dry-run] would commit $REPORT_PATH on branch $branch and push to origin"
+  else
+    local wt
+    wt="$(mktemp -d "${TMPDIR:-/tmp}/nightly-publish.XXXXXX")"
+    if git -C "$REPO_ROOT" worktree add --detach "$wt" HEAD >/dev/null 2>&1; then
+      mkdir -p "$wt/docs/reports/nightly"
+      cp "$REPORT_PATH" "$wt/docs/reports/nightly/$RUN_DATE.md"
+      git -C "$wt" checkout -q -B "$branch" \
+        && git -C "$wt" add "docs/reports/nightly/$RUN_DATE.md" \
+        && git -C "$wt" commit -q -m "nightly: morning report $RUN_DATE ($verdict)
+
+Automated nightly loop v0 report. Not for merge to main; read the file.
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>" \
+        && git -C "$wt" push origin "$branch" \
+        && log "published $branch to origin" \
+        || log "WARNING: git publish failed; report remains at $REPORT_PATH"
+      git -C "$REPO_ROOT" worktree remove --force "$wt" >/dev/null 2>&1 || true
+    else
+      log "WARNING: could not create publish worktree; report remains at $REPORT_PATH"
+    fi
+  fi
+
+  mkdir -p "$(dirname "$CAMPAIGN_LOG")" 2>/dev/null || true
+  if printf '%s\n' "$summary_line" >> "$CAMPAIGN_LOG" 2>/dev/null; then
+    log "campaign log appended: $CAMPAIGN_LOG"
+  else
+    log "WARNING: could not append to campaign log $CAMPAIGN_LOG"
+  fi
+  log "morning report: $REPORT_PATH (verdict=$verdict)"
+}
+
+finish() {
+  # The wrapper ALWAYS leaves a report file behind, whatever happened.
+  if [ ! -s "$REPORT_PATH" ]; then
+    write_red_stub "wrapper reached exit without a report (unexpected)"
+  fi
+  publish_report
+}
+
+# ---- 1. Preflight ---------------------------------------------------------
+log "nightly v0 start date=$RUN_DATE repo=$REPO_ROOT dry_run=$DRY_RUN"
+if [ -x "$PREFLIGHT_BIN" ] || [ -f "$PREFLIGHT_BIN" ]; then
+  PREFLIGHT_JSON="$(bash "$PREFLIGHT_BIN" 2>"$RUN_DIR/preflight_summary.txt")"
+  PF_EXIT=$?
+else
+  PREFLIGHT_JSON=""
+  PF_EXIT=2
+  echo "preflight script not found: $PREFLIGHT_BIN" > "$RUN_DIR/preflight_summary.txt"
+fi
+printf '%s\n' "$PREFLIGHT_JSON" > "$RUN_DIR/preflight.json"
+PREFLIGHT_SUMMARY="$(tr '\n' '; ' < "$RUN_DIR/preflight_summary.txt" | cut -c1-400)"
+log "preflight exit=$PF_EXIT"
+
+if [ "$PF_EXIT" -ge 2 ]; then
+  write_red_stub "preflight RED (exit $PF_EXIT); night skipped per guardrail"
+  finish
+  exit 0
+fi
+if [ "$PF_EXIT" -eq 1 ]; then
+  log "preflight DEGRADED - continuing (agent runs DEGRADED, e.g. receipt-tools MCP unauthenticated)"
+fi
+
+# ---- 2. Headless agent run ------------------------------------------------
+export NIGHTLY_DATE="$RUN_DATE"
+export NIGHTLY_REPORT_PATH="$REPORT_PATH"
+export NIGHTLY_RUN_DIR="$RUN_DIR"
+export NIGHTLY_REPO_ROOT="$REPO_ROOT"
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  log "[dry-run] skipping claude call; using canned agent report"
+  sed "s/{{DATE}}/$RUN_DATE/g" "$CANNED_REPORT" > "$REPORT_PATH"
+  AGENT_EXIT=0
+else
+  if [ ! -f "$BRIEF" ]; then
+    write_red_stub "brief missing: $BRIEF"
+    finish
+    exit 0
+  fi
+  log "launching headless claude ($CLAUDE_BIN), timeout=${TIMEOUT_SECS}s max_turns=$MAX_TURNS"
+  ( cd "$REPO_ROOT" && run_with_timeout "$TIMEOUT_SECS" \
+      "$CLAUDE_BIN" -p "$(cat "$BRIEF")" \
+      --permission-mode bypassPermissions \
+      --model claude-fable-5 \
+      --max-turns "$MAX_TURNS" \
+      > "$RUN_DIR/agent_stdout.log" 2> "$RUN_DIR/agent_stderr.log" )
+  AGENT_EXIT=$?
+  log "agent exit=$AGENT_EXIT"
+fi
+
+# ---- 3. Contract check ----------------------------------------------------
+if [ ! -s "$REPORT_PATH" ]; then
+  write_red_stub "agent produced no report (agent exit $AGENT_EXIT)"
+elif ! python3 "$CHECKER" "$REPORT_PATH" >> "$RUN_DIR/wrapper.log" 2>&1; then
+  cp "$REPORT_PATH" "$RUN_DIR/rejected_report.md" 2>/dev/null || true
+  write_red_stub "report failed contract check (agent exit $AGENT_EXIT); original preserved at $RUN_DIR/rejected_report.md"
+fi
+
+# ---- 4. Publish -----------------------------------------------------------
+finish
+exit 0

--- a/scripts/nightly/run_nightly.sh
+++ b/scripts/nightly/run_nightly.sh
@@ -66,24 +66,37 @@ done
 mkdir -p "$REPORT_DIR" "$RUN_DIR"
 START_EPOCH="$(date +%s)"
 
+# ---- Log retention ---------------------------------------------------------
+# Per-date run dirs older than 14 days are swept; the launchd stdout/stderr
+# logs are truncated IN PLACE (cat >, preserving the inode launchd holds
+# open) to their last 5MB when they exceed it.
+LOG_BASE="$(dirname "$RUN_DIR")"
+find "$LOG_BASE" -mindepth 1 -maxdepth 1 -type d -mtime +14 -exec rm -rf {} + 2>/dev/null
+LAUNCHD_LOG_CAP=5242880
+for launchd_log in "$HOME/Library/Logs/receipt-nightly.out.log" \
+                   "$HOME/Library/Logs/receipt-nightly.err.log"; do
+  if [ -f "$launchd_log" ]; then
+    log_size="$(stat -f%z "$launchd_log" 2>/dev/null || stat -c%s "$launchd_log" 2>/dev/null || echo 0)"
+    if [ "${log_size:-0}" -gt "$LAUNCHD_LOG_CAP" ]; then
+      tail -c "$LAUNCHD_LOG_CAP" "$launchd_log" > "$launchd_log.trunc.$$" \
+        && cat "$launchd_log.trunc.$$" > "$launchd_log"
+      rm -f "$launchd_log.trunc.$$"
+    fi
+  fi
+done
+
 log() {
   printf '[%s] %s\n' "$(date -u +%FT%TZ)" "$*" | tee -a "$RUN_DIR/wrapper.log" >&2
 }
 
 elapsed() { echo "$(( $(date +%s) - START_EPOCH ))"; }
 
-# Portable 4h watchdog: coreutils timeout, gtimeout, else the perl
-# alarm+exec idiom (the alarm survives exec; SIGALRM kills the child).
-run_with_timeout() {
-  local secs="$1"; shift
-  if command -v timeout >/dev/null 2>&1; then
-    timeout "$secs" "$@"
-  elif command -v gtimeout >/dev/null 2>&1; then
-    gtimeout "$secs" "$@"
-  else
-    perl -e 'alarm shift @ARGV; exec @ARGV or die "exec: $!"' "$secs" "$@"
-  fi
-}
+# 4h watchdog: scripts/nightly/watchdog.py owns setsid + group-kill
+# (SIGTERM to -PGID, 30s grace, then SIGKILL to -PGID) on every path. The
+# old timeout/gtimeout/perl-alarm chain is gone: the perl leg killed only
+# the direct child, leaving grandchildren (stdio MCP servers, subagents)
+# alive past the deadline.
+WATCHDOG="$SCRIPT_DIR/watchdog.py"
 
 PREFLIGHT_SUMMARY="not run"
 
@@ -138,6 +151,10 @@ publish_report() {
     if git -C "$REPO_ROOT" worktree add --detach "$wt" HEAD >/dev/null 2>&1; then
       mkdir -p "$wt/docs/reports/nightly"
       cp "$REPORT_PATH" "$wt/docs/reports/nightly/$RUN_DATE.md"
+      # Same-date re-run: refresh the remote-tracking ref, then push with
+      # --force-with-lease so the re-run's report wins (the branch is never
+      # merged; last-run-wins is the intended semantics) without blind force.
+      git -C "$wt" fetch -q origin "+refs/heads/$branch:refs/remotes/origin/$branch" 2>/dev/null || true
       git -C "$wt" checkout -q -B "$branch" \
         && git -C "$wt" add "docs/reports/nightly/$RUN_DATE.md" \
         && git -C "$wt" commit -q -m "nightly: morning report $RUN_DATE ($verdict)
@@ -145,7 +162,7 @@ publish_report() {
 Automated nightly loop v0 report. Not for merge to main; read the file.
 
 Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>" \
-        && git -C "$wt" push origin "$branch" \
+        && git -C "$wt" push --force-with-lease origin "$branch" \
         && log "published $branch to origin" \
         || log "WARNING: git publish failed; report remains at $REPORT_PATH"
       git -C "$REPO_ROOT" worktree remove --force "$wt" >/dev/null 2>&1 || true
@@ -210,8 +227,17 @@ else
     finish
     exit 0
   fi
+  # Preflight extension: prove group-kill works on THIS host before a real
+  # launch; otherwise a hung agent would outlive its 4h deadline via
+  # surviving grandchildren. Dry-run never launches, so it skips the probe.
+  if ! python3 "$WATCHDOG" --self-test >> "$RUN_DIR/wrapper.log" 2>&1; then
+    write_red_stub "watchdog group-kill self-test failed on this host; refusing real agent launch"
+    finish
+    exit 0
+  fi
+  log "watchdog self-test OK (setsid + group-kill)"
   log "launching headless claude ($CLAUDE_BIN), timeout=${TIMEOUT_SECS}s max_turns=$MAX_TURNS"
-  ( cd "$REPO_ROOT" && run_with_timeout "$TIMEOUT_SECS" \
+  ( cd "$REPO_ROOT" && python3 "$WATCHDOG" --grace 30 "$TIMEOUT_SECS" -- \
       "$CLAUDE_BIN" -p "$(cat "$BRIEF")" \
       --permission-mode bypassPermissions \
       --model claude-fable-5 \

--- a/scripts/nightly/watchdog.py
+++ b/scripts/nightly/watchdog.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Process-group watchdog for the nightly loop (W2 review finding #1).
+
+Runs a command in its OWN session/process group (``start_new_session=True``
+= setsid) and, on timeout, kills the WHOLE GROUP: SIGTERM to -PGID, a
+grace period, then SIGKILL to -PGID. This replaces the previous
+timeout/gtimeout/perl-alarm fallback chain, whose perl leg killed only the
+direct child and left grandchildren (stdio MCP servers, subagents) alive.
+
+Usage:
+    watchdog.py [--grace SECS] TIMEOUT_SECS -- COMMAND [ARGS...]
+    watchdog.py --self-test
+
+Exit codes:
+    child's exit code on normal completion
+    124  timeout (group killed)
+    127  command not found
+    64   usage error
+    --self-test: 0 iff setsid + group-kill provably work on this host
+    (a spawned grandchild stops writing after the kill).
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+
+DEFAULT_GRACE = 30.0
+TIMEOUT_EXIT = 124
+NOT_FOUND_EXIT = 127
+USAGE_EXIT = 64
+
+
+def _kill_group(pgid: int, sig: int) -> None:
+    try:
+        os.killpg(pgid, sig)
+    except (ProcessLookupError, PermissionError):
+        pass
+
+
+def run(timeout: float, grace: float, cmd: list[str]) -> int:
+    """Run cmd in its own process group under a group-kill watchdog."""
+    try:
+        proc = subprocess.Popen(cmd, start_new_session=True)
+    except FileNotFoundError:
+        print(f"watchdog: command not found: {cmd[0]}", file=sys.stderr)
+        return NOT_FOUND_EXIT
+    pgid = proc.pid  # start_new_session makes the child its own group leader
+
+    def _forward(signum: int, _frame: object) -> None:
+        _kill_group(pgid, signal.SIGTERM)
+        sys.exit(128 + signum)
+
+    signal.signal(signal.SIGTERM, _forward)
+    signal.signal(signal.SIGINT, _forward)
+
+    try:
+        return proc.wait(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        print(
+            f"watchdog: timeout after {timeout}s; SIGTERM to group {pgid}",
+            file=sys.stderr,
+        )
+        _kill_group(pgid, signal.SIGTERM)
+        try:
+            proc.wait(timeout=grace)
+        except subprocess.TimeoutExpired:
+            pass
+        # Always follow with a group SIGKILL: the direct child may be dead
+        # while TERM-ignoring grandchildren linger in the group.
+        _kill_group(pgid, signal.SIGKILL)
+        try:
+            proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            print(
+                f"watchdog: group {pgid} did not reap after SIGKILL",
+                file=sys.stderr,
+            )
+        return TIMEOUT_EXIT
+
+
+def self_test() -> int:
+    """Prove group-kill works HERE: a grandchild must die with the group.
+
+    Spawns sh -> backgrounded writer loop (a grandchild of the watchdog),
+    times the parent out, then asserts the writer stopped writing. This is
+    exactly the probe that exposed the perl-alarm fallback leaving
+    orphaned writers alive.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        out = os.path.join(tmp, "probe.out")
+        script = (
+            f'(while :; do echo alive >> "{out}"; sleep 0.1; done) & '
+            "sleep 30"
+        )
+        code = run(timeout=1.0, grace=1.0, cmd=["/bin/sh", "-c", script])
+        if code != TIMEOUT_EXIT:
+            print(
+                f"watchdog self-test: expected {TIMEOUT_EXIT}, got {code}",
+                file=sys.stderr,
+            )
+            return 1
+        if not os.path.exists(out):
+            print(
+                "watchdog self-test: probe writer never started",
+                file=sys.stderr,
+            )
+            return 1
+        time.sleep(0.4)
+        size_a = os.path.getsize(out)
+        time.sleep(0.8)
+        size_b = os.path.getsize(out)
+        if size_a != size_b:
+            print(
+                "watchdog self-test: grandchild survived the group kill "
+                f"({size_a} -> {size_b} bytes)",
+                file=sys.stderr,
+            )
+            return 1
+    print("watchdog self-test: group-kill OK", file=sys.stderr)
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    args = list(argv)
+    if args == ["--self-test"]:
+        return self_test()
+    grace = DEFAULT_GRACE
+    if len(args) >= 2 and args[0] == "--grace":
+        try:
+            grace = float(args[1])
+        except ValueError:
+            print(f"watchdog: bad --grace {args[1]!r}", file=sys.stderr)
+            return USAGE_EXIT
+        args = args[2:]
+    if "--" not in args:
+        print(__doc__, file=sys.stderr)
+        return USAGE_EXIT
+    sep = args.index("--")
+    head, cmd = args[:sep], args[sep + 1 :]
+    if len(head) != 1 or not cmd:
+        print(__doc__, file=sys.stderr)
+        return USAGE_EXIT
+    try:
+        timeout = float(head[0])
+    except ValueError:
+        print(f"watchdog: bad timeout {head[0]!r}", file=sys.stderr)
+        return USAGE_EXIT
+    return run(timeout=timeout, grace=grace, cmd=cmd)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tests/fixtures/nightly/empty_section.md
+++ b/tests/fixtures/nightly/empty_section.md
@@ -1,0 +1,31 @@
+# Nightly Report 2026-07-21
+
+## Verdict
+**Verdict: GREEN** - fleet ran and all 3 evals completed.
+
+## Budget
+- wall clock: 6120s
+- turns: 41 of 80
+- subagents: 2 of 3
+
+## Fleet
+| slug | version | gate | staleness |
+|------|---------|------|-----------|
+| costco | 1 | PASS | 0d |
+Delta vs yesterday: +13 ACTIVE (first post-mint night).
+
+## Tonight's Work
+- costco: eval GREEN (7/7 metrics PASS), sheet at ~/.nightly-loop/2026-07-21/eval/costco.sheet.png
+- vons: eval RED (columns FAIL, h=1.6 defect), finding recorded
+- sprouts: SKIPPED - golden receipt lookup exceeded 30min budget
+
+## Awaiting Owner
+
+
+## Failures & Anomalies
+- receipt-tools MCP unauthenticated; ran DEGRADED via direct AWS reads.
+
+## Tomorrow's Top 3
+1. vons - columns metric RED (h=1.6)
+2. sprouts - retry with cached golden receipt id
+3. smiths - next in rotation

--- a/tests/fixtures/nightly/missing_section.md
+++ b/tests/fixtures/nightly/missing_section.md
@@ -1,0 +1,28 @@
+# Nightly Report 2026-07-21
+
+## Verdict
+**Verdict: GREEN** - fleet ran and all 3 evals completed.
+
+## Budget
+- wall clock: 6120s
+- turns: 41 of 80
+- subagents: 2 of 3
+
+## Fleet
+| slug | version | gate | staleness |
+|------|---------|------|-----------|
+| costco | 1 | PASS | 0d |
+Delta vs yesterday: +13 ACTIVE (first post-mint night).
+
+## Tonight's Work
+- costco: eval GREEN (7/7 metrics PASS), sheet at ~/.nightly-loop/2026-07-21/eval/costco.sheet.png
+- vons: eval RED (columns FAIL, h=1.6 defect), finding recorded
+- sprouts: SKIPPED - golden receipt lookup exceeded 30min budget
+
+## Failures & Anomalies
+- receipt-tools MCP unauthenticated; ran DEGRADED via direct AWS reads.
+
+## Tomorrow's Top 3
+1. vons - columns metric RED (h=1.6)
+2. sprouts - retry with cached golden receipt id
+3. smiths - next in rotation

--- a/tests/fixtures/nightly/no_verdict.md
+++ b/tests/fixtures/nightly/no_verdict.md
@@ -1,0 +1,31 @@
+# Nightly Report 2026-07-21
+
+## Verdict
+All good tonight.
+
+## Budget
+- wall clock: 6120s
+- turns: 41 of 80
+- subagents: 2 of 3
+
+## Fleet
+| slug | version | gate | staleness |
+|------|---------|------|-----------|
+| costco | 1 | PASS | 0d |
+Delta vs yesterday: +13 ACTIVE (first post-mint night).
+
+## Tonight's Work
+- costco: eval GREEN (7/7 metrics PASS), sheet at ~/.nightly-loop/2026-07-21/eval/costco.sheet.png
+- vons: eval RED (columns FAIL, h=1.6 defect), finding recorded
+- sprouts: SKIPPED - golden receipt lookup exceeded 30min budget
+
+## Awaiting Owner
+None.
+
+## Failures & Anomalies
+- receipt-tools MCP unauthenticated; ran DEGRADED via direct AWS reads.
+
+## Tomorrow's Top 3
+1. vons - columns metric RED (h=1.6)
+2. sprouts - retry with cached golden receipt id
+3. smiths - next in rotation

--- a/tests/fixtures/nightly/valid_report.md
+++ b/tests/fixtures/nightly/valid_report.md
@@ -1,0 +1,31 @@
+# Nightly Report 2026-07-21
+
+## Verdict
+**Verdict: GREEN** - fleet ran and all 3 evals completed.
+
+## Budget
+- wall clock: 6120s
+- turns: 41 of 80
+- subagents: 2 of 3
+
+## Fleet
+| slug | version | gate | staleness |
+|------|---------|------|-----------|
+| costco | 1 | PASS | 0d |
+Delta vs yesterday: +13 ACTIVE (first post-mint night).
+
+## Tonight's Work
+- costco: eval GREEN (7/7 metrics PASS), sheet at ~/.nightly-loop/2026-07-21/eval/costco.sheet.png
+- vons: eval RED (columns FAIL, h=1.6 defect), finding recorded
+- sprouts: SKIPPED - golden receipt lookup exceeded 30min budget
+
+## Awaiting Owner
+None.
+
+## Failures & Anomalies
+- receipt-tools MCP unauthenticated; ran DEGRADED via direct AWS reads.
+
+## Tomorrow's Top 3
+1. vons - columns metric RED (h=1.6)
+2. sprouts - retry with cached golden receipt id
+3. smiths - next in rotation

--- a/tests/fixtures/nightly/verdict_in_fence.md
+++ b/tests/fixtures/nightly/verdict_in_fence.md
@@ -1,0 +1,34 @@
+# Nightly Report 2026-07-21
+
+## Verdict
+```
+**Verdict: GREEN** - fleet ran and all 3 evals completed.
+```
+See fenced line above.
+
+## Budget
+- wall clock: 6120s
+- turns: 41 of 80
+- subagents: 2 of 3
+
+## Fleet
+| slug | version | gate | staleness |
+|------|---------|------|-----------|
+| costco | 1 | PASS | 0d |
+Delta vs yesterday: +13 ACTIVE (first post-mint night).
+
+## Tonight's Work
+- costco: eval GREEN (7/7 metrics PASS), sheet at ~/.nightly-loop/2026-07-21/eval/costco.sheet.png
+- vons: eval RED (columns FAIL, h=1.6 defect), finding recorded
+- sprouts: SKIPPED - golden receipt lookup exceeded 30min budget
+
+## Awaiting Owner
+None.
+
+## Failures & Anomalies
+- receipt-tools MCP unauthenticated; ran DEGRADED via direct AWS reads.
+
+## Tomorrow's Top 3
+1. vons - columns metric RED (h=1.6)
+2. sprouts - retry with cached golden receipt id
+3. smiths - next in rotation

--- a/tests/test_check_contract.py
+++ b/tests/test_check_contract.py
@@ -98,6 +98,39 @@ def test_verdict_grammar_rejects(line: str):
     assert result["valid"] is False
 
 
+def test_verdict_inside_code_fence_not_counted():
+    result = check_contract.check_report_text(load("verdict_in_fence.md"))
+    assert result["valid"] is False
+    assert result["verdict"] is None
+    assert any("no parseable verdict" in p for p in result["problems"])
+
+
+def test_heading_inside_code_fence_not_counted():
+    text = load("valid_report.md").replace(
+        "## Awaiting Owner\nNone.\n",
+        "```\n## Awaiting Owner\n```\nNone.\n",
+    )
+    result = check_contract.check_report_text(text)
+    assert result["valid"] is False
+    assert "missing section: ## Awaiting Owner" in result["problems"]
+
+
+def test_empty_section_body_fails():
+    result = check_contract.check_report_text(load("empty_section.md"))
+    assert result["valid"] is False
+    assert "empty section: ## Awaiting Owner" in result["problems"]
+
+
+def test_section_body_of_only_a_fence_counts_as_empty():
+    text = load("valid_report.md").replace(
+        "## Awaiting Owner\nNone.\n",
+        "## Awaiting Owner\n```\nquoted stuff\n```\n",
+    )
+    result = check_contract.check_report_text(text)
+    assert result["valid"] is False
+    assert "empty section: ## Awaiting Owner" in result["problems"]
+
+
 def test_multiple_verdict_lines_rejected():
     text = load("valid_report.md") + "\n**Verdict: RED** - second verdict.\n"
     result = check_contract.check_report_text(text)

--- a/tests/test_check_contract.py
+++ b/tests/test_check_contract.py
@@ -1,0 +1,133 @@
+"""Contract-checker unit tests (W2, plan humble-skipping-quilt): the 7
+required sections, verdict-line grammar, ordering, and CLI exit codes.
+
+Fixtures live in tests/fixtures/nightly/.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts.nightly import check_contract
+
+FIXTURES = Path(__file__).parent / "fixtures" / "nightly"
+
+
+def load(name: str) -> str:
+    return (FIXTURES / name).read_text()
+
+
+# --------------------------------------------------------------------------
+# check_report_text
+# --------------------------------------------------------------------------
+
+
+def test_valid_report_passes():
+    result = check_contract.check_report_text(load("valid_report.md"))
+    assert result["valid"] is True
+    assert result["verdict"] == "GREEN"
+    assert result["problems"] == []
+
+
+def test_missing_section_fails_and_names_it():
+    result = check_contract.check_report_text(load("missing_section.md"))
+    assert result["valid"] is False
+    assert "missing section: ## Awaiting Owner" in result["problems"]
+
+
+def test_no_verdict_fails():
+    result = check_contract.check_report_text(load("no_verdict.md"))
+    assert result["valid"] is False
+    assert any("verdict" in p.lower() for p in result["problems"])
+    assert result["verdict"] is None
+
+
+def test_all_seven_sections_required_individually():
+    text = load("valid_report.md")
+    for section in check_contract.REQUIRED_SECTIONS:
+        mutated = text.replace(f"## {section}\n", "## Something Else\n")
+        result = check_contract.check_report_text(mutated)
+        assert result["valid"] is False, section
+        assert f"missing section: ## {section}" in result["problems"]
+
+
+def test_out_of_order_sections_fail():
+    text = load("valid_report.md")
+    lines = text.splitlines(keepends=True)
+    # Move the "## Tomorrow's Top 3" block before "## Verdict".
+    idx = lines.index("## Tomorrow's Top 3\n")
+    block, rest = lines[idx:], lines[:idx]
+    verdict_idx = rest.index("## Verdict\n")
+    mutated = "".join(rest[:verdict_idx] + block + ["\n"] + rest[verdict_idx:])
+    result = check_contract.check_report_text(mutated)
+    assert result["valid"] is False
+    assert any("out of order" in p for p in result["problems"])
+
+
+@pytest.mark.parametrize(
+    "line,expected",
+    [
+        ("**Verdict: GREEN** - all good.", "GREEN"),
+        ("**Verdict: YELLOW** - skips happened.", "YELLOW"),
+        ("**Verdict: RED** - preflight red.", "RED"),
+        ("Verdict: GREEN - bold optional.", "GREEN"),
+        ("Verdict: RED: colon separator.", "RED"),
+    ],
+)
+def test_verdict_grammar_accepts(line: str, expected: str):
+    text = load("no_verdict.md").replace("All good tonight.", line)
+    result = check_contract.check_report_text(text)
+    assert result["valid"] is True
+    assert result["verdict"] == expected
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        "**Verdict: green** - lowercase color.",
+        "**Verdict: GREEN**",  # no trailing sentence
+        "**Verdict: BLUE** - unknown color.",
+        "Verdict GREEN - missing colon.",
+    ],
+)
+def test_verdict_grammar_rejects(line: str):
+    text = load("no_verdict.md").replace("All good tonight.", line)
+    result = check_contract.check_report_text(text)
+    assert result["valid"] is False
+
+
+def test_multiple_verdict_lines_rejected():
+    text = load("valid_report.md") + "\n**Verdict: RED** - second verdict.\n"
+    result = check_contract.check_report_text(text)
+    assert result["valid"] is False
+    assert any("multiple verdict lines" in p for p in result["problems"])
+
+
+# --------------------------------------------------------------------------
+# CLI
+# --------------------------------------------------------------------------
+
+
+def test_cli_exit_codes(capsys):
+    assert check_contract.main([str(FIXTURES / "valid_report.md")]) == 0
+    assert check_contract.main([str(FIXTURES / "missing_section.md")]) == 1
+    assert check_contract.main([str(FIXTURES / "no_verdict.md")]) == 1
+    assert check_contract.main([str(FIXTURES / "does_not_exist.md")]) == 2
+
+
+def test_cli_verdict_flag(capsys):
+    rc = check_contract.main(["--verdict", str(FIXTURES / "valid_report.md")])
+    assert rc == 0
+    assert capsys.readouterr().out.strip() == "GREEN"
+
+
+def test_cli_json_flag(capsys):
+    import json
+
+    rc = check_contract.main(["--json", str(FIXTURES / "valid_report.md")])
+    assert rc == 0
+    doc = json.loads(capsys.readouterr().out)
+    assert doc["valid"] is True
+    assert doc["verdict"] == "GREEN"

--- a/tests/test_run_nightly.py
+++ b/tests/test_run_nightly.py
@@ -2,8 +2,9 @@
 humble-skipping-quilt): --dry-run must produce a contract-passing report,
 and a preflight RED must produce the RED stub without ever launching the
 agent. No claude call, no network push: preflight is faked, dry-run skips
-git, and the RED test publishes inside a throwaway git repo with no
-remote.
+git, and the RED test publishes inside a throwaway git repo whose origin
+is a local bare repo (exercising commit + --force-with-lease push and the
+same-date re-run).
 """
 
 from __future__ import annotations
@@ -61,8 +62,18 @@ def run_wrapper(
 
 
 def test_dry_run_produces_contract_passing_report(nightly_env, tmp_path):
+    # Seed a stale per-date run dir; the retention sweep must remove it.
+    import time as _time
+
+    stale = tmp_path / "logs" / "1998-12-01"
+    stale.mkdir(parents=True)
+    old = _time.time() - 20 * 86400
+    os.utime(stale, (old, old))
+
     proc = run_wrapper(nightly_env, "--dry-run")
     assert proc.returncode == 0, proc.stderr
+
+    assert not stale.exists(), "14-day log retention sweep did not run"
 
     report = tmp_path / "reports" / "1999-01-01.md"
     assert report.exists(), "wrapper must always produce a report"
@@ -93,8 +104,10 @@ def test_preflight_red_produces_red_stub(nightly_env, tmp_path):
         tmp_path / "fake_claude.sh",
         f'#!/bin/bash\ntouch "{sentinel}"\nexit 0\n',
     )
-    # Publish runs for real (no --dry-run) inside a throwaway repo with no
-    # origin remote: the commit leg is exercised, the push fails safely.
+    # Publish runs for real (no --dry-run) inside a throwaway repo whose
+    # origin is a local bare repo: the commit AND push legs are exercised.
+    origin = tmp_path / "origin.git"
+    subprocess.run(["git", "init", "-q", "--bare", str(origin)], check=True)
     stub_repo = tmp_path / "stub_repo"
     stub_repo.mkdir()
     for cmd in (
@@ -111,6 +124,7 @@ def test_preflight_red_produces_red_stub(nightly_env, tmp_path):
             "-m",
             "root",
         ],
+        ["git", "remote", "add", "origin", str(origin)],
     ):
         subprocess.run(cmd, cwd=stub_repo, check=True)
 
@@ -139,18 +153,34 @@ def test_preflight_red_produces_red_stub(nightly_env, tmp_path):
     assert result["verdict"] == "RED"
     assert "preflight RED" in text
 
-    # The stub was committed on the nightly/ branch in the throwaway repo.
-    branches = subprocess.run(
-        ["git", "branch", "--list", "nightly/1999-01-02"],
-        cwd=stub_repo,
-        capture_output=True,
-        text=True,
-        check=True,
-    ).stdout
-    assert "nightly/1999-01-02" in branches
+    # The stub was committed on the nightly/ branch AND pushed to origin.
+    def origin_sha() -> str:
+        return subprocess.run(
+            ["git", "rev-parse", "refs/heads/nightly/1999-01-02"],
+            cwd=origin,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+
+    first_sha = origin_sha()
+    assert first_sha
 
     campaign = (tmp_path / "CAMPAIGN_LOG.md").read_text()
     assert "nightly-v0 1999-01-02 verdict=RED" in campaign
+
+    # Same-date re-run: --force-with-lease must land the new commit on
+    # origin (last-run-wins; the branch is never merged). Distinct commit
+    # timestamps make the SHAs comparable (stub content is deterministic).
+    import time as _time
+
+    _time.sleep(1.1)
+    env["GIT_COMMITTER_DATE"] = "2000-01-01T00:00:00Z"
+    env["GIT_AUTHOR_DATE"] = "2000-01-01T00:00:00Z"
+    proc2 = run_wrapper(env)
+    assert proc2.returncode == 0, proc2.stderr
+    second_sha = origin_sha()
+    assert second_sha != first_sha, "re-run did not reach origin"
 
 
 def test_invalid_agent_report_replaced_by_red_stub(nightly_env, tmp_path):

--- a/tests/test_run_nightly.py
+++ b/tests/test_run_nightly.py
@@ -1,0 +1,208 @@
+"""End-to-end wrapper tests for scripts/nightly/run_nightly.sh (W2, plan
+humble-skipping-quilt): --dry-run must produce a contract-passing report,
+and a preflight RED must produce the RED stub without ever launching the
+agent. No claude call, no network push: preflight is faked, dry-run skips
+git, and the RED test publishes inside a throwaway git repo with no
+remote.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from scripts.nightly import check_contract
+
+REPO_ROOT = Path(__file__).parent.parent
+WRAPPER = REPO_ROOT / "scripts" / "nightly" / "run_nightly.sh"
+
+
+def write_executable(path: Path, body: str) -> Path:
+    path.write_text(body)
+    path.chmod(0o755)
+    return path
+
+
+@pytest.fixture()
+def nightly_env(tmp_path: Path) -> dict[str, str]:
+    """Hermetic env: fake healthy preflight, tmp report/log/campaign paths."""
+    preflight = write_executable(
+        tmp_path / "fake_preflight_ok.sh",
+        '#!/bin/bash\necho \'{"overall":"healthy","checks":{}}\'\n'
+        'echo "== agent preflight: healthy ==" >&2\nexit 0\n',
+    )
+    env = dict(os.environ)
+    env.update(
+        {
+            "NIGHTLY_DATE": "1999-01-01",
+            "NIGHTLY_REPORT_DIR": str(tmp_path / "reports"),
+            "NIGHTLY_LOG_DIR": str(tmp_path / "logs"),
+            "NIGHTLY_CAMPAIGN_LOG": str(tmp_path / "CAMPAIGN_LOG.md"),
+            "NIGHTLY_PREFLIGHT_BIN": str(preflight),
+        }
+    )
+    return env
+
+
+def run_wrapper(
+    env: dict[str, str], *args: str
+) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [str(WRAPPER), *args],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+
+
+def test_dry_run_produces_contract_passing_report(nightly_env, tmp_path):
+    proc = run_wrapper(nightly_env, "--dry-run")
+    assert proc.returncode == 0, proc.stderr
+
+    report = tmp_path / "reports" / "1999-01-01.md"
+    assert report.exists(), "wrapper must always produce a report"
+
+    result = check_contract.check_report_text(report.read_text())
+    assert result["valid"] is True, result["problems"]
+    assert result["verdict"] == "YELLOW"  # canned dry-run output is YELLOW
+    assert "1999-01-01" in report.read_text()  # {{DATE}} substituted
+
+    # Publish leg: no git mutation, but the campaign log line is appended.
+    campaign = (tmp_path / "CAMPAIGN_LOG.md").read_text()
+    assert "nightly-v0 1999-01-01 verdict=YELLOW" in campaign
+    wrapper_log = (
+        tmp_path / "logs" / "1999-01-01" / "wrapper.log"
+    ).read_text()
+    assert "[dry-run] would commit" in wrapper_log
+
+
+def test_preflight_red_produces_red_stub(nightly_env, tmp_path):
+    # Preflight exits 2 (RED); the agent must never be launched.
+    write_executable(
+        Path(nightly_env["NIGHTLY_PREFLIGHT_BIN"]),
+        '#!/bin/bash\necho \'{"overall":"red","checks":{}}\'\n'
+        'echo "== agent preflight: red ==" >&2\nexit 2\n',
+    )
+    sentinel = tmp_path / "claude_was_called"
+    fake_claude = write_executable(
+        tmp_path / "fake_claude.sh",
+        f'#!/bin/bash\ntouch "{sentinel}"\nexit 0\n',
+    )
+    # Publish runs for real (no --dry-run) inside a throwaway repo with no
+    # origin remote: the commit leg is exercised, the push fails safely.
+    stub_repo = tmp_path / "stub_repo"
+    stub_repo.mkdir()
+    for cmd in (
+        ["git", "init", "-q"],
+        [
+            "git",
+            "-c",
+            "user.email=t@t",
+            "-c",
+            "user.name=t",
+            "commit",
+            "-q",
+            "--allow-empty",
+            "-m",
+            "root",
+        ],
+    ):
+        subprocess.run(cmd, cwd=stub_repo, check=True)
+
+    env = dict(nightly_env)
+    env.update(
+        {
+            "NIGHTLY_DATE": "1999-01-02",
+            "NIGHTLY_REPO_ROOT": str(stub_repo),
+            "CLAUDE_BIN": str(fake_claude),
+            "GIT_AUTHOR_NAME": "t",
+            "GIT_AUTHOR_EMAIL": "t@t",
+            "GIT_COMMITTER_NAME": "t",
+            "GIT_COMMITTER_EMAIL": "t@t",
+        }
+    )
+    proc = run_wrapper(env)
+    assert proc.returncode == 0, proc.stderr
+
+    assert not sentinel.exists(), "claude must not run on preflight RED"
+
+    report = tmp_path / "reports" / "1999-01-02.md"
+    assert report.exists(), "RED stub must still be produced"
+    text = report.read_text()
+    result = check_contract.check_report_text(text)
+    assert result["valid"] is True, result["problems"]
+    assert result["verdict"] == "RED"
+    assert "preflight RED" in text
+
+    # The stub was committed on the nightly/ branch in the throwaway repo.
+    branches = subprocess.run(
+        ["git", "branch", "--list", "nightly/1999-01-02"],
+        cwd=stub_repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    assert "nightly/1999-01-02" in branches
+
+    campaign = (tmp_path / "CAMPAIGN_LOG.md").read_text()
+    assert "nightly-v0 1999-01-02 verdict=RED" in campaign
+
+
+def test_invalid_agent_report_replaced_by_red_stub(nightly_env, tmp_path):
+    """A claude run that writes garbage must end in a valid RED stub."""
+    bad_claude = write_executable(
+        tmp_path / "bad_claude.sh",
+        '#!/bin/bash\necho "not a report" > "$NIGHTLY_REPORT_PATH"\nexit 0\n',
+    )
+    stub_repo = tmp_path / "stub_repo2"
+    stub_repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=stub_repo, check=True)
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.email=t@t",
+            "-c",
+            "user.name=t",
+            "commit",
+            "-q",
+            "--allow-empty",
+            "-m",
+            "root",
+        ],
+        cwd=stub_repo,
+        check=True,
+    )
+    # The wrapper reads the brief from the repo root; give the stub repo one.
+    brief_dir = stub_repo / "docs" / "nightly"
+    brief_dir.mkdir(parents=True)
+    (brief_dir / "BRIEF.md").write_text("test brief\n")
+
+    env = dict(nightly_env)
+    env.update(
+        {
+            "NIGHTLY_DATE": "1999-01-03",
+            "NIGHTLY_REPO_ROOT": str(stub_repo),
+            "CLAUDE_BIN": str(bad_claude),
+            "GIT_AUTHOR_NAME": "t",
+            "GIT_AUTHOR_EMAIL": "t@t",
+            "GIT_COMMITTER_NAME": "t",
+            "GIT_COMMITTER_EMAIL": "t@t",
+        }
+    )
+    proc = run_wrapper(env)
+    assert proc.returncode == 0, proc.stderr
+
+    report = tmp_path / "reports" / "1999-01-03.md"
+    result = check_contract.check_report_text(report.read_text())
+    assert result["valid"] is True, result["problems"]
+    assert result["verdict"] == "RED"
+    assert "failed contract check" in report.read_text()
+    # The rejected original is preserved for debugging.
+    rejected = tmp_path / "logs" / "1999-01-03" / "rejected_report.md"
+    assert rejected.read_text() == "not a report\n"

--- a/tests/test_watchdog.py
+++ b/tests/test_watchdog.py
@@ -1,0 +1,92 @@
+"""Watchdog group-kill tests (W2 review finding #1).
+
+The regression test reproduces the reviewer's probe: a grandchild
+(backgrounded writer) must STOP writing after the watchdog times the
+parent out. The old perl alarm+exec fallback killed only the direct
+child, so the writer survived; the setsid + killpg watchdog must kill
+the whole group.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+from scripts.nightly import watchdog
+
+WATCHDOG_CLI = (
+    Path(__file__).parent.parent / "scripts" / "nightly" / "watchdog.py"
+)
+
+
+def test_normal_exit_passes_through_exit_code():
+    assert (
+        watchdog.run(timeout=10, grace=1, cmd=["/bin/sh", "-c", "exit 7"]) == 7
+    )
+    assert (
+        watchdog.run(timeout=10, grace=1, cmd=["/bin/sh", "-c", "true"]) == 0
+    )
+
+
+def test_missing_command_returns_127():
+    rc = watchdog.run(
+        timeout=5, grace=1, cmd=["/nonexistent-watchdog-probe-cmd"]
+    )
+    assert rc == watchdog.NOT_FOUND_EXIT
+
+
+def test_timeout_kills_whole_process_group_not_just_parent(tmp_path):
+    """Grandchild keeps-writing regression: FAILS with a parent-only kill
+    (the old perl alarm+exec fallback), passes with setsid + group-kill."""
+    out = tmp_path / "probe.out"
+    script = f'(while :; do echo alive >> "{out}"; sleep 0.1; done) & sleep 30'
+    started = time.time()
+    rc = watchdog.run(timeout=1.0, grace=1.0, cmd=["/bin/sh", "-c", script])
+    assert rc == watchdog.TIMEOUT_EXIT
+    assert time.time() - started < 15  # grace honored, no 30s hang
+
+    assert out.exists(), "writer grandchild never started"
+    time.sleep(0.4)
+    size_a = out.stat().st_size
+    assert size_a > 0
+    time.sleep(0.8)
+    size_b = out.stat().st_size
+    assert size_a == size_b, (
+        "grandchild survived the timeout kill "
+        f"({size_a} -> {size_b} bytes still growing)"
+    )
+
+
+def test_self_test_passes_on_this_host():
+    """The wrapper refuses a real launch unless this passes here."""
+    assert watchdog.self_test() == 0
+
+
+def test_cli_parsing_and_exit_passthrough():
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(WATCHDOG_CLI),
+            "--grace",
+            "1",
+            "5",
+            "--",
+            "/bin/sh",
+            "-c",
+            "exit 3",
+        ],
+        check=False,
+    )
+    assert proc.returncode == 3
+
+
+def test_cli_usage_errors():
+    for argv in ([], ["5"], ["--", "/bin/true"], ["notanumber", "--", "x"]):
+        proc = subprocess.run(
+            [sys.executable, str(WATCHDOG_CLI), *argv],
+            capture_output=True,
+            check=False,
+        )
+        assert proc.returncode == watchdog.USAGE_EXIT, argv


### PR DESCRIPTION
## What

Loop v0 of the standing nightly agent (plan humble-skipping-quilt W2): **eval-only, read-only**. The wrapper ALWAYS produces a morning report, even when everything fails.

- `scripts/nightly/run_nightly.sh` — preflight (`scripts/agent_preflight.sh`; exit 2 ⇒ RED stub report, night skipped) → headless `claude -p "$(cat docs/nightly/BRIEF.md)" --permission-mode bypassPermissions --model claude-fable-5 --max-turns 80` under a 4h portable watchdog (coreutils `timeout` → `gtimeout` → perl alarm+exec; macOS-safe) with `CLAUDE_BIN` override → `check_contract.py` (invalid/missing report ⇒ RED stub, rejected original preserved in the run dir) → publish: report committed on a `nightly/YYYY-MM-DD` branch pushed to origin (**never merged to main**) + one-line summary appended to `~/section_label_kickoff/CAMPAIGN_LOG.md`. `--dry-run` skips the claude call (canned agent output) and all git mutations.
- `docs/nightly/BRIEF.md` — v0 mission: fleet_status markdown into the report; 3 merchants by date-hash rotation over the ACTIVE fleet (13 bundles in dev); `full_fidelity_eval` in its CURRENT (legacy-path) form against dev on each golden receipt if cheap, else SKIPPED-with-reason; report per contract. Guardrails: never write DynamoDB/S3, never flip, never merge, ≤3 subagents; receipt-tools MCP unauthenticated ⇒ run DEGRADED, not fail.
- `docs/nightly/REPORT_CONTRACT.md` — the 7 sections (verdict line GREEN/YELLOW/RED + grammar; budget; fleet table + delta; tonight's work; awaiting owner; failures/anomalies; tomorrow's top-3).
- `scripts/nightly/check_contract.py` — presence + order of all 7 sections, exactly one parseable verdict line; `--verdict`/`--json`; exits 0/1/2.
- `infra/ops/com.tnorlund.receipt-nightly.plist` — 02:00 daily, `RunAtLoad` false, `caffeinate -ims` wrapper. **Committed, not installed** — installation is an owner op.

## Tests (21 passing)

- `tests/test_check_contract.py` (18): fixture reports valid / missing-section / no-verdict, per-section removal, ordering, verdict grammar accept/reject, multiple-verdict rejection, CLI exit codes + flags.
- `tests/test_run_nightly.py` (3): `--dry-run` produces a contract-passing report end-to-end (campaign-log line included); preflight-RED produces a contract-valid RED stub with the agent **provably not launched** (sentinel), publish-commit leg exercised in a throwaway repo; garbage agent output replaced by a valid RED stub with the original preserved.

## Dry-run verification (this machine)

Healthy-preflight path (preflight faked healthy because this laptop lacks the claude file-OAuth creds; they live on the mini):

```
[2026-07-22T01:52:47Z] nightly v0 start date=2026-07-21 repo=/private/tmp/claude-501/-Users-tnorlund-vegas-26/0b7783a2-bcd7-4533-ae1e-7863c4bcaae1/scratchpad/wt-nightly-loop dry_run=1
[2026-07-22T01:52:47Z] preflight exit=0
[2026-07-22T01:52:47Z] [dry-run] skipping claude call; using canned agent report
[2026-07-22T01:52:47Z] [dry-run] would commit /private/tmp/claude-501/-Users-tnorlund-vegas-26/0b7783a2-bcd7-4533-ae1e-7863c4bcaae1/scratchpad/wt-nightly-loop/docs/reports/nightly/2026-07-21.md on branch nightly/2026-07-21 and push to origin
[2026-07-22T01:52:47Z] campaign log appended: /private/tmp/claude-501/-Users-tnorlund-vegas-26/0b7783a2-bcd7-4533-ae1e-7863c4bcaae1/scratchpad/nightly-dryrun-logs2/CAMPAIGN_LOG.md
[2026-07-22T01:52:47Z] morning report: /private/tmp/claude-501/-Users-tnorlund-vegas-26/0b7783a2-bcd7-4533-ae1e-7863c4bcaae1/scratchpad/wt-nightly-loop/docs/reports/nightly/2026-07-21.md (verdict=YELLOW)
contract: VALID verdict=YELLOW
```

Induced-failure path — the REAL preflight on this laptop is RED (`claude_oauth=missing`), which exercised the RED-stub leg for real:

```
[2026-07-22T01:52:05Z] nightly v0 start date=2026-07-21 repo=/private/tmp/claude-501/-Users-tnorlund-vegas-26/0b7783a2-bcd7-4533-ae1e-7863c4bcaae1/scratchpad/wt-nightly-loop dry_run=1
[2026-07-22T01:52:07Z] preflight exit=2
[2026-07-22T01:52:07Z] writing RED stub report: preflight RED (exit 2); night skipped per guardrail
[2026-07-22T01:52:07Z] [dry-run] would commit /private/tmp/claude-501/-Users-tnorlund-vegas-26/0b7783a2-bcd7-4533-ae1e-7863c4bcaae1/scratchpad/wt-nightly-loop/docs/reports/nightly/2026-07-21.md on branch nightly/2026-07-21 and push to origin
[2026-07-22T01:52:07Z] campaign log appended: /private/tmp/claude-501/-Users-tnorlund-vegas-26/0b7783a2-bcd7-4533-ae1e-7863c4bcaae1/scratchpad/nightly-dryrun-logs/CAMPAIGN_LOG.md
[2026-07-22T01:52:07Z] morning report: /private/tmp/claude-501/-Users-tnorlund-vegas-26/0b7783a2-bcd7-4533-ae1e-7863c4bcaae1/scratchpad/wt-nightly-loop/docs/reports/nightly/2026-07-21.md (verdict=RED)
contract: VALID verdict=RED
```

Campaign-log line produced: `2026-07-22T01:52:07Z nightly-v0 2026-07-21 verdict=RED report=docs/reports/nightly/2026-07-21.md branch=nightly/2026-07-21 elapsed=2s`

No real `claude -p` was run — the supervised first night is owner-gated (plan: supervised run of loop v0 + one induced-failure night).

## Owner install (on the mini, after merge)

```sh
launchctl bootstrap gui/$UID /Users/tnorlund/Portfolio/infra/ops/com.tnorlund.receipt-nightly.plist
```

Uninstall: `launchctl bootout gui/$UID/com.tnorlund.receipt-nightly` • trigger now: `launchctl kickstart gui/$UID/com.tnorlund.receipt-nightly`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BeLcSviHL5vDgS3zTSMbsq