### PR TITLE
[receipt_renderer] Preserve near-body amount lanes

### DIFF
--- a/receipt_agent/receipt_agent/agents/label_evaluator/rendering/receipt_renderer.py
+++ b/receipt_agent/receipt_agent/agents/label_evaluator/rendering/receipt_renderer.py
@@ -281,6 +281,18 @@ def _scaled_bitmap_thin(base_thin: float, scale: float) -> float:
     return min(0.9, base + 2.0 * (1.0 - safe_scale))
 
 
+def remap_grid_column(
+    column: float | None,
+    source: GridSpec,
+    target: GridSpec,
+) -> float | None:
+    """Keep a shared lane on the same pixel edge across scaled row grids."""
+    if column is None:
+        return None
+    pixel_x = source.grid_left + float(column) * source.cell_w
+    return (pixel_x - target.grid_left) / max(target.cell_w, 1e-6)
+
+
 def render_receipt(
     receipt: Mapping[str, Any],
     *,
@@ -1052,9 +1064,16 @@ def _render_grid(
             row_cache[key] = (row_spec, row_font, row_cap)
             cached = row_cache[key]
         row_spec, row_font, row_cap = cached
-        # Lane only applies when the row shares the base cell grid (scale 1.0
-        # AND base condense -- a per-section condense changes the cell width).
-        lane = amount_lane if sc == 1.0 and sect_cond == 1.0 else None
+        # A small typographic size nudge still shares the body amount column:
+        # project that paper-space edge through pixels into the row grid.
+        # Larger section scales and per-section condensation describe a
+        # genuinely distinct layout, preserving the legacy no-lane behavior.
+        shares_body_lane = sect_cond == 1.0 and abs(sc - 1.0) < 0.05
+        lane = (
+            remap_grid_column(amount_lane, spec, row_spec)
+            if shares_body_lane
+            else None
+        )
         cp = (
             row_cap
             if row_cap

--- a/receipt_agent/tests/test_section_style.py
+++ b/receipt_agent/tests/test_section_style.py
@@ -5,7 +5,11 @@ import pytest
 from receipt_agent.agents.label_evaluator.rendering.receipt_renderer import (
     _scaled_bitmap_thin,
     _stylemap_uses_underlines,
+    remap_grid_column,
     section_style,
+)
+from receipt_agent.agents.label_evaluator.rendering.receipt_grid import (
+    GridSpec,
 )
 
 
@@ -24,6 +28,18 @@ def test_mapping_defaults_missing_keys_to_noop():
     assert section_style({"condense": 0.85}) == (1.0, 0.85)
     assert section_style({"height_scale": 0.9}) == (0.9, 1.0)
     assert section_style({}) == (1.0, 1.0)
+
+
+def test_scaled_row_amount_lane_keeps_the_same_pixel_edge():
+    base = GridSpec(cell_w=10.0, cell_h=18.0, font_px=12, grid_left=8.0)
+    scaled = GridSpec(cell_w=12.5, cell_h=18.0, font_px=15, grid_left=8.0)
+
+    mapped = remap_grid_column(30.0, base, scaled)
+
+    assert mapped == 24.0
+    assert base.grid_left + 30.0 * base.cell_w == (
+        scaled.grid_left + mapped * scaled.cell_w
+    )
 
 
 def test_date_time_header_vote_is_positional():

--- a/receipt_agent/tests/test_section_style.py
+++ b/receipt_agent/tests/test_section_style.py
@@ -2,14 +2,14 @@
 
 import pytest
 
+from receipt_agent.agents.label_evaluator.rendering.receipt_grid import (
+    GridSpec,
+)
 from receipt_agent.agents.label_evaluator.rendering.receipt_renderer import (
     _scaled_bitmap_thin,
     _stylemap_uses_underlines,
     remap_grid_column,
     section_style,
-)
-from receipt_agent.agents.label_evaluator.rendering.receipt_grid import (
-    GridSpec,
 )
 
 

--- a/synthesis_loop/evidence/vons_v1_columns.after.json
+++ b/synthesis_loop/evidence/vons_v1_columns.after.json
@@ -1,0 +1,52 @@
+{
+  "git_sha": "cb42230e916c7b8889c7c7ecfdb311388ba95355",
+  "dirty": false,
+  "bundle_hash": "63775db497ae88a596847c2ddea69cfa1271eda40b755c1e2fae87b36da506cb",
+  "image_id": "678a7c94-4948-4ebf-b8e9-9a17c13051ec",
+  "metric": "columns",
+  "receipt_id": 2,
+  "result": {
+    "amount": {
+      "abs_drift_px": 11.0,
+      "outlier_limit": 0.15,
+      "real": {
+        "lane_x_px": 719.84,
+        "n_rows": 13,
+        "outlier_frac": 0.0,
+        "wobble_iqr_px": 0.5
+      },
+      "synth": {
+        "lane_x_px": 708.93,
+        "n_rows": 13,
+        "outlier_frac": 0.077,
+        "wobble_iqr_px": 0.41
+      },
+      "verdict": "PASS"
+    },
+    "flag": {
+      "abs_drift_px": 7.5,
+      "real": {
+        "lane_x_px": 735.58,
+        "n_rows": 10,
+        "outlier_frac": 0.0,
+        "wobble_iqr_px": 0.23
+      },
+      "synth": {
+        "lane_x_px": 728.63,
+        "n_rows": 10,
+        "outlier_frac": 0.0,
+        "wobble_iqr_px": 0.74
+      },
+      "verdict": "PASS"
+    },
+    "lane_gap": {
+      "delta_px": 3.96,
+      "limit_px": 11.3,
+      "real_gap_px": 15.74,
+      "synth_gap_px": 19.7,
+      "verdict": "PASS"
+    },
+    "verdict": "PASS"
+  },
+  "truth_version": 1
+}

--- a/synthesis_loop/evidence/vons_v1_columns.before.json
+++ b/synthesis_loop/evidence/vons_v1_columns.before.json
@@ -1,0 +1,33 @@
+{
+  "base_git_sha": "e517d33fdc043abfcbff5f70e87dfd21bccc8952",
+  "bundle_hash": "63775db497ae88a596847c2ddea69cfa1271eda40b755c1e2fae87b36da506cb",
+  "image_id": "678a7c94-4948-4ebf-b8e9-9a17c13051ec",
+  "metric": "columns",
+  "receipt_id": 2,
+  "result": {
+    "failed_on": [
+      "outliers"
+    ],
+    "limits": {
+      "abs_drift_px": 22.61,
+      "outlier_frac": 0.15,
+      "wobble_iqr_px": 3.5
+    },
+    "real": {
+      "lane_x_px": 719.84,
+      "n_rows": 13,
+      "outlier_frac": 0.0,
+      "wobble_iqr_px": 0.5
+    },
+    "source": "bootstrap",
+    "synth": {
+      "abs_drift_px": 11.0,
+      "lane_x_px": 709.0,
+      "n_rows": 13,
+      "outlier_frac": 0.154,
+      "wobble_iqr_px": 0.45
+    },
+    "verdict": "FAIL"
+  },
+  "truth_version": 1
+}


### PR DESCRIPTION
## Summary

- treat small section font-size nudges as sharing the body amount column
- project the base lane through paper pixels into each scaled row grid
- retain legacy independent layout for larger scales and per-section condensation
- add focused grid-remapping coverage and exact Vons red/green evidence

## Fidelity proof

Golden: Vons `678a7c94-4948-4ebf-b8e9-9a17c13051ec#2`, ACTIVE truth v1 bundle `63775d…`.

- before columns: FAIL; amount outliers `0.154 > 0.150`
- after columns: PASS; amount outliers `0.077`, wobble `0.41px`, absolute drift `11px`
- flag lane remains PASS; amount↔flag gap delta `3.96px < 11.3px`
- tokens and logo remain PASS

Evidence: `synthesis_loop/evidence/vons_v1_columns.{before,after}.json`.

## Verification

- focused tests: 8 passed
- corpus regression gate: PASS, zero findings
- render guard: Costco golden/new and Sprouts byte-identical; only intended Vons target changed
- black and `git diff --check`: clean
- no DynamoDB writes

Ready for independent review. Do not merge until CI and owner review complete.

## Rebase validation
- Python 3.12 receipt-agent suite: 332 passed, 22 skipped
- Python 3.12 repository suite: 565 passed, 1 skipped
- corpus regression gate: `ok: true`, zero findings (eval-logic pin)
- production-render comparison against same-machine `origin/main`: both Costco pins and Sprouts byte-identical; only intended Vons target changed

## Measured-column coexistence
When this and #1241 are integrated, measured `row_columns` must take precedence. Use the scaled legacy projection only when `row_columns` is empty; `plan_grid_line` already gives measured columns precedence over `amount_lane`, so the two semantics coexist without ambiguity.
