### PR TITLE
[receipt_renderer] Preserve measured grocery row emphasis

### DIFF
--- a/receipt_agent/receipt_agent/agents/label_evaluator/rendering/receipt_renderer.py
+++ b/receipt_agent/receipt_agent/agents/label_evaluator/rendering/receipt_renderer.py
@@ -940,9 +940,7 @@ def _render_grid(
         # clears the observed 1.35x body-weight boundary; one dot remains
         # entirely inside this atlas's existing heavy glyph envelope.
         strike_offsets = (
-            (0, 1, 2)
-            if reinforce_bold
-            else ((0, 1) if sm_bold else (0,))
+            (0, 1, 2) if reinforce_bold else ((0, 1) if sm_bold else (0,))
         )
         run = _run_layout(line, center_to)
         if run is not None:

--- a/receipt_agent/receipt_agent/agents/label_evaluator/rendering/receipt_renderer.py
+++ b/receipt_agent/receipt_agent/agents/label_evaluator/rendering/receipt_renderer.py
@@ -55,6 +55,7 @@ from receipt_agent.agents.label_evaluator.rendering.receipt_grid import (
 )
 from receipt_agent.agents.label_evaluator.rendering.receipt_stylemap import (
     measured_row_style,
+    requires_bold_reinforcement,
     row_style,
 )
 
@@ -922,6 +923,7 @@ def _render_grid(
         )
         sm_bold = bool(sm_style and sm_style["bold"])
         sm_underline = bool(sm_style and sm_style["underline"])
+        reinforce_bold = sm_bold and requires_bold_reinforcement(row_text)
         # A genuinely-compiled heavy face beats a 1px double-strike; fall back
         # to double-strike only when the profile's heavy is the regular file.
         bfp = config.bitmap_font or {}
@@ -932,10 +934,20 @@ def _render_grid(
         ):
             bf_row = bmf_heavy
             sm_bold = False
+        # Most heavy atlases need no synthetic strike. Standalone transaction
+        # headings are a measured exception: their real thermal stroke is
+        # stronger than the compiled heavy face alone. A two-dot reinforcement
+        # clears the observed 1.35x body-weight boundary; one dot remains
+        # entirely inside this atlas's existing heavy glyph envelope.
+        strike_offsets = (
+            (0, 1, 2)
+            if reinforce_bold
+            else ((0, 1) if sm_bold else (0,))
+        )
         run = _run_layout(line, center_to)
         if run is not None:
             text, anchor, x, target_w = run
-            for dx in ((0, 1) if sm_bold else (0,)):
+            for dx in strike_offsets:
                 draw_text_run(
                     draw,
                     text,
@@ -956,7 +968,7 @@ def _render_grid(
                     sink_words=line,
                 )
         else:
-            for dx in ((0, 1) if sm_bold else (0,)):
+            for dx in strike_offsets:
                 draw_grid_line(
                     draw,
                     line,

--- a/receipt_agent/receipt_agent/agents/label_evaluator/rendering/receipt_stylemap.py
+++ b/receipt_agent/receipt_agent/agents/label_evaluator/rendering/receipt_stylemap.py
@@ -136,6 +136,7 @@ _RULES: list[tuple[str, re.Pattern]] = [
     ),
 ]
 _BARCODE_RE = re.compile(r"^\d{10,}$")
+_TRANSACTION_HEADING_RE = re.compile(r"^(?:SALE\s+)?TRANSACTION$", re.I)
 # Smith's (Kroger banner), M6 cold-start pilot: rules derived from the QA'd
 # VALID ReceiptSection rows on its 10 vetted dev scans. Only the sections whose
 # measured face departs from body are classified -- storefront (wordmark block
@@ -283,6 +284,15 @@ def row_style(
         return style
     style["scale"] = float(rule.get("sizeScale", 1.0))
     style["bold"] = rule.get("weight") == "bold"
+    # A standalone transaction heading is a display row, not ordinary footer
+    # prose. Fleet stylemaps historically pooled it with footer rows because
+    # the generic classifier quite reasonably maps the word "Transaction" to
+    # that section. Preserve the section's measured scale/underline settings,
+    # but select the heavy face for the standalone heading. Rows which merely
+    # contain the word ("Items in Transaction: 14", POS identifiers, payment
+    # narration) remain on the section's regular face.
+    if _TRANSACTION_HEADING_RE.fullmatch(row_text.strip()):
+        style["bold"] = True
     ul = rule.get("underline", False)
     if ul is True:
         style["underline"] = True

--- a/receipt_agent/receipt_agent/agents/label_evaluator/rendering/receipt_stylemap.py
+++ b/receipt_agent/receipt_agent/agents/label_evaluator/rendering/receipt_stylemap.py
@@ -229,6 +229,19 @@ def normalize_face_key(text: str) -> str:
     return " ".join(str(text).upper().split())[:60]
 
 
+def requires_bold_reinforcement(row_text: str) -> bool:
+    """Whether a display heading needs a one-dot strike over its heavy face.
+
+    Thermal ``SALE TRANSACTION`` headings are materially heavier than their
+    surrounding body rows. Some compiled merchant atlases carry a distinct
+    heavy face whose stroke delta is still too small to reproduce that measured
+    emphasis. Keep the reinforcement tied to the same standalone-heading
+    grammar as :func:`row_style`; payment narration and item-count prose that
+    merely contain the word ``transaction`` remain untouched.
+    """
+    return bool(_TRANSACTION_HEADING_RE.fullmatch(str(row_text).strip()))
+
+
 def _safe_scale(value: Any) -> float:
     """row_faces is an external API boundary: clamp scale to sane, finite."""
     try:
@@ -291,7 +304,7 @@ def row_style(
     # but select the heavy face for the standalone heading. Rows which merely
     # contain the word ("Items in Transaction: 14", POS identifiers, payment
     # narration) remain on the section's regular face.
-    if _TRANSACTION_HEADING_RE.fullmatch(row_text.strip()):
+    if requires_bold_reinforcement(row_text):
         style["bold"] = True
     ul = rule.get("underline", False)
     if ul is True:

--- a/receipt_agent/tests/test_receipt_stylemap.py
+++ b/receipt_agent/tests/test_receipt_stylemap.py
@@ -172,3 +172,26 @@ def test_qualified_multiword_department_tokens_match():
     assert classify_row("DEPT PATIO & OUTDOOR DECOR") == "section_header"
     # A non-token remainder still never matches.
     assert classify_row("FRESH HEALTH AND WELLNESS") != "section_header"
+
+
+def test_standalone_transaction_heading_uses_heavy_footer_face():
+    stylemap = {
+        "sections": {
+            "footer": {
+                "sizeScale": 1.09,
+                "weight": "normal",
+                "underline": False,
+            }
+        }
+    }
+
+    assert row_style(stylemap, "SALE TRANSACTION") == {
+        "scale": 1.09,
+        "bold": True,
+        "underline": False,
+    }
+    assert row_style(stylemap, "Items in Transaction: 14") == {
+        "scale": 1.09,
+        "bold": False,
+        "underline": False,
+    }

--- a/receipt_agent/tests/test_receipt_stylemap.py
+++ b/receipt_agent/tests/test_receipt_stylemap.py
@@ -2,6 +2,7 @@ from receipt_agent.agents.label_evaluator.rendering.receipt_stylemap import (
     classify_row,
     measured_row_style,
     normalize_face_key,
+    requires_bold_reinforcement,
     row_style,
 )
 
@@ -195,3 +196,7 @@ def test_standalone_transaction_heading_uses_heavy_footer_face():
         "bold": False,
         "underline": False,
     }
+    assert requires_bold_reinforcement("SALE TRANSACTION")
+    assert requires_bold_reinforcement("Transaction")
+    assert not requires_bold_reinforcement("Items in Transaction: 14")
+    assert not requires_bold_reinforcement("PAYMENT CARD PURCHASE TRANSACTION")

--- a/synthesis_loop/evidence/gelson_s_style.before.json
+++ b/synthesis_loop/evidence/gelson_s_style.before.json
@@ -1,0 +1,55 @@
+{
+  "base_git_sha": "e517d33fdc043abfcbff5f70e87dfd21bccc8952",
+  "bundle_hash": "9486f47c16ee3cc2e38dbe505b1feef6692cc1633d74d1ceafd7e3a423e48c09",
+  "image_id": "223c03e2-9f7e-481d-bc33-2b0631fbaaf9",
+  "merchant": "Gelson's Westlake Village",
+  "metric": "style",
+  "receipt_id": 1,
+  "result": {
+    "body_stroke_fail": false,
+    "body_stroke_rel": {
+      "real": 0.079,
+      "synth": 0.1046
+    },
+    "failing_classes": {
+      "address": {
+        "missing_style": [
+          "bold"
+        ],
+        "real": {
+          "bold": 3,
+          "n": 3,
+          "underline": 0
+        },
+        "synth": {
+          "bold": 0,
+          "n": 3,
+          "underline": 1
+        }
+      },
+      "footer": {
+        "missing_style": [
+          "bold"
+        ],
+        "real": {
+          "bold": 2,
+          "n": 2,
+          "underline": 0
+        },
+        "synth": {
+          "bold": 0,
+          "n": 2,
+          "underline": 0
+        }
+      }
+    },
+    "preserved_metrics": {
+      "arithmetic": "PASS",
+      "graphics": "PASS",
+      "logo": "PASS",
+      "tokens": "PASS"
+    },
+    "verdict": "FAIL"
+  },
+  "truth_version": 1
+}

--- a/synthesis_loop/evidence/grocery_style.unresolved.md
+++ b/synthesis_loop/evidence/grocery_style.unresolved.md
@@ -1,0 +1,41 @@
+# Grocery style reds not changed
+
+The focused renderer change fixes the independently identifiable Trader Joe's
+transaction-heading defect. Vons and Gelson's remain byte-identical to their
+baselines because their active v1 truth cannot honestly select a different
+face for the red rows.
+
+## Vons
+
+The red is receipt-relative fade, not an address-face omission:
+
+- real/synthetic `Main: (805) 497-1921` stroke-per-height: `0.1264 / 0.1264`;
+- real/synthetic `WESTLAKE CA 91360`: `0.1404 / 0.1404`;
+- body median: real `0.0948`, synthetic `0.1336`.
+
+Thus the address ink already matches in absolute terms. Selecting the heavy
+face would overprint the address while concealing the actual mismatch: the
+golden receipt's body is lighter than the consensus atlas. The v1 stylemap also
+explicitly says address/phone rows are body-identical and records
+`store_header`, `footer`, and `item` as normal weight
+(`tools/glyph-studio/fonts/vons/stylemap.json:10`,
+`:59`, and `:66`). An honest fix needs receipt-level measured row faces/fade or
+a reminted truth rule, not an unconditional address bold.
+
+## Gelson's Westlake Village
+
+The active stylemap has only one face rule, `section_header`; its source note
+explicitly says payment/summary/footer are body-normal
+(`tools/glyph-studio/fonts/gelsons/stylemap.json:3-16`). The golden receipt,
+however, measures address `3/3` and footer `2/2` bold relative to its unusually
+light body. No active rule distinguishes those rows, so `row_style` correctly
+falls back to the regular face when a section is absent
+(`receipt_agent/receipt_agent/agents/label_evaluator/rendering/receipt_stylemap.py:266-286`).
+
+Adding a merchant-name conditional would make this receipt pass by bypassing
+truth. Editing the local JSON would not change production either: online
+rendering consumes only the active bundle's inline, hash-verified document
+(`scripts/render_synthetic_receipts.py:1566-1577`,
+`:1620-1628`). Since this lane is read-only against dev DynamoDB, the remaining
+Gelson's red requires a new measured stylemap/truth version (or receipt-level
+`row_faces`) and remint.

--- a/synthesis_loop/evidence/trader_joe_s_style.after.json
+++ b/synthesis_loop/evidence/trader_joe_s_style.after.json
@@ -1,0 +1,48 @@
+{
+  "base_git_sha": "6426a9187accbdfbaae1fc138739241378c2a9e3",
+  "bundle_hash": "557c433fcc1e5d74ca66a54f194cf4deca9e39976d26412dc0e1b5ebd778c418",
+  "guards": {
+    "corpus_regression_gate": "PASS",
+    "render_regression_guard": {
+      "costco_golden": "byte-identical",
+      "costco_new": "byte-identical",
+      "sprouts": "byte-identical",
+      "vons_golden": "byte-identical"
+    }
+  },
+  "image_id": "4c262079-4fec-4724-a8e1-2886f38ea454",
+  "merchant": "Trader Joe's",
+  "metric": "style",
+  "receipt_id": 1,
+  "result": {
+    "body_stroke_fail": false,
+    "body_stroke_rel": {
+      "real": 0.1068,
+      "synth": 0.1068
+    },
+    "footer": {
+      "real": {
+        "bold": 1,
+        "n": 2,
+        "underline": 0
+      },
+      "synth": {
+        "bold": 1,
+        "n": 2,
+        "underline": 0
+      },
+      "verdict": "PASS"
+    },
+    "preserved_metrics": {
+      "arithmetic": "PASS",
+      "columns": "PASS",
+      "graphics": "PASS",
+      "tokens": "PASS"
+    },
+    "untested_classes": [
+      "total_line"
+    ],
+    "verdict": "PASS_WITH_GAPS"
+  },
+  "truth_version": 1
+}

--- a/synthesis_loop/evidence/trader_joe_s_style.before.json
+++ b/synthesis_loop/evidence/trader_joe_s_style.before.json
@@ -1,0 +1,39 @@
+{
+  "base_git_sha": "e517d33fdc043abfcbff5f70e87dfd21bccc8952",
+  "bundle_hash": "557c433fcc1e5d74ca66a54f194cf4deca9e39976d26412dc0e1b5ebd778c418",
+  "image_id": "4c262079-4fec-4724-a8e1-2886f38ea454",
+  "merchant": "Trader Joe's",
+  "metric": "style",
+  "receipt_id": 1,
+  "result": {
+    "body_stroke_fail": false,
+    "body_stroke_rel": {
+      "real": 0.1068,
+      "synth": 0.1068
+    },
+    "failing_classes": {
+      "footer": {
+        "missing_style": [
+          "bold"
+        ],
+        "real": {
+          "bold": 1,
+          "n": 2,
+          "underline": 0
+        },
+        "synth": {
+          "bold": 0,
+          "n": 2,
+          "underline": 0
+        }
+      }
+    },
+    "preserved_metrics": {
+      "arithmetic": "PASS",
+      "graphics": "PASS",
+      "tokens": "PASS"
+    },
+    "verdict": "FAIL"
+  },
+  "truth_version": 1
+}

--- a/synthesis_loop/evidence/vons_style.before.json
+++ b/synthesis_loop/evidence/vons_style.before.json
@@ -1,0 +1,38 @@
+{
+  "base_git_sha": "e517d33fdc043abfcbff5f70e87dfd21bccc8952",
+  "bundle_hash": "63775db497ae88a596847c2ddea69cfa1271eda40b755c1e2fae87b36da506cb",
+  "image_id": "678a7c94-4948-4ebf-b8e9-9a17c13051ec",
+  "merchant": "Vons",
+  "metric": "style",
+  "receipt_id": 2,
+  "result": {
+    "body_stroke_fail": false,
+    "body_stroke_rel": {
+      "real": 0.0948,
+      "synth": 0.1336
+    },
+    "failing_classes": {
+      "address": {
+        "missing_style": [
+          "bold"
+        ],
+        "real": {
+          "bold": 1,
+          "n": 2,
+          "underline": 0
+        },
+        "synth": {
+          "bold": 0,
+          "n": 2,
+          "underline": 0
+        }
+      }
+    },
+    "preserved_metrics": {
+      "logo": "PASS",
+      "tokens": "PASS"
+    },
+    "verdict": "FAIL"
+  },
+  "truth_version": 1
+}


### PR DESCRIPTION
## Summary

- recognize standalone transaction headings without bolding payment narration or item-count prose
- use the compiled heavy face and add a measured two-dot reinforcement when that face alone remains below the receipt's 1.35x stroke boundary
- document the sealed-truth conflicts that prevent honest Vons and Gelson's style renderer changes

## Red → green evidence

Trader Joe's golden `4c262079-4fec-4724-a8e1-2886f38ea454#1`:

- baseline style: **FAIL**, footer bold real/synth `1/2` vs `0/2`
- focused branch: **PASS_WITH_GAPS**, footer bold `1/2` vs `1/2`; body stroke `.1068/.1068`; `total_line` is untested because n=1
- combined measured-geometry stack: **PASS_WITH_GAPS** after two-dot reinforcement; a one-dot strike was byte-identical because it remained inside the compiled heavy glyph envelope

Tokens, columns, separators, graphics, logo, and arithmetic remain PASS on the combined Trader Joe's evaluation.

## Honest unresolved truth conflicts

Committed root note: `synthesis_loop/evidence/grocery_style.unresolved.md`.

- Vons active v1 explicitly says address/body normal. The golden's absolute address strokes already match synthetic exactly, but the evaluator compares them with an unusually light real body median.
- Gelson's active v1 contains only `section_header`; payment, summary, and footer are explicitly body-normal even though the golden evaluator observes relative boldness.

Those merchants require measured row faces / a reminted style map. This PR deliberately avoids merchant-pinned heavy-address/footer hacks.

## Guards

- focused style tests pass
- corpus regression gate passes
- Costco, Sprouts, and non-target render pins remain byte-identical on the focused branch
- no DynamoDB writes; no production access