### PR TITLE
feat(search): exclude non-item sections from product-line search

### DIFF
--- a/infra/mcp_server_lambda/lambdas/receipt_mcp_server_server.py
+++ b/infra/mcp_server_lambda/lambdas/receipt_mcp_server_server.py
@@ -96,13 +96,21 @@ def _load_config():
             config = {
                 "dynamodb_table_name": table_env,
                 "openai_api_key": os.environ.get("OPENAI_API_KEY", ""),
-                "chroma_cloud_api_key": os.environ.get("CHROMA_CLOUD_API_KEY", ""),
-                "chroma_cloud_tenant": os.environ.get("CHROMA_CLOUD_TENANT", ""),
-                "chroma_cloud_database": os.environ.get("CHROMA_CLOUD_DATABASE", ""),
+                "chroma_cloud_api_key": os.environ.get(
+                    "CHROMA_CLOUD_API_KEY", ""
+                ),
+                "chroma_cloud_tenant": os.environ.get(
+                    "CHROMA_CLOUD_TENANT", ""
+                ),
+                "chroma_cloud_database": os.environ.get(
+                    "CHROMA_CLOUD_DATABASE", ""
+                ),
                 "chroma_cloud_enabled": "true",
                 "openrouter_api_key": os.environ.get("OPENROUTER_API_KEY", ""),
                 "langchain_api_key": os.environ.get("LANGCHAIN_API_KEY", ""),
-                "google_places_api_key": os.environ.get("GOOGLE_PLACES_API_KEY", ""),
+                "google_places_api_key": os.environ.get(
+                    "GOOGLE_PLACES_API_KEY", ""
+                ),
             }
         else:
             from receipt_dynamo.data._pulumi import load_env, load_secrets
@@ -110,7 +118,9 @@ def _load_config():
             config = load_env(env=env)
             secrets = load_secrets(env=env)
             for key, value in secrets.items():
-                normalized_key = key.replace("portfolio:", "").lower().replace("-", "_")
+                normalized_key = (
+                    key.replace("portfolio:", "").lower().replace("-", "_")
+                )
                 config[normalized_key] = value
 
         # Environment variables override the merged config for the Chroma
@@ -127,7 +137,9 @@ def _load_config():
 
         # Set up API keys
         if config.get("openai_api_key"):
-            os.environ["RECEIPT_AGENT_OPENAI_API_KEY"] = config["openai_api_key"]
+            os.environ["RECEIPT_AGENT_OPENAI_API_KEY"] = config[
+                "openai_api_key"
+            ]
 
         _config = config
 
@@ -136,7 +148,9 @@ def _load_config():
 
 def chroma_is_configured(config) -> bool:
     """True when Chroma Cloud is enabled and an API key is present."""
-    enabled = str(config.get("chroma_cloud_enabled", "false")).lower() == "true"
+    enabled = (
+        str(config.get("chroma_cloud_enabled", "false")).lower() == "true"
+    )
     return enabled and bool(config.get("chroma_cloud_api_key"))
 
 
@@ -148,7 +162,9 @@ def get_dynamo_client():
         from receipt_agent.clients.factory import create_dynamo_client
 
         config = _load_config()
-        _dynamo_client = create_dynamo_client(table_name=config["dynamodb_table_name"])
+        _dynamo_client = create_dynamo_client(
+            table_name=config["dynamodb_table_name"]
+        )
         logger.info("DynamoDB client initialized")
 
     return _dynamo_client
@@ -652,7 +668,13 @@ Example:
                     },
                     "status_filter": {
                         "type": "string",
-                        "enum": ["VALID", "INVALID", "PENDING", "NEEDS_REVIEW", "NONE"],
+                        "enum": [
+                            "VALID",
+                            "INVALID",
+                            "PENDING",
+                            "NEEDS_REVIEW",
+                            "NONE",
+                        ],
                         "description": "Optional: filter by validation status. Omit to get all statuses.",
                     },
                     "sample_size": {
@@ -713,7 +735,13 @@ recommendation that you can review before taking any action.""",
                         "description": "The label to validate (e.g., GRAND_TOTAL)",
                     },
                 },
-                "required": ["image_id", "receipt_id", "line_id", "word_id", "label"],
+                "required": [
+                    "image_id",
+                    "receipt_id",
+                    "line_id",
+                    "word_id",
+                    "label",
+                ],
             },
         ),
         Tool(
@@ -756,7 +784,13 @@ WARNING: This WRITES to DynamoDB. Double-check the word context before calling."
                     },
                     "new_status": {
                         "type": "string",
-                        "enum": ["VALID", "INVALID", "PENDING", "NEEDS_REVIEW", "NONE"],
+                        "enum": [
+                            "VALID",
+                            "INVALID",
+                            "PENDING",
+                            "NEEDS_REVIEW",
+                            "NONE",
+                        ],
                         "description": "The new validation status to set",
                     },
                     "reasoning": {
@@ -919,7 +953,12 @@ image_id/receipt_id/line_id/word_id/label already exists.""",
                     },
                     "validation_status": {
                         "type": "string",
-                        "enum": ["PENDING", "VALID", "INVALID", "NEEDS_REVIEW"],
+                        "enum": [
+                            "PENDING",
+                            "VALID",
+                            "INVALID",
+                            "NEEDS_REVIEW",
+                        ],
                         "description": "Validation status for the new row. Defaults to VALID (human-reviewed). Use PENDING for machine-propagated rows (e.g. SECTION_* sections) that still need QA.",
                     },
                 },
@@ -1071,7 +1110,9 @@ sheet artifacts while the previous revision remains reviewable.""",
                         "type": "array",
                         "minItems": 1,
                         "maxItems": 23,
-                        "items": _resegment_segment_schema(legacy_selectors=False),
+                        "items": _resegment_segment_schema(
+                            legacy_selectors=False
+                        ),
                     },
                     "assignments": _resegment_assignments_schema(),
                     "visualization": _resegment_visualization_schema(),
@@ -1520,7 +1561,10 @@ that up separately (e.g. an IP-info service).""",
             inputSchema={
                 "type": "object",
                 "properties": {
-                    "ip": {"type": "string", "description": "Client IP (v4 or v6)"},
+                    "ip": {
+                        "type": "string",
+                        "description": "Client IP (v4 or v6)",
+                    },
                     "start_date": {
                         "type": "string",
                         "description": "Start date YYYY-MM-DD (PT)",
@@ -1778,7 +1822,13 @@ WARNING: This WRITES to DynamoDB.""",
                     },
                     "validation_status": {
                         "type": "string",
-                        "enum": ["VALID", "INVALID", "NEEDS_REVIEW", "PENDING", "NONE"],
+                        "enum": [
+                            "VALID",
+                            "INVALID",
+                            "NEEDS_REVIEW",
+                            "PENDING",
+                            "NONE",
+                        ],
                         "description": "The new validation status to set",
                     },
                 },
@@ -1829,7 +1879,13 @@ or any line_id is not on the receipt.""",
                     },
                     "validation_status": {
                         "type": "string",
-                        "enum": ["VALID", "INVALID", "NEEDS_REVIEW", "PENDING", "NONE"],
+                        "enum": [
+                            "VALID",
+                            "INVALID",
+                            "NEEDS_REVIEW",
+                            "PENDING",
+                            "NONE",
+                        ],
                         "description": "Validation status for the new section. Defaults to VALID.",
                     },
                     "model_source": {
@@ -1837,7 +1893,12 @@ or any line_id is not on the receipt.""",
                         "description": "Source tag for the row. Defaults to 'mcp-claude-review'.",
                     },
                 },
-                "required": ["image_id", "receipt_id", "section_type", "line_ids"],
+                "required": [
+                    "image_id",
+                    "receipt_id",
+                    "section_type",
+                    "line_ids",
+                ],
             },
         ),
         Tool(
@@ -1892,7 +1953,9 @@ def _fetch_mcp_preview(url: str) -> bytes:
 
 
 @server.call_tool()
-async def call_tool(name: str, arguments: dict) -> list[TextContent | ImageContent]:
+async def call_tool(
+    name: str, arguments: dict
+) -> list[TextContent | ImageContent]:
     """Handle tool calls."""
     try:
         dynamo_client = get_dynamo_client()
@@ -2091,7 +2154,9 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent | ImageConte
                 section_type=arguments["section_type"],
                 line_ids=arguments["line_ids"],
                 validation_status=arguments.get("validation_status", "VALID"),
-                model_source=arguments.get("model_source", "mcp-claude-review"),
+                model_source=arguments.get(
+                    "model_source", "mcp-claude-review"
+                ),
             )
         elif name == "delete_receipt_section":
             result = await delete_receipt_section_impl(
@@ -2274,7 +2339,9 @@ async def search_receipts_impl(
                 ):
                     key = (meta.get("image_id"), meta.get("receipt_id"))
                     distance = (
-                        results["distances"][0][idx] if results["distances"] else 1.0
+                        results["distances"][0][idx]
+                        if results["distances"]
+                        else 1.0
                     )
                     similarity = max(0.0, 1.0 - distance)
 
@@ -2328,7 +2395,9 @@ async def search_receipts_impl(
         return {"error": str(e)}
 
 
-async def get_receipt_impl(dynamo_client, image_id: str, receipt_id: int) -> dict:
+async def get_receipt_impl(
+    dynamo_client, image_id: str, receipt_id: int
+) -> dict:
     """Get full receipt details."""
     import statistics
 
@@ -2350,7 +2419,9 @@ async def get_receipt_impl(dynamo_client, image_id: str, receipt_id: int) -> dic
             history = labels_by_word.get((line_id, word_id), [])
             valid = [lb for lb in history if lb.validation_status == "VALID"]
             if valid:
-                valid.sort(key=lambda lb: str(lb.timestamp_added), reverse=True)
+                valid.sort(
+                    key=lambda lb: str(lb.timestamp_added), reverse=True
+                )
                 return valid[0].label
             return None
 
@@ -2387,7 +2458,9 @@ async def get_receipt_impl(dynamo_client, image_id: str, receipt_id: int) -> dic
             for w in sorted_words
             if w["word"].bounding_box.get("height")
         ]
-        y_tolerance = max(0.01, statistics.median(heights) * 0.75) if heights else 0.015
+        y_tolerance = (
+            max(0.01, statistics.median(heights) * 0.75) if heights else 0.015
+        )
 
         visual_lines = []
         current_line = [sorted_words[0]]
@@ -2396,7 +2469,9 @@ async def get_receipt_impl(dynamo_client, image_id: str, receipt_id: int) -> dic
         for w in sorted_words[1:]:
             if abs(w["y"] - current_y) <= y_tolerance:
                 current_line.append(w)
-                current_y = sum(c["y"] for c in current_line) / len(current_line)
+                current_y = sum(c["y"] for c in current_line) / len(
+                    current_line
+                )
             else:
                 current_line.sort(key=lambda c: c["x"])
                 visual_lines.append(current_line)
@@ -2429,7 +2504,13 @@ async def get_receipt_impl(dynamo_client, image_id: str, receipt_id: int) -> dic
 
         # Extract amounts
         amounts = []
-        currency_labels = ["TAX", "SUBTOTAL", "GRAND_TOTAL", "LINE_TOTAL", "UNIT_PRICE"]
+        currency_labels = [
+            "TAX",
+            "SUBTOTAL",
+            "GRAND_TOTAL",
+            "LINE_TOTAL",
+            "UNIT_PRICE",
+        ]
         for w in sorted_words:
             if w["label"] in currency_labels:
                 try:
@@ -2569,8 +2650,16 @@ async def search_product_lines_impl(
     """Search for product lines and extract prices for spending analysis.
 
     Supports both text (exact match) and semantic (embedding-based) search.
+    Results exclude sections that never hold products (totals, payment,
+    footer, ...); rows with no section_label are kept, because on
+    under-sectioned receipts those are the product lines.
     """
     import re
+
+    # Imported here, not at module scope: receipt_chroma.__init__ pulls in
+    # chromadb, and this server must stay importable without it
+    # (tests/test_receipt_mcp_lazy_chroma.py).
+    from receipt_chroma.section_labels import non_item_section_filter
 
     try:
         lines_collection = chroma_client.get_collection("lines")
@@ -2592,6 +2681,7 @@ async def search_product_lines_impl(
             results = lines_collection.query(
                 query_embeddings=query_embeddings,
                 n_results=limit * 3,  # Get more to filter duplicates
+                where=non_item_section_filter(),
                 include=["metadatas", "distances"],
             )
 
@@ -2621,7 +2711,11 @@ async def search_product_lines_impl(
                 seen.add(key)
 
                 # Calculate similarity from distance
-                distance = results["distances"][0][idx] if results["distances"] else 1.0
+                distance = (
+                    results["distances"][0][idx]
+                    if results["distances"]
+                    else 1.0
+                )
                 similarity = max(0.0, 1.0 - distance)
 
                 # Skip low similarity results
@@ -2648,7 +2742,9 @@ async def search_product_lines_impl(
             items = items[:limit]
 
             # Calculate total for items that have prices
-            total = sum(item["price"] for item in items if item["price"] is not None)
+            total = sum(
+                item["price"] for item in items if item["price"] is not None
+            )
 
             return {
                 "query": query,
@@ -2664,6 +2760,7 @@ async def search_product_lines_impl(
             # Text search (exact match)
             results = lines_collection.get(
                 where_document={"$contains": query.upper()},
+                where=non_item_section_filter(),
                 include=["metadatas"],
             )
 
@@ -2713,7 +2810,9 @@ async def search_product_lines_impl(
             items = items[:limit]
 
             # Calculate total for items that have prices
-            total = sum(item["price"] for item in items if item["price"] is not None)
+            total = sum(
+                item["price"] for item in items if item["price"] is not None
+            )
 
             return {
                 "query": query,
@@ -2751,14 +2850,18 @@ async def get_receipt_summaries_impl(
         end_dt = None
         if start_date:
             try:
-                start_dt = datetime.fromisoformat(start_date.replace("Z", "+00:00"))
+                start_dt = datetime.fromisoformat(
+                    start_date.replace("Z", "+00:00")
+                )
             except ValueError:
                 return {
                     "error": f"Invalid start_date format: '{start_date}'. Use ISO format (e.g., 2024-01-15)."
                 }
         if end_date:
             try:
-                end_dt = datetime.fromisoformat(end_date.replace("Z", "+00:00"))
+                end_dt = datetime.fromisoformat(
+                    end_date.replace("Z", "+00:00")
+                )
             except ValueError:
                 return {
                     "error": f"Invalid end_date format: '{end_date}'. Use ISO format (e.g., 2024-01-15)."
@@ -2921,14 +3024,18 @@ async def label_validation_summary_impl(dynamo_client) -> dict:
             last_key = None
 
             while True:
-                records, last_key = dynamo_client.get_receipt_word_labels_by_label(
-                    label=label,
-                    limit=1000,
-                    last_evaluated_key=last_key,
+                records, last_key = (
+                    dynamo_client.get_receipt_word_labels_by_label(
+                        label=label,
+                        limit=1000,
+                        last_evaluated_key=last_key,
+                    )
                 )
 
                 for record in records:
-                    status = getattr(record, "validation_status", None) or "NONE"
+                    status = (
+                        getattr(record, "validation_status", None) or "NONE"
+                    )
                     counts[status] += 1
 
                 if last_key is None:
@@ -2988,13 +3095,17 @@ async def list_words_by_label_impl(
             words.append(
                 {
                     "text": getattr(record, "text", ""),
-                    "validation_status": getattr(record, "validation_status", None)
+                    "validation_status": getattr(
+                        record, "validation_status", None
+                    )
                     or "NONE",
                     "image_id": record.image_id,
                     "receipt_id": record.receipt_id,
                     "line_id": record.line_id,
                     "word_id": record.word_id,
-                    "label_proposed_by": getattr(record, "label_proposed_by", None),
+                    "label_proposed_by": getattr(
+                        record, "label_proposed_by", None
+                    ),
                 }
             )
 
@@ -3097,7 +3208,9 @@ async def validate_word_similarity_impl(
                 positive_results.get("distances", [[]]),
             )
         ]:
-            for meta, dist in zip(metas[0] if metas else [], dists[0] if dists else []):
+            for meta, dist in zip(
+                metas[0] if metas else [], dists[0] if dists else []
+            ):
                 sim = dist_to_sim(dist)
                 if sim < MIN_SIMILARITY:
                     continue
@@ -3110,7 +3223,8 @@ async def validate_word_similarity_impl(
                         "text": meta.get("text", ""),
                         "similarity": round(sim, 3),
                         "merchant": meta.get("merchant_name", ""),
-                        "same_merchant": meta.get("merchant_name", "") == merchant_name,
+                        "same_merchant": meta.get("merchant_name", "")
+                        == merchant_name,
                     }
                 )
 
@@ -3120,7 +3234,9 @@ async def validate_word_similarity_impl(
                 negative_results.get("distances", [[]]),
             )
         ]:
-            for meta, dist in zip(metas[0] if metas else [], dists[0] if dists else []):
+            for meta, dist in zip(
+                metas[0] if metas else [], dists[0] if dists else []
+            ):
                 sim = dist_to_sim(dist)
                 if sim < MIN_SIMILARITY:
                     continue
@@ -3132,7 +3248,8 @@ async def validate_word_similarity_impl(
                         "text": meta.get("text", ""),
                         "similarity": round(sim, 3),
                         "merchant": meta.get("merchant_name", ""),
-                        "same_merchant": meta.get("merchant_name", "") == merchant_name,
+                        "same_merchant": meta.get("merchant_name", "")
+                        == merchant_name,
                     }
                 )
 
@@ -3188,12 +3305,12 @@ async def validate_word_similarity_impl(
             reason = f"{confidence:.0%} of similar words validated as {label}"
         elif confidence <= (1.0 - CONSENSUS_THRESHOLD):
             recommended_status = "INVALID"
-            reason = f"{1.0 - confidence:.0%} of similar words rejected {label}"
+            reason = (
+                f"{1.0 - confidence:.0%} of similar words rejected {label}"
+            )
         else:
             recommended_status = "NEEDS_REVIEW"
-            reason = (
-                f"Mixed evidence: {confidence:.0%} for, {1.0 - confidence:.0%} against"
-            )
+            reason = f"Mixed evidence: {confidence:.0%} for, {1.0 - confidence:.0%} against"
 
         # Find suggested labels if invalid or uncertain
         suggested_labels = []
@@ -3285,7 +3402,9 @@ async def update_word_label_impl(
             ValidationStatus(new_status)
         except ValueError:
             valid = [s.value for s in ValidationStatus]
-            return {"error": f"Invalid status '{new_status}'. Must be one of: {valid}"}
+            return {
+                "error": f"Invalid status '{new_status}'. Must be one of: {valid}"
+            }
 
         # Fetch existing record
         existing = dynamo_client.get_receipt_word_label(
@@ -3297,7 +3416,9 @@ async def update_word_label_impl(
         )
 
         # Use provided reasoning or keep existing
-        final_reasoning = reasoning if reasoning is not None else existing.reasoning
+        final_reasoning = (
+            reasoning if reasoning is not None else existing.reasoning
+        )
 
         # Build updated entity (triggers __post_init__ validation)
         updated = ReceiptWordLabel(
@@ -3323,7 +3444,8 @@ async def update_word_label_impl(
             "line_id": line_id,
             "word_id": word_id,
             "label": label,
-            "old_status": getattr(existing, "validation_status", None) or "NONE",
+            "old_status": getattr(existing, "validation_status", None)
+            or "NONE",
             "new_status": new_status,
             "reasoning": final_reasoning,
             "label_proposed_by": "mcp-claude-review",
@@ -3377,15 +3499,21 @@ async def get_receipt_words_impl(
             labels_by_word[(label.line_id, label.word_id)].append(
                 {
                     "label": label.label,
-                    "validation_status": getattr(label, "validation_status", None)
+                    "validation_status": getattr(
+                        label, "validation_status", None
+                    )
                     or "NONE",
-                    "label_proposed_by": getattr(label, "label_proposed_by", None),
+                    "label_proposed_by": getattr(
+                        label, "label_proposed_by", None
+                    ),
                 }
             )
 
         # Build word list
         words = []
-        for word in sorted(details.words, key=lambda w: (w.line_id, w.word_id)):
+        for word in sorted(
+            details.words, key=lambda w: (w.line_id, w.word_id)
+        ):
             if line_id is not None and word.line_id != line_id:
                 continue
             word_labels = labels_by_word.get((word.line_id, word.word_id), [])
@@ -3551,9 +3679,9 @@ async def list_recent_uploads_impl(dynamo_client, limit: int = 10) -> dict:
             results.append(
                 {
                     "image_id": img.image_id,
-                    "timestamp_added": _to_utc_dt(img.timestamp_added).isoformat(
-                        timespec="milliseconds"
-                    ),
+                    "timestamp_added": _to_utc_dt(
+                        img.timestamp_added
+                    ).isoformat(timespec="milliseconds"),
                     "image_type": img.image_type,
                     "receipt_count": len(receipts_info),
                     "width": img.width,
@@ -3631,7 +3759,11 @@ async def merge_receipts_impl(
         env = os.environ.get("PORTFOLIO_ENV", "dev")
         return await _invoke_lambda(
             f"merge-receipt-{env}-merge-receipt",
-            {"image_id": image_id, "receipt_ids": receipt_ids, "dry_run": dry_run},
+            {
+                "image_id": image_id,
+                "receipt_ids": receipt_ids,
+                "dry_run": dry_run,
+            },
         )
     except Exception as e:
         logger.exception("Error invoking merge-receipt Lambda")
@@ -3681,7 +3813,9 @@ async def revise_receipt_resegmentation_plan_impl(arguments: dict) -> dict:
         return {"error": str(e)}
 
 
-async def apply_receipt_resegmentation_impl(plan_id: str, plan_hash: str) -> dict:
+async def apply_receipt_resegmentation_impl(
+    plan_id: str, plan_hash: str
+) -> dict:
     """Invoke the receipt re-segmentation Lambda in apply mode."""
     try:
         env = os.environ.get("PORTFOLIO_ENV", "dev")
@@ -3749,22 +3883,28 @@ async def compute_reocr_region_impl(
 
         # Filter words to only those on the requested lines
         target_line_ids = set(line_ids)
-        words_in_region = [w for w in details.words if w.line_id in target_line_ids]
+        words_in_region = [
+            w for w in details.words if w.line_id in target_line_ids
+        ]
 
         if not words_in_region:
             return {
                 "error": f"No words found on line_ids {line_ids}",
-                "available_line_ids": sorted({w.line_id for w in details.words}),
+                "available_line_ids": sorted(
+                    {w.line_id for w in details.words}
+                ),
             }
 
         # Compute axis-aligned bounding box in receipt-relative space
         min_x = min(w.bounding_box["x"] for w in words_in_region)
         min_y = min(w.bounding_box["y"] for w in words_in_region)
         max_x = max(
-            w.bounding_box["x"] + w.bounding_box["width"] for w in words_in_region
+            w.bounding_box["x"] + w.bounding_box["width"]
+            for w in words_in_region
         )
         max_y = max(
-            w.bounding_box["y"] + w.bounding_box["height"] for w in words_in_region
+            w.bounding_box["y"] + w.bounding_box["height"]
+            for w in words_in_region
         )
 
         # Always use full width — Vision OCR produces better results with
@@ -3871,8 +4011,12 @@ async def compute_reocr_region_impl(
         }
 
         # Include context: which lines were found, word count
-        found_line_ids = sorted(target_line_ids & {w.line_id for w in details.words})
-        missing_line_ids = sorted(target_line_ids - {w.line_id for w in details.words})
+        found_line_ids = sorted(
+            target_line_ids & {w.line_id for w in details.words}
+        )
+        missing_line_ids = sorted(
+            target_line_ids - {w.line_id for w in details.words}
+        )
 
         return {
             "image_id": image_id,
@@ -3940,11 +4084,15 @@ async def get_receipt_image_url_impl(
         if receipt.cdn_avif_s3_key:
             variants["avif"] = f"https://{domain}/{receipt.cdn_avif_s3_key}"
         if receipt.cdn_thumbnail_s3_key:
-            variants["thumbnail"] = f"https://{domain}/{receipt.cdn_thumbnail_s3_key}"
+            variants["thumbnail"] = (
+                f"https://{domain}/{receipt.cdn_thumbnail_s3_key}"
+            )
         if receipt.cdn_small_s3_key:
             variants["small"] = f"https://{domain}/{receipt.cdn_small_s3_key}"
         if receipt.cdn_medium_s3_key:
-            variants["medium"] = f"https://{domain}/{receipt.cdn_medium_s3_key}"
+            variants["medium"] = (
+                f"https://{domain}/{receipt.cdn_medium_s3_key}"
+            )
         if variants:
             result["variants"] = variants
 
@@ -3954,7 +4102,9 @@ async def get_receipt_image_url_impl(
         return {"error": str(e)}
 
 
-async def delete_image_impl(dynamo_client, image_id: str, dry_run: bool = True) -> dict:
+async def delete_image_impl(
+    dynamo_client, image_id: str, dry_run: bool = True
+) -> dict:
     """Delete all DynamoDB records under an image partition key."""
     try:
         details = dynamo_client.get_image_details(image_id)
@@ -4035,10 +4185,16 @@ async def delete_receipt_impl(
         try:
             details = dynamo_client.get_receipt_details(image_id, receipt_id)
         except EntityNotFoundError:
-            return {"error": (f"Receipt {receipt_id} not found for image {image_id}")}
+            return {
+                "error": (
+                    f"Receipt {receipt_id} not found for image {image_id}"
+                )
+            }
 
         place = getattr(details, "place", None)
-        merchant_name = getattr(place, "merchant_name", None) if place else None
+        merchant_name = (
+            getattr(place, "merchant_name", None) if place else None
+        )
 
         # Note: ReceiptLetters are excluded from the GSI4 query that backs
         # get_receipt_details, so they are not counted here. The compactor
@@ -4106,12 +4262,18 @@ async def get_receipt_sections_impl(
         try:
             details = dynamo_client.get_receipt_details(image_id, receipt_id)
         except EntityNotFoundError:
-            return {"error": (f"Receipt {receipt_id} not found for image {image_id}")}
+            return {
+                "error": (
+                    f"Receipt {receipt_id} not found for image {image_id}"
+                )
+            }
 
         # line_id -> text so a reviewer can QA sections without a second call
         line_text = {line.line_id: line.text for line in details.lines or []}
 
-        sections = dynamo_client.get_receipt_sections_from_receipt(image_id, receipt_id)
+        sections = dynamo_client.get_receipt_sections_from_receipt(
+            image_id, receipt_id
+        )
 
         section_dicts = []
         for section in sorted(
@@ -4437,9 +4599,9 @@ def _athena_run(sql: str, max_wait: int = 90, max_rows: int = 5000) -> list:
     )["QueryExecutionId"]
     waited = 0.0
     while True:
-        status = ath.get_query_execution(QueryExecutionId=qid)["QueryExecution"][
-            "Status"
-        ]
+        status = ath.get_query_execution(QueryExecutionId=qid)[
+            "QueryExecution"
+        ]["Status"]
         state = status["State"]
         if state in ("SUCCEEDED", "FAILED", "CANCELLED"):
             break
@@ -4624,7 +4786,9 @@ async def analytics_top_impl(
             col = "org"
             extra = "AND org IS NOT NULL"
         else:
-            return {"error": "dimension must be: page, referrer, ip, country, org"}
+            return {
+                "error": "dimension must be: page, referrer, ip, country, org"
+            }
         sql = _analytics_base_cte(s, e) + f"""
 SELECT {col} AS value, count(*) AS hits, count(DISTINCT IF(sid <> '', sid, NULL)) AS sessions
 FROM base
@@ -4633,7 +4797,12 @@ GROUP BY {col}
 ORDER BY hits DESC
 LIMIT {limit}
 """
-        return {"dimension": dimension, "start": s, "end": e, "top": _athena_run(sql)}
+        return {
+            "dimension": dimension,
+            "start": s,
+            "end": e,
+            "top": _athena_run(sql),
+        }
     except Exception as exc:
         logger.exception("analytics_top failed")
         return {"error": str(exc)}
@@ -4838,7 +5007,9 @@ async def list_training_jobs_impl(
                 {
                     "name": job.name,
                     "status": job.status,
-                    "created_at": str(job.created_at) if job.created_at else None,
+                    "created_at": (
+                        str(job.created_at) if job.created_at else None
+                    ),
                     "best_f1": r.get("best_f1"),
                     "best_epoch": r.get("best_epoch"),
                     "num_train_samples": r.get("num_train_samples"),
@@ -4847,7 +5018,9 @@ async def list_training_jobs_impl(
                     "epochs": config.get("epochs"),
                     "batch_size": config.get("batch_size"),
                     "merge_amounts": config.get("merge_amounts"),
-                    "early_stopping_patience": config.get("early_stopping_patience"),
+                    "early_stopping_patience": config.get(
+                        "early_stopping_patience"
+                    ),
                 }
             )
 
@@ -4938,7 +5111,9 @@ async def set_active_model_impl(
         old_active = dynamo_client.get_active_model_job()
         if old_active:
             old_active.tags = {
-                k: v for k, v in (old_active.tags or {}).items() if k != "active_model"
+                k: v
+                for k, v in (old_active.tags or {}).items()
+                if k != "active_model"
             }
             dynamo_client.update_job(old_active)
 
@@ -4975,14 +5150,18 @@ async def get_label_distribution_impl(dynamo_client) -> dict:
             last_key = None
 
             while True:
-                records, last_key = dynamo_client.get_receipt_word_labels_by_label(
-                    label=label,
-                    limit=1000,
-                    last_evaluated_key=last_key,
+                records, last_key = (
+                    dynamo_client.get_receipt_word_labels_by_label(
+                        label=label,
+                        limit=1000,
+                        last_evaluated_key=last_key,
+                    )
                 )
 
                 for record in records:
-                    status = getattr(record, "validation_status", None) or "NONE"
+                    status = (
+                        getattr(record, "validation_status", None) or "NONE"
+                    )
                     counts[status] += 1
 
                 if last_key is None:

--- a/receipt_agent/receipt_agent/agents/question_answering/tools/search.py
+++ b/receipt_agent/receipt_agent/agents/question_answering/tools/search.py
@@ -23,6 +23,7 @@ from datetime import datetime
 from typing import Any, Callable, Optional
 
 from langchain_core.tools import tool
+from receipt_chroma.section_labels import non_item_section_filter
 
 logger = logging.getLogger(__name__)
 
@@ -974,6 +975,7 @@ def create_qa_tools(
                 results = lines_collection.query(
                     query_embeddings=query_embeddings,
                     n_results=min(limit * 3, CHROMA_MAX_N_RESULTS),
+                    where=non_item_section_filter(),
                     include=["metadatas", "distances"],
                 )
 
@@ -1080,6 +1082,7 @@ def create_qa_tools(
                 # Text search
                 results = lines_collection.get(
                     where_document={"$contains": query.upper()},
+                    where=non_item_section_filter(),
                     include=["metadatas"],
                 )
 

--- a/receipt_chroma/receipt_chroma/section_labels.py
+++ b/receipt_chroma/receipt_chroma/section_labels.py
@@ -61,4 +61,44 @@ def row_section_from_map(
     return None
 
 
-__all__ = ["row_section_from_map", "sections_to_line_map"]
+#: Sections that never contain a purchased product line. Product search
+#: excludes these rather than requiring ``section_label == "ITEMS"``.
+#:
+#: Measured on the dev LINES collection (34k rows): 30% of rows carry NO
+#: ``section_label`` at all, and of the 516 hand-verified product lines in
+#: the golden set only 90.9% are labeled ITEMS -- 7% sit in no section at
+#: all. Those unlabeled rows are overwhelmingly real products
+#: ("RAW WHOLE MILK 10.99 F", "ORGANIC POPCORN 6.49"), so an ``$in ITEMS``
+#: filter silently drops them. Chroma metadata filters do not match rows
+#: whose key is absent, but ``$nin`` DOES retain them -- verified against
+#: Chroma Cloud -- which is why the exclusion form is used here.
+NON_ITEM_SECTION_LABELS = (
+    "ADDRESS",
+    "BARCODE",
+    "FOOTER",
+    "PAYMENT",
+    "SECTION_HEADER",
+    "STOREFRONT",
+    "SUMMARY",
+    "SURVEY",
+    "TOTAL_LINE",
+    "TRANSACTION_INFO",
+)
+
+
+def non_item_section_filter() -> Dict[str, Any]:
+    """Chroma ``where`` clause excluding sections that hold no products.
+
+    Use for product/line-item search over the LINES collection. Rows with no
+    ``section_label`` are deliberately KEPT: on under-sectioned receipts the
+    product lines are exactly the unlabeled ones.
+    """
+    return {"section_label": {"$nin": list(NON_ITEM_SECTION_LABELS)}}
+
+
+__all__ = [
+    "NON_ITEM_SECTION_LABELS",
+    "non_item_section_filter",
+    "row_section_from_map",
+    "sections_to_line_map",
+]

--- a/receipt_chroma/tests/unit/test_line_metadata.py
+++ b/receipt_chroma/tests/unit/test_line_metadata.py
@@ -355,3 +355,34 @@ class TestEnrichRowMetadataWithLabels:
         enriched = enrich_row_metadata_with_labels(metadata, row_words, labels)
 
         assert enriched["label_status"] == "unvalidated"
+
+
+def test_non_item_section_filter_keeps_items_and_unlabeled() -> None:
+    """Product search must exclude non-item sections, not require ITEMS.
+
+    Measured on the dev LINES collection: 30% of rows carry no
+    ``section_label``, and 7% of hand-verified product lines sit in no
+    section at all. Chroma's ``$nin`` retains rows whose key is absent,
+    so the exclusion form keeps those real products while still dropping
+    totals/payment/footer rows. An ``$in ["ITEMS"]`` filter would silently
+    discard them.
+    """
+    from receipt_chroma.section_labels import (
+        NON_ITEM_SECTION_LABELS,
+        non_item_section_filter,
+    )
+
+    clause = non_item_section_filter()
+    excluded = clause["section_label"]["$nin"]
+
+    # the sections that genuinely never hold a product
+    assert "TOTAL_LINE" in excluded
+    assert "SUMMARY" in excluded
+    assert "PAYMENT" in excluded
+    assert "SECTION_HEADER" in excluded
+
+    # ITEMS and its deprecated aliases must never be excluded
+    for keep in ("ITEMS", "ITEMS_VALUE", "ITEMS_DESCRIPTION"):
+        assert keep not in excluded
+
+    assert set(excluded) == set(NON_ITEM_SECTION_LABELS)

--- a/scripts/receipt_mcp_server.py
+++ b/scripts/receipt_mcp_server.py
@@ -96,7 +96,9 @@ def _load_config():
 
         # Merge secrets
         for key, value in secrets.items():
-            normalized_key = key.replace("portfolio:", "").lower().replace("-", "_")
+            normalized_key = (
+                key.replace("portfolio:", "").lower().replace("-", "_")
+            )
             config[normalized_key] = value
 
         # Environment variables override Pulumi config for the Chroma keys,
@@ -113,7 +115,9 @@ def _load_config():
 
         # Set up API keys
         if config.get("openai_api_key"):
-            os.environ["RECEIPT_AGENT_OPENAI_API_KEY"] = config["openai_api_key"]
+            os.environ["RECEIPT_AGENT_OPENAI_API_KEY"] = config[
+                "openai_api_key"
+            ]
 
         _config = config
 
@@ -122,7 +126,9 @@ def _load_config():
 
 def chroma_is_configured(config) -> bool:
     """True when Chroma Cloud is enabled and an API key is present."""
-    enabled = str(config.get("chroma_cloud_enabled", "false")).lower() == "true"
+    enabled = (
+        str(config.get("chroma_cloud_enabled", "false")).lower() == "true"
+    )
     return enabled and bool(config.get("chroma_cloud_api_key"))
 
 
@@ -134,7 +140,9 @@ def get_dynamo_client():
         from receipt_agent.clients.factory import create_dynamo_client
 
         config = _load_config()
-        _dynamo_client = create_dynamo_client(table_name=config["dynamodb_table_name"])
+        _dynamo_client = create_dynamo_client(
+            table_name=config["dynamodb_table_name"]
+        )
         logger.info("DynamoDB client initialized")
 
     return _dynamo_client
@@ -638,7 +646,13 @@ Example:
                     },
                     "status_filter": {
                         "type": "string",
-                        "enum": ["VALID", "INVALID", "PENDING", "NEEDS_REVIEW", "NONE"],
+                        "enum": [
+                            "VALID",
+                            "INVALID",
+                            "PENDING",
+                            "NEEDS_REVIEW",
+                            "NONE",
+                        ],
                         "description": "Optional: filter by validation status. Omit to get all statuses.",
                     },
                     "sample_size": {
@@ -699,7 +713,13 @@ recommendation that you can review before taking any action.""",
                         "description": "The label to validate (e.g., GRAND_TOTAL)",
                     },
                 },
-                "required": ["image_id", "receipt_id", "line_id", "word_id", "label"],
+                "required": [
+                    "image_id",
+                    "receipt_id",
+                    "line_id",
+                    "word_id",
+                    "label",
+                ],
             },
         ),
         Tool(
@@ -742,7 +762,13 @@ WARNING: This WRITES to DynamoDB. Double-check the word context before calling."
                     },
                     "new_status": {
                         "type": "string",
-                        "enum": ["VALID", "INVALID", "PENDING", "NEEDS_REVIEW", "NONE"],
+                        "enum": [
+                            "VALID",
+                            "INVALID",
+                            "PENDING",
+                            "NEEDS_REVIEW",
+                            "NONE",
+                        ],
                         "description": "The new validation status to set",
                     },
                     "reasoning": {
@@ -905,7 +931,12 @@ image_id/receipt_id/line_id/word_id/label already exists.""",
                     },
                     "validation_status": {
                         "type": "string",
-                        "enum": ["PENDING", "VALID", "INVALID", "NEEDS_REVIEW"],
+                        "enum": [
+                            "PENDING",
+                            "VALID",
+                            "INVALID",
+                            "NEEDS_REVIEW",
+                        ],
                         "description": "Validation status for the new row. Defaults to VALID (human-reviewed). Use PENDING for machine-propagated rows (e.g. SECTION_* sections) that still need QA.",
                     },
                 },
@@ -1057,7 +1088,9 @@ sheet artifacts while the previous revision remains reviewable.""",
                         "type": "array",
                         "minItems": 1,
                         "maxItems": 23,
-                        "items": _resegment_segment_schema(legacy_selectors=False),
+                        "items": _resegment_segment_schema(
+                            legacy_selectors=False
+                        ),
                     },
                     "assignments": _resegment_assignments_schema(),
                     "visualization": _resegment_visualization_schema(),
@@ -1506,7 +1539,10 @@ that up separately (e.g. an IP-info service).""",
             inputSchema={
                 "type": "object",
                 "properties": {
-                    "ip": {"type": "string", "description": "Client IP (v4 or v6)"},
+                    "ip": {
+                        "type": "string",
+                        "description": "Client IP (v4 or v6)",
+                    },
                     "start_date": {
                         "type": "string",
                         "description": "Start date YYYY-MM-DD (PT)",
@@ -1764,7 +1800,13 @@ WARNING: This WRITES to DynamoDB.""",
                     },
                     "validation_status": {
                         "type": "string",
-                        "enum": ["VALID", "INVALID", "NEEDS_REVIEW", "PENDING", "NONE"],
+                        "enum": [
+                            "VALID",
+                            "INVALID",
+                            "NEEDS_REVIEW",
+                            "PENDING",
+                            "NONE",
+                        ],
                         "description": "The new validation status to set",
                     },
                 },
@@ -1815,7 +1857,13 @@ or any line_id is not on the receipt.""",
                     },
                     "validation_status": {
                         "type": "string",
-                        "enum": ["VALID", "INVALID", "NEEDS_REVIEW", "PENDING", "NONE"],
+                        "enum": [
+                            "VALID",
+                            "INVALID",
+                            "NEEDS_REVIEW",
+                            "PENDING",
+                            "NONE",
+                        ],
                         "description": "Validation status for the new section. Defaults to VALID.",
                     },
                     "model_source": {
@@ -1823,7 +1871,12 @@ or any line_id is not on the receipt.""",
                         "description": "Source tag for the row. Defaults to 'mcp-claude-review'.",
                     },
                 },
-                "required": ["image_id", "receipt_id", "section_type", "line_ids"],
+                "required": [
+                    "image_id",
+                    "receipt_id",
+                    "section_type",
+                    "line_ids",
+                ],
             },
         ),
         Tool(
@@ -1878,7 +1931,9 @@ def _fetch_mcp_preview(url: str) -> bytes:
 
 
 @server.call_tool()
-async def call_tool(name: str, arguments: dict) -> list[TextContent | ImageContent]:
+async def call_tool(
+    name: str, arguments: dict
+) -> list[TextContent | ImageContent]:
     """Handle tool calls."""
     try:
         dynamo_client = get_dynamo_client()
@@ -2077,7 +2132,9 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent | ImageConte
                 section_type=arguments["section_type"],
                 line_ids=arguments["line_ids"],
                 validation_status=arguments.get("validation_status", "VALID"),
-                model_source=arguments.get("model_source", "mcp-claude-review"),
+                model_source=arguments.get(
+                    "model_source", "mcp-claude-review"
+                ),
             )
         elif name == "delete_receipt_section":
             result = await delete_receipt_section_impl(
@@ -2260,7 +2317,9 @@ async def search_receipts_impl(
                 ):
                     key = (meta.get("image_id"), meta.get("receipt_id"))
                     distance = (
-                        results["distances"][0][idx] if results["distances"] else 1.0
+                        results["distances"][0][idx]
+                        if results["distances"]
+                        else 1.0
                     )
                     similarity = max(0.0, 1.0 - distance)
 
@@ -2314,7 +2373,9 @@ async def search_receipts_impl(
         return {"error": str(e)}
 
 
-async def get_receipt_impl(dynamo_client, image_id: str, receipt_id: int) -> dict:
+async def get_receipt_impl(
+    dynamo_client, image_id: str, receipt_id: int
+) -> dict:
     """Get full receipt details."""
     import statistics
 
@@ -2336,7 +2397,9 @@ async def get_receipt_impl(dynamo_client, image_id: str, receipt_id: int) -> dic
             history = labels_by_word.get((line_id, word_id), [])
             valid = [lb for lb in history if lb.validation_status == "VALID"]
             if valid:
-                valid.sort(key=lambda lb: str(lb.timestamp_added), reverse=True)
+                valid.sort(
+                    key=lambda lb: str(lb.timestamp_added), reverse=True
+                )
                 return valid[0].label
             return None
 
@@ -2373,7 +2436,9 @@ async def get_receipt_impl(dynamo_client, image_id: str, receipt_id: int) -> dic
             for w in sorted_words
             if w["word"].bounding_box.get("height")
         ]
-        y_tolerance = max(0.01, statistics.median(heights) * 0.75) if heights else 0.015
+        y_tolerance = (
+            max(0.01, statistics.median(heights) * 0.75) if heights else 0.015
+        )
 
         visual_lines = []
         current_line = [sorted_words[0]]
@@ -2382,7 +2447,9 @@ async def get_receipt_impl(dynamo_client, image_id: str, receipt_id: int) -> dic
         for w in sorted_words[1:]:
             if abs(w["y"] - current_y) <= y_tolerance:
                 current_line.append(w)
-                current_y = sum(c["y"] for c in current_line) / len(current_line)
+                current_y = sum(c["y"] for c in current_line) / len(
+                    current_line
+                )
             else:
                 current_line.sort(key=lambda c: c["x"])
                 visual_lines.append(current_line)
@@ -2415,7 +2482,13 @@ async def get_receipt_impl(dynamo_client, image_id: str, receipt_id: int) -> dic
 
         # Extract amounts
         amounts = []
-        currency_labels = ["TAX", "SUBTOTAL", "GRAND_TOTAL", "LINE_TOTAL", "UNIT_PRICE"]
+        currency_labels = [
+            "TAX",
+            "SUBTOTAL",
+            "GRAND_TOTAL",
+            "LINE_TOTAL",
+            "UNIT_PRICE",
+        ]
         for w in sorted_words:
             if w["label"] in currency_labels:
                 try:
@@ -2555,8 +2628,16 @@ async def search_product_lines_impl(
     """Search for product lines and extract prices for spending analysis.
 
     Supports both text (exact match) and semantic (embedding-based) search.
+    Results exclude sections that never hold products (totals, payment,
+    footer, ...); rows with no section_label are kept, because on
+    under-sectioned receipts those are the product lines.
     """
     import re
+
+    # Imported here, not at module scope: receipt_chroma.__init__ pulls in
+    # chromadb, and this server must stay importable without it
+    # (tests/test_receipt_mcp_lazy_chroma.py).
+    from receipt_chroma.section_labels import non_item_section_filter
 
     try:
         lines_collection = chroma_client.get_collection("lines")
@@ -2578,6 +2659,7 @@ async def search_product_lines_impl(
             results = lines_collection.query(
                 query_embeddings=query_embeddings,
                 n_results=limit * 3,  # Get more to filter duplicates
+                where=non_item_section_filter(),
                 include=["metadatas", "distances"],
             )
 
@@ -2607,7 +2689,11 @@ async def search_product_lines_impl(
                 seen.add(key)
 
                 # Calculate similarity from distance
-                distance = results["distances"][0][idx] if results["distances"] else 1.0
+                distance = (
+                    results["distances"][0][idx]
+                    if results["distances"]
+                    else 1.0
+                )
                 similarity = max(0.0, 1.0 - distance)
 
                 # Skip low similarity results
@@ -2634,7 +2720,9 @@ async def search_product_lines_impl(
             items = items[:limit]
 
             # Calculate total for items that have prices
-            total = sum(item["price"] for item in items if item["price"] is not None)
+            total = sum(
+                item["price"] for item in items if item["price"] is not None
+            )
 
             return {
                 "query": query,
@@ -2650,6 +2738,7 @@ async def search_product_lines_impl(
             # Text search (exact match)
             results = lines_collection.get(
                 where_document={"$contains": query.upper()},
+                where=non_item_section_filter(),
                 include=["metadatas"],
             )
 
@@ -2699,7 +2788,9 @@ async def search_product_lines_impl(
             items = items[:limit]
 
             # Calculate total for items that have prices
-            total = sum(item["price"] for item in items if item["price"] is not None)
+            total = sum(
+                item["price"] for item in items if item["price"] is not None
+            )
 
             return {
                 "query": query,
@@ -2737,14 +2828,18 @@ async def get_receipt_summaries_impl(
         end_dt = None
         if start_date:
             try:
-                start_dt = datetime.fromisoformat(start_date.replace("Z", "+00:00"))
+                start_dt = datetime.fromisoformat(
+                    start_date.replace("Z", "+00:00")
+                )
             except ValueError:
                 return {
                     "error": f"Invalid start_date format: '{start_date}'. Use ISO format (e.g., 2024-01-15)."
                 }
         if end_date:
             try:
-                end_dt = datetime.fromisoformat(end_date.replace("Z", "+00:00"))
+                end_dt = datetime.fromisoformat(
+                    end_date.replace("Z", "+00:00")
+                )
             except ValueError:
                 return {
                     "error": f"Invalid end_date format: '{end_date}'. Use ISO format (e.g., 2024-01-15)."
@@ -2907,14 +3002,18 @@ async def label_validation_summary_impl(dynamo_client) -> dict:
             last_key = None
 
             while True:
-                records, last_key = dynamo_client.get_receipt_word_labels_by_label(
-                    label=label,
-                    limit=1000,
-                    last_evaluated_key=last_key,
+                records, last_key = (
+                    dynamo_client.get_receipt_word_labels_by_label(
+                        label=label,
+                        limit=1000,
+                        last_evaluated_key=last_key,
+                    )
                 )
 
                 for record in records:
-                    status = getattr(record, "validation_status", None) or "NONE"
+                    status = (
+                        getattr(record, "validation_status", None) or "NONE"
+                    )
                     counts[status] += 1
 
                 if last_key is None:
@@ -2974,13 +3073,17 @@ async def list_words_by_label_impl(
             words.append(
                 {
                     "text": getattr(record, "text", ""),
-                    "validation_status": getattr(record, "validation_status", None)
+                    "validation_status": getattr(
+                        record, "validation_status", None
+                    )
                     or "NONE",
                     "image_id": record.image_id,
                     "receipt_id": record.receipt_id,
                     "line_id": record.line_id,
                     "word_id": record.word_id,
-                    "label_proposed_by": getattr(record, "label_proposed_by", None),
+                    "label_proposed_by": getattr(
+                        record, "label_proposed_by", None
+                    ),
                 }
             )
 
@@ -3083,7 +3186,9 @@ async def validate_word_similarity_impl(
                 positive_results.get("distances", [[]]),
             )
         ]:
-            for meta, dist in zip(metas[0] if metas else [], dists[0] if dists else []):
+            for meta, dist in zip(
+                metas[0] if metas else [], dists[0] if dists else []
+            ):
                 sim = dist_to_sim(dist)
                 if sim < MIN_SIMILARITY:
                     continue
@@ -3096,7 +3201,8 @@ async def validate_word_similarity_impl(
                         "text": meta.get("text", ""),
                         "similarity": round(sim, 3),
                         "merchant": meta.get("merchant_name", ""),
-                        "same_merchant": meta.get("merchant_name", "") == merchant_name,
+                        "same_merchant": meta.get("merchant_name", "")
+                        == merchant_name,
                     }
                 )
 
@@ -3106,7 +3212,9 @@ async def validate_word_similarity_impl(
                 negative_results.get("distances", [[]]),
             )
         ]:
-            for meta, dist in zip(metas[0] if metas else [], dists[0] if dists else []):
+            for meta, dist in zip(
+                metas[0] if metas else [], dists[0] if dists else []
+            ):
                 sim = dist_to_sim(dist)
                 if sim < MIN_SIMILARITY:
                     continue
@@ -3118,7 +3226,8 @@ async def validate_word_similarity_impl(
                         "text": meta.get("text", ""),
                         "similarity": round(sim, 3),
                         "merchant": meta.get("merchant_name", ""),
-                        "same_merchant": meta.get("merchant_name", "") == merchant_name,
+                        "same_merchant": meta.get("merchant_name", "")
+                        == merchant_name,
                     }
                 )
 
@@ -3174,12 +3283,12 @@ async def validate_word_similarity_impl(
             reason = f"{confidence:.0%} of similar words validated as {label}"
         elif confidence <= (1.0 - CONSENSUS_THRESHOLD):
             recommended_status = "INVALID"
-            reason = f"{1.0 - confidence:.0%} of similar words rejected {label}"
+            reason = (
+                f"{1.0 - confidence:.0%} of similar words rejected {label}"
+            )
         else:
             recommended_status = "NEEDS_REVIEW"
-            reason = (
-                f"Mixed evidence: {confidence:.0%} for, {1.0 - confidence:.0%} against"
-            )
+            reason = f"Mixed evidence: {confidence:.0%} for, {1.0 - confidence:.0%} against"
 
         # Find suggested labels if invalid or uncertain
         suggested_labels = []
@@ -3271,7 +3380,9 @@ async def update_word_label_impl(
             ValidationStatus(new_status)
         except ValueError:
             valid = [s.value for s in ValidationStatus]
-            return {"error": f"Invalid status '{new_status}'. Must be one of: {valid}"}
+            return {
+                "error": f"Invalid status '{new_status}'. Must be one of: {valid}"
+            }
 
         # Fetch existing record
         existing = dynamo_client.get_receipt_word_label(
@@ -3283,7 +3394,9 @@ async def update_word_label_impl(
         )
 
         # Use provided reasoning or keep existing
-        final_reasoning = reasoning if reasoning is not None else existing.reasoning
+        final_reasoning = (
+            reasoning if reasoning is not None else existing.reasoning
+        )
 
         # Build updated entity (triggers __post_init__ validation)
         updated = ReceiptWordLabel(
@@ -3309,7 +3422,8 @@ async def update_word_label_impl(
             "line_id": line_id,
             "word_id": word_id,
             "label": label,
-            "old_status": getattr(existing, "validation_status", None) or "NONE",
+            "old_status": getattr(existing, "validation_status", None)
+            or "NONE",
             "new_status": new_status,
             "reasoning": final_reasoning,
             "label_proposed_by": "mcp-claude-review",
@@ -3363,15 +3477,21 @@ async def get_receipt_words_impl(
             labels_by_word[(label.line_id, label.word_id)].append(
                 {
                     "label": label.label,
-                    "validation_status": getattr(label, "validation_status", None)
+                    "validation_status": getattr(
+                        label, "validation_status", None
+                    )
                     or "NONE",
-                    "label_proposed_by": getattr(label, "label_proposed_by", None),
+                    "label_proposed_by": getattr(
+                        label, "label_proposed_by", None
+                    ),
                 }
             )
 
         # Build word list
         words = []
-        for word in sorted(details.words, key=lambda w: (w.line_id, w.word_id)):
+        for word in sorted(
+            details.words, key=lambda w: (w.line_id, w.word_id)
+        ):
             if line_id is not None and word.line_id != line_id:
                 continue
             word_labels = labels_by_word.get((word.line_id, word.word_id), [])
@@ -3537,9 +3657,9 @@ async def list_recent_uploads_impl(dynamo_client, limit: int = 10) -> dict:
             results.append(
                 {
                     "image_id": img.image_id,
-                    "timestamp_added": _to_utc_dt(img.timestamp_added).isoformat(
-                        timespec="milliseconds"
-                    ),
+                    "timestamp_added": _to_utc_dt(
+                        img.timestamp_added
+                    ).isoformat(timespec="milliseconds"),
                     "image_type": img.image_type,
                     "receipt_count": len(receipts_info),
                     "width": img.width,
@@ -3617,7 +3737,11 @@ async def merge_receipts_impl(
         env = os.environ.get("PORTFOLIO_ENV", "dev")
         return await _invoke_lambda(
             f"merge-receipt-{env}-merge-receipt",
-            {"image_id": image_id, "receipt_ids": receipt_ids, "dry_run": dry_run},
+            {
+                "image_id": image_id,
+                "receipt_ids": receipt_ids,
+                "dry_run": dry_run,
+            },
         )
     except Exception as e:
         logger.exception("Error invoking merge-receipt Lambda")
@@ -3667,7 +3791,9 @@ async def revise_receipt_resegmentation_plan_impl(arguments: dict) -> dict:
         return {"error": str(e)}
 
 
-async def apply_receipt_resegmentation_impl(plan_id: str, plan_hash: str) -> dict:
+async def apply_receipt_resegmentation_impl(
+    plan_id: str, plan_hash: str
+) -> dict:
     """Invoke the receipt re-segmentation Lambda in apply mode."""
     try:
         env = os.environ.get("PORTFOLIO_ENV", "dev")
@@ -3735,22 +3861,28 @@ async def compute_reocr_region_impl(
 
         # Filter words to only those on the requested lines
         target_line_ids = set(line_ids)
-        words_in_region = [w for w in details.words if w.line_id in target_line_ids]
+        words_in_region = [
+            w for w in details.words if w.line_id in target_line_ids
+        ]
 
         if not words_in_region:
             return {
                 "error": f"No words found on line_ids {line_ids}",
-                "available_line_ids": sorted({w.line_id for w in details.words}),
+                "available_line_ids": sorted(
+                    {w.line_id for w in details.words}
+                ),
             }
 
         # Compute axis-aligned bounding box in receipt-relative space
         min_x = min(w.bounding_box["x"] for w in words_in_region)
         min_y = min(w.bounding_box["y"] for w in words_in_region)
         max_x = max(
-            w.bounding_box["x"] + w.bounding_box["width"] for w in words_in_region
+            w.bounding_box["x"] + w.bounding_box["width"]
+            for w in words_in_region
         )
         max_y = max(
-            w.bounding_box["y"] + w.bounding_box["height"] for w in words_in_region
+            w.bounding_box["y"] + w.bounding_box["height"]
+            for w in words_in_region
         )
 
         # Always use full width — Vision OCR produces better results with
@@ -3857,8 +3989,12 @@ async def compute_reocr_region_impl(
         }
 
         # Include context: which lines were found, word count
-        found_line_ids = sorted(target_line_ids & {w.line_id for w in details.words})
-        missing_line_ids = sorted(target_line_ids - {w.line_id for w in details.words})
+        found_line_ids = sorted(
+            target_line_ids & {w.line_id for w in details.words}
+        )
+        missing_line_ids = sorted(
+            target_line_ids - {w.line_id for w in details.words}
+        )
 
         return {
             "image_id": image_id,
@@ -3926,11 +4062,15 @@ async def get_receipt_image_url_impl(
         if receipt.cdn_avif_s3_key:
             variants["avif"] = f"https://{domain}/{receipt.cdn_avif_s3_key}"
         if receipt.cdn_thumbnail_s3_key:
-            variants["thumbnail"] = f"https://{domain}/{receipt.cdn_thumbnail_s3_key}"
+            variants["thumbnail"] = (
+                f"https://{domain}/{receipt.cdn_thumbnail_s3_key}"
+            )
         if receipt.cdn_small_s3_key:
             variants["small"] = f"https://{domain}/{receipt.cdn_small_s3_key}"
         if receipt.cdn_medium_s3_key:
-            variants["medium"] = f"https://{domain}/{receipt.cdn_medium_s3_key}"
+            variants["medium"] = (
+                f"https://{domain}/{receipt.cdn_medium_s3_key}"
+            )
         if variants:
             result["variants"] = variants
 
@@ -3940,7 +4080,9 @@ async def get_receipt_image_url_impl(
         return {"error": str(e)}
 
 
-async def delete_image_impl(dynamo_client, image_id: str, dry_run: bool = True) -> dict:
+async def delete_image_impl(
+    dynamo_client, image_id: str, dry_run: bool = True
+) -> dict:
     """Delete all DynamoDB records under an image partition key."""
     try:
         details = dynamo_client.get_image_details(image_id)
@@ -4021,10 +4163,16 @@ async def delete_receipt_impl(
         try:
             details = dynamo_client.get_receipt_details(image_id, receipt_id)
         except EntityNotFoundError:
-            return {"error": (f"Receipt {receipt_id} not found for image {image_id}")}
+            return {
+                "error": (
+                    f"Receipt {receipt_id} not found for image {image_id}"
+                )
+            }
 
         place = getattr(details, "place", None)
-        merchant_name = getattr(place, "merchant_name", None) if place else None
+        merchant_name = (
+            getattr(place, "merchant_name", None) if place else None
+        )
 
         # Note: ReceiptLetters are excluded from the GSI4 query that backs
         # get_receipt_details, so they are not counted here. The compactor
@@ -4092,12 +4240,18 @@ async def get_receipt_sections_impl(
         try:
             details = dynamo_client.get_receipt_details(image_id, receipt_id)
         except EntityNotFoundError:
-            return {"error": (f"Receipt {receipt_id} not found for image {image_id}")}
+            return {
+                "error": (
+                    f"Receipt {receipt_id} not found for image {image_id}"
+                )
+            }
 
         # line_id -> text so a reviewer can QA sections without a second call
         line_text = {line.line_id: line.text for line in details.lines or []}
 
-        sections = dynamo_client.get_receipt_sections_from_receipt(image_id, receipt_id)
+        sections = dynamo_client.get_receipt_sections_from_receipt(
+            image_id, receipt_id
+        )
 
         section_dicts = []
         for section in sorted(
@@ -4423,9 +4577,9 @@ def _athena_run(sql: str, max_wait: int = 90, max_rows: int = 5000) -> list:
     )["QueryExecutionId"]
     waited = 0.0
     while True:
-        status = ath.get_query_execution(QueryExecutionId=qid)["QueryExecution"][
-            "Status"
-        ]
+        status = ath.get_query_execution(QueryExecutionId=qid)[
+            "QueryExecution"
+        ]["Status"]
         state = status["State"]
         if state in ("SUCCEEDED", "FAILED", "CANCELLED"):
             break
@@ -4610,7 +4764,9 @@ async def analytics_top_impl(
             col = "org"
             extra = "AND org IS NOT NULL"
         else:
-            return {"error": "dimension must be: page, referrer, ip, country, org"}
+            return {
+                "error": "dimension must be: page, referrer, ip, country, org"
+            }
         sql = _analytics_base_cte(s, e) + f"""
 SELECT {col} AS value, count(*) AS hits, count(DISTINCT IF(sid <> '', sid, NULL)) AS sessions
 FROM base
@@ -4619,7 +4775,12 @@ GROUP BY {col}
 ORDER BY hits DESC
 LIMIT {limit}
 """
-        return {"dimension": dimension, "start": s, "end": e, "top": _athena_run(sql)}
+        return {
+            "dimension": dimension,
+            "start": s,
+            "end": e,
+            "top": _athena_run(sql),
+        }
     except Exception as exc:
         logger.exception("analytics_top failed")
         return {"error": str(exc)}
@@ -4824,7 +4985,9 @@ async def list_training_jobs_impl(
                 {
                     "name": job.name,
                     "status": job.status,
-                    "created_at": str(job.created_at) if job.created_at else None,
+                    "created_at": (
+                        str(job.created_at) if job.created_at else None
+                    ),
                     "best_f1": r.get("best_f1"),
                     "best_epoch": r.get("best_epoch"),
                     "num_train_samples": r.get("num_train_samples"),
@@ -4833,7 +4996,9 @@ async def list_training_jobs_impl(
                     "epochs": config.get("epochs"),
                     "batch_size": config.get("batch_size"),
                     "merge_amounts": config.get("merge_amounts"),
-                    "early_stopping_patience": config.get("early_stopping_patience"),
+                    "early_stopping_patience": config.get(
+                        "early_stopping_patience"
+                    ),
                 }
             )
 
@@ -4924,7 +5089,9 @@ async def set_active_model_impl(
         old_active = dynamo_client.get_active_model_job()
         if old_active:
             old_active.tags = {
-                k: v for k, v in (old_active.tags or {}).items() if k != "active_model"
+                k: v
+                for k, v in (old_active.tags or {}).items()
+                if k != "active_model"
             }
             dynamo_client.update_job(old_active)
 
@@ -4961,14 +5128,18 @@ async def get_label_distribution_impl(dynamo_client) -> dict:
             last_key = None
 
             while True:
-                records, last_key = dynamo_client.get_receipt_word_labels_by_label(
-                    label=label,
-                    limit=1000,
-                    last_evaluated_key=last_key,
+                records, last_key = (
+                    dynamo_client.get_receipt_word_labels_by_label(
+                        label=label,
+                        limit=1000,
+                        last_evaluated_key=last_key,
+                    )
                 )
 
                 for record in records:
-                    status = getattr(record, "validation_status", None) or "NONE"
+                    status = (
+                        getattr(record, "validation_status", None) or "NONE"
+                    )
                     counts[status] += 1
 
                 if last_key is None:


### PR DESCRIPTION
## Why

`search_product_lines` queries the Chroma LINES collection with no section filter, so headers, subtotals, totals, payment lines and footers come back as "products". ~16 of 32 marquee QA questions depend on this tool.

## Why not the obvious filter

`section_label $in ["ITEMS"]` is wrong, and measurement showed it before shipping:

- 30% of rows in the dev LINES collection carry **no** `section_label`
- of 516 hand-verified product lines (golden set), only 90.9% are labeled ITEMS; 7% sit in **no section at all** — a section-assignment gap, not stale Chroma metadata (DynamoDB agrees at 91.3%, so `publish_section_backfill` would not fix it)
- the unlabeled rows are overwhelmingly real products (`RAW WHOLE MILK 10.99 F`, `ORGANIC POPCORN 6.49`)

`$in ITEMS` on "coffee purchases" shrank 100 hits to 36, discarding 45 genuine products.

## What shipped

`non_item_section_filter()` in `receipt_chroma.section_labels` — `$nin` over the sections that never hold a product. `$nin` retains rows whose key is absent (verified against Chroma Cloud). Applied at all three call sites via the shared helper (three diverging copies is the same shape as the `build_receipt_rows` shadowing that caused the pairing data loss, #1299).

| query | before | after |
|---|---|---|
| semantic "breakfast items" | 100 hits, 28 noise | 100 hits, **0 noise** |
| semantic "coffee purchases" | 100 hits, 19 noise | 100 hits, **0 noise** |
| text "MILK" | 107 hits | 105 — drops exactly the header/total, keeps all 11 unlabeled products |

MCP copies import the helper lazily (`receipt_chroma.__init__` pulls in chromadb; the servers must stay importable without it — `test_receipt_mcp_lazy_chroma`, 23 tests, passing). Unit test pins the filter's shape and that ITEMS/aliases are never excluded.