### PR TITLE
Add the geometric reader visualization

### DIFF
--- a/infra/__main__.py
+++ b/infra/__main__.py
@@ -329,6 +329,19 @@ create_lambda_route(
     permission_name="word_similarity_lambda_permission",
 )
 
+# Geometric-reader API. The Lambda is always available, but is registered here
+# to keep this task's API wiring colocated with its explicit main-program hook.
+from routes.line_item_decode.infra import line_item_decode_lambda
+
+create_lambda_route(
+    api=api_gateway.api,
+    integration_name="line_item_decode_lambda_integration",
+    route_name="line_item_decode_route",
+    route_key="GET /line_item_decode",
+    lambda_function=line_item_decode_lambda,
+    permission_name="line_item_decode_lambda_permission",
+)
+
 # ValidateMerchantStepFunctions removed - redundant with LangGraph metadata creation
 # Metadata is now created by:
 # - Upload OCR Handler (LangGraph)

--- a/infra/routes/line_item_decode/handler/index.py
+++ b/infra/routes/line_item_decode/handler/index.py
@@ -1,0 +1,225 @@
+"""Serve deterministic receipt sections and decoded line items to the UI."""
+
+import json
+import logging
+import os
+import random
+from datetime import datetime, timezone
+from typing import Any
+
+from receipt_dynamo.data.dynamo_client import DynamoClient
+from receipt_dynamo.data.shared_exceptions import (
+    EntityNotFoundError,
+    OperationError,
+)
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+DYNAMODB_TABLE_NAME = os.environ["DYNAMODB_TABLE_NAME"]
+DEFAULT_BATCH_SIZE = 5
+MAX_BATCH_SIZE = 10
+CANDIDATE_SAMPLE_SIZE = 500
+
+IMAGE_FIELDS = (
+    "image_id",
+    "receipt_id",
+    "width",
+    "height",
+    "cdn_s3_bucket",
+    "cdn_s3_key",
+    "cdn_webp_s3_key",
+    "cdn_avif_s3_key",
+    "cdn_thumbnail_s3_key",
+    "cdn_thumbnail_webp_s3_key",
+    "cdn_thumbnail_avif_s3_key",
+    "cdn_small_s3_key",
+    "cdn_small_webp_s3_key",
+    "cdn_small_avif_s3_key",
+    "cdn_medium_s3_key",
+    "cdn_medium_webp_s3_key",
+    "cdn_medium_avif_s3_key",
+)
+
+
+def _response(status_code: int, body: dict[str, Any]) -> dict[str, Any]:
+    """Build an API Gateway response with consistent JSON headers."""
+    return {
+        "statusCode": status_code,
+        "body": json.dumps(body, default=str),
+        "headers": {
+            "Content-Type": "application/json",
+            "Access-Control-Allow-Origin": "*",
+        },
+    }
+
+
+def _batch_size(event: dict[str, Any]) -> int:
+    """Read the optional batch-size query parameter."""
+    params = event.get("queryStringParameters") or {}
+    raw_value = params.get("batch_size", params.get("limit"))
+    if raw_value is None:
+        return DEFAULT_BATCH_SIZE
+    try:
+        value = int(raw_value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("batch_size must be an integer") from exc
+    if not 1 <= value <= MAX_BATCH_SIZE:
+        raise ValueError(f"batch_size must be between 1 and {MAX_BATCH_SIZE}")
+    return value
+
+
+def _candidate_receipts(client: DynamoClient) -> list[tuple[str, int]]:
+    """Return randomized receipt IDs known to have decoded line items."""
+    line_items, _ = client.list_receipt_line_items(limit=CANDIDATE_SAMPLE_SIZE)
+    candidates = list(
+        {
+            (line_item.image_id, line_item.receipt_id)
+            for line_item in line_items
+        }
+    )
+    random.shuffle(candidates)
+    return candidates
+
+
+def _image_payload(receipt: Any) -> dict[str, Any]:
+    """Return the image-reference shape consumed by getBestImageUrl."""
+    return {
+        field: getattr(receipt, field)
+        for field in IMAGE_FIELDS
+        if getattr(receipt, field, None) is not None
+    }
+
+
+def _line_payload(line: Any) -> dict[str, Any]:
+    """Return OCR text with normalized and quadrilateral geometry."""
+    return {
+        "line_id": line.line_id,
+        "text": line.text,
+        "bounding_box": line.bounding_box,
+        "top_left": line.top_left,
+        "top_right": line.top_right,
+        "bottom_left": line.bottom_left,
+        "bottom_right": line.bottom_right,
+    }
+
+
+def _receipt_payload(client: DynamoClient, image_id: str, receipt_id: int):
+    """Hydrate one receipt's deterministic decode from normalized rows."""
+    details = client.get_receipt_details(image_id, receipt_id)
+    sections = client.get_receipt_sections_from_receipt(image_id, receipt_id)
+    line_items = client.get_receipt_line_items_from_receipt(
+        image_id, receipt_id
+    )
+    image = _image_payload(details.receipt)
+    if (
+        not line_items
+        or not sections
+        or not details.lines
+        or not image.get("cdn_s3_key")
+    ):
+        return None
+
+    try:
+        summary = client.get_receipt_summary(image_id, receipt_id)
+    except EntityNotFoundError:
+        summary = None
+
+    summary_merchant = summary.merchant_name if summary else None
+    place_merchant = (
+        details.place.merchant_name if details.place is not None else None
+    )
+    item_merchant = next(
+        (item.merchant_name for item in line_items if item.merchant_name),
+        None,
+    )
+
+    return {
+        "image_id": image_id,
+        "receipt_id": receipt_id,
+        "merchant_name": (
+            summary_merchant or place_merchant or item_merchant or "Unknown"
+        ),
+        "image": image,
+        "lines": [
+            _line_payload(line)
+            for line in sorted(details.lines, key=lambda value: value.line_id)
+        ],
+        "sections": [
+            {
+                "section_type": str(section.section_type),
+                "line_ids": sorted(set(section.line_ids)),
+            }
+            for section in sections
+        ],
+        "line_items": [
+            {
+                "name": item.name,
+                "price": item.price,
+                "quantity": item.quantity,
+                "unit_price": item.unit_price,
+                "is_discount": item.is_discount,
+                "line_ids": item.line_ids,
+                "reconciliation_status": item.reconciliation_status,
+            }
+            for item in sorted(line_items, key=lambda value: value.item_index)
+        ],
+        "printed_subtotal": summary.subtotal if summary else None,
+    }
+
+
+def handle_get_request(event: dict[str, Any]) -> dict[str, Any]:
+    """Return a randomized batch of receipts that have line items."""
+    try:
+        batch_size = _batch_size(event)
+    except ValueError as exc:
+        return _response(400, {"error": str(exc)})
+
+    try:
+        client = DynamoClient(DYNAMODB_TABLE_NAME)
+        candidates = _candidate_receipts(client)
+        receipts = []
+        for image_id, receipt_id in candidates:
+            if len(receipts) >= batch_size:
+                break
+            try:
+                payload = _receipt_payload(client, image_id, receipt_id)
+            except (EntityNotFoundError, ValueError) as exc:
+                logger.warning(
+                    "Skipping incomplete line-item receipt %s/%s: %s",
+                    image_id,
+                    receipt_id,
+                    exc,
+                )
+                continue
+            if payload is not None:
+                receipts.append(payload)
+
+        return _response(
+            200,
+            {
+                "receipts": receipts,
+                "batch_size": len(receipts),
+                "candidate_count": len(candidates),
+                "fetched_at": datetime.now(timezone.utc).isoformat(),
+            },
+        )
+    except OperationError as exc:
+        logger.error("Database operation failed: %s", exc)
+        return _response(500, {"error": "Database operation failed"})
+    except Exception:
+        logger.exception("Unexpected line-item decode route failure")
+        return _response(500, {"error": "Internal server error"})
+
+
+def handler(event, _context):
+    """Handle API Gateway requests for the geometric-reader data."""
+    logger.info("Received event: %s", event)
+    try:
+        method = event["requestContext"]["http"]["method"].upper()
+    except (KeyError, TypeError):
+        return _response(400, {"error": "Invalid event structure"})
+
+    if method != "GET":
+        return _response(405, {"error": f"Method {method} not allowed"})
+    return handle_get_request(event)

--- a/infra/routes/line_item_decode/infra.py
+++ b/infra/routes/line_item_decode/infra.py
@@ -1,0 +1,60 @@
+"""Pulumi resources for the line-item-decode API Lambda."""
+
+import json
+import os
+
+from dynamo_db import dynamodb_table
+from infra.components.lambda_layer import dynamo_layer
+from infra.components.route_lambda import (
+    ManagedPolicyDefinition,
+    RouteLambdaDefinition,
+    create_route_lambda,
+)
+
+HANDLER_DIR = os.path.join(os.path.dirname(__file__), "handler")
+ROUTE_NAME = os.path.basename(os.path.dirname(__file__))
+
+resources = create_route_lambda(
+    RouteLambdaDefinition(
+        role_name=f"api_{ROUTE_NAME}_lambda_role",
+        basic_execution_attachment_name=(
+            f"api_{ROUTE_NAME}_lambda_basic_execution"
+        ),
+        function_name=f"api_{ROUTE_NAME}_GET_lambda",
+        log_group_name=f"api_{ROUTE_NAME}_lambda_log_group",
+        handler_directory=HANDLER_DIR,
+        policy=ManagedPolicyDefinition(
+            resource_name=f"api_{ROUTE_NAME}_lambda_policy",
+            attachment_name=f"api_{ROUTE_NAME}_lambda_policy_attachment",
+            description=(
+                "Read receipts, sections, summaries, and line items from "
+                "DynamoDB"
+            ),
+            document=dynamodb_table.arn.apply(
+                lambda arn: json.dumps(
+                    {
+                        "Version": "2012-10-17",
+                        "Statement": [
+                            {
+                                "Effect": "Allow",
+                                "Action": [
+                                    "dynamodb:Query",
+                                    "dynamodb:GetItem",
+                                    "dynamodb:DescribeTable",
+                                ],
+                                "Resource": [arn, f"{arn}/index/*"],
+                            }
+                        ],
+                    }
+                )
+            ),
+        ),
+        environment={"DYNAMODB_TABLE_NAME": dynamodb_table.name},
+        layers=(dynamo_layer.arn,),
+        memory_size=1024,
+        timeout=30,
+        use_function_log_group_name=True,
+    )
+)
+
+line_item_decode_lambda = resources.function

--- a/portfolio/components/ui/Figures/GeometricReader/GeometricReader.module.css
+++ b/portfolio/components/ui/Figures/GeometricReader/GeometricReader.module.css
@@ -1,0 +1,494 @@
+.container {
+  width: 100%;
+  max-width: 1000px;
+  margin: 2rem auto;
+  padding: 1.5rem;
+  overflow: hidden;
+  background: var(--background-color);
+  border-radius: 12px;
+  contain: paint;
+}
+
+.receiptQueue {
+  position: relative;
+  z-index: 1;
+  width: var(--rf-queue-width, 120px);
+  height: var(--rf-queue-height, 400px);
+}
+
+.queuedReceipt {
+  position: absolute;
+  width: 100px;
+  overflow: hidden;
+  background: var(--background-color);
+  border: 1px solid #ccc;
+  box-shadow: 0 2px 6px rgb(0 0 0 / 20%);
+  transition:
+    transform calc(0.6s * var(--rf-motion-scale, 1)) ease-out,
+    opacity calc(0.35s * var(--rf-motion-scale, 1)) ease-out,
+    top calc(0.4s * var(--rf-motion-scale, 1)) ease,
+    left calc(0.4s * var(--rf-motion-scale, 1)) ease;
+  will-change: transform, opacity;
+}
+
+.queuedReceipt img {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+.activeReceipt {
+  width: 100%;
+  height: 100%;
+}
+
+.receiptImageWrapper {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 500px;
+}
+
+.receiptImageInner {
+  position: relative;
+  max-height: 500px;
+}
+
+.receiptImage {
+  display: block;
+  width: auto;
+  max-width: 100%;
+  height: auto;
+  max-height: 500px;
+}
+
+.receiptLoading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 400px;
+  color: var(--text-color);
+  opacity: 0.55;
+}
+
+.svgOverlay {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}
+
+.zone,
+.activeZone {
+  transform-box: fill-box;
+  transform-origin: top;
+  animation: zone-sweep calc(0.42s * var(--rf-motion-scale, 1)) ease-out both;
+}
+
+.activeZone > rect:first-child {
+  animation: zone-breathe calc(0.85s * var(--rf-motion-scale, 1)) ease-in-out
+    infinite alternate;
+}
+
+.zoneCaption {
+  font-family: "Monaco", "Menlo", "Consolas", monospace;
+  font-size: 17px;
+  font-weight: 700;
+  letter-spacing: 1.5px;
+  fill: white;
+}
+
+.priceCarrier {
+  animation: price-pulse calc(0.55s * var(--rf-motion-scale, 1)) ease-in-out
+    infinite alternate;
+  transform-box: fill-box;
+  transform-origin: center;
+}
+
+.ledgerPanel {
+  display: flex;
+  flex-direction: column;
+  width: 240px;
+  height: 500px;
+  min-height: 500px;
+  padding: 0.5rem 0;
+  color: var(--text-color);
+}
+
+.panelHeader {
+  display: flex;
+  flex-direction: column;
+  gap: 0.18rem;
+  min-height: 2.7rem;
+}
+
+.panelHeader strong {
+  overflow: hidden;
+  font-size: 0.96rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.eyebrow {
+  font-family: "Monaco", "Menlo", "Consolas", monospace;
+  font-size: 0.61rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  opacity: 0.5;
+}
+
+.phaseRail {
+  display: grid;
+  grid-template-columns: auto 1fr auto 1fr auto;
+  align-items: center;
+  margin: 0.65rem 0 0.75rem;
+}
+
+.phaseStep {
+  font-family: "Monaco", "Menlo", "Consolas", monospace;
+  font-size: 0.57rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.3;
+  transition:
+    opacity 180ms ease,
+    color 180ms ease;
+}
+
+.activePhase {
+  color: var(--color-blue);
+  opacity: 1;
+}
+
+.phaseLine {
+  height: 1px;
+  margin: 0 0.38rem;
+  background: currentcolor;
+  opacity: 0.16;
+}
+
+.sectionList {
+  display: grid;
+  gap: 0.28rem;
+  min-height: 8.5rem;
+  transition: min-height 240ms ease;
+}
+
+.compactSections {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.2rem 0.35rem;
+  min-height: 3.5rem;
+}
+
+.sectionRow {
+  display: grid;
+  grid-template-columns: 0.55rem minmax(0, 1fr) auto;
+  gap: 0.45rem;
+  align-items: center;
+  min-width: 0;
+  font-size: 0.72rem;
+  opacity: 0.14;
+  transform: translateX(4px);
+  transition:
+    opacity 220ms ease,
+    transform 220ms ease;
+}
+
+.compactSections .sectionRow {
+  grid-template-columns: 0.42rem minmax(0, 1fr);
+  gap: 0.25rem;
+  font-size: 0.6rem;
+}
+
+.sectionRow.revealed,
+.ledgerRow.revealed {
+  opacity: 1;
+  transform: translateX(0);
+}
+
+.sectionSwatch {
+  width: 0.55rem;
+  height: 0.55rem;
+  border-radius: 2px;
+}
+
+.compactSections .sectionSwatch {
+  width: 0.42rem;
+  height: 0.42rem;
+}
+
+.sectionRow > span:nth-child(2) {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  text-transform: capitalize;
+  white-space: nowrap;
+}
+
+.lineCount {
+  font-family: "Monaco", "Menlo", "Consolas", monospace;
+  font-size: 0.58rem;
+  opacity: 0.42;
+}
+
+.compactSections .lineCount {
+  display: none;
+}
+
+.ledger {
+  min-height: 7.5rem;
+  margin-top: 0.35rem;
+  overflow: hidden;
+  border-top: 1px solid color-mix(in srgb, var(--text-color) 14%, transparent);
+}
+
+.ledgerHeading,
+.ledgerRow {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.5rem;
+}
+
+.ledgerHeading {
+  padding: 0.42rem 0 0.28rem;
+  font-size: 0.58rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.4;
+}
+
+.ledgerRow {
+  align-items: start;
+  padding: 0.24rem 0;
+  font-size: 0.72rem;
+  opacity: 0;
+  transform: translateX(5px);
+  transition:
+    opacity 220ms ease,
+    transform 220ms ease;
+}
+
+.itemName {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.22rem;
+  align-items: center;
+  min-width: 0;
+}
+
+.quantityChip {
+  padding: 0.08rem 0.24rem;
+  font-family: "Monaco", "Menlo", "Consolas", monospace;
+  font-size: 0.52rem;
+  white-space: nowrap;
+  background: color-mix(in srgb, var(--color-cyan) 18%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-cyan) 50%, transparent);
+  border-radius: 999px;
+}
+
+.itemPrice,
+.runningTotal > span:last-child,
+.proofEquation {
+  font-family: "Monaco", "Menlo", "Consolas", monospace;
+  font-variant-numeric: tabular-nums;
+}
+
+.discount {
+  color: var(--color-teal);
+}
+
+.runningTotal {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  padding: 0.48rem 0;
+  margin-top: auto;
+  border-top: 1px solid color-mix(in srgb, var(--text-color) 18%, transparent);
+}
+
+.runningTotal > span:first-child {
+  font-size: 0.66rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  opacity: 0.52;
+}
+
+.runningTotal > span:last-child {
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.proof {
+  min-height: 5.4rem;
+  padding: 0.55rem 0.62rem;
+  opacity: 0;
+  background: color-mix(in srgb, var(--text-color) 3%, transparent);
+  border: 1px solid color-mix(in srgb, var(--text-color) 12%, transparent);
+  border-radius: 8px;
+  transform: translateY(4px);
+  transition:
+    opacity 240ms ease,
+    transform 240ms ease;
+}
+
+.proofVisible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.proofEquation {
+  display: flex;
+  gap: 0.42rem;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 0.44rem;
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+
+.proofOperator {
+  opacity: 0.38;
+}
+
+.proofBadge {
+  width: fit-content;
+  padding: 0.2rem 0.45rem;
+  margin: 0 auto;
+  font-family: "Monaco", "Menlo", "Consolas", monospace;
+  font-size: 0.6rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  border: 1px solid currentcolor;
+  border-radius: 999px;
+}
+
+.match {
+  color: var(--color-green);
+  background: color-mix(in srgb, var(--color-green) 10%, transparent);
+}
+
+.near {
+  color: var(--color-yellow);
+  background: color-mix(in srgb, var(--color-yellow) 10%, transparent);
+}
+
+.mismatch {
+  color: var(--color-red);
+  background: color-mix(in srgb, var(--color-red) 10%, transparent);
+}
+
+.noBaseline {
+  color: var(--text-color);
+  opacity: 0.56;
+}
+
+.reocrNote {
+  display: block;
+  margin-top: 0.34rem;
+  font-size: 0.6rem;
+  text-align: center;
+  text-transform: uppercase;
+  opacity: 0.58;
+}
+
+@keyframes zone-sweep {
+  from {
+    opacity: 0;
+    transform: scaleY(0.05);
+  }
+
+  to {
+    opacity: 1;
+    transform: scaleY(1);
+  }
+}
+
+@keyframes zone-breathe {
+  from {
+    fill-opacity: 0.16;
+  }
+  to {
+    fill-opacity: 0.32;
+  }
+}
+
+@keyframes price-pulse {
+  from {
+    transform: scale(0.985);
+  }
+  to {
+    transform: scale(1.015);
+  }
+}
+
+@media (max-width: 768px) {
+  .container {
+    padding: 1rem;
+  }
+
+  .activeReceipt,
+  .receiptImageWrapper {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+  }
+
+  .receiptImageInner,
+  .receiptImage {
+    max-height: 380px;
+  }
+
+  .ledgerPanel {
+    width: min(100%, 440px);
+    height: auto;
+    min-height: 27rem;
+    margin: 0 auto;
+  }
+
+  .sectionList {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    min-height: 4.2rem;
+  }
+
+  .sectionRow {
+    grid-template-columns: 0.5rem minmax(0, 1fr);
+  }
+
+  .lineCount {
+    display: none;
+  }
+
+  .ledger {
+    min-height: 7rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .receiptImageInner,
+  .receiptImage {
+    max-height: 300px;
+  }
+
+  .ledgerPanel {
+    min-height: 26rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .queuedReceipt,
+  .sectionRow,
+  .ledgerRow,
+  .proof {
+    transition: none;
+  }
+
+  .zone,
+  .activeZone,
+  .activeZone > rect:first-child,
+  .priceCarrier {
+    animation: none;
+  }
+}

--- a/portfolio/components/ui/Figures/GeometricReader/GeometricReader.test.tsx
+++ b/portfolio/components/ui/Figures/GeometricReader/GeometricReader.test.tsx
@@ -1,0 +1,155 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { api } from "../../../../services/api";
+import { LineItemDecodeResponse } from "../../../../types/api";
+import GeometricReader from ".";
+import { boundsForLineIds, getReceiptProof } from "./geometry";
+
+jest.mock("react-intersection-observer", () => ({
+  useInView: () => ({ ref: jest.fn(), inView: true }),
+}));
+
+jest.mock("../ReceiptFlow/useImageFormatSupport", () => ({
+  useImageFormatSupport: () => ({ supportsWebP: true, supportsAVIF: false }),
+}));
+
+jest.mock("../../../../utils/imageFormat", () => ({
+  getBestImageUrl: () => "/receipt.webp",
+  getJpegFallbackUrl: () => "/receipt.jpg",
+  usePreloadReceiptImages: jest.fn(),
+}));
+
+jest.mock("../../../../services/api", () => ({
+  api: { fetchLineItemDecode: jest.fn() },
+}));
+
+const response: LineItemDecodeResponse = {
+  receipts: [
+    {
+      image_id: "image-1",
+      receipt_id: 1,
+      merchant_name: "Test Market",
+      image: {
+        image_id: "image-1",
+        receipt_id: 1,
+        width: 600,
+        height: 1200,
+        cdn_s3_key: "receipt.jpg",
+      },
+      lines: [
+        {
+          line_id: 0,
+          text: "TEST MARKET",
+          bounding_box: { x: 0.2, y: 0.86, width: 0.5, height: 0.03 },
+        },
+        {
+          line_id: 1,
+          text: "BANANAS",
+          bounding_box: { x: 0.15, y: 0.55, width: 0.4, height: 0.03 },
+        },
+        {
+          line_id: 2,
+          text: "$1.69",
+          bounding_box: { x: 0.72, y: 0.55, width: 0.13, height: 0.03 },
+        },
+        {
+          line_id: 3,
+          text: "MILK $4.99",
+          bounding_box: { x: 0.15, y: 0.47, width: 0.7, height: 0.03 },
+        },
+        {
+          line_id: 4,
+          text: "SUBTOTAL $6.68",
+          bounding_box: { x: 0.45, y: 0.15, width: 0.4, height: 0.03 },
+        },
+      ],
+      sections: [
+        { section_type: "HEADER", line_ids: [0] },
+        { section_type: "ITEMS", line_ids: [1, 2, 3] },
+        { section_type: "SUMMARY", line_ids: [4] },
+      ],
+      line_items: [
+        {
+          name: "Bananas",
+          price: "1.69",
+          quantity: 1.31,
+          unit_price: 1.29,
+          is_discount: false,
+          line_ids: [1, 2],
+          reconciliation_status: "match",
+        },
+        {
+          name: "Milk",
+          price: "4.99",
+          quantity: null,
+          unit_price: null,
+          is_discount: false,
+          line_ids: [3],
+          reconciliation_status: "match",
+        },
+      ],
+      printed_subtotal: 6.68,
+    },
+  ],
+  batch_size: 1,
+  candidate_count: 1,
+  fetched_at: "2026-07-31T00:00:00Z",
+};
+
+beforeEach(() => {
+  jest.mocked(api.fetchLineItemDecode).mockResolvedValue(response);
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: (query: string) => ({
+      matches: query.includes("prefers-reduced-motion"),
+      media: query,
+      onchange: null,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    }),
+  });
+});
+
+test("reduced motion renders the resolved sections, ledger, and exact proof", async () => {
+  render(<GeometricReader />);
+
+  await waitFor(() =>
+    expect(screen.getByText("Test Market")).toBeInTheDocument(),
+  );
+  await waitFor(() =>
+    expect(screen.getByTestId("section-zone-HEADER")).toBeInTheDocument(),
+  );
+  expect(screen.getByTestId("section-zone-ITEMS")).toBeInTheDocument();
+  expect(screen.getByText("Bananas")).toBeInTheDocument();
+  expect(screen.getByText("Milk")).toBeInTheDocument();
+  expect(screen.getByText("reconciled · exact")).toBeInTheDocument();
+  expect(screen.queryByText("re-OCR queued")).not.toBeInTheDocument();
+});
+
+test("proof keeps persisted mismatch status and reports its delta", () => {
+  const proof = getReceiptProof({
+    line_items: response.receipts[0].line_items.map((item) => ({
+      ...item,
+      reconciliation_status: "mismatch",
+    })),
+    printed_subtotal: 7,
+  });
+
+  expect(proof).toEqual({
+    status: "mismatch",
+    decodedTotal: 6.68,
+    printedSubtotal: 7,
+    delta: -0.32,
+  });
+});
+
+test("geometry unions bottom-origin line boxes into a top-origin zone", () => {
+  const bounds = boundsForLineIds(response.receipts[0].lines, [1, 2]);
+  expect(bounds).not.toBeNull();
+  expect(bounds?.x).toBeCloseTo(0.15);
+  expect(bounds?.y).toBeCloseTo(0.42);
+  expect(bounds?.width).toBeCloseTo(0.7);
+  expect(bounds?.height).toBeCloseTo(0.03);
+});

--- a/portfolio/components/ui/Figures/GeometricReader/geometry.ts
+++ b/portfolio/components/ui/Figures/GeometricReader/geometry.ts
@@ -1,0 +1,119 @@
+import {
+  DecodedReceiptLineItem,
+  LineItemDecodeLine,
+  LineItemDecodeReceipt,
+  LineItemDecodeSection,
+  LineItemReconciliationStatus,
+} from "../../../../types/api";
+
+export interface NormalizedBounds {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface ReceiptProof {
+  status: LineItemReconciliationStatus;
+  decodedTotal: number;
+  printedSubtotal: number | null;
+  delta: number | null;
+}
+
+const roundCurrency = (value: number): number => Math.round(value * 100) / 100;
+
+export const boundsForLineIds = (
+  lines: LineItemDecodeLine[],
+  lineIds: number[],
+): NormalizedBounds | null => {
+  const wanted = new Set(lineIds);
+  const boxes = lines
+    .filter((line) => wanted.has(line.line_id))
+    .map((line) => line.bounding_box);
+  if (boxes.length === 0) return null;
+
+  let left = 1;
+  let top = 1;
+  let right = 0;
+  let bottom = 0;
+  for (const box of boxes) {
+    left = Math.min(left, box.x);
+    top = Math.min(top, 1 - box.y - box.height);
+    right = Math.max(right, box.x + box.width);
+    bottom = Math.max(bottom, 1 - box.y);
+  }
+
+  return {
+    x: Math.max(0, left),
+    y: Math.max(0, top),
+    width: Math.min(1, right) - Math.max(0, left),
+    height: Math.min(1, bottom) - Math.max(0, top),
+  };
+};
+
+export const orderSections = (
+  sections: LineItemDecodeSection[],
+): LineItemDecodeSection[] =>
+  [...sections].sort((left, right) => {
+    const leftLine = Math.min(...left.line_ids);
+    const rightLine = Math.min(...right.line_ids);
+    return leftLine - rightLine;
+  });
+
+const storedReceiptStatus = (
+  lineItems: DecodedReceiptLineItem[],
+): LineItemReconciliationStatus => {
+  const statuses = new Set(
+    lineItems.map((item) => item.reconciliation_status).filter(Boolean),
+  );
+  if (statuses.has("mismatch")) return "mismatch";
+  if (statuses.has("near")) return "near";
+  if (statuses.has("match") && statuses.size === 1) return "match";
+  return "no-baseline";
+};
+
+export const getReceiptProof = (
+  receipt: Pick<LineItemDecodeReceipt, "line_items" | "printed_subtotal">,
+): ReceiptProof => {
+  const decodedTotal = roundCurrency(
+    receipt.line_items.reduce((sum, item) => {
+      const value = Number.parseFloat(item.price);
+      return Number.isFinite(value) ? sum + value : sum;
+    }, 0),
+  );
+  const printedSubtotal = receipt.printed_subtotal;
+  if (printedSubtotal === null) {
+    return {
+      status: "no-baseline",
+      decodedTotal,
+      printedSubtotal,
+      delta: null,
+    };
+  }
+
+  const delta = roundCurrency(decodedTotal - printedSubtotal);
+  const storedStatus = storedReceiptStatus(receipt.line_items);
+  const status =
+    storedStatus === "match" && Math.abs(delta) >= 0.005
+      ? "mismatch"
+      : storedStatus;
+
+  return { status, decodedTotal, printedSubtotal, delta };
+};
+
+export const findPriceCarrierLineId = (
+  item: DecodedReceiptLineItem,
+  lines: LineItemDecodeLine[],
+): number | null => {
+  const price = Math.abs(Number.parseFloat(item.price)).toFixed(2);
+  const candidates = lines.filter((line) =>
+    item.line_ids.includes(line.line_id),
+  );
+  return (
+    [...candidates]
+      .reverse()
+      .find((line) => line.text.replaceAll(",", "").includes(price))?.line_id ??
+    item.line_ids.at(-1) ??
+    null
+  );
+};

--- a/portfolio/components/ui/Figures/GeometricReader/index.tsx
+++ b/portfolio/components/ui/Figures/GeometricReader/index.tsx
@@ -1,0 +1,1075 @@
+import { animated, useSpring } from "@react-spring/web";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { useInView } from "react-intersection-observer";
+import { api } from "../../../../services/api";
+import {
+  DecodedReceiptLineItem,
+  LineItemDecodeReceipt,
+  LineItemDecodeResponse,
+  LineItemDecodeSection,
+} from "../../../../types/api";
+import {
+  getBestImageUrl,
+  getJpegFallbackUrl,
+  usePreloadReceiptImages,
+} from "../../../../utils/imageFormat";
+import { LabelBoxOverlay, OverlayBox } from "../labelBoxOverlay";
+import sharedStyles from "../labelBoxOverlay.module.css";
+import { LABEL_COLORS } from "../labelStyles";
+import { FlyingReceipt } from "../ReceiptFlow/FlyingReceipt";
+import {
+  DEFAULT_LAYOUT_VARS,
+  ReceiptFlowLoadingShell,
+} from "../ReceiptFlow/ReceiptFlowLoadingShell";
+import { ReceiptFlowShell } from "../ReceiptFlow/ReceiptFlowShell";
+import {
+  getQueuePosition,
+  getReceiptMotionScale,
+  getVisibleQueueIndices,
+} from "../ReceiptFlow/receiptFlowUtils";
+import { ImageFormatSupport } from "../ReceiptFlow/types";
+import { useFlyingReceipt } from "../ReceiptFlow/useFlyingReceipt";
+import { useImageFormatSupport } from "../ReceiptFlow/useImageFormatSupport";
+import {
+  boundsForLineIds,
+  findPriceCarrierLineId,
+  getReceiptProof,
+  orderSections,
+} from "./geometry";
+import styles from "./GeometricReader.module.css";
+
+type Phase = "sections" | "decode" | "prove";
+
+interface PlaybackState {
+  phase: Phase;
+  sectionCount: number;
+  itemCount: number;
+  isTransitioning: boolean;
+}
+
+const SECTION_STEP_MS = 650;
+const ITEM_STEP_MS = 760;
+const PROVE_DURATION_MS = 1900;
+const TRANSITION_DURATION_MS = 600;
+const QUEUE_REFETCH_THRESHOLD = 7;
+const MAX_EMPTY_FETCHES = 3;
+const BATCH_SIZE = 10;
+
+const SECTION_STYLES: Record<string, { label: string; color: string }> = {
+  STOREFRONT: {
+    label: "Storefront",
+    color: "color-mix(in srgb, var(--color-blue) 42%, #8794a5)",
+  },
+  HEADER: {
+    label: "Header",
+    color: "color-mix(in srgb, var(--color-blue) 42%, #8794a5)",
+  },
+  ADDRESS: {
+    label: "Address",
+    color: "color-mix(in srgb, var(--color-blue) 34%, #8794a5)",
+  },
+  ITEMS: { label: "Items", color: "var(--color-yellow)" },
+  ITEMS_VALUE: { label: "Item values", color: "var(--color-yellow)" },
+  ITEMS_DESCRIPTION: {
+    label: "Item descriptions",
+    color: "var(--color-yellow)",
+  },
+  SECTION_HEADER: { label: "Section", color: "var(--color-yellow)" },
+  TOTAL_LINE: { label: "Total line", color: "var(--color-green)" },
+  SUMMARY: { label: "Summary", color: "var(--color-green)" },
+  PAYMENT: { label: "Payment", color: "var(--color-purple)" },
+  FOOTER: {
+    label: "Footer",
+    color: "color-mix(in srgb, var(--text-color) 48%, transparent)",
+  },
+  SURVEY: {
+    label: "Survey",
+    color: "color-mix(in srgb, var(--text-color) 48%, transparent)",
+  },
+  BARCODE: {
+    label: "Barcode",
+    color: "color-mix(in srgb, var(--text-color) 48%, transparent)",
+  },
+};
+
+const sectionStyle = (sectionType: string) =>
+  SECTION_STYLES[sectionType] ?? {
+    label: sectionType.toLowerCase().replaceAll("_", " "),
+    color: "var(--color-blue)",
+  };
+
+const makeBox = (top: number, left: number, width: number, height: number) => ({
+  x: left,
+  y: 1 - top - height,
+  width,
+  height,
+});
+
+const FALLBACK_IMAGES = [
+  {
+    image_id: "0fca7cfd-183e-4109-87a9-2b7b7b94e82d",
+    receipt_id: 2,
+    width: 830,
+    height: 2827,
+    cdn_s3_key: "assets/0fca7cfd-183e-4109-87a9-2b7b7b94e82d_RECEIPT_00002.jpg",
+    cdn_webp_s3_key:
+      "assets/0fca7cfd-183e-4109-87a9-2b7b7b94e82d_RECEIPT_00002.webp",
+    cdn_medium_s3_key:
+      "assets/0fca7cfd-183e-4109-87a9-2b7b7b94e82d_RECEIPT_00002.jpg",
+  },
+  {
+    image_id: "c914012e-3fc3-4ba2-b314-fa7d423acac8",
+    receipt_id: 2,
+    width: 871,
+    height: 2914,
+    cdn_s3_key: "assets/c914012e-3fc3-4ba2-b314-fa7d423acac8_RECEIPT_00002.jpg",
+    cdn_webp_s3_key:
+      "assets/c914012e-3fc3-4ba2-b314-fa7d423acac8_RECEIPT_00002.webp",
+    cdn_medium_s3_key:
+      "assets/c914012e-3fc3-4ba2-b314-fa7d423acac8_RECEIPT_00002.jpg",
+  },
+  {
+    image_id: "00ded398-af6f-4a49-86f7-c79ccb554e48",
+    receipt_id: 2,
+    width: 792,
+    height: 2575,
+    cdn_s3_key: "assets/00ded398-af6f-4a49-86f7-c79ccb554e48_RECEIPT_00002.jpg",
+    cdn_webp_s3_key:
+      "assets/00ded398-af6f-4a49-86f7-c79ccb554e48_RECEIPT_00002.webp",
+    cdn_medium_s3_key:
+      "assets/00ded398-af6f-4a49-86f7-c79ccb554e48_RECEIPT_00002.jpg",
+  },
+] as const;
+
+const FALLBACK_LINES = [
+  [0, "SPROUTS FARMERS MARKET", 0.06, 0.22, 0.56, 0.025],
+  [1, "123 MAIN STREET", 0.12, 0.25, 0.5, 0.019],
+  [2, "ORGANIC BANANAS", 0.35, 0.14, 0.46, 0.021],
+  [3, "1.31 @ 1.29", 0.39, 0.22, 0.38, 0.019],
+  [4, "$1.69", 0.39, 0.73, 0.14, 0.019],
+  [5, "ALMOND MILK", 0.46, 0.14, 0.42, 0.021],
+  [6, "$4.99", 0.46, 0.73, 0.14, 0.019],
+  [7, "SUBTOTAL", 0.75, 0.52, 0.22, 0.022],
+  [8, "$6.68", 0.75, 0.75, 0.14, 0.022],
+  [9, "VISA 4242", 0.84, 0.18, 0.3, 0.019],
+  [10, "THANK YOU", 0.92, 0.32, 0.28, 0.019],
+] as const;
+
+const FALLBACK_SECTIONS: LineItemDecodeSection[] = [
+  { section_type: "HEADER", line_ids: [0] },
+  { section_type: "ADDRESS", line_ids: [1] },
+  { section_type: "ITEMS", line_ids: [2, 3, 4, 5, 6] },
+  { section_type: "SUMMARY", line_ids: [7, 8] },
+  { section_type: "PAYMENT", line_ids: [9] },
+  { section_type: "FOOTER", line_ids: [10] },
+];
+
+const fallbackReceipt = (
+  image: (typeof FALLBACK_IMAGES)[number],
+  index: number,
+): LineItemDecodeReceipt => {
+  const reconciliation = (["match", "mismatch", "near"] as const)[index];
+  const printedSubtotal = [6.68, 7.18, 6.7][index];
+  return {
+    image_id: image.image_id,
+    receipt_id: image.receipt_id,
+    merchant_name: "Sprouts Farmers Market",
+    image: { ...image },
+    lines: FALLBACK_LINES.map(([line_id, text, top, left, width, height]) => ({
+      line_id,
+      text,
+      bounding_box: makeBox(top, left, width, height),
+    })),
+    sections: FALLBACK_SECTIONS,
+    line_items: [
+      {
+        name: "Organic bananas",
+        price: "1.69",
+        quantity: 1.31,
+        unit_price: 1.29,
+        is_discount: false,
+        line_ids: [2, 3, 4],
+        reconciliation_status: reconciliation,
+      },
+      {
+        name: "Almond milk",
+        price: "4.99",
+        quantity: null,
+        unit_price: null,
+        is_discount: false,
+        line_ids: [5, 6],
+        reconciliation_status: reconciliation,
+      },
+    ],
+    printed_subtotal: printedSubtotal,
+  };
+};
+
+const FALLBACK_RESPONSE: LineItemDecodeResponse = {
+  receipts: FALLBACK_IMAGES.map(fallbackReceipt),
+  batch_size: FALLBACK_IMAGES.length,
+  candidate_count: FALLBACK_IMAGES.length,
+  fetched_at: "2026-07-31T00:00:00Z",
+};
+
+const usePrefersReducedMotion = (): boolean => {
+  const [reduced, setReduced] = useState(false);
+  useEffect(() => {
+    if (typeof window.matchMedia !== "function") return;
+    const query = window.matchMedia("(prefers-reduced-motion: reduce)");
+    setReduced(query.matches);
+    const onChange = (event: MediaQueryListEvent) => setReduced(event.matches);
+    query.addEventListener("change", onChange);
+    return () => query.removeEventListener("change", onChange);
+  }, []);
+  return reduced;
+};
+
+interface ReceiptQueueProps {
+  receipts: LineItemDecodeReceipt[];
+  currentIndex: number;
+  formatSupport: ImageFormatSupport | null;
+  isTransitioning: boolean;
+  isPoolExhausted: boolean;
+  shouldAnimate: boolean;
+}
+
+const ReceiptQueue: React.FC<ReceiptQueueProps> = ({
+  receipts,
+  currentIndex,
+  formatSupport,
+  isTransitioning,
+  isPoolExhausted,
+  shouldAnimate,
+}) => {
+  const maxVisible = 6;
+  const visibleReceipts = useMemo(
+    () =>
+      getVisibleQueueIndices(
+        receipts.length,
+        currentIndex,
+        maxVisible,
+        isPoolExhausted,
+      ).map((index) => receipts[index]),
+    [receipts, currentIndex, isPoolExhausted],
+  );
+
+  if (!formatSupport) return <div className={styles.receiptQueue} />;
+
+  return (
+    <div className={styles.receiptQueue} data-rf-queue>
+      {visibleReceipts.map((receipt, index) => {
+        const receiptKey = `${receipt.image_id}-${receipt.receipt_id}`;
+        const { rotation, leftOffset } = getQueuePosition(receiptKey);
+        const adjustedIndex = isTransitioning ? index - 1 : index;
+        const isFlying = isTransitioning && index === 0;
+        const imageUrl = getBestImageUrl(
+          receipt.image,
+          formatSupport,
+          "thumbnail",
+        );
+        return (
+          <div
+            key={`${receiptKey}-queue-${index}`}
+            className={styles.queuedReceipt}
+            data-rf-card-id={receiptKey}
+            style={{
+              top: `${Math.max(0, adjustedIndex) * 20}px`,
+              left: `${10 + leftOffset}px`,
+              opacity: isFlying ? 0 : shouldAnimate ? 1 : 0,
+              transform: `rotate(${rotation}deg) translateY(${shouldAnimate ? 0 : -50}px)`,
+              transitionDelay: `${index * 50}ms`,
+              zIndex: maxVisible - index,
+            }}
+          >
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={imageUrl}
+              alt={`Queued receipt ${index + 1}`}
+              width={100}
+              height={150}
+              loading="lazy"
+              decoding="async"
+              onError={(event) => {
+                const fallback = getJpegFallbackUrl(receipt.image);
+                if (event.currentTarget.src !== fallback) {
+                  event.currentTarget.src = fallback;
+                }
+              }}
+            />
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+interface ActiveReceiptProps {
+  receipt: LineItemDecodeReceipt;
+  sections: LineItemDecodeSection[];
+  sectionCount: number;
+  itemCount: number;
+  phase: Phase;
+  formatSupport: ImageFormatSupport | null;
+}
+
+const ActiveReceipt: React.FC<ActiveReceiptProps> = ({
+  receipt,
+  sections,
+  sectionCount,
+  itemCount,
+  phase,
+  formatSupport,
+}) => {
+  const imageUrl = useMemo(
+    () =>
+      formatSupport ? getBestImageUrl(receipt.image, formatSupport) : null,
+    [receipt.image, formatSupport],
+  );
+  const { width, height } = receipt.image;
+  const revealedSections = sections.slice(0, sectionCount);
+  const visibleItems = receipt.line_items.slice(0, itemCount);
+
+  const itemBoxes = useMemo<OverlayBox[]>(
+    () =>
+      visibleItems.flatMap((item, index) => {
+        const bounds = boundsForLineIds(receipt.lines, item.line_ids);
+        if (!bounds) return [];
+        return [
+          {
+            key: `item-${index}`,
+            x: bounds.x * width,
+            y: bounds.y * height,
+            width: bounds.width * width,
+            height: bounds.height * height,
+            color: item.is_discount
+              ? LABEL_COLORS.DISCOUNT
+              : LABEL_COLORS.LINE_TOTAL,
+            testId: `item-block-${index}`,
+          },
+        ];
+      }),
+    [visibleItems, receipt.lines, width, height],
+  );
+
+  const activeItem = phase === "decode" ? visibleItems.at(-1) : undefined;
+  const priceCarrier = activeItem
+    ? findPriceCarrierLineId(activeItem, receipt.lines)
+    : null;
+  const priceBounds =
+    priceCarrier === null
+      ? null
+      : boundsForLineIds(receipt.lines, [priceCarrier]);
+
+  if (!imageUrl) return <div className={styles.receiptLoading}>Loading…</div>;
+
+  return (
+    <div className={styles.activeReceipt}>
+      <div className={styles.receiptImageWrapper}>
+        <div
+          className={`${styles.receiptImageInner} ${sharedStyles.receiptCard}`}
+        >
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={imageUrl}
+            alt={`${receipt.merchant_name ?? "Merchant"} receipt`}
+            width={width}
+            height={height}
+            className={styles.receiptImage}
+            onError={(event) => {
+              const fallback = getJpegFallbackUrl(receipt.image);
+              if (event.currentTarget.src !== fallback) {
+                event.currentTarget.src = fallback;
+              }
+            }}
+          />
+
+          <svg
+            className={styles.svgOverlay}
+            viewBox={`0 0 ${width} ${height}`}
+            preserveAspectRatio="none"
+            aria-hidden="true"
+          >
+            {revealedSections.map((section, index) => {
+              const bounds = boundsForLineIds(receipt.lines, section.line_ids);
+              if (!bounds) return null;
+              const visual = sectionStyle(section.section_type);
+              const x = bounds.x * width;
+              const y = bounds.y * height;
+              const zoneWidth = bounds.width * width;
+              const zoneHeight = bounds.height * height;
+              const labelWidth = Math.min(
+                zoneWidth,
+                visual.label.length * 17 + 30,
+              );
+              return (
+                <g
+                  key={`${section.section_type}-${index}`}
+                  className={
+                    index === sectionCount - 1 && phase === "sections"
+                      ? styles.activeZone
+                      : styles.zone
+                  }
+                  data-testid={`section-zone-${section.section_type}`}
+                >
+                  <rect
+                    x={x}
+                    y={y}
+                    width={zoneWidth}
+                    height={zoneHeight}
+                    fill={visual.color}
+                    fillOpacity={0.22}
+                    stroke={visual.color}
+                    strokeWidth={2}
+                  />
+                  <rect
+                    x={x}
+                    y={Math.max(0, y - 25)}
+                    width={labelWidth}
+                    height={25}
+                    fill={visual.color}
+                    fillOpacity={0.92}
+                  />
+                  <text
+                    x={x + 9}
+                    y={Math.max(17, y - 7)}
+                    className={styles.zoneCaption}
+                  >
+                    {visual.label.toUpperCase()}
+                  </text>
+                </g>
+              );
+            })}
+          </svg>
+
+          {itemBoxes.length > 0 ? (
+            <LabelBoxOverlay
+              width={width}
+              height={height}
+              boxes={itemBoxes}
+              className={styles.svgOverlay}
+            />
+          ) : null}
+
+          {priceBounds ? (
+            <svg
+              className={styles.svgOverlay}
+              viewBox={`0 0 ${width} ${height}`}
+              preserveAspectRatio="none"
+              aria-hidden="true"
+            >
+              <rect
+                x={priceBounds.x * width}
+                y={priceBounds.y * height}
+                width={priceBounds.width * width}
+                height={priceBounds.height * height}
+                fill={LABEL_COLORS.LINE_TOTAL}
+                fillOpacity={0.42}
+                stroke={LABEL_COLORS.LINE_TOTAL}
+                strokeWidth={5}
+                className={styles.priceCarrier}
+                data-testid="price-carrier"
+              />
+            </svg>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const currencyFormatter = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+});
+
+const formatCurrency = (value: number): string =>
+  currencyFormatter.format(value);
+
+const quantityLabel = (item: DecodedReceiptLineItem): string | null => {
+  if (item.quantity === null) return null;
+  const quantity = Number.isInteger(item.quantity)
+    ? item.quantity.toFixed(0)
+    : item.quantity.toFixed(2).replace(/0+$/, "").replace(/\.$/, "");
+  return item.unit_price === null
+    ? `×${quantity}`
+    : `${quantity} × ${formatCurrency(item.unit_price)}`;
+};
+
+interface LedgerPanelProps {
+  receipt: LineItemDecodeReceipt;
+  sections: LineItemDecodeSection[];
+  phase: Phase;
+  sectionCount: number;
+  itemCount: number;
+  reducedMotion: boolean;
+}
+
+const LedgerPanel: React.FC<LedgerPanelProps> = ({
+  receipt,
+  sections,
+  phase,
+  sectionCount,
+  itemCount,
+  reducedMotion,
+}) => {
+  const decodedTotal = receipt.line_items
+    .slice(0, itemCount)
+    .reduce((sum, item) => sum + (Number.parseFloat(item.price) || 0), 0);
+  const totalSpring = useSpring({
+    amount: decodedTotal,
+    immediate: reducedMotion || phase !== "decode",
+    config: { tension: 210, friction: 24 },
+  });
+  const proof = useMemo(() => getReceiptProof(receipt), [receipt]);
+  const proofVisible = phase === "prove";
+  const statusClass =
+    proof.status === "match"
+      ? styles.match
+      : proof.status === "near"
+        ? styles.near
+        : proof.status === "mismatch"
+          ? styles.mismatch
+          : styles.noBaseline;
+
+  return (
+    <div className={styles.ledgerPanel} data-testid="geometric-reader-ledger">
+      <div className={styles.panelHeader}>
+        <span className={styles.eyebrow}>Deterministic decode</span>
+        <strong>{receipt.merchant_name ?? "Unknown merchant"}</strong>
+      </div>
+
+      <div className={styles.phaseRail} aria-label={`Pipeline phase: ${phase}`}>
+        {(["sections", "decode", "prove"] as const).map((value, index) => (
+          <React.Fragment key={value}>
+            {index > 0 ? <span className={styles.phaseLine} /> : null}
+            <span
+              className={`${styles.phaseStep} ${phase === value ? styles.activePhase : ""}`}
+            >
+              {value}
+            </span>
+          </React.Fragment>
+        ))}
+      </div>
+
+      <div
+        className={`${styles.sectionList} ${phase !== "sections" ? styles.compactSections : ""}`}
+      >
+        {sections.map((section, index) => {
+          const visual = sectionStyle(section.section_type);
+          const revealed = index < sectionCount;
+          return (
+            <div
+              key={`${section.section_type}-${index}`}
+              className={`${styles.sectionRow} ${revealed ? styles.revealed : ""}`}
+              aria-hidden={!revealed}
+            >
+              <span
+                className={styles.sectionSwatch}
+                style={{ background: visual.color }}
+              />
+              <span>{visual.label}</span>
+              <span className={styles.lineCount}>
+                {section.line_ids.length}L
+              </span>
+            </div>
+          );
+        })}
+      </div>
+
+      <div className={styles.ledger} aria-label="Decoded line items">
+        <div className={styles.ledgerHeading}>
+          <span>Item</span>
+          <span>Price</span>
+        </div>
+        {receipt.line_items.map((item, index) => {
+          const revealed = index < itemCount;
+          const quantity = quantityLabel(item);
+          return (
+            <div
+              key={`${item.name}-${index}`}
+              className={`${styles.ledgerRow} ${revealed ? styles.revealed : ""} ${item.is_discount ? styles.discount : ""}`}
+              aria-hidden={!revealed}
+            >
+              <span className={styles.itemName}>
+                {item.name || "Unnamed item"}
+                {quantity ? (
+                  <small className={styles.quantityChip}>{quantity}</small>
+                ) : null}
+              </span>
+              <span className={styles.itemPrice}>
+                {formatCurrency(Number.parseFloat(item.price) || 0)}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+
+      <div className={styles.runningTotal}>
+        <span>Decoded sum</span>
+        <animated.span data-testid="decoded-total">
+          {totalSpring.amount.to((amount) => formatCurrency(amount))}
+        </animated.span>
+      </div>
+
+      <div
+        className={`${styles.proof} ${proofVisible ? styles.proofVisible : ""}`}
+        aria-live="polite"
+        aria-hidden={!proofVisible}
+      >
+        <div className={styles.proofEquation}>
+          <span>{formatCurrency(proof.decodedTotal)}</span>
+          <span className={styles.proofOperator}>↔</span>
+          <span>
+            {proof.printedSubtotal === null
+              ? "—"
+              : formatCurrency(proof.printedSubtotal)}
+          </span>
+        </div>
+        <div className={`${styles.proofBadge} ${statusClass}`}>
+          {proof.status === "match"
+            ? "reconciled · exact"
+            : proof.status === "near"
+              ? `near · Δ ${formatCurrency(Math.abs(proof.delta ?? 0))}`
+              : proof.status === "mismatch"
+                ? `mismatch · Δ ${formatCurrency(Math.abs(proof.delta ?? 0))}`
+                : proof.printedSubtotal === null
+                  ? "printed subtotal unavailable"
+                  : "reconciliation unavailable"}
+        </div>
+        {proof.status === "near" || proof.status === "mismatch" ? (
+          <span className={styles.reocrNote}>re-OCR queued</span>
+        ) : null}
+      </div>
+    </div>
+  );
+};
+
+const emptyPlayback: PlaybackState = {
+  phase: "sections",
+  sectionCount: 0,
+  itemCount: 0,
+  isTransitioning: false,
+};
+
+const samePlayback = (left: PlaybackState, right: PlaybackState) =>
+  left.phase === right.phase &&
+  left.sectionCount === right.sectionCount &&
+  left.itemCount === right.itemCount &&
+  left.isTransitioning === right.isTransitioning;
+
+interface GeometricReaderInnerProps {
+  observerRef: (node?: Element | null) => void;
+  inView: boolean;
+  receipts: LineItemDecodeReceipt[];
+  formatSupport: ImageFormatSupport | null;
+  isPoolExhausted: boolean;
+  onFetchMore: () => void;
+}
+
+const GeometricReaderInner: React.FC<GeometricReaderInnerProps> = ({
+  observerRef,
+  inView,
+  receipts,
+  formatSupport,
+  isPoolExhausted,
+  onFetchMore,
+}) => {
+  const reducedMotion = usePrefersReducedMotion();
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [playback, setPlayback] = useState<PlaybackState>(emptyPlayback);
+  const [queueVisible, setQueueVisible] = useState(false);
+  const animationRef = useRef<number | null>(null);
+  const isAnimatingRef = useRef(false);
+  const receiptsRef = useRef(receipts);
+  const isPoolExhaustedRef = useRef(isPoolExhausted);
+  receiptsRef.current = receipts;
+  isPoolExhaustedRef.current = isPoolExhausted;
+
+  useEffect(() => {
+    if (inView && receipts.length > 0) setQueueVisible(true);
+  }, [inView, receipts.length]);
+
+  const remainingReceipts = receipts.length - currentIndex;
+  useEffect(() => {
+    if (remainingReceipts < QUEUE_REFETCH_THRESHOLD && !isPoolExhausted) {
+      onFetchMore();
+    }
+  }, [remainingReceipts, isPoolExhausted, onFetchMore]);
+
+  useEffect(() => {
+    if (!reducedMotion) return;
+    const receipt = receipts[currentIndex];
+    if (!receipt) return;
+    setPlayback({
+      phase: "prove",
+      sectionCount: receipt.sections.length,
+      itemCount: receipt.line_items.length,
+      isTransitioning: false,
+    });
+  }, [reducedMotion, receipts, currentIndex]);
+
+  useEffect(() => {
+    if (
+      !inView ||
+      receipts.length === 0 ||
+      reducedMotion ||
+      isAnimatingRef.current
+    ) {
+      return;
+    }
+    isAnimatingRef.current = true;
+    let receiptIndex = currentIndex;
+    let startTime = performance.now();
+
+    const publish = (next: PlaybackState) => {
+      setPlayback((previous) =>
+        samePlayback(previous, next) ? previous : next,
+      );
+    };
+
+    const animate = (now: number) => {
+      const currentReceipts = receiptsRef.current;
+      const receipt = currentReceipts[receiptIndex];
+      if (!receipt) {
+        animationRef.current = requestAnimationFrame(animate);
+        return;
+      }
+
+      const sections = orderSections(receipt.sections);
+      const motionScale = getReceiptMotionScale();
+      const sectionDuration =
+        Math.max(1, sections.length) * SECTION_STEP_MS * motionScale;
+      const decodeDuration =
+        Math.max(1, receipt.line_items.length) * ITEM_STEP_MS * motionScale;
+      const proveDuration = PROVE_DURATION_MS * motionScale;
+      const transitionDuration = TRANSITION_DURATION_MS * motionScale;
+      const elapsed = now - startTime;
+
+      if (elapsed < sectionDuration) {
+        publish({
+          phase: "sections",
+          sectionCount:
+            sections.length === 0
+              ? 0
+              : Math.min(
+                  sections.length,
+                  Math.floor(elapsed / (SECTION_STEP_MS * motionScale)) + 1,
+                ),
+          itemCount: 0,
+          isTransitioning: false,
+        });
+      } else if (elapsed < sectionDuration + decodeDuration) {
+        const decodeElapsed = elapsed - sectionDuration;
+        publish({
+          phase: "decode",
+          sectionCount: sections.length,
+          itemCount:
+            receipt.line_items.length === 0
+              ? 0
+              : Math.min(
+                  receipt.line_items.length,
+                  Math.floor(decodeElapsed / (ITEM_STEP_MS * motionScale)) + 1,
+                ),
+          isTransitioning: false,
+        });
+      } else if (elapsed < sectionDuration + decodeDuration + proveDuration) {
+        publish({
+          phase: "prove",
+          sectionCount: sections.length,
+          itemCount: receipt.line_items.length,
+          isTransitioning: false,
+        });
+      } else if (
+        elapsed <
+        sectionDuration + decodeDuration + proveDuration + transitionDuration
+      ) {
+        publish({
+          phase: "prove",
+          sectionCount: sections.length,
+          itemCount: receipt.line_items.length,
+          isTransitioning: true,
+        });
+      } else {
+        let nextIndex = receiptIndex + 1;
+        if (nextIndex >= currentReceipts.length) {
+          if (!isPoolExhaustedRef.current) {
+            animationRef.current = requestAnimationFrame(animate);
+            return;
+          }
+          nextIndex = 0;
+        }
+        receiptIndex = nextIndex;
+        setCurrentIndex(nextIndex);
+        publish(emptyPlayback);
+        startTime = now;
+      }
+      animationRef.current = requestAnimationFrame(animate);
+    };
+
+    animationRef.current = requestAnimationFrame(animate);
+    return () => {
+      if (animationRef.current !== null)
+        cancelAnimationFrame(animationRef.current);
+      isAnimatingRef.current = false;
+    };
+    // The rAF loop owns receiptIndex after startup and reads changing data via refs.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [inView, receipts.length > 0, reducedMotion]);
+
+  const getNextReceipt = useCallback(
+    (items: LineItemDecodeReceipt[], index: number) => {
+      const next = index + 1;
+      return isPoolExhausted
+        ? items[next % items.length]
+        : (items[next] ?? null);
+    },
+    [isPoolExhausted],
+  );
+  const { flyingItem, showFlying } = useFlyingReceipt(
+    playback.isTransitioning,
+    receipts,
+    currentIndex,
+    getNextReceipt,
+  );
+
+  const flyingElement = useMemo(() => {
+    if (!showFlying || !flyingItem || !formatSupport) return null;
+    const imageUrl = getBestImageUrl(flyingItem.image, formatSupport);
+    const aspectRatio = flyingItem.image.width / flyingItem.image.height;
+    let displayHeight = Math.min(500, flyingItem.image.height);
+    let displayWidth = displayHeight * aspectRatio;
+    if (displayWidth > 350) {
+      displayWidth = 350;
+      displayHeight = displayWidth / aspectRatio;
+    }
+    return (
+      <FlyingReceipt
+        imageUrl={imageUrl}
+        displayWidth={displayWidth}
+        displayHeight={displayHeight}
+        receiptId={`${flyingItem.image_id}-${flyingItem.receipt_id}`}
+      />
+    );
+  }, [showFlying, flyingItem, formatSupport]);
+
+  const currentReceipt = receipts[currentIndex];
+  const currentSections = useMemo(
+    () => orderSections(currentReceipt.sections),
+    [currentReceipt.sections],
+  );
+  const nextReceipt = isPoolExhausted
+    ? receipts[(currentIndex + 1) % receipts.length]
+    : receipts[currentIndex + 1];
+  const nextSections = nextReceipt ? orderSections(nextReceipt.sections) : [];
+  const motionScale = getReceiptMotionScale();
+  const layoutVars = useMemo(
+    () =>
+      ({
+        ...DEFAULT_LAYOUT_VARS,
+        "--rf-align-items": "center",
+        "--rf-legend-width": "240px",
+        "--rf-legend-stage-height": "500px",
+        "--rf-mobile-legend-height": "28rem",
+        "--rf-motion-scale": motionScale,
+      }) as React.CSSProperties,
+    [motionScale],
+  );
+
+  return (
+    <div
+      ref={observerRef}
+      className={styles.container}
+      data-testid="geometric-reader"
+    >
+      <ReceiptFlowShell
+        layoutVars={layoutVars}
+        isTransitioning={playback.isTransitioning}
+        stabilizeLegend
+        queue={
+          <ReceiptQueue
+            receipts={receipts}
+            currentIndex={currentIndex}
+            formatSupport={formatSupport}
+            isTransitioning={playback.isTransitioning}
+            isPoolExhausted={isPoolExhausted}
+            shouldAnimate={queueVisible}
+          />
+        }
+        center={
+          <ActiveReceipt
+            receipt={currentReceipt}
+            sections={currentSections}
+            sectionCount={playback.sectionCount}
+            itemCount={playback.itemCount}
+            phase={playback.phase}
+            formatSupport={formatSupport}
+          />
+        }
+        flying={flyingElement}
+        next={
+          playback.isTransitioning && nextReceipt ? (
+            <ActiveReceipt
+              receipt={nextReceipt}
+              sections={nextSections}
+              sectionCount={0}
+              itemCount={0}
+              phase="sections"
+              formatSupport={formatSupport}
+            />
+          ) : null
+        }
+        legend={
+          <LedgerPanel
+            receipt={currentReceipt}
+            sections={currentSections}
+            phase={playback.phase}
+            sectionCount={playback.sectionCount}
+            itemCount={playback.itemCount}
+            reducedMotion={reducedMotion}
+          />
+        }
+        nextLegend={
+          playback.isTransitioning && nextReceipt ? (
+            <LedgerPanel
+              receipt={nextReceipt}
+              sections={nextSections}
+              phase="sections"
+              sectionCount={0}
+              itemCount={0}
+              reducedMotion={reducedMotion}
+            />
+          ) : null
+        }
+      />
+    </div>
+  );
+};
+
+const GeometricReader: React.FC = () => {
+  const { ref: lazyRef, inView: nearViewport } = useInView({
+    triggerOnce: true,
+    rootMargin: "200px",
+  });
+  const { ref: animationRef, inView } = useInView({
+    threshold: 0.3,
+    triggerOnce: false,
+  });
+  const setRefs = useCallback(
+    (node?: Element | null) => {
+      lazyRef(node);
+      animationRef(node);
+    },
+    [lazyRef, animationRef],
+  );
+  const [receipts, setReceipts] = useState<LineItemDecodeReceipt[]>([]);
+  const [initialLoading, setInitialLoading] = useState(true);
+  const [isPoolExhausted, setIsPoolExhausted] = useState(false);
+  const formatSupport = useImageFormatSupport();
+  const isFetchingRef = useRef(false);
+  const didInitialFetchRef = useRef(false);
+  const emptyFetchCountRef = useRef(0);
+  const seenReceiptIds = useRef(new Set<string>());
+
+  usePreloadReceiptImages(
+    receipts.map((receipt) => receipt.image),
+    formatSupport,
+  );
+
+  const appendResponse = useCallback((response: LineItemDecodeResponse) => {
+    const newReceipts = response.receipts.filter((receipt) => {
+      const key = `${receipt.image_id}-${receipt.receipt_id}`;
+      if (seenReceiptIds.current.has(key)) return false;
+      seenReceiptIds.current.add(key);
+      return true;
+    });
+    if (newReceipts.length > 0) {
+      setReceipts((current) => [...current, ...newReceipts]);
+      emptyFetchCountRef.current = 0;
+    } else {
+      emptyFetchCountRef.current += 1;
+      if (emptyFetchCountRef.current >= MAX_EMPTY_FETCHES) {
+        setIsPoolExhausted(true);
+      }
+    }
+  }, []);
+
+  const fetchMore = useCallback(async () => {
+    if (isFetchingRef.current || isPoolExhausted) return;
+    isFetchingRef.current = true;
+    try {
+      appendResponse(await api.fetchLineItemDecode(BATCH_SIZE));
+    } catch (error) {
+      console.error("Failed to fetch more geometric-reader receipts:", error);
+      setIsPoolExhausted(true);
+    } finally {
+      isFetchingRef.current = false;
+    }
+  }, [appendResponse, isPoolExhausted]);
+
+  useEffect(() => {
+    if (!nearViewport || didInitialFetchRef.current) return;
+    didInitialFetchRef.current = true;
+    const load = async () => {
+      try {
+        const response = await api.fetchLineItemDecode(BATCH_SIZE);
+        if (response.receipts.length === 0)
+          throw new Error("No decoded receipts");
+        appendResponse(response);
+      } catch (error) {
+        console.error("Using geometric-reader fallback data:", error);
+        appendResponse(FALLBACK_RESPONSE);
+        setIsPoolExhausted(true);
+      } finally {
+        setInitialLoading(false);
+      }
+    };
+    load();
+  }, [nearViewport, appendResponse]);
+
+  if (!nearViewport || initialLoading) {
+    return (
+      <div ref={setRefs} className={styles.container}>
+        <ReceiptFlowLoadingShell
+          variant="layoutlm"
+          layoutVars={
+            {
+              ...DEFAULT_LAYOUT_VARS,
+              "--rf-align-items": "center",
+            } as React.CSSProperties
+          }
+        />
+      </div>
+    );
+  }
+
+  if (receipts.length === 0) {
+    return (
+      <div ref={setRefs} className={styles.container}>
+        <ReceiptFlowLoadingShell
+          variant="layoutlm"
+          message="No line-item decode data available"
+        />
+      </div>
+    );
+  }
+
+  return (
+    <GeometricReaderInner
+      observerRef={setRefs}
+      inView={inView}
+      receipts={receipts}
+      formatSupport={formatSupport}
+      isPoolExhausted={isPoolExhausted}
+      onFetchMore={fetchMore}
+    />
+  );
+};
+
+export default GeometricReader;

--- a/portfolio/components/ui/Figures/index.ts
+++ b/portfolio/components/ui/Figures/index.ts
@@ -95,6 +95,13 @@ const DynamicLayoutLMInferenceVisualization = dynamic(
   }
 );
 export const LayoutLMInferenceVisualization = DynamicLayoutLMInferenceVisualization;
+export const GeometricReader = dynamic(
+  () => import("./GeometricReader"),
+  {
+    ssr: false,
+    loading: () => loadingShell("layoutlm"),
+  }
+);
 export const PageCurlLetter = dynamic(() => import("./PageCurlLetter"), { ssr: false });
 export const PrecisionRecallDartboard = dynamic(() => import("./PrecisionRecallDartboard"), { ssr: false });
 export { default as RandomReceiptWithLabels } from "./RandomReceiptWithLabels";

--- a/portfolio/services/api/index.ts
+++ b/portfolio/services/api/index.ts
@@ -16,6 +16,7 @@ import {
   MilkSimilarityResponse,
   TrainingMetricsResponse,
   LayoutLMBatchInferenceResponse,
+  LineItemDecodeResponse,
   EpochEvaluationResponse,
   EpochEvaluationJobsResponse,
   EpochEvaluationReceiptRecord,
@@ -276,6 +277,25 @@ const baseApi = {
     const apiUrl = getAPIUrl();
     const response = await fetch(
       `${apiUrl}/layoutlm_inference`,
+      fetchConfig
+    );
+    if (!response.ok) {
+      throw new Error(
+        `Network response was not ok (status: ${response.status})`
+      );
+    }
+    return response.json();
+  },
+
+  async fetchLineItemDecode(
+    batchSize: number = 5
+  ): Promise<LineItemDecodeResponse> {
+    const apiUrl = getAPIUrl();
+    const params = new URLSearchParams({
+      batch_size: batchSize.toString(),
+    });
+    const response = await fetch(
+      `${apiUrl}/line_item_decode?${params.toString()}`,
       fetchConfig
     );
     if (!response.ok) {

--- a/portfolio/types/api.ts
+++ b/portfolio/types/api.ts
@@ -510,6 +510,77 @@ export interface LayoutLMBatchInferenceResponse {
   legacy_mode?: boolean;
 }
 
+// Deterministic line-item decode visualization types
+
+export type LineItemReconciliationStatus =
+  | "match"
+  | "near"
+  | "mismatch"
+  | "no-baseline";
+
+export interface LineItemDecodeImage {
+  image_id: string;
+  receipt_id: number;
+  width: number;
+  height: number;
+  cdn_s3_bucket?: string;
+  cdn_s3_key: string;
+  cdn_webp_s3_key?: string;
+  cdn_avif_s3_key?: string;
+  cdn_thumbnail_s3_key?: string;
+  cdn_thumbnail_webp_s3_key?: string;
+  cdn_thumbnail_avif_s3_key?: string;
+  cdn_small_s3_key?: string;
+  cdn_small_webp_s3_key?: string;
+  cdn_small_avif_s3_key?: string;
+  cdn_medium_s3_key?: string;
+  cdn_medium_webp_s3_key?: string;
+  cdn_medium_avif_s3_key?: string;
+}
+
+export interface LineItemDecodeLine {
+  line_id: number;
+  text: string;
+  bounding_box: BoundingBox;
+  top_left?: Point;
+  top_right?: Point;
+  bottom_left?: Point;
+  bottom_right?: Point;
+}
+
+export interface LineItemDecodeSection {
+  section_type: string;
+  line_ids: number[];
+}
+
+export interface DecodedReceiptLineItem {
+  name: string;
+  price: string;
+  quantity: number | null;
+  unit_price: number | null;
+  is_discount: boolean;
+  line_ids: number[];
+  reconciliation_status: LineItemReconciliationStatus | null;
+}
+
+export interface LineItemDecodeReceipt {
+  image_id: string;
+  receipt_id: number;
+  merchant_name: string | null;
+  image: LineItemDecodeImage;
+  lines: LineItemDecodeLine[];
+  sections: LineItemDecodeSection[];
+  line_items: DecodedReceiptLineItem[];
+  printed_subtotal: number | null;
+}
+
+export interface LineItemDecodeResponse {
+  receipts: LineItemDecodeReceipt[];
+  batch_size: number;
+  candidate_count: number;
+  fetched_at: string;
+}
+
 // Per-Epoch Checkpoint Evaluation Types
 // Produced by the eval-checkpoints SageMaker Processing job and served by
 // GET /layoutlm_epochs. Each entry re-scores one checkpoint on the run's


### PR DESCRIPTION
## Summary

- add the exported `GeometricReader` figure: a continuous ReceiptFlow carousel through SECTIONS → DECODE → PROVE
- tint stored receipt sections, outline decoded item blocks, emphasize each price-carrying OCR line, and build a synchronized item ledger with quantity chips and a running sum
- reconcile against the stored printed subtotal without flattening real outcomes: exact matches are green, near/mismatch results show their delta and `re-OCR queued`
- add `GET /line_item_decode`, backed by the stack's `DYNAMODB_TABLE_NAME`, to sample receipts that have `RECEIPT_LINE_ITEM` rows and hydrate their receipt image, OCR lines, sections, full item set, and summary

## Existing patterns reused

- `LayoutLMBatchVisualization`: dual `useInView` gates, queue refill/deduplication, rAF playback ownership, motion scaling, loading fallback, and receipt-to-receipt timing
- shared `ReceiptFlowShell`, `FlyingReceipt`, `useFlyingReceipt`, queue geometry utilities, loading shell, and image-format detection/preloading
- shared `LabelBoxOverlay` and `labelStyles` palette for item geometry
- `@react-spring/web` for the running decoded sum, plus a static resolved state for `prefers-reduced-motion`
- `RouteLambdaDefinition`/`create_route_lambda`, the shared Dynamo layer, the `GSITYPE` line-item access pattern, `GSI4` receipt details, and receipt-partition reads used by existing routes

No MDX or page placement is included; the figure is exported for a separate editorial decision.

## Representative route response

Generated through the handler with a fixture-backed `DynamoClient` using the same entity attributes as the deployed layer:

```json
{
  "receipts": [
    {
      "image_id": "11111111-1111-4111-8111-111111111111",
      "receipt_id": 1,
      "merchant_name": "Test Market",
      "image": {
        "image_id": "11111111-1111-4111-8111-111111111111",
        "receipt_id": 1,
        "width": 600,
        "height": 1200,
        "cdn_s3_bucket": "cdn",
        "cdn_s3_key": "receipts/1.jpg",
        "cdn_webp_s3_key": "receipts/1.webp"
      },
      "lines": [
        {
          "line_id": 1,
          "text": "BANANAS $1.69",
          "bounding_box": { "x": 0.1, "y": 0.5, "width": 0.8, "height": 0.03 },
          "top_left": { "x": 0.1, "y": 0.47 },
          "top_right": { "x": 0.9, "y": 0.47 },
          "bottom_left": { "x": 0.1, "y": 0.5 },
          "bottom_right": { "x": 0.9, "y": 0.5 }
        }
      ],
      "sections": [{ "section_type": "ITEMS", "line_ids": [1] }],
      "line_items": [
        {
          "name": "Bananas",
          "price": "1.69",
          "quantity": 1.31,
          "unit_price": 1.29,
          "is_discount": false,
          "line_ids": [1],
          "reconciliation_status": "match"
        }
      ],
      "printed_subtotal": 1.69
    }
  ],
  "batch_size": 1,
  "candidate_count": 1,
  "fetched_at": "2026-07-31T17:31:38.407599+00:00"
}
```

## Validation

- `npm run lint` (0 errors; existing repository warnings only)
- `npm run type-check`
- `npm run test:ci` (53 suites, 322 tests)
- `npx jest components/ui/Figures/GeometricReader/GeometricReader.test.tsx --runInBand` (3 tests)
- `npx prettier --check` on all new figure TS/TSX/CSS files
- `black --check --line-length=79` on the new route plus `infra/__main__.py`
- Python 3.12 `py_compile` / AST validation on the new route and registration
- temporary local Next preview in the in-app browser at 1280×720 and 390×844: no console errors, no framework overlay, no horizontal overflow, mobile queue hidden, ledger stacked below the receipt
- observed a complete receipt handoff from an exact match to a persisted mismatch; the latter rendered `$6.68 ↔ $7.18`, `mismatch · Δ $0.50`, and `re-OCR queued`

Rendered desktop/mobile screenshots were captured during QA, but no GIF or screenshot binary is attached: this figure deliberately has no page route yet, and committing a preview page or media asset would exceed the requested file/editorial scope.

No `pulumi up` was run.
