### PR TITLE
fix: compaction lock heartbeat, reachable DLQ, and delta-failure propagation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,6 +53,14 @@ jobs:
           python -m pip install --quiet boto3 pytest
           python -m pytest -q infra/tests/test_email_receipt_inbox_handler.py
 
+      - name: Test compaction lock configuration
+        run: |
+          # Stubs its Lambda-only imports, so the venv above (pytest only) is
+          # enough. Guards the lock heartbeat wiring and delta-failure
+          # propagation that caused the 07-12 compaction outage.
+          source .venv-email-receipt/bin/activate
+          python -m pytest -q infra/tests/test_compaction_lock_config.py
+
   python-tests:
     name: Python (${{ matrix.package }})
     runs-on: [self-hosted, macOS, ARM64]

--- a/infra/__main__.py
+++ b/infra/__main__.py
@@ -50,12 +50,12 @@ from fix_place_lambda import create_fix_place_lambda
 from label_evaluator_step_functions import LabelEvaluatorStepFunction
 from label_refresh_lambda import create_label_refresh_lambda
 from merge_receipt_lambda import create_merge_receipt_lambda
-from resegment_receipt_lambda import create_resegment_receipt_lambda
 
 # Using the optimized docker-build based base images with scoped contexts
 from networking import PublicVpc
 from notifications import NotificationSystem
 from raw_bucket import raw_bucket  # Import the actual bucket instance
+from resegment_receipt_lambda import create_resegment_receipt_lambda
 from s3_website import site_bucket  # Import the site bucket instance
 from security import ChromaSecurity
 from trigger_reocr_lambda import create_trigger_reocr_lambda
@@ -1270,7 +1270,9 @@ resegment_receipt_lambda = create_resegment_receipt_lambda(
     chromadb_bucket_name=embedding_infrastructure.chromadb_buckets.bucket_name,
     chromadb_bucket_arn=embedding_infrastructure.chromadb_buckets.bucket_arn,
 )
-pulumi.export("resegment_receipt_lambda_arn", resegment_receipt_lambda.lambda_arn)
+pulumi.export(
+    "resegment_receipt_lambda_arn", resegment_receipt_lambda.lambda_arn
+)
 pulumi.export(
     "resegment_receipt_lambda_name",
     resegment_receipt_lambda.lambda_function.name,

--- a/infra/__main__.py
+++ b/infra/__main__.py
@@ -208,6 +208,7 @@ chromadb_infrastructure = create_chromadb_compaction_infrastructure(
     chromadb_buckets=shared_chromadb_buckets,
     subnet_ids=compaction_lambda_subnets,  # Private subnets only for Lambda
     lambda_security_group_id=security.sg_lambda_id,
+    alert_topic_arn=notification_system.critical_error_topic_arn,
 )
 
 # Create embedding infrastructure using shared bucket and queues

--- a/infra/chromadb_compaction/components/__init__.py
+++ b/infra/chromadb_compaction/components/__init__.py
@@ -3,12 +3,17 @@ ChromaDB Compaction Pulumi Components
 
 This package contains the Pulumi infrastructure components for ChromaDB
 compaction:
+- alarms: CloudWatch alarms on the compaction handler's EMF metrics
 - s3_buckets: S3 bucket resources for storing ChromaDB snapshots
 - sqs_queues: SQS queue resources for message passing
 - docker_image: Docker image building for container-based Lambda
 - lambda_functions: Hybrid Lambda deployment (zip + container)
 """
 
+from .alarms import (
+    ChromaDBCompactionAlarms,
+    create_chromadb_compaction_alarms,
+)
 from .docker_image import DockerImageComponent
 from .lambda_functions import (
     HybridLambdaDeployment,
@@ -20,6 +25,8 @@ from .sqs_queues import ChromaDBQueues, create_chromadb_queues
 # pylint: disable=duplicate-code
 # Export lists are expected to be similar between package __init__ files
 __all__ = [
+    "ChromaDBCompactionAlarms",
+    "create_chromadb_compaction_alarms",
     "ChromaDBBuckets",
     "create_chromadb_buckets",
     "ChromaDBQueues",

--- a/infra/chromadb_compaction/components/alarms.py
+++ b/infra/chromadb_compaction/components/alarms.py
@@ -1,0 +1,156 @@
+"""
+CloudWatch alarms for the ChromaDB compaction pipeline.
+
+The compaction handler already emits EMF metrics into the
+``EmbeddingWorkflow`` namespace, but nothing alarmed on them: the 07-12
+compaction storm ran for eleven days with CompactionLockAcquisitionFailed and
+CompactionSnapshotUploadError firing continuously and no notification.
+
+The handler emits these metrics without dimensions, so a single alarm per
+metric covers every stack.  Thresholds are set to catch a sustained failure
+mode rather than the occasional lock hand-off between the lines and words
+invocations.
+"""
+
+from typing import Optional
+
+import pulumi_aws as aws
+from pulumi import ComponentResource, Input, ResourceOptions
+
+# The handler's EmbeddedMetricsFormatter publishes to this namespace.
+METRICS_NAMESPACE = "EmbeddingWorkflow"
+
+
+class ChromaDBCompactionAlarms(ComponentResource):
+    """CloudWatch alarms on the compaction handler's EMF metrics."""
+
+    def __init__(
+        self,
+        name: str,
+        alert_topic_arn: Optional[Input[str]] = None,
+        stack: str = "dev",
+        opts: Optional[ResourceOptions] = None,
+    ):
+        """
+        Initialize compaction alarms.
+
+        Args:
+            name: The unique name of the resource
+            alert_topic_arn: SNS topic notified when an alarm fires.  When
+                omitted the alarms are still created (and visible in the
+                console) but send no notification.
+            stack: The Pulumi stack name, used for tagging
+            opts: Optional resource options
+        """
+        super().__init__("chromadb:compaction:Alarms", name, None, opts)
+
+        alarm_actions = [alert_topic_arn] if alert_topic_arn else None
+        tags = {
+            "Project": "ChromaDB",
+            "Component": "CompactionAlarms",
+            "Environment": stack,
+            "ManagedBy": "Pulumi",
+        }
+
+        # Lock acquisition failures mean a compaction cycle returned its whole
+        # batch for retry without doing any work.  A handful per hour is
+        # normal contention between the lines and words invocations; a
+        # sustained rate means the pipeline is spinning.
+        self.lock_acquisition_alarm = aws.cloudwatch.MetricAlarm(
+            f"{name}-lock-acquisition-failed",
+            alarm_description=(
+                "ChromaDB compaction is repeatedly failing to acquire the "
+                "collection lock - batches are being retried without "
+                "progress."
+            ),
+            metric_name="CompactionLockAcquisitionFailed",
+            namespace=METRICS_NAMESPACE,
+            statistic="Sum",
+            period=300,  # 5 minutes
+            evaluation_periods=3,  # sustained for 15 minutes
+            threshold=20,
+            comparison_operator="GreaterThanThreshold",
+            alarm_actions=alarm_actions,
+            ok_actions=alarm_actions,
+            treat_missing_data="notBreaching",
+            tags=tags,
+            opts=ResourceOptions(parent=self),
+        )
+
+        # A failed snapshot upload discards a completed merge, so any
+        # sustained rate means vectors are being silently dropped.
+        self.snapshot_upload_alarm = aws.cloudwatch.MetricAlarm(
+            f"{name}-snapshot-upload-error",
+            alarm_description=(
+                "ChromaDB compaction snapshot uploads are failing - merged "
+                "vectors are being discarded."
+            ),
+            metric_name="CompactionSnapshotUploadError",
+            namespace=METRICS_NAMESPACE,
+            statistic="Sum",
+            period=300,  # 5 minutes
+            evaluation_periods=2,  # sustained for 10 minutes
+            threshold=5,
+            comparison_operator="GreaterThanThreshold",
+            alarm_actions=alarm_actions,
+            ok_actions=alarm_actions,
+            treat_missing_data="notBreaching",
+            tags=tags,
+            opts=ResourceOptions(parent=self),
+        )
+
+        # Delta merges that fail leave a receipt without its vectors.  These
+        # are rare enough that any occurrence is worth a notification.
+        self.delta_merge_alarm = aws.cloudwatch.MetricAlarm(
+            f"{name}-delta-merge-error",
+            alarm_description=(
+                "ChromaDB delta merges are failing - affected receipts have "
+                "no vectors and their CompactionRuns stay pending."
+            ),
+            metric_name="CompactionDeltaMergeError",
+            namespace=METRICS_NAMESPACE,
+            statistic="Sum",
+            period=300,  # 5 minutes
+            evaluation_periods=1,
+            threshold=0,
+            comparison_operator="GreaterThanThreshold",
+            alarm_actions=alarm_actions,
+            ok_actions=alarm_actions,
+            treat_missing_data="notBreaching",
+            tags=tags,
+            opts=ResourceOptions(parent=self),
+        )
+
+        self.register_outputs(
+            {
+                "lock_acquisition_alarm_arn": self.lock_acquisition_alarm.arn,
+                "snapshot_upload_alarm_arn": self.snapshot_upload_alarm.arn,
+                "delta_merge_alarm_arn": self.delta_merge_alarm.arn,
+            }
+        )
+
+
+def create_chromadb_compaction_alarms(
+    name: str = "chromadb-compaction",
+    alert_topic_arn: Optional[Input[str]] = None,
+    stack: str = "dev",
+    opts: Optional[ResourceOptions] = None,
+) -> ChromaDBCompactionAlarms:
+    """
+    Factory function to create ChromaDB compaction alarms.
+
+    Args:
+        name: Base name for the resources
+        alert_topic_arn: SNS topic notified when an alarm fires
+        stack: The Pulumi stack name, used for tagging
+        opts: Optional resource options
+
+    Returns:
+        ChromaDBCompactionAlarms component resource
+    """
+    return ChromaDBCompactionAlarms(
+        name,
+        alert_topic_arn=alert_topic_arn,
+        stack=stack,
+        opts=opts,
+    )

--- a/infra/chromadb_compaction/components/lambda_functions.py
+++ b/infra/chromadb_compaction/components/lambda_functions.py
@@ -143,21 +143,21 @@ class HybridLambdaDeployment(ComponentResource):
                 "memory_size": 10240,  # 10GB (Lambda max) for large collections
                 # Increased ephemeral storage from 5GB to 10GB for large snapshot operations
                 "ephemeral_storage": 10240,  # 10GB for ChromaDB snapshots (largest seen: 552MB)
-                # Allow 2 concurrent invocations so lines and words queues
-                # can be processed in parallel.  Per-collection locks in the
-                # handler prevent concurrent writes to the same snapshot.
+                # Must equal the sum of the two event source mappings'
+                # maximum_concurrency (2 lines + 2 words).  Standard-queue ESMs
+                # cannot go below 2, so reserved=2 left half the poller slots
+                # permanently throttled — and a throttled poll still increments
+                # ApproximateReceiveCount, burning the message's retention
+                # budget until it expired unprocessed (~27k throttles/day
+                # during the 07-12 storm).
                 #
-                # Why 2, not 4 (sum of ESM maximum_concurrency)?
-                # Each handler invocation acquires a per-collection lock before
-                # downloading + mutating the snapshot.  A second invocation for
-                # the *same* collection would block on that lock until the first
-                # finishes, wasting Lambda billing time without adding throughput.
-                # reserved=2 gives us 1 lines + 1 words in parallel — the only
-                # combination that does useful work.  Bumping to 4 just adds two
-                # invocations that spin on the lock.  AWS ESM throttling here is
-                # intentional: messages stay in the queue until a slot opens,
-                # which is the correct back-pressure behaviour.
-                "reserved_concurrent_executions": 2,
+                # An invocation that loses the per-collection lock is cheap,
+                # not wasteful: acquire() fails immediately and the handler
+                # returns the batch for retry rather than blocking on the lock.
+                # Residual lock contention is now visible via the
+                # CompactionLockAcquisitionFailed alarm instead of hiding in
+                # SQS receive counts.
+                "reserved_concurrent_executions": 4,
                 "description": (
                     "Enhanced ChromaDB compaction handler for stream and "
                     "delta message processing"

--- a/infra/chromadb_compaction/components/sqs_queues.py
+++ b/infra/chromadb_compaction/components/sqs_queues.py
@@ -311,4 +311,6 @@ def create_chromadb_queues(
     Returns:
         ChromaDBQueues component resource
     """
-    return ChromaDBQueues(name, producer_role_arns=producer_role_arns, opts=opts)
+    return ChromaDBQueues(
+        name, producer_role_arns=producer_role_arns, opts=opts
+    )

--- a/infra/chromadb_compaction/components/sqs_queues.py
+++ b/infra/chromadb_compaction/components/sqs_queues.py
@@ -151,15 +151,21 @@ class ChromaDBQueues(ComponentResource):
             # Visibility timeout must be >= Lambda timeout per AWS requirements.
             visibility_timeout_seconds=900,
             receive_wait_time_seconds=20,  # Long polling
-            # High maxReceiveCount so the INTENDED back-pressure works: the
-            # consumer is deliberately concurrency-limited (reserved=2), so SQS
-            # throttles polls when no slot is free — and each throttled poll
-            # increments ApproximateReceiveCount. With maxReceiveCount=10 those
-            # throttle-bounces dead-lettered messages before they ever got a
-            # processing slot. A high cap lets them wait for a slot instead.
+            # maxReceiveCount has to clear throttle-bounces without going so
+            # high that the DLQ is unreachable.  Each poll (including one
+            # throttled by the consumer's reserved concurrency) increments
+            # ApproximateReceiveCount, which is why maxReceiveCount=10
+            # dead-lettered messages before they got a slot (issue #990).
+            # But retention/visibility caps receives at 345600/900 = 384, so
+            # the old cap of 1000 could never be reached: a poison message
+            # churned for 4 days and then expired silently instead of
+            # dead-lettering.  100 sits between the two — reachable in ~25h
+            # of consistent failure (4x margin inside retention), and far
+            # above the throttle-bounce rate now that reserved concurrency
+            # matches the event source mappings.
             redrive_policy=Output.all(self.lines_dlq.arn).apply(
                 lambda args: json.dumps(
-                    {"deadLetterTargetArn": args[0], "maxReceiveCount": 1000}
+                    {"deadLetterTargetArn": args[0], "maxReceiveCount": 100}
                 )
             ),
             tags={
@@ -177,14 +183,14 @@ class ChromaDBQueues(ComponentResource):
             message_retention_seconds=345600,  # 4 days
             visibility_timeout_seconds=900,
             receive_wait_time_seconds=20,  # Long polling
-            # See lines_queue: high cap so throttle-bounces don't dead-letter
-            # before a slot opens. The words queue is where this bit hard — a
-            # bulk delete/label-revalidation flood (one stream message per
-            # word/label change) throttle-bounced ~12k messages into the DLQ
-            # without ever being processed. See issue #990.
+            # See lines_queue for the arithmetic.  The words queue is where
+            # this bit hardest in both directions: a bulk delete/label-
+            # revalidation flood throttle-bounced ~12k messages into the DLQ
+            # under maxReceiveCount=10 (issue #990), and under 1000 the
+            # 07-12 compaction storm churned messages to expiry instead.
             redrive_policy=Output.all(self.words_dlq.arn).apply(
                 lambda args: json.dumps(
-                    {"deadLetterTargetArn": args[0], "maxReceiveCount": 1000}
+                    {"deadLetterTargetArn": args[0], "maxReceiveCount": 100}
                 )
             ),
             tags={

--- a/infra/chromadb_compaction/infrastructure.py
+++ b/infra/chromadb_compaction/infrastructure.py
@@ -8,8 +8,10 @@ Coordinates all components including SQS queues, S3 buckets, and hybrid Lambda d
 
 from typing import Optional
 
-from pulumi import ComponentResource, ResourceOptions
+import pulumi
+from pulumi import ComponentResource, Input, ResourceOptions
 
+from .components.alarms import create_chromadb_compaction_alarms
 from .components.lambda_functions import create_hybrid_lambda_deployment
 from .components.s3_buckets import create_chromadb_buckets
 from .components.sqs_queues import create_chromadb_queues
@@ -33,6 +35,7 @@ class ChromaDBCompactionInfrastructure(ComponentResource):
         chromadb_buckets=None,
         subnet_ids=None,
         lambda_security_group_id: str | None = None,
+        alert_topic_arn: Optional[Input[str]] = None,
         opts: Optional[ResourceOptions] = None,
     ):
         """
@@ -45,6 +48,7 @@ class ChromaDBCompactionInfrastructure(ComponentResource):
             chromadb_buckets: Shared ChromaDB S3 buckets component
             subnet_ids: Subnet IDs for Lambda placement
             lambda_security_group_id: Security group ID for Lambda VPC access
+            alert_topic_arn: SNS topic notified by the compaction alarms
             opts: Optional resource options
         """
         super().__init__(
@@ -76,6 +80,14 @@ class ChromaDBCompactionInfrastructure(ComponentResource):
             dynamodb_stream_arn=dynamodb_stream_arn,
             vpc_subnet_ids=subnet_ids,
             lambda_security_group_id=lambda_security_group_id,
+            opts=ResourceOptions(parent=self),
+        )
+
+        # Alarm on the compaction handler's EMF failure metrics.
+        self.alarms = create_chromadb_compaction_alarms(
+            name=f"{name}-alarms",
+            alert_topic_arn=alert_topic_arn,
+            stack=pulumi.get_stack(),
             opts=ResourceOptions(parent=self),
         )
 
@@ -111,6 +123,7 @@ def create_chromadb_compaction_infrastructure(
     chromadb_buckets=None,
     subnet_ids=None,
     lambda_security_group_id: str | None = None,
+    alert_topic_arn: Optional[Input[str]] = None,
     opts: Optional[ResourceOptions] = None,
 ) -> ChromaDBCompactionInfrastructure:
     """
@@ -123,6 +136,7 @@ def create_chromadb_compaction_infrastructure(
         chromadb_buckets: Shared ChromaDB S3 buckets component
         subnet_ids: Subnet IDs for Lambda placement
         lambda_security_group_id: Security group ID for Lambda VPC access
+        alert_topic_arn: SNS topic notified by the compaction alarms
         opts: Optional resource options
 
     Returns:
@@ -140,5 +154,6 @@ def create_chromadb_compaction_infrastructure(
         chromadb_buckets=chromadb_buckets,
         subnet_ids=subnet_ids,
         lambda_security_group_id=lambda_security_group_id,
+        alert_topic_arn=alert_topic_arn,
         opts=opts,
     )

--- a/infra/chromadb_compaction/lambdas/enhanced_compaction_handler.py
+++ b/infra/chromadb_compaction/lambdas/enhanced_compaction_handler.py
@@ -252,13 +252,21 @@ def _collect_failed_message_ids(
     """Collect message IDs for failed processing operations.
 
     Args:
-        result: CollectionUpdateResult with metadata_updates and label_updates
+        result: CollectionUpdateResult with metadata_updates, label_updates
+            and delta_merge_results
         messages: Original stream messages to match against
 
     Returns:
         List of stream record IDs for messages that failed processing
     """
     failed_ids: list[str] = []
+
+    # Delta merges carry the originating record id, so a failed merge can be
+    # retried instead of having its message deleted with the batch.
+    for run_result in result.failed_delta_merges:
+        record_id = run_result.get("record_id")
+        if record_id:
+            failed_ids.append(record_id)
 
     # Check metadata update failures (place updates + section recomputes
     # both key results by image_id/receipt_id)
@@ -329,10 +337,22 @@ def process_collection(  # pylint: disable=too-many-locals
     # Initialize DynamoDB client
     dynamo_client = DynamoClient(table_name)
 
-    # Initialize lock manager
+    # Initialize lock manager.  The duration/heartbeat settings come from the
+    # Lambda environment (set in components/lambda_functions.py); without them
+    # the LockManager defaults to a 5-minute lock that expires part-way
+    # through a large merge.
     lock_manager = LockManager(
         dynamo_client=dynamo_client,
         collection=collection,
+        heartbeat_interval=int(
+            os.environ.get("HEARTBEAT_INTERVAL_SECONDS", "30")
+        ),
+        lock_duration_minutes=int(
+            os.environ.get("LOCK_DURATION_MINUTES", "3")
+        ),
+        max_heartbeat_failures=int(
+            os.environ.get("MAX_HEARTBEAT_FAILURES", "3")
+        ),
     )
 
     # Acquire lock for atomic snapshot upload
@@ -342,6 +362,12 @@ def process_collection(  # pylint: disable=too-many-locals
         if metrics:
             metrics.count("CompactionLockAcquisitionFailed", 1)
         return {"failed_message_ids": [m.context.record_id for m in messages]}
+
+    # Keep the lock alive for the whole download/merge/upload cycle.  A merge
+    # of a multi-hundred-MB snapshot outlives the initial lock duration, and
+    # upload_snapshot_atomic discards the merged result at its ownership check
+    # if the lock expired in the meantime.
+    lock_manager.start_heartbeat()
 
     # Create temp directory for snapshot
     temp_dir = tempfile.mkdtemp(prefix=f"chroma-{collection.value}-")
@@ -455,6 +481,18 @@ def process_collection(  # pylint: disable=too-many-locals
         # detect completion.
         if result.delta_merge_results:
             for run_result in result.delta_merge_results:
+                # A failed merge stays PENDING so it is retried; marking it
+                # COMPLETED here would strand the receipt without vectors.
+                if run_result.get("error") is not None:
+                    op_logger.error(
+                        "Delta merge failed - leaving CompactionRun for retry",
+                        run_id=run_result.get("run_id"),
+                        collection=collection.value,
+                        error=run_result["error"],
+                    )
+                    if metrics:
+                        metrics.count("CompactionDeltaMergeError", 1)
+                    continue
                 try:
                     dynamo_client.mark_compaction_run_completed(
                         image_id=run_result["image_id"],
@@ -485,6 +523,15 @@ def process_collection(  # pylint: disable=too-many-locals
         }
 
     finally:
+        # Stop the heartbeat before releasing so the worker thread cannot
+        # re-extend a lock we no longer own.
+        try:
+            lock_manager.stop_heartbeat()
+        except Exception as e:  # pylint: disable=broad-exception-caught
+            op_logger.debug(
+                "Failed to stop heartbeat during cleanup", error=str(e)
+            )
+
         # Release lock if acquired
         try:
             lock_manager.release()

--- a/infra/tests/test_compaction_lock_config.py
+++ b/infra/tests/test_compaction_lock_config.py
@@ -1,0 +1,297 @@
+"""Tests for the ChromaDB compaction handler's lock and failure handling.
+
+The handler runs inside a Lambda package where ``utils`` and the monorepo
+packages are installed at build time, so this module stubs those imports and
+loads ``enhanced_compaction_handler.py`` directly from its path.  That keeps
+the test dependency-free (pytest only) while still exercising the real
+handler source.
+
+Covers two regressions that caused the 07-12 compaction outage:
+
+- ``LockManager`` was constructed without the duration/heartbeat settings the
+  Lambda's environment provides, and ``start_heartbeat()`` was never called,
+  so the lock expired mid-merge and ``upload_snapshot_atomic`` discarded the
+  merged snapshot at its ownership check.
+- Failed delta merges were dropped instead of being reported as batch item
+  failures, so their SQS messages were deleted and the receipts kept no
+  vectors.
+"""
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+HANDLER_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "chromadb_compaction"
+    / "lambdas"
+    / "enhanced_compaction_handler.py"
+)
+
+
+def _stub_module(name: str, **attrs) -> types.ModuleType:
+    """Create a stub module whose unknown attributes are MagicMocks."""
+    module = types.ModuleType(name)
+    for key, value in attrs.items():
+        setattr(module, key, value)
+    module.__getattr__ = lambda _name: MagicMock()  # type: ignore[attr-defined]
+    return module
+
+
+def _passthrough_decorator(*_args, **_kwargs):
+    """Stand in for the tracing/timeout decorators applied at import."""
+    return lambda func: func
+
+
+@pytest.fixture(name="handler")
+def handler_fixture(monkeypatch):
+    """Load the Lambda handler with its runtime-only imports stubbed."""
+    utils = _stub_module(
+        "utils",
+        get_operation_logger=lambda *_a, **_k: MagicMock(),
+        trace_function=_passthrough_decorator,
+        with_compaction_timeout_protection=_passthrough_decorator,
+        emf_metrics=MagicMock(),
+    )
+
+    class _ReceiptDynamoError(Exception):
+        """Real exception class so ``except`` clauses stay valid."""
+
+    stubs = {
+        "utils": utils,
+        "utils.lambda_types": _stub_module("utils.lambda_types"),
+        "utils.logging": _stub_module("utils.logging"),
+        "receipt_chroma": _stub_module("receipt_chroma"),
+        "receipt_chroma.compaction": _stub_module("receipt_chroma.compaction"),
+        "receipt_chroma.s3": _stub_module("receipt_chroma.s3"),
+        "receipt_dynamo": _stub_module("receipt_dynamo"),
+        "receipt_dynamo.constants": _stub_module("receipt_dynamo.constants"),
+        "receipt_dynamo.data": _stub_module("receipt_dynamo.data"),
+        "receipt_dynamo.data.dynamo_client": _stub_module(
+            "receipt_dynamo.data.dynamo_client"
+        ),
+        "receipt_dynamo.data.shared_exceptions": _stub_module(
+            "receipt_dynamo.data.shared_exceptions",
+            ReceiptDynamoError=_ReceiptDynamoError,
+        ),
+        "receipt_dynamo_stream": _stub_module("receipt_dynamo_stream"),
+        "receipt_dynamo_stream.models": _stub_module(
+            "receipt_dynamo_stream.models"
+        ),
+        "receipt_dynamo_stream.stream_types": _stub_module(
+            "receipt_dynamo_stream.stream_types"
+        ),
+    }
+    for name, module in stubs.items():
+        monkeypatch.setitem(sys.modules, name, module)
+
+    spec = importlib.util.spec_from_file_location(
+        "enhanced_compaction_handler_under_test", HANDLER_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _make_collection():
+    collection = MagicMock()
+    collection.value = "lines"
+    return collection
+
+
+def _make_message(record_id: str):
+    message = MagicMock()
+    message.context.record_id = record_id
+    message.entity_data = {}
+    return message
+
+
+def _make_result(**overrides):
+    """Build a stand-in CollectionUpdateResult."""
+    result = MagicMock()
+    result.has_errors = False
+    result.total_metadata_updated = 0
+    result.total_labels_updated = 0
+    result.total_sections_updated = 0
+    result.delta_merge_count = 0
+    result.delta_merge_results = []
+    result.failed_delta_merges = []
+    result.metadata_updates = []
+    result.label_updates = []
+    result.section_updates = []
+    for key, value in overrides.items():
+        setattr(result, key, value)
+    return result
+
+
+def _arrange_successful_cycle(handler, monkeypatch, result=None):
+    """Patch the handler's collaborators for one successful compaction."""
+    monkeypatch.setenv("CHROMADB_BUCKET", "test-bucket")
+    monkeypatch.setenv("DYNAMODB_TABLE_NAME", "test-table")
+    monkeypatch.setenv("HEARTBEAT_INTERVAL_SECONDS", "17")
+    monkeypatch.setenv("LOCK_DURATION_MINUTES", "11")
+    monkeypatch.setenv("MAX_HEARTBEAT_FAILURES", "4")
+
+    lock_manager = MagicMock()
+    lock_manager.acquire.return_value = True
+    lock_manager_cls = MagicMock(return_value=lock_manager)
+    monkeypatch.setattr(handler, "LockManager", lock_manager_cls)
+    monkeypatch.setattr(handler, "DynamoClient", MagicMock())
+    monkeypatch.setattr(handler, "ChromaClient", MagicMock())
+    monkeypatch.setattr(handler, "CloudConfig", MagicMock())
+    monkeypatch.setattr(
+        handler,
+        "download_snapshot_atomic",
+        MagicMock(return_value={"status": "success", "version": "v1"}),
+    )
+    monkeypatch.setattr(
+        handler,
+        "upload_snapshot_atomic",
+        MagicMock(return_value={"status": "success", "version_id": "v2"}),
+    )
+
+    dual_result = MagicMock()
+    dual_result.local_result = result if result is not None else _make_result()
+    monkeypatch.setattr(
+        handler,
+        "apply_collection_updates",
+        MagicMock(return_value=dual_result),
+    )
+
+    return lock_manager_cls, lock_manager
+
+
+class TestLockConfiguration:
+    """The lock must be built from the Lambda environment and kept alive."""
+
+    def test_lock_manager_uses_environment_configuration(
+        self, handler, monkeypatch
+    ):
+        lock_manager_cls, _ = _arrange_successful_cycle(handler, monkeypatch)
+
+        handler.process_collection(
+            collection=_make_collection(),
+            messages=[_make_message("record-1")],
+            op_logger=MagicMock(),
+        )
+
+        kwargs = lock_manager_cls.call_args.kwargs
+        assert kwargs["heartbeat_interval"] == 17
+        assert kwargs["lock_duration_minutes"] == 11
+        assert kwargs["max_heartbeat_failures"] == 4
+
+    def test_heartbeat_runs_for_the_whole_cycle(self, handler, monkeypatch):
+        _, lock_manager = _arrange_successful_cycle(handler, monkeypatch)
+
+        handler.process_collection(
+            collection=_make_collection(),
+            messages=[_make_message("record-1")],
+            op_logger=MagicMock(),
+        )
+
+        lock_manager.start_heartbeat.assert_called_once()
+        lock_manager.stop_heartbeat.assert_called_once()
+        lock_manager.release.assert_called_once()
+
+    def test_no_heartbeat_when_lock_is_not_acquired(
+        self, handler, monkeypatch
+    ):
+        _, lock_manager = _arrange_successful_cycle(handler, monkeypatch)
+        lock_manager.acquire.return_value = False
+
+        result = handler.process_collection(
+            collection=_make_collection(),
+            messages=[_make_message("record-1")],
+            op_logger=MagicMock(),
+        )
+
+        lock_manager.start_heartbeat.assert_not_called()
+        assert result["failed_message_ids"] == ["record-1"]
+
+
+class TestDeltaFailurePropagation:
+    """Failed delta merges must be retried, not silently deleted."""
+
+    def test_failed_delta_merge_is_reported_as_a_batch_failure(
+        self, handler, monkeypatch
+    ):
+        result = _make_result(
+            has_errors=True,
+            failed_delta_merges=[
+                {
+                    "run_id": "run-1",
+                    "error": "delta download failed",
+                    "record_id": "record-delta",
+                }
+            ],
+        )
+        _arrange_successful_cycle(handler, monkeypatch, result=result)
+
+        outcome = handler.process_collection(
+            collection=_make_collection(),
+            messages=[_make_message("record-delta")],
+            op_logger=MagicMock(),
+        )
+
+        assert outcome["failed_message_ids"] == ["record-delta"]
+
+    def test_failed_delta_merge_is_not_marked_completed(
+        self, handler, monkeypatch
+    ):
+        failed_run = {
+            "run_id": "run-1",
+            "image_id": "img-1",
+            "receipt_id": 1,
+            "merged_count": 0,
+            "error": "upsert verification failed",
+            "record_id": "record-delta",
+        }
+        result = _make_result(
+            has_errors=True,
+            delta_merge_results=[failed_run],
+            failed_delta_merges=[failed_run],
+        )
+        _arrange_successful_cycle(handler, monkeypatch, result=result)
+        dynamo_client = MagicMock()
+        monkeypatch.setattr(
+            handler, "DynamoClient", MagicMock(return_value=dynamo_client)
+        )
+
+        handler.process_collection(
+            collection=_make_collection(),
+            messages=[_make_message("record-delta")],
+            op_logger=MagicMock(),
+        )
+
+        dynamo_client.mark_compaction_run_completed.assert_not_called()
+
+    def test_successful_delta_merge_is_marked_completed(
+        self, handler, monkeypatch
+    ):
+        merged_run = {
+            "run_id": "run-1",
+            "image_id": "img-1",
+            "receipt_id": 1,
+            "merged_count": 12,
+            "error": None,
+            "record_id": "record-delta",
+        }
+        result = _make_result(delta_merge_results=[merged_run])
+        _arrange_successful_cycle(handler, monkeypatch, result=result)
+        dynamo_client = MagicMock()
+        monkeypatch.setattr(
+            handler, "DynamoClient", MagicMock(return_value=dynamo_client)
+        )
+
+        outcome = handler.process_collection(
+            collection=_make_collection(),
+            messages=[_make_message("record-delta")],
+            op_logger=MagicMock(),
+        )
+
+        dynamo_client.mark_compaction_run_completed.assert_called_once()
+        assert outcome["failed_message_ids"] == []

--- a/receipt_chroma/receipt_chroma/compaction/deltas.py
+++ b/receipt_chroma/receipt_chroma/compaction/deltas.py
@@ -46,7 +46,10 @@ def merge_compaction_deltas(
 
     Returns:
         Tuple of (total_vectors_merged, list of per-run merge results).
-        Each result dict has: run_id, image_id, receipt_id, merged_count
+        Each result dict has: run_id, image_id, receipt_id, merged_count,
+        error, record_id.  Failed runs are included with a non-None ``error``
+        and do not contribute to the merged total, so the caller can retry
+        their SQS messages rather than deleting them.
     """
     if not compaction_runs:
         return 0, []
@@ -67,10 +70,35 @@ def merge_compaction_deltas(
                 workdir=workdir,
             )
             if merged is not None:
-                total_merged += merged["merged_count"]
+                if merged.get("error") is None:
+                    total_merged += merged["merged_count"]
                 per_run_results.append(merged)
 
     return total_merged, per_run_results
+
+
+def _run_result(
+    msg: Any,
+    run_id: Any,
+    image_id: Any,
+    receipt_id: Any,
+    merged_count: int,
+    error: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Build a per-run merge result.
+
+    ``record_id`` carries the originating SQS message id so a failed merge can
+    be reported back to Lambda as a batch item failure.
+    """
+    context = getattr(msg, "context", None)
+    return {
+        "run_id": run_id,
+        "image_id": image_id,
+        "receipt_id": receipt_id,
+        "merged_count": merged_count,
+        "error": error,
+        "record_id": getattr(context, "record_id", None),
+    }
 
 
 def _process_single_run(
@@ -85,9 +113,16 @@ def _process_single_run(
     """Process one COMPACTION_RUN message: download delta and merge vectors.
 
     Returns:
-        Result dict with run_id, image_id, receipt_id, merged_count on
-        success, or ``None`` if the run was skipped or failed.
+        Result dict with run_id, image_id, receipt_id, merged_count and
+        ``error``.  ``error`` is ``None`` on success and a description of the
+        failure otherwise, so the caller can retry the originating SQS message
+        instead of deleting it.  ``None`` is returned only when the run has
+        nothing to merge (no delta prefix).
     """
+    run_id: Any = None
+    image_id: Any = None
+    receipt_id: Any = None
+
     try:
         entity = getattr(msg, "entity_data", {}) or {}
         run_id = entity.get("run_id")
@@ -125,10 +160,17 @@ def _process_single_run(
             logger.exception(
                 "Failed to download or extract delta: %s", delta_prefix
             )
-            return None
+            return _run_result(
+                msg,
+                run_id,
+                image_id,
+                receipt_id,
+                merged_count=0,
+                error=f"delta download failed: {delta_prefix}",
+            )
 
         # Merge delta vectors into snapshot
-        merged_count = _merge_delta_into_snapshot(
+        merged_count, merge_error = _merge_delta_into_snapshot(
             delta_dir=delta_dir,
             chroma_client=chroma_client,
             collection_name=collection.value,
@@ -138,22 +180,36 @@ def _process_single_run(
             receipt_id=receipt_id,
         )
 
+        if merge_error is not None:
+            return _run_result(
+                msg,
+                run_id,
+                image_id,
+                receipt_id,
+                merged_count=0,
+                error=merge_error,
+            )
+
         if (
             run_id is not None
             and image_id is not None
             and receipt_id is not None
         ):
-            return {
-                "run_id": run_id,
-                "image_id": image_id,
-                "receipt_id": receipt_id,
-                "merged_count": merged_count,
-            }
+            return _run_result(
+                msg, run_id, image_id, receipt_id, merged_count=merged_count
+            )
         return None
 
-    except Exception:
+    except Exception as exc:  # pylint: disable=broad-exception-caught
         logger.exception("Failed processing compaction run")
-        return None
+        return _run_result(
+            msg,
+            run_id,
+            image_id,
+            receipt_id,
+            merged_count=0,
+            error=f"{type(exc).__name__}: {exc}",
+        )
 
 
 def _merge_delta_into_snapshot(
@@ -164,11 +220,13 @@ def _merge_delta_into_snapshot(
     run_id: Any = None,
     image_id: Any = None,
     receipt_id: Any = None,
-) -> int:
+) -> Tuple[int, Optional[str]]:
     """Open a local delta directory and upsert its vectors into the snapshot.
 
     Returns:
-        Number of vectors merged (0 if the delta was empty or unreadable).
+        Tuple of (vectors merged, error).  ``error`` is ``None`` when the
+        merge succeeded — including for an empty delta, which merges zero
+        vectors legitimately — and a description otherwise.
     """
     delta_client = ChromaClient(persist_directory=delta_dir, mode="read")
     try:
@@ -185,7 +243,7 @@ def _merge_delta_into_snapshot(
                 receipt_id,
                 collection_name,
             )
-            return 0
+            return 0, None
 
         embeddings = data.get("embeddings")
         documents = data.get("documents")
@@ -231,7 +289,7 @@ def _merge_delta_into_snapshot(
 
         if missing_ids:
             logger.error(
-                "Upsert verification failed — returning 0 so the run "
+                "Upsert verification failed — reporting an error so the run "
                 "is not marked as merged and can be retried: "
                 "run_id=%s, image_id=%s, receipt_id=%s, "
                 "collection=%s, total=%d, missing=%d",
@@ -242,7 +300,10 @@ def _merge_delta_into_snapshot(
                 len(ids),
                 len(missing_ids),
             )
-            return 0
+            return 0, (
+                f"upsert verification failed: {len(missing_ids)} of "
+                f"{len(ids)} vectors missing"
+            )
 
         logger.info(
             "Upsert verified successfully: run_id=%s, image_id=%s, "
@@ -254,9 +315,9 @@ def _merge_delta_into_snapshot(
             len(ids),
         )
 
-        return len(ids)
+        return len(ids), None
 
-    except Exception:
+    except Exception as exc:  # pylint: disable=broad-exception-caught
         logger.exception(
             "Delta has no collection or failed to read: "
             "collection=%s, run_id=%s, image_id=%s, receipt_id=%s",
@@ -265,7 +326,7 @@ def _merge_delta_into_snapshot(
             image_id,
             receipt_id,
         )
-        return 0
+        return 0, f"delta merge failed: {type(exc).__name__}: {exc}"
     finally:
         delta_client.close()
 

--- a/receipt_chroma/receipt_chroma/compaction/models.py
+++ b/receipt_chroma/receipt_chroma/compaction/models.py
@@ -143,6 +143,15 @@ class CollectionUpdateResult:
         )
 
     @property
+    def failed_delta_merges(self) -> List[Dict[str, Any]]:
+        """Delta merges that failed and must be retried."""
+        return [
+            r
+            for r in (self.delta_merge_results or [])
+            if r.get("error") is not None
+        ]
+
+    @property
     def has_errors(self) -> bool:
         """Whether any updates had errors."""
         all_results = (
@@ -151,4 +160,6 @@ class CollectionUpdateResult:
             + list(self.receipt_deletions or [])
             + list(self.section_updates or [])
         )
-        return any(r.error is not None for r in all_results)
+        if any(r.error is not None for r in all_results):
+            return True
+        return bool(self.failed_delta_merges)

--- a/receipt_chroma/tests/integration/test_delta_merging.py
+++ b/receipt_chroma/tests/integration/test_delta_merging.py
@@ -427,9 +427,15 @@ class TestDeltaMerging:
             bucket=bucket_name,
         )
 
-        # Should not merge anything
+        # Should not merge anything, but the failure must be reported so the
+        # SQS message is retried instead of silently deleted.
         assert total_merged == 0
-        assert len(per_run_results) == 0
+        assert len(per_run_results) == 1
+        failure = per_run_results[0]
+        assert failure["error"] is not None
+        assert failure["merged_count"] == 0
+        assert failure["run_id"] == "run-missing"
+        assert failure["record_id"] == compaction_msg.context.record_id
 
         snapshot_client.close()
 

--- a/receipt_chroma/tests/unit/test_compaction_models.py
+++ b/receipt_chroma/tests/unit/test_compaction_models.py
@@ -272,6 +272,51 @@ class TestCollectionUpdateResult:
         )
         assert result_with_label_error.has_errors is True
 
+    def test_collection_result_has_errors_for_failed_delta_merge(self):
+        """A failed delta merge counts as an error so it can be retried."""
+        result = CollectionUpdateResult(
+            collection=ChromaDBCollection.LINES,
+            metadata_updates=[],
+            label_updates=[],
+            delta_merge_count=0,
+            delta_merge_results=[
+                {
+                    "run_id": "run-1",
+                    "image_id": "img-1",
+                    "receipt_id": 1,
+                    "merged_count": 0,
+                    "error": "delta download failed",
+                    "record_id": "record-1",
+                }
+            ],
+        )
+
+        assert result.has_errors is True
+        assert len(result.failed_delta_merges) == 1
+        assert result.failed_delta_merges[0]["record_id"] == "record-1"
+
+    def test_collection_result_successful_delta_merge_is_not_an_error(self):
+        """A successful delta merge must not mark the collection failed."""
+        result = CollectionUpdateResult(
+            collection=ChromaDBCollection.LINES,
+            metadata_updates=[],
+            label_updates=[],
+            delta_merge_count=10,
+            delta_merge_results=[
+                {
+                    "run_id": "run-1",
+                    "image_id": "img-1",
+                    "receipt_id": 1,
+                    "merged_count": 10,
+                    "error": None,
+                    "record_id": "record-1",
+                }
+            ],
+        )
+
+        assert result.has_errors is False
+        assert result.failed_delta_merges == []
+
     def test_collection_result_to_dict(self):
         """Test converting CollectionUpdateResult to dictionary."""
         result = CollectionUpdateResult(


### PR DESCRIPTION
## The outage

Between 07-12 and 07-23 the dev ChromaDB compaction pipeline ran in a
continuous failure loop. On 07-12 alone the words/lines queues logged ~5M
message-receives. `CompactionLockAcquisitionFailed` and
`CompactionSnapshotUploadError` fired at 150–6,000/day for two weeks with no
alarm attached to either. Eleven receipts ended up with no vectors in Chroma.

Three independent defects combined to make it both self-sustaining and silent.

## 1. The compaction lock expired mid-merge

`enhanced_compaction_handler.process_collection` constructed `LockManager`
with only `dynamo_client` and `collection`, so it took the class defaults —
a 5-minute lock — and never called `start_heartbeat()`. The Lambda already
sets `LOCK_DURATION_MINUTES`, `HEARTBEAT_INTERVAL_SECONDS` and
`MAX_HEARTBEAT_FAILURES`; nothing read them.

Merging a 554MB snapshot outlives 5 minutes. By upload time the lock had
expired, and `upload_snapshot_atomic` discarded the completed merge at its
ownership check (`receipt_chroma/s3/snapshot.py`). The batch was then retried,
re-downloaded, re-merged, and discarded again.

The handler now passes the env-var configuration, calls `start_heartbeat()`
after a successful acquire, and `stop_heartbeat()` in the existing `finally`
before `release()`. This mirrors the already-correct implementation in
`infra/embedding_step_functions/unified_embedding/handlers/compaction.py`.

## 2. Failed delta merges were swallowed

`receipt_chroma/compaction/deltas.py` returned `None` on delta download
failure and `0` on merge failure. Both were indistinguishable from "nothing to
do": the run never reached `batchItemFailures`, so SQS deleted the message.
Worse, a merge that failed verification still returned a result dict, so the
handler marked the `CompactionRun` **COMPLETED with `merged_vectors=0`** — the
mechanism behind the eleven receipts that kept their DynamoDB rows but lost
their vectors.

Failures now carry an `error` and the originating `record_id` through
`merge_compaction_deltas`, surface via a new
`CollectionUpdateResult.failed_delta_merges`, are counted by `has_errors`, and
land in `batchItemFailures`. A failed run is left pending for retry instead of
being marked completed, and emits a new `CompactionDeltaMergeError` metric.

## 3. The DLQ was unreachable and half the poller slots were throttled

These two are coupled, and **both fixes differ from what was originally
proposed** — see "Deviations" below.

- **maxReceiveCount 1000 → 100** on the lines/words queues. Retention
  (345,600s) divided by visibility timeout (900s) caps a message at 384
  receives, so 1000 could never be reached: poison messages churned for four
  days and then expired silently. 100 dead-letters after ~25h of consistent
  failure, a 4x margin inside retention.
- **reserved_concurrent_executions 2 → 4.** Each of the two event source
  mappings sets `maximum_concurrency=2` (the AWS minimum for standard queues),
  so 4 poller slots contended for 2 reserved slots. Half were permanently
  throttled — and a throttled poll still increments
  `ApproximateReceiveCount`, burning the message's retention budget. That is
  what produced ~27k throttles/day and fed the silent-expiry loop.

## 4. Alarms

New `ChromaDBCompactionAlarms` component covering
`CompactionLockAcquisitionFailed`, `CompactionSnapshotUploadError` and the new
`CompactionDeltaMergeError`, wired to the existing
`notification_system.critical_error_topic_arn` (same pattern as `BillingAlerts`).
The handler emits these into the `EmbeddingWorkflow` namespace with no
dimensions, verified against live CloudWatch — so one alarm per metric covers
every stack, and an alarm cannot tell dev from prod.

## Deviations from the original diagnosis

Two proposed changes would have caused regressions, so this PR does something
different. Please review these two hunks closely.

- **maxReceiveCount was proposed as 5.** The existing code comment documents
  issue #990, where `maxReceiveCount=10` dead-lettered ~12k words messages
  that had been throttle-bounced without ever being processed. 5 is stricter
  than the value that caused #990 and would reproduce it. 100 is chosen to sit
  above throttle-bounce noise and below the 384-receive retention ceiling.
- **Reserved concurrency was proposed as 1.** The premise was that all work
  serializes behind one lock, but there are two collections with two
  independent locks, and a lock-losing invocation returns immediately rather
  than spinning (`acquire()` fails fast and the handler returns the batch).
  Setting 1 would have left 3 of 4 poller slots throttled and serialized lines
  behind words, making the throttle-bounce mechanism worse.

## Tests

- `infra/tests/test_compaction_lock_config.py` (new, 6 tests) — loads the real
  handler with its Lambda-only imports stubbed, so it needs pytest alone.
  Asserts the lock is built from the environment, the heartbeat brackets the
  cycle, no heartbeat starts when the lock is not acquired, failed deltas
  become batch failures and are not marked completed, and successful ones
  still are. **4 of the 6 fail on the pre-fix handler.**
- `receipt_chroma` — new `has_errors` / `failed_delta_merges` unit tests, and
  `test_merge_deltas_missing_s3_files` updated: it previously asserted a
  missing delta produced zero results, which is precisely the silent drop
  being fixed.
- Added a CI step for the new infra test. `infra/tests/` was otherwise
  unreferenced except for one explicitly-named file, so nothing under it ran.

`receipt_chroma`: 490 passed, 7 skipped, 4 failed. The 4 failures
(`test_label_updates`, `test_processor` label assertions) reproduce
identically on clean `main` and are unrelated to this change.

Note: `infra/chromadb_compaction/tests/` cannot be collected at all — importing
the package evaluates Pulumi at import time and raises
`AttributeError: 'NoneType' object has no attribute 'Invoke'`. Pre-existing on
`main`, and why the new test lives in `infra/tests/`.

## Second commit: formatting only

`733ae15` is black/isort with no behaviour change. The `receipt_agent` CI job
lints each changed `.py` file in full, so pre-existing violations in
`infra/__main__.py` (an unsorted import, an over-long `pulumi.export`) and
`sqs_queues.py` (an over-long `return`) failed the job as soon as this PR
touched those files. All checks are green with it applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

