### PR TITLE
[scripts] import_crosswalk_notes: preserve curator comments as proposals (W-I)

### DIFF
--- a/receipt_dynamo/receipt_dynamo/migrations/crosswalk_notes.py
+++ b/receipt_dynamo/receipt_dynamo/migrations/crosswalk_notes.py
@@ -14,22 +14,27 @@ it to a live ``git show`` read and the governed ``add_proposal`` accessor.
 
 Design notes
 ------------
+* **Every extracted leaf is written.** Zero-text-loss means every leaf's
+  verbatim text persists in a written record, so preservation never depends
+  on a dedupe heuristic. A multi-topic note (e.g. the Costco ``_comment``,
+  which spans font, condense, footer *and* the self-checkout observation) is
+  never dropped because it happens to touch a topic another proposal covers.
+* **Relatedness is a non-suppressing annotation.** When an existing proposal
+  is textually related to a leaf, the written record carries a ``related_to``
+  field in its claim envelope naming that proposal's ``claim_slug`` - a
+  cross-reference, not a substitute. The relatedness signal is deliberately
+  conservative (a shared distinctive hyphenated compound like
+  ``self-checkout``, or a shared contiguous >=``MIN_COVERAGE_NGRAM`` token
+  phrase) so common bigrams such as ``font size`` do not trip it; but even a
+  false relatedness link is low-harm now, because it only adds a reference.
 * **Provenance lives in the claim body.** ``MerchantTruthProposal`` has no
   provenance field, so each imported claim is a canonical JSON envelope
-  ``{"provenance": {...}, "text": <verbatim>}``. ``text`` is the byte-exact
-  curator note; the zero-text-loss check verifies it round-trips identically
-  against a fresh ``git show``.
+  ``{"provenance": {...}, "text": <verbatim>}`` (plus ``related_to`` when
+  set). ``text`` is the byte-exact curator note.
 * **claim_slug is derived from the leaf path** (stable + deduplicatable), so
-  an idempotent re-run recognises an already-imported leaf and skips it.
-* **Textual dedupe is anchored on the *existing* proposal's claim_slug.** A
-  leaf is "covered by" a prior proposal when the leaf text contains, as a
-  contiguous token phrase, some >=2-token contiguous n-gram of that
-  proposal's claim_slug. The curator-authored claim_slug is the semantic key
-  of the observation, so this is a conservative, false-positive-resistant
-  signal: the Costco ``_comment`` (which mentions ``SELF-CHECKOUT``) is
-  covered by ``self-checkout-layout-variant`` and referenced rather than
-  duplicated, while the neighbouring ``layout_template._comment`` /
-  ``_face_source_comment`` notes are NOT falsely suppressed.
+  an idempotent re-run recognises an already-imported leaf and skips it - the
+  only non-writing disposition, and only because the text already persists in
+  the prior record.
 """
 
 from __future__ import annotations
@@ -48,8 +53,14 @@ COMMENT_FIELDS = frozenset({"_comment", "_face_source_comment"})
 # The system-of-record that authored these claims (contract §7.8 provenance).
 PROVENANCE_SOURCE = "profile-comment"
 
-# Minimum contiguous claim_slug n-gram length that counts as textual coverage.
-MIN_COVERAGE_NGRAM = 2
+# Minimum contiguous shared token phrase length that signals relatedness.
+# Bigrams over-trigger on boilerplate (e.g. "font size"); require three.
+MIN_COVERAGE_NGRAM = 3
+
+# A distinctive hyphenated compound: two or more alphabetic sub-words joined
+# by hyphens (e.g. "self-checkout", "variant-aware"). These are specific
+# enough to signal relatedness on their own.
+_HYPHEN_COMPOUND = re.compile(r"[a-z]+(?:-[a-z]+)+")
 
 
 @dataclass(frozen=True)
@@ -58,28 +69,32 @@ class ExtractedLeaf:
 
     merchant_name: str
     slug: str
-    leaf_path: (
-        str  # full source path, e.g. "profiles.Costco Wholesale._comment"
-    )
-    rel_path: str  # merchant-relative path, e.g. "layout_template._comment"
+    leaf_path: str  # full source path, e.g. profiles.Costco Wholesale._comment
+    rel_path: str  # merchant-relative path, e.g. layout_template._comment
     text: str
     claim_slug: str
 
 
 @dataclass(frozen=True)
 class LeafDecision:
-    """Per-leaf disposition in an import plan."""
+    """Per-leaf disposition in an import plan.
+
+    ``WRITE`` persists a new PROPOSED record (optionally annotated with
+    ``related_to``); ``SKIP_EXISTS`` is the idempotent no-op for a leaf whose
+    ``claim_slug`` is already present (its text already persists). There is no
+    suppressing disposition - a related leaf still writes.
+    """
 
     leaf: ExtractedLeaf
-    action: str  # WRITE | COVERED_BY | SKIP_EXISTS
-    covered_by: str | None = None  # existing claim_slug when COVERED_BY
-    matched_phrase: str | None = None  # the shared claim_slug phrase
+    action: str  # WRITE | SKIP_EXISTS
+    related_to: str | None = None  # existing claim_slug this leaf references
+    matched_phrase: str | None = None  # the shared compound / phrase
     proposal: MerchantTruthProposal | None = None  # set when action == WRITE
 
 
 @dataclass(frozen=True)
 class LeafVerification:
-    """Byte-identical text-loss result for one leaf."""
+    """Persistence result for one extracted leaf."""
 
     leaf_path: str
     ok: bool
@@ -97,8 +112,8 @@ class ImportPlan:
         return [d for d in self.decisions if d.action == "WRITE"]
 
     @property
-    def covered(self) -> list[LeafDecision]:
-        return [d for d in self.decisions if d.action == "COVERED_BY"]
+    def related(self) -> list[LeafDecision]:
+        return [d for d in self.decisions if d.related_to is not None]
 
     @property
     def skipped(self) -> list[LeafDecision]:
@@ -169,9 +184,19 @@ def extract_comment_leaves(document: dict[str, Any]) -> list[ExtractedLeaf]:
     return leaves
 
 
-def build_claim(text: str, leaf_path: str, git_sha: str) -> str:
-    """Build the canonical JSON claim envelope carrying text + provenance."""
-    envelope = {
+def build_claim(
+    text: str,
+    leaf_path: str,
+    git_sha: str,
+    *,
+    related_to: str | None = None,
+) -> str:
+    """Build the canonical JSON claim envelope carrying text + provenance.
+
+    ``related_to`` (when set) cross-references an existing proposal's
+    ``claim_slug``; it never replaces ``text``, which stays byte-exact.
+    """
+    envelope: dict[str, Any] = {
         "provenance": {
             "source": PROVENANCE_SOURCE,
             "leaf_path": leaf_path,
@@ -179,6 +204,8 @@ def build_claim(text: str, leaf_path: str, git_sha: str) -> str:
         },
         "text": text,
     }
+    if related_to is not None:
+        envelope["related_to"] = related_to
     return json.dumps(envelope, ensure_ascii=False, sort_keys=True)
 
 
@@ -187,51 +214,78 @@ def extract_text_from_claim(claim: str) -> str:
     return json.loads(claim)["text"]
 
 
+def _proposal_text(proposal: MerchantTruthProposal) -> str:
+    """Return an existing proposal's human text.
+
+    Crosswalk imports store a JSON envelope; owner proposals store plain
+    prose. Compare against the envelope's ``text`` when present.
+    """
+    claim = proposal.claim
+    try:
+        data = json.loads(claim)
+    except (ValueError, TypeError):
+        return claim
+    if isinstance(data, dict) and isinstance(data.get("text"), str):
+        return data["text"]
+    return claim
+
+
 def _normalize_tokens(text: str) -> list[str]:
     """Lowercase and split on non-alphanumerics into content tokens."""
     return [tok for tok in re.split(r"[^a-z0-9]+", text.lower()) if tok]
 
 
-def _claim_slug_ngrams(claim_slug: str) -> list[list[str]]:
-    """Return every contiguous >=MIN_COVERAGE_NGRAM token run of a slug."""
-    tokens = [tok for tok in claim_slug.split("-") if tok]
-    ngrams: list[list[str]] = []
-    for size in range(MIN_COVERAGE_NGRAM, len(tokens) + 1):
-        for start in range(0, len(tokens) - size + 1):
-            ngrams.append(tokens[start : start + size])
-    return ngrams
+def _compounds(text: str) -> set[str]:
+    """Distinctive hyphenated compound terms present in ``text``."""
+    return set(_HYPHEN_COMPOUND.findall(text.lower()))
 
 
-def _contiguous_sublist(needle: list[str], haystack: list[str]) -> bool:
-    if not needle or len(needle) > len(haystack):
-        return False
-    for start in range(0, len(haystack) - len(needle) + 1):
-        if haystack[start : start + len(needle)] == needle:
-            return True
-    return False
+def _longest_shared_phrase(left: str, right: str, min_len: int) -> str | None:
+    """Longest contiguous shared token run of >= ``min_len`` tokens, or None."""
+    left_tokens = _normalize_tokens(left)
+    right_tokens = _normalize_tokens(right)
+    upper = min(len(left_tokens), len(right_tokens))
+    for size in range(upper, min_len - 1, -1):
+        right_grams = {
+            tuple(right_tokens[i : i + size])
+            for i in range(len(right_tokens) - size + 1)
+        }
+        for start in range(len(left_tokens) - size + 1):
+            candidate = tuple(left_tokens[start : start + size])
+            if candidate in right_grams:
+                return " ".join(candidate)
+    return None
 
 
-def find_coverage(
+def find_related(
     leaf: ExtractedLeaf,
     existing: list[MerchantTruthProposal],
 ) -> tuple[str, str] | None:
-    """Return (existing_claim_slug, matched_phrase) if a proposal covers leaf.
+    """Return (existing_claim_slug, matched_term) if a proposal relates to leaf.
 
-    Coverage is anchored on the existing proposal's *claim_slug*: the leaf is
-    covered when its text contains a contiguous >=2-token n-gram of that slug
-    as a contiguous token phrase. Longer n-grams are preferred so the report
-    cites the most specific shared phrase.
+    Relatedness is a conservative textual signal against the existing
+    proposal's text: a shared distinctive hyphenated compound (preferred, e.g.
+    ``self-checkout``) or, failing that, a shared contiguous
+    >=``MIN_COVERAGE_NGRAM`` token phrase. It only annotates the written
+    record; it never suppresses a write.
     """
-    leaf_tokens = _normalize_tokens(leaf.text)
+    leaf_compounds = _compounds(leaf.text)
     best: tuple[str, str] | None = None
-    best_len = 0
+    best_score = 0
     for proposal in existing:
-        for ngram in _claim_slug_ngrams(proposal.claim_slug):
-            if len(ngram) > best_len and _contiguous_sublist(
-                ngram, leaf_tokens
-            ):
-                best = (proposal.claim_slug, " ".join(ngram))
-                best_len = len(ngram)
+        ptext = _proposal_text(proposal)
+        shared = leaf_compounds & _compounds(ptext)
+        if shared:
+            term = max(sorted(shared), key=len)
+            score = 1000 + len(term)  # compounds beat any phrase
+            if score > best_score:
+                best, best_score = (proposal.claim_slug, term), score
+            continue
+        phrase = _longest_shared_phrase(leaf.text, ptext, MIN_COVERAGE_NGRAM)
+        if phrase:
+            score = len(phrase.split())
+            if score > best_score:
+                best, best_score = (proposal.claim_slug, phrase), score
     return best
 
 
@@ -242,82 +296,110 @@ def plan_import(
     git_sha: str,
     created_at: str,
 ) -> ImportPlan:
-    """Decide per leaf: WRITE a new proposal, SKIP an idempotent re-run, or
-    reference a prior proposal that already covers the observation."""
+    """Decide per leaf: WRITE a new proposal (annotated with ``related_to``
+    when an existing proposal is related), or SKIP an idempotent re-run.
+
+    Every extracted leaf gets a persisting disposition - a related leaf still
+    writes its full record - so no curator note is ever dropped.
+    """
     decisions: list[LeafDecision] = []
     for leaf in leaves:
         existing = existing_by_slug.get(leaf.slug, [])
-        existing_slugs = {p.claim_slug for p in existing}
-        if leaf.claim_slug in existing_slugs:
+        if leaf.claim_slug in {p.claim_slug for p in existing}:
             decisions.append(LeafDecision(leaf=leaf, action="SKIP_EXISTS"))
             continue
-        coverage = find_coverage(leaf, existing)
-        if coverage is not None:
-            decisions.append(
-                LeafDecision(
-                    leaf=leaf,
-                    action="COVERED_BY",
-                    covered_by=coverage[0],
-                    matched_phrase=coverage[1],
-                )
-            )
-            continue
+        related = find_related(leaf, existing)
+        related_to = related[0] if related else None
         proposal = MerchantTruthProposal(
             slug=leaf.slug,
             created_at=created_at,
             claim_slug=leaf.claim_slug,
-            claim=build_claim(leaf.text, leaf.leaf_path, git_sha),
+            claim=build_claim(
+                leaf.text, leaf.leaf_path, git_sha, related_to=related_to
+            ),
         )
         decisions.append(
-            LeafDecision(leaf=leaf, action="WRITE", proposal=proposal)
+            LeafDecision(
+                leaf=leaf,
+                action="WRITE",
+                related_to=related_to,
+                matched_phrase=related[1] if related else None,
+                proposal=proposal,
+            )
         )
     return ImportPlan(decisions=decisions)
 
 
-def verify_no_text_loss(
+def verify_persistence(
     plan: ImportPlan,
     reference_document: dict[str, Any],
+    *,
+    scope: set[str] | None = None,
 ) -> list[LeafVerification]:
-    """Diff every extracted leaf against an independent re-read of the source.
+    """Assert every in-scope extracted leaf's text persists in a record.
 
-    ``reference_document`` is a fresh parse of ``git show <sha>:...`` obtained
-    separately from the extraction read. For each leaf we re-walk the
-    reference document to the same path and require the value to be
-    byte-identical to the captured text (and, for WRITE decisions, to the text
-    embedded in the built claim envelope). Any drift is reported red.
+    Extraction-driven (not write-driven): re-extract the leaves from a fresh
+    ``git show`` parse of the source and require, for each, a plan decision
+    whose persisted text is byte-identical. A leaf with no decision is
+    ``planless`` and fails - which makes the old "covered-but-unwritten"
+    suppression class structurally impossible: a dropped leaf is a red row,
+    not a silent omission.
+
+    ``scope`` (a set of ``leaf_path``) restricts the assertion to the leaves
+    the run intended to handle - e.g. when ``--merchants`` narrowed the plan.
+    Leaves outside scope were never in play and are not treated as planless.
+
+    Honesty note: this checks *extraction-faithfulness + envelope round-trip*,
+    not an OCR-of-the-database read-back. Extraction here re-uses the same
+    walker as the import path, so a walker bug would affect both reads; what it
+    proves is that the text captured for each source leaf survives verbatim
+    into the record scheduled to persist it (or into the prior record an
+    idempotent skip points at).
     """
-    reference = {
-        leaf.leaf_path: leaf.text
-        for leaf in extract_comment_leaves(reference_document)
-    }
+    decisions = {d.leaf.leaf_path: d for d in plan.decisions}
     results: list[LeafVerification] = []
-    for decision in plan.decisions:
-        leaf = decision.leaf
-        ref_text = reference.get(leaf.leaf_path)
-        if ref_text is None:
+    for leaf in extract_comment_leaves(reference_document):
+        if scope is not None and leaf.leaf_path not in scope:
+            continue
+        decision = decisions.get(leaf.leaf_path)
+        if decision is None:
             results.append(
                 LeafVerification(
                     leaf.leaf_path,
                     False,
-                    "leaf absent from independent re-read",
+                    "planless: no record scheduled to persist this leaf",
                 )
             )
             continue
-        captured = leaf.text
-        # For a WRITE, also confirm the claim envelope round-trips the text.
-        if decision.proposal is not None:
-            captured = extract_text_from_claim(decision.proposal.claim)
-        if ref_text == leaf.text == captured:
+        if decision.action == "SKIP_EXISTS":
+            ok = decision.leaf.text == leaf.text
             results.append(
-                LeafVerification(leaf.leaf_path, True, "byte-identical")
+                LeafVerification(
+                    leaf.leaf_path,
+                    ok,
+                    (
+                        "already persisted (idempotent skip)"
+                        if ok
+                        else "text drift vs source on an already-imported leaf"
+                    ),
+                )
+            )
+            continue
+        assert decision.proposal is not None
+        persisted = extract_text_from_claim(decision.proposal.claim)
+        if leaf.text == decision.leaf.text == persisted:
+            results.append(
+                LeafVerification(
+                    leaf.leaf_path, True, "persists byte-identical"
+                )
             )
         else:
             results.append(
                 LeafVerification(
                     leaf.leaf_path,
                     False,
-                    f"text drift: {len(ref_text)}B ref vs "
-                    f"{len(captured)}B captured",
+                    f"text drift: {len(leaf.text)}B source vs "
+                    f"{len(persisted)}B persisted",
                 )
             )
     return results

--- a/receipt_dynamo/receipt_dynamo/migrations/crosswalk_notes.py
+++ b/receipt_dynamo/receipt_dynamo/migrations/crosswalk_notes.py
@@ -1,0 +1,323 @@
+"""Preserve discarded merchant-profile curator comments as PROPOSED records.
+
+The v1 MerchantTruth migration classified every ``merchant_profiles.json``
+``_comment`` / ``_face_source_comment`` leaf as ``discarded-with-reason``
+(see ``merchant_truth_v1.classify_leaf``). That crosswalk disposition is
+correct for a *parity* mint, but it throws away rich curator knowledge -
+including the original Costco ``SELF-CHECKOUT`` observation. Contract §7.8
+requires that knowledge to survive into the truth system as PROPOSED
+records rather than living only in git history.
+
+This module holds the pure, git-free logic so it is unit-testable with
+injected file content; the ``scripts/import_crosswalk_notes.py`` CLI wires
+it to a live ``git show`` read and the governed ``add_proposal`` accessor.
+
+Design notes
+------------
+* **Provenance lives in the claim body.** ``MerchantTruthProposal`` has no
+  provenance field, so each imported claim is a canonical JSON envelope
+  ``{"provenance": {...}, "text": <verbatim>}``. ``text`` is the byte-exact
+  curator note; the zero-text-loss check verifies it round-trips identically
+  against a fresh ``git show``.
+* **claim_slug is derived from the leaf path** (stable + deduplicatable), so
+  an idempotent re-run recognises an already-imported leaf and skips it.
+* **Textual dedupe is anchored on the *existing* proposal's claim_slug.** A
+  leaf is "covered by" a prior proposal when the leaf text contains, as a
+  contiguous token phrase, some >=2-token contiguous n-gram of that
+  proposal's claim_slug. The curator-authored claim_slug is the semantic key
+  of the observation, so this is a conservative, false-positive-resistant
+  signal: the Costco ``_comment`` (which mentions ``SELF-CHECKOUT``) is
+  covered by ``self-checkout-layout-variant`` and referenced rather than
+  duplicated, while the neighbouring ``layout_template._comment`` /
+  ``_face_source_comment`` notes are NOT falsely suppressed.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from typing import Any, Iterable
+
+from receipt_dynamo.entities.merchant_truth import MerchantTruthProposal
+from receipt_dynamo.migrations.merchant_truth_v1 import slugify_merchant
+
+# Leaf field names the v1 crosswalk discarded as documentation-only.
+COMMENT_FIELDS = frozenset({"_comment", "_face_source_comment"})
+
+# The system-of-record that authored these claims (contract §7.8 provenance).
+PROVENANCE_SOURCE = "profile-comment"
+
+# Minimum contiguous claim_slug n-gram length that counts as textual coverage.
+MIN_COVERAGE_NGRAM = 2
+
+
+@dataclass(frozen=True)
+class ExtractedLeaf:
+    """One discarded curator-comment leaf, captured verbatim."""
+
+    merchant_name: str
+    slug: str
+    leaf_path: (
+        str  # full source path, e.g. "profiles.Costco Wholesale._comment"
+    )
+    rel_path: str  # merchant-relative path, e.g. "layout_template._comment"
+    text: str
+    claim_slug: str
+
+
+@dataclass(frozen=True)
+class LeafDecision:
+    """Per-leaf disposition in an import plan."""
+
+    leaf: ExtractedLeaf
+    action: str  # WRITE | COVERED_BY | SKIP_EXISTS
+    covered_by: str | None = None  # existing claim_slug when COVERED_BY
+    matched_phrase: str | None = None  # the shared claim_slug phrase
+    proposal: MerchantTruthProposal | None = None  # set when action == WRITE
+
+
+@dataclass(frozen=True)
+class LeafVerification:
+    """Byte-identical text-loss result for one leaf."""
+
+    leaf_path: str
+    ok: bool
+    detail: str
+
+
+@dataclass(frozen=True)
+class ImportPlan:
+    """The full set of per-leaf decisions for one run."""
+
+    decisions: list[LeafDecision] = field(default_factory=list)
+
+    @property
+    def to_write(self) -> list[LeafDecision]:
+        return [d for d in self.decisions if d.action == "WRITE"]
+
+    @property
+    def covered(self) -> list[LeafDecision]:
+        return [d for d in self.decisions if d.action == "COVERED_BY"]
+
+    @property
+    def skipped(self) -> list[LeafDecision]:
+        return [d for d in self.decisions if d.action == "SKIP_EXISTS"]
+
+
+def _walk(value: Any, prefix: tuple[str, ...]) -> Iterable[tuple[str, Any]]:
+    """Yield (dotted-path, leaf-value) for every scalar leaf under ``value``."""
+    if isinstance(value, dict):
+        for key in sorted(value):
+            yield from _walk(value[key], (*prefix, key))
+        return
+    if isinstance(value, list):
+        for item in value:
+            yield from _walk(item, (*prefix, "[]"))
+        return
+    yield (".".join(prefix), value)
+
+
+def derive_claim_slug(rel_path: str) -> str:
+    """Derive a stable, deduplicatable claim_slug from a leaf's relative path.
+
+    ``_comment`` (a merchant's top-level note) becomes ``profile-comment``;
+    nested notes keep their path, e.g. ``layout_template._comment`` becomes
+    ``layout-template-comment``. The mapping is deterministic so re-runs
+    recompute the identical claim_slug and dedupe against a prior import.
+    """
+    slug = re.sub(r"[^a-z0-9]+", "-", rel_path.lower()).strip("-")
+    if not slug:
+        raise ValueError(f"cannot derive claim_slug from {rel_path!r}")
+    if slug == "comment":
+        return "profile-comment"
+    return slug
+
+
+def extract_comment_leaves(document: dict[str, Any]) -> list[ExtractedLeaf]:
+    """Walk every ``*_comment`` leaf under each merchant profile, verbatim.
+
+    Only merchant-owned leaves are captured: registry-level documentation
+    (top-level ``_comment`` / ``_section_scale_note``) is out of scope.
+    """
+    profiles = document.get("profiles")
+    if not isinstance(profiles, dict):
+        raise ValueError("profile document must contain a profiles map")
+    leaves: list[ExtractedLeaf] = []
+    for merchant_name in sorted(profiles):
+        slug = slugify_merchant(merchant_name)
+        subtree = profiles[merchant_name]
+        for rel_path, value in _walk(subtree, ()):
+            segments = rel_path.split(".")
+            if not (COMMENT_FIELDS & set(segments)):
+                continue
+            if not isinstance(value, str):
+                raise ValueError(
+                    f"non-string comment leaf at "
+                    f"profiles.{merchant_name}.{rel_path}"
+                )
+            leaves.append(
+                ExtractedLeaf(
+                    merchant_name=merchant_name,
+                    slug=slug,
+                    leaf_path=f"profiles.{merchant_name}.{rel_path}",
+                    rel_path=rel_path,
+                    text=value,
+                    claim_slug=derive_claim_slug(rel_path),
+                )
+            )
+    return leaves
+
+
+def build_claim(text: str, leaf_path: str, git_sha: str) -> str:
+    """Build the canonical JSON claim envelope carrying text + provenance."""
+    envelope = {
+        "provenance": {
+            "source": PROVENANCE_SOURCE,
+            "leaf_path": leaf_path,
+            "git_sha": git_sha,
+        },
+        "text": text,
+    }
+    return json.dumps(envelope, ensure_ascii=False, sort_keys=True)
+
+
+def extract_text_from_claim(claim: str) -> str:
+    """Return the verbatim ``text`` embedded in a claim envelope."""
+    return json.loads(claim)["text"]
+
+
+def _normalize_tokens(text: str) -> list[str]:
+    """Lowercase and split on non-alphanumerics into content tokens."""
+    return [tok for tok in re.split(r"[^a-z0-9]+", text.lower()) if tok]
+
+
+def _claim_slug_ngrams(claim_slug: str) -> list[list[str]]:
+    """Return every contiguous >=MIN_COVERAGE_NGRAM token run of a slug."""
+    tokens = [tok for tok in claim_slug.split("-") if tok]
+    ngrams: list[list[str]] = []
+    for size in range(MIN_COVERAGE_NGRAM, len(tokens) + 1):
+        for start in range(0, len(tokens) - size + 1):
+            ngrams.append(tokens[start : start + size])
+    return ngrams
+
+
+def _contiguous_sublist(needle: list[str], haystack: list[str]) -> bool:
+    if not needle or len(needle) > len(haystack):
+        return False
+    for start in range(0, len(haystack) - len(needle) + 1):
+        if haystack[start : start + len(needle)] == needle:
+            return True
+    return False
+
+
+def find_coverage(
+    leaf: ExtractedLeaf,
+    existing: list[MerchantTruthProposal],
+) -> tuple[str, str] | None:
+    """Return (existing_claim_slug, matched_phrase) if a proposal covers leaf.
+
+    Coverage is anchored on the existing proposal's *claim_slug*: the leaf is
+    covered when its text contains a contiguous >=2-token n-gram of that slug
+    as a contiguous token phrase. Longer n-grams are preferred so the report
+    cites the most specific shared phrase.
+    """
+    leaf_tokens = _normalize_tokens(leaf.text)
+    best: tuple[str, str] | None = None
+    best_len = 0
+    for proposal in existing:
+        for ngram in _claim_slug_ngrams(proposal.claim_slug):
+            if len(ngram) > best_len and _contiguous_sublist(
+                ngram, leaf_tokens
+            ):
+                best = (proposal.claim_slug, " ".join(ngram))
+                best_len = len(ngram)
+    return best
+
+
+def plan_import(
+    leaves: list[ExtractedLeaf],
+    existing_by_slug: dict[str, list[MerchantTruthProposal]],
+    *,
+    git_sha: str,
+    created_at: str,
+) -> ImportPlan:
+    """Decide per leaf: WRITE a new proposal, SKIP an idempotent re-run, or
+    reference a prior proposal that already covers the observation."""
+    decisions: list[LeafDecision] = []
+    for leaf in leaves:
+        existing = existing_by_slug.get(leaf.slug, [])
+        existing_slugs = {p.claim_slug for p in existing}
+        if leaf.claim_slug in existing_slugs:
+            decisions.append(LeafDecision(leaf=leaf, action="SKIP_EXISTS"))
+            continue
+        coverage = find_coverage(leaf, existing)
+        if coverage is not None:
+            decisions.append(
+                LeafDecision(
+                    leaf=leaf,
+                    action="COVERED_BY",
+                    covered_by=coverage[0],
+                    matched_phrase=coverage[1],
+                )
+            )
+            continue
+        proposal = MerchantTruthProposal(
+            slug=leaf.slug,
+            created_at=created_at,
+            claim_slug=leaf.claim_slug,
+            claim=build_claim(leaf.text, leaf.leaf_path, git_sha),
+        )
+        decisions.append(
+            LeafDecision(leaf=leaf, action="WRITE", proposal=proposal)
+        )
+    return ImportPlan(decisions=decisions)
+
+
+def verify_no_text_loss(
+    plan: ImportPlan,
+    reference_document: dict[str, Any],
+) -> list[LeafVerification]:
+    """Diff every extracted leaf against an independent re-read of the source.
+
+    ``reference_document`` is a fresh parse of ``git show <sha>:...`` obtained
+    separately from the extraction read. For each leaf we re-walk the
+    reference document to the same path and require the value to be
+    byte-identical to the captured text (and, for WRITE decisions, to the text
+    embedded in the built claim envelope). Any drift is reported red.
+    """
+    reference = {
+        leaf.leaf_path: leaf.text
+        for leaf in extract_comment_leaves(reference_document)
+    }
+    results: list[LeafVerification] = []
+    for decision in plan.decisions:
+        leaf = decision.leaf
+        ref_text = reference.get(leaf.leaf_path)
+        if ref_text is None:
+            results.append(
+                LeafVerification(
+                    leaf.leaf_path,
+                    False,
+                    "leaf absent from independent re-read",
+                )
+            )
+            continue
+        captured = leaf.text
+        # For a WRITE, also confirm the claim envelope round-trips the text.
+        if decision.proposal is not None:
+            captured = extract_text_from_claim(decision.proposal.claim)
+        if ref_text == leaf.text == captured:
+            results.append(
+                LeafVerification(leaf.leaf_path, True, "byte-identical")
+            )
+        else:
+            results.append(
+                LeafVerification(
+                    leaf.leaf_path,
+                    False,
+                    f"text drift: {len(ref_text)}B ref vs "
+                    f"{len(captured)}B captured",
+                )
+            )
+    return results

--- a/receipt_dynamo/tests/integration/test_crosswalk_notes_live.py
+++ b/receipt_dynamo/tests/integration/test_crosswalk_notes_live.py
@@ -1,0 +1,133 @@
+"""Integration coverage for the crosswalk-notes import (W-I).
+
+Drives the CLI end-to-end against a moto-backed table: the v1 mint git_sha is
+read from a seeded v1 manifest, dedupe runs against a seeded self-checkout
+proposal through the governed ``add_proposal`` accessor, and a second --apply
+proves idempotency. The ``git show`` read is injected so the test is git-free.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from receipt_dynamo import DynamoClient
+from receipt_dynamo.entities.merchant_truth import (
+    COMPONENT_NAMES,
+    MerchantTruthManifest,
+    MerchantTruthProposal,
+    compute_bundle_hash,
+)
+
+pytestmark = pytest.mark.integration
+
+SHA = "eb9d3617122be21d0e0e956e04f3208aec701c29"
+
+COSTCO_COMMENT = (
+    "Real font extracted from the bitMatrix-C2 chart. SELF-CHECKOUT prints "
+    "as a large bold heading."
+)
+
+
+def _document() -> dict[str, Any]:
+    return {
+        "profiles": {
+            "Costco Wholesale": {
+                "_comment": COSTCO_COMMENT,
+                "layout_template": {"_comment": "Measured layout data."},
+                "typography": {"_face_source_comment": "M4 pilot flag."},
+            },
+            "Vons": {"_comment": "First studio-native merchant."},
+        }
+    }
+
+
+def _seed_v1_manifest(client: DynamoClient, table: str) -> None:
+    hashes = {
+        name: hashlib.sha256(name.encode()).hexdigest()
+        for name in COMPONENT_NAMES
+    }
+    manifest = MerchantTruthManifest(
+        slug="costco_wholesale",
+        version=1,
+        component_hashes=hashes,
+        bundle_hash=compute_bundle_hash(hashes),
+        status="SEALED",
+        provenance={"git_sha": SHA, "written_by": "test"},
+        mint_run_id="merchant-truth-v1-costco_wholesale-test",
+    )
+    client._client.put_item(TableName=table, Item=manifest.to_item())
+
+
+def _load_cli():
+    path = (
+        Path(__file__).resolve().parents[3]
+        / "scripts"
+        / "import_crosswalk_notes.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "import_crosswalk_notes", path
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+def _claim_slugs(client: DynamoClient, slug: str) -> set[str]:
+    return {p.claim_slug for p in client.list_merchant_truth_proposals(slug)}
+
+
+def test_apply_resolves_git_sha_dedupes_and_is_idempotent(
+    dynamodb_table: str, monkeypatch
+) -> None:
+    client = DynamoClient(dynamodb_table)
+    _seed_v1_manifest(client, dynamodb_table)
+    # A prior owner proposal that already covers the SELF-CHECKOUT observation.
+    client.add_proposal(
+        MerchantTruthProposal(
+            slug="costco_wholesale",
+            created_at="2026-07-21T23:18:30.430210+00:00",
+            claim_slug="self-checkout-layout-variant",
+            claim="Costco receipts have distinct formatting variants ...",
+        ),
+        dynamodb_table,
+    )
+
+    module = _load_cli()
+    monkeypatch.setattr(
+        module, "_git_show_document", lambda repo_root, git_sha: _document()
+    )
+
+    # No --git-sha: resolved from the seeded v1 manifest provenance.
+    rc = module.main(["--table", dynamodb_table, "--apply"])
+    assert rc == 0
+
+    costco = _claim_slugs(client, "costco_wholesale")
+    # _comment is covered-by the seeded proposal, so it is NOT duplicated.
+    assert costco == {
+        "self-checkout-layout-variant",
+        "layout-template-comment",
+        "typography-face-source-comment",
+    }
+    assert _claim_slugs(client, "vons") == {"profile-comment"}
+
+    # The written Costco layout note carries the resolved git_sha in its claim.
+    import json
+
+    layout = next(
+        p
+        for p in client.list_merchant_truth_proposals("costco_wholesale")
+        if p.claim_slug == "layout-template-comment"
+    )
+    assert json.loads(layout.claim)["provenance"]["git_sha"] == SHA
+
+    # Second apply writes nothing new (idempotent).
+    rc2 = module.main(["--table", dynamodb_table, "--apply"])
+    assert rc2 == 0
+    assert _claim_slugs(client, "costco_wholesale") == costco
+    assert _claim_slugs(client, "vons") == {"profile-comment"}

--- a/receipt_dynamo/tests/integration/test_crosswalk_notes_live.py
+++ b/receipt_dynamo/tests/integration/test_crosswalk_notes_live.py
@@ -31,6 +31,10 @@ COSTCO_COMMENT = (
     "Real font extracted from the bitMatrix-C2 chart. SELF-CHECKOUT prints "
     "as a large bold heading."
 )
+SELF_CHECKOUT_CLAIM = (
+    "Costco receipts differ from self-checkout receipts; measurement should "
+    "cluster by variant. Owner observation."
+)
 
 
 def _document() -> dict[str, Any]:
@@ -87,13 +91,13 @@ def test_apply_resolves_git_sha_dedupes_and_is_idempotent(
 ) -> None:
     client = DynamoClient(dynamodb_table)
     _seed_v1_manifest(client, dynamodb_table)
-    # A prior owner proposal that already covers the SELF-CHECKOUT observation.
+    # A prior owner proposal touching the self-checkout observation.
     client.add_proposal(
         MerchantTruthProposal(
             slug="costco_wholesale",
             created_at="2026-07-21T23:18:30.430210+00:00",
             claim_slug="self-checkout-layout-variant",
-            claim="Costco receipts have distinct formatting variants ...",
+            claim=SELF_CHECKOUT_CLAIM,
         ),
         dynamodb_table,
     )
@@ -108,23 +112,28 @@ def test_apply_resolves_git_sha_dedupes_and_is_idempotent(
     assert rc == 0
 
     costco = _claim_slugs(client, "costco_wholesale")
-    # _comment is covered-by the seeded proposal, so it is NOT duplicated.
+    # Every Costco leaf persists: the _comment is annotated, NOT suppressed.
     assert costco == {
         "self-checkout-layout-variant",
+        "profile-comment",
         "layout-template-comment",
         "typography-face-source-comment",
     }
     assert _claim_slugs(client, "vons") == {"profile-comment"}
 
-    # The written Costco layout note carries the resolved git_sha in its claim.
     import json
 
+    proposals = client.list_merchant_truth_proposals("costco_wholesale")
+    # The written Costco layout note carries the resolved git_sha in its claim.
     layout = next(
-        p
-        for p in client.list_merchant_truth_proposals("costco_wholesale")
-        if p.claim_slug == "layout-template-comment"
+        p for p in proposals if p.claim_slug == "layout-template-comment"
     )
     assert json.loads(layout.claim)["provenance"]["git_sha"] == SHA
+    # The full _comment persists verbatim, cross-referencing the owner proposal.
+    profile = next(p for p in proposals if p.claim_slug == "profile-comment")
+    profile_env = json.loads(profile.claim)
+    assert profile_env["text"] == COSTCO_COMMENT
+    assert profile_env["related_to"] == "self-checkout-layout-variant"
 
     # Second apply writes nothing new (idempotent).
     rc2 = module.main(["--table", dynamodb_table, "--apply"])

--- a/receipt_dynamo/tests/unit/test_crosswalk_notes.py
+++ b/receipt_dynamo/tests/unit/test_crosswalk_notes.py
@@ -8,6 +8,7 @@ AWS or git access is required.
 from __future__ import annotations
 
 import importlib.util
+import json
 from pathlib import Path
 from typing import Any
 
@@ -22,9 +23,9 @@ from receipt_dynamo.migrations.crosswalk_notes import (
     derive_claim_slug,
     extract_comment_leaves,
     extract_text_from_claim,
-    find_coverage,
+    find_related,
     plan_import,
-    verify_no_text_loss,
+    verify_persistence,
 )
 from receipt_dynamo.migrations.merchant_truth_v1_live import PROD_TABLE_NAME
 
@@ -40,6 +41,15 @@ COSTCO_COMMENT = (
 LAYOUT_COMMENT = (
     "Measured layout data (#1188 P2): columns/sections/separators from real "
     "receipts via glyphstudio.layout_template."
+)
+# The real Costco owner proposal - carries the hyphenated compound
+# "self-checkout" that links it to the Costco _comment.
+SELF_CHECKOUT_CLAIM = (
+    "Costco receipts have distinct formatting variants: warehouse register "
+    "receipts differ from self-checkout receipts. v1 layout_template pools "
+    "all 12 measured receipts into one template; measurement should cluster "
+    "by variant and either confirm bimodal layout (variant-aware truth in "
+    "v2) or refute. Owner observation, 2026-07-21."
 )
 
 
@@ -122,8 +132,6 @@ def test_build_claim_envelope_roundtrips_text_and_carries_provenance() -> None:
     claim = build_claim(
         COSTCO_COMMENT, "profiles.Costco Wholesale._comment", SHA
     )
-    import json
-
     envelope = json.loads(claim)
     assert extract_text_from_claim(claim) == COSTCO_COMMENT  # byte-identical
     assert envelope["provenance"] == {
@@ -131,22 +139,37 @@ def test_build_claim_envelope_roundtrips_text_and_carries_provenance() -> None:
         "leaf_path": "profiles.Costco Wholesale._comment",
         "git_sha": SHA,
     }
+    assert "related_to" not in envelope
+
+
+def test_build_claim_envelope_carries_related_to_without_touching_text() -> (
+    None
+):
+    claim = build_claim(
+        COSTCO_COMMENT,
+        "profiles.Costco Wholesale._comment",
+        SHA,
+        related_to="self-checkout-layout-variant",
+    )
+    envelope = json.loads(claim)
+    assert envelope["related_to"] == "self-checkout-layout-variant"
+    assert envelope["text"] == COSTCO_COMMENT  # byte-identical, untouched
 
 
 # --------------------------------------------------------------------------
-# dedupe (mutation-check: coverage must be selective)
+# relatedness is a NON-suppressing annotation (mutation-checked)
 # --------------------------------------------------------------------------
 
 
-def test_dedupe_covers_self_checkout_leaf_only() -> None:
-    """The self-checkout proposal covers the Costco _comment (which mentions
-    SELF-CHECKOUT) but NOT the sibling layout/face comments - proving coverage
-    is anchored on the proposal's claim_slug, not a blanket match."""
+def test_related_leaf_still_writes_full_record_with_reference() -> None:
+    """The multi-topic Costco _comment is NOT dropped: it writes its own full
+    record, annotated with related_to referencing the self-checkout proposal.
+    The neighbouring notes are not falsely annotated."""
     existing = [
         _seeded_proposal(
             "costco_wholesale",
             "self-checkout-layout-variant",
-            "Costco receipts have distinct formatting variants ...",
+            SELF_CHECKOUT_CLAIM,
         )
     ]
     leaves = extract_comment_leaves(_document())
@@ -158,33 +181,50 @@ def test_dedupe_covers_self_checkout_leaf_only() -> None:
     )
     actions = {d.leaf.leaf_path: d for d in plan.decisions}
 
-    covered = actions["profiles.Costco Wholesale._comment"]
-    assert covered.action == "COVERED_BY"
-    assert covered.covered_by == "self-checkout-layout-variant"
-    assert covered.matched_phrase == "self checkout"
+    costco = actions["profiles.Costco Wholesale._comment"]
+    assert costco.action == "WRITE"  # written, never suppressed
+    assert costco.related_to == "self-checkout-layout-variant"
+    assert costco.matched_phrase == "self-checkout"
+    # The full note persists verbatim, plus the cross-reference.
+    assert costco.proposal is not None
+    envelope = json.loads(costco.proposal.claim)
+    assert envelope["text"] == COSTCO_COMMENT
+    assert envelope["related_to"] == "self-checkout-layout-variant"
 
-    # The neighbouring notes are NOT falsely suppressed.
-    assert (
-        actions["profiles.Costco Wholesale.layout_template._comment"].action
-        == "WRITE"
-    )
-    assert (
-        actions[
-            "profiles.Costco Wholesale.typography._face_source_comment"
-        ].action
-        == "WRITE"
-    )
-    # An unrelated merchant is untouched by Costco's proposal.
-    assert actions["profiles.Vons._comment"].action == "WRITE"
+    # Neighbours: written, and NOT falsely related.
+    for path in (
+        "profiles.Costco Wholesale.layout_template._comment",
+        "profiles.Costco Wholesale.typography._face_source_comment",
+        "profiles.Vons._comment",
+    ):
+        assert actions[path].action == "WRITE"
+        assert actions[path].related_to is None
+
+    # Nothing suppressed: every leaf is a WRITE here.
+    assert len(plan.to_write) == 4
+    assert len(plan.related) == 1
 
 
-def test_find_coverage_returns_none_without_shared_phrase() -> None:
+def test_common_bigram_does_not_trigger_relatedness() -> None:
+    """A shared common bigram (e.g. 'font size') must NOT relate leaves - the
+    threshold is three contiguous tokens (or a distinctive hyphenated
+    compound), which guards against the reviewer's false-positive class."""
+    leaf = extract_comment_leaves(
+        {"profiles": {"Vons": {"_comment": "the font size is small"}}}
+    )[0]
+    existing = [
+        _seeded_proposal("vons", "type-scale", "increase font size slightly")
+    ]
+    assert find_related(leaf, existing) is None
+
+
+def test_find_related_returns_none_without_shared_signal() -> None:
     existing = [
         _seeded_proposal("vons", "self-checkout-layout-variant", "irrelevant")
     ]
     leaves = extract_comment_leaves(_document())
     vons = next(leaf for leaf in leaves if leaf.slug == "vons")
-    assert find_coverage(vons, existing) is None
+    assert find_related(vons, existing) is None
 
 
 # --------------------------------------------------------------------------
@@ -213,22 +253,47 @@ def test_idempotent_rerun_skips_already_imported_claim_slug() -> None:
 
 
 # --------------------------------------------------------------------------
-# zero-text-loss (red on a mutated leaf)
+# persistence / extraction-faithfulness (planless + mutated leaf go red)
 # --------------------------------------------------------------------------
 
 
-def test_verify_no_text_loss_clean_then_red_on_mutation() -> None:
+def test_verify_persistence_clean_when_every_leaf_writes() -> None:
     document = _document()
-    leaves = extract_comment_leaves(document)
-    plan = plan_import(leaves, {}, git_sha=SHA, created_at=NOW)
+    plan = plan_import(
+        extract_comment_leaves(document), {}, git_sha=SHA, created_at=NOW
+    )
+    assert all(result.ok for result in verify_persistence(plan, document))
 
-    clean = verify_no_text_loss(plan, document)
-    assert all(result.ok for result in clean)
 
-    # Mutate one leaf in the independent re-read: that leaf must go red.
+def test_verify_persistence_flags_a_planless_leaf() -> None:
+    """Dropping a leaf's decision (a suppression) is structurally caught: the
+    extraction-driven check reports the missing leaf as planless."""
+    from receipt_dynamo.migrations.crosswalk_notes import ImportPlan
+
+    document = _document()
+    full = plan_import(
+        extract_comment_leaves(document), {}, git_sha=SHA, created_at=NOW
+    )
+    dropped = ImportPlan(
+        decisions=[
+            d
+            for d in full.decisions
+            if d.leaf.leaf_path != "profiles.Costco Wholesale._comment"
+        ]
+    )
+    results = {r.leaf_path: r for r in verify_persistence(dropped, document)}
+    assert results["profiles.Costco Wholesale._comment"].ok is False
+    assert "planless" in results["profiles.Costco Wholesale._comment"].detail
+
+
+def test_verify_persistence_red_on_mutated_source_leaf() -> None:
+    document = _document()
+    plan = plan_import(
+        extract_comment_leaves(document), {}, git_sha=SHA, created_at=NOW
+    )
     mutated = _document()
     mutated["profiles"]["Costco Wholesale"]["_comment"] = COSTCO_COMMENT + " X"
-    reds = verify_no_text_loss(plan, mutated)
+    reds = verify_persistence(plan, mutated)
     failed = {r.leaf_path for r in reds if not r.ok}
     assert failed == {"profiles.Costco Wholesale._comment"}
 
@@ -311,17 +376,20 @@ def test_cli_prod_refusal_precedes_client(monkeypatch) -> None:
         module.main(["--table", PROD_TABLE_NAME])
 
 
-def test_cli_apply_writes_then_idempotent(monkeypatch) -> None:
+def test_cli_apply_writes_every_leaf_then_idempotent(monkeypatch) -> None:
     module = _load_cli()
     client = _FakeClient()
     _patch_cli(module, monkeypatch, client)
 
     rc = module.main(["--git-sha", SHA, "--apply"])
     assert rc == 0
-    # 4 leaves, none pre-existing, none covered -> 4 writes.
+    # 4 leaves, none pre-existing -> 4 writes.
     assert len(client.writes) == 4
-    written_slugs = {p.claim_slug for p in client.writes}
-    assert "profile-comment" in written_slugs
+    assert {p.claim_slug for p in client.writes} == {
+        "profile-comment",
+        "layout-template-comment",
+        "typography-face-source-comment",
+    }
 
     # Second apply against the now-populated store writes nothing new.
     client.writes.clear()
@@ -330,14 +398,14 @@ def test_cli_apply_writes_then_idempotent(monkeypatch) -> None:
     assert client.writes == []
 
 
-def test_cli_apply_references_existing_self_checkout(monkeypatch) -> None:
+def test_cli_apply_writes_related_leaf_with_reference(monkeypatch) -> None:
     module = _load_cli()
     seeded = {
         "costco_wholesale": [
             _seeded_proposal(
                 "costco_wholesale",
                 "self-checkout-layout-variant",
-                "Costco receipts have distinct formatting variants ...",
+                SELF_CHECKOUT_CLAIM,
             )
         ]
     }
@@ -348,9 +416,16 @@ def test_cli_apply_references_existing_self_checkout(monkeypatch) -> None:
         ["--git-sha", SHA, "--apply", "--merchants", "costco_wholesale"]
     )
     assert rc == 0
-    # _comment covered-by, so only layout + face comments are written.
+    # ALL three Costco leaves write (the _comment is annotated, not dropped).
     written = {p.claim_slug for p in client.writes}
     assert written == {
+        "profile-comment",
         "layout-template-comment",
         "typography-face-source-comment",
     }
+    profile = next(
+        p for p in client.writes if p.claim_slug == "profile-comment"
+    )
+    envelope = json.loads(profile.claim)
+    assert envelope["related_to"] == "self-checkout-layout-variant"
+    assert envelope["text"] == COSTCO_COMMENT  # full note preserved verbatim

--- a/receipt_dynamo/tests/unit/test_crosswalk_notes.py
+++ b/receipt_dynamo/tests/unit/test_crosswalk_notes.py
@@ -1,0 +1,356 @@
+"""Unit coverage for the crosswalk-notes import (W-I).
+
+Pure logic is exercised with injected file content (git-free); the CLI is
+exercised with an injected ``git show`` read and a fake governed client so no
+AWS or git access is required.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from receipt_dynamo.data.shared_exceptions import (
+    MerchantTruthTableMismatchError,
+)
+from receipt_dynamo.entities.merchant_truth import MerchantTruthProposal
+from receipt_dynamo.migrations.crosswalk_notes import (
+    build_claim,
+    derive_claim_slug,
+    extract_comment_leaves,
+    extract_text_from_claim,
+    find_coverage,
+    plan_import,
+    verify_no_text_loss,
+)
+from receipt_dynamo.migrations.merchant_truth_v1_live import PROD_TABLE_NAME
+
+pytestmark = pytest.mark.unit
+
+NOW = "2026-07-22T18:00:00+00:00"
+SHA = "eb9d3617122be21d0e0e956e04f3208aec701c29"
+
+COSTCO_COMMENT = (
+    "Real font extracted from the bitMatrix-C2 chart. SELF-CHECKOUT prints "
+    "as a large bold heading; the grand TOTAL prints reverse-video."
+)
+LAYOUT_COMMENT = (
+    "Measured layout data (#1188 P2): columns/sections/separators from real "
+    "receipts via glyphstudio.layout_template."
+)
+
+
+def _document() -> dict[str, Any]:
+    """A miniature profile document with per-merchant + registry comments."""
+    return {
+        # Registry-level docs are OUT of scope and must be ignored.
+        "_comment": "top-level registry note, not a merchant leaf",
+        "_section_scale_note": "registry documentation only",
+        "profiles": {
+            "Costco Wholesale": {
+                "_comment": COSTCO_COMMENT,
+                "layout_template": {"_comment": LAYOUT_COMMENT, "columns": 3},
+                "typography": {
+                    "_face_source_comment": "M4 pilot flag.",
+                    "condense": 0.93,
+                },
+            },
+            "Vons": {
+                "_comment": "First studio-native merchant.",
+            },
+        },
+    }
+
+
+def _seeded_proposal(
+    slug: str, claim_slug: str, claim: str
+) -> MerchantTruthProposal:
+    return MerchantTruthProposal(
+        slug=slug,
+        created_at="2026-07-21T23:18:30.430210+00:00",
+        claim_slug=claim_slug,
+        claim=claim,
+    )
+
+
+# --------------------------------------------------------------------------
+# extraction (git-free, injected content)
+# --------------------------------------------------------------------------
+
+
+def test_extract_comment_leaves_from_injected_document() -> None:
+    leaves = extract_comment_leaves(_document())
+    by_path = {leaf.leaf_path: leaf for leaf in leaves}
+
+    # Registry-level docs are excluded; only merchant-owned comments captured.
+    assert "_comment" not in by_path
+    assert set(by_path) == {
+        "profiles.Costco Wholesale._comment",
+        "profiles.Costco Wholesale.layout_template._comment",
+        "profiles.Costco Wholesale.typography._face_source_comment",
+        "profiles.Vons._comment",
+    }
+
+    costco = by_path["profiles.Costco Wholesale._comment"]
+    assert costco.slug == "costco_wholesale"
+    assert costco.text == COSTCO_COMMENT  # verbatim
+    assert costco.claim_slug == "profile-comment"
+
+    layout = by_path["profiles.Costco Wholesale.layout_template._comment"]
+    assert layout.claim_slug == "layout-template-comment"
+
+    face = by_path["profiles.Costco Wholesale.typography._face_source_comment"]
+    assert face.claim_slug == "typography-face-source-comment"
+
+
+def test_derive_claim_slug_cases() -> None:
+    assert derive_claim_slug("_comment") == "profile-comment"
+    assert (
+        derive_claim_slug("layout_template._comment")
+        == "layout-template-comment"
+    )
+    assert (
+        derive_claim_slug("typography._face_source_comment")
+        == "typography-face-source-comment"
+    )
+
+
+def test_build_claim_envelope_roundtrips_text_and_carries_provenance() -> None:
+    claim = build_claim(
+        COSTCO_COMMENT, "profiles.Costco Wholesale._comment", SHA
+    )
+    import json
+
+    envelope = json.loads(claim)
+    assert extract_text_from_claim(claim) == COSTCO_COMMENT  # byte-identical
+    assert envelope["provenance"] == {
+        "source": "profile-comment",
+        "leaf_path": "profiles.Costco Wholesale._comment",
+        "git_sha": SHA,
+    }
+
+
+# --------------------------------------------------------------------------
+# dedupe (mutation-check: coverage must be selective)
+# --------------------------------------------------------------------------
+
+
+def test_dedupe_covers_self_checkout_leaf_only() -> None:
+    """The self-checkout proposal covers the Costco _comment (which mentions
+    SELF-CHECKOUT) but NOT the sibling layout/face comments - proving coverage
+    is anchored on the proposal's claim_slug, not a blanket match."""
+    existing = [
+        _seeded_proposal(
+            "costco_wholesale",
+            "self-checkout-layout-variant",
+            "Costco receipts have distinct formatting variants ...",
+        )
+    ]
+    leaves = extract_comment_leaves(_document())
+    plan = plan_import(
+        leaves,
+        {"costco_wholesale": existing},
+        git_sha=SHA,
+        created_at=NOW,
+    )
+    actions = {d.leaf.leaf_path: d for d in plan.decisions}
+
+    covered = actions["profiles.Costco Wholesale._comment"]
+    assert covered.action == "COVERED_BY"
+    assert covered.covered_by == "self-checkout-layout-variant"
+    assert covered.matched_phrase == "self checkout"
+
+    # The neighbouring notes are NOT falsely suppressed.
+    assert (
+        actions["profiles.Costco Wholesale.layout_template._comment"].action
+        == "WRITE"
+    )
+    assert (
+        actions[
+            "profiles.Costco Wholesale.typography._face_source_comment"
+        ].action
+        == "WRITE"
+    )
+    # An unrelated merchant is untouched by Costco's proposal.
+    assert actions["profiles.Vons._comment"].action == "WRITE"
+
+
+def test_find_coverage_returns_none_without_shared_phrase() -> None:
+    existing = [
+        _seeded_proposal("vons", "self-checkout-layout-variant", "irrelevant")
+    ]
+    leaves = extract_comment_leaves(_document())
+    vons = next(leaf for leaf in leaves if leaf.slug == "vons")
+    assert find_coverage(vons, existing) is None
+
+
+# --------------------------------------------------------------------------
+# idempotent re-run
+# --------------------------------------------------------------------------
+
+
+def test_idempotent_rerun_skips_already_imported_claim_slug() -> None:
+    """A prior import of the same leaf (matching claim_slug) is skipped, and no
+    duplicate proposal is built."""
+    already = [
+        _seeded_proposal(
+            "vons",
+            "profile-comment",
+            build_claim("First studio-native merchant.", "x", SHA),
+        )
+    ]
+    leaves = [
+        leaf
+        for leaf in extract_comment_leaves(_document())
+        if leaf.slug == "vons"
+    ]
+    plan = plan_import(leaves, {"vons": already}, git_sha=SHA, created_at=NOW)
+    assert [d.action for d in plan.decisions] == ["SKIP_EXISTS"]
+    assert plan.to_write == []
+
+
+# --------------------------------------------------------------------------
+# zero-text-loss (red on a mutated leaf)
+# --------------------------------------------------------------------------
+
+
+def test_verify_no_text_loss_clean_then_red_on_mutation() -> None:
+    document = _document()
+    leaves = extract_comment_leaves(document)
+    plan = plan_import(leaves, {}, git_sha=SHA, created_at=NOW)
+
+    clean = verify_no_text_loss(plan, document)
+    assert all(result.ok for result in clean)
+
+    # Mutate one leaf in the independent re-read: that leaf must go red.
+    mutated = _document()
+    mutated["profiles"]["Costco Wholesale"]["_comment"] = COSTCO_COMMENT + " X"
+    reds = verify_no_text_loss(plan, mutated)
+    failed = {r.leaf_path for r in reds if not r.ok}
+    assert failed == {"profiles.Costco Wholesale._comment"}
+
+
+# --------------------------------------------------------------------------
+# CLI (injected git read + fake governed client)
+# --------------------------------------------------------------------------
+
+
+def _load_cli():
+    path = (
+        Path(__file__).resolve().parents[3]
+        / "scripts"
+        / "import_crosswalk_notes.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "import_crosswalk_notes", path
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+class _FakeManifest:
+    def __init__(self, git_sha: str) -> None:
+        self.provenance = {"git_sha": git_sha}
+
+
+class _FakeClient:
+    def __init__(self, seeded: dict[str, list] | None = None) -> None:
+        self.store: dict[str, list] = {
+            slug: list(items) for slug, items in (seeded or {}).items()
+        }
+        self.writes: list[MerchantTruthProposal] = []
+
+    def get_merchant_truth_manifest(self, slug: str, version: int):
+        return _FakeManifest(SHA)
+
+    def list_merchant_truth_proposals(self, slug: str):
+        return list(self.store.get(slug, []))
+
+    def add_proposal(
+        self, proposal: MerchantTruthProposal, table: str
+    ) -> None:
+        self.writes.append(proposal)
+        self.store.setdefault(proposal.slug, []).append(proposal)
+
+
+def _patch_cli(module, monkeypatch, client: _FakeClient) -> None:
+    monkeypatch.setattr(
+        module, "_git_show_document", lambda repo_root, git_sha: _document()
+    )
+    monkeypatch.setattr(module, "DynamoClient", lambda *a, **k: client)
+
+
+def test_cli_dry_run_is_write_free(monkeypatch) -> None:
+    module = _load_cli()
+    client = _FakeClient()
+    _patch_cli(module, monkeypatch, client)
+
+    rc = module.main(["--git-sha", SHA])
+
+    assert rc == 0
+    assert client.writes == []  # dry-run gate: nothing written
+
+
+def test_cli_prod_refusal_precedes_client(monkeypatch) -> None:
+    module = _load_cli()
+
+    def _explode(*_a, **_k):
+        raise AssertionError("client constructed before prod refusal")
+
+    monkeypatch.setattr(module, "DynamoClient", _explode)
+    monkeypatch.setattr(
+        module, "_git_show_document", lambda *a, **k: _document()
+    )
+
+    with pytest.raises(MerchantTruthTableMismatchError):
+        module.main(["--table", PROD_TABLE_NAME])
+
+
+def test_cli_apply_writes_then_idempotent(monkeypatch) -> None:
+    module = _load_cli()
+    client = _FakeClient()
+    _patch_cli(module, monkeypatch, client)
+
+    rc = module.main(["--git-sha", SHA, "--apply"])
+    assert rc == 0
+    # 4 leaves, none pre-existing, none covered -> 4 writes.
+    assert len(client.writes) == 4
+    written_slugs = {p.claim_slug for p in client.writes}
+    assert "profile-comment" in written_slugs
+
+    # Second apply against the now-populated store writes nothing new.
+    client.writes.clear()
+    rc2 = module.main(["--git-sha", SHA, "--apply"])
+    assert rc2 == 0
+    assert client.writes == []
+
+
+def test_cli_apply_references_existing_self_checkout(monkeypatch) -> None:
+    module = _load_cli()
+    seeded = {
+        "costco_wholesale": [
+            _seeded_proposal(
+                "costco_wholesale",
+                "self-checkout-layout-variant",
+                "Costco receipts have distinct formatting variants ...",
+            )
+        ]
+    }
+    client = _FakeClient(seeded)
+    _patch_cli(module, monkeypatch, client)
+
+    rc = module.main(
+        ["--git-sha", SHA, "--apply", "--merchants", "costco_wholesale"]
+    )
+    assert rc == 0
+    # _comment covered-by, so only layout + face comments are written.
+    written = {p.claim_slug for p in client.writes}
+    assert written == {
+        "layout-template-comment",
+        "typography-face-source-comment",
+    }

--- a/scripts/import_crosswalk_notes.py
+++ b/scripts/import_crosswalk_notes.py
@@ -13,11 +13,16 @@ Safety:
 * **Dry-run by default.** Nothing is written without ``--apply`` (owner-gated).
 * **Dev-pinned, prod refused unconditionally** *before* any boto3 client is
   built (the sibling ``migrate_merchant_truth_v1`` pattern).
-* **Idempotent.** A leaf whose claim_slug already exists is skipped; a leaf an
-  existing proposal already covers textually is referenced, not duplicated.
-* **Zero text loss.** The report diffs every extracted leaf against a fresh,
-  independent ``git show`` and requires byte-identical text before ``--apply``
-  writes anything.
+* **Every leaf persists.** Preservation never depends on a heuristic: each
+  extracted leaf writes its own full record. A leaf that is textually related
+  to an existing proposal is *annotated* with a ``related_to`` cross-reference,
+  not suppressed. The only non-writing disposition is an idempotent skip when
+  the leaf's claim_slug was already imported (its text already persists).
+* **Zero text loss = persistence.** The report re-extracts every leaf from a
+  fresh ``git show`` and asserts each maps to a record whose text is
+  byte-identical (a planless leaf fails), before ``--apply`` writes anything.
+  This proves extraction-faithfulness + envelope round-trip; the re-extract
+  shares the import walker, so it is not a database read-back.
 
 Examples::
 
@@ -43,7 +48,7 @@ from receipt_dynamo.migrations.crosswalk_notes import (
     ImportPlan,
     extract_comment_leaves,
     plan_import,
-    verify_no_text_loss,
+    verify_persistence,
 )
 from receipt_dynamo.migrations.merchant_truth_v1 import DEV_TABLE_NAME
 from receipt_dynamo.migrations.merchant_truth_v1_live import (
@@ -95,7 +100,8 @@ def _print_report(
     git_sha: str,
     apply: bool,
 ) -> bool:
-    """Print the full per-merchant report. Return True when text-loss is clean."""
+    """Print the full per-merchant report. Return True when every leaf's text
+    is verified to persist byte-identical."""
     mode = "APPLY" if apply else "DRY-RUN"
     print("=" * 72)
     print(f"import_crosswalk_notes  [{mode}]  table={table_name}")
@@ -116,11 +122,11 @@ def _print_report(
             leaf = decision.leaf
             if decision.action == "WRITE":
                 head = f"  [WOULD-WRITE] claim_slug={leaf.claim_slug}"
-            elif decision.action == "COVERED_BY":
-                head = (
-                    f"  [COVERED-BY]  {decision.covered_by} "
-                    f"(shared phrase: {decision.matched_phrase!r})"
-                )
+                if decision.related_to is not None:
+                    head += (
+                        f"  (related to: {decision.related_to}; "
+                        f"shared: {decision.matched_phrase!r})"
+                    )
             else:
                 head = f"  [SKIP-EXISTS] claim_slug={leaf.claim_slug}"
             print(head)
@@ -128,7 +134,15 @@ def _print_report(
             print(f"     text: {leaf.text!r}")
 
     print("\n" + "-" * 72)
-    print("ZERO-TEXT-LOSS VERIFICATION (vs independent git show)")
+    print("PERSISTENCE / EXTRACTION-FAITHFULNESS CHECK")
+    print(
+        "  (every extracted leaf must map to a record that persists its text "
+        "byte-identical;"
+    )
+    print(
+        "   extraction re-uses the import walker, so this proves round-trip "
+        "faithfulness, not a DB read-back)"
+    )
     print("-" * 72)
     clean = True
     for result in verifications:
@@ -141,9 +155,9 @@ def _print_report(
     print(
         f"SUMMARY: {len(plan.decisions)} leaves | "
         f"{len(plan.to_write)} to write | "
-        f"{len(plan.covered)} covered-by-existing | "
-        f"{len(plan.skipped)} already-imported | "
-        f"text-loss={'CLEAN' if clean else 'DIRTY'}"
+        f"{len(plan.related)} related-to-existing (annotated, not suppressed) "
+        f"| {len(plan.skipped)} already-imported | "
+        f"persistence={'CLEAN' if clean else 'DIRTY'}"
     )
     print("-" * 72)
     return clean
@@ -213,9 +227,12 @@ def main(argv: list[str] | None = None) -> int:
         leaves, existing_by_slug, git_sha=git_sha, created_at=created_at
     )
 
-    # Independent second read of the exact same source for the text-loss diff.
+    # Second read of the exact same source: re-extract the leaves and assert
+    # every one persists byte-identical in a scheduled record (no planless
+    # leaf), so preservation never depends on the relatedness heuristic.
     reference_document = _git_show_document(repo_root, git_sha)
-    verifications = verify_no_text_loss(plan, reference_document)
+    scope = {leaf.leaf_path for leaf in leaves}
+    verifications = verify_persistence(plan, reference_document, scope=scope)
 
     clean = _print_report(
         plan,
@@ -231,7 +248,8 @@ def main(argv: list[str] | None = None) -> int:
 
     if not clean:
         raise SystemExit(
-            "refusing to --apply: zero-text-loss verification failed"
+            "refusing to --apply: persistence verification failed "
+            "(a leaf's text would not persist byte-identical)"
         )
 
     written = 0

--- a/scripts/import_crosswalk_notes.py
+++ b/scripts/import_crosswalk_notes.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+"""Import discarded merchant-profile curator comments as PROPOSED records.
+
+The v1 MerchantTruth migration discarded every ``merchant_profiles.json``
+``_comment`` / ``_face_source_comment`` leaf as documentation-only. Contract
+§7.8 requires that curator knowledge - including the original Costco
+``SELF-CHECKOUT`` observation - to be preserved into the truth system as
+PROPOSED records. This script extracts those leaves *from git history* (the
+exact SHA the v1 mint recorded in provenance) and writes one PROPOSED record
+per leaf under the owning merchant's ``MERCHANT_TRUTH#{slug}`` partition.
+
+Safety:
+* **Dry-run by default.** Nothing is written without ``--apply`` (owner-gated).
+* **Dev-pinned, prod refused unconditionally** *before* any boto3 client is
+  built (the sibling ``migrate_merchant_truth_v1`` pattern).
+* **Idempotent.** A leaf whose claim_slug already exists is skipped; a leaf an
+  existing proposal already covers textually is referenced, not duplicated.
+* **Zero text loss.** The report diffs every extracted leaf against a fresh,
+  independent ``git show`` and requires byte-identical text before ``--apply``
+  writes anything.
+
+Examples::
+
+    # read-only dry run against dev (git + dev, no writes)
+    uv run scripts/import_crosswalk_notes.py
+
+    # owner apply to dev
+    uv run scripts/import_crosswalk_notes.py --apply
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+
+from botocore.exceptions import ClientError
+
+from receipt_dynamo import DynamoClient
+from receipt_dynamo.migrations.crosswalk_notes import (
+    ImportPlan,
+    extract_comment_leaves,
+    plan_import,
+    verify_no_text_loss,
+)
+from receipt_dynamo.migrations.merchant_truth_v1 import DEV_TABLE_NAME
+from receipt_dynamo.migrations.merchant_truth_v1_live import (
+    validate_live_table,
+)
+
+PROFILES_SOURCE_PATH = "scripts/merchant_profiles.json"
+GIT_SHA_MERCHANT = "costco_wholesale"  # v1 manifest carrying the mint git_sha
+
+
+def _git_show_document(repo_root: Path, git_sha: str) -> dict:
+    """Read the exact profile document out of git history at ``git_sha``."""
+    raw = subprocess.run(
+        ["git", "show", f"{git_sha}:{PROFILES_SOURCE_PATH}"],
+        cwd=repo_root,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    return json.loads(raw)
+
+
+def _resolve_v1_git_sha(client: DynamoClient, table_name: str) -> str:
+    """Read the git_sha the v1 mint recorded in provenance (contract §7.8).
+
+    The real run reads it live from the v1 manifest; tests seed the manifest
+    through moto and exercise the identical path.
+    """
+    manifest = client.get_merchant_truth_manifest(GIT_SHA_MERCHANT, 1)
+    if manifest is None:
+        raise SystemExit(
+            f"no v1 manifest for {GIT_SHA_MERCHANT!r} in {table_name!r}; "
+            "pass --git-sha explicitly"
+        )
+    git_sha = (manifest.provenance or {}).get("git_sha")
+    if not git_sha:
+        raise SystemExit(
+            f"v1 manifest for {GIT_SHA_MERCHANT!r} carries no git_sha "
+            "provenance; pass --git-sha explicitly"
+        )
+    return str(git_sha)
+
+
+def _print_report(
+    plan: ImportPlan,
+    verifications: list,
+    *,
+    table_name: str,
+    git_sha: str,
+    apply: bool,
+) -> bool:
+    """Print the full per-merchant report. Return True when text-loss is clean."""
+    mode = "APPLY" if apply else "DRY-RUN"
+    print("=" * 72)
+    print(f"import_crosswalk_notes  [{mode}]  table={table_name}")
+    print(f"source={PROFILES_SOURCE_PATH}@{git_sha}")
+    print("=" * 72)
+
+    by_merchant: dict[str, list] = {}
+    for decision in plan.decisions:
+        by_merchant.setdefault(decision.leaf.merchant_name, []).append(
+            decision
+        )
+
+    for merchant_name in sorted(by_merchant):
+        decisions = by_merchant[merchant_name]
+        slug = decisions[0].leaf.slug
+        print(f"\n### {merchant_name}  (MERCHANT_TRUTH#{slug})")
+        for decision in decisions:
+            leaf = decision.leaf
+            if decision.action == "WRITE":
+                head = f"  [WOULD-WRITE] claim_slug={leaf.claim_slug}"
+            elif decision.action == "COVERED_BY":
+                head = (
+                    f"  [COVERED-BY]  {decision.covered_by} "
+                    f"(shared phrase: {decision.matched_phrase!r})"
+                )
+            else:
+                head = f"  [SKIP-EXISTS] claim_slug={leaf.claim_slug}"
+            print(head)
+            print(f"     leaf_path: {leaf.leaf_path}")
+            print(f"     text: {leaf.text!r}")
+
+    print("\n" + "-" * 72)
+    print("ZERO-TEXT-LOSS VERIFICATION (vs independent git show)")
+    print("-" * 72)
+    clean = True
+    for result in verifications:
+        flag = "PASS" if result.ok else "FAIL"
+        if not result.ok:
+            clean = False
+        print(f"  [{flag}] {result.leaf_path}  ({result.detail})")
+
+    print("\n" + "-" * 72)
+    print(
+        f"SUMMARY: {len(plan.decisions)} leaves | "
+        f"{len(plan.to_write)} to write | "
+        f"{len(plan.covered)} covered-by-existing | "
+        f"{len(plan.skipped)} already-imported | "
+        f"text-loss={'CLEAN' if clean else 'DIRTY'}"
+    )
+    print("-" * 72)
+    return clean
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--table",
+        "--table-name",
+        dest="table_name",
+        default=None,
+        help=(
+            f"DynamoDB table (default: exact dev table {DEV_TABLE_NAME}). "
+            "The prod table is refused unconditionally; any other table "
+            "requires passing --table explicitly."
+        ),
+    )
+    parser.add_argument("--region", default="us-east-1")
+    parser.add_argument(
+        "--git-sha",
+        help=(
+            "Profile SHA to read from git history (default: the git_sha the "
+            "v1 mint recorded in the Costco v1 manifest provenance)."
+        ),
+    )
+    parser.add_argument(
+        "--merchants",
+        help="Comma-separated merchant slugs to restrict the run to.",
+    )
+    parser.add_argument("--created-at")
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help=(
+            "Owner-gated: write the planned PROPOSED records. Without this "
+            "flag no DynamoDB write ever happens."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    explicit_table = args.table_name is not None
+    table_name = args.table_name or DEV_TABLE_NAME
+    # Unconditional on every path (dry run included): prod refusal precedes
+    # the boto3 client and any read.
+    validate_live_table(table_name, explicit=explicit_table)
+
+    repo_root = Path(__file__).resolve().parents[1]
+    created_at = args.created_at or datetime.now(timezone.utc).isoformat()
+
+    client = DynamoClient(table_name, region=args.region)
+    git_sha = args.git_sha or _resolve_v1_git_sha(client, table_name)
+
+    document = _git_show_document(repo_root, git_sha)
+    leaves = extract_comment_leaves(document)
+    if args.merchants:
+        wanted = {
+            slug.strip() for slug in args.merchants.split(",") if slug.strip()
+        }
+        leaves = [leaf for leaf in leaves if leaf.slug in wanted]
+
+    existing_by_slug: dict[str, list] = {}
+    for slug in {leaf.slug for leaf in leaves}:
+        existing_by_slug[slug] = client.list_merchant_truth_proposals(slug)
+
+    plan = plan_import(
+        leaves, existing_by_slug, git_sha=git_sha, created_at=created_at
+    )
+
+    # Independent second read of the exact same source for the text-loss diff.
+    reference_document = _git_show_document(repo_root, git_sha)
+    verifications = verify_no_text_loss(plan, reference_document)
+
+    clean = _print_report(
+        plan,
+        verifications,
+        table_name=table_name,
+        git_sha=git_sha,
+        apply=args.apply,
+    )
+
+    if not args.apply:
+        print("\nDRY-RUN: no writes. Re-run with --apply (owner) to persist.")
+        return 0 if clean else 2
+
+    if not clean:
+        raise SystemExit(
+            "refusing to --apply: zero-text-loss verification failed"
+        )
+
+    written = 0
+    skipped = 0
+    for decision in plan.to_write:
+        assert decision.proposal is not None
+        try:
+            client.add_proposal(decision.proposal, table_name)
+            written += 1
+            print(f"  wrote {decision.leaf.slug}#{decision.leaf.claim_slug}")
+        except ClientError as error:
+            code = error.response.get("Error", {}).get("Code")
+            if code == "ConditionalCheckFailedException":
+                skipped += 1  # idempotent: another run already created it
+                print(
+                    f"  exists {decision.leaf.slug}#{decision.leaf.claim_slug}"
+                )
+            else:
+                raise
+    print(f"\nAPPLIED: {written} written, {skipped} already-present.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## W-I — Crosswalk notes → proposals

Implements **W-I** from the Costco-Complete-in-Dynamo plan (`humble-skipping-quilt.md`): the v1 MerchantTruth migration classified every `merchant_profiles.json` `_comment` / `_face_source_comment` leaf as `discarded-with-reason`. Per **contract §7.8** that curator knowledge — including the original Costco `SELF-CHECKOUT` observation — must be preserved into the truth system as **PROPOSED** records, not left only in git history.

### What it does
`scripts/import_crosswalk_notes.py` (pure logic in `receipt_dynamo/migrations/crosswalk_notes.py`):

1. **Extract from git history** at the exact SHA the v1 mint recorded in provenance. The real run reads `git_sha` live from the Costco v1 manifest provenance (`eb9d3617122b…`); tests seed it via moto. Walks every `*_comment` leaf per merchant → `{slug, leaf_path, verbatim text}`.
2. **One PROPOSED record per leaf** under the owning `MERCHANT_TRUTH#{slug}`, via the governed `add_proposal` accessor. `claim` is a canonical JSON envelope `{provenance, text[, related_to]}` (the entity has no provenance field); `text` is byte-exact; `claim_slug` derived from the leaf path (stable, deduplicatable).
3. **Every leaf persists — relatedness is a non-suppressing annotation.** Preservation never depends on a heuristic: each extracted leaf writes its own full record. When an existing proposal is textually related (a shared distinctive hyphenated compound like `self-checkout`, or a shared contiguous ≥3-token phrase — `MIN_COVERAGE_NGRAM=3`, so common bigrams like `font size` don't trip it), the written record is **annotated** with a `related_to` cross-reference rather than dropped. So the multi-topic Costco `_comment` (font + condense + footer + self-checkout) writes in full, referencing `self-checkout-layout-variant`. The only non-writing disposition is an **idempotent skip** when a leaf's `claim_slug` was already imported.
4. **Dry-run default**, full per-merchant report; `--apply` owner-gated; **dev-pinned with unconditional prod refusal before any client is built** (sibling `migrate_merchant_truth_v1` pattern).
5. **Zero-text-loss = persistence.** `verify_persistence` re-extracts every in-scope leaf from a fresh `git show` and asserts each maps to a record whose text is byte-identical; a **planless leaf fails**, making the covered-but-unwritten suppression class structurally impossible, and `--apply` refuses on any drift. Honest framing: this proves extraction-faithfulness + envelope round-trip (the re-extract shares the import walker), not a database read-back.

### Real read-only dry-run (git + dev)
**22 leaves | 22 to-write | 0 suppressed | 1 related-to-existing** (Costco `_comment` → `related_to=self-checkout-layout-variant`, shared compound `self-checkout`) | 0 already-imported | persistence **CLEAN**. Per merchant: Costco 3 writes (one annotated); Dollar Tree / Gelson's / The Stand / Wild Fork 2 each; all others 1.

### Staged owner apply (dev)
```
uv run scripts/import_crosswalk_notes.py --apply
```

### Tests (48 pass in this package area)
Git-free extraction fixture; related leaf still WRITES with reference; common-bigram (`font size`) does NOT relate; idempotent re-run skips; dry-run write-free; prod refusal precedes client; persistence red on a planless leaf and on a mutated source leaf; moto integration exercises `git_sha` resolution + governed apply + idempotency + `related_to` persistence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BeLcSviHL5vDgS3zTSMbsq

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a migration tool to import previously discarded merchant profile comments as proposed merchant-truth records.
  * Supports dry-run previews, merchant filtering, provenance tracking, related-claim linking, and persistence verification.
  * Added idempotent imports that skip records already present.
  * Added safeguards preventing writes when source content cannot be verified or production access is unsafe.

* **Tests**
  * Added unit and integration coverage for extraction, relationships, verification, dry runs, persistence, and repeat imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->