### PR TITLE
[receipt_renderer] Preserve stretched source geometry

### DIFF
--- a/receipt_agent/receipt_agent/agents/label_evaluator/rendering/receipt_grid.py
+++ b/receipt_agent/receipt_agent/agents/label_evaluator/rendering/receipt_grid.py
@@ -69,6 +69,9 @@ _GRID_FONT_MAX = 64
 # typical thermal body size; enough to land inside the [9, 28] px clamp.
 _FALLBACK_CHAR_WIDTH = 0.0125
 _FALLBACK_FONT_HEIGHT = 0.018
+_RUN_ADVANCE_CAP = 1.28
+_RUN_SEVERE_STRETCH = 1.60
+_RUN_SEVERE_ADVANCE_CAP = 1.65
 
 
 @dataclass(frozen=True)
@@ -674,10 +677,17 @@ def draw_text_run(
     if target_width and target_width > 0:
         # Mixed-layout rows are anchored by their observed OCR ink span, not the
         # table grid. Use that span to recover row pitch while keeping glyph
-        # shapes unscaled; a modest cap prevents noisy word boxes from turning
-        # normal receipt prose into display-style letterspacing.
+        # shapes unscaled. Keep the established modest cap for ordinary rows;
+        # only severe measured stretch may use the wider cap needed by
+        # horizontally foreshortened photographs.
         wanted = float(target_width) / max(1.0, len(text.rstrip()) - 0.5)
-        advance = max(base_advance, min(base_advance * 1.28, wanted))
+        stretch = wanted / base_advance
+        advance_cap = (
+            _RUN_SEVERE_ADVANCE_CAP
+            if stretch >= _RUN_SEVERE_STRETCH
+            else _RUN_ADVANCE_CAP
+        )
+        advance = max(base_advance, min(base_advance * advance_cap, wanted))
     pad = max(4, int(round(advance * 2)))
     width = max(8, int(round(advance * (len(text) + 2))) + 2 * pad)
     height = max(
@@ -848,6 +858,7 @@ _AMOUNT_LANE_TOL_CELLS = 4
 # carry a second, further-right amount column: "Total: USD$ 10.78" vs items).
 _AMOUNT_LANE_SNAP_CELLS = 2
 _RIGHT_SEGMENT_GAP_CELLS = 4.0
+_SOURCE_SEGMENT_STRETCH_RATIO = 1.5
 
 
 def _is_amount_prefix_token(text: str) -> bool:
@@ -1027,17 +1038,72 @@ def _truncate_to_cells(text: str, avail: int) -> tuple[str, int]:
     return glyphs[:avail], avail
 
 
+def _source_segment_is_stretched(
+    segment: Sequence[PlacedToken],
+    spec: GridSpec,
+) -> bool:
+    """Whether a compact plan erased substantial intra-column geometry."""
+    if len(segment) < 2:
+        return False
+    source_span = max(p.word.right for p in segment) - min(
+        p.word.left for p in segment
+    )
+    rendered_span = (
+        max(p.end_col for p in segment) - min(p.start_col for p in segment)
+    ) * spec.cell_w
+    minimum_source_span = _SOURCE_SEGMENT_STRETCH_RATIO * max(
+        rendered_span, 1.0
+    )
+    return source_span >= minimum_source_span
+
+
+def _align_stretched_source_segment(
+    segment: Sequence[PlacedToken],
+    spec: GridSpec,
+    previous_end: float,
+) -> float:
+    """Reset a stretched segment to its measured per-word source starts."""
+    for placed in segment:
+        source_start = (placed.word.left - spec.grid_left) / spec.cell_w
+        placed.start_col = max(source_start, previous_end + 1)
+        previous_end = placed.end_col
+    return previous_end
+
+
+def _right_align_source_segment(
+    segment: Sequence[PlacedToken],
+    spec: GridSpec,
+    previous_end: float,
+) -> float:
+    """Align an ordinary compact segment to its observed source right edge."""
+    source_right = max(p.word.right for p in segment)
+    rendered_right = (
+        spec.grid_left + max(p.end_col for p in segment) * spec.cell_w
+    )
+    shift = (source_right - rendered_right) / spec.cell_w
+    min_start = min(p.start_col for p in segment)
+    if min_start + shift <= previous_end:
+        shift = previous_end + 1 - min_start
+    if abs(shift) > 1e-6:
+        for placed in segment:
+            placed.start_col += shift
+    return max(previous_end, max(p.end_col for p in segment))
+
+
 def _right_align_source_segments(
     placed_row: Sequence[PlacedToken],
     spec: GridSpec,
 ) -> None:
-    """Right-anchor non-price column segments split by a large source gap.
+    """Preserve non-price columns split by a large source gap.
 
-    Payment/header rows often have left labels plus a right-justified value or
-    phrase. Those values are not prices, so the price lane cannot help; anchoring
-    them by their source left edge leaves short rendered text ending too far left
-    inside its OCR box. Split on real column gaps and align each later segment's
-    rendered right edge to the segment's observed source right edge.
+    Payment/header rows often have left labels plus a separated value or phrase.
+    Those values are not prices, so the price lane cannot help. Cursor-relative
+    compaction loses the measured gap, while right-aligning a whole compact
+    segment preserves only its final word and can move every earlier token
+    outside its own source box. Split on real column gaps. Preserve the
+    established right anchor for ordinary segments, but when a multi-word
+    source segment is at least 1.5x wider than its compact grid plan, reset each
+    token to its observed source start (moving it right only to avoid overlap).
     """
     if len(placed_row) < 2:
         return
@@ -1054,18 +1120,11 @@ def _right_align_source_segments(
         segment = placed_row[start_i:end_i]
         if not segment or any(p.is_price for p in segment):
             continue
-        source_right = max(p.word.right for p in segment)
-        rendered_right = (
-            spec.grid_left + max(p.end_col for p in segment) * spec.cell_w
-        )
-        shift = (source_right - rendered_right) / spec.cell_w
-        min_start = min(p.start_col for p in segment)
-        if min_start + shift <= prev_end:
-            shift = prev_end + 1 - min_start
-        if abs(shift) > 1e-6:
-            for placed in segment:
-                placed.start_col += shift
-        prev_end = max(prev_end, max(p.end_col for p in segment))
+        if _source_segment_is_stretched(segment, spec):
+            prev_end = _align_stretched_source_segment(segment, spec, prev_end)
+            continue
+
+        prev_end = _right_align_source_segment(segment, spec, prev_end)
 
 
 def draw_grid_line(

--- a/receipt_agent/tests/test_receipt_grid_geometry.py
+++ b/receipt_agent/tests/test_receipt_grid_geometry.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from PIL import Image, ImageDraw, ImageFont
 
+from receipt_agent.agents.label_evaluator.rendering import receipt_grid
 from receipt_agent.agents.label_evaluator.rendering.receipt_grid import (
     GridSpec,
     GridWord,
@@ -56,8 +59,11 @@ def test_text_run_can_recover_observed_source_span() -> None:
     image = Image.new("RGB", (600, 120), (255, 255, 255))
     draw = ImageDraw.Draw(image)
     font = ImageFont.truetype(
-        "receipt_agent/receipt_agent/agents/label_evaluator/rendering/"
-        "fonts/B612Mono-Regular.ttf",
+        str(
+            Path(receipt_grid.__file__).parent
+            / "fonts"
+            / "B612Mono-Regular.ttf"
+        ),
         18,
     )
     spec = GridSpec(cell_w=10.0, cell_h=20.0, font_px=18, grid_left=0.0)

--- a/receipt_agent/tests/test_receipt_grid_geometry.py
+++ b/receipt_agent/tests/test_receipt_grid_geometry.py
@@ -1,0 +1,85 @@
+"""Geometry contracts for mixed-layout receipt rows."""
+
+from __future__ import annotations
+
+from PIL import Image, ImageDraw, ImageFont
+
+from receipt_agent.agents.label_evaluator.rendering.receipt_grid import (
+    GridSpec,
+    GridWord,
+    PlacedToken,
+    _right_align_source_segments,
+    draw_text_run,
+)
+
+
+def _grid_word(
+    text: str,
+    left: float,
+    right: float,
+    *,
+    word_index: int | None = None,
+) -> GridWord:
+    return GridWord(
+        left=left,
+        top=20.0,
+        right=right,
+        bottom=40.0,
+        text=text,
+        ink=(0, 0, 0),
+        word_index=word_index,
+    )
+
+
+def test_source_column_segment_preserves_each_word_start() -> None:
+    """A compact glyph face must not collapse a measured source column."""
+    spec = GridSpec(cell_w=10.0, cell_h=20.0, font_px=18, grid_left=0.0)
+    placed = [
+        PlacedToken(_grid_word("Station:", 0.0, 80.0), 0, 8, False),
+        PlacedToken(_grid_word("9033-03", 90.0, 160.0), 9, 7, False),
+        # The right column starts after a large measured source gap. These
+        # compact placements reproduce the old cursor-relative collapse.
+        PlacedToken(_grid_word("Sales", 480.0, 570.0), 34, 5, False),
+        PlacedToken(_grid_word("Rep", 575.0, 640.0), 40, 3, False),
+        PlacedToken(_grid_word("LCOLE", 645.0, 745.0), 44, 5, False),
+    ]
+
+    _right_align_source_segments(placed, spec)
+
+    for token in placed[2:]:
+        rendered_left = spec.grid_left + token.start_col * spec.cell_w
+        assert abs(rendered_left - token.word.left) <= spec.cell_w / 2
+
+
+def test_text_run_can_recover_observed_source_span() -> None:
+    """Mixed prose rows may be substantially wider than the base cell grid."""
+    image = Image.new("RGB", (600, 120), (255, 255, 255))
+    draw = ImageDraw.Draw(image)
+    font = ImageFont.truetype(
+        "receipt_agent/receipt_agent/agents/label_evaluator/rendering/"
+        "fonts/B612Mono-Regular.ttf",
+        18,
+    )
+    spec = GridSpec(cell_w=10.0, cell_h=20.0, font_px=18, grid_left=0.0)
+    texts = ["Number", "of", "items", "purchased:", "2"]
+    words = [
+        _grid_word(text, 0.0, 1.0, word_index=index)
+        for index, text in enumerate(texts)
+    ]
+    boxes: list[dict] = []
+
+    draw_text_run(
+        draw,
+        " ".join(texts),
+        20.0,
+        70.0,
+        spec,
+        font,
+        (0, 0, 0),
+        cap_px=18,
+        target_width=480.0,
+        box_sink=boxes,
+        sink_words=words,
+    )
+
+    assert boxes[-1]["px"][2] - boxes[0]["px"][0] >= 450.0

--- a/synthesis_loop/evidence/wild_fork_v1_tokens.after.json
+++ b/synthesis_loop/evidence/wild_fork_v1_tokens.after.json
@@ -1,0 +1,38 @@
+{
+  "base_git_sha": "e517d33fdc043abfcbff5f70e87dfd21bccc8952",
+  "bundle_hash": "a9de285daf995ce20245bdb397f1a0c25a25ec5ab27587f723b0df5e6c7504cc",
+  "controls": {
+    "arithmetic": "PASS",
+    "columns": "PASS",
+    "graphics": "PASS",
+    "logo": "PASS",
+    "style": "PASS_WITH_GAPS"
+  },
+  "image_id": "f008ea77-272b-4554-b8a6-e1676ec6a088",
+  "metric": "tokens",
+  "receipt_id": 2,
+  "result": {
+    "ink_checked": 106,
+    "ink_missing_tokens": [
+      "PM",
+      "1",
+      "2"
+    ],
+    "ink_recall": 0.9717,
+    "missing_tokens": [],
+    "text_precision": 1.0,
+    "text_recall": 1.0,
+    "verdict": "PASS"
+  },
+  "truth_version": 1,
+  "verification": {
+    "corpus_regression_gate": "PASS (0 findings)",
+    "focused_tests": "25 passed",
+    "render_regression_guard": {
+      "costco_golden": "byte-identical",
+      "costco_new": "byte-identical",
+      "sprouts": "byte-identical",
+      "vons_golden": "byte-identical"
+    }
+  }
+}

--- a/synthesis_loop/evidence/wild_fork_v1_tokens.before.json
+++ b/synthesis_loop/evidence/wild_fork_v1_tokens.before.json
@@ -1,0 +1,24 @@
+{
+  "base_git_sha": "e517d33fdc043abfcbff5f70e87dfd21bccc8952",
+  "bundle_hash": "a9de285daf995ce20245bdb397f1a0c25a25ec5ab27587f723b0df5e6c7504cc",
+  "image_id": "f008ea77-272b-4554-b8a6-e1676ec6a088",
+  "metric": "tokens",
+  "receipt_id": 2,
+  "result": {
+    "ink_checked": 106,
+    "ink_missing_tokens": [
+      "CA",
+      "SALES",
+      "PM",
+      "QTY",
+      "1",
+      "2"
+    ],
+    "ink_recall": 0.9434,
+    "missing_tokens": [],
+    "text_precision": 1.0,
+    "text_recall": 1.0,
+    "verdict": "FAIL"
+  },
+  "truth_version": 1
+}


### PR DESCRIPTION
## Summary
- preserve per-word source starts for genuinely stretched multi-word segments
- allow wider run advance only when measured source geometry proves severe stretch
- leave ordinary compact rows on the legacy placement path
- resolve the focused test's font from the renderer module so it passes from both the repository root and CI's `receipt_agent/` working directory
- add focused geometry tests and committed red/change/green evidence

## Fidelity proof
Golden: genuine Wild Fork `f008ea77-272b-4554-b8a6-e1676ec6a088#2`, ACTIVE truth v1 bundle `a9de28…`. Receipt #1 under this image is Brent's Deli and was rejected as bad golden evidence.

- before tokens: **FAIL**, ink recall `0.9434`; displaced `CA`, `SALES`, `PM`, `QTY`, `1`, `2`
- after tokens: **PASS**, ink recall `0.9717`; text recall/precision remain `1.0`
- controls: columns, logo, graphics, arithmetic PASS; style remains PASS_WITH_GAPS
- remaining Wild Fork red is the independent separator metric

Evidence: `synthesis_loop/evidence/wild_fork_v1_tokens.{before,after}.json`.

## Verification
- focused geometry tests: 2 passed from repo root and 2 passed from CI's package working directory
- post-#1254 full `receipt_agent` simulation: **322 passed, 22 skipped**
- corpus regression gate: PASS, zero findings
- render guard: Costco golden/new, Vons, and Sprouts byte-identical
- black, isort, and `git diff --check`: clean
- no DynamoDB writes

Draft only; do not merge until #1254 lands and expanded CI is green.