### PR TITLE
[fix] Enforce global alias uniqueness at activation (codex review finding on #1203)

### DIFF
--- a/docs/architecture/MERCHANT_TRUTH_DYNAMO.md
+++ b/docs/architecture/MERCHANT_TRUTH_DYNAMO.md
@@ -276,6 +276,24 @@ precise.
    condition failure. A test drives **two concurrent first flips** and
    asserts exactly one wins and the other converges without a second ACTIVE.
 
+**Global alias uniqueness is an activation precondition.** The fleet alias
+map (`MerchantTruthLoader`) requires every normalized alias — the slug
+itself included — to resolve to exactly one ACTIVE merchant, so both
+activation operations run an alias-uniqueness guard in the accessor before
+writing: the candidate's `normalized_aliases` are checked against every
+other ACTIVE pointer (the same GSITYPE fleet sweep `fleet_status` uses),
+and a collision refuses the activation naming the alias and its owner. The
+guard lives in the accessor precisely so no caller can bypass it; the CLI
+additionally pre-checks in its DRY-RUN plan so the refusal appears in the
+review, not at write time. Because the GSITYPE read is eventually
+consistent the guard is best-effort against a same-instant race, so the
+loader's map builder degrades defensively rather than hard-failing: a
+collision that reaches the fleet resolves to a deterministic winner (the
+slug owning the alias as its own normalized identity, else the
+lexicographically smallest) with a loud `MerchantTruthAliasCollisionWarning`
+naming the losers — one bad activation must never take down every
+map-building consumer.
+
 A single-item pointer update means readers atomically see the old or new
 bundle, never a mix; rollback is the same subsequent-activation flip with
 `prev_version` as the target. Flip and rollback also **reconcile proposal

--- a/receipt_dynamo/receipt_dynamo/data/_merchant_truth.py
+++ b/receipt_dynamo/receipt_dynamo/data/_merchant_truth.py
@@ -27,6 +27,7 @@ from receipt_dynamo.entities.merchant_truth import (
     merchant_truth_pk,
     version_prefix,
 )
+from receipt_dynamo.merchant_truth_loader import normalize_merchant_alias
 
 if TYPE_CHECKING:
     from mypy_boto3_dynamodb.type_defs import TransactWriteItemTypeDef
@@ -532,6 +533,39 @@ class _MerchantTruth(FlattenedStandardMixin):
     def _to_dynamo(value: Any) -> dict[str, Any]:
         return to_dynamodb_value(value)
 
+    def _assert_alias_uniqueness(self, active: MerchantTruthActive) -> None:
+        """Refuse activation when an alias collides with another merchant.
+
+        The fleet alias map (``MerchantTruthLoader``) requires every
+        normalized alias — including the slug itself — to resolve to
+        exactly one ACTIVE merchant. Enforcing that here, on both
+        activation operations, means no caller can activate a bundle
+        whose identity would poison the fleet map for every consumer.
+        The read is the same GSITYPE fleet sweep the loader uses; it is
+        eventually consistent, so this guard is best-effort against a
+        same-instant race — the loader's deterministic-winner
+        degradation is the backstop for that window.
+        """
+        candidate = {
+            normalize_merchant_alias(alias)
+            for alias in [active.slug, *active.normalized_aliases]
+        }
+        for record in self.list_active_merchant_truth():
+            if record.slug == active.slug:
+                continue
+            theirs = {
+                normalize_merchant_alias(alias)
+                for alias in [record.slug, *record.normalized_aliases]
+            }
+            collisions = sorted(candidate & theirs)
+            if collisions:
+                raise MerchantTruthIntegrityError(
+                    f"cannot activate {active.slug} v{active.version}: "
+                    f"alias {collisions[0]!r} already belongs to ACTIVE "
+                    f"merchant {record.slug!r} "
+                    f"(all collisions: {collisions})"
+                )
+
     def initial_activate(
         self,
         active: MerchantTruthActive,
@@ -539,6 +573,7 @@ class _MerchantTruth(FlattenedStandardMixin):
     ) -> MerchantTruthActive:
         """Conditionally create the first ACTIVE pointer."""
         self._assert_expected_table(expected_table_name)
+        self._assert_alias_uniqueness(active)
         audit = self._audit(
             active.slug,
             active.version,
@@ -611,6 +646,7 @@ class _MerchantTruth(FlattenedStandardMixin):
     ) -> MerchantTruthActive:
         """Move ACTIVE under an exact previous version/hash condition."""
         self._assert_expected_table(expected_table_name)
+        self._assert_alias_uniqueness(active)
         current = self.get_active_merchant_truth(
             active.slug, consistent_read=True
         )

--- a/receipt_dynamo/receipt_dynamo/merchant_truth_loader.py
+++ b/receipt_dynamo/receipt_dynamo/merchant_truth_loader.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import re
 import unicodedata
+import warnings
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
@@ -120,6 +121,57 @@ def normalize_merchant_alias(value: str) -> str:
     return " ".join(normalized.split())
 
 
+class MerchantTruthAliasCollisionWarning(RuntimeWarning):
+    """A fleet alias is claimed by more than one ACTIVE merchant."""
+
+
+def build_fleet_alias_map(
+    active_records: list[MerchantTruthActive],
+) -> dict[str, str]:
+    """Build the fleet alias -> slug map, degrading loudly on collisions.
+
+    Global alias uniqueness is enforced at activation time (the accessor
+    refuses to activate a bundle whose aliases collide with a different
+    ACTIVE merchant). This builder is defense in depth: if a collision
+    reaches the fleet anyway, one bad activation must not take down every
+    consumer that builds the alias map. Each colliding alias resolves to
+    a deterministic winner — the slug whose own normalized form equals
+    the alias (it owns the alias as its identity), else the
+    lexicographically smallest slug — and a loud
+    ``MerchantTruthAliasCollisionWarning`` lists the losers.
+    """
+    claims: dict[str, set[str]] = {}
+    for active in sorted(active_records, key=lambda item: item.slug):
+        for alias in [active.slug, *active.normalized_aliases]:
+            claims.setdefault(normalize_merchant_alias(alias), set()).add(
+                active.slug
+            )
+    alias_map: dict[str, str] = {}
+    for alias, slugs in claims.items():
+        if len(slugs) == 1:
+            (alias_map[alias],) = slugs
+            continue
+        winner = next(
+            (
+                slug
+                for slug in sorted(slugs)
+                if normalize_merchant_alias(slug) == alias
+            ),
+            min(slugs),
+        )
+        losers = sorted(slugs - {winner})
+        warnings.warn(
+            f"fleet alias collision: {alias!r} is claimed by "
+            f"{sorted(slugs)}; resolving to {winner!r} (deterministic "
+            f"winner), ignoring {losers}. Fix the losing activation(s) — "
+            "activation-time uniqueness should have refused this.",
+            MerchantTruthAliasCollisionWarning,
+            stacklevel=2,
+        )
+        alias_map[alias] = winner
+    return alias_map
+
+
 class MerchantTruthLoader:
     """Resolve aliases, load complete bundles, and manage immutable caches."""
 
@@ -197,7 +249,6 @@ class MerchantTruthLoader:
     ) -> tuple[dict[str, str], dict[str, MerchantTruthActive]]:
         assert self._reader is not None
         active_records = self._reader.list_active_merchant_truth()
-        alias_map: dict[str, str] = {}
         active_by_slug: dict[str, MerchantTruthActive] = {}
         for active in active_records:
             if active.slug in active_by_slug:
@@ -205,16 +256,7 @@ class MerchantTruthLoader:
                     f"duplicate ACTIVE pointer for {active.slug}"
                 )
             active_by_slug[active.slug] = active
-            aliases = [active.slug, *active.normalized_aliases]
-            for alias in aliases:
-                normalized = normalize_merchant_alias(alias)
-                owner = alias_map.get(normalized)
-                if owner is not None and owner != active.slug:
-                    raise MerchantTruthIntegrityError(
-                        f"ambiguous merchant alias {normalized!r}: "
-                        f"{owner} vs {active.slug}"
-                    )
-                alias_map[normalized] = active.slug
+        alias_map = build_fleet_alias_map(active_records)
         self._write_json(
             self._cache_dir / "fleet-active.json",
             {"items": [record.to_item() for record in active_records]},
@@ -401,17 +443,10 @@ class MerchantTruthLoader:
     def _alias_map_from_records(
         active_records: list[MerchantTruthActive],
     ) -> dict[str, str]:
-        result: dict[str, str] = {}
-        for active in active_records:
-            for alias in [active.slug, *active.normalized_aliases]:
-                normalized = normalize_merchant_alias(alias)
-                owner = result.get(normalized)
-                if owner and owner != active.slug:
-                    raise MerchantTruthIntegrityError(
-                        f"ambiguous cached alias {normalized!r}"
-                    )
-                result[normalized] = active.slug
-        return result
+        # Same degradation as the online map: a collision in the cached
+        # fleet warns and resolves deterministically instead of hard-
+        # failing every offline consumer.
+        return build_fleet_alias_map(active_records)
 
     def _cache_active(self, active: MerchantTruthActive) -> None:
         self._write_json(

--- a/receipt_dynamo/tests/unit/test_merchant_truth_loader.py
+++ b/receipt_dynamo/tests/unit/test_merchant_truth_loader.py
@@ -18,8 +18,10 @@ from receipt_dynamo.entities.merchant_truth import (
     compute_bundle_hash,
 )
 from receipt_dynamo.merchant_truth_loader import (
+    MerchantTruthAliasCollisionWarning,
     MerchantTruthLoader,
     TruthResolutionMode,
+    build_fleet_alias_map,
 )
 
 pytestmark = pytest.mark.unit
@@ -164,12 +166,18 @@ def test_online_active_builds_alias_map_from_one_fleet_query(
     assert reader.bundle_calls == 1
 
 
-def test_fleet_alias_collision_fails_before_bundle_read(
+def test_fleet_alias_collision_degrades_to_deterministic_winner(
     tmp_path: Path,
 ) -> None:
+    """One bad activation must not take down every fleet-map consumer.
+
+    Activation-time uniqueness (the accessor guard) is the real fix;
+    this is defense in depth: a collision that reaches the fleet warns
+    loudly and resolves to a deterministic winner instead of raising.
+    """
     first, items = build_bundle()
     second = MerchantTruthActive(
-        slug="other-market",
+        slug="zz-market",
         version=1,
         bundle_hash=first.bundle_hash,
         normalized_aliases=["sprouts"],
@@ -178,13 +186,75 @@ def test_fleet_alias_collision_fails_before_bundle_read(
     )
     reader = FakeReader([first, second], items)
 
-    with pytest.raises(MerchantTruthIntegrityError, match="ambiguous"):
-        MerchantTruthLoader(reader, tmp_path).load(
+    with pytest.warns(
+        MerchantTruthAliasCollisionWarning, match="'sprouts'.*zz-market"
+    ):
+        artifact = MerchantTruthLoader(reader, tmp_path).load(
             "sprouts", TruthResolutionMode.ONLINE_ACTIVE
         )
 
+    # Neither slug owns 'sprouts' as its own normalized identity, so the
+    # lexicographically smallest slug wins deterministically.
+    assert artifact.slug == SLUG
+    assert artifact.gate_eligible
     assert reader.fleet_calls == 1
-    assert reader.bundle_calls == 0
+
+
+def test_alias_collision_winner_prefers_identity_owner() -> None:
+    """The slug whose own normalized form IS the alias wins the alias."""
+    digest = "a" * 64
+    contenders = [
+        MerchantTruthActive(
+            slug="aaa-market",
+            version=1,
+            bundle_hash=digest,
+            normalized_aliases=["other market"],
+            activated_at=NOW,
+            activated_by="owner",
+        ),
+        MerchantTruthActive(
+            slug="other-market",
+            version=1,
+            bundle_hash=digest,
+            normalized_aliases=["other market"],
+            activated_at=NOW,
+            activated_by="owner",
+        ),
+    ]
+
+    with pytest.warns(
+        MerchantTruthAliasCollisionWarning, match="'other market'"
+    ) as caught:
+        alias_map = build_fleet_alias_map(contenders)
+
+    # 'other-market' owns the alias as its own identity, so it beats the
+    # lexicographically smaller 'aaa-market'; every loser is named.
+    assert alias_map["other market"] == "other-market"
+    assert alias_map["aaa market"] == "aaa-market"
+    assert any("aaa-market" in str(w.message) for w in caught)
+
+
+def test_alias_collision_winner_is_input_order_independent() -> None:
+    digest = "b" * 64
+    records = [
+        MerchantTruthActive(
+            slug=slug,
+            version=1,
+            bundle_hash=digest,
+            normalized_aliases=["shared mart"],
+            activated_at=NOW,
+            activated_by="owner",
+        )
+        for slug in ("m-two", "m-one")
+    ]
+
+    with pytest.warns(MerchantTruthAliasCollisionWarning):
+        forward = build_fleet_alias_map(records)
+    with pytest.warns(MerchantTruthAliasCollisionWarning):
+        reverse = build_fleet_alias_map(list(reversed(records)))
+
+    assert forward == reverse
+    assert forward["shared mart"] == "m-one"
 
 
 def test_pinned_mode_requires_and_verifies_exact_tuple(tmp_path: Path) -> None:

--- a/scripts/activate_merchant_truth.py
+++ b/scripts/activate_merchant_truth.py
@@ -57,9 +57,13 @@ for _p in (REPO, os.path.join(REPO, "receipt_dynamo")):
 
 from receipt_dynamo.data.shared_exceptions import (  # noqa: E402
     MerchantTruthConflictError,
+    MerchantTruthIntegrityError,
 )
 from receipt_dynamo.entities.merchant_truth import (  # noqa: E402
     MerchantTruthActive,
+)
+from receipt_dynamo.merchant_truth_loader import (  # noqa: E402
+    normalize_merchant_alias,
 )
 
 # The loading/verification helpers are the diff tool's: import, don't copy.
@@ -173,8 +177,37 @@ def build_plan(
     )
     # Fail closed on a malformed identity component before any write plan
     # is shown, not at flip time.
-    plan.normalized_aliases  # noqa: B018  (validation side effect)
+    aliases = plan.normalized_aliases
+    _check_alias_uniqueness(client, slug, aliases)
     return plan
+
+
+def _check_alias_uniqueness(
+    client: "DynamoClient", slug: str, aliases: list[str]
+) -> None:
+    """Refuse a plan whose aliases collide with another ACTIVE merchant.
+
+    Mirrors the accessor's activation-time guard (which no caller can
+    bypass) so the collision surfaces in the DRY-RUN decision summary,
+    not only at write time. A collision would otherwise poison the fleet
+    alias map that MerchantTruthLoader builds for every consumer.
+    """
+    candidate = {normalize_merchant_alias(alias) for alias in [slug, *aliases]}
+    for record in client.list_active_merchant_truth():
+        if record.slug == slug:
+            continue
+        theirs = {
+            normalize_merchant_alias(alias)
+            for alias in [record.slug, *record.normalized_aliases]
+        }
+        collisions = sorted(candidate & theirs)
+        if collisions:
+            raise ActivationError(
+                f"alias collision: {collisions[0]!r} already belongs to "
+                f"ACTIVE merchant {record.slug!r}; activating {slug} "
+                f"would make the fleet alias map ambiguous "
+                f"(all collisions: {collisions})"
+            )
 
 
 def _mutation_lines(plan: ActivationPlan) -> list[str]:
@@ -363,6 +396,11 @@ def _run_single(
     except MerchantTruthConflictError as error:
         print("\n".join(render_conflict(error, client, slug)))
         return 3
+    except MerchantTruthIntegrityError as error:
+        # The accessor's own alias-uniqueness guard (or another
+        # integrity refusal) fired between plan and write.
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
     print("\n".join(render_result(verb, active)))
     return 0
 

--- a/tests/test_activate_merchant_truth.py
+++ b/tests/test_activate_merchant_truth.py
@@ -27,7 +27,10 @@ from botocore.exceptions import ClientError
 from moto import mock_aws
 
 from receipt_dynamo import DynamoClient
-from receipt_dynamo.data.shared_exceptions import MerchantTruthConflictError
+from receipt_dynamo.data.shared_exceptions import (
+    MerchantTruthConflictError,
+    MerchantTruthIntegrityError,
+)
 from receipt_dynamo.entities.merchant_truth import (
     COMPONENT_NAMES,
     MerchantTruthActive,
@@ -70,23 +73,32 @@ def mock_aws_services():
 # ---------------------------------------------------------------------------
 
 
-def component_payload(slug: str, name: str, version: int) -> Any:
+def component_payload(
+    slug: str,
+    name: str,
+    version: int,
+    aliases: list[str] | None = None,
+) -> Any:
     if name == "identity":
         return {
             "merchant_name": slug.title(),
             "slug": slug,
-            "normalized_aliases": [slug, f"{slug} store"],
+            "normalized_aliases": aliases or [slug, f"{slug} store"],
         }
     return {"component": name, "v": version}
 
 
-def build_components(slug: str, version: int) -> list[MerchantTruthComponent]:
+def build_components(
+    slug: str,
+    version: int,
+    aliases: list[str] | None = None,
+) -> list[MerchantTruthComponent]:
     return [
         MerchantTruthComponent(
             slug=slug,
             version=version,
             name=name,
-            payload=component_payload(slug, name, version),
+            payload=component_payload(slug, name, version, aliases),
             provenance=LEGACY_PROVENANCE,
         )
         for name in sorted(COMPONENT_NAMES)
@@ -409,13 +421,17 @@ def dynamodb_table():
 
 
 def seal_live(
-    client: DynamoClient, table: str, slug: str, version: int
+    client: DynamoClient,
+    table: str,
+    slug: str,
+    version: int,
+    aliases: list[str] | None = None,
 ) -> str:
     """Mint + seal one version through the real accessor; return its hash."""
     client.mint_version(
         slug,
         version,
-        build_components(slug, version),
+        build_components(slug, version, aliases),
         MINT_PROVENANCE,
         f"run-{slug}-{version}",
         table,
@@ -734,3 +750,196 @@ def test_single_conflict_exits_three_with_current_active(
     output = capsys.readouterr().out
     assert "CONFLICT" in output
     assert "Current ACTIVE for vons: v1" in output
+
+
+# ---------------------------------------------------------------------------
+# Global alias uniqueness (codex review finding: a colliding activation
+# used to succeed and only surface when the loader built the fleet map)
+# ---------------------------------------------------------------------------
+
+
+def test_dry_run_refuses_alias_collision_with_other_merchant(
+    dynamodb_table: str, capsys: pytest.CaptureFixture[str]
+) -> None:
+    client = DynamoClient(dynamodb_table)
+    seal_live(client, dynamodb_table, "vons", 1, aliases=["vons", "vons club"])
+    assert (
+        amt.main(
+            [
+                "--slug",
+                "vons",
+                "--version",
+                "1",
+                "--flip",
+                "--table",
+                dynamodb_table,
+            ],
+            client=client,
+        )
+        == 0
+    )
+    capsys.readouterr()
+    seal_live(
+        client,
+        dynamodb_table,
+        "vons_market",
+        1,
+        aliases=["vons market", "vons club"],
+    )
+
+    # The DRY-RUN already refuses: the collision must surface at review
+    # time, not only at write time.
+    exit_code = amt.main(
+        [
+            "--slug",
+            "vons_market",
+            "--version",
+            "1",
+            "--table",
+            dynamodb_table,
+        ],
+        client=client,
+    )
+
+    assert exit_code == 1
+    captured = capsys.readouterr()
+    assert "alias collision" in captured.err
+    assert "'vons club'" in captured.err
+    assert "'vons'" in captured.err
+    assert (
+        client.get_active_merchant_truth("vons_market", consistent_read=True)
+        is None
+    )
+    assert activation_audits(dynamodb_table, "vons_market") == []
+
+
+def test_accessor_refuses_colliding_initial_activation(
+    dynamodb_table: str,
+) -> None:
+    """The guard lives in the accessor: no caller can bypass it."""
+    client = DynamoClient(dynamodb_table)
+    hash_vons = seal_live(
+        client, dynamodb_table, "vons", 1, aliases=["vons", "vons club"]
+    )
+    client.initial_activate(
+        MerchantTruthActive(
+            slug="vons",
+            version=1,
+            bundle_hash=hash_vons,
+            normalized_aliases=["vons", "vons club"],
+            activated_at=NOW,
+            activated_by="owner",
+        ),
+        dynamodb_table,
+    )
+    hash_other = seal_live(
+        client,
+        dynamodb_table,
+        "vons_market",
+        1,
+        aliases=["vons market", "vons club"],
+    )
+
+    with pytest.raises(MerchantTruthIntegrityError, match="vons club"):
+        client.initial_activate(
+            MerchantTruthActive(
+                slug="vons_market",
+                version=1,
+                bundle_hash=hash_other,
+                normalized_aliases=["vons market", "vons club"],
+                activated_at=NOW,
+                activated_by="rogue-caller",
+            ),
+            dynamodb_table,
+        )
+
+    assert (
+        client.get_active_merchant_truth("vons_market", consistent_read=True)
+        is None
+    )
+    assert activation_audits(dynamodb_table, "vons_market") == []
+
+
+def test_accessor_refuses_colliding_flip(dynamodb_table: str) -> None:
+    client = DynamoClient(dynamodb_table)
+    hash_vons = seal_live(
+        client, dynamodb_table, "vons", 1, aliases=["vons", "vons club"]
+    )
+    client.initial_activate(
+        MerchantTruthActive(
+            slug="vons",
+            version=1,
+            bundle_hash=hash_vons,
+            normalized_aliases=["vons", "vons club"],
+            activated_at=NOW,
+            activated_by="owner",
+        ),
+        dynamodb_table,
+    )
+    hash_b1 = seal_live(client, dynamodb_table, "beta", 1)
+    client.initial_activate(make_active("beta", 1, hash_b1), dynamodb_table)
+    hash_b2 = seal_live(client, dynamodb_table, "beta", 2)
+
+    with pytest.raises(MerchantTruthIntegrityError, match="vons club"):
+        client.flip_active(
+            MerchantTruthActive(
+                slug="beta",
+                version=2,
+                bundle_hash=hash_b2,
+                normalized_aliases=["beta", "vons club"],
+                activated_at=NOW,
+                activated_by="rogue-caller",
+            ),
+            1,
+            hash_b1,
+            dynamodb_table,
+        )
+
+    active = client.get_active_merchant_truth("beta", consistent_read=True)
+    assert active is not None
+    assert (active.version, active.bundle_hash) == (1, hash_b1)
+
+
+def test_non_colliding_aliases_still_activate(dynamodb_table: str) -> None:
+    """The guard refuses collisions only — disjoint fleets are untouched."""
+    client = DynamoClient(dynamodb_table)
+    hash_vons = seal_live(client, dynamodb_table, "vons", 1)
+    client.initial_activate(make_active("vons", 1, hash_vons), dynamodb_table)
+    hash_beta = seal_live(client, dynamodb_table, "beta", 1)
+
+    result = client.initial_activate(
+        make_active("beta", 1, hash_beta), dynamodb_table
+    )
+
+    assert (result.version, result.bundle_hash) == (1, hash_beta)
+
+
+def test_all_sealed_flip_continues_past_alias_collision(
+    dynamodb_table: str, capsys: pytest.CaptureFixture[str]
+) -> None:
+    client = DynamoClient(dynamodb_table)
+    seal_live(
+        client, dynamodb_table, "alpha", 1, aliases=["alpha", "shared mart"]
+    )
+    seal_live(
+        client, dynamodb_table, "beta", 1, aliases=["beta", "shared mart"]
+    )
+    seal_live(client, dynamodb_table, "gamma", 1)
+
+    exit_code = amt.main(
+        ["--all-sealed", "--flip", "--table", dynamodb_table], client=client
+    )
+
+    # alpha wins 'shared mart' (activates first, alphabetical sweep),
+    # beta is refused as a per-merchant ERROR, gamma still activates.
+    assert exit_code == 1
+    output = capsys.readouterr().out
+    assert "| alpha | 1 | ACTIVATED |" in output
+    assert "| beta | 1 | ERROR: alias collision" in output
+    assert "| gamma | 1 | ACTIVATED |" in output
+    assert (
+        client.get_active_merchant_truth("beta", consistent_read=True) is None
+    )
+    for slug in ("alpha", "gamma"):
+        active = client.get_active_merchant_truth(slug, consistent_read=True)
+        assert active is not None and active.version == 1


### PR DESCRIPTION
## Finding (codex independent review of #1203)

The G2 activation path never enforced global alias uniqueness: a SEALED bundle whose identity `normalized_aliases` collide with a **different** ACTIVE merchant's aliases activated cleanly. The collision only surfaced later, when `MerchantTruthLoader` built the fleet alias map — which hard-failed on ambiguity — so one bad activation could block **every** renderer/eval consumer at startup.

## Fix

**Activation-time refusal, enforced in the accessor so no caller can bypass it** (this is where the contract's write-governance lives — every other activation invariant, SEALED + gate-PASS + expected-prev, is already a `_MerchantTruth` condition):

- `_MerchantTruth._assert_alias_uniqueness` runs at the top of **both** activation operations (`initial_activate`, `flip_active`): candidate normalized aliases (the slug included, matching the loader's map semantics) are checked against every other ACTIVE pointer via the same GSITYPE fleet sweep `fleet_status` uses. A collision raises `MerchantTruthIntegrityError` **naming the colliding alias and its owning slug**, before any write.
- `scripts/activate_merchant_truth.py` pre-checks the same invariant in `build_plan`, so the refusal shows up in the DRY-RUN decision summary (exit 1), and `--all-sealed` records it as a per-merchant ERROR row and continues the sweep. An accessor-raised integrity error on the execute path exits 1 cleanly instead of tracebacking.

**Defense in depth — loader hardening** (`receipt_dynamo/merchant_truth_loader.py`): the fleet map no longer hard-fails on a collision. New shared `build_fleet_alias_map` (used by both the online map and the cached-records map) resolves each colliding alias to a **deterministic winner** — the slug that owns the alias as its own normalized identity, else the lexicographically smallest slug — and emits a loud `MerchantTruthAliasCollisionWarning` listing the losers. Input-order independent. The GSITYPE guard read is eventually consistent, so a same-instant race can still slip a collision through; this degradation is the backstop that keeps consumers alive while the losing activation gets fixed.

Contract updated: `docs/architecture/MERCHANT_TRUTH_DYNAMO.md` now states alias uniqueness as an activation precondition and documents the loader's degradation rule.

## Tests

Suites: `tests/test_activate_merchant_truth.py` (19), `receipt_dynamo/tests/unit/test_merchant_truth_loader.py` (+3, 1 rewritten from hard-fail to degradation), plus fleet_status / merchant_truth_diff / accessor unit / integration suites — **105 passed** in the combined run.

- moto: CLI DRY-RUN refuses a colliding activation (names alias + owner; no pointer, no audit)
- moto: direct accessor calls refused for both `initial_activate` and `flip_active` (rogue-caller bypass proof; winner's pointer untouched)
- moto: non-colliding activations unaffected
- moto: `--all-sealed --flip` continues past a collision — alias winner activates, loser is an ERROR row, later merchants still activate, exit 1
- loader: collision degrades to deterministic winner with `MerchantTruthAliasCollisionWarning` (end-to-end load succeeds for the winner); identity-owner beats lexicographic; input-order independence

### Mutation-honesty (verified by hand, mutations reverted)

- Removing the accessor guard turns **`test_accessor_refuses_colliding_initial_activation`** and **`test_accessor_refuses_colliding_flip`** red (2 failed / 17 passed).
- Removing the CLI pre-check turns **`test_dry_run_refuses_alias_collision_with_other_merchant`** and **`test_all_sealed_flip_continues_past_alias_collision`** red (2 failed / 17 passed).

No live writes were performed; the 13 SEALED dev bundles remain untouched and awaiting the owner's G2 flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BeLcSviHL5vDgS3zTSMbsq