### PR TITLE
feat(line-items): band-block decoder replaces banded extraction (Phase D)

### DIFF
--- a/receipt_upload/receipt_upload/line_items/assets/block_role_priors_v1.json
+++ b/receipt_upload/receipt_upload/line_items/assets/block_role_priors_v1.json
@@ -1,0 +1,981 @@
+{
+ "_README": "Template->role priors for item-block decoding, trained on the 25-receipt hand-labeled golden set (line_items_golden.json). Regenerate with scripts/build_block_role_priors.py when the golden set grows. Ships like section_order_priors_v2.json; the Swift worker loads the same asset.",
+ "templates": {
+  "#": {
+   "purity": 1.0,
+   "role": "MEMBER",
+   "support": 2
+  },
+  "# # # STRAWBERRIES SEAWEED SALJ #.# #.#": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "# # #.# #.#": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 12
+  },
+  "# # CHICKN HNY RSTD SALAD MIX #.# #.#": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "# # COCKTAIL BUFALA MOZZ TOM #.# #.#": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "# # FAST SET <A> #.#": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "# # GA STR <A> #.#": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "# # IN. DOWN S <A* #.#": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "# #\" SEWER/DRA <A=": {
+   "purity": 1.0,
+   "role": "MEMBER",
+   "support": 1
+  },
+  "# #\" SEWER/DRA <A>": {
+   "purity": 1.0,
+   "role": "MEMBER",
+   "support": 1
+  },
+  "# ##WATERSTOP <A> #.#": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "# #$#.#": {
+   "purity": 1.0,
+   "role": "MEMBER",
+   "support": 1
+  },
+  "# #' S COLICORNIA MONDELUKE #.# #.#": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "# #'-#GA STD <A= #.#": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "# #-GAL GRID <A>": {
+   "purity": 1.0,
+   "role": "MEMBER",
+   "support": 1
+  },
+  "# #-VOLT MAX <A,S\u00bb #.#": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "# #-VOLT MAX <A> #.#": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "# #-VOLT MAX =A , SA #.#": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "# #.# #.#": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 3
+  },
+  "# #/# COP EL# <A=": {
+   "purity": 1.0,
+   "role": "MEMBER",
+   "support": 1
+  },
+  "# #/# COP EL# <A>": {
+   "purity": 1.0,
+   "role": "MEMBER",
+   "support": 1
+  },
+  "# #/#CRDWSC## <A> #.#": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "# #/#FNDWSC## <A* #.#": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "# #/#IN X #FT STEEL TRACK # GA": {
+   "purity": 1.0,
+   "role": "MEMBER",
+   "support": 1
+  },
+  "# #/#X#MX# <A= #.#": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "# #X#/# # PK <A- #.#": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "# #X#/# IN MIN =A= #.#": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "# #X#X#PRIME <A>": {
+   "purity": 1.0,
+   "role": "MEMBER",
+   "support": 1
+  },
+  "# @ $#.#": {
+   "purity": 1.0,
+   "role": "MEMBER",
+   "support": 1
+  },
+  "# ABC BURGER[BEEL! $#.#": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "# ADJUSTABOX# <A\u00bb #.#": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "# ALBACORE SUSHI #.#": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "# AMAZON #.#": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "# ANIMAL FRY #.#": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "# ASSORTED (YE <A> #.#": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "# BEHR CAULK <A>": {
+   "purity": 1.0,
+   "role": "MEMBER",
+   "support": 1
+  },
+  "# BERRIES NF $# #.#": {
+   "purity": 1.0,
+   "role": "MEMBER",
+   "support": 1
+  },
+  "# BERRIES NF $#.#": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 3
+  },
+  "# CAULK GUN =A> #.#": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "# CHL COUPLG <A> #.#": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "# CRISPY PORK BELLY BASIL #.#": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "# CUT FRUIT NF $#.#": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "# D ULTRA #.# <A=": {
+   "purity": 1.0,
+   "role": "MEMBER",
+   "support": 1
+  },
+  "# D/W SCREW <A*": {
+   "purity": 1.0,
+   "role": "MEMBER",
+   "support": 1
+  },
+  "# DOWNSPT ADPT <A> #.#": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "# FINGERJOINT <A>": {
+   "purity": 1.0,
+   "role": "MEMBER",
+   "support": 1
+  },
+  "# FINGERJOINT \u00abA> #.#": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "# GAL BUCKET-HOMER LOGO (ORANGE)": {
+   "purity": 1.0,
+   "role": "MEMBER",
+   "support": 1
+  },
+  "# GG BACON NF $# #.#": {
+   "purity": 1.0,
+   "role": "MEMBER",
+   "support": 1
+  },
+  "# GG WATER NF P $#.#": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "# GHIRARDELLI NF $#.#": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "# GLAD CLING WRAP #.# #.# T": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "# HAMBURGER #.#": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "# HOMER BUCKET <A> #.#": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "# HSKY #GMIXR \u00abA=": {
+   "purity": 1.0,
+   "role": "MEMBER",
+   "support": 1
+  },
+  "# IN. DOWN SPOUT CATCH BASIN KIT": {
+   "purity": 1.0,
+   "role": "MEMBER",
+   "support": 1
+  },
+  "# JAPANESE SCALLOP SUSHI #.#": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "# JT COMPOUND <A> #.#": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "# LARGE BOTTLED BEER #.#": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "# LT COMPOUND <A> #.#": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "# MACH SCR <A-": {
+   "purity": 1.0,
+   "role": "MEMBER",
+   "support": 1
+  },
+  "# MACH SCR <A> #.#": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "# MANGO STICKY RICE #.#": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "# MEAT PATTY #.#": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "# MELAMINE \u2264A> #.#": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "# METAL TRIM <A>": {
+   "purity": 1.0,
+   "role": "MEMBER",
+   "support": 1
+  },
+  "# NAKED WINGS": {
+   "purity": 1.0,
+   "role": "MEMBER",
+   "support": 1
+  },
+  "# ONION RINGS|LO] $#.#": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "# PAINT SHIELD <A\u00bb": {
+   "purity": 1.0,
+   "role": "MEMBER",
+   "support": 1
+  },
+  "# PONZU SAUCE #.#": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "# REG CHOCOLATE SHK #.#": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "# STEAMED WHITE RICE #.#": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "# STL TRACK <A>": {
+   "purity": 1.0,
+   "role": "MEMBER",
+   "support": 1
+  },
+  "# TARGET BAG T P $#.#": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "# TITEBOND# # <A> #.#": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "# UITIMATE EGG $#.#": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "# VERSABOND <A=": {
+   "purity": 1.0,
+   "role": "MEMBER",
+   "support": 1
+  },
+  "# WINGS #.#": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "#\" SEWER/DRAIN EL #D D# PVC": {
+   "purity": 1.0,
+   "role": "MEMBER",
+   "support": 2
+  },
+  "#\"\u0425\u0417\"X#\" DOWNSPOUT ADPTR PVC": {
+   "purity": 1.0,
+   "role": "MEMBER",
+   "support": 1
+  },
+  "#'# ORG HORIZON ATAULFO #.# #.#": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "#-#-# #X#X#PRIME <A>": {
+   "purity": 1.0,
+   "role": "MEMBER",
+   "support": 1
+  },
+  "#-#-# CA LBR FEE <A, U>": {
+   "purity": 1.0,
+   "role": "MEMBER",
+   "support": 1
+  },
+  "#-#-# CA LBR FEE <A,U\u00bb #.#N": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "#-#-# CA_ LBR FEE \u00abA,U=": {
+   "purity": 1.0,
+   "role": "MEMBER",
+   "support": 1
+  },
+  "#-#-# CA_LBR FEE <A, U>": {
+   "purity": 1.0,
+   "role": "MEMBER",
+   "support": 1
+  },
+  "#-#-# CA_LBR FEE \u00abA, U= #.#N": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "#-#-# SP#-D CHANNEL #' CHANNEL ARAIN <A> # WITH GRATES": {
+   "purity": 1.0,
+   "role": "MEMBER",
+   "support": 1
+  },
+  "#-#/# X # STEEL STUD # GA": {
+   "purity": 1.0,
+   "role": "MEMBER",
+   "support": 1
+  },
+  "#-#/#\" COARSE DRYWALL SCREW # LB": {
+   "purity": 1.0,
+   "role": "MEMBER",
+   "support": 1
+  },
+  "#-#/#\" FINE DRYWALL SCREW # LB": {
+   "purity": 1.0,
+   "role": "MEMBER",
+   "support": 1
+  },
+  "#.#": {
+   "purity": 0.6666666666666666,
+   "role": "OUTSIDE",
+   "support": 3
+  },
+  "#.# #.#": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 9
+  },
+  "#.# #.#N": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "#.#INX#. #INX#IN WHT MEL": {
+   "purity": 1.0,
+   "role": "MEMBER",
+   "support": 1
+  },
+  "#/#\" COP EL # DEG CXC": {
+   "purity": 1.0,
+   "role": "MEMBER",
+   "support": 2
+  },
+  "#/#INX#FT L-METAL TRIM": {
+   "purity": 1.0,
+   "role": "MEMBER",
+   "support": 1
+  },
+  "#@#.# #.#": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 8
+  },
+  "#@#.# #.#N": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "#IN X #.#IN X #IN PRMD FJ": {
+   "purity": 1.0,
+   "role": "MEMBER",
+   "support": 1
+  },
+  "#LB BAG BABY CARROT #.#": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "#LB QUIKRETE WATER-STOP CEMENT": {
+   "purity": 1.0,
+   "role": "MEMBER",
+   "support": 1
+  },
+  "#X#-#/#\" TRIM HEAD SCREW # LB": {
+   "purity": 1.0,
+   "role": "MEMBER",
+   "support": 1
+  },
+  "#X#-#FT PRIMED FJ S#S BOARD": {
+   "purity": 1.0,
+   "role": "MEMBER",
+   "support": 2
+  },
+  "+ FRIED MUSTARD": {
+   "purity": 1.0,
+   "role": "MEMBER",
+   "support": 1
+  },
+  "- -PRO XTRA PREFERRED PRICING--": {
+   "purity": 1.0,
+   "role": "OUTSIDE",
+   "support": 1
+  },
+  "- PRO XTRA PREFERRED PRICING": {
+   "purity": 1.0,
+   "role": "OUTSIDE",
+   "support": 1
+  },
+  "- PRO XTRA PREFERRED PRICING-": {
+   "purity": 1.0,
+   "role": "OUTSIDE",
+   "support": 1
+  },
+  "-- PRO XTRA PREFERRED PRICING--.": {
+   "purity": 1.0,
+   "role": "OUTSIDE",
+   "support": 1
+  },
+  "------PRO XTRA PREFERRED PRICIN": {
+   "purity": 1.0,
+   "role": "OUTSIDE",
+   "support": 1
+  },
+  "-----PRO XTRA PREFERRED PRICING-----": {
+   "purity": 1.0,
+   "role": "OUTSIDE",
+   "support": 1
+  },
+  "----PRO XTRA PREFERRED PRICING-": {
+   "purity": 1.0,
+   "role": "OUTSIDE",
+   "support": 1
+  },
+  "---PRO XTRA PREFERRED PRICING": {
+   "purity": 1.0,
+   "role": "OUTSIDE",
+   "support": 1
+  },
+  "---PRO XTRA PREFERRED PRICING-": {
+   "purity": 1.0,
+   "role": "OUTSIDE",
+   "support": 1
+  },
+  "---PRO XTRA PREFERRED PRICING--": {
+   "purity": 1.0,
+   "role": "OUTSIDE",
+   "support": 1
+  },
+  "-PRO XTRA PREFERRED PRICING-": {
+   "purity": 1.0,
+   "role": "OUTSIDE",
+   "support": 1
+  },
+  "-PRO XTRA PREFERRED PRICING.-": {
+   "purity": 1.0,
+   "role": "OUTSIDE",
+   "support": 1
+  },
+  ". #IN X #.#IN X #IN PRMD FJ BOARD": {
+   "purity": 1.0,
+   "role": "MEMBER",
+   "support": 1
+  },
+  ".#": {
+   "purity": 1.0,
+   "role": "OUTSIDE",
+   "support": 1
+  },
+  "ARNOLD PALMER #.#": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "ASSTD (Y&R> WNGD WIRE CONN #PK": {
+   "purity": 1.0,
+   "role": "MEMBER",
+   "support": 1
+  },
+  "AVOCADO MASH #OZ TRAY": {
+   "purity": 1.0,
+   "role": "MEMBER",
+   "support": 2
+  },
+  "BEANS GREEN ORGANIC #LB $#.#": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "BEHR MULTI-PURP CAULK #.# OZ WHITE": {
+   "purity": 1.0,
+   "role": "MEMBER",
+   "support": 1
+  },
+  "BEST # X #/# IN SHEDLESS KNIT ASSEM": {
+   "purity": 1.0,
+   "role": "MEMBER",
+   "support": 1
+  },
+  "BETTER # X #/# IN KNIT MINI GPK": {
+   "purity": 1.0,
+   "role": "MEMBER",
+   "support": 1
+  },
+  "BLACK TRUFFLE FIOCCHETTI": {
+   "purity": 1.0,
+   "role": "MEMBER",
+   "support": 1
+  },
+  "BLSL CHICKEN THIGHS #.#": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "BOTTLE DEPOSIT FEE $#.#": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "BROCCOLI FLORETS #.#": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "BURGER[BEEF]": {
+   "purity": 1.0,
+   "role": "MEMBER",
+   "support": 1
+  },
+  "BUTTER CHARDONNAY #.# T": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "CA LUMBER FEE": {
+   "purity": 1.0,
+   "role": "MEMBER",
+   "support": 4
+  },
+  "CARLON NEW WORK #G #CU ADJUSTABLE": {
+   "purity": 1.0,
+   "role": "MEMBER",
+   "support": 1
+  },
+  "CHICKEN GYOZA $#.#": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 2
+  },
+  "CLOROX DISINFECTING BLEAC... $#.# T": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "DESCRIPTION": {
+   "purity": 1.0,
+   "role": "OUTSIDE",
+   "support": 2
+  },
+  "DW # FV ADV BL. COMBO KIT": {
+   "purity": 1.0,
+   "role": "MEMBER",
+   "support": 1
+  },
+  "DW #V XR BL #-#/#\" GRINDER": {
+   "purity": 1.0,
+   "role": "MEMBER",
+   "support": 1
+  },
+  "DW #V XR BL (#) #AH HMR COMBO KIT": {
+   "purity": 1.0,
+   "role": "MEMBER",
+   "support": 1
+  },
+  "DW BACKWALL BOGO -#.#": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "DYNAFLEX ULTRA #.# OZ BLACK ADVANCE": {
+   "purity": 1.0,
+   "role": "MEMBER",
+   "support": 1
+  },
+  "E # # AHI BAGEL TUNA CH #.# #.#": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "E # BEEF FLANK #.#": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "E #H# BAGUETTE #, #. # #": {
+   "purity": 1.0,
+   "role": "MEMBER",
+   "support": 1
+  },
+  "EGG BITES UNEXPECTED CHE $#.#": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "GROCERY": {
+   "purity": 1.0,
+   "role": "OUTSIDE",
+   "support": 1
+  },
+  "GUAVA NECTAR JUICE ORG # $#.#": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "HALF & HALF PINT $#.#": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "HDX # GA ET STRAINER - # PK": {
+   "purity": 1.0,
+   "role": "MEMBER",
+   "support": 1
+  },
+  "HOT SMOKED SALMON CLASSIC": {
+   "purity": 1.0,
+   "role": "MEMBER",
+   "support": 2
+  },
+  "HOT SMOKED SALMON PEPPER": {
+   "purity": 1.0,
+   "role": "MEMBER",
+   "support": 1
+  },
+  "HUSKY NARROW PAINT MIXER # GALLON": {
+   "purity": 1.0,
+   "role": "MEMBER",
+   "support": 1
+  },
+  "HW FAST SET LITE # MIN # LB BAG": {
+   "purity": 1.0,
+   "role": "MEMBER",
+   "support": 1
+  },
+  "HW RED DOT ALL PURP JC BOX #.# GAL": {
+   "purity": 1.0,
+   "role": "MEMBER",
+   "support": 2
+  },
+  "I: IFS # LB. #.# #.#": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "IF $#.#/#": {
+   "purity": 1.0,
+   "role": "MEMBER",
+   "support": 1
+  },
+  "ITEM QTY PRICE TOTAL": {
+   "purity": 1.0,
+   "role": "OUTSIDE",
+   "support": 1
+  },
+  "ITEM UTY PRICE TOTAL": {
+   "purity": 1.0,
+   "role": "OUTSIDE",
+   "support": 1
+  },
+  "LARGE ALFRESCO EGGS #.#": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "LOBSTER MAC AND CHEESE #C": {
+   "purity": 1.0,
+   "role": "MEMBER",
+   "support": 1
+  },
+  "LOBSTER RAVIOLI #OZ FW": {
+   "purity": 1.0,
+   "role": "MEMBER",
+   "support": 1
+  },
+  "MANGO NECTAR JUICE ORG # $#.#": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "MAX REFUND VALUE $#.#": {
+   "purity": 1.0,
+   "role": "MEMBER",
+   "support": 15
+  },
+  "MAX REFUND VALUE $#.#/#": {
+   "purity": 1.0,
+   "role": "MEMBER",
+   "support": 7
+  },
+  "MCH SCRW ZINC PHL FLT ## X #-#/#": {
+   "purity": 1.0,
+   "role": "MEMBER",
+   "support": 1
+  },
+  "MCH SCRW ZINC PHL FLT ## X #.": {
+   "purity": 1.0,
+   "role": "MEMBER",
+   "support": 1
+  },
+  "MEDIUM RARE": {
+   "purity": 1.0,
+   "role": "MEMBER",
+   "support": 2
+  },
+  "MILK QUART WHOLE $#.#": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "MKE MX# SDS+ #/#\" X #\" DRILL BIT": {
+   "purity": 1.0,
+   "role": "MEMBER",
+   "support": 1
+  },
+  "MULTI-FLORAL AND CLOVER $#.#": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "NLP SAVINGS $#.#": {
+   "purity": 1.0,
+   "role": "MEMBER",
+   "support": 3
+  },
+  "OL IPOP GRAPE #.# F": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "OLIPOP SPRKL TONIC #.# F": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "OR # '# BLUEBERRI! S&P PISTACH #.# #.#": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "ORG # CNT GARLIC #.#": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "ORG A#/A# #% FAT MLK #.#": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "ORG GINGER ROOT #.#": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "ORGANIC GREEN ONIONS #.#": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "OUTY # GALLON BUCKET GRID": {
+   "purity": 1.0,
+   "role": "MEMBER",
+   "support": 1
+  },
+  "PRICING -#.#": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "PRO XTRA MEMBER STATEMENT": {
+   "purity": 1.0,
+   "role": "OUTSIDE",
+   "support": 1
+  },
+  "PRO XTRA PREFERRED PRICING -#.#": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 11
+  },
+  "R-ARUGULA LEMON BASIL CO $#,#": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "R-SALAD COMPLETE CAESAR $#.#": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "RANCH": {
+   "purity": 1.0,
+   "role": "MEMBER",
+   "support": 1
+  },
+  "ROCKENWAGNER FRENCH LOAF $#.# F": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "SALAD CHICKEN APPLE WALD $#.#": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "SOUR CREAM #.#": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "SPEE-D CHANNEL DRAIN COUPLING": {
+   "purity": 1.0,
+   "role": "MEMBER",
+   "support": 1
+  },
+  "SPICY SPUDS $#.#": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 3
+  },
+  "SUPER SPINACH SALAD $#.#": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  },
+  "TRIM # IN CARDBOARD PAINT SHIELD": {
+   "purity": 1.0,
+   "role": "MEMBER",
+   "support": 1
+  },
+  "VERSABOND BONDING MORTAR-WHITE #LB": {
+   "purity": 1.0,
+   "role": "MEMBER",
+   "support": 1
+  },
+  "WATER (# #.#) #.#": {
+   "purity": 1.0,
+   "role": "PRICE",
+   "support": 1
+  }
+ },
+ "version": "block-role-priors-v1"
+}

--- a/receipt_upload/receipt_upload/line_items/blocks.py
+++ b/receipt_upload/receipt_upload/line_items/blocks.py
@@ -276,7 +276,11 @@ def decode_blocks(ocr_receipt: dict, priors: dict) -> list[dict]:
         return len(toks) < 2
 
     items = []
-    for p in price_idx:
+    # Emission order matches the banded implementation (ascending y,
+    # bottom of the receipt first): item order is a pinned guarantee --
+    # backfill derives item_index from list position, and the echo-dedup
+    # fixture asserts positional semantics.
+    for p in reversed(price_idx):
         pl = lines[p]
         parsed = parse_band(list(words_by_line[pl["line_id"]]))
         if parsed is None or parsed.get("price") is None:
@@ -536,7 +540,9 @@ def decode_band_blocks(ocr_receipt: dict, priors: dict) -> list[dict]:
         return len(re.findall(r"[A-Za-z]{2,}", stripped)) < 2
 
     items = []
-    for p in price_idx:
+    # Emission order matches the banded implementation (ascending y --
+    # bottom of the receipt first): item order is a pinned guarantee.
+    for p in reversed(price_idx):
         parsed = parsed_cache.get(p) or parse_band(list(bands[p]["words"]))
         if parsed is None or parsed.get("price") is None:
             continue
@@ -556,13 +562,23 @@ def decode_band_blocks(ocr_receipt: dict, priors: dict) -> list[dict]:
                     parsed["unit_price"] = mp["unit_price"]
                     break
         if _sku_dominated(parsed.get("name") or ""):
+            # Donor criterion is _name_is_real (>=3 alpha chars), NOT the
+            # two-token SKU test: single-word product names ("BREAD",
+            # "YOGURT") are real names, and requiring two tokens silently
+            # discarded them -- the boundary-steal guarantee failure the
+            # first integration attempt was reverted on.
             cands = [
                 (len(bands[i]["text"]), bands[i]["text"])
                 for i in blocks[p]
-                if not _sku_dominated(bands[i]["text"])
+                if _name_is_real(bands[i]["text"])
             ]
             if cands:
                 parsed["name"] = max(cands)[1].strip()
+                parsed["stacked"] = True
+        if not _name_is_real(parsed.get("name") or ""):
+            # No name anywhere: keep the price, flag the quality --
+            # identical semantics to the banded path.
+            parsed["name_quality"] = "low"
         parsed["line_ids"] = sorted(
             set(bands[p]["line_ids"]).union(
                 *(bands[i]["line_ids"] for i in blocks[p])

--- a/receipt_upload/receipt_upload/line_items/blocks.py
+++ b/receipt_upload/receipt_upload/line_items/blocks.py
@@ -66,6 +66,11 @@ def _line_amounts(words: list[dict]) -> list[float]:
         t = w["text"]
         if t.endswith(")") and "(" not in t:
             continue  # OCR carcass ("80.00)" from "@0.00)"), never a price
+        # OCR fuses trailing taxability flags onto amounts ("0.38N",
+        # "0.20N" on Home Depot fee lines); strip a single trailing letter
+        # when what remains is an amount shape.
+        if re.fullmatch(r"\$?\d[\d.,]*\d[A-Z]", t):
+            t = t[:-1]
         if looks_like_receipt_amount(t) and re.search(r"\d[.,]\d{2}(?!\d)", t):
             v = parse_receipt_amount(t)
             if v is not None:
@@ -140,3 +145,155 @@ def derive_block_labels(golden_receipt: dict, ocr_receipt: dict) -> list[dict]:
             }
         )
     return out
+
+
+def build_role_priors(labeled: list[list[dict]]) -> dict:
+    """Template -> role frequency table from derived labels.
+
+    ``labeled`` is a list of per-receipt outputs of derive_block_labels.
+    Templates are digit-collapsed shapes, so "MAX REFUND VALUE $ #.#"
+    learned on one receipt applies to every other receipt printing it.
+    """
+    from collections import Counter as _C
+
+    table: dict[str, Any] = {}
+    counts: dict[str, _C] = {}
+    for rows in labeled:
+        for r in rows:
+            counts.setdefault(r["template"], _C())[r["role"]] += 1
+    for tpl, c in counts.items():
+        total = sum(c.values())
+        role, n = c.most_common(1)[0]
+        table[tpl] = {"role": role, "support": total, "purity": n / total}
+    return table
+
+
+def decode_blocks(ocr_receipt: dict, priors: dict) -> list[dict]:
+    """Segment the ITEMS zone into item blocks and emit items.
+
+    Role per line: the learned template table when it has seen the shape
+    (purity >= 0.75, support >= 2), else structural fallback -- a line
+    whose amounts reach the zone's right-most amount column is PRICE, an
+    alpha-bearing line is MEMBER, else OUTSIDE. Blocks: each PRICE line
+    seeds a block; MEMBER lines attach to the nearer adjacent PRICE line
+    in reading order, with the receipt-wide orientation rule from
+    extract_items reused for ties. The item's name prefers alpha-rich
+    member text over SKU-heavy text; price is the PRICE line's rightmost
+    amount.
+    """
+    words_by_line: dict[int, list[dict]] = defaultdict(list)
+    for w in ocr_receipt["words"]:
+        words_by_line[w["line_id"]].append(w)
+    for ws in words_by_line.values():
+        ws.sort(key=lambda w: w["x"])
+    zone = set(ocr_receipt["items_line_ids"])
+    line_order = sorted(
+        (lid for lid in words_by_line if lid in zone),
+        key=lambda lid: -(
+            sum(w["y_mid"] for w in words_by_line[lid])
+            / len(words_by_line[lid])
+        ),
+    )
+    if not line_order:
+        return []
+
+    # zone price column = right-most x of any amount word, minus tolerance
+    amt_x = []
+    for lid in line_order:
+        for w in words_by_line[lid]:
+            t = w["text"]
+            if re.fullmatch(r"\$?\d[\d.,]*\d[A-Z]", t):
+                t = t[:-1]
+            if looks_like_receipt_amount(t) and re.search(
+                r"\d[.,]\d{2}(?!\d)", t
+            ):
+                amt_x.append(w["x"])
+    col_x = max(amt_x) if amt_x else None
+
+    lines = []
+    for lid in line_order:
+        ws = words_by_line[lid]
+        text = " ".join(w["text"] for w in ws)
+        tpl = templatize(text)
+        amounts = _line_amounts(ws)
+        prior = priors.get(tpl)
+        if prior and prior["purity"] >= 0.75 and prior["support"] >= 2:
+            role = prior["role"]
+        elif (
+            amounts
+            and col_x is not None
+            and any(
+                abs(w["x"] - col_x) < 0.15 for w in ws if _line_amounts([w])
+            )
+        ):
+            role = "PRICE"
+        elif re.search(r"[A-Za-z]{3,}", text):
+            role = "MEMBER"
+        else:
+            role = "MEMBER" if amounts else "OUTSIDE"
+        lines.append(
+            {
+                "line_id": lid,
+                "text": text,
+                "template": tpl,
+                "role": role,
+                "amounts": amounts,
+            }
+        )
+
+    price_idx = [i for i, l in enumerate(lines) if l["role"] == "PRICE"]
+    if not price_idx:
+        return []
+    # attach members to the nearer adjacent PRICE line (index distance in
+    # reading order; ties go up, matching how metadata precedes totals)
+    blocks: dict[int, list[int]] = {p: [] for p in price_idx}
+    for i, l in enumerate(lines):
+        if l["role"] != "MEMBER":
+            continue
+        prev_p = max((p for p in price_idx if p < i), default=None)
+        next_p = min((p for p in price_idx if p > i), default=None)
+        if prev_p is None and next_p is None:
+            continue
+        if prev_p is None:
+            blocks[next_p].append(i)
+        elif next_p is None:
+            blocks[prev_p].append(i)
+        else:
+            blocks[prev_p if (i - prev_p) <= (next_p - i) else next_p].append(
+                i
+            )
+
+    items = []
+    for p in price_idx:
+        pl = lines[p]
+        if not pl["amounts"]:
+            continue
+        price = pl["amounts"][-1]
+        # name: alpha-rich member text, SKU-stripped; fall back to the
+        # PRICE line's own non-amount text
+        cands = []
+        for i in blocks[p]:
+            t = lines[i]["text"]
+            stripped = re.sub(r"\d{4,}", " ", t)
+            toks = re.findall(r"[A-Za-z]{2,}", stripped)
+            if len(toks) >= 2:
+                cands.append((len(" ".join(toks)), t))
+        if cands:
+            name = max(cands)[1]
+        else:
+            name = " ".join(
+                w["text"]
+                for w in words_by_line[pl["line_id"]]
+                if not _line_amounts([w])
+            )
+        items.append(
+            {
+                "name": name.strip(),
+                "price": price,
+                "quantity": None,
+                "line_ids": sorted(
+                    {pl["line_id"]} | {lines[i]["line_id"] for i in blocks[p]}
+                ),
+            }
+        )
+    return items

--- a/receipt_upload/receipt_upload/line_items/blocks.py
+++ b/receipt_upload/receipt_upload/line_items/blocks.py
@@ -312,6 +312,66 @@ def decode_blocks(ocr_receipt: dict, priors: dict) -> list[dict]:
     return items
 
 
+def merge_price_fragments(words: list[dict]) -> list[dict]:
+    """Concatenate OCR-shattered price fragments within a band.
+
+    Vision splits some prices into adjacent tokens -- "1." + "99" for 1.99
+    (Costco), "5," + "90" (comma for period). Textract read the same
+    pixels whole, which is a large part of its 90% vs our 85% recall.
+    Merge an x-adjacent pair when the left token is digits ending in a
+    separator and the right is exactly two digits, yielding a valid
+    amount. Digit MISREADS (4.89 read as 1.89) are left alone: no
+    geometry can recover a digit OCR never produced -- that class is the
+    re-OCR trigger's job.
+    """
+    if len(words) < 2:
+        return words
+    ws = sorted(words, key=lambda w: w["x"])
+    out: list[dict] = []
+    i = 0
+    while i < len(ws):
+        w = ws[i]
+        if i + 1 < len(ws):
+            nxt = ws[i + 1]
+            gap = nxt["x"] - w["x"]
+            if (
+                re.fullmatch(r"\$?\d{1,4}[.,]", w["text"])
+                and re.fullmatch(r"\d{2}", nxt["text"])
+                and 0 <= gap < 0.08
+            ):
+                merged = dict(w)
+                merged["text"] = w["text"].replace(",", ".") + nxt["text"]
+                out.append(merged)
+                i += 2
+                continue
+        out.append(w)
+        i += 1
+    return out
+
+
+def should_reocr_items_zone(
+    items: list[dict], printed_subtotal: float | None
+) -> bool:
+    """Reconciliation-triggered re-OCR decision (pure; wiring is the
+    pipeline's REGIONAL_REOCR job).
+
+    Fires when the decoded items exist but do not sum to the receipt's own
+    printed subtotal beyond the reconcile tolerance -- the signature of
+    digit-level OCR misreads (4.89 -> 1.89) that no downstream logic can
+    recover. Deliberately does NOT fire on empty zones (nothing to
+    re-read) or on match/near (re-OCR spends time to fix nothing; most
+    receipts are already right). Known limit, verified on Twin Peaks: some
+    glyphs are unreadable at any resolution; the caller must cap attempts.
+    """
+    if not items or printed_subtotal is None or printed_subtotal <= 0:
+        return False
+    total = sum(
+        i["price"] for i in items if isinstance(i.get("price"), (int, float))
+    )
+    diff = abs(round(total, 2) - printed_subtotal)
+    return diff > max(1.0, printed_subtotal * 0.10)
+
+
 def _zone_bands(ocr_receipt: dict) -> list[dict]:
     """Deskewed visual bands over the zone, as decode units.
 
@@ -326,6 +386,11 @@ def _zone_bands(ocr_receipt: dict) -> list[dict]:
     words = [w for w in ocr_receipt["words"] if w["line_id"] in zone]
     out = []
     for band in band_words(words):
+        # merge_price_fragments is deliberately NOT applied here: run
+        # unconditionally it manufactured a plausible-but-wrong 5.90 from
+        # "5,"+"90" (truth 5.99 -- shattered AND digit-misread) and failed
+        # Costco's precision floor. Fragment reconstruction is a REPAIR
+        # action for the reconciliation-triggered path, alongside re-OCR.
         text = " ".join(w["text"] for w in band)
         out.append(
             {

--- a/receipt_upload/receipt_upload/line_items/blocks.py
+++ b/receipt_upload/receipt_upload/line_items/blocks.py
@@ -391,6 +391,64 @@ def decode_band_blocks(ocr_receipt: dict, priors: dict) -> list[dict]:
             b["role"] = "OUTSIDE"
 
     price_idx = [i for i, b in enumerate(bands) if b["role"] == "PRICE"]
+
+    # META absorption, ported from extract_items -- the corpus sweep vetoed
+    # the decoder without it (match 415->389, +70 items): qty bands
+    # ("2 @ 8.99") and price echoes emitted as their own items on formats
+    # outside the golden set. A PRICE band with no real name is absorbed by
+    # an ADJACENT price band when its qty*unit explains that neighbor's
+    # price, or when it merely echoes the neighbor's price with SKU/qty
+    # signature. Absorbed bands transplant quantity and stop being items.
+    from receipt_upload.line_items.geometry import (
+        SKU_LIKE_RE,
+        _name_is_real,
+    )
+
+    parsed_cache: dict[int, dict | None] = {
+        p: parse_band(list(bands[p]["words"])) for p in price_idx
+    }
+    absorbed: set[int] = set()
+    for pos, p in enumerate(price_idx):
+        mp = parsed_cache[p]
+        if mp is None or _name_is_real(mp.get("name") or ""):
+            continue
+        qty, unit = mp.get("quantity"), mp.get("unit_price")
+        for npos in (pos - 1, pos + 1):
+            if not 0 <= npos < len(price_idx):
+                continue
+            q = price_idx[npos]
+            if q in absorbed:
+                continue
+            nb = parsed_cache[q]
+            if nb is None or nb.get("price") is None:
+                continue
+            if (
+                qty is not None
+                and unit is not None
+                and abs(qty * unit - nb["price"]) <= 0.02
+            ):
+                if nb.get("quantity") is None:
+                    nb["quantity"], nb["unit_price"] = qty, unit
+                absorbed.add(p)
+                break
+            # Echo absorption ONLY into a real-named neighbor -- the same
+            # constraint extract_items enforces via kind==ITEM. Without it,
+            # Wild Fork's genuinely distinct same-priced SKU rows (two
+            # items at 8.98) absorb each other: measured recall 100->45%.
+            if (
+                mp.get("price") is not None
+                and _name_is_real(nb.get("name") or "")
+                and abs(mp["price"]) == abs(nb["price"])
+                and (
+                    SKU_LIKE_RE.search(mp.get("raw_text") or "")
+                    or qty is not None
+                )
+            ):
+                if qty is not None and nb.get("quantity") is None:
+                    nb["quantity"], nb["unit_price"] = qty, unit
+                absorbed.add(p)
+                break
+    price_idx = [p for p in price_idx if p not in absorbed]
     blocks: dict[int, list[int]] = {p: [] for p in price_idx}
     for i, b in enumerate(bands):
         if b["role"] != "MEMBER":
@@ -414,7 +472,7 @@ def decode_band_blocks(ocr_receipt: dict, priors: dict) -> list[dict]:
 
     items = []
     for p in price_idx:
-        parsed = parse_band(list(bands[p]["words"]))
+        parsed = parsed_cache.get(p) or parse_band(list(bands[p]["words"]))
         if parsed is None or parsed.get("price") is None:
             continue
         if parsed.get("quantity") is None:

--- a/receipt_upload/receipt_upload/line_items/blocks.py
+++ b/receipt_upload/receipt_upload/line_items/blocks.py
@@ -507,3 +507,12 @@ def decode_band_blocks(ocr_receipt: dict, priors: dict) -> list[dict]:
         )
         items.append(parsed)
     return items
+
+
+def load_default_priors() -> dict:
+    """The committed template->role prior asset (golden-set trained)."""
+    import json
+    from pathlib import Path
+
+    path = Path(__file__).parent / "assets" / "block_role_priors_v1.json"
+    return json.load(open(path))["templates"]

--- a/receipt_upload/receipt_upload/line_items/blocks.py
+++ b/receipt_upload/receipt_upload/line_items/blocks.py
@@ -310,3 +310,142 @@ def decode_blocks(ocr_receipt: dict, priors: dict) -> list[dict]:
         parsed["line_ids"] = sorted({pl["line_id"], *member_ids})
         items.append(parsed)
     return items
+
+
+def _zone_bands(ocr_receipt: dict) -> list[dict]:
+    """Deskewed visual bands over the zone, as decode units.
+
+    Bands restore same-visual-row joining (name left, price right as two
+    OCR lines) that line-level decode measurably lost -- In-N-Out /
+    The Stand / Smith's / Target names went to 0-25% on lines and their
+    layouts never let name meet price in one parse_band call.
+    """
+    from receipt_upload.line_items.geometry import band_words
+
+    zone = set(ocr_receipt["items_line_ids"])
+    words = [w for w in ocr_receipt["words"] if w["line_id"] in zone]
+    out = []
+    for band in band_words(words):
+        text = " ".join(w["text"] for w in band)
+        out.append(
+            {
+                "words": band,
+                "line_ids": sorted({w["line_id"] for w in band}),
+                "text": text,
+                "template": templatize(text),
+                "amounts": _line_amounts(band),
+                "y": sum(w["y_mid"] for w in band) / len(band),
+            }
+        )
+    out.sort(key=lambda b: -b["y"])  # reading order
+    return out
+
+
+def derive_band_labels(golden_receipt: dict, ocr_receipt: dict) -> list[dict]:
+    """Band-granularity roles lifted from the line-level derivation."""
+    line_roles = {
+        r["line_id"]: r
+        for r in derive_block_labels(golden_receipt, ocr_receipt)
+    }
+    out = []
+    for b in _zone_bands(ocr_receipt):
+        roles = [line_roles.get(lid) for lid in b["line_ids"]]
+        roles = [r for r in roles if r]
+        if any(r["role"] == "PRICE" for r in roles):
+            role, blk = "PRICE", next(
+                r["block_index"] for r in roles if r["role"] == "PRICE"
+            )
+        elif any(r["role"] == "MEMBER" for r in roles):
+            role = "MEMBER"
+            blk = next(
+                r["block_index"] for r in roles if r["role"] == "MEMBER"
+            )
+        else:
+            role, blk = "OUTSIDE", None
+        out.append(
+            {
+                **{k: b[k] for k in ("text", "template")},
+                "role": role,
+                "block_index": blk,
+            }
+        )
+    return out
+
+
+def decode_band_blocks(ocr_receipt: dict, priors: dict) -> list[dict]:
+    """Block decode over deskewed visual bands (the corrected unit)."""
+    from receipt_upload.line_items.geometry import parse_band
+
+    bands = _zone_bands(ocr_receipt)
+    if not bands:
+        return []
+    for b in bands:
+        prior = priors.get(b["template"])
+        if prior and prior["purity"] >= 0.75 and prior["support"] >= 2:
+            b["role"] = prior["role"]
+        elif b["amounts"]:
+            b["role"] = "PRICE"
+        elif re.search(r"[A-Za-z]{3,}", b["text"]):
+            b["role"] = "MEMBER"
+        else:
+            b["role"] = "OUTSIDE"
+
+    price_idx = [i for i, b in enumerate(bands) if b["role"] == "PRICE"]
+    blocks: dict[int, list[int]] = {p: [] for p in price_idx}
+    for i, b in enumerate(bands):
+        if b["role"] != "MEMBER":
+            continue
+        prev_p = max((p for p in price_idx if p < i), default=None)
+        next_p = min((p for p in price_idx if p > i), default=None)
+        if prev_p is None and next_p is None:
+            continue
+        if prev_p is None:
+            blocks[next_p].append(i)
+        elif next_p is None:
+            blocks[prev_p].append(i)
+        else:
+            blocks[prev_p if (i - prev_p) <= (next_p - i) else next_p].append(
+                i
+            )
+
+    def _sku_dominated(name: str) -> bool:
+        stripped = re.sub(r"\d{4,}", " ", name or "")
+        return len(re.findall(r"[A-Za-z]{2,}", stripped)) < 2
+
+    items = []
+    for p in price_idx:
+        parsed = parse_band(list(bands[p]["words"]))
+        if parsed is None or parsed.get("price") is None:
+            continue
+        if parsed.get("quantity") is None:
+            for i in blocks[p]:
+                mp = parse_band(list(bands[i]["words"]))
+                if (
+                    mp
+                    and mp.get("quantity") is not None
+                    and mp.get("unit_price") is not None
+                    and abs(
+                        mp["quantity"] * mp["unit_price"] - parsed["price"]
+                    )
+                    <= 0.02
+                ):
+                    parsed["quantity"] = mp["quantity"]
+                    parsed["unit_price"] = mp["unit_price"]
+                    break
+        if _sku_dominated(parsed.get("name") or ""):
+            cands = [
+                (len(bands[i]["text"]), bands[i]["text"])
+                for i in blocks[p]
+                if not _sku_dominated(bands[i]["text"])
+            ]
+            if cands:
+                parsed["name"] = max(cands)[1].strip()
+        parsed["line_ids"] = sorted(
+            set(bands[p]["line_ids"]).union(
+                *(bands[i]["line_ids"] for i in blocks[p])
+            )
+            if blocks[p]
+            else set(bands[p]["line_ids"])
+        )
+        items.append(parsed)
+    return items

--- a/receipt_upload/receipt_upload/line_items/blocks.py
+++ b/receipt_upload/receipt_upload/line_items/blocks.py
@@ -1,0 +1,142 @@
+"""Item-block segmentation over the ITEMS zone (Phase D.6a).
+
+Blocks are the section problem one level down: contiguous runs of OCR lines
+forming one purchased item (SKU / description / qty / discount / annotation
+members, exactly one price-carrier line). This module decodes at the OCR
+LINE level, not the visual-band level, deliberately: the Home Depot failure
+included a description line band-merging into a neighbouring SKU line, and
+line-level decode sidesteps banding entirely.
+
+Stage 1 (this commit): derive supervised block labels from the golden
+fixtures. The hand-labeled ``line_ids`` on every golden item are free
+segmentation labels; the item's ``price`` identifies which member line
+carries it. These labels train the decoder's priors and evaluate it.
+
+Roles:
+  PRICE   -- the line carrying the item's extended total
+  MEMBER  -- any other line inside an item's line_ids (SKU, description,
+             qty, refund-note, ...)
+  OUTSIDE -- zone lines belonging to no item (headers, stray annotations)
+Discount items keep the same roles with ``is_discount`` carried on the
+block, mirroring the golden truth.
+
+Prior art: receipt_agent's item_line_grammar (feat/item-grammar-refine)
+learns per-merchant item-row templates for synthesis from the same kind of
+labels -- shape templatization and label-derived column medians. It never
+segments; the concepts transfer, the code does not (it reads synth-batch
+exports).
+"""
+
+from __future__ import annotations
+
+import re
+from collections import defaultdict
+from typing import Any
+
+from receipt_dynamo.amounts import (
+    looks_like_receipt_amount,
+    parse_receipt_amount,
+)
+
+__all__ = ["derive_block_labels", "templatize"]
+
+
+def templatize(text: str) -> str:
+    """Digit-collapsed shape of a line ("MAX REFUND VALUE $ #.#")."""
+    t = re.sub(r"\s+", " ", (text or "").strip().upper())
+    return re.sub(r"\d+", "#", t)
+
+
+def _money(v: Any) -> float | None:
+    if v is None:
+        return None
+    t = str(v).replace("$", "").replace(",", "").strip()
+    neg = t.startswith("-") or (t.startswith("(") and t.endswith(")"))
+    t = t.strip("()").lstrip("-")
+    try:
+        val = float(t)
+    except ValueError:
+        return None
+    return -val if neg else val
+
+
+def _line_amounts(words: list[dict]) -> list[float]:
+    out = []
+    for w in words:
+        t = w["text"]
+        if t.endswith(")") and "(" not in t:
+            continue  # OCR carcass ("80.00)" from "@0.00)"), never a price
+        if looks_like_receipt_amount(t) and re.search(r"\d[.,]\d{2}(?!\d)", t):
+            v = parse_receipt_amount(t)
+            if v is not None:
+                out.append(v)
+    return out
+
+
+def derive_block_labels(golden_receipt: dict, ocr_receipt: dict) -> list[dict]:
+    """Per-line role labels for one golden receipt.
+
+    Returns one record per zone line: {line_id, text, template, role,
+    block_index (or None), is_discount}. ``role`` is PRICE / MEMBER /
+    OUTSIDE. A PRICE line is the member line whose parsed amounts include
+    the item's price; when several member lines carry it (SKU-row echo
+    layouts), the LAST in reading order wins, matching how receipts print
+    the extended total after the metadata.
+    """
+    words_by_line: dict[int, list[dict]] = defaultdict(list)
+    for w in ocr_receipt["words"]:
+        words_by_line[w["line_id"]].append(w)
+    for ws in words_by_line.values():
+        ws.sort(key=lambda w: w["x"])
+    # reading order: larger y_mid is higher on the receipt
+    line_order = sorted(
+        words_by_line,
+        key=lambda lid: -(
+            sum(w["y_mid"] for w in words_by_line[lid])
+            / len(words_by_line[lid])
+        ),
+    )
+    rank = {lid: i for i, lid in enumerate(line_order)}
+
+    role: dict[int, str] = {}
+    block_of: dict[int, int] = {}
+    discount: dict[int, bool] = {}
+    for b_idx, item in enumerate(golden_receipt["true_items"]):
+        lids = [lid for lid in (item.get("line_ids") or []) if lid in rank]
+        if not lids:
+            continue
+        target = _money(item.get("price"))
+        carriers = [
+            lid
+            for lid in lids
+            if target is not None
+            and any(
+                abs(a - target) < 0.005
+                for a in _line_amounts(words_by_line[lid])
+            )
+        ]
+        price_line = (
+            max(carriers, key=lambda lid: rank[lid]) if carriers else None
+        )
+        for lid in lids:
+            role[lid] = "PRICE" if lid == price_line else "MEMBER"
+            block_of[lid] = b_idx
+            discount[lid] = bool(item.get("is_discount"))
+
+    zone = set(ocr_receipt["items_line_ids"])
+    out = []
+    for lid in line_order:
+        if lid not in zone:
+            continue
+        text = " ".join(w["text"] for w in words_by_line[lid])
+        out.append(
+            {
+                "line_id": lid,
+                "text": text,
+                "template": templatize(text),
+                "role": role.get(lid, "OUTSIDE"),
+                "block_index": block_of.get(lid),
+                "is_discount": discount.get(lid, False),
+            }
+        )
+    return out

--- a/receipt_upload/receipt_upload/line_items/blocks.py
+++ b/receipt_upload/receipt_upload/line_items/blocks.py
@@ -263,37 +263,50 @@ def decode_blocks(ocr_receipt: dict, priors: dict) -> list[dict]:
                 i
             )
 
+    # Hybrid emit (composition rule): the decoder decided GROUPING only.
+    # Per-line parsing/naming is parse_band, the mature component -- v1
+    # rebuilt naming and regressed every single-row format while fixing
+    # the multi-row ones. Member text replaces the parsed name only when
+    # the PRICE line's own name is missing or SKU-dominated.
+    from receipt_upload.line_items.geometry import parse_band
+
+    def _sku_dominated(name: str) -> bool:
+        stripped = re.sub(r"\d{4,}", " ", name or "")
+        toks = re.findall(r"[A-Za-z]{2,}", stripped)
+        return len(toks) < 2
+
     items = []
     for p in price_idx:
         pl = lines[p]
-        if not pl["amounts"]:
+        parsed = parse_band(list(words_by_line[pl["line_id"]]))
+        if parsed is None or parsed.get("price") is None:
             continue
-        price = pl["amounts"][-1]
-        # name: alpha-rich member text, SKU-stripped; fall back to the
-        # PRICE line's own non-amount text
-        cands = []
-        for i in blocks[p]:
-            t = lines[i]["text"]
-            stripped = re.sub(r"\d{4,}", " ", t)
-            toks = re.findall(r"[A-Za-z]{2,}", stripped)
-            if len(toks) >= 2:
-                cands.append((len(" ".join(toks)), t))
-        if cands:
-            name = max(cands)[1]
-        else:
-            name = " ".join(
-                w["text"]
-                for w in words_by_line[pl["line_id"]]
-                if not _line_amounts([w])
-            )
-        items.append(
-            {
-                "name": name.strip(),
-                "price": price,
-                "quantity": None,
-                "line_ids": sorted(
-                    {pl["line_id"]} | {lines[i]["line_id"] for i in blocks[p]}
-                ),
-            }
-        )
+        member_ids = [lines[i]["line_id"] for i in blocks[p]]
+        # qty metadata on a member line ("2@7.97") explains this price
+        if parsed.get("quantity") is None:
+            for i in blocks[p]:
+                mp = parse_band(list(words_by_line[lines[i]["line_id"]]))
+                if (
+                    mp
+                    and mp.get("quantity") is not None
+                    and mp.get("unit_price") is not None
+                    and abs(
+                        mp["quantity"] * mp["unit_price"] - parsed["price"]
+                    )
+                    <= 0.02
+                ):
+                    parsed["quantity"] = mp["quantity"]
+                    parsed["unit_price"] = mp["unit_price"]
+                    break
+        if _sku_dominated(parsed.get("name") or ""):
+            cands = []
+            for i in blocks[p]:
+                t = lines[i]["text"]
+                if _sku_dominated(t):
+                    continue
+                cands.append((len(t), t))
+            if cands:
+                parsed["name"] = max(cands)[1].strip()
+        parsed["line_ids"] = sorted({pl["line_id"], *member_ids})
+        items.append(parsed)
     return items

--- a/receipt_upload/receipt_upload/line_items/geometry.py
+++ b/receipt_upload/receipt_upload/line_items/geometry.py
@@ -299,6 +299,29 @@ def _name_is_real(name: str) -> bool:
 def extract_items(
     words: list[dict], line_ids: set[int]
 ) -> tuple[list[dict], bool]:
+    """Extract items via the band-block decoder (Phase D integration).
+
+    Delegates to receipt_upload.line_items.blocks.decode_band_blocks with
+    the committed golden-trained priors. Gates at swap time: all 12
+    semantic guarantees, golden floors LOO 85/57/86 with zero failures,
+    corpus sweep match 418 vs 415. The banded implementation remains below
+    as _extract_items_banded for the corpus diff harness.
+    """
+    from receipt_upload.line_items.blocks import (
+        decode_band_blocks,
+        load_default_priors,
+    )
+
+    items = decode_band_blocks(
+        {"words": list(words), "items_line_ids": sorted(line_ids)},
+        load_default_priors(),
+    )
+    return items, False
+
+
+def _extract_items_banded(
+    words: list[dict], line_ids: set[int]
+) -> tuple[list[dict], bool]:
     """Extract items from the section's words.
 
     Bands classify as ITEM (real name + price), NAME (name, no price), or

--- a/receipt_upload/receipt_upload/line_items/geometry.py
+++ b/receipt_upload/receipt_upload/line_items/geometry.py
@@ -97,18 +97,12 @@ def band_words(words: list[dict]) -> list[list[dict]]:
         return []
     med_h = sorted(w["h"] for w in words)[len(words) // 2] or 0.01
 
-    # INTERIM GUARD -- this is a tuned heuristic, not a principled rule.
-    # Applying deskew unconditionally cost one line item on a receipt whose
-    # drift was inside the band gap, and this condition was chosen to make
-    # that regression disappear. It is acceptable only because banding
-    # itself is scheduled for replacement by price-anchored assignment
-    # (with a structural stranded-ends check instead of thresholds), at
-    # which point this guard is deleted along with band_words.
+    # Deskew unconditionally. The former activation guard (skip when drift
+    # was below the band gap) was a tuned constant; the low-drift receipt it
+    # protected is now handled structurally by the name-assignment stage in
+    # extract_items, which pairs name rows to priced rows by need and
+    # distance instead of depending on band membership alone.
     slope = estimate_skew(words)
-    xs = [w["x"] for w in words]
-    span = (max(xs) - min(xs)) if xs else 0.0
-    if abs(slope) * span < med_h * 0.6:
-        slope = 0.0
 
     def y_flat(w: dict) -> float:
         return w["y_mid"] - slope * w["x"]
@@ -355,28 +349,19 @@ def extract_items(
         else:
             bands.append(("META", parsed))
 
-    items: list[dict] = []
-    pending_name: Optional[dict] = None
+    # --- META resolution against adjacent ITEMs (qty transplant / echo
+    # dedupe). Unchanged rules; runs before name assignment so a NAME band
+    # never attaches to a META that is about to be absorbed by a neighbor.
+    dropped: set[int] = set()
     for i, (kind, data) in enumerate(bands):
-        if kind == "NAME_USED":
+        if kind != "META":
             continue
-        if kind == "NAME":
-            pending_name = data
-            continue
-        if kind == "ITEM":
-            if data["price"] == 0 and data["quantity"] is None:
-                continue
-            items.append(data)
-            pending_name = None
-            continue
-        # META band
         neighbors = [
             bands[j][1]
             for j in (i - 1, i + 1)
             if 0 <= j < len(bands) and bands[j][0] == "ITEM"
         ]
         qty, unit = data.get("quantity"), data.get("unit_price")
-        attached = False
         for nb in neighbors:
             # qty metadata explains the neighbor's price -> attach
             if (
@@ -392,7 +377,7 @@ def extract_items(
                         "price_word_id": data["price_word_id"],
                     }
                 )
-                attached = True
+                dropped.add(i)
                 break
             # Same price -> a price echo of the neighbor, but ONLY when
             # the META text actually looks like SKU/qty metadata. Two
@@ -410,52 +395,122 @@ def extract_items(
                         "price_word_id": data["price_word_id"],
                     }
                 )
-                attached = True
+                dropped.add(i)
                 break
-        if attached:
+
+    # --- Name assignment. A NAME band may attach ONLY to an adjacent
+    # priced band that NEEDS a name (no real alpha name of its own) --
+    # anchors that already carry a real name never receive attachments,
+    # matching the old pending_name behaviour where an ITEM discarded any
+    # pending name. Rules, in order:
+    #   1. neither adjacent priced band needs a name -> the NAME band is
+    #      dropped (department headers, wrapped notes);
+    #   2. exactly one needs -> attach there;
+    #   3. both need -> a single receipt-wide orientation (all-prev or
+    #      all-next) chosen to minimize priced bands left without a real
+    #      name (the structural stranded-ends criterion), then by total
+    #      attach distance. Per-name float comparisons are NOT used here:
+    #      uniform row pitch makes them coin flips.
+    # This subsumes both stacked directions (name-above and name-below)
+    # without a per-receipt direction vote, which the corpus analysis
+    # showed cannot work (Home Depot needs both in one receipt).
+    priced = [
+        i
+        for i, (k, _) in enumerate(bands)
+        if k in ("ITEM", "META") and i not in dropped
+    ]
+    name_idxs = [i for i, (k, _) in enumerate(bands) if k == "NAME"]
+
+    def _needs_name(idx: int) -> bool:
+        # An anchor needs a name when its own row does not carry a
+        # human-readable one. Beyond "no real alpha at all" (META), a row
+        # whose alpha survives only as a single compressed code after SKU
+        # stripping ("764666103221 15/8CRDWSC5#" -> "CRDWSC") is a SKU
+        # line, not a product name: real names keep >= 2 alpha words.
+        # This is a structural property of the text, not a tuned constant.
+        own = bands[idx][1].get("name") or ""
+        if not _name_is_real(own):
+            return True
+        stripped = re.sub(r"\d{4,}", " ", own)
+        tokens = [
+            t
+            for t in re.findall(r"[A-Za-z]{2,}", stripped)
+            if t.upper() not in UNIT_WORDS
+        ]
+        return len(tokens) < 2
+
+    forced: dict[int, int] = {}
+    ambiguous: list[tuple[int, int, int, float, float]] = []
+    for n in name_idxs:
+        prev_p = max((p for p in priced if p < n), default=None)
+        next_p = min((p for p in priced if p > n), default=None)
+        prev_ok = prev_p is not None and _needs_name(prev_p)
+        next_ok = next_p is not None and _needs_name(next_p)
+        if not prev_ok and not next_ok:
+            continue  # rule 1: nobody needs this name
+        if prev_ok != next_ok:
+            forced[n] = prev_p if prev_ok else next_p
             continue
-        if data["price"] == 0 and pending_name is None:
+        d_prev = abs(bands[n][1]["y_mid"] - bands[prev_p][1]["y_mid"])
+        d_next = abs(bands[next_p][1]["y_mid"] - bands[n][1]["y_mid"])
+        ambiguous.append((n, prev_p, next_p, d_prev, d_next))
+
+    best_assign: dict[int, int] = dict(forced)
+    if ambiguous:
+        best_key = None
+        for orientation in ("prev", "next"):
+            trial = dict(forced)
+            total_d = 0.0
+            for n, prev_p, next_p, d_prev, d_next in ambiguous:
+                if orientation == "prev":
+                    trial[n] = prev_p
+                    total_d += d_prev
+                else:
+                    trial[n] = next_p
+                    total_d += d_next
+            named = set(trial.values())
+            unnamed = sum(
+                1 for p in priced if _needs_name(p) and p not in named
+            )
+            key = (unnamed, total_d, orientation)
+            if best_key is None or key < best_key:
+                best_key = key
+                best_assign = trial
+
+    attached_names: dict[int, list[dict]] = {}
+    for n, p in best_assign.items():
+        attached_names.setdefault(p, []).append(bands[n][1])
+
+    # --- Emit items in band order, merging attached names.
+    items: list[dict] = []
+    for i in priced:
+        kind, data = bands[i]
+        names = attached_names.get(i, [])
+        if names:
+            # Only needing anchors receive names, so the attached
+            # description IS the product name (golden truth uses the
+            # human-readable line, not the SKU line).
+            data["name"] = " ".join(nm["name"] for nm in names).strip()
+            data["line_ids"] = sorted(
+                set(data["line_ids"])
+                | {lid for nm in names for lid in nm["line_ids"]}
+            )
+            data["name_band"] = names[0]["band"]
+            data["name_word_ids"] = [
+                ref for nm in names for ref in nm["name_word_ids"]
+            ]
+            data["stacked"] = True
+        if kind == "ITEM":
+            if data["price"] == 0 and data["quantity"] is None:
+                continue
+            items.append(data)
+            continue
+        # surviving META
+        if data["price"] == 0 and not names:
             # unnamed zero band is noise; a named $0.00 item (free/comped
             # line with its price in the price column) is kept via pairing
             continue
-        if (
-            pending_name is None
-            and i + 1 < len(bands)
-            and bands[i + 1][0] == "NAME"
-        ):
-            # A name band may sit just below the price band — but only
-            # claim it when it is geometrically closer to THIS price than
-            # to the next priced band below it (otherwise it is that
-            # band's name, and stealing it mispairs name and price).
-            cand = bands[i + 1][1]
-            next_priced = next(
-                (
-                    bands[j][1]
-                    for j in range(i + 2, len(bands))
-                    if bands[j][0] in ("ITEM", "META")
-                ),
-                None,
-            )
-            gap_up = abs(cand["y_mid"] - data["y_mid"])
-            gap_down = (
-                abs(next_priced["y_mid"] - cand["y_mid"])
-                if next_priced is not None
-                else float("inf")
-            )
-            if gap_up <= gap_down:
-                pending_name = cand
-                bands[i + 1] = ("NAME_USED", cand)
-        if pending_name is not None:
-            # stacked layout: name band paired with price-only band
-            data["name"] = pending_name["name"]
-            data["line_ids"] = sorted(
-                set(data["line_ids"]) | set(pending_name["line_ids"])
-            )
-            data["name_band"] = pending_name["band"]
-            data["name_word_ids"] = pending_name["name_word_ids"]
-            data["stacked"] = True
-            pending_name = None
-        else:
+        if not names:
             # No name anywhere (SKU-only or garbled OCR). Keep the price —
             # dropping it hides real spend — but flag the name quality.
             data["name_quality"] = "low"

--- a/receipt_upload/tests/test_line_item_golden_regression.py
+++ b/receipt_upload/tests/test_line_item_golden_regression.py
@@ -70,18 +70,22 @@ def _score_receipt(
     return matched, name_ok, len(truth)
 
 
-# (recall_floor, name_floor) per merchant, from the measured post-deskew
-# baseline (2026-07-30), rounded DOWN slightly for run-to-run stability.
+# (recall_floor, name_floor, precision_floor) per merchant, from the
+# measured post-deskew baseline (2026-07-30), rounded DOWN slightly for
+# run-to-run stability. Precision floors added after the corpus sweep
+# vetoed a decoder that PASSED recall/name floors while over-generating
+# (+70 items corpus-wide): over-generation is invisible to recall and
+# names, so it must be gated explicitly.
 _FLOORS = {
-    "Sprouts Farmers Market": (1.00, 0.85),
-    "Roast & Rice Asian Fusion": (1.00, 1.00),
-    "TRADER JOE'S": (1.00, 1.00),
-    "Trader Joe's": (1.00, 1.00),
-    "In-N-Out Burger": (1.00, 1.00),
-    "Wild Fork": (1.00, 0.60),
-    "The Home Depot": (0.80, 0.25),
-    "Costco Wholesale": (0.40, 0.00),
-    "Target": (0.65, 0.10),
+    "Sprouts Farmers Market": (1.00, 0.85, 0.95),
+    "Roast & Rice Asian Fusion": (1.00, 1.00, 0.95),
+    "TRADER JOE'S": (1.00, 1.00, 0.95),
+    "Trader Joe's": (1.00, 1.00, 0.95),
+    "In-N-Out Burger": (1.00, 1.00, 0.75),
+    "Wild Fork": (1.00, 0.60, 0.95),
+    "The Home Depot": (0.80, 0.25, 0.50),
+    "Costco Wholesale": (0.40, 0.00, 0.85),
+    "Target": (0.65, 0.10, 0.90),
 }
 
 
@@ -106,22 +110,25 @@ def test_golden_set_per_merchant_floors() -> None:
         items, _ = extract_items(o["words"], set(o["items_line_ids"]))
         truth = [t for t in g["true_items"] if not t.get("is_discount")]
         m, n, tc = _score_receipt(truth, items)
-        agg = per.setdefault(g["merchant"], [0, 0, 0])
+        agg = per.setdefault(g["merchant"], [0, 0, 0, 0])
         agg[0] += m
         agg[1] += n
         agg[2] += tc
+        agg[3] += len(items)
 
     failures = []
-    for merchant, (m, n, tc) in sorted(per.items()):
+    for merchant, (m, n, tc, np_) in sorted(per.items()):
         recall = m / tc if tc else 0.0
         names = n / m if m else 0.0
+        precision = m / np_ if np_ else 0.0
         floor = _FLOORS.get(merchant)
         if floor is None:
             continue
-        rf, nf = floor
-        if recall < rf or names < nf:
+        rf, nf, pf = floor
+        if recall < rf or names < nf or precision < pf:
             failures.append(
                 f"{merchant}: recall {recall:.0%} (floor {rf:.0%}), "
-                f"names {names:.0%} (floor {nf:.0%})"
+                f"names {names:.0%} (floor {nf:.0%}), "
+                f"precision {precision:.0%} (floor {pf:.0%})"
             )
     assert not failures, "golden regression:\n  " + "\n  ".join(failures)

--- a/scripts/benchmark_textract_line_items.py
+++ b/scripts/benchmark_textract_line_items.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Benchmark AWS Textract AnalyzeExpense against the golden line-item set.
+
+Runs each golden receipt's warped crop through AnalyzeExpense, maps its
+LineItemGroups onto our item schema, and scores BOTH Textract and our block
+decoder with the same matcher on the same hand-labeled truth -- vendor
+comparison on our yardstick, not theirs. Responses are cached to avoid
+re-billing (~$0.10/page).
+
+First run (2026-07-30): OURS 85%/57%/86% vs TEXTRACT 90%/47%/99%
+(recall/names/precision). Complementary, not dominant: Textract's recall
+edge is mostly OCR quality (it reads the Costco/Target price digits our
+Vision pass shattered), while our names beat it overall and Home Depot
+names are 42% vs their 0% (they emit SKU rows as names). Both Trader Joe's
+receipts -- the skewed ones -- drop Textract to 33/43% recall while our
+deskewed decoder holds 100%.
+"""
+
+import json
+import os
+import sys
+import time
+from collections import defaultdict
+from pathlib import Path
+
+import boto3
+
+REPO = Path(__file__).resolve().parent.parent
+FIXTURES = REPO / "receipt_upload" / "tests" / "fixtures"
+CROPS = Path(os.environ.get("GOLDEN_CROPS_DIR", "."))
+CACHE = Path(os.environ.get("TEXTRACT_CACHE", "textract_bench.json"))
+
+
+def fetch(gold: dict) -> dict:
+    cache = json.load(open(CACHE)) if CACHE.exists() else {}
+    tx = boto3.client("textract", region_name="us-east-1")
+    for key in gold:
+        ck = f"{key[0][:8]}_{key[1]}"
+        if ck in cache:
+            continue
+        img = open(CROPS / f"{ck}.jpg", "rb").read()
+        r = tx.analyze_expense(Document={"Bytes": img})
+        items = []
+        for d in r.get("ExpenseDocuments", []):
+            for g in d.get("LineItemGroups", []):
+                for li in g.get("LineItems", []):
+                    f = {
+                        x["Type"]["Text"]: x.get("ValueDetection", {}).get(
+                            "Text"
+                        )
+                        for x in li.get("LineItemExpenseFields", [])
+                    }
+                    if f.get("PRICE") is None and f.get("ITEM") is None:
+                        continue
+                    items.append(
+                        {
+                            "name": (f.get("ITEM") or "")
+                            .replace("\n", " ")
+                            .strip(),
+                            "price": f.get("PRICE"),
+                            "quantity": f.get("QUANTITY"),
+                        }
+                    )
+        cache[ck] = items
+        time.sleep(0.3)
+    json.dump(cache, open(CACHE, "w"), indent=1)
+    return cache
+
+
+def main() -> None:
+    sys.path.insert(0, str(REPO / "receipt_upload" / "tests"))
+    import test_line_item_golden_regression as T
+
+    from receipt_upload.line_items.blocks import (
+        build_role_priors,
+        decode_band_blocks,
+        derive_band_labels,
+    )
+
+    gold = {
+        (r["image_id"], r["receipt_id"]): r
+        for r in json.load(open(FIXTURES / "line_items_golden.json"))[
+            "receipts"
+        ]
+    }
+    ocr = {
+        (r["image_id"], r["receipt_id"]): r
+        for r in json.load(open(FIXTURES / "line_items_golden_ocr.json"))[
+            "receipts"
+        ]
+    }
+    tex = fetch(gold)
+    all_labels = {k: derive_band_labels(gold[k], ocr[k]) for k in gold}
+    res = defaultdict(lambda: defaultdict(lambda: [0, 0, 0, 0]))
+    for key, g in gold.items():
+        truth = [t for t in g["true_items"] if not t.get("is_discount")]
+        ours = decode_band_blocks(
+            ocr[key],
+            build_role_priors([v for k, v in all_labels.items() if k != key]),
+        )
+        preds = {
+            "OURS": [
+                {"name": p.get("name"), "price": p.get("price")} for p in ours
+            ],
+            "TEXTRACT": tex[f"{key[0][:8]}_{key[1]}"],
+        }
+        for tag, pred in preds.items():
+            m, n, tc = T._score_receipt(truth, pred)
+            a = res[tag][g["merchant"]]
+            a[0] += m
+            a[1] += n
+            a[2] += tc
+            a[3] += len(pred)
+    for tag in ("OURS", "TEXTRACT"):
+        per = res[tag]
+        tm = tn = tt = tp = 0
+        print(f"\n=== {tag} ===")
+        for merch, (m, n, tc, np_) in sorted(
+            per.items(), key=lambda x: -x[1][2]
+        ):
+            tm += m
+            tn += n
+            tt += tc
+            tp += np_
+            print(
+                f"{merch[:29]:<30}"
+                f"{(m / tc if tc else 0):>8.0%}"
+                f"{(n / m if m else 0):>7.0%}"
+                f"{(m / np_ if np_ else 0):>7.0%}"
+            )
+        print(f"{'TOTAL':<30}{tm / tt:>8.0%}{tn / tm:>7.0%}{tm / tp:>7.0%}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What this is

The line-item extractor's grouping/pairing layer, rebuilt as a **block decoder**: deskewed visual bands → learned template-role priors (committed JSON asset, `section_order_priors` pattern) → need-gated name assignment with a receipt-wide orientation rule → META absorption → `parse_band` emission. `extract_items` now delegates to it; the banded implementation remains as `_extract_items_banded` for the diff harness.

Also in this PR: the AnalyzeExpense benchmark script, the reconciliation-triggered re-OCR decision function, and the fragment-repair utility (repair-pass only — unconditional application failed a precision floor and was reverted).

## Evidence (all measured, all reproducible from committed fixtures)

| Gate | Result |
|---|---|
| 12 semantic guarantees | 12/12 (three previously-failing guarantees fixed: single-word donor names, `name_quality=low` on unnamed survivors, pinned emission order) |
| Golden triple floors (recall/name/precision, per-merchant) | zero failures |
| Leave-one-receipt-out (honest accuracy) | **85% / 57% / 86%** vs banded baseline 83/47/— |
| Corpus sweep, all 686 ITEMS receipts | match **418 vs 415**, mismatch 172 vs 176, empties 59 vs 55 |
| AWS Textract AnalyzeExpense, same crops, same scorer | vendor 90/47/99 — **our names ahead (57 vs 47)**; HD names 42% vs vendor 0%; skewed TJ receipts: ours 100% recall, vendor 33/43% |

## Honest caveats, in the code and commit history

- The CI floor gate scores golden receipts with priors trained on them — it is a **regression pin**, not an unbiased estimate; LOO is the honest number. Fixed by the queued self-labeling step (priors from reconciling corpus receipts).
- Vendor recall edge is OCR quality (digit misreads), not extraction: addressed by the shipped `should_reocr_items_zone()` trigger (fires on 4/25 golden — exactly the misread receipts) pending `REGIONAL_REOCR` wiring.
- Twin Peaks `@0.00` class is unreadable at any resolution (verified); the decoder compensates structurally.

## Design lineage

Three designs were built and killed by the gates before this one (line-level decode, unconditional deskew guard, unconditional fragment merge) — each veto measured, each recorded in the commit trail. Architecture matches the published convergence (SPADE's grouping-over-tagging, DeepCPCFG's grammar+learned-scores) while staying deterministic and on-device; priors ship as JSON so the Swift port loads the same asset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added improved receipt item-block decoding for more reliable identification of item names, prices, quantities, and unit prices.
  - Added support for recognizing varied receipt layouts and associating item names with nearby prices.
  - Improved handling of split OCR price values and repeated price text.

- **Bug Fixes**
  - Improved receipt item extraction through better layout analysis, metadata handling, and subtotal consistency checks.
  - Preserved item identifiers and relevant item details more reliably across receipt formats.

- **Tests**
  - Expanded regression checks to monitor item recall, name accuracy, and precision across merchants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->