### PR TITLE
fix(infra): unbreak prod deploy — empty StringAsset in line-item Lambda bundle

### DIFF
--- a/infra/chromadb_compaction/components/lambda_functions.py
+++ b/infra/chromadb_compaction/components/lambda_functions.py
@@ -598,9 +598,7 @@ class HybridLambdaDeployment(ComponentResource):
             # The inline sqs_policy grants receive/delete on the queue;
             # without the explicit dependency AWS can reject the mapping
             # when it is created before the IAM update lands.
-            opts=ResourceOptions(
-                parent=self, depends_on=[self.sqs_policy]
-            ),
+            opts=ResourceOptions(parent=self, depends_on=[self.sqs_policy]),
         )
 
         # Export useful properties

--- a/infra/chromadb_compaction/components/lambda_functions.py
+++ b/infra/chromadb_compaction/components/lambda_functions.py
@@ -595,7 +595,12 @@ class HybridLambdaDeployment(ComponentResource):
             batch_size=50,
             maximum_batching_window_in_seconds=5,
             function_response_types=["ReportBatchItemFailures"],
-            opts=ResourceOptions(parent=self),
+            # The inline sqs_policy grants receive/delete on the queue;
+            # without the explicit dependency AWS can reject the mapping
+            # when it is created before the IAM update lands.
+            opts=ResourceOptions(
+                parent=self, depends_on=[self.sqs_policy]
+            ),
         )
 
         # Export useful properties
@@ -655,6 +660,9 @@ class HybridLambdaDeployment(ComponentResource):
                                     "dynamodb:PutItem",
                                     "dynamodb:UpdateItem",
                                     "dynamodb:DeleteItem",
+                                    # line-item updater writes rows via
+                                    # batch_write_item
+                                    "dynamodb:BatchWriteItem",
                                     "dynamodb:Query",
                                     "dynamodb:DescribeTable",
                                 ],

--- a/infra/chromadb_compaction/components/lambda_functions.py
+++ b/infra/chromadb_compaction/components/lambda_functions.py
@@ -497,8 +497,12 @@ class HybridLambdaDeployment(ComponentResource):
                     "# deploy-time stub: only line_items is bundled; the real\n"
                     "# receipt_upload __init__ pulls PIL and the full package.\n"
                 ),
+                # Must be non-empty: an empty StringAsset serializes with no
+                # "text" field and crashes the Python SDK when the engine
+                # echoes the archive back ("Invalid asset encountered when
+                # unmarshalling resource property").
                 "receipt_upload/line_items/__init__.py": pulumi.StringAsset(
-                    ""
+                    "# namespace stub\n"
                 ),
                 "receipt_upload/line_items/geometry.py": pulumi.FileAsset(
                     _repo_root

--- a/infra/receipt_line_item_updater/line_item_processor.py
+++ b/infra/receipt_line_item_updater/line_item_processor.py
@@ -26,6 +26,7 @@ from datetime import datetime, timezone
 from typing import Any
 
 from receipt_dynamo.data.dynamo_client import DynamoClient
+from receipt_dynamo.data.shared_exceptions import EntityNotFoundError
 from receipt_dynamo.entities.receipt_line_item import ReceiptLineItem
 from receipt_upload.line_items.geometry import extract_items, reconcile
 
@@ -49,11 +50,14 @@ def update_receipt_line_items(
         image_id, receipt_id
     )
 
-    # ITEMS zone: any non-INVALID ITEMS section; prefer VALID over PENDING
-    # when both exist so provenance reflects the strongest source.
+    # ITEMS zone: any non-INVALID canonical ITEMS section; prefer VALID
+    # over PENDING when both exist so provenance reflects the strongest
+    # source. Exact match (like the backfill script): legacy
+    # ITEMS_VALUE / ITEMS_DESCRIPTION zones are partial (prices-only or
+    # names-only) and must not masquerade as a full ITEMS section.
     items_section = None
     for s in sections:
-        if "ITEM" not in str(getattr(s, "section_type", "") or "").upper():
+        if str(getattr(s, "section_type", "") or "").upper() != "ITEMS":
             continue
         status = str(getattr(s, "validation_status", "") or "").upper()
         if status == "INVALID":
@@ -99,7 +103,11 @@ def update_receipt_line_items(
                 "tax": getattr(inner, "tax", None),
             }
             merchant = getattr(inner, "merchant_name", None)
-    except Exception:  # noqa: BLE001 - summary may not exist yet
+    except EntityNotFoundError:
+        # Only "summary does not exist yet" is a valid no-baseline case.
+        # Operational failures (throttling, access, malformed data) must
+        # propagate so SQS retries instead of acking rows with a silently
+        # wrong no-baseline status and a missing merchant.
         logger.info(
             "no summary for %s:%d; reconciliation is no-baseline",
             image_id[:8],

--- a/receipt_dynamo_stream/receipt_dynamo_stream/change_detection/detector.py
+++ b/receipt_dynamo_stream/receipt_dynamo_stream/change_detection/detector.py
@@ -21,8 +21,10 @@ CHROMADB_RELEVANT_FIELDS = {
         "label_proposed_by",
         "label_consolidated_from",
     ],
+    # timestamp_computed only: the summary updater stamps a fresh value on
+    # every write, and the nested ``summary`` dataclass is not JSON
+    # serializable (it would crash the SQS publisher).
     "RECEIPT_SUMMARY": [
-        "summary",
         "timestamp_computed",
     ],
     "RECEIPT_SECTION": [

--- a/receipt_dynamo_stream/receipt_dynamo_stream/message_builder.py
+++ b/receipt_dynamo_stream/receipt_dynamo_stream/message_builder.py
@@ -289,21 +289,30 @@ def _extract_receipt_summary(
 
 def _extract_receipt_section(
     entity: ReceiptSection,
-) -> tuple[dict[str, object], list[ChromaDBCollection]]:
-    """Extract section data targeting the LINES collection only.
+) -> tuple[dict[str, object], list[ChromaDBCollection | TargetQueue]]:
+    """Extract section data targeting the LINES collection.
 
     ``section_label`` lives on LINES (visual-row) metadata. The message
     carries only (image_id, receipt_id): the consumer recomputes labels
     from the receipt's *current* section set in DynamoDB, so the event
     image is deliberately not trusted (see compaction sections module).
     ``section_type`` is included only for within-batch deduplication.
+
+    Canonical ITEMS sections additionally target LINE_ITEMS: a section
+    invalidation or line_ids edit must recompute (or clear) the
+    receipt's line items even when no summary rewrite follows.
     """
+    targets: list[ChromaDBCollection | TargetQueue] = [
+        ChromaDBCollection.LINES
+    ]
+    if str(entity.section_type).upper() == "ITEMS":
+        targets.append(TargetQueue.LINE_ITEMS)
     return {
         "entity_type": "RECEIPT_SECTION",
         "image_id": entity.image_id,
         "receipt_id": entity.receipt_id,
         "section_type": str(entity.section_type),
-    }, [ChromaDBCollection.LINES]
+    }, targets
 
 
 def _extract_receipt(

--- a/receipt_dynamo_stream/receipt_dynamo_stream/parsing/parsers.py
+++ b/receipt_dynamo_stream/receipt_dynamo_stream/parsing/parsers.py
@@ -35,12 +35,15 @@ logger = logging.getLogger(__name__)
 # SK pattern matchers in order of specificity (most specific first)
 _SK_PATTERN_MATCHERS: list[tuple[Callable[[str], bool], str]] = [
     (lambda sk: "#PLACE" in sk, "RECEIPT_PLACE"),
-    # RECEIPT#00001#SUMMARY; the "#SUMMARY" suffix appears in no other SK
-    (lambda sk: sk.endswith("#SUMMARY"), "RECEIPT_SUMMARY"),
     (lambda sk: "#LABEL#" in sk, "RECEIPT_WORD_LABEL"),
     # RECEIPT#00001#SECTION#{TYPE}; "#SECTION#" appears in no other
-    # entity SK (receipt_section.py is the only entity emitting it)
+    # entity SK (receipt_section.py is the only entity emitting it).
+    # Must run BEFORE the summary matcher: SectionType.SUMMARY yields
+    # SKs like RECEIPT#00001#SECTION#SUMMARY which also end in
+    # "#SUMMARY" and would otherwise be misparsed as summary records.
     (lambda sk: "#SECTION#" in sk, "RECEIPT_SECTION"),
+    # RECEIPT#00001#SUMMARY (checked after "#SECTION#" above)
+    (lambda sk: sk.endswith("#SUMMARY"), "RECEIPT_SUMMARY"),
     (lambda sk: "#COMPACTION_RUN#" in sk, "COMPACTION_RUN"),
     (lambda sk: "#WORD#" in sk and "#LINE#" in sk, "RECEIPT_WORD"),
     (lambda sk: "#LINE#" in sk, "RECEIPT_LINE"),

--- a/receipt_dynamo_stream/tests/unit/test_receipt_summary_stream.py
+++ b/receipt_dynamo_stream/tests/unit/test_receipt_summary_stream.py
@@ -26,7 +26,10 @@ from receipt_dynamo_stream.parsing import detect_entity_type
 IMAGE_ID = "550e8400-e29b-41d4-a716-446655440000"
 
 
-def _make_record(subtotal: float = 10.55) -> ReceiptSummaryRecord:
+def _make_record(
+    subtotal: float = 10.55,
+    ts: str = "2026-07-30T12:00:00+00:00",
+) -> ReceiptSummaryRecord:
     summary = ReceiptSummary(
         image_id=IMAGE_ID,
         receipt_id=1,
@@ -36,7 +39,7 @@ def _make_record(subtotal: float = 10.55) -> ReceiptSummaryRecord:
             tax=0.88,
         ),
     )
-    return ReceiptSummaryRecord(summary=summary)
+    return ReceiptSummaryRecord(summary=summary, timestamp_computed=ts)
 
 
 def _stream_record(
@@ -68,6 +71,12 @@ def test_summary_sk_does_not_shadow_others() -> None:
     assert (
         detect_entity_type("RECEIPT#00001#SECTION#ITEMS") == "RECEIPT_SECTION"
     )
+    # SectionType.SUMMARY also ends in "#SUMMARY": the section matcher
+    # must win or these records get misparsed as summary records.
+    assert (
+        detect_entity_type("RECEIPT#00001#SECTION#SUMMARY")
+        == "RECEIPT_SECTION"
+    )
 
 
 def test_summary_routes_to_line_items_queue() -> None:
@@ -86,7 +95,56 @@ def test_summary_insert_produces_message() -> None:
 
 
 def test_summary_modify_produces_message() -> None:
-    record = _stream_record("MODIFY", _make_record(10.55), _make_record(12.00))
+    record = _stream_record(
+        "MODIFY",
+        _make_record(10.55, ts="2026-07-30T12:00:00+00:00"),
+        _make_record(12.00, ts="2026-07-30T12:05:00+00:00"),
+    )
     messages = build_messages_from_records([record])
     assert len(messages) == 1
     assert TargetQueue.LINE_ITEMS in messages[0].collections
+
+
+def test_summary_message_is_json_serializable() -> None:
+    """The nested ReceiptSummary dataclass must never reach the SQS
+    payload: change detection tracks timestamp_computed only."""
+    import json
+
+    from receipt_dynamo_stream.sqs_publisher import _message_to_dict
+
+    record = _stream_record(
+        "MODIFY",
+        _make_record(10.55, ts="2026-07-30T12:00:00+00:00"),
+        _make_record(12.00, ts="2026-07-30T12:05:00+00:00"),
+    )
+    (message,) = build_messages_from_records([record])
+    json.dumps(_message_to_dict(message))  # must not raise
+
+
+def test_items_section_routes_to_line_items() -> None:
+    """Invalidating or editing an ITEMS section must recompute line
+    items even when no summary rewrite follows."""
+    from datetime import datetime, timezone
+
+    from receipt_dynamo.entities.receipt_section import ReceiptSection
+
+    created = datetime(2026, 7, 30, 12, 0, 0, tzinfo=timezone.utc)
+    section = ReceiptSection(
+        image_id=IMAGE_ID,
+        receipt_id=1,
+        section_type="ITEMS",
+        line_ids=[4, 5, 6],
+        created_at=created,
+    )
+    _, targets = _extract_entity_data("RECEIPT_SECTION", section)
+    assert TargetQueue.LINE_ITEMS in targets
+
+    header = ReceiptSection(
+        image_id=IMAGE_ID,
+        receipt_id=1,
+        section_type="HEADER",
+        line_ids=[1, 2],
+        created_at=created,
+    )
+    _, targets = _extract_entity_data("RECEIPT_SECTION", header)
+    assert TargetQueue.LINE_ITEMS not in targets


### PR DESCRIPTION
CI's Deploy job failed on main (run 30595293216) with:

```
AssertionError: Invalid asset encountered when unmarshalling resource property
While processing resource: 'chromadb-prod-line-item-event-source-mapping'
```

Root cause: `receipt_upload/line_items/__init__.py` was bundled as `pulumi.StringAsset("")`. An empty StringAsset serializes with no `text` field, so the Python SDK cannot reconstruct the asset when the engine echoes the Lambda's `code` archive back during `resolve_outputs`, and the program aborts before registering the event source mapping.

Fix: give the stub non-empty content (`# namespace stub`). One-line change plus an explanatory comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KMeX4w8g3NsVg7ckN7wyBh

---

**Also folds in the 7 codex review findings from #1309** (verified each against the code before fixing):

| # | Finding | Fix |
|---|---|---|
| P1 | `FieldChange` carries the non-serializable `ReceiptSummary` dataclass → `json.dumps` crash in the SQS publisher | detector tracks only `timestamp_computed` (freshly stamped on every write) |
| P1 | `endswith("#SUMMARY")` shadows `SECTION#SUMMARY` SKs (SectionType.SUMMARY is real) | section matcher ordered first + regression test |
| P1 | role lacks `dynamodb:BatchWriteItem` (row writes use `batch_write_item`) | granted |
| P1 | ESM could be created before the SQS IAM policy update | `depends_on=[self.sqs_policy]` |
| P2 | ITEMS-section invalidation never triggered recompute (only summary events did) | canonical ITEMS sections also route to LINE_ITEMS |
| P2 | broad `except` on summary read acked operational failures as "no-baseline" | catch `EntityNotFoundError` only |
| P2 | substring `"ITEM" in type` matched legacy partial zones (ITEMS_VALUE/ITEMS_DESCRIPTION) | exact `== "ITEMS"` like the backfill |

Tests: 143 stream unit tests pass (3 new: SECTION#SUMMARY parse, JSON-serializability of the summary payload, ITEMS→LINE_ITEMS routing); golden line-item gate passes.