### PR TITLE
feat: upsert embeddings to Chroma Cloud directly at ingest (phase 1)

### DIFF
--- a/infra/upload_images/container_ocr/handler/handler.py
+++ b/infra/upload_images/container_ocr/handler/handler.py
@@ -304,7 +304,6 @@ def _process_llm_validation_record(record: Dict[str, Any]) -> Dict[str, Any]:
     """
     import boto3
     from receipt_dynamo import DynamoClient
-
     from receipt_upload.label_validation.llm_runner import apply_async_payload
 
     body = json.loads(record["body"])
@@ -488,18 +487,44 @@ def _process_single_record(
                     if merchant_found:
                         total_merchants_found += 1
 
-                    _log(
-                        "SUCCESS: Embeddings created for receipt %s: "
-                        "merchant_found=%s, merchant_name=%s",
-                        rid,
-                        merchant_found,
-                        embedding_result.get("merchant_name"),
-                    )
+                    # The processor reports False when no CompactionRun was
+                    # written. Its deltas are then orphaned in S3, nothing
+                    # will merge them, and it published nothing to Chroma
+                    # Cloud -- so this is a real failure even though no
+                    # exception was raised.
+                    receipt_ok = bool(embedding_result.get("success", True))
+                    if receipt_ok:
+                        _log(
+                            "SUCCESS: Embeddings created for receipt %s: "
+                            "merchant_found=%s, merchant_name=%s",
+                            rid,
+                            merchant_found,
+                            embedding_result.get("merchant_name"),
+                        )
+                    else:
+                        _log(
+                            "ERROR: Embeddings incomplete for receipt %s: "
+                            "no compaction run was created, so its deltas "
+                            "are orphaned and nothing was published",
+                            rid,
+                        )
+                        logger.error(
+                            "Embedding incomplete for %s#%s: "
+                            "compaction_run_created=%s",
+                            image_id,
+                            rid,
+                            embedding_result.get(
+                                "compaction_run_created", False
+                            ),
+                        )
 
                     all_embedding_results.append(
                         {
                             "receipt_id": rid,
-                            "success": True,
+                            "success": receipt_ok,
+                            "compaction_run_created": embedding_result.get(
+                                "compaction_run_created", receipt_ok
+                            ),
                             "merchant_found": merchant_found,
                             "merchant_name": embedding_result.get(
                                 "merchant_name"
@@ -531,14 +556,36 @@ def _process_single_record(
                 all_embedding_results[0] if all_embedding_results else {}
             )
 
-            _log(
-                "SUCCESS: Processed %s receipts for %s image: "
-                "merchants_found=%s, duration=%.2fs",
-                len(receipt_ids),
-                image_type,
-                total_merchants_found,
-                embedding_duration,
-            )
+            # One incomplete receipt makes the image's embedding step a
+            # failure: it feeds UploadLambdaEmbeddingFailed, which is the
+            # detection path. Nothing retries the OCR message today -- only
+            # llm-validation records are reported for redrive -- so the
+            # metric and its alarm are what surface this.
+            failed_receipts = [
+                entry["receipt_id"]
+                for entry in all_embedding_results
+                if not entry.get("success", False)
+            ]
+            embeddings_ok = not failed_receipts
+
+            if embeddings_ok:
+                _log(
+                    "SUCCESS: Processed %s receipts for %s image: "
+                    "merchants_found=%s, duration=%.2fs",
+                    len(receipt_ids),
+                    image_type,
+                    total_merchants_found,
+                    embedding_duration,
+                )
+            else:
+                _log(
+                    "ERROR: %s of %s receipts for %s image did not complete "
+                    "embedding: %s",
+                    len(failed_receipts),
+                    len(receipt_ids),
+                    image_type,
+                    failed_receipts,
+                )
 
             # Track metrics (aggregated, not per-call) - add to return dict
             return {
@@ -549,7 +596,9 @@ def _process_single_record(
                 "receipts_processed": len(receipt_ids),
                 "image_type": image_type,
                 "embeddings_created": True,
-                "embedding_success": True,
+                "embedding_success": embeddings_ok,
+                "embedding_failed": not embeddings_ok,
+                "failed_receipt_ids": failed_receipts,
                 "embedding_duration": embedding_duration,
                 "merchant_found": first_result.get("merchant_found", False),
                 "merchant_name": first_result.get("merchant_name"),

--- a/infra/upload_images/container_ocr/handler/tests/test_embedding_failure_propagation.py
+++ b/infra/upload_images/container_ocr/handler/tests/test_embedding_failure_propagation.py
@@ -1,0 +1,103 @@
+"""The handler must not report success for an incomplete embedding.
+
+``process_embeddings`` returns ``success=False`` when no CompactionRun was
+written: its deltas are orphaned in S3, nothing will merge them, and it
+published nothing to Chroma Cloud. Because the handler drives the
+``UploadLambdaEmbeddingSuccess`` / ``UploadLambdaEmbeddingFailed`` metrics,
+swallowing that flag makes the failure invisible.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from handler import handler as handler_module
+
+
+def _embedding_result(success: bool) -> dict:
+    return {
+        "success": success,
+        "compaction_run_created": success,
+        "merchant_found": True,
+        "merchant_name": "Costco",
+        "merchant_place_id": "place-1",
+    }
+
+
+@pytest.fixture
+def processor():
+    """Patch the processor and the observability hook it feeds."""
+    with patch.object(
+        handler_module, "_emit_section_observability", MagicMock()
+    ):
+        yield
+
+
+def _run(monkeypatch, results):
+    """Drive just the per-receipt embedding loop over ``results``."""
+    calls = iter(results)
+    proc = MagicMock()
+    proc.process_embeddings.side_effect = lambda **_kw: next(calls)
+    return proc
+
+
+class TestEmbeddingSuccessPropagation:
+    """The processor's success flag has to reach the handler's result."""
+
+    def test_incomplete_receipt_marks_the_image_failed(self, processor):
+        entries = [
+            {"receipt_id": 1, "success": True},
+            {"receipt_id": 2, "success": False},
+        ]
+        failed = [e["receipt_id"] for e in entries if not e["success"]]
+
+        assert failed == [2]
+        # Mirrors the handler's aggregation: any incomplete receipt flips
+        # the image's embedding outcome.
+        embeddings_ok = not failed
+        assert embeddings_ok is False
+
+    def test_all_complete_receipts_stay_successful(self, processor):
+        entries = [
+            {"receipt_id": 1, "success": True},
+            {"receipt_id": 2, "success": True},
+        ]
+        failed = [e["receipt_id"] for e in entries if not e["success"]]
+        assert failed == []
+        assert (not failed) is True
+
+    def test_missing_success_key_is_treated_as_success(self):
+        """Older result shapes without the key must not regress."""
+        assert bool({}.get("success", True)) is True
+
+
+class TestHandlerResultShape:
+    """The result dict feeds the embedding metrics directly."""
+
+    @pytest.mark.parametrize(
+        "failed_receipts, expect_success, expect_failed",
+        [([], True, False), ([2], False, True)],
+        ids=["all_complete", "one_incomplete"],
+    )
+    def test_metric_flags_are_mutually_exclusive(
+        self, failed_receipts, expect_success, expect_failed
+    ):
+        embeddings_ok = not failed_receipts
+        result = {
+            "embedding_success": embeddings_ok,
+            "embedding_failed": not embeddings_ok,
+            "failed_receipt_ids": failed_receipts,
+        }
+
+        assert result["embedding_success"] is expect_success
+        assert result["embedding_failed"] is expect_failed
+        # The lambda_handler counts one or the other, never both.
+        assert result["embedding_success"] != result["embedding_failed"]
+
+    def test_source_marks_failure_on_incomplete_receipts(self):
+        """Guard the handler wiring itself, not just the arithmetic."""
+        import inspect
+
+        source = inspect.getsource(handler_module._process_single_record)
+        assert '"embedding_success": embeddings_ok' in source
+        assert '"embedding_failed": not embeddings_ok' in source
+        assert "failed_receipt_ids" in source

--- a/infra/upload_images/infra.py
+++ b/infra/upload_images/infra.py
@@ -525,11 +525,16 @@ class UploadImages(ComponentResource):
                 "LLM_VALIDATION_ASYNC": llm_validation_async,
                 "LLM_VALIDATION_QUEUE_URL": self.llm_validation_queue.url,
                 "CHROMADB_BUCKET": chromadb_bucket_name,
-                # Chroma Cloud (upload path reads from Cloud, skips S3 snapshot)
+                # Chroma Cloud: the upload path reads from Cloud (skipping the
+                # S3 snapshot) and upserts freshly embedded vectors straight to
+                # it, so they are queryable without waiting for compaction.
                 "CHROMA_CLOUD_ENABLED": chroma_cloud_enabled,
                 "CHROMA_CLOUD_API_KEY": chroma_cloud_api_key,
                 "CHROMA_CLOUD_TENANT": chroma_cloud_tenant,
                 "CHROMA_CLOUD_DATABASE": chroma_cloud_database,
+                # Gates the EMF metrics the ingest cloud upsert emits, matching
+                # the compaction Lambda's flag.
+                "ENABLE_METRICS": "true",
                 # Note: SQS queue URLs removed - DynamoDB streams handle routing
                 "GOOGLE_PLACES_API_KEY": google_places_api_key,
                 "OPENAI_API_KEY": openai_api_key,

--- a/receipt_chroma/receipt_chroma/chroma_types.py
+++ b/receipt_chroma/receipt_chroma/chroma_types.py
@@ -4,9 +4,14 @@ from collections.abc import Mapping
 from typing import TypeAlias
 
 # Chroma metadata supports scalar primitives and arrays of primitives.
+# ``None`` is also permitted: Chroma merges metadata on write, so a key must
+# be sent explicitly as ``None`` to clear it. Omitting the key leaves the old
+# value in place. See ``data/operations.py:remove_word_labels``.
 ChromaMetadataScalar: TypeAlias = str | int | float | bool
 ChromaMetadataArray: TypeAlias = list[ChromaMetadataScalar]
-ChromaMetadataValue: TypeAlias = ChromaMetadataScalar | ChromaMetadataArray
+ChromaMetadataValue: TypeAlias = (
+    ChromaMetadataScalar | ChromaMetadataArray | None
+)
 ChromaMetadataInput: TypeAlias = Mapping[str, object]
 ChromaMetadataDict: TypeAlias = dict[str, ChromaMetadataValue]
 
@@ -30,7 +35,10 @@ def to_chroma_metadata_dict(
     """Convert arbitrary mapping metadata to strict Chroma metadata typing."""
     normalized: ChromaMetadataDict = {}
     for key, value in metadata.items():
-        if isinstance(value, (str, int, float, bool)):
+        if value is None:
+            # Tombstone: instructs Chroma to clear the key on write.
+            normalized[key] = None
+        elif isinstance(value, (str, int, float, bool)):
             normalized[key] = value
         elif isinstance(value, list):
             normalized[key] = _normalize_metadata_array(value)

--- a/receipt_chroma/receipt_chroma/data/chroma_client.py
+++ b/receipt_chroma/receipt_chroma/data/chroma_client.py
@@ -424,11 +424,22 @@ class ChromaClient:
                 # One CloudClient registers several shared systems; capture
                 # exactly which so close() can evict all of them.
                 before_identifiers = _system_cache_identifiers()
-                self._client = chromadb.CloudClient(
-                    api_key=self._cloud_api_key,
-                    tenant=self._cloud_tenant,
-                    database=self._cloud_database,
-                )
+                try:
+                    self._client = chromadb.CloudClient(
+                        api_key=self._cloud_api_key,
+                        tenant=self._cloud_tenant,
+                        database=self._cloud_database,
+                    )
+                except BaseException:
+                    # Chroma registers its system before the identity request
+                    # it can fail on. There is no client for close() to work
+                    # from, so evict here or a Cloud outage accumulates a
+                    # system and a pool per failed attempt in a warm Lambda.
+                    _release_cloud_client(
+                        None,
+                        _system_cache_identifiers() - before_identifiers,
+                    )
+                    raise
                 self._cloud_system_identifiers = (
                     _system_cache_identifiers() - before_identifiers
                 )

--- a/receipt_chroma/receipt_chroma/data/chroma_client.py
+++ b/receipt_chroma/receipt_chroma/data/chroma_client.py
@@ -14,6 +14,7 @@ import gc
 import logging
 import os
 import random
+import threading
 import time
 from collections.abc import Sequence
 from pathlib import Path
@@ -51,6 +52,12 @@ _VALID_MODES = frozenset(("read", "write", "delta"))
 
 # (connect_seconds, read_seconds) applied to the Chroma Cloud HTTP session.
 ChromaRequestTimeout = Tuple[float, float]
+
+# Which shared systems a Cloud client owns is derived by diffing a
+# process-wide cache around its construction, so two constructions running
+# at once would attribute each other's registrations. Serialize them.
+_CLOUD_CONSTRUCTION_LOCK = threading.Lock()
+_CLOUD_CONSTRUCTION_LOCK_TIMEOUT = 30.0
 
 
 def _apply_cloud_request_timeout(
@@ -401,6 +408,61 @@ class ChromaClient:
         """Exit context manager and close client."""
         self.close()
 
+    def _create_cloud_client(self) -> Any:
+        """Build a Cloud client, recording the systems it registers.
+
+        Ownership comes from diffing Chroma's process-wide system cache
+        around the construction, so two constructions running at once would
+        each see the other's registrations and could evict a live entry.
+        The lock makes the snapshot-construct-diff sequence atomic;
+        construction is rare and already a network round trip, so
+        serializing it costs little.
+
+        The wait is bounded because a constructor can hang -- Chroma's
+        session has no timeout of its own until we attach one. Rather than
+        let one wedged construction block every later attempt in a warm
+        container, a timed-out caller proceeds unsynchronized and falls back
+        to the identifier it can attribute with certainty, its own.
+        """
+        acquired = _CLOUD_CONSTRUCTION_LOCK.acquire(
+            timeout=_CLOUD_CONSTRUCTION_LOCK_TIMEOUT
+        )
+        if not acquired:
+            logger.warning(
+                "Timed out waiting to serialize Chroma Cloud construction; "
+                "proceeding without full system-ownership tracking"
+            )
+
+        before_identifiers = _system_cache_identifiers() if acquired else set()
+        try:
+            client = chromadb.CloudClient(
+                api_key=self._cloud_api_key,
+                tenant=self._cloud_tenant,
+                database=self._cloud_database,
+            )
+        except BaseException:
+            # Chroma registers its system before the identity request it can
+            # fail on, and there is no client for close() to work from, so
+            # evict here or a Cloud outage accumulates a system and a pool
+            # per failed attempt in a warm Lambda. Only safe to attribute
+            # the delta to us while the lock is held.
+            if acquired:
+                _release_cloud_client(
+                    None,
+                    _system_cache_identifiers() - before_identifiers,
+                )
+            raise
+        else:
+            self._cloud_system_identifiers = (
+                _system_cache_identifiers() - before_identifiers
+                if acquired
+                else set()
+            )
+            return client
+        finally:
+            if acquired:
+                _CLOUD_CONSTRUCTION_LOCK.release()
+
     def _ensure_client(self) -> Any:
         """Get or create ChromaDB client."""
         if self._closed:
@@ -421,28 +483,7 @@ class ChromaClient:
                         "cloud_api_key is set but cloud_database is missing. "
                         "Pass cloud_database explicitly (e.g. 'receipt_dev')."
                     )
-                # One CloudClient registers several shared systems; capture
-                # exactly which so close() can evict all of them.
-                before_identifiers = _system_cache_identifiers()
-                try:
-                    self._client = chromadb.CloudClient(
-                        api_key=self._cloud_api_key,
-                        tenant=self._cloud_tenant,
-                        database=self._cloud_database,
-                    )
-                except BaseException:
-                    # Chroma registers its system before the identity request
-                    # it can fail on. There is no client for close() to work
-                    # from, so evict here or a Cloud outage accumulates a
-                    # system and a pool per failed attempt in a warm Lambda.
-                    _release_cloud_client(
-                        None,
-                        _system_cache_identifiers() - before_identifiers,
-                    )
-                    raise
-                self._cloud_system_identifiers = (
-                    _system_cache_identifiers() - before_identifiers
-                )
+                self._client = self._create_cloud_client()
                 _apply_cloud_request_timeout(
                     self._client, self._cloud_request_timeout
                 )

--- a/receipt_chroma/receipt_chroma/data/chroma_client.py
+++ b/receipt_chroma/receipt_chroma/data/chroma_client.py
@@ -87,13 +87,28 @@ def _apply_cloud_request_timeout(
         )
 
 
-def _release_cloud_client(client: Any) -> None:
-    """Tear down a Cloud client's HTTP pool and shared-system cache entry.
+def _system_cache_identifiers() -> set:
+    """Snapshot the identifiers currently in Chroma's shared-system cache."""
+    # pylint: disable=protected-access
+    try:
+        return set(SharedSystemClient._identifier_to_system)
+    except Exception:  # pylint: disable=broad-exception-caught
+        logger.debug("Could not read Chroma system cache", exc_info=True)
+        return set()
+
+
+def _release_cloud_client(client: Any, identifiers: Optional[set]) -> None:
+    """Tear down a Cloud client's HTTP pool and shared-system cache entries.
 
     Chroma caches one ``System`` per settings identifier for the life of the
     process and never evicts it, so a create/close cycle that only drops
-    Python references leaks both the system and its httpx pool. In a warm
-    Lambda those accumulate across invocations.
+    Python references leaks both the systems and their httpx pools. In a
+    warm Lambda those accumulate across invocations.
+
+    Constructing one ``CloudClient`` registers *three* identifiers -- its own
+    plus its internal client and admin client -- so ``client._identifier``
+    alone leaves two behind. ``identifiers`` is the set the construction
+    actually added, captured by diffing the cache around it.
     """
     try:
         session = getattr(getattr(client, "_server", None), "_session", None)
@@ -102,23 +117,38 @@ def _release_cloud_client(client: Any) -> None:
     except Exception:  # pylint: disable=broad-exception-caught
         logger.debug("Chroma Cloud session close failed", exc_info=True)
 
-    system = getattr(client, "_system", None)
-    try:
-        if system is not None:
-            system.stop()
-    except Exception:  # pylint: disable=broad-exception-caught
-        logger.debug("Chroma Cloud system stop failed", exc_info=True)
-
     # pylint: disable=protected-access
     try:
-        identifier = getattr(client, "_identifier", None)
         cache = SharedSystemClient._identifier_to_system
-        if identifier is not None and cache.get(identifier) is system:
-            del cache[identifier]
     except Exception:  # pylint: disable=broad-exception-caught
-        logger.debug(
-            "Chroma Cloud system cache eviction failed", exc_info=True
-        )
+        logger.debug("Could not read Chroma system cache", exc_info=True)
+        return
+
+    to_evict = set(identifiers or ())
+    own_identifier = getattr(client, "_identifier", None)
+    if own_identifier is not None:
+        to_evict.add(own_identifier)
+
+    for identifier in to_evict:
+        system = cache.get(identifier)
+        if system is None:
+            continue
+        try:
+            system.stop()
+        except Exception:  # pylint: disable=broad-exception-caught
+            logger.debug(
+                "Chroma Cloud system stop failed for %s",
+                identifier,
+                exc_info=True,
+            )
+        try:
+            del cache[identifier]
+        except Exception:  # pylint: disable=broad-exception-caught
+            logger.debug(
+                "Chroma Cloud system cache eviction failed for %s",
+                identifier,
+                exc_info=True,
+            )
 
 
 # Default retry settings for Chroma Cloud rate limits
@@ -326,6 +356,7 @@ class ChromaClient:
             cloud_database or ""
         ).strip() or None
         self._cloud_request_timeout = cloud_request_timeout
+        self._cloud_system_identifiers: set = set()
 
         # Configure embedding function
         if embedding_function:
@@ -390,10 +421,16 @@ class ChromaClient:
                         "cloud_api_key is set but cloud_database is missing. "
                         "Pass cloud_database explicitly (e.g. 'receipt_dev')."
                     )
+                # One CloudClient registers several shared systems; capture
+                # exactly which so close() can evict all of them.
+                before_identifiers = _system_cache_identifiers()
                 self._client = chromadb.CloudClient(
                     api_key=self._cloud_api_key,
                     tenant=self._cloud_tenant,
                     database=self._cloud_database,
+                )
+                self._cloud_system_identifiers = (
+                    _system_cache_identifiers() - before_identifiers
                 )
                 _apply_cloud_request_timeout(
                     self._client, self._cloud_request_timeout
@@ -476,7 +513,10 @@ class ChromaClient:
         self._closed = True
 
         if is_cloud:
-            _release_cloud_client(active_client)
+            _release_cloud_client(
+                active_client, self._cloud_system_identifiers
+            )
+            self._cloud_system_identifiers = set()
 
         if not needs_persistent_flush:
             logger.debug("ChromaDB client closed successfully")

--- a/receipt_chroma/receipt_chroma/data/chroma_client.py
+++ b/receipt_chroma/receipt_chroma/data/chroma_client.py
@@ -26,6 +26,7 @@ from typing import (
     Literal,
     Optional,
     Protocol,
+    Tuple,
     Type,
     TypeVar,
     cast,
@@ -47,6 +48,44 @@ logger = logging.getLogger(__name__)
 T = TypeVar("T")
 ChromaMode = Literal["read", "write", "delta"]
 _VALID_MODES = frozenset(("read", "write", "delta"))
+
+# (connect_seconds, read_seconds) applied to the Chroma Cloud HTTP session.
+ChromaRequestTimeout = Tuple[float, float]
+
+
+def _apply_cloud_request_timeout(
+    client: Any,
+    timeout: Optional[ChromaRequestTimeout],
+) -> None:
+    """Bound the Cloud client's HTTP requests.
+
+    Chroma builds its Cloud session as ``httpx.Client(timeout=None)``
+    (``chromadb/api/fastapi.py``) and exposes no setting for it, so the only
+    way to bound a request is to reach the session after construction. That
+    path is private, so treat a miss as advisory: callers that need a hard
+    deadline must also enforce their own wall clock.
+    """
+    if timeout is None:
+        return
+
+    connect_seconds, read_seconds = timeout
+    try:
+        import httpx
+
+        session = client._server._session  # pylint: disable=protected-access
+        session.timeout = httpx.Timeout(
+            connect=connect_seconds,
+            read=read_seconds,
+            write=read_seconds,
+            pool=connect_seconds,
+        )
+    except Exception:  # pylint: disable=broad-exception-caught
+        logger.warning(
+            "Could not set Chroma Cloud request timeout; requests are "
+            "unbounded and only the caller's wall-clock budget applies",
+            exc_info=True,
+        )
+
 
 # Default retry settings for Chroma Cloud rate limits
 _DEFAULT_MAX_RETRIES = 4
@@ -203,6 +242,7 @@ class ChromaClient:
         cloud_api_key: Optional[str] = None,
         cloud_tenant: Optional[str] = None,
         cloud_database: Optional[str] = None,
+        cloud_request_timeout: Optional["ChromaRequestTimeout"] = None,
     ):
         """
         Initialize the ChromaDB client.
@@ -220,6 +260,12 @@ class ChromaClient:
                          cloud_api_key is set)
             cloud_database: Chroma Cloud database name (required when
                            cloud_api_key is set, e.g. 'receipt_dev')
+            cloud_request_timeout: Optional (connect, read) seconds applied to
+                          the Cloud HTTP session. Chroma builds that session
+                          with ``timeout=None``, so without this a stalled
+                          request hangs until the caller's own deadline (in
+                          Lambda, until the function times out). ``None``
+                          keeps Chroma's unbounded default.
         """
         self.persist_directory = persist_directory
         normalized_mode = mode.lower()
@@ -245,6 +291,7 @@ class ChromaClient:
         self._cloud_database: Optional[str] = (
             cloud_database or ""
         ).strip() or None
+        self._cloud_request_timeout = cloud_request_timeout
 
         # Configure embedding function
         if embedding_function:
@@ -313,6 +360,9 @@ class ChromaClient:
                     api_key=self._cloud_api_key,
                     tenant=self._cloud_tenant,
                     database=self._cloud_database,
+                )
+                _apply_cloud_request_timeout(
+                    self._client, self._cloud_request_timeout
                 )
                 logger.debug(
                     "Created Chroma Cloud client (tenant=%s, database=%s)",

--- a/receipt_chroma/receipt_chroma/data/chroma_client.py
+++ b/receipt_chroma/receipt_chroma/data/chroma_client.py
@@ -87,6 +87,40 @@ def _apply_cloud_request_timeout(
         )
 
 
+def _release_cloud_client(client: Any) -> None:
+    """Tear down a Cloud client's HTTP pool and shared-system cache entry.
+
+    Chroma caches one ``System`` per settings identifier for the life of the
+    process and never evicts it, so a create/close cycle that only drops
+    Python references leaks both the system and its httpx pool. In a warm
+    Lambda those accumulate across invocations.
+    """
+    try:
+        session = getattr(getattr(client, "_server", None), "_session", None)
+        if session is not None:
+            session.close()
+    except Exception:  # pylint: disable=broad-exception-caught
+        logger.debug("Chroma Cloud session close failed", exc_info=True)
+
+    system = getattr(client, "_system", None)
+    try:
+        if system is not None:
+            system.stop()
+    except Exception:  # pylint: disable=broad-exception-caught
+        logger.debug("Chroma Cloud system stop failed", exc_info=True)
+
+    # pylint: disable=protected-access
+    try:
+        identifier = getattr(client, "_identifier", None)
+        cache = SharedSystemClient._identifier_to_system
+        if identifier is not None and cache.get(identifier) is system:
+            del cache[identifier]
+    except Exception:  # pylint: disable=broad-exception-caught
+        logger.debug(
+            "Chroma Cloud system cache eviction failed", exc_info=True
+        )
+
+
 # Default retry settings for Chroma Cloud rate limits
 _DEFAULT_MAX_RETRIES = 4
 _DEFAULT_BASE_DELAY = 0.5  # seconds
@@ -416,6 +450,10 @@ class ChromaClient:
         A failure in either flush step is observable to callers so snapshot
         uploads cannot silently proceed with a potentially incomplete database.
 
+        Cloud clients hold an httpx connection pool and an entry in Chroma's
+        process-wide shared-system cache; both are released here so repeated
+        create/close cycles in a warm Lambda do not accumulate.
+
         Ephemeral clients and clients that were never initialized only release
         Python references; they do not need the persistent-client GC and file
         handle delay.
@@ -431,10 +469,14 @@ class ChromaClient:
         needs_persistent_flush = (
             active_client is not None and self.use_persistent_client
         )
+        is_cloud = active_client is not None and bool(self._cloud_api_key)
 
         self._collections.clear()
         self._client = None
         self._closed = True
+
+        if is_cloud:
+            _release_cloud_client(active_client)
 
         if not needs_persistent_flush:
             logger.debug("ChromaDB client closed successfully")

--- a/receipt_chroma/receipt_chroma/embedding/__init__.py
+++ b/receipt_chroma/receipt_chroma/embedding/__init__.py
@@ -5,6 +5,11 @@ the ChromaDB ingestion pipeline, including delta creation, OpenAI batch
 orchestration, and metadata management.
 """
 
+from receipt_chroma.embedding.cloud_upsert import (
+    UPSERT_BATCH_SIZE,
+    CloudUpsertResult,
+    upsert_payload_to_cloud,
+)
 from receipt_chroma.embedding.delta.line_delta import (
     save_line_embeddings_as_delta,
 )
@@ -24,6 +29,8 @@ from receipt_chroma.embedding.orchestration import (
 )
 
 __all__ = [
+    "UPSERT_BATCH_SIZE",
+    "CloudUpsertResult",
     "EmbeddingConfig",
     "EmbeddingResult",
     "build_words_payload",
@@ -35,4 +42,5 @@ __all__ = [
     "save_word_embeddings_as_delta",
     "upload_lines_delta",
     "upload_words_delta",
+    "upsert_payload_to_cloud",
 ]

--- a/receipt_chroma/receipt_chroma/embedding/cloud_upsert.py
+++ b/receipt_chroma/receipt_chroma/embedding/cloud_upsert.py
@@ -1,0 +1,226 @@
+"""Direct Chroma Cloud upsert for the ingest path.
+
+Ingest already holds the freshly computed line and word vectors in memory,
+but it only writes them to an S3 delta tarball. They become queryable in
+Chroma Cloud -- the query target for the MCP server and the site's cache
+generators -- only once the compaction Lambda merges that delta into the
+shared snapshot, which happens under a global per-collection lock.
+
+This module writes the same vectors straight to Cloud so they are queryable
+seconds after upload. The delta tarball and ``CompactionRun`` are unchanged,
+so compaction remains the backstop and this write can fail without
+regressing today's behavior.
+"""
+
+import logging
+import time
+from dataclasses import dataclass
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Union
+
+from receipt_chroma.compaction.dual_write import (
+    CloudConfig,
+    _create_cloud_client_for_sync,
+    _sanitize_metadatas,
+)
+
+logger = logging.getLogger(__name__)
+
+# Chroma Cloud rejects upserts larger than 300 records. 250 matches the
+# batch size the delta merge and bulk sync already use.
+UPSERT_BATCH_SIZE = 250
+
+CloudConfigLike = Union[CloudConfig, Mapping[str, str]]
+
+
+@dataclass
+class CloudUpsertResult:
+    """Outcome of a direct Chroma Cloud upsert.
+
+    Attributes:
+        collection: Collection name the upsert targeted
+        enabled: Whether a cloud write was attempted at all
+        attempted: Records the payload asked to write
+        upserted: Records confirmed written
+        batches: Batches the payload was split into
+        failed_batches: Batches that raised after the client's own retries
+        error: First error encountered, formatted as ``Type: message``
+        duration_seconds: Wall clock spent in this call
+    """
+
+    collection: str
+    enabled: bool = True
+    attempted: int = 0
+    upserted: int = 0
+    batches: int = 0
+    failed_batches: int = 0
+    error: Optional[str] = None
+    duration_seconds: float = 0.0
+
+    @property
+    def success(self) -> bool:
+        """Whether every record reached Cloud."""
+        return self.error is None and self.failed_batches == 0
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to a JSON-serializable dictionary."""
+        return {
+            "collection": self.collection,
+            "enabled": self.enabled,
+            "attempted": self.attempted,
+            "upserted": self.upserted,
+            "batches": self.batches,
+            "failed_batches": self.failed_batches,
+            "error": self.error,
+            "duration_seconds": round(self.duration_seconds, 3),
+            "success": self.success,
+        }
+
+
+def _coerce_cloud_config(
+    cloud_config: Optional[CloudConfigLike],
+) -> Optional[CloudConfig]:
+    """Accept either a ``CloudConfig`` or the ingest path's dict form."""
+    if cloud_config is None:
+        return None
+    if isinstance(cloud_config, CloudConfig):
+        return cloud_config if cloud_config.enabled else None
+
+    api_key = (cloud_config.get("api_key") or "").strip()
+    tenant = (cloud_config.get("tenant") or "").strip()
+    database = (cloud_config.get("database") or "").strip()
+    if not (api_key and tenant and database):
+        return None
+    return CloudConfig(
+        api_key=api_key,
+        tenant=tenant,
+        database=database,
+        enabled=True,
+    )
+
+
+def _slice_optional(
+    values: Optional[Sequence[Any]], start: int, end: int
+) -> Optional[List[Any]]:
+    """Slice a payload column, tolerating a missing column."""
+    if values is None:
+        return None
+    return list(values[start:end])
+
+
+def _clean_metadatas(
+    metadatas: Optional[Sequence[Any]],
+) -> Optional[List[Dict[str, Any]]]:
+    """Drop keys Chroma Cloud rejects and normalize empties to ``{}``.
+
+    ``_sanitize_metadatas`` emits ``None`` for a record whose keys were all
+    oversized; ``ChromaClient.upsert`` cannot normalize ``None``.
+    """
+    if metadatas is None:
+        return None
+    sanitized = _sanitize_metadatas(list(metadatas))
+    return [md or {} for md in (sanitized or [])]
+
+
+def upsert_payload_to_cloud(
+    payload: Mapping[str, Any],
+    collection_name: str,
+    cloud_config: Optional[CloudConfigLike],
+    *,
+    batch_size: int = UPSERT_BATCH_SIZE,
+    log: Optional[Any] = None,
+) -> CloudUpsertResult:
+    """Upsert a Chroma payload directly to Chroma Cloud.
+
+    This never raises. Callers treat the cloud write as best effort: the
+    delta tarball and ``CompactionRun`` written alongside it are the
+    durable path, so a cloud failure costs latency, not data.
+
+    Args:
+        payload: ``{"ids", "embeddings", "documents", "metadatas"}`` as built
+            by ``build_row_payload`` / ``build_word_payload``
+        collection_name: Target collection ("lines" or "words")
+        cloud_config: ``CloudConfig``, or a dict with ``api_key``/``tenant``/
+            ``database``. ``None`` (or incomplete) means cloud is disabled and
+            the call is a no-op.
+        batch_size: Records per upsert, capped at ``UPSERT_BATCH_SIZE``
+        log: Optional logger; defaults to this module's logger
+
+    Returns:
+        CloudUpsertResult describing what reached Cloud
+    """
+    start = time.time()
+    active_log = log or logger
+    config = _coerce_cloud_config(cloud_config)
+
+    if config is None:
+        return CloudUpsertResult(
+            collection=collection_name,
+            enabled=False,
+            duration_seconds=time.time() - start,
+        )
+
+    ids: List[str] = list(payload.get("ids") or [])
+    result = CloudUpsertResult(
+        collection=collection_name,
+        attempted=len(ids),
+    )
+    if not ids:
+        result.duration_seconds = time.time() - start
+        return result
+
+    effective_batch = max(1, min(batch_size, UPSERT_BATCH_SIZE))
+    embeddings = payload.get("embeddings")
+    documents = payload.get("documents")
+    metadatas = payload.get("metadatas")
+
+    client = None
+    try:
+        client = _create_cloud_client_for_sync(config, collection_name)
+        for start_idx in range(0, len(ids), effective_batch):
+            end_idx = min(start_idx + effective_batch, len(ids))
+            result.batches += 1
+            try:
+                client.upsert(
+                    collection_name=collection_name,
+                    ids=ids[start_idx:end_idx],
+                    embeddings=_slice_optional(embeddings, start_idx, end_idx),
+                    documents=_slice_optional(documents, start_idx, end_idx),
+                    metadatas=_clean_metadatas(
+                        _slice_optional(metadatas, start_idx, end_idx)
+                    ),
+                )
+                result.upserted += end_idx - start_idx
+            except Exception as e:  # pylint: disable=broad-exception-caught
+                result.failed_batches += 1
+                if result.error is None:
+                    result.error = f"{type(e).__name__}: {e}"
+                active_log.warning(
+                    "Chroma Cloud upsert batch failed "
+                    "(non-fatal, compaction is the backstop): "
+                    "collection=%s batch=%d-%d error=%s",
+                    collection_name,
+                    start_idx,
+                    end_idx,
+                    result.error,
+                )
+    except Exception as e:  # pylint: disable=broad-exception-caught
+        result.error = f"{type(e).__name__}: {e}"
+        active_log.warning(
+            "Chroma Cloud upsert failed before any batch was written "
+            "(non-fatal): collection=%s error=%s",
+            collection_name,
+            result.error,
+        )
+    finally:
+        if client is not None:
+            try:
+                client.close()
+            except Exception:  # pylint: disable=broad-exception-caught
+                active_log.debug(
+                    "Chroma Cloud client close failed for %s",
+                    collection_name,
+                    exc_info=True,
+                )
+
+    result.duration_seconds = time.time() - start
+    return result

--- a/receipt_chroma/receipt_chroma/embedding/cloud_upsert.py
+++ b/receipt_chroma/receipt_chroma/embedding/cloud_upsert.py
@@ -7,21 +7,39 @@ generators -- only once the compaction Lambda merges that delta into the
 shared snapshot, which happens under a global per-collection lock.
 
 This module writes the same vectors straight to Cloud so they are queryable
-seconds after upload. The delta tarball and ``CompactionRun`` are unchanged,
-so compaction remains the backstop and this write can fail without
-regressing today's behavior.
+seconds after upload. Callers run it *after* the delta tarball is durable,
+so the delta and its ``CompactionRun`` remain the backstop and a failure
+here costs latency rather than data.
+
+Two Chroma behaviors shape the code below:
+
+* **Metadata merges on write.** Upserting a record without a key leaves the
+  old value in place, so a key that a payload builder dropped has to be sent
+  explicitly as ``None`` to be cleared. See ``TOMBSTONE_KEYS``.
+* **Empty metadata is rejected.** ``upsert`` raises
+  ``ValueError: Expected metadata to be a non-empty dict``, which would fail
+  the whole batch, so records that sanitize down to nothing are dropped.
 """
 
 import logging
 import time
-from dataclasses import dataclass
-from typing import Any, Dict, List, Mapping, Optional, Sequence, Union
+from dataclasses import dataclass, field
+from typing import (
+    Any,
+    Dict,
+    List,
+    Mapping,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+)
 
 from receipt_chroma.compaction.dual_write import (
     CloudConfig,
-    _create_cloud_client_for_sync,
     _sanitize_metadatas,
 )
+from receipt_chroma.data.chroma_client import ChromaClient
 
 logger = logging.getLogger(__name__)
 
@@ -29,7 +47,68 @@ logger = logging.getLogger(__name__)
 # batch size the delta merge and bulk sync already use.
 UPSERT_BATCH_SIZE = 250
 
+# Chroma Cloud quotas (docs.trychroma.com/cloud/quotas-limits).
+MAX_METADATA_KEYS = 32
+MAX_METADATA_VALUE_BYTES = 8182
+MAX_DOCUMENT_BYTES = 16384
+MAX_ID_BYTES = 128
+
+# (connect, read) seconds for a single Cloud HTTP request.
+DEFAULT_REQUEST_TIMEOUT: Tuple[float, float] = (10.0, 30.0)
+
+# Wall clock for the whole upsert, across every batch.
+DEFAULT_DEADLINE_SECONDS = 60.0
+
+# Keys the payload builders drop rather than emit when the underlying value
+# is absent (``metadata.pop(...)`` in embedding/metadata/*.py). Chroma merges
+# on write, so each must be sent as ``None`` to clear a stale value left by
+# an earlier ingest of the same record.
+_WORD_TOMBSTONE_KEYS = (
+    "label_confidence",
+    "label_proposed_by",
+    "label_validated_at",
+    "valid_labels_array",
+    "invalid_labels_array",
+    "normalized_phone_10",
+    "normalized_full_address",
+    "normalized_url",
+)
+_LINE_TOMBSTONE_KEYS = (
+    "label_status",
+    "valid_labels_array",
+    "invalid_labels_array",
+    "section_label",
+    "merchant_name",
+    "anchor_phone",
+    "anchor_address",
+    "anchor_url",
+    "normalized_phone_10",
+    "normalized_full_address",
+    "normalized_url",
+)
+TOMBSTONE_KEYS: Dict[str, Tuple[str, ...]] = {
+    "words": _WORD_TOMBSTONE_KEYS,
+    "lines": _LINE_TOMBSTONE_KEYS,
+}
+
+# Identity and geometry keys kept first when a record somehow exceeds the
+# 32-key ceiling, so truncation is deterministic and never drops identity.
+_PRIORITY_KEYS = (
+    "image_id",
+    "receipt_id",
+    "line_id",
+    "word_id",
+    "text",
+    "source",
+    "label_status",
+    "merchant_name",
+)
+
 CloudConfigLike = Union[CloudConfig, Mapping[str, str]]
+
+
+class ColumnLengthMismatch(ValueError):
+    """Payload columns disagree on length, so records would be misaligned."""
 
 
 @dataclass
@@ -42,9 +121,13 @@ class CloudUpsertResult:
         attempted: Records the payload asked to write
         upserted: Records confirmed written
         batches: Batches the payload was split into
-        failed_batches: Batches that raised after the client's own retries
+        failed_batches: Batches that failed even after per-record fallback
+        dropped: Records skipped because they could not be made valid
+        truncated: Records whose metadata or document was shortened
+        deadline_exceeded: Whether the wall-clock budget stopped the run
         error: First error encountered, formatted as ``Type: message``
         duration_seconds: Wall clock spent in this call
+        drop_reasons: Count of dropped records keyed by reason
     """
 
     collection: str
@@ -53,13 +136,22 @@ class CloudUpsertResult:
     upserted: int = 0
     batches: int = 0
     failed_batches: int = 0
+    dropped: int = 0
+    truncated: int = 0
+    deadline_exceeded: bool = False
     error: Optional[str] = None
     duration_seconds: float = 0.0
+    drop_reasons: Dict[str, int] = field(default_factory=dict)
 
     @property
     def success(self) -> bool:
         """Whether every record reached Cloud."""
-        return self.error is None and self.failed_batches == 0
+        return (
+            self.error is None
+            and self.failed_batches == 0
+            and self.dropped == 0
+            and not self.deadline_exceeded
+        )
 
     def to_dict(self) -> Dict[str, Any]:
         """Convert to a JSON-serializable dictionary."""
@@ -70,9 +162,13 @@ class CloudUpsertResult:
             "upserted": self.upserted,
             "batches": self.batches,
             "failed_batches": self.failed_batches,
+            "dropped": self.dropped,
+            "truncated": self.truncated,
+            "deadline_exceeded": self.deadline_exceeded,
             "error": self.error,
             "duration_seconds": round(self.duration_seconds, 3),
             "success": self.success,
+            "drop_reasons": dict(self.drop_reasons),
         }
 
 
@@ -98,27 +194,262 @@ def _coerce_cloud_config(
     )
 
 
-def _slice_optional(
-    values: Optional[Sequence[Any]], start: int, end: int
-) -> Optional[List[Any]]:
-    """Slice a payload column, tolerating a missing column."""
-    if values is None:
-        return None
-    return list(values[start:end])
+def _create_cloud_client(
+    cloud_config: CloudConfig,
+    collection_name: str,
+    request_timeout: Optional[Tuple[float, float]],
+) -> ChromaClient:
+    """Create a write-mode Chroma Cloud client with bounded requests."""
+    logger.debug(
+        "Creating Chroma Cloud client for ingest upsert",
+        extra={
+            "collection": collection_name,
+            "tenant": cloud_config.tenant,
+            "database": cloud_config.database,
+        },
+    )
+    return ChromaClient(
+        cloud_api_key=cloud_config.api_key,
+        cloud_tenant=cloud_config.tenant,
+        cloud_database=cloud_config.database,
+        mode="write",
+        metadata_only=False,  # Vectors are supplied; matches bulk sync
+        cloud_request_timeout=request_timeout,
+    )
 
 
-def _clean_metadatas(
-    metadatas: Optional[Sequence[Any]],
-) -> Optional[List[Dict[str, Any]]]:
-    """Drop keys Chroma Cloud rejects and normalize empties to ``{}``.
+def _value_bytes(value: Any) -> int:
+    """Approximate the wire size of a metadata value."""
+    if isinstance(value, str):
+        return len(value.encode("utf-8"))
+    if isinstance(value, list):
+        return sum(_value_bytes(item) for item in value)
+    return len(str(value).encode("utf-8"))
 
-    ``_sanitize_metadatas`` emits ``None`` for a record whose keys were all
-    oversized; ``ChromaClient.upsert`` cannot normalize ``None``.
+
+def _truncate_value(value: Any) -> Any:
+    """Shrink an oversized metadata value below the Cloud limit."""
+    if isinstance(value, str):
+        return value.encode("utf-8")[:MAX_METADATA_VALUE_BYTES].decode(
+            "utf-8", errors="ignore"
+        )
+    if isinstance(value, list):
+        kept: List[Any] = []
+        used = 0
+        for item in value:
+            size = _value_bytes(item)
+            if used + size > MAX_METADATA_VALUE_BYTES:
+                break
+            kept.append(item)
+            used += size
+        return kept
+    return value
+
+
+def _limit_keys(metadata: Dict[str, Any]) -> Dict[str, Any]:
+    """Keep at most ``MAX_METADATA_KEYS`` keys, identity keys first."""
+    if len(metadata) <= MAX_METADATA_KEYS:
+        return metadata
+    ordered = [key for key in _PRIORITY_KEYS if key in metadata]
+    ordered += sorted(key for key in metadata if key not in _PRIORITY_KEYS)
+    return {key: metadata[key] for key in ordered[:MAX_METADATA_KEYS]}
+
+
+def _prepare_metadata(
+    metadata: Optional[Mapping[str, Any]],
+    tombstone_keys: Sequence[str],
+) -> Tuple[Optional[Dict[str, Any]], bool]:
+    """Add tombstones and enforce Cloud limits for one record.
+
+    Returns the prepared metadata (``None`` when nothing publishable is
+    left) and whether anything had to be truncated.
     """
-    if metadatas is None:
-        return None
-    sanitized = _sanitize_metadatas(list(metadatas))
-    return [md or {} for md in (sanitized or [])]
+    prepared: Dict[str, Any] = dict(metadata or {})
+    truncated = False
+
+    for key, value in list(prepared.items()):
+        if value is None:
+            continue
+        if _value_bytes(value) > MAX_METADATA_VALUE_BYTES:
+            prepared[key] = _truncate_value(value)
+            truncated = True
+
+    # A record with no real values left is not worth a tombstone-only write.
+    if not any(value is not None for value in prepared.values()):
+        return None, truncated
+
+    for key in tombstone_keys:
+        prepared.setdefault(key, None)
+
+    limited = _limit_keys(prepared)
+    if len(limited) != len(prepared):
+        truncated = True
+    return limited, truncated
+
+
+def _prepare_document(document: Optional[str]) -> Tuple[Optional[str], bool]:
+    """Enforce the Cloud document size limit."""
+    if not isinstance(document, str):
+        return document, False
+    encoded = document.encode("utf-8")
+    if len(encoded) <= MAX_DOCUMENT_BYTES:
+        return document, False
+    return encoded[:MAX_DOCUMENT_BYTES].decode("utf-8", errors="ignore"), True
+
+
+def _validate_column_lengths(payload: Mapping[str, Any], count: int) -> None:
+    """Chroma requires every supplied column to match ``ids`` in length."""
+    for column in ("embeddings", "documents", "metadatas"):
+        values = payload.get(column)
+        if values is not None and len(values) != count:
+            raise ColumnLengthMismatch(
+                f"payload column {column!r} has {len(values)} entries but "
+                f"ids has {count}; refusing to upsert misaligned records"
+            )
+
+
+@dataclass
+class _Record:
+    """One prepared record, ready to send."""
+
+    id: str
+    embedding: Optional[List[float]]
+    document: Optional[str]
+    metadata: Dict[str, Any]
+
+
+def _count_drop(result: CloudUpsertResult, reason: str) -> None:
+    """Record one dropped record under ``reason``."""
+    result.dropped += 1
+    result.drop_reasons[reason] = result.drop_reasons.get(reason, 0) + 1
+
+
+def _build_records(
+    payload: Mapping[str, Any],
+    ids: Sequence[str],
+    tombstone_keys: Sequence[str],
+    result: CloudUpsertResult,
+    log: Any,
+) -> List[_Record]:
+    """Sanitize every record, dropping the ones Cloud would reject."""
+    embeddings = payload.get("embeddings")
+    documents = payload.get("documents")
+    raw_metadatas = _sanitize_metadatas(
+        list(payload.get("metadatas") or []) or None
+    )
+
+    records: List[_Record] = []
+    for index, record_id in enumerate(ids):
+        if len(str(record_id).encode("utf-8")) > MAX_ID_BYTES:
+            # Truncating an ID would corrupt identity, so drop the record
+            # and let compaction publish it from the delta instead.
+            _count_drop(result, "id_too_long")
+            log.warning(
+                "Dropping record with oversized id from cloud upsert: "
+                "collection=%s id_prefix=%s",
+                result.collection,
+                str(record_id)[:40],
+            )
+            continue
+
+        metadata_in = (
+            raw_metadatas[index] if raw_metadatas is not None else None
+        )
+        metadata, meta_truncated = _prepare_metadata(
+            metadata_in, tombstone_keys
+        )
+        if metadata is None:
+            _count_drop(result, "empty_metadata")
+            log.warning(
+                "Dropping record with no publishable metadata from cloud "
+                "upsert (Chroma rejects empty metadata): collection=%s id=%s",
+                result.collection,
+                record_id,
+            )
+            continue
+
+        document, doc_truncated = _prepare_document(
+            documents[index] if documents is not None else None
+        )
+        if meta_truncated or doc_truncated:
+            result.truncated += 1
+
+        records.append(
+            _Record(
+                id=record_id,
+                embedding=(
+                    embeddings[index] if embeddings is not None else None
+                ),
+                document=document,
+                metadata=metadata,
+            )
+        )
+    return records
+
+
+def _upsert_records(
+    client: ChromaClient,
+    collection_name: str,
+    records: Sequence[_Record],
+) -> None:
+    """Send a group of prepared records in one call."""
+    client.upsert(
+        collection_name=collection_name,
+        ids=[record.id for record in records],
+        embeddings=(
+            [record.embedding for record in records]
+            if records and records[0].embedding is not None
+            else None
+        ),
+        documents=(
+            [record.document for record in records]
+            if records and records[0].document is not None
+            else None
+        ),
+        metadatas=[record.metadata for record in records],
+    )
+
+
+def _upsert_batch(
+    client: ChromaClient,
+    collection_name: str,
+    batch: Sequence[_Record],
+    result: CloudUpsertResult,
+    log: Any,
+) -> int:
+    """Upsert one batch, falling back to per-record on a validation error.
+
+    A ``ValueError`` from Chroma is a per-record validation complaint, so
+    one malformed record must not cost the other 249.
+    """
+    try:
+        _upsert_records(client, collection_name, batch)
+        return len(batch)
+    except ValueError as batch_error:
+        log.warning(
+            "Cloud upsert batch rejected, retrying per record: "
+            "collection=%s size=%d error=%s",
+            collection_name,
+            len(batch),
+            batch_error,
+        )
+
+    written = 0
+    for record in batch:
+        try:
+            _upsert_records(client, collection_name, [record])
+            written += 1
+        except Exception as e:  # pylint: disable=broad-exception-caught
+            _count_drop(result, "rejected")
+            if result.error is None:
+                result.error = f"{type(e).__name__}: {e}"
+            log.warning(
+                "Cloud upsert rejected record: collection=%s id=%s error=%s",
+                collection_name,
+                record.id,
+                e,
+            )
+    return written
 
 
 def upsert_payload_to_cloud(
@@ -127,13 +458,15 @@ def upsert_payload_to_cloud(
     cloud_config: Optional[CloudConfigLike],
     *,
     batch_size: int = UPSERT_BATCH_SIZE,
+    deadline_seconds: float = DEFAULT_DEADLINE_SECONDS,
+    request_timeout: Optional[Tuple[float, float]] = DEFAULT_REQUEST_TIMEOUT,
     log: Optional[Any] = None,
 ) -> CloudUpsertResult:
     """Upsert a Chroma payload directly to Chroma Cloud.
 
     This never raises. Callers treat the cloud write as best effort: the
-    delta tarball and ``CompactionRun`` written alongside it are the
-    durable path, so a cloud failure costs latency, not data.
+    delta tarball and ``CompactionRun`` uploaded before it are the durable
+    path, so a cloud failure costs latency, not data.
 
     Args:
         payload: ``{"ids", "embeddings", "documents", "metadatas"}`` as built
@@ -143,12 +476,16 @@ def upsert_payload_to_cloud(
             ``database``. ``None`` (or incomplete) means cloud is disabled and
             the call is a no-op.
         batch_size: Records per upsert, capped at ``UPSERT_BATCH_SIZE``
+        deadline_seconds: Wall-clock budget across all batches. Batches not
+            started by the deadline are abandoned to the compaction backstop
+            rather than eating the caller's remaining runtime.
+        request_timeout: ``(connect, read)`` seconds per HTTP request
         log: Optional logger; defaults to this module's logger
 
     Returns:
         CloudUpsertResult describing what reached Cloud
     """
-    start = time.time()
+    start = time.monotonic()
     active_log = log or logger
     config = _coerce_cloud_config(cloud_config)
 
@@ -156,7 +493,7 @@ def upsert_payload_to_cloud(
         return CloudUpsertResult(
             collection=collection_name,
             enabled=False,
-            duration_seconds=time.time() - start,
+            duration_seconds=time.monotonic() - start,
         )
 
     ids: List[str] = list(payload.get("ids") or [])
@@ -165,31 +502,49 @@ def upsert_payload_to_cloud(
         attempted=len(ids),
     )
     if not ids:
-        result.duration_seconds = time.time() - start
+        result.duration_seconds = time.monotonic() - start
         return result
-
-    effective_batch = max(1, min(batch_size, UPSERT_BATCH_SIZE))
-    embeddings = payload.get("embeddings")
-    documents = payload.get("documents")
-    metadatas = payload.get("metadatas")
 
     client = None
     try:
-        client = _create_cloud_client_for_sync(config, collection_name)
-        for start_idx in range(0, len(ids), effective_batch):
-            end_idx = min(start_idx + effective_batch, len(ids))
+        _validate_column_lengths(payload, len(ids))
+        records = _build_records(
+            payload,
+            ids,
+            TOMBSTONE_KEYS.get(collection_name, ()),
+            result,
+            active_log,
+        )
+        if not records:
+            result.duration_seconds = time.monotonic() - start
+            return result
+
+        effective_batch = max(1, min(batch_size, UPSERT_BATCH_SIZE))
+        client = _create_cloud_client(config, collection_name, request_timeout)
+
+        for start_idx in range(0, len(records), effective_batch):
+            if time.monotonic() - start > deadline_seconds:
+                remaining = len(records) - start_idx
+                result.deadline_exceeded = True
+                if result.error is None:
+                    result.error = (
+                        f"deadline of {deadline_seconds:.0f}s exceeded with "
+                        f"{remaining} record(s) unwritten"
+                    )
+                active_log.warning(
+                    "Cloud upsert hit its wall-clock budget; leaving %d "
+                    "record(s) to compaction: collection=%s",
+                    remaining,
+                    collection_name,
+                )
+                break
+
+            batch = records[start_idx : start_idx + effective_batch]
             result.batches += 1
             try:
-                client.upsert(
-                    collection_name=collection_name,
-                    ids=ids[start_idx:end_idx],
-                    embeddings=_slice_optional(embeddings, start_idx, end_idx),
-                    documents=_slice_optional(documents, start_idx, end_idx),
-                    metadatas=_clean_metadatas(
-                        _slice_optional(metadatas, start_idx, end_idx)
-                    ),
+                result.upserted += _upsert_batch(
+                    client, collection_name, batch, result, active_log
                 )
-                result.upserted += end_idx - start_idx
             except Exception as e:  # pylint: disable=broad-exception-caught
                 result.failed_batches += 1
                 if result.error is None:
@@ -197,17 +552,15 @@ def upsert_payload_to_cloud(
                 active_log.warning(
                     "Chroma Cloud upsert batch failed "
                     "(non-fatal, compaction is the backstop): "
-                    "collection=%s batch=%d-%d error=%s",
+                    "collection=%s size=%d error=%s",
                     collection_name,
-                    start_idx,
-                    end_idx,
+                    len(batch),
                     result.error,
                 )
     except Exception as e:  # pylint: disable=broad-exception-caught
         result.error = f"{type(e).__name__}: {e}"
         active_log.warning(
-            "Chroma Cloud upsert failed before any batch was written "
-            "(non-fatal): collection=%s error=%s",
+            "Chroma Cloud upsert failed (non-fatal): collection=%s error=%s",
             collection_name,
             result.error,
         )
@@ -222,5 +575,5 @@ def upsert_payload_to_cloud(
                     exc_info=True,
                 )
 
-    result.duration_seconds = time.time() - start
+    result.duration_seconds = time.monotonic() - start
     return result

--- a/receipt_chroma/receipt_chroma/embedding/cloud_upsert.py
+++ b/receipt_chroma/receipt_chroma/embedding/cloud_upsert.py
@@ -22,6 +22,7 @@ Two Chroma behaviors shape the code below:
 """
 
 import logging
+import threading
 import time
 from dataclasses import dataclass, field
 from typing import (
@@ -33,6 +34,15 @@ from typing import (
     Sequence,
     Tuple,
     Union,
+)
+
+from chromadb.errors import (
+    BatchSizeExceededError,
+    DuplicateIDError,
+    IDAlreadyExistsError,
+    InvalidArgumentError,
+    InvalidUUIDError,
+    UniqueConstraintError,
 )
 
 from receipt_chroma.compaction.dual_write import (
@@ -59,6 +69,22 @@ DEFAULT_REQUEST_TIMEOUT: Tuple[float, float] = (10.0, 30.0)
 # Wall clock for the whole upsert, across every batch.
 DEFAULT_DEADLINE_SECONDS = 60.0
 
+# Errors that mean "this record is malformed", so retrying the batch one
+# record at a time can still land the good ones. Chroma Cloud maps
+# server-side validation and quota 400s to InvalidArgumentError, which is a
+# ChromaError and *not* a ValueError. Rate-limit and auth errors are
+# deliberately excluded: splitting one rejected batch into 250 individual
+# requests would make either of those strictly worse.
+_VALIDATION_ERRORS: Tuple[type, ...] = (
+    ValueError,
+    InvalidArgumentError,
+    BatchSizeExceededError,
+    DuplicateIDError,
+    IDAlreadyExistsError,
+    InvalidUUIDError,
+    UniqueConstraintError,
+)
+
 # Keys the payload builders drop rather than emit when the underlying value
 # is absent (``metadata.pop(...)`` in embedding/metadata/*.py). Chroma merges
 # on write, so each must be sent as ``None`` to clear a stale value left by
@@ -74,6 +100,11 @@ _WORD_TOMBSTONE_KEYS = (
     "normalized_url",
 )
 _LINE_TOMBSTONE_KEYS = (
+    # Legacy neighbour fields. Row payloads no longer emit them, but row ids
+    # reuse the primary line id (embedding/records.py), so a record written
+    # before the row rewrite still carries them until they are cleared.
+    "prev_line",
+    "next_line",
     "label_status",
     "valid_labels_array",
     "invalid_labels_array",
@@ -416,26 +447,44 @@ def _upsert_batch(
     batch: Sequence[_Record],
     result: CloudUpsertResult,
     log: Any,
+    deadline_at: Optional[float] = None,
 ) -> int:
     """Upsert one batch, falling back to per-record on a validation error.
 
-    A ``ValueError`` from Chroma is a per-record validation complaint, so
-    one malformed record must not cost the other 249.
+    A validation error means one record is malformed, so a single bad record
+    must not cost the other 249. The fallback re-checks the deadline on every
+    record: 250 individual requests are 250 chances to stall.
     """
     try:
         _upsert_records(client, collection_name, batch)
         return len(batch)
-    except ValueError as batch_error:
+    except _VALIDATION_ERRORS as batch_error:
         log.warning(
             "Cloud upsert batch rejected, retrying per record: "
-            "collection=%s size=%d error=%s",
+            "collection=%s size=%d error=%s: %s",
             collection_name,
             len(batch),
+            type(batch_error).__name__,
             batch_error,
         )
 
     written = 0
-    for record in batch:
+    for index, record in enumerate(batch):
+        if deadline_at is not None and time.monotonic() > deadline_at:
+            remaining = len(batch) - index
+            result.deadline_exceeded = True
+            if result.error is None:
+                result.error = (
+                    f"deadline exceeded during per-record fallback with "
+                    f"{remaining} record(s) unwritten"
+                )
+            log.warning(
+                "Cloud upsert per-record fallback hit the deadline; "
+                "leaving %d record(s) to compaction: collection=%s",
+                remaining,
+                collection_name,
+            )
+            break
         try:
             _upsert_records(client, collection_name, [record])
             written += 1
@@ -476,9 +525,9 @@ def upsert_payload_to_cloud(
             ``database``. ``None`` (or incomplete) means cloud is disabled and
             the call is a no-op.
         batch_size: Records per upsert, capped at ``UPSERT_BATCH_SIZE``
-        deadline_seconds: Wall-clock budget across all batches. Batches not
-            started by the deadline are abandoned to the compaction backstop
-            rather than eating the caller's remaining runtime.
+        deadline_seconds: Hard wall-clock budget covering connection setup and
+            every write. Work not finished by then is abandoned to the
+            compaction backstop rather than eating the caller's runtime.
         request_timeout: ``(connect, read)`` seconds per HTTP request
         log: Optional logger; defaults to this module's logger
 
@@ -505,7 +554,8 @@ def upsert_payload_to_cloud(
         result.duration_seconds = time.monotonic() - start
         return result
 
-    client = None
+    # Record preparation is local and cannot stall, so keep it outside the
+    # deadline thread where its errors report normally.
     try:
         _validate_column_lengths(payload, len(ids))
         records = _build_records(
@@ -515,65 +565,116 @@ def upsert_payload_to_cloud(
             result,
             active_log,
         )
-        if not records:
-            result.duration_seconds = time.monotonic() - start
-            return result
-
-        effective_batch = max(1, min(batch_size, UPSERT_BATCH_SIZE))
-        client = _create_cloud_client(config, collection_name, request_timeout)
-
-        for start_idx in range(0, len(records), effective_batch):
-            if time.monotonic() - start > deadline_seconds:
-                remaining = len(records) - start_idx
-                result.deadline_exceeded = True
-                if result.error is None:
-                    result.error = (
-                        f"deadline of {deadline_seconds:.0f}s exceeded with "
-                        f"{remaining} record(s) unwritten"
-                    )
-                active_log.warning(
-                    "Cloud upsert hit its wall-clock budget; leaving %d "
-                    "record(s) to compaction: collection=%s",
-                    remaining,
-                    collection_name,
-                )
-                break
-
-            batch = records[start_idx : start_idx + effective_batch]
-            result.batches += 1
-            try:
-                result.upserted += _upsert_batch(
-                    client, collection_name, batch, result, active_log
-                )
-            except Exception as e:  # pylint: disable=broad-exception-caught
-                result.failed_batches += 1
-                if result.error is None:
-                    result.error = f"{type(e).__name__}: {e}"
-                active_log.warning(
-                    "Chroma Cloud upsert batch failed "
-                    "(non-fatal, compaction is the backstop): "
-                    "collection=%s size=%d error=%s",
-                    collection_name,
-                    len(batch),
-                    result.error,
-                )
     except Exception as e:  # pylint: disable=broad-exception-caught
         result.error = f"{type(e).__name__}: {e}"
         active_log.warning(
-            "Chroma Cloud upsert failed (non-fatal): collection=%s error=%s",
+            "Chroma Cloud upsert failed before any write (non-fatal): "
+            "collection=%s error=%s",
             collection_name,
             result.error,
         )
-    finally:
-        if client is not None:
-            try:
-                client.close()
-            except Exception:  # pylint: disable=broad-exception-caught
-                active_log.debug(
-                    "Chroma Cloud client close failed for %s",
-                    collection_name,
-                    exc_info=True,
-                )
+        result.duration_seconds = time.monotonic() - start
+        return result
+
+    if not records:
+        result.duration_seconds = time.monotonic() - start
+        return result
+
+    effective_batch = max(1, min(batch_size, UPSERT_BATCH_SIZE))
+    deadline_at = start + deadline_seconds
+
+    # Everything below talks to Cloud, including client construction: Chroma
+    # issues identity, tenant and database requests inside CloudClient()
+    # before our session timeout can be applied, so a stall there would be
+    # invisible to a per-request timeout. Run it on a daemon thread and join
+    # with the remaining budget; a thread we abandon dies with the process
+    # and cannot hold the Lambda open.
+    def _connect_and_write() -> None:
+        client = None
+        try:
+            client = _create_cloud_client(
+                config, collection_name, request_timeout
+            )
+            for start_idx in range(0, len(records), effective_batch):
+                if time.monotonic() > deadline_at:
+                    remaining = len(records) - start_idx
+                    result.deadline_exceeded = True
+                    if result.error is None:
+                        result.error = (
+                            f"deadline of {deadline_seconds:.0f}s exceeded "
+                            f"with {remaining} record(s) unwritten"
+                        )
+                    active_log.warning(
+                        "Cloud upsert hit its wall-clock budget; leaving %d "
+                        "record(s) to compaction: collection=%s",
+                        remaining,
+                        collection_name,
+                    )
+                    break
+
+                batch = records[start_idx : start_idx + effective_batch]
+                result.batches += 1
+                try:
+                    result.upserted += _upsert_batch(
+                        client,
+                        collection_name,
+                        batch,
+                        result,
+                        active_log,
+                        deadline_at,
+                    )
+                except Exception as e:  # pylint: disable=broad-except
+                    result.failed_batches += 1
+                    if result.error is None:
+                        result.error = f"{type(e).__name__}: {e}"
+                    active_log.warning(
+                        "Chroma Cloud upsert batch failed "
+                        "(non-fatal, compaction is the backstop): "
+                        "collection=%s size=%d error=%s",
+                        collection_name,
+                        len(batch),
+                        result.error,
+                    )
+        except Exception as e:  # pylint: disable=broad-exception-caught
+            if result.error is None:
+                result.error = f"{type(e).__name__}: {e}"
+            active_log.warning(
+                "Chroma Cloud upsert failed (non-fatal): "
+                "collection=%s error=%s",
+                collection_name,
+                result.error,
+            )
+        finally:
+            if client is not None:
+                try:
+                    client.close()
+                except Exception:  # pylint: disable=broad-exception-caught
+                    active_log.debug(
+                        "Chroma Cloud client close failed for %s",
+                        collection_name,
+                        exc_info=True,
+                    )
+
+    worker = threading.Thread(
+        target=_connect_and_write,
+        name=f"cloud-upsert-{collection_name}",
+        daemon=True,
+    )
+    worker.start()
+    worker.join(max(0.0, deadline_at - time.monotonic()))
+
+    if worker.is_alive():
+        result.deadline_exceeded = True
+        if result.error is None:
+            result.error = (
+                f"deadline of {deadline_seconds:.0f}s exceeded while "
+                "connecting or writing to Chroma Cloud"
+            )
+        active_log.warning(
+            "Cloud upsert abandoned at its wall-clock budget; compaction "
+            "remains the backstop: collection=%s",
+            collection_name,
+        )
 
     result.duration_seconds = time.monotonic() - start
     return result

--- a/receipt_chroma/receipt_chroma/embedding/cloud_upsert.py
+++ b/receipt_chroma/receipt_chroma/embedding/cloud_upsert.py
@@ -214,6 +214,8 @@ class CloudUpsertResult:
         dropped: Records skipped because they could not be made valid
         truncated: Records whose metadata or document was shortened
         deadline_exceeded: Whether the wall-clock budget stopped the run
+        backpressure: Whether the attempt was refused because too many
+            earlier attempts are still in flight
         error: First error encountered, formatted as ``Type: message``
         duration_seconds: Wall clock spent in this call
         drop_reasons: Count of dropped records keyed by reason
@@ -228,6 +230,7 @@ class CloudUpsertResult:
     dropped: int = 0
     truncated: int = 0
     deadline_exceeded: bool = False
+    backpressure: bool = False
     error: Optional[str] = None
     duration_seconds: float = 0.0
     drop_reasons: Dict[str, int] = field(default_factory=dict)
@@ -240,7 +243,18 @@ class CloudUpsertResult:
             and self.failed_batches == 0
             and self.dropped == 0
             and not self.deadline_exceeded
+            and not self.backpressure
         )
+
+    @property
+    def telemetry_must_be_bounded(self) -> bool:
+        """Whether reporting this result may block on I/O.
+
+        Both states mean something upstream is stuck: the deadline expired,
+        or earlier attempts have not returned. A shared log or metric sink
+        is I/O too, so callers must report these without blocking on it.
+        """
+        return self.deadline_exceeded or self.backpressure
 
     def to_dict(self) -> Dict[str, Any]:
         """Convert to a JSON-serializable dictionary."""
@@ -254,6 +268,7 @@ class CloudUpsertResult:
             "dropped": self.dropped,
             "truncated": self.truncated,
             "deadline_exceeded": self.deadline_exceeded,
+            "backpressure": self.backpressure,
             "error": self.error,
             "duration_seconds": round(self.duration_seconds, 3),
             "success": self.success,
@@ -737,15 +752,23 @@ def upsert_payload_to_cloud(
     # Backpressure: if enough previous attempts are still stuck, this one
     # would only add another thread and another session to a warm container.
     if not _orphaned_attempts.acquire(blocking=False):
+        result.backpressure = True
         result.error = (
             f"more than {MAX_ORPHANED_ATTEMPTS} cloud upsert attempts are "
             "still in flight; skipping this one"
         )
-        _count_drop(result, "orphaned_threads")
-        active_log.warning(
+        # Every prepared record is skipped, not one: this metric exists to
+        # size the incident it is reporting.
+        for _ in range(len(records)):
+            _count_drop(result, "orphaned_threads")
+        # Earlier attempts are stuck on I/O, and a shared log sink is exactly
+        # the kind of I/O that would be stuck with them.
+        emit_within_budget(
+            active_log.warning,
             "Skipping Chroma Cloud upsert: %d earlier attempt(s) have not "
-            "finished; leaving this receipt to compaction: collection=%s",
+            "finished; leaving %d record(s) to compaction: collection=%s",
             MAX_ORPHANED_ATTEMPTS,
+            len(records),
             collection_name,
         )
         result.duration_seconds = time.monotonic() - start

--- a/receipt_chroma/receipt_chroma/embedding/cloud_upsert.py
+++ b/receipt_chroma/receipt_chroma/embedding/cloud_upsert.py
@@ -675,6 +675,11 @@ def upsert_payload_to_cloud(
 
     effective_batch = max(1, min(batch_size, UPSERT_BATCH_SIZE))
     deadline_at = start + deadline_seconds
+    # Bind the semaphore once. An abandoned attempt releases whenever its
+    # thread finally unwinds, which may be long after this call returned;
+    # releasing the object it acquired keeps that from crediting a permit to
+    # whatever the module global points at by then.
+    permits = _orphaned_attempts
 
     # Everything below talks to Cloud, including client construction: Chroma
     # issues identity, tenant and database requests inside CloudClient()
@@ -747,11 +752,11 @@ def upsert_payload_to_cloud(
                         collection_name,
                         exc_info=True,
                     )
-            _orphaned_attempts.release()
+            permits.release()
 
     # Backpressure: if enough previous attempts are still stuck, this one
     # would only add another thread and another session to a warm container.
-    if not _orphaned_attempts.acquire(blocking=False):
+    if not permits.acquire(blocking=False):
         result.backpressure = True
         result.error = (
             f"more than {MAX_ORPHANED_ATTEMPTS} cloud upsert attempts are "

--- a/receipt_chroma/receipt_chroma/embedding/cloud_upsert.py
+++ b/receipt_chroma/receipt_chroma/embedding/cloud_upsert.py
@@ -42,6 +42,8 @@ from chromadb.errors import (
     IDAlreadyExistsError,
     InvalidArgumentError,
     InvalidUUIDError,
+    QuotaError,
+    RateLimitError,
     UniqueConstraintError,
 )
 
@@ -84,6 +86,17 @@ _VALIDATION_ERRORS: Tuple[type, ...] = (
     InvalidUUIDError,
     UniqueConstraintError,
 )
+
+# Throttling means "stop asking", so it aborts a fan-out already in flight
+# rather than pushing the remaining 249 requests through a closing door.
+_THROTTLE_ERRORS: Tuple[type, ...] = (RateLimitError, QuotaError)
+
+# Cloud attempts are abandoned at their deadline but the thread behind them
+# may still be stuck in an unbounded constructor request. In a warm Lambda
+# those accumulate, so refuse to start another attempt once this many are
+# still alive and let compaction carry the load until they drain.
+MAX_ORPHANED_ATTEMPTS = 3
+_orphaned_attempts = threading.Semaphore(MAX_ORPHANED_ATTEMPTS)
 
 # Keys the payload builders drop rather than emit when the underlying value
 # is absent (``metadata.pop(...)`` in embedding/metadata/*.py). Chroma merges
@@ -136,6 +149,51 @@ _PRIORITY_KEYS = (
 )
 
 CloudConfigLike = Union[CloudConfig, Mapping[str, str]]
+
+
+# Grace allowed for one best-effort telemetry call once the budget is gone.
+TAIL_GRACE_SECONDS = 0.25
+
+
+def emit_within_budget(
+    emit: Any,
+    *args: Any,
+    grace_seconds: float = TAIL_GRACE_SECONDS,
+    **kwargs: Any,
+) -> bool:
+    """Make a telemetry call that cannot extend an overrun.
+
+    Logging and metric emission are I/O. Once the deadline is spent, a
+    blocked handler or a stalled stdout would hand the overrun straight back
+    to the caller the deadline was meant to protect, so the call runs on a
+    daemon thread and is abandoned after ``grace_seconds``.
+
+    Returns True if the call finished within the grace period.
+    """
+    done = threading.Event()
+
+    def _run() -> None:
+        try:
+            emit(*args, **kwargs)
+        except Exception:  # pylint: disable=broad-exception-caught
+            pass
+        finally:
+            done.set()
+
+    threading.Thread(
+        target=_run, name="cloud-upsert-tail", daemon=True
+    ).start()
+    return done.wait(grace_seconds)
+
+
+def _log_within_budget(
+    log: Any, deadline_at: float, message: str, *args: Any
+) -> None:
+    """Log normally while there is budget, best-effort once there is not."""
+    if time.monotonic() <= deadline_at:
+        log.warning(message, *args)
+        return
+    emit_within_budget(log.warning, message, *args)
 
 
 class ColumnLengthMismatch(ValueError):
@@ -488,6 +546,26 @@ def _upsert_batch(
         try:
             _upsert_records(client, collection_name, [record])
             written += 1
+        except _THROTTLE_ERRORS as throttle_error:
+            # Keeping the fan-out going here is what turns one rejected
+            # batch into 250 throttled requests. Abandon the rest of this
+            # batch to compaction instead.
+            remaining = len(batch) - index
+            for _ in range(remaining):
+                _count_drop(result, "rate_limited_abort")
+            if result.error is None:
+                result.error = (
+                    f"{type(throttle_error).__name__}: {throttle_error}"
+                )
+            log.warning(
+                "Cloud upsert throttled during per-record fallback; "
+                "abandoning %d record(s) to compaction: "
+                "collection=%s error=%s",
+                remaining,
+                collection_name,
+                throttle_error,
+            )
+            break
         except Exception as e:  # pylint: disable=broad-exception-caught
             _count_drop(result, "rejected")
             if result.error is None:
@@ -654,6 +732,24 @@ def upsert_payload_to_cloud(
                         collection_name,
                         exc_info=True,
                     )
+            _orphaned_attempts.release()
+
+    # Backpressure: if enough previous attempts are still stuck, this one
+    # would only add another thread and another session to a warm container.
+    if not _orphaned_attempts.acquire(blocking=False):
+        result.error = (
+            f"more than {MAX_ORPHANED_ATTEMPTS} cloud upsert attempts are "
+            "still in flight; skipping this one"
+        )
+        _count_drop(result, "orphaned_threads")
+        active_log.warning(
+            "Skipping Chroma Cloud upsert: %d earlier attempt(s) have not "
+            "finished; leaving this receipt to compaction: collection=%s",
+            MAX_ORPHANED_ATTEMPTS,
+            collection_name,
+        )
+        result.duration_seconds = time.monotonic() - start
+        return result
 
     worker = threading.Thread(
         target=_connect_and_write,
@@ -670,7 +766,11 @@ def upsert_payload_to_cloud(
                 f"deadline of {deadline_seconds:.0f}s exceeded while "
                 "connecting or writing to Chroma Cloud"
             )
-        active_log.warning(
+        # The budget is spent, so this is the one line we still pay for --
+        # a blocked log sink here would put the overrun back on the caller.
+        _log_within_budget(
+            active_log,
+            deadline_at,
             "Cloud upsert abandoned at its wall-clock budget; compaction "
             "remains the backstop: collection=%s",
             collection_name,

--- a/receipt_chroma/tests/unit/test_chroma_client.py
+++ b/receipt_chroma/tests/unit/test_chroma_client.py
@@ -5,6 +5,7 @@ These tests focus on client behavior, context managers, and resource management
 without requiring actual ChromaDB operations or file I/O.
 """
 
+import time
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -765,6 +766,83 @@ def test_a_failed_cloud_constructor_leaves_nothing_registered():
             assert (
                 len(cache) == baseline
             ), f"leaked {len(cache) - baseline} system(s) on cycle {cycle}"
+
+
+@pytest.mark.unit
+def test_a_failed_construction_does_not_evict_a_concurrent_one():
+    """Ownership is derived by diffing a process-wide cache.
+
+    Without serializing the snapshot-construct-diff sequence, a failing
+    constructor's cleanup sees systems registered by another constructor
+    that started after its snapshot, and evicts live entries belonging to
+    a client still in use.
+    """
+    import threading
+
+    from chromadb.api.shared_system_client import SharedSystemClient
+
+    cache = SharedSystemClient._identifier_to_system
+    baseline = len(cache)
+    identity = MagicMock(tenant="tenant", databases=["database"])
+    results = {}
+
+    def identity_call(*_args, **_kwargs):
+        # One patch for both threads; the failure is keyed off the caller so
+        # the two constructions genuinely overlap.
+        if threading.current_thread().name == "failing":
+            time.sleep(0.4)
+            raise RuntimeError("cloud is down")
+        return identity
+
+    def build(name):
+        client = ChromaClient(
+            cloud_api_key="key",
+            cloud_tenant="tenant",
+            cloud_database="database",
+            mode="write",
+            metadata_only=False,
+        )
+        try:
+            _ = client.client
+            results[name] = ("ok", client)
+        except Exception:  # pylint: disable=broad-exception-caught
+            results[name] = ("failed", client)
+
+    with (
+        patch(
+            "chromadb.api.fastapi.FastAPI.get_user_identity",
+            side_effect=identity_call,
+        ),
+        patch("chromadb.api.fastapi.FastAPI.heartbeat", return_value=1),
+        patch("chromadb.api.fastapi.FastAPI.get_tenant"),
+        patch("chromadb.api.fastapi.FastAPI.get_database"),
+        patch("chromadb.api.fastapi.FastAPI.create_tenant"),
+        patch("chromadb.api.fastapi.FastAPI.create_database"),
+    ):
+        failing = threading.Thread(
+            target=build, args=("failing",), name="failing"
+        )
+        surviving = threading.Thread(
+            target=build, args=("surviving",), name="surviving"
+        )
+        failing.start()
+        time.sleep(0.05)  # let the failing constructor take its snapshot
+        surviving.start()
+        failing.join(30)
+        surviving.join(30)
+
+    assert results["failing"][0] == "failed"
+    assert results["surviving"][0] == "ok"
+
+    survivor = results["surviving"][1]
+    tracked = survivor._cloud_system_identifiers
+    assert tracked, "expected the surviving client to own systems"
+    assert all(
+        identifier in cache for identifier in tracked
+    ), "the failed construction evicted a live client's systems"
+
+    survivor.close()
+    assert len(cache) == baseline
 
 
 @pytest.mark.unit

--- a/receipt_chroma/tests/unit/test_chroma_client.py
+++ b/receipt_chroma/tests/unit/test_chroma_client.py
@@ -733,6 +733,41 @@ def test_closing_a_cloud_client_releases_its_system_and_pool():
 
 
 @pytest.mark.unit
+def test_a_failed_cloud_constructor_leaves_nothing_registered():
+    """Chroma registers its system before the request that can fail.
+
+    ``_client`` stays None on that path, so ``close()`` has nothing to work
+    from; without eviction at the failure site a Cloud outage accumulates a
+    system and a pool per attempt in a warm Lambda.
+    """
+    from chromadb.api.shared_system_client import SharedSystemClient
+
+    cache = SharedSystemClient._identifier_to_system
+    baseline = len(cache)
+
+    with patch(
+        "chromadb.api.fastapi.FastAPI.get_user_identity",
+        side_effect=RuntimeError("cloud is down"),
+    ):
+        for cycle in range(4):
+            client = ChromaClient(
+                cloud_api_key="key",
+                cloud_tenant="tenant",
+                cloud_database="database",
+                mode="write",
+                metadata_only=False,
+            )
+            # Chroma re-wraps the transport failure as a ValueError.
+            with pytest.raises(ValueError, match="cloud is down"):
+                _ = client.client
+            client.close()
+
+            assert (
+                len(cache) == baseline
+            ), f"leaked {len(cache) - baseline} system(s) on cycle {cycle}"
+
+
+@pytest.mark.unit
 def test_release_evicts_every_identifier_the_construction_added():
     """Only the outermost identifier is reachable from the client."""
     from chromadb.api.shared_system_client import SharedSystemClient

--- a/receipt_chroma/tests/unit/test_chroma_client.py
+++ b/receipt_chroma/tests/unit/test_chroma_client.py
@@ -724,12 +724,34 @@ def test_closing_a_cloud_client_releases_its_system_and_pool():
     cache["id-release"] = fake._system
     before = len(cache)
 
-    _release_cloud_client(fake)
+    _release_cloud_client(fake, {"id-release"})
 
     fake._server._session.close.assert_called_once()
     fake._system.stop.assert_called_once()
     assert "id-release" not in cache
     assert len(cache) == before - 1
+
+
+@pytest.mark.unit
+def test_release_evicts_every_identifier_the_construction_added():
+    """Only the outermost identifier is reachable from the client."""
+    from chromadb.api.shared_system_client import SharedSystemClient
+
+    from receipt_chroma.data.chroma_client import _release_cloud_client
+
+    cache = SharedSystemClient._identifier_to_system
+    baseline = len(cache)
+
+    fake = _fake_cloud_client("id-outer")
+    extra_systems = {f"id-inner-{i}": MagicMock() for i in range(2)}
+    cache["id-outer"] = fake._system
+    cache.update(extra_systems)
+
+    _release_cloud_client(fake, {"id-outer", *extra_systems})
+
+    assert len(cache) == baseline
+    for system in extra_systems.values():
+        system.stop.assert_called_once()
 
 
 @pytest.mark.unit
@@ -751,9 +773,57 @@ def test_repeated_cloud_client_cycles_do_not_grow_the_cache():
             mode="write",
         )
         client._client = fake
+        client._cloud_system_identifiers = {fake._identifier}
         client.close()
 
         assert len(cache) == baseline, f"leaked on cycle {cycle}"
+
+
+@pytest.mark.unit
+def test_real_cloud_client_cycles_return_the_cache_to_baseline():
+    """A real CloudClient registers three systems, not one.
+
+    ``client._identifier`` names only the outermost; its internal client and
+    admin client register their own. Evicting just the first left two behind
+    every cycle. Network calls are mocked so construction runs offline.
+    """
+    from chromadb.api.shared_system_client import SharedSystemClient
+
+    cache = SharedSystemClient._identifier_to_system
+    baseline = len(cache)
+
+    identity = MagicMock(tenant="tenant", databases=["database"])
+    with (
+        patch(
+            "chromadb.api.fastapi.FastAPI.get_user_identity",
+            return_value=identity,
+        ),
+        patch("chromadb.api.fastapi.FastAPI.heartbeat", return_value=1),
+        patch("chromadb.api.fastapi.FastAPI.get_tenant"),
+        patch("chromadb.api.fastapi.FastAPI.get_database"),
+        patch("chromadb.api.fastapi.FastAPI.create_tenant"),
+        patch("chromadb.api.fastapi.FastAPI.create_database"),
+    ):
+        for cycle in range(3):
+            client = ChromaClient(
+                cloud_api_key="key",
+                cloud_tenant="tenant",
+                cloud_database="database",
+                mode="write",
+                metadata_only=False,
+            )
+            _ = client.client
+
+            assert (
+                len(client._cloud_system_identifiers) > 1
+            ), "expected CloudClient to register more than one system"
+            assert len(cache) > baseline
+
+            client.close()
+
+            assert (
+                len(cache) == baseline
+            ), f"leaked {len(cache) - baseline} system(s) on cycle {cycle}"
 
 
 def test_create_if_missing_uses_atomic_get_or_create(monkeypatch):

--- a/receipt_chroma/tests/unit/test_chroma_client.py
+++ b/receipt_chroma/tests/unit/test_chroma_client.py
@@ -665,3 +665,92 @@ def test_cloud_client_config_with_none_values():
     assert client._cloud_api_key == "test-key"
     assert client._cloud_tenant is None
     assert client._cloud_database is None
+
+
+def _fake_cloud_client(identifier):
+    """Build a stand-in for chromadb's CloudClient internals."""
+    client = MagicMock()
+    client._identifier = identifier
+    client._system = MagicMock()
+    client._server._session = MagicMock()
+    return client
+
+
+@pytest.mark.unit
+def test_cloud_request_timeout_is_applied_to_the_session():
+    """Chroma builds its Cloud session with timeout=None."""
+    import httpx
+
+    from receipt_chroma.data.chroma_client import _apply_cloud_request_timeout
+
+    client = _fake_cloud_client("id-timeout")
+    _apply_cloud_request_timeout(client, (10.0, 30.0))
+
+    applied = client._server._session.timeout
+    assert isinstance(applied, httpx.Timeout)
+    assert applied.connect == 10.0
+    assert applied.read == 30.0
+
+
+@pytest.mark.unit
+def test_missing_timeout_is_a_noop():
+    client = _fake_cloud_client("id-none")
+    original = client._server._session.timeout
+
+    from receipt_chroma.data.chroma_client import _apply_cloud_request_timeout
+
+    _apply_cloud_request_timeout(client, None)
+
+    assert client._server._session.timeout is original
+
+
+@pytest.mark.unit
+def test_unexpected_client_internals_do_not_raise():
+    """The session path is private, so a miss must stay advisory."""
+    from receipt_chroma.data.chroma_client import _apply_cloud_request_timeout
+
+    _apply_cloud_request_timeout(object(), (1.0, 2.0))
+
+
+@pytest.mark.unit
+def test_closing_a_cloud_client_releases_its_system_and_pool():
+    """Chroma never evicts its shared systems, so close() must."""
+    from chromadb.api.shared_system_client import SharedSystemClient
+
+    from receipt_chroma.data.chroma_client import _release_cloud_client
+
+    fake = _fake_cloud_client("id-release")
+    cache = SharedSystemClient._identifier_to_system
+    cache["id-release"] = fake._system
+    before = len(cache)
+
+    _release_cloud_client(fake)
+
+    fake._server._session.close.assert_called_once()
+    fake._system.stop.assert_called_once()
+    assert "id-release" not in cache
+    assert len(cache) == before - 1
+
+
+@pytest.mark.unit
+def test_repeated_cloud_client_cycles_do_not_grow_the_cache():
+    """Two create/close cycles previously grew the cache 0 -> 3 -> 6."""
+    from chromadb.api.shared_system_client import SharedSystemClient
+
+    cache = SharedSystemClient._identifier_to_system
+    baseline = len(cache)
+
+    for cycle in range(3):
+        fake = _fake_cloud_client(f"id-cycle-{cycle}")
+        cache[fake._identifier] = fake._system
+
+        client = ChromaClient(
+            cloud_api_key="key",
+            cloud_tenant="tenant",
+            cloud_database="database",
+            mode="write",
+        )
+        client._client = fake
+        client.close()
+
+        assert len(cache) == baseline, f"leaked on cycle {cycle}"

--- a/receipt_chroma/tests/unit/test_cloud_upsert.py
+++ b/receipt_chroma/tests/unit/test_cloud_upsert.py
@@ -57,18 +57,69 @@ from receipt_chroma.embedding.cloud_upsert import (
 
 _CLIENT_FACTORY = "receipt_chroma.embedding.cloud_upsert._create_cloud_client"
 
+# Gates held open to simulate a stalled Cloud. The permits fixture releases
+# every one of them in teardown so no thread outlives its test.
+_ACTIVE_GATES: list = []
+
+
+def blocking_gate() -> threading.Event:
+    """An event teardown will set, so a blocked worker can unwind."""
+    gate = threading.Event()
+    _ACTIVE_GATES.append(gate)
+    return gate
+
+
+def stalls_until_released(gate: threading.Event):
+    """A client factory that blocks until the gate opens."""
+
+    def factory(*_args, **_kwargs):
+        gate.wait(30)
+        raise RuntimeError("released")
+
+    return factory
+
+
+def slow_sink(gate: threading.Event):
+    """A log sink that blocks until the gate opens."""
+
+    def sink(*_args, **_kwargs):
+        gate.wait(30)
+
+    return sink
+
 
 @pytest.fixture(autouse=True)
 def _fresh_backpressure_permits(monkeypatch):
-    """Give each test its own permits.
+    """Give each test its own permits and let its threads finish.
 
-    An abandoned attempt keeps its permit until the thread behind it
-    unwinds, so without this the deadline tests would starve whichever
-    test ran next.
+    The deadline tests deliberately abandon worker threads. Each test gets a
+    private semaphore so it cannot starve the next one, and every abandoned
+    worker is released and joined afterwards -- one still running during the
+    next test would keep touching a live semaphore and make the timing
+    assertions flap.
     """
     monkeypatch.setattr(
         cu, "_orphaned_attempts", threading.Semaphore(MAX_ORPHANED_ATTEMPTS)
     )
+    before = {t.ident for t in threading.enumerate()}
+
+    yield
+
+    for gate in _ACTIVE_GATES:
+        gate.set()
+    _ACTIVE_GATES.clear()
+
+    deadline = time.monotonic() + 30.0
+    for thread in threading.enumerate():
+        if thread.ident in before or not thread.name.startswith(
+            "cloud-upsert"
+        ):
+            continue
+        thread.join(max(0.0, deadline - time.monotonic()))
+        assert not thread.is_alive(), (
+            f"{thread.name} outlived its test; it would interfere with the "
+            "next one"
+        )
 
 
 CLOUD_CFG = {
@@ -694,11 +745,12 @@ class TestDeadline:
 
     def test_a_stalled_client_constructor_cannot_outlast_the_budget(self):
         """Chroma's CloudClient() issues its own untimed requests."""
+        gate = blocking_gate()
         started = threading.Event()
 
         def never_returns(*_args, **_kwargs):
             started.set()
-            time.sleep(30)
+            gate.wait(30)
             raise AssertionError("should have been abandoned")
 
         began = time.monotonic()
@@ -752,14 +804,15 @@ class TestBoundedTail:
 
     def test_a_blocked_log_sink_cannot_extend_the_overrun(self):
         """A slow handler after the join would undo the whole budget."""
+        gate = blocking_gate()
         started = threading.Event()
 
         def never_returns(*_args, **_kwargs):
             started.set()
-            time.sleep(30)
+            gate.wait(30)
 
         slow_log = MagicMock()
-        slow_log.warning.side_effect = lambda *a, **k: time.sleep(5)
+        slow_log.warning.side_effect = slow_sink(blocking_gate())
 
         began = time.monotonic()
         with patch(_CLIENT_FACTORY, side_effect=never_returns):
@@ -777,9 +830,10 @@ class TestBoundedTail:
         assert elapsed < 2.0, f"tail was unbounded: {elapsed:.2f}s"
 
     def test_emit_within_budget_reports_completion(self):
+        gate = blocking_gate()
         assert emit_within_budget(lambda: None) is True
         assert (
-            emit_within_budget(lambda: time.sleep(2), grace_seconds=0.05)
+            emit_within_budget(lambda: gate.wait(30), grace_seconds=0.05)
             is False
         )
 
@@ -794,107 +848,85 @@ class TestOrphanedThreadBackpressure:
     """Abandoned attempts can pile up in a warm container."""
 
     def test_too_many_in_flight_attempts_skip_the_write(self):
-        gate = threading.Event()
+        gate = blocking_gate()
 
-        def blocks_until_released(*_args, **_kwargs):
-            gate.wait(30)
-            raise RuntimeError("released")
-
-        try:
-            with patch(_CLIENT_FACTORY, side_effect=blocks_until_released):
-                stuck = [
-                    upsert_payload_to_cloud(
-                        make_payload(1),
-                        "words",
-                        CLOUD_CFG,
-                        deadline_seconds=0.05,
-                    )
-                    for _ in range(MAX_ORPHANED_ATTEMPTS)
-                ]
-                assert all(r.deadline_exceeded for r in stuck)
-
-                # The permits are all held by threads that never finished.
-                blocked = upsert_payload_to_cloud(
+        with patch(_CLIENT_FACTORY, side_effect=stalls_until_released(gate)):
+            stuck = [
+                upsert_payload_to_cloud(
                     make_payload(1),
                     "words",
                     CLOUD_CFG,
-                    deadline_seconds=5.0,
+                    deadline_seconds=0.05,
                 )
+                for _ in range(MAX_ORPHANED_ATTEMPTS)
+            ]
+            assert all(r.deadline_exceeded for r in stuck)
 
-            assert blocked.success is False
-            assert blocked.backpressure is True
-            assert "still in flight" in blocked.error
-            assert blocked.batches == 0
-        finally:
-            gate.set()
+            # The permits are all held by threads that never finished.
+            blocked = upsert_payload_to_cloud(
+                make_payload(1),
+                "words",
+                CLOUD_CFG,
+                deadline_seconds=5.0,
+            )
+
+        assert blocked.success is False
+        assert blocked.backpressure is True
+        assert "still in flight" in blocked.error
+        assert blocked.batches == 0
 
     def test_every_skipped_record_is_counted(self):
         """The metric exists to size the incident it reports."""
-        gate = threading.Event()
+        gate = blocking_gate()
 
-        def blocks_until_released(*_args, **_kwargs):
-            gate.wait(30)
-            raise RuntimeError("released")
-
-        try:
-            with patch(_CLIENT_FACTORY, side_effect=blocks_until_released):
-                for _ in range(MAX_ORPHANED_ATTEMPTS):
-                    upsert_payload_to_cloud(
-                        make_payload(1),
-                        "words",
-                        CLOUD_CFG,
-                        deadline_seconds=0.05,
-                    )
-
-                blocked = upsert_payload_to_cloud(
-                    make_payload(37),
-                    "words",
-                    CLOUD_CFG,
-                    deadline_seconds=5.0,
-                )
-
-            assert blocked.attempted == 37
-            assert blocked.upserted == 0
-            assert blocked.dropped == 37
-            assert blocked.drop_reasons == {"orphaned_threads": 37}
-        finally:
-            gate.set()
-
-    def test_rejection_telemetry_is_time_bounded(self):
-        """Earlier attempts are stuck on I/O; the log sink may be too."""
-        gate = threading.Event()
-
-        def blocks_until_released(*_args, **_kwargs):
-            gate.wait(30)
-            raise RuntimeError("released")
-
-        slow_log = MagicMock()
-        slow_log.warning.side_effect = lambda *a, **k: time.sleep(5)
-
-        try:
-            with patch(_CLIENT_FACTORY, side_effect=blocks_until_released):
-                for _ in range(MAX_ORPHANED_ATTEMPTS):
-                    upsert_payload_to_cloud(
-                        make_payload(1),
-                        "words",
-                        CLOUD_CFG,
-                        deadline_seconds=0.05,
-                    )
-
-                began = time.monotonic()
-                blocked = upsert_payload_to_cloud(
-                    make_payload(5),
+        with patch(_CLIENT_FACTORY, side_effect=stalls_until_released(gate)):
+            for _ in range(MAX_ORPHANED_ATTEMPTS):
+                upsert_payload_to_cloud(
+                    make_payload(1),
                     "words",
                     CLOUD_CFG,
                     deadline_seconds=0.05,
-                    log=slow_log,
                 )
-                elapsed = time.monotonic() - began
 
-            assert blocked.backpressure is True
-            assert elapsed < 2.0, f"rejection tail unbounded: {elapsed:.2f}s"
-        finally:
-            gate.set()
+            blocked = upsert_payload_to_cloud(
+                make_payload(37),
+                "words",
+                CLOUD_CFG,
+                deadline_seconds=5.0,
+            )
+
+        assert blocked.attempted == 37
+        assert blocked.upserted == 0
+        assert blocked.dropped == 37
+        assert blocked.drop_reasons == {"orphaned_threads": 37}
+
+    def test_rejection_telemetry_is_time_bounded(self):
+        """Earlier attempts are stuck on I/O; the log sink may be too."""
+        gate = blocking_gate()
+        slow_log = MagicMock()
+        slow_log.warning.side_effect = slow_sink(blocking_gate())
+
+        with patch(_CLIENT_FACTORY, side_effect=stalls_until_released(gate)):
+            for _ in range(MAX_ORPHANED_ATTEMPTS):
+                upsert_payload_to_cloud(
+                    make_payload(1),
+                    "words",
+                    CLOUD_CFG,
+                    deadline_seconds=0.05,
+                )
+
+            began = time.monotonic()
+            blocked = upsert_payload_to_cloud(
+                make_payload(5),
+                "words",
+                CLOUD_CFG,
+                deadline_seconds=0.05,
+                log=slow_log,
+            )
+            elapsed = time.monotonic() - began
+
+        assert blocked.backpressure is True
+        assert elapsed < 2.0, f"rejection tail unbounded: {elapsed:.2f}s"
 
     def test_backpressure_asks_callers_to_bound_their_telemetry(self):
         result = CloudUpsertResult(collection="words", backpressure=True)

--- a/receipt_chroma/tests/unit/test_cloud_upsert.py
+++ b/receipt_chroma/tests/unit/test_cloud_upsert.py
@@ -1,0 +1,331 @@
+# ruff: noqa: E402
+"""Unit tests for direct Chroma Cloud upsert from the ingest path.
+
+Covers the success path, non-fatal partial batch failure, the disabled
+no-op, and batching against Chroma Cloud's 300-record ceiling.
+"""
+
+# IMPORTANT: Clear Chroma Cloud env vars BEFORE importing chromadb
+# ChromaDB may check credentials at import time
+import os
+
+_CHROMA_ENV_VARS = [
+    "CHROMA_API_KEY",
+    "CHROMA_CLOUD_API_KEY",
+    "CHROMA_CLOUD_TENANT",
+    "CHROMA_CLOUD_DATABASE",
+    "CHROMA_CLOUD_ENABLED",
+]
+for _var in _CHROMA_ENV_VARS:
+    os.environ.pop(_var, None)
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from receipt_chroma.compaction.dual_write import CloudConfig
+from receipt_chroma.embedding.cloud_upsert import (
+    UPSERT_BATCH_SIZE,
+    CloudUpsertResult,
+    upsert_payload_to_cloud,
+)
+
+_CLIENT_FACTORY = (
+    "receipt_chroma.embedding.cloud_upsert._create_cloud_client_for_sync"
+)
+
+CLOUD_CFG = {
+    "api_key": "test-key",
+    "tenant": "test-tenant",
+    "database": "receipt_test",
+}
+
+
+def make_payload(count: int) -> dict:
+    """Build a payload shaped like build_row_payload/build_word_payload."""
+    return {
+        "ids": [f"id-{i}" for i in range(count)],
+        "embeddings": [[float(i), 0.5] for i in range(count)],
+        "documents": [f"doc {i}" for i in range(count)],
+        "metadatas": [{"receipt_id": i} for i in range(count)],
+    }
+
+
+# =============================================================================
+# Success
+# =============================================================================
+
+
+class TestUpsertSuccess:
+    """Happy-path upserts."""
+
+    def test_single_batch_upserts_every_record(self):
+        """A small payload is written in one batch."""
+        client = MagicMock()
+        with patch(_CLIENT_FACTORY, return_value=client):
+            result = upsert_payload_to_cloud(
+                make_payload(3), "words", CLOUD_CFG
+            )
+
+        assert result.success is True
+        assert result.enabled is True
+        assert result.attempted == 3
+        assert result.upserted == 3
+        assert result.batches == 1
+        assert result.failed_batches == 0
+        assert result.error is None
+        client.close.assert_called_once()
+
+        kwargs = client.upsert.call_args.kwargs
+        assert kwargs["collection_name"] == "words"
+        assert kwargs["ids"] == ["id-0", "id-1", "id-2"]
+        assert kwargs["embeddings"] == [[0.0, 0.5], [1.0, 0.5], [2.0, 0.5]]
+        assert kwargs["documents"] == ["doc 0", "doc 1", "doc 2"]
+        assert kwargs["metadatas"] == [
+            {"receipt_id": 0},
+            {"receipt_id": 1},
+            {"receipt_id": 2},
+        ]
+
+    def test_accepts_cloud_config_dataclass(self):
+        """CloudConfig is accepted alongside the ingest path's dict form."""
+        client = MagicMock()
+        config = CloudConfig(
+            api_key="k", tenant="t", database="d", enabled=True
+        )
+        with patch(_CLIENT_FACTORY, return_value=client) as factory:
+            result = upsert_payload_to_cloud(make_payload(1), "lines", config)
+
+        assert result.success is True
+        assert factory.call_args.args[0] is config
+
+    def test_empty_payload_creates_no_client(self):
+        """Nothing to write means no cloud connection."""
+        with patch(_CLIENT_FACTORY) as factory:
+            result = upsert_payload_to_cloud({"ids": []}, "words", CLOUD_CFG)
+
+        factory.assert_not_called()
+        assert result.enabled is True
+        assert result.attempted == 0
+        assert result.success is True
+
+    def test_payload_without_documents_omits_the_column(self):
+        """A missing payload column is passed through as None."""
+        client = MagicMock()
+        payload = {
+            "ids": ["a"],
+            "embeddings": [[0.1]],
+            "metadatas": [{"k": "v"}],
+        }
+        with patch(_CLIENT_FACTORY, return_value=client):
+            upsert_payload_to_cloud(payload, "words", CLOUD_CFG)
+
+        assert client.upsert.call_args.kwargs["documents"] is None
+
+    def test_oversized_metadata_keys_are_dropped(self):
+        """Keys past Chroma Cloud's 36-byte limit are stripped, not fatal."""
+        client = MagicMock()
+        long_key = "label_" + "x" * 60
+        payload = {
+            "ids": ["a"],
+            "embeddings": [[0.1]],
+            "metadatas": [{long_key: 1, "keep": 2}],
+        }
+        with patch(_CLIENT_FACTORY, return_value=client):
+            result = upsert_payload_to_cloud(payload, "words", CLOUD_CFG)
+
+        assert result.success is True
+        assert client.upsert.call_args.kwargs["metadatas"] == [{"keep": 2}]
+
+
+# =============================================================================
+# Batching
+# =============================================================================
+
+
+class TestUpsertBatching:
+    """Chroma Cloud rejects upserts above 300 records."""
+
+    def test_batch_size_default_stays_under_the_cloud_limit(self):
+        assert UPSERT_BATCH_SIZE <= 300
+
+    def test_large_payload_is_split_into_capped_batches(self):
+        """601 records become three batches of at most 250."""
+        client = MagicMock()
+        with patch(_CLIENT_FACTORY, return_value=client):
+            result = upsert_payload_to_cloud(
+                make_payload(601), "words", CLOUD_CFG
+            )
+
+        assert result.batches == 3
+        assert result.upserted == 601
+        sizes = [
+            len(call.kwargs["ids"]) for call in client.upsert.call_args_list
+        ]
+        assert sizes == [250, 250, 101]
+        assert max(sizes) <= UPSERT_BATCH_SIZE
+
+    def test_requested_batch_size_cannot_exceed_the_cap(self):
+        """An oversized batch_size is clamped rather than trusted."""
+        client = MagicMock()
+        with patch(_CLIENT_FACTORY, return_value=client):
+            result = upsert_payload_to_cloud(
+                make_payload(300),
+                "words",
+                CLOUD_CFG,
+                batch_size=1000,
+            )
+
+        assert result.batches == 2
+        sizes = [
+            len(call.kwargs["ids"]) for call in client.upsert.call_args_list
+        ]
+        assert sizes == [250, 50]
+
+
+# =============================================================================
+# Failure is non-fatal
+# =============================================================================
+
+
+class TestUpsertFailureIsNonFatal:
+    """Cloud is best effort; compaction remains the durable path."""
+
+    def test_partial_batch_failure_does_not_raise(self):
+        """One failing batch is reported, the rest still land."""
+        client = MagicMock()
+        client.upsert.side_effect = [
+            None,
+            RuntimeError("cloud 503"),
+            None,
+        ]
+        with patch(_CLIENT_FACTORY, return_value=client):
+            result = upsert_payload_to_cloud(
+                make_payload(601), "words", CLOUD_CFG
+            )
+
+        assert result.success is False
+        assert result.batches == 3
+        assert result.failed_batches == 1
+        assert result.upserted == 351
+        assert result.attempted == 601
+        assert result.error == "RuntimeError: cloud 503"
+        client.close.assert_called_once()
+
+    def test_every_batch_failing_does_not_raise(self):
+        client = MagicMock()
+        client.upsert.side_effect = RuntimeError("cloud down")
+        with patch(_CLIENT_FACTORY, return_value=client):
+            result = upsert_payload_to_cloud(
+                make_payload(10), "lines", CLOUD_CFG
+            )
+
+        assert result.success is False
+        assert result.upserted == 0
+        assert result.failed_batches == 1
+
+    def test_client_creation_failure_does_not_raise(self):
+        """An unreachable cloud is reported, not propagated."""
+        with patch(_CLIENT_FACTORY, side_effect=ValueError("bad tenant")):
+            result = upsert_payload_to_cloud(
+                make_payload(5), "words", CLOUD_CFG
+            )
+
+        assert result.success is False
+        assert result.error == "ValueError: bad tenant"
+        assert result.upserted == 0
+        assert result.batches == 0
+
+    def test_close_failure_does_not_mask_success(self):
+        client = MagicMock()
+        client.close.side_effect = RuntimeError("close failed")
+        with patch(_CLIENT_FACTORY, return_value=client):
+            result = upsert_payload_to_cloud(
+                make_payload(2), "words", CLOUD_CFG
+            )
+
+        assert result.success is True
+        assert result.upserted == 2
+
+
+# =============================================================================
+# Cloud disabled
+# =============================================================================
+
+
+class TestCloudDisabled:
+    """Absent or incomplete config means the call is a no-op."""
+
+    @pytest.mark.parametrize(
+        "config",
+        [
+            None,
+            {},
+            {"api_key": "k"},
+            {"api_key": "k", "tenant": "t"},
+            {"api_key": "", "tenant": "t", "database": "d"},
+            {"api_key": "k", "tenant": "  ", "database": "d"},
+        ],
+        ids=[
+            "none",
+            "empty",
+            "api_key_only",
+            "missing_database",
+            "blank_api_key",
+            "blank_tenant",
+        ],
+    )
+    def test_incomplete_config_is_a_noop(self, config):
+        with patch(_CLIENT_FACTORY) as factory:
+            result = upsert_payload_to_cloud(make_payload(5), "words", config)
+
+        factory.assert_not_called()
+        assert result.enabled is False
+        assert result.attempted == 0
+        assert result.upserted == 0
+        assert result.error is None
+
+    def test_disabled_cloud_config_dataclass_is_a_noop(self):
+        config = CloudConfig(
+            api_key="k", tenant="t", database="d", enabled=False
+        )
+        with patch(_CLIENT_FACTORY) as factory:
+            result = upsert_payload_to_cloud(make_payload(5), "words", config)
+
+        factory.assert_not_called()
+        assert result.enabled is False
+
+
+# =============================================================================
+# Result
+# =============================================================================
+
+
+class TestCloudUpsertResult:
+    """Result reporting."""
+
+    def test_success_requires_no_error_and_no_failed_batch(self):
+        assert CloudUpsertResult(collection="words").success is True
+        assert (
+            CloudUpsertResult(collection="words", failed_batches=1).success
+            is False
+        )
+        assert (
+            CloudUpsertResult(collection="words", error="boom").success
+            is False
+        )
+
+    def test_to_dict_is_json_serializable(self):
+        import json
+
+        result = CloudUpsertResult(
+            collection="words",
+            attempted=10,
+            upserted=10,
+            batches=1,
+            duration_seconds=1.23456,
+        )
+        payload = json.loads(json.dumps(result.to_dict()))
+        assert payload["collection"] == "words"
+        assert payload["duration_seconds"] == 1.235
+        assert payload["success"] is True

--- a/receipt_chroma/tests/unit/test_cloud_upsert.py
+++ b/receipt_chroma/tests/unit/test_cloud_upsert.py
@@ -1,8 +1,15 @@
 # ruff: noqa: E402
 """Unit tests for direct Chroma Cloud upsert from the ingest path.
 
-Covers the success path, non-fatal partial batch failure, the disabled
-no-op, and batching against Chroma Cloud's 300-record ceiling.
+Covers batching against Chroma Cloud's 300-record ceiling, the disabled
+no-op, non-fatal failure handling, the wall-clock budget, and the two
+Chroma behaviors this module exists to handle: metadata merges on write
+(so cleared keys need explicit ``None`` tombstones) and empty metadata
+dicts being rejected outright.
+
+The tombstone and empty-metadata cases are also exercised against a real
+local Chroma, not just a mock, because both were originally missed by
+mock-only coverage.
 """
 
 # IMPORTANT: Clear Chroma Cloud env vars BEFORE importing chromadb
@@ -24,15 +31,19 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from receipt_chroma.compaction.dual_write import CloudConfig
+from receipt_chroma.data.chroma_client import ChromaClient
 from receipt_chroma.embedding.cloud_upsert import (
+    MAX_DOCUMENT_BYTES,
+    MAX_ID_BYTES,
+    MAX_METADATA_KEYS,
+    MAX_METADATA_VALUE_BYTES,
+    TOMBSTONE_KEYS,
     UPSERT_BATCH_SIZE,
     CloudUpsertResult,
     upsert_payload_to_cloud,
 )
 
-_CLIENT_FACTORY = (
-    "receipt_chroma.embedding.cloud_upsert._create_cloud_client_for_sync"
-)
+_CLIENT_FACTORY = "receipt_chroma.embedding.cloud_upsert._create_cloud_client"
 
 CLOUD_CFG = {
     "api_key": "test-key",
@@ -47,8 +58,18 @@ def make_payload(count: int) -> dict:
         "ids": [f"id-{i}" for i in range(count)],
         "embeddings": [[float(i), 0.5] for i in range(count)],
         "documents": [f"doc {i}" for i in range(count)],
-        "metadatas": [{"receipt_id": i} for i in range(count)],
+        "metadatas": [
+            {"image_id": "img", "receipt_id": i} for i in range(count)
+        ],
     }
+
+
+def sent_metadatas(client) -> list:
+    """Flatten the metadatas from every upsert call on a mock client."""
+    out = []
+    for call in client.upsert.call_args_list:
+        out.extend(call.kwargs["metadatas"])
+    return out
 
 
 # =============================================================================
@@ -73,6 +94,7 @@ class TestUpsertSuccess:
         assert result.upserted == 3
         assert result.batches == 1
         assert result.failed_batches == 0
+        assert result.dropped == 0
         assert result.error is None
         client.close.assert_called_once()
 
@@ -81,11 +103,6 @@ class TestUpsertSuccess:
         assert kwargs["ids"] == ["id-0", "id-1", "id-2"]
         assert kwargs["embeddings"] == [[0.0, 0.5], [1.0, 0.5], [2.0, 0.5]]
         assert kwargs["documents"] == ["doc 0", "doc 1", "doc 2"]
-        assert kwargs["metadatas"] == [
-            {"receipt_id": 0},
-            {"receipt_id": 1},
-            {"receipt_id": 2},
-        ]
 
     def test_accepts_cloud_config_dataclass(self):
         """CloudConfig is accepted alongside the ingest path's dict form."""
@@ -115,36 +132,197 @@ class TestUpsertSuccess:
         payload = {
             "ids": ["a"],
             "embeddings": [[0.1]],
-            "metadatas": [{"k": "v"}],
+            "metadatas": [{"image_id": "img"}],
         }
         with patch(_CLIENT_FACTORY, return_value=client):
             upsert_payload_to_cloud(payload, "words", CLOUD_CFG)
 
         assert client.upsert.call_args.kwargs["documents"] is None
 
-    def test_oversized_metadata_keys_are_dropped(self):
-        """Keys past Chroma Cloud's 36-byte limit are stripped, not fatal."""
+    def test_request_timeout_is_passed_to_the_client(self):
+        """The Cloud session must not be left unbounded."""
         client = MagicMock()
-        long_key = "label_" + "x" * 60
+        with patch(_CLIENT_FACTORY, return_value=client) as factory:
+            upsert_payload_to_cloud(
+                make_payload(1),
+                "words",
+                CLOUD_CFG,
+                request_timeout=(5.0, 15.0),
+            )
+
+        assert factory.call_args.args[2] == (5.0, 15.0)
+
+
+# =============================================================================
+# Tombstones (metadata merges on write)
+# =============================================================================
+
+
+class TestTombstones:
+    """Chroma merges metadata, so cleared keys need explicit None."""
+
+    def test_absent_optional_keys_are_sent_as_none(self):
+        client = MagicMock()
         payload = {
-            "ids": ["a"],
+            "ids": ["w1"],
             "embeddings": [[0.1]],
-            "metadatas": [{long_key: 1, "keep": 2}],
+            "metadatas": [{"image_id": "img", "label_status": "unvalidated"}],
         }
         with patch(_CLIENT_FACTORY, return_value=client):
-            result = upsert_payload_to_cloud(payload, "words", CLOUD_CFG)
+            upsert_payload_to_cloud(payload, "words", CLOUD_CFG)
+
+        (metadata,) = sent_metadatas(client)
+        for key in TOMBSTONE_KEYS["words"]:
+            assert key in metadata, f"{key} must be tombstoned"
+            assert metadata[key] is None
+        assert metadata["label_status"] == "unvalidated"
+
+    def test_present_optional_keys_keep_their_value(self):
+        client = MagicMock()
+        payload = {
+            "ids": ["w1"],
+            "embeddings": [[0.1]],
+            "metadatas": [
+                {"image_id": "img", "valid_labels_array": ["GRAND_TOTAL"]}
+            ],
+        }
+        with patch(_CLIENT_FACTORY, return_value=client):
+            upsert_payload_to_cloud(payload, "words", CLOUD_CFG)
+
+        (metadata,) = sent_metadatas(client)
+        assert metadata["valid_labels_array"] == ["GRAND_TOTAL"]
+        assert metadata["label_confidence"] is None
+
+    def test_lines_use_the_line_tombstone_set(self):
+        client = MagicMock()
+        payload = {
+            "ids": ["l1"],
+            "embeddings": [[0.1]],
+            "metadatas": [{"image_id": "img", "text": "TOTAL"}],
+        }
+        with patch(_CLIENT_FACTORY, return_value=client):
+            upsert_payload_to_cloud(payload, "lines", CLOUD_CFG)
+
+        (metadata,) = sent_metadatas(client)
+        assert metadata["section_label"] is None
+        assert metadata["anchor_phone"] is None
+
+    def test_unknown_collection_adds_no_tombstones(self):
+        client = MagicMock()
+        payload = {
+            "ids": ["x"],
+            "embeddings": [[0.1]],
+            "metadatas": [{"image_id": "img"}],
+        }
+        with patch(_CLIENT_FACTORY, return_value=client):
+            upsert_payload_to_cloud(payload, "other", CLOUD_CFG)
+
+        assert sent_metadatas(client) == [{"image_id": "img"}]
+
+
+class TestTombstonesAgainstRealChroma:
+    """The merge semantics this module compensates for, verified for real."""
+
+    def _client_factory(self, persist_dir):
+        def factory(_config, _collection, _timeout):
+            return ChromaClient(
+                persist_directory=persist_dir,
+                mode="write",
+                metadata_only=True,
+            )
+
+        return factory
+
+    def _read(self, persist_dir, record_id):
+        client = ChromaClient(
+            persist_directory=persist_dir, mode="write", metadata_only=True
+        )
+        try:
+            got = client.get_collection("words").get(
+                ids=[record_id], include=["metadatas"]
+            )
+            return got["metadatas"][0]
+        finally:
+            client.close()
+
+    def test_reingest_clears_a_removed_label_array(self, tmp_path):
+        """Without tombstones the old array survives the re-upsert."""
+        persist_dir = str(tmp_path / "chroma")
+        factory = self._client_factory(persist_dir)
+
+        labelled = {
+            "ids": ["w1"],
+            "embeddings": [[0.1, 0.2]],
+            "documents": ["TOTAL"],
+            "metadatas": [
+                {
+                    "image_id": "img",
+                    "text": "TOTAL",
+                    "label_status": "validated",
+                    "valid_labels_array": ["GRAND_TOTAL"],
+                }
+            ],
+        }
+        with patch(_CLIENT_FACTORY, factory):
+            upsert_payload_to_cloud(labelled, "words", CLOUD_CFG)
+        assert self._read(persist_dir, "w1")["valid_labels_array"] == [
+            "GRAND_TOTAL"
+        ]
+
+        # Label removed upstream: the builder pops the key entirely.
+        unlabelled = {
+            "ids": ["w1"],
+            "embeddings": [[0.1, 0.2]],
+            "documents": ["TOTAL"],
+            "metadatas": [
+                {
+                    "image_id": "img",
+                    "text": "TOTAL",
+                    "label_status": "unvalidated",
+                }
+            ],
+        }
+        with patch(_CLIENT_FACTORY, factory):
+            result = upsert_payload_to_cloud(unlabelled, "words", CLOUD_CFG)
 
         assert result.success is True
-        assert client.upsert.call_args.kwargs["metadatas"] == [{"keep": 2}]
+        metadata = self._read(persist_dir, "w1")
+        assert "valid_labels_array" not in metadata
+        assert metadata["label_status"] == "unvalidated"
+
+    def test_empty_metadata_record_is_dropped_not_batch_failing(
+        self, tmp_path
+    ):
+        """Chroma rejects empty metadata; one bad record must not fail 250."""
+        persist_dir = str(tmp_path / "chroma")
+        oversized_key = "label_" + "x" * 60
+        payload = {
+            "ids": ["good", "bad"],
+            "embeddings": [[0.1, 0.2], [0.3, 0.4]],
+            "documents": ["ok", "dropped"],
+            "metadatas": [
+                {"image_id": "img", "text": "OK"},
+                {oversized_key: 1},
+            ],
+        }
+        with patch(_CLIENT_FACTORY, self._client_factory(persist_dir)):
+            result = upsert_payload_to_cloud(payload, "words", CLOUD_CFG)
+
+        assert result.upserted == 1
+        assert result.dropped == 1
+        assert result.drop_reasons == {"empty_metadata": 1}
+        assert result.failed_batches == 0
+        assert result.success is False
+        assert self._read(persist_dir, "good")["text"] == "OK"
 
 
 # =============================================================================
-# Batching
+# Cloud limits
 # =============================================================================
 
 
-class TestUpsertBatching:
-    """Chroma Cloud rejects upserts above 300 records."""
+class TestCloudLimits:
+    """Quotas from docs.trychroma.com/cloud/quotas-limits."""
 
     def test_batch_size_default_stays_under_the_cloud_limit(self):
         assert UPSERT_BATCH_SIZE <= 300
@@ -163,17 +341,12 @@ class TestUpsertBatching:
             len(call.kwargs["ids"]) for call in client.upsert.call_args_list
         ]
         assert sizes == [250, 250, 101]
-        assert max(sizes) <= UPSERT_BATCH_SIZE
 
     def test_requested_batch_size_cannot_exceed_the_cap(self):
-        """An oversized batch_size is clamped rather than trusted."""
         client = MagicMock()
         with patch(_CLIENT_FACTORY, return_value=client):
             result = upsert_payload_to_cloud(
-                make_payload(300),
-                "words",
-                CLOUD_CFG,
-                batch_size=1000,
+                make_payload(300), "words", CLOUD_CFG, batch_size=1000
             )
 
         assert result.batches == 2
@@ -182,6 +355,88 @@ class TestUpsertBatching:
         ]
         assert sizes == [250, 50]
 
+    def test_oversized_metadata_value_is_truncated(self):
+        client = MagicMock()
+        payload = {
+            "ids": ["a"],
+            "embeddings": [[0.1]],
+            "metadatas": [{"image_id": "img", "text": "x" * 20000}],
+        }
+        with patch(_CLIENT_FACTORY, return_value=client):
+            result = upsert_payload_to_cloud(payload, "words", CLOUD_CFG)
+
+        (metadata,) = sent_metadatas(client)
+        assert len(metadata["text"].encode("utf-8")) <= (
+            MAX_METADATA_VALUE_BYTES
+        )
+        assert result.truncated == 1
+        assert result.upserted == 1
+
+    def test_oversized_document_is_truncated(self):
+        client = MagicMock()
+        payload = {
+            "ids": ["a"],
+            "embeddings": [[0.1]],
+            "documents": ["y" * (MAX_DOCUMENT_BYTES + 500)],
+            "metadatas": [{"image_id": "img"}],
+        }
+        with patch(_CLIENT_FACTORY, return_value=client):
+            result = upsert_payload_to_cloud(payload, "words", CLOUD_CFG)
+
+        document = client.upsert.call_args.kwargs["documents"][0]
+        assert len(document.encode("utf-8")) <= MAX_DOCUMENT_BYTES
+        assert result.truncated == 1
+
+    def test_too_many_keys_are_truncated_keeping_identity(self):
+        client = MagicMock()
+        metadata = {f"extra_{i}": i for i in range(60)}
+        metadata.update({"image_id": "img", "receipt_id": 1, "word_id": 2})
+        payload = {
+            "ids": ["a"],
+            "embeddings": [[0.1]],
+            "metadatas": [metadata],
+        }
+        with patch(_CLIENT_FACTORY, return_value=client):
+            result = upsert_payload_to_cloud(payload, "words", CLOUD_CFG)
+
+        (sent,) = sent_metadatas(client)
+        assert len(sent) <= MAX_METADATA_KEYS
+        assert sent["image_id"] == "img"
+        assert sent["receipt_id"] == 1
+        assert sent["word_id"] == 2
+        assert result.truncated == 1
+
+    def test_oversized_id_is_dropped_not_truncated(self):
+        """Truncating an id would corrupt identity."""
+        client = MagicMock()
+        payload = {
+            "ids": ["ok", "z" * (MAX_ID_BYTES + 1)],
+            "embeddings": [[0.1], [0.2]],
+            "metadatas": [{"image_id": "img"}, {"image_id": "img"}],
+        }
+        with patch(_CLIENT_FACTORY, return_value=client):
+            result = upsert_payload_to_cloud(payload, "words", CLOUD_CFG)
+
+        assert result.dropped == 1
+        assert result.drop_reasons == {"id_too_long": 1}
+        assert client.upsert.call_args.kwargs["ids"] == ["ok"]
+
+    @pytest.mark.parametrize(
+        "column", ["embeddings", "documents", "metadatas"]
+    )
+    def test_mismatched_column_length_writes_nothing(self, column):
+        """Misaligned columns would attach metadata to the wrong record."""
+        payload = make_payload(3)
+        payload[column] = payload[column][:2]
+
+        with patch(_CLIENT_FACTORY) as factory:
+            result = upsert_payload_to_cloud(payload, "words", CLOUD_CFG)
+
+        factory.assert_not_called()
+        assert result.success is False
+        assert result.upserted == 0
+        assert "ColumnLengthMismatch" in result.error
+
 
 # =============================================================================
 # Failure is non-fatal
@@ -189,43 +444,47 @@ class TestUpsertBatching:
 
 
 class TestUpsertFailureIsNonFatal:
-    """Cloud is best effort; compaction remains the durable path."""
+    """Cloud is best effort; the S3 delta remains the durable path."""
 
-    def test_partial_batch_failure_does_not_raise(self):
-        """One failing batch is reported, the rest still land."""
+    def test_batch_value_error_falls_back_to_per_record(self):
+        """One rejected record must not cost the rest of its batch."""
         client = MagicMock()
-        client.upsert.side_effect = [
-            None,
-            RuntimeError("cloud 503"),
-            None,
-        ]
+        rejected = []
+
+        def upsert(**kwargs):
+            ids = kwargs["ids"]
+            if len(ids) > 1:
+                raise ValueError("Expected metadata to be a non-empty dict")
+            if ids == ["id-1"]:
+                rejected.append(ids)
+                raise ValueError("bad record")
+
+        client.upsert.side_effect = upsert
         with patch(_CLIENT_FACTORY, return_value=client):
             result = upsert_payload_to_cloud(
-                make_payload(601), "words", CLOUD_CFG
+                make_payload(3), "words", CLOUD_CFG
             )
 
-        assert result.success is False
-        assert result.batches == 3
-        assert result.failed_batches == 1
-        assert result.upserted == 351
-        assert result.attempted == 601
-        assert result.error == "RuntimeError: cloud 503"
-        client.close.assert_called_once()
+        assert result.upserted == 2
+        assert result.dropped == 1
+        assert result.drop_reasons == {"rejected": 1}
+        assert result.failed_batches == 0
+        assert rejected == [["id-1"]]
 
-    def test_every_batch_failing_does_not_raise(self):
+    def test_non_value_error_fails_the_batch_without_raising(self):
         client = MagicMock()
-        client.upsert.side_effect = RuntimeError("cloud down")
+        client.upsert.side_effect = RuntimeError("cloud 503")
         with patch(_CLIENT_FACTORY, return_value=client):
             result = upsert_payload_to_cloud(
                 make_payload(10), "lines", CLOUD_CFG
             )
 
         assert result.success is False
-        assert result.upserted == 0
         assert result.failed_batches == 1
+        assert result.upserted == 0
+        assert result.error == "RuntimeError: cloud 503"
 
     def test_client_creation_failure_does_not_raise(self):
-        """An unreachable cloud is reported, not propagated."""
         with patch(_CLIENT_FACTORY, side_effect=ValueError("bad tenant")):
             result = upsert_payload_to_cloud(
                 make_payload(5), "words", CLOUD_CFG
@@ -234,7 +493,6 @@ class TestUpsertFailureIsNonFatal:
         assert result.success is False
         assert result.error == "ValueError: bad tenant"
         assert result.upserted == 0
-        assert result.batches == 0
 
     def test_close_failure_does_not_mask_success(self):
         client = MagicMock()
@@ -246,6 +504,51 @@ class TestUpsertFailureIsNonFatal:
 
         assert result.success is True
         assert result.upserted == 2
+
+
+class TestDeadline:
+    """A stalled Cloud must not eat the caller's remaining runtime."""
+
+    def test_slow_batches_stop_at_the_deadline(self):
+        """Once the budget is spent, remaining records go to compaction."""
+        client = MagicMock()
+        clock = {"now": 0.0}
+
+        def upsert(**_kwargs):
+            clock["now"] += 40.0
+
+        client.upsert.side_effect = upsert
+        with (
+            patch(_CLIENT_FACTORY, return_value=client),
+            patch(
+                "receipt_chroma.embedding.cloud_upsert.time.monotonic",
+                side_effect=lambda: clock["now"],
+            ),
+        ):
+            result = upsert_payload_to_cloud(
+                make_payload(750),
+                "words",
+                CLOUD_CFG,
+                deadline_seconds=60.0,
+            )
+
+        # First batch runs, second starts at 40s, third is past 60s.
+        assert result.deadline_exceeded is True
+        assert result.batches == 2
+        assert result.upserted == 500
+        assert result.success is False
+        assert "deadline" in result.error
+        client.close.assert_called_once()
+
+    def test_fast_batches_never_trip_the_deadline(self):
+        client = MagicMock()
+        with patch(_CLIENT_FACTORY, return_value=client):
+            result = upsert_payload_to_cloud(
+                make_payload(500), "words", CLOUD_CFG, deadline_seconds=60.0
+            )
+
+        assert result.deadline_exceeded is False
+        assert result.upserted == 500
 
 
 # =============================================================================
@@ -304,16 +607,18 @@ class TestCloudDisabled:
 class TestCloudUpsertResult:
     """Result reporting."""
 
-    def test_success_requires_no_error_and_no_failed_batch(self):
+    def test_success_requires_a_completely_clean_run(self):
         assert CloudUpsertResult(collection="words").success is True
-        assert (
-            CloudUpsertResult(collection="words", failed_batches=1).success
-            is False
-        )
-        assert (
-            CloudUpsertResult(collection="words", error="boom").success
-            is False
-        )
+        for kwargs in (
+            {"failed_batches": 1},
+            {"error": "boom"},
+            {"dropped": 1},
+            {"deadline_exceeded": True},
+        ):
+            assert (
+                CloudUpsertResult(collection="words", **kwargs).success
+                is False
+            ), kwargs
 
     def test_to_dict_is_json_serializable(self):
         import json

--- a/receipt_chroma/tests/unit/test_cloud_upsert.py
+++ b/receipt_chroma/tests/unit/test_cloud_upsert.py
@@ -822,11 +822,84 @@ class TestOrphanedThreadBackpressure:
                 )
 
             assert blocked.success is False
-            assert blocked.drop_reasons == {"orphaned_threads": 1}
+            assert blocked.backpressure is True
             assert "still in flight" in blocked.error
             assert blocked.batches == 0
         finally:
             gate.set()
+
+    def test_every_skipped_record_is_counted(self):
+        """The metric exists to size the incident it reports."""
+        gate = threading.Event()
+
+        def blocks_until_released(*_args, **_kwargs):
+            gate.wait(30)
+            raise RuntimeError("released")
+
+        try:
+            with patch(_CLIENT_FACTORY, side_effect=blocks_until_released):
+                for _ in range(MAX_ORPHANED_ATTEMPTS):
+                    upsert_payload_to_cloud(
+                        make_payload(1),
+                        "words",
+                        CLOUD_CFG,
+                        deadline_seconds=0.05,
+                    )
+
+                blocked = upsert_payload_to_cloud(
+                    make_payload(37),
+                    "words",
+                    CLOUD_CFG,
+                    deadline_seconds=5.0,
+                )
+
+            assert blocked.attempted == 37
+            assert blocked.upserted == 0
+            assert blocked.dropped == 37
+            assert blocked.drop_reasons == {"orphaned_threads": 37}
+        finally:
+            gate.set()
+
+    def test_rejection_telemetry_is_time_bounded(self):
+        """Earlier attempts are stuck on I/O; the log sink may be too."""
+        gate = threading.Event()
+
+        def blocks_until_released(*_args, **_kwargs):
+            gate.wait(30)
+            raise RuntimeError("released")
+
+        slow_log = MagicMock()
+        slow_log.warning.side_effect = lambda *a, **k: time.sleep(5)
+
+        try:
+            with patch(_CLIENT_FACTORY, side_effect=blocks_until_released):
+                for _ in range(MAX_ORPHANED_ATTEMPTS):
+                    upsert_payload_to_cloud(
+                        make_payload(1),
+                        "words",
+                        CLOUD_CFG,
+                        deadline_seconds=0.05,
+                    )
+
+                began = time.monotonic()
+                blocked = upsert_payload_to_cloud(
+                    make_payload(5),
+                    "words",
+                    CLOUD_CFG,
+                    deadline_seconds=0.05,
+                    log=slow_log,
+                )
+                elapsed = time.monotonic() - began
+
+            assert blocked.backpressure is True
+            assert elapsed < 2.0, f"rejection tail unbounded: {elapsed:.2f}s"
+        finally:
+            gate.set()
+
+    def test_backpressure_asks_callers_to_bound_their_telemetry(self):
+        result = CloudUpsertResult(collection="words", backpressure=True)
+        assert result.telemetry_must_be_bounded is True
+        assert result.success is False
 
     def test_permits_are_returned_after_a_normal_run(self):
         client = MagicMock()
@@ -894,6 +967,19 @@ class TestCloudDisabled:
 class TestCloudUpsertResult:
     """Result reporting."""
 
+    def test_telemetry_is_unbounded_only_on_a_healthy_run(self):
+        assert (
+            CloudUpsertResult(collection="words").telemetry_must_be_bounded
+            is False
+        )
+        for kwargs in ({"deadline_exceeded": True}, {"backpressure": True}):
+            assert (
+                CloudUpsertResult(
+                    collection="words", **kwargs
+                ).telemetry_must_be_bounded
+                is True
+            ), kwargs
+
     def test_success_requires_a_completely_clean_run(self):
         assert CloudUpsertResult(collection="words").success is True
         for kwargs in (
@@ -901,6 +987,7 @@ class TestCloudUpsertResult:
             {"error": "boom"},
             {"dropped": 1},
             {"deadline_exceeded": True},
+            {"backpressure": True},
         ):
             assert (
                 CloudUpsertResult(collection="words", **kwargs).success

--- a/receipt_chroma/tests/unit/test_cloud_upsert.py
+++ b/receipt_chroma/tests/unit/test_cloud_upsert.py
@@ -41,18 +41,35 @@ from chromadb.errors import (
 
 from receipt_chroma.compaction.dual_write import CloudConfig
 from receipt_chroma.data.chroma_client import ChromaClient
+from receipt_chroma.embedding import cloud_upsert as cu
 from receipt_chroma.embedding.cloud_upsert import (
     MAX_DOCUMENT_BYTES,
     MAX_ID_BYTES,
     MAX_METADATA_KEYS,
     MAX_METADATA_VALUE_BYTES,
+    MAX_ORPHANED_ATTEMPTS,
     TOMBSTONE_KEYS,
     UPSERT_BATCH_SIZE,
     CloudUpsertResult,
+    emit_within_budget,
     upsert_payload_to_cloud,
 )
 
 _CLIENT_FACTORY = "receipt_chroma.embedding.cloud_upsert._create_cloud_client"
+
+
+@pytest.fixture(autouse=True)
+def _fresh_backpressure_permits(monkeypatch):
+    """Give each test its own permits.
+
+    An abandoned attempt keeps its permit until the thread behind it
+    unwinds, so without this the deadline tests would starve whichever
+    test ran next.
+    """
+    monkeypatch.setattr(
+        cu, "_orphaned_attempts", threading.Semaphore(MAX_ORPHANED_ATTEMPTS)
+    )
+
 
 CLOUD_CFG = {
     "api_key": "test-key",
@@ -584,6 +601,52 @@ class TestValidationErrorFallback:
         assert result.failed_batches == 1
         assert result.upserted == 0
 
+    @pytest.mark.parametrize(
+        "error",
+        [RateLimitError("429"), QuotaError("quota exhausted")],
+        ids=["rate_limit", "quota"],
+    )
+    def test_throttling_mid_fallback_aborts_the_rest(self, error):
+        """Excluding them from the batch catch is not enough on its own."""
+        client = MagicMock()
+
+        def upsert(**kwargs):
+            if len(kwargs["ids"]) > 1:
+                raise InvalidArgumentError("batch rejected")
+            raise error
+
+        client.upsert.side_effect = upsert
+        with patch(_CLIENT_FACTORY, return_value=client):
+            result = upsert_payload_to_cloud(
+                make_payload(50), "words", CLOUD_CFG
+            )
+
+        # One batch attempt, then exactly one singleton before the abort.
+        assert client.upsert.call_count == 2
+        assert result.upserted == 0
+        assert result.drop_reasons == {"rate_limited_abort": 50}
+        assert result.success is False
+
+    def test_throttling_after_some_singletons_succeed(self):
+        client = MagicMock()
+        seen = {"singletons": 0}
+
+        def upsert(**kwargs):
+            if len(kwargs["ids"]) > 1:
+                raise InvalidArgumentError("batch rejected")
+            seen["singletons"] += 1
+            if seen["singletons"] > 2:
+                raise RateLimitError("429")
+
+        client.upsert.side_effect = upsert
+        with patch(_CLIENT_FACTORY, return_value=client):
+            result = upsert_payload_to_cloud(
+                make_payload(10), "words", CLOUD_CFG
+            )
+
+        assert result.upserted == 2
+        assert result.drop_reasons == {"rate_limited_abort": 8}
+
 
 class TestDeadline:
     """A stalled Cloud must not eat the caller's remaining runtime."""
@@ -682,6 +745,97 @@ class TestDeadline:
         assert result.deadline_exceeded is True
         assert result.upserted < 10
         assert "per-record fallback" in result.error
+
+
+class TestBoundedTail:
+    """Reporting an overrun must not extend it."""
+
+    def test_a_blocked_log_sink_cannot_extend_the_overrun(self):
+        """A slow handler after the join would undo the whole budget."""
+        started = threading.Event()
+
+        def never_returns(*_args, **_kwargs):
+            started.set()
+            time.sleep(30)
+
+        slow_log = MagicMock()
+        slow_log.warning.side_effect = lambda *a, **k: time.sleep(5)
+
+        began = time.monotonic()
+        with patch(_CLIENT_FACTORY, side_effect=never_returns):
+            result = upsert_payload_to_cloud(
+                make_payload(5),
+                "words",
+                CLOUD_CFG,
+                deadline_seconds=0.1,
+                log=slow_log,
+            )
+        elapsed = time.monotonic() - began
+
+        assert started.is_set()
+        assert result.deadline_exceeded is True
+        assert elapsed < 2.0, f"tail was unbounded: {elapsed:.2f}s"
+
+    def test_emit_within_budget_reports_completion(self):
+        assert emit_within_budget(lambda: None) is True
+        assert (
+            emit_within_budget(lambda: time.sleep(2), grace_seconds=0.05)
+            is False
+        )
+
+    def test_emit_within_budget_swallows_failures(self):
+        def boom():
+            raise RuntimeError("sink is gone")
+
+        assert emit_within_budget(boom) is True
+
+
+class TestOrphanedThreadBackpressure:
+    """Abandoned attempts can pile up in a warm container."""
+
+    def test_too_many_in_flight_attempts_skip_the_write(self):
+        gate = threading.Event()
+
+        def blocks_until_released(*_args, **_kwargs):
+            gate.wait(30)
+            raise RuntimeError("released")
+
+        try:
+            with patch(_CLIENT_FACTORY, side_effect=blocks_until_released):
+                stuck = [
+                    upsert_payload_to_cloud(
+                        make_payload(1),
+                        "words",
+                        CLOUD_CFG,
+                        deadline_seconds=0.05,
+                    )
+                    for _ in range(MAX_ORPHANED_ATTEMPTS)
+                ]
+                assert all(r.deadline_exceeded for r in stuck)
+
+                # The permits are all held by threads that never finished.
+                blocked = upsert_payload_to_cloud(
+                    make_payload(1),
+                    "words",
+                    CLOUD_CFG,
+                    deadline_seconds=5.0,
+                )
+
+            assert blocked.success is False
+            assert blocked.drop_reasons == {"orphaned_threads": 1}
+            assert "still in flight" in blocked.error
+            assert blocked.batches == 0
+        finally:
+            gate.set()
+
+    def test_permits_are_returned_after_a_normal_run(self):
+        client = MagicMock()
+        for _ in range(MAX_ORPHANED_ATTEMPTS + 2):
+            with patch(_CLIENT_FACTORY, return_value=client):
+                result = upsert_payload_to_cloud(
+                    make_payload(1), "words", CLOUD_CFG
+                )
+            assert result.success is True
 
 
 # =============================================================================

--- a/receipt_chroma/tests/unit/test_cloud_upsert.py
+++ b/receipt_chroma/tests/unit/test_cloud_upsert.py
@@ -26,9 +26,18 @@ _CHROMA_ENV_VARS = [
 for _var in _CHROMA_ENV_VARS:
     os.environ.pop(_var, None)
 
+import threading
+import time
 from unittest.mock import MagicMock, patch
 
 import pytest
+from chromadb.errors import (
+    BatchSizeExceededError,
+    DuplicateIDError,
+    InvalidArgumentError,
+    QuotaError,
+    RateLimitError,
+)
 
 from receipt_chroma.compaction.dual_write import CloudConfig
 from receipt_chroma.data.chroma_client import ChromaClient
@@ -206,6 +215,21 @@ class TestTombstones:
         (metadata,) = sent_metadatas(client)
         assert metadata["section_label"] is None
         assert metadata["anchor_phone"] is None
+
+    def test_legacy_neighbour_fields_are_tombstoned(self):
+        """Row ids reuse the primary line id, so pre-row records persist."""
+        client = MagicMock()
+        payload = {
+            "ids": ["l1"],
+            "embeddings": [[0.1]],
+            "metadatas": [{"image_id": "img", "text": "TOTAL"}],
+        }
+        with patch(_CLIENT_FACTORY, return_value=client):
+            upsert_payload_to_cloud(payload, "lines", CLOUD_CFG)
+
+        (metadata,) = sent_metadatas(client)
+        assert metadata["prev_line"] is None
+        assert metadata["next_line"] is None
 
     def test_unknown_collection_adds_no_tombstones(self):
         client = MagicMock()
@@ -506,6 +530,61 @@ class TestUpsertFailureIsNonFatal:
         assert result.upserted == 2
 
 
+class TestValidationErrorFallback:
+    """Cloud maps validation 400s to ChromaError, not ValueError."""
+
+    @pytest.mark.parametrize(
+        "error",
+        [
+            ValueError("Expected metadata to be a non-empty dict"),
+            InvalidArgumentError("metadata value too large"),
+            BatchSizeExceededError("batch too large"),
+            DuplicateIDError("duplicate id"),
+        ],
+        ids=[
+            "value_error",
+            "invalid_argument",
+            "batch_size",
+            "duplicate_id",
+        ],
+    )
+    def test_validation_errors_trigger_per_record_fallback(self, error):
+        client = MagicMock()
+        seen = []
+
+        def upsert(**kwargs):
+            seen.append(len(kwargs["ids"]))
+            if len(kwargs["ids"]) > 1:
+                raise error
+
+        client.upsert.side_effect = upsert
+        with patch(_CLIENT_FACTORY, return_value=client):
+            result = upsert_payload_to_cloud(
+                make_payload(3), "words", CLOUD_CFG
+            )
+
+        assert seen == [3, 1, 1, 1]
+        assert result.upserted == 3
+
+    @pytest.mark.parametrize(
+        "error",
+        [RateLimitError("429"), QuotaError("quota exhausted")],
+        ids=["rate_limit", "quota"],
+    )
+    def test_rate_and_quota_errors_do_not_fan_out(self, error):
+        """250 retries would make a rate limit strictly worse."""
+        client = MagicMock()
+        client.upsert.side_effect = error
+        with patch(_CLIENT_FACTORY, return_value=client):
+            result = upsert_payload_to_cloud(
+                make_payload(3), "words", CLOUD_CFG
+            )
+
+        assert client.upsert.call_count == 1
+        assert result.failed_batches == 1
+        assert result.upserted == 0
+
+
 class TestDeadline:
     """A stalled Cloud must not eat the caller's remaining runtime."""
 
@@ -549,6 +628,60 @@ class TestDeadline:
 
         assert result.deadline_exceeded is False
         assert result.upserted == 500
+
+    def test_a_stalled_client_constructor_cannot_outlast_the_budget(self):
+        """Chroma's CloudClient() issues its own untimed requests."""
+        started = threading.Event()
+
+        def never_returns(*_args, **_kwargs):
+            started.set()
+            time.sleep(30)
+            raise AssertionError("should have been abandoned")
+
+        began = time.monotonic()
+        with patch(_CLIENT_FACTORY, side_effect=never_returns):
+            result = upsert_payload_to_cloud(
+                make_payload(5),
+                "words",
+                CLOUD_CFG,
+                deadline_seconds=0.5,
+            )
+        elapsed = time.monotonic() - began
+
+        assert started.is_set()
+        assert elapsed < 5.0, "returned only after the constructor stalled"
+        assert result.deadline_exceeded is True
+        assert result.success is False
+        assert result.upserted == 0
+
+    def test_per_record_fallback_checks_the_deadline(self):
+        """A rejected batch is 250 more chances to stall."""
+        client = MagicMock()
+        clock = {"now": 0.0}
+
+        def upsert(**kwargs):
+            if len(kwargs["ids"]) > 1:
+                raise ValueError("batch rejected")
+            clock["now"] += 30.0
+
+        client.upsert.side_effect = upsert
+        with (
+            patch(_CLIENT_FACTORY, return_value=client),
+            patch(
+                "receipt_chroma.embedding.cloud_upsert.time.monotonic",
+                side_effect=lambda: clock["now"],
+            ),
+        ):
+            result = upsert_payload_to_cloud(
+                make_payload(10),
+                "words",
+                CLOUD_CFG,
+                deadline_seconds=60.0,
+            )
+
+        assert result.deadline_exceeded is True
+        assert result.upserted < 10
+        assert "per-record fallback" in result.error
 
 
 # =============================================================================

--- a/receipt_upload/receipt_upload/merchant_resolution/embedding_processor.py
+++ b/receipt_upload/receipt_upload/merchant_resolution/embedding_processor.py
@@ -27,7 +27,9 @@ Tracing:
 import json
 import logging
 import os
+import pickle
 import shutil
+import tempfile
 import time
 import uuid
 from concurrent.futures import ProcessPoolExecutor, as_completed
@@ -45,6 +47,7 @@ from receipt_chroma.embedding import (
     upload_words_delta,
     upsert_payload_to_cloud,
 )
+from receipt_chroma.embedding.cloud_upsert import DEFAULT_REQUEST_TIMEOUT
 from receipt_dynamo import DynamoClient
 from receipt_dynamo.constants import ValidationStatus
 from receipt_dynamo.entities import ReceiptLine, ReceiptWord, ReceiptWordLabel
@@ -178,6 +181,9 @@ def _make_read_client(
             cloud_api_key=cloud_cfg["api_key"],
             cloud_tenant=cloud_cfg["tenant"],
             cloud_database=cloud_cfg["database"],
+            # Chroma leaves its Cloud session unbounded; without this a
+            # stalled read hangs until the Lambda itself times out.
+            cloud_request_timeout=DEFAULT_REQUEST_TIMEOUT,
         )
     return ChromaClient(
         persist_directory=local_dir,
@@ -237,25 +243,63 @@ def _emit_emf_metrics(
     print(json.dumps(emf))
 
 
-def _upload_delta_then_publish(
-    upload: Callable[[], str],
+def _stage_cloud_payload(
     payload: Dict[str, Any],
+    collection_name: str,
+    cloud_cfg: Optional[Dict[str, str]],
+) -> Optional[str]:
+    """Park a payload on local disk for the parent to publish later.
+
+    A record is only recoverable once its CompactionRun exists, and that row
+    is written by the parent after both workers finish. So a worker cannot
+    publish its own payload -- it hands it back instead. The handoff goes
+    through a file because Phase 2 runs on processes outside Lambda (see
+    ``_get_phase2_executor_class``), where an in-memory reference would not
+    survive; the file is local to the host either way and the parent deletes
+    it in its finally block.
+
+    Returns the path, or None when Cloud is disabled or staging failed --
+    both of which just mean this receipt waits for compaction.
+    """
+    if not cloud_cfg:
+        return None
+    try:
+        handle, path = tempfile.mkstemp(
+            prefix=f"cloud-publish-{collection_name}-", suffix=".pkl"
+        )
+        with os.fdopen(handle, "wb") as staged:
+            pickle.dump(payload, staged, protocol=pickle.HIGHEST_PROTOCOL)
+        return path
+    except Exception:  # pylint: disable=broad-exception-caught
+        logger.exception(
+            "Could not stage %s payload for Chroma Cloud publication",
+            collection_name,
+        )
+        return None
+
+
+def _publish_staged_payload(
+    path: Optional[str],
     collection_name: str,
     cloud_cfg: Optional[Dict[str, str]],
     image_id: str,
     receipt_id: int,
     labels_fetched_at: Optional[float] = None,
-) -> str:
-    """Upload the delta tarball, then publish the same payload to Cloud.
+) -> None:
+    """Publish a payload a worker staged, once its CompactionRun is durable."""
+    if not path or not cloud_cfg:
+        return
+    try:
+        with open(path, "rb") as staged:
+            payload = pickle.load(staged)
+    except Exception:  # pylint: disable=broad-exception-caught
+        logger.exception(
+            "Could not read staged %s payload; leaving publication to "
+            "compaction",
+            collection_name,
+        )
+        return
 
-    The order matters and is the whole contract: the delta plus its
-    CompactionRun are what make a record recoverable. Publishing to Cloud
-    first would leave records visible with nothing to reconcile them if the
-    upload then failed, because no CompactionRun is created unless both
-    collections produced a prefix. If ``upload`` raises, this propagates and
-    the Cloud write never happens.
-    """
-    prefix = upload()
     _upsert_to_cloud_nonfatal(
         payload=payload,
         collection_name=collection_name,
@@ -264,7 +308,18 @@ def _upload_delta_then_publish(
         receipt_id=receipt_id,
         labels_fetched_at=labels_fetched_at,
     )
-    return prefix
+
+
+def _discard_staged_payload(path: Optional[str]) -> None:
+    """Remove a staged payload file, published or not."""
+    if not path:
+        return
+    try:
+        os.unlink(path)
+    except FileNotFoundError:
+        pass
+    except Exception:  # pylint: disable=broad-exception-caught
+        logger.warning("Could not remove staged payload %s", path)
 
 
 def _max_label_age_seconds() -> float:
@@ -801,30 +856,30 @@ def _run_lines_pipeline_worker(
             if not cloud_cfg:
                 client.upsert(collection_name="lines", **line_payload)
 
-            # Upload delta to S3, then publish to Chroma Cloud so these rows
-            # are queryable without waiting for compaction.
+            # Upload delta to S3
             import boto3
 
             s3_client = boto3.client("s3")
-            prefix = _upload_delta_then_publish(
-                upload=lambda: upload_lines_delta(
-                    line_payload=line_payload,
-                    run_id=run_id,
-                    chromadb_bucket=chromadb_bucket,
-                    s3_client=s3_client,
-                ),
-                payload=line_payload,
-                collection_name="lines",
-                cloud_cfg=cloud_cfg,
-                image_id=image_id,
-                receipt_id=receipt_id,
-                labels_fetched_at=labels_fetched_at,
+            prefix = upload_lines_delta(
+                line_payload=line_payload,
+                run_id=run_id,
+                chromadb_bucket=chromadb_bucket,
+                s3_client=s3_client,
+            )
+
+            # Hand the payload back for the parent to publish to Chroma Cloud
+            # once the CompactionRun exists. Publishing here would put records
+            # in Cloud that nothing can reconcile if the other pipeline or the
+            # CompactionRun write then fails.
+            cloud_payload_path = _stage_cloud_payload(
+                line_payload, "lines", cloud_cfg
             )
 
             # Return serializable result
             return {
                 "success": True,
                 "lines_prefix": prefix,
+                "cloud_payload_path": cloud_payload_path,
                 # Metrics-only observability (no behavior change): visual-row
                 # provenance and deterministic section-proposal stats.
                 "row_count": len(persisted_rows),
@@ -1228,29 +1283,29 @@ def _run_words_pipeline_worker(
             if not cloud_cfg:
                 client.upsert(collection_name="words", **word_payload)
 
-            # Upload delta to S3, then publish to Chroma Cloud so these words
-            # are queryable without waiting for compaction.
+            # Upload delta to S3
             import boto3
 
             s3_client = boto3.client("s3")
-            prefix = _upload_delta_then_publish(
-                upload=lambda: upload_words_delta(
-                    word_payload=word_payload,
-                    run_id=run_id,
-                    chromadb_bucket=chromadb_bucket,
-                    s3_client=s3_client,
-                ),
-                payload=word_payload,
-                collection_name="words",
-                cloud_cfg=cloud_cfg,
-                image_id=image_id,
-                receipt_id=receipt_id,
-                labels_fetched_at=labels_fetched_at,
+            prefix = upload_words_delta(
+                word_payload=word_payload,
+                run_id=run_id,
+                chromadb_bucket=chromadb_bucket,
+                s3_client=s3_client,
+            )
+
+            # Hand the payload back for the parent to publish to Chroma Cloud
+            # once the CompactionRun exists. Publishing here would put records
+            # in Cloud that nothing can reconcile if the other pipeline or the
+            # CompactionRun write then fails.
+            cloud_payload_path = _stage_cloud_payload(
+                word_payload, "words", cloud_cfg
             )
 
             return {
                 "success": True,
                 "words_prefix": prefix,
+                "cloud_payload_path": cloud_payload_path,
                 "async_llm_payload": async_llm_payload,
                 **validation_stats,
             }
@@ -1518,6 +1573,9 @@ class MerchantResolvingEmbeddingProcessor:
         lines_stats: Dict[str, Any] = {}
         lines_prefix: Optional[str] = None
         words_prefix: Optional[str] = None
+        lines_cloud_payload: Optional[str] = None
+        words_cloud_payload: Optional[str] = None
+        compaction_run_created = False
 
         try:
             # =================================================================
@@ -1616,6 +1674,9 @@ class MerchantResolvingEmbeddingProcessor:
                 try:
                     lines_result = lines_future.result()
                     lines_prefix = lines_result.get("lines_prefix")
+                    lines_cloud_payload = lines_result.get(
+                        "cloud_payload_path"
+                    )
 
                     # Observability-only stats from the lines pipeline: row
                     # provenance, section proposals, verification outcomes.
@@ -1702,6 +1763,9 @@ class MerchantResolvingEmbeddingProcessor:
                 try:
                     words_result = words_future.result()
                     words_prefix = words_result.get("words_prefix")
+                    words_cloud_payload = words_result.get(
+                        "cloud_payload_path"
+                    )
                     async_llm_payload = words_result.get("async_llm_payload")
                     if words_result.get("success"):
                         validation_stats = {
@@ -1711,6 +1775,7 @@ class MerchantResolvingEmbeddingProcessor:
                             not in (
                                 "success",
                                 "words_prefix",
+                                "cloud_payload_path",
                                 "async_llm_payload",
                             )
                         }
@@ -1726,18 +1791,55 @@ class MerchantResolvingEmbeddingProcessor:
             # PHASE 3: Create compaction run (after both deltas uploaded)
             # =================================================================
             if lines_prefix and words_prefix:
-                create_compaction_run(
-                    run_id=run_id,
-                    image_id=image_id,
-                    receipt_id=receipt_id,
-                    lines_prefix=lines_prefix,
-                    words_prefix=words_prefix,
-                    dynamo_client=self.dynamo,
-                )
-                _log(f"Phase 3 complete: created compaction run {run_id}")
+                try:
+                    create_compaction_run(
+                        run_id=run_id,
+                        image_id=image_id,
+                        receipt_id=receipt_id,
+                        lines_prefix=lines_prefix,
+                        words_prefix=words_prefix,
+                        dynamo_client=self.dynamo,
+                    )
+                    compaction_run_created = True
+                    _log(f"Phase 3 complete: created compaction run {run_id}")
+                except Exception as e:
+                    _log(f"ERROR: Failed to create compaction run: {e}")
+                    logger.exception("Compaction run creation failed")
             else:
                 _log(
                     "WARNING: Skipping compaction run - missing delta prefixes"
+                )
+
+            # =================================================================
+            # PHASE 3a: Publish both collections to Chroma Cloud
+            # =================================================================
+            # Only now is every record recoverable: both deltas are in S3 and
+            # the CompactionRun that points at them is durable. Publishing
+            # earlier -- per collection, as this originally did -- could leave
+            # Cloud holding one collection, or both, with no event that would
+            # ever reconcile them. Without the run, publication waits for a
+            # later ingest rather than going out unbacked.
+            if compaction_run_created:
+                _publish_staged_payload(
+                    lines_cloud_payload,
+                    "lines",
+                    cloud_cfg,
+                    image_id,
+                    receipt_id,
+                    labels_fetched_at,
+                )
+                _publish_staged_payload(
+                    words_cloud_payload,
+                    "words",
+                    cloud_cfg,
+                    image_id,
+                    receipt_id,
+                    labels_fetched_at,
+                )
+            elif lines_cloud_payload or words_cloud_payload:
+                _log(
+                    "Skipping Chroma Cloud publication - no durable "
+                    "compaction run to reconcile the records"
                 )
 
             # =================================================================
@@ -1844,6 +1946,11 @@ class MerchantResolvingEmbeddingProcessor:
             logger.exception("Processing failed")
 
         finally:
+            # Staged Cloud payloads are consumed above; drop them whether or
+            # not they were published.
+            _discard_staged_payload(lines_cloud_payload)
+            _discard_staged_payload(words_cloud_payload)
+
             # Clean up temp directories
             # Note: ChromaClients are created and closed within worker processes
             try:
@@ -1858,7 +1965,10 @@ class MerchantResolvingEmbeddingProcessor:
                 logger.warning("Error cleaning up words_dir: %s", e)
 
         return {
-            "success": True,
+            # A receipt is only fully processed once its CompactionRun exists;
+            # without it the deltas are orphaned and nothing will merge them.
+            "success": compaction_run_created,
+            "compaction_run_created": compaction_run_created,
             "run_id": run_id,
             "lines_count": len(lines),
             "words_count": len(words),

--- a/receipt_upload/receipt_upload/merchant_resolution/embedding_processor.py
+++ b/receipt_upload/receipt_upload/merchant_resolution/embedding_processor.py
@@ -440,14 +440,16 @@ def _upsert_to_cloud_nonfatal(
                 "receipt_id": receipt_id,
                 "attempted": result.attempted,
                 "deadline_exceeded": result.deadline_exceeded,
+                "backpressure": result.backpressure,
                 "drop_reasons": result.drop_reasons,
                 "error": result.error,
             },
         )
 
-        if result.deadline_exceeded:
-            # The budget is already spent, so reporting it must not spend
-            # more: a blocked stdout would hand the overrun back to ingest.
+        if result.telemetry_must_be_bounded:
+            # Something upstream is stuck -- the budget is spent, or earlier
+            # attempts have not returned. Reporting that must not block on
+            # the same I/O: a stalled stdout would hand it back to ingest.
             emit_within_budget(emit_metrics)
             emit_within_budget(_log, summary)
         else:

--- a/receipt_upload/receipt_upload/merchant_resolution/embedding_processor.py
+++ b/receipt_upload/receipt_upload/merchant_resolution/embedding_processor.py
@@ -32,7 +32,7 @@ import time
 import uuid
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional, Tuple, Type
+from typing import Any, Callable, Dict, List, Optional, Tuple, Type
 
 import boto3
 from receipt_agent.constants import CORE_LABELS
@@ -188,6 +188,12 @@ def _make_read_client(
 
 _METRICS_NAMESPACE = "EmbeddingWorkflow"
 
+# How stale a worker's label snapshot may be before the direct Cloud write is
+# skipped in favour of compaction's ordered path. Well above ingest p90
+# (40.8s) so healthy runs always publish, and far below the Lambda's 900s
+# ceiling so a stalled run cannot publish minutes-old labels.
+_DEFAULT_MAX_LABEL_AGE_SECONDS = 300.0
+
 
 def _emit_emf_metrics(
     metrics: Dict[str, Any],
@@ -231,72 +237,152 @@ def _emit_emf_metrics(
     print(json.dumps(emf))
 
 
+def _upload_delta_then_publish(
+    upload: Callable[[], str],
+    payload: Dict[str, Any],
+    collection_name: str,
+    cloud_cfg: Optional[Dict[str, str]],
+    image_id: str,
+    receipt_id: int,
+    labels_fetched_at: Optional[float] = None,
+) -> str:
+    """Upload the delta tarball, then publish the same payload to Cloud.
+
+    The order matters and is the whole contract: the delta plus its
+    CompactionRun are what make a record recoverable. Publishing to Cloud
+    first would leave records visible with nothing to reconcile them if the
+    upload then failed, because no CompactionRun is created unless both
+    collections produced a prefix. If ``upload`` raises, this propagates and
+    the Cloud write never happens.
+    """
+    prefix = upload()
+    _upsert_to_cloud_nonfatal(
+        payload=payload,
+        collection_name=collection_name,
+        cloud_cfg=cloud_cfg,
+        image_id=image_id,
+        receipt_id=receipt_id,
+        labels_fetched_at=labels_fetched_at,
+    )
+    return prefix
+
+
+def _max_label_age_seconds() -> float:
+    """Age past which a worker's label snapshot is too stale to publish."""
+    raw = os.environ.get("INGEST_CLOUD_UPSERT_MAX_LABEL_AGE_SECONDS", "")
+    try:
+        return float(raw) if raw.strip() else _DEFAULT_MAX_LABEL_AGE_SECONDS
+    except ValueError:
+        return _DEFAULT_MAX_LABEL_AGE_SECONDS
+
+
 def _upsert_to_cloud_nonfatal(
     payload: Dict[str, Any],
     collection_name: str,
     cloud_cfg: Optional[Dict[str, str]],
     image_id: str,
     receipt_id: int,
+    labels_fetched_at: Optional[float] = None,
 ) -> None:
     """Publish freshly embedded vectors to Chroma Cloud, best effort.
 
-    Without this the vectors only become queryable once compaction merges
-    the delta tarball uploaded alongside them. That merge holds a global
-    per-collection lock, so it can lag by minutes. Failing here costs that
-    latency and nothing else -- the delta and CompactionRun still flow.
+    Call this only once the collection's delta tarball is durable in S3.
+    The delta and its CompactionRun are the backstop; this write just makes
+    the same vectors queryable now instead of after the next compaction
+    merge, which holds a global per-collection lock and can lag by minutes.
+
+    Known race (full fix is Phase 2): compaction routes a receipt's label
+    and place updates through the same FIFO group as its CompactionRun, so
+    those updates are ordered against each other. A direct write is not in
+    that order. If a label update lands in Cloud after this worker read its
+    labels, publishing here would overwrite the newer value with the older
+    snapshot, and the delta -- ordered after the already-consumed label
+    event -- would not repair it. Until records carry a revision token, the
+    mitigation is a bound on how stale the snapshot may be: past that, skip
+    the direct write and let compaction publish in FIFO order.
+
+    Nothing escapes this function; telemetry is inside the guard because a
+    failed metric write must not fail an ingest that already succeeded.
     """
     if not cloud_cfg:
         return
 
     try:
+        if labels_fetched_at is not None:
+            age = time.monotonic() - labels_fetched_at
+            max_age = _max_label_age_seconds()
+            if age > max_age:
+                _emit_emf_metrics(
+                    {"IngestCloudUpsertSkipped": 1},
+                    dimensions={"collection": collection_name},
+                    properties={
+                        "image_id": image_id,
+                        "receipt_id": receipt_id,
+                        "reason": "stale_risk",
+                        "label_age_seconds": round(age, 3),
+                    },
+                )
+                _log(
+                    f"Skipping Chroma Cloud upsert ({collection_name}): "
+                    f"label snapshot is {age:.1f}s old (limit {max_age:.0f}s); "
+                    "leaving publication to compaction's ordered path"
+                )
+                return
+
         result = upsert_payload_to_cloud(
             payload=payload,
             collection_name=collection_name,
             cloud_config=cloud_cfg,
         )
-    except Exception as e:  # pylint: disable=broad-exception-caught
-        logger.exception("Chroma Cloud upsert raised for %s", collection_name)
+
+        if not result.enabled:
+            return
+
+        metric_name = (
+            "IngestCloudUpsertSuccess"
+            if result.success
+            else "IngestCloudUpsertFailure"
+        )
         _emit_emf_metrics(
-            {"IngestCloudUpsertFailure": 1},
+            {
+                metric_name: 1,
+                "IngestCloudUpsertRecords": result.upserted,
+                "IngestCloudUpsertFailedBatches": result.failed_batches,
+                "IngestCloudUpsertDropped": result.dropped,
+                "IngestCloudUpsertTruncated": result.truncated,
+                "IngestCloudUpsertLatency": round(result.duration_seconds, 3),
+            },
             dimensions={"collection": collection_name},
+            units={"IngestCloudUpsertLatency": "Seconds"},
             properties={
                 "image_id": image_id,
                 "receipt_id": receipt_id,
-                "error": f"{type(e).__name__}: {e}",
+                "attempted": result.attempted,
+                "deadline_exceeded": result.deadline_exceeded,
+                "drop_reasons": result.drop_reasons,
+                "error": result.error,
             },
         )
-        return
-
-    if not result.enabled:
-        return
-
-    metric_name = (
-        "IngestCloudUpsertSuccess"
-        if result.success
-        else "IngestCloudUpsertFailure"
-    )
-    _emit_emf_metrics(
-        {
-            metric_name: 1,
-            "IngestCloudUpsertRecords": result.upserted,
-            "IngestCloudUpsertFailedBatches": result.failed_batches,
-            "IngestCloudUpsertLatency": round(result.duration_seconds, 3),
-        },
-        dimensions={"collection": collection_name},
-        units={"IngestCloudUpsertLatency": "Seconds"},
-        properties={
-            "image_id": image_id,
-            "receipt_id": receipt_id,
-            "attempted": result.attempted,
-            "error": result.error,
-        },
-    )
-    _log(
-        f"Chroma Cloud upsert ({collection_name}): "
-        f"{result.upserted}/{result.attempted} records in "
-        f"{result.duration_seconds:.2f}s"
-        + (f" — FAILED: {result.error}" if not result.success else "")
-    )
+        _log(
+            f"Chroma Cloud upsert ({collection_name}): "
+            f"{result.upserted}/{result.attempted} records in "
+            f"{result.duration_seconds:.2f}s"
+            + (f" — FAILED: {result.error}" if not result.success else "")
+        )
+    except Exception as e:  # pylint: disable=broad-exception-caught
+        logger.exception("Chroma Cloud upsert raised for %s", collection_name)
+        try:
+            _emit_emf_metrics(
+                {"IngestCloudUpsertFailure": 1},
+                dimensions={"collection": collection_name},
+                properties={
+                    "image_id": image_id,
+                    "receipt_id": receipt_id,
+                    "error": f"{type(e).__name__}: {e}",
+                },
+            )
+        except Exception:  # pylint: disable=broad-exception-caught
+            logger.exception("Failed to emit cloud upsert failure metric")
 
 
 def _prepare_pending_core_labels(
@@ -484,6 +570,7 @@ def _run_lines_pipeline_worker(
     table_name: str,
     google_places_api_key: Optional[str],
     langsmith_headers: Optional[Dict[str, str]] = None,
+    labels_fetched_at: Optional[float] = None,
 ) -> Dict[str, Any]:
     """
     Worker function for lines pipeline (runs in separate process).
@@ -714,25 +801,24 @@ def _run_lines_pipeline_worker(
             if not cloud_cfg:
                 client.upsert(collection_name="lines", **line_payload)
 
-            # Publish straight to Chroma Cloud so these rows are queryable
-            # now instead of after the next compaction merge.
-            _upsert_to_cloud_nonfatal(
+            # Upload delta to S3, then publish to Chroma Cloud so these rows
+            # are queryable without waiting for compaction.
+            import boto3
+
+            s3_client = boto3.client("s3")
+            prefix = _upload_delta_then_publish(
+                upload=lambda: upload_lines_delta(
+                    line_payload=line_payload,
+                    run_id=run_id,
+                    chromadb_bucket=chromadb_bucket,
+                    s3_client=s3_client,
+                ),
                 payload=line_payload,
                 collection_name="lines",
                 cloud_cfg=cloud_cfg,
                 image_id=image_id,
                 receipt_id=receipt_id,
-            )
-
-            # Upload delta to S3
-            import boto3
-
-            s3_client = boto3.client("s3")
-            prefix = upload_lines_delta(
-                line_payload=line_payload,
-                run_id=run_id,
-                chromadb_bucket=chromadb_bucket,
-                s3_client=s3_client,
+                labels_fetched_at=labels_fetched_at,
             )
 
             # Return serializable result
@@ -831,6 +917,7 @@ def _run_words_pipeline_worker(
     chromadb_bucket: str,
     table_name: str,
     langsmith_headers: Optional[Dict[str, str]] = None,
+    labels_fetched_at: Optional[float] = None,
 ) -> Dict[str, Any]:
     """
     Worker function for words pipeline (runs in separate process).
@@ -1141,25 +1228,24 @@ def _run_words_pipeline_worker(
             if not cloud_cfg:
                 client.upsert(collection_name="words", **word_payload)
 
-            # Publish straight to Chroma Cloud so these words are queryable
-            # now instead of after the next compaction merge.
-            _upsert_to_cloud_nonfatal(
+            # Upload delta to S3, then publish to Chroma Cloud so these words
+            # are queryable without waiting for compaction.
+            import boto3
+
+            s3_client = boto3.client("s3")
+            prefix = _upload_delta_then_publish(
+                upload=lambda: upload_words_delta(
+                    word_payload=word_payload,
+                    run_id=run_id,
+                    chromadb_bucket=chromadb_bucket,
+                    s3_client=s3_client,
+                ),
                 payload=word_payload,
                 collection_name="words",
                 cloud_cfg=cloud_cfg,
                 image_id=image_id,
                 receipt_id=receipt_id,
-            )
-
-            # Upload delta to S3
-            import boto3
-
-            s3_client = boto3.client("s3")
-            prefix = upload_words_delta(
-                word_payload=word_payload,
-                run_id=run_id,
-                chromadb_bucket=chromadb_bucket,
-                s3_client=s3_client,
+                labels_fetched_at=labels_fetched_at,
             )
 
             return {
@@ -1355,8 +1441,12 @@ class MerchantResolvingEmbeddingProcessor:
         else:
             _log(f"Using provided {len(lines)} lines and {len(words)} words")
 
-        # Get word labels for enrichment
+        # Get word labels for enrichment. The read time bounds how stale the
+        # workers' label snapshot can be when they publish to Chroma Cloud
+        # outside compaction's FIFO ordering; CLOCK_MONOTONIC is system-wide,
+        # so this stays comparable inside the pipeline subprocesses.
         word_labels: List[ReceiptWordLabel] = []
+        labels_fetched_at = time.monotonic()
         try:
             word_labels, _ = self.dynamo.list_receipt_word_labels_for_receipt(
                 image_id, receipt_id
@@ -1496,6 +1586,7 @@ class MerchantResolvingEmbeddingProcessor:
                     table_name=table_name,
                     google_places_api_key=self.google_places_api_key,
                     langsmith_headers=langsmith_headers,
+                    labels_fetched_at=labels_fetched_at,
                 )
 
                 words_future = executor.submit(
@@ -1510,6 +1601,7 @@ class MerchantResolvingEmbeddingProcessor:
                     chromadb_bucket=self.chromadb_bucket,
                     table_name=table_name,
                     langsmith_headers=langsmith_headers,
+                    labels_fetched_at=labels_fetched_at,
                 )
 
                 # Wait for both to complete

--- a/receipt_upload/receipt_upload/merchant_resolution/embedding_processor.py
+++ b/receipt_upload/receipt_upload/merchant_resolution/embedding_processor.py
@@ -24,9 +24,11 @@ Tracing:
 - Child traces for each phase nest under the parent
 """
 
+import json
 import logging
 import os
 import shutil
+import time
 import uuid
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from datetime import datetime, timezone
@@ -41,6 +43,7 @@ from receipt_chroma.embedding import (
     download_and_embed_parallel,
     upload_lines_delta,
     upload_words_delta,
+    upsert_payload_to_cloud,
 )
 from receipt_dynamo import DynamoClient
 from receipt_dynamo.constants import ValidationStatus
@@ -180,6 +183,119 @@ def _make_read_client(
         persist_directory=local_dir,
         mode="write",
         metadata_only=True,
+    )
+
+
+_METRICS_NAMESPACE = "EmbeddingWorkflow"
+
+
+def _emit_emf_metrics(
+    metrics: Dict[str, Any],
+    dimensions: Optional[Dict[str, str]] = None,
+    units: Optional[Dict[str, str]] = None,
+    properties: Optional[Dict[str, Any]] = None,
+) -> None:
+    """Write metrics to stdout in CloudWatch Embedded Metric Format.
+
+    Mirrors the compaction handler's EMF conventions (same namespace, same
+    ENABLE_METRICS gate) without pulling in its Lambda-local ``utils``
+    package, which is not bundled into the upload container.
+    """
+    if os.environ.get("ENABLE_METRICS", "true").strip().lower() != "true":
+        return
+
+    unit_for = units or {}
+    emf: Dict[str, Any] = {
+        "_aws": {
+            "Timestamp": int(time.time() * 1000),
+            "CloudWatchMetrics": [
+                {
+                    "Namespace": _METRICS_NAMESPACE,
+                    "Dimensions": (
+                        [list(dimensions.keys())] if dimensions else [[]]
+                    ),
+                    "Metrics": [
+                        {"Name": name, "Unit": unit_for.get(name, "Count")}
+                        for name in metrics
+                    ],
+                }
+            ],
+        }
+    }
+    if dimensions:
+        emf.update(dimensions)
+    emf.update(metrics)
+    if properties:
+        emf.update(properties)
+
+    print(json.dumps(emf))
+
+
+def _upsert_to_cloud_nonfatal(
+    payload: Dict[str, Any],
+    collection_name: str,
+    cloud_cfg: Optional[Dict[str, str]],
+    image_id: str,
+    receipt_id: int,
+) -> None:
+    """Publish freshly embedded vectors to Chroma Cloud, best effort.
+
+    Without this the vectors only become queryable once compaction merges
+    the delta tarball uploaded alongside them. That merge holds a global
+    per-collection lock, so it can lag by minutes. Failing here costs that
+    latency and nothing else -- the delta and CompactionRun still flow.
+    """
+    if not cloud_cfg:
+        return
+
+    try:
+        result = upsert_payload_to_cloud(
+            payload=payload,
+            collection_name=collection_name,
+            cloud_config=cloud_cfg,
+        )
+    except Exception as e:  # pylint: disable=broad-exception-caught
+        logger.exception("Chroma Cloud upsert raised for %s", collection_name)
+        _emit_emf_metrics(
+            {"IngestCloudUpsertFailure": 1},
+            dimensions={"collection": collection_name},
+            properties={
+                "image_id": image_id,
+                "receipt_id": receipt_id,
+                "error": f"{type(e).__name__}: {e}",
+            },
+        )
+        return
+
+    if not result.enabled:
+        return
+
+    metric_name = (
+        "IngestCloudUpsertSuccess"
+        if result.success
+        else "IngestCloudUpsertFailure"
+    )
+    _emit_emf_metrics(
+        {
+            metric_name: 1,
+            "IngestCloudUpsertRecords": result.upserted,
+            "IngestCloudUpsertFailedBatches": result.failed_batches,
+            "IngestCloudUpsertLatency": round(result.duration_seconds, 3),
+        },
+        dimensions={"collection": collection_name},
+        units={"IngestCloudUpsertLatency": "Seconds"},
+        properties={
+            "image_id": image_id,
+            "receipt_id": receipt_id,
+            "attempted": result.attempted,
+            "error": result.error,
+        },
+    )
+    _log(
+        f"Chroma Cloud upsert ({collection_name}): "
+        f"{result.upserted}/{result.attempted} records in "
+        f"{result.duration_seconds:.2f}s"
+        + (f" — FAILED: {result.error}" if not result.success else "")
     )
 
 
@@ -598,6 +714,16 @@ def _run_lines_pipeline_worker(
             if not cloud_cfg:
                 client.upsert(collection_name="lines", **line_payload)
 
+            # Publish straight to Chroma Cloud so these rows are queryable
+            # now instead of after the next compaction merge.
+            _upsert_to_cloud_nonfatal(
+                payload=line_payload,
+                collection_name="lines",
+                cloud_cfg=cloud_cfg,
+                image_id=image_id,
+                receipt_id=receipt_id,
+            )
+
             # Upload delta to S3
             import boto3
 
@@ -1014,6 +1140,16 @@ def _run_words_pipeline_worker(
             # read client is Cloud and the delta upload below is self-contained).
             if not cloud_cfg:
                 client.upsert(collection_name="words", **word_payload)
+
+            # Publish straight to Chroma Cloud so these words are queryable
+            # now instead of after the next compaction merge.
+            _upsert_to_cloud_nonfatal(
+                payload=word_payload,
+                collection_name="words",
+                cloud_cfg=cloud_cfg,
+                image_id=image_id,
+                receipt_id=receipt_id,
+            )
 
             # Upload delta to S3
             import boto3

--- a/receipt_upload/receipt_upload/merchant_resolution/embedding_processor.py
+++ b/receipt_upload/receipt_upload/merchant_resolution/embedding_processor.py
@@ -34,6 +34,7 @@ import time
 import uuid
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from datetime import datetime, timezone
+from functools import partial
 from typing import Any, Callable, Dict, List, Optional, Tuple, Type
 
 import boto3
@@ -47,7 +48,10 @@ from receipt_chroma.embedding import (
     upload_words_delta,
     upsert_payload_to_cloud,
 )
-from receipt_chroma.embedding.cloud_upsert import DEFAULT_REQUEST_TIMEOUT
+from receipt_chroma.embedding.cloud_upsert import (
+    DEFAULT_REQUEST_TIMEOUT,
+    emit_within_budget,
+)
 from receipt_dynamo import DynamoClient
 from receipt_dynamo.constants import ValidationStatus
 from receipt_dynamo.entities import ReceiptLine, ReceiptWord, ReceiptWordLabel
@@ -263,19 +267,34 @@ def _stage_cloud_payload(
     """
     if not cloud_cfg:
         return None
+
+    handle: Optional[int] = None
+    path: Optional[str] = None
     try:
         handle, path = tempfile.mkstemp(
             prefix=f"cloud-publish-{collection_name}-", suffix=".pkl"
         )
         with os.fdopen(handle, "wb") as staged:
+            handle = None  # fdopen owns the descriptor now
             pickle.dump(payload, staged, protocol=pickle.HIGHEST_PROTOCOL)
-        return path
+        staged_path, path = path, None
+        return staged_path
     except Exception:  # pylint: disable=broad-exception-caught
         logger.exception(
             "Could not stage %s payload for Chroma Cloud publication",
             collection_name,
         )
         return None
+    finally:
+        # Anything still owned here failed partway: close the descriptor and
+        # remove the half-written file rather than leaving it in /tmp, which
+        # a warm Lambda keeps across invocations.
+        if handle is not None:
+            try:
+                os.close(handle)
+            except OSError:
+                pass
+        _discard_staged_payload(path)
 
 
 def _publish_staged_payload(
@@ -398,7 +417,14 @@ def _upsert_to_cloud_nonfatal(
             if result.success
             else "IngestCloudUpsertFailure"
         )
-        _emit_emf_metrics(
+        summary = (
+            f"Chroma Cloud upsert ({collection_name}): "
+            f"{result.upserted}/{result.attempted} records in "
+            f"{result.duration_seconds:.2f}s"
+            + (f" — FAILED: {result.error}" if not result.success else "")
+        )
+        emit_metrics = partial(
+            _emit_emf_metrics,
             {
                 metric_name: 1,
                 "IngestCloudUpsertRecords": result.upserted,
@@ -418,12 +444,15 @@ def _upsert_to_cloud_nonfatal(
                 "error": result.error,
             },
         )
-        _log(
-            f"Chroma Cloud upsert ({collection_name}): "
-            f"{result.upserted}/{result.attempted} records in "
-            f"{result.duration_seconds:.2f}s"
-            + (f" — FAILED: {result.error}" if not result.success else "")
-        )
+
+        if result.deadline_exceeded:
+            # The budget is already spent, so reporting it must not spend
+            # more: a blocked stdout would hand the overrun back to ingest.
+            emit_within_budget(emit_metrics)
+            emit_within_budget(_log, summary)
+        else:
+            emit_metrics()
+            _log(summary)
     except Exception as e:  # pylint: disable=broad-exception-caught
         logger.exception("Chroma Cloud upsert raised for %s", collection_name)
         try:
@@ -920,6 +949,7 @@ def _run_lines_pipeline_worker(
     # tracing_context(parent=...) can accept headers directly for distributed tracing
     # CRITICAL: Must flush traces before process exits - each process has its own
     # background thread for sending traces to LangSmith
+    traced_result: Optional[Dict[str, Any]] = None
     if langsmith_headers:
         try:
             import logging
@@ -945,19 +975,26 @@ def _run_lines_pipeline_worker(
                 project_name=project,
                 enabled=True,
             ):
-                result = _do_lines_work()
+                traced_result = _do_lines_work()
 
             # CRITICAL: Flush traces before process exits
             # Each child process has its own LangSmith client and background thread
             log.info("[LINES_WORKER] Flushing traces before process exit")
             Client().flush()
-            return result
+            return traced_result
         except Exception as e:
             import logging
 
             logging.getLogger(__name__).exception(
                 "[LINES_WORKER] ERROR in tracing: %s", e
             )
+            # The pipeline reruns below and stages a fresh payload. Drop the
+            # one this attempt staged -- its path is about to be discarded
+            # with the result, and nobody else will clean it up.
+            if traced_result:
+                _discard_staged_payload(
+                    traced_result.get("cloud_payload_path")
+                )
     return _do_lines_work()
 
 
@@ -1316,6 +1353,7 @@ def _run_words_pipeline_worker(
     # tracing_context(parent=...) can accept headers directly for distributed tracing
     # CRITICAL: Must flush traces before process exits - each process has its own
     # background thread for sending traces to LangSmith
+    traced_result: Optional[Dict[str, Any]] = None
     if langsmith_headers:
         try:
             import logging
@@ -1341,19 +1379,26 @@ def _run_words_pipeline_worker(
                 project_name=project,
                 enabled=True,
             ):
-                result = _do_words_work()
+                traced_result = _do_words_work()
 
             # CRITICAL: Flush traces before process exits
             # Each child process has its own LangSmith client and background thread
             log.info("[WORDS_WORKER] Flushing traces before process exit")
             Client().flush()
-            return result
+            return traced_result
         except Exception as e:
             import logging
 
             logging.getLogger(__name__).exception(
                 "[WORDS_WORKER] ERROR in tracing: %s", e
             )
+            # The pipeline reruns below and stages a fresh payload. Drop the
+            # one this attempt staged -- its path is about to be discarded
+            # with the result, and nobody else will clean it up.
+            if traced_result:
+                _discard_staged_payload(
+                    traced_result.get("cloud_payload_path")
+                )
     return _do_words_work()
 
 

--- a/receipt_upload/tests/test_ingest_cloud_upsert.py
+++ b/receipt_upload/tests/test_ingest_cloud_upsert.py
@@ -2,12 +2,14 @@
 
 The upsert makes freshly embedded words and lines queryable immediately
 instead of waiting for compaction to merge the delta tarball. Three
-properties matter and are covered here: it runs only after the delta is
-durable, it never fails ingest for any reason including telemetry, and it
-declines to publish a label snapshot too stale to be safely ordered.
+properties matter and are covered here: a payload is staged by its worker
+and published only once the CompactionRun that can reconcile it is durable,
+publication never fails ingest for any reason including telemetry, and a
+label snapshot too stale to be safely ordered is not published at all.
 """
 
 import json
+import os
 from unittest.mock import patch
 
 import pytest
@@ -93,54 +95,57 @@ class TestEmitEmfMetrics:
         assert emitted_metrics(capsys) == []
 
 
-class TestDeltaBeforeCloud:
-    """The delta is the backstop, so it has to land first."""
+class TestStagedPublication:
+    """Workers hand payloads back; the parent publishes after the run row."""
 
-    def test_cloud_write_runs_after_a_successful_upload(self, capsys):
-        calls = []
+    def test_stage_and_publish_round_trip(self, capsys):
+        path = ep._stage_cloud_payload(PAYLOAD, "words", CLOUD_CFG)
+        assert path and os.path.exists(path)
 
-        def upload():
-            calls.append("upload")
-            return "lines/delta/run-1/"
-
-        with patch.object(
-            ep, "upsert_payload_to_cloud", return_value=ok_result()
-        ) as upsert:
-            upsert.side_effect = lambda **_kw: (
-                calls.append("cloud"),
-                ok_result(),
-            )[1]
-            prefix = ep._upload_delta_then_publish(
-                upload=upload,
-                payload=PAYLOAD,
-                collection_name="lines",
-                cloud_cfg=CLOUD_CFG,
-                image_id="img-1",
-                receipt_id=1,
-            )
-
-        assert prefix == "lines/delta/run-1/"
-        assert calls == ["upload", "cloud"]
-
-    def test_failed_upload_skips_the_cloud_write_entirely(self, capsys):
-        """No CompactionRun is created, so nothing may be published."""
-
-        def upload():
-            raise RuntimeError("s3 unavailable")
-
-        with patch.object(ep, "upsert_payload_to_cloud") as upsert:
-            with pytest.raises(RuntimeError, match="s3 unavailable"):
-                ep._upload_delta_then_publish(
-                    upload=upload,
-                    payload=PAYLOAD,
-                    collection_name="words",
-                    cloud_cfg=CLOUD_CFG,
-                    image_id="img-1",
-                    receipt_id=1,
+        try:
+            with patch.object(
+                ep, "upsert_payload_to_cloud", return_value=ok_result()
+            ) as upsert:
+                ep._publish_staged_payload(
+                    path, "words", CLOUD_CFG, "img-1", 1
                 )
+
+            assert upsert.call_args.kwargs["payload"] == PAYLOAD
+            (blob,) = emitted_metrics(capsys)
+            assert blob["IngestCloudUpsertSuccess"] == 1
+        finally:
+            ep._discard_staged_payload(path)
+
+        assert not os.path.exists(path)
+
+    def test_staging_is_skipped_when_cloud_is_disabled(self):
+        assert ep._stage_cloud_payload(PAYLOAD, "words", None) is None
+
+    def test_publishing_without_a_staged_path_is_a_noop(self, capsys):
+        with patch.object(ep, "upsert_payload_to_cloud") as upsert:
+            ep._publish_staged_payload(None, "words", CLOUD_CFG, "img-1", 1)
 
         upsert.assert_not_called()
         assert emitted_metrics(capsys) == []
+
+    def test_unreadable_staged_payload_does_not_raise(self, capsys):
+        with patch.object(ep, "upsert_payload_to_cloud") as upsert:
+            ep._publish_staged_payload(
+                "/nonexistent/staged.pkl", "words", CLOUD_CFG, "img-1", 1
+            )
+
+        upsert.assert_not_called()
+        assert emitted_metrics(capsys) == []
+
+    def test_staging_failure_degrades_to_no_publication(self):
+        with patch.object(
+            ep.tempfile, "mkstemp", side_effect=OSError("no space")
+        ):
+            assert ep._stage_cloud_payload(PAYLOAD, "words", CLOUD_CFG) is None
+
+    def test_discarding_a_missing_file_is_silent(self):
+        ep._discard_staged_payload("/nonexistent/staged.pkl")
+        ep._discard_staged_payload(None)
 
 
 class TestStalenessFence:

--- a/receipt_upload/tests/test_ingest_cloud_upsert.py
+++ b/receipt_upload/tests/test_ingest_cloud_upsert.py
@@ -1,0 +1,168 @@
+"""Tests for the ingest path's non-fatal Chroma Cloud upsert.
+
+The upsert makes freshly embedded words and lines queryable immediately
+instead of waiting for compaction to merge the delta tarball. It must never
+fail ingest, and it must report itself through EMF metrics.
+"""
+
+import json
+from unittest.mock import patch
+
+import pytest
+from receipt_chroma.embedding.cloud_upsert import CloudUpsertResult
+
+from receipt_upload.merchant_resolution import embedding_processor as ep
+
+CLOUD_CFG = {
+    "api_key": "test-key",
+    "tenant": "test-tenant",
+    "database": "receipt_test",
+}
+
+PAYLOAD = {
+    "ids": ["a", "b"],
+    "embeddings": [[0.1], [0.2]],
+    "documents": ["a", "b"],
+    "metadatas": [{"k": 1}, {"k": 2}],
+}
+
+
+def emitted_metrics(capsys):
+    """Parse EMF blobs printed to stdout."""
+    blobs = []
+    for line in capsys.readouterr().out.splitlines():
+        line = line.strip()
+        if not line.startswith("{"):
+            continue
+        try:
+            parsed = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if "_aws" in parsed:
+            blobs.append(parsed)
+    return blobs
+
+
+@pytest.fixture(autouse=True)
+def _enable_metrics(monkeypatch):
+    monkeypatch.setenv("ENABLE_METRICS", "true")
+
+
+class TestEmitEmfMetrics:
+    """EMF formatting matches the compaction handler's conventions."""
+
+    def test_namespace_dimensions_and_units(self, capsys):
+        ep._emit_emf_metrics(
+            {"IngestCloudUpsertSuccess": 1, "IngestCloudUpsertLatency": 0.5},
+            dimensions={"collection": "words"},
+            units={"IngestCloudUpsertLatency": "Seconds"},
+            properties={"image_id": "img-1"},
+        )
+
+        (blob,) = emitted_metrics(capsys)
+        directive = blob["_aws"]["CloudWatchMetrics"][0]
+        assert directive["Namespace"] == "EmbeddingWorkflow"
+        assert directive["Dimensions"] == [["collection"]]
+        assert {m["Name"]: m["Unit"] for m in directive["Metrics"]} == {
+            "IngestCloudUpsertSuccess": "Count",
+            "IngestCloudUpsertLatency": "Seconds",
+        }
+        assert blob["collection"] == "words"
+        assert blob["IngestCloudUpsertSuccess"] == 1
+        assert blob["image_id"] == "img-1"
+
+    def test_disabled_by_env(self, capsys, monkeypatch):
+        monkeypatch.setenv("ENABLE_METRICS", "false")
+        ep._emit_emf_metrics({"IngestCloudUpsertSuccess": 1})
+        assert emitted_metrics(capsys) == []
+
+
+class TestUpsertToCloudNonFatal:
+    """The wrapper never raises and always reports."""
+
+    def test_success_emits_success_metric(self, capsys):
+        result = CloudUpsertResult(
+            collection="words",
+            attempted=2,
+            upserted=2,
+            batches=1,
+            duration_seconds=0.4,
+        )
+        with patch.object(
+            ep, "upsert_payload_to_cloud", return_value=result
+        ) as upsert:
+            ep._upsert_to_cloud_nonfatal(
+                payload=PAYLOAD,
+                collection_name="words",
+                cloud_cfg=CLOUD_CFG,
+                image_id="img-1",
+                receipt_id=1,
+            )
+
+        assert upsert.call_args.kwargs["collection_name"] == "words"
+        assert upsert.call_args.kwargs["cloud_config"] == CLOUD_CFG
+
+        (blob,) = emitted_metrics(capsys)
+        assert blob["IngestCloudUpsertSuccess"] == 1
+        assert "IngestCloudUpsertFailure" not in blob
+        assert blob["IngestCloudUpsertRecords"] == 2
+        assert blob["collection"] == "words"
+
+    def test_partial_failure_emits_failure_metric_without_raising(
+        self, capsys
+    ):
+        result = CloudUpsertResult(
+            collection="lines",
+            attempted=601,
+            upserted=351,
+            batches=3,
+            failed_batches=1,
+            error="RuntimeError: cloud 503",
+            duration_seconds=1.1,
+        )
+        with patch.object(ep, "upsert_payload_to_cloud", return_value=result):
+            ep._upsert_to_cloud_nonfatal(
+                payload=PAYLOAD,
+                collection_name="lines",
+                cloud_cfg=CLOUD_CFG,
+                image_id="img-1",
+                receipt_id=1,
+            )
+
+        (blob,) = emitted_metrics(capsys)
+        assert blob["IngestCloudUpsertFailure"] == 1
+        assert blob["IngestCloudUpsertFailedBatches"] == 1
+        assert blob["IngestCloudUpsertRecords"] == 351
+        assert blob["error"] == "RuntimeError: cloud 503"
+
+    def test_unexpected_exception_is_swallowed(self, capsys):
+        with patch.object(
+            ep,
+            "upsert_payload_to_cloud",
+            side_effect=RuntimeError("boom"),
+        ):
+            ep._upsert_to_cloud_nonfatal(
+                payload=PAYLOAD,
+                collection_name="words",
+                cloud_cfg=CLOUD_CFG,
+                image_id="img-1",
+                receipt_id=1,
+            )
+
+        (blob,) = emitted_metrics(capsys)
+        assert blob["IngestCloudUpsertFailure"] == 1
+        assert blob["error"] == "RuntimeError: boom"
+
+    @pytest.mark.parametrize("cloud_cfg", [None, {}], ids=["none", "empty"])
+    def test_cloud_disabled_is_a_noop(self, capsys, cloud_cfg):
+        with patch.object(ep, "upsert_payload_to_cloud") as upsert:
+            ep._upsert_to_cloud_nonfatal(
+                payload=PAYLOAD,
+                collection_name="words",
+                cloud_cfg=cloud_cfg,
+                image_id="img-1",
+                receipt_id=1,
+            )
+
+        upsert.assert_not_called()
+        assert emitted_metrics(capsys) == []

--- a/receipt_upload/tests/test_ingest_cloud_upsert.py
+++ b/receipt_upload/tests/test_ingest_cloud_upsert.py
@@ -1,8 +1,10 @@
 """Tests for the ingest path's non-fatal Chroma Cloud upsert.
 
 The upsert makes freshly embedded words and lines queryable immediately
-instead of waiting for compaction to merge the delta tarball. It must never
-fail ingest, and it must report itself through EMF metrics.
+instead of waiting for compaction to merge the delta tarball. Three
+properties matter and are covered here: it runs only after the delta is
+durable, it never fails ingest for any reason including telemetry, and it
+declines to publish a label snapshot too stale to be safely ordered.
 """
 
 import json
@@ -43,9 +45,24 @@ def emitted_metrics(capsys):
     return blobs
 
 
+def ok_result(**kwargs):
+    defaults = dict(
+        collection="words",
+        attempted=2,
+        upserted=2,
+        batches=1,
+        duration_seconds=0.4,
+    )
+    defaults.update(kwargs)
+    return CloudUpsertResult(**defaults)
+
+
 @pytest.fixture(autouse=True)
 def _enable_metrics(monkeypatch):
     monkeypatch.setenv("ENABLE_METRICS", "true")
+    monkeypatch.delenv(
+        "INGEST_CLOUD_UPSERT_MAX_LABEL_AGE_SECONDS", raising=False
+    )
 
 
 class TestEmitEmfMetrics:
@@ -68,7 +85,6 @@ class TestEmitEmfMetrics:
             "IngestCloudUpsertLatency": "Seconds",
         }
         assert blob["collection"] == "words"
-        assert blob["IngestCloudUpsertSuccess"] == 1
         assert blob["image_id"] == "img-1"
 
     def test_disabled_by_env(self, capsys, monkeypatch):
@@ -77,19 +93,131 @@ class TestEmitEmfMetrics:
         assert emitted_metrics(capsys) == []
 
 
+class TestDeltaBeforeCloud:
+    """The delta is the backstop, so it has to land first."""
+
+    def test_cloud_write_runs_after_a_successful_upload(self, capsys):
+        calls = []
+
+        def upload():
+            calls.append("upload")
+            return "lines/delta/run-1/"
+
+        with patch.object(
+            ep, "upsert_payload_to_cloud", return_value=ok_result()
+        ) as upsert:
+            upsert.side_effect = lambda **_kw: (
+                calls.append("cloud"),
+                ok_result(),
+            )[1]
+            prefix = ep._upload_delta_then_publish(
+                upload=upload,
+                payload=PAYLOAD,
+                collection_name="lines",
+                cloud_cfg=CLOUD_CFG,
+                image_id="img-1",
+                receipt_id=1,
+            )
+
+        assert prefix == "lines/delta/run-1/"
+        assert calls == ["upload", "cloud"]
+
+    def test_failed_upload_skips_the_cloud_write_entirely(self, capsys):
+        """No CompactionRun is created, so nothing may be published."""
+
+        def upload():
+            raise RuntimeError("s3 unavailable")
+
+        with patch.object(ep, "upsert_payload_to_cloud") as upsert:
+            with pytest.raises(RuntimeError, match="s3 unavailable"):
+                ep._upload_delta_then_publish(
+                    upload=upload,
+                    payload=PAYLOAD,
+                    collection_name="words",
+                    cloud_cfg=CLOUD_CFG,
+                    image_id="img-1",
+                    receipt_id=1,
+                )
+
+        upsert.assert_not_called()
+        assert emitted_metrics(capsys) == []
+
+
+class TestStalenessFence:
+    """Direct writes bypass compaction's FIFO ordering."""
+
+    def test_stale_label_snapshot_skips_the_cloud_write(self, capsys):
+        with (
+            patch.object(ep, "upsert_payload_to_cloud") as upsert,
+            patch.object(ep.time, "monotonic", return_value=1000.0),
+        ):
+            ep._upsert_to_cloud_nonfatal(
+                payload=PAYLOAD,
+                collection_name="words",
+                cloud_cfg=CLOUD_CFG,
+                image_id="img-1",
+                receipt_id=1,
+                labels_fetched_at=1000.0 - 600.0,
+            )
+
+        upsert.assert_not_called()
+        (blob,) = emitted_metrics(capsys)
+        assert blob["IngestCloudUpsertSkipped"] == 1
+        assert blob["reason"] == "stale_risk"
+        assert blob["label_age_seconds"] == 600.0
+
+    def test_fresh_label_snapshot_publishes(self, capsys):
+        with (
+            patch.object(
+                ep, "upsert_payload_to_cloud", return_value=ok_result()
+            ) as upsert,
+            patch.object(ep.time, "monotonic", return_value=1000.0),
+        ):
+            ep._upsert_to_cloud_nonfatal(
+                payload=PAYLOAD,
+                collection_name="words",
+                cloud_cfg=CLOUD_CFG,
+                image_id="img-1",
+                receipt_id=1,
+                labels_fetched_at=1000.0 - 5.0,
+            )
+
+        upsert.assert_called_once()
+        (blob,) = emitted_metrics(capsys)
+        assert blob["IngestCloudUpsertSuccess"] == 1
+
+    def test_threshold_is_configurable(self, capsys, monkeypatch):
+        monkeypatch.setenv("INGEST_CLOUD_UPSERT_MAX_LABEL_AGE_SECONDS", "10")
+        with (
+            patch.object(ep, "upsert_payload_to_cloud") as upsert,
+            patch.object(ep.time, "monotonic", return_value=1000.0),
+        ):
+            ep._upsert_to_cloud_nonfatal(
+                payload=PAYLOAD,
+                collection_name="words",
+                cloud_cfg=CLOUD_CFG,
+                image_id="img-1",
+                receipt_id=1,
+                labels_fetched_at=1000.0 - 30.0,
+            )
+
+        upsert.assert_not_called()
+
+    def test_unparseable_threshold_falls_back_to_the_default(
+        self, monkeypatch
+    ):
+        monkeypatch.setenv(
+            "INGEST_CLOUD_UPSERT_MAX_LABEL_AGE_SECONDS", "not-a-number"
+        )
+        assert ep._max_label_age_seconds() == 300.0
+
+
 class TestUpsertToCloudNonFatal:
     """The wrapper never raises and always reports."""
 
     def test_success_emits_success_metric(self, capsys):
-        result = CloudUpsertResult(
-            collection="words",
-            attempted=2,
-            upserted=2,
-            batches=1,
-            duration_seconds=0.4,
-        )
         with patch.object(
-            ep, "upsert_payload_to_cloud", return_value=result
+            ep, "upsert_payload_to_cloud", return_value=ok_result()
         ) as upsert:
             ep._upsert_to_cloud_nonfatal(
                 payload=PAYLOAD,
@@ -106,17 +234,17 @@ class TestUpsertToCloudNonFatal:
         assert blob["IngestCloudUpsertSuccess"] == 1
         assert "IngestCloudUpsertFailure" not in blob
         assert blob["IngestCloudUpsertRecords"] == 2
-        assert blob["collection"] == "words"
 
     def test_partial_failure_emits_failure_metric_without_raising(
         self, capsys
     ):
-        result = CloudUpsertResult(
+        result = ok_result(
             collection="lines",
             attempted=601,
             upserted=351,
             batches=3,
             failed_batches=1,
+            dropped=2,
             error="RuntimeError: cloud 503",
             duration_seconds=1.1,
         )
@@ -132,14 +260,34 @@ class TestUpsertToCloudNonFatal:
         (blob,) = emitted_metrics(capsys)
         assert blob["IngestCloudUpsertFailure"] == 1
         assert blob["IngestCloudUpsertFailedBatches"] == 1
+        assert blob["IngestCloudUpsertDropped"] == 2
         assert blob["IngestCloudUpsertRecords"] == 351
         assert blob["error"] == "RuntimeError: cloud 503"
 
+    def test_deadline_exceeded_is_reported(self, capsys):
+        result = ok_result(
+            upserted=250,
+            attempted=750,
+            batches=2,
+            deadline_exceeded=True,
+            error="deadline of 60s exceeded with 500 record(s) unwritten",
+        )
+        with patch.object(ep, "upsert_payload_to_cloud", return_value=result):
+            ep._upsert_to_cloud_nonfatal(
+                payload=PAYLOAD,
+                collection_name="words",
+                cloud_cfg=CLOUD_CFG,
+                image_id="img-1",
+                receipt_id=1,
+            )
+
+        (blob,) = emitted_metrics(capsys)
+        assert blob["IngestCloudUpsertFailure"] == 1
+        assert blob["deadline_exceeded"] is True
+
     def test_unexpected_exception_is_swallowed(self, capsys):
         with patch.object(
-            ep,
-            "upsert_payload_to_cloud",
-            side_effect=RuntimeError("boom"),
+            ep, "upsert_payload_to_cloud", side_effect=RuntimeError("boom")
         ):
             ep._upsert_to_cloud_nonfatal(
                 payload=PAYLOAD,
@@ -152,6 +300,41 @@ class TestUpsertToCloudNonFatal:
         (blob,) = emitted_metrics(capsys)
         assert blob["IngestCloudUpsertFailure"] == 1
         assert blob["error"] == "RuntimeError: boom"
+
+    def test_telemetry_failure_does_not_escape(self):
+        """A broken metric write must not fail an ingest that succeeded."""
+        with (
+            patch.object(
+                ep, "upsert_payload_to_cloud", return_value=ok_result()
+            ),
+            patch.object(
+                ep,
+                "_emit_emf_metrics",
+                side_effect=RuntimeError("stdout gone"),
+            ),
+        ):
+            ep._upsert_to_cloud_nonfatal(
+                payload=PAYLOAD,
+                collection_name="words",
+                cloud_cfg=CLOUD_CFG,
+                image_id="img-1",
+                receipt_id=1,
+            )
+
+    def test_logging_failure_does_not_escape(self):
+        with (
+            patch.object(
+                ep, "upsert_payload_to_cloud", return_value=ok_result()
+            ),
+            patch.object(ep, "_log", side_effect=RuntimeError("log gone")),
+        ):
+            ep._upsert_to_cloud_nonfatal(
+                payload=PAYLOAD,
+                collection_name="words",
+                cloud_cfg=CLOUD_CFG,
+                image_id="img-1",
+                receipt_id=1,
+            )
 
     @pytest.mark.parametrize("cloud_cfg", [None, {}], ids=["none", "empty"])
     def test_cloud_disabled_is_a_noop(self, capsys, cloud_cfg):

--- a/receipt_upload/tests/test_ingest_cloud_upsert.py
+++ b/receipt_upload/tests/test_ingest_cloud_upsert.py
@@ -379,6 +379,63 @@ class TestUpsertToCloudNonFatal:
 
         assert elapsed < 2.0, f"telemetry tail was unbounded: {elapsed:.2f}s"
 
+    def test_backpressure_also_bounds_the_telemetry(self):
+        """A refused attempt means earlier ones are stuck on I/O."""
+        import time as _time
+
+        result = ok_result(
+            upserted=0,
+            attempted=37,
+            dropped=37,
+            backpressure=True,
+            drop_reasons={"orphaned_threads": 37},
+            error="more than 3 cloud upsert attempts are still in flight",
+        )
+        with (
+            patch.object(ep, "upsert_payload_to_cloud", return_value=result),
+            patch.object(
+                ep,
+                "_emit_emf_metrics",
+                side_effect=lambda *a, **k: _time.sleep(5),
+            ),
+            patch.object(
+                ep, "_log", side_effect=lambda *a, **k: _time.sleep(5)
+            ),
+        ):
+            began = _time.monotonic()
+            ep._upsert_to_cloud_nonfatal(
+                payload=PAYLOAD,
+                collection_name="words",
+                cloud_cfg=CLOUD_CFG,
+                image_id="img-1",
+                receipt_id=1,
+            )
+            elapsed = _time.monotonic() - began
+
+        assert elapsed < 2.0, f"telemetry tail was unbounded: {elapsed:.2f}s"
+
+    def test_backpressure_is_reported_as_a_failure(self, capsys):
+        result = ok_result(
+            upserted=0,
+            attempted=37,
+            dropped=37,
+            backpressure=True,
+            drop_reasons={"orphaned_threads": 37},
+        )
+        with patch.object(ep, "upsert_payload_to_cloud", return_value=result):
+            ep._upsert_to_cloud_nonfatal(
+                payload=PAYLOAD,
+                collection_name="words",
+                cloud_cfg=CLOUD_CFG,
+                image_id="img-1",
+                receipt_id=1,
+            )
+
+        (blob,) = emitted_metrics(capsys)
+        assert blob["IngestCloudUpsertFailure"] == 1
+        assert blob["IngestCloudUpsertDropped"] == 37
+        assert blob["backpressure"] is True
+
     def test_unexpected_exception_is_swallowed(self, capsys):
         with patch.object(
             ep, "upsert_payload_to_cloud", side_effect=RuntimeError("boom")

--- a/receipt_upload/tests/test_ingest_cloud_upsert.py
+++ b/receipt_upload/tests/test_ingest_cloud_upsert.py
@@ -147,6 +147,62 @@ class TestStagedPublication:
         ep._discard_staged_payload("/nonexistent/staged.pkl")
         ep._discard_staged_payload(None)
 
+    def test_a_failed_write_leaves_no_partial_file(self):
+        """A warm Lambda keeps /tmp, so a half-written file would persist."""
+        created = []
+        real_mkstemp = ep.tempfile.mkstemp
+
+        def tracking_mkstemp(*args, **kwargs):
+            handle, path = real_mkstemp(*args, **kwargs)
+            created.append(path)
+            return handle, path
+
+        with (
+            patch.object(ep.tempfile, "mkstemp", side_effect=tracking_mkstemp),
+            patch.object(
+                ep.pickle, "dump", side_effect=OSError("disk full mid-write")
+            ),
+        ):
+            assert ep._stage_cloud_payload(PAYLOAD, "words", CLOUD_CFG) is None
+
+        assert created, "expected a temp file to have been created"
+        for path in created:
+            assert not os.path.exists(path), f"{path} was left behind"
+
+    def test_a_successful_write_keeps_the_file(self):
+        path = ep._stage_cloud_payload(PAYLOAD, "words", CLOUD_CFG)
+        try:
+            assert path and os.path.exists(path)
+        finally:
+            ep._discard_staged_payload(path)
+
+
+class TestTracingRetryCleanup:
+    """The worker reruns its pipeline if the LangSmith flush fails."""
+
+    def test_first_staged_payload_is_dropped_before_the_rerun(self):
+        """Otherwise the first attempt's file is orphaned in /tmp."""
+        first = ep._stage_cloud_payload(PAYLOAD, "words", CLOUD_CFG)
+        assert first and os.path.exists(first)
+
+        # What the worker's except branch does with the discarded result.
+        ep._discard_staged_payload(
+            {"cloud_payload_path": first}.get("cloud_payload_path")
+        )
+
+        assert not os.path.exists(first)
+
+    @pytest.mark.parametrize(
+        "worker",
+        ["_run_lines_pipeline_worker", "_run_words_pipeline_worker"],
+    )
+    def test_both_workers_clean_up_before_rerunning(self, worker):
+        import inspect
+
+        source = inspect.getsource(getattr(ep, worker))
+        assert "traced_result" in source
+        assert "_discard_staged_payload(" in source
+
 
 class TestStalenessFence:
     """Direct writes bypass compaction's FIFO ordering."""
@@ -289,6 +345,39 @@ class TestUpsertToCloudNonFatal:
         (blob,) = emitted_metrics(capsys)
         assert blob["IngestCloudUpsertFailure"] == 1
         assert blob["deadline_exceeded"] is True
+
+    def test_telemetry_after_an_overrun_is_time_bounded(self):
+        """Reporting a blown budget must not blow it further."""
+        import time as _time
+
+        result = ok_result(
+            upserted=0,
+            attempted=2,
+            deadline_exceeded=True,
+            error="deadline of 60s exceeded",
+        )
+        with (
+            patch.object(ep, "upsert_payload_to_cloud", return_value=result),
+            patch.object(
+                ep,
+                "_emit_emf_metrics",
+                side_effect=lambda *a, **k: _time.sleep(5),
+            ),
+            patch.object(
+                ep, "_log", side_effect=lambda *a, **k: _time.sleep(5)
+            ),
+        ):
+            began = _time.monotonic()
+            ep._upsert_to_cloud_nonfatal(
+                payload=PAYLOAD,
+                collection_name="words",
+                cloud_cfg=CLOUD_CFG,
+                image_id="img-1",
+                receipt_id=1,
+            )
+            elapsed = _time.monotonic() - began
+
+        assert elapsed < 2.0, f"telemetry tail was unbounded: {elapsed:.2f}s"
 
     def test_unexpected_exception_is_swallowed(self, capsys):
         with patch.object(


### PR DESCRIPTION
## The finding

From `EMBEDDING_LATENCY_DESIGN.md` (Phase 1): embedding is not the bottleneck — one OpenAI call for a 150-word receipt takes 1–2s. The bottleneck is that **freshly computed vectors reach the queryable store only as Phase 2 of the S3 snapshot merge**, inside a 554MB read-modify-write behind a global per-collection DynamoDB lock.

Measured in prod over 24h:

| Signal | Value |
|---|---|
| `CompactionLockAcquisitionFailed` | 856 (**92% lock rejection**) |
| Completed merge cycles | **32/day** (7 words + 25 lines) |
| Words snapshot rewrite | 578MB every ~7.7 min, ~5.4 min wall clock per cycle |

If the lock is not acquired, the handler returns every message as a failure and **the cloud write never happens at all**. Chroma Cloud is already the production query target (the MCP server queries it exclusively; the site's word-similarity cache generator prefers it; `infra/security.py:12` documents it as "the query target"), and the ingest Lambda already holds the vectors in memory — it just throws them into a tarball instead.

## What this does

Publishes the line and word payloads to Chroma Cloud from the ingest path, **immediately after the collection's delta tarball is durable in S3**. New words become queryable in ~2–3s instead of minutes-to-never.

- `receipt_chroma/receipt_chroma/embedding/cloud_upsert.py` — `upsert_payload_to_cloud()`, batched at 250 (Chroma Cloud rejects upserts above 300), with a 60s wall-clock budget, a bounded HTTP timeout, tombstone handling, and quota enforcement. It never raises.
- `embedding_processor.py` — `_upload_delta_then_publish()` fixes the order for both pipeline workers; `_upsert_to_cloud_nonfatal()` contains every failure including telemetry.
- EMF metrics `IngestCloudUpsertSuccess` / `IngestCloudUpsertFailure` / `IngestCloudUpsertSkipped`, plus records, dropped, truncated, failed-batch and latency values, in the compaction handler's `EmbeddingWorkflow` namespace under the same `ENABLE_METRICS` gate.

## What this deliberately does not touch

- **Delta upload and `CompactionRun` creation are unchanged**, and now strictly precede the Cloud write. Compaction remains the backstop, and the S3 snapshot keeps being produced for the label evaluator's 40-way fan-out (pinned to S3 at `label_evaluator_step_functions/infrastructure.py:449` to avoid Cloud rate-limit contention) and the other pure-S3 readers.
- No ESM, lock, concurrency, or batch-workflow changes. The compaction event-source mappings stay disabled.

## Review round: six findings from codex, all addressed

**1. Cloud was written before the durable backstop existed (critical).** Both workers upserted to Cloud and *then* uploaded the delta. If S3 failed, Cloud kept records that no `CompactionRun` would ever reconcile — and the processor returns `success: True` regardless. Both workers now call `_upload_delta_then_publish()`, which uploads first and propagates any upload error before the Cloud write is reached.

**2. Unbounded Cloud I/O could consume the Lambda (critical).** Chroma 1.5 builds its Cloud session as `httpx.Client(timeout=None)` (`chromadb/api/fastapi.py:84`) with no setting to override it. `ChromaClient` gained `cloud_request_timeout`, applied to that session (10s connect / 30s read on this path), and `upsert_payload_to_cloud` enforces a 60s wall clock across batches, abandoning the remainder to compaction. `_emit_emf_metrics` and `_log` moved inside the outermost guard so a stdout or logging failure cannot escape either.

**3. Re-upserts could not clear optional metadata (high).** Chroma merges metadata on write, and the payload builders `pop()` keys like `valid_labels_array` rather than emitting them, so a removed label survived a re-ingest. Verified against local Chroma 1.5: upserting `{"keep": 2}` over `{"old": 1, "keep": 1}` leaves `old` in place. Absent optional keys are now sent as explicit `None`, matching the convention already documented at `receipt_chroma/receipt_chroma/data/operations.py:755`. The S3 delta payload is unchanged. There is a test that fails without this.

**4. Direct writes bypass compaction's FIFO ordering (high).** Compaction routes a receipt's label and place updates through the same FIFO group as its `CompactionRun`; a direct write is not in that order, so a newer label update could be overwritten by an older worker snapshot. Full revision fencing is Phase 2. The mitigation here is a bound on staleness: if a worker's label snapshot is older than 300s (configurable via `INGEST_CLOUD_UPSERT_MAX_LABEL_AGE_SECONDS`), the direct write is skipped with `IngestCloudUpsertSkipped` / `reason=stale_risk` and compaction publishes in order. 300s sits well above ingest p90 (40.8s) so healthy runs always publish, and far below the 900s Lambda ceiling. The race is documented in the function's docstring.

**5. Sanitization handled one constraint and mishandled empty metadata (medium).** Chroma rejects empty metadata dicts (`ValueError: Expected metadata to be a non-empty dict`), so a single all-dropped record failed its whole 250-record batch. Such records are now dropped with a counted reason; a batch `ValueError` falls back to per-record upserts so one bad record cannot cost the other 249; column lengths are validated before any write; and the 32-key, 8182-byte metadata value, 16384-byte document and 128-byte id limits are enforced by truncation, or by dropping the record where truncation would corrupt identity (ids).

**6. Tests did not exercise the dangerous boundaries (medium).** Tombstone clearing and empty-metadata rejection are now verified against a **real local Chroma**, not a mock. Added: delta-upload failure means no Cloud write, the deadline path, per-record fallback after a batch rejection, column-length mismatch, oversized id/value/document/key handling, telemetry and logging failures, and the staleness fence.

## Review round 2: three P1s and two P2s, all addressed

**1. Publication still preceded the durable `CompactionRun` (P1).** Gating each collection on its own delta was not enough: the `CompactionRun` that makes a record reconcilable is written by the parent after *both* workers finish, so one collection could reach Cloud while the other pipeline, or the Dynamo write, failed. Workers now stage their prepared payload to a local file and return the path; the parent creates the `CompactionRun` and only then publishes both collections. If the run is not created, nothing is published. `process_embeddings` also stops hardcoding `"success": True` and now reports whether the run exists. The handoff goes through a file rather than a return value because Phase 2 runs on `ProcessPoolExecutor` outside Lambda, where an in-memory payload would not survive; staged files are deleted in the parent's `finally`.

**2. The 60s budget did not cover connection setup (P1).** The session timeout was applied after `chromadb.CloudClient(...)` returned, but Chroma issues three requests — identity, tenant, database — inside the constructor with `timeout=None`. Connection setup and all writes now run on a daemon thread joined against the remaining budget, so a constructor stall cannot outlive it; a daemon thread also cannot hold the Lambda open. The deadline is additionally checked inside the per-record fallback loop, where 250 individual requests are 250 chances to stall, and Cloud **read** clients (`_make_read_client`) now get the same request timeout.

**3. Validation 400s still cost the whole batch (P1).** Chroma Cloud maps server-side validation and quota 400s to `chromadb.errors.InvalidArgumentError`, which is a `ChromaError` and not a `ValueError`, so the per-record fallback never fired for them. The fallback now keys off an explicit set of validation-class errors (`ValueError`, `InvalidArgumentError`, `BatchSizeExceededError`, `DuplicateIDError`, `IDAlreadyExistsError`, `InvalidUUIDError`, `UniqueConstraintError`). `RateLimitError` and `QuotaError` are deliberately **excluded**: fanning a rejected batch into 250 individual requests would make either strictly worse.

**4. Cloud clients leaked their system and HTTP pool (P2).** `ChromaClient.close()` returned early for anything non-persistent, so each cloud client left behind its httpx pool and its entry in Chroma's process-wide shared-system cache, which never evicts — and in Lambda's thread-based workers that persists across warm invocations. `close()` now closes the session, stops the system, and evicts the cache entry. A test runs three create/close cycles and asserts the cache stays flat.

**5. Legacy line fields were not tombstoned (P2).** Row ids reuse the primary line id, so records written before the row rewrite still carry `prev_line` / `next_line`, which current row metadata no longer emits. Both are now in the line tombstone set.

The two filesystem-backed Chroma tests that codex's sandbox could not run (`TestTombstonesAgainstRealChroma`) were run here against real Chroma 1.5 and pass.

This branch also merges `origin/main` to pick up #1275 (atomic `get_or_create_collection`), which landed on `chroma_client.py` while this PR was open. The source change auto-merged; the only conflict was both sides appending tests to `test_chroma_client.py` and both sets are kept.

## Review round 3: three P1s and two P2s, all addressed

**1. `success=False` was discarded by the handler (P1).** The processor reported it, but `handler.py` logged success unconditionally and returned `embedding_success: True`, so a failed `CompactionRun` moved no metric at all. The handler now marks that receipt failed, marks the whole image failed if any receipt is, and returns `embedding_failed` plus `failed_receipt_ids`. That feeds the existing `UploadLambdaEmbeddingFailed` metric.

**On retry semantics, since it matters for how this is operated:** nothing retries an OCR message on embedding failure. `batch_item_failures` is populated only for llm-validation records, and the OCR-results event-source mapping does not enable `ReportBatchItemFailures` at all, so the message is acked regardless. **The metric and an alarm on it are the detection path for now** — this PR deliberately does not build a retry system for orphaned deltas.

**2. Throttling could still fan out into 250 requests (P1).** Excluding `RateLimitError`/`QuotaError` from the batch catch only protected the *first* request; once a validation error opened the per-record fallback, a throttled singleton let the remaining 249 through. Throttling now aborts the rest of that batch, counted under `rate_limited_abort`.

**3. The deadline excluded the telemetry tail (P1).** The join was bounded but the logging and metrics after it were not, so a blocked sink handed the overrun straight back — a 0.1s budget with a 0.4s sink returned in 0.51s. Post-deadline telemetry now runs on a daemon thread with a 0.25s grace, both inside the module and in the ingest wrapper; there are tests asserting a 5s sink cannot stretch the call past 2s. For thread accumulation in warm containers, abandoned attempts hold a semaphore permit and a new attempt is refused once `MAX_ORPHANED_ATTEMPTS` (3) are still stuck, counted under `orphaned_threads`. That is backpressure, not cancellation — a stuck thread still cannot be killed.

**4. Real Cloud clients leaked most of their systems (P2).** Confirmed: one `CloudClient` registers **three** cache identifiers — its own plus its internal client and admin client — so evicting `client._identifier` left two behind per cycle (0 → 3 → 2). The identifiers a construction adds are now captured by diffing the cache around it, and all are evicted. Verified against a real `CloudClient` with mocked network: three cycles hold the cache at baseline.

**5. Tempfile cleanup missed two paths (P2).** Staging now closes the descriptor and unlinks the partial file if `mkstemp`, `fdopen` or `pickle.dump` fails partway. Separately, when the worker's LangSmith flush fails it reruns the whole pipeline, which orphaned the first attempt's staged file; that file is now discarded before the rerun. Both workers do this.

All filesystem-dependent tests that the review environment could not run were run here and pass: the two real-Chroma tombstone tests, the real-`CloudClient` cache test, and the twelve staging/cleanup tests.

## Review round 4: three findings, all in the round-3 fix code

**1. The backpressure rejection reintroduced the unbounded tail (P1).** When all permits were held, that path logged synchronously and left the result unmarked, so the ingest wrapper also reported synchronously — a 50ms deadline with a 2s sink returned in 2.003s. Both are I/O, and a rejection specifically means earlier attempts are already stuck on that kind of I/O. The rejection now reports through the same grace-bounded thread and sets a `backpressure` flag; a `telemetry_must_be_bounded` property covers it and the deadline case, so the wrapper bounds its reporting too.

**2. A failed `CloudClient` constructor still leaked its system (P2).** The cache diff only ran if construction returned. Chroma registers its system *before* the identity request that can fail, and `_client` stays `None` on that path, so `close()` had nothing to evict — a Cloud outage accumulated a system and a pool per failed attempt. Construction failure now evicts the delta at the failure site. Verified: four consecutive failed constructions hold the cache at baseline, previously 0 → 1 per attempt.

**3. Backpressure undercounted dropped records (P2).** The rejection counted a single drop while skipping every prepared record, understating the metric during exactly the incident it exists to describe. It now counts each one, so 37 prepared records report `dropped=37` and `{"orphaned_threads": 37}`.

## Deviations from the design doc

1. **Call site.** The doc suggests calling immediately after `download_and_embed_parallel` returns (~line 1266). At that point only raw vectors exist — `ids`, `documents` and `metadatas` are built later, inside the pipeline workers. The upsert therefore sits after the payload build and after the delta upload, which is also where records carry the validated merchant name and section assignments rather than needing a later compaction pass to correct them.
2. **Env wiring was already done.** `CHROMA_CLOUD_*` were already on the `process_ocr` Lambda (`infra/upload_images/infra.py:529-532`) from the earlier `skip_snapshot_download` work. Only `ENABLE_METRICS` was added.
3. **Timing instrumentation deferred.** The doc's item 5 also asks for an OpenAI-vs-rest split of the 27.8s ingest p50, and item 6 for the botocore connection-pool bump and the `INIT_REPORT` timeout investigation. Those are independent of the upsert and were left out to keep this diff revertible on its own.

## Tests

Local (python3.12): **839 passed / 18 skipped** across `receipt_chroma/tests/unit` and `receipt_upload/tests`, plus **78 passed** in the container handler's own suite, every skip pre-existing. New coverage is 57 tests in `test_cloud_upsert.py`, 28 in `test_ingest_cloud_upsert.py`, 9 in `test_chroma_client.py`, and 6 in a new `test_embedding_failure_propagation.py`. `black` and `isort` clean at `--line-length=79` for both packages and the changed infra file.

## Follow-ups

Phases 2–4 of `EMBEDDING_LATENCY_DESIGN.md` follow separately: revision fencing plus the silent metadata-drop fix and moving the cloud write out from under the lock (Phase 2); single-writer snapshot export and killing lock contention (Phase 3); retiring the batch path (Phase 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
