### PR TITLE
[migrations] mint replay: skip-if-sealed + --merchants filter

### DIFF
--- a/receipt_dynamo/receipt_dynamo/migrations/merchant_truth_v1.py
+++ b/receipt_dynamo/receipt_dynamo/migrations/merchant_truth_v1.py
@@ -374,8 +374,14 @@ def build_v1_payloads(
     git_sha: str,
     generated_at: str,
     stylemap_root: Path | None = None,
+    expected_missing_slugs: frozenset[str] | None = None,
 ) -> tuple[list[MerchantV1Payload], list[LeafDisposition]]:
-    """Build all exact nine-item mint payloads without any DynamoDB writes."""
+    """Build all exact nine-item mint payloads without any DynamoDB writes.
+
+    ``expected_missing_slugs`` makes the MerchantFont coverage expectation
+    declarative per run (default: the historical asset-blocked trio). Any
+    coverage differing from the stated expectation still hard-fails.
+    """
     crosswalk = build_crosswalk(document)
     profiles: dict[str, dict[str, Any]] = document["profiles"]
     font_rows = [
@@ -386,15 +392,20 @@ def build_v1_payloads(
     for font in font_rows:
         fonts_by_name.setdefault(font.merchant_name, []).append(font)
 
+    expected_missing = (
+        EXPECTED_MISSING_FONT_SLUGS
+        if expected_missing_slugs is None
+        else frozenset(expected_missing_slugs)
+    )
     missing_slugs = {
         slugify_merchant(name)
         for name in profiles
         if name not in fonts_by_name
     }
-    if missing_slugs != EXPECTED_MISSING_FONT_SLUGS:
+    if missing_slugs != expected_missing:
         raise ValueError(
             "MerchantFont coverage changed; expected missing "
-            f"{sorted(EXPECTED_MISSING_FONT_SLUGS)}, got "
+            f"{sorted(expected_missing)}, got "
             f"{sorted(missing_slugs)}"
         )
 

--- a/receipt_dynamo/receipt_dynamo/migrations/merchant_truth_v1_live.py
+++ b/receipt_dynamo/receipt_dynamo/migrations/merchant_truth_v1_live.py
@@ -86,6 +86,14 @@ class MerchantTruthWriter(Protocol):
         consistent_read: bool = False,
     ) -> list[dict[str, Any]]: ...
 
+    def get_merchant_truth_manifest(
+        self,
+        slug: str,
+        version: int,
+        *,
+        consistent_read: bool = False,
+    ) -> MerchantTruthManifest | None: ...
+
 
 def validate_live_table(table_name: str, *, explicit: bool) -> None:
     """Refuse every live target except the pinned dev table.
@@ -169,20 +177,54 @@ class LiveMintResult:
 
     merchant_name: str
     slug: str
-    action: str  # "MINTED_SEALED" | "EXCLUDED"
+    # "MINTED_SEALED" | "EXCLUDED" | "SKIPPED_SEALED" | "CONFLICT_SEALED"
+    action: str
     version: int
     bundle_hash: str | None = None
     blockers: tuple[str, ...] = ()
+    source_bundle_hash: str | None = None
 
     @property
     def report_line(self) -> str:
+        digest = (self.bundle_hash or "")[:12]
         if self.action == "EXCLUDED":
             return (
                 f"EXCLUDED (asset-blocked) {self.slug}: "
                 f"{'; '.join(self.blockers)}"
             )
-        digest = (self.bundle_hash or "")[:12]
+        if self.action == "SKIPPED_SEALED":
+            return f"SKIPPED (already sealed, bundle={digest}) {self.slug}"
+        if self.action == "CONFLICT_SEALED":
+            source_digest = (self.source_bundle_hash or "")[:12]
+            return (
+                f"CONFLICT (sealed bundle differs from source) "
+                f"{self.slug}: sealed={digest} source={source_digest}"
+            )
         return f"MINTED+SEALED v{self.version} {self.slug} bundle={digest}"
+
+
+def filter_payloads(
+    payloads: Sequence[MerchantV1Payload],
+    merchants: Sequence[str],
+) -> list[MerchantV1Payload]:
+    """Restrict payloads to explicitly requested slugs, failing closed.
+
+    Unknown slugs are an operator error (typo or a merchant absent from the
+    source registry) and abort before anything is written or minted.
+    """
+    requested = sorted(
+        {slug.strip() for slug in merchants if slug and slug.strip()}
+    )
+    if not requested:
+        raise ValueError("--merchants was passed but contains no slugs")
+    known = {payload.slug for payload in payloads}
+    unknown = sorted(set(requested) - known)
+    if unknown:
+        raise ValueError(
+            f"unknown merchant slugs: {', '.join(unknown)}; "
+            f"known slugs: {', '.join(sorted(known))}"
+        )
+    return [payload for payload in payloads if payload.slug in requested]
 
 
 def _payload_entities(
@@ -221,9 +263,12 @@ def run_live_mint(
     """Mint + seal v1 for every unblocked merchant through the accessor.
 
     Blocked merchants (any non-empty ``blockers``) are excluded, never
-    minted, and reported. The dry-run payload items are replayed verbatim:
-    the accessor re-derives hashes, re-validates governance, and writes its
-    own MINT/SEAL audit rows.
+    minted, and reported. Merchants whose target version is already SEALED
+    are skipped (identical bundle) or reported as a drift CONFLICT
+    (different bundle) without writing, so a full replay is idempotent
+    regardless of the current git SHA. The dry-run payload items are
+    replayed verbatim: the accessor re-derives hashes, re-validates
+    governance, and writes its own MINT/SEAL audit rows.
     """
     validate_live_table(table_name, explicit=explicit_table)
     results: list[LiveMintResult] = []
@@ -240,6 +285,36 @@ def run_live_mint(
             )
             continue
         manifest, components = _payload_entities(payload)
+        existing = client.get_merchant_truth_manifest(
+            payload.slug, manifest.version, consistent_read=True
+        )
+        if existing is not None and existing.status == "SEALED":
+            # The mint run_id is git-sha-dependent, so replaying under a
+            # newer HEAD must not abort on merchants sealed by an earlier
+            # run: an identical bundle is an idempotent no-op, a different
+            # bundle is a drift signal to surface — never overwritten.
+            if existing.bundle_hash == manifest.bundle_hash:
+                results.append(
+                    LiveMintResult(
+                        merchant_name=payload.merchant_name,
+                        slug=payload.slug,
+                        action="SKIPPED_SEALED",
+                        version=existing.version,
+                        bundle_hash=existing.bundle_hash,
+                    )
+                )
+            else:
+                results.append(
+                    LiveMintResult(
+                        merchant_name=payload.merchant_name,
+                        slug=payload.slug,
+                        action="CONFLICT_SEALED",
+                        version=existing.version,
+                        bundle_hash=existing.bundle_hash,
+                        source_bundle_hash=manifest.bundle_hash,
+                    )
+                )
+            continue
         client.mint_version(
             payload.slug,
             manifest.version,

--- a/receipt_dynamo/tests/integration/test_merchant_truth_v1_live.py
+++ b/receipt_dynamo/tests/integration/test_merchant_truth_v1_live.py
@@ -439,14 +439,14 @@ def _create_dev_named_table() -> None:
     )
 
 
-def _seed_dev_sources() -> None:
+def _seed_dev_sources(publish_all: bool = False) -> None:
     dynamodb = boto3.client("dynamodb", region_name="us-east-1")
     s3 = boto3.client("s3", region_name="us-east-1")
     s3.create_bucket(Bucket="font-bucket")
     for merchant in MERCHANTS:
         slug = slugify_merchant(merchant)
         dynamodb.put_item(TableName=DEV_TABLE_NAME, Item=catalog_item(slug))
-        if slug in EXPECTED_MISSING_FONT_SLUGS:
+        if not publish_all and slug in EXPECTED_MISSING_FONT_SLUGS:
             continue
         font = merchant_font(merchant)
         dynamodb.put_item(TableName=DEV_TABLE_NAME, Item=font.to_item())
@@ -465,6 +465,19 @@ def seeded_dev_environment(tmp_path: Path):
     with mock_aws():
         _create_dev_named_table()
         _seed_dev_sources()
+        profiles_path = tmp_path / "profiles.json"
+        profiles_path.write_text(
+            json.dumps(profile_document()), encoding="utf-8"
+        )
+        yield profiles_path
+
+
+@pytest.fixture
+def published_dev_environment(tmp_path: Path):
+    """Publish-day state: all 16 merchants have MerchantFont rows."""
+    with mock_aws():
+        _create_dev_named_table()
+        _seed_dev_sources(publish_all=True)
         profiles_path = tmp_path / "profiles.json"
         profiles_path.write_text(
             json.dumps(profile_document()), encoding="utf-8"
@@ -660,6 +673,87 @@ def test_script_replay_after_partial_mint_skips_and_verifies(
     assert "CONFLICT" not in captured
     assert "skipped 2 already-sealed" in captured
     assert "VERIFY OK: 13 live bundles byte-match" in captured
+
+
+def test_default_expectation_fails_once_all_fonts_are_published(
+    published_dev_environment: Path, tmp_path: Path
+) -> None:
+    """Coverage differing from the (default) expectation still hard-fails."""
+    with pytest.raises(ValueError, match="MerchantFont coverage changed"):
+        _script_main(
+            [
+                "--profiles",
+                str(published_dev_environment),
+                "--output-dir",
+                str(tmp_path / "payloads"),
+                "--git-sha",
+                GIT_SHA,
+                "--generated-at",
+                NOW,
+            ]
+        )
+
+
+def test_empty_expected_missing_slugs_covers_publish_day(
+    published_dev_environment: Path, tmp_path: Path, capsys
+) -> None:
+    """The staged owner command: post-publish mint of the trio with an
+    explicitly empty missing-font expectation and zero code changes."""
+    output_dir = tmp_path / "payloads"
+
+    exit_code = _script_main(
+        [
+            "--profiles",
+            str(published_dev_environment),
+            "--output-dir",
+            str(output_dir),
+            "--git-sha",
+            GIT_SHA,
+            "--generated-at",
+            NOW,
+            "--merchants",
+            "amazon_fresh,dollar_tree,smith_s",
+            "--expected-missing-slugs",
+            "",
+            "--live",
+            "--verify",
+        ]
+    )
+
+    captured = capsys.readouterr().out
+    assert exit_code == 0
+    assert "merchants: 3" in captured
+    assert captured.count("MINTED+SEALED v1") == 3
+    assert "EXCLUDED" not in captured
+    assert "VERIFY OK: 3 live bundles byte-match" in captured
+    client = DynamoClient(DEV_TABLE_NAME)
+    for slug in ("amazon_fresh", "dollar_tree", "smith_s"):
+        manifest = client.get_merchant_truth_manifest(
+            slug, 1, consistent_read=True
+        )
+        assert manifest is not None and manifest.status == "SEALED"
+
+
+def test_wrong_declared_expectation_still_hard_fails(
+    published_dev_environment: Path, tmp_path: Path
+) -> None:
+    """The flag is declarative, not a bypass: a stated expectation that
+    does not match reality fails identically."""
+    with pytest.raises(ValueError, match="MerchantFont coverage changed"):
+        _script_main(
+            [
+                "--profiles",
+                str(published_dev_environment),
+                "--output-dir",
+                str(tmp_path / "payloads"),
+                "--git-sha",
+                GIT_SHA,
+                "--generated-at",
+                NOW,
+                "--expected-missing-slugs",
+                "amazon_fresh",
+            ]
+        )
 
 
 @pytest.mark.parametrize(

--- a/receipt_dynamo/tests/integration/test_merchant_truth_v1_live.py
+++ b/receipt_dynamo/tests/integration/test_merchant_truth_v1_live.py
@@ -31,6 +31,7 @@ from receipt_dynamo.migrations.merchant_truth_v1 import (
 from receipt_dynamo.migrations.merchant_truth_v1_live import (
     PROD_TABLE_NAME,
     bootstrap_gate_results,
+    filter_payloads,
     run_live_mint,
     validate_live_table,
     verify_live_against_dry_run,
@@ -141,13 +142,13 @@ def catalog_item(slug: str) -> dict[str, Any]:
     }
 
 
-def built_payloads():
+def built_payloads(git_sha: str = GIT_SHA, generated_at: str = NOW):
     return build_v1_payloads(
         profile_document(),
         FakeSource(),  # type: ignore[arg-type]
         profiles_source_path="scripts/merchant_profiles.json",
-        git_sha=GIT_SHA,
-        generated_at=NOW,
+        git_sha=git_sha,
+        generated_at=generated_at,
     )
 
 
@@ -308,6 +309,113 @@ def test_unmapped_leaf_fails_before_any_payload_is_built() -> None:
         )
 
 
+OTHER_GIT_SHA = "b" * 40
+LATER = "2026-07-21T16:00:00+00:00"
+
+
+def live(client, payloads, payload_dir, generated_at: str = NOW):
+    return run_live_mint(
+        client,
+        payloads,
+        table_name=client.table_name,
+        gate_results=gate_results(payload_dir),
+        generated_at=generated_at,
+        explicit_table=True,
+    )
+
+
+def test_full_replay_skips_sealed_merchants_instead_of_aborting(
+    dynamodb_table: str, tmp_path: Path
+) -> None:
+    """Reviewer finding on #1205: run_id is git-sha-dependent, so a replay
+    under a newer HEAD used to raise MerchantTruthConflictError on the
+    first already-sealed merchant. It must skip them and mint the rest."""
+    client = DynamoClient(dynamodb_table)
+    payloads_a, _ = built_payloads()
+    live(client, filter_payloads(payloads_a, ["cvs", "vons"]), tmp_path)
+
+    payloads_b, _ = built_payloads(git_sha=OTHER_GIT_SHA)
+    results = live(client, payloads_b, tmp_path)
+
+    by_action: dict[str, set[str]] = {}
+    for result in results:
+        by_action.setdefault(result.action, set()).add(result.slug)
+    assert by_action["SKIPPED_SEALED"] == {"cvs", "vons"}
+    assert len(by_action["MINTED_SEALED"]) == 11
+    assert by_action["EXCLUDED"] == set(EXPECTED_MISSING_FONT_SLUGS)
+    assert "CONFLICT_SEALED" not in by_action
+    skipped = next(r for r in results if r.action == "SKIPPED_SEALED")
+    assert (
+        f"SKIPPED (already sealed, bundle={skipped.bundle_hash[:12]})"
+        in skipped.report_line
+    )
+    # Every unblocked merchant ends up sealed and read-back-verifiable.
+    payload_dir = tmp_path / "payloads"
+    payloads_c, crosswalk = built_payloads(git_sha=OTHER_GIT_SHA)
+    write_dry_run_payloads(
+        payload_dir,
+        payloads_c,
+        crosswalk,
+        generated_at=NOW,
+        git_sha=OTHER_GIT_SHA,
+    )
+    verify_results = verify_live_against_dry_run(
+        client,
+        payload_dir,
+        sorted(p.slug for p in payloads_c if not p.blockers),
+        work_dir=tmp_path / "_live_verify",
+    )
+    assert all(result.ok for result in verify_results)
+
+
+def test_sealed_bundle_differing_from_source_reports_conflict(
+    dynamodb_table: str, tmp_path: Path
+) -> None:
+    client = DynamoClient(dynamodb_table)
+    payloads_a, _ = built_payloads()
+    live(client, filter_payloads(payloads_a, ["cvs"]), tmp_path)
+    sealed = client.get_merchant_truth_manifest("cvs", 1, consistent_read=True)
+    assert sealed is not None
+
+    # A later generated_at changes catalog_snapshot.as_of, so the source
+    # would now produce a different bundle: drift, not an idempotent skip.
+    payloads_b, _ = built_payloads(generated_at=LATER)
+    results = live(
+        client,
+        filter_payloads(payloads_b, ["cvs", "vons"]),
+        tmp_path,
+        generated_at=LATER,
+    )
+
+    conflict = next(r for r in results if r.slug == "cvs")
+    assert conflict.action == "CONFLICT_SEALED"
+    assert conflict.bundle_hash == sealed.bundle_hash
+    assert conflict.source_bundle_hash != sealed.bundle_hash
+    assert (
+        "CONFLICT (sealed bundle differs from source)" in conflict.report_line
+    )
+    # The conflict did not write: the sealed manifest is untouched.
+    after = client.get_merchant_truth_manifest("cvs", 1, consistent_read=True)
+    assert after is not None
+    assert after.bundle_hash == sealed.bundle_hash
+    assert after.sealed_at == sealed.sealed_at
+    # And the loop continued past the conflict.
+    minted = next(r for r in results if r.slug == "vons")
+    assert minted.action == "MINTED_SEALED"
+
+
+def test_filter_payloads_validates_slugs_against_the_payload_set() -> None:
+    payloads, _ = built_payloads()
+
+    filtered = filter_payloads(payloads, ["vons", "cvs"])
+    assert [p.slug for p in filtered] == ["cvs", "vons"]
+
+    with pytest.raises(ValueError, match="unknown merchant slugs: wallmart"):
+        filter_payloads(payloads, ["cvs", "wallmart"])
+    with pytest.raises(ValueError, match="contains no slugs"):
+        filter_payloads(payloads, [" ", ""])
+
+
 def _create_dev_named_table() -> None:
     boto3.client("dynamodb", region_name="us-east-1").create_table(
         TableName=DEV_TABLE_NAME,
@@ -452,6 +560,106 @@ def test_script_default_stays_dry_run_and_write_free(
         ExpressionAttributeValues={":type": {"S": "MERCHANT_TRUTH_MANIFEST"}},
     )
     assert truth_rows["Items"] == []
+
+
+def test_script_merchants_filter_applies_to_dry_run(
+    seeded_dev_environment: Path, tmp_path: Path, capsys
+) -> None:
+    output_dir = tmp_path / "payloads"
+
+    exit_code = _script_main(
+        [
+            "--profiles",
+            str(seeded_dev_environment),
+            "--output-dir",
+            str(output_dir),
+            "--git-sha",
+            GIT_SHA,
+            "--generated-at",
+            NOW,
+            "--merchants",
+            "cvs,vons",
+        ]
+    )
+
+    captured = capsys.readouterr().out
+    assert exit_code == 0
+    assert "DRY RUN: wrote 2 merchant payloads" in captured
+    payload_files = sorted(
+        p.name for p in output_dir.glob("*.json") if not p.name.startswith("_")
+    )
+    assert payload_files == ["cvs.json", "vons.json"]
+
+
+def test_script_merchants_filter_rejects_unknown_slug(
+    seeded_dev_environment: Path, tmp_path: Path
+) -> None:
+    with pytest.raises(ValueError, match="unknown merchant slugs"):
+        _script_main(
+            [
+                "--profiles",
+                str(seeded_dev_environment),
+                "--output-dir",
+                str(tmp_path / "payloads"),
+                "--git-sha",
+                GIT_SHA,
+                "--generated-at",
+                NOW,
+                "--merchants",
+                "cvs,wallmart",
+                "--live",
+            ]
+        )
+
+
+def test_script_replay_after_partial_mint_skips_and_verifies(
+    seeded_dev_environment: Path, tmp_path: Path, capsys
+) -> None:
+    """End-to-end reviewer scenario: partial mint at one git SHA, then a
+    full --live --verify replay at a different SHA skips the sealed
+    merchants, mints the rest, and exits 0."""
+    first = _script_main(
+        [
+            "--profiles",
+            str(seeded_dev_environment),
+            "--output-dir",
+            str(tmp_path / "payloads-1"),
+            "--git-sha",
+            GIT_SHA,
+            "--generated-at",
+            NOW,
+            "--merchants",
+            "cvs,vons",
+            "--live",
+            "--verify",
+        ]
+    )
+    assert first == 0
+    capsys.readouterr()
+
+    exit_code = _script_main(
+        [
+            "--profiles",
+            str(seeded_dev_environment),
+            "--output-dir",
+            str(tmp_path / "payloads-2"),
+            "--git-sha",
+            OTHER_GIT_SHA,
+            "--generated-at",
+            NOW,
+            "--live",
+            "--verify",
+        ]
+    )
+
+    captured = capsys.readouterr().out
+    assert exit_code == 0
+    assert captured.count("MINTED+SEALED v1") == 11
+    assert captured.count("SKIPPED (already sealed, bundle=") == 2
+    assert captured.count("EXCLUDED (asset-blocked)") == 3
+    assert "CONFLICT" not in captured
+    assert "skipped 2 already-sealed" in captured
+    assert "VERIFY OK: 13 live bundles byte-match" in captured
 
 
 @pytest.mark.parametrize(

--- a/scripts/migrate_merchant_truth_v1.py
+++ b/scripts/migrate_merchant_truth_v1.py
@@ -29,6 +29,7 @@ from receipt_dynamo.migrations.merchant_truth_v1 import (
 )
 from receipt_dynamo.migrations.merchant_truth_v1_live import (
     bootstrap_gate_results,
+    filter_payloads,
     format_live_banner,
     run_live_mint,
     validate_live_table,
@@ -64,6 +65,14 @@ def main(argv: list[str] | None = None) -> int:
             f"DynamoDB table (default: exact dev table {DEV_TABLE_NAME}). "
             "Live mode refuses any other table unless passed explicitly; "
             "the prod table is refused unconditionally."
+        ),
+    )
+    parser.add_argument(
+        "--merchants",
+        help=(
+            "Comma-separated merchant slugs to restrict the run to; "
+            "validated against the payload set and applied to dry-run, "
+            "--live, and --verify alike."
         ),
     )
     parser.add_argument("--region", default="us-east-1")
@@ -113,6 +122,8 @@ def main(argv: list[str] | None = None) -> int:
         generated_at=generated_at,
         stylemap_root=args.stylemap_root,
     )
+    if args.merchants:
+        payloads = filter_payloads(payloads, args.merchants.split(","))
     write_dry_run_payloads(
         args.output_dir,
         payloads,
@@ -147,8 +158,12 @@ def main(argv: list[str] | None = None) -> int:
             print(result.report_line)
         minted = [r for r in results if r.action == "MINTED_SEALED"]
         excluded = [r for r in results if r.action == "EXCLUDED"]
+        skipped = [r for r in results if r.action == "SKIPPED_SEALED"]
+        conflicts = [r for r in results if r.action == "CONFLICT_SEALED"]
         print(
             f"LIVE: minted+sealed {len(minted)} merchants on {table_name}; "
+            f"skipped {len(skipped)} already-sealed; "
+            f"{len(conflicts)} sealed-bundle conflicts; "
             f"excluded {len(excluded)} asset-blocked merchants; dry-run "
             f"payloads written to {args.output_dir}"
         )

--- a/scripts/migrate_merchant_truth_v1.py
+++ b/scripts/migrate_merchant_truth_v1.py
@@ -75,6 +75,16 @@ def main(argv: list[str] | None = None) -> int:
             "--live, and --verify alike."
         ),
     )
+    parser.add_argument(
+        "--expected-missing-slugs",
+        default=None,
+        help=(
+            "Comma-separated slugs expected to have NO MerchantFont row "
+            "(default: the historical asset-blocked trio). Pass an empty "
+            'string ("") once all fonts are published. Coverage differing '
+            "from this expectation hard-fails before anything is written."
+        ),
+    )
     parser.add_argument("--region", default="us-east-1")
     parser.add_argument("--git-sha")
     parser.add_argument("--generated-at")
@@ -114,6 +124,13 @@ def main(argv: list[str] | None = None) -> int:
         boto3.client("s3", region_name=args.region),
         table_name,
     )
+    expected_missing = None
+    if args.expected_missing_slugs is not None:
+        expected_missing = frozenset(
+            slug.strip()
+            for slug in args.expected_missing_slugs.split(",")
+            if slug.strip()
+        )
     payloads, crosswalk = build_v1_payloads(
         document,
         source,
@@ -121,6 +138,7 @@ def main(argv: list[str] | None = None) -> int:
         git_sha=git_sha,
         generated_at=generated_at,
         stylemap_root=args.stylemap_root,
+        expected_missing_slugs=expected_missing,
     )
     if args.merchants:
         payloads = filter_payloads(payloads, args.merchants.split(","))


### PR DESCRIPTION
## Why

Reviewer finding on #1205 (W7 asset landing): `run_live_mint` replays ALL unblocked merchants, and the mint `run_id` is git-sha-dependent (`merchant-truth-v1-{slug}-{git_sha[:12]}`). The 13 existing dev seals were minted at `eb9d3617122b`, so under any newer HEAD the first already-sealed merchant raises `MerchantTruthConflictError` mid-loop, unguarded — the W7 post-publish mint could not run. Reproduced on origin/main under moto: partial mint at SHA `a…`, full replay at SHA `b…` → `MerchantTruthConflictError: version already belongs to a different mint`.

## What

1. **Skip-if-sealed guard** in `run_live_mint`: before minting each merchant, a strong `get_merchant_truth_manifest` point-read (added to the `MerchantTruthWriter` protocol).
   - SEALED with the **identical** bundle hash the source would produce → `SKIPPED (already sealed, bundle=<hash12>)` report line, loop continues. Full replay is now idempotent regardless of git SHA.
   - SEALED with a **different** bundle hash → `CONFLICT (sealed bundle differs from source)` with both hashes, **no write**, loop continues — a drift signal, never a skip and never an overwrite. With `--verify` the conflict merchant fails byte-comparison, so the run exits nonzero.
2. **`--merchants slug1,slug2`** on `scripts/migrate_merchant_truth_v1.py` (`filter_payloads` helper): validated against the payload set — an unknown slug fails closed before any file is written or row minted — and applies to dry-run, `--live`, and `--verify` alike. This is the targeting tool for the W7 post-publish mint of the 3 previously blocked merchants.

## Tests (moto; live-file suite 11 → 17)

- Full replay over 2 sealed + 11 new: mints only the new ones, 2 `SKIPPED_SEALED`, no conflict, all 13 read-back-verify OK (the exact abort scenario, now green; confirmed red on origin/main).
- Sealed-bundle drift (later `generated_at` ⇒ different `catalog_snapshot.as_of` ⇒ different bundle): reports `CONFLICT_SEALED`, sealed manifest untouched (hash + sealed_at unchanged), and the loop continues to mint the next merchant.
- `filter_payloads`: unknown slug and empty list fail closed with clear messages.
- Script level: dry-run with `--merchants cvs,vons` writes only those payload files; unknown slug rejected before any write; end-to-end partial mint → full `--live --verify` replay at a different SHA exits 0 with `11 MINTED+SEALED / 2 SKIPPED / 3 EXCLUDED / VERIFY OK: 13`.
- Full merchant-truth suite: **75 passed**; black/isort clean.

## Publish-day expectation is now declarative (`--expected-missing-slugs`)

`build_v1_payloads` hard-pins which merchants are expected to have NO MerchantFont row. That expectation is now a per-run declaration instead of a code constant: `--expected-missing-slugs` takes a comma list (default unchanged: `amazon_fresh,dollar_tree,smith_s`), and `--expected-missing-slugs ""` states that every merchant is published. **The drift assertion keeps its spirit**: coverage differing from the *stated* expectation still hard-fails before anything is written — the flag is declarative, not a bypass (tested: a wrong declared expectation fails identically).

## Staged owner command for the W7 post-publish mint (zero code changes)

Once the 3 vaulted fonts (#1205) are published as MerchantFont rows in dev:

```bash
python scripts/migrate_merchant_truth_v1.py \
  --profiles scripts/merchant_profiles.json \
  --output-dir ~/section_label_kickoff/truth_v1_payloads \
  --merchants amazon_fresh,dollar_tree,smith_s \
  --expected-missing-slugs "" \
  --live --verify
```

Expected: banner (table / 3 / SHA), 3 `MINTED+SEALED v1`, 0 EXCLUDED, `VERIFY OK: 3`, exit 0. A full no-filter replay is also safe: the 13 existing seals report as `SKIPPED (already sealed, …)`.

Publish-day moto coverage: with all 16 fonts present, the default expectation hard-fails (`MerchantFont coverage changed`); the staged command above mints+seals the trio end-to-end with `VERIFY OK: 3`; a wrong declared expectation still hard-fails. Full merchant-truth suite: **78 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BeLcSviHL5vDgS3zTSMbsq
