### PR TITLE
[nightly] H2: token-budget circuit breaker (exit 123)

### DIFF
--- a/scripts/nightly/run_nightly.sh
+++ b/scripts/nightly/run_nightly.sh
@@ -23,6 +23,8 @@
 #   NIGHTLY_PREFLIGHT_BIN   default $REPO_ROOT/scripts/agent_preflight.sh
 #   NIGHTLY_TIMEOUT_SECS    default 14400 (4h)
 #   NIGHTLY_MAX_TURNS       default 80
+#   NIGHTLY_TOKEN_BUDGET    default 2000000 (H2 token circuit breaker ceiling;
+#                           breach -> watchdog exit 123 -> RED stub)
 #
 # Exit: 0 report produced and published (any verdict); 1 only when even the
 # stub/publish path failed.
@@ -39,6 +41,11 @@ CAMPAIGN_LOG="${NIGHTLY_CAMPAIGN_LOG:-$HOME/section_label_kickoff/CAMPAIGN_LOG.m
 PREFLIGHT_BIN="${NIGHTLY_PREFLIGHT_BIN:-$REPO_ROOT/scripts/agent_preflight.sh}"
 TIMEOUT_SECS="${NIGHTLY_TIMEOUT_SECS:-14400}"
 MAX_TURNS="${NIGHTLY_MAX_TURNS:-80}"
+# H2 token circuit breaker ceiling (conservative ~2M/run, raisable as trust
+# builds). Exported so it is visible to the loop and any child process.
+export NIGHTLY_TOKEN_BUDGET="${NIGHTLY_TOKEN_BUDGET:-2000000}"
+# Must match watchdog.py TOKEN_EXIT (exit code on a token-budget group-kill).
+TOKEN_EXIT_CODE=123
 BRIEF="$REPO_ROOT/docs/nightly/BRIEF.md"
 CANNED_REPORT="$SCRIPT_DIR/fixtures/canned_agent_report.md"
 CHECKER="$SCRIPT_DIR/check_contract.py"
@@ -91,6 +98,36 @@ log() {
 }
 
 elapsed() { echo "$(( $(date +%s) - START_EPOCH ))"; }
+
+# H2: actual tokens consumed this run, summed from run_metrics.json the same
+# way the breaker counts (all four usage types, deduped per message). Echoes an
+# integer, or nothing on any error (fail quiet; a missing number never breaks
+# the report).
+read_token_total() {
+  [ -s "$RUN_DIR/run_metrics.json" ] || return 0
+  python3 - "$RUN_DIR/run_metrics.json" <<'PY' 2>/dev/null || true
+import json, sys
+try:
+    m = json.load(open(sys.argv[1]))
+    t = m.get("token_totals") or {}
+    print(sum(v for v in t.values() if isinstance(v, int)))
+except Exception:
+    pass
+PY
+}
+
+# H2: wire actual-vs-ceiling into a healthy report's Budget section, inserted
+# right after the "## Budget" heading so the contract check still passes.
+inject_budget_token_line() {
+  local line="$1" tmp
+  [ -s "$REPORT_PATH" ] || return 0
+  tmp="$(mktemp "${TMPDIR:-/tmp}/nightly-budget.XXXXXX")" || return 0
+  awk -v ins="$line" '
+    { print }
+    /^## Budget[[:space:]]*$/ && !done { print ins; done=1 }
+  ' "$REPORT_PATH" > "$tmp" && cat "$tmp" > "$REPORT_PATH"
+  rm -f "$tmp"
+}
 
 # 4h watchdog: scripts/nightly/watchdog.py owns setsid + group-kill
 # (SIGTERM to -PGID, 30s grace, then SIGKILL to -PGID) on every path. The
@@ -243,7 +280,13 @@ else
   # (this is what watchdogs H2/H3 poll). The old plain-text agent_stdout.log is
   # regenerated below from the trajectory's final result event so the human
   # continuity (and any log reader) still sees a readable final message.
-  ( cd "$REPO_ROOT" && python3 "$WATCHDOG" --grace 30 "$TIMEOUT_SECS" -- \
+  # H2: --token-budget + --trajectory arm the token circuit breaker. The
+  # watchdog polls trajectory.jsonl (~15s) and group-kills with exit 123 if
+  # the deduped token sum breaches NIGHTLY_TOKEN_BUDGET.
+  ( cd "$REPO_ROOT" && python3 "$WATCHDOG" --grace 30 \
+      --token-budget "$NIGHTLY_TOKEN_BUDGET" \
+      --trajectory "$RUN_DIR/trajectory.jsonl" \
+      "$TIMEOUT_SECS" -- \
       "$CLAUDE_BIN" -p "$(cat "$BRIEF")" \
       --output-format stream-json --verbose \
       --permission-mode bypassPermissions \
@@ -268,6 +311,16 @@ else
     -o "$RUN_DIR/run_metrics.json" 2>> "$RUN_DIR/wrapper.log" \
     && log "run_metrics.json written (claude $CLAUDE_VERSION)" \
     || log "WARNING: run_metrics.json generation failed"
+
+  # H2: map the token circuit breaker's exit 123 to its own RED stub, and on
+  # healthy nights record actual-vs-ceiling in the report's Budget section.
+  TOKEN_TOTAL="$(read_token_total)"
+  if [ "$AGENT_EXIT" -eq "$TOKEN_EXIT_CODE" ]; then
+    log "token budget breached: ${TOKEN_TOTAL:-unknown} of $NIGHTLY_TOKEN_BUDGET tokens (watchdog exit 123)"
+    write_red_stub "token budget exceeded (${TOKEN_TOTAL:-unknown} of $NIGHTLY_TOKEN_BUDGET tokens)"
+  elif [ -s "$REPORT_PATH" ]; then
+    inject_budget_token_line "- tokens: ${TOKEN_TOTAL:-n/a} of $NIGHTLY_TOKEN_BUDGET (budget)"
+  fi
 fi
 
 # ---- 3. Contract check ----------------------------------------------------

--- a/scripts/nightly/watchdog.py
+++ b/scripts/nightly/watchdog.py
@@ -93,6 +93,11 @@ def _token_usage(trajectory: str) -> int | None:
     treated as "no signal", never as a reason to kill a healthy night. The
     underlying parser is already tolerant (counts what parses, skips garbage),
     so pure-garbage or partial files yield 0 here, never an exception.
+
+    Boundary: a zero-token wedge (a trajectory that parses cleanly but grows no
+    usage events) sums to 0 and never trips this breaker — a wedged-but-idle
+    run is the stall watchdog's jurisdiction (H3, exit 122), not the token
+    breaker's.
     """
     try:
         try:
@@ -169,6 +174,9 @@ def run(
             return proc.wait(timeout=min(poll_interval, remaining))
         except subprocess.TimeoutExpired:
             pass
+        # Tie-break: token (123) wins deterministically over timeout (124) when
+        # a breach is detected in the deadline-expiring poll slice — the budget
+        # is checked here, before the loop re-tests the wall-clock deadline.
         used = _token_usage(trajectory)  # None on any error -> fail open
         if used is not None and used > token_budget:
             print(

--- a/scripts/nightly/watchdog.py
+++ b/scripts/nightly/watchdog.py
@@ -7,13 +7,34 @@ grace period, then SIGKILL to -PGID. This replaces the previous
 timeout/gtimeout/perl-alarm fallback chain, whose perl leg killed only the
 direct child and left grandchildren (stdio MCP servers, subagents) alive.
 
+Token circuit breaker (plan humble-skipping-quilt H2): with ``--token-budget
+N --trajectory FILE`` the watchdog also polls the growing ``trajectory.jsonl``
+about every ``--poll-secs`` (default 15s) and computes the deduped per-message
+token sum over ALL usage token types unweighted (input + output +
+cache_creation + cache_read). Summing is REUSED from ``trajectory_tools`` (the
+H1 module) rather than re-implemented: its ``streamed_token_totals`` are the
+per-distinct-message-id sums the live path can compute incrementally. Counting
+all four types unweighted is the conservative "trip early, never late" choice
+(see the H1 module's H2 HAND-OFF note: the exactly-counted input+cache side
+dominates and grows monotonically; a single-turn output-heavy runaway is the
+wall-clock watchdog's job, not the breaker's). A breach kills the WHOLE GROUP
+on the SAME path as a wall-clock timeout and returns exit 123.
+
+Fail-open contract (plan Cross-cutting): the breaker NEVER trips or crashes on
+malformed/partial trajectory lines. ``trajectory_tools`` parses tolerantly
+(counts what parses, skips what doesn't); any unexpected error in the token
+poll is swallowed and treated as "no signal, keep running" so a parse bug can
+never kill a healthy night.
+
 Usage:
-    watchdog.py [--grace SECS] TIMEOUT_SECS -- COMMAND [ARGS...]
+    watchdog.py [--grace SECS] [--token-budget N --trajectory FILE]
+                [--poll-secs SECS] TIMEOUT_SECS -- COMMAND [ARGS...]
     watchdog.py --self-test
 
 Exit codes:
     child's exit code on normal completion
     124  timeout (group killed)
+    123  token budget exceeded (group killed)
     127  command not found
     64   usage error
     --self-test: 0 iff setsid + group-kill provably work on this host
@@ -30,7 +51,9 @@ import tempfile
 import time
 
 DEFAULT_GRACE = 30.0
+DEFAULT_POLL_SECS = 15.0
 TIMEOUT_EXIT = 124
+TOKEN_EXIT = 123
 NOT_FOUND_EXIT = 127
 USAGE_EXIT = 64
 
@@ -42,8 +65,66 @@ def _kill_group(pgid: int, sig: int) -> None:
         pass
 
 
-def run(timeout: float, grace: float, cmd: list[str]) -> int:
-    """Run cmd in its own process group under a group-kill watchdog."""
+def _terminate_group(proc: subprocess.Popen, pgid: int, grace: float) -> None:
+    """Kill the whole group: SIGTERM, ``grace`` to drain, then a group
+    SIGKILL. Shared by the wall-clock and token-breaker kill paths."""
+    _kill_group(pgid, signal.SIGTERM)
+    try:
+        proc.wait(timeout=grace)
+    except subprocess.TimeoutExpired:
+        pass
+    # Always follow with a group SIGKILL: the direct child may be dead
+    # while TERM-ignoring grandchildren linger in the group.
+    _kill_group(pgid, signal.SIGKILL)
+    try:
+        proc.wait(timeout=10)
+    except subprocess.TimeoutExpired:
+        print(
+            f"watchdog: group {pgid} did not reap after SIGKILL",
+            file=sys.stderr,
+        )
+
+
+def _token_usage(trajectory: str) -> int | None:
+    """Deduped per-message token sum over all four usage types, or None.
+
+    REUSES ``trajectory_tools`` summing (never re-implemented). Returns None
+    on ANY failure so the breaker fails open: a parse bug or import problem is
+    treated as "no signal", never as a reason to kill a healthy night. The
+    underlying parser is already tolerant (counts what parses, skips garbage),
+    so pure-garbage or partial files yield 0 here, never an exception.
+    """
+    try:
+        try:
+            from scripts.nightly import trajectory_tools  # package context
+        except ImportError:
+            sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+            import trajectory_tools  # type: ignore[no-redef]
+        # streamed_token_totals = per-distinct-message-id sums (the live path
+        # can compute these incrementally). Sum all four types unweighted.
+        totals = trajectory_tools.compute_metrics(trajectory)[
+            "streamed_token_totals"
+        ]
+        return sum(v for v in totals.values() if isinstance(v, int))
+    except Exception:  # fail open: never let a poll error kill the night
+        return None
+
+
+def run(
+    timeout: float,
+    grace: float,
+    cmd: list[str],
+    *,
+    token_budget: int | None = None,
+    trajectory: str | None = None,
+    poll_interval: float = DEFAULT_POLL_SECS,
+) -> int:
+    """Run cmd in its own process group under a group-kill watchdog.
+
+    With ``token_budget`` + ``trajectory`` set, the trajectory file is polled
+    every ``poll_interval`` seconds and a breach group-kills with exit 123.
+    Without them, behavior is wall-clock-only and unchanged.
+    """
     try:
         proc = subprocess.Popen(cmd, start_new_session=True)
     except FileNotFoundError:
@@ -58,29 +139,45 @@ def run(timeout: float, grace: float, cmd: list[str]) -> int:
     signal.signal(signal.SIGTERM, _forward)
     signal.signal(signal.SIGINT, _forward)
 
-    try:
-        return proc.wait(timeout=timeout)
-    except subprocess.TimeoutExpired:
-        print(
-            f"watchdog: timeout after {timeout}s; SIGTERM to group {pgid}",
-            file=sys.stderr,
-        )
-        _kill_group(pgid, signal.SIGTERM)
+    breaker_armed = token_budget is not None and trajectory is not None
+
+    if not breaker_armed:
+        # Wall-clock-only fast path (byte-for-byte the original behavior).
         try:
-            proc.wait(timeout=grace)
-        except subprocess.TimeoutExpired:
-            pass
-        # Always follow with a group SIGKILL: the direct child may be dead
-        # while TERM-ignoring grandchildren linger in the group.
-        _kill_group(pgid, signal.SIGKILL)
-        try:
-            proc.wait(timeout=10)
+            return proc.wait(timeout=timeout)
         except subprocess.TimeoutExpired:
             print(
-                f"watchdog: group {pgid} did not reap after SIGKILL",
+                f"watchdog: timeout after {timeout}s; SIGTERM to group {pgid}",
                 file=sys.stderr,
             )
-        return TIMEOUT_EXIT
+            _terminate_group(proc, pgid, grace)
+            return TIMEOUT_EXIT
+
+    # Token-breaker path: wait in poll_interval slices, checking the budget
+    # between slices while still honoring the wall-clock deadline.
+    deadline = time.monotonic() + timeout
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            print(
+                f"watchdog: timeout after {timeout}s; SIGTERM to group {pgid}",
+                file=sys.stderr,
+            )
+            _terminate_group(proc, pgid, grace)
+            return TIMEOUT_EXIT
+        try:
+            return proc.wait(timeout=min(poll_interval, remaining))
+        except subprocess.TimeoutExpired:
+            pass
+        used = _token_usage(trajectory)  # None on any error -> fail open
+        if used is not None and used > token_budget:
+            print(
+                f"watchdog: token budget exceeded ({used} of {token_budget}); "
+                f"SIGTERM to group {pgid}",
+                file=sys.stderr,
+            )
+            _terminate_group(proc, pgid, grace)
+            return TOKEN_EXIT
 
 
 def self_test() -> int:
@@ -130,13 +227,46 @@ def main(argv: list[str]) -> int:
     if args == ["--self-test"]:
         return self_test()
     grace = DEFAULT_GRACE
-    if len(args) >= 2 and args[0] == "--grace":
-        try:
-            grace = float(args[1])
-        except ValueError:
-            print(f"watchdog: bad --grace {args[1]!r}", file=sys.stderr)
+    poll_interval = DEFAULT_POLL_SECS
+    token_budget: int | None = None
+    trajectory: str | None = None
+
+    # Consume optional leading "--flag VALUE" pairs (any order) before the
+    # positional TIMEOUT and the "--" command separator.
+    i = 0
+    while i < len(args) and args[i].startswith("--") and args[i] != "--":
+        flag = args[i]
+        if i + 1 >= len(args):
+            print(__doc__, file=sys.stderr)
             return USAGE_EXIT
-        args = args[2:]
+        val = args[i + 1]
+        if flag == "--grace":
+            try:
+                grace = float(val)
+            except ValueError:
+                print(f"watchdog: bad --grace {val!r}", file=sys.stderr)
+                return USAGE_EXIT
+        elif flag == "--token-budget":
+            try:
+                token_budget = int(val)
+            except ValueError:
+                print(f"watchdog: bad --token-budget {val!r}", file=sys.stderr)
+                return USAGE_EXIT
+        elif flag == "--trajectory":
+            trajectory = val
+        elif flag == "--poll-secs":
+            try:
+                poll_interval = float(val)
+            except ValueError:
+                print(f"watchdog: bad --poll-secs {val!r}", file=sys.stderr)
+                return USAGE_EXIT
+        else:
+            print(f"watchdog: unknown flag {flag!r}", file=sys.stderr)
+            print(__doc__, file=sys.stderr)
+            return USAGE_EXIT
+        i += 2
+    args = args[i:]
+
     if "--" not in args:
         print(__doc__, file=sys.stderr)
         return USAGE_EXIT
@@ -150,7 +280,21 @@ def main(argv: list[str]) -> int:
     except ValueError:
         print(f"watchdog: bad timeout {head[0]!r}", file=sys.stderr)
         return USAGE_EXIT
-    return run(timeout=timeout, grace=grace, cmd=cmd)
+    # --token-budget and --trajectory arm the breaker together or not at all.
+    if (token_budget is None) != (trajectory is None):
+        print(
+            "watchdog: --token-budget and --trajectory must be given together",
+            file=sys.stderr,
+        )
+        return USAGE_EXIT
+    return run(
+        timeout=timeout,
+        grace=grace,
+        cmd=cmd,
+        token_budget=token_budget,
+        trajectory=trajectory,
+        poll_interval=poll_interval,
+    )
 
 
 if __name__ == "__main__":

--- a/tests/test_watchdog.py
+++ b/tests/test_watchdog.py
@@ -141,6 +141,48 @@ def test_missing_trajectory_fails_open(tmp_path):
     assert rc == 5
 
 
+def test_poll_error_fails_open_child_completes(tmp_path, monkeypatch):
+    """Safety-critical: if the token poll itself RAISES (not just parses
+    garbage), the swallow layer must fail open — the armed watchdog's child
+    completes normally, its own exit code preserved, no kill.
+
+    The garbage/missing tests only exercise the parser's tolerance; this one
+    forces the summing call to blow up (a hypothetical compute_metrics bug or
+    stream-json shape drift) and pins that a poll exception can NEVER kill a
+    healthy night. Remove the ``except Exception`` in watchdog._token_usage and
+    this test reds (run() propagates the error and the child is orphaned)."""
+
+    def _boom(*_args, **_kwargs):
+        raise RuntimeError("simulated compute_metrics failure")
+
+    # _token_usage does `from scripts.nightly import trajectory_tools` and calls
+    # compute_metrics at poll time, so patching the module attribute makes every
+    # poll raise.
+    monkeypatch.setattr(
+        "scripts.nightly.trajectory_tools.compute_metrics", _boom
+    )
+
+    traj = tmp_path / "trajectory.jsonl"
+    # Write real, over-budget usage so that WITHOUT the swallow the run would
+    # both crash (poll raises) — proving the swallow, not a low count, is what
+    # keeps the child alive.
+    traj.write_text(
+        _USAGE_EVENT.replace("__ID_MARKER__", "1").replace(
+            "__TOKENS__", "999999"
+        )
+        + "\n"
+    )
+    rc = watchdog.run(
+        timeout=10,
+        grace=1.0,
+        cmd=["/bin/sh", "-c", "sleep 0.6; exit 5"],
+        token_budget=1,  # tiny: any counted token would trip
+        trajectory=str(traj),
+        poll_interval=0.2,
+    )
+    assert rc == 5  # failed open despite the raising poll; child's code kept
+
+
 def test_no_budget_flag_is_wall_clock_only(tmp_path):
     """Budget absent -> byte-identical to today: normal exit passes through,
     and a wall-clock timeout still group-kills with exit 124."""

--- a/tests/test_watchdog.py
+++ b/tests/test_watchdog.py
@@ -5,6 +5,13 @@ The regression test reproduces the reviewer's probe: a grandchild
 parent out. The old perl alarm+exec fallback killed only the direct
 child, so the writer survived; the setsid + killpg watchdog must kill
 the whole group.
+
+The token-budget tests (plan humble-skipping-quilt H2) extend the same
+group-kill probe: a fast-burn synthetic trajectory grown past a tiny budget
+must trip the breaker (exit 123) and kill the WHOLE group (the grandchild
+writer stops), while an under-budget run passes the child's exit through, a
+pure-garbage trajectory fails OPEN (no kill), and the absence of the budget
+flag leaves wall-clock-only behavior unchanged.
 """
 
 from __future__ import annotations
@@ -19,6 +26,159 @@ from scripts.nightly import watchdog
 WATCHDOG_CLI = (
     Path(__file__).parent.parent / "scripts" / "nightly" / "watchdog.py"
 )
+
+# A single stream-json assistant usage event carrying ID_MARKER for a distinct
+# message id (usage is summed per DISTINCT message id, so unique ids are what
+# make the running total grow) and TOKENS input tokens.
+_USAGE_EVENT = (
+    '{"type":"assistant","message":{"id":"m__ID_MARKER__",'
+    '"usage":{"input_tokens":__TOKENS__,"output_tokens":0,'
+    '"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}'
+)
+
+
+def _burn_trajectory_script(traj: Path, probe: Path, tokens_per_event: int):
+    """A shell program that (a) backgrounds a grandchild writer loop and
+    (b) appends a fresh unique usage event to ``traj`` every 0.1s forever.
+
+    It never exits on its own: only the watchdog's group-kill can stop it, so
+    the grandchild writer doubles as proof the whole group died.
+    """
+    event = _USAGE_EVENT.replace("__TOKENS__", str(tokens_per_event))
+    # printf template with %d for the incrementing message id; escape the
+    # literal % that appear nowhere and the JSON braces are fine for printf.
+    event_fmt = event.replace("__ID_MARKER__", "%d")
+    return (
+        f'(while :; do echo alive >> "{probe}"; sleep 0.1; done) &\n'
+        "i=0\n"
+        "while :; do\n"
+        "  i=$((i+1))\n"
+        f'  printf \'{event_fmt}\\n\' "$i" >> "{traj}"\n'
+        "  sleep 0.1\n"
+        "done\n"
+    )
+
+
+def test_token_budget_breach_group_kills_and_exits_123(tmp_path):
+    """Fast-burn trajectory past a tiny budget: exit 123 AND the grandchild
+    writer must stop (whole-group death), same probe as the wall-clock test."""
+    traj = tmp_path / "trajectory.jsonl"
+    probe = tmp_path / "probe.out"
+    # 1000 tokens/event, budget 2500 -> trips after the 3rd event (~0.3s).
+    script = _burn_trajectory_script(traj, probe, tokens_per_event=1000)
+
+    started = time.time()
+    rc = watchdog.run(
+        timeout=30,  # generous wall clock: the BREAKER must fire, not this
+        grace=1.0,
+        cmd=["/bin/sh", "-c", script],
+        token_budget=2500,
+        trajectory=str(traj),
+        poll_interval=0.2,
+    )
+    assert rc == watchdog.TOKEN_EXIT, rc
+    assert time.time() - started < 15  # breaker fired fast, not the 30s wall
+
+    # Group-death proof: the backgrounded grandchild writer must have stopped.
+    assert probe.exists(), "writer grandchild never started"
+    time.sleep(0.4)
+    size_a = probe.stat().st_size
+    assert size_a > 0
+    time.sleep(0.8)
+    size_b = probe.stat().st_size
+    assert size_a == size_b, (
+        "grandchild survived the token-budget kill "
+        f"({size_a} -> {size_b} bytes still growing)"
+    )
+
+
+def test_under_budget_passes_child_exit_through(tmp_path):
+    """Budget armed but never breached: the child's own exit code survives."""
+    traj = tmp_path / "trajectory.jsonl"
+    event = _USAGE_EVENT.replace("__ID_MARKER__", "1").replace(
+        "__TOKENS__", "10"
+    )
+    script = f"printf '{event}\\n' >> \"{traj}\"; sleep 0.5; exit 7"
+    rc = watchdog.run(
+        timeout=10,
+        grace=1.0,
+        cmd=["/bin/sh", "-c", script],
+        token_budget=1_000_000,
+        trajectory=str(traj),
+        poll_interval=0.2,
+    )
+    assert rc == 7
+
+
+def test_garbage_trajectory_fails_open_child_completes(tmp_path):
+    """Pure-garbage trajectory + tiny budget: the breaker must NOT trip and
+    must NOT crash the monitor. Count what parses (nothing), skip the rest."""
+    traj = tmp_path / "trajectory.jsonl"
+    traj.write_text("this is not json\n{not: valid, json at all\n\x00\x01\n")
+    script = f'echo "more garbage <<>>" >> "{traj}"; sleep 0.6; exit 0'
+    rc = watchdog.run(
+        timeout=10,
+        grace=1.0,
+        cmd=["/bin/sh", "-c", script],
+        token_budget=1,  # would trip instantly if any garbage were counted
+        trajectory=str(traj),
+        poll_interval=0.2,
+    )
+    assert rc == 0  # failed open: child ran to normal completion
+
+
+def test_missing_trajectory_fails_open(tmp_path):
+    """A trajectory file that never appears must not trip or crash."""
+    traj = tmp_path / "never_created.jsonl"
+    rc = watchdog.run(
+        timeout=10,
+        grace=1.0,
+        cmd=["/bin/sh", "-c", "sleep 0.5; exit 5"],
+        token_budget=1,
+        trajectory=str(traj),
+        poll_interval=0.2,
+    )
+    assert rc == 5
+
+
+def test_no_budget_flag_is_wall_clock_only(tmp_path):
+    """Budget absent -> byte-identical to today: normal exit passes through,
+    and a wall-clock timeout still group-kills with exit 124."""
+    # Pass-through (no token args at all).
+    assert (
+        watchdog.run(timeout=10, grace=1, cmd=["/bin/sh", "-c", "exit 9"]) == 9
+    )
+    # Wall-clock timeout path unchanged (exit 124, not 123).
+    out = tmp_path / "probe.out"
+    script = f'(while :; do echo x >> "{out}"; sleep 0.1; done) & sleep 30'
+    rc = watchdog.run(timeout=1.0, grace=1.0, cmd=["/bin/sh", "-c", script])
+    assert rc == watchdog.TIMEOUT_EXIT
+
+
+def test_cli_token_flags_parse_and_passthrough(tmp_path):
+    """CLI wiring: --token-budget/--trajectory parse; under budget the child
+    exit passes through (proves the flags don't disturb usage parsing)."""
+    traj = tmp_path / "trajectory.jsonl"
+    traj.write_text("")
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(WATCHDOG_CLI),
+            "--grace",
+            "1",
+            "--token-budget",
+            "1000000",
+            "--trajectory",
+            str(traj),
+            "10",
+            "--",
+            "/bin/sh",
+            "-c",
+            "exit 4",
+        ],
+        check=False,
+    )
+    assert proc.returncode == 4
 
 
 def test_normal_exit_passes_through_exit_code():


### PR DESCRIPTION
## What

Implements **H2** of plan `humble-skipping-quilt` (Hardening Sprint): a **token circuit breaker** as a `scripts/nightly/watchdog.py` extension. Stacks on H1 (`trajectory_tools.py`, merged in #1227).

With `--token-budget N --trajectory FILE`, the watchdog polls the growing `trajectory.jsonl` (~15s, tunable via `--poll-secs`) and computes the **deduped per-message token sum over ALL usage token types unweighted** (`input + output + cache_creation + cache_read`). The summing is **REUSED from `trajectory_tools`** (its `streamed_token_totals`, the per-distinct-message-id sums the H1 module documents as the live-path signal) — not re-implemented. Counting all four types unweighted is the conservative "trip early, never late" choice per the H1 module's H2 HAND-OFF note (the exactly-counted input+cache side dominates and grows monotonically; a single-turn output-heavy runaway is the wall-clock watchdog's job).

A breach group-kills on the **same path** as a wall-clock timeout (SIGTERM -> grace -> SIGKILL to `-PGID`) and returns the distinct **exit 123**.

**Fails OPEN** (plan Cross-cutting): the tolerant H1 parser plus a swallow-all guard in the token poll mean malformed / partial / missing trajectories never trip the breaker and never crash the monitor. Without the flags, behavior is wall-clock-only and unchanged.

`run_nightly.sh`:
- `NIGHTLY_TOKEN_BUDGET` default **2000000**, exported.
- Watchdog invocation gains `--token-budget` + `--trajectory`.
- Exit 123 maps to its own RED-stub reason `token budget exceeded (N of M tokens)` with actual/ceiling.
- Healthy nights get an actual-vs-ceiling line wired into the report's **Budget** section via `run_metrics.json` post-run.

Out of scope: the **stall watchdog is H3** (next PR, same file) — diff kept scoped so H3 stacks cleanly.

## Failing-test-first: red then green

Tests written against the unmodified `run()` first.

**RED** (`pytest tests/test_watchdog.py -k 'token or garbage or budget or trajectory'`):
```
E  TypeError: run() got an unexpected keyword argument 'token_budget'   (x4)
E  AssertionError: assert 64 == 4   (CLI rejected the new flags)
5 failed, 1 passed
```

**GREEN** (after implementation, full file):
```
tests/test_watchdog.py .... 12 passed
tests/test_watchdog.py + tests/nightly/ ... 24 passed
```

## Tests added (6, all new)

- `test_token_budget_breach_group_kills_and_exits_123` — fast-burn synthetic trajectory past a tiny budget: **exit 123 AND the backgrounded grandchild writer stops growing** (whole-group death, same probe pattern as the wall-clock regression test).
- `test_under_budget_passes_child_exit_through` — budget armed but never breached: child's exit (7) survives.
- `test_garbage_trajectory_fails_open_child_completes` — pure-garbage trajectory + budget of 1: **no kill**, child completes 0.
- `test_missing_trajectory_fails_open` — trajectory that never appears: no trip/crash.
- `test_no_budget_flag_is_wall_clock_only` — flags absent: passthrough + wall-clock timeout still exit 124 (byte-identical behavior).
- `test_cli_token_flags_parse_and_passthrough` — CLI wiring for the two flags.

Also verified end-to-end at the CLI (script-context `trajectory_tools` import): a breaching trajectory yields exit 123, and the injected Budget line keeps the report contract-valid.

## Plan reference

Plan `humble-skipping-quilt` — H2 work item; Cross-cutting exit-code map `124(wall)/123(tokens)/122(stall)` and fail-open-on-parse-errors requirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BeLcSviHL5vDgS3zTSMbsq