### PR TITLE
[synthesis_loop] H6: standing corpus regression gate

### DIFF
--- a/synthesis_loop/corpus_baseline.json
+++ b/synthesis_loop/corpus_baseline.json
@@ -11,9 +11,18 @@
         },
         "columns": {
           "bands": {
-            "ITEMS": "PASS",
-            "PAYMENT": "UNTESTED",
-            "SUMMARY": "UNTESTED"
+            "ITEMS": {
+              "source": "bootstrap",
+              "verdict": "PASS"
+            },
+            "PAYMENT": {
+              "source": "bootstrap",
+              "verdict": "UNTESTED"
+            },
+            "SUMMARY": {
+              "source": "bootstrap",
+              "verdict": "UNTESTED"
+            }
           },
           "verdict": "PASS_WITH_GAPS"
         },
@@ -74,7 +83,10 @@
         },
         "columns": {
           "bands": {
-            "ALL": "PASS"
+            "ALL": {
+              "source": "bootstrap",
+              "verdict": "PASS"
+            }
           },
           "verdict": "PASS"
         },
@@ -120,6 +132,70 @@
       "truth": {
         "bundle_hash": "4010db5d5de3b0da8889df9c233ac86d92e54f15df8e7b7aa164c654154663be",
         "slug": "fixture_mart",
+        "version": 1
+      }
+    },
+    "variant_selftest_v1": {
+      "merchant": "Variant Selftest",
+      "metrics": {
+        "arithmetic": {
+          "n_items": 5,
+          "testable": 0,
+          "verdict": "UNTESTED",
+          "violated": 0
+        },
+        "columns": {
+          "bands": {
+            "ITEMS": {
+              "source": "profile",
+              "verdict": "PASS"
+            }
+          },
+          "verdict": "PASS"
+        },
+        "coverage_gaps": [
+          "arithmetic",
+          "graphics",
+          "style",
+          "style:total_line"
+        ],
+        "graphics": {
+          "verdict": "SKIPPED"
+        },
+        "logo": {
+          "area_ratio": null,
+          "center_offset_frac": null,
+          "size_ratio": null,
+          "verdict": "PASS"
+        },
+        "overall": "PASS_WITH_GAPS",
+        "separators": {
+          "kind_mismatches": 0,
+          "real_count": 0,
+          "synth_count": 0,
+          "verdict": "PASS"
+        },
+        "style": {
+          "body_stroke_rel_real": 0.0427,
+          "body_stroke_rel_synth": 0.0427,
+          "verdict": "UNTESTED"
+        },
+        "tokens": {
+          "ink_recall": 1.0,
+          "text_precision": 1.0,
+          "text_recall": 1.0,
+          "verdict": "PASS"
+        }
+      },
+      "name": "variant_selftest_v1",
+      "render_hashes": {
+        "real": "9cf391db7e6144773abf27ef9ac0fc48bc1a56a8341abc900360810c20b63a02",
+        "syn": "9cf391db7e6144773abf27ef9ac0fc48bc1a56a8341abc900360810c20b63a02"
+      },
+      "slug": "costco",
+      "truth": {
+        "bundle_hash": "78186ca27049c2b0f9126f54b8601ee4a555193889311a21f740d9cb172bcc52",
+        "slug": "variant_selftest",
         "version": 1
       }
     }

--- a/synthesis_loop/corpus_baseline.json
+++ b/synthesis_loop/corpus_baseline.json
@@ -1,0 +1,128 @@
+{
+  "entries": {
+    "costco_wholesale_v1": {
+      "merchant": "Costco Wholesale",
+      "metrics": {
+        "arithmetic": {
+          "n_items": 5,
+          "testable": 3,
+          "verdict": "PASS",
+          "violated": 0
+        },
+        "columns": {
+          "bands": {
+            "ITEMS": "PASS",
+            "PAYMENT": "UNTESTED",
+            "SUMMARY": "UNTESTED"
+          },
+          "verdict": "PASS_WITH_GAPS"
+        },
+        "coverage_gaps": [
+          "columns",
+          "columns:PAYMENT:amount",
+          "columns:SUMMARY:amount",
+          "graphics"
+        ],
+        "graphics": {
+          "verdict": "SKIPPED"
+        },
+        "logo": {
+          "area_ratio": 1.0,
+          "center_offset_frac": 0.0,
+          "size_ratio": 1.0,
+          "verdict": "PASS"
+        },
+        "overall": "PASS_WITH_GAPS",
+        "separators": {
+          "kind_mismatches": 0,
+          "real_count": 0,
+          "synth_count": 0,
+          "verdict": "PASS"
+        },
+        "style": {
+          "body_stroke_rel_real": 0.0427,
+          "body_stroke_rel_synth": 0.0427,
+          "verdict": "PASS"
+        },
+        "tokens": {
+          "ink_recall": 1.0,
+          "text_precision": 1.0,
+          "text_recall": 1.0,
+          "verdict": "PASS"
+        }
+      },
+      "name": "costco_wholesale_v1",
+      "render_hashes": {
+        "real": "b94210d9a3c15edf27c135568bcb975198e0ce4a037d17aa1eafb4c511931d8e",
+        "syn": "b94210d9a3c15edf27c135568bcb975198e0ce4a037d17aa1eafb4c511931d8e"
+      },
+      "slug": "costco",
+      "truth": {
+        "bundle_hash": "c5cd31202f7a52cee5f5b492c675ae4ed1d94241529bdc3d16d85b18bf7fd064",
+        "slug": "costco_wholesale",
+        "version": 1
+      }
+    },
+    "fixture_mart_v1": {
+      "merchant": "Fixture Mart",
+      "metrics": {
+        "arithmetic": {
+          "n_items": 4,
+          "testable": 3,
+          "verdict": "PASS",
+          "violated": 0
+        },
+        "columns": {
+          "bands": {
+            "ALL": "PASS"
+          },
+          "verdict": "PASS"
+        },
+        "coverage_gaps": [
+          "graphics",
+          "style",
+          "style:summary"
+        ],
+        "graphics": {
+          "verdict": "SKIPPED"
+        },
+        "logo": {
+          "area_ratio": 1.0,
+          "center_offset_frac": 0.0,
+          "size_ratio": 1.0,
+          "verdict": "PASS"
+        },
+        "overall": "PASS_WITH_GAPS",
+        "separators": {
+          "kind_mismatches": 0,
+          "real_count": 0,
+          "synth_count": 0,
+          "verdict": "PASS"
+        },
+        "style": {
+          "body_stroke_rel_real": 0.0549,
+          "body_stroke_rel_synth": 0.0549,
+          "verdict": "PASS_WITH_GAPS"
+        },
+        "tokens": {
+          "ink_recall": 1.0,
+          "text_precision": 1.0,
+          "text_recall": 1.0,
+          "verdict": "PASS"
+        }
+      },
+      "name": "fixture_mart_v1",
+      "render_hashes": {
+        "real": "2908e4329a6dc30dda137560a01b9c7fedf150bd68f65d79ad465d5006f5534c",
+        "syn": "2908e4329a6dc30dda137560a01b9c7fedf150bd68f65d79ad465d5006f5534c"
+      },
+      "slug": "fixture_mart",
+      "truth": {
+        "bundle_hash": "4010db5d5de3b0da8889df9c233ac86d92e54f15df8e7b7aa164c654154663be",
+        "slug": "fixture_mart",
+        "version": 1
+      }
+    }
+  },
+  "version": 1
+}

--- a/synthesis_loop/corpus_manifest.json
+++ b/synthesis_loop/corpus_manifest.json
@@ -1,0 +1,19 @@
+{
+ "version": 1,
+ "entries": [
+  {
+   "name": "costco_wholesale_v1",
+   "merchant": "Costco Wholesale",
+   "truth_fixture": "tests/fixtures/merchant_truth/costco_wholesale_v1.json",
+   "eval_inputs": "tests/fixtures/corpus_gate/costco_wholesale_v1.inputs.json",
+   "columns_source": "bootstrap"
+  },
+  {
+   "name": "fixture_mart_v1",
+   "merchant": "Fixture Mart",
+   "truth_fixture": "tests/fixtures/merchant_truth/fixture_mart.v1.json",
+   "eval_inputs": "tests/fixtures/corpus_gate/fixture_mart_v1.inputs.json",
+   "columns_source": "bootstrap"
+  }
+ ]
+}

--- a/synthesis_loop/corpus_manifest.json
+++ b/synthesis_loop/corpus_manifest.json
@@ -14,6 +14,13 @@
    "truth_fixture": "tests/fixtures/merchant_truth/fixture_mart.v1.json",
    "eval_inputs": "tests/fixtures/corpus_gate/fixture_mart_v1.inputs.json",
    "columns_source": "bootstrap"
+  },
+  {
+   "name": "variant_selftest_v1",
+   "merchant": "Variant Selftest",
+   "truth_fixture": "tests/fixtures/merchant_truth/variant_selftest.v1.json",
+   "eval_inputs": "tests/fixtures/corpus_gate/variant_selftest_v1.inputs.json",
+   "columns_source": "profile"
   }
  ]
 }

--- a/synthesis_loop/corpus_regression_gate.py
+++ b/synthesis_loop/corpus_regression_gate.py
@@ -1,0 +1,493 @@
+#!/usr/bin/env python3.12
+"""Standing eval-regression corpus gate (offline, zero AWS, PR-runner-safe).
+
+Companion to ``render_regression_guard.py``. Where that guard pins the
+production RENDERER's pixels (re-rendering shipped receipts through
+``glyph_review`` -- which needs the dev table + S3 + creds), THIS gate pins
+the EVAL LOGIC: it freezes ``full_fidelity_eval``'s seven metric verdicts and
+their load-bearing numeric values over a corpus of committed offline fixtures,
+so a change to a metric threshold, the merchant-truth loader, or the stylemap
+classifier that silently flips a corpus receipt's verdict fails loudly in CI
+-- with NO AWS credentials.
+
+Why this cannot just shell out to ``full_fidelity_eval run --truth-fixture``:
+that subcommand's ``--truth-fixture`` flag only makes the merchant-TRUTH
+resolution offline. The receipt it evaluates is still fetched live --
+``section_compare.render_pair`` reads the font profile, glyph atlas, receipt
+words and the real S3 image from the dev table for EVERY run. Truth-fixture
+mode is therefore NOT zero-AWS for ``run``, and one corpus merchant
+(``fixture_mart``) is a pure fixture with no receipt in any table at all. So
+the gate drives the eval's genuinely-offline pure core directly:
+``resolve_truth(fixture_path=...)`` + ``evaluate_pair(...)``, feeding it
+vendored receipt inputs (OCR word manifests) and deterministically-rendered
+image pairs. No boto3, no DynamoDB, no S3. The default ``--write-gate-record
+False`` is not even reachable here (the CLI ``run`` path is not used), so no
+gate record is ever written.
+
+The corpus:
+  - ``corpus_manifest.json`` (beside this script) lists entries; each names a
+    committed merchant-truth fixture (``tests/fixtures/merchant_truth/*.json``)
+    plus a committed eval-input bundle
+    (``tests/fixtures/corpus_gate/*.inputs.json`` -- the OCR word manifest and
+    the synth word list). Adding a future merchant = add a truth fixture, add
+    an inputs bundle, add a manifest entry, re-``capture``.
+  - ``corpus_baseline.json`` (beside this script) is the committed baseline:
+    per-entry metric verdicts, the relevant metric values, and render hashes.
+
+Verbs (mirroring render_regression_guard's capture/compare/check):
+  corpus_regression_gate.py capture [out_path]
+      Run the offline eval over every manifest entry and WRITE the baseline
+      (default: the committed ``corpus_baseline.json``). Re-capture and commit
+      only for an intended, reviewed eval change.
+  corpus_regression_gate.py compare <baseline_path> [--json]
+      Fresh-capture and diff against ``baseline_path``; print findings.
+  corpus_regression_gate.py check [--json]
+      Fresh-capture and diff against the COMMITTED baseline. Exit nonzero on
+      any regression. ``--json`` emits the findings as a machine-parseable
+      document (``{"ok": bool, "findings": [...]}``) on stdout -- H7's CI
+      comment poster consumes this directly.
+
+Each finding names the receipt, the metric, the field, the baseline and
+current values, and (for numerics) the delta -- e.g.
+``{"receipt": "costco_wholesale_v1", "metric": "tokens", "field": "verdict",
+"baseline": "PASS", "current": "FAIL"}``.
+
+Intended CI invocation (wired in H7, NOT here):
+    python3.12 synthesis_loop/corpus_regression_gate.py check --json
+On a self-hosted PR runner with NO AWS credentials. Exit 0 = corpus stable;
+exit 1 = a metric verdict/value/render-hash regressed (findings on stdout for
+the comment poster); exit 2 = usage error.
+
+Determinism: the eval core is pure over its inputs (median/numpy, no RNG). The
+ONE nondeterminism source is metric 5 (graphics), which shells out to the
+Swift ``receipt-ocr`` barcode detector whose availability varies by machine.
+The gate PINS it OFF (``RECEIPT_OCR_BIN`` -> a guaranteed-missing path) so
+graphics is deterministically ``SKIPPED`` on every runner and two same-commit
+captures are byte-identical. The fixtures carry no barcodes, so nothing is
+lost by pinning it off.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.dirname(HERE)
+for _p in (HERE, os.path.join(REPO, "scripts")):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+MANIFEST_PATH = os.path.join(HERE, "corpus_manifest.json")
+COMMITTED_BASELINE = os.path.join(HERE, "corpus_baseline.json")
+
+# The one pinned nondeterminism source (see module docstring): force the
+# barcode detector missing so metric_graphics is deterministically SKIPPED.
+# Set BEFORE full_fidelity_eval is imported (it reads the env at import time).
+_MISSING_BARCODE_BIN = os.path.join(HERE, "__corpus_gate_no_barcode_bin__")
+os.environ["RECEIPT_OCR_BIN"] = _MISSING_BARCODE_BIN
+
+# Numeric fields equal within this are "unchanged" (rounding stability).
+_EPS = 1e-6
+
+_METRIC_ORDER = (
+    "columns",
+    "style",
+    "tokens",
+    "separators",
+    "graphics",
+    "logo",
+    "arithmetic",
+)
+
+
+def _load_json(path: str) -> dict:
+    with open(path, encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def _repo_path(rel: str) -> str:
+    """Resolve a manifest-relative path against the repo root."""
+    return rel if os.path.isabs(rel) else os.path.join(REPO, rel)
+
+
+# ---------------------------------------------------------------------------
+# deterministic offline render: OCR-format words -> a stable pixel image.
+# This is NOT the production renderer (that needs AWS and is render_regression
+# _guard's jurisdiction); it is a fixed, reproducible stand-in so evaluate_pair
+# has real pixels to measure. The renderer-format bbox convention (0-1000,
+# y-up) matches full_fidelity_eval.words_to_px.
+# ---------------------------------------------------------------------------
+def render_fixture_image(words: list[dict], w: int, h: int):
+    import numpy as np
+    from PIL import Image
+
+    arr = np.full((h, w), 245, dtype=np.uint8)
+    for word in words:
+        bb = word.get("bbox")
+        if not bb:
+            continue
+        x0, y0, x1, y1 = (float(v) for v in bb[:4])
+        left = int(min(x0, x1) / 1000.0 * w)
+        right = int(max(x0, x1) / 1000.0 * w)
+        top = int((1 - max(y0, y1) / 1000.0) * h)
+        bottom = int((1 - min(y0, y1) / 1000.0) * h)
+        left = max(0, min(w, left))
+        right = max(0, min(w, right))
+        top = max(0, min(h, top))
+        bottom = max(0, min(h, bottom))
+        if right - left < 1 or bottom - top < 1:
+            continue
+        # Ink the glyph run, leaving a 1px inter-character comb so the column
+        # and token ink-scans see structured strokes, not a solid bar.
+        block = arr[top:bottom, left:right]
+        block[:, ::2] = 30
+    return Image.fromarray(arr, "L").convert("RGB"), arr
+
+
+def _pixel_hash(arr) -> str:
+    """SHA over the raw pixel buffer (PIL/zlib-version independent)."""
+    return hashlib.sha256(arr.tobytes()).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# compact per-entry summary of an evaluate_pair result. Only the load-bearing
+# scalars are recorded, so a baseline diff can name a metric + a numeric delta
+# without carrying the eval's large nested arrays.
+# ---------------------------------------------------------------------------
+def _metric_summary(checks: dict) -> dict:
+    col = checks["columns"]
+    style = checks["style"]
+    tokens = checks["tokens"]
+    seps = checks["separators"]
+    logo = checks["logo"]
+    arith = checks["arithmetic"]
+    return {
+        "overall": checks["overall"],
+        "coverage_gaps": sorted(checks.get("coverage_gaps", [])),
+        "columns": {
+            "verdict": col["verdict"],
+            "bands": {
+                name: band["verdict"]
+                for name, band in (col.get("bands") or {}).items()
+            },
+        },
+        "style": {
+            "verdict": style["verdict"],
+            "body_stroke_rel_real": (style.get("body_stroke_rel") or {}).get(
+                "real"
+            ),
+            "body_stroke_rel_synth": (style.get("body_stroke_rel") or {}).get(
+                "synth"
+            ),
+        },
+        "tokens": {
+            "verdict": tokens["verdict"],
+            "text_recall": tokens.get("text_recall"),
+            "text_precision": tokens.get("text_precision"),
+            "ink_recall": tokens.get("ink_recall"),
+        },
+        "separators": {
+            "verdict": seps["verdict"],
+            "real_count": seps.get("real_count"),
+            "synth_count": seps.get("synth_count"),
+            "kind_mismatches": seps.get("kind_mismatches"),
+        },
+        "graphics": {"verdict": checks["graphics"]["verdict"]},
+        "logo": {
+            "verdict": logo["verdict"],
+            "size_ratio": logo.get("size_ratio"),
+            "area_ratio": logo.get("area_ratio"),
+            "center_offset_frac": logo.get("center_offset_frac"),
+        },
+        "arithmetic": {
+            "verdict": arith["verdict"],
+            **{
+                k: v
+                for k, v in arith.items()
+                if k != "verdict"
+                and (isinstance(v, (int, float, bool)) or v is None)
+            },
+        },
+    }
+
+
+def capture_entry(entry: dict) -> dict:
+    """Run the offline eval for one corpus entry -> baseline record."""
+    import full_fidelity_eval as ffe
+
+    # Pin the graphics nondeterminism OFF at runtime too: if another test
+    # imported full_fidelity_eval before our env export ran, its _BARCODE_BIN
+    # may still point at a present Swift binary. Force it missing so
+    # metric_graphics is deterministically SKIPPED on every machine.
+    ffe._BARCODE_BIN = _MISSING_BARCODE_BIN
+
+    inputs = _load_json(_repo_path(entry["eval_inputs"]))
+    truth = ffe.resolve_truth(
+        entry["merchant"],
+        fixture_path=_repo_path(entry["truth_fixture"]),
+    )
+    canvas = inputs.get("canvas") or {"w": 400, "h": 600}
+    w, h = int(canvas["w"]), int(canvas["h"])
+    manifest_words = inputs["manifest_words"]
+    syn_words = inputs["syn_words"]
+    real_img, real_arr = render_fixture_image(manifest_words, w, h)
+    syn_img, syn_arr = render_fixture_image(syn_words, w, h)
+    checks = ffe.evaluate_pair(
+        real_img,
+        syn_img,
+        manifest_words,
+        syn_words,
+        slug=inputs["slug"],
+        truth=truth,
+        real_png="<offline>",
+        syn_png="<offline>",
+        composed=bool(inputs.get("composed", False)),
+        columns_source=entry.get("columns_source", "bootstrap"),
+        section_sequence=inputs.get("section_sequence") or [],
+    )
+    return {
+        "name": entry["name"],
+        "merchant": entry["merchant"],
+        "slug": inputs["slug"],
+        "truth": {
+            "slug": truth.slug,
+            "version": truth.version,
+            "bundle_hash": truth.bundle_hash,
+        },
+        "render_hashes": {
+            "real": _pixel_hash(real_arr),
+            "syn": _pixel_hash(syn_arr),
+        },
+        "metrics": _metric_summary(checks),
+    }
+
+
+def capture_all(manifest_path: str = MANIFEST_PATH) -> dict:
+    manifest = _load_json(manifest_path)
+    entries = [capture_entry(e) for e in manifest["entries"]]
+    return {
+        "version": manifest.get("version", 1),
+        "entries": {e["name"]: e for e in entries},
+    }
+
+
+def capture(out_path: str | None = None) -> int:
+    baseline = capture_all()
+    out_path = out_path or COMMITTED_BASELINE
+    with open(out_path, "w", encoding="utf-8") as fh:
+        json.dump(baseline, fh, indent=2, sort_keys=True)
+        fh.write("\n")
+    print(f"corpus baseline captured: {out_path}")
+    print(f"  entries: {sorted(baseline['entries'])}")
+    for name, rec in sorted(baseline["entries"].items()):
+        print(f"  {name}: overall={rec['metrics']['overall']}")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# diff: baseline record vs fresh record -> findings naming receipt+metric+delta
+# ---------------------------------------------------------------------------
+def _walk_scalars(node, prefix=""):
+    """Yield (dotted_field, value) for every scalar leaf in a metric dict."""
+    if isinstance(node, dict):
+        for key in sorted(node):
+            yield from _walk_scalars(
+                node[key], f"{prefix}.{key}" if prefix else str(key)
+            )
+    elif isinstance(node, list):
+        # lists (e.g. coverage_gaps) compare as a whole ordered value
+        yield prefix, tuple(node)
+    else:
+        yield prefix, node
+
+
+def _diff_entry(name: str, base: dict, cur: dict) -> list[dict]:
+    findings: list[dict] = []
+
+    # truth tuple + render hashes: any drift is a regression of the pinned
+    # inputs, reported under a synthetic metric name.
+    for field in ("slug", "version", "bundle_hash"):
+        b = base.get("truth", {}).get(field)
+        c = cur.get("truth", {}).get(field)
+        if b != c:
+            findings.append(
+                {
+                    "receipt": name,
+                    "metric": "truth",
+                    "field": field,
+                    "baseline": b,
+                    "current": c,
+                }
+            )
+    for side in ("real", "syn"):
+        b = base.get("render_hashes", {}).get(side)
+        c = cur.get("render_hashes", {}).get(side)
+        if b != c:
+            findings.append(
+                {
+                    "receipt": name,
+                    "metric": "render",
+                    "field": side,
+                    "baseline": b,
+                    "current": c,
+                }
+            )
+
+    base_m = base.get("metrics", {})
+    cur_m = cur.get("metrics", {})
+    base_leaves = dict(_walk_scalars(base_m))
+    cur_leaves = dict(_walk_scalars(cur_m))
+    for field in sorted(set(base_leaves) | set(cur_leaves)):
+        b = base_leaves.get(field)
+        c = cur_leaves.get(field)
+        if b == c:
+            continue
+        # numeric drift within rounding epsilon is not a regression
+        if (
+            isinstance(b, (int, float))
+            and isinstance(c, (int, float))
+            and not isinstance(b, bool)
+            and not isinstance(c, bool)
+            and abs(b - c) <= _EPS
+        ):
+            continue
+        metric = field.split(".", 1)[0]
+        finding = {
+            "receipt": name,
+            "metric": metric,
+            "field": field,
+            "baseline": _jsonable(b),
+            "current": _jsonable(c),
+        }
+        if (
+            isinstance(b, (int, float))
+            and isinstance(c, (int, float))
+            and not isinstance(b, bool)
+            and not isinstance(c, bool)
+        ):
+            finding["delta"] = round(c - b, 6)
+        findings.append(finding)
+    return findings
+
+
+def _jsonable(value):
+    return list(value) if isinstance(value, tuple) else value
+
+
+def diff_baselines(baseline: dict, current: dict) -> list[dict]:
+    findings: list[dict] = []
+    base_entries = baseline.get("entries", {})
+    cur_entries = current.get("entries", {})
+    missing = sorted(set(base_entries) - set(cur_entries))
+    extra = sorted(set(cur_entries) - set(base_entries))
+    for name in missing:
+        findings.append(
+            {
+                "receipt": name,
+                "metric": "corpus",
+                "field": "presence",
+                "baseline": "present",
+                "current": "missing",
+            }
+        )
+    for name in extra:
+        findings.append(
+            {
+                "receipt": name,
+                "metric": "corpus",
+                "field": "presence",
+                "baseline": "absent",
+                "current": "present",
+            }
+        )
+    for name in sorted(set(base_entries) & set(cur_entries)):
+        findings.extend(
+            _diff_entry(name, base_entries[name], cur_entries[name])
+        )
+    return findings
+
+
+def _print_findings(findings: list[dict]) -> None:
+    for f in findings:
+        line = (
+            f"REGRESSION {f['receipt']} / {f['metric']} / {f['field']}: "
+            f"{f['baseline']!r} -> {f['current']!r}"
+        )
+        if "delta" in f:
+            line += f" (delta {f['delta']:+g})"
+        print(line)
+
+
+def compare(baseline_path: str, as_json: bool = False) -> int:
+    baseline = _load_json(baseline_path)
+    current = capture_all()
+    findings = diff_baselines(baseline, current)
+    if as_json:
+        print(
+            json.dumps(
+                {"ok": not findings, "findings": findings},
+                indent=2,
+                sort_keys=True,
+            )
+        )
+    else:
+        if findings:
+            _print_findings(findings)
+            print(f"REGRESSION: {len(findings)} finding(s) vs {baseline_path}")
+        else:
+            print(f"corpus stable vs {baseline_path}")
+    return 1 if findings else 0
+
+
+def check(as_json: bool = False) -> int:
+    """Diff a fresh offline capture against the COMMITTED baseline."""
+    baseline = _load_json(COMMITTED_BASELINE)
+    current = capture_all()
+    findings = diff_baselines(baseline, current)
+    if as_json:
+        print(
+            json.dumps(
+                {
+                    "ok": not findings,
+                    "baseline": os.path.relpath(COMMITTED_BASELINE, REPO),
+                    "findings": findings,
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+    else:
+        if findings:
+            _print_findings(findings)
+            print(
+                f"REGRESSION vs committed baseline: {len(findings)} finding(s)"
+            )
+        else:
+            print("corpus stable vs committed baseline")
+    return 1 if findings else 0
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    sub = ap.add_subparsers(dest="verb", required=True)
+    p_cap = sub.add_parser("capture")
+    p_cap.add_argument("out_path", nargs="?", default=None)
+    p_cmp = sub.add_parser("compare")
+    p_cmp.add_argument("baseline_path")
+    p_cmp.add_argument("--json", action="store_true", dest="as_json")
+    p_chk = sub.add_parser("check")
+    p_chk.add_argument("--json", action="store_true", dest="as_json")
+    args = ap.parse_args(argv)
+    if args.verb == "capture":
+        return capture(args.out_path)
+    if args.verb == "compare":
+        return compare(args.baseline_path, as_json=args.as_json)
+    return check(as_json=args.as_json)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/synthesis_loop/corpus_regression_gate.py
+++ b/synthesis_loop/corpus_regression_gate.py
@@ -24,6 +24,25 @@ image pairs. No boto3, no DynamoDB, no S3. The default ``--write-gate-record
 False`` is not even reachable here (the CLI ``run`` path is not used), so no
 gate record is ever written.
 
+Consequently, what THIS gate does NOT cover -- deliberately, because each
+needs AWS and/or is another guard's jurisdiction:
+  - the production RENDERER's pixels (``section_compare.render_pair`` -- font
+    profile, glyph atlas, receipt words, real S3 image): render_regression
+    _guard.py's job, and it needs the dev table + S3 + creds. Our "render
+    hashes" pin the DETERMINISTIC fixture render of the committed words, not
+    production renderer output.
+  - ``build_stamp`` provenance (git SHA / dirty-worktree / atlas hash /
+    ``inputs_hash`` over live image+manifest+detector bytes): a run-stamp
+    concern, not a metric-verdict concern, and it reads the worktree/AWS.
+  - compose-derivation (``compose_dollartree.canonical_words`` and the
+    ``composed`` re-layout branch in ``run``): the corpus feeds ``syn_words``
+    directly, so ``composed`` is carried as a fixture flag, not derived.
+  - ``section_sequence`` LOADING (``load_section_sequence`` -- a Dynamo read):
+    the corpus vendors the sequence in the inputs bundle instead.
+  - the ONLINE freshness gate (``_capture_expected_active`` strong-read +
+    stale-cache detection) and PINNED mode: fixture mode's fail-closed hash
+    verification is the only truth-resolution path exercised here.
+
 The corpus:
   - ``corpus_manifest.json`` (beside this script) lists entries; each names a
     committed merchant-truth fixture (``tests/fixtures/merchant_truth/*.json``)
@@ -50,7 +69,11 @@ Verbs (mirroring render_regression_guard's capture/compare/check):
 Each finding names the receipt, the metric, the field, the baseline and
 current values, and (for numerics) the delta -- e.g.
 ``{"receipt": "costco_wholesale_v1", "metric": "tokens", "field": "verdict",
-"baseline": "PASS", "current": "FAIL"}``.
+"baseline": "PASS", "current": "FAIL"}``. NOTE for consumers (H7's poster):
+``delta`` is OPTIONAL -- it is present only when both values are numeric
+(verdict/string/render-hash findings carry no ``delta``), so a consumer must
+``.get("delta")`` rather than index it. The gate's own text printer already
+guards it this way.
 
 Intended CI invocation (wired in H7, NOT here):
     python3.12 synthesis_loop/corpus_regression_gate.py check --json
@@ -171,7 +194,15 @@ def _metric_summary(checks: dict) -> dict:
         "columns": {
             "verdict": col["verdict"],
             "bands": {
-                name: band["verdict"]
+                # per band: verdict + which lane SOURCE produced it. For
+                # columns_source="profile" entries the source is "profile"
+                # (the §7.2 variant selection ran); a profile/select_variant
+                # regression that empties the lane flips it to
+                # "bootstrap(no-profile-data)", a recorded regression.
+                name: {
+                    "verdict": band["verdict"],
+                    "source": band.get("source"),
+                }
                 for name, band in (col.get("bands") or {}).items()
             },
         },

--- a/tests/fixtures/corpus_gate/build_corpus_inputs.py
+++ b/tests/fixtures/corpus_gate/build_corpus_inputs.py
@@ -105,6 +105,46 @@ def fixture_mart_words() -> list[dict]:
     return rows
 
 
+def variant_selftest_words() -> list[dict]:
+    """A receipt exercising the §7.2 profile/variant column path.
+
+    Uses the costco SECTION_BANDS (via ``slug="costco"``) so item rows land
+    in the ITEMS band. The amount lane is inked at right-edge x=0.70 -- where
+    the ``variant_selftest`` truth bundle's WINNING variant (checkout-high,
+    support 7) places it. The words carry both the ``SELF`` and ``CHECKOUT``
+    text markers, so both variants match and the tie-break selects the
+    high-support one; a selector regression to the DEFAULT (x=0.86) or the
+    low-support variant (x=0.60) moves the profile lane off the ink and the
+    columns metric goes UNTESTED.
+    """
+    rows = []
+    # STOREFRONT
+    rows += _row(950, [("VARIANT", 340, 260, []), ("SELFTEST", 620, 260, [])])
+    # ITEMS: amounts right-edge at x=560+140=700 -> 0.70 (the winner lane)
+    rows += _row(
+        860, [("MILK", 120, 170, []), ("3.99", 560, 140, ["LINE_TOTAL"])]
+    )
+    rows += _row(
+        820, [("BREAD", 120, 200, []), ("2.50", 560, 140, ["LINE_TOTAL"])]
+    )
+    rows += _row(
+        780, [("EGGS", 120, 160, []), ("4.29", 560, 140, ["LINE_TOTAL"])]
+    )
+    rows += _row(
+        740, [("CHEESE", 120, 240, []), ("5.75", 560, 140, ["LINE_TOTAL"])]
+    )
+    rows += _row(
+        700, [("JUICE", 120, 190, []), ("4.25", 560, 140, ["LINE_TOTAL"])]
+    )
+    # SUMMARY
+    rows += _row(420, [("TOTAL", 120, 200, []), ("20.78", 540, 160, [])])
+    # PAYMENT: the SELF / CHECKOUT markers the classifier_hint matches on
+    rows += _row(260, [("SELF", 200, 160, []), ("CHECKOUT", 420, 300, [])])
+    # FOOTER
+    rows += _row(120, [("THANK", 250, 200, []), ("YOU", 470, 150, [])])
+    return rows
+
+
 BUNDLES = {
     "costco_wholesale_v1.inputs.json": {
         "slug": "costco",
@@ -125,6 +165,21 @@ BUNDLES = {
         "section_sequence": [],
         "canvas": {"w": 420, "h": 700},
         "words": fixture_mart_words,
+    },
+    "variant_selftest_v1.inputs.json": {
+        # slug=costco borrows costco's SECTION_BANDS so items land in the
+        # ITEMS band; the truth resolves via merchant "Variant Selftest".
+        "slug": "costco",
+        "composed": False,
+        "section_sequence": [
+            "storefront",
+            "items",
+            "summary",
+            "payment",
+            "footer",
+        ],
+        "canvas": {"w": 460, "h": 900},
+        "words": variant_selftest_words,
     },
 }
 

--- a/tests/fixtures/corpus_gate/build_corpus_inputs.py
+++ b/tests/fixtures/corpus_gate/build_corpus_inputs.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3.12
+"""Regenerate the committed corpus-gate eval-input bundles (offline).
+
+Each bundle is the vendored, AWS-free stand-in for one receipt that
+``corpus_regression_gate.py`` feeds to ``full_fidelity_eval.evaluate_pair``:
+an OCR word manifest (``manifest_words`` -- what the "real" side prints) and
+the synth word list (``syn_words`` -- what the render drew). The gate renders
+a deterministic image pair from these words, so no real receipt / S3 image is
+ever needed.
+
+Words use full_fidelity_eval's renderer format: ``bbox`` is ``[x0, y0, x1,
+y1]`` on a 0-1000 grid with a y-UP origin (y=1000 is the top of the receipt).
+Rows are placed so that, for slugs with declared SECTION_BANDS (costco), each
+line falls in its intended band.
+
+Deterministic: re-running writes byte-identical JSON. Run from the repo root:
+
+    python3.12 tests/fixtures/corpus_gate/build_corpus_inputs.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+
+def _word(text, x, y, width, labels=None, height=26):
+    """A word box: left x, bottom y (renderer y-up), width -- all /1000."""
+    return {
+        "text": text,
+        "line_id": 0,
+        "word_id": 0,
+        "bbox": [x, y, x + width, y + height],
+        "labels": list(labels or []),
+    }
+
+
+def _row(y, cells):
+    """A row at renderer-y ``y``; cells = list of (text, x, width, labels)."""
+    return [_word(t, x, y, w, lbl) for (t, x, w, lbl) in cells]
+
+
+def costco_words() -> list[dict]:
+    """A small Costco-shaped receipt landing lines in their SECTION_BANDS.
+
+    STOREFRONT ~910-1000, ITEMS ~450-910, SUMMARY ~340-450,
+    PAYMENT ~180-340, FOOTER ~0-180 (renderer y-up).
+    """
+    rows = []
+    # STOREFRONT
+    rows += _row(950, [("COSTCO", 380, 240, [])])
+    rows += _row(920, [("WHOLESALE", 360, 280, [])])
+    # ITEMS (description left, line total right; a couple carry LINE_TOTAL)
+    rows += _row(
+        860, [("BANANAS", 120, 260, []), ("1.99", 720, 130, ["LINE_TOTAL"])]
+    )
+    rows += _row(
+        820, [("MILK", 120, 170, []), ("3.49", 720, 130, ["LINE_TOTAL"])]
+    )
+    rows += _row(
+        780, [("EGGS", 120, 160, []), ("4.29", 720, 130, ["LINE_TOTAL"])]
+    )
+    rows += _row(
+        740, [("BREAD", 120, 200, []), ("2.50", 720, 130, ["LINE_TOTAL"])]
+    )
+    rows += _row(
+        700, [("COFFEE", 120, 230, []), ("9.99", 720, 130, ["LINE_TOTAL"])]
+    )
+    # SUMMARY
+    rows += _row(420, [("SUBTOTAL", 120, 300, []), ("22.26", 700, 150, [])])
+    rows += _row(390, [("TAX", 120, 120, []), ("0.00", 720, 130, [])])
+    rows += _row(360, [("TOTAL", 120, 200, []), ("22.26", 700, 150, [])])
+    # PAYMENT
+    rows += _row(300, [("VISA", 120, 160, []), ("22.26", 700, 150, [])])
+    rows += _row(260, [("CHANGE", 120, 230, []), ("0.00", 720, 130, [])])
+    # FOOTER
+    rows += _row(120, [("THANK", 250, 200, []), ("YOU", 470, 150, [])])
+    rows += _row(80, [("ITEMS", 250, 200, []), ("SOLD", 470, 180, [])])
+    return rows
+
+
+def fixture_mart_words() -> list[dict]:
+    """A generic single-band receipt for the pure-fixture merchant."""
+    rows = []
+    rows += _row(950, [("FIXTURE", 340, 240, []), ("MART", 600, 170, [])])
+    rows += _row(
+        860, [("APPLES", 120, 230, []), ("3.99", 720, 130, ["LINE_TOTAL"])]
+    )
+    rows += _row(
+        820, [("BREAD", 120, 200, []), ("2.50", 720, 130, ["LINE_TOTAL"])]
+    )
+    rows += _row(
+        780, [("CHEESE", 120, 240, []), ("5.75", 720, 130, ["LINE_TOTAL"])]
+    )
+    rows += _row(
+        740, [("JUICE", 120, 190, []), ("4.25", 720, 130, ["LINE_TOTAL"])]
+    )
+    rows += _row(600, [("SUBTOTAL", 120, 300, []), ("16.49", 700, 150, [])])
+    rows += _row(560, [("TAX", 120, 120, []), ("0.00", 720, 130, [])])
+    rows += _row(520, [("TOTAL", 120, 200, []), ("16.49", 700, 150, [])])
+    rows += _row(400, [("CASH", 120, 160, []), ("16.49", 700, 150, [])])
+    rows += _row(120, [("THANK", 300, 200, []), ("YOU", 520, 150, [])])
+    return rows
+
+
+BUNDLES = {
+    "costco_wholesale_v1.inputs.json": {
+        "slug": "costco",
+        "composed": False,
+        "section_sequence": [
+            "STOREFRONT",
+            "ITEMS",
+            "SUMMARY",
+            "PAYMENT",
+            "FOOTER",
+        ],
+        "canvas": {"w": 460, "h": 900},
+        "words": costco_words,
+    },
+    "fixture_mart_v1.inputs.json": {
+        "slug": "fixture_mart",
+        "composed": False,
+        "section_sequence": [],
+        "canvas": {"w": 420, "h": 700},
+        "words": fixture_mart_words,
+    },
+}
+
+
+def build_one(spec: dict) -> dict:
+    words = spec["words"]()
+    return {
+        "slug": spec["slug"],
+        "composed": spec["composed"],
+        "section_sequence": spec["section_sequence"],
+        "canvas": spec["canvas"],
+        # clean baseline: the synth drew exactly the manifest (real) content
+        "manifest_words": words,
+        "syn_words": words,
+    }
+
+
+def main() -> int:
+    for filename, spec in BUNDLES.items():
+        out = os.path.join(HERE, filename)
+        with open(out, "w", encoding="utf-8") as fh:
+            json.dump(build_one(spec), fh, indent=1, sort_keys=True)
+            fh.write("\n")
+        print(f"wrote {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/corpus_gate/costco_wholesale_v1.inputs.json
+++ b/tests/fixtures/corpus_gate/costco_wholesale_v1.inputs.json
@@ -1,0 +1,663 @@
+{
+ "canvas": {
+  "h": 900,
+  "w": 460
+ },
+ "composed": false,
+ "manifest_words": [
+  {
+   "bbox": [
+    380,
+    950,
+    620,
+    976
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "COSTCO",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    360,
+    920,
+    640,
+    946
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "WHOLESALE",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    120,
+    860,
+    380,
+    886
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "BANANAS",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    720,
+    860,
+    850,
+    886
+   ],
+   "labels": [
+    "LINE_TOTAL"
+   ],
+   "line_id": 0,
+   "text": "1.99",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    120,
+    820,
+    290,
+    846
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "MILK",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    720,
+    820,
+    850,
+    846
+   ],
+   "labels": [
+    "LINE_TOTAL"
+   ],
+   "line_id": 0,
+   "text": "3.49",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    120,
+    780,
+    280,
+    806
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "EGGS",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    720,
+    780,
+    850,
+    806
+   ],
+   "labels": [
+    "LINE_TOTAL"
+   ],
+   "line_id": 0,
+   "text": "4.29",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    120,
+    740,
+    320,
+    766
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "BREAD",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    720,
+    740,
+    850,
+    766
+   ],
+   "labels": [
+    "LINE_TOTAL"
+   ],
+   "line_id": 0,
+   "text": "2.50",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    120,
+    700,
+    350,
+    726
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "COFFEE",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    720,
+    700,
+    850,
+    726
+   ],
+   "labels": [
+    "LINE_TOTAL"
+   ],
+   "line_id": 0,
+   "text": "9.99",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    120,
+    420,
+    420,
+    446
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "SUBTOTAL",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    700,
+    420,
+    850,
+    446
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "22.26",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    120,
+    390,
+    240,
+    416
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "TAX",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    720,
+    390,
+    850,
+    416
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "0.00",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    120,
+    360,
+    320,
+    386
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "TOTAL",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    700,
+    360,
+    850,
+    386
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "22.26",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    120,
+    300,
+    280,
+    326
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "VISA",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    700,
+    300,
+    850,
+    326
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "22.26",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    120,
+    260,
+    350,
+    286
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "CHANGE",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    720,
+    260,
+    850,
+    286
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "0.00",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    250,
+    120,
+    450,
+    146
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "THANK",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    470,
+    120,
+    620,
+    146
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "YOU",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    250,
+    80,
+    450,
+    106
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "ITEMS",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    470,
+    80,
+    650,
+    106
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "SOLD",
+   "word_id": 0
+  }
+ ],
+ "section_sequence": [
+  "STOREFRONT",
+  "ITEMS",
+  "SUMMARY",
+  "PAYMENT",
+  "FOOTER"
+ ],
+ "slug": "costco",
+ "syn_words": [
+  {
+   "bbox": [
+    380,
+    950,
+    620,
+    976
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "COSTCO",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    360,
+    920,
+    640,
+    946
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "WHOLESALE",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    120,
+    860,
+    380,
+    886
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "BANANAS",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    720,
+    860,
+    850,
+    886
+   ],
+   "labels": [
+    "LINE_TOTAL"
+   ],
+   "line_id": 0,
+   "text": "1.99",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    120,
+    820,
+    290,
+    846
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "MILK",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    720,
+    820,
+    850,
+    846
+   ],
+   "labels": [
+    "LINE_TOTAL"
+   ],
+   "line_id": 0,
+   "text": "3.49",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    120,
+    780,
+    280,
+    806
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "EGGS",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    720,
+    780,
+    850,
+    806
+   ],
+   "labels": [
+    "LINE_TOTAL"
+   ],
+   "line_id": 0,
+   "text": "4.29",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    120,
+    740,
+    320,
+    766
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "BREAD",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    720,
+    740,
+    850,
+    766
+   ],
+   "labels": [
+    "LINE_TOTAL"
+   ],
+   "line_id": 0,
+   "text": "2.50",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    120,
+    700,
+    350,
+    726
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "COFFEE",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    720,
+    700,
+    850,
+    726
+   ],
+   "labels": [
+    "LINE_TOTAL"
+   ],
+   "line_id": 0,
+   "text": "9.99",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    120,
+    420,
+    420,
+    446
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "SUBTOTAL",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    700,
+    420,
+    850,
+    446
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "22.26",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    120,
+    390,
+    240,
+    416
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "TAX",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    720,
+    390,
+    850,
+    416
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "0.00",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    120,
+    360,
+    320,
+    386
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "TOTAL",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    700,
+    360,
+    850,
+    386
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "22.26",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    120,
+    300,
+    280,
+    326
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "VISA",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    700,
+    300,
+    850,
+    326
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "22.26",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    120,
+    260,
+    350,
+    286
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "CHANGE",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    720,
+    260,
+    850,
+    286
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "0.00",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    250,
+    120,
+    450,
+    146
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "THANK",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    470,
+    120,
+    620,
+    146
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "YOU",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    250,
+    80,
+    450,
+    106
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "ITEMS",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    470,
+    80,
+    650,
+    106
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "SOLD",
+   "word_id": 0
+  }
+ ]
+}

--- a/tests/fixtures/corpus_gate/fixture_mart_v1.inputs.json
+++ b/tests/fixtures/corpus_gate/fixture_mart_v1.inputs.json
@@ -1,0 +1,509 @@
+{
+ "canvas": {
+  "h": 700,
+  "w": 420
+ },
+ "composed": false,
+ "manifest_words": [
+  {
+   "bbox": [
+    340,
+    950,
+    580,
+    976
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "FIXTURE",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    600,
+    950,
+    770,
+    976
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "MART",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    120,
+    860,
+    350,
+    886
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "APPLES",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    720,
+    860,
+    850,
+    886
+   ],
+   "labels": [
+    "LINE_TOTAL"
+   ],
+   "line_id": 0,
+   "text": "3.99",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    120,
+    820,
+    320,
+    846
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "BREAD",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    720,
+    820,
+    850,
+    846
+   ],
+   "labels": [
+    "LINE_TOTAL"
+   ],
+   "line_id": 0,
+   "text": "2.50",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    120,
+    780,
+    360,
+    806
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "CHEESE",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    720,
+    780,
+    850,
+    806
+   ],
+   "labels": [
+    "LINE_TOTAL"
+   ],
+   "line_id": 0,
+   "text": "5.75",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    120,
+    740,
+    310,
+    766
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "JUICE",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    720,
+    740,
+    850,
+    766
+   ],
+   "labels": [
+    "LINE_TOTAL"
+   ],
+   "line_id": 0,
+   "text": "4.25",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    120,
+    600,
+    420,
+    626
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "SUBTOTAL",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    700,
+    600,
+    850,
+    626
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "16.49",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    120,
+    560,
+    240,
+    586
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "TAX",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    720,
+    560,
+    850,
+    586
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "0.00",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    120,
+    520,
+    320,
+    546
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "TOTAL",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    700,
+    520,
+    850,
+    546
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "16.49",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    120,
+    400,
+    280,
+    426
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "CASH",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    700,
+    400,
+    850,
+    426
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "16.49",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    300,
+    120,
+    500,
+    146
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "THANK",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    520,
+    120,
+    670,
+    146
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "YOU",
+   "word_id": 0
+  }
+ ],
+ "section_sequence": [],
+ "slug": "fixture_mart",
+ "syn_words": [
+  {
+   "bbox": [
+    340,
+    950,
+    580,
+    976
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "FIXTURE",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    600,
+    950,
+    770,
+    976
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "MART",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    120,
+    860,
+    350,
+    886
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "APPLES",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    720,
+    860,
+    850,
+    886
+   ],
+   "labels": [
+    "LINE_TOTAL"
+   ],
+   "line_id": 0,
+   "text": "3.99",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    120,
+    820,
+    320,
+    846
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "BREAD",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    720,
+    820,
+    850,
+    846
+   ],
+   "labels": [
+    "LINE_TOTAL"
+   ],
+   "line_id": 0,
+   "text": "2.50",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    120,
+    780,
+    360,
+    806
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "CHEESE",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    720,
+    780,
+    850,
+    806
+   ],
+   "labels": [
+    "LINE_TOTAL"
+   ],
+   "line_id": 0,
+   "text": "5.75",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    120,
+    740,
+    310,
+    766
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "JUICE",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    720,
+    740,
+    850,
+    766
+   ],
+   "labels": [
+    "LINE_TOTAL"
+   ],
+   "line_id": 0,
+   "text": "4.25",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    120,
+    600,
+    420,
+    626
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "SUBTOTAL",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    700,
+    600,
+    850,
+    626
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "16.49",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    120,
+    560,
+    240,
+    586
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "TAX",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    720,
+    560,
+    850,
+    586
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "0.00",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    120,
+    520,
+    320,
+    546
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "TOTAL",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    700,
+    520,
+    850,
+    546
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "16.49",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    120,
+    400,
+    280,
+    426
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "CASH",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    700,
+    400,
+    850,
+    426
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "16.49",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    300,
+    120,
+    500,
+    146
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "THANK",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    520,
+    120,
+    670,
+    146
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "YOU",
+   "word_id": 0
+  }
+ ]
+}

--- a/tests/fixtures/corpus_gate/variant_selftest_v1.inputs.json
+++ b/tests/fixtures/corpus_gate/variant_selftest_v1.inputs.json
@@ -1,0 +1,471 @@
+{
+ "canvas": {
+  "h": 900,
+  "w": 460
+ },
+ "composed": false,
+ "manifest_words": [
+  {
+   "bbox": [
+    340,
+    950,
+    600,
+    976
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "VARIANT",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    620,
+    950,
+    880,
+    976
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "SELFTEST",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    120,
+    860,
+    290,
+    886
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "MILK",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    560,
+    860,
+    700,
+    886
+   ],
+   "labels": [
+    "LINE_TOTAL"
+   ],
+   "line_id": 0,
+   "text": "3.99",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    120,
+    820,
+    320,
+    846
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "BREAD",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    560,
+    820,
+    700,
+    846
+   ],
+   "labels": [
+    "LINE_TOTAL"
+   ],
+   "line_id": 0,
+   "text": "2.50",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    120,
+    780,
+    280,
+    806
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "EGGS",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    560,
+    780,
+    700,
+    806
+   ],
+   "labels": [
+    "LINE_TOTAL"
+   ],
+   "line_id": 0,
+   "text": "4.29",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    120,
+    740,
+    360,
+    766
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "CHEESE",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    560,
+    740,
+    700,
+    766
+   ],
+   "labels": [
+    "LINE_TOTAL"
+   ],
+   "line_id": 0,
+   "text": "5.75",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    120,
+    700,
+    310,
+    726
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "JUICE",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    560,
+    700,
+    700,
+    726
+   ],
+   "labels": [
+    "LINE_TOTAL"
+   ],
+   "line_id": 0,
+   "text": "4.25",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    120,
+    420,
+    320,
+    446
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "TOTAL",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    540,
+    420,
+    700,
+    446
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "20.78",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    200,
+    260,
+    360,
+    286
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "SELF",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    420,
+    260,
+    720,
+    286
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "CHECKOUT",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    250,
+    120,
+    450,
+    146
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "THANK",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    470,
+    120,
+    620,
+    146
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "YOU",
+   "word_id": 0
+  }
+ ],
+ "section_sequence": [
+  "storefront",
+  "items",
+  "summary",
+  "payment",
+  "footer"
+ ],
+ "slug": "costco",
+ "syn_words": [
+  {
+   "bbox": [
+    340,
+    950,
+    600,
+    976
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "VARIANT",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    620,
+    950,
+    880,
+    976
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "SELFTEST",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    120,
+    860,
+    290,
+    886
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "MILK",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    560,
+    860,
+    700,
+    886
+   ],
+   "labels": [
+    "LINE_TOTAL"
+   ],
+   "line_id": 0,
+   "text": "3.99",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    120,
+    820,
+    320,
+    846
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "BREAD",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    560,
+    820,
+    700,
+    846
+   ],
+   "labels": [
+    "LINE_TOTAL"
+   ],
+   "line_id": 0,
+   "text": "2.50",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    120,
+    780,
+    280,
+    806
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "EGGS",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    560,
+    780,
+    700,
+    806
+   ],
+   "labels": [
+    "LINE_TOTAL"
+   ],
+   "line_id": 0,
+   "text": "4.29",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    120,
+    740,
+    360,
+    766
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "CHEESE",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    560,
+    740,
+    700,
+    766
+   ],
+   "labels": [
+    "LINE_TOTAL"
+   ],
+   "line_id": 0,
+   "text": "5.75",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    120,
+    700,
+    310,
+    726
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "JUICE",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    560,
+    700,
+    700,
+    726
+   ],
+   "labels": [
+    "LINE_TOTAL"
+   ],
+   "line_id": 0,
+   "text": "4.25",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    120,
+    420,
+    320,
+    446
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "TOTAL",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    540,
+    420,
+    700,
+    446
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "20.78",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    200,
+    260,
+    360,
+    286
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "SELF",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    420,
+    260,
+    720,
+    286
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "CHECKOUT",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    250,
+    120,
+    450,
+    146
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "THANK",
+   "word_id": 0
+  },
+  {
+   "bbox": [
+    470,
+    120,
+    620,
+    146
+   ],
+   "labels": [],
+   "line_id": 0,
+   "text": "YOU",
+   "word_id": 0
+  }
+ ]
+}

--- a/tests/fixtures/merchant_truth/build_variant_fixture.py
+++ b/tests/fixtures/merchant_truth/build_variant_fixture.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3.12
+"""Regenerate the committed §7.2 variant-aware merchant-truth fixture.
+
+Sibling of ``build_fixture.py``. Where that mints a variant-BLIND bundle
+(``fixture_mart``), this mints ``variant_selftest`` -- a SEALED/PASS bundle
+whose C#layout component carries a ``template.variants[]`` block, so the
+corpus regression gate can exercise ``full_fidelity_eval.profile_columns``'s
+variant-selection path (``columns_source="profile"``) end to end. A
+regression in ``profile_columns`` / ``merchant_truth_variants.select_variant``
+that stops honoring the matching variant's lane flips the corpus receipt's
+columns verdict.
+
+The template's DEFAULT ``items`` amount lane sits at x=0.86; two variants
+carry text-marker hints -- a low-support ``self`` variant (x=0.60, support 2)
+and a high-support ``checkout`` variant (x=0.70, support 7). A receipt whose
+words contain BOTH markers matches both; the §7.2 tie-break (highest support,
+then smallest variant_id) must select ``checkout`` -> x=0.70, which is where
+the corpus receipt's amounts are actually inked. If selection regresses to the
+DEFAULT (x=0.86) or the low-support variant (x=0.60), the profile lane no
+longer sits on the ink and the columns metric goes UNTESTED instead of PASS.
+
+Deterministic: re-running writes byte-identical JSON. Run from the repo root:
+
+    python3.12 tests/fixtures/merchant_truth/build_variant_fixture.py
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.dirname(os.path.dirname(os.path.dirname(HERE)))
+sys.path.insert(0, os.path.join(REPO, "receipt_dynamo"))
+
+from receipt_dynamo.entities.merchant_truth import (  # noqa: E402
+    MerchantTruthComponent,
+    MerchantTruthManifest,
+    compute_bundle_hash,
+    hash_payload,
+)
+
+NOW = "2026-07-21T00:00:00+00:00"
+SLUG = "variant_selftest"
+ATLAS_BYTES = b"variant-selftest-atlas-bytes\n"
+
+
+def layout_template() -> dict:
+    """A schema-v1 layout template with two text-marker variants (§7.2)."""
+    return {
+        "version": 1,
+        "columns": {
+            "items": [
+                {"role": "amount", "anchor": "right", "x": 0.86, "support": 9}
+            ]
+        },
+        "sections": [{"name": "items"}],
+        "separators": [{"char": "-"}],
+        "variants": [
+            {
+                "variant_id": "self-low",
+                "classifier_hint": {
+                    "type": "text_marker",
+                    "tokens": ["SELF"],
+                },
+                "columns": {
+                    "items": [
+                        {
+                            "role": "amount",
+                            "anchor": "right",
+                            "x": 0.60,
+                            "support": 2,
+                        }
+                    ]
+                },
+                "sections": [{"name": "items"}],
+                "separators": [{"char": "-"}],
+                "support": 2,
+                "source_receipt_keys": ["IMAGE#self#RECEIPT#00001"],
+            },
+            {
+                "variant_id": "checkout-high",
+                "classifier_hint": {
+                    "type": "text_marker",
+                    "tokens": ["CHECKOUT"],
+                },
+                "columns": {
+                    "items": [
+                        {
+                            "role": "amount",
+                            "anchor": "right",
+                            "x": 0.70,
+                            "support": 7,
+                        }
+                    ]
+                },
+                "sections": [{"name": "items"}],
+                "separators": [{"char": "-"}],
+                "support": 7,
+                "source_receipt_keys": ["IMAGE#checkout#RECEIPT#00001"],
+            },
+        ],
+    }
+
+
+def payloads() -> dict:
+    atlas_hash = hashlib.sha256(ATLAS_BYTES).hexdigest()
+    catalog_items: list = []
+    return {
+        "identity": {
+            "merchant_name": "Variant Selftest",
+            "slug": SLUG,
+            "aliases": ["VARIANT SELFTEST #001"],
+            "upper_slug": SLUG.upper(),
+            "normalized_aliases": ["variant selftest", "variant selftest 001"],
+        },
+        "typography": {
+            "typography": {
+                "bitmap_font": {"regular": "variant_selftest.glyphs.npz"},
+                "bitmap_thin": 0.2,
+                "condense": 0.9,
+                "pitch_ratio": 0.55,
+            },
+            "section_scale": {"HEADER": 0.8},
+        },
+        "flags": {
+            "typography": {"font": "PTMONO", "dashed_separators": True},
+        },
+        "layout": {"available": True, "template": layout_template()},
+        "assets": {
+            "fonts": {
+                "regular": {
+                    "bucket_alias": "merchant-font-artifacts",
+                    "s3_key": (
+                        f"merchant_fonts/{SLUG}/"
+                        f"regular-{atlas_hash[:12]}.npz"
+                    ),
+                    "content_hash": atlas_hash,
+                    "source_commit": "fixture",
+                    "compiled_at": NOW,
+                    "cap_h": 58.0,
+                    "advance_ratio": 0.54,
+                    "pitch_check": "OK",
+                    "glyph_count": 94,
+                    "cache_filename": "variant_selftest.glyphs.npz",
+                }
+            },
+            # wordmark-as-text merchant (no logo asset): the storefront band's
+            # logo metric is a presence-only check.
+            "profile": {},
+            "missing_merchant_font": False,
+        },
+        "stylemap": {
+            "available": True,
+            "document": {
+                "version": 1,
+                "source": "fixture",
+                "sections": {"HEADER": {"face": "regular"}},
+            },
+            "source": None,
+        },
+        "catalog_snapshot": {
+            "items": catalog_items,
+            "item_count": 0,
+            "catalog_hash": hash_payload(catalog_items),
+            "as_of": NOW,
+        },
+    }
+
+
+def build_items() -> list[dict]:
+    provenance = {
+        "source_kind": "migration",
+        "written_by": {"kind": "migration", "name": "fixture", "version": "1"},
+        "pipeline": "fixture",
+        "provenance_completeness": "legacy",
+    }
+    components = [
+        MerchantTruthComponent(
+            slug=SLUG,
+            version=1,
+            name=name,
+            payload=payload,
+            provenance=provenance,
+        )
+        for name, payload in sorted(payloads().items())
+    ]
+    hashes = {item.name: item.content_hash for item in components}
+    manifest = MerchantTruthManifest(
+        slug=SLUG,
+        version=1,
+        component_hashes=hashes,
+        bundle_hash=compute_bundle_hash(hashes),
+        status="SEALED",
+        provenance={"written_by": "fixture", "minted_at": NOW},
+        mint_run_id="variant-selftest-v1",
+        gate_status="PASS",
+        sealed_at=NOW,
+    )
+    return [manifest.to_item(), *[item.to_item() for item in components]]
+
+
+def main() -> int:
+    out = os.path.join(HERE, "variant_selftest.v1.json")
+    with open(out, "w", encoding="utf-8") as fh:
+        json.dump({"items": build_items()}, fh, indent=1, sort_keys=True)
+        fh.write("\n")
+    print(f"wrote {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/fixtures/merchant_truth/variant_selftest.v1.json
+++ b/tests/fixtures/merchant_truth/variant_selftest.v1.json
@@ -1,0 +1,444 @@
+{
+ "items": [
+  {
+   "PK": {
+    "S": "MERCHANT_TRUTH#variant_selftest"
+   },
+   "SK": {
+    "S": "TRUTH#v0000000001#MANIFEST"
+   },
+   "TYPE": {
+    "S": "MERCHANT_TRUTH_MANIFEST"
+   },
+   "bundle_hash": {
+    "S": "78186ca27049c2b0f9126f54b8601ee4a555193889311a21f740d9cb172bcc52"
+   },
+   "component_count": {
+    "N": "7"
+   },
+   "component_hashes": {
+    "M": {
+     "assets": {
+      "S": "f62deb1bd8d6888671c8aa434c2a8d8defe69e3391b4ebe4aa75073343245ce3"
+     },
+     "catalog_snapshot": {
+      "S": "581b6ba782e93119cca0a2193e34ae411d6841bebb74708807f98ae6f58ea7a8"
+     },
+     "flags": {
+      "S": "9172e8f20d8c61e921ccdee257e9b809e8d70d9b145a6abf1ff4de0c06a82e27"
+     },
+     "identity": {
+      "S": "d0ef38457194dc9d5340789e6990ff01ec0abaa4150b6005fba4704855d73c07"
+     },
+     "layout": {
+      "S": "f58134c7b4bedb9d6aaa7b199f3163a642e00be84a98cbebb87195c044a7b27b"
+     },
+     "stylemap": {
+      "S": "58781d458867757da9b12e785823898b3f605e10d3f49d54efce2def115a267f"
+     },
+     "typography": {
+      "S": "07f9821d117be661d2d25d768c78c3b7c7267a93adabe5ec5b2a5519cb748919"
+     }
+    }
+   },
+   "confirmed_proposals": {
+    "L": []
+   },
+   "gate_results": {
+    "M": {}
+   },
+   "gate_status": {
+    "S": "PASS"
+   },
+   "mint_run_id": {
+    "S": "variant-selftest-v1"
+   },
+   "provenance": {
+    "M": {
+     "minted_at": {
+      "S": "2026-07-21T00:00:00+00:00"
+     },
+     "written_by": {
+      "S": "fixture"
+     }
+    }
+   },
+   "sealed_at": {
+    "S": "2026-07-21T00:00:00+00:00"
+   },
+   "slug": {
+    "S": "variant_selftest"
+   },
+   "status": {
+    "S": "SEALED"
+   },
+   "version": {
+    "N": "1"
+   }
+  },
+  {
+   "PK": {
+    "S": "MERCHANT_TRUTH#variant_selftest"
+   },
+   "SK": {
+    "S": "TRUTH#v0000000001#C#assets"
+   },
+   "TYPE": {
+    "S": "MERCHANT_TRUTH_COMPONENT"
+   },
+   "component": {
+    "S": "assets"
+   },
+   "content_hash": {
+    "S": "f62deb1bd8d6888671c8aa434c2a8d8defe69e3391b4ebe4aa75073343245ce3"
+   },
+   "payload": {
+    "S": "{\"fonts\":{\"regular\":{\"advance_ratio\":0.54,\"bucket_alias\":\"merchant-font-artifacts\",\"cache_filename\":\"variant_selftest.glyphs.npz\",\"cap_h\":58.0,\"compiled_at\":\"2026-07-21T00:00:00+00:00\",\"content_hash\":\"3c85f7d3015a3cf11e8ffc1170d7c19c0fd04042809c073cd9b83daa173f67f7\",\"glyph_count\":94,\"pitch_check\":\"OK\",\"s3_key\":\"merchant_fonts/variant_selftest/regular-3c85f7d3015a.npz\",\"source_commit\":\"fixture\"}},\"missing_merchant_font\":false,\"profile\":{}}"
+   },
+   "provenance": {
+    "M": {
+     "pipeline": {
+      "S": "fixture"
+     },
+     "provenance_completeness": {
+      "S": "legacy"
+     },
+     "source_kind": {
+      "S": "migration"
+     },
+     "written_by": {
+      "M": {
+       "kind": {
+        "S": "migration"
+       },
+       "name": {
+        "S": "fixture"
+       },
+       "version": {
+        "S": "1"
+       }
+      }
+     }
+    }
+   },
+   "slug": {
+    "S": "variant_selftest"
+   },
+   "version": {
+    "N": "1"
+   }
+  },
+  {
+   "PK": {
+    "S": "MERCHANT_TRUTH#variant_selftest"
+   },
+   "SK": {
+    "S": "TRUTH#v0000000001#C#catalog_snapshot"
+   },
+   "TYPE": {
+    "S": "MERCHANT_TRUTH_COMPONENT"
+   },
+   "component": {
+    "S": "catalog_snapshot"
+   },
+   "content_hash": {
+    "S": "581b6ba782e93119cca0a2193e34ae411d6841bebb74708807f98ae6f58ea7a8"
+   },
+   "payload": {
+    "S": "{\"as_of\":\"2026-07-21T00:00:00+00:00\",\"catalog_hash\":\"4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945\",\"item_count\":0,\"items\":[]}"
+   },
+   "provenance": {
+    "M": {
+     "pipeline": {
+      "S": "fixture"
+     },
+     "provenance_completeness": {
+      "S": "legacy"
+     },
+     "source_kind": {
+      "S": "migration"
+     },
+     "written_by": {
+      "M": {
+       "kind": {
+        "S": "migration"
+       },
+       "name": {
+        "S": "fixture"
+       },
+       "version": {
+        "S": "1"
+       }
+      }
+     }
+    }
+   },
+   "slug": {
+    "S": "variant_selftest"
+   },
+   "version": {
+    "N": "1"
+   }
+  },
+  {
+   "PK": {
+    "S": "MERCHANT_TRUTH#variant_selftest"
+   },
+   "SK": {
+    "S": "TRUTH#v0000000001#C#flags"
+   },
+   "TYPE": {
+    "S": "MERCHANT_TRUTH_COMPONENT"
+   },
+   "component": {
+    "S": "flags"
+   },
+   "content_hash": {
+    "S": "9172e8f20d8c61e921ccdee257e9b809e8d70d9b145a6abf1ff4de0c06a82e27"
+   },
+   "payload": {
+    "S": "{\"typography\":{\"dashed_separators\":true,\"font\":\"PTMONO\"}}"
+   },
+   "provenance": {
+    "M": {
+     "pipeline": {
+      "S": "fixture"
+     },
+     "provenance_completeness": {
+      "S": "legacy"
+     },
+     "source_kind": {
+      "S": "migration"
+     },
+     "written_by": {
+      "M": {
+       "kind": {
+        "S": "migration"
+       },
+       "name": {
+        "S": "fixture"
+       },
+       "version": {
+        "S": "1"
+       }
+      }
+     }
+    }
+   },
+   "slug": {
+    "S": "variant_selftest"
+   },
+   "version": {
+    "N": "1"
+   }
+  },
+  {
+   "PK": {
+    "S": "MERCHANT_TRUTH#variant_selftest"
+   },
+   "SK": {
+    "S": "TRUTH#v0000000001#C#identity"
+   },
+   "TYPE": {
+    "S": "MERCHANT_TRUTH_COMPONENT"
+   },
+   "component": {
+    "S": "identity"
+   },
+   "content_hash": {
+    "S": "d0ef38457194dc9d5340789e6990ff01ec0abaa4150b6005fba4704855d73c07"
+   },
+   "payload": {
+    "S": "{\"aliases\":[\"VARIANT SELFTEST #001\"],\"merchant_name\":\"Variant Selftest\",\"normalized_aliases\":[\"variant selftest\",\"variant selftest 001\"],\"slug\":\"variant_selftest\",\"upper_slug\":\"VARIANT_SELFTEST\"}"
+   },
+   "provenance": {
+    "M": {
+     "pipeline": {
+      "S": "fixture"
+     },
+     "provenance_completeness": {
+      "S": "legacy"
+     },
+     "source_kind": {
+      "S": "migration"
+     },
+     "written_by": {
+      "M": {
+       "kind": {
+        "S": "migration"
+       },
+       "name": {
+        "S": "fixture"
+       },
+       "version": {
+        "S": "1"
+       }
+      }
+     }
+    }
+   },
+   "slug": {
+    "S": "variant_selftest"
+   },
+   "version": {
+    "N": "1"
+   }
+  },
+  {
+   "PK": {
+    "S": "MERCHANT_TRUTH#variant_selftest"
+   },
+   "SK": {
+    "S": "TRUTH#v0000000001#C#layout"
+   },
+   "TYPE": {
+    "S": "MERCHANT_TRUTH_COMPONENT"
+   },
+   "component": {
+    "S": "layout"
+   },
+   "content_hash": {
+    "S": "f58134c7b4bedb9d6aaa7b199f3163a642e00be84a98cbebb87195c044a7b27b"
+   },
+   "payload": {
+    "S": "{\"available\":true,\"template\":{\"columns\":{\"items\":[{\"anchor\":\"right\",\"role\":\"amount\",\"support\":9,\"x\":0.86}]},\"sections\":[{\"name\":\"items\"}],\"separators\":[{\"char\":\"-\"}],\"variants\":[{\"classifier_hint\":{\"tokens\":[\"SELF\"],\"type\":\"text_marker\"},\"columns\":{\"items\":[{\"anchor\":\"right\",\"role\":\"amount\",\"support\":2,\"x\":0.6}]},\"sections\":[{\"name\":\"items\"}],\"separators\":[{\"char\":\"-\"}],\"source_receipt_keys\":[\"IMAGE#self#RECEIPT#00001\"],\"support\":2,\"variant_id\":\"self-low\"},{\"classifier_hint\":{\"tokens\":[\"CHECKOUT\"],\"type\":\"text_marker\"},\"columns\":{\"items\":[{\"anchor\":\"right\",\"role\":\"amount\",\"support\":7,\"x\":0.7}]},\"sections\":[{\"name\":\"items\"}],\"separators\":[{\"char\":\"-\"}],\"source_receipt_keys\":[\"IMAGE#checkout#RECEIPT#00001\"],\"support\":7,\"variant_id\":\"checkout-high\"}],\"version\":1}}"
+   },
+   "provenance": {
+    "M": {
+     "pipeline": {
+      "S": "fixture"
+     },
+     "provenance_completeness": {
+      "S": "legacy"
+     },
+     "source_kind": {
+      "S": "migration"
+     },
+     "written_by": {
+      "M": {
+       "kind": {
+        "S": "migration"
+       },
+       "name": {
+        "S": "fixture"
+       },
+       "version": {
+        "S": "1"
+       }
+      }
+     }
+    }
+   },
+   "slug": {
+    "S": "variant_selftest"
+   },
+   "version": {
+    "N": "1"
+   }
+  },
+  {
+   "PK": {
+    "S": "MERCHANT_TRUTH#variant_selftest"
+   },
+   "SK": {
+    "S": "TRUTH#v0000000001#C#stylemap"
+   },
+   "TYPE": {
+    "S": "MERCHANT_TRUTH_COMPONENT"
+   },
+   "component": {
+    "S": "stylemap"
+   },
+   "content_hash": {
+    "S": "58781d458867757da9b12e785823898b3f605e10d3f49d54efce2def115a267f"
+   },
+   "payload": {
+    "S": "{\"available\":true,\"document\":{\"sections\":{\"HEADER\":{\"face\":\"regular\"}},\"source\":\"fixture\",\"version\":1},\"source\":null}"
+   },
+   "provenance": {
+    "M": {
+     "pipeline": {
+      "S": "fixture"
+     },
+     "provenance_completeness": {
+      "S": "legacy"
+     },
+     "source_kind": {
+      "S": "migration"
+     },
+     "written_by": {
+      "M": {
+       "kind": {
+        "S": "migration"
+       },
+       "name": {
+        "S": "fixture"
+       },
+       "version": {
+        "S": "1"
+       }
+      }
+     }
+    }
+   },
+   "slug": {
+    "S": "variant_selftest"
+   },
+   "version": {
+    "N": "1"
+   }
+  },
+  {
+   "PK": {
+    "S": "MERCHANT_TRUTH#variant_selftest"
+   },
+   "SK": {
+    "S": "TRUTH#v0000000001#C#typography"
+   },
+   "TYPE": {
+    "S": "MERCHANT_TRUTH_COMPONENT"
+   },
+   "component": {
+    "S": "typography"
+   },
+   "content_hash": {
+    "S": "07f9821d117be661d2d25d768c78c3b7c7267a93adabe5ec5b2a5519cb748919"
+   },
+   "payload": {
+    "S": "{\"section_scale\":{\"HEADER\":0.8},\"typography\":{\"bitmap_font\":{\"regular\":\"variant_selftest.glyphs.npz\"},\"bitmap_thin\":0.2,\"condense\":0.9,\"pitch_ratio\":0.55}}"
+   },
+   "provenance": {
+    "M": {
+     "pipeline": {
+      "S": "fixture"
+     },
+     "provenance_completeness": {
+      "S": "legacy"
+     },
+     "source_kind": {
+      "S": "migration"
+     },
+     "written_by": {
+      "M": {
+       "kind": {
+        "S": "migration"
+       },
+       "name": {
+        "S": "fixture"
+       },
+       "version": {
+        "S": "1"
+       }
+      }
+     }
+    }
+   },
+   "slug": {
+    "S": "variant_selftest"
+   },
+   "version": {
+    "N": "1"
+   }
+  }
+ ]
+}

--- a/tests/test_corpus_regression_gate.py
+++ b/tests/test_corpus_regression_gate.py
@@ -164,6 +164,85 @@ def test_json_findings_are_machine_parseable(temp_corpus, tmp_path, capsys):
 
 
 # --------------------------------------------------------------------------
+# §7.2 profile / variant-selection path (columns_source="profile")
+# --------------------------------------------------------------------------
+def _variant_entry() -> dict:
+    manifest = gate._load_json(gate.MANIFEST_PATH)
+    return next(
+        e for e in manifest["entries"] if e["name"] == "variant_selftest_v1"
+    )
+
+
+def test_variant_entry_columns_derive_from_profile_not_bootstrap():
+    """The variant corpus entry's ITEMS lane comes from the PROFILE path.
+
+    ``source == "profile"`` proves ``profile_columns`` consumed the layout
+    template's variant lane; a regression that emptied it would fall back to
+    ``bootstrap(no-profile-data)`` and this pin would flip.
+    """
+    rec = gate.capture_entry(_variant_entry())
+    bands = rec["metrics"]["columns"]["bands"]
+    assert "ITEMS" in bands, bands
+    assert bands["ITEMS"]["source"] == "profile"
+    assert rec["metrics"]["columns"]["verdict"] == "PASS"
+
+
+def test_variant_tie_break_selects_highest_support():
+    """The receipt matches BOTH variants; §7.2 tie-break must pick support 7."""
+    from receipt_dynamo.merchant_truth_variants import (
+        normalize_word_set,
+        select_variant,
+    )
+
+    entry = _variant_entry()
+    truth = gate._load_json(gate._repo_path(entry["truth_fixture"]))
+    template = None
+    for item in truth["items"]:
+        if item["SK"]["S"].endswith("C#layout"):
+            # low-level DynamoDB item format: payload is {"S": "<json>"}
+            template = json.loads(item["payload"]["S"])["template"]
+    assert template and template.get("variants")
+    inputs = gate._load_json(gate._repo_path(entry["eval_inputs"]))
+    word_set = normalize_word_set(
+        [w["text"] for w in inputs["manifest_words"]]
+    )
+    chosen = select_variant(
+        template,
+        section_sequence=inputs["section_sequence"],
+        word_set=word_set,
+    )
+    assert chosen is not None
+    assert chosen["variant_id"] == "checkout-high"
+
+
+def test_select_variant_regression_flips_corpus_verdict(monkeypatch):
+    """A select_variant regression must flip the corpus columns verdict.
+
+    Simulate the regression by patching the shared selector to always fall
+    back to DEFAULT (as a variant-blind reader would): the DEFAULT lane sits
+    at x=0.86, off the inked amounts at x=0.70, so the columns metric drops
+    from PASS to UNTESTED -- a recorded regression naming this receipt +
+    columns.
+    """
+    import receipt_dynamo.merchant_truth_variants as variants
+
+    baseline = gate._load_json(gate.COMMITTED_BASELINE)
+    base_rec = baseline["entries"]["variant_selftest_v1"]
+    assert base_rec["metrics"]["columns"]["verdict"] == "PASS"
+
+    monkeypatch.setattr(
+        variants, "select_variant", lambda *a, **k: None, raising=True
+    )
+    regressed = gate.capture_entry(_variant_entry())
+    assert regressed["metrics"]["columns"]["verdict"] != "PASS"
+
+    findings = gate._diff_entry("variant_selftest_v1", base_rec, regressed)
+    columns = [f for f in findings if f["metric"] == "columns"]
+    assert columns, f"expected a columns finding, got {findings}"
+    assert any(f["field"] == "columns.verdict" for f in columns)
+
+
+# --------------------------------------------------------------------------
 # committed-artifact guards (what CI actually runs)
 # --------------------------------------------------------------------------
 def test_committed_baseline_in_sync_with_fixtures():

--- a/tests/test_corpus_regression_gate.py
+++ b/tests/test_corpus_regression_gate.py
@@ -1,0 +1,200 @@
+"""Tests for the standing eval-regression corpus gate (H6).
+
+Prove the three behaviors the sprint acceptance requires (item 4):
+  - a seeded one-value mutation in a COPY of a corpus fixture makes ``compare``
+    fail, naming the receipt AND the metric;
+  - a clean corpus produces no findings (exit 0);
+  - two same-commit captures are byte-identical (determinism).
+
+Plus guards on the committed artifacts (baseline in sync with fixtures) and
+the pinned nondeterminism (graphics deterministically SKIPPED), and that the
+``--json`` findings are machine-parseable for H7's comment poster.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+
+import pytest
+
+from synthesis_loop import corpus_regression_gate as gate
+
+
+def _write(path, payload) -> None:
+    path.write_text(json.dumps(payload, indent=1, sort_keys=True), "utf-8")
+
+
+@pytest.fixture()
+def temp_corpus(tmp_path, monkeypatch):
+    """A one-entry temp corpus reusing the committed fixture_mart fixtures.
+
+    Copies the eval-input bundle into ``tmp_path`` (so the test can mutate it
+    without touching the committed fixture) and writes a temp manifest that
+    points the gate at it. The hash-verified truth fixture is referenced
+    read-only at its committed absolute path.
+    """
+    entry = {
+        "name": "fixture_mart_v1",
+        "merchant": "Fixture Mart",
+        "truth_fixture": gate._repo_path(
+            "tests/fixtures/merchant_truth/fixture_mart.v1.json"
+        ),
+        "eval_inputs": str(tmp_path / "fixture_mart_v1.inputs.json"),
+        "columns_source": "bootstrap",
+    }
+    committed_inputs = gate._repo_path(
+        "tests/fixtures/corpus_gate/fixture_mart_v1.inputs.json"
+    )
+    inputs = json.loads(open(committed_inputs, encoding="utf-8").read())
+    _write(tmp_path / "fixture_mart_v1.inputs.json", inputs)
+    manifest_path = tmp_path / "manifest.json"
+    _write(manifest_path, {"version": 1, "entries": [entry]})
+    return {
+        "manifest": str(manifest_path),
+        "inputs_path": tmp_path / "fixture_mart_v1.inputs.json",
+        "inputs": inputs,
+        "name": entry["name"],
+    }
+
+
+# --------------------------------------------------------------------------
+# determinism
+# --------------------------------------------------------------------------
+def test_same_commit_captures_are_byte_identical(temp_corpus):
+    a = gate.capture_all(temp_corpus["manifest"])
+    b = gate.capture_all(temp_corpus["manifest"])
+    assert a == b
+    dump_a = json.dumps(a, indent=2, sort_keys=True)
+    dump_b = json.dumps(b, indent=2, sort_keys=True)
+    assert dump_a == dump_b
+
+
+def test_graphics_is_pinned_skipped(temp_corpus):
+    """The one nondeterminism source (barcode detector) is pinned OFF."""
+    cap = gate.capture_all(temp_corpus["manifest"])
+    rec = cap["entries"][temp_corpus["name"]]
+    assert rec["metrics"]["graphics"]["verdict"] == "SKIPPED"
+
+
+# --------------------------------------------------------------------------
+# clean corpus -> no findings
+# --------------------------------------------------------------------------
+def test_clean_corpus_has_no_findings(temp_corpus):
+    baseline = gate.capture_all(temp_corpus["manifest"])
+    current = gate.capture_all(temp_corpus["manifest"])
+    assert gate.diff_baselines(baseline, current) == []
+
+
+def test_clean_compare_exits_zero(temp_corpus, tmp_path):
+    baseline = gate.capture_all(temp_corpus["manifest"])
+    baseline_path = tmp_path / "baseline.json"
+    _write(baseline_path, baseline)
+    monkeypatched = _use_manifest(temp_corpus["manifest"])
+    with monkeypatched:
+        rc = gate.compare(str(baseline_path))
+    assert rc == 0
+
+
+# --------------------------------------------------------------------------
+# seeded one-value mutation -> compare fails naming receipt + metric
+# --------------------------------------------------------------------------
+def test_seeded_token_mutation_names_receipt_and_metric(temp_corpus):
+    baseline = gate.capture_all(temp_corpus["manifest"])
+
+    # ONE-VALUE mutation in a COPY of the fixture: erase a single word from
+    # the synth render so it no longer matches the real manifest.
+    mutated = copy.deepcopy(temp_corpus["inputs"])
+    before = len(mutated["syn_words"])
+    mutated["syn_words"] = [
+        w for w in mutated["syn_words"] if w["text"] != "CHEESE"
+    ]
+    assert len(mutated["syn_words"]) == before - 1  # exactly one value changed
+    _write(temp_corpus["inputs_path"], mutated)
+
+    current = gate.capture_all(temp_corpus["manifest"])
+    findings = gate.diff_baselines(baseline, current)
+
+    assert findings, "mutation must produce findings"
+    # every finding names THIS receipt
+    assert all(f["receipt"] == temp_corpus["name"] for f in findings)
+    # the tokens metric is named as regressed
+    tokens = [f for f in findings if f["metric"] == "tokens"]
+    assert tokens, f"expected a tokens finding, got {findings}"
+    assert any(f["field"] == "tokens.verdict" for f in tokens)
+    # the recall drop carries a signed delta
+    recall = [f for f in tokens if f["field"] == "tokens.text_recall"]
+    assert recall and recall[0]["delta"] < 0
+
+
+def test_mutation_makes_compare_exit_nonzero(temp_corpus, tmp_path):
+    baseline = gate.capture_all(temp_corpus["manifest"])
+    baseline_path = tmp_path / "baseline.json"
+    _write(baseline_path, baseline)
+
+    mutated = copy.deepcopy(temp_corpus["inputs"])
+    mutated["syn_words"] = [
+        w for w in mutated["syn_words"] if w["text"] != "CHEESE"
+    ]
+    _write(temp_corpus["inputs_path"], mutated)
+
+    with _use_manifest(temp_corpus["manifest"]):
+        rc = gate.compare(str(baseline_path))
+    assert rc == 1
+
+
+def test_json_findings_are_machine_parseable(temp_corpus, tmp_path, capsys):
+    baseline = gate.capture_all(temp_corpus["manifest"])
+    baseline_path = tmp_path / "baseline.json"
+    _write(baseline_path, baseline)
+
+    mutated = copy.deepcopy(temp_corpus["inputs"])
+    mutated["syn_words"] = [
+        w for w in mutated["syn_words"] if w["text"] != "CHEESE"
+    ]
+    _write(temp_corpus["inputs_path"], mutated)
+
+    with _use_manifest(temp_corpus["manifest"]):
+        gate.compare(str(baseline_path), as_json=True)
+    doc = json.loads(capsys.readouterr().out)
+    assert doc["ok"] is False
+    assert doc["findings"]
+    for f in doc["findings"]:
+        assert {"receipt", "metric", "field"} <= set(f)
+
+
+# --------------------------------------------------------------------------
+# committed-artifact guards (what CI actually runs)
+# --------------------------------------------------------------------------
+def test_committed_baseline_in_sync_with_fixtures():
+    """`check` against the committed baseline + committed fixtures is clean."""
+    baseline = gate._load_json(gate.COMMITTED_BASELINE)
+    current = gate.capture_all()
+    assert gate.diff_baselines(baseline, current) == []
+
+
+def test_committed_check_exits_zero():
+    assert gate.check() == 0
+
+
+# --------------------------------------------------------------------------
+# helper: run compare/check against a temp manifest by patching capture_all's
+# default manifest path.
+# --------------------------------------------------------------------------
+class _use_manifest:
+    def __init__(self, manifest_path):
+        self.manifest_path = manifest_path
+        self._orig = None
+
+    def __enter__(self):
+        self._orig = gate.capture_all
+
+        def _patched(manifest_path=self.manifest_path):
+            return self._orig(manifest_path)
+
+        gate.capture_all = _patched
+        return self
+
+    def __exit__(self, *exc):
+        gate.capture_all = self._orig
+        return False


### PR DESCRIPTION
## H6 — standing eval-regression corpus gate (offline, zero AWS, PR-runner-safe)

Implements **H6** from the hardening sprint plan (`humble-skipping-quilt.md`), Phase 3, and **sprint acceptance item 4** (seeded fixture mutation → named receipt+metric; clean → green; same-commit captures byte-identical).

`synthesis_loop/corpus_regression_gate.py` is modeled on `render_regression_guard.py` (same `capture`/`compare`/`check` verbs + committed-baseline pattern). Where the render guard pins the production **renderer's pixels** (and needs the dev table + S3 + creds), this gate pins the **eval logic**: it freezes `full_fidelity_eval`'s seven metric verdicts and their load-bearing numeric values over a corpus of committed offline fixtures, so a metric-threshold / loader / stylemap change that silently flips a corpus receipt's verdict fails loudly — with **no AWS credentials**.

### Load-bearing finding (verified on main @ `cd26274ed`)
The plan assumed `full_fidelity_eval run --truth-fixture` is zero-AWS. It is **not**: `--truth-fixture` only makes merchant-**truth** resolution offline. The receipt itself is still fetched live — `section_compare.render_pair` reads the font profile, glyph atlas, receipt words and the real S3 image from the dev table on **every** run, and one corpus merchant (`fixture_mart`) has no receipt in any table at all. So the gate drives the eval's genuinely-offline pure core directly: `resolve_truth(fixture_path=...)` + `evaluate_pair(...)`, feeding it vendored receipt inputs (OCR word manifests) and deterministically-rendered image pairs. No boto3 / DynamoDB / S3. `--write-gate-record` (default off) is moot since the CLI `run` path is never used — **no gate record is ever written**.

### The corpus
- `synthesis_loop/corpus_manifest.json` — entries; each names a committed merchant-truth fixture (`tests/fixtures/merchant_truth/*.json`) + an eval-input bundle (`tests/fixtures/corpus_gate/*.inputs.json`, built reproducibly by `build_corpus_inputs.py`).
- `synthesis_loop/corpus_baseline.json` — committed baseline: per-entry metric verdicts, relevant metric values, render hashes.
- Adding a future merchant = add fixture + inputs bundle + manifest entry + re-`capture`.

### Machine-parseable output (for H7)
`check --json` emits `{"ok": bool, "findings": [{receipt, metric, field, baseline, current, delta}]}` on stdout — H7's `post_gate_comment.sh` consumes it directly. **No CI wiring in this PR** (H7 owns it); intended invocation documented in the module docstring:
```
python3.12 synthesis_loop/corpus_regression_gate.py check --json
```

### Determinism finding
The eval core is pure (median/numpy, no RNG). The one nondeterminism source is metric 5 (graphics), which shells out to the Swift `receipt-ocr` barcode detector whose presence varies by machine. **Pinned OFF** at both import and runtime (`RECEIPT_OCR_BIN` / `ffe._BARCODE_BIN` → a guaranteed-missing path) so graphics is deterministically `SKIPPED` on every runner. Verified: two same-commit captures are byte-identical (`shasum` match).

### Failing-test-first — red then green
`tests/test_corpus_regression_gate.py` (9 tests). Red-then-green evidence:
- **RED (import):** with the module removed, collection errors (`cannot import name 'corpus_regression_gate'`).
- **RED (logic):** with `diff_baselines` neutered to return `[]`, the 3 mutation-detection tests fail (`3 failed, 6 passed`) — proving the tests genuinely exercise regression detection, not just import.
- **GREEN:** module restored → `9 passed`.

Tests prove: a **one-value mutation in a copy of a fixture** (erase a single word from `syn_words`) makes `compare` exit 1 and produce a finding naming the receipt (`fixture_mart_v1`) and metric (`tokens`, with a signed `text_recall` delta); a clean corpus yields no findings (exit 0); two same-commit captures are byte-identical; graphics is pinned `SKIPPED`; committed baseline is in sync with committed fixtures; `--json` findings are machine-parseable.

### Scope hygiene
Purely additive — no existing files touched; `scripts/nightly/*` untouched (H1 owns those). `black --check --line-length=79` and `isort --check-only --profile=black --line-length=79` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BeLcSviHL5vDgS3zTSMbsq