### PR TITLE
[ci] Cover receipt renderer and repository tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -159,11 +159,14 @@ jobs:
             pip install black isort
             BASE_REF="${{ github.base_ref || 'main' }}"
             CHANGED_PY="$(git diff --name-only --diff-filter=ACMRT \
-              "origin/$BASE_REF"...HEAD -- receipt_agent \
+              "origin/$BASE_REF"...HEAD \
               | grep '\.py$' || true)"
             if [ -n "$CHANGED_PY" ]; then
-              black --check --line-length=79 $CHANGED_PY
-              isort --check-only --profile=black --line-length=79 $CHANGED_PY
+              while IFS= read -r py_file; do
+                black --check --line-length=79 "$py_file"
+                isort --check-only --profile=black --line-length=79 \
+                  "$py_file"
+              done <<< "$CHANGED_PY"
             fi
           else
             pip install -e "${{ matrix.package }}[lint]"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,11 +55,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        package: [receipt_dynamo, receipt_dynamo_stream, receipt_chroma, receipt_places, receipt_langsmith, receipt_upload]
+        package:
+          - receipt_dynamo
+          - receipt_dynamo_stream
+          - receipt_chroma
+          - receipt_places
+          - receipt_langsmith
+          - receipt_upload
+          - receipt_agent
     steps:
       - uses: actions/checkout@v7
         with:
           clean: true
+          fetch-depth: 0
 
       - name: Setup Python
         run: |
@@ -122,15 +130,46 @@ jobs:
                 pydantic pydantic-settings structlog requests tenacity
               pip install pytest pytest-mock pytest-cov pytest-xdist pytest-timeout pytest-rerunfailures moto responses
               ;;
+            receipt_agent)
+              # Renderer tests need the local data stack, but the sibling
+              # packages are not published on PyPI. Keep every local package
+              # editable so this job always exercises the checked-out code.
+              pip install -e receipt_dynamo
+              pip install --no-deps -e receipt_dynamo_stream
+              pip install --no-deps -e receipt_chroma
+              pip install --no-deps -e receipt_places
+              pip install --no-deps -e receipt_agent
+              pip install --no-deps -e receipt_upload
+              pip install boto3 chromadb "openai>=2.8.1,<3.0.0" Pillow \
+                pillow-avif-plugin langsmith langgraph \
+                "langchain-core>=0.3.0" "langchain-openai>=0.2.0" httpx \
+                pydantic pydantic-settings structlog requests tenacity \
+                segno python-barcode numpy
+              pip install pytest pytest-asyncio pytest-mock pytest-cov \
+                pytest-xdist pytest-timeout pytest-rerunfailures moto \
+                responses
+              ;;
             *)
               pip install -e "${{ matrix.package }}[test]"
               ;;
           esac
 
           # Lint (uses versions from pyproject.toml [lint] dependency)
-          pip install -e "${{ matrix.package }}[lint]"
-          black --check --line-length=79 ${{ matrix.package }}
-          isort --check-only --profile=black --line-length=79 ${{ matrix.package }}
+          if [ "${{ matrix.package }}" = "receipt_agent" ]; then
+            pip install black isort
+            BASE_REF="${{ github.base_ref || 'main' }}"
+            CHANGED_PY="$(git diff --name-only --diff-filter=ACMRT \
+              "origin/$BASE_REF"...HEAD -- receipt_agent \
+              | grep '\.py$' || true)"
+            if [ -n "$CHANGED_PY" ]; then
+              black --check --line-length=79 $CHANGED_PY
+              isort --check-only --profile=black --line-length=79 $CHANGED_PY
+            fi
+          else
+            pip install -e "${{ matrix.package }}[lint]"
+            black --check --line-length=79 ${{ matrix.package }}
+            isort --check-only --profile=black --line-length=79 ${{ matrix.package }}
+          fi
 
           # Test
           # --reruns 1 --reruns-delay 2: retry once with a 2s pause to absorb
@@ -149,6 +188,60 @@ jobs:
           name: coverage-${{ matrix.package }}
           path: ${{ matrix.package }}/coverage.xml
           retention-days: 1
+
+  repository-tests:
+    name: Python (repository tests)
+    runs-on: [self-hosted, macOS, ARM64]
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          clean: true
+
+      - name: Setup Python
+        run: |
+          if [ -f "/Library/Frameworks/Python.framework/Versions/3.12/bin/python3" ]; then
+            echo "/Library/Frameworks/Python.framework/Versions/3.12/bin" >> $GITHUB_PATH
+          elif [ -f "/opt/homebrew/bin/python3.12" ]; then
+            echo "/opt/homebrew/bin" >> $GITHUB_PATH
+          fi
+
+      - name: Install editable local stack
+        run: |
+          PYTHON=$(command -v python3.12 || command -v python3)
+          if [ -z "$PYTHON" ]; then
+            echo "::error::No python3.12 or python3 found on PATH"
+            exit 1
+          fi
+          "$PYTHON" -m venv .venv-repository-tests
+          source .venv-repository-tests/bin/activate
+          pip install --upgrade pip wheel
+          pip install -e receipt_dynamo
+          pip install --no-deps -e receipt_dynamo_stream
+          pip install --no-deps -e receipt_chroma
+          pip install --no-deps -e receipt_places
+          pip install --no-deps -e receipt_agent
+          pip install --no-deps -e receipt_upload
+          pip install boto3 chromadb "openai>=2.8.1,<3.0.0" Pillow \
+            pillow-avif-plugin langsmith langgraph \
+            "langchain-core>=0.3.0" "langchain-openai>=0.2.0" httpx \
+            pydantic pydantic-settings structlog requests tenacity \
+            segno python-barcode numpy
+          pip install pytest pytest-asyncio pytest-mock pytest-xdist \
+            pytest-timeout pytest-rerunfailures moto responses
+
+      - name: Test root and maintained script suites
+        run: |
+          source .venv-repository-tests/bin/activate
+          SCRIPT_TESTS=()
+          while IFS= read -r test_file; do
+            SCRIPT_TESTS+=("$test_file")
+          done < <(find scripts -maxdepth 1 -name 'test_*.py' \
+            ! -name 'test_noise_detection.py' \
+            ! -name 'test_realtime_embedding.py' \
+            ! -name 'test_spark_processor_local.py' -print)
+          python -m pytest tests "${SCRIPT_TESTS[@]}" \
+            -n auto --timeout=120 --tb=short --maxfail=5 \
+            --reruns 1 --reruns-delay 2
 
   typescript-tests:
     name: TypeScript
@@ -223,7 +316,12 @@ jobs:
 
   deploy:
     name: Deploy
-    needs: [lambda-syntax, python-tests, typescript-tests, browser-tests]
+    needs:
+      - lambda-syntax
+      - python-tests
+      - repository-tests
+      - typescript-tests
+      - browser-tests
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: ubuntu-latest
     environment: production

--- a/receipt_agent/tests/conftest.py
+++ b/receipt_agent/tests/conftest.py
@@ -45,14 +45,13 @@ def mock_dynamo_client() -> MagicMock:
         "value": "Test Merchant",
     }
 
-    client.get_receipt_details.return_value = (
-        MagicMock(),  # image
-        mock_receipt,  # receipt
-        [mock_word],  # words
-        [mock_line],  # lines
-        None,  # ocr_results
-        [],  # labels
-    )
+    mock_details = MagicMock()
+    mock_details.receipt = mock_receipt
+    mock_details.words = [mock_word]
+    mock_details.lines = [mock_line]
+    mock_details.letters = []
+    mock_details.labels = []
+    client.get_receipt_details.return_value = mock_details
 
     # Mock get_receipt_places_by_merchant
     client.get_receipt_places_by_merchant.return_value = ([mock_place], None)

--- a/receipt_agent/tests/test_chroma_helpers.py
+++ b/receipt_agent/tests/test_chroma_helpers.py
@@ -51,6 +51,11 @@ class FakeChromaClient:
         del query_embeddings, n_results, include
 
         label_value = where.get("label_TOTAL")
+        if collection_name == "words":
+            if "valid_labels_array" in where:
+                label_value = True
+            elif "invalid_labels_array" in where:
+                label_value = False
         if collection_name == "words" and label_value is True:
             return {
                 "metadatas": [
@@ -198,6 +203,7 @@ def test_format_label_evidence_for_prompt_includes_source_tags():
 # Helpers for unlabeled-word consensus tests
 # ---------------------------------------------------------------------------
 
+
 def _make_word_dict(
     image_id="img1",
     receipt_id=1,
@@ -247,7 +253,9 @@ class UnfilteredFakeChromaClient:
             return {"embeddings": [self._get_embedding]}
         return {"embeddings": []}
 
-    def query(self, collection_name, query_embeddings, n_results, include, **kwargs):
+    def query(
+        self, collection_name, query_embeddings, n_results, include, **kwargs
+    ):
         metadatas = []
         distances = []
         for neighbor in self._query_neighbors:
@@ -270,21 +278,31 @@ def test_discover_candidate_label_returns_dominant_label():
     neighbors = [
         {
             "metadata": {
-                "image_id": "img2", "receipt_id": 2, "line_id": 1, "word_id": i,
-                "text": "item", "valid_labels_array": ["LINE_TOTAL"],
+                "image_id": "img2",
+                "receipt_id": 2,
+                "line_id": 1,
+                "word_id": i,
+                "text": "item",
+                "valid_labels_array": ["LINE_TOTAL"],
             },
             "distance": 0.1,
         }
         for i in range(5)
     ]
     # Add a couple with a different label
-    neighbors.append({
-        "metadata": {
-            "image_id": "img3", "receipt_id": 3, "line_id": 1, "word_id": 1,
-            "text": "tax", "valid_labels_array": ["TAX"],
-        },
-        "distance": 0.2,
-    })
+    neighbors.append(
+        {
+            "metadata": {
+                "image_id": "img3",
+                "receipt_id": 3,
+                "line_id": 1,
+                "word_id": 1,
+                "text": "tax",
+                "valid_labels_array": ["TAX"],
+            },
+            "distance": 0.2,
+        }
+    )
 
     result = _discover_candidate_label(
         chroma_client=UnfilteredFakeChromaClient(query_neighbors=neighbors),
@@ -300,8 +318,12 @@ def test_discover_candidate_label_returns_none_when_no_dominant():
     neighbors = [
         {
             "metadata": {
-                "image_id": "img2", "receipt_id": 2, "line_id": 1, "word_id": i,
-                "text": f"word{i}", "valid_labels_array": [f"LABEL_{i}"],
+                "image_id": "img2",
+                "receipt_id": 2,
+                "line_id": 1,
+                "word_id": i,
+                "text": f"word{i}",
+                "valid_labels_array": [f"LABEL_{i}"],
             },
             "distance": 0.1,
         }
@@ -333,8 +355,12 @@ def test_discover_candidate_label_skips_unlabeled_labels():
     neighbors = [
         {
             "metadata": {
-                "image_id": "img2", "receipt_id": 2, "line_id": 1, "word_id": i,
-                "text": "word", "valid_labels_array": ["O"],
+                "image_id": "img2",
+                "receipt_id": 2,
+                "line_id": 1,
+                "word_id": i,
+                "text": "word",
+                "valid_labels_array": ["O"],
             },
             "distance": 0.1,
         }
@@ -352,26 +378,40 @@ def test_discover_candidate_label_skips_unlabeled_labels():
 @pytest.mark.unit
 def test_discover_candidate_label_excludes_self():
     """Should skip the query word's own chroma ID."""
-    self_id = _word_chroma_id(image_id="img2", receipt_id=2, line_id=1, word_id=1)
+    self_id = _word_chroma_id(
+        image_id="img2", receipt_id=2, line_id=1, word_id=1
+    )
     neighbors = [
         {
             "metadata": {
-                "image_id": "img2", "receipt_id": 2, "line_id": 1, "word_id": 1,
-                "text": "self", "valid_labels_array": ["TOTAL"],
+                "image_id": "img2",
+                "receipt_id": 2,
+                "line_id": 1,
+                "word_id": 1,
+                "text": "self",
+                "valid_labels_array": ["TOTAL"],
             },
             "distance": 0.05,
         },
         {
             "metadata": {
-                "image_id": "img3", "receipt_id": 3, "line_id": 1, "word_id": 1,
-                "text": "other1", "valid_labels_array": ["TOTAL"],
+                "image_id": "img3",
+                "receipt_id": 3,
+                "line_id": 1,
+                "word_id": 1,
+                "text": "other1",
+                "valid_labels_array": ["TOTAL"],
             },
             "distance": 0.1,
         },
         {
             "metadata": {
-                "image_id": "img4", "receipt_id": 4, "line_id": 1, "word_id": 1,
-                "text": "other2", "valid_labels_array": ["TOTAL"],
+                "image_id": "img4",
+                "receipt_id": 4,
+                "line_id": 1,
+                "word_id": 1,
+                "text": "other2",
+                "valid_labels_array": ["TOTAL"],
             },
             "distance": 0.15,
         },
@@ -396,8 +436,12 @@ def test_discover_and_evaluate_returns_candidate_and_consensus():
     neighbors = [
         {
             "metadata": {
-                "image_id": f"nb{i}", "receipt_id": i + 10, "line_id": 1, "word_id": 1,
-                "text": "item", "valid_labels_array": ["LINE_TOTAL"],
+                "image_id": f"nb{i}",
+                "receipt_id": i + 10,
+                "line_id": 1,
+                "word_id": 1,
+                "text": "item",
+                "valid_labels_array": ["LINE_TOTAL"],
                 "invalid_labels_array": [],
             },
             "distance": 0.1,
@@ -423,8 +467,12 @@ def test_discover_and_evaluate_returns_none_no_dominant():
     neighbors = [
         {
             "metadata": {
-                "image_id": f"nb{i}", "receipt_id": i + 10, "line_id": 1, "word_id": 1,
-                "text": "word", "valid_labels_array": [f"UNIQUE_{i}"],
+                "image_id": f"nb{i}",
+                "receipt_id": i + 10,
+                "line_id": 1,
+                "word_id": 1,
+                "text": "word",
+                "valid_labels_array": [f"UNIQUE_{i}"],
                 "invalid_labels_array": [],
             },
             "distance": 0.1,
@@ -457,8 +505,12 @@ def test_discover_and_evaluate_mixed_consensus():
         # 3 neighbors with LINE_TOTAL as valid
         {
             "metadata": {
-                "image_id": f"v{i}", "receipt_id": i + 10, "line_id": 1, "word_id": 1,
-                "text": "amount", "valid_labels_array": ["LINE_TOTAL"],
+                "image_id": f"v{i}",
+                "receipt_id": i + 10,
+                "line_id": 1,
+                "word_id": 1,
+                "text": "amount",
+                "valid_labels_array": ["LINE_TOTAL"],
                 "invalid_labels_array": [],
             },
             "distance": 0.1 + i * 0.01,
@@ -468,8 +520,12 @@ def test_discover_and_evaluate_mixed_consensus():
         # 2 neighbors with LINE_TOTAL as invalid
         {
             "metadata": {
-                "image_id": f"i{i}", "receipt_id": i + 20, "line_id": 1, "word_id": 1,
-                "text": "price", "valid_labels_array": [],
+                "image_id": f"i{i}",
+                "receipt_id": i + 20,
+                "line_id": 1,
+                "word_id": 1,
+                "text": "price",
+                "valid_labels_array": [],
                 "invalid_labels_array": ["LINE_TOTAL"],
             },
             "distance": 0.15 + i * 0.01,
@@ -500,7 +556,10 @@ def _make_consensus_neighbors(target_label, count=5, valid=True):
     neighbors = []
     for i in range(count):
         meta = {
-            "image_id": f"nb{i}", "receipt_id": i + 10, "line_id": 1, "word_id": 1,
+            "image_id": f"nb{i}",
+            "receipt_id": i + 10,
+            "line_id": 1,
+            "word_id": 1,
             "text": "amount",
         }
         if valid:
@@ -563,8 +622,12 @@ def test_chroma_resolve_unlabeled_word_no_dominant_label():
     neighbors = [
         {
             "metadata": {
-                "image_id": f"nb{i}", "receipt_id": i + 10, "line_id": 1, "word_id": 1,
-                "text": "word", "valid_labels_array": [f"UNIQUE_{i}"],
+                "image_id": f"nb{i}",
+                "receipt_id": i + 10,
+                "line_id": 1,
+                "word_id": 1,
+                "text": "word",
+                "valid_labels_array": [f"UNIQUE_{i}"],
             },
             "distance": 0.1 + i * 0.02,
         }
@@ -617,7 +680,9 @@ def test_chroma_resolve_mixed_labeled_and_unlabeled():
 
     labeled_word = _make_word_dict(current_label="TOTAL", word_text="12.99")
     unlabeled_word = _make_word_dict(
-        current_label="", word_text="5.00", word_id=4,
+        current_label="",
+        word_text="5.00",
+        word_id=4,
     )
 
     resolved, unresolved = chroma_resolve_words(

--- a/receipt_agent/tests/test_llm_factory.py
+++ b/receipt_agent/tests/test_llm_factory.py
@@ -128,7 +128,7 @@ class TestErrorDetection:
 class TestCreateLLM:
     """Tests for create_llm function."""
 
-    @patch("receipt_agent.utils.llm_factory.ChatOpenAI")
+    @patch("langchain_openai.ChatOpenAI")
     def test_creates_openrouter_with_env_vars(self, mock_chat_openai):
         """Test that create_llm creates ChatOpenAI for OpenRouter."""
         mock_chat_openai.return_value = MagicMock()
@@ -150,7 +150,7 @@ class TestCreateLLM:
         assert call_kwargs["api_key"] == "or_test_key"
         assert call_kwargs["temperature"] == 0.0
 
-    @patch("receipt_agent.utils.llm_factory.ChatOpenAI")
+    @patch("langchain_openai.ChatOpenAI")
     def test_creates_with_custom_params(self, mock_chat_openai):
         """Test that create_llm respects custom parameters."""
         mock_chat_openai.return_value = MagicMock()
@@ -167,7 +167,7 @@ class TestCreateLLM:
         assert call_kwargs["temperature"] == 0.7
         assert call_kwargs["timeout"] == 300
 
-    @patch("receipt_agent.utils.llm_factory.ChatOpenAI")
+    @patch("langchain_openai.ChatOpenAI")
     def test_includes_openrouter_headers(self, mock_chat_openai):
         """Test that create_llm includes OpenRouter-specific headers."""
         mock_chat_openai.return_value = MagicMock()
@@ -191,7 +191,7 @@ class TestCreateLLM:
             ):
                 create_llm()
 
-    @patch("receipt_agent.utils.llm_factory.ChatOpenAI")
+    @patch("langchain_openai.ChatOpenAI")
     def test_uses_receipt_agent_prefix_env_vars(self, mock_chat_openai):
         """Test that RECEIPT_AGENT_ prefixed env vars are used."""
         mock_chat_openai.return_value = MagicMock()
@@ -420,6 +420,8 @@ class TestCreateLLMInvoker:
             model="test-model",
             temperature=0.5,
             timeout=120,
+            reasoning=None,
+            reasoning_effort=None,
         )
 
 

--- a/receipt_agent/tests/test_structured_output_utils.py
+++ b/receipt_agent/tests/test_structured_output_utils.py
@@ -68,7 +68,11 @@ class TestInvokeStructuredWithRetry:
         llm = MagicMock()
         structured_llm = MagicMock()
         structured_response = MagicMock()
-        structured_llm.invoke.return_value = structured_response
+        structured_llm.invoke.return_value = {
+            "parsed": structured_response,
+            "parsing_error": None,
+            "raw": MagicMock(),
+        }
         llm.with_structured_output.return_value = structured_llm
 
         result = invoke_structured_with_retry(
@@ -81,7 +85,9 @@ class TestInvokeStructuredWithRetry:
         assert result.success is True
         assert result.response == structured_response
         assert result.attempts == 1
-        llm.with_structured_output.assert_called_once_with(DummySchema)
+        llm.with_structured_output.assert_called_once_with(
+            DummySchema, include_raw=True
+        )
 
     def test_failure_returns_metadata(self):
         """Returns structured failure metadata after retries are exhausted."""
@@ -141,7 +147,13 @@ class TestAinvokeStructuredWithRetry:
         llm = MagicMock()
         structured_llm = MagicMock()
         structured_response = MagicMock()
-        structured_llm.ainvoke = AsyncMock(return_value=structured_response)
+        structured_llm.ainvoke = AsyncMock(
+            return_value={
+                "parsed": structured_response,
+                "parsing_error": None,
+                "raw": MagicMock(),
+            }
+        )
         llm.with_structured_output.return_value = structured_llm
 
         result = await ainvoke_structured_with_retry(
@@ -176,7 +188,9 @@ class TestAinvokeStructuredWithRetry:
         """Rate limit errors are propagated for Step Functions retry handling."""
         llm = MagicMock()
         structured_llm = MagicMock()
-        structured_llm.ainvoke = AsyncMock(side_effect=LLMRateLimitError("429"))
+        structured_llm.ainvoke = AsyncMock(
+            side_effect=LLMRateLimitError("429")
+        )
         llm.with_structured_output.return_value = structured_llm
 
         with pytest.raises(LLMRateLimitError):

--- a/receipt_agent/tests/test_trace_id_consistency.py
+++ b/receipt_agent/tests/test_trace_id_consistency.py
@@ -1,13 +1,4 @@
-"""Test trace ID generation consistency across modules.
-
-The trace ID generation logic is duplicated in:
-- infra/label_evaluator_step_functions/handlers/fetch_receipt_data.py
-- infra/label_evaluator_step_functions/lambdas/utils/tracing.py
-
-This is necessary because fetch_receipt_data.py is a zip-based Lambda that
-cannot import from the container-based tracing.py module. This test ensures
-both implementations produce identical trace IDs for the same inputs.
-"""
+"""Test the active receipt trace ID contract."""
 
 import sys
 import uuid
@@ -17,50 +8,21 @@ import pytest
 
 # Add paths to import from actual source modules
 _PROJECT_ROOT = Path(__file__).resolve().parents[2]
-_HANDLERS_PATH = (
-    _PROJECT_ROOT / "infra" / "label_evaluator_step_functions" / "handlers"
-)
 _TRACING_PATH = (
     _PROJECT_ROOT / "infra" / "label_evaluator_step_functions" / "lambdas"
 )
-sys.path.insert(0, str(_HANDLERS_PATH))
 sys.path.insert(0, str(_TRACING_PATH))
 
-# Import TRACE_NAMESPACE from the actual source modules
+# Import the contract from the active unified evaluator source.
 # pylint: disable=wrong-import-position,import-error
-from fetch_receipt_data import (  # noqa: E402
-    TRACE_NAMESPACE as FETCH_TRACE_NAMESPACE,
-)
 from utils.tracing import (  # noqa: E402
-    TRACE_NAMESPACE as TRACING_TRACE_NAMESPACE,
+    TRACE_NAMESPACE,
+    generate_receipt_trace_id,
 )
 
-# Use fetch_receipt_data as the reference namespace
-TRACE_NAMESPACE = FETCH_TRACE_NAMESPACE
 
-
-def generate_receipt_trace_id_fetch(
-    execution_arn: str,
-    image_id: str,
-    receipt_id: int,
-) -> str:
-    """Implementation from fetch_receipt_data.py."""
-    parts = [execution_arn, image_id, str(receipt_id)]
-    return str(uuid.uuid5(TRACE_NAMESPACE, ":".join(parts)))
-
-
-def generate_receipt_trace_id_tracing(
-    execution_arn: str,
-    image_id: str,
-    receipt_id: int,
-) -> str:
-    """Implementation from tracing.py."""
-    parts = [execution_arn, image_id, str(receipt_id)]
-    return str(uuid.uuid5(TRACE_NAMESPACE, ":".join(parts)))
-
-
-class TestTraceIdConsistency:
-    """Verify trace ID generation is consistent across modules."""
+class TestReceiptTraceId:
+    """Verify the active receipt trace ID contract."""
 
     @pytest.mark.parametrize(
         "execution_arn,image_id,receipt_id",
@@ -85,34 +47,24 @@ class TestTraceIdConsistency:
             ("arn:with:colons", "id:with:colons", 999),
         ],
     )
-    def test_implementations_match(
+    def test_matches_uuid5_contract(
         self, execution_arn: str, image_id: str, receipt_id: int
     ):
-        """Both implementations should produce identical trace IDs."""
-        fetch_id = generate_receipt_trace_id_fetch(
-            execution_arn, image_id, receipt_id
-        )
-        tracing_id = generate_receipt_trace_id_tracing(
-            execution_arn, image_id, receipt_id
+        """The public helper should retain its deterministic UUID5 contract."""
+        actual = generate_receipt_trace_id(execution_arn, image_id, receipt_id)
+        expected = str(
+            uuid.uuid5(
+                TRACE_NAMESPACE,
+                ":".join([execution_arn, image_id, str(receipt_id)]),
+            )
         )
 
-        assert fetch_id == tracing_id, (
-            f"Trace ID mismatch for ({execution_arn}, {image_id}, {receipt_id}): "
-            f"fetch={fetch_id}, tracing={tracing_id}"
-        )
+        assert actual == expected
 
     def test_namespace_matches(self):
-        """Verify TRACE_NAMESPACE is consistent across both source modules."""
+        """Verify the pinned namespace remains stable."""
         expected = uuid.UUID("a1b2c3d4-e5f6-7890-abcd-ef1234567890")
-        assert (
-            FETCH_TRACE_NAMESPACE == expected
-        ), f"fetch_receipt_data.TRACE_NAMESPACE mismatch: {FETCH_TRACE_NAMESPACE}"
-        assert (
-            TRACING_TRACE_NAMESPACE == expected
-        ), f"tracing.TRACE_NAMESPACE mismatch: {TRACING_TRACE_NAMESPACE}"
-        assert (
-            FETCH_TRACE_NAMESPACE == TRACING_TRACE_NAMESPACE
-        ), "TRACE_NAMESPACE differs between fetch_receipt_data.py and tracing.py"
+        assert TRACE_NAMESPACE == expected
 
     def test_deterministic(self):
         """Same inputs should always produce same output."""
@@ -121,11 +73,10 @@ class TestTraceIdConsistency:
             "img-001",
             1,
         )
-        id1 = generate_receipt_trace_id_fetch(*args)
-        id2 = generate_receipt_trace_id_fetch(*args)
-        id3 = generate_receipt_trace_id_tracing(*args)
+        id1 = generate_receipt_trace_id(*args)
+        id2 = generate_receipt_trace_id(*args)
 
-        assert id1 == id2 == id3
+        assert id1 == id2
 
     def test_different_receipts_have_different_ids(self):
         """Different receipt_ids should produce different trace IDs."""
@@ -133,14 +84,14 @@ class TestTraceIdConsistency:
             "arn:aws:states:us-west-2:123456789:execution:test:abc123",
             "img-001",
         )
-        id1 = generate_receipt_trace_id_fetch(*base_args, 1)
-        id2 = generate_receipt_trace_id_fetch(*base_args, 2)
+        id1 = generate_receipt_trace_id(*base_args, 1)
+        id2 = generate_receipt_trace_id(*base_args, 2)
 
         assert id1 != id2
 
     def test_valid_uuid_format(self):
         """Generated IDs should be valid UUIDs."""
-        trace_id = generate_receipt_trace_id_fetch(
+        trace_id = generate_receipt_trace_id(
             "arn:aws:states:us-west-2:123456789:execution:test:abc123",
             "img-001",
             1,


### PR DESCRIPTION
## Summary
- add `receipt_agent` to the Python 3.12 matrix with the complete editable local package stack
- run root `tests/` plus maintained top-level `scripts/test_*.py` in a dedicated repository job
- make deploy depend on the new repository test job
- lint every changed Python file one at a time so each package's configuration resolves correctly
- refresh dormant test doubles for current lazy imports, structured-output envelopes, Dynamo receipt details, Chroma label filters, and the active unified trace helper

## Why
The existing matrix installed `receipt_agent` only as a dependency of `receipt_upload`; it never executed `receipt_agent/tests`. Root renderer tests and script tests also had no job, so renderer PRs could appear green without testing their changes.

Three top-level script harnesses remain intentionally outside this first CI gate: `test_noise_detection.py` and `test_realtime_embedding.py` import the removed `receipt_label` package, while `test_spark_processor_local.py` is a local PySpark harness. The job names these exclusions explicitly rather than silently swallowing collection failures.

## Local verification
Fresh Python 3.12 venv with editable `receipt_dynamo`, `receipt_dynamo_stream`, `receipt_chroma`, `receipt_places`, `receipt_agent`, and `receipt_upload`:

- `receipt_agent/tests`: **320 passed, 22 skipped** with xdist, 120-second timeout, rerun policy, and coverage XML
- root tests plus maintained top-level script tests: **552 passed, 1 skipped**
- changed-file Black (line length 79): PASS
- changed-file isort (Black profile, line length 79): PASS
- workflow YAML parse: PASS
- Prettier: PASS
- `git diff --check`: clean

## GitHub Actions proof
The expanded workflow now runs both new checks:

- `Python (receipt_agent)`: PASS
- `Python (repository tests)`: PASS
- all existing Python, TypeScript, Lambda, and Browser jobs: PASS

The first attempt lost two self-hosted runners; GitHub's annotations explicitly reported runner communication loss. Rerunning only failed jobs completed successfully with no code change.

This CI PR must land before the receipt-render-fidelity PRs can truthfully claim full CI coverage. Do not merge without owner review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded automated repository-wide test coverage, including script tests.
  * Updated test expectations for structured LLM responses, receipt details, label filtering, and trace ID generation.
  * Improved validation of deterministic and correctly formatted receipt trace IDs.

* **Chores**
  * Refined continuous integration checks and deployment gating.
  * Optimized linting to focus on changed Python files for the receipt processing package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->