### PR TITLE
[receipt_renderer] Preserve Costco payment tail

### DIFF
--- a/receipt_agent/receipt_agent/agents/label_evaluator/rendering/receipt_renderer.py
+++ b/receipt_agent/receipt_agent/agents/label_evaluator/rendering/receipt_renderer.py
@@ -176,7 +176,12 @@ class RenderConfig:
     # are generic / off; a merchant profile supplies its own wording so no merchant
     # phrase is hardcoded in the renderer. (see docs/…-generalization.md, PR-2)
     total_include_tokens: tuple[str, ...] = ("TOTAL",)
-    total_exclude_tokens: tuple[str, ...] = ("SUBTOTAL", "NUMBER")
+    total_exclude_tokens: tuple[str, ...] = (
+        "SUBTOTAL",
+        "NUMBER",
+        "SOLD",
+        "TAX",
+    )
     heading_bleed_phrase: str | None = None
     reverse_date_anchor: str | None = None
     dash_after_amount_date: bool = False
@@ -336,7 +341,7 @@ def render_receipt(
 def _is_final_total(
     row_text: str,
     include: tuple[str, ...] = ("TOTAL",),
-    exclude: tuple[str, ...] = ("SUBTOTAL", "NUMBER"),
+    exclude: tuple[str, ...] = ("SUBTOTAL", "NUMBER", "SOLD", "TAX"),
 ) -> bool:
     """True for the grand-TOTAL row (Costco reverse-videos its amount), but not
     SUBTOTAL nor the "TOTAL NUMBER OF ITEMS SOLD" line. The include/exclude token
@@ -348,6 +353,111 @@ def _is_final_total(
 
 
 _DATE_LED = re.compile(f"^{date_core(US)}$")
+
+
+def _separator_anchor_rows(
+    rows: Sequence[Sequence[GridWord]],
+    row_texts: Sequence[str],
+    config: RenderConfig,
+) -> set[int]:
+    """Rows after which a profile-requested dashed separator is printed.
+
+    A grand-total rule needs both the configured total wording and a currency
+    amount. The amount requirement prevents item-count rows such as
+    ``TOTAL ... ITEMS SOLD = 4`` from becoming separators when OCR fragments
+    the configured exclusion word. ``total_exclude_tokens`` additionally
+    rejects summary lookalikes such as ``TOTAL TAX``.
+    """
+    anchors: set[int] = set()
+    if not (config.dashed_separators or config.dash_around_phrases):
+        return anchors
+    for k, (line, text) in enumerate(zip(rows, row_texts)):
+        previous = row_texts[k - 1] if k > 0 else ""
+        first = text.split()[0] if text.split() else ""
+        is_total_row = (
+            config.dashed_separators
+            and any(is_price_token(word.text) for word in line)
+            and _is_final_total(
+                text,
+                config.total_include_tokens,
+                config.total_exclude_tokens,
+            )
+        )
+        is_amount_date = (
+            config.dashed_separators
+            and config.dash_after_amount_date
+            and "AMOUNT" in previous
+            and bool(_DATE_LED.match(first))
+        )
+        if is_total_row or is_amount_date:
+            anchors.add(k)
+        for phrase in config.dash_around_phrases or ():
+            if text.startswith(phrase.upper()) and any(
+                is_price_token(word.text) for word in line
+            ):
+                anchors.add(k)
+                if k > 0:
+                    anchors.add(k - 1)
+    return anchors
+
+
+def _separator_layout(
+    baselines: Sequence[float],
+    dash_after_rows: set[int],
+    *,
+    pitch: float,
+    cap_h: float,
+) -> tuple[list[float], list[float]]:
+    """Place separator baselines in existing whitespace when possible.
+
+    The old implementation inserted a full body row for every separator and
+    shifted the entire remaining receipt. Multi-tender receipts therefore
+    accumulated hundreds of pixels of drift even though their source layout
+    already reserved generous gaps around tender summaries.
+
+    A thin dash row only needs the whitespace between the current row's
+    descender and the next row's cap. Existing gaps are left untouched. For a
+    genuinely cramped pair, add only the missing clearance rather than a full
+    pitch. This keeps later rows stable while still preventing overprint.
+    """
+    adjusted = [float(value) for value in baselines]
+    dash_ys: list[float] = []
+    if not adjusted or not dash_after_rows:
+        return adjusted, dash_ys
+
+    pitch = max(1.0, float(pitch))
+    cap_h = max(1.0, float(cap_h))
+    # Current descenders consume about .22 cap and the next row consumes one
+    # cap above its baseline. The remaining .18 cap gives the dash ink and a
+    # small paper gap on each side.
+    required_gap = max(pitch, cap_h * 1.40)
+    for k in sorted(dash_after_rows):
+        if k < 0 or k >= len(adjusted):
+            continue
+        current = adjusted[k]
+        if k + 1 >= len(adjusted):
+            dash_ys.append(current + cap_h * 0.90)
+            continue
+
+        gap = adjusted[k + 1] - current
+        extra = max(0.0, required_gap - gap)
+        if extra:
+            for j in range(k + 1, len(adjusted)):
+                adjusted[j] += extra
+            gap += extra
+
+        whitespace_start = current + cap_h * 0.22
+        whitespace_end = adjusted[k + 1] - cap_h
+        if whitespace_end > whitespace_start:
+            ink_target = (whitespace_start + whitespace_end) / 2.0
+        else:
+            ink_target = current + gap / 2.0
+        # ``draw_token_chars`` receives a text baseline. A hyphen's ink sits
+        # around half a cap above that baseline (both the bitmap atlas and the
+        # TTF fallback do this), so lower the draw baseline to put the visible
+        # dash—not its invisible text baseline—in the whitespace target.
+        dash_ys.append(ink_target + cap_h * 0.55)
+    return adjusted, dash_ys
 
 
 def _draw_dash_row(
@@ -596,6 +706,10 @@ def _render_grid(
     # PAYMENT) drop the lane since they carry no price column.
     section_scale = config.section_scale or {}
     section_font = config.section_font or {}
+    # Section assignment is layout geometry, not only draw styling. Resolve it
+    # before baseline floors so a half-height footer also occupies half-height
+    # rows instead of being drawn small on body-sized spacing.
+    eff_sections = effective_row_sections(rows)
     # Normalize headings to (substring, scale) rules.
     raw_head = config.display_headings or ()
     if hasattr(raw_head, "items"):
@@ -630,7 +744,14 @@ def _render_grid(
             and _bleed in _row_texts_pitch[k - 1]
         ):
             hs = items_sold_scale
-        return float(hs) if hs else 1.0
+        if hs:
+            return float(hs)
+        section = eff_sections[k]
+        return (
+            section_style(section_scale.get(section, 1.0))[0]
+            if section
+            else 1.0
+        )
 
     _scales = [_row_scale(k) for k in range(len(rows))]
     per_row_pitch = [
@@ -711,50 +832,17 @@ def _render_grid(
             return text, "left", min(w.left for w in line), target_w
         return None
 
-    eff_sections = effective_row_sections(rows)
     # Rows after which Costco prints a dashed rule (dropped by OCR): the grand
     # TOTAL, and the AMOUNT-block transaction-date line (the date row whose prior
     # row is the "AMOUNT:" line).
     row_texts = [" ".join(w.text for w in ln).upper() for ln in rows]
-    dash_after_rows: set[int] = set()
-    # dash_around_phrases works standalone: a merchant may bracket specific
-    # rows (Target's REC# line) without the Costco-style after-TOTAL rule
-    # that dashed_separators switches on.
-    if config.dashed_separators or config.dash_around_phrases:
-        for k, t in enumerate(row_texts):
-            prevt = row_texts[k - 1] if k > 0 else ""
-            first = t.split()[0] if t.split() else ""
-            is_total_row = config.dashed_separators and _is_final_total(
-                t, config.total_include_tokens, config.total_exclude_tokens
-            )
-            is_amount_date = (
-                config.dashed_separators
-                and config.dash_after_amount_date
-                and "AMOUNT" in prevt
-                and _DATE_LED.match(first)
-            )
-            if is_total_row or is_amount_date:
-                dash_after_rows.add(k)
-            for phrase in config.dash_around_phrases or ():
-                if t.startswith(phrase.upper()) and any(
-                    ch.isdigit() for ch in t
-                ):
-                    dash_after_rows.add(k)
-                    if k > 0:
-                        dash_after_rows.add(k - 1)
-    # The OCR drops the dashed rule, so no blank line exists for it -- reserve one
-    # line below each anchor by pushing the following rows down, and place the rule
-    # in the created gap (else it overprints the next row).
-    dash_ys: list[float] = []
-    if dash_after_rows:
-        pitch = float(min_pitch)
-        adjusted, shift = [], 0.0
-        for k, b in enumerate(baselines):
-            adjusted.append(b + shift)
-            if k in dash_after_rows:
-                dash_ys.append(adjusted[k] + pitch * 0.9)
-                shift += pitch
-        baselines = adjusted
+    dash_after_rows = _separator_anchor_rows(rows, row_texts, config)
+    baselines, dash_ys = _separator_layout(
+        baselines,
+        dash_after_rows,
+        pitch=float(min_pitch),
+        cap_h=cap_h,
+    )
     row_cache: dict[tuple, tuple] = {}
     prev_text = ""
     for line, baseline, sect in zip(rows, baselines, eff_sections):

--- a/receipt_agent/tests/test_section_style.py
+++ b/receipt_agent/tests/test_section_style.py
@@ -1,5 +1,7 @@
 """section_scale schema: legacy float vs {height_scale, condense} mapping."""
 
+import pytest
+
 from receipt_agent.agents.label_evaluator.rendering.receipt_renderer import (
     section_style,
 )
@@ -85,3 +87,119 @@ def test_non_positional_label_beats_date_time_everywhere():
         section_for_labels(["DATE", "PAYMENT_METHOD"], in_header_zone=False)
         == "PAYMENT"
     )
+
+
+def test_section_height_scale_affects_baseline_pitch(monkeypatch):
+    from receipt_agent.agents.label_evaluator.rendering import (
+        receipt_renderer as renderer,
+    )
+
+    captured = {}
+    original = renderer.assign_row_baselines
+
+    def capture(rows, ascent, min_pitch):
+        captured["pitch"] = list(min_pitch)
+        captured["sections"] = renderer.effective_row_sections(rows)
+        return original(rows, ascent, min_pitch)
+
+    monkeypatch.setattr(renderer, "assign_row_baselines", capture)
+    words = [
+        {
+            "text": "ITEM",
+            "bbox": [50, 790, 200, 810],
+            "labels": ["PRODUCT_NAME"],
+        },
+        {
+            "text": "1.00",
+            "bbox": [750, 790, 900, 810],
+            "labels": ["LINE_TOTAL"],
+        },
+        {"text": "RETURN", "bbox": [50, 590, 250, 610], "labels": []},
+        {"text": "POLICY", "bbox": [50, 560, 250, 580], "labels": []},
+        {"text": "DETAILS", "bbox": [50, 530, 250, 550], "labels": []},
+    ]
+    renderer.render_receipt(
+        {"words": words},
+        config=renderer.RenderConfig(
+            width=400,
+            height=600,
+            grid_mode=True,
+            min_font_px=20,
+            max_font_px=20,
+            section_scale={"FOOTER": 0.5},
+        ),
+        coord_max=1000,
+    )
+
+    assert captured["sections"] == ["BODY", "FOOTER", "FOOTER", "FOOTER"]
+    # The transition into FOOTER still clears the preceding body row. Once
+    # both neighboring rows are footer-sized, the geometric floor halves.
+    assert captured["pitch"][1] == captured["pitch"][0]
+    assert captured["pitch"][2] == captured["pitch"][0] * 0.5
+    assert captured["pitch"][3] == captured["pitch"][0] * 0.5
+
+
+def test_separator_anchors_reject_summary_and_item_count_lookalikes():
+    from receipt_agent.agents.label_evaluator.rendering.receipt_grid import (
+        GridWord,
+    )
+    from receipt_agent.agents.label_evaluator.rendering.receipt_renderer import (
+        RenderConfig,
+        _separator_anchor_rows,
+    )
+
+    def row(text, top):
+        words = []
+        left = 10.0
+        for token in text.split():
+            right = left + max(10.0, len(token) * 8.0)
+            words.append(
+                GridWord(
+                    left=left,
+                    top=top,
+                    right=right,
+                    bottom=top + 20.0,
+                    text=token,
+                    ink=(0, 0, 0),
+                )
+            )
+            left = right + 8.0
+        return words
+
+    texts = [
+        "**** TOTAL 957.97",
+        "TOTAL TAX 78.00",
+        "TOTAL NU BE EMS SOLD - 4",
+    ]
+    rows = [row(text, index * 40.0) for index, text in enumerate(texts)]
+    assert _separator_anchor_rows(
+        rows,
+        texts,
+        RenderConfig(dashed_separators=True),
+    ) == {0}
+
+
+def test_separator_layout_uses_existing_gap_and_only_adds_missing_clearance():
+    from receipt_agent.agents.label_evaluator.rendering.receipt_renderer import (
+        _separator_layout,
+    )
+
+    roomy, dash_ys = _separator_layout(
+        [100.0, 180.0, 260.0],
+        {0, 1},
+        pitch=40.0,
+        cap_h=36.0,
+    )
+    assert roomy == [100.0, 180.0, 260.0]
+    assert 100.0 < dash_ys[0] < 180.0
+    assert 180.0 < dash_ys[1] < 260.0
+
+    cramped, _ = _separator_layout(
+        [100.0, 130.0, 180.0],
+        {0},
+        pitch=40.0,
+        cap_h=36.0,
+    )
+    # Required clearance is 50.4px, so add 20.4px—not a full 40px row.
+    assert cramped[1] == pytest.approx(150.4)
+    assert cramped[2] == pytest.approx(200.4)

--- a/synthesis_loop/evidence/costco_v2_tokens.after.json
+++ b/synthesis_loop/evidence/costco_v2_tokens.after.json
@@ -1,0 +1,42 @@
+{
+  "base_git_sha": "e517d33fdc043abfcbff5f70e87dfd21bccc8952",
+  "bundle_hash": "6b709eb08fa7d09387dba01ebb212810f397b088c8636b7a0442571f8bfd53d7",
+  "controls": {
+    "graphics": "PASS",
+    "logo": "PASS",
+    "style": "PASS_WITH_GAPS"
+  },
+  "image_id": "0324604e-e1f7-4021-b887-7ef7e012c563",
+  "legacy_v1_scoreboard_receipt": {
+    "after_ink_recall": 1.0,
+    "before_ink_recall": 0.7232,
+    "verdict": "PASS"
+  },
+  "metric": "tokens",
+  "receipt_id": 1,
+  "result": {
+    "ink_checked": 161,
+    "ink_missing_tokens": [
+      "A",
+      "PIN"
+    ],
+    "ink_recall": 0.9876,
+    "missing_tokens": [
+      "0272472026",
+      "2TB"
+    ],
+    "text_recall": 0.9876,
+    "verdict": "PASS"
+  },
+  "truth_version": 2,
+  "verification": {
+    "corpus_regression_gate": "PASS (0 findings)",
+    "focused_tests": "64 passed",
+    "render_regression_guard": {
+      "costco_golden": "CHANGED (expected)",
+      "costco_new": "CHANGED (expected)",
+      "sprouts": "byte-identical",
+      "vons_golden": "byte-identical"
+    }
+  }
+}

--- a/synthesis_loop/evidence/costco_v2_tokens.before.json
+++ b/synthesis_loop/evidence/costco_v2_tokens.before.json
@@ -1,0 +1,36 @@
+{
+  "base_git_sha": "e517d33fdc043abfcbff5f70e87dfd21bccc8952",
+  "bundle_hash": "6b709eb08fa7d09387dba01ebb212810f397b088c8636b7a0442571f8bfd53d7",
+  "image_id": "0324604e-e1f7-4021-b887-7ef7e012c563",
+  "metric": "tokens",
+  "receipt_id": 1,
+  "result": {
+    "ink_checked": 161,
+    "ink_missing_tokens": [
+      "SEQ#:",
+      "SHOP",
+      "CARD",
+      "RESP:",
+      "APPROVED",
+      "195.40",
+      "SHOP",
+      "CARD",
+      "APP#:",
+      "REMAINING",
+      "BALANCE:",
+      "$0.00",
+      "AID:",
+      "BY",
+      "PIN",
+      "TRAN",
+      "ID#:",
+      "78.00",
+      "78.00",
+      "THE"
+    ],
+    "ink_recall": 0.8758,
+    "text_recall": 0.9938,
+    "verdict": "FAIL"
+  },
+  "truth_version": 2
+}

--- a/synthesis_loop/section_compare.py
+++ b/synthesis_loop/section_compare.py
@@ -219,9 +219,7 @@ def render_pair(merchant: str, image_id: str, receipt_id: int):
         **typ,
     )
     syn = Image.open(tmp).convert("RGB")
-    rendered_words = _render_true_words(
-        words, box_sink, width=wt, height=ht
-    )
+    rendered_words = _render_true_words(words, box_sink, width=wt, height=ht)
     real = None
     for bkt, key in [
         (rec.cdn_s3_bucket, rec.cdn_s3_key),

--- a/synthesis_loop/section_compare.py
+++ b/synthesis_loop/section_compare.py
@@ -18,6 +18,7 @@ AWS_REGION, BITMATRIX_DIR, PORTFOLIO_ENV=dev).
 
 from __future__ import annotations
 
+import math
 import os
 import sys
 from io import BytesIO
@@ -64,6 +65,56 @@ def _font(size: int):
         return ImageFont.truetype(_LABEL_FONT, size)
     except OSError:
         return ImageFont.load_default()
+
+
+def _render_true_words(
+    words: list[dict],
+    box_sink: list[dict],
+    *,
+    width: int,
+    height: int,
+) -> list[dict]:
+    """Return renderer-format words with bboxes from their actual draw plan.
+
+    ``box_sink`` uses absolute output pixels while the fidelity evaluator
+    consumes 0..1000 receipt coordinates with y increasing upward. Words
+    intentionally represented by a graphic (the logo) or a structural draw
+    path (a full asterisk rule) have no sink entry and retain their source box.
+    """
+    placements: dict[int, dict] = {}
+    for placement in box_sink:
+        index = placement.get("word_index")
+        px = placement.get("px")
+        if not isinstance(index, int) or not isinstance(px, (list, tuple)):
+            continue
+        if len(px) < 4:
+            continue
+        try:
+            values = tuple(float(value) for value in px[:4])
+        except (TypeError, ValueError):
+            continue
+        if not all(math.isfinite(value) for value in values):
+            continue
+        placements[index] = dict(placement, px=values)
+
+    rendered = []
+    for index, source in enumerate(words):
+        word = dict(source)
+        word.pop("_box_index", None)
+        placement = placements.get(index)
+        if placement is not None and width > 0 and height > 0:
+            x0, y0, x1, y1 = placement["px"]
+            left, right = sorted((x0, x1))
+            top, bottom = sorted((y0, y1))
+            word["bbox"] = [
+                left / width * 1000.0,
+                (1.0 - top / height) * 1000.0,
+                right / width * 1000.0,
+                (1.0 - bottom / height) * 1000.0,
+            ]
+            word["text"] = str(placement.get("text") or word.get("text") or "")
+        rendered.append(word)
+    return rendered
 
 
 def render_pair(merchant: str, image_id: str, receipt_id: int):
@@ -131,8 +182,9 @@ def render_pair(merchant: str, image_id: str, receipt_id: int):
                 if lbl.get((w.line_id, w.word_id)) not in (None, "O")
                 else []
             ),
+            "_box_index": index,
         }
-        for w in ws
+        for index, w in enumerate(ws)
     ]
     barcodes = []
     if hasattr(c, "list_receipt_barcodes_from_receipt"):
@@ -154,6 +206,7 @@ def render_pair(merchant: str, image_id: str, receipt_id: int):
     wt = 760
     ht = int(round(wt * rec.height / rec.width))
     tmp = f"/tmp/_seccompare_{image_id}_{receipt_id}.png"
+    box_sink: list[dict] = []
     rsr._render_cached_hybrid(
         {"words": words, "barcodes": barcodes, "merchant_name": merchant},
         atlas,
@@ -162,9 +215,13 @@ def render_pair(merchant: str, image_id: str, receipt_id: int):
         height=ht,
         path=tmp,
         section_scale=ss,
+        box_sink=box_sink,
         **typ,
     )
     syn = Image.open(tmp).convert("RGB")
+    rendered_words = _render_true_words(
+        words, box_sink, width=wt, height=ht
+    )
     real = None
     for bkt, key in [
         (rec.cdn_s3_bucket, rec.cdn_s3_key),
@@ -181,7 +238,7 @@ def render_pair(merchant: str, image_id: str, receipt_id: int):
             continue
     if real is not None:
         real = real.resize((wt, ht))
-    return real, syn, len(barcodes), words
+    return real, syn, len(barcodes), rendered_words
 
 
 def stack_section(real, syn, name, y0, y1, pad=14):

--- a/tests/test_full_fidelity_eval.py
+++ b/tests/test_full_fidelity_eval.py
@@ -22,6 +22,7 @@ for _p in (
         sys.path.insert(0, _p)
 
 import full_fidelity_eval as ffe  # noqa: E402
+import section_compare  # noqa: E402
 
 W, H = 400, 300
 
@@ -524,6 +525,41 @@ def test_render_path_call_sites_reference_shared_patterns():
 
     assert rsr._PRICE_TOKEN_RE is SYNTH_PRICE_TOKEN
     assert cdt._PRICE_RE is DOLLARTREE_PRICE_TOKEN
+
+
+def test_render_true_words_convert_box_sink_pixels_to_receipt_coordinates():
+    words = [
+        {
+            "text": "SOURCE",
+            "bbox": [10.0, 900.0, 100.0, 850.0],
+            "labels": ["PRODUCT_NAME"],
+            "_box_index": 0,
+        },
+        {
+            "text": "LOGO",
+            "bbox": [200.0, 950.0, 700.0, 900.0],
+            "labels": ["MERCHANT_NAME"],
+            "_box_index": 1,
+        },
+    ]
+    rendered = section_compare._render_true_words(
+        words,
+        [
+            {
+                "word_index": 0,
+                "text": "DRAWN",
+                "px": (20.0, 100.0, 60.0, 120.0),
+            }
+        ],
+        width=200,
+        height=400,
+    )
+
+    assert rendered[0]["text"] == "DRAWN"
+    assert rendered[0]["bbox"] == [100.0, 750.0, 300.0, 700.0]
+    # Graphic-backed words have no text sink and retain their source geometry.
+    assert rendered[1]["bbox"] == words[1]["bbox"]
+    assert all("_box_index" not in word for word in rendered)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- compute effective section geometry before planning row baselines so scaled sections occupy scaled pitch
- place inferred separator rules into existing whitespace instead of shifting every later row by a full body pitch
- reject `TOTAL TAX` and item-count lookalikes as grand-total separator anchors
- expose renderer `box_sink` placements to the fidelity evaluator so token/column metrics judge actual drawn geometry
- commit exact OPEN-v2 red/green token evidence

This addresses the scale-without-geometry root cause described in #1217 while retaining the independently loaded source manifest.

## Fidelity proof

Golden: Costco Wholesale `0324604e-e1f7-4021-b887-7ef7e012c563`, receipt `1`, truth v2 bundle `6b709e…`.

- tokens before: `FAIL`, ink recall `0.8758`, 20 ink-missing tail tokens
- tokens after: `PASS`, ink recall `0.9876`, only `A` and `PIN` remain clipped below the gate allowance
- legacy scoreboard receipt: ink recall `0.7232 → 1.0000`, `PASS`
- controls: logo `PASS`, graphics `PASS`, style `PASS_WITH_GAPS`
- incidental separator result: `PASS`, measured y delta `0.0033`

Evidence is committed under `synthesis_loop/evidence/costco_v2_tokens.{before,after}.json`.

## Verification

- focused pytest: 64 passed (48-test focused rerun also green)
- `synthesis_loop/corpus_regression_gate.py check --json`: PASS, zero findings
- render regression guard: Vons and Sprouts byte-identical; both pinned Costco renders change as expected
- no DynamoDB writes; evaluated the exact OPEN v2 components through the sealed fixture evaluation path

Draft only; do not merge until the independent review lane completes.