### PR TITLE
[ci] Verify committed evidence against ACTIVE merchant truth

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -199,6 +199,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           clean: true
+          fetch-depth: 0
 
       - name: Setup Python
         run: |
@@ -231,6 +232,17 @@ jobs:
             segno python-barcode numpy
           pip install pytest pytest-asyncio pytest-mock pytest-xdist \
             pytest-timeout pytest-rerunfailures moto responses
+
+      - name: Verify eval regression corpus
+        run: |
+          source .venv-repository-tests/bin/activate
+          python synthesis_loop/corpus_regression_gate.py check --json
+
+      - name: Verify evidence provenance
+        run: |
+          source .venv-repository-tests/bin/activate
+          python scripts/verify_evidence_stamps.py --json \
+            --head "$GITHUB_SHA"
 
       - name: Test root and maintained script suites
         run: |

--- a/evidence/ACTIVE_FLEET.json
+++ b/evidence/ACTIVE_FLEET.json
@@ -1,0 +1,61 @@
+{
+  "active": {
+    "costco_wholesale": {
+      "bundle_hash": "c5cd31202f7a52cee5f5b492c675ae4ed1d94241529bdc3d16d85b18bf7fd064",
+      "version": 1
+    },
+    "cvs": {
+      "bundle_hash": "9a2aee9fc39eabb8469d0fb66d7d63140a2cae80a1e41a43fed6d702670c3faf",
+      "version": 1
+    },
+    "gelson_s_westlake_village": {
+      "bundle_hash": "9486f47c16ee3cc2e38dbe505b1feef6692cc1633d74d1ceafd7e3a423e48c09",
+      "version": 1
+    },
+    "in_n_out_burger": {
+      "bundle_hash": "36a82f4e2ae8cb81b9868a67abe5d983dc7525b2f5c35fe0c481643a301faec3",
+      "version": 1
+    },
+    "italia_deli___bakery": {
+      "bundle_hash": "84726353150b127ed12862239c00863948bb1b9dd5b5104841208fd7c2fba5a5",
+      "version": 1
+    },
+    "neighborly": {
+      "bundle_hash": "1efafa7688feb3df4090df7442cfbf9a898025f39ead6a98ba0c04f8484fce72",
+      "version": 1
+    },
+    "sprouts_farmers_market": {
+      "bundle_hash": "18dc387fbfd985fbc236e413ca051959613fe6e66c263f2a9a23fe67551cb74b",
+      "version": 1
+    },
+    "target": {
+      "bundle_hash": "98db85a38da588db0f566a540f3f0a4454eedcbb8565fbdc6f41f3ac496e4a12",
+      "version": 1
+    },
+    "the_home_depot": {
+      "bundle_hash": "89807363837eb4f6e3ae2d2d08f24c9454b73e0008d0c215003cf80fb1a583fe",
+      "version": 1
+    },
+    "the_stand___american_classics_redefined": {
+      "bundle_hash": "c9d40358fc1665323c3639239ff4b19e1c1c02c032f723a260c2cb7c6d9dcd27",
+      "version": 1
+    },
+    "trader_joe_s": {
+      "bundle_hash": "557c433fcc1e5d74ca66a54f194cf4deca9e39976d26412dc0e1b5ebd778c418",
+      "version": 1
+    },
+    "vons": {
+      "bundle_hash": "63775db497ae88a596847c2ddea69cfa1271eda40b755c1e2fae87b36da506cb",
+      "version": 1
+    },
+    "wild_fork": {
+      "bundle_hash": "a9de285daf995ce20245bdb397f1a0c25a25ec5ab27587f723b0df5e6c7504cc",
+      "version": 1
+    }
+  },
+  "schema_version": 1,
+  "source": {
+    "read_mode": "strong-per-slug",
+    "table": "ReceiptsTable-dc5be22"
+  }
+}

--- a/evidence/wild_fork_separator_logo_filter/RESULT.md
+++ b/evidence/wild_fork_separator_logo_filter/RESULT.md
@@ -34,7 +34,7 @@ measured graphic remains matched and gated.
 | Metric | Before | After |
 |---|---|---|
 | separators | FAIL: real 1, synth 2; phantom y=0.0247 | PASS: no logo strokes in either rule inventory |
-| tokens | PASS: ink recall 0.9717 | PASS: ink recall 0.9717 |
+| tokens | PASS: ink recall 0.9717 | PASS: ink recall 1.0000 |
 | columns | PASS | PASS |
 | graphics | PASS | PASS |
 | logo | PASS | PASS |
@@ -54,3 +54,7 @@ has insufficient coverage; every tested fidelity metric is green.
 
 All live evaluation used read-only dev table `ReceiptsTable-dc5be22`; no gate
 record or other DynamoDB row was written.
+
+The committed after-evidence was re-derived on clean `main` at `9299de46e` so
+its provenance SHA survives the original PR's squash merge and passes the
+standing ancestor check.

--- a/evidence/wild_fork_separator_logo_filter/after.json
+++ b/evidence/wild_fork_separator_logo_filter/after.json
@@ -5,11 +5,17 @@
     "slug": "wild_fork"
   },
   "stamp": {
+    "atlas_hash": "b20b0630057ed0d0",
     "dirty": false,
-    "git_sha": "ca833b8f5f7a783bb36f0ce75d83fd6c79b4cb74",
+    "git_sha": "9299de46eec9361dc8318958afe71c81ffe125ac",
+    "inputs_hash": "3db5094c05b19c80",
+    "merchant": "Wild Fork",
     "merchant_truth": {
       "bundle_hash": "a9de285daf995ce20245bdb397f1a0c25a25ec5ab27587f723b0df5e6c7504cc",
+      "expected_bundle_hash": "a9de285daf995ce20245bdb397f1a0c25a25ec5ab27587f723b0df5e6c7504cc",
+      "expected_version": 1,
       "mode": "online-active",
+      "slug": "wild_fork",
       "version": 1
     }
   },
@@ -26,7 +32,7 @@
       "verdict": "PASS_WITH_GAPS"
     },
     "tokens": {
-      "ink_recall": 0.9717,
+      "ink_recall": 1.0,
       "text_precision": 1.0,
       "text_recall": 1.0,
       "verdict": "PASS"
@@ -44,7 +50,7 @@
       "verdict": "PASS"
     },
     "logo": {
-      "area_ratio": 0.985,
+      "area_ratio": 0.968,
       "center_offset_frac": 0.0099,
       "size_ratio": 1.0,
       "width_ratio": 0.945,

--- a/scripts/verify_evidence_stamps.py
+++ b/scripts/verify_evidence_stamps.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3.12
+"""Verify committed evaluation evidence against the ACTIVE merchant fleet.
+
+The default verification path is hermetic and reads the committed
+``evidence/ACTIVE_FLEET.json`` snapshot. Refreshing that snapshot is an
+explicit, read-only DynamoDB operation:
+
+    python3.12 scripts/verify_evidence_stamps.py --refresh-active-fleet
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_EVIDENCE_ROOT = REPO_ROOT / "evidence"
+DEFAULT_ACTIVE_FLEET = DEFAULT_EVIDENCE_ROOT / "ACTIVE_FLEET.json"
+DEFAULT_TABLE = "ReceiptsTable-dc5be22"
+
+ActiveFleet = dict[str, tuple[int, str]]
+AncestorChecker = Callable[[str, str], bool]
+
+
+def _short_hash(value: str) -> str:
+    return f"{value[:8]}…"
+
+
+def _display_path(path: Path) -> str:
+    try:
+        return str(path.resolve().relative_to(REPO_ROOT))
+    except ValueError:
+        return str(path)
+
+
+def load_active_fleet(path: Path) -> ActiveFleet:
+    """Load and validate the committed ACTIVE-fleet snapshot."""
+    with path.open(encoding="utf-8") as handle:
+        document = json.load(handle)
+    if document.get("schema_version") != 1:
+        raise ValueError(f"{path}: unsupported or missing schema_version")
+    records = document.get("active")
+    if not isinstance(records, dict):
+        raise ValueError(f"{path}: active must be an object")
+
+    active: ActiveFleet = {}
+    for slug, record in records.items():
+        if not isinstance(slug, str) or not isinstance(record, dict):
+            raise ValueError(f"{path}: malformed ACTIVE record")
+        version = record.get("version")
+        bundle_hash = record.get("bundle_hash")
+        if (
+            not isinstance(version, int)
+            or isinstance(version, bool)
+            or not isinstance(bundle_hash, str)
+            or not bundle_hash
+        ):
+            raise ValueError(f"{path}: malformed ACTIVE record for {slug}")
+        active[slug] = (version, bundle_hash)
+    return active
+
+
+def _stamp_slug(document: dict[str, Any], truth: dict[str, Any]) -> str | None:
+    slug = truth.get("slug")
+    if isinstance(slug, str) and slug:
+        return slug
+    receipt = document.get("receipt")
+    if isinstance(receipt, dict):
+        slug = receipt.get("slug")
+        if isinstance(slug, str) and slug:
+            return slug
+    return None
+
+
+def _git_is_ancestor(git_sha: str, head: str) -> bool:
+    result = subprocess.run(
+        ["git", "merge-base", "--is-ancestor", git_sha, head],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    return result.returncode == 0
+
+
+def verify_document(
+    path: Path,
+    document: dict[str, Any],
+    active: ActiveFleet,
+    head: str,
+    *,
+    is_ancestor: AncestorChecker = _git_is_ancestor,
+) -> list[str]:
+    """Return every provenance error for one stamped evidence document."""
+    stamp = document.get("stamp")
+    if not isinstance(stamp, dict):
+        return []
+
+    display = _display_path(path)
+    findings: list[str] = []
+    truth = stamp.get("merchant_truth")
+    if not isinstance(truth, dict):
+        return [f"{display}: stamp.merchant_truth must be an object"]
+
+    mode = truth.get("mode")
+    if mode != "online-active":
+        findings.append(
+            f"{display}: evidence mode is {mode!r}, not 'online-active'; "
+            "fixture and pinned bundles do not describe deployed truth."
+        )
+
+    slug = _stamp_slug(document, truth)
+    version = truth.get("version")
+    bundle_hash = truth.get("bundle_hash")
+    if (
+        slug is None
+        or not isinstance(version, int)
+        or isinstance(version, bool)
+        or not isinstance(bundle_hash, str)
+        or not bundle_hash
+    ):
+        findings.append(
+            f"{display}: stamp must identify merchant truth with slug, "
+            "integer version, and bundle_hash."
+        )
+    elif slug not in active:
+        findings.append(
+            f"{display}: measured {slug} v{version} "
+            f"({_short_hash(bundle_hash)}) but no ACTIVE snapshot entry "
+            "exists for that merchant."
+        )
+    else:
+        active_version, active_hash = active[slug]
+        if (version, bundle_hash) != (active_version, active_hash):
+            findings.append(
+                f"{display} measured {slug} v{version} "
+                f"({_short_hash(bundle_hash)}) but ACTIVE is "
+                f"v{active_version} ({_short_hash(active_hash)}); this "
+                "evidence describes a bundle nobody uses."
+            )
+
+    dirty = stamp.get("dirty")
+    if dirty is True:
+        findings.append(
+            f"{display}: evidence was measured from a dirty worktree."
+        )
+    elif dirty not in (None, False):
+        findings.append(f"{display}: stamp.dirty must be a boolean.")
+
+    git_sha = stamp.get("git_sha")
+    if not isinstance(git_sha, str) or not git_sha:
+        findings.append(f"{display}: stamp.git_sha is missing.")
+    elif not is_ancestor(git_sha, head):
+        findings.append(
+            f"{display}: stamped git_sha {git_sha} is not an ancestor "
+            f"of PR head {head}."
+        )
+    return findings
+
+
+def verify_evidence(
+    evidence_root: Path,
+    active: ActiveFleet,
+    head: str,
+    *,
+    is_ancestor: AncestorChecker = _git_is_ancestor,
+) -> tuple[int, list[str]]:
+    """Verify every JSON document below ``evidence_root`` carrying a stamp."""
+    checked = 0
+    findings: list[str] = []
+    for path in sorted(evidence_root.rglob("*.json")):
+        try:
+            with path.open(encoding="utf-8") as handle:
+                document = json.load(handle)
+        except (OSError, json.JSONDecodeError) as error:
+            findings.append(f"{_display_path(path)}: invalid JSON: {error}")
+            continue
+        if not isinstance(document, dict) or "stamp" not in document:
+            continue
+        checked += 1
+        findings.extend(
+            verify_document(
+                path,
+                document,
+                active,
+                head,
+                is_ancestor=is_ancestor,
+            )
+        )
+    return checked, findings
+
+
+def _snapshot_document(reader: Any, table: str) -> dict[str, Any]:
+    """Strong-read ACTIVE tuples discovered through the fleet index."""
+    records: dict[str, dict[str, Any]] = {}
+    for candidate in reader.list_active_merchant_truth():
+        active = reader.get_active_merchant_truth(
+            candidate.slug,
+            consistent_read=True,
+        )
+        if active is None:
+            raise RuntimeError(
+                f"ACTIVE pointer disappeared during refresh: {candidate.slug}"
+            )
+        records[active.slug] = {
+            "bundle_hash": active.bundle_hash,
+            "version": active.version,
+        }
+    return {
+        "active": records,
+        "schema_version": 1,
+        "source": {
+            "read_mode": "strong-per-slug",
+            "table": table,
+        },
+    }
+
+
+def refresh_active_fleet(path: Path, table: str) -> None:
+    """Refresh the local snapshot using DynamoDB reads only."""
+    from receipt_dynamo.data.dynamo_client import DynamoClient
+
+    document = _snapshot_document(DynamoClient(table), table)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(document, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--evidence-root",
+        type=Path,
+        default=DEFAULT_EVIDENCE_ROOT,
+    )
+    parser.add_argument(
+        "--active-fleet",
+        type=Path,
+        default=DEFAULT_ACTIVE_FLEET,
+    )
+    parser.add_argument(
+        "--head",
+        default=os.environ.get("GITHUB_SHA", "HEAD"),
+    )
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument(
+        "--refresh-active-fleet",
+        action="store_true",
+        help="read ACTIVE pointers from DynamoDB and rewrite the snapshot",
+    )
+    parser.add_argument(
+        "--table",
+        default=os.environ.get("DYNAMODB_TABLE_NAME", DEFAULT_TABLE),
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    if args.refresh_active_fleet:
+        refresh_active_fleet(args.active_fleet, args.table)
+        print(f"refreshed {args.active_fleet} from {args.table} (read-only)")
+        return 0
+
+    try:
+        active = load_active_fleet(args.active_fleet)
+        checked, findings = verify_evidence(
+            args.evidence_root,
+            active,
+            args.head,
+        )
+    except (OSError, ValueError) as error:
+        findings = [str(error)]
+        checked = 0
+
+    result = {
+        "checked": checked,
+        "findings": findings,
+        "ok": not findings,
+    }
+    if args.json:
+        print(json.dumps(result, indent=2, sort_keys=True))
+    elif findings:
+        print("\n".join(findings), file=sys.stderr)
+    else:
+        print(f"verified {checked} stamped evidence files")
+    return 1 if findings else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/evidence/costco_v2_fixture_stamp.json
+++ b/tests/fixtures/evidence/costco_v2_fixture_stamp.json
@@ -1,0 +1,17 @@
+{
+  "receipt": {
+    "image_id": "85a28b87-0a52-4fac-83a0-3a3f11d6f6c1",
+    "receipt_id": 1,
+    "slug": "costco_wholesale"
+  },
+  "stamp": {
+    "dirty": false,
+    "git_sha": "0123456789abcdef0123456789abcdef01234567",
+    "merchant_truth": {
+      "bundle_hash": "6b709eb08fa7d09387dba01ebb212810f397b088c8636b7a0442571f8bfd53d7",
+      "mode": "fixture",
+      "slug": "costco_wholesale",
+      "version": 2
+    }
+  }
+}

--- a/tests/test_verify_evidence_stamps.py
+++ b/tests/test_verify_evidence_stamps.py
@@ -1,0 +1,147 @@
+"""Tests for committed evidence provenance verification."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts import verify_evidence_stamps as verifier
+
+FIXTURES = Path(__file__).parent / "fixtures" / "evidence"
+COSTCO_V1_HASH = (
+    "c5cd31202f7a52cee5f5b492c675ae4ed1d94241529bdc3d16d85b18bf7fd064"
+)
+
+
+def _costco_active() -> verifier.ActiveFleet:
+    return {"costco_wholesale": (1, COSTCO_V1_HASH)}
+
+
+def test_costco_v2_fixture_is_rejected_with_both_bundles_named():
+    path = FIXTURES / "costco_v2_fixture_stamp.json"
+    document = json.loads(path.read_text(encoding="utf-8"))
+
+    findings = verifier.verify_document(
+        path,
+        document,
+        _costco_active(),
+        "HEAD",
+        is_ancestor=lambda _sha, _head: True,
+    )
+
+    assert any("mode is 'fixture'" in finding for finding in findings)
+    mismatch = next(
+        finding
+        for finding in findings
+        if "evidence describes a bundle nobody uses" in finding
+    )
+    assert "costco_wholesale v2 (6b709eb0…)" in mismatch
+    assert "ACTIVE is v1 (c5cd3120…)" in mismatch
+
+
+def test_clean_online_active_stamp_passes(tmp_path):
+    path = tmp_path / "after.json"
+    document = {
+        "stamp": {
+            "dirty": False,
+            "git_sha": "abc123",
+            "merchant_truth": {
+                "bundle_hash": COSTCO_V1_HASH,
+                "mode": "online-active",
+                "slug": "costco_wholesale",
+                "version": 1,
+            },
+        }
+    }
+
+    assert (
+        verifier.verify_document(
+            path,
+            document,
+            _costco_active(),
+            "pr-head",
+            is_ancestor=lambda sha, head: (sha, head) == ("abc123", "pr-head"),
+        )
+        == []
+    )
+
+
+def test_dirty_and_non_ancestor_stamp_fail(tmp_path):
+    path = tmp_path / "after.json"
+    document = {
+        "stamp": {
+            "dirty": True,
+            "git_sha": "branch-only",
+            "merchant_truth": {
+                "bundle_hash": COSTCO_V1_HASH,
+                "mode": "online-active",
+                "slug": "costco_wholesale",
+                "version": 1,
+            },
+        }
+    }
+
+    findings = verifier.verify_document(
+        path,
+        document,
+        _costco_active(),
+        "pr-head",
+        is_ancestor=lambda _sha, _head: False,
+    )
+
+    assert any("dirty worktree" in finding for finding in findings)
+    assert any("not an ancestor" in finding for finding in findings)
+
+
+def test_legacy_receipt_slug_is_accepted(tmp_path):
+    path = tmp_path / "before.json"
+    document = {
+        "receipt": {"slug": "costco_wholesale"},
+        "stamp": {
+            "git_sha": "abc123",
+            "merchant_truth": {
+                "bundle_hash": COSTCO_V1_HASH,
+                "mode": "online-active",
+                "version": 1,
+            },
+        },
+    }
+
+    assert (
+        verifier.verify_document(
+            path,
+            document,
+            _costco_active(),
+            "HEAD",
+            is_ancestor=lambda _sha, _head: True,
+        )
+        == []
+    )
+
+
+def test_snapshot_refresh_uses_strong_reads():
+    class Active:
+        def __init__(self, slug, version, bundle_hash):
+            self.slug = slug
+            self.version = version
+            self.bundle_hash = bundle_hash
+
+    class Reader:
+        def __init__(self):
+            self.strong_reads = []
+
+        def list_active_merchant_truth(self):
+            return [Active("costco_wholesale", 1, "eventual")]
+
+        def get_active_merchant_truth(self, slug, *, consistent_read=False):
+            self.strong_reads.append((slug, consistent_read))
+            return Active(slug, 1, COSTCO_V1_HASH)
+
+    reader = Reader()
+    document = verifier._snapshot_document(reader, "ReceiptsTable-dev")
+
+    assert reader.strong_reads == [("costco_wholesale", True)]
+    assert document["active"]["costco_wholesale"] == {
+        "bundle_hash": COSTCO_V1_HASH,
+        "version": 1,
+    }


### PR DESCRIPTION
Implements R1 from `docs/plans/RENDER_SYNTHESIS_HARDENING_2026-07-24.md`.

Adds `scripts/verify_evidence_stamps.py` + a CI job that rejects evidence whose `build_stamp` was measured against a bundle that is not the ACTIVE one.

Catches the exact failure that made this sprint's Costco evidence misleading: `costco_v2_*.json` were measured against truth **v2** (`6b709eb0…`, `mode: fixture`, fabricated SEALED payload) while ACTIVE is v1 (`c5cd3120…`). Negative fixture `tests/fixtures/evidence/costco_v2_fixture_stamp.json` reproduces it; 5 tests pass.

Also re-derives `evidence/wild_fork_separator_logo_filter/after.json` on clean main so it carries the previously-missing `inputs_hash`/`atlas_hash` and passes the new ancestor check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation for evidence provenance, active merchant data, and commit ancestry.
  * Added support for refreshing the active merchant snapshot using strongly consistent data reads.
  * Added a committed active-fleet snapshot for evidence verification.

* **Bug Fixes**
  * Corrected evidence metrics and refreshed associated provenance metadata.

* **Tests**
  * Added coverage for valid, outdated, modified, and legacy evidence stamps.
  * Automated regression and provenance checks in the repository test workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->