### PR TITLE
feat: port QA agent improvements from #714 (date anchoring, synth reasoning, shaping, OCR filter, evidence capture)

### DIFF
--- a/receipt_agent/receipt_agent/agents/question_answering/__init__.py
+++ b/receipt_agent/receipt_agent/agents/question_answering/__init__.py
@@ -38,6 +38,8 @@ from receipt_agent.agents.question_answering.graph import (
     SYNTHESIZE_SYSTEM_PROMPT,
     answer_question,
     answer_question_sync,
+    build_date_context,
+    build_evidence,
     create_qa_graph,
 )
 
@@ -89,6 +91,8 @@ __all__ = [
     "SYNTHESIZE_PROMPT",
     "PLAN_SYSTEM_PROMPT",
     "SYNTHESIZE_SYSTEM_PROMPT",
+    "build_date_context",
+    "build_evidence",
     # State schemas
     "AmountItem",
     "AnswerWithEvidence",

--- a/receipt_agent/receipt_agent/agents/question_answering/graph.py
+++ b/receipt_agent/receipt_agent/agents/question_answering/graph.py
@@ -18,7 +18,9 @@ to answer questions like:
 """
 
 import asyncio
+import calendar
 import logging
+from datetime import date, datetime
 from typing import Any, Callable, Optional
 
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
@@ -103,6 +105,8 @@ You have been given:
 5. Be precise with amounts — use exact numbers.
 6. For "how much" questions, always state the total.
 7. If the agent found nothing relevant, say so clearly.
+8. **If outliers were excluded**, say so in one short sentence — the totals
+   already omit them, so do not add them back.
 
 ## Evidence Format
 Include evidence array with:
@@ -110,6 +114,66 @@ Include evidence array with:
 - receipt_id: Receipt number
 - item: Relevant item/description
 - amount: Dollar amount (if applicable)
+"""
+
+
+# ==============================================================================
+# Date Anchoring
+# ==============================================================================
+
+
+def _month_bounds(year: int, month: int) -> tuple[date, date]:
+    """Return the first and last calendar day of a month."""
+    last_day = calendar.monthrange(year, month)[1]
+    return date(year, month, 1), date(year, month, last_day)
+
+
+def build_date_context(today: Optional[date] = None) -> str:
+    """Build the prompt block that anchors relative date phrases.
+
+    Without this, the LLM falls back on its training cutoff and resolves
+    "last month" to whatever year it believes the present to be. Every
+    prompt that can produce or consume a date filter gets this block.
+
+    Args:
+        today: Date to anchor against. Defaults to the local current date,
+            so the value is resolved per invocation rather than at import.
+
+    Returns:
+        A markdown block listing today's date and the ISO ranges for the
+        relative phrases that show up in receipt questions.
+    """
+    if today is None:
+        today = datetime.now().date()
+
+    this_month_start, this_month_end = _month_bounds(today.year, today.month)
+    if today.month == 1:
+        last_month_start, last_month_end = _month_bounds(today.year - 1, 12)
+    else:
+        last_month_start, last_month_end = _month_bounds(
+            today.year, today.month - 1
+        )
+
+    quarter = (today.month - 1) // 3
+    quarter_start, _ = _month_bounds(today.year, quarter * 3 + 1)
+    _, quarter_end = _month_bounds(today.year, quarter * 3 + 3)
+
+    return f"""
+
+## Today's Date
+Today is {today.strftime("%A")}, {today.isoformat()}.
+
+Resolve relative time phrases against that date, NOT against any date you
+may assume from training data. Use these ISO ranges for start_date/end_date:
+- "today" -> {today.isoformat()} to {today.isoformat()}
+- "this month" -> {this_month_start.isoformat()} to {this_month_end.isoformat()}
+- "last month" -> {last_month_start.isoformat()} to {last_month_end.isoformat()}
+- "this quarter" -> {quarter_start.isoformat()} to {quarter_end.isoformat()}
+- "this year" -> {today.year}-01-01 to {today.year}-12-31
+- "last year" -> {today.year - 1}-01-01 to {today.year - 1}-12-31
+
+When the question has no explicit year, assume the most recent occurrence
+on or before today.
 """
 
 
@@ -128,9 +192,10 @@ def create_plan_node(llm: Any) -> Callable:
         """Classify the question and determine retrieval strategy."""
         question = state.question
 
-        # Build prompt for classification
+        # Build prompt for classification. The date block is rebuilt per
+        # call so long-lived Lambda containers don't answer with a stale day.
         messages = [
-            SystemMessage(content=PLAN_SYSTEM_PROMPT),
+            SystemMessage(content=PLAN_SYSTEM_PROMPT + build_date_context()),
             HumanMessage(content=f"Classify this question: {question}"),
         ]
 
@@ -480,6 +545,82 @@ def create_shape_node(state_holder: dict) -> Callable:
 # ==============================================================================
 
 
+MAX_EVIDENCE_ITEMS = 200
+
+
+def build_evidence(summaries: list[ReceiptSummary]) -> list[dict]:
+    """Build the evidence array from every shaped receipt.
+
+    Evidence rows are what the trace viewer joins against
+    receipts-lookup.json to render thumbnails, so a receipt that never
+    appears here is invisible in the UI. Summary-tier receipts carry no
+    line items, so emitting only line-item rows dropped every receipt that
+    came from get_receipt_summaries — the common case for aggregation
+    questions. Each summary now contributes at least one row.
+    """
+    # Grouped per receipt so the size cap below can never cost a receipt
+    # its only row.
+    per_receipt: list[list[dict]] = []
+
+    for summary in summaries:
+        if not summary.image_id:
+            continue
+
+        base = {
+            "image_id": summary.image_id,
+            "receipt_id": summary.receipt_id,
+            "merchant": summary.merchant,
+        }
+
+        if summary.line_items:
+            per_receipt.append(
+                [
+                    {
+                        **base,
+                        "item": item.item_text or "",
+                        "amount": item.amount,
+                    }
+                    for item in summary.line_items
+                ]
+            )
+            continue
+
+        # Summary-tier receipt: describe it at the receipt level so it
+        # still carries an imageId into the trace.
+        if summary.item_count:
+            item_text = (
+                f"{summary.item_count} item"
+                f"{'' if summary.item_count == 1 else 's'}"
+            )
+        else:
+            item_text = "Receipt total"
+
+        per_receipt.append(
+            [{**base, "item": item_text, "amount": summary.grand_total}]
+        )
+
+    total_rows = sum(len(rows) for rows in per_receipt)
+    if total_rows <= MAX_EVIDENCE_ITEMS:
+        return [row for rows in per_receipt for row in rows]
+
+    logger.info(
+        "Trimming evidence from %d to %d rows across %d receipts",
+        total_rows,
+        MAX_EVIDENCE_ITEMS,
+        len(per_receipt),
+    )
+
+    # One row per receipt first, then top up with the remaining line items.
+    evidence = [rows[0] for rows in per_receipt[:MAX_EVIDENCE_ITEMS]]
+    for rows in per_receipt:
+        for row in rows[1:]:
+            if len(evidence) >= MAX_EVIDENCE_ITEMS:
+                return evidence
+            evidence.append(row)
+
+    return evidence
+
+
 def create_synthesize_node(llm: Any, state_holder: dict) -> Callable:
     """Create the answer synthesis node.
 
@@ -563,9 +704,14 @@ def create_synthesize_node(llm: Any, state_holder: dict) -> Callable:
                     if agg.get("average_receipt")
                     else ""
                 )
+                excluded = agg.get("excluded_outlier_count") or 0
+                outlier_str = (
+                    f", {excluded} OCR outlier(s) excluded" if excluded else ""
+                )
                 agg_parts.append(
                     f"  {agg['source']}: {agg['count']} receipts, "
                     f"total=${agg['total_spending']:.2f}{avg_str}"
+                    f"{outlier_str}"
                 )
             context_str += "\n".join(agg_parts)
 
@@ -575,7 +721,9 @@ def create_synthesize_node(llm: Any, state_holder: dict) -> Callable:
             agent_section = f"Agent Analysis:\n{agent_reasoning}\n\n"
 
         messages = [
-            SystemMessage(content=SYNTHESIZE_SYSTEM_PROMPT),
+            SystemMessage(
+                content=SYNTHESIZE_SYSTEM_PROMPT + build_date_context()
+            ),
             HumanMessage(
                 content=f"Question: {state.question}\n\n"
                 f"{agent_section}"
@@ -595,18 +743,12 @@ def create_synthesize_node(llm: Any, state_holder: dict) -> Callable:
             total_amount = aggregated.get("total")
 
         # Build evidence from structured summaries
-        evidence = []
-        for summary in summaries:
-            for item in summary.line_items:
-                evidence.append(
-                    {
-                        "image_id": summary.image_id,
-                        "receipt_id": summary.receipt_id,
-                        "merchant": summary.merchant,
-                        "item": item.item_text or "",
-                        "amount": item.amount,
-                    }
-                )
+        evidence = build_evidence(summaries)
+        logger.info(
+            "Captured %d evidence rows from %d receipt summaries",
+            len(evidence),
+            len(summaries),
+        )
 
         # Store in state_holder for extraction
         state_holder["answer"] = {
@@ -668,9 +810,12 @@ def route_after_agent(state: QAState, state_holder: dict) -> str:
                     )
                     return "shape"
             else:
-                # No tool calls - LLM responded with text
-                # Check if we have retrieved anything
-                if state_holder.get("retrieved_receipts"):
+                # No tool calls - LLM responded with text.
+                # Shape whenever either tier holds receipts; skipping on
+                # summary-only retrievals ended the run with no evidence.
+                if state_holder.get("retrieved_receipts") or state_holder.get(
+                    "summary_receipts"
+                ):
                     return "shape"
                 else:
                     # Extract answer from content
@@ -857,11 +1002,12 @@ async def answer_question(
     state_holder["searches"] = []
     state_holder["fetched_receipt_keys"] = set()
 
-    # Create initial state
+    # Create initial state. Date context is resolved here, at question
+    # time, so a warm Lambda container never reuses yesterday's anchor.
     initial_state = QAState(
         question=question,
         messages=[
-            SystemMessage(content=SYSTEM_PROMPT),
+            SystemMessage(content=SYSTEM_PROMPT + build_date_context()),
             HumanMessage(content=question),
         ],
     )

--- a/receipt_agent/receipt_agent/agents/question_answering/tools/__init__.py
+++ b/receipt_agent/receipt_agent/agents/question_answering/tools/__init__.py
@@ -3,6 +3,11 @@
 from receipt_agent.agents.question_answering.tools.search import (
     SYSTEM_PROMPT,
     create_qa_tools,
+    partition_ocr_outliers,
 )
 
-__all__ = ["create_qa_tools", "SYSTEM_PROMPT"]
+__all__ = [
+    "create_qa_tools",
+    "partition_ocr_outliers",
+    "SYSTEM_PROMPT",
+]

--- a/receipt_agent/receipt_agent/agents/question_answering/tools/search.py
+++ b/receipt_agent/receipt_agent/agents/question_answering/tools/search.py
@@ -27,6 +27,101 @@ from langchain_core.tools import tool
 logger = logging.getLogger(__name__)
 
 
+# ==============================================================================
+# OCR Outlier Filtering
+# ==============================================================================
+
+# A dropped decimal point or a run-together digit turns "12.99" into
+# "1299.00" or worse, and a single such misread swamps an aggregate. These
+# ceilings sit well above any plausible value for the receipts in this
+# dataset, so anything past them is a parse artifact rather than a purchase.
+OCR_MAX_LINE_ITEM_AMOUNT = 10_000.0
+OCR_MAX_RECEIPT_TOTAL = 50_000.0
+
+# Secondary relative rule: an amount can be under the ceiling and still be
+# obvious garbage next to its peers. Both conditions must hold, and only
+# once there are enough samples for the median to mean anything.
+OCR_OUTLIER_MEDIAN_RATIO = 100.0
+OCR_OUTLIER_MIN_ABSOLUTE = 5_000.0
+OCR_OUTLIER_MIN_SAMPLES = 8
+
+
+def _coerce_amount(value: Any) -> Optional[float]:
+    """Return value as a float, or None when it isn't a usable number."""
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    return float(value)
+
+
+def partition_ocr_outliers(
+    records: list[dict],
+    amount_key: str = "amount",
+    ceiling: float = OCR_MAX_LINE_ITEM_AMOUNT,
+) -> tuple[list[dict], list[dict]]:
+    """Split records into (kept, outliers) by their amount field.
+
+    Records with a missing or non-numeric amount are always kept — this
+    filter targets OCR misreads, not incomplete data. Negative amounts are
+    kept too, since discounts and refunds are legitimate.
+
+    Args:
+        records: Dicts carrying an amount under ``amount_key``.
+        amount_key: Field holding the dollar value.
+        ceiling: Absolute cutoff above which an amount is a misread.
+
+    Returns:
+        (kept, outliers) preserving the input order within each list.
+    """
+    amounts = [
+        amount
+        for record in records
+        if (amount := _coerce_amount(record.get(amount_key))) is not None
+        and amount > 0
+    ]
+
+    relative_threshold: Optional[float] = None
+    if len(amounts) >= OCR_OUTLIER_MIN_SAMPLES:
+        median = statistics.median(amounts)
+        if median > 0:
+            relative_threshold = max(
+                median * OCR_OUTLIER_MEDIAN_RATIO, OCR_OUTLIER_MIN_ABSOLUTE
+            )
+
+    kept: list[dict] = []
+    outliers: list[dict] = []
+    for record in records:
+        amount = _coerce_amount(record.get(amount_key))
+        is_outlier = amount is not None and (
+            amount > ceiling
+            or (relative_threshold is not None and amount > relative_threshold)
+        )
+        (outliers if is_outlier else kept).append(record)
+
+    if outliers:
+        logger.info(
+            "Dropped %d OCR outlier(s) from %d records (ceiling=%.2f)",
+            len(outliers),
+            len(records),
+            ceiling,
+        )
+
+    return kept, outliers
+
+
+def summarize_ocr_outliers(outliers: list[dict]) -> list[dict]:
+    """Describe dropped outliers compactly for the LLM."""
+    return [
+        {
+            "image_id": o.get("image_id"),
+            "receipt_id": o.get("receipt_id"),
+            "merchant": o.get("merchant") or o.get("merchant_name"),
+            "amount": o.get("amount") or o.get("grand_total"),
+            "reason": "Amount is implausibly large; likely an OCR misread",
+        }
+        for o in outliers[:10]
+    ]
+
+
 def create_qa_tools(
     dynamo_client: Any,
     chroma_client: Any,
@@ -640,8 +735,6 @@ def create_qa_tools(
                 "count": 0,
             }
 
-        total = 0.0
-        count = 0
         breakdown = []
 
         for receipt in retrieved:
@@ -667,8 +760,6 @@ def create_qa_tools(
                         continue
 
                 amount_value = amt.get("amount", 0.0)
-                total += amount_value
-                count += 1
 
                 # Get product name from the line (for breakdown)
                 line_idx = amt.get("line_idx")
@@ -716,13 +807,30 @@ def create_qa_tools(
                     }
                 )
 
-        return {
+        # Drop OCR misreads before summing — one bad parse is enough to
+        # make the reported total meaningless.
+        ceiling = (
+            OCR_MAX_RECEIPT_TOTAL
+            if label_type in ("GRAND_TOTAL", "SUBTOTAL")
+            else OCR_MAX_LINE_ITEM_AMOUNT
+        )
+        breakdown, outliers = partition_ocr_outliers(
+            breakdown, ceiling=ceiling
+        )
+
+        total = sum(item["amount"] for item in breakdown)
+
+        result = {
             "label_type": label_type,
             "filter_text": filter_text,
             "total": round(total, 2),
-            "count": count,
+            "count": len(breakdown),
             "breakdown": breakdown,
         }
+        if outliers:
+            result["excluded_outliers"] = summarize_ocr_outliers(outliers)
+            result["excluded_outlier_count"] = len(outliers)
+        return result
 
     @tool
     def list_merchants() -> dict:
@@ -1144,6 +1252,14 @@ def create_qa_tools(
                 if len(filtered) >= limit:
                     break
 
+            # Drop receipts whose totals are OCR misreads before they can
+            # skew the aggregate or reach the synthesizer as evidence.
+            filtered, outliers = partition_ocr_outliers(
+                filtered,
+                amount_key="grand_total",
+                ceiling=OCR_MAX_RECEIPT_TOTAL,
+            )
+
             # Store all summary dicts for the shape node
             for s in filtered:
                 key = (s.get("image_id"), s.get("receipt_id"))
@@ -1157,25 +1273,28 @@ def create_qa_tools(
             receipts_with_totals = sum(1 for s in filtered if s["grand_total"])
 
             # Store aggregates for synthesizer
-            state_holder["aggregates"].append({
-                "source": (
-                    f"get_receipt_summaries("
-                    f"merchant={merchant_filter}, "
-                    f"category={category_filter}, "
-                    f"start={start_date}, "
-                    f"end={end_date})"
-                ),
-                "count": len(filtered),
-                "total_spending": round(total_spending, 2),
-                "total_tax": round(total_tax, 2),
-                "total_tip": round(total_tip, 2),
-                "receipts_with_totals": receipts_with_totals,
-                "average_receipt": (
-                    round(total_spending / receipts_with_totals, 2)
-                    if receipts_with_totals > 0
-                    else None
-                ),
-            })
+            state_holder["aggregates"].append(
+                {
+                    "source": (
+                        f"get_receipt_summaries("
+                        f"merchant={merchant_filter}, "
+                        f"category={category_filter}, "
+                        f"start={start_date}, "
+                        f"end={end_date})"
+                    ),
+                    "count": len(filtered),
+                    "total_spending": round(total_spending, 2),
+                    "total_tax": round(total_tax, 2),
+                    "total_tip": round(total_tip, 2),
+                    "receipts_with_totals": receipts_with_totals,
+                    "average_receipt": (
+                        round(total_spending / receipts_with_totals, 2)
+                        if receipts_with_totals > 0
+                        else None
+                    ),
+                    "excluded_outlier_count": len(outliers),
+                }
+            )
 
             # Auto-fetch a few sample receipts
             fetched_count = 0
@@ -1187,7 +1306,7 @@ def create_qa_tools(
                     if details:
                         fetched_count += 1
 
-            return {
+            result = {
                 "count": len(filtered),
                 "total_spending": round(total_spending, 2),
                 "total_tax": round(total_tax, 2),
@@ -1207,6 +1326,10 @@ def create_qa_tools(
                 "summaries": filtered,
                 "auto_fetched": fetched_count,
             }
+            if outliers:
+                result["excluded_outliers"] = summarize_ocr_outliers(outliers)
+                result["excluded_outlier_count"] = len(outliers)
+            return result
 
         except Exception as e:
             logger.error("Error getting receipt summaries: %s", e)

--- a/receipt_agent/tests/test_qa_agent_improvements.py
+++ b/receipt_agent/tests/test_qa_agent_improvements.py
@@ -1,0 +1,356 @@
+"""Tests for QA agent date anchoring, evidence capture, and OCR filtering."""
+
+from datetime import date
+
+import pytest
+
+from receipt_agent.agents.question_answering.graph import (
+    MAX_EVIDENCE_ITEMS,
+    build_date_context,
+    build_evidence,
+)
+from receipt_agent.agents.question_answering.state import (
+    AmountItem,
+    ReceiptSummary,
+)
+from receipt_agent.agents.question_answering.tools.search import (
+    OCR_MAX_LINE_ITEM_AMOUNT,
+    OCR_MAX_RECEIPT_TOTAL,
+    partition_ocr_outliers,
+)
+
+# ==============================================================================
+# Date anchoring
+# ==============================================================================
+
+
+def test_date_context_states_the_anchor_date():
+    context = build_date_context(date(2026, 7, 28))
+
+    assert "2026-07-28" in context
+    assert "Tuesday" in context
+
+
+def test_date_context_resolves_relative_ranges():
+    context = build_date_context(date(2026, 7, 28))
+
+    assert '"last month" -> 2026-06-01 to 2026-06-30' in context
+    assert '"this month" -> 2026-07-01 to 2026-07-31' in context
+    assert '"this year" -> 2026-01-01 to 2026-12-31' in context
+    assert '"last year" -> 2025-01-01 to 2025-12-31' in context
+    assert '"this quarter" -> 2026-07-01 to 2026-09-30' in context
+
+
+def test_date_context_rolls_last_month_back_a_year_in_january():
+    context = build_date_context(date(2026, 1, 15))
+
+    assert '"last month" -> 2025-12-01 to 2025-12-31' in context
+    assert '"this quarter" -> 2026-01-01 to 2026-03-31' in context
+
+
+def test_date_context_handles_leap_february():
+    context = build_date_context(date(2028, 2, 10))
+
+    assert '"this month" -> 2028-02-01 to 2028-02-29' in context
+
+
+def test_date_context_defaults_to_today():
+    from datetime import datetime
+
+    assert datetime.now().date().isoformat() in build_date_context()
+
+
+def test_prompts_carry_date_context():
+    """Every prompt that can emit or read a date filter is anchored."""
+    from receipt_agent.agents.question_answering import graph as qa_graph
+
+    captured: list = []
+
+    class FakeLLM:
+        def invoke(self, messages):
+            captured.append(messages)
+            raise RuntimeError("stop after capturing the prompt")
+
+        def with_structured_output(self, _schema):
+            return self
+
+    plan_node = qa_graph.create_plan_node(FakeLLM())
+    state = qa_graph.QAState(question="How much did I spend last month?")
+
+    # Classification failure falls back to defaults, which is fine here —
+    # we only care that the prompt it sent was anchored.
+    plan_node(state)
+
+    system_prompt = captured[0][0].content
+    assert "## Today's Date" in system_prompt
+
+
+# ==============================================================================
+# Evidence capture
+# ==============================================================================
+
+
+def _summary(image_id="img-1", receipt_id=1, **kwargs):
+    kwargs.setdefault("merchant", "Costco")
+    return ReceiptSummary(image_id=image_id, receipt_id=receipt_id, **kwargs)
+
+
+def test_evidence_includes_line_items_when_present():
+    summaries = [
+        _summary(
+            line_items=[
+                AmountItem(
+                    label="LINE_TOTAL", amount=12.99, item_text="COFFEE"
+                ),
+                AmountItem(label="LINE_TOTAL", amount=4.50, item_text="MILK"),
+            ]
+        )
+    ]
+
+    evidence = build_evidence(summaries)
+
+    assert [e["item"] for e in evidence] == ["COFFEE", "MILK"]
+    assert all(e["image_id"] == "img-1" for e in evidence)
+
+
+def test_summary_tier_receipts_still_produce_evidence():
+    """The regression that left 31 of 32 questions without thumbnails.
+
+    Receipts from get_receipt_summaries carry no line items, so evidence
+    built only from line items dropped them entirely and the frontend had
+    no imageId to join a thumbnail against.
+    """
+    summaries = [
+        _summary(
+            image_id="img-a",
+            receipt_id=1,
+            grand_total=48.20,
+            item_count=7,
+            line_items=[],
+        ),
+        _summary(
+            image_id="img-b",
+            receipt_id=2,
+            grand_total=15.00,
+            line_items=[],
+        ),
+    ]
+
+    evidence = build_evidence(summaries)
+
+    assert len(evidence) == 2
+    assert {e["image_id"] for e in evidence} == {"img-a", "img-b"}
+    assert evidence[0]["item"] == "7 items"
+    assert evidence[0]["amount"] == 48.20
+    assert evidence[1]["item"] == "Receipt total"
+
+
+def test_single_item_receipt_is_not_pluralized():
+    evidence = build_evidence([_summary(item_count=1, line_items=[])])
+
+    assert evidence[0]["item"] == "1 item"
+
+
+def test_detail_receipt_without_extractable_items_still_appears():
+    """A fetched receipt whose line items failed to parse keeps its row."""
+    evidence = build_evidence(
+        [_summary(grand_total=33.10, line_items=[], labels_found=["TAX"])]
+    )
+
+    assert len(evidence) == 1
+    assert evidence[0]["amount"] == 33.10
+
+
+def test_evidence_skips_summaries_without_an_image_id():
+    evidence = build_evidence([_summary(image_id="", grand_total=10.0)])
+
+    assert evidence == []
+
+
+def test_evidence_cap_keeps_one_row_per_receipt():
+    """Trimming must never cost a receipt its only chance at a thumbnail."""
+    summaries = [
+        _summary(
+            image_id=f"img-{i}",
+            receipt_id=i,
+            line_items=[
+                AmountItem(label="LINE_TOTAL", amount=1.0, item_text=f"x{j}")
+                for j in range(10)
+            ],
+        )
+        for i in range(60)
+    ]
+
+    evidence = build_evidence(summaries)
+
+    assert len(evidence) == MAX_EVIDENCE_ITEMS
+    covered = {e["image_id"] for e in evidence}
+    assert len(covered) == 60
+
+
+# ==============================================================================
+# Routing to the shape node
+# ==============================================================================
+
+
+def _agent_state_with_text_reply():
+    from langchain_core.messages import AIMessage
+
+    from receipt_agent.agents.question_answering.state import QAState
+
+    return QAState(
+        question="How much did I spend at Costco last month?",
+        messages=[AIMessage(content="You spent $312.40 across 6 receipts.")],
+    )
+
+
+def test_summary_only_retrieval_routes_to_shape():
+    """Aggregation questions never touch the detail tier, but still have
+    receipts worth shaping into evidence."""
+    from receipt_agent.agents.question_answering.graph import (
+        route_after_agent,
+    )
+
+    state_holder = {
+        "retrieved_receipts": [],
+        "summary_receipts": [{"image_id": "img-a", "receipt_id": 1}],
+    }
+
+    assert (
+        route_after_agent(_agent_state_with_text_reply(), state_holder)
+        == "shape"
+    )
+
+
+def test_detail_retrieval_still_routes_to_shape():
+    from receipt_agent.agents.question_answering.graph import (
+        route_after_agent,
+    )
+
+    state_holder = {
+        "retrieved_receipts": [{"image_id": "img-a", "receipt_id": 1}],
+        "summary_receipts": [],
+    }
+
+    assert (
+        route_after_agent(_agent_state_with_text_reply(), state_holder)
+        == "shape"
+    )
+
+
+def test_no_receipts_ends_without_shaping():
+    from receipt_agent.agents.question_answering.graph import (
+        route_after_agent,
+    )
+
+    state_holder = {"retrieved_receipts": [], "summary_receipts": []}
+
+    assert (
+        route_after_agent(_agent_state_with_text_reply(), state_holder)
+        == "end"
+    )
+    assert state_holder["answer"]["evidence"] == []
+
+
+# ==============================================================================
+# OCR outlier filtering
+# ==============================================================================
+
+
+def test_amounts_over_the_ceiling_are_dropped():
+    records = [
+        {"amount": 12.99},
+        {"amount": 1_299_999.00},
+        {"amount": 4.50},
+    ]
+
+    kept, outliers = partition_ocr_outliers(records)
+
+    assert [r["amount"] for r in kept] == [12.99, 4.50]
+    assert [r["amount"] for r in outliers] == [1_299_999.00]
+
+
+def test_plausible_large_purchase_is_kept():
+    """A big-but-real Costco run must survive the filter."""
+    records = [{"amount": 20.0} for _ in range(20)]
+    records.append({"amount": 1_450.00})
+
+    kept, outliers = partition_ocr_outliers(records)
+
+    assert outliers == []
+    assert len(kept) == 21
+
+
+def test_relative_rule_drops_garbage_under_the_ceiling():
+    records = [{"amount": 20.0} for _ in range(20)]
+    records.append({"amount": 9_000.00})
+
+    kept, outliers = partition_ocr_outliers(records)
+
+    assert [r["amount"] for r in outliers] == [9_000.00]
+    assert len(kept) == 20
+
+
+def test_relative_rule_needs_enough_samples():
+    """Too few samples means no reliable median, so only the ceiling applies."""
+    records = [{"amount": 20.0}, {"amount": 9_000.00}]
+
+    kept, outliers = partition_ocr_outliers(records)
+
+    assert outliers == []
+    assert len(kept) == 2
+
+
+def test_missing_and_non_numeric_amounts_are_kept():
+    records = [
+        {"amount": None},
+        {"amount": "not a number"},
+        {"merchant": "Costco"},
+    ]
+
+    kept, outliers = partition_ocr_outliers(records)
+
+    assert len(kept) == 3
+    assert outliers == []
+
+
+def test_negative_amounts_are_kept_as_discounts():
+    records = [{"amount": -5.00}, {"amount": 12.99}]
+
+    kept, outliers = partition_ocr_outliers(records)
+
+    assert len(kept) == 2
+    assert outliers == []
+
+
+def test_grand_total_ceiling_is_higher_than_line_item_ceiling():
+    assert OCR_MAX_RECEIPT_TOTAL > OCR_MAX_LINE_ITEM_AMOUNT
+
+    record = [{"grand_total": 20_000.00}]
+
+    kept, outliers = partition_ocr_outliers(
+        record, amount_key="grand_total", ceiling=OCR_MAX_RECEIPT_TOTAL
+    )
+    assert len(kept) == 1
+
+    kept, outliers = partition_ocr_outliers(
+        record, amount_key="grand_total", ceiling=OCR_MAX_LINE_ITEM_AMOUNT
+    )
+    assert len(outliers) == 1
+
+
+def test_input_order_is_preserved():
+    records = [{"amount": float(i)} for i in range(1, 11)]
+    records.insert(5, {"amount": 999_999.0})
+
+    kept, _ = partition_ocr_outliers(records)
+
+    assert [r["amount"] for r in kept] == [float(i) for i in range(1, 11)]
+
+
+@pytest.mark.parametrize("empty", [[], ()])
+def test_empty_input_is_handled(empty):
+    kept, outliers = partition_ocr_outliers(list(empty))
+
+    assert kept == []
+    assert outliers == []


### PR DESCRIPTION
Ports the agent improvements from the closed [#714](https://github.com/tnorlund/Portfolio/pull/714) (branch `origin/chore/qa-evaluation`) onto current main, without the Neo4j layer. During #714's evaluation these took the 32-question scorecard from 9 F's to 0 F's / 9 A's / 20 B's.

## What was already on main

Diffing `origin/chore/qa-evaluation` against its merge-base and then against `origin/main` shows **#716 already landed the entire non-Neo4j portion of #714** — byte-identical, not a partial version:

| #714 file | branch vs merge-base | still missing on main |
| --- | --- | --- |
| `graph.py` | 164 lines | Neo4j wiring only (27 lines) |
| `state.py` | 12 lines | nothing |
| `tools/search.py` | 31 lines | nothing |

So **synthesizer reasoning** (the `Agent Analysis` block, "trust the agent's analysis" rules, agent-reasoning extraction from the last `AIMessage`) and **hybrid shaping** (two-tier detail/summary shape node, `tip`/`date`/`item_count` on `ReceiptSummary`, `MAX_RECEIPTS` 50 → 200, summary-tier pass-through, pre-computed aggregates) are already present and needed no porting. This PR covers the remaining gaps.

## 1. Today's-date anchoring (new)

Verified missing: a fresh run answered "groceries last month" with May 2024, because nothing told the model what today is.

`build_date_context()` in `graph.py` builds a prompt block naming today's date and the resolved ISO ranges for `today`/`this month`/`last month`/`this quarter`/`this year`/`last year` — the exact strings the agent needs for `start_date`/`end_date` on `get_receipt_summaries`. It is injected into all three prompts that can emit or consume a date filter: the planner, the agent's system message, and the synthesizer.

Resolved per invocation via `datetime.now()`, not at import — a warm Lambda container would otherwise keep answering with the day it booted. `today` is injectable for tests.

## 2. Synthesizer reasoning

Already on main via #716. The only addition here is one rule telling the synthesizer to mention excluded outliers in a sentence rather than adding them back (see 4).

## 3. Hybrid shaping

Already on main via #716. **Skipped:** #714's `tools/neo4j_search.py` (1,122 lines), `create_neo4j_qa_tools`, `NEO4J_SYSTEM_PROMPT`, and the `neo4j_client` parameter on `create_qa_graph` that routes 7 of 9 tools through Cypher. Nothing in items 1–5 depends on it; the DynamoDB/ChromaDB tool path is unchanged.

## 4. OCR-outlier filter (new)

A dropped decimal turns `12.99` into `1299.00`, and one such misread makes an aggregate meaningless. `partition_ocr_outliers()` in `tools/search.py` splits records into kept/outliers using an absolute ceiling (10k for line items, 50k for receipt totals) plus a conservative relative rule — an amount must be over 100x the median *and* over \$5,000, with at least 8 samples for the median to mean anything. A single \$1,450 Costco run among \$20 receipts survives; \$9,000 does not.

Missing, non-numeric, and negative amounts are always kept — this targets misreads, not incomplete data, and negatives are legitimate discounts. Applied in `aggregate_amounts` and `get_receipt_summaries`; both report `excluded_outliers`/`excluded_outlier_count` so the synthesizer can say what was dropped instead of silently under-reporting.

## 5. Receipt-evidence capture (the visible goal)

On dev, only 1 of 32 questions carried receipt thumbnails. Root cause, in `synthesize_node`:

```python
for summary in summaries:
    for item in summary.line_items:
        evidence.append(...)
```

Evidence rows are what `_enrich_evidence` in `qa_viz_cache_helpers.py` joins against `receipts-lookup.json` to attach `thumbnailKey`, and `QAAgentFlow.tsx` skips any receipt missing `imageId` **or** `thumbnailKey`. Summary-tier receipts carry `line_items=[]` by construction, so every receipt from `get_receipt_summaries` — the common case for aggregation questions — produced zero rows and vanished from the UI. Detail-tier receipts whose line items failed to parse vanished too.

Two fixes:

- **`build_evidence()`**: every shaped summary now contributes at least one row. Line items when present; otherwise a receipt-level row (`"7 items"` or `"Receipt total"` with the grand total). The 200-row cap is applied per-receipt-first, so trimming can never cost a receipt its only chance at a thumbnail.
- **`route_after_agent`**: also routes to `shape` when only `summary_receipts` is populated. Previously it checked `retrieved_receipts` alone, so summary-only retrievals ended the run without shaping and with empty evidence.

No frontend or viz-cache changes needed — both already handle these rows.

## Tests

`receipt_agent/tests/test_qa_agent_improvements.py`, 25 new tests: date context contents and the January/leap-February/quarter boundaries, per-invocation defaulting, planner prompt anchoring; evidence for summary-tier and unparseable detail-tier receipts, pluralization, cap-preserves-coverage; outlier ceilings, the large-but-real purchase, sample-count floor, null/negative handling, order preservation; and the three routing cases.

```
25 passed                                    # new tests
369 passed, 22 skipped, 5 failed             # full receipt_agent suite
```

The 5 failures are `pytest-asyncio` not being installed in this environment and reproduce identically on unmodified `origin/main` (verified by stashing). `black --line-length=79` and `isort --profile=black --line-length=79` are clean on all changed files.

One note: `black` also reformatted a pre-existing `state_holder["aggregates"].append({...})` block in `search.py` that #716 landed unformatted. `search.py` was not black-clean on main before this PR; CI lints changed files, so the fix is required now that the file is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)