### PR TITLE
[glyphstudio] Variant clustering: cluster-before-pool layout templates (W-G)

### DIFF
--- a/scripts/build_variant_layout.py
+++ b/scripts/build_variant_layout.py
@@ -1,0 +1,331 @@
+#!/usr/bin/env python3
+"""Variant-clustered layout template for one merchant (W-G).
+
+READ-ONLY against DynamoDB/S3 (dev): enumerates the merchant's receipts via
+the ReceiptPlace GSI1 (``MERCHANT#<SLUG>``), keeps SCAN images only (PHOTO
+receipts are recorded as excluded in the output provenance -- perspective
+distortion poisons column geometry), runs ``glyphstudio.stylescan.measure``
+per receipt into a persisted scan dir, then clusters BEFORE pooling via
+``glyphstudio.variant_cluster`` and emits a v3.1-shaped layout payload:
+
+* ``template``  -- dominant cluster as the top-level default (``version: 1``,
+  ``columns``/``sections``/``separators``; passes the existing
+  ``validate_layout_template`` unchanged), other clusters as
+  ``template.variants[]``.
+* ``verdict``   -- CONFIRM/REFUTE for the layout-variant proposal, with
+  per-cluster support, receipt refs, and distinguishing features.
+* ``provenance``-- full corpus + parameter provenance, including the PHOTO
+  exclusion list.
+
+Persisted-artifact convention (gitignored via tools/glyph-studio/.gitignore
+``.out/``; the LAYOUT of these dirs is the committed contract, the artifacts
+are not):
+
+    tools/glyph-studio/.out/stylescan/<merchant_slug>/
+        <image_id>_<receipt_id>.json   one stylescan.measure record
+        manifest.json                  sha256 per record + run provenance
+    tools/glyph-studio/.out/variant_layout/
+        <merchant_slug>_variant_layout.json
+
+Usage:
+  python scripts/build_variant_layout.py                      # Costco, dev
+  python scripts/build_variant_layout.py --skip-existing      # reuse scans
+  python scripts/build_variant_layout.py --print-distances    # calibration
+
+This script never writes to DynamoDB and never touches
+scripts/merchant_profiles.json -- consuming the payload is W-J's mint.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import sys
+from datetime import datetime, timezone
+
+_REPO = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
+for _p in (
+    os.path.join(_REPO, "tools", "glyph-studio", "py"),
+    os.path.join(_REPO, "receipt_dynamo"),
+):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from glyphstudio.layout_template import (  # noqa: E402
+    validate_layout_template,
+)
+from glyphstudio.variant_cluster import (  # noqa: E402
+    DEFAULT_THRESHOLD,
+    MIN_VARIANT_SUPPORT,
+    build_variant_payload,
+    median_link_summary,
+    pairwise_distance_report,
+    receipt_key,
+)
+
+GLYPH_OUT = os.path.join(_REPO, "tools", "glyph-studio", ".out")
+
+
+def merchant_slug(merchant_name: str) -> str:
+    """Same normalization as ReceiptPlace GSI1PK, lowercased for paths."""
+    return re.sub(r"[^A-Z0-9]+", "_", merchant_name.upper()).strip("_").lower()
+
+
+def _sha256_file(path: str) -> str:
+    with open(path, "rb") as fh:
+        return hashlib.sha256(fh.read()).hexdigest()
+
+
+def enumerate_receipts(
+    table: str, merchant: str
+) -> list[tuple[str, int, str]]:
+    """All (image_id, receipt_id, image_type) for a merchant, sorted."""
+    from receipt_dynamo.data.dynamo_client import DynamoClient
+
+    client = DynamoClient(table)
+    places = []
+    lek = None
+    while True:
+        page, lek = client.get_receipt_places_by_merchant(
+            merchant, last_evaluated_key=lek
+        )
+        places.extend(page)
+        if not lek:
+            break
+    image_types: dict[str, str] = {}
+    out = []
+    for place in places:
+        if place.image_id not in image_types:
+            image_types[place.image_id] = str(
+                client.get_image(place.image_id).image_type
+            )
+        out.append(
+            (
+                place.image_id,
+                int(place.receipt_id),
+                image_types[place.image_id],
+            )
+        )
+    return sorted(set(out))
+
+
+def run_stylescans(
+    receipts: list[tuple[str, int]],
+    scan_dir: str,
+    *,
+    stylescan_merchant: str,
+    skip_existing: bool,
+) -> tuple[list[tuple[str, dict]], list[dict]]:
+    """Measure (or reload) each receipt into ``scan_dir``.
+
+    Returns ``(scans_by_key, failed)``; failures are recorded, not fatal --
+    a drifted receipt must not block the corpus measurement.
+    """
+    from glyphstudio.stylescan import measure
+
+    os.makedirs(scan_dir, exist_ok=True)
+    scans_by_key: list[tuple[str, dict]] = []
+    failed: list[dict] = []
+    for image_id, receipt_id in receipts:
+        key = receipt_key(image_id, receipt_id)
+        path = os.path.join(scan_dir, f"{image_id}_{receipt_id}.json")
+        try:
+            if skip_existing and os.path.exists(path):
+                with open(path, encoding="utf-8") as fh:
+                    record = json.load(fh)
+            else:
+                record = measure(
+                    image_id, receipt_id, merchant=stylescan_merchant
+                )
+                with open(path, "w", encoding="utf-8") as fh:
+                    json.dump(record, fh, indent=1)
+            if not record.get("lines"):
+                raise RuntimeError("stylescan produced no lines")
+            scans_by_key.append((key, record))
+            print(
+                f"  scan {key}: {len(record['lines'])} lines -> "
+                f"{os.path.relpath(path, _REPO)}"
+            )
+        except Exception as exc:  # noqa: BLE001 - record, keep measuring
+            failed.append({"receipt_key": key, "error": str(exc)[:200]})
+            print(f"  FAILED {key}: {exc}", file=sys.stderr)
+    return scans_by_key, failed
+
+
+def write_manifest(
+    scan_dir: str,
+    *,
+    merchant: str,
+    table: str,
+    scans_by_key: list[tuple[str, dict]],
+    excluded: list[dict],
+    failed: list[dict],
+) -> str:
+    entries = []
+    for key, record in scans_by_key:
+        fname = f"{record['image_id']}_{record['receipt_id']}.json"
+        entries.append(
+            {
+                "receipt_key": key,
+                "file": fname,
+                "sha256": _sha256_file(os.path.join(scan_dir, fname)),
+                "n_lines": len(record.get("lines") or []),
+            }
+        )
+    manifest = {
+        "merchant": merchant,
+        "table": table,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "scans": entries,
+        "excluded": excluded,
+        "failed": failed,
+    }
+    path = os.path.join(scan_dir, "manifest.json")
+    with open(path, "w", encoding="utf-8") as fh:
+        json.dump(manifest, fh, indent=1)
+        fh.write("\n")
+    return path
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    ap.add_argument("--merchant", default="Costco Wholesale")
+    ap.add_argument(
+        "--stylescan-merchant",
+        default="costco",
+        help="stylescan rule-set key (see stylescan._MERCHANT_RULES)",
+    )
+    ap.add_argument(
+        "--table",
+        default=os.environ.get("DYNAMODB_TABLE_NAME", "ReceiptsTable-dc5be22"),
+    )
+    ap.add_argument("--scan-dir", default=None)
+    ap.add_argument("--out", default=None)
+    ap.add_argument("--threshold", type=float, default=DEFAULT_THRESHOLD)
+    ap.add_argument(
+        "--min-variant-support", type=int, default=MIN_VARIANT_SUPPORT
+    )
+    ap.add_argument("--proposal", default="self-checkout-layout-variant")
+    ap.add_argument(
+        "--skip-existing",
+        action="store_true",
+        help="reuse scan records already in the scan dir (default: fresh)",
+    )
+    ap.add_argument(
+        "--print-distances",
+        action="store_true",
+        help="print the full pairwise distance report (calibration)",
+    )
+    args = ap.parse_args(argv)
+    os.environ.setdefault("DYNAMODB_TABLE_NAME", args.table)
+
+    slug = merchant_slug(args.merchant)
+    scan_dir = args.scan_dir or os.path.join(GLYPH_OUT, "stylescan", slug)
+    out_path = args.out or os.path.join(
+        GLYPH_OUT, "variant_layout", f"{slug}_variant_layout.json"
+    )
+
+    print(f"enumerating {args.merchant!r} receipts from {args.table} ...")
+    all_receipts = enumerate_receipts(args.table, args.merchant)
+    scan_receipts = [(i, r) for i, r, t in all_receipts if t.upper() == "SCAN"]
+    excluded = [
+        {
+            "receipt_key": receipt_key(i, r),
+            "reason": f"image_type={t.upper()}",
+        }
+        for i, r, t in all_receipts
+        if t.upper() != "SCAN"
+    ]
+    print(
+        f"  {len(all_receipts)} receipts: {len(scan_receipts)} SCAN, "
+        f"{len(excluded)} excluded (non-SCAN)"
+    )
+
+    print(f"stylescan -> {os.path.relpath(scan_dir, _REPO)}")
+    scans_by_key, failed = run_stylescans(
+        scan_receipts,
+        scan_dir,
+        stylescan_merchant=args.stylescan_merchant,
+        skip_existing=args.skip_existing,
+    )
+    manifest_path = write_manifest(
+        scan_dir,
+        merchant=args.merchant,
+        table=args.table,
+        scans_by_key=scans_by_key,
+        excluded=excluded,
+        failed=failed,
+    )
+    print(f"manifest -> {os.path.relpath(manifest_path, _REPO)}")
+    if len(scans_by_key) < 2:
+        raise SystemExit(
+            f"need >= 2 usable scans, got {len(scans_by_key)} "
+            f"({len(failed)} failed)"
+        )
+
+    if args.print_distances:
+        report = pairwise_distance_report(scans_by_key)
+        for a, b, d in sorted(report, key=lambda t: t[2]):
+            print(f"  d={d:.4f}  {a}  {b}")
+        print(f"  summary: {median_link_summary(report)}")
+
+    payload = build_variant_payload(
+        scans_by_key,
+        threshold=args.threshold,
+        min_variant_support=args.min_variant_support,
+        proposal=args.proposal,
+        excluded_receipt_keys=excluded,
+        measured_at=datetime.now(timezone.utc).isoformat(),
+    )
+    payload["provenance"]["failed_receipt_keys"] = failed
+    payload["provenance"]["scan_manifest"] = {
+        "path": os.path.relpath(manifest_path, _REPO),
+        "sha256": _sha256_file(manifest_path),
+    }
+
+    problems = validate_layout_template(payload["template"])
+    if problems:
+        raise SystemExit(f"emitted template failed validation: {problems}")
+    for variant in payload["template"]["variants"]:
+        problems = validate_layout_template({"version": 1, **variant})
+        if problems:
+            raise SystemExit(
+                f"variant {variant['variant_id']!r} failed validation: "
+                f"{problems}"
+            )
+
+    os.makedirs(os.path.dirname(out_path), exist_ok=True)
+    with open(out_path, "w", encoding="utf-8") as fh:
+        json.dump(payload, fh, indent=1)
+        fh.write("\n")
+
+    verdict = payload["verdict"]
+    print(f"\npayload -> {os.path.relpath(out_path, _REPO)}")
+    print(f"payload sha256: {_sha256_file(out_path)}")
+    print(f"\nverdict: {verdict['status']} ({verdict['reason']})")
+    for cluster in verdict["clusters"]:
+        print(
+            f"  cluster {cluster['variant_id']!r}: "
+            f"support={cluster['support']}"
+        )
+        for ref in cluster["receipt_refs"]:
+            print(f"    {ref}")
+    for deg in verdict["degenerate_clusters"]:
+        print(f"  DEGENERATE cluster ({deg['reason']}): {deg['receipt_refs']}")
+    for out in verdict["outliers"]:
+        print(f"  outlier(s): {out['receipt_refs']}")
+    if verdict["distinguishing_features"]:
+        print("distinguishing features:")
+        for feat in verdict["distinguishing_features"]:
+            print(f"  - {feat}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/glyph-studio/README.md
+++ b/tools/glyph-studio/README.md
@@ -65,6 +65,27 @@ changes. To publish for real, back up and copy the npz into `$BITMATRIX_DIR`
   auto-derived). Generated npz/PNGs live in `.out/` (gitignored); the JSON
   sources are the committable truth.
 
+## Layout variant clustering (W-G)
+
+`scripts/build_variant_layout.py` (repo root) measures a merchant's SCAN
+receipts with `glyphstudio.stylescan`, clusters the per-receipt layout
+signatures BEFORE pooling (`glyphstudio.variant_cluster`), then pools each
+cluster through `layout_template.build_layout_template`. Persisted-artifact
+convention (artifacts gitignored via `.out/`; this layout is the contract):
+
+```
+tools/glyph-studio/.out/stylescan/<merchant_slug>/
+    <image_id>_<receipt_id>.json   # one stylescan.measure record
+    manifest.json                  # sha256 per record + run provenance
+tools/glyph-studio/.out/variant_layout/
+    <merchant_slug>_variant_layout.json  # template + verdict + provenance
+```
+
+The emitted `template` keeps `version: 1` (dominant cluster at the top
+level, other clusters in `template.variants[]`) and must pass
+`layout_template.validate_layout_template` unchanged. A committed sample of
+the real Costco run lives at `fixtures/costco_variant_layout.sample.json`.
+
 ## MCP server
 
 `server/mcp.mjs` is a stdio Model Context Protocol server — a sibling entry

--- a/tools/glyph-studio/fixtures/costco_variant_layout.sample.json
+++ b/tools/glyph-studio/fixtures/costco_variant_layout.sample.json
@@ -1,0 +1,438 @@
+{
+ "template": {
+  "version": 1,
+  "_comment": "Measured layout, cluster-before-pool (W-G): receipts clustered by layout signature, columns/sections/separators pooled per cluster via glyphstudio.variant_cluster. Top level = dominant cluster; other clusters in `variants`.",
+  "measured": {
+   "receipts": 24,
+   "tool_git_sha": "f030a417a0bd",
+   "tool_dirty": true,
+   "receipts_total": 31,
+   "clustering": {
+    "algorithm": "average-linkage-agglomerative",
+    "deterministic": true,
+    "threshold": 0.18,
+    "weights": {
+     "sequence": 0.3,
+     "markers": 0.2,
+     "columns": 0.35,
+     "positions": 0.15
+    },
+    "column_x_scale": 0.25,
+    "min_variant_support": 2,
+    "required_variant_sections": [
+     "items"
+    ],
+    "clusters": 1,
+    "degenerate_clusters": 1,
+    "outliers": 5
+   }
+  },
+  "columns": {
+   "barcode": [
+    {
+     "role": "desc",
+     "anchor": "left",
+     "x": 0.2459,
+     "spread": 0.0042,
+     "support": 21
+    }
+   ],
+   "footer": [
+    {
+     "role": "desc",
+     "anchor": "left",
+     "x": 0.0125,
+     "spread": 0.0166,
+     "support": 23
+    },
+    {
+     "role": "desc",
+     "anchor": "left",
+     "x": 0.2667,
+     "spread": 0.0044,
+     "support": 21
+    }
+   ],
+   "items": [
+    {
+     "role": "desc",
+     "anchor": "left",
+     "x": 0.0125,
+     "spread": 0.0125,
+     "support": 21
+    },
+    {
+     "role": "amount",
+     "anchor": "right",
+     "x": 0.9357,
+     "spread": 0.0095,
+     "support": 24
+    }
+   ],
+   "payment": [
+    {
+     "role": "label",
+     "anchor": "left",
+     "x": 0.0124,
+     "spread": 0.0125,
+     "support": 23
+    },
+    {
+     "role": "label",
+     "anchor": "left",
+     "x": 0.2228,
+     "spread": 0.0044,
+     "support": 23
+    },
+    {
+     "role": "amount",
+     "anchor": "right",
+     "x": 0.3875,
+     "spread": 0.0089,
+     "support": 24
+    },
+    {
+     "role": "amount",
+     "anchor": "right",
+     "x": 0.9399,
+     "spread": 0.0084,
+     "support": 23
+    }
+   ],
+   "storefront": [
+    {
+     "role": "desc",
+     "anchor": "left",
+     "x": 0.0125,
+     "spread": 0.0125,
+     "support": 23
+    },
+    {
+     "role": "desc",
+     "anchor": "left",
+     "x": 0.1039,
+     "spread": 0.0088,
+     "support": 24
+    },
+    {
+     "role": "desc",
+     "anchor": "left",
+     "x": 0.2261,
+     "spread": 0.0084,
+     "support": 24
+    },
+    {
+     "role": "desc",
+     "anchor": "left",
+     "x": 0.3417,
+     "spread": 0.0167,
+     "support": 17
+    }
+   ],
+   "summary": [
+    {
+     "role": "label",
+     "anchor": "left",
+     "x": 0.0167,
+     "spread": 0.0104,
+     "support": 23
+    },
+    {
+     "role": "label",
+     "anchor": "left",
+     "x": 0.0833,
+     "spread": 0.0083,
+     "support": 22
+    },
+    {
+     "role": "label",
+     "anchor": "left",
+     "x": 0.2228,
+     "spread": 0.0063,
+     "support": 24
+    },
+    {
+     "role": "qty",
+     "anchor": "right",
+     "x": 0.8852,
+     "spread": 0.0042,
+     "support": 21
+    },
+    {
+     "role": "amount",
+     "anchor": "right",
+     "x": 0.9354,
+     "spread": 0.0125,
+     "support": 24
+    }
+   ],
+   "total_line": [
+    {
+     "role": "label",
+     "anchor": "left",
+     "x": 0.0915,
+     "spread": 0.0084,
+     "support": 19
+    }
+   ]
+  },
+  "sections": [
+   {
+    "name": "storefront",
+    "pos_frac_med": 0.039,
+    "support": 24
+   },
+   {
+    "name": "items",
+    "pos_frac_med": 0.303,
+    "support": 24
+   },
+   {
+    "name": "summary",
+    "pos_frac_med": 0.353,
+    "support": 24
+   },
+   {
+    "name": "total_line",
+    "pos_frac_med": 0.39,
+    "support": 22
+   },
+   {
+    "name": "payment",
+    "pos_frac_med": 0.428,
+    "support": 24
+   },
+   {
+    "name": "barcode",
+    "pos_frac_med": 0.788,
+    "support": 23
+   },
+   {
+    "name": "footer",
+    "pos_frac_med": 0.807,
+    "support": 24
+   }
+  ],
+  "separators": [],
+  "variant_id": "default",
+  "support": 24,
+  "source_receipt_keys": [
+   "IMAGE#04b16930-7baf-4539-866f-b77d8e73cff8#RECEIPT#00001",
+   "IMAGE#20576ddd-8a2c-4aea-841e-da553b8a7ff1#RECEIPT#00001",
+   "IMAGE#25c91d78-ed11-4c68-8051-e1d364762bcb#RECEIPT#00001",
+   "IMAGE#471788b6-a210-4570-b5c4-47de5ac4518d#RECEIPT#00001",
+   "IMAGE#5cef2e7e-baad-4c29-9e5f-6a3d5ec20885#RECEIPT#00001",
+   "IMAGE#71d1d906-9bdb-4965-9c62-2fb388b5d5fa#RECEIPT#00001",
+   "IMAGE#750e0675-f318-4d1d-994c-c330ff6cb3f3#RECEIPT#00001",
+   "IMAGE#758cbedf-f1dd-4466-98ec-faf86e82d422#RECEIPT#00001",
+   "IMAGE#75ec2ac9-e043-4270-b7ec-67e4f225dae9#RECEIPT#00002",
+   "IMAGE#7ee15df8-703f-46c1-83c7-22a463c923c4#RECEIPT#00001",
+   "IMAGE#8388d1f1-b5d6-4560-b7dc-db273815dda1#RECEIPT#00001",
+   "IMAGE#84efc4e9-87e8-4bda-beb9-1668328c6801#RECEIPT#00002",
+   "IMAGE#909a2b84-0b9d-496a-adf9-16588602a055#RECEIPT#00001",
+   "IMAGE#909a2b84-0b9d-496a-adf9-16588602a055#RECEIPT#00002",
+   "IMAGE#a861f6a6-8d6d-42bc-907c-3330d8bd2022#RECEIPT#00001",
+   "IMAGE#ac5fd741-29f2-4e05-bf69-9c216ec8a56a#RECEIPT#00002",
+   "IMAGE#b44d58bc-cdad-443b-bea3-958a2fbb76e6#RECEIPT#00001",
+   "IMAGE#c1672313-25b9-4d14-9951-691a2003dacf#RECEIPT#00001",
+   "IMAGE#d67ee0e3-6f30-4142-8209-cebbf309f40e#RECEIPT#00002",
+   "IMAGE#d84d4101-8a2f-4b6f-9c4e-4d89af1850f5#RECEIPT#00002",
+   "IMAGE#e8b658b6-e731-4aab-8c9b-cd9df55efc57#RECEIPT#00001",
+   "IMAGE#ed28a4ce-2258-4745-87ba-2fc662c94abf#RECEIPT#00001",
+   "IMAGE#ed28a4ce-2258-4745-87ba-2fc662c94abf#RECEIPT#00002",
+   "IMAGE#fa0fe8e6-5270-4b37-9149-113de515f436#RECEIPT#00001"
+  ],
+  "variants": []
+ },
+ "verdict": {
+  "proposal": "self-checkout-layout-variant",
+  "status": "REFUTE",
+  "reason": "single stable cluster at threshold 0.18; no second usable layout format found (1 degenerate cluster(s) demoted: pooled template unusable as a layout)",
+  "clusters": [
+   {
+    "variant_id": "default",
+    "support": 24,
+    "receipt_refs": [
+     "IMAGE#04b16930-7baf-4539-866f-b77d8e73cff8#RECEIPT#00001",
+     "IMAGE#20576ddd-8a2c-4aea-841e-da553b8a7ff1#RECEIPT#00001",
+     "IMAGE#25c91d78-ed11-4c68-8051-e1d364762bcb#RECEIPT#00001",
+     "IMAGE#471788b6-a210-4570-b5c4-47de5ac4518d#RECEIPT#00001",
+     "IMAGE#5cef2e7e-baad-4c29-9e5f-6a3d5ec20885#RECEIPT#00001",
+     "IMAGE#71d1d906-9bdb-4965-9c62-2fb388b5d5fa#RECEIPT#00001",
+     "IMAGE#750e0675-f318-4d1d-994c-c330ff6cb3f3#RECEIPT#00001",
+     "IMAGE#758cbedf-f1dd-4466-98ec-faf86e82d422#RECEIPT#00001",
+     "IMAGE#75ec2ac9-e043-4270-b7ec-67e4f225dae9#RECEIPT#00002",
+     "IMAGE#7ee15df8-703f-46c1-83c7-22a463c923c4#RECEIPT#00001",
+     "IMAGE#8388d1f1-b5d6-4560-b7dc-db273815dda1#RECEIPT#00001",
+     "IMAGE#84efc4e9-87e8-4bda-beb9-1668328c6801#RECEIPT#00002",
+     "IMAGE#909a2b84-0b9d-496a-adf9-16588602a055#RECEIPT#00001",
+     "IMAGE#909a2b84-0b9d-496a-adf9-16588602a055#RECEIPT#00002",
+     "IMAGE#a861f6a6-8d6d-42bc-907c-3330d8bd2022#RECEIPT#00001",
+     "IMAGE#ac5fd741-29f2-4e05-bf69-9c216ec8a56a#RECEIPT#00002",
+     "IMAGE#b44d58bc-cdad-443b-bea3-958a2fbb76e6#RECEIPT#00001",
+     "IMAGE#c1672313-25b9-4d14-9951-691a2003dacf#RECEIPT#00001",
+     "IMAGE#d67ee0e3-6f30-4142-8209-cebbf309f40e#RECEIPT#00002",
+     "IMAGE#d84d4101-8a2f-4b6f-9c4e-4d89af1850f5#RECEIPT#00002",
+     "IMAGE#e8b658b6-e731-4aab-8c9b-cd9df55efc57#RECEIPT#00001",
+     "IMAGE#ed28a4ce-2258-4745-87ba-2fc662c94abf#RECEIPT#00001",
+     "IMAGE#ed28a4ce-2258-4745-87ba-2fc662c94abf#RECEIPT#00002",
+     "IMAGE#fa0fe8e6-5270-4b37-9149-113de515f436#RECEIPT#00001"
+    ],
+    "markers_common": [
+     "footer",
+     "items_sold",
+     "payment",
+     "summary",
+     "warehouse_header"
+    ],
+    "marker_prevalence": {
+     "footer": 24,
+     "items_sold": 24,
+     "payment": 24,
+     "savings": 2,
+     "self_checkout": 22,
+     "summary": 24,
+     "total_line": 22,
+     "warehouse_header": 24
+    }
+   }
+  ],
+  "degenerate_clusters": [
+   {
+    "receipt_refs": [
+     "IMAGE#314ac65b-2b97-45d6-81c2-e48fb0b8cef4#RECEIPT#00001",
+     "IMAGE#3ea1b045-48f9-425e-a9e6-10a347a71113#RECEIPT#00001"
+    ],
+    "reason": "pooled template missing required section(s): items",
+    "markers_common": [
+     "footer",
+     "items_sold",
+     "payment",
+     "savings",
+     "self_checkout",
+     "summary",
+     "total_line",
+     "warehouse_header"
+    ]
+   }
+  ],
+  "outliers": [
+   {
+    "receipt_refs": [
+     "IMAGE#0324604e-e1f7-4021-b887-7ef7e012c563#RECEIPT#00001"
+    ]
+   },
+   {
+    "receipt_refs": [
+     "IMAGE#165b9d15-9fa1-4a3c-a568-1b4e98170ab5#RECEIPT#00001"
+    ]
+   },
+   {
+    "receipt_refs": [
+     "IMAGE#41885f70-0a10-4897-8840-8f7373d150cd#RECEIPT#00001"
+    ]
+   },
+   {
+    "receipt_refs": [
+     "IMAGE#57cb7f2c-7dcc-4974-9ef8-a460232f3b1d#RECEIPT#00001"
+    ]
+   },
+   {
+    "receipt_refs": [
+     "IMAGE#6cd1f7f5-d988-4e11-9209-cb6535fc3b04#RECEIPT#00001"
+    ]
+   }
+  ],
+  "distinguishing_features": []
+ },
+ "provenance": {
+  "source_kind": "measurement",
+  "pipeline": "build_variant_layout",
+  "pipeline_version": "1",
+  "git_sha": "f030a417a0bd",
+  "measured_at": "2026-07-22T07:12:36.566890+00:00",
+  "source_receipt_keys": [
+   "IMAGE#0324604e-e1f7-4021-b887-7ef7e012c563#RECEIPT#00001",
+   "IMAGE#04b16930-7baf-4539-866f-b77d8e73cff8#RECEIPT#00001",
+   "IMAGE#165b9d15-9fa1-4a3c-a568-1b4e98170ab5#RECEIPT#00001",
+   "IMAGE#20576ddd-8a2c-4aea-841e-da553b8a7ff1#RECEIPT#00001",
+   "IMAGE#25c91d78-ed11-4c68-8051-e1d364762bcb#RECEIPT#00001",
+   "IMAGE#314ac65b-2b97-45d6-81c2-e48fb0b8cef4#RECEIPT#00001",
+   "IMAGE#3ea1b045-48f9-425e-a9e6-10a347a71113#RECEIPT#00001",
+   "IMAGE#41885f70-0a10-4897-8840-8f7373d150cd#RECEIPT#00001",
+   "IMAGE#471788b6-a210-4570-b5c4-47de5ac4518d#RECEIPT#00001",
+   "IMAGE#57cb7f2c-7dcc-4974-9ef8-a460232f3b1d#RECEIPT#00001",
+   "IMAGE#5cef2e7e-baad-4c29-9e5f-6a3d5ec20885#RECEIPT#00001",
+   "IMAGE#6cd1f7f5-d988-4e11-9209-cb6535fc3b04#RECEIPT#00001",
+   "IMAGE#71d1d906-9bdb-4965-9c62-2fb388b5d5fa#RECEIPT#00001",
+   "IMAGE#750e0675-f318-4d1d-994c-c330ff6cb3f3#RECEIPT#00001",
+   "IMAGE#758cbedf-f1dd-4466-98ec-faf86e82d422#RECEIPT#00001",
+   "IMAGE#75ec2ac9-e043-4270-b7ec-67e4f225dae9#RECEIPT#00002",
+   "IMAGE#7ee15df8-703f-46c1-83c7-22a463c923c4#RECEIPT#00001",
+   "IMAGE#8388d1f1-b5d6-4560-b7dc-db273815dda1#RECEIPT#00001",
+   "IMAGE#84efc4e9-87e8-4bda-beb9-1668328c6801#RECEIPT#00002",
+   "IMAGE#909a2b84-0b9d-496a-adf9-16588602a055#RECEIPT#00001",
+   "IMAGE#909a2b84-0b9d-496a-adf9-16588602a055#RECEIPT#00002",
+   "IMAGE#a861f6a6-8d6d-42bc-907c-3330d8bd2022#RECEIPT#00001",
+   "IMAGE#ac5fd741-29f2-4e05-bf69-9c216ec8a56a#RECEIPT#00002",
+   "IMAGE#b44d58bc-cdad-443b-bea3-958a2fbb76e6#RECEIPT#00001",
+   "IMAGE#c1672313-25b9-4d14-9951-691a2003dacf#RECEIPT#00001",
+   "IMAGE#d67ee0e3-6f30-4142-8209-cebbf309f40e#RECEIPT#00002",
+   "IMAGE#d84d4101-8a2f-4b6f-9c4e-4d89af1850f5#RECEIPT#00002",
+   "IMAGE#e8b658b6-e731-4aab-8c9b-cd9df55efc57#RECEIPT#00001",
+   "IMAGE#ed28a4ce-2258-4745-87ba-2fc662c94abf#RECEIPT#00001",
+   "IMAGE#ed28a4ce-2258-4745-87ba-2fc662c94abf#RECEIPT#00002",
+   "IMAGE#fa0fe8e6-5270-4b37-9149-113de515f436#RECEIPT#00001"
+  ],
+  "excluded_receipt_keys": [
+   {
+    "receipt_key": "IMAGE#01c0bc98-4fdc-4f7d-baf6-72c2e3a9564d#RECEIPT#00001",
+    "reason": "image_type=PHOTO"
+   },
+   {
+    "receipt_key": "IMAGE#3885af9f-8f97-4cf3-9b6c-8d838e133a2d#RECEIPT#00001",
+    "reason": "image_type=PHOTO"
+   },
+   {
+    "receipt_key": "IMAGE#5e75a5a5-eefc-4451-8729-13ec76bb5d38#RECEIPT#00001",
+    "reason": "image_type=PHOTO"
+   },
+   {
+    "receipt_key": "IMAGE#60a24649-c5c8-4c5b-8dd6-ba5d90e8b96b#RECEIPT#00001",
+    "reason": "image_type=PHOTO"
+   },
+   {
+    "receipt_key": "IMAGE#85fceeb9-11ba-4308-8791-9da6dc548162#RECEIPT#00001",
+    "reason": "image_type=PHOTO"
+   },
+   {
+    "receipt_key": "IMAGE#9cca4a13-d159-4150-92a3-0ecd34f8c4f8#RECEIPT#00001",
+    "reason": "image_type=PHOTO"
+   },
+   {
+    "receipt_key": "IMAGE#d655ab48-2205-4287-b4f8-0762588f20d5#RECEIPT#00001",
+    "reason": "image_type=PHOTO"
+   },
+   {
+    "receipt_key": "IMAGE#f2446845-6bb0-416c-bfa3-cad9cb4ad80e#RECEIPT#00001",
+    "reason": "image_type=PHOTO"
+   }
+  ],
+  "params": {
+   "threshold": 0.18,
+   "weights": {
+    "sequence": 0.3,
+    "markers": 0.2,
+    "columns": 0.35,
+    "positions": 0.15
+   },
+   "column_x_scale": 0.25,
+   "min_variant_support": 2
+  },
+  "failed_receipt_keys": [],
+  "scan_manifest": {
+   "path": "tools/glyph-studio/.out/stylescan/costco_wholesale/manifest.json",
+   "sha256": "3052e1672c611f2e8d35b45d7bacf8b54d61fe45cd829b9fca82c7890bfce306"
+  }
+ }
+}

--- a/tools/glyph-studio/py/glyphstudio/variant_cluster.py
+++ b/tools/glyph-studio/py/glyphstudio/variant_cluster.py
@@ -1,0 +1,588 @@
+"""Cluster-before-pool layout variants (W-G, Costco v2 pilot).
+
+``build_layout_template`` pools column/section/separator evidence across ALL
+of a merchant's scans, which averages away real format families (Costco
+register vs self-checkout). This module clusters the per-receipt stylescan
+records FIRST, then pools per cluster:
+
+1. ``receipt_signature``   -- one scan -> a layout signature: the canonical
+   section sequence + first-appearance position fractions, the raw stylescan
+   section markers present (``self_checkout`` survives here even though it
+   canonicalizes to ``storefront``), and the per-section column lanes from
+   the columnscan rider.
+2. ``signature_distance``  -- weighted distance over signature space
+   (sequence edit distance / marker Jaccard / matched-lane column geometry /
+   section position fractions).
+3. ``cluster_signatures``  -- deterministic average-linkage agglomerative
+   clustering with a fixed distance threshold. There is NO randomness
+   anywhere (the "seed" is the algorithm itself): receipts are processed in
+   sorted-receipt-key order and merge ties break on the lowest cluster
+   index, so a shuffled input yields byte-identical output.
+4. ``build_variant_payload`` -- pools each cluster through the EXISTING
+   ``build_layout_template`` machinery and emits a v3.1-shaped layout
+   payload: dominant cluster as the top-level default (``version: 1`` --
+   passes the unchanged ``validate_layout_template``), other clusters as
+   ``template.variants[]`` with ``{variant_id, classifier_hint, columns,
+   sections, separators, support, source_receipt_keys}``, plus a
+   CONFIRM/REFUTE verdict block for the layout-variant proposal.
+
+Scan-dir convention (artifacts are NOT committed; ``tools/glyph-studio/
+.gitignore`` ignores ``.out/``):
+
+    tools/glyph-studio/.out/stylescan/<merchant_slug>/
+        <image_id>_<receipt_id>.json   -- one stylescan.measure record
+        manifest.json                  -- sha256 per record + provenance
+    tools/glyph-studio/.out/variant_layout/
+        <merchant_slug>_variant_layout.json  -- the emitted payload
+
+Driven by ``scripts/build_variant_layout.py``.
+"""
+
+from __future__ import annotations
+
+from statistics import mean, median
+
+try:
+    from .layout_template import (
+        _line_y_frac,
+        build_layout_template,
+    )
+    from .sections import normalize_stylescan_section
+    from .styleagg import receipt_section_columns
+except ImportError:  # bare-script invocation
+    from layout_template import _line_y_frac, build_layout_template
+    from sections import normalize_stylescan_section
+    from styleagg import receipt_section_columns
+
+# --- signature space --------------------------------------------------------
+
+# Raw stylescan section names that describe CONTENT of a single row, not the
+# receipt's format family -- excluded from the marker set.
+_NON_MARKER_RAW = frozenset({"item", "other", "separator", "barcode_caption"})
+
+# Distance component weights (sum to 1). Column geometry dominates: two
+# format families print the same sections at different lanes long before
+# they reorder them.
+WEIGHTS = {
+    "sequence": 0.30,
+    "markers": 0.20,
+    "columns": 0.35,
+    "positions": 0.15,
+}
+# An x-delta of this fraction of paper width makes two same-role lanes
+# "fully different" (cost 1.0); deltas scale linearly below it.
+COLUMN_X_SCALE = 0.25
+# Two receipts merge (average linkage) while their cluster distance is at or
+# under this. Calibrated so content jitter (item-count differences, small
+# lane wobble) stays a single cluster while a lane shift of ~0.05+ paper
+# width plus marker/sequence deltas separates.
+DEFAULT_THRESHOLD = 0.18
+# A cluster needs at least this many receipts to be emitted as a variant
+# (pooling's own support floor is 2; a singleton pools to nothing).
+MIN_VARIANT_SUPPORT = 2
+# A pooled variant must retain these canonical sections to be a usable
+# layout template; a cluster whose pooling drops them (e.g. every item row
+# reclassified by a content rule) is a measurement artifact, recorded as
+# DEGENERATE in the verdict rather than emitted as a variant.
+REQUIRED_VARIANT_SECTIONS = ("items",)
+# A classifier-hint marker must be common to every receipt of one cluster
+# and present in at most this fraction of the other cluster's receipts --
+# markers merely missing from a couple of the other side's receipts are
+# noise, not classifiers.
+MARKER_DISTINCTIVE_MAX_OTHER_FRAC = 0.2
+
+
+def receipt_key(image_id: str, receipt_id: int | str) -> str:
+    """Canonical receipt reference: matches the Dynamo key vocabulary."""
+    return f"IMAGE#{image_id}#RECEIPT#{int(receipt_id):05d}"
+
+
+def receipt_signature(scan: dict) -> dict:
+    """One stylescan record -> layout signature (see module docstring)."""
+    lines = scan.get("lines") or []
+    n = max(1, len(lines))
+    sequence: list[str] = []
+    positions: dict[str, float] = {}
+    markers: set[str] = set()
+    for i, line in enumerate(lines):
+        raw = line.get("section")
+        canonical = line.get(
+            "section_canonical"
+        ) or normalize_stylescan_section(raw)
+        if raw and raw not in _NON_MARKER_RAW:
+            markers.add(raw)
+        if canonical and canonical not in positions:
+            sequence.append(canonical)
+            positions[canonical] = _line_y_frac(line, scan, i, n)
+    return {
+        "sequence": sequence,
+        "positions": positions,
+        "markers": frozenset(markers),
+        "columns": receipt_section_columns(lines),
+    }
+
+
+# --- distance ---------------------------------------------------------------
+
+
+def _levenshtein(a: list[str], b: list[str]) -> int:
+    if not a:
+        return len(b)
+    if not b:
+        return len(a)
+    prev = list(range(len(b) + 1))
+    for i, ca in enumerate(a, 1):
+        cur = [i]
+        for j, cb in enumerate(b, 1):
+            cur.append(
+                min(
+                    prev[j] + 1,
+                    cur[j - 1] + 1,
+                    prev[j - 1] + (ca != cb),
+                )
+            )
+        prev = cur
+    return prev[-1]
+
+
+def _sequence_dist(a: list[str], b: list[str]) -> float:
+    denom = max(len(a), len(b), 1)
+    return _levenshtein(a, b) / denom
+
+
+def _marker_dist(a: frozenset, b: frozenset) -> float:
+    union = a | b
+    if not union:
+        return 0.0
+    return 1.0 - len(a & b) / len(union)
+
+
+def _lane_xs(cols: list[dict], role: str) -> list[float]:
+    return sorted(c["x"] for c in cols if c["role"] == role)
+
+
+def _columns_dist(
+    ca: dict[str, list[dict]], cb: dict[str, list[dict]]
+) -> float:
+    """Matched-lane geometry distance over every (section, role) slot.
+
+    Same-role lanes match greedily by nearest x (cost ``|dx|/COLUMN_X_SCALE``
+    capped at 1); a lane with no counterpart costs 1. Averaged over slots so
+    receipts with many sections aren't penalized for having more evidence.
+    """
+    slots = sorted(
+        {(sec, c["role"]) for sec, cols in ca.items() for c in cols}
+        | {(sec, c["role"]) for sec, cols in cb.items() for c in cols}
+    )
+    if not slots:
+        return 0.0
+    cost = 0.0
+    count = 0
+    for sec, role in slots:
+        xs_a = _lane_xs(ca.get(sec, []), role)
+        xs_b = _lane_xs(cb.get(sec, []), role)
+        remaining = list(xs_b)
+        for x in xs_a:
+            if remaining:
+                nearest = min(remaining, key=lambda v: abs(v - x))
+                remaining.remove(nearest)
+                cost += min(abs(nearest - x) / COLUMN_X_SCALE, 1.0)
+            else:
+                cost += 1.0
+            count += 1
+        cost += len(remaining)
+        count += len(remaining)
+    return cost / max(count, 1)
+
+
+def _positions_dist(pa: dict[str, float], pb: dict[str, float]) -> float:
+    shared = sorted(set(pa) & set(pb))
+    if not shared:
+        return 1.0
+    return min(mean(abs(pa[s] - pb[s]) for s in shared) / 0.5, 1.0)
+
+
+def signature_distance(a: dict, b: dict) -> float:
+    return (
+        WEIGHTS["sequence"] * _sequence_dist(a["sequence"], b["sequence"])
+        + WEIGHTS["markers"] * _marker_dist(a["markers"], b["markers"])
+        + WEIGHTS["columns"] * _columns_dist(a["columns"], b["columns"])
+        + WEIGHTS["positions"]
+        * _positions_dist(a["positions"], b["positions"])
+    )
+
+
+# --- clustering -------------------------------------------------------------
+
+
+def cluster_signatures(
+    signatures: list[dict], *, threshold: float = DEFAULT_THRESHOLD
+) -> list[list[int]]:
+    """Average-linkage agglomerative clustering, fully deterministic.
+
+    Returns clusters as sorted index lists, ordered by (-size, first index).
+    Merge order: always the pair with the smallest average distance; exact
+    ties break on the lowest (i, j) cluster indices.
+    """
+    n = len(signatures)
+    dist = [[0.0] * n for _ in range(n)]
+    for i in range(n):
+        for j in range(i + 1, n):
+            d = signature_distance(signatures[i], signatures[j])
+            dist[i][j] = dist[j][i] = d
+    clusters: list[list[int]] = [[i] for i in range(n)]
+    while len(clusters) > 1:
+        best: tuple[float, int, int] | None = None
+        for i in range(len(clusters)):
+            for j in range(i + 1, len(clusters)):
+                d = mean(dist[a][b] for a in clusters[i] for b in clusters[j])
+                if d <= threshold and (best is None or d < best[0] - 1e-12):
+                    best = (d, i, j)
+        if best is None:
+            break
+        _, i, j = best
+        clusters[i] = sorted(clusters[i] + clusters[j])
+        del clusters[j]
+    clusters = [sorted(c) for c in clusters]
+    clusters.sort(key=lambda c: (-len(c), c[0]))
+    return clusters
+
+
+# --- payload ----------------------------------------------------------------
+
+
+def _common_markers(signatures: list[dict], members: list[int]) -> frozenset:
+    common: frozenset | None = None
+    for idx in members:
+        m = signatures[idx]["markers"]
+        common = m if common is None else common & m
+    return common or frozenset()
+
+
+def _section_names(template: dict) -> list[str]:
+    return [s["name"] for s in template.get("sections", [])]
+
+
+def _marker_prevalence(
+    signatures: list[dict], members: list[int]
+) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for idx in members:
+        for marker in signatures[idx]["markers"]:
+            counts[marker] = counts.get(marker, 0) + 1
+    return dict(sorted(counts.items()))
+
+
+def _distinctive_markers(
+    signatures: list[dict],
+    members: list[int],
+    others: list[int],
+    *,
+    max_other_frac: float = MARKER_DISTINCTIVE_MAX_OTHER_FRAC,
+) -> list[str]:
+    """Markers common to EVERY ``members`` receipt and present in at most
+    ``max_other_frac`` of ``others`` -- crisp per-receipt classifiers."""
+    common = _common_markers(signatures, members)
+    other_counts = _marker_prevalence(signatures, others)
+    limit = max_other_frac * max(len(others), 1)
+    return sorted(m for m in common if other_counts.get(m, 0) <= limit)
+
+
+def _missing_variant_sections(template: dict) -> list[str]:
+    """REQUIRED_VARIANT_SECTIONS a pooled cluster template failed to keep
+    (either absent from ``sections`` or without any column lane)."""
+    names = set(_section_names(template))
+    columns = template.get("columns") or {}
+    return [
+        sec
+        for sec in REQUIRED_VARIANT_SECTIONS
+        if sec not in names or not columns.get(sec)
+    ]
+
+
+def _classifier_hint(
+    signatures: list[dict],
+    members: list[int],
+    default_members: list[int],
+    template: dict,
+    default_template: dict,
+) -> dict:
+    """Machine-usable features separating a variant from the default.
+
+    ``markers_any``/``markers_absent`` are raw stylescan section names common
+    to every receipt of one cluster and rare (<= MARKER_DISTINCTIVE_MAX_
+    OTHER_FRAC) in the other -- a variant-aware reader (W-H) can classify a
+    receipt by probing its lines against the same stylescan rules.
+    """
+    return {
+        "markers_any": _distinctive_markers(
+            signatures, members, default_members
+        ),
+        "markers_absent": _distinctive_markers(
+            signatures, default_members, members
+        ),
+        "sections_added": sorted(
+            set(_section_names(template))
+            - set(_section_names(default_template))
+        ),
+        "sections_missing": sorted(
+            set(_section_names(default_template))
+            - set(_section_names(template))
+        ),
+    }
+
+
+def _variant_id(hint: dict, ordinal: int) -> str:
+    for marker in hint.get("markers_any", []):
+        return marker
+    return f"variant-{ordinal}"
+
+
+def _column_shift_features(
+    variant_id: str, template: dict, default_template: dict
+) -> list[str]:
+    """Human-readable lane shifts between a variant and the default."""
+    out: list[str] = []
+    for sec, cols in sorted((template.get("columns") or {}).items()):
+        base = default_template.get("columns", {}).get(sec, [])
+        for col in cols:
+            xs = _lane_xs(base, col["role"])
+            if not xs:
+                continue
+            nearest = min(xs, key=lambda v: abs(v - col["x"]))
+            delta = col["x"] - nearest
+            if abs(delta) >= 0.03:
+                out.append(
+                    f"{variant_id}: {sec}.{col['role']} lane at "
+                    f"x={col['x']:.3f} vs default x={nearest:.3f} "
+                    f"(shift {delta:+.3f})"
+                )
+    return out
+
+
+def _strip_template(template: dict) -> dict:
+    """The pooled measurement of one cluster, without the top-level wrapper
+    keys (version/_comment/measured) that only the default carries."""
+    return {
+        "columns": template["columns"],
+        "sections": template["sections"],
+        "separators": template["separators"],
+    }
+
+
+def build_variant_payload(
+    scans_by_key: list[tuple[str, dict]],
+    *,
+    threshold: float = DEFAULT_THRESHOLD,
+    min_variant_support: int = MIN_VARIANT_SUPPORT,
+    proposal: str = "self-checkout-layout-variant",
+    excluded_receipt_keys: list[dict] | None = None,
+    measured_at: str | None = None,
+) -> dict:
+    """Cluster scans, pool per cluster, emit template + verdict + provenance.
+
+    ``scans_by_key`` pairs each stylescan record with its canonical receipt
+    key; input order is irrelevant (sorted internally). ``excluded_receipt_
+    keys`` records receipts deliberately left out of the corpus (the PHOTO
+    exclusion) as ``{"receipt_key", "reason"}`` dicts.
+    """
+    ordered = sorted(scans_by_key, key=lambda kv: kv[0])
+    keys = [k for k, _ in ordered]
+    if len(set(keys)) != len(keys):
+        raise ValueError("duplicate receipt keys in scans_by_key")
+    scans = [s for _, s in ordered]
+    signatures = [receipt_signature(s) for s in scans]
+    clusters = cluster_signatures(signatures, threshold=threshold)
+
+    kept = [c for c in clusters if len(c) >= min_variant_support]
+    outliers = [c for c in clusters if len(c) < min_variant_support]
+    fallback_pooled_all = False
+    if not kept:
+        # No stable cluster at all: fall back to pooling the whole corpus as
+        # one cluster (the plan's REFUTE fallback -- nothing blocks the mint).
+        kept = [sorted(i for c in clusters for i in c)]
+        outliers = []
+        fallback_pooled_all = True
+
+    templates = [
+        build_layout_template([scans[i] for i in members]) for members in kept
+    ]
+    default_members, default_template = kept[0], templates[0]
+
+    variants = []
+    variant_members: list[list[int]] = []
+    degenerate: list[dict] = []
+    distinguishing: list[str] = []
+    for members, tpl in zip(kept[1:], templates[1:]):
+        missing = _missing_variant_sections(tpl)
+        if missing:
+            # The cluster is real signature-space structure, but its pooled
+            # template is unusable as a layout (a receipt layout without an
+            # items block is a classification artifact, not a format).
+            degenerate.append(
+                {
+                    "receipt_refs": [keys[i] for i in members],
+                    "reason": (
+                        "pooled template missing required section(s): "
+                        + ", ".join(missing)
+                    ),
+                    "markers_common": sorted(
+                        _common_markers(signatures, members)
+                    ),
+                }
+            )
+            continue
+        hint = _classifier_hint(
+            signatures, members, default_members, tpl, default_template
+        )
+        vid = _variant_id(hint, len(variants) + 1)
+        variants.append(
+            {
+                "variant_id": vid,
+                "classifier_hint": hint,
+                **_strip_template(tpl),
+                "support": len(members),
+                "source_receipt_keys": [keys[i] for i in members],
+            }
+        )
+        variant_members.append(members)
+        for feat_key, label in (
+            ("markers_any", "prints"),
+            ("markers_absent", "omits"),
+            ("sections_added", "adds section"),
+            ("sections_missing", "drops section"),
+        ):
+            for name in hint[feat_key]:
+                distinguishing.append(f"{vid}: {label} {name!r}")
+        distinguishing.extend(
+            _column_shift_features(vid, tpl, default_template)
+        )
+
+    template = dict(default_template)
+    template["_comment"] = (
+        "Measured layout, cluster-before-pool (W-G): receipts clustered by "
+        "layout signature, columns/sections/separators pooled per cluster "
+        "via glyphstudio.variant_cluster. Top level = dominant cluster; "
+        "other clusters in `variants`."
+    )
+    template["variant_id"] = "default"
+    template["support"] = len(default_members)
+    template["source_receipt_keys"] = [keys[i] for i in default_members]
+    template["variants"] = variants
+    template["measured"] = {
+        **default_template["measured"],
+        "receipts": len(default_members),
+        "receipts_total": len(scans),
+        "clustering": {
+            "algorithm": "average-linkage-agglomerative",
+            "deterministic": True,
+            "threshold": threshold,
+            "weights": WEIGHTS,
+            "column_x_scale": COLUMN_X_SCALE,
+            "min_variant_support": min_variant_support,
+            "required_variant_sections": list(REQUIRED_VARIANT_SECTIONS),
+            "clusters": 1 + len(variants),
+            "degenerate_clusters": len(degenerate),
+            "outliers": sum(len(c) for c in outliers),
+        },
+    }
+
+    confirmed = bool(variants)
+    if fallback_pooled_all:
+        reason = (
+            "no cluster reached min support "
+            f"{min_variant_support}; pooled all receipts as one template"
+        )
+    elif confirmed:
+        reason = (
+            f"{1 + len(variants)} stable clusters separate at threshold "
+            f"{threshold}; distinguishing features listed"
+        )
+    else:
+        reason = (
+            "single stable cluster at threshold "
+            f"{threshold}; no second usable layout format found"
+        )
+        if degenerate:
+            reason += (
+                f" ({len(degenerate)} degenerate cluster(s) demoted: "
+                "pooled template unusable as a layout)"
+            )
+    verdict = {
+        "proposal": proposal,
+        "status": "CONFIRM" if confirmed else "REFUTE",
+        "reason": reason,
+        "clusters": [
+            {
+                "variant_id": (
+                    "default"
+                    if ordinal == 0
+                    else variants[ordinal - 1]["variant_id"]
+                ),
+                "support": len(members),
+                "receipt_refs": [keys[i] for i in members],
+                "markers_common": sorted(_common_markers(signatures, members)),
+                "marker_prevalence": _marker_prevalence(signatures, members),
+            }
+            for ordinal, members in enumerate(
+                [default_members, *variant_members]
+            )
+        ],
+        "degenerate_clusters": degenerate,
+        "outliers": [
+            {"receipt_refs": [keys[i] for i in members]}
+            for members in outliers
+        ],
+        "distinguishing_features": distinguishing,
+    }
+
+    provenance = {
+        "source_kind": "measurement",
+        "pipeline": "build_variant_layout",
+        "pipeline_version": "1",
+        "git_sha": default_template["measured"].get("tool_git_sha"),
+        "measured_at": measured_at,
+        "source_receipt_keys": keys,
+        "excluded_receipt_keys": excluded_receipt_keys or [],
+        "params": {
+            "threshold": threshold,
+            "weights": WEIGHTS,
+            "column_x_scale": COLUMN_X_SCALE,
+            "min_variant_support": min_variant_support,
+        },
+    }
+    return {"template": template, "verdict": verdict, "provenance": provenance}
+
+
+def pairwise_distance_report(
+    scans_by_key: list[tuple[str, dict]],
+) -> list[tuple[str, str, float]]:
+    """(key_a, key_b, distance) for every pair -- threshold calibration aid."""
+    ordered = sorted(scans_by_key, key=lambda kv: kv[0])
+    sigs = [receipt_signature(s) for _, s in ordered]
+    out = []
+    for i in range(len(ordered)):
+        for j in range(i + 1, len(ordered)):
+            out.append(
+                (
+                    ordered[i][0],
+                    ordered[j][0],
+                    round(signature_distance(sigs[i], sigs[j]), 4),
+                )
+            )
+    return out
+
+
+def median_link_summary(
+    report: list[tuple[str, str, float]],
+) -> dict[str, float]:
+    """Distance distribution summary for the CLI printout."""
+    ds = [d for _, _, d in report]
+    if not ds:
+        return {}
+    ds_sorted = sorted(ds)
+    return {
+        "min": ds_sorted[0],
+        "median": round(median(ds_sorted), 4),
+        "max": ds_sorted[-1],
+    }

--- a/tools/glyph-studio/py/tests/test_variant_cluster.py
+++ b/tools/glyph-studio/py/tests/test_variant_cluster.py
@@ -1,0 +1,357 @@
+"""Unit tests for cluster-before-pool layout variants (W-G).
+
+Two synthetic populations (register vs self-checkout) MUST separate; a
+homogeneous population with content jitter must NOT split; a shuffled input
+order must yield byte-identical output; every emitted template/variant must
+pass the unchanged validate_layout_template.
+"""
+
+import json
+import os
+import random
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), os.pardir))
+
+from glyphstudio.layout_template import (  # noqa: E402
+    validate_layout_template,
+)
+from glyphstudio.variant_cluster import (  # noqa: E402
+    build_variant_payload,
+    cluster_signatures,
+    receipt_key,
+    receipt_signature,
+    signature_distance,
+)
+
+_H = 2000
+
+
+def _line(y_frac, raw, canonical, text, tokens):
+    y = int(y_frac * _H)
+    return {
+        "section": raw,
+        "section_canonical": canonical,
+        "text": text,
+        "tokens": tokens,
+        "bbox": [50, y - 10, 950, y + 10],
+    }
+
+
+def _tok(role, left, right):
+    return {"role": role, "l": round(left, 4), "r": round(right, 4)}
+
+
+def _register_scan(i):
+    """Register-format receipt: member line, amounts at x~0.86, footer +
+    barcode trailer. Content jitter: item count and lane wobble vary."""
+    jx = 0.004 * ((i % 3) - 1)
+    lines = [
+        _line(0.02, "warehouse_header", "storefront", "COSTCO WHOLESALE", []),
+        _line(0.05, "member", "storefront", "Member 111222333444", []),
+        _line(0.08, "separator", None, "*" * 12, []),
+    ]
+    y = 0.14
+    for n in range(5 + (i % 3)):
+        lines.append(
+            _line(
+                y,
+                "item",
+                "items",
+                f"ITEM {n} 9.99",
+                [
+                    _tok("desc", 0.05 + jx, 0.30),
+                    _tok("amount", 0.80, 0.86 + jx),
+                ],
+            )
+        )
+        y += 0.05
+    lines += [
+        _line(
+            0.55,
+            "summary",
+            "summary",
+            "SUBTOTAL 59.94",
+            [_tok("label", 0.40 + jx, 0.52), _tok("amount", 0.80, 0.86 + jx)],
+        ),
+        _line(
+            0.58,
+            "summary",
+            "summary",
+            "TAX 4.94",
+            [_tok("label", 0.40 + jx, 0.46), _tok("amount", 0.80, 0.86 + jx)],
+        ),
+        _line(
+            0.62,
+            "total_line",
+            "total_line",
+            "**** TOTAL 64.88",
+            [_tok("label", 0.35, 0.50), _tok("amount", 0.80, 0.86 + jx)],
+        ),
+        _line(0.70, "payment", "payment", "XXXXXXXXXXXX1234 CHIP", []),
+        _line(
+            0.75,
+            "items_sold",
+            "summary",
+            "ITEMS SOLD 6",
+            [_tok("label", 0.30, 0.48), _tok("amount", 0.80, 0.86 + jx)],
+        ),
+        _line(0.85, "footer", "footer", "OP# 12 THANK YOU", []),
+    ]
+    if i % 4 != 3:  # one register receipt lacks the barcode trailer
+        lines.append(
+            _line(0.92, "barcode_caption", "barcode", "1234567890123", [])
+        )
+    return {
+        "image_id": f"reg-{i:04d}",
+        "receipt_id": 1,
+        "image_size": [1000, _H],
+        "lines": lines,
+    }
+
+
+def _selfcheckout_scan(i):
+    """Self-checkout format: SELF-CHECKOUT lane header, no member line, no
+    footer/barcode trailer, amounts in a narrower lane at x~0.70."""
+    jx = 0.004 * ((i % 3) - 1)
+    lines = [
+        _line(0.02, "self_checkout", "storefront", "SELF-CHECKOUT", []),
+        _line(0.05, "warehouse_header", "storefront", "COSTCO WHOLESALE", []),
+    ]
+    y = 0.12
+    for n in range(4 + (i % 2)):
+        lines.append(
+            _line(
+                y,
+                "item",
+                "items",
+                f"ITEM {n} 7.49",
+                [
+                    _tok("desc", 0.08 + jx, 0.32),
+                    _tok("amount", 0.64, 0.70 + jx),
+                ],
+            )
+        )
+        y += 0.05
+    lines += [
+        _line(
+            0.48,
+            "summary",
+            "summary",
+            "SUBTOTAL 29.96",
+            [_tok("label", 0.40 + jx, 0.52), _tok("amount", 0.64, 0.70 + jx)],
+        ),
+        _line(
+            0.54,
+            "total_line",
+            "total_line",
+            "**** TOTAL 32.43",
+            [_tok("label", 0.35, 0.50), _tok("amount", 0.64, 0.70 + jx)],
+        ),
+        _line(
+            0.60,
+            "items_sold",
+            "summary",
+            "ITEMS SOLD 4",
+            [_tok("label", 0.30, 0.48), _tok("amount", 0.64, 0.70 + jx)],
+        ),
+        _line(0.66, "payment", "payment", "XXXXXXXXXXXX1234 CHIP", []),
+    ]
+    return {
+        "image_id": f"sfc-{i:04d}",
+        "receipt_id": 1,
+        "image_size": [1000, _H],
+        "lines": lines,
+    }
+
+
+def _keyed(scans):
+    return [(receipt_key(s["image_id"], s["receipt_id"]), s) for s in scans]
+
+
+def _mixed_corpus():
+    return _keyed(
+        [_register_scan(i) for i in range(5)]
+        + [_selfcheckout_scan(i) for i in range(4)]
+    )
+
+
+def test_signature_captures_markers_and_columns():
+    sig = receipt_signature(_selfcheckout_scan(0))
+    assert "self_checkout" in sig["markers"]
+    assert "item" not in sig["markers"]  # content rows are not markers
+    assert sig["sequence"][0] == "storefront"
+    amounts = [
+        c["x"] for c in sig["columns"]["items"] if c["role"] == "amount"
+    ]
+    assert amounts and abs(amounts[0] - 0.696) < 0.02
+
+
+def test_within_population_distance_below_between():
+    reg = [receipt_signature(_register_scan(i)) for i in range(3)]
+    sfc = [receipt_signature(_selfcheckout_scan(i)) for i in range(3)]
+    within = max(
+        signature_distance(reg[0], reg[1]),
+        signature_distance(reg[0], reg[2]),
+        signature_distance(sfc[0], sfc[1]),
+    )
+    between = min(signature_distance(a, b) for a in reg for b in sfc)
+    assert within < 0.18 < between
+
+
+def test_two_populations_separate():
+    payload = build_variant_payload(_mixed_corpus())
+    template, verdict = payload["template"], payload["verdict"]
+    assert verdict["status"] == "CONFIRM"
+    assert len(verdict["clusters"]) == 2
+    # dominant cluster = the 5 register receipts, top-level default
+    assert template["support"] == 5
+    assert all("reg-" in k for k in template["source_receipt_keys"])
+    (variant,) = template["variants"]
+    assert variant["support"] == 4
+    assert all("sfc-" in k for k in variant["source_receipt_keys"])
+    # the classifier hint names the self-checkout lane header marker
+    assert variant["variant_id"] == "self_checkout"
+    assert "self_checkout" in variant["classifier_hint"]["markers_any"]
+    assert "member" in variant["classifier_hint"]["markers_absent"]
+    # per-cluster pooling kept the distinct amount lanes
+    default_amount = [
+        c["x"] for c in template["columns"]["items"] if c["role"] == "amount"
+    ]
+    variant_amount = [
+        c["x"] for c in variant["columns"]["items"] if c["role"] == "amount"
+    ]
+    assert abs(default_amount[0] - 0.86) < 0.02
+    assert abs(variant_amount[0] - 0.70) < 0.02
+    assert verdict["distinguishing_features"]
+
+
+def test_homogeneous_population_does_not_split():
+    payload = build_variant_payload(
+        _keyed([_register_scan(i) for i in range(6)])
+    )
+    assert payload["verdict"]["status"] == "REFUTE"
+    assert payload["template"]["variants"] == []
+    assert payload["template"]["support"] == 6
+    assert len(payload["verdict"]["clusters"]) == 1
+
+
+def test_shuffled_input_is_deterministic():
+    corpus = _mixed_corpus()
+    shuffled = list(corpus)
+    random.Random(42).shuffle(shuffled)
+    a = build_variant_payload(corpus)
+    b = build_variant_payload(shuffled)
+    assert json.dumps(a, sort_keys=True) == json.dumps(b, sort_keys=True)
+
+
+def test_cluster_signatures_orders_are_stable():
+    sigs = [
+        receipt_signature(s)
+        for _, s in sorted(_mixed_corpus(), key=lambda kv: kv[0])
+    ]
+    clusters = cluster_signatures(sigs)
+    assert [len(c) for c in clusters] == [5, 4]
+    assert clusters == [sorted(c) for c in clusters]
+
+
+def test_emitted_payload_passes_existing_validator():
+    payload = build_variant_payload(_mixed_corpus())
+    assert validate_layout_template(payload["template"]) == []
+    for variant in payload["template"]["variants"]:
+        assert validate_layout_template({"version": 1, **variant}) == []
+
+
+def test_photo_exclusion_recorded_in_provenance():
+    excluded = [
+        {
+            "receipt_key": receipt_key("photo-0001", 1),
+            "reason": "image_type=PHOTO",
+        }
+    ]
+    payload = build_variant_payload(
+        _mixed_corpus(), excluded_receipt_keys=excluded
+    )
+    assert payload["provenance"]["excluded_receipt_keys"] == excluded
+    assert payload["provenance"]["source_receipt_keys"] == sorted(
+        k for k, _ in _mixed_corpus()
+    )
+
+
+def test_singleton_outlier_not_emitted_as_variant():
+    """An outlier receipt (unique layout) is reported, never a variant --
+    pooling with support floor 2 would emit an empty template for it."""
+    weird = _selfcheckout_scan(99)
+    # push it far from both populations: extra-narrow lanes, no summary
+    for line in weird["lines"]:
+        for tok in line["tokens"]:
+            tok["l"] = round(tok["l"] * 0.5, 4)
+            tok["r"] = round(tok["r"] * 0.5, 4)
+    weird["lines"] = [
+        l for l in weird["lines"] if l["section"] != "items_sold"
+    ]
+    weird["image_id"] = "odd-0001"
+    corpus = _keyed([_register_scan(i) for i in range(5)] + [weird])
+    payload = build_variant_payload(corpus)
+    assert payload["template"]["variants"] == []
+    assert payload["verdict"]["status"] == "REFUTE"
+    outlier_refs = [
+        ref
+        for out in payload["verdict"]["outliers"]
+        for ref in out["receipt_refs"]
+    ]
+    assert outlier_refs == [receipt_key("odd-0001", 1)]
+
+
+def _itemless_scan(i):
+    """A cluster-forming scan whose item rows were swallowed by a content
+    rule (the real Costco INSTANT-SAVINGS case): canonically there is no
+    items section left, so its pooled template is unusable as a layout."""
+    scan = _selfcheckout_scan(i)
+    for line in scan["lines"]:
+        if line["section"] == "item":
+            line["section"] = "savings"
+            line["section_canonical"] = "summary"
+    scan["image_id"] = f"sav-{i:04d}"
+    return scan
+
+
+def test_degenerate_cluster_demoted_not_emitted():
+    corpus = _keyed(
+        [_register_scan(i) for i in range(5)]
+        + [_itemless_scan(i) for i in range(2)]
+    )
+    payload = build_variant_payload(corpus)
+    # the itemless pair clusters, but its pooled template lacks the items
+    # section -> demoted to a DEGENERATE record, not a variant
+    assert payload["template"]["variants"] == []
+    assert payload["verdict"]["status"] == "REFUTE"
+    (deg,) = payload["verdict"]["degenerate_clusters"]
+    assert "items" in deg["reason"]
+    assert deg["receipt_refs"] == [
+        receipt_key("sav-0000", 1),
+        receipt_key("sav-0001", 1),
+    ]
+    # verdict clusters carry marker prevalence for the owner's review
+    assert (
+        payload["verdict"]["clusters"][0]["marker_prevalence"]["member"] == 5
+    )
+
+
+def test_classifier_hint_markers_are_distinctive():
+    """Markers shared by both populations must never become classifiers;
+    only markers common to one side and rare on the other survive."""
+    payload = build_variant_payload(_mixed_corpus())
+    (variant,) = payload["template"]["variants"]
+    hint = variant["classifier_hint"]
+    for shared in (
+        "warehouse_header",
+        "items_sold",
+        "summary",
+        "total_line",
+        "payment",
+    ):
+        assert shared not in hint["markers_any"]
+        assert shared not in hint["markers_absent"]
+    assert hint["markers_any"] == ["self_checkout"]
+    assert set(hint["markers_absent"]) == {"member", "footer"}


### PR DESCRIPTION
## What

W-G of the Costco v2 sprint (the long pole): the variant-clustering measurement pipeline. `build_layout_template` pools evidence across ALL scans, which would average away real format families — this clusters per-receipt layout signatures FIRST, then pools per cluster through the existing machinery.

- **`glyphstudio/variant_cluster.py`** — layout signatures (canonical section sequence + position fractions, raw stylescan *format markers* — `self_checkout` survives even though it canonicalizes to `storefront` — and columnscan lane geometry), weighted signature distance, and deterministic average-linkage agglomerative clustering. No randomness anywhere: sorted-receipt-key order + lowest-index tie-breaks ⇒ shuffled input yields byte-identical output.
- **`scripts/build_variant_layout.py`** — read-only driver over dev: ReceiptPlace GSI1 (`MERCHANT#COSTCO_WHOLESALE`) enumeration → SCAN-only corpus (PHOTO exclusions recorded in output provenance) → fresh `stylescan.measure` per receipt into the persisted scan-dir convention (`tools/glyph-studio/.out/stylescan/<slug>/` + `manifest.json` with per-record sha256) → cluster → pool per cluster → emit payload. Never writes Dynamo or `merchant_profiles.json` (consuming the payload is W-J's mint).
- **Payload shape (v3.1, invariant 2)** — `template` keeps `version: 1`; dominant cluster is the top-level default (`columns`/`sections`/`separators`, plus `support` + `source_receipt_keys` — v1's were empty); other clusters land in `template.variants[]` as `{variant_id, classifier_hint, columns, sections, separators, support, source_receipt_keys}`. Passes the **unchanged** `validate_layout_template` (top level and every variant re-wrapped as `{version: 1, ...}`).
- **Verdict block** — CONFIRM/REFUTE for the `self-checkout-layout-variant` proposal with per-cluster `receipt_refs`, `markers_common`, `marker_prevalence`, degenerate clusters, and outliers.

Two robustness rules that the real corpus forced:
- **Distinctive classifier hints**: a hint marker must be common to every receipt of one cluster and present in ≤20% of the other's — without this, `total_line` (missing from 2 noisy scans) polluted the hints.
- **Degenerate-cluster demotion**: a cluster whose pooled template loses the `items` section (real case below) is real signature-space structure but unusable as a layout — recorded as DEGENERATE in the verdict, never emitted as a variant.

## Real run over the dev corpus (`ReceiptsTable-dc5be22`, read-only)

Corpus: **39 Costco receipt-places → 31 SCAN measured (0 failures), 8 PHOTO excluded** (recorded in `provenance.excluded_receipt_keys`). Note: plan said 29 SCAN; the corpus has grown to 31.

**Verdict: REFUTE** — single stable cluster at threshold 0.18; no second usable layout format.

| cluster | support | note |
|---|---|---|
| `default` | **24** | the dominant layout; `SELF-CHECKOUT` header prevalent in **22/24** |
| degenerate (demoted) | 2 | `314ac65b…#1`, `3ea1b045…#1` — INSTANT-SAVINGS-heavy receipts whose item rows the stylescan `savings` rule (`/\d+$`) reclassified; pooled template lost the `items` section entirely |
| singleton outliers | 5×1 | `0324604e…#1`, `165b9d15…#1`, `41885f70…#1`, `57cb7f2c…#1`, `6cd1f7f5…#1` |

**The surprise that decides the proposal**: `self_checkout` is not a minority variant marker — it appears on **24/31** receipts. The self-checkout receipt IS the dominant Costco layout in this corpus. Of the 7 receipts *without* the header (the register candidates):
- 2 (`84efc4e9…#2`, `ac5fd741…#2`) are layout-identical to the dominant cluster (signature distance 0.04–0.07) and merge into it;
- the other 5 are mutually heterogeneous (pairwise distances 0.20–0.55 — different section orders, different lane geometry, one carries the corpus's only `member` line) and never cohere into a register cluster.

So register-vs-self-checkout does **not** split Costco's layout at this signature granularity: there is one stable format (which happens to be the self-checkout print), plus one-off register receipts that differ from each other as much as from the default. Threshold stability: the `[24, 2, 5×1]` structure holds for thresholds 0.16–0.18; at 0.20 the savings pair merges into the default (still REFUTE); no setting produces a stable register cluster.

Default template highlights (support = receipts): sections `storefront → items → summary → total_line → payment → barcode → footer`; items lanes `desc x=0.0125 (21)`, `amount x=0.9357 (24/24)`; distance distribution min 0.005 / median 0.142 / max 0.551.

- Emitted payload sha256: `a203d4a8ff2dbae625f0a7d9038f2a9a701b1a6c631b123380f7c66ecfe782fa`
- Committed sample (full payload incl. verdict + provenance): `tools/glyph-studio/fixtures/costco_variant_layout.sample.json`

**For W-J**: this payload resolves the open `self-checkout-layout-variant` proposal as **REFUTED**, with receipt_refs per cluster in `verdict.clusters` / `degenerate_clusters` / `outliers`. The v2 layout component ships the single default template with real `support`/`source_receipt_keys` (24 receipts) and an empty `variants[]` — fully within invariant 2. The degenerate savings pair is a *stylescan classification* finding (the `savings` rule `/\d+$` swallows item rows on savings-heavy receipts), worth a follow-up proposal of its own.

## Tests

11 new fixture-based tests in `tools/glyph-studio/py/tests/test_variant_cluster.py` (glyph-studio suite: 279 pass locally):
- two synthetic populations (register vs self-checkout) MUST separate — CONFIRM, hint `markers_any=[self_checkout]`, distinct amount lanes preserved per cluster;
- homogeneous population with content jitter must NOT split (over-clustering guard);
- shuffled input order → identical output (determinism);
- emitted template + every variant pass the unchanged `validate_layout_template`;
- degenerate demotion (itemless cluster → DEGENERATE record, REFUTE), distinctive-marker hints, singleton-outlier handling, PHOTO-exclusion provenance.

## Verification

- Real run: `python scripts/build_variant_layout.py --print-distances` (fresh stylescan of all 31 SCAN receipts; log excerpts above; payload validates and is committed as the sample fixture).
- `python -m pytest tests -q` in `tools/glyph-studio/py`: 279 passed (`test_section_propagate` collection error is a pre-existing local-venv receipt_chroma mismatch, untouched here).
- No writes to any Dynamo table; S3/CDN reads only; `merchant_profiles.json` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BeLcSviHL5vDgS3zTSMbsq