### PR TITLE
feat: line-item reconciliation MCP tools (diagnose / guarded repair / worklist)

### DIFF
--- a/infra/mcp_server_lambda/lambdas/receipt_mcp_server_server.py
+++ b/infra/mcp_server_lambda/lambdas/receipt_mcp_server_server.py
@@ -1931,6 +1931,142 @@ WARNING: This WRITES to DynamoDB and is irreversible for that row.""",
                 "required": ["image_id", "receipt_id", "section_type"],
             },
         ),
+        Tool(
+            name="get_receipt_line_items",
+            description="""Diagnostic view of a receipt's decoded line items.
+
+Returns the RECEIPT_LINE_ITEM rows the deterministic geometric extractor
+wrote for this receipt (name, price, quantity, unit_price, is_discount,
+line_ids, name_quality, reconciliation_status, extractor_version), the
+summary baseline figures (subtotal / tax / grand_total / merchant_name),
+items_sum (sum of non-discount item prices, matching reconcile()), and
+delta = items_sum - baseline, where baseline is the printed subtotal,
+else grand_total - tax. Also returns the ITEMS section's line_ids so
+you can see which lines the extractor was allowed to read.
+
+Use this FIRST when investigating a reconciliation mismatch: it shows
+what was decoded versus what the printed baseline says. Follow up with
+get_receipt (line text) to find priced lines outside the zone, then
+extend_items_section to repair the boundary.""",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "image_id": {
+                        "type": "string",
+                        "description": "Image ID of the receipt",
+                    },
+                    "receipt_id": {
+                        "type": "integer",
+                        "description": "Receipt ID",
+                    },
+                },
+                "required": ["image_id", "receipt_id"],
+            },
+        ),
+        Tool(
+            name="extend_items_section",
+            description="""Arithmetic-VERIFIED extension of the ITEMS section.
+
+Simulates adding add_line_ids to the receipt's ITEMS section by running
+the real geometric extractor (receipt_upload.line_items.geometry) over
+both the current zone and the extended zone, reconciling each against
+the summary baseline. The extension is applied ONLY when BOTH hold:
+  1. |delta| strictly shrinks (delta = non-discount item sum minus
+     baseline), and
+  2. reconciliation status improves (mismatch -> near/match, or
+     near -> match).
+Otherwise the tool refuses and returns both evaluations.
+
+Defaults to dry_run=true (report only). With dry_run=false it updates
+the ITEMS ReceiptSection line_ids, PRESERVING its validation_status (a
+reconciliation-verified extension never demotes VALID), then rewrites
+the receipt summary with a fresh timestamp_computed so the stream stage
+regenerates the RECEIPT_LINE_ITEM rows automatically.
+
+This is the guarded repair path for zone-gap shortfall mismatches:
+real priced lines exist but the ITEMS zone does not reach them.
+
+WARNING: with dry_run=false this WRITES to DynamoDB (section update +
+summary rewrite) and triggers async line-item regeneration.""",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "image_id": {
+                        "type": "string",
+                        "description": "Image ID of the receipt",
+                    },
+                    "receipt_id": {
+                        "type": "integer",
+                        "description": "Receipt ID",
+                    },
+                    "add_line_ids": {
+                        "type": "array",
+                        "items": {"type": "integer"},
+                        "minItems": 1,
+                        "description": (
+                            "Line IDs to add to the ITEMS section"
+                        ),
+                    },
+                    "dry_run": {
+                        "type": "boolean",
+                        "default": True,
+                        "description": (
+                            "true (default): evaluate only. false: apply "
+                            "when the arithmetic guard passes."
+                        ),
+                    },
+                },
+                "required": ["image_id", "receipt_id", "add_line_ids"],
+            },
+        ),
+        Tool(
+            name="list_reconciliation_worklist",
+            description="""Queue of receipts whose line items fail reconciliation.
+
+Scans RECEIPT_LINE_ITEM rows, groups them by receipt, and keeps the
+receipts whose receipt-level status matches `status` (a receipt is
+"mismatch" when any of its items is mismatch, etc.). Optionally filters
+by case-insensitive merchant substring. For each receipt it returns
+image_id, receipt_id, merchant, item count, items_sum (non-discount),
+subtotal (the reconcile baseline: printed subtotal, else
+grand_total - tax) and delta — sorted by |delta| descending, so the
+worst arithmetic failures come first.
+
+Use this to build a repair queue, then get_receipt_line_items on each
+receipt to diagnose, and extend_items_section to fix zone-gap cases.""",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "merchant_name": {
+                        "type": "string",
+                        "description": (
+                            "Optional case-insensitive merchant substring "
+                            "filter"
+                        ),
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": [
+                            "mismatch",
+                            "near",
+                            "match",
+                            "no-baseline",
+                        ],
+                        "default": "mismatch",
+                        "description": (
+                            "Receipt-level reconciliation status to list"
+                        ),
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "default": 25,
+                        "minimum": 1,
+                        "maximum": 100,
+                        "description": "Max receipts to return",
+                    },
+                },
+            },
+        ),
     ]
 
 
@@ -2164,6 +2300,27 @@ async def call_tool(
                 image_id=arguments["image_id"],
                 receipt_id=arguments["receipt_id"],
                 section_type=arguments["section_type"],
+            )
+        elif name == "get_receipt_line_items":
+            result = await get_receipt_line_items_impl(
+                dynamo_client,
+                image_id=arguments["image_id"],
+                receipt_id=arguments["receipt_id"],
+            )
+        elif name == "extend_items_section":
+            result = await extend_items_section_impl(
+                dynamo_client,
+                image_id=arguments["image_id"],
+                receipt_id=arguments["receipt_id"],
+                add_line_ids=arguments["add_line_ids"],
+                dry_run=arguments.get("dry_run", True),
+            )
+        elif name == "list_reconciliation_worklist":
+            result = await list_reconciliation_worklist_impl(
+                dynamo_client,
+                merchant_name=arguments.get("merchant_name"),
+                status=arguments.get("status", "mismatch"),
+                limit=arguments.get("limit", 25),
             )
         elif name == "list_training_jobs":
             result = await list_training_jobs_impl(
@@ -4559,6 +4716,554 @@ async def delete_receipt_section_impl(
 
     except Exception as e:
         logger.exception("Error deleting receipt section")
+        return {"error": str(e)}
+
+
+# ---------------------------------------------------------------------------
+# Line-item reconciliation tools — deterministic extraction diagnostics
+# plus arithmetic-verified ITEMS-section repair. The extraction/reconcile
+# logic is imported from receipt_upload.line_items.geometry (the same code
+# the ingest stream runs), so what these tools simulate is exactly what
+# production recomputes after a summary rewrite.
+# ---------------------------------------------------------------------------
+
+# Receipt-level severity used to roll item statuses up to one receipt
+# status (worst wins) in the worklist.
+_RECON_SEVERITY = {"match": 0, "near": 1, "no-baseline": 2, "mismatch": 3}
+
+
+def _extraction_words(details) -> list[dict]:
+    """ReceiptWord entities -> word dicts the geometric extractor eats.
+
+    Mirrors scripts/extract_line_items.fetch_receipt_records: line_id,
+    word_id, text, x, y_mid (= bbox y + height/2), h — all in the stored
+    receipt-normalized coordinate space.
+    """
+    words: list[dict] = []
+    for word in details.words or []:
+        bb = word.bounding_box or {}
+        try:
+            words.append(
+                {
+                    "line_id": int(word.line_id),
+                    "word_id": int(word.word_id),
+                    "text": str(word.text or ""),
+                    "x": float(bb.get("x", 0)),
+                    "y_mid": float(bb.get("y", 0))
+                    + float(bb.get("height", 0)) / 2,
+                    "h": float(bb.get("height", 0)),
+                }
+            )
+        except (TypeError, ValueError):
+            continue
+    return words
+
+
+def _summary_baseline(record) -> tuple[dict, Optional[float]]:
+    """ReceiptSummaryRecord -> (reconcile() summary dict, baseline).
+
+    Baseline mirrors receipt_upload.line_items.geometry.reconcile: the
+    printed subtotal, else grand_total - tax; None when unusable.
+    """
+    summary = {
+        "subtotal": record.subtotal,
+        "grand_total": record.grand_total,
+        "tax": record.tax,
+    }
+    baseline = record.subtotal
+    if baseline is None and record.grand_total is not None:
+        baseline = record.grand_total - (record.tax or 0.0)
+    if baseline is not None and baseline <= 0:
+        baseline = None
+    return summary, baseline
+
+
+def _evaluate_items_zone(words: list[dict], summary: dict, line_ids) -> dict:
+    """Run the real extractor over a line set and reconcile.
+
+    Discounts are excluded from the sum, matching the stream stage and
+    scripts/repair_item_sections.evaluate.
+    """
+    from receipt_upload.line_items.geometry import extract_items, reconcile
+
+    items, collapsed = extract_items(words, set(line_ids))
+    status, items_sum, baseline = reconcile(
+        [x for x in items if not x["is_discount"]], summary
+    )
+    delta = (
+        round(items_sum - baseline, 2)
+        if items_sum is not None and baseline is not None
+        else None
+    )
+    return {
+        "status": status,
+        "items_sum": items_sum,
+        "baseline": baseline,
+        "delta": delta,
+        "n_items": len(items),
+        "collapsed_banding": collapsed,
+    }
+
+
+async def get_receipt_line_items_impl(
+    dynamo_client, image_id: str, receipt_id: int
+) -> dict:
+    """Diagnostic view: decoded line items vs the summary baseline."""
+    from receipt_dynamo.data.shared_exceptions import EntityNotFoundError
+
+    try:
+        line_items = dynamo_client.get_receipt_line_items_from_receipt(
+            image_id, receipt_id
+        )
+
+        try:
+            record = dynamo_client.get_receipt_summary(image_id, receipt_id)
+        except EntityNotFoundError:
+            record = None
+
+        items_section_line_ids = None
+        items_section_status = None
+        try:
+            sections = dynamo_client.get_receipt_sections_from_receipt(
+                image_id, receipt_id
+            )
+        except EntityNotFoundError:
+            sections = []
+        for section in sections or []:
+            if section.section_type == "ITEMS":
+                items_section_line_ids = sorted(
+                    int(x) for x in section.line_ids or []
+                )
+                items_section_status = section.validation_status or "NONE"
+                break
+
+        items = [
+            {
+                "item_index": li.item_index,
+                "name": li.name,
+                "price": float(li.price),
+                "quantity": li.quantity,
+                "unit_price": li.unit_price,
+                "is_discount": li.is_discount,
+                "line_ids": li.line_ids,
+                "name_quality": li.name_quality,
+                "reconciliation_status": li.reconciliation_status,
+                "extractor_version": li.extractor_version,
+            }
+            for li in line_items
+        ]
+        # Discounts excluded from the sum, matching reconcile()'s callers
+        # (the stream stage and repair_item_sections.evaluate).
+        items_sum = round(
+            sum(float(li.price) for li in line_items if not li.is_discount),
+            2,
+        )
+
+        summary = None
+        baseline = None
+        if record is not None:
+            figures, baseline = _summary_baseline(record)
+            summary = {**figures, "merchant_name": record.merchant_name}
+        delta = (
+            round(items_sum - baseline, 2) if baseline is not None else None
+        )
+
+        statuses = {
+            li.reconciliation_status
+            for li in line_items
+            if li.reconciliation_status
+        }
+        receipt_status = (
+            max(statuses, key=lambda s: _RECON_SEVERITY.get(s, -1))
+            if statuses
+            else None
+        )
+
+        return {
+            "image_id": image_id,
+            "receipt_id": receipt_id,
+            "item_count": len(items),
+            "items": items,
+            "summary": summary,
+            "items_sum": items_sum,
+            "delta": delta,
+            "reconciliation_status": receipt_status,
+            "items_section_line_ids": items_section_line_ids,
+            "items_section_status": items_section_status,
+        }
+
+    except Exception as e:
+        logger.exception("Error getting receipt line items")
+        return {"error": str(e)}
+
+
+async def extend_items_section_impl(
+    dynamo_client,
+    image_id: str,
+    receipt_id: int,
+    add_line_ids: list,
+    dry_run: bool = True,
+) -> dict:
+    """Extend the ITEMS section, gated on reconciliation arithmetic.
+
+    Apply happens ONLY when the extended zone strictly shrinks |delta|
+    AND improves the reconciliation status (mismatch -> near/match, or
+    near -> match). On apply, the section keeps its validation_status (a
+    verified extension never demotes VALID — the repair_item_sections
+    lesson) and the receipt summary is rewritten with a fresh
+    timestamp_computed so the stream stage regenerates line items.
+    """
+    from datetime import datetime, timezone
+
+    from receipt_dynamo.data.shared_exceptions import EntityNotFoundError
+    from receipt_dynamo.entities.receipt_section import ReceiptSection
+    from receipt_dynamo.entities.receipt_summary_record import (
+        ReceiptSummaryRecord,
+    )
+
+    # Guard ranking (strict improvement required to apply). Distinct from
+    # _RECON_SEVERITY: "no-baseline" is never rankable here.
+    guard_rank = {"match": 0, "near": 1, "mismatch": 2}
+
+    try:
+        try:
+            added = sorted({int(lid) for lid in (add_line_ids or [])})
+        except (TypeError, ValueError):
+            return {"error": "add_line_ids must be a list of integers"}
+        if not added:
+            return {
+                "error": "add_line_ids must be a non-empty list of integers"
+            }
+
+        try:
+            details = dynamo_client.get_receipt_details(image_id, receipt_id)
+        except EntityNotFoundError:
+            return {
+                "error": (
+                    f"Receipt {receipt_id} not found for image {image_id}"
+                )
+            }
+
+        receipt_line_ids = {line.line_id for line in details.lines or []}
+        unknown = sorted(set(added) - receipt_line_ids)
+        if unknown:
+            return {
+                "error": (
+                    f"line_ids {unknown} do not exist on receipt "
+                    f"{receipt_id} (image {image_id})"
+                )
+            }
+
+        try:
+            sections = dynamo_client.get_receipt_sections_from_receipt(
+                image_id, receipt_id
+            )
+        except EntityNotFoundError:
+            sections = []
+        items_section = next(
+            (s for s in sections or [] if s.section_type == "ITEMS"), None
+        )
+        if items_section is None:
+            return {
+                "error": (
+                    f"Receipt {receipt_id} (image {image_id}) has no ITEMS "
+                    "section to extend. Use create_receipt_section instead."
+                )
+            }
+
+        current_lids = sorted(int(x) for x in items_section.line_ids or [])
+        already = sorted(set(added) & set(current_lids))
+        if already:
+            return {
+                "error": (
+                    f"line_ids {already} are already in the ITEMS section"
+                )
+            }
+
+        # Lines claimed by another section are exactly how summary/payment
+        # rows leak into ITEMS — refuse rather than double-claim them.
+        for section in sections or []:
+            if section.section_type == "ITEMS":
+                continue
+            overlap = sorted(
+                set(added) & {int(x) for x in section.line_ids or []}
+            )
+            if overlap:
+                return {
+                    "error": (
+                        f"line_ids {overlap} already belong to section "
+                        f"{section.section_type}; refusing to double-claim"
+                    )
+                }
+
+        try:
+            record = dynamo_client.get_receipt_summary(image_id, receipt_id)
+        except EntityNotFoundError:
+            return {
+                "error": (
+                    "No RECEIPT_SUMMARY baseline for this receipt; an "
+                    "extension cannot be arithmetic-verified. Refusing."
+                )
+            }
+        summary, baseline = _summary_baseline(record)
+        if baseline is None:
+            return {
+                "error": (
+                    "Summary has no usable baseline (no subtotal and no "
+                    "grand_total); an extension cannot be verified."
+                )
+            }
+
+        # When the section is row-anchored, keep the anchor consistent:
+        # every line must be covered by a ReceiptRow, and rows are the
+        # authoritative grouping (widen line_ids to the covering union).
+        extended_lids = sorted(set(current_lids) | set(added))
+        final_lids = extended_lids
+        new_row_ids = items_section.row_ids
+        if items_section.row_ids is not None:
+            rows = (
+                dynamo_client.get_receipt_rows_from_receipt(
+                    image_id, receipt_id
+                )
+                or []
+            )
+            covering = [
+                r
+                for r in rows
+                if set(int(x) for x in r.line_ids) & set(extended_lids)
+            ]
+            union: set[int] = set()
+            for r in covering:
+                union |= {int(x) for x in r.line_ids}
+            uncovered = sorted(set(extended_lids) - union)
+            if uncovered:
+                return {
+                    "error": (
+                        f"line_ids {uncovered} map to no ReceiptRow; "
+                        "refusing to break the section's row anchor"
+                    )
+                }
+            new_row_ids = sorted({int(r.row_id) for r in covering})
+            if union != set(extended_lids):
+                final_lids = sorted(union)
+
+        words = _extraction_words(details)
+        before = _evaluate_items_zone(words, summary, current_lids)
+        after = _evaluate_items_zone(words, summary, final_lids)
+
+        result: dict[str, Any] = {
+            "image_id": image_id,
+            "receipt_id": receipt_id,
+            "added_line_ids": added,
+            "current_line_ids": current_lids,
+            "extended_line_ids": final_lids,
+            "before": before,
+            "after": after,
+            "dry_run": dry_run,
+            "applied": False,
+        }
+
+        if before["status"] == "match":
+            result["verified"] = False
+            result["refusal"] = (
+                "Current ITEMS zone already reconciles (match); nothing "
+                "to repair."
+            )
+            return result
+        if (
+            before["status"] not in guard_rank
+            or after["status"] not in guard_rank
+            or before["delta"] is None
+            or after["delta"] is None
+        ):
+            result["verified"] = False
+            result["refusal"] = (
+                "Cannot verify the extension: reconciliation did not "
+                "produce comparable deltas for both zones."
+            )
+            return result
+
+        shrinks = abs(after["delta"]) < abs(before["delta"])
+        improves = guard_rank[after["status"]] < guard_rank[before["status"]]
+        if not (shrinks and improves):
+            result["verified"] = False
+            result["refusal"] = (
+                "Arithmetic guard failed: extension must strictly shrink "
+                f"|delta| (before {before['delta']}, after "
+                f"{after['delta']}) AND improve status (before "
+                f"{before['status']!r}, after {after['status']!r})."
+            )
+            return result
+
+        result["verified"] = True
+        if dry_run:
+            result["note"] = (
+                "Arithmetic guard passed; re-run with dry_run=false to "
+                "apply."
+            )
+            return result
+
+        model_source = items_section.model_source or ""
+        if "mcp-extend-items-v1" not in model_source:
+            model_source = (
+                f"{model_source}+mcp-extend-items-v1"
+                if model_source
+                else "mcp-extend-items-v1"
+            )
+        updated = ReceiptSection(
+            receipt_id=items_section.receipt_id,
+            image_id=items_section.image_id,
+            section_type="ITEMS",
+            line_ids=final_lids,
+            created_at=items_section.created_at,
+            confidence=items_section.confidence,
+            model_source=model_source,
+            # Preserve the prior status: the extension is reconciliation-
+            # verified, and demoting VALID would hide the section from the
+            # extractor's VALID gate (the repair_item_sections lesson).
+            validation_status=items_section.validation_status,
+            row_ids=new_row_ids,
+        )
+        dynamo_client.update_receipt_section(updated)
+
+        # Rewrite the summary with a fresh timestamp_computed so the
+        # stream stage regenerates the receipt's line items over the
+        # extended section.
+        refreshed = ReceiptSummaryRecord(
+            summary=record.summary,
+            timestamp_computed=datetime.now(timezone.utc).isoformat(),
+        )
+        dynamo_client.update_receipt_summary(refreshed)
+
+        result["applied"] = True
+        result["summary_rewritten"] = True
+        result["validation_status"] = items_section.validation_status or "NONE"
+        result["model_source"] = model_source
+        return result
+
+    except Exception as e:
+        logger.exception("Error extending items section")
+        return {"error": str(e)}
+
+
+async def list_reconciliation_worklist_impl(
+    dynamo_client,
+    merchant_name: Optional[str] = None,
+    status: str = "mismatch",
+    limit: int = 25,
+) -> dict:
+    """Queue of receipts failing reconciliation, worst |delta| first."""
+    from receipt_dynamo.data.shared_exceptions import EntityNotFoundError
+
+    page_size = 1000
+    max_pages = 25  # scan cap: 25k RECEIPT_LINE_ITEM rows
+    max_summary_fetches = 300
+
+    try:
+        normalized_status = str(status or "mismatch").strip().lower()
+        if normalized_status not in _RECON_SEVERITY:
+            return {
+                "error": (
+                    f"Invalid status {status!r}; expected one of "
+                    f"{sorted(_RECON_SEVERITY)}"
+                )
+            }
+        try:
+            limit = max(1, min(int(limit), 100))
+        except (TypeError, ValueError):
+            return {"error": "limit must be an integer"}
+
+        receipts: dict[tuple, dict] = {}
+        last_key = None
+        pages = 0
+        scan_truncated = False
+        while True:
+            batch, last_key = dynamo_client.list_receipt_line_items(
+                limit=page_size, last_evaluated_key=last_key
+            )
+            pages += 1
+            for li in batch:
+                bucket = receipts.setdefault(
+                    (li.image_id, li.receipt_id),
+                    {
+                        "merchant": None,
+                        "items": 0,
+                        "items_sum": 0.0,
+                        "statuses": set(),
+                    },
+                )
+                bucket["items"] += 1
+                if not li.is_discount:
+                    bucket["items_sum"] += float(li.price)
+                if li.merchant_name and not bucket["merchant"]:
+                    bucket["merchant"] = li.merchant_name
+                if li.reconciliation_status:
+                    bucket["statuses"].add(li.reconciliation_status)
+            if last_key is None:
+                break
+            if pages >= max_pages:
+                scan_truncated = True
+                break
+
+        needle = (merchant_name or "").strip().lower()
+        candidates = []
+        for (img, rid), bucket in receipts.items():
+            statuses = bucket["statuses"]
+            receipt_status = (
+                max(statuses, key=lambda s: _RECON_SEVERITY[s])
+                if statuses
+                else "no-baseline"
+            )
+            if receipt_status != normalized_status:
+                continue
+            if needle and needle not in (bucket["merchant"] or "").lower():
+                continue
+            candidates.append(
+                {
+                    "image_id": img,
+                    "receipt_id": rid,
+                    "merchant": bucket["merchant"],
+                    "items": bucket["items"],
+                    "items_sum": round(bucket["items_sum"], 2),
+                }
+            )
+
+        for i, cand in enumerate(candidates):
+            baseline = None
+            if i < max_summary_fetches:
+                try:
+                    record = dynamo_client.get_receipt_summary(
+                        cand["image_id"], cand["receipt_id"]
+                    )
+                    _, baseline = _summary_baseline(record)
+                except EntityNotFoundError:
+                    baseline = None
+            cand["subtotal"] = baseline
+            cand["delta"] = (
+                round(cand["items_sum"] - baseline, 2)
+                if baseline is not None
+                else None
+            )
+
+        candidates.sort(
+            key=lambda c: (
+                c["delta"] is None,
+                -abs(c["delta"]) if c["delta"] is not None else 0.0,
+            )
+        )
+
+        return {
+            "status": normalized_status,
+            "merchant_filter": merchant_name,
+            "receipts_scanned": len(receipts),
+            "matching": len(candidates),
+            "worklist": candidates[:limit],
+            "scan_truncated": scan_truncated,
+            "summaries_truncated": len(candidates) > max_summary_fetches,
+        }
+
+    except Exception as e:
+        logger.exception("Error listing reconciliation worklist")
         return {"error": str(e)}
 
 

--- a/scripts/receipt_mcp_server.py
+++ b/scripts/receipt_mcp_server.py
@@ -1909,6 +1909,142 @@ WARNING: This WRITES to DynamoDB and is irreversible for that row.""",
                 "required": ["image_id", "receipt_id", "section_type"],
             },
         ),
+        Tool(
+            name="get_receipt_line_items",
+            description="""Diagnostic view of a receipt's decoded line items.
+
+Returns the RECEIPT_LINE_ITEM rows the deterministic geometric extractor
+wrote for this receipt (name, price, quantity, unit_price, is_discount,
+line_ids, name_quality, reconciliation_status, extractor_version), the
+summary baseline figures (subtotal / tax / grand_total / merchant_name),
+items_sum (sum of non-discount item prices, matching reconcile()), and
+delta = items_sum - baseline, where baseline is the printed subtotal,
+else grand_total - tax. Also returns the ITEMS section's line_ids so
+you can see which lines the extractor was allowed to read.
+
+Use this FIRST when investigating a reconciliation mismatch: it shows
+what was decoded versus what the printed baseline says. Follow up with
+get_receipt (line text) to find priced lines outside the zone, then
+extend_items_section to repair the boundary.""",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "image_id": {
+                        "type": "string",
+                        "description": "Image ID of the receipt",
+                    },
+                    "receipt_id": {
+                        "type": "integer",
+                        "description": "Receipt ID",
+                    },
+                },
+                "required": ["image_id", "receipt_id"],
+            },
+        ),
+        Tool(
+            name="extend_items_section",
+            description="""Arithmetic-VERIFIED extension of the ITEMS section.
+
+Simulates adding add_line_ids to the receipt's ITEMS section by running
+the real geometric extractor (receipt_upload.line_items.geometry) over
+both the current zone and the extended zone, reconciling each against
+the summary baseline. The extension is applied ONLY when BOTH hold:
+  1. |delta| strictly shrinks (delta = non-discount item sum minus
+     baseline), and
+  2. reconciliation status improves (mismatch -> near/match, or
+     near -> match).
+Otherwise the tool refuses and returns both evaluations.
+
+Defaults to dry_run=true (report only). With dry_run=false it updates
+the ITEMS ReceiptSection line_ids, PRESERVING its validation_status (a
+reconciliation-verified extension never demotes VALID), then rewrites
+the receipt summary with a fresh timestamp_computed so the stream stage
+regenerates the RECEIPT_LINE_ITEM rows automatically.
+
+This is the guarded repair path for zone-gap shortfall mismatches:
+real priced lines exist but the ITEMS zone does not reach them.
+
+WARNING: with dry_run=false this WRITES to DynamoDB (section update +
+summary rewrite) and triggers async line-item regeneration.""",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "image_id": {
+                        "type": "string",
+                        "description": "Image ID of the receipt",
+                    },
+                    "receipt_id": {
+                        "type": "integer",
+                        "description": "Receipt ID",
+                    },
+                    "add_line_ids": {
+                        "type": "array",
+                        "items": {"type": "integer"},
+                        "minItems": 1,
+                        "description": (
+                            "Line IDs to add to the ITEMS section"
+                        ),
+                    },
+                    "dry_run": {
+                        "type": "boolean",
+                        "default": True,
+                        "description": (
+                            "true (default): evaluate only. false: apply "
+                            "when the arithmetic guard passes."
+                        ),
+                    },
+                },
+                "required": ["image_id", "receipt_id", "add_line_ids"],
+            },
+        ),
+        Tool(
+            name="list_reconciliation_worklist",
+            description="""Queue of receipts whose line items fail reconciliation.
+
+Scans RECEIPT_LINE_ITEM rows, groups them by receipt, and keeps the
+receipts whose receipt-level status matches `status` (a receipt is
+"mismatch" when any of its items is mismatch, etc.). Optionally filters
+by case-insensitive merchant substring. For each receipt it returns
+image_id, receipt_id, merchant, item count, items_sum (non-discount),
+subtotal (the reconcile baseline: printed subtotal, else
+grand_total - tax) and delta — sorted by |delta| descending, so the
+worst arithmetic failures come first.
+
+Use this to build a repair queue, then get_receipt_line_items on each
+receipt to diagnose, and extend_items_section to fix zone-gap cases.""",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "merchant_name": {
+                        "type": "string",
+                        "description": (
+                            "Optional case-insensitive merchant substring "
+                            "filter"
+                        ),
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": [
+                            "mismatch",
+                            "near",
+                            "match",
+                            "no-baseline",
+                        ],
+                        "default": "mismatch",
+                        "description": (
+                            "Receipt-level reconciliation status to list"
+                        ),
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "default": 25,
+                        "minimum": 1,
+                        "maximum": 100,
+                        "description": "Max receipts to return",
+                    },
+                },
+            },
+        ),
     ]
 
 
@@ -2142,6 +2278,27 @@ async def call_tool(
                 image_id=arguments["image_id"],
                 receipt_id=arguments["receipt_id"],
                 section_type=arguments["section_type"],
+            )
+        elif name == "get_receipt_line_items":
+            result = await get_receipt_line_items_impl(
+                dynamo_client,
+                image_id=arguments["image_id"],
+                receipt_id=arguments["receipt_id"],
+            )
+        elif name == "extend_items_section":
+            result = await extend_items_section_impl(
+                dynamo_client,
+                image_id=arguments["image_id"],
+                receipt_id=arguments["receipt_id"],
+                add_line_ids=arguments["add_line_ids"],
+                dry_run=arguments.get("dry_run", True),
+            )
+        elif name == "list_reconciliation_worklist":
+            result = await list_reconciliation_worklist_impl(
+                dynamo_client,
+                merchant_name=arguments.get("merchant_name"),
+                status=arguments.get("status", "mismatch"),
+                limit=arguments.get("limit", 25),
             )
         elif name == "list_training_jobs":
             result = await list_training_jobs_impl(
@@ -4537,6 +4694,554 @@ async def delete_receipt_section_impl(
 
     except Exception as e:
         logger.exception("Error deleting receipt section")
+        return {"error": str(e)}
+
+
+# ---------------------------------------------------------------------------
+# Line-item reconciliation tools — deterministic extraction diagnostics
+# plus arithmetic-verified ITEMS-section repair. The extraction/reconcile
+# logic is imported from receipt_upload.line_items.geometry (the same code
+# the ingest stream runs), so what these tools simulate is exactly what
+# production recomputes after a summary rewrite.
+# ---------------------------------------------------------------------------
+
+# Receipt-level severity used to roll item statuses up to one receipt
+# status (worst wins) in the worklist.
+_RECON_SEVERITY = {"match": 0, "near": 1, "no-baseline": 2, "mismatch": 3}
+
+
+def _extraction_words(details) -> list[dict]:
+    """ReceiptWord entities -> word dicts the geometric extractor eats.
+
+    Mirrors scripts/extract_line_items.fetch_receipt_records: line_id,
+    word_id, text, x, y_mid (= bbox y + height/2), h — all in the stored
+    receipt-normalized coordinate space.
+    """
+    words: list[dict] = []
+    for word in details.words or []:
+        bb = word.bounding_box or {}
+        try:
+            words.append(
+                {
+                    "line_id": int(word.line_id),
+                    "word_id": int(word.word_id),
+                    "text": str(word.text or ""),
+                    "x": float(bb.get("x", 0)),
+                    "y_mid": float(bb.get("y", 0))
+                    + float(bb.get("height", 0)) / 2,
+                    "h": float(bb.get("height", 0)),
+                }
+            )
+        except (TypeError, ValueError):
+            continue
+    return words
+
+
+def _summary_baseline(record) -> tuple[dict, Optional[float]]:
+    """ReceiptSummaryRecord -> (reconcile() summary dict, baseline).
+
+    Baseline mirrors receipt_upload.line_items.geometry.reconcile: the
+    printed subtotal, else grand_total - tax; None when unusable.
+    """
+    summary = {
+        "subtotal": record.subtotal,
+        "grand_total": record.grand_total,
+        "tax": record.tax,
+    }
+    baseline = record.subtotal
+    if baseline is None and record.grand_total is not None:
+        baseline = record.grand_total - (record.tax or 0.0)
+    if baseline is not None and baseline <= 0:
+        baseline = None
+    return summary, baseline
+
+
+def _evaluate_items_zone(words: list[dict], summary: dict, line_ids) -> dict:
+    """Run the real extractor over a line set and reconcile.
+
+    Discounts are excluded from the sum, matching the stream stage and
+    scripts/repair_item_sections.evaluate.
+    """
+    from receipt_upload.line_items.geometry import extract_items, reconcile
+
+    items, collapsed = extract_items(words, set(line_ids))
+    status, items_sum, baseline = reconcile(
+        [x for x in items if not x["is_discount"]], summary
+    )
+    delta = (
+        round(items_sum - baseline, 2)
+        if items_sum is not None and baseline is not None
+        else None
+    )
+    return {
+        "status": status,
+        "items_sum": items_sum,
+        "baseline": baseline,
+        "delta": delta,
+        "n_items": len(items),
+        "collapsed_banding": collapsed,
+    }
+
+
+async def get_receipt_line_items_impl(
+    dynamo_client, image_id: str, receipt_id: int
+) -> dict:
+    """Diagnostic view: decoded line items vs the summary baseline."""
+    from receipt_dynamo.data.shared_exceptions import EntityNotFoundError
+
+    try:
+        line_items = dynamo_client.get_receipt_line_items_from_receipt(
+            image_id, receipt_id
+        )
+
+        try:
+            record = dynamo_client.get_receipt_summary(image_id, receipt_id)
+        except EntityNotFoundError:
+            record = None
+
+        items_section_line_ids = None
+        items_section_status = None
+        try:
+            sections = dynamo_client.get_receipt_sections_from_receipt(
+                image_id, receipt_id
+            )
+        except EntityNotFoundError:
+            sections = []
+        for section in sections or []:
+            if section.section_type == "ITEMS":
+                items_section_line_ids = sorted(
+                    int(x) for x in section.line_ids or []
+                )
+                items_section_status = section.validation_status or "NONE"
+                break
+
+        items = [
+            {
+                "item_index": li.item_index,
+                "name": li.name,
+                "price": float(li.price),
+                "quantity": li.quantity,
+                "unit_price": li.unit_price,
+                "is_discount": li.is_discount,
+                "line_ids": li.line_ids,
+                "name_quality": li.name_quality,
+                "reconciliation_status": li.reconciliation_status,
+                "extractor_version": li.extractor_version,
+            }
+            for li in line_items
+        ]
+        # Discounts excluded from the sum, matching reconcile()'s callers
+        # (the stream stage and repair_item_sections.evaluate).
+        items_sum = round(
+            sum(float(li.price) for li in line_items if not li.is_discount),
+            2,
+        )
+
+        summary = None
+        baseline = None
+        if record is not None:
+            figures, baseline = _summary_baseline(record)
+            summary = {**figures, "merchant_name": record.merchant_name}
+        delta = (
+            round(items_sum - baseline, 2) if baseline is not None else None
+        )
+
+        statuses = {
+            li.reconciliation_status
+            for li in line_items
+            if li.reconciliation_status
+        }
+        receipt_status = (
+            max(statuses, key=lambda s: _RECON_SEVERITY.get(s, -1))
+            if statuses
+            else None
+        )
+
+        return {
+            "image_id": image_id,
+            "receipt_id": receipt_id,
+            "item_count": len(items),
+            "items": items,
+            "summary": summary,
+            "items_sum": items_sum,
+            "delta": delta,
+            "reconciliation_status": receipt_status,
+            "items_section_line_ids": items_section_line_ids,
+            "items_section_status": items_section_status,
+        }
+
+    except Exception as e:
+        logger.exception("Error getting receipt line items")
+        return {"error": str(e)}
+
+
+async def extend_items_section_impl(
+    dynamo_client,
+    image_id: str,
+    receipt_id: int,
+    add_line_ids: list,
+    dry_run: bool = True,
+) -> dict:
+    """Extend the ITEMS section, gated on reconciliation arithmetic.
+
+    Apply happens ONLY when the extended zone strictly shrinks |delta|
+    AND improves the reconciliation status (mismatch -> near/match, or
+    near -> match). On apply, the section keeps its validation_status (a
+    verified extension never demotes VALID — the repair_item_sections
+    lesson) and the receipt summary is rewritten with a fresh
+    timestamp_computed so the stream stage regenerates line items.
+    """
+    from datetime import datetime, timezone
+
+    from receipt_dynamo.data.shared_exceptions import EntityNotFoundError
+    from receipt_dynamo.entities.receipt_section import ReceiptSection
+    from receipt_dynamo.entities.receipt_summary_record import (
+        ReceiptSummaryRecord,
+    )
+
+    # Guard ranking (strict improvement required to apply). Distinct from
+    # _RECON_SEVERITY: "no-baseline" is never rankable here.
+    guard_rank = {"match": 0, "near": 1, "mismatch": 2}
+
+    try:
+        try:
+            added = sorted({int(lid) for lid in (add_line_ids or [])})
+        except (TypeError, ValueError):
+            return {"error": "add_line_ids must be a list of integers"}
+        if not added:
+            return {
+                "error": "add_line_ids must be a non-empty list of integers"
+            }
+
+        try:
+            details = dynamo_client.get_receipt_details(image_id, receipt_id)
+        except EntityNotFoundError:
+            return {
+                "error": (
+                    f"Receipt {receipt_id} not found for image {image_id}"
+                )
+            }
+
+        receipt_line_ids = {line.line_id for line in details.lines or []}
+        unknown = sorted(set(added) - receipt_line_ids)
+        if unknown:
+            return {
+                "error": (
+                    f"line_ids {unknown} do not exist on receipt "
+                    f"{receipt_id} (image {image_id})"
+                )
+            }
+
+        try:
+            sections = dynamo_client.get_receipt_sections_from_receipt(
+                image_id, receipt_id
+            )
+        except EntityNotFoundError:
+            sections = []
+        items_section = next(
+            (s for s in sections or [] if s.section_type == "ITEMS"), None
+        )
+        if items_section is None:
+            return {
+                "error": (
+                    f"Receipt {receipt_id} (image {image_id}) has no ITEMS "
+                    "section to extend. Use create_receipt_section instead."
+                )
+            }
+
+        current_lids = sorted(int(x) for x in items_section.line_ids or [])
+        already = sorted(set(added) & set(current_lids))
+        if already:
+            return {
+                "error": (
+                    f"line_ids {already} are already in the ITEMS section"
+                )
+            }
+
+        # Lines claimed by another section are exactly how summary/payment
+        # rows leak into ITEMS — refuse rather than double-claim them.
+        for section in sections or []:
+            if section.section_type == "ITEMS":
+                continue
+            overlap = sorted(
+                set(added) & {int(x) for x in section.line_ids or []}
+            )
+            if overlap:
+                return {
+                    "error": (
+                        f"line_ids {overlap} already belong to section "
+                        f"{section.section_type}; refusing to double-claim"
+                    )
+                }
+
+        try:
+            record = dynamo_client.get_receipt_summary(image_id, receipt_id)
+        except EntityNotFoundError:
+            return {
+                "error": (
+                    "No RECEIPT_SUMMARY baseline for this receipt; an "
+                    "extension cannot be arithmetic-verified. Refusing."
+                )
+            }
+        summary, baseline = _summary_baseline(record)
+        if baseline is None:
+            return {
+                "error": (
+                    "Summary has no usable baseline (no subtotal and no "
+                    "grand_total); an extension cannot be verified."
+                )
+            }
+
+        # When the section is row-anchored, keep the anchor consistent:
+        # every line must be covered by a ReceiptRow, and rows are the
+        # authoritative grouping (widen line_ids to the covering union).
+        extended_lids = sorted(set(current_lids) | set(added))
+        final_lids = extended_lids
+        new_row_ids = items_section.row_ids
+        if items_section.row_ids is not None:
+            rows = (
+                dynamo_client.get_receipt_rows_from_receipt(
+                    image_id, receipt_id
+                )
+                or []
+            )
+            covering = [
+                r
+                for r in rows
+                if set(int(x) for x in r.line_ids) & set(extended_lids)
+            ]
+            union: set[int] = set()
+            for r in covering:
+                union |= {int(x) for x in r.line_ids}
+            uncovered = sorted(set(extended_lids) - union)
+            if uncovered:
+                return {
+                    "error": (
+                        f"line_ids {uncovered} map to no ReceiptRow; "
+                        "refusing to break the section's row anchor"
+                    )
+                }
+            new_row_ids = sorted({int(r.row_id) for r in covering})
+            if union != set(extended_lids):
+                final_lids = sorted(union)
+
+        words = _extraction_words(details)
+        before = _evaluate_items_zone(words, summary, current_lids)
+        after = _evaluate_items_zone(words, summary, final_lids)
+
+        result: dict[str, Any] = {
+            "image_id": image_id,
+            "receipt_id": receipt_id,
+            "added_line_ids": added,
+            "current_line_ids": current_lids,
+            "extended_line_ids": final_lids,
+            "before": before,
+            "after": after,
+            "dry_run": dry_run,
+            "applied": False,
+        }
+
+        if before["status"] == "match":
+            result["verified"] = False
+            result["refusal"] = (
+                "Current ITEMS zone already reconciles (match); nothing "
+                "to repair."
+            )
+            return result
+        if (
+            before["status"] not in guard_rank
+            or after["status"] not in guard_rank
+            or before["delta"] is None
+            or after["delta"] is None
+        ):
+            result["verified"] = False
+            result["refusal"] = (
+                "Cannot verify the extension: reconciliation did not "
+                "produce comparable deltas for both zones."
+            )
+            return result
+
+        shrinks = abs(after["delta"]) < abs(before["delta"])
+        improves = guard_rank[after["status"]] < guard_rank[before["status"]]
+        if not (shrinks and improves):
+            result["verified"] = False
+            result["refusal"] = (
+                "Arithmetic guard failed: extension must strictly shrink "
+                f"|delta| (before {before['delta']}, after "
+                f"{after['delta']}) AND improve status (before "
+                f"{before['status']!r}, after {after['status']!r})."
+            )
+            return result
+
+        result["verified"] = True
+        if dry_run:
+            result["note"] = (
+                "Arithmetic guard passed; re-run with dry_run=false to "
+                "apply."
+            )
+            return result
+
+        model_source = items_section.model_source or ""
+        if "mcp-extend-items-v1" not in model_source:
+            model_source = (
+                f"{model_source}+mcp-extend-items-v1"
+                if model_source
+                else "mcp-extend-items-v1"
+            )
+        updated = ReceiptSection(
+            receipt_id=items_section.receipt_id,
+            image_id=items_section.image_id,
+            section_type="ITEMS",
+            line_ids=final_lids,
+            created_at=items_section.created_at,
+            confidence=items_section.confidence,
+            model_source=model_source,
+            # Preserve the prior status: the extension is reconciliation-
+            # verified, and demoting VALID would hide the section from the
+            # extractor's VALID gate (the repair_item_sections lesson).
+            validation_status=items_section.validation_status,
+            row_ids=new_row_ids,
+        )
+        dynamo_client.update_receipt_section(updated)
+
+        # Rewrite the summary with a fresh timestamp_computed so the
+        # stream stage regenerates the receipt's line items over the
+        # extended section.
+        refreshed = ReceiptSummaryRecord(
+            summary=record.summary,
+            timestamp_computed=datetime.now(timezone.utc).isoformat(),
+        )
+        dynamo_client.update_receipt_summary(refreshed)
+
+        result["applied"] = True
+        result["summary_rewritten"] = True
+        result["validation_status"] = items_section.validation_status or "NONE"
+        result["model_source"] = model_source
+        return result
+
+    except Exception as e:
+        logger.exception("Error extending items section")
+        return {"error": str(e)}
+
+
+async def list_reconciliation_worklist_impl(
+    dynamo_client,
+    merchant_name: Optional[str] = None,
+    status: str = "mismatch",
+    limit: int = 25,
+) -> dict:
+    """Queue of receipts failing reconciliation, worst |delta| first."""
+    from receipt_dynamo.data.shared_exceptions import EntityNotFoundError
+
+    page_size = 1000
+    max_pages = 25  # scan cap: 25k RECEIPT_LINE_ITEM rows
+    max_summary_fetches = 300
+
+    try:
+        normalized_status = str(status or "mismatch").strip().lower()
+        if normalized_status not in _RECON_SEVERITY:
+            return {
+                "error": (
+                    f"Invalid status {status!r}; expected one of "
+                    f"{sorted(_RECON_SEVERITY)}"
+                )
+            }
+        try:
+            limit = max(1, min(int(limit), 100))
+        except (TypeError, ValueError):
+            return {"error": "limit must be an integer"}
+
+        receipts: dict[tuple, dict] = {}
+        last_key = None
+        pages = 0
+        scan_truncated = False
+        while True:
+            batch, last_key = dynamo_client.list_receipt_line_items(
+                limit=page_size, last_evaluated_key=last_key
+            )
+            pages += 1
+            for li in batch:
+                bucket = receipts.setdefault(
+                    (li.image_id, li.receipt_id),
+                    {
+                        "merchant": None,
+                        "items": 0,
+                        "items_sum": 0.0,
+                        "statuses": set(),
+                    },
+                )
+                bucket["items"] += 1
+                if not li.is_discount:
+                    bucket["items_sum"] += float(li.price)
+                if li.merchant_name and not bucket["merchant"]:
+                    bucket["merchant"] = li.merchant_name
+                if li.reconciliation_status:
+                    bucket["statuses"].add(li.reconciliation_status)
+            if last_key is None:
+                break
+            if pages >= max_pages:
+                scan_truncated = True
+                break
+
+        needle = (merchant_name or "").strip().lower()
+        candidates = []
+        for (img, rid), bucket in receipts.items():
+            statuses = bucket["statuses"]
+            receipt_status = (
+                max(statuses, key=lambda s: _RECON_SEVERITY[s])
+                if statuses
+                else "no-baseline"
+            )
+            if receipt_status != normalized_status:
+                continue
+            if needle and needle not in (bucket["merchant"] or "").lower():
+                continue
+            candidates.append(
+                {
+                    "image_id": img,
+                    "receipt_id": rid,
+                    "merchant": bucket["merchant"],
+                    "items": bucket["items"],
+                    "items_sum": round(bucket["items_sum"], 2),
+                }
+            )
+
+        for i, cand in enumerate(candidates):
+            baseline = None
+            if i < max_summary_fetches:
+                try:
+                    record = dynamo_client.get_receipt_summary(
+                        cand["image_id"], cand["receipt_id"]
+                    )
+                    _, baseline = _summary_baseline(record)
+                except EntityNotFoundError:
+                    baseline = None
+            cand["subtotal"] = baseline
+            cand["delta"] = (
+                round(cand["items_sum"] - baseline, 2)
+                if baseline is not None
+                else None
+            )
+
+        candidates.sort(
+            key=lambda c: (
+                c["delta"] is None,
+                -abs(c["delta"]) if c["delta"] is not None else 0.0,
+            )
+        )
+
+        return {
+            "status": normalized_status,
+            "merchant_filter": merchant_name,
+            "receipts_scanned": len(receipts),
+            "matching": len(candidates),
+            "worklist": candidates[:limit],
+            "scan_truncated": scan_truncated,
+            "summaries_truncated": len(candidates) > max_summary_fetches,
+        }
+
+    except Exception as e:
+        logger.exception("Error listing reconciliation worklist")
         return {"error": str(e)}
 
 

--- a/tests/test_receipt_mcp_line_item_tools.py
+++ b/tests/test_receipt_mcp_line_item_tools.py
@@ -1,0 +1,715 @@
+"""Tests for the line-item reconciliation tools on both MCP servers.
+
+The two servers (stdio ``scripts/receipt_mcp_server.py`` and the Lambda
+``infra/mcp_server_lambda/lambdas/receipt_mcp_server_server.py``) must
+expose the same tool surface. These tests import each module with a
+minimal fake ``mcp`` package (the real dependency is not installed in
+CI), assert the three line-item tools are registered with valid input
+schemas and matching impls, and exercise the impl functions with stub
+dynamo clients — in particular the arithmetic guard of
+``extend_items_section``, which must refuse any extension that does not
+strictly shrink |delta| AND improve the reconciliation status.
+"""
+
+import asyncio
+import importlib.util
+import sys
+import types
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+SERVER_FILES = {
+    "stdio": REPO_ROOT / "scripts" / "receipt_mcp_server.py",
+    "lambda": (
+        REPO_ROOT
+        / "infra"
+        / "mcp_server_lambda"
+        / "lambdas"
+        / "receipt_mcp_server_server.py"
+    ),
+}
+
+EXPECTED_LINE_ITEM_TOOLS = {
+    "get_receipt_line_items",
+    "extend_items_section",
+    "list_reconciliation_worklist",
+}
+
+VALID_IMAGE_ID = "3f2a1b0c-4d5e-4f70-8192-a3b4c5d6e7f8"
+OTHER_IMAGE_ID = "9e8d7c6b-5a49-4382-a1b0-c9d8e7f6a5b4"
+
+
+class _FakeTool:
+    """Stand-in for mcp.types.Tool that just records its fields."""
+
+    def __init__(self, name, description, inputSchema):
+        self.name = name
+        self.description = description
+        self.inputSchema = inputSchema
+
+
+class _FakeContent:
+    def __init__(self, **kwargs):
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+
+def _install_mcp_stubs():
+    """Register a minimal fake `mcp` package so the servers import cleanly."""
+    mcp_mod = types.ModuleType("mcp")
+    server_mod = types.ModuleType("mcp.server")
+    stdio_mod = types.ModuleType("mcp.server.stdio")
+    types_mod = types.ModuleType("mcp.types")
+
+    class _FakeServer:
+        def __init__(self, name):
+            self.name = name
+
+        def list_tools(self):
+            def decorator(func):
+                return func
+
+            return decorator
+
+        def call_tool(self):
+            def decorator(func):
+                return func
+
+            return decorator
+
+    def _fake_stdio_server(*args, **kwargs):  # pragma: no cover - unused
+        raise RuntimeError("stdio_server is not exercised in tests")
+
+    server_mod.Server = _FakeServer
+    stdio_mod.stdio_server = _fake_stdio_server
+    types_mod.Tool = _FakeTool
+    types_mod.TextContent = _FakeContent
+    types_mod.ImageContent = _FakeContent
+
+    sys.modules["mcp"] = mcp_mod
+    sys.modules["mcp.server"] = server_mod
+    sys.modules["mcp.server.stdio"] = stdio_mod
+    sys.modules["mcp.types"] = types_mod
+
+
+def _load_module(label, path):
+    _install_mcp_stubs()
+    spec = importlib.util.spec_from_file_location(
+        f"receipt_mcp_server_{label}", path
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+# ---------------------------------------------------------------------------
+# Registration / schema parity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("label", sorted(SERVER_FILES))
+def test_line_item_tools_present_with_valid_schema(label):
+    module = _load_module(label, SERVER_FILES[label])
+    tools = asyncio.run(module.list_tools())
+    by_name = {t.name: t for t in tools}
+
+    missing = EXPECTED_LINE_ITEM_TOOLS - set(by_name)
+    assert not missing, f"missing line-item tools in {label}: {missing}"
+
+    for name in EXPECTED_LINE_ITEM_TOOLS:
+        tool = by_name[name]
+        schema = tool.inputSchema
+        assert isinstance(schema, dict)
+        assert schema.get("type") == "object"
+        assert isinstance(schema.get("properties"), dict)
+        assert isinstance(tool.description, str) and tool.description.strip()
+
+    assert set(by_name["get_receipt_line_items"].inputSchema["required"]) == {
+        "image_id",
+        "receipt_id",
+    }
+
+    extend_schema = by_name["extend_items_section"].inputSchema
+    assert set(extend_schema["required"]) == {
+        "image_id",
+        "receipt_id",
+        "add_line_ids",
+    }
+    # dry_run must default to True: the write path is opt-in.
+    assert extend_schema["properties"]["dry_run"]["default"] is True
+    assert extend_schema["properties"]["add_line_ids"]["items"] == {
+        "type": "integer"
+    }
+
+    worklist_schema = by_name["list_reconciliation_worklist"].inputSchema
+    assert "required" not in worklist_schema
+    assert worklist_schema["properties"]["status"]["default"] == "mismatch"
+    assert set(worklist_schema["properties"]["status"]["enum"]) == {
+        "mismatch",
+        "near",
+        "match",
+        "no-baseline",
+    }
+
+
+@pytest.mark.parametrize("label", sorted(SERVER_FILES))
+def test_line_item_tool_impls_exist(label):
+    module = _load_module(label, SERVER_FILES[label])
+    for name in EXPECTED_LINE_ITEM_TOOLS:
+        impl = getattr(module, f"{name}_impl", None)
+        assert callable(impl), f"missing {name}_impl in {label} server"
+
+
+def test_both_servers_expose_identical_line_item_tool_shape():
+    stdio = _load_module("stdio-li", SERVER_FILES["stdio"])
+    lam = _load_module("lambda-li", SERVER_FILES["lambda"])
+
+    def shape(module):
+        tools = asyncio.run(module.list_tools())
+        return {
+            t.name: (t.description, t.inputSchema)
+            for t in tools
+            if t.name in EXPECTED_LINE_ITEM_TOOLS
+        }
+
+    assert shape(stdio) == shape(lam)
+
+
+# ---------------------------------------------------------------------------
+# Stub receipt world: a 4-line receipt whose arithmetic is fully known.
+#   line 1  APPLES   3.00   (in ITEMS)
+#   line 2  BANANAS  2.00   (in ITEMS)
+#   line 3  ORANGES  4.00   (outside ITEMS — the zone gap)
+#   line 4  JUNKTHING 50.00 (outside ITEMS — absorbing it breaks arithmetic)
+# summary: subtotal 9.00, tax 0.72, grand_total 9.72
+# Current zone {1,2} reconciles mismatch (5 vs 9); {1,2,3} is a match;
+# {1,2,3,4} is a worse mismatch (59 vs 9).
+# ---------------------------------------------------------------------------
+
+
+def _word(line_id, word_id, text, x, y):
+    return SimpleNamespace(
+        line_id=line_id,
+        word_id=word_id,
+        text=text,
+        bounding_box={"x": x, "y": y - 0.01, "width": 0.1, "height": 0.02},
+    )
+
+
+def _receipt_words():
+    return [
+        _word(1, 1, "APPLES", 0.05, 0.10),
+        _word(1, 2, "3.00", 0.80, 0.10),
+        _word(2, 1, "BANANAS", 0.05, 0.15),
+        _word(2, 2, "2.00", 0.80, 0.15),
+        _word(3, 1, "ORANGES", 0.05, 0.20),
+        _word(3, 2, "4.00", 0.80, 0.20),
+        _word(4, 1, "JUNKTHING", 0.05, 0.25),
+        _word(4, 2, "50.00", 0.80, 0.25),
+    ]
+
+
+def _summary_record(subtotal=9.00, tax=0.72, grand_total=9.72):
+    """A real ReceiptSummaryRecord (the apply path rebuilds one from it)."""
+    from receipt_dynamo.entities.receipt_summary import (
+        MonetaryTotals,
+        ReceiptSummary,
+    )
+    from receipt_dynamo.entities.receipt_summary_record import (
+        ReceiptSummaryRecord,
+    )
+
+    summary = ReceiptSummary(
+        image_id=VALID_IMAGE_ID,
+        receipt_id=1,
+        merchant_name="Test Mart",
+        totals=MonetaryTotals(
+            grand_total=grand_total, subtotal=subtotal, tax=tax
+        ),
+        item_count=3,
+    )
+    return ReceiptSummaryRecord(
+        summary=summary,
+        timestamp_computed="2026-01-01T00:00:00+00:00",
+    )
+
+
+def _items_section(line_ids=(1, 2), validation_status="VALID"):
+    from receipt_dynamo.entities.receipt_section import ReceiptSection
+
+    return ReceiptSection(
+        receipt_id=1,
+        image_id=VALID_IMAGE_ID,
+        section_type="ITEMS",
+        line_ids=list(line_ids),
+        created_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        model_source="section-seed-v0",
+        validation_status=validation_status,
+    )
+
+
+class _StubDynamoClient:
+    """Stub dynamo client for the extend/diagnostic impls."""
+
+    def __init__(
+        self,
+        sections=None,
+        summary_record="default",
+        line_items=(),
+    ):
+        self.sections = sections if sections is not None else []
+        self.summary_record = (
+            _summary_record()
+            if summary_record == "default"
+            else summary_record
+        )
+        self.line_items = list(line_items)
+        self.updated_sections = []
+        self.updated_summaries = []
+
+    def get_receipt_details(self, image_id, receipt_id):
+        return SimpleNamespace(
+            lines=[SimpleNamespace(line_id=i) for i in (1, 2, 3, 4)],
+            words=_receipt_words(),
+        )
+
+    def get_receipt_sections_from_receipt(self, image_id, receipt_id):
+        return self.sections
+
+    def get_receipt_summary(self, image_id, receipt_id):
+        if self.summary_record is None:
+            from receipt_dynamo.data.shared_exceptions import (
+                EntityNotFoundError,
+            )
+
+            raise EntityNotFoundError("summary not found")
+        return self.summary_record
+
+    def get_receipt_line_items_from_receipt(self, image_id, receipt_id):
+        return self.line_items
+
+    def update_receipt_section(self, section):
+        self.updated_sections.append(section)
+
+    def update_receipt_summary(self, record):
+        self.updated_summaries.append(record)
+
+
+# ---------------------------------------------------------------------------
+# get_receipt_line_items_impl
+# ---------------------------------------------------------------------------
+
+
+def _line_item(
+    item_index,
+    name,
+    price,
+    is_discount=False,
+    reconciliation_status="mismatch",
+    merchant_name="Test Mart",
+    image_id=VALID_IMAGE_ID,
+    receipt_id=1,
+):
+    return SimpleNamespace(
+        image_id=image_id,
+        receipt_id=receipt_id,
+        item_index=item_index,
+        name=name,
+        price=str(price),
+        quantity=None,
+        unit_price=None,
+        is_discount=is_discount,
+        line_ids=[item_index + 1],
+        name_quality="ok",
+        merchant_name=merchant_name,
+        reconciliation_status=reconciliation_status,
+        extractor_version="line-items-blocks-v2",
+    )
+
+
+@pytest.mark.parametrize("label", sorted(SERVER_FILES))
+def test_get_receipt_line_items_diagnostic_view(label):
+    pytest.importorskip("receipt_dynamo")
+    module = _load_module(label, SERVER_FILES[label])
+    client = _StubDynamoClient(
+        sections=[_items_section(line_ids=(1, 2))],
+        line_items=[
+            _line_item(0, "APPLES", "3.00"),
+            _line_item(1, "BANANAS", "2.00"),
+            _line_item(2, "COUPON", "-1.00", is_discount=True),
+        ],
+    )
+    result = asyncio.run(
+        module.get_receipt_line_items_impl(client, VALID_IMAGE_ID, 1)
+    )
+
+    assert "error" not in result
+    assert result["item_count"] == 3
+    # Discounts are excluded from the sum, matching reconcile()'s callers.
+    assert result["items_sum"] == 5.00
+    assert result["summary"]["subtotal"] == 9.00
+    assert result["summary"]["merchant_name"] == "Test Mart"
+    assert result["delta"] == -4.00
+    assert result["reconciliation_status"] == "mismatch"
+    assert result["items_section_line_ids"] == [1, 2]
+    assert result["items_section_status"] == "VALID"
+    first = result["items"][0]
+    assert first["name"] == "APPLES"
+    assert first["price"] == 3.00
+    assert first["extractor_version"] == "line-items-blocks-v2"
+    assert first["name_quality"] == "ok"
+
+
+@pytest.mark.parametrize("label", sorted(SERVER_FILES))
+def test_get_receipt_line_items_without_summary(label):
+    pytest.importorskip("receipt_dynamo")
+    module = _load_module(label, SERVER_FILES[label])
+    client = _StubDynamoClient(
+        sections=[],
+        summary_record=None,
+        line_items=[_line_item(0, "APPLES", "3.00")],
+    )
+    result = asyncio.run(
+        module.get_receipt_line_items_impl(client, VALID_IMAGE_ID, 1)
+    )
+    assert "error" not in result
+    assert result["summary"] is None
+    assert result["delta"] is None
+    assert result["items_section_line_ids"] is None
+
+
+# ---------------------------------------------------------------------------
+# extend_items_section_impl — the arithmetic guard
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("label", sorted(SERVER_FILES))
+def test_extend_verified_dry_run_does_not_write(label):
+    pytest.importorskip("receipt_dynamo")
+    pytest.importorskip("receipt_upload")
+    module = _load_module(label, SERVER_FILES[label])
+    client = _StubDynamoClient(sections=[_items_section(line_ids=(1, 2))])
+
+    result = asyncio.run(
+        module.extend_items_section_impl(client, VALID_IMAGE_ID, 1, [3])
+    )
+
+    assert "error" not in result
+    assert result["verified"] is True
+    assert result["applied"] is False
+    assert result["dry_run"] is True
+    assert result["before"]["status"] == "mismatch"
+    assert result["after"]["status"] == "match"
+    assert abs(result["after"]["delta"]) < abs(result["before"]["delta"])
+    assert client.updated_sections == []
+    assert client.updated_summaries == []
+
+
+@pytest.mark.parametrize("label", sorted(SERVER_FILES))
+def test_extend_apply_updates_section_and_rewrites_summary(label):
+    pytest.importorskip("receipt_dynamo")
+    pytest.importorskip("receipt_upload")
+    module = _load_module(label, SERVER_FILES[label])
+    client = _StubDynamoClient(sections=[_items_section(line_ids=(1, 2))])
+
+    result = asyncio.run(
+        module.extend_items_section_impl(
+            client, VALID_IMAGE_ID, 1, [3], dry_run=False
+        )
+    )
+
+    assert "error" not in result
+    assert result["verified"] is True
+    assert result["applied"] is True
+    assert result["summary_rewritten"] is True
+
+    assert len(client.updated_sections) == 1
+    written = client.updated_sections[0]
+    assert written.section_type == "ITEMS"
+    assert sorted(written.line_ids) == [1, 2, 3]
+    # The repair_item_sections lesson: never demote a VALID section.
+    assert written.validation_status == "VALID"
+    assert "mcp-extend-items-v1" in written.model_source
+
+    # Summary rewritten with a FRESH timestamp so the stream stage
+    # regenerates the RECEIPT_LINE_ITEM rows.
+    assert len(client.updated_summaries) == 1
+    rewritten = client.updated_summaries[0]
+    assert rewritten.timestamp_computed != "2026-01-01T00:00:00+00:00"
+    assert rewritten.subtotal == 9.00
+    assert rewritten.merchant_name == "Test Mart"
+
+
+@pytest.mark.parametrize("label", sorted(SERVER_FILES))
+def test_extend_refuses_when_arithmetic_worsens(label):
+    """Absorbing a junk 50.00 band makes |delta| grow — must refuse."""
+    pytest.importorskip("receipt_dynamo")
+    pytest.importorskip("receipt_upload")
+    module = _load_module(label, SERVER_FILES[label])
+    client = _StubDynamoClient(sections=[_items_section(line_ids=(1, 2))])
+
+    result = asyncio.run(
+        module.extend_items_section_impl(
+            client, VALID_IMAGE_ID, 1, [4], dry_run=False
+        )
+    )
+
+    assert "error" not in result
+    assert result["verified"] is False
+    assert result["applied"] is False
+    assert "refusal" in result
+    assert result["before"]["delta"] == -4.00
+    assert result["after"]["delta"] == 46.00
+    assert client.updated_sections == []
+    assert client.updated_summaries == []
+
+
+@pytest.mark.parametrize("label", sorted(SERVER_FILES))
+def test_extend_refuses_when_already_matching(label):
+    pytest.importorskip("receipt_dynamo")
+    pytest.importorskip("receipt_upload")
+    module = _load_module(label, SERVER_FILES[label])
+    client = _StubDynamoClient(sections=[_items_section(line_ids=(1, 2, 3))])
+
+    result = asyncio.run(
+        module.extend_items_section_impl(
+            client, VALID_IMAGE_ID, 1, [4], dry_run=False
+        )
+    )
+
+    assert result["verified"] is False
+    assert "refusal" in result
+    assert client.updated_sections == []
+
+
+@pytest.mark.parametrize("label", sorted(SERVER_FILES))
+def test_extend_refuses_lines_claimed_by_other_sections(label):
+    pytest.importorskip("receipt_dynamo")
+    module = _load_module(label, SERVER_FILES[label])
+    from receipt_dynamo.entities.receipt_section import ReceiptSection
+
+    summary_section = ReceiptSection(
+        receipt_id=1,
+        image_id=VALID_IMAGE_ID,
+        section_type="SUMMARY",
+        line_ids=[4],
+        created_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        model_source="section-seed-v0",
+        validation_status="VALID",
+    )
+    client = _StubDynamoClient(
+        sections=[_items_section(line_ids=(1, 2)), summary_section]
+    )
+
+    result = asyncio.run(
+        module.extend_items_section_impl(client, VALID_IMAGE_ID, 1, [4])
+    )
+    assert "error" in result
+    assert "SUMMARY" in result["error"]
+    assert client.updated_sections == []
+
+
+@pytest.mark.parametrize("label", sorted(SERVER_FILES))
+def test_extend_refuses_without_summary_baseline(label):
+    pytest.importorskip("receipt_dynamo")
+    module = _load_module(label, SERVER_FILES[label])
+    client = _StubDynamoClient(
+        sections=[_items_section(line_ids=(1, 2))], summary_record=None
+    )
+
+    result = asyncio.run(
+        module.extend_items_section_impl(client, VALID_IMAGE_ID, 1, [3])
+    )
+    assert "error" in result
+    assert "baseline" in result["error"].lower()
+    assert client.updated_sections == []
+
+
+@pytest.mark.parametrize("label", sorted(SERVER_FILES))
+def test_extend_rejects_unknown_line_ids(label):
+    pytest.importorskip("receipt_dynamo")
+    module = _load_module(label, SERVER_FILES[label])
+    client = _StubDynamoClient(sections=[_items_section(line_ids=(1, 2))])
+
+    result = asyncio.run(
+        module.extend_items_section_impl(client, VALID_IMAGE_ID, 1, [99])
+    )
+    assert "error" in result
+    assert "99" in result["error"]
+    assert client.updated_sections == []
+
+
+# ---------------------------------------------------------------------------
+# list_reconciliation_worklist_impl
+# ---------------------------------------------------------------------------
+
+
+class _WorklistClient:
+    """Stub with paginated line items + per-receipt summaries."""
+
+    def __init__(self, pages, summaries):
+        self._pages = pages
+        self._summaries = summaries
+        self.summary_calls = 0
+
+    def list_receipt_line_items(self, limit=None, last_evaluated_key=None):
+        idx = 0 if last_evaluated_key is None else last_evaluated_key["page"]
+        items = self._pages[idx]
+        next_key = {"page": idx + 1} if idx + 1 < len(self._pages) else None
+        return items, next_key
+
+    def get_receipt_summary(self, image_id, receipt_id):
+        self.summary_calls += 1
+        key = (image_id, receipt_id)
+        if key not in self._summaries:
+            from receipt_dynamo.data.shared_exceptions import (
+                EntityNotFoundError,
+            )
+
+            raise EntityNotFoundError("summary not found")
+        subtotal = self._summaries[key]
+        return SimpleNamespace(subtotal=subtotal, grand_total=None, tax=None)
+
+
+@pytest.mark.parametrize("label", sorted(SERVER_FILES))
+def test_worklist_groups_filters_and_sorts_by_abs_delta(label):
+    pytest.importorskip("receipt_dynamo")
+    module = _load_module(label, SERVER_FILES[label])
+
+    pages = [
+        [
+            # Receipt A: mismatch, delta -4.00
+            _line_item(0, "APPLES", "3.00", image_id=VALID_IMAGE_ID),
+            _line_item(1, "BANANAS", "2.00", image_id=VALID_IMAGE_ID),
+        ],
+        [
+            # Receipt B (other merchant): mismatch, delta -90.00
+            _line_item(
+                0,
+                "WIDGET",
+                "10.00",
+                image_id=OTHER_IMAGE_ID,
+                merchant_name="Mega Store",
+            ),
+            # Receipt B second page item; discount must not join the sum
+            _line_item(
+                1,
+                "COUPON",
+                "-5.00",
+                is_discount=True,
+                image_id=OTHER_IMAGE_ID,
+                merchant_name="Mega Store",
+            ),
+            # Receipt C: all items match — filtered out for "mismatch"
+            _line_item(
+                0,
+                "CLEAN",
+                "7.00",
+                reconciliation_status="match",
+                image_id=VALID_IMAGE_ID,
+                receipt_id=2,
+            ),
+        ],
+    ]
+    summaries = {
+        (VALID_IMAGE_ID, 1): 9.00,
+        (OTHER_IMAGE_ID, 1): 100.00,
+        (VALID_IMAGE_ID, 2): 7.00,
+    }
+    client = _WorklistClient(pages, summaries)
+
+    result = asyncio.run(
+        module.list_reconciliation_worklist_impl(client, status="mismatch")
+    )
+
+    assert "error" not in result
+    assert result["receipts_scanned"] == 3
+    assert result["matching"] == 2
+    worklist = result["worklist"]
+    # Sorted by |delta| descending: B (-90.00) before A (-4.00).
+    assert [w["image_id"] for w in worklist] == [
+        OTHER_IMAGE_ID,
+        VALID_IMAGE_ID,
+    ]
+    b, a = worklist
+    assert b["merchant"] == "Mega Store"
+    assert b["items"] == 2
+    assert b["items_sum"] == 10.00  # discount excluded
+    assert b["subtotal"] == 100.00
+    assert b["delta"] == -90.00
+    assert a["delta"] == -4.00
+    # Receipt C matched — its summary is never fetched.
+    assert client.summary_calls == 2
+
+
+@pytest.mark.parametrize("label", sorted(SERVER_FILES))
+def test_worklist_merchant_filter_is_case_insensitive_substring(label):
+    pytest.importorskip("receipt_dynamo")
+    module = _load_module(label, SERVER_FILES[label])
+    pages = [
+        [
+            _line_item(0, "APPLES", "3.00", image_id=VALID_IMAGE_ID),
+            _line_item(
+                0,
+                "WIDGET",
+                "10.00",
+                image_id=OTHER_IMAGE_ID,
+                merchant_name="Mega Store",
+            ),
+        ]
+    ]
+    client = _WorklistClient(
+        pages,
+        {(VALID_IMAGE_ID, 1): 9.00, (OTHER_IMAGE_ID, 1): 100.00},
+    )
+
+    result = asyncio.run(
+        module.list_reconciliation_worklist_impl(
+            client, merchant_name="mega", status="mismatch"
+        )
+    )
+    assert result["matching"] == 1
+    assert result["worklist"][0]["merchant"] == "Mega Store"
+
+
+@pytest.mark.parametrize("label", sorted(SERVER_FILES))
+def test_worklist_rejects_invalid_status(label):
+    module = _load_module(label, SERVER_FILES[label])
+
+    class _Exploding:
+        def __getattr__(self, name):
+            raise AssertionError("client must not be called")
+
+    result = asyncio.run(
+        module.list_reconciliation_worklist_impl(_Exploding(), status="bogus")
+    )
+    assert "error" in result
+    assert "bogus" in result["error"]
+
+
+@pytest.mark.parametrize("label", sorted(SERVER_FILES))
+def test_worklist_missing_summary_sorts_last(label):
+    pytest.importorskip("receipt_dynamo")
+    module = _load_module(label, SERVER_FILES[label])
+    pages = [
+        [
+            _line_item(0, "APPLES", "3.00", image_id=VALID_IMAGE_ID),
+            _line_item(0, "GHOST", "1.00", image_id=OTHER_IMAGE_ID),
+        ]
+    ]
+    client = _WorklistClient(pages, {(VALID_IMAGE_ID, 1): 9.00})
+
+    result = asyncio.run(
+        module.list_reconciliation_worklist_impl(client, status="mismatch")
+    )
+    worklist = result["worklist"]
+    assert len(worklist) == 2
+    assert worklist[0]["image_id"] == VALID_IMAGE_ID
+    assert worklist[1]["subtotal"] is None
+    assert worklist[1]["delta"] is None


### PR DESCRIPTION
## What

Adds three MCP tools to the receipt server, mirrored in both implementations (`scripts/receipt_mcp_server.py` stdio + `infra/mcp_server_lambda/lambdas/receipt_mcp_server_server.py` Lambda), completing the two-path line-item architecture:

1. **Deterministic extraction** stays in the pipeline: `receipt_upload.line_items.geometry` (band-block decoder + `reconcile()`) is the only thing that ever writes `RECEIPT_LINE_ITEM` rows, regenerated by the stream stage after a summary rewrite.
2. **Agent repair** happens only through guarded tools that *simulate with the real extractor and verify the arithmetic before any write* — the agent can never hand-edit items, only widen the evidence the extractor is allowed to read, and only when the printed baseline (96% bank-confirmed) says the result got better.

## The three tools

### `get_receipt_line_items(image_id, receipt_id)` — diagnose
Decoded items (name, price, quantity, unit_price, is_discount, line_ids, name_quality, reconciliation_status, extractor_version), summary baseline figures, `items_sum` (non-discount, matching `reconcile()`), `delta = items_sum − baseline` (baseline = subtotal, else grand_total − tax), and the ITEMS section's line_ids.

### `extend_items_section(image_id, receipt_id, add_line_ids, dry_run=true)` — guarded repair
Targets the dominant failure mode (H-zone-gap: 45% of mismatches — real priced lines the ITEMS zone doesn't reach). Simulates by running `extract_items` over the current zone and the extended zone, reconciling both against the summary baseline. **Applies only when BOTH hold:** `|delta|` strictly shrinks AND status improves (mismatch→near/match, near→match); otherwise returns a refusal carrying both evaluations. Additional guards:

- refuses line_ids not on the receipt, already in ITEMS, or claimed by another section (how summary/payment rows leak in)
- refuses when there is no usable summary baseline (nothing to verify against)
- row-anchored sections stay consistent: added lines must map to ReceiptRows; rows' union is authoritative and the guard re-verifies the final zone
- on apply: `update_receipt_section` **preserving `validation_status`** (a verified extension never demotes VALID — the `repair_item_sections` lesson), appends `+mcp-extend-items-v1` to model_source, then rewrites the summary with a fresh `timestamp_computed` so the stream stage regenerates the line items
- `dry_run` defaults to true; the write path is opt-in

### `list_reconciliation_worklist(merchant_name?, status="mismatch", limit=25)` — queue
Scans `RECEIPT_LINE_ITEM` rows (paginated, capped at 25k rows / 300 summary fetches), rolls item statuses up per receipt (worst wins), filters by status + case-insensitive merchant substring, returns per receipt image_id, receipt_id, merchant, items, items_sum, subtotal, delta — sorted by |delta| descending so the worst arithmetic failures surface first.

## Tests

`tests/test_receipt_mcp_line_item_tools.py` (31 tests, following the section-tools convention): registration/schema parity across both servers, plus impl tests with stub dynamo clients on a synthetic receipt whose arithmetic is fully known — verified dry-run makes no writes, apply preserves VALID and rewrites the summary with a fresh timestamp, refusals on worsened arithmetic / already-matching / cross-section claims / missing baseline / unknown lines, and worklist grouping/filtering/sorting. Existing MCP suites (`test_receipt_mcp_section_tools.py`, `test_receipt_mcp_lazy_chroma.py`) still pass (86 total). Both server files `py_compile` clean; black + isort (`--profile=black --line-length=79`) applied; the inter-file diff remains only the pre-existing `_load_config` divergence.

## Context

Failure-mode analysis over the 646-receipt dev corpus: 151 mismatches, 45% zone-gap shortfall; the printed baseline is bank-confirmed on 96% of receipts with a Chase match, which is what justifies using reconciliation as the hard gate these tools enforce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KMeX4w8g3NsVg7ckN7wyBh