### PR TITLE
[receipt_renderer] Honor measured flag lanes

### DIFF
--- a/receipt_agent/receipt_agent/agents/label_evaluator/rendering/receipt_grid.py
+++ b/receipt_agent/receipt_agent/agents/label_evaluator/rendering/receipt_grid.py
@@ -1138,6 +1138,7 @@ def _measured_lane_starts(
 
     amount_x = usable("amount", "right")
     qty_x = usable("qty", "right")
+    flag_x = usable("flag", "left")
     label_x = usable("label", "left")
     desc_x = usable("desc", "left")
     starts: dict[int, float] = {}
@@ -1200,6 +1201,18 @@ def _measured_lane_starts(
         starts[index] = (
             target - spec.grid_left
         ) / spec.cell_w - drawn_cell_count(word.text)
+
+    flag_candidates = [
+        index
+        for index, word in enumerate(line)
+        if index not in starts
+        and index > 0
+        and is_price_token(line[index - 1].text)
+        and len(word.text.strip()) == 1
+        and word.text.strip().isalpha()
+    ]
+    for index, target in assign_unique(flag_candidates, flag_x, edge="left"):
+        starts[index] = (target - spec.grid_left) / spec.cell_w
 
     if label_x and line:
         label_candidates = [
@@ -1406,7 +1419,16 @@ def plan_grid_line(
                                 for column in measured_columns or ()
                             )
                         )
-                        else "left"
+                        else (
+                            "left_flag"
+                            if len(word.text.strip()) == 1
+                            and word.text.strip().isalpha()
+                            and any(
+                                str(column.get("role") or "").lower() == "flag"
+                                for column in measured_columns or ()
+                            )
+                            else "left"
+                        )
                     )
                     if i in measured
                     else ("right_aux" if measured_tax_flag else None)
@@ -1513,12 +1535,31 @@ def draw_grid_line(
     if center_to is None and placed_row and not measured_columns:
         _right_align_source_segments(placed_row, spec)
 
+    has_flag_lane = any(
+        str(column.get("role") or "").lower() == "flag"
+        for column in measured_columns or ()
+    )
+
+    def _measured_ink_shift_px(placed: PlacedToken) -> float:
+        """Translate measured OCR-box anchors onto their visible ink edges."""
+        if placed.measured_anchor in ("right", "right_aux"):
+            # Sections with a detached flag lane expose both bearings: amount
+            # ink ends one cell inside its right-anchored OCR box. Other
+            # measured sections retain the calibrated quarter-cell inset.
+            return (-1.0 if has_flag_lane else -0.25) * spec.cell_w
+        if placed.measured_anchor == "left_flag":
+            # The detached flag's ink starts one cell inside its left-anchored
+            # OCR box, symmetrically preserving the measured amount/flag gap.
+            return spec.cell_w
+        return 0.0
+
     def _record_boxes():
         if box_sink is None:
             return
         cap = float(cap_px or spec.font_px)
         for p in placed_row:
-            x0 = spec.grid_left + p.start_col * spec.cell_w
+            ink_shift = x_shift_px + _measured_ink_shift_px(p)
+            x0 = spec.grid_left + p.start_col * spec.cell_w + ink_shift
             x1 = x0 + p.cells * spec.cell_w
             desc = 0.22 * cap if _has_descender(p.draw_text) else 0.04 * cap
             box_sink.append(
@@ -1543,14 +1584,7 @@ def draw_grid_line(
     _record_boxes()
     for i, placed in enumerate(placed_row):
         ink = placed.word.ink
-        # OCR right-edge lanes include a small printer side bearing.  Keep the
-        # render-true bbox on the measured edge, but inset visible glyph ink by
-        # a quarter cell (and carry an adjacent tax flag with it).
-        measured_right_inset_px = (
-            -0.25 * spec.cell_w
-            if placed.measured_anchor in ("right", "right_aux")
-            else 0.0
-        )
+        measured_ink_shift_px = _measured_ink_shift_px(placed)
         # price -> box extends LEFT into the amount lane; date -> tight box.
         rev_price = reverse_price and placed.is_price
         rev_date = reverse_date and i == 0 and _is_date_token(placed.draw_text)
@@ -1567,14 +1601,14 @@ def draw_grid_line(
                         round(
                             spec.grid_left
                             + (placed.start_col - 0.4) * spec.cell_w
-                            + measured_right_inset_px
+                            + measured_ink_shift_px
                         )
                     )
                     x1 = int(
                         round(
                             spec.grid_left
                             + (placed.end_col + 0.4) * spec.cell_w
-                            + measured_right_inset_px
+                            + measured_ink_shift_px
                         )
                     )
                 else:
@@ -1583,7 +1617,7 @@ def draw_grid_line(
                             spec.grid_left
                             + (placed.start_col - price_box_extend_cells)
                             * spec.cell_w
-                            + measured_right_inset_px
+                            + measured_ink_shift_px
                         )
                     )
                     x1 = int(
@@ -1591,7 +1625,7 @@ def draw_grid_line(
                             spec.grid_left
                             + (placed.end_col + (0 if measured_columns else 1))
                             * spec.cell_w
-                            + measured_right_inset_px
+                            + measured_ink_shift_px
                         )
                     )
                 x0 = max(int(spec.grid_left), x0)
@@ -1612,12 +1646,14 @@ def draw_grid_line(
             bitmap_font=bitmap_font,
             cap_px=cap_px,
             left_edge_col=(
-                placed.start_col if placed.measured_anchor == "left" else None
+                placed.start_col
+                if placed.measured_anchor in ("left", "left_flag")
+                else None
             ),
             right_edge_col=placed.end_col if placed.is_price else None,
             bitmap_thin=bitmap_thin,
             condense_glyphs=condense_glyphs,
-            x_shift_px=x_shift_px + measured_right_inset_px,
+            x_shift_px=x_shift_px + measured_ink_shift_px,
         )
 
 

--- a/receipt_agent/tests/test_measured_layout.py
+++ b/receipt_agent/tests/test_measured_layout.py
@@ -1,10 +1,16 @@
 """Measured Merchant Truth column routing and grid placement."""
 
-import pytest
+from dataclasses import replace
+from pathlib import Path
 
+import pytest
+from PIL import Image, ImageDraw, ImageFont
+
+from receipt_agent.agents.label_evaluator.rendering import receipt_grid
 from receipt_agent.agents.label_evaluator.rendering.receipt_grid import (
     GridSpec,
     GridWord,
+    draw_grid_line,
     effective_canonical_row_sections,
     plan_grid_line,
 )
@@ -94,6 +100,83 @@ def test_measured_description_and_quantity_roles_use_their_declared_edges():
     # drawable grid; the quantity retains its measured right edge.
     assert 10 + by_text["ITEM"].start_col * 10 == pytest.approx(10)
     assert 10 + by_text["3"].end_col * 10 == pytest.approx(0.8852 * 760)
+
+
+def test_measured_flag_lane_anchors_detached_flag_to_declared_left_edge():
+    spec = GridSpec(cell_w=10.0, cell_h=20.0, font_px=16, grid_left=10.0)
+    line = [_word("4.29", 565, 615), _word("F", 620, 650)]
+    columns = [
+        {"role": "amount", "anchor": "right", "x": 0.8085},
+        {"role": "flag", "anchor": "left", "x": 0.8187},
+    ]
+
+    placed = plan_grid_line(
+        line,
+        spec,
+        measured_columns=columns,
+        paper_width=760,
+    )
+    by_text = {token.word.text: token for token in placed}
+
+    assert 10 + by_text["4.29"].end_col * 10 == pytest.approx(0.8085 * 760)
+    assert 10 + by_text["F"].start_col * 10 == pytest.approx(0.8187 * 760)
+    assert by_text["F"].measured_anchor == "left_flag"
+
+
+def test_flag_lane_bearings_are_reflected_in_render_true_boxes():
+    spec = GridSpec(cell_w=10.0, cell_h=20.0, font_px=16, grid_left=10.0)
+    line = [
+        replace(_word("4.29", 565, 615), word_index=0),
+        replace(_word("F", 620, 650), word_index=1),
+    ]
+    columns = [
+        {"role": "amount", "anchor": "right", "x": 0.8085},
+        {"role": "flag", "anchor": "left", "x": 0.8187},
+    ]
+    font_path = (
+        Path(receipt_grid.__file__).parent / "fonts" / "B612Mono-Regular.ttf"
+    )
+    image = Image.new("RGB", (760, 180), "white")
+    sink = []
+
+    draw_grid_line(
+        ImageDraw.Draw(image),
+        line,
+        100,
+        spec,
+        ImageFont.truetype(str(font_path), 16),
+        measured_columns=columns,
+        paper_width=760,
+        box_sink=sink,
+    )
+    by_index = {placement["word_index"]: placement for placement in sink}
+
+    assert by_index[0]["px"][2] == pytest.approx(0.8085 * 760 - spec.cell_w)
+    assert by_index[1]["px"][0] == pytest.approx(0.8187 * 760 + spec.cell_w)
+
+
+def test_amount_only_lane_keeps_quarter_cell_bearing():
+    spec = GridSpec(cell_w=10.0, cell_h=20.0, font_px=16, grid_left=10.0)
+    line = [replace(_word("116.99", 650, 710), word_index=0)]
+    columns = [{"role": "amount", "anchor": "right", "x": 0.9399}]
+    font_path = (
+        Path(receipt_grid.__file__).parent / "fonts" / "B612Mono-Regular.ttf"
+    )
+    image = Image.new("RGB", (760, 180), "white")
+    sink = []
+
+    draw_grid_line(
+        ImageDraw.Draw(image),
+        line,
+        100,
+        spec,
+        ImageFont.truetype(str(font_path), 16),
+        measured_columns=columns,
+        paper_width=760,
+        box_sink=sink,
+    )
+
+    assert sink[0]["px"][2] == pytest.approx(0.9399 * 760 - 0.25 * spec.cell_w)
 
 
 def test_canonical_sections_use_labels_then_generic_payment_markers():

--- a/synthesis_loop/evidence/gelsons_flag_lanes.after.json
+++ b/synthesis_loop/evidence/gelsons_flag_lanes.after.json
@@ -1,0 +1,42 @@
+{
+  "artifact": "/tmp/top5-gelsons-lane-final/gelson_s_westlake_village_eval/gelson_s_westlake_village.checks.json",
+  "git_sha": "aa5b74ddae5c128a49418f4f23f2701d8fe3b313",
+  "merchant": "Gelson's Westlake Village",
+  "merchant_truth": {
+    "bundle_hash": "9486f47c16ee3cc2e38dbe505b1feef6692cc1633d74d1ceafd7e3a423e48c09",
+    "slug": "gelson_s_westlake_village",
+    "version": 1
+  },
+  "metric": "columns",
+  "receipt": "223c03e2-9f7e-481d-bc33-2b0631fbaaf9#1",
+  "result": {
+    "amount": {
+      "abs_drift_px": 1.0,
+      "outlier_frac": 0.0,
+      "verdict": "PASS",
+      "wobble_iqr_px": 0.0,
+      "wobble_limit_px": 3.84
+    },
+    "amount_flag_gap": {
+      "delta_px": 2.64,
+      "limit_px": 13.18,
+      "real_gap_px": 42.64,
+      "synth_gap_px": 40.0,
+      "verdict": "PASS"
+    },
+    "flag": {
+      "abs_drift_px": 2.0,
+      "outlier_frac": 0.0,
+      "verdict": "PASS",
+      "wobble_iqr_px": 1.0
+    },
+    "verdict": "PASS"
+  },
+  "unchanged_metrics": {
+    "arithmetic": "PASS",
+    "graphics": "PASS",
+    "logo": "PASS",
+    "separators": "PASS",
+    "tokens": "PASS"
+  }
+}

--- a/synthesis_loop/evidence/gelsons_flag_lanes.before.json
+++ b/synthesis_loop/evidence/gelsons_flag_lanes.before.json
@@ -1,0 +1,36 @@
+{
+  "artifact": "/tmp/top5-gelsons-columns-test-eval/gelson_s_westlake_village_eval/gelson_s_westlake_village.checks.json",
+  "git_sha": "3e7fbc0785a97b5ee3470f706777b4bb11f0649c",
+  "merchant": "Gelson's Westlake Village",
+  "merchant_truth": {
+    "bundle_hash": "9486f47c16ee3cc2e38dbe505b1feef6692cc1633d74d1ceafd7e3a423e48c09",
+    "slug": "gelson_s_westlake_village",
+    "version": 1
+  },
+  "metric": "columns",
+  "receipt": "223c03e2-9f7e-481d-bc33-2b0631fbaaf9#1",
+  "result": {
+    "amount": {
+      "failed_on": [
+        "wobble"
+      ],
+      "outlier_frac": 0.0,
+      "verdict": "FAIL",
+      "wobble_iqr_px": 7.0,
+      "wobble_limit_px": 3.84
+    },
+    "amount_flag_gap": {
+      "delta_px": 41.64,
+      "limit_px": 13.18,
+      "real_gap_px": 42.64,
+      "synth_gap_px": 1.0,
+      "verdict": "FAIL"
+    },
+    "flag": {
+      "outlier_frac": 0.0,
+      "verdict": "PASS",
+      "wobble_iqr_px": 0.0
+    },
+    "verdict": "FAIL"
+  }
+}


### PR DESCRIPTION
## Folded into #1241

This PR genuinely depended on #1241's generic measured-column machinery, so keeping it as a hidden child stack would make the release order fragile. Its three logical commits—red evidence, renderer/test change, and green evidence—have been preserved on #1241, where the full Costco + Gelson measured-lane concern now lives.

No merge occurred. This PR is closed as superseded by #1241.

Verification on the folded #1241 result:
- Gelson columns: **FAIL → PASS**
- 45 focused measured-layout/full-fidelity tests passed on Python 3.12
- corpus regression gate: PASS, zero findings
- black, isort, and `git diff --check`: clean
- no DynamoDB writes