### PR TITLE
[render] Match Sprouts section styles

### DIFF
--- a/receipt_agent/receipt_agent/agents/label_evaluator/rendering/bitmap_font.py
+++ b/receipt_agent/receipt_agent/agents/label_evaluator/rendering/bitmap_font.py
@@ -69,6 +69,7 @@ class BitmapFont:
         *,
         thin: float = 0.0,
         vscale: float = 1.0,
+        baseline_variation: int = 0,
     ):
         data = np.load(atlas_path)
         self.glyphs = {
@@ -104,6 +105,11 @@ class BitmapFont:
         # glyphs ~17% too TALL at correct pitch (GOLD_STANDARD.md I2), so the
         # fix must be vertical-only. 1.0 (default) is byte-identical.
         self.vscale = max(0.5, min(1.5, float(vscale or 1.0)))
+        # Consensus atlases phase-lock every copy of a glyph to the same pixel
+        # rows. For stylemaps that distinguish real underlines, one pixel of
+        # deterministic character-level variation restores the small
+        # per-glyph baseline spread present in the source scans.
+        self.baseline_variation = max(0, min(2, int(baseline_variation or 0)))
         # key: (char, cap_px, thin, vscale)
         self._cache: dict[tuple[str, int, float, float], tuple] = {}
 
@@ -144,6 +150,8 @@ class BitmapFont:
             h = max(1, int(round(im.height * self.vscale)))
             im = im.resize((im.width, h), Image.NEAREST)
             off = int(round(off * self.vscale))
+        if self.baseline_variation:
+            off += ((ord(ch) % 3) - 1) * self.baseline_variation
         self._cache[key] = (im, h, off)
         return self._cache[key]
 

--- a/receipt_agent/receipt_agent/agents/label_evaluator/rendering/receipt_renderer.py
+++ b/receipt_agent/receipt_agent/agents/label_evaluator/rendering/receipt_renderer.py
@@ -251,6 +251,30 @@ def section_style(value: Any) -> tuple[float, float]:
     return _clamped_scale(value, 0.25, 4.0), 1.0
 
 
+def _stylemap_uses_underlines(stylemap: Mapping[str, Any] | None) -> bool:
+    """Whether a stylemap needs real underline/non-underline separation."""
+    sections = (stylemap or {}).get("sections") or {}
+    return any(
+        rule.get("underline") in (True, "sometimes")
+        for rule in sections.values()
+        if isinstance(rule, Mapping)
+    )
+
+
+def _scaled_bitmap_thin(base_thin: float, scale: float) -> float:
+    """Keep materially downscaled regular bitmap rows visually lighter.
+
+    Nearest-neighbor bitmap scaling quantizes a 15% size reduction without
+    necessarily removing a stroke pixel. Compensate only at 0.9x or below;
+    near-body 0.95x sections retain the merchant's calibrated body thinning.
+    """
+    base = max(0.0, min(0.9, float(base_thin or 0.0)))
+    safe_scale = _clamped_scale(scale, 0.25, 4.0)
+    if safe_scale > 0.9:
+        return base
+    return min(0.9, base + 2.0 * (1.0 - safe_scale))
+
+
 def render_receipt(
     receipt: Mapping[str, Any],
     *,
@@ -536,6 +560,7 @@ def _render_grid(
     # Bitmap (glyph-atlas) font: the merchant's actual letterforms. cap_px is the
     # target cap height (~0.72 of the em); advance comes from the atlas.
     bmf = bmf_heavy = None
+    bmf_light: dict[float, Any] = {}
     cap_px = None
     if config.bitmap_font:
         from receipt_agent.agents.label_evaluator.rendering.bitmap_font import (
@@ -544,16 +569,36 @@ def _render_grid(
 
         bitmap_thin = max(0.0, min(0.9, float(config.bitmap_thin or 0.0)))
         glyph_vscale = float(config.bitmap_glyph_vscale or 1.0)
+        sections = (config.stylemap or {}).get("sections") or {}
+        baseline_variation = int(_stylemap_uses_underlines(config.stylemap))
         bmf = BitmapFont(
             config.bitmap_font["regular"],
             thin=bitmap_thin,
             vscale=glyph_vscale,
+            baseline_variation=baseline_variation,
         )
+        light_scales = {
+            _clamped_scale(rule.get("sizeScale", 1.0), 0.25, 4.0)
+            for rule in sections.values()
+            if isinstance(rule, Mapping)
+            and rule.get("weight") != "bold"
+            and _clamped_scale(rule.get("sizeScale", 1.0), 0.25, 4.0) <= 0.9
+        }
+        for light_scale in light_scales:
+            bmf_light[light_scale] = BitmapFont(
+                config.bitmap_font["regular"],
+                thin=_scaled_bitmap_thin(bitmap_thin, light_scale),
+                vscale=glyph_vscale,
+                baseline_variation=baseline_variation,
+            )
         heavy_path = config.bitmap_font.get(
             "heavy", config.bitmap_font["regular"]
         )
         bmf_heavy = BitmapFont(
-            heavy_path, thin=bitmap_thin, vscale=glyph_vscale
+            heavy_path,
+            thin=bitmap_thin,
+            vscale=glyph_vscale,
+            baseline_variation=baseline_variation,
         )
         cap_ratio = max(0.5, min(1.0, float(config.bitmap_cap_ratio)))
         cap_px = max(6, int(round(sizing.font_px * cap_ratio)))
@@ -819,6 +864,12 @@ def _render_grid(
                 )
             if sm_style is not None and sm_style["scale"] != 1.0:
                 sc = sc * sm_style["scale"]
+            if (
+                sm_style is not None
+                and not sm_style["bold"]
+                and sm_style["scale"] <= 0.9
+            ):
+                bf_row = bmf_light.get(sm_style["scale"], bf_row)
         if _is_asterisk_rule(row_text):
             n = int(content_cw / spec.cell_w)
             draw_token_chars(

--- a/receipt_agent/tests/test_bitmap_font.py
+++ b/receipt_agent/tests/test_bitmap_font.py
@@ -1,0 +1,24 @@
+import numpy as np
+
+from receipt_agent.agents.label_evaluator.rendering.bitmap_font import (
+    BitmapFont,
+)
+
+
+def test_baseline_variation_is_opt_in_and_keeps_glyph_shape(tmp_path):
+    path = tmp_path / "atlas.npz"
+    np.savez(
+        path,
+        c65=np.ones((10, 6), dtype=np.uint8),
+        o65=np.asarray(0, dtype=np.int16),
+    )
+
+    plain = BitmapFont(str(path))
+    varied = BitmapFont(str(path), baseline_variation=1)
+    plain_glyph, plain_height, plain_offset = plain.glyph("A", 10)
+    varied_glyph, varied_height, varied_offset = varied.glyph("A", 10)
+
+    assert plain_height == varied_height
+    assert plain_offset == 0
+    assert varied_offset == 1
+    assert np.array_equal(np.asarray(plain_glyph), np.asarray(varied_glyph))

--- a/receipt_agent/tests/test_section_style.py
+++ b/receipt_agent/tests/test_section_style.py
@@ -1,6 +1,8 @@
 """section_scale schema: legacy float vs {height_scale, condense} mapping."""
 
 from receipt_agent.agents.label_evaluator.rendering.receipt_renderer import (
+    _scaled_bitmap_thin,
+    _stylemap_uses_underlines,
     section_style,
 )
 
@@ -72,6 +74,26 @@ def test_unlabeled_priceless_receipt_never_becomes_all_footer():
 
     rows = [row("GELSONS MARKET", 10.0), row("THANK YOU", 40.0)]
     assert effective_row_sections(rows) == [None, None]
+
+
+def test_underline_stylemap_enables_bitmap_baseline_variation():
+    assert _stylemap_uses_underlines(
+        {
+            "sections": {
+                "item": {"underline": False},
+                "section_header": {"underline": "sometimes"},
+            }
+        }
+    )
+    assert not _stylemap_uses_underlines(
+        {"sections": {"item": {"underline": False}}}
+    )
+
+
+def test_material_bitmap_downscale_compensates_stroke_quantization():
+    assert _scaled_bitmap_thin(0.225, 0.95) == 0.225
+    assert _scaled_bitmap_thin(0.225, 0.85) == 0.525
+    assert _scaled_bitmap_thin(0.8, 0.5) == 0.9
 
 
 def test_non_positional_label_beats_date_time_everywhere():

--- a/synthesis_loop/evidence/sprouts_style.after.json
+++ b/synthesis_loop/evidence/sprouts_style.after.json
@@ -1,0 +1,91 @@
+{
+  "base_git_sha": "e517d33fdc043abfcbff5f70e87dfd21bccc8952",
+  "bundle_hash": "18dc387fbfd985fbc236e413ca051959613fe6e66c263f2a9a23fe67551cb74b",
+  "controls": {
+    "arithmetic": "PASS",
+    "logo": "PASS",
+    "tokens": "PASS"
+  },
+  "image_id": "00ded398-af6f-4a49-86f7-c79ccb554e48",
+  "metric": "style",
+  "receipt_id": 1,
+  "result": {
+    "body_stroke_fail": false,
+    "body_stroke_rel": {
+      "real": 0.114,
+      "synth": 0.114
+    },
+    "previously_failing_classes": {
+      "address": {
+        "real": {
+          "bold": 1,
+          "n": 7,
+          "underline": 0
+        },
+        "synth": {
+          "bold": 0,
+          "n": 7,
+          "underline": 3
+        },
+        "verdict": "PASS"
+      },
+      "barcode_caption": {
+        "real": {
+          "bold": 0,
+          "n": 2,
+          "underline": 0
+        },
+        "synth": {
+          "bold": 0,
+          "n": 2,
+          "underline": 0
+        },
+        "verdict": "PASS"
+      },
+      "store_hours": {
+        "real": {
+          "bold": 0,
+          "n": 2,
+          "underline": 0
+        },
+        "synth": {
+          "bold": 0,
+          "n": 2,
+          "underline": 0
+        },
+        "verdict": "PASS"
+      },
+      "summary": {
+        "real": {
+          "bold": 0,
+          "n": 2,
+          "underline": 0
+        },
+        "synth": {
+          "bold": 0,
+          "n": 2,
+          "underline": 0
+        },
+        "verdict": "PASS"
+      }
+    },
+    "untested_classes": [
+      "balance_due",
+      "section_header",
+      "total_line",
+      "transaction"
+    ],
+    "verdict": "PASS_WITH_GAPS"
+  },
+  "truth_version": 1,
+  "verification": {
+    "corpus_regression_gate": "PASS (0 findings)",
+    "focused_tests": "71 passed",
+    "render_regression_guard": {
+      "costco_golden": "byte-identical",
+      "costco_new": "byte-identical",
+      "sprouts": "CHANGED (expected)",
+      "vons_golden": "byte-identical"
+    }
+  }
+}

--- a/synthesis_loop/evidence/sprouts_style.before.json
+++ b/synthesis_loop/evidence/sprouts_style.before.json
@@ -1,0 +1,83 @@
+{
+  "base_git_sha": "e517d33fdc043abfcbff5f70e87dfd21bccc8952",
+  "bundle_hash": "18dc387fbfd985fbc236e413ca051959613fe6e66c263f2a9a23fe67551cb74b",
+  "image_id": "00ded398-af6f-4a49-86f7-c79ccb554e48",
+  "metric": "style",
+  "receipt_id": 1,
+  "result": {
+    "body_stroke_fail": false,
+    "body_stroke_rel": {
+      "real": 0.114,
+      "synth": 0.114
+    },
+    "failing_classes": {
+      "address": {
+        "extra_style": [
+          "underline"
+        ],
+        "real": {
+          "bold": 1,
+          "n": 7,
+          "underline": 0
+        },
+        "synth": {
+          "bold": 0,
+          "n": 7,
+          "underline": 4
+        }
+      },
+      "barcode_caption": {
+        "extra_style": [
+          "bold"
+        ],
+        "real": {
+          "bold": 0,
+          "n": 2,
+          "underline": 0
+        },
+        "synth": {
+          "bold": 1,
+          "n": 2,
+          "underline": 0
+        }
+      },
+      "store_hours": {
+        "extra_style": [
+          "underline"
+        ],
+        "real": {
+          "bold": 0,
+          "n": 2,
+          "underline": 0
+        },
+        "synth": {
+          "bold": 0,
+          "n": 2,
+          "underline": 1
+        }
+      },
+      "summary": {
+        "extra_style": [
+          "underline"
+        ],
+        "real": {
+          "bold": 0,
+          "n": 2,
+          "underline": 0
+        },
+        "synth": {
+          "bold": 0,
+          "n": 2,
+          "underline": 1
+        }
+      }
+    },
+    "preserved_metrics": {
+      "arithmetic": "PASS",
+      "logo": "PASS",
+      "tokens": "PASS"
+    },
+    "verdict": "FAIL"
+  },
+  "truth_version": 1
+}


### PR DESCRIPTION
## Summary
- restore one pixel of deterministic baseline variation for consensus bitmap atlases when the measured stylemap distinguishes true underlines
- compensate stroke quantization for materially downscaled regular bitmap rows
- keep body-size and bold rows on their calibrated faces

## Fidelity proof
Sprouts `00ded398-af6f-4a49-86f7-c79ccb554e48#1`, active truth v1 `18dc387f…`:

- style: **FAIL → PASS_WITH_GAPS**
- address false underlines: `4/7 → 3/7` (PASS)
- barcode-caption false bold: `1/2 → 0/2` (PASS)
- store-hours false underline: `1/2 → 0/2` (PASS)
- summary false underline: `1/2 → 0/2` (PASS)
- body stroke: unchanged at real/synth `0.114 / 0.114`
- tokens, logo, arithmetic: remain PASS

Committed evidence:
- `synthesis_loop/evidence/sprouts_style.before.json`
- `synthesis_loop/evidence/sprouts_style.after.json`

## Guards
- 71 focused/related tests passed
- corpus regression gate: PASS, 0 findings
- render guard: Costco golden/new and Vons byte-identical; Sprouts changed as expected

Dev DynamoDB was read-only; no gate record was written.