### PR TITLE
[receipt_renderer] Preserve scannable Vons Code128

### DIFF
--- a/synthesis_loop/evidence/vons_v1_graphics.after.json
+++ b/synthesis_loop/evidence/vons_v1_graphics.after.json
@@ -1,0 +1,56 @@
+{
+  "receipt": "678a7c94-4948-4ebf-b8e9-9a17c13051ec#2",
+  "git_sha": "66f1d86457ae3f5c5529ba526266cf468b3e7d63",
+  "dirty": false,
+  "truth": {
+    "bundle_hash": "63775db497ae88a596847c2ddea69cfa1271eda40b755c1e2fae87b36da506cb",
+    "expected_bundle_hash": "63775db497ae88a596847c2ddea69cfa1271eda40b755c1e2fae87b36da506cb",
+    "expected_version": 1,
+    "mode": "online-active",
+    "slug": "vons",
+    "version": 1
+  },
+  "metric": {
+    "matched": [
+      {
+        "dy": 0.0,
+        "payload_match": true,
+        "real": {
+          "kind": "1d",
+          "payload": "00313505101552502031820",
+          "symbology": "code128",
+          "x_frac": 0.0,
+          "y_frac": 1.0
+        },
+        "synth": {
+          "kind": "1d",
+          "payload": "00313505101552502031820",
+          "symbology": "code128",
+          "x_frac": 0.0,
+          "y_frac": 1.0
+        }
+      }
+    ],
+    "missing_in_synth": [],
+    "phantom_in_synth": [],
+    "real": [
+      {
+        "kind": "1d",
+        "payload": "00313505101552502031820",
+        "symbology": "code128",
+        "x_frac": 0.0,
+        "y_frac": 1.0
+      }
+    ],
+    "synth": [
+      {
+        "kind": "1d",
+        "payload": "00313505101552502031820",
+        "symbology": "code128",
+        "x_frac": 0.0,
+        "y_frac": 1.0
+      }
+    ],
+    "verdict": "PASS"
+  }
+}

--- a/synthesis_loop/evidence/vons_v1_graphics.before.json
+++ b/synthesis_loop/evidence/vons_v1_graphics.before.json
@@ -1,0 +1,36 @@
+{
+  "receipt": "678a7c94-4948-4ebf-b8e9-9a17c13051ec#2",
+  "git_sha": "e517d33fdc043abfcbff5f70e87dfd21bccc8952",
+  "truth": {
+    "bundle_hash": "63775db497ae88a596847c2ddea69cfa1271eda40b755c1e2fae87b36da506cb",
+    "expected_bundle_hash": "63775db497ae88a596847c2ddea69cfa1271eda40b755c1e2fae87b36da506cb",
+    "expected_version": 1,
+    "mode": "online-active",
+    "slug": "vons",
+    "version": 1
+  },
+  "metric": {
+    "matched": [],
+    "missing_in_synth": [
+      {
+        "kind": "1d",
+        "payload": "00313505101552502031820",
+        "symbology": "code128",
+        "x_frac": 0.0,
+        "y_frac": 1.0
+      }
+    ],
+    "phantom_in_synth": [],
+    "real": [
+      {
+        "kind": "1d",
+        "payload": "00313505101552502031820",
+        "symbology": "code128",
+        "x_frac": 0.0,
+        "y_frac": 1.0
+      }
+    ],
+    "synth": [],
+    "verdict": "FAIL"
+  }
+}


### PR DESCRIPTION
## Summary
- keep Vons' inferred in-body transaction payload as raw numeric Code128 through the merchant profile centralized by #1245
- remove the duplicate renderer helper and duplicate test class that previously conflicted with #1245
- retain only Vons' committed red/green fidelity evidence in this child PR

## Fidelity proof
Golden: Vons `678a7c94-4948-4ebf-b8e9-9a17c13051ec#2`, ACTIVE truth v1 bundle `63775d…`.

- before graphics: **FAIL**; real Vision detector decoded Code128 `00313505101552502031820`, synth detector found no code
- after graphics: **PASS**; real and synth both decode the exact Code128 payload, with no missing or phantom symbols
- controls: tokens PASS and logo PASS
- remaining Vons reds are unrelated and handled in separate focused lanes

Evidence: `synthesis_loop/evidence/vons_v1_graphics.{before,after}.json`.

## Stack
This is intentionally a minimal same-topic child of #1245. The executable implementation and shared coverage live in #1245; this PR contributes only the Vons red/green evidence and should be retargeted to `main` after #1245 lands.

## Verification
- 41 focused renderer/glyph tests passed on Python 3.12 against the stacked result
- diff versus #1245 is exactly the two Vons evidence JSON files
- black, isort, and `git diff --check`: clean
- no DynamoDB writes

Draft only; do not merge until #1245 has independent review and expanded CI is green.