### PR TITLE
Add CDN re-warp scan/repair tool for receipt crops

### DIFF
--- a/scripts/rewarp_receipt_cdn_images.py
+++ b/scripts/rewarp_receipt_cdn_images.py
@@ -111,9 +111,14 @@ PROBED_VARIANTS: tuple[tuple[str, str], ...] = (
 VERDICT_SEVERITY = {
     "ok": 0,
     "cdn_unreadable": 1,
-    "aspect_mismatch": 2,
-    "rotated_90": 3,
+    "stale_timestamp": 2,
+    "aspect_mismatch": 3,
+    "rotated_90": 4,
 }
+
+# Verdicts that mean the published asset does not depict the receipt the
+# entity describes, and so should be rebuilt.
+MISMATCH_VERDICTS = ("rotated_90", "aspect_mismatch", "stale_timestamp")
 
 
 @dataclass
@@ -126,6 +131,7 @@ class VariantProbe:
     width: Optional[int] = None
     height: Optional[int] = None
     aspect: Optional[float] = None
+    last_modified: Optional[str] = None
     note: Optional[str] = None
 
 
@@ -140,20 +146,18 @@ class ScanResult:
     entity_height: int = 0
     entity_aspect: Optional[float] = None
     quad_aspect: Optional[float] = None
+    entity_timestamp: Optional[str] = None
+    newest_asset_timestamp: Optional[str] = None
     variants: list[VariantProbe] = field(default_factory=list)
     notes: list[str] = field(default_factory=list)
 
     @property
     def is_mismatch(self) -> bool:
-        return self.status in ("rotated_90", "aspect_mismatch")
+        return self.status in MISMATCH_VERDICTS
 
     @property
     def bad_variants(self) -> list[VariantProbe]:
-        return [
-            v
-            for v in self.variants
-            if v.verdict in ("rotated_90", "aspect_mismatch")
-        ]
+        return [v for v in self.variants if v.verdict in MISMATCH_VERDICTS]
 
 
 def _aspect(width: float, height: float) -> Optional[float]:
@@ -224,8 +228,8 @@ def _open_image_size(data: bytes) -> Optional[tuple[int, int]]:
 
 def _probe_cdn_size(
     s3_client: Any, bucket: str, key: str
-) -> tuple[Optional[tuple[int, int]], Optional[str]]:
-    """Pixel dimensions of a CDN object, or an error string.
+) -> tuple[Optional[tuple[int, int]], Optional[str], Optional[datetime]]:
+    """Pixel dimensions and mtime of a CDN object, or an error string.
 
     A ranged GET of the header is enough for JPEG/WebP/AVIF; the full
     object is fetched only if the header alone will not parse.
@@ -237,26 +241,49 @@ def _probe_cdn_size(
             Range=f"bytes=0-{HEADER_PROBE_BYTES - 1}",
         )
         head = response["Body"].read()
+        last_modified = response.get("LastModified")
     except ClientError as exc:
         code = exc.response.get("Error", {}).get("Code", "")
         if code in ("NoSuchKey", "404", "NoSuchBucket", "AccessDenied"):
-            return None, f"s3_error:{code}"
-        return None, f"s3_error:{code or exc}"
+            return None, f"s3_error:{code}", None
+        return None, f"s3_error:{code or exc}", None
     except BotoCoreError as exc:
-        return None, f"s3_error:{exc}"
+        return None, f"s3_error:{exc}", None
 
     size = _open_image_size(head)
     if size is not None:
-        return size, None
+        return size, None, last_modified
 
     try:
         full = s3_client.get_object(Bucket=bucket, Key=key)["Body"].read()
     except (ClientError, BotoCoreError) as exc:
-        return None, f"s3_error:{exc}"
+        return None, f"s3_error:{exc}", None
     size = _open_image_size(full)
     if size is None:
-        return None, "undecodable"
-    return size, None
+        return None, "undecodable", last_modified
+    return size, None, last_modified
+
+
+def _entity_timestamp(receipt: Receipt) -> Optional[datetime]:
+    """The Receipt row's own timestamp, as an aware UTC datetime.
+
+    ``timestamp_added`` is the only timestamp the entity carries. It is
+    rewritten whenever the receipt is re-created (re-segmentation), so an
+    asset older than it cannot depict the current geometry.
+    """
+    raw = getattr(receipt, "timestamp_added", None)
+    if isinstance(raw, datetime):
+        parsed = raw
+    elif isinstance(raw, str):
+        try:
+            parsed = datetime.fromisoformat(raw)
+        except ValueError:
+            return None
+    else:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
 
 
 def scan_receipt(
@@ -315,6 +342,30 @@ def scan_receipt(
         (v.verdict for v in result.variants),
         key=lambda verdict: VERDICT_SEVERITY.get(verdict, 0),
     )
+
+    # Aspect grading only catches assets whose *shape* changed. A crop
+    # rebuilt from shifted corners can keep almost the same ratio while
+    # every word box lands off the text, so also compare when the asset
+    # was written against when the receipt row was written.
+    entity_ts = _entity_timestamp(receipt)
+    if entity_ts is not None:
+        result.entity_timestamp = entity_ts.isoformat()
+
+    mtimes = [
+        datetime.fromisoformat(v.last_modified)
+        for v in result.variants
+        if v.last_modified
+    ]
+    if mtimes:
+        newest = max(mtimes)
+        result.newest_asset_timestamp = newest.isoformat()
+        if entity_ts is not None and newest < entity_ts:
+            result.notes.append(
+                f"asset written {newest.isoformat()} predates receipt "
+                f"row {entity_ts.isoformat()}"
+            )
+            if result.status == "ok":
+                result.status = "stale_timestamp"
     return result
 
 
@@ -327,7 +378,11 @@ def _probe_variant(
 ) -> VariantProbe:
     """Measure one CDN variant and grade it against the entity aspect."""
     probe = VariantProbe(name=name, key=key, verdict="ok")
-    size, error = _probe_cdn_size(s3_client, bucket, key)
+    size, error, last_modified = _probe_cdn_size(s3_client, bucket, key)
+    if last_modified is not None:
+        probe.last_modified = last_modified.astimezone(
+            timezone.utc
+        ).isoformat()
     if size is None:
         probe.verdict = "cdn_unreadable"
         probe.note = error or "unknown"
@@ -772,6 +827,17 @@ def parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
         help="Restrict to this image id. Repeatable.",
     )
     parser.add_argument(
+        "--force",
+        action="store_true",
+        help=(
+            "Rebuild every receipt matched by --image-id/--image-ids-file "
+            "regardless of its scan verdict. For assets the aspect check "
+            "cannot see through, e.g. a shifted crop that kept its ratio. "
+            "Backups and the alignment self-check still apply -- the "
+            "self-check is the real gate. Refused with --apply-all."
+        ),
+    )
+    parser.add_argument(
         "--image-ids-file",
         help=(
             "File of image ids, one per line (blank lines and '#' "
@@ -854,6 +920,22 @@ def main(argv: Optional[list[str]] = None) -> int:
             "--apply without an image filter requires --apply-all; "
             "refusing to rewrite every receipt in %s by accident.",
             args.table,
+        )
+        return 2
+
+    if args.force and args.apply_all:
+        logger.error(
+            "--force with --apply-all would rebuild every receipt in %s "
+            "with no verdict filtering at all; refusing. Name the "
+            "receipts with --image-id or --image-ids-file.",
+            args.table,
+        )
+        return 2
+
+    if args.force and not args.image_ids and not args.image_ids_file:
+        logger.error(
+            "--force needs --image-id or --image-ids-file to say what to "
+            "rebuild."
         )
         return 2
 
@@ -975,7 +1057,17 @@ def main(argv: Optional[list[str]] = None) -> int:
     if args.apply or args.dry_run_apply:
         by_key = {(r.image_id, r.receipt_id): r for r in receipts}
         applied: list[dict[str, Any]] = []
-        for result in mismatches:
+        # --force rebuilds everything named on the command line; the
+        # alignment self-check, not the scan verdict, decides what is
+        # safe to publish.
+        targets = results if args.force else mismatches
+        if args.force:
+            logger.info(
+                "--force: rebuilding all %d matched receipts regardless "
+                "of scan verdict",
+                len(targets),
+            )
+        for result in targets:
             if (result.image_id, result.receipt_id) in excludes:
                 applied.append(
                     {

--- a/scripts/rewarp_receipt_cdn_images.py
+++ b/scripts/rewarp_receipt_cdn_images.py
@@ -1,0 +1,891 @@
+#!/usr/bin/env python3
+"""Detect and repair receipt CDN images that disagree with their entity.
+
+A published CDN crop is supposed to be the receipt warped upright. When
+the served asset was built from different geometry than the Receipt row
+now carries -- a stale crop left behind after re-segmentation, two
+receipts' assets swapped, or a crop stored rotated -- the rendered image
+no longer lines up with the OCR coordinate frame every downstream
+consumer assumes.
+
+The Receipt entity is the source of truth. Its four image-normalised,
+y-up corners plus ``width``/``height`` define the upright warp that the
+receipt-relative OCR coordinates live in. Repairs re-derive that warp
+with the same transform the FIRST_PASS ingest path uses
+(``ocr_processor._get_perspective_coeffs`` ->
+``Image.transform(PERSPECTIVE)``, shared here via
+``ocr_migration_publish_crops.warp_receipt_crop``), so a repaired asset
+lands in the coordinate frame the words were recorded in.
+
+Scan mode measures every published size variant independently -- they
+are uploaded separately and have been observed to disagree -- and grades
+each one's pixel aspect ratio against the entity's declared dimensions.
+Apply mode rebuilds the crop from the original upload and republishes
+every variant to the same keys, but only after a self-check projects
+real OCR word boxes onto the new canvas and confirms the text lands
+inside them.
+
+Usage::
+
+    # scan (default; never writes)
+    python scripts/rewarp_receipt_cdn_images.py \
+        --table ReceiptsTable-dc5be22 --report-json /tmp/scan.json
+
+    # preview what a repair would do, uploading nothing
+    python scripts/rewarp_receipt_cdn_images.py \
+        --table ReceiptsTable-dc5be22 --dry-run-apply
+
+    # repair a single image's receipts
+    python scripts/rewarp_receipt_cdn_images.py \
+        --table ReceiptsTable-dc5be22 --image-id <uuid> --apply
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import logging
+import math
+import os
+import sys
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import asdict, dataclass, field
+from typing import Any, Optional
+
+import boto3
+from botocore.config import Config as BotoConfig
+from botocore.exceptions import BotoCoreError, ClientError
+from PIL import Image as PIL_Image
+from PIL import ImageOps, ImageStat, UnidentifiedImageError
+
+from receipt_dynamo import DynamoClient
+from receipt_dynamo.entities import Image as ImageEntity
+from receipt_dynamo.entities import Receipt, ReceiptWord
+from receipt_upload.utils import upload_all_cdn_formats
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# isort: off
+from scripts.ocr_migration_publish_crops import (  # noqa: E402
+    CDN_KEY_FIELDS,
+    expected_cdn_keys,
+    warp_receipt_crop,
+)
+
+# isort: on
+
+logger = logging.getLogger("rewarp_receipt_cdn_images")
+
+# Aspect ratios within this relative tolerance are treated as equal. CDN
+# variants are resized with integer rounding, so a thumbnail's ratio
+# never matches the full-size ratio exactly.
+ASPECT_TOLERANCE = 0.04
+
+# A quad whose implied aspect ratio disagrees with the entity's declared
+# width/height by more than this is reported as suspect entity geometry.
+QUAD_ASPECT_TOLERANCE = 0.20
+
+# Mean 0-255 luminance gap (surrounding ring minus word interior) that a
+# rebuilt crop must clear for its OCR boxes to count as aligned.
+DEFAULT_DARKNESS_MARGIN = 6.0
+
+# Bytes pulled for a ranged probe. Enough for any JPEG/WebP/AVIF header,
+# and usually the whole thumbnail.
+HEADER_PROBE_BYTES = 65536
+
+
+# Size variants probed during a scan, worst-first for reporting. Each
+# variant is checked independently because they are uploaded separately
+# and have been observed to disagree with each other.
+PROBED_VARIANTS: tuple[tuple[str, str], ...] = (
+    ("full", "cdn_s3_key"),
+    ("medium", "cdn_medium_s3_key"),
+    ("small", "cdn_small_s3_key"),
+    ("thumbnail", "cdn_thumbnail_s3_key"),
+)
+
+# Verdicts ordered by severity, so a receipt's overall status is the
+# worst of its variants.
+VERDICT_SEVERITY = {
+    "ok": 0,
+    "cdn_unreadable": 1,
+    "aspect_mismatch": 2,
+    "rotated_90": 3,
+}
+
+
+@dataclass
+class VariantProbe:
+    """One CDN size variant's measured dimensions and verdict."""
+
+    name: str
+    key: str
+    verdict: str
+    width: Optional[int] = None
+    height: Optional[int] = None
+    aspect: Optional[float] = None
+    note: Optional[str] = None
+
+
+@dataclass
+class ScanResult:
+    """One receipt's scan verdict across all CDN size variants."""
+
+    image_id: str
+    receipt_id: int
+    status: str
+    entity_width: int = 0
+    entity_height: int = 0
+    entity_aspect: Optional[float] = None
+    quad_aspect: Optional[float] = None
+    variants: list[VariantProbe] = field(default_factory=list)
+    notes: list[str] = field(default_factory=list)
+
+    @property
+    def is_mismatch(self) -> bool:
+        return self.status in ("rotated_90", "aspect_mismatch")
+
+    @property
+    def bad_variants(self) -> list[VariantProbe]:
+        return [
+            v
+            for v in self.variants
+            if v.verdict in ("rotated_90", "aspect_mismatch")
+        ]
+
+
+def _aspect(width: float, height: float) -> Optional[float]:
+    if width <= 0 or height <= 0:
+        return None
+    return width / height
+
+
+def _close(a: float, b: float, tolerance: float) -> bool:
+    """Relative comparison in log space, so a/b and b/a are symmetric."""
+    if a <= 0 or b <= 0:
+        return False
+    return abs(math.log(a / b)) <= math.log1p(tolerance)
+
+
+def _corner_pixels(
+    receipt: Receipt, image_width: int, image_height: int
+) -> list[tuple[float, float]]:
+    """The receipt's four corners as PIL pixels on the original image.
+
+    Entity corners are image-normalised and y-up (OCR convention); PIL
+    counts rows downward, hence the ``1 - y``.
+    """
+    return [
+        (
+            receipt.top_left["x"] * image_width,
+            (1.0 - receipt.top_left["y"]) * image_height,
+        ),
+        (
+            receipt.top_right["x"] * image_width,
+            (1.0 - receipt.top_right["y"]) * image_height,
+        ),
+        (
+            receipt.bottom_right["x"] * image_width,
+            (1.0 - receipt.bottom_right["y"]) * image_height,
+        ),
+        (
+            receipt.bottom_left["x"] * image_width,
+            (1.0 - receipt.bottom_left["y"]) * image_height,
+        ),
+    ]
+
+
+def _quad_aspect(
+    receipt: Receipt, image_width: int, image_height: int
+) -> Optional[float]:
+    """Aspect ratio implied by the corner quad itself, in image pixels.
+
+    Compared against the declared width/height this catches entities
+    whose stored dimensions never matched their own geometry.
+    """
+    tl, tr, br, bl = _corner_pixels(receipt, image_width, image_height)
+    top = math.dist(tl, tr)
+    bottom = math.dist(bl, br)
+    left = math.dist(tl, bl)
+    right = math.dist(tr, br)
+    return _aspect((top + bottom) / 2.0, (left + right) / 2.0)
+
+
+def _open_image_size(data: bytes) -> Optional[tuple[int, int]]:
+    """Read pixel dimensions from (possibly partial) encoded bytes."""
+    try:
+        with PIL_Image.open(io.BytesIO(data)) as img:
+            return img.size
+    except (UnidentifiedImageError, OSError, ValueError):
+        return None
+
+
+def _probe_cdn_size(
+    s3_client: Any, bucket: str, key: str
+) -> tuple[Optional[tuple[int, int]], Optional[str]]:
+    """Pixel dimensions of a CDN object, or an error string.
+
+    A ranged GET of the header is enough for JPEG/WebP/AVIF; the full
+    object is fetched only if the header alone will not parse.
+    """
+    try:
+        response = s3_client.get_object(
+            Bucket=bucket,
+            Key=key,
+            Range=f"bytes=0-{HEADER_PROBE_BYTES - 1}",
+        )
+        head = response["Body"].read()
+    except ClientError as exc:
+        code = exc.response.get("Error", {}).get("Code", "")
+        if code in ("NoSuchKey", "404", "NoSuchBucket", "AccessDenied"):
+            return None, f"s3_error:{code}"
+        return None, f"s3_error:{code or exc}"
+    except BotoCoreError as exc:
+        return None, f"s3_error:{exc}"
+
+    size = _open_image_size(head)
+    if size is not None:
+        return size, None
+
+    try:
+        full = s3_client.get_object(Bucket=bucket, Key=key)["Body"].read()
+    except (ClientError, BotoCoreError) as exc:
+        return None, f"s3_error:{exc}"
+    size = _open_image_size(full)
+    if size is None:
+        return None, "undecodable"
+    return size, None
+
+
+def scan_receipt(
+    receipt: Receipt,
+    image_entity: Optional[ImageEntity],
+    s3_client: Any,
+) -> ScanResult:
+    """Compare a receipt's published CDN asset against its entity."""
+    result = ScanResult(
+        image_id=receipt.image_id,
+        receipt_id=receipt.receipt_id,
+        status="ok",
+        entity_width=receipt.width,
+        entity_height=receipt.height,
+    )
+    result.entity_aspect = _aspect(receipt.width, receipt.height)
+
+    if image_entity is not None:
+        try:
+            result.quad_aspect = _quad_aspect(
+                receipt, image_entity.width, image_entity.height
+            )
+        except (TypeError, KeyError, ValueError) as exc:
+            result.notes.append(f"quad_aspect_failed:{exc}")
+        if (
+            result.quad_aspect is not None
+            and result.entity_aspect is not None
+            and not _close(
+                result.quad_aspect,
+                result.entity_aspect,
+                QUAD_ASPECT_TOLERANCE,
+            )
+        ):
+            result.notes.append("entity_geometry_suspect")
+    else:
+        result.notes.append("image_entity_missing")
+
+    bucket = receipt.cdn_s3_bucket
+    if not bucket:
+        result.status = "no_cdn_asset"
+        return result
+
+    for name, field_name in PROBED_VARIANTS:
+        key = getattr(receipt, field_name, None)
+        if not key:
+            continue
+        result.variants.append(
+            _probe_variant(s3_client, bucket, name, key, result.entity_aspect)
+        )
+
+    if not result.variants:
+        result.status = "no_cdn_asset"
+        return result
+
+    result.status = max(
+        (v.verdict for v in result.variants),
+        key=lambda verdict: VERDICT_SEVERITY.get(verdict, 0),
+    )
+    return result
+
+
+def _probe_variant(
+    s3_client: Any,
+    bucket: str,
+    name: str,
+    key: str,
+    entity_aspect: Optional[float],
+) -> VariantProbe:
+    """Measure one CDN variant and grade it against the entity aspect."""
+    probe = VariantProbe(name=name, key=key, verdict="ok")
+    size, error = _probe_cdn_size(s3_client, bucket, key)
+    if size is None:
+        probe.verdict = "cdn_unreadable"
+        probe.note = error or "unknown"
+        return probe
+
+    probe.width, probe.height = size
+    probe.aspect = _aspect(*size)
+    if probe.aspect is None or entity_aspect is None:
+        probe.verdict = "cdn_unreadable"
+        probe.note = "degenerate_dimensions"
+        return probe
+
+    if _close(probe.aspect, entity_aspect, ASPECT_TOLERANCE):
+        probe.verdict = "ok"
+    elif _close(probe.aspect, 1.0 / entity_aspect, ASPECT_TOLERANCE):
+        probe.verdict = "rotated_90"
+    else:
+        probe.verdict = "aspect_mismatch"
+    return probe
+
+
+def _word_boxes_in_pixels(
+    words: list[ReceiptWord], canvas_width: int, canvas_height: int
+) -> list[tuple[int, int, int, int]]:
+    """Receipt-relative y-up word boxes as PIL pixel boxes."""
+    boxes: list[tuple[int, int, int, int]] = []
+    for word in words:
+        bbox = getattr(word, "bounding_box", None)
+        if not bbox:
+            continue
+        try:
+            x = float(bbox["x"])
+            y = float(bbox["y"])
+            w = float(bbox["width"])
+            h = float(bbox["height"])
+        except (KeyError, TypeError, ValueError):
+            continue
+        left = int(round(x * canvas_width))
+        right = int(round((x + w) * canvas_width))
+        # y is the bottom edge in y-up space; PIL rows count downward.
+        top = int(round((1.0 - (y + h)) * canvas_height))
+        bottom = int(round((1.0 - y) * canvas_height))
+        left, right = max(0, min(left, right)), min(
+            canvas_width, max(left, right)
+        )
+        top, bottom = max(0, min(top, bottom)), min(
+            canvas_height, max(top, bottom)
+        )
+        if right - left < 4 or bottom - top < 4:
+            continue
+        boxes.append((left, top, right, bottom))
+    return boxes
+
+
+def _select_probe_boxes(
+    words: list[ReceiptWord],
+    canvas_width: int,
+    canvas_height: int,
+    sample: int,
+) -> list[tuple[int, int, int, int]]:
+    """Pick text-bearing boxes spread down the receipt.
+
+    Sampling across the vertical span matters: a rotated or otherwise
+    wrong warp can still align near one edge by luck.
+    """
+    candidates = [
+        word
+        for word in words
+        if len((getattr(word, "text", "") or "").strip()) >= 3
+    ]
+    if not candidates:
+        candidates = list(words)
+    candidates.sort(
+        key=lambda w: float((w.bounding_box or {}).get("y", 0.0)),
+        reverse=True,
+    )
+    boxes = _word_boxes_in_pixels(candidates, canvas_width, canvas_height)
+    if len(boxes) <= sample:
+        return boxes
+    step = len(boxes) / float(sample)
+    return [boxes[int(i * step)] for i in range(sample)]
+
+
+def _mean_luminance(gray: PIL_Image.Image, box: tuple[int, int, int, int]):
+    """(mean, pixel count) for a crop, or None when the crop is empty."""
+    left, top, right, bottom = box
+    if right <= left or bottom <= top:
+        return None
+    crop = gray.crop(box)
+    count = (right - left) * (bottom - top)
+    return ImageStat.Stat(crop).mean[0], count
+
+
+def text_alignment_score(
+    warped: PIL_Image.Image,
+    words: list[ReceiptWord],
+    sample: int = 5,
+) -> tuple[Optional[float], int]:
+    """How much darker word interiors are than their surroundings.
+
+    Projects OCR boxes onto the rebuilt canvas and measures the 0-255
+    luminance gap between each box and the ring just outside it. Text is
+    dark on light paper, so a correct warp yields a positive gap; a warp
+    that does not match the OCR frame yields roughly zero.
+
+    Returns ``(mean gap, boxes measured)``; the gap is ``None`` when no
+    box could be measured.
+    """
+    boxes = _select_probe_boxes(words, warped.width, warped.height, sample)
+    if not boxes:
+        return None, 0
+
+    gray = warped.convert("L")
+    gaps: list[float] = []
+    for box in boxes:
+        left, top, right, bottom = box
+        pad_x = max(2, (right - left) // 2)
+        pad_y = max(2, (bottom - top))
+        outer = (
+            max(0, left - pad_x),
+            max(0, top - pad_y),
+            min(warped.width, right + pad_x),
+            min(warped.height, bottom + pad_y),
+        )
+        inner_stat = _mean_luminance(gray, box)
+        outer_stat = _mean_luminance(gray, outer)
+        if inner_stat is None or outer_stat is None:
+            continue
+        inner_mean, inner_count = inner_stat
+        outer_mean, outer_count = outer_stat
+        ring_count = outer_count - inner_count
+        if ring_count <= 0:
+            continue
+        ring_mean = (
+            outer_mean * outer_count - inner_mean * inner_count
+        ) / ring_count
+        gaps.append(ring_mean - inner_mean)
+
+    if not gaps:
+        return None, 0
+    return sum(gaps) / len(gaps), len(gaps)
+
+
+def _derive_base_key(receipt: Receipt) -> Optional[str]:
+    """Base CDN key (no size suffix, no extension) for this receipt."""
+    if not receipt.cdn_s3_key:
+        return None
+    base, _ext = os.path.splitext(receipt.cdn_s3_key)
+    return base
+
+
+def _expected_key_conflicts(
+    receipt: Receipt, base_key: str
+) -> list[tuple[str, str, str]]:
+    """Entity CDN keys that a republish would not overwrite in place.
+
+    ``upload_all_cdn_formats`` derives every variant key from the base
+    key. If the entity points somewhere else, republishing would orphan
+    the live asset instead of fixing it, so the caller must not proceed.
+    """
+    derived = expected_cdn_keys(base_key)
+    conflicts = []
+    for field_name, dict_key in CDN_KEY_FIELDS:
+        current = getattr(receipt, field_name, None)
+        if not current:
+            continue
+        expected = derived[dict_key]
+        if current != expected:
+            conflicts.append((field_name, current, expected))
+    return conflicts
+
+
+def _load_original(
+    s3_client: Any, bucket: str, key: str
+) -> tuple[Optional[PIL_Image.Image], list[str]]:
+    """Fetch the original upload, oriented the way OCR saw it.
+
+    Nothing in the ingest path applies EXIF orientation, but Vision
+    does, so the entity's normalised corners live in the transposed
+    frame. Re-warping without this step is what produces a sideways
+    crop.
+    """
+    notes: list[str] = []
+    try:
+        body = s3_client.get_object(Bucket=bucket, Key=key)["Body"].read()
+    except (ClientError, BotoCoreError) as exc:
+        notes.append(f"original_download_failed:{exc}")
+        return None, notes
+
+    try:
+        image = PIL_Image.open(io.BytesIO(body))
+        image.load()
+    except (UnidentifiedImageError, OSError, ValueError) as exc:
+        notes.append(f"original_undecodable:{exc}")
+        return None, notes
+
+    before = image.size
+    oriented = ImageOps.exif_transpose(image) or image
+    if oriented.size != before:
+        notes.append(f"exif_transposed:{before}->{oriented.size}")
+    return oriented, notes
+
+
+def rewarp_receipt(
+    dynamo: DynamoClient,
+    s3_client: Any,
+    receipt: Receipt,
+    image_entity: ImageEntity,
+    darkness_margin: float,
+    dry_run: bool,
+) -> dict[str, Any]:
+    """Rebuild and republish one receipt's CDN variants.
+
+    Returns a record describing what happened. The upload only runs once
+    the rebuilt crop passes the OCR text-alignment self-check.
+    """
+    record: dict[str, Any] = {
+        "image_id": receipt.image_id,
+        "receipt_id": receipt.receipt_id,
+        "status": "skipped",
+        "notes": [],
+    }
+
+    base_key = _derive_base_key(receipt)
+    if not base_key or not receipt.cdn_s3_bucket:
+        record["status"] = "skipped_no_cdn_asset"
+        return record
+
+    conflicts = _expected_key_conflicts(receipt, base_key)
+    if conflicts:
+        record["status"] = "skipped_key_mismatch"
+        record["notes"] = [
+            f"{name}: entity={current} derived={expected}"
+            for name, current, expected in conflicts
+        ]
+        return record
+
+    original, notes = _load_original(
+        s3_client, image_entity.raw_s3_bucket, image_entity.raw_s3_key
+    )
+    record["notes"].extend(notes)
+    if original is None:
+        record["status"] = "failed_original"
+        return record
+
+    image_width, image_height = original.size
+    entity_aspect = _aspect(image_entity.width, image_entity.height)
+    actual_aspect = _aspect(image_width, image_height)
+    if (
+        entity_aspect
+        and actual_aspect
+        and not _close(entity_aspect, actual_aspect, ASPECT_TOLERANCE)
+    ):
+        record["status"] = "skipped_original_aspect"
+        record["notes"].append(
+            f"image entity {image_entity.width}x{image_entity.height} "
+            f"disagrees with original {image_width}x{image_height}"
+        )
+        return record
+
+    try:
+        warped = warp_receipt_crop(original, receipt)
+    except (ValueError, OSError) as exc:
+        record["status"] = "failed_warp"
+        record["notes"].append(str(exc))
+        return record
+
+    words = dynamo.list_receipt_words_from_receipt(
+        receipt.image_id, receipt.receipt_id
+    )
+    gap, measured = text_alignment_score(warped, words)
+    record["alignment_gap"] = None if gap is None else round(gap, 2)
+    record["alignment_boxes"] = measured
+    if gap is None:
+        record["status"] = "skipped_no_words"
+        return record
+    if gap < darkness_margin:
+        record["status"] = "skipped_alignment_check"
+        record["notes"].append(
+            f"text/background gap {gap:.2f} below margin {darkness_margin}"
+        )
+        return record
+
+    if dry_run:
+        record["status"] = "would_apply"
+        return record
+
+    try:
+        upload_all_cdn_formats(
+            warped,
+            receipt.cdn_s3_bucket,
+            base_key,
+            generate_thumbnails=True,
+        )
+    except (ClientError, BotoCoreError, OSError) as exc:
+        record["status"] = "failed_upload"
+        record["notes"].append(str(exc))
+        return record
+
+    record["status"] = "applied"
+    return record
+
+
+def _load_receipts(
+    dynamo: DynamoClient, image_ids: Optional[set[str]]
+) -> list[Receipt]:
+    receipts, _ = dynamo.list_receipts()
+    if image_ids:
+        receipts = [r for r in receipts if r.image_id in image_ids]
+    return receipts
+
+
+def _load_images(dynamo: DynamoClient) -> dict[str, ImageEntity]:
+    images: dict[str, ImageEntity] = {}
+    last_key = None
+    while True:
+        page, last_key = dynamo.list_images(last_evaluated_key=last_key)
+        for image in page:
+            images[image.image_id] = image
+        if not last_key:
+            break
+    return images
+
+
+def _summarize(results: list[ScanResult]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for result in results:
+        counts[result.status] = counts.get(result.status, 0) + 1
+    return dict(sorted(counts.items()))
+
+
+def parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Scan for (and optionally repair) receipt CDN images whose "
+            "warp does not match the Receipt entity's geometry."
+        )
+    )
+    parser.add_argument(
+        "--table",
+        required=True,
+        help="DynamoDB table name (e.g. ReceiptsTable-dc5be22).",
+    )
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument(
+        "--scan-only",
+        action="store_true",
+        default=True,
+        help="Report mismatches without writing (default).",
+    )
+    mode.add_argument(
+        "--apply",
+        action="store_true",
+        help="Rebuild and republish CDN assets for mismatched receipts.",
+    )
+    mode.add_argument(
+        "--dry-run-apply",
+        action="store_true",
+        help=(
+            "Rebuild each mismatched crop and run the alignment "
+            "self-check, but upload nothing. Use this to preview what "
+            "--apply would do."
+        ),
+    )
+    parser.add_argument(
+        "--apply-all",
+        action="store_true",
+        help=(
+            "Required with --apply when no --image-id filter is given, "
+            "so an unfiltered rewrite is never a fat-finger away."
+        ),
+    )
+    parser.add_argument(
+        "--image-id",
+        action="append",
+        dest="image_ids",
+        help="Restrict to this image id. Repeatable.",
+    )
+    parser.add_argument(
+        "--report-json",
+        help="Write the full scan/apply report to this path.",
+    )
+    parser.add_argument(
+        "--workers",
+        type=int,
+        default=16,
+        help="Parallel S3 probes during scanning (default: 16).",
+    )
+    parser.add_argument(
+        "--darkness-margin",
+        type=float,
+        default=DEFAULT_DARKNESS_MARGIN,
+        help=(
+            "Minimum 0-255 luminance gap between OCR word interiors and "
+            "their surroundings for a rebuilt crop to be published "
+            f"(default: {DEFAULT_DARKNESS_MARGIN})."
+        ),
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Log every receipt, not just mismatches.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    args = parse_args(argv)
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(levelname)s %(message)s",
+    )
+    # --verbose is about per-receipt detail, not boto's wire logging.
+    for noisy in ("boto3", "botocore", "urllib3", "s3transfer"):
+        logging.getLogger(noisy).setLevel(logging.WARNING)
+
+    if args.apply and not args.image_ids and not args.apply_all:
+        logger.error(
+            "--apply without --image-id requires --apply-all; refusing to "
+            "rewrite every receipt in %s by accident.",
+            args.table,
+        )
+        return 2
+
+    dynamo = DynamoClient(args.table)
+    s3_client = boto3.client(
+        "s3",
+        config=BotoConfig(max_pool_connections=max(args.workers, 10)),
+    )
+
+    image_ids = set(args.image_ids) if args.image_ids else None
+    receipts = _load_receipts(dynamo, image_ids)
+    images = _load_images(dynamo)
+    logger.info("Scanning %d receipts in %s", len(receipts), args.table)
+
+    results: list[ScanResult] = []
+    with ThreadPoolExecutor(max_workers=args.workers) as pool:
+        futures = {
+            pool.submit(
+                scan_receipt, receipt, images.get(receipt.image_id), s3_client
+            ): receipt
+            for receipt in receipts
+        }
+        for future in as_completed(futures):
+            receipt = futures[future]
+            try:
+                results.append(future.result())
+            except Exception as exc:  # pylint: disable=broad-except
+                results.append(
+                    ScanResult(
+                        image_id=receipt.image_id,
+                        receipt_id=receipt.receipt_id,
+                        status="scan_error",
+                        notes=[str(exc)],
+                    )
+                )
+
+    results.sort(key=lambda r: (r.image_id, r.receipt_id))
+    counts = _summarize(results)
+    mismatches = [r for r in results if r.is_mismatch]
+    suspect = [r for r in results if "entity_geometry_suspect" in r.notes]
+
+    logger.info("Scan summary for %s: %s", args.table, counts)
+    for result in results:
+        logger.debug(
+            "%s/%d %s entity=%dx%d variants: %s",
+            result.image_id,
+            result.receipt_id,
+            result.status,
+            result.entity_width,
+            result.entity_height,
+            ", ".join(
+                f"{v.name}={v.width}x{v.height}({v.verdict})"
+                for v in result.variants
+            ),
+        )
+    for result in mismatches:
+        detail = ", ".join(
+            f"{v.name}={v.width}x{v.height}({v.verdict})"
+            for v in result.bad_variants
+        )
+        logger.info(
+            "MISMATCH %s/%d status=%s entity=%dx%d bad_variants: %s",
+            result.image_id,
+            result.receipt_id,
+            result.status,
+            result.entity_width,
+            result.entity_height,
+            detail,
+        )
+    for result in suspect:
+        logger.info(
+            "ENTITY-SUSPECT %s/%d entity_aspect=%.3f quad_aspect=%.3f",
+            result.image_id,
+            result.receipt_id,
+            result.entity_aspect or 0.0,
+            result.quad_aspect or 0.0,
+        )
+
+    report: dict[str, Any] = {
+        "table": args.table,
+        "receipts_scanned": len(results),
+        "counts": counts,
+        "mismatches": [asdict(r) for r in mismatches],
+        "entity_geometry_suspect": [asdict(r) for r in suspect],
+    }
+
+    if args.apply or args.dry_run_apply:
+        by_key = {(r.image_id, r.receipt_id): r for r in receipts}
+        applied: list[dict[str, Any]] = []
+        for result in mismatches:
+            receipt = by_key.get((result.image_id, result.receipt_id))
+            image_entity = images.get(result.image_id)
+            if receipt is None or image_entity is None:
+                applied.append(
+                    {
+                        "image_id": result.image_id,
+                        "receipt_id": result.receipt_id,
+                        "status": "skipped_missing_entity",
+                    }
+                )
+                continue
+            record = rewarp_receipt(
+                dynamo,
+                s3_client,
+                receipt,
+                image_entity,
+                args.darkness_margin,
+                dry_run=args.dry_run_apply,
+            )
+            logger.info(
+                "%s %s/%d gap=%s %s",
+                record["status"].upper(),
+                record["image_id"],
+                record["receipt_id"],
+                record.get("alignment_gap"),
+                "; ".join(record.get("notes", [])),
+            )
+            applied.append(record)
+        report["applied"] = applied
+        report["apply_counts"] = _summarize(
+            [
+                ScanResult(
+                    image_id=r["image_id"],
+                    receipt_id=r["receipt_id"],
+                    status=r["status"],
+                )
+                for r in applied
+            ]
+        )
+        logger.info("Apply summary: %s", report["apply_counts"])
+
+    if args.report_json:
+        with open(args.report_json, "w", encoding="utf-8") as handle:
+            json.dump(report, handle, indent=2)
+        logger.info("Wrote report to %s", args.report_json)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/rewarp_receipt_cdn_images.py
+++ b/scripts/rewarp_receipt_cdn_images.py
@@ -588,7 +588,8 @@ def _load_original(
 
 def _backup_existing_variants(
     s3_client: Any,
-    bucket: str,
+    source_bucket: str,
+    dest_bucket: str,
     receipt: Receipt,
     backup_prefix: str,
 ) -> tuple[list[str], Optional[str]]:
@@ -596,8 +597,12 @@ def _backup_existing_variants(
 
     The site bucket has no versioning, so a republish is otherwise
     unrecoverable. Copies are server-side (no download) and land at
-    ``{backup_prefix}{original_key}``, which is also exactly the
-    argument order ``aws s3 cp`` needs to put them back.
+    ``{dest_bucket}/{backup_prefix}{original_key}``.
+
+    The destination must NOT be the site bucket. The prod deploy runs
+    ``aws s3 sync ... --delete --exclude "assets/*"`` (main.yml), so any
+    prefix that is not part of the built site is deleted on the next
+    deploy -- which is exactly how an earlier backup run was lost.
 
     Returns ``(copied keys, error)``; a non-None error means the caller
     must not overwrite anything for this receipt.
@@ -609,9 +614,9 @@ def _backup_existing_variants(
             continue
         try:
             s3_client.copy_object(
-                Bucket=bucket,
+                Bucket=dest_bucket,
                 Key=f"{backup_prefix}{key}",
-                CopySource={"Bucket": bucket, "Key": key},
+                CopySource={"Bucket": source_bucket, "Key": key},
             )
             copied.append(key)
         except ClientError as exc:
@@ -633,6 +638,8 @@ def rewarp_receipt(
     darkness_margin: float,
     dry_run: bool,
     backup_prefix: Optional[str] = None,
+    backup_bucket: Optional[str] = None,
+    allow_same_bucket: bool = False,
 ) -> dict[str, Any]:
     """Rebuild and republish one receipt's CDN variants.
 
@@ -713,10 +720,28 @@ def rewarp_receipt(
     # Back up before the first overwrite, never after: a partial upload
     # with no backup is the one outcome there is no way back from.
     if backup_prefix:
+        # Default to the raw-photo bucket: it always exists for this
+        # receipt and the site deploy never syncs over it.
+        dest_bucket = backup_bucket or image_entity.raw_s3_bucket
+        if dest_bucket == receipt.cdn_s3_bucket and not allow_same_bucket:
+            record["status"] = "skipped_backup_same_bucket"
+            record["notes"].append(
+                f"refusing to back up into the site bucket "
+                f"{dest_bucket}: the prod deploy's 'aws s3 sync --delete "
+                f"--exclude assets/*' removes any non-site prefix, which "
+                f"already destroyed one backup run. Pass --backup-bucket "
+                f"or --allow-same-bucket."
+            )
+            return record
         copied, error = _backup_existing_variants(
-            s3_client, receipt.cdn_s3_bucket, receipt, backup_prefix
+            s3_client,
+            receipt.cdn_s3_bucket,
+            dest_bucket,
+            receipt,
+            backup_prefix,
         )
         record["backed_up"] = len(copied)
+        record["backup_bucket"] = dest_bucket
         if error:
             record["status"] = "skipped_backup_failed"
             record["notes"].append(error)
@@ -857,11 +882,28 @@ def parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
         ),
     )
     parser.add_argument(
+        "--backup-bucket",
+        help=(
+            "Bucket to copy live CDN objects into before overwriting. "
+            "Defaults to the image's raw-photo bucket. Must not be the "
+            "site bucket: the prod deploy syncs with --delete and only "
+            "excludes assets/*, so any other prefix there is destroyed "
+            "on the next deploy."
+        ),
+    )
+    parser.add_argument(
+        "--allow-same-bucket",
+        action="store_true",
+        help=(
+            "Permit backing up into the site bucket anyway. The next "
+            "site deploy will delete those backups."
+        ),
+    )
+    parser.add_argument(
         "--backup-prefix",
         help=(
-            "S3 key prefix (same bucket) to copy live CDN objects to "
-            "before overwriting them. Defaults to a timestamped "
-            "'backups/rewarp-<UTC>/' prefix."
+            "Key prefix for backups. Defaults to a timestamped "
+            "'rewarp-backups/<UTC>/' prefix."
         ),
     )
     parser.add_argument(
@@ -948,13 +990,17 @@ def main(argv: Optional[list[str]] = None) -> int:
     backup_prefix: Optional[str] = None
     if args.apply and not args.no_backup:
         backup_prefix = args.backup_prefix or (
-            "backups/rewarp-"
+            "rewarp-backups/"
             + datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
             + "/"
         )
         if not backup_prefix.endswith("/"):
             backup_prefix += "/"
-        logger.info("Backing up replaced objects under %s", backup_prefix)
+        logger.info(
+            "Backing up replaced objects to %s under %s",
+            args.backup_bucket or "the image's raw-photo bucket",
+            backup_prefix,
+        )
     elif args.apply:
         logger.warning(
             "--no-backup: overwrites will be unrecoverable on an "
@@ -1097,6 +1143,8 @@ def main(argv: Optional[list[str]] = None) -> int:
                 args.darkness_margin,
                 dry_run=args.dry_run_apply,
                 backup_prefix=backup_prefix,
+                backup_bucket=args.backup_bucket,
+                allow_same_bucket=args.allow_same_bucket,
             )
             logger.info(
                 "%s %s/%d gap=%s %s",

--- a/scripts/rewarp_receipt_cdn_images.py
+++ b/scripts/rewarp_receipt_cdn_images.py
@@ -51,6 +51,7 @@ import os
 import sys
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
 from typing import Any, Optional
 
 import boto3
@@ -530,6 +531,45 @@ def _load_original(
     return oriented, notes
 
 
+def _backup_existing_variants(
+    s3_client: Any,
+    bucket: str,
+    receipt: Receipt,
+    backup_prefix: str,
+) -> tuple[list[str], Optional[str]]:
+    """Server-side copy the live CDN objects aside before overwriting.
+
+    The site bucket has no versioning, so a republish is otherwise
+    unrecoverable. Copies are server-side (no download) and land at
+    ``{backup_prefix}{original_key}``, which is also exactly the
+    argument order ``aws s3 cp`` needs to put them back.
+
+    Returns ``(copied keys, error)``; a non-None error means the caller
+    must not overwrite anything for this receipt.
+    """
+    copied: list[str] = []
+    for field_name, _dict_key in CDN_KEY_FIELDS:
+        key = getattr(receipt, field_name, None)
+        if not key:
+            continue
+        try:
+            s3_client.copy_object(
+                Bucket=bucket,
+                Key=f"{backup_prefix}{key}",
+                CopySource={"Bucket": bucket, "Key": key},
+            )
+            copied.append(key)
+        except ClientError as exc:
+            code = exc.response.get("Error", {}).get("Code", "")
+            if code in ("NoSuchKey", "404"):
+                # Nothing published at this key yet; nothing to lose.
+                continue
+            return copied, f"backup_failed:{key}:{code or exc}"
+        except BotoCoreError as exc:
+            return copied, f"backup_failed:{key}:{exc}"
+    return copied, None
+
+
 def rewarp_receipt(
     dynamo: DynamoClient,
     s3_client: Any,
@@ -537,6 +577,7 @@ def rewarp_receipt(
     image_entity: ImageEntity,
     darkness_margin: float,
     dry_run: bool,
+    backup_prefix: Optional[str] = None,
 ) -> dict[str, Any]:
     """Rebuild and republish one receipt's CDN variants.
 
@@ -614,6 +655,18 @@ def rewarp_receipt(
         record["status"] = "would_apply"
         return record
 
+    # Back up before the first overwrite, never after: a partial upload
+    # with no backup is the one outcome there is no way back from.
+    if backup_prefix:
+        copied, error = _backup_existing_variants(
+            s3_client, receipt.cdn_s3_bucket, receipt, backup_prefix
+        )
+        record["backed_up"] = len(copied)
+        if error:
+            record["status"] = "skipped_backup_failed"
+            record["notes"].append(error)
+            return record
+
     try:
         upload_all_cdn_formats(
             warped,
@@ -628,6 +681,19 @@ def rewarp_receipt(
 
     record["status"] = "applied"
     return record
+
+
+def _parse_excludes(raw: list[str]) -> set[tuple[str, int]]:
+    """Parse ``image_id:receipt_id`` exclusions into a lookup set."""
+    excludes: set[tuple[str, int]] = set()
+    for item in raw:
+        image_id, _, receipt_id = item.partition(":")
+        if not image_id or not receipt_id.isdigit():
+            raise ValueError(
+                f"--exclude expects IMAGE_ID:RECEIPT_ID, got {item!r}"
+            )
+        excludes.add((image_id, int(receipt_id)))
+    return excludes
 
 
 def _load_receipts(
@@ -706,6 +772,41 @@ def parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
         help="Restrict to this image id. Repeatable.",
     )
     parser.add_argument(
+        "--image-ids-file",
+        help=(
+            "File of image ids, one per line (blank lines and '#' "
+            "comments ignored). Merged with any --image-id values."
+        ),
+    )
+    parser.add_argument(
+        "--exclude",
+        action="append",
+        dest="excludes",
+        default=[],
+        metavar="IMAGE_ID:RECEIPT_ID",
+        help=(
+            "Never repair this receipt, even if it scans as mismatched. "
+            "Repeatable. Use for receipts whose entity geometry is known "
+            "to be wrong, where a re-warp would bake in the error."
+        ),
+    )
+    parser.add_argument(
+        "--backup-prefix",
+        help=(
+            "S3 key prefix (same bucket) to copy live CDN objects to "
+            "before overwriting them. Defaults to a timestamped "
+            "'backups/rewarp-<UTC>/' prefix."
+        ),
+    )
+    parser.add_argument(
+        "--no-backup",
+        action="store_true",
+        help=(
+            "Overwrite without backing up first. The site bucket is not "
+            "versioned, so this makes --apply unrecoverable."
+        ),
+    )
+    parser.add_argument(
         "--report-json",
         help="Write the full scan/apply report to this path.",
     )
@@ -743,13 +844,40 @@ def main(argv: Optional[list[str]] = None) -> int:
     for noisy in ("boto3", "botocore", "urllib3", "s3transfer"):
         logging.getLogger(noisy).setLevel(logging.WARNING)
 
-    if args.apply and not args.image_ids and not args.apply_all:
+    if (
+        args.apply
+        and not args.image_ids
+        and not args.image_ids_file
+        and not args.apply_all
+    ):
         logger.error(
-            "--apply without --image-id requires --apply-all; refusing to "
-            "rewrite every receipt in %s by accident.",
+            "--apply without an image filter requires --apply-all; "
+            "refusing to rewrite every receipt in %s by accident.",
             args.table,
         )
         return 2
+
+    try:
+        excludes = _parse_excludes(args.excludes)
+    except ValueError as exc:
+        logger.error("%s", exc)
+        return 2
+
+    backup_prefix: Optional[str] = None
+    if args.apply and not args.no_backup:
+        backup_prefix = args.backup_prefix or (
+            "backups/rewarp-"
+            + datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+            + "/"
+        )
+        if not backup_prefix.endswith("/"):
+            backup_prefix += "/"
+        logger.info("Backing up replaced objects under %s", backup_prefix)
+    elif args.apply:
+        logger.warning(
+            "--no-backup: overwrites will be unrecoverable on an "
+            "unversioned bucket."
+        )
 
     dynamo = DynamoClient(args.table)
     s3_client = boto3.client(
@@ -757,7 +885,17 @@ def main(argv: Optional[list[str]] = None) -> int:
         config=BotoConfig(max_pool_connections=max(args.workers, 10)),
     )
 
-    image_ids = set(args.image_ids) if args.image_ids else None
+    image_ids = set(args.image_ids or [])
+    if args.image_ids_file:
+        with open(args.image_ids_file, encoding="utf-8") as handle:
+            for line in handle:
+                entry = line.split("#", 1)[0].strip()
+                if entry:
+                    image_ids.add(entry)
+    if not image_ids:
+        image_ids = None
+    else:
+        logger.info("Restricted to %d image ids", len(image_ids))
     receipts = _load_receipts(dynamo, image_ids)
     images = _load_images(dynamo)
     logger.info("Scanning %d receipts in %s", len(receipts), args.table)
@@ -838,6 +976,16 @@ def main(argv: Optional[list[str]] = None) -> int:
         by_key = {(r.image_id, r.receipt_id): r for r in receipts}
         applied: list[dict[str, Any]] = []
         for result in mismatches:
+            if (result.image_id, result.receipt_id) in excludes:
+                applied.append(
+                    {
+                        "image_id": result.image_id,
+                        "receipt_id": result.receipt_id,
+                        "status": "skipped_excluded",
+                        "notes": ["excluded on the command line"],
+                    }
+                )
+                continue
             receipt = by_key.get((result.image_id, result.receipt_id))
             image_entity = images.get(result.image_id)
             if receipt is None or image_entity is None:
@@ -856,6 +1004,7 @@ def main(argv: Optional[list[str]] = None) -> int:
                 image_entity,
                 args.darkness_margin,
                 dry_run=args.dry_run_apply,
+                backup_prefix=backup_prefix,
             )
             logger.info(
                 "%s %s/%d gap=%s %s",

--- a/tests/test_rewarp_receipt_cdn_images.py
+++ b/tests/test_rewarp_receipt_cdn_images.py
@@ -1,0 +1,222 @@
+"""Unit tests for the CDN re-warp tool (pure parts only).
+
+No AWS, no network: aspect grading, the OCR box projection, the
+text-alignment gate that guards every republish, and the CDN key
+conflict check.
+"""
+
+from __future__ import annotations
+
+import math
+from types import SimpleNamespace
+
+import pytest
+from PIL import Image as PIL_Image
+from PIL import ImageDraw
+
+from scripts import rewarp_receipt_cdn_images as rw
+
+IMG = "0e2f8a2c-1111-4222-8333-944445555666"
+
+
+def make_receipt(width: int, height: int, **overrides) -> SimpleNamespace:
+    """Duck-typed receipt occupying the middle of a portrait photo."""
+    fields = {
+        "image_id": IMG,
+        "receipt_id": 1,
+        "width": width,
+        "height": height,
+        "top_left": {"x": 0.25, "y": 0.75},
+        "top_right": {"x": 0.75, "y": 0.75},
+        "bottom_right": {"x": 0.75, "y": 0.25},
+        "bottom_left": {"x": 0.25, "y": 0.25},
+        "cdn_s3_bucket": "site-bucket",
+        "cdn_s3_key": f"assets/{IMG}/1.jpg",
+        "cdn_thumbnail_s3_key": f"assets/{IMG}/1_thumbnail.jpg",
+    }
+    fields.update(overrides)
+    return SimpleNamespace(**fields)
+
+
+def make_word(x: float, y: float, width: float, height: float, text: str):
+    return SimpleNamespace(
+        text=text,
+        bounding_box={"x": x, "y": y, "width": width, "height": height},
+    )
+
+
+# --------------------------------------------------------------------- #
+# Aspect grading                                                        #
+# --------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "cdn_size,expected",
+    [
+        ((866, 2688), "ok"),
+        ((96, 300), "ok"),  # thumbnail, integer-rounded
+        ((2688, 866), "rotated_90"),
+        ((300, 96), "rotated_90"),
+        ((848, 2420), "aspect_mismatch"),  # stale crop, still portrait
+    ],
+)
+def test_variant_verdicts(monkeypatch, cdn_size, expected):
+    monkeypatch.setattr(
+        rw, "_probe_cdn_size", lambda *a, **k: (cdn_size, None)
+    )
+    probe = rw._probe_variant(
+        None, "bucket", "full", "key.jpg", rw._aspect(866, 2688)
+    )
+    assert probe.verdict == expected
+
+
+def test_scan_status_is_worst_variant(monkeypatch):
+    """A receipt is only 'ok' when every published variant agrees."""
+    sizes = {
+        "assets/x/1.jpg": (866, 2688),
+        "assets/x/1_thumbnail.jpg": (2688, 866),
+    }
+    monkeypatch.setattr(
+        rw,
+        "_probe_cdn_size",
+        lambda client, bucket, key: (sizes[key], None),
+    )
+    receipt = make_receipt(
+        866,
+        2688,
+        cdn_s3_key="assets/x/1.jpg",
+        cdn_thumbnail_s3_key="assets/x/1_thumbnail.jpg",
+    )
+    result = rw.scan_receipt(receipt, None, None)
+    assert result.status == "rotated_90"
+    assert result.is_mismatch
+    assert {v.name for v in result.bad_variants} == {"thumbnail"}
+
+
+def test_quad_aspect_flags_inconsistent_entity():
+    """Corners spanning a 3:4 photo cannot describe a 1:4 receipt."""
+    receipt = make_receipt(200, 800)
+    # Corners cover the full 600x800 image -> quad aspect 0.75, while the
+    # declared dimensions claim 0.25.
+    receipt.top_left = {"x": 0.0, "y": 1.0}
+    receipt.top_right = {"x": 1.0, "y": 1.0}
+    receipt.bottom_right = {"x": 1.0, "y": 0.0}
+    receipt.bottom_left = {"x": 0.0, "y": 0.0}
+    quad = rw._quad_aspect(receipt, 600, 800)
+    assert quad == pytest.approx(0.75)
+    assert not rw._close(quad, rw._aspect(200, 800), rw.QUAD_ASPECT_TOLERANCE)
+
+
+# --------------------------------------------------------------------- #
+# OCR box projection                                                    #
+# --------------------------------------------------------------------- #
+
+
+def test_word_boxes_flip_y_up_to_pil_rows():
+    """Receipt-relative y is bottom-up; PIL rows count downward."""
+    word = make_word(0.1, 0.8, 0.5, 0.1, "TOTAL")
+    (box,) = rw._word_boxes_in_pixels([word], 100, 1000)
+    left, top, right, bottom = box
+    assert (left, right) == (10, 60)
+    # y=0.8 is the bottom edge, y+h=0.9 the top -> rows 100..200.
+    assert (top, bottom) == (100, 200)
+
+
+# --------------------------------------------------------------------- #
+# Text-alignment gate                                                   #
+# --------------------------------------------------------------------- #
+
+
+def _receipt_canvas(width: int, height: int, words) -> PIL_Image.Image:
+    """White canvas with a dark bar drawn exactly where each word sits."""
+    canvas = PIL_Image.new("RGB", (width, height), "white")
+    draw = ImageDraw.Draw(canvas)
+    for box in rw._word_boxes_in_pixels(words, width, height):
+        draw.rectangle(box, fill=(20, 20, 20))
+    return canvas
+
+
+def test_alignment_gate_accepts_matching_text():
+    words = [
+        make_word(0.1, 0.05 + 0.09 * i, 0.6, 0.04, f"ITEM{i}")
+        for i in range(10)
+    ]
+    canvas = _receipt_canvas(400, 1200, words)
+    gap, measured = rw.text_alignment_score(canvas, words)
+    assert measured > 0
+    assert gap > rw.DEFAULT_DARKNESS_MARGIN
+
+
+def test_alignment_gate_rejects_shifted_text():
+    """The gate is what stops a wrong warp from being published."""
+    words = [
+        make_word(0.1, 0.05 + 0.09 * i, 0.6, 0.04, f"ITEM{i}")
+        for i in range(10)
+    ]
+    # Render the text half a line lower than the OCR boxes claim: the
+    # boxes now straddle blank paper and their own gaps.
+    shifted = [
+        make_word(0.1, 0.05 + 0.09 * i + 0.045, 0.6, 0.04, f"ITEM{i}")
+        for i in range(10)
+    ]
+    canvas = _receipt_canvas(400, 1200, shifted)
+    gap, _ = rw.text_alignment_score(canvas, words)
+    assert gap < rw.DEFAULT_DARKNESS_MARGIN
+
+
+def test_alignment_gate_rejects_blank_canvas():
+    words = [
+        make_word(0.1, 0.05 + 0.09 * i, 0.6, 0.04, f"ITEM{i}")
+        for i in range(10)
+    ]
+    canvas = PIL_Image.new("RGB", (400, 1200), "white")
+    gap, _ = rw.text_alignment_score(canvas, words)
+    assert gap == pytest.approx(0.0, abs=0.01)
+
+
+def test_alignment_score_reports_no_boxes_when_words_missing():
+    canvas = PIL_Image.new("RGB", (400, 1200), "white")
+    assert rw.text_alignment_score(canvas, []) == (None, 0)
+
+
+def test_probe_boxes_spread_down_the_receipt():
+    """Sampling must span the receipt, not cluster at one edge."""
+    words = [
+        make_word(0.1, 0.01 + 0.0098 * i, 0.6, 0.005, f"ITEM{i}")
+        for i in range(100)
+    ]
+    boxes = rw._select_probe_boxes(words, 400, 4000, sample=5)
+    assert len(boxes) == 5
+    tops = [box[1] for box in boxes]
+    assert max(tops) - min(tops) > 2000
+
+
+# --------------------------------------------------------------------- #
+# CDN key safety                                                        #
+# --------------------------------------------------------------------- #
+
+
+def test_no_conflicts_for_conventional_keys():
+    receipt = make_receipt(866, 2688)
+    base = rw._derive_base_key(receipt)
+    assert base == f"assets/{IMG}/1"
+    assert rw._expected_key_conflicts(receipt, base) == []
+
+
+def test_conflicts_reported_for_legacy_key_layout():
+    """Legacy ``{image_id}_RECEIPT_00003`` keys must block a republish."""
+    receipt = make_receipt(
+        942,
+        1480,
+        cdn_s3_key=f"assets/{IMG}_RECEIPT_00003.jpg",
+        cdn_thumbnail_s3_key=f"assets/{IMG}_RECEIPT_00003_thumb.jpg",
+    )
+    base = rw._derive_base_key(receipt)
+    conflicts = rw._expected_key_conflicts(receipt, base)
+    assert [name for name, _, _ in conflicts] == ["cdn_thumbnail_s3_key"]
+
+
+def test_close_is_symmetric():
+    assert rw._close(0.32, 0.33, 0.05) == rw._close(0.33, 0.32, 0.05)
+    assert not rw._close(0.32, 1.0 / 0.32, 0.05)
+    assert math.isclose(rw._aspect(866, 2688), 866 / 2688)

--- a/tests/test_rewarp_receipt_cdn_images.py
+++ b/tests/test_rewarp_receipt_cdn_images.py
@@ -322,23 +322,34 @@ class FakeS3:
             raise ClientError(
                 {"Error": {"Code": "AccessDenied"}}, "CopyObject"
             )
-        self.copies.append((source, Key))
+        self.copies.append(((CopySource["Bucket"], source), (Bucket, Key)))
 
 
-def test_backup_copies_every_populated_variant():
+def test_backup_lands_in_a_different_bucket():
+    """Backups must leave the site bucket entirely.
+
+    The prod deploy runs `aws s3 sync --delete --exclude "assets/*"`, so
+    a backup prefix in the site bucket is deleted by the next deploy --
+    which is how a real backup run was lost.
+    """
     receipt = make_receipt(866, 2688)
     s3 = FakeS3()
     copied, error = rw._backup_existing_variants(
-        s3, "site-bucket", receipt, "backups/run/"
+        s3, "site-bucket", "raw-bucket", receipt, "rewarp-backups/run/"
     )
     assert error is None
-    # Only the two keys this fixture populates.
     assert copied == [f"assets/{IMG}/1.jpg", f"assets/{IMG}/1_thumbnail.jpg"]
     assert s3.copies == [
-        (f"assets/{IMG}/1.jpg", f"backups/run/assets/{IMG}/1.jpg"),
         (
-            f"assets/{IMG}/1_thumbnail.jpg",
-            f"backups/run/assets/{IMG}/1_thumbnail.jpg",
+            ("site-bucket", f"assets/{IMG}/1.jpg"),
+            ("raw-bucket", f"rewarp-backups/run/assets/{IMG}/1.jpg"),
+        ),
+        (
+            ("site-bucket", f"assets/{IMG}/1_thumbnail.jpg"),
+            (
+                "raw-bucket",
+                f"rewarp-backups/run/assets/{IMG}/1_thumbnail.jpg",
+            ),
         ),
     ]
 
@@ -348,7 +359,7 @@ def test_backup_tolerates_missing_objects():
     receipt = make_receipt(866, 2688)
     s3 = FakeS3(missing={f"assets/{IMG}/1.jpg"})
     copied, error = rw._backup_existing_variants(
-        s3, "site-bucket", receipt, "backups/run/"
+        s3, "site-bucket", "raw-bucket", receipt, "rewarp-backups/run/"
     )
     assert error is None
     assert copied == [f"assets/{IMG}/1_thumbnail.jpg"]
@@ -358,10 +369,77 @@ def test_backup_failure_is_reported_so_caller_can_abort():
     receipt = make_receipt(866, 2688)
     s3 = FakeS3(fail_key=f"assets/{IMG}/1.jpg")
     _copied, error = rw._backup_existing_variants(
-        s3, "site-bucket", receipt, "backups/run/"
+        s3, "site-bucket", "raw-bucket", receipt, "rewarp-backups/run/"
     )
     assert error is not None
     assert "AccessDenied" in error
+
+
+def _rewarp_with_stubs(monkeypatch, uploaded, **kwargs):
+    """Drive rewarp_receipt past everything except the backup step."""
+    monkeypatch.setattr(
+        rw, "upload_all_cdn_formats", lambda *a, **k: uploaded.append(a)
+    )
+    monkeypatch.setattr(
+        rw,
+        "_load_original",
+        lambda *a, **k: (PIL_Image.new("RGB", (100, 200)), []),
+    )
+    monkeypatch.setattr(
+        rw, "warp_receipt_crop", lambda *a, **k: PIL_Image.new("RGB", (8, 8))
+    )
+    monkeypatch.setattr(rw, "text_alignment_score", lambda *a, **k: (99.0, 5))
+    dynamo = SimpleNamespace(
+        list_receipt_words_from_receipt=lambda *a, **k: []
+    )
+    image_entity = SimpleNamespace(
+        width=100,
+        height=200,
+        raw_s3_bucket="raw-bucket",
+        raw_s3_key="raw.png",
+    )
+    return rw.rewarp_receipt(
+        dynamo,
+        FakeS3(),
+        make_receipt(866, 2688),
+        image_entity,
+        darkness_margin=6.0,
+        dry_run=False,
+        backup_prefix="rewarp-backups/run/",
+        **kwargs,
+    )
+
+
+def test_backup_defaults_to_the_raw_photo_bucket(monkeypatch):
+    uploaded: list = []
+    record = _rewarp_with_stubs(monkeypatch, uploaded)
+    assert record["status"] == "applied"
+    assert record["backup_bucket"] == "raw-bucket"
+    assert uploaded
+
+
+def test_backup_into_the_site_bucket_is_refused(monkeypatch):
+    """Same-bucket backup is the exact mistake that lost the last run."""
+    uploaded: list = []
+    record = _rewarp_with_stubs(
+        monkeypatch, uploaded, backup_bucket="site-bucket"
+    )
+    assert record["status"] == "skipped_backup_same_bucket"
+    assert uploaded == []
+    assert "sync --delete" in " ".join(record["notes"])
+
+
+def test_same_bucket_backup_allowed_with_explicit_opt_in(monkeypatch):
+    uploaded: list = []
+    record = _rewarp_with_stubs(
+        monkeypatch,
+        uploaded,
+        backup_bucket="site-bucket",
+        allow_same_bucket=True,
+    )
+    assert record["status"] == "applied"
+    assert record["backup_bucket"] == "site-bucket"
+    assert uploaded
 
 
 def test_rewarp_aborts_when_backup_fails(monkeypatch):

--- a/tests/test_rewarp_receipt_cdn_images.py
+++ b/tests/test_rewarp_receipt_cdn_images.py
@@ -8,6 +8,7 @@ conflict check.
 from __future__ import annotations
 
 import math
+from datetime import datetime, timezone
 from types import SimpleNamespace
 
 import pytest
@@ -34,6 +35,7 @@ def make_receipt(width: int, height: int, **overrides) -> SimpleNamespace:
         "cdn_s3_bucket": "site-bucket",
         "cdn_s3_key": f"assets/{IMG}/1.jpg",
         "cdn_thumbnail_s3_key": f"assets/{IMG}/1_thumbnail.jpg",
+        "timestamp_added": "2026-01-01T00:00:00+00:00",
     }
     fields.update(overrides)
     return SimpleNamespace(**fields)
@@ -63,7 +65,7 @@ def make_word(x: float, y: float, width: float, height: float, text: str):
 )
 def test_variant_verdicts(monkeypatch, cdn_size, expected):
     monkeypatch.setattr(
-        rw, "_probe_cdn_size", lambda *a, **k: (cdn_size, None)
+        rw, "_probe_cdn_size", lambda *a, **k: (cdn_size, None, None)
     )
     probe = rw._probe_variant(
         None, "bucket", "full", "key.jpg", rw._aspect(866, 2688)
@@ -80,7 +82,7 @@ def test_scan_status_is_worst_variant(monkeypatch):
     monkeypatch.setattr(
         rw,
         "_probe_cdn_size",
-        lambda client, bucket, key: (sizes[key], None),
+        lambda client, bucket, key: (sizes[key], None, None),
     )
     receipt = make_receipt(
         866,
@@ -218,6 +220,88 @@ def test_conflicts_reported_for_legacy_key_layout():
 
 
 # --------------------------------------------------------------------- #
+# Staleness signal                                                      #
+# --------------------------------------------------------------------- #
+
+
+def _stub_probe(monkeypatch, size, mtime):
+    monkeypatch.setattr(
+        rw,
+        "_probe_cdn_size",
+        lambda *a, **k: (size, None, mtime),
+    )
+
+
+def test_stale_when_asset_predates_receipt_row(monkeypatch):
+    """The case aspect grading cannot see: right shape, wrong crop.
+
+    Mirrors prod 04b16930: the asset was written 2026-01-16 but the
+    receipt row was rewritten 2026-07-11, so the crop cannot depict the
+    geometry the row now carries even though its ratio still matches.
+    """
+    _stub_probe(
+        monkeypatch,
+        (846, 2462),
+        datetime(2026, 1, 16, 19, 12, 47, tzinfo=timezone.utc),
+    )
+    receipt = make_receipt(
+        846, 2462, timestamp_added="2026-07-11T23:27:29.682716+00:00"
+    )
+    result = rw.scan_receipt(receipt, None, None)
+    assert result.status == "stale_timestamp"
+    assert result.is_mismatch
+    assert "predates receipt row" in " ".join(result.notes)
+
+
+def test_not_stale_when_asset_newer_than_row(monkeypatch):
+    _stub_probe(
+        monkeypatch,
+        (846, 2462),
+        datetime(2026, 8, 1, tzinfo=timezone.utc),
+    )
+    receipt = make_receipt(
+        846, 2462, timestamp_added="2026-07-11T23:27:29.682716+00:00"
+    )
+    assert rw.scan_receipt(receipt, None, None).status == "ok"
+
+
+def test_aspect_mismatch_outranks_staleness(monkeypatch):
+    """A wrong-shape asset keeps the more specific verdict."""
+    _stub_probe(
+        monkeypatch,
+        (2462, 846),
+        datetime(2026, 1, 16, tzinfo=timezone.utc),
+    )
+    receipt = make_receipt(
+        846, 2462, timestamp_added="2026-07-11T23:27:29.682716+00:00"
+    )
+    result = rw.scan_receipt(receipt, None, None)
+    assert result.status == "rotated_90"
+    # The staleness evidence is still recorded, just not the headline.
+    assert "predates receipt row" in " ".join(result.notes)
+
+
+def test_naive_entity_timestamp_treated_as_utc():
+    receipt = make_receipt(846, 2462, timestamp_added="2026-07-11T23:27:29")
+    parsed = rw._entity_timestamp(receipt)
+    assert parsed is not None and parsed.tzinfo is not None
+
+
+@pytest.mark.parametrize("bad", [None, "", "not-a-date", 12345])
+def test_unparseable_entity_timestamp_is_not_fatal(bad):
+    receipt = make_receipt(846, 2462, timestamp_added=bad)
+    assert rw._entity_timestamp(receipt) is None
+
+
+def test_stale_verdict_ranks_below_aspect_mismatch():
+    assert (
+        rw.VERDICT_SEVERITY["stale_timestamp"]
+        < rw.VERDICT_SEVERITY["aspect_mismatch"]
+    )
+    assert "stale_timestamp" in rw.MISMATCH_VERDICTS
+
+
+# --------------------------------------------------------------------- #
 # Backup before overwrite                                               #
 # --------------------------------------------------------------------- #
 
@@ -340,6 +424,43 @@ def test_parse_excludes():
 def test_parse_excludes_rejects_malformed(bad):
     with pytest.raises(ValueError):
         rw._parse_excludes([bad])
+
+
+# --------------------------------------------------------------------- #
+# --force guardrails                                                    #
+# --------------------------------------------------------------------- #
+
+
+def test_force_with_apply_all_is_refused():
+    """Unfiltered + unfiltered is the one combination with no brakes."""
+    assert (
+        rw.main(
+            [
+                "--table",
+                "t",
+                "--apply",
+                "--apply-all",
+                "--force",
+            ]
+        )
+        == 2
+    )
+
+
+def test_force_without_image_filter_is_refused():
+    assert rw.main(["--table", "t", "--apply", "--force"]) == 2
+
+
+def test_apply_without_filter_or_apply_all_is_refused():
+    assert rw.main(["--table", "t", "--apply"]) == 2
+
+
+def test_force_parses_with_an_image_filter(monkeypatch):
+    """--force + a named image is the supported shape."""
+    args = rw.parse_args(
+        ["--table", "t", "--apply", "--force", "--image-id", IMG]
+    )
+    assert args.force and args.image_ids == [IMG]
 
 
 def test_close_is_symmetric():

--- a/tests/test_rewarp_receipt_cdn_images.py
+++ b/tests/test_rewarp_receipt_cdn_images.py
@@ -11,6 +11,7 @@ import math
 from types import SimpleNamespace
 
 import pytest
+from botocore.exceptions import ClientError
 from PIL import Image as PIL_Image
 from PIL import ImageDraw
 
@@ -214,6 +215,131 @@ def test_conflicts_reported_for_legacy_key_layout():
     base = rw._derive_base_key(receipt)
     conflicts = rw._expected_key_conflicts(receipt, base)
     assert [name for name, _, _ in conflicts] == ["cdn_thumbnail_s3_key"]
+
+
+# --------------------------------------------------------------------- #
+# Backup before overwrite                                               #
+# --------------------------------------------------------------------- #
+
+
+class FakeS3:
+    """Records copy_object calls; optionally fails one key."""
+
+    def __init__(self, missing=(), fail_key=None):
+        self.copies: list[tuple[str, str]] = []
+        self.missing = set(missing)
+        self.fail_key = fail_key
+
+    def copy_object(self, Bucket, Key, CopySource):  # noqa: N803
+        source = CopySource["Key"]
+        if source in self.missing:
+            raise ClientError({"Error": {"Code": "NoSuchKey"}}, "CopyObject")
+        if source == self.fail_key:
+            raise ClientError(
+                {"Error": {"Code": "AccessDenied"}}, "CopyObject"
+            )
+        self.copies.append((source, Key))
+
+
+def test_backup_copies_every_populated_variant():
+    receipt = make_receipt(866, 2688)
+    s3 = FakeS3()
+    copied, error = rw._backup_existing_variants(
+        s3, "site-bucket", receipt, "backups/run/"
+    )
+    assert error is None
+    # Only the two keys this fixture populates.
+    assert copied == [f"assets/{IMG}/1.jpg", f"assets/{IMG}/1_thumbnail.jpg"]
+    assert s3.copies == [
+        (f"assets/{IMG}/1.jpg", f"backups/run/assets/{IMG}/1.jpg"),
+        (
+            f"assets/{IMG}/1_thumbnail.jpg",
+            f"backups/run/assets/{IMG}/1_thumbnail.jpg",
+        ),
+    ]
+
+
+def test_backup_tolerates_missing_objects():
+    """A key with nothing published has nothing to lose."""
+    receipt = make_receipt(866, 2688)
+    s3 = FakeS3(missing={f"assets/{IMG}/1.jpg"})
+    copied, error = rw._backup_existing_variants(
+        s3, "site-bucket", receipt, "backups/run/"
+    )
+    assert error is None
+    assert copied == [f"assets/{IMG}/1_thumbnail.jpg"]
+
+
+def test_backup_failure_is_reported_so_caller_can_abort():
+    receipt = make_receipt(866, 2688)
+    s3 = FakeS3(fail_key=f"assets/{IMG}/1.jpg")
+    _copied, error = rw._backup_existing_variants(
+        s3, "site-bucket", receipt, "backups/run/"
+    )
+    assert error is not None
+    assert "AccessDenied" in error
+
+
+def test_rewarp_aborts_when_backup_fails(monkeypatch):
+    """A failed backup must stop the overwrite, not just warn."""
+    uploaded = []
+    monkeypatch.setattr(
+        rw,
+        "upload_all_cdn_formats",
+        lambda *a, **k: uploaded.append(a),
+    )
+    monkeypatch.setattr(
+        rw,
+        "_backup_existing_variants",
+        lambda *a, **k: ([], "backup_failed:boom"),
+    )
+    # Same aspect as the image entity below, so the run reaches the
+    # backup step rather than stopping at the aspect guard.
+    monkeypatch.setattr(
+        rw,
+        "_load_original",
+        lambda *a, **k: (PIL_Image.new("RGB", (100, 200)), []),
+    )
+    monkeypatch.setattr(
+        rw, "warp_receipt_crop", lambda *a, **k: PIL_Image.new("RGB", (8, 8))
+    )
+    monkeypatch.setattr(rw, "text_alignment_score", lambda *a, **k: (99.0, 5))
+
+    dynamo = SimpleNamespace(
+        list_receipt_words_from_receipt=lambda *a, **k: []
+    )
+    image_entity = SimpleNamespace(
+        width=100, height=200, raw_s3_bucket="raw", raw_s3_key="raw.png"
+    )
+    record = rw.rewarp_receipt(
+        dynamo,
+        None,
+        make_receipt(866, 2688),
+        image_entity,
+        darkness_margin=6.0,
+        dry_run=False,
+        backup_prefix="backups/run/",
+    )
+    assert record["status"] == "skipped_backup_failed"
+    assert uploaded == []
+
+
+# --------------------------------------------------------------------- #
+# Exclusions                                                            #
+# --------------------------------------------------------------------- #
+
+
+def test_parse_excludes():
+    assert rw._parse_excludes([f"{IMG}:3", f"{IMG}:11"]) == {
+        (IMG, 3),
+        (IMG, 11),
+    }
+
+
+@pytest.mark.parametrize("bad", ["no-colon", f"{IMG}:", f"{IMG}:abc", ":3"])
+def test_parse_excludes_rejects_malformed(bad):
+    with pytest.raises(ValueError):
+        rw._parse_excludes([bad])
 
 
 def test_close_is_symmetric():


### PR DESCRIPTION
## What this adds

`scripts/rewarp_receipt_cdn_images.py` — scans every receipt's published CDN
assets against its Receipt entity and can rebuild the ones that disagree.

The Receipt entity is the source of truth: its four image-normalised, y-up
corners plus `width`/`height` define the upright warp that the receipt-relative
OCR coordinates live in. When the served asset was built from different
geometry than the row now carries, the rendered crop no longer lines up with
the OCR frame.

- **Scan** (default, never writes) measures all four size variants
  (`full`/`medium`/`small`/`thumbnail`) independently, since they are uploaded
  separately and turned out to disagree with each other. A receipt's status is
  the worst of its variants: `rotated_90`, `aspect_mismatch`, or `ok`.
- **Apply** rebuilds the crop from the original upload with the same
  PERSPECTIVE transform the FIRST_PASS ingest path uses, then republishes all
  12 CDN variants to the same keys.
- The warp math is **not** duplicated — it reuses `perspective_coeffs` /
  `warp_receipt_crop` / `expected_cdn_keys` from
  `scripts/ocr_migration_publish_crops.py`, so there is one definition.

### Guards on the repair path

Every republish must clear all of these or the receipt is skipped and logged:

1. **Text-alignment self-check.** Real OCR word boxes are projected onto the
   rebuilt canvas; the text must be measurably darker inside the boxes than in
   the ring around them (default gap ≥ 6.0 of 255). A unit test confirms this
   gate *rejects* a canvas whose text is shifted half a line, so it discriminates
   rather than always passing.
2. **CDN key conflict check** — refuses when the entity's keys are not what
   `upload_all_cdn_formats` would derive from the base key, so a repair can
   never orphan the live asset (this catches the legacy
   `{image_id}_RECEIPT_00003` key layout).
3. **EXIF orientation** is applied to the original before warping. Nothing in
   the ingest path does this, but Vision does, so the entity's corners live in
   the transposed frame.
4. **`--apply` without `--image-id` requires `--apply-all`**, so an unfiltered
   rewrite of a whole table is never one flag away.

`--dry-run-apply` runs the full rebuild and self-check and uploads nothing.

## Scan results

| Table | Receipts | `ok` | `aspect_mismatch` | `rotated_90` |
|---|---|---|---|---|
| `ReceiptsTable-dc5be22` (dev) | 821 | 821 | 0 | 0 |
| `ReceiptsTable-d7ff76a` (prod) | 821 | 681 | **140** | 0 |

**No rotated assets were found in either table.** The reported symptom (a
landscape CDN file for portrait receipt `7ee15df8-.../1`) did not reproduce:
that receipt's dev asset measures 866x2688, exactly its entity dimensions. Its
*prod* asset measures 848x2420 — portrait, but built from older geometry.

Prod's 140 mismatched receipts span **104 images**. Two clear patterns:

- **Stale crops** (the bulk): prod assets were generated from an earlier
  segmentation and never regenerated after the entities were updated. 93 are
  smaller than the entity claims, 47 larger.
- **Swapped receipt assets** (12 images): receipt 1 serves receipt 2's crop and
  vice versa. Example `016bda87-...`: receipt 1's entity is 817x3133 but its
  asset is 869x2859, which is receipt 2's entity size.

Dev being clean while prod is not is consistent with dev DynamoDB having been
copied to prod without the matching S3 assets.

`--dry-run-apply` on a prod sample rebuilt all four receipts successfully, with
alignment gaps of 7.6–33.3 (well clear of the 6.0 floor), so the repair path
works on real data.

**Nothing was applied to either table.** This PR is the tool plus the scan.

## Receipts where the entity data itself looks wrong

Six receipts (identical in both tables) declare dimensions that do not match
their own corner quad — all are `receipt 3`/`receipt 4` on multi-receipt images,
with corners spanning the full 3:4 photo while the declared aspect is something
else. These need their geometry fixed before any re-warp would be meaningful:

```
3404eeb0-531f-49dc-806c-9ec2b18bf640 receipt 3: declared 280x1190 (aspect 0.235) vs corner quad aspect 0.748
4d2c992c-b0ec-4c11-8565-0d407111bc65 receipt 3: declared 774x1942 (aspect 0.399) vs corner quad aspect 0.726
4efce3f8-4370-49a4-a38c-98b8db6c5fb7 receipt 3: declared 1926x1959 (aspect 0.983) vs corner quad aspect 0.727
5195dba0-2b41-4f10-ac24-8ca555883865 receipt 3: declared 346x959 (aspect 0.361) vs corner quad aspect 0.749
5988b5be-335f-4dbe-a826-1335e72a488c receipt 4: declared 843x1452 (aspect 0.581) vs corner quad aspect 0.726
74a4f6ee-ac21-4d42-a2bf-e1414b954ae4 receipt 3: declared 1548x1757 (aspect 0.881) vs corner quad aspect 0.726
```

## Testing

`tests/test_rewarp_receipt_cdn_images.py` — 16 tests, no AWS or network:
aspect grading (including that a receipt is only `ok` when every variant is),
the y-up→PIL row flip in OCR box projection, the alignment gate accepting
matching text and rejecting shifted/blank canvases, probe-box spread, and the
CDN key conflict check. The existing `test_ocr_migration_publish_crops.py`
still passes against the shared helpers.

<details>
<summary>All 140 affected prod receipts</summary>

```
016bda87-f2a9-4dfc-85cc-e2b672ccb27a receipt 1: entity 817x3133, cdn full 869x2859
016bda87-f2a9-4dfc-85cc-e2b672ccb27a receipt 2: entity 869x2859, cdn full 817x3117
04ebdb8a-b560-4c00-aa09-f6afa3bda458 receipt 1: entity 846x3133, cdn full 811x2820
05410ae8-bf1c-488b-87e5-1f7b006a442a receipt 1: entity 635x1284, cdn full 648x1259
082f1bfa-ca36-4f11-ba76-dd4c0b8d83cc receipt 1: entity 787x3055, cdn full 787x3176
082f1bfa-ca36-4f11-ba76-dd4c0b8d83cc receipt 2: entity 787x3181, cdn full 787x3053
11da3353-cc82-45d8-829f-26f2f124d3aa receipt 1: entity 847x3169, cdn full 805x2890
129ee4aa-2053-4cd7-8534-a9817f8a3402 receipt 1: entity 915x3960, cdn full 115x381
1828b9ba-6f91-4d06-a738-1a7a1539f35f receipt 1: entity 815x2320, cdn full 866x2080
1828b9ba-6f91-4d06-a738-1a7a1539f35f receipt 2: entity 866x2080, cdn full 815x2320
195a4fb9-bc25-4e01-a876-a7d5e5ff3ff0 receipt 1: entity 389x941, cdn full 577x986
195a4fb9-bc25-4e01-a876-a7d5e5ff3ff0 receipt 2: entity 577x986, cdn full 389x941
1bfb07b7-aefd-4579-b721-df597471b96b receipt 1: entity 873x3157, cdn full 823x2255
1bfb07b7-aefd-4579-b721-df597471b96b receipt 2: entity 826x2255, cdn full 868x3134
1d5ab3e0-7d81-4de4-b23d-1f490f85d89c receipt 1: entity 844x2283, cdn full 829x2098
1e44245d-51a9-47ea-8ba2-622cb6cd4232 receipt 1: entity 767x1795, cdn full 876x1577
1e44245d-51a9-47ea-8ba2-622cb6cd4232 receipt 2: entity 876x1577, cdn full 767x1795
2360d36e-8211-46c4-9bc8-106766d80038 receipt 1: entity 878x2470, cdn full 883x3174
2360d36e-8211-46c4-9bc8-106766d80038 receipt 2: entity 883x3174, cdn full 875x2189
249eb736-449e-49fd-b08b-a9bfeec8094b receipt 1: entity 847x2458, cdn full 845x2310
29c1d8af-035c-431f-9d80-e4053cf28a00 receipt 1: entity 889x3840, cdn full 848x3273
2c9b770c-9407-4cdc-b0eb-3a5b27f0af15 receipt 1: entity 852x2738, cdn full 867x2414
2c9b770c-9407-4cdc-b0eb-3a5b27f0af15 receipt 2: entity 868x2218, cdn full 833x3164
32e93177-6528-4d63-b637-45d53d1cf3f3 receipt 1: entity 791x2923, cdn full 794x3165
32e93177-6528-4d63-b637-45d53d1cf3f3 receipt 2: entity 802x3218, cdn full 791x2923
37900099-30b4-4788-b128-73512a936045 receipt 1: entity 595x2135, cdn full 804x3047
37900099-30b4-4788-b128-73512a936045 receipt 2: entity 807x3075, cdn full 595x2135
3a2d8bae-0033-439c-a3fb-616a39f09947 receipt 1: entity 890x2052, cdn full 601x1972
3a2d8bae-0033-439c-a3fb-616a39f09947 receipt 2: entity 616x2062, cdn full 889x2036
3be818da-3892-40ae-bf7a-e2d6fffd3f37 receipt 1: entity 310x423, cdn full 305x675
3dcca0af-1803-4760-8794-5b1711cb4245 receipt 1: entity 835x2584, cdn full 876x2106
3dcca0af-1803-4760-8794-5b1711cb4245 receipt 2: entity 876x2106, cdn full 834x2575
3ef3ec1e-5e38-432d-9415-6b01584dfb6d receipt 1: entity 821x3450, cdn full 766x1337
471788b6-a210-4570-b5c4-47de5ac4518d receipt 1: entity 871x2845, cdn full 853x2585
490a4076-6d7c-45bf-8fcc-5570a295d429 receipt 1: entity 866x2935, cdn full 592x2101
490a4076-6d7c-45bf-8fcc-5570a295d429 receipt 2: entity 592x2101, cdn full 866x2935
492f9ae1-90a5-4943-9f26-8bb98052fb4d receipt 1: entity 1013x1378, cdn full 888x1310
4b0935bd-1023-4dba-a615-c8d37247a0d3 receipt 1: entity 872x3629, cdn full 840x3350
4b326441-103c-4dae-809e-899404c29ac1 receipt 1: entity 648x1452, cdn full 603x1186
51cdfd0b-cced-44e8-bd54-6fc5a2051ac2 receipt 1: entity 844x3459, cdn full 770x859
58dfb81d-9af4-4307-a1e4-67ec67daac67 receipt 1: entity 437x800, cdn full 416x804
5985d2dd-462e-4ccb-928c-4f4d596d6be2 receipt 1: entity 812x2617, cdn full 821x3131
5985d2dd-462e-4ccb-928c-4f4d596d6be2 receipt 2: entity 827x2567, cdn full 821x3130
5988b5be-335f-4dbe-a826-1335e72a488c receipt 2: entity 823x1646, cdn full 92x306
5cef2e7e-baad-4c29-9e5f-6a3d5ec20885 receipt 1: entity 869x2646, cdn full 850x2372
5dcf582e-cdfe-40f8-89f4-53b1cf3fc893 receipt 1: entity 406x971, cdn full 392x982
60a24649-c5c8-4c5b-8dd6-ba5d90e8b96b receipt 1: entity 335x862, cdn full 320x869
62130e63-c4d8-46a5-bd4b-243400494b10 receipt 1: entity 649x1452, cdn full 603x1187
6213c9c4-573b-4cc0-850e-5769927917c0 receipt 1: entity 862x2874, cdn full 859x2748
6213c9c4-573b-4cc0-850e-5769927917c0 receipt 2: entity 859x2748, cdn full 862x2874
63aa7edd-cf85-42fd-8c62-363981a115fe receipt 1: entity 843x2705, cdn full 807x2405
687da832-1d9b-48c2-a295-1cc122c23ed8 receipt 1: entity 867x1979, cdn full 861x1856
6a23eb4b-f1a9-40c0-9cfa-c2a45d3940a9 receipt 1: entity 797x2984, cdn full 863x1880
6a23eb4b-f1a9-40c0-9cfa-c2a45d3940a9 receipt 2: entity 863x1892, cdn full 800x2957
6b415a15-6aa7-4cf3-932c-436cf28f9b0c receipt 1: entity 619x1682, cdn full 599x1543
6c180601-5d7e-4429-88ed-ea908d19e9ae receipt 1: entity 848x3169, cdn full 809x2891
6cd1f7f5-d988-4e11-9209-cb6535fc3b04 receipt 1: entity 898x3706, cdn full 868x3276
6d7db41f-6e9b-4f43-a577-3208194f64e5 receipt 1: entity 843x3422, cdn full 866x2057
6d7db41f-6e9b-4f43-a577-3208194f64e5 receipt 2: entity 866x2057, cdn full 834x3372
6e58ca91-4d12-47e1-ac65-a51402090206 receipt 1: entity 817x2687, cdn full 826x2834
6e58ca91-4d12-47e1-ac65-a51402090206 receipt 2: entity 827x2566, cdn full 817x3129
6f323479-9357-464b-b2e6-2883fde9f019 receipt 1: entity 824x2586, cdn full 802x2397
6fa7cc7a-144c-43fb-be37-609e28c28a43 receipt 1: entity 888x1534, cdn full 855x2155
6fa7cc7a-144c-43fb-be37-609e28c28a43 receipt 2: entity 856x2178, cdn full 889x1450
728bc793-a1b8-4dcb-9528-4d6e23572b9d receipt 1: entity 871x3341, cdn full 864x2971
739dfe4b-edac-49b1-86c3-3568a7c98492 receipt 1: entity 1261x3123, cdn full 1181x3143
74965b95-a2ae-4680-a220-135b2a2d3228 receipt 1: entity 373x1096, cdn full 363x1110
79ad7b62-ea9d-4636-a411-8fe3f837ca96 receipt 1: entity 813x2543, cdn full 796x2803
79ad7b62-ea9d-4636-a411-8fe3f837ca96 receipt 2: entity 797x2817, cdn full 799x2511
7ca97b51-7369-4321-bd01-0211f2bf2557 receipt 1: entity 885x2352, cdn full 600x1265
7ca97b51-7369-4321-bd01-0211f2bf2557 receipt 2: entity 601x1267, cdn full 868x2142
7e1688d4-b0c1-4339-9ecc-682e56a648e0 receipt 1: entity 862x3612, cdn full 815x929
7ee15df8-703f-46c1-83c7-22a463c923c4 receipt 1: entity 866x2688, cdn full 848x2420
82c4720e-1c52-4dad-b8af-8605f84dc2ab receipt 1: entity 2088x3070, cdn full 351x603
8388d1f1-b5d6-4560-b7dc-db273815dda1 receipt 1: entity 866x2692, cdn full 847x2432
864e5b51-3ab1-49d9-9275-4779086efb84 receipt 1: entity 856x2052, cdn full 815x2751
864e5b51-3ab1-49d9-9275-4779086efb84 receipt 2: entity 815x2751, cdn full 857x2045
8729d932-8637-4ab6-b38b-bae0e92c51e5 receipt 1: entity 874x2856, cdn full 826x2440
87589280-36d1-4495-9ea2-9a4c5d921ba3 receipt 1: entity 866x3281, cdn full 864x2463
879b0fa6-c951-461b-a937-1bee74190b0a receipt 1: entity 867x2475, cdn full 809x2891
879b0fa6-c951-461b-a937-1bee74190b0a receipt 2: entity 809x2891, cdn full 867x2475
8e6faa9a-13e6-4c80-8e8a-08278988555b receipt 1: entity 454x728, cdn full 422x748
935fccdc-7022-4993-bb9d-27bfe682397f receipt 1: entity 916x1537, cdn full 877x1212
942be309-1647-48a5-bd77-cc220528cf0a receipt 1: entity 819x2091, cdn full 856x3202
942be309-1647-48a5-bd77-cc220528cf0a receipt 2: entity 857x3202, cdn full 819x2091
955da9a2-74f8-418e-be0b-be462b21af1f receipt 1: entity 770x1887, cdn full 762x1140
955da9a2-74f8-418e-be0b-be462b21af1f receipt 2: entity 767x1164, cdn full 770x1887
95718576-7873-4170-9b71-7736a44a2bd1 receipt 1: entity 797x2485, cdn full 828x2978
95718576-7873-4170-9b71-7736a44a2bd1 receipt 2: entity 829x3270, cdn full 793x2409
99526556-f9de-46a1-8061-131463a43459 receipt 1: entity 837x3705, cdn full 889x3609
9af03fd2-e3a5-4798-99f5-3db3f5db00fd receipt 2: entity 605x1129, cdn full 586x955
9bcec419-cb7b-44ae-94d7-a362def7d36e receipt 1: entity 311x684, cdn full 308x1015
9ea929c0-5d5f-4e07-8d10-251eea6a9aae receipt 1: entity 298x1112, cdn full 289x1114
9ed1103e-0b4e-4089-8fa4-6f29b6dc198b receipt 1: entity 934x3654, cdn full 890x3320
a07be6c6-09ee-4dca-a1c1-b1d6f8602065 receipt 1: entity 939x3883, cdn full 894x3450
a2d33e1e-ec1c-4d56-880f-9aa60baa41e7 receipt 1: entity 861x2532, cdn full 823x3206
a2d33e1e-ec1c-4d56-880f-9aa60baa41e7 receipt 2: entity 827x3255, cdn full 860x2530
a49fd6b9-5576-4a42-becd-1428a030ea07 receipt 1: entity 798x3008, cdn full 872x2267
a49fd6b9-5576-4a42-becd-1428a030ea07 receipt 2: entity 872x2303, cdn full 798x3008
a762ca4d-860c-4116-abb1-e25f61145294 receipt 1: entity 789x3195, cdn full 877x2400
a762ca4d-860c-4116-abb1-e25f61145294 receipt 2: entity 877x2401, cdn full 788x3196
a7b6f2e2-7c2e-4c61-b8df-023a9c6d3de4 receipt 1: entity 916x1567, cdn full 885x1216
a893938d-146c-4381-a00a-88082627f353 receipt 1: entity 877x2715, cdn full 859x2765
ace17905-a686-4e4e-964a-05fda9f966dd receipt 1: entity 306x732, cdn full 306x874
adb04b5e-4714-4e33-a3e8-7a874ad1549a receipt 1: entity 774x1019, cdn full 802x2988
adb04b5e-4714-4e33-a3e8-7a874ad1549a receipt 2: entity 799x3008, cdn full 773x1015
b4b269e9-5213-4e9a-b3df-661bc57dd81a receipt 1: entity 829x3196, cdn full 812x3006
b50ba18b-7511-4a85-87cd-74aa5e147e10 receipt 1: entity 758x2546, cdn full 861x2226
b50ba18b-7511-4a85-87cd-74aa5e147e10 receipt 2: entity 865x2243, cdn full 758x2541
b6e7af49-3802-46f2-822e-bbd49cd55ada receipt 2: entity 827x2606, cdn full 826x2915
b800a56a-ee4b-4315-a241-48ccf5e6237c receipt 1: entity 811x2573, cdn full 814x2391
b800a56a-ee4b-4315-a241-48ccf5e6237c receipt 2: entity 781x2919, cdn full 815x2675
b81f388d-5c6d-459e-a5c5-d38007950ba5 receipt 1: entity 866x1905, cdn full 859x1632
bc2bdd5b-4e46-4447-bac2-eec51401be4c receipt 1: entity 398x836, cdn full 384x840
bf801942-b2a2-4393-a4a3-4aa2e022a161 receipt 1: entity 869x1642, cdn full 826x3014
c1672313-25b9-4d14-9951-691a2003dacf receipt 1: entity 891x2968, cdn full 853x2482
c8a2468a-e1a7-4562-ab60-df3e68c7ac23 receipt 1: entity 939x2737, cdn full 977x2679
ccfbeaca-6f40-4e9f-ba5e-6a30a643f0aa receipt 1: entity 866x3779, cdn full 818x3700
cd456f8c-111e-4d7c-83ae-9552ad7004a7 receipt 1: entity 869x2515, cdn full 801x3176
ceb066a5-b621-46b6-9f8f-754d998670a7 receipt 1: entity 800x3213, cdn full 819x2897
ceb066a5-b621-46b6-9f8f-754d998670a7 receipt 2: entity 823x2963, cdn full 800x3213
cee0fbe1-d84a-4f69-9af1-7166226e8b88 receipt 1: entity 826x1990, cdn full 796x2504
cee0fbe1-d84a-4f69-9af1-7166226e8b88 receipt 2: entity 802x2533, cdn full 829x2033
d0fa3716-3985-4121-bbcf-10f07ef398b3 receipt 1: entity 445x822, cdn full 394x853
d36c2083-68bd-4690-b47f-11ffdc5e86e7 receipt 1: entity 783x2294, cdn full 825x2923
d36c2083-68bd-4690-b47f-11ffdc5e86e7 receipt 2: entity 825x2923, cdn full 783x2242
db2cea4b-a8a6-4c97-8a4d-ed6430cb6791 receipt 1: entity 920x1728, cdn full 885x1436
dbc78ee2-8d3c-4a31-b28a-0293583a2a25 receipt 1: entity 883x2046, cdn full 935x2754
dbc78ee2-8d3c-4a31-b28a-0293583a2a25 receipt 2: entity 935x2792, cdn full 883x1968
dc09ed13-1fde-4b80-b5cc-0ca5efdcac49 receipt 1: entity 866x3793, cdn full 866x3267
e0e74bc2-5acf-4dad-85ab-7e1d5f89cd6d receipt 1: entity 909x1801, cdn full 870x1806
e1f519d5-a977-4916-bc2b-0f122564730d receipt 1: entity 2058x2767, cdn full 856x2759
e8b658b6-e731-4aab-8c9b-cd9df55efc57 receipt 1: entity 899x2958, cdn full 857x2482
eaeee5ef-ba10-48c6-9cfe-591d043d7d65 receipt 1: entity 888x3672, cdn full 830x993
ec9ced37-d4de-4815-b055-d99d96abc253 receipt 3: entity 942x1480, cdn full 195x934
ed3f3909-62d8-430b-9a1a-e82628d9d5ee receipt 1: entity 833x3018, cdn full 828x962
f1844265-90f3-4c5c-81a0-5944f1c6fe9a receipt 1: entity 331x802, cdn full 318x813
f2446845-6bb0-416c-bfa3-cad9cb4ad80e receipt 1: entity 367x1099, cdn full 477x1241
fb588a3b-49ab-4ee7-accd-f1953b7378c3 receipt 1: entity 773x1719, cdn full 801x1982
ff649c4b-5c31-4247-b78c-d9b0c56610ad receipt 1: entity 851x3490, cdn full 768x879
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KMeX4w8g3NsVg7ckN7wyBh


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a command-line tool to detect unreadable, incorrectly oriented, outdated, or mismatched receipt images across CDN variants.
  * Supports filtering, parallel scans, structured results, and JSON reports.
  * Added dry-run and guarded repair workflows to correct and republish receipt image variants after validation, with optional backups and detailed failure reporting.

* **Tests**
  * Added comprehensive automated coverage for image validation, OCR alignment, geometry checks, CDN consistency, and repair safeguards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->