### PR TITLE
fix(pairing): recover product names printed right of the amount

### DIFF
--- a/receipt_chroma/receipt_chroma/embedding/formatting/receipt_rows.py
+++ b/receipt_chroma/receipt_chroma/embedding/formatting/receipt_rows.py
@@ -136,6 +136,20 @@ def pair_row_label_amount(
         for word in row_words
         if _right_edge(word) <= amount_x and not is_amount_text(word.text)
     ).strip()
+    if not label_text:
+        # Amount-left layouts put the product name to the RIGHT of the price
+        # ("2.49 SOUR CREAM", "$14.00 Spicy Salame Sandwich"). The left-side
+        # scan above yields nothing for those rows, and the name used to be
+        # dropped entirely -- a corpus audit found 208 stored rows carrying an
+        # amount with an empty label. Only consult the right side when the
+        # left side is empty, so normal label-left rows are untouched.
+        amount_right = _right_edge(amount)
+        label_text = " ".join(
+            word.text.strip()
+            for word in row_words
+            if float(word.bounding_box.get("x", 0.0)) >= amount_right
+            and not is_amount_text(word.text)
+        ).strip()
     return LabelAmountPair(
         label_text=label_text,
         amount_text=amount.text,

--- a/receipt_chroma/tests/unit/test_receipt_rows.py
+++ b/receipt_chroma/tests/unit/test_receipt_rows.py
@@ -153,3 +153,63 @@ def test_build_receipt_rows_rejects_mixed_receipts() -> None:
 
     with pytest.raises(ValueError, match="exactly one receipt"):
         build_receipt_rows(lines, [])
+
+
+def test_build_receipt_rows_recovers_label_right_of_amount() -> None:
+    """Amount-left layouts keep the product name.
+
+    Sprouts and several restaurant formats print the price first
+    ("2.49 SOUR CREAM"). The label is assembled from words left of the
+    amount, which is empty for these rows, so the name used to be dropped.
+    """
+    lines = [
+        FakeLine(
+            1,
+            "2.49 SOUR CREAM",
+            {"x": 0.05, "y": 0.60, "width": 0.90, "height": 0.04},
+        ),
+        FakeLine(
+            2,
+            "3.99 WHOLE MILK",
+            {"x": 0.05, "y": 0.50, "width": 0.90, "height": 0.04},
+        ),
+    ]
+    words = [
+        FakeWord(1, 1, "2.49", {"x": 0.05, "width": 0.12}),
+        FakeWord(1, 2, "SOUR", {"x": 0.25, "width": 0.14}),
+        FakeWord(1, 3, "CREAM", {"x": 0.42, "width": 0.16}),
+        FakeWord(2, 1, "3.99", {"x": 0.05, "width": 0.12}),
+        FakeWord(2, 2, "WHOLE", {"x": 0.25, "width": 0.15}),
+        FakeWord(2, 3, "MILK", {"x": 0.43, "width": 0.13}),
+    ]
+
+    rows = build_receipt_rows(lines, words)
+
+    assert [r.label_text for r in rows] == ["SOUR CREAM", "WHOLE MILK"]
+    assert [r.amount_text for r in rows] == ["2.49", "3.99"]
+
+
+def test_build_receipt_rows_prefers_label_left_of_amount() -> None:
+    """The right-side fallback must not fire when a left label exists.
+
+    Trailing tokens after the price (tax flags like "T", "<A>") must not be
+    appended to, or replace, a perfectly good left-hand label.
+    """
+    lines = [
+        FakeLine(
+            1,
+            "ORGANIC APPLES $4.99 T",
+            {"x": 0.05, "y": 0.60, "width": 0.92, "height": 0.04},
+        )
+    ]
+    words = [
+        FakeWord(1, 1, "ORGANIC", {"x": 0.05, "width": 0.18}),
+        FakeWord(1, 2, "APPLES", {"x": 0.25, "width": 0.16}),
+        FakeWord(1, 3, "$4.99", {"x": 0.75, "width": 0.16}),
+        FakeWord(1, 4, "T", {"x": 0.93, "width": 0.04}),
+    ]
+
+    rows = build_receipt_rows(lines, words)
+
+    assert rows[0].label_text == "ORGANIC APPLES"
+    assert rows[0].amount_text == "$4.99"


### PR DESCRIPTION
## The bug

`pair_row_label_amount` assembles a row's label only from words whose right edge is at or left of the amount's left edge:

```python
if _right_edge(word) <= amount_x and not is_amount_text(word.text)
```

Receipts that print the price first — `2.49 SOUR CREAM`, `$14.00 Spicy Salame Sandwich` — yield an empty label, and the product name is discarded. The row still gets an `amount_text`, so it looks like a valid line item with a blank name.

## Scale

A dev-corpus audit found **208 stored rows carrying an amount with an empty label**. An independent re-run of the pairing logic across all 686 receipts with an ITEMS section attributed **30 ITEMS-zone rows** to this layout specifically, concentrated in Sprouts, In-N-Out, and Pasta Sisters.

This is the cheap half of the name-loss problem. The other half — continuation lines, where the name is on an *adjacent* row — is ~204 rows, needs cross-row inference, and is not addressed here. This fix involves no inference at all: the name is already in the same row, just on the wrong side of the price.

## The fix

Fall back to words right of the amount **only when the left-hand label is empty**. Label-left rows are untouched, and trailing tax flags (`T`, `<A>`) are never appended to a good label.

## Validation

Loading both module versions side by side:

```
BEFORE: label=''            amount='2.49'
AFTER : label='SOUR CREAM'  amount='2.49'

guard — "ORGANIC APPLES $4.99 T":
BEFORE: 'ORGANIC APPLES'
AFTER : 'ORGANIC APPLES'
```

Two tests added: one for the recovered layout, one pinning the guard. 13/13 pass.

⚠️ **Note for reviewers:** running those tests under pytest does *not* by itself demonstrate the fix. pytest inserts the package rootdir onto `sys.path`, so a fixed and an unfixed checkout import the same source and both pass. I hit this while trying to prove the tests fail without the change. The side-by-side module load above is what actually distinguishes them.

## Related

- #1299 — the backfill script that was stripping pairing entirely
- Continuation-line defect (~204 rows, 81% concentrated in Wild Fork / Home Depot / Floor & Decor) is measured but deliberately not fixed here; a gap-based rule was tested and ruled out on measured distributions.