### PR TITLE
fix: raise QA RunAllQuestions timeout 900s -> 2400s

### DIFF
--- a/infra/qa_agent_step_functions/infrastructure.py
+++ b/infra/qa_agent_step_functions/infrastructure.py
@@ -567,7 +567,9 @@ def _build_state_machine_definition(
                     "langchain_project.$": "$.Payload.langchain_project",
                 },
                 "ResultPath": "$.questions_result",
-                "TimeoutSeconds": 900,
+                # 900s was knife-edge for 32 questions (cold starts + provider
+                # variance timed out an entire healthy run on 2026-07-28).
+                "TimeoutSeconds": 2400,
                 "Retry": [
                     {
                         "ErrorEquals": [


### PR DESCRIPTION
The RunAllQuestions state timeout was knife-edge: a healthy 32-question run takes ~10 minutes, and on 2026-07-28 one run passed with seconds to spare while the next — same code, same model — timed out at 900s mid-classification with zero written results (cold starts + LLM-provider variance). 2400s gives ~4x headroom on observed p50 while still bounding a genuinely wedged run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the maximum execution time for full QA runs, reducing failures caused by cold starts and temporary provider delays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->