### PR TITLE
fix: align QA agent IaC with actual system limits

### DIFF
--- a/infra/qa_agent_step_functions/infrastructure.py
+++ b/infra/qa_agent_step_functions/infrastructure.py
@@ -43,6 +43,13 @@ chroma_cloud_api_key = config.require_secret("CHROMA_CLOUD_API_KEY")
 chroma_cloud_tenant = config.get("CHROMA_CLOUD_TENANT") or ""
 chroma_cloud_database = config.get("CHROMA_CLOUD_DATABASE") or ""
 
+# Model is a stack config so per-stack experiments (e.g. a pricier model on
+# one stack) live in IaC instead of hand-edited Lambda env that the next
+# deploy silently reverts. Override: pulumi config set portfolio:QA_OPENROUTER_MODEL <slug>
+qa_openrouter_model = (
+    config.get("QA_OPENROUTER_MODEL") or "openai/gpt-oss-120b"
+)
+
 HANDLERS_DIR = os.path.join(os.path.dirname(__file__), "handlers")
 
 
@@ -290,7 +297,7 @@ class QAAgentStepFunction(ComponentResource):
             "environment": {
                 "DYNAMODB_TABLE_NAME": dynamodb_table_name,
                 "OPENROUTER_API_KEY": openrouter_api_key,
-                "OPENROUTER_MODEL": "openai/gpt-oss-120b",
+                "OPENROUTER_MODEL": qa_openrouter_model,
                 "LANGCHAIN_API_KEY": langchain_api_key,
                 "LANGCHAIN_TRACING_V2": "true",
                 "LANGCHAIN_PROJECT": "qa-agent-marquee",
@@ -567,9 +574,11 @@ def _build_state_machine_definition(
                     "langchain_project.$": "$.Payload.langchain_project",
                 },
                 "ResultPath": "$.questions_result",
-                # 900s was knife-edge for 32 questions (cold starts + provider
-                # variance timed out an entire healthy run on 2026-07-28).
-                "TimeoutSeconds": 2400,
+                # The Lambda's own timeout is 900s — the AWS hard maximum —
+                # so this state can never legitimately run longer than that.
+                # Small margin covers invoke/retry overhead; anything past
+                # it means the task is already dead.
+                "TimeoutSeconds": 960,
                 "Retry": [
                     {
                         "ErrorEquals": [

--- a/infra/qa_agent_step_functions/lambdas/run_question.py
+++ b/infra/qa_agent_step_functions/lambdas/run_question.py
@@ -62,7 +62,12 @@ QUESTIONS = [
     "Find receipts with handwritten notes",
 ]
 
-CONCURRENCY = 10
+# All 32 questions must finish inside one Lambda invocation, and 900s is
+# the AWS hard ceiling — there is no bigger timeout to reach for. At 10,
+# questions run in ~3 stacked waves and a slow model risks the ceiling;
+# at 32 every question runs in a single wave, so wall time is the slowest
+# question rather than the sum of the slowest per wave.
+CONCURRENCY = 32
 
 
 class CostTrackingCallback(BaseCallbackHandler):


### PR DESCRIPTION
## What

Three truths the QA pipeline learned the hard way this week, moved into code:

1. **`run_question.py`: `CONCURRENCY` 10 → 32.** All 32 questions must finish inside one Lambda invocation, and that Lambda is already at AWS's hard 900s ceiling — there is no bigger timeout to give it. At concurrency 10 the questions run in ~3 stacked waves, so a slow provider day (like grok/gpt-oss variance on 2026-07-28/29) times out the whole run. At 32, wall time ≈ the slowest single question: dev completed in 7m09s *with* wave-stacking, so this adds comfortable headroom even for slower models like gpt-5.6-luna.

2. **`infrastructure.py`: `RunAllQuestions` `TimeoutSeconds` 2400 → 960.** #1281 raised the state timeout believing the state was timing out; the failures were actually `Sandbox.Timedout` from the Lambda itself at 900s. A state timeout beyond the Lambda's lifetime is unreachable — 960 (900 + invoke margin) states the real contract.

3. **`infrastructure.py`: `OPENROUTER_MODEL` becomes stack config** (`portfolio:QA_OPENROUTER_MODEL`, default `openai/gpt-oss-120b`). Model experiments have been hand-edits to the Lambda env that every deploy silently reverts — now they're `pulumi config set` per stack, in IaC where they belong.

## Context

Part of the prod QA viz refresh saga: #1281 (timeout, superseded by this), #1282 (evidence capture), #1283 (Chroma quota clamp + cheap model default), plus tonight's purge of 804 orphaned DynamoDB rows for 169 deleted receipts that the agent was chasing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RYquMqYASyC2K7T9TJWLJ7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration support for selecting the AI model used by question-answering workflows.
  * Increased question-processing capacity, allowing more questions to be handled concurrently.

* **Bug Fixes**
  * Improved workflow timing and timeout handling to better align with platform limits and reduce unnecessary delays during question processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->