### PR TITLE
[render] Fix Sprouts amount-column fidelity

### DIFF
--- a/scripts/render_synthetic_receipts.py
+++ b/scripts/render_synthetic_receipts.py
@@ -938,7 +938,11 @@ def _smooth_luma_field(rng, height, width, scale, amp):
 
 
 def _composite_paper_texture(
-    image, *, seed: int | None = None, strength: float | None = None
+    image,
+    *,
+    seed: int | None = None,
+    strength: float | None = None,
+    protect_paper: bool = False,
 ):
     """Composite thermal-paper realism onto a clean render.
 
@@ -947,6 +951,13 @@ def _composite_paper_texture(
     print-head banding, a top-to-bottom thermal fade, fine grain, an edge
     vignette, and a fractional-degree skew with paper-colour fill (the scan tilt).
     ``strength`` (env ``RECEIPT_PAPER_STRENGTH``, default 1.0) scales the effect.
+
+    When ``protect_paper`` is true, clean paper pixels retain a minimum luma
+    after the stacked effects.  This is used by profiles that carry a measured
+    ink colour: the renderer can distinguish intentional ink from paper and
+    must not let independent grain/vignette layers combine into isolated
+    ink-dark pixels.  The texture and cyan scanner bars remain visible; only
+    paper pixels that cross the paper/ink separation are lifted.
     """
     import numpy as np
     from PIL import Image, ImageFilter
@@ -959,6 +970,7 @@ def _composite_paper_texture(
     s = max(0.0, float(strength))
     source_mode = image.mode
     base = image.convert("RGB")
+    clean_luma = np.asarray(base.convert("L"), dtype=np.float32)
     # Ink bleed: thermal dots spread slightly -- soften the razor-digital edges.
     if s > 0:
         base = base.filter(ImageFilter.GaussianBlur(0.6 * min(s, 1.5)))
@@ -1003,6 +1015,20 @@ def _composite_paper_texture(
         rgb[..., 0] -= 24.0 * s * ew
         rgb[..., 1] -= 2.0 * s * ew
         rgb[..., 2] -= 4.0 * s * ew
+
+    if protect_paper:
+        paper_reference = float(np.percentile(clean_luma, 85))
+        paper_mask = clean_luma >= paper_reference - 18.0
+        paper_floor = paper_reference - 35.0
+        textured_luma = (
+            rgb[..., 0] * 0.299 + rgb[..., 1] * 0.587 + rgb[..., 2] * 0.114
+        )
+        lift = np.where(
+            paper_mask,
+            np.maximum(0.0, paper_floor - textured_luma),
+            0.0,
+        )
+        rgb += lift[:, :, None]
 
     rgb = np.clip(rgb, 0.0, 255.0).astype(np.uint8)
     textured = Image.fromarray(rgb, mode="RGB")
@@ -2138,7 +2164,13 @@ def _render_cached_hybrid(
     # metrics (measured on the textured image) bounce run-to-run whenever an
     # evaluator re-rendered to a fresh debug path. See _content_texture_seed.
     texture_seed = _content_texture_seed(receipt)
-    image = _composite_paper_texture(image, seed=texture_seed)
+    image = _composite_paper_texture(
+        image,
+        seed=texture_seed,
+        # A measured ink colour makes paper/ink separation explicit. Preserve
+        # that separation through the otherwise independent texture layers.
+        protect_paper=ink is not None,
+    )
     os.makedirs(os.path.dirname(os.path.abspath(path)), exist_ok=True)
     image.convert("RGB").save(path, format="PNG")
     return path

--- a/scripts/test_render_paper_texture.py
+++ b/scripts/test_render_paper_texture.py
@@ -1,0 +1,45 @@
+"""Regression tests for paper/ink separation in synthetic receipt texture."""
+
+import os
+import sys
+
+from PIL import Image, ImageStat
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import render_synthetic_receipts as rsr  # noqa: E402
+
+
+def test_protected_paper_does_not_create_ink_dark_speckles():
+    paper = Image.new("RGB", (200, 400), (250, 249, 245))
+
+    unprotected = rsr._composite_paper_texture(paper, seed=123, strength=1.0)
+    protected = rsr._composite_paper_texture(
+        paper,
+        seed=123,
+        strength=1.0,
+        protect_paper=True,
+    )
+
+    assert ImageStat.Stat(unprotected.convert("L")).extrema[0][0] < 210
+    assert ImageStat.Stat(protected.convert("L")).extrema[0][0] >= 205
+
+
+def test_protected_paper_keeps_intentional_ink_dark():
+    paper = Image.new("RGB", (200, 400), (250, 249, 245))
+    for x in range(70, 130):
+        for y in range(180, 220):
+            paper.putpixel((x, y), (38, 36, 34))
+
+    protected = rsr._composite_paper_texture(
+        paper,
+        seed=123,
+        strength=1.0,
+        protect_paper=True,
+    )
+
+    assert (
+        ImageStat.Stat(protected.crop((80, 185, 120, 215)).convert("L")).mean[
+            0
+        ]
+        < 80
+    )

--- a/synthesis_loop/evidence/sprouts_v1_columns.after.json
+++ b/synthesis_loop/evidence/sprouts_v1_columns.after.json
@@ -1,0 +1,53 @@
+{
+  "bundle_hash": "18dc387fbfd985fbc236e413ca051959613fe6e66c263f2a9a23fe67551cb74b",
+  "controls": {
+    "arithmetic": "PASS",
+    "logo": "PASS",
+    "tokens": "PASS"
+  },
+  "eval_git_sha": "bd4cfa21f7670dfa3f31509b5cac0a208e76a1df",
+  "image_id": "00ded398-af6f-4a49-86f7-c79ccb554e48",
+  "metric": "columns",
+  "receipt_id": 1,
+  "result": {
+    "failed_on": [],
+    "limits": {
+      "abs_drift_px": 27.26,
+      "outlier_frac": 0.15,
+      "shear_px_per_100px": 6.0,
+      "wobble_iqr_px": 2.5
+    },
+    "real": {
+      "lane_x_px": 695.0,
+      "median_dev_px": -4.81,
+      "n_rows": 5,
+      "outlier_frac": 0.0,
+      "tilt_px_per_100px": 0.0,
+      "wobble_iqr_px": 0.0
+    },
+    "source": "bootstrap",
+    "synth": {
+      "abs_drift_px": 3.0,
+      "lane_x_px": 697.02,
+      "median_dev_px": -1.81,
+      "n_rows": 5,
+      "outlier_frac": 0.0,
+      "shear_px_per_100px": 1.83,
+      "tilt_px_per_100px": -1.833,
+      "wobble_iqr_px": 1.31
+    },
+    "verdict": "PASS"
+  },
+  "truth_version": 1,
+  "verification": {
+    "corpus_regression_gate": "PASS (0 findings)",
+    "focused_tests": "6 passed",
+    "render_regression_guard": {
+      "costco_golden": "byte-identical",
+      "costco_new": "byte-identical",
+      "sprouts": "CHANGED (expected)",
+      "sprouts_sha256": "dc99fc499ffe7c47194f833149f80a670c413678d086a86914b7c1792da09891",
+      "vons_golden": "byte-identical"
+    }
+  }
+}

--- a/synthesis_loop/evidence/sprouts_v1_columns.before.json
+++ b/synthesis_loop/evidence/sprouts_v1_columns.before.json
@@ -1,0 +1,47 @@
+{
+  "base_git_sha": "e517d33fdc043abfcbff5f70e87dfd21bccc8952",
+  "bundle_hash": "18dc387fbfd985fbc236e413ca051959613fe6e66c263f2a9a23fe67551cb74b",
+  "controls": {
+    "arithmetic": "PASS",
+    "logo": "PASS",
+    "tokens": "PASS"
+  },
+  "image_id": "00ded398-af6f-4a49-86f7-c79ccb554e48",
+  "metric": "columns",
+  "receipt_id": 1,
+  "result": {
+    "failed_on": [
+      "wobble",
+      "outliers",
+      "abs_drift",
+      "shear"
+    ],
+    "limits": {
+      "abs_drift_px": 27.26,
+      "outlier_frac": 0.15,
+      "shear_px_per_100px": 6.0,
+      "wobble_iqr_px": 2.5
+    },
+    "real": {
+      "lane_x_px": 695.0,
+      "median_dev_px": -4.81,
+      "n_rows": 5,
+      "outlier_frac": 0.0,
+      "tilt_px_per_100px": 0.0,
+      "wobble_iqr_px": 0.0
+    },
+    "source": "bootstrap",
+    "synth": {
+      "abs_drift_px": 40.0,
+      "lane_x_px": 725.29,
+      "median_dev_px": 35.19,
+      "n_rows": 5,
+      "outlier_frac": 0.2,
+      "shear_px_per_100px": 25.71,
+      "tilt_px_per_100px": -25.715,
+      "wobble_iqr_px": 9.39
+    },
+    "verdict": "FAIL"
+  },
+  "truth_version": 1
+}


### PR DESCRIPTION
## Summary
- preserve paper/ink separation when merchant truth supplies a measured ink color
- prevent stacked paper texture from creating isolated ink-dark pixels that masquerade as amount-lane edges
- add deterministic paper-texture regression coverage

## Fidelity proof
Sprouts `00ded398-af6f-4a49-86f7-c79ccb554e48#1`, active truth v1 `18dc387f…`:

- columns: **FAIL → PASS**
- synth lane x: `725.29 → 697.02 px` (real `695.0 px`)
- median deviation: `+35.19 → -1.81 px`
- wobble: `9.39 → 1.31 px`
- outliers: `0.20 → 0`
- shear: `25.71 → 1.83 px/100px`
- absolute drift: `40 → 3 px`
- tokens, logo, arithmetic: remain PASS

Committed evidence:
- `synthesis_loop/evidence/sprouts_v1_columns.before.json`
- `synthesis_loop/evidence/sprouts_v1_columns.after.json`

## Guards
- 6 focused tests passed
- corpus regression gate: PASS, 0 findings
- render guard: Costco golden/new and Vons byte-identical; Sprouts changed as expected

Dev DynamoDB was read-only; no gate record was written.