### PR TITLE
feat(line-items): stream-triggered ingest stage — line items at ingestion

### DIFF
--- a/infra/chromadb_compaction/components/lambda_functions.py
+++ b/infra/chromadb_compaction/components/lambda_functions.py
@@ -347,6 +347,7 @@ class HybridLambdaDeployment(ComponentResource):
                     "LINES_QUEUE_URL": chromadb_queues.lines_queue_url,
                     "WORDS_QUEUE_URL": chromadb_queues.words_queue_url,
                     "RECEIPT_SUMMARY_QUEUE_URL": chromadb_queues.summary_queue_url,
+                    "LINE_ITEM_QUEUE_URL": chromadb_queues.line_item_queue_url,
                     "LOG_LEVEL": "INFO",
                     # Stream processing configuration (aligned with code and infrastructure)
                     "MAX_RECORDS_PER_INVOCATION": "10",  # Matches DynamoDB Stream batch_size
@@ -470,10 +471,134 @@ class HybridLambdaDeployment(ComponentResource):
             opts=ResourceOptions(parent=self),
         )
 
+        # ------------------------------------------------------------------
+        # Line-item updater: rewrites RECEIPT_LINE_ITEM rows when a
+        # receipt's summary changes. Bundles the CANONICAL extraction
+        # modules from receipt_upload as FileAssets -- no copies live in
+        # the repo, so the logic cannot fork (the build_receipt_rows
+        # shadowing lesson).
+        # ------------------------------------------------------------------
+        _repo_root = Path(__file__).parent.parent.parent.parent
+        line_item_updater_code = pulumi.AssetArchive(
+            {
+                "handler.py": pulumi.FileAsset(
+                    _repo_root
+                    / "infra"
+                    / "receipt_line_item_updater"
+                    / "handler.py"
+                ),
+                "line_item_processor.py": pulumi.FileAsset(
+                    _repo_root
+                    / "infra"
+                    / "receipt_line_item_updater"
+                    / "line_item_processor.py"
+                ),
+                "receipt_upload/__init__.py": pulumi.StringAsset(
+                    "# deploy-time stub: only line_items is bundled; the real\n"
+                    "# receipt_upload __init__ pulls PIL and the full package.\n"
+                ),
+                "receipt_upload/line_items/__init__.py": pulumi.StringAsset(
+                    ""
+                ),
+                "receipt_upload/line_items/geometry.py": pulumi.FileAsset(
+                    _repo_root
+                    / "receipt_upload"
+                    / "receipt_upload"
+                    / "line_items"
+                    / "geometry.py"
+                ),
+                "receipt_upload/line_items/blocks.py": pulumi.FileAsset(
+                    _repo_root
+                    / "receipt_upload"
+                    / "receipt_upload"
+                    / "line_items"
+                    / "blocks.py"
+                ),
+                "receipt_upload/line_items/assets/block_role_priors_v1.json": pulumi.FileAsset(
+                    _repo_root
+                    / "receipt_upload"
+                    / "receipt_upload"
+                    / "line_items"
+                    / "assets"
+                    / "block_role_priors_v1.json"
+                ),
+                "receipt_upload/line_items/assets/block_role_priors_v2.json": pulumi.FileAsset(
+                    _repo_root
+                    / "receipt_upload"
+                    / "receipt_upload"
+                    / "line_items"
+                    / "assets"
+                    / "block_role_priors_v2.json"
+                ),
+            }
+        )
+
+        self.line_item_updater_log_group = aws.cloudwatch.LogGroup(
+            f"{name}-line-item-updater-log-group",
+            retention_in_days=14,
+            tags={
+                "Project": "ChromaDB",
+                "Component": "LineItemUpdater",
+                "Environment": stack,
+                "ManagedBy": "Pulumi",
+            },
+            opts=ResourceOptions(parent=self),
+        )
+
+        self.line_item_updater_function = aws.lambda_.Function(
+            f"{name}-line-item-updater",
+            runtime="python3.12",
+            architectures=["arm64"],
+            code=line_item_updater_code,
+            handler="handler.lambda_handler",
+            role=self.lambda_role.arn,
+            timeout=120,  # extraction fetches words+sections; queue vis is 2x
+            memory_size=512,
+            environment={
+                "variables": {
+                    "DYNAMODB_TABLE_NAME": Output.all(
+                        dynamodb_table_arn
+                    ).apply(lambda args: args[0].split("/")[-1]),
+                    "LOG_LEVEL": "INFO",
+                }
+            },
+            description=(
+                "Rewrites RECEIPT_LINE_ITEM rows via the band-block decoder "
+                "when a receipt's summary changes"
+            ),
+            tags={
+                "Project": "ChromaDB",
+                "Component": "LineItemUpdater",
+                "Environment": stack,
+                "ManagedBy": "Pulumi",
+                "environment": stack,
+            },
+            layers=[dynamo_layer.arn],
+            opts=ResourceOptions(
+                parent=self,
+                depends_on=[
+                    self.lambda_role,
+                    self.line_item_updater_log_group,
+                ],
+                ignore_changes=["layers"],
+            ),
+        )
+
+        self.line_item_event_source_mapping = aws.lambda_.EventSourceMapping(
+            f"{name}-line-item-event-source-mapping",
+            event_source_arn=chromadb_queues.line_item_queue_arn,
+            function_name=self.line_item_updater_function.arn,
+            batch_size=50,
+            maximum_batching_window_in_seconds=5,
+            function_response_types=["ReportBatchItemFailures"],
+            opts=ResourceOptions(parent=self),
+        )
+
         # Export useful properties
         self.stream_processor_arn = self.stream_processor_function.arn
         self.enhanced_compaction_arn = self.enhanced_compaction_function.arn
         self.summary_updater_arn = self.summary_updater_function.arn
+        self.line_item_updater_arn = self.line_item_updater_function.arn
         self.role_arn = self.lambda_role.arn
 
         # Register outputs
@@ -581,6 +706,8 @@ class HybridLambdaDeployment(ComponentResource):
                 chromadb_queues.words_dlq_arn,
                 chromadb_queues.summary_queue_arn,
                 chromadb_queues.summary_dlq_arn,
+                chromadb_queues.line_item_queue_arn,
+                chromadb_queues.line_item_dlq_arn,
             ).apply(
                 lambda args: json.dumps(
                     {
@@ -602,6 +729,8 @@ class HybridLambdaDeployment(ComponentResource):
                                     args[3],  # Words DLQ ARN
                                     args[4],  # Summary queue ARN
                                     args[5],  # Summary DLQ ARN
+                                    args[6],  # Line-item queue ARN
+                                    args[7],  # Line-item DLQ ARN
                                 ],
                             }
                         ],

--- a/infra/chromadb_compaction/components/sqs_queues.py
+++ b/infra/chromadb_compaction/components/sqs_queues.py
@@ -239,6 +239,43 @@ class ChromaDBQueues(ComponentResource):
             opts=ResourceOptions(parent=self),
         )
 
+        # Line-item recompute DLQ + queue (mirrors the summary pair; the
+        # consumer rewrites RECEIPT_LINE_ITEM rows when a receipt's summary
+        # changes).
+        self.line_item_dlq = aws.sqs.Queue(
+            f"{name}-line-item-dlq",
+            message_retention_seconds=1209600,  # 14 days
+            visibility_timeout_seconds=300,
+            receive_wait_time_seconds=0,
+            tags={
+                "Project": "ChromaDB",
+                "Component": "LineItem-DLQ",
+                "Environment": stack,
+                "ManagedBy": "Pulumi",
+            },
+            opts=ResourceOptions(parent=self),
+        )
+
+        self.line_item_queue = aws.sqs.Queue(
+            f"{name}-line-item-queue",
+            message_retention_seconds=345600,  # 4 days
+            visibility_timeout_seconds=240,  # 2x line-item Lambda timeout
+            receive_wait_time_seconds=20,
+            delay_seconds=15,  # batch bursts of summary rewrites
+            redrive_policy=Output.all(self.line_item_dlq.arn).apply(
+                lambda args: json.dumps(
+                    {"deadLetterTargetArn": args[0], "maxReceiveCount": 3}
+                )
+            ),
+            tags={
+                "Project": "ChromaDB",
+                "Component": "LineItem-Queue",
+                "Environment": stack,
+                "ManagedBy": "Pulumi",
+            },
+            opts=ResourceOptions(parent=self),
+        )
+
         # Create queue policies with least-privilege access
         self.lines_queue_policy = aws.sqs.QueuePolicy(
             f"{name}-lines-queue-policy",
@@ -277,6 +314,9 @@ class ChromaDBQueues(ComponentResource):
         self.lines_dlq_arn = self.lines_dlq.arn
         self.words_dlq_arn = self.words_dlq.arn
         self.summary_dlq_arn = self.summary_dlq.arn
+        self.line_item_queue_url = self.line_item_queue.url
+        self.line_item_queue_arn = self.line_item_queue.arn
+        self.line_item_dlq_arn = self.line_item_dlq.arn
 
         # Register outputs
         self.register_outputs(
@@ -290,6 +330,9 @@ class ChromaDBQueues(ComponentResource):
                 "lines_dlq_arn": self.lines_dlq_arn,
                 "words_dlq_arn": self.words_dlq_arn,
                 "summary_dlq_arn": self.summary_dlq_arn,
+                "line_item_queue_url": self.line_item_queue_url,
+                "line_item_queue_arn": self.line_item_queue_arn,
+                "line_item_dlq_arn": self.line_item_dlq_arn,
             }
         )
 

--- a/infra/receipt_line_item_updater/handler.py
+++ b/infra/receipt_line_item_updater/handler.py
@@ -1,0 +1,73 @@
+"""Lambda handler for receipt line-item recompute messages.
+
+Triggered by SQS when a RECEIPT_SUMMARY record changes (insert or modify)
+-- the point at which words, sections, summary and merchant all exist for
+a receipt -- and rewrites its RECEIPT_LINE_ITEM rows via the canonical
+band-block decoder. Mirrors receipt_summary_updater's handler contract:
+per-receipt dedupe and partial-batch failure reporting.
+"""
+
+import logging
+import os
+from typing import Any
+
+# pylint: disable-next=wrong-import-order  # Local Lambda module
+from line_item_processor import deduplicate_messages, update_receipt_line_items
+from receipt_dynamo.data.shared_exceptions import (
+    DynamoDBError,
+    EntityError,
+    OperationError,
+)
+
+log_level = os.environ.get("LOG_LEVEL", "INFO").upper()
+logging.basicConfig(level=getattr(logging, log_level, logging.INFO))
+logger = logging.getLogger(__name__)
+
+
+def lambda_handler(event: dict[str, Any], _context: Any) -> dict[str, Any]:
+    """Process line-item recompute messages from SQS."""
+    records = event.get("Records", [])
+    if not records:
+        logger.info("No records to process")
+        return {"batchItemFailures": []}
+
+    unique_receipts, malformed_message_ids = deduplicate_messages(records)
+    logger.info(
+        "Processing %d unique receipts from %d messages (%d malformed)",
+        len(unique_receipts),
+        len(records),
+        len(malformed_message_ids),
+    )
+
+    failed_message_ids: list[str] = list(malformed_message_ids)
+    success_count = 0
+    for (image_id, receipt_id), message_ids in unique_receipts.items():
+        try:
+            result = update_receipt_line_items(image_id, receipt_id)
+            success_count += 1
+            logger.info(
+                "line items updated for %s:%d: %s",
+                image_id[:8],
+                receipt_id,
+                result,
+            )
+        except (EntityError, OperationError, DynamoDBError) as e:
+            logger.error(
+                "failed line items for %s:%d: %s",
+                image_id[:8],
+                receipt_id,
+                e,
+                exc_info=True,
+            )
+            failed_message_ids.extend(message_ids)
+
+    logger.info(
+        "Completed: %d succeeded, %d failed",
+        success_count,
+        len(unique_receipts) - success_count,
+    )
+    return {
+        "batchItemFailures": [
+            {"itemIdentifier": msg_id} for msg_id in failed_message_ids
+        ]
+    }

--- a/infra/receipt_line_item_updater/line_item_processor.py
+++ b/infra/receipt_line_item_updater/line_item_processor.py
@@ -1,0 +1,180 @@
+"""Business logic for recomputing RECEIPT_LINE_ITEM rows for one receipt.
+
+Triggered when a receipt's summary changes -- the moment at which words,
+sections, summary and merchant all exist -- so extraction always sees a
+complete receipt. This also regenerates line items after resegmentation for
+free: resegmentation rewrites the summary, which re-fires this stage.
+
+Extraction is the canonical band-block decoder from
+``receipt_upload.line_items``; those modules (and the priors asset) are
+bundled into this Lambda's archive at deploy time as FileAssets referencing
+the canonical sources -- no copies live in the repo, so the logic cannot
+fork the way the shadowed ``build_receipt_rows`` once did.
+
+Unlike the backfill script (which gates on VALID ITEMS sections), this
+stage extracts on PENDING sections too and records
+``source_section_status`` -- consumers filter on VALID when they want
+precision; gating production on VALID is what once limited coverage to
+hand-repaired receipts.
+"""
+
+import json
+import logging
+import os
+from collections import defaultdict
+from datetime import datetime, timezone
+from typing import Any
+
+from receipt_dynamo.data.dynamo_client import DynamoClient
+from receipt_dynamo.entities.receipt_line_item import ReceiptLineItem
+from receipt_upload.line_items.geometry import extract_items, reconcile
+
+logger = logging.getLogger(__name__)
+
+TABLE_NAME = os.environ.get("DYNAMODB_TABLE_NAME", "")
+dynamo_client = DynamoClient(TABLE_NAME) if TABLE_NAME else None
+
+EXTRACTOR_VERSION = "line-items-blocks-v2"
+
+
+def update_receipt_line_items(
+    image_id: str, receipt_id: int
+) -> dict[str, Any]:
+    """Recompute and rewrite RECEIPT_LINE_ITEM rows for one receipt."""
+    if dynamo_client is None:
+        raise ValueError("DYNAMODB_TABLE_NAME environment variable not set")
+
+    words = dynamo_client.list_receipt_words_from_receipt(image_id, receipt_id)
+    sections = dynamo_client.get_receipt_sections_from_receipt(
+        image_id, receipt_id
+    )
+
+    # ITEMS zone: any non-INVALID ITEMS section; prefer VALID over PENDING
+    # when both exist so provenance reflects the strongest source.
+    items_section = None
+    for s in sections:
+        if "ITEM" not in str(getattr(s, "section_type", "") or "").upper():
+            continue
+        status = str(getattr(s, "validation_status", "") or "").upper()
+        if status == "INVALID":
+            continue
+        if items_section is None or status == "VALID":
+            items_section = s
+        if status == "VALID":
+            break
+    if items_section is None or not words:
+        # Nothing to extract; clear stale rows so a receipt whose ITEMS
+        # section was invalidated does not keep phantom items.
+        deleted = dynamo_client.delete_receipt_line_items_for_receipt(
+            image_id, receipt_id
+        )
+        return {"items": 0, "deleted": deleted, "reason": "no-items-zone"}
+
+    line_ids = {int(x) for x in (items_section.line_ids or [])}
+    word_dicts = [
+        {
+            "line_id": w.line_id,
+            "word_id": w.word_id,
+            "text": w.text,
+            "x": w.bounding_box.get("x", 0.0),
+            "y_mid": w.bounding_box.get("y", 0.0)
+            + w.bounding_box.get("height", 0.0) / 2,
+            "h": w.bounding_box.get("height", 0.0),
+        }
+        for w in words
+        if w.line_id in line_ids
+    ]
+
+    items, collapsed = extract_items(word_dicts, line_ids)
+
+    summary_dict = None
+    merchant = None
+    try:
+        record = dynamo_client.get_receipt_summary(image_id, receipt_id)
+        inner = getattr(record, "summary", None)
+        if inner is not None:
+            summary_dict = {
+                "subtotal": getattr(inner, "subtotal", None),
+                "grand_total": getattr(inner, "grand_total", None),
+                "tax": getattr(inner, "tax", None),
+            }
+            merchant = getattr(inner, "merchant_name", None)
+    except Exception:  # noqa: BLE001 - summary may not exist yet
+        logger.info(
+            "no summary for %s:%d; reconciliation is no-baseline",
+            image_id[:8],
+            receipt_id,
+        )
+
+    status, _, _ = reconcile(
+        [x for x in items if not x.get("is_discount")], summary_dict
+    )
+
+    now = datetime.now(timezone.utc)
+    entities = []
+    for idx, it in enumerate(items):
+        name = it.get("name") or ""
+        quality = (
+            "low" if it.get("name_quality") == "low" or not name else "ok"
+        )
+        entities.append(
+            ReceiptLineItem(
+                receipt_id=receipt_id,
+                image_id=image_id,
+                item_index=idx,
+                name=name,
+                price=f"{it['price']:.2f}",
+                line_ids=[int(x) for x in it["line_ids"]],
+                extractor_version=EXTRACTOR_VERSION,
+                extracted_at=now,
+                quantity=it.get("quantity"),
+                unit_price=it.get("unit_price"),
+                is_discount=bool(it.get("is_discount")),
+                raw_text=it.get("raw_text") or "",
+                name_quality=quality,
+                merchant_name=merchant,
+                source_section_status=getattr(
+                    items_section, "validation_status", None
+                ),
+                source_model_source=getattr(
+                    items_section, "model_source", None
+                ),
+                reconciliation_status=status,
+                collapsed_banding=bool(collapsed),
+            )
+        )
+
+    deleted = dynamo_client.delete_receipt_line_items_for_receipt(
+        image_id, receipt_id
+    )
+    if entities:
+        dynamo_client.add_receipt_line_items(entities)
+    return {
+        "items": len(entities),
+        "deleted": deleted,
+        "reconciliation": status,
+    }
+
+
+def deduplicate_messages(
+    records: list[dict[str, Any]],
+) -> tuple[dict[tuple[str, int], list[str]], list[str]]:
+    """Deduplicate SQS records by (image_id, receipt_id).
+
+    Returns (unique_receipts -> message_ids, malformed_message_ids).
+    """
+    unique: dict[tuple[str, int], list[str]] = defaultdict(list)
+    malformed: list[str] = []
+    for record in records:
+        msg_id = record.get("messageId", "")
+        try:
+            body = json.loads(record.get("body", "{}"))
+            data = body.get("entity_data") or body
+            image_id = data["image_id"]
+            receipt_id = int(data["receipt_id"])
+        except (KeyError, TypeError, ValueError, json.JSONDecodeError):
+            logger.warning("malformed message %s", msg_id)
+            malformed.append(msg_id)
+            continue
+        unique[(image_id, receipt_id)].append(msg_id)
+    return dict(unique), malformed

--- a/receipt_dynamo_stream/receipt_dynamo_stream/change_detection/detector.py
+++ b/receipt_dynamo_stream/receipt_dynamo_stream/change_detection/detector.py
@@ -21,6 +21,10 @@ CHROMADB_RELEVANT_FIELDS = {
         "label_proposed_by",
         "label_consolidated_from",
     ],
+    "RECEIPT_SUMMARY": [
+        "summary",
+        "timestamp_computed",
+    ],
     "RECEIPT_SECTION": [
         "section_type",
         "line_ids",

--- a/receipt_dynamo_stream/receipt_dynamo_stream/message_builder.py
+++ b/receipt_dynamo_stream/receipt_dynamo_stream/message_builder.py
@@ -18,6 +18,9 @@ from receipt_dynamo.entities.receipt import Receipt
 from receipt_dynamo.entities.receipt_line import ReceiptLine
 from receipt_dynamo.entities.receipt_place import ReceiptPlace
 from receipt_dynamo.entities.receipt_section import ReceiptSection
+from receipt_dynamo.entities.receipt_summary_record import (
+    ReceiptSummaryRecord,
+)
 from receipt_dynamo.entities.receipt_word import ReceiptWord
 from receipt_dynamo.entities.receipt_word_label import ReceiptWordLabel
 from receipt_dynamo_stream.change_detection import (
@@ -45,7 +48,7 @@ logger = logging.getLogger(__name__)
 # ReceiptSection INSERTs matter because creating a section changes the
 # correct ``section_label`` for the receipt's rows in ChromaDB; other
 # entity INSERTs are covered by the embedding pipeline itself.
-_INSERT_SYNCED_ENTITY_TYPES = frozenset({"RECEIPT_SECTION"})
+_INSERT_SYNCED_ENTITY_TYPES = frozenset({"RECEIPT_SECTION", "RECEIPT_SUMMARY"})
 
 
 def build_messages_from_records(
@@ -266,6 +269,24 @@ def _extract_receipt_word_label(
     ]
 
 
+def _extract_receipt_summary(
+    entity: ReceiptSummaryRecord,
+) -> tuple[dict[str, object], list[ChromaDBCollection | TargetQueue]]:
+    """Route summary changes to the LINE_ITEMS queue.
+
+    The summary is written when a receipt's words, sections, labels and
+    merchant all exist, so it is the correct trigger for line-item
+    recomputation -- and resegmentation rewrites it, which regenerates
+    line items automatically. The consumer refetches current state from
+    DynamoDB; the event image is not trusted.
+    """
+    return {
+        "entity_type": "RECEIPT_SUMMARY",
+        "image_id": entity.image_id,
+        "receipt_id": entity.receipt_id,
+    }, [TargetQueue.LINE_ITEMS]
+
+
 def _extract_receipt_section(
     entity: ReceiptSection,
 ) -> tuple[dict[str, object], list[ChromaDBCollection]]:
@@ -337,6 +358,7 @@ _ENTITY_EXTRACTORS: dict[str, tuple[type, _ExtractorFunc]] = {
     "RECEIPT_PLACE": (ReceiptPlace, _extract_receipt_place),
     "RECEIPT_WORD_LABEL": (ReceiptWordLabel, _extract_receipt_word_label),
     "RECEIPT_SECTION": (ReceiptSection, _extract_receipt_section),
+    "RECEIPT_SUMMARY": (ReceiptSummaryRecord, _extract_receipt_summary),
     "RECEIPT": (Receipt, _extract_receipt),
     "RECEIPT_WORD": (ReceiptWord, _extract_receipt_word),
     "RECEIPT_LINE": (ReceiptLine, _extract_receipt_line),

--- a/receipt_dynamo_stream/receipt_dynamo_stream/models.py
+++ b/receipt_dynamo_stream/receipt_dynamo_stream/models.py
@@ -40,6 +40,7 @@ class TargetQueue(str, Enum):
     LINES = "lines"
     WORDS = "words"
     RECEIPT_SUMMARY = "receipt_summary"
+    LINE_ITEMS = "line_items"
 
 
 @dataclass(frozen=True)

--- a/receipt_dynamo_stream/receipt_dynamo_stream/parsing/parsers.py
+++ b/receipt_dynamo_stream/receipt_dynamo_stream/parsing/parsers.py
@@ -15,6 +15,9 @@ from receipt_dynamo.entities.receipt import item_to_receipt
 from receipt_dynamo.entities.receipt_line import item_to_receipt_line
 from receipt_dynamo.entities.receipt_place import item_to_receipt_place
 from receipt_dynamo.entities.receipt_section import item_to_receipt_section
+from receipt_dynamo.entities.receipt_summary_record import (
+    item_to_receipt_summary_record,
+)
 from receipt_dynamo.entities.receipt_word import item_to_receipt_word
 from receipt_dynamo.entities.receipt_word_label import (
     item_to_receipt_word_label,
@@ -32,6 +35,8 @@ logger = logging.getLogger(__name__)
 # SK pattern matchers in order of specificity (most specific first)
 _SK_PATTERN_MATCHERS: list[tuple[Callable[[str], bool], str]] = [
     (lambda sk: "#PLACE" in sk, "RECEIPT_PLACE"),
+    # RECEIPT#00001#SUMMARY; the "#SUMMARY" suffix appears in no other SK
+    (lambda sk: sk.endswith("#SUMMARY"), "RECEIPT_SUMMARY"),
     (lambda sk: "#LABEL#" in sk, "RECEIPT_WORD_LABEL"),
     # RECEIPT#00001#SECTION#{TYPE}; "#SECTION#" appears in no other
     # entity SK (receipt_section.py is the only entity emitting it)
@@ -47,6 +52,7 @@ _ENTITY_PARSERS: dict[
     str, Callable[[dict[str, dict[str, object]]], StreamEntity]
 ] = {
     "RECEIPT_PLACE": item_to_receipt_place,
+    "RECEIPT_SUMMARY": item_to_receipt_summary_record,
     "RECEIPT_WORD_LABEL": item_to_receipt_word_label,
     "RECEIPT_SECTION": item_to_receipt_section,
     "RECEIPT": item_to_receipt,

--- a/receipt_dynamo_stream/receipt_dynamo_stream/sqs_publisher.py
+++ b/receipt_dynamo_stream/receipt_dynamo_stream/sqs_publisher.py
@@ -43,6 +43,7 @@ def publish_messages(
     lines_messages: list[tuple[dict[str, object], ChromaDBCollection]] = []
     words_messages: list[tuple[dict[str, object], ChromaDBCollection]] = []
     summary_messages: list[tuple[dict[str, object], TargetQueue]] = []
+    line_item_messages: list[tuple[dict[str, object], TargetQueue]] = []
 
     for msg in messages:
         msg_dict = _message_to_dict(msg)
@@ -52,6 +53,8 @@ def publish_messages(
             words_messages.append((msg_dict, ChromaDBCollection.WORDS))
         if TargetQueue.RECEIPT_SUMMARY in msg.collections:
             summary_messages.append((msg_dict, TargetQueue.RECEIPT_SUMMARY))
+        if TargetQueue.LINE_ITEMS in msg.collections:
+            line_item_messages.append((msg_dict, TargetQueue.LINE_ITEMS))
 
     if lines_messages:
         sent_count += send_batch_to_queue(
@@ -77,6 +80,15 @@ def publish_messages(
             summary_messages,
             "RECEIPT_SUMMARY_QUEUE_URL",
             TargetQueue.RECEIPT_SUMMARY,
+            metrics,
+        )
+
+    if line_item_messages:
+        sent_count += send_batch_to_queue(
+            sqs,
+            line_item_messages,
+            "LINE_ITEM_QUEUE_URL",
+            TargetQueue.LINE_ITEMS,
             metrics,
         )
 

--- a/receipt_dynamo_stream/tests/unit/test_receipt_summary_stream.py
+++ b/receipt_dynamo_stream/tests/unit/test_receipt_summary_stream.py
@@ -1,0 +1,92 @@
+"""Unit tests for RECEIPT_SUMMARY stream support (line-item trigger).
+
+A receipt's summary is written when its words, sections, labels and
+merchant all exist, so summary INSERT/MODIFY is the trigger for
+RECEIPT_LINE_ITEM recomputation. These tests pin: SK detection, the
+LINE_ITEMS queue routing, and INSERT firing (a receipt's FIRST summary
+must produce line items, not just later edits).
+"""
+
+from typing import Any, Optional
+
+from receipt_dynamo.entities.receipt_summary import (
+    MonetaryTotals,
+    ReceiptSummary,
+)
+from receipt_dynamo.entities.receipt_summary_record import (
+    ReceiptSummaryRecord,
+)
+from receipt_dynamo_stream.message_builder import (
+    _extract_entity_data,
+    build_messages_from_records,
+)
+from receipt_dynamo_stream.models import TargetQueue
+from receipt_dynamo_stream.parsing import detect_entity_type
+
+IMAGE_ID = "550e8400-e29b-41d4-a716-446655440000"
+
+
+def _make_record(subtotal: float = 10.55) -> ReceiptSummaryRecord:
+    summary = ReceiptSummary(
+        image_id=IMAGE_ID,
+        receipt_id=1,
+        totals=MonetaryTotals(
+            subtotal=subtotal,
+            grand_total=subtotal + 0.88,
+            tax=0.88,
+        ),
+    )
+    return ReceiptSummaryRecord(summary=summary)
+
+
+def _stream_record(
+    event_name: str,
+    old: Optional[ReceiptSummaryRecord],
+    new: Optional[ReceiptSummaryRecord],
+) -> dict[str, Any]:
+    entity = old or new
+    assert entity is not None
+    dynamodb: dict[str, Any] = {"Keys": entity.key}
+    if old is not None:
+        dynamodb["OldImage"] = old.to_item()
+    if new is not None:
+        dynamodb["NewImage"] = new.to_item()
+    return {
+        "eventName": event_name,
+        "eventID": "event-summary-1",
+        "awsRegion": "us-east-1",
+        "dynamodb": dynamodb,
+    }
+
+
+def test_detect_entity_type_summary_sk() -> None:
+    assert detect_entity_type("RECEIPT#00001#SUMMARY") == "RECEIPT_SUMMARY"
+
+
+def test_summary_sk_does_not_shadow_others() -> None:
+    assert detect_entity_type("RECEIPT#00001") == "RECEIPT"
+    assert (
+        detect_entity_type("RECEIPT#00001#SECTION#ITEMS") == "RECEIPT_SECTION"
+    )
+
+
+def test_summary_routes_to_line_items_queue() -> None:
+    data, targets = _extract_entity_data("RECEIPT_SUMMARY", _make_record())
+    assert data["image_id"] == IMAGE_ID
+    assert data["receipt_id"] == 1
+    assert targets == [TargetQueue.LINE_ITEMS]
+
+
+def test_summary_insert_produces_message() -> None:
+    """A receipt's FIRST summary must trigger line-item extraction."""
+    record = _stream_record("INSERT", None, _make_record())
+    messages = build_messages_from_records([record])
+    assert len(messages) == 1
+    assert TargetQueue.LINE_ITEMS in messages[0].collections
+
+
+def test_summary_modify_produces_message() -> None:
+    record = _stream_record("MODIFY", _make_record(10.55), _make_record(12.00))
+    messages = build_messages_from_records([record])
+    assert len(messages) == 1
+    assert TargetQueue.LINE_ITEMS in messages[0].collections


### PR DESCRIPTION
Task #3: the last plumbing between the decoder and automatic line items. RECEIPT_SUMMARY changes (the moment words/sections/labels/merchant all exist) route to a new queue + Lambda that rewrites RECEIPT_LINE_ITEM via the canonical band-block decoder — bundled into the archive as FileAssets referencing canonical sources (no forked copies). Resegmentation regenerates items for free (it rewrites the summary). Extracts on PENDING sections with provenance recorded; invalidated ITEMS sections clear stale rows. 5 new stream unit tests (SK detection, LINE_ITEMS routing, INSERT firing), 141 passing. Post-deploy acceptance: upload a fresh receipt → items appear with no script; resegment → recomputed, not duplicated.