### PR TITLE
[receipt_dynamo] v2 seal plumbing: version readers + eval→seal gate bridge (W-C/W-D)

### DIFF
--- a/receipt_dynamo/receipt_dynamo/data/_merchant_truth.py
+++ b/receipt_dynamo/receipt_dynamo/data/_merchant_truth.py
@@ -920,6 +920,81 @@ class _MerchantTruth(FlattenedStandardMixin):
         )
         return [MerchantTruthProposal.from_item(item) for item in items]
 
+    def _highest_manifest_item(
+        self, slug: str, *, sealed_only: bool
+    ) -> dict[str, Any] | None:
+        """Return the highest-version manifest item via a descending Query.
+
+        Contract §7.4: descending Query on ``begins_with(SK, "TRUTH#v")``,
+        first manifest. A ``FilterExpression`` keeps only manifest rows (so
+        components never win the "first" slot) and, when ``sealed_only``,
+        only SEALED manifests. With ``ScanIndexForward=False`` DynamoDB
+        returns matches in descending SK order, so the first item of the
+        first non-empty page is the highest matching version. Pagination is
+        honored because a FilterExpression can empty a page while more pages
+        remain. Gaps in the version sequence (from an OPEN-version cleanup)
+        are irrelevant: "latest" is whatever the Query returns, never a count.
+        """
+        names: dict[str, str] = {"#type": "TYPE"}
+        values: dict[str, Any] = {
+            ":pk": {"S": merchant_truth_pk(slug)},
+            ":sk": {"S": "TRUTH#v"},
+            ":manifest": {"S": "MERCHANT_TRUTH_MANIFEST"},
+        }
+        filter_expression = "#type = :manifest"
+        if sealed_only:
+            names["#status"] = "status"
+            values[":sealed"] = {"S": "SEALED"}
+            filter_expression += " AND #status = :sealed"
+        exclusive_start_key = None
+        while True:
+            request: dict[str, Any] = {
+                "TableName": self.table_name,
+                "KeyConditionExpression": (
+                    "PK = :pk AND begins_with(SK, :sk)"
+                ),
+                "FilterExpression": filter_expression,
+                "ExpressionAttributeNames": names,
+                "ExpressionAttributeValues": values,
+                "ScanIndexForward": False,
+            }
+            if exclusive_start_key is not None:
+                request["ExclusiveStartKey"] = exclusive_start_key
+            response = self._client.query(**request)
+            items = response.get("Items", [])
+            if items:
+                return items[0]
+            exclusive_start_key = response.get("LastEvaluatedKey")
+            if not exclusive_start_key:
+                return None
+
+    def get_latest_merchant_truth_version(
+        self, slug: str, *, sealed_only: bool
+    ) -> int | None:
+        """Return the highest existing version for ``slug`` (contract §7.4).
+
+        ``sealed_only=True`` returns the highest SEALED version (what
+        promotion/diff/mint-from want); otherwise the highest version of any
+        status, OPEN included (what mint allocation must see so it never
+        collides with an in-flight OPEN version). ``None`` when the partition
+        holds no matching manifest.
+        """
+        item = self._highest_manifest_item(slug, sealed_only=sealed_only)
+        return int(item["version"]["N"]) if item else None
+
+    def next_mint_version(self, slug: str) -> int:
+        """Return the next version to allocate for ``slug`` (contract §7.4).
+
+        ``get_latest_merchant_truth_version(sealed_only=False) + 1`` (1 when
+        no versions exist). Sees OPEN versions so a fresh mint never collides
+        with an in-flight one; version numbers are never reused, and gaps
+        left by an OPEN-version cleanup are legal and expected.
+        """
+        latest = self.get_latest_merchant_truth_version(
+            slug, sealed_only=False
+        )
+        return 1 if latest is None else latest + 1
+
     def _query_all(self, **params: Any) -> list[dict[str, Any]]:
         items: list[dict[str, Any]] = []
         exclusive_start_key = None

--- a/receipt_dynamo/receipt_dynamo/data/merchant_truth_gate_bridge.py
+++ b/receipt_dynamo/receipt_dynamo/data/merchant_truth_gate_bridge.py
@@ -1,0 +1,125 @@
+"""Adapt ``full_fidelity_eval`` output onto the seal gate contract.
+
+``full_fidelity_eval`` emits ``checks["overall"] ∈ {PASS, PASS_WITH_GAPS,
+FAIL}`` with a per-metric verdict under each metric key, while
+``_MerchantTruth.seal_version`` derives its gate from an explicit
+``gate_results`` block (``_derive_gate_status``: explicit ``status``/``passed``,
+fail-closed on ambiguity). This bridge maps one onto the other under the
+PASS_WITH_GAPS policy of contract §7.5 / §7.6:
+
+- ``PASS`` -> seals with a passing signal, no gaps.
+- ``PASS_WITH_GAPS`` -> **seals** with a passing signal while recording the
+  gap list verbatim, so a sealed-with-gaps version is still owner-gated at
+  flip time and its gaps are never summarized away.
+- ``FAIL`` -> **blocks the seal** (``GateBlockedError``); the version stays
+  OPEN and the derived gaps ride the exception as the work list.
+
+Consistency invariant (§7.5): ``overall == "PASS_WITH_GAPS"`` **iff** the gap
+list is non-empty. A ``PASS_WITH_GAPS`` with an empty gap list, or a non-empty
+gap list presented as a plain ``PASS``, is a bridge error and fails closed.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Iterator
+
+from receipt_dynamo.data.shared_exceptions import (
+    GateBlockedError,
+    GateBridgeError,
+)
+
+__all__ = [
+    "bridge_eval_to_gate_results",
+    "GateBlockedError",
+    "GateBridgeError",
+]
+
+VALID_OVERALL = frozenset({"PASS", "PASS_WITH_GAPS", "FAIL"})
+
+# Keys in the eval ``checks`` dict that are aggregate signals, not metrics.
+_NON_METRIC_KEYS = frozenset({"overall", "coverage_gaps"})
+
+
+def _metric_entries(
+    checks: dict[str, Any],
+) -> Iterator[tuple[str, dict[str, Any]]]:
+    """Yield ``(name, entry)`` for each per-metric verdict block.
+
+    A metric entry is any dict value carrying a ``"verdict"`` key; the
+    aggregate ``overall`` (a string) and ``coverage_gaps`` (a list) never
+    match. Sorted by name so the derived ``per_metric``/``gaps`` are
+    deterministic. This shape covers both the seven-metric synthetic pair
+    eval and the three-metric real-real eval without enumerating names.
+    """
+    for name in sorted(checks):
+        if name in _NON_METRIC_KEYS:
+            continue
+        entry = checks[name]
+        if isinstance(entry, dict) and "verdict" in entry:
+            yield name, entry
+
+
+def bridge_eval_to_gate_results(checks: dict[str, Any]) -> dict[str, Any]:
+    """Convert eval ``checks`` into a ``seal_version`` gate_results block.
+
+    Returns the ``gate_results`` dict that ``seal_version`` accepts for a
+    ``PASS`` or ``PASS_WITH_GAPS`` overall. Raises :class:`GateBlockedError`
+    on ``FAIL`` (the seal is blocked, version stays OPEN) and
+    :class:`GateBridgeError` on structurally inconsistent input (unknown
+    ``overall``, the empty-gaps invariant, or non-PASS metrics dressed as a
+    plain ``PASS``).
+
+    ``gaps`` is exactly the non-PASS subset of the per-metric verdicts,
+    each ``{metric, verdict, detail}`` where ``detail`` is the metric entry's
+    remaining fields (everything but ``verdict``), recorded verbatim.
+    ``per_metric`` keeps the full picture (every metric's verdict).
+    """
+    if not isinstance(checks, dict):
+        raise GateBridgeError("eval checks must be a mapping")
+
+    overall = checks.get("overall")
+    if overall not in VALID_OVERALL:
+        raise GateBridgeError(f"unknown eval overall verdict: {overall!r}")
+
+    per_metric: list[dict[str, Any]] = []
+    gaps: list[dict[str, Any]] = []
+    for name, entry in _metric_entries(checks):
+        verdict = entry.get("verdict")
+        per_metric.append({"metric": name, "verdict": verdict})
+        if verdict != "PASS":
+            detail = {
+                key: value for key, value in entry.items() if key != "verdict"
+            }
+            gaps.append({"metric": name, "verdict": verdict, "detail": detail})
+
+    # Two-way consistency invariant (§7.5): PASS_WITH_GAPS iff gaps non-empty.
+    if overall == "PASS_WITH_GAPS" and not gaps:
+        raise GateBridgeError(
+            "overall PASS_WITH_GAPS carries an empty gap list; the "
+            "gaps-invariant requires a non-empty gap list"
+        )
+    if overall == "PASS" and gaps:
+        raise GateBridgeError(
+            "overall PASS presents non-PASS metrics as a plain pass: "
+            f"{[gap['metric'] for gap in gaps]}"
+        )
+
+    if overall == "FAIL":
+        raise GateBlockedError(
+            "eval FAIL blocks the seal; version stays OPEN",
+            gate_results={
+                "status": "FAIL",
+                "passed": False,
+                "overall": "FAIL",
+                "per_metric": per_metric,
+                "gaps": gaps,
+            },
+        )
+
+    return {
+        "status": "PASS",
+        "passed": True,
+        "overall": overall,
+        "per_metric": per_metric,
+        "gaps": gaps,
+    }

--- a/receipt_dynamo/receipt_dynamo/data/shared_exceptions.py
+++ b/receipt_dynamo/receipt_dynamo/data/shared_exceptions.py
@@ -101,3 +101,31 @@ class MerchantTruthTableMismatchError(MerchantTruthError, ValueError):
 
 class MerchantTruthPromotionError(MerchantTruthError):
     """Raised when fail-closed promotion cannot preserve the truth closure."""
+
+
+class GateBridgeError(MerchantTruthError, ValueError):
+    """Raised when eval output cannot be adapted into a seal gate signal.
+
+    The eval->seal bridge (contract §7.5) fails closed on structurally
+    inconsistent input: an unknown ``overall`` verdict, an
+    ``overall == PASS_WITH_GAPS`` carrying an empty gap list, or a non-empty
+    gap list masquerading as a plain ``PASS``.
+    """
+
+
+class GateBlockedError(MerchantTruthError):
+    """Raised when a failing eval blocks a seal (contract §7.5).
+
+    A ``FAIL`` overall leaves the version OPEN. The gate record written for
+    the failing run is the work list for closing it, so the derived
+    ``gate_results`` (with the failing gaps) ride along on the exception.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        gate_results: dict | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.gate_results = gate_results or {}

--- a/receipt_dynamo/tests/integration/test_merchant_truth_seal_bridge.py
+++ b/receipt_dynamo/tests/integration/test_merchant_truth_seal_bridge.py
@@ -1,0 +1,127 @@
+"""End-to-end moto coverage for the §7.5 eval->seal gate bridge.
+
+Mints an OPEN version and seals it *through the bridge*: a PASS_WITH_GAPS
+eval payload seals with its gap list carried verbatim onto the sealed
+manifest, and a FAIL payload blocks the seal so the version stays OPEN.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from receipt_dynamo import DynamoClient
+from receipt_dynamo.data.merchant_truth_gate_bridge import (
+    GateBlockedError,
+    bridge_eval_to_gate_results,
+)
+from receipt_dynamo.entities.merchant_truth import (
+    COMPONENT_NAMES,
+    MerchantTruthComponent,
+)
+
+pytestmark = pytest.mark.integration
+SLUG = "costco-wholesale"
+NOW = "2026-07-22T16:00:00+00:00"
+LEGACY_PROVENANCE = {
+    "source_kind": "migration",
+    "provenance_completeness": "legacy",
+    "written_by": {
+        "kind": "migration",
+        "name": "merchant_truth_v1",
+        "version": "1",
+    },
+}
+MINT_PROVENANCE = {
+    "written_by": {
+        "kind": "migration",
+        "name": "merchant_truth_v1",
+        "version": "1",
+    }
+}
+
+
+def _mint_open(client: DynamoClient, table: str, version: int) -> None:
+    components = [
+        MerchantTruthComponent(
+            slug=SLUG,
+            version=version,
+            name=name,
+            payload={"component": name, "v": version},
+            provenance=dict(LEGACY_PROVENANCE),
+        )
+        for name in sorted(COMPONENT_NAMES)
+    ]
+    client.mint_version(
+        SLUG,
+        version,
+        components,
+        MINT_PROVENANCE,
+        f"run-{version}",
+        table,
+        created_at=NOW,
+    )
+
+
+def _eval_pass_with_gaps() -> dict:
+    return {
+        "columns": {"verdict": "PASS"},
+        "style": {"verdict": "PASS"},
+        "tokens": {"verdict": "PASS"},
+        "separators": {"verdict": "PASS_WITH_GAPS", "score": 0.72},
+        "graphics": {"verdict": "PASS"},
+        "logo": {"verdict": "UNTESTED", "note": "no storefront ink in real"},
+        "arithmetic": {"verdict": "PASS"},
+        "coverage_gaps": ["logo", "separators"],
+        "overall": "PASS_WITH_GAPS",
+    }
+
+
+def test_seal_through_bridge_carries_gaps_verbatim(
+    dynamodb_table: str,
+) -> None:
+    client = DynamoClient(dynamodb_table)
+    _mint_open(client, dynamodb_table, 1)
+
+    gate_results = bridge_eval_to_gate_results(_eval_pass_with_gaps())
+    sealed = client.seal_version(
+        SLUG, 1, gate_results, [], dynamodb_table, sealed_at=NOW
+    )
+
+    assert sealed.status == "SEALED"
+    assert sealed.gate_status == "PASS"
+
+    reloaded = client.get_merchant_truth_manifest(
+        SLUG, 1, consistent_read=True
+    )
+    assert reloaded is not None
+    stored = reloaded.gate_results
+    assert stored["overall"] == "PASS_WITH_GAPS"
+    gaps = {gap["metric"]: gap for gap in stored["gaps"]}
+    assert set(gaps) == {"separators", "logo"}
+    assert gaps["logo"]["verdict"] == "UNTESTED"
+    assert gaps["logo"]["detail"] == {"note": "no storefront ink in real"}
+    assert gaps["separators"]["detail"] == {"score": 0.72}
+
+
+def test_fail_payload_blocks_seal_and_leaves_version_open(
+    dynamodb_table: str,
+) -> None:
+    client = DynamoClient(dynamodb_table)
+    _mint_open(client, dynamodb_table, 1)
+
+    failing = {
+        "columns": {"verdict": "FAIL", "detail": "cols drift"},
+        "tokens": {"verdict": "PASS"},
+        "overall": "FAIL",
+    }
+    with pytest.raises(GateBlockedError):
+        gate_results = bridge_eval_to_gate_results(failing)
+        client.seal_version(
+            SLUG, 1, gate_results, [], dynamodb_table, sealed_at=NOW
+        )
+
+    reloaded = client.get_merchant_truth_manifest(
+        SLUG, 1, consistent_read=True
+    )
+    assert reloaded is not None
+    assert reloaded.status == "OPEN"

--- a/receipt_dynamo/tests/integration/test_merchant_truth_version_readers.py
+++ b/receipt_dynamo/tests/integration/test_merchant_truth_version_readers.py
@@ -1,0 +1,152 @@
+"""Moto coverage for the §7.4 version-number readers.
+
+Exercises the readers against a real (moto) partition: an empty partition,
+a v1-only partition, a sealed+open mix (where ``sealed_only`` must skip a
+higher OPEN version), and a gap left by an OPEN-version cleanup (where
+"latest" is whatever the descending Query returns, never a count).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from receipt_dynamo import DynamoClient
+from receipt_dynamo.entities.merchant_truth import (
+    COMPONENT_NAMES,
+    MerchantTruthComponent,
+)
+from receipt_dynamo.migrations.merchant_truth_v1_live import (
+    cleanup_unsealed_open_version,
+)
+
+pytestmark = pytest.mark.integration
+SLUG = "costco-wholesale"
+NOW = "2026-07-22T16:00:00+00:00"
+LEGACY_PROVENANCE = {
+    "source_kind": "migration",
+    "provenance_completeness": "legacy",
+    "written_by": {
+        "kind": "migration",
+        "name": "merchant_truth_v1",
+        "version": "1",
+    },
+}
+MINT_PROVENANCE = {
+    "written_by": {
+        "kind": "migration",
+        "name": "merchant_truth_v1",
+        "version": "1",
+    }
+}
+
+
+def _components(version: int) -> list[MerchantTruthComponent]:
+    return [
+        MerchantTruthComponent(
+            slug=SLUG,
+            version=version,
+            name=name,
+            payload={"component": name, "v": version},
+            provenance=dict(LEGACY_PROVENANCE),
+        )
+        for name in sorted(COMPONENT_NAMES)
+    ]
+
+
+def _mint_open(client: DynamoClient, table: str, version: int) -> None:
+    client.mint_version(
+        SLUG,
+        version,
+        _components(version),
+        MINT_PROVENANCE,
+        f"run-{version}",
+        table,
+        created_at=NOW,
+    )
+
+
+def _mint_and_seal(client: DynamoClient, table: str, version: int) -> None:
+    _mint_open(client, table, version)
+    client.seal_version(
+        SLUG,
+        version,
+        {"status": "PASS", "report": f"s3://eval/v{version}.json"},
+        [],
+        table,
+        sealed_at=NOW,
+    )
+
+
+def test_latest_and_next_over_empty_partition(dynamodb_table: str) -> None:
+    client = DynamoClient(dynamodb_table)
+
+    assert (
+        client.get_latest_merchant_truth_version(SLUG, sealed_only=False)
+        is None
+    )
+    assert (
+        client.get_latest_merchant_truth_version(SLUG, sealed_only=True)
+        is None
+    )
+    assert client.next_mint_version(SLUG) == 1
+
+
+def test_latest_and_next_with_v1_only(dynamodb_table: str) -> None:
+    client = DynamoClient(dynamodb_table)
+    _mint_and_seal(client, dynamodb_table, 1)
+
+    assert (
+        client.get_latest_merchant_truth_version(SLUG, sealed_only=False) == 1
+    )
+    assert (
+        client.get_latest_merchant_truth_version(SLUG, sealed_only=True) == 1
+    )
+    assert client.next_mint_version(SLUG) == 2
+
+
+def test_sealed_only_skips_a_higher_open_version(
+    dynamodb_table: str,
+) -> None:
+    client = DynamoClient(dynamodb_table)
+    _mint_and_seal(client, dynamodb_table, 1)
+    _mint_open(client, dynamodb_table, 2)  # in-flight, never sealed
+
+    # mint allocation must see the OPEN v2 so it never collides...
+    assert (
+        client.get_latest_merchant_truth_version(SLUG, sealed_only=False) == 2
+    )
+    assert client.next_mint_version(SLUG) == 3
+    # ...while promotion/diff want the highest SEALED, which is still v1.
+    assert (
+        client.get_latest_merchant_truth_version(SLUG, sealed_only=True) == 1
+    )
+
+
+def test_gap_after_open_version_cleanup_is_legal(
+    dynamodb_table: str,
+) -> None:
+    client = DynamoClient(dynamodb_table)
+    _mint_and_seal(client, dynamodb_table, 1)
+    _mint_open(client, dynamodb_table, 2)  # abandoned OPEN
+    _mint_and_seal(client, dynamodb_table, 3)
+
+    # Clean up the abandoned OPEN v2, leaving a permanent gap below v3.
+    result = cleanup_unsealed_open_version(
+        client._client,
+        table_name=dynamodb_table,
+        slug=SLUG,
+        version=2,
+        explicit_table=True,
+        delete=True,
+    )
+    assert result.deleted
+
+    # "latest" is whatever the descending Query returns, never a count:
+    # the v2 gap does not fool the reader into reporting v2.
+    assert (
+        client.get_latest_merchant_truth_version(SLUG, sealed_only=False) == 3
+    )
+    assert (
+        client.get_latest_merchant_truth_version(SLUG, sealed_only=True) == 3
+    )
+    assert client.next_mint_version(SLUG) == 4

--- a/receipt_dynamo/tests/unit/test_merchant_truth_access.py
+++ b/receipt_dynamo/tests/unit/test_merchant_truth_access.py
@@ -37,6 +37,7 @@ class RecordingClient:
         self.updates: list[dict[str, Any]] = []
         self.get_responses: list[dict[str, Any]] = []
         self.query_responses: list[dict[str, Any]] = []
+        self.query_calls: list[dict[str, Any]] = []
         self.transaction_errors: list[ClientError] = []
 
     def transact_write_items(self, **kwargs: Any) -> None:
@@ -53,7 +54,8 @@ class RecordingClient:
     def get_item(self, **_kwargs: Any) -> dict[str, Any]:
         return self.get_responses.pop(0) if self.get_responses else {}
 
-    def query(self, **_kwargs: Any) -> dict[str, Any]:
+    def query(self, **kwargs: Any) -> dict[str, Any]:
+        self.query_calls.append(kwargs)
         return self.query_responses.pop(0) if self.query_responses else {}
 
 
@@ -500,6 +502,79 @@ def test_mint_rejects_duplicate_component_and_writes_nothing() -> None:
         )
 
     assert client.transactions == []
+
+
+def test_latest_version_over_empty_partition_is_none() -> None:
+    client = RecordingClient()
+    client.query_responses.append({})
+    truth = accessor(client)
+
+    assert (
+        truth.get_latest_merchant_truth_version(SLUG, sealed_only=False)
+        is None
+    )
+
+
+def test_next_mint_version_starts_at_one_for_empty_partition() -> None:
+    client = RecordingClient()
+    client.query_responses.append({})
+    truth = accessor(client)
+
+    assert truth.next_mint_version(SLUG) == 1
+
+
+def test_latest_version_reads_first_descending_manifest() -> None:
+    client = RecordingClient()
+    client.query_responses.append({"Items": [manifest(3).to_item()]})
+    truth = accessor(client)
+
+    assert (
+        truth.get_latest_merchant_truth_version(SLUG, sealed_only=False) == 3
+    )
+    request = client.query_calls[0]
+    assert request["ScanIndexForward"] is False
+    assert request["ExpressionAttributeValues"][":sk"] == {"S": "TRUTH#v"}
+    # Without sealed_only, the filter keeps manifests but not the SEALED
+    # status, so open in-flight versions are visible to mint allocation.
+    assert ":sealed" not in request["ExpressionAttributeValues"]
+
+
+def test_next_mint_version_is_latest_plus_one() -> None:
+    client = RecordingClient()
+    client.query_responses.append({"Items": [manifest(4).to_item()]})
+    truth = accessor(client)
+
+    assert truth.next_mint_version(SLUG) == 5
+
+
+def test_latest_version_paginates_past_filtered_empty_pages() -> None:
+    client = RecordingClient()
+    # A FilterExpression can empty a page while more pages remain; the reader
+    # must follow LastEvaluatedKey rather than stop at the first empty page.
+    client.query_responses.append(
+        {"Items": [], "LastEvaluatedKey": {"PK": {"S": "x"}}}
+    )
+    client.query_responses.append({"Items": [manifest(7).to_item()]})
+    truth = accessor(client)
+
+    assert (
+        truth.get_latest_merchant_truth_version(SLUG, sealed_only=False) == 7
+    )
+    assert len(client.query_calls) == 2
+    assert "ExclusiveStartKey" in client.query_calls[1]
+
+
+def test_latest_sealed_only_carries_the_status_filter() -> None:
+    client = RecordingClient()
+    client.query_responses.append(
+        {"Items": [manifest(2, status="SEALED").to_item()]}
+    )
+    truth = accessor(client)
+
+    assert truth.get_latest_merchant_truth_version(SLUG, sealed_only=True) == 2
+    request = client.query_calls[0]
+    assert request["ExpressionAttributeValues"][":sealed"] == {"S": "SEALED"}
+    assert "#status = :sealed" in request["FilterExpression"]
 
 
 def test_dev_table_guard_fails_before_any_write() -> None:

--- a/receipt_dynamo/tests/unit/test_merchant_truth_gate_bridge.py
+++ b/receipt_dynamo/tests/unit/test_merchant_truth_gate_bridge.py
@@ -1,0 +1,142 @@
+"""Contract tests for the eval->seal gate bridge (contract §7.5 / §7.6)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from receipt_dynamo.data.merchant_truth_gate_bridge import (
+    GateBlockedError,
+    GateBridgeError,
+    bridge_eval_to_gate_results,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def checks(overall: str, **metrics: dict[str, Any]) -> dict[str, Any]:
+    """Build an eval-shaped ``checks`` dict with an overall + per-metric."""
+    doc: dict[str, Any] = dict(metrics)
+    doc["overall"] = overall
+    return doc
+
+
+def test_pass_seals_with_no_gaps() -> None:
+    result = bridge_eval_to_gate_results(
+        checks(
+            "PASS",
+            columns={"verdict": "PASS"},
+            tokens={"verdict": "PASS"},
+        )
+    )
+
+    assert result["status"] == "PASS"
+    assert result["passed"] is True
+    assert result["overall"] == "PASS"
+    assert result["gaps"] == []
+    assert {m["metric"] for m in result["per_metric"]} == {
+        "columns",
+        "tokens",
+    }
+
+
+def test_pass_with_gaps_seals_and_records_gaps_verbatim() -> None:
+    result = bridge_eval_to_gate_results(
+        checks(
+            "PASS_WITH_GAPS",
+            columns={"verdict": "PASS"},
+            logo={"verdict": "UNTESTED", "note": "no storefront ink in real"},
+            separators={"verdict": "PASS_WITH_GAPS", "score": 0.71},
+        )
+    )
+
+    # Seals with a passing signal while carrying the gap list.
+    assert result["status"] == "PASS"
+    assert result["passed"] is True
+    assert result["overall"] == "PASS_WITH_GAPS"
+
+    gaps = {gap["metric"]: gap for gap in result["gaps"]}
+    assert set(gaps) == {"logo", "separators"}
+    # detail is the metric entry verbatim minus its verdict -- never summarized.
+    assert gaps["logo"]["verdict"] == "UNTESTED"
+    assert gaps["logo"]["detail"] == {"note": "no storefront ink in real"}
+    assert gaps["separators"]["detail"] == {"score": 0.71}
+
+
+def test_gaps_are_exactly_the_non_pass_subset() -> None:
+    result = bridge_eval_to_gate_results(
+        checks(
+            "PASS_WITH_GAPS",
+            columns={"verdict": "PASS"},
+            style={"verdict": "PASS_WITH_GAPS"},
+            tokens={"verdict": "PASS"},
+            separators={"verdict": "SKIPPED"},
+            graphics={"verdict": "PASS"},
+            logo={"verdict": "UNTESTED"},
+            arithmetic={"verdict": "PASS"},
+        )
+    )
+
+    gap_metrics = {gap["metric"] for gap in result["gaps"]}
+    pass_metrics = {
+        m["metric"] for m in result["per_metric"] if m["verdict"] == "PASS"
+    }
+    # gaps == non-PASS subset, and it is disjoint from the PASS metrics.
+    assert gap_metrics == {"style", "separators", "logo"}
+    assert gap_metrics.isdisjoint(pass_metrics)
+    assert len(result["per_metric"]) == 7
+
+
+def test_fail_blocks_seal_and_carries_gaps_on_exception() -> None:
+    with pytest.raises(GateBlockedError) as excinfo:
+        bridge_eval_to_gate_results(
+            checks(
+                "FAIL",
+                columns={"verdict": "FAIL", "detail": "cols drift"},
+                tokens={"verdict": "PASS"},
+            )
+        )
+
+    blocked = excinfo.value.gate_results
+    assert blocked["status"] == "FAIL"
+    assert blocked["passed"] is False
+    assert {gap["metric"] for gap in blocked["gaps"]} == {"columns"}
+
+
+def test_pass_with_gaps_but_empty_gaps_is_a_bridge_error() -> None:
+    with pytest.raises(GateBridgeError, match="empty gap list"):
+        bridge_eval_to_gate_results(
+            checks(
+                "PASS_WITH_GAPS",
+                columns={"verdict": "PASS"},
+                tokens={"verdict": "PASS"},
+            )
+        )
+
+
+def test_pass_with_non_pass_metric_is_a_bridge_error() -> None:
+    with pytest.raises(GateBridgeError, match="plain pass"):
+        bridge_eval_to_gate_results(
+            checks(
+                "PASS",
+                columns={"verdict": "PASS"},
+                logo={"verdict": "UNTESTED"},
+            )
+        )
+
+
+@pytest.mark.parametrize(
+    "overall",
+    ["", "pass", "GREEN", "WARN", None],
+)
+def test_unknown_overall_is_rejected(overall: Any) -> None:
+    with pytest.raises(GateBridgeError, match="unknown eval overall"):
+        bridge_eval_to_gate_results(
+            checks(overall, columns={"verdict": "PASS"})
+        )
+
+
+def test_non_mapping_input_is_rejected() -> None:
+    with pytest.raises(GateBridgeError, match="must be a mapping"):
+        bridge_eval_to_gate_results(["not", "a", "dict"])  # type: ignore[arg-type]


### PR DESCRIPTION
Implements **W-C** and **W-D** from the Costco-Complete-in-Dynamo plan
(`.claude/plans/humble-skipping-quilt.md`, Phase 0/1), governed by the
MerchantTruth v3.1 schema-evolution amendment landed in #1210
(`docs/architecture/MERCHANT_TRUTH_DYNAMO.md` §7). #1210 has merged to
main, so this stacks cleanly; if it is ever reverted, this depends on §7
and must merge after it.

Merchant-generic by construction (Costco pilots v2, but nothing here is
Costco-specific).

## W-C — version-number readers (§7.4)
`receipt_dynamo/data/_merchant_truth.py` (auto-wired into `DynamoClient`
via the mixin):
- `get_latest_merchant_truth_version(slug, *, sealed_only)` — highest
  version via a descending Query over `begins_with(SK, "TRUTH#v")`. A
  `FilterExpression` keeps only manifest rows (components never win the
  "first" slot) and, when `sealed_only`, only SEALED manifests.
  `sealed_only=True` is what promotion/diff/mint-from want; `False` is
  what mint allocation needs so it sees an in-flight OPEN version and
  never collides.
- `next_mint_version(slug)` — `latest(sealed_only=False) + 1` (1 on an
  empty partition). Versions never reused; post-cleanup gaps are legal;
  "latest" is whatever the descending Query returns, never a count.
- Pagination honored (a FilterExpression can empty a page while more
  pages remain).

## W-D — eval→seal gate bridge + PASS_WITH_GAPS policy (§7.5)
New `receipt_dynamo/data/merchant_truth_gate_bridge.py`:
`bridge_eval_to_gate_results(checks)` converts `full_fidelity_eval`'s
`checks["overall"]` + per-metric verdicts into the explicit
`gate_results` block `_derive_gate_status` accepts.
- **PASS** → seals.
- **PASS_WITH_GAPS** → seals with a passing signal while recording the
  gap list **verbatim** (`{metric, verdict, detail}` = exactly the
  non-PASS subset of the per-metric verdicts; `detail` is the metric
  entry's remaining fields). Never summarized away; flips stay
  owner-gated.
- **FAIL** → raises typed `GateBlockedError`; version stays OPEN, derived
  gaps ride the exception as the work list.
- Two-way invariant fails closed: `PASS_WITH_GAPS` + empty gaps → bridge
  error; non-empty gaps may never present as plain `PASS`; unknown
  `overall` rejected. New typed `GateBridgeError` / `GateBlockedError`.

## Tests (moto only — never real AWS)
Full merchant-truth suite green: **102 passed**. 24 new tests.
- W-C: 6 unit (descending-Query shape, sealed_only status filter,
  filtered-empty-page pagination) + 4 moto integration (empty / v1-only /
  sealed+open mix / gap-after-cleanup).
- W-D: 12 unit (all three overalls, empty-gaps rejection, non-PASS-as-PASS
  rejection, unknown/non-mapping input, gaps-subset exactness) + 2 moto
  integration end-to-end (mint OPEN → seal THROUGH the bridge with a
  PASS_WITH_GAPS payload; sealed manifest carries verbatim gaps / FAIL
  blocks the seal, version stays OPEN).
- `black --line-length 79` and `isort` clean.

### Mutation honesty
- **(a) neutralize the `sealed_only` status filter** → `test_sealed_only_skips_a_higher_open_version`
  (moto) and `test_latest_sealed_only_carries_the_status_filter` (unit)
  FAIL (reader returns the higher OPEN v2 instead of SEALED v1).
- **(b) turn the FAIL branch into a seal** → `test_fail_blocks_seal_and_carries_gaps_on_exception`
  (unit) and `test_fail_payload_blocks_seal_and_leaves_version_open`
  (moto) FAIL (no `GateBlockedError`; version would seal).

Both mutations applied and reverted; kills confirmed.

## Contract ambiguity
None material. Two design calls, both resolvable from §7 text: (1) gap
`detail` is defined as the metric entry's non-`verdict` fields, captured
verbatim to satisfy "never summarized away" (§7.5/§7.6 name the field but
not its contents); (2) the bridge's own two-way invariant is a defensive
guard — with `full_fidelity_eval`'s current aggregation, `overall ==
PASS_WITH_GAPS` already implies a non-PASS top-level metric, so the
non-PASS subset is non-empty exactly when overall is PASS_WITH_GAPS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BeLcSviHL5vDgS3zTSMbsq