### PR TITLE
[synthesis_loop] Ignore storefront photo-edge artifacts

### DIFF
--- a/synthesis_loop/evidence/trader_joe_s_v1_logo.after.json
+++ b/synthesis_loop/evidence/trader_joe_s_v1_logo.after.json
@@ -1,0 +1,34 @@
+{
+  "receipt": "4c262079-4fec-4724-a8e1-2886f38ea454#1",
+  "git_sha": "7040f886820330e522207b799e1fedb67934d6e8",
+  "dirty": false,
+  "truth": {
+    "bundle_hash": "557c433fcc1e5d74ca66a54f194cf4deca9e39976d26412dc0e1b5ebd778c418",
+    "expected_bundle_hash": "557c433fcc1e5d74ca66a54f194cf4deca9e39976d26412dc0e1b5ebd778c418",
+    "expected_version": 1,
+    "mode": "online-active",
+    "slug": "trader_joe_s",
+    "version": 1
+  },
+  "metric": {
+    "area_ratio": 1.173,
+    "center_offset_frac": 0.0329,
+    "real": {
+      "area": 18139.0,
+      "cx": 410.5,
+      "cy": 48.0,
+      "h": 69.0,
+      "w": 612.0
+    },
+    "size_ratio": 0.971,
+    "synth": {
+      "area": 21272.0,
+      "cx": 385.5,
+      "cy": 55.0,
+      "h": 67.0,
+      "w": 600.0
+    },
+    "verdict": "PASS",
+    "width_ratio": 0.98
+  }
+}

--- a/synthesis_loop/evidence/trader_joe_s_v1_logo.before.json
+++ b/synthesis_loop/evidence/trader_joe_s_v1_logo.before.json
@@ -1,0 +1,33 @@
+{
+  "receipt": "4c262079-4fec-4724-a8e1-2886f38ea454#1",
+  "git_sha": "e517d33fdc043abfcbff5f70e87dfd21bccc8952",
+  "truth": {
+    "bundle_hash": "557c433fcc1e5d74ca66a54f194cf4deca9e39976d26412dc0e1b5ebd778c418",
+    "expected_bundle_hash": "557c433fcc1e5d74ca66a54f194cf4deca9e39976d26412dc0e1b5ebd778c418",
+    "expected_version": 1,
+    "mode": "online-active",
+    "slug": "trader_joe_s",
+    "version": 1
+  },
+  "metric": {
+    "area_ratio": 0.313,
+    "center_offset_frac": 0.2158,
+    "real": {
+      "area": 13912.0,
+      "cx": 30.5,
+      "cy": 118.5,
+      "h": 238.0,
+      "w": 62.0
+    },
+    "size_ratio": 0.265,
+    "synth": {
+      "area": 4360.0,
+      "cx": 194.5,
+      "cy": 54.0,
+      "h": 63.0,
+      "w": 116.0
+    },
+    "verdict": "FAIL",
+    "width_ratio": 1.871
+  }
+}

--- a/synthesis_loop/full_fidelity_eval.py
+++ b/synthesis_loop/full_fidelity_eval.py
@@ -1996,6 +1996,7 @@ def load_section_sequence(
     """
     try:
         from glyphstudio.sections import is_canonical_section
+
         from receipt_dynamo.data.dynamo_client import DynamoClient
 
         table = os.environ.get("DYNAMODB_TABLE_NAME", "ReceiptsTable-dc5be22")

--- a/synthesis_loop/full_fidelity_eval.py
+++ b/synthesis_loop/full_fidelity_eval.py
@@ -1551,7 +1551,14 @@ def metric_graphics(real_png: str, syn_png: str) -> dict:
 # metric 6: logo presence / size / offset
 # ---------------------------------------------------------------------------
 def _largest_blob(gray: np.ndarray) -> dict | None:
-    """Largest 8-connected ink component in a band (pure-numpy label pass)."""
+    """Dominant same-line logo envelope in a storefront band.
+
+    Receipt photos can carry a dark scanner edge through the full storefront
+    band.  A raw largest-component rule mistakes that substrate for the logo.
+    Reject tall edge-connected strips, then merge substantial components on the
+    dominant component's visual row so disconnected wordmark letters are
+    measured as one logo rather than one arbitrary glyph.
+    """
     thresh = paper_threshold(gray)
     ink = (gray < thresh).astype(np.int32)
     if int(ink.sum()) < 16:
@@ -1559,7 +1566,7 @@ def _largest_blob(gray: np.ndarray) -> dict | None:
     H, W = ink.shape
     labels = np.zeros((H, W), dtype=np.int32)
     next_label = 0
-    best = None
+    components = []
     stack: list[tuple[int, int]] = []
     for sy in range(H):
         for sx in range(W):
@@ -1587,15 +1594,57 @@ def _largest_blob(gray: np.ndarray) -> dict | None:
                         ):
                             labels[ny, nx] = next_label
                             stack.append((ny, nx))
-            if best is None or n > best["area"]:
-                best = {
+            components.append(
+                {
                     "area": n,
+                    "x0": x0,
+                    "x1": x1,
+                    "y0": y0,
+                    "y1": y1,
                     "w": x1 - x0 + 1,
                     "h": y1 - y0 + 1,
                     "cx": (x0 + x1) / 2.0,
                     "cy": (y0 + y1) / 2.0,
                 }
-    return best
+            )
+    usable = [
+        component
+        for component in components
+        if not (
+            component["h"] >= 0.55 * H
+            and (component["x0"] <= 1 or component["x1"] >= W - 2)
+        )
+    ]
+    if not usable:
+        usable = components
+    anchor = max(usable, key=lambda component: component["area"])
+    min_area = max(4, int(round(0.015 * anchor["area"])))
+
+    def same_visual_row(component: dict) -> bool:
+        overlap = max(
+            0,
+            min(anchor["y1"], component["y1"])
+            - max(anchor["y0"], component["y0"])
+            + 1,
+        )
+        return (
+            component["area"] >= min_area
+            and component["h"] >= 0.25 * anchor["h"]
+            and overlap >= 0.30 * min(anchor["h"], component["h"])
+        )
+
+    row = [component for component in usable if same_visual_row(component)]
+    x0 = min(component["x0"] for component in row)
+    x1 = max(component["x1"] for component in row)
+    y0 = min(component["y0"] for component in row)
+    y1 = max(component["y1"] for component in row)
+    return {
+        "area": sum(component["area"] for component in row),
+        "w": x1 - x0 + 1,
+        "h": y1 - y0 + 1,
+        "cx": (x0 + x1) / 2.0,
+        "cy": (y0 + y1) / 2.0,
+    }
 
 
 def metric_logo(

--- a/tests/test_full_fidelity_eval.py
+++ b/tests/test_full_fidelity_eval.py
@@ -368,6 +368,22 @@ def test_logo_metric_flags_missing_and_offset():
     assert out3["verdict"] == "PASS"
 
 
+def test_logo_metric_ignores_photo_edge_and_merges_wordmark_letters():
+    real = blank()
+    stamp(real, 0, 0, 30, 45)  # scanner/photo edge, not storefront ink
+    for left in (100, 150, 200):
+        stamp(real, left, 10, left + 30, 31)
+    synth = blank()
+    for left in (103, 151, 199):
+        stamp(synth, left, 11, left + 29, 31)
+
+    out = ffe.metric_logo(real, synth, (0.0, 0.15), expects_logo=True)
+
+    assert out["verdict"] == "PASS", out
+    assert out["real"]["w"] == 130
+    assert out["real"]["cx"] == 164.5
+
+
 # ---------------------------------------------------------------------------
 # arithmetic
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- reject tall edge-connected scanner/photo strips from storefront logo measurement
- merge substantial same-row components so disconnected wordmark letters are measured as one logo
- preserve the existing mass, size, width, and center fidelity gates
- add a regression fixture and exact Trader Joe's red/green evidence

## Fidelity proof

Golden: Trader Joe's `4c262079-4fec-4724-a8e1-2886f38ea454#1`, ACTIVE truth v1 bundle `557c43…`.

- before logo: FAIL; the judge selected the photograph's black left strip (`62x238`, center x `30.5`) instead of the wordmark
- after logo: PASS; real wordmark envelope `612x69`, synth `600x67`; height ratio `0.971`, width ratio `0.980`, area ratio `1.173`, center offset `0.0329`
- Vons and Gelson logo diagnostics remain PASS under the corrected component logic
- remaining Trader Joe's reds are renderer style/separator concerns handled separately

Evidence: `synthesis_loop/evidence/trader_joe_s_v1_logo.{before,after}.json`.

## Verification

- `tests/test_full_fidelity_eval.py`: 38 passed
- corpus regression gate: PASS, zero findings
- render regression guard: all four pinned renders byte-identical
- `git diff --check`: clean
- no DynamoDB writes

Draft only; do not merge until independent review completes.