### PR TITLE
[receipt_renderer] Honor measured column lanes

### DIFF
--- a/receipt_agent/receipt_agent/agents/label_evaluator/rendering/receipt_grid.py
+++ b/receipt_agent/receipt_agent/agents/label_evaluator/rendering/receipt_grid.py
@@ -1149,6 +1149,7 @@ def _measured_lane_starts(
 
     amount_x = usable("amount", "right")
     qty_x = usable("qty", "right")
+    flag_x = usable("flag", "left")
     label_x = usable("label", "left")
     desc_x = usable("desc", "left")
     starts: dict[int, float] = {}
@@ -1211,6 +1212,18 @@ def _measured_lane_starts(
         starts[index] = (
             target - spec.grid_left
         ) / spec.cell_w - drawn_cell_count(word.text)
+
+    flag_candidates = [
+        index
+        for index, word in enumerate(line)
+        if index not in starts
+        and index > 0
+        and is_price_token(line[index - 1].text)
+        and len(word.text.strip()) == 1
+        and word.text.strip().isalpha()
+    ]
+    for index, target in assign_unique(flag_candidates, flag_x, edge="left"):
+        starts[index] = (target - spec.grid_left) / spec.cell_w
 
     if label_x and line:
         label_candidates = [
@@ -1417,7 +1430,16 @@ def plan_grid_line(
                                 for column in measured_columns or ()
                             )
                         )
-                        else "left"
+                        else (
+                            "left_flag"
+                            if len(word.text.strip()) == 1
+                            and word.text.strip().isalpha()
+                            and any(
+                                str(column.get("role") or "").lower() == "flag"
+                                for column in measured_columns or ()
+                            )
+                            else "left"
+                        )
                     )
                     if i in measured
                     else ("right_aux" if measured_tax_flag else None)
@@ -1572,12 +1594,31 @@ def draw_grid_line(
     if center_to is None and placed_row and not measured_columns:
         _right_align_source_segments(placed_row, spec)
 
+    has_flag_lane = any(
+        str(column.get("role") or "").lower() == "flag"
+        for column in measured_columns or ()
+    )
+
+    def _measured_ink_shift_px(placed: PlacedToken) -> float:
+        """Translate measured OCR-box anchors onto their visible ink edges."""
+        if placed.measured_anchor in ("right", "right_aux"):
+            # Sections with a detached flag lane expose both bearings: amount
+            # ink ends one cell inside its right-anchored OCR box. Other
+            # measured sections retain the calibrated quarter-cell inset.
+            return (-1.0 if has_flag_lane else -0.25) * spec.cell_w
+        if placed.measured_anchor == "left_flag":
+            # The detached flag's ink starts one cell inside its left-anchored
+            # OCR box, symmetrically preserving the measured amount/flag gap.
+            return spec.cell_w
+        return 0.0
+
     def _record_boxes():
         if box_sink is None:
             return
         cap = float(cap_px or spec.font_px)
         for p in placed_row:
-            x0 = spec.grid_left + p.start_col * spec.cell_w
+            ink_shift = x_shift_px + _measured_ink_shift_px(p)
+            x0 = spec.grid_left + p.start_col * spec.cell_w + ink_shift
             x1 = x0 + p.cells * spec.cell_w
             desc = 0.22 * cap if _has_descender(p.draw_text) else 0.04 * cap
             box_sink.append(
@@ -1602,14 +1643,7 @@ def draw_grid_line(
     _record_boxes()
     for i, placed in enumerate(placed_row):
         ink = placed.word.ink
-        # OCR right-edge lanes include a small printer side bearing.  Keep the
-        # render-true bbox on the measured edge, but inset visible glyph ink by
-        # a quarter cell (and carry an adjacent tax flag with it).
-        measured_right_inset_px = (
-            -0.25 * spec.cell_w
-            if placed.measured_anchor in ("right", "right_aux")
-            else 0.0
-        )
+        measured_ink_shift_px = _measured_ink_shift_px(placed)
         # price -> box extends LEFT into the amount lane; date -> tight box.
         rev_price = reverse_price and placed.is_price
         rev_date = reverse_date and i == 0 and _is_date_token(placed.draw_text)
@@ -1626,14 +1660,14 @@ def draw_grid_line(
                         round(
                             spec.grid_left
                             + (placed.start_col - 0.4) * spec.cell_w
-                            + measured_right_inset_px
+                            + measured_ink_shift_px
                         )
                     )
                     x1 = int(
                         round(
                             spec.grid_left
                             + (placed.end_col + 0.4) * spec.cell_w
-                            + measured_right_inset_px
+                            + measured_ink_shift_px
                         )
                     )
                 else:
@@ -1642,7 +1676,7 @@ def draw_grid_line(
                             spec.grid_left
                             + (placed.start_col - price_box_extend_cells)
                             * spec.cell_w
-                            + measured_right_inset_px
+                            + measured_ink_shift_px
                         )
                     )
                     x1 = int(
@@ -1650,7 +1684,7 @@ def draw_grid_line(
                             spec.grid_left
                             + (placed.end_col + (0 if measured_columns else 1))
                             * spec.cell_w
-                            + measured_right_inset_px
+                            + measured_ink_shift_px
                         )
                     )
                 x0 = max(int(spec.grid_left), x0)
@@ -1671,12 +1705,14 @@ def draw_grid_line(
             bitmap_font=bitmap_font,
             cap_px=cap_px,
             left_edge_col=(
-                placed.start_col if placed.measured_anchor == "left" else None
+                placed.start_col
+                if placed.measured_anchor in ("left", "left_flag")
+                else None
             ),
             right_edge_col=placed.end_col if placed.is_price else None,
             bitmap_thin=bitmap_thin,
             condense_glyphs=condense_glyphs,
-            x_shift_px=x_shift_px + measured_right_inset_px,
+            x_shift_px=x_shift_px + measured_ink_shift_px,
         )
 
 

--- a/receipt_agent/receipt_agent/agents/label_evaluator/rendering/receipt_grid.py
+++ b/receipt_agent/receipt_agent/agents/label_evaluator/rendering/receipt_grid.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 from statistics import median
-from typing import Any, Sequence
+from typing import Any, Mapping, Sequence
 
 from PIL import Image, ImageDraw, ImageFont
 
@@ -206,6 +206,10 @@ class GridWord:
     # labels. Lets the renderer print each section at its own size/font, the way
     # real thermal receipts switch between Font A / Font B per region.
     section: str | None = None
+    # Original word labels, retained for the measured-layout path.  The legacy
+    # planner ignores this field; truth layouts use it to distinguish canonical
+    # sections and roles such as QUANTITY without merchant-specific text rules.
+    labels: tuple[str, ...] = ()
 
     @property
     def center_y(self) -> float:
@@ -241,6 +245,200 @@ SECTION_LABELS: dict[str, frozenset[str]] = {
     ),
     "PAYMENT": frozenset({"PAYMENT_METHOD", "LOYALTY_ID"}),
 }
+
+
+# Canonical section seeds shared by the renderer and the truth layout schema.
+# This is deliberately kept local to the rendering package: receipt-agent can
+# render without the Glyph Studio tooling being installed.  SECTION_* labels
+# take priority; the core-label projection mirrors glyphstudio.sections.
+_CANONICAL_SECTIONS = frozenset(
+    {
+        "storefront",
+        "address",
+        "items",
+        "section_header",
+        "summary",
+        "total_line",
+        "payment",
+        "survey",
+        "footer",
+        "barcode",
+    }
+)
+_CORE_LABEL_SECTION = {
+    "MERCHANT_NAME": "storefront",
+    "STORE_HOURS": "storefront",
+    "ADDRESS_LINE": "address",
+    "PHONE_NUMBER": "address",
+    "PRODUCT_NAME": "items",
+    "QUANTITY": "items",
+    "UNIT_PRICE": "items",
+    "LINE_TOTAL": "items",
+    "SUBTOTAL": "summary",
+    "TAX": "summary",
+    "DISCOUNT": "summary",
+    "COUPON": "summary",
+    "TIP": "summary",
+    "REFUND": "summary",
+    "GRAND_TOTAL": "total_line",
+    "PAYMENT_METHOD": "payment",
+    "CHANGE": "payment",
+    "CASH_BACK": "payment",
+    "LOYALTY_ID": "payment",
+    "WEBSITE": "footer",
+}
+_PAYMENT_MARKERS = (
+    "AMOUNT",
+    "APPROVED",
+    "AUTH",
+    "BALANCE",
+    "CARD",
+    "CHANGE",
+    "CREDIT",
+    "DEBIT",
+    "EFT",
+    "ENTRY",
+    "ISSUER",
+    "PURCHASE",
+    "RESP:",
+    "SEQ#",
+    "SWIPED",
+    "TRAN ID",
+    "VERIFIED BY PIN",
+)
+
+
+def _clean_label(label: Any) -> str:
+    value = str(label or "").upper()
+    return value[2:] if value[:2] in ("B-", "I-") else value
+
+
+def canonical_section_for_labels(
+    labels: Sequence[str] | None,
+) -> str | None:
+    """Canonical truth-layout section seeded by a word's labels."""
+    for raw in labels or ():
+        label = _clean_label(raw)
+        if label.startswith("SECTION_"):
+            section = label[len("SECTION_") :].lower()
+            if section in _CANONICAL_SECTIONS:
+                return section
+    for raw in labels or ():
+        section = _CORE_LABEL_SECTION.get(_clean_label(raw))
+        if section:
+            return section
+    return None
+
+
+def _canonical_row_seed(line: Sequence[GridWord]) -> str | None:
+    """Strongest canonical-section evidence carried by one visual row."""
+    counts: dict[str, int] = {}
+    for word in line:
+        section = canonical_section_for_labels(word.labels)
+        if section:
+            counts[section] = counts.get(section, 0) + 1
+    if counts:
+        return max(counts, key=counts.get)
+
+    text = " ".join(word.text for word in line).upper()
+    compact = re.sub(r"\s+", " ", text).strip()
+    if "SUBTOTAL" in compact or re.search(r"\bTAX\b", compact):
+        return "summary"
+    if "TOTAL NUMBER OF ITEMS" in compact or compact.startswith("TOTAL TAX"):
+        return "summary"
+    if (
+        compact.startswith("TOTAL ")
+        or compact == "TOTAL"
+        or compact.startswith("**** TOTAL")
+    ):
+        return "total_line"
+    if any(marker in compact for marker in _PAYMENT_MARKERS):
+        return "payment"
+    if re.search(r"X{4,}\d{2,4}", compact):
+        return "payment"
+    return None
+
+
+def effective_canonical_row_sections(
+    rows: Sequence[Sequence[GridWord]],
+    layout_template: Mapping[str, Any] | None,
+    paper_height: float,
+) -> list[str | None]:
+    """Resolve each row onto the truth layout's canonical section vocabulary.
+
+    Strong word labels and generic transaction markers win.  Sparse/unlabelled
+    rows fall back to the nearest measured section position, so the renderer can
+    consume a layout template without hard-coding a merchant or receipt shape.
+    """
+    if not isinstance(layout_template, Mapping):
+        return [None] * len(rows)
+
+    sections: list[tuple[str, float]] = []
+    for raw in layout_template.get("sections") or ():
+        if not isinstance(raw, Mapping):
+            continue
+        name = str(raw.get("name") or "").lower()
+        try:
+            pos = float(raw.get("pos_frac_med"))
+        except (TypeError, ValueError):
+            continue
+        if name in _CANONICAL_SECTIONS and 0.0 <= pos <= 1.0:
+            sections.append((name, pos))
+    sections.sort(key=lambda item: item[1])
+
+    result: list[str | None] = []
+    height = max(1.0, float(paper_height))
+    for row in rows:
+        seed = _canonical_row_seed(row)
+        if seed is not None:
+            result.append(seed)
+            continue
+        if not sections or not row:
+            result.append(None)
+            continue
+        y_frac = median(word.center_y for word in row) / height
+        result.append(min(sections, key=lambda item: abs(item[1] - y_frac))[0])
+    return result
+
+
+def layout_columns_by_section(
+    layout_template: Mapping[str, Any] | None,
+    row_sections: Sequence[str | None],
+    rows: Sequence[Sequence[GridWord]],
+) -> dict[str, list[dict]]:
+    """Variant-aware measured columns for the canonical sections in ``rows``."""
+    if not isinstance(layout_template, Mapping):
+        return {}
+
+    sequence: list[str] = []
+    for section in row_sections:
+        if section and (not sequence or sequence[-1] != section):
+            sequence.append(section)
+    words = [word.text for row in rows for word in row]
+    try:
+        from receipt_dynamo.merchant_truth_variants import (
+            normalize_word_set,
+            variant_columns,
+        )
+
+        word_set = normalize_word_set(words)
+        return {
+            section: variant_columns(
+                layout_template,
+                section,
+                section_sequence=sequence,
+                word_set=word_set,
+            )
+            for section in set(sequence)
+        }
+    except ImportError:
+        # receipt-agent normally depends on receipt-dynamo.  Keep direct,
+        # stripped-down renderer use graceful by consuming DEFAULT columns.
+        columns = layout_template.get("columns") or {}
+        return {
+            section: [dict(col) for col in columns.get(section) or ()]
+            for section in set(sequence)
+        }
 
 
 # HEADER labels that are POSITIONAL: a date/time is only header typography
@@ -460,6 +658,7 @@ def draw_token_chars(
     condense: float = 1.0,
     bitmap_font=None,
     cap_px: int | None = None,
+    left_edge_col: float | None = None,
     right_edge_col: float | None = None,
     bitmap_thin: float = 0.0,
     condense_glyphs: bool = False,
@@ -550,6 +749,18 @@ def draw_token_chars(
             img.paste(Image.new("RGB", glyph.size, ink), (x, y), glyph)
 
         col = start_col
+        left_shift = 0.0
+        if left_edge_col is not None:
+            first = next((c for c in text if c != " "), "")
+            if first:
+                first_res = bitmap_font.glyph(first, cap_px or spec.font_px)
+                if first_res is not None:
+                    first_width = first_res[0].width
+                    if condense_glyphs and condense < 0.999:
+                        first_width = max(
+                            1, int(round(first_width * condense))
+                        )
+                    left_shift = -(spec.cell_w - first_width) / 2.0
         right_shift = 0.0
         if right_edge_col is not None:
             last = next((c for c in reversed(text) if c != " "), "")
@@ -579,6 +790,7 @@ def draw_token_chars(
                         spec.grid_left
                         + col * spec.cell_w
                         + (spec.cell_w - gi.width) / 2.0
+                        + left_shift
                         + right_shift
                         + x_shift_px
                     )
@@ -589,7 +801,11 @@ def draw_token_chars(
                 # A data-built atlas may lack a rare glyph (e.g. 'j'/'z'); fall
                 # back to the TTF face so it renders instead of dropping out.
                 # (Chart atlases like Costco's are complete, so this never fires.)
-                _draw_ttf_fallback(char, col, right_shift + x_shift_px)
+                _draw_ttf_fallback(
+                    char,
+                    col,
+                    left_shift + right_shift + x_shift_px,
+                )
             col += 1
         return
     if condense >= 0.999:
@@ -838,6 +1054,9 @@ class PlacedToken:
     # The text actually drawn -- equals the word text unless a long description was
     # truncated (with an ellipsis) to clear the price column. Empty -> use word.text.
     text: str = ""
+    # Measured truth-lane edge carried into glyph drawing so bitmap side
+    # bearings do not turn a straight bbox lane into visible-ink wobble.
+    measured_anchor: str | None = None
 
     @property
     def draw_text(self) -> str:
@@ -896,10 +1115,145 @@ def amount_lane_end(
     return int(round(median(cluster)))
 
 
+def _measured_lane_starts(
+    line: Sequence[GridWord],
+    spec: GridSpec,
+    columns: Sequence[Mapping[str, Any]],
+    paper_width: float,
+) -> dict[int, float]:
+    """Token start columns implied by measured section/role anchors.
+
+    Amount and quantity roles anchor the token's right edge.  Label/description
+    roles anchor only source segment starts, preserving ordinary word flow
+    inside each segment.  Multiple measured lanes are selected by nearest
+    source edge, which naturally handles inline and far-right payment amounts.
+    """
+
+    def usable(role: str, anchor: str) -> list[float]:
+        xs: list[float] = []
+        for column in columns:
+            if str(column.get("role") or "").lower() != role:
+                continue
+            if str(column.get("anchor") or "").lower() != anchor:
+                continue
+            try:
+                x = float(column.get("x"))
+            except (TypeError, ValueError):
+                continue
+            if 0.0 <= x <= 1.0:
+                target = x * float(paper_width)
+                if anchor == "left":
+                    target = max(spec.grid_left, target)
+                xs.append(target)
+        return sorted(xs)
+
+    amount_x = usable("amount", "right")
+    qty_x = usable("qty", "right")
+    label_x = usable("label", "left")
+    desc_x = usable("desc", "left")
+    starts: dict[int, float] = {}
+
+    def assign_unique(
+        candidates: Sequence[int],
+        targets: Sequence[float],
+        *,
+        edge: str,
+    ) -> list[tuple[int, float]]:
+        """Greedy minimum-distance matching with one token per measured lane."""
+        pairs = sorted(
+            (
+                (
+                    abs(
+                        (
+                            line[index].right
+                            if edge == "right"
+                            else line[index].left
+                        )
+                        - target
+                    ),
+                    index,
+                    target,
+                )
+                for index in candidates
+                for target in targets
+            ),
+            key=lambda pair: (pair[0], pair[1], pair[2]),
+        )
+        used_indexes: set[int] = set()
+        used_targets: set[float] = set()
+        assigned: list[tuple[int, float]] = []
+        for _, index, target in pairs:
+            if index in used_indexes or target in used_targets:
+                continue
+            used_indexes.add(index)
+            used_targets.add(target)
+            assigned.append((index, target))
+        return assigned
+
+    for index, word in enumerate(line):
+        if is_price_token(word.text) and amount_x:
+            target = min(amount_x, key=lambda x: abs(x - word.right))
+            starts[index] = (
+                target - spec.grid_left
+            ) / spec.cell_w - drawn_cell_count(word.text)
+
+    qty_candidates = [
+        index
+        for index, word in enumerate(line)
+        if index not in starts
+        and (
+            "QUANTITY" in {_clean_label(label) for label in word.labels}
+            or bool(re.fullmatch(r"\d{1,3}", word.text.strip()))
+        )
+    ]
+    for index, target in assign_unique(qty_candidates, qty_x, edge="right"):
+        word = line[index]
+        starts[index] = (
+            target - spec.grid_left
+        ) / spec.cell_w - drawn_cell_count(word.text)
+
+    if label_x and line:
+        label_candidates = [
+            index
+            for index, word in enumerate(line)
+            if index not in starts
+            and sum(ch.isalpha() for ch in word.text) >= 2
+            and any(
+                abs(word.left - target) <= 2.25 * spec.cell_w
+                for target in label_x
+            )
+        ]
+        for index, target in assign_unique(
+            label_candidates, label_x, edge="left"
+        ):
+            starts[index] = (target - spec.grid_left) / spec.cell_w
+
+    if desc_x and line:
+        segment_starts = [0]
+        for index, (left_word, right_word) in enumerate(
+            zip(line, line[1:]), start=1
+        ):
+            gap_cells = (right_word.left - left_word.right) / max(
+                spec.cell_w, 1.0
+            )
+            if gap_cells > _RIGHT_SEGMENT_GAP_CELLS:
+                segment_starts.append(index)
+        segment_starts = [
+            index for index in segment_starts if index not in starts
+        ]
+        for index, target in assign_unique(
+            segment_starts, desc_x, edge="left"
+        ):
+            starts[index] = (target - spec.grid_left) / spec.cell_w
+    return starts
+
+
 def plan_grid_line(
     line: Sequence[GridWord],
     spec: GridSpec,
     amount_lane: int | None = None,
+    measured_columns: Sequence[Mapping[str, Any]] | None = None,
+    paper_width: float | None = None,
 ) -> list[PlacedToken]:
     """Resolve every word of one visual row to a grid column (no drawing).
 
@@ -929,15 +1283,31 @@ def plan_grid_line(
     cell_of = [drawn_cell_count(w.text) for w in line]
     is_p = [is_price_token(w.text) for w in line]
     price_idxs = [i for i, p in enumerate(is_p) if p]
+    measured = (
+        _measured_lane_starts(
+            line,
+            spec,
+            measured_columns,
+            paper_width,
+        )
+        if measured_columns and paper_width
+        else {}
+    )
 
     # Right-anchored price slots: the rightmost price owns the amount lane; each
     # further-left price (a unit price on a weight/qty line) gets its own slot one
     # cell to the left, so two amounts never overprint into "23.9723.97". Only
     # prices already near the lane are stacked; far-left prices (coupon columns)
     # keep their own column.
-    anchored: dict[int, int] = {}
+    anchored: dict[int, float] = {}
     leftmost_price_start = None
-    if amount_lane is not None and price_idxs:
+    if measured:
+        anchored.update(
+            {index: start for index, start in measured.items() if is_p[index]}
+        )
+        if anchored:
+            leftmost_price_start = min(anchored.values())
+    elif amount_lane is not None and price_idxs:
         slot_right = amount_lane
         for i in reversed(price_idxs):
             abs_end = round((line[i].right - spec.grid_left) / spec.cell_w)
@@ -972,12 +1342,21 @@ def plan_grid_line(
         price = is_p[i]
         cells = cell_of[i]
         text = word.text
+        measured_tax_flag = (
+            i > 0
+            and i - 1 in measured
+            and is_p[i - 1]
+            and len(word.text.strip()) == 1
+            and word.text.strip().isalpha()
+        )
         amount_prefix = (
             not price
             and i + 1 in anchored
             and _is_amount_prefix_token(word.text)
         )
-        if i in anchored:
+        if i in measured:
+            start = measured[i]
+        elif i in anchored:
             start = anchored[i]
         elif amount_prefix:
             # Right-align the prefix ("USD$", "AMOUNT:") to its own source
@@ -988,6 +1367,12 @@ def plan_grid_line(
             absolute = token_start_col(word.text, word.left, word.right, spec)
             if cursor_col is None:
                 start = absolute
+            elif measured_tax_flag:
+                # A measured amount's one-letter tax flag occupies the amount
+                # cell's right bearing on real receipts.  The legacy full-cell
+                # de-glue gap pushes that flag two cells beyond the measured
+                # lane and makes the amount ink scan wobble.
+                start = cursor_col - 0.25
             elif price:
                 # A non-anchored price still must not glue to the prior token.
                 start = max(absolute, cursor_col + 1)
@@ -1009,7 +1394,7 @@ def plan_grid_line(
                 and not amount_prefix
                 and (not price_idxs or i < price_idxs[0])
             ):
-                avail = leftmost_price_start - 1 - start
+                avail = int(leftmost_price_start - 1 - start)
                 if avail <= 0:
                     continue  # no room: drop this token rather than overprint
                 if cells > avail:
@@ -1021,6 +1406,22 @@ def plan_grid_line(
                 cells=cells,
                 is_price=price,
                 text=text,
+                measured_anchor=(
+                    (
+                        "right"
+                        if price
+                        or (
+                            re.fullmatch(r"\d{1,3}", word.text.strip())
+                            and any(
+                                str(column.get("role") or "").lower() == "qty"
+                                for column in measured_columns or ()
+                            )
+                        )
+                        else "left"
+                    )
+                    if i in measured
+                    else ("right_aux" if measured_tax_flag else None)
+                ),
             )
         )
         # Advance past EVERY token so the next word clears it by at least one cell.
@@ -1134,6 +1535,8 @@ def draw_grid_line(
     spec: GridSpec,
     font: ImageFont.FreeTypeFont,
     amount_lane: int | None = None,
+    measured_columns: Sequence[Mapping[str, Any]] | None = None,
+    paper_width: float | None = None,
     stroke: int = 0,
     condense: float = 1.0,
     bitmap_font=None,
@@ -1145,7 +1548,7 @@ def draw_grid_line(
     background: tuple[int, int, int] = (255, 255, 255),
     center_to: float | None = None,
     price_box_extend_cells: int = 4,
-    x_shift_px: int = 0,
+    x_shift_px: float = 0,
     box_sink: list | None = None,
 ) -> None:
     """Draw every word of one visual row at a single shared baseline.
@@ -1159,8 +1562,14 @@ def draw_grid_line(
     span is centered there -- for centered display lines (address, headings, footer)
     whose condensed rendered width is narrower than the source and would drift left.
     """
-    placed_row = plan_grid_line(line, spec, amount_lane=amount_lane)
-    if center_to is None and placed_row:
+    placed_row = plan_grid_line(
+        line,
+        spec,
+        amount_lane=amount_lane,
+        measured_columns=measured_columns,
+        paper_width=paper_width,
+    )
+    if center_to is None and placed_row and not measured_columns:
         _right_align_source_segments(placed_row, spec)
 
     def _record_boxes():
@@ -1193,6 +1602,14 @@ def draw_grid_line(
     _record_boxes()
     for i, placed in enumerate(placed_row):
         ink = placed.word.ink
+        # OCR right-edge lanes include a small printer side bearing.  Keep the
+        # render-true bbox on the measured edge, but inset visible glyph ink by
+        # a quarter cell (and carry an adjacent tax flag with it).
+        measured_right_inset_px = (
+            -0.25 * spec.cell_w
+            if placed.measured_anchor in ("right", "right_aux")
+            else 0.0
+        )
         # price -> box extends LEFT into the amount lane; date -> tight box.
         rev_price = reverse_price and placed.is_price
         rev_date = reverse_date and i == 0 and _is_date_token(placed.draw_text)
@@ -1209,12 +1626,14 @@ def draw_grid_line(
                         round(
                             spec.grid_left
                             + (placed.start_col - 0.4) * spec.cell_w
+                            + measured_right_inset_px
                         )
                     )
                     x1 = int(
                         round(
                             spec.grid_left
                             + (placed.end_col + 0.4) * spec.cell_w
+                            + measured_right_inset_px
                         )
                     )
                 else:
@@ -1223,11 +1642,15 @@ def draw_grid_line(
                             spec.grid_left
                             + (placed.start_col - price_box_extend_cells)
                             * spec.cell_w
+                            + measured_right_inset_px
                         )
                     )
                     x1 = int(
                         round(
-                            spec.grid_left + (placed.end_col + 1) * spec.cell_w
+                            spec.grid_left
+                            + (placed.end_col + (0 if measured_columns else 1))
+                            * spec.cell_w
+                            + measured_right_inset_px
                         )
                     )
                 x0 = max(int(spec.grid_left), x0)
@@ -1247,10 +1670,13 @@ def draw_grid_line(
             condense=condense,
             bitmap_font=bitmap_font,
             cap_px=cap_px,
+            left_edge_col=(
+                placed.start_col if placed.measured_anchor == "left" else None
+            ),
             right_edge_col=placed.end_col if placed.is_price else None,
             bitmap_thin=bitmap_thin,
             condense_glyphs=condense_glyphs,
-            x_shift_px=x_shift_px,
+            x_shift_px=x_shift_px + measured_right_inset_px,
         )
 
 

--- a/receipt_agent/receipt_agent/agents/label_evaluator/rendering/receipt_renderer.py
+++ b/receipt_agent/receipt_agent/agents/label_evaluator/rendering/receipt_renderer.py
@@ -53,6 +53,7 @@ from receipt_agent.agents.label_evaluator.rendering.receipt_grid import (
     group_words_into_grid_lines,
     is_price_token,
     layout_columns_by_section,
+    line_baseline,
     section_for_labels,
 )
 from receipt_agent.agents.label_evaluator.rendering.receipt_stylemap import (

--- a/receipt_agent/receipt_agent/agents/label_evaluator/rendering/receipt_renderer.py
+++ b/receipt_agent/receipt_agent/agents/label_evaluator/rendering/receipt_renderer.py
@@ -47,10 +47,12 @@ from receipt_agent.agents.label_evaluator.rendering.receipt_grid import (
     draw_text_run,
     draw_token_chars,
     drawn_cell_count,
+    effective_canonical_row_sections,
     effective_row_sections,
     glyph_advance,
     group_words_into_grid_lines,
     is_price_token,
+    layout_columns_by_section,
     section_for_labels,
 )
 from receipt_agent.agents.label_evaluator.rendering.receipt_stylemap import (
@@ -123,6 +125,10 @@ class RenderConfig:
     # hard (non-anti-aliased) glyphs on a shared baseline. When False the legacy
     # per-token box-fitting path is used (see ``render_receipt``).
     grid_mode: bool = False
+    # Optional Merchant Truth C#layout template.  When present, grid rows are
+    # routed through canonical sections and role lanes; None leaves the legacy
+    # planner and rendered bytes unchanged.
+    layout_template: Mapping[str, Any] | None = None
     # Per-section typography (real thermal receipts switch Font A / Font B per
     # region). A ``section_scale`` entry is either a bare float that multiplies
     # the body font size (e.g. {"HEADER": 0.8}) or a mapping
@@ -666,6 +672,7 @@ def _render_grid(
                 section=section_for_labels(
                     word.get("labels"), in_header_zone=in_header_zone
                 ),
+                labels=tuple(word.get("labels") or ()),
             )
         )
     # Bitmap (glyph-atlas) font: the merchant's actual letterforms. cap_px is the
@@ -745,6 +752,12 @@ def _render_grid(
 
     rows = group_words_into_grid_lines(grid_words, spec.cell_h)
     amount_lane = amount_lane_end(rows, spec)
+    canonical_sections = effective_canonical_row_sections(
+        rows, config.layout_template, config.height
+    )
+    measured_columns = layout_columns_by_section(
+        config.layout_template, canonical_sections, rows
+    )
 
     # Per-section typography: a row whose section has a scale != 1.0 or a font
     # override is drawn with its own (cached) spec/font. BODY/TOTALS stay at the
@@ -891,7 +904,10 @@ def _render_grid(
     )
     row_cache: dict[tuple, tuple] = {}
     prev_text = ""
-    for line, baseline, sect in zip(rows, baselines, eff_sections):
+    for line, baseline, sect, canonical_section in zip(
+        rows, baselines, eff_sections, canonical_sections
+    ):
+        row_columns = measured_columns.get(canonical_section or "") or None
         row_text = " ".join(w.text for w in line).upper()
         # A display heading (e.g. SELF-CHECKOUT, THANK YOU, ITEMS SOLD:) renders
         # heavy + enlarged; the heavy face is NOT applied to the whole TOTALS zone
@@ -921,7 +937,7 @@ def _render_grid(
             and config.reverse_date_anchor in prev_text
         )
         prev_text = row_text
-        center_to = _center_target(line)
+        center_to = None if row_columns else _center_target(line)
         fpath = section_font.get(sect) if sect else None
         # A row's section condense applies whether or not the row is an
         # enlarged display heading -- the heading scale overrides HEIGHT
@@ -981,7 +997,7 @@ def _render_grid(
             sm_style and (sm_style["bold"] or sm_style["underline"])
         )
         if sc == 1.0 and sect_cond == 1.0 and not fpath and not sm_extra:
-            run = _run_layout(line, center_to)
+            run = None if row_columns else _run_layout(line, center_to)
             if run is not None:
                 text, anchor, x, target_w = run
                 draw_text_run(
@@ -1011,6 +1027,8 @@ def _render_grid(
                 spec,
                 font,
                 amount_lane=amount_lane,
+                measured_columns=row_columns,
+                paper_width=config.width,
                 stroke=config.stroke,
                 condense=config.condense,
                 condense_glyphs=config.condense_glyphs,
@@ -1081,7 +1099,7 @@ def _render_grid(
         strike_offsets = (
             (0, 1, 2) if reinforce_bold else ((0, 1) if sm_bold else (0,))
         )
-        run = _run_layout(line, center_to)
+        run = None if row_columns else _run_layout(line, center_to)
         if run is not None:
             text, anchor, x, target_w = run
             for dx in strike_offsets:
@@ -1113,6 +1131,8 @@ def _render_grid(
                     row_spec,
                     row_font,
                     amount_lane=lane,
+                    measured_columns=row_columns,
+                    paper_width=config.width,
                     stroke=config.stroke,
                     condense=eff_cond,
                     condense_glyphs=config.condense_glyphs,

--- a/receipt_agent/tests/test_measured_layout.py
+++ b/receipt_agent/tests/test_measured_layout.py
@@ -1,10 +1,16 @@
 """Measured Merchant Truth column routing and grid placement."""
 
-import pytest
+from dataclasses import replace
+from pathlib import Path
 
+import pytest
+from PIL import Image, ImageDraw, ImageFont
+
+from receipt_agent.agents.label_evaluator.rendering import receipt_grid
 from receipt_agent.agents.label_evaluator.rendering.receipt_grid import (
     GridSpec,
     GridWord,
+    draw_grid_line,
     effective_canonical_row_sections,
     plan_grid_line,
 )
@@ -94,6 +100,83 @@ def test_measured_description_and_quantity_roles_use_their_declared_edges():
     # drawable grid; the quantity retains its measured right edge.
     assert 10 + by_text["ITEM"].start_col * 10 == pytest.approx(10)
     assert 10 + by_text["3"].end_col * 10 == pytest.approx(0.8852 * 760)
+
+
+def test_measured_flag_lane_anchors_detached_flag_to_declared_left_edge():
+    spec = GridSpec(cell_w=10.0, cell_h=20.0, font_px=16, grid_left=10.0)
+    line = [_word("4.29", 565, 615), _word("F", 620, 650)]
+    columns = [
+        {"role": "amount", "anchor": "right", "x": 0.8085},
+        {"role": "flag", "anchor": "left", "x": 0.8187},
+    ]
+
+    placed = plan_grid_line(
+        line,
+        spec,
+        measured_columns=columns,
+        paper_width=760,
+    )
+    by_text = {token.word.text: token for token in placed}
+
+    assert 10 + by_text["4.29"].end_col * 10 == pytest.approx(0.8085 * 760)
+    assert 10 + by_text["F"].start_col * 10 == pytest.approx(0.8187 * 760)
+    assert by_text["F"].measured_anchor == "left_flag"
+
+
+def test_flag_lane_bearings_are_reflected_in_render_true_boxes():
+    spec = GridSpec(cell_w=10.0, cell_h=20.0, font_px=16, grid_left=10.0)
+    line = [
+        replace(_word("4.29", 565, 615), word_index=0),
+        replace(_word("F", 620, 650), word_index=1),
+    ]
+    columns = [
+        {"role": "amount", "anchor": "right", "x": 0.8085},
+        {"role": "flag", "anchor": "left", "x": 0.8187},
+    ]
+    font_path = (
+        Path(receipt_grid.__file__).parent / "fonts" / "B612Mono-Regular.ttf"
+    )
+    image = Image.new("RGB", (760, 180), "white")
+    sink = []
+
+    draw_grid_line(
+        ImageDraw.Draw(image),
+        line,
+        100,
+        spec,
+        ImageFont.truetype(str(font_path), 16),
+        measured_columns=columns,
+        paper_width=760,
+        box_sink=sink,
+    )
+    by_index = {placement["word_index"]: placement for placement in sink}
+
+    assert by_index[0]["px"][2] == pytest.approx(0.8085 * 760 - spec.cell_w)
+    assert by_index[1]["px"][0] == pytest.approx(0.8187 * 760 + spec.cell_w)
+
+
+def test_amount_only_lane_keeps_quarter_cell_bearing():
+    spec = GridSpec(cell_w=10.0, cell_h=20.0, font_px=16, grid_left=10.0)
+    line = [replace(_word("116.99", 650, 710), word_index=0)]
+    columns = [{"role": "amount", "anchor": "right", "x": 0.9399}]
+    font_path = (
+        Path(receipt_grid.__file__).parent / "fonts" / "B612Mono-Regular.ttf"
+    )
+    image = Image.new("RGB", (760, 180), "white")
+    sink = []
+
+    draw_grid_line(
+        ImageDraw.Draw(image),
+        line,
+        100,
+        spec,
+        ImageFont.truetype(str(font_path), 16),
+        measured_columns=columns,
+        paper_width=760,
+        box_sink=sink,
+    )
+
+    assert sink[0]["px"][2] == pytest.approx(0.9399 * 760 - 0.25 * spec.cell_w)
 
 
 def test_canonical_sections_use_labels_then_generic_payment_markers():

--- a/receipt_agent/tests/test_measured_layout.py
+++ b/receipt_agent/tests/test_measured_layout.py
@@ -1,0 +1,126 @@
+"""Measured Merchant Truth column routing and grid placement."""
+
+import pytest
+
+from receipt_agent.agents.label_evaluator.rendering.receipt_grid import (
+    GridSpec,
+    GridWord,
+    effective_canonical_row_sections,
+    plan_grid_line,
+)
+
+INK = (0, 0, 0)
+
+
+def _word(text, left, right, *, top=100, labels=()):
+    return GridWord(
+        left=float(left),
+        top=float(top),
+        right=float(right),
+        bottom=float(top + 16),
+        text=text,
+        ink=INK,
+        labels=tuple(labels),
+    )
+
+
+def test_no_layout_columns_preserve_the_legacy_plan():
+    spec = GridSpec(cell_w=10.0, cell_h=20.0, font_px=16, grid_left=10.0)
+    line = [_word("ITEM", 20, 70), _word("12.99", 660, 710)]
+
+    legacy = plan_grid_line(line, spec, amount_lane=70)
+    absent = plan_grid_line(
+        line,
+        spec,
+        amount_lane=70,
+        measured_columns=None,
+        paper_width=760,
+    )
+
+    assert [
+        (token.start_col, token.cells, token.draw_text) for token in absent
+    ] == [(token.start_col, token.cells, token.draw_text) for token in legacy]
+
+
+def test_measured_payment_lanes_anchor_labels_and_both_amount_edges():
+    spec = GridSpec(cell_w=10.0, cell_h=20.0, font_px=16, grid_left=10.0)
+    line = [
+        _word("AMOUNT:", 165, 225),
+        _word("$181.60", 230, 305),
+        _word("116.99", 650, 710),
+    ]
+    columns = [
+        {"role": "label", "anchor": "left", "x": 0.2228},
+        {"role": "amount", "anchor": "right", "x": 0.3875},
+        {"role": "amount", "anchor": "right", "x": 0.9399},
+    ]
+
+    placed = plan_grid_line(
+        line,
+        spec,
+        amount_lane=70,
+        measured_columns=columns,
+        paper_width=760,
+    )
+    by_text = {token.word.text: token for token in placed}
+
+    assert 10 + by_text["AMOUNT:"].start_col * 10 == pytest.approx(
+        0.2228 * 760
+    )
+    assert 10 + by_text["$181.60"].end_col * 10 == pytest.approx(0.3875 * 760)
+    assert 10 + by_text["116.99"].end_col * 10 == pytest.approx(0.9399 * 760)
+
+
+def test_measured_description_and_quantity_roles_use_their_declared_edges():
+    spec = GridSpec(cell_w=10.0, cell_h=20.0, font_px=16, grid_left=10.0)
+    line = [
+        _word("ITEM", 35, 85),
+        _word("3", 640, 650, labels=("QUANTITY",)),
+    ]
+    columns = [
+        {"role": "desc", "anchor": "left", "x": 0.0125},
+        {"role": "qty", "anchor": "right", "x": 0.8852},
+    ]
+
+    placed = plan_grid_line(
+        line,
+        spec,
+        measured_columns=columns,
+        paper_width=760,
+    )
+    by_text = {token.word.text: token for token in placed}
+
+    # The paper margin clamps a measured edge that falls just outside the
+    # drawable grid; the quantity retains its measured right edge.
+    assert 10 + by_text["ITEM"].start_col * 10 == pytest.approx(10)
+    assert 10 + by_text["3"].end_col * 10 == pytest.approx(0.8852 * 760)
+
+
+def test_canonical_sections_use_labels_then_generic_payment_markers():
+    rows = [
+        [_word("COSTCO", 250, 360, top=40, labels=("MERCHANT_NAME",))],
+        [_word("ITEM", 20, 80, top=220, labels=("PRODUCT_NAME",))],
+        [_word("SUBTOTAL", 20, 100, top=340, labels=("SUBTOTAL",))],
+        [_word("TOTAL", 60, 120, top=390)],
+        [_word("APPROVED", 20, 100, top=450)],
+        [_word("THANK", 260, 310, top=820)],
+    ]
+    template = {
+        "sections": [
+            {"name": "storefront", "pos_frac_med": 0.04},
+            {"name": "items", "pos_frac_med": 0.30},
+            {"name": "summary", "pos_frac_med": 0.35},
+            {"name": "total_line", "pos_frac_med": 0.39},
+            {"name": "payment", "pos_frac_med": 0.43},
+            {"name": "footer", "pos_frac_med": 0.81},
+        ]
+    }
+
+    assert effective_canonical_row_sections(rows, template, 1000) == [
+        "storefront",
+        "items",
+        "summary",
+        "total_line",
+        "payment",
+        "footer",
+    ]

--- a/scripts/render_synthetic_receipts.py
+++ b/scripts/render_synthetic_receipts.py
@@ -1891,6 +1891,18 @@ def _content_texture_seed(receipt: dict) -> int:
     return zlib.crc32("\n".join(parts).encode("utf-8"))
 
 
+def _measured_layout_template(
+    merchant_profile: dict,
+    *,
+    compose_kind: str | None,
+) -> dict | None:
+    """Keep source-measured geometry out of canonical composed layouts."""
+    layout_template = merchant_profile.get("layout_template")
+    if not isinstance(layout_template, dict) or compose_kind:
+        return None
+    return copy.deepcopy(layout_template)
+
+
 def _render_cached_hybrid(
     receipt: dict,
     atlas,
@@ -1933,9 +1945,8 @@ def _render_cached_hybrid(
     # photo) and route the words through a composer BEFORE any layout. This
     # is the production hook -- glyph_review, section_compare and normal
     # renders all pass through here, so the composed layout IS the render.
-    compose_kind = get_merchant_profile(receipt.get("merchant_name")).get(
-        "compose"
-    )
+    merchant_profile = get_merchant_profile(receipt.get("merchant_name"))
+    compose_kind = merchant_profile.get("compose")
     if compose_kind == "dollartree":
         synth_dir = os.path.join(REPO_ROOT, "synthesis_loop")
         if synth_dir not in sys.path:
@@ -2007,9 +2018,14 @@ def _render_cached_hybrid(
         max_font_px=max(28, int(height / 45)),
         grid_mode=True,
         # C#layout is selected alongside the rest of this merchant's verified
-        # truth profile.  The renderer consumes it section-by-section; absence
+        # truth profile. The renderer consumes it section-by-section; absence
         # remains a strict no-op for merchants without measured geometry.
-        layout_template=copy.deepcopy(merchant_profile.get("layout_template")),
+        # Canonical composers already own their output geometry and therefore
+        # do not reapply lanes measured from the source photos.
+        layout_template=_measured_layout_template(
+            merchant_profile,
+            compose_kind=compose_kind,
+        ),
         # Optional body-font override. None -> the grid-font candidate list
         # (Andale -> vendored B612 -> legacy). The grid recalibrates cell_w / row
         # pitch from whatever face loads, so the SAME layout renders in any font.

--- a/scripts/render_synthetic_receipts.py
+++ b/scripts/render_synthetic_receipts.py
@@ -2006,6 +2006,10 @@ def _render_cached_hybrid(
         min_font_px=9,
         max_font_px=max(28, int(height / 45)),
         grid_mode=True,
+        # C#layout is selected alongside the rest of this merchant's verified
+        # truth profile.  The renderer consumes it section-by-section; absence
+        # remains a strict no-op for merchants without measured geometry.
+        layout_template=copy.deepcopy(merchant_profile.get("layout_template")),
         # Optional body-font override. None -> the grid-font candidate list
         # (Andale -> vendored B612 -> legacy). The grid recalibrates cell_w / row
         # pitch from whatever face loads, so the SAME layout renders in any font.

--- a/synthesis_loop/evidence/costco_v2_columns.after.json
+++ b/synthesis_loop/evidence/costco_v2_columns.after.json
@@ -1,0 +1,50 @@
+{
+  "base_git_sha": "e517d33fdc043abfcbff5f70e87dfd21bccc8952",
+  "bundle_hash": "6b709eb08fa7d09387dba01ebb212810f397b088c8636b7a0442571f8bfd53d7",
+  "controls": {
+    "graphics": "PASS",
+    "logo": "PASS",
+    "separators": "PASS",
+    "style": "PASS_WITH_GAPS",
+    "tokens": "PASS"
+  },
+  "image_id": "0324604e-e1f7-4021-b887-7ef7e012c563",
+  "metric": "columns",
+  "receipt_id": 1,
+  "result": {
+    "failed_on": [],
+    "limits": {
+      "abs_drift_px": 26.8,
+      "outlier_frac": 0.4,
+      "shear_px_per_100px": 6.0,
+      "wobble_iqr_px": 3.86
+    },
+    "real": {
+      "lane_x_px": 685.19,
+      "n_rows": 8,
+      "outlier_frac": 0.25,
+      "wobble_iqr_px": 0.68
+    },
+    "source": "bootstrap",
+    "synth": {
+      "abs_drift_px": 23.5,
+      "lane_x_px": 708.57,
+      "n_rows": 12,
+      "outlier_frac": 0.083,
+      "shear_px_per_100px": 3.0,
+      "wobble_iqr_px": 3.28
+    },
+    "verdict": "PASS"
+  },
+  "truth_version": 2,
+  "verification": {
+    "corpus_regression_gate": "PASS (0 findings)",
+    "focused_tests": "98 passed",
+    "render_regression_guard": {
+      "costco_golden": "CHANGED (expected)",
+      "costco_new": "CHANGED (expected)",
+      "sprouts": "byte-identical",
+      "vons_golden": "byte-identical"
+    }
+  }
+}

--- a/synthesis_loop/evidence/costco_v2_columns.before.json
+++ b/synthesis_loop/evidence/costco_v2_columns.before.json
@@ -1,0 +1,37 @@
+{
+  "base_git_sha": "e517d33fdc043abfcbff5f70e87dfd21bccc8952",
+  "bundle_hash": "6b709eb08fa7d09387dba01ebb212810f397b088c8636b7a0442571f8bfd53d7",
+  "image_id": "0324604e-e1f7-4021-b887-7ef7e012c563",
+  "metric": "columns",
+  "receipt_id": 1,
+  "result": {
+    "failed_on": [
+      "wobble",
+      "outliers",
+      "shear"
+    ],
+    "limits": {
+      "abs_drift_px": 26.8,
+      "outlier_frac": 0.4,
+      "shear_px_per_100px": 6.0,
+      "wobble_iqr_px": 3.86
+    },
+    "real": {
+      "lane_x_px": 685.19,
+      "n_rows": 8,
+      "outlier_frac": 0.25,
+      "wobble_iqr_px": 0.68
+    },
+    "source": "bootstrap",
+    "synth": {
+      "abs_drift_px": 25.0,
+      "lane_x_px": 703.16,
+      "n_rows": 6,
+      "outlier_frac": 0.5,
+      "shear_px_per_100px": 10.33,
+      "wobble_iqr_px": 10.71
+    },
+    "verdict": "FAIL"
+  },
+  "truth_version": 2
+}

--- a/synthesis_loop/evidence/dollar_tree_column_blast_radius.after.json
+++ b/synthesis_loop/evidence/dollar_tree_column_blast_radius.after.json
@@ -1,0 +1,23 @@
+{
+  "git_sha": "2089caf4b0433756791c059289431e96b64fcf10",
+  "merchant": "Dollar Tree",
+  "merchant_truth": {
+    "bundle_hash": "d6bd3769a14349e2449e55a607ecc49eba57598c9cb5ace310f1b80ef0261d0b",
+    "mode": "fixture",
+    "note": "No ACTIVE Dollar Tree truth exists in dev; this is a hash-verified dry v1 fixture built from the legacy profile.",
+    "slug": "dollar_tree",
+    "version": 1
+  },
+  "metric": "columns",
+  "receipt": "0944ee8d-4a0d-464e-8109-de35a9ba379a#1",
+  "regression_verdict": "PASS",
+  "result": {
+    "abs_drift_px": 53.5,
+    "known_baseline_gap": "Source photos are sheared; the canonical composer intentionally owns render geometry.",
+    "shear_px_per_100px": 35.48,
+    "verdict": "FAIL",
+    "wobble_iqr_px": 15.9
+  },
+  "synthetic_sha256": "085236d9ade0668301827a136cfaae617409bce9402142a77a17e90b54f13e85",
+  "unchanged_from_parent": true
+}

--- a/synthesis_loop/evidence/dollar_tree_column_blast_radius.before.json
+++ b/synthesis_loop/evidence/dollar_tree_column_blast_radius.before.json
@@ -1,0 +1,28 @@
+{
+  "baseline": {
+    "abs_drift_px": 53.5,
+    "git_sha": "b1be770d0d23b7901f18277d232231842b509676",
+    "shear_px_per_100px": 35.48,
+    "synthetic_sha256": "085236d9ade0668301827a136cfaae617409bce9402142a77a17e90b54f13e85",
+    "verdict": "FAIL",
+    "wobble_iqr_px": 15.9
+  },
+  "captured_regression": {
+    "abs_drift_px": 48.5,
+    "git_sha": "cdfd224a6fcf1349c6f517156d1dbfeb384c4ee9",
+    "shear_px_per_100px": 66.55,
+    "synthetic_sha256": "17f1c8cb09cf2ead9cc8b023fa67c52757291c5c23c28c329877cc5f8eeb8ed7",
+    "verdict": "FAIL",
+    "wobble_iqr_px": 18.95
+  },
+  "merchant": "Dollar Tree",
+  "merchant_truth": {
+    "bundle_hash": "d6bd3769a14349e2449e55a607ecc49eba57598c9cb5ace310f1b80ef0261d0b",
+    "mode": "fixture",
+    "note": "No ACTIVE Dollar Tree truth exists in dev; this is a hash-verified dry v1 fixture built from the legacy profile.",
+    "slug": "dollar_tree",
+    "version": 1
+  },
+  "metric": "columns",
+  "receipt": "0944ee8d-4a0d-464e-8109-de35a9ba379a#1"
+}

--- a/synthesis_loop/evidence/gelsons_column_blast_radius.after.json
+++ b/synthesis_loop/evidence/gelsons_column_blast_radius.after.json
@@ -1,0 +1,29 @@
+{
+  "git_sha": "2089caf4b0433756791c059289431e96b64fcf10",
+  "merchant": "Gelson's Westlake Village",
+  "merchant_truth": {
+    "bundle_hash": "9486f47c16ee3cc2e38dbe505b1feef6692cc1633d74d1ceafd7e3a423e48c09",
+    "mode": "online-active",
+    "slug": "gelson_s_westlake_village",
+    "version": 1
+  },
+  "metric": "columns",
+  "receipt": "223c03e2-9f7e-481d-bc33-2b0631fbaaf9#1",
+  "result": {
+    "amount_abs_drift_px": 1.0,
+    "amount_outlier_frac": 0.0,
+    "amount_wobble_iqr_px": 0.0,
+    "amount_to_flag_gap_delta_px": 2.64,
+    "amount_to_flag_gap_limit_px": 13.18,
+    "flag_abs_drift_px": 2.0,
+    "flag_outlier_frac": 0.0,
+    "verdict": "PASS"
+  },
+  "synthetic_sha256": "4b4a4c31bca4562b3382b7de00866b35cffe789425d359563472718fb3e6ef64",
+  "unchanged_metrics": {
+    "arithmetic": "PASS",
+    "logo": "PASS",
+    "separators": "PASS",
+    "tokens": "PASS"
+  }
+}

--- a/synthesis_loop/evidence/gelsons_column_blast_radius.before.json
+++ b/synthesis_loop/evidence/gelsons_column_blast_radius.before.json
@@ -1,0 +1,21 @@
+{
+  "git_sha": "b1be770d0d23b7901f18277d232231842b509676",
+  "merchant": "Gelson's Westlake Village",
+  "merchant_truth": {
+    "bundle_hash": "9486f47c16ee3cc2e38dbe505b1feef6692cc1633d74d1ceafd7e3a423e48c09",
+    "mode": "online-active",
+    "slug": "gelson_s_westlake_village",
+    "version": 1
+  },
+  "metric": "columns",
+  "receipt": "223c03e2-9f7e-481d-bc33-2b0631fbaaf9#1",
+  "result": {
+    "amount_abs_drift_px": 17.0,
+    "amount_outlier_frac": 0.222,
+    "amount_wobble_iqr_px": 2.41,
+    "amount_to_flag_gap_delta_px": 24.12,
+    "amount_to_flag_gap_limit_px": 13.18,
+    "verdict": "FAIL"
+  },
+  "synthetic_sha256": "57c29fb877513e40c1d0fe8518ba4ac6c671a7c5d18f72ebfe80dc76dd208347"
+}

--- a/synthesis_loop/evidence/gelsons_flag_lanes.after.json
+++ b/synthesis_loop/evidence/gelsons_flag_lanes.after.json
@@ -1,0 +1,42 @@
+{
+  "artifact": "/tmp/top5-gelsons-lane-final/gelson_s_westlake_village_eval/gelson_s_westlake_village.checks.json",
+  "git_sha": "aa5b74ddae5c128a49418f4f23f2701d8fe3b313",
+  "merchant": "Gelson's Westlake Village",
+  "merchant_truth": {
+    "bundle_hash": "9486f47c16ee3cc2e38dbe505b1feef6692cc1633d74d1ceafd7e3a423e48c09",
+    "slug": "gelson_s_westlake_village",
+    "version": 1
+  },
+  "metric": "columns",
+  "receipt": "223c03e2-9f7e-481d-bc33-2b0631fbaaf9#1",
+  "result": {
+    "amount": {
+      "abs_drift_px": 1.0,
+      "outlier_frac": 0.0,
+      "verdict": "PASS",
+      "wobble_iqr_px": 0.0,
+      "wobble_limit_px": 3.84
+    },
+    "amount_flag_gap": {
+      "delta_px": 2.64,
+      "limit_px": 13.18,
+      "real_gap_px": 42.64,
+      "synth_gap_px": 40.0,
+      "verdict": "PASS"
+    },
+    "flag": {
+      "abs_drift_px": 2.0,
+      "outlier_frac": 0.0,
+      "verdict": "PASS",
+      "wobble_iqr_px": 1.0
+    },
+    "verdict": "PASS"
+  },
+  "unchanged_metrics": {
+    "arithmetic": "PASS",
+    "graphics": "PASS",
+    "logo": "PASS",
+    "separators": "PASS",
+    "tokens": "PASS"
+  }
+}

--- a/synthesis_loop/evidence/gelsons_flag_lanes.before.json
+++ b/synthesis_loop/evidence/gelsons_flag_lanes.before.json
@@ -1,0 +1,36 @@
+{
+  "artifact": "/tmp/top5-gelsons-columns-test-eval/gelson_s_westlake_village_eval/gelson_s_westlake_village.checks.json",
+  "git_sha": "3e7fbc0785a97b5ee3470f706777b4bb11f0649c",
+  "merchant": "Gelson's Westlake Village",
+  "merchant_truth": {
+    "bundle_hash": "9486f47c16ee3cc2e38dbe505b1feef6692cc1633d74d1ceafd7e3a423e48c09",
+    "slug": "gelson_s_westlake_village",
+    "version": 1
+  },
+  "metric": "columns",
+  "receipt": "223c03e2-9f7e-481d-bc33-2b0631fbaaf9#1",
+  "result": {
+    "amount": {
+      "failed_on": [
+        "wobble"
+      ],
+      "outlier_frac": 0.0,
+      "verdict": "FAIL",
+      "wobble_iqr_px": 7.0,
+      "wobble_limit_px": 3.84
+    },
+    "amount_flag_gap": {
+      "delta_px": 41.64,
+      "limit_px": 13.18,
+      "real_gap_px": 42.64,
+      "synth_gap_px": 1.0,
+      "verdict": "FAIL"
+    },
+    "flag": {
+      "outlier_frac": 0.0,
+      "verdict": "PASS",
+      "wobble_iqr_px": 0.0
+    },
+    "verdict": "FAIL"
+  }
+}

--- a/synthesis_loop/evidence/the_stand_column_blast_radius.after.json
+++ b/synthesis_loop/evidence/the_stand_column_blast_radius.after.json
@@ -1,0 +1,27 @@
+{
+  "git_sha": "2089caf4b0433756791c059289431e96b64fcf10",
+  "merchant": "The Stand - American Classics Redefined",
+  "merchant_truth": {
+    "bundle_hash": "c9d40358fc1665323c3639239ff4b19e1c1c02c032f723a260c2cb7c6d9dcd27",
+    "mode": "online-active",
+    "slug": "the_stand___american_classics_redefined",
+    "version": 1
+  },
+  "metric": "columns",
+  "receipt": "016bda87-f2a9-4dfc-85cc-e2b672ccb27a#1",
+  "result": {
+    "abs_drift_px": 4.0,
+    "outlier_frac": 0.0,
+    "shear_px_per_100px": 1.08,
+    "verdict": "PASS",
+    "wobble_iqr_px": 0.68,
+    "wobble_limit_px": 3.38
+  },
+  "synthetic_sha256": "e09d6f10f6aa060db31737c0aa312b96425ec454d049cb9625126bf69534613d",
+  "unchanged_metrics": {
+    "arithmetic": "PASS",
+    "logo": "PASS",
+    "separators": "PASS",
+    "tokens": "PASS"
+  }
+}

--- a/synthesis_loop/evidence/the_stand_column_blast_radius.before.json
+++ b/synthesis_loop/evidence/the_stand_column_blast_radius.before.json
@@ -1,0 +1,21 @@
+{
+  "git_sha": "b1be770d0d23b7901f18277d232231842b509676",
+  "merchant": "The Stand - American Classics Redefined",
+  "merchant_truth": {
+    "bundle_hash": "c9d40358fc1665323c3639239ff4b19e1c1c02c032f723a260c2cb7c6d9dcd27",
+    "mode": "online-active",
+    "slug": "the_stand___american_classics_redefined",
+    "version": 1
+  },
+  "metric": "columns",
+  "receipt": "016bda87-f2a9-4dfc-85cc-e2b672ccb27a#1",
+  "result": {
+    "abs_drift_px": 5.0,
+    "outlier_frac": 0.0,
+    "shear_px_per_100px": 0.94,
+    "verdict": "PASS",
+    "wobble_iqr_px": 0.46,
+    "wobble_limit_px": 3.38
+  },
+  "synthetic_sha256": "25c58932c68f3e341a85b1726db5f136b06dc9deb9752fe654ab9d508742306e"
+}

--- a/tests/test_render_systemic_fixes.py
+++ b/tests/test_render_systemic_fixes.py
@@ -123,6 +123,37 @@ class TestPhraseRunMatch:
         assert not rsr._phrase_run_match(["HOW", "X", "DOERS"], ["HOWDOERS"])
 
 
+class TestMeasuredLayoutTemplate:
+    def test_ocr_layout_receives_a_copy(self):
+        template = {"columns": {"items": [{"role": "amount", "x": 0.8}]}}
+        profile = {"layout_template": template}
+
+        selected = rsr._measured_layout_template(
+            profile,
+            compose_kind=None,
+        )
+
+        assert selected == template
+        assert selected is not template
+
+    def test_composer_owns_output_geometry(self):
+        profile = {
+            "compose": "dollartree",
+            "layout_template": {"columns": {"items": []}},
+        }
+
+        assert (
+            rsr._measured_layout_template(
+                profile,
+                compose_kind="dollartree",
+            )
+            is None
+        )
+
+    def test_missing_layout_remains_a_noop(self):
+        assert rsr._measured_layout_template({}, compose_kind=None) is None
+
+
 class TestWordmarkSeedFilter:
     """P1 review finding: an UNLABELED word on the brand line (e.g. its label
     was INVALID-filtered) must not be seeded into the wordmark cluster."""


### PR DESCRIPTION
## Summary
- carry the selected Merchant Truth `C#layout` template into `RenderConfig`
- resolve rendered rows onto canonical, variant-aware truth sections
- anchor amount, quantity, label, description, and tax-flag roles to measured lane edges
- account for bitmap-glyph side bearings while retaining render-true word boxes
- fold #1251's Gelson flag-lane extension into this single measured-columns PR
- keep canonical composers in sole control of output geometry
- leave evaluator bands and thresholds unchanged

This is the measured-columns change rebased directly onto `main`; it deliberately excludes #1240/#1255 separator code and is not stacked. The measured-layout blast radius was explicitly evaluated for every profile carrying a layout template: Costco, Gelson's, The Stand, and Dollar Tree.

## Fidelity proof
Costco `0324604e-e1f7-4021-b887-7ef7e012c563#1`, truth v2 bundle `6b709e…`:

- columns: **FAIL → PASS**
- wobble `10.71 → 3.28` (limit `3.86`)
- outliers `0.50 → 0.083` (limit `0.40`)
- shear `10.33 → 3.00` (limit `6.00`)
- controls: tokens, separators, logo, graphics PASS; style PASS_WITH_GAPS

Gelson's `223c03e2-9f7e-481d-bc33-2b0631fbaaf9#1`, active truth v1:

- columns: **FAIL → PASS**
- amount drift `17 → 1px`; outliers `.222 → 0`; wobble `2.41 → 0`
- amount↔flag gap error `24.12 → 2.64px` (limit `13.18`)
- tokens, separators, logo, arithmetic remain PASS

The Stand `016bda87…#1`:

- columns remain **PASS**
- drift improves `5 → 4px`; wobble `.46 → .68` remains far below the `3.38px` limit
- tokens, separators, logo, arithmetic remain PASS

Dollar Tree `0944ee8d…#1`:

- the first pass reapplied sheared-photo lanes after canonical composition, worsening shear `35.48 → 66.55`
- the composer-geometry guard restores the exact parent PNG SHA and all parent metric values
- its pre-existing fixture-mode fidelity gaps remain documented; this PR adds no regression

Evidence:
- `synthesis_loop/evidence/costco_v2_columns.{before,after}.json`
- `synthesis_loop/evidence/gelsons_flag_lanes.{before,after}.json`
- `synthesis_loop/evidence/{gelsons,the_stand,dollar_tree}_column_blast_radius.{before,after}.json`

Dollar Tree has no ACTIVE truth in dev, so its proof uses a hash-verified dry v1 fixture built from the legacy profile. No DynamoDB writes occurred.

## Verification
- 85 focused measured-layout/separator/systemic/composer tests passed on Python 3.12
- corpus regression gate: PASS, zero findings
- black, isort, and `git diff --check`: clean
- graphics is SKIPPED where the local Vision helper is unavailable

Ready for independent review. Do not merge until CI and owner review complete.

## Rebase validation
- Python 3.12 receipt-agent suite: 338 passed, 22 skipped
- Python 3.12 repository suite: 568 passed, 1 skipped
- corpus regression gate: `ok: true`, zero findings (eval-logic pin)
- production-render comparison against same-machine `origin/main`: Vons and Sprouts byte-identical; both Costco pins changed as intended by the measured-column path
