### PR TITLE
fix: accept UUIDv5 batch ids in assert_valid_uuid

### DIFF
--- a/receipt_dynamo/receipt_dynamo/entities/util.py
+++ b/receipt_dynamo/receipt_dynamo/entities/util.py
@@ -56,12 +56,12 @@ def assert_type(
         raise exc_type(format_type_error(name, value, expected))
 
 
-# Regex for UUID version 4 (case-insensitive, enforcing the '4' and the
-# [89AB] variant).
+# Regex for RFC-4122 UUIDs of version 4 (random) or version 5 (namespaced,
+# used for deterministic/idempotent batch ids), enforcing the [89AB] variant.
 UUID_V4_REGEX = re.compile(
     r"^[0-9A-Fa-f]{8}-"
     r"[0-9A-Fa-f]{4}-"
-    r"4[0-9A-Fa-f]{3}-"
+    r"[45][0-9A-Fa-f]{3}-"
     r"[89ABab][0-9A-Fa-f]{3}-"
     r"[0-9A-Fa-f]{12}$"
 )


### PR DESCRIPTION
#1263's idempotent submit path derives batch ids with `uuid5(NAMESPACE_URL, ...)` for dedup, but `assert_valid_uuid` enforces the version-4 nibble, so the first real `word-submit-sf`/`line-submit-sf` executions on dev failed at `get_batch_summary` with `uuid must be a valid UUIDv4`. CI missed it because the handlers' tests mock the Dynamo client.

Relax the regex to accept the v5 version nibble alongside v4 (same RFC-4122 variant enforcement). Error message intentionally unchanged — 38 existing tests assert its exact text. All 2,262 receipt_dynamo unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)