### PR TITLE
Refine the section embedding explorer

### DIFF
--- a/docs/SECTION_GEOMETRY_EMBEDDING_EXPERIMENT.md
+++ b/docs/SECTION_GEOMETRY_EMBEDDING_EXPERIMENT.md
@@ -1,0 +1,106 @@
+# Section geometry and embedding experiment
+
+## Result
+
+A receipt-grouped holdout shows that Chroma row embeddings materially improve
+the semi-Markov section decoder. The useful signal comes from cross-receipt KNN
+votes plus a smaller centroid-projection term. The additional geometry and
+arithmetic emission model did not add validation lift and was assigned weight
+zero.
+
+| Metric | Fair baseline | Chroma hybrid | Delta |
+|---|---:|---:|---:|
+| Row agreement | 3,622/4,214 (85.95%) | 3,828/4,214 (90.84%) | +4.89 pp |
+| Macro section recall | 83.45% | 88.17% | +4.72 pp |
+| ITEMS recall | 83.94% | 89.53% | +5.60 pp |
+| PAYMENT recall | 85.16% | 92.12% | +6.96 pp |
+| SUMMARY recall | 83.25% | 90.05% | +6.81 pp |
+| TRANSACTION_INFO recall | 83.14% | 87.79% | +4.65 pp |
+
+The paired test has 236 rows fixed by the hybrid versus 30 regressed, for a
+net 206-row improvement. The exact two-sided McNemar p-value is
+`7.42e-41`. A 5,000-sample receipt bootstrap puts the row-agreement delta at
+`[+3.87, +5.94]` percentage points (95% interval).
+
+## Design
+
+The experiment reads the repository's local analytics cache and performs no
+AWS writes. It uses 783 receipts with QA-VALID section evidence and splits by
+receipt, never row, into 478 train, 138 validation, and 167 test receipts.
+The test partition is untouched during weight selection. After selection, the
+baseline and evidence models are refit on train plus validation and evaluated
+once on test.
+
+The comparison is fair to the existing decoder: both arms learn the same
+lexical, layout, duration, and transition priors from the same split. The
+hybrid adds section-aligned evidence before the existing semi-Markov decode:
+
+1. **Geometry and arithmetic likelihood** over normalized row position,
+   extents, height, vertical gaps, price-column offset, amount density,
+   normalized amount magnitude, sign, and running-sum reconciliation.
+2. **Embedding projection** onto L2-normalized section centroids.
+3. **Embedding KNN** using non-negative cosine-weighted votes from 15 labeled
+   rows in other receipts.
+
+Validation selected weights `geometry_math=0.0`,
+`embedding_projection=0.5`, and `embedding_knn=1.0`. KNN alone reached 90.65%
+test agreement; the centroid term supplied a small further lift to 90.84%.
+Fine-grained geometry/arithmetic did not improve on the decoder's existing
+layout evidence, so it should not be integrated on the strength of this pass.
+
+Embedding coverage was 28,172/28,191 corpus rows and 6,152/6,160 test rows
+(99.87%). Missing vectors receive no embedding evidence and retain the normal
+decoder behavior.
+
+## Snapshot issue found
+
+The documented cache validator reported the freshly downloaded Chroma
+components as valid because it only ran SQLite `quick_check`. Chroma 1.3.6
+could not execute `count()` on either native snapshot:
+
+```text
+Error sending backfill request to compactor: Failed to pull logs from the log store
+```
+
+For the line snapshot, the HNSW vector checkpoint trailed the metadata
+checkpoint by 218 records. Every skipped record was a contiguous operation-1
+UPDATE with a NULL vector, so none could affect the vector segment. The
+experiment clones the snapshot locally, proves those predicates in one SQLite
+transaction, advances only the copied vector checkpoint, and then requires a
+successful Chroma `count()` (34,045 vectors). It refuses any vector write,
+delete/non-UPDATE operation, gap, or concurrent checkpoint change.
+
+This guarded copy is an experiment workaround, not the deployment fix. The
+snapshot producer should flush/advance metadata-only vector checkpoints before
+publishing, and local cache validation should execute a real Chroma operation
+rather than equate SQLite integrity with collection readability.
+
+## Reproduction
+
+```bash
+python3.12 scripts/local_analytics_cache.py sync \
+  --env dev --components dynamodb,chroma
+
+PYTHONPATH=receipt_dynamo:receipt_chroma:receipt_upload \
+python3.12 scripts/evaluate_section_geometry.py \
+  --output .cache/section-geometry/report.json
+```
+
+The measured run used DynamoDB mirror time
+`2026-07-29T20:41:05.751096+00:00`, line snapshot
+`20260729_203457_486164_849816c8`, and word snapshot
+`20260729_203556_291391_09b2715f`.
+
+## Recommended integration
+
+Feed cross-receipt VALID-neighbor log votes into the deterministic decoder's
+per-section emission evidence, using the row embeddings already produced by
+the upload pipeline. Preserve the current sequence/duration decoder and its
+additive PENDING-only persistence contract. Keep the existing asynchronous
+verifier as independent provenance rather than using it as the sole consumer
+of embeddings.
+
+Before changing runtime assignment, repeat the shadow evaluation on receipts
+created after this snapshot and add abstention/calibration gates for missing or
+low-consensus neighbors. Do not add the experimental geometry/arithmetic
+features unless a boundary-specific model demonstrates out-of-time lift.

--- a/portfolio/components/ui/Figures/SectionEmbeddingExplorer/SectionEmbeddingExplorer.module.css
+++ b/portfolio/components/ui/Figures/SectionEmbeddingExplorer/SectionEmbeddingExplorer.module.css
@@ -23,13 +23,10 @@
   overflow: hidden;
 }
 
-.interactiveStage {
-  height: min(60vh, 520px);
-  min-height: 440px;
-}
-
+.interactiveStage,
 .staticStage {
-  height: 500px;
+  height: 520px;
+  min-height: 520px;
 }
 
 .actLayer {
@@ -52,29 +49,22 @@
   animation: layer-out 380ms ease both;
 }
 
-.receiptAct,
-.projectionAct,
-.neighborsAct,
-.decodeAct,
-.resultAct {
+.scene {
   position: relative;
   box-sizing: border-box;
   width: 100%;
   height: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
 }
 
 .actAnnotation {
   position: absolute;
   top: 0.35rem;
   left: 0.25rem;
-  z-index: 4;
+  z-index: 20;
   display: grid;
-  grid-template-columns: auto 1fr;
+  grid-template-columns: auto minmax(0, 1fr);
   column-gap: 0.65rem;
-  max-width: 30rem;
+  width: min(100% - 0.5rem, 36rem);
   pointer-events: none;
 }
 
@@ -101,65 +91,10 @@
   letter-spacing: -0.08em;
 }
 
-.stageNote {
+.stackField {
   position: absolute;
-  right: 0.25rem;
-  bottom: 0.1rem;
-  margin: 0;
-  color: rgba(var(--text-color-rgb), 0.42);
-  font-size: 0.66rem;
-}
-
-/* Receipt ----------------------------------------------------------- */
-
-.receiptPaper {
-  position: relative;
-  width: min(76%, 430px);
-  padding: 1rem 4.75rem 1rem 1rem;
-  border-top: 1px solid rgba(var(--text-color-rgb), 0.1);
-  border-bottom: 1px solid rgba(var(--text-color-rgb), 0.1);
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-  font-size: clamp(0.61rem, 1.25vw, 0.78rem);
-  letter-spacing: 0.012em;
-}
-
-.receiptPaper::before,
-.receiptPaper::after {
-  content: "";
-  position: absolute;
-  left: 0;
-  right: 0;
-  height: 20px;
-  opacity: 0.3;
-  background: repeating-linear-gradient(
-    135deg,
-    transparent 0 7px,
-    rgba(var(--text-color-rgb), 0.12) 7px 8px
-  );
-}
-
-.receiptPaper::before { top: -20px; }
-.receiptPaper::after { bottom: -20px; transform: rotate(180deg); }
-
-.receiptRow {
-  position: relative;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 1rem;
-  height: 24px;
-  white-space: nowrap;
-  transition: color 240ms ease;
-}
-
-.receiptRow::before {
-  content: "";
-  position: absolute;
-  left: -0.85rem;
-  width: 3px;
-  height: 3px;
-  border-radius: 50%;
-  background: var(--section-color);
+  inset: 4.45rem 0 1.85rem;
+  isolation: isolate;
 }
 
 .container [data-section="TRANSACTION_INFO"] { --section-color: var(--color-blue); }
@@ -167,442 +102,351 @@
 .container [data-section="SUMMARY"] { --section-color: var(--color-orange); }
 .container [data-section="PAYMENT"] { --section-color: var(--color-green); }
 
-.receiptSectionRail {
+/* Receipt stack ---------------------------------------------------- */
+
+.receiptCard {
   position: absolute;
-  top: 1rem;
-  right: 0;
-  width: 4rem;
-  height: calc(100% - 2rem);
+  box-sizing: border-box;
+  overflow: hidden;
+  border: 1px solid rgba(var(--text-color-rgb), 0.16);
+  border-radius: 3px;
+  color: var(--text-color);
+  background:
+    linear-gradient(rgba(var(--text-color-rgb), 0.025), rgba(var(--text-color-rgb), 0.008)),
+    var(--background-color);
+  box-shadow: 0 9px 26px rgba(0, 0, 0, 0.22);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  transition:
+    opacity 420ms ease,
+    transform 520ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    box-shadow 420ms ease;
 }
 
-.railSegment {
-  position: absolute;
-  left: 0;
-  width: 100%;
-  border-left: 2px solid var(--section-color);
-  transition: opacity 220ms ease;
+.receiptHeader,
+.receiptFooter {
+  position: relative;
+  z-index: 5;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0 0.7rem;
+  border-bottom: 1px solid rgba(var(--text-color-rgb), 0.11);
+  color: rgba(var(--text-color-rgb), 0.48);
+  font-family: system-ui, sans-serif;
+  font-size: 0.54rem;
+  letter-spacing: 0.06em;
 }
 
-.railSegment::before,
-.railSegment::after {
-  content: "";
-  position: absolute;
-  left: 0;
-  width: 6px;
-  height: 2px;
-  background: var(--section-color);
+.receiptHeader {
+  height: 27px;
+  text-transform: uppercase;
 }
 
-.railSegment::before { top: 0; }
-.railSegment::after { bottom: 0; }
+.receiptHeader strong {
+  overflow: hidden;
+  color: rgba(var(--text-color-rgb), 0.78);
+  font-size: 0.62rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 
-.railSegment span {
+.receiptFooter {
+  height: 20px;
+  border-top: 1px solid rgba(var(--text-color-rgb), 0.09);
+  border-bottom: 0;
+  font-size: 0.5rem;
+  text-transform: uppercase;
+}
+
+.currentReceipt {
+  --row-height: 21px;
+  top: 3.5rem;
+  left: 9%;
+  z-index: 10;
+  width: 360px;
+  transform: translateY(calc((1 - var(--act-progress)) * 10px));
+}
+
+.referenceReceipt {
+  --row-height: 29px;
+  z-index: calc(7 - var(--reference-index));
+  width: 185px;
+  opacity: 0.24;
+  transform: translateY(-8px) rotate(var(--receipt-rotation)) scale(0.94);
+  transform-origin: center bottom;
+}
+
+.referenceReceipt[data-reference-index="0"] {
+  top: 2.8rem;
+  left: 46%;
+  --receipt-rotation: -2.2deg;
+}
+
+.referenceReceipt[data-reference-index="1"] {
+  top: 4.2rem;
+  left: 59%;
+  --receipt-rotation: 2deg;
+}
+
+.referenceReceipt[data-reference-index="2"] {
+  top: 5.9rem;
+  left: 71%;
+  --receipt-rotation: -1.6deg;
+}
+
+.referenceReceipt[data-reference-index="3"] {
+  top: 7.8rem;
+  left: 78%;
+  --receipt-rotation: 2.2deg;
+}
+
+.scene[data-act="ocr"] .referenceReceipt {
+  opacity: 0.12;
+  transform: translateY(-18px) rotate(var(--receipt-rotation)) scale(0.9);
+}
+
+.scene[data-act="baseline"] .referenceReceipt {
+  opacity: 0.23;
+}
+
+.scene[data-act="neighbors"] .referenceReceipt {
+  opacity: 0.96;
+  transform: translateY(0) rotate(var(--receipt-rotation)) scale(1);
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.3);
+}
+
+.scene[data-act="corrected"] .referenceReceipt {
+  opacity: 0.42;
+  transform: translateY(4px) rotate(var(--receipt-rotation)) scale(0.97);
+}
+
+.scene[data-act="final"] .referenceReceipt {
+  opacity: 0.26;
+  transform: translateY(7px) rotate(var(--receipt-rotation)) scale(0.94);
+}
+
+.receiptRows {
+  position: relative;
+}
+
+.receiptRow {
+  position: relative;
+  z-index: 3;
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  height: var(--row-height);
+  padding: 0 0.6rem 0 4.8rem;
+  color: rgba(var(--text-color-rgb), 0.8);
+  font-size: 0.62rem;
+  letter-spacing: 0.008em;
+  transition:
+    color 300ms ease,
+    background 340ms ease,
+    box-shadow 340ms ease,
+    opacity 240ms ease,
+    transform 240ms ease;
+}
+
+.receiptRow > span:first-child {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.receiptRow > span:last-child:not(:first-child) {
+  flex: 0 0 auto;
+  font-variant-numeric: tabular-nums;
+}
+
+.referenceReceipt .receiptRow {
+  padding-right: 0.45rem;
+  padding-left: 3.5rem;
+  font-size: 0.47rem;
+}
+
+.sectionBands {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  pointer-events: none;
+}
+
+.sectionBand {
+  position: absolute;
+  top: calc(var(--band-start) * var(--row-height));
+  right: 0.35rem;
+  left: 0.35rem;
+  height: calc(var(--band-length) * var(--row-height));
+  overflow: hidden;
+  border-top: 1px solid color-mix(in srgb, var(--section-color) 28%, transparent);
+  border-bottom: 1px solid color-mix(in srgb, var(--section-color) 28%, transparent);
+  border-left: 3px solid var(--section-color);
+  background: color-mix(in srgb, var(--section-color) 9%, transparent);
+  transition:
+    top 480ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    height 480ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    opacity 300ms ease;
+}
+
+.sectionBand span {
   position: absolute;
   top: 50%;
-  left: 0.55rem;
+  left: 0.48rem;
+  width: 3.5rem;
   transform: translateY(-50%);
   color: var(--section-color);
   font-family: system-ui, sans-serif;
-  font-size: 0.56rem;
+  font-size: 0.5rem;
   font-weight: 700;
-  letter-spacing: 0.04em;
+  letter-spacing: 0.035em;
 }
 
-/* Projection -------------------------------------------------------- */
-
-.projectionAct,
-.neighborsAct,
-.decodeAct {
-  padding-top: 2.7rem;
-  padding-bottom: 3rem;
+.sectionBand[data-compact="true"] span {
+  left: 0.35rem;
+  width: 2.7rem;
+  font-size: 0.38rem;
 }
 
-.projectionSvg {
-  width: min(92%, 740px);
-  max-height: 100%;
-  overflow: visible;
+.scene[data-act="baseline"] .currentReceipt .receiptRow[data-row-id="subtotal"],
+.scene[data-act="baseline"] .currentReceipt .receiptRow[data-row-id="visa"] {
+  box-shadow: inset 3px 0 var(--color-red);
 }
 
-.axes path,
-.decodeColumn {
-  fill: none;
-  stroke: rgba(var(--text-color-rgb), 0.12);
-  stroke-width: 1;
-  vector-effect: non-scaling-stroke;
-}
-
-.axes text {
-  fill: rgba(var(--text-color-rgb), 0.42);
-  font-size: 9px;
-  letter-spacing: 0.03em;
-}
-
-.clusterHalo,
-.projectionPoint,
-.queryPoint circle:first-child,
-.correctionHalo {
-  fill: var(--section-color);
-}
-
-.clusterHalo {
-  stroke: var(--section-color);
-  stroke-width: 1;
-  vector-effect: non-scaling-stroke;
-}
-
-.clusterLabel {
-  fill: var(--section-color);
-  font-size: 10px;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-}
-
-.projectionPoint {
-  stroke: var(--background-color);
-  stroke-width: 1.5;
-  vector-effect: non-scaling-stroke;
-}
-
-.projectionPoint[data-neighbor="true"] {
-  stroke: var(--text-color);
-  stroke-width: 1.2;
-}
-
-.queryPoint {
-  --section-color: var(--text-color);
-}
-
-.queryPoint circle:first-child {
-  stroke: var(--background-color);
-  stroke-width: 3;
-  vector-effect: non-scaling-stroke;
-}
-
-.queryPulse {
-  fill: none;
-  stroke: var(--text-color);
-  stroke-width: 1.5;
-  vector-effect: non-scaling-stroke;
-  transform-box: fill-box;
-  transform-origin: center;
-  animation: query-pulse 1.8s ease-in-out infinite;
-}
-
-.queryPoint text {
-  fill: var(--text-color);
-  paint-order: stroke;
-  stroke: var(--background-color);
-  stroke-width: 4px;
-  stroke-linejoin: round;
-  font-size: 10px;
-  font-weight: 700;
-}
-
-.neighborLine {
-  stroke: var(--section-color);
-  stroke-width: 1.25;
-  vector-effect: non-scaling-stroke;
-}
-
-.queryControl {
-  position: absolute;
-  right: 0;
-  bottom: 0.25rem;
-  left: 0;
-  z-index: 5;
-  display: flex;
-  justify-content: center;
-  gap: 0.42rem;
-}
-
-.queryButton {
-  min-height: 32px;
-  padding: 0.34rem 0.72rem;
-  border: 1px solid rgba(var(--text-color-rgb), 0.16);
-  border-radius: 999px;
-  color: rgba(var(--text-color-rgb), 0.56);
-  background: transparent;
-  font: inherit;
-  font-size: 0.67rem;
-  cursor: pointer;
-  transition: border-color 180ms ease, color 180ms ease, background 180ms ease, transform 180ms ease;
-}
-
-.queryButton:hover,
-.queryButton:focus-visible {
+.receiptRow[data-neighbor="true"] {
+  z-index: 6;
   color: var(--text-color);
-  border-color: rgba(var(--text-color-rgb), 0.42);
+  background: color-mix(in srgb, var(--section-color) 14%, transparent);
+  box-shadow:
+    inset 0 0 0 1px color-mix(in srgb, var(--section-color) 72%, transparent),
+    0 0 15px color-mix(in srgb, var(--section-color) 22%, transparent);
 }
 
-.queryButton:active { transform: scale(0.97); }
-
-.queryButton[data-active="true"] {
-  color: var(--background-color);
-  border-color: var(--text-color);
-  background: var(--text-color);
+.currentReceipt .receiptRow[data-neighbor="true"] {
+  animation: neighbor-glow 1.8s ease-in-out infinite;
 }
 
-/* Neighbors --------------------------------------------------------- */
-
-.neighborLayout {
-  display: grid;
-  grid-template-columns: minmax(0, 1.45fr) minmax(180px, 0.55fr);
-  align-items: center;
-  width: 100%;
-  min-height: 0;
-}
-
-.neighborLayout .projectionSvg {
-  width: 100%;
-}
-
-.votePanel {
-  display: flex;
-  flex-direction: column;
-  gap: 0.58rem;
-  padding-right: 0.25rem;
-}
-
-.voteHeader {
-  display: flex;
-  flex-direction: column;
-  color: rgba(var(--text-color-rgb), 0.5);
-  font-size: 0.64rem;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-}
-
-.voteHeader strong {
+.receiptRow[data-changed="true"] {
+  z-index: 6;
   color: var(--text-color);
-  font-size: 0.72rem;
+  background: rgba(var(--text-color-rgb), 0.035);
+  box-shadow: inset 0 0 0 1px rgba(var(--text-color-rgb), 0.74);
 }
 
-.voteRow {
-  display: grid;
-  grid-template-columns: 3.2rem minmax(60px, 1fr) 2rem;
-  align-items: center;
-  gap: 0.45rem;
-  color: var(--section-color);
-  font-size: 0.62rem;
-  font-weight: 700;
+.scene[data-act="corrected"] .receiptRow[data-changed="true"] {
+  animation: corrected-row 820ms ease both;
 }
 
-.voteRow > strong { text-align: right; }
+/* Neighbor vote connections + schematic map ----------------------- */
 
-.voteTrack,
-.resultTrack {
-  position: relative;
-  height: 4px;
-  overflow: hidden;
-  border-radius: 999px;
-  background: rgba(var(--text-color-rgb), 0.1);
-}
-
-.voteTrack span {
+.neighborConnections {
   position: absolute;
-  inset: 0 auto 0 0;
-  border-radius: inherit;
-  background: var(--section-color);
-  transition: width 120ms linear;
-}
-
-.weightEquation {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.35rem;
-  margin-top: 0.3rem;
-  color: rgba(var(--text-color-rgb), 0.52);
-  font-size: 0.62rem;
-}
-
-.weightEquation span {
-  padding: 0.24rem 0.4rem;
-  border: 1px solid rgba(var(--text-color-rgb), 0.12);
-  border-radius: 4px;
-}
-
-.weightEquation strong { color: var(--text-color); }
-
-/* Decode ------------------------------------------------------------ */
-
-.decodeChart {
-  position: relative;
-  width: min(94%, 720px);
-  height: min(100%, 350px);
-  margin-top: 0.5rem;
-}
-
-.decodeChart svg {
-  display: block;
+  inset: 0;
+  z-index: 11;
   width: 100%;
   height: 100%;
   overflow: visible;
+  pointer-events: none;
 }
 
-.decodeHeader {
-  fill: var(--section-color);
-  font-size: 9px;
-  font-weight: 700;
-  letter-spacing: 0.06em;
-}
-
-.decodeRowLabel {
-  fill: rgba(var(--text-color-rgb), 0.5);
-  font-size: 8px;
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-}
-
-.baselinePath,
-.decodedPath {
+.neighborConnections path {
   fill: none;
+  stroke: var(--section-color);
+  stroke-width: 2.2;
   stroke-linecap: round;
-  stroke-linejoin: round;
+  stroke-dasharray: 8 6;
+  opacity: 1;
+  filter: drop-shadow(0 0 3px color-mix(in srgb, var(--section-color) 34%, transparent));
+  vector-effect: non-scaling-stroke;
+  animation: connection-flow 1.6s linear infinite;
+}
+
+.neighborConnections circle {
+  fill: var(--section-color);
+  stroke: var(--background-color);
+  stroke-width: 2;
   vector-effect: non-scaling-stroke;
 }
 
-.baselinePath {
-  stroke: var(--color-red);
-  stroke-width: 1.4;
-  stroke-dasharray: 4 5 !important;
-  opacity: 0.58;
-}
-
-.decodedPath {
-  stroke: var(--text-color);
-  stroke-width: 2.5;
-}
-
-.correctionHalo {
-  opacity: 0.22;
-  animation: correction-glow 1.8s ease-in-out infinite;
-}
-
-.decodeComparison {
+.embeddingInset {
   position: absolute;
-  right: 0;
+  right: 0.65rem;
+  bottom: 0.3rem;
+  z-index: 12;
+  width: 220px;
+  color: rgba(var(--text-color-rgb), 0.48);
+  transition: opacity 280ms ease;
+}
+
+.embeddingInset svg {
+  display: block;
+  width: 100%;
+  height: auto;
+  overflow: visible;
+}
+
+.embeddingInset g > circle:first-child {
+  fill: color-mix(in srgb, var(--section-color) 12%, transparent);
+  stroke: color-mix(in srgb, var(--section-color) 36%, transparent);
+  stroke-width: 1;
+}
+
+.embeddingInset g > circle:not(:first-child) {
+  fill: var(--section-color);
+}
+
+.embeddingInset path {
+  fill: none;
+  stroke: rgba(var(--text-color-rgb), 0.34);
+  stroke-width: 1;
+  stroke-dasharray: 2 3;
+}
+
+.embeddingInset .insetQuery {
+  fill: var(--text-color);
+  stroke: var(--background-color);
+  stroke-width: 2;
+}
+
+.embeddingInset span {
+  display: block;
+  margin-top: -0.1rem;
+  font-size: 0.56rem;
+  text-align: right;
+}
+
+.evidenceLine {
+  position: absolute;
+  right: 0.25rem;
   bottom: 0.25rem;
+  left: 0.25rem;
+  z-index: 20;
   display: flex;
   align-items: center;
-  gap: 0.38rem;
-  color: rgba(var(--text-color-rgb), 0.5);
-  font-size: 0.62rem;
-}
-
-.sectionPill {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.25rem;
-  padding: 0.22rem 0.38rem;
-  border: 1px solid color-mix(in srgb, var(--section-color) 45%, transparent);
-  border-radius: 4px;
-  color: var(--section-color);
-  font-weight: 700;
-}
-
-.sectionPill[data-muted="true"] {
-  text-decoration: line-through;
-  opacity: 0.55;
-}
-
-.sectionDot {
-  width: 0.38rem;
-  height: 0.38rem;
-  border-radius: 50%;
-  background: var(--section-color);
-}
-
-.decodeArrow { color: var(--text-color); }
-
-/* Result ------------------------------------------------------------ */
-
-.resultAct {
-  flex-direction: column;
-  gap: 1.4rem;
-  padding: 4.4rem 0.25rem 1rem;
-}
-
-.resultBars {
-  display: flex;
-  flex-direction: column;
-  gap: 1.15rem;
-  width: min(88%, 650px);
-}
-
-.resultRow {
-  display: grid;
-  grid-template-columns: 7.2rem minmax(120px, 1fr) 4rem;
-  align-items: center;
-  gap: 0.75rem;
-  font-size: 0.76rem;
-}
-
-.resultRow > span { color: rgba(var(--text-color-rgb), 0.58); }
-.resultRow > strong { font-size: 1.02rem; text-align: right; }
-
-.resultTrack { height: 8px; }
-.resultTrack > span {
-  position: absolute;
-  inset: 0 auto 0 0;
-  border-radius: inherit;
-  transition: width 120ms linear;
-}
-.baselineFill { background: rgba(var(--text-color-rgb), 0.34); }
-.hybridFill { background: var(--color-green); }
-
-.deltaCallout {
-  display: flex;
-  align-items: baseline;
-  gap: 0.55rem;
-}
-
-.deltaCallout strong {
-  color: var(--color-green);
-  font-size: clamp(2.25rem, 8vw, 4.3rem);
-  line-height: 1;
-  letter-spacing: -0.055em;
-}
-
-.deltaCallout span {
-  color: rgba(var(--text-color-rgb), 0.54);
-  font-size: 0.78rem;
-}
-
-.pairedCounts {
-  display: flex;
-  align-items: center;
-  gap: 2rem;
-}
-
-.pairedCounts > div {
-  display: flex;
-  align-items: baseline;
-  gap: 0.4rem;
-}
-
-.pairedCounts strong { font-size: 1.5rem; }
-.pairedCounts > div:first-child strong { color: var(--color-green); }
-.pairedCounts > div:last-child strong { color: var(--color-red); }
-.pairedCounts span { color: rgba(var(--text-color-rgb), 0.54); font-size: 0.7rem; }
-
-.pairedRule {
-  width: 1px;
-  height: 1.8rem;
-  background: rgba(var(--text-color-rgb), 0.14);
-}
-
-.resultFootnote {
-  margin: 0;
-  color: rgba(var(--text-color-rgb), 0.4);
+  justify-content: flex-start;
+  gap: 0.5rem;
+  color: rgba(var(--text-color-rgb), 0.48);
   font-size: 0.64rem;
-  text-align: center;
+  line-height: 1.3;
 }
 
-/* Step controls ----------------------------------------------------- */
+.evidenceRule {
+  width: 1.7rem;
+  height: 1px;
+  flex: 0 0 auto;
+  background: rgba(var(--text-color-rgb), 0.24);
+}
+
+/* Step controls ---------------------------------------------------- */
 
 .progress {
   display: flex;
-  justify-content: center;
   align-items: center;
+  justify-content: center;
   gap: 0.08rem;
   margin: 0.1rem 0 0;
   padding: 0;
@@ -630,15 +474,34 @@
 }
 
 .progressButton:hover span,
-.progressButton:focus-visible span { transform: scale(1.35); }
-.progressButton:focus-visible { outline: 2px solid var(--color-blue); outline-offset: -4px; border-radius: 50%; }
-.progressButton[data-done="true"] span { background: rgba(var(--text-color-rgb), 0.48); }
-.progressButton[data-active="true"] span { background: var(--text-color); transform: scale(1.18); }
+.progressButton:focus-visible span {
+  transform: scale(1.35);
+}
+
+.progressButton:focus-visible {
+  border-radius: 50%;
+  outline: 2px solid var(--color-blue);
+  outline-offset: -4px;
+}
+
+.progressButton[data-done="true"] span {
+  background: rgba(var(--text-color-rgb), 0.48);
+}
+
+.progressButton[data-active="true"] span {
+  transform: scale(1.18);
+  background: var(--text-color);
+}
 
 .staticStack {
   display: flex;
   flex-direction: column;
   gap: 2.5rem;
+}
+
+.staticAct + .staticAct {
+  padding-top: 1.5rem;
+  border-top: 1px solid rgba(var(--text-color-rgb), 0.1);
 }
 
 @keyframes layer-in {
@@ -651,91 +514,151 @@
   to { opacity: 0; transform: translateY(-12px); }
 }
 
-@keyframes query-pulse {
-  0%, 100% { transform: scale(0.78); opacity: 0.12; }
-  50% { transform: scale(1.18); opacity: 0.55; }
+@keyframes neighbor-glow {
+  0%, 100% { box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--section-color) 58%, transparent), 0 0 8px transparent; }
+  50% { box-shadow: inset 0 0 0 1px var(--section-color), 0 0 18px color-mix(in srgb, var(--section-color) 28%, transparent); }
 }
 
-@keyframes correction-glow {
-  0%, 100% { transform: scale(0.76); opacity: 0.1; }
-  50% { transform: scale(1.18); opacity: 0.3; }
+@keyframes connection-flow {
+  to { stroke-dashoffset: -14; }
+}
+
+@keyframes corrected-row {
+  0% { transform: translateX(-5px); opacity: 0.55; }
+  55% { transform: translateX(2px); opacity: 1; }
+  100% { transform: translateX(0); opacity: 1; }
 }
 
 @media (max-width: 700px) {
-  .interactiveStage { height: 540px; min-height: 540px; }
-  .staticStage { height: 540px; }
-  .actAnnotation { right: 0.25rem; max-width: none; }
-  .actAnnotation strong { font-size: 0.86rem; }
-  .actAnnotation > span:last-child { font-size: 0.66rem; }
-  .actNumber { font-size: 1.4rem; }
-
-  .receiptPaper {
-    width: min(88%, 390px);
-    padding-right: 3.85rem;
-    font-size: clamp(0.52rem, 2.25vw, 0.68rem);
-  }
-  .receiptSectionRail { width: 3.2rem; }
-  .railSegment span { font-size: 0.48rem; }
-
-  .projectionAct,
-  .neighborsAct,
-  .decodeAct { padding-top: 3.35rem; padding-bottom: 4.1rem; }
-  .projectionSvg { width: 100%; }
-
-  .neighborLayout {
-    grid-template-columns: 1fr;
-    grid-template-rows: minmax(0, 1fr) auto;
-    height: 100%;
-    padding-top: 0.2rem;
+  .interactiveStage,
+  .staticStage {
+    height: 560px;
+    min-height: 560px;
   }
 
-  .neighborLayout .projectionSvg { min-height: 0; }
-  .votePanel {
-    display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 0.42rem 0.7rem;
-    padding: 0 0.45rem;
+  .actAnnotation {
+    right: 0.25rem;
+    width: auto;
   }
-  .voteHeader,
-  .weightEquation { grid-column: 1 / -1; }
-  .voteRow { grid-template-columns: 2.55rem minmax(42px, 1fr) 1.8rem; }
-  .weightEquation { margin-top: 0; }
 
-  .queryControl { flex-wrap: nowrap; gap: 0.3rem; }
-  .queryButton { min-height: 34px; padding: 0.3rem 0.58rem; font-size: 0.61rem; }
+  .actAnnotation strong {
+    font-size: 0.86rem;
+  }
 
-  .decodeChart { width: 100%; height: 340px; }
-  .decodeComparison { right: 0.2rem; bottom: -0.3rem; }
-  .resultAct { gap: 1.7rem; padding-top: 4.7rem; }
-  .resultBars { width: 96%; }
-  .resultRow { grid-template-columns: 5.5rem minmax(86px, 1fr) 3.6rem; gap: 0.45rem; font-size: 0.68rem; }
-  .deltaCallout { flex-direction: column; align-items: center; gap: 0.15rem; }
-  .pairedCounts { gap: 0.85rem; }
-  .pairedCounts > div { flex-direction: column; align-items: center; gap: 0; }
-  .resultFootnote { max-width: 19rem; line-height: 1.45; }
+  .actAnnotation > span:last-child {
+    font-size: 0.66rem;
+  }
+
+  .actNumber {
+    font-size: 1.4rem;
+  }
+
+  .stackField {
+    inset: 5.25rem 0 2.2rem;
+  }
+
+  .currentReceipt {
+    --row-height: 19px;
+    top: 7.25rem;
+    left: 1rem;
+    width: min(290px, calc(100% - 2rem));
+  }
+
+  .currentReceipt .receiptRow {
+    padding-left: 4rem;
+    font-size: 0.54rem;
+  }
+
+  .currentReceipt .sectionBand span {
+    width: 3rem;
+    font-size: 0.43rem;
+  }
+
+  .referenceReceipt {
+    --row-height: 24px;
+    width: 145px;
+  }
+
+  .referenceReceipt .receiptRow {
+    padding-left: 2.8rem;
+    font-size: 0.4rem;
+  }
+
+  .referenceReceipt .sectionBand span {
+    width: 2.2rem;
+    font-size: 0.32rem;
+  }
+
+  .referenceReceipt[data-reference-index="0"] {
+    top: 1.5rem;
+    left: 28%;
+  }
+
+  .referenceReceipt[data-reference-index="1"] {
+    top: 3rem;
+    left: 59%;
+  }
+
+  .referenceReceipt[data-reference-index="2"],
+  .referenceReceipt[data-reference-index="3"] {
+    display: none;
+  }
+
+  .neighborConnections,
+  .embeddingInset {
+    display: none;
+  }
+
+  .evidenceLine {
+    font-size: 0.58rem;
+  }
 }
 
 @media (max-width: 390px) {
-  .decodeRowLabel { font-size: 7px; }
-  .decodeHeader { font-size: 8px; }
-  .receiptPaper { width: 94%; }
+  .currentReceipt {
+    left: 0.75rem;
+    width: calc(100% - 1.5rem);
+  }
+
+  .referenceReceipt[data-reference-index="0"] {
+    left: 23%;
+  }
+
+  .referenceReceipt[data-reference-index="1"] {
+    left: 57%;
+  }
 }
 
 @media (max-width: 350px) {
   .interactiveStage,
-  .staticStage { height: 575px; min-height: 575px; }
-  .queryControl { flex-wrap: wrap; align-content: flex-end; }
+  .staticStage {
+    height: 585px;
+    min-height: 585px;
+  }
+
+  .currentReceipt {
+    top: 7.9rem;
+  }
+
+  .evidenceLine {
+    align-items: flex-start;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {
   .actLayer.entering,
   .actLayer.leaving,
-  .queryPulse,
-  .correctionHalo { animation: none; }
+  .currentReceipt .receiptRow[data-neighbor="true"],
+  .scene[data-act="corrected"] .receiptRow[data-changed="true"],
+  .neighborConnections path {
+    animation: none;
+  }
+
+  .receiptCard,
   .receiptRow,
-  .railSegment,
-  .queryButton,
+  .sectionBand,
   .progressButton span,
-  .voteTrack span,
-  .resultTrack > span { transition: none; }
+  .embeddingInset {
+    transition: none;
+  }
 }

--- a/portfolio/components/ui/Figures/SectionEmbeddingExplorer/SectionEmbeddingExplorer.module.css
+++ b/portfolio/components/ui/Figures/SectionEmbeddingExplorer/SectionEmbeddingExplorer.module.css
@@ -1,0 +1,741 @@
+.container {
+  width: 100%;
+  max-width: 900px;
+  margin: 0 auto;
+  color: var(--text-color);
+}
+
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+}
+
+.stage {
+  position: relative;
+  width: 100%;
+  overflow: hidden;
+}
+
+.interactiveStage {
+  height: min(60vh, 520px);
+  min-height: 440px;
+}
+
+.staticStage {
+  height: 500px;
+}
+
+.actLayer {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: stretch;
+  justify-content: stretch;
+  opacity: 1;
+}
+
+.actLayer.entering {
+  z-index: 2;
+  animation: layer-in 380ms ease both;
+}
+
+.actLayer.leaving {
+  z-index: 1;
+  pointer-events: none;
+  animation: layer-out 380ms ease both;
+}
+
+.receiptAct,
+.projectionAct,
+.neighborsAct,
+.decodeAct,
+.resultAct {
+  position: relative;
+  box-sizing: border-box;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.actAnnotation {
+  position: absolute;
+  top: 0.35rem;
+  left: 0.25rem;
+  z-index: 4;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  column-gap: 0.65rem;
+  max-width: 30rem;
+  pointer-events: none;
+}
+
+.actAnnotation strong {
+  align-self: end;
+  font-size: clamp(0.88rem, 1.6vw, 1.02rem);
+  line-height: 1.25;
+}
+
+.actAnnotation > span:last-child {
+  grid-column: 2;
+  margin-top: 0.12rem;
+  color: rgba(var(--text-color-rgb), 0.58);
+  font-size: 0.73rem;
+  line-height: 1.35;
+}
+
+.actNumber {
+  grid-row: 1 / 3;
+  color: rgba(var(--text-color-rgb), 0.32);
+  font-size: 1.65rem;
+  font-weight: 700;
+  line-height: 1;
+  letter-spacing: -0.08em;
+}
+
+.stageNote {
+  position: absolute;
+  right: 0.25rem;
+  bottom: 0.1rem;
+  margin: 0;
+  color: rgba(var(--text-color-rgb), 0.42);
+  font-size: 0.66rem;
+}
+
+/* Receipt ----------------------------------------------------------- */
+
+.receiptPaper {
+  position: relative;
+  width: min(76%, 430px);
+  padding: 1rem 4.75rem 1rem 1rem;
+  border-top: 1px solid rgba(var(--text-color-rgb), 0.1);
+  border-bottom: 1px solid rgba(var(--text-color-rgb), 0.1);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: clamp(0.61rem, 1.25vw, 0.78rem);
+  letter-spacing: 0.012em;
+}
+
+.receiptPaper::before,
+.receiptPaper::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  height: 20px;
+  opacity: 0.3;
+  background: repeating-linear-gradient(
+    135deg,
+    transparent 0 7px,
+    rgba(var(--text-color-rgb), 0.12) 7px 8px
+  );
+}
+
+.receiptPaper::before { top: -20px; }
+.receiptPaper::after { bottom: -20px; transform: rotate(180deg); }
+
+.receiptRow {
+  position: relative;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  height: 24px;
+  white-space: nowrap;
+  transition: color 240ms ease;
+}
+
+.receiptRow::before {
+  content: "";
+  position: absolute;
+  left: -0.85rem;
+  width: 3px;
+  height: 3px;
+  border-radius: 50%;
+  background: var(--section-color);
+}
+
+.container [data-section="TRANSACTION_INFO"] { --section-color: var(--color-blue); }
+.container [data-section="ITEMS"] { --section-color: var(--color-purple); }
+.container [data-section="SUMMARY"] { --section-color: var(--color-orange); }
+.container [data-section="PAYMENT"] { --section-color: var(--color-green); }
+
+.receiptSectionRail {
+  position: absolute;
+  top: 1rem;
+  right: 0;
+  width: 4rem;
+  height: calc(100% - 2rem);
+}
+
+.railSegment {
+  position: absolute;
+  left: 0;
+  width: 100%;
+  border-left: 2px solid var(--section-color);
+  transition: opacity 220ms ease;
+}
+
+.railSegment::before,
+.railSegment::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  width: 6px;
+  height: 2px;
+  background: var(--section-color);
+}
+
+.railSegment::before { top: 0; }
+.railSegment::after { bottom: 0; }
+
+.railSegment span {
+  position: absolute;
+  top: 50%;
+  left: 0.55rem;
+  transform: translateY(-50%);
+  color: var(--section-color);
+  font-family: system-ui, sans-serif;
+  font-size: 0.56rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+}
+
+/* Projection -------------------------------------------------------- */
+
+.projectionAct,
+.neighborsAct,
+.decodeAct {
+  padding-top: 2.7rem;
+  padding-bottom: 3rem;
+}
+
+.projectionSvg {
+  width: min(92%, 740px);
+  max-height: 100%;
+  overflow: visible;
+}
+
+.axes path,
+.decodeColumn {
+  fill: none;
+  stroke: rgba(var(--text-color-rgb), 0.12);
+  stroke-width: 1;
+  vector-effect: non-scaling-stroke;
+}
+
+.axes text {
+  fill: rgba(var(--text-color-rgb), 0.42);
+  font-size: 9px;
+  letter-spacing: 0.03em;
+}
+
+.clusterHalo,
+.projectionPoint,
+.queryPoint circle:first-child,
+.correctionHalo {
+  fill: var(--section-color);
+}
+
+.clusterHalo {
+  stroke: var(--section-color);
+  stroke-width: 1;
+  vector-effect: non-scaling-stroke;
+}
+
+.clusterLabel {
+  fill: var(--section-color);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+}
+
+.projectionPoint {
+  stroke: var(--background-color);
+  stroke-width: 1.5;
+  vector-effect: non-scaling-stroke;
+}
+
+.projectionPoint[data-neighbor="true"] {
+  stroke: var(--text-color);
+  stroke-width: 1.2;
+}
+
+.queryPoint {
+  --section-color: var(--text-color);
+}
+
+.queryPoint circle:first-child {
+  stroke: var(--background-color);
+  stroke-width: 3;
+  vector-effect: non-scaling-stroke;
+}
+
+.queryPulse {
+  fill: none;
+  stroke: var(--text-color);
+  stroke-width: 1.5;
+  vector-effect: non-scaling-stroke;
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: query-pulse 1.8s ease-in-out infinite;
+}
+
+.queryPoint text {
+  fill: var(--text-color);
+  paint-order: stroke;
+  stroke: var(--background-color);
+  stroke-width: 4px;
+  stroke-linejoin: round;
+  font-size: 10px;
+  font-weight: 700;
+}
+
+.neighborLine {
+  stroke: var(--section-color);
+  stroke-width: 1.25;
+  vector-effect: non-scaling-stroke;
+}
+
+.queryControl {
+  position: absolute;
+  right: 0;
+  bottom: 0.25rem;
+  left: 0;
+  z-index: 5;
+  display: flex;
+  justify-content: center;
+  gap: 0.42rem;
+}
+
+.queryButton {
+  min-height: 32px;
+  padding: 0.34rem 0.72rem;
+  border: 1px solid rgba(var(--text-color-rgb), 0.16);
+  border-radius: 999px;
+  color: rgba(var(--text-color-rgb), 0.56);
+  background: transparent;
+  font: inherit;
+  font-size: 0.67rem;
+  cursor: pointer;
+  transition: border-color 180ms ease, color 180ms ease, background 180ms ease, transform 180ms ease;
+}
+
+.queryButton:hover,
+.queryButton:focus-visible {
+  color: var(--text-color);
+  border-color: rgba(var(--text-color-rgb), 0.42);
+}
+
+.queryButton:active { transform: scale(0.97); }
+
+.queryButton[data-active="true"] {
+  color: var(--background-color);
+  border-color: var(--text-color);
+  background: var(--text-color);
+}
+
+/* Neighbors --------------------------------------------------------- */
+
+.neighborLayout {
+  display: grid;
+  grid-template-columns: minmax(0, 1.45fr) minmax(180px, 0.55fr);
+  align-items: center;
+  width: 100%;
+  min-height: 0;
+}
+
+.neighborLayout .projectionSvg {
+  width: 100%;
+}
+
+.votePanel {
+  display: flex;
+  flex-direction: column;
+  gap: 0.58rem;
+  padding-right: 0.25rem;
+}
+
+.voteHeader {
+  display: flex;
+  flex-direction: column;
+  color: rgba(var(--text-color-rgb), 0.5);
+  font-size: 0.64rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.voteHeader strong {
+  color: var(--text-color);
+  font-size: 0.72rem;
+}
+
+.voteRow {
+  display: grid;
+  grid-template-columns: 3.2rem minmax(60px, 1fr) 2rem;
+  align-items: center;
+  gap: 0.45rem;
+  color: var(--section-color);
+  font-size: 0.62rem;
+  font-weight: 700;
+}
+
+.voteRow > strong { text-align: right; }
+
+.voteTrack,
+.resultTrack {
+  position: relative;
+  height: 4px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: rgba(var(--text-color-rgb), 0.1);
+}
+
+.voteTrack span {
+  position: absolute;
+  inset: 0 auto 0 0;
+  border-radius: inherit;
+  background: var(--section-color);
+  transition: width 120ms linear;
+}
+
+.weightEquation {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  margin-top: 0.3rem;
+  color: rgba(var(--text-color-rgb), 0.52);
+  font-size: 0.62rem;
+}
+
+.weightEquation span {
+  padding: 0.24rem 0.4rem;
+  border: 1px solid rgba(var(--text-color-rgb), 0.12);
+  border-radius: 4px;
+}
+
+.weightEquation strong { color: var(--text-color); }
+
+/* Decode ------------------------------------------------------------ */
+
+.decodeChart {
+  position: relative;
+  width: min(94%, 720px);
+  height: min(100%, 350px);
+  margin-top: 0.5rem;
+}
+
+.decodeChart svg {
+  display: block;
+  width: 100%;
+  height: 100%;
+  overflow: visible;
+}
+
+.decodeHeader {
+  fill: var(--section-color);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+}
+
+.decodeRowLabel {
+  fill: rgba(var(--text-color-rgb), 0.5);
+  font-size: 8px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+}
+
+.baselinePath,
+.decodedPath {
+  fill: none;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  vector-effect: non-scaling-stroke;
+}
+
+.baselinePath {
+  stroke: var(--color-red);
+  stroke-width: 1.4;
+  stroke-dasharray: 4 5 !important;
+  opacity: 0.58;
+}
+
+.decodedPath {
+  stroke: var(--text-color);
+  stroke-width: 2.5;
+}
+
+.correctionHalo {
+  opacity: 0.22;
+  animation: correction-glow 1.8s ease-in-out infinite;
+}
+
+.decodeComparison {
+  position: absolute;
+  right: 0;
+  bottom: 0.25rem;
+  display: flex;
+  align-items: center;
+  gap: 0.38rem;
+  color: rgba(var(--text-color-rgb), 0.5);
+  font-size: 0.62rem;
+}
+
+.sectionPill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.22rem 0.38rem;
+  border: 1px solid color-mix(in srgb, var(--section-color) 45%, transparent);
+  border-radius: 4px;
+  color: var(--section-color);
+  font-weight: 700;
+}
+
+.sectionPill[data-muted="true"] {
+  text-decoration: line-through;
+  opacity: 0.55;
+}
+
+.sectionDot {
+  width: 0.38rem;
+  height: 0.38rem;
+  border-radius: 50%;
+  background: var(--section-color);
+}
+
+.decodeArrow { color: var(--text-color); }
+
+/* Result ------------------------------------------------------------ */
+
+.resultAct {
+  flex-direction: column;
+  gap: 1.4rem;
+  padding: 4.4rem 0.25rem 1rem;
+}
+
+.resultBars {
+  display: flex;
+  flex-direction: column;
+  gap: 1.15rem;
+  width: min(88%, 650px);
+}
+
+.resultRow {
+  display: grid;
+  grid-template-columns: 7.2rem minmax(120px, 1fr) 4rem;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 0.76rem;
+}
+
+.resultRow > span { color: rgba(var(--text-color-rgb), 0.58); }
+.resultRow > strong { font-size: 1.02rem; text-align: right; }
+
+.resultTrack { height: 8px; }
+.resultTrack > span {
+  position: absolute;
+  inset: 0 auto 0 0;
+  border-radius: inherit;
+  transition: width 120ms linear;
+}
+.baselineFill { background: rgba(var(--text-color-rgb), 0.34); }
+.hybridFill { background: var(--color-green); }
+
+.deltaCallout {
+  display: flex;
+  align-items: baseline;
+  gap: 0.55rem;
+}
+
+.deltaCallout strong {
+  color: var(--color-green);
+  font-size: clamp(2.25rem, 8vw, 4.3rem);
+  line-height: 1;
+  letter-spacing: -0.055em;
+}
+
+.deltaCallout span {
+  color: rgba(var(--text-color-rgb), 0.54);
+  font-size: 0.78rem;
+}
+
+.pairedCounts {
+  display: flex;
+  align-items: center;
+  gap: 2rem;
+}
+
+.pairedCounts > div {
+  display: flex;
+  align-items: baseline;
+  gap: 0.4rem;
+}
+
+.pairedCounts strong { font-size: 1.5rem; }
+.pairedCounts > div:first-child strong { color: var(--color-green); }
+.pairedCounts > div:last-child strong { color: var(--color-red); }
+.pairedCounts span { color: rgba(var(--text-color-rgb), 0.54); font-size: 0.7rem; }
+
+.pairedRule {
+  width: 1px;
+  height: 1.8rem;
+  background: rgba(var(--text-color-rgb), 0.14);
+}
+
+.resultFootnote {
+  margin: 0;
+  color: rgba(var(--text-color-rgb), 0.4);
+  font-size: 0.64rem;
+  text-align: center;
+}
+
+/* Step controls ----------------------------------------------------- */
+
+.progress {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0.08rem;
+  margin: 0.1rem 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.progressButton {
+  position: relative;
+  display: grid;
+  place-items: center;
+  width: 38px;
+  height: 38px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+}
+
+.progressButton span {
+  width: 0.62rem;
+  height: 0.62rem;
+  border-radius: 50%;
+  background: rgba(var(--text-color-rgb), 0.2);
+  transition: background 220ms ease, transform 220ms ease;
+}
+
+.progressButton:hover span,
+.progressButton:focus-visible span { transform: scale(1.35); }
+.progressButton:focus-visible { outline: 2px solid var(--color-blue); outline-offset: -4px; border-radius: 50%; }
+.progressButton[data-done="true"] span { background: rgba(var(--text-color-rgb), 0.48); }
+.progressButton[data-active="true"] span { background: var(--text-color); transform: scale(1.18); }
+
+.staticStack {
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+}
+
+@keyframes layer-in {
+  from { opacity: 0; transform: translateY(12px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes layer-out {
+  from { opacity: 1; transform: translateY(0); }
+  to { opacity: 0; transform: translateY(-12px); }
+}
+
+@keyframes query-pulse {
+  0%, 100% { transform: scale(0.78); opacity: 0.12; }
+  50% { transform: scale(1.18); opacity: 0.55; }
+}
+
+@keyframes correction-glow {
+  0%, 100% { transform: scale(0.76); opacity: 0.1; }
+  50% { transform: scale(1.18); opacity: 0.3; }
+}
+
+@media (max-width: 700px) {
+  .interactiveStage { height: 540px; min-height: 540px; }
+  .staticStage { height: 540px; }
+  .actAnnotation { right: 0.25rem; max-width: none; }
+  .actAnnotation strong { font-size: 0.86rem; }
+  .actAnnotation > span:last-child { font-size: 0.66rem; }
+  .actNumber { font-size: 1.4rem; }
+
+  .receiptPaper {
+    width: min(88%, 390px);
+    padding-right: 3.85rem;
+    font-size: clamp(0.52rem, 2.25vw, 0.68rem);
+  }
+  .receiptSectionRail { width: 3.2rem; }
+  .railSegment span { font-size: 0.48rem; }
+
+  .projectionAct,
+  .neighborsAct,
+  .decodeAct { padding-top: 3.35rem; padding-bottom: 4.1rem; }
+  .projectionSvg { width: 100%; }
+
+  .neighborLayout {
+    grid-template-columns: 1fr;
+    grid-template-rows: minmax(0, 1fr) auto;
+    height: 100%;
+    padding-top: 0.2rem;
+  }
+
+  .neighborLayout .projectionSvg { min-height: 0; }
+  .votePanel {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.42rem 0.7rem;
+    padding: 0 0.45rem;
+  }
+  .voteHeader,
+  .weightEquation { grid-column: 1 / -1; }
+  .voteRow { grid-template-columns: 2.55rem minmax(42px, 1fr) 1.8rem; }
+  .weightEquation { margin-top: 0; }
+
+  .queryControl { flex-wrap: nowrap; gap: 0.3rem; }
+  .queryButton { min-height: 34px; padding: 0.3rem 0.58rem; font-size: 0.61rem; }
+
+  .decodeChart { width: 100%; height: 340px; }
+  .decodeComparison { right: 0.2rem; bottom: -0.3rem; }
+  .resultAct { gap: 1.7rem; padding-top: 4.7rem; }
+  .resultBars { width: 96%; }
+  .resultRow { grid-template-columns: 5.5rem minmax(86px, 1fr) 3.6rem; gap: 0.45rem; font-size: 0.68rem; }
+  .deltaCallout { flex-direction: column; align-items: center; gap: 0.15rem; }
+  .pairedCounts { gap: 0.85rem; }
+  .pairedCounts > div { flex-direction: column; align-items: center; gap: 0; }
+  .resultFootnote { max-width: 19rem; line-height: 1.45; }
+}
+
+@media (max-width: 390px) {
+  .decodeRowLabel { font-size: 7px; }
+  .decodeHeader { font-size: 8px; }
+  .receiptPaper { width: 94%; }
+}
+
+@media (max-width: 350px) {
+  .interactiveStage,
+  .staticStage { height: 575px; min-height: 575px; }
+  .queryControl { flex-wrap: wrap; align-content: flex-end; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .actLayer.entering,
+  .actLayer.leaving,
+  .queryPulse,
+  .correctionHalo { animation: none; }
+  .receiptRow,
+  .railSegment,
+  .queryButton,
+  .progressButton span,
+  .voteTrack span,
+  .resultTrack > span { transition: none; }
+}

--- a/portfolio/components/ui/Figures/SectionEmbeddingExplorer/SectionEmbeddingExplorer.module.css
+++ b/portfolio/components/ui/Figures/SectionEmbeddingExplorer/SectionEmbeddingExplorer.module.css
@@ -25,8 +25,8 @@
 
 .interactiveStage,
 .staticStage {
-  height: 520px;
-  min-height: 520px;
+  height: 590px;
+  min-height: 590px;
 }
 
 .actLayer {
@@ -111,9 +111,7 @@
   border: 1px solid rgba(var(--text-color-rgb), 0.16);
   border-radius: 3px;
   color: var(--text-color);
-  background:
-    linear-gradient(rgba(var(--text-color-rgb), 0.025), rgba(var(--text-color-rgb), 0.008)),
-    var(--background-color);
+  background: #111;
   box-shadow: 0 9px 26px rgba(0, 0, 0, 0.22);
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
   transition:
@@ -160,44 +158,42 @@
 }
 
 .currentReceipt {
-  --row-height: 21px;
-  top: 3.5rem;
-  left: 9%;
+  top: 0.25rem;
+  left: 10.5%;
   z-index: 10;
-  width: 360px;
+  width: 205px;
   transform: translateY(calc((1 - var(--act-progress)) * 10px));
 }
 
 .referenceReceipt {
-  --row-height: 29px;
   z-index: calc(7 - var(--reference-index));
-  width: 185px;
+  width: 118px;
   opacity: 0.24;
   transform: translateY(-8px) rotate(var(--receipt-rotation)) scale(0.94);
   transform-origin: center bottom;
 }
 
 .referenceReceipt[data-reference-index="0"] {
-  top: 2.8rem;
-  left: 46%;
+  top: 0.9rem;
+  left: 48%;
   --receipt-rotation: -2.2deg;
 }
 
 .referenceReceipt[data-reference-index="1"] {
-  top: 4.2rem;
-  left: 59%;
+  top: 3.2rem;
+  left: 61%;
   --receipt-rotation: 2deg;
 }
 
 .referenceReceipt[data-reference-index="2"] {
-  top: 5.9rem;
-  left: 71%;
+  top: 1.8rem;
+  left: 73%;
   --receipt-rotation: -1.6deg;
 }
 
 .referenceReceipt[data-reference-index="3"] {
-  top: 7.8rem;
-  left: 78%;
+  top: 4.8rem;
+  left: 84%;
   --receipt-rotation: 2.2deg;
 }
 
@@ -226,47 +222,81 @@
   transform: translateY(7px) rotate(var(--receipt-rotation)) scale(0.94);
 }
 
-.receiptRows {
+.imagePlane {
   position: relative;
+  width: 100%;
+  overflow: hidden;
+  background: #ece8dd;
 }
 
-.receiptRow {
-  position: relative;
+.imagePlane > img {
+  position: absolute;
+  inset: 0;
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: fill;
+}
+
+.imageShade {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  background: rgba(8, 10, 13, 0.06);
+  pointer-events: none;
+}
+
+.rowBox {
+  position: absolute;
   z-index: 3;
   box-sizing: border-box;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.5rem;
-  height: var(--row-height);
-  padding: 0 0.6rem 0 4.8rem;
-  color: rgba(var(--text-color-rgb), 0.8);
-  font-size: 0.62rem;
-  letter-spacing: 0.008em;
+  min-width: 2px;
+  min-height: 2px;
+  border: 1px solid color-mix(in srgb, var(--section-color, white) 88%, transparent);
+  border-radius: 1px;
+  background: color-mix(in srgb, var(--section-color, white) 9%, transparent);
+  box-shadow: 0 0 0 0.5px rgba(0, 0, 0, 0.28);
   transition:
-    color 300ms ease,
+    top 480ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    height 480ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    border-color 300ms ease,
     background 340ms ease,
     box-shadow 340ms ease,
     opacity 240ms ease,
     transform 240ms ease;
 }
 
-.receiptRow > span:first-child {
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
+.rowBox .rowStatus,
+.rowBox .neighborScore {
+  position: absolute;
+  top: -8px;
+  right: -1px;
+  z-index: 8;
+  border-radius: 999px;
+  font-family: system-ui, sans-serif;
+  font-size: 0.38rem;
+  font-weight: 750;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.04em;
+  line-height: 1;
   white-space: nowrap;
 }
 
-.receiptRow > span:last-child:not(:first-child) {
-  flex: 0 0 auto;
-  font-variant-numeric: tabular-nums;
+.rowBox .rowStatus {
+  padding: 0.14rem 0.23rem;
+  color: var(--section-color);
+  background: color-mix(in srgb, var(--section-color) 18%, #161616);
 }
 
-.referenceReceipt .receiptRow {
-  padding-right: 0.45rem;
-  padding-left: 3.5rem;
-  font-size: 0.47rem;
+.rowBox .neighborScore {
+  top: -9px;
+  padding: 0.13rem 0.22rem;
+  color: var(--section-color);
+  background: color-mix(in srgb, var(--section-color) 18%, #161616);
+}
+
+.referenceReceipt .rowBox {
+  border-width: 0.75px;
 }
 
 .sectionBands {
@@ -278,10 +308,9 @@
 
 .sectionBand {
   position: absolute;
-  top: calc(var(--band-start) * var(--row-height));
-  right: 0.35rem;
-  left: 0.35rem;
-  height: calc(var(--band-length) * var(--row-height));
+  right: 0.18rem;
+  left: 0.18rem;
+  min-height: 2px;
   overflow: hidden;
   border-top: 1px solid color-mix(in srgb, var(--section-color) 28%, transparent);
   border-bottom: 1px solid color-mix(in srgb, var(--section-color) 28%, transparent);
@@ -295,49 +324,58 @@
 
 .sectionBand span {
   position: absolute;
-  top: 50%;
-  left: 0.48rem;
-  width: 3.5rem;
-  transform: translateY(-50%);
+  top: 0.16rem;
+  left: 0.3rem;
   color: var(--section-color);
   font-family: system-ui, sans-serif;
-  font-size: 0.5rem;
+  font-size: 0.41rem;
   font-weight: 700;
   letter-spacing: 0.035em;
+  line-height: 1;
+  text-shadow: 0 1px 2px #fff, 0 0 2px #fff;
 }
 
 .sectionBand[data-compact="true"] span {
-  left: 0.35rem;
-  width: 2.7rem;
-  font-size: 0.38rem;
+  top: 0.1rem;
+  left: 0.18rem;
+  font-size: 0.28rem;
 }
 
-.scene[data-act="baseline"] .currentReceipt .receiptRow[data-row-id="subtotal"],
-.scene[data-act="baseline"] .currentReceipt .receiptRow[data-row-id="visa"] {
-  box-shadow: inset 3px 0 var(--color-red);
+.scene[data-act="baseline"] .currentReceipt .rowBox[data-baseline-error="true"] {
+  border-color: var(--color-red);
+  box-shadow: 0 0 0 1px var(--color-red), 0 0 9px color-mix(in srgb, var(--color-red) 46%, transparent);
 }
 
-.receiptRow[data-neighbor="true"] {
+.rowBox[data-neighbor="true"] {
   z-index: 6;
-  color: var(--text-color);
-  background: color-mix(in srgb, var(--section-color) 14%, transparent);
+  background: color-mix(in srgb, var(--section-color) 20%, transparent);
   box-shadow:
-    inset 0 0 0 1px color-mix(in srgb, var(--section-color) 72%, transparent),
+    0 0 0 1px color-mix(in srgb, var(--section-color) 88%, transparent),
     0 0 15px color-mix(in srgb, var(--section-color) 22%, transparent);
 }
 
-.currentReceipt .receiptRow[data-neighbor="true"] {
+.currentReceipt .rowBox[data-neighbor="true"] {
   animation: neighbor-glow 1.8s ease-in-out infinite;
 }
 
-.receiptRow[data-changed="true"] {
+.rowBox[data-changed="true"] {
   z-index: 6;
-  color: var(--text-color);
-  background: rgba(var(--text-color-rgb), 0.035);
-  box-shadow: inset 0 0 0 1px rgba(var(--text-color-rgb), 0.74);
+  background: color-mix(in srgb, var(--section-color) 15%, transparent);
+  box-shadow: 0 0 0 1px rgba(var(--text-color-rgb), 0.88), 0 0 9px rgba(0, 0, 0, 0.3);
 }
 
-.scene[data-act="corrected"] .receiptRow[data-changed="true"] {
+.rowBox[data-unresolved="true"] {
+  background: color-mix(in srgb, var(--color-red) 8%, transparent);
+  border-color: var(--color-red);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--color-red) 78%, transparent);
+}
+
+.rowBox[data-unresolved="true"] .rowStatus {
+  color: var(--color-red);
+  background: color-mix(in srgb, var(--color-red) 13%, var(--background-color));
+}
+
+.scene[data-act="corrected"] .rowBox[data-changed="true"] {
   animation: corrected-row 820ms ease both;
 }
 
@@ -432,6 +470,15 @@
   color: rgba(var(--text-color-rgb), 0.48);
   font-size: 0.64rem;
   line-height: 1.3;
+}
+
+.snapshotTag {
+  margin-left: auto;
+  color: rgba(var(--text-color-rgb), 0.34);
+  font-size: 0.55rem;
+  letter-spacing: 0.035em;
+  text-transform: uppercase;
+  white-space: nowrap;
 }
 
 .evidenceRule {
@@ -532,8 +579,8 @@
 @media (max-width: 700px) {
   .interactiveStage,
   .staticStage {
-    height: 560px;
-    min-height: 560px;
+    height: 650px;
+    min-height: 650px;
   }
 
   .actAnnotation {
@@ -558,45 +605,23 @@
   }
 
   .currentReceipt {
-    --row-height: 19px;
-    top: 7.25rem;
-    left: 1rem;
-    width: min(290px, calc(100% - 2rem));
-  }
-
-  .currentReceipt .receiptRow {
-    padding-left: 4rem;
-    font-size: 0.54rem;
-  }
-
-  .currentReceipt .sectionBand span {
-    width: 3rem;
-    font-size: 0.43rem;
+    top: 2.75rem;
+    left: 0.9rem;
+    width: min(220px, calc(100% - 2rem));
   }
 
   .referenceReceipt {
-    --row-height: 24px;
-    width: 145px;
-  }
-
-  .referenceReceipt .receiptRow {
-    padding-left: 2.8rem;
-    font-size: 0.4rem;
-  }
-
-  .referenceReceipt .sectionBand span {
-    width: 2.2rem;
-    font-size: 0.32rem;
+    width: 104px;
   }
 
   .referenceReceipt[data-reference-index="0"] {
-    top: 1.5rem;
-    left: 28%;
+    top: 0.7rem;
+    left: 44%;
   }
 
   .referenceReceipt[data-reference-index="1"] {
-    top: 3rem;
-    left: 59%;
+    top: 2.4rem;
+    left: 69%;
   }
 
   .referenceReceipt[data-reference-index="2"],
@@ -612,32 +637,37 @@
   .evidenceLine {
     font-size: 0.58rem;
   }
+
+  .snapshotTag {
+    display: none;
+  }
 }
 
 @media (max-width: 390px) {
   .currentReceipt {
     left: 0.75rem;
-    width: calc(100% - 1.5rem);
+    width: min(220px, calc(100% - 1.5rem));
   }
 
   .referenceReceipt[data-reference-index="0"] {
-    left: 23%;
+    left: 43%;
   }
 
   .referenceReceipt[data-reference-index="1"] {
-    left: 57%;
+    left: 68%;
   }
 }
 
 @media (max-width: 350px) {
   .interactiveStage,
   .staticStage {
-    height: 585px;
-    min-height: 585px;
+    height: 665px;
+    min-height: 665px;
   }
 
   .currentReceipt {
-    top: 7.9rem;
+    top: 3.2rem;
+    width: 205px;
   }
 
   .evidenceLine {
@@ -648,14 +678,14 @@
 @media (prefers-reduced-motion: reduce) {
   .actLayer.entering,
   .actLayer.leaving,
-  .currentReceipt .receiptRow[data-neighbor="true"],
-  .scene[data-act="corrected"] .receiptRow[data-changed="true"],
+  .currentReceipt .rowBox[data-neighbor="true"],
+  .scene[data-act="corrected"] .rowBox[data-changed="true"],
   .neighborConnections path {
     animation: none;
   }
 
   .receiptCard,
-  .receiptRow,
+  .rowBox,
   .sectionBand,
   .progressButton span,
   .embeddingInset {

--- a/portfolio/components/ui/Figures/SectionEmbeddingExplorer/SectionEmbeddingExplorer.test.tsx
+++ b/portfolio/components/ui/Figures/SectionEmbeddingExplorer/SectionEmbeddingExplorer.test.tsx
@@ -1,0 +1,97 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import SectionEmbeddingExplorer, { advanceExplorerAutoplay } from ".";
+import {
+  EXPLORER_ACTS,
+  nearestProjectionPoints,
+  QUERY_BY_ID,
+} from "./sectionData";
+
+jest.mock("react-intersection-observer", () => ({
+  useInView: () => ({ ref: jest.fn(), inView: true }),
+}));
+
+let reducedMotion = false;
+
+beforeEach(() => {
+  jest.spyOn(window, "requestAnimationFrame").mockImplementation(() => 0);
+  jest.spyOn(window, "cancelAnimationFrame").mockImplementation(() => {});
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: () => ({
+      matches: reducedMotion,
+      media: "(prefers-reduced-motion: reduce)",
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+    }),
+  });
+});
+
+afterEach(() => {
+  reducedMotion = false;
+  jest.restoreAllMocks();
+});
+
+test("autoplay math advances and wraps with its remainder", () => {
+  expect(advanceExplorerAutoplay(1, 0.2, 1400, 7000, 5)).toEqual({
+    activeAct: 1,
+    actProgress: 0.4,
+  });
+  const wrapped = advanceExplorerAutoplay(4, 0.9, 1800, 9000, 5);
+  expect(wrapped.activeAct).toBe(0);
+  expect(wrapped.actProgress).toBeCloseTo(0.1, 5);
+});
+
+test("the explainer opens on ordered receipt rows and exposes five steps", () => {
+  render(<SectionEmbeddingExplorer />);
+  expect(screen.getByTestId("section-embedding-explorer")).toHaveAttribute(
+    "data-mode",
+    "autoplay",
+  );
+  expect(screen.getByTestId("section-act-receipt")).toBeInTheDocument();
+  expect(screen.getAllByTestId(/section-act-dot-/)).toHaveLength(
+    EXPLORER_ACTS.length,
+  );
+});
+
+test("manual navigation resolves an act and row choices update neighbor votes", () => {
+  render(<SectionEmbeddingExplorer />);
+  fireEvent.click(screen.getByTestId("section-act-dot-2"));
+  expect(screen.getByTestId("section-act-neighbors")).toBeInTheDocument();
+  fireEvent.click(screen.getByRole("button", { name: "VISA •••• 1234" }));
+  expect(screen.getByRole("button", { name: "VISA •••• 1234" })).toHaveAttribute(
+    "aria-pressed",
+    "true",
+  );
+  expect(screen.getByText("85%")).toBeInTheDocument();
+});
+
+test("the result act reports the measured held-out comparison", () => {
+  render(<SectionEmbeddingExplorer />);
+  fireEvent.click(screen.getByTestId("section-act-dot-4"));
+  expect(screen.getByText("85.95%")).toBeInTheDocument();
+  expect(screen.getByText("90.84%")).toBeInTheDocument();
+  expect(screen.getByText("+4.89 pp")).toBeInTheDocument();
+});
+
+test("reduced motion renders every step as a resolved static stack", () => {
+  reducedMotion = true;
+  render(<SectionEmbeddingExplorer />);
+  expect(screen.getByTestId("section-embedding-explorer")).toHaveAttribute(
+    "data-mode",
+    "static",
+  );
+  expect(screen.getByTestId("section-act-receipt")).toBeInTheDocument();
+  expect(screen.getByTestId("section-act-projection")).toBeInTheDocument();
+  expect(screen.getByTestId("section-act-neighbors")).toBeInTheDocument();
+  expect(screen.getByTestId("section-act-decode")).toBeInTheDocument();
+  expect(screen.getByTestId("section-act-result")).toBeInTheDocument();
+});
+
+test("the neighborhood contains exactly 15 rows from other merchants", () => {
+  const neighbors = nearestProjectionPoints(QUERY_BY_ID.subtotal);
+  expect(neighbors).toHaveLength(15);
+  expect(neighbors.every((neighbor) => neighbor.merchant !== "Sprouts")).toBe(
+    true,
+  );
+});
+

--- a/portfolio/components/ui/Figures/SectionEmbeddingExplorer/SectionEmbeddingExplorer.test.tsx
+++ b/portfolio/components/ui/Figures/SectionEmbeddingExplorer/SectionEmbeddingExplorer.test.tsx
@@ -37,75 +37,120 @@ test("autoplay math advances and wraps with its remainder", () => {
   expect(wrapped.actProgress).toBeCloseTo(0.1, 5);
 });
 
-test("opens on unassigned Apple OCR rows and exposes five steps", () => {
+test("opens on unassigned real Apple OCR rows and exposes five steps", () => {
   render(<SectionEmbeddingExplorer />);
   expect(screen.getByTestId("section-embedding-explorer")).toHaveAttribute(
     "data-mode",
     "autoplay",
   );
   expect(screen.getByTestId("section-act-ocr")).toBeInTheDocument();
-  expect(screen.getByTestId("section-row-subtotal")).not.toHaveAttribute(
+  expect(screen.getByTestId("section-row-row-11")).not.toHaveAttribute(
     "data-section",
   );
+  expect(screen.getByTestId("section-current-receipt")).toHaveAttribute(
+    "data-source-id",
+    "d47b0f01 · R1",
+  );
+  expect(screen.getAllByText("Salt & Straw").length).toBeGreaterThan(0);
   expect(screen.getByText(/LayoutLM labels words separately/)).toBeInTheDocument();
   expect(screen.getAllByTestId(/section-act-dot-/)).toHaveLength(
     EXPLORER_ACTS.length,
   );
 });
 
+test("renders the real receipt image and positions row overlays from stored geometry", () => {
+  render(<SectionEmbeddingExplorer />);
+  const image = screen.getByTestId("section-current-image");
+  expect(image).toHaveAttribute(
+    "src",
+    expect.stringContaining(
+      "/assets/d47b0f01-859d-499b-a9b0-4feb312b4d27/1.webp",
+    ),
+  );
+  expect(image).toHaveAttribute("width", "425");
+  expect(image).toHaveAttribute("height", "884");
+
+  const subtotalBox = screen.getByTestId("section-row-row-11");
+  expect(parseFloat(subtotalBox.style.left)).toBeCloseTo(8.4592, 3);
+  expect(parseFloat(subtotalBox.style.top)).toBeCloseTo(50.2907, 3);
+  expect(parseFloat(subtotalBox.style.width)).toBeCloseTo(17.5227, 3);
+  expect(parseFloat(subtotalBox.style.height)).toBeCloseTo(2.3256, 3);
+  expect(subtotalBox).toHaveAccessibleName(/OCR row 11: Subtotal/);
+});
+
 test.each([
   [0, "section-act-ocr", undefined, undefined],
-  [1, "section-act-baseline", "ITEMS", "SUMMARY"],
-  [2, "section-act-neighbors", "ITEMS", "SUMMARY"],
+  [1, "section-act-baseline", "TRANSACTION_INFO", "TRANSACTION_INFO"],
+  [2, "section-act-neighbors", "TRANSACTION_INFO", "TRANSACTION_INFO"],
   [3, "section-act-corrected", "SUMMARY", "PAYMENT"],
   [4, "section-act-final", "SUMMARY", "PAYMENT"],
 ] as const)(
   "manual step %i renders its resolved receipt assignments",
-  (index, actTestId, subtotalSection, visaSection) => {
+  (index, actTestId, subtotalSection, paymentSection) => {
     render(<SectionEmbeddingExplorer />);
     fireEvent.click(screen.getByTestId(`section-act-dot-${index}`));
     const act = screen.getByTestId(actTestId);
     expect(act).toBeInTheDocument();
-    const subtotal = within(act).getByTestId("section-row-subtotal");
-    const visa = within(act).getByTestId("section-row-visa");
+    const subtotal = within(act).getByTestId("section-row-row-11");
+    const paymentTime = within(act).getByTestId("section-row-row-34");
     if (subtotalSection) {
       expect(subtotal).toHaveAttribute("data-section", subtotalSection);
-      expect(visa).toHaveAttribute("data-section", visaSection);
+      expect(paymentTime).toHaveAttribute("data-section", paymentSection);
     } else {
       expect(subtotal).not.toHaveAttribute("data-section");
-      expect(visa).not.toHaveAttribute("data-section");
+      expect(paymentTime).not.toHaveAttribute("data-section");
     }
   },
 );
 
-test("neighbor step shows the labeled stack and row search provenance", () => {
+test("neighbor step shows real labeled receipts and measured search provenance", () => {
   render(<SectionEmbeddingExplorer />);
   fireEvent.click(screen.getByTestId("section-act-dot-2"));
   const act = screen.getByTestId("section-act-neighbors");
   expect(within(act).getAllByTestId(/section-reference-receipt-/)).toHaveLength(4);
-  expect(within(act).getByText(/OpenAI creates row embeddings/)).toBeInTheDocument();
-  expect(within(act).getByText(/2-D map is schematic, not literal/)).toBeInTheDocument();
+  expect(within(act).getAllByTestId(/section-reference-image-/)).toHaveLength(4);
+  expect(within(act).getByText("Mouthful Eatery")).toBeInTheDocument();
+  expect(within(act).getByText("Aloha Sunrise Cafe")).toBeInTheDocument();
+  expect(within(act).getAllByText("0.901").length).toBeGreaterThan(0);
+  expect(within(act).getByText(/OpenAI created the row embeddings/)).toBeInTheDocument();
+  expect(within(act).getByText(/2-D map is schematic/)).toBeInTheDocument();
   expect(document.querySelectorAll('[data-neighbor="true"]').length).toBeGreaterThan(4);
 });
 
-test("corrected and final steps mark both rows that changed", () => {
+test("corrected and final steps keep six fixes and one unresolved row honest", () => {
   render(<SectionEmbeddingExplorer />);
   fireEvent.click(screen.getByTestId("section-act-dot-3"));
   const correctedAct = screen.getByTestId("section-act-corrected");
-  expect(within(correctedAct).getByTestId("section-row-subtotal")).toHaveAttribute(
-    "data-changed",
+  expect(within(correctedAct).getByTestId("section-row-row-11")).toHaveAttribute(
+    "data-corrected",
     "true",
   );
-  expect(within(correctedAct).getByTestId("section-row-visa")).toHaveAttribute(
-    "data-changed",
+  expect(within(correctedAct).getByTestId("section-row-row-34")).toHaveAttribute(
+    "data-corrected",
     "true",
   );
+  expect(within(correctedAct).getByTestId("section-row-row-31")).toHaveAttribute(
+    "data-unresolved",
+    "true",
+  );
+  expect(correctedAct.querySelectorAll('[data-corrected="true"]')).toHaveLength(6);
+  expect(correctedAct.querySelectorAll('[data-unresolved="true"]')).toHaveLength(1);
   expect(within(correctedAct).getByText(/geometry ×0.0/)).toBeInTheDocument();
 
   fireEvent.click(screen.getByTestId("section-act-dot-4"));
+  const finalAct = screen.getByTestId("section-act-final");
   expect(
-    within(screen.getByTestId("section-act-final")).getByText(
-      /held-out row agreement \+4.89 pp/,
+    within(finalAct).getByTestId("section-current-receipt").querySelectorAll(
+      '[data-testid="section-band"]',
+    ),
+  ).toHaveLength(4);
+  expect(within(finalAct).getByTestId("section-row-row-31")).toHaveAttribute(
+    "data-section",
+    "PAYMENT",
+  );
+  expect(
+    within(finalAct).getByText(
+      /held-out agreement \+4.89 pp/,
     ),
   ).toBeInTheDocument();
 });

--- a/portfolio/components/ui/Figures/SectionEmbeddingExplorer/SectionEmbeddingExplorer.test.tsx
+++ b/portfolio/components/ui/Figures/SectionEmbeddingExplorer/SectionEmbeddingExplorer.test.tsx
@@ -1,10 +1,6 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import SectionEmbeddingExplorer, { advanceExplorerAutoplay } from ".";
-import {
-  EXPLORER_ACTS,
-  nearestProjectionPoints,
-  QUERY_BY_ID,
-} from "./sectionData";
+import { EXPLORER_ACTS } from "./sectionData";
 
 jest.mock("react-intersection-observer", () => ({
   useInView: () => ({ ref: jest.fn(), inView: true }),
@@ -32,45 +28,102 @@ afterEach(() => {
 });
 
 test("autoplay math advances and wraps with its remainder", () => {
-  expect(advanceExplorerAutoplay(1, 0.2, 1400, 7000, 5)).toEqual({
+  expect(advanceExplorerAutoplay(1, 0.2, 1360, 6800, 5)).toEqual({
     activeAct: 1,
     actProgress: 0.4,
   });
-  const wrapped = advanceExplorerAutoplay(4, 0.9, 1800, 9000, 5);
+  const wrapped = advanceExplorerAutoplay(4, 0.9, 1640, 8200, 5);
   expect(wrapped.activeAct).toBe(0);
   expect(wrapped.actProgress).toBeCloseTo(0.1, 5);
 });
 
-test("the explainer opens on ordered receipt rows and exposes five steps", () => {
+test("opens on unassigned Apple OCR rows and exposes five steps", () => {
   render(<SectionEmbeddingExplorer />);
   expect(screen.getByTestId("section-embedding-explorer")).toHaveAttribute(
     "data-mode",
     "autoplay",
   );
-  expect(screen.getByTestId("section-act-receipt")).toBeInTheDocument();
+  expect(screen.getByTestId("section-act-ocr")).toBeInTheDocument();
+  expect(screen.getByTestId("section-row-subtotal")).not.toHaveAttribute(
+    "data-section",
+  );
+  expect(screen.getByText(/LayoutLM labels words separately/)).toBeInTheDocument();
   expect(screen.getAllByTestId(/section-act-dot-/)).toHaveLength(
     EXPLORER_ACTS.length,
   );
 });
 
-test("manual navigation resolves an act and row choices update neighbor votes", () => {
+test.each([
+  [0, "section-act-ocr", undefined, undefined],
+  [1, "section-act-baseline", "ITEMS", "SUMMARY"],
+  [2, "section-act-neighbors", "ITEMS", "SUMMARY"],
+  [3, "section-act-corrected", "SUMMARY", "PAYMENT"],
+  [4, "section-act-final", "SUMMARY", "PAYMENT"],
+] as const)(
+  "manual step %i renders its resolved receipt assignments",
+  (index, actTestId, subtotalSection, visaSection) => {
+    render(<SectionEmbeddingExplorer />);
+    fireEvent.click(screen.getByTestId(`section-act-dot-${index}`));
+    const act = screen.getByTestId(actTestId);
+    expect(act).toBeInTheDocument();
+    const subtotal = within(act).getByTestId("section-row-subtotal");
+    const visa = within(act).getByTestId("section-row-visa");
+    if (subtotalSection) {
+      expect(subtotal).toHaveAttribute("data-section", subtotalSection);
+      expect(visa).toHaveAttribute("data-section", visaSection);
+    } else {
+      expect(subtotal).not.toHaveAttribute("data-section");
+      expect(visa).not.toHaveAttribute("data-section");
+    }
+  },
+);
+
+test("neighbor step shows the labeled stack and row search provenance", () => {
   render(<SectionEmbeddingExplorer />);
   fireEvent.click(screen.getByTestId("section-act-dot-2"));
-  expect(screen.getByTestId("section-act-neighbors")).toBeInTheDocument();
-  fireEvent.click(screen.getByRole("button", { name: "VISA •••• 1234" }));
-  expect(screen.getByRole("button", { name: "VISA •••• 1234" })).toHaveAttribute(
-    "aria-pressed",
-    "true",
-  );
-  expect(screen.getByText("85%")).toBeInTheDocument();
+  const act = screen.getByTestId("section-act-neighbors");
+  expect(within(act).getAllByTestId(/section-reference-receipt-/)).toHaveLength(4);
+  expect(within(act).getByText(/OpenAI creates row embeddings/)).toBeInTheDocument();
+  expect(within(act).getByText(/2-D map is schematic, not literal/)).toBeInTheDocument();
+  expect(document.querySelectorAll('[data-neighbor="true"]').length).toBeGreaterThan(4);
 });
 
-test("the result act reports the measured held-out comparison", () => {
+test("corrected and final steps mark both rows that changed", () => {
   render(<SectionEmbeddingExplorer />);
+  fireEvent.click(screen.getByTestId("section-act-dot-3"));
+  const correctedAct = screen.getByTestId("section-act-corrected");
+  expect(within(correctedAct).getByTestId("section-row-subtotal")).toHaveAttribute(
+    "data-changed",
+    "true",
+  );
+  expect(within(correctedAct).getByTestId("section-row-visa")).toHaveAttribute(
+    "data-changed",
+    "true",
+  );
+  expect(within(correctedAct).getByText(/geometry ×0.0/)).toBeInTheDocument();
+
   fireEvent.click(screen.getByTestId("section-act-dot-4"));
-  expect(screen.getByText("85.95%")).toBeInTheDocument();
-  expect(screen.getByText("90.84%")).toBeInTheDocument();
-  expect(screen.getByText("+4.89 pp")).toBeInTheDocument();
+  expect(
+    within(screen.getByTestId("section-act-final")).getByText(
+      /held-out row agreement \+4.89 pp/,
+    ),
+  ).toBeInTheDocument();
+});
+
+test("arrow, Home, and End keys select and focus resolved steps", () => {
+  render(<SectionEmbeddingExplorer />);
+  const first = screen.getByTestId("section-act-dot-0");
+  first.focus();
+  fireEvent.keyDown(first, { key: "ArrowRight" });
+  expect(screen.getByTestId("section-act-dot-1")).toHaveFocus();
+  expect(screen.getByTestId("section-act-baseline")).toBeInTheDocument();
+
+  fireEvent.keyDown(screen.getByTestId("section-act-dot-1"), { key: "End" });
+  expect(screen.getByTestId("section-act-dot-4")).toHaveFocus();
+  expect(screen.getByTestId("section-act-final")).toBeInTheDocument();
+
+  fireEvent.keyDown(screen.getByTestId("section-act-dot-4"), { key: "Home" });
+  expect(screen.getByTestId("section-act-dot-0")).toHaveFocus();
 });
 
 test("reduced motion renders every step as a resolved static stack", () => {
@@ -80,18 +133,7 @@ test("reduced motion renders every step as a resolved static stack", () => {
     "data-mode",
     "static",
   );
-  expect(screen.getByTestId("section-act-receipt")).toBeInTheDocument();
-  expect(screen.getByTestId("section-act-projection")).toBeInTheDocument();
-  expect(screen.getByTestId("section-act-neighbors")).toBeInTheDocument();
-  expect(screen.getByTestId("section-act-decode")).toBeInTheDocument();
-  expect(screen.getByTestId("section-act-result")).toBeInTheDocument();
+  for (const act of EXPLORER_ACTS) {
+    expect(screen.getByTestId(`section-act-${act.id}`)).toBeInTheDocument();
+  }
 });
-
-test("the neighborhood contains exactly 15 rows from other merchants", () => {
-  const neighbors = nearestProjectionPoints(QUERY_BY_ID.subtotal);
-  expect(neighbors).toHaveLength(15);
-  expect(neighbors.every((neighbor) => neighbor.merchant !== "Sprouts")).toBe(
-    true,
-  );
-});
-

--- a/portfolio/components/ui/Figures/SectionEmbeddingExplorer/index.tsx
+++ b/portfolio/components/ui/Figures/SectionEmbeddingExplorer/index.tsx
@@ -1,19 +1,22 @@
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, {
+  KeyboardEvent,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import { useInView } from "react-intersection-observer";
 import { useActTransition } from "../SynthesisPipeline/actTransition";
 import styles from "./SectionEmbeddingExplorer.module.css";
 import {
+  CHANGED_ROW_IDS,
   EXPLORER_ACTS,
   EXPERIMENT_METRICS,
   ExplorerActId,
-  nearestProjectionPoints,
-  PROJECTION_POINTS,
-  QUERY_BY_ID,
-  QUERY_SCENARIOS,
-  QueryScenario,
   RECEIPT_ROWS,
+  REFERENCE_RECEIPTS,
+  ReferenceReceipt,
   SECTION_BY_ID,
-  SECTIONS,
   SectionId,
 } from "./sectionData";
 
@@ -21,6 +24,7 @@ const AUTOPLAY_IDLE_RESUME_MS = 10_000;
 
 const usePrefersReducedMotion = (): boolean => {
   const [reduced, setReduced] = useState(false);
+
   useEffect(() => {
     if (typeof window.matchMedia !== "function") return;
     const media = window.matchMedia("(prefers-reduced-motion: reduce)");
@@ -29,6 +33,7 @@ const usePrefersReducedMotion = (): boolean => {
     media.addEventListener?.("change", onChange);
     return () => media.removeEventListener?.("change", onChange);
   }, []);
+
   return reduced;
 };
 
@@ -47,6 +52,7 @@ export const advanceExplorerAutoplay = (
   if (dwellMs <= 0 || actCount <= 0) {
     return { activeAct, actProgress: 1 };
   }
+
   let progress = Math.max(0, actProgress + dtMs / dwellMs);
   let act = activeAct;
   while (progress >= 1) {
@@ -63,74 +69,154 @@ const phase = (value: number, start: number, end: number): number => {
   return t * t * (3 - 2 * t);
 };
 
-const rowY = (index: number): number => 52 + index * 24;
-const sectionX = (section: SectionId): number =>
-  190 + SECTIONS.findIndex((candidate) => candidate.id === section) * 110;
+type Assignment = SectionId | null;
 
-interface ScenarioControlProps {
-  selected: QueryScenario["id"];
-  onSelect: (id: QueryScenario["id"]) => void;
+interface SectionSpan {
+  section: SectionId;
+  start: number;
+  length: number;
 }
 
-const ScenarioControl: React.FC<ScenarioControlProps> = ({
-  selected,
-  onSelect,
+const sectionSpans = (assignments: Assignment[]): SectionSpan[] => {
+  const spans: SectionSpan[] = [];
+  assignments.forEach((section, index) => {
+    if (!section) return;
+    const previous = spans[spans.length - 1];
+    if (previous?.section === section && previous.start + previous.length === index) {
+      previous.length += 1;
+      return;
+    }
+    spans.push({ section, start: index, length: 1 });
+  });
+  return spans;
+};
+
+const assignmentsForAct = (
+  actId: ExplorerActId,
+  progress: number,
+): Assignment[] => {
+  if (actId === "ocr") return RECEIPT_ROWS.map(() => null);
+  if (actId === "baseline" || actId === "neighbors") {
+    return RECEIPT_ROWS.map((row) => row.baseline);
+  }
+  if (actId === "final") return RECEIPT_ROWS.map((row) => row.truth);
+
+  return RECEIPT_ROWS.map((row) => {
+    if (row.id === "subtotal" && progress >= 0.38) return row.truth;
+    if (row.id === "visa" && progress >= 0.67) return row.truth;
+    return row.baseline;
+  });
+};
+
+const ACT_COPY: Record<
+  ExplorerActId,
+  { title: string; detail: string; evidence: string; sceneLabel: string }
+> = {
+  ocr: {
+    title: "Start with complete Apple OCR rows.",
+    detail: "LayoutLM labels words separately. This pass assigns one section to each complete row.",
+    evidence: "LayoutLM → words · section decoder → rows",
+    sceneLabel: "Apple OCR rows are visible on the current receipt without section assignments.",
+  },
+  baseline: {
+    title: "Let the fair baseline draw its boundaries.",
+    detail: "Two row-by-row guesses push ITEMS and SUMMARY one row too far.",
+    evidence: "merchant identity · helpful, optional",
+    sceneLabel: "Baseline section bands contain incorrect boundaries at subtotal and Visa rows.",
+  },
+  neighbors: {
+    title: "Search labeled rows from other receipts.",
+    detail: "OpenAI creates row embeddings; Chroma finds the nearest labeled rows.",
+    evidence: "4 of 15 neighbors shown · 2-D map is schematic, not literal",
+    sceneLabel: "Similar subtotal and payment rows are highlighted across the labeled receipt stack.",
+  },
+  corrected: {
+    title: "Move the assignments downstream.",
+    detail: "Neighbor votes and sequence order correct rows, then redraw contiguous boundaries.",
+    evidence: "experimental geometry ×0.0 · receipt math ×0.0",
+    sceneLabel: "Subtotal moves from items to summary and Visa moves from summary to payment.",
+  },
+  final: {
+    title: "Finish with one clean section sequence.",
+    detail: "The outlined rows changed; every section is contiguous on the front receipt.",
+    evidence: `held-out row agreement +${EXPERIMENT_METRICS.deltaPoints} pp · ${EXPERIMENT_METRICS.fixed} fixed`,
+    sceneLabel: "The current receipt has clean contiguous bands and highlights the two changed rows.",
+  },
+};
+
+interface SectionBandsProps {
+  assignments: Assignment[];
+  opacity: number;
+  compact?: boolean;
+}
+
+const SectionBands: React.FC<SectionBandsProps> = ({
+  assignments,
+  opacity,
+  compact = false,
 }) => (
-  <div className={styles.queryControl} aria-label="Row to classify">
-    {QUERY_SCENARIOS.map((scenario) => (
-      <button
-        key={scenario.id}
-        type="button"
-        className={styles.queryButton}
-        data-active={selected === scenario.id}
-        aria-pressed={selected === scenario.id}
-        onClick={() => onSelect(scenario.id)}
+  <div className={styles.sectionBands} aria-hidden="true">
+    {sectionSpans(assignments).map((span, index) => (
+      <div
+        key={`${span.section}-${span.start}-${index}`}
+        className={styles.sectionBand}
+        data-section={span.section}
+        data-compact={compact || undefined}
+        style={
+          {
+            "--band-start": span.start,
+            "--band-length": span.length,
+            opacity,
+          } as React.CSSProperties
+        }
       >
-        {scenario.label}
-      </button>
+        <span>{SECTION_BY_ID[span.section].shortLabel}</span>
+      </div>
     ))}
   </div>
 );
 
-const SectionPill: React.FC<{ section: SectionId; muted?: boolean }> = ({
-  section,
-  muted = false,
-}) => (
-  <span
-    className={styles.sectionPill}
-    data-section={section}
-    data-muted={muted || undefined}
-  >
-    <span className={styles.sectionDot} aria-hidden="true" />
-    {SECTION_BY_ID[section].shortLabel}
-  </span>
-);
-
-interface ActProps extends ScenarioControlProps {
+interface CurrentReceiptProps {
+  actId: ExplorerActId;
   progress: number;
-  reducedMotion: boolean;
 }
 
-const ReceiptAct: React.FC<ActProps> = ({ progress, reducedMotion }) => {
-  const p = reducedMotion ? 1 : progress;
+const CurrentReceipt: React.FC<CurrentReceiptProps> = ({ actId, progress }) => {
+  const assignments = assignmentsForAct(actId, progress);
+  const bandsVisible = actId === "ocr" ? phase(progress, 1.1, 1.2) : phase(progress, 0.08, 0.42);
+  const rowReveal = actId === "ocr" ? progress : 1;
+  const showNeighbors = actId === "neighbors";
+  const showChanges = actId === "corrected" || actId === "final";
+
   return (
-    <div className={styles.receiptAct} data-testid="section-act-receipt">
-      <div className={styles.actAnnotation}>
-        <span className={styles.actNumber}>01</span>
-        <strong>Keep the receipt in reading order.</strong>
-        <span>Each line is one row the decoder must place.</span>
+    <div
+      className={`${styles.receiptCard} ${styles.currentReceipt}`}
+      data-testid="section-current-receipt"
+      data-assignment={actId}
+      aria-hidden="true"
+    >
+      <div className={styles.receiptHeader}>
+        <strong>SPROUTS</strong>
+        <span>{actId === "ocr" ? "APPLE OCR" : "CURRENT"}</span>
       </div>
-      <div className={styles.receiptPaper} aria-hidden="true">
+      <div className={styles.receiptRows}>
+        <SectionBands assignments={assignments} opacity={bandsVisible} />
         {RECEIPT_ROWS.map((row, index) => {
-          const reveal = phase(p, index * 0.045, 0.32 + index * 0.045);
+          const reveal = phase(rowReveal, index * 0.035, 0.3 + index * 0.04);
+          const assignment = assignments[index];
+          const corrected = assignment === row.truth && row.baseline !== row.truth;
           return (
             <div
               key={row.id}
               className={styles.receiptRow}
-              data-section={row.truth}
+              data-row-id={row.id}
+              data-section={assignment ?? undefined}
+              data-neighbor={showNeighbors && CHANGED_ROW_IDS.has(row.id) || undefined}
+              data-changed={showChanges && corrected || undefined}
+              data-testid={`section-row-${row.id}`}
               style={{
                 opacity: reveal,
-                transform: `translateY(${(1 - reveal) * 8}px)`,
+                transform: `translateY(${(1 - reveal) * 5}px)`,
               }}
             >
               <span>{row.text}</span>
@@ -138,369 +224,143 @@ const ReceiptAct: React.FC<ActProps> = ({ progress, reducedMotion }) => {
             </div>
           );
         })}
-        <div className={styles.receiptSectionRail}>
-          {SECTIONS.map((section) => {
-            const rows = RECEIPT_ROWS.filter((row) => row.truth === section.id);
-            const first = RECEIPT_ROWS.findIndex(
-              (row) => row.truth === section.id,
-            );
-            return (
-              <div
-                key={section.id}
-                className={styles.railSegment}
-                data-section={section.id}
-                style={{
-                  top: `${first * 24 + 7}px`,
-                  height: `${rows.length * 24 - 5}px`,
-                  opacity: phase(p, 0.52, 0.85),
-                }}
-              >
-                <span>{section.shortLabel}</span>
-              </div>
-            );
-          })}
-        </div>
       </div>
-      <p className={styles.stageNote}>Schematic receipt · section order is real</p>
+      <div className={styles.receiptFooter}>
+        <span>11 complete rows</span>
+        <span>{actId === "ocr" ? "unassigned" : "ordered"}</span>
+      </div>
     </div>
   );
 };
 
-const ProjectionSvg: React.FC<{
-  scenario: QueryScenario;
-  progress: number;
+const ReferenceReceiptCard: React.FC<{
+  receipt: ReferenceReceipt;
+  index: number;
   showNeighbors: boolean;
-}> = ({ scenario, progress, showNeighbors }) => {
-  const neighbors = nearestProjectionPoints(scenario);
-  const settle = phase(progress, 0.05, 0.72);
-  const lineReveal = phase(progress, 0.18, 0.82);
-  const queryX = 72 + scenario.x * 5.55;
-  const queryY = 326 - scenario.y * 2.8;
+  progress: number;
+}> = ({ receipt, index, showNeighbors, progress }) => {
+  const assignments = receipt.rows.map((row) => row.section);
+  return (
+    <div
+      className={`${styles.receiptCard} ${styles.referenceReceipt}`}
+      data-reference-index={index}
+      data-testid={`section-reference-receipt-${index}`}
+      aria-hidden="true"
+      style={{ "--reference-index": index } as React.CSSProperties}
+    >
+      <div className={styles.receiptHeader}>
+        <strong>{receipt.merchant}</strong>
+        <span>LABELED</span>
+      </div>
+      <div className={styles.receiptRows}>
+        <SectionBands assignments={assignments} opacity={1} compact />
+        {receipt.rows.map((row) => {
+          const isNeighbor = showNeighbors && Boolean(row.matches);
+          const reveal = phase(progress, 0.14 + index * 0.06, 0.62 + index * 0.06);
+          return (
+            <div
+              key={row.id}
+              className={styles.receiptRow}
+              data-section={row.section}
+              data-neighbor={isNeighbor || undefined}
+              data-neighbor-kind={row.matches}
+              style={{ opacity: showNeighbors ? 0.46 + reveal * 0.54 : 1 }}
+            >
+              <span>{row.text}</span>
+              {row.amount ? <span>{row.amount}</span> : null}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+const NeighborConnections: React.FC<{ progress: number }> = ({ progress }) => {
+  const reveal = phase(progress, 0.14, 0.78);
   return (
     <svg
-      className={styles.projectionSvg}
-      viewBox="0 0 680 350"
-      role="img"
-      aria-label={
-        showNeighbors
-          ? `Fifteen cross-receipt neighbors vote on ${scenario.label}`
-          : `${scenario.label} projected among labeled receipt row clusters`
-      }
+      className={styles.neighborConnections}
+      viewBox="0 0 900 450"
+      aria-hidden="true"
+      style={{ opacity: reveal }}
     >
-      <g className={styles.axes}>
-        <path d="M72 24V326H642" />
-        <text x="78" y="42">semantic row embeddings</text>
-        <text x="638" y="342" textAnchor="end">schematic 2-D view</text>
-      </g>
-
-      {showNeighbors
-        ? neighbors.map((neighbor, index) => {
-            const x = 72 + neighbor.x * 5.55;
-            const y = 326 - neighbor.y * 2.8;
-            const reveal = phase(lineReveal, index / 22, 0.5 + index / 30);
-            return (
-              <line
-                key={`line-${neighbor.id}`}
-                className={styles.neighborLine}
-                data-section={neighbor.section}
-                x1={queryX}
-                y1={queryY}
-                x2={queryX + (x - queryX) * reveal}
-                y2={queryY + (y - queryY) * reveal}
-                opacity={0.12 + reveal * 0.34}
-              />
-            );
-          })
-        : null}
-
-      {SECTIONS.map((section) => {
-        const points = PROJECTION_POINTS.filter(
-          (point) => point.section === section.id,
-        );
-        const cx = points.reduce((sum, point) => sum + point.x, 0) / points.length;
-        const cy = points.reduce((sum, point) => sum + point.y, 0) / points.length;
-        return (
-          <g key={section.id} data-section={section.id}>
-            <ellipse
-              className={styles.clusterHalo}
-              cx={72 + cx * 5.55}
-              cy={326 - cy * 2.8}
-              rx={58 * settle}
-              ry={34 * settle}
-              opacity={0.08 + settle * 0.09}
-            />
-            <text
-              className={styles.clusterLabel}
-              x={72 + cx * 5.55}
-              y={326 - cy * 2.8 - 42}
-              textAnchor="middle"
-              opacity={settle}
-            >
-              {section.shortLabel}
-            </text>
-          </g>
-        );
-      })}
-
-      {PROJECTION_POINTS.map((point, index) => {
-        const destinationX = 72 + point.x * 5.55;
-        const destinationY = 326 - point.y * 2.8;
-        const localSettle = phase(
-          progress,
-          0.03 + (index % 8) * 0.018,
-          0.5 + (index % 8) * 0.018,
-        );
-        const isNeighbor = showNeighbors && neighbors.some((n) => n.id === point.id);
-        return (
-          <circle
-            key={point.id}
-            className={styles.projectionPoint}
-            data-section={point.section}
-            data-neighbor={isNeighbor || undefined}
-            cx={340 + (destinationX - 340) * localSettle}
-            cy={175 + (destinationY - 175) * localSettle}
-            r={isNeighbor ? 5 : 3.5}
-            opacity={showNeighbors && !isNeighbor ? 0.18 : 0.76}
-          >
-            <title>{`${point.merchant} · ${SECTION_BY_ID[point.section].label}`}</title>
-          </circle>
-        );
-      })}
-
-      <g
-        className={styles.queryPoint}
-        transform={`translate(${340 + (queryX - 340) * settle} ${
-          175 + (queryY - 175) * settle
-        })`}
-      >
-        <circle r="10" />
-        <circle className={styles.queryPulse} r="16" opacity={showNeighbors ? 0.7 : 0.35} />
-        <text x="14" y="-14">{scenario.label}</text>
-      </g>
+      <path data-section="SUMMARY" d="M441 236 C474 226 486 166 507 155" pathLength="1" />
+      <path data-section="PAYMENT" d="M441 303 C510 321 560 226 624 210" pathLength="1" />
+      <path data-section="SUMMARY" d="M441 236 C551 276 640 216 732 208" pathLength="1" />
+      <path data-section="PAYMENT" d="M441 303 C610 350 715 290 804 272" pathLength="1" />
+      <circle data-section="SUMMARY" cx="441" cy="236" r="4" />
+      <circle data-section="PAYMENT" cx="441" cy="303" r="4" />
+      <circle data-section="SUMMARY" cx="507" cy="155" r="4" />
+      <circle data-section="PAYMENT" cx="624" cy="210" r="4" />
+      <circle data-section="SUMMARY" cx="732" cy="208" r="4" />
+      <circle data-section="PAYMENT" cx="804" cy="272" r="4" />
     </svg>
   );
 };
 
-const ProjectionAct: React.FC<ActProps> = ({
-  progress,
-  reducedMotion,
-  selected,
-  onSelect,
-}) => {
-  const scenario = QUERY_BY_ID[selected];
+const EmbeddingInset: React.FC<{ progress: number }> = ({ progress }) => {
+  const reveal = phase(progress, 0.36, 0.9);
   return (
-    <div className={styles.projectionAct} data-testid="section-act-projection">
-      <div className={styles.actAnnotation}>
-        <span className={styles.actNumber}>02</span>
-        <strong>Project wording and context into Chroma.</strong>
-        <span>Nearby rows have been used in the same kind of section.</span>
-      </div>
-      <ProjectionSvg
-        scenario={scenario}
-        progress={reducedMotion ? 1 : progress}
-        showNeighbors={false}
-      />
-      <ScenarioControl selected={selected} onSelect={onSelect} />
+    <div className={styles.embeddingInset} style={{ opacity: reveal }} aria-hidden="true">
+      <svg viewBox="0 0 180 78">
+        <g data-section="TRANSACTION_INFO"><circle cx="25" cy="54" r="12" /><circle cx="20" cy="51" r="2" /><circle cx="30" cy="58" r="2" /></g>
+        <g data-section="ITEMS"><circle cx="63" cy="31" r="15" /><circle cx="58" cy="28" r="2" /><circle cx="69" cy="35" r="2" /></g>
+        <g data-section="SUMMARY"><circle cx="118" cy="48" r="14" /><circle cx="113" cy="44" r="2" /><circle cx="124" cy="51" r="2" /></g>
+        <g data-section="PAYMENT"><circle cx="154" cy="21" r="13" /><circle cx="150" cy="18" r="2" /><circle cx="159" cy="24" r="2" /></g>
+        <path d="M103 38L116 46M103 38L148 23" />
+        <circle className={styles.insetQuery} cx="103" cy="38" r="4" />
+      </svg>
+      <span>schematic 2-D map · not literal</span>
     </div>
   );
 };
 
-const VoteBars: React.FC<{ scenario: QueryScenario; progress: number }> = ({
-  scenario,
-  progress,
-}) => (
-  <div className={styles.votePanel} aria-label="Cosine-weighted neighbor votes">
-    <div className={styles.voteHeader}>
-      <span>15 neighbors</span>
-      <strong>cosine-weighted vote</strong>
-    </div>
-    {SECTIONS.map((section, index) => {
-      const value = scenario.votes[section.id];
-      const reveal = phase(progress, 0.36 + index * 0.06, 0.78 + index * 0.04);
-      return (
-        <div key={section.id} className={styles.voteRow} data-section={section.id}>
-          <span>{section.shortLabel}</span>
-          <div className={styles.voteTrack}>
-            <span style={{ width: `${value * reveal * 100}%` }} />
-          </div>
-          <strong>{Math.round(value * 100)}%</strong>
-        </div>
-      );
-    })}
-    <div className={styles.weightEquation}>
-      <span>KNN × <strong>1.0</strong></span>
-      <span>centroid × <strong>0.5</strong></span>
-    </div>
-  </div>
-);
-
-const NeighborsAct: React.FC<ActProps> = ({
-  progress,
-  reducedMotion,
-  selected,
-  onSelect,
-}) => {
-  const scenario = QUERY_BY_ID[selected];
+const ReceiptStackScene: React.FC<{
+  actId: ExplorerActId;
+  progress: number;
+  reducedMotion: boolean;
+}> = ({ actId, progress, reducedMotion }) => {
   const p = reducedMotion ? 1 : progress;
+  const copy = ACT_COPY[actId];
+  const showNeighbors = actId === "neighbors";
+
   return (
-    <div className={styles.neighborsAct} data-testid="section-act-neighbors">
+    <div
+      className={styles.scene}
+      data-act={actId}
+      data-testid={`section-act-${actId}`}
+      role="img"
+      aria-label={copy.sceneLabel}
+      style={{ "--act-progress": p } as React.CSSProperties}
+    >
       <div className={styles.actAnnotation}>
-        <span className={styles.actNumber}>03</span>
-        <strong>Ask labeled rows from other receipts.</strong>
-        <span>Same-receipt rows are excluded; closer cosine matches vote harder.</span>
+        <span className={styles.actNumber}>{String(EXPLORER_ACTS.findIndex((act) => act.id === actId) + 1).padStart(2, "0")}</span>
+        <strong>{copy.title}</strong>
+        <span>{copy.detail}</span>
       </div>
-      <div className={styles.neighborLayout}>
-        <ProjectionSvg scenario={scenario} progress={p} showNeighbors />
-        <VoteBars scenario={scenario} progress={p} />
+
+      <div className={styles.stackField} data-testid="section-receipt-stack">
+        {REFERENCE_RECEIPTS.map((receipt, index) => (
+          <ReferenceReceiptCard
+            key={receipt.id}
+            receipt={receipt}
+            index={index}
+            showNeighbors={showNeighbors}
+            progress={p}
+          />
+        ))}
+        <CurrentReceipt actId={actId} progress={p} />
+        {showNeighbors ? <NeighborConnections progress={p} /> : null}
+        {showNeighbors ? <EmbeddingInset progress={p} /> : null}
       </div>
-      <ScenarioControl selected={selected} onSelect={onSelect} />
+
+      <div className={styles.evidenceLine} data-testid="section-evidence-line">
+        <span className={styles.evidenceRule} aria-hidden="true" />
+        <span>{copy.evidence}</span>
+      </div>
     </div>
   );
-};
-
-const DecodeAct: React.FC<ActProps> = ({
-  progress,
-  reducedMotion,
-  selected,
-  onSelect,
-}) => {
-  const p = reducedMotion ? 1 : progress;
-  const selectedScenario = QUERY_BY_ID[selected];
-  const scan = phase(p, 0.05, 0.9);
-  const correctedRows = new Set(["subtotal", "visa"]);
-  const baselinePath = RECEIPT_ROWS.map((row, index) =>
-    `${index === 0 ? "M" : "L"}${sectionX(row.baseline)} ${rowY(index)}`,
-  ).join(" ");
-  const decodedPath = RECEIPT_ROWS.map((row, index) =>
-    `${index === 0 ? "M" : "L"}${sectionX(row.truth)} ${rowY(index)}`,
-  ).join(" ");
-  return (
-    <div className={styles.decodeAct} data-testid="section-act-decode">
-      <div className={styles.actAnnotation}>
-        <span className={styles.actNumber}>04</span>
-        <strong>Decode the whole receipt, not isolated rows.</strong>
-        <span>
-          Transition and duration priors prefer contiguous spans. Added
-          geometry/math stayed at ×0.0.
-        </span>
-      </div>
-      <div className={styles.decodeChart}>
-        <svg
-          viewBox="0 0 660 330"
-          role="img"
-          aria-label="Baseline row guesses compared with the contiguous semi-Markov decoded path"
-        >
-          {SECTIONS.map((section) => (
-            <g key={section.id} data-section={section.id}>
-              <text className={styles.decodeHeader} x={sectionX(section.id)} y="22" textAnchor="middle">
-                {section.shortLabel}
-              </text>
-              <line className={styles.decodeColumn} x1={sectionX(section.id)} y1="34" x2={sectionX(section.id)} y2="306" />
-            </g>
-          ))}
-          {RECEIPT_ROWS.map((row, index) => {
-            const y = rowY(index);
-            const revealed = scan >= (index + 1) / RECEIPT_ROWS.length;
-            return (
-              <g key={row.id} opacity={revealed ? 1 : 0.16}>
-                <text className={styles.decodeRowLabel} x="8" y={y + 4}>
-                  {row.id === "merchant" ? "merchant" : row.text.slice(0, 14)}
-                </text>
-                {correctedRows.has(row.id) ? (
-                  <circle
-                    className={styles.correctionHalo}
-                    data-section={row.truth}
-                    cx={sectionX(row.truth)}
-                    cy={y}
-                    r="11"
-                  />
-                ) : null}
-              </g>
-            );
-          })}
-          <path className={styles.baselinePath} d={baselinePath} pathLength="1" strokeDasharray="1" strokeDashoffset={1 - scan} />
-          <path className={styles.decodedPath} d={decodedPath} pathLength="1" strokeDasharray="1" strokeDashoffset={1 - phase(p, 0.32, 1)} />
-        </svg>
-        <div className={styles.decodeComparison}>
-          <span>row alone</span>
-          <SectionPill section={selectedScenario.baseline} muted />
-          <span className={styles.decodeArrow} aria-hidden="true">→</span>
-          <span>full sequence</span>
-          <SectionPill section={selectedScenario.decoded} />
-        </div>
-      </div>
-      <ScenarioControl selected={selected} onSelect={onSelect} />
-    </div>
-  );
-};
-
-const ResultAct: React.FC<ActProps> = ({ progress, reducedMotion }) => {
-  const p = reducedMotion ? 1 : progress;
-  const baseline = phase(p, 0.08, 0.5);
-  const hybrid = phase(p, 0.28, 0.82);
-  return (
-    <div className={styles.resultAct} data-testid="section-act-result">
-      <div className={styles.actAnnotation}>
-        <span className={styles.actNumber}>05</span>
-        <strong>Then make the holdout decide.</strong>
-        <span>167 unseen receipts · 4,214 rows · receipt-grouped split</span>
-      </div>
-      <div className={styles.resultBars}>
-        <div className={styles.resultRow}>
-          <span>fair baseline</span>
-          <div className={styles.resultTrack}>
-            <span className={styles.baselineFill} style={{ width: `${EXPERIMENT_METRICS.baselineAgreement * baseline}%` }} />
-          </div>
-          <strong>{EXPERIMENT_METRICS.baselineAgreement}%</strong>
-        </div>
-        <div className={styles.resultRow}>
-          <span>Chroma hybrid</span>
-          <div className={styles.resultTrack}>
-            <span className={styles.hybridFill} style={{ width: `${EXPERIMENT_METRICS.hybridAgreement * hybrid}%` }} />
-          </div>
-          <strong>{EXPERIMENT_METRICS.hybridAgreement}%</strong>
-        </div>
-      </div>
-      <div className={styles.deltaCallout} style={{ opacity: phase(p, 0.48, 0.78) }}>
-        <strong>+{EXPERIMENT_METRICS.deltaPoints} pp</strong>
-        <span>row agreement</span>
-      </div>
-      <div className={styles.pairedCounts} style={{ opacity: phase(p, 0.62, 0.94) }}>
-        <div>
-          <strong>{EXPERIMENT_METRICS.fixed}</strong>
-          <span>rows fixed</span>
-        </div>
-        <span className={styles.pairedRule} aria-hidden="true" />
-        <div>
-          <strong>{EXPERIMENT_METRICS.regressed}</strong>
-          <span>rows regressed</span>
-        </div>
-      </div>
-      <p className={styles.resultFootnote}>
-        95% receipt bootstrap: +{EXPERIMENT_METRICS.bootstrapLow} to +{EXPERIMENT_METRICS.bootstrapHigh} pp · embedding coverage {EXPERIMENT_METRICS.coverage}%
-      </p>
-    </div>
-  );
-};
-
-const ActView: React.FC<ActProps & { actId: ExplorerActId }> = ({
-  actId,
-  ...props
-}) => {
-  switch (actId) {
-    case "receipt":
-      return <ReceiptAct {...props} />;
-    case "projection":
-      return <ProjectionAct {...props} />;
-    case "neighbors":
-      return <NeighborsAct {...props} />;
-    case "decode":
-      return <DecodeAct {...props} />;
-    case "result":
-      return <ResultAct {...props} />;
-    default:
-      return null;
-  }
 };
 
 const SectionEmbeddingExplorer: React.FC = () => {
@@ -512,14 +372,15 @@ const SectionEmbeddingExplorer: React.FC = () => {
   const [activeAct, setActiveAct] = useState(0);
   const [actProgress, setActProgress] = useState(0);
   const [paused, setPaused] = useState(false);
-  const [selected, setSelected] = useState<QueryScenario["id"]>("subtotal");
   const activeRef = useRef(0);
   const progressRef = useRef(0);
   const resumeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const progressButtons = useRef<Array<HTMLButtonElement | null>>([]);
 
   useEffect(() => {
     activeRef.current = activeAct;
   }, [activeAct]);
+
   useEffect(() => {
     progressRef.current = actProgress;
   }, [actProgress]);
@@ -531,6 +392,7 @@ const SectionEmbeddingExplorer: React.FC = () => {
     let last = performance.now();
     let act = activeRef.current;
     let progress = progressRef.current;
+
     const tick = (time: number) => {
       const next = advanceExplorerAutoplay(
         act,
@@ -548,6 +410,7 @@ const SectionEmbeddingExplorer: React.FC = () => {
       setActProgress(progress);
       raf = requestAnimationFrame(tick);
     };
+
     raf = requestAnimationFrame(tick);
     return () => cancelAnimationFrame(raf);
   }, [playing]);
@@ -562,10 +425,7 @@ const SectionEmbeddingExplorer: React.FC = () => {
   const pauseForInteraction = useCallback(() => {
     setPaused(true);
     if (resumeTimer.current) clearTimeout(resumeTimer.current);
-    resumeTimer.current = setTimeout(
-      () => setPaused(false),
-      AUTOPLAY_IDLE_RESUME_MS,
-    );
+    resumeTimer.current = setTimeout(() => setPaused(false), AUTOPLAY_IDLE_RESUME_MS);
   }, []);
 
   const jumpToAct = useCallback(
@@ -579,22 +439,30 @@ const SectionEmbeddingExplorer: React.FC = () => {
     [pauseForInteraction],
   );
 
-  const selectScenario = useCallback(
-    (id: QueryScenario["id"]) => {
-      setSelected(id);
-      pauseForInteraction();
+  const onProgressKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLButtonElement>, index: number) => {
+      let next = index;
+      if (event.key === "ArrowRight" || event.key === "ArrowDown") {
+        next = (index + 1) % EXPLORER_ACTS.length;
+      } else if (event.key === "ArrowLeft" || event.key === "ArrowUp") {
+        next = (index - 1 + EXPLORER_ACTS.length) % EXPLORER_ACTS.length;
+      } else if (event.key === "Home") {
+        next = 0;
+      } else if (event.key === "End") {
+        next = EXPLORER_ACTS.length - 1;
+      } else {
+        return;
+      }
+
+      event.preventDefault();
+      jumpToAct(next);
+      progressButtons.current[next]?.focus();
     },
-    [pauseForInteraction],
+    [jumpToAct],
   );
 
   const transition = useActTransition(activeAct, !reducedMotion);
   const activeMeta = EXPLORER_ACTS[activeAct] ?? EXPLORER_ACTS[0];
-  const actProps = (progress: number): ActProps => ({
-    progress,
-    reducedMotion,
-    selected,
-    onSelect: selectScenario,
-  });
 
   if (reducedMotion) {
     return (
@@ -607,13 +475,13 @@ const SectionEmbeddingExplorer: React.FC = () => {
         aria-labelledby="section-explorer-title"
       >
         <h3 id="section-explorer-title" className={styles.srOnly}>
-          How cross-receipt embeddings improve receipt section classification
+          How row embeddings correct receipt section boundaries
         </h3>
         <div className={styles.staticStack}>
           {EXPLORER_ACTS.map((act) => (
             <section key={act.id} className={styles.staticAct}>
               <div className={`${styles.stage} ${styles.staticStage}`}>
-                <ActView actId={act.id} {...actProps(1)} />
+                <ReceiptStackScene actId={act.id} progress={1} reducedMotion />
               </div>
             </section>
           ))}
@@ -627,6 +495,7 @@ const SectionEmbeddingExplorer: React.FC = () => {
     phase: "entering" | "active" | "leaving";
     progress: number;
   }> = [];
+
   if (transition.leaving !== null) {
     layers.push({
       id: EXPLORER_ACTS[transition.leaving].id,
@@ -634,6 +503,7 @@ const SectionEmbeddingExplorer: React.FC = () => {
       progress: 1,
     });
   }
+
   layers.push({
     id: EXPLORER_ACTS[transition.current].id,
     phase: transition.leaving !== null ? "entering" : "active",
@@ -652,16 +522,10 @@ const SectionEmbeddingExplorer: React.FC = () => {
       aria-describedby="section-explorer-description"
     >
       <h3 id="section-explorer-title" className={styles.srOnly}>
-        How cross-receipt embeddings improve receipt section classification
+        How row embeddings correct receipt section boundaries
       </h3>
       <p id="section-explorer-description" className={styles.srOnly}>
-        An animated five-step explainer. Receipt rows are projected into Chroma
-        embedding space. Fifteen labeled rows from other receipts cast
-        cosine-weighted section votes. A semi-Markov decoder combines those
-        votes with the ordered receipt sequence. On 167 held-out receipts, row
-        agreement rises from 85.95 to 90.84 percent. Geometry and arithmetic
-        evidence was tested separately and received weight zero because it did
-        not improve validation results.
+        A five-step explainer. Apple OCR provides complete rows. LayoutLM labels individual words, while this visualization assigns sections to complete rows. OpenAI creates row embeddings and Chroma searches labeled rows from other receipts. The two-dimensional map is schematic. Merchant identity is optional. Experimental geometry and receipt math currently have zero weight.
       </p>
       <p className={styles.srOnly} aria-live="polite" data-testid="section-act-label">
         {activeMeta.accessibleLabel}
@@ -675,17 +539,18 @@ const SectionEmbeddingExplorer: React.FC = () => {
             data-phase={layer.phase}
             aria-hidden={layer.phase === "leaving"}
           >
-            <ActView actId={layer.id} {...actProps(layer.progress)} />
+            <ReceiptStackScene actId={layer.id} progress={layer.progress} reducedMotion={false} />
           </div>
         ))}
       </div>
 
-      <ol className={styles.progress} aria-label="Section classifier steps">
+      <ol className={styles.progress} aria-label="Section assignment steps">
         {EXPLORER_ACTS.map((act) => {
           const isActive = act.index === activeAct;
           return (
             <li key={act.id}>
               <button
+                ref={(node) => { progressButtons.current[act.index] = node; }}
                 type="button"
                 className={styles.progressButton}
                 data-active={isActive}
@@ -694,6 +559,7 @@ const SectionEmbeddingExplorer: React.FC = () => {
                 aria-label={act.accessibleLabel}
                 title={act.label}
                 onClick={() => jumpToAct(act.index)}
+                onKeyDown={(event) => onProgressKeyDown(event, act.index)}
                 data-testid={`section-act-dot-${act.index}`}
               >
                 <span aria-hidden="true" />

--- a/portfolio/components/ui/Figures/SectionEmbeddingExplorer/index.tsx
+++ b/portfolio/components/ui/Figures/SectionEmbeddingExplorer/index.tsx
@@ -1,0 +1,709 @@
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import { useInView } from "react-intersection-observer";
+import { useActTransition } from "../SynthesisPipeline/actTransition";
+import styles from "./SectionEmbeddingExplorer.module.css";
+import {
+  EXPLORER_ACTS,
+  EXPERIMENT_METRICS,
+  ExplorerActId,
+  nearestProjectionPoints,
+  PROJECTION_POINTS,
+  QUERY_BY_ID,
+  QUERY_SCENARIOS,
+  QueryScenario,
+  RECEIPT_ROWS,
+  SECTION_BY_ID,
+  SECTIONS,
+  SectionId,
+} from "./sectionData";
+
+const AUTOPLAY_IDLE_RESUME_MS = 10_000;
+
+const usePrefersReducedMotion = (): boolean => {
+  const [reduced, setReduced] = useState(false);
+  useEffect(() => {
+    if (typeof window.matchMedia !== "function") return;
+    const media = window.matchMedia("(prefers-reduced-motion: reduce)");
+    setReduced(media.matches);
+    const onChange = (event: MediaQueryListEvent) => setReduced(event.matches);
+    media.addEventListener?.("change", onChange);
+    return () => media.removeEventListener?.("change", onChange);
+  }, []);
+  return reduced;
+};
+
+export interface ExplorerAutoplayState {
+  activeAct: number;
+  actProgress: number;
+}
+
+export const advanceExplorerAutoplay = (
+  activeAct: number,
+  actProgress: number,
+  dtMs: number,
+  dwellMs: number,
+  actCount: number,
+): ExplorerAutoplayState => {
+  if (dwellMs <= 0 || actCount <= 0) {
+    return { activeAct, actProgress: 1 };
+  }
+  let progress = Math.max(0, actProgress + dtMs / dwellMs);
+  let act = activeAct;
+  while (progress >= 1) {
+    progress -= 1;
+    act = (act + 1) % actCount;
+  }
+  return { activeAct: act, actProgress: progress };
+};
+
+const phase = (value: number, start: number, end: number): number => {
+  if (value <= start) return 0;
+  if (value >= end) return 1;
+  const t = (value - start) / (end - start);
+  return t * t * (3 - 2 * t);
+};
+
+const rowY = (index: number): number => 52 + index * 24;
+const sectionX = (section: SectionId): number =>
+  190 + SECTIONS.findIndex((candidate) => candidate.id === section) * 110;
+
+interface ScenarioControlProps {
+  selected: QueryScenario["id"];
+  onSelect: (id: QueryScenario["id"]) => void;
+}
+
+const ScenarioControl: React.FC<ScenarioControlProps> = ({
+  selected,
+  onSelect,
+}) => (
+  <div className={styles.queryControl} aria-label="Row to classify">
+    {QUERY_SCENARIOS.map((scenario) => (
+      <button
+        key={scenario.id}
+        type="button"
+        className={styles.queryButton}
+        data-active={selected === scenario.id}
+        aria-pressed={selected === scenario.id}
+        onClick={() => onSelect(scenario.id)}
+      >
+        {scenario.label}
+      </button>
+    ))}
+  </div>
+);
+
+const SectionPill: React.FC<{ section: SectionId; muted?: boolean }> = ({
+  section,
+  muted = false,
+}) => (
+  <span
+    className={styles.sectionPill}
+    data-section={section}
+    data-muted={muted || undefined}
+  >
+    <span className={styles.sectionDot} aria-hidden="true" />
+    {SECTION_BY_ID[section].shortLabel}
+  </span>
+);
+
+interface ActProps extends ScenarioControlProps {
+  progress: number;
+  reducedMotion: boolean;
+}
+
+const ReceiptAct: React.FC<ActProps> = ({ progress, reducedMotion }) => {
+  const p = reducedMotion ? 1 : progress;
+  return (
+    <div className={styles.receiptAct} data-testid="section-act-receipt">
+      <div className={styles.actAnnotation}>
+        <span className={styles.actNumber}>01</span>
+        <strong>Keep the receipt in reading order.</strong>
+        <span>Each line is one row the decoder must place.</span>
+      </div>
+      <div className={styles.receiptPaper} aria-hidden="true">
+        {RECEIPT_ROWS.map((row, index) => {
+          const reveal = phase(p, index * 0.045, 0.32 + index * 0.045);
+          return (
+            <div
+              key={row.id}
+              className={styles.receiptRow}
+              data-section={row.truth}
+              style={{
+                opacity: reveal,
+                transform: `translateY(${(1 - reveal) * 8}px)`,
+              }}
+            >
+              <span>{row.text}</span>
+              {row.amount ? <span>{row.amount}</span> : null}
+            </div>
+          );
+        })}
+        <div className={styles.receiptSectionRail}>
+          {SECTIONS.map((section) => {
+            const rows = RECEIPT_ROWS.filter((row) => row.truth === section.id);
+            const first = RECEIPT_ROWS.findIndex(
+              (row) => row.truth === section.id,
+            );
+            return (
+              <div
+                key={section.id}
+                className={styles.railSegment}
+                data-section={section.id}
+                style={{
+                  top: `${first * 24 + 7}px`,
+                  height: `${rows.length * 24 - 5}px`,
+                  opacity: phase(p, 0.52, 0.85),
+                }}
+              >
+                <span>{section.shortLabel}</span>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+      <p className={styles.stageNote}>Schematic receipt · section order is real</p>
+    </div>
+  );
+};
+
+const ProjectionSvg: React.FC<{
+  scenario: QueryScenario;
+  progress: number;
+  showNeighbors: boolean;
+}> = ({ scenario, progress, showNeighbors }) => {
+  const neighbors = nearestProjectionPoints(scenario);
+  const settle = phase(progress, 0.05, 0.72);
+  const lineReveal = phase(progress, 0.18, 0.82);
+  const queryX = 72 + scenario.x * 5.55;
+  const queryY = 326 - scenario.y * 2.8;
+  return (
+    <svg
+      className={styles.projectionSvg}
+      viewBox="0 0 680 350"
+      role="img"
+      aria-label={
+        showNeighbors
+          ? `Fifteen cross-receipt neighbors vote on ${scenario.label}`
+          : `${scenario.label} projected among labeled receipt row clusters`
+      }
+    >
+      <g className={styles.axes}>
+        <path d="M72 24V326H642" />
+        <text x="78" y="42">semantic row embeddings</text>
+        <text x="638" y="342" textAnchor="end">schematic 2-D view</text>
+      </g>
+
+      {showNeighbors
+        ? neighbors.map((neighbor, index) => {
+            const x = 72 + neighbor.x * 5.55;
+            const y = 326 - neighbor.y * 2.8;
+            const reveal = phase(lineReveal, index / 22, 0.5 + index / 30);
+            return (
+              <line
+                key={`line-${neighbor.id}`}
+                className={styles.neighborLine}
+                data-section={neighbor.section}
+                x1={queryX}
+                y1={queryY}
+                x2={queryX + (x - queryX) * reveal}
+                y2={queryY + (y - queryY) * reveal}
+                opacity={0.12 + reveal * 0.34}
+              />
+            );
+          })
+        : null}
+
+      {SECTIONS.map((section) => {
+        const points = PROJECTION_POINTS.filter(
+          (point) => point.section === section.id,
+        );
+        const cx = points.reduce((sum, point) => sum + point.x, 0) / points.length;
+        const cy = points.reduce((sum, point) => sum + point.y, 0) / points.length;
+        return (
+          <g key={section.id} data-section={section.id}>
+            <ellipse
+              className={styles.clusterHalo}
+              cx={72 + cx * 5.55}
+              cy={326 - cy * 2.8}
+              rx={58 * settle}
+              ry={34 * settle}
+              opacity={0.08 + settle * 0.09}
+            />
+            <text
+              className={styles.clusterLabel}
+              x={72 + cx * 5.55}
+              y={326 - cy * 2.8 - 42}
+              textAnchor="middle"
+              opacity={settle}
+            >
+              {section.shortLabel}
+            </text>
+          </g>
+        );
+      })}
+
+      {PROJECTION_POINTS.map((point, index) => {
+        const destinationX = 72 + point.x * 5.55;
+        const destinationY = 326 - point.y * 2.8;
+        const localSettle = phase(
+          progress,
+          0.03 + (index % 8) * 0.018,
+          0.5 + (index % 8) * 0.018,
+        );
+        const isNeighbor = showNeighbors && neighbors.some((n) => n.id === point.id);
+        return (
+          <circle
+            key={point.id}
+            className={styles.projectionPoint}
+            data-section={point.section}
+            data-neighbor={isNeighbor || undefined}
+            cx={340 + (destinationX - 340) * localSettle}
+            cy={175 + (destinationY - 175) * localSettle}
+            r={isNeighbor ? 5 : 3.5}
+            opacity={showNeighbors && !isNeighbor ? 0.18 : 0.76}
+          >
+            <title>{`${point.merchant} · ${SECTION_BY_ID[point.section].label}`}</title>
+          </circle>
+        );
+      })}
+
+      <g
+        className={styles.queryPoint}
+        transform={`translate(${340 + (queryX - 340) * settle} ${
+          175 + (queryY - 175) * settle
+        })`}
+      >
+        <circle r="10" />
+        <circle className={styles.queryPulse} r="16" opacity={showNeighbors ? 0.7 : 0.35} />
+        <text x="14" y="-14">{scenario.label}</text>
+      </g>
+    </svg>
+  );
+};
+
+const ProjectionAct: React.FC<ActProps> = ({
+  progress,
+  reducedMotion,
+  selected,
+  onSelect,
+}) => {
+  const scenario = QUERY_BY_ID[selected];
+  return (
+    <div className={styles.projectionAct} data-testid="section-act-projection">
+      <div className={styles.actAnnotation}>
+        <span className={styles.actNumber}>02</span>
+        <strong>Project wording and context into Chroma.</strong>
+        <span>Nearby rows have been used in the same kind of section.</span>
+      </div>
+      <ProjectionSvg
+        scenario={scenario}
+        progress={reducedMotion ? 1 : progress}
+        showNeighbors={false}
+      />
+      <ScenarioControl selected={selected} onSelect={onSelect} />
+    </div>
+  );
+};
+
+const VoteBars: React.FC<{ scenario: QueryScenario; progress: number }> = ({
+  scenario,
+  progress,
+}) => (
+  <div className={styles.votePanel} aria-label="Cosine-weighted neighbor votes">
+    <div className={styles.voteHeader}>
+      <span>15 neighbors</span>
+      <strong>cosine-weighted vote</strong>
+    </div>
+    {SECTIONS.map((section, index) => {
+      const value = scenario.votes[section.id];
+      const reveal = phase(progress, 0.36 + index * 0.06, 0.78 + index * 0.04);
+      return (
+        <div key={section.id} className={styles.voteRow} data-section={section.id}>
+          <span>{section.shortLabel}</span>
+          <div className={styles.voteTrack}>
+            <span style={{ width: `${value * reveal * 100}%` }} />
+          </div>
+          <strong>{Math.round(value * 100)}%</strong>
+        </div>
+      );
+    })}
+    <div className={styles.weightEquation}>
+      <span>KNN × <strong>1.0</strong></span>
+      <span>centroid × <strong>0.5</strong></span>
+    </div>
+  </div>
+);
+
+const NeighborsAct: React.FC<ActProps> = ({
+  progress,
+  reducedMotion,
+  selected,
+  onSelect,
+}) => {
+  const scenario = QUERY_BY_ID[selected];
+  const p = reducedMotion ? 1 : progress;
+  return (
+    <div className={styles.neighborsAct} data-testid="section-act-neighbors">
+      <div className={styles.actAnnotation}>
+        <span className={styles.actNumber}>03</span>
+        <strong>Ask labeled rows from other receipts.</strong>
+        <span>Same-receipt rows are excluded; closer cosine matches vote harder.</span>
+      </div>
+      <div className={styles.neighborLayout}>
+        <ProjectionSvg scenario={scenario} progress={p} showNeighbors />
+        <VoteBars scenario={scenario} progress={p} />
+      </div>
+      <ScenarioControl selected={selected} onSelect={onSelect} />
+    </div>
+  );
+};
+
+const DecodeAct: React.FC<ActProps> = ({
+  progress,
+  reducedMotion,
+  selected,
+  onSelect,
+}) => {
+  const p = reducedMotion ? 1 : progress;
+  const selectedScenario = QUERY_BY_ID[selected];
+  const scan = phase(p, 0.05, 0.9);
+  const correctedRows = new Set(["subtotal", "visa"]);
+  const baselinePath = RECEIPT_ROWS.map((row, index) =>
+    `${index === 0 ? "M" : "L"}${sectionX(row.baseline)} ${rowY(index)}`,
+  ).join(" ");
+  const decodedPath = RECEIPT_ROWS.map((row, index) =>
+    `${index === 0 ? "M" : "L"}${sectionX(row.truth)} ${rowY(index)}`,
+  ).join(" ");
+  return (
+    <div className={styles.decodeAct} data-testid="section-act-decode">
+      <div className={styles.actAnnotation}>
+        <span className={styles.actNumber}>04</span>
+        <strong>Decode the whole receipt, not isolated rows.</strong>
+        <span>
+          Transition and duration priors prefer contiguous spans. Added
+          geometry/math stayed at ×0.0.
+        </span>
+      </div>
+      <div className={styles.decodeChart}>
+        <svg
+          viewBox="0 0 660 330"
+          role="img"
+          aria-label="Baseline row guesses compared with the contiguous semi-Markov decoded path"
+        >
+          {SECTIONS.map((section) => (
+            <g key={section.id} data-section={section.id}>
+              <text className={styles.decodeHeader} x={sectionX(section.id)} y="22" textAnchor="middle">
+                {section.shortLabel}
+              </text>
+              <line className={styles.decodeColumn} x1={sectionX(section.id)} y1="34" x2={sectionX(section.id)} y2="306" />
+            </g>
+          ))}
+          {RECEIPT_ROWS.map((row, index) => {
+            const y = rowY(index);
+            const revealed = scan >= (index + 1) / RECEIPT_ROWS.length;
+            return (
+              <g key={row.id} opacity={revealed ? 1 : 0.16}>
+                <text className={styles.decodeRowLabel} x="8" y={y + 4}>
+                  {row.id === "merchant" ? "merchant" : row.text.slice(0, 14)}
+                </text>
+                {correctedRows.has(row.id) ? (
+                  <circle
+                    className={styles.correctionHalo}
+                    data-section={row.truth}
+                    cx={sectionX(row.truth)}
+                    cy={y}
+                    r="11"
+                  />
+                ) : null}
+              </g>
+            );
+          })}
+          <path className={styles.baselinePath} d={baselinePath} pathLength="1" strokeDasharray="1" strokeDashoffset={1 - scan} />
+          <path className={styles.decodedPath} d={decodedPath} pathLength="1" strokeDasharray="1" strokeDashoffset={1 - phase(p, 0.32, 1)} />
+        </svg>
+        <div className={styles.decodeComparison}>
+          <span>row alone</span>
+          <SectionPill section={selectedScenario.baseline} muted />
+          <span className={styles.decodeArrow} aria-hidden="true">→</span>
+          <span>full sequence</span>
+          <SectionPill section={selectedScenario.decoded} />
+        </div>
+      </div>
+      <ScenarioControl selected={selected} onSelect={onSelect} />
+    </div>
+  );
+};
+
+const ResultAct: React.FC<ActProps> = ({ progress, reducedMotion }) => {
+  const p = reducedMotion ? 1 : progress;
+  const baseline = phase(p, 0.08, 0.5);
+  const hybrid = phase(p, 0.28, 0.82);
+  return (
+    <div className={styles.resultAct} data-testid="section-act-result">
+      <div className={styles.actAnnotation}>
+        <span className={styles.actNumber}>05</span>
+        <strong>Then make the holdout decide.</strong>
+        <span>167 unseen receipts · 4,214 rows · receipt-grouped split</span>
+      </div>
+      <div className={styles.resultBars}>
+        <div className={styles.resultRow}>
+          <span>fair baseline</span>
+          <div className={styles.resultTrack}>
+            <span className={styles.baselineFill} style={{ width: `${EXPERIMENT_METRICS.baselineAgreement * baseline}%` }} />
+          </div>
+          <strong>{EXPERIMENT_METRICS.baselineAgreement}%</strong>
+        </div>
+        <div className={styles.resultRow}>
+          <span>Chroma hybrid</span>
+          <div className={styles.resultTrack}>
+            <span className={styles.hybridFill} style={{ width: `${EXPERIMENT_METRICS.hybridAgreement * hybrid}%` }} />
+          </div>
+          <strong>{EXPERIMENT_METRICS.hybridAgreement}%</strong>
+        </div>
+      </div>
+      <div className={styles.deltaCallout} style={{ opacity: phase(p, 0.48, 0.78) }}>
+        <strong>+{EXPERIMENT_METRICS.deltaPoints} pp</strong>
+        <span>row agreement</span>
+      </div>
+      <div className={styles.pairedCounts} style={{ opacity: phase(p, 0.62, 0.94) }}>
+        <div>
+          <strong>{EXPERIMENT_METRICS.fixed}</strong>
+          <span>rows fixed</span>
+        </div>
+        <span className={styles.pairedRule} aria-hidden="true" />
+        <div>
+          <strong>{EXPERIMENT_METRICS.regressed}</strong>
+          <span>rows regressed</span>
+        </div>
+      </div>
+      <p className={styles.resultFootnote}>
+        95% receipt bootstrap: +{EXPERIMENT_METRICS.bootstrapLow} to +{EXPERIMENT_METRICS.bootstrapHigh} pp · embedding coverage {EXPERIMENT_METRICS.coverage}%
+      </p>
+    </div>
+  );
+};
+
+const ActView: React.FC<ActProps & { actId: ExplorerActId }> = ({
+  actId,
+  ...props
+}) => {
+  switch (actId) {
+    case "receipt":
+      return <ReceiptAct {...props} />;
+    case "projection":
+      return <ProjectionAct {...props} />;
+    case "neighbors":
+      return <NeighborsAct {...props} />;
+    case "decode":
+      return <DecodeAct {...props} />;
+    case "result":
+      return <ResultAct {...props} />;
+    default:
+      return null;
+  }
+};
+
+const SectionEmbeddingExplorer: React.FC = () => {
+  const { ref: inViewRef, inView } = useInView({
+    threshold: 0.4,
+    fallbackInView: true,
+  });
+  const reducedMotion = usePrefersReducedMotion();
+  const [activeAct, setActiveAct] = useState(0);
+  const [actProgress, setActProgress] = useState(0);
+  const [paused, setPaused] = useState(false);
+  const [selected, setSelected] = useState<QueryScenario["id"]>("subtotal");
+  const activeRef = useRef(0);
+  const progressRef = useRef(0);
+  const resumeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    activeRef.current = activeAct;
+  }, [activeAct]);
+  useEffect(() => {
+    progressRef.current = actProgress;
+  }, [actProgress]);
+
+  const playing = inView && !paused && !reducedMotion;
+  useEffect(() => {
+    if (!playing) return;
+    let raf = 0;
+    let last = performance.now();
+    let act = activeRef.current;
+    let progress = progressRef.current;
+    const tick = (time: number) => {
+      const next = advanceExplorerAutoplay(
+        act,
+        progress,
+        time - last,
+        EXPLORER_ACTS[act].dwellMs,
+        EXPLORER_ACTS.length,
+      );
+      last = time;
+      act = next.activeAct;
+      progress = next.actProgress;
+      activeRef.current = act;
+      progressRef.current = progress;
+      setActiveAct(act);
+      setActProgress(progress);
+      raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [playing]);
+
+  useEffect(
+    () => () => {
+      if (resumeTimer.current) clearTimeout(resumeTimer.current);
+    },
+    [],
+  );
+
+  const pauseForInteraction = useCallback(() => {
+    setPaused(true);
+    if (resumeTimer.current) clearTimeout(resumeTimer.current);
+    resumeTimer.current = setTimeout(
+      () => setPaused(false),
+      AUTOPLAY_IDLE_RESUME_MS,
+    );
+  }, []);
+
+  const jumpToAct = useCallback(
+    (index: number) => {
+      setActiveAct(index);
+      setActProgress(1);
+      activeRef.current = index;
+      progressRef.current = 1;
+      pauseForInteraction();
+    },
+    [pauseForInteraction],
+  );
+
+  const selectScenario = useCallback(
+    (id: QueryScenario["id"]) => {
+      setSelected(id);
+      pauseForInteraction();
+    },
+    [pauseForInteraction],
+  );
+
+  const transition = useActTransition(activeAct, !reducedMotion);
+  const activeMeta = EXPLORER_ACTS[activeAct] ?? EXPLORER_ACTS[0];
+  const actProps = (progress: number): ActProps => ({
+    progress,
+    reducedMotion,
+    selected,
+    onSelect: selectScenario,
+  });
+
+  if (reducedMotion) {
+    return (
+      <section
+        ref={inViewRef}
+        id="section-embedding-explorer"
+        data-testid="section-embedding-explorer"
+        data-mode="static"
+        className={styles.container}
+        aria-labelledby="section-explorer-title"
+      >
+        <h3 id="section-explorer-title" className={styles.srOnly}>
+          How cross-receipt embeddings improve receipt section classification
+        </h3>
+        <div className={styles.staticStack}>
+          {EXPLORER_ACTS.map((act) => (
+            <section key={act.id} className={styles.staticAct}>
+              <div className={`${styles.stage} ${styles.staticStage}`}>
+                <ActView actId={act.id} {...actProps(1)} />
+              </div>
+            </section>
+          ))}
+        </div>
+      </section>
+    );
+  }
+
+  const layers: Array<{
+    id: ExplorerActId;
+    phase: "entering" | "active" | "leaving";
+    progress: number;
+  }> = [];
+  if (transition.leaving !== null) {
+    layers.push({
+      id: EXPLORER_ACTS[transition.leaving].id,
+      phase: "leaving",
+      progress: 1,
+    });
+  }
+  layers.push({
+    id: EXPLORER_ACTS[transition.current].id,
+    phase: transition.leaving !== null ? "entering" : "active",
+    progress: actProgress,
+  });
+
+  return (
+    <section
+      ref={inViewRef}
+      id="section-embedding-explorer"
+      data-testid="section-embedding-explorer"
+      data-mode="autoplay"
+      data-paused={paused || undefined}
+      className={styles.container}
+      aria-labelledby="section-explorer-title"
+      aria-describedby="section-explorer-description"
+    >
+      <h3 id="section-explorer-title" className={styles.srOnly}>
+        How cross-receipt embeddings improve receipt section classification
+      </h3>
+      <p id="section-explorer-description" className={styles.srOnly}>
+        An animated five-step explainer. Receipt rows are projected into Chroma
+        embedding space. Fifteen labeled rows from other receipts cast
+        cosine-weighted section votes. A semi-Markov decoder combines those
+        votes with the ordered receipt sequence. On 167 held-out receipts, row
+        agreement rises from 85.95 to 90.84 percent. Geometry and arithmetic
+        evidence was tested separately and received weight zero because it did
+        not improve validation results.
+      </p>
+      <p className={styles.srOnly} aria-live="polite" data-testid="section-act-label">
+        {activeMeta.accessibleLabel}
+      </p>
+
+      <div className={`${styles.stage} ${styles.interactiveStage}`} data-testid="section-explorer-stage">
+        {layers.map((layer) => (
+          <div
+            key={layer.id}
+            className={`${styles.actLayer} ${styles[layer.phase]}`}
+            data-phase={layer.phase}
+            aria-hidden={layer.phase === "leaving"}
+          >
+            <ActView actId={layer.id} {...actProps(layer.progress)} />
+          </div>
+        ))}
+      </div>
+
+      <ol className={styles.progress} aria-label="Section classifier steps">
+        {EXPLORER_ACTS.map((act) => {
+          const isActive = act.index === activeAct;
+          return (
+            <li key={act.id}>
+              <button
+                type="button"
+                className={styles.progressButton}
+                data-active={isActive}
+                data-done={act.index < activeAct}
+                aria-pressed={isActive}
+                aria-label={act.accessibleLabel}
+                title={act.label}
+                onClick={() => jumpToAct(act.index)}
+                data-testid={`section-act-dot-${act.index}`}
+              >
+                <span aria-hidden="true" />
+              </button>
+            </li>
+          );
+        })}
+      </ol>
+    </section>
+  );
+};
+
+export default SectionEmbeddingExplorer;

--- a/portfolio/components/ui/Figures/SectionEmbeddingExplorer/index.tsx
+++ b/portfolio/components/ui/Figures/SectionEmbeddingExplorer/index.tsx
@@ -7,9 +7,14 @@ import React, {
 } from "react";
 import { useInView } from "react-intersection-observer";
 import { useActTransition } from "../SynthesisPipeline/actTransition";
+import { getCdnBaseUrl } from "../../../../utils/cdnBase";
 import styles from "./SectionEmbeddingExplorer.module.css";
 import {
+  BoundingBox,
   CHANGED_ROW_IDS,
+  CORPUS_SNAPSHOT,
+  CORRECTED_ROW_IDS,
+  CURRENT_RECEIPT,
   EXPLORER_ACTS,
   EXPERIMENT_METRICS,
   ExplorerActId,
@@ -18,6 +23,7 @@ import {
   ReferenceReceipt,
   SECTION_BY_ID,
   SectionId,
+  UNRESOLVED_ROW_IDS,
 } from "./sectionData";
 
 const AUTOPLAY_IDLE_RESUME_MS = 10_000;
@@ -74,19 +80,49 @@ type Assignment = SectionId | null;
 interface SectionSpan {
   section: SectionId;
   start: number;
-  length: number;
+  end: number;
+  top: number;
+  height: number;
 }
 
-const sectionSpans = (assignments: Assignment[]): SectionSpan[] => {
+const topForBox = (box: BoundingBox): number => 1 - box.yMax;
+const bottomForBox = (box: BoundingBox): number => 1 - box.yMin;
+const percent = (value: number): string => `${Math.max(0, Math.min(1, value)) * 100}%`;
+
+const boxStyle = (box: BoundingBox): React.CSSProperties => ({
+  left: percent(box.xMin),
+  top: percent(topForBox(box)),
+  width: percent(Math.min(1, box.xMax) - Math.max(0, box.xMin)),
+  height: percent(box.yMax - box.yMin),
+});
+
+const receiptImageUrl = (key: string): string =>
+  `${getCdnBaseUrl().replace(/\/$/, "")}/${key}`;
+
+const sectionSpans = (
+  assignments: Assignment[],
+  boxes: BoundingBox[],
+): SectionSpan[] => {
   const spans: SectionSpan[] = [];
   assignments.forEach((section, index) => {
     if (!section) return;
     const previous = spans[spans.length - 1];
-    if (previous?.section === section && previous.start + previous.length === index) {
-      previous.length += 1;
+    const rowTop = topForBox(boxes[index]);
+    const rowBottom = bottomForBox(boxes[index]);
+    if (previous?.section === section && previous.end + 1 === index) {
+      const previousBottom = previous.top + previous.height;
+      previous.end = index;
+      previous.top = Math.min(previous.top, rowTop);
+      previous.height = Math.max(previousBottom, rowBottom) - previous.top;
       return;
     }
-    spans.push({ section, start: index, length: 1 });
+    spans.push({
+      section,
+      start: index,
+      end: index,
+      top: rowTop,
+      height: rowBottom - rowTop,
+    });
   });
   return spans;
 };
@@ -99,11 +135,14 @@ const assignmentsForAct = (
   if (actId === "baseline" || actId === "neighbors") {
     return RECEIPT_ROWS.map((row) => row.baseline);
   }
-  if (actId === "final") return RECEIPT_ROWS.map((row) => row.truth);
+  if (actId === "final") return RECEIPT_ROWS.map((row) => row.hybrid);
 
+  const changedRows = RECEIPT_ROWS.filter((row) => CHANGED_ROW_IDS.has(row.id));
   return RECEIPT_ROWS.map((row) => {
-    if (row.id === "subtotal" && progress >= 0.38) return row.truth;
-    if (row.id === "visa" && progress >= 0.67) return row.truth;
+    const changedIndex = changedRows.findIndex((candidate) => candidate.id === row.id);
+    if (changedIndex >= 0 && progress >= 0.24 + changedIndex * 0.085) {
+      return row.hybrid;
+    }
     return row.baseline;
   });
 };
@@ -113,59 +152,62 @@ const ACT_COPY: Record<
   { title: string; detail: string; evidence: string; sceneLabel: string }
 > = {
   ocr: {
-    title: "Start with complete Apple OCR rows.",
-    detail: "LayoutLM labels words separately. This pass assigns one section to each complete row.",
-    evidence: "LayoutLM → words · section decoder → rows",
-    sceneLabel: "Apple OCR rows are visible on the current receipt without section assignments.",
+    title: "Start with rows from a real test receipt.",
+    detail: "LayoutLM labels words separately. This pass assigns one section to each complete Apple OCR row.",
+    evidence: `${CURRENT_RECEIPT.merchant} · ${CURRENT_RECEIPT.sourceId} · ${CURRENT_RECEIPT.visibleRows} stored OCR row boxes shown`,
+    sceneLabel: "Real Apple OCR rows from a Salt and Straw test receipt are visible without section assignments.",
   },
   baseline: {
-    title: "Let the fair baseline draw its boundaries.",
-    detail: "Two row-by-row guesses push ITEMS and SUMMARY one row too far.",
+    title: "Run the measured baseline on those rows.",
+    detail: "Seven visible rows land in the wrong band, splitting INFO, ITEMS, and SUMMARY.",
     evidence: "merchant identity · helpful, optional",
-    sceneLabel: "Baseline section bands contain incorrect boundaries at subtotal and Visa rows.",
+    sceneLabel: "Measured baseline assignments contain seven incorrect rows and fragmented section boundaries.",
   },
   neighbors: {
-    title: "Search labeled rows from other receipts.",
-    detail: "OpenAI creates row embeddings; Chroma finds the nearest labeled rows.",
-    evidence: "4 of 15 neighbors shown · 2-D map is schematic, not literal",
-    sceneLabel: "Similar subtotal and payment rows are highlighted across the labeled receipt stack.",
+    title: "Search actual labeled rows from the corpus.",
+    detail: "OpenAI created the row embeddings; Chroma returned these QA-valid neighbors and cosine scores.",
+    evidence: "4 real receipts shown · cosine 0.840–0.901 · 2-D map is schematic",
+    sceneLabel: "Real summary and payment neighbors are highlighted with measured cosine similarity scores.",
   },
   corrected: {
-    title: "Move the assignments downstream.",
-    detail: "Neighbor votes and sequence order correct rows, then redraw contiguous boundaries.",
+    title: "Apply the hybrid assignments downstream.",
+    detail: "Seven rows move. Six reach QA truth; the $6.48 total remains an honest miss.",
     evidence: "experimental geometry ×0.0 · receipt math ×0.0",
-    sceneLabel: "Subtotal moves from items to summary and Visa moves from summary to payment.",
+    sceneLabel: "Seven measured assignments move, six are corrected, and the six dollar forty-eight total remains unresolved.",
   },
   final: {
-    title: "Finish with one clean section sequence.",
-    detail: "The outlined rows changed; every section is contiguous on the front receipt.",
-    evidence: `held-out row agreement +${EXPERIMENT_METRICS.deltaPoints} pp · ${EXPERIMENT_METRICS.fixed} fixed`,
-    sceneLabel: "The current receipt has clean contiguous bands and highlights the two changed rows.",
+    title: "Finish with one contiguous hybrid sequence.",
+    detail: "Outlined rows changed. FIX marks six corrections; MISS keeps the unresolved total visible.",
+    evidence: `this receipt: 6 fixed · 1 unresolved · held-out agreement +${EXPERIMENT_METRICS.deltaPoints} pp`,
+    sceneLabel: "The real receipt has contiguous hybrid bands, with six corrected rows and one unresolved row highlighted.",
   },
 };
 
 interface SectionBandsProps {
   assignments: Assignment[];
+  boxes: BoundingBox[];
   opacity: number;
   compact?: boolean;
 }
 
 const SectionBands: React.FC<SectionBandsProps> = ({
   assignments,
+  boxes,
   opacity,
   compact = false,
 }) => (
   <div className={styles.sectionBands} aria-hidden="true">
-    {sectionSpans(assignments).map((span, index) => (
+    {sectionSpans(assignments, boxes).map((span, index) => (
       <div
         key={`${span.section}-${span.start}-${index}`}
         className={styles.sectionBand}
+        data-testid="section-band"
         data-section={span.section}
         data-compact={compact || undefined}
         style={
           {
-            "--band-start": span.start,
-            "--band-length": span.length,
+            top: percent(span.top),
+            height: percent(span.height),
             opacity,
           } as React.CSSProperties
         }
@@ -193,41 +235,70 @@ const CurrentReceipt: React.FC<CurrentReceiptProps> = ({ actId, progress }) => {
       className={`${styles.receiptCard} ${styles.currentReceipt}`}
       data-testid="section-current-receipt"
       data-assignment={actId}
-      aria-hidden="true"
+      data-source-id={CURRENT_RECEIPT.sourceId}
+      aria-label={`${CURRENT_RECEIPT.merchant} receipt image with stored OCR row bounding boxes`}
     >
       <div className={styles.receiptHeader}>
-        <strong>SPROUTS</strong>
-        <span>{actId === "ocr" ? "APPLE OCR" : "CURRENT"}</span>
+        <strong>{CURRENT_RECEIPT.merchant}</strong>
+        <span>{actId === "ocr" ? "APPLE OCR BOXES" : "TEST RECEIPT"}</span>
       </div>
-      <div className={styles.receiptRows}>
-        <SectionBands assignments={assignments} opacity={bandsVisible} />
+      <div
+        className={styles.imagePlane}
+        style={{ aspectRatio: `${CURRENT_RECEIPT.width} / ${CURRENT_RECEIPT.height}` }}
+      >
+        <img
+          src={receiptImageUrl(CURRENT_RECEIPT.imageKey)}
+          width={CURRENT_RECEIPT.width}
+          height={CURRENT_RECEIPT.height}
+          alt=""
+          data-testid="section-current-image"
+        />
+        <div className={styles.imageShade} aria-hidden="true" />
+        <SectionBands
+          assignments={assignments}
+          boxes={RECEIPT_ROWS.map((row) => row.bbox)}
+          opacity={bandsVisible}
+        />
         {RECEIPT_ROWS.map((row, index) => {
           const reveal = phase(rowReveal, index * 0.035, 0.3 + index * 0.04);
           const assignment = assignments[index];
-          const corrected = assignment === row.truth && row.baseline !== row.truth;
+          const changed = assignment === row.hybrid && row.baseline !== row.hybrid;
+          const corrected = changed && CORRECTED_ROW_IDS.has(row.id);
+          const unresolved = changed && UNRESOLVED_ROW_IDS.has(row.id);
           return (
             <div
               key={row.id}
-              className={styles.receiptRow}
+              className={styles.rowBox}
               data-row-id={row.id}
               data-section={assignment ?? undefined}
               data-neighbor={showNeighbors && CHANGED_ROW_IDS.has(row.id) || undefined}
-              data-changed={showChanges && corrected || undefined}
+              data-baseline-error={actId === "baseline" && row.baseline !== row.truth || undefined}
+              data-changed={showChanges && changed || undefined}
+              data-corrected={showChanges && corrected || undefined}
+              data-unresolved={showChanges && unresolved || undefined}
+              data-source-truth={row.sourceTruth}
+              data-source-baseline={row.sourceBaseline}
+              data-source-hybrid={row.sourceHybrid}
               data-testid={`section-row-${row.id}`}
+              aria-label={`OCR row ${row.rowId}: ${row.text}`}
+              title={row.text}
               style={{
+                ...boxStyle(row.bbox),
                 opacity: reveal,
-                transform: `translateY(${(1 - reveal) * 5}px)`,
+                transform: `translateY(${(1 - reveal) * 4}px)`,
               }}
             >
-              <span>{row.text}</span>
-              {row.amount ? <span>{row.amount}</span> : null}
+              <span className={styles.srOnly}>{row.text}</span>
+              {showChanges && changed ? (
+                <span className={styles.rowStatus}>{unresolved ? "MISS" : "FIX"}</span>
+              ) : null}
             </div>
           );
         })}
       </div>
       <div className={styles.receiptFooter}>
-        <span>11 complete rows</span>
-        <span>{actId === "ocr" ? "unassigned" : "ordered"}</span>
+        <span>{CURRENT_RECEIPT.visibleRows} stored row boxes</span>
+        <span>{CURRENT_RECEIPT.sourceId}</span>
       </div>
     </div>
   );
@@ -245,32 +316,60 @@ const ReferenceReceiptCard: React.FC<{
       className={`${styles.receiptCard} ${styles.referenceReceipt}`}
       data-reference-index={index}
       data-testid={`section-reference-receipt-${index}`}
-      aria-hidden="true"
+      data-source-id={receipt.sourceId}
+      aria-label={`${receipt.merchant} labeled neighbor receipt image`}
       style={{ "--reference-index": index } as React.CSSProperties}
     >
       <div className={styles.receiptHeader}>
         <strong>{receipt.merchant}</strong>
-        <span>LABELED</span>
+        <span>LABELED IMAGE</span>
       </div>
-      <div className={styles.receiptRows}>
-        <SectionBands assignments={assignments} opacity={1} compact />
+      <div
+        className={styles.imagePlane}
+        style={{ aspectRatio: `${receipt.width} / ${receipt.height}` }}
+      >
+        <img
+          src={receiptImageUrl(receipt.imageKey)}
+          width={receipt.width}
+          height={receipt.height}
+          alt=""
+          data-testid={`section-reference-image-${index}`}
+        />
+        <div className={styles.imageShade} aria-hidden="true" />
+        <SectionBands
+          assignments={assignments}
+          boxes={receipt.rows.map((row) => row.bbox)}
+          opacity={1}
+          compact
+        />
         {receipt.rows.map((row) => {
           const isNeighbor = showNeighbors && Boolean(row.matches);
           const reveal = phase(progress, 0.14 + index * 0.06, 0.62 + index * 0.06);
           return (
             <div
               key={row.id}
-              className={styles.receiptRow}
+              className={styles.rowBox}
               data-section={row.section}
               data-neighbor={isNeighbor || undefined}
-              data-neighbor-kind={row.matches}
-              style={{ opacity: showNeighbors ? 0.46 + reveal * 0.54 : 1 }}
+              data-neighbor-kind={row.matches ? receipt.neighborSection : undefined}
+              aria-label={row.text}
+              title={row.text}
+              style={{
+                ...boxStyle(row.bbox),
+                opacity: showNeighbors ? 0.46 + reveal * 0.54 : 1,
+              }}
             >
-              <span>{row.text}</span>
-              {row.amount ? <span>{row.amount}</span> : null}
+              <span className={styles.srOnly}>{row.text}</span>
+              {isNeighbor && row.similarity ? (
+                <span className={styles.neighborScore}>{row.similarity.toFixed(3)}</span>
+              ) : null}
             </div>
           );
         })}
+      </div>
+      <div className={styles.receiptFooter}>
+        <span>{receipt.sourceId}</span>
+        <span>cos {receipt.bestSimilarity.toFixed(3)}</span>
       </div>
     </div>
   );
@@ -285,16 +384,16 @@ const NeighborConnections: React.FC<{ progress: number }> = ({ progress }) => {
       aria-hidden="true"
       style={{ opacity: reveal }}
     >
-      <path data-section="SUMMARY" d="M441 236 C474 226 486 166 507 155" pathLength="1" />
-      <path data-section="PAYMENT" d="M441 303 C510 321 560 226 624 210" pathLength="1" />
-      <path data-section="SUMMARY" d="M441 236 C551 276 640 216 732 208" pathLength="1" />
-      <path data-section="PAYMENT" d="M441 303 C610 350 715 290 804 272" pathLength="1" />
-      <circle data-section="SUMMARY" cx="441" cy="236" r="4" />
-      <circle data-section="PAYMENT" cx="441" cy="303" r="4" />
-      <circle data-section="SUMMARY" cx="507" cy="155" r="4" />
-      <circle data-section="PAYMENT" cx="624" cy="210" r="4" />
-      <circle data-section="SUMMARY" cx="732" cy="208" r="4" />
-      <circle data-section="PAYMENT" cx="804" cy="272" r="4" />
+      <path data-section="SUMMARY" d="M300 248 C348 243 390 248 435 250" pathLength="1" />
+      <path data-section="PAYMENT" d="M300 308 C392 302 466 228 550 213" pathLength="1" />
+      <path data-section="SUMMARY" d="M300 248 C420 238 540 175 658 160" pathLength="1" />
+      <path data-section="PAYMENT" d="M300 308 C466 347 616 332 758 316" pathLength="1" />
+      <circle data-section="SUMMARY" cx="300" cy="248" r="4" />
+      <circle data-section="PAYMENT" cx="300" cy="308" r="4" />
+      <circle data-section="SUMMARY" cx="435" cy="250" r="4" />
+      <circle data-section="PAYMENT" cx="550" cy="213" r="4" />
+      <circle data-section="SUMMARY" cx="658" cy="160" r="4" />
+      <circle data-section="PAYMENT" cx="758" cy="316" r="4" />
     </svg>
   );
 };
@@ -358,6 +457,7 @@ const ReceiptStackScene: React.FC<{
       <div className={styles.evidenceLine} data-testid="section-evidence-line">
         <span className={styles.evidenceRule} aria-hidden="true" />
         <span>{copy.evidence}</span>
+        <span className={styles.snapshotTag}>real snapshot · {CORPUS_SNAPSHOT.receipts} receipts</span>
       </div>
     </div>
   );
@@ -525,7 +625,7 @@ const SectionEmbeddingExplorer: React.FC = () => {
         How row embeddings correct receipt section boundaries
       </h3>
       <p id="section-explorer-description" className={styles.srOnly}>
-        A five-step explainer. Apple OCR provides complete rows. LayoutLM labels individual words, while this visualization assigns sections to complete rows. OpenAI creates row embeddings and Chroma searches labeled rows from other receipts. The two-dimensional map is schematic. Merchant identity is optional. Experimental geometry and receipt math currently have zero weight.
+        A five-step explainer using genuine receipt images, stored Apple OCR row bounding boxes, and QA-valid labels from the July 29 dev snapshot. LayoutLM labels individual words, while this visualization assigns sections to complete rows. OpenAI creates row embeddings and Chroma searches labeled rows from other receipts. The two-dimensional map is schematic. Merchant identity is optional. Experimental geometry and receipt math currently have zero weight.
       </p>
       <p className={styles.srOnly} aria-live="polite" data-testid="section-act-label">
         {activeMeta.accessibleLabel}

--- a/portfolio/components/ui/Figures/SectionEmbeddingExplorer/sectionData.ts
+++ b/portfolio/components/ui/Figures/SectionEmbeddingExplorer/sectionData.ts
@@ -1,0 +1,325 @@
+export type SectionId =
+  | "TRANSACTION_INFO"
+  | "ITEMS"
+  | "SUMMARY"
+  | "PAYMENT";
+
+export interface SectionDefinition {
+  id: SectionId;
+  shortLabel: string;
+  label: string;
+  color: string;
+}
+
+export const SECTIONS: SectionDefinition[] = [
+  {
+    id: "TRANSACTION_INFO",
+    shortLabel: "INFO",
+    label: "Transaction info",
+    color: "var(--color-blue)",
+  },
+  {
+    id: "ITEMS",
+    shortLabel: "ITEMS",
+    label: "Items",
+    color: "var(--color-purple)",
+  },
+  {
+    id: "SUMMARY",
+    shortLabel: "SUM",
+    label: "Summary",
+    color: "var(--color-orange)",
+  },
+  {
+    id: "PAYMENT",
+    shortLabel: "PAY",
+    label: "Payment",
+    color: "var(--color-green)",
+  },
+];
+
+export const SECTION_BY_ID = Object.fromEntries(
+  SECTIONS.map((section) => [section.id, section]),
+) as Record<SectionId, SectionDefinition>;
+
+export interface ReceiptRow {
+  id: string;
+  text: string;
+  amount?: string;
+  truth: SectionId;
+  baseline: SectionId;
+}
+
+/**
+ * A compact, intentionally schematic receipt. The row text makes the evidence
+ * legible; the held-out metrics shown by the figure are the measured values.
+ */
+export const RECEIPT_ROWS: ReceiptRow[] = [
+  {
+    id: "merchant",
+    text: "SPROUTS FARMERS MARKET",
+    truth: "TRANSACTION_INFO",
+    baseline: "TRANSACTION_INFO",
+  },
+  {
+    id: "address",
+    text: "1234 MARKET STREET",
+    truth: "TRANSACTION_INFO",
+    baseline: "TRANSACTION_INFO",
+  },
+  {
+    id: "date",
+    text: "07/29/26  12:41 PM",
+    truth: "TRANSACTION_INFO",
+    baseline: "TRANSACTION_INFO",
+  },
+  {
+    id: "milk",
+    text: "ORGANIC WHOLE MILK",
+    amount: "4.99",
+    truth: "ITEMS",
+    baseline: "ITEMS",
+  },
+  {
+    id: "bananas",
+    text: "BANANAS 1.34 LB",
+    amount: "1.58",
+    truth: "ITEMS",
+    baseline: "ITEMS",
+  },
+  {
+    id: "avocado",
+    text: "HASS AVOCADO",
+    amount: "2.50",
+    truth: "ITEMS",
+    baseline: "ITEMS",
+  },
+  {
+    id: "subtotal",
+    text: "SUBTOTAL",
+    amount: "9.07",
+    truth: "SUMMARY",
+    baseline: "ITEMS",
+  },
+  {
+    id: "tax",
+    text: "TAX",
+    amount: "0.00",
+    truth: "SUMMARY",
+    baseline: "SUMMARY",
+  },
+  {
+    id: "total",
+    text: "TOTAL",
+    amount: "9.07",
+    truth: "SUMMARY",
+    baseline: "SUMMARY",
+  },
+  {
+    id: "visa",
+    text: "VISA ******** 1234",
+    truth: "PAYMENT",
+    baseline: "SUMMARY",
+  },
+  {
+    id: "approved",
+    text: "APPROVED",
+    truth: "PAYMENT",
+    baseline: "PAYMENT",
+  },
+];
+
+export interface QueryScenario {
+  id: "subtotal" | "visa" | "milk";
+  label: string;
+  rowId: string;
+  x: number;
+  y: number;
+  votes: Record<SectionId, number>;
+  baseline: SectionId;
+  decoded: SectionId;
+}
+
+export const QUERY_SCENARIOS: QueryScenario[] = [
+  {
+    id: "subtotal",
+    label: "SUBTOTAL 9.07",
+    rowId: "subtotal",
+    x: 64,
+    y: 57,
+    votes: {
+      TRANSACTION_INFO: 0.03,
+      ITEMS: 0.16,
+      SUMMARY: 0.76,
+      PAYMENT: 0.05,
+    },
+    baseline: "ITEMS",
+    decoded: "SUMMARY",
+  },
+  {
+    id: "visa",
+    label: "VISA •••• 1234",
+    rowId: "visa",
+    x: 78,
+    y: 78,
+    votes: {
+      TRANSACTION_INFO: 0.02,
+      ITEMS: 0.03,
+      SUMMARY: 0.1,
+      PAYMENT: 0.85,
+    },
+    baseline: "SUMMARY",
+    decoded: "PAYMENT",
+  },
+  {
+    id: "milk",
+    label: "WHOLE MILK 4.99",
+    rowId: "milk",
+    x: 30,
+    y: 48,
+    votes: {
+      TRANSACTION_INFO: 0.02,
+      ITEMS: 0.92,
+      SUMMARY: 0.05,
+      PAYMENT: 0.01,
+    },
+    baseline: "ITEMS",
+    decoded: "ITEMS",
+  },
+];
+
+export const QUERY_BY_ID = Object.fromEntries(
+  QUERY_SCENARIOS.map((scenario) => [scenario.id, scenario]),
+) as Record<QueryScenario["id"], QueryScenario>;
+
+export interface ProjectionPoint {
+  id: string;
+  merchant: string;
+  section: SectionId;
+  x: number;
+  y: number;
+}
+
+const CLUSTER_CENTERS: Record<SectionId, { x: number; y: number }> = {
+  TRANSACTION_INFO: { x: 23, y: 23 },
+  ITEMS: { x: 31, y: 52 },
+  SUMMARY: { x: 64, y: 55 },
+  PAYMENT: { x: 78, y: 79 },
+};
+
+const POINT_OFFSETS = [
+  [-8, -2],
+  [-5, 6],
+  [-2, -7],
+  [1, 3],
+  [4, -4],
+  [6, 5],
+  [9, 0],
+  [0, 9],
+] as const;
+
+const MERCHANTS = [
+  "Costco",
+  "Vons",
+  "Target",
+  "CVS",
+  "Trader Joe's",
+  "In-N-Out",
+  "Wild Fork",
+  "Ralphs",
+];
+
+export const PROJECTION_POINTS: ProjectionPoint[] = SECTIONS.flatMap(
+  (section) => {
+    const center = CLUSTER_CENTERS[section.id];
+    return POINT_OFFSETS.map(([dx, dy], index) => ({
+      id: `${section.id}-${index}`,
+      merchant: MERCHANTS[index],
+      section: section.id,
+      x: center.x + dx,
+      y: center.y + dy,
+    }));
+  },
+);
+
+/** Return the 15 visible cross-receipt neighbors closest in the 2-D explainer. */
+export const nearestProjectionPoints = (
+  scenario: QueryScenario,
+  count = 15,
+): ProjectionPoint[] =>
+  PROJECTION_POINTS.map((point) => ({
+    point,
+    distance: Math.hypot(point.x - scenario.x, point.y - scenario.y),
+  }))
+    .sort((a, b) => a.distance - b.distance)
+    .slice(0, count)
+    .map(({ point }) => point);
+
+export type ExplorerActId =
+  | "receipt"
+  | "projection"
+  | "neighbors"
+  | "decode"
+  | "result";
+
+export interface ExplorerAct {
+  id: ExplorerActId;
+  index: number;
+  label: string;
+  accessibleLabel: string;
+  dwellMs: number;
+}
+
+export const EXPLORER_ACTS: ExplorerAct[] = [
+  {
+    id: "receipt",
+    index: 0,
+    label: "Read the rows",
+    accessibleLabel: "Step 1: read the receipt as an ordered row sequence",
+    dwellMs: 5200,
+  },
+  {
+    id: "projection",
+    index: 1,
+    label: "Project meaning",
+    accessibleLabel: "Step 2: project rows into embedding space",
+    dwellMs: 7000,
+  },
+  {
+    id: "neighbors",
+    index: 2,
+    label: "Let neighbors vote",
+    accessibleLabel: "Step 3: collect cosine-weighted cross-receipt votes",
+    dwellMs: 8000,
+  },
+  {
+    id: "decode",
+    index: 3,
+    label: "Decode the sequence",
+    accessibleLabel: "Step 4: decode one contiguous receipt sequence",
+    dwellMs: 7600,
+  },
+  {
+    id: "result",
+    index: 4,
+    label: "Check the holdout",
+    accessibleLabel: "Step 5: compare held-out accuracy",
+    dwellMs: 9000,
+  },
+];
+
+export const EXPERIMENT_METRICS = {
+  receipts: 167,
+  rows: 4214,
+  baselineCorrect: 3622,
+  hybridCorrect: 3828,
+  baselineAgreement: 85.95,
+  hybridAgreement: 90.84,
+  deltaPoints: 4.89,
+  fixed: 236,
+  regressed: 30,
+  coverage: 99.87,
+  bootstrapLow: 3.87,
+  bootstrapHigh: 5.94,
+} as const;
+

--- a/portfolio/components/ui/Figures/SectionEmbeddingExplorer/sectionData.ts
+++ b/portfolio/components/ui/Figures/SectionEmbeddingExplorer/sectionData.ts
@@ -42,146 +42,352 @@ export const SECTION_BY_ID = Object.fromEntries(
   SECTIONS.map((section) => [section.id, section]),
 ) as Record<SectionId, SectionDefinition>;
 
-export interface ReceiptRow {
-  id: string;
-  text: string;
-  amount?: string;
-  truth: SectionId;
-  baseline: SectionId;
+export const CORPUS_SNAPSHOT = {
+  id: "20260729_203457_486164_849816c8",
+  dynamodbSyncedAt: "2026-07-29T20:41:05.751096+00:00",
+  receipts: 783,
+  embeddedRows: 28_172,
+  note: "Genuine QA-valid corpus rows and receipt images from the frozen dev snapshot.",
+} as const;
+
+export interface BoundingBox {
+  xMin: number;
+  xMax: number;
+  yMin: number;
+  yMax: number;
 }
 
-/** A compact held-out receipt with two deliberately wrong baseline boundaries. */
-export const RECEIPT_ROWS: ReceiptRow[] = [
-  {
-    id: "merchant",
-    text: "SPROUTS FARMERS MARKET",
-    truth: "TRANSACTION_INFO",
-    baseline: "TRANSACTION_INFO",
-  },
-  {
-    id: "address",
-    text: "1234 MARKET STREET",
-    truth: "TRANSACTION_INFO",
-    baseline: "TRANSACTION_INFO",
-  },
-  {
-    id: "date",
-    text: "07/29/26  12:41 PM",
-    truth: "TRANSACTION_INFO",
-    baseline: "TRANSACTION_INFO",
-  },
-  {
-    id: "milk",
-    text: "ORGANIC WHOLE MILK",
-    amount: "4.99",
-    truth: "ITEMS",
-    baseline: "ITEMS",
-  },
-  {
-    id: "bananas",
-    text: "BANANAS 1.34 LB",
-    amount: "1.58",
-    truth: "ITEMS",
-    baseline: "ITEMS",
-  },
-  {
-    id: "avocado",
-    text: "HASS AVOCADO",
-    amount: "2.50",
-    truth: "ITEMS",
-    baseline: "ITEMS",
-  },
-  {
-    id: "subtotal",
-    text: "SUBTOTAL",
-    amount: "9.07",
-    truth: "SUMMARY",
-    baseline: "ITEMS",
-  },
-  {
-    id: "tax",
-    text: "TAX",
-    amount: "0.00",
-    truth: "SUMMARY",
-    baseline: "SUMMARY",
-  },
-  {
-    id: "total",
-    text: "TOTAL",
-    amount: "9.07",
-    truth: "SUMMARY",
-    baseline: "SUMMARY",
-  },
-  {
-    id: "visa",
-    text: "VISA ******** 1234",
-    truth: "PAYMENT",
-    baseline: "SUMMARY",
-  },
-  {
-    id: "approved",
-    text: "APPROVED",
-    truth: "PAYMENT",
-    baseline: "PAYMENT",
-  },
-];
+export interface ReceiptRow {
+  id: string;
+  rowId: number;
+  text: string;
+  truth: SectionId;
+  baseline: SectionId;
+  hybrid: SectionId;
+  sourceTruth: string;
+  sourceBaseline: string;
+  sourceHybrid: string;
+  bbox: BoundingBox;
+}
 
-export const CHANGED_ROW_IDS = new Set(["subtotal", "visa"]);
+export interface CurrentReceipt {
+  sourceId: string;
+  merchant: string;
+  visibleRows: number;
+  sourceRows: number;
+  imageId: string;
+  imageKey: string;
+  width: number;
+  height: number;
+  rows: ReceiptRow[];
+}
+
+/**
+ * A crop of one genuine receipt in the untouched test split. Text is the
+ * materialized Apple Vision OCR row text. The source labels and predictions
+ * are preserved alongside the four display bands.
+ */
+export const CURRENT_RECEIPT: CurrentReceipt = {
+  sourceId: "d47b0f01 · R1",
+  merchant: "Salt & Straw",
+  visibleRows: 14,
+  sourceRows: 24,
+  imageId: "d47b0f01-859d-499b-a9b0-4feb312b4d27",
+  imageKey: "assets/d47b0f01-859d-499b-a9b0-4feb312b4d27/1.webp",
+  width: 425,
+  height: 884,
+  rows: [
+    {
+      id: "row-2",
+      rowId: 2,
+      text: "Salt & Straw",
+      truth: "TRANSACTION_INFO",
+      baseline: "TRANSACTION_INFO",
+      hybrid: "TRANSACTION_INFO",
+      sourceTruth: "STOREFRONT",
+      sourceBaseline: "STOREFRONT",
+      sourceHybrid: "STOREFRONT",
+      bbox: { xMin: 0.4316419539420748, xMax: 0.6952462630241061, yMin: 0.871117548766409, yMax: 0.8977778003838407 },
+    },
+    {
+      id: "row-8",
+      rowId: 8,
+      text: "Check #16",
+      truth: "TRANSACTION_INFO",
+      baseline: "TRANSACTION_INFO",
+      hybrid: "TRANSACTION_INFO",
+      sourceTruth: "TRANSACTION_INFO",
+      sourceBaseline: "TRANSACTION_INFO",
+      sourceHybrid: "TRANSACTION_INFO",
+      bbox: { xMin: 0.08436126395558124, xMax: 0.2872399413237453, yMin: 0.6158350615110841, yMax: 0.6414323816642471 },
+    },
+    {
+      id: "row-10",
+      rowId: 10,
+      text: "1 Kid Scoop  $5.25",
+      truth: "ITEMS",
+      baseline: "ITEMS",
+      hybrid: "ITEMS",
+      sourceTruth: "ITEMS",
+      sourceBaseline: "ITEMS",
+      sourceHybrid: "ITEMS",
+      bbox: { xMin: 0.0859641899893249, xMax: 0.9849961475574337, yMin: 0.5144183078305706, yMax: 0.5547417460194478 },
+    },
+    {
+      id: "row-11",
+      rowId: 11,
+      text: "Subtotal",
+      truth: "SUMMARY",
+      baseline: "TRANSACTION_INFO",
+      hybrid: "SUMMARY",
+      sourceTruth: "SUMMARY",
+      sourceBaseline: "SECTION_HEADER",
+      sourceHybrid: "SUMMARY",
+      bbox: { xMin: 0.0845921503955299, xMax: 0.25981872815431895, yMin: 0.47383720902711646, yMax: 0.49709302306590664 },
+    },
+    {
+      id: "row-12",
+      rowId: 12,
+      text: "Tax  $5.25",
+      truth: "SUMMARY",
+      baseline: "ITEMS",
+      hybrid: "SUMMARY",
+      sourceTruth: "SUMMARY",
+      sourceBaseline: "ITEMS",
+      sourceHybrid: "SUMMARY",
+      bbox: { xMin: 0.07854984832382587, xMax: 0.9791741579031199, yMin: 0.4491279073382469, yMax: 0.48293016961824553 },
+    },
+    {
+      id: "row-29",
+      rowId: 29,
+      text: "$0.44",
+      truth: "SUMMARY",
+      baseline: "ITEMS",
+      hybrid: "SUMMARY",
+      sourceTruth: "SUMMARY",
+      sourceBaseline: "ITEMS",
+      sourceHybrid: "SUMMARY",
+      bbox: { xMin: 0.864048341546288, xMax: 0.9788519609310535, yMin: 0.4316860462364188, yMax: 0.4549418602752091 },
+    },
+    {
+      id: "row-30",
+      rowId: 30,
+      text: "$0.79",
+      truth: "SUMMARY",
+      baseline: "ITEMS",
+      hybrid: "SUMMARY",
+      sourceTruth: "SUMMARY",
+      sourceBaseline: "ITEMS",
+      sourceHybrid: "SUMMARY",
+      bbox: { xMin: 0.8640483400604525, xMax: 0.9818731081268587, yMin: 0.40406976735075995, yMax: 0.4273255813895501 },
+    },
+    {
+      id: "row-14",
+      rowId: 14,
+      text: "Total",
+      truth: "SUMMARY",
+      baseline: "TRANSACTION_INFO",
+      hybrid: "SUMMARY",
+      sourceTruth: "TOTAL_LINE",
+      sourceBaseline: "SECTION_HEADER",
+      sourceHybrid: "TOTAL_LINE",
+      bbox: { xMin: 0.06948640334129311, xMax: 0.18126888167381264, yMin: 0.3909883722829304, yMax: 0.41424418632172066 },
+    },
+    {
+      id: "row-31",
+      rowId: 31,
+      text: "$6.48",
+      truth: "SUMMARY",
+      baseline: "ITEMS",
+      hybrid: "PAYMENT",
+      sourceTruth: "TOTAL_LINE",
+      sourceBaseline: "ITEMS",
+      sourceHybrid: "PAYMENT",
+      bbox: { xMin: 0.86393578019384, xMax: 0.9819856688046797, yMin: 0.37487560840177114, yMax: 0.39983369441556516 },
+    },
+    {
+      id: "row-15",
+      rowId: 15,
+      text: "Input Type  C (EMV Chip Read)",
+      truth: "PAYMENT",
+      baseline: "PAYMENT",
+      hybrid: "PAYMENT",
+      sourceTruth: "PAYMENT",
+      sourceBaseline: "PAYMENT",
+      sourceHybrid: "PAYMENT",
+      bbox: { xMin: 0.06042296107288371, xMax: 0.9833943142488845, yMin: 0.31496484453490325, yMax: 0.3548076919394373 },
+    },
+    {
+      id: "row-16",
+      rowId: 16,
+      text: "VISA DEBIT  •••• ••••",
+      truth: "PAYMENT",
+      baseline: "PAYMENT",
+      hybrid: "PAYMENT",
+      sourceTruth: "PAYMENT",
+      sourceBaseline: "PAYMENT",
+      sourceHybrid: "PAYMENT",
+      bbox: { xMin: 0.05431972610547643, xMax: 0.2810277034003983, yMin: 0.3021877615959917, yMax: 0.32571921502205936 },
+    },
+    {
+      id: "row-34",
+      rowId: 34,
+      text: "12:54 PM",
+      truth: "PAYMENT",
+      baseline: "TRANSACTION_INFO",
+      hybrid: "PAYMENT",
+      sourceTruth: "PAYMENT",
+      sourceBaseline: "TRANSACTION_INFO",
+      sourceHybrid: "PAYMENT",
+      bbox: { xMin: 0.8002513412598269, xMax: 0.9852471450928346, yMin: 0.2580989826297774, yMax: 0.28405218010902544 },
+    },
+    {
+      id: "row-18",
+      rowId: 18,
+      text: "Transaction Type  Sale",
+      truth: "PAYMENT",
+      baseline: "PAYMENT",
+      hybrid: "PAYMENT",
+      sourceTruth: "PAYMENT",
+      sourceBaseline: "PAYMENT",
+      sourceHybrid: "PAYMENT",
+      bbox: { xMin: 0.04061723786687492, xMax: 0.9879154062440662, yMin: 0.22819767460851192, yMax: 0.26802326052058534 },
+    },
+    {
+      id: "row-36",
+      rowId: 36,
+      text: "Approved",
+      truth: "PAYMENT",
+      baseline: "PAYMENT",
+      hybrid: "PAYMENT",
+      sourceTruth: "PAYMENT",
+      sourceBaseline: "PAYMENT",
+      sourceHybrid: "PAYMENT",
+      bbox: { xMin: 0.7974159531303394, xMax: 0.9880825333305348, yMin: 0.1959203958698077, yMax: 0.22123076734209302 },
+    },
+  ],
+};
+
+export const RECEIPT_ROWS = CURRENT_RECEIPT.rows;
+
+export const CHANGED_ROW_IDS = new Set(
+  RECEIPT_ROWS.filter((row) => row.baseline !== row.hybrid).map((row) => row.id),
+);
+
+export const CORRECTED_ROW_IDS = new Set(
+  RECEIPT_ROWS.filter(
+    (row) => row.baseline !== row.hybrid && row.hybrid === row.truth,
+  ).map((row) => row.id),
+);
+
+export const UNRESOLVED_ROW_IDS = new Set(
+  RECEIPT_ROWS.filter(
+    (row) => row.baseline !== row.hybrid && row.hybrid !== row.truth,
+  ).map((row) => row.id),
+);
 
 export interface ReferenceReceiptRow {
   id: string;
   text: string;
-  amount?: string;
   section: SectionId;
-  matches?: "subtotal" | "visa";
+  matches?: boolean;
+  similarity?: number;
+  bbox: BoundingBox;
 }
 
 export interface ReferenceReceipt {
   id: string;
+  sourceId: string;
   merchant: string;
+  bestSimilarity: number;
+  neighborSection: "SUMMARY" | "PAYMENT";
+  imageId: string;
+  imageKey: string;
+  width: number;
+  height: number;
   rows: ReferenceReceiptRow[];
 }
 
-/** Representative labeled receipts. Four of the 15 searched neighbors are drawn. */
+/** Real QA-valid neighbors returned by the frozen train + validation corpus. */
 export const REFERENCE_RECEIPTS: ReferenceReceipt[] = [
   {
-    id: "costco",
-    merchant: "COSTCO",
+    id: "05de0b2d",
+    sourceId: "05de0b2d · R1",
+    merchant: "Brooklyn's Best Pizza & Pasta",
+    bestSimilarity: 0.9006,
+    neighborSection: "SUMMARY",
+    imageId: "05de0b2d-dbec-4531-87df-ded7b7a838ae",
+    imageKey: "assets/05de0b2d-dbec-4531-87df-ded7b7a838ae/1.webp",
+    width: 298,
+    height: 856,
     rows: [
-      { id: "costco-info", text: "COSTCO #117", section: "TRANSACTION_INFO" },
-      { id: "costco-item", text: "ORG WHOLE MILK", amount: "4.69", section: "ITEMS" },
-      { id: "costco-subtotal", text: "SUBTOTAL", amount: "12.47", section: "SUMMARY", matches: "subtotal" },
-      { id: "costco-pay", text: "VISA •••• 8472", section: "PAYMENT" },
+      { id: "05de0b2d-13", text: "Check #233", section: "TRANSACTION_INFO", bbox: { xMin: 0.02461650716763117, xMax: 0.9921757418553313, yMin: 0.5111637776211981, yMax: 0.5353858475803746 } },
+      { id: "05de0b2d-14", text: "Ordered: 5/24/26 8:17 PM", section: "TRANSACTION_INFO", bbox: { xMin: 0.020683214131498488, xMax: 0.9958333272401257, yMin: 0.48695652206284357, yMax: 0.5132299470962375 } },
+      { id: "05de0b2d-15", text: "1 Specialty Slice  $5.00", section: "ITEMS", bbox: { xMin: 0.020833344547526025, xMax: 0.9875000002083333, yMin: 0.44347826057143036, yMax: 0.46521739122759087 } },
+      { id: "05de0b2d-18", text: "Tax  $0.42", section: "SUMMARY", matches: true, similarity: 0.9006, bbox: { xMin: 0.02083333401462132, xMax: 0.9796297266114673, yMin: 0.35615673332073483, yMax: 0.3811594205585088 } },
+      { id: "05de0b2d-20", text: "Input Type  C (EMV Chip Read)", section: "PAYMENT", bbox: { xMin: 0.016524995121292477, xMax: 0.9708333346354165, yMin: 0.2913043481430494, yMax: 0.311812660101507 } },
+      { id: "05de0b2d-21", text: "VISA DEBIT  •••• ••••", section: "PAYMENT", bbox: { xMin: 0.016666667854166633, xMax: 0.9708333313690476, yMin: 0.26949860692742866, yMax: 0.28840579729280824 } },
+      { id: "05de0b2d-22", text: "Transaction Type  Sale", section: "PAYMENT", bbox: { xMin: 0.01249999531250009, xMax: 0.9791666671666667, yMin: 0.24637681146976464, yMax: 0.2652173914667213 } },
     ],
   },
   {
-    id: "vons",
-    merchant: "VONS",
+    id: "534f5ac3",
+    sourceId: "534f5ac3 · R1",
+    merchant: "Mouthful Eatery",
+    bestSimilarity: 0.8469,
+    neighborSection: "PAYMENT",
+    imageId: "534f5ac3-528e-44a5-81c3-b2164691ed34",
+    imageKey: "assets/534f5ac3-528e-44a5-81c3-b2164691ed34/1.webp",
+    width: 844,
+    height: 1845,
     rows: [
-      { id: "vons-info", text: "VONS STORE 2091", section: "TRANSACTION_INFO" },
-      { id: "vons-item", text: "BANANAS", amount: "1.92", section: "ITEMS" },
-      { id: "vons-summary", text: "TOTAL", amount: "18.39", section: "SUMMARY" },
-      { id: "vons-visa", text: "VISA •••• 0064", section: "PAYMENT", matches: "visa" },
+      { id: "534f5ac3-16", text: "Transaction Type  Sale", section: "PAYMENT", bbox: { xMin: 0.012698413113343292, xMax: 0.9873015839877272, yMin: 0.5232558142112325, yMax: 0.5466605673212334 } },
+      { id: "534f5ac3-17", text: "Authorization  Approved", section: "PAYMENT", matches: true, similarity: 0.7025, bbox: { xMin: 0.0158730123339586, xMax: 0.987684683877715, yMin: 0.4992901073900855, yMax: 0.5210587296881212 } },
+      { id: "534f5ac3-18", text: "Approval Code  ••••••", section: "PAYMENT", matches: true, similarity: 0.7285, bbox: { xMin: 0.015748855640673496, xMax: 0.9876722120071473, yMin: 0.47495325981162717, yMax: 0.4990656500320111 } },
+      { id: "534f5ac3-19", text: "Payment ID  ••••••••", section: "PAYMENT", matches: true, similarity: 0.8469, bbox: { xMin: 0.015517874210284617, xMax: 0.9874357500199271, yMin: 0.4512162712567863, yMax: 0.47560860176019104 } },
+      { id: "534f5ac3-20", text: "Application ID  ••••••••", section: "PAYMENT", bbox: { xMin: 0.015873009116963856, xMax: 0.9873015812076668, yMin: 0.42863677987968285, yMax: 0.4505946938778531 } },
+      { id: "534f5ac3-21", text: "Application Label  VISA DEBIT", section: "PAYMENT", bbox: { xMin: 0.015873016921026904, xMax: 0.9875559122092072, yMin: 0.40530649556672027, yMax: 0.4279050098228866 } },
+      { id: "534f5ac3-22", text: "Card Reader  BBPOS", section: "PAYMENT", bbox: { xMin: 0.015729814639077404, xMax: 0.9904761891149071, yMin: 0.38191141987538724, yMax: 0.40406976762306457 } },
     ],
   },
   {
-    id: "target",
-    merchant: "TARGET",
+    id: "72369a3a",
+    sourceId: "72369a3a · R1",
+    merchant: "Aloha Sunrise Cafe",
+    bestSimilarity: 0.8591,
+    neighborSection: "SUMMARY",
+    imageId: "72369a3a-3f70-4c6d-99f9-0813e509bca4",
+    imageKey: "assets/72369a3a-3f70-4c6d-99f9-0813e509bca4/1.webp",
+    width: 338,
+    height: 718,
     rows: [
-      { id: "target-info", text: "TARGET T-1329", section: "TRANSACTION_INFO" },
-      { id: "target-item", text: "OAT MILK", amount: "5.49", section: "ITEMS" },
-      { id: "target-subtotal", text: "SUBTOTAL", amount: "27.18", section: "SUMMARY", matches: "subtotal" },
-      { id: "target-pay", text: "CARD APPROVED", section: "PAYMENT" },
+      { id: "72369a3a-12", text: "1 Jarritos Soda  $3.49", section: "ITEMS", bbox: { xMin: 0.018518518855436355, xMax: 0.9938271583147716, yMin: 0.6584302328349758, yMax: 0.6816860463925929 } },
+      { id: "72369a3a-13", text: "1 Spam Musubi  $3.69", section: "ITEMS", bbox: { xMin: 0.015432098493373545, xMax: 0.9939370584702212, yMin: 0.6337099808316321, yMax: 0.6600168536229825 } },
+      { id: "72369a3a-16", text: "Subtotal  $41.06", section: "SUMMARY", bbox: { xMin: -0.0003661445969677146, xMax: 0.9908209205877049, yMin: 0.5870861214208098, yMax: 0.6112439677483434 } },
+      { id: "72369a3a-17", text: "Tax 8.375%  $3.44", section: "SUMMARY", matches: true, similarity: 0.8591, bbox: { xMin: 0.0030864197304808273, xMax: 0.9814814805917245, yMin: 0.56104651172648, yMax: 0.5857558141106162 } },
+      { id: "72369a3a-18", text: "Total  $44.50", section: "SUMMARY", bbox: { xMin: 0.012345681040883008, xMax: 0.9816773426980626, yMin: 0.5389329910334377, yMax: 0.5613577068693826 } },
+      { id: "72369a3a-20", text: "DEBIT CARD SALE  $44.50", section: "PAYMENT", bbox: { xMin: 0.018518513873617564, xMax: 0.975308643670665, yMin: 0.504360465209359, yMax: 0.5263653484222194 } },
+      { id: "72369a3a-21", text: "VISA  ••••", section: "PAYMENT", bbox: { xMin: 0.02129613636958686, xMax: 0.2441359648607978, yMin: 0.48317074597462584, yMax: 0.5037478588082847 } },
     ],
   },
   {
-    id: "cvs",
-    merchant: "CVS",
+    id: "2732aa05",
+    sourceId: "2732aa05 · R1",
+    merchant: "Jamba",
+    bestSimilarity: 0.8402,
+    neighborSection: "PAYMENT",
+    imageId: "2732aa05-e670-4bab-a6a3-4b841c24f431",
+    imageKey: "assets/2732aa05-e670-4bab-a6a3-4b841c24f431/1.webp",
+    width: 857,
+    height: 2522,
     rows: [
-      { id: "cvs-info", text: "CVS/PHARMACY", section: "TRANSACTION_INFO" },
-      { id: "cvs-item", text: "COUGH DROPS", amount: "6.99", section: "ITEMS" },
-      { id: "cvs-summary", text: "TOTAL", amount: "7.61", section: "SUMMARY" },
-      { id: "cvs-visa", text: "VISA •••• 4418", section: "PAYMENT", matches: "visa" },
+      { id: "2732aa05-20", text: "Transaction Type  Sale", section: "PAYMENT", matches: true, similarity: 0.8209, bbox: { xMin: 0.020833335364583292, xMax: 0.9791666656666667, yMin: 0.42008486598481276, yMax: 0.43847241817360316 } },
+      { id: "2732aa05-21", text: "Authorization  Approved", section: "PAYMENT", matches: true, similarity: 0.6895, bbox: { xMin: 0.020833331041666726, xMax: 0.9797946965191265, yMin: 0.402397686390478, yMax: 0.42221334643178954 } },
+      { id: "2732aa05-22", text: "Approval Code  ••••••", section: "PAYMENT", matches: true, similarity: 0.7119, bbox: { xMin: 0.02063123263451695, xMax: 0.9792930998462025, yMin: 0.38571579923219124, yMax: 0.40463567440492054 } },
+      { id: "2732aa05-23", text: "Payment ID  ••••••••", section: "PAYMENT", matches: true, similarity: 0.8402, bbox: { xMin: 0.020670088504964143, xMax: 0.9791666687916666, yMin: 0.36916548858735865, yMax: 0.38755304077614905 } },
+      { id: "2732aa05-24", text: "Application ID  ••••••••", section: "PAYMENT", bbox: { xMin: 0.02083334084960944, xMax: 0.9791666685416666, yMin: 0.3521923618108965, yMax: 0.3691654882029577 } },
+      { id: "2732aa05-25", text: "Application Label  VISA DEBIT", section: "PAYMENT", bbox: { xMin: 0.020833335711263088, xMax: 0.9751302883585702, yMin: 0.3350254885145023, yMax: 0.35238610968695117 } },
+      { id: "2732aa05-26", text: "Card Reader  BBPOS", section: "PAYMENT", bbox: { xMin: 0.02071924490834209, xMax: 0.9710535601208902, yMin: 0.31804939029374213, yMax: 0.3340250224603445 } },
     ],
   },
 ];
@@ -205,36 +411,36 @@ export const EXPLORER_ACTS: ExplorerAct[] = [
   {
     id: "ocr",
     index: 0,
-    label: "Apple OCR rows",
-    accessibleLabel: "Step 1: show Apple OCR rows before section assignment",
+    label: "Real OCR rows",
+    accessibleLabel: "Step 1: show real Apple OCR rows before section assignment",
     dwellMs: 5200,
   },
   {
     id: "baseline",
     index: 1,
     label: "Baseline sections",
-    accessibleLabel: "Step 2: show baseline row sections and incorrect boundaries",
+    accessibleLabel: "Step 2: show measured baseline assignments and incorrect boundaries",
     dwellMs: 6800,
   },
   {
     id: "neighbors",
     index: 2,
-    label: "Chroma neighbors",
-    accessibleLabel: "Step 3: let Chroma neighbors vote across labeled receipts",
+    label: "Real Chroma neighbors",
+    accessibleLabel: "Step 3: let real Chroma neighbors vote across QA-valid receipts",
     dwellMs: 7600,
   },
   {
     id: "corrected",
     index: 3,
     label: "Move boundaries",
-    accessibleLabel: "Step 4: correct downstream row labels and section boundaries",
+    accessibleLabel: "Step 4: apply the measured hybrid assignments downstream",
     dwellMs: 7200,
   },
   {
     id: "final",
     index: 4,
     label: "Contiguous result",
-    accessibleLabel: "Step 5: show contiguous section bands and changed rows",
+    accessibleLabel: "Step 5: show contiguous hybrid bands, six fixes, and one unresolved row",
     dwellMs: 8200,
   },
 ];

--- a/portfolio/components/ui/Figures/SectionEmbeddingExplorer/sectionData.ts
+++ b/portfolio/components/ui/Figures/SectionEmbeddingExplorer/sectionData.ts
@@ -26,13 +26,13 @@ export const SECTIONS: SectionDefinition[] = [
   },
   {
     id: "SUMMARY",
-    shortLabel: "SUM",
+    shortLabel: "SUMMARY",
     label: "Summary",
     color: "var(--color-orange)",
   },
   {
     id: "PAYMENT",
-    shortLabel: "PAY",
+    shortLabel: "PAYMENT",
     label: "Payment",
     color: "var(--color-green)",
   },
@@ -50,10 +50,7 @@ export interface ReceiptRow {
   baseline: SectionId;
 }
 
-/**
- * A compact, intentionally schematic receipt. The row text makes the evidence
- * legible; the held-out metrics shown by the figure are the measured values.
- */
+/** A compact held-out receipt with two deliberately wrong baseline boundaries. */
 export const RECEIPT_ROWS: ReceiptRow[] = [
   {
     id: "merchant",
@@ -129,138 +126,72 @@ export const RECEIPT_ROWS: ReceiptRow[] = [
   },
 ];
 
-export interface QueryScenario {
-  id: "subtotal" | "visa" | "milk";
-  label: string;
-  rowId: string;
-  x: number;
-  y: number;
-  votes: Record<SectionId, number>;
-  baseline: SectionId;
-  decoded: SectionId;
+export const CHANGED_ROW_IDS = new Set(["subtotal", "visa"]);
+
+export interface ReferenceReceiptRow {
+  id: string;
+  text: string;
+  amount?: string;
+  section: SectionId;
+  matches?: "subtotal" | "visa";
 }
 
-export const QUERY_SCENARIOS: QueryScenario[] = [
-  {
-    id: "subtotal",
-    label: "SUBTOTAL 9.07",
-    rowId: "subtotal",
-    x: 64,
-    y: 57,
-    votes: {
-      TRANSACTION_INFO: 0.03,
-      ITEMS: 0.16,
-      SUMMARY: 0.76,
-      PAYMENT: 0.05,
-    },
-    baseline: "ITEMS",
-    decoded: "SUMMARY",
-  },
-  {
-    id: "visa",
-    label: "VISA •••• 1234",
-    rowId: "visa",
-    x: 78,
-    y: 78,
-    votes: {
-      TRANSACTION_INFO: 0.02,
-      ITEMS: 0.03,
-      SUMMARY: 0.1,
-      PAYMENT: 0.85,
-    },
-    baseline: "SUMMARY",
-    decoded: "PAYMENT",
-  },
-  {
-    id: "milk",
-    label: "WHOLE MILK 4.99",
-    rowId: "milk",
-    x: 30,
-    y: 48,
-    votes: {
-      TRANSACTION_INFO: 0.02,
-      ITEMS: 0.92,
-      SUMMARY: 0.05,
-      PAYMENT: 0.01,
-    },
-    baseline: "ITEMS",
-    decoded: "ITEMS",
-  },
-];
-
-export const QUERY_BY_ID = Object.fromEntries(
-  QUERY_SCENARIOS.map((scenario) => [scenario.id, scenario]),
-) as Record<QueryScenario["id"], QueryScenario>;
-
-export interface ProjectionPoint {
+export interface ReferenceReceipt {
   id: string;
   merchant: string;
-  section: SectionId;
-  x: number;
-  y: number;
+  rows: ReferenceReceiptRow[];
 }
 
-const CLUSTER_CENTERS: Record<SectionId, { x: number; y: number }> = {
-  TRANSACTION_INFO: { x: 23, y: 23 },
-  ITEMS: { x: 31, y: 52 },
-  SUMMARY: { x: 64, y: 55 },
-  PAYMENT: { x: 78, y: 79 },
-};
-
-const POINT_OFFSETS = [
-  [-8, -2],
-  [-5, 6],
-  [-2, -7],
-  [1, 3],
-  [4, -4],
-  [6, 5],
-  [9, 0],
-  [0, 9],
-] as const;
-
-const MERCHANTS = [
-  "Costco",
-  "Vons",
-  "Target",
-  "CVS",
-  "Trader Joe's",
-  "In-N-Out",
-  "Wild Fork",
-  "Ralphs",
+/** Representative labeled receipts. Four of the 15 searched neighbors are drawn. */
+export const REFERENCE_RECEIPTS: ReferenceReceipt[] = [
+  {
+    id: "costco",
+    merchant: "COSTCO",
+    rows: [
+      { id: "costco-info", text: "COSTCO #117", section: "TRANSACTION_INFO" },
+      { id: "costco-item", text: "ORG WHOLE MILK", amount: "4.69", section: "ITEMS" },
+      { id: "costco-subtotal", text: "SUBTOTAL", amount: "12.47", section: "SUMMARY", matches: "subtotal" },
+      { id: "costco-pay", text: "VISA •••• 8472", section: "PAYMENT" },
+    ],
+  },
+  {
+    id: "vons",
+    merchant: "VONS",
+    rows: [
+      { id: "vons-info", text: "VONS STORE 2091", section: "TRANSACTION_INFO" },
+      { id: "vons-item", text: "BANANAS", amount: "1.92", section: "ITEMS" },
+      { id: "vons-summary", text: "TOTAL", amount: "18.39", section: "SUMMARY" },
+      { id: "vons-visa", text: "VISA •••• 0064", section: "PAYMENT", matches: "visa" },
+    ],
+  },
+  {
+    id: "target",
+    merchant: "TARGET",
+    rows: [
+      { id: "target-info", text: "TARGET T-1329", section: "TRANSACTION_INFO" },
+      { id: "target-item", text: "OAT MILK", amount: "5.49", section: "ITEMS" },
+      { id: "target-subtotal", text: "SUBTOTAL", amount: "27.18", section: "SUMMARY", matches: "subtotal" },
+      { id: "target-pay", text: "CARD APPROVED", section: "PAYMENT" },
+    ],
+  },
+  {
+    id: "cvs",
+    merchant: "CVS",
+    rows: [
+      { id: "cvs-info", text: "CVS/PHARMACY", section: "TRANSACTION_INFO" },
+      { id: "cvs-item", text: "COUGH DROPS", amount: "6.99", section: "ITEMS" },
+      { id: "cvs-summary", text: "TOTAL", amount: "7.61", section: "SUMMARY" },
+      { id: "cvs-visa", text: "VISA •••• 4418", section: "PAYMENT", matches: "visa" },
+    ],
+  },
 ];
 
-export const PROJECTION_POINTS: ProjectionPoint[] = SECTIONS.flatMap(
-  (section) => {
-    const center = CLUSTER_CENTERS[section.id];
-    return POINT_OFFSETS.map(([dx, dy], index) => ({
-      id: `${section.id}-${index}`,
-      merchant: MERCHANTS[index],
-      section: section.id,
-      x: center.x + dx,
-      y: center.y + dy,
-    }));
-  },
-);
-
-/** Return the 15 visible cross-receipt neighbors closest in the 2-D explainer. */
-export const nearestProjectionPoints = (
-  scenario: QueryScenario,
-  count = 15,
-): ProjectionPoint[] =>
-  PROJECTION_POINTS.map((point) => ({
-    point,
-    distance: Math.hypot(point.x - scenario.x, point.y - scenario.y),
-  }))
-    .sort((a, b) => a.distance - b.distance)
-    .slice(0, count)
-    .map(({ point }) => point);
-
 export type ExplorerActId =
-  | "receipt"
-  | "projection"
+  | "ocr"
+  | "baseline"
   | "neighbors"
-  | "decode"
-  | "result";
+  | "corrected"
+  | "final";
 
 export interface ExplorerAct {
   id: ExplorerActId;
@@ -272,54 +203,48 @@ export interface ExplorerAct {
 
 export const EXPLORER_ACTS: ExplorerAct[] = [
   {
-    id: "receipt",
+    id: "ocr",
     index: 0,
-    label: "Read the rows",
-    accessibleLabel: "Step 1: read the receipt as an ordered row sequence",
+    label: "Apple OCR rows",
+    accessibleLabel: "Step 1: show Apple OCR rows before section assignment",
     dwellMs: 5200,
   },
   {
-    id: "projection",
+    id: "baseline",
     index: 1,
-    label: "Project meaning",
-    accessibleLabel: "Step 2: project rows into embedding space",
-    dwellMs: 7000,
+    label: "Baseline sections",
+    accessibleLabel: "Step 2: show baseline row sections and incorrect boundaries",
+    dwellMs: 6800,
   },
   {
     id: "neighbors",
     index: 2,
-    label: "Let neighbors vote",
-    accessibleLabel: "Step 3: collect cosine-weighted cross-receipt votes",
-    dwellMs: 8000,
-  },
-  {
-    id: "decode",
-    index: 3,
-    label: "Decode the sequence",
-    accessibleLabel: "Step 4: decode one contiguous receipt sequence",
+    label: "Chroma neighbors",
+    accessibleLabel: "Step 3: let Chroma neighbors vote across labeled receipts",
     dwellMs: 7600,
   },
   {
-    id: "result",
+    id: "corrected",
+    index: 3,
+    label: "Move boundaries",
+    accessibleLabel: "Step 4: correct downstream row labels and section boundaries",
+    dwellMs: 7200,
+  },
+  {
+    id: "final",
     index: 4,
-    label: "Check the holdout",
-    accessibleLabel: "Step 5: compare held-out accuracy",
-    dwellMs: 9000,
+    label: "Contiguous result",
+    accessibleLabel: "Step 5: show contiguous section bands and changed rows",
+    dwellMs: 8200,
   },
 ];
 
 export const EXPERIMENT_METRICS = {
   receipts: 167,
   rows: 4214,
-  baselineCorrect: 3622,
-  hybridCorrect: 3828,
   baselineAgreement: 85.95,
   hybridAgreement: 90.84,
   deltaPoints: 4.89,
   fixed: 236,
   regressed: 30,
-  coverage: 99.87,
-  bootstrapLow: 3.87,
-  bootstrapHigh: 5.94,
 } as const;
-

--- a/portfolio/components/ui/Figures/index.ts
+++ b/portfolio/components/ui/Figures/index.ts
@@ -182,3 +182,10 @@ export const SynthesisPipeline = dynamic(
     loading: () => loadingShell("within"),
   }
 );
+export const SectionEmbeddingExplorer = dynamic(
+  () => import("./SectionEmbeddingExplorer"),
+  {
+    ssr: false,
+    loading: () => loadingShell("within"),
+  }
+);

--- a/portfolio/e2e/section-embedding-explorer.spec.ts
+++ b/portfolio/e2e/section-embedding-explorer.spec.ts
@@ -37,8 +37,8 @@ test("every resolved section-assignment step remains stable and keyboard accessi
 
   const expectedAssignments = [
     [null, null],
-    ["ITEMS", "SUMMARY"],
-    ["ITEMS", "SUMMARY"],
+    ["TRANSACTION_INFO", "TRANSACTION_INFO"],
+    ["TRANSACTION_INFO", "TRANSACTION_INFO"],
     ["SUMMARY", "PAYMENT"],
     ["SUMMARY", "PAYMENT"],
   ] as const;
@@ -49,20 +49,54 @@ test("every resolved section-assignment step remains stable and keyboard accessi
     await expect(page.getByTestId(`section-act-${ACTS[index]}`)).toBeVisible();
     await expect(dots.nth(index)).toHaveAttribute("aria-pressed", "true");
 
-    const [subtotal, visa] = expectedAssignments[index];
-    const subtotalRow = page.getByTestId("section-row-subtotal");
-    const visaRow = page.getByTestId("section-row-visa");
+    const [subtotal, paymentTime] = expectedAssignments[index];
+    const subtotalRow = page.getByTestId("section-row-row-11");
+    const paymentTimeRow = page.getByTestId("section-row-row-34");
     if (subtotal) {
       await expect(subtotalRow).toHaveAttribute("data-section", subtotal);
-      await expect(visaRow).toHaveAttribute("data-section", visa);
+      await expect(paymentTimeRow).toHaveAttribute("data-section", paymentTime);
     } else {
       await expect(subtotalRow).not.toHaveAttribute("data-section");
-      await expect(visaRow).not.toHaveAttribute("data-section");
+      await expect(paymentTimeRow).not.toHaveAttribute("data-section");
     }
 
     const box = await stage.boundingBox();
     expect(Math.round(box?.height ?? 0)).toBe(Math.round(boxBefore?.height ?? 0));
   }
+
+  await expect(page.getByTestId("section-current-receipt")).toHaveAttribute(
+    "data-source-id",
+    "d47b0f01 · R1",
+  );
+  const currentImage = page.getByTestId("section-current-image");
+  await expect(currentImage).toHaveAttribute(
+    "src",
+    /assets\/d47b0f01-859d-499b-a9b0-4feb312b4d27\/1\.webp/,
+  );
+  await expect
+    .poll(() => currentImage.evaluate((image: HTMLImageElement) => image.naturalWidth))
+    .toBe(425);
+
+  const imageBox = await currentImage.boundingBox();
+  const subtotalBox = await page.getByTestId("section-row-row-11").boundingBox();
+  expect((subtotalBox?.x ?? 0) - (imageBox?.x ?? 0)).toBeCloseTo(
+    (imageBox?.width ?? 0) * 0.0845921503955299,
+    0,
+  );
+  expect((subtotalBox?.y ?? 0) - (imageBox?.y ?? 0)).toBeCloseTo(
+    (imageBox?.height ?? 0) * (1 - 0.49709302306590664),
+    0,
+  );
+  await dots.nth(4).click();
+  await expect(page.locator('[data-testid="section-act-final"] [data-corrected="true"]')).toHaveCount(6);
+  await expect(page.locator('[data-testid="section-act-final"] [data-unresolved="true"]')).toHaveCount(1);
+  await expect(page.getByTestId("section-row-row-31")).toHaveAttribute(
+    "data-section",
+    "PAYMENT",
+  );
+  await expect(
+    page.getByTestId("section-act-final").getByTestId("section-current-receipt").getByTestId("section-band"),
+  ).toHaveCount(4);
 
   await dots.nth(0).focus();
   await dots.nth(0).press("End");
@@ -102,12 +136,16 @@ test("mobile keeps the current receipt readable and shows fewer background recei
   const currentReceipt = page.getByTestId("section-current-receipt");
   await expect(currentReceipt).toBeVisible();
   const currentBox = await currentReceipt.boundingBox();
-  expect(currentBox?.width ?? 0).toBeGreaterThanOrEqual(280);
+  expect(currentBox?.width ?? 0).toBeGreaterThanOrEqual(200);
+  const image = page.getByTestId("section-current-image");
+  await expect
+    .poll(() => image.evaluate((node: HTMLImageElement) => node.naturalHeight))
+    .toBe(884);
 
   await expect(page.locator('[data-testid^="section-reference-receipt-"]:visible')).toHaveCount(2);
   const neighborAct = page.getByTestId("section-act-neighbors");
-  await expect(neighborAct.getByText(/OpenAI creates row embeddings/)).toBeVisible();
-  await expect(neighborAct.getByText(/2-D map is schematic, not literal/)).toBeVisible();
+  await expect(neighborAct.getByText(/OpenAI created the row embeddings/)).toBeVisible();
+  await expect(neighborAct.getByText(/2-D map is schematic/)).toBeVisible();
   await figure.scrollIntoViewIfNeeded();
 });
 

--- a/portfolio/e2e/section-embedding-explorer.spec.ts
+++ b/portfolio/e2e/section-embedding-explorer.spec.ts
@@ -1,8 +1,21 @@
-import { expect, test } from "@playwright/test";
+import { expect, Page, test } from "@playwright/test";
 
 const PAGE = process.env.BASE_URL ? "/receipt" : "/receipt.html";
 
-test("section embedding explainer survives every act and remains usable on mobile", async ({
+const ACTS = ["ocr", "baseline", "neighbors", "corrected", "final"] as const;
+
+async function findFigure(page: Page) {
+  const figure = page.getByTestId("section-embedding-explorer");
+  for (let i = 0; i < 50 && (await figure.count()) === 0; i += 1) {
+    await page.mouse.wheel(0, 700);
+    await page.waitForTimeout(150);
+  }
+  await expect(figure).toBeVisible({ timeout: 15_000 });
+  await figure.scrollIntoViewIfNeeded();
+  return figure;
+}
+
+test("every resolved section-assignment step remains stable and keyboard accessible", async ({
   page,
 }) => {
   const errors: string[] = [];
@@ -16,54 +29,102 @@ test("section embedding explainer survives every act and remains usable on mobil
   });
 
   await page.goto(PAGE, { waitUntil: "networkidle" });
-
-  const figure = page.getByTestId("section-embedding-explorer");
-  for (let i = 0; i < 50 && (await figure.count()) === 0; i += 1) {
-    await page.mouse.wheel(0, 700);
-    await page.waitForTimeout(150);
-  }
-  await expect(figure).toBeVisible({ timeout: 15_000 });
-  await figure.scrollIntoViewIfNeeded();
-
+  const figure = await findFigure(page);
   const stage = page.getByTestId("section-explorer-stage");
   const boxBefore = await stage.boundingBox();
   const dots = page.locator('[data-testid^="section-act-dot-"]');
   await expect(dots).toHaveCount(5);
-  for (let index = 0; index < 5; index += 1) {
+
+  const expectedAssignments = [
+    [null, null],
+    ["ITEMS", "SUMMARY"],
+    ["ITEMS", "SUMMARY"],
+    ["SUMMARY", "PAYMENT"],
+    ["SUMMARY", "PAYMENT"],
+  ] as const;
+
+  for (let index = 0; index < ACTS.length; index += 1) {
     await dots.nth(index).click();
     await page.waitForTimeout(420);
+    await expect(page.getByTestId(`section-act-${ACTS[index]}`)).toBeVisible();
+    await expect(dots.nth(index)).toHaveAttribute("aria-pressed", "true");
+
+    const [subtotal, visa] = expectedAssignments[index];
+    const subtotalRow = page.getByTestId("section-row-subtotal");
+    const visaRow = page.getByTestId("section-row-visa");
+    if (subtotal) {
+      await expect(subtotalRow).toHaveAttribute("data-section", subtotal);
+      await expect(visaRow).toHaveAttribute("data-section", visa);
+    } else {
+      await expect(subtotalRow).not.toHaveAttribute("data-section");
+      await expect(visaRow).not.toHaveAttribute("data-section");
+    }
+
     const box = await stage.boundingBox();
     expect(Math.round(box?.height ?? 0)).toBe(Math.round(boxBefore?.height ?? 0));
   }
 
-  await dots.nth(2).click();
-  const visa = page.getByRole("button", { name: "VISA •••• 1234" });
-  await visa.click();
-  await expect(visa).toHaveAttribute("aria-pressed", "true");
-  await expect(page.getByText("85%")).toBeVisible();
+  await dots.nth(0).focus();
+  await dots.nth(0).press("End");
+  await expect(dots.nth(4)).toBeFocused();
+  await expect(dots.nth(4)).toHaveAttribute("aria-pressed", "true");
+  await dots.nth(4).press("ArrowLeft");
+  await expect(dots.nth(3)).toBeFocused();
+  await expect(dots.nth(3)).toHaveAttribute("aria-pressed", "true");
 
-  await page.setViewportSize({ width: 390, height: 844 });
   await figure.scrollIntoViewIfNeeded();
+  expect(errors, errors.join("\n")).toHaveLength(0);
+});
+
+test("mobile keeps the current receipt readable and shows fewer background receipts", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto(PAGE, { waitUntil: "networkidle" });
+  const figure = await findFigure(page);
+  await page.getByTestId("section-act-dot-2").click();
+  await page.waitForTimeout(420);
+
   const viewportOverflow = await page.evaluate(() =>
     Math.max(0, document.documentElement.scrollWidth - window.innerWidth),
   );
   expect(viewportOverflow).toBe(0);
-  await expect(visa).toBeVisible();
 
-  expect(errors, errors.join("\n")).toHaveLength(0);
+  const stageMetrics = await page.getByTestId("section-explorer-stage").evaluate((node) => ({
+    clientWidth: node.clientWidth,
+    scrollWidth: node.scrollWidth,
+    clientHeight: node.clientHeight,
+    scrollHeight: node.scrollHeight,
+  }));
+  expect(stageMetrics.scrollWidth).toBe(stageMetrics.clientWidth);
+  expect(stageMetrics.scrollHeight).toBe(stageMetrics.clientHeight);
+
+  const currentReceipt = page.getByTestId("section-current-receipt");
+  await expect(currentReceipt).toBeVisible();
+  const currentBox = await currentReceipt.boundingBox();
+  expect(currentBox?.width ?? 0).toBeGreaterThanOrEqual(280);
+
+  await expect(page.locator('[data-testid^="section-reference-receipt-"]:visible')).toHaveCount(2);
+  const neighborAct = page.getByTestId("section-act-neighbors");
+  await expect(neighborAct.getByText(/OpenAI creates row embeddings/)).toBeVisible();
+  await expect(neighborAct.getByText(/2-D map is schematic, not literal/)).toBeVisible();
+  await figure.scrollIntoViewIfNeeded();
 });
 
-test("reduced motion exposes a resolved static stack", async ({ browser }) => {
+test("reduced motion exposes every resolved state without animation", async ({ browser }) => {
   const context = await browser.newContext({ reducedMotion: "reduce" });
   const page = await context.newPage();
   await page.goto(PAGE, { waitUntil: "networkidle" });
-  const figure = page.getByTestId("section-embedding-explorer");
-  for (let i = 0; i < 50 && (await figure.count()) === 0; i += 1) {
-    await page.mouse.wheel(0, 700);
-    await page.waitForTimeout(150);
-  }
+  const figure = await findFigure(page);
   await expect(figure).toHaveAttribute("data-mode", "static");
-  await expect(page.getByTestId("section-act-result")).toBeAttached();
+  for (const act of ACTS) {
+    await expect(page.getByTestId(`section-act-${act}`)).toBeAttached();
+  }
+  const animationName = await page
+    .getByTestId("section-act-neighbors")
+    .locator("path")
+    .first()
+    .evaluate((node) => getComputedStyle(node).animationName);
+  expect(animationName).toBe("none");
   await context.close();
 });
-

--- a/portfolio/e2e/section-embedding-explorer.spec.ts
+++ b/portfolio/e2e/section-embedding-explorer.spec.ts
@@ -1,0 +1,69 @@
+import { expect, test } from "@playwright/test";
+
+const PAGE = process.env.BASE_URL ? "/receipt" : "/receipt.html";
+
+test("section embedding explainer survives every act and remains usable on mobile", async ({
+  page,
+}) => {
+  const errors: string[] = [];
+  const noise =
+    /Failed to fetch|net::ERR_|Load failed|CORS policy|api\.tylernorlund\.com|Failed to load resource/;
+  page.on("pageerror", (error) => errors.push(`pageerror: ${error.message}`));
+  page.on("console", (message) => {
+    if (message.type() === "error" && !noise.test(message.text())) {
+      errors.push(`console: ${message.text().slice(0, 200)}`);
+    }
+  });
+
+  await page.goto(PAGE, { waitUntil: "networkidle" });
+
+  const figure = page.getByTestId("section-embedding-explorer");
+  for (let i = 0; i < 50 && (await figure.count()) === 0; i += 1) {
+    await page.mouse.wheel(0, 700);
+    await page.waitForTimeout(150);
+  }
+  await expect(figure).toBeVisible({ timeout: 15_000 });
+  await figure.scrollIntoViewIfNeeded();
+
+  const stage = page.getByTestId("section-explorer-stage");
+  const boxBefore = await stage.boundingBox();
+  const dots = page.locator('[data-testid^="section-act-dot-"]');
+  await expect(dots).toHaveCount(5);
+  for (let index = 0; index < 5; index += 1) {
+    await dots.nth(index).click();
+    await page.waitForTimeout(420);
+    const box = await stage.boundingBox();
+    expect(Math.round(box?.height ?? 0)).toBe(Math.round(boxBefore?.height ?? 0));
+  }
+
+  await dots.nth(2).click();
+  const visa = page.getByRole("button", { name: "VISA •••• 1234" });
+  await visa.click();
+  await expect(visa).toHaveAttribute("aria-pressed", "true");
+  await expect(page.getByText("85%")).toBeVisible();
+
+  await page.setViewportSize({ width: 390, height: 844 });
+  await figure.scrollIntoViewIfNeeded();
+  const viewportOverflow = await page.evaluate(() =>
+    Math.max(0, document.documentElement.scrollWidth - window.innerWidth),
+  );
+  expect(viewportOverflow).toBe(0);
+  await expect(visa).toBeVisible();
+
+  expect(errors, errors.join("\n")).toHaveLength(0);
+});
+
+test("reduced motion exposes a resolved static stack", async ({ browser }) => {
+  const context = await browser.newContext({ reducedMotion: "reduce" });
+  const page = await context.newPage();
+  await page.goto(PAGE, { waitUntil: "networkidle" });
+  const figure = page.getByTestId("section-embedding-explorer");
+  for (let i = 0; i < 50 && (await figure.count()) === 0; i += 1) {
+    await page.mouse.wheel(0, 700);
+    await page.waitForTimeout(150);
+  }
+  await expect(figure).toHaveAttribute("data-mode", "static");
+  await expect(page.getByTestId("section-act-result")).toBeAttached();
+  await context.close();
+});
+

--- a/portfolio/pages/receipt.tsx
+++ b/portfolio/pages/receipt.tsx
@@ -27,6 +27,7 @@ import {
   ReceiptHealthExplorer,
   ReceiptBoundingBoxGrid,
   ReceiptStack,
+  SectionEmbeddingExplorer,
   StreamBitsRoutingDiagram,
   TrainingMetricsAnimation,
   UploadDiagram,
@@ -516,6 +517,24 @@ M1LK 2%           1    $4.4g`}</code>
       <FigureBoundary name="synthesis-pipeline" intrinsicSize="640px">
         <ClientOnly>
           <SynthesisPipeline />
+        </ClientOnly>
+      </FigureBoundary>
+
+      <p>
+        Word labels are only half the problem. The receipt still has to decide
+        where the item list stops, the totals start, and the payment record
+        begins. I tested more geometry and receipt math, then tried asking
+        Chroma which labeled rows from other receipts looked like each row.
+        The embeddings helped. The extra geometry didn&apos;t.
+      </p>
+
+      <FigureBoundary
+        name="section-embedding-explorer"
+        intrinsicSize="640px"
+        mobileIntrinsicSize="620px"
+      >
+        <ClientOnly>
+          <SectionEmbeddingExplorer />
         </ClientOnly>
       </FigureBoundary>
 

--- a/receipt_dynamo/receipt_dynamo/data/_receipt_word_label.py
+++ b/receipt_dynamo/receipt_dynamo/data/_receipt_word_label.py
@@ -9,11 +9,10 @@ from typing import Any
 
 from botocore.exceptions import ClientError
 
-from receipt_dynamo.constants import ValidationStatus
+from receipt_dynamo.constants import CORE_LABELS, ValidationStatus
 from receipt_dynamo.data.base_operations import (
     FlattenedStandardMixin,
-    PutRequestTypeDef,
-    WriteRequestTypeDef,
+    TransactWriteItemTypeDef,
     handle_dynamodb_errors,
 )
 from receipt_dynamo.data.base_operations.shared_utils import (
@@ -47,7 +46,10 @@ class _ReceiptWordLabel(
     """
 
     def _validate_receipt_word_labels_for_add(
-        self, receipt_word_labels: list[ReceiptWordLabel]
+        self,
+        receipt_word_labels: list[ReceiptWordLabel],
+        *,
+        allow_non_core_labels: bool = False,
     ) -> None:
         """Custom validation for add operation with specific error messages"""
         if receipt_word_labels is None:
@@ -66,13 +68,41 @@ class _ReceiptWordLabel(
                     "ReceiptWordLabel class."
                 )
 
+        if not isinstance(allow_non_core_labels, bool):
+            raise EntityValidationError(
+                "allow_non_core_labels must be a boolean"
+            )
+
+        if allow_non_core_labels:
+            return
+
+        invalid_labels = sorted(
+            {item.label for item in receipt_word_labels} - set(CORE_LABELS)
+        )
+        if invalid_labels:
+            rendered = ", ".join(repr(label) for label in invalid_labels)
+            raise EntityValidationError(
+                "Cannot add non-core receipt word label(s): "
+                f"{rendered}. New labels must be present in CORE_LABELS; "
+                "allow_non_core_labels=True is reserved for controlled "
+                "legacy restoration."
+            )
+
     @handle_dynamodb_errors("add_receipt_word_label")
-    def add_receipt_word_label(self, receipt_word_label: ReceiptWordLabel):
-        """Adds a receipt word label to the database
+    def add_receipt_word_label(
+        self,
+        receipt_word_label: ReceiptWordLabel,
+        *,
+        allow_non_core_labels: bool = False,
+    ):
+        """Add a canonical receipt word label to the database.
 
         Args:
             receipt_word_label (ReceiptWordLabel): The receipt word label to
                 add to the database
+            allow_non_core_labels: Permit historical labels outside
+                ``CORE_LABELS``. This is intended only for controlled legacy
+                restoration, never model or application writes.
 
         Raises:
             ValueError: When a receipt word label with the same ID
@@ -80,6 +110,10 @@ class _ReceiptWordLabel(
         """
         self._validate_entity(
             receipt_word_label, ReceiptWordLabel, "receipt_word_label"
+        )
+        self._validate_receipt_word_labels_for_add(
+            [receipt_word_label],
+            allow_non_core_labels=allow_non_core_labels,
         )
         self._add_entity(
             receipt_word_label, condition_expression="attribute_not_exists(PK)"
@@ -125,28 +159,74 @@ class _ReceiptWordLabel(
 
     @handle_dynamodb_errors("add_receipt_word_labels")
     def add_receipt_word_labels(
-        self, receipt_word_labels: list[ReceiptWordLabel]
+        self,
+        receipt_word_labels: list[ReceiptWordLabel],
+        *,
+        allow_non_core_labels: bool = False,
     ):
-        """Adds a list of receipt word labels to the database
+        """Add receipt word labels without overwriting existing rows.
+
+        DynamoDB ``BatchWriteItem`` does not support condition expressions.
+        Using it for an add operation would turn a retry into an overwrite and
+        could replace a reviewed label's status or reasoning.  Conditional
+        transactional puts preserve the same create-only contract as
+        :meth:`add_receipt_word_label`.
 
         Args:
             receipt_word_labels (list[ReceiptWordLabel]): The receipt word
                 labels to add to the database
+            allow_non_core_labels: Permit historical labels outside
+                ``CORE_LABELS``. This is intended only for controlled legacy
+                restoration, never model or application writes.
 
         Raises:
-            ValueError: When a receipt word label with the same ID
-                already exists
+            EntityAlreadyExistsError: When any receipt word label in a
+                transaction chunk already exists.
         """
         # Custom validation for add operation with specific error messages
-        self._validate_receipt_word_labels_for_add(receipt_word_labels)
+        self._validate_receipt_word_labels_for_add(
+            receipt_word_labels,
+            allow_non_core_labels=allow_non_core_labels,
+        )
 
-        request_items = [
-            WriteRequestTypeDef(
-                PutRequest=PutRequestTypeDef(Item=label.to_item())
+        transact_items = [
+            TransactWriteItemTypeDef(
+                Put={
+                    "TableName": self.table_name,
+                    "Item": label.to_item(),
+                    "ConditionExpression": (
+                        "attribute_not_exists(PK) AND "
+                        "attribute_not_exists(SK)"
+                    ),
+                }
             )
             for label in receipt_word_labels
         ]
-        self._batch_write_with_retry(request_items)
+
+        try:
+            self._transact_write_with_chunking(transact_items)
+        except ClientError as error:
+            error_code = error.response.get("Error", {}).get("Code", "")
+            cancellation_reasons = error.response.get(
+                "CancellationReasons", []
+            )
+            error_message = error.response.get("Error", {}).get("Message", "")
+            conditional_failure = (
+                any(
+                    reason.get("Code") == "ConditionalCheckFailed"
+                    for reason in cancellation_reasons
+                )
+                or "ConditionalCheckFailed" in error_message
+            )
+
+            if (
+                error_code == "TransactionCanceledException"
+                and conditional_failure
+            ):
+                raise EntityAlreadyExistsError(
+                    "One or more receipt word labels already exist"
+                ) from error
+            raise
 
     def _handle_add_receipt_word_labels_error(self, error: ClientError):
         """Handle errors specific to add_receipt_word_labels"""

--- a/receipt_dynamo/receipt_dynamo/data/import_image.py
+++ b/receipt_dynamo/receipt_dynamo/data/import_image.py
@@ -133,7 +133,13 @@ def import_image(table_name: str, json_path: str) -> None:
 
     if entities["receipt_word_labels"]:
         # type: ignore[arg-type]
-        dynamo_client.add_receipt_word_labels(entities["receipt_word_labels"])
+        # Imports restore an existing snapshot rather than minting new labels.
+        # Preserve legacy keys verbatim; ordinary application/model writes
+        # remain restricted to CORE_LABELS by the default add policy.
+        dynamo_client.add_receipt_word_labels(
+            entities["receipt_word_labels"],
+            allow_non_core_labels=True,
+        )
 
     if entities["receipt_places"]:
         # type: ignore[arg-type]

--- a/receipt_dynamo/tests/integration/test__export_and_import.py
+++ b/receipt_dynamo/tests/integration/test__export_and_import.py
@@ -14,6 +14,7 @@ from receipt_dynamo import (
     ReceiptLetter,
     ReceiptLine,
     ReceiptWord,
+    ReceiptWordLabel,
     Word,
     delete_image_data,
     export_image,
@@ -286,6 +287,17 @@ def test_export_and_import_image(dynamodb_table, export_dir):
             confidence=1,
         )
     ]
+    legacy_receipt_word_labels = [
+        ReceiptWordLabel(
+            image_id=image.image_id,
+            receipt_id=receipts[0].receipt_id,
+            line_id=receipt_lines[0].line_id,
+            word_id=receipt_words[0].word_id,
+            label="ITEM_NAME",
+            reasoning="Historical label preserved by snapshot restore",
+            timestamp_added=datetime.datetime.now(datetime.timezone.utc),
+        )
+    ]
 
     client.add_image(image)
     client.add_lines(lines)
@@ -295,6 +307,10 @@ def test_export_and_import_image(dynamodb_table, export_dir):
     client.add_receipt_lines(receipt_lines)
     client.add_receipt_words(receipt_words)
     client.add_receipt_letters(receipt_letters)
+    client.add_receipt_word_labels(
+        legacy_receipt_word_labels,
+        allow_non_core_labels=True,
+    )
     # Act
     export_image(dynamodb_table, image.image_id, output_dir=export_dir)
 
@@ -310,6 +326,7 @@ def test_export_and_import_image(dynamodb_table, export_dir):
     client.delete_receipt_lines(receipt_lines)
     client.delete_receipt_words(receipt_words)
     client.delete_receipt_letters(receipt_letters)
+    client.delete_receipt_word_labels(legacy_receipt_word_labels)
 
     # Assert
     assert len(client.list_images()[0]) == 0
@@ -320,6 +337,7 @@ def test_export_and_import_image(dynamodb_table, export_dir):
     assert len(client.list_receipt_lines()[0]) == 0
     assert len(client.list_receipt_words()[0]) == 0
     assert len(client.list_receipt_letters()[0]) == 0
+    assert len(client.list_receipt_word_labels()[0]) == 0
 
     # Act
     import_image(dynamodb_table, f"{export_dir}/{image.image_id}.json")
@@ -344,6 +362,9 @@ def test_export_and_import_image(dynamodb_table, export_dir):
     assert client.list_receipt_words()[0][0].text == "Hello"
     assert len(client.list_receipt_letters()[0]) == 1
     assert client.list_receipt_letters()[0][0].text == "H"
+    restored_labels = client.list_receipt_word_labels()[0]
+    assert len(restored_labels) == 1
+    assert restored_labels[0].label == "ITEM_NAME"
 
 
 @pytest.mark.integration

--- a/receipt_dynamo/tests/integration/test__receipt.py
+++ b/receipt_dynamo/tests/integration/test__receipt.py
@@ -131,7 +131,7 @@ def _sample_receipt_word_labels(
             receipt_id=1,
             line_id=1,
             word_id=2,
-            label="store_name",
+            label="MERCHANT_NAME",
             reasoning="This is a store name",
             timestamp_added=datetime.now().isoformat(),
         ),

--- a/receipt_dynamo/tests/integration/test__receipt_word_label.py
+++ b/receipt_dynamo/tests/integration/test__receipt_word_label.py
@@ -35,7 +35,7 @@ CORRECT_RECEIPT_WORD_LABEL_PARAMS: Dict[str, Any] = {
     "image_id": "3f52804b-2fad-4e00-92c8-b593da3a8ed3",
     "line_id": 10,
     "word_id": 5,
-    "label": "ITEM",
+    "label": "PRODUCT_NAME",
     "reasoning": "This word appears to be an item description",
     "timestamp_added": "2024-03-20T12:00:00+00:00",
     "validation_status": ValidationStatus.VALID,
@@ -56,7 +56,7 @@ def _another_receipt_word_label() -> ReceiptWordLabel:
         image_id="4a63915c-22f5-4f11-a3d9-c684eb4b9ef4",
         line_id=20,
         word_id=10,
-        label="PRICE",
+        label="LINE_TOTAL",
         reasoning="This word appears to be a price",
         timestamp_added="2024-03-20T13:00:00+00:00",
         validation_status=ValidationStatus.VALID,
@@ -76,7 +76,7 @@ def _batch_receipt_word_labels() -> List[ReceiptWordLabel]:
                 image_id=str(uuid4()),
                 line_id=(i % 10) + 1,
                 word_id=(i % 5) + 1,
-                label="ITEM" if i % 2 == 0 else "PRICE",
+                label="PRODUCT_NAME" if i % 2 == 0 else "LINE_TOTAL",
                 reasoning=f"Test label {i}",
                 timestamp_added=base_time.isoformat(),
                 validation_status=ValidationStatus.VALID,
@@ -599,7 +599,7 @@ def test_list_receipt_word_labels_for_image_success(
             image_id=sample_receipt_word_label.image_id,
             line_id=i + 1,
             word_id=i + 1,
-            label="ITEM" if i % 2 == 0 else "PRICE",
+            label="PRODUCT_NAME" if i % 2 == 0 else "LINE_TOTAL",
             reasoning=f"Label {i}",
             timestamp_added=sample_receipt_word_label.timestamp_added,
         )
@@ -653,7 +653,7 @@ def test_list_receipt_word_labels_for_image_with_pagination(
             image_id=image_id,
             line_id=(i % 3) + 1,  # 3 lines per receipt
             word_id=(i % 2) + 1,  # 2 words per line
-            label="ITEM" if i % 2 == 0 else "PRICE",
+            label="PRODUCT_NAME" if i % 2 == 0 else "LINE_TOTAL",
             reasoning=f"Label {i}",
             timestamp_added="2024-03-20T12:00:00+00:00",
         )
@@ -702,7 +702,7 @@ def test_list_receipt_word_labels_success(
             image_id=str(uuid4()),
             line_id=i + 1,
             word_id=i + 1,
-            label="ITEM",
+            label="PRODUCT_NAME",
             reasoning=f"Receipt label {i}",
             timestamp_added="2024-03-20T12:00:00+00:00",
         )
@@ -734,7 +734,7 @@ def test_list_receipt_word_labels_for_receipt_success(
             image_id=image_id,
             line_id=i + 1,
             word_id=i + 1,
-            label="ITEM" if i % 2 == 0 else "PRICE",
+            label="PRODUCT_NAME" if i % 2 == 0 else "LINE_TOTAL",
             reasoning=f"Receipt 1 label {i}",
             timestamp_added="2024-03-20T12:00:00+00:00",
         )
@@ -813,7 +813,7 @@ def test_list_receipt_word_labels_for_receipt_with_pagination(
                 image_id=image_id,
                 line_id=line_id,
                 word_id=word_id,
-                label="ITEM" if word_id == 1 else "PRICE",
+                label="PRODUCT_NAME" if word_id == 1 else "LINE_TOTAL",
                 reasoning=f"Line {line_id} word {word_id}",
                 timestamp_added="2024-03-20T12:00:00+00:00",
             )
@@ -892,41 +892,177 @@ def test_list_receipt_word_labels_for_receipt_validation(
 
 
 # -------------------------------------------------------------------
-#                   BATCH OPERATIONS WITH UNPROCESSED ITEMS
+#                   CONDITIONAL BATCH ADD SAFETY
 # -------------------------------------------------------------------
 
 
 @pytest.mark.integration
-def test_add_receipt_word_labels_batch_with_unprocessed(
+def test_add_receipt_word_labels_uses_conditional_transactions(
     dynamodb_table: Literal["MyMockedTable"],
     batch_receipt_word_labels: List[ReceiptWordLabel],
     mocker: MockerFixture,
 ) -> None:
-    """Tests that add_receipt_word_labels handles unprocessed items correctly."""
+    """Batch adds use create-only puts rather than unconditional writes."""
     client = DynamoClient(dynamodb_table)
     labels_to_add = batch_receipt_word_labels[:5]
 
-    # Mock batch_write_item to return unprocessed items on first call
     # pylint: disable=protected-access
-    mock_batch = mocker.patch.object(
+    mock_transact = mocker.patch.object(
         client._client,
-        "batch_write_item",
-        side_effect=[
-            {
-                "UnprocessedItems": {
-                    dynamodb_table: [
-                        {"PutRequest": {"Item": labels_to_add[0].to_item()}}
-                    ]
-                }
-            },
-            {},  # Success on retry
-        ],
+        "transact_write_items",
+        return_value={},
     )
 
     client.add_receipt_word_labels(labels_to_add)
 
-    # Should be called twice (initial + retry)
-    assert mock_batch.call_count == 2
+    mock_transact.assert_called_once()
+    transact_items = mock_transact.call_args.kwargs["TransactItems"]
+    assert len(transact_items) == len(labels_to_add)
+    assert all(
+        item["Put"]["ConditionExpression"]
+        == "attribute_not_exists(PK) AND attribute_not_exists(SK)"
+        for item in transact_items
+    )
+
+
+@pytest.mark.integration
+def test_add_receipt_word_labels_does_not_overwrite_existing_label(
+    dynamodb_table: Literal["MyMockedTable"],
+    sample_receipt_word_label: ReceiptWordLabel,
+) -> None:
+    """A bulk add cannot clobber a human-reviewed label on a rerun."""
+    client = DynamoClient(dynamodb_table)
+    existing = sample_receipt_word_label
+    existing.validation_status = ValidationStatus.VALID.value
+    existing.reasoning = "Reviewed by a human"
+    client.add_receipt_word_label(existing)
+
+    replacement = ReceiptWordLabel(
+        image_id=existing.image_id,
+        receipt_id=existing.receipt_id,
+        line_id=existing.line_id,
+        word_id=existing.word_id,
+        label=existing.label,
+        reasoning="Machine-generated replacement",
+        timestamp_added=existing.timestamp_added,
+        validation_status=ValidationStatus.PENDING.value,
+    )
+
+    with pytest.raises(EntityAlreadyExistsError, match="already exist"):
+        client.add_receipt_word_labels([replacement])
+
+    stored = client.get_receipt_word_label(
+        existing.image_id,
+        existing.receipt_id,
+        existing.line_id,
+        existing.word_id,
+        existing.label,
+    )
+    assert stored.validation_status == ValidationStatus.VALID.value
+    assert stored.reasoning == "Reviewed by a human"
+
+
+@pytest.mark.integration
+def test_add_receipt_word_labels_maps_conditional_transaction_failure(
+    dynamodb_table: Literal["MyMockedTable"],
+    sample_receipt_word_label: ReceiptWordLabel,
+    mocker: MockerFixture,
+) -> None:
+    """Conditional transaction cancellation has a domain-level error."""
+    client = DynamoClient(dynamodb_table)
+    # pylint: disable=protected-access
+    mocker.patch.object(
+        client._client,
+        "transact_write_items",
+        side_effect=ClientError(
+            {
+                "Error": {
+                    "Code": "TransactionCanceledException",
+                    "Message": "Transaction cancelled [ConditionalCheckFailed]",
+                },
+                "CancellationReasons": [
+                    {"Code": "ConditionalCheckFailed", "Message": "exists"}
+                ],
+            },
+            "TransactWriteItems",
+        ),
+    )
+
+    with pytest.raises(EntityAlreadyExistsError, match="already exist"):
+        client.add_receipt_word_labels([sample_receipt_word_label])
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    "invalid_label",
+    [
+        "SUBTOTAL SHOULD BE 50.63 OR FIX THE DISCOUNTS",
+        "7829.53",
+        "LOYAULTY_ID",
+    ],
+)
+def test_add_receipt_word_label_rejects_non_core_label(
+    dynamodb_table: Literal["MyMockedTable"],
+    sample_receipt_word_label: ReceiptWordLabel,
+    invalid_label: str,
+) -> None:
+    """Application/model writes cannot mint arbitrary label keys."""
+    client = DynamoClient(dynamodb_table)
+    sample_receipt_word_label.label = invalid_label
+
+    with pytest.raises(
+        EntityValidationError,
+        match="Cannot add non-core receipt word label",
+    ):
+        client.add_receipt_word_label(sample_receipt_word_label)
+
+
+@pytest.mark.integration
+def test_add_receipt_word_labels_rejects_non_core_batch_before_write(
+    dynamodb_table: Literal["MyMockedTable"],
+    sample_receipt_word_label: ReceiptWordLabel,
+    mocker: MockerFixture,
+) -> None:
+    """One polluted value rejects the batch before DynamoDB is called."""
+    client = DynamoClient(dynamodb_table)
+    sample_receipt_word_label.label = "ITEM_PRICE"
+    # pylint: disable=protected-access
+    mock_transact = mocker.patch.object(
+        client._client,
+        "transact_write_items",
+    )
+
+    with pytest.raises(
+        EntityValidationError,
+        match="Cannot add non-core receipt word label",
+    ):
+        client.add_receipt_word_labels([sample_receipt_word_label])
+
+    mock_transact.assert_not_called()
+
+
+@pytest.mark.integration
+def test_add_receipt_word_label_allows_explicit_legacy_restoration(
+    dynamodb_table: Literal["MyMockedTable"],
+    sample_receipt_word_label: ReceiptWordLabel,
+) -> None:
+    """Controlled restore paths can preserve a historical non-core key."""
+    client = DynamoClient(dynamodb_table)
+    sample_receipt_word_label.label = "ITEM_NAME"
+
+    client.add_receipt_word_label(
+        sample_receipt_word_label,
+        allow_non_core_labels=True,
+    )
+
+    stored = client.get_receipt_word_label(
+        sample_receipt_word_label.image_id,
+        sample_receipt_word_label.receipt_id,
+        sample_receipt_word_label.line_id,
+        sample_receipt_word_label.word_id,
+        sample_receipt_word_label.label,
+    )
+    assert stored.label == "ITEM_NAME"
 
 
 @pytest.mark.integration
@@ -967,7 +1103,7 @@ def test_list_receipt_word_labels_with_validation_status(
             image_id=image_id,
             line_id=i + 1,
             word_id=1,
-            label="ITEM",
+            label="PRODUCT_NAME",
             reasoning="Valid label",
             timestamp_added="2024-03-20T12:00:00+00:00",
             validation_status=ValidationStatus.VALID,
@@ -980,7 +1116,7 @@ def test_list_receipt_word_labels_with_validation_status(
             image_id=image_id,
             line_id=i + 1,
             word_id=2,
-            label="PRICE",
+            label="LINE_TOTAL",
             reasoning="Invalid label",
             timestamp_added="2024-03-20T12:00:00+00:00",
             validation_status=ValidationStatus.INVALID,

--- a/receipt_layoutlm/receipt_layoutlm/inference.py
+++ b/receipt_layoutlm/receipt_layoutlm/inference.py
@@ -114,6 +114,17 @@ class LayoutLMInference:
             self._parse_run_json(local_run_json)
             return
 
+        # Checkpoint dirs are children of the run output dir, which holds
+        # run.json (e.g. <output>/run.json vs <output>/checkpoint-1234/).
+        # Without this, in-process evals of a just-saved checkpoint load no
+        # label_merges and score merged runs against unmerged gold labels.
+        parent_run_json = os.path.join(
+            os.path.dirname(self._model_dir.rstrip(os.sep)), "run.json"
+        )
+        if os.path.exists(parent_run_json):
+            self._parse_run_json(parent_run_json)
+            return
+
         if not s3_uri or not s3_uri.startswith("s3://"):
             return
 

--- a/scripts/evaluate_section_geometry.py
+++ b/scripts/evaluate_section_geometry.py
@@ -1,0 +1,982 @@
+#!/usr/bin/env python3
+"""Evaluate structure and Chroma projection evidence for receipt sections.
+
+This is an offline, read-only experiment.  It consumes the repository's local
+analytics cache, learns only from QA-VALID section rows, splits by receipt,
+and compares the existing semi-Markov decoder with three supplemental signals:
+
+* geometry + arithmetic: a regularized diagonal class model over row layout,
+  price-column alignment, amount magnitude, and running-sum residuals;
+* embedding projection: cosine projection onto section centroids; and
+* embedding neighborhood: cosine-weighted KNN votes.
+
+No DynamoDB or S3 writes are performed.  Chroma snapshots affected by the
+metadata-only vector-checkpoint lag are repaired only in a separate local copy
+and only after proving that every skipped log record is a vector-free UPDATE.
+"""
+
+# Monorepo sibling paths must be installed before runtime imports.
+# pylint: disable=wrong-import-position,too-many-locals
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import re
+import shutil
+import sqlite3
+import sys
+from collections import Counter, defaultdict
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, replace
+from pathlib import Path
+from statistics import fmean, median
+from typing import Any
+
+import numpy as np
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+for _package in ("receipt_dynamo", "receipt_chroma", "receipt_upload"):
+    sys.path.insert(0, str(_REPO_ROOT / _package))
+
+from receipt_chroma import ChromaClient  # noqa: E402
+from receipt_dynamo import (  # noqa: E402
+    item_to_receipt_line,
+    item_to_receipt_row,
+    item_to_receipt_section,
+)
+from receipt_dynamo.constants import ValidationStatus  # noqa: E402
+from receipt_upload.section_assignment import (  # noqa: E402
+    RowFeatures,
+    assign_feature_sections,
+    extract_row_features,
+    learn_prior,
+)
+
+_AMOUNT_RE = re.compile(
+    r"^\(?\s*([-+])?\s*\$?\s*([\d,]+(?:\.\d{1,2})?)\s*([-])?\s*\)?$"
+)
+_EPSILON = 1e-8
+_KNN_NEIGHBORS = 15
+_WEIGHT_CHOICES = (0.0, 0.25, 0.5, 1.0)
+
+
+@dataclass(frozen=True)
+class ReceiptCase:
+    """One receipt and its observable/truth evidence."""
+
+    image_id: str
+    receipt_id: int
+    merchant: str
+    features: tuple[RowFeatures, ...]
+    truth: Mapping[int, str]
+    structure: np.ndarray
+
+    @property
+    def key(self) -> tuple[str, int]:
+        return self.image_id, self.receipt_id
+
+
+@dataclass(frozen=True)
+class EvidenceWeights:
+    """Fusion weights selected on the validation receipt split."""
+
+    geometry_math: float = 0.0
+    embedding_projection: float = 0.0
+    embedding_knn: float = 0.0
+
+    def as_dict(self) -> dict[str, float]:
+        return {
+            "geometry_math": self.geometry_math,
+            "embedding_projection": self.embedding_projection,
+            "embedding_knn": self.embedding_knn,
+        }
+
+
+@dataclass(frozen=True)
+class CaseEvidence:
+    """Section-aligned supplemental scores for one receipt."""
+
+    geometry_math: np.ndarray
+    embedding_projection: np.ndarray
+    embedding_knn: np.ndarray
+    embedding_available: np.ndarray
+
+
+@dataclass(frozen=True)
+class EvidenceModel:
+    """Training-split geometry and embedding projection model."""
+
+    sections: tuple[str, ...]
+    structure_mean: np.ndarray
+    structure_scale: np.ndarray
+    class_structure_mean: np.ndarray
+    class_structure_scale: np.ndarray
+    embedding_centroids: np.ndarray | None
+    train_embeddings: np.ndarray | None
+    train_embedding_labels: np.ndarray | None
+
+
+def _arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--cache-root",
+        type=Path,
+        default=_REPO_ROOT / ".cache" / "analytics" / "dev",
+    )
+    parser.add_argument(
+        "--working-root",
+        type=Path,
+        default=_REPO_ROOT / ".cache" / "section-geometry",
+        help="Ignored local directory for a guarded Chroma read copy",
+    )
+    parser.add_argument("--output", type=Path)
+    parser.add_argument(
+        "--max-receipts",
+        type=int,
+        help="Deterministic receipt cap for quick smoke experiments",
+    )
+    parser.add_argument("--seed", default="section-geometry-v1")
+    parser.add_argument("--knn-neighbors", type=int, default=_KNN_NEIGHBORS)
+    return parser.parse_args()
+
+
+def _wire_items(
+    connection: sqlite3.Connection,
+    entity_type: str,
+    image_id: str | None = None,
+    receipt_id: int | None = None,
+) -> list[dict[str, Any]]:
+    clauses = ["entity_type = ?"]
+    parameters: list[Any] = [entity_type]
+    if image_id is not None:
+        clauses.append("image_id = ?")
+        parameters.append(image_id)
+    if receipt_id is not None:
+        clauses.append("receipt_id = ?")
+        parameters.append(receipt_id)
+    rows = connection.execute(
+        "SELECT dynamodb_json FROM dynamo_items WHERE " + " AND ".join(clauses),
+        parameters,
+    ).fetchall()
+    return [json.loads(row[0]) for row in rows]
+
+
+def _row_label(row: Any, line_sections: Mapping[int, set[str]]) -> str | None:
+    votes = Counter(
+        section
+        for line_id in row.line_ids
+        if line_id in line_sections
+        for section in line_sections[line_id]
+    )
+    if not votes:
+        return None
+    maximum = max(votes.values())
+    leaders = sorted(label for label, count in votes.items() if count == maximum)
+    return leaders[0] if len(leaders) == 1 else None
+
+
+def _parse_amount(value: str | None) -> float | None:
+    if not value:
+        return None
+    match = _AMOUNT_RE.fullmatch(value.strip())
+    if not match:
+        return None
+    amount = float(match.group(2).replace(",", ""))
+    if match.group(1) == "-" or match.group(3) == "-":
+        amount *= -1
+    return amount
+
+
+def _structure_matrix(features: Sequence[RowFeatures]) -> np.ndarray:
+    """Build scale-free geometry and arithmetic row features."""
+
+    if not features:
+        return np.empty((0, 16), dtype=np.float32)
+    rows = [feature.row for feature in features]
+    heights = np.asarray(
+        [max(row.y_max - row.y_min, _EPSILON) for row in rows],
+        dtype=np.float32,
+    )
+    typical_height = max(float(median(heights.tolist())), _EPSILON)
+    amounts = [_parse_amount(row.amount_text) for row in rows]
+    maximum_amount = max((abs(value) for value in amounts if value), default=1.0)
+    amount_flags = np.asarray(
+        [float(value is not None) for value in amounts], dtype=np.float32
+    )
+    matrix: list[list[float]] = []
+    prior_amounts: list[float] = []
+    for index, (feature, amount) in enumerate(zip(features, amounts, strict=True)):
+        row = feature.row
+        gap_above = 0.0
+        if index:
+            gap_above = max(0.0, rows[index - 1].y_min - row.y_max)
+        gap_below = 0.0
+        if index + 1 < len(rows):
+            gap_below = max(0.0, row.y_min - rows[index + 1].y_max)
+        arithmetic_fit = 1.0
+        if amount is not None and abs(amount) > _EPSILON and prior_amounts:
+            window_sums = [
+                sum(prior_amounts[-width:])
+                for width in range(1, min(len(prior_amounts), 12) + 1)
+            ]
+            arithmetic_fit = min(
+                min(
+                    abs(abs(amount) - candidate) / max(abs(amount), candidate, _EPSILON)
+                    for candidate in window_sums
+                ),
+                1.0,
+            )
+        radius_start = max(0, index - 2)
+        radius_end = min(len(rows), index + 3)
+        local_amount_density = float(np.mean(amount_flags[radius_start:radius_end]))
+        price_offset = 0.0
+        if row.price_column_x is not None:
+            price_offset = row.x_max - row.price_column_x
+        matrix.append(
+            [
+                feature.position,
+                (row.y_min + row.y_max) / 2,
+                math.log1p((row.y_max - row.y_min) / typical_height),
+                row.x_min,
+                row.x_max,
+                (row.x_min + row.x_max) / 2,
+                row.x_max - row.x_min,
+                math.log1p(gap_above / typical_height),
+                math.log1p(gap_below / typical_height),
+                float(amount is not None),
+                float(row.amount_text is not None),
+                price_offset,
+                (
+                    math.log1p(abs(amount)) / math.log1p(maximum_amount)
+                    if amount is not None
+                    else 0.0
+                ),
+                float(amount is not None and amount < 0),
+                1.0 - arithmetic_fit if amount is not None else 0.0,
+                local_amount_density,
+            ]
+        )
+        if amount is not None:
+            prior_amounts.append(abs(amount))
+    return np.asarray(matrix, dtype=np.float32)
+
+
+def load_cases(db_path: Path, max_receipts: int | None = None) -> list[ReceiptCase]:
+    """Load the QA-VALID receipt corpus from the SQLite mirror."""
+
+    uri = f"file:{db_path}?mode=ro"
+    with sqlite3.connect(uri, uri=True) as connection:
+        valid_sections = [
+            item_to_receipt_section(item)
+            for item in _wire_items(connection, "RECEIPT_SECTION")
+            if item.get("validation_status", {}).get("S")
+            == ValidationStatus.VALID.value
+        ]
+        sections_by_receipt: dict[tuple[str, int], list[Any]] = defaultdict(list)
+        for section in valid_sections:
+            sections_by_receipt[(section.image_id, section.receipt_id)].append(section)
+        keys = sorted(sections_by_receipt)
+        if max_receipts is not None:
+            keys = keys[:max_receipts]
+
+        result: list[ReceiptCase] = []
+        for image_id, receipt_id in keys:
+            rows = sorted(
+                (
+                    item_to_receipt_row(item)
+                    for item in _wire_items(
+                        connection, "RECEIPT_ROW", image_id, receipt_id
+                    )
+                ),
+                key=lambda row: (-(row.y_min + row.y_max), row.row_id),
+            )
+            lines = [
+                item_to_receipt_line(item)
+                for item in _wire_items(
+                    connection, "RECEIPT_LINE", image_id, receipt_id
+                )
+            ]
+            if not rows or not lines:
+                continue
+            line_sections: dict[int, set[str]] = defaultdict(set)
+            for section in sections_by_receipt[(image_id, receipt_id)]:
+                for line_id in section.line_ids:
+                    line_sections[line_id].add(str(section.section_type))
+            truth = {
+                row.row_id: label
+                for row in rows
+                if (label := _row_label(row, line_sections)) is not None
+            }
+            if not truth:
+                continue
+            place_rows = connection.execute(
+                """SELECT item_json FROM dynamo_items
+                   WHERE entity_type = 'RECEIPT_PLACE'
+                     AND image_id = ? AND receipt_id = ? LIMIT 1""",
+                (image_id, receipt_id),
+            ).fetchall()
+            merchant = ""
+            if place_rows:
+                merchant = str(json.loads(place_rows[0][0]).get("merchant_name", ""))
+            features = tuple(extract_row_features(rows, lines))
+            result.append(
+                ReceiptCase(
+                    image_id=image_id,
+                    receipt_id=receipt_id,
+                    merchant=merchant,
+                    features=features,
+                    truth=truth,
+                    structure=_structure_matrix(features),
+                )
+            )
+    return result
+
+
+def _chroma_count(path: Path) -> int:
+    with ChromaClient(persist_directory=str(path), mode="read") as client:
+        return int(client.get_collection("lines").count())
+
+
+def repair_metadata_only_vector_lag(db_path: Path) -> dict[str, int]:
+    """Advance a copied vector checkpoint over proven metadata-only updates.
+
+    Chroma 1.3.6 can fail to open an atomically downloaded snapshot when its
+    vector segment checkpoint trails metadata-only UPDATE log records whose
+    vectors are NULL.  Those records cannot affect the HNSW vector segment.
+    Every safety predicate is checked in one immediate transaction before the
+    single checkpoint update is allowed.
+    """
+
+    with sqlite3.connect(db_path) as connection:
+        connection.execute("BEGIN IMMEDIATE")
+        segments = connection.execute("""SELECT s.id, s.scope, m.seq_id
+               FROM segments s JOIN max_seq_id m ON m.segment_id = s.id
+               WHERE s.scope IN ('VECTOR', 'METADATA')""").fetchall()
+        by_scope = {
+            scope: (segment_id, int(seq_id)) for segment_id, scope, seq_id in segments
+        }
+        if set(by_scope) != {"VECTOR", "METADATA"}:
+            raise RuntimeError("Expected exactly one VECTOR and METADATA checkpoint")
+        vector_id, vector_seq = by_scope["VECTOR"]
+        _, metadata_seq = by_scope["METADATA"]
+        if vector_seq >= metadata_seq:
+            connection.rollback()
+            return {"from_seq": vector_seq, "to_seq": vector_seq, "updates": 0}
+        rows = connection.execute(
+            """SELECT seq_id, operation, vector IS NULL
+               FROM embeddings_queue
+               WHERE seq_id > ? AND seq_id <= ? ORDER BY seq_id""",
+            (vector_seq, metadata_seq),
+        ).fetchall()
+        expected = metadata_seq - vector_seq
+        if len(rows) != expected:
+            raise RuntimeError(
+                "Unsafe Chroma repair: vector-lag log range is not contiguous"
+            )
+        if any(
+            int(seq_id) != vector_seq + index
+            or int(operation) != 1
+            or int(vector_is_null) != 1
+            for index, (seq_id, operation, vector_is_null) in enumerate(rows, start=1)
+        ):
+            raise RuntimeError(
+                "Unsafe Chroma repair: lag contains a vector write, delete, "
+                "or non-UPDATE operation"
+            )
+        cursor = connection.execute(
+            "UPDATE max_seq_id SET seq_id = ? WHERE segment_id = ? AND seq_id = ?",
+            (metadata_seq, vector_id, vector_seq),
+        )
+        if cursor.rowcount != 1:
+            raise RuntimeError("Chroma vector checkpoint changed during repair")
+        connection.commit()
+        return {
+            "from_seq": vector_seq,
+            "to_seq": metadata_seq,
+            "updates": len(rows),
+        }
+
+
+def prepare_chroma_lines(source: Path, working: Path) -> tuple[Path, dict[str, Any]]:
+    """Return a readable line snapshot, repairing only a separate copy."""
+
+    try:
+        count = _chroma_count(source)
+        return source, {"copied": False, "repair": None, "vector_count": count}
+    except Exception as error:  # the exact Chroma exception changed across 1.x
+        if (
+            "backfill" not in str(error).casefold()
+            or "log" not in str(error).casefold()
+        ):
+            raise
+        if not working.exists():
+            working.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copytree(source, working)
+        repair = repair_metadata_only_vector_lag(working / "chroma.sqlite3")
+        count = _chroma_count(working)
+        return working, {
+            "copied": True,
+            "source_error": str(error),
+            "repair": repair,
+            "vector_count": count,
+        }
+
+
+def _chroma_id(case: ReceiptCase, row_id: int) -> str:
+    return f"IMAGE#{case.image_id}#RECEIPT#{case.receipt_id:05d}" f"#LINE#{row_id:05d}"
+
+
+def load_embeddings(
+    path: Path, cases: Sequence[ReceiptCase], batch_size: int = 1000
+) -> tuple[dict[tuple[str, int, int], np.ndarray], dict[str, int]]:
+    """Load exact row vectors; no nearest-neighbor query or metadata is used."""
+
+    requested: dict[str, tuple[str, int, int]] = {}
+    for case in cases:
+        for feature in case.features:
+            requested[_chroma_id(case, feature.row.row_id)] = (
+                case.image_id,
+                case.receipt_id,
+                feature.row.row_id,
+            )
+    result: dict[tuple[str, int, int], np.ndarray] = {}
+    ids = sorted(requested)
+    with ChromaClient(persist_directory=str(path), mode="read") as client:
+        collection = client.get_collection("lines")
+        for offset in range(0, len(ids), batch_size):
+            payload = collection.get(
+                ids=ids[offset : offset + batch_size], include=["embeddings"]
+            )
+            embeddings = payload.get("embeddings")
+            if embeddings is None:
+                continue
+            for chroma_id, embedding in zip(payload["ids"], embeddings, strict=True):
+                result[requested[chroma_id]] = np.asarray(embedding, dtype=np.float32)
+    return result, {"requested": len(ids), "found": len(result)}
+
+
+def _split_value(case: ReceiptCase, seed: str) -> int:
+    payload = f"{seed}:{case.image_id}:{case.receipt_id}".encode()
+    return int.from_bytes(hashlib.sha256(payload).digest()[:8], "big") % 100
+
+
+def split_cases(
+    cases: Sequence[ReceiptCase], seed: str
+) -> tuple[list[ReceiptCase], list[ReceiptCase], list[ReceiptCase]]:
+    train, validation, test = [], [], []
+    for case in cases:
+        value = _split_value(case, seed)
+        if value < 60:
+            train.append(case)
+        elif value < 80:
+            validation.append(case)
+        else:
+            test.append(case)
+    return train, validation, test
+
+
+def _decoder_model(cases: Sequence[ReceiptCase]) -> dict[str, Any]:
+    labeled = [
+        [
+            (feature, case.truth[feature.row.row_id])
+            for feature in case.features
+            if feature.row.row_id in case.truth
+        ]
+        for case in cases
+    ]
+    labeled = [receipt for receipt in labeled if receipt]
+    return {
+        "schema_version": "geometry-experiment-v1",
+        "global": learn_prior(labeled),
+        "merchants": {},
+    }
+
+
+def _normalize_rows(values: np.ndarray) -> np.ndarray:
+    return values / (np.linalg.norm(values, axis=1, keepdims=True) + _EPSILON)
+
+
+def fit_evidence_model(
+    cases: Sequence[ReceiptCase],
+    embeddings: Mapping[tuple[str, int, int], np.ndarray],
+    sections: Sequence[str],
+) -> EvidenceModel:
+    """Fit regularized class geometry and embedding centroids."""
+
+    section_tuple = tuple(sections)
+    section_index = {section: index for index, section in enumerate(section_tuple)}
+    structures: list[np.ndarray] = []
+    labels: list[int] = []
+    embedding_rows: list[np.ndarray] = []
+    embedding_labels: list[int] = []
+    for case in cases:
+        for row_index, feature in enumerate(case.features):
+            label = case.truth.get(feature.row.row_id)
+            if label not in section_index:
+                continue
+            label_index = section_index[label]
+            structures.append(case.structure[row_index])
+            labels.append(label_index)
+            embedding = embeddings.get(
+                (case.image_id, case.receipt_id, feature.row.row_id)
+            )
+            if embedding is not None:
+                embedding_rows.append(embedding)
+                embedding_labels.append(label_index)
+    structure_values = np.asarray(structures, dtype=np.float32)
+    label_values = np.asarray(labels, dtype=np.int32)
+    structure_mean = structure_values.mean(axis=0)
+    structure_scale = np.maximum(structure_values.std(axis=0), 0.05)
+    normalized_structure = (structure_values - structure_mean) / structure_scale
+    pooled_variance = np.maximum(normalized_structure.var(axis=0), 0.05)
+    class_means = []
+    class_scales = []
+    for index in range(len(section_tuple)):
+        selected = normalized_structure[label_values == index]
+        if not len(selected):
+            raise RuntimeError(f"No structure training rows for {section_tuple[index]}")
+        class_means.append(selected.mean(axis=0))
+        variance = (selected.var(axis=0) * len(selected) + pooled_variance * 8) / (
+            len(selected) + 8
+        )
+        class_scales.append(np.sqrt(np.maximum(variance, 0.05)))
+
+    embedding_centroids = None
+    train_embeddings = None
+    train_embedding_labels = None
+    if embedding_rows:
+        train_embeddings = _normalize_rows(np.asarray(embedding_rows, dtype=np.float32))
+        train_embedding_labels = np.asarray(embedding_labels, dtype=np.int32)
+        centroids = []
+        for index in range(len(section_tuple)):
+            selected = train_embeddings[train_embedding_labels == index]
+            if not len(selected):
+                raise RuntimeError(
+                    f"No embedding training rows for {section_tuple[index]}"
+                )
+            centroid = selected.mean(axis=0, keepdims=True)
+            centroids.append(_normalize_rows(centroid)[0])
+        embedding_centroids = np.asarray(centroids, dtype=np.float32)
+    return EvidenceModel(
+        sections=section_tuple,
+        structure_mean=structure_mean,
+        structure_scale=structure_scale,
+        class_structure_mean=np.asarray(class_means, dtype=np.float32),
+        class_structure_scale=np.asarray(class_scales, dtype=np.float32),
+        embedding_centroids=embedding_centroids,
+        train_embeddings=train_embeddings,
+        train_embedding_labels=train_embedding_labels,
+    )
+
+
+def _center_clip(scores: np.ndarray, limit: float = 8.0) -> np.ndarray:
+    centered = scores - scores.mean(axis=1, keepdims=True)
+    return np.clip(centered, -limit, limit).astype(np.float32)
+
+
+def case_evidence(
+    case: ReceiptCase,
+    model: EvidenceModel,
+    embeddings: Mapping[tuple[str, int, int], np.ndarray],
+    knn_neighbors: int,
+) -> CaseEvidence:
+    """Project one receipt onto the learned structure and embedding spaces."""
+
+    normalized = (case.structure - model.structure_mean) / model.structure_scale
+    residual = (
+        normalized[:, None, :] - model.class_structure_mean[None, :, :]
+    ) / model.class_structure_scale[None, :, :]
+    geometry = -0.5 * np.mean(
+        residual * residual + 2 * np.log(model.class_structure_scale[None, :, :]),
+        axis=2,
+    )
+    geometry = _center_clip(geometry)
+
+    row_embeddings: list[np.ndarray] = []
+    available = []
+    dimension = (
+        model.embedding_centroids.shape[1]
+        if model.embedding_centroids is not None
+        else 0
+    )
+    for feature in case.features:
+        embedding = embeddings.get((case.image_id, case.receipt_id, feature.row.row_id))
+        available.append(embedding is not None)
+        row_embeddings.append(
+            embedding
+            if embedding is not None
+            else np.zeros(dimension, dtype=np.float32)
+        )
+    available_array = np.asarray(available, dtype=bool)
+    projection = np.zeros((len(case.features), len(model.sections)), dtype=np.float32)
+    knn = np.zeros_like(projection)
+    if (
+        model.embedding_centroids is not None
+        and model.train_embeddings is not None
+        and model.train_embedding_labels is not None
+        and np.any(available_array)
+    ):
+        query = _normalize_rows(np.asarray(row_embeddings, dtype=np.float32))
+        projection = _center_clip((query @ model.embedding_centroids.T) / 0.05)
+        projection[~available_array] = 0.0
+
+        similarities = query[available_array] @ model.train_embeddings.T
+        neighbors = min(knn_neighbors, model.train_embeddings.shape[0])
+        indices = np.argpartition(-similarities, kth=neighbors - 1, axis=1)[
+            :, :neighbors
+        ]
+        probabilities = np.full(
+            (indices.shape[0], len(model.sections)), 0.1, dtype=np.float32
+        )
+        for query_index, neighbor_indices in enumerate(indices):
+            for neighbor_index in neighbor_indices:
+                weight = max(float(similarities[query_index, neighbor_index]), 0.0)
+                probabilities[
+                    query_index, model.train_embedding_labels[neighbor_index]
+                ] += weight
+        probabilities /= probabilities.sum(axis=1, keepdims=True)
+        knn[available_array] = _center_clip(np.log(probabilities + _EPSILON))
+    return CaseEvidence(geometry, projection, knn, available_array)
+
+
+def _lexical_scores(
+    feature: RowFeatures, model: Mapping[str, Any], sections: Sequence[str]
+) -> np.ndarray:
+    result = []
+    for section in sections:
+        token_log_odds = model["global"]["section_models"][section].get(
+            "token_log_odds", {}
+        )
+        result.append(
+            sum(
+                float(token_log_odds[token])
+                for token in feature.tokens
+                if token in token_log_odds
+            )
+        )
+    return np.asarray(result, dtype=np.float32)
+
+
+def _predict(
+    case: ReceiptCase,
+    decoder_model: Mapping[str, Any],
+    evidence: CaseEvidence | None = None,
+    weights: EvidenceWeights | None = None,
+) -> dict[int, str]:
+    if evidence is None or weights is None or not any(weights.as_dict().values()):
+        features = case.features
+    else:
+        sections = tuple(decoder_model["global"]["sections"])
+        features = tuple(
+            replace(
+                feature,
+                token_evidence=tuple(
+                    zip(
+                        sections,
+                        (
+                            _lexical_scores(feature, decoder_model, sections)
+                            + weights.geometry_math * evidence.geometry_math[index]
+                            + weights.embedding_projection
+                            * evidence.embedding_projection[index]
+                            + weights.embedding_knn * evidence.embedding_knn[index]
+                        ).tolist(),
+                        strict=True,
+                    )
+                ),
+            )
+            for index, feature in enumerate(case.features)
+        )
+    return {
+        assignment.row.row_id: assignment.section_type
+        for assignment in assign_feature_sections(features, decoder_model)
+    }
+
+
+def score_cases(
+    cases: Sequence[ReceiptCase],
+    decoder_model: Mapping[str, Any],
+    evidence: Mapping[tuple[str, int], CaseEvidence] | None = None,
+    weights: EvidenceWeights | None = None,
+) -> dict[str, Any]:
+    matched = 0
+    total = 0
+    per_type_total: Counter[str] = Counter()
+    per_type_matched: Counter[str] = Counter()
+    case_scores = []
+    for case in cases:
+        predicted = _predict(
+            case,
+            decoder_model,
+            evidence.get(case.key) if evidence else None,
+            weights,
+        )
+        case_matched = 0
+        for row_id, expected in case.truth.items():
+            total += 1
+            per_type_total[expected] += 1
+            if predicted.get(row_id) == expected:
+                matched += 1
+                case_matched += 1
+                per_type_matched[expected] += 1
+        case_scores.append(case_matched / len(case.truth))
+    per_type = {
+        section: {
+            "matched": per_type_matched[section],
+            "scored": count,
+            "recall": per_type_matched[section] / count,
+        }
+        for section, count in sorted(per_type_total.items())
+    }
+    return {
+        "receipts": len(cases),
+        "matched": matched,
+        "scored": total,
+        "agreement": matched / total if total else 0.0,
+        "mean_receipt_agreement": fmean(case_scores) if case_scores else 0.0,
+        "macro_recall": (
+            fmean(item["recall"] for item in per_type.values()) if per_type else 0.0
+        ),
+        "per_type": per_type,
+    }
+
+
+def _objective(score: Mapping[str, Any]) -> tuple[float, float]:
+    return float(score["agreement"]), float(score["macro_recall"])
+
+
+def tune_weights(
+    cases: Sequence[ReceiptCase],
+    decoder_model: Mapping[str, Any],
+    evidence: Mapping[tuple[str, int], CaseEvidence],
+) -> tuple[EvidenceWeights, list[dict[str, Any]]]:
+    """Use two deterministic coordinate-descent passes on validation only."""
+
+    current = EvidenceWeights()
+    trials: list[dict[str, Any]] = []
+    fields = ("geometry_math", "embedding_projection", "embedding_knn")
+    for _ in range(2):
+        for field in fields:
+            candidates = []
+            for choice in _WEIGHT_CHOICES:
+                candidate = replace(current, **{field: choice})
+                score = score_cases(cases, decoder_model, evidence, candidate)
+                trials.append(
+                    {
+                        "weights": candidate.as_dict(),
+                        "agreement": score["agreement"],
+                        "macro_recall": score["macro_recall"],
+                    }
+                )
+                candidates.append((candidate, score))
+            current, _ = max(
+                candidates,
+                key=lambda item: (
+                    _objective(item[1]),
+                    -sum(item[0].as_dict().values()),
+                ),
+            )
+    return current, trials
+
+
+def _metric_delta(
+    baseline: Mapping[str, Any], candidate: Mapping[str, Any]
+) -> dict[str, float]:
+    result = {
+        "agreement": float(candidate["agreement"] - baseline["agreement"]),
+        "macro_recall": float(candidate["macro_recall"] - baseline["macro_recall"]),
+    }
+    all_types = set(baseline["per_type"]) | set(candidate["per_type"])
+    for section in sorted(all_types):
+        before = baseline["per_type"].get(section, {}).get("recall", 0.0)
+        after = candidate["per_type"].get(section, {}).get("recall", 0.0)
+        result[f"recall_{section}"] = float(after - before)
+    return result
+
+
+def paired_comparison(
+    cases: Sequence[ReceiptCase],
+    decoder_model: Mapping[str, Any],
+    evidence: Mapping[tuple[str, int], CaseEvidence],
+    weights: EvidenceWeights,
+    *,
+    bootstrap_seed: int = 20260729,
+    bootstrap_samples: int = 5000,
+) -> dict[str, Any]:
+    """Return paired row outcomes and a receipt-bootstrap interval."""
+
+    before_only = 0
+    after_only = 0
+    both_correct = 0
+    both_wrong = 0
+    receipt_outcomes: list[tuple[int, int, int]] = []
+    for case in cases:
+        baseline = _predict(case, decoder_model)
+        hybrid = _predict(case, decoder_model, evidence[case.key], weights)
+        baseline_matched = 0
+        hybrid_matched = 0
+        for row_id, expected in case.truth.items():
+            before = baseline.get(row_id) == expected
+            after = hybrid.get(row_id) == expected
+            baseline_matched += int(before)
+            hybrid_matched += int(after)
+            if before and after:
+                both_correct += 1
+            elif before:
+                before_only += 1
+            elif after:
+                after_only += 1
+            else:
+                both_wrong += 1
+        receipt_outcomes.append((baseline_matched, hybrid_matched, len(case.truth)))
+
+    discordant = before_only + after_only
+    tail = min(before_only, after_only)
+    mcnemar_p = min(
+        1.0,
+        2
+        * sum(
+            math.comb(discordant, value) * (0.5**discordant)
+            for value in range(tail + 1)
+        ),
+    )
+    values = np.asarray(receipt_outcomes, dtype=np.float64)
+    generator = np.random.default_rng(bootstrap_seed)
+    deltas = np.empty(bootstrap_samples, dtype=np.float64)
+    for sample in range(bootstrap_samples):
+        indices = generator.integers(0, len(values), size=len(values))
+        selected = values[indices]
+        deltas[sample] = (selected[:, 1].sum() - selected[:, 0].sum()) / selected[
+            :, 2
+        ].sum()
+    lower, upper = np.quantile(deltas, [0.025, 0.975])
+    return {
+        "both_correct": both_correct,
+        "baseline_only_correct": before_only,
+        "hybrid_only_correct": after_only,
+        "both_wrong": both_wrong,
+        "net_rows": after_only - before_only,
+        "exact_mcnemar_two_sided_p": mcnemar_p,
+        "receipt_bootstrap_delta_95pct": [float(lower), float(upper)],
+        "bootstrap_samples": bootstrap_samples,
+    }
+
+
+def evaluate(args: argparse.Namespace) -> dict[str, Any]:
+    manifest = json.loads((args.cache_root / "manifest.json").read_text())
+    for component in ("dynamodb", "chroma"):
+        if manifest.get("components", {}).get(component, {}).get("valid") is not True:
+            raise RuntimeError(f"Local analytics {component} component is not valid")
+    cases = load_cases(args.cache_root / "dynamodb.sqlite3", args.max_receipts)
+    train, validation, test = split_cases(cases, args.seed)
+    if not train or not validation or not test:
+        raise RuntimeError("Receipt split produced an empty partition")
+    line_version = manifest["components"]["chroma"]["collections"]["lines"][
+        "version_id"
+    ]
+    chroma_path, repair = prepare_chroma_lines(
+        args.cache_root / "chroma" / "lines",
+        args.working_root / "chroma" / line_version / "lines",
+    )
+    embeddings, embedding_coverage = load_embeddings(chroma_path, cases)
+
+    tuning_decoder = _decoder_model(train)
+    tuning_sections = tuning_decoder["global"]["sections"]
+    tuning_evidence_model = fit_evidence_model(train, embeddings, tuning_sections)
+    validation_evidence = {
+        case.key: case_evidence(
+            case, tuning_evidence_model, embeddings, args.knn_neighbors
+        )
+        for case in validation
+    }
+    validation_baseline = score_cases(validation, tuning_decoder)
+    weights, tuning_trials = tune_weights(
+        validation, tuning_decoder, validation_evidence
+    )
+    validation_hybrid = score_cases(
+        validation, tuning_decoder, validation_evidence, weights
+    )
+
+    training = train + validation
+    final_decoder = _decoder_model(training)
+    final_sections = final_decoder["global"]["sections"]
+    final_evidence_model = fit_evidence_model(training, embeddings, final_sections)
+    test_evidence = {
+        case.key: case_evidence(
+            case, final_evidence_model, embeddings, args.knn_neighbors
+        )
+        for case in test
+    }
+    baseline = score_cases(test, final_decoder)
+    hybrid = score_cases(test, final_decoder, test_evidence, weights)
+    paired = paired_comparison(test, final_decoder, test_evidence, weights)
+    ablations = {}
+    for field in weights.as_dict():
+        component_weight = EvidenceWeights(**{field: getattr(weights, field)})
+        ablations[field] = score_cases(
+            test, final_decoder, test_evidence, component_weight
+        )
+
+    available = sum(
+        int(item.embedding_available.sum()) for item in test_evidence.values()
+    )
+    test_rows = sum(len(case.features) for case in test)
+    return {
+        "experiment": "section-geometry-embedding-v1",
+        "cache": {
+            "dynamodb_synced_at": manifest["components"]["dynamodb"]["synced_at"],
+            "dynamodb_rows": manifest["components"]["dynamodb"]["row_count"],
+            "chroma_versions": {
+                name: value["version_id"]
+                for name, value in manifest["components"]["chroma"][
+                    "collections"
+                ].items()
+            },
+            "chroma_read_repair": repair,
+        },
+        "corpus": {
+            "receipts": len(cases),
+            "split": {
+                "train": len(train),
+                "validation": len(validation),
+                "test": len(test),
+            },
+            "section_types": final_sections,
+            "embedding_coverage": {
+                **embedding_coverage,
+                "test_rows": test_rows,
+                "test_found": available,
+                "test_fraction": available / test_rows if test_rows else 0.0,
+            },
+        },
+        "selection": {
+            "weights": weights.as_dict(),
+            "validation_baseline": validation_baseline,
+            "validation_hybrid": validation_hybrid,
+            "trials": tuning_trials,
+        },
+        "test": {
+            "baseline": baseline,
+            "hybrid": hybrid,
+            "delta": _metric_delta(baseline, hybrid),
+            "paired": paired,
+            "ablations": ablations,
+        },
+    }
+
+
+def main() -> int:
+    args = _arguments()
+    report = evaluate(args)
+    rendered = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered, encoding="utf-8")
+    print(rendered, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/extract_line_items.py
+++ b/scripts/extract_line_items.py
@@ -1,0 +1,433 @@
+"""Extract line-item product details from ITEMS sections via geometry.
+
+No ML: for each receipt with a VALID ITEMS section, cluster the section's
+words into visual bands by y-center (Apple Vision splits name and price
+columns into separate OCR lines, so per-line parsing fails; per-band
+parsing recovers the pairing), then parse each band into
+(name, quantity, unit_price, price, flags).
+
+Validation built in:
+  1. Reconciliation — sum of extracted item prices vs the receipt
+     summary's subtotal (else grand_total - tax), classified as
+     match / near / mismatch / no-baseline.
+  2. Leakage — priced bands on lines outside any section for receipts
+     WITH an ITEMS section (section too narrow).
+  3. No-ITEMS triage — receipts without an ITEMS section classified as
+     genuinely item-less vs likely-missing-section, using priced lines
+     outside SUMMARY / TOTAL_LINE / PAYMENT / TRANSACTION_INFO sections.
+
+Usage:
+    python3.12 scripts/extract_line_items.py [--table ReceiptsTable-dc5be22]
+        [--out /path/to/items.jsonl] [--limit N] [--receipt IMAGE_ID:RID]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from collections import Counter
+from typing import Any, Optional
+
+import boto3
+from boto3.dynamodb.types import TypeDeserializer
+
+_DES = TypeDeserializer()
+
+PRICE_RE = re.compile(r"\$?(\d{1,4}(?:,\d{3})?\.\d{2})(-?)")
+# "2 @ 3.99", "1.23 lb @ 4.99/lb", "3 @ $0.99 ea"
+QTY_RE = re.compile(
+    r"(\d+(?:\.\d+)?)\s*(?:lb|LB|Lb)?\s*@\s*\$?(\d{1,4}\.\d{2})"
+)
+# Standalone leading quantity: "2 BURRITO ..." only when integer < 100
+LEAD_QTY_RE = re.compile(r"^(\d{1,2})\s+(?=[A-Za-z])")
+TAX_FLAG_RE = re.compile(r"\s+[TFNOAB]X?$")
+DISCOUNT_WORDS = ("SAVED", "SAVING", "OFF", "COUPON", "DISCOUNT", "PROMO")
+NON_ITEM_SECTIONS = {
+    "SUMMARY",
+    "TOTAL_LINE",
+    "PAYMENT",
+    "TRANSACTION_INFO",
+    "SURVEY",
+    "FOOTER",
+    "BARCODE",
+    "STOREFRONT",
+    "ADDRESS",
+}
+
+
+def _query_all(client, **kwargs):
+    while True:
+        resp = client.query(**kwargs)
+        yield from resp["Items"]
+        if "LastEvaluatedKey" not in resp:
+            return
+        kwargs["ExclusiveStartKey"] = resp["LastEvaluatedKey"]
+
+
+def _deser(item: dict) -> dict:
+    return {k: _DES.deserialize(v) for k, v in item.items()}
+
+
+def fetch_receipt_records(client, table: str, image_id: str, receipt_id: int):
+    """One query per receipt: words, sections, summary in a single sweep."""
+    words: list[dict] = []
+    sections: list[dict] = []
+    summary: Optional[dict] = None
+    for raw in _query_all(
+        client,
+        TableName=table,
+        KeyConditionExpression="PK = :pk AND begins_with(SK, :sk)",
+        ExpressionAttributeValues={
+            ":pk": {"S": f"IMAGE#{image_id}"},
+            ":sk": {"S": f"RECEIPT#{receipt_id:05d}"},
+        },
+    ):
+        t = raw.get("TYPE", {}).get("S")
+        if t == "RECEIPT_WORD":
+            m = re.match(
+                r"RECEIPT#\d+#LINE#(\d+)#WORD#(\d+)$", raw["SK"]["S"]
+            )
+            if not m:
+                continue
+            item = _deser(raw)
+            bb = item.get("bounding_box") or {}
+            try:
+                words.append(
+                    {
+                        "line_id": int(m.group(1)),
+                        "word_id": int(m.group(2)),
+                        "text": str(item.get("text", "")),
+                        "x": float(bb.get("x", 0)),
+                        "y_mid": float(bb.get("y", 0))
+                        + float(bb.get("height", 0)) / 2,
+                        "h": float(bb.get("height", 0)),
+                    }
+                )
+            except (TypeError, ValueError):
+                continue
+        elif t == "RECEIPT_SECTION":
+            sections.append(_deser(raw))
+        elif t == "RECEIPT_SUMMARY":
+            summary = _deser(raw)
+    return words, sections, summary
+
+
+def band_words(words: list[dict]) -> list[list[dict]]:
+    """Cluster words into visual bands by y-center gaps."""
+    if not words:
+        return []
+    ws = sorted(words, key=lambda w: w["y_mid"])
+    med_h = sorted(w["h"] for w in ws)[len(ws) // 2] or 0.01
+    bands: list[list[dict]] = [[ws[0]]]
+    for w in ws[1:]:
+        if w["y_mid"] - bands[-1][-1]["y_mid"] < med_h * 0.6:
+            bands[-1].append(w)
+        else:
+            bands.append([w])
+    for band in bands:
+        band.sort(key=lambda w: w["x"])
+    return bands
+
+
+def parse_band(text: str) -> Optional[dict[str, Any]]:
+    """Parse one visual band into a line-item dict (or None if no price)."""
+    prices = PRICE_RE.findall(text)
+    if not prices:
+        return None
+    raw_price, neg = prices[-1]
+    price = float(raw_price.replace(",", ""))
+    if neg == "-":
+        price = -price
+
+    qty = unit_price = None
+    m = QTY_RE.search(text)
+    if m:
+        qty = float(m.group(1))
+        unit_price = float(m.group(2))
+
+    upper = text.upper()
+    is_discount = price < 0 or any(w in upper for w in DISCOUNT_WORDS)
+
+    name = text
+    name = QTY_RE.sub(" ", name)
+    name = PRICE_RE.sub(" ", name)
+    name = TAX_FLAG_RE.sub(" ", name)
+    name = re.sub(r"\s{2,}", " ", name).strip(" @$-")
+    if qty is None:
+        m2 = LEAD_QTY_RE.match(name)
+        if m2:
+            qty = float(m2.group(1))
+            name = name[m2.end():]
+    name = name.strip()
+
+    return {
+        "name": name,
+        "quantity": qty,
+        "unit_price": unit_price,
+        "price": price,
+        "is_discount": is_discount,
+        "raw_text": text,
+    }
+
+
+# Tokens that don't count as product-name content (units, tax flags, SKU-ish)
+UNIT_WORDS = {
+    "EA", "LB", "KG", "OZ", "CT", "PK", "X", "C", "F", "T", "N", "O",
+    "A", "B", "TX", "FS", "QTY", "EACH",
+}
+# "2 3.99" — bare qty + unit-price with no @ separator
+BARE_QTY_RE = re.compile(r"^(\d{1,2})\s+\$?(\d{1,4}\.\d{2})\s*$")
+
+
+def _name_is_real(name: str) -> bool:
+    tokens = re.findall(r"[A-Za-z]{2,}", name or "")
+    real = [t for t in tokens if t.upper() not in UNIT_WORDS]
+    return len("".join(real)) >= 3
+
+
+def extract_items(
+    words: list[dict], line_ids: set[int]
+) -> tuple[list[dict], bool]:
+    """Extract items from the section's words.
+
+    Bands classify as ITEM (real name + price), NAME (name, no price), or
+    META (price/qty but no real name: SKU echoes, weight lines, bare
+    "2 3.99" qty lines). META bands never become items on their own —
+    they attach quantity to an adjacent ITEM, pair with a preceding NAME
+    band (stacked name-over-price layouts), or are dropped as price
+    echoes when a neighbor already carries the same price.
+
+    Returns (items, collapsed); collapsed flags degenerate banding
+    (skewed geometry merged many prices into one band).
+    """
+    section_words = [w for w in words if w["line_id"] in line_ids]
+    collapsed = False
+    bands = []
+    for band in band_words(section_words):
+        text = " ".join(w["text"] for w in band)
+        lids = sorted({w["line_id"] for w in band})
+        parsed = parse_band(text)
+        if parsed is not None and len(PRICE_RE.findall(text)) >= 3 and len(text) > 80:
+            collapsed = True
+        if parsed is None:
+            if _name_is_real(text):
+                bands.append(("NAME", {"name": text.strip(), "line_ids": lids}))
+            continue
+        m = BARE_QTY_RE.match(text.replace("$", "").strip())
+        if m:
+            parsed["quantity"] = float(m.group(1))
+            parsed["unit_price"] = float(m.group(2))
+        parsed["line_ids"] = lids
+        if _name_is_real(parsed["name"]) or parsed["is_discount"]:
+            bands.append(("ITEM", parsed))
+        else:
+            bands.append(("META", parsed))
+
+    items: list[dict] = []
+    pending_name: Optional[dict] = None
+    for i, (kind, data) in enumerate(bands):
+        if kind == "NAME_USED":
+            continue
+        if kind == "NAME":
+            pending_name = data
+            continue
+        if kind == "ITEM":
+            if data["price"] == 0 and data["quantity"] is None:
+                continue
+            items.append(data)
+            pending_name = None
+            continue
+        # META band
+        neighbors = [
+            bands[j][1]
+            for j in (i - 1, i + 1)
+            if 0 <= j < len(bands) and bands[j][0] == "ITEM"
+        ]
+        qty, unit = data.get("quantity"), data.get("unit_price")
+        attached = False
+        for nb in neighbors:
+            # qty metadata explains the neighbor's price -> attach
+            if (
+                qty is not None
+                and unit is not None
+                and abs(qty * unit - nb["price"]) <= 0.02
+            ):
+                nb["quantity"], nb["unit_price"] = qty, unit
+                attached = True
+                break
+            # same price -> SKU/price echo of the neighbor, drop
+            if abs(data["price"]) == abs(nb["price"]):
+                if qty is not None and nb["quantity"] is None:
+                    nb["quantity"], nb["unit_price"] = qty, unit
+                attached = True
+                break
+        if attached or data["price"] == 0:
+            continue
+        if pending_name is None and i + 1 < len(bands) and bands[i + 1][0] == "NAME":
+            # name band may sit just below the price band in y-order
+            pending_name = bands[i + 1][1]
+            bands[i + 1] = ("NAME_USED", bands[i + 1][1])
+        if pending_name is not None:
+            # stacked layout: name band paired with price-only band
+            data["name"] = pending_name["name"]
+            data["line_ids"] = sorted(
+                set(data["line_ids"]) | set(pending_name["line_ids"])
+            )
+            pending_name = None
+        else:
+            # No name anywhere (SKU-only or garbled OCR). Keep the price —
+            # dropping it hides real spend — but flag the name quality.
+            data["name_quality"] = "low"
+        items.append(data)
+    return items, collapsed
+
+
+def reconcile(
+    items: list[dict], summary: Optional[dict]
+) -> tuple[str, Optional[float], Optional[float]]:
+    """Compare extracted item sum against summary subtotal/grand_total."""
+    if summary is None:
+        return "no-baseline", None, None
+
+    def _f(key):
+        v = summary.get(key)
+        try:
+            return float(v) if v is not None else None
+        except (TypeError, ValueError):
+            return None
+
+    subtotal, grand, tax = _f("subtotal"), _f("grand_total"), _f("tax")
+    baseline = subtotal
+    if baseline is None and grand is not None:
+        baseline = grand - (tax or 0.0)
+    if baseline is None or baseline <= 0:
+        return "no-baseline", None, None
+    item_sum = round(sum(i["price"] for i in items), 2)
+    diff = abs(item_sum - baseline)
+    if diff <= max(0.02, baseline * 0.01):
+        return "match", item_sum, baseline
+    if diff <= max(1.0, baseline * 0.10):
+        return "near", item_sum, baseline
+    return "mismatch", item_sum, baseline
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--table", default="ReceiptsTable-dc5be22")
+    ap.add_argument("--out", default=None)
+    ap.add_argument("--limit", type=int, default=None)
+    ap.add_argument("--receipt", help="IMAGE_ID:RECEIPT_ID single-receipt mode")
+    args = ap.parse_args()
+
+    client = boto3.client("dynamodb", region_name="us-east-1")
+
+    # Collect ITEMS sections (and all sectioned receipts) via GSITYPE.
+    items_secs: dict[tuple[str, int], dict] = {}
+    sectioned: set[tuple[str, int]] = set()
+    for raw in _query_all(
+        client,
+        TableName=args.table,
+        IndexName="GSITYPE",
+        KeyConditionExpression="#t = :t",
+        ExpressionAttributeNames={"#t": "TYPE"},
+        ExpressionAttributeValues={":t": {"S": "RECEIPT_SECTION"}},
+    ):
+        item = _deser(raw)
+        m = re.match(r"IMAGE#(.+)", item["PK"])
+        m2 = re.match(r"RECEIPT#(\d+)#", item["SK"])
+        if not (m and m2):
+            continue
+        key = (m.group(1), int(m2.group(1)))
+        sectioned.add(key)
+        if (
+            item.get("section_type") == "ITEMS"
+            and item.get("validation_status") == "VALID"
+        ):
+            items_secs[key] = item
+
+    targets = sorted(items_secs)
+    if args.receipt:
+        img, rid = args.receipt.split(":")
+        targets = [(img, int(rid))]
+    if args.limit:
+        targets = targets[: args.limit]
+
+    out_f = open(args.out, "w") if args.out else None
+    recon = Counter()
+    leaky = 0
+    n_items_total = 0
+    mismatches = []
+    for i, key in enumerate(targets):
+        img, rid = key
+        words, sections, summary = fetch_receipt_records(
+            client, args.table, img, rid
+        )
+        sec = items_secs.get(key) or next(
+            (s for s in sections if s.get("section_type") == "ITEMS"), None
+        )
+        if sec is None:
+            continue
+        line_ids = {int(x) for x in sec.get("line_ids", [])}
+        items, collapsed = extract_items(words, line_ids)
+        n_items_total += len(items)
+        status, item_sum, baseline = reconcile(
+            [x for x in items if not x["is_discount"]], summary
+        )
+        if collapsed:
+            status = f"{status}+collapsed"
+        recon[status] += 1
+        if status == "mismatch":
+            mismatches.append((img, rid, item_sum, baseline))
+
+        # Leakage: priced words on lines outside ANY section
+        all_sectioned_lines: set[int] = set()
+        for s in sections:
+            all_sectioned_lines.update(int(x) for x in s.get("line_ids", []))
+        stray = {
+            w["line_id"]
+            for w in words
+            if w["line_id"] not in all_sectioned_lines
+            and PRICE_RE.search(w["text"])
+        }
+        if stray:
+            leaky += 1
+
+        if out_f:
+            out_f.write(
+                json.dumps(
+                    {
+                        "image_id": img,
+                        "receipt_id": rid,
+                        "collapsed_banding": collapsed,
+                        "items": items,
+                        "reconciliation": {
+                            "status": status,
+                            "item_sum": item_sum,
+                            "baseline": baseline,
+                        },
+                        "stray_priced_lines": sorted(stray),
+                    }
+                )
+                + "\n"
+            )
+        if (i + 1) % 100 == 0:
+            print(f"  {i + 1}/{len(targets)}", file=sys.stderr, flush=True)
+
+    if out_f:
+        out_f.close()
+
+    print(f"receipts processed: {len(targets)}")
+    print(f"items extracted: {n_items_total}")
+    print(f"reconciliation: {dict(recon)}")
+    print(f"receipts with priced lines outside all sections: {leaky}")
+    print("worst mismatches (item_sum vs baseline):")
+    for img, rid, s, b in sorted(
+        mismatches, key=lambda x: abs((x[2] or 0) - (x[3] or 0)), reverse=True
+    )[:10]:
+        print(f"  {img}:{rid}  sum={s} baseline={b}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_evaluate_section_geometry.py
+++ b/tests/test_evaluate_section_geometry.py
@@ -1,0 +1,127 @@
+"""Tests for the offline section geometry/embedding experiment."""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timezone
+
+import numpy as np
+
+from receipt_dynamo.entities import ReceiptRow
+from receipt_upload.section_assignment import RowFeatures
+from scripts.evaluate_section_geometry import (
+    EvidenceWeights,
+    _metric_delta,
+    _structure_matrix,
+    repair_metadata_only_vector_lag,
+)
+
+
+def _feature(row_id: int, *, amount: str | None = None) -> RowFeatures:
+    row = ReceiptRow(
+        image_id="00000000-0000-4000-8000-000000000001",
+        receipt_id=1,
+        row_id=row_id,
+        line_ids=[row_id],
+        grouping_version="visual-rows-v1",
+        y_min=0.9 - row_id * 0.1,
+        y_max=0.95 - row_id * 0.1,
+        x_min=0.1,
+        x_max=0.9,
+        created_at=datetime(2026, 7, 29, tzinfo=timezone.utc),
+        price_column_x=0.9 if amount else None,
+        label_text="total" if amount else None,
+        amount_text=amount,
+        amount_line_id=row_id if amount else None,
+        amount_word_id=1 if amount else None,
+    )
+    return RowFeatures(
+        row=row,
+        position=(row_id - 1) / 2,
+        x_span=0.8,
+        alpha_ratio=0.5,
+        has_amount=float(amount is not None),
+        amount_density=0.5,
+        has_quantity=0.0,
+        tokens=(),
+    )
+
+
+def test_structure_matrix_contains_arithmetic_reconciliation() -> None:
+    matrix = _structure_matrix(
+        [
+            _feature(1, amount="2.00"),
+            _feature(2, amount="3.00"),
+            _feature(3, amount="5.00"),
+        ]
+    )
+    assert matrix.shape == (3, 16)
+    assert np.isfinite(matrix).all()
+    assert matrix[2, 14] == 1.0
+
+
+def _lag_database(path: str, unsafe: bool = False) -> None:
+    with sqlite3.connect(path) as connection:
+        connection.executescript("""
+            CREATE TABLE segments(id TEXT PRIMARY KEY, scope TEXT);
+            CREATE TABLE max_seq_id(segment_id TEXT PRIMARY KEY, seq_id INTEGER);
+            CREATE TABLE embeddings_queue(
+                seq_id INTEGER PRIMARY KEY,
+                operation INTEGER,
+                vector BLOB
+            );
+            INSERT INTO segments VALUES ('vector', 'VECTOR'), ('metadata', 'METADATA');
+            INSERT INTO max_seq_id VALUES ('vector', 10), ('metadata', 12);
+            INSERT INTO embeddings_queue VALUES (11, 1, NULL);
+            """)
+        connection.execute(
+            "INSERT INTO embeddings_queue VALUES (12, ?, ?)",
+            (2 if unsafe else 1, b"vector" if unsafe else None),
+        )
+
+
+def test_metadata_only_vector_lag_repair_is_guarded(tmp_path) -> None:
+    path = tmp_path / "safe.sqlite3"
+    _lag_database(str(path))
+    assert repair_metadata_only_vector_lag(path) == {
+        "from_seq": 10,
+        "to_seq": 12,
+        "updates": 2,
+    }
+    with sqlite3.connect(path) as connection:
+        assert (
+            connection.execute(
+                "SELECT seq_id FROM max_seq_id WHERE segment_id='vector'"
+            ).fetchone()[0]
+            == 12
+        )
+
+
+def test_vector_lag_repair_rejects_vector_writes(tmp_path) -> None:
+    path = tmp_path / "unsafe.sqlite3"
+    _lag_database(str(path), unsafe=True)
+    try:
+        repair_metadata_only_vector_lag(path)
+    except RuntimeError as error:
+        assert "Unsafe Chroma repair" in str(error)
+    else:  # pragma: no cover - assertion aid
+        raise AssertionError("unsafe vector checkpoint advance was accepted")
+
+
+def test_metric_delta_reports_per_section_recall() -> None:
+    baseline = {
+        "agreement": 0.5,
+        "macro_recall": 0.4,
+        "per_type": {"ITEMS": {"recall": 0.25}},
+    }
+    candidate = {
+        "agreement": 0.75,
+        "macro_recall": 0.6,
+        "per_type": {"ITEMS": {"recall": 0.75}},
+    }
+    assert _metric_delta(baseline, candidate) == {
+        "agreement": 0.25,
+        "macro_recall": 0.19999999999999996,
+        "recall_ITEMS": 0.5,
+    }
+    assert EvidenceWeights(embedding_knn=1.0).as_dict()["embedding_knn"] == 1.0

--- a/tests/test_resegment_receipt_lambda.py
+++ b/tests/test_resegment_receipt_lambda.py
@@ -1072,7 +1072,7 @@ def test_apply_reverifies_source_fingerprint_before_commit(monkeypatch):
         real_stage(**kwargs)
         # A concurrent writer edits a source label between the up-front
         # fingerprint check and the commit transaction.
-        client.add_receipt_word_labels(
+        client.update_receipt_word_labels(
             [
                 ReceiptWordLabel(
                     image_id=image_id,


### PR DESCRIPTION
## Summary

- rebuild the Section Embedding Explorer around a readable stack of row-level receipts
- animate baseline errors, Chroma neighbor voting, corrected boundaries, and the final contiguous decode
- preserve autoplay and keyboard controls while adding resolved-step, mobile-overflow, and reduced-motion coverage

## Validation

- `npm test -- --runInBand components/ui/Figures/SectionEmbeddingExplorer/SectionEmbeddingExplorer.test.tsx`
- `npm run type-check`
- targeted ESLint
- `npx playwright test e2e/section-embedding-explorer.spec.ts --config e2e/playwright.config.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an interactive section-embedding explorer to the receipt page, showing how geometry and neighboring receipts improve section assignments.
  * Added autoplay, step controls, keyboard navigation, responsive layouts, and reduced-motion support.
  * Added an offline evaluation tool for comparing section-decoding approaches.
  * Added line-item extraction and subtotal reconciliation tooling.

* **Bug Fixes**
  * Improved model configuration loading from checkpoint and best-model directories.
  * Prevented bulk label writes from overwriting existing reviewed labels.
  * Preserved legacy labels during receipt import and export.

* **Documentation**
  * Added a detailed experiment report with results, methodology, reproduction steps, and integration guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->