### PR TITLE
fix(viz): address similarity cache ignores label validation status

### DIFF
--- a/infra/routes/address_similarity_cache_generator/lambdas/index.py
+++ b/infra/routes/address_similarity_cache_generator/lambdas/index.py
@@ -250,6 +250,14 @@ def handler(_event, _context):
         address_labels, _ = dynamo_client.get_receipt_word_labels_by_label(
             "ADDRESS_LINE", limit=100
         )
+        # Only VALID labels: invalidated ADDRESS_LINE rows (e.g. promo fine
+        # print whose state abbreviations fooled a labeling pass) must not
+        # seed or render in the similarity viz.
+        address_labels = [
+            lbl
+            for lbl in address_labels
+            if lbl.validation_status == "VALID"
+        ]
 
         if not address_labels:
             logger.warning("No address labels found")
@@ -285,6 +293,7 @@ def handler(_event, _context):
             label
             for label in original_receipt.labels
             if label.label.upper() == "ADDRESS_LINE"
+            and label.validation_status == "VALID"
         ]
 
         # Group address labels by line_id
@@ -520,6 +529,7 @@ def handler(_event, _context):
                     label
                     for label in similar_receipt.labels
                     if label.label.upper() == "ADDRESS_LINE"
+                    and label.validation_status == "VALID"
                 ]
 
                 if not similar_labels:


### PR DESCRIPTION
## Problem

The address-similarity viz on tylernorlund.com renders promo fine print as an "address" crop (seen on receipt `86cca8b7:1`, Similar #3): the text *"Valid 6/24/24–6/30/24 in-store in our AZ … CA, CO, FL, KS…"* shows up alongside the real address regions.

## Root cause

The promo lines **were** mislabeled `ADDRESS_LINE` (state abbreviations fooled a labeling pass) — but validation already caught them and marked all three lines **INVALID**. The cache generator never checks `validation_status`, in three places:

1. the random seed pick from `get_receipt_word_labels_by_label("ADDRESS_LINE")`
2. the original receipt's address crop groups
3. each similar receipt's crop groups

So invalidated labels still seed and render in the similarity cards.

## Fix

Filter to `validation_status == "VALID"` at all three selection sites. (The Dynamo accessor has no status parameter, so the filter is client-side in the Lambda.)

## Verification

- Confirmed on dev that `86cca8b7:1` lines 69–71 carry `ADDRESS_LINE/INVALID` while the genuine address (lines 29–31) is VALID — with this filter the promo block can no longer be selected.
- Takes effect after deploy + the next scheduled cache generation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RYquMqYASyC2K7T9TJWLJ7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved address similarity results by excluding invalidated address-line labels from candidate selection and receipt comparisons.
  * Ensured only valid address-line data contributes to similarity matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->