### PR TITLE
fix: skip batch results for entities deleted between submit and poll

### DIFF
--- a/receipt_chroma/receipt_chroma/embedding/delta/line_delta.py
+++ b/receipt_chroma/receipt_chroma/embedding/delta/line_delta.py
@@ -156,7 +156,21 @@ def save_line_embeddings_as_delta(
         parsed.append((result, meta))
         image_id = meta["image_id"]
         receipt_id = meta["receipt_id"]
-        lines = descriptions[image_id][receipt_id]["lines"]
+        # A receipt deleted between submit and poll (merges, dedupe,
+        # promotions) is a skip, not a failure — treat like stale so the
+        # rest of the batch still ingests.
+        _details = descriptions.get(image_id, {}).get(receipt_id)
+        if _details is None:
+            if (image_id, receipt_id) not in stale_receipts:
+                logger.warning(
+                    "Receipt deleted since submit; skipping its results: "
+                    "image_id=%s receipt_id=%s",
+                    image_id,
+                    receipt_id,
+                )
+            stale_receipts.add((image_id, receipt_id))
+            continue
+        lines = _details["lines"]
         rows_map = get_visual_rows_map(image_id, receipt_id, lines)
         if meta["line_id"] not in rows_map:
             if (image_id, receipt_id) not in stale_receipts:

--- a/receipt_chroma/receipt_chroma/embedding/delta/word_delta.py
+++ b/receipt_chroma/receipt_chroma/embedding/delta/word_delta.py
@@ -4,6 +4,7 @@ This module provides functionality for saving word embedding results
 as ChromaDB delta files for compaction.
 """
 
+import logging
 from typing import Dict, List, Optional, TypedDict
 
 from receipt_chroma.chroma_types import (
@@ -17,6 +18,8 @@ from receipt_chroma.embedding.metadata.word_metadata import (
     enrich_word_metadata_with_anchors,
     enrich_word_metadata_with_labels,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class WordMetadataBase(TypedDict):
@@ -115,8 +118,20 @@ def save_word_embeddings_as_delta(  # pylint: disable=too-many-statements
         word_id = _meta["word_id"]
         source = "openai_embedding_batch"
 
-        # From the descriptions, get the receipt details for this result
-        receipt_details = descriptions[image_id][receipt_id]
+        # From the descriptions, get the receipt details for this result.
+        # The receipt (or individual word) may have been deleted between
+        # submit and poll (merges, dedupe, promotions). A deleted entity is
+        # a skip, not a failure — raising here fed the circuit breaker and
+        # killed entire ingest runs over rows that no longer exist.
+        receipt_details = descriptions.get(image_id, {}).get(receipt_id)
+        if receipt_details is None:
+            logger.warning(
+                "Receipt deleted since submit; skipping result: "
+                "image_id=%s receipt_id=%s",
+                image_id,
+                receipt_id,
+            )
+            continue
         words = receipt_details["words"]
         labels = receipt_details["labels"]
         place = receipt_details["place"]
@@ -131,11 +146,15 @@ def save_word_embeddings_as_delta(  # pylint: disable=too-many-statements
             None,
         )
         if target_word is None:
-            raise ValueError(
-                f"No ReceiptWord found for image_id={image_id}, "
-                f"receipt_id={receipt_id}, line_id={line_id}, "
-                f"word_id={word_id}"
+            logger.warning(
+                "ReceiptWord deleted since submit; skipping result: "
+                "image_id=%s receipt_id=%s line_id=%s word_id=%s",
+                image_id,
+                receipt_id,
+                line_id,
+                word_id,
             )
+            continue
 
         # Filter labels to only those for this specific word
         word_labels = [

--- a/receipt_chroma/tests/unit/test_delta_parsing.py
+++ b/receipt_chroma/tests/unit/test_delta_parsing.py
@@ -363,3 +363,49 @@ class TestSectionWiring:
                 sqs_queue_url=None,
             )
         assert "section_label" not in captured["metadatas"][0]
+
+
+def test_word_delta_skips_deleted_receipt_and_word(monkeypatch, caplog):
+    """Batch results referencing rows deleted between submit and poll must
+    be skipped (with a warning), not raise — raising fed the circuit
+    breaker and killed whole ingest runs (2026-07-28 prod incident)."""
+    from unittest.mock import MagicMock, patch
+
+    from receipt_chroma.embedding.delta import word_delta
+
+    results = [
+        {  # whole receipt deleted
+            "custom_id": "IMAGE#11111111-1111-4111-8111-111111111111#"
+            "RECEIPT#00001#LINE#00001#WORD#00001",
+            "embedding": [0.0] * 8,
+        },
+        {  # word deleted, receipt survives with an unrelated word
+            "custom_id": "IMAGE#22222222-2222-4222-8222-222222222222#"
+            "RECEIPT#00001#LINE#00010#WORD#00002",
+            "embedding": [0.0] * 8,
+        },
+    ]
+    surviving_word = MagicMock(line_id=99, word_id=1)
+    descriptions = {
+        "22222222-2222-4222-8222-222222222222": {
+            1: {
+                "words": [surviving_word],
+                "labels": [],
+                "place": MagicMock(merchant_name="M"),
+            }
+        }
+    }
+    with patch.object(
+        word_delta, "produce_embedding_delta", return_value={}
+    ) as produce:
+        word_delta.save_word_embeddings_as_delta(
+            results=results,
+            descriptions=descriptions,
+            batch_id="00000000-0000-4000-8000-000000000000",
+            bucket_name="b",
+            sqs_queue_url=None,
+        )
+    # nothing raised; both results skipped -> empty payload handed through
+    args, kwargs = produce.call_args
+    payload_ids = kwargs.get("ids", args[0] if args else [])
+    assert payload_ids == []


### PR DESCRIPTION
When rows are deleted between OpenAI batch submit and poll (receipt merges, dedupe, dev→prod promotion), the poll path raised `No ReceiptWord found …` per missing row; each error fed the `chromadb_operations` circuit breaker until it opened and the ingest execution failed — `word-ingest-sf-prod` died repeatedly today on batches containing words from receipts the promotion had deleted minutes after submit.

Deleted entities are now warn-and-skip in both `word_delta` and `line_delta` (guarding both the receipt-level dict lookups and the word-level miss), matching `line_delta`'s existing stale-receipt skip philosophy: one gone row must not kill the whole ingest run. Regression test covers deleted-receipt and deleted-word results producing an empty payload without raising.

Follows #1275 (get_or_create race) as the second breaker-feeder fix. Related: #1274, #1272.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented errors when receipts or receipt words are deleted while embedding results are being processed.
  * Skips outdated embedding results safely and records a warning instead of failing the operation.

* **Tests**
  * Added coverage for deleted receipts and words to verify processing completes successfully without producing invalid embeddings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->