### PR TITLE
[mcp] Lazy Chroma init for local stdio receipt-tools (W-B)

### DIFF
--- a/infra/mcp_server_lambda/lambdas/receipt_mcp_server_server.py
+++ b/infra/mcp_server_lambda/lambdas/receipt_mcp_server_server.py
@@ -13,8 +13,16 @@ Usage:
     uv run scripts/receipt_mcp_server.py
 
 Environment:
-    Requires Pulumi config for DynamoDB and ChromaDB credentials.
+    Requires Pulumi config for DynamoDB credentials.
     Set PORTFOLIO_ENV=dev or PORTFOLIO_ENV=prod
+
+    Chroma Cloud credentials are OPTIONAL: without them the server still
+    starts and serves every Dynamo-backed tool; only the vector-search
+    tools (search_receipts, list_all_receipts, search_product_lines,
+    validate_word_similarity) return a structured error at call time.
+    CHROMA_CLOUD_ENABLED / CHROMA_CLOUD_API_KEY / CHROMA_CLOUD_TENANT /
+    CHROMA_CLOUD_DATABASE environment variables override Pulumi config
+    (e.g. CHROMA_CLOUD_ENABLED=false runs Dynamo-only).
 """
 
 import asyncio
@@ -43,24 +51,41 @@ from mcp.types import ImageContent, TextContent, Tool
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-# Global clients (initialized on startup)
+# Global clients (initialized lazily on first use)
 _dynamo_client = None
 _chroma_client = None
 _embed_fn = None
+_config = None
+
+# Tools that require Chroma Cloud (vector/embedding search). Every other
+# tool is served from DynamoDB / Lambda / Athena and must keep working
+# when Chroma Cloud is not configured.
+CHROMA_TOOLS = frozenset(
+    {
+        "search_receipts",
+        "list_all_receipts",
+        "search_product_lines",
+        "validate_word_similarity",
+    }
+)
+
+CHROMA_NOT_CONFIGURED_MESSAGE = (
+    "Chroma Cloud not configured: set CHROMA_CLOUD_ENABLED=true and "
+    "CHROMA_CLOUD_API_KEY (plus CHROMA_CLOUD_TENANT / "
+    "CHROMA_CLOUD_DATABASE) in Pulumi config or the environment to "
+    "enable semantic search."
+)
 
 
-def get_clients():
-    """Get or initialize database clients."""
-    global _dynamo_client, _chroma_client, _embed_fn
+class ChromaNotConfiguredError(RuntimeError):
+    """Raised when a Chroma-backed tool is called without Chroma Cloud creds."""
 
-    if _dynamo_client is None:
-        from receipt_agent.clients.factory import (
-            create_chroma_client,
-            create_dynamo_client,
-            create_embed_fn,
-        )
-        from receipt_chroma import ChromaClient
 
+def _load_config():
+    """Load and cache config (Lambda env vars first, Pulumi fallback)."""
+    global _config
+
+    if _config is None:
         env = os.environ.get("PORTFOLIO_ENV", "dev")
         logger.info("Loading %s environment...", env)
 
@@ -88,36 +113,85 @@ def get_clients():
                 normalized_key = key.replace("portfolio:", "").lower().replace("-", "_")
                 config[normalized_key] = value
 
+        # Environment variables override the merged config for the Chroma
+        # keys, so the server can run Dynamo-only (CHROMA_CLOUD_ENABLED=false)
+        # or be pointed at Chroma without Pulumi.
+        for env_key in (
+            "CHROMA_CLOUD_ENABLED",
+            "CHROMA_CLOUD_API_KEY",
+            "CHROMA_CLOUD_TENANT",
+            "CHROMA_CLOUD_DATABASE",
+        ):
+            if os.environ.get(env_key) is not None:
+                config[env_key.lower()] = os.environ[env_key]
+
         # Set up API keys
         if config.get("openai_api_key"):
             os.environ["RECEIPT_AGENT_OPENAI_API_KEY"] = config["openai_api_key"]
 
-        # Create DynamoDB client
+        _config = config
+
+    return _config
+
+
+def chroma_is_configured(config) -> bool:
+    """True when Chroma Cloud is enabled and an API key is present."""
+    enabled = str(config.get("chroma_cloud_enabled", "false")).lower() == "true"
+    return enabled and bool(config.get("chroma_cloud_api_key"))
+
+
+def get_dynamo_client():
+    """Get or initialize the DynamoDB client (no Chroma required)."""
+    global _dynamo_client
+
+    if _dynamo_client is None:
+        from receipt_agent.clients.factory import create_dynamo_client
+
+        config = _load_config()
         _dynamo_client = create_dynamo_client(table_name=config["dynamodb_table_name"])
+        logger.info("DynamoDB client initialized")
 
-        # Create ChromaDB client
-        chroma_cloud_api_key = config.get("chroma_cloud_api_key")
-        chroma_cloud_enabled = (
-            config.get("chroma_cloud_enabled", "false").lower() == "true"
-        )
+    return _dynamo_client
 
-        if not chroma_cloud_enabled or not chroma_cloud_api_key:
-            raise ValueError(
-                "Chroma Cloud is required. Set chroma_cloud_enabled=true and "
-                "chroma_cloud_api_key in Pulumi config."
-            )
+
+def get_chroma_clients():
+    """Get or initialize the Chroma Cloud client and embedding function.
+
+    Raises ChromaNotConfiguredError when Chroma Cloud credentials are
+    absent, so Chroma-backed tools fail cleanly at call time instead of
+    the server crashing at startup.
+    """
+    global _chroma_client, _embed_fn
+
+    if _chroma_client is None:
+        from receipt_agent.clients.factory import create_embed_fn
+        from receipt_chroma import ChromaClient
+
+        config = _load_config()
+        if not chroma_is_configured(config):
+            raise ChromaNotConfiguredError(CHROMA_NOT_CONFIGURED_MESSAGE)
 
         _chroma_client = ChromaClient(
-            cloud_api_key=chroma_cloud_api_key,
+            cloud_api_key=config.get("chroma_cloud_api_key"),
             cloud_tenant=config.get("chroma_cloud_tenant"),
             cloud_database=config.get("chroma_cloud_database"),
             mode="read",
         )
-
         _embed_fn = create_embed_fn()
-        logger.info("Clients initialized successfully")
+        logger.info("Chroma clients initialized")
 
-    return _dynamo_client, _chroma_client, _embed_fn
+    return _chroma_client, _embed_fn
+
+
+def get_clients():
+    """Get or initialize all database clients (requires Chroma Cloud).
+
+    Backwards-compatible wrapper; prefer get_dynamo_client() /
+    get_chroma_clients() so Dynamo-only tools work without Chroma creds.
+    """
+    dynamo_client = get_dynamo_client()
+    chroma_client, embed_fn = get_chroma_clients()
+    return dynamo_client, chroma_client, embed_fn
 
 
 # Create MCP server
@@ -1821,7 +1895,11 @@ def _fetch_mcp_preview(url: str) -> bytes:
 async def call_tool(name: str, arguments: dict) -> list[TextContent | ImageContent]:
     """Handle tool calls."""
     try:
-        dynamo_client, chroma_client, embed_fn = get_clients()
+        dynamo_client = get_dynamo_client()
+        if name in CHROMA_TOOLS:
+            chroma_client, embed_fn = get_chroma_clients()
+        else:
+            chroma_client = embed_fn = None
 
         if name == "search_receipts":
             result = await search_receipts_impl(
@@ -2122,6 +2200,20 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent | ImageConte
                     )
         return content
 
+    except ChromaNotConfiguredError as e:
+        logger.warning("Chroma tool %r unavailable: %s", name, e)
+        return [
+            TextContent(
+                type="text",
+                text=json.dumps(
+                    {
+                        "error": str(e),
+                        "error_type": "chroma_not_configured",
+                        "tool": name,
+                    }
+                ),
+            )
+        ]
     except Exception as e:
         logger.exception("Tool error")
         return [TextContent(type="text", text=json.dumps({"error": str(e)}))]
@@ -4926,11 +5018,23 @@ async def main():
     """Run the MCP server."""
     logger.info("Starting Receipt MCP Server...")
 
-    # Pre-initialize clients
+    # Pre-initialize clients (Chroma is optional: Dynamo-only is fine)
     try:
-        get_clients()
+        get_dynamo_client()
     except Exception as e:
-        logger.error("Failed to initialize clients: %s", e)
+        logger.error("Failed to initialize DynamoDB client: %s", e)
+        # Continue anyway - will retry on first tool call
+    try:
+        get_chroma_clients()
+    except ChromaNotConfiguredError as e:
+        logger.warning(
+            "%s Chroma-backed tools (%s) are disabled; Dynamo-backed "
+            "tools remain available.",
+            e,
+            ", ".join(sorted(CHROMA_TOOLS)),
+        )
+    except Exception as e:
+        logger.error("Failed to initialize Chroma clients: %s", e)
         # Continue anyway - will retry on first tool call
 
     async with stdio_server() as (read_stream, write_stream):

--- a/scripts/receipt_mcp_server.py
+++ b/scripts/receipt_mcp_server.py
@@ -13,8 +13,16 @@ Usage:
     uv run scripts/receipt_mcp_server.py
 
 Environment:
-    Requires Pulumi config for DynamoDB and ChromaDB credentials.
+    Requires Pulumi config for DynamoDB credentials.
     Set PORTFOLIO_ENV=dev or PORTFOLIO_ENV=prod
+
+    Chroma Cloud credentials are OPTIONAL: without them the server still
+    starts and serves every Dynamo-backed tool; only the vector-search
+    tools (search_receipts, list_all_receipts, search_product_lines,
+    validate_word_similarity) return a structured error at call time.
+    CHROMA_CLOUD_ENABLED / CHROMA_CLOUD_API_KEY / CHROMA_CLOUD_TENANT /
+    CHROMA_CLOUD_DATABASE environment variables override Pulumi config
+    (e.g. CHROMA_CLOUD_ENABLED=false runs Dynamo-only).
 """
 
 import asyncio
@@ -43,23 +51,41 @@ from mcp.types import ImageContent, TextContent, Tool
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-# Global clients (initialized on startup)
+# Global clients (initialized lazily on first use)
 _dynamo_client = None
 _chroma_client = None
 _embed_fn = None
+_config = None
+
+# Tools that require Chroma Cloud (vector/embedding search). Every other
+# tool is served from DynamoDB / Lambda / Athena and must keep working
+# when Chroma Cloud is not configured.
+CHROMA_TOOLS = frozenset(
+    {
+        "search_receipts",
+        "list_all_receipts",
+        "search_product_lines",
+        "validate_word_similarity",
+    }
+)
+
+CHROMA_NOT_CONFIGURED_MESSAGE = (
+    "Chroma Cloud not configured: set CHROMA_CLOUD_ENABLED=true and "
+    "CHROMA_CLOUD_API_KEY (plus CHROMA_CLOUD_TENANT / "
+    "CHROMA_CLOUD_DATABASE) in Pulumi config or the environment to "
+    "enable semantic search."
+)
 
 
-def get_clients():
-    """Get or initialize database clients."""
-    global _dynamo_client, _chroma_client, _embed_fn
+class ChromaNotConfiguredError(RuntimeError):
+    """Raised when a Chroma-backed tool is called without Chroma Cloud creds."""
 
-    if _dynamo_client is None:
-        from receipt_agent.clients.factory import (
-            create_chroma_client,
-            create_dynamo_client,
-            create_embed_fn,
-        )
-        from receipt_chroma import ChromaClient
+
+def _load_config():
+    """Load and cache Pulumi config + secrets (env vars override Chroma keys)."""
+    global _config
+
+    if _config is None:
         from receipt_dynamo.data._pulumi import load_env, load_secrets
 
         env = os.environ.get("PORTFOLIO_ENV", "dev")
@@ -73,36 +99,85 @@ def get_clients():
             normalized_key = key.replace("portfolio:", "").lower().replace("-", "_")
             config[normalized_key] = value
 
+        # Environment variables override Pulumi config for the Chroma keys,
+        # so the server can run Dynamo-only (CHROMA_CLOUD_ENABLED=false) or
+        # be pointed at Chroma without Pulumi.
+        for env_key in (
+            "CHROMA_CLOUD_ENABLED",
+            "CHROMA_CLOUD_API_KEY",
+            "CHROMA_CLOUD_TENANT",
+            "CHROMA_CLOUD_DATABASE",
+        ):
+            if os.environ.get(env_key) is not None:
+                config[env_key.lower()] = os.environ[env_key]
+
         # Set up API keys
         if config.get("openai_api_key"):
             os.environ["RECEIPT_AGENT_OPENAI_API_KEY"] = config["openai_api_key"]
 
-        # Create DynamoDB client
+        _config = config
+
+    return _config
+
+
+def chroma_is_configured(config) -> bool:
+    """True when Chroma Cloud is enabled and an API key is present."""
+    enabled = str(config.get("chroma_cloud_enabled", "false")).lower() == "true"
+    return enabled and bool(config.get("chroma_cloud_api_key"))
+
+
+def get_dynamo_client():
+    """Get or initialize the DynamoDB client (no Chroma required)."""
+    global _dynamo_client
+
+    if _dynamo_client is None:
+        from receipt_agent.clients.factory import create_dynamo_client
+
+        config = _load_config()
         _dynamo_client = create_dynamo_client(table_name=config["dynamodb_table_name"])
+        logger.info("DynamoDB client initialized")
 
-        # Create ChromaDB client
-        chroma_cloud_api_key = config.get("chroma_cloud_api_key")
-        chroma_cloud_enabled = (
-            config.get("chroma_cloud_enabled", "false").lower() == "true"
-        )
+    return _dynamo_client
 
-        if not chroma_cloud_enabled or not chroma_cloud_api_key:
-            raise ValueError(
-                "Chroma Cloud is required. Set chroma_cloud_enabled=true and "
-                "chroma_cloud_api_key in Pulumi config."
-            )
+
+def get_chroma_clients():
+    """Get or initialize the Chroma Cloud client and embedding function.
+
+    Raises ChromaNotConfiguredError when Chroma Cloud credentials are
+    absent, so Chroma-backed tools fail cleanly at call time instead of
+    the server crashing at startup.
+    """
+    global _chroma_client, _embed_fn
+
+    if _chroma_client is None:
+        from receipt_agent.clients.factory import create_embed_fn
+        from receipt_chroma import ChromaClient
+
+        config = _load_config()
+        if not chroma_is_configured(config):
+            raise ChromaNotConfiguredError(CHROMA_NOT_CONFIGURED_MESSAGE)
 
         _chroma_client = ChromaClient(
-            cloud_api_key=chroma_cloud_api_key,
+            cloud_api_key=config.get("chroma_cloud_api_key"),
             cloud_tenant=config.get("chroma_cloud_tenant"),
             cloud_database=config.get("chroma_cloud_database"),
             mode="read",
         )
-
         _embed_fn = create_embed_fn()
-        logger.info("Clients initialized successfully")
+        logger.info("Chroma clients initialized")
 
-    return _dynamo_client, _chroma_client, _embed_fn
+    return _chroma_client, _embed_fn
+
+
+def get_clients():
+    """Get or initialize all database clients (requires Chroma Cloud).
+
+    Backwards-compatible wrapper; prefer get_dynamo_client() /
+    get_chroma_clients() so Dynamo-only tools work without Chroma creds.
+    """
+    dynamo_client = get_dynamo_client()
+    chroma_client, embed_fn = get_chroma_clients()
+    return dynamo_client, chroma_client, embed_fn
 
 
 # Create MCP server
@@ -1806,7 +1881,11 @@ def _fetch_mcp_preview(url: str) -> bytes:
 async def call_tool(name: str, arguments: dict) -> list[TextContent | ImageContent]:
     """Handle tool calls."""
     try:
-        dynamo_client, chroma_client, embed_fn = get_clients()
+        dynamo_client = get_dynamo_client()
+        if name in CHROMA_TOOLS:
+            chroma_client, embed_fn = get_chroma_clients()
+        else:
+            chroma_client = embed_fn = None
 
         if name == "search_receipts":
             result = await search_receipts_impl(
@@ -2107,6 +2186,20 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent | ImageConte
                     )
         return content
 
+    except ChromaNotConfiguredError as e:
+        logger.warning("Chroma tool %r unavailable: %s", name, e)
+        return [
+            TextContent(
+                type="text",
+                text=json.dumps(
+                    {
+                        "error": str(e),
+                        "error_type": "chroma_not_configured",
+                        "tool": name,
+                    }
+                ),
+            )
+        ]
     except Exception as e:
         logger.exception("Tool error")
         return [TextContent(type="text", text=json.dumps({"error": str(e)}))]
@@ -4911,11 +5004,23 @@ async def main():
     """Run the MCP server."""
     logger.info("Starting Receipt MCP Server...")
 
-    # Pre-initialize clients
+    # Pre-initialize clients (Chroma is optional: Dynamo-only is fine)
     try:
-        get_clients()
+        get_dynamo_client()
     except Exception as e:
-        logger.error("Failed to initialize clients: %s", e)
+        logger.error("Failed to initialize DynamoDB client: %s", e)
+        # Continue anyway - will retry on first tool call
+    try:
+        get_chroma_clients()
+    except ChromaNotConfiguredError as e:
+        logger.warning(
+            "%s Chroma-backed tools (%s) are disabled; Dynamo-backed "
+            "tools remain available.",
+            e,
+            ", ".join(sorted(CHROMA_TOOLS)),
+        )
+    except Exception as e:
+        logger.error("Failed to initialize Chroma clients: %s", e)
         # Continue anyway - will retry on first tool call
 
     async with stdio_server() as (read_stream, write_stream):

--- a/tests/test_receipt_mcp_lazy_chroma.py
+++ b/tests/test_receipt_mcp_lazy_chroma.py
@@ -1,0 +1,285 @@
+"""Tests for lazy Chroma initialization on both MCP server implementations.
+
+The two servers (stdio `scripts/receipt_mcp_server.py` and the Lambda
+`infra/mcp_server_lambda/lambdas/receipt_mcp_server_server.py`) must start and
+serve every Dynamo-backed tool with NO Chroma Cloud credentials; only the
+vector-search tools (CHROMA_TOOLS) may fail, and they must fail at CALL time
+with a structured `chroma_not_configured` error instead of crashing the
+server. When Chroma IS configured, behavior is unchanged.
+
+No network: Dynamo/Chroma clients are stubbed, and the factory modules are
+replaced in sys.modules where construction is exercised.
+"""
+
+import asyncio
+import json
+import sys
+import types
+
+import pytest
+
+from test_receipt_mcp_section_tools import SERVER_FILES, _load_module
+
+EXPECTED_CHROMA_TOOLS = {
+    "search_receipts",
+    "list_all_receipts",
+    "search_product_lines",
+    "validate_word_similarity",
+}
+
+CONFIG_WITHOUT_CHROMA = {
+    "dynamodb_table_name": "ReceiptsTable-test",
+}
+
+CONFIG_WITH_CHROMA = {
+    "dynamodb_table_name": "ReceiptsTable-test",
+    "chroma_cloud_enabled": "true",
+    "chroma_cloud_api_key": "ck-test-key",
+    "chroma_cloud_tenant": "tenant-1",
+    "chroma_cloud_database": "receipt_test",
+}
+
+
+class _StubDynamoClient:
+    """Minimal Dynamo client for the list_merchants happy path."""
+
+    def list_receipt_places(self, limit, last_evaluated_key=None):
+        place = types.SimpleNamespace(merchant_name="Costco Wholesale")
+        return [place], None
+
+
+class _FakeChromaClient:
+    """Records constructor kwargs; never touches the network."""
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+
+def _install_client_factories(monkeypatch, module):
+    """Replace receipt_chroma / receipt_agent factory imports with fakes.
+
+    The server imports these lazily inside get_dynamo_client /
+    get_chroma_clients, so sys.modules injection is enough.
+    """
+    chroma_mod = types.ModuleType("receipt_chroma")
+    chroma_mod.ChromaClient = _FakeChromaClient
+
+    factory_mod = types.ModuleType("receipt_agent.clients.factory")
+    factory_mod.create_dynamo_client = lambda table_name: types.SimpleNamespace(
+        table_name=table_name
+    )
+    factory_mod.create_embed_fn = lambda: (lambda texts: [[0.0] for _ in texts])
+
+    agent_mod = types.ModuleType("receipt_agent")
+    clients_mod = types.ModuleType("receipt_agent.clients")
+    agent_mod.clients = clients_mod
+    clients_mod.factory = factory_mod
+
+    monkeypatch.setitem(sys.modules, "receipt_chroma", chroma_mod)
+    monkeypatch.setitem(sys.modules, "receipt_agent", agent_mod)
+    monkeypatch.setitem(sys.modules, "receipt_agent.clients", clients_mod)
+    monkeypatch.setitem(
+        sys.modules, "receipt_agent.clients.factory", factory_mod
+    )
+
+
+def _tool_result(module, name, arguments):
+    content = asyncio.run(module.call_tool(name, arguments))
+    assert content, "call_tool returned no content"
+    return json.loads(content[0].text)
+
+
+# ---------------------------------------------------------------------------
+# Tool classification
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("label", sorted(SERVER_FILES))
+def test_chroma_tools_set_matches_expected(label):
+    module = _load_module(label, SERVER_FILES[label])
+    assert set(module.CHROMA_TOOLS) == EXPECTED_CHROMA_TOOLS
+
+    # Every CHROMA_TOOL is a real registered tool.
+    tool_names = {t.name for t in asyncio.run(module.list_tools())}
+    assert EXPECTED_CHROMA_TOOLS <= tool_names
+
+
+def test_both_servers_agree_on_chroma_tools():
+    stdio = _load_module("stdio", SERVER_FILES["stdio"])
+    lam = _load_module("lambda", SERVER_FILES["lambda"])
+    assert set(stdio.CHROMA_TOOLS) == set(lam.CHROMA_TOOLS)
+
+
+# ---------------------------------------------------------------------------
+# Startup / init without Chroma env
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("label", sorted(SERVER_FILES))
+def test_dynamo_client_initializes_without_chroma_config(label, monkeypatch):
+    module = _load_module(label, SERVER_FILES[label])
+    _install_client_factories(monkeypatch, module)
+    module._config = dict(CONFIG_WITHOUT_CHROMA)
+
+    client = module.get_dynamo_client()
+    assert client.table_name == "ReceiptsTable-test"
+    # Cached for subsequent calls.
+    assert module.get_dynamo_client() is client
+
+
+@pytest.mark.parametrize("label", sorted(SERVER_FILES))
+def test_get_chroma_clients_raises_structured_error(label, monkeypatch):
+    module = _load_module(label, SERVER_FILES[label])
+    _install_client_factories(monkeypatch, module)
+    module._config = dict(CONFIG_WITHOUT_CHROMA)
+
+    with pytest.raises(module.ChromaNotConfiguredError) as excinfo:
+        module.get_chroma_clients()
+    assert "Chroma Cloud not configured" in str(excinfo.value)
+    assert "CHROMA_CLOUD_API_KEY" in str(excinfo.value)
+
+
+@pytest.mark.parametrize("label", sorted(SERVER_FILES))
+def test_chroma_is_configured_truth_table(label):
+    module = _load_module(label, SERVER_FILES[label])
+    assert module.chroma_is_configured(CONFIG_WITH_CHROMA) is True
+    assert module.chroma_is_configured(CONFIG_WITHOUT_CHROMA) is False
+    assert (
+        module.chroma_is_configured(
+            {"chroma_cloud_enabled": "true", "chroma_cloud_api_key": ""}
+        )
+        is False
+    )
+    assert (
+        module.chroma_is_configured(
+            {"chroma_cloud_enabled": "false", "chroma_cloud_api_key": "k"}
+        )
+        is False
+    )
+
+
+# ---------------------------------------------------------------------------
+# call_tool routing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("label", sorted(SERVER_FILES))
+def test_dynamo_tool_works_without_chroma(label, monkeypatch):
+    """A Dynamo-backed tool must succeed and never touch Chroma init."""
+    module = _load_module(label, SERVER_FILES[label])
+    module.get_dynamo_client = lambda: _StubDynamoClient()
+
+    def _boom():
+        raise AssertionError(
+            "get_chroma_clients must not be called for a Dynamo tool"
+        )
+
+    module.get_chroma_clients = _boom
+
+    result = _tool_result(module, "list_merchants", {})
+    assert "error" not in result
+    assert result["merchants"][0]["merchant"] == "Costco Wholesale"
+
+
+@pytest.mark.parametrize("label", sorted(SERVER_FILES))
+@pytest.mark.parametrize("tool_name", sorted(EXPECTED_CHROMA_TOOLS))
+def test_chroma_tool_returns_structured_error(label, tool_name, monkeypatch):
+    """Every Chroma tool fails cleanly at call time when unconfigured."""
+    module = _load_module(label, SERVER_FILES[label])
+    _install_client_factories(monkeypatch, module)
+    module._config = dict(CONFIG_WITHOUT_CHROMA)
+
+    args = {
+        "search_receipts": {"query": "COFFEE"},
+        "list_all_receipts": {},
+        "search_product_lines": {"query": "MILK"},
+        "validate_word_similarity": {
+            "image_id": "3f2a1b0c-4d5e-4f70-8192-a3b4c5d6e7f8",
+            "receipt_id": 1,
+            "line_id": 1,
+            "word_id": 1,
+            "label": "GRAND_TOTAL",
+        },
+    }[tool_name]
+
+    result = _tool_result(module, tool_name, args)
+    assert result["error_type"] == "chroma_not_configured"
+    assert result["tool"] == tool_name
+    assert "Chroma Cloud not configured" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# Configured path unchanged
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("label", sorted(SERVER_FILES))
+def test_configured_path_builds_chroma_client(label, monkeypatch):
+    module = _load_module(label, SERVER_FILES[label])
+    _install_client_factories(monkeypatch, module)
+    module._config = dict(CONFIG_WITH_CHROMA)
+
+    dynamo_client, chroma_client, embed_fn = module.get_clients()
+    assert dynamo_client.table_name == "ReceiptsTable-test"
+    assert isinstance(chroma_client, _FakeChromaClient)
+    assert chroma_client.kwargs == {
+        "cloud_api_key": "ck-test-key",
+        "cloud_tenant": "tenant-1",
+        "cloud_database": "receipt_test",
+        "mode": "read",
+    }
+    assert callable(embed_fn)
+
+    # Cached: same objects on repeat and via the granular getters.
+    assert module.get_clients() == (dynamo_client, chroma_client, embed_fn)
+    assert module.get_chroma_clients() == (chroma_client, embed_fn)
+
+
+def _install_fake_pulumi(monkeypatch, secrets):
+    """Replace receipt_dynamo.data._pulumi so _load_config needs no CLI."""
+    pulumi_mod = types.ModuleType("receipt_dynamo.data._pulumi")
+    pulumi_mod.load_env = lambda env: {"dynamodb_table_name": "ReceiptsTable-test"}
+    pulumi_mod.load_secrets = lambda env: dict(secrets)
+
+    dynamo_pkg = types.ModuleType("receipt_dynamo")
+    data_pkg = types.ModuleType("receipt_dynamo.data")
+    dynamo_pkg.data = data_pkg
+    data_pkg._pulumi = pulumi_mod
+
+    monkeypatch.setitem(sys.modules, "receipt_dynamo", dynamo_pkg)
+    monkeypatch.setitem(sys.modules, "receipt_dynamo.data", data_pkg)
+    monkeypatch.setitem(sys.modules, "receipt_dynamo.data._pulumi", pulumi_mod)
+
+
+@pytest.mark.parametrize("label", sorted(SERVER_FILES))
+def test_env_var_can_disable_chroma(label, monkeypatch):
+    """CHROMA_CLOUD_ENABLED=false in the environment must override config
+    that has full Chroma creds (Dynamo-only mode)."""
+    module = _load_module(label, SERVER_FILES[label])
+    _install_client_factories(monkeypatch, module)
+    _install_fake_pulumi(
+        monkeypatch,
+        secrets={
+            "portfolio:CHROMA_CLOUD_ENABLED": "true",
+            "portfolio:CHROMA_CLOUD_API_KEY": "ck-test-key",
+            "portfolio:CHROMA_CLOUD_TENANT": "tenant-1",
+            "portfolio:CHROMA_CLOUD_DATABASE": "receipt_test",
+        },
+    )
+    monkeypatch.delenv("DYNAMODB_TABLE_NAME", raising=False)
+    monkeypatch.setenv("CHROMA_CLOUD_ENABLED", "false")
+    for key in (
+        "CHROMA_CLOUD_API_KEY",
+        "CHROMA_CLOUD_TENANT",
+        "CHROMA_CLOUD_DATABASE",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+    config = module._load_config()
+    assert config["chroma_cloud_enabled"] == "false"
+    assert module.chroma_is_configured(config) is False
+
+    # Dynamo still initializes; Chroma errors cleanly.
+    assert module.get_dynamo_client().table_name == "ReceiptsTable-test"
+    with pytest.raises(module.ChromaNotConfiguredError):
+        module.get_chroma_clients()

--- a/tests/test_receipt_mcp_section_tools.py
+++ b/tests/test_receipt_mcp_section_tools.py
@@ -261,7 +261,7 @@ def test_resegment_proxies_force_lambda_mode(label, monkeypatch):
 @pytest.mark.parametrize("label", sorted(SERVER_FILES))
 def test_resegment_plan_attaches_contact_sheet_as_image_content(label, monkeypatch):
     module = _load_module(label, SERVER_FILES[label])
-    monkeypatch.setattr(module, "get_clients", lambda: (object(), object(), object()))
+    monkeypatch.setattr(module, "get_dynamo_client", lambda: object())
 
     async def fake_plan(_arguments):
         return {


### PR DESCRIPTION
## What

`scripts/receipt_mcp_server.py` (and its Lambda twin) required Chroma Cloud creds at startup via `get_clients()`, so the local stdio server could not run Dynamo-only curation tools without Chroma. This PR makes Chroma initialization **lazy**:

- `get_clients()` is split into `get_dynamo_client()` and `get_chroma_clients()` (with `get_clients()` kept as a back-compat wrapper).
- The server starts and serves every Dynamo-backed tool (`get_receipt_words`, `create/update_word_label`, `get_label_distribution`, `list_words_by_label`, `get_receipt_sections`, ...) with no Chroma configuration.
- The four Chroma-dependent tools (`search_receipts`, `list_all_receipts`, `search_product_lines`, `validate_word_similarity`) raise a structured error **at call time**: `{"error": "Chroma Cloud not configured: set CHROMA_CLOUD_ENABLED=true and CHROMA_CLOUD_API_KEY ... to enable semantic search.", "error_type": "chroma_not_configured", "tool": ...}` — the server keeps running.
- `CHROMA_CLOUD_ENABLED` / `CHROMA_CLOUD_API_KEY` / `CHROMA_CLOUD_TENANT` / `CHROMA_CLOUD_DATABASE` env vars now override Pulumi config (so `CHROMA_CLOUD_ENABLED=false` runs Dynamo-only even where Pulumi has creds).
- Behavior is byte-for-byte unchanged when Chroma IS configured.

**Lambda twin**: `infra/mcp_server_lambda/lambdas/receipt_mcp_server_server.py` *duplicates* `get_clients()` (env-first config branch) rather than sharing it, so the identical change is applied there. Post-change `diff` between the two files shows only the pre-existing differences: the `_load_config()` body (Lambda env-first vs Pulumi) and the "keep in sync" NOTE lines. The Lambda gains the same resilience: missing `CHROMA_CLOUD_API_KEY` no longer breaks every tool call, only the four vector tools.

## Tests

`tests/test_receipt_mcp_lazy_chroma.py` (follows the `test_receipt_mcp_section_tools.py` module-loading convention, parametrized over **both** server twins, no network):

- `CHROMA_TOOLS` matches the expected 4 tools and both twins agree
- Dynamo client initializes without any Chroma config; cached on reuse
- `get_chroma_clients()` raises `ChromaNotConfiguredError` with the structured message
- `call_tool` on a Dynamo tool succeeds with a stub client and provably never touches Chroma init
- `call_tool` on each of the 4 Chroma tools returns the structured `chroma_not_configured` payload
- Configured path unchanged: `get_clients()` builds the ChromaClient with exactly the same kwargs as before (mocked factories) and caches
- `CHROMA_CLOUD_ENABLED=false` env override wins over Pulumi-provided creds through `_load_config()`

One existing test updated: `test_resegment_plan_attaches_contact_sheet_as_image_content` stubbed `get_clients`; now stubs `get_dynamo_client`.

`python3 -m pytest tests/test_receipt_mcp_lazy_chroma.py tests/test_receipt_mcp_section_tools.py` → **55 passed**.

## Verification (live, read-only against dev Dynamo)

Launched the stdio server locally with `PORTFOLIO_ENV=dev`, `CHROMA_CLOUD_ENABLED=false`, and no `CHROMA_CLOUD_*` creds in the environment, then drove a JSON-RPC `initialize` + `tools/call` exchange over stdin:

Startup log (no crash, clean warning):
```
INFO:__main__:Loading dev environment...
INFO:receipt_agent.clients.factory:Created DynamoDB client for table: ReceiptsTable-dc5be22
INFO:__main__:DynamoDB client initialized
WARNING:__main__:Chroma Cloud not configured: set CHROMA_CLOUD_ENABLED=true and CHROMA_CLOUD_API_KEY (plus CHROMA_CLOUD_TENANT / CHROMA_CLOUD_DATABASE) in Pulumi config or the environment to enable semantic search. Chroma-backed tools (list_all_receipts, search_product_lines, search_receipts, validate_word_similarity) are disabled; Dynamo-backed tools remain available.
```

Dynamo read tool works:
```
initialize -> {"name": "receipt-tools", "version": "1.26.0"}
list_recent_uploads -> {"total_images": 633, "showing": 2, "uploads": [{"image_id": "24c75335-810a-41a8-badd-a7b9325afb64", ..., "receipts": [{"receipt_id": 1, "merchant_name": "Whole Foods Market"}]}, ...]}
```

Chroma tool errors cleanly (server keeps serving, exit code 0):
```
search_product_lines -> {
  "error": "Chroma Cloud not configured: set CHROMA_CLOUD_ENABLED=true and CHROMA_CLOUD_API_KEY (plus CHROMA_CLOUD_TENANT / CHROMA_CLOUD_DATABASE) in Pulumi config or the environment to enable semantic search.",
  "error_type": "chroma_not_configured",
  "tool": "search_product_lines"
}
```

Configured path re-verified live (same server, Pulumi-provided creds, no env override):
```
search_product_lines("MILK") -> {"total_matches": 106, "items": [{"text": "MILK CHOCOLATE CHIPS 19.98", "merchant": "Sprouts Farmers Market", ...}, ...]}
```

Part of the Costco v2 sprint (W-B, Phase 0 unblocker): lets curation agents run receipt-tools locally over stdio without Chroma Cloud access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BeLcSviHL5vDgS3zTSMbsq

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * DynamoDB-backed receipt tools now work without Chroma Cloud credentials.
  * Chroma-backed tools initialize only when needed.
  * Added clear, structured errors when Chroma Cloud is unavailable.
  * Chroma can be disabled through configuration while DynamoDB functionality remains available.
  * Environment settings can override local configuration for Chroma setup.

* **Bug Fixes**
  * Server startup no longer fails when optional Chroma configuration is missing.

* **Tests**
  * Added coverage for DynamoDB-only operation, Chroma configuration states, structured errors, and environment-based disabling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->