### PR TITLE
[receipt_renderer] Honor measured separator rows

### DIFF
--- a/receipt_agent/receipt_agent/agents/label_evaluator/rendering/receipt_renderer.py
+++ b/receipt_agent/receipt_agent/agents/label_evaluator/rendering/receipt_renderer.py
@@ -51,6 +51,7 @@ from receipt_agent.agents.label_evaluator.rendering.receipt_grid import (
     glyph_advance,
     group_words_into_grid_lines,
     is_price_token,
+    line_baseline,
     section_for_labels,
 )
 from receipt_agent.agents.label_evaluator.rendering.receipt_stylemap import (
@@ -189,6 +190,12 @@ class RenderConfig:
     # Rows containing any of these phrases get a dashed rule ABOVE and BELOW
     # (Costco wraps each "Shop Card" tender subtotal in rules; OCR drops them).
     dash_around_phrases: tuple = ()
+    # Measured rule-row inventory from ``layout_template.separators``.
+    # ``None`` means no measured inventory was supplied and preserves the
+    # legacy phrase heuristics byte-for-byte.  An explicit empty sequence is
+    # authoritative: draw literal OCR rule rows, but do not invent additional
+    # rules. Non-empty entries are drawn at their measured ``pos_frac_med``.
+    measured_separators: Sequence[Mapping[str, Any]] | None = None
     # Opt-in: also horizontally condense bitmap GLYPH IMAGES (not just cell
     # advance). Merchants calibrated before this knob existed keep the old
     # behavior; In-N-Out was calibrated with it on.
@@ -500,23 +507,26 @@ def _draw_dash_row(
     cap_px=None,
     bitmap_thin: float = 0.0,
     condense_glyphs: bool = False,
+    char: str = "-",
 ) -> None:
-    """A thermal separator rule printed as a run of actual ``-`` glyphs.
+    """A thermal separator rule printed as a run of actual rule glyphs.
 
-    Costco prints its section separators as a full-width row of the dash
-    character in the same monospace face as the body (dropped by OCR). Rendering
-    them through :func:`draw_token_chars` -- rather than a drawn line -- gives the
-    real letterform (bitmap atlas), condense, stroke and ink of the body text, so
-    the rule reads as printed dashes instead of a clean vector line. ``condense_glyphs``
-    mirrors the body text's per-glyph x-resize so the dashes track the same width.
+    Rendering measured separator characters through :func:`draw_token_chars`
+    -- rather than a drawn line -- gives the real letterform (bitmap atlas),
+    condense, stroke and ink of the body text, so the rule reads as printed
+    glyphs instead of a clean vector line. ``condense_glyphs`` mirrors the body
+    text's per-glyph x-resize so the rule tracks the same width.
     """
+    char = str(char or "-")[:1]
+    if char not in "*-=_~":
+        return
     start_col = int(round((x0 - spec.grid_left) / spec.cell_w))
     n = int((x1 - x0) / spec.cell_w)
     if n <= 0:
         return
     draw_token_chars(
         draw,
-        "-" * n,
+        char * n,
         start_col,
         baseline_y,
         spec,
@@ -536,6 +546,16 @@ def _is_asterisk_rule(row_text: str) -> bool:
     if len(chars) < 3 or any(ch.isalnum() for ch in chars):
         return False
     return chars.count("*") / len(chars) >= 0.75
+
+
+def _literal_separator_char(row_text: str) -> str | None:
+    """Return the dominant glyph for a literal OCR separator row."""
+    chars = [ch for ch in row_text if not ch.isspace()]
+    if len(chars) < 3 or any(ch.isalnum() for ch in chars):
+        return None
+    allowed = "*-=_~"
+    dominant = max(allowed, key=chars.count)
+    return dominant if chars.count(dominant) / len(chars) >= 0.75 else None
 
 
 def _ocr_grid_metrics(
@@ -882,13 +902,23 @@ def _render_grid(
     # TOTAL, and the AMOUNT-block transaction-date line (the date row whose prior
     # row is the "AMOUNT:" line).
     row_texts = [" ".join(w.text for w in ln).upper() for ln in rows]
-    dash_after_rows = _separator_anchor_rows(rows, row_texts, config)
+    dash_after_rows = (
+        _separator_anchor_rows(rows, row_texts, config)
+        if config.measured_separators is None
+        else set()
+    )
     baselines, dash_ys = _separator_layout(
         baselines,
         dash_after_rows,
         pitch=float(min_pitch),
         cap_h=cap_h,
     )
+    measured_separators: list[Mapping[str, Any]] = [
+        entry
+        for entry in (config.measured_separators or ())
+        if isinstance(entry, Mapping)
+    ]
+    measured_separator_used: set[int] = set()
     row_cache: dict[tuple, tuple] = {}
     prev_text = ""
     for line, baseline, sect in zip(rows, baselines, eff_sections):
@@ -959,13 +989,57 @@ def _render_grid(
                 and sm_style["scale"] <= 0.9
             ):
                 bf_row = bmf_light.get(sm_style["scale"], bf_row)
-        if _is_asterisk_rule(row_text):
+        literal_separator = (
+            _literal_separator_char(row_text)
+            if config.measured_separators is not None
+            else ("*" if _is_asterisk_rule(row_text) else None)
+        )
+        if literal_separator is not None:
+            # A literal OCR rule already carries real vertical geometry. The
+            # normal baseline pass may push it hundreds of pixels after dense
+            # payment rows, so measured-layout mode restores its source row.
+            # When the template also contains a matching measured entry, its
+            # paper fraction wins and that entry is marked consumed.
+            separator_cap_px = (
+                max(
+                    6,
+                    int(round(float(cap_px or sizing.font_px) * 0.85)),
+                )
+                if config.measured_separators is not None
+                else cap_px
+            )
+            separator_baseline = (
+                line_baseline(line, ascent)
+                if config.measured_separators is not None
+                else baseline
+            )
+            source_y_frac = median(w.center_y for w in line) / config.height
+            candidates: list[tuple[float, int, float]] = []
+            for index, entry in enumerate(measured_separators):
+                if index in measured_separator_used:
+                    continue
+                if str(entry.get("char") or "")[:1] != literal_separator:
+                    continue
+                try:
+                    pos_frac = float(entry["pos_frac_med"])
+                except (KeyError, TypeError, ValueError):
+                    continue
+                if 0.0 <= pos_frac <= 1.0:
+                    candidates.append(
+                        (abs(pos_frac - source_y_frac), index, pos_frac)
+                    )
+            if candidates:
+                _distance, index, pos_frac = min(candidates)
+                measured_separator_used.add(index)
+                separator_baseline = pos_frac * config.height + 0.35 * float(
+                    separator_cap_px or sizing.font_px
+                )
             n = int(content_cw / spec.cell_w)
             draw_token_chars(
                 draw,
-                "*" * max(3, n),
+                literal_separator * max(3, n),
                 0,
-                baseline,
+                separator_baseline,
                 spec,
                 font,
                 line[0].ink,
@@ -973,7 +1047,7 @@ def _render_grid(
                 condense=config.condense,
                 condense_glyphs=config.condense_glyphs,
                 bitmap_font=bf_row,
-                cap_px=cap_px,
+                cap_px=separator_cap_px,
                 bitmap_thin=config.bitmap_thin,
             )
             continue
@@ -1157,6 +1231,39 @@ def _render_grid(
             bitmap_font=dash_bmf,
             cap_px=cap_px,
             bitmap_thin=config.bitmap_thin,
+        )
+    # Measured rows without a corresponding literal OCR token are still part of
+    # the observed merchant inventory. Draw each at its measured paper fraction
+    # without reserving a synthetic blank row or shifting downstream content.
+    measured_cap_px = max(
+        6, int(round(float(cap_px or sizing.font_px) * 0.85))
+    )
+    for index, entry in enumerate(measured_separators):
+        if index in measured_separator_used:
+            continue
+        char = str(entry.get("char") or "")[:1]
+        try:
+            pos_frac = float(entry["pos_frac_med"])
+        except (KeyError, TypeError, ValueError):
+            continue
+        if char not in "*-=_~" or not 0.0 <= pos_frac <= 1.0:
+            continue
+        measured_bmf = bmf if (bmf is not None and bmf.has(char)) else None
+        _draw_dash_row(
+            draw,
+            content_left,
+            content_right,
+            pos_frac * config.height + 0.35 * float(measured_cap_px),
+            spec,
+            font,
+            ink=_ink_for({}, config),
+            stroke=config.stroke,
+            condense=config.condense,
+            condense_glyphs=config.condense_glyphs,
+            bitmap_font=measured_bmf,
+            cap_px=measured_cap_px,
+            bitmap_thin=config.bitmap_thin,
+            char=char,
         )
 
 

--- a/receipt_agent/tests/test_receipt_renderer_separators.py
+++ b/receipt_agent/tests/test_receipt_renderer_separators.py
@@ -1,0 +1,106 @@
+from unittest.mock import patch
+
+import pytest
+
+from receipt_agent.agents.label_evaluator.rendering import receipt_renderer
+from receipt_agent.agents.label_evaluator.rendering.receipt_grid import (
+    build_grid_spec,
+)
+from receipt_agent.agents.label_evaluator.rendering.receipt_renderer import (
+    RenderConfig,
+    render_receipt,
+)
+
+
+def _word(text, line_id, bbox):
+    return {
+        "text": text,
+        "line_id": line_id,
+        "word_id": 1,
+        "bbox": bbox,
+        "labels": [],
+    }
+
+
+def test_measured_empty_inventory_suppresses_phrase_separator_heuristics():
+    receipt = {
+        "words": [
+            _word("TOTAL", 1, [60, 800, 300, 760]),
+            _word("1.00", 1, [700, 800, 940, 760]),
+            _word("NEXT", 2, [60, 700, 300, 660]),
+        ]
+    }
+    config = RenderConfig(
+        width=240,
+        height=360,
+        margin=10,
+        grid_mode=True,
+        dashed_separators=True,
+        measured_separators=(),
+    )
+
+    with patch.object(receipt_renderer, "_draw_dash_row") as draw_rule:
+        render_receipt(receipt, config=config, coord_max=1000.0)
+
+    draw_rule.assert_not_called()
+
+
+def test_literal_rule_uses_source_y_with_measured_layout():
+    words = [
+        _word(
+            f"ROW{i}",
+            i,
+            [60, 900 - i * 12, 300, 875 - i * 12],
+        )
+        for i in range(20)
+    ]
+    star_bbox = [40, 250, 950, 235]
+    words.append(_word("*" * 20, 99, star_bbox))
+    receipt = {"words": words}
+    config = RenderConfig(
+        width=240,
+        height=360,
+        margin=10,
+        grid_mode=True,
+        measured_separators=(),
+    )
+    captured = []
+
+    def record_rule(*args, **kwargs):
+        if str(args[1]).startswith("*"):
+            captured.append(args[3])
+
+    with patch.object(receipt_renderer, "draw_token_chars", record_rule):
+        render_receipt(receipt, config=config, coord_max=1000.0)
+
+    assert len(captured) == 1
+    inner_w = config.width - 2 * config.margin
+    inner_h = config.height - 2 * config.margin
+    sizing = build_grid_spec(None, inner_w, inner_h, config)
+    font = receipt_renderer._load_grid_font(sizing.font_px, config)
+    ascent, _descent = font.getmetrics()
+    source_box = receipt_renderer._to_pixel_box(
+        star_bbox, 1000.0, config, inner_w, inner_h
+    )
+    assert source_box is not None
+    assert captured[0] == pytest.approx(source_box[1] + ascent)
+
+
+def test_nonempty_measured_inventory_draws_at_measured_fraction():
+    receipt = {"words": [_word("BODY", 1, [60, 800, 300, 760])]}
+    config = RenderConfig(
+        width=240,
+        height=360,
+        margin=10,
+        grid_mode=True,
+        measured_separators=(
+            {"char": "=", "pos_frac_med": 0.6, "support": 4},
+        ),
+    )
+
+    with patch.object(receipt_renderer, "_draw_dash_row") as draw_rule:
+        render_receipt(receipt, config=config, coord_max=1000.0)
+
+    draw_rule.assert_called_once()
+    assert draw_rule.call_args.kwargs["char"] == "="
+    assert draw_rule.call_args.args[3] > 0.6 * config.height

--- a/scripts/render_synthetic_receipts.py
+++ b/scripts/render_synthetic_receipts.py
@@ -1933,9 +1933,8 @@ def _render_cached_hybrid(
     # photo) and route the words through a composer BEFORE any layout. This
     # is the production hook -- glyph_review, section_compare and normal
     # renders all pass through here, so the composed layout IS the render.
-    compose_kind = get_merchant_profile(receipt.get("merchant_name")).get(
-        "compose"
-    )
+    merchant_profile = get_merchant_profile(receipt.get("merchant_name"))
+    compose_kind = merchant_profile.get("compose")
     if compose_kind == "dollartree":
         synth_dir = os.path.join(REPO_ROOT, "synthesis_loop")
         if synth_dir not in sys.path:
@@ -1961,6 +1960,19 @@ def _render_cached_hybrid(
     # tokens just before drawing -- fixes the dominant remaining realism tell
     # without re-running synthesis. Mutates the per-render receipt dict in place.
     clean_for_render(receipt)
+    layout_template = merchant_profile.get("layout_template")
+    measured_separators = None
+    if (
+        isinstance(layout_template, dict)
+        and "separators" in layout_template
+        and isinstance(layout_template["separators"], list)
+    ):
+        # ``None`` and ``[]`` are intentionally different. Missing layout data
+        # preserves the legacy phrase heuristics; a measured empty inventory
+        # disables them while literal OCR rule rows remain authoritative.
+        measured_separators = tuple(
+            copy.deepcopy(layout_template["separators"])
+        )
     config = RenderConfig(
         bitmap_font=bitmap_font,
         width=width,
@@ -1984,6 +1996,7 @@ def _render_cached_hybrid(
         mixed_layout=mixed_layout,
         stylemap=stylemap,
         dash_around_phrases=tuple(dash_around_phrases or ()),
+        measured_separators=measured_separators,
         pitch_ratio=pitch_ratio,
         condense_glyphs=bool(condense_glyphs),
         box_sink=box_sink,

--- a/scripts/render_synthetic_receipts.py
+++ b/scripts/render_synthetic_receipts.py
@@ -1891,6 +1891,32 @@ def _content_texture_seed(receipt: dict) -> int:
     return zlib.crc32("\n".join(parts).encode("utf-8"))
 
 
+def _measured_separator_inventory(
+    merchant_profile: dict,
+    *,
+    compose_kind: str | None,
+) -> tuple[dict, ...] | None:
+    """Return measured rules without reinterpreting composed punctuation."""
+    layout_template = merchant_profile.get("layout_template")
+    if not (
+        isinstance(layout_template, dict)
+        and "separators" in layout_template
+        and isinstance(layout_template["separators"], list)
+    ):
+        return None
+    separators = layout_template["separators"]
+    if compose_kind and not separators:
+        # A composer replaces source geometry with a canonical layout. With
+        # an authoritative empty inventory, the canonical output already is
+        # the separator policy; routing it through the source-row literal
+        # detector can turn punctuation-only rows into phantom rules.
+        return None
+    # ``None`` and ``[]`` intentionally differ for ordinary OCR layouts:
+    # missing data preserves legacy heuristics, while an explicit empty
+    # inventory disables them and retains only literal source rule rows.
+    return tuple(copy.deepcopy(separators))
+
+
 def _render_cached_hybrid(
     receipt: dict,
     atlas,
@@ -1960,19 +1986,10 @@ def _render_cached_hybrid(
     # tokens just before drawing -- fixes the dominant remaining realism tell
     # without re-running synthesis. Mutates the per-render receipt dict in place.
     clean_for_render(receipt)
-    layout_template = merchant_profile.get("layout_template")
-    measured_separators = None
-    if (
-        isinstance(layout_template, dict)
-        and "separators" in layout_template
-        and isinstance(layout_template["separators"], list)
-    ):
-        # ``None`` and ``[]`` are intentionally different. Missing layout data
-        # preserves the legacy phrase heuristics; a measured empty inventory
-        # disables them while literal OCR rule rows remain authoritative.
-        measured_separators = tuple(
-            copy.deepcopy(layout_template["separators"])
-        )
+    measured_separators = _measured_separator_inventory(
+        merchant_profile,
+        compose_kind=compose_kind,
+    )
     config = RenderConfig(
         bitmap_font=bitmap_font,
         width=width,

--- a/synthesis_loop/evidence/costco_v2_separators.after.json
+++ b/synthesis_loop/evidence/costco_v2_separators.after.json
@@ -1,0 +1,48 @@
+{
+  "base_git_sha": "e517d33fdc043abfcbff5f70e87dfd21bccc8952",
+  "bundle_hash": "6b709eb08fa7d09387dba01ebb212810f397b088c8636b7a0442571f8bfd53d7",
+  "controls": {
+    "arithmetic": "PASS",
+    "graphics": "PASS",
+    "logo": "PASS",
+    "style": "PASS_WITH_GAPS",
+    "tokens": "PASS"
+  },
+  "image_id": "0324604e-e1f7-4021-b887-7ef7e012c563",
+  "metric": "separators",
+  "receipt_id": 1,
+  "result": {
+    "kind_mismatches": 0,
+    "matched": [
+      {
+        "dy": 0.0042,
+        "real": {
+          "height_px": 18,
+          "kind": "double",
+          "y_frac": 0.858
+        },
+        "synth": {
+          "height_px": 19,
+          "kind": "dash",
+          "y_frac": 0.8622
+        }
+      }
+    ],
+    "missing_in_synth": [],
+    "phantom_in_synth": [],
+    "real_count": 1,
+    "synth_count": 1,
+    "verdict": "PASS"
+  },
+  "truth_version": 2,
+  "verification": {
+    "corpus_regression_gate": "PASS (0 findings)",
+    "focused_tests": "34 passed",
+    "render_regression_guard": {
+      "costco_golden": "CHANGED (expected)",
+      "costco_new": "CHANGED (expected)",
+      "sprouts": "byte-identical",
+      "vons_golden": "byte-identical"
+    }
+  }
+}

--- a/synthesis_loop/evidence/costco_v2_separators.before.json
+++ b/synthesis_loop/evidence/costco_v2_separators.before.json
@@ -1,0 +1,32 @@
+{
+  "base_git_sha": "e517d33fdc043abfcbff5f70e87dfd21bccc8952",
+  "bundle_hash": "6b709eb08fa7d09387dba01ebb212810f397b088c8636b7a0442571f8bfd53d7",
+  "image_id": "0324604e-e1f7-4021-b887-7ef7e012c563",
+  "integrated_predecessor": {
+    "missing_in_synth": 1,
+    "phantom_in_synth": 7,
+    "real_count": 1,
+    "synth_count": 7,
+    "verdict": "FAIL"
+  },
+  "metric": "separators",
+  "origin_main_result": {
+    "missing_in_synth": 1,
+    "phantom_in_synth": 1,
+    "real": {
+      "height_px": 18,
+      "kind": "double",
+      "y_frac": 0.858
+    },
+    "real_count": 1,
+    "synth": {
+      "height_px": 20,
+      "kind": "dash",
+      "y_frac": 0.9837
+    },
+    "synth_count": 1,
+    "verdict": "FAIL"
+  },
+  "receipt_id": 1,
+  "truth_version": 2
+}

--- a/synthesis_loop/evidence/dollar_tree_separator_blast_radius.after.json
+++ b/synthesis_loop/evidence/dollar_tree_separator_blast_radius.after.json
@@ -1,0 +1,24 @@
+{
+  "git_sha": "b1be770d0d23b7901f18277d232231842b509676",
+  "merchant": "Dollar Tree",
+  "merchant_truth": {
+    "bundle_hash": "d6bd3769a14349e2449e55a607ecc49eba57598c9cb5ace310f1b80ef0261d0b",
+    "mode": "fixture",
+    "note": "No ACTIVE Dollar Tree truth exists in dev; this is a hash-verified dry v1 fixture built from the legacy profile.",
+    "slug": "dollar_tree",
+    "version": 1
+  },
+  "metric": "separators",
+  "receipt": "0944ee8d-4a0d-464e-8109-de35a9ba379a#1",
+  "regression_verdict": "PASS",
+  "result": {
+    "known_baseline_gap": "Three real rules remain missing in the canonical composer output.",
+    "missing_in_synth": 3,
+    "phantom_in_synth": 0,
+    "real_count": 3,
+    "synth_count": 0,
+    "verdict": "FAIL"
+  },
+  "synthetic_sha256": "085236d9ade0668301827a136cfaae617409bce9402142a77a17e90b54f13e85",
+  "unchanged_from_parent": true
+}

--- a/synthesis_loop/evidence/dollar_tree_separator_blast_radius.before.json
+++ b/synthesis_loop/evidence/dollar_tree_separator_blast_radius.before.json
@@ -1,0 +1,26 @@
+{
+  "baseline": {
+    "git_sha": "819d03373a179e76d32175553b294f0b9fb6742b",
+    "missing_in_synth": 3,
+    "phantom_in_synth": 0,
+    "synthetic_sha256": "085236d9ade0668301827a136cfaae617409bce9402142a77a17e90b54f13e85",
+    "verdict": "FAIL"
+  },
+  "captured_regression": {
+    "git_sha": "aca111e0d8b092ca590b58f0b48675306bf5eaa5",
+    "missing_in_synth": 3,
+    "phantom_in_synth": 4,
+    "synthetic_sha256": "d56c8911c7de48a2be9b52874979cf949f70e139ed41469b714f54b6c1765297",
+    "verdict": "FAIL"
+  },
+  "merchant": "Dollar Tree",
+  "merchant_truth": {
+    "bundle_hash": "d6bd3769a14349e2449e55a607ecc49eba57598c9cb5ace310f1b80ef0261d0b",
+    "mode": "fixture",
+    "note": "No ACTIVE Dollar Tree truth exists in dev; this is a hash-verified dry v1 fixture built from the legacy profile.",
+    "slug": "dollar_tree",
+    "version": 1
+  },
+  "metric": "separators",
+  "receipt": "0944ee8d-4a0d-464e-8109-de35a9ba379a#1"
+}

--- a/synthesis_loop/evidence/gelsons_separator_blast_radius.after.json
+++ b/synthesis_loop/evidence/gelsons_separator_blast_radius.after.json
@@ -1,0 +1,29 @@
+{
+  "git_sha": "b1be770d0d23b7901f18277d232231842b509676",
+  "merchant": "Gelson's Westlake Village",
+  "merchant_truth": {
+    "bundle_hash": "9486f47c16ee3cc2e38dbe505b1feef6692cc1633d74d1ceafd7e3a423e48c09",
+    "mode": "online-active",
+    "slug": "gelson_s_westlake_village",
+    "version": 1
+  },
+  "metric": "separators",
+  "receipt": "223c03e2-9f7e-481d-bc33-2b0631fbaaf9#1",
+  "result": {
+    "missing_in_synth": 0,
+    "phantom_in_synth": 0,
+    "real_count": 2,
+    "synth_count": 2,
+    "synth_y_frac": [
+      0.8708,
+      0.9376
+    ],
+    "verdict": "PASS"
+  },
+  "synthetic_sha256": "57c29fb877513e40c1d0fe8518ba4ac6c671a7c5d18f72ebfe80dc76dd208347",
+  "unchanged_metrics": {
+    "arithmetic": "PASS",
+    "logo": "PASS",
+    "tokens": "PASS"
+  }
+}

--- a/synthesis_loop/evidence/gelsons_separator_blast_radius.before.json
+++ b/synthesis_loop/evidence/gelsons_separator_blast_radius.before.json
@@ -1,0 +1,24 @@
+{
+  "git_sha": "819d03373a179e76d32175553b294f0b9fb6742b",
+  "merchant": "Gelson's Westlake Village",
+  "merchant_truth": {
+    "bundle_hash": "9486f47c16ee3cc2e38dbe505b1feef6692cc1633d74d1ceafd7e3a423e48c09",
+    "mode": "online-active",
+    "slug": "gelson_s_westlake_village",
+    "version": 1
+  },
+  "metric": "separators",
+  "receipt": "223c03e2-9f7e-481d-bc33-2b0631fbaaf9#1",
+  "result": {
+    "missing_in_synth": 0,
+    "phantom_in_synth": 0,
+    "real_count": 2,
+    "synth_count": 2,
+    "synth_y_frac": [
+      0.8692,
+      0.9416
+    ],
+    "verdict": "PASS"
+  },
+  "synthetic_sha256": "736ca91488e030c68103818aa4a53c263cb4c361057f3a67b7961851be1e37da"
+}

--- a/synthesis_loop/evidence/the_stand_separator_blast_radius.after.json
+++ b/synthesis_loop/evidence/the_stand_separator_blast_radius.after.json
@@ -1,0 +1,26 @@
+{
+  "git_sha": "b1be770d0d23b7901f18277d232231842b509676",
+  "merchant": "The Stand - American Classics Redefined",
+  "merchant_truth": {
+    "bundle_hash": "c9d40358fc1665323c3639239ff4b19e1c1c02c032f723a260c2cb7c6d9dcd27",
+    "mode": "online-active",
+    "slug": "the_stand___american_classics_redefined",
+    "version": 1
+  },
+  "metric": "separators",
+  "receipt": "016bda87-f2a9-4dfc-85cc-e2b672ccb27a#1",
+  "result": {
+    "missing_in_synth": 0,
+    "phantom_in_synth": 0,
+    "real_count": 0,
+    "synth_count": 0,
+    "verdict": "PASS"
+  },
+  "synthetic_sha256": "25c58932c68f3e341a85b1726db5f136b06dc9deb9752fe654ab9d508742306e",
+  "unchanged_metrics": {
+    "arithmetic": "PASS",
+    "columns": "PASS",
+    "logo": "PASS",
+    "tokens": "PASS"
+  }
+}

--- a/synthesis_loop/evidence/the_stand_separator_blast_radius.before.json
+++ b/synthesis_loop/evidence/the_stand_separator_blast_radius.before.json
@@ -1,0 +1,20 @@
+{
+  "git_sha": "819d03373a179e76d32175553b294f0b9fb6742b",
+  "merchant": "The Stand - American Classics Redefined",
+  "merchant_truth": {
+    "bundle_hash": "c9d40358fc1665323c3639239ff4b19e1c1c02c032f723a260c2cb7c6d9dcd27",
+    "mode": "online-active",
+    "slug": "the_stand___american_classics_redefined",
+    "version": 1
+  },
+  "metric": "separators",
+  "receipt": "016bda87-f2a9-4dfc-85cc-e2b672ccb27a#1",
+  "result": {
+    "missing_in_synth": 0,
+    "phantom_in_synth": 0,
+    "real_count": 0,
+    "synth_count": 0,
+    "verdict": "PASS"
+  },
+  "synthetic_sha256": "25c58932c68f3e341a85b1726db5f136b06dc9deb9752fe654ab9d508742306e"
+}

--- a/tests/test_render_systemic_fixes.py
+++ b/tests/test_render_systemic_fixes.py
@@ -123,6 +123,44 @@ class TestPhraseRunMatch:
         assert not rsr._phrase_run_match(["HOW", "X", "DOERS"], ["HOWDOERS"])
 
 
+class TestMeasuredSeparatorInventory:
+    def test_empty_ocr_inventory_remains_authoritative(self):
+        profile = {"layout_template": {"separators": []}}
+
+        assert (
+            rsr._measured_separator_inventory(profile, compose_kind=None) == ()
+        )
+
+    def test_empty_composed_inventory_preserves_canonical_output(self):
+        profile = {
+            "compose": "dollartree",
+            "layout_template": {"separators": []},
+        }
+
+        assert (
+            rsr._measured_separator_inventory(
+                profile,
+                compose_kind="dollartree",
+            )
+            is None
+        )
+
+    def test_measured_rows_still_apply_to_composed_layout(self):
+        row = {"char": "*", "pos_frac_med": 0.75}
+        profile = {
+            "compose": "canonical",
+            "layout_template": {"separators": [row]},
+        }
+
+        inventory = rsr._measured_separator_inventory(
+            profile,
+            compose_kind="canonical",
+        )
+
+        assert inventory == (row,)
+        assert inventory[0] is not row
+
+
 class TestWordmarkSeedFilter:
     """P1 review finding: an UNLABELED word on the brand line (e.g. its label
     was INVALID-filtered) must not be seeded into the wordmark cluster."""


### PR DESCRIPTION
> Supersedes #1240. GitHub would not reopen the closed PR after its required history rewrite, so this replacement preserves the rebased branch and targets `main` directly.

## Summary
- carry `C#layout.template.separators` through the render configuration
- distinguish missing separator measurements from an authoritative empty/list inventory
- suppress legacy phrase heuristics when measured separator data is present
- preserve literal OCR rule rows at source geometry and draw nonempty measured rules at `pos_frac_med`
- preserve canonical composed layouts when their measured separator inventory is empty

This is the separator-only change rebased directly onto `main`; it is not stacked. The measured-layout blast radius was explicitly evaluated for every profile that carries a layout template: Costco, Gelson's, The Stand, and Dollar Tree.

## Costco fidelity proof
Golden `0324604e-e1f7-4021-b887-7ef7e012c563#1`, truth v2 bundle `6b709e…`:

- separators: **FAIL → PASS**
- real rule `y=.858`; synth `y=.8622`; `dy=.0042`
- missing 0, phantom 0, kind mismatches 0
- controls: tokens, arithmetic, logo, graphics PASS; style PASS_WITH_GAPS

Evidence: `synthesis_loop/evidence/costco_v2_separators.{before,after}.json`.

## Cross-merchant proof
- Gelson's `223c03e2…#1`: two real/two synth rules remain PASS with zero missing or phantom; final y fractions `.8708` and `.9376` track real `.8663` and `.9390`
- The Stand `016bda87…#1`: zero-rule inventory remains PASS and the synthetic PNG is byte-identical to the parent
- Dollar Tree `0944ee8d…#1`: the first pass exposed four phantom rules from composed punctuation. The composer-aware guard removes all four and restores the exact parent PNG SHA. Dollar Tree's pre-existing three missing real rules remain a documented fixture-mode gap; this PR adds no regression.

Evidence:
- `synthesis_loop/evidence/gelsons_separator_blast_radius.{before,after}.json`
- `synthesis_loop/evidence/the_stand_separator_blast_radius.{before,after}.json`
- `synthesis_loop/evidence/dollar_tree_separator_blast_radius.{before,after}.json`

Dollar Tree has no ACTIVE truth in dev, so its proof uses a hash-verified dry v1 fixture built from the legacy profile. No DynamoDB writes occurred.

## Verification
- 37 focused separator/systemic/composer tests passed on Python 3.12
- corpus regression gate: PASS, zero findings
- black, isort, and `git diff --check`: clean
- graphics is SKIPPED where the local Vision helper is unavailable

Ready for independent review. Do not merge until CI and owner review complete.

## Rebase validation
- Python 3.12 receipt-agent suite: 334 passed, 22 skipped
- Python 3.12 repository suite: 568 passed, 1 skipped
- corpus regression gate: `ok: true`, zero findings (eval-logic pin)
- production-render comparison against same-machine `origin/main`: Vons and Sprouts byte-identical; both Costco pins changed as intended by this separator PR
