### PR TITLE
feat(line-items): non-product band filter (summary figures, promo echoes, tender)

### DIFF
--- a/infra/receipt_line_item_updater/line_item_processor.py
+++ b/infra/receipt_line_item_updater/line_item_processor.py
@@ -89,8 +89,9 @@ def update_receipt_line_items(
         if w.line_id in line_ids
     ]
 
-    items, collapsed = extract_items(word_dicts, line_ids)
-
+    # Summary is fetched BEFORE extraction: the decoder's non-product
+    # band filter needs the printed subtotal/tax/grand_total to recognize
+    # summary figures leaking into the ITEMS zone.
     summary_dict = None
     merchant = None
     try:
@@ -113,6 +114,10 @@ def update_receipt_line_items(
             image_id[:8],
             receipt_id,
         )
+
+    items, collapsed = extract_items(
+        word_dicts, line_ids, summary=summary_dict
+    )
 
     status, _, _ = reconcile(
         [x for x in items if not x.get("is_discount")], summary_dict

--- a/receipt_upload/receipt_upload/line_items/blocks.py
+++ b/receipt_upload/receipt_upload/line_items/blocks.py
@@ -38,7 +38,11 @@ from receipt_dynamo.amounts import (
     parse_receipt_amount,
 )
 
-__all__ = ["derive_block_labels", "templatize"]
+__all__ = [
+    "derive_block_labels",
+    "filter_summary_figure_items",
+    "templatize",
+]
 
 
 def templatize(text: str) -> str:
@@ -441,9 +445,105 @@ def derive_band_labels(golden_receipt: dict, ocr_receipt: dict) -> list[dict]:
     return out
 
 
-def decode_band_blocks(ocr_receipt: dict, priors: dict) -> list[dict]:
-    """Block decode over deskewed visual bands (the corrected unit)."""
+def filter_summary_figure_items(
+    items: list[dict], summary: dict | None
+) -> list[dict]:
+    """Drop non-product bands whose price equals a printed summary figure.
+
+    Mode A/F of the failure-mode analysis: receipts that print their
+    subtotal / tax / grand total INSIDE the ITEMS zone (Mob Museum's bare
+    "57.90" == grand total; In-N-Out's "DRIVE-Thru Eat Out 14.50" order
+    line == subtotal) emit that figure as an item and double the sum.
+
+    Guards, all load-bearing:
+      * Runs only when the receipt does NOT already reconcile -- a
+        matching receipt is never touched, so the filter cannot lose a
+        currently-matching receipt.
+      * n_items >= 2: at least 2 other non-discount items must survive
+        every drop. Single-item receipts legitimately have item price ==
+        total (Barnes & Noble / CVS / Target / LA County in the report).
+      * An UNNAMED band (no real name) matching subtotal / tax /
+        grand_total is dropped only when the drop strictly improves the
+        reconciliation delta.
+      * A NAMED band may match only subtotal / grand_total (a product
+        coincidentally priced at the tax amount must survive) and is
+        dropped only when the remaining items then reconcile to a match
+        -- the self-verifying "apply, then re-reconcile" rule.
+    """
+    from receipt_upload.line_items.geometry import _name_is_real
+
+    if not summary or not items:
+        return items
+
+    def _f(key: str) -> float | None:
+        v = summary.get(key)
+        try:
+            return float(v) if v is not None else None
+        except (TypeError, ValueError):
+            return None
+
+    subtotal, tax, grand = _f("subtotal"), _f("tax"), _f("grand_total")
+    baseline = subtotal
+    if baseline is None and grand is not None:
+        baseline = grand - (tax or 0.0)
+    if baseline is None or baseline <= 0:
+        return items
+
+    non_disc = [i for i in items if not i.get("is_discount")]
+    cur = round(sum(i["price"] for i in non_disc), 2)
+    tol = max(0.02, baseline * 0.01)
+    if abs(cur - baseline) <= tol:
+        return items  # already reconciles; never touch a match
+
+    drop: set[int] = set()
+    changed = True
+    while changed:
+        changed = False
+        for idx, it in enumerate(items):
+            if idx in drop or it.get("is_discount"):
+                continue
+            price = it.get("price")
+            if not isinstance(price, (int, float)) or price <= 0:
+                continue
+            unnamed = not _name_is_real(it.get("name") or "")
+            figures = [subtotal, grand] + ([tax] if unnamed else [])
+            # 1% figure tolerance (same shape as reconcile's match band):
+            # the printed figure itself carries OCR jitter -- Trader Joe's
+            # 0e75127f prints "$16.41" for a summary total read as 16.47.
+            if not any(
+                f is not None and abs(price - f) <= max(0.02, f * 0.01)
+                for f in figures
+            ):
+                continue
+            if len(non_disc) - len(drop) - 1 < 2:
+                continue  # at least 2 other items must survive
+            new_diff = abs(round(cur - price, 2) - baseline)
+            if unnamed:
+                ok = new_diff < abs(cur - baseline) - 0.005
+            else:
+                ok = new_diff <= tol
+            if ok:
+                drop.add(idx)
+                cur = round(cur - price, 2)
+                changed = True
+    if not drop:
+        return items
+    return [it for i, it in enumerate(items) if i not in drop]
+
+
+def decode_band_blocks(
+    ocr_receipt: dict, priors: dict, summary: dict | None = None
+) -> list[dict]:
+    """Block decode over deskewed visual bands (the corrected unit).
+
+    ``summary`` (optional {subtotal, tax, grand_total}) enables the
+    non-product band filter: printed summary figures leaking into the
+    ITEMS zone are dropped via filter_summary_figure_items. Callers
+    without a summary (golden gate, ingest paths before the summary
+    exists) pass None and get the unfiltered decode.
+    """
     from receipt_upload.line_items.geometry import (
+        NON_PRODUCT_NOTE_RE,
         SALE_PRICE_RE,
         SETTLEMENT_RE,
         WAS_PRICE_RE,
@@ -464,6 +564,7 @@ def decode_band_blocks(ocr_receipt: dict, priors: dict) -> list[dict]:
             SETTLEMENT_RE.match(bare)
             or WAS_PRICE_RE.search(b["text"])
             or SALE_PRICE_RE.search(b["text"])
+            or NON_PRODUCT_NOTE_RE.search(b["text"])
         ):
             b["role"] = "OUTSIDE"
             continue
@@ -646,7 +747,7 @@ def decode_band_blocks(ocr_receipt: dict, priors: dict) -> list[dict]:
             else set(bands[p]["line_ids"])
         )
         items.append(parsed)
-    return items
+    return filter_summary_figure_items(items, summary)
 
 
 def load_default_priors() -> dict:

--- a/receipt_upload/receipt_upload/line_items/geometry.py
+++ b/receipt_upload/receipt_upload/line_items/geometry.py
@@ -45,11 +45,15 @@ QTY_AT_OCR_RE = re.compile(r"(\d+(?:\.\d+)?)\s*g\s*\$(\d+\.\d{2,3})")
 # Leading "1x" / "2X" multiplier
 QTY_MULT_RE = re.compile(r"^(\d{1,2})[xX]$")
 # Settlement lines are never items even when a broken ITEMS section
-# includes them (BALANCE DUE / Balance to pay / CREDIT / CHANGE ...)
+# includes them (BALANCE DUE / Balance to pay / CREDIT / CHANGE ...).
+# OCR sometimes scrambles word order ("17.98 DUE BALANCE") or prefixes an
+# item count ("[1 item] Sub Total 16.00"); both forms are covered here.
 SETTLEMENT_RE = re.compile(
-    r"^\W*(?:BALANCE(?:\s+DUE|\s+TO\s+PAY)?|TO\s+PAY|CREDIT|DEBIT"
+    r"^\W*(?:ITEMS?\W+)?"
+    r"(?:BALANCE(?:\s+DUE|\s+TO\s+PAY)?|DUE\s+BALANCE"
+    r"|(?:AMOUNT|TOTAL)\s+(?:DUE|TO\s+PAY)|TO\s+PAY|CREDIT|(?:AUTH\s+)?DEBIT"
     r"|CHANGE(?:\s+DUE)?|CASH(?:\s+BACK)?|TENDER(?:ED)?"
-    r"|SUB\s*TOTAL|TOTAL|(?:SALES\s+)?TAX)\W*$",
+    r"|SUB\W{0,2}T(?:OTA|T)L|TOTAL|(?:SALES\s+)?TAX)\W*$",
     re.IGNORECASE,
 )
 # Price-comparison metadata ("SALE 2 @ $1.89, WAS: $3.59 each"): the WAS
@@ -57,8 +61,25 @@ SETTLEMENT_RE = re.compile(
 WAS_PRICE_RE = re.compile(r"\b(?:WAS|REG)\b[:.]?\s*\$?\d", re.IGNORECASE)
 # BOGO annotation echo: "PENNE RIGATE PAST Sale Price 1.99" restates the
 # post-discount unit price already carried by the discount line; counting
-# it double-counts. Exact phrase only — "BAG SALE PAPER EA" is a real item.
-SALE_PRICE_RE = re.compile(r"\bSALE\s+PRICE\b", re.IGNORECASE)
+# it double-counts. Target prints the same echo as "Regular Price $22.99"
+# under each discounted item (mode D in the failure-mode report: dropping
+# that one band closes the delta exactly), and Nordstrom Rack prints it as
+# "Comparable Value 59.95". Exact phrases only — "BAG SALE PAPER EA" is a
+# real item.
+SALE_PRICE_RE = re.compile(
+    r"\b(?:(?:SALE|REG(?:ULAR)?\.?)\s+PRICE|COMPARABLE\s+VALUE)\b",
+    re.IGNORECASE,
+)
+# Non-product annotations that carry an amount but are never items:
+# tip-suggestion footers ("22% Tip = 4.40", "15% = 10.73", "18%: (Tip
+# Total 9.27)") and transaction-count notes ("Items in Transaction: 5").
+# The %-sign / exact-phrase anchors keep product names ("6% FAT MLK",
+# "STEAK TIPS") out of reach.
+NON_PRODUCT_NOTE_RE = re.compile(
+    r"\d{1,3}\s*%\s*[:=]|%\s*TIP\b|\bTIP\s+TOTAL\b"
+    r"|\bITEMS?\s+IN\s+TRANSACTION\b",
+    re.IGNORECASE,
+)
 # Standalone leading quantity: "2 BURRITO ..." only when integer < 100
 LEAD_QTY_RE = re.compile(r"^(\d{1,2})\s+(?=[A-Za-z])")
 TAX_FLAG_RE = re.compile(r"\s+[TFNOAB]X?$")
@@ -331,7 +352,9 @@ def _name_is_real(name: str) -> bool:
 
 
 def extract_items(
-    words: list[dict], line_ids: set[int]
+    words: list[dict],
+    line_ids: set[int],
+    summary: Optional[dict] = None,
 ) -> tuple[list[dict], bool]:
     """Extract items via the band-block decoder (Phase D integration).
 
@@ -340,6 +363,12 @@ def extract_items(
     semantic guarantees, golden floors LOO 85/57/86 with zero failures,
     corpus sweep match 418 vs 415. The banded implementation remains below
     as _extract_items_banded for the corpus diff harness.
+
+    ``summary`` (optional {subtotal, tax, grand_total}) activates the
+    non-product band filter: bands whose price merely restates a printed
+    summary figure are dropped (see blocks.filter_summary_figure_items
+    for the guards). Default None preserves the unfiltered decode for
+    callers that have no summary.
     """
     from receipt_upload.line_items.blocks import (
         decode_band_blocks,
@@ -349,6 +378,7 @@ def extract_items(
     items = decode_band_blocks(
         {"words": list(words), "items_line_ids": sorted(line_ids)},
         load_default_priors(),
+        summary=summary,
     )
     return items, False
 

--- a/receipt_upload/tests/test_line_item_geometry.py
+++ b/receipt_upload/tests/test_line_item_geometry.py
@@ -157,3 +157,141 @@ def test_word_ids_retained_for_label_projection():
     parsed = parse_band(band)
     assert parsed["price_word_id"] == {"line_id": 1, "word_id": 3}
     assert [w["word_id"] for w in parsed["name_word_ids"]] == [1, 2]
+
+
+# --- non-product band filter (summary-figure / promo-echo / tender) ------
+
+
+def items_with_summary(words, summary):
+    line_ids = {w["line_id"] for w in words}
+    items, _ = extract_items(words, line_ids, summary=summary)
+    return items
+
+
+def test_summary_figure_unnamed_band_dropped():
+    # Mob Museum: a bare "57.90" band == printed grand total emitted as an
+    # unnamed item alongside the two real tickets. With the summary
+    # available, the figure band is dropped and the receipt reconciles.
+    words = (
+        row(1, 0.30, "1", "Adult-Local-Any", "19.95")
+        + row(2, 0.25, "1", "Adult-Anytime", "37.95")
+        + row(3, 0.20, "57.90")
+    )
+    items = items_with_summary(words, {"grand_total": "57.90", "tax": "0.0"})
+    assert sorted(i["price"] for i in items) == [19.95, 37.95]
+
+
+def test_summary_figure_named_order_line_dropped():
+    # In-N-Out prints the order type + total INSIDE the items block
+    # ("DRIVE-Thru Eat Out 14.50"); the band carries a real-looking name,
+    # so it may only drop when the remaining items then reconcile.
+    words = (
+        row(1, 0.30, "5", "Meat", "Patty", "9.75")
+        + row(2, 0.25, "1", "Animal", "Fry", "4.75")
+        + row(3, 0.20, "DRIVE-Tat", ".", "Out", "14.50")
+    )
+    items = items_with_summary(
+        words,
+        {"subtotal": "14.5", "grand_total": "15.91", "tax": "1.41"},
+    )
+    assert sorted(i["price"] for i in items) == [4.75, 9.75]
+
+
+def test_summary_figure_guard_needs_two_survivors():
+    # n_items >= 2 guard (LOAD-BEARING): when dropping the figure band
+    # would leave fewer than 2 items, nothing is dropped -- single-item
+    # receipts legitimately have item price == total.
+    words = row(1, 0.30, "2", "Animal", "Fry", "9.20") + row(
+        2, 0.25, "DRIVE", "Eat", "In", "9.20"
+    )
+    items = items_with_summary(
+        words, {"subtotal": "9.2", "grand_total": "9.97"}
+    )
+    assert sorted(i["price"] for i in items) == [9.2, 9.2]
+
+
+def test_summary_figure_single_item_receipt_untouched():
+    # A one-item receipt whose only item equals the printed total already
+    # reconciles; the filter must never touch it (Barnes & Noble / CVS /
+    # Target / LA County in the failure-mode report).
+    words = row(1, 0.30, "HARDCOVER", "BOOK", "24.99")
+    items = items_with_summary(
+        words, {"subtotal": "24.99", "grand_total": "27.05", "tax": "2.06"}
+    )
+    assert len(items) == 1
+    assert items[0]["price"] == 24.99
+
+
+def test_named_item_at_tax_amount_survives():
+    # A real product coincidentally priced at the tax figure must survive
+    # even on a receipt that fails to reconcile: named bands are never
+    # matched against the tax figure.
+    words = (
+        row(1, 0.30, "COFFEE", "2.33")
+        + row(2, 0.25, "BAGEL", "5.00")
+        + row(3, 0.20, "MUFFIN", "3.00")
+    )
+    items = items_with_summary(
+        words, {"subtotal": "8.00", "grand_total": "10.33", "tax": "2.33"}
+    )
+    assert sorted(i["price"] for i in items) == [2.33, 3.0, 5.0]
+
+
+def test_sprouts_promo_echo_absorbs_not_emits():
+    # Sprouts prints "1@2 FOR 14.00" under each half of a 2-for deal; the
+    # promo band explains the neighboring 7.00 item (1 * 7.00) and must
+    # absorb into it instead of emitting a second 14.00 item.
+    words = row(1, 0.30, "BEER", "BRATWURST", "7.00", "F") + row(
+        2, 0.25, "1@2", "FOR", "14.00"
+    )
+    items, _ = items_for(words)
+    assert len(items) == 1
+    assert items[0]["price"] == 7.0
+    assert items[0]["quantity"] == 1.0
+    assert items[0]["unit_price"] == 7.0
+
+
+def test_target_regular_price_echo_dropped():
+    # Target restates the pre-discount price as "Regular Price $22.99"
+    # under the discounted item; it is an annotation, never an item.
+    words = row(1, 0.30, "070050839", "FOOD", "CHOPPER", "T", "$19.54") + row(
+        2, 0.25, "Regular", "Price", "$22.99"
+    )
+    items, _ = items_for(words)
+    assert [i["price"] for i in items] == [19.54]
+
+
+def test_tip_suggestion_and_count_notes_are_not_items():
+    # Restaurant tip-suggestion footers and transaction-count notes carry
+    # amounts but are never items; product names with a bare percent
+    # ("6% FAT MLK") must survive.
+    for tokens in (
+        ["22%", "Tip", "=", "4.40"],
+        ["15%", "=", "10.73"],
+        ["18%:", "(Tip", "Total", "9.27"],
+        ["Items", "in", "Transaction:", "5", "5.49"],
+        ["Comparable", "Value", "59.95"],
+    ):
+        words = row(1, 0.30, "REAL", "WIDGET", "3.00") + row(2, 0.25, *tokens)
+        items, _ = items_for(words)
+        assert [i["price"] for i in items] == [
+            3.0
+        ], f"note band leaked: {tokens}"
+    words = row(1, 0.30, "JRG", "A2/A2", "6%", "FAT", "MLK", "7.99")
+    items, _ = items_for(words)
+    assert [i["price"] for i in items] == [7.99]
+
+
+def test_settlement_scrambled_and_prefixed_forms():
+    # OCR word-order scramble ("17.98 DUE BALANCE"), item-count prefix
+    # ("[1 item] Sub Total 16.00"), and AUTH DEBIT are settlement bands.
+    for tokens in (
+        ["17.98", "DUE", "BALANCE"],
+        ["[1", "item]", "Sub", "Total", "16.00"],
+        ["2014.98", "AUTH", "DEBIT", "$20.47"],
+    ):
+        words = row(1, 0.30, "REAL", "WIDGET", "3.00") + row(2, 0.25, *tokens)
+        items, _ = items_for(words)
+        assert [i["price"] for i in items] == [
+            3.0
+        ], f"settlement band leaked: {tokens}"

--- a/scripts/backfill_receipt_line_items.py
+++ b/scripts/backfill_receipt_line_items.py
@@ -94,7 +94,7 @@ def main() -> None:
         sec = targets.get((img, rid))
         words, _, summary = fetch_receipt_records(client, args.table, img, rid)
         line_ids = {int(x) for x in (sec.get("line_ids") or [])}
-        items, collapsed = extract_items(words, line_ids)
+        items, collapsed = extract_items(words, line_ids, summary=summary)
         status, _, _ = reconcile(
             [x for x in items if not x["is_discount"]], summary
         )


### PR DESCRIPTION
Implements the **non-product band filter** from the per-merchant failure-mode analysis (modes A / C / D: summary figures, tender lines, and promo echoes emitted as items). Fixes 1, 4 and 5 of the report shipped as one change, since they are the same underlying defect: non-product bands reach the extractor because broken ITEMS zones include summary/payment rows.

## What changed

- **`filter_summary_figure_items`** (`receipt_upload/line_items/blocks.py`): an emitted item whose price equals the printed subtotal / tax / grand_total (1% figure tolerance — the printed figure itself carries OCR jitter, e.g. TJ prints `$16.41` for a total read as 16.47) is dropped. Guards, all load-bearing:
  - runs **only when the receipt does not already reconcile** — a matching receipt is never touched, so the filter cannot lose a match;
  - **>= 2 other non-discount items must survive** every drop — single-item receipts legitimately have item price == total (Barnes & Noble / CVS / Target / LA County in the report);
  - **unnamed** bands (Mob Museum's bare `57.90`) may match any figure, but only on strict delta improvement;
  - **named** bands (In-N-Out's `DRIVE-Thru Eat Out 14.50` order line) never match the tax figure — a product coincidentally priced at the tax amount survives — and drop only when the remaining items then reconcile to a match (self-verifying "apply, then re-reconcile").
- **Summary threading**: `extract_items` / `decode_band_blocks` accept an optional `summary` dict; the line-item updater Lambda (summary fetch moved before extraction) and the backfill script pass the summary they already fetch. Default `None` keeps all other callers (golden gate, ingest) on the unfiltered decode.
- **`SALE_PRICE_RE`**: Target's `Regular Price $22.99` and Nordstrom Rack's `Comparable Value 59.95` pre-discount echoes join `Sale Price` (mode D).
- **`SETTLEMENT_RE`**: OCR-scrambled `DUE BALANCE`, `AUTH DEBIT`, item-count-prefixed `[1 item] Sub Total`, garbled `Sub/Ttl` (mode C).
- **`NON_PRODUCT_NOTE_RE`** (new): tip-suggestion footers (`22% Tip =`, `15% = 10.73`, `Tip Total`) and `Items in Transaction: N` count notes.

Note on mode D: the Sprouts `1@2 FOR 14.00` promo echo from the report (08665671) is already absorbed by main's #1311/#1312 QTY_FOR guards on a fresh decode — the stored rows that the report measured predate them. A unit test now pins that behavior; the live D-mode leak was Target's `Regular Price` variant, fixed here.

## Gate 1 — golden regression

`test_line_item_golden_regression.py` + `test_line_item_geometry.py` + `test_reconstructor_line_items.py`: **33 passed, no floor lowered** (the golden gate runs without a summary, so its floors measure the same decode as before; 9 new unit tests pin the filter, the n>=2 guard, the Sprouts promo dedup, and the new regexes).

## Gate 2 — corpus sweep (dev table `ReceiptsTable-dc5be22`, 679 receipts with non-INVALID ITEMS zones, fresh decode on both sides)

| | origin/main | this branch |
|---|---:|---:|
| match | **435** | **452 (+17)** |
| near | 36 | 38 |
| mismatch | 157 | 138 |
| no-baseline | 51 | 51 |

Per-receipt flip check: **17 gained match, 0 previously-matching receipts lost, 2 upgraded mismatch → near** (Roast & Rice 492f9ae1, Target ace17905). Against the **stored** rows the report measured (411 match), the fresh decoder now stands at **+41**; the delta between 411 and main's fresh 435 is #1311/#1312 guard wins that were never backfilled.

## Per-merchant before/after (merchants that improved)

| merchant | n | match before | match after | delta | receipt structure driving the gain |
|---|---:|---:|---:|---:|---|
| In-N-Out Burger | 17 | 10 (59%) | 14 (82%) | +4 | prints the order-type + total line INSIDE the items block (`DRIVE-Thru Eat Out 14.50`, `COUNTER-Eat In 23.90`) — named summary-figure bands, dropped when the rest reconciles |
| Target | 29 | 18 (62%) | 21 (72%) | +3 | `Regular Price $X` pre-discount echo printed under each discounted item |
| Trader Joe's | 12 | 8 (67%) | 9 (75%) | +1 | prints the settlement total as a bare `$18.34` band inside the items zone |
| TRADER JOE'S | 13 | 10 (77%) | 11 (85%) | +1 | same, with OCR jitter on the printed figure (`$16.41` vs summary 16.47 — the 1% figure tolerance) |
| Vons | 27 | 15 (56%) | 16 (59%) | +1 | unnamed total band (`11.97`) inside the items zone |
| The Mob Museum | 1 | 0 | 1 | +1 | ticket stub prints `57.90` (== grand total) under the DESCRIPTION/AMOUNT table |
| Jason's Deli #216 | 1 | 0 | 1 | +1 | unnamed `34.64` total band in the items zone |
| Philz Coffee | 1 | 0 | 1 | +1 | total band picked up a stray modifier name (`Sweet Sugar 14.30`) — named tier, drop re-reconciles exactly |
| CPK Town Square | 1 | 0 | 1 | +1 | tip-suggestion footer `22% Tip = 1.98` |
| Twisted Oak Tavern | 1 | 0 | 1 | +1 | tip-suggestion footer `15% = 10.73` |
| Nordstrom Rack | 1 | 0 | 1 | +1 | `Comparable Value 59.95` pre-discount echo |
| Yözen Frogurt | 1 | 0 | 1 | +1 | garbled `Sub/Ttl 19.97` settlement band |

Sprouts is +0 **on a fresh decode** because its report wins (promo echoes, `BALANCE DUE`/`CREDIT` bands) were already fixed on main — they show as failures only in the stale stored rows; a backfill run picks them up.

Deliberately NOT fixed (guard working as designed): In-N-Out 93d1a557 (`DRIVE Eat In 9.20` + one 9.20 item — dropping would leave a single survivor) and TJ 65392832 (unnamed 5.49 == subtotal with only one other item).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KMeX4w8g3NsVg7ckN7wyBh
