### PR TITLE
Emit receipt structure from the Swift worker

### DIFF
--- a/receipt_ocr_swift/Scripts/generate_receipt_structure_parity.py
+++ b/receipt_ocr_swift/Scripts/generate_receipt_structure_parity.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Generate end-to-end rows -> sections -> line-items expectations."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+from generate_section_parity import reconstruct
+
+from receipt_chroma.embedding.formatting import build_receipt_rows
+from receipt_dynamo.amounts import (
+    looks_like_receipt_amount,
+    parse_receipt_amount,
+)
+from receipt_upload.line_items.blocks import should_reocr_items_zone
+from receipt_upload.line_items.geometry import extract_items, reconcile
+from receipt_upload.section_assignment import (
+    assign_row_sections,
+    load_prior_model,
+    sections_from_assignments,
+)
+
+_SUBTOTAL_RE = re.compile(r"\bSUB\s*TOTAL\b", re.IGNORECASE)
+
+
+def _printed_subtotal(rows, lines, words) -> float | None:
+    lines_by_id = {line.line_id: line for line in lines}
+    for row in rows:
+        text = " ".join(lines_by_id[line_id].text for line_id in row.line_ids)
+        if not _SUBTOTAL_RE.search(text):
+            continue
+        amount = parse_receipt_amount(row.amount_text)
+        if amount is not None and amount > 0:
+            return amount
+        row_ids = set(row.line_ids)
+        candidates = sorted(
+            (
+                word
+                for word in words
+                if word.line_id in row_ids
+                and looks_like_receipt_amount(word.text)
+            ),
+            key=lambda word: (
+                word.bounding_box["x"],
+                word.line_id,
+                word.word_id,
+            ),
+        )
+        for word in reversed(candidates):
+            amount = parse_receipt_amount(word.text)
+            if amount is not None and amount > 0:
+                return amount
+    return None
+
+
+def main() -> None:
+    script_dir = Path(__file__).resolve().parent
+    package_dir = script_dir.parent
+    repo_root = package_dir.parent
+    input_path = (
+        repo_root / "receipt_upload/tests/fixtures/line_items_golden_ocr.json"
+    )
+    output_path = (
+        package_dir
+        / "Tests/ReceiptOCRCoreTests/Fixtures/receipt_structure_parity_expected.json"
+    )
+    fixture = json.loads(input_path.read_text(encoding="utf-8"))
+    model = load_prior_model()
+    expected = []
+    for receipt in fixture["receipts"]:
+        lines, words = reconstruct(receipt)
+        rows = build_receipt_rows(lines, words)
+        assignments = assign_row_sections(
+            rows, lines, model, receipt.get("merchant")
+        )
+        sections = sections_from_assignments(assignments)
+        items_lines = next(
+            (
+                set(section.line_ids)
+                for section in sections
+                if section.section_type == "ITEMS"
+            ),
+            set(),
+        )
+        items, _ = extract_items(receipt["words"], items_lines)
+        subtotal = _printed_subtotal(rows, lines, words)
+        status, _, _ = reconcile(
+            [item for item in items if not item.get("is_discount")],
+            {"subtotal": subtotal} if subtotal is not None else None,
+        )
+        expected.append(
+            {
+                "image_id": receipt["image_id"],
+                "receipt_id": receipt["receipt_id"],
+                "sections": [
+                    {
+                        "section_type": section.section_type,
+                        "line_ids": section.line_ids,
+                    }
+                    for section in sections
+                ],
+                "line_items": [
+                    {
+                        "item_index": index,
+                        "name": item["name"],
+                        "price": item["price"],
+                        "quantity": item.get("quantity"),
+                        "unit_price": item.get("unit_price"),
+                        "is_discount": bool(item.get("is_discount")),
+                        "name_quality": item.get("name_quality") or "ok",
+                        "line_ids": item["line_ids"],
+                        "reconciliation_status": status,
+                    }
+                    for index, item in enumerate(items)
+                ],
+                "printed_subtotal": subtotal,
+                "reconciliation_status": status,
+                "should_reocr_items_zone": should_reocr_items_zone(
+                    items, subtotal
+                ),
+            }
+        )
+
+    if len(expected) != 33:
+        raise RuntimeError(f"expected 33 receipts, got {len(expected)}")
+    output_path.write_text(
+        json.dumps(expected, indent=2) + "\n", encoding="utf-8"
+    )
+    print(f"wrote {len(expected)}/33 receipts to {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/receipt_ocr_swift/Sources/ReceiptOCRCore/Models/ReceiptDetection.swift
+++ b/receipt_ocr_swift/Sources/ReceiptOCRCore/Models/ReceiptDetection.swift
@@ -129,6 +129,13 @@ public struct ReceiptOutput: Codable {
     /// the warped crop, matching `lines`).
     public var barcodes: [Barcode]?
 
+    /// Deterministic row-to-section predictions emitted by the Mac worker.
+    public let sections: [ReceiptSectionPayload]
+
+    /// Deterministic line items decoded from this receipt's predicted ITEMS
+    /// section and reconciled against its own printed subtotal.
+    public let lineItems: [ReceiptLineItemPayload]
+
     /// True when this crop probably contains multiple overlapping receipts that
     /// couldn't be confidently split — flag for human review.
     public let needsReview: Bool
@@ -143,8 +150,18 @@ public struct ReceiptOutput: Codable {
         lines: [Line]? = nil,
         layoutlmPredictions: [LinePrediction]? = nil,
         barcodes: [Barcode]? = nil,
+        sections: [ReceiptSectionPayload]? = nil,
+        lineItems: [ReceiptLineItemPayload]? = nil,
         needsReview: Bool = false
     ) {
+        let structure = lines.flatMap {
+            try? buildOnDeviceReceiptStructure(
+                lines: $0, receiptId: clusterId,
+                merchantName: merchantNameFromLayoutPredictions(
+                    layoutlmPredictions
+                )
+            )
+        }
         self.clusterId = clusterId
         self.bounds = bounds
         self.warpedWidth = warpedWidth
@@ -154,11 +171,29 @@ public struct ReceiptOutput: Codable {
         self.lines = lines
         self.layoutlmPredictions = layoutlmPredictions
         self.barcodes = barcodes
+        self.sections = sections ?? structure?.sections ?? []
+        self.lineItems = lineItems ?? structure?.lineItems ?? []
         self.needsReview = needsReview
     }
 
     /// Create from a ProcessedReceipt
-    public init(from processed: ProcessedReceipt, s3Key: String? = nil, lines: [Line]? = nil, layoutlmPredictions: [LinePrediction]? = nil, barcodes: [Barcode]? = nil) {
+    public init(
+        from processed: ProcessedReceipt,
+        s3Key: String? = nil,
+        lines: [Line]? = nil,
+        layoutlmPredictions: [LinePrediction]? = nil,
+        barcodes: [Barcode]? = nil,
+        sections: [ReceiptSectionPayload]? = nil,
+        lineItems: [ReceiptLineItemPayload]? = nil
+    ) {
+        let structure = lines.flatMap {
+            try? buildOnDeviceReceiptStructure(
+                lines: $0, receiptId: processed.clusterId,
+                merchantName: merchantNameFromLayoutPredictions(
+                    layoutlmPredictions
+                )
+            )
+        }
         self.clusterId = processed.clusterId
         self.bounds = processed.bounds
         self.warpedWidth = processed.warpedWidth
@@ -168,6 +203,8 @@ public struct ReceiptOutput: Codable {
         self.lines = lines
         self.layoutlmPredictions = layoutlmPredictions
         self.barcodes = barcodes
+        self.sections = sections ?? structure?.sections ?? []
+        self.lineItems = lineItems ?? structure?.lineItems ?? []
         self.needsReview = processed.needsReview
     }
 
@@ -181,6 +218,8 @@ public struct ReceiptOutput: Codable {
         case lines
         case layoutlmPredictions = "layoutlm_predictions"
         case barcodes
+        case sections
+        case lineItems = "line_items"
         case needsReview = "needs_review"
     }
 }

--- a/receipt_ocr_swift/Sources/ReceiptOCRCore/ReceiptProcessing/ReceiptStructurePipeline.swift
+++ b/receipt_ocr_swift/Sources/ReceiptOCRCore/ReceiptProcessing/ReceiptStructurePipeline.swift
@@ -1,0 +1,215 @@
+import Foundation
+
+public let swiftWorkerModelSource = "swift-worker-v1"
+
+/// JSON contract for one on-device section prediction.
+public struct ReceiptSectionPayload: Codable, Sendable, Equatable {
+    public let sectionType: String
+    public let lineIds: [Int]
+    public let rowIds: [Int]
+    public let confidence: Double
+    public let modelSource: String
+
+    enum CodingKeys: String, CodingKey {
+        case sectionType = "section_type"
+        case lineIds = "line_ids"
+        case rowIds = "row_ids"
+        case confidence
+        case modelSource = "model_source"
+    }
+}
+
+/// JSON contract for one on-device line item.
+public struct ReceiptLineItemPayload: Codable, Sendable, Equatable {
+    public let itemIndex: Int
+    public let name: String
+    public let price: Double
+    public let quantity: Double?
+    public let unitPrice: Double?
+    public let isDiscount: Bool
+    public let nameQuality: String
+    public let lineIds: [Int]
+    public let reconciliationStatus: String
+    public let modelSource: String
+
+    enum CodingKeys: String, CodingKey {
+        case itemIndex = "item_index"
+        case name
+        case price
+        case quantity
+        case unitPrice = "unit_price"
+        case isDiscount = "is_discount"
+        case nameQuality = "name_quality"
+        case lineIds = "line_ids"
+        case reconciliationStatus = "reconciliation_status"
+        case modelSource = "model_source"
+    }
+}
+
+/// Full deterministic structure produced after refinement OCR on a warped
+/// receipt. Re-OCR remains a separate worker job; this result exposes the
+/// already-ported decision so callers can route it without recomputing.
+public struct OnDeviceReceiptStructure: Sendable, Equatable {
+    public let sections: [ReceiptSectionPayload]
+    public let lineItems: [ReceiptLineItemPayload]
+    public let printedSubtotal: Double?
+    public let reconciliationStatus: String
+    public let shouldReocrItemsZone: Bool
+}
+
+private enum ReceiptStructureRegex {
+    static let subtotal = Rx("\\bSUB\\s*TOTAL\\b", ci: true)
+}
+
+private let cachedSectionPriorModel: Result<SectionPriorModel, Error> = Result {
+    try loadSectionPriorModel()
+}
+
+/// Recover the merchant text already predicted by on-device LayoutLM so the
+/// assigner can select its measured merchant prior when one exists.
+public func merchantNameFromLayoutPredictions(
+    _ predictions: [LinePrediction]?
+) -> String? {
+    guard let predictions else { return nil }
+    let tokens = predictions.flatMap { prediction in
+        zip(prediction.tokens, prediction.labels).compactMap { token, label in
+            label.uppercased().hasSuffix("MERCHANT_NAME") && !token.isEmpty
+                ? token : nil
+        }
+    }
+    let name = tokens.joined(separator: " ")
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+    return name.isEmpty ? nil : name
+}
+
+private func textForRow(
+    _ row: ReceiptVisualRow, linesById: [Int: SectionLine]
+) -> String {
+    row.lineIds.compactMap { linesById[$0]?.text }.joined(separator: " ")
+}
+
+/// Find the receipt's own printed subtotal from visual rows. The aligned
+/// row-builder amount wins; a rightmost word-level amount is the fallback for
+/// receipts whose amount column is too sparse to detect.
+public func findPrintedSubtotal(
+    rows: [ReceiptVisualRow], lines: [SectionLine]
+) -> Double? {
+    let linesById = Dictionary(uniqueKeysWithValues: lines.map {
+        ($0.lineId, $0)
+    })
+    for row in rows {
+        let text = textForRow(row, linesById: linesById)
+        guard ReceiptStructureRegex.subtotal.search(text) != nil else {
+            continue
+        }
+        if let amount = Amounts.parseReceiptAmount(row.amountText), amount > 0 {
+            return amount
+        }
+        let rowIds = Set(row.lineIds)
+        let candidates = lines.filter { rowIds.contains($0.lineId) }
+            .flatMap(\.words)
+            .filter { Amounts.looksLikeReceiptAmount($0.text) }
+            .stableSorted {
+                if $0.boundingBox.x != $1.boundingBox.x {
+                    return $0.boundingBox.x < $1.boundingBox.x
+                }
+                if $0.lineId != $1.lineId { return $0.lineId < $1.lineId }
+                return $0.wordId < $1.wordId
+            }
+        for word in candidates.reversed() {
+            if let amount = Amounts.parseReceiptAmount(word.text), amount > 0 {
+                return amount
+            }
+        }
+    }
+    return nil
+}
+
+/// Run rows -> sections -> line items -> subtotal reconciliation.
+public func buildOnDeviceReceiptStructure(
+    lines: [SectionLine], merchantName: String? = nil
+) throws -> OnDeviceReceiptStructure {
+    guard !lines.isEmpty else {
+        return OnDeviceReceiptStructure(
+            sections: [], lineItems: [], printedSubtotal: nil,
+            reconciliationStatus: "no-baseline",
+            shouldReocrItemsZone: false
+        )
+    }
+    let rows = buildReceiptRows(lines: lines)
+    let model = try cachedSectionPriorModel.get()
+    let predictions = sectionsFromAssignments(
+        assignRowSections(
+            rows: rows, lines: lines, model: model,
+            merchantName: merchantName
+        )
+    )
+    let sections = predictions.map { section in
+        ReceiptSectionPayload(
+            sectionType: section.sectionType,
+            lineIds: section.lineIds,
+            rowIds: section.rowIds,
+            confidence: section.confidence,
+            modelSource: swiftWorkerModelSource
+        )
+    }
+
+    let itemsLineIds = Set(
+        sections.first { $0.sectionType == "ITEMS" }?.lineIds ?? []
+    )
+    let zoneWords = lines.flatMap(\.words).map { word in
+        ZoneWord(
+            lineId: word.lineId,
+            wordId: word.wordId,
+            text: word.text,
+            x: word.boundingBox.x,
+            yMid: word.boundingBox.y + word.boundingBox.height / 2,
+            h: word.boundingBox.height
+        )
+    }
+    let decoded = itemsLineIds.isEmpty
+        ? [] : extractLineItems(words: zoneWords, zoneLineIds: itemsLineIds)
+    let printedSubtotal = findPrintedSubtotal(rows: rows, lines: lines)
+    let reconciliation = reconcileLineItems(
+        items: decoded.filter { !$0.isDiscount },
+        subtotal: printedSubtotal, grandTotal: nil, tax: nil
+    )
+    let lineItems = decoded.enumerated().map { index, item in
+        ReceiptLineItemPayload(
+            itemIndex: index,
+            name: item.name,
+            price: item.price,
+            quantity: item.quantity,
+            unitPrice: item.unitPrice,
+            isDiscount: item.isDiscount,
+            nameQuality: item.nameQuality ?? "ok",
+            lineIds: item.lineIds,
+            reconciliationStatus: reconciliation.status,
+            modelSource: swiftWorkerModelSource
+        )
+    }
+    return OnDeviceReceiptStructure(
+        sections: sections,
+        lineItems: lineItems,
+        printedSubtotal: printedSubtotal,
+        reconciliationStatus: reconciliation.status,
+        shouldReocrItemsZone: shouldReocrItemsZone(
+            items: decoded, printedSubtotal: printedSubtotal
+        )
+    )
+}
+
+#if os(macOS)
+/// Production adapter for refinement OCR. Empty lines/words are skipped to
+/// mirror the cloud parser while their original 1-based IDs are preserved.
+public func buildOnDeviceReceiptStructure(
+    lines: [Line], receiptId: Int, merchantName: String? = nil
+) throws -> OnDeviceReceiptStructure {
+    let sectionLines = makeSectionLines(
+        lines, imageId: "", receiptId: receiptId
+    )
+    return try buildOnDeviceReceiptStructure(
+        lines: sectionLines, merchantName: merchantName
+    )
+}
+#endif

--- a/receipt_ocr_swift/Sources/ReceiptOCRCore/Sections/SectionAssignment.swift
+++ b/receipt_ocr_swift/Sources/ReceiptOCRCore/Sections/SectionAssignment.swift
@@ -791,10 +791,13 @@ public func sectionsFromAssignments(
 public func makeSectionLines(
     _ lines: [Line], imageId: String, receiptId: Int
 ) -> [SectionLine] {
-    lines.enumerated().map { lineOffset, line in
+    lines.enumerated().compactMap { lineOffset, line -> SectionLine? in
+        guard !line.text.isEmpty else { return nil }
         let lineId = lineOffset + 1
-        let words = line.words.enumerated().map { wordOffset, word in
-            SectionWord(
+        let words = line.words.enumerated().compactMap {
+            wordOffset, word -> SectionWord? in
+            guard !word.text.isEmpty, word.confidence > 0 else { return nil }
+            return SectionWord(
                 lineId: lineId, wordId: wordOffset + 1, text: word.text,
                 boundingBox: SectionRect(
                     x: Double(word.boundingBox.x),

--- a/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/Fixtures/receipt_structure_parity_expected.json
+++ b/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/Fixtures/receipt_structure_parity_expected.json
@@ -1,0 +1,4289 @@
+[
+  {
+    "image_id": "b50ba18b-7511-4a85-87cd-74aa5e147e10",
+    "receipt_id": 2,
+    "sections": [
+      {
+        "section_type": "ITEMS",
+        "line_ids": [
+          8,
+          10,
+          9,
+          11
+        ]
+      }
+    ],
+    "line_items": [
+      {
+        "item_index": 0,
+        "name": "Rockenwagner French Loaf",
+        "price": 4.99,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          9,
+          11
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 1,
+        "name": "Clorox Disinfecting Bleac...",
+        "price": 8.99,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          8,
+          10
+        ],
+        "reconciliation_status": "no-baseline"
+      }
+    ],
+    "printed_subtotal": null,
+    "reconciliation_status": "no-baseline",
+    "should_reocr_items_zone": false
+  },
+  {
+    "image_id": "165b9d15-9fa1-4a3c-a568-1b4e98170ab5",
+    "receipt_id": 1,
+    "sections": [
+      {
+        "section_type": "ITEMS",
+        "line_ids": [
+          35,
+          42,
+          12,
+          14,
+          16,
+          33,
+          39,
+          22,
+          26,
+          20,
+          24,
+          37,
+          29,
+          30,
+          31,
+          15,
+          18,
+          45,
+          13,
+          17,
+          23,
+          28,
+          38,
+          21,
+          19,
+          25,
+          34,
+          32,
+          40,
+          48,
+          47,
+          43,
+          44,
+          36,
+          41
+        ]
+      }
+    ],
+    "line_items": [
+      {
+        "item_index": 0,
+        "name": "i: IFS 3 LB.",
+        "price": 7.49,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          45,
+          47,
+          48
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 1,
+        "name": "E 1391546 29827 AHI BAGEL TUNA CH",
+        "price": 7.99,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          35,
+          37,
+          38,
+          39,
+          40,
+          41,
+          42,
+          43,
+          44
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 2,
+        "name": "1113319 15' S COLICORNIA MONDELUKE",
+        "price": 1.89,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          33,
+          34,
+          35,
+          36
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 3,
+        "name": "003 137 003 STRAWBERRIES SEAWEED SALJ",
+        "price": 1.99,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          26,
+          29,
+          30,
+          31,
+          32
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 4,
+        "name": "or 57554 '917 BLUEBERRI! S&P PISTACH",
+        "price": 5.79,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          22,
+          24,
+          25,
+          26,
+          28
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 5,
+        "name": "709616 25595 COCKTAIL BUFALA MOZZ TOM",
+        "price": 6.99,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          18,
+          20,
+          21,
+          22,
+          23
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 6,
+        "name": "1055663 1131563 CHICKN HNY RSTD SALAD MIX",
+        "price": 8.49,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          14,
+          16,
+          17,
+          18,
+          19
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 7,
+        "name": "10'8249 ORG HORIZON ATAULFO",
+        "price": 6.99,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          12,
+          13,
+          14,
+          15
+        ],
+        "reconciliation_status": "no-baseline"
+      }
+    ],
+    "printed_subtotal": null,
+    "reconciliation_status": "no-baseline",
+    "should_reocr_items_zone": false
+  },
+  {
+    "image_id": "5cef2e7e-baad-4c29-9e5f-6a3d5ec20885",
+    "receipt_id": 1,
+    "sections": [
+      {
+        "section_type": "ITEMS",
+        "line_ids": [
+          10,
+          11,
+          15
+        ]
+      }
+    ],
+    "line_items": [
+      {
+        "item_index": 0,
+        "name": "E 33977 BEEF FLANK",
+        "price": 46.28,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          10,
+          11,
+          15
+        ],
+        "reconciliation_status": "no-baseline"
+      }
+    ],
+    "printed_subtotal": null,
+    "reconciliation_status": "no-baseline",
+    "should_reocr_items_zone": false
+  },
+  {
+    "image_id": "659623a5-5989-4e61-b153-9cda1331cc8e",
+    "receipt_id": 2,
+    "sections": [
+      {
+        "section_type": "BARCODE",
+        "line_ids": [
+          36,
+          38
+        ]
+      },
+      {
+        "section_type": "ITEMS",
+        "line_ids": [
+          37,
+          40
+        ]
+      }
+    ],
+    "line_items": [
+      {
+        "item_index": 0,
+        "name": "BUTTER CHARDONNAY",
+        "price": 17.99,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          37,
+          40
+        ],
+        "reconciliation_status": "no-baseline"
+      }
+    ],
+    "printed_subtotal": null,
+    "reconciliation_status": "no-baseline",
+    "should_reocr_items_zone": false
+  },
+  {
+    "image_id": "2360d36e-8211-46c4-9bc8-106766d80038",
+    "receipt_id": 1,
+    "sections": [
+      {
+        "section_type": "ITEMS",
+        "line_ids": [
+          7,
+          17,
+          10,
+          18,
+          19
+        ]
+      }
+    ],
+    "line_items": [
+      {
+        "item_index": 0,
+        "name": "",
+        "price": 6.8,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "low",
+        "line_ids": [
+          19
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 1,
+        "name": "Reg Chocolate Shk",
+        "price": 3.05,
+        "quantity": 1.0,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          10,
+          18
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 2,
+        "name": "Hamburger",
+        "price": 3.75,
+        "quantity": 1.0,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          7,
+          17
+        ],
+        "reconciliation_status": "no-baseline"
+      }
+    ],
+    "printed_subtotal": null,
+    "reconciliation_status": "no-baseline",
+    "should_reocr_items_zone": false
+  },
+  {
+    "image_id": "6b4b3394-cb57-4ce6-9782-751563165946",
+    "receipt_id": 2,
+    "sections": [
+      {
+        "section_type": "ITEMS",
+        "line_ids": [
+          11,
+          20,
+          12,
+          13,
+          21
+        ]
+      }
+    ],
+    "line_items": [
+      {
+        "item_index": 0,
+        "name": "Animal Fry",
+        "price": 4.75,
+        "quantity": 1.0,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          13,
+          21
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 1,
+        "name": "Meat Patty",
+        "price": 9.75,
+        "quantity": 5.0,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          11,
+          12,
+          20
+        ],
+        "reconciliation_status": "no-baseline"
+      }
+    ],
+    "printed_subtotal": null,
+    "reconciliation_status": "no-baseline",
+    "should_reocr_items_zone": false
+  },
+  {
+    "image_id": "1f68d3a7-6835-4e4d-845c-bab6c4eb8280",
+    "receipt_id": 1,
+    "sections": [
+      {
+        "section_type": "ITEMS",
+        "line_ids": [
+          13,
+          14,
+          27,
+          16,
+          17,
+          28,
+          5,
+          19,
+          29,
+          6,
+          20,
+          30,
+          7,
+          21,
+          31,
+          8,
+          22,
+          32,
+          9,
+          23,
+          33
+        ]
+      }
+    ],
+    "line_items": [
+      {
+        "item_index": 0,
+        "name": "Ponzu Sauce",
+        "price": 1.0,
+        "quantity": 1.0,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          9,
+          23,
+          33
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 1,
+        "name": "Steamed White Rice",
+        "price": 3.0,
+        "quantity": 1.0,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          8,
+          22,
+          32
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 2,
+        "name": "Albacore Sushi",
+        "price": 10.0,
+        "quantity": 1.0,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          7,
+          21,
+          31
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 3,
+        "name": "Japanese Scallop Sushi",
+        "price": 12.0,
+        "quantity": 1.0,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          6,
+          20,
+          30
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 4,
+        "name": "Mango Sticky Rice",
+        "price": 14.0,
+        "quantity": 1.0,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          5,
+          19,
+          29
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 5,
+        "name": "Crispy Pork Belly Basil",
+        "price": 20.0,
+        "quantity": 1.0,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          16,
+          17,
+          28
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 6,
+        "name": "Large Bottled Beer",
+        "price": 13.0,
+        "quantity": 1.0,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          13,
+          14,
+          27
+        ],
+        "reconciliation_status": "no-baseline"
+      }
+    ],
+    "printed_subtotal": null,
+    "reconciliation_status": "no-baseline",
+    "should_reocr_items_zone": false
+  },
+  {
+    "image_id": "abb331f5-5fdb-4868-9e63-331a385dc012",
+    "receipt_id": 1,
+    "sections": [
+      {
+        "section_type": "ITEMS",
+        "line_ids": [
+          7,
+          11,
+          8,
+          12
+        ]
+      }
+    ],
+    "line_items": [
+      {
+        "item_index": 0,
+        "name": "OLIPOP SPRKL TONIC",
+        "price": 1.99,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          8,
+          12
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 1,
+        "name": "OL IPOP GRAPE",
+        "price": 2.49,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          7,
+          11
+        ],
+        "reconciliation_status": "no-baseline"
+      }
+    ],
+    "printed_subtotal": null,
+    "reconciliation_status": "no-baseline",
+    "should_reocr_items_zone": false
+  },
+  {
+    "image_id": "887079fa-bb3e-480a-8202-e759afe63f1a",
+    "receipt_id": 2,
+    "sections": [
+      {
+        "section_type": "ITEMS",
+        "line_ids": [
+          14,
+          15
+        ]
+      },
+      {
+        "section_type": "TOTAL_LINE",
+        "line_ids": [
+          17,
+          18
+        ]
+      }
+    ],
+    "line_items": [
+      {
+        "item_index": 0,
+        "name": "ORG A2/A2 6% FAT MLK",
+        "price": 7.99,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          14,
+          15
+        ],
+        "reconciliation_status": "no-baseline"
+      }
+    ],
+    "printed_subtotal": null,
+    "reconciliation_status": "no-baseline",
+    "should_reocr_items_zone": false
+  },
+  {
+    "image_id": "c2bb8fff-fc28-4c2d-ab98-13300c3b4c2e",
+    "receipt_id": 1,
+    "sections": [
+      {
+        "section_type": "ITEMS",
+        "line_ids": [
+          14,
+          16,
+          15,
+          17,
+          19,
+          20
+        ]
+      }
+    ],
+    "line_items": [
+      {
+        "item_index": 0,
+        "name": "SOUR CREAM",
+        "price": 2.79,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          19,
+          20
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 1,
+        "name": "BROCCOLI FLORETS",
+        "price": 3.49,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          15,
+          17
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 2,
+        "name": "1LB BAG BABY CARROT",
+        "price": 1.29,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          14,
+          16
+        ],
+        "reconciliation_status": "no-baseline"
+      }
+    ],
+    "printed_subtotal": null,
+    "reconciliation_status": "no-baseline",
+    "should_reocr_items_zone": false
+  },
+  {
+    "image_id": "c2c5aadf-58e8-4276-95ae-0f46039946da",
+    "receipt_id": 1,
+    "sections": [
+      {
+        "section_type": "ITEMS",
+        "line_ids": [
+          15,
+          18,
+          16,
+          19,
+          17,
+          20,
+          22,
+          23
+        ]
+      }
+    ],
+    "line_items": [
+      {
+        "item_index": 0,
+        "name": "LARGE ALFRESCO EGGS",
+        "price": 10.99,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          22,
+          23
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 1,
+        "name": "ORGANIC GREEN ONIONS",
+        "price": 1.29,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          17,
+          20
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 2,
+        "name": "ORG GINGER ROOT",
+        "price": 7.99,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          16,
+          19
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 3,
+        "name": "ORG 3 CNT GARLIC",
+        "price": 2.99,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          15,
+          18
+        ],
+        "reconciliation_status": "no-baseline"
+      }
+    ],
+    "printed_subtotal": null,
+    "reconciliation_status": "no-baseline",
+    "should_reocr_items_zone": false
+  },
+  {
+    "image_id": "5dcf582e-cdfe-40f8-89f4-53b1cf3fc893",
+    "receipt_id": 1,
+    "sections": [
+      {
+        "section_type": "ITEMS",
+        "line_ids": [
+          19,
+          8,
+          9,
+          10,
+          20,
+          21,
+          11,
+          12,
+          22,
+          23,
+          14,
+          15,
+          16,
+          17,
+          18,
+          24,
+          25,
+          26,
+          27
+        ]
+      },
+      {
+        "section_type": "SECTION_HEADER",
+        "line_ids": [
+          13
+        ]
+      }
+    ],
+    "line_items": [
+      {
+        "item_index": 0,
+        "name": "GUAVA NECTAR JUICE ORG 3",
+        "price": 3.99,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          18,
+          27
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 1,
+        "name": "MANGO NECTAR JUICE ORG 6",
+        "price": 5.49,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          17,
+          26
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 2,
+        "name": "MULTI-FLORAL AND CLOVER",
+        "price": 3.99,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          16,
+          25
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 3,
+        "name": "SUPER SPINACH SALAD",
+        "price": 4.49,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          15,
+          24
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 4,
+        "name": "",
+        "price": 8.98,
+        "quantity": 2.0,
+        "unit_price": 4.49,
+        "is_discount": false,
+        "name_quality": "low",
+        "line_ids": [
+          23
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 5,
+        "name": "SALAD CHICKEN APPLE WALD",
+        "price": 5.99,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          12,
+          22
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 6,
+        "name": "EGG BITES UNEXPECTED CHE",
+        "price": 7.58,
+        "quantity": 2.0,
+        "unit_price": 3.79,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          10,
+          21
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 7,
+        "name": "MILK QUART WHOLE",
+        "price": 1.79,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          9,
+          20
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 8,
+        "name": "HALF & HALF PINT",
+        "price": 1.99,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          8,
+          19
+        ],
+        "reconciliation_status": "no-baseline"
+      }
+    ],
+    "printed_subtotal": null,
+    "reconciliation_status": "no-baseline",
+    "should_reocr_items_zone": false
+  },
+  {
+    "image_id": "6d820865-13fd-4b9f-b2e0-6b81e6a2fff2",
+    "receipt_id": 1,
+    "sections": [
+      {
+        "section_type": "ITEMS",
+        "line_ids": [
+          7,
+          18,
+          19,
+          8,
+          20,
+          21,
+          9,
+          22,
+          23,
+          10,
+          24,
+          25,
+          27,
+          11,
+          26,
+          28,
+          12,
+          29,
+          30,
+          31,
+          13,
+          32
+        ]
+      },
+      {
+        "section_type": "SUMMARY",
+        "line_ids": [
+          14,
+          33
+        ]
+      },
+      {
+        "section_type": "TOTAL_LINE",
+        "line_ids": [
+          16,
+          34
+        ]
+      }
+    ],
+    "line_items": [
+      {
+        "item_index": 0,
+        "name": "203600096 GG WATER NF P",
+        "price": 3.59,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          13,
+          32
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 1,
+        "name": "210100025 GG BACON NF",
+        "price": 1.79,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          12,
+          29,
+          30,
+          31
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 2,
+        "name": "211350249 CUT FRUIT NF",
+        "price": 5.99,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          11,
+          26,
+          28
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 3,
+        "name": "266080008 BERRIES NF",
+        "price": 1.89,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          10,
+          24,
+          25,
+          27
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 4,
+        "name": "266080007 BERRIES NF",
+        "price": 6.99,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          9,
+          22,
+          23
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 5,
+        "name": "266085239 BERRIES NF",
+        "price": 5.69,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          8,
+          20,
+          21
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 6,
+        "name": "266087500 BERRIES NF",
+        "price": 6.79,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          7,
+          18,
+          19
+        ],
+        "reconciliation_status": "no-baseline"
+      }
+    ],
+    "printed_subtotal": null,
+    "reconciliation_status": "no-baseline",
+    "should_reocr_items_zone": false
+  },
+  {
+    "image_id": "7ca97b51-7369-4321-bd01-0211f2bf2557",
+    "receipt_id": 1,
+    "sections": [
+      {
+        "section_type": "SECTION_HEADER",
+        "line_ids": [
+          10
+        ]
+      },
+      {
+        "section_type": "TOTAL_LINE",
+        "line_ids": [
+          11,
+          16,
+          17
+        ]
+      }
+    ],
+    "line_items": [],
+    "printed_subtotal": null,
+    "reconciliation_status": "no-baseline",
+    "should_reocr_items_zone": false
+  },
+  {
+    "image_id": "1bfb07b7-aefd-4579-b721-df597471b96b",
+    "receipt_id": 1,
+    "sections": [
+      {
+        "section_type": "ITEMS",
+        "line_ids": [
+          11,
+          12,
+          13,
+          14,
+          15,
+          17,
+          18,
+          19,
+          20,
+          21,
+          22,
+          23,
+          24,
+          25,
+          26,
+          27,
+          30,
+          31,
+          32,
+          33,
+          34,
+          35,
+          36,
+          37,
+          38,
+          40,
+          41,
+          45,
+          46,
+          49,
+          50,
+          51,
+          52,
+          53,
+          54,
+          55,
+          56,
+          57,
+          58,
+          59,
+          60,
+          61,
+          62,
+          63,
+          64,
+          65,
+          66,
+          67,
+          68,
+          69,
+          70,
+          71,
+          72,
+          73,
+          74
+        ]
+      }
+    ],
+    "line_items": [
+      {
+        "item_index": 0,
+        "name": "Pro Xtra Preferred Pricing",
+        "price": -0.64,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": true,
+        "name_quality": "ok",
+        "line_ids": [
+          72,
+          73,
+          74
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 1,
+        "name": "1-5/8\" COARSE DRYWALL SCREW 5 LB",
+        "price": 25.98,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          68,
+          69,
+          70,
+          71
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 2,
+        "name": "1-5/8\" FINE DRYWALL SCREW 1 LB",
+        "price": 5.97,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          65,
+          66,
+          67
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 3,
+        "name": "Pro Xtra Preferred Pricing",
+        "price": -1.27,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": true,
+        "name_quality": "ok",
+        "line_ids": [
+          61,
+          62,
+          63,
+          64
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 4,
+        "name": "20LB QUIKRETE WATER-STOP CEMENT",
+        "price": 25.45,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          58,
+          59,
+          60
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 5,
+        "name": "Pro Xtra Preferred Pricing",
+        "price": -0.12,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": true,
+        "name_quality": "ok",
+        "line_ids": [
+          53,
+          54,
+          55,
+          56,
+          57
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 6,
+        "name": "------Pro Xtra Preferred Pricin",
+        "price": 15.94,
+        "quantity": 2.0,
+        "unit_price": 7.97,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          49,
+          50,
+          51,
+          52
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 7,
+        "name": "",
+        "price": 50.94,
+        "quantity": 3.0,
+        "unit_price": 16.98,
+        "is_discount": false,
+        "name_quality": "low",
+        "line_ids": [
+          45,
+          46
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 8,
+        "name": "820909095569 CAULK GUN =A>",
+        "price": 19.98,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          40,
+          41
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 9,
+        "name": "037083014143 TITEBOND3 16 <A>",
+        "price": 9.98,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          37,
+          38
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 10,
+        "name": "DYNAFLEX ULTRA 10.1 OZ BLACK ADVANCE",
+        "price": 17.56,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          34,
+          35,
+          36
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 11,
+        "name": "070798182202 D ULTRA 10.1 <A=",
+        "price": 31.02,
+        "quantity": 2.0,
+        "unit_price": 15.51,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          30,
+          31,
+          32,
+          33
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 12,
+        "name": "5/8INX10FT L-METAL TRIM",
+        "price": 22.86,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          25,
+          26,
+          27
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 13,
+        "name": "2 1/2IN X 10FT STEEL TRACK 25 GA",
+        "price": 45.84,
+        "quantity": 3.0,
+        "unit_price": 15.28,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          21,
+          22,
+          23,
+          24
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 14,
+        "name": "751361004144 10'-25GA STD <A=",
+        "price": 14.98,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          17,
+          18,
+          19,
+          20
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 15,
+        "name": "000516315018 JT COMPOUND <A>",
+        "price": 12.52,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          14,
+          15
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 16,
+        "name": "HW RED DOT ALL PURP JC BOX 3.5 GAL",
+        "price": 29.22,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          11,
+          12,
+          13
+        ],
+        "reconciliation_status": "no-baseline"
+      }
+    ],
+    "printed_subtotal": null,
+    "reconciliation_status": "no-baseline",
+    "should_reocr_items_zone": false
+  },
+  {
+    "image_id": "879b0fa6-c951-461b-a937-1bee74190b0a",
+    "receipt_id": 2,
+    "sections": [
+      {
+        "section_type": "ITEMS",
+        "line_ids": [
+          8,
+          9,
+          10,
+          11,
+          12,
+          14,
+          15,
+          17,
+          19,
+          20,
+          21,
+          22,
+          23,
+          24,
+          25,
+          26,
+          27,
+          28,
+          29,
+          30,
+          31,
+          32,
+          33,
+          34,
+          35,
+          36,
+          37,
+          39,
+          38,
+          40,
+          41,
+          42,
+          43,
+          44,
+          45,
+          46,
+          47,
+          49,
+          48,
+          50,
+          51,
+          52,
+          53,
+          54,
+          55,
+          56,
+          57,
+          58,
+          59,
+          60,
+          61,
+          62,
+          63,
+          64,
+          65,
+          66,
+          67,
+          69,
+          68,
+          70,
+          71,
+          86
+        ]
+      },
+      {
+        "section_type": "SECTION_HEADER",
+        "line_ids": [
+          16,
+          18
+        ]
+      }
+    ],
+    "line_items": [
+      {
+        "item_index": 0,
+        "name": "Pro Xtra Preferred Pricing",
+        "price": -0.6,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": true,
+        "name_quality": "ok",
+        "line_ids": [
+          70,
+          71,
+          86
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 1,
+        "name": "MAX REFUND VALUE",
+        "price": 7.342,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          68
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 2,
+        "name": "3/4\" COP EL 45 DEG CXC",
+        "price": 7.72,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          66,
+          67,
+          69
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 3,
+        "name": "MAX REFUND VALUE",
+        "price": 4.002,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          64,
+          65
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 4,
+        "name": "1/2\" COP EL 45 DEG CXC",
+        "price": 4.22,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          61,
+          62,
+          63
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 5,
+        "name": "Pro Xtra Preferred Pricing",
+        "price": -0.53,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": true,
+        "name_quality": "ok",
+        "line_ids": [
+          56,
+          57,
+          58,
+          59,
+          60
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 6,
+        "name": "MKE MX4 SDS+ 5/8\" X 8\" DRILL BIT",
+        "price": 17.77,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          53,
+          54,
+          55
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 7,
+        "name": "Pro Xtra Preferred Pricing",
+        "price": -0.9,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": true,
+        "name_quality": "ok",
+        "line_ids": [
+          50,
+          51,
+          52
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 8,
+        "name": "MAX REFUND VALUE",
+        "price": 44.013,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          48
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 9,
+        "name": "VERSABOND BONDING MORTAR-WHITE 50LB",
+        "price": 44.91,
+        "quantity": 3.0,
+        "unit_price": 14.97,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          45,
+          46,
+          47,
+          49
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 10,
+        "name": "Pro Xtra Preferred Pricing",
+        "price": -0.82,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": true,
+        "name_quality": "ok",
+        "line_ids": [
+          40,
+          41,
+          42,
+          43,
+          44
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 11,
+        "name": "1X5-8FT PRIMED FJ S4S BOARD",
+        "price": 10.97,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          37,
+          38,
+          39
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 12,
+        "name": "MAX REFUND VALUE",
+        "price": 29.305,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          36
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 13,
+        "name": ". 719IN X 1.5IN X 96IN PRMD FJ BOARD",
+        "price": 29.9,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          32,
+          33,
+          34,
+          35
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 14,
+        "name": "000516311010 LT COMPOUND <A>",
+        "price": 14.61,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          28,
+          29,
+          30,
+          31
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 15,
+        "name": "CARLON NEW WORK 3G 49CU ADJUSTABLE",
+        "price": 13.4,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          25,
+          26,
+          27
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 16,
+        "name": "000516221654 20 FAST SET <A>",
+        "price": 15.51,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          21,
+          22,
+          23,
+          24
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 17,
+        "name": "0.25N",
+        "price": 0.0,
+        "quantity": 5.0,
+        "unit_price": 0.05,
+        "is_discount": false,
+        "name_quality": "low",
+        "line_ids": [
+          19,
+          20
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 18,
+        "name": "0.750INX23. 75INX97IN WHT MEL",
+        "price": 38.97,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          8,
+          9,
+          10
+        ],
+        "reconciliation_status": "no-baseline"
+      }
+    ],
+    "printed_subtotal": null,
+    "reconciliation_status": "no-baseline",
+    "should_reocr_items_zone": false
+  },
+  {
+    "image_id": "ccfbeaca-6f40-4e9f-ba5e-6a30a643f0aa",
+    "receipt_id": 1,
+    "sections": [
+      {
+        "section_type": "ITEMS",
+        "line_ids": [
+          10,
+          11,
+          12,
+          13,
+          14,
+          15,
+          16,
+          17,
+          18,
+          20,
+          23,
+          21,
+          22,
+          24,
+          28,
+          29,
+          30,
+          31,
+          32,
+          33,
+          34,
+          35,
+          36,
+          37,
+          38,
+          39,
+          40,
+          41,
+          42,
+          43,
+          44,
+          45,
+          46,
+          47,
+          48,
+          49,
+          50,
+          51,
+          52,
+          53,
+          54,
+          55,
+          56,
+          57,
+          58,
+          60,
+          63,
+          64,
+          65,
+          66,
+          67,
+          68,
+          71,
+          72,
+          73,
+          74,
+          75,
+          76,
+          77,
+          78,
+          79,
+          80,
+          81,
+          82,
+          83,
+          84,
+          85,
+          86,
+          87,
+          88,
+          89,
+          90,
+          91,
+          92,
+          94,
+          95,
+          96,
+          97,
+          98,
+          99,
+          100,
+          101,
+          102,
+          103,
+          104,
+          105,
+          106,
+          107,
+          108,
+          109,
+          110,
+          111,
+          112,
+          113,
+          114,
+          115,
+          116,
+          117,
+          118,
+          122,
+          124
+        ]
+      },
+      {
+        "section_type": "PAYMENT",
+        "line_ids": [
+          61,
+          62,
+          69,
+          70,
+          119,
+          120,
+          123,
+          121,
+          125,
+          126
+        ]
+      },
+      {
+        "section_type": "SECTION_HEADER",
+        "line_ids": [
+          19,
+          25,
+          59
+        ]
+      }
+    ],
+    "line_items": [
+      {
+        "item_index": 0,
+        "name": "Pricing",
+        "price": -0.26,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": true,
+        "name_quality": "ok",
+        "line_ids": [
+          122,
+          124
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 1,
+        "name": "Pro Xtra Preferred Pricing",
+        "price": -0.54,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": true,
+        "name_quality": "ok",
+        "line_ids": [
+          115,
+          116,
+          117,
+          118
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 2,
+        "name": "077089375060 6X3/4 IN MIN =A=",
+        "price": 6.37,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          111,
+          112,
+          113,
+          114
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 3,
+        "name": "BETTER 6 X 3/8 IN KNIT MINI GPK",
+        "price": 11.54,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          108,
+          109,
+          110
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 4,
+        "name": "DW Backwall BOGO",
+        "price": -199.0,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": true,
+        "name_quality": "ok",
+        "line_ids": [
+          104,
+          105,
+          106,
+          107
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 5,
+        "name": "885911677202 20-VOLT MAX <A>",
+        "price": 199.0,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          100,
+          101,
+          102,
+          103
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 6,
+        "name": "885911881135 20-VOLT MAX <A,S\u00bb",
+        "price": 299.0,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          97,
+          98,
+          99
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 7,
+        "name": "Pro Xtra Preferred Pricing",
+        "price": -1.96,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": true,
+        "name_quality": "ok",
+        "line_ids": [
+          95,
+          96
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 8,
+        "name": "1X5-8FT PRIMED FJ S4S BOARD",
+        "price": 21.94,
+        "quantity": 2.0,
+        "unit_price": 10.97,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          91,
+          92,
+          94
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 9,
+        "name": "MAX REFUND VALUE",
+        "price": 72.328,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          89,
+          90
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 10,
+        "name": "719IN X 3.5IN X 96IN PRMD FJ",
+        "price": 73.84,
+        "quantity": 8.0,
+        "unit_price": 9.23,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          86,
+          87,
+          88
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 11,
+        "name": "Pro Xtra Preferred Pricing",
+        "price": -7.89,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": true,
+        "name_quality": "ok",
+        "line_ids": [
+          81,
+          82,
+          83,
+          84,
+          85
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 12,
+        "name": "052063061313 9 IN. DOWN S <A*",
+        "price": 44.97,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          77,
+          78,
+          79,
+          80
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 13,
+        "name": "052063059891 DOWNSPT ADPT <A>",
+        "price": 4.74,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          74,
+          75,
+          76
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 14,
+        "name": "MAX REFUND VALUE",
+        "price": 10.222,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          73
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 15,
+        "name": "",
+        "price": 10.54,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "low",
+        "line_ids": [
+          71,
+          72
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 16,
+        "name": "MAX REFUND VALUE",
+        "price": 27.606,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          68
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 17,
+        "name": "3\" SEWER/DRAIN EL 45D D3034 PVC",
+        "price": 28.44,
+        "quantity": 6.0,
+        "unit_price": 4.74,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          64,
+          65,
+          66,
+          67
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 18,
+        "name": "052063402482 CHL COUPLG <A>",
+        "price": 5.47,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          57,
+          58,
+          60,
+          63
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 19,
+        "name": "Pro Xtra Preferred Pricing",
+        "price": -0.27,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": true,
+        "name_quality": "ok",
+        "line_ids": [
+          52,
+          53,
+          54,
+          55,
+          56
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 20,
+        "name": "887480310610 MACH SCR <A>",
+        "price": 1.38,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          46,
+          47,
+          48,
+          49,
+          50,
+          51
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 21,
+        "name": "811108037139 ASSORTED (YE <A>",
+        "price": 14.48,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          42,
+          43,
+          44,
+          45
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 22,
+        "name": "BEHR MULTI-PURP CAULK 10.1 OZ WHITE",
+        "price": 13.44,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          39,
+          40,
+          41
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 23,
+        "name": "047034115737 5 GA STR <A>",
+        "price": 4.27,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          35,
+          36,
+          37,
+          38
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 24,
+        "name": "NLP Savings",
+        "price": 0.5,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": true,
+        "name_quality": "ok",
+        "line_ids": [
+          33,
+          34
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 25,
+        "name": "084305355546 HOMER BUCKET <A>",
+        "price": 3.98,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          30,
+          31,
+          32
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 26,
+        "name": "NLP Savings",
+        "price": 0.0,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": true,
+        "name_quality": "ok",
+        "line_ids": [
+          28,
+          29
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 27,
+        "name": "NLP Savings",
+        "price": 0.0,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": true,
+        "name_quality": "ok",
+        "line_ids": [
+          21,
+          22,
+          24
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 28,
+        "name": "0.20N",
+        "price": 200.1,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "low",
+        "line_ids": [
+          20,
+          23
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 29,
+        "name": "TRIM 31 IN CARDBOARD PAINT SHIELD",
+        "price": 1.96,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          15,
+          16,
+          17,
+          18
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 30,
+        "name": "885911724890 20-VOLT MAX =A , Sa",
+        "price": 299.0,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          10,
+          11,
+          12,
+          13,
+          14
+        ],
+        "reconciliation_status": "no-baseline"
+      }
+    ],
+    "printed_subtotal": null,
+    "reconciliation_status": "no-baseline",
+    "should_reocr_items_zone": false
+  },
+  {
+    "image_id": "291cfd80-5b29-428e-b650-5e4505c4cbd7",
+    "receipt_id": 2,
+    "sections": [
+      {
+        "section_type": "ITEMS",
+        "line_ids": [
+          13,
+          16,
+          23,
+          17,
+          14,
+          18,
+          24,
+          19,
+          20
+        ]
+      },
+      {
+        "section_type": "PAYMENT",
+        "line_ids": [
+          15,
+          21,
+          25,
+          22
+        ]
+      }
+    ],
+    "line_items": [
+      {
+        "item_index": 0,
+        "name": "Uitimate Egg",
+        "price": 12.75,
+        "quantity": 1.0,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          14,
+          18,
+          19,
+          20,
+          24
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 1,
+        "name": "ABC Burger[Beel!",
+        "price": 13.25,
+        "quantity": 1.0,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          13,
+          16,
+          17,
+          23
+        ],
+        "reconciliation_status": "no-baseline"
+      }
+    ],
+    "printed_subtotal": null,
+    "reconciliation_status": "no-baseline",
+    "should_reocr_items_zone": false
+  },
+  {
+    "image_id": "84bf7d03-b76f-419a-8579-cdea86fbb374",
+    "receipt_id": 1,
+    "sections": [
+      {
+        "section_type": "ITEMS",
+        "line_ids": [
+          19,
+          9,
+          20,
+          10,
+          11,
+          12,
+          21,
+          22,
+          23,
+          13,
+          24
+        ]
+      },
+      {
+        "section_type": "TOTAL_LINE",
+        "line_ids": [
+          14,
+          15,
+          25
+        ]
+      }
+    ],
+    "line_items": [
+      {
+        "item_index": 0,
+        "name": "",
+        "price": 4.49,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "low",
+        "line_ids": [
+          24
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 1,
+        "name": "SPICY SPUDS",
+        "price": 4.49,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          13,
+          23
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 2,
+        "name": "R-ARUGULA LEMON BASIL CO",
+        "price": 3.99,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          12,
+          22
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 3,
+        "name": "BEANS GREEN ORGANIC 1LB",
+        "price": 3.29,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          11,
+          21
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 4,
+        "name": "CHICKEN GYOZA",
+        "price": 3.99,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          10,
+          20
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 5,
+        "name": "CHICKEN GYOZA",
+        "price": 3.99,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          9,
+          19
+        ],
+        "reconciliation_status": "no-baseline"
+      }
+    ],
+    "printed_subtotal": null,
+    "reconciliation_status": "no-baseline",
+    "should_reocr_items_zone": false
+  },
+  {
+    "image_id": "01024cab-3c61-4aac-b1ec-e9ce56947fe3",
+    "receipt_id": 2,
+    "sections": [
+      {
+        "section_type": "ITEMS",
+        "line_ids": [
+          11,
+          12,
+          15,
+          13,
+          16
+        ]
+      },
+      {
+        "section_type": "SECTION_HEADER",
+        "line_ids": [
+          14
+        ]
+      },
+      {
+        "section_type": "TOTAL_LINE",
+        "line_ids": [
+          17
+        ]
+      }
+    ],
+    "line_items": [
+      {
+        "item_index": 0,
+        "name": "12 Naked Wings",
+        "price": 18.49,
+        "quantity": 12.0,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          12,
+          13,
+          16
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 1,
+        "name": "Water (2",
+        "price": 0.0,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          11,
+          15
+        ],
+        "reconciliation_status": "no-baseline"
+      }
+    ],
+    "printed_subtotal": null,
+    "reconciliation_status": "no-baseline",
+    "should_reocr_items_zone": false
+  },
+  {
+    "image_id": "6f2f1d08-af1e-4716-a26c-dea4c065ab62",
+    "receipt_id": 2,
+    "sections": [
+      {
+        "section_type": "ITEMS",
+        "line_ids": [
+          12
+        ]
+      }
+    ],
+    "line_items": [
+      {
+        "item_index": 0,
+        "name": "79936653722 AMAZON",
+        "price": 50.0,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          12
+        ],
+        "reconciliation_status": "no-baseline"
+      }
+    ],
+    "printed_subtotal": null,
+    "reconciliation_status": "no-baseline",
+    "should_reocr_items_zone": false
+  },
+  {
+    "image_id": "78e5a740-8f66-495c-b4d3-2e1c40498995",
+    "receipt_id": 1,
+    "sections": [
+      {
+        "section_type": "ITEMS",
+        "line_ids": [
+          9,
+          10,
+          14,
+          16
+        ]
+      }
+    ],
+    "line_items": [
+      {
+        "item_index": 0,
+        "name": "1258700020 GLAD CLING WRAP",
+        "price": 6.99,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          9,
+          10,
+          14,
+          16
+        ],
+        "reconciliation_status": "no-baseline"
+      }
+    ],
+    "printed_subtotal": null,
+    "reconciliation_status": "no-baseline",
+    "should_reocr_items_zone": false
+  },
+  {
+    "image_id": "758cbedf-f1dd-4466-98ec-faf86e82d422",
+    "receipt_id": 2,
+    "sections": [
+      {
+        "section_type": "ITEMS",
+        "line_ids": [
+          16,
+          19,
+          20,
+          17,
+          23,
+          25,
+          26,
+          18,
+          24,
+          27,
+          28
+        ]
+      },
+      {
+        "section_type": "SECTION_HEADER",
+        "line_ids": [
+          15
+        ]
+      },
+      {
+        "section_type": "TOTAL_LINE",
+        "line_ids": [
+          11,
+          12,
+          13,
+          14
+        ]
+      }
+    ],
+    "line_items": [
+      {
+        "item_index": 0,
+        "name": "6164 1",
+        "price": 6.98,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "low",
+        "line_ids": [
+          18,
+          24,
+          27,
+          28
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 1,
+        "name": "6164 1",
+        "price": 6.98,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "low",
+        "line_ids": [
+          17,
+          23,
+          25,
+          26
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 2,
+        "name": "6164",
+        "price": 6.98,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "low",
+        "line_ids": [
+          16,
+          19,
+          20
+        ],
+        "reconciliation_status": "no-baseline"
+      }
+    ],
+    "printed_subtotal": null,
+    "reconciliation_status": "no-baseline",
+    "should_reocr_items_zone": false
+  },
+  {
+    "image_id": "9ed1103e-0b4e-4089-8fa4-6f29b6dc198b",
+    "receipt_id": 1,
+    "sections": [
+      {
+        "section_type": "ITEMS",
+        "line_ids": [
+          15,
+          16,
+          38,
+          51,
+          17,
+          18,
+          19,
+          20,
+          40,
+          52,
+          22,
+          23,
+          41,
+          53,
+          24,
+          25,
+          26,
+          42,
+          54,
+          27,
+          28,
+          31,
+          43,
+          55,
+          29,
+          30,
+          32,
+          44,
+          56,
+          33,
+          34,
+          45,
+          57,
+          35,
+          36,
+          37,
+          46,
+          58
+        ]
+      },
+      {
+        "section_type": "SECTION_HEADER",
+        "line_ids": [
+          21
+        ]
+      }
+    ],
+    "line_items": [
+      {
+        "item_index": 0,
+        "name": "6164 1",
+        "price": 6.98,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "low",
+        "line_ids": [
+          36,
+          37,
+          46,
+          58
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 1,
+        "name": "Hot Smoked Salmon Pepper",
+        "price": 6.98,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          34,
+          35,
+          45,
+          57
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 2,
+        "name": "Hot Smoked Salmon Classic",
+        "price": 6.98,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          30,
+          32,
+          33,
+          44,
+          56
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 3,
+        "name": "Hot Smoked Salmon Classic",
+        "price": 6.98,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          28,
+          29,
+          31,
+          43,
+          55
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 4,
+        "name": "Avocado Mash 8oz Tray",
+        "price": 3.97,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          25,
+          26,
+          27,
+          42,
+          54
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 5,
+        "name": "Avocado Mash 8oz Tray",
+        "price": 3.97,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          22,
+          23,
+          24,
+          41,
+          53
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 6,
+        "name": "8105 1",
+        "price": 7.98,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "low",
+        "line_ids": [
+          19,
+          20,
+          40,
+          52
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 7,
+        "name": "Lobster Mac and Cheese 2c",
+        "price": 18.98,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          15,
+          16,
+          17,
+          18,
+          38,
+          51
+        ],
+        "reconciliation_status": "no-baseline"
+      }
+    ],
+    "printed_subtotal": null,
+    "reconciliation_status": "no-baseline",
+    "should_reocr_items_zone": false
+  },
+  {
+    "image_id": "fb588a3b-49ab-4ee7-accd-f1953b7378c3",
+    "receipt_id": 2,
+    "sections": [
+      {
+        "section_type": "ITEMS",
+        "line_ids": [
+          12,
+          13,
+          33,
+          15,
+          22,
+          23,
+          34,
+          17,
+          24,
+          25,
+          35,
+          19,
+          26,
+          27,
+          36,
+          21,
+          28,
+          37
+        ]
+      },
+      {
+        "section_type": "PAYMENT",
+        "line_ids": [
+          29
+        ]
+      },
+      {
+        "section_type": "SECTION_HEADER",
+        "line_ids": [
+          14
+        ]
+      }
+    ],
+    "line_items": [
+      {
+        "item_index": 0,
+        "name": "8129",
+        "price": 14.98,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "low",
+        "line_ids": [
+          21,
+          28,
+          37
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 1,
+        "name": "8129 1",
+        "price": 14.98,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "low",
+        "line_ids": [
+          19,
+          26,
+          27,
+          36
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 2,
+        "name": "6255 1",
+        "price": 44.98,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "low",
+        "line_ids": [
+          17,
+          24,
+          25,
+          35
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 3,
+        "name": "Item Qty Price Total",
+        "price": 44.98,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          12,
+          13,
+          15,
+          22,
+          23,
+          33,
+          34
+        ],
+        "reconciliation_status": "no-baseline"
+      }
+    ],
+    "printed_subtotal": null,
+    "reconciliation_status": "no-baseline",
+    "should_reocr_items_zone": false
+  },
+  {
+    "image_id": "a7fef2ca-b84d-5405-a0f5-cbefe598a2dc",
+    "receipt_id": 1,
+    "sections": [
+      {
+        "section_type": "ADDRESS",
+        "line_ids": [
+          5
+        ]
+      },
+      {
+        "section_type": "ITEMS",
+        "line_ids": [
+          6,
+          7
+        ]
+      },
+      {
+        "section_type": "TOTAL_LINE",
+        "line_ids": [
+          8,
+          9
+        ]
+      }
+    ],
+    "line_items": [
+      {
+        "item_index": 0,
+        "name": "HOT BAR",
+        "price": 10.55,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          6,
+          7
+        ],
+        "reconciliation_status": "no-baseline"
+      }
+    ],
+    "printed_subtotal": null,
+    "reconciliation_status": "no-baseline",
+    "should_reocr_items_zone": false
+  },
+  {
+    "image_id": "0951426f-b7f9-5435-8569-7319cf0db1f4",
+    "receipt_id": 1,
+    "sections": [],
+    "line_items": [],
+    "printed_subtotal": null,
+    "reconciliation_status": "no-baseline",
+    "should_reocr_items_zone": false
+  },
+  {
+    "image_id": "cf8e3a6e-0947-4a3d-9bc0-7ce3894c9912",
+    "receipt_id": 1,
+    "sections": [
+      {
+        "section_type": "ITEMS",
+        "line_ids": [
+          37,
+          63,
+          88,
+          38,
+          39,
+          64,
+          89,
+          40,
+          65,
+          90,
+          41,
+          66,
+          91,
+          43,
+          67,
+          92,
+          44,
+          68,
+          93,
+          45,
+          46,
+          69,
+          94,
+          50,
+          70,
+          95,
+          51,
+          52,
+          71,
+          53,
+          54,
+          55,
+          72,
+          96,
+          57,
+          73,
+          97,
+          58,
+          74,
+          98,
+          59,
+          75,
+          99
+        ]
+      },
+      {
+        "section_type": "SUMMARY",
+        "line_ids": [
+          42
+        ]
+      },
+      {
+        "section_type": "TOTAL_LINE",
+        "line_ids": [
+          61,
+          76,
+          100
+        ]
+      }
+    ],
+    "line_items": [
+      {
+        "item_index": 0,
+        "name": "ORGANIC SOUR CREAM",
+        "price": 3.29,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          59,
+          75,
+          99
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 1,
+        "name": "ORG LRG GRADE EGGS",
+        "price": 11.99,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          58,
+          74,
+          98
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 2,
+        "name": "ORG A2/A2 6% FAT MLK",
+        "price": 7.99,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          57,
+          73,
+          97
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 3,
+        "name": "KOREAN BBQ SAUCE",
+        "price": 6.99,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          55,
+          72,
+          96
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 4,
+        "name": "*CRV FS 05",
+        "price": 0.1,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          52,
+          71
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 5,
+        "name": "100% COCONUT H20 WIT",
+        "price": 4.0,
+        "quantity": 2.0,
+        "unit_price": 2.0,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          50,
+          70,
+          95
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 6,
+        "name": "WHITE ONIONS",
+        "price": 1.59,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          46,
+          69,
+          94
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 7,
+        "name": "RED BELL PEPPERS",
+        "price": 3.0,
+        "quantity": 2.0,
+        "unit_price": 1.5,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          44,
+          68,
+          93
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 8,
+        "name": "ORGANIC GREEN ONIONS",
+        "price": 1.29,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          43,
+          67,
+          92
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 9,
+        "name": "ORG SLICED CRIMINI",
+        "price": 6.98,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          41,
+          66,
+          91
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 10,
+        "name": "ORG GINGER ROOT",
+        "price": 7.99,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          40,
+          65,
+          90
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 11,
+        "name": "ORG 2 LB CARROTS",
+        "price": 2.79,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          39,
+          64,
+          89
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 12,
+        "name": "JALAPENO PEPPERS",
+        "price": 1.0,
+        "quantity": 4.0,
+        "unit_price": 0.25,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          37,
+          63,
+          88
+        ],
+        "reconciliation_status": "no-baseline"
+      }
+    ],
+    "printed_subtotal": null,
+    "reconciliation_status": "no-baseline",
+    "should_reocr_items_zone": false
+  },
+  {
+    "image_id": "4d0bdfd5-4d5f-4c01-8f20-7f21090ab361",
+    "receipt_id": 2,
+    "sections": [
+      {
+        "section_type": "ITEMS",
+        "line_ids": [
+          35,
+          51,
+          36,
+          52,
+          37,
+          53,
+          38,
+          39,
+          54,
+          41,
+          55,
+          43,
+          56,
+          45,
+          57
+        ]
+      },
+      {
+        "section_type": "SUMMARY",
+        "line_ids": [
+          47,
+          59
+        ]
+      },
+      {
+        "section_type": "TOTAL_LINE",
+        "line_ids": [
+          46,
+          58,
+          50,
+          62
+        ]
+      }
+    ],
+    "line_items": [
+      {
+        "item_index": 0,
+        "name": "BRIOCHE BURGER BUNS",
+        "price": 6.99,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          45,
+          57
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 1,
+        "name": "RAW MILK",
+        "price": 6.99,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          43,
+          56
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 2,
+        "name": "SWEET CHILI SAUCE",
+        "price": 3.99,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          41,
+          55
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 3,
+        "name": "SEEDLESS LEMONS BAG",
+        "price": 4.99,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          39,
+          54
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 4,
+        "name": "ORGANIC GREEN ONIONS",
+        "price": 1.5,
+        "quantity": 1.0,
+        "unit_price": 1.5,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          37,
+          53
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 5,
+        "name": "ORG GINGER ROOT",
+        "price": 7.99,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          36,
+          52
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 6,
+        "name": "CRISPY ONIONS",
+        "price": 2.49,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          35,
+          51
+        ],
+        "reconciliation_status": "no-baseline"
+      }
+    ],
+    "printed_subtotal": null,
+    "reconciliation_status": "no-baseline",
+    "should_reocr_items_zone": false
+  },
+  {
+    "image_id": "f1844265-90f3-4c5c-81a0-5944f1c6fe9a",
+    "receipt_id": 1,
+    "sections": [
+      {
+        "section_type": "ITEMS",
+        "line_ids": [
+          8,
+          9,
+          11,
+          12,
+          10,
+          28,
+          29,
+          30,
+          31,
+          32,
+          13,
+          14,
+          33,
+          15,
+          16,
+          17,
+          34,
+          35,
+          18,
+          19,
+          36,
+          20,
+          37,
+          21
+        ]
+      },
+      {
+        "section_type": "SUMMARY",
+        "line_ids": [
+          22
+        ]
+      },
+      {
+        "section_type": "TOTAL_LINE",
+        "line_ids": [
+          24,
+          39
+        ]
+      }
+    ],
+    "line_items": [
+      {
+        "item_index": 0,
+        "name": "LEMON EACH",
+        "price": 0.98,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          21,
+          37
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 1,
+        "name": "A-AVOCADO HASS LARGE EAC",
+        "price": 7.16,
+        "quantity": 4.0,
+        "unit_price": 1.79,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          19,
+          36
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 2,
+        "name": "POTATO SWEET EACH",
+        "price": 1.98,
+        "quantity": 2.0,
+        "unit_price": 0.99,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          17,
+          35
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 3,
+        "name": "TUNA SOLID WHITE ALBACOR",
+        "price": 1.99,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          16,
+          34
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 4,
+        "name": "TUNA SOLID WHITE ALBACOR",
+        "price": 3.98,
+        "quantity": 2.0,
+        "unit_price": 1.99,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          14,
+          33
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 5,
+        "name": "SALSA AUTENTICA",
+        "price": 2.29,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          13,
+          32
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 6,
+        "name": "SALMON FILLET SKIN ON",
+        "price": 6.69,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          12,
+          31
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 7,
+        "name": "SALMON FILLET SKIN ON",
+        "price": 9.39,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          11,
+          30
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 8,
+        "name": "MANGO NECTAR JUICE ORG 6",
+        "price": 5.49,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          9,
+          10,
+          29
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 9,
+        "name": "ORG KOSHER DILL PICKLE S",
+        "price": 3.99,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          8,
+          28
+        ],
+        "reconciliation_status": "no-baseline"
+      }
+    ],
+    "printed_subtotal": null,
+    "reconciliation_status": "no-baseline",
+    "should_reocr_items_zone": false
+  },
+  {
+    "image_id": "b4c2a475-d739-4a42-afbf-6b5e06443ba1",
+    "receipt_id": 1,
+    "sections": [
+      {
+        "section_type": "FOOTER",
+        "line_ids": [
+          51
+        ]
+      },
+      {
+        "section_type": "ITEMS",
+        "line_ids": [
+          8,
+          9,
+          10,
+          26,
+          11,
+          12,
+          13,
+          14,
+          15,
+          27,
+          16,
+          17,
+          18,
+          28,
+          19,
+          20,
+          21,
+          29,
+          31,
+          22,
+          23,
+          24,
+          30,
+          32,
+          25
+        ]
+      },
+      {
+        "section_type": "SURVEY",
+        "line_ids": [
+          52
+        ]
+      }
+    ],
+    "line_items": [
+      {
+        "item_index": 0,
+        "name": "Blueberries, 1 Pint now",
+        "price": 2.39,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          23,
+          24,
+          30,
+          32
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 1,
+        "name": "365 Everyday Value, Orgar.. now",
+        "price": 2.09,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          20,
+          21,
+          29,
+          31
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 2,
+        "name": "Amazon Fresh Brand, Stopl. now",
+        "price": 3.78,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          17,
+          18,
+          28
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 3,
+        "name": "Amazon Fresh, Greek Nonfa.. not",
+        "price": 1.89,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          13,
+          14,
+          15,
+          27
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 4,
+        "name": "Amazon Fresh, Small Curd nOW",
+        "price": 950.93,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          8,
+          9,
+          10,
+          26
+        ],
+        "reconciliation_status": "no-baseline"
+      }
+    ],
+    "printed_subtotal": null,
+    "reconciliation_status": "no-baseline",
+    "should_reocr_items_zone": false
+  },
+  {
+    "image_id": "63243f38-61e2-4079-9c08-490825a7aff7",
+    "receipt_id": 2,
+    "sections": [
+      {
+        "section_type": "ITEMS",
+        "line_ids": [
+          34,
+          47,
+          69,
+          36,
+          48,
+          70,
+          37,
+          49,
+          38,
+          50,
+          71,
+          39,
+          51,
+          72,
+          41,
+          52,
+          42,
+          53,
+          43,
+          54,
+          45,
+          55,
+          73
+        ]
+      },
+      {
+        "section_type": "SUMMARY",
+        "line_ids": [
+          46
+        ]
+      }
+    ],
+    "line_items": [
+      {
+        "item_index": 0,
+        "name": "ROLLED OATS",
+        "price": 7.0,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          45,
+          55,
+          73
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 1,
+        "name": "SPROUTS LRG EGGS",
+        "price": 3.99,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          43,
+          54
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 2,
+        "name": "ORG A2/A2 6% FAT MLK",
+        "price": 7.99,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          42,
+          53
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 3,
+        "name": "HEAVY WHIPPING CREAM",
+        "price": 4.29,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          41,
+          52
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 4,
+        "name": "PENNE RIGATE PASTA",
+        "price": 3.99,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          39,
+          51,
+          72
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 5,
+        "name": "BOGO 50% OFF GROC",
+        "price": -2.0,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": true,
+        "name_quality": "ok",
+        "line_ids": [
+          37,
+          49
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 6,
+        "name": "PENNE RIGATE PAST",
+        "price": 3.99,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          36,
+          48,
+          70
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 7,
+        "name": "ORGANIC SHALLOTS",
+        "price": 3.49,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          34,
+          47,
+          69
+        ],
+        "reconciliation_status": "no-baseline"
+      }
+    ],
+    "printed_subtotal": null,
+    "reconciliation_status": "no-baseline",
+    "should_reocr_items_zone": false
+  },
+  {
+    "image_id": "8d089201-9f33-42ec-bad8-a2482777c958",
+    "receipt_id": 1,
+    "sections": [
+      {
+        "section_type": "ITEMS",
+        "line_ids": [
+          35,
+          36,
+          40,
+          41,
+          37,
+          38,
+          39,
+          42,
+          45,
+          49,
+          50,
+          48,
+          51,
+          53,
+          54,
+          66,
+          55,
+          56,
+          57,
+          67,
+          68,
+          58,
+          59,
+          60,
+          69,
+          61,
+          70,
+          62,
+          63,
+          71,
+          72,
+          64,
+          65,
+          73
+        ]
+      },
+      {
+        "section_type": "SECTION_HEADER",
+        "line_ids": [
+          46
+        ]
+      }
+    ],
+    "line_items": [
+      {
+        "item_index": 0,
+        "name": "SHALLOTS",
+        "price": 0.84,
+        "quantity": 0.21,
+        "unit_price": 3.99,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          63,
+          71,
+          72
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 1,
+        "name": "GARLIC-BULK",
+        "price": 2.24,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          60,
+          69
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 2,
+        "name": "ITAL PARSLEY ORG",
+        "price": 2.0,
+        "quantity": 1.0,
+        "unit_price": 2.0,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          57,
+          67,
+          68
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 3,
+        "name": "POTATO-RUSSET",
+        "price": 9.74,
+        "quantity": 3.91,
+        "unit_price": 2.49,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          54,
+          66
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 4,
+        "name": "BAG SALE PAPER EA",
+        "price": 0.1,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          48,
+          51
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 5,
+        "name": "GELSON'S EGGS",
+        "price": 4.99,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          45,
+          49,
+          50
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 6,
+        "name": "CRUSHED TOMATOES",
+        "price": 5.99,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          39,
+          42
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 7,
+        "name": "PENNE RIGATE #41",
+        "price": 3.5,
+        "quantity": 1.0,
+        "unit_price": 3.5,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          36,
+          40,
+          41
+        ],
+        "reconciliation_status": "no-baseline"
+      }
+    ],
+    "printed_subtotal": null,
+    "reconciliation_status": "no-baseline",
+    "should_reocr_items_zone": false
+  }
+]

--- a/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/Fixtures/swift_single_pass_contract.json
+++ b/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/Fixtures/swift_single_pass_contract.json
@@ -889,6 +889,57 @@
           "confidence": 0.9
         }
       ],
+      "sections": [
+        {
+          "section_type": "ITEMS",
+          "line_ids": [
+            3
+          ],
+          "row_ids": [
+            3
+          ],
+          "confidence": 0.9999816459913875,
+          "model_source": "swift-worker-v1"
+        },
+        {
+          "section_type": "STOREFRONT",
+          "line_ids": [
+            1
+          ],
+          "row_ids": [
+            1
+          ],
+          "confidence": 0.9068789909517392,
+          "model_source": "swift-worker-v1"
+        },
+        {
+          "section_type": "TOTAL_LINE",
+          "line_ids": [
+            4
+          ],
+          "row_ids": [
+            4
+          ],
+          "confidence": 0.9565566777426845,
+          "model_source": "swift-worker-v1"
+        }
+      ],
+      "line_items": [
+        {
+          "item_index": 0,
+          "name": "ORGANIC",
+          "price": 3.99,
+          "quantity": null,
+          "unit_price": null,
+          "is_discount": false,
+          "name_quality": "ok",
+          "line_ids": [
+            3
+          ],
+          "reconciliation_status": "no-baseline",
+          "model_source": "swift-worker-v1"
+        }
+      ],
       "needs_review": false
     }
   ],

--- a/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/OCRResultContractTests.swift
+++ b/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/OCRResultContractTests.swift
@@ -144,6 +144,17 @@ final class OCRResultContractTests: XCTestCase {
         XCTAssertEqual(barcodeDict["symbology"] as? String, "EAN13")
         XCTAssertEqual(barcodeDict["payload"] as? String, "0123456789012")
         XCTAssertNotNil(barcodeDict["bounding_box"] as? [String: Any])
+
+        // On-device deterministic structure is additive to the established
+        // receipt contract, including empty arrays when no items are decoded.
+        let sections = try XCTUnwrap(json["sections"] as? [[String: Any]])
+        XCTAssertFalse(sections.isEmpty)
+        for section in sections {
+            XCTAssertEqual(
+                section["model_source"] as? String, "swift-worker-v1"
+            )
+        }
+        XCTAssertNotNil(json["line_items"] as? [[String: Any]])
     }
 
     func test_classification_encodes_python_parser_contract_keys() throws {
@@ -481,6 +492,19 @@ final class OCRResultContractTests: XCTestCase {
                 )
                 XCTAssertEqual(tokens.count, labels.count)
                 XCTAssertEqual(tokens.count, confidences.count)
+            }
+            let sections = try XCTUnwrap(
+                receipt["sections"] as? [[String: Any]]
+            )
+            let lineItems = try XCTUnwrap(
+                receipt["line_items"] as? [[String: Any]]
+            )
+            XCTAssertFalse(sections.isEmpty)
+            XCTAssertFalse(lineItems.isEmpty)
+            for entity in sections + lineItems {
+                XCTAssertEqual(
+                    entity["model_source"] as? String, "swift-worker-v1"
+                )
             }
         }
     }

--- a/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/ReceiptStructurePipelineTests.swift
+++ b/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/ReceiptStructurePipelineTests.swift
@@ -1,0 +1,286 @@
+import Foundation
+import Testing
+
+@testable import ReceiptOCRCore
+
+@Suite struct ReceiptStructurePipelineTests {
+    struct OCRFixture: Decodable {
+        let receipts: [OCRReceipt]
+    }
+
+    struct OCRReceipt: Decodable {
+        let imageId: String
+        let receiptId: Int
+        let merchant: String?
+        let words: [ZoneWord]
+
+        enum CodingKeys: String, CodingKey {
+            case imageId = "image_id"
+            case receiptId = "receipt_id"
+            case merchant
+            case words
+        }
+    }
+
+    struct ExpectedReceipt: Decodable {
+        let imageId: String
+        let receiptId: Int
+        let sections: [ExpectedSection]
+        let lineItems: [ExpectedItem]
+        let printedSubtotal: Double?
+        let reconciliationStatus: String
+        let shouldReocrItemsZone: Bool
+
+        enum CodingKeys: String, CodingKey {
+            case imageId = "image_id"
+            case receiptId = "receipt_id"
+            case sections
+            case lineItems = "line_items"
+            case printedSubtotal = "printed_subtotal"
+            case reconciliationStatus = "reconciliation_status"
+            case shouldReocrItemsZone = "should_reocr_items_zone"
+        }
+    }
+
+    struct ExpectedSection: Decodable {
+        let sectionType: String
+        let lineIds: [Int]
+
+        enum CodingKeys: String, CodingKey {
+            case sectionType = "section_type"
+            case lineIds = "line_ids"
+        }
+    }
+
+    struct ExpectedItem: Decodable {
+        let itemIndex: Int
+        let name: String
+        let price: Double
+        let quantity: Double?
+        let unitPrice: Double?
+        let isDiscount: Bool
+        let nameQuality: String
+        let lineIds: [Int]
+        let reconciliationStatus: String
+
+        enum CodingKeys: String, CodingKey {
+            case itemIndex = "item_index"
+            case name
+            case price
+            case quantity
+            case unitPrice = "unit_price"
+            case isDiscount = "is_discount"
+            case nameQuality = "name_quality"
+            case lineIds = "line_ids"
+            case reconciliationStatus = "reconciliation_status"
+        }
+    }
+
+    struct ContractEnvelope: Decodable {
+        let receipts: [ContractReceipt]
+    }
+
+    struct ContractReceipt: Decodable {
+        let clusterId: Int
+        let lines: [Line]
+        let layoutlmPredictions: [LinePrediction]?
+    }
+
+    private func load<T: Decodable>(_ name: String, as type: T.Type) throws
+        -> T
+    {
+        let url = try #require(
+            Bundle.module.url(
+                forResource: name, withExtension: "json",
+                subdirectory: "Fixtures"
+            )
+        )
+        return try JSONDecoder().decode(T.self, from: Data(contentsOf: url))
+    }
+
+    private func loadContract() throws -> ContractEnvelope {
+        let url = try #require(
+            Bundle.module.url(
+                forResource: "swift_single_pass_contract",
+                withExtension: "json", subdirectory: "Fixtures"
+            )
+        )
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        return try decoder.decode(
+            ContractEnvelope.self, from: Data(contentsOf: url)
+        )
+    }
+
+    private func reconstruct(_ receipt: OCRReceipt) -> [SectionLine] {
+        let words = receipt.words.map { word in
+            SectionWord(
+                lineId: word.lineId, wordId: word.wordId, text: word.text,
+                boundingBox: SectionRect(
+                    x: word.x, y: word.yMid - word.h / 2,
+                    width: 0, height: word.h
+                )
+            )
+        }
+        let grouped = Dictionary(grouping: words, by: \.lineId)
+        return grouped.keys.sorted().map { lineId in
+            let members = grouped[lineId]!
+            let ordered = members.stableSorted {
+                if $0.boundingBox.x != $1.boundingBox.x {
+                    return $0.boundingBox.x < $1.boundingBox.x
+                }
+                return $0.wordId < $1.wordId
+            }
+            let xMin = members.map { $0.boundingBox.x }.min()!
+            let xMax = members.map { $0.boundingBox.x }.max()!
+            let yMin = members.map { $0.boundingBox.y }.min()!
+            let yMax = members.map {
+                $0.boundingBox.y + $0.boundingBox.height
+            }.max()!
+            return SectionLine(
+                imageId: receipt.imageId, receiptId: receipt.receiptId,
+                lineId: lineId,
+                text: ordered.map(\.text).joined(separator: " "),
+                boundingBox: SectionRect(
+                    x: xMin, y: yMin, width: xMax - xMin,
+                    height: yMax - yMin
+                ),
+                words: ordered
+            )
+        }
+    }
+
+    private func equalMoney(_ left: Double?, _ right: Double?) -> Bool {
+        switch (left, right) {
+        case (nil, nil):
+            return true
+        case let (left?, right?):
+            return abs(left - right) <= 0.005
+        default:
+            return false
+        }
+    }
+
+    @Test func goldenEndToEndParity33Receipts() throws {
+        let fixture = try load("line_items_golden_ocr", as: OCRFixture.self)
+        let expected = try load(
+            "receipt_structure_parity_expected",
+            as: [ExpectedReceipt].self
+        )
+        #expect(fixture.receipts.count == 33)
+        #expect(expected.count == 33)
+
+        var passed = 0
+        var failures: [String] = []
+        for (receipt, expectation) in zip(fixture.receipts, expected) {
+            let result = try buildOnDeviceReceiptStructure(
+                lines: reconstruct(receipt), merchantName: receipt.merchant
+            )
+            var differences: [String] = []
+            if result.sections.map(\.sectionType)
+                != expectation.sections.map(\.sectionType)
+            {
+                differences.append("section types")
+            }
+            if result.sections.map(\.lineIds)
+                != expectation.sections.map(\.lineIds)
+            {
+                differences.append("section line_ids")
+            }
+            if result.lineItems.count != expectation.lineItems.count {
+                differences.append(
+                    "item count \(result.lineItems.count) != "
+                        + "\(expectation.lineItems.count)"
+                )
+            } else {
+                for (got, wanted) in zip(
+                    result.lineItems, expectation.lineItems
+                ) {
+                    if got.itemIndex != wanted.itemIndex
+                        || got.name != wanted.name
+                        || !equalMoney(got.price, wanted.price)
+                        || !equalMoney(got.quantity, wanted.quantity)
+                        || !equalMoney(got.unitPrice, wanted.unitPrice)
+                        || got.isDiscount != wanted.isDiscount
+                        || got.nameQuality != wanted.nameQuality
+                        || got.lineIds != wanted.lineIds
+                        || got.reconciliationStatus
+                            != wanted.reconciliationStatus
+                        || got.modelSource != swiftWorkerModelSource
+                    {
+                        differences.append("item[\(got.itemIndex)]")
+                    }
+                }
+            }
+            if !equalMoney(
+                result.printedSubtotal, expectation.printedSubtotal
+            ) {
+                differences.append("printed subtotal")
+            }
+            if result.reconciliationStatus
+                != expectation.reconciliationStatus
+            {
+                differences.append("reconciliation")
+            }
+            if result.shouldReocrItemsZone
+                != expectation.shouldReocrItemsZone
+            {
+                differences.append("should_reocr")
+            }
+            if result.sections.contains(where: {
+                $0.modelSource != swiftWorkerModelSource
+            }) {
+                differences.append("section provenance")
+            }
+            if differences.isEmpty {
+                passed += 1
+            } else {
+                failures.append(
+                    "\(receipt.merchant ?? "?") \(receipt.imageId)"
+                        + "#\(receipt.receiptId): "
+                        + differences.joined(separator: ", ")
+                )
+            }
+        }
+        #expect(
+            passed == 33,
+            Comment(
+                rawValue: "pipeline parity \(passed)/33; failures:\n"
+                    + failures.joined(separator: "\n")
+            )
+        )
+    }
+
+    @Test func contractReceiptFindsAndReconcilesPrintedSubtotal() throws {
+        let fixture = try loadContract()
+        let receipt = try #require(fixture.receipts.first)
+        let merchant = merchantNameFromLayoutPredictions(
+            receipt.layoutlmPredictions
+        )
+        #expect(merchant == "SPROUTS FARMERS MARKET")
+        var lines = receipt.lines
+        let total = try #require(lines.last)
+        lines[lines.count - 1] = Line(
+            text: "SUBTOTAL 3.99",
+            boundingBox: total.boundingBox,
+            topLeft: total.topLeft,
+            topRight: total.topRight,
+            bottomLeft: total.bottomLeft,
+            bottomRight: total.bottomRight,
+            angleDegrees: total.angleDegrees,
+            angleRadians: total.angleRadians,
+            confidence: total.confidence,
+            words: total.words
+        )
+        let result = try buildOnDeviceReceiptStructure(
+            lines: lines, receiptId: receipt.clusterId,
+            merchantName: merchant
+        )
+        #expect(equalMoney(result.printedSubtotal, 3.99))
+        #expect(result.reconciliationStatus == "match")
+        #expect(result.shouldReocrItemsZone == false)
+        #expect(result.lineItems.count == 1)
+        #expect(equalMoney(result.lineItems.first?.price, 3.99))
+        #expect(result.lineItems.first?.modelSource == swiftWorkerModelSource)
+    }
+}


### PR DESCRIPTION
## What changed

- run the deterministic Swift row builder, section assigner, and line-item decoder when each warped receipt's refinement OCR output is created
- reconcile decoded non-discount items against an exact `SUBTOTAL` row detected in that receipt's own OCR, while preserving the existing re-OCR decision as stage output
- add provenance-stamped `sections` and `line_items` arrays to every receipt payload with `model_source: swift-worker-v1`
- keep existing payload fields unchanged; empty arrays preserve the cloud pipeline as the failure fallback
- add an end-to-end Python expectation generator and Swift golden tests over all 33 OCR receipts, plus a full worker-contract subtotal/reconciliation test

## Stack

This draft is based on `codex/swift-section-assigner` / #1314. Review and merge that Phase 1 parity port first.

## Fixture note

The 33-receipt golden fixture contains only compact ITEMS-zone word geometry, so it exercises rows -> sections -> decoding with no printed subtotal baseline. The existing full single-pass worker fixture separately verifies printed-subtotal discovery, `match` reconciliation, upload JSON, and provenance.

## Validation

- Python end-to-end expectation generation: 33/33 receipts
- `swift build`: passed
- `swift test --filter SectionAssignmentParityTests`: passed, 33/33
- `swift test --skip-build --filter LineItemParityTests`: passed, 33/33
- `swift test --skip-build --filter ReceiptStructurePipelineTests`: passed, 2/2
- `swift test --skip-build --filter OCRResultContractTests`: passed, 5/5
- `pytest infra/upload_images/container_ocr/handler/tests/test_swift_payload_contract.py -q`: 12 passed
- Black check and `receipt_chroma` public-facade policy test: passed

No Python assigner, decoder, pipeline, test fixture, or regression floor was changed.
