### PR TITLE
[synthesis_loop] Exclude measured logos from separator inventory

### DIFF
--- a/evidence/wild_fork_separator_logo_filter/RESULT.md
+++ b/evidence/wild_fork_separator_logo_filter/RESULT.md
@@ -1,0 +1,51 @@
+# Wild Fork separator/logo classification proof
+
+Golden receipt: `f008ea77-272b-4554-b8a6-e1676ec6a088#2`.
+Merchant truth: online-active `wild_fork` v1,
+bundle `a9de285daf995ce20245bdb397f1a0c25a25ec5ab27587f723b0df5e6c7504cc`.
+
+## Root cause
+
+The red separator candidates were logo strokes, not receipt rules. On the
+clean token-fix parent (`678e683a0`), the metric compared:
+
+- real y=0.0157 (42 px);
+- synth y=0.0150 (40 px);
+- phantom synth y=0.0247 (66 px).
+
+The independent logo metric measured the real and synth logo bounds at
+`cy=160, h=321`, covering all three candidates, and passed the logo itself.
+The two faded item-header dash rules visible lower in both panels were not the
+candidates responsible for the gate failure.
+
+The separator inventory now excludes only the vertical extent of an expected
+logo's measured dominant connected component. It does not loosen separator
+thresholds or apply a fixed merchant/page cutoff. A regression fixture proves
+that logo-like horizontal strokes are removed while a genuine rule outside the
+measured graphic remains matched and gated.
+
+## Metric proof
+
+| Metric | Before | After |
+|---|---|---|
+| separators | FAIL: real 1, synth 2; phantom y=0.0247 | PASS: no logo strokes in either rule inventory |
+| tokens | PASS: ink recall 0.9717 | PASS: ink recall 0.9717 |
+| columns | PASS | PASS |
+| graphics | PASS | PASS |
+| logo | PASS | PASS |
+| arithmetic | PASS | PASS |
+
+The full golden eval is `PASS_WITH_GAPS` only because the policy style class
+has insufficient coverage; every tested fidelity metric is green.
+
+## Guards
+
+- Full-fidelity metric/truth/gate tests: 56 passed.
+- `synthesis_loop/corpus_regression_gate.py check --json`: `ok: true`,
+  zero findings.
+- `synthesis_loop/render_regression_guard.py check`: Costco golden, Costco
+  new, Vons golden, and Sprouts are byte-identical to the committed baseline.
+- Black and `git diff --check`: clean.
+
+All live evaluation used read-only dev table `ReceiptsTable-dc5be22`; no gate
+record or other DynamoDB row was written.

--- a/evidence/wild_fork_separator_logo_filter/RESULT.md
+++ b/evidence/wild_fork_separator_logo_filter/RESULT.md
@@ -18,6 +18,11 @@ The independent logo metric measured the real and synth logo bounds at
 The two faded item-header dash rules visible lower in both panels were not the
 candidates responsible for the gate failure.
 
+The real-vs-itself control makes the classification error explicit: before
+logo exclusion it reports `PASS`, count 1/1, with its sole matched
+"separator" at y=0.0157 (the logo stroke) and `dy=0`. Thus the metric was
+self-consistent but measuring the wrong visual object.
+
 The separator inventory now excludes only the vertical extent of an expected
 logo's measured dominant connected component. It does not loosen separator
 thresholds or apply a fixed merchant/page cutoff. A regression fixture proves

--- a/evidence/wild_fork_separator_logo_filter/after.json
+++ b/evidence/wild_fork_separator_logo_filter/after.json
@@ -1,0 +1,59 @@
+{
+  "receipt": {
+    "image_id": "f008ea77-272b-4554-b8a6-e1676ec6a088",
+    "receipt_id": 2,
+    "slug": "wild_fork"
+  },
+  "stamp": {
+    "dirty": false,
+    "git_sha": "ca833b8f5f7a783bb36f0ce75d83fd6c79b4cb74",
+    "merchant_truth": {
+      "bundle_hash": "a9de285daf995ce20245bdb397f1a0c25a25ec5ab27587f723b0df5e6c7504cc",
+      "mode": "online-active",
+      "version": 1
+    }
+  },
+  "metrics": {
+    "overall": "PASS_WITH_GAPS",
+    "coverage_gaps": [
+      "style",
+      "style:policy"
+    ],
+    "columns": {
+      "verdict": "PASS"
+    },
+    "style": {
+      "verdict": "PASS_WITH_GAPS"
+    },
+    "tokens": {
+      "ink_recall": 0.9717,
+      "text_precision": 1.0,
+      "text_recall": 1.0,
+      "verdict": "PASS"
+    },
+    "separators": {
+      "kind_mismatches": 0,
+      "matched": [],
+      "missing_in_synth": [],
+      "phantom_in_synth": [],
+      "real_count": 0,
+      "synth_count": 0,
+      "verdict": "PASS"
+    },
+    "graphics": {
+      "verdict": "PASS"
+    },
+    "logo": {
+      "area_ratio": 0.985,
+      "center_offset_frac": 0.0099,
+      "size_ratio": 1.0,
+      "width_ratio": 0.945,
+      "verdict": "PASS"
+    },
+    "arithmetic": {
+      "testable": 3,
+      "violated": 0,
+      "verdict": "PASS"
+    }
+  }
+}

--- a/evidence/wild_fork_separator_logo_filter/before.json
+++ b/evidence/wild_fork_separator_logo_filter/before.json
@@ -56,6 +56,13 @@
     }
   },
   "diagnosis": {
+    "real_real_unmasked": {
+      "real_count": 1,
+      "synth_count": 1,
+      "matched_y_frac": 0.0157,
+      "dy": 0.0,
+      "verdict": "PASS"
+    },
     "real_detected_y_px": 42.0,
     "synth_detected_y_px": [
       40.1,
@@ -69,6 +76,6 @@
       "cy": 160.0,
       "h": 321.0
     },
-    "note": "Every gated candidate lies inside the measured storefront-logo bounding box. The real receipt's two item-header dash rules are lower on the page and are not the candidates being compared."
+    "note": "The real-vs-itself metric calls the logo stroke at y=0.0157 the receipt's sole separator. Every gated real-vs-synth candidate lies inside the measured storefront-logo bounding box. The real receipt's two item-header dash rules are lower on the page and are not the candidates being compared."
   }
 }

--- a/evidence/wild_fork_separator_logo_filter/before.json
+++ b/evidence/wild_fork_separator_logo_filter/before.json
@@ -1,0 +1,74 @@
+{
+  "receipt": {
+    "image_id": "f008ea77-272b-4554-b8a6-e1676ec6a088",
+    "receipt_id": 2,
+    "slug": "wild_fork"
+  },
+  "stamp": {
+    "git_sha": "678e683a00d9fbe571de20cf1e50a4a4d3bc7a8f",
+    "merchant_truth": {
+      "bundle_hash": "a9de285daf995ce20245bdb397f1a0c25a25ec5ab27587f723b0df5e6c7504cc",
+      "mode": "online-active",
+      "version": 1
+    }
+  },
+  "metrics": {
+    "tokens": {
+      "ink_recall": 0.9717,
+      "text_precision": 1.0,
+      "text_recall": 1.0,
+      "verdict": "PASS"
+    },
+    "separators": {
+      "kind_mismatches": 0,
+      "matched": [
+        {
+          "dy": 0.0007,
+          "real": {
+            "height_px": 7,
+            "kind": "dash",
+            "y_frac": 0.0157
+          },
+          "synth": {
+            "height_px": 17,
+            "kind": "dash",
+            "y_frac": 0.015
+          }
+        }
+      ],
+      "missing_in_synth": [],
+      "phantom_in_synth": [
+        {
+          "height_px": 5,
+          "kind": "dash",
+          "y_frac": 0.0247
+        }
+      ],
+      "real_count": 1,
+      "synth_count": 2,
+      "verdict": "FAIL"
+    },
+    "graphics": {
+      "verdict": "PASS"
+    },
+    "logo": {
+      "verdict": "PASS"
+    }
+  },
+  "diagnosis": {
+    "real_detected_y_px": 42.0,
+    "synth_detected_y_px": [
+      40.1,
+      66.1
+    ],
+    "logo_real_bbox": {
+      "cy": 160.0,
+      "h": 321.0
+    },
+    "logo_synth_bbox": {
+      "cy": 160.0,
+      "h": 321.0
+    },
+    "note": "Every gated candidate lies inside the measured storefront-logo bounding box. The real receipt's two item-header dash rules are lower on the page and are not the candidates being compared."
+  }
+}

--- a/synthesis_loop/full_fidelity_eval.py
+++ b/synthesis_loop/full_fidelity_eval.py
@@ -1360,6 +1360,47 @@ def _drop_text_bands(
     return kept
 
 
+def _drop_excluded_y_bands(
+    seps: list[dict],
+    excluded: tuple[tuple[float, float], ...],
+) -> list[dict]:
+    """Remove rule candidates inside a separately measured graphic region.
+
+    A wide logo can contain several thin horizontal strokes which satisfy the
+    separator detector's pixel-shape heuristics.  Those strokes belong to the
+    logo metric, not the receipt's rule inventory.  Exclusions are derived from
+    the logo's measured connected-component bounds rather than a fixed top-page
+    cutoff, so genuine rules outside the graphic remain testable.
+    """
+    return [
+        sep
+        for sep in seps
+        if not any(y0 <= sep["y_frac"] <= y1 for y0, y1 in excluded)
+    ]
+
+
+def _logo_separator_exclusion(
+    logo: dict,
+    side: str,
+    storefront_band: tuple[float, float],
+    image_height: int,
+) -> tuple[tuple[float, float], ...]:
+    """Return the measured logo's vertical extent as a normalized y-band."""
+    blob = logo.get(side)
+    if not blob:
+        return ()
+    band_top = int(storefront_band[0] * image_height)
+    cy = band_top + float(blob["cy"])
+    half_h = float(blob["h"]) / 2.0
+    margin = 2.0
+    return (
+        (
+            max(0.0, (cy - half_h - margin) / image_height),
+            min(1.0, (cy + half_h + margin) / image_height),
+        ),
+    )
+
+
 def metric_separators(
     real_gray: np.ndarray,
     syn_gray: np.ndarray,
@@ -1367,6 +1408,8 @@ def metric_separators(
     rows_syn: list[list[dict]] | None = None,
     *,
     composed: bool = False,
+    excluded_real_y: tuple[tuple[float, float], ...] = (),
+    excluded_syn_y: tuple[tuple[float, float], ...] = (),
 ) -> dict:
     """Count/order/y agreement of full-width rules.
 
@@ -1382,11 +1425,17 @@ def metric_separators(
     photo carries but the detector's span/coverage bars cannot see through
     the curl. Rules the real side has that the synth DROPPED always gate.
     """
-    real_seps = _drop_text_bands(
-        detect_separators(real_gray), rows_real, real_gray.shape[0]
+    real_seps = _drop_excluded_y_bands(
+        _drop_text_bands(
+            detect_separators(real_gray), rows_real, real_gray.shape[0]
+        ),
+        excluded_real_y,
     )
-    syn_seps = _drop_text_bands(
-        detect_separators(syn_gray), rows_syn, syn_gray.shape[0]
+    syn_seps = _drop_excluded_y_bands(
+        _drop_text_bands(
+            detect_separators(syn_gray), rows_syn, syn_gray.shape[0]
+        ),
+        excluded_syn_y,
     )
     matched = []
     kind_fails = []
@@ -2116,16 +2165,35 @@ def evaluate_pair(
         real_gray, syn_gray, rows_real, rows_syn, classes_real, classes_syn
     )
     tokens = metric_tokens(words_real, words_syn, syn_gray, composed=composed)
-    separators = metric_separators(
-        real_gray, syn_gray, rows_real, rows_syn, composed=composed
-    )
     graphics = metric_graphics(real_png, syn_png)
+    expects_logo = bool(
+        (truth.component("assets").get("profile") or {}).get("logo")
+    )
     logo = metric_logo(
         real_gray,
         syn_gray,
         storefront_band,
-        expects_logo=bool(
-            (truth.component("assets").get("profile") or {}).get("logo")
+        expects_logo=expects_logo,
+    )
+    separators = metric_separators(
+        real_gray,
+        syn_gray,
+        rows_real,
+        rows_syn,
+        composed=composed,
+        excluded_real_y=(
+            _logo_separator_exclusion(
+                logo, "real", storefront_band, real_gray.shape[0]
+            )
+            if expects_logo
+            else ()
+        ),
+        excluded_syn_y=(
+            _logo_separator_exclusion(
+                logo, "synth", storefront_band, syn_gray.shape[0]
+            )
+            if expects_logo
+            else ()
         ),
     )
     arithmetic = arithmetic_check(words_syn)

--- a/synthesis_loop/full_fidelity_eval.py
+++ b/synthesis_loop/full_fidelity_eval.py
@@ -1996,6 +1996,7 @@ def load_section_sequence(
     """
     try:
         from glyphstudio.sections import is_canonical_section
+
         from receipt_dynamo.data.dynamo_client import DynamoClient
 
         table = os.environ.get("DYNAMODB_TABLE_NAME", "ReceiptsTable-dc5be22")

--- a/tests/test_full_fidelity_eval.py
+++ b/tests/test_full_fidelity_eval.py
@@ -314,6 +314,37 @@ def test_separator_detector_ignores_text_rows():
     assert ffe.detect_separators(img) == []
 
 
+def test_separator_metric_excludes_measured_logo_strokes_only():
+    # Wild Fork's circular logo creates one real and two synthetic horizontal
+    # candidates even in the real-vs-real-aligned pair. They are graphic ink,
+    # while the matching rule at y=200 remains separator evidence.
+    real = _with_rules([30, 200])
+    syn = _with_rules([30, 60, 200])
+    unmasked = ffe.metric_separators(real, syn)
+    assert unmasked["verdict"] == "FAIL"
+    assert unmasked["phantom_in_synth"][0]["y_frac"] == 0.2033
+
+    logo = {
+        "real": {"cy": 45.0, "h": 70.0},
+        "synth": {"cy": 45.0, "h": 70.0},
+    }
+    storefront = (0.0, 0.15)
+    masked = ffe.metric_separators(
+        real,
+        syn,
+        excluded_real_y=ffe._logo_separator_exclusion(
+            logo, "real", storefront, H
+        ),
+        excluded_syn_y=ffe._logo_separator_exclusion(
+            logo, "synth", storefront, H
+        ),
+    )
+    assert masked["verdict"] == "PASS"
+    assert masked["real_count"] == 1
+    assert masked["synth_count"] == 1
+    assert masked["matched"][0]["real"]["y_frac"] == 0.67
+
+
 # ---------------------------------------------------------------------------
 # graphics (detector unavailable path only -- the Swift binary is exercised
 # in the live validation runs, not unit tests)


### PR DESCRIPTION
## Summary

- exclude separator candidates whose ink lies inside the measured merchant-logo envelope
- preserve genuine rules outside that envelope
- add focused red/green evidence, a real-vs-real detector control, and regression coverage

This is stacked on #1250 so the exact Wild Fork golden is evaluated with the source-geometry token fix.

## Red → green evidence

Golden: `wild_fork` receipt `f008ea77-272b-4554-b8a6-e1676ec6a088#2`.

Before, separators failed with real/synthetic counts `1/2` and a phantom rule at normalized y `.0247`. Every top-of-receipt candidate (40, 42, and 66 px) lies inside the measured Wild Fork logo envelope (`cy=160`, `h=321`). An unmasked real-vs-real control proves the detector selected the logo at y `.0157` as its sole matching “separator” while ignoring the lower true rules.

After measured-logo exclusion, separators **PASS** with missing/phantom counts `0/0`. Tokens remain PASS at ink recall `.9717`; columns, graphics, logo, and arithmetic remain PASS. Overall is PASS_WITH_GAPS only because the sealed style policy lacks fully testable style rows.

Committed proof: `synthesis_loop/evidence/wild_fork_separator_logo_filter/`.

## Guards

- 56 focused/related tests pass
- corpus regression gate passes with zero findings
- genuine separator ink outside a measured logo remains inventoried
- Costco (two pins), Vons, and Sprouts render pins are byte-identical
- no DynamoDB writes; no production access