### PR TITLE
fix: unique branch state names in backfill Step Function ASL

### DIFF
--- a/infra/embedding_step_functions/components/backfill_workflow.py
+++ b/infra/embedding_step_functions/components/backfill_workflow.py
@@ -53,6 +53,7 @@ def _control_task(
 def _child_branch(
     state_machine_arn: str,
     *,
+    branch_name: str,
     submission_namespace: str | None = None,
 ) -> dict[str, Any]:
     child_input: dict[str, Any] = {
@@ -60,10 +61,11 @@ def _child_branch(
     }
     if submission_namespace:
         child_input["submission_namespace"] = submission_namespace
+    state_name = f"Run{branch_name}"
     return {
-        "StartAt": "RunChildWorkflow",
+        "StartAt": state_name,
         "States": {
-            "RunChildWorkflow": {
+            state_name: {
                 "Type": "Task",
                 "Resource": "arn:aws:states:::states:startExecution.sync:2",
                 "Parameters": {
@@ -163,10 +165,12 @@ def build_backfill_definition(
             "Branches": [
                 _child_branch(
                     line_submit_arn,
+                    branch_name="LineSubmit",
                     submission_namespace="backfill-v1",
                 ),
                 _child_branch(
                     word_submit_arn,
+                    branch_name="WordSubmit",
                     submission_namespace="backfill-v1",
                 ),
             ],
@@ -188,8 +192,8 @@ def build_backfill_definition(
         "IngestActive": {
             "Type": "Parallel",
             "Branches": [
-                _child_branch(line_ingest_arn),
-                _child_branch(word_ingest_arn),
+                _child_branch(line_ingest_arn, branch_name="LineIngest"),
+                _child_branch(word_ingest_arn, branch_name="WordIngest"),
             ],
             "ResultPath": None,
             "Next": "Inspect",

--- a/infra/embedding_step_functions/tests/test_workflow_definitions.py
+++ b/infra/embedding_step_functions/tests/test_workflow_definitions.py
@@ -78,7 +78,7 @@ def test_embed_all_definition_is_manual_resumable_and_payload_bounded() -> (
     assert states["WaitForFixedPoint"]["Next"] == "ConfirmFixedPoint"
     assert states["MarkBackfillComplete"]["Parameters"]["action"] == "complete"
     for branch in states["SubmitMissing"]["Branches"]:
-        child_input = branch["States"]["RunChildWorkflow"]["Parameters"][
+        child_input = branch["States"][branch["StartAt"]]["Parameters"][
             "Input"
         ]
         assert child_input["submission_namespace"] == "backfill-v1"
@@ -86,8 +86,10 @@ def test_embed_all_definition_is_manual_resumable_and_payload_bounded() -> (
     for state_name in ("SubmitMissing", "IngestActive"):
         state = states[state_name]
         assert state["ResultPath"] is None
+        branch_start_names = [b["StartAt"] for b in state["Branches"]]
+        assert len(set(branch_start_names)) == len(branch_start_names)
         for branch in state["Branches"]:
-            child = branch["States"]["RunChildWorkflow"]
+            child = branch["States"][branch["StartAt"]]
             assert child["Resource"].endswith("startExecution.sync:2")
             assert child["ResultPath"] is None
 


### PR DESCRIPTION
AWS rejects `embedding-backfill-v1` with `DUPLICATE_STATE_NAME: RunChildWorkflow` — every parallel branch built by `_child_branch` used the same inner state name, which the provider-side ASL validator refuses. Surfaced on the first dev deploy of #1263 (CI never validates the definition against AWS).

- Name each branch state after its role: `RunLineSubmit`, `RunWordSubmit`, `RunLineIngest`, `RunWordIngest`
- Update `test_workflow_definitions.py` to resolve child states via each branch's `StartAt` and assert branch state names are unique, so a regression fails in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved backfill workflow branch identification with distinct names for submission and ingestion paths.
  * Enhanced workflow definitions to provide clearer state transitions and easier traceability during execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->