### PR TITLE
[scripts] mint_merchant_truth_v2: measurement mint + eval-gated seal (W-J)

### DIFF
--- a/docs/architecture/MERCHANT_TRUTH_DYNAMO.md
+++ b/docs/architecture/MERCHANT_TRUTH_DYNAMO.md
@@ -610,7 +610,8 @@ optional key is added:
   canonical section sequence.
 - `text_marker` — args `{"tokens": [...normalized tokens...]}`; matches when
   every token is present in the receipt's **normalized OCR word set**
-  (upper-cased, punctuation-stripped).
+  (upper-cased, punctuation-tokenized — split on non-alphanumerics, matching
+  the shipped selector).
 
 Readers match hints against exactly those two inputs — the canonical
 section sequence for the `section_*` types, the normalized OCR word set for
@@ -638,6 +639,15 @@ This sanctions W-J minting the distinction into Costco v2 and W-K making
 the renderer shim **version-conditional**: the shim stays for v1 bundles
 and is dropped for v2+ bundles, which are trusted to mean exactly what they
 say.
+
+**Provenance of a re-encoding.** A §7.3 representation migration of a
+v1-measured component is minted `source_kind=measurement` with a `pipeline`
+naming the migration (e.g. `v1-representation-migration`), a `derived_from`
+block recording the v1 payload hash, and `measured_at` = the migration time;
+it is **neither the legacy escape nor a carry** (§7.7). Re-encoding
+`section_scale` changes the payload hash, so the carry rule (hash-match
+required) cannot apply, and the re-encoded values are still measurement-derived
+truth — the `provenance_completeness=legacy` escape is forbidden here (§7.7).
 
 ### 7.4 Version-number readers
 
@@ -710,7 +720,11 @@ the merchant partition:
   `{metric, verdict, detail}` entries — exactly the non-PASS subset of the
   `per_metric` verdicts (which remain the full picture); this is the same
   gap list §7.5 requires verbatim, so the §7.5 invariant applies: `overall
-  == "PASS_WITH_GAPS"` iff `gaps` is non-empty.
+  == "PASS_WITH_GAPS"` iff `gaps` is non-empty. A record MAY also carry an
+  optional `coverage` field — the sub-metric coverage paths (`checks
+  ["coverage_gaps"]`) that flagged incomplete coverage; these are **kept out
+  of `gaps`** (they are not per-metric verdicts) and never perturb the §7.5
+  invariant.
 - **Append-only:** conditional create
   (`attribute_not_exists(PK) AND attribute_not_exists(SK)`); no
   update/delete accessor, same discipline as components.

--- a/receipt_dynamo/tests/integration/test_mint_merchant_truth_v2.py
+++ b/receipt_dynamo/tests/integration/test_mint_merchant_truth_v2.py
@@ -1,0 +1,584 @@
+"""Moto coverage for the W-J v2 mint driver (scripts/mint_merchant_truth_v2.py).
+
+The driver is a top-level script (not a package module); it is loaded from its
+path and it inserts ``scripts/`` + repo root onto ``sys.path`` for its sibling
+imports (merchant_truth_diff, the renderer shim registry). These tests exercise
+the whole contract-section-7 ceremony against a real moto partition:
+
+- full assembly with a populated catalog + a live PASS seal;
+- carried-component hash + provenance faithfulness, and the mutation refusal;
+- the section-7.3 typography encoding in both directions;
+- proposal-resolution idempotency;
+- the empty-catalog dry-run warning (no writes, no hard block);
+- a FAIL gate leaving the version OPEN with the gate record as the work list;
+- the live banner + prod refusal.
+
+No live writes and no real fidelity eval run: the eval is injected.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+from types import SimpleNamespace
+
+import pytest
+
+from receipt_dynamo import DynamoClient
+from receipt_dynamo.entities.merchant_catalog_item import MerchantCatalogItem
+from receipt_dynamo.entities.merchant_truth import (
+    COMPONENT_NAMES,
+    MerchantTruthComponent,
+    MerchantTruthProposal,
+)
+from receipt_dynamo.entities.merchant_truth_gate import (
+    MerchantTruthGateRecord,
+)
+
+pytestmark = pytest.mark.integration
+
+_HERE = os.path.dirname(__file__)
+_REPO = os.path.abspath(os.path.join(_HERE, "..", "..", ".."))
+_DRIVER_PATH = os.path.join(_REPO, "scripts", "mint_merchant_truth_v2.py")
+
+
+def _load_driver():
+    spec = importlib.util.spec_from_file_location(
+        "mint_merchant_truth_v2", _DRIVER_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+mint = _load_driver()
+
+SLUG = "costco_wholesale"
+MERCHANT = "Costco Wholesale"
+NOW = "2026-07-22T16:00:00+00:00"
+PROPOSAL = "self-checkout-layout-variant"
+
+LEGACY_PROVENANCE = {
+    "source_kind": "migration",
+    "provenance_completeness": "legacy",
+    "written_by": {
+        "kind": "migration",
+        "name": "merchant_truth_v1",
+        "version": "1",
+    },
+    "source_path": "scripts/merchant_profiles.json",
+    "git_sha": "v1sha",
+    "measured_at": None,
+    "source_receipt_keys": [],
+}
+
+
+def _v1_payload(name: str) -> dict:
+    if name == "typography":
+        return {
+            "typography": {"cap_h": 12, "advance_ratio": 0.5},
+            "section_scale": {},
+        }
+    if name == "layout":
+        return {"available": False, "template": None}
+    if name == "catalog_snapshot":
+        return {
+            "items": [],
+            "item_count": 0,
+            "catalog_hash": "0",
+            "as_of": NOW,
+        }
+    if name == "identity":
+        return {
+            "slug": SLUG,
+            "merchant_name": MERCHANT,
+            "normalized_aliases": [SLUG],
+        }
+    return {"component": name, "v": 1}
+
+
+def _v1_components() -> list[MerchantTruthComponent]:
+    return [
+        MerchantTruthComponent(
+            slug=SLUG,
+            version=1,
+            name=name,
+            payload=_v1_payload(name),
+            provenance=dict(LEGACY_PROVENANCE),
+        )
+        for name in sorted(COMPONENT_NAMES)
+    ]
+
+
+def _seal_v1(client: DynamoClient, table: str) -> None:
+    client.mint_version(
+        SLUG,
+        1,
+        _v1_components(),
+        {"written_by": {"kind": "migration", "name": "v1", "version": "1"}},
+        "run-v1",
+        table,
+        created_at=NOW,
+    )
+    client.seal_version(
+        SLUG,
+        1,
+        {"status": "PASS", "passed": True},
+        [],
+        table,
+        sealed_at=NOW,
+    )
+
+
+def _seed_catalog(client: DynamoClient, table: str, *, count: int = 3) -> None:
+    items = [
+        MerchantCatalogItem(
+            merchant_name=MERCHANT,
+            product_text=f"KS ITEM {i}",
+            price=f"{i}.99",
+            category="GROCERY",
+            taxable=False,
+            source="observed",
+            observed_count=i + 1,
+            source_receipt_keys=[f"img{i}#0000{i}"],
+            last_updated=NOW,
+        )
+        for i in range(1, count + 1)
+    ]
+    client.add_merchant_catalog_items(items)
+
+
+def _seed_proposal(client: DynamoClient, table: str) -> None:
+    client.add_proposal(
+        MerchantTruthProposal(
+            slug=SLUG,
+            created_at="2026-07-01T00:00:00+00:00",
+            claim_slug=PROPOSAL,
+            claim="register vs self-checkout formatting",
+        ),
+        table,
+    )
+
+
+VARIANT_PAYLOAD = {
+    "template": {
+        "version": 1,
+        "columns": {"items": [{"role": "name", "anchor": "left", "x": 0.1}]},
+        "sections": [{"name": "items", "pos_frac_med": 0.5, "support": 20}],
+        "separators": [],
+        "variant_id": "default",
+        "support": 24,
+        "source_receipt_keys": [
+            "IMAGE#a#RECEIPT#00001",
+            "IMAGE#b#RECEIPT#00001",
+        ],
+        "variants": [],
+    },
+    "verdict": {
+        "proposal": PROPOSAL,
+        "status": "REFUTE",
+        "reason": "single stable cluster",
+        "clusters": [
+            {
+                "variant_id": "default",
+                "support": 24,
+                "receipt_refs": [
+                    "IMAGE#a#RECEIPT#00001",
+                    "IMAGE#b#RECEIPT#00001",
+                ],
+            }
+        ],
+    },
+    "provenance": {
+        "source_kind": "measurement",
+        "pipeline": "build_variant_layout",
+        "pipeline_version": "1",
+        "git_sha": "wgsha",
+        "measured_at": "2026-07-22T07:00:00+00:00",
+        "source_receipt_keys": [
+            "IMAGE#a#RECEIPT#00001",
+            "IMAGE#b#RECEIPT#00001",
+        ],
+        "excluded_receipt_keys": [
+            {"receipt_key": "IMAGE#c", "reason": "PHOTO"}
+        ],
+        "params": {"threshold": 0.18},
+    },
+}
+
+
+def _args(table: str, **overrides) -> SimpleNamespace:
+    base = dict(
+        merchant=MERCHANT,
+        slug=SLUG,
+        layout_payload=None,  # set per-test via a temp file
+        from_version=None,
+        proposal=PROPOSAL,
+        table_name=table,
+        git_sha="v2sha",
+        generated_at=NOW,
+        eval_image_id=None,
+        eval_receipt_id=None,
+        eval_out_root=".out",
+        allow_dirty=False,
+        live=False,
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+@pytest.fixture
+def layout_file(tmp_path):
+    import json
+
+    path = tmp_path / "variant.json"
+    path.write_text(json.dumps(VARIANT_PAYLOAD))
+    return str(path)
+
+
+def _pass_eval(**kwargs):
+    return {
+        "columns": {"verdict": "PASS"},
+        "tokens": {"verdict": "PASS"},
+        "separators": {"verdict": "PASS"},
+        "logo": {"verdict": "PASS"},
+        "arithmetic": {"verdict": "PASS"},
+        "overall": "PASS",
+        "coverage_gaps": [],
+    }
+
+
+def _gaps_eval(**kwargs):
+    return {
+        "columns": {"verdict": "PASS"},
+        "tokens": {"verdict": "PASS_WITH_GAPS", "detail": "1 token missing"},
+        "overall": "PASS_WITH_GAPS",
+        "coverage_gaps": ["logo"],
+    }
+
+
+def _fail_eval_factory(table: str):
+    def runner(*, components, slug, version, **kwargs):
+        # Simulate `full_fidelity_eval --write-gate-record`: persist the gate
+        # record for the failing run BEFORE returning the checks, so the driver
+        # bridge finds a durable work list.
+        client = DynamoClient(table)
+        client.add_gate_record(
+            MerchantTruthGateRecord(
+                slug=slug,
+                run_at="2026-07-22T18:00:00+00:00",
+                version=version,
+                bundle_hash=mint.bundle_hash_of(components),
+                eval_git_sha="evalsha",
+                overall="FAIL",
+                per_metric=[
+                    {"metric": "columns", "verdict": "FAIL"},
+                    {"metric": "tokens", "verdict": "PASS"},
+                ],
+                gaps=[
+                    {
+                        "metric": "columns",
+                        "verdict": "FAIL",
+                        "detail": {"note": "lane drift"},
+                    }
+                ],
+                coverage=["logo"],
+                evidence_refs=["s3://eval/costco.checks.json"],
+                receipt_tested={"merchant": MERCHANT},
+            ),
+            table,
+        )
+        return {
+            "columns": {"verdict": "FAIL", "note": "lane drift"},
+            "tokens": {"verdict": "PASS"},
+            "overall": "FAIL",
+            "coverage_gaps": ["logo"],
+        }
+
+    return runner
+
+
+# --------------------------------------------------------------------------
+
+
+def test_full_assembly_and_pass_seal(dynamodb_table, layout_file):
+    client = DynamoClient(dynamodb_table)
+    _seal_v1(client, dynamodb_table)
+    _seed_catalog(client, dynamodb_table, count=3)
+    _seed_proposal(client, dynamodb_table)
+
+    args = _args(
+        dynamodb_table,
+        layout_payload=layout_file,
+        live=True,
+        eval_image_id="IMG",
+        eval_receipt_id=1,
+    )
+    rc = mint.run(args, eval_runner=_pass_eval)
+    assert rc == 0
+
+    v2 = client.get_merchant_truth_manifest(SLUG, 2, consistent_read=True)
+    assert v2 is not None and v2.status == "SEALED"
+    components = {
+        c.name: c
+        for c in client.list_merchant_truth_components(
+            SLUG, 2, consistent_read=True
+        )
+    }
+    assert set(components) == COMPONENT_NAMES
+
+    # Carried components are hash-identical to v1 and carry the marker.
+    v1 = {c.name: c for c in _v1_components()}
+    for name in mint.CARRIED_COMPONENTS:
+        assert components[name].content_hash == v1[name].content_hash
+        assert components[name].provenance["carried_forward_from"] == "v1"
+
+    # Measured catalog snapshot inlines the live rows.
+    snap = components["catalog_snapshot"].payload
+    assert snap["item_count"] == 3
+    assert (
+        components["catalog_snapshot"].provenance["source_kind"]
+        == "measurement"
+    )
+
+    # Layout carries the variant template + the resolved verdict evidence.
+    assert components["layout"].payload["template"]["variant_id"] == "default"
+    assert components["layout"].provenance["verdict"]["status"] == "REFUTE"
+
+    # Proposal resolved to MEASURED_IN_CANDIDATE by v2.
+    props = {
+        p.claim_slug: p for p in client.list_merchant_truth_proposals(SLUG)
+    }
+    assert props[PROPOSAL].status == "MEASURED_IN_CANDIDATE"
+    assert props[PROPOSAL].resolution == "refuted"
+    assert props[PROPOSAL].resolved_by_version == 2
+
+
+def test_carry_mutation_rejected():
+    src = MerchantTruthComponent(
+        slug=SLUG,
+        version=1,
+        name="identity",
+        payload={"slug": SLUG},
+        provenance=dict(LEGACY_PROVENANCE),
+    )
+    faithful = mint.carry_component(src, 2)
+    mint.assert_carry_faithful(faithful, src)  # no raise
+
+    # A carry that stamps a fresh measured_at is the carry-that-lies hole.
+    lying = MerchantTruthComponent(
+        slug=SLUG,
+        version=2,
+        name="identity",
+        payload={"slug": SLUG},
+        provenance={
+            **dict(LEGACY_PROVENANCE),
+            "carried_forward_from": "v1",
+            "measured_at": NOW,
+        },
+    )
+    with pytest.raises(mint.MintError, match="carry-that-lies"):
+        mint.assert_carry_faithful(lying, src)
+
+    # A payload edit under a carry marker is also refused.
+    edited = MerchantTruthComponent(
+        slug=SLUG,
+        version=2,
+        name="identity",
+        payload={"slug": SLUG, "extra": 1},
+        provenance={**dict(LEGACY_PROVENANCE), "carried_forward_from": "v1"},
+    )
+    with pytest.raises(mint.MintError, match="hash-preserving"):
+        mint.assert_carry_faithful(edited, src)
+
+
+def test_typography_section_scale_both_cases():
+    v1typ = MerchantTruthComponent(
+        slug=SLUG,
+        version=1,
+        name="typography",
+        payload={"typography": {"cap_h": 12}, "section_scale": {}},
+        provenance=dict(LEGACY_PROVENANCE),
+    )
+    # Costco is NOT in the shim registry -> absent (default HEADER shrink).
+    comp, rule = mint.build_typography_component(
+        SLUG,
+        2,
+        v1typ,
+        explicit_empty=False,
+        corpus_source_receipt_keys=["IMAGE#a#RECEIPT#00001"],
+        git_sha="s",
+        generated_at=NOW,
+    )
+    assert rule == "absent_default"
+    assert "section_scale" not in comp.payload
+    # Not the legacy escape: fresh measurement provenance recording v1's hash.
+    assert comp.provenance["written_by"]["kind"] == "measurement_pipeline"
+    assert comp.provenance["source_kind"] == "measurement"
+    assert comp.provenance.get("provenance_completeness") != "legacy"
+    assert (
+        comp.provenance["derived_from"]["payload_hash"] == v1typ.content_hash
+    )
+    assert comp.provenance["source_receipt_keys"] == ["IMAGE#a#RECEIPT#00001"]
+
+    # A registry merchant -> explicit uniform {} present.
+    comp2, rule2 = mint.build_typography_component(
+        "in_n_out_burger",
+        2,
+        v1typ,
+        explicit_empty=True,
+        corpus_source_receipt_keys=["IMAGE#a#RECEIPT#00001"],
+        git_sha="s",
+        generated_at=NOW,
+    )
+    assert rule2 == "explicit_uniform"
+    assert comp2.payload["section_scale"] == {}
+
+
+def test_proposal_resolution_idempotent(dynamodb_table):
+    client = DynamoClient(dynamodb_table)
+    _seed_proposal(client, dynamodb_table)
+    verdict = VARIANT_PAYLOAD["verdict"]
+
+    first = mint.resolve_layout_proposal(
+        client,
+        dynamodb_table,
+        SLUG,
+        verdict=verdict,
+        version=2,
+        proposal_claim=PROPOSAL,
+    )
+    assert "refuted" in first
+
+    second = mint.resolve_layout_proposal(
+        client,
+        dynamodb_table,
+        SLUG,
+        verdict=verdict,
+        version=2,
+        proposal_claim=PROPOSAL,
+    )
+    assert "idempotent skip" in second
+
+    # An absent proposal is reported, not an error.
+    absent = mint.resolve_layout_proposal(
+        client,
+        dynamodb_table,
+        SLUG,
+        verdict=verdict,
+        version=2,
+        proposal_claim="no-such-proposal",
+    )
+    assert "nothing to resolve" in absent
+
+
+def test_empty_catalog_dry_run_warns_no_writes(
+    dynamodb_table, layout_file, capsys
+):
+    client = DynamoClient(dynamodb_table)
+    _seal_v1(client, dynamodb_table)
+    # No catalog seeded -> empty partition.
+    args = _args(dynamodb_table, layout_payload=layout_file, live=False)
+    rc = mint.run(args)
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "partition for 'costco_wholesale' is EMPTY" in out
+    assert "DRY RUN" in out
+    # No v2 written.
+    assert (
+        client.get_merchant_truth_manifest(SLUG, 2, consistent_read=True)
+        is None
+    )
+
+
+def test_fail_gate_leaves_open(dynamodb_table, layout_file, capsys):
+    client = DynamoClient(dynamodb_table)
+    _seal_v1(client, dynamodb_table)
+    _seed_catalog(client, dynamodb_table, count=2)
+    _seed_proposal(client, dynamodb_table)
+
+    args = _args(
+        dynamodb_table,
+        layout_payload=layout_file,
+        live=True,
+        eval_image_id="IMG",
+        eval_receipt_id=1,
+    )
+    rc = mint.run(args, eval_runner=_fail_eval_factory(dynamodb_table))
+    assert rc == 3  # documented mintable-when-fixed state
+
+    v2 = client.get_merchant_truth_manifest(SLUG, 2, consistent_read=True)
+    assert v2 is not None and v2.status == "OPEN"  # left OPEN, not sealed
+
+    # The gate record persists as the work list.
+    gate_records = client.list_gate_records(SLUG)
+    assert any(r.overall == "FAIL" and r.version == 2 for r in gate_records)
+    out = capsys.readouterr().out
+    assert "GATE FAILED" in out and "stays OPEN" in out
+
+
+def test_pass_with_gaps_seals(dynamodb_table, layout_file):
+    client = DynamoClient(dynamodb_table)
+    _seal_v1(client, dynamodb_table)
+    _seed_catalog(client, dynamodb_table, count=1)
+    _seed_proposal(client, dynamodb_table)
+
+    args = _args(
+        dynamodb_table,
+        layout_payload=layout_file,
+        live=True,
+        eval_image_id="IMG",
+        eval_receipt_id=1,
+    )
+    rc = mint.run(args, eval_runner=_gaps_eval)
+    assert rc == 0
+    v2 = client.get_merchant_truth_manifest(SLUG, 2, consistent_read=True)
+    assert v2.status == "SEALED"
+    assert v2.gate_results["overall"] == "PASS_WITH_GAPS"
+    assert len(v2.gate_results["gaps"]) == 1  # gaps recorded verbatim
+
+
+def test_live_banner_and_prod_refusal(dynamodb_table, layout_file, capsys):
+    from receipt_dynamo.data.shared_exceptions import (
+        MerchantTruthTableMismatchError,
+    )
+    from receipt_dynamo.migrations.merchant_truth_v1_live import (
+        PROD_TABLE_NAME,
+    )
+
+    # Prod table is refused unconditionally in live mode.
+    prod_args = _args(
+        PROD_TABLE_NAME,
+        layout_payload=layout_file,
+        live=True,
+        eval_image_id="IMG",
+        eval_receipt_id=1,
+    )
+    with pytest.raises(MerchantTruthTableMismatchError):
+        mint.run(prod_args, eval_runner=_pass_eval)
+
+    # The live banner is printed on the real ceremony.
+    client = DynamoClient(dynamodb_table)
+    _seal_v1(client, dynamodb_table)
+    _seed_catalog(client, dynamodb_table, count=1)
+    _seed_proposal(client, dynamodb_table)
+    ok_args = _args(
+        dynamodb_table,
+        layout_payload=layout_file,
+        live=True,
+        eval_image_id="IMG",
+        eval_receipt_id=1,
+    )
+    mint.run(ok_args, eval_runner=_pass_eval)
+    out = capsys.readouterr().out
+    assert "LIVE MERCHANT-TRUTH V2 MINT" in out
+    assert dynamodb_table in out
+
+
+def test_live_requires_eval_target(dynamodb_table, layout_file):
+    client = DynamoClient(dynamodb_table)
+    _seal_v1(client, dynamodb_table)
+    _seed_catalog(client, dynamodb_table, count=1)
+    args = _args(dynamodb_table, layout_payload=layout_file, live=True)
+    with pytest.raises(SystemExit, match="eval-image-id"):
+        mint.run(args, eval_runner=_pass_eval)

--- a/receipt_dynamo/tests/integration/test_mint_merchant_truth_v2.py
+++ b/receipt_dynamo/tests/integration/test_mint_merchant_truth_v2.py
@@ -391,6 +391,17 @@ def test_carry_mutation_rejected():
     with pytest.raises(mint.MintError, match="hash-preserving"):
         mint.assert_carry_faithful(edited, src)
 
+    # The marker must name the EXACT source version, not merely be v-prefixed.
+    wrong_version = MerchantTruthComponent(
+        slug=SLUG,
+        version=2,
+        name="identity",
+        payload={"slug": SLUG},
+        provenance={**dict(LEGACY_PROVENANCE), "carried_forward_from": "v2"},
+    )
+    with pytest.raises(mint.MintError, match="exact source version"):
+        mint.assert_carry_faithful(wrong_version, src)
+
 
 def test_typography_section_scale_both_cases():
     v1typ = MerchantTruthComponent(
@@ -491,6 +502,40 @@ def test_empty_catalog_dry_run_warns_no_writes(
     )
 
 
+def test_empty_catalog_live_refused_by_governance(dynamodb_table, layout_file):
+    """--live with an empty catalog partition is refused (governance-correct).
+
+    An empty ``catalog_snapshot`` is ``source_kind=measurement`` with no
+    ``source_receipt_keys``; ``mint_version`` validates every component BEFORE
+    any write, so the mint is rejected with zero writes. The owner must run
+    ``ingest_merchant_catalog --apply`` first (the dry-run warns loudly).
+    """
+    from receipt_dynamo.data.shared_exceptions import (
+        MerchantTruthIntegrityError,
+    )
+
+    client = DynamoClient(dynamodb_table)
+    _seal_v1(client, dynamodb_table)
+    # No catalog seeded -> empty partition.
+    args = _args(
+        dynamodb_table,
+        layout_payload=layout_file,
+        live=True,
+        eval_image_id="IMG",
+        eval_receipt_id=1,
+    )
+    with pytest.raises(
+        MerchantTruthIntegrityError, match="source_receipt_keys"
+    ):
+        mint.run(args, eval_runner=_pass_eval)
+
+    # Zero writes: no OPEN v2 manifest landed.
+    assert (
+        client.get_merchant_truth_manifest(SLUG, 2, consistent_read=True)
+        is None
+    )
+
+
 def test_fail_gate_leaves_open(dynamodb_table, layout_file, capsys):
     client = DynamoClient(dynamodb_table)
     _seal_v1(client, dynamodb_table)
@@ -539,14 +584,11 @@ def test_pass_with_gaps_seals(dynamodb_table, layout_file):
 
 
 def test_live_banner_and_prod_refusal(dynamodb_table, layout_file, capsys):
-    from receipt_dynamo.data.shared_exceptions import (
-        MerchantTruthTableMismatchError,
-    )
     from receipt_dynamo.migrations.merchant_truth_v1_live import (
         PROD_TABLE_NAME,
     )
 
-    # Prod table is refused unconditionally in live mode.
+    # Prod is refused unconditionally by marker substring on EVERY path.
     prod_args = _args(
         PROD_TABLE_NAME,
         layout_payload=layout_file,
@@ -554,8 +596,13 @@ def test_live_banner_and_prod_refusal(dynamodb_table, layout_file, capsys):
         eval_image_id="IMG",
         eval_receipt_id=1,
     )
-    with pytest.raises(MerchantTruthTableMismatchError):
+    with pytest.raises(SystemExit, match="prod table"):
         mint.run(prod_args, eval_runner=_pass_eval)
+
+    # ... including the dry-run read path, and a prod-suffixed variant.
+    prod_dry = _args(f"ReceiptsTable-{mint._PROD_MARKER}-shadow", live=False)
+    with pytest.raises(SystemExit, match="prod table"):
+        mint.run(prod_dry, eval_runner=_pass_eval)
 
     # The live banner is printed on the real ceremony.
     client = DynamoClient(dynamodb_table)

--- a/scripts/mint_merchant_truth_v2.py
+++ b/scripts/mint_merchant_truth_v2.py
@@ -111,6 +111,11 @@ DEFAULT_LAYOUT_PAYLOAD = os.path.join(
     "costco_variant_layout.sample.json",
 )
 DEFAULT_PROPOSAL = "self-checkout-layout-variant"
+# The prod-table marker: the same substring the eval's gate-write refusal uses
+# (``full_fidelity_eval._GATE_PROD_MARKER``), so the prod refusal is a
+# marker-substring check on EVERY path here (dry-run read and live write), not
+# an exact-name match that a prod-suffixed variant could slip past.
+_PROD_MARKER = PROD_TABLE_NAME.rsplit("-", 1)[-1]
 DRIVER_NAME = "mint_merchant_truth_v2"
 DRIVER_VERSION = "2"
 
@@ -127,6 +132,23 @@ class MintError(RuntimeError):
 # --------------------------------------------------------------------------
 # Small helpers
 # --------------------------------------------------------------------------
+
+
+def _refuse_prod(table: str) -> None:
+    """Refuse the prod table on EVERY path by a marker-substring check.
+
+    Prod promotion is a separate owner-gated step; the driver never reads or
+    writes prod. This mirrors ``validate_live_table`` (exact prod name) but
+    uses the same marker substring the eval's gate-write refusal does, so a
+    prod-suffixed table variant is refused too -- identical semantics on the
+    dry-run read path and the live write path.
+    """
+    if table == PROD_TABLE_NAME or _PROD_MARKER in table:
+        raise SystemExit(
+            f"refusing to target the prod table {table!r} (marker "
+            f"{_PROD_MARKER!r}); prod is a separate owner-gated step and this "
+            "refusal is unconditional on every path"
+        )
 
 
 def _git_sha(explicit: str | None) -> str:
@@ -191,10 +213,12 @@ def assert_carry_faithful(
             "a carry must be hash-preserving (section 7.7)"
         )
     marker = candidate.provenance.get("carried_forward_from")
-    if not (isinstance(marker, str) and marker.startswith("v")):
+    expected_marker = f"v{source.version}"
+    if marker != expected_marker:
         raise MintError(
-            f"carry of {candidate.name!r} is missing a valid "
-            "carried_forward_from marker (section 7.7)"
+            f"carry of {candidate.name!r} must name its exact source version "
+            f"with carried_forward_from == {expected_marker!r}, not "
+            f"{marker!r} (section 7.7)"
         )
     stripped = {
         key: value
@@ -902,10 +926,10 @@ def run(args, *, client_factory=None, eval_runner=None) -> int:
     generated_at = _now(args.generated_at)
     run_id = f"merchant-truth-v2-{slug}-{git_sha[:12]}"
 
+    # Prod is refused identically on every path (dry-run read + live write).
+    _refuse_prod(table)
     if args.live:
         validate_live_table(table, explicit=args.table_name is not None)
-    elif table == PROD_TABLE_NAME:
-        raise SystemExit("refusing to read against the prod table")
 
     make_client = client_factory or (lambda: DynamoClient(table))
     client = make_client()

--- a/scripts/mint_merchant_truth_v2.py
+++ b/scripts/mint_merchant_truth_v2.py
@@ -1,0 +1,1113 @@
+#!/usr/bin/env python3
+"""Measurement-driven v2 mint driver (Costco is the pilot invocation).
+
+The v1 migration (``migrate_merchant_truth_v1.py``) minted a *parity* snapshot
+of the legacy profile JSON. This driver mints the first **real** measurement
+bundle on top of it, per contract section 7 (v3.1, schema-evolution):
+
+    docs/architecture/MERCHANT_TRUTH_DYNAMO.md
+
+It is merchant-generic; ``--merchant "Costco Wholesale"`` is the pilot. Per
+component, following the section-7.7 measurement-mint provenance rules:
+
+- ``layout``          MEASURED from a variant-layout payload file (W-G output,
+                      ``scripts/build_variant_layout.py``): default variant plus
+                      ``template.variants[]`` (section 7.2), with the clustering
+                      measurement provenance.
+- ``catalog_snapshot``MEASURED inline from the live ``MerchantCatalogItem``
+                      partition (``{items[], item_count, catalog_hash, as_of}``,
+                      the migration's ``_catalog_record`` shape). Empty partition
+                      is WARNED in the dry-run, never hard-blocked (the owner runs
+                      ``ingest_merchant_catalog --apply`` first).
+- ``typography``      REBUILT from v1's values with the section-7.3 ``section_scale``
+                      encoding (explicit-empty ``{}`` vs. absent). This is NOT a
+                      carry: section 7.7's carry rule requires a payload hash match,
+                      and re-encoding ``section_scale`` changes the hash, so carry is
+                      structurally impossible. It mints as a fresh
+                      ``measurement_pipeline`` component whose provenance records
+                      ``pipeline = "v1-representation-migration"`` and the v1 source
+                      hash under ``derived_from`` -- NOT the ``provenance_completeness
+                      = legacy`` escape, which section 7.7 forbids on a re-measured
+                      component. (Design call documented in the PR body.)
+- ``identity`` / ``stylemap`` / ``assets`` / ``flags`` CARRIED forward from v1,
+                      hash-preserving, reusing the SOURCE's provenance verbatim plus
+                      the ``carried_forward_from`` marker (section 7.7). A carry that
+                      stamps a fresh ``measured_at`` / ``source_receipt_keys`` is a
+                      mint error (the carry-that-lies hole) and is refused here before
+                      any write.
+
+Seal path: mint the OPEN v2, resolve the layout-variant proposal by the payload's
+verdict (section 7.2), run ``full_fidelity_eval`` against the exact v2 bundle
+content with ``--write-gate-record`` (section 7.6), and seal THROUGH
+``bridge_eval_to_gate_results`` (section 7.5). A ``FAIL`` raises
+``GateBlockedError``: the version stays OPEN and the gate record is the work list
+(a mintable-when-fixed state, not an error).
+
+Because the loader refuses to resolve a non-SEALED bundle (chicken-and-egg: seal
+needs the eval, the eval needs a resolvable bundle), the candidate is evaluated
+through a **local SEALED fixture snapshot** written to a temp file and never to
+DynamoDB. The gate record and the real seal both reference the same
+content-derived ``bundle_hash``, so they stay consistent with the OPEN->SEALED
+transition (sealing never changes component hashes).
+
+DRY-RUN is the default: it assembles, prints the bundle summary + a
+``merchant_truth_diff``-style v1->v2 preview + the empty-catalog warning, and
+stages the exact live command. ``--live`` is dev-pinned with a loud banner; the
+prod table is refused unconditionally (the migration's ``validate_live_table``).
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from datetime import datetime, timezone
+from typing import Any, Callable, Sequence
+
+_REPO = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
+for _p in (
+    os.path.join(_REPO, "receipt_dynamo"),
+    os.path.dirname(__file__),  # sibling scripts (merchant_truth_diff, ...)
+    _REPO,
+):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from receipt_dynamo.data.merchant_truth_gate_bridge import (  # noqa: E402
+    GateBlockedError,
+    bridge_eval_to_gate_results,
+)
+from receipt_dynamo.entities.merchant_truth import (  # noqa: E402
+    COMPONENT_NAMES,
+    MerchantTruthComponent,
+    MerchantTruthManifest,
+    MerchantTruthProposal,
+    compute_bundle_hash,
+    hash_payload,
+)
+from receipt_dynamo.migrations.merchant_truth_v1 import (  # noqa: E402
+    DEV_TABLE_NAME,
+    _catalog_record,
+    slugify_merchant,
+)
+from receipt_dynamo.migrations.merchant_truth_v1_live import (  # noqa: E402
+    PROD_TABLE_NAME,
+    validate_live_table,
+)
+
+# The four components carried verbatim from v1; the other three are measured.
+CARRIED_COMPONENTS = ("identity", "stylemap", "assets", "flags")
+MEASURED_COMPONENTS = ("typography", "layout", "catalog_snapshot")
+DEFAULT_MERCHANT = "Costco Wholesale"
+DEFAULT_LAYOUT_PAYLOAD = os.path.join(
+    _REPO,
+    "tools",
+    "glyph-studio",
+    "fixtures",
+    "costco_variant_layout.sample.json",
+)
+DEFAULT_PROPOSAL = "self-checkout-layout-variant"
+DRIVER_NAME = "mint_merchant_truth_v2"
+DRIVER_VERSION = "2"
+
+
+# --------------------------------------------------------------------------
+# Errors
+# --------------------------------------------------------------------------
+
+
+class MintError(RuntimeError):
+    """A pre-write assembly / governance violation caught by the driver."""
+
+
+# --------------------------------------------------------------------------
+# Small helpers
+# --------------------------------------------------------------------------
+
+
+def _git_sha(explicit: str | None) -> str:
+    if explicit:
+        return explicit
+    try:
+        return (
+            subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=_REPO)
+            .decode()
+            .strip()
+        )
+    except Exception:  # pragma: no cover - git absent
+        return "unknown"
+
+
+def _now(explicit: str | None) -> str:
+    return explicit or datetime.now(timezone.utc).isoformat()
+
+
+# --------------------------------------------------------------------------
+# section 7.7 carry rule
+# --------------------------------------------------------------------------
+
+
+def carry_component(
+    source: MerchantTruthComponent, target_version: int
+) -> MerchantTruthComponent:
+    """Carry one component to ``target_version``, hash-preserving.
+
+    The payload is copied unchanged (so the content hash matches the source),
+    and the provenance is the SOURCE's provenance verbatim plus a
+    ``carried_forward_from`` marker naming the source version (section 7.7). No
+    fresh ``measured_at`` / ``source_receipt_keys`` is asserted.
+    """
+    provenance = copy.deepcopy(source.provenance)
+    provenance["carried_forward_from"] = f"v{source.version}"
+    return MerchantTruthComponent(
+        slug=source.slug,
+        version=target_version,
+        name=source.name,
+        payload=copy.deepcopy(source.payload),
+        provenance=provenance,
+    )
+
+
+def assert_carry_faithful(
+    candidate: MerchantTruthComponent, source: MerchantTruthComponent
+) -> None:
+    """Refuse a carry that mutated the payload or asserted a fresh measurement.
+
+    Section 7.7 carry rule, enforced by the driver (the data layer's
+    ``_validate_component_governance`` does not check the carry marker). A
+    faithful carry is exactly ``source.provenance`` plus ``carried_forward_from``
+    naming a version, over a byte-identical payload. Anything else -- a payload
+    edit, a fresh ``measured_at``, new ``source_receipt_keys`` -- is the
+    carry-that-lies hole and raises :class:`MintError`.
+    """
+    if candidate.content_hash != source.content_hash:
+        raise MintError(
+            f"carry of {candidate.name!r} mutated the payload "
+            f"({source.content_hash[:12]} -> {candidate.content_hash[:12]}); "
+            "a carry must be hash-preserving (section 7.7)"
+        )
+    marker = candidate.provenance.get("carried_forward_from")
+    if not (isinstance(marker, str) and marker.startswith("v")):
+        raise MintError(
+            f"carry of {candidate.name!r} is missing a valid "
+            "carried_forward_from marker (section 7.7)"
+        )
+    stripped = {
+        key: value
+        for key, value in candidate.provenance.items()
+        if key != "carried_forward_from"
+    }
+    if stripped != source.provenance:
+        raise MintError(
+            f"carry of {candidate.name!r} does not reuse the source "
+            "provenance verbatim: a carried component may not stamp a fresh "
+            "measured_at / source_receipt_keys or otherwise edit provenance "
+            "(section 7.7 carry-that-lies hole)"
+        )
+
+
+# --------------------------------------------------------------------------
+# section 7.3 typography (rebuilt, not carried)
+# --------------------------------------------------------------------------
+
+
+def encode_section_scale(
+    v1_typography_payload: dict[str, Any], *, explicit_empty: bool
+) -> tuple[dict[str, Any], str]:
+    """Apply the section-7.3 ``section_scale`` encoding to a v1 payload.
+
+    Returns ``(new_payload, rule)`` where ``rule`` is one of
+    ``"explicit_uniform"`` (key present ``{}``), ``"per_section"`` (key present,
+    non-empty), or ``"absent_default"`` (key removed). ``explicit_empty`` comes
+    from the renderer's v1 shim registry
+    (``_V1_EXPLICIT_EMPTY_SECTION_SCALE``): merchants in it meant an EXPLICIT
+    uniform scale, everyone else's collapsed ``{}`` meant "never measured ->
+    default HEADER shrink" (absent).
+    """
+    payload = copy.deepcopy(v1_typography_payload)
+    v1_scale = payload.get("section_scale") or {}
+    if v1_scale:
+        payload["section_scale"] = dict(v1_scale)
+        return payload, "per_section"
+    if explicit_empty:
+        payload["section_scale"] = {}
+        return payload, "explicit_uniform"
+    payload.pop("section_scale", None)
+    return payload, "absent_default"
+
+
+def build_typography_component(
+    slug: str,
+    version: int,
+    v1_typography: MerchantTruthComponent,
+    *,
+    explicit_empty: bool,
+    corpus_source_receipt_keys: Sequence[str],
+    git_sha: str,
+    generated_at: str,
+) -> tuple[MerchantTruthComponent, str]:
+    """Rebuild the typography component with the section-7.3 encoding.
+
+    Provenance is a fresh ``measurement_pipeline`` write (NOT the legacy
+    migration escape, which section 7.7 forbids on a re-measured component):
+    ``pipeline = "v1-representation-migration"``, ``measured_at`` = the mint
+    time, ``source_receipt_keys`` = the measured corpus that backs this mint
+    (the receipts the typography metrics derive from), and ``derived_from``
+    records the v1 typography payload hash.
+    """
+    payload, rule = encode_section_scale(
+        v1_typography.payload, explicit_empty=explicit_empty
+    )
+    provenance = {
+        "source_kind": "measurement",
+        "written_by": {
+            "kind": "measurement_pipeline",
+            "name": DRIVER_NAME,
+            "version": DRIVER_VERSION,
+        },
+        "pipeline": "v1-representation-migration",
+        "pipeline_version": "1",
+        "git_sha": git_sha,
+        "measured_at": generated_at,
+        "source_object": f"merchant_truth:v{v1_typography.version}:typography",
+        "source_receipt_keys": sorted(set(corpus_source_receipt_keys)),
+        "derived_from": {
+            "version": v1_typography.version,
+            "component": "typography",
+            "payload_hash": v1_typography.content_hash,
+        },
+        "representation_migration": {
+            "contract": "section 7.3",
+            "section_scale_rule": rule,
+            "from_v1_shim": "_V1_EXPLICIT_EMPTY_SECTION_SCALE",
+        },
+    }
+    component = MerchantTruthComponent(
+        slug=slug,
+        version=version,
+        name="typography",
+        payload=payload,
+        provenance=provenance,
+    )
+    return component, rule
+
+
+# --------------------------------------------------------------------------
+# layout (measured from the W-G variant payload)
+# --------------------------------------------------------------------------
+
+
+def load_variant_payload(path: str) -> dict[str, Any]:
+    with open(path, "r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+    for key in ("template", "verdict", "provenance"):
+        if key not in payload:
+            raise MintError(
+                f"variant-layout payload {path!r} missing {key!r}; expected "
+                "the build_variant_layout.py output shape (template/verdict/"
+                "provenance)"
+            )
+    return payload
+
+
+def build_layout_component(
+    slug: str,
+    version: int,
+    variant_payload: dict[str, Any],
+    *,
+    source_object: str,
+    git_sha_fallback: str,
+    generated_at_fallback: str,
+) -> MerchantTruthComponent:
+    """Mint the layout component from a variant-layout payload (section 7.2).
+
+    Payload is the migration's ``{"available", "template"}`` shape; the
+    template is the W-G template verbatim (default variant at the top level +
+    ``template.variants[]``). Provenance is the payload's measurement block,
+    augmented with the ``written_by`` identity and a ``source_object`` the
+    data-layer governance requires.
+    """
+    template = copy.deepcopy(variant_payload["template"])
+    payload = {"available": True, "template": template}
+
+    measured = copy.deepcopy(variant_payload.get("provenance") or {})
+    provenance: dict[str, Any] = {
+        "source_kind": measured.get("source_kind", "measurement"),
+        "written_by": {
+            "kind": "measurement_pipeline",
+            "name": measured.get("pipeline", "build_variant_layout"),
+            "version": str(measured.get("pipeline_version", "1")),
+        },
+        "pipeline": measured.get("pipeline", "build_variant_layout"),
+        "pipeline_version": str(measured.get("pipeline_version", "1")),
+        "git_sha": measured.get("git_sha") or git_sha_fallback,
+        "measured_at": measured.get("measured_at") or generated_at_fallback,
+        "source_object": source_object,
+        "source_receipt_keys": list(measured.get("source_receipt_keys") or []),
+    }
+    # Preserve the clustering evidence + the resolved proposal verdict verbatim.
+    for key in (
+        "excluded_receipt_keys",
+        "params",
+        "scan_manifest",
+        "failed_receipt_keys",
+    ):
+        if key in measured:
+            provenance[key] = measured[key]
+    provenance["verdict"] = copy.deepcopy(variant_payload.get("verdict") or {})
+
+    return MerchantTruthComponent(
+        slug=slug,
+        version=version,
+        name="layout",
+        payload=payload,
+        provenance=provenance,
+    )
+
+
+# --------------------------------------------------------------------------
+# catalog_snapshot (measured inline from the live partition)
+# --------------------------------------------------------------------------
+
+
+def build_catalog_snapshot(
+    catalog_items: Sequence[Any], *, generated_at: str
+) -> tuple[dict[str, Any], list[str]]:
+    """Build the ``catalog_snapshot`` payload + the union of receipt keys.
+
+    Mirrors the v1 migration's ``_catalog_record`` shape exactly: decode each
+    entity's low-level item, strip key/index attrs, sort by
+    ``(category, product_text, price)``, and hash the sorted list.
+    """
+    records = sorted(
+        (_catalog_record(item.to_item()) for item in catalog_items),
+        key=lambda record: (
+            str(record.get("category", "")),
+            str(record.get("product_text", "")),
+            str(record.get("price", "")),
+        ),
+    )
+    receipt_keys: set[str] = set()
+    for record in records:
+        receipt_keys.update(record.get("source_receipt_keys") or [])
+    snapshot = {
+        "items": records,
+        "item_count": len(records),
+        "catalog_hash": hash_payload(records),
+        "as_of": generated_at,
+    }
+    return snapshot, sorted(receipt_keys)
+
+
+def build_catalog_component(
+    slug: str,
+    version: int,
+    catalog_items: Sequence[Any],
+    *,
+    git_sha: str,
+    generated_at: str,
+) -> tuple[MerchantTruthComponent, dict[str, Any]]:
+    """Mint the catalog_snapshot component from live rows (section 7.7).
+
+    Returns ``(component, info)``; ``info`` carries ``item_count`` and whether
+    the partition was empty so the caller can warn.
+    """
+    snapshot, receipt_keys = build_catalog_snapshot(
+        catalog_items, generated_at=generated_at
+    )
+    provenance = {
+        "source_kind": "measurement",
+        "written_by": {
+            "kind": "measurement_pipeline",
+            "name": "ingest_merchant_catalog",
+            "version": "1",
+        },
+        "pipeline": "ingest_merchant_catalog",
+        "pipeline_version": "1",
+        "git_sha": git_sha,
+        "measured_at": generated_at,
+        "source_object": f"MERCHANT_CATALOG#{slug}",
+        "source_receipt_keys": receipt_keys,
+        "item_count": snapshot["item_count"],
+        "catalog_hash": snapshot["catalog_hash"],
+    }
+    component = MerchantTruthComponent(
+        slug=slug,
+        version=version,
+        name="catalog_snapshot",
+        payload=snapshot,
+        provenance=provenance,
+    )
+    info = {
+        "item_count": snapshot["item_count"],
+        "empty": snapshot["item_count"] == 0,
+    }
+    return component, info
+
+
+# --------------------------------------------------------------------------
+# Assembly
+# --------------------------------------------------------------------------
+
+
+def _explicit_empty_registry() -> frozenset[str]:
+    """The renderer's v1 shim registry, the section-7.3 source of truth."""
+    try:
+        from render_synthetic_receipts import (  # noqa: WPS433
+            _V1_EXPLICIT_EMPTY_SECTION_SCALE,
+        )
+
+        return frozenset(_V1_EXPLICIT_EMPTY_SECTION_SCALE)
+    except Exception:  # pragma: no cover - renderer deps absent
+        # Vendored fallback (kept in sync with render_synthetic_receipts).
+        return frozenset({"in_n_out_burger", "sprouts_farmers_market"})
+
+
+def assemble_v2_components(
+    slug: str,
+    version: int,
+    v1_components: dict[str, MerchantTruthComponent],
+    variant_payload: dict[str, Any],
+    catalog_items: Sequence[Any],
+    *,
+    explicit_empty: bool,
+    layout_source_object: str,
+    git_sha: str,
+    generated_at: str,
+) -> tuple[list[MerchantTruthComponent], dict[str, Any]]:
+    """Assemble all 7 v2 components; enforce the section-7.7 carry rule.
+
+    Returns ``(components, info)`` where ``info`` records the section-7.3
+    typography rule, the layout verdict, and the catalog empty/count.
+    """
+    missing = COMPONENT_NAMES - set(v1_components)
+    if missing:
+        raise MintError(
+            f"v1 bundle for {slug!r} is missing components {sorted(missing)}; "
+            "cannot carry forward"
+        )
+
+    components: dict[str, MerchantTruthComponent] = {}
+
+    # Carried, hash-preserving.
+    for name in CARRIED_COMPONENTS:
+        carried = carry_component(v1_components[name], version)
+        assert_carry_faithful(carried, v1_components[name])
+        components[name] = carried
+
+    # Measured: layout first (its corpus feeds the typography provenance).
+    layout = build_layout_component(
+        slug,
+        version,
+        variant_payload,
+        source_object=layout_source_object,
+        git_sha_fallback=git_sha,
+        generated_at_fallback=generated_at,
+    )
+    components["layout"] = layout
+    corpus = layout.provenance.get("source_receipt_keys") or []
+
+    typography, section_scale_rule = build_typography_component(
+        slug,
+        version,
+        v1_components["typography"],
+        explicit_empty=explicit_empty,
+        corpus_source_receipt_keys=corpus,
+        git_sha=git_sha,
+        generated_at=generated_at,
+    )
+    components["typography"] = typography
+
+    catalog, catalog_info = build_catalog_component(
+        slug,
+        version,
+        catalog_items,
+        git_sha=git_sha,
+        generated_at=generated_at,
+    )
+    components["catalog_snapshot"] = catalog
+
+    ordered = [components[name] for name in sorted(COMPONENT_NAMES)]
+    info = {
+        "section_scale_rule": section_scale_rule,
+        "verdict": variant_payload.get("verdict") or {},
+        "catalog": catalog_info,
+    }
+    return ordered, info
+
+
+def manifest_provenance(
+    slug: str,
+    run_id: str,
+    *,
+    git_sha: str,
+    generated_at: str,
+    source_bundle_hash: str,
+    source_version: int,
+) -> dict[str, Any]:
+    return {
+        "written_by": {
+            "kind": "measurement_pipeline",
+            "name": DRIVER_NAME,
+            "version": DRIVER_VERSION,
+        },
+        "minted_at": generated_at,
+        "run_id": run_id,
+        "git_sha": git_sha,
+        "source_bundle": {
+            "version": source_version,
+            "bundle_hash": source_bundle_hash,
+        },
+        "measured_components": list(MEASURED_COMPONENTS),
+        "carried_components": list(CARRIED_COMPONENTS),
+    }
+
+
+def bundle_hash_of(components: Sequence[MerchantTruthComponent]) -> str:
+    return compute_bundle_hash(
+        {component.name: component.content_hash for component in components}
+    )
+
+
+# --------------------------------------------------------------------------
+# Read v1 + preview
+# --------------------------------------------------------------------------
+
+
+def read_v1_bundle(
+    client: Any, slug: str, *, version: int | None
+) -> tuple[MerchantTruthManifest, dict[str, MerchantTruthComponent]]:
+    """Read the SEALED v1 (or an explicit version) to carry forward from."""
+    if version is None:
+        version = client.get_latest_merchant_truth_version(
+            slug, sealed_only=True
+        )
+        if version is None:
+            raise MintError(
+                f"no SEALED version exists for {slug!r}; mint v1 first"
+            )
+    manifest = client.get_merchant_truth_manifest(
+        slug, version, consistent_read=True
+    )
+    if manifest is None:
+        raise MintError(f"no manifest for {slug!r} v{version}")
+    if manifest.status != "SEALED":
+        raise MintError(
+            f"{slug!r} v{version} is {manifest.status}; carry-from requires a "
+            "SEALED source"
+        )
+    components = {
+        component.name: component
+        for component in client.list_merchant_truth_components(
+            slug, version, consistent_read=True
+        )
+    }
+    return manifest, components
+
+
+def render_preview(
+    v1_manifest: MerchantTruthManifest,
+    v1_components: dict[str, MerchantTruthComponent],
+    v2_manifest: MerchantTruthManifest,
+    v2_components: Sequence[MerchantTruthComponent],
+    *,
+    table: str,
+) -> str:
+    """A merchant_truth_diff-style v1->v2 preview (before any seal)."""
+    from merchant_truth_diff import Bundle, render_version_diff  # noqa: WPS433
+
+    old = Bundle(manifest=v1_manifest, components=dict(v1_components))
+    new = Bundle(
+        manifest=v2_manifest,
+        components={component.name: component for component in v2_components},
+    )
+    return "\n".join(render_version_diff(old, new, table=table))
+
+
+# --------------------------------------------------------------------------
+# Proposal resolution (section 7.2 verdict)
+# --------------------------------------------------------------------------
+
+
+def resolve_layout_proposal(
+    client: Any,
+    table: str,
+    slug: str,
+    *,
+    verdict: dict[str, Any],
+    version: int,
+    proposal_claim: str,
+) -> str:
+    """Resolve the layout-variant proposal by the clustering verdict.
+
+    ``REFUTE`` -> ``resolve_proposal(..., "refuted")``; ``CONFIRM`` ->
+    ``"confirmed"``. Idempotent: an already-resolved proposal (not OPEN) is
+    skipped, and an absent proposal is reported. Returns a short status string.
+    """
+    status = str(verdict.get("status", "")).upper()
+    resolution = {"REFUTE": "refuted", "CONFIRM": "confirmed"}.get(status)
+    if resolution is None:
+        return f"skipped (verdict status {status!r} is not CONFIRM/REFUTE)"
+
+    proposals = client.list_merchant_truth_proposals(slug)
+    match = next(
+        (p for p in proposals if p.claim_slug == proposal_claim), None
+    )
+    if match is None:
+        return f"no proposal {proposal_claim!r} found (nothing to resolve)"
+    if match.status != "OPEN":
+        return (
+            f"already resolved ({match.status}); idempotent skip "
+            f"[{proposal_claim}]"
+        )
+    client.resolve_proposal(match, version, resolution, table)
+    refs = verdict.get("clusters") or []
+    ref_count = sum(len(cluster.get("receipt_refs") or []) for cluster in refs)
+    return (
+        f"{resolution} (resolved_by_version=v{version}, "
+        f"{ref_count} cluster receipt_refs recorded in the verdict)"
+    )
+
+
+# --------------------------------------------------------------------------
+# Eval + gate + seal (section 7.5 / 7.6)
+# --------------------------------------------------------------------------
+
+
+def _fixture_items(
+    components: Sequence[MerchantTruthComponent], *, slug: str, version: int
+) -> list[dict[str, Any]]:
+    """Low-level items for a SEALED eval fixture (never written to DynamoDB)."""
+    component_hashes = {c.name: c.content_hash for c in components}
+    manifest = MerchantTruthManifest(
+        slug=slug,
+        version=version,
+        component_hashes=component_hashes,
+        bundle_hash=compute_bundle_hash(component_hashes),
+        status="SEALED",
+        provenance={"written_by": {"kind": "measurement_pipeline"}},
+        mint_run_id=f"eval-fixture-{slug}-v{version}",
+        gate_status="PASS",
+        gate_results={"status": "PASS", "passed": True},
+    )
+    return [manifest.to_item(), *[c.to_item() for c in components]]
+
+
+def default_eval_runner(
+    *,
+    components: Sequence[MerchantTruthComponent],
+    slug: str,
+    version: int,
+    merchant: str,
+    image_id: str,
+    receipt_id: int,
+    table: str,
+    out_root: str,
+    allow_dirty: bool,
+) -> dict[str, Any]:
+    """Run ``full_fidelity_eval`` against the candidate bundle content.
+
+    Writes the candidate to a temp SEALED fixture (chicken-and-egg: the loader
+    only resolves SEALED bundles), shells out to the eval with
+    ``--write-gate-record`` so the eval persists one MERCHANT_TRUTH_GATE record
+    (dev-pinned, prod refused inside the eval), then parses and returns this
+    run's ``checks``.
+    """
+    with tempfile.TemporaryDirectory() as work:
+        fixture_path = os.path.join(work, f"{slug}_v{version}.fixture.json")
+        with open(fixture_path, "w", encoding="utf-8") as handle:
+            json.dump(
+                {
+                    "items": _fixture_items(
+                        components, slug=slug, version=version
+                    )
+                },
+                handle,
+            )
+        eval_out = os.path.join(work, "eval")
+        cmd = [
+            sys.executable,
+            os.path.join(_REPO, "synthesis_loop", "full_fidelity_eval.py"),
+            "run",
+            merchant,
+            image_id,
+            str(receipt_id),
+            slug,
+            "--out-root",
+            eval_out,
+            "--truth-fixture",
+            fixture_path,
+            "--write-gate-record",
+        ]
+        if allow_dirty:
+            cmd.append("--allow-dirty")
+        env = dict(os.environ)
+        env["DYNAMODB_TABLE_NAME"] = table
+        proc = subprocess.run(cmd, env=env, cwd=_REPO)
+        checks_path = os.path.join(
+            eval_out, f"{slug}_eval", f"{slug}.checks.json"
+        )
+        if not os.path.exists(checks_path):
+            raise MintError(
+                f"eval produced no checks at {checks_path!r} "
+                f"(exit {proc.returncode}); cannot gate the seal"
+            )
+        with open(checks_path, "r", encoding="utf-8") as handle:
+            doc = json.load(handle)
+        return doc.get("checks", doc)
+
+
+def eval_gate_and_seal(
+    client: Any,
+    table: str,
+    slug: str,
+    version: int,
+    components: Sequence[MerchantTruthComponent],
+    *,
+    eval_runner: Callable[..., dict[str, Any]],
+    confirmed_proposals: Sequence[str],
+    generated_at: str,
+    actor: str = "mint_merchant_truth_v2",
+    eval_kwargs: dict[str, Any] | None = None,
+) -> tuple[MerchantTruthManifest | None, dict[str, Any]]:
+    """Eval -> bridge -> seal. Returns ``(sealed_manifest | None, checks)``.
+
+    On a ``FAIL`` overall the bridge raises :class:`GateBlockedError`; the seal
+    is not attempted (version stays OPEN) and the derived gate_results (the work
+    list) are printed. Returns ``(None, checks)`` in that case.
+    """
+    checks = eval_runner(
+        components=components,
+        slug=slug,
+        version=version,
+        table=table,
+        **(eval_kwargs or {}),
+    )
+    try:
+        gate_results = bridge_eval_to_gate_results(checks)
+    except GateBlockedError as blocked:
+        print(_format_gate_worklist(slug, version, blocked.gate_results))
+        return None, checks
+    sealed = client.seal_version(
+        slug,
+        version,
+        gate_results,
+        list(confirmed_proposals),
+        table,
+        sealed_at=generated_at,
+        actor=actor,
+    )
+    overall = gate_results.get("overall")
+    gap_count = len(gate_results.get("gaps") or [])
+    print(
+        f"SEALED {slug} v{version} (overall={overall}, gaps={gap_count}); "
+        "flip to ACTIVE stays owner-gated."
+    )
+    return sealed, checks
+
+
+def _format_gate_worklist(
+    slug: str, version: int, gate_results: dict[str, Any]
+) -> str:
+    lines = [
+        "",
+        "=" * 72,
+        f"GATE FAILED: {slug} v{version} stays OPEN (mintable-when-fixed).",
+        "The MERCHANT_TRUTH_GATE record is the work list:",
+    ]
+    for gap in gate_results.get("gaps") or []:
+        lines.append(
+            f"  - {gap.get('metric')}: {gap.get('verdict')} "
+            f"{json.dumps(gap.get('detail', {}), sort_keys=True)}"
+        )
+    lines.append("=" * 72)
+    return "\n".join(lines)
+
+
+# --------------------------------------------------------------------------
+# Dry-run / live orchestration
+# --------------------------------------------------------------------------
+
+
+def _bundle_summary(
+    slug: str,
+    version: int,
+    components: Sequence[MerchantTruthComponent],
+    info: dict[str, Any],
+    *,
+    bundle_hash: str,
+) -> str:
+    lines = [
+        "=" * 72,
+        f"ASSEMBLED CANDIDATE: {slug} v{version}",
+        f"  bundle_hash: {bundle_hash}",
+        f"  section_scale rule (7.3): {info['section_scale_rule']}",
+        f"  layout verdict (7.2): {info['verdict'].get('status', 'n/a')} "
+        f"-- {info['verdict'].get('proposal', 'n/a')}",
+        f"  catalog items: {info['catalog']['item_count']}"
+        + ("  [EMPTY]" if info["catalog"]["empty"] else ""),
+        "  components:",
+    ]
+    for component in components:
+        prov = component.provenance
+        carried = prov.get("carried_forward_from")
+        kind = (prov.get("written_by") or {}).get("kind")
+        tag = f"carried<-{carried}" if carried else f"measured({kind})"
+        lines.append(
+            f"    - {component.name:16s} {component.content_hash[:12]}  {tag}"
+        )
+    lines.append("=" * 72)
+    return "\n".join(lines)
+
+
+def _empty_catalog_warning(slug: str) -> str:
+    return "\n".join(
+        [
+            "!" * 72,
+            f"WARNING: the MerchantCatalogItem partition for {slug!r} is EMPTY.",
+            "  catalog_snapshot will inline zero items. A LIVE mint will then be",
+            "  refused by measurement provenance governance (an empty",
+            "  source_kind=measurement carries no source_receipt_keys).",
+            "  Populate it first:",
+            f"    PORTFOLIO_ENV=dev python scripts/ingest_merchant_catalog.py "
+            f"--merchant '<name>' --apply",
+            "!" * 72,
+        ]
+    )
+
+
+def _staged_live_command(args, slug: str) -> str:
+    parts = [
+        "PORTFOLIO_ENV=dev python scripts/mint_merchant_truth_v2.py",
+        f"--merchant '{args.merchant}'",
+        f"--layout-payload {args.layout_payload}",
+        f"--eval-image-id <IMAGE_ID> --eval-receipt-id <RECEIPT_ID>",
+        "--live",
+    ]
+    if args.slug:
+        parts.append(f"--slug {slug}")
+    return "  " + " \\\n    ".join(parts)
+
+
+def run(args, *, client_factory=None, eval_runner=None) -> int:
+    from receipt_dynamo.data.dynamo_client import DynamoClient
+
+    slug = args.slug or slugify_merchant(args.merchant)
+    table = args.table_name or DEV_TABLE_NAME
+    git_sha = _git_sha(args.git_sha)
+    generated_at = _now(args.generated_at)
+    run_id = f"merchant-truth-v2-{slug}-{git_sha[:12]}"
+
+    if args.live:
+        validate_live_table(table, explicit=args.table_name is not None)
+    elif table == PROD_TABLE_NAME:
+        raise SystemExit("refusing to read against the prod table")
+
+    make_client = client_factory or (lambda: DynamoClient(table))
+    client = make_client()
+
+    # --- read v1, allocate version -------------------------------------
+    v1_manifest, v1_components = read_v1_bundle(
+        client, slug, version=args.from_version
+    )
+    version = client.next_mint_version(slug)
+
+    variant_payload = load_variant_payload(args.layout_payload)
+    catalog_items = client.list_merchant_catalog_items(args.merchant)
+    explicit_empty = slug in _explicit_empty_registry()
+
+    components, info = assemble_v2_components(
+        slug,
+        version,
+        v1_components,
+        variant_payload,
+        catalog_items,
+        explicit_empty=explicit_empty,
+        layout_source_object=(
+            os.path.relpath(args.layout_payload, _REPO)
+            if args.layout_payload.startswith(_REPO)
+            else args.layout_payload
+        ),
+        git_sha=git_sha,
+        generated_at=generated_at,
+    )
+    bundle_hash = bundle_hash_of(components)
+
+    # --- preview (both modes) ------------------------------------------
+    candidate_manifest = MerchantTruthManifest(
+        slug=slug,
+        version=version,
+        component_hashes={c.name: c.content_hash for c in components},
+        bundle_hash=bundle_hash,
+        status="OPEN",
+        provenance=manifest_provenance(
+            slug,
+            run_id,
+            git_sha=git_sha,
+            generated_at=generated_at,
+            source_bundle_hash=v1_manifest.bundle_hash,
+            source_version=v1_manifest.version,
+        ),
+        mint_run_id=run_id,
+    )
+    print(
+        _bundle_summary(
+            slug, version, components, info, bundle_hash=bundle_hash
+        )
+    )
+    print()
+    print(
+        render_preview(
+            v1_manifest,
+            v1_components,
+            candidate_manifest,
+            components,
+            table=table,
+        )
+    )
+    if info["catalog"]["empty"]:
+        print()
+        print(_empty_catalog_warning(slug))
+
+    if not args.live:
+        print()
+        print("DRY RUN — no DynamoDB writes. Stage the live mint with:")
+        print(_staged_live_command(args, slug))
+        return 0
+
+    # --- LIVE ceremony -------------------------------------------------
+    if args.eval_image_id is None or args.eval_receipt_id is None:
+        raise SystemExit(
+            "--live requires --eval-image-id and --eval-receipt-id "
+            "(the receipt the fidelity eval renders against)"
+        )
+    print()
+    print(_v2_banner(table, slug, version, git_sha))
+
+    existing = client.get_merchant_truth_manifest(
+        slug, version, consistent_read=True
+    )
+    if existing is not None and existing.status == "SEALED":
+        print(f"SKIP: {slug} v{version} already SEALED (idempotent).")
+        return 0
+
+    minted = client.mint_version(
+        slug,
+        version,
+        components,
+        candidate_manifest.provenance,
+        run_id,
+        table,
+        created_at=generated_at,
+    )
+    print(f"MINTED OPEN {slug} v{version} bundle_hash={minted.bundle_hash}")
+
+    proposal_status = resolve_layout_proposal(
+        client,
+        table,
+        slug,
+        verdict=info["verdict"],
+        version=version,
+        proposal_claim=args.proposal,
+    )
+    print(f"PROPOSAL {args.proposal}: {proposal_status}")
+
+    runner = eval_runner or default_eval_runner
+    confirmed = (
+        [args.proposal]
+        if str(info["verdict"].get("status", "")).upper() == "CONFIRM"
+        else []
+    )
+    sealed, _checks = eval_gate_and_seal(
+        client,
+        table,
+        slug,
+        version,
+        components,
+        eval_runner=runner,
+        confirmed_proposals=confirmed,
+        generated_at=generated_at,
+        eval_kwargs={
+            "merchant": args.merchant,
+            "image_id": args.eval_image_id,
+            "receipt_id": args.eval_receipt_id,
+            "out_root": args.eval_out_root,
+            "allow_dirty": args.allow_dirty,
+        },
+    )
+    if sealed is None:
+        return 3  # documented mintable-when-fixed state; not a crash
+    return 0
+
+
+def _v2_banner(table: str, slug: str, version: int, git_sha: str) -> str:
+    bar = "=" * 72
+    return "\n".join(
+        [
+            bar,
+            "LIVE MERCHANT-TRUTH V2 MINT — DynamoDB WRITES WILL OCCUR",
+            f"  table:     {table}",
+            f"  merchant:  {slug} (mint OPEN v{version} + eval-gated seal)",
+            f"  git SHA:   {git_sha}",
+            bar,
+        ]
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--merchant", default=DEFAULT_MERCHANT)
+    parser.add_argument(
+        "--slug", default=None, help="override the slugified merchant name"
+    )
+    parser.add_argument(
+        "--layout-payload",
+        default=DEFAULT_LAYOUT_PAYLOAD,
+        help="variant-layout payload JSON (build_variant_layout.py output)",
+    )
+    parser.add_argument(
+        "--from-version",
+        type=int,
+        default=None,
+        help="explicit v1 source version (default: latest SEALED)",
+    )
+    parser.add_argument(
+        "--proposal",
+        default=DEFAULT_PROPOSAL,
+        help="layout-variant proposal claim_slug to resolve by the verdict",
+    )
+    parser.add_argument(
+        "--table",
+        "--table-name",
+        dest="table_name",
+        default=None,
+        help=(
+            f"DynamoDB table (default dev {DEV_TABLE_NAME!r}); the prod table "
+            "is refused unconditionally"
+        ),
+    )
+    parser.add_argument("--git-sha", default=None)
+    parser.add_argument("--generated-at", default=None)
+    parser.add_argument("--eval-image-id", default=None)
+    parser.add_argument("--eval-receipt-id", type=int, default=None)
+    parser.add_argument("--eval-out-root", default=".out")
+    parser.add_argument("--allow-dirty", action="store_true")
+    parser.add_argument(
+        "--live",
+        action="store_true",
+        help="perform the mint+seal ceremony (default: dry-run, no writes)",
+    )
+    return parser
+
+
+def main(argv=None) -> int:
+    args = build_parser().parse_args(argv)
+    return run(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Capstone of the Costco complete-in-Dynamo pilot (plan `humble-skipping-quilt`, **W-J**). Adds `scripts/mint_merchant_truth_v2.py` — the merchant-generic, measurement-driven v2 mint driver (Costco is the pilot invocation) — plus a moto test suite. Implements contract **§7 (v3.1)** in `docs/architecture/MERCHANT_TRUTH_DYNAMO.md`. Builds on #1215 (version readers + gate bridge), #1219 (gate records + `--write-gate-record`), #1213/#1220 (variant machinery), #1212/#1222 (catalog entity + miner), #1221 (alias guards).

## What it does
Per component, following §7.7 measurement-mint provenance:
- **layout** — MEASURED from a `build_variant_layout.py` payload file (`--layout-payload`; default = the committed `tools/glyph-studio/fixtures/costco_variant_layout.sample.json`): default variant at the top level + `template.variants[]` (§7.2), measurement provenance augmented with the `written_by` identity + `source_object` the data-layer governance requires; the resolved verdict is recorded verbatim in provenance.
- **catalog_snapshot** — MEASURED inline from the live `MerchantCatalogItem` partition via `client.list_merchant_catalog_items`, in the migration's `_catalog_record` shape (`{items[], item_count, catalog_hash, as_of}`); `source_receipt_keys` = union over items.
- **typography** — REBUILT from v1 with the §7.3 `section_scale` encoding.
- **identity / stylemap / assets / flags** — CARRIED forward from v1 (§7.7), hash-preserving, source provenance verbatim + `carried_forward_from`.

Seal path: allocate via `next_mint_version` → assemble → mint OPEN v2 → resolve the `self-checkout-layout-variant` proposal by the payload verdict (REFUTE→`refuted`, idempotent skip if already resolved) → run `full_fidelity_eval --write-gate-record` against the exact v2 content → seal through `bridge_eval_to_gate_results` (§7.5). **FAIL** → `GateBlockedError` → version stays OPEN, gate record is the printed work list, exit 3 (mintable-when-fixed, not a crash). **PASS / PASS_WITH_GAPS** → seals (gaps recorded verbatim); the flip to ACTIVE stays owner-gated.

**Dry-run is the default**: bundle summary + a `merchant_truth_diff`-style v1→v2 preview (`render_version_diff`) + the empty-catalog warning + the staged live command. `--live` is dev-pinned with a loud banner; the prod table is refused unconditionally (`validate_live_table`). No live writes in this PR — the live mint is the owner's ceremony.

## The typography §7.3-vs-§7.7 design call
§7.3 requires v2 to encode `section_scale` explicitly (present `{}` = measured-uniform; absent = default HEADER shrink). §7.7's **carry rule requires a payload hash match**, and re-encoding `section_scale` changes the typography payload hash — so **carry is structurally impossible**, and §7.7 forbids modifying a carried payload. Therefore typography is minted as a **rebuilt measured component**, NOT a carry:
- `written_by.kind = "measurement_pipeline"`, `source_kind = "measurement"`, `pipeline = "v1-representation-migration"`, fresh `measured_at` (legitimate — the no-fresh-`measured_at` rule applies only to *carried* components), `git_sha`.
- `derived_from = {version: 1, component: "typography", payload_hash: <v1 hash>}` records the v1 source hash; a `representation_migration` block records the §7.3 rule applied.
- `source_receipt_keys` = the measured SCAN corpus (the layout payload's `source_receipt_keys`) — the receipts the typography metrics derive from — which also satisfies the governance requirement that a `source_kind=measurement` component carry receipt keys.
- It is explicitly **NOT** the `provenance_completeness=legacy` / `source_kind=migration` escape, which §7.7 forbids on a re-measured component.

**Costco specifically resolves to `section_scale` ABSENT**: Costco is not in the renderer's `_V1_EXPLICIT_EMPTY_SECTION_SCALE` registry (`{in_n_out_burger, sprouts_farmers_market}`), so its v1 collapsed `{}` meant "never measured → default HEADER shrink". The driver reads that registry (the §7.3 source of truth) to pick the encoding per merchant.

The §7.7 carry-that-lies hole is enforced by the driver (`assert_carry_faithful`), since the data-layer `_validate_component_governance` does not check the carry marker: a carried component must be `source.provenance + carried_forward_from` over a byte-identical payload — any payload edit or fresh `measured_at`/`source_receipt_keys` is refused before any write.

Note on "PINNED to the OPEN v2": the loader refuses to resolve a non-SEALED bundle (and the OPEN v2 can't be loaded online until sealed — chicken-and-egg). The eval is therefore run against a **local SEALED fixture snapshot** of the exact candidate components, written to a temp file and **never** to DynamoDB. The gate record and the real seal both reference the same content-derived `bundle_hash` (sealing never changes component hashes), so they stay consistent across the OPEN→SEALED transition.

## Tests (9, moto)
`receipt_dynamo/tests/integration/test_mint_merchant_truth_v2.py` — all pass:
1. full assembly with a populated catalog + a live PASS seal (carried hashes == v1, marker present; catalog inlined; layout verdict recorded; proposal → MEASURED_IN_CANDIDATE/`refuted`)
2. carried-component mutation refused (fresh `measured_at` and payload edit both raise)
3. §7.3 typography encoding both cases (Costco → absent; registry merchant → explicit `{}`)
4. proposal-resolution idempotency (resolve → skip → absent-proposal report)
5. empty-catalog dry-run warns, no writes, no hard-block
6. FAIL gate leaves the version OPEN + gate record persists as the work list (exit 3)
7. PASS_WITH_GAPS seals with gaps recorded verbatim
8. live banner + unconditional prod refusal
9. `--live` requires an eval target

Formatted with black/isort (line-length 79); mypy clean.

## Staged owner command (the live ceremony — NOT run here)
Owner prerequisites: `ingest_merchant_catalog.py --apply` so the catalog partition is non-empty (dry-run warns loudly otherwise); pick a representative Costco receipt for the fidelity eval.

```
PORTFOLIO_ENV=dev python scripts/mint_merchant_truth_v2.py \
    --merchant 'Costco Wholesale' \
    --layout-payload tools/glyph-studio/fixtures/costco_variant_layout.sample.json \
    --eval-image-id <IMAGE_ID> --eval-receipt-id <RECEIPT_ID> \
    --live
```
(Run without `--live` first for the dry-run bundle + v1→v2 diff. After a PASS/PASS_WITH_GAPS seal, the ACTIVE flip stays a separate owner step.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BeLcSviHL5vDgS3zTSMbsq