### PR TITLE
[email] Authenticate sender dispatch against SES results (#1218)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,6 +41,14 @@ jobs:
           find infra -name '*.py' -not -path '*/node_modules/*' -not -path '*/.venv*/*' -print0 \
             | xargs -0 "$PYTHON" -m py_compile
 
+      - name: Test inbound email sender authentication
+        run: |
+          PYTHON=$(command -v python3.12 || command -v python3)
+          "$PYTHON" -m venv .venv-email-receipt
+          source .venv-email-receipt/bin/activate
+          python -m pip install --quiet boto3 pytest
+          python -m pytest -q infra/tests/test_email_receipt_inbox_handler.py
+
   python-tests:
     name: Python (${{ matrix.package }})
     runs-on: [self-hosted, macOS, ARM64]

--- a/infra/email_receipt_inbox/lambdas/handler.py
+++ b/infra/email_receipt_inbox/lambdas/handler.py
@@ -10,8 +10,10 @@ parsed/<messageId>.<ingest_id>.json:
                                   # spoofable identity keying the parsed object
       "s3_key": "raw/...",
       "from_domain": "doordash.com",
-      "original_from": "...",     # unwrapped when the mail arrived via a
-                                  # forwarding rule (X-Forwarded-For et al.)
+      "original_from": "...",     # authenticated sender selected for dispatch
+      "transport_from": "...",    # raw RFC-822 From claim
+      "claimed_original_from": "..." | null,  # raw X-Original-From claim
+      "sender_auth_source": "ses-dmarc" | null,
       "subject": "...",
       "group": "doordash" | null,
       "classification": "receipt" | "txn_signal" | "needs_ocr" | "non_receipt"
@@ -52,44 +54,109 @@ s3 = boto3.client("s3")
 # normalized copy, and parser-specific representations at once, so a large
 # payload can OOM. Reject anything oversized BEFORE fetching it into memory.
 MAX_RAW_BYTES = 15 * 1024 * 1024
+SES_AUTHSERV_ID = "amazonses.com"
 
 
-def _from_domain(msg) -> tuple[str, str]:
-    """Return (from_addr, domain) for sender dispatch.
+def _unique_header(msg, name: str) -> str | None:
+    values = msg.get_all(name) or []
+    if len(values) != 1:
+        return None
+    return str(values[0])
 
-    ``Reply-To`` is deliberately NOT consulted: it is free-form and often
-    points marketing/spoofed mail at an unrelated domain. ``X-Original-From``
-    is honored only for the documented iCloud auto-forwarding case (the
-    forwarder rewrites ``From`` to itself but preserves the original sender
-    here); the SES authentication verdicts recorded alongside let the
-    downstream reconciliation plane decide how much to trust it.
+
+def _single_address(values) -> tuple[str, str]:
+    """Return one unambiguous mailbox and its ASCII domain, else empty."""
+    if isinstance(values, str):
+        values = [values]
+    addresses = [
+        addr.strip()
+        for _name, addr in email.utils.getaddresses(list(values or []))
+        if addr and "@" in addr
+    ]
+    if len(addresses) != 1:
+        return "", ""
+    addr = addresses[0]
+    domain = addr.rsplit("@", 1)[1].strip().rstrip(".").lower()
+    if not domain or not re.fullmatch(r"[a-z0-9.-]+", domain):
+        return "", ""
+    return addr, domain
+
+
+def _trusted_ses_auth_results(msg) -> str | None:
+    """Return the sole SES authentication result, rejecting impostor copies.
+
+    SES adds one ``Authentication-Results: amazonses.com`` field to the S3
+    object. A sender can add lookalike MIME headers, but cannot suppress the
+    SES-added field; requiring exactly one means an unstripped impostor makes
+    the message fail closed instead of becoming another spoofing primitive.
     """
-    for header in ("X-Original-From", "From"):
-        raw = msg.get(header)
-        if not raw:
+    matches = []
+    for value in msg.get_all("Authentication-Results") or []:
+        authserv_id, separator, _results = str(value).partition(";")
+        if separator and authserv_id.strip().lower() == SES_AUTHSERV_ID:
+            matches.append(str(value))
+    return matches[0] if len(matches) == 1 else None
+
+
+def _auth_entries(value: str) -> list[tuple[str, str, str]]:
+    pattern = re.compile(
+        r"(?:^|;)\s*(spf|dkim|dmarc|arc)\s*=\s*([a-z_]+)(.*?)"
+        r"(?=;\s*(?:spf|dkim|dmarc|arc)\s*=|$)",
+        re.IGNORECASE | re.DOTALL,
+    )
+    return [
+        (mechanism.lower(), status.lower(), details)
+        for mechanism, status, details in pattern.findall(value)
+    ]
+
+
+def _identity_domain(value: str) -> str:
+    identity = value.strip().strip("<>\"'")
+    domain = identity.rsplit("@", 1)[-1].rstrip(".").lower()
+    if not domain or not re.fullmatch(r"[a-z0-9.-]+", domain):
+        return ""
+    return domain
+
+
+def _authenticated_sender(msg) -> tuple[str, str, str | None]:
+    """Bind sender dispatch to SES DMARC PASS for the visible From identity."""
+    addr, domain = _single_address(msg.get_all("From") or [])
+    auth_results = _trusted_ses_auth_results(msg)
+    if not addr or not auth_results:
+        return "", "", None
+    for mechanism, status, details in _auth_entries(auth_results):
+        if mechanism != "dmarc" or status != "pass":
             continue
-        addr = email.utils.parseaddr(raw)[1]
-        m = re.search(r"@([\w.\-]+)", addr or "")
-        if m:
-            return addr, m.group(1).lower()
-    return "", ""
+        match = re.search(
+            r"(?:^|[;\s])header\.from\s*=\s*([^;\s()]+)",
+            details,
+            re.IGNORECASE,
+        )
+        if match and _identity_domain(match.group(1)) == domain:
+            return addr, domain, "ses-dmarc"
+    return "", "", None
 
 
 def _ses_auth(msg) -> dict:
-    """Extract the SES-stamped spam/virus verdicts and SPF/DKIM/DMARC results.
+    """Extract unique SES-stamped content and authentication results.
 
     SES writes these headers into the stored message; scan_enabled only
-    *produces* them, it never rejects, so the pipeline must gate on them.
+    *produces* them, it never rejects. Duplicates fail closed because a sender
+    may have injected a lookalike before SES added its authoritative field.
     """
-    spam = (msg.get("X-SES-Spam-Verdict") or "").strip().upper() or None
-    virus = (msg.get("X-SES-Virus-Verdict") or "").strip().upper() or None
-    ar = " ".join(msg.get_all("Authentication-Results") or [])
-    auth = {}
-    for mech in ("spf", "dkim", "dmarc"):
-        m = re.search(rf"\b{mech}=(\w+)", ar)
-        if m:
-            auth[mech] = m.group(1).lower()
-    return {"spam_verdict": spam, "virus_verdict": virus, "auth": auth}
+    spam = (_unique_header(msg, "X-SES-Spam-Verdict") or "").strip().upper()
+    virus = (_unique_header(msg, "X-SES-Virus-Verdict") or "").strip().upper()
+    auth = {
+        mechanism: status
+        for mechanism, status, _details in _auth_entries(
+            _trusted_ses_auth_results(msg) or "")
+        if mechanism in ("spf", "dkim", "dmarc")
+    }
+    return {
+        "spam_verdict": spam or None,
+        "virus_verdict": virus or None,
+        "auth": auth,
+    }
 
 
 def _content_rejected(spam, virus) -> bool:
@@ -158,38 +225,36 @@ def lambda_handler(event, _context):
             out["message_id"] = (msg.get("Message-ID") or key).strip()
             out["subject"] = msg.get("Subject", "")
             out.update(_ses_auth(msg))
-            from_addr, domain = _from_domain(msg)
+            transport_addr, _transport_domain = _single_address(
+                msg.get_all("From") or [])
+            claimed_addr, claimed_domain = _single_address(
+                msg.get_all("X-Original-From") or [])
+            from_addr, domain, auth_source = _authenticated_sender(msg)
             out["from_domain"] = domain
             out["original_from"] = from_addr
+            out["transport_from"] = transport_addr
+            out["claimed_original_from"] = claimed_addr or None
+            out["sender_auth_source"] = auth_source
             if _content_rejected(spam=out["spam_verdict"],
                                  virus=out["virus_verdict"]):
                 # SES flagged (or could not clear) malware/spam; hold it out of
                 # reconciliation. Distinct from parser-determined non_receipt so
                 # downstream can treat scan failures differently.
                 out["classification"] = "quarantine"
+            elif auth_source is None:
+                out["classification"] = "quarantine"
+                out["error"] = "sender identity was not authenticated by SES"
             else:
                 grp = registry.group_for_domain(domain)
-                out["group"] = grp
-                if grp:
-                    # The registry chose the group from the canonical sender
-                    # (X-Original-From in the iCloud-forwarding case), but the
-                    # parsers re-dispatch on the message's own ``From`` header —
-                    # which the forwarder rewrote to itself. Normalize ONLY the
-                    # parser's temp copy so its From matches the sender the
-                    # registry keyed on; the stored raw/ evidence is untouched.
-                    parser_bytes = raw
-                    orig_from = msg.get("X-Original-From")
-                    if orig_from:
-                        norm = email.message_from_bytes(
-                            raw, policy=email.policy.default)
-                        if norm.get("From") is not None:
-                            norm.replace_header("From", orig_from)
-                        else:
-                            norm["From"] = orig_from
-                        parser_bytes = norm.as_bytes()
+                claimed_grp = registry.group_for_domain(claimed_domain)
+                if claimed_grp and claimed_grp != grp:
+                    out["classification"] = "quarantine"
+                    out["error"] = "unauthenticated X-Original-From claim"
+                elif grp:
+                    out["group"] = grp
                     with tempfile.NamedTemporaryFile(
                             suffix=".eml", delete=False) as tmp:
-                        tmp.write(parser_bytes)
+                        tmp.write(raw)
                         path = tmp.name
                     try:
                         parsed = registry.run_parser(grp, path)

--- a/infra/tests/test_email_receipt_inbox_handler.py
+++ b/infra/tests/test_email_receipt_inbox_handler.py
@@ -1,0 +1,93 @@
+"""Adversarial sender-authentication tests for the inbound email handler."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from io import BytesIO
+from pathlib import Path
+
+import boto3
+
+
+HANDLER_PATH = (
+    Path(__file__).parents[1]
+    / "email_receipt_inbox"
+    / "lambdas"
+    / "handler.py"
+)
+
+
+class FakeS3:
+    def __init__(self, raw: bytes) -> None:
+        self.raw = raw
+        self.writes: list[dict] = []
+
+    def get_object(self, **_kwargs):
+        return {"Body": BytesIO(self.raw)}
+
+    def put_object(self, **kwargs):
+        self.writes.append(kwargs)
+
+
+def _load_handler(monkeypatch, s3: FakeS3):
+    monkeypatch.setattr(boto3, "client", lambda *_args, **_kwargs: s3)
+    monkeypatch.syspath_prepend(str(HANDLER_PATH.parent))
+    spec = importlib.util.spec_from_file_location("email_receipt_handler", HANDLER_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _s3_event() -> dict:
+    return {
+        "Records": [
+            {
+                "s3": {
+                    "bucket": {"name": "mail-dev"},
+                    "object": {
+                        "key": "raw/message-id",
+                        "size": 512,
+                        "eTag": "etag",
+                    },
+                }
+            }
+        ]
+    }
+
+
+def test_spoofed_x_original_from_cannot_select_costco_parser(monkeypatch) -> None:
+    raw = b"\r\n".join(
+        [
+            b"From: Attacker <attacker@evil.example>",
+            b"X-Original-From: Costco <receipts@online.costco.com>",
+            b"Authentication-Results: amazonses.com; spf=pass "
+            b"envelope-from=attacker@evil.example; dkim=pass "
+            b"header.i=@evil.example; dmarc=pass "
+            b"header.from=evil.example;",
+            b"X-SES-Spam-Verdict: PASS",
+            b"X-SES-Virus-Verdict: PASS",
+            b"Subject: Your Costco receipt",
+            b"Message-ID: <spoof@evil.example>",
+            b"",
+            b"fake receipt body",
+        ]
+    )
+    fake_s3 = FakeS3(raw)
+    handler = _load_handler(monkeypatch, fake_s3)
+    parser_calls = []
+    monkeypatch.setattr(
+        handler.registry,
+        "run_parser",
+        lambda group, path: parser_calls.append((group, path))
+        or {"grand_total": 123.45},
+    )
+
+    result = handler.lambda_handler(_s3_event(), None)
+
+    assert result["processed"][0]["classification"] == "unknown_sender"
+    assert parser_calls == []
+    persisted = json.loads(fake_s3.writes[0]["Body"])
+    assert persisted["from_domain"] == "evil.example"
+    assert persisted["original_from"] == "attacker@evil.example"

--- a/infra/tests/test_email_receipt_inbox_handler.py
+++ b/infra/tests/test_email_receipt_inbox_handler.py
@@ -9,7 +9,6 @@ from pathlib import Path
 
 import boto3
 
-
 HANDLER_PATH = (
     Path(__file__).parents[1]
     / "email_receipt_inbox"
@@ -33,7 +32,9 @@ class FakeS3:
 def _load_handler(monkeypatch, s3: FakeS3):
     monkeypatch.setattr(boto3, "client", lambda *_args, **_kwargs: s3)
     monkeypatch.syspath_prepend(str(HANDLER_PATH.parent))
-    spec = importlib.util.spec_from_file_location("email_receipt_handler", HANDLER_PATH)
+    spec = importlib.util.spec_from_file_location(
+        "email_receipt_handler", HANDLER_PATH
+    )
     assert spec is not None and spec.loader is not None
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
@@ -57,7 +58,35 @@ def _s3_event() -> dict:
     }
 
 
-def test_spoofed_x_original_from_cannot_select_costco_parser(monkeypatch) -> None:
+def _message(
+    from_header: str,
+    *,
+    original_from: str | None = None,
+    auth_results: tuple[str, ...] = (),
+    virus: str = "PASS",
+) -> bytes:
+    headers = [f"From: {from_header}"]
+    if original_from is not None:
+        headers.append(f"X-Original-From: {original_from}")
+    headers.extend(
+        f"Authentication-Results: {value}" for value in auth_results
+    )
+    headers.extend(
+        [
+            "X-SES-Spam-Verdict: PASS",
+            f"X-SES-Virus-Verdict: {virus}",
+            "Subject: Your receipt",
+            "Message-ID: <message-id@example.com>",
+            "",
+            "receipt body",
+        ]
+    )
+    return "\r\n".join(headers).encode()
+
+
+def test_spoofed_x_original_from_cannot_select_costco_parser(
+    monkeypatch,
+) -> None:
     raw = b"\r\n".join(
         [
             b"From: Attacker <attacker@evil.example>",
@@ -86,8 +115,177 @@ def test_spoofed_x_original_from_cannot_select_costco_parser(monkeypatch) -> Non
 
     result = handler.lambda_handler(_s3_event(), None)
 
-    assert result["processed"][0]["classification"] == "unknown_sender"
+    assert result["processed"][0]["classification"] == "quarantine"
     assert parser_calls == []
     persisted = json.loads(fake_s3.writes[0]["Body"])
     assert persisted["from_domain"] == "evil.example"
     assert persisted["original_from"] == "attacker@evil.example"
+    assert persisted["transport_from"] == "attacker@evil.example"
+    assert persisted["claimed_original_from"] == "receipts@online.costco.com"
+    assert persisted["sender_auth_source"] == "ses-dmarc"
+    assert persisted["error"] == "unauthenticated X-Original-From claim"
+
+
+def test_authenticated_direct_sender_reaches_costco_parser(
+    monkeypatch,
+) -> None:
+    raw = _message(
+        "Costco <receipts@online.costco.com>",
+        auth_results=(
+            "amazonses.com; spf=pass envelope-from=online.costco.com; "
+            "dkim=pass header.i=@online.costco.com; dmarc=pass "
+            "header.from=online.costco.com;",
+        ),
+    )
+    fake_s3 = FakeS3(raw)
+    handler = _load_handler(monkeypatch, fake_s3)
+    parser_calls = []
+    monkeypatch.setattr(
+        handler.registry,
+        "run_parser",
+        lambda group, path: parser_calls.append(group)
+        or {"grand_total": 123.45},
+    )
+
+    result = handler.lambda_handler(_s3_event(), None)
+
+    assert result["processed"][0]["classification"] == "receipt"
+    assert parser_calls == ["costco"]
+    persisted = json.loads(fake_s3.writes[0]["Body"])
+    assert persisted["from_domain"] == "online.costco.com"
+    assert persisted["sender_auth_source"] == "ses-dmarc"
+
+
+def test_duplicate_ses_authentication_results_fail_closed(monkeypatch) -> None:
+    raw = _message(
+        "Attacker <attacker@evil.example>",
+        original_from="Costco <receipts@online.costco.com>",
+        auth_results=(
+            "amazonses.com; dmarc=pass header.from=online.costco.com;",
+            "amazonses.com; dmarc=pass header.from=evil.example;",
+        ),
+    )
+    fake_s3 = FakeS3(raw)
+    handler = _load_handler(monkeypatch, fake_s3)
+    parser_calls = []
+    monkeypatch.setattr(
+        handler.registry,
+        "run_parser",
+        lambda group, path: parser_calls.append((group, path)) or {},
+    )
+
+    result = handler.lambda_handler(_s3_event(), None)
+
+    assert result["processed"][0]["classification"] == "quarantine"
+    assert parser_calls == []
+    persisted = json.loads(fake_s3.writes[0]["Body"])
+    assert persisted["sender_auth_source"] is None
+    assert persisted["auth"] == {}
+
+
+def test_non_ses_authentication_results_cannot_override_ses(
+    monkeypatch,
+) -> None:
+    raw = _message(
+        "Costco <receipts@online.costco.com>",
+        auth_results=(
+            "attacker.example; dmarc=pass header.from=evil.example;",
+            "amazonses.com; dmarc=pass header.from=online.costco.com;",
+        ),
+    )
+    fake_s3 = FakeS3(raw)
+    handler = _load_handler(monkeypatch, fake_s3)
+    parser_calls = []
+    monkeypatch.setattr(
+        handler.registry,
+        "run_parser",
+        lambda group, path: parser_calls.append(group)
+        or {"grand_total": 123.45},
+    )
+
+    result = handler.lambda_handler(_s3_event(), None)
+
+    assert result["processed"][0]["classification"] == "receipt"
+    assert parser_calls == ["costco"]
+
+
+def test_misaligned_dmarc_identity_fails_closed(monkeypatch) -> None:
+    raw = _message(
+        "Costco <receipts@online.costco.com>",
+        auth_results=(
+            "amazonses.com; spf=pass envelope-from=evil.example; "
+            "dkim=pass header.i=@evil.example; dmarc=pass "
+            "header.from=evil.example;",
+        ),
+    )
+    fake_s3 = FakeS3(raw)
+    handler = _load_handler(monkeypatch, fake_s3)
+    parser_calls = []
+    monkeypatch.setattr(
+        handler.registry,
+        "run_parser",
+        lambda group, path: parser_calls.append((group, path)) or {},
+    )
+
+    result = handler.lambda_handler(_s3_event(), None)
+
+    assert result["processed"][0]["classification"] == "quarantine"
+    assert parser_calls == []
+
+
+def test_unvalidated_arc_cannot_authenticate_original_sender(
+    monkeypatch,
+) -> None:
+    raw = _message(
+        "Forwarder <forwarder@icloud.com>",
+        original_from="Costco <receipts@online.costco.com>",
+        auth_results=(
+            "amazonses.com; dmarc=pass header.from=icloud.com; arc=pass;",
+        ),
+    ).replace(
+        b"X-SES-Spam-Verdict",
+        b"ARC-Seal: i=1; cv=pass; d=icloud.com; b=forged\r\n"
+        b"ARC-Authentication-Results: i=1; dmarc=pass "
+        b"header.from=online.costco.com;\r\nX-SES-Spam-Verdict",
+    )
+    fake_s3 = FakeS3(raw)
+    handler = _load_handler(monkeypatch, fake_s3)
+    parser_calls = []
+    monkeypatch.setattr(
+        handler.registry,
+        "run_parser",
+        lambda group, path: parser_calls.append((group, path)) or {},
+    )
+
+    result = handler.lambda_handler(_s3_event(), None)
+
+    assert result["processed"][0]["classification"] == "quarantine"
+    assert parser_calls == []
+    persisted = json.loads(fake_s3.writes[0]["Body"])
+    assert persisted["from_domain"] == "icloud.com"
+    assert persisted["error"] == "unauthenticated X-Original-From claim"
+
+
+def test_content_rejection_precedes_authenticated_dispatch(
+    monkeypatch,
+) -> None:
+    raw = _message(
+        "Costco <receipts@online.costco.com>",
+        auth_results=(
+            "amazonses.com; dmarc=pass header.from=online.costco.com;",
+        ),
+        virus="FAIL",
+    )
+    fake_s3 = FakeS3(raw)
+    handler = _load_handler(monkeypatch, fake_s3)
+    parser_calls = []
+    monkeypatch.setattr(
+        handler.registry,
+        "run_parser",
+        lambda group, path: parser_calls.append((group, path)) or {},
+    )
+
+    result = handler.lambda_handler(_s3_event(), None)
+
+    assert result["processed"][0]["classification"] == "quarantine"
+    assert parser_calls == []

--- a/infra/tests/test_email_receipt_inbox_handler.py
+++ b/infra/tests/test_email_receipt_inbox_handler.py
@@ -233,6 +233,34 @@ def test_misaligned_dmarc_identity_fails_closed(monkeypatch) -> None:
     assert parser_calls == []
 
 
+def test_aligned_from_with_failing_dmarc_quarantines(monkeypatch) -> None:
+    # The canonical direct spoof: the visible From aligns with the DMARC
+    # identity, but DMARC itself FAILED. Accepting any non-"pass" status
+    # here would let an attacker mail as receipts@online.costco.com; this
+    # pins the status == "pass" gate the mutation check found uncovered.
+    raw = _message(
+        "Costco <receipts@online.costco.com>",
+        auth_results=(
+            "amazonses.com; spf=fail envelope-from=online.costco.com; "
+            "dkim=fail header.i=@online.costco.com; dmarc=fail "
+            "header.from=online.costco.com;",
+        ),
+    )
+    fake_s3 = FakeS3(raw)
+    handler = _load_handler(monkeypatch, fake_s3)
+    parser_calls = []
+    monkeypatch.setattr(
+        handler.registry,
+        "run_parser",
+        lambda group, path: parser_calls.append((group, path)) or {},
+    )
+
+    result = handler.lambda_handler(_s3_event(), None)
+
+    assert result["processed"][0]["classification"] == "quarantine"
+    assert parser_calls == []
+
+
 def test_unvalidated_arc_cannot_authenticate_original_sender(
     monkeypatch,
 ) -> None:


### PR DESCRIPTION
Closes #1218.

## What changed

- Authenticate dispatch from the raw message's sole `From` mailbox only when a unique SES-owned `Authentication-Results` field (`amazonses.com`) reports `dmarc=pass` and its `header.from` domain exactly aligns.
- Treat missing, duplicate, forged, or misaligned authentication evidence as unauthenticated and fail closed.
- Keep `X-Original-From` and raw ARC fields as claims/diagnostics only; neither may select a parser or rewrite parser input.
- Quarantine an authenticated outer sender that uses `X-Original-From` to claim a different registered merchant.
- Preserve the existing version-pinned S3 trigger/read path; this PR makes no SES rule or infrastructure cutover.
- Run the inbox adversarial suite in CI.

## Adversarial test first

**Red — `e36e43f6a`**

```
FAILED test_spoofed_x_original_from_cannot_select_costco_parser
expected classification: unknown_sender
actual classification: receipt
```

The old handler trusted `X-Original-From: ...@online.costco.com`, selected the Costco parser, and persisted the attacker-controlled identity.

**Green — `8600eeb7a`**

```
7 passed in 0.22s
```

Coverage includes spoofed `X-Original-From`, direct authenticated Costco mail, duplicate SES authentication fields, non-SES override attempts, DMARC misalignment, unvalidated ARC claims, and virus rejection precedence.

## Mutation honesty

Restoring the old `X-Original-From`-first domain selection makes the original adversarial test fail again: classification becomes `receipt` and the Costco parser is called. The test therefore specifically kills the vulnerable behavior rather than merely exercising the new path.

## Verification (rebased on `5aef41721`)

- `pytest -q infra/tests/test_email_receipt_inbox_handler.py`: **7 passed**
- full root `tests/` suite: **481 passed, 1 skipped**
- handler/parser `py_compile`: pass
- workflow YAML parse: pass
- `git diff --check`: pass
- independent adversarial review: no spoof bypass or deploy blocker found
- read-only compatibility probe of 100 recent dev raw messages: 99 authenticated with the SES header shape; the one rejection had SES DMARC=fail; all 7 Costco samples authenticated

## Compatibility / rollout note

This intentionally stops treating forwarded `X-Original-From` or unvalidated raw ARC fields as identity. A forwarded receipt whose authenticated outer sender is not the merchant will quarantine until a cryptographically validated forwarding/ARC path is designed. The claimed header is retained in output for diagnosis.

Draft only. No merge, deployment, AWS mutation, production access, or data migration was performed.