### PR TITLE
[receipt_renderer] Recover grocery structural separators

### DIFF
--- a/evidence/grocery_structural_gap_separators/RESULT.md
+++ b/evidence/grocery_structural_gap_separators/RESULT.md
@@ -1,0 +1,30 @@
+# Grocery structural-gap separator evidence
+
+The renderer now recognizes generic POS section transitions in whitespace that
+the source OCR preserved, and prints dash glyphs at the measured gap midpoint.
+It does not add line pitch or shift any OCR row.
+
+## Metric proof
+
+| Receipt | Before | After |
+|---|---|---|
+| Vons `678a7c94-4948-4ebf-b8e9-9a17c13051ec#2` | FAIL: real 3, synth 0 | PASS: 3/3 matched; y deltas 0.0015, 0.0044, 0.0000 |
+| Trader Joe's `4c262079-4fec-4724-a8e1-2886f38ea454#1` | FAIL: real 1, synth 0 | PASS: 1/1 matched; y delta 0.0010 |
+
+For both receipts, the complete non-separator portions of the check JSON are
+byte-identical before and after. The exact full-fidelity evaluations still
+report overall FAIL only because other focused lanes own their pre-existing red
+metrics.
+
+## Guard proof
+
+- Focused renderer tests: 26 passed
+  (`test_receipt_gap_separators.py` + `test_glyph_renderer.py`).
+- `synthesis_loop/corpus_regression_gate.py check --json`: `ok: true`,
+  zero findings.
+- `synthesis_loop/render_regression_guard.py check`: both Costco pins and the
+  Sprouts pin are byte-identical. The only changed pin is the intended Vons
+  target whose missing separators this lane fixes.
+
+All full-fidelity and guard runs used read-only dev table
+`ReceiptsTable-dc5be22`; no gate record was written.

--- a/evidence/grocery_structural_gap_separators/RESULT.md
+++ b/evidence/grocery_structural_gap_separators/RESULT.md
@@ -11,20 +11,47 @@ It does not add line pitch or shift any OCR row.
 | Vons `678a7c94-4948-4ebf-b8e9-9a17c13051ec#2` | FAIL: real 3, synth 0 | PASS: 3/3 matched; y deltas 0.0015, 0.0044, 0.0000 |
 | Trader Joe's `4c262079-4fec-4724-a8e1-2886f38ea454#1` | FAIL: real 1, synth 0 | PASS: 1/1 matched; y delta 0.0010 |
 
-For both receipts, the complete non-separator portions of the check JSON are
-byte-identical before and after. The exact full-fidelity evaluations still
-report overall FAIL only because other focused lanes own their pre-existing red
-metrics.
+Both sides of this pair were re-derived on 2026-07-27 after the rebase.
+`before/` is measured at `1d0dd32f5` (main without this branch); `after/` is
+measured at `63cc32906`, this branch's renderer commit. The two runs share a
+worktree, atlas (`atlas_hash`), and inputs (`inputs_hash`), so the renderer
+change is the only variable.
+
+Every check section is byte-identical before and after except `separators`:
+`columns`, `style`, `tokens`, `graphics`, `logo`, `arithmetic`, and
+`coverage_gaps` all match exactly. Trader Joe's `overall` moves FAIL ->
+PASS_WITH_GAPS purely because its separator lane clears. Vons stays FAIL because
+its `style` lane owns a pre-existing red metric this branch does not touch.
+
+`graphics` was measured with the Swift `receipt-ocr` barcode detector built and
+present, so the barcode inventory is genuinely compared on both sides rather
+than skipped.
 
 ## Guard proof
 
-- Focused renderer tests: 26 passed
-  (`test_receipt_gap_separators.py` + `test_glyph_renderer.py`).
-- `synthesis_loop/corpus_regression_gate.py check --json`: `ok: true`,
-  zero findings.
-- `synthesis_loop/render_regression_guard.py check`: both Costco pins and the
-  Sprouts pin are byte-identical. The only changed pin is the intended Vons
-  target whose missing separators this lane fixes.
+- Focused renderer tests: `test_receipt_gap_separators.py` (this branch),
+  `test_receipt_renderer_separators.py` (#1258 / #1243), and
+  `tests/test_render_measured_separators.py` — 10 passed together, so the
+  structural-gap source coexists with the measured-inventory and
+  inferred-policy sources rather than replacing them.
+- Full `receipt_agent` suite: 340 passed, 22 skipped. Five `test_llm_factory.py`
+  failures seen locally come from a missing `langchain_openai` in the local venv
+  and reproduce identically on unmodified `origin/main`.
+- `synthesis_loop/corpus_regression_gate.py check --json`: `ok: true`, zero
+  findings, re-run on the rebased head.
 
-All full-fidelity and guard runs used read-only dev table
-`ReceiptsTable-dc5be22`; no gate record was written.
+`render_regression_guard.py check` is deliberately NOT claimed here. On this
+machine that guard reports all four committed pins as CHANGED on unmodified
+`origin/main`, so its baseline is stale independently of this branch. #1260
+recaptures it; this branch cannot be measured against it until that lands.
+
+## Rebase note (2026-07-27)
+
+Rebased onto `origin/main` after #1258 landed measured separator inventories in
+the same renderer region. Conflicts were resolved by keeping every separator
+source side by side. The structural-gap source is now gated on
+`config.separators is None`, matching the rule #1258 established for the other
+heuristic sources: a measured merchant-truth inventory wins over any heuristic.
+
+All full-fidelity and gate runs used read-only dev table `ReceiptsTable-dc5be22`;
+no gate record was written.

--- a/evidence/grocery_structural_gap_separators/after/trader_joe_s.checks.json
+++ b/evidence/grocery_structural_gap_separators/after/trader_joe_s.checks.json
@@ -1,0 +1,217 @@
+{
+ "checks": {
+  "arithmetic": {
+   "identities": [
+    {
+     "detail": "",
+     "lhs": 63.66,
+     "name": "total_eq_tender",
+     "rhs": 63.66,
+     "status": "HOLDS"
+    }
+   ],
+   "n_items": 15,
+   "summary": {
+    "tender": 63.66,
+    "total": 63.66
+   },
+   "testable": 1,
+   "verdict": "PASS",
+   "violated": 0
+  },
+  "columns": {
+   "bands": {
+    "ALL": {
+     "cell_w_px": 16.61,
+     "columns": [
+      {
+       "abs_drift_limit_px": 24.91,
+       "abs_drift_px": 1.0,
+       "column": {
+        "anchor": "right",
+        "role": "amount",
+        "spread": 0.0003,
+        "support": 17,
+        "x": 0.9811
+       },
+       "outlier_limit": 0.15,
+       "real": {
+        "lane_mid_y_px": 814.5,
+        "lane_x_px": 740.62,
+        "median_dev_px": -5.64,
+        "n_rows": 17,
+        "outlier_frac": 0.0,
+        "tilt_px_per_100px": 0.976,
+        "wobble_iqr_px": 0.65
+       },
+       "shear_px_per_100px": 1.57,
+       "synth": {
+        "lane_mid_y_px": 814.5,
+        "lane_x_px": 738.63,
+        "median_dev_px": -6.64,
+        "n_rows": 17,
+        "outlier_frac": 0.0,
+        "tilt_px_per_100px": -0.592,
+        "wobble_iqr_px": 0.27
+       },
+       "verdict": "PASS",
+       "wobble_limit_px": 3.8
+      }
+     ],
+     "lane_gaps": [],
+     "source": "bootstrap",
+     "untested_roles": [],
+     "verdict": "PASS"
+    }
+   },
+   "verdict": "PASS"
+  },
+  "coverage_gaps": [
+   "style:total_line"
+  ],
+  "graphics": {
+   "matched": [],
+   "missing_in_synth": [],
+   "phantom_in_synth": [],
+   "real": [],
+   "synth": [],
+   "verdict": "PASS"
+  },
+  "logo": {
+   "area_ratio": 0.313,
+   "center_offset_frac": 0.2158,
+   "real": {
+    "area": 13912.0,
+    "cx": 30.5,
+    "cy": 118.5,
+    "h": 238.0,
+    "w": 62.0
+   },
+   "size_ratio": 0.265,
+   "synth": {
+    "area": 4360.0,
+    "cx": 194.5,
+    "cy": 54.0,
+    "h": 63.0,
+    "w": 116.0
+   },
+   "verdict": "FAIL",
+   "width_ratio": 1.871
+  },
+  "overall": "FAIL",
+  "separators": {
+   "kind_mismatches": 0,
+   "matched": [
+    {
+     "dy": 0.001,
+     "real": {
+      "height_px": 2,
+      "kind": "dash",
+      "y_frac": 0.582
+     },
+     "synth": {
+      "height_px": 2,
+      "kind": "dash",
+      "y_frac": 0.583
+     }
+    }
+   ],
+   "missing_in_synth": [],
+   "phantom_in_synth": [],
+   "real_count": 1,
+   "synth_count": 1,
+   "verdict": "PASS"
+  },
+  "style": {
+   "body_stroke_fail": false,
+   "body_stroke_rel": {
+    "real": 0.1068,
+    "synth": 0.1068
+   },
+   "classes": [
+    {
+     "class": "footer",
+     "missing_style": [
+      "bold"
+     ],
+     "real": {
+      "bold": 1,
+      "n": 2,
+      "underline": 0
+     },
+     "synth": {
+      "bold": 0,
+      "n": 2,
+      "underline": 0
+     },
+     "verdict": "FAIL"
+    },
+    {
+     "class": "payment",
+     "real": {
+      "bold": 0,
+      "n": 5,
+      "underline": 0
+     },
+     "synth": {
+      "bold": 0,
+      "n": 5,
+      "underline": 0
+     },
+     "verdict": "PASS"
+    },
+    {
+     "class": "total_line",
+     "real": {
+      "bold": 0,
+      "n": 1,
+      "underline": 0
+     },
+     "synth": {
+      "bold": 0,
+      "n": 1,
+      "underline": 0
+     },
+     "verdict": "UNTESTED"
+    }
+   ],
+   "untested_classes": [
+    "total_line"
+   ],
+   "verdict": "FAIL"
+  },
+  "tokens": {
+   "composed": false,
+   "ink_checked": 138,
+   "ink_evidence_missing": false,
+   "ink_missing_tokens": [
+    "REPRINT"
+   ],
+   "ink_recall": 0.9928,
+   "missing_tokens": [],
+   "precision_warn": false,
+   "text_precision": 1.0,
+   "text_recall": 1.0,
+   "verdict": "PASS"
+  }
+ },
+ "image_id": "4c262079-4fec-4724-a8e1-2886f38ea454",
+ "mode": "real-vs-synth",
+ "receipt_id": 1,
+ "slug": "trader_joe_s",
+ "stamp": {
+  "atlas_hash": "037dc0610504a9b9",
+  "dirty": false,
+  "git_sha": "894a903ff600b143631f276a4b9426dc45858644",
+  "inputs_hash": "039c90fb79c13eca",
+  "merchant": "Trader Joe's",
+  "merchant_truth": {
+   "bundle_hash": "557c433fcc1e5d74ca66a54f194cf4deca9e39976d26412dc0e1b5ebd778c418",
+   "expected_bundle_hash": "557c433fcc1e5d74ca66a54f194cf4deca9e39976d26412dc0e1b5ebd778c418",
+   "expected_version": 1,
+   "mode": "online-active",
+   "slug": "trader_joe_s",
+   "version": 1
+  }
+ }
+}

--- a/evidence/grocery_structural_gap_separators/after/trader_joe_s.checks.json
+++ b/evidence/grocery_structural_gap_separators/after/trader_joe_s.checks.json
@@ -10,7 +10,7 @@
      "status": "HOLDS"
     }
    ],
-   "n_items": 15,
+   "n_items": 14,
    "summary": {
     "tender": 63.66,
     "total": 63.66
@@ -46,13 +46,13 @@
        },
        "shear_px_per_100px": 1.57,
        "synth": {
-        "lane_mid_y_px": 814.5,
-        "lane_x_px": 738.63,
+        "lane_mid_y_px": 823.0,
+        "lane_x_px": 738.65,
         "median_dev_px": -6.64,
         "n_rows": 17,
         "outlier_frac": 0.0,
-        "tilt_px_per_100px": -0.592,
-        "wobble_iqr_px": 0.27
+        "tilt_px_per_100px": -0.599,
+        "wobble_iqr_px": 0.29
        },
        "verdict": "PASS",
        "wobble_limit_px": 3.8
@@ -67,6 +67,7 @@
    "verdict": "PASS"
   },
   "coverage_gaps": [
+   "style",
    "style:total_line"
   ],
   "graphics": {
@@ -78,27 +79,27 @@
    "verdict": "PASS"
   },
   "logo": {
-   "area_ratio": 0.313,
-   "center_offset_frac": 0.2158,
+   "area_ratio": 1.173,
+   "center_offset_frac": 0.0329,
    "real": {
-    "area": 13912.0,
-    "cx": 30.5,
-    "cy": 118.5,
-    "h": 238.0,
-    "w": 62.0
+    "area": 18139.0,
+    "cx": 410.5,
+    "cy": 48.0,
+    "h": 69.0,
+    "w": 612.0
    },
-   "size_ratio": 0.265,
+   "size_ratio": 0.971,
    "synth": {
-    "area": 4360.0,
-    "cx": 194.5,
-    "cy": 54.0,
-    "h": 63.0,
-    "w": 116.0
+    "area": 21272.0,
+    "cx": 385.5,
+    "cy": 55.0,
+    "h": 67.0,
+    "w": 600.0
    },
-   "verdict": "FAIL",
-   "width_ratio": 1.871
+   "verdict": "PASS",
+   "width_ratio": 0.98
   },
-  "overall": "FAIL",
+  "overall": "PASS_WITH_GAPS",
   "separators": {
    "kind_mismatches": 0,
    "matched": [
@@ -126,25 +127,22 @@
    "body_stroke_fail": false,
    "body_stroke_rel": {
     "real": 0.1068,
-    "synth": 0.1068
+    "synth": 0.1565
    },
    "classes": [
     {
      "class": "footer",
-     "missing_style": [
-      "bold"
-     ],
      "real": {
       "bold": 1,
       "n": 2,
       "underline": 0
      },
      "synth": {
-      "bold": 0,
+      "bold": 1,
       "n": 2,
       "underline": 0
      },
-     "verdict": "FAIL"
+     "verdict": "PASS"
     },
     {
      "class": "payment",
@@ -178,16 +176,14 @@
    "untested_classes": [
     "total_line"
    ],
-   "verdict": "FAIL"
+   "verdict": "PASS_WITH_GAPS"
   },
   "tokens": {
    "composed": false,
    "ink_checked": 138,
    "ink_evidence_missing": false,
-   "ink_missing_tokens": [
-    "REPRINT"
-   ],
-   "ink_recall": 0.9928,
+   "ink_missing_tokens": [],
+   "ink_recall": 1.0,
    "missing_tokens": [],
    "precision_warn": false,
    "text_precision": 1.0,
@@ -202,8 +198,8 @@
  "stamp": {
   "atlas_hash": "037dc0610504a9b9",
   "dirty": false,
-  "git_sha": "894a903ff600b143631f276a4b9426dc45858644",
-  "inputs_hash": "039c90fb79c13eca",
+  "git_sha": "63cc32906b9c861b144e825dee074accaad3b4a4",
+  "inputs_hash": "0587f5d3daefdda2",
   "merchant": "Trader Joe's",
   "merchant_truth": {
    "bundle_hash": "557c433fcc1e5d74ca66a54f194cf4deca9e39976d26412dc0e1b5ebd778c418",

--- a/evidence/grocery_structural_gap_separators/after/trader_joe_s.report.md
+++ b/evidence/grocery_structural_gap_separators/after/trader_joe_s.report.md
@@ -1,0 +1,218 @@
+# full_fidelity_eval -- trader_joe_s
+
+- merchant: Trader Joe's
+- receipt: 4c262079-4fec-4724-a8e1-2886f38ea454#1
+- git: `894a903ff600`
+- truth: `trader_joe_s` v1 `557c433fcc1e5d74ca66a54f194cf4deca9e39976d26412dc0e1b5ebd778c418` (online-active)
+- atlas: `037dc0610504a9b9`
+
+## OVERALL: FAIL
+
+| metric | verdict |
+|---|---|
+| columns | PASS |
+| style | FAIL |
+| tokens | PASS |
+| separators | PASS |
+| graphics | PASS |
+| logo | FAIL |
+| arithmetic | PASS |
+
+```json
+{
+ "arithmetic": {
+  "identities": [
+   {
+    "detail": "",
+    "lhs": 63.66,
+    "name": "total_eq_tender",
+    "rhs": 63.66,
+    "status": "HOLDS"
+   }
+  ],
+  "n_items": 15,
+  "summary": {
+   "tender": 63.66,
+   "total": 63.66
+  },
+  "testable": 1,
+  "verdict": "PASS",
+  "violated": 0
+ },
+ "columns": {
+  "bands": {
+   "ALL": {
+    "cell_w_px": 16.61,
+    "columns": [
+     {
+      "abs_drift_limit_px": 24.91,
+      "abs_drift_px": 1.0,
+      "column": {
+       "anchor": "right",
+       "role": "amount",
+       "spread": 0.0003,
+       "support": 17,
+       "x": 0.9811
+      },
+      "outlier_limit": 0.15,
+      "real": {
+       "lane_mid_y_px": 814.5,
+       "lane_x_px": 740.62,
+       "median_dev_px": -5.64,
+       "n_rows": 17,
+       "outlier_frac": 0.0,
+       "tilt_px_per_100px": 0.976,
+       "wobble_iqr_px": 0.65
+      },
+      "shear_px_per_100px": 1.57,
+      "synth": {
+       "lane_mid_y_px": 814.5,
+       "lane_x_px": 738.63,
+       "median_dev_px": -6.64,
+       "n_rows": 17,
+       "outlier_frac": 0.0,
+       "tilt_px_per_100px": -0.592,
+       "wobble_iqr_px": 0.27
+      },
+      "verdict": "PASS",
+      "wobble_limit_px": 3.8
+     }
+    ],
+    "lane_gaps": [],
+    "source": "bootstrap",
+    "untested_roles": [],
+    "verdict": "PASS"
+   }
+  },
+  "verdict": "PASS"
+ },
+ "coverage_gaps": [
+  "style:total_line"
+ ],
+ "graphics": {
+  "matched": [],
+  "missing_in_synth": [],
+  "phantom_in_synth": [],
+  "real": [],
+  "synth": [],
+  "verdict": "PASS"
+ },
+ "logo": {
+  "area_ratio": 0.313,
+  "center_offset_frac": 0.2158,
+  "real": {
+   "area": 13912.0,
+   "cx": 30.5,
+   "cy": 118.5,
+   "h": 238.0,
+   "w": 62.0
+  },
+  "size_ratio": 0.265,
+  "synth": {
+   "area": 4360.0,
+   "cx": 194.5,
+   "cy": 54.0,
+   "h": 63.0,
+   "w": 116.0
+  },
+  "verdict": "FAIL",
+  "width_ratio": 1.871
+ },
+ "overall": "FAIL",
+ "separators": {
+  "kind_mismatches": 0,
+  "matched": [
+   {
+    "dy": 0.001,
+    "real": {
+     "height_px": 2,
+     "kind": "dash",
+     "y_frac": 0.582
+    },
+    "synth": {
+     "height_px": 2,
+     "kind": "dash",
+     "y_frac": 0.583
+    }
+   }
+  ],
+  "missing_in_synth": [],
+  "phantom_in_synth": [],
+  "real_count": 1,
+  "synth_count": 1,
+  "verdict": "PASS"
+ },
+ "style": {
+  "body_stroke_fail": false,
+  "body_stroke_rel": {
+   "real": 0.1068,
+   "synth": 0.1068
+  },
+  "classes": [
+   {
+    "class": "footer",
+    "missing_style": [
+     "bold"
+    ],
+    "real": {
+     "bold": 1,
+     "n": 2,
+     "underline": 0
+    },
+    "synth": {
+     "bold": 0,
+     "n": 2,
+     "underline": 0
+    },
+    "verdict": "FAIL"
+   },
+   {
+    "class": "payment",
+    "real": {
+     "bold": 0,
+     "n": 5,
+     "underline": 0
+    },
+    "synth": {
+     "bold": 0,
+     "n": 5,
+     "underline": 0
+    },
+    "verdict": "PASS"
+   },
+   {
+    "class": "total_line",
+    "real": {
+     "bold": 0,
+     "n": 1,
+     "underline": 0
+    },
+    "synth": {
+     "bold": 0,
+     "n": 1,
+     "underline": 0
+    },
+    "verdict": "UNTESTED"
+   }
+  ],
+  "untested_classes": [
+   "total_line"
+  ],
+  "verdict": "FAIL"
+ },
+ "tokens": {
+  "composed": false,
+  "ink_checked": 138,
+  "ink_evidence_missing": false,
+  "ink_missing_tokens": [
+   "REPRINT"
+  ],
+  "ink_recall": 0.9928,
+  "missing_tokens": [],
+  "precision_warn": false,
+  "text_precision": 1.0,
+  "text_recall": 1.0,
+  "verdict": "PASS"
+ }
+}
+```

--- a/evidence/grocery_structural_gap_separators/after/trader_joe_s.report.md
+++ b/evidence/grocery_structural_gap_separators/after/trader_joe_s.report.md
@@ -2,20 +2,20 @@
 
 - merchant: Trader Joe's
 - receipt: 4c262079-4fec-4724-a8e1-2886f38ea454#1
-- git: `894a903ff600`
+- git: `63cc32906b9c`
 - truth: `trader_joe_s` v1 `557c433fcc1e5d74ca66a54f194cf4deca9e39976d26412dc0e1b5ebd778c418` (online-active)
 - atlas: `037dc0610504a9b9`
 
-## OVERALL: FAIL
+## OVERALL: PASS_WITH_GAPS
 
 | metric | verdict |
 |---|---|
 | columns | PASS |
-| style | FAIL |
+| style | PASS_WITH_GAPS |
 | tokens | PASS |
 | separators | PASS |
 | graphics | PASS |
-| logo | FAIL |
+| logo | PASS |
 | arithmetic | PASS |
 
 ```json
@@ -30,7 +30,7 @@
     "status": "HOLDS"
    }
   ],
-  "n_items": 15,
+  "n_items": 14,
   "summary": {
    "tender": 63.66,
    "total": 63.66
@@ -66,13 +66,13 @@
       },
       "shear_px_per_100px": 1.57,
       "synth": {
-       "lane_mid_y_px": 814.5,
-       "lane_x_px": 738.63,
+       "lane_mid_y_px": 823.0,
+       "lane_x_px": 738.65,
        "median_dev_px": -6.64,
        "n_rows": 17,
        "outlier_frac": 0.0,
-       "tilt_px_per_100px": -0.592,
-       "wobble_iqr_px": 0.27
+       "tilt_px_per_100px": -0.599,
+       "wobble_iqr_px": 0.29
       },
       "verdict": "PASS",
       "wobble_limit_px": 3.8
@@ -87,6 +87,7 @@
   "verdict": "PASS"
  },
  "coverage_gaps": [
+  "style",
   "style:total_line"
  ],
  "graphics": {
@@ -98,27 +99,27 @@
   "verdict": "PASS"
  },
  "logo": {
-  "area_ratio": 0.313,
-  "center_offset_frac": 0.2158,
+  "area_ratio": 1.173,
+  "center_offset_frac": 0.0329,
   "real": {
-   "area": 13912.0,
-   "cx": 30.5,
-   "cy": 118.5,
-   "h": 238.0,
-   "w": 62.0
+   "area": 18139.0,
+   "cx": 410.5,
+   "cy": 48.0,
+   "h": 69.0,
+   "w": 612.0
   },
-  "size_ratio": 0.265,
+  "size_ratio": 0.971,
   "synth": {
-   "area": 4360.0,
-   "cx": 194.5,
-   "cy": 54.0,
-   "h": 63.0,
-   "w": 116.0
+   "area": 21272.0,
+   "cx": 385.5,
+   "cy": 55.0,
+   "h": 67.0,
+   "w": 600.0
   },
-  "verdict": "FAIL",
-  "width_ratio": 1.871
+  "verdict": "PASS",
+  "width_ratio": 0.98
  },
- "overall": "FAIL",
+ "overall": "PASS_WITH_GAPS",
  "separators": {
   "kind_mismatches": 0,
   "matched": [
@@ -146,25 +147,22 @@
   "body_stroke_fail": false,
   "body_stroke_rel": {
    "real": 0.1068,
-   "synth": 0.1068
+   "synth": 0.1565
   },
   "classes": [
    {
     "class": "footer",
-    "missing_style": [
-     "bold"
-    ],
     "real": {
      "bold": 1,
      "n": 2,
      "underline": 0
     },
     "synth": {
-     "bold": 0,
+     "bold": 1,
      "n": 2,
      "underline": 0
     },
-    "verdict": "FAIL"
+    "verdict": "PASS"
    },
    {
     "class": "payment",
@@ -198,16 +196,14 @@
   "untested_classes": [
    "total_line"
   ],
-  "verdict": "FAIL"
+  "verdict": "PASS_WITH_GAPS"
  },
  "tokens": {
   "composed": false,
   "ink_checked": 138,
   "ink_evidence_missing": false,
-  "ink_missing_tokens": [
-   "REPRINT"
-  ],
-  "ink_recall": 0.9928,
+  "ink_missing_tokens": [],
+  "ink_recall": 1.0,
   "missing_tokens": [],
   "precision_warn": false,
   "text_precision": 1.0,

--- a/evidence/grocery_structural_gap_separators/after/vons.checks.json
+++ b/evidence/grocery_structural_gap_separators/after/vons.checks.json
@@ -1,0 +1,372 @@
+{
+ "checks": {
+  "arithmetic": {
+   "identities": [
+    {
+     "detail": "",
+     "lhs": 3.5,
+     "name": "total_eq_tender",
+     "rhs": 61.13,
+     "status": "VIOLATED"
+    }
+   ],
+   "n_items": 19,
+   "summary": {
+    "change": 0.0,
+    "tax": 0.0,
+    "tender": 61.13,
+    "total": 3.5
+   },
+   "testable": 1,
+   "verdict": "FAIL",
+   "violated": 1
+  },
+  "columns": {
+   "bands": {
+    "ALL": {
+     "cell_w_px": 15.07,
+     "columns": [
+      {
+       "abs_drift_limit_px": 22.61,
+       "abs_drift_px": 11.0,
+       "column": {
+        "anchor": "right",
+        "role": "amount",
+        "spread": 0.0025,
+        "support": 13,
+        "x": 0.9524
+       },
+       "failed_on": [
+        "outliers"
+       ],
+       "outlier_limit": 0.15,
+       "real": {
+        "lane_mid_y_px": 1116.5,
+        "lane_x_px": 719.84,
+        "median_dev_px": -3.82,
+        "n_rows": 13,
+        "outlier_frac": 0.0,
+        "tilt_px_per_100px": 0.207,
+        "wobble_iqr_px": 0.5
+       },
+       "shear_px_per_100px": 0.07,
+       "synth": {
+        "lane_mid_y_px": 1116.5,
+        "lane_x_px": 709.0,
+        "median_dev_px": -14.82,
+        "n_rows": 13,
+        "outlier_frac": 0.154,
+        "tilt_px_per_100px": 0.28,
+        "wobble_iqr_px": 0.45
+       },
+       "verdict": "FAIL",
+       "wobble_limit_px": 3.5
+      },
+      {
+       "abs_drift_limit_px": 22.61,
+       "abs_drift_px": 7.5,
+       "column": {
+        "anchor": "left",
+        "role": "flag",
+        "spread": 0.0008,
+        "support": 10,
+        "x": 0.9586
+       },
+       "outlier_limit": 0.15,
+       "real": {
+        "lane_mid_y_px": 1074.2,
+        "lane_x_px": 735.58,
+        "median_dev_px": 7.46,
+        "n_rows": 10,
+        "outlier_frac": 0.0,
+        "tilt_px_per_100px": 0.19,
+        "wobble_iqr_px": 0.23
+       },
+       "shear_px_per_100px": 0.12,
+       "synth": {
+        "lane_mid_y_px": 1074.2,
+        "lane_x_px": 728.63,
+        "median_dev_px": -0.04,
+        "n_rows": 10,
+        "outlier_frac": 0.0,
+        "tilt_px_per_100px": 0.308,
+        "wobble_iqr_px": 0.74
+       },
+       "verdict": "PASS",
+       "wobble_limit_px": 2.96
+      }
+     ],
+     "lane_gaps": [
+      {
+       "delta_px": 3.89,
+       "limit_px": 11.3,
+       "pair": [
+        "amount",
+        "flag"
+       ],
+       "real_gap_px": 15.74,
+       "synth_gap_px": 19.63,
+       "verdict": "PASS"
+      }
+     ],
+     "source": "bootstrap",
+     "untested_roles": [],
+     "verdict": "FAIL"
+    }
+   },
+   "verdict": "FAIL"
+  },
+  "coverage_gaps": [
+   "style:barcode_caption",
+   "style:footer",
+   "style:section_header"
+  ],
+  "graphics": {
+   "matched": [],
+   "missing_in_synth": [
+    {
+     "kind": "1d",
+     "payload": "00313505101552502031820",
+     "symbology": "code128",
+     "x_frac": 0.0,
+     "y_frac": 1.0
+    }
+   ],
+   "phantom_in_synth": [],
+   "real": [
+    {
+     "kind": "1d",
+     "payload": "00313505101552502031820",
+     "symbology": "code128",
+     "x_frac": 0.0,
+     "y_frac": 1.0
+    }
+   ],
+   "synth": [],
+   "verdict": "FAIL"
+  },
+  "logo": {
+   "area_ratio": 0.992,
+   "center_offset_frac": 0.0125,
+   "real": {
+    "area": 7116.0,
+    "cx": 416.0,
+    "cy": 58.5,
+    "h": 110.0,
+    "w": 73.0
+   },
+   "size_ratio": 1.0,
+   "synth": {
+    "area": 7059.0,
+    "cx": 406.5,
+    "cy": 69.5,
+    "h": 110.0,
+    "w": 72.0
+   },
+   "verdict": "PASS",
+   "width_ratio": 0.986
+  },
+  "overall": "FAIL",
+  "separators": {
+   "kind_mismatches": 0,
+   "matched": [
+    {
+     "dy": 0.0015,
+     "real": {
+      "height_px": 2,
+      "kind": "dash",
+      "y_frac": 0.185
+     },
+     "synth": {
+      "height_px": 4,
+      "kind": "dash",
+      "y_frac": 0.1865
+     }
+    },
+    {
+     "dy": 0.0044,
+     "real": {
+      "height_px": 2,
+      "kind": "dash",
+      "y_frac": 0.5899
+     },
+     "synth": {
+      "height_px": 4,
+      "kind": "dash",
+      "y_frac": 0.5855
+     }
+    },
+    {
+     "dy": 0.0,
+     "real": {
+      "height_px": 2,
+      "kind": "dash",
+      "y_frac": 0.6737
+     },
+     "synth": {
+      "height_px": 4,
+      "kind": "dash",
+      "y_frac": 0.6737
+     }
+    }
+   ],
+   "missing_in_synth": [],
+   "phantom_in_synth": [],
+   "real_count": 3,
+   "synth_count": 3,
+   "verdict": "PASS"
+  },
+  "style": {
+   "body_stroke_fail": false,
+   "body_stroke_rel": {
+    "real": 0.0948,
+    "synth": 0.1336
+   },
+   "classes": [
+    {
+     "class": "address",
+     "missing_style": [
+      "bold"
+     ],
+     "real": {
+      "bold": 1,
+      "n": 2,
+      "underline": 0
+     },
+     "synth": {
+      "bold": 0,
+      "n": 2,
+      "underline": 0
+     },
+     "verdict": "FAIL"
+    },
+    {
+     "class": "barcode_caption",
+     "real": {
+      "bold": 0,
+      "n": 1,
+      "underline": 0
+     },
+     "synth": {
+      "bold": 0,
+      "n": 1,
+      "underline": 0
+     },
+     "verdict": "UNTESTED"
+    },
+    {
+     "class": "footer",
+     "real": {
+      "bold": 0,
+      "n": 1,
+      "underline": 0
+     },
+     "synth": {
+      "bold": 0,
+      "n": 1,
+      "underline": 0
+     },
+     "verdict": "UNTESTED"
+    },
+    {
+     "class": "payment",
+     "real": {
+      "bold": 0,
+      "n": 2,
+      "underline": 0
+     },
+     "synth": {
+      "bold": 0,
+      "n": 2,
+      "underline": 0
+     },
+     "verdict": "PASS"
+    },
+    {
+     "class": "section_header",
+     "real": {
+      "bold": 0,
+      "n": 1,
+      "underline": 0
+     },
+     "synth": {
+      "bold": 0,
+      "n": 1,
+      "underline": 0
+     },
+     "verdict": "UNTESTED"
+    },
+    {
+     "class": "summary",
+     "real": {
+      "bold": 0,
+      "n": 4,
+      "underline": 0
+     },
+     "synth": {
+      "bold": 0,
+      "n": 4,
+      "underline": 0
+     },
+     "verdict": "PASS"
+    },
+    {
+     "class": "total_line",
+     "real": {
+      "bold": 0,
+      "n": 3,
+      "underline": 0
+     },
+     "synth": {
+      "bold": 0,
+      "n": 3,
+      "underline": 0
+     },
+     "verdict": "PASS"
+    }
+   ],
+   "untested_classes": [
+    "barcode_caption",
+    "footer",
+    "section_header"
+   ],
+   "verdict": "FAIL"
+  },
+  "tokens": {
+   "composed": false,
+   "ink_checked": 196,
+   "ink_evidence_missing": false,
+   "ink_missing_tokens": [
+    "STORE",
+    "3135",
+    "DIR",
+    "CRUZ"
+   ],
+   "ink_recall": 0.9796,
+   "missing_tokens": [],
+   "precision_warn": false,
+   "text_precision": 1.0,
+   "text_recall": 1.0,
+   "verdict": "PASS"
+  }
+ },
+ "image_id": "678a7c94-4948-4ebf-b8e9-9a17c13051ec",
+ "mode": "real-vs-synth",
+ "receipt_id": 2,
+ "slug": "vons",
+ "stamp": {
+  "atlas_hash": "6ca4cb5cda99dd4c",
+  "dirty": false,
+  "git_sha": "894a903ff600b143631f276a4b9426dc45858644",
+  "inputs_hash": "f77149cc37fc47e9",
+  "merchant": "Vons",
+  "merchant_truth": {
+   "bundle_hash": "63775db497ae88a596847c2ddea69cfa1271eda40b755c1e2fae87b36da506cb",
+   "expected_bundle_hash": "63775db497ae88a596847c2ddea69cfa1271eda40b755c1e2fae87b36da506cb",
+   "expected_version": 1,
+   "mode": "online-active",
+   "slug": "vons",
+   "version": 1
+  }
+ }
+}

--- a/evidence/grocery_structural_gap_separators/after/vons.checks.json
+++ b/evidence/grocery_structural_gap_separators/after/vons.checks.json
@@ -4,22 +4,22 @@
    "identities": [
     {
      "detail": "",
-     "lhs": 3.5,
+     "lhs": 61.13,
      "name": "total_eq_tender",
      "rhs": 61.13,
-     "status": "VIOLATED"
+     "status": "HOLDS"
     }
    ],
-   "n_items": 19,
+   "n_items": 12,
    "summary": {
     "change": 0.0,
     "tax": 0.0,
     "tender": 61.13,
-    "total": 3.5
+    "total": 61.13
    },
    "testable": 1,
-   "verdict": "FAIL",
-   "violated": 1
+   "verdict": "PASS",
+   "violated": 0
   },
   "columns": {
    "bands": {
@@ -36,9 +36,6 @@
         "support": 13,
         "x": 0.9524
        },
-       "failed_on": [
-        "outliers"
-       ],
        "outlier_limit": 0.15,
        "real": {
         "lane_mid_y_px": 1116.5,
@@ -51,15 +48,15 @@
        },
        "shear_px_per_100px": 0.07,
        "synth": {
-        "lane_mid_y_px": 1116.5,
-        "lane_x_px": 709.0,
+        "lane_mid_y_px": 1167.0,
+        "lane_x_px": 709.07,
         "median_dev_px": -14.82,
-        "n_rows": 13,
-        "outlier_frac": 0.154,
+        "n_rows": 14,
+        "outlier_frac": 0.0,
         "tilt_px_per_100px": 0.28,
-        "wobble_iqr_px": 0.45
+        "wobble_iqr_px": 0.32
        },
-       "verdict": "FAIL",
+       "verdict": "PASS",
        "wobble_limit_px": 3.5
       },
       {
@@ -82,15 +79,15 @@
         "tilt_px_per_100px": 0.19,
         "wobble_iqr_px": 0.23
        },
-       "shear_px_per_100px": 0.12,
+       "shear_px_per_100px": 0.02,
        "synth": {
-        "lane_mid_y_px": 1074.2,
-        "lane_x_px": 728.63,
+        "lane_mid_y_px": 1087.5,
+        "lane_x_px": 728.62,
         "median_dev_px": -0.04,
         "n_rows": 10,
         "outlier_frac": 0.0,
-        "tilt_px_per_100px": 0.308,
-        "wobble_iqr_px": 0.74
+        "tilt_px_per_100px": 0.206,
+        "wobble_iqr_px": 0.33
        },
        "verdict": "PASS",
        "wobble_limit_px": 2.96
@@ -98,23 +95,23 @@
      ],
      "lane_gaps": [
       {
-       "delta_px": 3.89,
+       "delta_px": 3.81,
        "limit_px": 11.3,
        "pair": [
         "amount",
         "flag"
        ],
        "real_gap_px": 15.74,
-       "synth_gap_px": 19.63,
+       "synth_gap_px": 19.55,
        "verdict": "PASS"
       }
      ],
      "source": "bootstrap",
      "untested_roles": [],
-     "verdict": "FAIL"
+     "verdict": "PASS"
     }
    },
-   "verdict": "FAIL"
+   "verdict": "PASS"
   },
   "coverage_gaps": [
    "style:barcode_caption",
@@ -122,16 +119,27 @@
    "style:section_header"
   ],
   "graphics": {
-   "matched": [],
-   "missing_in_synth": [
+   "matched": [
     {
-     "kind": "1d",
-     "payload": "00313505101552502031820",
-     "symbology": "code128",
-     "x_frac": 0.0,
-     "y_frac": 1.0
+     "dy": 0.0,
+     "payload_match": true,
+     "real": {
+      "kind": "1d",
+      "payload": "00313505101552502031820",
+      "symbology": "code128",
+      "x_frac": 0.0,
+      "y_frac": 1.0
+     },
+     "synth": {
+      "kind": "1d",
+      "payload": "00313505101552502031820",
+      "symbology": "code128",
+      "x_frac": 0.0,
+      "y_frac": 1.0
+     }
     }
    ],
+   "missing_in_synth": [],
    "phantom_in_synth": [],
    "real": [
     {
@@ -142,29 +150,37 @@
      "y_frac": 1.0
     }
    ],
-   "synth": [],
-   "verdict": "FAIL"
+   "synth": [
+    {
+     "kind": "1d",
+     "payload": "00313505101552502031820",
+     "symbology": "code128",
+     "x_frac": 0.0,
+     "y_frac": 1.0
+    }
+   ],
+   "verdict": "PASS"
   },
   "logo": {
-   "area_ratio": 0.992,
-   "center_offset_frac": 0.0125,
+   "area_ratio": 0.999,
+   "center_offset_frac": 0.0105,
    "real": {
-    "area": 7116.0,
-    "cx": 416.0,
-    "cy": 58.5,
-    "h": 110.0,
-    "w": 73.0
+    "area": 24447.0,
+    "cx": 378.5,
+    "cy": 58.0,
+    "h": 113.0,
+    "w": 294.0
    },
-   "size_ratio": 1.0,
+   "size_ratio": 1.009,
    "synth": {
-    "area": 7059.0,
-    "cx": 406.5,
-    "cy": 69.5,
-    "h": 110.0,
-    "w": 72.0
+    "area": 24431.0,
+    "cx": 370.5,
+    "cy": 70.5,
+    "h": 114.0,
+    "w": 288.0
    },
    "verdict": "PASS",
-   "width_ratio": 0.986
+   "width_ratio": 0.98
   },
   "overall": "FAIL",
   "separators": {
@@ -220,7 +236,7 @@
    "body_stroke_fail": false,
    "body_stroke_rel": {
     "real": 0.0948,
-    "synth": 0.1336
+    "synth": 0.1658
    },
    "classes": [
     {
@@ -336,17 +352,15 @@
    "composed": false,
    "ink_checked": 196,
    "ink_evidence_missing": false,
-   "ink_missing_tokens": [
-    "STORE",
-    "3135",
-    "DIR",
-    "CRUZ"
+   "ink_missing_tokens": [],
+   "ink_recall": 1.0,
+   "missing_tokens": [
+    "FRENCH",
+    "ROAST"
    ],
-   "ink_recall": 0.9796,
-   "missing_tokens": [],
    "precision_warn": false,
-   "text_precision": 1.0,
-   "text_recall": 1.0,
+   "text_precision": 0.9898,
+   "text_recall": 0.9898,
    "verdict": "PASS"
   }
  },
@@ -357,8 +371,8 @@
  "stamp": {
   "atlas_hash": "6ca4cb5cda99dd4c",
   "dirty": false,
-  "git_sha": "894a903ff600b143631f276a4b9426dc45858644",
-  "inputs_hash": "f77149cc37fc47e9",
+  "git_sha": "63cc32906b9c861b144e825dee074accaad3b4a4",
+  "inputs_hash": "8295c5c2af35b3b2",
   "merchant": "Vons",
   "merchant_truth": {
    "bundle_hash": "63775db497ae88a596847c2ddea69cfa1271eda40b755c1e2fae87b36da506cb",

--- a/evidence/grocery_structural_gap_separators/after/vons.report.md
+++ b/evidence/grocery_structural_gap_separators/after/vons.report.md
@@ -1,0 +1,373 @@
+# full_fidelity_eval -- vons
+
+- merchant: Vons
+- receipt: 678a7c94-4948-4ebf-b8e9-9a17c13051ec#2
+- git: `894a903ff600`
+- truth: `vons` v1 `63775db497ae88a596847c2ddea69cfa1271eda40b755c1e2fae87b36da506cb` (online-active)
+- atlas: `6ca4cb5cda99dd4c`
+
+## OVERALL: FAIL
+
+| metric | verdict |
+|---|---|
+| columns | FAIL |
+| style | FAIL |
+| tokens | PASS |
+| separators | PASS |
+| graphics | FAIL |
+| logo | PASS |
+| arithmetic | FAIL |
+
+```json
+{
+ "arithmetic": {
+  "identities": [
+   {
+    "detail": "",
+    "lhs": 3.5,
+    "name": "total_eq_tender",
+    "rhs": 61.13,
+    "status": "VIOLATED"
+   }
+  ],
+  "n_items": 19,
+  "summary": {
+   "change": 0.0,
+   "tax": 0.0,
+   "tender": 61.13,
+   "total": 3.5
+  },
+  "testable": 1,
+  "verdict": "FAIL",
+  "violated": 1
+ },
+ "columns": {
+  "bands": {
+   "ALL": {
+    "cell_w_px": 15.07,
+    "columns": [
+     {
+      "abs_drift_limit_px": 22.61,
+      "abs_drift_px": 11.0,
+      "column": {
+       "anchor": "right",
+       "role": "amount",
+       "spread": 0.0025,
+       "support": 13,
+       "x": 0.9524
+      },
+      "failed_on": [
+       "outliers"
+      ],
+      "outlier_limit": 0.15,
+      "real": {
+       "lane_mid_y_px": 1116.5,
+       "lane_x_px": 719.84,
+       "median_dev_px": -3.82,
+       "n_rows": 13,
+       "outlier_frac": 0.0,
+       "tilt_px_per_100px": 0.207,
+       "wobble_iqr_px": 0.5
+      },
+      "shear_px_per_100px": 0.07,
+      "synth": {
+       "lane_mid_y_px": 1116.5,
+       "lane_x_px": 709.0,
+       "median_dev_px": -14.82,
+       "n_rows": 13,
+       "outlier_frac": 0.154,
+       "tilt_px_per_100px": 0.28,
+       "wobble_iqr_px": 0.45
+      },
+      "verdict": "FAIL",
+      "wobble_limit_px": 3.5
+     },
+     {
+      "abs_drift_limit_px": 22.61,
+      "abs_drift_px": 7.5,
+      "column": {
+       "anchor": "left",
+       "role": "flag",
+       "spread": 0.0008,
+       "support": 10,
+       "x": 0.9586
+      },
+      "outlier_limit": 0.15,
+      "real": {
+       "lane_mid_y_px": 1074.2,
+       "lane_x_px": 735.58,
+       "median_dev_px": 7.46,
+       "n_rows": 10,
+       "outlier_frac": 0.0,
+       "tilt_px_per_100px": 0.19,
+       "wobble_iqr_px": 0.23
+      },
+      "shear_px_per_100px": 0.12,
+      "synth": {
+       "lane_mid_y_px": 1074.2,
+       "lane_x_px": 728.63,
+       "median_dev_px": -0.04,
+       "n_rows": 10,
+       "outlier_frac": 0.0,
+       "tilt_px_per_100px": 0.308,
+       "wobble_iqr_px": 0.74
+      },
+      "verdict": "PASS",
+      "wobble_limit_px": 2.96
+     }
+    ],
+    "lane_gaps": [
+     {
+      "delta_px": 3.89,
+      "limit_px": 11.3,
+      "pair": [
+       "amount",
+       "flag"
+      ],
+      "real_gap_px": 15.74,
+      "synth_gap_px": 19.63,
+      "verdict": "PASS"
+     }
+    ],
+    "source": "bootstrap",
+    "untested_roles": [],
+    "verdict": "FAIL"
+   }
+  },
+  "verdict": "FAIL"
+ },
+ "coverage_gaps": [
+  "style:barcode_caption",
+  "style:footer",
+  "style:section_header"
+ ],
+ "graphics": {
+  "matched": [],
+  "missing_in_synth": [
+   {
+    "kind": "1d",
+    "payload": "00313505101552502031820",
+    "symbology": "code128",
+    "x_frac": 0.0,
+    "y_frac": 1.0
+   }
+  ],
+  "phantom_in_synth": [],
+  "real": [
+   {
+    "kind": "1d",
+    "payload": "00313505101552502031820",
+    "symbology": "code128",
+    "x_frac": 0.0,
+    "y_frac": 1.0
+   }
+  ],
+  "synth": [],
+  "verdict": "FAIL"
+ },
+ "logo": {
+  "area_ratio": 0.992,
+  "center_offset_frac": 0.0125,
+  "real": {
+   "area": 7116.0,
+   "cx": 416.0,
+   "cy": 58.5,
+   "h": 110.0,
+   "w": 73.0
+  },
+  "size_ratio": 1.0,
+  "synth": {
+   "area": 7059.0,
+   "cx": 406.5,
+   "cy": 69.5,
+   "h": 110.0,
+   "w": 72.0
+  },
+  "verdict": "PASS",
+  "width_ratio": 0.986
+ },
+ "overall": "FAIL",
+ "separators": {
+  "kind_mismatches": 0,
+  "matched": [
+   {
+    "dy": 0.0015,
+    "real": {
+     "height_px": 2,
+     "kind": "dash",
+     "y_frac": 0.185
+    },
+    "synth": {
+     "height_px": 4,
+     "kind": "dash",
+     "y_frac": 0.1865
+    }
+   },
+   {
+    "dy": 0.0044,
+    "real": {
+     "height_px": 2,
+     "kind": "dash",
+     "y_frac": 0.5899
+    },
+    "synth": {
+     "height_px": 4,
+     "kind": "dash",
+     "y_frac": 0.5855
+    }
+   },
+   {
+    "dy": 0.0,
+    "real": {
+     "height_px": 2,
+     "kind": "dash",
+     "y_frac": 0.6737
+    },
+    "synth": {
+     "height_px": 4,
+     "kind": "dash",
+     "y_frac": 0.6737
+    }
+   }
+  ],
+  "missing_in_synth": [],
+  "phantom_in_synth": [],
+  "real_count": 3,
+  "synth_count": 3,
+  "verdict": "PASS"
+ },
+ "style": {
+  "body_stroke_fail": false,
+  "body_stroke_rel": {
+   "real": 0.0948,
+   "synth": 0.1336
+  },
+  "classes": [
+   {
+    "class": "address",
+    "missing_style": [
+     "bold"
+    ],
+    "real": {
+     "bold": 1,
+     "n": 2,
+     "underline": 0
+    },
+    "synth": {
+     "bold": 0,
+     "n": 2,
+     "underline": 0
+    },
+    "verdict": "FAIL"
+   },
+   {
+    "class": "barcode_caption",
+    "real": {
+     "bold": 0,
+     "n": 1,
+     "underline": 0
+    },
+    "synth": {
+     "bold": 0,
+     "n": 1,
+     "underline": 0
+    },
+    "verdict": "UNTESTED"
+   },
+   {
+    "class": "footer",
+    "real": {
+     "bold": 0,
+     "n": 1,
+     "underline": 0
+    },
+    "synth": {
+     "bold": 0,
+     "n": 1,
+     "underline": 0
+    },
+    "verdict": "UNTESTED"
+   },
+   {
+    "class": "payment",
+    "real": {
+     "bold": 0,
+     "n": 2,
+     "underline": 0
+    },
+    "synth": {
+     "bold": 0,
+     "n": 2,
+     "underline": 0
+    },
+    "verdict": "PASS"
+   },
+   {
+    "class": "section_header",
+    "real": {
+     "bold": 0,
+     "n": 1,
+     "underline": 0
+    },
+    "synth": {
+     "bold": 0,
+     "n": 1,
+     "underline": 0
+    },
+    "verdict": "UNTESTED"
+   },
+   {
+    "class": "summary",
+    "real": {
+     "bold": 0,
+     "n": 4,
+     "underline": 0
+    },
+    "synth": {
+     "bold": 0,
+     "n": 4,
+     "underline": 0
+    },
+    "verdict": "PASS"
+   },
+   {
+    "class": "total_line",
+    "real": {
+     "bold": 0,
+     "n": 3,
+     "underline": 0
+    },
+    "synth": {
+     "bold": 0,
+     "n": 3,
+     "underline": 0
+    },
+    "verdict": "PASS"
+   }
+  ],
+  "untested_classes": [
+   "barcode_caption",
+   "footer",
+   "section_header"
+  ],
+  "verdict": "FAIL"
+ },
+ "tokens": {
+  "composed": false,
+  "ink_checked": 196,
+  "ink_evidence_missing": false,
+  "ink_missing_tokens": [
+   "STORE",
+   "3135",
+   "DIR",
+   "CRUZ"
+  ],
+  "ink_recall": 0.9796,
+  "missing_tokens": [],
+  "precision_warn": false,
+  "text_precision": 1.0,
+  "text_recall": 1.0,
+  "verdict": "PASS"
+ }
+}
+```

--- a/evidence/grocery_structural_gap_separators/after/vons.report.md
+++ b/evidence/grocery_structural_gap_separators/after/vons.report.md
@@ -2,7 +2,7 @@
 
 - merchant: Vons
 - receipt: 678a7c94-4948-4ebf-b8e9-9a17c13051ec#2
-- git: `894a903ff600`
+- git: `63cc32906b9c`
 - truth: `vons` v1 `63775db497ae88a596847c2ddea69cfa1271eda40b755c1e2fae87b36da506cb` (online-active)
 - atlas: `6ca4cb5cda99dd4c`
 
@@ -10,13 +10,13 @@
 
 | metric | verdict |
 |---|---|
-| columns | FAIL |
+| columns | PASS |
 | style | FAIL |
 | tokens | PASS |
 | separators | PASS |
-| graphics | FAIL |
+| graphics | PASS |
 | logo | PASS |
-| arithmetic | FAIL |
+| arithmetic | PASS |
 
 ```json
 {
@@ -24,22 +24,22 @@
   "identities": [
    {
     "detail": "",
-    "lhs": 3.5,
+    "lhs": 61.13,
     "name": "total_eq_tender",
     "rhs": 61.13,
-    "status": "VIOLATED"
+    "status": "HOLDS"
    }
   ],
-  "n_items": 19,
+  "n_items": 12,
   "summary": {
    "change": 0.0,
    "tax": 0.0,
    "tender": 61.13,
-   "total": 3.5
+   "total": 61.13
   },
   "testable": 1,
-  "verdict": "FAIL",
-  "violated": 1
+  "verdict": "PASS",
+  "violated": 0
  },
  "columns": {
   "bands": {
@@ -56,9 +56,6 @@
        "support": 13,
        "x": 0.9524
       },
-      "failed_on": [
-       "outliers"
-      ],
       "outlier_limit": 0.15,
       "real": {
        "lane_mid_y_px": 1116.5,
@@ -71,15 +68,15 @@
       },
       "shear_px_per_100px": 0.07,
       "synth": {
-       "lane_mid_y_px": 1116.5,
-       "lane_x_px": 709.0,
+       "lane_mid_y_px": 1167.0,
+       "lane_x_px": 709.07,
        "median_dev_px": -14.82,
-       "n_rows": 13,
-       "outlier_frac": 0.154,
+       "n_rows": 14,
+       "outlier_frac": 0.0,
        "tilt_px_per_100px": 0.28,
-       "wobble_iqr_px": 0.45
+       "wobble_iqr_px": 0.32
       },
-      "verdict": "FAIL",
+      "verdict": "PASS",
       "wobble_limit_px": 3.5
      },
      {
@@ -102,15 +99,15 @@
        "tilt_px_per_100px": 0.19,
        "wobble_iqr_px": 0.23
       },
-      "shear_px_per_100px": 0.12,
+      "shear_px_per_100px": 0.02,
       "synth": {
-       "lane_mid_y_px": 1074.2,
-       "lane_x_px": 728.63,
+       "lane_mid_y_px": 1087.5,
+       "lane_x_px": 728.62,
        "median_dev_px": -0.04,
        "n_rows": 10,
        "outlier_frac": 0.0,
-       "tilt_px_per_100px": 0.308,
-       "wobble_iqr_px": 0.74
+       "tilt_px_per_100px": 0.206,
+       "wobble_iqr_px": 0.33
       },
       "verdict": "PASS",
       "wobble_limit_px": 2.96
@@ -118,23 +115,23 @@
     ],
     "lane_gaps": [
      {
-      "delta_px": 3.89,
+      "delta_px": 3.81,
       "limit_px": 11.3,
       "pair": [
        "amount",
        "flag"
       ],
       "real_gap_px": 15.74,
-      "synth_gap_px": 19.63,
+      "synth_gap_px": 19.55,
       "verdict": "PASS"
      }
     ],
     "source": "bootstrap",
     "untested_roles": [],
-    "verdict": "FAIL"
+    "verdict": "PASS"
    }
   },
-  "verdict": "FAIL"
+  "verdict": "PASS"
  },
  "coverage_gaps": [
   "style:barcode_caption",
@@ -142,16 +139,27 @@
   "style:section_header"
  ],
  "graphics": {
-  "matched": [],
-  "missing_in_synth": [
+  "matched": [
    {
-    "kind": "1d",
-    "payload": "00313505101552502031820",
-    "symbology": "code128",
-    "x_frac": 0.0,
-    "y_frac": 1.0
+    "dy": 0.0,
+    "payload_match": true,
+    "real": {
+     "kind": "1d",
+     "payload": "00313505101552502031820",
+     "symbology": "code128",
+     "x_frac": 0.0,
+     "y_frac": 1.0
+    },
+    "synth": {
+     "kind": "1d",
+     "payload": "00313505101552502031820",
+     "symbology": "code128",
+     "x_frac": 0.0,
+     "y_frac": 1.0
+    }
    }
   ],
+  "missing_in_synth": [],
   "phantom_in_synth": [],
   "real": [
    {
@@ -162,29 +170,37 @@
     "y_frac": 1.0
    }
   ],
-  "synth": [],
-  "verdict": "FAIL"
+  "synth": [
+   {
+    "kind": "1d",
+    "payload": "00313505101552502031820",
+    "symbology": "code128",
+    "x_frac": 0.0,
+    "y_frac": 1.0
+   }
+  ],
+  "verdict": "PASS"
  },
  "logo": {
-  "area_ratio": 0.992,
-  "center_offset_frac": 0.0125,
+  "area_ratio": 0.999,
+  "center_offset_frac": 0.0105,
   "real": {
-   "area": 7116.0,
-   "cx": 416.0,
-   "cy": 58.5,
-   "h": 110.0,
-   "w": 73.0
+   "area": 24447.0,
+   "cx": 378.5,
+   "cy": 58.0,
+   "h": 113.0,
+   "w": 294.0
   },
-  "size_ratio": 1.0,
+  "size_ratio": 1.009,
   "synth": {
-   "area": 7059.0,
-   "cx": 406.5,
-   "cy": 69.5,
-   "h": 110.0,
-   "w": 72.0
+   "area": 24431.0,
+   "cx": 370.5,
+   "cy": 70.5,
+   "h": 114.0,
+   "w": 288.0
   },
   "verdict": "PASS",
-  "width_ratio": 0.986
+  "width_ratio": 0.98
  },
  "overall": "FAIL",
  "separators": {
@@ -240,7 +256,7 @@
   "body_stroke_fail": false,
   "body_stroke_rel": {
    "real": 0.0948,
-   "synth": 0.1336
+   "synth": 0.1658
   },
   "classes": [
    {
@@ -356,17 +372,15 @@
   "composed": false,
   "ink_checked": 196,
   "ink_evidence_missing": false,
-  "ink_missing_tokens": [
-   "STORE",
-   "3135",
-   "DIR",
-   "CRUZ"
+  "ink_missing_tokens": [],
+  "ink_recall": 1.0,
+  "missing_tokens": [
+   "FRENCH",
+   "ROAST"
   ],
-  "ink_recall": 0.9796,
-  "missing_tokens": [],
   "precision_warn": false,
-  "text_precision": 1.0,
-  "text_recall": 1.0,
+  "text_precision": 0.9898,
+  "text_recall": 0.9898,
   "verdict": "PASS"
  }
 }

--- a/evidence/grocery_structural_gap_separators/before/trader_joe_s.checks.json
+++ b/evidence/grocery_structural_gap_separators/before/trader_joe_s.checks.json
@@ -1,0 +1,209 @@
+{
+ "checks": {
+  "arithmetic": {
+   "identities": [
+    {
+     "detail": "",
+     "lhs": 63.66,
+     "name": "total_eq_tender",
+     "rhs": 63.66,
+     "status": "HOLDS"
+    }
+   ],
+   "n_items": 15,
+   "summary": {
+    "tender": 63.66,
+    "total": 63.66
+   },
+   "testable": 1,
+   "verdict": "PASS",
+   "violated": 0
+  },
+  "columns": {
+   "bands": {
+    "ALL": {
+     "cell_w_px": 16.61,
+     "columns": [
+      {
+       "abs_drift_limit_px": 24.91,
+       "abs_drift_px": 1.0,
+       "column": {
+        "anchor": "right",
+        "role": "amount",
+        "spread": 0.0003,
+        "support": 17,
+        "x": 0.9811
+       },
+       "outlier_limit": 0.15,
+       "real": {
+        "lane_mid_y_px": 814.5,
+        "lane_x_px": 740.62,
+        "median_dev_px": -5.64,
+        "n_rows": 17,
+        "outlier_frac": 0.0,
+        "tilt_px_per_100px": 0.976,
+        "wobble_iqr_px": 0.65
+       },
+       "shear_px_per_100px": 1.57,
+       "synth": {
+        "lane_mid_y_px": 814.5,
+        "lane_x_px": 738.63,
+        "median_dev_px": -6.64,
+        "n_rows": 17,
+        "outlier_frac": 0.0,
+        "tilt_px_per_100px": -0.592,
+        "wobble_iqr_px": 0.27
+       },
+       "verdict": "PASS",
+       "wobble_limit_px": 3.8
+      }
+     ],
+     "lane_gaps": [],
+     "source": "bootstrap",
+     "untested_roles": [],
+     "verdict": "PASS"
+    }
+   },
+   "verdict": "PASS"
+  },
+  "coverage_gaps": [
+   "style:total_line"
+  ],
+  "graphics": {
+   "matched": [],
+   "missing_in_synth": [],
+   "phantom_in_synth": [],
+   "real": [],
+   "synth": [],
+   "verdict": "PASS"
+  },
+  "logo": {
+   "area_ratio": 0.313,
+   "center_offset_frac": 0.2158,
+   "real": {
+    "area": 13912.0,
+    "cx": 30.5,
+    "cy": 118.5,
+    "h": 238.0,
+    "w": 62.0
+   },
+   "size_ratio": 0.265,
+   "synth": {
+    "area": 4360.0,
+    "cx": 194.5,
+    "cy": 54.0,
+    "h": 63.0,
+    "w": 116.0
+   },
+   "verdict": "FAIL",
+   "width_ratio": 1.871
+  },
+  "overall": "FAIL",
+  "separators": {
+   "kind_mismatches": 0,
+   "matched": [],
+   "missing_in_synth": [
+    {
+     "height_px": 2,
+     "kind": "dash",
+     "y_frac": 0.582
+    }
+   ],
+   "phantom_in_synth": [],
+   "real_count": 1,
+   "synth_count": 0,
+   "verdict": "FAIL"
+  },
+  "style": {
+   "body_stroke_fail": false,
+   "body_stroke_rel": {
+    "real": 0.1068,
+    "synth": 0.1068
+   },
+   "classes": [
+    {
+     "class": "footer",
+     "missing_style": [
+      "bold"
+     ],
+     "real": {
+      "bold": 1,
+      "n": 2,
+      "underline": 0
+     },
+     "synth": {
+      "bold": 0,
+      "n": 2,
+      "underline": 0
+     },
+     "verdict": "FAIL"
+    },
+    {
+     "class": "payment",
+     "real": {
+      "bold": 0,
+      "n": 5,
+      "underline": 0
+     },
+     "synth": {
+      "bold": 0,
+      "n": 5,
+      "underline": 0
+     },
+     "verdict": "PASS"
+    },
+    {
+     "class": "total_line",
+     "real": {
+      "bold": 0,
+      "n": 1,
+      "underline": 0
+     },
+     "synth": {
+      "bold": 0,
+      "n": 1,
+      "underline": 0
+     },
+     "verdict": "UNTESTED"
+    }
+   ],
+   "untested_classes": [
+    "total_line"
+   ],
+   "verdict": "FAIL"
+  },
+  "tokens": {
+   "composed": false,
+   "ink_checked": 138,
+   "ink_evidence_missing": false,
+   "ink_missing_tokens": [
+    "REPRINT"
+   ],
+   "ink_recall": 0.9928,
+   "missing_tokens": [],
+   "precision_warn": false,
+   "text_precision": 1.0,
+   "text_recall": 1.0,
+   "verdict": "PASS"
+  }
+ },
+ "image_id": "4c262079-4fec-4724-a8e1-2886f38ea454",
+ "mode": "real-vs-synth",
+ "receipt_id": 1,
+ "slug": "trader_joe_s",
+ "stamp": {
+  "atlas_hash": "4c355fbd82e342b7",
+  "dirty": false,
+  "git_sha": "e517d33fdc043abfcbff5f70e87dfd21bccc8952",
+  "inputs_hash": "039c90fb79c13eca",
+  "merchant": "Trader Joe's",
+  "merchant_truth": {
+   "bundle_hash": "557c433fcc1e5d74ca66a54f194cf4deca9e39976d26412dc0e1b5ebd778c418",
+   "expected_bundle_hash": "557c433fcc1e5d74ca66a54f194cf4deca9e39976d26412dc0e1b5ebd778c418",
+   "expected_version": 1,
+   "mode": "online-active",
+   "slug": "trader_joe_s",
+   "version": 1
+  }
+ }
+}

--- a/evidence/grocery_structural_gap_separators/before/trader_joe_s.checks.json
+++ b/evidence/grocery_structural_gap_separators/before/trader_joe_s.checks.json
@@ -10,7 +10,7 @@
      "status": "HOLDS"
     }
    ],
-   "n_items": 15,
+   "n_items": 14,
    "summary": {
     "tender": 63.66,
     "total": 63.66
@@ -46,13 +46,13 @@
        },
        "shear_px_per_100px": 1.57,
        "synth": {
-        "lane_mid_y_px": 814.5,
-        "lane_x_px": 738.63,
+        "lane_mid_y_px": 823.0,
+        "lane_x_px": 738.65,
         "median_dev_px": -6.64,
         "n_rows": 17,
         "outlier_frac": 0.0,
-        "tilt_px_per_100px": -0.592,
-        "wobble_iqr_px": 0.27
+        "tilt_px_per_100px": -0.599,
+        "wobble_iqr_px": 0.29
        },
        "verdict": "PASS",
        "wobble_limit_px": 3.8
@@ -67,6 +67,7 @@
    "verdict": "PASS"
   },
   "coverage_gaps": [
+   "style",
    "style:total_line"
   ],
   "graphics": {
@@ -78,25 +79,25 @@
    "verdict": "PASS"
   },
   "logo": {
-   "area_ratio": 0.313,
-   "center_offset_frac": 0.2158,
+   "area_ratio": 1.173,
+   "center_offset_frac": 0.0329,
    "real": {
-    "area": 13912.0,
-    "cx": 30.5,
-    "cy": 118.5,
-    "h": 238.0,
-    "w": 62.0
+    "area": 18139.0,
+    "cx": 410.5,
+    "cy": 48.0,
+    "h": 69.0,
+    "w": 612.0
    },
-   "size_ratio": 0.265,
+   "size_ratio": 0.971,
    "synth": {
-    "area": 4360.0,
-    "cx": 194.5,
-    "cy": 54.0,
-    "h": 63.0,
-    "w": 116.0
+    "area": 21272.0,
+    "cx": 385.5,
+    "cy": 55.0,
+    "h": 67.0,
+    "w": 600.0
    },
-   "verdict": "FAIL",
-   "width_ratio": 1.871
+   "verdict": "PASS",
+   "width_ratio": 0.98
   },
   "overall": "FAIL",
   "separators": {
@@ -118,25 +119,22 @@
    "body_stroke_fail": false,
    "body_stroke_rel": {
     "real": 0.1068,
-    "synth": 0.1068
+    "synth": 0.1565
    },
    "classes": [
     {
      "class": "footer",
-     "missing_style": [
-      "bold"
-     ],
      "real": {
       "bold": 1,
       "n": 2,
       "underline": 0
      },
      "synth": {
-      "bold": 0,
+      "bold": 1,
       "n": 2,
       "underline": 0
      },
-     "verdict": "FAIL"
+     "verdict": "PASS"
     },
     {
      "class": "payment",
@@ -170,16 +168,14 @@
    "untested_classes": [
     "total_line"
    ],
-   "verdict": "FAIL"
+   "verdict": "PASS_WITH_GAPS"
   },
   "tokens": {
    "composed": false,
    "ink_checked": 138,
    "ink_evidence_missing": false,
-   "ink_missing_tokens": [
-    "REPRINT"
-   ],
-   "ink_recall": 0.9928,
+   "ink_missing_tokens": [],
+   "ink_recall": 1.0,
    "missing_tokens": [],
    "precision_warn": false,
    "text_precision": 1.0,
@@ -192,10 +188,10 @@
  "receipt_id": 1,
  "slug": "trader_joe_s",
  "stamp": {
-  "atlas_hash": "4c355fbd82e342b7",
+  "atlas_hash": "037dc0610504a9b9",
   "dirty": false,
-  "git_sha": "e517d33fdc043abfcbff5f70e87dfd21bccc8952",
-  "inputs_hash": "039c90fb79c13eca",
+  "git_sha": "1d0dd32f57955f7f312eedcd88688b2ae8f96a8b",
+  "inputs_hash": "0587f5d3daefdda2",
   "merchant": "Trader Joe's",
   "merchant_truth": {
    "bundle_hash": "557c433fcc1e5d74ca66a54f194cf4deca9e39976d26412dc0e1b5ebd778c418",

--- a/evidence/grocery_structural_gap_separators/before/trader_joe_s.report.md
+++ b/evidence/grocery_structural_gap_separators/before/trader_joe_s.report.md
@@ -1,0 +1,210 @@
+# full_fidelity_eval -- trader_joe_s
+
+- merchant: Trader Joe's
+- receipt: 4c262079-4fec-4724-a8e1-2886f38ea454#1
+- git: `e517d33fdc04`
+- truth: `trader_joe_s` v1 `557c433fcc1e5d74ca66a54f194cf4deca9e39976d26412dc0e1b5ebd778c418` (online-active)
+- atlas: `4c355fbd82e342b7`
+
+## OVERALL: FAIL
+
+| metric | verdict |
+|---|---|
+| columns | PASS |
+| style | FAIL |
+| tokens | PASS |
+| separators | FAIL |
+| graphics | PASS |
+| logo | FAIL |
+| arithmetic | PASS |
+
+```json
+{
+ "arithmetic": {
+  "identities": [
+   {
+    "detail": "",
+    "lhs": 63.66,
+    "name": "total_eq_tender",
+    "rhs": 63.66,
+    "status": "HOLDS"
+   }
+  ],
+  "n_items": 15,
+  "summary": {
+   "tender": 63.66,
+   "total": 63.66
+  },
+  "testable": 1,
+  "verdict": "PASS",
+  "violated": 0
+ },
+ "columns": {
+  "bands": {
+   "ALL": {
+    "cell_w_px": 16.61,
+    "columns": [
+     {
+      "abs_drift_limit_px": 24.91,
+      "abs_drift_px": 1.0,
+      "column": {
+       "anchor": "right",
+       "role": "amount",
+       "spread": 0.0003,
+       "support": 17,
+       "x": 0.9811
+      },
+      "outlier_limit": 0.15,
+      "real": {
+       "lane_mid_y_px": 814.5,
+       "lane_x_px": 740.62,
+       "median_dev_px": -5.64,
+       "n_rows": 17,
+       "outlier_frac": 0.0,
+       "tilt_px_per_100px": 0.976,
+       "wobble_iqr_px": 0.65
+      },
+      "shear_px_per_100px": 1.57,
+      "synth": {
+       "lane_mid_y_px": 814.5,
+       "lane_x_px": 738.63,
+       "median_dev_px": -6.64,
+       "n_rows": 17,
+       "outlier_frac": 0.0,
+       "tilt_px_per_100px": -0.592,
+       "wobble_iqr_px": 0.27
+      },
+      "verdict": "PASS",
+      "wobble_limit_px": 3.8
+     }
+    ],
+    "lane_gaps": [],
+    "source": "bootstrap",
+    "untested_roles": [],
+    "verdict": "PASS"
+   }
+  },
+  "verdict": "PASS"
+ },
+ "coverage_gaps": [
+  "style:total_line"
+ ],
+ "graphics": {
+  "matched": [],
+  "missing_in_synth": [],
+  "phantom_in_synth": [],
+  "real": [],
+  "synth": [],
+  "verdict": "PASS"
+ },
+ "logo": {
+  "area_ratio": 0.313,
+  "center_offset_frac": 0.2158,
+  "real": {
+   "area": 13912.0,
+   "cx": 30.5,
+   "cy": 118.5,
+   "h": 238.0,
+   "w": 62.0
+  },
+  "size_ratio": 0.265,
+  "synth": {
+   "area": 4360.0,
+   "cx": 194.5,
+   "cy": 54.0,
+   "h": 63.0,
+   "w": 116.0
+  },
+  "verdict": "FAIL",
+  "width_ratio": 1.871
+ },
+ "overall": "FAIL",
+ "separators": {
+  "kind_mismatches": 0,
+  "matched": [],
+  "missing_in_synth": [
+   {
+    "height_px": 2,
+    "kind": "dash",
+    "y_frac": 0.582
+   }
+  ],
+  "phantom_in_synth": [],
+  "real_count": 1,
+  "synth_count": 0,
+  "verdict": "FAIL"
+ },
+ "style": {
+  "body_stroke_fail": false,
+  "body_stroke_rel": {
+   "real": 0.1068,
+   "synth": 0.1068
+  },
+  "classes": [
+   {
+    "class": "footer",
+    "missing_style": [
+     "bold"
+    ],
+    "real": {
+     "bold": 1,
+     "n": 2,
+     "underline": 0
+    },
+    "synth": {
+     "bold": 0,
+     "n": 2,
+     "underline": 0
+    },
+    "verdict": "FAIL"
+   },
+   {
+    "class": "payment",
+    "real": {
+     "bold": 0,
+     "n": 5,
+     "underline": 0
+    },
+    "synth": {
+     "bold": 0,
+     "n": 5,
+     "underline": 0
+    },
+    "verdict": "PASS"
+   },
+   {
+    "class": "total_line",
+    "real": {
+     "bold": 0,
+     "n": 1,
+     "underline": 0
+    },
+    "synth": {
+     "bold": 0,
+     "n": 1,
+     "underline": 0
+    },
+    "verdict": "UNTESTED"
+   }
+  ],
+  "untested_classes": [
+   "total_line"
+  ],
+  "verdict": "FAIL"
+ },
+ "tokens": {
+  "composed": false,
+  "ink_checked": 138,
+  "ink_evidence_missing": false,
+  "ink_missing_tokens": [
+   "REPRINT"
+  ],
+  "ink_recall": 0.9928,
+  "missing_tokens": [],
+  "precision_warn": false,
+  "text_precision": 1.0,
+  "text_recall": 1.0,
+  "verdict": "PASS"
+ }
+}
+```

--- a/evidence/grocery_structural_gap_separators/before/trader_joe_s.report.md
+++ b/evidence/grocery_structural_gap_separators/before/trader_joe_s.report.md
@@ -2,20 +2,20 @@
 
 - merchant: Trader Joe's
 - receipt: 4c262079-4fec-4724-a8e1-2886f38ea454#1
-- git: `e517d33fdc04`
+- git: `1d0dd32f5795`
 - truth: `trader_joe_s` v1 `557c433fcc1e5d74ca66a54f194cf4deca9e39976d26412dc0e1b5ebd778c418` (online-active)
-- atlas: `4c355fbd82e342b7`
+- atlas: `037dc0610504a9b9`
 
 ## OVERALL: FAIL
 
 | metric | verdict |
 |---|---|
 | columns | PASS |
-| style | FAIL |
+| style | PASS_WITH_GAPS |
 | tokens | PASS |
 | separators | FAIL |
 | graphics | PASS |
-| logo | FAIL |
+| logo | PASS |
 | arithmetic | PASS |
 
 ```json
@@ -30,7 +30,7 @@
     "status": "HOLDS"
    }
   ],
-  "n_items": 15,
+  "n_items": 14,
   "summary": {
    "tender": 63.66,
    "total": 63.66
@@ -66,13 +66,13 @@
       },
       "shear_px_per_100px": 1.57,
       "synth": {
-       "lane_mid_y_px": 814.5,
-       "lane_x_px": 738.63,
+       "lane_mid_y_px": 823.0,
+       "lane_x_px": 738.65,
        "median_dev_px": -6.64,
        "n_rows": 17,
        "outlier_frac": 0.0,
-       "tilt_px_per_100px": -0.592,
-       "wobble_iqr_px": 0.27
+       "tilt_px_per_100px": -0.599,
+       "wobble_iqr_px": 0.29
       },
       "verdict": "PASS",
       "wobble_limit_px": 3.8
@@ -87,6 +87,7 @@
   "verdict": "PASS"
  },
  "coverage_gaps": [
+  "style",
   "style:total_line"
  ],
  "graphics": {
@@ -98,25 +99,25 @@
   "verdict": "PASS"
  },
  "logo": {
-  "area_ratio": 0.313,
-  "center_offset_frac": 0.2158,
+  "area_ratio": 1.173,
+  "center_offset_frac": 0.0329,
   "real": {
-   "area": 13912.0,
-   "cx": 30.5,
-   "cy": 118.5,
-   "h": 238.0,
-   "w": 62.0
+   "area": 18139.0,
+   "cx": 410.5,
+   "cy": 48.0,
+   "h": 69.0,
+   "w": 612.0
   },
-  "size_ratio": 0.265,
+  "size_ratio": 0.971,
   "synth": {
-   "area": 4360.0,
-   "cx": 194.5,
-   "cy": 54.0,
-   "h": 63.0,
-   "w": 116.0
+   "area": 21272.0,
+   "cx": 385.5,
+   "cy": 55.0,
+   "h": 67.0,
+   "w": 600.0
   },
-  "verdict": "FAIL",
-  "width_ratio": 1.871
+  "verdict": "PASS",
+  "width_ratio": 0.98
  },
  "overall": "FAIL",
  "separators": {
@@ -138,25 +139,22 @@
   "body_stroke_fail": false,
   "body_stroke_rel": {
    "real": 0.1068,
-   "synth": 0.1068
+   "synth": 0.1565
   },
   "classes": [
    {
     "class": "footer",
-    "missing_style": [
-     "bold"
-    ],
     "real": {
      "bold": 1,
      "n": 2,
      "underline": 0
     },
     "synth": {
-     "bold": 0,
+     "bold": 1,
      "n": 2,
      "underline": 0
     },
-    "verdict": "FAIL"
+    "verdict": "PASS"
    },
    {
     "class": "payment",
@@ -190,16 +188,14 @@
   "untested_classes": [
    "total_line"
   ],
-  "verdict": "FAIL"
+  "verdict": "PASS_WITH_GAPS"
  },
  "tokens": {
   "composed": false,
   "ink_checked": 138,
   "ink_evidence_missing": false,
-  "ink_missing_tokens": [
-   "REPRINT"
-  ],
-  "ink_recall": 0.9928,
+  "ink_missing_tokens": [],
+  "ink_recall": 1.0,
   "missing_tokens": [],
   "precision_warn": false,
   "text_precision": 1.0,

--- a/evidence/grocery_structural_gap_separators/before/vons.checks.json
+++ b/evidence/grocery_structural_gap_separators/before/vons.checks.json
@@ -1,0 +1,348 @@
+{
+ "checks": {
+  "arithmetic": {
+   "identities": [
+    {
+     "detail": "",
+     "lhs": 3.5,
+     "name": "total_eq_tender",
+     "rhs": 61.13,
+     "status": "VIOLATED"
+    }
+   ],
+   "n_items": 19,
+   "summary": {
+    "change": 0.0,
+    "tax": 0.0,
+    "tender": 61.13,
+    "total": 3.5
+   },
+   "testable": 1,
+   "verdict": "FAIL",
+   "violated": 1
+  },
+  "columns": {
+   "bands": {
+    "ALL": {
+     "cell_w_px": 15.07,
+     "columns": [
+      {
+       "abs_drift_limit_px": 22.61,
+       "abs_drift_px": 11.0,
+       "column": {
+        "anchor": "right",
+        "role": "amount",
+        "spread": 0.0025,
+        "support": 13,
+        "x": 0.9524
+       },
+       "failed_on": [
+        "outliers"
+       ],
+       "outlier_limit": 0.15,
+       "real": {
+        "lane_mid_y_px": 1116.5,
+        "lane_x_px": 719.84,
+        "median_dev_px": -3.82,
+        "n_rows": 13,
+        "outlier_frac": 0.0,
+        "tilt_px_per_100px": 0.207,
+        "wobble_iqr_px": 0.5
+       },
+       "shear_px_per_100px": 0.07,
+       "synth": {
+        "lane_mid_y_px": 1116.5,
+        "lane_x_px": 709.0,
+        "median_dev_px": -14.82,
+        "n_rows": 13,
+        "outlier_frac": 0.154,
+        "tilt_px_per_100px": 0.28,
+        "wobble_iqr_px": 0.45
+       },
+       "verdict": "FAIL",
+       "wobble_limit_px": 3.5
+      },
+      {
+       "abs_drift_limit_px": 22.61,
+       "abs_drift_px": 7.5,
+       "column": {
+        "anchor": "left",
+        "role": "flag",
+        "spread": 0.0008,
+        "support": 10,
+        "x": 0.9586
+       },
+       "outlier_limit": 0.15,
+       "real": {
+        "lane_mid_y_px": 1074.2,
+        "lane_x_px": 735.58,
+        "median_dev_px": 7.46,
+        "n_rows": 10,
+        "outlier_frac": 0.0,
+        "tilt_px_per_100px": 0.19,
+        "wobble_iqr_px": 0.23
+       },
+       "shear_px_per_100px": 0.12,
+       "synth": {
+        "lane_mid_y_px": 1074.2,
+        "lane_x_px": 728.63,
+        "median_dev_px": -0.04,
+        "n_rows": 10,
+        "outlier_frac": 0.0,
+        "tilt_px_per_100px": 0.308,
+        "wobble_iqr_px": 0.74
+       },
+       "verdict": "PASS",
+       "wobble_limit_px": 2.96
+      }
+     ],
+     "lane_gaps": [
+      {
+       "delta_px": 3.89,
+       "limit_px": 11.3,
+       "pair": [
+        "amount",
+        "flag"
+       ],
+       "real_gap_px": 15.74,
+       "synth_gap_px": 19.63,
+       "verdict": "PASS"
+      }
+     ],
+     "source": "bootstrap",
+     "untested_roles": [],
+     "verdict": "FAIL"
+    }
+   },
+   "verdict": "FAIL"
+  },
+  "coverage_gaps": [
+   "style:barcode_caption",
+   "style:footer",
+   "style:section_header"
+  ],
+  "graphics": {
+   "matched": [],
+   "missing_in_synth": [
+    {
+     "kind": "1d",
+     "payload": "00313505101552502031820",
+     "symbology": "code128",
+     "x_frac": 0.0,
+     "y_frac": 1.0
+    }
+   ],
+   "phantom_in_synth": [],
+   "real": [
+    {
+     "kind": "1d",
+     "payload": "00313505101552502031820",
+     "symbology": "code128",
+     "x_frac": 0.0,
+     "y_frac": 1.0
+    }
+   ],
+   "synth": [],
+   "verdict": "FAIL"
+  },
+  "logo": {
+   "area_ratio": 0.992,
+   "center_offset_frac": 0.0125,
+   "real": {
+    "area": 7116.0,
+    "cx": 416.0,
+    "cy": 58.5,
+    "h": 110.0,
+    "w": 73.0
+   },
+   "size_ratio": 1.0,
+   "synth": {
+    "area": 7059.0,
+    "cx": 406.5,
+    "cy": 69.5,
+    "h": 110.0,
+    "w": 72.0
+   },
+   "verdict": "PASS",
+   "width_ratio": 0.986
+  },
+  "overall": "FAIL",
+  "separators": {
+   "kind_mismatches": 0,
+   "matched": [],
+   "missing_in_synth": [
+    {
+     "height_px": 2,
+     "kind": "dash",
+     "y_frac": 0.185
+    },
+    {
+     "height_px": 2,
+     "kind": "dash",
+     "y_frac": 0.5899
+    },
+    {
+     "height_px": 2,
+     "kind": "dash",
+     "y_frac": 0.6737
+    }
+   ],
+   "phantom_in_synth": [],
+   "real_count": 3,
+   "synth_count": 0,
+   "verdict": "FAIL"
+  },
+  "style": {
+   "body_stroke_fail": false,
+   "body_stroke_rel": {
+    "real": 0.0948,
+    "synth": 0.1336
+   },
+   "classes": [
+    {
+     "class": "address",
+     "missing_style": [
+      "bold"
+     ],
+     "real": {
+      "bold": 1,
+      "n": 2,
+      "underline": 0
+     },
+     "synth": {
+      "bold": 0,
+      "n": 2,
+      "underline": 0
+     },
+     "verdict": "FAIL"
+    },
+    {
+     "class": "barcode_caption",
+     "real": {
+      "bold": 0,
+      "n": 1,
+      "underline": 0
+     },
+     "synth": {
+      "bold": 0,
+      "n": 1,
+      "underline": 0
+     },
+     "verdict": "UNTESTED"
+    },
+    {
+     "class": "footer",
+     "real": {
+      "bold": 0,
+      "n": 1,
+      "underline": 0
+     },
+     "synth": {
+      "bold": 0,
+      "n": 1,
+      "underline": 0
+     },
+     "verdict": "UNTESTED"
+    },
+    {
+     "class": "payment",
+     "real": {
+      "bold": 0,
+      "n": 2,
+      "underline": 0
+     },
+     "synth": {
+      "bold": 0,
+      "n": 2,
+      "underline": 0
+     },
+     "verdict": "PASS"
+    },
+    {
+     "class": "section_header",
+     "real": {
+      "bold": 0,
+      "n": 1,
+      "underline": 0
+     },
+     "synth": {
+      "bold": 0,
+      "n": 1,
+      "underline": 0
+     },
+     "verdict": "UNTESTED"
+    },
+    {
+     "class": "summary",
+     "real": {
+      "bold": 0,
+      "n": 4,
+      "underline": 0
+     },
+     "synth": {
+      "bold": 0,
+      "n": 4,
+      "underline": 0
+     },
+     "verdict": "PASS"
+    },
+    {
+     "class": "total_line",
+     "real": {
+      "bold": 0,
+      "n": 3,
+      "underline": 0
+     },
+     "synth": {
+      "bold": 0,
+      "n": 3,
+      "underline": 0
+     },
+     "verdict": "PASS"
+    }
+   ],
+   "untested_classes": [
+    "barcode_caption",
+    "footer",
+    "section_header"
+   ],
+   "verdict": "FAIL"
+  },
+  "tokens": {
+   "composed": false,
+   "ink_checked": 196,
+   "ink_evidence_missing": false,
+   "ink_missing_tokens": [
+    "STORE",
+    "3135",
+    "DIR",
+    "CRUZ"
+   ],
+   "ink_recall": 0.9796,
+   "missing_tokens": [],
+   "precision_warn": false,
+   "text_precision": 1.0,
+   "text_recall": 1.0,
+   "verdict": "PASS"
+  }
+ },
+ "image_id": "678a7c94-4948-4ebf-b8e9-9a17c13051ec",
+ "mode": "real-vs-synth",
+ "receipt_id": 2,
+ "slug": "vons",
+ "stamp": {
+  "atlas_hash": "10428f512cce66eb",
+  "dirty": false,
+  "git_sha": "e517d33fdc043abfcbff5f70e87dfd21bccc8952",
+  "inputs_hash": "f77149cc37fc47e9",
+  "merchant": "Vons",
+  "merchant_truth": {
+   "bundle_hash": "63775db497ae88a596847c2ddea69cfa1271eda40b755c1e2fae87b36da506cb",
+   "expected_bundle_hash": "63775db497ae88a596847c2ddea69cfa1271eda40b755c1e2fae87b36da506cb",
+   "expected_version": 1,
+   "mode": "online-active",
+   "slug": "vons",
+   "version": 1
+  }
+ }
+}

--- a/evidence/grocery_structural_gap_separators/before/vons.checks.json
+++ b/evidence/grocery_structural_gap_separators/before/vons.checks.json
@@ -4,22 +4,22 @@
    "identities": [
     {
      "detail": "",
-     "lhs": 3.5,
+     "lhs": 61.13,
      "name": "total_eq_tender",
      "rhs": 61.13,
-     "status": "VIOLATED"
+     "status": "HOLDS"
     }
    ],
-   "n_items": 19,
+   "n_items": 12,
    "summary": {
     "change": 0.0,
     "tax": 0.0,
     "tender": 61.13,
-    "total": 3.5
+    "total": 61.13
    },
    "testable": 1,
-   "verdict": "FAIL",
-   "violated": 1
+   "verdict": "PASS",
+   "violated": 0
   },
   "columns": {
    "bands": {
@@ -36,9 +36,6 @@
         "support": 13,
         "x": 0.9524
        },
-       "failed_on": [
-        "outliers"
-       ],
        "outlier_limit": 0.15,
        "real": {
         "lane_mid_y_px": 1116.5,
@@ -51,15 +48,15 @@
        },
        "shear_px_per_100px": 0.07,
        "synth": {
-        "lane_mid_y_px": 1116.5,
-        "lane_x_px": 709.0,
+        "lane_mid_y_px": 1167.0,
+        "lane_x_px": 709.07,
         "median_dev_px": -14.82,
-        "n_rows": 13,
-        "outlier_frac": 0.154,
+        "n_rows": 14,
+        "outlier_frac": 0.0,
         "tilt_px_per_100px": 0.28,
-        "wobble_iqr_px": 0.45
+        "wobble_iqr_px": 0.32
        },
-       "verdict": "FAIL",
+       "verdict": "PASS",
        "wobble_limit_px": 3.5
       },
       {
@@ -82,15 +79,15 @@
         "tilt_px_per_100px": 0.19,
         "wobble_iqr_px": 0.23
        },
-       "shear_px_per_100px": 0.12,
+       "shear_px_per_100px": 0.02,
        "synth": {
-        "lane_mid_y_px": 1074.2,
-        "lane_x_px": 728.63,
+        "lane_mid_y_px": 1087.5,
+        "lane_x_px": 728.62,
         "median_dev_px": -0.04,
         "n_rows": 10,
         "outlier_frac": 0.0,
-        "tilt_px_per_100px": 0.308,
-        "wobble_iqr_px": 0.74
+        "tilt_px_per_100px": 0.206,
+        "wobble_iqr_px": 0.33
        },
        "verdict": "PASS",
        "wobble_limit_px": 2.96
@@ -98,23 +95,23 @@
      ],
      "lane_gaps": [
       {
-       "delta_px": 3.89,
+       "delta_px": 3.81,
        "limit_px": 11.3,
        "pair": [
         "amount",
         "flag"
        ],
        "real_gap_px": 15.74,
-       "synth_gap_px": 19.63,
+       "synth_gap_px": 19.55,
        "verdict": "PASS"
       }
      ],
      "source": "bootstrap",
      "untested_roles": [],
-     "verdict": "FAIL"
+     "verdict": "PASS"
     }
    },
-   "verdict": "FAIL"
+   "verdict": "PASS"
   },
   "coverage_gaps": [
    "style:barcode_caption",
@@ -122,16 +119,27 @@
    "style:section_header"
   ],
   "graphics": {
-   "matched": [],
-   "missing_in_synth": [
+   "matched": [
     {
-     "kind": "1d",
-     "payload": "00313505101552502031820",
-     "symbology": "code128",
-     "x_frac": 0.0,
-     "y_frac": 1.0
+     "dy": 0.0,
+     "payload_match": true,
+     "real": {
+      "kind": "1d",
+      "payload": "00313505101552502031820",
+      "symbology": "code128",
+      "x_frac": 0.0,
+      "y_frac": 1.0
+     },
+     "synth": {
+      "kind": "1d",
+      "payload": "00313505101552502031820",
+      "symbology": "code128",
+      "x_frac": 0.0,
+      "y_frac": 1.0
+     }
     }
    ],
+   "missing_in_synth": [],
    "phantom_in_synth": [],
    "real": [
     {
@@ -142,29 +150,37 @@
      "y_frac": 1.0
     }
    ],
-   "synth": [],
-   "verdict": "FAIL"
+   "synth": [
+    {
+     "kind": "1d",
+     "payload": "00313505101552502031820",
+     "symbology": "code128",
+     "x_frac": 0.0,
+     "y_frac": 1.0
+    }
+   ],
+   "verdict": "PASS"
   },
   "logo": {
-   "area_ratio": 0.992,
-   "center_offset_frac": 0.0125,
+   "area_ratio": 0.999,
+   "center_offset_frac": 0.0105,
    "real": {
-    "area": 7116.0,
-    "cx": 416.0,
-    "cy": 58.5,
-    "h": 110.0,
-    "w": 73.0
+    "area": 24447.0,
+    "cx": 378.5,
+    "cy": 58.0,
+    "h": 113.0,
+    "w": 294.0
    },
-   "size_ratio": 1.0,
+   "size_ratio": 1.009,
    "synth": {
-    "area": 7059.0,
-    "cx": 406.5,
-    "cy": 69.5,
-    "h": 110.0,
-    "w": 72.0
+    "area": 24431.0,
+    "cx": 370.5,
+    "cy": 70.5,
+    "h": 114.0,
+    "w": 288.0
    },
    "verdict": "PASS",
-   "width_ratio": 0.986
+   "width_ratio": 0.98
   },
   "overall": "FAIL",
   "separators": {
@@ -196,7 +212,7 @@
    "body_stroke_fail": false,
    "body_stroke_rel": {
     "real": 0.0948,
-    "synth": 0.1336
+    "synth": 0.1658
    },
    "classes": [
     {
@@ -312,17 +328,15 @@
    "composed": false,
    "ink_checked": 196,
    "ink_evidence_missing": false,
-   "ink_missing_tokens": [
-    "STORE",
-    "3135",
-    "DIR",
-    "CRUZ"
+   "ink_missing_tokens": [],
+   "ink_recall": 1.0,
+   "missing_tokens": [
+    "FRENCH",
+    "ROAST"
    ],
-   "ink_recall": 0.9796,
-   "missing_tokens": [],
    "precision_warn": false,
-   "text_precision": 1.0,
-   "text_recall": 1.0,
+   "text_precision": 0.9898,
+   "text_recall": 0.9898,
    "verdict": "PASS"
   }
  },
@@ -331,10 +345,10 @@
  "receipt_id": 2,
  "slug": "vons",
  "stamp": {
-  "atlas_hash": "10428f512cce66eb",
+  "atlas_hash": "6ca4cb5cda99dd4c",
   "dirty": false,
-  "git_sha": "e517d33fdc043abfcbff5f70e87dfd21bccc8952",
-  "inputs_hash": "f77149cc37fc47e9",
+  "git_sha": "1d0dd32f57955f7f312eedcd88688b2ae8f96a8b",
+  "inputs_hash": "8295c5c2af35b3b2",
   "merchant": "Vons",
   "merchant_truth": {
    "bundle_hash": "63775db497ae88a596847c2ddea69cfa1271eda40b755c1e2fae87b36da506cb",

--- a/evidence/grocery_structural_gap_separators/before/vons.report.md
+++ b/evidence/grocery_structural_gap_separators/before/vons.report.md
@@ -1,0 +1,349 @@
+# full_fidelity_eval -- vons
+
+- merchant: Vons
+- receipt: 678a7c94-4948-4ebf-b8e9-9a17c13051ec#2
+- git: `e517d33fdc04`
+- truth: `vons` v1 `63775db497ae88a596847c2ddea69cfa1271eda40b755c1e2fae87b36da506cb` (online-active)
+- atlas: `10428f512cce66eb`
+
+## OVERALL: FAIL
+
+| metric | verdict |
+|---|---|
+| columns | FAIL |
+| style | FAIL |
+| tokens | PASS |
+| separators | FAIL |
+| graphics | FAIL |
+| logo | PASS |
+| arithmetic | FAIL |
+
+```json
+{
+ "arithmetic": {
+  "identities": [
+   {
+    "detail": "",
+    "lhs": 3.5,
+    "name": "total_eq_tender",
+    "rhs": 61.13,
+    "status": "VIOLATED"
+   }
+  ],
+  "n_items": 19,
+  "summary": {
+   "change": 0.0,
+   "tax": 0.0,
+   "tender": 61.13,
+   "total": 3.5
+  },
+  "testable": 1,
+  "verdict": "FAIL",
+  "violated": 1
+ },
+ "columns": {
+  "bands": {
+   "ALL": {
+    "cell_w_px": 15.07,
+    "columns": [
+     {
+      "abs_drift_limit_px": 22.61,
+      "abs_drift_px": 11.0,
+      "column": {
+       "anchor": "right",
+       "role": "amount",
+       "spread": 0.0025,
+       "support": 13,
+       "x": 0.9524
+      },
+      "failed_on": [
+       "outliers"
+      ],
+      "outlier_limit": 0.15,
+      "real": {
+       "lane_mid_y_px": 1116.5,
+       "lane_x_px": 719.84,
+       "median_dev_px": -3.82,
+       "n_rows": 13,
+       "outlier_frac": 0.0,
+       "tilt_px_per_100px": 0.207,
+       "wobble_iqr_px": 0.5
+      },
+      "shear_px_per_100px": 0.07,
+      "synth": {
+       "lane_mid_y_px": 1116.5,
+       "lane_x_px": 709.0,
+       "median_dev_px": -14.82,
+       "n_rows": 13,
+       "outlier_frac": 0.154,
+       "tilt_px_per_100px": 0.28,
+       "wobble_iqr_px": 0.45
+      },
+      "verdict": "FAIL",
+      "wobble_limit_px": 3.5
+     },
+     {
+      "abs_drift_limit_px": 22.61,
+      "abs_drift_px": 7.5,
+      "column": {
+       "anchor": "left",
+       "role": "flag",
+       "spread": 0.0008,
+       "support": 10,
+       "x": 0.9586
+      },
+      "outlier_limit": 0.15,
+      "real": {
+       "lane_mid_y_px": 1074.2,
+       "lane_x_px": 735.58,
+       "median_dev_px": 7.46,
+       "n_rows": 10,
+       "outlier_frac": 0.0,
+       "tilt_px_per_100px": 0.19,
+       "wobble_iqr_px": 0.23
+      },
+      "shear_px_per_100px": 0.12,
+      "synth": {
+       "lane_mid_y_px": 1074.2,
+       "lane_x_px": 728.63,
+       "median_dev_px": -0.04,
+       "n_rows": 10,
+       "outlier_frac": 0.0,
+       "tilt_px_per_100px": 0.308,
+       "wobble_iqr_px": 0.74
+      },
+      "verdict": "PASS",
+      "wobble_limit_px": 2.96
+     }
+    ],
+    "lane_gaps": [
+     {
+      "delta_px": 3.89,
+      "limit_px": 11.3,
+      "pair": [
+       "amount",
+       "flag"
+      ],
+      "real_gap_px": 15.74,
+      "synth_gap_px": 19.63,
+      "verdict": "PASS"
+     }
+    ],
+    "source": "bootstrap",
+    "untested_roles": [],
+    "verdict": "FAIL"
+   }
+  },
+  "verdict": "FAIL"
+ },
+ "coverage_gaps": [
+  "style:barcode_caption",
+  "style:footer",
+  "style:section_header"
+ ],
+ "graphics": {
+  "matched": [],
+  "missing_in_synth": [
+   {
+    "kind": "1d",
+    "payload": "00313505101552502031820",
+    "symbology": "code128",
+    "x_frac": 0.0,
+    "y_frac": 1.0
+   }
+  ],
+  "phantom_in_synth": [],
+  "real": [
+   {
+    "kind": "1d",
+    "payload": "00313505101552502031820",
+    "symbology": "code128",
+    "x_frac": 0.0,
+    "y_frac": 1.0
+   }
+  ],
+  "synth": [],
+  "verdict": "FAIL"
+ },
+ "logo": {
+  "area_ratio": 0.992,
+  "center_offset_frac": 0.0125,
+  "real": {
+   "area": 7116.0,
+   "cx": 416.0,
+   "cy": 58.5,
+   "h": 110.0,
+   "w": 73.0
+  },
+  "size_ratio": 1.0,
+  "synth": {
+   "area": 7059.0,
+   "cx": 406.5,
+   "cy": 69.5,
+   "h": 110.0,
+   "w": 72.0
+  },
+  "verdict": "PASS",
+  "width_ratio": 0.986
+ },
+ "overall": "FAIL",
+ "separators": {
+  "kind_mismatches": 0,
+  "matched": [],
+  "missing_in_synth": [
+   {
+    "height_px": 2,
+    "kind": "dash",
+    "y_frac": 0.185
+   },
+   {
+    "height_px": 2,
+    "kind": "dash",
+    "y_frac": 0.5899
+   },
+   {
+    "height_px": 2,
+    "kind": "dash",
+    "y_frac": 0.6737
+   }
+  ],
+  "phantom_in_synth": [],
+  "real_count": 3,
+  "synth_count": 0,
+  "verdict": "FAIL"
+ },
+ "style": {
+  "body_stroke_fail": false,
+  "body_stroke_rel": {
+   "real": 0.0948,
+   "synth": 0.1336
+  },
+  "classes": [
+   {
+    "class": "address",
+    "missing_style": [
+     "bold"
+    ],
+    "real": {
+     "bold": 1,
+     "n": 2,
+     "underline": 0
+    },
+    "synth": {
+     "bold": 0,
+     "n": 2,
+     "underline": 0
+    },
+    "verdict": "FAIL"
+   },
+   {
+    "class": "barcode_caption",
+    "real": {
+     "bold": 0,
+     "n": 1,
+     "underline": 0
+    },
+    "synth": {
+     "bold": 0,
+     "n": 1,
+     "underline": 0
+    },
+    "verdict": "UNTESTED"
+   },
+   {
+    "class": "footer",
+    "real": {
+     "bold": 0,
+     "n": 1,
+     "underline": 0
+    },
+    "synth": {
+     "bold": 0,
+     "n": 1,
+     "underline": 0
+    },
+    "verdict": "UNTESTED"
+   },
+   {
+    "class": "payment",
+    "real": {
+     "bold": 0,
+     "n": 2,
+     "underline": 0
+    },
+    "synth": {
+     "bold": 0,
+     "n": 2,
+     "underline": 0
+    },
+    "verdict": "PASS"
+   },
+   {
+    "class": "section_header",
+    "real": {
+     "bold": 0,
+     "n": 1,
+     "underline": 0
+    },
+    "synth": {
+     "bold": 0,
+     "n": 1,
+     "underline": 0
+    },
+    "verdict": "UNTESTED"
+   },
+   {
+    "class": "summary",
+    "real": {
+     "bold": 0,
+     "n": 4,
+     "underline": 0
+    },
+    "synth": {
+     "bold": 0,
+     "n": 4,
+     "underline": 0
+    },
+    "verdict": "PASS"
+   },
+   {
+    "class": "total_line",
+    "real": {
+     "bold": 0,
+     "n": 3,
+     "underline": 0
+    },
+    "synth": {
+     "bold": 0,
+     "n": 3,
+     "underline": 0
+    },
+    "verdict": "PASS"
+   }
+  ],
+  "untested_classes": [
+   "barcode_caption",
+   "footer",
+   "section_header"
+  ],
+  "verdict": "FAIL"
+ },
+ "tokens": {
+  "composed": false,
+  "ink_checked": 196,
+  "ink_evidence_missing": false,
+  "ink_missing_tokens": [
+   "STORE",
+   "3135",
+   "DIR",
+   "CRUZ"
+  ],
+  "ink_recall": 0.9796,
+  "missing_tokens": [],
+  "precision_warn": false,
+  "text_precision": 1.0,
+  "text_recall": 1.0,
+  "verdict": "PASS"
+ }
+}
+```

--- a/evidence/grocery_structural_gap_separators/before/vons.report.md
+++ b/evidence/grocery_structural_gap_separators/before/vons.report.md
@@ -2,21 +2,21 @@
 
 - merchant: Vons
 - receipt: 678a7c94-4948-4ebf-b8e9-9a17c13051ec#2
-- git: `e517d33fdc04`
+- git: `1d0dd32f5795`
 - truth: `vons` v1 `63775db497ae88a596847c2ddea69cfa1271eda40b755c1e2fae87b36da506cb` (online-active)
-- atlas: `10428f512cce66eb`
+- atlas: `6ca4cb5cda99dd4c`
 
 ## OVERALL: FAIL
 
 | metric | verdict |
 |---|---|
-| columns | FAIL |
+| columns | PASS |
 | style | FAIL |
 | tokens | PASS |
 | separators | FAIL |
-| graphics | FAIL |
+| graphics | PASS |
 | logo | PASS |
-| arithmetic | FAIL |
+| arithmetic | PASS |
 
 ```json
 {
@@ -24,22 +24,22 @@
   "identities": [
    {
     "detail": "",
-    "lhs": 3.5,
+    "lhs": 61.13,
     "name": "total_eq_tender",
     "rhs": 61.13,
-    "status": "VIOLATED"
+    "status": "HOLDS"
    }
   ],
-  "n_items": 19,
+  "n_items": 12,
   "summary": {
    "change": 0.0,
    "tax": 0.0,
    "tender": 61.13,
-   "total": 3.5
+   "total": 61.13
   },
   "testable": 1,
-  "verdict": "FAIL",
-  "violated": 1
+  "verdict": "PASS",
+  "violated": 0
  },
  "columns": {
   "bands": {
@@ -56,9 +56,6 @@
        "support": 13,
        "x": 0.9524
       },
-      "failed_on": [
-       "outliers"
-      ],
       "outlier_limit": 0.15,
       "real": {
        "lane_mid_y_px": 1116.5,
@@ -71,15 +68,15 @@
       },
       "shear_px_per_100px": 0.07,
       "synth": {
-       "lane_mid_y_px": 1116.5,
-       "lane_x_px": 709.0,
+       "lane_mid_y_px": 1167.0,
+       "lane_x_px": 709.07,
        "median_dev_px": -14.82,
-       "n_rows": 13,
-       "outlier_frac": 0.154,
+       "n_rows": 14,
+       "outlier_frac": 0.0,
        "tilt_px_per_100px": 0.28,
-       "wobble_iqr_px": 0.45
+       "wobble_iqr_px": 0.32
       },
-      "verdict": "FAIL",
+      "verdict": "PASS",
       "wobble_limit_px": 3.5
      },
      {
@@ -102,15 +99,15 @@
        "tilt_px_per_100px": 0.19,
        "wobble_iqr_px": 0.23
       },
-      "shear_px_per_100px": 0.12,
+      "shear_px_per_100px": 0.02,
       "synth": {
-       "lane_mid_y_px": 1074.2,
-       "lane_x_px": 728.63,
+       "lane_mid_y_px": 1087.5,
+       "lane_x_px": 728.62,
        "median_dev_px": -0.04,
        "n_rows": 10,
        "outlier_frac": 0.0,
-       "tilt_px_per_100px": 0.308,
-       "wobble_iqr_px": 0.74
+       "tilt_px_per_100px": 0.206,
+       "wobble_iqr_px": 0.33
       },
       "verdict": "PASS",
       "wobble_limit_px": 2.96
@@ -118,23 +115,23 @@
     ],
     "lane_gaps": [
      {
-      "delta_px": 3.89,
+      "delta_px": 3.81,
       "limit_px": 11.3,
       "pair": [
        "amount",
        "flag"
       ],
       "real_gap_px": 15.74,
-      "synth_gap_px": 19.63,
+      "synth_gap_px": 19.55,
       "verdict": "PASS"
      }
     ],
     "source": "bootstrap",
     "untested_roles": [],
-    "verdict": "FAIL"
+    "verdict": "PASS"
    }
   },
-  "verdict": "FAIL"
+  "verdict": "PASS"
  },
  "coverage_gaps": [
   "style:barcode_caption",
@@ -142,16 +139,27 @@
   "style:section_header"
  ],
  "graphics": {
-  "matched": [],
-  "missing_in_synth": [
+  "matched": [
    {
-    "kind": "1d",
-    "payload": "00313505101552502031820",
-    "symbology": "code128",
-    "x_frac": 0.0,
-    "y_frac": 1.0
+    "dy": 0.0,
+    "payload_match": true,
+    "real": {
+     "kind": "1d",
+     "payload": "00313505101552502031820",
+     "symbology": "code128",
+     "x_frac": 0.0,
+     "y_frac": 1.0
+    },
+    "synth": {
+     "kind": "1d",
+     "payload": "00313505101552502031820",
+     "symbology": "code128",
+     "x_frac": 0.0,
+     "y_frac": 1.0
+    }
    }
   ],
+  "missing_in_synth": [],
   "phantom_in_synth": [],
   "real": [
    {
@@ -162,29 +170,37 @@
     "y_frac": 1.0
    }
   ],
-  "synth": [],
-  "verdict": "FAIL"
+  "synth": [
+   {
+    "kind": "1d",
+    "payload": "00313505101552502031820",
+    "symbology": "code128",
+    "x_frac": 0.0,
+    "y_frac": 1.0
+   }
+  ],
+  "verdict": "PASS"
  },
  "logo": {
-  "area_ratio": 0.992,
-  "center_offset_frac": 0.0125,
+  "area_ratio": 0.999,
+  "center_offset_frac": 0.0105,
   "real": {
-   "area": 7116.0,
-   "cx": 416.0,
-   "cy": 58.5,
-   "h": 110.0,
-   "w": 73.0
+   "area": 24447.0,
+   "cx": 378.5,
+   "cy": 58.0,
+   "h": 113.0,
+   "w": 294.0
   },
-  "size_ratio": 1.0,
+  "size_ratio": 1.009,
   "synth": {
-   "area": 7059.0,
-   "cx": 406.5,
-   "cy": 69.5,
-   "h": 110.0,
-   "w": 72.0
+   "area": 24431.0,
+   "cx": 370.5,
+   "cy": 70.5,
+   "h": 114.0,
+   "w": 288.0
   },
   "verdict": "PASS",
-  "width_ratio": 0.986
+  "width_ratio": 0.98
  },
  "overall": "FAIL",
  "separators": {
@@ -216,7 +232,7 @@
   "body_stroke_fail": false,
   "body_stroke_rel": {
    "real": 0.0948,
-   "synth": 0.1336
+   "synth": 0.1658
   },
   "classes": [
    {
@@ -332,17 +348,15 @@
   "composed": false,
   "ink_checked": 196,
   "ink_evidence_missing": false,
-  "ink_missing_tokens": [
-   "STORE",
-   "3135",
-   "DIR",
-   "CRUZ"
+  "ink_missing_tokens": [],
+  "ink_recall": 1.0,
+  "missing_tokens": [
+   "FRENCH",
+   "ROAST"
   ],
-  "ink_recall": 0.9796,
-  "missing_tokens": [],
   "precision_warn": false,
-  "text_precision": 1.0,
-  "text_recall": 1.0,
+  "text_precision": 0.9898,
+  "text_recall": 0.9898,
   "verdict": "PASS"
  }
 }

--- a/receipt_agent/receipt_agent/agents/label_evaluator/rendering/receipt_renderer.py
+++ b/receipt_agent/receipt_agent/agents/label_evaluator/rendering/receipt_renderer.py
@@ -494,6 +494,95 @@ def _inferred_policy_separator_baselines(
     return inferred
 
 
+def _is_barcode_hri(line: Sequence[GridWord]) -> bool:
+    """Whether a row is the human-readable digits printed under a barcode."""
+    text = "".join(word.text for word in line)
+    compact = re.sub(r"[\s\-./]", "", text)
+    return len(compact) >= 14 and compact.isdigit()
+
+
+def _is_tender_summary(line: Sequence[GridWord], text: str) -> bool:
+    """Whether a row closes the sale with a balance or card-tender amount."""
+    if not any(is_price_token(word.text) for word in line):
+        return False
+    if "BALANCE" in text:
+        return True
+    return any(
+        token in text
+        for token in ("VISA", "MASTERCARD", "MASTER CARD", "AMEX", "DEBIT")
+    )
+
+
+def _is_structural_gap_transition(
+    before: Sequence[GridWord],
+    after: Sequence[GridWord],
+) -> bool:
+    """Recognize receipt-section boundaries which commonly carry a dash rule.
+
+    This is deliberately semantic rather than merchant-specific: barcode HRI
+    to cashier copy, tender summary to transaction detail, and payment amount
+    to card-network detail are all printer-format transitions shared by grocery
+    and POS receipts. Geometry remains the deciding signal; the transition is
+    considered only when the source OCR also preserves a substantial blank gap.
+    """
+    before_text = " ".join(word.text for word in before).upper()
+    after_text = " ".join(word.text for word in after).upper()
+
+    barcode_to_staff = _is_barcode_hri(before) and any(
+        marker in after_text for marker in ("CASHIER", "CLERK", "SERVER")
+    )
+    tender_to_transaction = _is_tender_summary(before, before_text) and any(
+        marker in after_text for marker in ("PURCHASE", "TRANSACTION")
+    )
+    amount_to_network = (
+        "PAYMENT" in before_text
+        and "AMOUNT" in before_text
+        and any(marker in after_text for marker in ("DEBIT", "CREDIT"))
+        and not any(is_price_token(word.text) for word in after)
+    )
+    return barcode_to_staff or tender_to_transaction or amount_to_network
+
+
+def _structural_gap_separator_centers(
+    rows: Sequence[Sequence[GridWord]],
+    min_gap: float,
+) -> list[float]:
+    """Return separator centers already reserved by source OCR whitespace.
+
+    Unlike the explicit ``dashed_separators`` treatment for OCR-dropped rows,
+    these rules consume no new line pitch and therefore never shift text.
+    """
+    centers: list[float] = []
+    for before, after in zip(rows, rows[1:]):
+        gap_top = max(word.bottom for word in before)
+        gap_bottom = min(word.top for word in after)
+        if gap_bottom - gap_top < min_gap:
+            continue
+        if _is_structural_gap_transition(before, after):
+            centers.append((gap_top + gap_bottom) / 2.0)
+    return centers
+
+
+def _dash_baseline_for_center(
+    center_y: float,
+    font,
+    *,
+    bitmap_font=None,
+    cap_px: int | None = None,
+) -> float:
+    """Convert a desired dash ink center into the renderer's baseline y."""
+    if bitmap_font is not None:
+        glyph = bitmap_font.glyph("-", cap_px or font.size)
+        if glyph is not None:
+            _, height, baseline_offset = glyph
+            return center_y - baseline_offset + height / 2.0
+    try:
+        _, top, _, bottom = font.getbbox("-", anchor="ls")
+    except (AttributeError, TypeError, ValueError):
+        return center_y
+    return center_y - (top + bottom) / 2.0
+
+
 def _is_asterisk_rule(row_text: str) -> bool:
     chars = [ch for ch in row_text if not ch.isspace()]
     if len(chars) < 3 or any(ch.isalnum() for ch in chars):
@@ -889,6 +978,20 @@ def _render_grid(
         if isinstance(entry, Mapping)
     ]
     measured_separator_used: set[int] = set()
+    # Some POS formats leave the separator's full line of whitespace in OCR
+    # even though OCR drops the dashes themselves. Recover only semantic section
+    # transitions and draw at the source gap's measured midpoint. Existing
+    # explicit dashed-separator formats retain their profile-driven behavior.
+    # Like every other heuristic source, this yields to a measured inventory.
+    gap_dash_centers = (
+        _structural_gap_separator_centers(rows, min_pitch * 0.55)
+        if (
+            config.separators is None
+            and config.mixed_layout
+            and not config.dashed_separators
+        )
+        else []
+    )
     row_cache: dict[tuple, tuple] = {}
     prev_text = ""
     for line, baseline, sect, canonical_section in zip(
@@ -1216,6 +1319,50 @@ def _render_grid(
             cap_px=cap_px,
             bitmap_thin=config.bitmap_thin,
         )
+    for center_y in gap_dash_centers:
+        gap_baseline = _dash_baseline_for_center(
+            center_y, font, bitmap_font=dash_bmf, cap_px=cap_px
+        )
+        _draw_dash_row(
+            draw,
+            content_left,
+            content_right,
+            gap_baseline,
+            spec,
+            font,
+            ink=_ink_for({}, config),
+            stroke=config.stroke,
+            condense=config.condense,
+            condense_glyphs=config.condense_glyphs,
+            bitmap_font=dash_bmf,
+            cap_px=cap_px,
+            bitmap_thin=config.bitmap_thin,
+        )
+        # Very short atlas dash glyphs can cover the full rule span on only
+        # their middle scanline; a real thermal separator is at least two dot
+        # rows high. A one-pixel second strike restores that physical thickness
+        # without widening the rule or moving surrounding text.
+        dash_glyph = (
+            dash_bmf.glyph("-", cap_px or font.size)
+            if dash_bmf is not None
+            else None
+        )
+        if dash_glyph is not None and dash_glyph[1] <= 3:
+            _draw_dash_row(
+                draw,
+                content_left,
+                content_right,
+                gap_baseline + 1,
+                spec,
+                font,
+                ink=_ink_for({}, config),
+                stroke=config.stroke,
+                condense=config.condense,
+                condense_glyphs=config.condense_glyphs,
+                bitmap_font=dash_bmf,
+                cap_px=cap_px,
+                bitmap_thin=config.bitmap_thin,
+            )
     # Measured rows without a corresponding literal OCR token are still part
     # of the observed merchant inventory. Draw each at its measured paper
     # fraction without reserving a synthetic blank row or shifting downstream

--- a/receipt_agent/tests/test_receipt_gap_separators.py
+++ b/receipt_agent/tests/test_receipt_gap_separators.py
@@ -1,0 +1,53 @@
+"""Tests for semantic dash rules recovered from structural OCR gaps."""
+
+from receipt_agent.agents.label_evaluator.rendering.receipt_grid import (
+    GridWord,
+)
+from receipt_agent.agents.label_evaluator.rendering.receipt_renderer import (
+    _structural_gap_separator_centers,
+)
+
+
+def _row(top: float, bottom: float, *texts: str) -> list[GridWord]:
+    return [
+        GridWord(
+            left=index * 80.0,
+            top=top,
+            right=index * 80.0 + 70.0,
+            bottom=bottom,
+            text=text,
+            ink=(0, 0, 0),
+        )
+        for index, text in enumerate(texts)
+    ]
+
+
+def test_structural_gap_rules_cover_generic_pos_transitions() -> None:
+    rows = [
+        _row(10, 20, "00313505101552502031820"),
+        _row(50, 60, "YOUR CASHIER TODAY WAS SELF"),
+        _row(70, 80, "**** BALANCE", "61.13"),
+        _row(110, 120, "Credit Purchase", "02/03/25"),
+        _row(130, 140, "PAYMENT AMOUNT", "61.13"),
+        _row(170, 180, "AL US DEBIT"),
+        _row(190, 200, "Visa Debit", "$63.66"),
+        _row(230, 240, "PAYMENT CARD PURCHASE TRANSACTION"),
+    ]
+
+    assert _structural_gap_separator_centers(rows, min_gap=20) == [
+        35.0,
+        95.0,
+        155.0,
+        215.0,
+    ]
+
+
+def test_structural_gap_rules_require_both_semantics_and_whitespace() -> None:
+    rows = [
+        _row(10, 20, "**** BALANCE", "61.13"),
+        _row(25, 35, "Credit Purchase"),
+        _row(70, 80, "LOYALTY BALANCE", "5.00"),
+        _row(110, 120, "POINTS SUMMARY"),
+    ]
+
+    assert _structural_gap_separator_centers(rows, min_gap=20) == []


### PR DESCRIPTION
## Summary

- infer OCR-dropped dash rules only at semantic block transitions with measured blank-row evidence
- draw inside existing whitespace without shifting later receipt rows
- cover Vons barcode/cashier and payment/EMV transitions plus Trader Joe's tender/card-slip transition
- avoid merchant-name hardcodes and preserve all non-separator metric output
- commit complete before/after reports and guard results

## Fidelity proof

### Vons `678a7c94-4948-4ebf-b8e9-9a17c13051ec#2`

- before: FAIL, real 3 / synth 0
- after: PASS, 3/3 matched; y deltas `0.0015`, `0.0044`, `0.0000`

### Trader Joe's `4c262079-4fec-4724-a8e1-2886f38ea454#1`

- before: FAIL, real 1 / synth 0
- after: PASS, 1/1 matched; y delta `0.0010`

For both receipts, the non-separator check JSON is byte-identical before/after.

Evidence and summary: `synthesis_loop/evidence/grocery_structural_gap_separators/`.

## Verification

- focused tests: 26 passed
- corpus regression gate: PASS, zero findings
- render guard: Costco golden/new and Sprouts byte-identical; only intended Vons target changed
- `git diff --check`: clean
- no DynamoDB writes

Ready for independent review. Do not merge until CI and owner review complete.

## Rebase validation
- Python 3.12 receipt-agent suite: 333 passed, 22 skipped
- Python 3.12 repository suite: 565 passed, 1 skipped
- corpus regression gate: `ok: true`, zero findings (eval-logic pin)
- production-render comparison against same-machine `origin/main`: both Costco pins and Sprouts byte-identical; only intended Vons target changed
