### PR TITLE
[synthesis_loop] Reconcile Costco and Vons receipt arithmetic

### DIFF
--- a/receipt_agent/receipt_agent/agents/label_evaluator/rendering/content_clean.py
+++ b/receipt_agent/receipt_agent/agents/label_evaluator/rendering/content_clean.py
@@ -6,19 +6,20 @@ deterministic, high-frequency ones just before drawing -- it does NOT re-run the
 synthesis pipeline, so it only affects the rendered image (the demo), not the
 stored training labels.
 
-Two repairs, both low-risk and context-gated:
+Repairs are low-risk and context-gated:
 
 * :func:`canonicalize_auth_tokens` -- the EMV / payment-auth block: ``DID:``/``AND:``
   -> ``AID:`` (only before a hex AID), ``WIN`` -> ``PIN`` (only after ``BY``),
   ``Seg#`` -> ``Seq#``, and a stray trailing period on a price.
-* (future) totals reconciliation lives alongside this and is applied by the same
-  :func:`clean_for_render` entry point.
+* :func:`fix_item_amount_ocr` -- amount-shaped OCR confusions are repaired only
+  on rows carrying a product label.
 """
 
 from __future__ import annotations
 
 import re
-from typing import Any, Mapping
+from collections.abc import Mapping
+from typing import Any
 
 from receipt_agent.agents.label_evaluator.rendering.number_format import (
     US as _NF,
@@ -31,6 +32,9 @@ from receipt_agent.agents.label_evaluator.rendering.number_format import (
 )
 from receipt_agent.agents.label_evaluator.rendering.number_format import (
     integer_part as _integer_part,
+)
+from receipt_agent.agents.label_evaluator.rendering.row_bands import (
+    group_rows_quantized,
 )
 
 # A hex Application IDentifier as printed in the EMV block, e.g. A0000000980840.
@@ -47,6 +51,24 @@ _PRICE_TRAILING_DOT = re.compile(
 _AMOUNT_3DEC = re.compile(
     f"^([-+]?{_NF.currency}?{_integer_part(_NF)}){_NF.decimal}(\\d{{3}})"
     f"([-+]?{_NF.tax_flag}?)$"
+)
+
+# Amount-shaped OCR token with a two-digit fractional part. The candidate may
+# contain common digit confusions, but is never repaired without product-row
+# evidence (see ``fix_item_amount_ocr``).
+_ITEM_AMOUNT_OCR = re.compile(
+    r"^([-+]?\$?)([0-9OILSBY]+)([.,])([0-9OILSBY]{2})([A-Z]?)([-+]?)$",
+    re.I,
+)
+_DIGIT_OCR_TRANSLATION = str.maketrans(
+    {
+        "O": "0",
+        "I": "1",
+        "L": "1",
+        "S": "5",
+        "B": "8",
+        "Y": "7",
+    }
 )
 
 # Date / time tokens. A printed transaction line is ``<date> <time> ...`` so the
@@ -140,6 +162,48 @@ def fix_currency_decimals(words: list[dict]) -> int:
     return n
 
 
+def fix_item_amount_ocr(words: list[dict]) -> int:
+    """Repair amount-shaped digit confusions on labeled product rows.
+
+    A product row can contain an unlabeled amount even when its description
+    words carry ``PRODUCT_NAME``. Require that row evidence, a decimal-shaped
+    token, and at least one actual OCR correction (letter substitution or
+    decimal comma) before mutating anything. Product codes and prose therefore
+    remain untouched.
+    """
+    positioned = [word for word in words if word.get("bbox")]
+    rows = group_rows_quantized(
+        positioned,
+        lambda word: float(word["bbox"][1]) + float(word["bbox"][3]),
+        step=16,
+        descending=True,
+    )
+
+    changed = 0
+    for row in rows:
+        has_product = any(
+            "PRODUCT_NAME" in (word.get("labels") or []) for word in row
+        )
+        if not has_product:
+            continue
+        for word in row:
+            text = str(word.get("text") or "").strip()
+            match = _ITEM_AMOUNT_OCR.fullmatch(text)
+            if match is None:
+                continue
+            whole = match.group(2).upper().translate(_DIGIT_OCR_TRANSLATION)
+            fraction = match.group(4).upper().translate(_DIGIT_OCR_TRANSLATION)
+            repaired = (
+                f"{match.group(1)}{whole}.{fraction}"
+                f"{match.group(5)}{match.group(6)}"
+            )
+            if repaired == text:
+                continue
+            word["text"] = repaired
+            changed += 1
+    return changed
+
+
 def canonicalize_dates(words: list[dict]) -> int:
     """Repair garbled transaction-date tokens to the receipt's canonical date.
 
@@ -192,16 +256,18 @@ def fix_items_sold_separator(words: list[dict]) -> int:
 def clean_for_render(receipt: Mapping[str, Any]) -> dict:
     """Apply all render-time content repairs to ``receipt`` (mutates word dicts).
 
-    Returns a small report ``{auth_fixed, totals_fixed, dates_fixed, seps_fixed}``.
+    Returns a small report of repair counts.
     """
     words = list(_iter_word_dicts(receipt))
     auth_fixed = canonicalize_auth_tokens(words)
     totals_fixed = fix_currency_decimals(words)
+    item_amounts_fixed = fix_item_amount_ocr(words)
     dates_fixed = canonicalize_dates(words)
     seps_fixed = fix_items_sold_separator(words)
     return {
         "auth_fixed": auth_fixed,
         "totals_fixed": totals_fixed,
+        "item_amounts_fixed": item_amounts_fixed,
         "dates_fixed": dates_fixed,
         "seps_fixed": seps_fixed,
     }

--- a/receipt_agent/receipt_agent/agents/label_evaluator/rendering/content_clean.py
+++ b/receipt_agent/receipt_agent/agents/label_evaluator/rendering/content_clean.py
@@ -199,6 +199,11 @@ def fix_item_amount_ocr(words: list[dict]) -> int:
             )
             if repaired == text:
                 continue
+            # A local OCR repair must not re-seed the whole page's stochastic
+            # paper texture. Preserve the source token solely for deterministic
+            # texture identity; rendering and evaluation still consume
+            # ``repaired`` below.
+            word.setdefault("_texture_seed_text", text)
             word["text"] = repaired
             changed += 1
     return changed

--- a/receipt_agent/tests/test_content_clean.py
+++ b/receipt_agent/tests/test_content_clean.py
@@ -29,6 +29,7 @@ def test_item_amount_ocr_repair_requires_product_row():
 
     assert fix_item_amount_ocr(words) == 1
     assert words[2]["text"] == "579.99"
+    assert words[2]["_texture_seed_text"] == "5Y9,99"
     assert words[4]["text"] == "5Y9,99"
 
 

--- a/receipt_agent/tests/test_content_clean.py
+++ b/receipt_agent/tests/test_content_clean.py
@@ -1,0 +1,47 @@
+"""Focused tests for context-gated render-time content repair."""
+
+from receipt_agent.agents.label_evaluator.rendering.content_clean import (
+    clean_for_render,
+    fix_item_amount_ocr,
+)
+
+
+def _word(text, line_id, labels=()):
+    y = 900 - line_id * 24
+    return {
+        "text": text,
+        "line_id": line_id,
+        "labels": list(labels),
+        "bbox": [40, y, 160, y + 12],
+    }
+
+
+def test_item_amount_ocr_repair_requires_product_row():
+    split_line_amount = _word("5Y9,99", 99)
+    split_line_amount["bbox"] = _word("MAC", 1)["bbox"]
+    words = [
+        _word("MAC", 1, ["PRODUCT_NAME"]),
+        _word("MINI", 1, ["PRODUCT_NAME"]),
+        split_line_amount,
+        _word("REFERENCE", 2),
+        _word("5Y9,99", 2),
+    ]
+
+    assert fix_item_amount_ocr(words) == 1
+    assert words[2]["text"] == "579.99"
+    assert words[4]["text"] == "5Y9,99"
+
+
+def test_clean_for_render_reports_item_amount_repairs():
+    receipt = {
+        "words": [
+            _word("SANDISK", 7, ["PRODUCT_NAME"]),
+            _word("2TB", 7),
+            _word("2I9,99", 7),
+        ]
+    }
+
+    report = clean_for_render(receipt)
+
+    assert receipt["words"][-1]["text"] == "219.99"
+    assert report["item_amounts_fixed"] == 1

--- a/scripts/render_synthetic_receipts.py
+++ b/scripts/render_synthetic_receipts.py
@@ -1860,7 +1860,7 @@ def _content_texture_seed(receipt: dict) -> int:
         word_id = _coerce_id(word.get("word_id"))
         bbox = word.get("bbox") or []
         bbox_str = ",".join(f"{float(v):.2f}" for v in bbox)
-        text = word.get("text", "")
+        text = word.get("_texture_seed_text", word.get("text", ""))
         parts.append(f"{line_id}:{word_id}:{text}:{bbox_str}")
     return zlib.crc32("\n".join(parts).encode("utf-8"))
 

--- a/scripts/test_render_texture_seed.py
+++ b/scripts/test_render_texture_seed.py
@@ -65,6 +65,17 @@ def test_seed_changes_with_content():
     assert rsr._content_texture_seed(r) != rsr._content_texture_seed(other2)
 
 
+def test_seed_preserves_source_identity_for_local_render_repairs():
+    source = _receipt()
+    repaired = _receipt()
+    repaired["words"][0]["_texture_seed_text"] = "DOUBLE-DOUBLE"
+    repaired["words"][0]["text"] = "DOUBLE DOUBLE"
+
+    assert rsr._content_texture_seed(source) == rsr._content_texture_seed(
+        repaired
+    )
+
+
 def test_seed_handles_empty_and_missing_fields():
     # Must not raise on sparse dicts (barcodes-only / logo-only receipts).
     assert isinstance(rsr._content_texture_seed({}), int)

--- a/synthesis_loop/evidence/costco_v2_arithmetic.after.json
+++ b/synthesis_loop/evidence/costco_v2_arithmetic.after.json
@@ -1,0 +1,58 @@
+{
+  "base_git_sha": "e517d33fdc043abfcbff5f70e87dfd21bccc8952",
+  "bundle_hash": "6b709eb08fa7d09387dba01ebb212810f397b088c8636b7a0442571f8bfd53d7",
+  "controls": {
+    "graphics": "PASS",
+    "logo": "PASS",
+    "style": "PASS_WITH_GAPS"
+  },
+  "image_id": "0324604e-e1f7-4021-b887-7ef7e012c563",
+  "metric": "arithmetic",
+  "receipt_id": 1,
+  "result": {
+    "identities": [
+      {
+        "detail": "3 items",
+        "lhs": 879.97,
+        "name": "sum_lines_eq_subtotal",
+        "rhs": 879.97,
+        "status": "HOLDS"
+      },
+      {
+        "detail": "",
+        "lhs": 957.97,
+        "name": "subtotal_plus_tax_eq_total",
+        "rhs": 957.97,
+        "status": "HOLDS"
+      },
+      {
+        "detail": "",
+        "lhs": 957.97,
+        "name": "total_eq_tender",
+        "rhs": 957.97,
+        "status": "HOLDS"
+      }
+    ],
+    "n_items": 3,
+    "summary": {
+      "change": 0.0,
+      "subtotal": 879.97,
+      "tax": 78.0,
+      "tender": 957.97,
+      "total": 957.97
+    },
+    "testable": 3,
+    "verdict": "PASS",
+    "violated": 0
+  },
+  "truth_version": 2,
+  "verification": {
+    "corpus_regression_gate": "PASS (0 findings)",
+    "focused_tests": "40 passed",
+    "render_regression_guard": {
+      "costco_new": "CHANGED (expected)",
+      "sprouts": "byte-identical",
+      "vons_golden": "byte-identical"
+    }
+  }
+}

--- a/synthesis_loop/evidence/costco_v2_arithmetic.before.json
+++ b/synthesis_loop/evidence/costco_v2_arithmetic.before.json
@@ -1,0 +1,21 @@
+{
+  "base_git_sha": "e517d33fdc043abfcbff5f70e87dfd21bccc8952",
+  "bundle_hash": "6b709eb08fa7d09387dba01ebb212810f397b088c8636b7a0442571f8bfd53d7",
+  "image_id": "0324604e-e1f7-4021-b887-7ef7e012c563",
+  "metric": "arithmetic",
+  "receipt_id": 1,
+  "result": {
+    "n_items": 13,
+    "summary": {
+      "change": 0.0,
+      "subtotal": 879.97,
+      "tax": 78.0,
+      "tender": 181.6,
+      "total": 957.97
+    },
+    "testable": 3,
+    "verdict": "FAIL",
+    "violated": 2
+  },
+  "truth_version": 2
+}

--- a/synthesis_loop/evidence/vons_v1_arithmetic.after.json
+++ b/synthesis_loop/evidence/vons_v1_arithmetic.after.json
@@ -1,0 +1,34 @@
+{
+  "receipt": "678a7c94-4948-4ebf-b8e9-9a17c13051ec#2",
+  "git_sha": "bf55f4d88abe18f87271d93542dd7bd5a68dbfb7",
+  "dirty": false,
+  "truth": {
+    "bundle_hash": "63775db497ae88a596847c2ddea69cfa1271eda40b755c1e2fae87b36da506cb",
+    "expected_bundle_hash": "63775db497ae88a596847c2ddea69cfa1271eda40b755c1e2fae87b36da506cb",
+    "expected_version": 1,
+    "mode": "online-active",
+    "slug": "vons",
+    "version": 1
+  },
+  "metric": {
+    "identities": [
+      {
+        "detail": "",
+        "lhs": 61.13,
+        "name": "total_eq_tender",
+        "rhs": 61.13,
+        "status": "HOLDS"
+      }
+    ],
+    "n_items": 12,
+    "summary": {
+      "change": 0.0,
+      "tax": 0.0,
+      "tender": 61.13,
+      "total": 61.13
+    },
+    "testable": 1,
+    "verdict": "PASS",
+    "violated": 0
+  }
+}

--- a/synthesis_loop/evidence/vons_v1_arithmetic.before.json
+++ b/synthesis_loop/evidence/vons_v1_arithmetic.before.json
@@ -1,0 +1,33 @@
+{
+  "receipt": "678a7c94-4948-4ebf-b8e9-9a17c13051ec#2",
+  "git_sha": "e517d33fdc043abfcbff5f70e87dfd21bccc8952",
+  "truth": {
+    "bundle_hash": "63775db497ae88a596847c2ddea69cfa1271eda40b755c1e2fae87b36da506cb",
+    "expected_bundle_hash": "63775db497ae88a596847c2ddea69cfa1271eda40b755c1e2fae87b36da506cb",
+    "expected_version": 1,
+    "mode": "online-active",
+    "slug": "vons",
+    "version": 1
+  },
+  "metric": {
+    "identities": [
+      {
+        "detail": "",
+        "lhs": 3.5,
+        "name": "total_eq_tender",
+        "rhs": 61.13,
+        "status": "VIOLATED"
+      }
+    ],
+    "n_items": 19,
+    "summary": {
+      "change": 0.0,
+      "tax": 0.0,
+      "tender": 61.13,
+      "total": 3.5
+    },
+    "testable": 1,
+    "verdict": "FAIL",
+    "violated": 1
+  }
+}

--- a/synthesis_loop/full_fidelity_eval.py
+++ b/synthesis_loop/full_fidelity_eval.py
@@ -1966,6 +1966,7 @@ def load_section_sequence(
     """
     try:
         from glyphstudio.sections import is_canonical_section
+
         from receipt_dynamo.data.dynamo_client import DynamoClient
 
         table = os.environ.get("DYNAMODB_TABLE_NAME", "ReceiptsTable-dc5be22")

--- a/synthesis_loop/full_fidelity_eval.py
+++ b/synthesis_loop/full_fidelity_eval.py
@@ -1717,6 +1717,7 @@ def arithmetic_check(words: list[dict]) -> dict:
             if _amount_of(w["text"]) is not None
         ]
         label_of = {lbl for w in row for lbl in (w.get("labels") or [])}
+        discount_row = bool(label_of & _DISCOUNT_LABELS)
         explicit_item = bool(
             label_of & {"LINE_TOTAL", "UNIT_PRICE", "QUANTITY", "PRODUCT_NAME"}
         )
@@ -1730,11 +1731,20 @@ def arithmetic_check(words: list[dict]) -> dict:
             summary.setdefault("change", amounts[-1][1])
         elif _TIP_RE.match(text) and amounts:
             summary.setdefault("tip", amounts[-1][1])
-        elif _TOTAL_RE.match(text) and amounts:
-            summary.setdefault("total", amounts[-1][1])
-            in_item_region = False
         elif _TENDER_RE.match(text) and amounts:
             summary["tender"] = summary.get("tender", 0.0) + amounts[-1][1]
+        elif (
+            ("GRAND_TOTAL" in label_of or _TOTAL_RE.match(text))
+            and amounts
+            and not discount_row
+        ):
+            # Some registers print "**** BALANCE" rather than a textual
+            # TOTAL/BALANCE DUE anchor.  The validated GRAND_TOTAL label is the
+            # stronger signal in that case.  Conversely, a later loyalty block
+            # may contain "Total Savings"; discount labels keep that value from
+            # replacing the actual transaction total.
+            summary.setdefault("total", amounts[-1][1])
+            in_item_region = False
         elif "LINE_TOTAL" in label_of or (
             in_item_region
             and amounts

--- a/synthesis_loop/full_fidelity_eval.py
+++ b/synthesis_loop/full_fidelity_eval.py
@@ -1660,7 +1660,7 @@ _TAX_RE = re.compile(r"^(SALES\s+TAX|SALES$|TAX\b|CA\s+TAX|NV\s+TAX)", re.I)
 _TOTAL_RE = re.compile(r"^\**\s*(TOTAL|BALANCE\s+DUE|AMOUNT\s+DUE)\b", re.I)
 _TENDER_RE = re.compile(
     r"^(AMERICAN|EXPRES|VISA|MASTERCARD|MC\b|DEBIT|CASH\b|EFT|CHARGE\b|"
-    r"US\s+DEBIT|CREDIT\s+CARD)",
+    r"US\s+DEBIT|CREDIT\s+CARD|SHOP\s+CARD|GIFT\s+CARD)",
     re.I,
 )
 _CHANGE_RE = re.compile(r"^CHANGE\b", re.I)
@@ -1705,6 +1705,7 @@ def arithmetic_check(words: list[dict]) -> dict:
     rows = group_visual_rows(px)
     items = []
     summary: dict[str, float] = {}
+    in_item_region = True
     has_discount = any(
         set(w.get("labels") or []) & _DISCOUNT_LABELS for w in words
     )
@@ -1716,21 +1717,29 @@ def arithmetic_check(words: list[dict]) -> dict:
             if _amount_of(w["text"]) is not None
         ]
         label_of = {lbl for w in row for lbl in (w.get("labels") or [])}
+        explicit_item = bool(
+            label_of & {"LINE_TOTAL", "UNIT_PRICE", "QUANTITY", "PRODUCT_NAME"}
+        )
         if _SUBTOTAL_RE.match(text) and amounts:
             summary.setdefault("subtotal", amounts[-1][1])
+            in_item_region = False
         elif _TAX_RE.match(text) and amounts:
             summary.setdefault("tax", amounts[-1][1])
+            in_item_region = False
         elif _CHANGE_RE.match(text) and amounts:
             summary.setdefault("change", amounts[-1][1])
         elif _TIP_RE.match(text) and amounts:
             summary.setdefault("tip", amounts[-1][1])
         elif _TOTAL_RE.match(text) and amounts:
             summary.setdefault("total", amounts[-1][1])
+            in_item_region = False
         elif _TENDER_RE.match(text) and amounts:
-            summary.setdefault("tender", amounts[-1][1])
+            summary["tender"] = summary.get("tender", 0.0) + amounts[-1][1]
         elif "LINE_TOTAL" in label_of or (
-            amounts
+            in_item_region
+            and amounts
             and any(ch.isalpha() for ch in text)
+            and explicit_item
             and not any(
                 rx.match(text)
                 for rx in (

--- a/tests/test_full_fidelity_eval.py
+++ b/tests/test_full_fidelity_eval.py
@@ -471,6 +471,42 @@ def test_arithmetic_ignores_payment_detail_and_sums_split_tenders():
     assert all(i["status"] == "HOLDS" for i in out["identities"])
 
 
+def test_arithmetic_prefers_labeled_balance_over_total_savings():
+    words = []
+
+    def add_row(y, entries):
+        for text, left, labels in entries:
+            words.append(_wordline(text, y, left=left, labels=labels))
+
+    add_row(
+        900,
+        [
+            ("**** BALANCE", 40, []),
+            ("61.13", 800, ["GRAND_TOTAL"]),
+        ],
+    )
+    add_row(
+        860,
+        [
+            ("Visa", 40, ["PAYMENT_METHOD"]),
+            ("61.13", 800, []),
+        ],
+    )
+    add_row(
+        820,
+        [
+            ("Total Savings", 40, ["DISCOUNT"]),
+            ("3.50", 800, ["DISCOUNT"]),
+        ],
+    )
+
+    out = ffe.arithmetic_check(words)
+
+    assert out["verdict"] == "PASS", out
+    assert out["summary"]["total"] == 61.13
+    assert out["summary"]["tender"] == 61.13
+
+
 # ---------------------------------------------------------------------------
 # codex-review hardening (round 1)
 # ---------------------------------------------------------------------------

--- a/tests/test_full_fidelity_eval.py
+++ b/tests/test_full_fidelity_eval.py
@@ -430,6 +430,47 @@ def test_arithmetic_untestable_without_amounts():
     assert out["verdict"] == "UNTESTED"
 
 
+def test_arithmetic_ignores_payment_detail_and_sums_split_tenders():
+    words = []
+
+    def add_row(y, entries):
+        for text, left, labels in entries:
+            words.append(_wordline(text, y, left=left, labels=labels))
+
+    add_row(
+        900,
+        [
+            ("ITEM A", 20, ["PRODUCT_NAME"]),
+            ("10.00", 800, ["LINE_TOTAL"]),
+        ],
+    )
+    add_row(
+        860,
+        [
+            ("ITEM B", 20, ["PRODUCT_NAME"]),
+            ("20.00", 800, ["LINE_TOTAL"]),
+        ],
+    )
+    add_row(820, [("SUBTOTAL", 300, []), ("30.00", 800, ["SUBTOTAL"])])
+    add_row(780, [("TAX", 300, []), ("3.00", 800, ["TAX"])])
+    add_row(740, [("TOTAL", 300, []), ("33.00", 800, ["GRAND_TOTAL"])])
+    add_row(700, [("AMOUNT:", 40, []), ("$11.00", 800, [])])
+    add_row(660, [("REMAINING BALANCE:", 40, []), ("$0.00", 800, [])])
+    add_row(620, [("Shop Card", 40, []), ("11.00", 800, [])])
+    add_row(580, [("AMOUNT:", 40, []), ("$22.00", 800, [])])
+    add_row(540, [("EFT/Debit", 40, ["PAYMENT_METHOD"]), ("22.00", 800, [])])
+    add_row(500, [("CHANGE", 40, []), ("0.00", 800, [])])
+    add_row(460, [("A 9.75% Tax", 40, []), ("3.00", 800, [])])
+    add_row(420, [("TOTAL TAX", 40, []), ("3.00", 800, [])])
+
+    out = ffe.arithmetic_check(words)
+
+    assert out["verdict"] == "PASS", out
+    assert out["n_items"] == 2
+    assert out["summary"]["tender"] == 33.0
+    assert all(i["status"] == "HOLDS" for i in out["identities"])
+
+
 # ---------------------------------------------------------------------------
 # codex-review hardening (round 1)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- repair amount-shaped OCR digit confusions only on visually aligned product rows
- stop item accumulation at receipt summaries so payment/auth detail is not counted as merchandise
- recognize and sum split Shop Card / gift-card tender rows
- prefer validated `GRAND_TOTAL` labels when registers print nonstandard anchors such as `**** BALANCE`
- reject discount-labeled `Total Savings` rows as transaction totals
- preserve the source token for deterministic paper-texture identity
- commit exact red/green evidence for both golden receipts

## Fidelity proof

### Costco Wholesale

Golden: `0324604e-e1f7-4021-b887-7ef7e012c563#1`, OPEN truth v2 bundle `6b709e…`.

- before: FAIL, 13 inferred items, 2 violated identities
- after: PASS, 3 items, 0 violations; `879.97 + 78.00 == 957.97`, split tender `957.97 == total`

### Vons

Golden: `678a7c94-4948-4ebf-b8e9-9a17c13051ec#2`, ACTIVE truth v1 bundle `63775d…`.

- before: FAIL; the judge ignored labeled `**** BALANCE 61.13`, selected later savings `Total 3.50`, then violated `total == tender 61.13`
- after: PASS; labeled total `61.13 == tender 61.13`, 0 violations
- controls: tokens PASS and logo PASS; remaining unrelated Vons reds are unchanged and handled in separate lanes

Evidence is committed under `synthesis_loop/evidence/{costco_v2,vons_v1}_arithmetic.{before,after}.json`.

## Verification

- `tests/test_full_fidelity_eval.py`: 39 passed
- `synthesis_loop/corpus_regression_gate.py check --json`: PASS, zero findings
- prior renderer guard: Vons and Sprouts byte-identical; only pinned Costco v2 changes as expected
- no DynamoDB writes

Draft only; do not merge until the independent review lane completes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved synthetic receipt rendering by correcting common OCR errors in item amounts when product context is available.
  * Preserved texture consistency when repaired text is displayed.
  * Improved arithmetic validation for receipts with discounts, alternate tender types, balances, and grand totals.

* **Tests**
  * Added regression coverage for OCR amount repairs, texture determinism, and expanded arithmetic validation scenarios.

* **Documentation**
  * Updated repair reporting to include item amount corrections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->