### PR TITLE
fix: QA agent fixes from the luna scorecard (null dates, empty synthesize, coverage)

### DIFF
--- a/receipt_agent/receipt_agent/agents/question_answering/graph.py
+++ b/receipt_agent/receipt_agent/agents/question_answering/graph.py
@@ -810,23 +810,12 @@ def route_after_agent(state: QAState, state_holder: dict) -> str:
                     )
                     return "shape"
             else:
-                # No tool calls - LLM responded with text.
-                # Shape whenever either tier holds receipts; skipping on
-                # summary-only retrievals ended the run with no evidence.
-                if state_holder.get("retrieved_receipts") or state_holder.get(
-                    "summary_receipts"
-                ):
-                    return "shape"
-                else:
-                    # Extract answer from content
-                    if last_message.content:
-                        state_holder["answer"] = {
-                            "answer": str(last_message.content),
-                            "total_amount": None,
-                            "receipt_count": 0,
-                            "evidence": [],
-                        }
-                    return "end"
+                # No tool calls - LLM responded with text. Always shape:
+                # even a correct "nothing found" must reach synthesize so
+                # the trace carries a final answer — ending here left the
+                # viz with an empty Result panel (2026-07-29 scorecard,
+                # Q24, where 10 tool calls rightly found no pet food).
+                return "shape"
 
     return "end"
 

--- a/receipt_agent/receipt_agent/agents/question_answering/tools/search.py
+++ b/receipt_agent/receipt_agent/agents/question_answering/tools/search.py
@@ -1049,16 +1049,32 @@ def create_qa_tools(
 
                 _track_search(query, "semantic", len(items))
 
-                return {
+                result = {
                     "query": query,
                     "search_type": "semantic",
                     "total_matches": len(results["ids"][0]),
                     "unique_items": len(items),
                     "items": items,
-                    "raw_total": round(total, 2),
                     "auto_fetched": fetched_count,
                     "note": "Review items for relevance before summing prices.",
                 }
+                # A summable total next to nothing-but-noise invites the
+                # model to report it. When even the best hit is weak, the
+                # matches are almost certainly irrelevant — say so instead
+                # of offering a number.
+                max_sim = max(
+                    (i.get("similarity", 0) for i in items), default=0
+                )
+                if max_sim >= 0.5:
+                    result["raw_total"] = round(total, 2)
+                else:
+                    result["raw_total"] = None
+                    result["note"] = (
+                        f"All matches are weak (best similarity "
+                        f"{max_sim:.2f}); they are likely irrelevant. "
+                        "Do not sum or cite these prices."
+                    )
+                return result
 
             else:
                 # Text search
@@ -1213,6 +1229,10 @@ def create_qa_tools(
                     break
 
             filtered = []
+            undated_excluded = 0
+            undated_spending = 0.0
+            uncategorized_excluded = 0
+            uncategorized_spending = 0.0
             for record in all_summaries:
                 place_key = f"{record.image_id}_{record.receipt_id}"
                 place = places_by_key.get(place_key)
@@ -1228,6 +1248,15 @@ def create_qa_tools(
                         continue
 
                 if category_filter:
+                    # A third of receipts have no category at all; count
+                    # them out loud so percentages keep an honest
+                    # denominator instead of silently vanishing.
+                    if not merchant_category and not (
+                        place and place.merchant_types
+                    ):
+                        uncategorized_excluded += 1
+                        uncategorized_spending += record.grand_total or 0
+                        continue
                     category_match = False
                     if (
                         merchant_category
@@ -1243,6 +1272,15 @@ def create_qa_tools(
                     if not category_match:
                         continue
 
+                # A date filter must not pass receipts with no date at
+                # all — asserting "spent $X in July" while citing undated
+                # receipts was the largest wrong-number source in the
+                # 2026-07-29 scorecard. They are counted and reported
+                # separately instead of silently included.
+                if (start_dt or end_dt) and not record.date:
+                    undated_excluded += 1
+                    undated_spending += record.grand_total or 0
+                    continue
                 if start_dt and record.date:
                     if record.date < start_dt:
                         continue
@@ -1298,6 +1336,8 @@ def create_qa_tools(
                         else None
                     ),
                     "excluded_outlier_count": len(outliers),
+                    "undated_excluded": undated_excluded,
+                    "uncategorized_excluded": uncategorized_excluded,
                 }
             )
 
@@ -1331,6 +1371,26 @@ def create_qa_tools(
                 "summaries": filtered,
                 "auto_fetched": fetched_count,
             }
+            if undated_excluded:
+                result["undated_excluded"] = {
+                    "count": undated_excluded,
+                    "total_spending": round(undated_spending, 2),
+                    "note": (
+                        "Receipts with no date cannot satisfy a date "
+                        "filter and are NOT included above. State this "
+                        "coverage gap when answering."
+                    ),
+                }
+            if uncategorized_excluded:
+                result["uncategorized_excluded"] = {
+                    "count": uncategorized_excluded,
+                    "total_spending": round(uncategorized_spending, 2),
+                    "note": (
+                        "Receipts with no category are NOT included "
+                        "above. Include this bucket in any percentage "
+                        "or breakdown denominator."
+                    ),
+                }
             if outliers:
                 result["excluded_outliers"] = summarize_ocr_outliers(outliers)
                 result["excluded_outlier_count"] = len(outliers)
@@ -1358,6 +1418,7 @@ def create_qa_tools(
         """
         try:
             category_counts: dict[str, int] = defaultdict(int)
+            categorized = 0
             last_key = None
 
             while True:
@@ -1369,7 +1430,22 @@ def create_qa_tools(
                 for place in places:
                     if place.merchant_category:
                         category_counts[place.merchant_category] += 1
+                        categorized += 1
 
+                if last_key is None:
+                    break
+
+            # Receipts without a category hold a third of all spend; a
+            # breakdown that omits them reports percentages against a
+            # fictional denominator.
+            total_receipts = 0
+            last_key = None
+            while True:
+                records, last_key = dynamo_client.list_receipt_summaries(
+                    limit=1000,
+                    last_evaluated_key=last_key,
+                )
+                total_receipts += len(records)
                 if last_key is None:
                     break
 
@@ -1381,6 +1457,12 @@ def create_qa_tools(
 
             return {
                 "total_categories": len(sorted_categories),
+                "total_receipts": total_receipts,
+                "uncategorized_receipts": max(total_receipts - categorized, 0),
+                "note": (
+                    "Uncategorized receipts match NO category filter; "
+                    "include them in any breakdown denominator."
+                ),
                 "categories": [
                     {"category": cat, "receipt_count": count}
                     for cat, count in sorted_categories
@@ -1456,6 +1538,22 @@ A separate step will format your answer with supporting receipt details.
 
 **For merchant/date aggregation**:
 - Use get_receipt_summaries (pre-computed, fast)
+
+**For merchant totals** ("total at Costco", "gas stations"):
+- Merchant names have case and suffix variants ("Speedway"/"SPEEDWAY",
+  three CVS spellings). Call list_merchants() FIRST and aggregate over
+  EVERY variant that is the same real merchant — a single-pass search
+  under one spelling badly undercounts.
+- For merchant-type questions (gas stations, pharmacies), enumerate the
+  merchants of that type from list_merchants(), then aggregate each.
+
+**Partial data is not a refusal.** Many receipts have no date or no
+category. If a question needs dates or categories, answer over the
+receipts that HAVE them and state the coverage (e.g. "among the 680
+dated receipts..."). Tool results report excluded undated/uncategorized
+buckets — cite them. Never answer "cannot be determined" when a covered
+subset supports a direct answer, and never assert a date range that the
+cited receipts do not actually carry.
 
 ## When to Stop
 

--- a/receipt_agent/tests/test_qa_agent_improvements.py
+++ b/receipt_agent/tests/test_qa_agent_improvements.py
@@ -238,7 +238,9 @@ def test_detail_retrieval_still_routes_to_shape():
     )
 
 
-def test_no_receipts_ends_without_shaping():
+def test_no_receipts_still_routes_to_shape():
+    # A correct "nothing found" must reach synthesize so the trace carries
+    # a final answer; ending early left the viz with an empty Result panel.
     from receipt_agent.agents.question_answering.graph import (
         route_after_agent,
     )
@@ -247,9 +249,9 @@ def test_no_receipts_ends_without_shaping():
 
     assert (
         route_after_agent(_agent_state_with_text_reply(), state_holder)
-        == "end"
+        == "shape"
     )
-    assert state_holder["answer"]["evidence"] == []
+    assert "answer" not in state_holder
 
 
 # ==============================================================================


### PR DESCRIPTION
## Context

An Opus agent graded all 32 answers from the 2026-07-29 prod QA run (`gpt-5.6-luna`) against MCP ground truth: 6A/10B/8C/4D/4F. The four F's and most D's trace to five specific defects — three in tools, one in graph routing, one in prompting. This PR fixes all five.

## Fixes

1. **Null-date leak (tool) — the largest wrong-number source.** `get_receipt_summaries` applied date filters only `if record.date`, so all 369 undated receipts passed through every date window: querying July 2026 returned 410 receipts/$4,325 when the true July set is 41/$1,383. Q13 (F) asserted "last week" over five undated receipts; Q6's tax total was inflated 79%. Date filters now exclude undated rows, reported as an `undated_excluded` bucket (count + spend + coverage note).

2. **Zero-result questions skipped synthesize (graph).** `route_after_agent` ended the run when the agent answered with no receipts retrieved — Q24's *correct* "no pet food found" conclusion rendered as an empty Result panel (the 1 in 31/32 evidence coverage). Text replies now always route through shape → synthesize.

3. **Merchant-variant enumeration (prompt).** Q1 found 14/40 Costco receipts ($755 vs $3,314); Q10 reported $4.24 of gas vs $442.33 while the same run's Q8 had already surfaced the missing Speedway receipts. The DB holds 227 merchant strings for far fewer real merchants; the prompt now requires `list_merchants()` variant enumeration before merchant/type aggregates.

4. **Uncategorized bucket surfaced (tool).** 567 of 1,049 receipts ($10.5k — a third of spend) have no category and silently vanished from every category filter, making Q18's "grocery = 66%" really 21%. `get_receipt_summaries` now reports `uncategorized_excluded`; `list_categories` reports `total_receipts`/`uncategorized_receipts`.

5. **Refusal + noise-total traps (tool + prompt).** `search_product_lines` offered a summable `raw_total` ($198.14) over nothing but sub-0.41-similarity noise; weak result sets now return `raw_total: null` with a do-not-sum note. The prompt directs answering over the covered subset with stated coverage instead of refusing (Q14/Q22/Q29 declined computable answers).

## Tests

`test_qa_agent_improvements.py`: 25 passed. One test rewritten — `test_no_receipts_ends_without_shaping` pinned the exact empty-panel behavior bug 2 removes; it now asserts routing to shape.

## Verification plan

Deploy dev → rerun `qa-agent-dev` → re-grade the affected questions (0, 6, 13, 14, 18, 20, 21, 22, 24, 29) → prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RYquMqYASyC2K7T9TJWLJ7