### PR TITLE
feat: add Swift receipt understanding shadow pipeline

### DIFF
--- a/docs/architecture/mac-ocr-aws-handoff.md
+++ b/docs/architecture/mac-ocr-aws-handoff.md
@@ -22,12 +22,13 @@ evaluation).
                                       │ 5. cluster + warp receipts      │
                                       │ 6. Vision OCR (warped crops)    │
                                       │ 7. LayoutLM (CoreML) per line   │
-                                      │ 8. upload warped crops → S3     │
-                                      │ 9. PENDING ReceiptWordLabels    │
+                                      │ 8. retain shadow input          │
+                                      │ 9. upload warped crops → S3     │
+                                      │10. PENDING ReceiptWordLabels    │
                                       │    → DynamoDB (direct write)    │
-                                      │10. upload OCR JSON → S3         │
-                                      │11. OCRRoutingDecision → Dynamo  │
- ┌────────────────────────┐  SQS      │12. send ocr-results message     │
+                                      │11. upload OCR JSON → S3         │
+                                      │12. OCRRoutingDecision → Dynamo  │
+ ┌────────────────────────┐  SQS      │13. send result, complete + ack  │
  │ process-OCR-results    │◄──────────┴──────────────────────────────────┘
  │ Lambda (container)     │
  │  A. parse Swift JSON → Receipt, Line/Word/Letter,                     │
@@ -45,6 +46,9 @@ evaluation).
  └───────────────────────────────────────────────────────────────────────┘
 ```
 
+After step 13, the Mac runs the optional read-only shadow analysis before its
+next queue poll.
+
 ## Where each stage executes
 
 | Stage | Executes on | Code |
@@ -52,6 +56,7 @@ evaluation).
 | Receipt detection, warp, Vision OCR | Mac | `receipt_ocr_swift/Sources/ReceiptOCRCore/{OCR,ReceiptProcessing,Clustering}` |
 | Image classification (NATIVE/PHOTO/SCAN) | Mac | `Classification/ImageClassifier.swift` |
 | LayoutLM word-label inference | Mac (CoreML) | `LayoutLM/LayoutLMInference.swift` |
+| First-pass understanding comparison | Mac, opt-in shadow only | `Understanding/` + `Worker/OCRWorker.swift` |
 | OCR JSON parse → Dynamo entities | AWS Lambda | `infra/upload_images/container_ocr/handler/ocr_processor.py` |
 | Visual-row materialization (ReceiptRow) | AWS Lambda | `receipt_upload/receipt_processing/rows.py` |
 | Row/word embeddings (OpenAI) | AWS Lambda | `receipt_chroma.embedding.download_and_embed_parallel` |
@@ -61,11 +66,19 @@ evaluation).
 | Label validation (Chroma KNN + LLM) | AWS Lambda (words pipeline) | `receipt_upload/label_validation/` |
 | Chroma compaction (snapshot merge) | AWS, async | triggered by `CompactionRun` Dynamo stream |
 
-Section segmentation is deliberately **not** ported to Swift. The Mac worker
-ships evidence (OCR geometry + LayoutLM labels); every merchant-conditioned
-or cross-receipt decision (merchant resolution, sections, verification,
-validation) runs in AWS where the priors, Chroma index, and DynamoDB state
-live.
+Production merchant, section, verification, and validation ownership remains
+in AWS. The Mac worker now has an opt-in shadow implementation for
+same-receipt comparisons: it reproduces visual rows and OpenAI inputs, reads
+Chroma plus VALID DynamoDB evidence, resolves merchant/location
+conservatively, applies the packaged deterministic section decoder, and emits
+consistency checks and candidate payloads. The shadow has no candidate writer,
+never mutates production receipt entities, and is disabled by default.
+
+The Swift decoder intentionally keeps LayoutLM as a word-label model; it does
+not assume the CoreML bundle has a section head. The research branch did not
+contain a deployable section-centroid artifact, so shadow neighbor evidence is
+the directly reproducible cosine-weighted VALID-receipt KNN signal rather than
+an invented centroid model.
 
 ## Artifacts crossing the boundary
 
@@ -85,7 +98,10 @@ Returned to AWS by the Swift worker:
 - warped receipt crops → `raw-bucket/receipts/{image_id}/{file}` (S3);
 - one OCR JSON per image → `raw-bucket/ocr_results/{image}-{job}.json` (S3);
 - `ReceiptWordLabel` items (PENDING, `label_proposed_by="auto-inference"`)
-  written directly to DynamoDB. **This write is best-effort**: a failure of
+  written directly to DynamoDB with a create-only condition. Existing
+  PENDING, NEEDS_REVIEW, or human-VALID keys are never replaced, and a
+  conditional collision is an idempotent success. **This write is
+  best-effort**: a failure of
   `addReceiptWordLabels` is logged (`failed_upload_labels`) and the worker
   still sends the results message, completes the job, and deletes the SQS
   message — so a transient DynamoDB failure permanently drops that
@@ -95,6 +111,47 @@ Returned to AWS by the Swift worker:
 - `OCRRoutingDecision` (PENDING) pointing at the JSON;
 - an `ocr-results` SQS message:
   `{image_id, job_id, s3_key, s3_bucket, receipt_count}`.
+
+The optional understanding shadow returns no artifact to AWS. After the
+production handoff and input acknowledgement, it writes a text-free structured
+timing summary. A complete JSON comparison report is written only when
+`RECEIPT_UNDERSTANDING_REPORT_DIR` is configured; its directory and files are
+restricted to the worker account (0700 and 0600). Candidate payloads are
+PENDING or NEEDS_REVIEW, carry confidence/model/provenance and a create-only
+condition, and exist only for parity inspection in this mode.
+
+## Mac understanding shadow contract
+
+Set `RECEIPT_UNDERSTANDING_SHADOW=1` to run the comparison pipeline for
+first-pass jobs. The worker retains the in-memory OCR result, completes every
+production upload and notification, acknowledges the input SQS message, and
+only then runs shadow analysis before its next poll. This prevents comparison
+latency or retries from extending the production message's visibility window.
+Configure
+`RECEIPT_SECTION_PRIOR_PATH` when the packaged
+`receipt_upload/receipt_upload/assets/section_order_priors_v2.json` cannot be
+resolved from the worker directory. OpenAI and Chroma use
+`OPENAI_API_KEY`, `CHROMA_CLOUD_API_KEY`, `CHROMA_CLOUD_TENANT`, and
+`CHROMA_CLOUD_DATABASE`; Places is optional through
+`GOOGLE_PLACES_API_KEY`. Set `RECEIPT_UNDERSTANDING_REPORT_DIR` only on a
+comparison worker that should retain full local reports.
+
+Compatibility invariants:
+
+- visual row union, ordering, row IDs, text joining, and
+  `<EDGE>\nTARGET\n<EDGE>` context formatting match Python;
+- embeddings use `text-embedding-3-small` at its native 1,536 dimensions;
+- Chroma uses the Python `lines` IDs/metadata and excludes the current receipt
+  in both the server filter and a defensive client check;
+- Chroma `section_label` metadata is never accepted as truth: neighboring
+  receipt sections are strongly read from DynamoDB and must be VALID;
+- known-receipt merchant votes are capped per receipt; conflicting LayoutLM,
+  known-receipt, or Places evidence causes abstention;
+- Places is consulted only when no reliable known-receipt result or identity
+  conflict exists;
+- missing embeddings and OpenAI/Chroma/Places failures fall back to the
+  deterministic decoder without affecting OCR publication;
+- every stage and total wall time are included in the shadow report.
 
 ## The OCR JSON schema (Swift → Python)
 

--- a/infra/upload_images/container_ocr/handler/tests/test_swift_payload_contract.py
+++ b/infra/upload_images/container_ocr/handler/tests/test_swift_payload_contract.py
@@ -53,6 +53,9 @@ import pytest
 from handler.ocr_processor import OCRProcessor
 from moto import mock_aws
 from receipt_agent.constants import CORE_LABELS
+from receipt_chroma.embedding.formatting.line_format import (
+    get_row_embedding_inputs,
+)
 from receipt_dynamo.data.dynamo_client import DynamoClient
 from receipt_dynamo.entities import OCRJob, OCRRoutingDecision
 
@@ -128,6 +131,30 @@ def test_receipt_lines_words_letters_parse(parser, swift_payload):
     assert all(
         (letter.line_id, letter.word_id) == (1, 1) for letter in letters
     )
+
+
+def test_shared_fixture_row_embedding_text_matches_swift(
+    parser, swift_payload
+):
+    """Pin the byte-exact row text consumed by both embedding clients."""
+    receipt = swift_payload["receipts"][0]
+    lines, _, _ = parser._parse_receipt_ocr_from_swift(
+        IMAGE_ID, receipt["cluster_id"], receipt["lines"]
+    )
+
+    assert get_row_embedding_inputs(lines) == [
+        (
+            "<EDGE>\nSPROUTS FARMERS MARKET\nORGANIC BANANAS 3.99",
+            [1],
+        ),
+        (
+            "SPROUTS FARMERS MARKET\n"
+            "ORGANIC BANANAS 3.99\n"
+            "TOTAL 3.99",
+            [3],
+        ),
+        ("ORGANIC BANANAS 3.99\nTOTAL 3.99\n<EDGE>", [4]),
+    ]
 
 
 def test_first_pass_lines_parse(parser, swift_payload):

--- a/receipt_ocr_swift/Package.swift
+++ b/receipt_ocr_swift/Package.swift
@@ -9,6 +9,7 @@ let package = Package(
     products: [
         .executable(name: "receipt-ocr", targets: ["ReceiptOCRCLI"]),
         .library(name: "ReceiptOCRCore", targets: ["ReceiptOCRCore"]),
+        .library(name: "ReceiptChroma", targets: ["ReceiptChroma"]),
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.3.0"),
@@ -19,9 +20,16 @@ let package = Package(
         .target(
             name: "ReceiptOCRCore",
             dependencies: [
+                "ReceiptChroma",
                 .product(name: "SotoS3", package: "soto"),
                 .product(name: "SotoSQS", package: "soto"),
                 .product(name: "SotoDynamoDB", package: "soto"),
+                .product(name: "Logging", package: "swift-log"),
+            ]
+        ),
+        .target(
+            name: "ReceiptChroma",
+            dependencies: [
                 .product(name: "Logging", package: "swift-log"),
             ]
         ),
@@ -35,8 +43,12 @@ let package = Package(
         ),
         .testTarget(
             name: "ReceiptOCRCoreTests",
-            dependencies: ["ReceiptOCRCore"],
+            dependencies: ["ReceiptOCRCore", "ReceiptChroma"],
             resources: [.copy("Fixtures")]
+        ),
+        .testTarget(
+            name: "ReceiptChromaTests",
+            dependencies: ["ReceiptChroma"]
         ),
         .testTarget(
             name: "IntegrationTests",
@@ -49,5 +61,3 @@ let package = Package(
         ),
     ]
 )
-
-

--- a/receipt_ocr_swift/README.md
+++ b/receipt_ocr_swift/README.md
@@ -6,6 +6,7 @@ A Swift implementation of the receipt OCR processing pipeline, replacing the Pyt
 
 - **Native macOS OCR**: Uses Apple Vision framework for high-quality text recognition
 - **AWS Integration**: Full integration with SQS, S3, and DynamoDB using Soto SDK
+- **Chroma Cloud client**: Typed, async read/write access through the `ReceiptChroma` library
 - **Retry Logic**: Exponential backoff for resilient AWS operations
 - **Structured Logging**: Comprehensive logging with configurable levels
 - **Continuous Processing**: Process all messages in queue until empty
@@ -48,6 +49,7 @@ swift build --product receipt-ocr
 ```bash
 # Unit tests only
 swift test --filter ReceiptOCRCoreTests
+swift test --filter ReceiptChromaTests
 
 # Integration tests with LocalStack
 docker-compose -f Tests/IntegrationTests/docker-compose.yml up -d
@@ -70,6 +72,80 @@ swift run -c release receipt-ocr --env dev --region us-east-1 --continuous
 # Process with custom log level
 swift run -c release receipt-ocr --env dev --region us-east-1 --log-level debug
 ```
+
+### ReceiptChroma library
+
+`ReceiptChroma` is a separate, low-level library product in this package. It
+implements the Chroma Cloud v2 transport boundary without coupling Chroma
+credentials or embedding generation to the OCR worker:
+
+```swift
+import ReceiptChroma
+
+let configuration = try ChromaConfiguration(
+    apiKey: chromaAPIKey,
+    tenant: chromaTenant,
+    database: "receipt_dev",
+    mode: .read
+)
+let chroma = ChromaClient(configuration: configuration)
+
+let result = try await chroma.query(
+    collectionName: "lines",
+    queryEmbeddings: [embedding],
+    nResults: 10,
+    where: ["merchant_name": ["$eq": "Trader Joe's"]]
+)
+await chroma.close()
+```
+
+The client provides collection lookup/listing, atomic get-or-create in write
+mode, batched upserts, vector queries, filtered gets/deletes, counts, typed
+errors, request timeouts, and 429-only exponential retry. Metadata supports
+explicit `null` tombstones so callers can clear keys that Chroma would
+otherwise retain during a merge. Receipt-specific callers must provide the
+complete tombstone set required by their collection.
+
+Callers must provide embeddings. Local persistent databases, OpenAI embedding
+jobs, S3 deltas/snapshots, DynamoDB locks, and compaction remain owned by the
+Python `receipt_chroma` pipeline so its durability ordering is unchanged. This
+library is not a replacement for `upsert_payload_to_cloud` and does not provide
+its receipt sanitization, per-record fallback, or whole-operation deadline.
+
+### Receipt understanding shadow mode
+
+The macOS worker can run an opt-in, read-only first-pass understanding pipeline
+after Vision OCR and LayoutLM inference. It reconstructs the same visual rows
+and embedding inputs as Python, queries the `lines` collection while excluding
+the current receipt, hydrates only VALID known-receipt evidence from DynamoDB,
+resolves merchant/location conservatively, and applies the existing
+semi-Markov section decoder with cosine-weighted neighbor evidence.
+
+Shadow mode runs only after the production OCR handoff is durable and the
+input SQS message is acknowledged. It emits a text-free timing summary. A
+complete PENDING or NEEDS_REVIEW comparison report is written only when
+`RECEIPT_UNDERSTANDING_REPORT_DIR` is set; the worker creates access-controlled
+local files and never uploads them. Shadow mode has no candidate writer and
+cannot change production receipt entities.
+
+Enable it only on comparison workers:
+
+```bash
+export RECEIPT_UNDERSTANDING_SHADOW=1
+export RECEIPT_SECTION_PRIOR_PATH=/absolute/path/to/section_order_priors_v2.json
+export OPENAI_API_KEY=...
+export CHROMA_CLOUD_API_KEY=...
+export CHROMA_CLOUD_TENANT=...
+export CHROMA_CLOUD_DATABASE=...
+# Optional, used only when no reliable known-receipt match exists:
+export GOOGLE_PLACES_API_KEY=...
+# Optional local comparison artifacts; directory is 0700 and reports are 0600:
+export RECEIPT_UNDERSTANDING_REPORT_DIR=/absolute/private/path
+```
+
+Without OpenAI or Chroma credentials, the decoder runs its deterministic
+offline fallback. OpenAI, Chroma, Places, and analysis failures do not affect
+OCR publication. `RECEIPT_UNDERSTANDING_SHADOW` defaults to disabled.
 
 ### Local Image Processing
 
@@ -144,6 +220,7 @@ receipt_ocr_swift/
 │       ├── Config/             # Configuration management
 │       ├── Models/              # Data models
 │       ├── OCR/                 # OCR engine implementations
+│       ├── Understanding/       # Shadow receipt-understanding pipeline
 │       ├── Util/                # Utilities (retry, date formatting)
 │       └── Worker/              # Main OCR worker
 ├── Tests/

--- a/receipt_ocr_swift/Sources/ReceiptChroma/ChromaClient.swift
+++ b/receipt_ocr_swift/Sources/ReceiptChroma/ChromaClient.swift
@@ -1,0 +1,846 @@
+import Foundation
+import Logging
+
+#if canImport(FoundationNetworking)
+  import FoundationNetworking
+#endif
+
+/// An async Chroma Cloud v2 client for receipt vector collections.
+///
+/// This client intentionally covers the deployed Cloud read/write boundary.
+/// The Python pipeline remains responsible for embedding generation, S3
+/// deltas, compaction, and local persistent Chroma databases.
+public actor ChromaClient {
+  public typealias Sleeper = @Sendable (UInt64) async throws -> Void
+  public typealias Jitter = @Sendable (TimeInterval) -> TimeInterval
+
+  private let configuration: ChromaConfiguration
+  private let transport: any ChromaHTTPTransport
+  private let closeTransportOnClose: Bool
+  private let sleeper: Sleeper
+  private let jitter: Jitter
+  private var logger: Logger
+  private var collections: [String: ChromaCollection] = [:]
+  private var closed = false
+
+  private let encoder: JSONEncoder = {
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.sortedKeys]
+    return encoder
+  }()
+
+  private let decoder = JSONDecoder()
+
+  public init(
+    configuration: ChromaConfiguration,
+    transport: any ChromaHTTPTransport = URLSessionChromaHTTPTransport(),
+    closeTransportOnClose: Bool = true,
+    logger: Logger = Logger(label: "receipt-chroma"),
+    sleeper: @escaping Sleeper = { nanoseconds in
+      try await Task.sleep(nanoseconds: nanoseconds)
+    },
+    jitter: @escaping Jitter = { upperBound in
+      guard upperBound > 0 else { return 0 }
+      return Double.random(in: 0...upperBound)
+    }
+  ) {
+    self.configuration = configuration
+    self.transport = transport
+    self.closeTransportOnClose = closeTransportOnClose
+    self.logger = logger
+    self.sleeper = sleeper
+    self.jitter = jitter
+  }
+
+  /// Marks the client closed and releases its collection cache.
+  ///
+  /// Closing is idempotent. Any later operation throws ``ReceiptChromaError/closed``.
+  public func close() async {
+    guard !closed else { return }
+    collections.removeAll()
+    closed = true
+    if closeTransportOnClose {
+      await transport.close()
+    }
+  }
+
+  public func getCollection(
+    _ name: String,
+    createIfMissing: Bool = false,
+    metadata: ChromaMetadata? = nil
+  ) async throws -> ChromaCollection {
+    try ensureOpen()
+    let normalizedName = try validateCollectionName(name)
+    if let metadata {
+      try validateMetadata(
+        metadata,
+        maximumValueBytes: ChromaCloudLimits.maximumCollectionMetadataValueBytes
+      )
+    }
+
+    if let collection = collections[normalizedName] {
+      return collection
+    }
+
+    do {
+      let request = try makeRequest(
+        method: "GET",
+        path: collectionPath + [normalizedName]
+      )
+      let collection = try await send(request, as: ChromaCollection.self)
+      collections[normalizedName] = collection
+      return collection
+    } catch ReceiptChromaError.http(let status, _, _, _) where status == 404 {
+      guard createIfMissing, configuration.mode == .write else {
+        throw ReceiptChromaError.collectionNotFound(normalizedName)
+      }
+
+      let payload = CreateCollectionRequest(
+        name: normalizedName,
+        metadata: metadata,
+        getOrCreate: true
+      )
+      let request = try makeRequest(
+        method: "POST",
+        path: collectionPath,
+        body: payload
+      )
+      let collection = try await send(request, as: ChromaCollection.self)
+      collections[normalizedName] = collection
+      return collection
+    }
+  }
+
+  @discardableResult
+  public func upsert(
+    collectionName: String,
+    ids: [String],
+    embeddings: [[Double]],
+    documents: [String?]? = nil,
+    metadatas: [ChromaMetadata?]? = nil,
+    uris: [String?]? = nil
+  ) async throws -> Int {
+    try ensureWriteable()
+    try validateUpsert(
+      ids: ids,
+      embeddings: embeddings,
+      documents: documents,
+      metadatas: metadatas,
+      uris: uris
+    )
+
+    let collection = try await getCollection(
+      collectionName,
+      createIfMissing: true
+    )
+    var completed = 0
+
+    for lowerBound in stride(
+      from: 0,
+      to: ids.count,
+      by: ChromaCloudLimits.upsertBatchSize
+    ) {
+      let upperBound = min(
+        lowerBound + ChromaCloudLimits.upsertBatchSize,
+        ids.count
+      )
+      let range = lowerBound..<upperBound
+      let payload = UpsertRequest(
+        ids: Array(ids[range]),
+        embeddings: Array(embeddings[range]),
+        documents: documents.map { Array($0[range]) },
+        metadatas: metadatas.map { Array($0[range]) },
+        uris: uris.map { Array($0[range]) }
+      )
+
+      do {
+        let request = try makeRequest(
+          method: "POST",
+          path: collectionPath + [collection.id, "upsert"],
+          body: payload
+        )
+        _ = try await send(request, as: EmptyResponse.self)
+        completed = upperBound
+      } catch {
+        guard completed > 0 else { throw error }
+        throw ReceiptChromaError.partialBatch(
+          completed: completed,
+          total: ids.count,
+          message: error.localizedDescription
+        )
+      }
+    }
+
+    return completed
+  }
+
+  public func query(
+    collectionName: String,
+    queryEmbeddings: [[Double]],
+    nResults: Int = 10,
+    where whereFilter: ChromaFilter? = nil,
+    whereDocument: ChromaFilter? = nil,
+    ids: [String]? = nil,
+    include: [ChromaInclude] = [.metadatas, .documents, .distances]
+  ) async throws -> ChromaQueryResult {
+    try ensureOpen()
+    try validateEmbeddings(queryEmbeddings, field: "queryEmbeddings")
+    guard nResults > 0 else {
+      throw ReceiptChromaError.invalidRequest(
+        "nResults must be positive"
+      )
+    }
+    if let ids {
+      try validateIDs(ids, maximumCount: ChromaCloudLimits.maximumQueryResults)
+    }
+    try validateFilter(whereFilter)
+    try validateFilter(whereDocument, fullText: true)
+
+    let collection = try await getCollection(collectionName)
+    let payload = QueryRequest(
+      queryEmbeddings: queryEmbeddings,
+      nResults: min(nResults, ChromaCloudLimits.maximumQueryResults),
+      whereFilter: whereFilter,
+      whereDocument: whereDocument,
+      ids: ids,
+      include: include
+    )
+    let request = try makeRequest(
+      method: "POST",
+      path: collectionPath + [collection.id, "query"],
+      body: payload
+    )
+    return try await send(request, as: ChromaQueryResult.self)
+  }
+
+  public func get(
+    collectionName: String,
+    ids: [String]? = nil,
+    where whereFilter: ChromaFilter? = nil,
+    whereDocument: ChromaFilter? = nil,
+    include: [ChromaInclude] = [.metadatas, .documents, .embeddings],
+    limit: Int? = nil,
+    offset: Int? = nil
+  ) async throws -> ChromaGetResult {
+    try ensureOpen()
+    guard ids != nil || whereFilter != nil || whereDocument != nil else {
+      throw ReceiptChromaError.invalidRequest(
+        "get requires ids, where, or whereDocument"
+      )
+    }
+    try validatePagination(limit: limit, offset: offset)
+    if let limit, limit > ChromaCloudLimits.maximumQueryResults {
+      throw ReceiptChromaError.invalidRequest(
+        "limit must not exceed \(ChromaCloudLimits.maximumQueryResults)"
+      )
+    }
+    guard !include.contains(.distances) else {
+      throw ReceiptChromaError.invalidRequest(
+        "get does not support the distances include"
+      )
+    }
+    if let ids {
+      try validateIDs(ids, maximumCount: ChromaCloudLimits.maximumQueryResults)
+    }
+    try validateFilter(whereFilter)
+    try validateFilter(whereDocument, fullText: true)
+
+    let collection = try await getCollection(collectionName)
+    let payload = GetRequest(
+      ids: ids,
+      whereFilter: whereFilter,
+      whereDocument: whereDocument,
+      include: include,
+      limit: limit,
+      offset: offset
+    )
+    let request = try makeRequest(
+      method: "POST",
+      path: collectionPath + [collection.id, "get"],
+      body: payload
+    )
+    return try await send(request, as: ChromaGetResult.self)
+  }
+
+  public func delete(
+    collectionName: String,
+    ids: [String]? = nil,
+    where whereFilter: ChromaFilter? = nil,
+    whereDocument: ChromaFilter? = nil
+  ) async throws {
+    try ensureWriteable()
+    guard ids != nil || whereFilter != nil || whereDocument != nil else {
+      throw ReceiptChromaError.invalidRequest(
+        "delete requires ids, where, or whereDocument"
+      )
+    }
+    if let ids {
+      try validateIDs(ids, maximumCount: ChromaCloudLimits.maximumQueryResults)
+    }
+    try validateFilter(whereFilter)
+    try validateFilter(whereDocument, fullText: true)
+
+    let collection = try await getCollection(collectionName)
+    let payload = DeleteRequest(
+      ids: ids,
+      whereFilter: whereFilter,
+      whereDocument: whereDocument
+    )
+    let request = try makeRequest(
+      method: "POST",
+      path: collectionPath + [collection.id, "delete"],
+      body: payload
+    )
+    _ = try await send(request, as: EmptyResponse.self)
+  }
+
+  public func count(collectionName: String) async throws -> Int {
+    try ensureOpen()
+    let collection = try await getCollection(collectionName)
+    let request = try makeRequest(
+      method: "GET",
+      path: collectionPath + [collection.id, "count"]
+    )
+    return try await send(request, as: Int.self)
+  }
+
+  public func listCollections() async throws -> [ChromaCollection] {
+    try ensureOpen()
+    let request = try makeRequest(method: "GET", path: collectionPath)
+    let result = try await send(request, as: [ChromaCollection].self)
+    for collection in result {
+      collections[collection.name] = collection
+    }
+    return result
+  }
+
+  public func collectionExists(_ name: String) async throws -> Bool {
+    try ensureOpen()
+    let normalizedName = try validateCollectionName(name)
+    let request = try makeRequest(
+      method: "GET",
+      path: collectionPath + [normalizedName]
+    )
+
+    do {
+      let collection = try await send(request, as: ChromaCollection.self)
+      collections[normalizedName] = collection
+      return true
+    } catch ReceiptChromaError.http(let status, _, _, _) where status == 404 {
+      collections[normalizedName] = nil
+      return false
+    }
+  }
+
+  private var collectionPath: [String] {
+    [
+      "tenants",
+      configuration.tenant,
+      "databases",
+      configuration.database,
+      "collections",
+    ]
+  }
+
+  private func ensureOpen() throws {
+    guard !closed else {
+      throw ReceiptChromaError.closed
+    }
+  }
+
+  private func ensureWriteable() throws {
+    try ensureOpen()
+    guard configuration.mode == .write else {
+      throw ReceiptChromaError.readOnly
+    }
+  }
+
+  private func validateCollectionName(_ name: String) throws -> String {
+    let normalizedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !normalizedName.isEmpty else {
+      throw ReceiptChromaError.invalidRequest(
+        "collection name must not be blank"
+      )
+    }
+    guard
+      normalizedName.utf8.count <= ChromaCloudLimits.maximumCollectionNameBytes
+    else {
+      throw ReceiptChromaError.invalidRequest(
+        "collection name exceeds \(ChromaCloudLimits.maximumCollectionNameBytes) UTF-8 bytes"
+      )
+    }
+    return normalizedName
+  }
+
+  private func makeRequest<Body: Encodable>(
+    method: String,
+    path: [String],
+    body: Body
+  ) throws -> URLRequest {
+    var request = try makeRequest(method: method, path: path)
+    request.httpBody = try encoder.encode(body)
+    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    return request
+  }
+
+  private func makeRequest(method: String, path: [String]) throws -> URLRequest {
+    var url = configuration.baseURL
+    for component in path {
+      url.appendPathComponent(component)
+    }
+
+    guard let scheme = url.scheme, let host = url.host,
+      !scheme.isEmpty, !host.isEmpty
+    else {
+      throw ReceiptChromaError.configuration(
+        "could not build request URL"
+      )
+    }
+
+    var request = URLRequest(
+      url: url,
+      timeoutInterval: configuration.requestTimeout
+    )
+    request.httpMethod = method
+    request.setValue("application/json", forHTTPHeaderField: "Accept")
+    request.setValue(
+      configuration.apiKey,
+      forHTTPHeaderField: "x-chroma-token"
+    )
+    return request
+  }
+
+  private func send<Response: Decodable>(
+    _ request: URLRequest,
+    as responseType: Response.Type
+  ) async throws -> Response {
+    let policy = configuration.retryPolicy
+
+    for attempt in 0...policy.maxRetries {
+      try Task.checkCancellation()
+
+      let data: Data
+      let response: HTTPURLResponse
+      do {
+        (data, response) = try await transport.data(for: request)
+      } catch is CancellationError {
+        throw CancellationError()
+      } catch let error as ReceiptChromaError {
+        throw error
+      } catch {
+        throw ReceiptChromaError.transport(error.localizedDescription)
+      }
+
+      if response.statusCode == 429, attempt < policy.maxRetries {
+        let baseDelay = min(
+          policy.baseDelay * pow(2, Double(attempt)),
+          policy.maxDelay
+        )
+        let sampledJitter = jitter(baseDelay * 0.5)
+        let delay = min(
+          baseDelay
+            + (sampledJitter.isFinite ? max(0, sampledJitter) : 0),
+          policy.maxDelay
+        )
+        logger.warning(
+          "Chroma rate limited; retrying",
+          metadata: [
+            "attempt": "\(attempt + 1)",
+            "max_attempts": "\(policy.maxRetries + 1)",
+            "delay_seconds": "\(delay)",
+          ]
+        )
+        let maximumConvertibleNanoseconds = Double(UInt64.max - 2_047)
+        let nanoseconds = UInt64(
+          min(delay * 1_000_000_000, maximumConvertibleNanoseconds)
+        )
+        try await sleeper(nanoseconds)
+        continue
+      }
+
+      guard (200..<300).contains(response.statusCode) else {
+        throw decodeHTTPError(data: data, response: response)
+      }
+
+      let responseData = data.isEmpty ? Data("{}".utf8) : data
+      do {
+        return try decoder.decode(responseType, from: responseData)
+      } catch {
+        throw ReceiptChromaError.invalidResponse(
+          "could not decode \(responseType): \(error.localizedDescription)"
+        )
+      }
+    }
+
+    throw ReceiptChromaError.invalidResponse(
+      "request exhausted retries without a response"
+    )
+  }
+
+  private func decodeHTTPError(
+    data: Data,
+    response: HTTPURLResponse
+  ) -> ReceiptChromaError {
+    let payload = try? decoder.decode(ChromaAPIError.self, from: data)
+    let fallback = String(data: data, encoding: .utf8)?
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+    let message =
+      payload?.message ?? payload?.detail
+      ?? (fallback?.isEmpty == false ? fallback! : "request failed")
+    let traceID =
+      response.value(forHTTPHeaderField: "chroma-trace-id")
+      ?? response.value(forHTTPHeaderField: "x-chroma-trace-id")
+    return .http(
+      status: response.statusCode,
+      type: payload?.error,
+      message: message,
+      traceID: traceID
+    )
+  }
+
+  private func validateUpsert(
+    ids: [String],
+    embeddings: [[Double]],
+    documents: [String?]?,
+    metadatas: [ChromaMetadata?]?,
+    uris: [String?]?
+  ) throws {
+    guard !ids.isEmpty else {
+      throw ReceiptChromaError.invalidRequest(
+        "upsert requires at least one record"
+      )
+    }
+    try validateIDs(ids)
+    try validateEmbeddings(embeddings, field: "embeddings")
+    try validateCount(embeddings.count, field: "embeddings", expected: ids.count)
+
+    if let documents {
+      try validateCount(documents.count, field: "documents", expected: ids.count)
+      for document in documents.compactMap({ $0 }) {
+        guard document.utf8.count <= ChromaCloudLimits.maximumDocumentBytes else {
+          throw ReceiptChromaError.invalidRequest(
+            "document exceeds \(ChromaCloudLimits.maximumDocumentBytes) UTF-8 bytes"
+          )
+        }
+      }
+    }
+
+    if let metadatas {
+      try validateCount(metadatas.count, field: "metadatas", expected: ids.count)
+      for metadata in metadatas.compactMap({ $0 }) {
+        try validateMetadata(metadata)
+      }
+    }
+
+    if let uris {
+      try validateCount(uris.count, field: "uris", expected: ids.count)
+      for uri in uris.compactMap({ $0 }) {
+        guard uri.utf8.count <= ChromaCloudLimits.maximumURIBytes else {
+          throw ReceiptChromaError.invalidRequest(
+            "URI exceeds \(ChromaCloudLimits.maximumURIBytes) UTF-8 bytes"
+          )
+        }
+      }
+    }
+  }
+
+  private func validateIDs(
+    _ ids: [String],
+    maximumCount: Int? = nil
+  ) throws {
+    guard !ids.isEmpty else {
+      throw ReceiptChromaError.invalidRequest(
+        "record IDs must not be empty"
+      )
+    }
+    if let maximumCount, ids.count > maximumCount {
+      throw ReceiptChromaError.invalidRequest(
+        "record IDs must not exceed \(maximumCount) per request"
+      )
+    }
+    var seen = Set<String>()
+    for id in ids {
+      guard !id.isEmpty else {
+        throw ReceiptChromaError.invalidRequest("record IDs must not be empty")
+      }
+      guard id.utf8.count <= ChromaCloudLimits.maximumIDBytes else {
+        throw ReceiptChromaError.invalidRequest(
+          "record ID exceeds \(ChromaCloudLimits.maximumIDBytes) UTF-8 bytes"
+        )
+      }
+      guard seen.insert(id).inserted else {
+        throw ReceiptChromaError.invalidRequest(
+          "record IDs must be unique; duplicate '\(id)'"
+        )
+      }
+    }
+  }
+
+  private func validateEmbeddings(
+    _ embeddings: [[Double]],
+    field: String
+  ) throws {
+    guard !embeddings.isEmpty else {
+      throw ReceiptChromaError.invalidRequest(
+        "\(field) must not be empty"
+      )
+    }
+    guard let dimensions = embeddings.first?.count, dimensions > 0 else {
+      throw ReceiptChromaError.invalidRequest(
+        "\(field) vectors must not be empty"
+      )
+    }
+    guard dimensions <= ChromaCloudLimits.maximumEmbeddingDimensions else {
+      throw ReceiptChromaError.invalidRequest(
+        "\(field) exceeds \(ChromaCloudLimits.maximumEmbeddingDimensions) dimensions"
+      )
+    }
+    guard embeddings.allSatisfy({ $0.count == dimensions }) else {
+      throw ReceiptChromaError.invalidRequest(
+        "\(field) vectors must have equal dimensions"
+      )
+    }
+    guard embeddings.joined().allSatisfy(\.isFinite) else {
+      throw ReceiptChromaError.invalidRequest(
+        "\(field) must contain only finite values"
+      )
+    }
+  }
+
+  private func validateMetadata(
+    _ metadata: ChromaMetadata,
+    maximumValueBytes: Int = ChromaCloudLimits.maximumMetadataValueBytes
+  ) throws {
+    guard !metadata.isEmpty else {
+      throw ReceiptChromaError.invalidRequest(
+        "metadata dictionaries must not be empty; use nil to omit metadata"
+      )
+    }
+    guard metadata.count <= ChromaCloudLimits.maximumMetadataKeys else {
+      throw ReceiptChromaError.invalidRequest(
+        "metadata exceeds \(ChromaCloudLimits.maximumMetadataKeys) keys"
+      )
+    }
+
+    for (key, value) in metadata {
+      guard !key.isEmpty,
+        !key.hasPrefix("#"),
+        !key.hasPrefix("$"),
+        key.utf8.count <= ChromaCloudLimits.maximumMetadataKeyBytes
+      else {
+        throw ReceiptChromaError.invalidRequest(
+          "metadata keys must be 1...\(ChromaCloudLimits.maximumMetadataKeyBytes) UTF-8 bytes and must not start with '#' or '$'"
+        )
+      }
+      guard isMetadataValue(value) else {
+        throw ReceiptChromaError.invalidRequest(
+          "metadata '\(key)' must be a scalar, null, or an array of scalars"
+        )
+      }
+      guard metadataValueBytes(value) <= maximumValueBytes else {
+        throw ReceiptChromaError.invalidRequest(
+          "metadata '\(key)' exceeds \(maximumValueBytes) bytes"
+        )
+      }
+    }
+  }
+
+  private func isMetadataValue(_ value: JSONValue) -> Bool {
+    switch value {
+    case .string, .integer, .bool, .null:
+      return true
+    case .number(let number):
+      return number.isFinite
+    case .array(let values):
+      guard let first = values.first else { return false }
+      let expectedKind = metadataArrayKind(first)
+      guard expectedKind != nil else { return false }
+      return values.allSatisfy { value in
+        metadataArrayKind(value) == expectedKind
+      }
+    case .object:
+      return false
+    }
+  }
+
+  private func metadataArrayKind(_ value: JSONValue) -> Int? {
+    switch value {
+    case .string:
+      return 0
+    case .integer:
+      return 1
+    case .number(let number):
+      return number.isFinite ? 1 : nil
+    case .bool:
+      return 2
+    default:
+      return nil
+    }
+  }
+
+  private func metadataValueBytes(_ value: JSONValue) -> Int {
+    switch value {
+    case .string(let string):
+      return string.utf8.count
+    case .integer(let integer):
+      return String(integer).utf8.count
+    case .number(let number):
+      return String(number).utf8.count
+    case .bool(let boolean):
+      return String(boolean).utf8.count
+    case .null:
+      return 4
+    case .array(let values):
+      return values.reduce(0) { $0 + metadataValueBytes($1) }
+    case .object:
+      return 0
+    }
+  }
+
+  private func validateCount(
+    _ actual: Int,
+    field: String,
+    expected: Int
+  ) throws {
+    guard actual == expected else {
+      throw ReceiptChromaError.invalidRequest(
+        "\(field) has \(actual) values; expected \(expected)"
+      )
+    }
+  }
+
+  private func validatePagination(limit: Int?, offset: Int?) throws {
+    if let limit, limit <= 0 {
+      throw ReceiptChromaError.invalidRequest("limit must be positive")
+    }
+    if let offset, offset < 0 {
+      throw ReceiptChromaError.invalidRequest("offset must not be negative")
+    }
+  }
+
+  private func validateFilter(
+    _ filter: ChromaFilter?,
+    fullText: Bool = false
+  ) throws {
+    guard let filter else { return }
+    let predicateCount = countPredicates(in: .object(filter))
+    guard predicateCount <= ChromaCloudLimits.maximumWherePredicates else {
+      throw ReceiptChromaError.invalidRequest(
+        "where filter exceeds \(ChromaCloudLimits.maximumWherePredicates) predicates"
+      )
+    }
+    if fullText, containsOversizedString(in: .object(filter)) {
+      throw ReceiptChromaError.invalidRequest(
+        "full-text or regex filter exceeds \(ChromaCloudLimits.maximumFullTextSearchBytes) UTF-8 bytes"
+      )
+    }
+  }
+
+  private func countPredicates(in value: JSONValue) -> Int {
+    switch value {
+    case .object(let object):
+      return object.reduce(into: 0) { count, entry in
+        if entry.key == "$and" || entry.key == "$or" {
+          count += countPredicates(in: entry.value)
+        } else if entry.key.hasPrefix("$") {
+          count += max(1, countPredicates(in: entry.value))
+        } else {
+          count += 1
+        }
+      }
+    case .array(let values):
+      return values.reduce(0) { $0 + countPredicates(in: $1) }
+    default:
+      return 0
+    }
+  }
+
+  private func containsOversizedString(in value: JSONValue) -> Bool {
+    switch value {
+    case .string(let string):
+      return string.utf8.count > ChromaCloudLimits.maximumFullTextSearchBytes
+    case .array(let values):
+      return values.contains(where: containsOversizedString)
+    case .object(let object):
+      return object.values.contains(where: containsOversizedString)
+    default:
+      return false
+    }
+  }
+}
+
+private struct CreateCollectionRequest: Encodable {
+  let name: String
+  let metadata: ChromaMetadata?
+  let getOrCreate: Bool
+
+  enum CodingKeys: String, CodingKey {
+    case name
+    case metadata
+    case getOrCreate = "get_or_create"
+  }
+}
+
+private struct UpsertRequest: Encodable {
+  let ids: [String]
+  let embeddings: [[Double]]
+  let documents: [String?]?
+  let metadatas: [ChromaMetadata?]?
+  let uris: [String?]?
+}
+
+private struct QueryRequest: Encodable {
+  let queryEmbeddings: [[Double]]
+  let nResults: Int
+  let whereFilter: ChromaFilter?
+  let whereDocument: ChromaFilter?
+  let ids: [String]?
+  let include: [ChromaInclude]
+
+  enum CodingKeys: String, CodingKey {
+    case queryEmbeddings = "query_embeddings"
+    case nResults = "n_results"
+    case whereFilter = "where"
+    case whereDocument = "where_document"
+    case ids
+    case include
+  }
+}
+
+private struct GetRequest: Encodable {
+  let ids: [String]?
+  let whereFilter: ChromaFilter?
+  let whereDocument: ChromaFilter?
+  let include: [ChromaInclude]
+  let limit: Int?
+  let offset: Int?
+
+  enum CodingKeys: String, CodingKey {
+    case ids
+    case whereFilter = "where"
+    case whereDocument = "where_document"
+    case include
+    case limit
+    case offset
+  }
+}
+
+private struct DeleteRequest: Encodable {
+  let ids: [String]?
+  let whereFilter: ChromaFilter?
+  let whereDocument: ChromaFilter?
+
+  enum CodingKeys: String, CodingKey {
+    case ids
+    case whereFilter = "where"
+    case whereDocument = "where_document"
+  }
+}
+
+private struct EmptyResponse: Decodable {}
+
+private struct ChromaAPIError: Decodable {
+  let error: String?
+  let message: String?
+  let detail: String?
+}

--- a/receipt_ocr_swift/Sources/ReceiptChroma/ChromaConfiguration.swift
+++ b/receipt_ocr_swift/Sources/ReceiptChroma/ChromaConfiguration.swift
@@ -1,0 +1,118 @@
+import Foundation
+
+public enum ChromaMode: String, Codable, Sendable {
+  case read
+  case write
+}
+
+public struct ChromaRetryPolicy: Equatable, Sendable {
+  public let maxRetries: Int
+  public let baseDelay: TimeInterval
+  public let maxDelay: TimeInterval
+
+  public init(
+    maxRetries: Int = 4,
+    baseDelay: TimeInterval = 0.5,
+    maxDelay: TimeInterval = 8
+  ) {
+    self.maxRetries = maxRetries
+    self.baseDelay = baseDelay
+    self.maxDelay = maxDelay
+  }
+}
+
+public struct ChromaConfiguration: Equatable, Sendable {
+  public let apiKey: String
+  public let tenant: String
+  public let database: String
+  public let mode: ChromaMode
+  public let baseURL: URL
+  public let requestTimeout: TimeInterval
+  public let retryPolicy: ChromaRetryPolicy
+
+  public init(
+    apiKey: String,
+    tenant: String,
+    database: String,
+    mode: ChromaMode = .read,
+    baseURL: URL = URL(string: "https://api.trychroma.com/api/v2")!,
+    requestTimeout: TimeInterval = 30,
+    retryPolicy: ChromaRetryPolicy = ChromaRetryPolicy()
+  ) throws {
+    let normalizedAPIKey = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+    let normalizedTenant = tenant.trimmingCharacters(in: .whitespacesAndNewlines)
+    let normalizedDatabase = database.trimmingCharacters(in: .whitespacesAndNewlines)
+
+    guard !normalizedAPIKey.isEmpty else {
+      throw ReceiptChromaError.configuration("apiKey must not be blank")
+    }
+    guard !normalizedTenant.isEmpty else {
+      throw ReceiptChromaError.configuration("tenant must not be blank")
+    }
+    guard !normalizedDatabase.isEmpty else {
+      throw ReceiptChromaError.configuration("database must not be blank")
+    }
+    guard
+      normalizedDatabase.utf8.count
+        <= ChromaCloudLimits.maximumDatabaseNameBytes
+    else {
+      throw ReceiptChromaError.configuration(
+        "database exceeds \(ChromaCloudLimits.maximumDatabaseNameBytes) UTF-8 bytes"
+      )
+    }
+    guard let scheme = baseURL.scheme?.lowercased(),
+      let host = baseURL.host?.lowercased(),
+      ["http", "https"].contains(scheme)
+    else {
+      throw ReceiptChromaError.configuration(
+        "baseURL must be an absolute HTTP(S) URL"
+      )
+    }
+    let isLoopback =
+      host == "localhost" || host == "::1" || host.hasPrefix("127.")
+    guard scheme == "https" || isLoopback else {
+      throw ReceiptChromaError.configuration(
+        "baseURL must use HTTPS unless it targets a loopback host"
+      )
+    }
+    guard requestTimeout.isFinite, requestTimeout > 0 else {
+      throw ReceiptChromaError.configuration("requestTimeout must be positive")
+    }
+    guard retryPolicy.maxRetries >= 0,
+      retryPolicy.baseDelay.isFinite,
+      retryPolicy.maxDelay.isFinite,
+      retryPolicy.baseDelay >= 0,
+      retryPolicy.maxDelay >= retryPolicy.baseDelay
+    else {
+      throw ReceiptChromaError.configuration(
+        "retry delays must be non-negative and maxDelay must be at least baseDelay"
+      )
+    }
+
+    self.apiKey = normalizedAPIKey
+    self.tenant = normalizedTenant
+    self.database = normalizedDatabase
+    self.mode = mode
+    self.baseURL = baseURL
+    self.requestTimeout = requestTimeout
+    self.retryPolicy = retryPolicy
+  }
+}
+
+/// Limits enforced by the deployed Chroma Cloud ingestion path.
+public enum ChromaCloudLimits {
+  public static let upsertBatchSize = 250
+  public static let maximumQueryResults = 300
+  public static let maximumIDBytes = 128
+  public static let maximumURIBytes = 256
+  public static let maximumDocumentBytes = 16_384
+  public static let maximumDatabaseNameBytes = 128
+  public static let maximumCollectionNameBytes = 128
+  public static let maximumMetadataKeys = 32
+  public static let maximumMetadataKeyBytes = 36
+  public static let maximumMetadataValueBytes = 8_182
+  public static let maximumCollectionMetadataValueBytes = 256
+  public static let maximumEmbeddingDimensions = 4_096
+  public static let maximumWherePredicates = 8
+  public static let maximumFullTextSearchBytes = 256
+}

--- a/receipt_ocr_swift/Sources/ReceiptChroma/ChromaHTTPTransport.swift
+++ b/receipt_ocr_swift/Sources/ReceiptChroma/ChromaHTTPTransport.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+  import FoundationNetworking
+#endif
+
+public protocol ChromaHTTPTransport: Sendable {
+  func data(for request: URLRequest) async throws -> (Data, HTTPURLResponse)
+  func close() async
+}
+
+extension ChromaHTTPTransport {
+  public func close() async {}
+}
+
+public struct URLSessionChromaHTTPTransport: ChromaHTTPTransport {
+  private let session: URLSession
+
+  public init(configuration: URLSessionConfiguration = .default) {
+    self.session = URLSession(configuration: configuration)
+  }
+
+  public func data(for request: URLRequest) async throws -> (Data, HTTPURLResponse) {
+    let (data, response) = try await session.data(for: request)
+    guard let httpResponse = response as? HTTPURLResponse else {
+      throw ReceiptChromaError.invalidResponse(
+        "transport returned a non-HTTP response"
+      )
+    }
+    return (data, httpResponse)
+  }
+
+  public func close() async {
+    session.invalidateAndCancel()
+  }
+}

--- a/receipt_ocr_swift/Sources/ReceiptChroma/ChromaModels.swift
+++ b/receipt_ocr_swift/Sources/ReceiptChroma/ChromaModels.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+public enum ChromaInclude: String, Codable, CaseIterable, Sendable {
+  case embeddings
+  case documents
+  case metadatas
+  case distances
+  case uris
+}
+
+public struct ChromaCollection: Codable, Equatable, Sendable {
+  public let id: String
+  public let name: String
+  public let metadata: ChromaMetadata?
+  public let dimension: Int?
+  public let tenant: String?
+  public let database: String?
+  public let version: Int?
+  public let logPosition: Int?
+  public let configuration: JSONValue?
+  public let schema: JSONValue?
+
+  enum CodingKeys: String, CodingKey {
+    case id
+    case name
+    case metadata
+    case dimension
+    case tenant
+    case database
+    case version
+    case logPosition = "log_position"
+    case configuration = "configuration_json"
+    case schema
+  }
+}
+
+public struct ChromaGetResult: Codable, Equatable, Sendable {
+  public let ids: [String]
+  public let included: [ChromaInclude]?
+  public let embeddings: [[Double]?]?
+  public let documents: [String?]?
+  public let metadatas: [ChromaMetadata?]?
+  public let uris: [String?]?
+}
+
+public struct ChromaQueryResult: Codable, Equatable, Sendable {
+  public let ids: [[String]]
+  public let included: [ChromaInclude]?
+  public let embeddings: [[[Double]?]]?
+  public let documents: [[String?]]?
+  public let metadatas: [[ChromaMetadata?]]?
+  public let distances: [[Double?]]?
+  public let uris: [[String?]]?
+}

--- a/receipt_ocr_swift/Sources/ReceiptChroma/JSONValue.swift
+++ b/receipt_ocr_swift/Sources/ReceiptChroma/JSONValue.swift
@@ -1,0 +1,109 @@
+import Foundation
+
+/// A lossless, recursive JSON value used for Chroma metadata and filters.
+///
+/// Chroma metadata upserts merge with existing metadata. Use ``null`` to
+/// explicitly remove an existing key; omitting the key leaves it unchanged.
+public enum JSONValue: Codable, Equatable, Sendable {
+  case string(String)
+  case integer(Int64)
+  case number(Double)
+  case bool(Bool)
+  case array([JSONValue])
+  case object([String: JSONValue])
+  case null
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+
+    if container.decodeNil() {
+      self = .null
+    } else if let value = try? container.decode(Bool.self) {
+      self = .bool(value)
+    } else if let value = try? container.decode(Int64.self) {
+      self = .integer(value)
+    } else if let value = try? container.decode(Double.self) {
+      self = .number(value)
+    } else if let value = try? container.decode(String.self) {
+      self = .string(value)
+    } else if let value = try? container.decode([JSONValue].self) {
+      self = .array(value)
+    } else if let value = try? container.decode([String: JSONValue].self) {
+      self = .object(value)
+    } else {
+      throw DecodingError.dataCorruptedError(
+        in: container,
+        debugDescription: "Unsupported JSON value"
+      )
+    }
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+
+    switch self {
+    case .string(let value):
+      try container.encode(value)
+    case .integer(let value):
+      try container.encode(value)
+    case .number(let value):
+      try container.encode(value)
+    case .bool(let value):
+      try container.encode(value)
+    case .array(let value):
+      try container.encode(value)
+    case .object(let value):
+      try container.encode(value)
+    case .null:
+      try container.encodeNil()
+    }
+  }
+}
+
+extension JSONValue: ExpressibleByStringLiteral {
+  public init(stringLiteral value: String) {
+    self = .string(value)
+  }
+}
+
+extension JSONValue: ExpressibleByIntegerLiteral {
+  public init(integerLiteral value: Int64) {
+    self = .integer(value)
+  }
+}
+
+extension JSONValue: ExpressibleByFloatLiteral {
+  public init(floatLiteral value: Double) {
+    self = .number(value)
+  }
+}
+
+extension JSONValue: ExpressibleByBooleanLiteral {
+  public init(booleanLiteral value: Bool) {
+    self = .bool(value)
+  }
+}
+
+extension JSONValue: ExpressibleByArrayLiteral {
+  public init(arrayLiteral elements: JSONValue...) {
+    self = .array(elements)
+  }
+}
+
+extension JSONValue: ExpressibleByDictionaryLiteral {
+  public init(dictionaryLiteral elements: (String, JSONValue)...) {
+    self = .object(Dictionary(uniqueKeysWithValues: elements))
+  }
+}
+
+extension JSONValue: ExpressibleByNilLiteral {
+  public init(nilLiteral: ()) {
+    self = .null
+  }
+}
+
+/// Metadata attached to a Chroma record.
+public typealias ChromaMetadata = [String: JSONValue]
+
+/// A recursive Chroma `where` or `where_document` expression.
+public typealias ChromaFilter = [String: JSONValue]

--- a/receipt_ocr_swift/Sources/ReceiptChroma/ReceiptChromaError.swift
+++ b/receipt_ocr_swift/Sources/ReceiptChroma/ReceiptChromaError.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// Errors surfaced by the Swift receipt-Chroma boundary.
+public enum ReceiptChromaError: Error, Equatable, Sendable {
+  case configuration(String)
+  case closed
+  case readOnly
+  case collectionNotFound(String)
+  case invalidRequest(String)
+  case http(status: Int, type: String?, message: String, traceID: String?)
+  case invalidResponse(String)
+  case transport(String)
+  case partialBatch(completed: Int, total: Int, message: String)
+}
+
+extension ReceiptChromaError: LocalizedError {
+  public var errorDescription: String? {
+    switch self {
+    case .configuration(let message):
+      return "Invalid Chroma configuration: \(message)"
+    case .closed:
+      return "Cannot use a closed Chroma client"
+    case .readOnly:
+      return "This Chroma client is read-only"
+    case .collectionNotFound(let name):
+      return "Chroma collection '\(name)' was not found"
+    case .invalidRequest(let message):
+      return "Invalid Chroma request: \(message)"
+    case .http(let status, let type, let message, let traceID):
+      let typeSuffix = type.map { " (\($0))" } ?? ""
+      let traceSuffix = traceID.map { " [trace \($0)]" } ?? ""
+      return "Chroma HTTP \(status)\(typeSuffix): \(message)\(traceSuffix)"
+    case .invalidResponse(let message):
+      return "Invalid Chroma response: \(message)"
+    case .transport(let message):
+      return "Chroma transport failed: \(message)"
+    case .partialBatch(let completed, let total, let message):
+      return "Chroma upsert stopped after \(completed) of \(total) records: \(message)"
+    }
+  }
+}

--- a/receipt_ocr_swift/Sources/ReceiptOCRCore/AWS/SotoAWSClients.swift
+++ b/receipt_ocr_swift/Sources/ReceiptOCRCore/AWS/SotoAWSClients.swift
@@ -178,47 +178,38 @@ public final class SotoDynamoClient: DynamoClientProtocol {
     public func addReceiptWordLabels(_ labels: [ReceiptWordLabel]) async throws {
         guard !labels.isEmpty else { return }
 
-        // Process in chunks of 25 (DynamoDB batch write limit)
-        let chunkSize = 25
-        var remaining = labels[...]
-
-        while !remaining.isEmpty {
-            let chunk = remaining.prefix(chunkSize)
-            remaining = remaining.dropFirst(chunkSize)
-
-            var writeRequests = chunk.map { label -> DynamoDB.WriteRequest in
-                let dict = label.toDynamoItemDict()
-                let item = Self.convertToAttributeValues(dict)
-                return DynamoDB.WriteRequest(putRequest: .init(item: item))
-            }
-
-            // Retry with exponential backoff until all items are processed
-            let maxRetries = 8
-            var retryCount = 0
-            let baseDelayMs: UInt64 = 50
-
-            while !writeRequests.isEmpty && retryCount < maxRetries {
-                let req = DynamoDB.BatchWriteItemInput(requestItems: [tableName: writeRequests])
-                let resp = try await dynamo.batchWriteItem(req)
-
-                // Check for unprocessed items
-                if let unprocessed = resp.unprocessedItems?[tableName], !unprocessed.isEmpty {
-                    writeRequests = unprocessed
-                    retryCount += 1
-
-                    // Exponential backoff with jitter
-                    let delayMs = baseDelayMs * UInt64(1 << retryCount)
-                    let jitter = UInt64.random(in: 0...delayMs / 4)
-                    try await Task.sleep(nanoseconds: (delayMs + jitter) * 1_000_000)
-                } else {
-                    // All items processed
-                    writeRequests = []
+        // BatchWrite cannot express a condition and could replace a human-VALID
+        // label with a new PENDING inference. Create each exact label key once.
+        // Retrying after a partial network failure is safe because collisions
+        // are treated as successful idempotent replays.
+        let maximumConcurrentWrites = 8
+        for start in stride(
+            from: 0,
+            to: labels.count,
+            by: maximumConcurrentWrites
+        ) {
+            let end = min(start + maximumConcurrentWrites, labels.count)
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                for label in labels[start..<end] {
+                    group.addTask {
+                        let item = Self.convertToAttributeValues(
+                            label.toDynamoItemDict()
+                        )
+                        let request = DynamoDB.PutItemInput(
+                            conditionExpression:
+                                "attribute_not_exists(PK) AND attribute_not_exists(SK)",
+                            item: item,
+                            tableName: self.tableName
+                        )
+                        do {
+                            _ = try await self.dynamo.putItem(request)
+                        } catch let error as DynamoDBErrorType
+                            where error.errorCode == "ConditionalCheckFailedException" {
+                            // Existing PENDING or human-VALID rows win.
+                        }
+                    }
                 }
-            }
-
-            // If we still have unprocessed items after max retries, throw an error
-            if !writeRequests.isEmpty {
-                throw BatchWriteError.unprocessedItems(count: writeRequests.count)
+                try await group.waitForAll()
             }
         }
     }
@@ -313,3 +304,87 @@ public final class SotoDynamoClient: DynamoClientProtocol {
     }
 }
 
+#if os(macOS)
+extension SotoDynamoClient: KnownReceiptEvidenceProviding {
+    public func evidence(
+        for references: Set<ReceiptReference>
+    ) async throws -> [ReceiptReference: KnownReceiptEvidence] {
+        var result: [ReceiptReference: KnownReceiptEvidence] = [:]
+        for reference in references.sorted(by: {
+            $0.imageID == $1.imageID
+                ? $0.receiptID < $1.receiptID
+                : $0.imageID < $1.imageID
+        }) {
+            let partition = "IMAGE#\(reference.imageID)"
+            let receiptPrefix = "RECEIPT#" + String(format: "%05d", reference.receiptID)
+
+            let placeRequest = DynamoDB.GetItemInput(
+                consistentRead: true,
+                key: [
+                    "PK": .s(partition),
+                    "SK": .s("\(receiptPrefix)#PLACE")
+                ],
+                tableName: tableName
+            )
+            let place = try await dynamo.getItem(placeRequest).item
+
+            var validSectionByLine: [Int: String] = [:]
+            var lastKey: [String: DynamoDB.AttributeValue]? = nil
+            repeat {
+                let request = DynamoDB.QueryInput(
+                    consistentRead: true,
+                    exclusiveStartKey: lastKey,
+                    expressionAttributeNames: [
+                        "#pk": "PK",
+                        "#sk": "SK",
+                        "#status": "validation_status"
+                    ],
+                    expressionAttributeValues: [
+                        ":pk": .s(partition),
+                        ":prefix": .s("\(receiptPrefix)#SECTION#"),
+                        ":valid": .s("VALID")
+                    ],
+                    filterExpression: "#status = :valid",
+                    keyConditionExpression: "#pk = :pk AND begins_with(#sk, :prefix)",
+                    tableName: tableName
+                )
+                let response = try await dynamo.query(request)
+                for item in response.items ?? [] {
+                    guard
+                        case .s(let section)? = item["section_type"],
+                        case .l(let rawLineIDs)? = item["line_ids"]
+                    else { continue }
+                    for value in rawLineIDs {
+                        guard case .n(let raw) = value, let lineID = Int(raw) else {
+                            continue
+                        }
+                        validSectionByLine[lineID] = section
+                    }
+                }
+                lastKey = response.lastEvaluatedKey
+            } while lastKey?.isEmpty == false
+
+            func string(_ key: String) -> String? {
+                guard case .s(let value)? = place?[key] else { return nil }
+                return value
+            }
+            func number(_ key: String) -> Double? {
+                guard case .n(let value)? = place?[key] else { return nil }
+                return Double(value)
+            }
+            result[reference] = KnownReceiptEvidence(
+                reference: reference,
+                placeID: string("place_id"),
+                merchantName: string("merchant_name"),
+                formattedAddress: string("formatted_address"),
+                phoneNumber: string("phone_number"),
+                website: string("website"),
+                placeValidationStatus: string("validation_status"),
+                placeConfidence: number("confidence"),
+                validSectionByLine: validSectionByLine
+            )
+        }
+        return result
+    }
+}
+#endif

--- a/receipt_ocr_swift/Sources/ReceiptOCRCore/Understanding/DeterministicSectionDecoder.swift
+++ b/receipt_ocr_swift/Sources/ReceiptOCRCore/Understanding/DeterministicSectionDecoder.swift
@@ -1,0 +1,681 @@
+import Foundation
+
+#if os(macOS)
+
+  public enum SectionDecoderError: Error, LocalizedError {
+    case invalidPrior(String)
+
+    public var errorDescription: String? {
+      switch self {
+      case .invalidPrior(let message):
+        return "Invalid section prior: \(message)"
+      }
+    }
+  }
+
+  private struct SectionDistribution: Decodable {
+    let mean: Double
+    let std: Double
+  }
+
+  private struct SectionProbability: Decodable {
+    let probability: Double
+  }
+
+  private struct SectionModel: Decodable {
+    let features: [String: SectionDistribution]
+    let binaryFeatures: [String: SectionProbability]
+    let duration: SectionDistribution
+    let tokenLogOdds: [String: Double]
+
+    private enum CodingKeys: String, CodingKey {
+      case features
+      case binaryFeatures = "binary_features"
+      case duration
+      case tokenLogOdds = "token_log_odds"
+    }
+
+    init(from decoder: Decoder) throws {
+      let values = try decoder.container(keyedBy: CodingKeys.self)
+      features = try values.decode(
+        [String: SectionDistribution].self,
+        forKey: .features
+      )
+      binaryFeatures = try values.decode(
+        [String: SectionProbability].self,
+        forKey: .binaryFeatures
+      )
+      duration = try values.decode(
+        SectionDistribution.self,
+        forKey: .duration
+      )
+      tokenLogOdds =
+        try values.decodeIfPresent(
+          [String: Double].self,
+          forKey: .tokenLogOdds
+        ) ?? [:]
+    }
+  }
+
+  private struct SectionPrior: Decodable {
+    let sections: [String]
+    let sectionModels: [String: SectionModel]
+    let transitions: [String: [String: Double]]
+
+    private enum CodingKeys: String, CodingKey {
+      case sections
+      case sectionModels = "section_models"
+      case transitions
+    }
+  }
+
+  private struct SectionPriorBundle: Decodable {
+    let global: SectionPrior
+    let merchants: [String: SectionPrior]
+  }
+
+  private struct SectionRowFeatures {
+    let row: VisualReceiptRow
+    let position: Double
+    let xSpan: Double
+    let alphaRatio: Double
+    let hasAmount: Double
+    let amountDensity: Double
+    let hasQuantity: Double
+    let tokens: [String]
+    let tokenEvidence: [String: Double]?
+
+    func numeric(_ name: String) -> Double {
+      switch name {
+      case "position": return position
+      case "x_span": return xSpan
+      case "alpha_ratio": return alphaRatio
+      case "amount_density": return amountDensity
+      default: return 0
+      }
+    }
+
+    func binary(_ name: String) -> Double {
+      switch name {
+      case "has_amount": return hasAmount
+      case "has_quantity": return hasQuantity
+      default: return 0
+      }
+    }
+  }
+
+  private struct DecoderCell {
+    let score: Double
+    let start: Int
+    let previousState: Int?
+  }
+
+  /// Swift port of `receipt_upload.section_assignment`.
+  ///
+  /// The prior remains the committed Python asset and is loaded by URL. This
+  /// avoids maintaining two copies of either the model or the section vocabulary.
+  public struct DeterministicSectionDecoder: Sendable {
+    private static let epsilon = 1e-9
+    private let prior: SectionPriorBundle
+
+    public init(priorURL: URL) throws {
+      let data = try Data(contentsOf: priorURL)
+      self.prior = try JSONDecoder().decode(SectionPriorBundle.self, from: data)
+      guard !prior.global.sections.isEmpty else {
+        throw SectionDecoderError.invalidPrior("global sections are empty")
+      }
+      guard Set(prior.global.sections).count == prior.global.sections.count else {
+        throw SectionDecoderError.invalidPrior(
+          "global sections contain duplicates"
+        )
+      }
+      for section in prior.global.sections
+      where prior.global.sectionModels[section] == nil {
+        throw SectionDecoderError.invalidPrior(
+          "global model is missing \(section)"
+        )
+      }
+      try Self.validate(
+        prior.global,
+        name: "global",
+        requiredSections: prior.global.sections,
+        requiresEveryModel: true
+      )
+      for (merchant, model) in prior.merchants {
+        try Self.validate(
+          model,
+          name: "merchant \(merchant)",
+          requiredSections: prior.global.sections,
+          requiresEveryModel: false
+        )
+      }
+    }
+
+    /// Decode rows with optional cosine-weighted, human-VALID neighbor evidence.
+    ///
+    /// Chroma metadata labels are deliberately ignored. A neighbor contributes
+    /// only when its referenced Dynamo section maps a plurality of the
+    /// neighbor's row line IDs to one VALID section.
+    public func assign(
+      rows: [VisualReceiptRow],
+      merchantName: String?,
+      neighbors: [[SectionNeighbor]] = [],
+      knownEvidence: [ReceiptReference: KnownReceiptEvidence] = [:]
+    ) -> [SectionAssignment] {
+      guard !rows.isEmpty else { return [] }
+      let orderedRows = rows.sorted {
+        let lhs = -($0.bounds.yMin + $0.bounds.yMax)
+        let rhs = -($1.bounds.yMin + $1.bounds.yMax)
+        return lhs == rhs ? $0.rowID < $1.rowID : lhs < rhs
+      }
+      let selectedPrior =
+        prior.merchants[Self.normalizeMerchantKey(merchantName)] ?? prior.global
+      let sections = orderedSections(selectedPrior)
+      guard !sections.isEmpty else { return [] }
+
+      let extracted = extractFeatures(orderedRows)
+      let neighborResult = neighborEvidence(
+        rows: orderedRows,
+        sections: sections,
+        neighbors: neighbors,
+        knownEvidence: knownEvidence
+      )
+      let features = zip(extracted, neighborResult.scores).map {
+        feature, evidence -> SectionRowFeatures in
+        guard let evidence else { return feature }
+        var combined: [String: Double] = [:]
+        for section in sections {
+          let lexical = feature.tokens.reduce(0.0) { total, token in
+            total
+              + (prior.global.sectionModels[section]?.tokenLogOdds[token] ?? 0)
+          }
+          combined[section] =
+            lexical
+            + ReceiptUnderstandingConstants.embeddingKNNWeight
+            * (evidence[section] ?? 0)
+        }
+        return SectionRowFeatures(
+          row: feature.row,
+          position: feature.position,
+          xSpan: feature.xSpan,
+          alphaRatio: feature.alphaRatio,
+          hasAmount: feature.hasAmount,
+          amountDensity: feature.amountDensity,
+          hasQuantity: feature.hasQuantity,
+          tokens: feature.tokens,
+          tokenEvidence: combined
+        )
+      }
+
+      let emissions = features.map { feature in
+        sections.map { section in
+          emission(
+            feature,
+            section: section,
+            model: selectedPrior.sectionModels[section]
+              ?? prior.global.sectionModels[section]!,
+            fallback: prior.global.sectionModels[section]!
+          )
+        }
+      }
+      let states = decode(
+        features: features,
+        sections: sections,
+        emissions: emissions,
+        selectedPrior: selectedPrior
+      )
+
+      return zip(features.indices, states).map { index, state in
+        SectionAssignment(
+          rowID: features[index].row.rowID,
+          lineIDs: features[index].row.lineIDs,
+          sectionType: sections[state],
+          confidence: confidence(emissions[index], chosen: state),
+          neighborConfidence: neighborResult.confidences[index],
+          neighborCount: neighborResult.counts[index]
+        )
+      }
+    }
+
+    public static func normalizeMerchantKey(_ name: String?) -> String {
+      guard let name, !name.isEmpty else { return "" }
+      let pattern = try! NSRegularExpression(pattern: "[a-z0-9]+")
+      let lowered = name.lowercased()
+      let range = NSRange(lowered.startIndex..., in: lowered)
+      return pattern.matches(in: lowered, range: range).compactMap {
+        Range($0.range, in: lowered).map { String(lowered[$0]) }
+      }.joined(separator: " ")
+    }
+
+    private static func validate(
+      _ prior: SectionPrior,
+      name: String,
+      requiredSections: [String],
+      requiresEveryModel: Bool
+    ) throws {
+      let numericFeatures = [
+        "position", "x_span", "alpha_ratio", "amount_density",
+      ]
+      let binaryFeatures = ["has_amount", "has_quantity"]
+      for section in requiredSections {
+        guard let model = prior.sectionModels[section] else {
+          if requiresEveryModel {
+            throw SectionDecoderError.invalidPrior(
+              "\(name) model is missing \(section)"
+            )
+          }
+          continue
+        }
+        for feature in numericFeatures {
+          guard let distribution = model.features[feature] else {
+            throw SectionDecoderError.invalidPrior(
+              "\(name).\(section) is missing feature \(feature)"
+            )
+          }
+          guard
+            distribution.mean.isFinite,
+            distribution.std.isFinite,
+            distribution.std >= 0
+          else {
+            throw SectionDecoderError.invalidPrior(
+              "\(name).\(section).\(feature) is not finite"
+            )
+          }
+        }
+        for feature in binaryFeatures {
+          guard let distribution = model.binaryFeatures[feature] else {
+            throw SectionDecoderError.invalidPrior(
+              "\(name).\(section) is missing binary feature \(feature)"
+            )
+          }
+          guard
+            distribution.probability.isFinite,
+            (0...1).contains(distribution.probability)
+          else {
+            throw SectionDecoderError.invalidPrior(
+              "\(name).\(section).\(feature) is outside 0...1"
+            )
+          }
+        }
+        guard
+          model.duration.mean.isFinite,
+          model.duration.std.isFinite,
+          model.duration.std >= 0,
+          model.tokenLogOdds.values.allSatisfy(\.isFinite)
+        else {
+          throw SectionDecoderError.invalidPrior(
+            "\(name).\(section) has an invalid duration or token weight"
+          )
+        }
+      }
+      for (source, destinations) in prior.transitions {
+        for (destination, probability) in destinations
+        where !probability.isFinite || probability < 0 || probability > 1 {
+          throw SectionDecoderError.invalidPrior(
+            "\(name) transition \(source)->\(destination) is outside 0...1"
+          )
+        }
+      }
+    }
+
+    private func extractFeatures(
+      _ rows: [VisualReceiptRow]
+    ) -> [SectionRowFeatures] {
+      let tokensByRow = rows.map { Self.tokens($0.text) }
+      let amountFlags = zip(rows, tokensByRow).map {
+        row, tokens in
+        (row.amountText != nil || tokens.contains("__amount__")) ? 1.0 : 0.0
+      }
+      return rows.indices.map { index in
+        let row = rows[index]
+        let text = row.text
+        let letters = text.unicodeScalars.filter {
+          CharacterSet.letters.contains($0)
+        }.count
+        let digits = text.unicodeScalars.filter {
+          CharacterSet.decimalDigits.contains($0)
+        }.count
+        let visible = max(letters + digits, 1)
+        let lower = max(0, index - 2)
+        let upper = min(rows.count, index + 3)
+        let density =
+          amountFlags[lower..<upper].reduce(0, +) / Double(upper - lower)
+        return SectionRowFeatures(
+          row: row,
+          position: rows.count > 1
+            ? Double(index) / Double(rows.count - 1) : 0.5,
+          xSpan: row.bounds.xMax - row.bounds.xMin,
+          alphaRatio: Double(letters) / Double(visible),
+          hasAmount: amountFlags[index],
+          amountDensity: density,
+          hasQuantity: Self.hasQuantity(text) ? 1 : 0,
+          tokens: tokensByRow[index],
+          tokenEvidence: nil
+        )
+      }
+    }
+
+    private func orderedSections(_ selected: SectionPrior) -> [String] {
+      prior.global.sections.sorted { lhs, rhs in
+        let lhsModel =
+          selected.sectionModels[lhs] ?? prior.global.sectionModels[lhs]!
+        let rhsModel =
+          selected.sectionModels[rhs] ?? prior.global.sectionModels[rhs]!
+        let lhsMean = lhsModel.features["position"]!.mean
+        let rhsMean = rhsModel.features["position"]!.mean
+        return lhsMean == rhsMean ? lhs < rhs : lhsMean < rhsMean
+      }
+    }
+
+    private func emission(
+      _ feature: SectionRowFeatures,
+      section: String,
+      model: SectionModel,
+      fallback: SectionModel
+    ) -> Double {
+      let numericOrder = ["position", "x_span", "alpha_ratio", "amount_density"]
+      var score = numericOrder.reduce(0.0) { total, name in
+        let candidate = model.features[name]!
+        let distribution =
+          candidate.std > Self.epsilon ? candidate : fallback.features[name]!
+        return total + gaussian(feature.numeric(name), distribution)
+      }
+      let binaryOrder = ["has_amount", "has_quantity"]
+      score += binaryOrder.reduce(0.0) { total, name in
+        let distribution =
+          model.binaryFeatures[name] ?? fallback.binaryFeatures[name]!
+        return total + bernoulli(feature.binary(name), distribution)
+      }
+      if let tokenEvidence = feature.tokenEvidence {
+        score += tokenEvidence[section] ?? 0
+      } else {
+        let odds =
+          model.tokenLogOdds.isEmpty
+          ? fallback.tokenLogOdds : model.tokenLogOdds
+        score += feature.tokens.reduce(0.0) {
+          $0 + (odds[$1] ?? 0)
+        }
+      }
+      return score
+    }
+
+    private func decode(
+      features: [SectionRowFeatures],
+      sections: [String],
+      emissions: [[Double]],
+      selectedPrior: SectionPrior
+    ) -> [Int] {
+      var prefixes = Array(
+        repeating: [0.0],
+        count: sections.count
+      )
+      for state in sections.indices {
+        for row in emissions {
+          prefixes[state].append(prefixes[state].last! + row[state])
+        }
+      }
+
+      var paths: [[DecoderCell]] = []
+      for end in features.indices {
+        var current: [DecoderCell] = []
+        for state in sections.indices {
+          var best: DecoderCell?
+          for start in 0...end {
+            let duration = end - start + 1
+            let segment =
+              prefixes[state][end + 1] - prefixes[state][start]
+              + durationScore(
+                selectedPrior,
+                section: sections[state],
+                duration: duration
+              )
+            if start == 0 {
+              let candidate = DecoderCell(
+                score: log(
+                  max(
+                    transition(
+                      selectedPrior,
+                      source: "<START>",
+                      destination: sections[state]
+                    ),
+                    Self.epsilon
+                  )
+                ) + segment,
+                start: start,
+                previousState: nil
+              )
+              if isBetter(candidate, than: best) { best = candidate }
+            } else {
+              for previous in sections.indices where previous != state {
+                let candidate = DecoderCell(
+                  score: paths[start - 1][previous].score
+                    + log(
+                      max(
+                        transition(
+                          selectedPrior,
+                          source: sections[previous],
+                          destination: sections[state]
+                        ),
+                        Self.epsilon
+                      )
+                    ) + segment,
+                  start: start,
+                  previousState: previous
+                )
+                if isBetter(candidate, than: best) { best = candidate }
+              }
+            }
+          }
+          current.append(best!)
+        }
+        paths.append(current)
+      }
+
+      var state = sections.indices.first!
+      var terminalScore = -Double.infinity
+      for index in sections.indices {
+        let score =
+          paths.last![index].score
+          + log(
+            max(
+              transition(
+                selectedPrior,
+                source: sections[index],
+                destination: "<END>"
+              ),
+              Self.epsilon
+            )
+          )
+        if score > terminalScore {
+          terminalScore = score
+          state = index
+        }
+      }
+      var states = Array(repeating: 0, count: features.count)
+      var end = features.count - 1
+      while end >= 0 {
+        let cell = paths[end][state]
+        for index in cell.start...end { states[index] = state }
+        guard let previous = cell.previousState else { break }
+        end = cell.start - 1
+        state = previous
+      }
+      return states
+    }
+
+    private func isBetter(
+      _ candidate: DecoderCell,
+      than current: DecoderCell?
+    ) -> Bool {
+      guard let current else { return true }
+      if candidate.score != current.score {
+        return candidate.score > current.score
+      }
+      if candidate.start != current.start {
+        return candidate.start < current.start
+      }
+      return (candidate.previousState ?? 0) < (current.previousState ?? 0)
+    }
+
+    private func transition(
+      _ selected: SectionPrior,
+      source: String,
+      destination: String
+    ) -> Double {
+      selected.transitions[source]?[destination]
+        ?? prior.global.transitions[source]?[destination]
+        ?? Self.epsilon
+    }
+
+    private func durationScore(
+      _ selected: SectionPrior,
+      section: String,
+      duration: Int
+    ) -> Double {
+      let selectedModel =
+        selected.sectionModels[section] ?? prior.global.sectionModels[section]!
+      return gaussian(log(Double(duration)), selectedModel.duration)
+    }
+
+    private func gaussian(
+      _ value: Double,
+      _ distribution: SectionDistribution
+    ) -> Double {
+      let std = max(distribution.std, Self.epsilon)
+      let z = (value - distribution.mean) / std
+      return -0.5 * z * z - log(std)
+    }
+
+    private func bernoulli(
+      _ value: Double,
+      _ distribution: SectionProbability
+    ) -> Double {
+      let probability = min(
+        max(distribution.probability, Self.epsilon),
+        1 - Self.epsilon
+      )
+      return log(value != 0 ? probability : 1 - probability)
+    }
+
+    private func confidence(_ scores: [Double], chosen: Int) -> Double {
+      let peak = scores.max()!
+      let weights = scores.map { exp($0 - peak) }
+      return weights[chosen] / max(weights.reduce(0, +), Self.epsilon)
+    }
+
+    private func neighborEvidence(
+      rows: [VisualReceiptRow],
+      sections: [String],
+      neighbors: [[SectionNeighbor]],
+      knownEvidence: [ReceiptReference: KnownReceiptEvidence]
+    ) -> (
+      scores: [[String: Double]?],
+      confidences: [Double?],
+      counts: [Int]
+    ) {
+      var scores: [[String: Double]?] = []
+      var confidences: [Double?] = []
+      var counts: [Int] = []
+      for index in rows.indices {
+        let rowNeighbors = index < neighbors.count ? neighbors[index] : []
+        var probabilities = Dictionary(
+          uniqueKeysWithValues: sections.map { ($0, 0.1) }
+        )
+        var used = 0
+        var totalWeight = 0.0
+        for neighbor in rowNeighbors {
+          guard
+            let known = knownEvidence[neighbor.reference],
+            let section = pluralitySection(
+              lineIDs: neighbor.rowLineIDs,
+              validSections: known.validSectionByLine
+            ),
+            probabilities[section] != nil
+          else { continue }
+          let weight = max(neighbor.cosineSimilarity, 0)
+          probabilities[section, default: 0] += weight
+          totalWeight += weight
+          used += 1
+        }
+        guard used > 0, totalWeight > 0 else {
+          scores.append(nil)
+          confidences.append(nil)
+          counts.append(0)
+          continue
+        }
+        let sum = probabilities.values.reduce(0, +)
+        let logs = sections.map {
+          log((probabilities[$0] ?? 0) / sum + Self.epsilon)
+        }
+        let mean = logs.reduce(0, +) / Double(logs.count)
+        scores.append(
+          Dictionary(
+            uniqueKeysWithValues: zip(
+              sections,
+              logs.map { min(max($0 - mean, -6), 6) }
+            )
+          )
+        )
+        let winning = probabilities.values.max() ?? 0
+        confidences.append(winning / sum)
+        counts.append(used)
+      }
+      return (scores, confidences, counts)
+    }
+
+    private func pluralitySection(
+      lineIDs: [Int],
+      validSections: [Int: String]
+    ) -> String? {
+      var counts: [String: Int] = [:]
+      for lineID in lineIDs {
+        if let section = validSections[lineID] {
+          counts[section, default: 0] += 1
+        }
+      }
+      guard let maximum = counts.values.max() else { return nil }
+      let winners = counts.filter { $0.value == maximum }.map(\.key)
+      return winners.count == 1 ? winners[0] : nil
+    }
+
+    private static func tokens(_ text: String) -> [String] {
+      let lowered = text.lowercased()
+      let regex = try! NSRegularExpression(
+        pattern: "[a-z]+|\\d+(?:\\.\\d+)?"
+      )
+      let range = NSRange(lowered.startIndex..., in: lowered)
+      return regex.matches(in: lowered, range: range).compactMap { match in
+        guard let tokenRange = Range(match.range, in: lowered) else {
+          return nil
+        }
+        let token = String(lowered[tokenRange])
+        if looksLikeReceiptAmount(token) { return "__amount__" }
+        if token.allSatisfy(\.isNumber) { return "__number__" }
+        return token
+      }
+    }
+
+    private static func looksLikeReceiptAmount(_ text: String) -> Bool {
+      if text.range(of: #"[$€£¥₹]"#, options: .regularExpression) != nil {
+        return true
+      }
+      let patterns = [
+        #"-?\(?\d{1,3}(,\d{3})+(\.\d{2})?\)?-?"#,
+        #"-?\(?\d+([.,]\d{2})\)?-?"#,
+      ]
+      return patterns.contains {
+        text.range(of: "^(?:\($0))$", options: .regularExpression) != nil
+      }
+    }
+
+    private static func hasQuantity(_ text: String) -> Bool {
+      let pattern =
+        #"(?:\b\d+\s*(?:@|x)\s*\$?\d)|(?:\b(?:each|ea)\b)|(?:/\s*lb\b)"#
+      return text.range(
+        of: pattern,
+        options: [.regularExpression, .caseInsensitive]
+      ) != nil
+    }
+  }
+
+#endif

--- a/receipt_ocr_swift/Sources/ReceiptOCRCore/Understanding/EmbeddingAndChroma.swift
+++ b/receipt_ocr_swift/Sources/ReceiptOCRCore/Understanding/EmbeddingAndChroma.swift
@@ -1,0 +1,431 @@
+import Foundation
+import Logging
+import ReceiptChroma
+
+#if canImport(FoundationNetworking)
+  import FoundationNetworking
+#endif
+
+#if os(macOS)
+
+  public enum ReceiptEmbeddingError: Error, LocalizedError {
+    case invalidConfiguration(String)
+    case invalidResponse(String)
+    case http(status: Int, body: String)
+
+    public var errorDescription: String? {
+      switch self {
+      case .invalidConfiguration(let message):
+        return message
+      case .invalidResponse(let message):
+        return "Invalid OpenAI embedding response: \(message)"
+      case .http(let status, let body):
+        return "OpenAI embedding request failed (\(status)): \(body)"
+      }
+    }
+  }
+
+  public protocol OpenAIEmbeddingHTTPTransport: Sendable {
+    func send(_ request: URLRequest) async throws -> (Data, HTTPURLResponse)
+  }
+
+  public actor URLSessionOpenAIEmbeddingTransport:
+    OpenAIEmbeddingHTTPTransport
+  {
+    private let session: URLSession
+
+    public init(timeout: TimeInterval = 30) {
+      let configuration = URLSessionConfiguration.ephemeral
+      configuration.timeoutIntervalForRequest = timeout
+      configuration.timeoutIntervalForResource = timeout
+      self.session = URLSession(configuration: configuration)
+    }
+
+    public func send(
+      _ request: URLRequest
+    ) async throws -> (Data, HTTPURLResponse) {
+      let (data, response) = try await session.data(for: request)
+      guard let http = response as? HTTPURLResponse else {
+        throw ReceiptEmbeddingError.invalidResponse("non-HTTP response")
+      }
+      return (data, http)
+    }
+  }
+
+  /// OpenAI embeddings provider pinned to the exact Python request contract.
+  ///
+  /// The payload contains only `input` and `model`; it intentionally omits a
+  /// `dimensions` field because Python relies on the model's native 1,536
+  /// dimensions. Response items are restored to request order by `index`.
+  public struct OpenAIRowEmbeddingProvider: RowEmbeddingProviding {
+    public typealias Sleeper = @Sendable (UInt64) async throws -> Void
+
+    private let apiKey: String
+    private let endpoint: URL
+    private let transport: any OpenAIEmbeddingHTTPTransport
+    private let maximumRetries: Int
+    private let sleeper: Sleeper
+
+    public init(
+      apiKey: String,
+      endpoint: URL = URL(string: "https://api.openai.com/v1/embeddings")!,
+      transport: any OpenAIEmbeddingHTTPTransport =
+        URLSessionOpenAIEmbeddingTransport(),
+      maximumRetries: Int = 3,
+      sleeper: @escaping Sleeper = {
+        try await Task.sleep(nanoseconds: $0)
+      }
+    ) throws {
+      let key = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+      guard !key.isEmpty else {
+        throw ReceiptEmbeddingError.invalidConfiguration(
+          "OpenAI API key must not be blank"
+        )
+      }
+      guard
+        endpoint.scheme?.lowercased() == "https"
+          || endpoint.host == "localhost"
+          || endpoint.host?.hasPrefix("127.") == true
+      else {
+        throw ReceiptEmbeddingError.invalidConfiguration(
+          "OpenAI endpoint must use HTTPS unless it is loopback"
+        )
+      }
+      guard maximumRetries >= 0 else {
+        throw ReceiptEmbeddingError.invalidConfiguration(
+          "maximumRetries must not be negative"
+        )
+      }
+      self.apiKey = key
+      self.endpoint = endpoint
+      self.transport = transport
+      self.maximumRetries = maximumRetries
+      self.sleeper = sleeper
+    }
+
+    public func embedRows(_ inputs: [String]) async throws -> [[Double]] {
+      guard !inputs.isEmpty else { return [] }
+      let body = try JSONSerialization.data(
+        withJSONObject: [
+          "input": inputs,
+          "model": ReceiptUnderstandingConstants.embeddingModel,
+        ],
+        options: [.sortedKeys]
+      )
+      var request = URLRequest(url: endpoint)
+      request.httpMethod = "POST"
+      request.httpBody = body
+      request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+      request.setValue(
+        "Bearer \(apiKey)",
+        forHTTPHeaderField: "Authorization"
+      )
+
+      var attempt = 0
+      while true {
+        do {
+          let (data, response) = try await transport.send(request)
+          if (200..<300).contains(response.statusCode) {
+            return try decode(data, expectedCount: inputs.count)
+          }
+          let message =
+            String(data: data, encoding: .utf8)
+            ?? "<\(data.count) response bytes>"
+          let retryable =
+            response.statusCode == 429 || response.statusCode >= 500
+          guard retryable, attempt < maximumRetries else {
+            throw ReceiptEmbeddingError.http(
+              status: response.statusCode,
+              body: message
+            )
+          }
+        } catch let error as ReceiptEmbeddingError {
+          throw error
+        } catch {
+          guard attempt < maximumRetries else { throw error }
+        }
+        let delay = UInt64(250 * (1 << attempt)) * 1_000_000
+        attempt += 1
+        try await sleeper(delay)
+      }
+    }
+
+    private func decode(
+      _ data: Data,
+      expectedCount: Int
+    ) throws -> [[Double]] {
+      struct Response: Decodable {
+        struct Item: Decodable {
+          let index: Int
+          let embedding: [Double]
+        }
+        let data: [Item]
+      }
+      let response = try JSONDecoder().decode(Response.self, from: data)
+      guard response.data.count == expectedCount else {
+        throw ReceiptEmbeddingError.invalidResponse(
+          "expected \(expectedCount) vectors, got \(response.data.count)"
+        )
+      }
+      let ordered = response.data.sorted { $0.index < $1.index }
+      guard ordered.map(\.index) == Array(0..<expectedCount) else {
+        throw ReceiptEmbeddingError.invalidResponse(
+          "response indexes are missing or duplicated"
+        )
+      }
+      for item in ordered
+      where item.embedding.count
+        != ReceiptUnderstandingConstants.embeddingDimensions
+      {
+        throw ReceiptEmbeddingError.invalidResponse(
+          "index \(item.index) has \(item.embedding.count) dimensions; "
+            + "expected \(ReceiptUnderstandingConstants.embeddingDimensions)"
+        )
+      }
+      return ordered.map(\.embedding)
+    }
+  }
+
+  public struct ReceiptChromaRowRecord: Equatable, Sendable {
+    public let id: String
+    public let document: String
+    public let embeddingInput: String
+    public let metadata: ChromaMetadata
+
+    public init(
+      id: String,
+      document: String,
+      embeddingInput: String,
+      metadata: ChromaMetadata
+    ) {
+      self.id = id
+      self.document = document
+      self.embeddingInput = embeddingInput
+      self.metadata = metadata
+    }
+  }
+
+  /// Shared Swift representation of the Python `lines` collection contract.
+  public enum ReceiptChromaRowContract {
+    public static func record(
+      reference: ReceiptReference,
+      row: VisualReceiptRow,
+      sourceLines: [Line],
+      merchantName: String? = nil,
+      sectionLabel: String? = nil,
+      normalizedPhone10: String? = nil,
+      normalizedFullAddress: String? = nil,
+      normalizedURL: String? = nil
+    ) -> ReceiptChromaRowRecord {
+      let sourceByID = Dictionary(
+        uniqueKeysWithValues: sourceLines.enumerated().map {
+          ($0.offset + 1, $0.element)
+        }
+      )
+      let rowLines = row.lineIDs.compactMap { sourceByID[$0] }
+      let confidence =
+        rowLines.isEmpty
+        ? 0
+        : rowLines.reduce(0.0) { $0 + Double($1.confidence) }
+          / Double(rowLines.count)
+      let id =
+        "IMAGE#\(reference.imageID)#RECEIPT#"
+        + String(format: "%05d", reference.receiptID)
+        + "#LINE#" + String(format: "%05d", row.rowID)
+      var metadata: ChromaMetadata = [
+        "image_id": .string(reference.imageID),
+        "receipt_id": .integer(Int64(reference.receiptID)),
+        "line_id": .integer(Int64(row.rowID)),
+        "text": .string(row.text),
+        "confidence": .number(confidence),
+        "avg_word_confidence": .number(confidence),
+        "x": .number(row.bounds.xMin),
+        "y": .number(row.bounds.yMin),
+        "width": .number(row.bounds.xMax - row.bounds.xMin),
+        "height": .number(row.bounds.yMax - row.bounds.yMin),
+        "source": .string("openai_embedding_batch"),
+        "row_line_ids": .string(
+          "[" + row.lineIDs.map(String.init).joined(separator: ", ") + "]"
+        ),
+      ]
+      if let merchantName = normalizedNonempty(merchantName) {
+        metadata["merchant_name"] = .string(pythonTitle(merchantName))
+      }
+      if let sectionLabel = normalizedNonempty(sectionLabel) {
+        metadata["section_label"] = .string(sectionLabel)
+      }
+      if let normalizedPhone10 = normalizedNonempty(normalizedPhone10) {
+        metadata["normalized_phone_10"] = .string(normalizedPhone10)
+      }
+      if let normalizedFullAddress = normalizedNonempty(
+        normalizedFullAddress
+      ) {
+        metadata["normalized_full_address"] = .string(normalizedFullAddress)
+      }
+      if let normalizedURL = normalizedNonempty(normalizedURL) {
+        metadata["normalized_url"] = .string(normalizedURL)
+      }
+      return ReceiptChromaRowRecord(
+        id: id,
+        document: row.text,
+        embeddingInput: row.embeddingInput,
+        metadata: metadata
+      )
+    }
+
+    private static func normalizedNonempty(_ value: String?) -> String? {
+      let result = value?.trimmingCharacters(in: .whitespacesAndNewlines)
+      return result?.isEmpty == false ? result : nil
+    }
+
+    private static func pythonTitle(_ value: String) -> String {
+      var result = ""
+      var previousWasCased = false
+      for character in value {
+        let isCased = character.isLetter
+        if isCased {
+          result +=
+            previousWasCased
+            ? String(character).lowercased()
+            : String(character).uppercased()
+        } else {
+          result.append(character)
+        }
+        previousWasCased = isCased
+      }
+      return result
+    }
+  }
+
+  /// Read-only Chroma neighbor adapter with server and client self-exclusion.
+  public struct ChromaRowNeighborQuery: ReceiptNeighborQuerying {
+    private let client: ChromaClient
+    private let collectionName: String
+
+    public init(client: ChromaClient, collectionName: String = "lines") {
+      self.client = client
+      self.collectionName = collectionName
+    }
+
+    public func queryRows(
+      embeddings: [[Double]],
+      excluding reference: ReceiptReference,
+      nResults: Int
+    ) async throws -> [[SectionNeighbor]] {
+      guard !embeddings.isEmpty else { return [] }
+      for vector in embeddings
+      where vector.count != ReceiptUnderstandingConstants.embeddingDimensions {
+        throw ReceiptEmbeddingError.invalidConfiguration(
+          "Chroma query vector dimension \(vector.count) does not match "
+            + "\(ReceiptUnderstandingConstants.embeddingDimensions)"
+        )
+      }
+      let collection = try await client.getCollection(collectionName)
+      if let dimension = collection.dimension,
+        dimension != ReceiptUnderstandingConstants.embeddingDimensions
+      {
+        throw ReceiptEmbeddingError.invalidConfiguration(
+          "Chroma collection dimension \(dimension) does not match "
+            + "\(ReceiptUnderstandingConstants.embeddingDimensions)"
+        )
+      }
+      let filter: ChromaFilter = [
+        "$or": .array([
+          .object([
+            "image_id": .object(["$ne": .string(reference.imageID)])
+          ]),
+          .object([
+            "receipt_id": .object([
+              "$ne": .integer(Int64(reference.receiptID))
+            ])
+          ]),
+        ])
+      ]
+      let result = try await client.query(
+        collectionName: collectionName,
+        queryEmbeddings: embeddings,
+        nResults: nResults,
+        where: filter,
+        include: [.embeddings, .metadatas, .documents]
+      )
+
+      return embeddings.indices.map { queryIndex in
+        let ids = item(result.ids, queryIndex) ?? []
+        let metadata = item(result.metadatas, queryIndex) ?? []
+        let documents = item(result.documents, queryIndex) ?? []
+        let neighborEmbeddings = item(result.embeddings, queryIndex) ?? []
+        return ids.indices.compactMap { neighborIndex -> SectionNeighbor? in
+          guard
+            neighborIndex < metadata.count,
+            let metadata = metadata[neighborIndex],
+            let imageID = string(metadata["image_id"]),
+            let receiptID = integer(metadata["receipt_id"]),
+            let lineID = integer(metadata["line_id"]),
+            imageID != reference.imageID || receiptID != reference.receiptID,
+            neighborIndex < neighborEmbeddings.count,
+            let neighborEmbedding = neighborEmbeddings[neighborIndex],
+            neighborEmbedding.count == embeddings[queryIndex].count
+          else { return nil }
+          return SectionNeighbor(
+            reference: ReceiptReference(
+              imageID: imageID,
+              receiptID: receiptID
+            ),
+            lineID: lineID,
+            rowLineIDs: parseRowLineIDs(metadata["row_line_ids"])
+              ?? [lineID],
+            document: neighborIndex < documents.count
+              ? documents[neighborIndex] : nil,
+            cosineSimilarity: cosine(
+              embeddings[queryIndex],
+              neighborEmbedding
+            ),
+            metadataSection: string(metadata["section_label"]),
+            metadataMerchantName: string(metadata["merchant_name"])
+          )
+        }
+      }
+    }
+
+    private func item<T>(_ values: [T]?, _ index: Int) -> T? {
+      guard let values, index < values.count else { return nil }
+      return values[index]
+    }
+
+    private func string(_ value: JSONValue?) -> String? {
+      guard case .string(let result)? = value else { return nil }
+      return result
+    }
+
+    private func integer(_ value: JSONValue?) -> Int? {
+      switch value {
+      case .integer(let result): return Int(result)
+      case .number(let result): return Int(result)
+      default: return nil
+      }
+    }
+
+    private func parseRowLineIDs(_ value: JSONValue?) -> [Int]? {
+      guard case .string(let raw)? = value,
+        let data = raw.data(using: .utf8)
+      else { return nil }
+      return try? JSONDecoder().decode([Int].self, from: data)
+    }
+
+    private func cosine(_ lhs: [Double], _ rhs: [Double]) -> Double {
+      var dot: Float = 0
+      var lhsMagnitude: Float = 0
+      var rhsMagnitude: Float = 0
+      for index in lhs.indices {
+        let left = Float(lhs[index])
+        let right = Float(rhs[index])
+        dot += left * right
+        lhsMagnitude += left * left
+        rhsMagnitude += right * right
+      }
+      let denominator = sqrt(lhsMagnitude) * sqrt(rhsMagnitude) + 1e-8
+      return Double(dot / denominator)
+    }
+  }
+
+#endif

--- a/receipt_ocr_swift/Sources/ReceiptOCRCore/Understanding/GooglePlacesLookup.swift
+++ b/receipt_ocr_swift/Sources/ReceiptOCRCore/Understanding/GooglePlacesLookup.swift
@@ -1,0 +1,197 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+  import FoundationNetworking
+#endif
+
+#if os(macOS)
+
+  /// Conservative adapter for the existing Google Places Text Search service.
+  ///
+  /// It is called only after known-receipt resolution abstains. Google response
+  /// rank alone is never treated as confidence: the returned place must match
+  /// receipt identity fields strongly enough to clear the resolver's 0.8 gate.
+  public struct GooglePlacesLookup: PlacesLookingUp {
+    private struct SearchResponse: Decodable {
+      struct Place: Decodable {
+        struct DisplayName: Decodable {
+          let text: String
+        }
+        let id: String
+        let displayName: DisplayName?
+        let formattedAddress: String?
+        let nationalPhoneNumber: String?
+        let websiteUri: String?
+      }
+      let places: [Place]?
+    }
+
+    private let apiKey: String
+    private let endpoint: URL
+    private let session: URLSession
+
+    public init(
+      apiKey: String,
+      endpoint: URL = URL(
+        string: "https://places.googleapis.com/v1/places:searchText"
+      )!,
+      timeout: TimeInterval = 20
+    ) throws {
+      let key = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+      guard !key.isEmpty else {
+        throw ReceiptEmbeddingError.invalidConfiguration(
+          "Google Places API key must not be blank"
+        )
+      }
+      self.apiKey = key
+      self.endpoint = endpoint
+      let configuration = URLSessionConfiguration.ephemeral
+      configuration.timeoutIntervalForRequest = timeout
+      configuration.timeoutIntervalForResource = timeout
+      self.session = URLSession(configuration: configuration)
+    }
+
+    public func lookup(
+      identity: ReceiptIdentitySignals
+    ) async throws -> PlacesCandidate? {
+      let textQuery =
+        (identity.merchantNames.prefix(1)
+        + identity.addresses.prefix(1)
+        + identity.phoneNumbers.prefix(1)).joined(separator: " ")
+      guard !textQuery.isEmpty else { return nil }
+
+      var request = URLRequest(url: endpoint)
+      request.httpMethod = "POST"
+      request.httpBody = try JSONSerialization.data(
+        withJSONObject: ["textQuery": textQuery]
+      )
+      request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+      request.setValue(apiKey, forHTTPHeaderField: "X-Goog-Api-Key")
+      request.setValue(
+        "places.id,places.displayName,places.formattedAddress,"
+          + "places.nationalPhoneNumber,places.websiteUri",
+        forHTTPHeaderField: "X-Goog-FieldMask"
+      )
+      let (data, response) = try await session.data(for: request)
+      guard let http = response as? HTTPURLResponse,
+        (200..<300).contains(http.statusCode)
+      else {
+        let status = (response as? HTTPURLResponse)?.statusCode ?? -1
+        throw ReceiptEmbeddingError.http(
+          status: status,
+          body: String(data: data, encoding: .utf8) ?? "<invalid response>"
+        )
+      }
+      let places =
+        try JSONDecoder().decode(
+          SearchResponse.self,
+          from: data
+        ).places ?? []
+      let scored = places.compactMap {
+        candidate($0, identity: identity)
+      }.sorted {
+        $0.confidence == $1.confidence
+          ? $0.placeID < $1.placeID : $0.confidence > $1.confidence
+      }
+      guard let top = scored.first, top.confidence >= 0.8 else { return nil }
+      if scored.count > 1,
+        abs(top.confidence - scored[1].confidence) < 0.05
+      {
+        return nil
+      }
+      return top
+    }
+
+    private func candidate(
+      _ place: SearchResponse.Place,
+      identity: ReceiptIdentitySignals
+    ) -> PlacesCandidate? {
+      guard let name = place.displayName?.text, !name.isEmpty else {
+        return nil
+      }
+      var score = 0.0
+      var matched: [String] = []
+      let nameScore =
+        identity.merchantNames.map {
+          tokenSimilarity($0, name)
+        }.max() ?? 0
+      if nameScore >= 0.7 {
+        score += 0.4 * nameScore
+        matched.append("merchant_name")
+      }
+      if let address = place.formattedAddress,
+        identity.addresses.contains(where: {
+          let left = normalize($0)
+          let right = normalize(address)
+          return !left.isEmpty && !right.isEmpty
+            && (left.contains(right) || right.contains(left))
+        })
+      {
+        score += 0.4
+        matched.append("address")
+      }
+      if let phone = place.nationalPhoneNumber,
+        identity.phoneNumbers.contains(where: {
+          let left = phoneDigits($0)
+          let right = phoneDigits(phone)
+          return !left.isEmpty && left == right
+        })
+      {
+        score += 0.6
+        matched.append("phone")
+      }
+      if let website = place.websiteUri,
+        identity.websites.contains(where: {
+          let left = normalizeURL($0)
+          let right = normalizeURL(website)
+          return !left.isEmpty && left == right
+        })
+      {
+        score += 0.5
+        matched.append("website")
+      }
+      return PlacesCandidate(
+        merchantName: name,
+        placeID: place.id,
+        formattedAddress: place.formattedAddress,
+        phoneNumber: place.nationalPhoneNumber,
+        website: place.websiteUri,
+        confidence: min(score, 0.99),
+        matchedFields: matched
+      )
+    }
+
+    private func normalize(_ value: String) -> String {
+      value.lowercased().filter { $0.isLetter || $0.isNumber }
+    }
+
+    private func tokenSimilarity(_ lhs: String, _ rhs: String) -> Double {
+      let left = Set(
+        lhs.lowercased().split(whereSeparator: { !$0.isLetter && !$0.isNumber })
+      )
+      let right = Set(
+        rhs.lowercased().split(whereSeparator: { !$0.isLetter && !$0.isNumber })
+      )
+      guard !left.isEmpty, !right.isEmpty else { return 0 }
+      return Double(left.intersection(right).count)
+        / Double(left.union(right).count)
+    }
+
+    private func phoneDigits(_ value: String) -> String {
+      var digits = String(value.filter(\.isNumber))
+      if digits.count == 11, digits.hasPrefix("1") {
+        digits.removeFirst()
+      }
+      guard digits.count == 10, Set(digits).count > 1 else { return "" }
+      return digits
+    }
+
+    private func normalizeURL(_ value: String) -> String {
+      normalize(value)
+        .replacingOccurrences(of: "https", with: "")
+        .replacingOccurrences(of: "http", with: "")
+        .replacingOccurrences(of: "www", with: "")
+    }
+  }
+
+#endif

--- a/receipt_ocr_swift/Sources/ReceiptOCRCore/Understanding/ReceiptUnderstandingPipeline.swift
+++ b/receipt_ocr_swift/Sources/ReceiptOCRCore/Understanding/ReceiptUnderstandingPipeline.swift
@@ -1,0 +1,765 @@
+import Foundation
+
+#if os(macOS)
+
+  public struct ReceiptIdentityResolver: Sendable {
+    private struct PlaceVote {
+      let evidence: KnownReceiptEvidence
+      var weight: Double
+      var references: Set<ReceiptReference>
+    }
+
+    public init() {}
+
+    public func extractSignals(
+      rows: [VisualReceiptRow]
+    ) -> ReceiptIdentitySignals {
+      var names: [String] = []
+      var addresses: [String] = []
+      var phones: [String] = []
+      var websites: [String] = []
+      for row in rows {
+        let grouped = Dictionary(
+          grouping: row.layoutEvidence.filter { $0.confidence >= 0.5 }
+        ) { Self.baseLabel($0.label) }
+        func phrase(_ label: String) -> String? {
+          let words = grouped[label, default: []].map(\.text)
+          let result = words.joined(separator: " ")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+          return result.isEmpty ? nil : result
+        }
+        if let value = phrase("MERCHANT_NAME") { names.append(value) }
+        if let value = phrase("ADDRESS_LINE") ?? phrase("ADDRESS") {
+          addresses.append(value)
+        }
+        if let value = phrase("PHONE_NUMBER") { phones.append(value) }
+        if let value = phrase("WEBSITE") { websites.append(value) }
+      }
+      return ReceiptIdentitySignals(
+        merchantNames: Self.unique(names),
+        addresses: Self.unique(addresses),
+        phoneNumbers: Self.unique(phones),
+        websites: Self.unique(websites)
+      )
+    }
+
+    public func resolveKnown(
+      identity: ReceiptIdentitySignals,
+      neighbors: [[SectionNeighbor]],
+      knownEvidence: [ReceiptReference: KnownReceiptEvidence]
+    ) -> (resolution: MerchantResolution?, conflict: String?) {
+      // Cap repeated rows from one receipt at its strongest cosine so a long
+      // receipt cannot manufacture consensus with itself.
+      var bestByReference: [ReceiptReference: Double] = [:]
+      for neighbor in neighbors.flatMap({ $0 }) {
+        bestByReference[neighbor.reference] = max(
+          bestByReference[neighbor.reference] ?? 0,
+          max(neighbor.cosineSimilarity, 0)
+        )
+      }
+      var votes: [String: PlaceVote] = [:]
+      for (reference, weight) in bestByReference {
+        guard
+          weight > 0,
+          let known = knownEvidence[reference],
+          known.isHumanValidatedPlace,
+          let placeID = Self.nonempty(known.placeID),
+          let merchantName = Self.nonempty(known.merchantName)
+        else { continue }
+        if var vote = votes[placeID] {
+          vote.weight += weight
+          vote.references.insert(reference)
+          votes[placeID] = vote
+        } else {
+          votes[placeID] = PlaceVote(
+            evidence: known,
+            weight: weight,
+            references: [reference]
+          )
+        }
+        _ = merchantName
+      }
+      let ranked = votes.values.sorted {
+        $0.weight == $1.weight
+          ? ($0.evidence.placeID ?? "") < ($1.evidence.placeID ?? "")
+          : $0.weight > $1.weight
+      }
+      guard let top = ranked.first else { return (nil, nil) }
+      let total = ranked.reduce(0.0) { $0 + $1.weight }
+      let share = top.weight / max(total, 1e-9)
+      if ranked.count > 1, share < 0.72, ranked[1].weight >= 0.5 {
+        return (nil, "known receipt identities disagree")
+      }
+
+      let matches = matchedFields(identity: identity, known: top.evidence)
+      let hasLayoutIdentity =
+        !identity.merchantNames.isEmpty || !identity.addresses.isEmpty
+        || !identity.phoneNumbers.isEmpty || !identity.websites.isEmpty
+      if hasLayoutIdentity, matches.isEmpty {
+        return (nil, "LayoutLM identity conflicts with known receipt identity")
+      }
+      let independentKnownConsensus = top.references.count >= 2
+      let reliable =
+        top.weight >= 0.75 && share >= 0.72
+        && (!matches.isEmpty || independentKnownConsensus)
+      guard reliable else { return (nil, nil) }
+      return (
+        MerchantResolution(
+          merchantName: top.evidence.merchantName,
+          placeID: top.evidence.placeID,
+          formattedAddress: top.evidence.formattedAddress,
+          confidence: min(
+            0.99,
+            0.65 + 0.2 * share + 0.05 * Double(matches.count)
+          ),
+          source: .knownReceipt,
+          matchedFields: matches,
+          evidence: top.references.sorted {
+            $0.imageID == $1.imageID
+              ? $0.receiptID < $1.receiptID
+              : $0.imageID < $1.imageID
+          }.map {
+            "VALID_RECEIPT:\($0.imageID):\($0.receiptID)"
+          }
+        ),
+        nil
+      )
+    }
+
+    public func resolvePlaces(
+      identity: ReceiptIdentitySignals,
+      candidate: PlacesCandidate?
+    ) -> MerchantResolution {
+      guard let candidate, candidate.confidence >= 0.8 else {
+        return .abstained("no reliable known receipt or Places match")
+      }
+      return MerchantResolution(
+        merchantName: candidate.merchantName,
+        placeID: candidate.placeID,
+        formattedAddress: candidate.formattedAddress,
+        confidence: candidate.confidence,
+        source: .places,
+        matchedFields: candidate.matchedFields,
+        evidence: ["EXTERNAL_PLACES_LOOKUP"]
+      )
+    }
+
+    private func matchedFields(
+      identity: ReceiptIdentitySignals,
+      known: KnownReceiptEvidence
+    ) -> [String] {
+      var fields: [String] = []
+      if let knownName = Self.nonempty(known.merchantName),
+        identity.merchantNames.contains(where: {
+          Self.nameSimilarity($0, knownName) >= 0.7
+        })
+      {
+        fields.append("merchant_name")
+      }
+      if let knownAddress = Self.nonempty(known.formattedAddress),
+        identity.addresses.contains(where: {
+          let observed = Self.normalized($0)
+          let expected = Self.normalized(knownAddress)
+          return !observed.isEmpty && !expected.isEmpty
+            && (observed.contains(expected) || expected.contains(observed))
+        })
+      {
+        fields.append("address")
+      }
+      if let knownPhone = Self.nonempty(known.phoneNumber),
+        identity.phoneNumbers.contains(where: {
+          let observed = Self.phone($0)
+          let expected = Self.phone(knownPhone)
+          return !observed.isEmpty && observed == expected
+        })
+      {
+        fields.append("phone")
+      }
+      if let knownWebsite = Self.nonempty(known.website),
+        identity.websites.contains(where: {
+          let observed = Self.website($0)
+          let expected = Self.website(knownWebsite)
+          return !observed.isEmpty && observed == expected
+        })
+      {
+        fields.append("website")
+      }
+      return fields
+    }
+
+    private static func baseLabel(_ label: String) -> String {
+      let upper = label.uppercased()
+      if upper.hasPrefix("B-") || upper.hasPrefix("I-") {
+        return String(upper.dropFirst(2))
+      }
+      return upper
+    }
+
+    private static func unique(_ values: [String]) -> [String] {
+      var seen: Set<String> = []
+      return values.filter {
+        let key = normalized($0)
+        return !key.isEmpty && seen.insert(key).inserted
+      }
+    }
+
+    private static func nonempty(_ value: String?) -> String? {
+      let result = value?.trimmingCharacters(in: .whitespacesAndNewlines)
+      return result?.isEmpty == false ? result : nil
+    }
+
+    private static func normalized(_ value: String) -> String {
+      let folded = value.folding(
+        options: [.diacriticInsensitive, .caseInsensitive],
+        locale: Locale(identifier: "en_US_POSIX")
+      )
+      let separated = folded.unicodeScalars.reduce(into: "") { result, scalar in
+        result +=
+          CharacterSet.alphanumerics.contains(scalar)
+          ? String(scalar) : " "
+      }
+      return separated.split(separator: " ").map { String($0) }
+        .joined(separator: " ")
+    }
+
+    private static func nameSimilarity(_ lhs: String, _ rhs: String) -> Double {
+      let left = Set(normalized(lhs).split(separator: " ").map(String.init))
+      let right = Set(normalized(rhs).split(separator: " ").map(String.init))
+      guard !left.isEmpty, !right.isEmpty else { return 0 }
+      return Double(left.intersection(right).count)
+        / Double(left.union(right).count)
+    }
+
+    private static func phone(_ value: String) -> String {
+      var digits = String(value.filter(\.isNumber))
+      if digits.count == 11, digits.hasPrefix("1") {
+        digits.removeFirst()
+      }
+      guard digits.count == 10, Set(digits).count > 1 else { return "" }
+      return digits
+    }
+
+    private static func website(_ value: String) -> String {
+      var result = normalized(value).replacingOccurrences(of: " ", with: "")
+      for prefix in ["https", "http", "www"] where result.hasPrefix(prefix) {
+        result.removeFirst(prefix.count)
+      }
+      return result
+    }
+  }
+
+  public struct ReceiptConsistencyChecker: Sendable {
+    public init() {}
+
+    public func check(
+      rows: [VisualReceiptRow],
+      sections: [SectionAssignment],
+      merchant: MerchantResolution
+    ) -> [ConsistencyIssue] {
+      let sectionByRow = Dictionary(
+        uniqueKeysWithValues: sections.map { ($0.rowID, $0.sectionType) }
+      )
+      var issues: [ConsistencyIssue] = []
+      for row in rows {
+        guard let section = sectionByRow[row.rowID] else { continue }
+        let labels = Set(
+          row.layoutEvidence.map {
+            baseLabel($0.label)
+          }
+        ).subtracting(["O"])
+        if !labels.isDisjoint(
+          with: ["PRODUCT_NAME", "QUANTITY", "UNIT_PRICE", "LINE_TOTAL"]
+        ), section != "ITEMS" {
+          issues.append(
+            issue(
+              "ITEM_LABEL_OUTSIDE_ITEMS",
+              "Product or item-price labels appear in \(section)",
+              row.rowID
+            )
+          )
+        }
+        if !labels.isDisjoint(with: ["SUBTOTAL", "TAX", "TIP"]),
+          section != "SUMMARY"
+        {
+          issues.append(
+            issue(
+              "SUMMARY_LABEL_OUTSIDE_SUMMARY",
+              "Tax or summary labels appear in \(section)",
+              row.rowID
+            )
+          )
+        }
+        if labels.contains("GRAND_TOTAL"),
+          !["SUMMARY", "TOTAL_LINE"].contains(section)
+        {
+          issues.append(
+            issue(
+              "TOTAL_LABEL_OUTSIDE_SUMMARY",
+              "Grand total label appears in \(section)",
+              row.rowID
+            )
+          )
+        }
+        if !labels.isDisjoint(
+          with: ["PAYMENT_METHOD", "CHANGE", "CASH_BACK", "REFUND"]
+        ), section != "PAYMENT" {
+          issues.append(
+            issue(
+              "PAYMENT_LABEL_OUTSIDE_PAYMENT",
+              "Payment label appears in \(section)",
+              row.rowID
+            )
+          )
+        }
+      }
+      issues.append(contentsOf: sectionOrderIssues(sections))
+      issues.append(contentsOf: arithmeticIssues(rows))
+      if merchant.source == .abstained,
+        let reason = merchant.abstainReason,
+        reason.localizedCaseInsensitiveContains("conflict")
+          || reason.localizedCaseInsensitiveContains("disagree")
+      {
+        issues.append(
+          ConsistencyIssue(
+            code: "MERCHANT_IDENTITY_CONFLICT",
+            severity: .conflict,
+            message: reason
+          )
+        )
+      }
+      return issues
+    }
+
+    private func sectionOrderIssues(
+      _ assignments: [SectionAssignment]
+    ) -> [ConsistencyIssue] {
+      let order = [
+        "STOREFRONT", "ADDRESS", "SECTION_HEADER", "ITEMS", "SUMMARY",
+        "TOTAL_LINE", "PAYMENT", "BARCODE", "SURVEY", "FOOTER",
+      ]
+      let rank = Dictionary(
+        uniqueKeysWithValues: order.enumerated().map { ($1, $0) }
+      )
+      var priorRank = -1
+      for assignment in assignments {
+        guard let current = rank[assignment.sectionType] else { continue }
+        if current < priorRank {
+          return [
+            ConsistencyIssue(
+              code: "SECTION_ORDER_CONFLICT",
+              severity: .conflict,
+              message: "Section order moves backward at \(assignment.sectionType)",
+              rowIDs: [assignment.rowID]
+            )
+          ]
+        }
+        priorRank = current
+      }
+      return []
+    }
+
+    private func arithmeticIssues(
+      _ rows: [VisualReceiptRow]
+    ) -> [ConsistencyIssue] {
+      func values(_ label: String) -> [(Int, Double)] {
+        rows.compactMap { row in
+          guard
+            row.layoutEvidence.contains(where: {
+              baseLabel($0.label) == label
+            }), let value = parseAmount(row.amountText ?? row.text)
+          else { return nil }
+          return (row.rowID, value)
+        }
+      }
+      let subtotals = values("SUBTOTAL")
+      let taxes = values("TAX")
+      let tips = values("TIP")
+      let totals = values("GRAND_TOTAL")
+      guard let subtotal = subtotals.last, let total = totals.last else {
+        return []
+      }
+      let expected =
+        subtotal.1 + taxes.reduce(0) { $0 + $1.1 }
+        + tips.reduce(0) { $0 + $1.1 }
+      guard abs(expected - total.1) > 0.05 else { return [] }
+      return [
+        ConsistencyIssue(
+          code: "RECEIPT_ARITHMETIC_CONFLICT",
+          severity: .conflict,
+          message: String(
+            format: "Subtotal, tax, and tip %.2f do not reconcile to total %.2f",
+            expected,
+            total.1
+          ),
+          rowIDs: [subtotal.0, total.0]
+        )
+      ]
+    }
+
+    private func parseAmount(_ text: String) -> Double? {
+      let expression = try! NSRegularExpression(
+        pattern: #"[-+]?\$?\d[\d,]*\.\d{2}-?"#
+      )
+      let range = NSRange(text.startIndex..., in: text)
+      guard
+        let match = expression.matches(in: text, range: range).last,
+        let swiftRange = Range(match.range, in: text)
+      else {
+        return nil
+      }
+      let raw = String(text[swiftRange])
+      var compact = raw.replacingOccurrences(of: "$", with: "")
+        .replacingOccurrences(of: ",", with: "")
+      let negative = compact.hasSuffix("-")
+      if negative { compact.removeLast() }
+      guard let value = Double(compact) else { return nil }
+      return negative ? -value : value
+    }
+
+    private func baseLabel(_ label: String) -> String {
+      let upper = label.uppercased()
+      return upper.hasPrefix("B-") || upper.hasPrefix("I-")
+        ? String(upper.dropFirst(2)) : upper
+    }
+
+    private func issue(
+      _ code: String,
+      _ message: String,
+      _ rowID: Int
+    ) -> ConsistencyIssue {
+      ConsistencyIssue(
+        code: code,
+        severity: .warning,
+        message: message,
+        rowIDs: [rowID]
+      )
+    }
+  }
+
+  public struct ReceiptCandidateBuilder: Sendable {
+    public init() {}
+
+    public func build(
+      reference: ReceiptReference,
+      sections: [SectionAssignment],
+      merchant: MerchantResolution,
+      issues: [ConsistencyIssue],
+      forceNeedsReview: Bool = false
+    ) -> [CandidateWrite] {
+      let hasIssue = !issues.isEmpty
+      var result: [CandidateWrite] = []
+      let grouped = Dictionary(grouping: sections, by: \.sectionType)
+      for sectionType in grouped.keys.sorted() {
+        let assignments = grouped[sectionType]!
+        let confidence =
+          assignments.reduce(0.0) {
+            $0 + $1.confidence
+          } / Double(assignments.count)
+        let status: CandidateValidationStatus =
+          hasIssue || forceNeedsReview
+            || confidence
+              < ReceiptUnderstandingConstants.minimumSectionCandidateConfidence
+          ? .needsReview : .pending
+        var provenance = [
+          ReceiptUnderstandingConstants.sectionModelSource,
+          ReceiptUnderstandingConstants.modelVersion,
+        ]
+        if assignments.contains(where: { $0.neighborCount > 0 }) {
+          provenance.append("chroma_cosine_valid_sections")
+        }
+        if forceNeedsReview {
+          provenance.append("offline_fallback")
+        }
+        result.append(
+          CandidateWrite(
+            entityType: .section,
+            idempotencyKey:
+              "IMAGE#\(reference.imageID)#RECEIPT#"
+              + String(format: "%05d", reference.receiptID)
+              + "#SECTION#\(sectionType)",
+            validationStatus: status,
+            confidence: confidence,
+            provenance: provenance,
+            sectionType: sectionType,
+            lineIDs: assignments.flatMap(\.lineIDs),
+            rowIDs: assignments.map(\.rowID),
+            evidence: issues.map(\.code)
+          )
+        )
+      }
+      if merchant.source != .abstained,
+        let merchantName = merchant.merchantName,
+        let placeID = merchant.placeID
+      {
+        var provenance = [
+          merchant.source.rawValue,
+          ReceiptUnderstandingConstants.modelVersion,
+        ]
+        if forceNeedsReview {
+          provenance.append("offline_fallback")
+        }
+        result.append(
+          CandidateWrite(
+            entityType: .place,
+            idempotencyKey:
+              "IMAGE#\(reference.imageID)#RECEIPT#"
+              + String(format: "%05d", reference.receiptID) + "#PLACE",
+            validationStatus:
+              hasIssue || forceNeedsReview || merchant.confidence < 0.8
+              ? .needsReview : .pending,
+            confidence: merchant.confidence,
+            provenance: provenance,
+            merchantName: merchantName,
+            placeID: placeID,
+            evidence: merchant.evidence + issues.map(\.code)
+          )
+        )
+      }
+      return result
+    }
+  }
+
+  /// Best-effort, shadow-only first-pass receipt understanding pipeline.
+  ///
+  /// No collaborator in this type can execute a production entity write.
+  /// Candidate payloads are returned for parity comparison and remain PENDING or
+  /// NEEDS_REVIEW.
+  public struct ReceiptUnderstandingPipeline: ReceiptUnderstandingAnalyzing {
+    private let rowBuilder: VisualRowBuilder
+    private let embedder: (any RowEmbeddingProviding)?
+    private let neighborQuery: (any ReceiptNeighborQuerying)?
+    private let knownEvidenceProvider: (any KnownReceiptEvidenceProviding)?
+    private let places: (any PlacesLookingUp)?
+    private let sectionDecoder: DeterministicSectionDecoder
+    private let identityResolver: ReceiptIdentityResolver
+    private let consistencyChecker: ReceiptConsistencyChecker
+    private let candidateBuilder: ReceiptCandidateBuilder
+
+    public init(
+      priorURL: URL,
+      embedder: (any RowEmbeddingProviding)? = nil,
+      neighborQuery: (any ReceiptNeighborQuerying)? = nil,
+      knownEvidenceProvider: (any KnownReceiptEvidenceProviding)? = nil,
+      places: (any PlacesLookingUp)? = nil
+    ) throws {
+      self.rowBuilder = VisualRowBuilder()
+      self.embedder = embedder
+      self.neighborQuery = neighborQuery
+      self.knownEvidenceProvider = knownEvidenceProvider
+      self.places = places
+      self.sectionDecoder = try DeterministicSectionDecoder(
+        priorURL: priorURL
+      )
+      self.identityResolver = ReceiptIdentityResolver()
+      self.consistencyChecker = ReceiptConsistencyChecker()
+      self.candidateBuilder = ReceiptCandidateBuilder()
+    }
+
+    public func analyze(
+      reference: ReceiptReference,
+      lines: [Line],
+      predictions: [LinePrediction]
+    ) async -> ReceiptUnderstandingReport {
+      let totalStart = DispatchTime.now().uptimeNanoseconds
+      var timings: [StageTiming] = []
+      var errors: [String] = []
+      var offline = false
+
+      let rows = measure("row_construction", timings: &timings) {
+        rowBuilder.build(lines: lines, predictions: predictions)
+      }
+      let identity = measure("identity_extraction", timings: &timings) {
+        identityResolver.extractSignals(rows: rows)
+      }
+
+      var embeddings: [[Double]] = []
+      let embeddingStart = DispatchTime.now().uptimeNanoseconds
+      if let embedder {
+        do {
+          embeddings = try await embedder.embedRows(
+            rows.map(\.embeddingInput)
+          )
+          if embeddings.count != rows.count
+            || embeddings.contains(where: {
+              $0.count != ReceiptUnderstandingConstants.embeddingDimensions
+            })
+          {
+            offline = true
+            errors.append(
+              "openai_embeddings: missing or dimension-mismatched vectors"
+            )
+            embeddings = []
+          }
+        } catch {
+          offline = true
+          errors.append("openai_embeddings: \(error.localizedDescription)")
+        }
+      } else {
+        offline = true
+        errors.append("openai_embeddings: unavailable")
+      }
+      timings.append(timing("openai_embeddings", since: embeddingStart))
+
+      var neighbors: [[SectionNeighbor]] = []
+      let chromaStart = DispatchTime.now().uptimeNanoseconds
+      if embeddings.count == rows.count, let neighborQuery {
+        do {
+          neighbors = try await neighborQuery.queryRows(
+            embeddings: embeddings,
+            excluding: reference,
+            nResults: ReceiptUnderstandingConstants.sectionNeighborCount
+          )
+        } catch {
+          offline = true
+          errors.append("chroma_query: \(error.localizedDescription)")
+        }
+      } else if !rows.isEmpty {
+        offline = true
+        errors.append("chroma_query: unavailable")
+      }
+      timings.append(timing("chroma_query", since: chromaStart))
+
+      var known: [ReceiptReference: KnownReceiptEvidence] = [:]
+      var strongestByReference: [ReceiptReference: Double] = [:]
+      for neighbor in neighbors.flatMap({ $0 }) {
+        strongestByReference[neighbor.reference] = max(
+          strongestByReference[neighbor.reference] ?? 0,
+          neighbor.cosineSimilarity
+        )
+      }
+      let references = Set(
+        strongestByReference.sorted {
+          if $0.value != $1.value { return $0.value > $1.value }
+          if $0.key.imageID != $1.key.imageID {
+            return $0.key.imageID < $1.key.imageID
+          }
+          return $0.key.receiptID < $1.key.receiptID
+        }.prefix(ReceiptUnderstandingConstants.maximumKnownReceiptReferences)
+          .map(\.key)
+      )
+      let evidenceNeighbors = neighbors.map { rowNeighbors in
+        rowNeighbors.filter { references.contains($0.reference) }
+      }
+      let knownStart = DispatchTime.now().uptimeNanoseconds
+      if !references.isEmpty, let knownEvidenceProvider {
+        do {
+          known = try await knownEvidenceProvider.evidence(for: references)
+        } catch {
+          offline = true
+          errors.append("known_receipts: \(error.localizedDescription)")
+        }
+      } else if !references.isEmpty {
+        offline = true
+        errors.append("known_receipts: unavailable")
+      }
+      timings.append(timing("known_receipts", since: knownStart))
+
+      let resolutionStart = DispatchTime.now().uptimeNanoseconds
+      let knownResolution = identityResolver.resolveKnown(
+        identity: identity,
+        neighbors: evidenceNeighbors,
+        knownEvidence: known
+      )
+      let merchant: MerchantResolution
+      var placesMilliseconds = 0.0
+      if let conflict = knownResolution.conflict {
+        merchant = .abstained(conflict)
+      } else if let resolved = knownResolution.resolution {
+        merchant = resolved
+      } else if let places,
+        !identity.merchantNames.isEmpty || !identity.addresses.isEmpty
+          || !identity.phoneNumbers.isEmpty || !identity.websites.isEmpty
+      {
+        let placesStart = DispatchTime.now().uptimeNanoseconds
+        do {
+          merchant = identityResolver.resolvePlaces(
+            identity: identity,
+            candidate: try await places.lookup(identity: identity)
+          )
+        } catch {
+          offline = true
+          errors.append("places_lookup: \(error.localizedDescription)")
+          merchant = .abstained("Places lookup failed")
+        }
+        placesMilliseconds = milliseconds(since: placesStart)
+      } else if !identity.merchantNames.isEmpty || !identity.addresses.isEmpty
+        || !identity.phoneNumbers.isEmpty || !identity.websites.isEmpty
+      {
+        offline = true
+        errors.append("places_lookup: unavailable")
+        merchant = .abstained("Places lookup unavailable")
+      } else {
+        merchant = .abstained("insufficient identity evidence")
+      }
+      timings.append(
+        StageTiming(
+          stage: "places_lookup",
+          milliseconds: placesMilliseconds
+        )
+      )
+      timings.append(timing("merchant_resolution", since: resolutionStart))
+
+      let sections = measure("section_decoder", timings: &timings) {
+        sectionDecoder.assign(
+          rows: rows,
+          merchantName: merchant.merchantName,
+          neighbors: evidenceNeighbors,
+          knownEvidence: known
+        )
+      }
+      let issues = measure("consistency_checks", timings: &timings) {
+        consistencyChecker.check(
+          rows: rows,
+          sections: sections,
+          merchant: merchant
+        )
+      }
+      let candidates = measure("candidate_payloads", timings: &timings) {
+        candidateBuilder.build(
+          reference: reference,
+          sections: sections,
+          merchant: merchant,
+          issues: issues,
+          forceNeedsReview: offline
+        )
+      }
+      let total = milliseconds(since: totalStart)
+      return ReceiptUnderstandingReport(
+        reference: reference,
+        rows: rows,
+        identitySignals: identity,
+        merchantResolution: merchant,
+        sections: sections,
+        consistencyIssues: issues,
+        candidates: candidates,
+        timings: timings,
+        totalMilliseconds: total,
+        offlineFallback: offline,
+        errors: errors
+      )
+    }
+
+    private func measure<T>(
+      _ name: String,
+      timings: inout [StageTiming],
+      operation: () -> T
+    ) -> T {
+      let start = DispatchTime.now().uptimeNanoseconds
+      let result = operation()
+      timings.append(timing(name, since: start))
+      return result
+    }
+
+    private func timing(
+      _ stage: String,
+      since start: UInt64
+    ) -> StageTiming {
+      StageTiming(stage: stage, milliseconds: milliseconds(since: start))
+    }
+
+    private func milliseconds(since start: UInt64) -> Double {
+      Double(DispatchTime.now().uptimeNanoseconds - start) / 1_000_000
+    }
+  }
+
+#endif

--- a/receipt_ocr_swift/Sources/ReceiptOCRCore/Understanding/UnderstandingModels.swift
+++ b/receipt_ocr_swift/Sources/ReceiptOCRCore/Understanding/UnderstandingModels.swift
@@ -1,0 +1,461 @@
+import Foundation
+
+#if os(macOS)
+
+  public enum ReceiptUnderstandingConstants {
+    public static let schemaVersion = 1
+    public static let groupingVersion = "visual-rows-v1"
+    public static let modelVersion = "swift-receipt-understanding-shadow-v1"
+    public static let embeddingModel = "text-embedding-3-small"
+    public static let embeddingDimensions = 1_536
+    public static let sectionModelSource = "upload-determinism-v1"
+    public static let sectionNeighborCount = 15
+    public static let maximumKnownReceiptReferences = 15
+    public static let embeddingKNNWeight = 1.0
+    public static let minimumSectionCandidateConfidence = 0.6
+  }
+
+  public struct ReceiptReference: Codable, Equatable, Hashable, Sendable {
+    public let imageID: String
+    public let receiptID: Int
+
+    public init(imageID: String, receiptID: Int) {
+      self.imageID = imageID
+      self.receiptID = receiptID
+    }
+  }
+
+  public struct VisualRowBounds: Codable, Equatable, Sendable {
+    public let xMin: Double
+    public let yMin: Double
+    public let xMax: Double
+    public let yMax: Double
+
+    public init(xMin: Double, yMin: Double, xMax: Double, yMax: Double) {
+      self.xMin = xMin
+      self.yMin = yMin
+      self.xMax = xMax
+      self.yMax = yMax
+    }
+  }
+
+  public struct LayoutWordEvidence: Codable, Equatable, Sendable {
+    public let lineID: Int
+    public let wordID: Int
+    public let text: String
+    public let label: String
+    public let confidence: Double
+
+    public init(
+      lineID: Int,
+      wordID: Int,
+      text: String,
+      label: String,
+      confidence: Double
+    ) {
+      self.lineID = lineID
+      self.wordID = wordID
+      self.text = text
+      self.label = label
+      self.confidence = confidence
+    }
+  }
+
+  public struct VisualReceiptRow: Codable, Equatable, Sendable {
+    public let rowID: Int
+    public let lineIDs: [Int]
+    public let text: String
+    public let embeddingInput: String
+    public let bounds: VisualRowBounds
+    public let priceColumnX: Double?
+    public let labelText: String?
+    public let amountText: String?
+    public let layoutEvidence: [LayoutWordEvidence]
+
+    public init(
+      rowID: Int,
+      lineIDs: [Int],
+      text: String,
+      embeddingInput: String,
+      bounds: VisualRowBounds,
+      priceColumnX: Double? = nil,
+      labelText: String? = nil,
+      amountText: String? = nil,
+      layoutEvidence: [LayoutWordEvidence] = []
+    ) {
+      self.rowID = rowID
+      self.lineIDs = lineIDs
+      self.text = text
+      self.embeddingInput = embeddingInput
+      self.bounds = bounds
+      self.priceColumnX = priceColumnX
+      self.labelText = labelText
+      self.amountText = amountText
+      self.layoutEvidence = layoutEvidence
+    }
+  }
+
+  public struct SectionNeighbor: Codable, Equatable, Sendable {
+    public let reference: ReceiptReference
+    public let lineID: Int
+    public let rowLineIDs: [Int]
+    public let document: String?
+    public let cosineSimilarity: Double
+    public let metadataSection: String?
+    public let metadataMerchantName: String?
+
+    public init(
+      reference: ReceiptReference,
+      lineID: Int,
+      rowLineIDs: [Int],
+      document: String?,
+      cosineSimilarity: Double,
+      metadataSection: String?,
+      metadataMerchantName: String?
+    ) {
+      self.reference = reference
+      self.lineID = lineID
+      self.rowLineIDs = rowLineIDs
+      self.document = document
+      self.cosineSimilarity = cosineSimilarity
+      self.metadataSection = metadataSection
+      self.metadataMerchantName = metadataMerchantName
+    }
+  }
+
+  public struct KnownReceiptEvidence: Codable, Equatable, Sendable {
+    public let reference: ReceiptReference
+    public let placeID: String?
+    public let merchantName: String?
+    public let formattedAddress: String?
+    public let phoneNumber: String?
+    public let website: String?
+    public let placeValidationStatus: String?
+    public let placeConfidence: Double?
+    public let validSectionByLine: [Int: String]
+
+    public init(
+      reference: ReceiptReference,
+      placeID: String? = nil,
+      merchantName: String? = nil,
+      formattedAddress: String? = nil,
+      phoneNumber: String? = nil,
+      website: String? = nil,
+      placeValidationStatus: String? = nil,
+      placeConfidence: Double? = nil,
+      validSectionByLine: [Int: String] = [:]
+    ) {
+      self.reference = reference
+      self.placeID = placeID
+      self.merchantName = merchantName
+      self.formattedAddress = formattedAddress
+      self.phoneNumber = phoneNumber
+      self.website = website
+      self.placeValidationStatus = placeValidationStatus
+      self.placeConfidence = placeConfidence
+      self.validSectionByLine = validSectionByLine
+    }
+
+    public var isHumanValidatedPlace: Bool {
+      let status = placeValidationStatus?
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+        .uppercased()
+      return status == "MATCHED" && (placeConfidence ?? 0) >= 0.8
+    }
+  }
+
+  public struct ReceiptIdentitySignals: Codable, Equatable, Sendable {
+    public let merchantNames: [String]
+    public let addresses: [String]
+    public let phoneNumbers: [String]
+    public let websites: [String]
+
+    public init(
+      merchantNames: [String] = [],
+      addresses: [String] = [],
+      phoneNumbers: [String] = [],
+      websites: [String] = []
+    ) {
+      self.merchantNames = merchantNames
+      self.addresses = addresses
+      self.phoneNumbers = phoneNumbers
+      self.websites = websites
+    }
+  }
+
+  public enum MerchantResolutionSource: String, Codable, Sendable {
+    case knownReceipt = "KNOWN_RECEIPT"
+    case places = "PLACES"
+    case abstained = "ABSTAINED"
+  }
+
+  public struct MerchantResolution: Codable, Equatable, Sendable {
+    public let merchantName: String?
+    public let placeID: String?
+    public let formattedAddress: String?
+    public let confidence: Double
+    public let source: MerchantResolutionSource
+    public let matchedFields: [String]
+    public let evidence: [String]
+    public let abstainReason: String?
+
+    public init(
+      merchantName: String?,
+      placeID: String?,
+      formattedAddress: String?,
+      confidence: Double,
+      source: MerchantResolutionSource,
+      matchedFields: [String] = [],
+      evidence: [String] = [],
+      abstainReason: String? = nil
+    ) {
+      self.merchantName = merchantName
+      self.placeID = placeID
+      self.formattedAddress = formattedAddress
+      self.confidence = confidence
+      self.source = source
+      self.matchedFields = matchedFields
+      self.evidence = evidence
+      self.abstainReason = abstainReason
+    }
+
+    public static func abstained(_ reason: String) -> MerchantResolution {
+      MerchantResolution(
+        merchantName: nil,
+        placeID: nil,
+        formattedAddress: nil,
+        confidence: 0,
+        source: .abstained,
+        abstainReason: reason
+      )
+    }
+  }
+
+  public struct PlacesCandidate: Codable, Equatable, Sendable {
+    public let merchantName: String
+    public let placeID: String
+    public let formattedAddress: String?
+    public let phoneNumber: String?
+    public let website: String?
+    public let confidence: Double
+    public let matchedFields: [String]
+
+    public init(
+      merchantName: String,
+      placeID: String,
+      formattedAddress: String? = nil,
+      phoneNumber: String? = nil,
+      website: String? = nil,
+      confidence: Double,
+      matchedFields: [String] = []
+    ) {
+      self.merchantName = merchantName
+      self.placeID = placeID
+      self.formattedAddress = formattedAddress
+      self.phoneNumber = phoneNumber
+      self.website = website
+      self.confidence = confidence
+      self.matchedFields = matchedFields
+    }
+  }
+
+  public struct SectionAssignment: Codable, Equatable, Sendable {
+    public let rowID: Int
+    public let lineIDs: [Int]
+    public let sectionType: String
+    public let confidence: Double
+    public let neighborConfidence: Double?
+    public let neighborCount: Int
+
+    public init(
+      rowID: Int,
+      lineIDs: [Int],
+      sectionType: String,
+      confidence: Double,
+      neighborConfidence: Double? = nil,
+      neighborCount: Int = 0
+    ) {
+      self.rowID = rowID
+      self.lineIDs = lineIDs
+      self.sectionType = sectionType
+      self.confidence = confidence
+      self.neighborConfidence = neighborConfidence
+      self.neighborCount = neighborCount
+    }
+  }
+
+  public enum ConsistencySeverity: String, Codable, Sendable {
+    case warning = "WARNING"
+    case conflict = "CONFLICT"
+  }
+
+  public struct ConsistencyIssue: Codable, Equatable, Sendable {
+    public let code: String
+    public let severity: ConsistencySeverity
+    public let message: String
+    public let rowIDs: [Int]
+
+    public init(
+      code: String,
+      severity: ConsistencySeverity,
+      message: String,
+      rowIDs: [Int] = []
+    ) {
+      self.code = code
+      self.severity = severity
+      self.message = message
+      self.rowIDs = rowIDs
+    }
+  }
+
+  public enum CandidateValidationStatus: String, Codable, Sendable {
+    case pending = "PENDING"
+    case needsReview = "NEEDS_REVIEW"
+  }
+
+  public enum CandidateEntityType: String, Codable, Sendable {
+    case section = "RECEIPT_SECTION"
+    case place = "RECEIPT_PLACE"
+  }
+
+  public struct CandidateWrite: Codable, Equatable, Sendable {
+    public let entityType: CandidateEntityType
+    public let idempotencyKey: String
+    public let conditionExpression: String
+    public let validationStatus: CandidateValidationStatus
+    public let confidence: Double
+    public let modelVersion: String
+    public let provenance: [String]
+    public let sectionType: String?
+    public let lineIDs: [Int]
+    public let rowIDs: [Int]
+    public let merchantName: String?
+    public let placeID: String?
+    public let evidence: [String]
+
+    public init(
+      entityType: CandidateEntityType,
+      idempotencyKey: String,
+      conditionExpression: String =
+        "attribute_not_exists(PK) AND attribute_not_exists(SK)",
+      validationStatus: CandidateValidationStatus,
+      confidence: Double,
+      modelVersion: String = ReceiptUnderstandingConstants.modelVersion,
+      provenance: [String],
+      sectionType: String? = nil,
+      lineIDs: [Int] = [],
+      rowIDs: [Int] = [],
+      merchantName: String? = nil,
+      placeID: String? = nil,
+      evidence: [String] = []
+    ) {
+      self.entityType = entityType
+      self.idempotencyKey = idempotencyKey
+      self.conditionExpression = conditionExpression
+      self.validationStatus = validationStatus
+      self.confidence = confidence
+      self.modelVersion = modelVersion
+      self.provenance = provenance
+      self.sectionType = sectionType
+      self.lineIDs = lineIDs
+      self.rowIDs = rowIDs
+      self.merchantName = merchantName
+      self.placeID = placeID
+      self.evidence = evidence
+    }
+  }
+
+  public struct StageTiming: Codable, Equatable, Sendable {
+    public let stage: String
+    public let milliseconds: Double
+
+    public init(stage: String, milliseconds: Double) {
+      self.stage = stage
+      self.milliseconds = milliseconds
+    }
+  }
+
+  public struct ReceiptUnderstandingReport: Codable, Equatable, Sendable {
+    public let schemaVersion: Int
+    public let mode: String
+    public let reference: ReceiptReference
+    public let modelVersion: String
+    public let groupingVersion: String
+    public let embeddingModel: String
+    public let embeddingDimensions: Int
+    public let rows: [VisualReceiptRow]
+    public let identitySignals: ReceiptIdentitySignals
+    public let merchantResolution: MerchantResolution
+    public let sections: [SectionAssignment]
+    public let consistencyIssues: [ConsistencyIssue]
+    public let candidates: [CandidateWrite]
+    public let timings: [StageTiming]
+    public let totalMilliseconds: Double
+    public let offlineFallback: Bool
+    public let errors: [String]
+
+    public init(
+      reference: ReceiptReference,
+      rows: [VisualReceiptRow],
+      identitySignals: ReceiptIdentitySignals,
+      merchantResolution: MerchantResolution,
+      sections: [SectionAssignment],
+      consistencyIssues: [ConsistencyIssue],
+      candidates: [CandidateWrite],
+      timings: [StageTiming],
+      totalMilliseconds: Double,
+      offlineFallback: Bool,
+      errors: [String]
+    ) {
+      self.schemaVersion = ReceiptUnderstandingConstants.schemaVersion
+      self.mode = "SHADOW"
+      self.reference = reference
+      self.modelVersion = ReceiptUnderstandingConstants.modelVersion
+      self.groupingVersion = ReceiptUnderstandingConstants.groupingVersion
+      self.embeddingModel = ReceiptUnderstandingConstants.embeddingModel
+      self.embeddingDimensions =
+        ReceiptUnderstandingConstants.embeddingDimensions
+      self.rows = rows
+      self.identitySignals = identitySignals
+      self.merchantResolution = merchantResolution
+      self.sections = sections
+      self.consistencyIssues = consistencyIssues
+      self.candidates = candidates
+      self.timings = timings
+      self.totalMilliseconds = totalMilliseconds
+      self.offlineFallback = offlineFallback
+      self.errors = errors
+    }
+  }
+
+  public protocol RowEmbeddingProviding: Sendable {
+    func embedRows(_ inputs: [String]) async throws -> [[Double]]
+  }
+
+  public protocol ReceiptNeighborQuerying: Sendable {
+    func queryRows(
+      embeddings: [[Double]],
+      excluding reference: ReceiptReference,
+      nResults: Int
+    ) async throws -> [[SectionNeighbor]]
+  }
+
+  public protocol KnownReceiptEvidenceProviding: Sendable {
+    func evidence(
+      for references: Set<ReceiptReference>
+    ) async throws -> [ReceiptReference: KnownReceiptEvidence]
+  }
+
+  public protocol PlacesLookingUp: Sendable {
+    func lookup(identity: ReceiptIdentitySignals) async throws -> PlacesCandidate?
+  }
+
+  public protocol ReceiptUnderstandingAnalyzing: Sendable {
+    func analyze(
+      reference: ReceiptReference,
+      lines: [Line],
+      predictions: [LinePrediction]
+    ) async -> ReceiptUnderstandingReport
+  }
+
+#endif

--- a/receipt_ocr_swift/Sources/ReceiptOCRCore/Understanding/VisualRowBuilder.swift
+++ b/receipt_ocr_swift/Sources/ReceiptOCRCore/Understanding/VisualRowBuilder.swift
@@ -1,0 +1,365 @@
+import Foundation
+
+#if os(macOS)
+
+  /// Builds the same visual rows and row-embedding text as the Python upload
+  /// pipeline.
+  ///
+  /// Apple Vision can emit the label and amount on one printed row as separate
+  /// ``Line`` values. The canonical Python implementation joins those values
+  /// using inclusive centroid overlap and union-find connected components. This
+  /// type intentionally mirrors that behavior so shadow understanding keeps the
+  /// same row identity as the persisted `ReceiptRow` entities.
+  public struct VisualRowBuilder: Sendable {
+    private struct IndexedLine {
+      let index: Int
+      let lineID: Int
+      let line: Line
+    }
+
+    private struct IndexedWord {
+      let lineID: Int
+      let wordID: Int
+      let word: Word
+    }
+
+    private struct PriceColumn {
+      let x: Double
+      let tolerance: Double
+    }
+
+    private struct LabelAmountPair {
+      let labelText: String
+      let amountText: String
+    }
+
+    private struct RowDraft {
+      let lines: [IndexedLine]
+      let text: String
+      let bounds: VisualRowBounds
+      let pair: LabelAmountPair?
+      let layoutEvidence: [LayoutWordEvidence]
+    }
+
+    private struct UnionFind {
+      private var parent: [Int]
+
+      init(count: Int) {
+        parent = Array(0..<count)
+      }
+
+      mutating func find(_ value: Int) -> Int {
+        if parent[value] != value {
+          parent[value] = find(parent[value])
+        }
+        return parent[value]
+      }
+
+      mutating func union(_ first: Int, _ second: Int) {
+        let firstRoot = find(first)
+        let secondRoot = find(second)
+        if firstRoot != secondRoot {
+          // This direction matches line_format.py's `parent[px] = py`.
+          parent[firstRoot] = secondRoot
+        }
+      }
+    }
+
+    private static let amountExpression = try! NSRegularExpression(
+      pattern: #"^(?:\()?[-+]?\$?(?:\d+|\d{1,3}(?:,\d{3})+)\.\d{2}-?(?:\))?$"#
+    )
+
+    public init() {}
+
+    /// Materialize visual rows in top-to-bottom order.
+    ///
+    /// - Parameters:
+    ///   - lines: OCR lines in their original serialized order. Their 1-based
+    ///     array positions remain the canonical line IDs even after row sorting.
+    ///   - predictions: LayoutLM predictions parallel to `lines`. Short or
+    ///     internally uneven prediction arrays are mapped without shifting any
+    ///     later line or word IDs.
+    public func build(
+      lines: [Line],
+      predictions: [LinePrediction] = []
+    ) -> [VisualReceiptRow] {
+      guard !lines.isEmpty else { return [] }
+
+      // The Python Swift-payload parser drops empty lines but never reclaims
+      // their 1-based positions. Filtering after enumeration preserves those
+      // intentional ID gaps.
+      let indexedLines = lines.enumerated().compactMap { index, line in
+        line.text.isEmpty
+          ? nil
+          : IndexedLine(index: index, lineID: index + 1, line: line)
+      }
+      guard !indexedLines.isEmpty else { return [] }
+      let rows = group(indexedLines)
+      let words = indexedLines.flatMap { indexedLine in
+        indexedLine.line.words.enumerated().compactMap {
+          wordIndex, word -> IndexedWord? in
+          // Match `_parse_receipt_ocr_from_swift`: invalid words are omitted,
+          // while their original word IDs remain reserved.
+          guard !word.text.isEmpty, word.confidence > 0 else { return nil }
+          return IndexedWord(
+            lineID: indexedLine.lineID,
+            wordID: wordIndex + 1,
+            word: word
+          )
+        }
+      }
+      let priceColumn = detectPriceColumn(words)
+
+      let drafts = rows.map { row -> RowDraft in
+        let boxes = row.map(\.line.boundingBox)
+        let rowLineIDs = Set(row.map(\.lineID))
+        return RowDraft(
+          lines: row,
+          text: row.map(\.line.text).joined(separator: " "),
+          bounds: VisualRowBounds(
+            xMin: boxes.map { Double($0.x) }.min() ?? 0,
+            yMin: boxes.map { Double($0.y) }.min() ?? 0,
+            xMax: boxes.map { Double($0.x + $0.width) }.max() ?? 0,
+            yMax: boxes.map { Double($0.y + $0.height) }.max() ?? 0
+          ),
+          pair: pairLabelAndAmount(
+            rowLineIDs: rowLineIDs,
+            words: words,
+            priceColumn: priceColumn
+          ),
+          layoutEvidence: layoutEvidence(for: row, predictions: predictions)
+        )
+      }
+
+      return drafts.enumerated().map { index, draft in
+        let above = index > 0 ? drafts[index - 1].text : "<EDGE>"
+        let below =
+          index + 1 < drafts.count
+          ? drafts[index + 1].text
+          : "<EDGE>"
+        return VisualReceiptRow(
+          rowID: draft.lines[0].lineID,
+          lineIDs: draft.lines.map(\.lineID),
+          text: draft.text,
+          embeddingInput: "\(above)\n\(draft.text)\n\(below)",
+          bounds: draft.bounds,
+          priceColumnX: priceColumn?.x,
+          labelText: draft.pair?.labelText,
+          amountText: draft.pair?.amountText,
+          layoutEvidence: draft.layoutEvidence
+        )
+      }
+    }
+
+    private func group(_ lines: [IndexedLine]) -> [[IndexedLine]] {
+      var unionFind = UnionFind(count: lines.count)
+
+      for firstIndex in lines.indices {
+        let firstBox = lines[firstIndex].line.boundingBox
+        let firstMinimumY = Double(firstBox.y)
+        let firstMaximumY = Double(firstBox.y + firstBox.height)
+        let firstCentroidY = firstMinimumY + Double(firstBox.height) / 2
+
+        for secondIndex in lines.indices where secondIndex > firstIndex {
+          let secondBox = lines[secondIndex].line.boundingBox
+          let secondMinimumY = Double(secondBox.y)
+          let secondMaximumY = Double(secondBox.y + secondBox.height)
+          let secondCentroidY =
+            secondMinimumY + Double(secondBox.height) / 2
+
+          let firstCentroidInSecond =
+            secondMinimumY <= firstCentroidY
+            && firstCentroidY <= secondMaximumY
+          let secondCentroidInFirst =
+            firstMinimumY <= secondCentroidY
+            && secondCentroidY <= firstMaximumY
+          if firstCentroidInSecond || secondCentroidInFirst {
+            unionFind.union(firstIndex, secondIndex)
+          }
+        }
+      }
+
+      // Python dictionaries retain the insertion order of the first member seen
+      // for each component. Keep that order explicitly for deterministic ties.
+      var components: [Int: [IndexedLine]] = [:]
+      var componentOrder: [Int] = []
+      for index in lines.indices {
+        let root = unionFind.find(index)
+        if components[root] == nil {
+          components[root] = []
+          componentOrder.append(root)
+        }
+        components[root, default: []].append(lines[index])
+      }
+
+      let orderedComponents = componentOrder.enumerated().map {
+        componentIndex, root -> (Int, [IndexedLine], Double) in
+        let component = (components[root] ?? []).sorted { first, second in
+          let firstX = Double(first.line.boundingBox.x)
+          let secondX = Double(second.line.boundingBox.x)
+          return firstX == secondX ? first.index < second.index : firstX < secondX
+        }
+        let averageY =
+          component.reduce(0.0) {
+            $0 + Double($1.line.boundingBox.y)
+          } / Double(component.count)
+        return (componentIndex, component, averageY)
+      }
+
+      return orderedComponents.sorted { first, second in
+        first.2 == second.2 ? first.0 < second.0 : first.2 > second.2
+      }.map(\.1)
+    }
+
+    private func layoutEvidence(
+      for row: [IndexedLine],
+      predictions: [LinePrediction]
+    ) -> [LayoutWordEvidence] {
+      row.flatMap { indexedLine -> [LayoutWordEvidence] in
+        guard indexedLine.index < predictions.count else { return [] }
+        let prediction = predictions[indexedLine.index]
+        let count = min(
+          prediction.tokens.count,
+          prediction.labels.count,
+          prediction.confidences.count
+        )
+        return (0..<count).map { wordIndex in
+          LayoutWordEvidence(
+            lineID: indexedLine.lineID,
+            wordID: wordIndex + 1,
+            text: prediction.tokens[wordIndex],
+            label: prediction.labels[wordIndex],
+            confidence: Double(prediction.confidences[wordIndex])
+          )
+        }
+      }
+    }
+
+    private func detectPriceColumn(_ words: [IndexedWord]) -> PriceColumn? {
+      let amounts = words.filter { Self.isAmountText($0.word.text) }
+      guard !amounts.isEmpty else { return nil }
+
+      let widths = amounts.compactMap { indexedWord -> Double? in
+        let compact = indexedWord.word.text
+          .trimmingCharacters(in: .whitespacesAndNewlines)
+          .replacingOccurrences(of: " ", with: "")
+        let width =
+          Double(indexedWord.word.boundingBox.width)
+          / Double(max(compact.count, 1))
+        return width == 0 ? nil : width
+      }
+      let tolerance = median(widths) ?? 0
+      let ordered = amounts.enumerated().sorted { first, second in
+        let firstEdge = rightEdge(first.element.word)
+        let secondEdge = rightEdge(second.element.word)
+        return firstEdge == secondEdge
+          ? first.offset < second.offset
+          : firstEdge < secondEdge
+      }.map(\.element)
+
+      var clusters: [[IndexedWord]] = []
+      for word in ordered {
+        if let lastWord = clusters.last?.last,
+          rightEdge(word.word) - rightEdge(lastWord.word) <= tolerance
+        {
+          clusters[clusters.count - 1].append(word)
+        } else {
+          clusters.append([word])
+        }
+      }
+
+      var winner = clusters[0]
+      for cluster in clusters.dropFirst() where isBetter(cluster, than: winner) {
+        winner = cluster
+      }
+      return PriceColumn(
+        x: median(winner.map { rightEdge($0.word) }) ?? 0,
+        tolerance: tolerance
+      )
+    }
+
+    private func isBetter(
+      _ candidate: [IndexedWord],
+      than current: [IndexedWord]
+    ) -> Bool {
+      let candidateKey = (
+        Set(candidate.map(\.lineID)).count,
+        candidate.count,
+        median(candidate.map { rightEdge($0.word) }) ?? 0
+      )
+      let currentKey = (
+        Set(current.map(\.lineID)).count,
+        current.count,
+        median(current.map { rightEdge($0.word) }) ?? 0
+      )
+      if candidateKey.0 != currentKey.0 {
+        return candidateKey.0 > currentKey.0
+      }
+      if candidateKey.1 != currentKey.1 {
+        return candidateKey.1 > currentKey.1
+      }
+      return candidateKey.2 > currentKey.2
+    }
+
+    private func pairLabelAndAmount(
+      rowLineIDs: Set<Int>,
+      words: [IndexedWord],
+      priceColumn: PriceColumn?
+    ) -> LabelAmountPair? {
+      guard let priceColumn else { return nil }
+      let rowWords = words.filter { rowLineIDs.contains($0.lineID) }.sorted {
+        first, second in
+        let firstX = Double(first.word.boundingBox.x)
+        let secondX = Double(second.word.boundingBox.x)
+        if firstX != secondX { return firstX < secondX }
+        if first.lineID != second.lineID { return first.lineID < second.lineID }
+        return first.wordID < second.wordID
+      }
+      let candidates = rowWords.filter {
+        Self.isAmountText($0.word.text)
+          && abs(rightEdge($0.word) - priceColumn.x) <= priceColumn.tolerance
+      }
+      guard var amount = candidates.first else { return nil }
+      for candidate in candidates.dropFirst()
+      where rightEdge(candidate.word) > rightEdge(amount.word) {
+        amount = candidate
+      }
+
+      let amountX = Double(amount.word.boundingBox.x)
+      let labelText = rowWords.filter {
+        rightEdge($0.word) <= amountX && !Self.isAmountText($0.word.text)
+      }.map {
+        $0.word.text.trimmingCharacters(in: .whitespacesAndNewlines)
+      }.joined(separator: " ").trimmingCharacters(in: .whitespacesAndNewlines)
+
+      return LabelAmountPair(
+        labelText: labelText,
+        amountText: amount.word.text
+      )
+    }
+
+    private func rightEdge(_ word: Word) -> Double {
+      Double(word.boundingBox.x + word.boundingBox.width)
+    }
+
+    private func median(_ values: [Double]) -> Double? {
+      guard !values.isEmpty else { return nil }
+      let sorted = values.sorted()
+      let middle = sorted.count / 2
+      if sorted.count.isMultiple(of: 2) {
+        return (sorted[middle - 1] + sorted[middle]) / 2
+      }
+      return sorted[middle]
+    }
+
+    static func isAmountText(_ text: String) -> Bool {
+      let compact =
+        text
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+        .replacingOccurrences(of: " ", with: "")
+      let range = NSRange(compact.startIndex..<compact.endIndex, in: compact)
+      return amountExpression.firstMatch(in: compact, range: range) != nil
+    }
+  }
+
+#endif

--- a/receipt_ocr_swift/Sources/ReceiptOCRCore/Worker/OCRWorker.swift
+++ b/receipt_ocr_swift/Sources/ReceiptOCRCore/Worker/OCRWorker.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Logging
+import ReceiptChroma
 #if os(macOS)
 import AppKit
 import CoreGraphics
@@ -135,6 +136,9 @@ public final class OCRWorker {
     private let sqs: SQSClientProtocol
     private let s3: S3ClientProtocol
     private let dynamo: DynamoClientProtocol
+    #if os(macOS)
+    private var understandingAnalyzer: (any ReceiptUnderstandingAnalyzing)? = nil
+    #endif
     // Hold factory to manage AWSClient lifecycle when using Soto-backed clients
     private let sotoFactory: SotoAWSFactory?
 
@@ -156,6 +160,28 @@ public final class OCRWorker {
         logger.logLevel = .from(string: config.logLevel)
         self.logger = logger
     }
+
+    #if os(macOS)
+    public convenience init(
+        config: Config,
+        ocr: OCREngineProtocol,
+        sqs: SQSClientProtocol,
+        s3: S3ClientProtocol,
+        dynamo: DynamoClientProtocol,
+        sotoFactory: SotoAWSFactory? = nil,
+        understandingAnalyzer: any ReceiptUnderstandingAnalyzing
+    ) {
+        self.init(
+            config: config,
+            ocr: ocr,
+            sqs: sqs,
+            s3: s3,
+            dynamo: dynamo,
+            sotoFactory: sotoFactory
+        )
+        self.understandingAnalyzer = understandingAnalyzer
+    }
+    #endif
 
     public static func make(config: Config, stubOCR: Bool) async throws -> OCRWorker {
         let factory = SotoAWSFactory(config: config)
@@ -195,18 +221,128 @@ public final class OCRWorker {
         let engine: OCREngineProtocol = StubOCREngine()
         #endif
 
-        let worker = OCRWorker(
+        let dynamoClient = SotoDynamoClient(
+            dynamo: factory.makeDynamo(),
+            tableName: config.dynamoTableName
+        )
+        #if os(macOS)
+        do {
+            if let analyzer = try makeShadowUnderstandingAnalyzer(
+                dynamo: dynamoClient,
+                logger: modelLogger
+            ) {
+                return OCRWorker(
+                    config: config,
+                    ocr: engine,
+                    sqs: SotoSQSClient(sqs: factory.makeSQS()),
+                    s3: s3Client,
+                    dynamo: dynamoClient,
+                    sotoFactory: factory,
+                    understandingAnalyzer: analyzer
+                )
+            }
+        } catch {
+            let message =
+                "receipt_understanding_shadow_setup_failed "
+                + "shadow_disabled=true error=\(error)"
+            modelLogger.warning("\(message)")
+        }
+        #endif
+        return OCRWorker(
             config: config,
             ocr: engine,
             sqs: SotoSQSClient(sqs: factory.makeSQS()),
             s3: s3Client,
-            dynamo: SotoDynamoClient(dynamo: factory.makeDynamo(), tableName: config.dynamoTableName),
+            dynamo: dynamoClient,
             sotoFactory: factory
         )
-        return worker
     }
 
     #if os(macOS)
+    private static func makeShadowUnderstandingAnalyzer(
+        dynamo: SotoDynamoClient,
+        logger: Logger
+    ) throws -> (any ReceiptUnderstandingAnalyzing)? {
+        let environment = ProcessInfo.processInfo.environment
+        let enabled = ["1", "true", "yes"].contains(
+            (environment["RECEIPT_UNDERSTANDING_SHADOW"] ?? "").lowercased()
+        )
+        guard enabled else { return nil }
+
+        let explicitPath = environment["RECEIPT_SECTION_PRIOR_PATH"]
+        let workingDirectory = URL(
+            fileURLWithPath: FileManager.default.currentDirectoryPath,
+            isDirectory: true
+        )
+        let candidates = [
+            explicitPath.map { URL(fileURLWithPath: $0) },
+            workingDirectory.appendingPathComponent(
+                "receipt_upload/receipt_upload/assets/"
+                    + "section_order_priors_v2.json"
+            ),
+            workingDirectory.appendingPathComponent(
+                "../receipt_upload/receipt_upload/assets/"
+                    + "section_order_priors_v2.json"
+            )
+        ].compactMap { $0 }
+        guard let priorURL = candidates.first(where: {
+            FileManager.default.fileExists(atPath: $0.path)
+        }) else {
+            throw ConfigError.invalid(
+                "RECEIPT_UNDERSTANDING_SHADOW requires "
+                    + "RECEIPT_SECTION_PRIOR_PATH"
+            )
+        }
+
+        var embedder: (any RowEmbeddingProviding)?
+        if let key = environment["OPENAI_API_KEY"], !key.isEmpty {
+            embedder = try OpenAIRowEmbeddingProvider(apiKey: key)
+        } else {
+            let message =
+                "receipt_understanding_shadow_openai_unavailable "
+                + "offline_fallback=true"
+            logger.warning("\(message)")
+        }
+
+        var neighborQuery: (any ReceiptNeighborQuerying)?
+        let chromaKey = environment["CHROMA_CLOUD_API_KEY"]
+        let chromaTenant = environment["CHROMA_CLOUD_TENANT"]
+        let chromaDatabase = environment["CHROMA_CLOUD_DATABASE"]
+        if let chromaKey, let chromaTenant, let chromaDatabase,
+           !chromaKey.isEmpty, !chromaTenant.isEmpty, !chromaDatabase.isEmpty {
+            let configuration = try ChromaConfiguration(
+                apiKey: chromaKey,
+                tenant: chromaTenant,
+                database: chromaDatabase,
+                mode: .read
+            )
+            neighborQuery = ChromaRowNeighborQuery(
+                client: ChromaClient(configuration: configuration)
+            )
+        } else {
+            let message =
+                "receipt_understanding_shadow_chroma_unavailable "
+                + "offline_fallback=true"
+            logger.warning("\(message)")
+        }
+
+        var places: (any PlacesLookingUp)?
+        if let key = environment["GOOGLE_PLACES_API_KEY"], !key.isEmpty {
+            places = try GooglePlacesLookup(apiKey: key)
+        }
+        let message =
+            "receipt_understanding_shadow_enabled prior=\(priorURL.path) "
+            + "production_writes=false"
+        logger.info("\(message)")
+        return try ReceiptUnderstandingPipeline(
+            priorURL: priorURL,
+            embedder: embedder,
+            neighborQuery: neighborQuery,
+            knownEvidenceProvider: dynamo,
+            places: places
+        )
+    }
+
     private func cropImageData(_ imageData: Data, region: ReOCRRegion) throws -> Data {
         // trigger_reocr always sends full-width (x=0..1) with line-based
         // vertical padding. Use the region directly so crop and overlay
@@ -262,6 +398,9 @@ public final class OCRWorker {
         }
         var imageURLs: [URL] = []
         var contexts: [Context] = []
+        #if os(macOS)
+        var shadowInputs: [(jsonData: Data, imageID: String)] = []
+        #endif
 
         for msg in messages {
             guard let data = msg.body.data(using: .utf8),
@@ -364,6 +503,11 @@ public final class OCRWorker {
             // Parse the OCR result JSON to get receipt info.
             // Regional re-OCR jobs should not upload warped receipt images.
             let jsonData = try Data(contentsOf: resultURL)
+            #if os(macOS)
+            if ctx.jobType == .firstPass {
+                shadowInputs.append((jsonData: jsonData, imageID: ctx.imageId))
+            }
+            #endif
             let receipts: [ParsedReceiptInfo]
             if ctx.jobType == .regionalReocr {
                 receipts = []
@@ -485,7 +629,125 @@ public final class OCRWorker {
         let entries = contexts.map { SQSDeleteEntry(id: $0.message.messageId, receiptHandle: $0.message.receiptHandle) }
         logger.info("sqs_delete_batch count=\(entries.count)")
         try await Retry.withBackoff { try await self.sqs.deleteMessages(queueURL: self.config.ocrJobQueueURL, entries: entries) }
+
+        // Shadow network work starts only after OCR results are durably
+        // published, jobs are completed, and source messages are acknowledged.
+        // Its latency can delay the next poll but cannot expose the current
+        // messages for duplicate production processing.
+        #if os(macOS)
+        await withTaskGroup(of: Void.self) { group in
+            for input in shadowInputs {
+                group.addTask {
+                    await self.runShadowUnderstanding(
+                        jsonData: input.jsonData,
+                        imageID: input.imageID
+                    )
+                }
+            }
+        }
+        #endif
         
         return true
     }
+
+    #if os(macOS)
+    private func runShadowUnderstanding(
+        jsonData: Data,
+        imageID: String
+    ) async {
+        guard let understandingAnalyzer else { return }
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        do {
+            let output = try decoder.decode(ImageResult.self, from: jsonData)
+            for receipt in output.receipts ?? [] {
+                guard let lines = receipt.lines, !lines.isEmpty else { continue }
+                let report = await understandingAnalyzer.analyze(
+                    reference: ReceiptReference(
+                        imageID: imageID,
+                        receiptID: receipt.clusterId
+                    ),
+                    lines: lines,
+                    predictions: receipt.layoutlmPredictions ?? []
+                )
+                let summary =
+                    "receipt_understanding_shadow_complete "
+                    + "image_id=\(imageID) receipt_id=\(receipt.clusterId) "
+                    + "rows=\(report.rows.count) "
+                    + "sections=\(report.sections.count) "
+                    + "candidates=\(report.candidates.count) "
+                    + "issues=\(report.consistencyIssues.count) "
+                    + "offline_fallback=\(report.offlineFallback) "
+                    + "total_ms=\(report.totalMilliseconds)"
+                logger.info("\(summary)")
+                let encoder = JSONEncoder()
+                encoder.outputFormatting = [.sortedKeys]
+                if let data = try? encoder.encode(report) {
+                    do {
+                        if let url = try persistShadowReport(
+                            data,
+                            imageID: imageID,
+                            receiptID: receipt.clusterId
+                        ) {
+                            let reportMessage =
+                                "receipt_understanding_shadow_report_saved "
+                                + "image_id=\(imageID) "
+                                + "receipt_id=\(receipt.clusterId) "
+                                + "path=\(url.path)"
+                            logger.info("\(reportMessage)")
+                        }
+                    } catch {
+                        let reportErrorMessage =
+                            "receipt_understanding_shadow_report_failed "
+                            + "image_id=\(imageID) "
+                            + "receipt_id=\(receipt.clusterId) "
+                            + "error=\(error)"
+                        logger.warning("\(reportErrorMessage)")
+                    }
+                }
+            }
+        } catch {
+            // Understanding is best effort: it must never fail OCR publication,
+            // routing, job completion, or SQS deletion.
+            let message =
+                "receipt_understanding_shadow_failed image_id=\(imageID) "
+                + "error=\(error)"
+            logger.warning("\(message)")
+        }
+    }
+
+    private func persistShadowReport(
+        _ data: Data,
+        imageID: String,
+        receiptID: Int
+    ) throws -> URL? {
+        let environment = ProcessInfo.processInfo.environment
+        guard let rawDirectory = environment["RECEIPT_UNDERSTANDING_REPORT_DIR"],
+              !rawDirectory.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else { return nil }
+        let directory = URL(fileURLWithPath: rawDirectory, isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700]
+        )
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o700],
+            ofItemAtPath: directory.path
+        )
+        let safeImageID = imageID.map {
+            $0.isLetter || $0.isNumber || $0 == "-" || $0 == "_" ? $0 : "_"
+        }
+        let fileName =
+            "receipt-understanding-\(String(safeImageID))-"
+            + String(format: "%05d", receiptID) + ".json"
+        let url = directory.appendingPathComponent(fileName)
+        try data.write(to: url, options: .atomic)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o600],
+            ofItemAtPath: url.path
+        )
+        return url
+    }
+    #endif
 }

--- a/receipt_ocr_swift/Tests/ReceiptChromaTests/ChromaClientTests.swift
+++ b/receipt_ocr_swift/Tests/ReceiptChromaTests/ChromaClientTests.swift
@@ -1,0 +1,556 @@
+import Foundation
+import XCTest
+
+@testable import ReceiptChroma
+
+final class ChromaClientTests: XCTestCase {
+  func testGetsCollectionWithAuthAndCachesByName() async throws {
+    let transport = MockChromaTransport([
+      .init(json: collectionJSON(name: "receipt rows", id: "collection-1"))
+    ])
+    let client = try makeClient(transport: transport)
+
+    let first = try await client.getCollection("receipt rows")
+    let second = try await client.getCollection("receipt rows")
+
+    XCTAssertEqual(first, second)
+    let requests = await transport.requests()
+    XCTAssertEqual(requests.count, 1)
+    XCTAssertEqual(requests[0].method, "GET")
+    XCTAssertEqual(
+      requests[0].url.absoluteString,
+      "https://example.test/api/v2/tenants/tenant-id/databases/receipt_dev/collections/receipt%20rows"
+    )
+    XCTAssertEqual(requests[0].headers["X-Chroma-Token"], "test-key")
+    XCTAssertEqual(requests[0].headers["Accept"], "application/json")
+  }
+
+  func testMissingWritableCollectionUsesAtomicGetOrCreate() async throws {
+    let transport = MockChromaTransport([
+      .init(
+        status: 404,
+        json: #"{"error":"NotFoundError","message":"missing"}"#
+      ),
+      .init(json: collectionJSON(name: "lines", id: "lines-id")),
+    ])
+    let client = try makeClient(mode: .write, transport: transport)
+
+    let collection = try await client.getCollection(
+      "lines",
+      createIfMissing: true,
+      metadata: ["description": "Receipt lines"]
+    )
+
+    XCTAssertEqual(collection.id, "lines-id")
+    let requests = await transport.requests()
+    XCTAssertEqual(requests.map(\.method), ["GET", "POST"])
+    let body = try XCTUnwrap(requests[1].body)
+    let json = try XCTUnwrap(
+      JSONSerialization.jsonObject(with: body) as? [String: Any]
+    )
+    XCTAssertEqual(json["name"] as? String, "lines")
+    XCTAssertEqual(json["get_or_create"] as? Bool, true)
+    XCTAssertEqual(
+      (json["metadata"] as? [String: Any])?["description"] as? String,
+      "Receipt lines"
+    )
+  }
+
+  func testReadModeNeverCreatesMissingCollection() async throws {
+    let transport = MockChromaTransport([
+      .init(status: 404, json: #"{"message":"missing"}"#)
+    ])
+    let client = try makeClient(mode: .read, transport: transport)
+
+    do {
+      _ = try await client.getCollection("words", createIfMissing: true)
+      XCTFail("Expected collectionNotFound")
+    } catch {
+      XCTAssertEqual(
+        error as? ReceiptChromaError,
+        .collectionNotFound("words")
+      )
+    }
+
+    let requestCount = await transport.requests().count
+    XCTAssertEqual(requestCount, 1)
+  }
+
+  func testUpsertBatchesAt250AndPreservesNullMetadata() async throws {
+    let transport = MockChromaTransport([
+      .init(json: collectionJSON(name: "words", id: "words-id")),
+      .init(json: "{}"),
+      .init(json: "{}"),
+    ])
+    let client = try makeClient(mode: .write, transport: transport)
+    let ids = (0..<251).map { "word-\($0)" }
+    let embeddings = (0..<251).map { [Double($0), 0.5] }
+    var metadatas = [ChromaMetadata?](repeating: nil, count: 251)
+    metadatas[0] = ["obsolete_label": .null, "validated": true]
+
+    let count = try await client.upsert(
+      collectionName: "words",
+      ids: ids,
+      embeddings: embeddings,
+      metadatas: metadatas
+    )
+
+    XCTAssertEqual(count, 251)
+    let requests = await transport.requests()
+    XCTAssertEqual(requests.count, 3)
+    let firstBody = try jsonBody(requests[1])
+    let secondBody = try jsonBody(requests[2])
+    XCTAssertEqual((firstBody["ids"] as? [String])?.count, 250)
+    XCTAssertEqual((secondBody["ids"] as? [String])?.count, 1)
+    let firstMetadatas = try XCTUnwrap(firstBody["metadatas"] as? [Any])
+    let firstMetadata = try XCTUnwrap(firstMetadatas[0] as? [String: Any])
+    XCTAssertTrue(firstMetadata["obsolete_label"] is NSNull)
+    XCTAssertEqual(firstMetadata["validated"] as? Bool, true)
+  }
+
+  func testUpsertReportsPartialBatchProgress() async throws {
+    let transport = MockChromaTransport([
+      .init(json: collectionJSON(name: "words", id: "words-id")),
+      .init(json: "{}"),
+      .init(status: 500, json: #"{"message":"server failed"}"#),
+    ])
+    let client = try makeClient(mode: .write, transport: transport)
+    let ids = (0..<251).map { "word-\($0)" }
+    let embeddings = ids.map { _ in [0.1] }
+
+    do {
+      _ = try await client.upsert(
+        collectionName: "words",
+        ids: ids,
+        embeddings: embeddings
+      )
+      XCTFail("Expected partial batch error")
+    } catch ReceiptChromaError.partialBatch(
+      let completed,
+      let total,
+      let message
+    ) {
+      XCTAssertEqual(completed, 250)
+      XCTAssertEqual(total, 251)
+      XCTAssertTrue(message.contains("500"))
+    } catch {
+      XCTFail("Unexpected error: \(error)")
+    }
+  }
+
+  func testQueryClampsCloudLimitAndDecodesNestedResults() async throws {
+    let transport = MockChromaTransport([
+      .init(json: collectionJSON(name: "lines", id: "lines-id")),
+      .init(
+        json: """
+          {
+            "ids": [["row-1"]],
+            "included": ["metadatas", "documents", "distances"],
+            "embeddings": null,
+            "documents": [["MILK ORGANIC HALF GALLON"]],
+            "metadatas": [[{"receipt_id": 1}]],
+            "distances": [[0.125]],
+            "uris": null
+          }
+          """
+      ),
+    ])
+    let client = try makeClient(transport: transport)
+
+    let result = try await client.query(
+      collectionName: "lines",
+      queryEmbeddings: [[0.1, 0.2]],
+      nResults: 999,
+      where: ["merchant": ["$eq": "Trader Joe's"]]
+    )
+
+    XCTAssertEqual(result.ids, [["row-1"]])
+    XCTAssertEqual(result.included, [.metadatas, .documents, .distances])
+    XCTAssertEqual(result.documents, [["MILK ORGANIC HALF GALLON"]])
+    XCTAssertEqual(result.metadatas?[0][0]?["receipt_id"], .integer(1))
+    XCTAssertEqual(result.distances?[0][0], 0.125)
+
+    let requests = await transport.requests()
+    let body = try jsonBody(requests[1])
+    XCTAssertEqual(body["n_results"] as? Int, 300)
+    XCTAssertNotNil(body["where"])
+    XCTAssertEqual(
+      body["include"] as? [String],
+      ["metadatas", "documents", "distances"]
+    )
+  }
+
+  func testGetSendsRecursiveFiltersAndDecodesNullFields() async throws {
+    let transport = MockChromaTransport([
+      .init(json: collectionJSON(name: "words", id: "words-id")),
+      .init(
+        json: """
+          {
+            "ids": ["word-1"],
+            "included": ["metadatas", "documents", "embeddings"],
+            "embeddings": [[0.1, 0.2]],
+            "documents": [null],
+            "metadatas": [{"label": null}],
+            "uris": null
+          }
+          """
+      ),
+    ])
+    let client = try makeClient(transport: transport)
+
+    let result = try await client.get(
+      collectionName: "words",
+      where: [
+        "$and": [
+          ["receipt_id": ["$eq": 1]],
+          ["label": ["$ne": "INVALID"]],
+        ]
+      ],
+      limit: 20,
+      offset: 5
+    )
+
+    XCTAssertEqual(result.ids, ["word-1"])
+    XCTAssertEqual(result.included, [.metadatas, .documents, .embeddings])
+    let documents = try XCTUnwrap(result.documents)
+    XCTAssertNil(documents[0])
+    XCTAssertEqual(result.metadatas?[0]?["label"], .null)
+    let requests = await transport.requests()
+    let body = try jsonBody(requests[1])
+    XCTAssertEqual(body["limit"] as? Int, 20)
+    XCTAssertEqual(body["offset"] as? Int, 5)
+    XCTAssertNotNil(body["where"])
+  }
+
+  func testReadOnlyAndIdsOrFilterGuardsRunBeforeTransport() async throws {
+    let readTransport = MockChromaTransport([])
+    let readClient = try makeClient(mode: .read, transport: readTransport)
+
+    do {
+      _ = try await readClient.upsert(
+        collectionName: "words",
+        ids: ["id"],
+        embeddings: [[0.1]]
+      )
+      XCTFail("Expected readOnly")
+    } catch {
+      XCTAssertEqual(error as? ReceiptChromaError, .readOnly)
+    }
+
+    let writeTransport = MockChromaTransport([])
+    let writeClient = try makeClient(mode: .write, transport: writeTransport)
+    do {
+      try await writeClient.delete(collectionName: "words")
+      XCTFail("Expected invalidRequest")
+    } catch ReceiptChromaError.invalidRequest(let message) {
+      XCTAssertTrue(message.contains("requires"))
+    } catch {
+      XCTFail("Unexpected error: \(error)")
+    }
+
+    let readRequestCount = await readTransport.requests().count
+    let writeRequestCount = await writeTransport.requests().count
+    XCTAssertEqual(readRequestCount, 0)
+    XCTAssertEqual(writeRequestCount, 0)
+  }
+
+  func testRetriesOnlyRateLimitsWithExponentialDelay() async throws {
+    let transport = MockChromaTransport([
+      .init(status: 429, json: #"{"message":"Too many requests"}"#),
+      .init(json: collectionJSON(name: "lines", id: "lines-id")),
+    ])
+    let recorder = SleepRecorder()
+    let client = try makeClient(
+      transport: transport,
+      retryPolicy: ChromaRetryPolicy(
+        maxRetries: 2,
+        baseDelay: 0.5,
+        maxDelay: 8
+      ),
+      sleeper: { nanoseconds in
+        await recorder.sleep(nanoseconds)
+      }
+    )
+
+    _ = try await client.getCollection("lines")
+
+    let requestCount = await transport.requests().count
+    let recordedSleeps = await recorder.values()
+    XCTAssertEqual(requestCount, 2)
+    XCTAssertEqual(recordedSleeps, [500_000_000])
+  }
+
+  func testHTTPErrorPreservesTypeMessageAndTraceIDWithoutRetry() async throws {
+    let transport = MockChromaTransport([
+      .init(
+        status: 401,
+        json: #"{"error":"AuthorizationError","message":"bad token"}"#,
+        headers: ["chroma-trace-id": "trace-123"]
+      )
+    ])
+    let client = try makeClient(transport: transport)
+
+    do {
+      _ = try await client.getCollection("lines")
+      XCTFail("Expected HTTP error")
+    } catch {
+      XCTAssertEqual(
+        error as? ReceiptChromaError,
+        .http(
+          status: 401,
+          type: "AuthorizationError",
+          message: "bad token",
+          traceID: "trace-123"
+        )
+      )
+    }
+
+    let requestCount = await transport.requests().count
+    XCTAssertEqual(requestCount, 1)
+  }
+
+  func testCloseIsIdempotentAndRejectsLaterUse() async throws {
+    let transport = MockChromaTransport([])
+    let client = try makeClient(transport: transport)
+
+    await client.close()
+    await client.close()
+    let closeCount = await transport.closeCount()
+    XCTAssertEqual(closeCount, 1)
+
+    do {
+      _ = try await client.listCollections()
+      XCTFail("Expected closed")
+    } catch {
+      XCTAssertEqual(error as? ReceiptChromaError, .closed)
+    }
+  }
+
+  func testRejectsMisalignedAndOversizedPayloadsBeforeTransport() async throws {
+    let transport = MockChromaTransport([])
+    let client = try makeClient(mode: .write, transport: transport)
+
+    do {
+      _ = try await client.upsert(
+        collectionName: "words",
+        ids: ["one", "two"],
+        embeddings: [[0.1]]
+      )
+      XCTFail("Expected invalidRequest")
+    } catch ReceiptChromaError.invalidRequest(let message) {
+      XCTAssertTrue(message.contains("expected 2"))
+    } catch {
+      XCTFail("Unexpected error: \(error)")
+    }
+
+    do {
+      _ = try await client.upsert(
+        collectionName: "words",
+        ids: [String(repeating: "x", count: 129)],
+        embeddings: [[0.1]]
+      )
+      XCTFail("Expected invalidRequest")
+    } catch ReceiptChromaError.invalidRequest(let message) {
+      XCTAssertTrue(message.contains("128"))
+    } catch {
+      XCTFail("Unexpected error: \(error)")
+    }
+
+    let requestCount = await transport.requests().count
+    XCTAssertEqual(requestCount, 0)
+  }
+
+  func testRejectsDuplicateIDsAcrossBatchBoundary() async throws {
+    let transport = MockChromaTransport([])
+    let client = try makeClient(mode: .write, transport: transport)
+    var ids = (0..<251).map { "word-\($0)" }
+    ids[250] = ids[0]
+
+    do {
+      _ = try await client.upsert(
+        collectionName: "words",
+        ids: ids,
+        embeddings: ids.map { _ in [0.1] }
+      )
+      XCTFail("Expected invalidRequest")
+    } catch ReceiptChromaError.invalidRequest(let message) {
+      XCTAssertTrue(message.contains("unique"))
+    } catch {
+      XCTFail("Unexpected error: \(error)")
+    }
+
+    let requestCount = await transport.requests().count
+    XCTAssertEqual(requestCount, 0)
+  }
+
+  func testCollectionExistsBypassesStaleCache() async throws {
+    let transport = MockChromaTransport([
+      .init(json: collectionJSON(name: "lines", id: "lines-id")),
+      .init(status: 404, json: #"{"message":"missing"}"#),
+    ])
+    let client = try makeClient(transport: transport)
+
+    _ = try await client.getCollection("lines")
+    let exists = try await client.collectionExists("lines")
+
+    XCTAssertEqual(exists, false)
+    let requestCount = await transport.requests().count
+    XCTAssertEqual(requestCount, 2)
+  }
+
+  func testRejectsUnsupportedGetIncludeAndOversizedReadBeforeTransport()
+    async throws
+  {
+    let transport = MockChromaTransport([])
+    let client = try makeClient(transport: transport)
+
+    do {
+      _ = try await client.get(
+        collectionName: "words",
+        ids: ["word-1"],
+        include: [.distances]
+      )
+      XCTFail("Expected invalidRequest")
+    } catch ReceiptChromaError.invalidRequest(let message) {
+      XCTAssertTrue(message.contains("distances"))
+    } catch {
+      XCTFail("Unexpected error: \(error)")
+    }
+
+    do {
+      _ = try await client.get(
+        collectionName: "words",
+        ids: ["word-1"],
+        limit: 301
+      )
+      XCTFail("Expected invalidRequest")
+    } catch ReceiptChromaError.invalidRequest(let message) {
+      XCTAssertTrue(message.contains("300"))
+    } catch {
+      XCTFail("Unexpected error: \(error)")
+    }
+
+    let requestCount = await transport.requests().count
+    XCTAssertEqual(requestCount, 0)
+  }
+
+  func testRejectsInvalidMetadataShapesAndHonorsRawByteLimit() async throws {
+    let transport = MockChromaTransport([])
+    let client = try makeClient(mode: .write, transport: transport)
+
+    let invalidMetadatas: [ChromaMetadata] = [
+      [:],
+      ["mixed": [.string("a"), .integer(2)]],
+      ["empty_array": .array([])],
+      ["$reserved": "value"],
+      ["not_finite": .number(.infinity)],
+      ["too_long": .string(String(repeating: "x", count: 8_183))],
+    ]
+    for metadata in invalidMetadatas {
+      do {
+        _ = try await client.upsert(
+          collectionName: "words",
+          ids: ["word-1"],
+          embeddings: [[0.1]],
+          metadatas: [metadata]
+        )
+        XCTFail("Expected invalidRequest")
+      } catch ReceiptChromaError.invalidRequest {
+      } catch {
+        XCTFail("Unexpected error: \(error)")
+      }
+    }
+
+    let boundaryTransport = MockChromaTransport([
+      .init(json: collectionJSON(name: "words", id: "words-id")),
+      .init(json: "{}"),
+    ])
+    let boundaryClient = try makeClient(
+      mode: .write,
+      transport: boundaryTransport
+    )
+    let completed = try await boundaryClient.upsert(
+      collectionName: "words",
+      ids: ["word-1"],
+      embeddings: [[0.1]],
+      metadatas: [
+        ["at_limit": .string(String(repeating: "x", count: 8_182))]
+      ]
+    )
+
+    XCTAssertEqual(completed, 1)
+    let invalidRequestCount = await transport.requests().count
+    XCTAssertEqual(invalidRequestCount, 0)
+  }
+
+  func testCountsFullTextLeafPredicatesBeforeTransport() async throws {
+    let transport = MockChromaTransport([])
+    let client = try makeClient(transport: transport)
+    let predicates = (0..<9).map { index in
+      JSONValue.object(["$contains": .string("term-\(index)")])
+    }
+
+    do {
+      _ = try await client.get(
+        collectionName: "words",
+        whereDocument: ["$and": .array(predicates)]
+      )
+      XCTFail("Expected invalidRequest")
+    } catch ReceiptChromaError.invalidRequest(let message) {
+      XCTAssertTrue(message.contains("8 predicates"))
+    } catch {
+      XCTFail("Unexpected error: \(error)")
+    }
+
+    let requestCount = await transport.requests().count
+    XCTAssertEqual(requestCount, 0)
+  }
+
+  private func makeClient(
+    mode: ChromaMode = .read,
+    transport: MockChromaTransport,
+    retryPolicy: ChromaRetryPolicy = ChromaRetryPolicy(),
+    sleeper: @escaping ChromaClient.Sleeper = { _ in }
+  ) throws -> ChromaClient {
+    let configuration = try ChromaConfiguration(
+      apiKey: "test-key",
+      tenant: "tenant-id",
+      database: "receipt_dev",
+      mode: mode,
+      baseURL: URL(string: "https://example.test/api/v2")!,
+      retryPolicy: retryPolicy
+    )
+    return ChromaClient(
+      configuration: configuration,
+      transport: transport,
+      sleeper: sleeper,
+      jitter: { _ in 0 }
+    )
+  }
+
+  private func collectionJSON(name: String, id: String) -> String {
+    """
+    {
+      "id": "\(id)",
+      "name": "\(name)",
+      "metadata": null,
+      "dimension": 1536,
+      "tenant": "tenant-id",
+      "database": "receipt_dev",
+      "version": 1,
+      "log_position": 10,
+      "configuration_json": {},
+      "schema": null
+    }
+    """
+  }
+
+  private func jsonBody(
+    _ request: RecordedChromaRequest
+  ) throws -> [String: Any] {
+    let body = try XCTUnwrap(request.body)
+    return try XCTUnwrap(
+      JSONSerialization.jsonObject(with: body) as? [String: Any]
+    )
+  }
+}

--- a/receipt_ocr_swift/Tests/ReceiptChromaTests/ChromaConfigurationTests.swift
+++ b/receipt_ocr_swift/Tests/ReceiptChromaTests/ChromaConfigurationTests.swift
@@ -1,0 +1,77 @@
+import Foundation
+import XCTest
+
+@testable import ReceiptChroma
+
+final class ChromaConfigurationTests: XCTestCase {
+  func testNormalizesRequiredValues() throws {
+    let configuration = try ChromaConfiguration(
+      apiKey: "  secret \n",
+      tenant: " tenant-id ",
+      database: " receipt_dev "
+    )
+
+    XCTAssertEqual(configuration.apiKey, "secret")
+    XCTAssertEqual(configuration.tenant, "tenant-id")
+    XCTAssertEqual(configuration.database, "receipt_dev")
+    XCTAssertEqual(
+      configuration.baseURL.absoluteString,
+      "https://api.trychroma.com/api/v2"
+    )
+  }
+
+  func testRejectsBlankAndInvalidConfiguration() {
+    XCTAssertThrowsError(
+      try ChromaConfiguration(apiKey: " ", tenant: "tenant", database: "db")
+    )
+    XCTAssertThrowsError(
+      try ChromaConfiguration(apiKey: "key", tenant: "", database: "db")
+    )
+    XCTAssertThrowsError(
+      try ChromaConfiguration(
+        apiKey: "key",
+        tenant: "tenant",
+        database: "db",
+        requestTimeout: 0
+      )
+    )
+    XCTAssertThrowsError(
+      try ChromaConfiguration(
+        apiKey: "key",
+        tenant: "tenant",
+        database: "db",
+        retryPolicy: ChromaRetryPolicy(
+          maxRetries: 1,
+          baseDelay: 2,
+          maxDelay: 1
+        )
+      )
+    )
+    XCTAssertThrowsError(
+      try ChromaConfiguration(
+        apiKey: "key",
+        tenant: "tenant",
+        database: "db",
+        baseURL: URL(string: "http://api.example.com/api/v2")!
+      )
+    )
+  }
+
+  func testAllowsHTTPOnlyForLoopbackHosts() throws {
+    let localhost = try ChromaConfiguration(
+      apiKey: "key",
+      tenant: "tenant",
+      database: "db",
+      baseURL: URL(string: "http://localhost:8000/api/v2")!
+    )
+    let loopback = try ChromaConfiguration(
+      apiKey: "key",
+      tenant: "tenant",
+      database: "db",
+      baseURL: URL(string: "http://127.0.0.1:8000/api/v2")!
+    )
+
+    XCTAssertEqual(localhost.baseURL.host, "localhost")
+    XCTAssertEqual(loopback.baseURL.host, "127.0.0.1")
+  }
+}

--- a/receipt_ocr_swift/Tests/ReceiptChromaTests/JSONValueTests.swift
+++ b/receipt_ocr_swift/Tests/ReceiptChromaTests/JSONValueTests.swift
@@ -1,0 +1,34 @@
+import XCTest
+
+@testable import ReceiptChroma
+
+final class JSONValueTests: XCTestCase {
+  func testRoundTripsEveryJSONShapeAndPreservesNull() throws {
+    let value: JSONValue = [
+      "string": "receipt",
+      "integer": 7,
+      "number": 1.25,
+      "bool": true,
+      "array": ["a", 2, false],
+      "object": ["nested": "value"],
+      "tombstone": nil,
+    ]
+
+    let data = try JSONEncoder().encode(value)
+    let decoded = try JSONDecoder().decode(JSONValue.self, from: data)
+
+    XCTAssertEqual(decoded, value)
+    XCTAssertTrue(String(data: data, encoding: .utf8)!.contains("\"tombstone\":null"))
+  }
+
+  func testDecodesIntegerBeforeFloatingPointNumber() throws {
+    XCTAssertEqual(
+      try JSONDecoder().decode(JSONValue.self, from: Data("42".utf8)),
+      .integer(42)
+    )
+    XCTAssertEqual(
+      try JSONDecoder().decode(JSONValue.self, from: Data("42.5".utf8)),
+      .number(42.5)
+    )
+  }
+}

--- a/receipt_ocr_swift/Tests/ReceiptChromaTests/MockChromaTransport.swift
+++ b/receipt_ocr_swift/Tests/ReceiptChromaTests/MockChromaTransport.swift
@@ -1,0 +1,87 @@
+import Foundation
+
+@testable import ReceiptChroma
+
+#if canImport(FoundationNetworking)
+  import FoundationNetworking
+#endif
+
+struct RecordedChromaRequest: Sendable {
+  let url: URL
+  let method: String
+  let headers: [String: String]
+  let body: Data?
+}
+
+actor MockChromaTransport: ChromaHTTPTransport {
+  struct Stub: Sendable {
+    let status: Int
+    let data: Data
+    let headers: [String: String]
+
+    init(
+      status: Int = 200,
+      json: String,
+      headers: [String: String] = [:]
+    ) {
+      self.status = status
+      self.data = Data(json.utf8)
+      self.headers = headers
+    }
+  }
+
+  private var stubs: [Stub]
+  private var recordedRequests: [RecordedChromaRequest] = []
+  private var closeCalls = 0
+
+  init(_ stubs: [Stub]) {
+    self.stubs = stubs
+  }
+
+  func data(for request: URLRequest) async throws -> (Data, HTTPURLResponse) {
+    recordedRequests.append(
+      RecordedChromaRequest(
+        url: request.url!,
+        method: request.httpMethod ?? "GET",
+        headers: request.allHTTPHeaderFields ?? [:],
+        body: request.httpBody
+      )
+    )
+
+    guard !stubs.isEmpty else {
+      throw ReceiptChromaError.transport("No mock response queued")
+    }
+    let stub = stubs.removeFirst()
+    let response = HTTPURLResponse(
+      url: request.url!,
+      statusCode: stub.status,
+      httpVersion: "HTTP/1.1",
+      headerFields: stub.headers
+    )!
+    return (stub.data, response)
+  }
+
+  func requests() -> [RecordedChromaRequest] {
+    recordedRequests
+  }
+
+  func close() async {
+    closeCalls += 1
+  }
+
+  func closeCount() -> Int {
+    closeCalls
+  }
+}
+
+actor SleepRecorder {
+  private var recorded: [UInt64] = []
+
+  func sleep(_ nanoseconds: UInt64) {
+    recorded.append(nanoseconds)
+  }
+
+  func values() -> [UInt64] {
+    recorded
+  }
+}

--- a/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/OCRResultContractTests.swift
+++ b/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/OCRResultContractTests.swift
@@ -305,7 +305,7 @@ final class OCRResultContractTests: XCTestCase {
 
     // MARK: - Worker: the shared fixture drives the full upload/handoff path.
 
-    private final class SQSMock: SQSClientProtocol {
+    private final class SQSMock: SQSClientProtocol, @unchecked Sendable {
         var messages: [SQSMessage] = []
         var sentMessages: [String] = []
         var deleted: [SQSDeleteEntry] = []
@@ -365,6 +365,46 @@ final class OCRResultContractTests: XCTestCase {
         }
     }
 
+    private actor UnderstandingAnalyzerSpy: ReceiptUnderstandingAnalyzing {
+        private var references: [ReceiptReference] = []
+        private var lineCounts: [Int] = []
+        private var acknowledgedBeforeAnalysis: [Bool] = []
+        private let acknowledgementCheck: @Sendable () -> Bool
+
+        init(
+            acknowledgementCheck: @escaping @Sendable () -> Bool = { true }
+        ) {
+            self.acknowledgementCheck = acknowledgementCheck
+        }
+
+        func analyze(
+            reference: ReceiptReference,
+            lines: [Line],
+            predictions: [LinePrediction]
+        ) async -> ReceiptUnderstandingReport {
+            references.append(reference)
+            lineCounts.append(lines.count)
+            acknowledgedBeforeAnalysis.append(acknowledgementCheck())
+            return ReceiptUnderstandingReport(
+                reference: reference,
+                rows: [],
+                identitySignals: ReceiptIdentitySignals(),
+                merchantResolution: .abstained("test"),
+                sections: [],
+                consistencyIssues: [],
+                candidates: [],
+                timings: [],
+                totalMilliseconds: 0,
+                offlineFallback: true,
+                errors: []
+            )
+        }
+
+        func observations() -> ([ReceiptReference], [Int], [Bool]) {
+            (references, lineCounts, acknowledgedBeforeAnalysis)
+        }
+    }
+
     func test_worker_uploads_fixture_and_writes_pending_labels() async throws {
         let cfg = Config(
             ocrJobQueueURL: "q-jobs",
@@ -392,9 +432,17 @@ final class OCRResultContractTests: XCTestCase {
             createdAt: now, updatedAt: now, status: .pending
         )
         s3.objects["raw-bucket:images/IMG_CONTRACT.png"] = Data([0xFF, 0xD8, 0xFF])
+        let analyzer = UnderstandingAnalyzerSpy {
+            !sqs.deleted.isEmpty
+        }
 
         let worker = OCRWorker(
-            config: cfg, ocr: FixtureOCREngine(), sqs: sqs, s3: s3, dynamo: dynamo
+            config: cfg,
+            ocr: FixtureOCREngine(),
+            sqs: sqs,
+            s3: s3,
+            dynamo: dynamo,
+            understandingAnalyzer: analyzer
         )
         let processedBatch = try await worker.processBatch()
         XCTAssertTrue(processedBatch)
@@ -433,6 +481,16 @@ final class OCRResultContractTests: XCTestCase {
             XCTAssertEqual(label.validationStatus, .pending)
             XCTAssertEqual(label.labelProposedBy, "auto-inference")
         }
+
+        // The shadow analyzer receives receipt-local Vision/LayoutLM output
+        // only after the production message has been acknowledged.
+        let observations = await analyzer.observations()
+        XCTAssertEqual(
+            observations.0,
+            [ReceiptReference(imageID: imageId, receiptID: 1)]
+        )
+        XCTAssertEqual(observations.1, [4])
+        XCTAssertEqual(observations.2, [true])
 
         // The OCR-results message carries the pointer contract the Lambda
         // parses: job_id + image_id (routing), s3 location, receipt count.

--- a/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/OpenAIRowEmbeddingProviderTests.swift
+++ b/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/OpenAIRowEmbeddingProviderTests.swift
@@ -1,0 +1,132 @@
+import Foundation
+import XCTest
+
+@testable import ReceiptOCRCore
+
+final class OpenAIRowEmbeddingProviderTests: XCTestCase {
+  private actor Transport: OpenAIEmbeddingHTTPTransport {
+    struct Reply: Sendable {
+      let status: Int
+      let data: Data
+    }
+
+    private var replies: [Reply]
+    private(set) var requests: [URLRequest] = []
+
+    init(_ replies: [Reply]) {
+      self.replies = replies
+    }
+
+    func send(
+      _ request: URLRequest
+    ) async throws -> (Data, HTTPURLResponse) {
+      requests.append(request)
+      let reply = replies.removeFirst()
+      let response = HTTPURLResponse(
+        url: request.url!,
+        statusCode: reply.status,
+        httpVersion: nil,
+        headerFields: nil
+      )!
+      return (reply.data, response)
+    }
+
+    func capturedRequests() -> [URLRequest] { requests }
+  }
+
+  private actor SleepProbe {
+    private(set) var delays: [UInt64] = []
+    func record(_ delay: UInt64) { delays.append(delay) }
+    func count() -> Int { delays.count }
+  }
+
+  private func response(
+    count: Int,
+    dimension: Int = ReceiptUnderstandingConstants.embeddingDimensions,
+    reversed: Bool = false
+  ) throws -> Data {
+    let indexes =
+      reversed
+      ? Array((0..<count).reversed()) : Array(0..<count)
+    return try JSONSerialization.data(
+      withJSONObject: [
+        "data": indexes.map {
+          [
+            "index": $0,
+            "embedding": Array(repeating: Double($0 + 1), count: dimension),
+          ]
+        }
+      ]
+    )
+  }
+
+  func testRequestMatchesPythonAndResponseIsSortedByIndex() async throws {
+    let transport = Transport([
+      .init(status: 200, data: try response(count: 2, reversed: true))
+    ])
+    let provider = try OpenAIRowEmbeddingProvider(
+      apiKey: "secret",
+      endpoint: URL(string: "http://127.0.0.1/embeddings")!,
+      transport: transport
+    )
+
+    let vectors = try await provider.embedRows(["A\nB\nC", "D\nE\nF"])
+
+    XCTAssertEqual(vectors.count, 2)
+    XCTAssertEqual(vectors[0][0], 1)
+    XCTAssertEqual(vectors[1][0], 2)
+    let requests = await transport.capturedRequests()
+    let request = try XCTUnwrap(requests.first)
+    let body = try XCTUnwrap(
+      JSONSerialization.jsonObject(with: request.httpBody!) as? [String: Any]
+    )
+    XCTAssertEqual(
+      body["model"] as? String,
+      ReceiptUnderstandingConstants.embeddingModel
+    )
+    XCTAssertEqual(body["input"] as? [String], ["A\nB\nC", "D\nE\nF"])
+    XCTAssertNil(body["dimensions"])
+  }
+
+  func testRetriesRateLimitsAndServerFailures() async throws {
+    let transport = Transport([
+      .init(status: 429, data: Data("rate limited".utf8)),
+      .init(status: 500, data: Data("server".utf8)),
+      .init(status: 200, data: try response(count: 1)),
+    ])
+    let sleep = SleepProbe()
+    let provider = try OpenAIRowEmbeddingProvider(
+      apiKey: "secret",
+      endpoint: URL(string: "http://localhost/embeddings")!,
+      transport: transport,
+      maximumRetries: 2,
+      sleeper: { await sleep.record($0) }
+    )
+
+    let vectors = try await provider.embedRows(["row"])
+
+    XCTAssertEqual(vectors.count, 1)
+    let sleepCount = await sleep.count()
+    let requestCount = await transport.capturedRequests().count
+    XCTAssertEqual(sleepCount, 2)
+    XCTAssertEqual(requestCount, 3)
+  }
+
+  func testRejectsMissingOrWrongDimensionEmbeddings() async throws {
+    let transport = Transport([
+      .init(status: 200, data: try response(count: 1, dimension: 8))
+    ])
+    let provider = try OpenAIRowEmbeddingProvider(
+      apiKey: "secret",
+      endpoint: URL(string: "http://127.0.0.1/embeddings")!,
+      transport: transport
+    )
+
+    do {
+      _ = try await provider.embedRows(["row"])
+      XCTFail("expected dimension validation to fail")
+    } catch {
+      XCTAssertTrue(error.localizedDescription.contains("dimensions"))
+    }
+  }
+}

--- a/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/ReceiptChromaParityTests.swift
+++ b/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/ReceiptChromaParityTests.swift
@@ -1,0 +1,193 @@
+import CoreGraphics
+import Foundation
+import ReceiptChroma
+import XCTest
+
+@testable import ReceiptOCRCore
+
+final class ReceiptChromaParityTests: XCTestCase {
+  private actor Transport: ChromaHTTPTransport {
+    private var replies: [(Int, Data)]
+    private var captured: [URLRequest] = []
+
+    init(_ replies: [(Int, Data)]) {
+      self.replies = replies
+    }
+
+    func data(
+      for request: URLRequest
+    ) async throws -> (Data, HTTPURLResponse) {
+      captured.append(request)
+      let reply = replies.removeFirst()
+      return (
+        reply.1,
+        HTTPURLResponse(
+          url: request.url!,
+          statusCode: reply.0,
+          httpVersion: nil,
+          headerFields: nil
+        )!
+      )
+    }
+
+    func requests() -> [URLRequest] { captured }
+  }
+
+  private func line(_ text: String, confidence: Float = 0.9) -> Line {
+    let point = CodablePoint(x: 0, y: 0)
+    return Line(
+      text: text,
+      boundingBox: NormalizedRect(
+        x: 0.1,
+        y: 0.2,
+        width: 0.4,
+        height: 0.1
+      ),
+      topLeft: point,
+      topRight: point,
+      bottomLeft: point,
+      bottomRight: point,
+      angleDegrees: 0,
+      angleRadians: 0,
+      confidence: confidence,
+      words: []
+    )
+  }
+
+  func testRowRecordMatchesPythonIDsDocumentsAndMetadata() {
+    let row = VisualReceiptRow(
+      rowID: 1,
+      lineIDs: [1, 2],
+      text: "ORGANIC APPLES 4.99",
+      embeddingInput: "<EDGE>\nORGANIC APPLES 4.99\nTOTAL 4.99",
+      bounds: VisualRowBounds(
+        xMin: 0.1,
+        yMin: 0.2,
+        xMax: 0.9,
+        yMax: 0.3
+      )
+    )
+
+    let record = ReceiptChromaRowContract.record(
+      reference: ReceiptReference(imageID: "image", receiptID: 7),
+      row: row,
+      sourceLines: [
+        line("ORGANIC APPLES", confidence: 0.8),
+        line("4.99", confidence: 1),
+      ],
+      merchantName: "smith's market",
+      sectionLabel: "ITEMS",
+      normalizedPhone10: "4155551212"
+    )
+
+    XCTAssertEqual(
+      record.id,
+      "IMAGE#image#RECEIPT#00007#LINE#00001"
+    )
+    XCTAssertEqual(record.document, "ORGANIC APPLES 4.99")
+    XCTAssertEqual(
+      record.embeddingInput,
+      "<EDGE>\nORGANIC APPLES 4.99\nTOTAL 4.99"
+    )
+    XCTAssertEqual(record.metadata["row_line_ids"], .string("[1, 2]"))
+    XCTAssertEqual(
+      record.metadata["source"],
+      .string("openai_embedding_batch")
+    )
+    // Python `str.title()` treats the apostrophe as a word boundary.
+    XCTAssertEqual(
+      record.metadata["merchant_name"],
+      .string("Smith'S Market")
+    )
+    XCTAssertEqual(record.metadata["section_label"], .string("ITEMS"))
+    XCTAssertEqual(
+      record.metadata["normalized_phone_10"],
+      .string("4155551212")
+    )
+  }
+
+  func testQueryUsesExactSelfExclusionAndComputesCosineLocally() async throws {
+    let dimension = ReceiptUnderstandingConstants.embeddingDimensions
+    let collection = try JSONSerialization.data(
+      withJSONObject: [
+        "id": "collection-id",
+        "name": "lines",
+        "dimension": dimension,
+      ]
+    )
+    let vectors = [
+      Array(repeating: 1.0, count: dimension),
+      Array(repeating: 2.0, count: dimension),
+    ]
+    let queryResponse = try JSONSerialization.data(
+      withJSONObject: [
+        "ids": [["self", "other"]],
+        "included": ["embeddings", "metadatas", "documents"],
+        "embeddings": [vectors],
+        "documents": [["SELF", "KNOWN"]],
+        "metadatas": [
+          [
+            [
+              "image_id": "current",
+              "receipt_id": 1,
+              "line_id": 1,
+              "row_line_ids": "[1]",
+            ],
+            [
+              "image_id": "known",
+              "receipt_id": 2,
+              "line_id": 9,
+              "row_line_ids": "[9, 10]",
+              "section_label": "PENDING_IS_NOT_TRUSTED",
+            ],
+          ]
+        ],
+      ]
+    )
+    let transport = Transport([(200, collection), (200, queryResponse)])
+    let configuration = try ChromaConfiguration(
+      apiKey: "key",
+      tenant: "tenant",
+      database: "database",
+      baseURL: URL(string: "http://127.0.0.1/api/v2")!
+    )
+    let client = ChromaClient(
+      configuration: configuration,
+      transport: transport,
+      closeTransportOnClose: false
+    )
+    let query = ChromaRowNeighborQuery(client: client)
+
+    let result = try await query.queryRows(
+      embeddings: [Array(repeating: 1, count: dimension)],
+      excluding: ReceiptReference(imageID: "current", receiptID: 1),
+      nResults: 15
+    )
+
+    XCTAssertEqual(result.count, 1)
+    XCTAssertEqual(result[0].count, 1)
+    XCTAssertEqual(result[0][0].reference.imageID, "known")
+    XCTAssertEqual(result[0][0].rowLineIDs, [9, 10])
+    XCTAssertEqual(result[0][0].cosineSimilarity, 1, accuracy: 1e-6)
+
+    let requests = await transport.requests()
+    let body = try XCTUnwrap(requests.last?.httpBody)
+    let json = try XCTUnwrap(
+      JSONSerialization.jsonObject(with: body) as? [String: Any]
+    )
+    XCTAssertEqual(json["n_results"] as? Int, 15)
+    let include = try XCTUnwrap(json["include"] as? [String])
+    XCTAssertEqual(Set(include), Set(["embeddings", "metadatas", "documents"]))
+    let filter = try XCTUnwrap(json["where"] as? [String: Any])
+    let or = try XCTUnwrap(filter["$or"] as? [[String: Any]])
+    XCTAssertEqual(or.count, 2)
+    XCTAssertEqual(
+      ((or[0]["image_id"] as? [String: Any])?["$ne"] as? String),
+      "current"
+    )
+    XCTAssertEqual(
+      ((or[1]["receipt_id"] as? [String: Any])?["$ne"] as? Int),
+      1
+    )
+  }
+}

--- a/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/ReceiptUnderstandingPipelineTests.swift
+++ b/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/ReceiptUnderstandingPipelineTests.swift
@@ -1,0 +1,669 @@
+import CoreGraphics
+import XCTest
+
+@testable import ReceiptOCRCore
+
+final class ReceiptUnderstandingPipelineTests: XCTestCase {
+  private enum Failure: Error { case unavailable }
+
+  private struct FailingEmbedder: RowEmbeddingProviding {
+    func embedRows(_ inputs: [String]) async throws -> [[Double]] {
+      throw Failure.unavailable
+    }
+  }
+
+  private struct MissingEmbedder: RowEmbeddingProviding {
+    func embedRows(_ inputs: [String]) async throws -> [[Double]] { [] }
+  }
+
+  private struct StaticEmbedder: RowEmbeddingProviding {
+    func embedRows(_ inputs: [String]) async throws -> [[Double]] {
+      inputs.map {
+        _ in
+        Array(
+          repeating: 0.1,
+          count: ReceiptUnderstandingConstants.embeddingDimensions
+        )
+      }
+    }
+  }
+
+  private struct FailingNeighbors: ReceiptNeighborQuerying {
+    func queryRows(
+      embeddings: [[Double]],
+      excluding reference: ReceiptReference,
+      nResults: Int
+    ) async throws -> [[SectionNeighbor]] {
+      throw Failure.unavailable
+    }
+  }
+
+  private struct EmptyNeighbors: ReceiptNeighborQuerying {
+    func queryRows(
+      embeddings: [[Double]],
+      excluding reference: ReceiptReference,
+      nResults: Int
+    ) async throws -> [[SectionNeighbor]] {
+      Array(repeating: [], count: embeddings.count)
+    }
+  }
+
+  private struct FailingPlaces: PlacesLookingUp {
+    func lookup(
+      identity: ReceiptIdentitySignals
+    ) async throws -> PlacesCandidate? {
+      throw Failure.unavailable
+    }
+  }
+
+  private struct ManyNeighbors: ReceiptNeighborQuerying {
+    func queryRows(
+      embeddings: [[Double]],
+      excluding reference: ReceiptReference,
+      nResults: Int
+    ) async throws -> [[SectionNeighbor]] {
+      embeddings.map { _ in
+        (0..<30).map { index in
+          SectionNeighbor(
+            reference: ReceiptReference(
+              imageID: "known-\(index)",
+              receiptID: 1
+            ),
+            lineID: 1,
+            rowLineIDs: [1],
+            document: nil,
+            cosineSimilarity: 1 - Double(index) / 100,
+            metadataSection: nil,
+            metadataMerchantName: nil
+          )
+        }
+      }
+    }
+  }
+
+  private actor EvidenceSpy: KnownReceiptEvidenceProviding {
+    private var requested: Set<ReceiptReference> = []
+
+    func evidence(
+      for references: Set<ReceiptReference>
+    ) async throws -> [ReceiptReference: KnownReceiptEvidence] {
+      requested = references
+      return [:]
+    }
+
+    func requestedReferences() -> Set<ReceiptReference> {
+      requested
+    }
+  }
+
+  private static var priorURL: URL {
+    URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .appendingPathComponent(
+        "receipt_upload/receipt_upload/assets/section_order_priors_v2.json"
+      )
+  }
+
+  private func row(
+    _ id: Int,
+    _ text: String,
+    y: Double,
+    amount: String? = nil,
+    labels: [String] = []
+  ) -> VisualReceiptRow {
+    VisualReceiptRow(
+      rowID: id,
+      lineIDs: [id],
+      text: text,
+      embeddingInput: "<EDGE>\n\(text)\n<EDGE>",
+      bounds: VisualRowBounds(
+        xMin: 0.05,
+        yMin: y,
+        xMax: 0.95,
+        yMax: y + 0.04
+      ),
+      priceColumnX: amount == nil ? nil : 0.95,
+      labelText: amount == nil
+        ? nil
+        : text.replacingOccurrences(of: amount!, with: "")
+          .trimmingCharacters(in: .whitespaces),
+      amountText: amount,
+      layoutEvidence: labels.enumerated().map {
+        LayoutWordEvidence(
+          lineID: id,
+          wordID: $0.offset + 1,
+          text: text.split(separator: " ").first.map(String.init) ?? text,
+          label: "B-\($0.element)",
+          confidence: 0.95
+        )
+      }
+    )
+  }
+
+  private func line(_ text: String) -> Line {
+    let point = CodablePoint(x: 0, y: 0)
+    return Line(
+      text: text,
+      boundingBox: NormalizedRect(
+        x: 0.05,
+        y: 0.8,
+        width: 0.9,
+        height: 0.04
+      ),
+      topLeft: point,
+      topRight: point,
+      bottomLeft: point,
+      bottomRight: point,
+      angleDegrees: 0,
+      angleRadians: 0,
+      confidence: 1,
+      words: []
+    )
+  }
+
+  func testPythonGoldenSectionAssignmentsAndConfidenceParity() throws {
+    let decoder = try DeterministicSectionDecoder(
+      priorURL: Self.priorURL
+    )
+    let rows = [
+      row(1, "SPROUTS FARMERS MARKET", y: 0.9),
+      row(2, "123 MAIN ST", y: 0.8),
+      row(3, "ORGANIC APPLES 4.99", y: 0.6, amount: "4.99"),
+      row(4, "SUBTOTAL 4.99", y: 0.3, amount: "4.99"),
+      row(5, "TAX 0.41", y: 0.25, amount: "0.41"),
+      row(6, "TOTAL 5.40", y: 0.2, amount: "5.40"),
+      row(7, "VISA 5.40", y: 0.1, amount: "5.40"),
+    ]
+
+    let assignments = decoder.assign(
+      rows: rows,
+      merchantName: "Sprouts Farmers Market"
+    )
+
+    XCTAssertEqual(
+      assignments.map(\.sectionType),
+      [
+        "STOREFRONT", "ITEMS", "ITEMS", "SUMMARY", "SUMMARY",
+        "SUMMARY", "TOTAL_LINE",
+      ]
+    )
+    let pythonConfidences = [
+      0.999_921_212_448_287_6,
+      0.073_218_084_870_463_19,
+      0.997_576_809_809_947_1,
+      0.983_596_969_525_279_6,
+      0.997_122_693_335_959_8,
+      0.133_612_048_032_665_3,
+      0.177_567_111_292_142_84,
+    ]
+    for (actual, expected) in zip(
+      assignments.map(\.confidence),
+      pythonConfidences
+    ) {
+      XCTAssertEqual(actual, expected, accuracy: 1e-10)
+    }
+  }
+
+  func testMalformedPriorIsRejectedBeforeDecoding() throws {
+    let data = try Data(contentsOf: Self.priorURL)
+    var root = try XCTUnwrap(
+      JSONSerialization.jsonObject(with: data) as? [String: Any]
+    )
+    var global = try XCTUnwrap(root["global"] as? [String: Any])
+    var models = try XCTUnwrap(
+      global["section_models"] as? [String: Any]
+    )
+    let section = try XCTUnwrap(
+      (global["sections"] as? [String])?.first
+    )
+    var model = try XCTUnwrap(models[section] as? [String: Any])
+    var features = try XCTUnwrap(model["features"] as? [String: Any])
+    features.removeValue(forKey: "position")
+    model["features"] = features
+    models[section] = model
+    global["section_models"] = models
+    root["global"] = global
+
+    let url = FileManager.default.temporaryDirectory.appendingPathComponent(
+      "malformed-section-prior-\(UUID().uuidString).json"
+    )
+    defer { try? FileManager.default.removeItem(at: url) }
+    try JSONSerialization.data(withJSONObject: root).write(to: url)
+
+    XCTAssertThrowsError(
+      try DeterministicSectionDecoder(priorURL: url)
+    )
+  }
+
+  func testCosineNeighborsRequireValidDynamoSectionEvidence() throws {
+    let decoder = try DeterministicSectionDecoder(
+      priorURL: Self.priorURL
+    )
+    let reference = ReceiptReference(imageID: "known", receiptID: 2)
+    let neighbors = [
+      SectionNeighbor(
+        reference: reference,
+        lineID: 9,
+        rowLineIDs: [9, 10],
+        document: "VISA 5.40",
+        cosineSimilarity: 0.95,
+        metadataSection: "ITEMS",
+        metadataMerchantName: "Store"
+      )
+    ]
+    let known = KnownReceiptEvidence(
+      reference: reference,
+      validSectionByLine: [9: "PAYMENT", 10: "PAYMENT"]
+    )
+
+    let assignment = try XCTUnwrap(
+      decoder.assign(
+        rows: [row(1, "VISA 5.40", y: 0.1, amount: "5.40")],
+        merchantName: nil,
+        neighbors: [neighbors],
+        knownEvidence: [reference: known]
+      ).first
+    )
+
+    XCTAssertEqual(assignment.neighborCount, 1)
+    XCTAssertNotNil(assignment.neighborConfidence)
+    // The unverified Chroma metadata says ITEMS and must not be used.
+    XCTAssertNotEqual(assignment.sectionType, "ITEMS")
+  }
+
+  func testMerchantResolutionAbstainsOnConflictingIdentity() {
+    let resolver = ReceiptIdentityResolver()
+    let reference = ReceiptReference(imageID: "known", receiptID: 3)
+    let identity = ReceiptIdentitySignals(
+      merchantNames: ["Completely Different Shop"]
+    )
+    let neighbors = [
+      [
+        SectionNeighbor(
+          reference: reference,
+          lineID: 1,
+          rowLineIDs: [1],
+          document: nil,
+          cosineSimilarity: 0.95,
+          metadataSection: nil,
+          metadataMerchantName: nil
+        )
+      ]
+    ]
+    let known = KnownReceiptEvidence(
+      reference: reference,
+      placeID: "place-1",
+      merchantName: "Trusted Grocery",
+      placeValidationStatus: "MATCHED",
+      placeConfidence: 0.99
+    )
+
+    let result = resolver.resolveKnown(
+      identity: identity,
+      neighbors: neighbors,
+      knownEvidence: [reference: known]
+    )
+
+    XCTAssertNil(result.resolution)
+    XCTAssertEqual(
+      result.conflict,
+      "LayoutLM identity conflicts with known receipt identity"
+    )
+  }
+
+  func testMerchantResolutionUsesReliableKnownReceiptEvidence() throws {
+    let resolver = ReceiptIdentityResolver()
+    let reference = ReceiptReference(imageID: "known", receiptID: 4)
+    let known = KnownReceiptEvidence(
+      reference: reference,
+      placeID: "place-1",
+      merchantName: "Trusted Grocery",
+      formattedAddress: "123 Main Street",
+      placeValidationStatus: "MATCHED",
+      placeConfidence: 0.99
+    )
+    let result = resolver.resolveKnown(
+      identity: ReceiptIdentitySignals(
+        merchantNames: ["Trusted Grocery"],
+        addresses: ["123 Main Street"]
+      ),
+      neighbors: [
+        [
+          SectionNeighbor(
+            reference: reference,
+            lineID: 1,
+            rowLineIDs: [1],
+            document: nil,
+            cosineSimilarity: 0.95,
+            metadataSection: nil,
+            metadataMerchantName: nil
+          )
+        ]
+      ],
+      knownEvidence: [reference: known]
+    )
+
+    let resolution = try XCTUnwrap(result.resolution)
+    XCTAssertNil(result.conflict)
+    XCTAssertEqual(resolution.source, .knownReceipt)
+    XCTAssertEqual(resolution.placeID, "place-1")
+    XCTAssertEqual(
+      resolution.matchedFields,
+      ["merchant_name", "address"]
+    )
+  }
+
+  func testUnknownMerchantAbstainsInsteadOfCreatingNegativePlace() {
+    let resolver = ReceiptIdentityResolver()
+    let result = resolver.resolvePlaces(
+      identity: ReceiptIdentitySignals(),
+      candidate: nil
+    )
+    XCTAssertEqual(result.source, .abstained)
+    XCTAssertNil(result.placeID)
+  }
+
+  func testPunctuationAndTrivialPhoneDoNotCountAsIdentityMatches() {
+    let resolver = ReceiptIdentityResolver()
+    let reference = ReceiptReference(imageID: "known", receiptID: 5)
+    let known = KnownReceiptEvidence(
+      reference: reference,
+      placeID: "place-1",
+      merchantName: "Trusted Grocery",
+      formattedAddress: "123 Main Street",
+      phoneNumber: "0000000000",
+      placeValidationStatus: "MATCHED",
+      placeConfidence: 0.99
+    )
+    let result = resolver.resolveKnown(
+      identity: ReceiptIdentitySignals(
+        addresses: ["---"],
+        phoneNumbers: ["0000000000"]
+      ),
+      neighbors: [
+        [
+          SectionNeighbor(
+            reference: reference,
+            lineID: 1,
+            rowLineIDs: [1],
+            document: nil,
+            cosineSimilarity: 0.95,
+            metadataSection: nil,
+            metadataMerchantName: nil
+          )
+        ]
+      ],
+      knownEvidence: [reference: known]
+    )
+
+    XCTAssertNil(result.resolution)
+    XCTAssertNotNil(result.conflict)
+  }
+
+  func testConflictsCreateNeedsReviewPayloadsAndNeverValidPayloads() {
+    let candidates = ReceiptCandidateBuilder().build(
+      reference: ReceiptReference(imageID: "image", receiptID: 1),
+      sections: [
+        SectionAssignment(
+          rowID: 1,
+          lineIDs: [1],
+          sectionType: "ITEMS",
+          confidence: 0.8
+        )
+      ],
+      merchant: .abstained("identity conflict"),
+      issues: [
+        ConsistencyIssue(
+          code: "MERCHANT_IDENTITY_CONFLICT",
+          severity: .conflict,
+          message: "conflict"
+        )
+      ]
+    )
+
+    XCTAssertEqual(candidates.map(\.validationStatus), [.needsReview])
+    XCTAssertEqual(
+      candidates.first?.conditionExpression,
+      "attribute_not_exists(PK) AND attribute_not_exists(SK)"
+    )
+    XCTAssertEqual(
+      candidates.first?.idempotencyKey,
+      "IMAGE#image#RECEIPT#00001#SECTION#ITEMS"
+    )
+  }
+
+  func testUncertainSectionsNeedReviewWhileHighConfidenceSectionsStayPending() {
+    let builder = ReceiptCandidateBuilder()
+    let reference = ReceiptReference(imageID: "image", receiptID: 1)
+    let uncertain = builder.build(
+      reference: reference,
+      sections: [
+        SectionAssignment(
+          rowID: 1,
+          lineIDs: [1],
+          sectionType: "ITEMS",
+          confidence: 0.59
+        )
+      ],
+      merchant: .abstained("unknown"),
+      issues: []
+    )
+    let confident = builder.build(
+      reference: reference,
+      sections: [
+        SectionAssignment(
+          rowID: 1,
+          lineIDs: [1],
+          sectionType: "ITEMS",
+          confidence: 0.9
+        )
+      ],
+      merchant: .abstained("unknown"),
+      issues: []
+    )
+
+    XCTAssertEqual(uncertain.first?.validationStatus, .needsReview)
+    XCTAssertEqual(confident.first?.validationStatus, .pending)
+  }
+
+  func testOpenAIFailureFallsBackOfflineAndStillDecodesSections() async throws {
+    let pipeline = try ReceiptUnderstandingPipeline(
+      priorURL: Self.priorURL,
+      embedder: FailingEmbedder()
+    )
+
+    let report = await pipeline.analyze(
+      reference: ReceiptReference(imageID: "image", receiptID: 1),
+      lines: [line("TOTAL 5.40")],
+      predictions: [
+        LinePrediction(
+          tokens: ["TOTAL", "5.40"],
+          labels: ["B-GRAND_TOTAL", "I-GRAND_TOTAL"],
+          confidences: [0.9, 0.9],
+          allProbabilities: nil
+        )
+      ]
+    )
+
+    XCTAssertTrue(report.offlineFallback)
+    XCTAssertFalse(report.sections.isEmpty)
+    XCTAssertTrue(
+      report.candidates.allSatisfy {
+        $0.validationStatus == .needsReview
+          && $0.provenance.contains("offline_fallback")
+      }
+    )
+    XCTAssertTrue(
+      report.errors.contains {
+        $0.hasPrefix("openai_embeddings:")
+      }
+    )
+    XCTAssertGreaterThanOrEqual(report.totalMilliseconds, 0)
+    XCTAssertTrue(
+      report.timings.contains { $0.stage == "section_decoder" }
+    )
+  }
+
+  func testMissingEmbeddingsAndChromaFailureAreNonfatal() async throws {
+    let missingPipeline = try ReceiptUnderstandingPipeline(
+      priorURL: Self.priorURL,
+      embedder: MissingEmbedder()
+    )
+    let missing = await missingPipeline.analyze(
+      reference: ReceiptReference(imageID: "image", receiptID: 1),
+      lines: [line("TOTAL 5.40")],
+      predictions: []
+    )
+    XCTAssertTrue(missing.offlineFallback)
+    XCTAssertTrue(
+      missing.errors.contains {
+        $0.contains("missing or dimension-mismatched")
+      }
+    )
+    XCTAssertFalse(missing.sections.isEmpty)
+    XCTAssertTrue(
+      missing.candidates.allSatisfy {
+        $0.validationStatus == .needsReview
+      }
+    )
+
+    let chromaPipeline = try ReceiptUnderstandingPipeline(
+      priorURL: Self.priorURL,
+      embedder: StaticEmbedder(),
+      neighborQuery: FailingNeighbors()
+    )
+    let chroma = await chromaPipeline.analyze(
+      reference: ReceiptReference(imageID: "image", receiptID: 1),
+      lines: [line("TOTAL 5.40")],
+      predictions: []
+    )
+    XCTAssertTrue(chroma.offlineFallback)
+    XCTAssertTrue(
+      chroma.errors.contains { $0.hasPrefix("chroma_query:") }
+    )
+    XCTAssertFalse(chroma.sections.isEmpty)
+    XCTAssertTrue(
+      chroma.candidates.allSatisfy {
+        $0.validationStatus == .needsReview
+      }
+    )
+  }
+
+  func testPlacesFailureIsTimedAndMarksOfflineFallback() async throws {
+    let pipeline = try ReceiptUnderstandingPipeline(
+      priorURL: Self.priorURL,
+      embedder: StaticEmbedder(),
+      neighborQuery: EmptyNeighbors(),
+      places: FailingPlaces()
+    )
+    let report = await pipeline.analyze(
+      reference: ReceiptReference(imageID: "image", receiptID: 1),
+      lines: [line("TRUSTED GROCERY")],
+      predictions: [
+        LinePrediction(
+          tokens: ["TRUSTED", "GROCERY"],
+          labels: ["B-MERCHANT_NAME", "I-MERCHANT_NAME"],
+          confidences: [0.95, 0.95],
+          allProbabilities: nil
+        )
+      ]
+    )
+
+    XCTAssertTrue(report.offlineFallback)
+    XCTAssertTrue(
+      report.errors.contains { $0.hasPrefix("places_lookup:") }
+    )
+    XCTAssertTrue(
+      report.timings.contains { $0.stage == "places_lookup" }
+    )
+  }
+
+  func testKnownReceiptHydrationIsBoundedToStrongestReferences() async throws {
+    let evidence = EvidenceSpy()
+    let pipeline = try ReceiptUnderstandingPipeline(
+      priorURL: Self.priorURL,
+      embedder: StaticEmbedder(),
+      neighborQuery: ManyNeighbors(),
+      knownEvidenceProvider: evidence
+    )
+    _ = await pipeline.analyze(
+      reference: ReceiptReference(imageID: "image", receiptID: 1),
+      lines: [line("TOTAL 5.40")],
+      predictions: []
+    )
+
+    let references = await evidence.requestedReferences()
+    XCTAssertEqual(
+      references.count,
+      ReceiptUnderstandingConstants.maximumKnownReceiptReferences
+    )
+    XCTAssertTrue(
+      references.contains(
+        ReceiptReference(imageID: "known-0", receiptID: 1)
+      )
+    )
+    XCTAssertFalse(
+      references.contains(
+        ReceiptReference(imageID: "known-29", receiptID: 1)
+      )
+    )
+  }
+
+  func testConsistencyChecksLabelsSectionsAndArithmeticIndependently() {
+    let rows = [
+      row(
+        1,
+        "APPLE 4.00",
+        y: 0.6,
+        amount: "4.00",
+        labels: ["PRODUCT_NAME"]
+      ),
+      row(
+        2,
+        "SUBTOTAL 4.00",
+        y: 0.3,
+        amount: "4.00",
+        labels: ["SUBTOTAL"]
+      ),
+      row(
+        3,
+        "TAX 1.00",
+        y: 0.2,
+        amount: "1.00",
+        labels: ["TAX"]
+      ),
+      row(
+        4,
+        "TOTAL 9.00",
+        y: 0.1,
+        amount: "9.00",
+        labels: ["GRAND_TOTAL"]
+      ),
+    ]
+    let assignments = rows.map {
+      SectionAssignment(
+        rowID: $0.rowID,
+        lineIDs: $0.lineIDs,
+        sectionType: "PAYMENT",
+        confidence: 0.9
+      )
+    }
+    let issues = ReceiptConsistencyChecker().check(
+      rows: rows,
+      sections: assignments,
+      merchant: .abstained("unknown")
+    )
+
+    XCTAssertTrue(
+      issues.contains { $0.code == "ITEM_LABEL_OUTSIDE_ITEMS" }
+    )
+    XCTAssertTrue(
+      issues.contains { $0.code == "SUMMARY_LABEL_OUTSIDE_SUMMARY" }
+    )
+    XCTAssertTrue(
+      issues.contains { $0.code == "RECEIPT_ARITHMETIC_CONFLICT" }
+    )
+  }
+}

--- a/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/VisualRowBuilderTests.swift
+++ b/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/VisualRowBuilderTests.swift
@@ -1,0 +1,309 @@
+import CoreGraphics
+import XCTest
+
+@testable import ReceiptOCRCore
+
+final class VisualRowBuilderTests: XCTestCase {
+  private func point(_ x: CGFloat, _ y: CGFloat) -> CodablePoint {
+    CodablePoint(x: x, y: y)
+  }
+
+  private func makeWord(
+    _ text: String,
+    x: CGFloat,
+    y: CGFloat = 0,
+    width: CGFloat,
+    height: CGFloat = 0.04
+  ) -> Word {
+    Word(
+      text: text,
+      boundingBox: NormalizedRect(x: x, y: y, width: width, height: height),
+      topLeft: point(x, y + height),
+      topRight: point(x + width, y + height),
+      bottomLeft: point(x, y),
+      bottomRight: point(x + width, y),
+      angleDegrees: 0,
+      angleRadians: 0,
+      confidence: 1,
+      letters: [],
+      extractedData: nil
+    )
+  }
+
+  private func makeLine(
+    _ text: String,
+    x: CGFloat,
+    y: CGFloat,
+    width: CGFloat = 0.2,
+    height: CGFloat = 0.1,
+    words: [Word] = []
+  ) -> Line {
+    Line(
+      text: text,
+      boundingBox: NormalizedRect(x: x, y: y, width: width, height: height),
+      topLeft: point(x, y + height),
+      topRight: point(x + width, y + height),
+      bottomLeft: point(x, y),
+      bottomRight: point(x + width, y),
+      angleDegrees: 0,
+      angleRadians: 0,
+      confidence: 1,
+      words: words
+    )
+  }
+
+  func test_emptyInputProducesNoRows() {
+    XCTAssertEqual(VisualRowBuilder().build(lines: []), [])
+  }
+
+  func test_filteredLineDoesNotReclaimItsOriginalID() {
+    let lines = [
+      makeLine("", x: 0.1, y: 0.9),
+      makeLine("KEPT", x: 0.1, y: 0.5),
+    ]
+    let predictions = [
+      LinePrediction(
+        tokens: ["DROPPED"],
+        labels: ["O"],
+        confidences: [1],
+        allProbabilities: nil
+      ),
+      LinePrediction(
+        tokens: ["KEPT"],
+        labels: ["B-MERCHANT_NAME"],
+        confidences: [1],
+        allProbabilities: nil
+      ),
+    ]
+
+    let rows = VisualRowBuilder().build(lines: lines, predictions: predictions)
+
+    XCTAssertEqual(rows.count, 1)
+    XCTAssertEqual(rows[0].rowID, 2)
+    XCTAssertEqual(rows[0].lineIDs, [2])
+    XCTAssertEqual(rows[0].layoutEvidence.first?.lineID, 2)
+  }
+
+  func test_inclusiveCentroidOverlapUsesTransitiveComponents() {
+    let lines = [
+      makeLine("TOP", x: 0.1, y: 0.9),
+      // A and B touch only because A's centroid is exactly B's upper edge.
+      makeLine("A", x: 0.8, y: 0.5, height: 0.25),
+      // B similarly connects to C, while A and C do not directly overlap.
+      makeLine("B", x: 0.4, y: 0.125, height: 0.5),
+      makeLine("C", x: 0.1, y: 0, height: 0.375),
+    ]
+
+    let rows = VisualRowBuilder().build(lines: lines)
+
+    XCTAssertEqual(rows.count, 2)
+    XCTAssertEqual(rows[0].lineIDs, [1])
+    XCTAssertEqual(rows[0].embeddingInput, "<EDGE>\nTOP\nC B A")
+    XCTAssertEqual(rows[1].rowID, 4)
+    XCTAssertEqual(rows[1].lineIDs, [4, 3, 2])
+    XCTAssertEqual(rows[1].text, "C B A")
+    XCTAssertEqual(rows[1].embeddingInput, "TOP\nC B A\n<EDGE>")
+  }
+
+  func test_equalXKeepsOriginalLineOrder() {
+    let lines = [
+      makeLine("FIRST", x: 0.2, y: 0.5),
+      makeLine("SECOND", x: 0.2, y: 0.52),
+    ]
+
+    let rows = VisualRowBuilder().build(lines: lines)
+
+    XCTAssertEqual(rows.map(\.lineIDs), [[1, 2]])
+    XCTAssertEqual(rows[0].rowID, 1)
+    XCTAssertEqual(rows[0].text, "FIRST SECOND")
+  }
+
+  func test_priceColumnAndLabelPairingMatchPythonReceiptRows() throws {
+    let lines = [
+      makeLine(
+        "ORGANIC APPLES",
+        x: 0.05,
+        y: 0.80,
+        width: 0.45,
+        height: 0.04,
+        words: [
+          makeWord("ORGANIC", x: 0.05, y: 0.80, width: 0.18),
+          makeWord("APPLES", x: 0.25, y: 0.80, width: 0.16),
+        ]
+      ),
+      makeLine(
+        "$4.99",
+        x: 0.82,
+        y: 0.80,
+        width: 0.13,
+        height: 0.04,
+        words: [makeWord("$4.99", x: 0.82, y: 0.80, width: 0.13)]
+      ),
+      makeLine(
+        "TOTAL $4.99",
+        x: 0.05,
+        y: 0.20,
+        width: 0.90,
+        height: 0.04,
+        words: [
+          makeWord("TOTAL", x: 0.05, y: 0.20, width: 0.15),
+          makeWord("$4.99", x: 0.82, y: 0.20, width: 0.13),
+        ]
+      ),
+      makeLine(
+        "$0.50",
+        x: 0.40,
+        y: 0.05,
+        width: 0.15,
+        height: 0.04,
+        words: [makeWord("$0.50", x: 0.40, y: 0.05, width: 0.15)]
+      ),
+    ]
+
+    let rows = VisualRowBuilder().build(lines: lines)
+    let itemRow = try XCTUnwrap(rows.first)
+    let totalRow = try XCTUnwrap(rows.dropFirst().first)
+
+    XCTAssertEqual(itemRow.rowID, 1)
+    XCTAssertEqual(itemRow.lineIDs, [1, 2])
+    XCTAssertEqual(
+      try XCTUnwrap(itemRow.priceColumnX),
+      0.95,
+      accuracy: 0.000_001
+    )
+    XCTAssertEqual(itemRow.labelText, "ORGANIC APPLES")
+    XCTAssertEqual(itemRow.amountText, "$4.99")
+    XCTAssertEqual(itemRow.bounds.xMin, 0.05, accuracy: 0.000_001)
+    XCTAssertEqual(itemRow.bounds.yMin, 0.80, accuracy: 0.000_001)
+    XCTAssertEqual(itemRow.bounds.xMax, 0.95, accuracy: 0.000_001)
+    XCTAssertEqual(itemRow.bounds.yMax, 0.84, accuracy: 0.000_001)
+
+    XCTAssertEqual(totalRow.rowID, 3)
+    XCTAssertEqual(totalRow.labelText, "TOTAL")
+    XCTAssertEqual(totalRow.amountText, "$4.99")
+    // The isolated amount is not close enough to the dominant price column.
+    XCTAssertNil(rows.last?.amountText)
+  }
+
+  func test_layoutEvidenceUsesOriginalIDsAfterGeometrySorting() {
+    let lines = [
+      makeLine("BOTTOM", x: 0.1, y: 0.1),
+      makeLine("9.99", x: 0.8, y: 0.8),
+      makeLine("PRODUCT", x: 0.1, y: 0.8),
+    ]
+    let predictions = [
+      LinePrediction(
+        tokens: ["BOTTOM"],
+        labels: ["B-FOOTER"],
+        confidences: [0.7],
+        allProbabilities: nil
+      ),
+      LinePrediction(
+        tokens: ["9.99"],
+        labels: ["B-LINE_TOTAL"],
+        confidences: [0.9],
+        allProbabilities: nil
+      ),
+      // The shorter label array maps only word 1 and never shifts line 2.
+      LinePrediction(
+        tokens: ["PRODUCT", "EXTRA"],
+        labels: ["B-PRODUCT_NAME"],
+        confidences: [0.8, 0.1],
+        allProbabilities: nil
+      ),
+    ]
+
+    let rows = VisualRowBuilder().build(
+      lines: lines,
+      predictions: predictions
+    )
+
+    XCTAssertEqual(rows[0].lineIDs, [3, 2])
+    XCTAssertEqual(rows[0].rowID, 3)
+    XCTAssertEqual(rows[0].embeddingInput, "<EDGE>\nPRODUCT 9.99\nBOTTOM")
+    XCTAssertEqual(
+      rows[0].layoutEvidence,
+      [
+        LayoutWordEvidence(
+          lineID: 3,
+          wordID: 1,
+          text: "PRODUCT",
+          label: "B-PRODUCT_NAME",
+          confidence: Double(Float(0.8))
+        ),
+        LayoutWordEvidence(
+          lineID: 2,
+          wordID: 1,
+          text: "9.99",
+          label: "B-LINE_TOTAL",
+          confidence: Double(Float(0.9))
+        ),
+      ]
+    )
+    XCTAssertEqual(rows[1].layoutEvidence.first?.lineID, 1)
+  }
+
+  func test_amountRecognitionMatchesCanonicalCentsPattern() {
+    let cases: [(String, Bool)] = [
+      ("$12.99", true),
+      ("1234.56", true),
+      ("$10000.00", true),
+      ("1,234.50", true),
+      ("(2.00)", true),
+      ("12,34.56", false),
+      ("12/99", false),
+    ]
+
+    for (text, expected) in cases {
+      XCTAssertEqual(
+        VisualRowBuilder.isAmountText(text),
+        expected,
+        "unexpected amount recognition for \(text)"
+      )
+    }
+  }
+
+  func testSharedSwiftPythonFixtureHasIdenticalRowsAndContexts() throws {
+    struct Envelope: Decodable {
+      let receipts: [ReceiptOutput]
+    }
+    let fixtureURL = URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()
+      .appendingPathComponent("Fixtures/swift_single_pass_contract.json")
+    let decoder = JSONDecoder()
+    decoder.keyDecodingStrategy = .convertFromSnakeCase
+    let receipt = try XCTUnwrap(
+      decoder.decode(
+        Envelope.self,
+        from: Data(contentsOf: fixtureURL)
+      ).receipts.first
+    )
+
+    let rows = VisualRowBuilder().build(
+      lines: try XCTUnwrap(receipt.lines),
+      predictions: receipt.layoutlmPredictions ?? []
+    )
+
+    XCTAssertEqual(rows.map(\.rowID), [1, 3, 4])
+    XCTAssertEqual(
+      rows.map(\.text),
+      [
+        "SPROUTS FARMERS MARKET",
+        "ORGANIC BANANAS 3.99",
+        "TOTAL 3.99",
+      ]
+    )
+    XCTAssertEqual(
+      rows.map(\.embeddingInput),
+      [
+        "<EDGE>\nSPROUTS FARMERS MARKET\nORGANIC BANANAS 3.99",
+        "SPROUTS FARMERS MARKET\nORGANIC BANANAS 3.99\nTOTAL 3.99",
+        "ORGANIC BANANAS 3.99\nTOTAL 3.99\n<EDGE>",
+      ]
+    )
+    XCTAssertEqual(rows[1].labelText, "ORGANIC")
+    XCTAssertEqual(rows[1].amountText, "3.99")
+    XCTAssertEqual(rows[2].labelText, "TOTAL")
+    XCTAssertEqual(rows[2].amountText, "3.99")
+  }
+}


### PR DESCRIPTION
## Summary

- add a typed async `ReceiptChroma` Swift library for Chroma Cloud v2 reads/writes, validation, batching, retry handling, and filters
- reproduce the Python visual-row, context, OpenAI `text-embedding-3-small` (1,536-dimensional), row metadata, stable-ID, and current-receipt exclusion contracts
- add the Mac first-pass receipt understanding pipeline: LayoutLM identity signals, VALID known-receipt hydration, conservative Places fallback, deterministic semi-Markov sections with cosine-weighted cross-receipt evidence, and independent label/order/identity/arithmetic checks
- emit create-only PENDING/NEEDS_REVIEW candidate payloads with confidence, model version, evidence, and provenance; offline or conflicting results are always NEEDS_REVIEW
- make existing LayoutLM word-label persistence conditional and idempotent so existing records, including human-VALID records, cannot be replaced

## Rollout safety

- disabled by default behind `RECEIPT_UNDERSTANDING_SHADOW=1`
- no production candidate writer
- shadow network work starts only after OCR uploads, routing, result notification, job completion, and input SQS acknowledgement
- OpenAI, Chroma, Places, configuration, and analysis failures cannot fail OCR publication
- normal logs contain only counts and stage timings; full comparison reports are optional local 0600 files in a 0700 directory
- Chroma section metadata is never treated as truth; section evidence must hydrate from VALID DynamoDB `ReceiptSection` records

## Existing work reused

I inspected `codex/section-geometry-visualization` / draft PR #1289 before implementing. It contains the section-geometry research but no Swift implementation or deployable centroid artifact. This change reuses the packaged deterministic prior asset and the directly reproducible VALID-receipt KNN evidence without copying or inventing a centroid model.

## Verification

- `swift build --target ReceiptOCRCore`
- `swift build --target ReceiptChroma`
- all new ReceiptOCRCore and ReceiptChroma Swift test sources compile/typecheck
- `xcrun swift-format lint` passes for all new Swift sources/tests
- 46 Python parity/golden tests pass across row formatting, section assignment, and the shared Swift/Python OCR payload contract

`swift test` cannot execute on this host because only Command Line Tools are installed and its Swift toolchain has no XCTest module. The test sources were typechecked against the built modules as a host-compatible substitute; CI/full Xcode should execute them.