### PR TITLE
fix(ci): restore evidence provenance on main after #1248 squash

### DIFF
--- a/evidence/grocery_structural_gap_separators/RESULT.md
+++ b/evidence/grocery_structural_gap_separators/RESULT.md
@@ -11,11 +11,16 @@ It does not add line pitch or shift any OCR row.
 | Vons `678a7c94-4948-4ebf-b8e9-9a17c13051ec#2` | FAIL: real 3, synth 0 | PASS: 3/3 matched; y deltas 0.0015, 0.0044, 0.0000 |
 | Trader Joe's `4c262079-4fec-4724-a8e1-2886f38ea454#1` | FAIL: real 1, synth 0 | PASS: 1/1 matched; y delta 0.0010 |
 
-Both sides of this pair were re-derived on 2026-07-27 after the rebase.
-`before/` is measured at `1d0dd32f5` (main without this branch); `after/` is
-measured at `63cc32906`, this branch's renderer commit. The two runs share a
-worktree, atlas (`atlas_hash`), and inputs (`inputs_hash`), so the renderer
-change is the only variable.
+Both sides of this pair were measured on 2026-07-27. `before/` is measured at
+`1d0dd32f5` (main without this change); `after/` is measured at `8324e542c`,
+the squash commit that landed this work on main. The two runs share a worktree,
+atlas (`atlas_hash`), and inputs (`inputs_hash`), so the renderer change is the
+only variable.
+
+The `after/` side was re-measured once more after the squash merge: the original
+stamp pointed at the pre-squash branch commit `63cc32906`, which the squash
+orphaned, and `verify_evidence_stamps.py` requires the stamped SHA to be an
+ancestor of HEAD. Re-running against `8324e542c` reproduced identical metrics.
 
 Every check section is byte-identical before and after except `separators`:
 `columns`, `style`, `tokens`, `graphics`, `logo`, `arithmetic`, and

--- a/evidence/grocery_structural_gap_separators/after/trader_joe_s.checks.json
+++ b/evidence/grocery_structural_gap_separators/after/trader_joe_s.checks.json
@@ -198,7 +198,7 @@
  "stamp": {
   "atlas_hash": "037dc0610504a9b9",
   "dirty": false,
-  "git_sha": "63cc32906b9c861b144e825dee074accaad3b4a4",
+  "git_sha": "8324e542c9e54fb0952c7b9002ffaa4dfd61f853",
   "inputs_hash": "0587f5d3daefdda2",
   "merchant": "Trader Joe's",
   "merchant_truth": {

--- a/evidence/grocery_structural_gap_separators/after/trader_joe_s.report.md
+++ b/evidence/grocery_structural_gap_separators/after/trader_joe_s.report.md
@@ -2,7 +2,7 @@
 
 - merchant: Trader Joe's
 - receipt: 4c262079-4fec-4724-a8e1-2886f38ea454#1
-- git: `63cc32906b9c`
+- git: `8324e542c9e5`
 - truth: `trader_joe_s` v1 `557c433fcc1e5d74ca66a54f194cf4deca9e39976d26412dc0e1b5ebd778c418` (online-active)
 - atlas: `037dc0610504a9b9`
 

--- a/evidence/grocery_structural_gap_separators/after/vons.checks.json
+++ b/evidence/grocery_structural_gap_separators/after/vons.checks.json
@@ -371,7 +371,7 @@
  "stamp": {
   "atlas_hash": "6ca4cb5cda99dd4c",
   "dirty": false,
-  "git_sha": "63cc32906b9c861b144e825dee074accaad3b4a4",
+  "git_sha": "8324e542c9e54fb0952c7b9002ffaa4dfd61f853",
   "inputs_hash": "8295c5c2af35b3b2",
   "merchant": "Vons",
   "merchant_truth": {

--- a/evidence/grocery_structural_gap_separators/after/vons.report.md
+++ b/evidence/grocery_structural_gap_separators/after/vons.report.md
@@ -2,7 +2,7 @@
 
 - merchant: Vons
 - receipt: 678a7c94-4948-4ebf-b8e9-9a17c13051ec#2
-- git: `63cc32906b9c`
+- git: `8324e542c9e5`
 - truth: `vons` v1 `63775db497ae88a596847c2ddea69cfa1271eda40b755c1e2fae87b36da506cb` (online-active)
 - atlas: `6ca4cb5cda99dd4c`
 


### PR DESCRIPTION
## main is currently red

Run [30302866543](https://github.com/tnorlund/Portfolio/actions/runs/30302866543) — the `Python (repository tests)` job fails at the **Verify evidence provenance** step. Every PR branched from main inherits the failure.

## Cause

The `after/` evidence for the grocery separator lane was stamped `git_sha 63cc32906`, which was #1248's branch commit. Squash-merging #1248 replaced that commit with `8324e542c` and orphaned the original, so `verify_evidence_stamps.py` (#1257) correctly reports:

```
evidence/grocery_structural_gap_separators/after/trader_joe_s.checks.json:
  stamped git_sha 63cc32906… is not an ancestor of PR head HEAD.
evidence/grocery_structural_gap_separators/after/vons.checks.json:
  stamped git_sha 63cc32906… is not an ancestor of PR head HEAD.
```

The check is right and the evidence was right — the squash simply broke the link between them.

## Fix

Re-ran the full-fidelity eval for both receipts against main `@8324e542c` and committed the result. Same worktree, so `atlas_hash` and `inputs_hash` still match the `before/` side and the pair stays controlled.

**The metrics are unchanged**, which is the point — this re-stamps provenance, it does not move any number:

| Receipt | Before (`1d0dd32f5`) | After (`8324e542c`) |
|---|---|---|
| Vons `678a7c94…#2` | FAIL: real 3, synth 0 | PASS: 3/3, dy 0.0015 / 0.0044 / 0.0000 |
| Trader Joe's `4c262079…#1` | FAIL: real 1, synth 0 | PASS: 1/1, dy 0.0010 |

`separators` remains the only check section that differs between the two sides (plus Trader Joe's `overall`, which improves as a consequence). `verify_evidence_stamps.py` now reports **verified 6 stamped evidence files**.

## Worth knowing for future evidence PRs

This is structural, not a one-off. Evidence that measures a PR's *own* change cannot carry an ancestor-of-main SHA until after that PR merges — and squash-merge orphans the branch commit it was stamped with. So any PR that commits `after/` evidence will red-line main on squash.

Two ways out: merge those PRs with `--merge` instead of `--squash`, or re-stamp the evidence on main afterward as this PR does. Might be worth a note in the evidence runbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)