### PR TITLE
[receipt_renderer] Extract separator planning into its own module

### DIFF
--- a/receipt_agent/receipt_agent/agents/label_evaluator/rendering/receipt_renderer.py
+++ b/receipt_agent/receipt_agent/agents/label_evaluator/rendering/receipt_renderer.py
@@ -23,7 +23,6 @@ from __future__ import annotations
 
 import math
 import os
-import re
 from dataclasses import dataclass, replace
 from statistics import median
 from typing import Any, Mapping, Sequence
@@ -32,10 +31,6 @@ from PIL import Image, ImageDraw, ImageFont
 
 from receipt_agent.agents.label_evaluator.rendering.font_profile import (
     MerchantFontProfile,
-)
-from receipt_agent.agents.label_evaluator.rendering.number_format import (
-    US,
-    date_core,
 )
 from receipt_agent.agents.label_evaluator.rendering.receipt_grid import (
     GridSpec,
@@ -57,6 +52,11 @@ from receipt_agent.agents.label_evaluator.rendering.receipt_stylemap import (
     measured_row_style,
     requires_bold_reinforcement,
     row_style,
+)
+from receipt_agent.agents.label_evaluator.rendering.separators import (
+    SEPARATOR_SOURCES,
+    _is_final_total,
+    _separator_layout,
 )
 
 # Grid-path body face, most receipt-like first. Real thermal receipts use a
@@ -361,128 +361,6 @@ def render_receipt(
         )
 
     return image
-
-
-def _is_final_total(
-    row_text: str,
-    include: tuple[str, ...] = ("TOTAL",),
-    exclude: tuple[str, ...] = ("SUBTOTAL", "NUMBER", "SOLD", "TAX"),
-) -> bool:
-    """True for the grand-TOTAL row (Costco reverse-videos its amount), but not
-    SUBTOTAL nor the "TOTAL NUMBER OF ITEMS SOLD" line. The include/exclude token
-    sets come from the merchant profile (defaults match Costco's wording)."""
-    t = row_text.upper()
-    if not all(tok in t for tok in include):
-        return False
-    return not any(tok in t for tok in exclude)
-
-
-_DATE_LED = re.compile(f"^{date_core(US)}$")
-
-
-def _separator_anchor_rows(
-    rows: Sequence[Sequence[GridWord]],
-    row_texts: Sequence[str],
-    config: RenderConfig,
-) -> set[int]:
-    """Rows after which a profile-requested dashed separator is printed.
-
-    A grand-total rule needs both the configured total wording and a currency
-    amount. The amount requirement prevents item-count rows such as
-    ``TOTAL ... ITEMS SOLD = 4`` from becoming separators when OCR fragments
-    the configured exclusion word. ``total_exclude_tokens`` additionally
-    rejects summary lookalikes such as ``TOTAL TAX``.
-    """
-    anchors: set[int] = set()
-    if not (config.dashed_separators or config.dash_around_phrases):
-        return anchors
-    for k, (line, text) in enumerate(zip(rows, row_texts)):
-        previous = row_texts[k - 1] if k > 0 else ""
-        first = text.split()[0] if text.split() else ""
-        is_total_row = (
-            config.dashed_separators
-            and any(is_price_token(word.text) for word in line)
-            and _is_final_total(
-                text,
-                config.total_include_tokens,
-                config.total_exclude_tokens,
-            )
-        )
-        is_amount_date = (
-            config.dashed_separators
-            and config.dash_after_amount_date
-            and "AMOUNT" in previous
-            and bool(_DATE_LED.match(first))
-        )
-        if is_total_row or is_amount_date:
-            anchors.add(k)
-        for phrase in config.dash_around_phrases or ():
-            if text.startswith(phrase.upper()) and any(
-                is_price_token(word.text) for word in line
-            ):
-                anchors.add(k)
-                if k > 0:
-                    anchors.add(k - 1)
-    return anchors
-
-
-def _separator_layout(
-    baselines: Sequence[float],
-    dash_after_rows: set[int],
-    *,
-    pitch: float,
-    cap_h: float,
-) -> tuple[list[float], list[float]]:
-    """Place separator baselines in existing whitespace when possible.
-
-    The old implementation inserted a full body row for every separator and
-    shifted the entire remaining receipt. Multi-tender receipts therefore
-    accumulated hundreds of pixels of drift even though their source layout
-    already reserved generous gaps around tender summaries.
-
-    A thin dash row only needs the whitespace between the current row's
-    descender and the next row's cap. Existing gaps are left untouched. For a
-    genuinely cramped pair, add only the missing clearance rather than a full
-    pitch. This keeps later rows stable while still preventing overprint.
-    """
-    adjusted = [float(value) for value in baselines]
-    dash_ys: list[float] = []
-    if not adjusted or not dash_after_rows:
-        return adjusted, dash_ys
-
-    pitch = max(1.0, float(pitch))
-    cap_h = max(1.0, float(cap_h))
-    # Current descenders consume about .22 cap and the next row consumes one
-    # cap above its baseline. The remaining .18 cap gives the dash ink and a
-    # small paper gap on each side.
-    required_gap = max(pitch, cap_h * 1.40)
-    for k in sorted(dash_after_rows):
-        if k < 0 or k >= len(adjusted):
-            continue
-        current = adjusted[k]
-        if k + 1 >= len(adjusted):
-            dash_ys.append(current + cap_h * 0.90)
-            continue
-
-        gap = adjusted[k + 1] - current
-        extra = max(0.0, required_gap - gap)
-        if extra:
-            for j in range(k + 1, len(adjusted)):
-                adjusted[j] += extra
-            gap += extra
-
-        whitespace_start = current + cap_h * 0.22
-        whitespace_end = adjusted[k + 1] - cap_h
-        if whitespace_end > whitespace_start:
-            ink_target = (whitespace_start + whitespace_end) / 2.0
-        else:
-            ink_target = current + gap / 2.0
-        # ``draw_token_chars`` receives a text baseline. A hyphen's ink sits
-        # around half a cap above that baseline (both the bitmap atlas and the
-        # TTF fallback do this), so lower the draw baseline to put the visible
-        # dash—not its invisible text baseline—in the whitespace target.
-        dash_ys.append(ink_target + cap_h * 0.55)
-    return adjusted, dash_ys
 
 
 def _draw_dash_row(
@@ -882,7 +760,9 @@ def _render_grid(
     # TOTAL, and the AMOUNT-block transaction-date line (the date row whose prior
     # row is the "AMOUNT:" line).
     row_texts = [" ".join(w.text for w in ln).upper() for ln in rows]
-    dash_after_rows = _separator_anchor_rows(rows, row_texts, config)
+    dash_after_rows: set[int] = set()
+    for separator_source in SEPARATOR_SOURCES:
+        dash_after_rows.update(separator_source(rows, row_texts, config))
     baselines, dash_ys = _separator_layout(
         baselines,
         dash_after_rows,

--- a/receipt_agent/receipt_agent/agents/label_evaluator/rendering/separators.py
+++ b/receipt_agent/receipt_agent/agents/label_evaluator/rendering/separators.py
@@ -1,0 +1,156 @@
+"""Separator anchor sources and vertical layout for receipt rendering."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable, Sequence
+from typing import Protocol
+
+from receipt_agent.agents.label_evaluator.rendering.number_format import (
+    US,
+    date_core,
+)
+from receipt_agent.agents.label_evaluator.rendering.receipt_grid import (
+    GridWord,
+    is_price_token,
+)
+
+
+class SeparatorConfig(Protocol):
+    """The RenderConfig fields consumed by separator sources."""
+
+    dashed_separators: bool
+    dash_around_phrases: tuple
+    dash_after_amount_date: bool
+    total_include_tokens: tuple[str, ...]
+    total_exclude_tokens: tuple[str, ...]
+
+
+SeparatorSource = Callable[
+    [
+        Sequence[Sequence[GridWord]],
+        Sequence[str],
+        SeparatorConfig,
+    ],
+    set[int],
+]
+
+
+def _is_final_total(
+    row_text: str,
+    include: tuple[str, ...] = ("TOTAL",),
+    exclude: tuple[str, ...] = ("SUBTOTAL", "NUMBER", "SOLD", "TAX"),
+) -> bool:
+    """True for a grand-total row, excluding summary lookalikes."""
+    text = row_text.upper()
+    if not all(token in text for token in include):
+        return False
+    return not any(token in text for token in exclude)
+
+
+_DATE_LED = re.compile(f"^{date_core(US)}$")
+
+
+def _separator_anchor_rows(
+    rows: Sequence[Sequence[GridWord]],
+    row_texts: Sequence[str],
+    config: SeparatorConfig,
+) -> set[int]:
+    """Rows after which a profile-requested dashed separator is printed.
+
+    A grand-total rule needs both the configured total wording and a currency
+    amount. The amount requirement prevents item-count rows such as
+    ``TOTAL ... ITEMS SOLD = 4`` from becoming separators when OCR fragments
+    the configured exclusion word. ``total_exclude_tokens`` additionally
+    rejects summary lookalikes such as ``TOTAL TAX``.
+    """
+    anchors: set[int] = set()
+    if not (config.dashed_separators or config.dash_around_phrases):
+        return anchors
+    for index, (line, text) in enumerate(zip(rows, row_texts)):
+        previous = row_texts[index - 1] if index > 0 else ""
+        first = text.split()[0] if text.split() else ""
+        is_total_row = (
+            config.dashed_separators
+            and any(is_price_token(word.text) for word in line)
+            and _is_final_total(
+                text,
+                config.total_include_tokens,
+                config.total_exclude_tokens,
+            )
+        )
+        is_amount_date = (
+            config.dashed_separators
+            and config.dash_after_amount_date
+            and "AMOUNT" in previous
+            and bool(_DATE_LED.match(first))
+        )
+        if is_total_row or is_amount_date:
+            anchors.add(index)
+        for phrase in config.dash_around_phrases or ():
+            if text.startswith(phrase.upper()) and any(
+                is_price_token(word.text) for word in line
+            ):
+                anchors.add(index)
+                if index > 0:
+                    anchors.add(index - 1)
+    return anchors
+
+
+# _render_grid iterates this collection. A new independent separator detector
+# can land as a new function/module plus one list entry instead of editing the
+# shared renderer control flow.
+SEPARATOR_SOURCES: tuple[SeparatorSource, ...] = (_separator_anchor_rows,)
+
+
+def _separator_layout(
+    baselines: Sequence[float],
+    dash_after_rows: set[int],
+    *,
+    pitch: float,
+    cap_h: float,
+) -> tuple[list[float], list[float]]:
+    """Place separator baselines in existing whitespace when possible.
+
+    A thin dash row only needs the whitespace between the current row's
+    descender and the next row's cap. Existing gaps are left untouched. For a
+    genuinely cramped pair, add only the missing clearance rather than a full
+    pitch. This keeps later rows stable while still preventing overprint.
+    """
+    adjusted = [float(value) for value in baselines]
+    dash_ys: list[float] = []
+    if not adjusted or not dash_after_rows:
+        return adjusted, dash_ys
+
+    pitch = max(1.0, float(pitch))
+    cap_h = max(1.0, float(cap_h))
+    # Current descenders consume about .22 cap and the next row consumes one
+    # cap above its baseline. The remaining .18 cap gives the dash ink and a
+    # small paper gap on each side.
+    required_gap = max(pitch, cap_h * 1.40)
+    for index in sorted(dash_after_rows):
+        if index < 0 or index >= len(adjusted):
+            continue
+        current = adjusted[index]
+        if index + 1 >= len(adjusted):
+            dash_ys.append(current + cap_h * 0.90)
+            continue
+
+        gap = adjusted[index + 1] - current
+        extra = max(0.0, required_gap - gap)
+        if extra:
+            for following in range(index + 1, len(adjusted)):
+                adjusted[following] += extra
+            gap += extra
+
+        whitespace_start = current + cap_h * 0.22
+        whitespace_end = adjusted[index + 1] - cap_h
+        if whitespace_end > whitespace_start:
+            ink_target = (whitespace_start + whitespace_end) / 2.0
+        else:
+            ink_target = current + gap / 2.0
+        # ``draw_token_chars`` receives a text baseline. A hyphen's ink sits
+        # around half a cap above that baseline, so lower the draw baseline to
+        # put the visible dash—not its invisible text baseline—in whitespace.
+        dash_ys.append(ink_target + cap_h * 0.55)
+    return adjusted, dash_ys

--- a/receipt_agent/tests/test_section_style.py
+++ b/receipt_agent/tests/test_section_style.py
@@ -167,6 +167,8 @@ def test_separator_anchors_reject_summary_and_item_count_lookalikes():
     )
     from receipt_agent.agents.label_evaluator.rendering.receipt_renderer import (
         RenderConfig,
+    )
+    from receipt_agent.agents.label_evaluator.rendering.separators import (
         _separator_anchor_rows,
     )
 
@@ -202,7 +204,7 @@ def test_separator_anchors_reject_summary_and_item_count_lookalikes():
 
 
 def test_separator_layout_uses_existing_gap_and_only_adds_missing_clearance():
-    from receipt_agent.agents.label_evaluator.rendering.receipt_renderer import (
+    from receipt_agent.agents.label_evaluator.rendering.separators import (
         _separator_layout,
     )
 
@@ -225,3 +227,37 @@ def test_separator_layout_uses_existing_gap_and_only_adds_missing_clearance():
     # Required clearance is 50.4px, so add 20.4px—not a full 40px row.
     assert cramped[1] == pytest.approx(150.4)
     assert cramped[2] == pytest.approx(200.4)
+
+
+def test_render_grid_iterates_separator_sources(monkeypatch):
+    from receipt_agent.agents.label_evaluator.rendering import receipt_renderer
+    from receipt_agent.agents.label_evaluator.rendering.receipt_renderer import (
+        RenderConfig,
+        render_receipt,
+    )
+
+    calls = []
+
+    def source(rows, row_texts, config):
+        calls.append((rows, row_texts, config))
+        return set()
+
+    monkeypatch.setattr(receipt_renderer, "SEPARATOR_SOURCES", (source,))
+    render_receipt(
+        {
+            "words": [
+                {
+                    "text": "BODY",
+                    "line_id": 1,
+                    "word_id": 1,
+                    "bbox": [100, 800, 300, 760],
+                    "labels": [],
+                }
+            ]
+        },
+        config=RenderConfig(width=240, height=360, grid_mode=True),
+        coord_max=1000,
+    )
+
+    assert len(calls) == 1
+    assert calls[0][1] == ["BODY"]


### PR DESCRIPTION
Implements Phase 3.2 from the hardening plan. Pure motion, no behavior change.

Moves `_separator_anchor_rows` / `_separator_layout` out of `receipt_renderer.py` into `rendering/separators.py` (-136 / +156). Separator sources become a list, so a future separator fix is a **new file plus one list entry** instead of an insertion at the shared anchor after `_draw_dash_row` — the anchor where #1243, #1248 and #1255 all collided.

This is the shared base whose absence made both Costco branches independently ship byte-identical re-extractions of these same two functions.