### PR TITLE
[render] Variant-aware readers + §7.2 hint reconciliation (W-H)

### DIFF
--- a/receipt_dynamo/receipt_dynamo/merchant_truth_variants.py
+++ b/receipt_dynamo/receipt_dynamo/merchant_truth_variants.py
@@ -1,0 +1,228 @@
+"""§7.2 layout-variant selection and ``classifier_hint`` matching.
+
+Single source of truth for the ``template.variants[]`` shape and the
+structured ``classifier_hint`` rules defined in
+``docs/architecture/MERCHANT_TRUTH_DYNAMO.md`` §7.2. Every consumer of the
+variant machinery imports from here so the *generator* (W-G,
+``glyphstudio.variant_cluster`` — emits hints) and the *readers* (W-H:
+``full_fidelity_eval.profile_columns`` selects a variant,
+``merchant_truth_diff.diff_layout`` descends the list) share one
+implementation of the selection algorithm — there is no second copy to drift.
+
+A ``classifier_hint`` is a structured rule, never free text::
+
+    {"type": "section_presence" | "section_order" | "text_marker", ...args}
+
+The reader matches a hint against exactly two inputs derived from the receipt
+under consideration and *nothing else*:
+
+* the **canonical section sequence** — the receipt's ``RECEIPT_SECTION``
+  canonical names in top-to-bottom order — for the ``section_*`` types, and
+* the **normalized OCR word set** — every OCR word upper-cased and
+  punctuation-stripped — for ``text_marker``.
+
+Selection is deterministic. When more than one variant's hint matches, the
+variant with the highest ``support`` wins; equal support breaks ties by the
+lexicographically smallest ``variant_id``. No match, no hint, a malformed
+hint, or an unrecognized ``type`` falls back to the DEFAULT variant (the
+template's top-level ``columns`` / ``sections`` / ``separators``).
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Iterable
+
+# Structured classifier_hint type tags (§7.2).
+HINT_SECTION_PRESENCE = "section_presence"
+HINT_SECTION_ORDER = "section_order"
+HINT_TEXT_MARKER = "text_marker"
+
+HINT_TYPES = frozenset(
+    {HINT_SECTION_PRESENCE, HINT_SECTION_ORDER, HINT_TEXT_MARKER}
+)
+
+# OCR words and hint markers normalize by splitting on every non-alphanumeric
+# run and upper-casing. "SELF-CHECKOUT" and a stylescan marker "self_checkout"
+# both normalize to the tokens {"SELF", "CHECKOUT"}, so a hint minted from a
+# marker matches the receipt regardless of how the OCR split the printed text.
+_TOKEN_SPLIT = re.compile(r"[^0-9A-Za-z]+")
+
+
+def normalize_section(name: Any) -> str:
+    """Canonical section name comparison key (case/space-insensitive)."""
+    return str(name).strip().lower()
+
+
+def normalize_section_sequence(sequence: Iterable[Any]) -> list[str]:
+    """A receipt's canonical section names, normalized, order preserved."""
+    return [normalize_section(s) for s in (sequence or []) if str(s).strip()]
+
+
+def marker_tokens(text: Any) -> list[str]:
+    """Split one printed marker / OCR word into normalized tokens."""
+    if text is None:
+        return []
+    return [tok for tok in _TOKEN_SPLIT.split(str(text).upper()) if tok]
+
+
+def normalize_word_set(words: Iterable[Any]) -> frozenset[str]:
+    """Words -> normalized OCR token set (upper-cased, punctuation-stripped).
+
+    Accepts raw strings or word dicts carrying a ``text`` field, so callers
+    can pass the eval's word dicts directly.
+    """
+    tokens: set[str] = set()
+    for word in words or ():
+        text = word.get("text") if isinstance(word, dict) else word
+        tokens.update(marker_tokens(text))
+    return frozenset(tokens)
+
+
+# --- hint builders (used by the W-G generator to emit §7.2 shapes) ---------
+
+
+def make_section_presence_hint(sections: Iterable[Any]) -> dict:
+    return {
+        "type": HINT_SECTION_PRESENCE,
+        "sections": [normalize_section(s) for s in sections],
+    }
+
+
+def make_section_order_hint(sequence: Iterable[Any]) -> dict:
+    return {
+        "type": HINT_SECTION_ORDER,
+        "sequence": [normalize_section(s) for s in sequence],
+    }
+
+
+def make_text_marker_hint(tokens: Iterable[Any]) -> dict:
+    # Deduplicate while keeping a deterministic (sorted) order.
+    flat: set[str] = set()
+    for tok in tokens:
+        flat.update(marker_tokens(tok))
+    return {"type": HINT_TEXT_MARKER, "tokens": sorted(flat)}
+
+
+# --- matching --------------------------------------------------------------
+
+
+def _is_ordered_subsequence(needle: list[str], haystack: list[str]) -> bool:
+    """True when every element of ``needle`` appears in ``haystack`` in that
+    relative order (not necessarily contiguous)."""
+    it = iter(haystack)
+    return all(any(h == n for h in it) for n in needle)
+
+
+def hint_matches(
+    hint: Any,
+    *,
+    section_sequence: list[str],
+    word_set: frozenset[str],
+) -> bool:
+    """True when ``hint`` matches this receipt's section sequence / word set.
+
+    A missing, malformed, or unrecognized-``type`` hint never matches (the
+    caller falls back to DEFAULT). An empty argument list never matches —
+    a rule that constrains nothing is not a classifier.
+    """
+    if not isinstance(hint, dict):
+        return False
+    htype = hint.get("type")
+    if htype == HINT_SECTION_PRESENCE:
+        sections = hint.get("sections")
+        if not isinstance(sections, list) or not sections:
+            return False
+        present = set(section_sequence)
+        return all(normalize_section(s) in present for s in sections)
+    if htype == HINT_SECTION_ORDER:
+        sequence = hint.get("sequence")
+        if not isinstance(sequence, list) or not sequence:
+            return False
+        return _is_ordered_subsequence(
+            [normalize_section(s) for s in sequence], section_sequence
+        )
+    if htype == HINT_TEXT_MARKER:
+        tokens = hint.get("tokens")
+        if not isinstance(tokens, list) or not tokens:
+            return False
+        return all(t and str(t).upper() in word_set for t in tokens)
+    return False
+
+
+def _support(variant: Any) -> int:
+    try:
+        return int(variant.get("support", 0))
+    except (TypeError, ValueError):
+        return 0
+
+
+def iter_variants(template: Any) -> list[dict]:
+    """The template's variant entries (empty when the key is absent/blank)."""
+    if not isinstance(template, dict):
+        return []
+    variants = template.get("variants")
+    if not isinstance(variants, list):
+        return []
+    return [v for v in variants if isinstance(v, dict)]
+
+
+def select_variant(
+    template: Any,
+    *,
+    section_sequence: Iterable[Any] | None = None,
+    word_set: Iterable[Any] | None = None,
+) -> dict | None:
+    """The variant whose ``classifier_hint`` matches, or ``None`` for DEFAULT.
+
+    ``None`` means the caller should read the template's top-level
+    (DEFAULT-variant) ``columns`` / ``sections`` / ``separators``. This is
+    always the outcome when ``template.variants`` is absent or empty, so a
+    variant-blind bundle behaves exactly as it did before §7.2.
+
+    Tie-break (§7.2): highest ``support`` first, then lexicographically
+    smallest ``variant_id`` — fully deterministic.
+    """
+    variants = iter_variants(template)
+    if not variants:
+        return None
+    seq = normalize_section_sequence(section_sequence or [])
+    words = (
+        word_set
+        if isinstance(word_set, frozenset)
+        else frozenset(str(w).upper() for w in (word_set or []))
+    )
+    matches = [
+        v
+        for v in variants
+        if hint_matches(
+            v.get("classifier_hint"), section_sequence=seq, word_set=words
+        )
+    ]
+    if not matches:
+        return None
+    matches.sort(key=lambda v: (-_support(v), str(v.get("variant_id", ""))))
+    return matches[0]
+
+
+def variant_columns(
+    template: Any,
+    section: str,
+    *,
+    section_sequence: Iterable[Any] | None = None,
+    word_set: Iterable[Any] | None = None,
+) -> list[dict]:
+    """Columns for ``section`` from the selected variant, else the DEFAULT.
+
+    When no variant matches (the only possible outcome for a variant-blind
+    template) this reads the template's top-level ``columns`` — byte-identical
+    to the pre-§7.2 reader.
+    """
+    variant = select_variant(
+        template, section_sequence=section_sequence, word_set=word_set
+    )
+    source = variant if variant is not None else template
+    if not isinstance(source, dict):
+        return []
+    cols = (source.get("columns") or {}).get(section) or []
+    return [dict(c) for c in cols]

--- a/scripts/merchant_truth_diff.py
+++ b/scripts/merchant_truth_diff.py
@@ -302,9 +302,88 @@ def diff_layout(old_payload: Any, new_payload: Any) -> list[str]:
                 new_columns.get(section) or [],
             )
         )
-    old_rest = {k: v for k, v in old_template.items() if k != "columns"}
-    new_rest = {k: v for k, v in new_template.items() if k != "columns"}
+    # §7.2 variants[] descend semantically (added/removed variants + per-variant
+    # column moves in paper-width units); everything else diffs as leaves. Both
+    # `columns` and `variants` are pulled out of the leaf diff so they are not
+    # double-reported. A variant-blind template (no `variants`) yields no
+    # variant lines, so v1 bundles diff byte-identically to before.
+    lines.extend(
+        _diff_variants(
+            old_template.get("variants") or [],
+            new_template.get("variants") or [],
+        )
+    )
+    old_rest = {
+        k: v
+        for k, v in old_template.items()
+        if k not in {"columns", "variants"}
+    }
+    new_rest = {
+        k: v
+        for k, v in new_template.items()
+        if k not in {"columns", "variants"}
+    }
     lines.extend(diff_leaves(old_rest, new_rest, prefix="template"))
+    return lines
+
+
+def _variants_by_id(
+    variants: list[Any],
+) -> dict[str, dict[str, Any]]:
+    """Index variant entries by ``variant_id`` (skip malformed entries)."""
+    keyed: dict[str, dict[str, Any]] = {}
+    for index, variant in enumerate(variants):
+        if not isinstance(variant, dict):
+            continue
+        vid = str(variant.get("variant_id", f"variant[{index}]"))
+        keyed[vid] = variant
+    return keyed
+
+
+def _diff_variants(
+    old_variants: list[Any], new_variants: list[Any]
+) -> list[str]:
+    """Per-variant sub-diff over ``template.variants[]`` (§7.2).
+
+    Variants are paired by ``variant_id``: an id only on one side is an
+    added/removed variant; a shared id descends into per-section column moves
+    (paper-width units) plus a leaf diff of the variant's other keys
+    (``classifier_hint`` / ``support`` / ``source_receipt_keys`` / sections /
+    separators).
+    """
+    lines: list[str] = []
+    old_keyed = _variants_by_id(old_variants)
+    new_keyed = _variants_by_id(new_variants)
+    for vid in sorted(set(old_keyed) | set(new_keyed)):
+        prefix = f"variant[{vid}]"
+        if vid not in new_keyed:
+            old_variant = old_keyed[vid]
+            lines.append(
+                f"- {prefix} removed "
+                f"(support {format_value(old_variant.get('support'))})"
+            )
+            continue
+        if vid not in old_keyed:
+            new_variant = new_keyed[vid]
+            lines.append(
+                f"- {prefix} added "
+                f"(support {format_value(new_variant.get('support'))})"
+            )
+            continue
+        old_variant, new_variant = old_keyed[vid], new_keyed[vid]
+        old_columns = old_variant.get("columns") or {}
+        new_columns = new_variant.get("columns") or {}
+        for section in sorted(set(old_columns) | set(new_columns)):
+            lines.extend(
+                _diff_section_columns(
+                    f"{prefix} {section}",
+                    old_columns.get(section) or [],
+                    new_columns.get(section) or [],
+                )
+            )
+        old_rest = {k: v for k, v in old_variant.items() if k != "columns"}
+        new_rest = {k: v for k, v in new_variant.items() if k != "columns"}
+        lines.extend(diff_leaves(old_rest, new_rest, prefix=prefix))
     return lines
 
 

--- a/synthesis_loop/full_fidelity_eval.py
+++ b/synthesis_loop/full_fidelity_eval.py
@@ -1932,12 +1932,66 @@ def _load_real(merchant: str, image_id: str, receipt_id: int):
     return real, words, rec
 
 
-def profile_columns(truth: TruthContext, section: str) -> list[dict]:
+def load_section_sequence(
+    merchant: str, image_id: str, receipt_id: int
+) -> list[str]:
+    """The receipt's canonical section names in top-to-bottom order.
+
+    Reads ``RECEIPT_SECTION`` rows, maps each ``section_type`` onto the shared
+    canonical vocabulary (``STOREFRONT`` -> ``storefront`` etc.; non-canonical
+    legacy/metadata types are skipped), and orders sections by their first
+    line. This is the ``section_sequence`` the §7.2 ``section_*`` hints match
+    against. Best-effort: any failure yields ``[]`` (text_marker hints still
+    work, and a variant-blind bundle ignores it entirely).
+    """
+    try:
+        from glyphstudio.sections import is_canonical_section
+        from receipt_dynamo.data.dynamo_client import DynamoClient
+
+        table = os.environ.get("DYNAMODB_TABLE_NAME", "ReceiptsTable-dc5be22")
+        client = DynamoClient(table)
+        sections = client.get_receipt_sections_from_receipt(
+            image_id, receipt_id
+        )
+        ordered = sorted(
+            sections,
+            key=lambda s: min(s.line_ids) if s.line_ids else 1 << 30,
+        )
+        sequence: list[str] = []
+        for section in ordered:
+            canonical = str(section.section_type).strip().lower()
+            if is_canonical_section(canonical) and canonical not in sequence:
+                sequence.append(canonical)
+        return sequence
+    except Exception as exc:  # noqa: BLE001 -- best-effort, never fatal
+        print(
+            f"section sequence unavailable for {merchant} "
+            f"{image_id}/{receipt_id}: {exc}",
+            file=sys.stderr,
+        )
+        return []
+
+
+def profile_columns(
+    truth: TruthContext,
+    section: str,
+    *,
+    section_sequence: "list[str] | None" = None,
+    word_set: "frozenset[str] | None" = None,
+) -> list[dict]:
     """Measured columns from the bundle's C#layout template (P2 source).
 
     Validates the template's schema version and shape before consuming it --
     a template from a future schema version (or a hand-mangled one) is
     ignored loudly rather than silently misread.
+
+    §7.2 variant-aware: when the template carries ``variants[]``, the columns
+    come from the variant whose ``classifier_hint`` matches the receipt under
+    eval (its canonical ``section_sequence`` / normalized ``word_set``),
+    selected by the shared ``merchant_truth_variants`` algorithm. A
+    variant-blind template (no ``variants``) reads the top-level DEFAULT
+    columns exactly as before -- the selector returns the DEFAULT and the
+    output is byte-identical.
     """
     template = truth.component("layout").get("template") or {}
     if not template:
@@ -1951,8 +2005,14 @@ def profile_columns(truth: TruthContext, section: str) -> list[dict]:
             file=sys.stderr,
         )
         return []
-    cols = (template.get("columns") or {}).get(section) or []
-    return [dict(c) for c in cols]
+    from receipt_dynamo.merchant_truth_variants import variant_columns
+
+    return variant_columns(
+        template,
+        section,
+        section_sequence=section_sequence or [],
+        word_set=word_set or frozenset(),
+    )
 
 
 def evaluate_pair(
@@ -1967,11 +2027,20 @@ def evaluate_pair(
     syn_png: str,
     composed: bool,
     columns_source: str = "bootstrap",
+    section_sequence: "list[str] | None" = None,
 ) -> dict:
     """All 7 metrics over an aligned (real, synth) image pair."""
     W, H = syn_img.size
     real_gray = np.asarray(real_img.convert("L"), dtype=np.uint8)
     syn_gray = np.asarray(syn_img.convert("L"), dtype=np.uint8)
+    # §7.2 variant selection inputs, derived from the receipt under eval:
+    # the normalized OCR word set (from the real receipt's words) and its
+    # canonical section sequence (passed in by run()). Both feed
+    # profile_columns' variant selection; a variant-blind bundle ignores them.
+    from receipt_dynamo.merchant_truth_variants import normalize_word_set
+
+    receipt_word_set = normalize_word_set(words_real)
+    receipt_section_sequence = section_sequence or []
     px_real = words_to_px(words_real, W, H)
     px_syn = words_to_px(words_syn, W, H)
     rows_real = group_visual_rows(px_real)
@@ -2001,7 +2070,12 @@ def evaluate_pair(
         band_rows_real = rows_in(rows_real, (y0, y1))
         band_rows_syn = rows_in(rows_syn, (y0, y1))
         if columns_source == "profile":
-            columns = profile_columns(truth, canonical)
+            columns = profile_columns(
+                truth,
+                canonical,
+                section_sequence=receipt_section_sequence,
+                word_set=receipt_word_set,
+            )
             source = "profile"
             if not columns:
                 columns = derive_columns_bootstrap(band_rows_real, W)
@@ -2202,6 +2276,9 @@ def run(args) -> int:
     real.save(real_png)
     syn.save(syn_png)
     stamp["inputs_hash"] = inputs_hash(real_png, manifest_words)
+    section_sequence = load_section_sequence(
+        args.merchant, args.image_id, args.receipt_id
+    )
     checks = evaluate_pair(
         real,
         syn,
@@ -2213,6 +2290,7 @@ def run(args) -> int:
         syn_png=syn_png,
         composed=composed,
         columns_source=args.columns_source,
+        section_sequence=section_sequence,
     )
     doc = {
         "mode": "real-vs-synth",

--- a/tests/fixtures/variant_layout_two_variants.json
+++ b/tests/fixtures/variant_layout_two_variants.json
@@ -1,0 +1,248 @@
+{
+  "_comment": "W-H fixtures: valid schema-v1 layout templates carrying template.variants[] that exercise every §7.2 classifier_hint type, the multi-match support tie-break, malformed-hint fallback, and the empty-variants (byte-identical DEFAULT) regression. Each `template` passes validate_layout_template. The DEFAULT items.amount lane sits at x=0.86; each variant moves it so a selection is observable in the returned columns.",
+  "text_marker": {
+    "template": {
+      "version": 1,
+      "columns": {
+        "items": [
+          {"role": "desc", "anchor": "left", "x": 0.05, "support": 9},
+          {"role": "amount", "anchor": "right", "x": 0.86, "support": 9}
+        ]
+      },
+      "sections": [{"name": "storefront"}, {"name": "items"}],
+      "separators": [{"char": "*"}],
+      "variants": [
+        {
+          "variant_id": "self-checkout",
+          "classifier_hint": {"type": "text_marker", "tokens": ["SELF", "CHECKOUT"]},
+          "columns": {
+            "items": [
+              {"role": "desc", "anchor": "left", "x": 0.08, "support": 7},
+              {"role": "amount", "anchor": "right", "x": 0.70, "support": 7}
+            ]
+          },
+          "sections": [{"name": "storefront"}, {"name": "items"}],
+          "separators": [{"char": "="}],
+          "support": 7,
+          "source_receipt_keys": ["IMAGE#sfc#RECEIPT#00001"]
+        }
+      ]
+    },
+    "matching_word_set": ["COSTCO", "SELF", "CHECKOUT", "TOTAL"],
+    "matching_section_sequence": ["storefront", "items", "summary"],
+    "nonmatching_word_set": ["COSTCO", "MEMBER", "TOTAL"],
+    "nonmatching_section_sequence": ["storefront", "items", "summary"],
+    "default_amount_x": 0.86,
+    "variant_amount_x": 0.70
+  },
+  "section_presence": {
+    "template": {
+      "version": 1,
+      "columns": {
+        "items": [
+          {"role": "amount", "anchor": "right", "x": 0.86, "support": 9}
+        ]
+      },
+      "sections": [{"name": "items"}],
+      "separators": [{"char": "-"}],
+      "variants": [
+        {
+          "variant_id": "survey-variant",
+          "classifier_hint": {"type": "section_presence", "sections": ["survey"]},
+          "columns": {
+            "items": [
+              {"role": "amount", "anchor": "right", "x": 0.80, "support": 4}
+            ]
+          },
+          "sections": [{"name": "items"}, {"name": "survey"}],
+          "separators": [{"char": "-"}],
+          "support": 4,
+          "source_receipt_keys": ["IMAGE#svy#RECEIPT#00001"]
+        }
+      ]
+    },
+    "matching_section_sequence": ["storefront", "items", "summary", "survey"],
+    "nonmatching_section_sequence": ["storefront", "items", "summary"],
+    "default_amount_x": 0.86,
+    "variant_amount_x": 0.80
+  },
+  "section_order": {
+    "template": {
+      "version": 1,
+      "columns": {
+        "items": [
+          {"role": "amount", "anchor": "right", "x": 0.86, "support": 9}
+        ]
+      },
+      "sections": [{"name": "items"}],
+      "separators": [{"char": "-"}],
+      "variants": [
+        {
+          "variant_id": "payment-before-total",
+          "classifier_hint": {"type": "section_order", "sequence": ["payment", "total_line"]},
+          "columns": {
+            "items": [
+              {"role": "amount", "anchor": "right", "x": 0.75, "support": 3}
+            ]
+          },
+          "sections": [{"name": "items"}],
+          "separators": [{"char": "-"}],
+          "support": 3,
+          "source_receipt_keys": ["IMAGE#ord#RECEIPT#00001"]
+        }
+      ]
+    },
+    "matching_section_sequence": ["storefront", "items", "payment", "total_line"],
+    "nonmatching_section_sequence": ["storefront", "items", "total_line", "payment"],
+    "default_amount_x": 0.86,
+    "variant_amount_x": 0.75
+  },
+  "tie_break": {
+    "_comment": "Both variants' hints match the same receipt; the higher-support variant (self-checkout, 7) must win over low-support (2). Equal support would fall back to lexicographically smallest variant_id.",
+    "template": {
+      "version": 1,
+      "columns": {
+        "items": [
+          {"role": "amount", "anchor": "right", "x": 0.86, "support": 9}
+        ]
+      },
+      "sections": [{"name": "items"}],
+      "separators": [{"char": "-"}],
+      "variants": [
+        {
+          "variant_id": "low-support",
+          "classifier_hint": {"type": "text_marker", "tokens": ["SELF"]},
+          "columns": {
+            "items": [
+              {"role": "amount", "anchor": "right", "x": 0.60, "support": 2}
+            ]
+          },
+          "sections": [{"name": "items"}],
+          "separators": [{"char": "-"}],
+          "support": 2,
+          "source_receipt_keys": ["IMAGE#low#RECEIPT#00001"]
+        },
+        {
+          "variant_id": "high-support",
+          "classifier_hint": {"type": "text_marker", "tokens": ["CHECKOUT"]},
+          "columns": {
+            "items": [
+              {"role": "amount", "anchor": "right", "x": 0.70, "support": 7}
+            ]
+          },
+          "sections": [{"name": "items"}],
+          "separators": [{"char": "-"}],
+          "support": 7,
+          "source_receipt_keys": ["IMAGE#high#RECEIPT#00001"]
+        }
+      ]
+    },
+    "matching_word_set": ["SELF", "CHECKOUT"],
+    "winner_variant_id": "high-support",
+    "winner_amount_x": 0.70,
+    "loser_amount_x": 0.60,
+    "default_amount_x": 0.86
+  },
+  "tie_break_equal_support": {
+    "_comment": "Two matching variants of equal support: lexicographically smallest variant_id ('aaa-variant') wins over 'zzz-variant'.",
+    "template": {
+      "version": 1,
+      "columns": {
+        "items": [
+          {"role": "amount", "anchor": "right", "x": 0.86, "support": 9}
+        ]
+      },
+      "sections": [{"name": "items"}],
+      "separators": [{"char": "-"}],
+      "variants": [
+        {
+          "variant_id": "zzz-variant",
+          "classifier_hint": {"type": "text_marker", "tokens": ["MARK"]},
+          "columns": {"items": [{"role": "amount", "anchor": "right", "x": 0.55, "support": 4}]},
+          "sections": [{"name": "items"}],
+          "separators": [{"char": "-"}],
+          "support": 4,
+          "source_receipt_keys": ["IMAGE#zzz#RECEIPT#00001"]
+        },
+        {
+          "variant_id": "aaa-variant",
+          "classifier_hint": {"type": "text_marker", "tokens": ["MARK"]},
+          "columns": {"items": [{"role": "amount", "anchor": "right", "x": 0.65, "support": 4}]},
+          "sections": [{"name": "items"}],
+          "separators": [{"char": "-"}],
+          "support": 4,
+          "source_receipt_keys": ["IMAGE#aaa#RECEIPT#00001"]
+        }
+      ]
+    },
+    "matching_word_set": ["MARK"],
+    "winner_variant_id": "aaa-variant",
+    "winner_amount_x": 0.65
+  },
+  "malformed": {
+    "_comment": "Malformed / unknown-type hints must never match; the reader falls back to the DEFAULT top-level columns.",
+    "template": {
+      "version": 1,
+      "columns": {
+        "items": [
+          {"role": "amount", "anchor": "right", "x": 0.86, "support": 9}
+        ]
+      },
+      "sections": [{"name": "items"}],
+      "separators": [{"char": "-"}],
+      "variants": [
+        {
+          "variant_id": "bad-type",
+          "classifier_hint": {"type": "regex_match", "pattern": ".*"},
+          "columns": {"items": [{"role": "amount", "anchor": "right", "x": 0.50, "support": 3}]},
+          "sections": [{"name": "items"}],
+          "separators": [{"char": "-"}],
+          "support": 3,
+          "source_receipt_keys": ["IMAGE#bad#RECEIPT#00001"]
+        },
+        {
+          "variant_id": "not-a-dict-hint",
+          "classifier_hint": "self-checkout",
+          "columns": {"items": [{"role": "amount", "anchor": "right", "x": 0.40, "support": 2}]},
+          "sections": [{"name": "items"}],
+          "separators": [{"char": "-"}],
+          "support": 2,
+          "source_receipt_keys": ["IMAGE#str#RECEIPT#00001"]
+        },
+        {
+          "variant_id": "empty-args",
+          "classifier_hint": {"type": "text_marker", "tokens": []},
+          "columns": {"items": [{"role": "amount", "anchor": "right", "x": 0.30, "support": 2}]},
+          "sections": [{"name": "items"}],
+          "separators": [{"char": "-"}],
+          "support": 2,
+          "source_receipt_keys": ["IMAGE#emp#RECEIPT#00001"]
+        }
+      ]
+    },
+    "word_set": ["SELF", "CHECKOUT"],
+    "section_sequence": ["storefront", "items", "survey"],
+    "default_amount_x": 0.86
+  },
+  "empty_variants": {
+    "_comment": "The Costco-shaped REFUTE case: variants[] empty. Selection must return DEFAULT; profile_columns output is byte-identical to the pre-§7.2 reader.",
+    "template": {
+      "version": 1,
+      "columns": {
+        "items": [
+          {"role": "desc", "anchor": "left", "x": 0.05, "support": 12},
+          {"role": "amount", "anchor": "right", "x": 0.86, "support": 12}
+        ],
+        "summary": [
+          {"role": "amount", "anchor": "right", "x": 0.86, "support": 8}
+        ]
+      },
+      "sections": [{"name": "storefront"}, {"name": "items"}, {"name": "summary"}],
+      "separators": [{"char": "*"}],
+      "variants": []
+    },
+    "word_set": ["COSTCO", "SELF", "CHECKOUT"],
+    "section_sequence": ["storefront", "items", "summary"],
+    "default_amount_x": 0.86
+  }
+}

--- a/tests/test_full_fidelity_eval_variants.py
+++ b/tests/test_full_fidelity_eval_variants.py
@@ -1,0 +1,155 @@
+"""W-H eval consumer: profile_columns selects a §7.2 layout variant.
+
+These tests drive ``full_fidelity_eval.profile_columns`` against committed
+fixture templates carrying ``template.variants[]`` and assert the columns come
+from the variant whose ``classifier_hint`` matches the receipt under eval
+(its normalized OCR word set / canonical section sequence).
+
+RED-ON-MAIN: ``test_profile_columns_selects_matching_variant`` and
+``test_profile_columns_tie_break_prefers_highest_support`` FAIL on current
+origin/main, where ``profile_columns`` reads only the top-level DEFAULT
+columns and ignores ``variants`` entirely -- they return the DEFAULT lane
+(x=0.86) instead of the variant lane. They pass only with the variant-aware
+reader wired in this PR.
+
+The empty-variants regression (``test_profile_columns_*_default*``) passes on
+both main and this branch -- proving the DEFAULT path is byte-identical.
+"""
+
+import json
+import os
+import sys
+from types import SimpleNamespace
+
+# Resolve BOTH the eval package and this worktree's receipt_dynamo ahead of any
+# editable install, so profile_columns imports the merchant_truth_variants
+# module added in this PR.
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.dirname(HERE)
+for _p in (
+    os.path.join(REPO, "receipt_dynamo"),
+    os.path.join(REPO, "synthesis_loop"),
+    os.path.join(REPO, "scripts"),
+    os.path.join(REPO, "receipt_agent"),
+    os.path.join(REPO, "tools", "glyph-studio", "py"),
+):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+import full_fidelity_eval as ffe  # noqa: E402
+
+from receipt_dynamo.merchant_truth_variants import (  # noqa: E402
+    normalize_word_set,
+)
+
+FIXTURE = os.path.join(HERE, "fixtures", "variant_layout_two_variants.json")
+
+
+def _cases() -> dict:
+    with open(FIXTURE, encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def _truth(template: dict) -> "ffe.TruthContext":
+    artifact = SimpleNamespace(
+        slug="costco",
+        version=2,
+        bundle_hash="deadbeef",
+        components={"layout": {"template": template}},
+    )
+    return ffe.TruthContext(
+        artifact=artifact,
+        expected_version=2,
+        expected_bundle_hash="deadbeef",
+        mode="fixture",
+    )
+
+
+def _amount_x(columns: list[dict]) -> float:
+    return next(c["x"] for c in columns if c["role"] == "amount")
+
+
+def test_profile_columns_selects_matching_variant():
+    """RED ON MAIN: profile_columns must return the matched variant's lane."""
+    case = _cases()["text_marker"]
+    truth = _truth(case["template"])
+    words = normalize_word_set(case["matching_word_set"])
+    cols = ffe.profile_columns(
+        truth,
+        "items",
+        section_sequence=case["matching_section_sequence"],
+        word_set=words,
+    )
+    assert _amount_x(cols) == case["variant_amount_x"]  # 0.70, not 0.86
+
+
+def test_profile_columns_section_presence_variant():
+    case = _cases()["section_presence"]
+    truth = _truth(case["template"])
+    cols = ffe.profile_columns(
+        truth,
+        "items",
+        section_sequence=case["matching_section_sequence"],
+    )
+    assert _amount_x(cols) == case["variant_amount_x"]
+
+
+def test_profile_columns_tie_break_prefers_highest_support():
+    """RED ON MAIN: both variants match; highest support must win."""
+    case = _cases()["tie_break"]
+    truth = _truth(case["template"])
+    words = normalize_word_set(case["matching_word_set"])
+    cols = ffe.profile_columns(truth, "items", word_set=words)
+    assert _amount_x(cols) == case["winner_amount_x"]
+
+
+def test_profile_columns_no_match_uses_default():
+    case = _cases()["text_marker"]
+    truth = _truth(case["template"])
+    cols = ffe.profile_columns(
+        truth,
+        "items",
+        section_sequence=[],
+        word_set=frozenset(),
+    )
+    assert _amount_x(cols) == case["default_amount_x"]
+
+
+def test_profile_columns_malformed_hint_uses_default():
+    case = _cases()["malformed"]
+    truth = _truth(case["template"])
+    words = normalize_word_set(case["word_set"])
+    cols = ffe.profile_columns(
+        truth,
+        "items",
+        section_sequence=case["section_sequence"],
+        word_set=words,
+    )
+    assert _amount_x(cols) == case["default_amount_x"]
+
+
+def test_profile_columns_empty_variants_byte_identical_to_default():
+    """The Costco (REFUTE) shape: variants[] empty. profile_columns must
+    return EXACTLY the template's top-level columns -- identical to a
+    variant-blind read, on both main and this branch."""
+    case = _cases()["empty_variants"]
+    template = case["template"]
+    truth = _truth(template)
+    words = normalize_word_set(case["word_set"])
+    for section in ("items", "summary"):
+        cols = ffe.profile_columns(
+            truth,
+            section,
+            section_sequence=case["section_sequence"],
+            word_set=words,
+        )
+        assert cols == [dict(c) for c in template["columns"][section]]
+
+
+def test_profile_columns_default_call_still_works():
+    """Legacy call sites pass no variant inputs; a variant-blind template
+    keeps returning its DEFAULT columns."""
+    case = _cases()["empty_variants"]
+    truth = _truth(case["template"])
+    cols = ffe.profile_columns(truth, "items")
+    assert _amount_x(cols) == case["default_amount_x"]

--- a/tests/test_merchant_truth_diff.py
+++ b/tests/test_merchant_truth_diff.py
@@ -742,6 +742,109 @@ def test_layout_diff_expresses_moves_in_paper_width_units() -> None:
     assert "- template.measured.receipts: 12 -> 15" in lines
 
 
+def _layout_with_variants(variants: list[dict]) -> dict:
+    """A minimal layout payload whose template carries §7.2 variants[]."""
+    return {
+        "available": True,
+        "template": {
+            "version": 1,
+            "columns": {
+                "items": [
+                    {
+                        "role": "amount",
+                        "anchor": "right",
+                        "x": 0.86,
+                        "support": 9,
+                    }
+                ]
+            },
+            "variants": variants,
+        },
+    }
+
+
+def _variant(variant_id: str, amount_x: float, support: int) -> dict:
+    return {
+        "variant_id": variant_id,
+        "classifier_hint": {"type": "text_marker", "tokens": ["SELF"]},
+        "columns": {
+            "items": [
+                {
+                    "role": "amount",
+                    "anchor": "right",
+                    "x": amount_x,
+                    "support": support,
+                }
+            ]
+        },
+        "support": support,
+        "source_receipt_keys": [f"IMAGE#{variant_id}#RECEIPT#00001"],
+    }
+
+
+def test_layout_diff_descends_variant_column_moves() -> None:
+    """A per-variant column move is reported in paper-width units under a
+    variant[...] prefix -- W-H's variant-aware diff_layout."""
+    old = _layout_with_variants([_variant("self-checkout", 0.7000, 7)])
+    new = _layout_with_variants([_variant("self-checkout", 0.7063, 7)])
+
+    lines = mtd.diff_layout(old, new)
+
+    assert (
+        "- variant[self-checkout] items: amount/right column "
+        "x 0.7000 -> 0.7063 (moved +0.0063 paper-width)" in lines
+    )
+
+
+def test_layout_diff_reports_added_and_removed_variants() -> None:
+    old = _layout_with_variants([_variant("self-checkout", 0.70, 7)])
+    new = _layout_with_variants([_variant("register-express", 0.80, 5)])
+
+    lines = mtd.diff_layout(old, new)
+
+    assert any(
+        line.startswith("- variant[self-checkout] removed") for line in lines
+    )
+    assert any(
+        line.startswith("- variant[register-express] added") for line in lines
+    )
+
+
+def test_layout_diff_reports_variant_support_and_hint_change() -> None:
+    old = _layout_with_variants([_variant("self-checkout", 0.70, 7)])
+    new_variant = _variant("self-checkout", 0.70, 9)
+    new_variant["classifier_hint"] = {
+        "type": "text_marker",
+        "tokens": ["SELF", "CHECKOUT"],
+    }
+    new = _layout_with_variants([new_variant])
+
+    lines = mtd.diff_layout(old, new)
+
+    assert "- variant[self-checkout].support: 7 -> 9" in lines
+    assert any(
+        "variant[self-checkout].classifier_hint" in line for line in lines
+    )
+
+
+def test_layout_diff_without_variants_is_unchanged() -> None:
+    """A variant-blind layout (no variants key) yields no variant lines --
+    v1 bundles diff byte-identically to the pre-§7.2 differ."""
+    old = _v1_payloads()["layout"]
+    new = _v2_payloads()["layout"]
+    assert "variants" not in old["template"]
+    assert "variants" not in new["template"]
+
+    lines = mtd.diff_layout(old, new)
+
+    assert not any("variant[" in line for line in lines)
+    # the established layout assertions still hold
+    assert (
+        "- items: amount/right column x 0.9439 -> 0.9502 "
+        "(moved +0.0063 paper-width)" in lines
+    )
+
+
 def test_catalog_diff_reports_added_removed_and_price_changes() -> None:
     old = _v1_payloads()["catalog_snapshot"]
     new = _v2_payloads()["catalog_snapshot"]

--- a/tests/test_merchant_truth_variants.py
+++ b/tests/test_merchant_truth_variants.py
@@ -1,0 +1,270 @@
+"""Unit tests for the shared §7.2 layout-variant selector (W-H).
+
+One implementation of the selection algorithm (§7.2 of
+``docs/architecture/MERCHANT_TRUTH_DYNAMO.md``) backs both readers -- the eval
+``profile_columns`` and ``merchant_truth_diff.diff_layout`` -- and the W-G
+generator's hint emission. These tests pin every hint type, the multi-match
+support tie-break, the equal-support lexical tie-break, malformed/unknown-type
+fallback to DEFAULT, and the empty-variants no-op.
+
+Mutation-honesty anchors (named so a reviewer can flip the code and watch the
+right test go red):
+  * ``test_tie_break_highest_support_wins`` fails if the tie-break selects the
+    lowest support instead of the highest.
+  * ``test_no_match_falls_back_to_default`` and
+    ``test_unknown_type_falls_back_to_default`` fail if a non-matching /
+    unknown-type hint is allowed to select a variant instead of DEFAULT.
+"""
+
+import json
+import os
+import sys
+
+# Resolve receipt_dynamo from THIS worktree (ahead of any editable install).
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.dirname(HERE)
+sys.path.insert(0, os.path.join(REPO, "receipt_dynamo"))
+
+import pytest  # noqa: E402
+
+from receipt_dynamo.merchant_truth_variants import (  # noqa: E402
+    HINT_SECTION_PRESENCE,
+    HINT_TEXT_MARKER,
+    hint_matches,
+    make_section_order_hint,
+    make_section_presence_hint,
+    make_text_marker_hint,
+    marker_tokens,
+    normalize_word_set,
+    select_variant,
+    variant_columns,
+)
+
+FIXTURE = os.path.join(HERE, "fixtures", "variant_layout_two_variants.json")
+
+
+def _cases() -> dict:
+    with open(FIXTURE, encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def _amount_x(columns: list[dict]) -> float:
+    return next(c["x"] for c in columns if c["role"] == "amount")
+
+
+# --- normalization ---------------------------------------------------------
+
+
+def test_normalize_word_set_strips_punctuation_and_splits():
+    assert normalize_word_set(["Self-Checkout", "Costco!"]) == frozenset(
+        {"SELF", "CHECKOUT", "COSTCO"}
+    )
+    # word dicts (the eval's shape) are accepted directly
+    assert normalize_word_set([{"text": "Member 12"}]) == frozenset(
+        {"MEMBER", "12"}
+    )
+
+
+def test_marker_tokens_splits_underscore_marker():
+    assert marker_tokens("self_checkout") == ["SELF", "CHECKOUT"]
+
+
+# --- hint matching (each type) --------------------------------------------
+
+
+def test_text_marker_matches_word_set():
+    case = _cases()["text_marker"]
+    template = case["template"]
+    words = normalize_word_set(case["matching_word_set"])
+    variant = select_variant(template, word_set=words)
+    assert variant is not None
+    assert variant["variant_id"] == "self-checkout"
+    assert _amount_x(variant["columns"]["items"]) == case["variant_amount_x"]
+
+
+def test_text_marker_missing_token_does_not_match():
+    case = _cases()["text_marker"]
+    words = normalize_word_set(case["nonmatching_word_set"])
+    assert select_variant(case["template"], word_set=words) is None
+
+
+def test_section_presence_matches_sequence():
+    case = _cases()["section_presence"]
+    variant = select_variant(
+        case["template"], section_sequence=case["matching_section_sequence"]
+    )
+    assert variant is not None
+    assert variant["variant_id"] == "survey-variant"
+    assert _amount_x(variant["columns"]["items"]) == case["variant_amount_x"]
+
+
+def test_section_presence_absent_section_does_not_match():
+    case = _cases()["section_presence"]
+    assert (
+        select_variant(
+            case["template"],
+            section_sequence=case["nonmatching_section_sequence"],
+        )
+        is None
+    )
+
+
+def test_section_order_matches_relative_order():
+    case = _cases()["section_order"]
+    variant = select_variant(
+        case["template"], section_sequence=case["matching_section_sequence"]
+    )
+    assert variant is not None
+    assert variant["variant_id"] == "payment-before-total"
+
+
+def test_section_order_wrong_order_does_not_match():
+    case = _cases()["section_order"]
+    assert (
+        select_variant(
+            case["template"],
+            section_sequence=case["nonmatching_section_sequence"],
+        )
+        is None
+    )
+
+
+def test_section_order_is_subsequence_not_contiguous():
+    hint = make_section_order_hint(["items", "total_line"])
+    assert hint_matches(
+        hint,
+        section_sequence=["storefront", "items", "payment", "total_line"],
+        word_set=frozenset(),
+    )
+
+
+# --- tie-break -------------------------------------------------------------
+
+
+def test_tie_break_highest_support_wins():
+    """Both hints match; the highest-support variant must win (§7.2)."""
+    case = _cases()["tie_break"]
+    words = normalize_word_set(case["matching_word_set"])
+    variant = select_variant(case["template"], word_set=words)
+    assert variant is not None
+    assert variant["variant_id"] == case["winner_variant_id"]
+    assert _amount_x(variant["columns"]["items"]) == case["winner_amount_x"]
+    # explicitly: the low-support lane must NOT be the one selected
+    assert _amount_x(variant["columns"]["items"]) != case["loser_amount_x"]
+
+
+def test_tie_break_equal_support_lexical_smallest_variant_id():
+    case = _cases()["tie_break_equal_support"]
+    words = normalize_word_set(case["matching_word_set"])
+    variant = select_variant(case["template"], word_set=words)
+    assert variant is not None
+    assert variant["variant_id"] == case["winner_variant_id"]
+    assert _amount_x(variant["columns"]["items"]) == case["winner_amount_x"]
+
+
+# --- fallback to DEFAULT ---------------------------------------------------
+
+
+def test_no_match_falls_back_to_default():
+    """No hint matches -> DEFAULT (select_variant returns None)."""
+    case = _cases()["text_marker"]
+    assert select_variant(case["template"], word_set=frozenset()) is None
+
+
+def test_unknown_type_falls_back_to_default():
+    case = _cases()["malformed"]
+    words = normalize_word_set(case["word_set"])
+    variant = select_variant(
+        case["template"],
+        section_sequence=case["section_sequence"],
+        word_set=words,
+    )
+    assert variant is None
+    # and variant_columns therefore reads the DEFAULT lane
+    cols = variant_columns(
+        case["template"],
+        "items",
+        section_sequence=case["section_sequence"],
+        word_set=words,
+    )
+    assert _amount_x(cols) == case["default_amount_x"]
+
+
+def test_malformed_hints_never_match():
+    for hint in ({"type": "regex_match"}, "self-checkout", None, 42, {}):
+        assert not hint_matches(
+            hint, section_sequence=["items"], word_set=frozenset({"SELF"})
+        )
+
+
+def test_empty_args_hint_never_matches():
+    assert not hint_matches(
+        make_text_marker_hint([]),
+        section_sequence=["items"],
+        word_set=frozenset({"SELF"}),
+    )
+    assert not hint_matches(
+        {"type": HINT_SECTION_PRESENCE, "sections": []},
+        section_sequence=["items"],
+        word_set=frozenset(),
+    )
+
+
+# --- empty-variants regression (DEFAULT byte-identical) --------------------
+
+
+def test_empty_variants_selects_default():
+    case = _cases()["empty_variants"]
+    template = case["template"]
+    words = normalize_word_set(case["word_set"])
+    assert (
+        select_variant(
+            template,
+            section_sequence=case["section_sequence"],
+            word_set=words,
+        )
+        is None
+    )
+
+
+def test_variant_columns_empty_variants_equals_raw_default():
+    """variant_columns on a variant-blind template returns exactly the
+    template's top-level columns -- the byte-identical regression guard."""
+    case = _cases()["empty_variants"]
+    template = case["template"]
+    words = normalize_word_set(case["word_set"])
+    for section in ("items", "summary"):
+        got = variant_columns(
+            template,
+            section,
+            section_sequence=case["section_sequence"],
+            word_set=words,
+        )
+        assert got == [dict(c) for c in template["columns"][section]]
+
+
+def test_absent_variants_key_selects_default():
+    template = {"version": 1, "columns": {"items": []}}
+    assert select_variant(template, word_set=frozenset({"SELF"})) is None
+
+
+# --- builders round-trip with the matcher ---------------------------------
+
+
+def test_builders_emit_matchable_hints():
+    tm = make_text_marker_hint(["self_checkout"])
+    assert tm == {"type": HINT_TEXT_MARKER, "tokens": ["CHECKOUT", "SELF"]}
+    assert hint_matches(
+        tm,
+        section_sequence=[],
+        word_set=normalize_word_set(["SELF-CHECKOUT lane"]),
+    )
+    sp = make_section_presence_hint(["Survey"])
+    assert sp == {"type": HINT_SECTION_PRESENCE, "sections": ["survey"]}
+    assert hint_matches(
+        sp, section_sequence=["items", "survey"], word_set=frozenset()
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tools/glyph-studio/py/glyphstudio/variant_cluster.py
+++ b/tools/glyph-studio/py/glyphstudio/variant_cluster.py
@@ -54,6 +54,13 @@ except ImportError:  # bare-script invocation
     from sections import normalize_stylescan_section
     from styleagg import receipt_section_columns
 
+# §7.2 classifier_hint shape + builders live in receipt_dynamo so the W-H
+# readers (eval / diff) and this generator share one definition of the rule.
+from receipt_dynamo.merchant_truth_variants import (  # noqa: E402
+    make_section_presence_hint,
+    make_text_marker_hint,
+)
+
 # --- signature space --------------------------------------------------------
 
 # Raw stylescan section names that describe CONTENT of a single row, not the
@@ -300,19 +307,21 @@ def _missing_variant_sections(template: dict) -> list[str]:
     ]
 
 
-def _classifier_hint(
+def _hint_features(
     signatures: list[dict],
     members: list[int],
     default_members: list[int],
     template: dict,
     default_template: dict,
 ) -> dict:
-    """Machine-usable features separating a variant from the default.
+    """Raw distinctive signals separating a variant from the default.
 
     ``markers_any``/``markers_absent`` are raw stylescan section names common
     to every receipt of one cluster and rare (<= MARKER_DISTINCTIVE_MAX_
-    OTHER_FRAC) in the other -- a variant-aware reader (W-H) can classify a
-    receipt by probing its lines against the same stylescan rules.
+    OTHER_FRAC) in the other; ``sections_added``/``sections_missing`` are the
+    canonical section-name deltas. These feed the verdict's human-readable
+    ``distinguishing_features`` and the variant id, and are reconciled into a
+    §7.2 structured ``classifier_hint`` by ``_structured_hint``.
     """
     return {
         "markers_any": _distinctive_markers(
@@ -332,8 +341,41 @@ def _classifier_hint(
     }
 
 
-def _variant_id(hint: dict, ordinal: int) -> str:
-    for marker in hint.get("markers_any", []):
+def _structured_hint(features: dict) -> dict | None:
+    """Reconcile raw distinctive features into a §7.2 ``classifier_hint``.
+
+    The W-H readers match a hint against exactly two inputs -- the receipt's
+    canonical section sequence and its normalized OCR word set -- so only
+    *positive* signals a reader can observe translate:
+
+    * ``markers_any`` (distinctive printed lane markers, e.g. ``self_checkout``
+      for the self-checkout header) -> a ``text_marker`` hint whose tokens are
+      the markers' normalized words; a receipt printing that text matches.
+    * ``sections_added`` (canonical sections the variant has and the default
+      lacks) -> a ``section_presence`` hint over those section names.
+
+    ``text_marker`` is preferred because a distinctive printed marker is the
+    crispest classifier (it is exactly why raw markers survive canonicalization
+    in the signature). ``markers_absent``/``sections_missing`` describe what a
+    variant *lacks*; §7.2 has no absence primitive, so they inform the verdict
+    but never a hint (a receipt that lacks them simply falls to the DEFAULT).
+    Returns ``None`` when no positive signal exists -- the variant is still
+    emitted with provenance, but is only reachable once a positive classifier
+    is found.
+    """
+    markers_any = features.get("markers_any") or []
+    if markers_any:
+        hint = make_text_marker_hint(markers_any)
+        if hint["tokens"]:
+            return hint
+    sections_added = features.get("sections_added") or []
+    if sections_added:
+        return make_section_presence_hint(sections_added)
+    return None
+
+
+def _variant_id(features: dict, ordinal: int) -> str:
+    for marker in features.get("markers_any", []):
         return marker
     return f"variant-{ordinal}"
 
@@ -432,14 +474,14 @@ def build_variant_payload(
                 }
             )
             continue
-        hint = _classifier_hint(
+        features = _hint_features(
             signatures, members, default_members, tpl, default_template
         )
-        vid = _variant_id(hint, len(variants) + 1)
+        vid = _variant_id(features, len(variants) + 1)
         variants.append(
             {
                 "variant_id": vid,
-                "classifier_hint": hint,
+                "classifier_hint": _structured_hint(features),
                 **_strip_template(tpl),
                 "support": len(members),
                 "source_receipt_keys": [keys[i] for i in members],
@@ -452,7 +494,7 @@ def build_variant_payload(
             ("sections_added", "adds section"),
             ("sections_missing", "drops section"),
         ):
-            for name in hint[feat_key]:
+            for name in features[feat_key]:
                 distinguishing.append(f"{vid}: {label} {name!r}")
         distinguishing.extend(
             _column_shift_features(vid, tpl, default_template)

--- a/tools/glyph-studio/py/tests/test_variant_cluster.py
+++ b/tools/glyph-studio/py/tests/test_variant_cluster.py
@@ -210,10 +210,17 @@ def test_two_populations_separate():
     (variant,) = template["variants"]
     assert variant["support"] == 4
     assert all("sfc-" in k for k in variant["source_receipt_keys"])
-    # the classifier hint names the self-checkout lane header marker
+    # the classifier hint is a §7.2 structured rule keyed off the distinctive
+    # self-checkout lane-header marker (reconciled to a text_marker hint)
     assert variant["variant_id"] == "self_checkout"
-    assert "self_checkout" in variant["classifier_hint"]["markers_any"]
-    assert "member" in variant["classifier_hint"]["markers_absent"]
+    assert variant["classifier_hint"] == {
+        "type": "text_marker",
+        "tokens": ["CHECKOUT", "SELF"],
+    }
+    # the raw distinctive signals survive in the verdict's features
+    feats = payload["verdict"]["distinguishing_features"]
+    assert any("prints 'self_checkout'" in f for f in feats)
+    assert any("omits 'member'" in f for f in feats)
     # per-cluster pooling kept the distinct amount lanes
     default_amount = [
         c["x"] for c in template["columns"]["items"] if c["role"] == "amount"
@@ -340,10 +347,16 @@ def test_degenerate_cluster_demoted_not_emitted():
 
 def test_classifier_hint_markers_are_distinctive():
     """Markers shared by both populations must never become classifiers;
-    only markers common to one side and rare on the other survive."""
+    only markers common to one side and rare on the other survive. The raw
+    distinctive signal is now surfaced in the verdict's marker features
+    (``prints``/``omits``); the variant carries the reconciled §7.2 hint."""
     payload = build_variant_payload(_mixed_corpus())
-    (variant,) = payload["template"]["variants"]
-    hint = variant["classifier_hint"]
+    marker_feats = [
+        f
+        for f in payload["verdict"]["distinguishing_features"]
+        if " prints '" in f or " omits '" in f
+    ]
+    text = " ".join(marker_feats)
     for shared in (
         "warehouse_header",
         "items_sold",
@@ -351,7 +364,41 @@ def test_classifier_hint_markers_are_distinctive():
         "total_line",
         "payment",
     ):
-        assert shared not in hint["markers_any"]
-        assert shared not in hint["markers_absent"]
-    assert hint["markers_any"] == ["self_checkout"]
-    assert set(hint["markers_absent"]) == {"member", "footer"}
+        assert shared not in text
+    assert any(f.endswith("prints 'self_checkout'") for f in marker_feats)
+    absent = {
+        f.split("omits ")[1].strip("'")
+        for f in marker_feats
+        if " omits '" in f
+    }
+    assert absent == {"member", "footer"}
+
+
+def test_generator_emits_valid_section72_hints_round_trip():
+    """The reconciled hint is a §7.2 structured rule that the SHARED selector
+    (receipt_dynamo.merchant_truth_variants) consumes: a self-checkout
+    receipt's word set selects the variant, a register receipt falls to
+    DEFAULT. This is the W-G -> W-H compatibility contract, exercised end to
+    end on the synthetic 2-population corpus."""
+    from receipt_dynamo.merchant_truth_variants import (
+        HINT_TYPES,
+        normalize_word_set,
+        select_variant,
+    )
+
+    payload = build_variant_payload(_mixed_corpus())
+    template = payload["template"]
+    (variant,) = template["variants"]
+    assert variant["classifier_hint"]["type"] in HINT_TYPES
+
+    sfc_words = normalize_word_set(
+        line["text"] for line in _selfcheckout_scan(0)["lines"]
+    )
+    selected = select_variant(template, word_set=sfc_words)
+    assert selected is not None
+    assert selected["variant_id"] == "self_checkout"
+
+    reg_words = normalize_word_set(
+        line["text"] for line in _register_scan(0)["lines"]
+    )
+    assert select_variant(template, word_set=reg_words) is None


### PR DESCRIPTION
## What

Wires the MerchantTruth **v3.1 §7.2 layout-variant** machinery into the two readers and reconciles the W-G hint **generator** onto the structured hint shape. This makes the `template.variants[]` contract correct **before** any merchant mints a real variant.

Plan: `humble-skipping-quilt` (W-H). Contract: `docs/architecture/MERCHANT_TRUTH_DYNAMO.md` §7.2, landed in **#1210**. Reconciles the pre-§7.2 hint generator flagged in **#1213**'s review.

### Rescope context
W-G (**#1213**, merged) ran live and returned **REFUTE** — Costco has no real variants (empty `variants[]`) — so verification here is **fixture-based**, not a live metric. #1213's review also found its hint generator (`variant_cluster.py`) emitting a pre-§7.2 shape (`{markers_any, markers_absent, sections_added, sections_missing}`); reconciling that is part of this PR.

## Shared selector (one implementation)
`receipt_dynamo/receipt_dynamo/merchant_truth_variants.py` — parses structured `classifier_hint`s (`{"type": "section_presence"|"section_order"|"text_marker", ...args}`), matches against the receipt's **canonical section sequence** (`section_*`) / **normalized OCR word set** (`text_marker`), applies the §7.2 tie-break (**highest support**, then **lexicographically smallest `variant_id`**), and falls back to **DEFAULT** on no-match / malformed / unknown-type.

**Home rationale:** §7.2 is a MerchantTruth *contract* concept (it lives in `MERCHANT_TRUTH_DYNAMO.md`), and all three consumers — eval, diff, and the glyphstudio generator — **already depend on `receipt_dynamo`** (glyphstudio's `stylescan.py` imports it; both scripts add it to path). Homing it here means one import target and zero duplication; the generator imports the same hint *builders* the readers consume, guaranteeing round-trip symmetry.

## Consumers
1. **Eval** (`synthesis_loop/full_fidelity_eval.py`): `profile_columns` selects the variant via the shared selector; `evaluate_pair` derives the normalized word set from the real receipt's words; `run()` loads the canonical section sequence (`RECEIPT_SECTION` → canonical, best-effort). Empty `variants[]` is byte-identical to today.
2. **Diff** (`scripts/merchant_truth_diff.py`): `diff_layout` descends `variants[]` — added/removed variants + per-variant column moves in **paper-width units**, under a `variant[...]` prefix. Variant-blind templates diff byte-identically (goldens unchanged).
3. **Generator** (`glyphstudio/variant_cluster.py`): `build_variant_payload` emits §7.2-shaped hints via the shared builders (`markers → text_marker`, `sections_added → section_presence`); raw distinctive signals stay in the verdict's `distinguishing_features`. The committed REFUTE sample fixture (no hints) is unaffected.

## Tests (fixture-based, failing-test-first)
Committed 2-variant fixtures (`tests/fixtures/variant_layout_two_variants.json`) exercise **every hint type + multi-match tie-break + equal-support lexical tie-break + malformed-hint fallback**.

**RED ON MAIN:** `test_profile_columns_selects_matching_variant` and `test_profile_columns_tie_break_prefers_highest_support` **fail on current `origin/main`**, where `profile_columns` reads only the top-level DEFAULT columns and ignores `variants` — they get the DEFAULT lane `x=0.86` instead of the variant lane `x=0.70`. Verified against `origin/main:synthesis_loop/full_fidelity_eval.py`:
```
text_marker: main profile_columns returns x=0.86 (DEFAULT); test expects variant x=0.7 -> FAIL (red on main)
tie_break:   main profile_columns returns x=0.86 (DEFAULT); test expects variant x=0.7 -> FAIL (red on main)
```

**Empty-variants regression:** `test_profile_columns_empty_variants_byte_identical_to_default` proves the Costco (REFUTE) shape reads exactly the top-level columns.

**Generator round-trip:** `test_generator_emits_valid_section72_hints_round_trip` feeds the generator's emitted hint through the shared selector on the synthetic 2-population corpus (self-checkout receipt selects the variant; register receipt → DEFAULT).

**Mutation-honesty (both demonstrated):**
- Tie-break → lowest-support wins ⇒ `test_tie_break_highest_support_wins` + `test_profile_columns_tie_break_prefers_highest_support` go **red**.
- DEFAULT fallback broken (no-match returns a variant) ⇒ `test_no_match_falls_back_to_default`, `test_unknown_type_falls_back_to_default`, `test_profile_columns_no_match_uses_default` go **red**.

Counts: **73 tests** pass across the four suites (19 selector + 7 eval-consumer + 35 diff incl. 4 new + 12 generator incl. 1 new). Existing diff goldens unchanged.

## Scope
Read-only (no dev writes; moto/fixtures throughout). Renderer unchanged (still reads DEFAULT — variant-aware rendering is a documented non-goal / loop-era follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BeLcSviHL5vDgS3zTSMbsq