### PR TITLE
fix: clamp Chroma queries to cloud quota; default QA model to gpt-oss-120b

### DIFF
--- a/infra/qa_agent_step_functions/infrastructure.py
+++ b/infra/qa_agent_step_functions/infrastructure.py
@@ -21,10 +21,6 @@ from typing import Optional
 
 import pulumi
 import pulumi_aws as aws
-
-# Import shared components
-from codebuild_docker_image import CodeBuildDockerImage
-from lambda_layer import dynamo_layer
 from pulumi import (
     AssetArchive,
     ComponentResource,
@@ -33,6 +29,10 @@ from pulumi import (
     Output,
     ResourceOptions,
 )
+
+# Import shared components
+from codebuild_docker_image import CodeBuildDockerImage
+from lambda_layer import dynamo_layer
 
 # Load secrets
 config = Config("portfolio")

--- a/infra/qa_agent_step_functions/infrastructure.py
+++ b/infra/qa_agent_step_functions/infrastructure.py
@@ -290,7 +290,7 @@ class QAAgentStepFunction(ComponentResource):
             "environment": {
                 "DYNAMODB_TABLE_NAME": dynamodb_table_name,
                 "OPENROUTER_API_KEY": openrouter_api_key,
-                "OPENROUTER_MODEL": "x-ai/grok-4.5",
+                "OPENROUTER_MODEL": "openai/gpt-oss-120b",
                 "LANGCHAIN_API_KEY": langchain_api_key,
                 "LANGCHAIN_TRACING_V2": "true",
                 "LANGCHAIN_PROJECT": "qa-agent-marquee",

--- a/receipt_agent/receipt_agent/agents/question_answering/tools/search.py
+++ b/receipt_agent/receipt_agent/agents/question_answering/tools/search.py
@@ -26,6 +26,11 @@ from langchain_core.tools import tool
 
 logger = logging.getLogger(__name__)
 
+# Chroma Cloud rejects queries requesting more than 300 results per call
+# ("NumResults" quota). Requests above it fail outright, which sends the
+# agent into retry loops, so every n_results must stay at or under this.
+CHROMA_MAX_N_RESULTS = 300
+
 
 # ==============================================================================
 # OCR Outlier Filtering
@@ -471,7 +476,7 @@ def create_qa_tools(
 
                 results = lines_collection.query(
                     query_embeddings=query_embeddings,
-                    n_results=limit * 2,
+                    n_results=min(limit * 2, CHROMA_MAX_N_RESULTS),
                     include=["metadatas", "distances"],
                 )
 
@@ -631,7 +636,7 @@ def create_qa_tools(
 
             results = lines_collection.query(
                 query_embeddings=query_embeddings,
-                n_results=limit * 3,
+                n_results=min(limit * 3, CHROMA_MAX_N_RESULTS),
                 include=["metadatas", "distances", "documents"],
             )
 
@@ -968,7 +973,7 @@ def create_qa_tools(
 
                 results = lines_collection.query(
                     query_embeddings=query_embeddings,
-                    n_results=limit * 3,
+                    n_results=min(limit * 3, CHROMA_MAX_N_RESULTS),
                     include=["metadatas", "distances"],
                 )
 


### PR DESCRIPTION
## Problem

Prod QA runs (`qa-agent-prod`) keep dying at exactly 900s — the Lambda hard ceiling — while dev passes the identical code and data in ~7 minutes. #1281 raised the step-function state timeout to 2400s, but the Lambda itself dies first, so that timeout is unreachable.

Prod logs show the real cause:

```
Semantic search error: Quota exceeded: 'Number of results' exceeded quota limit
for action 'Query': current usage of 600 exceeds limit of 300.
...
GRAPH_RECURSION_LIMIT
```

The search tools request `n_results=limit*2` / `limit*3`; when the agent picks `limit=200`, the 600-result query exceeds Chroma Cloud's 300-result `NumResults` quota and fails outright. The agent then retries in a loop until it hits LangGraph's recursion limit — multiplied across questions, the invocation burns its full 15 minutes. Whether a run survives depends on what limits the LLM happens to choose, which is why dev passed and prod flipped a coin and lost.

## Fix

- **`tools/search.py`**: add `CHROMA_MAX_N_RESULTS = 300` and clamp all three lines-collection query sites with `min(...)`. (`tools_simplified.py` has the same pattern but is imported nowhere — left alone.)
- **`infra/qa_agent_step_functions/infrastructure.py`**: set the deployed `OPENROUTER_MODEL` to `openai/gpt-oss-120b` (~\$0.04/\$0.17 per M tokens vs grok-4.5's \$2/\$6). This model was already proven on the dev QA run (32/32 questions, evidence rendering verified on the frontend); until now it had to be re-pinned by hand after every deploy because Pulumi reset the env to grok.

## Verification

- Dev QA run 6c8e2092 (same code, gpt-oss-120b): SUCCEEDED, 32/32 questions, 31/32 with receipt evidence, RunAllQuestions in 7m09s.
- Prod failure 80f048e5 execution history + CloudWatch logs pinpoint the quota error and recursion loops; dev logs for the passing run contain zero occurrences of either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RYquMqYASyC2K7T9TJWLJ7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved receipt and product searches by preventing oversized result requests that could exceed search service limits.
  * Updated the QA pipeline’s underlying AI model to improve response generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->