### PR TITLE
[synthesis_loop] Eval cutover to MerchantTruthLoader — PINNED freshness gate (W8)

### DIFF
--- a/synthesis_loop/full_fidelity_eval.py
+++ b/synthesis_loop/full_fidelity_eval.py
@@ -24,14 +24,29 @@ crops. Seven metrics, each with a machine verdict:
                   sum(lines) = subtotal, subtotal + tax = total = tender.
 
 Every run emits ``<slug>.checks.json`` + ``<slug>.report.md`` + a stamped
-``<slug>.sheet.png``, all carrying the git SHA, merchant-profile hash and
-atlas hash; a dirty worktree refuses to run unless ``--allow-dirty``.
+``<slug>.sheet.png``, all carrying the git SHA, the merchant-truth bundle
+tuple ``{slug, version, bundle_hash}`` actually used, and the atlas hash; a
+dirty worktree refuses to run unless ``--allow-dirty``.
+
+Merchant truth (W8): all merchant truth (layout columns, typography names,
+engine flags, logo expectation) is resolved through ``MerchantTruthLoader``
+-- the eval never opens ``scripts/merchant_profiles.json``. Three modes:
+
+- online-active (default): the expected ACTIVE tuple is captured with a
+  strong read BEFORE the bundle load; a realized bundle that differs FAILS
+  the eval (stale-cache detection).
+- pinned (``--pin-version`` + ``--pin-bundle-hash``): the realized tuple
+  must equal the pin or the eval FAILS. PINNED mode IS the freshness gate.
+- fixture (``--truth-fixture PATH``): CI/offline -- a vendored bundle,
+  still hash-verified fail-closed by the loader.
 
 Usage:
   full_fidelity_eval.py run <merchant> <image_id> <receipt_id> <slug>
       [--out-root DIR] [--allow-dirty] [--columns-source bootstrap|profile]
+      [--pin-version N --pin-bundle-hash HASH | --truth-fixture PATH]
   full_fidelity_eval.py real-real <merchant> <image_id_a> <receipt_id_a>
       <image_id_b> <receipt_id_b> <slug> [--out-root DIR] [--allow-dirty]
+      [--pin-version N --pin-bundle-hash HASH | --truth-fixture PATH]
 
 ``real-real`` compares two REAL receipts of the same merchant (no synth):
 the cross-receipt sanity leg of the metric-validation table -- structural
@@ -51,7 +66,10 @@ import re
 import subprocess
 import sys
 import tempfile
+from dataclasses import dataclass
+from pathlib import Path
 from statistics import median
+from typing import Any
 
 import numpy as np
 
@@ -219,33 +237,218 @@ def worktree_state() -> tuple[str, bool]:
     return sha, dirty
 
 
-def profile_hash(merchant: str) -> str:
-    with open(
-        os.path.join(REPO, "scripts", "merchant_profiles.json"),
-        encoding="utf-8",
-    ) as fh:
-        profiles = json.load(fh)["profiles"]
-    block = profiles.get(merchant, {})
-    payload = json.dumps(block, sort_keys=True).encode()
-    return hashlib.sha256(payload).hexdigest()[:16]
+# ---------------------------------------------------------------------------
+# merchant truth resolution (W8): the eval reads versioned MerchantTruth
+# bundles through the fail-closed loader -- never merchant_profiles.json.
+# ---------------------------------------------------------------------------
+class TruthFreshnessError(SystemExit):
+    """Realized truth bundle differs from the expected tuple: eval FAILS."""
 
 
-def atlas_hash(merchant: str) -> str:
-    """SHA over the render ARTIFACTS the profile references: atlas npz,
+@dataclass(frozen=True)
+class TruthContext:
+    """The verified bundle this eval ran against, plus the expected tuple.
+
+    ``artifact`` is a loader ``MerchantTruthArtifact`` (already
+    gate-eligible); ``expected_*`` is the tuple captured for the run (the
+    pin in pinned mode, the strong-read ACTIVE tuple in online mode, the
+    fixture's own manifest in fixture mode).
+    """
+
+    artifact: Any
+    expected_version: int
+    expected_bundle_hash: str
+    mode: str
+
+    @property
+    def slug(self) -> str:
+        return self.artifact.slug
+
+    @property
+    def version(self) -> int:
+        return self.artifact.version
+
+    @property
+    def bundle_hash(self) -> str:
+        return self.artifact.bundle_hash
+
+    def component(self, name: str) -> dict:
+        payload = self.artifact.components.get(name)
+        return payload if isinstance(payload, dict) else {}
+
+
+def _default_cache_dir() -> Path:
+    return Path(
+        os.environ.get("MERCHANT_TRUTH_CACHE_DIR")
+        or os.path.expanduser("~/.cache/merchant_truth")
+    )
+
+
+def _dynamo_reader():
+    from receipt_dynamo.data.dynamo_client import DynamoClient
+
+    table = os.environ.get("DYNAMODB_TABLE_NAME", "ReceiptsTable-dc5be22")
+    return DynamoClient(table)
+
+
+def _capture_expected_active(reader, merchant: str):
+    """Strong-read the expected ACTIVE tuple ONCE, before the bundle load.
+
+    This is the online half of the freshness gate: the tuple captured here
+    is what the realized bundle must equal, so a loader that (for any
+    reason) served an older bundle than the current ACTIVE fails the run
+    instead of stamping stale truth.
+    """
+    from receipt_dynamo.data.shared_exceptions import (
+        MerchantTruthIntegrityError,
+    )
+    from receipt_dynamo.merchant_truth_loader import normalize_merchant_alias
+
+    normalized = normalize_merchant_alias(merchant)
+    slug = None
+    for active in reader.list_active_merchant_truth():
+        aliases = {
+            normalize_merchant_alias(alias)
+            for alias in [active.slug, *active.normalized_aliases]
+        }
+        if normalized in aliases:
+            slug = active.slug
+            break
+    if slug is None:
+        raise MerchantTruthIntegrityError(
+            f"no ACTIVE merchant truth matches {merchant!r}"
+        )
+    captured = reader.get_active_merchant_truth(slug, consistent_read=True)
+    if captured is None:
+        raise MerchantTruthIntegrityError(
+            f"merchant {slug!r} has no ACTIVE pointer"
+        )
+    return captured
+
+
+def resolve_truth(
+    merchant: str,
+    *,
+    pin_version: int | None = None,
+    pin_bundle_hash: str | None = None,
+    fixture_path: str | None = None,
+    reader=None,
+    cache_dir: str | Path | None = None,
+) -> TruthContext:
+    """Resolve one merchant's truth bundle and enforce THE FRESHNESS GATE.
+
+    - fixture: offline; the vendored bundle is hash-verified and must be
+      for the requested merchant.
+    - pinned: the realized ``{version, bundle_hash}`` must equal the pin.
+    - online-active (default): the expected ACTIVE tuple is captured with
+      a strong read BEFORE the load; a realized bundle that differs fails
+      (stale-cache detection).
+    """
+    from receipt_dynamo.data.shared_exceptions import (
+        MerchantTruthIntegrityError,
+    )
+    from receipt_dynamo.merchant_truth_loader import (
+        MerchantTruthLoader,
+        TruthResolutionMode,
+        normalize_merchant_alias,
+    )
+
+    if fixture_path and (
+        pin_version is not None or pin_bundle_hash is not None
+    ):
+        raise SystemExit(
+            "--truth-fixture and --pin-version/--pin-bundle-hash are "
+            "mutually exclusive"
+        )
+    if (pin_version is None) != (pin_bundle_hash is None):
+        raise SystemExit(
+            "pinned mode requires BOTH --pin-version and --pin-bundle-hash"
+        )
+    cache = Path(cache_dir) if cache_dir else _default_cache_dir()
+
+    if fixture_path:
+        loader = MerchantTruthLoader(None, cache)
+        artifact = loader.load(
+            merchant,
+            TruthResolutionMode.FIXTURE,
+            fixture_path=Path(fixture_path),
+        )
+        identity = artifact.components.get("identity") or {}
+        known = {
+            normalize_merchant_alias(alias)
+            for alias in [
+                artifact.slug,
+                *(identity.get("normalized_aliases") or []),
+            ]
+        }
+        if normalize_merchant_alias(merchant) not in known:
+            raise SystemExit(
+                f"truth fixture is for {artifact.slug!r}, not {merchant!r}"
+            )
+        expected_version = artifact.version
+        expected_hash = artifact.expected_bundle_hash
+        mode = "fixture"
+    elif pin_version is not None:
+        reader = reader if reader is not None else _dynamo_reader()
+        loader = MerchantTruthLoader(reader, cache)
+        artifact = loader.load(
+            merchant,
+            TruthResolutionMode.PINNED,
+            pin_version=pin_version,
+            pin_bundle_hash=pin_bundle_hash,
+        )
+        expected_version = pin_version
+        expected_hash = pin_bundle_hash
+        mode = "pinned"
+    else:
+        reader = reader if reader is not None else _dynamo_reader()
+        expected = _capture_expected_active(reader, merchant)
+        loader = MerchantTruthLoader(reader, cache)
+        artifact = loader.load(merchant, TruthResolutionMode.ONLINE_ACTIVE)
+        expected_version = expected.version
+        expected_hash = expected.bundle_hash
+        mode = "online-active"
+
+    # THE FRESHNESS GATE: the realized bundle must equal the expected tuple.
+    try:
+        artifact.assert_gate_eligible(
+            expected_version=expected_version,
+            expected_bundle_hash=expected_hash,
+        )
+    except MerchantTruthIntegrityError as error:
+        raise TruthFreshnessError(
+            f"freshness gate: realized bundle {artifact.slug} "
+            f"v{artifact.version} {artifact.bundle_hash} does not match the "
+            f"expected {mode} tuple v{expected_version} {expected_hash}: "
+            f"{error}"
+        ) from error
+    return TruthContext(
+        artifact=artifact,
+        expected_version=expected_version,
+        expected_bundle_hash=expected_hash,
+        mode=mode,
+    )
+
+
+def atlas_hash(truth: TruthContext) -> str:
+    """SHA over the render ARTIFACTS the bundle references: atlas npz,
     logo, and the published stylemap JSON (stylemaps change styling without
-    touching the profile block, so they must be in the stamp)."""
-    with open(
-        os.path.join(REPO, "scripts", "merchant_profiles.json"),
-        encoding="utf-8",
-    ) as fh:
-        block = json.load(fh)["profiles"].get(merchant, {})
+    touching the typography block, so they must be in the stamp). Names come
+    from C#typography (bitmap fonts) and C#assets (logo/stylemap filenames);
+    bytes are hashed from the local BITMATRIX_DIR the render actually used.
+    """
     bitdir = os.environ.get("BITMATRIX_DIR", "/tmp/bitmatrix")
-    typography = block.get("typography") or {}
+    typography = truth.component("typography").get("typography") or {}
+    assets_profile = truth.component("assets").get("profile") or {}
     names = sorted(
         set(
-            list(typography.get("bitmap_font", {}).values())
-            + ([block["logo"]] if block.get("logo") else [])
-            + ([typography["stylemap"]] if typography.get("stylemap") else [])
+            list((typography.get("bitmap_font") or {}).values())
+            + ([assets_profile["logo"]] if assets_profile.get("logo") else [])
+            + (
+                [assets_profile["stylemap_filename"]]
+                if assets_profile.get("stylemap_filename")
+                else []
+            )
         )
     )
     digest = hashlib.sha256()
@@ -260,7 +463,9 @@ def atlas_hash(merchant: str) -> str:
     return digest.hexdigest()[:16]
 
 
-def build_stamp(merchant: str, *, allow_dirty: bool) -> dict:
+def build_stamp(
+    merchant: str, truth: TruthContext, *, allow_dirty: bool
+) -> dict:
     sha, dirty = worktree_state()
     if dirty and not allow_dirty:
         raise SystemExit(
@@ -270,8 +475,15 @@ def build_stamp(merchant: str, *, allow_dirty: bool) -> dict:
     return {
         "git_sha": sha,
         "dirty": dirty,
-        "profile_hash": profile_hash(merchant),
-        "atlas_hash": atlas_hash(merchant),
+        "merchant_truth": {
+            "slug": truth.slug,
+            "version": truth.version,
+            "bundle_hash": truth.bundle_hash,
+            "mode": truth.mode,
+            "expected_version": truth.expected_version,
+            "expected_bundle_hash": truth.expected_bundle_hash,
+        },
+        "atlas_hash": atlas_hash(truth),
         "merchant": merchant,
     }
 
@@ -1720,23 +1932,14 @@ def _load_real(merchant: str, image_id: str, receipt_id: int):
     return real, words, rec
 
 
-def profile_block(merchant: str) -> dict:
-    with open(
-        os.path.join(REPO, "scripts", "merchant_profiles.json"),
-        encoding="utf-8",
-    ) as fh:
-        return json.load(fh)["profiles"].get(merchant, {})
+def profile_columns(truth: TruthContext, section: str) -> list[dict]:
+    """Measured columns from the bundle's C#layout template (P2 source).
 
-
-def profile_columns(merchant: str, section: str) -> list[dict]:
-    """Measured columns from the profile's layout_template (P2 source).
-
-    Validates the block's schema version and shape before consuming it --
+    Validates the template's schema version and shape before consuming it --
     a template from a future schema version (or a hand-mangled one) is
     ignored loudly rather than silently misread.
     """
-    block = profile_block(merchant)
-    template = block.get("layout_template") or {}
+    template = truth.component("layout").get("template") or {}
     if not template:
         return []
     from glyphstudio.layout_template import validate_layout_template
@@ -1744,7 +1947,7 @@ def profile_columns(merchant: str, section: str) -> list[dict]:
     problems = validate_layout_template(template)
     if problems:
         print(
-            f"layout_template for {merchant!r} ignored: {problems}",
+            f"layout_template for {truth.slug!r} ignored: {problems}",
             file=sys.stderr,
         )
         return []
@@ -1759,7 +1962,7 @@ def evaluate_pair(
     words_syn: list[dict],
     *,
     slug: str,
-    merchant: str,
+    truth: TruthContext,
     real_png: str,
     syn_png: str,
     composed: bool,
@@ -1798,7 +2001,7 @@ def evaluate_pair(
         band_rows_real = rows_in(rows_real, (y0, y1))
         band_rows_syn = rows_in(rows_syn, (y0, y1))
         if columns_source == "profile":
-            columns = profile_columns(merchant, canonical)
+            columns = profile_columns(truth, canonical)
             source = "profile"
             if not columns:
                 columns = derive_columns_bootstrap(band_rows_real, W)
@@ -1846,7 +2049,9 @@ def evaluate_pair(
         real_gray,
         syn_gray,
         storefront_band,
-        expects_logo=bool(profile_block(merchant).get("logo")),
+        expects_logo=bool(
+            (truth.component("assets").get("profile") or {}).get("logo")
+        ),
     )
     arithmetic = arithmetic_check(words_syn)
 
@@ -1903,7 +2108,11 @@ def _write_report(out_stem: str, doc: dict) -> None:
         ),
         f"- git: `{stamp['git_sha'][:12]}`"
         + (" (DIRTY)" if stamp["dirty"] else ""),
-        f"- profile: `{stamp['profile_hash']}` atlas: `{stamp['atlas_hash']}`",
+        f"- truth: `{stamp['merchant_truth']['slug']}` "
+        f"v{stamp['merchant_truth']['version']} "
+        f"`{stamp['merchant_truth']['bundle_hash']}` "
+        f"({stamp['merchant_truth']['mode']})",
+        f"- atlas: `{stamp['atlas_hash']}`",
         "",
         f"## OVERALL: {checks['overall']}",
         "",
@@ -1944,10 +2153,12 @@ def _write_sheet(out_stem: str, real_img, syn_img, doc: dict) -> None:
         )
     except OSError:
         f = ImageFont.load_default()
+    truth = stamp["merchant_truth"]
     text = (
         f"{doc['slug']}  {doc['checks']['overall']}  "
         f"git {stamp['git_sha'][:12]}{'+DIRTY' if stamp['dirty'] else ''}  "
-        f"profile {stamp['profile_hash']}  atlas {stamp['atlas_hash']}"
+        f"truth {truth['slug']}@v{truth['version']} "
+        f"{truth['bundle_hash'][:12]}  atlas {stamp['atlas_hash']}"
     )
     dd.text((pad, 8), text, fill=(180, 0, 0), font=f)
     dd.text((pad, 30), "REAL", fill=(0, 0, 0), font=f)
@@ -1958,7 +2169,13 @@ def _write_sheet(out_stem: str, real_img, syn_img, doc: dict) -> None:
 def run(args) -> int:
     import section_compare
 
-    stamp = build_stamp(args.merchant, allow_dirty=args.allow_dirty)
+    truth = resolve_truth(
+        args.merchant,
+        pin_version=args.pin_version,
+        pin_bundle_hash=args.pin_bundle_hash,
+        fixture_path=args.truth_fixture,
+    )
+    stamp = build_stamp(args.merchant, truth, allow_dirty=args.allow_dirty)
     out_dir = os.path.join(args.out_root, f"{args.slug}_eval")
     os.makedirs(out_dir, exist_ok=True)
     real, syn, _n_bar, words = section_compare.render_pair(
@@ -1972,10 +2189,10 @@ def run(args) -> int:
     _, manifest_words, _ = _load_real(
         args.merchant, args.image_id, args.receipt_id
     )
-    block = profile_block(args.merchant)
-    composed = bool(block.get("compose"))
+    flags = truth.component("flags")
+    composed = bool(flags.get("compose"))
     words_syn = words
-    if composed and block.get("compose") == "dollartree":
+    if composed and flags.get("compose") == "dollartree":
         from compose_dollartree import canonical_words
 
         words_syn = canonical_words(words)
@@ -1991,7 +2208,7 @@ def run(args) -> int:
         manifest_words,
         words_syn,
         slug=args.slug,
-        merchant=args.merchant,
+        truth=truth,
         real_png=real_png,
         syn_png=syn_png,
         composed=composed,
@@ -2028,7 +2245,13 @@ def run(args) -> int:
 
 
 def run_real_real(args) -> int:
-    stamp = build_stamp(args.merchant, allow_dirty=args.allow_dirty)
+    truth = resolve_truth(
+        args.merchant,
+        pin_version=args.pin_version,
+        pin_bundle_hash=args.pin_bundle_hash,
+        fixture_path=args.truth_fixture,
+    )
+    stamp = build_stamp(args.merchant, truth, allow_dirty=args.allow_dirty)
     out_dir = os.path.join(args.out_root, f"{args.slug}_eval")
     os.makedirs(out_dir, exist_ok=True)
     real_a, words_a, _rec_a = _load_real(
@@ -2140,6 +2363,23 @@ def main(argv=None) -> int:
     p_rr.add_argument("slug")
     p_rr.add_argument("--out-root", default=".out")
     p_rr.add_argument("--allow-dirty", action="store_true")
+    for sub_parser in (p_run, p_rr):
+        sub_parser.add_argument(
+            "--pin-version",
+            type=int,
+            default=None,
+            help="pinned mode: exact bundle version (with --pin-bundle-hash)",
+        )
+        sub_parser.add_argument(
+            "--pin-bundle-hash",
+            default=None,
+            help="pinned mode: exact bundle hash (with --pin-version)",
+        )
+        sub_parser.add_argument(
+            "--truth-fixture",
+            default=None,
+            help="fixture mode: vendored truth bundle JSON (CI/offline)",
+        )
     args = ap.parse_args(argv)
     if args.mode == "run":
         return run(args)

--- a/tests/fixtures/merchant_truth/costco_wholesale_v1.json
+++ b/tests/fixtures/merchant_truth/costco_wholesale_v1.json
@@ -1,0 +1,666 @@
+{
+ "items": [
+  {
+   "PK": {
+    "S": "MERCHANT_TRUTH#costco_wholesale"
+   },
+   "SK": {
+    "S": "TRUTH#v0000000001#C#assets"
+   },
+   "TYPE": {
+    "S": "MERCHANT_TRUTH_COMPONENT"
+   },
+   "component": {
+    "S": "assets"
+   },
+   "content_hash": {
+    "S": "f7e32df3005b76f01c7e4b959a4b89dd1417431f2aa9ef036ae4bb45fb27e525"
+   },
+   "payload": {
+    "S": "{\"fonts\":{\"heavy\":{\"advance_ratio\":0.6451612903225806,\"bucket_alias\":\"merchant-font-artifacts\",\"cache_filename\":\"bitMatrix-C2-heavy.glyphs.npz\",\"cap_h\":31.0,\"compiled_at\":\"2026-07-06T23:36:27+00:00\",\"content_hash\":\"2672820ca5969b2aabf3d99e7e255ce3f5f37fea76a4ff1259f06cb8188ae66c\",\"glyph_count\":94,\"pitch_check\":\"prebuilt (no source pitch target)\",\"s3_key\":\"merchant_fonts/costco_wholesale/heavy-2672820ca596.npz\",\"source_commit\":\"e35720ee9a64\"},\"regular\":{\"advance_ratio\":0.6129032258064516,\"bucket_alias\":\"merchant-font-artifacts\",\"cache_filename\":\"bitMatrix-C2.glyphs.npz\",\"cap_h\":31.0,\"compiled_at\":\"2026-07-06T23:36:27+00:00\",\"content_hash\":\"bc14ace8711abf952ec870be16b16d6041a82991d53f92283f7666751dd5d282\",\"glyph_count\":94,\"pitch_check\":\"prebuilt (no source pitch target)\",\"s3_key\":\"merchant_fonts/costco_wholesale/regular-bc14ace8711a.npz\",\"source_commit\":\"e35720ee9a64\"}},\"logo\":{\"bucket_alias\":\"merchant-font-artifacts\",\"content_hash\":\"105ad5310b941eb231a731ff346f4ac7ec853bcb24ce04ca2a8ce3ed9b56810a\",\"s3_key\":\"merchant_fonts/costco_wholesale/logo-105ad531.png\",\"size\":3935},\"missing_merchant_font\":false,\"profile\":{\"logo\":\"bitMatrix-C2_logo.png\",\"logo_anchor\":{\"center\":true,\"extend_left\":false,\"phrases\":[\"COSTCO\",\"EWHOLESALE\",\"WHOLESALE\"]}}}"
+   },
+   "provenance": {
+    "M": {
+     "git_sha": {
+      "S": "eb9d3617122be21d0e0e956e04f3208aec701c29"
+     },
+     "measured_at": {
+      "NULL": true
+     },
+     "migrated_at": {
+      "S": "2026-07-21T17:06:49.844567+00:00"
+     },
+     "pipeline": {
+      "S": "merchant_truth_v1"
+     },
+     "pipeline_version": {
+      "S": "1"
+     },
+     "provenance_completeness": {
+      "S": "legacy"
+     },
+     "source_kind": {
+      "S": "migration"
+     },
+     "source_objects": {
+      "L": [
+       {
+        "S": "s3://raw-image-bucket-c779c32/merchant_fonts/costco_wholesale/stylemap-a56efa58.json"
+       },
+       {
+        "S": "s3://raw-image-bucket-c779c32/merchant_fonts/costco_wholesale/logo-105ad531.png"
+       }
+      ]
+     },
+     "source_path": {
+      "S": "scripts/merchant_profiles.json"
+     },
+     "source_receipt_keys": {
+      "L": []
+     },
+     "written_by": {
+      "M": {
+       "kind": {
+        "S": "migration"
+       },
+       "name": {
+        "S": "merchant_truth_v1"
+       },
+       "version": {
+        "S": "1"
+       }
+      }
+     }
+    }
+   },
+   "slug": {
+    "S": "costco_wholesale"
+   },
+   "version": {
+    "N": "1"
+   }
+  },
+  {
+   "PK": {
+    "S": "MERCHANT_TRUTH#costco_wholesale"
+   },
+   "SK": {
+    "S": "TRUTH#v0000000001#C#catalog_snapshot"
+   },
+   "TYPE": {
+    "S": "MERCHANT_TRUTH_COMPONENT"
+   },
+   "component": {
+    "S": "catalog_snapshot"
+   },
+   "content_hash": {
+    "S": "835af79b29ea3d7f438dc4aa38802935d18a7e56711576c66001d32730c56914"
+   },
+   "payload": {
+    "S": "{\"as_of\":\"2026-07-21T17:06:49.844567+00:00\",\"catalog_hash\":\"4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945\",\"item_count\":0,\"items\":[]}"
+   },
+   "provenance": {
+    "M": {
+     "git_sha": {
+      "S": "eb9d3617122be21d0e0e956e04f3208aec701c29"
+     },
+     "measured_at": {
+      "NULL": true
+     },
+     "migrated_at": {
+      "S": "2026-07-21T17:06:49.844567+00:00"
+     },
+     "pipeline": {
+      "S": "merchant_truth_v1"
+     },
+     "pipeline_version": {
+      "S": "1"
+     },
+     "provenance_completeness": {
+      "S": "legacy"
+     },
+     "source_kind": {
+      "S": "migration"
+     },
+     "source_objects": {
+      "L": []
+     },
+     "source_path": {
+      "S": "scripts/merchant_profiles.json"
+     },
+     "source_receipt_keys": {
+      "L": []
+     },
+     "written_by": {
+      "M": {
+       "kind": {
+        "S": "migration"
+       },
+       "name": {
+        "S": "merchant_truth_v1"
+       },
+       "version": {
+        "S": "1"
+       }
+      }
+     }
+    }
+   },
+   "slug": {
+    "S": "costco_wholesale"
+   },
+   "version": {
+    "N": "1"
+   }
+  },
+  {
+   "PK": {
+    "S": "MERCHANT_TRUTH#costco_wholesale"
+   },
+   "SK": {
+    "S": "TRUTH#v0000000001#C#flags"
+   },
+   "TYPE": {
+    "S": "MERCHANT_TRUTH_COMPONENT"
+   },
+   "component": {
+    "S": "flags"
+   },
+   "content_hash": {
+    "S": "4359b2e0a16bb8d784963f461a99f576abd17a221444cbe6097d8f290ae06208"
+   },
+   "payload": {
+    "S": "{\"typography\":{\"dash_after_amount_date\":true,\"dash_around_phrases\":[\"SHOP CARD\"],\"dashed_separators\":true,\"display_headings\":{\"ITEMS SOLD:\":1.8,\"PLEASE COME AGAIN\":1.4,\"SELF CHECKOUT\":1.7,\"SELF-CHECKOUT\":1.7,\"THANK YOU\":1.4},\"face_source\":\"stylemap\",\"heading_bleed_phrase\":\"ITEMS SOLD:\",\"reverse_date_after_items\":true,\"reverse_date_anchor\":\"NUMBER OF ITEMS SOLD\",\"reverse_total\":true}}"
+   },
+   "provenance": {
+    "M": {
+     "git_sha": {
+      "S": "eb9d3617122be21d0e0e956e04f3208aec701c29"
+     },
+     "measured_at": {
+      "NULL": true
+     },
+     "migrated_at": {
+      "S": "2026-07-21T17:06:49.844567+00:00"
+     },
+     "pipeline": {
+      "S": "merchant_truth_v1"
+     },
+     "pipeline_version": {
+      "S": "1"
+     },
+     "provenance_completeness": {
+      "S": "legacy"
+     },
+     "source_kind": {
+      "S": "migration"
+     },
+     "source_objects": {
+      "L": []
+     },
+     "source_path": {
+      "S": "scripts/merchant_profiles.json"
+     },
+     "source_receipt_keys": {
+      "L": []
+     },
+     "written_by": {
+      "M": {
+       "kind": {
+        "S": "migration"
+       },
+       "name": {
+        "S": "merchant_truth_v1"
+       },
+       "version": {
+        "S": "1"
+       }
+      }
+     }
+    }
+   },
+   "slug": {
+    "S": "costco_wholesale"
+   },
+   "version": {
+    "N": "1"
+   }
+  },
+  {
+   "PK": {
+    "S": "MERCHANT_TRUTH#costco_wholesale"
+   },
+   "SK": {
+    "S": "TRUTH#v0000000001#C#identity"
+   },
+   "TYPE": {
+    "S": "MERCHANT_TRUTH_COMPONENT"
+   },
+   "component": {
+    "S": "identity"
+   },
+   "content_hash": {
+    "S": "175c84d2a749719eed5f1da4154406f1874b087ee2066783bfaaf120d1d41e7b"
+   },
+   "payload": {
+    "S": "{\"aliases\":[],\"merchant_name\":\"Costco Wholesale\",\"normalized_aliases\":[\"costco wholesale\"],\"slug\":\"costco_wholesale\",\"upper_slug\":\"COSTCO_WHOLESALE\"}"
+   },
+   "provenance": {
+    "M": {
+     "git_sha": {
+      "S": "eb9d3617122be21d0e0e956e04f3208aec701c29"
+     },
+     "measured_at": {
+      "NULL": true
+     },
+     "migrated_at": {
+      "S": "2026-07-21T17:06:49.844567+00:00"
+     },
+     "pipeline": {
+      "S": "merchant_truth_v1"
+     },
+     "pipeline_version": {
+      "S": "1"
+     },
+     "provenance_completeness": {
+      "S": "legacy"
+     },
+     "source_kind": {
+      "S": "migration"
+     },
+     "source_objects": {
+      "L": []
+     },
+     "source_path": {
+      "S": "scripts/merchant_profiles.json"
+     },
+     "source_receipt_keys": {
+      "L": []
+     },
+     "written_by": {
+      "M": {
+       "kind": {
+        "S": "migration"
+       },
+       "name": {
+        "S": "merchant_truth_v1"
+       },
+       "version": {
+        "S": "1"
+       }
+      }
+     }
+    }
+   },
+   "slug": {
+    "S": "costco_wholesale"
+   },
+   "version": {
+    "N": "1"
+   }
+  },
+  {
+   "PK": {
+    "S": "MERCHANT_TRUTH#costco_wholesale"
+   },
+   "SK": {
+    "S": "TRUTH#v0000000001#C#layout"
+   },
+   "TYPE": {
+    "S": "MERCHANT_TRUTH_COMPONENT"
+   },
+   "component": {
+    "S": "layout"
+   },
+   "content_hash": {
+    "S": "7e6a7a3232a157e633099f10a6f92a05510bb74266e99af3454cb5f30f29c685"
+   },
+   "payload": {
+    "S": "{\"available\":true,\"template\":{\"columns\":{\"barcode\":[{\"anchor\":\"left\",\"role\":\"desc\",\"spread\":0.007,\"support\":7,\"x\":0.2479}],\"footer\":[{\"anchor\":\"left\",\"role\":\"desc\",\"spread\":0.0186,\"support\":8,\"x\":0.0171},{\"anchor\":\"left\",\"role\":\"desc\",\"spread\":0.0071,\"support\":6,\"x\":0.1788},{\"anchor\":\"left\",\"role\":\"desc\",\"spread\":0.0086,\"support\":8,\"x\":0.2713}],\"items\":[{\"anchor\":\"left\",\"role\":\"desc\",\"spread\":0.0078,\"support\":6,\"x\":0.007},{\"anchor\":\"right\",\"role\":\"amount\",\"spread\":0.0096,\"support\":8,\"x\":0.9439}],\"payment\":[{\"anchor\":\"left\",\"role\":\"label\",\"spread\":0.0124,\"support\":8,\"x\":0.0063},{\"anchor\":\"left\",\"role\":\"label\",\"spread\":0.0037,\"support\":11,\"x\":0.2229},{\"anchor\":\"right\",\"role\":\"amount\",\"spread\":0.0285,\"support\":12,\"x\":0.394},{\"anchor\":\"right\",\"role\":\"amount\",\"spread\":0.0124,\"support\":9,\"x\":0.9417}],\"storefront\":[{\"anchor\":\"left\",\"role\":\"desc\",\"spread\":0.0083,\"support\":7,\"x\":0.0},{\"anchor\":\"left\",\"role\":\"desc\",\"spread\":0.0131,\"support\":9,\"x\":0.1035},{\"anchor\":\"left\",\"role\":\"desc\",\"spread\":0.0187,\"support\":7,\"x\":0.2229},{\"anchor\":\"left\",\"role\":\"desc\",\"spread\":0.0151,\"support\":8,\"x\":0.3396}],\"summary\":[{\"anchor\":\"left\",\"role\":\"label\",\"spread\":0.0036,\"support\":6,\"x\":0.0101},{\"anchor\":\"left\",\"role\":\"label\",\"spread\":0.0166,\"support\":8,\"x\":0.0935},{\"anchor\":\"left\",\"role\":\"label\",\"spread\":0.0085,\"support\":11,\"x\":0.2218},{\"anchor\":\"right\",\"role\":\"qty\",\"spread\":0.0167,\"support\":8,\"x\":0.8863},{\"anchor\":\"right\",\"role\":\"amount\",\"spread\":0.0026,\"support\":10,\"x\":0.9376}],\"total_line\":[{\"anchor\":\"left\",\"role\":\"label\",\"spread\":0.0156,\"support\":7,\"x\":0.0874}]},\"measured\":{\"receipts\":12,\"tool_dirty\":false,\"tool_git_sha\":\"d9ce9cb82ecf\"},\"sections\":[{\"name\":\"storefront\",\"pos_frac_med\":0.05,\"support\":12},{\"name\":\"items\",\"pos_frac_med\":0.255,\"support\":11},{\"name\":\"summary\",\"pos_frac_med\":0.351,\"support\":12},{\"name\":\"total_line\",\"pos_frac_med\":0.392,\"support\":9},{\"name\":\"payment\",\"pos_frac_med\":0.427,\"support\":12},{\"name\":\"barcode\",\"pos_frac_med\":0.805,\"support\":9},{\"name\":\"footer\",\"pos_frac_med\":0.819,\"support\":10}],\"separators\":[],\"version\":1}}"
+   },
+   "provenance": {
+    "M": {
+     "git_sha": {
+      "S": "eb9d3617122be21d0e0e956e04f3208aec701c29"
+     },
+     "measured_at": {
+      "NULL": true
+     },
+     "migrated_at": {
+      "S": "2026-07-21T17:06:49.844567+00:00"
+     },
+     "pipeline": {
+      "S": "merchant_truth_v1"
+     },
+     "pipeline_version": {
+      "S": "1"
+     },
+     "provenance_completeness": {
+      "S": "legacy"
+     },
+     "source_kind": {
+      "S": "migration"
+     },
+     "source_objects": {
+      "L": []
+     },
+     "source_path": {
+      "S": "scripts/merchant_profiles.json"
+     },
+     "source_receipt_keys": {
+      "L": []
+     },
+     "written_by": {
+      "M": {
+       "kind": {
+        "S": "migration"
+       },
+       "name": {
+        "S": "merchant_truth_v1"
+       },
+       "version": {
+        "S": "1"
+       }
+      }
+     }
+    }
+   },
+   "slug": {
+    "S": "costco_wholesale"
+   },
+   "version": {
+    "N": "1"
+   }
+  },
+  {
+   "PK": {
+    "S": "MERCHANT_TRUTH#costco_wholesale"
+   },
+   "SK": {
+    "S": "TRUTH#v0000000001#C#stylemap"
+   },
+   "TYPE": {
+    "S": "MERCHANT_TRUTH_COMPONENT"
+   },
+   "component": {
+    "S": "stylemap"
+   },
+   "content_hash": {
+    "S": "86e085f273272b4c00d5fbd23b910b4b0302cd372419cc813e98f5856f00428e"
+   },
+   "payload": {
+    "S": "{\"available\":true,\"document\":{\"audit\":{\"ITEMS SOLD:=1.8\":\"PARTIAL: measured ~1.5-1.6x (coded 1.8 high)\",\"MISSED: barcode_caption\":\"Barcode digits print 0.83x body, stroke_rel 0.88, n=34 - smaller+lighter, no rule exists\",\"MISSED: thank-you sub-body size\":\"Thank You / Please Come Again actually print ~0.84x body; rules render them 1.4x\",\"SELF-CHECKOUT=1.7\":\"PARTIAL: real and heavy, but measured 1.5-1.65x (coded 1.7 slightly high)\",\"THANK YOU=1.4\":\"WRONG (pixel-confirmed): prints 0.84x body, normal weight -- rule should be removed or ~0.85\",\"condense=0.93\":\"UNMEASURED: no char-pitch data in scans\",\"dashed_separators=true\":\"UNMEASURED: scanner does not measure dash runs (separator section n=3)\",\"display_headings.ITEMS SOLD:=1.8\":\"PARTIAL: large+heavy CONFIRMED (stroke_rel 1.26) but scale overstated - measured cap_rel med 1.48 (IQR 1.36-1.50, n=31); use ~1.5\",\"display_headings.PLEASE COME AGAIN=1.4\":\"WRONG: cap_rel med 0.84 (IQR 0.80-0.88, n=12), stroke_rel 1.11 - smaller than body, not 1.4x\",\"display_headings.SELF-CHECKOUT=1.7\":\"PARTIAL: large+heavy CONFIRMED (stroke_rel 1.32) but scale overstated - measured cap_rel med 1.51 (IQR 1.47-1.53, n=23); use ~1.5\",\"display_headings.THANK YOU=1.4\":\"WRONG: 'Thank You!' measures cap_rel med 0.84 (IQR 0.79-0.87, n=30), stroke_rel 1.03 - SMALLER than body at normal weight, not a 1.4x heading\",\"reverse_date_after_items=true\":\"CONFIRMED as a boxed/reversed field by raw pixels (verifiers) -- same OCR blindness. Treatment varies: full reverse or outline box.\",\"reverse_total=true\":\"CONFIRMED by raw pixels (verifiers, 4/4 receipts) -- fleet 'WRONG' verdict was a detection failure (OCR-blind to knockout text). Nuance: reversal covers the amount field only.\",\"section_scale={} (header=body)\":\"CONFIRMED: warehouse_header address lines cap_rel med 0.955, stroke_rel 0.945 (n=67) - uniform with body\",\"underline (no rule)\":\"CONFIRMED absent: 15/~1380 lines (1.1%) underline flags, all scattered coupon/OCR noise; no systematic underlines (unlike Sprouts)\"},\"letterOverrides\":{\"$\":{\"capRel\":1.065,\"n\":65,\"strokeRel\":1.165},\"(\":{\"capRel\":0.911,\"n\":53,\"strokeRel\":0.812},\")\":{\"capRel\":0.909,\"n\":59,\"strokeRel\":0.818},\"-\":{\"capRel\":0.945,\"n\":274,\"strokeRel\":1.32},\"=\":{\"capRel\":1.0,\"n\":99,\"strokeRel\":1.636},\"L\":{\"capRel\":1.0,\"n\":721,\"strokeRel\":0.818},\"M\":{\"capRel\":1.0,\"n\":650,\"strokeRel\":0.81},\"N\":{\"capRel\":1.0,\"n\":773,\"strokeRel\":0.841},\"S\":{\"capRel\":1.0,\"n\":969,\"strokeRel\":1.159},\"U\":{\"capRel\":1.022,\"n\":371,\"strokeRel\":0.82},\"V\":{\"capRel\":0.977,\"n\":572,\"strokeRel\":0.79},\"W\":{\"capRel\":1.0,\"n\":404,\"strokeRel\":0.761},\"Z\":{\"capRel\":0.935,\"n\":22,\"strokeRel\":1.378},\"d\":{\"capRel\":0.956,\"n\":245,\"strokeRel\":0.783},\"h\":{\"capRel\":0.957,\"n\":364,\"strokeRel\":0.82},\"i\":{\"capRel\":1.0,\"n\":502,\"strokeRel\":0.763},\"k\":{\"capRel\":1.0,\"n\":251,\"strokeRel\":0.813},\"l\":{\"capRel\":1.0,\"n\":708,\"strokeRel\":0.761},\"u\":{\"capRel\":0.932,\"n\":206,\"strokeRel\":0.843},\"v\":{\"capRel\":1.038,\"n\":9,\"strokeRel\":0.826},\"w\":{\"capRel\":0.928,\"n\":39,\"strokeRel\":0.82},\"y\":{\"capRel\":0.945,\"n\":124,\"strokeRel\":0.746}},\"limitations\":[\"stylescan iterates OCR words/lines; reverse-video and boxed fields produce no/garbled OCR and are invisible to it. Reverse-video measurement must come from raw-pixel scanning (band darkness independent of words) -- future stylescan fix.\"],\"sections\":{\"barcode_caption\":{\"notes\":\"n=34. Digits under barcode print smaller AND lighter than body: cap_rel med 0.83 (IQR 0.77-0.84), stroke_rel med 0.88. Rule set misses this entirely.\",\"reverseVideo\":false,\"reverseVideoRate\":0.029,\"sizeScale\":0.828,\"strokeRel\":0.881,\"underline\":false,\"underlineRate\":0.0,\"weight\":\"normal\"},\"date_box\":{\"match\":\"date after TOTAL NUMBER OF ITEMS SOLD\",\"notes\":\"CORRECTED BY ADVERSARIAL VERIFICATION: date after ITEMS SOLD is boxed on 2/2 raw scans (one verifier read full reverse video, the other a printed outline box with dark digits -- treatment may vary by register). Fleet missed it: OCR garbles/drops boxed digits.\",\"reverseVideo\":\"boxed_field\",\"reverseVideoRate\":1.0,\"sizeScale\":1.0,\"underline\":false,\"weight\":\"normal\"},\"footer\":{\"notes\":\"n=70. OP#/Whse/Trm lines slightly smaller than body (cap_rel med 0.98, p25 0.91), stroke_rel 1.00. No styling.\",\"reverseVideo\":false,\"reverseVideoRate\":0.0,\"sizeScale\":0.977,\"strokeRel\":1.0,\"underline\":false,\"underlineRate\":0.0,\"weight\":\"normal\"},\"item\":{\"notes\":\"n=159. Body baseline by construction: cap_rel med 1.01, stroke_rel med 1.01. No underline/reverse (1 OCR-noise hit each).\",\"reverseVideo\":false,\"reverseVideoRate\":0.006,\"sizeScale\":1.014,\"strokeRel\":1.01,\"underline\":false,\"underlineRate\":0.006,\"weight\":\"normal\"},\"items_sold\":{\"notes\":\"n=70. Mixed: 'ITEMS SOLD:' display heading cap_rel med 1.48 (IQR 1.36-1.50, n=31) stroke_rel 1.26; plain 'TOTAL NUMBER OF ITEMS SOLD = N' lines print near body size (section p25 cap_rel 1.00).\",\"reverseVideo\":false,\"reverseVideoRate\":0.0,\"sizeScale\":1.149,\"strokeRel\":1.025,\"underline\":false,\"underlineRate\":0.0,\"weight\":\"normal\"},\"member\":{\"notes\":\"n=5 only; stroke_rel med 1.19 hints slightly heavy Member line, but n too small to trust.\",\"reverseVideo\":false,\"reverseVideoRate\":0.0,\"sizeScale\":1.227,\"strokeRel\":1.195,\"underline\":false,\"underlineRate\":0.0,\"weight\":\"heavy\"},\"other\":{\"notes\":\"n=395 unclassified (addresses, dates, marketing/coupon blocks). ~body size. Underline/reverse hits are coupon-graphic OCR noise.\",\"reverseVideo\":false,\"reverseVideoRate\":0.023,\"sizeScale\":1.0,\"strokeRel\":0.995,\"underline\":false,\"underlineRate\":0.033,\"weight\":\"normal\"},\"payment\":{\"notes\":\"n=266. Body size (cap_rel med 1.00, stroke_rel 0.99). Reverse 2/266 = OCR noise.\",\"reverseVideo\":false,\"reverseVideoRate\":0.008,\"sizeScale\":1.0,\"strokeRel\":0.987,\"underline\":false,\"underlineRate\":0.0,\"weight\":\"normal\"},\"savings\":{\"notes\":\"n=6. INSTANT SAVINGS ~body size; 1/6 underline hit (single receipt, likely noise). n too small for a rule.\",\"reverseVideo\":false,\"reverseVideoRate\":0.0,\"sizeScale\":1.027,\"strokeRel\":1.009,\"underline\":false,\"underlineRate\":0.167,\"weight\":\"normal\"},\"self_checkout\":{\"notes\":\"n=66. Bimodal: SELF-CHECKOUT heading cap_rel med 1.51 (IQR 1.47-1.53, n=23) stroke_rel 1.32 = large+heavy. 'Thank You!' lines in this section cap_rel med 0.84, stroke_rel 1.03 = SMALLER than body, normal weight.\",\"reverseVideo\":false,\"reverseVideoRate\":0.0,\"sizeScale\":0.886,\"strokeRel\":1.129,\"underline\":false,\"underlineRate\":0.0,\"weight\":\"normal\"},\"summary\":{\"notes\":\"n=64. SUBTOTAL/TAX at ~body size (cap_rel med 1.05, stroke_rel 1.05). No reverse, no underline.\",\"reverseVideo\":false,\"reverseVideoRate\":0.0,\"sizeScale\":1.045,\"strokeRel\":1.051,\"underline\":false,\"underlineRate\":0.0,\"weight\":\"normal\"},\"total_line\":{\"notes\":\"CORRECTED BY ADVERSARIAL VERIFICATION: the fleet measured 0/43 reverse because OCR cannot read white-on-black digits -- reversed regions produce NO words, so line-based scanning is structurally blind to them. Raw pixels on 2/2 held-out receipts show the TOTAL AMOUNT as white knockout digits in a solid black band; the '**** TOTAL' label prints normal-video. Field-level reversal, not whole-line.\",\"reverseVideo\":\"amount_field\",\"reverseVideoRate\":1.0,\"sizeScale\":0.932,\"strokeRel\":1.055,\"underline\":false,\"underlineRate\":0.0,\"weight\":\"normal\"},\"warehouse_header\":{\"notes\":\"n=137. Bimodal: COSTCO/WHOLESALE logo lines cap_rel med 2.30, stroke_rel 1.32, reverse-video 49% (WHOLESALE band; render via logo image). Address/store lines cap_rel med 0.955, stroke_rel 0.945 (n=67) -> header text prints at ~body size.\",\"reverseVideo\":false,\"reverseVideoRate\":0.139,\"sizeScale\":1.233,\"strokeRel\":1.027,\"underline\":false,\"underlineRate\":0.0,\"weight\":\"normal\"}},\"source\":{\"date\":\"2026-07-06\",\"normalization\":\"per-receipt: cap_px/body_cap_px, stroke_med/body_stroke_px; medians reported\",\"receipts\":38,\"scan_dir\":\"tools/glyph-studio/.out/stylescan-costco\"},\"version\":1},\"source\":{\"bucket_alias\":\"merchant-font-artifacts\",\"content_hash\":\"a56efa587a6d7e8ffc3f56dbd258aba55ee1b624915db86024189ab011c4d88c\",\"s3_key\":\"merchant_fonts/costco_wholesale/stylemap-a56efa58.json\",\"size\":8972}}"
+   },
+   "provenance": {
+    "M": {
+     "git_sha": {
+      "S": "eb9d3617122be21d0e0e956e04f3208aec701c29"
+     },
+     "measured_at": {
+      "NULL": true
+     },
+     "migrated_at": {
+      "S": "2026-07-21T17:06:49.844567+00:00"
+     },
+     "pipeline": {
+      "S": "merchant_truth_v1"
+     },
+     "pipeline_version": {
+      "S": "1"
+     },
+     "provenance_completeness": {
+      "S": "legacy"
+     },
+     "source_kind": {
+      "S": "migration"
+     },
+     "source_objects": {
+      "L": [
+       {
+        "S": "s3://raw-image-bucket-c779c32/merchant_fonts/costco_wholesale/stylemap-a56efa58.json"
+       },
+       {
+        "S": "s3://raw-image-bucket-c779c32/merchant_fonts/costco_wholesale/logo-105ad531.png"
+       }
+      ]
+     },
+     "source_path": {
+      "S": "scripts/merchant_profiles.json"
+     },
+     "source_receipt_keys": {
+      "L": []
+     },
+     "written_by": {
+      "M": {
+       "kind": {
+        "S": "migration"
+       },
+       "name": {
+        "S": "merchant_truth_v1"
+       },
+       "version": {
+        "S": "1"
+       }
+      }
+     }
+    }
+   },
+   "slug": {
+    "S": "costco_wholesale"
+   },
+   "version": {
+    "N": "1"
+   }
+  },
+  {
+   "PK": {
+    "S": "MERCHANT_TRUTH#costco_wholesale"
+   },
+   "SK": {
+    "S": "TRUTH#v0000000001#C#typography"
+   },
+   "TYPE": {
+    "S": "MERCHANT_TRUTH_COMPONENT"
+   },
+   "component": {
+    "S": "typography"
+   },
+   "content_hash": {
+    "S": "70947f1d6ca65a1d9ac57441b115b5eb30d8f08d4522259caba7311c42e80647"
+   },
+   "payload": {
+    "S": "{\"section_scale\":{\"FOOTER\":0.5},\"typography\":{\"bitmap_font\":{\"heavy\":\"bitMatrix-C2-heavy.glyphs.npz\",\"regular\":\"bitMatrix-C2.glyphs.npz\"},\"bitmap_thin\":0.0,\"condense\":0.93}}"
+   },
+   "provenance": {
+    "M": {
+     "git_sha": {
+      "S": "eb9d3617122be21d0e0e956e04f3208aec701c29"
+     },
+     "measured_at": {
+      "NULL": true
+     },
+     "migrated_at": {
+      "S": "2026-07-21T17:06:49.844567+00:00"
+     },
+     "pipeline": {
+      "S": "merchant_truth_v1"
+     },
+     "pipeline_version": {
+      "S": "1"
+     },
+     "provenance_completeness": {
+      "S": "legacy"
+     },
+     "source_kind": {
+      "S": "migration"
+     },
+     "source_objects": {
+      "L": []
+     },
+     "source_path": {
+      "S": "scripts/merchant_profiles.json"
+     },
+     "source_receipt_keys": {
+      "L": []
+     },
+     "written_by": {
+      "M": {
+       "kind": {
+        "S": "migration"
+       },
+       "name": {
+        "S": "merchant_truth_v1"
+       },
+       "version": {
+        "S": "1"
+       }
+      }
+     }
+    }
+   },
+   "slug": {
+    "S": "costco_wholesale"
+   },
+   "version": {
+    "N": "1"
+   }
+  },
+  {
+   "PK": {
+    "S": "MERCHANT_TRUTH#costco_wholesale"
+   },
+   "SK": {
+    "S": "TRUTH#v0000000001#MANIFEST"
+   },
+   "TYPE": {
+    "S": "MERCHANT_TRUTH_MANIFEST"
+   },
+   "bundle_hash": {
+    "S": "c5cd31202f7a52cee5f5b492c675ae4ed1d94241529bdc3d16d85b18bf7fd064"
+   },
+   "component_count": {
+    "N": "7"
+   },
+   "component_hashes": {
+    "M": {
+     "assets": {
+      "S": "f7e32df3005b76f01c7e4b959a4b89dd1417431f2aa9ef036ae4bb45fb27e525"
+     },
+     "catalog_snapshot": {
+      "S": "835af79b29ea3d7f438dc4aa38802935d18a7e56711576c66001d32730c56914"
+     },
+     "flags": {
+      "S": "4359b2e0a16bb8d784963f461a99f576abd17a221444cbe6097d8f290ae06208"
+     },
+     "identity": {
+      "S": "175c84d2a749719eed5f1da4154406f1874b087ee2066783bfaaf120d1d41e7b"
+     },
+     "layout": {
+      "S": "7e6a7a3232a157e633099f10a6f92a05510bb74266e99af3454cb5f30f29c685"
+     },
+     "stylemap": {
+      "S": "86e085f273272b4c00d5fbd23b910b4b0302cd372419cc813e98f5856f00428e"
+     },
+     "typography": {
+      "S": "70947f1d6ca65a1d9ac57441b115b5eb30d8f08d4522259caba7311c42e80647"
+     }
+    }
+   },
+   "confirmed_proposals": {
+    "L": []
+   },
+   "gate_results": {
+    "M": {
+     "evidence": {
+      "M": {
+       "dry_run_payload_dir": {
+        "S": "/Users/tnorlund/section_label_kickoff/truth_v1_payloads"
+       },
+       "generated_at": {
+        "S": "2026-07-21T17:06:49.844567+00:00"
+       },
+       "git_sha": {
+        "S": "eb9d3617122be21d0e0e956e04f3208aec701c29"
+       }
+      }
+     },
+     "gate": {
+      "S": "merchant_truth_v1_bootstrap"
+     },
+     "kind": {
+      "S": "migration-bootstrap-seal"
+     },
+     "note": {
+      "S": "bootstrap seal: gate passes on dry-run<->live source parity only; no fidelity eval has run against truth-loaded renders yet"
+     },
+     "passed": {
+      "BOOL": true
+     },
+     "status": {
+      "S": "PASS"
+     },
+     "written_by": {
+      "M": {
+       "kind": {
+        "S": "migration"
+       },
+       "name": {
+        "S": "merchant_truth_v1"
+       },
+       "version": {
+        "S": "1"
+       }
+      }
+     }
+    }
+   },
+   "gate_status": {
+    "S": "PASS"
+   },
+   "mint_run_id": {
+    "S": "merchant-truth-v1-costco_wholesale-eb9d3617122b"
+   },
+   "provenance": {
+    "M": {
+     "git_sha": {
+      "S": "eb9d3617122be21d0e0e956e04f3208aec701c29"
+     },
+     "migration_blockers": {
+      "L": []
+     },
+     "minted_at": {
+      "S": "2026-07-21T17:06:49.844567+00:00"
+     },
+     "run_id": {
+      "S": "merchant-truth-v1-costco_wholesale-eb9d3617122b"
+     },
+     "written_by": {
+      "M": {
+       "kind": {
+        "S": "migration"
+       },
+       "name": {
+        "S": "merchant_truth_v1"
+       },
+       "version": {
+        "S": "1"
+       }
+      }
+     }
+    }
+   },
+   "sealed_at": {
+    "S": "2026-07-21T17:06:49.844567+00:00"
+   },
+   "slug": {
+    "S": "costco_wholesale"
+   },
+   "status": {
+    "S": "SEALED"
+   },
+   "version": {
+    "N": "1"
+   }
+  }
+ ]
+}

--- a/tests/test_full_fidelity_eval_truth.py
+++ b/tests/test_full_fidelity_eval_truth.py
@@ -1,0 +1,448 @@
+"""W8: full_fidelity_eval reads MerchantTruth bundles, never the profile JSON.
+
+Covers the four contract points of the cutover:
+
+1. PINNED freshness gate -- a pin that does not match the realized bundle
+   fails the eval.
+2. ONLINE-ACTIVE freshness gate -- the expected ACTIVE tuple is captured
+   before the load; a loader that realizes a different bundle (stale cache /
+   racing flip) fails the eval.
+3. FIXTURE mode -- a vendored bundle resolves with no reader at all
+   (CI/offline), still hash-verified, and refuses a fixture for the wrong
+   merchant.
+4. Metric parity -- identical inputs produce byte-identical eval output
+   whether truth comes from the vendored costco v1 bundle or from the same
+   data read the legacy way (merchant_profiles.json), proving the cutover
+   changed the data source, not the metrics.
+"""
+
+import json
+import os
+import sys
+
+import numpy as np
+import pytest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.dirname(HERE)
+for _p in (
+    os.path.join(REPO, "synthesis_loop"),
+    os.path.join(REPO, "scripts"),
+    os.path.join(REPO, "receipt_agent"),
+    os.path.join(REPO, "receipt_dynamo"),
+    os.path.join(REPO, "tools", "glyph-studio", "py"),
+):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+import full_fidelity_eval as ffe  # noqa: E402
+
+from receipt_dynamo.data.shared_exceptions import (  # noqa: E402
+    MerchantTruthIntegrityError,
+)
+from receipt_dynamo.entities.merchant_truth import (  # noqa: E402
+    COMPONENT_NAMES,
+    MerchantTruthActive,
+    MerchantTruthComponent,
+    MerchantTruthManifest,
+    compute_bundle_hash,
+)
+
+COSTCO_FIXTURE = os.path.join(
+    REPO, "tests", "fixtures", "merchant_truth", "costco_wholesale_v1.json"
+)
+SLUG = "costco_wholesale"
+NOW = "2026-07-21T00:00:00+00:00"
+
+
+# ---------------------------------------------------------------------------
+# bundle scaffolding (mirrors receipt_dynamo's loader test helpers)
+# ---------------------------------------------------------------------------
+def build_bundle(version: int, marker: str = ""):
+    """A SEALED/PASS bundle whose hashes vary with ``version``+``marker``."""
+    components = [
+        MerchantTruthComponent(
+            slug=SLUG,
+            version=version,
+            name=name,
+            payload={"name": name, "version": version, "marker": marker},
+            provenance={"source_kind": "migration"},
+        )
+        for name in sorted(COMPONENT_NAMES)
+    ]
+    hashes = {item.name: item.content_hash for item in components}
+    bundle_hash = compute_bundle_hash(hashes)
+    manifest = MerchantTruthManifest(
+        slug=SLUG,
+        version=version,
+        component_hashes=hashes,
+        bundle_hash=bundle_hash,
+        status="SEALED",
+        provenance={"written_by": "test"},
+        mint_run_id=f"run-{version}",
+        gate_status="PASS",
+    )
+    active = MerchantTruthActive(
+        slug=SLUG,
+        version=version,
+        bundle_hash=bundle_hash,
+        normalized_aliases=["costco", "costco wholesale"],
+        activated_at=NOW,
+        activated_by="owner",
+    )
+    items = [manifest.to_item(), *[c.to_item() for c in components]]
+    return active, bundle_hash, items
+
+
+class FakeReader:
+    """Read-only reader double; ``active_queue`` scripts successive
+    strong reads of TRUTH#ACTIVE (capture first, loader's read second)."""
+
+    def __init__(self, fleet, bundles, active_queue=None):
+        self.fleet = fleet
+        self.bundles = bundles  # {(slug, version): items}
+        self.active_queue = list(active_queue) if active_queue else None
+
+    def list_active_merchant_truth(self):
+        return list(self.fleet)
+
+    def list_merchant_truth_manifests(self):
+        return []
+
+    def get_merchant_truth_manifest(
+        self, slug, version, *, consistent_read=False
+    ):
+        return None
+
+    def list_merchant_truth_components(
+        self, slug, version, *, consistent_read=False
+    ):
+        return []
+
+    def get_active_merchant_truth(self, slug, *, consistent_read=False):
+        if self.active_queue:
+            return self.active_queue.pop(0)
+        for active in self.fleet:
+            if active.slug == slug:
+                return active
+        return None
+
+    def read_merchant_truth_bundle_items(
+        self, slug, version, *, consistent_read=False
+    ):
+        return list(self.bundles.get((slug, version), []))
+
+
+# ---------------------------------------------------------------------------
+# 1. PINNED mode is the freshness gate
+# ---------------------------------------------------------------------------
+def test_pinned_match_resolves(tmp_path):
+    active, bundle_hash, items = build_bundle(1)
+    reader = FakeReader([active], {(SLUG, 1): items})
+    ctx = ffe.resolve_truth(
+        "Costco Wholesale",
+        pin_version=1,
+        pin_bundle_hash=bundle_hash,
+        reader=reader,
+        cache_dir=tmp_path,
+    )
+    assert (ctx.slug, ctx.version, ctx.bundle_hash) == (SLUG, 1, bundle_hash)
+    assert ctx.mode == "pinned"
+
+
+def test_pinned_mismatch_fails(tmp_path):
+    active, _bundle_hash, items = build_bundle(1)
+    reader = FakeReader([active], {(SLUG, 1): items})
+    with pytest.raises(MerchantTruthIntegrityError):
+        ffe.resolve_truth(
+            "Costco Wholesale",
+            pin_version=1,
+            pin_bundle_hash="0" * 64,
+            reader=reader,
+            cache_dir=tmp_path,
+        )
+
+
+def test_pinned_missing_version_fails(tmp_path):
+    active, bundle_hash, items = build_bundle(1)
+    reader = FakeReader([active], {(SLUG, 1): items})
+    with pytest.raises(MerchantTruthIntegrityError):
+        ffe.resolve_truth(
+            "Costco Wholesale",
+            pin_version=7,
+            pin_bundle_hash=bundle_hash,
+            reader=reader,
+            cache_dir=tmp_path,
+        )
+
+
+def test_half_a_pin_is_rejected(tmp_path):
+    active, _bundle_hash, items = build_bundle(1)
+    reader = FakeReader([active], {(SLUG, 1): items})
+    with pytest.raises(SystemExit):
+        ffe.resolve_truth(
+            "Costco Wholesale",
+            pin_version=1,
+            reader=reader,
+            cache_dir=tmp_path,
+        )
+
+
+# ---------------------------------------------------------------------------
+# 2. ONLINE-ACTIVE freshness gate (stale-cache detection)
+# ---------------------------------------------------------------------------
+def test_online_active_fresh_resolves(tmp_path):
+    active, bundle_hash, items = build_bundle(1)
+    reader = FakeReader([active], {(SLUG, 1): items})
+    ctx = ffe.resolve_truth(
+        "Costco Wholesale", reader=reader, cache_dir=tmp_path
+    )
+    assert (ctx.version, ctx.bundle_hash) == (1, bundle_hash)
+    assert ctx.mode == "online-active"
+    assert (ctx.expected_version, ctx.expected_bundle_hash) == (
+        1,
+        bundle_hash,
+    )
+
+
+def test_online_active_stale_bundle_fails(tmp_path):
+    """Expected tuple captured at run start = v2; the loader then realizes
+    v1 (a stale replica / racing flip). The eval must FAIL, not stamp v1."""
+    active_v1, _hash_v1, items_v1 = build_bundle(1)
+    active_v2, _hash_v2, items_v2 = build_bundle(2)
+    reader = FakeReader(
+        [active_v2],
+        {(SLUG, 1): items_v1, (SLUG, 2): items_v2},
+        # capture strong-reads v2; the loader's own strong read then sees v1
+        active_queue=[active_v2, active_v1],
+    )
+    with pytest.raises(ffe.TruthFreshnessError):
+        ffe.resolve_truth(
+            "Costco Wholesale", reader=reader, cache_dir=tmp_path
+        )
+
+
+def test_unknown_merchant_fails(tmp_path):
+    active, _bundle_hash, items = build_bundle(1)
+    reader = FakeReader([active], {(SLUG, 1): items})
+    with pytest.raises(MerchantTruthIntegrityError):
+        ffe.resolve_truth(
+            "No Such Merchant", reader=reader, cache_dir=tmp_path
+        )
+
+
+# ---------------------------------------------------------------------------
+# 3. FIXTURE mode: offline, hash-verified, merchant-checked
+# ---------------------------------------------------------------------------
+def test_fixture_mode_resolves_offline(tmp_path):
+    ctx = ffe.resolve_truth(
+        "Costco Wholesale",
+        fixture_path=COSTCO_FIXTURE,
+        reader=None,  # no network surface at all
+        cache_dir=tmp_path,
+    )
+    with open(COSTCO_FIXTURE, encoding="utf-8") as fh:
+        items = json.load(fh)["items"]
+    manifest = next(
+        MerchantTruthManifest.from_item(item)
+        for item in items
+        if item["TYPE"]["S"] == "MERCHANT_TRUTH_MANIFEST"
+    )
+    assert (ctx.slug, ctx.version, ctx.bundle_hash) == (
+        manifest.slug,
+        manifest.version,
+        manifest.bundle_hash,
+    )
+    assert ctx.mode == "fixture"
+    layout = ctx.component("layout")
+    assert layout["available"] and layout["template"]["columns"]
+
+
+def test_fixture_for_wrong_merchant_fails(tmp_path):
+    with pytest.raises(SystemExit):
+        ffe.resolve_truth(
+            "Vons",
+            fixture_path=COSTCO_FIXTURE,
+            reader=None,
+            cache_dir=tmp_path,
+        )
+
+
+def test_fixture_and_pin_are_mutually_exclusive(tmp_path):
+    with pytest.raises(SystemExit):
+        ffe.resolve_truth(
+            "Costco Wholesale",
+            fixture_path=COSTCO_FIXTURE,
+            pin_version=1,
+            pin_bundle_hash="0" * 64,
+            reader=None,
+            cache_dir=tmp_path,
+        )
+
+
+def test_tampered_fixture_fails(tmp_path):
+    with open(COSTCO_FIXTURE, encoding="utf-8") as fh:
+        doc = json.load(fh)
+    for item in doc["items"]:
+        if item["SK"]["S"].endswith("#C#layout"):
+            item["payload"]["S"] = item["payload"]["S"].replace(
+                "0.9439", "0.5000"
+            )
+    tampered = tmp_path / "tampered.json"
+    tampered.write_text(json.dumps(doc), encoding="utf-8")
+    with pytest.raises((MerchantTruthIntegrityError, ValueError)):
+        ffe.resolve_truth(
+            "Costco Wholesale",
+            fixture_path=str(tampered),
+            reader=None,
+            cache_dir=tmp_path,
+        )
+
+
+# ---------------------------------------------------------------------------
+# 4. metric parity: legacy profile JSON vs loader bundle, identical output
+# ---------------------------------------------------------------------------
+class _LegacyArtifact:
+    """Stub artifact whose components are built straight from the legacy
+    merchant_profiles.json block, mapped exactly as migration mapped them."""
+
+    def __init__(self, slug, components):
+        self.slug = slug
+        self.version = 0
+        self.bundle_hash = "legacy"
+        self.components = components
+
+
+def _legacy_truth_context():
+    with open(
+        os.path.join(REPO, "scripts", "merchant_profiles.json"),
+        encoding="utf-8",
+    ) as fh:
+        block = json.load(fh)["profiles"]["Costco Wholesale"]
+    typography = block.get("typography") or {}
+    template = dict(block.get("layout_template") or {})
+    template.pop("_comment", None)
+    components = {
+        "layout": {"available": bool(template), "template": template},
+        "assets": {
+            "profile": {
+                "logo": block.get("logo"),
+                "logo_anchor": block.get("logo_anchor"),
+                "stylemap_filename": typography.get("stylemap"),
+            }
+        },
+        "typography": {
+            "typography": {
+                key: typography[key]
+                for key in ("bitmap_font", "bitmap_thin", "condense")
+                if key in typography
+            },
+            "section_scale": block.get("section_scale") or {},
+        },
+        "flags": {"compose": block.get("compose")},
+    }
+    return ffe.TruthContext(
+        artifact=_LegacyArtifact(SLUG, components),
+        expected_version=0,
+        expected_bundle_hash="legacy",
+        mode="legacy",
+    )
+
+
+def _synthetic_pair(tmp_path):
+    """A small deterministic (real, synth) pair with an items amount lane
+    near the costco template's items amount column (x=0.9439)."""
+    from PIL import Image
+
+    W, H = 400, 300
+    real = np.full((H, W), 235, dtype=np.uint8)
+    syn = np.full((H, W), 235, dtype=np.uint8)
+
+    def word(text, l, t, r, b, labels=()):
+        # renderer-format bbox: 0-1000, y-up
+        return {
+            "text": text,
+            "labels": list(labels),
+            "bbox": [
+                l / W * 1000,
+                (1 - b / H) * 1000,
+                r / W * 1000,
+                (1 - t / H) * 1000,
+            ],
+        }
+
+    words = []
+    lane_r = int(0.9439 * W)
+    for i in range(6):
+        y = 40 + i * 22  # inside the costco ITEMS band (0.09-0.55)
+        words.append(word("ITEM%d" % i, 12, y, 90, y + 12))
+        words.append(word("2.99", lane_r - 34, y, lane_r, y + 12))
+        for img in (real, syn):
+            img[y : y + 12, 12:90] = 30
+            img[y : y + 12, lane_r - 34 : lane_r] = 30
+    y = 200  # SUMMARY band
+    words.append(word("TOTAL", 12, y, 60, y + 12))
+    words.append(word("17.94", lane_r - 40, y, lane_r, y + 12))
+    for img in (real, syn):
+        img[y : y + 12, 12:60] = 30
+        img[y : y + 12, lane_r - 40 : lane_r] = 30
+
+    real_img = Image.fromarray(real).convert("RGB")
+    syn_img = Image.fromarray(syn).convert("RGB")
+    real_png = str(tmp_path / "real.png")
+    syn_png = str(tmp_path / "syn.png")
+    real_img.save(real_png)
+    syn_img.save(syn_png)
+    return real_img, syn_img, words, real_png, syn_png
+
+
+def test_metric_parity_legacy_vs_loader(tmp_path):
+    """Identical inputs + identical truth data => byte-identical eval
+    output, whether truth flows from the vendored costco v1 bundle or from
+    the legacy profile JSON. Proves the cutover is a data-source change."""
+    loader_ctx = ffe.resolve_truth(
+        "Costco Wholesale",
+        fixture_path=COSTCO_FIXTURE,
+        reader=None,
+        cache_dir=tmp_path,
+    )
+    legacy_ctx = _legacy_truth_context()
+
+    # the truth-derived eval inputs must agree exactly
+    for section in ("items", "summary", "payment", "footer"):
+        assert ffe.profile_columns(loader_ctx, section) == ffe.profile_columns(
+            legacy_ctx, section
+        )
+    assert bool(
+        (loader_ctx.component("assets").get("profile") or {}).get("logo")
+    ) == bool(
+        (legacy_ctx.component("assets").get("profile") or {}).get("logo")
+    )
+    assert bool(loader_ctx.component("flags").get("compose")) == bool(
+        legacy_ctx.component("flags").get("compose")
+    )
+    assert ffe.atlas_hash(loader_ctx) == ffe.atlas_hash(legacy_ctx)
+
+    real_img, syn_img, words, real_png, syn_png = _synthetic_pair(tmp_path)
+    results = []
+    for ctx in (legacy_ctx, loader_ctx):
+        checks = ffe.evaluate_pair(
+            real_img,
+            syn_img,
+            words,
+            words,
+            slug="costco",
+            truth=ctx,
+            real_png=real_png,
+            syn_png=syn_png,
+            composed=False,
+            columns_source="profile",
+        )
+        results.append(json.dumps(checks, sort_keys=True))
+    assert results[0] == results[1]
+    # the profile-columns source actually engaged (not the bootstrap path)
+    checks = json.loads(results[1])
+    assert any(
+        band["source"] == "profile"
+        for band in checks["columns"]["bands"].values()
+    )


### PR DESCRIPTION
Implements **W8** of the plan (`~/.claude/plans/humble-skipping-quilt.md`) — eval cutover to `MerchantTruthLoader` — closing part of the #1188 P4 leftovers (freshness/pin gate wiring for the eval consumer). Contract: `docs/architecture/MERCHANT_TRUTH_DYNAMO.md` §4 (truth-resolution modes, recipe stamping).

## What changed

`synthesis_loop/full_fidelity_eval.py` no longer opens `scripts/merchant_profiles.json` (its 3 direct reads — `profile_hash`, `atlas_hash`, `profile_block`/`profile_columns` — are gone). All merchant truth resolves through the fail-closed loader:

| eval need | bundle source |
|---|---|
| measured layout columns (`--columns-source profile`) | `C#layout.template` |
| atlas-hash artifact names (npz / logo / stylemap filenames) | `C#typography.typography.bitmap_font` + `C#assets.profile.{logo,stylemap_filename}` |
| `compose` engine flag (incl. dollartree canonical words) | `C#flags.compose` |
| logo expectation (`expects_logo`) | `C#assets.profile.logo` |
| recipe stamp | `{slug, version, bundle_hash, mode}` of the bundle actually used (replaces `profile_hash`) |

**THE FRESHNESS GATE**
- **pinned** (`--pin-version` + `--pin-bundle-hash`): the realized tuple must equal the pin or the eval fails (loader verifies manifest/component/bundle hashes fail-closed; the realized tuple is additionally asserted against the pin).
- **online-active** (default): the expected ACTIVE tuple is captured with a **strong read before the bundle load**; a realized bundle that differs fails — stale-cache / racing-flip detection, per finding 5 of the contract doc.
- **fixture** (`--truth-fixture PATH`): CI/offline; vendored bundle, still hash-verified; a fixture for the wrong merchant or a tampered payload is refused. `tests/fixtures/merchant_truth/costco_wholesale_v1.json` is the real dev costco v1 bundle (loader low-level items format).

Metric behavior is **unchanged** — this is a data-source cutover. `render_regression_guard` is untouched (re-baseline is W9; the eval doesn't render differently).

## Parity evidence (legacy vs loader, same receipt, live dev — read-only)

Both paths run against dev `ReceiptsTable-dc5be22`, merchant `Costco Wholesale`, receipt `0324604e-e1f7-4021-b887-7ef7e012c563#1`, same `RECEIPT_OCR_BIN`, warm font cache.

**Legacy path** (parent commit `472087e23`, pre-cutover code):
```
OVERALL FAIL -> .../legacy2/costco_eval/costco.checks.json ...
  columns     FAIL
  style       PASS_WITH_GAPS
  tokens      FAIL
  separators  FAIL
  graphics    PASS
  logo        FAIL
  arithmetic  FAIL
stamp: profile_hash=9f3c45a0a1ba9dc4 atlas_hash=3d0a24ac0ba6e9bb inputs_hash=d5ef5a8438d91a13
```

**Loader path** (this branch, `12d54365b`):
```
OVERALL FAIL -> .../loader2/costco_eval/costco.checks.json ...
  columns     FAIL
  style       PASS_WITH_GAPS
  tokens      FAIL
  separators  FAIL
  graphics    PASS
  logo        FAIL
  arithmetic  FAIL
stamp: merchant_truth={slug: costco_wholesale, version: 1, bundle_hash: c5cd31202f7a52cee5f5b492c675ae4ed1d94241529bdc3d16d85b18bf7fd064, mode: online-active}
       atlas_hash=3d0a24ac0ba6e9bb inputs_hash=d5ef5a8438d91a13
```

The full `checks` blocks are **byte-identical** — `sha256(canonical checks JSON)` both sides:
```
8219bb9dc21c44c128a285224e8783f71c69a196a0396676302d509a8797307f
```
(The eval FAILs are the receipt's pre-existing fidelity defects, identically measured by both paths — parity is about identical measurement, not a green verdict.)

Live pinned smoke: `--pin-version 1 --pin-bundle-hash c5cd31…` runs and its `checks` are byte-identical to the online-active run (3-way match); the same pin with a wrong hash fails closed before rendering (`MerchantTruthIntegrityError: manifest does not match the expected bundle hash`).

## Tests (12 new, all root tests green)

- `test_pinned_mismatch_fails` / `test_pinned_missing_version_fails` / `test_pinned_match_resolves` / `test_half_a_pin_is_rejected`
- `test_online_active_stale_bundle_fails` (mock reader: capture sees v2, loader realizes v1 → `TruthFreshnessError`), `test_online_active_fresh_resolves`, `test_unknown_merchant_fails`
- `test_fixture_mode_resolves_offline` (reader=None), `test_fixture_for_wrong_merchant_fails`, `test_fixture_and_pin_are_mutually_exclusive`, `test_tampered_fixture_fails`
- `test_metric_parity_legacy_vs_loader`: identical synthetic inputs through `evaluate_pair` with truth from the vendored costco v1 bundle vs the same data read the legacy way from `merchant_profiles.json` → byte-identical output; also asserts columns/logo/compose/atlas-name equality per section and that the `profile` columns source actually engaged.

`tests/`: 340 passed, 1 skipped (pre-existing `test_resegment_receipt_lambda` collection error is a stale-editable-install environment artifact, unrelated).

## Schema-mapping notes

- The eval's atlas/logo needs did not map onto the three "named" components alone: the legacy `logo` filename and `typography.stylemap` filename live in **`C#assets.profile`** (as `logo` / `stylemap_filename`), not in `C#typography` or `C#flags`. The cutover reads them from there; parity confirms equivalence.
- `atlas_hash` still hashes the **local** `BITMATRIX_DIR` bytes (what the render actually used) — only the *name list* now comes from the bundle. On a cold cache the stamp hashes `<missing>` sentinels until the renderer fetches (pre-existing legacy behavior, observed during the first parity run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BeLcSviHL5vDgS3zTSMbsq
