### PR TITLE
[ci] Never cancel a main-push run mid-deploy

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,9 +7,13 @@ on:
     branches: [main]
   workflow_dispatch:
 
+# Superseded PR runs are cancelled (a new push makes the old one moot), but
+# main-push runs are NEVER cancelled: their `deploy` job runs `pulumi up`, and
+# killing that mid-update can leave the stack locked or partially applied. A
+# burst of merges must queue, not interrupt each other.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   PYTHONPATH: ${{ github.workspace }}
@@ -331,6 +335,12 @@ jobs:
 
   deploy:
     name: Deploy
+    # One production deploy at a time, across runs. Never cancel a running
+    # one - Pulumi holds an account-wide lock and an interrupted update is
+    # how that lock gets stranded.
+    concurrency:
+      group: deploy-production
+      cancel-in-progress: false
     needs:
       - lambda-syntax
       - python-tests


### PR DESCRIPTION
`cancel-in-progress: true` applied to every event, so each merge to main killed the previous run — including its `Deploy infrastructure` step, which is a live `pulumi up`.

Merging 6 PRs in ~30 minutes today did exactly that: run `30116926481` sat **48 minutes** in `Deploy infrastructure` waiting on a lock left by a cancelled predecessor, then failed. Prod's last successful deploy before that was 2026-07-23. Interrupting Pulumi mid-update can strand its account-wide lock or leave the stack partially applied — see the known dev-blocks-prod 409 behaviour.

- `cancel-in-progress` now only applies to `pull_request` runs, where a superseded run is genuinely moot.
- The `deploy` job gets its own `deploy-production` concurrency group with `cancel-in-progress: false`, so a burst of merges **queues** its deploys instead of interrupting them.

Test jobs still cancel on PR pushes, which is what that setting is actually for.