### PR TITLE
Fix CICD ribbon corner geometry

### DIFF
--- a/portfolio/components/ui/Figures/CICDLoop.tsx
+++ b/portfolio/components/ui/Figures/CICDLoop.tsx
@@ -392,8 +392,8 @@ function getPointAndTangentAtArcLength(
 
 /**
  * Build a filled ribbon segment path with:
- * - Arrow tip at the end (triangle added)
- * - Notch at the start (triangle cut out using evenodd)
+ * - An explicit arrow tip at the end
+ * - An explicit chevron notch at the start
  *
  * @param startGap - Gap geometry for the start (notch): position, tangent, normal, and half-width of gap
  * @param endGap - Gap geometry for the end (arrow): position, tangent, normal, and half-width of gap
@@ -498,8 +498,11 @@ function buildRibbonSegmentPath(
     rightEdge[rightEdge.length - 1] = endR;
   }
 
-  // Build outer polygon path (left edge -> arrow tip -> right edge back)
-  const outer =
+  // Build one continuous polygon so the arrow-base corners and notch apex are
+  // part of the ribbon outline. The previous compound-path approach omitted
+  // endR and subtracted a triangle whose base coincided with the outer path;
+  // both produced small wedges at the joins when the SVG was rasterized.
+  return (
     `M ${leftEdge[0].x} ${leftEdge[0].y} ` +
     leftEdge
       .slice(1)
@@ -507,20 +510,11 @@ function buildRibbonSegmentPath(
       .join(" ") +
     ` L ${tip.x} ${tip.y} ` +
     rightEdge
-      .slice(0, -1)
       .reverse()
       .map((p) => `L ${p.x} ${p.y}`)
       .join(" ") +
-    ` Z`;
-
-  // Build notch hole as a triangle subpath (evenodd will subtract it)
-  const hole =
-    `M ${notchL.x} ${notchL.y}` +
-    ` L ${notchApex.x} ${notchApex.y}` +
-    ` L ${notchR.x} ${notchR.y}` +
-    ` Z`;
-
-  return `${outer} ${hole}`;
+    ` L ${notchApex.x} ${notchApex.y} Z`
+  );
 }
 
 /**
@@ -1035,7 +1029,6 @@ const CICDLoop: React.FC<CICDLoopProps> = ({
                   ref={(el) => { ribbonRefs.current[i] = el; }}
                   d={g.ribbonD}
                   fill={color}
-                  fillRule="evenodd"
                 />
 
                 {/* Label along segment centerline */}


### PR DESCRIPTION
## Summary

- build each CICD ribbon as one continuous SVG polygon
- restore the omitted right-hand arrow-base corner
- remove the overlapping `evenodd` notch subpath that caused visible wedges at ribbon joins

## Why

The previous path skipped `endR` when tracing the return edge, then subtracted a triangular notch whose base coincided with the outer path. Rasterization exposed those overlapping and missing edges as imperfect black wedges, especially at larger display sizes.

## Impact

Arrow tips and chevron notches now render as explicit, continuous corners across all seven CICD segments. The existing animation, layout, labels, and colors are unchanged.

## Validation

- `npm run type-check`
- `npx eslint components/ui/Figures/CICDLoop.tsx` (no errors; one pre-existing unused constant warning)
- `npm run build`
- rendered QA at 1440×1000 and 390×844
- verified all seven ribbons contain exactly one SVG move and one close command
- verified lazy reveal reaches full opacity with no browser console warnings or errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the CI/CD loop ribbon graphic by eliminating visible wedge and join artifacts.
  * Updated the ribbon rendering for cleaner, more consistent arrow shapes and notches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->