### PR TITLE
Simplify milk retrieval timing graph

### DIFF
--- a/portfolio/components/ui/Figures/WordSimilarity.tsx
+++ b/portfolio/components/ui/Figures/WordSimilarity.tsx
@@ -710,9 +710,8 @@ const TimingBreakdown: React.FC<{
   }
 
   steps.push(
-    { name: "Chroma Init", ms: timing.chromadb_init_ms, color: "var(--color-blue)" },
+    { name: "Open Chroma", ms: timing.chromadb_init_ms, color: "var(--color-blue)" },
     { name: "Chroma Fetch", ms: timing.chromadb_fetch_all_ms, color: "var(--color-purple)" },
-    { name: "Filter Lines", ms: timing.filter_lines_ms, color: "var(--color-yellow)" },
     { name: "Fetch Receipts", ms: timing.dynamo_fetch_total_ms, color: "var(--color-orange)" },
   );
 

--- a/portfolio/e2e/word-similarity.spec.ts
+++ b/portfolio/e2e/word-similarity.spec.ts
@@ -121,21 +121,31 @@ test.describe("WordSimilarity", () => {
 
     // Wait for page to be ready
     await expect(
-      page.locator("h1", { hasText: "Introduction" })
+      page
+        .getByRole("heading", { name: "Introduction", exact: true })
+        .filter({ visible: true })
     ).toBeVisible({ timeout: 15000 });
 
     // Scroll to the milk section
-    const milkHeading = page.locator("h1", { hasText: "Asking About the $$$ Spent on Milk" });
+    const milkHeading = page
+      .getByRole("heading", { name: "Asking About the $$$ Spent on Milk" })
+      .filter({ visible: true });
     await milkHeading.scrollIntoViewIfNeeded();
 
     // Wait for timing breakdown to be visible
     // The timing breakdown shows "Document Retrieval" as the header
-    const timingSection = page.locator("text=Document Retrieval");
+    const timingSection = page
+      .getByText(/^Document Retrieval:/)
+      .filter({ visible: true });
     await expect(timingSection).toBeVisible({ timeout: 15000 });
 
     // Check for Chroma-related timing labels
-    await expect(page.locator("text=Chroma Init")).toBeVisible();
-    await expect(page.locator("text=Chroma Fetch")).toBeVisible();
+    const timingFigure = page
+      .locator('[data-testid="word-similarity"]')
+      .filter({ visible: true });
+    await expect(timingFigure.getByText("Open Chroma", { exact: true })).toBeVisible();
+    await expect(timingFigure.getByText("Chroma Fetch", { exact: true })).toBeVisible();
+    await expect(timingFigure.getByText("Filter Lines", { exact: true })).toHaveCount(0);
   });
 
   test("handles missing commentary gracefully", async ({ page }) => {


### PR DESCRIPTION
## Summary

- rename the milk timing graph's `Chroma Init` step to `Open Chroma`
- remove the negligible `Filter Lines` segment while leaving the backend dairy filtering intact
- update the end-to-end coverage to assert the streamlined graph against the visible responsive figure

## Why

Chroma already performs the `MILK` document filter server-side, so the remaining in-memory exclusion pass is too small to warrant a separate flame-graph segment. The initialization measurement still captures meaningful lazy client and collection setup, but `Open Chroma` describes that work more accurately.

## Impact

The milk table's timing graph now emphasizes the meaningful retrieval costs: opening Chroma, fetching from Chroma, fetching receipts, and finalization. The response schema and cache generator remain unchanged.

## Validation

- `npx eslint components/ui/Figures/WordSimilarity.tsx e2e/word-similarity.spec.ts`
- `npm run type-check`
- `npx playwright test e2e/word-similarity.spec.ts --grep "displays timing breakdown" --project=chromium`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Renamed the document retrieval timing step from “Chroma Init” to “Open Chroma” for clearer labeling.
* **Tests**
  * Updated automated checks to validate the revised timing labels and ensure “Filter Lines” is not displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->