### PR TITLE
[render] Emit a decodable Sprouts Code128 barcode

### DIFF
--- a/receipt_agent/receipt_agent/agents/label_evaluator/rendering/receipt_graphics.py
+++ b/receipt_agent/receipt_agent/agents/label_evaluator/rendering/receipt_graphics.py
@@ -71,6 +71,40 @@ def _normalize_barcode_data(data: str, kind: str) -> str:
     return str(data) if data else (digits or "0")
 
 
+def _barcode_symbol(data: str, kind: str):
+    """Build a barcode symbol without dropping a leading Code128 ``99`` pair.
+
+    ``python-barcode`` represents both Code128 data and charset-switch opcodes
+    as integers. Its first-code optimizer therefore mistakes a leading numeric
+    data pair of ``99`` for a switch-to-Code-C instruction and removes it. A
+    Sprouts transaction payload begins with that pair, so the generated symbol
+    encoded only the remaining 18 digits. Preserve the pair when the encoder
+    already started in Code C; all other symbols keep the dependency's normal
+    optimization path.
+    """
+    import barcode
+    from barcode.codex import Code128
+    from barcode.writer import ImageWriter
+
+    if kind == "code128":
+
+        class ReceiptCode128(Code128):
+            """Code128 with the leading-99 optimizer ambiguity removed."""
+
+            def _try_to_optimize(self, encoded: list[int]) -> list[int]:
+                if (
+                    self._charset == "C"
+                    and self.code.startswith("99")
+                    and encoded[:2] == [105, 99]
+                ):
+                    return encoded
+                return super()._try_to_optimize(encoded)
+
+        return ReceiptCode128(data, writer=ImageWriter())
+    cls = barcode.get_barcode_class(kind)
+    return cls(data, writer=ImageWriter())
+
+
 def render_barcode_tile(
     data: str,
     kind: str,
@@ -85,15 +119,11 @@ def render_barcode_tile(
     ``False`` because most receipt footer barcodes are printed *without* a digit
     caption, and the spurious caption was one of the realism tells.
     """
-    import barcode
-    from barcode.writer import ImageWriter
-
     kind = kind if kind in _SUPPORTED_KINDS else "code128"
     w_px = max(40, int(w_px))
     h_px = max(20, int(h_px))
     payload = _normalize_barcode_data(data, kind)
 
-    writer = ImageWriter()
     # ``module_height`` is in mm; pick a value that gives the writer a tall-ish
     # raster which we then resample to the requested pixel box. The actual
     # aspect is governed by the resize below, so this only needs to be sane.
@@ -110,8 +140,7 @@ def render_barcode_tile(
         options["font_size"] = 8
         options["text_distance"] = 3.0
 
-    cls = barcode.get_barcode_class(kind)
-    rendered = cls(payload, writer=writer).render(options)
+    rendered = _barcode_symbol(payload, kind).render(options)
     tile = rendered.convert("L")
     if tile.size != (w_px, h_px):
         # Bars are vertical: resample so widths stay as even as possible. NEAREST
@@ -141,10 +170,16 @@ def graphics_profile_for_merchant(merchant: str | None) -> dict:
     kind = "code128"
     if any(token in name for token in _UPCA_MERCHANTS):
         kind = "upca"
-    return {
+    profile = {
         "barcode_kind": kind,
         # Receipt footers carry the transaction barcode without a printed digit
         # caption; the QR (when present) is the scannable anchor.
         "barcode_with_hri": False,
         "qr": True,
     }
+    if "sprouts" in name:
+        # The long printed HRI is the real Code128 data, not merely a visual
+        # density hint. Preserve it so the synthetic symbol decodes to the
+        # transaction payload printed directly below it.
+        profile["inbody_barcode"] = {"payload_from_hri": True}
+    return profile

--- a/receipt_agent/receipt_agent/agents/label_evaluator/rendering/receipt_graphics.py
+++ b/receipt_agent/receipt_agent/agents/label_evaluator/rendering/receipt_graphics.py
@@ -181,5 +181,8 @@ def graphics_profile_for_merchant(merchant: str | None) -> dict:
         # The long printed HRI is the real Code128 data, not merely a visual
         # density hint. Preserve it so the synthetic symbol decodes to the
         # transaction payload printed directly below it.
-        profile["inbody_barcode"] = {"payload_from_hri": True}
+        profile["inbody_barcode"] = {
+            "payload_from_hri": True,
+            "preserve_quiet_zone": True,
+        }
     return profile

--- a/receipt_agent/receipt_agent/agents/label_evaluator/rendering/receipt_graphics.py
+++ b/receipt_agent/receipt_agent/agents/label_evaluator/rendering/receipt_graphics.py
@@ -185,4 +185,10 @@ def graphics_profile_for_merchant(merchant: str | None) -> dict:
             "payload_from_hri": True,
             "preserve_quiet_zone": True,
         }
+    if "vons" in name:
+        # Vons prints a long numeric Code128 transaction symbol. Keeping the
+        # digits in Code C yields modules wide enough for Vision to decode;
+        # inserting visual-density separators forces Code B and collapses the
+        # resized modules into an undecodable hairline pattern.
+        profile["inbody_barcode"] = {"payload_shaping": "raw"}
     return profile

--- a/scripts/render_synthetic_receipts.py
+++ b/scripts/render_synthetic_receipts.py
@@ -2428,6 +2428,18 @@ def _fit_1d_barcode_tile_to_box(tile, w_px: int, h_px: int):
     return gray
 
 
+def _fit_inbody_barcode_tile(tile, w_px: int, h_px: int, options: dict):
+    """Size an in-body barcode while retaining configured scanner margins."""
+    if not options.get("preserve_quiet_zone"):
+        return _fit_1d_barcode_tile_to_box(tile, w_px, h_px)
+    from PIL import Image
+
+    size = (max(1, int(w_px)), max(1, int(h_px)))
+    if tile.size != size:
+        return tile.resize(size, Image.NEAREST)
+    return tile
+
+
 def _hri_digits(text: str) -> str | None:
     """The digit string if ``text`` is a long human-readable barcode caption."""
     digits = re.sub(r"[^0-9]", "", str(text or ""))
@@ -2725,7 +2737,7 @@ def _overlay_inbody_barcodes(
         tile = receipt_graphics.render_barcode_tile(
             payload, ib["symbology"], bar_w, bar_h, with_hri=False
         )
-        tile = _fit_1d_barcode_tile_to_box(tile, bar_w, bar_h)
+        tile = _fit_inbody_barcode_tile(tile, bar_w, bar_h, ib)
         y_top = int(top - 6 - bar_h)
         _paste_graphic_tile(image, tile, int(cx - bar_w / 2), y_top)
         stamped_bands.append((float(y_top), float(top - 6)))

--- a/scripts/render_synthetic_receipts.py
+++ b/scripts/render_synthetic_receipts.py
@@ -2601,6 +2601,13 @@ def _visual_barcode_payload(digits: str, symbology: str) -> str:
     return "-".join(pair for pair in pairs if pair)
 
 
+def _inbody_barcode_payload(digits: str, options: dict) -> str:
+    """Return the configured data encoded by an HRI-derived barcode."""
+    if options.get("payload_from_hri"):
+        return digits
+    return _visual_barcode_payload(digits, options["symbology"])
+
+
 def graphics_for_merchant(merchant: str | None) -> dict:
     """Merchant graphics choices: the substring-default profile from
     receipt_graphics (barcode symbology / QR), overlaid with any explicit
@@ -2711,8 +2718,9 @@ def _overlay_inbody_barcodes(
             )
         )
         cx = (left + right) / 2.0
-        payload = _visual_barcode_payload(
-            digits[: ib["max_digits"]], ib["symbology"]
+        payload = _inbody_barcode_payload(
+            digits[: ib["max_digits"]],
+            ib,
         )
         tile = receipt_graphics.render_barcode_tile(
             payload, ib["symbology"], bar_w, bar_h, with_hri=False

--- a/scripts/render_synthetic_receipts.py
+++ b/scripts/render_synthetic_receipts.py
@@ -2614,10 +2614,14 @@ def _visual_barcode_payload(digits: str, symbology: str) -> str:
 
 
 def _inbody_barcode_payload(digits: str, options: dict) -> str:
-    """Return the configured data encoded by an HRI-derived barcode."""
+    """Select the configured scanner-safe HRI-derived payload."""
+    max_digits = int(options.get("max_digits", len(digits)))
+    raw = digits[:max_digits]
     if options.get("payload_from_hri"):
-        return digits
-    return _visual_barcode_payload(digits, options["symbology"])
+        return raw
+    if options.get("payload_shaping") == "raw":
+        return raw
+    return _visual_barcode_payload(raw, options["symbology"])
 
 
 def graphics_for_merchant(merchant: str | None) -> dict:
@@ -2731,7 +2735,7 @@ def _overlay_inbody_barcodes(
         )
         cx = (left + right) / 2.0
         payload = _inbody_barcode_payload(
-            digits[: ib["max_digits"]],
+            digits,
             ib,
         )
         tile = receipt_graphics.render_barcode_tile(

--- a/synthesis_loop/evidence/sprouts_graphics_green.md
+++ b/synthesis_loop/evidence/sprouts_graphics_green.md
@@ -1,0 +1,89 @@
+# Sprouts graphics fidelity: green proof
+
+## Root cause
+
+The fallback renderer found the 20-digit HRI and drew a bar field, but it did
+not encode the printed value:
+
+1. `scripts/render_synthetic_receipts.py` converted the exact HRI
+   `99022003402972471754` to a hyphenated visual-density surrogate.
+2. `python-barcode`'s Code128 optimizer interpreted a leading numeric data
+   pair of `99` as a charset-switch opcode and removed it. An isolated render
+   decoded as `022003402972471754`, proving that the symbol itself had lost the
+   first pair.
+3. After the normal crop and paper-texture passes, Vision could not decode the
+   hyphenated surrogate at all, producing the graphics red baseline.
+
+The renderer now keeps Sprouts' printed HRI as the Code128 payload and
+preserves a leading `99` data pair in the encoder. Other merchants retain the
+existing visual-density fallback.
+
+## Fidelity result
+
+The same read-only dev receipt and truth tuple from the red baseline were
+evaluated with:
+
+```text
+python synthesis_loop/full_fidelity_eval.py run \
+  "Sprouts Farmers Market" \
+  00ded398-af6f-4a49-86f7-c79ccb554e48 1 sprouts \
+  --out-root /tmp/sprouts-graphics-after --allow-dirty
+```
+
+Before:
+
+```text
+graphics FAIL
+real  = Code128 99022003402972471754
+synth = none
+```
+
+After:
+
+```text
+graphics PASS
+real  = Code128 99022003402972471754
+synth = Code128 99022003402972471754
+payload_match = true
+missing_in_synth = []
+phantom_in_synth = []
+```
+
+The passing guard metrics stayed green:
+
+```text
+tokens     PASS -> PASS
+logo       PASS -> PASS
+arithmetic PASS -> PASS
+```
+
+The full receipt remains overall `FAIL` only because the independent columns,
+style, and separators lanes are still red on this branch.
+
+## Regression guards
+
+```text
+pytest tests/test_render_systemic_fixes.py
+15 passed
+
+corpus_regression_gate.py check --json
+{"ok": true, "findings": []}
+
+render_regression_guard.py check /tmp/sprouts-graphics-render-guard
+costco_golden: byte-identical
+costco_new: byte-identical
+vons_golden: byte-identical
+sprouts: CHANGED (expected)
+```
+
+The intended Sprouts change is confined to the barcode box:
+
+```text
+baseline SHA256 d19f03193d9b808e6e89e022ebdd5daba60e75ff4b526051321e146e2807028b
+current  SHA256 f0d84b17e1c224b7d7039664fcf812e16e24c3cca81f72d454ac3c9d3bea3cf6
+changed bbox [194, 1633, 640, 1725]
+changed pixels 38181 / 1897720 (2.0119%)
+pixel MAD 2.019530
+```
+
+Formatting, focused MyPy, and focused Pylint checks also pass.

--- a/synthesis_loop/evidence/sprouts_graphics_protected_paper.md
+++ b/synthesis_loop/evidence/sprouts_graphics_protected_paper.md
@@ -1,0 +1,50 @@
+# Sprouts graphics: protected-paper integration proof
+
+## Integration red
+
+Combining the measured-column change `bd4cfa21f` with the initial graphics
+fix `026bbe2c4` enabled protected-paper texture. The synthetic barcode remained
+visible, but the production Vision detector returned no symbols:
+
+```text
+image: /tmp/sprouts-integration-3lanes/sprouts_eval/sprouts.syn.png
+graphics: FAIL
+real:  Code128 99022003402972471754
+synth: none
+```
+
+The exact Code128 payload fix was still present. The remaining failure was
+the in-body sizing pass: `_fit_1d_barcode_tile_to_box` cropped the generator's
+scanner quiet zones and stretched the bars across the complete target box.
+That symbol decoded at only `0.532922` confidence with the original texture
+and stopped decoding when protected-paper processing sharpened the paper/ink
+boundary.
+
+## Renderer hardening
+
+Sprouts now retains `python-barcode`'s quiet zones around its HRI-derived
+Code128 symbol. The existing crop-to-ink behavior remains the default for
+other merchant profiles, so their bytes are unchanged.
+
+A unit test asserts that both outer edges of the prepared Sprouts barcode are
+paper, preventing a future crop from silently removing the scanner margins.
+
+## Before and after
+
+| render mode | before | after | detector confidence |
+|---|---|---|---:|
+| original texture | PASS | PASS | 0.831938 |
+| protected paper (`bd4cfa21f`) | FAIL | PASS | 0.845623 |
+
+Both passing detections decode the exact payload:
+
+```text
+symbology: Code128
+payload: 99022003402972471754
+payload_match: true
+missing_in_synth: []
+phantom_in_synth: []
+```
+
+Tokens, logo, and arithmetic remain `PASS` in the standalone lane. The
+protected-paper integration run also keeps the measured columns `PASS`.

--- a/synthesis_loop/evidence/sprouts_graphics_red.md
+++ b/synthesis_loop/evidence/sprouts_graphics_red.md
@@ -1,0 +1,51 @@
+# Sprouts graphics fidelity: red baseline
+
+- renderer commit: `e517d33fdc043abfcbff5f70e87dfd21bccc8952`
+- merchant: `Sprouts Farmers Market`
+- receipt: `00ded398-af6f-4a49-86f7-c79ccb554e48#1`
+- truth: `sprouts_farmers_market` v1
+  `18dc387fbfd985fbc236e413ca051959613fe6e66c263f2a9a23fe67551cb74b`
+- table: read-only dev `ReceiptsTable-dc5be22`
+
+Command:
+
+```text
+python synthesis_loop/full_fidelity_eval.py run \
+  "Sprouts Farmers Market" \
+  00ded398-af6f-4a49-86f7-c79ccb554e48 1 sprouts \
+  --out-root /tmp/sprouts-graphics-before
+```
+
+Graphics result:
+
+```json
+{
+  "verdict": "FAIL",
+  "real": [
+    {
+      "kind": "1d",
+      "payload": "99022003402972471754",
+      "symbology": "code128",
+      "x_frac": 0.0,
+      "y_frac": 1.0
+    }
+  ],
+  "synth": [],
+  "matched": [],
+  "missing_in_synth": [
+    {
+      "kind": "1d",
+      "payload": "99022003402972471754",
+      "symbology": "code128",
+      "x_frac": 0.0,
+      "y_frac": 1.0
+    }
+  ],
+  "phantom_in_synth": []
+}
+```
+
+Passing guard metrics at the same baseline were tokens, logo, and
+arithmetic. The synthetic image visibly contained a barcode-like bar field
+above the matching HRI caption, but the production Vision detector decoded no
+symbol from it.

--- a/tests/test_render_systemic_fixes.py
+++ b/tests/test_render_systemic_fixes.py
@@ -12,6 +12,9 @@ import pytest
 
 pytest.importorskip("PIL")
 
+from receipt_agent.agents.label_evaluator.rendering import (  # noqa: E402
+    receipt_graphics,
+)
 from scripts import render_synthetic_receipts as rsr  # noqa: E402
 
 
@@ -165,3 +168,42 @@ class TestWordmarkSeedFilter:
         }
         cluster, _ = rsr._logo_wordmark_words(receipt)
         assert {w["text"] for w in cluster} == {"SPROUTS", "FARMERS"}
+
+
+class TestInbodyBarcodePayload:
+    """HRI-derived Code128 symbols must remain decodable and truthful."""
+
+    PAYLOAD = "99022003402972471754"
+
+    def test_code128_encoder_keeps_a_leading_99_data_pair(self):
+        symbol = receipt_graphics._barcode_symbol(  # pylint: disable=protected-access
+            self.PAYLOAD,
+            "code128",
+        )
+
+        # Code128 Start C (105) followed by the first data pair (99). The
+        # dependency's optimizer previously mistook that data pair for a
+        # charset-switch opcode and deleted it.
+        assert symbol.encoded[:2] == [105, 99]
+
+    def test_sprouts_preserves_the_hri_as_the_encoded_payload(self):
+        options = receipt_graphics.graphics_profile_for_merchant(
+            "Sprouts Farmers Market"
+        )["inbody_barcode"]
+
+        assert (
+            rsr._inbody_barcode_payload(  # pylint: disable=protected-access
+                self.PAYLOAD,
+                options,
+            )
+            == self.PAYLOAD
+        )
+
+    def test_other_inbody_barcodes_keep_the_density_shaping_default(self):
+        assert (
+            rsr._inbody_barcode_payload(  # pylint: disable=protected-access
+                "12345678901234",
+                {"symbology": "code128"},
+            )
+            == "12-34-56-78-90-12-34"
+        )

--- a/tests/test_render_systemic_fixes.py
+++ b/tests/test_render_systemic_fixes.py
@@ -199,6 +199,19 @@ class TestInbodyBarcodePayload:
             == self.PAYLOAD
         )
 
+    def test_vons_keeps_numeric_code128_for_scannable_modules(self):
+        profile = receipt_graphics.graphics_profile_for_merchant("Vons")
+        options = {
+            **rsr._INBODY_BARCODE_DEFAULTS,
+            **profile["inbody_barcode"],
+        }
+
+        payload = rsr._inbody_barcode_payload(
+            "00313505101552502031820", options
+        )
+
+        assert payload == "00313505101552502031820"
+
     def test_other_inbody_barcodes_keep_the_density_shaping_default(self):
         assert (
             rsr._inbody_barcode_payload(  # pylint: disable=protected-access

--- a/tests/test_render_systemic_fixes.py
+++ b/tests/test_render_systemic_fixes.py
@@ -207,3 +207,27 @@ class TestInbodyBarcodePayload:
             )
             == "12-34-56-78-90-12-34"
         )
+
+    def test_sprouts_keeps_scanner_quiet_zones_around_the_symbol(self):
+        options = receipt_graphics.graphics_profile_for_merchant(
+            "Sprouts Farmers Market"
+        )["inbody_barcode"]
+        tile = receipt_graphics.render_barcode_tile(
+            self.PAYLOAD,
+            "code128",
+            445,
+            84,
+            with_hri=False,
+        )
+
+        prepared = (
+            rsr._fit_inbody_barcode_tile(  # pylint: disable=protected-access
+                tile,
+                445,
+                84,
+                options,
+            ).convert("L")
+        )
+
+        assert prepared.crop((0, 0, 3, 84)).getextrema()[0] > 230
+        assert prepared.crop((442, 0, 445, 84)).getextrema()[0] > 230


### PR DESCRIPTION
## Summary
- preserve Sprouts' exact printed HRI as the Code128 payload
- avoid a leading-`99` optimizer ambiguity when building the symbol
- retain scanner quiet zones instead of cropping them during in-body sizing
- centralize merchant payload selection so Vons can use its raw numeric payload without duplicating renderer helpers or tests
- keep every other merchant on the existing density-shaping path

## Fidelity proof
Sprouts `00ded398-af6f-4a49-86f7-c79ccb554e48#1`, active truth v1 `18dc387f…`:

- graphics: **FAIL → PASS**
- real/synth payload: exact `99022003402972471754`
- missing/phantom: `1/0 → 0/0`
- detector confidence: marginal `0.533 → 0.832`; `0.846` with the column lane's protected-paper texture
- tokens, logo, arithmetic: remain PASS
- protected-paper integration also keeps columns PASS

Committed evidence:
- `synthesis_loop/evidence/sprouts_graphics_red.md`
- `synthesis_loop/evidence/sprouts_graphics_green.md`
- `synthesis_loop/evidence/sprouts_graphics_protected_paper.md`

## Guards
- 41 focused renderer/glyph tests passed on Python 3.12
- corpus regression gate: PASS, 0 findings
- render guard: Costco golden/new and Vons byte-identical before the Vons profile is enabled; Sprouts changed as expected
- black, isort, and `git diff --check`: clean

Dev DynamoDB was read-only; no gate record was written.

Draft only; do not merge until independent review and expanded CI complete.