### PR TITLE
[nightly] H3: stall watchdog (exit 122)

### DIFF
--- a/scripts/nightly/run_nightly.sh
+++ b/scripts/nightly/run_nightly.sh
@@ -25,6 +25,9 @@
 #   NIGHTLY_MAX_TURNS       default 80
 #   NIGHTLY_TOKEN_BUDGET    default 2000000 (H2 token circuit breaker ceiling;
 #                           breach -> watchdog exit 123 -> RED stub)
+#   NIGHTLY_STALL_SECS      default 1200 (H3 stall watchdog; no progress on the
+#                           trajectory/report for this many seconds -> watchdog
+#                           exit 122 -> RED stub)
 #
 # Exit: 0 report produced and published (any verdict); 1 only when even the
 # stub/publish path failed.
@@ -46,6 +49,11 @@ MAX_TURNS="${NIGHTLY_MAX_TURNS:-80}"
 export NIGHTLY_TOKEN_BUDGET="${NIGHTLY_TOKEN_BUDGET:-2000000}"
 # Must match watchdog.py TOKEN_EXIT (exit code on a token-budget group-kill).
 TOKEN_EXIT_CODE=123
+# H3 stall watchdog: kill the run if no progress (trajectory/report mtime) for
+# this many seconds. Default 20min. Exported so it is visible to the loop.
+export NIGHTLY_STALL_SECS="${NIGHTLY_STALL_SECS:-1200}"
+# Must match watchdog.py STALL_EXIT (exit code on a no-progress group-kill).
+STALL_EXIT_CODE=122
 BRIEF="$REPO_ROOT/docs/nightly/BRIEF.md"
 CANNED_REPORT="$SCRIPT_DIR/fixtures/canned_agent_report.md"
 CHECKER="$SCRIPT_DIR/check_contract.py"
@@ -114,6 +122,26 @@ try:
 except Exception:
     pass
 PY
+}
+
+# H3: name which progress signal went quiet for the stall RED stub. Echoes
+# "<basename>, <age>s ago" for the newest existing progress file, or a note if
+# none ever appeared. Fails quiet (never breaks the report on a stat error).
+stall_last_activity() {
+  local now newest_m="" newest_f="" f m
+  now="$(date +%s)"
+  for f in "$RUN_DIR/trajectory.jsonl" "$NIGHTLY_REPORT_PATH"; do
+    m="$(stat -f%m "$f" 2>/dev/null || stat -c%Y "$f" 2>/dev/null || echo '')"
+    [ -n "$m" ] || continue  # missing/stat error: contributes nothing
+    if [ -z "$newest_m" ] || [ "$m" -gt "$newest_m" ]; then
+      newest_m="$m"; newest_f="$f"
+    fi
+  done
+  if [ -z "$newest_m" ]; then
+    echo "no progress file ever appeared"
+  else
+    echo "$(basename "$newest_f"), $((now - newest_m))s ago"
+  fi
 }
 
 # H2: wire actual-vs-ceiling into a healthy report's Budget section, inserted
@@ -283,9 +311,16 @@ else
   # H2: --token-budget + --trajectory arm the token circuit breaker. The
   # watchdog polls trajectory.jsonl (~15s) and group-kills with exit 123 if
   # the deduped token sum breaches NIGHTLY_TOKEN_BUDGET.
+  # H3: --stall-secs + --progress arm the stall watchdog on the SAME poll loop.
+  # Progress = newest mtime across trajectory.jsonl (primary: any agent activity
+  # touches it) and the report path (secondary). No progress for
+  # NIGHTLY_STALL_SECS -> group-kill with exit 122.
   ( cd "$REPO_ROOT" && python3 "$WATCHDOG" --grace 30 \
       --token-budget "$NIGHTLY_TOKEN_BUDGET" \
       --trajectory "$RUN_DIR/trajectory.jsonl" \
+      --stall-secs "$NIGHTLY_STALL_SECS" \
+      --progress "$RUN_DIR/trajectory.jsonl" \
+      --progress "$NIGHTLY_REPORT_PATH" \
       "$TIMEOUT_SECS" -- \
       "$CLAUDE_BIN" -p "$(cat "$BRIEF")" \
       --output-format stream-json --verbose \
@@ -312,12 +347,17 @@ else
     && log "run_metrics.json written (claude $CLAUDE_VERSION)" \
     || log "WARNING: run_metrics.json generation failed"
 
-  # H2: map the token circuit breaker's exit 123 to its own RED stub, and on
-  # healthy nights record actual-vs-ceiling in the report's Budget section.
+  # Map the watchdog's group-kill exits to their own RED stubs (token 123 wins
+  # over stall 122, matching the watchdog's own precedence), and on healthy
+  # nights record actual-vs-ceiling in the report's Budget section.
   TOKEN_TOTAL="$(read_token_total)"
   if [ "$AGENT_EXIT" -eq "$TOKEN_EXIT_CODE" ]; then
     log "token budget breached: ${TOKEN_TOTAL:-unknown} of $NIGHTLY_TOKEN_BUDGET tokens (watchdog exit 123)"
     write_red_stub "token budget exceeded (${TOKEN_TOTAL:-unknown} of $NIGHTLY_TOKEN_BUDGET tokens)"
+  elif [ "$AGENT_EXIT" -eq "$STALL_EXIT_CODE" ]; then
+    STALL_WHERE="$(stall_last_activity)"
+    log "stall watchdog fired: no progress for ${NIGHTLY_STALL_SECS}s (last activity: $STALL_WHERE) (watchdog exit 122)"
+    write_red_stub "stalled: no progress for ${NIGHTLY_STALL_SECS}s (last activity: $STALL_WHERE)"
   elif [ -s "$REPORT_PATH" ]; then
     inject_budget_token_line "- tokens: ${TOKEN_TOTAL:-n/a} of $NIGHTLY_TOKEN_BUDGET (budget)"
   fi

--- a/scripts/nightly/run_nightly.sh
+++ b/scripts/nightly/run_nightly.sh
@@ -357,7 +357,17 @@ else
   elif [ "$AGENT_EXIT" -eq "$STALL_EXIT_CODE" ]; then
     STALL_WHERE="$(stall_last_activity)"
     log "stall watchdog fired: no progress for ${NIGHTLY_STALL_SECS}s (last activity: $STALL_WHERE) (watchdog exit 122)"
-    write_red_stub "stalled: no progress for ${NIGHTLY_STALL_SECS}s (last activity: $STALL_WHERE)"
+    # A wedged run must NOT publish as healthy: the RED stub is always written.
+    # But if the agent had already produced a report, preserve its original
+    # bytes (mirroring rejected_report.md) before the stub overwrites it, and
+    # point the owner at it.
+    STALL_STUB="stalled: no progress for ${NIGHTLY_STALL_SECS}s (last activity: $STALL_WHERE)"
+    if [ -s "$REPORT_PATH" ]; then
+      cp "$REPORT_PATH" "$RUN_DIR/stalled_report.md" 2>/dev/null \
+        && STALL_STUB="$STALL_STUB; partial report preserved at $RUN_DIR/stalled_report.md" \
+        || log "WARNING: could not preserve stalled report copy"
+    fi
+    write_red_stub "$STALL_STUB"
   elif [ -s "$REPORT_PATH" ]; then
     inject_budget_token_line "- tokens: ${TOKEN_TOTAL:-n/a} of $NIGHTLY_TOKEN_BUDGET (budget)"
   fi

--- a/scripts/nightly/watchdog.py
+++ b/scripts/nightly/watchdog.py
@@ -33,12 +33,11 @@ this item. The progress signal is the NEWEST mtime across all ``--progress``
 files (primary: trajectory.jsonl, which any agent activity touches; secondary:
 the report path). If ``now - newest_mtime > stall_secs`` the whole group is
 killed on the same path and the watchdog returns exit 122. A progress file that
-does not exist YET contributes nothing (the trajectory appears within seconds
-of launch); but so a run where NO progress file EVER appears still trips, the
-watchdog's own START TIME is the baseline mtime, so a never-created file trips
-at stall_secs after launch. Fails OPEN on any stat error (same swallow
-discipline as the token breaker): a stat glitch must never kill a healthy
-night.
+does not yet exist contributes nothing (the trajectory appears within seconds
+of launch); the watchdog's own start time is the baseline, so a run where no
+progress file ever appears trips at stall_secs from launch. Fails OPEN on any
+stat error (same swallow discipline as the token breaker): a stat glitch must
+never kill a healthy night.
 
 Precedence when multiple limits are coincident in one poll slice: token (123) >
 stall (122) > wall (124). The token and stall breaches are tested between wait

--- a/scripts/nightly/watchdog.py
+++ b/scripts/nightly/watchdog.py
@@ -26,8 +26,29 @@ malformed/partial trajectory lines. ``trajectory_tools`` parses tolerantly
 poll is swallowed and treated as "no signal, keep running" so a parse bug can
 never kill a healthy night.
 
+Stall watchdog (plan humble-skipping-quilt H3): with ``--stall-secs N`` and one
+or more ``--progress FILE`` the SAME poll loop also watches for a wedged-but-
+idle run — the zero-token-wedge boundary the token breaker explicitly leaves to
+this item. The progress signal is the NEWEST mtime across all ``--progress``
+files (primary: trajectory.jsonl, which any agent activity touches; secondary:
+the report path). If ``now - newest_mtime > stall_secs`` the whole group is
+killed on the same path and the watchdog returns exit 122. A progress file that
+does not exist YET contributes nothing (the trajectory appears within seconds
+of launch); but so a run where NO progress file EVER appears still trips, the
+watchdog's own START TIME is the baseline mtime, so a never-created file trips
+at stall_secs after launch. Fails OPEN on any stat error (same swallow
+discipline as the token breaker): a stat glitch must never kill a healthy
+night.
+
+Precedence when multiple limits are coincident in one poll slice: token (123) >
+stall (122) > wall (124). The token and stall breaches are tested between wait
+slices, in that order, before the loop re-tests the wall-clock deadline at the
+top — so an earlier limit deterministically wins the tie (this extends the
+token-vs-wall tie-break note below).
+
 Usage:
     watchdog.py [--grace SECS] [--token-budget N --trajectory FILE]
+                [--stall-secs N --progress FILE [--progress FILE ...]]
                 [--poll-secs SECS] TIMEOUT_SECS -- COMMAND [ARGS...]
     watchdog.py --self-test
 
@@ -35,6 +56,7 @@ Exit codes:
     child's exit code on normal completion
     124  timeout (group killed)
     123  token budget exceeded (group killed)
+    122  stalled: no progress within --stall-secs (group killed)
     127  command not found
     64   usage error
     --self-test: 0 iff setsid + group-kill provably work on this host
@@ -54,6 +76,7 @@ DEFAULT_GRACE = 30.0
 DEFAULT_POLL_SECS = 15.0
 TIMEOUT_EXIT = 124
 TOKEN_EXIT = 123
+STALL_EXIT = 122
 NOT_FOUND_EXIT = 127
 USAGE_EXIT = 64
 
@@ -115,6 +138,39 @@ def _token_usage(trajectory: str) -> int | None:
         return None
 
 
+def _stall_tripped(
+    progress_files: list[str], baseline: float, stall_secs: float
+) -> bool:
+    """True iff no --progress file has been touched within ``stall_secs``.
+
+    The progress signal is the NEWEST mtime across all ``progress_files``. A
+    file that does not exist YET contributes nothing (``FileNotFoundError`` is
+    skipped) — the trajectory appears within seconds of launch, so a briefly-
+    absent file is normal. If NO file has ever appeared, ``baseline`` (the
+    watchdog's own start time) is the clock, so a never-created progress file
+    trips at ``stall_secs`` after launch rather than never.
+
+    Fails OPEN (returns False) on ANY unexpected stat error — the same swallow
+    discipline as the token breaker's ``_token_usage``: a stat glitch must
+    never kill a healthy night. Only a genuinely missing file (skipped) is
+    distinguished from a stat failure (swallowed -> no trip).
+    """
+    try:
+        newest = baseline
+        seen = False
+        for path in progress_files:
+            try:
+                mtime = os.stat(path).st_mtime
+            except FileNotFoundError:
+                continue  # not created yet: contributes nothing
+            if not seen or mtime > newest:
+                newest = mtime
+                seen = True
+        return (time.time() - newest) > stall_secs
+    except Exception:  # fail open on any stat error (never kill a healthy run)
+        return False
+
+
 def run(
     timeout: float,
     grace: float,
@@ -123,18 +179,27 @@ def run(
     token_budget: int | None = None,
     trajectory: str | None = None,
     poll_interval: float = DEFAULT_POLL_SECS,
+    stall_secs: float | None = None,
+    progress_files: list[str] | None = None,
 ) -> int:
     """Run cmd in its own process group under a group-kill watchdog.
 
     With ``token_budget`` + ``trajectory`` set, the trajectory file is polled
     every ``poll_interval`` seconds and a breach group-kills with exit 123.
-    Without them, behavior is wall-clock-only and unchanged.
+    With ``stall_secs`` + ``progress_files`` set, the SAME poll loop watches the
+    newest progress-file mtime and group-kills with exit 122 when no progress
+    has been made within ``stall_secs``. With NEITHER armed, behavior is
+    wall-clock-only and unchanged.
     """
+    progress_files = progress_files or []
     try:
         proc = subprocess.Popen(cmd, start_new_session=True)
     except FileNotFoundError:
         print(f"watchdog: command not found: {cmd[0]}", file=sys.stderr)
         return NOT_FOUND_EXIT
+    launch_time = (
+        time.time()
+    )  # stall baseline: a never-created file trips here
     pgid = proc.pid  # start_new_session makes the child its own group leader
 
     def _forward(signum: int, _frame: object) -> None:
@@ -145,8 +210,9 @@ def run(
     signal.signal(signal.SIGINT, _forward)
 
     breaker_armed = token_budget is not None and trajectory is not None
+    stall_armed = stall_secs is not None and len(progress_files) > 0
 
-    if not breaker_armed:
+    if not (breaker_armed or stall_armed):
         # Wall-clock-only fast path (byte-for-byte the original behavior).
         try:
             return proc.wait(timeout=timeout)
@@ -158,8 +224,11 @@ def run(
             _terminate_group(proc, pgid, grace)
             return TIMEOUT_EXIT
 
-    # Token-breaker path: wait in poll_interval slices, checking the budget
-    # between slices while still honoring the wall-clock deadline.
+    # Monitor path: wait in poll_interval slices, checking each armed limit
+    # between slices while still honoring the wall-clock deadline. Precedence
+    # when coincident: token (123) > stall (122) > wall (124) — the first two
+    # are tested here, in that order, before the loop re-tests the wall-clock
+    # deadline at the top, so an earlier limit deterministically wins the tie.
     deadline = time.monotonic() + timeout
     while True:
         remaining = deadline - time.monotonic()
@@ -174,18 +243,28 @@ def run(
             return proc.wait(timeout=min(poll_interval, remaining))
         except subprocess.TimeoutExpired:
             pass
-        # Tie-break: token (123) wins deterministically over timeout (124) when
-        # a breach is detected in the deadline-expiring poll slice — the budget
-        # is checked here, before the loop re-tests the wall-clock deadline.
-        used = _token_usage(trajectory)  # None on any error -> fail open
-        if used is not None and used > token_budget:
+        # 1) Token (123): wins over stall and over the deadline-expiring slice.
+        if breaker_armed:
+            used = _token_usage(trajectory)  # None on any error -> fail open
+            if used is not None and used > token_budget:
+                print(
+                    f"watchdog: token budget exceeded ({used} of "
+                    f"{token_budget}); SIGTERM to group {pgid}",
+                    file=sys.stderr,
+                )
+                _terminate_group(proc, pgid, grace)
+                return TOKEN_EXIT
+        # 2) Stall (122): wins over the wall-clock re-test at the loop top.
+        if stall_armed and _stall_tripped(
+            progress_files, launch_time, stall_secs
+        ):
             print(
-                f"watchdog: token budget exceeded ({used} of {token_budget}); "
+                f"watchdog: no progress for >{stall_secs}s; "
                 f"SIGTERM to group {pgid}",
                 file=sys.stderr,
             )
             _terminate_group(proc, pgid, grace)
-            return TOKEN_EXIT
+            return STALL_EXIT
 
 
 def self_test() -> int:
@@ -238,9 +317,11 @@ def main(argv: list[str]) -> int:
     poll_interval = DEFAULT_POLL_SECS
     token_budget: int | None = None
     trajectory: str | None = None
+    stall_secs: float | None = None
+    progress_files: list[str] = []
 
-    # Consume optional leading "--flag VALUE" pairs (any order) before the
-    # positional TIMEOUT and the "--" command separator.
+    # Consume optional leading "--flag VALUE" pairs (any order, --progress
+    # REPEATABLE) before the positional TIMEOUT and the "--" command separator.
     i = 0
     while i < len(args) and args[i].startswith("--") and args[i] != "--":
         flag = args[i]
@@ -262,6 +343,14 @@ def main(argv: list[str]) -> int:
                 return USAGE_EXIT
         elif flag == "--trajectory":
             trajectory = val
+        elif flag == "--stall-secs":
+            try:
+                stall_secs = float(val)
+            except ValueError:
+                print(f"watchdog: bad --stall-secs {val!r}", file=sys.stderr)
+                return USAGE_EXIT
+        elif flag == "--progress":
+            progress_files.append(val)
         elif flag == "--poll-secs":
             try:
                 poll_interval = float(val)
@@ -295,6 +384,13 @@ def main(argv: list[str]) -> int:
             file=sys.stderr,
         )
         return USAGE_EXIT
+    # --stall-secs and --progress arm the stall watchdog together or not at all.
+    if (stall_secs is None) != (len(progress_files) == 0):
+        print(
+            "watchdog: --stall-secs and --progress must be given together",
+            file=sys.stderr,
+        )
+        return USAGE_EXIT
     return run(
         timeout=timeout,
         grace=grace,
@@ -302,6 +398,8 @@ def main(argv: list[str]) -> int:
         token_budget=token_budget,
         trajectory=trajectory,
         poll_interval=poll_interval,
+        stall_secs=stall_secs,
+        progress_files=progress_files,
     )
 
 

--- a/tests/test_run_nightly.py
+++ b/tests/test_run_nightly.py
@@ -335,3 +335,88 @@ def test_invalid_agent_report_replaced_by_red_stub(nightly_env, tmp_path):
     # The rejected original is preserved for debugging.
     rejected = tmp_path / "logs" / "1999-01-03" / "rejected_report.md"
     assert rejected.read_text() == "not a report\n"
+
+
+def test_stall_exit_preserves_partial_report_and_writes_stub(
+    nightly_env, tmp_path
+):
+    """H3 policy: an induced stall (the agent exits 122, the code the stall
+    watchdog returns on a no-progress group-kill) must PUBLISH the RED stub — a
+    wedged run must never publish as healthy — but if the agent had already
+    written a report, its ORIGINAL BYTES are preserved at
+    $RUN_DIR/stalled_report.md (mirroring rejected_report.md) and named in the
+    stub."""
+    partial = (
+        "# Nightly Report (partial, agent wedged)\n\n"
+        "## Verdict\n**Verdict: GREEN** - looked fine until it hung\n\n"
+        "PARTIAL-REPORT-SENTINEL-do-not-lose-me\n"
+    )
+    # Fake claude: writes a partial report to the report path, emits one
+    # stream-json line to stdout (-> trajectory.jsonl), then exits 122.
+    stall_claude = write_executable(
+        tmp_path / "stall_claude.sh",
+        "#!/bin/bash\n"
+        'for a in "$@"; do\n'
+        '  if [ "$a" = "--version" ]; then echo "9.9.9 (Fake)"; exit 0; fi\n'
+        "done\n"
+        f"cat > \"$NIGHTLY_REPORT_PATH\" <<'REPORT'\n{partial}REPORT\n"
+        'echo \'{"type":"assistant","message":'
+        '{"id":"m1","usage":{"input_tokens":1}}}\'\n'
+        "exit 122\n",
+    )
+    stub_repo = tmp_path / "stub_repo_stall"
+    stub_repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=stub_repo, check=True)
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.email=t@t",
+            "-c",
+            "user.name=t",
+            "commit",
+            "-q",
+            "--allow-empty",
+            "-m",
+            "root",
+        ],
+        cwd=stub_repo,
+        check=True,
+    )
+    brief_dir = stub_repo / "docs" / "nightly"
+    brief_dir.mkdir(parents=True)
+    (brief_dir / "BRIEF.md").write_text("test brief\n")
+
+    env = dict(nightly_env)
+    env.update(
+        {
+            "NIGHTLY_DATE": "1999-01-05",
+            "NIGHTLY_REPO_ROOT": str(stub_repo),
+            "CLAUDE_BIN": str(stall_claude),
+            "GIT_AUTHOR_NAME": "t",
+            "GIT_AUTHOR_EMAIL": "t@t",
+            "GIT_COMMITTER_NAME": "t",
+            "GIT_COMMITTER_EMAIL": "t@t",
+        }
+    )
+    proc = run_wrapper(env)
+    assert proc.returncode == 0, proc.stderr
+
+    run_dir = tmp_path / "logs" / "1999-01-05"
+
+    # 1. The partial report is preserved verbatim (original bytes).
+    stalled = run_dir / "stalled_report.md"
+    assert stalled.exists(), "partial report must be preserved on a stall"
+    assert stalled.read_text() == partial
+
+    # 2. The PUBLISHED report is the RED stub, not the partial (no healthy
+    #    publish of a wedged run).
+    report = tmp_path / "reports" / "1999-01-05.md"
+    text = report.read_text()
+    assert "PARTIAL-REPORT-SENTINEL-do-not-lose-me" not in text
+    result = check_contract.check_report_text(text)
+    assert result["valid"] is True, result["problems"]
+    assert result["verdict"] == "RED"
+    assert "stalled: no progress" in text
+    # 3. The stub names the preserved copy.
+    assert "stalled_report.md" in text

--- a/tests/test_watchdog.py
+++ b/tests/test_watchdog.py
@@ -12,10 +12,19 @@ must trip the breaker (exit 123) and kill the WHOLE group (the grandchild
 writer stops), while an under-budget run passes the child's exit through, a
 pure-garbage trajectory fails OPEN (no kill), and the absence of the budget
 flag leaves wall-clock-only behavior unchanged.
+
+The stall tests (plan humble-skipping-quilt H3) reuse the same group-kill
+probe for a different silence: a child that writes progress briefly then
+sleeps forever must be killed at ~stall+grace (exit 122), a continuous writer
+survives to its own exit, a never-created progress file trips at stall_secs
+after launch (the watchdog's start time is the baseline), and a stat error in
+the poll fails OPEN. A combined test arms wall + budget + stall together and
+shows each fires independently with its own exit code.
 """
 
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 import time
@@ -221,6 +230,239 @@ def test_cli_token_flags_parse_and_passthrough(tmp_path):
         check=False,
     )
     assert proc.returncode == 4
+
+
+# --- H3: stall watchdog (exit 122) -----------------------------------------
+
+
+def test_stall_write_then_sleep_group_kills_and_exits_122(tmp_path):
+    """Write-then-sleep probe: the child touches the progress file a few times
+    then sleeps forever. The stall watchdog must kill the WHOLE group at
+    ~stall+grace (exit 122); the backgrounded grandchild writer is the
+    group-death proof (it must FREEZE after the kill)."""
+    progress = tmp_path / "trajectory.jsonl"
+    probe = tmp_path / "probe.out"
+    # Grandchild writer -> probe (NOT a progress file: it keeps writing until
+    # the group dies). Main proc touches progress 3x (~0.3s) then sleeps 300s,
+    # so the progress signal goes quiet and the stall trips.
+    script = (
+        f'(while :; do echo alive >> "{probe}"; sleep 0.1; done) &\n'
+        f'for i in 1 2 3; do echo tick >> "{progress}"; sleep 0.1; done\n'
+        "sleep 300\n"
+    )
+    started = time.time()
+    rc = watchdog.run(
+        timeout=30,  # generous wall clock: STALL must fire, not the wall
+        grace=1.0,
+        cmd=["/bin/sh", "-c", script],
+        stall_secs=1.0,
+        progress_files=[str(progress)],
+        poll_interval=0.2,
+    )
+    assert rc == watchdog.STALL_EXIT, rc
+    assert time.time() - started < 15  # stall fired fast, not the 30s wall
+
+    # Group-death proof: the backgrounded grandchild writer must have stopped.
+    assert probe.exists(), "writer grandchild never started"
+    time.sleep(0.4)
+    size_a = probe.stat().st_size
+    assert size_a > 0
+    time.sleep(0.8)
+    size_b = probe.stat().st_size
+    assert size_a == size_b, (
+        "grandchild survived the stall kill "
+        f"({size_a} -> {size_b} bytes still growing)"
+    )
+
+
+def test_stall_continuous_writer_survives_to_its_own_exit(tmp_path):
+    """A child that keeps touching the progress file faster than stall_secs
+    never trips the stall watchdog and reaches its own exit code."""
+    progress = tmp_path / "trajectory.jsonl"
+    # Touch progress every 0.1s for ~2s (well under stall_secs=1.0), then exit.
+    script = (
+        f'for i in $(seq 1 20); do echo tick >> "{progress}"; sleep 0.1; '
+        "done\n"
+        "exit 6\n"
+    )
+    rc = watchdog.run(
+        timeout=30,
+        grace=1.0,
+        cmd=["/bin/sh", "-c", script],
+        stall_secs=1.0,
+        progress_files=[str(progress)],
+        poll_interval=0.2,
+    )
+    assert rc == 6
+
+
+def test_stall_never_created_progress_trips_at_stall_secs(tmp_path):
+    """A progress file that NEVER appears must still trip: the watchdog's own
+    start time is the baseline, so a never-created file trips at stall_secs
+    after launch (not immediately, and not never)."""
+    progress = tmp_path / "never_created.jsonl"  # nothing ever writes it
+    started = time.time()
+    rc = watchdog.run(
+        timeout=30,
+        grace=0.5,
+        cmd=["/bin/sh", "-c", "sleep 300"],  # idle: never writes anything
+        stall_secs=1.0,
+        progress_files=[str(progress)],
+        poll_interval=0.2,
+    )
+    assert rc == watchdog.STALL_EXIT, rc
+    elapsed = time.time() - started
+    assert elapsed >= 0.9, elapsed  # did NOT trip before stall_secs
+    assert elapsed < 10, elapsed  # DID trip (baseline is the clock)
+
+
+def test_stall_stat_error_fails_open_child_completes(tmp_path, monkeypatch):
+    """Safety-critical: if os.stat itself RAISES (a non-missing error), the
+    swallow layer must fail open — the armed watchdog's child completes
+    normally, no kill. Mirrors the token breaker's poll-error test. The tiny
+    stall_secs would trip instantly if the error were not swallowed."""
+    progress = tmp_path / "trajectory.jsonl"
+    progress.write_text("tick\n")  # exists, but stat will blow up on it
+    real_stat = os.stat
+
+    def _boom(path, *args, **kwargs):
+        if str(path) == str(progress):
+            raise RuntimeError("simulated stat failure")
+        return real_stat(path, *args, **kwargs)
+
+    monkeypatch.setattr(os, "stat", _boom)
+
+    rc = watchdog.run(
+        timeout=10,
+        grace=0.5,
+        cmd=["/bin/sh", "-c", "sleep 0.6; exit 5"],
+        stall_secs=0.1,  # tiny: would trip at once if the error weren't swallowed
+        progress_files=[str(progress)],
+        poll_interval=0.2,
+    )
+    assert rc == 5  # failed open despite the raising stat; child's code kept
+
+
+def test_combined_wall_budget_stall_each_trips_independently(tmp_path):
+    """Arm wall + budget + stall together and prove each fires on its own in
+    three scenarios, each with its distinct exit code."""
+    # --- Scenario 1: WALL trips (124). No usage events (token can't fire),
+    # progress kept fresh (stall can't fire), short 1s wall wins.
+    progress1 = tmp_path / "s1_progress.jsonl"
+    traj1 = tmp_path / "s1_traj.jsonl"
+    traj1.write_text("")  # stays empty -> 0 tokens
+    script1 = f'while :; do echo tick >> "{progress1}"; sleep 0.1; done\n'
+    started = time.time()
+    rc1 = watchdog.run(
+        timeout=1.0,
+        grace=1.0,
+        cmd=["/bin/sh", "-c", script1],
+        token_budget=1_000_000,
+        trajectory=str(traj1),
+        stall_secs=30.0,
+        progress_files=[str(progress1)],
+        poll_interval=0.2,
+    )
+    assert rc1 == watchdog.TIMEOUT_EXIT, rc1  # 124
+    assert time.time() - started < 10
+
+    # --- Scenario 2: TOKEN trips (123). Fast burn past a tiny budget; the burn
+    # keeps its own trajectory fresh (stall can't fire), 30s wall is generous.
+    traj2 = tmp_path / "s2_traj.jsonl"
+    probe2 = tmp_path / "s2_probe.out"
+    script2 = _burn_trajectory_script(traj2, probe2, tokens_per_event=1000)
+    rc2 = watchdog.run(
+        timeout=30,
+        grace=1.0,
+        cmd=["/bin/sh", "-c", script2],
+        token_budget=2500,
+        trajectory=str(traj2),
+        stall_secs=30.0,
+        progress_files=[str(traj2)],  # fresh -> stall silent
+        poll_interval=0.2,
+    )
+    assert rc2 == watchdog.TOKEN_EXIT, rc2  # 123
+
+    # --- Scenario 3: STALL trips (122). Progress goes quiet, no usage events
+    # (token silent), 30s wall is generous.
+    progress3 = tmp_path / "s3_progress.jsonl"
+    traj3 = tmp_path / "s3_traj.jsonl"
+    traj3.write_text("")  # empty -> 0 tokens, token can't fire
+    script3 = (
+        f'for i in 1 2 3; do echo tick >> "{progress3}"; sleep 0.1; done\n'
+        "sleep 300\n"
+    )
+    rc3 = watchdog.run(
+        timeout=30,
+        grace=1.0,
+        cmd=["/bin/sh", "-c", script3],
+        token_budget=1_000_000,
+        trajectory=str(traj3),
+        stall_secs=1.0,
+        progress_files=[str(progress3)],
+        poll_interval=0.2,
+    )
+    assert rc3 == watchdog.STALL_EXIT, rc3  # 122
+
+
+def test_no_stall_flag_is_wall_clock_only(tmp_path):
+    """Stall (and token) flags absent -> byte-identical wall-clock-only path:
+    normal exit passes through, and a wall-clock timeout still exits 124."""
+    assert (
+        watchdog.run(timeout=10, grace=1, cmd=["/bin/sh", "-c", "exit 8"]) == 8
+    )
+    out = tmp_path / "probe.out"
+    script = f'(while :; do echo x >> "{out}"; sleep 0.1; done) & sleep 30'
+    rc = watchdog.run(timeout=1.0, grace=1.0, cmd=["/bin/sh", "-c", script])
+    assert rc == watchdog.TIMEOUT_EXIT
+
+
+def test_cli_stall_flags_parse_and_passthrough(tmp_path):
+    """CLI wiring: --stall-secs parses and --progress is REPEATABLE; under the
+    threshold (fresh files) the child's exit passes through."""
+    progress = tmp_path / "trajectory.jsonl"
+    progress.write_text("")
+    report = tmp_path / "report.md"
+    report.write_text("")
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(WATCHDOG_CLI),
+            "--grace",
+            "1",
+            "--stall-secs",
+            "30",
+            "--progress",
+            str(progress),
+            "--progress",
+            str(report),
+            "10",
+            "--",
+            "/bin/sh",
+            "-c",
+            "exit 4",
+        ],
+        check=False,
+    )
+    assert proc.returncode == 4
+
+
+def test_cli_stall_requires_progress():
+    """--stall-secs without any --progress is a usage error (both-or-neither)."""
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(WATCHDOG_CLI),
+            "--stall-secs",
+            "30",
+            "10",
+            "--",
+            "/bin/true",
+        ],
+        capture_output=True,
+        check=False,
+    )
+    assert proc.returncode == watchdog.USAGE_EXIT
 
 
 def test_normal_exit_passes_through_exit_code():


### PR DESCRIPTION
## What

Adds a **no-progress stall watchdog** to `scripts/nightly/watchdog.py`, implementing **H3** of plan `humble-skipping-quilt` (Phase 1, gates unsupervised nights). It shares the H1/H2 poll loop and the `_terminate_group` group-kill path, and closes the **zero-token-wedge boundary** that the H2 token breaker's docstring explicitly hands to this item: a run that parses cleanly but makes no progress is *idle*, not *burning tokens*, so the token breaker (123) never fires — the stall watchdog (122) is its jurisdiction.

## How

**`watchdog.py`**
- `run()` gains `stall_secs` + `progress_files` (both default off). Progress signal = **newest mtime across all `--progress` files** (primary: `trajectory.jsonl`, touched by any agent activity; secondary: the report path). `now - newest_mtime > stall_secs` → shared `_terminate_group` → **exit 122**.
- A file that doesn't exist YET contributes nothing (`FileNotFoundError` skipped). If **no** progress file ever appears, the **watchdog's own start time** is the baseline mtime, so a never-created file still trips at `stall_secs` after launch.
- **Fails open** on any stat error (same swallow discipline as H2's `_token_usage`), pinned by a monkeypatched-`os.stat` test.
- **One monitor, deterministic precedence:** `token (123) > stall (122) > wall (124)` when coincident — the two breaches are tested between wait slices, in that order, before the loop re-tests the wall deadline at the top. Documented in the module docstring (extends the existing token-vs-wall tie-break note).
- CLI: `--stall-secs N` and **repeatable** `--progress FILE`; both-or-neither usage validation.

**`run_nightly.sh`**
- `NIGHTLY_STALL_SECS` default **1200 (20 min)** exported; watchdog armed with `--stall-secs "$NIGHTLY_STALL_SECS" --progress "$RUN_DIR/trajectory.jsonl" --progress "$NIGHTLY_REPORT_PATH"`.
- exit 122 → RED stub `stalled: no progress for Ns (last activity: <basename>, <age>s ago)`, naming which signal went quiet (or "no progress file ever appeared").

## Failing-test-first — red then green

Tests were written first. With the source reverted to the H2 version (H3 tests present):

```
FAILED test_stall_write_then_sleep_group_kills_and_exits_122
FAILED test_stall_continuous_writer_survives_to_its_own_exit
FAILED test_stall_never_created_progress_trips_at_stall_secs
FAILED test_stall_stat_error_fails_open_child_completes
FAILED test_combined_wall_budget_stall_each_trips_independently
FAILED test_cli_stall_flags_parse_and_passthrough
6 failed, 2 passed, 13 deselected
```

With the H3 implementation in place:

```
tests/test_watchdog.py .....................  21 passed
```

(The 2 that pass under the reverted source — `test_no_stall_flag_is_wall_clock_only`, `test_cli_stall_requires_progress` — need no new code by design.)

## Coverage (H3 test list)

- **(a)** write-then-sleep probe → killed at ~stall+grace, **exit 122**, group-death proof (backgrounded grandchild writer freezes).
- **(b)** continuous-writer child survives to its own exit code.
- **(c)** never-created progress file → trips at `stall_secs` from launch (baseline = start time).
- **(d)** stat-error fails open (monkeypatched `os.stat` raises → child completes, no kill).
- **(e)** **combined** wall+budget+stall armed together; three scenarios each trip independently with distinct exits: WALL→124, TOKEN→123, STALL→122.
- **(f)** no-flag path byte-identical (wall-clock-only fast path unchanged).
- CLI: repeatable `--progress` parse + both-or-neither usage error.

## Verification
- `pytest tests/test_watchdog.py` → 21 passed.
- `bash -n` clean; isolated `--dry-run` of `run_nightly.sh` runs clean.
- `black --line-length=79` / `isort --profile=black --line-length=79` clean.
- CLI smoke: `watchdog.py --stall-secs 1 --progress <never> 30 -- sh -c 'sleep 300'` → exit 122.

Plan: `humble-skipping-quilt` H3. Deps H2 (merged, #1229).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BeLcSviHL5vDgS3zTSMbsq