### PR TITLE
[render] Fix phrase-anchor row erasure + glyph_review multi-label collapse (#1216)

### DIFF
--- a/scripts/render_synthetic_receipts.py
+++ b/scripts/render_synthetic_receipts.py
@@ -2980,11 +2980,13 @@ def _phrase_logo_placement(
     Some merchants print the wordmark as a pure graphic (no OCR text) beside a
     slogan (e.g. The Home Depot's tilted square + "How doers get more done."). The
     ``MERCHANT_NAME``/brand logo-line detection finds nothing, so we anchor off
-    the slogan instead: any line whose alphanumeric-normalized text contains one
-    of the profile ``phrases`` is part of the lockup. Those words are suppressed
-    (the logo depicts them) and the logo is sized to a band matching its own pixel
-    aspect ratio, optionally extended left to the margin to cover the graphic mark
-    that sits left of the slogan. Returns (drop_words, bbox) or ``None``.
+    the slogan instead: any contiguous word span whose alphanumeric-normalized
+    text equals one of the profile ``phrases`` is part of the lockup. Only those
+    matched words are suppressed (the logo depicts them), while unrelated words
+    on the same OCR row remain renderable. The logo is sized to a band matching
+    its own pixel aspect ratio, optionally extended left to the margin to cover
+    the graphic mark that sits left of the slogan. Returns (drop_words, bbox) or
+    ``None``.
     """
     norm = [_normalize_phrase(p) for p in phrases if p]
     if not norm:
@@ -2996,23 +2998,35 @@ def _phrase_logo_placement(
         # ("HOWDOERS" = "HOW"+"DOERS") but a short brand phrase never fires on
         # an unrelated word that merely contains it ("TREE" must not match
         # "STREET"). A whole-line substring test conflates the two.
-        toks = [_normalize_phrase(w.get("text") or "") for w in words]
-        toks = [t for t in toks if t]
-        if not toks or not _phrase_run_match(toks, norm):
+        word_tokens = [
+            (word, _normalize_phrase(word.get("text") or "")) for word in words
+        ]
+        word_tokens = [(word, token) for word, token in word_tokens if token]
+        toks = [token for _word, token in word_tokens]
+        spans = _phrase_run_spans(toks, norm)
+        if not spans:
             continue
+        matched_indexes = {
+            index for start, stop in spans for index in range(start, stop)
+        }
+        matched_words = [
+            word
+            for index, (word, _token) in enumerate(word_tokens)
+            if index in matched_indexes
+        ]
         # This anchors a TOP-of-receipt lockup; short brand phrases ("VONS")
         # also match footer URLs / body mentions, which unions a bogus
         # mid-receipt band and drops body words. Only accept header lines.
         ys = [
             v
-            for w in words
+            for w in matched_words
             if w.get("bbox")
             for v in (w["bbox"][1], w["bbox"][3])
         ]
         if ys and (sum(ys) / len(ys)) < 780.0:
             continue
         if ys:
-            matched.append((max(ys), max(ys) - min(ys), words))
+            matched.append((max(ys), max(ys) - min(ys), matched_words))
     # Absorb only the TOP cluster of matched lines (contiguous within ~one
     # line height). A graphic badge's shed tokens sit adjacent to each other;
     # a REAL text line printed further below (The Stand's "THE STAND" under
@@ -3079,20 +3093,29 @@ def _phrase_run_match(tokens: list[str], norm_phrases: list[str]) -> bool:
     This keeps multi-word slogan anchors working while stopping short brand
     phrases from firing on unrelated words.
     """
+    return bool(_phrase_run_spans(tokens, norm_phrases))
+
+
+def _phrase_run_spans(
+    tokens: list[str], norm_phrases: list[str]
+) -> list[tuple[int, int]]:
+    """Return every contiguous token span that exactly matches a phrase."""
     n = len(tokens)
     # Stop each run once it can no longer equal any phrase (longest phrase's
     # length), so a configured phrase longer than any fixed cap still matches
     # while runaway concatenation is still bounded.
-    max_len = max((len(p) for p in norm_phrases), default=0)
+    phrase_set = set(norm_phrases)
+    max_len = max((len(p) for p in phrase_set), default=0)
+    spans = []
     for i in range(n):
         acc = ""
         for j in range(i, n):
             acc += tokens[j]
-            if acc in norm_phrases:
-                return True
+            if acc in phrase_set:
+                spans.append((i, j + 1))
             if len(acc) > max_len:
                 break
-    return False
+    return spans
 
 
 def _flatten_receipt_words(receipt: dict) -> list[dict]:

--- a/synthesis_loop/glyph_review.py
+++ b/synthesis_loop/glyph_review.py
@@ -38,6 +38,37 @@ def _label_font(size: int):
         return ImageFont.load_default()
 
 
+def _validation_status(label) -> str:
+    status = getattr(label, "validation_status", "") or ""
+    status = getattr(status, "value", status)
+    return str(status).strip().upper()
+
+
+def _labels_by_coordinate(
+    labels, receipt_id
+) -> dict[tuple[int, int], list[str]]:
+    """Collect every renderable label, with reviewed labels ordered first."""
+    grouped: dict[tuple[int, int], dict[str, int]] = {}
+    for item in labels:
+        if item.receipt_id != receipt_id:
+            continue
+        status = _validation_status(item)
+        label = str(getattr(item, "label", "") or "").strip()
+        if not label or status == "INVALID" or label.upper() == "O":
+            continue
+        coordinate = (item.line_id, item.word_id)
+        rank = 0 if status == "VALID" else 1
+        label_ranks = grouped.setdefault(coordinate, {})
+        label_ranks[label] = min(rank, label_ranks.get(label, rank))
+    return {
+        coordinate: sorted(
+            label_ranks,
+            key=lambda label: (label_ranks[label], label),
+        )
+        for coordinate, label_ranks in grouped.items()
+    }
+
+
 def sheet(atlas_path: str, out_png: str) -> int:
     a = np.load(atlas_path)
     chars = sorted(chr(int(k[1:])) for k in a.files if k.startswith("c"))
@@ -144,14 +175,9 @@ def receipt(
             f"receipt {receipt_id} not found for image {image_id}; found {found}"
         )
     ws = [w for w in d.receipt_words if w.receipt_id == receipt_id]
-    lbl = {
-        (l.line_id, l.word_id): l.label
-        for l in d.receipt_word_labels
-        if l.receipt_id == receipt_id
-        # INVALID labels are not on the printed receipt; keep unreviewed ones
-        # (same policy as _real_receipt_dict in render_synthetic_receipts).
-        and str(getattr(l, "validation_status", "") or "").upper() != "INVALID"
-    }
+    # INVALID labels are not on the printed receipt; keep unreviewed ones
+    # (same policy as _real_receipt_dict in render_synthetic_receipts).
+    lbl = _labels_by_coordinate(d.receipt_word_labels, receipt_id)
     words = [
         {
             "text": w.text,
@@ -163,11 +189,7 @@ def receipt(
                 w.bottom_right["x"] * 1000,
                 w.bottom_right["y"] * 1000,
             ],
-            "labels": (
-                [lbl[(w.line_id, w.word_id)]]
-                if lbl.get((w.line_id, w.word_id)) not in (None, "O")
-                else []
-            ),
+            "labels": lbl.get((w.line_id, w.word_id), []),
         }
         for w in ws
     ]

--- a/tests/test_render_erasure_hygiene.py
+++ b/tests/test_render_erasure_hygiene.py
@@ -7,6 +7,7 @@ from types import ModuleType, SimpleNamespace
 
 from PIL import Image
 
+from receipt_dynamo.constants import ValidationStatus
 from scripts import render_synthetic_receipts as rsr
 from synthesis_loop import glyph_review
 
@@ -40,8 +41,9 @@ def test_phrase_logo_placement_drops_only_matched_span() -> None:
     )
 
     assert placed is not None
-    dropped, _bbox = placed
+    dropped, bbox = placed
     assert [word["text"] for word in dropped] == ["COSTCO"]
+    assert bbox[2] <= phrase["bbox"][2]
 
 
 def test_glyph_review_preserves_all_word_labels_in_stable_order(
@@ -62,7 +64,9 @@ def test_glyph_review_preserves_all_word_labels_in_stable_order(
         Image.new("RGB", (20, 40), "white").save(path)
 
     fake_renderer._render_cached_hybrid = capture_render
-    monkeypatch.setitem(sys.modules, "render_synthetic_receipts", fake_renderer)
+    monkeypatch.setitem(
+        sys.modules, "render_synthetic_receipts", fake_renderer
+    )
 
     word = SimpleNamespace(
         receipt_id=1,
@@ -78,14 +82,14 @@ def test_glyph_review_preserves_all_word_labels_in_stable_order(
             line_id=2,
             word_id=3,
             label="MERCHANT_NAME",
-            validation_status="PENDING",
+            validation_status="VALID",
         ),
         SimpleNamespace(
             receipt_id=1,
             line_id=2,
             word_id=3,
             label="ADDRESS_LINE",
-            validation_status="VALID",
+            validation_status="PENDING",
         ),
     ]
     receipt = SimpleNamespace(
@@ -129,6 +133,32 @@ def test_glyph_review_preserves_all_word_labels_in_stable_order(
 
     assert result == 0
     assert captured["words"][0]["labels"] == [
-        "ADDRESS_LINE",
         "MERCHANT_NAME",
+        "ADDRESS_LINE",
     ]
+
+
+def test_glyph_review_label_order_filters_and_deduplicates() -> None:
+    def label(name, status):
+        return SimpleNamespace(
+            receipt_id=1,
+            line_id=4,
+            word_id=5,
+            label=name,
+            validation_status=status,
+        )
+
+    labels = [
+        label("PAYMENT_METHOD", "pending"),
+        label("COUPON", "pending"),
+        label("DATE", ValidationStatus.VALID),
+        label("ADDRESS_LINE", "valid"),
+        label("PAYMENT_METHOD", ValidationStatus.VALID),
+        label("IGNORED", ValidationStatus.INVALID),
+        label("O", "VALID"),
+        label(None, "VALID"),
+    ]
+
+    assert glyph_review._labels_by_coordinate(labels, 1) == {
+        (4, 5): ["ADDRESS_LINE", "DATE", "PAYMENT_METHOD", "COUPON"]
+    }

--- a/tests/test_render_erasure_hygiene.py
+++ b/tests/test_render_erasure_hygiene.py
@@ -1,0 +1,134 @@
+"""Adversarial tests for render evidence erasure regressions (#1216)."""
+
+from __future__ import annotations
+
+import sys
+from types import ModuleType, SimpleNamespace
+
+from PIL import Image
+
+from scripts import render_synthetic_receipts as rsr
+from synthesis_loop import glyph_review
+
+
+def test_phrase_logo_placement_drops_only_matched_span() -> None:
+    phrase = {
+        "text": "COSTCO",
+        "bbox": [100.0, 920.0, 350.0, 960.0],
+        "labels": ["MERCHANT_NAME"],
+    }
+    address_number = {
+        "text": "123",
+        "bbox": [370.0, 920.0, 450.0, 960.0],
+        "labels": ["ADDRESS_LINE"],
+    }
+    address_street = {
+        "text": "MAIN",
+        "bbox": [470.0, 920.0, 650.0, 960.0],
+        "labels": ["ADDRESS_LINE"],
+    }
+    receipt = {"words": [phrase, address_number, address_street]}
+    config = SimpleNamespace(width=760, height=1800, margin=24)
+
+    placed = rsr._phrase_logo_placement(
+        receipt,
+        ["COSTCO"],
+        config=config,
+        logo=Image.new("L", (240, 60), 0),
+        coord_max=1000.0,
+        extend_left=False,
+    )
+
+    assert placed is not None
+    dropped, _bbox = placed
+    assert [word["text"] for word in dropped] == ["COSTCO"]
+
+
+def test_glyph_review_preserves_all_word_labels_in_stable_order(
+    monkeypatch, tmp_path
+) -> None:
+    captured: dict = {}
+
+    fake_renderer = ModuleType("render_synthetic_receipts")
+    fake_renderer.cached_font_profile = lambda *_args, **_kwargs: None
+    fake_renderer.section_scale_for_merchant = lambda *_args: {}
+    fake_renderer.merchant_typography = lambda *_args: {
+        "bitmap_font": "regular.npz",
+        "bitmap_thin": "regular.npz",
+    }
+
+    def capture_render(receipt, _atlas, *, path, **_kwargs) -> None:
+        captured.update(receipt)
+        Image.new("RGB", (20, 40), "white").save(path)
+
+    fake_renderer._render_cached_hybrid = capture_render
+    monkeypatch.setitem(sys.modules, "render_synthetic_receipts", fake_renderer)
+
+    word = SimpleNamespace(
+        receipt_id=1,
+        line_id=2,
+        word_id=3,
+        text="MAIN",
+        top_left={"x": 0.1, "y": 0.2},
+        bottom_right={"x": 0.3, "y": 0.25},
+    )
+    labels = [
+        SimpleNamespace(
+            receipt_id=1,
+            line_id=2,
+            word_id=3,
+            label="MERCHANT_NAME",
+            validation_status="PENDING",
+        ),
+        SimpleNamespace(
+            receipt_id=1,
+            line_id=2,
+            word_id=3,
+            label="ADDRESS_LINE",
+            validation_status="VALID",
+        ),
+    ]
+    receipt = SimpleNamespace(
+        receipt_id=1,
+        width=100,
+        height=200,
+        cdn_s3_bucket=None,
+        cdn_s3_key=None,
+        raw_s3_bucket=None,
+        raw_s3_key=None,
+    )
+    details = SimpleNamespace(
+        receipts=[receipt],
+        receipt_words=[word],
+        receipt_word_labels=labels,
+    )
+
+    class FakeDynamoClient:
+        def __init__(self, *_args, **_kwargs) -> None:
+            pass
+
+        def get_image_details(self, _image_id):
+            return details
+
+    import receipt_dynamo.data.dynamo_client as dynamo_client
+
+    monkeypatch.setattr(dynamo_client, "DynamoClient", FakeDynamoClient)
+    monkeypatch.setattr(
+        glyph_review,
+        "_save_zoom_crops",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        "boto3.client",
+        lambda *_args, **_kwargs: SimpleNamespace(),
+    )
+
+    result = glyph_review.receipt(
+        "Costco Wholesale", "image-id", 1, str(tmp_path / "review.png")
+    )
+
+    assert result == 0
+    assert captured["words"][0]["labels"] == [
+        "ADDRESS_LINE",
+        "MERCHANT_NAME",
+    ]


### PR DESCRIPTION
Closes #1216.

## What changed

- Phrase-anchored logo placement now finds every exact contiguous phrase span and suppresses only the matched OCR words. Unrelated same-row evidence remains renderable, and the logo bbox is derived only from the matched span.
- `glyph_review` now keeps every label at a word coordinate in a list-valued mapping. Ordering is deterministic: VALID labels first, then label name. INVALID, `O`, and empty labels stay excluded; duplicate labels collapse to their strongest status.
- Scope is limited to `scripts/render_synthetic_receipts.py`, `synthesis_loop/glyph_review.py`, and `tests/test_render_erasure_hygiene.py`.

## Adversarial test-first evidence

Red/test-only commit: `187e1991a`

```
pytest -q tests/test_render_erasure_hygiene.py
2 failed
```

- `COSTCO 123 MAIN`: actual dropped words were `["COSTCO", "123", "MAIN"]`; expected only `["COSTCO"]`.
- One word with ADDRESS_LINE + MERCHANT_NAME: actual output exposed one label; expected both.

Green/fix commit: `c5e72397f`

The adversarial fixture also asserts the replacement logo bbox cannot cover `123 MAIN`, and adds enum/string status, VALID-first ordering, alphabetical tie-breaking, INVALID/`O` filtering, and deduplication coverage.

## Mutation honesty

Each production fix was absent at the red commit above:

- Restore whole-row phrase suppression -> `test_phrase_logo_placement_drops_only_matched_span` fails.
- Restore the scalar last-write-wins label dict -> `test_glyph_review_preserves_all_word_labels_in_stable_order` fails.

No production behavior was mocked in the phrase-span test. The glyph-review test stubs Dynamo/S3/render output only to inspect the exact receipt payload passed to the renderer.

## Verification

- Pinned formatter: Black 24.10.0 + isort, line length 79.
- Full root suite after rebasing onto current `origin/main`: **433 passed, 1 skipped**.
- Render-focused suite: **62 passed** across glyph renderer, section style, receipt style map, adversarial erasure, systemic erasure, and guard unit tests.
- Live read-only dev guard:
  - `DYNAMODB_TABLE_NAME=ReceiptsTable-dc5be22`
  - `synthesis_loop/render_regression_guard.py check`
  - `costco_golden: byte-identical`
  - `costco_new: byte-identical`
  - `sprouts: byte-identical`
  - `vons_golden: byte-identical`
  - `all pinned renders match the committed baseline`

The guard used read-only dev DynamoDB/S3 access. No baseline was captured, changed, or re-baselined. Production table `d7ff76a` was never used.