### PR TITLE
[render] Restore Sprouts policy separator

### DIFF
--- a/receipt_agent/receipt_agent/agents/label_evaluator/rendering/receipt_renderer.py
+++ b/receipt_agent/receipt_agent/agents/label_evaluator/rendering/receipt_renderer.py
@@ -531,6 +531,62 @@ def _draw_dash_row(
     )
 
 
+def _inferred_policy_separator_baselines(
+    rows: Sequence[Sequence[GridWord]],
+    sections: Sequence[str | None],
+    baselines: Sequence[float],
+    *,
+    min_pitch: float,
+    cap_h: float,
+    content_top: float,
+    content_height: float,
+) -> list[float]:
+    """Infer an OCR-dropped dash rule before a lower legal-policy block.
+
+    Vision commonly drops a thin rule even though it preserves the deliberately
+    blank row around it.  A lower-page website row is classified as HEADER while
+    the legal copy beneath it is predominantly alphabetic (its labels may be
+    sparse or noisy).  When that semantic transition also has roughly one blank
+    text row, place the dash ink in the observed whitespace.  Requiring all three
+    signals keeps normal paragraph gaps and top header transitions untouched.
+    """
+    if not (
+        len(rows) == len(sections) == len(baselines)
+        and min_pitch > 0
+        and content_height > 0
+    ):
+        return []
+
+    inferred: list[float] = []
+    lower_page = content_top + 0.55 * content_height
+    for index in range(len(rows) - 1):
+        if sections[index] != "HEADER":
+            continue
+        if baselines[index] < lower_page:
+            continue
+        current_text = " ".join(word.text for word in rows[index])
+        if not re.search(
+            r"[A-Za-z][A-Za-z0-9.-]*\.[A-Za-z]{2,}", current_text
+        ):
+            continue
+        following_text = "".join(word.text for word in rows[index + 1])
+        following_letters = sum(ch.isalpha() for ch in following_text)
+        following_digits = sum(ch.isdigit() for ch in following_text)
+        if (
+            following_letters < 10
+            or following_letters <= 3 * following_digits
+            or any(is_price_token(word.text) for word in rows[index + 1])
+        ):
+            continue
+        gap = float(baselines[index + 1] - baselines[index])
+        if not 1.55 * min_pitch <= gap <= 3.25 * min_pitch:
+            continue
+        ink_midpoint = (baselines[index] + baselines[index + 1]) / 2.0
+        # A hyphen's visible bar sits about half a cap above the text baseline.
+        inferred.append(ink_midpoint + 0.5 * cap_h)
+    return inferred
+
+
 def _is_asterisk_rule(row_text: str) -> bool:
     chars = [ch for ch in row_text if not ch.isspace()]
     if len(chars) < 3 or any(ch.isalnum() for ch in chars):
@@ -878,6 +934,15 @@ def _render_grid(
             return text, "left", min(w.left for w in line), target_w
         return None
 
+    inferred_gap_dash_ys = _inferred_policy_separator_baselines(
+        rows,
+        eff_sections,
+        baselines,
+        min_pitch=float(min_pitch),
+        cap_h=cap_h,
+        content_top=float(config.margin),
+        content_height=float(inner_h),
+    )
     # Rows after which Costco prints a dashed rule (dropped by OCR): the grand
     # TOTAL, and the AMOUNT-block transaction-date line (the date row whose prior
     # row is the "AMOUNT:" line).
@@ -1142,7 +1207,7 @@ def _render_grid(
     # gap below each anchor row. Use the merchant's bitmap face when it carries a
     # dash glyph, else the body TTF (which always has one).
     dash_bmf = bmf if (bmf is not None and bmf.has("-")) else None
-    for y in dash_ys:
+    for y in [*dash_ys, *inferred_gap_dash_ys]:
         _draw_dash_row(
             draw,
             content_left,

--- a/receipt_agent/receipt_agent/agents/label_evaluator/rendering/receipt_renderer.py
+++ b/receipt_agent/receipt_agent/agents/label_evaluator/rendering/receipt_renderer.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import math
 import os
+import re
 from dataclasses import dataclass, replace
 from statistics import median
 from typing import Any, Mapping, Sequence

--- a/receipt_agent/tests/test_receipt_renderer_separators.py
+++ b/receipt_agent/tests/test_receipt_renderer_separators.py
@@ -1,0 +1,71 @@
+from receipt_agent.agents.label_evaluator.rendering.receipt_grid import (
+    GridWord,
+)
+from receipt_agent.agents.label_evaluator.rendering.receipt_renderer import (
+    _inferred_policy_separator_baselines,
+)
+
+
+def _row(text: str) -> list[GridWord]:
+    return [
+        GridWord(
+            left=20.0,
+            top=680.0,
+            right=300.0,
+            bottom=700.0,
+            text=text,
+            ink=(0, 0, 0),
+        )
+    ]
+
+
+def test_infers_rule_in_blank_row_before_lower_policy_copy() -> None:
+    result = _inferred_policy_separator_baselines(
+        [_row("by email at Grocer.example"), _row("Please keep your receipt")],
+        ["HEADER", "FOOTER"],
+        [700.0, 760.0],
+        min_pitch=30.0,
+        cap_h=20.0,
+        content_top=10.0,
+        content_height=1000.0,
+    )
+
+    assert result == [740.0]
+
+
+def test_does_not_infer_rule_without_website_boundary_or_blank_row() -> None:
+    common = {
+        "sections": ["HEADER", "FOOTER"],
+        "min_pitch": 30.0,
+        "cap_h": 20.0,
+        "content_top": 10.0,
+        "content_height": 1000.0,
+    }
+
+    no_website = _inferred_policy_separator_baselines(
+        [_row("save money save paper"), _row("Please keep your receipt")],
+        baselines=[700.0, 760.0],
+        **common,
+    )
+    no_blank_row = _inferred_policy_separator_baselines(
+        [_row("visit Grocer.example"), _row("Please keep your receipt")],
+        baselines=[700.0, 740.0],
+        **common,
+    )
+
+    assert no_website == []
+    assert no_blank_row == []
+
+
+def test_does_not_infer_rule_in_top_header() -> None:
+    result = _inferred_policy_separator_baselines(
+        [_row("visit Grocer.example"), _row("Please keep your receipt")],
+        ["HEADER", "FOOTER"],
+        [300.0, 360.0],
+        min_pitch=30.0,
+        cap_h=20.0,
+        content_top=10.0,
+        content_height=1000.0,
+    )
+
+    assert result == []

--- a/synthesis_loop/evidence/sprouts_v1_separators.after.json
+++ b/synthesis_loop/evidence/sprouts_v1_separators.after.json
@@ -1,0 +1,72 @@
+{
+  "base_git_sha": "e517d33fdc043abfcbff5f70e87dfd21bccc8952",
+  "bundle_hash": "18dc387fbfd985fbc236e413ca051959613fe6e66c263f2a9a23fe67551cb74b",
+  "controls": {
+    "arithmetic": "PASS",
+    "logo": "PASS",
+    "tokens": "PASS"
+  },
+  "image_id": "00ded398-af6f-4a49-86f7-c79ccb554e48",
+  "metric": "separators",
+  "receipt_id": 1,
+  "result": {
+    "kind_mismatches": 0,
+    "matched": [
+      {
+        "dy": 0.0012,
+        "real": {
+          "height_px": 12,
+          "kind": "dash",
+          "y_frac": 0.6254
+        },
+        "synth": {
+          "height_px": 22,
+          "kind": "double",
+          "y_frac": 0.6266
+        }
+      },
+      {
+        "dy": 0.0006,
+        "real": {
+          "height_px": 13,
+          "kind": "double",
+          "y_frac": 0.7837
+        },
+        "synth": {
+          "height_px": 22,
+          "kind": "double",
+          "y_frac": 0.7831
+        }
+      },
+      {
+        "dy": 0.0024,
+        "real": {
+          "height_px": 3,
+          "kind": "dash",
+          "y_frac": 0.8987
+        },
+        "synth": {
+          "height_px": 3,
+          "kind": "dash",
+          "y_frac": 0.9011
+        }
+      }
+    ],
+    "missing_in_synth": [],
+    "phantom_in_synth": [],
+    "real_count": 3,
+    "synth_count": 3,
+    "verdict": "PASS"
+  },
+  "truth_version": 1,
+  "verification": {
+    "corpus_regression_gate": "PASS (0 findings)",
+    "focused_tests": "3 passed",
+    "render_regression_guard": {
+      "costco_golden": "byte-identical",
+      "costco_new": "byte-identical",
+      "sprouts": "CHANGED (expected)",
+      "vons_golden": "byte-identical"
+    }
+  }
+}

--- a/synthesis_loop/evidence/sprouts_v1_separators.before.json
+++ b/synthesis_loop/evidence/sprouts_v1_separators.before.json
@@ -1,0 +1,55 @@
+{
+  "base_git_sha": "e517d33fdc043abfcbff5f70e87dfd21bccc8952",
+  "bundle_hash": "18dc387fbfd985fbc236e413ca051959613fe6e66c263f2a9a23fe67551cb74b",
+  "controls": {
+    "arithmetic": "PASS",
+    "logo": "PASS",
+    "tokens": "PASS"
+  },
+  "image_id": "00ded398-af6f-4a49-86f7-c79ccb554e48",
+  "metric": "separators",
+  "receipt_id": 1,
+  "result": {
+    "kind_mismatches": 0,
+    "matched": [
+      {
+        "dy": 0.0012,
+        "real": {
+          "height_px": 12,
+          "kind": "dash",
+          "y_frac": 0.6254
+        },
+        "synth": {
+          "height_px": 22,
+          "kind": "double",
+          "y_frac": 0.6266
+        }
+      },
+      {
+        "dy": 0.0006,
+        "real": {
+          "height_px": 13,
+          "kind": "double",
+          "y_frac": 0.7837
+        },
+        "synth": {
+          "height_px": 22,
+          "kind": "double",
+          "y_frac": 0.7831
+        }
+      }
+    ],
+    "missing_in_synth": [
+      {
+        "height_px": 3,
+        "kind": "dash",
+        "y_frac": 0.8987
+      }
+    ],
+    "phantom_in_synth": [],
+    "real_count": 3,
+    "synth_count": 2,
+    "verdict": "FAIL"
+  },
+  "truth_version": 1
+}


### PR DESCRIPTION
## Summary
- infer an OCR-dropped dash rule only at a lower-page website-to-legal-copy boundary with a measured blank row
- render the missing rule in observed whitespace without shifting downstream receipt content
- add focused positive and false-positive coverage

## Fidelity proof
Sprouts `00ded398-af6f-4a49-86f7-c79ccb554e48#1`, active truth v1 `18dc387f…`:

- separators: **FAIL → PASS**
- count: real/synth `3/2 → 3/3`
- missing policy rule: `y=.8987` real matched by `y=.9011` synth (`dy=.0024`)
- missing/phantom: `1/0 → 0/0`
- tokens, logo, arithmetic: remain PASS

Committed evidence:
- `synthesis_loop/evidence/sprouts_v1_separators.before.json`
- `synthesis_loop/evidence/sprouts_v1_separators.after.json`

## Guards
- 3 focused tests passed
- corpus regression gate: PASS, 0 findings
- render guard: Costco golden/new and Vons byte-identical; Sprouts changed as expected

Dev DynamoDB was read-only; no gate record was written.

## Rebase validation
- Python 3.12 receipt-agent suite: 334 passed, 22 skipped
- Python 3.12 repository suite: 565 passed, 1 skipped
- corpus regression gate: `ok: true`, zero findings (eval-logic pin)
- production-render comparison against same-machine `origin/main`: both Costco pins and Vons byte-identical; Sprouts changed as intended
