### PR TITLE
fix: atomic get_or_create_collection in create_if_missing path

### DIFF
--- a/receipt_chroma/receipt_chroma/data/chroma_client.py
+++ b/receipt_chroma/receipt_chroma/data/chroma_client.py
@@ -481,7 +481,10 @@ class ChromaClient:
 
             except (NotFoundError, ValueError) as e:
                 if create_if_missing and self.mode != "read":
-                    # Create new collection
+                    # get_or_create is atomic server-side; a plain
+                    # create_collection here raced with concurrent workers
+                    # ("Collection [x] already exists"), and each benign
+                    # collision fed circuit-breaker failure counts.
                     create_args = {
                         "name": name,
                         "metadata": metadata
@@ -493,9 +496,9 @@ class ChromaClient:
                         )
 
                     self._collections[name] = _retry_with_backoff(
-                        self.client.create_collection, **create_args
+                        self.client.get_or_create_collection, **create_args
                     )
-                    logger.info("Created new collection: %s", name)
+                    logger.info("Got or created collection: %s", name)
                 else:
                     raise ValueError(
                         f"Collection '{name}' not found and "

--- a/receipt_chroma/tests/unit/test_chroma_client.py
+++ b/receipt_chroma/tests/unit/test_chroma_client.py
@@ -665,3 +665,33 @@ def test_cloud_client_config_with_none_values():
     assert client._cloud_api_key == "test-key"
     assert client._cloud_tenant is None
     assert client._cloud_database is None
+
+
+def test_create_if_missing_uses_atomic_get_or_create(monkeypatch):
+    """Concurrent workers racing to create a collection must not fail with
+    'Collection already exists' — the create path must call the atomic
+    get_or_create_collection rather than create_collection."""
+    from unittest.mock import MagicMock
+
+    from chromadb.errors import NotFoundError
+
+    from receipt_chroma.data.chroma_client import ChromaClient
+
+    client = ChromaClient(mode="delta")
+    inner = MagicMock()
+    inner.get_collection.side_effect = NotFoundError("nope")
+    inner.create_collection.side_effect = AssertionError(
+        "must not call non-atomic create_collection"
+    )
+    sentinel = MagicMock(name="collection")
+    inner.get_or_create_collection.return_value = sentinel
+    monkeypatch.setattr(client, "_client", inner, raising=False)
+    monkeypatch.setattr(
+        type(client), "client", property(lambda self: inner), raising=False
+    )
+
+    coll = client.get_collection("words", create_if_missing=True)
+
+    assert coll is sentinel
+    inner.get_or_create_collection.assert_called_once()
+    client.close()


### PR DESCRIPTION
Fixes #1274. The `create_if_missing` branch of `ChromaClient.get_collection` did get→create non-atomically; with 4 parallel cloud-sync workers plus concurrent compact lambdas, losers of the race fail with `Collection [lines] already exists`, and every benign collision counts as a failure on the `chromadb_operations` circuit breaker — after 5 the breaker opens and the ingest execution dies (`word-ingest-sf-prod` failed 14 consecutive runs this way, blocking prod embedding ingestion).

Switch to Chroma's server-side atomic `get_or_create_collection`. Regression test asserts the non-atomic `create_collection` is never called on the miss path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)