### PR TITLE
chore: harden CI review gating

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,5 +1,7 @@
 language: en-US
 reviews:
+  auto_review:
+    drafts: true
   path_instructions:
     - path: "**/*.py"
       instructions: |

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+/receipt_agent/receipt_agent/agents/label_evaluator/rendering/  @tnorlund
+/synthesis_loop/corpus_baseline.json                            @tnorlund
+/synthesis_loop/render_regression_baseline.json                 @tnorlund


### PR DESCRIPTION
## Summary

- enable CodeRabbit auto-review for draft pull requests
- add `@tnorlund` ownership for renderer code and both evidence baselines
- keep repository ruleset creation as an explicit owner-only follow-up

## Validation

- parsed `.coderabbit.yaml` with PyYAML and asserted `reviews.auto_review.drafts: true`
- `git diff --check`
- verified this branch contains exactly two commits directly on `main`

## Owner follow-up: create the main branch ruleset

This intentionally was **not** executed. An owner with repository Administration (write) permission can run the command below after reviewing it. It creates one active ruleset targeting only `refs/heads/main`, requires the four named checks and one approval, and blocks force-pushes.

```bash
gh api --method POST repos/tnorlund/Portfolio/rulesets \
  -H "Accept: application/vnd.github+json" \
  -H "X-GitHub-Api-Version: 2026-03-10" \
  --input - <<'JSON'
{
  "name": "Protect main",
  "target": "branch",
  "enforcement": "active",
  "conditions": {
    "ref_name": {
      "include": ["refs/heads/main"],
      "exclude": []
    }
  },
  "rules": [
    {
      "type": "required_status_checks",
      "parameters": {
        "do_not_enforce_on_create": false,
        "required_status_checks": [
          {"context": "Python (receipt_agent)"},
          {"context": "Python (repository tests)"},
          {"context": "Lambda Syntax"},
          {"context": "TypeScript"}
        ],
        "strict_required_status_checks_policy": true
      }
    },
    {
      "type": "pull_request",
      "parameters": {
        "dismiss_stale_reviews_on_push": false,
        "require_code_owner_review": false,
        "require_last_push_approval": false,
        "required_approving_review_count": 1,
        "required_review_thread_resolution": false
      }
    },
    {
      "type": "non_fast_forward"
    }
  ]
}
JSON
```

Schema checked against GitHub's official repository ruleset API documentation: https://docs.github.com/en/rest/repos/rules#create-a-repository-ruleset
