### PR TITLE
[catalog] label hygiene: VALID-only mining, deterministic duplicate resolution, derived taxability

### DIFF
--- a/receipt_dynamo/receipt_dynamo/entities/merchant_catalog_item.py
+++ b/receipt_dynamo/receipt_dynamo/entities/merchant_catalog_item.py
@@ -50,7 +50,10 @@ class MerchantCatalogItem(DynamoDBEntity):
         product_text: Product text exactly as observed on the receipt row.
         price: Decimal-as-string, e.g. ``"1.99"`` (mode across observations).
         category: Section category (PRODUCE / DAIRY / ... / UNCATEGORIZED).
-        taxable: Whether the item is taxable.
+        taxable: Whether the item is taxable — ``True``/``False`` only when
+            the receipt carried an explicit taxability signal (tax-flag
+            letter on the price line); ``None`` when no signal was observed.
+            Never defaulted/hardcoded.
         source: Always ``"observed"`` — the catalog is mined-only.
         observed_count: How many times the item was observed (>= 1).
         upc: Optional UPC when a barcode was decoded for the item.
@@ -78,7 +81,7 @@ class MerchantCatalogItem(DynamoDBEntity):
     product_text: str
     price: str
     category: str
-    taxable: bool
+    taxable: bool | None = None
     source: str = "observed"
     observed_count: int = 1
     upc: str | None = None
@@ -99,8 +102,8 @@ class MerchantCatalogItem(DynamoDBEntity):
         self.price = str(self.price)
         if not isinstance(self.category, str) or not self.category:
             self.category = "UNCATEGORIZED"
-        if not isinstance(self.taxable, bool):
-            raise ValueError("taxable must be a bool")
+        if self.taxable is not None and not isinstance(self.taxable, bool):
+            raise ValueError("taxable must be a bool or None (no signal)")
         if self.source != "observed":
             raise ValueError(
                 "source must be 'observed' — the catalog is mined-only "
@@ -162,7 +165,11 @@ class MerchantCatalogItem(DynamoDBEntity):
             "product_text": {"S": self.product_text},
             "price": {"S": self.price},
             "category": {"S": self.category},
-            "taxable": {"BOOL": self.taxable},
+            "taxable": (
+                {"BOOL": self.taxable}
+                if self.taxable is not None
+                else {"NULL": True}
+            ),
             "source": {"S": self.source},
             "observed_count": {"N": str(self.observed_count)},
             "source_receipt_keys": {
@@ -194,6 +201,10 @@ class MerchantCatalogItem(DynamoDBEntity):
         try:
             upc_attr = item.get("upc", {})
             upc = None if upc_attr.get("NULL") else upc_attr.get("S")
+            taxable_attr = item["taxable"]
+            taxable = (
+                None if taxable_attr.get("NULL") else taxable_attr["BOOL"]
+            )
             source_keys = [
                 entry["S"]
                 for entry in item["source_receipt_keys"].get("L", [])
@@ -203,7 +214,7 @@ class MerchantCatalogItem(DynamoDBEntity):
                 product_text=item["product_text"]["S"],
                 price=item["price"]["S"],
                 category=item["category"]["S"],
-                taxable=item["taxable"]["BOOL"],
+                taxable=taxable,
                 source=item["source"]["S"],
                 observed_count=int(item["observed_count"]["N"]),
                 upc=upc,

--- a/receipt_dynamo/tests/integration/test__merchant_catalog_item.py
+++ b/receipt_dynamo/tests/integration/test__merchant_catalog_item.py
@@ -56,6 +56,25 @@ class TestMerchantCatalogItemOperations:
         assert fetched == item
         assert fetched.source_receipt_keys == ["img-1#00001", "img-2#00002"]
 
+    def test_taxable_none_roundtrips_through_dynamo(
+        self, client: DynamoClient
+    ) -> None:
+        item = MerchantCatalogItem(
+            merchant_name="Costco Wholesale",
+            product_text="NO SIGNAL ITEM",
+            price="2.49",
+            category="GROCERY",
+            taxable=None,
+            source="observed",
+            observed_count=1,
+            source_receipt_keys=["img-1#00001"],
+        )
+        client.add_merchant_catalog_item(item)
+        fetched = client.get_merchant_catalog_item(
+            "Costco Wholesale", "GROCERY", "NO SIGNAL ITEM"
+        )
+        assert fetched.taxable is None
+
     def test_add_duplicate_raises(self, client: DynamoClient) -> None:
         item = make_item()
         client.add_merchant_catalog_item(item)

--- a/receipt_dynamo/tests/unit/test_merchant_catalog_item.py
+++ b/receipt_dynamo/tests/unit/test_merchant_catalog_item.py
@@ -58,6 +58,42 @@ def test_roundtrip(catalog_item):
 
 
 @pytest.mark.unit
+def test_taxable_none_roundtrip():
+    """taxable=None (no taxability signal observed) serializes as NULL and
+    survives the roundtrip — never coerced to False."""
+    item = MerchantCatalogItem(
+        merchant_name="Costco Wholesale",
+        product_text="KS WATER 40PK",
+        price="3.99",
+        category="GROCERY",
+        taxable=None,
+        source="observed",
+        observed_count=1,
+        source_receipt_keys=["abc#00001"],
+    )
+    assert item.to_item()["taxable"] == {"NULL": True}
+    restored = item_to_merchant_catalog_item(item.to_item())
+    assert restored.taxable is None
+    assert restored == item
+
+
+@pytest.mark.unit
+def test_taxable_true_roundtrip():
+    item = MerchantCatalogItem(
+        merchant_name="Costco Wholesale",
+        product_text="PAPER TOWELS",
+        price="12.99",
+        category="HOUSEHOLD",
+        taxable=True,
+        source="observed",
+        observed_count=1,
+        source_receipt_keys=["abc#00001"],
+    )
+    assert item.to_item()["taxable"] == {"BOOL": True}
+    assert item_to_merchant_catalog_item(item.to_item()).taxable is True
+
+
+@pytest.mark.unit
 def test_null_upc_roundtrip():
     item = MerchantCatalogItem(
         merchant_name="Costco Wholesale",

--- a/scripts/ingest_merchant_catalog.py
+++ b/scripts/ingest_merchant_catalog.py
@@ -9,6 +9,13 @@ category comes from the nearest section-header row; a NON_PRODUCT stoplist
 keeps tax/totals/tender/coupon rows out. Every mined item records the
 receipt keys it was observed on (``source_receipt_keys``).
 
+LABEL HYGIENE: only labels whose validation_status is in
+ACCEPTED_LABEL_STATUSES (= VALID) are minable, and duplicate labels on the
+same word resolve deterministically (VALID first, then newest
+timestamp_added, then label text — never dict last-write-wins). Taxability
+is derived from an explicit tax-flag letter on the price line when present
+and is None otherwise — never hardcoded.
+
 ATTRIBUTION SPOT-CHECK (before any mining): each receipt's merchant
 attribution (the ReceiptPlace merchant) is cross-checked against brand
 signals in its OCR text and label-reasoning text. A receipt whose signals
@@ -252,6 +259,11 @@ def check_attribution(
     reasoning text. Any foreign-brand evidence quarantines the receipt —
     with or without supporting evidence for the attributed brand — because
     a conflicted receipt must never be silently mined.
+
+    Deliberately scans ALL labels' reasoning, ignoring validation_status:
+    quarantine wants the widest evidence net (the known BJ's evidence lives
+    in reasoning attached to a word whose labels were later revised), and
+    unlike mining, a false hit here only holds a receipt for review.
     """
     ocr_corpus = " ".join(
         str(word.text) for word in details.words if word.text
@@ -338,8 +350,87 @@ def check_attribution(
 
 
 # ---------------------------------------------------------------------------
+# Label hygiene: validation-status filter + deterministic duplicate resolution
+# ---------------------------------------------------------------------------
+
+# Only VALID labels are minable. The catalog feeds the truth system's
+# catalog_snapshot, so mining trusts exactly the labels the rest of the
+# pipeline treats as confirmed: the section evaluator counts VALID only
+# (scripts/evaluate_section_assignment.py), llm_review protects/emits VALID
+# as the reviewed state, and the MCP server documents PENDING as
+# machine-propagated rows that "need review before they count". INVALID is
+# a rejection and must never mine; PENDING/NONE/NEEDS_REVIEW are unreviewed
+# proposals and are excluded too (measured on the 39 dev Costco receipts:
+# name/price labels split VALID=344 / INVALID=481 / PENDING=1 — the
+# unfiltered miner was eating rejected labels).
+ACCEPTED_LABEL_STATUSES = frozenset({"VALID"})
+
+_STATUS_RANK = {"VALID": 0}  # anything else ranks after VALID
+
+
+def _label_timestamp(label: Any) -> str:
+    """ISO timestamp string for deterministic newest-first ordering."""
+    value = getattr(label, "timestamp_added", "") or ""
+    return str(value)
+
+
+def resolve_word_labels(labels: Iterable[Any]) -> dict[tuple[int, int], Any]:
+    """(line_id, word_id) -> the single authoritative label for that word.
+
+    Words routinely carry multiple label rows (measured: 673/2099 labeled
+    dev Costco words) — typically an older rejected proposal plus a newer
+    confirmed label (e.g. AMOUNT/INVALID superseded by LINE_TOTAL/VALID).
+    Resolution is deterministic, never dict-insertion last-write-wins:
+
+    1. only ACCEPTED_LABEL_STATUSES survive the hygiene filter;
+    2. VALID ranks before any other accepted status (future-proofing if the
+       accepted set is ever widened);
+    3. newest ``timestamp_added`` wins;
+    4. lexicographically smallest label string as the final total-order
+       tie-break.
+    """
+    by_word: dict[tuple[int, int], list[Any]] = {}
+    for label in labels:
+        if label.validation_status not in ACCEPTED_LABEL_STATUSES:
+            continue
+        by_word.setdefault((label.line_id, label.word_id), []).append(label)
+    resolved: dict[tuple[int, int], Any] = {}
+    for word_key, candidates in by_word.items():
+        # Three stable sorts compose into one deterministic total order
+        # (last sort is the primary key): label asc, then newest timestamp,
+        # then status rank.
+        candidates.sort(key=lambda label: str(label.label))
+        candidates.sort(key=_label_timestamp, reverse=True)
+        candidates.sort(
+            key=lambda label: _STATUS_RANK.get(label.validation_status, 1)
+        )
+        resolved[word_key] = candidates[0]
+    return resolved
+
+
+# ---------------------------------------------------------------------------
 # Observed miner
 # ---------------------------------------------------------------------------
+
+# Taxability comes only from an explicit tax-flag letter on the price line —
+# either attached to the amount ("1.25T", the Sprouts/Dollar Tree form the
+# historical _line_is_taxable/compose_dollartree read) or a detached
+# single-letter word to the right of the price in the same y-band ("9.99 A",
+# the Costco form: 27 detached "A" flags measured on the dev corpus; the
+# render pipeline's PRICE_TOKEN grammar reserves the same trailing-letter
+# slot). Letters not in this map — and rows with no flag at all — yield
+# taxable=None (unknown), NEVER a hardcoded False.
+TAX_FLAG_MEANING: dict[str, bool] = {
+    "T": True,  # taxable (Sprouts / Dollar Tree)
+    "A": True,  # tax A applied (Costco)
+    "B": True,  # tax B applied
+    "X": True,  # taxed (Walmart-style)
+    "F": False,  # food / non-taxable (e.g. "MILK 4.29 F")
+    "N": False,  # non-taxable
+    "O": False,  # non-taxable (Walmart-style)
+    "E": False,  # tax-exempt
+}
+_ATTACHED_FLAG_RE = re.compile(r"\d[.,]\d{2}([A-Z])$")
 
 
 def _is_non_product(text: str) -> bool:
@@ -376,13 +467,21 @@ def mine_receipt(receipt_key: str, details: "ReceiptDetails") -> list[dict]:
     the name word(s) (PRODUCT_NAME/ITEM_NAME) in the same y-band to its
     LEFT. Category = nearest section-header row by y-distance
     (orientation-free: items cluster right under their header).
+
+    Labels pass through the hygiene layer first: only
+    ACCEPTED_LABEL_STATUSES mine, and duplicate labels on a word resolve
+    deterministically (see resolve_word_labels). Taxability is derived
+    per-row from an explicit tax-flag letter (attached to the amount or a
+    detached single letter right of the price); no flag -> None.
     """
     label_by_word = {
-        (label.line_id, label.word_id): label.label for label in details.labels
+        word_key: label.label
+        for word_key, label in resolve_word_labels(details.labels).items()
     }
     names: list[tuple[float, float, str]] = []
-    prices: list[tuple[float, float, float, str]] = []
+    prices: list[tuple[float, float, float, str, str | None]] = []
     sections: list[tuple[float, str]] = []
+    flags: list[tuple[float, float, str]] = []
     for word in details.words:
         word_label = label_by_word.get((word.line_id, word.word_id))
         y_center, x_center, height = _ycx(word)
@@ -393,12 +492,42 @@ def mine_receipt(receipt_key: str, details: "ReceiptDetails") -> list[dict]:
             price = _price_str(text)
             # negative line totals are markdowns/credits, not products
             if price is not None and not price.startswith("-"):
-                prices.append((y_center, x_center, height, price))
+                attached = _ATTACHED_FLAG_RE.search(
+                    text.replace("$", "").strip().upper()
+                )
+                prices.append(
+                    (
+                        y_center,
+                        x_center,
+                        height,
+                        price,
+                        attached.group(1) if attached else None,
+                    )
+                )
         elif text.upper().strip(":") in SECTION_KEYWORDS:
             sections.append((y_center, text.upper().strip(":")))
+        else:
+            stripped = text.strip()
+            if len(stripped) == 1 and stripped.isalpha():
+                flags.append((y_center, x_center, stripped.upper()))
 
     rows: list[dict] = []
-    for price_y, price_x, price_h, price in prices:
+    for price_y, price_x, price_h, price, attached_flag in prices:
+        flag = attached_flag
+        if flag is None:
+            # nearest detached single-letter word right of the price,
+            # same y-band ("9.99 A")
+            detached = [
+                candidate
+                for candidate in flags
+                if abs(candidate[0] - price_y) < max(0.006, price_h * 0.8)
+                and candidate[1] > price_x
+            ]
+            if detached:
+                flag = min(
+                    detached, key=lambda candidate: candidate[1] - price_x
+                )[2]
+        taxable = TAX_FLAG_MEANING.get(flag) if flag else None
         band = [
             name
             for name in names
@@ -424,6 +553,7 @@ def mine_receipt(receipt_key: str, details: "ReceiptDetails") -> list[dict]:
                 "price": price,
                 "category": category,
                 "receipt_key": receipt_key,
+                "taxable": taxable,
             }
         )
     return rows
@@ -432,7 +562,8 @@ def mine_receipt(receipt_key: str, details: "ReceiptDetails") -> list[dict]:
 def aggregate_observations(
     mined_rows: Iterable[dict],
 ) -> dict[str, dict]:
-    """normalized_name -> {product_text, prices[], count, keys[], category}."""
+    """normalized_name -> {product_text, prices[], count, keys[], category,
+    tax_signals[]}."""
     observations: dict[str, dict] = {}
     for row in mined_rows:
         norm = normalize_product_text(row["product_text"])
@@ -444,10 +575,13 @@ def aggregate_observations(
                 "count": 0,
                 "keys": [],
                 "category": row["category"],
+                "tax_signals": [],
             },
         )
         record["prices"].append(row["price"])
         record["count"] += 1
+        if row.get("taxable") is not None:
+            record["tax_signals"].append(row["taxable"])
         if row["receipt_key"] not in record["keys"]:
             record["keys"].append(row["receipt_key"])
         if (
@@ -461,17 +595,25 @@ def aggregate_observations(
 def build_catalog(
     merchant_name: str, observations: dict[str, dict]
 ) -> list[MerchantCatalogItem]:
-    """Aggregated observations -> MerchantCatalogItem rows (mined-only)."""
+    """Aggregated observations -> MerchantCatalogItem rows (mined-only).
+
+    ``taxable`` is unanimous-signal only: True when at least one observed
+    row carried a taxable flag and none carried a non-taxable flag, False
+    for the inverse, None when there was no flag at all or the flags
+    disagree — never a hardcoded default.
+    """
     items: list[MerchantCatalogItem] = []
     for record in observations.values():
         mode_price = collections.Counter(record["prices"]).most_common(1)[0][0]
+        signals = set(record.get("tax_signals") or [])
+        taxable = signals.pop() if len(signals) == 1 else None
         items.append(
             MerchantCatalogItem(
                 merchant_name=merchant_name,
                 product_text=record["product_text"],
                 price=mode_price,
                 category=record["category"],
-                taxable=False,
+                taxable=taxable,
                 source="observed",
                 observed_count=record["count"],
                 source_receipt_keys=list(record["keys"]),
@@ -657,6 +799,15 @@ def main(
     print(
         "  by_category="
         + json.dumps(dict(sorted(by_category.items())), sort_keys=True)
+    )
+    by_taxable = collections.Counter(
+        {True: "true", False: "false", None: "unknown"}[item.taxable]
+        for item in items
+    )
+    print(
+        "  taxable="
+        + json.dumps(dict(sorted(by_taxable.items())), sort_keys=True)
+        + "  (from explicit tax-flag letters only; unknown = no signal)"
     )
     for item in sorted(items, key=lambda x: -x.observed_count)[:10]:
         keys_preview = ",".join(item.source_receipt_keys[:2])

--- a/tests/test_ingest_merchant_catalog.py
+++ b/tests/test_ingest_merchant_catalog.py
@@ -56,6 +56,8 @@ class FakeLabel:
     word_id: int
     label: str
     reasoning: str | None = None
+    validation_status: str = "VALID"
+    timestamp_added: str = "2026-07-01T00:00:00+00:00"
 
 
 @dataclass
@@ -76,6 +78,7 @@ def _receipt(
     header: list[str],
     sections: list[tuple[str, float]] = (),
     reasonings: dict[int, str] | None = None,
+    statuses: dict[int, str] | None = None,
 ) -> FakeDetails:
     """Build a fake receipt.
 
@@ -83,6 +86,8 @@ def _receipt(
     go at x ~0.1.., the price at x=0.80. header: unlabeled words at the top.
     sections: (keyword, y) unlabeled section-header words.
     reasonings: row index -> reasoning text attached to that row's label.
+    statuses: row index -> validation_status for that row's labels
+    (default VALID).
     """
     words: list[FakeWord] = []
     labels: list[FakeLabel] = []
@@ -106,12 +111,21 @@ def _receipt(
                     word_index,
                     "PRODUCT_NAME",
                     (reasonings or {}).get(index),
+                    (statuses or {}).get(index, "VALID"),
                 )
             )
         line_id += 1
         words.append(FakeWord(line_id, 0, price_text, 0.80, y))
         if price_label:
-            labels.append(FakeLabel(line_id, 0, price_label))
+            labels.append(
+                FakeLabel(
+                    line_id,
+                    0,
+                    price_label,
+                    None,
+                    (statuses or {}).get(index, "VALID"),
+                )
+            )
     return FakeDetails(words=words, labels=labels)
 
 
@@ -273,6 +287,197 @@ def test_every_mined_item_records_provenance() -> None:
     water = next(i for i in items if i.product_text == "KS WATER")
     assert water.observed_count == 2
     assert water.source_receipt_keys == ["img-a#00001", "img-b#00001"]
+
+
+# ---------------------------------------------------------------------------
+# Label hygiene: validation-status filter + duplicate resolution
+# ---------------------------------------------------------------------------
+
+
+def test_invalid_labeled_rows_never_mine() -> None:
+    details = _receipt(
+        rows=[
+            ("KS WATER", "3.99", 0.30, "LINE_TOTAL"),
+            ("REJECTED THING", "9.99", 0.40, "LINE_TOTAL"),
+        ],
+        header=["COSTCO"],
+        statuses={1: "INVALID"},
+    )
+    rows = imc.mine_receipt("img#00001", details)
+    assert {row["product_text"] for row in rows} == {"KS WATER"}
+
+
+@pytest.mark.parametrize("status", ["PENDING", "NONE", "NEEDS_REVIEW"])
+def test_unreviewed_statuses_do_not_mine(status: str) -> None:
+    """Only VALID mines: PENDING/NONE/NEEDS_REVIEW are unreviewed
+    proposals (the section evaluator and MCP review flow count VALID
+    only), and INVALID is a rejection."""
+    details = _receipt(
+        rows=[("KS WATER", "3.99", 0.30, "LINE_TOTAL")],
+        header=["COSTCO"],
+        statuses={0: status},
+    )
+    assert imc.mine_receipt("img#00001", details) == []
+
+
+def test_status_filter_is_the_deciding_factor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """In-suite mutation check on ACCEPTED_LABEL_STATUSES: the same
+    INVALID-labeled fixture mines once the filter is widened, proving the
+    status filter (not some other fixture property) is what excludes it —
+    this test goes red if the filter constant stops being consulted."""
+    details = _receipt(
+        rows=[("KS WATER", "3.99", 0.30, "LINE_TOTAL")],
+        header=["COSTCO"],
+        statuses={0: "INVALID"},
+    )
+    assert imc.mine_receipt("img#00001", details) == []
+    monkeypatch.setattr(
+        imc, "ACCEPTED_LABEL_STATUSES", frozenset({"VALID", "INVALID"})
+    )
+    rows = imc.mine_receipt("img#00001", details)
+    assert {row["product_text"] for row in rows} == {"KS WATER"}
+
+
+def test_duplicate_resolution_prefers_valid_over_others(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The measured dev pattern: an older rejected proposal plus a newer
+    confirmed label on the same word. VALID outranks even when the
+    accepted set is widened; input ordering never changes the result."""
+    monkeypatch.setattr(
+        imc, "ACCEPTED_LABEL_STATUSES", frozenset({"VALID", "PENDING"})
+    )
+    valid_old = FakeLabel(
+        14, 1, "LINE_TOTAL", None, "VALID", "2026-06-15T19:37:00+00:00"
+    )
+    pending_new = FakeLabel(
+        14, 1, "AMOUNT", None, "PENDING", "2026-06-15T19:38:09+00:00"
+    )
+    for ordering in ([valid_old, pending_new], [pending_new, valid_old]):
+        assert imc.resolve_word_labels(ordering)[(14, 1)] is valid_old
+
+
+def test_duplicate_resolution_newest_wins_deterministically() -> None:
+    older = FakeLabel(
+        1, 1, "ITEM_NAME", None, "VALID", "2026-06-01T00:00:00+00:00"
+    )
+    newer = FakeLabel(
+        1, 1, "PRODUCT_NAME", None, "VALID", "2026-06-02T00:00:00+00:00"
+    )
+    for ordering in ([older, newer], [newer, older]):
+        assert imc.resolve_word_labels(ordering)[(1, 1)] is newer
+
+
+def test_duplicate_resolution_total_order_tiebreak() -> None:
+    """Same status, same timestamp: lexicographically smallest label wins
+    regardless of input order — never dict last-write-wins."""
+    timestamp = "2026-06-02T00:00:00+00:00"
+    item_name = FakeLabel(1, 1, "ITEM_NAME", None, "VALID", timestamp)
+    product = FakeLabel(1, 1, "PRODUCT_NAME", None, "VALID", timestamp)
+    for ordering in ([item_name, product], [product, item_name]):
+        assert imc.resolve_word_labels(ordering)[(1, 1)] is item_name
+
+
+def test_invalid_labels_are_filtered_before_resolution() -> None:
+    invalid_new = FakeLabel(
+        1, 1, "AMOUNT", None, "INVALID", "2026-06-15T19:38:09+00:00"
+    )
+    valid_old = FakeLabel(
+        1, 1, "LINE_TOTAL", None, "VALID", "2026-06-15T19:37:00+00:00"
+    )
+    resolved = imc.resolve_word_labels([invalid_new, valid_old])
+    assert resolved[(1, 1)] is valid_old
+    assert imc.resolve_word_labels([invalid_new]) == {}
+
+
+# ---------------------------------------------------------------------------
+# Taxability: derived from explicit tax flags, never hardcoded
+# ---------------------------------------------------------------------------
+
+
+def test_taxable_from_detached_costco_flag() -> None:
+    details = _receipt(
+        rows=[("KS WATER", "3.99", 0.30, "LINE_TOTAL")],
+        header=["COSTCO"],
+    )
+    details.words.append(FakeWord(99, 0, "A", 0.90, 0.30))
+    [row] = imc.mine_receipt("img#00001", details)
+    assert row["taxable"] is True
+
+
+def test_taxable_from_attached_flag() -> None:
+    details = _receipt(
+        rows=[("SCRUB BRUSH", "1.25T", 0.30, "LINE_TOTAL")],
+        header=["COSTCO"],
+    )
+    [row] = imc.mine_receipt("img#00001", details)
+    assert row["price"] == "1.25"
+    assert row["taxable"] is True
+
+
+def test_nontaxable_food_flag() -> None:
+    details = _receipt(
+        rows=[("MILK", "4.29", 0.30, "LINE_TOTAL")],
+        header=["COSTCO"],
+    )
+    details.words.append(FakeWord(99, 0, "F", 0.90, 0.30))
+    [row] = imc.mine_receipt("img#00001", details)
+    assert row["taxable"] is False
+
+
+def test_no_flag_means_unknown_never_false() -> None:
+    details = _receipt(
+        rows=[("KS WATER", "3.99", 0.30, "LINE_TOTAL")],
+        header=["COSTCO"],
+    )
+    [row] = imc.mine_receipt("img#00001", details)
+    assert row["taxable"] is None
+    items = imc.build_catalog(
+        "Costco Wholesale", imc.aggregate_observations([row])
+    )
+    assert items[0].taxable is None
+
+
+def test_flag_in_another_band_or_left_of_price_is_ignored() -> None:
+    details = _receipt(
+        rows=[("KS WATER", "3.99", 0.30, "LINE_TOTAL")],
+        header=["COSTCO"],
+    )
+    details.words.append(FakeWord(99, 0, "A", 0.90, 0.50))  # other band
+    details.words.append(FakeWord(98, 0, "A", 0.50, 0.30))  # left of price
+    [row] = imc.mine_receipt("img#00001", details)
+    assert row["taxable"] is None
+
+
+def test_conflicting_tax_signals_yield_unknown() -> None:
+    taxed = _receipt(
+        rows=[("KS WATER", "3.99", 0.30, "LINE_TOTAL")], header=["COSTCO"]
+    )
+    taxed.words.append(FakeWord(99, 0, "A", 0.90, 0.30))
+    exempt = _receipt(
+        rows=[("KS WATER", "3.99", 0.30, "LINE_TOTAL")], header=["COSTCO"]
+    )
+    exempt.words.append(FakeWord(99, 0, "F", 0.90, 0.30))
+    mined = [
+        *imc.mine_receipt("img-a#00001", taxed),
+        *imc.mine_receipt("img-b#00001", exempt),
+    ]
+    items = imc.build_catalog(
+        "Costco Wholesale", imc.aggregate_observations(mined)
+    )
+    assert items[0].taxable is None
+
+
+def test_unknown_flag_letter_is_no_signal() -> None:
+    details = _receipt(
+        rows=[("KS WATER", "3.99", 0.30, "LINE_TOTAL")],
+        header=["COSTCO"],
+    )
+    details.words.append(FakeWord(99, 0, "Q", 0.90, 0.30))
+    [row] = imc.mine_receipt("img#00001", details)
+    assert row["taxable"] is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why

The codex independent review of #1212 (merged) found a material gap that BLOCKS the pending owner `--apply`: the miner consumed labels **regardless of `validation_status`** (a read-only dev census confirms the exposure: name/price labels on the 39 dev Costco receipts split **VALID=344 / INVALID=481 / PENDING=1**), resolved duplicate labels by dict last-write-wins, and **hardcoded `taxable=False`** on every item.

## What

1. **Validation-status filter** — `ACCEPTED_LABEL_STATUSES = {VALID}`. INVALID is a rejection and never mines. **Decision documented (VALID-only, not also-PENDING):** the pipeline's own consumers treat VALID as the only counted state — `scripts/evaluate_section_assignment.py` counts VALID only, `llm_review` emits/protects VALID as the reviewed state and INVALID as the rejection, and the MCP review flow documents PENDING as machine-propagated rows that "need review before they count". PENDING/NONE/NEEDS_REVIEW are therefore excluded as unreviewed (costs 1 label on the whole dev Costco corpus).
2. **Deterministic duplicate resolution** (`resolve_word_labels`) — measured **673/2099** labeled dev Costco words carry multiple label rows, typically an older rejected proposal plus a newer confirmed label (`AMOUNT/INVALID` superseded by `LINE_TOTAL/VALID`). Resolution is a total order: accepted-status filter → VALID rank → newest `timestamp_added` → label text tiebreak. Never insertion-order last-write-wins.
3. **Taxability derived, never defaulted** — explicit tax-flag letters only: attached (`1.25T`, the Sprouts/Dollar Tree form the historical `_line_is_taxable` read) or a detached single letter right of the price in the same y-band (the Costco `9.99 A` form — **27 detached `A` flags measured on dev**; the render pipeline's `PRICE_TOKEN` grammar reserves the same trailing-letter slot). Mapped via `TAX_FLAG_MEANING`; no flag / unknown letter / conflicting observations ⇒ `taxable=None`. `MerchantCatalogItem.taxable` is now `bool | None` (NULL in Dynamo).

## Headline evidence — REAL dev dry-run delta vs the merged miner (39 receipts)

Item count is coincidentally still **75**, but the catalog contents changed materially:

- **29 items DROPPED** — INVALID-label artifacts: item-number-prefixed duplicates (`1424237 KS GR FD BTR`, `10715 MED OOL DATE`), stray tax-flag merges (`E BEEF BULGOGI`, `E ORG. DATES`), non-products (`E REDEMP VA`).
- **29 items ADDED** — recovered by VALID-first duplicate resolution (their `LINE_TOTAL`/`PRODUCT_NAME` labels were shadowed by newer INVALID proposals under last-write-wins): `ORGANIC GRND ×3`, `ORG CHKTENDR ×2`, `BEEF FLANK`, `REGGIANO`, …
- **All 46 kept items changed**: observation counts corrected (`KS GR FD BTR ×2→×4`, `IRISH BUTTER ×1→×3`), mode prices corrected (`PASTURE EGGS 8.29→8.79`, `ORG FR EGGS 7.59→7.99`), and every hardcoded `taxable: false` replaced by honest signal-derived values.
- Observed rows **82 → 89** (VALID resolution recovers price words that INVALID rows were masking).
- **Taxability: 5 true (Costco `A` flag: ROTISSERIE, \*\*KS TOWEL\*\*, \*\*KS ULTRA\*\*, KS BAGS, ROTISSERIE TIDEF&GPOD) / 70 unknown — zero fabricated falses.**
- Attribution unchanged: 39 checked → OK=38, QUARANTINED=1 (the BJ's receipt `01c0bc98…#00001`). The spot-check deliberately scans ALL labels' reasoning regardless of status — the BJ's evidence lives on a revised word and must keep counting.

## Tests (70 in the touched suites, all green; receipt_dynamo unit suite 2209 passed)

- INVALID-labeled fixture word never mines; PENDING/NONE/NEEDS_REVIEW parametrized exclusion
- **Mutation checks on the status filter**: an in-suite check (`test_status_filter_is_the_deciding_factor`) widens `ACCEPTED_LABEL_STATUSES` and proves the same fixture then mines; manually deleting the filter line fails 6 tests; deleting the timestamp sort fails the determinism test
- Duplicate-resolution determinism under both input orderings: VALID-over-others, newest-wins, total-order tiebreak, filter-before-resolve
- Taxability: attached flag, detached Costco flag, food-flag `F`⇒False, no-flag⇒None (never False), off-band/left-of-price flags ignored, unknown letter⇒None, conflicting signals⇒None; entity + moto NULL roundtrips

## Owner `--apply` (still gated — NOT run; unblocked by this PR once merged)

```bash
cd ~/Portfolio && .venv/bin/python scripts/ingest_merchant_catalog.py \
  --merchant "Costco Wholesale" --apply \
  --attribution-report ~/section_label_kickoff/costco_catalog_attribution.json \
  --dump ~/section_label_kickoff/costco_catalog_items.json
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BeLcSviHL5vDgS3zTSMbsq