### PR TITLE
Speed up milk receipt fetches

### DIFF
--- a/infra/routes/word_similarity_cache_generator/lambdas/index.py
+++ b/infra/routes/word_similarity_cache_generator/lambdas/index.py
@@ -17,6 +17,7 @@ from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Optional
 
 import boto3
@@ -34,6 +35,8 @@ CHROMADB_BUCKET = os.environ["CHROMADB_BUCKET"]
 S3_CACHE_BUCKET = os.environ.get("S3_CACHE_BUCKET", CHROMADB_BUCKET)
 CACHE_KEY = "word-similarity-cache/milk.json"
 TARGET_WORD = "MILK"
+LOCAL_CACHE_OUTPUT = os.environ.get("LOCAL_CACHE_OUTPUT")
+LOCAL_CHROMADB_PATH = os.environ.get("LOCAL_CHROMADB_PATH")
 
 # Chroma Cloud configuration (optional - falls back to S3 if not set)
 CHROMA_CLOUD_ENABLED = (
@@ -67,7 +70,11 @@ def normalize_merchant(name: str) -> str:
 
 
 # Pattern to match price-like tokens (used to extract product name from row text)
-def find_milk_line(lines, target_word: str = "MILK") -> tuple[str, int] | None:
+def find_milk_line(
+    lines,
+    target_word: str = "MILK",
+    candidate_line_ids: set[int] | None = None,
+) -> tuple[str, int] | None:
     """Find the specific OCR line containing the target word.
 
     When visual rows contain multiple products (e.g., KOMBUCHA and RAW MILK
@@ -76,6 +83,8 @@ def find_milk_line(lines, target_word: str = "MILK") -> tuple[str, int] | None:
     Args:
         lines: List of ReceiptLine entities from DynamoDB
         target_word: Word to search for (default: MILK)
+        candidate_line_ids: Optional line IDs eligible to be returned. Other
+            lines remain available for detecting a following VOID marker.
 
     Returns:
         Tuple of (text, line_id) for the line containing target_word,
@@ -83,6 +92,11 @@ def find_milk_line(lines, target_word: str = "MILK") -> tuple[str, int] | None:
     """
     by_id = {line.line_id: line.text.upper() for line in lines}
     for line in lines:
+        if (
+            candidate_line_ids is not None
+            and line.line_id not in candidate_line_ids
+        ):
+            continue
         if target_word in line.text.upper():
             # Check exclusions
             text_upper = line.text.upper()
@@ -92,10 +106,64 @@ def find_milk_line(lines, target_word: str = "MILK") -> tuple[str, int] | None:
             # Skip voided purchases: receipts print the item line and then a
             # "Voided <item>" marker on the following line(s). Treat a VOID
             # marker within the next two lines as voiding this candidate.
-            if any("VOID" in by_id.get(line.line_id + off, "") for off in (1, 2)):
+            if any(
+                "VOID" in by_id.get(line.line_id + off, "") for off in (1, 2)
+            ):
                 continue
             return (line.text, line.line_id)
     return None
+
+
+def parse_row_line_ids(metadata: dict) -> list[int]:
+    """Return the visual row's DynamoDB line IDs from Chroma metadata."""
+    raw_line_ids = metadata.get("row_line_ids")
+    if isinstance(raw_line_ids, str):
+        try:
+            raw_line_ids = json.loads(raw_line_ids)
+        except (TypeError, ValueError):
+            raw_line_ids = None
+
+    if not isinstance(raw_line_ids, (list, tuple)):
+        raw_line_ids = [metadata.get("line_id")]
+
+    line_ids = []
+    for line_id in raw_line_ids:
+        if isinstance(line_id, bool):
+            continue
+        try:
+            parsed = int(line_id)
+        except (TypeError, ValueError):
+            continue
+        if parsed >= 0 and parsed not in line_ids:
+            line_ids.append(parsed)
+
+    if not line_ids:
+        raise ValueError("Chroma row is missing a valid line_id")
+    return line_ids
+
+
+def add_line_context(line_ids: list[int], radius: int = 2) -> list[int]:
+    """Include nearby OCR line IDs needed for price and VOID detection."""
+    return sorted(
+        {
+            candidate
+            for line_id in line_ids
+            for candidate in range(
+                max(0, line_id - radius), line_id + radius + 1
+            )
+        }
+    )
+
+
+def merge_row_line_ids(matches: list[dict]) -> list[int]:
+    """Combine visual-row line IDs for every milk match on a receipt."""
+    line_ids: list[int] = []
+    for match in matches:
+        for line_id in parse_row_line_ids(match):
+            if line_id not in line_ids:
+                line_ids.append(line_id)
+    return line_ids
+
 
 # Price ranges for inferring milk sizes
 MILK_SIZE_RANGES = {
@@ -175,6 +243,7 @@ class TimingStats:
     filter_lines: float = 0.0
     dynamo_fetch_total: float = 0.0
     dynamo_fetch_details: list = field(default_factory=list)
+    dynamo_items_returned: list[int] = field(default_factory=list)
     visual_line_assembly: list = field(default_factory=list)
     total: float = 0.0
     parallel_workers: int = 0
@@ -207,6 +276,7 @@ class TimingStats:
                 "min_ms": round(min(self.dynamo_fetch_details) * 1000, 1),
                 "max_ms": round(max(self.dynamo_fetch_details) * 1000, 1),
                 "count": len(self.dynamo_fetch_details),
+                "items_returned": sum(self.dynamo_items_returned),
             }
 
             # Calculate speedup from parallelization
@@ -624,10 +694,16 @@ def _fetch_lines_from_s3(timing: TimingStats, temp_dir: str) -> list:
 
     logger.info("Snapshot downloaded successfully (%.2fs)", timing.s3_download)
 
-    # Step 2: Initialize local ChromaDB
+    return _fetch_lines_from_local(timing, temp_dir)
+
+
+def _fetch_lines_from_local(timing: TimingStats, chroma_path: str) -> list:
+    """Fetch target rows from an existing local ChromaDB snapshot."""
+    timing.use_chroma_cloud = False
+
     step_start = time.time()
     client = ChromaClient(
-        persist_directory=temp_dir,
+        persist_directory=chroma_path,
         mode="read",
         metadata_only=True,
     )
@@ -636,11 +712,15 @@ def _fetch_lines_from_s3(timing: TimingStats, temp_dir: str) -> list:
         timing.chromadb_init = time.time() - step_start
 
         step_start = time.time()
-        all_lines = lines_collection.get(include=["metadatas"])
+        all_lines = lines_collection.get(
+            where_document={"$contains": TARGET_WORD},
+            include=["metadatas"],
+        )
         timing.chromadb_fetch_all = time.time() - step_start
         logger.info(
-            "Fetched %d lines from local ChromaDB (%.2fs)",
+            "Fetched %d lines containing '%s' from local ChromaDB (%.2fs)",
             len(all_lines["ids"]),
+            TARGET_WORD,
             timing.chromadb_fetch_all,
         )
     finally:
@@ -672,8 +752,21 @@ def handler(_event, _context):
             DYNAMODB_TABLE_NAME, max_pool_connections=100
         )
 
-        # Step 1: Fetch lines (Cloud or S3)
-        if CHROMA_CLOUD_ENABLED:
+        # Step 1: Fetch lines (local snapshot, Cloud, or S3)
+        if LOCAL_CHROMADB_PATH:
+            local_chroma_path = (
+                Path(LOCAL_CHROMADB_PATH).expanduser().resolve()
+            )
+            if (local_chroma_path / "chroma.sqlite3").is_file():
+                all_lines = _fetch_lines_from_local(
+                    timing, str(local_chroma_path)
+                )
+            else:
+                local_chroma_path.mkdir(parents=True, exist_ok=True)
+                all_lines = _fetch_lines_from_s3(
+                    timing, str(local_chroma_path)
+                )
+        elif CHROMA_CLOUD_ENABLED:
             try:
                 all_lines = _fetch_lines_from_cloud(timing)
             except Exception as e:
@@ -707,6 +800,8 @@ def handler(_event, _context):
                             "image_id": meta.get("image_id"),
                             "receipt_id": meta.get("receipt_id"),
                             "line_id": meta.get("line_id"),
+                            "row_line_ids": meta.get("row_line_ids"),
+                            "merchant_name": meta.get("merchant_name"),
                         }
                     )
 
@@ -730,21 +825,52 @@ def handler(_event, _context):
             receipt_id = int(matches[0]["receipt_id"])
             line_id = int(matches[0]["line_id"])
             product_text = matches[0]["text"]
-            work_items.append((image_id, receipt_id, line_id, product_text))
+            row_line_ids = merge_row_line_ids(matches)
+            merchant_name = matches[0].get("merchant_name")
+            work_items.append(
+                (
+                    image_id,
+                    receipt_id,
+                    line_id,
+                    product_text,
+                    row_line_ids,
+                    merchant_name,
+                )
+            )
 
         def process_receipt(work_item):
-            image_id, receipt_id, chromadb_line_id, row_text = work_item
-            timings = {"details": 0, "visual_line": 0}
+            (
+                image_id,
+                receipt_id,
+                chromadb_line_id,
+                row_text,
+                row_line_ids,
+                chroma_merchant_name,
+            ) = work_item
+            timings = {"details": 0, "visual_line": 0, "items": 0}
             try:
                 t0 = time.time()
-                details = dynamo_client.get_receipt_details(
-                    image_id, receipt_id
+                details = dynamo_client.get_receipt_details_for_lines(
+                    image_id,
+                    receipt_id,
+                    add_line_context(row_line_ids),
                 )
                 timings["details"] = time.time() - t0
+                timings["items"] = (
+                    1
+                    + int(details.place is not None)
+                    + len(details.lines)
+                    + len(details.words)
+                    + len(details.labels)
+                )
 
                 # Find the specific OCR line containing "MILK"
                 # This returns both text and line_id for accurate price lookup
-                milk_line = find_milk_line(details.lines, TARGET_WORD)
+                milk_line = find_milk_line(
+                    details.lines,
+                    TARGET_WORD,
+                    candidate_line_ids=set(row_line_ids),
+                )
                 if milk_line:
                     product_text, milk_line_id = milk_line
                 else:
@@ -764,26 +890,28 @@ def handler(_event, _context):
                 timings["visual_line"] = time.time() - t0
 
                 merchant = normalize_merchant(
-                    details.place.merchant_name if details.place else "Unknown"
+                    details.place.merchant_name
+                    if details.place
+                    else chroma_merchant_name or "Unknown"
                 )
                 price = line_total or unit_price
                 if not price:
                     # Some receipts (e.g. Target) print the price at the end
-                    # of the product line itself; split it out rather than
-                    # shipping a priceless row with the price in the name.
-                    m = re.search(r"\s+\$?(\d{1,3}\.\d{2})\s*$", product_text)
+                    # of the visual row. Use Chroma's combined row text because
+                    # the focused DynamoDB response may hold the product and
+                    # price in non-contiguous ReceiptLine entities.
+                    m = re.search(r"\s+\$?(\d{1,3}\.\d{2})\s*$", row_text)
                     if m:
                         price = m.group(1)
-                        product_text = product_text[: m.start()].rstrip()
+                        if product_text == row_text:
+                            product_text = product_text[: m.start()].rstrip()
                 product_text = strip_upc_prefix(product_text)
                 size = infer_size(product_text, price)
 
-                # NOTE: details.lines (the full per-receipt line list, ~75 lines
-                # x 69 receipts ~= 2.8 MB across the response) is intentionally
-                # NOT included in the cache entry. WordSimilarity.tsx builds a
-                # cropped image from `receipt` + `bbox` only and never reads
-                # `lines`. Including it inflated the API payload ~20x for no
-                # frontend benefit. See PR notes / type def MilkReceiptData.
+                # The focused line entities are used only to calculate this
+                # cache entry. WordSimilarity.tsx builds the crop from
+                # `receipt` + `bbox` and never reads `lines`, so do not include
+                # them in the response.
 
                 return {
                     "image_id": image_id,
@@ -825,6 +953,9 @@ def handler(_event, _context):
                         timing.dynamo_fetch_details.append(
                             result["_timings"]["details"]
                         )
+                        timing.dynamo_items_returned.append(
+                            result["_timings"]["items"]
+                        )
                         timing.visual_line_assembly.append(
                             result["_timings"]["visual_line"]
                         )
@@ -856,7 +987,9 @@ def handler(_event, _context):
             if r["price"]:
                 try:
                     summary[key]["prices"].append(
-                        float(str(r["price"]).replace("$", "").replace(",", ""))
+                        float(
+                            str(r["price"]).replace("$", "").replace(",", "")
+                        )
                     )
                 except ValueError:
                     pass
@@ -917,14 +1050,24 @@ def handler(_event, _context):
             "commentary": commentary,
         }
 
-        # Step 7: Upload to S3
-        logger.info("Uploading cache to S3: %s/%s", S3_CACHE_BUCKET, CACHE_KEY)
-        s3_client.put_object(
-            Bucket=S3_CACHE_BUCKET,
-            Key=CACHE_KEY,
-            Body=json.dumps(response_data, default=str),
-            ContentType="application/json",
-        )
+        # Step 7: Persist the cache. Local runs can write the complete result
+        # to disk without mutating the deployed S3 cache.
+        response_json = json.dumps(response_data, default=str)
+        if LOCAL_CACHE_OUTPUT:
+            output_path = Path(LOCAL_CACHE_OUTPUT).expanduser().resolve()
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_text(response_json, encoding="utf-8")
+            logger.info("Wrote local cache to %s", output_path)
+        else:
+            logger.info(
+                "Uploading cache to S3: %s/%s", S3_CACHE_BUCKET, CACHE_KEY
+            )
+            s3_client.put_object(
+                Bucket=S3_CACHE_BUCKET,
+                Key=CACHE_KEY,
+                Body=response_json,
+                ContentType="application/json",
+            )
 
         logger.info(
             "Cache generation complete: %d receipts, %d summary rows (total %.2fs)",
@@ -957,3 +1100,9 @@ def handler(_event, _context):
             logger.info("Cleaned up temp directory")
         except Exception as e:
             logger.warning("Failed to cleanup: %s", e)
+
+
+if __name__ == "__main__":
+    handler_result = handler({}, None)
+    print(handler_result["body"])
+    raise SystemExit(0 if handler_result["statusCode"] < 400 else 1)

--- a/infra/routes/word_similarity_cache_generator/tests/test_focused_receipt_fetch.py
+++ b/infra/routes/word_similarity_cache_generator/tests/test_focused_receipt_fetch.py
@@ -1,0 +1,127 @@
+"""Tests for focused receipt reads in the milk cache generator."""
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from unittest.mock import MagicMock
+
+import boto3
+import pytest
+
+
+def _load_handler(monkeypatch: pytest.MonkeyPatch) -> ModuleType:
+    """Load the Lambda module without initializing production clients."""
+    monkeypatch.setenv("DYNAMODB_TABLE_NAME", "test-table")
+    monkeypatch.setenv("CHROMADB_BUCKET", "test-chroma-bucket")
+    monkeypatch.setattr(boto3, "client", MagicMock())
+
+    receipt_chroma_module = ModuleType("receipt_chroma")
+    receipt_chroma_module.__path__ = []
+    setattr(receipt_chroma_module, "ChromaClient", MagicMock())
+    monkeypatch.setitem(sys.modules, "receipt_chroma", receipt_chroma_module)
+
+    compaction_module = ModuleType("receipt_chroma.compaction")
+    compaction_module.__path__ = []
+    setattr(compaction_module, "CloudConfig", MagicMock())
+    monkeypatch.setitem(
+        sys.modules, "receipt_chroma.compaction", compaction_module
+    )
+
+    chroma_s3_module = ModuleType("receipt_chroma.s3")
+    setattr(chroma_s3_module, "download_snapshot_atomic", MagicMock())
+    monkeypatch.setitem(sys.modules, "receipt_chroma.s3", chroma_s3_module)
+
+    receipt_dynamo_module = ModuleType("receipt_dynamo")
+    setattr(receipt_dynamo_module, "DynamoClient", MagicMock())
+    monkeypatch.setitem(sys.modules, "receipt_dynamo", receipt_dynamo_module)
+
+    handler_path = Path(__file__).parents[1] / "lambdas" / "index.py"
+    spec = importlib.util.spec_from_file_location(
+        "word_similarity_cache_generator", handler_path
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_parse_row_line_ids_prefers_visual_row_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    handler = _load_handler(monkeypatch)
+    row_line_ids = handler.parse_row_line_ids(
+        {"line_id": 4, "row_line_ids": "[4, 7, 7]"}
+    )
+
+    assert row_line_ids == [4, 7]
+    assert handler.parse_row_line_ids({"line_id": 9}) == [9]
+
+
+def test_add_line_context_includes_nearby_lines(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    handler = _load_handler(monkeypatch)
+
+    assert handler.add_line_context([1, 3], radius=1) == [0, 1, 2, 3, 4]
+
+
+def test_merge_row_line_ids_preserves_all_visual_rows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    handler = _load_handler(monkeypatch)
+
+    assert handler.merge_row_line_ids(
+        [
+            {"line_id": 42, "row_line_ids": "[42, 51]"},
+            {"line_id": 48, "row_line_ids": "[48, 43]"},
+        ]
+    ) == [42, 51, 48, 43]
+
+
+def test_s3_snapshot_queries_only_target_documents(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    handler = _load_handler(monkeypatch)
+    collection = MagicMock()
+    collection.get.return_value = {"ids": ["row-1"], "metadatas": [{}]}
+    client = MagicMock()
+    client.get_collection.return_value = collection
+    handler.ChromaClient = MagicMock(return_value=client)
+    handler.download_snapshot_atomic.return_value = {"status": "downloaded"}
+
+    result = handler._fetch_lines_from_s3(handler.TimingStats(), "/tmp/chroma")
+
+    assert result["ids"] == ["row-1"]
+    handler.ChromaClient.assert_called_once_with(
+        persist_directory="/tmp/chroma",
+        mode="read",
+        metadata_only=True,
+    )
+    collection.get.assert_called_once_with(
+        where_document={"$contains": "MILK"},
+        include=["metadatas"],
+    )
+
+
+def test_find_milk_line_limits_candidates_but_detects_void_marker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    handler = _load_handler(monkeypatch)
+    lines = [
+        SimpleNamespace(line_id=8, text="OTHER MILK"),
+        SimpleNamespace(line_id=10, text="RAW WHOLE MILK"),
+        SimpleNamespace(line_id=11, text="VOID"),
+    ]
+
+    assert (
+        handler.find_milk_line(
+            lines,
+            candidate_line_ids={10},
+        )
+        is None
+    )
+    assert handler.find_milk_line(
+        lines[:2],
+        candidate_line_ids={10},
+    ) == ("RAW WHOLE MILK", 10)

--- a/portfolio/types/api.ts
+++ b/portfolio/types/api.ts
@@ -346,6 +346,7 @@ export interface MilkSimilarityTiming {
     count: number;
     sequential_ms: number;
     speedup: number;
+    items_returned?: number;
   };
   visual_line_assembly?: {
     avg_ms: number;

--- a/receipt_dynamo/receipt_dynamo/data/_receipt.py
+++ b/receipt_dynamo/receipt_dynamo/data/_receipt.py
@@ -32,8 +32,72 @@ from receipt_dynamo.entities.receipt_word_label import (
 
 from ._receipt_details_processor import process_receipt_details_query
 
+_RECEIPT_DETAILS_CONVERTERS = {
+    "RECEIPT": ("receipt", item_to_receipt),
+    "RECEIPT_LINE": ("line", item_to_receipt_line),
+    "RECEIPT_WORD": ("word", item_to_receipt_word),
+    "RECEIPT_WORD_LABEL": ("label", item_to_receipt_word_label),
+    "RECEIPT_PLACE": ("place", item_to_receipt_place),
+    "RECEIPT_BARCODE": ("barcode", item_to_receipt_barcode),
+}
+
 
 class _Receipt(FlattenedStandardMixin):
+    @staticmethod
+    def _convert_receipt_details_item(item):
+        """Convert one GSI4 item into its ReceiptDetails collection name."""
+        item_type = item.get("TYPE", {}).get("S")
+        converter = _RECEIPT_DETAILS_CONVERTERS.get(item_type)
+        if converter is None:
+            return None
+        collection_name, convert_item = converter
+        return (collection_name, convert_item(item))
+
+    @staticmethod
+    def _build_receipt_details(
+        items: list,
+        image_id: str,
+        receipt_id: int,
+    ) -> ReceiptDetails:
+        """Build ReceiptDetails from converted GSI4 items."""
+        receipt = None
+        place = None
+        lines, words, labels, barcodes = [], [], [], []
+
+        for item in items:
+            if item is None:
+                continue
+            item_type, entity = item
+            if item_type == "receipt":
+                receipt = entity
+            elif item_type == "line":
+                lines.append(entity)
+            elif item_type == "word":
+                words.append(entity)
+            elif item_type == "label":
+                labels.append(entity)
+            elif item_type == "place":
+                place = entity
+            elif item_type == "barcode":
+                barcodes.append(entity)
+
+        if receipt is None:
+            raise EntityNotFoundError(
+                (
+                    "receipt not found for "
+                    f"image_id={image_id}, receipt_id={receipt_id}"
+                )
+            )
+        return ReceiptDetails(
+            receipt=receipt,
+            lines=lines,
+            words=words,
+            labels=labels,
+            place=place,
+            barcodes=barcodes,
+            # letters excluded by GSI4 design - uses default empty list
+        )
+
     @handle_dynamodb_errors("add_receipt")
     def add_receipt(self, receipt: Receipt):
         """Adds a receipt to the database
@@ -451,24 +515,6 @@ class _Receipt(FlattenedStandardMixin):
                 Note: letters will be an empty list (excluded from GSI4).
         """
 
-        # Custom converter function that handles multiple entity types
-        # Note: RECEIPT_LETTER is not included because GSI4 excludes letters
-        def convert_item(item):
-            item_type = item.get("TYPE", {}).get("S")
-            if item_type == "RECEIPT":
-                return ("receipt", item_to_receipt(item))
-            if item_type == "RECEIPT_LINE":
-                return ("line", item_to_receipt_line(item))
-            if item_type == "RECEIPT_WORD":
-                return ("word", item_to_receipt_word(item))
-            if item_type == "RECEIPT_WORD_LABEL":
-                return ("label", item_to_receipt_word_label(item))
-            if item_type == "RECEIPT_PLACE":
-                return ("place", item_to_receipt_place(item))
-            if item_type == "RECEIPT_BARCODE":
-                return ("barcode", item_to_receipt_barcode(item))
-            return None
-
         # Query GSI4 for all receipt-related items (excluding letters)
         # GSI4PK: IMAGE#{image_id}#RECEIPT#{receipt_id:05d}
         items, _ = self._query_entities(
@@ -478,49 +524,84 @@ class _Receipt(FlattenedStandardMixin):
             expression_attribute_values={
                 ":pk": {"S": f"IMAGE#{image_id}#RECEIPT#{receipt_id:05d}"},
             },
-            converter_func=convert_item,
+            converter_func=self._convert_receipt_details_item,
             limit=None,  # Get all items
             last_evaluated_key=None,
         )
 
-        receipt = None
-        place = None
-        lines, words, labels, barcodes = [], [], [], []
+        return self._build_receipt_details(items, image_id, receipt_id)
 
-        # Process converted items
-        for item in items:
-            if item is None:
-                continue
-            item_type, entity = item
-            if item_type == "receipt":
-                receipt = entity
-            elif item_type == "line":
-                lines.append(entity)
-            elif item_type == "word":
-                words.append(entity)
-            elif item_type == "label":
-                labels.append(entity)
-            elif item_type == "place":
-                place = entity
-            elif item_type == "barcode":
-                barcodes.append(entity)
+    @handle_dynamodb_errors("get_receipt_details_for_lines")
+    def get_receipt_details_for_lines(
+        self,
+        image_id: str,
+        receipt_id: int,
+        line_ids: list[int],
+    ) -> ReceiptDetails:
+        """Get receipt details restricted to selected receipt lines.
 
-        if receipt is None:
-            raise EntityNotFoundError(
-                (
-                    "receipt not found for "
-                    f"image_id={image_id}, receipt_id={receipt_id}"
-                )
+        The receipt header and place are always returned. Lines, words, and
+        labels are returned only when their primary-table sort key belongs to
+        one of ``line_ids``. DynamoDB still evaluates the GSI4 partition, but
+        filtering server-side avoids transferring and deserializing hundreds
+        of unrelated items for callers that need only a visual row.
+
+        Args:
+            image_id: The ID of the image the receipt belongs to.
+            receipt_id: The ID of the receipt to get.
+            line_ids: Non-empty list of receipt line IDs to include.
+
+        Returns:
+            ReceiptDetails containing the receipt, place, and focused line
+            data. Letters and barcodes are excluded.
+        """
+        self._validate_image_id(image_id)
+        self._validate_receipt_id(receipt_id)
+        if not isinstance(line_ids, list) or not line_ids:
+            raise EntityValidationError("line_ids must be a non-empty list.")
+        if not all(
+            isinstance(line_id, int)
+            and not isinstance(line_id, bool)
+            and line_id >= 0
+            for line_id in line_ids
+        ):
+            raise EntityValidationError(
+                "line_ids must contain non-negative integers."
             )
-        return ReceiptDetails(
-            receipt=receipt,
-            lines=lines,
-            words=words,
-            labels=labels,
-            place=place,
-            barcodes=barcodes,
-            # letters excluded by GSI4 design - uses default empty list
+
+        unique_line_ids = sorted(set(line_ids))
+        line_filters = []
+        expression_values = {
+            ":pk": {"S": f"IMAGE#{image_id}#RECEIPT#{receipt_id:05d}"},
+            ":receipt": {"S": "RECEIPT"},
+            ":place": {"S": "RECEIPT_PLACE"},
+            ":line": {"S": "RECEIPT_LINE"},
+            ":word": {"S": "RECEIPT_WORD"},
+            ":label": {"S": "RECEIPT_WORD_LABEL"},
+        }
+        for index, line_id in enumerate(unique_line_ids):
+            value_name = f":line_id_{index}"
+            expression_values[value_name] = {"S": f"#LINE#{line_id:05d}"}
+            line_filters.append(f"contains(#sk, {value_name})")
+
+        filter_expression = (
+            "#type IN (:receipt, :place) OR "
+            "(#type IN (:line, :word, :label) AND ("
+            + " OR ".join(line_filters)
+            + "))"
         )
+        items, _ = self._query_entities(
+            index_name="GSI4",
+            key_condition_expression="GSI4PK = :pk",
+            expression_attribute_names={"#type": "TYPE", "#sk": "SK"},
+            expression_attribute_values=expression_values,
+            converter_func=self._convert_receipt_details_item,
+            filter_expression=filter_expression,
+            limit=None,
+            last_evaluated_key=None,
+        )
+
+        return self._build_receipt_details(items, image_id, receipt_id)
 
     @handle_dynamodb_errors("list_receipts")
     def list_receipts(

--- a/receipt_dynamo/tests/integration/test__receipt.py
+++ b/receipt_dynamo/tests/integration/test__receipt.py
@@ -5,6 +5,7 @@ This file contains refactored tests using pytest.mark.parametrize to reduce
 code duplication.
 """
 
+from dataclasses import replace
 from datetime import datetime
 from typing import Any, Literal, Type
 from uuid import uuid4
@@ -18,6 +19,7 @@ from receipt_dynamo import (
     Image,
     Receipt,
     ReceiptLetter,
+    ReceiptLine,
     ReceiptWord,
     ReceiptWordLabel,
 )
@@ -927,6 +929,62 @@ def test_get_receipt_details_success(
     assert (
         lines == []
     ), "No lines were added in this test, so expect an empty list."
+
+
+@pytest.mark.integration
+def test_get_receipt_details_for_lines_filters_unrelated_items(
+    dynamodb_table: Literal["MyMockedTable"],
+    sample_receipt: Receipt,
+    sample_receipt_word: ReceiptWord,
+) -> None:
+    """The focused GSI4 read returns only requested line data."""
+    client = DynamoClient(dynamodb_table)
+    first_line = ReceiptLine(
+        image_id=sample_receipt.image_id,
+        receipt_id=sample_receipt.receipt_id,
+        line_id=1,
+        text="FIRST",
+        bounding_box={"x": 0, "y": 0, "width": 10, "height": 10},
+        top_left={"x": 0, "y": 10},
+        top_right={"x": 10, "y": 10},
+        bottom_left={"x": 0, "y": 0},
+        bottom_right={"x": 10, "y": 0},
+        angle_degrees=0,
+        angle_radians=0,
+        confidence=1,
+    )
+    second_line = replace(first_line, line_id=2, text="SECOND")
+    second_word = replace(
+        sample_receipt_word,
+        line_id=2,
+        text="second-word",
+    )
+    first_label = ReceiptWordLabel(
+        image_id=sample_receipt.image_id,
+        receipt_id=sample_receipt.receipt_id,
+        line_id=1,
+        word_id=1,
+        label="PRODUCT_NAME",
+        reasoning="test",
+        timestamp_added=datetime.now().isoformat(),
+    )
+    second_label = replace(first_label, line_id=2, label="LINE_TOTAL")
+
+    client.add_receipt(sample_receipt)
+    client.add_receipt_lines([first_line, second_line])
+    client.add_receipt_words([sample_receipt_word, second_word])
+    client.add_receipt_word_labels([first_label, second_label])
+
+    details = client.get_receipt_details_for_lines(
+        sample_receipt.image_id,
+        sample_receipt.receipt_id,
+        [2],
+    )
+
+    assert details.receipt == sample_receipt
+    assert [line.line_id for line in details.lines] == [2]
+    assert [word.line_id for word in details.words] == [2]
+    assert [label.line_id for label in details.labels] == [2]
 
 
 # -------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- add a focused DynamoDB receipt-details read that returns the receipt header, merchant, and only the requested lines, words, and labels
- use Chroma visual-row line IDs plus nearby context when generating the milk cache
- merge multiple milk-row matches per receipt, preserve row-text price fallback, and report returned entity counts
- query only `MILK` documents from S3-backed Chroma snapshots
- add reusable local Chroma snapshot and local JSON output modes for safe reproduction without overwriting the deployed cache

## Why

The cached production flamegraph reports 9.4 seconds in “Fetch Receipts.” The previous generator queried every GSI4 entity for each matching receipt, transferring and deserializing tens of thousands of unrelated entities.

Against the current production S3 snapshot and DynamoDB table, a paired local comparison reduced the Dynamo wall time from 3.524 seconds to 0.824 seconds and returned entities from 27,644 to 3,624. The filter reduces transfer and deserialization work; DynamoDB still evaluates the GSI4 partition, so this does not claim an RCU reduction.

## Validation

- 5 focused cache-generator unit tests
- 2 receipt DynamoDB integration tests
- Black and isort checks
- end-to-end local generation against the current production S3 snapshot and DynamoDB table:
  - 78 available receipts
  - 0 missing prices
  - 0 missing crop bounds
  - 882 ms focused Dynamo fetch in the final clean-branch run

No AWS deployment is included in this PR.