### PR TITLE
fix(summary): printed grand-total fallback for label-starved receipts (Sprouts)

### DIFF
--- a/receipt_dynamo/receipt_dynamo/amounts.py
+++ b/receipt_dynamo/receipt_dynamo/amounts.py
@@ -7,6 +7,75 @@ from typing import Any
 
 _CURRENCY_SYMBOLS = r"$€£¥₹"
 
+# ---------------------------------------------------------------------------
+# Shared summary-line keyword patterns.
+#
+# These are the canonical copies of the keyword patterns used to recognize
+# receipt summary rows ("Total:", "BALANCE DUE", "Subtotal", ...). They are
+# defined here (rather than in receipt_upload) because receipt_dynamo sits at
+# the bottom of the dependency graph, so both receipt_upload's amount
+# classifier and receipt_dynamo's ReceiptSummary printed-total fallback can
+# import them without forking the regexes.
+# ---------------------------------------------------------------------------
+
+TOTAL_KEYWORD_RE = re.compile(
+    r"\b(total|amount\s+due|balance|authorized)\b", re.I
+)
+SUBTOTAL_KEYWORD_RE = re.compile(r"\bsub[-\s]?total\b", re.I)
+TAX_KEYWORD_RE = re.compile(r"\b(tax|vat)\b", re.I)
+NON_PAYMENT_SUMMARY_RE = re.compile(
+    r"\b("
+    r"savings?|discounts?|refunds?|returns?|coupons?|promos?|"
+    r"promotion|rewards?|loyalty|cash\s+back|cashback|store\s+credit"
+    r")\b",
+    re.I,
+)
+# Tokens that turn a "total" row into a non-monetary count/summary row
+# (e.g. "TOTAL NUMBER OF ITEMS SOLD"), which must NOT be read as a
+# grand-total row.
+GRAND_TOTAL_DISQUALIFIER_TOKENS = frozenset(
+    {
+        "number",
+        "items",
+        "item",
+        "qty",
+        "quantity",
+        "count",
+        "sold",
+        "transactions",
+        "transaction",
+        "pieces",
+        "units",
+        "lines",
+        "savings",
+        "saved",
+    }
+)
+
+
+def is_grand_total_line(line_text: str) -> bool:
+    """Return whether joined line text reads as a grand-total row.
+
+    A grand-total row carries a total/balance/amount-due keyword, is not a
+    subtotal or tax row, is not a non-payment summary row (savings,
+    discounts, ...), and is not an item-count row ("TOTAL NUMBER OF ITEMS
+    SOLD").
+    """
+    if not line_text:
+        return False
+    if not TOTAL_KEYWORD_RE.search(line_text):
+        return False
+    if SUBTOTAL_KEYWORD_RE.search(line_text):
+        return False
+    if TAX_KEYWORD_RE.search(line_text):
+        return False
+    if NON_PAYMENT_SUMMARY_RE.search(line_text):
+        return False
+    tokens = {
+        token for token in re.split(r"[^a-z]+", line_text.lower()) if token
+    }
+    return not (tokens & GRAND_TOTAL_DISQUALIFIER_TOKENS)
+
 
 def parse_receipt_amount(text: Any) -> float | None:
     """Parse receipt currency/amount text without changing the OCR text.

--- a/receipt_dynamo/receipt_dynamo/entities/receipt_summary.py
+++ b/receipt_dynamo/receipt_dynamo/entities/receipt_summary.py
@@ -20,6 +20,14 @@ from datetime import datetime
 from math import isfinite
 from typing import TYPE_CHECKING
 
+from receipt_dynamo.amounts import (
+    NON_PAYMENT_SUMMARY_RE,
+    SUBTOTAL_KEYWORD_RE,
+    TAX_KEYWORD_RE,
+    is_grand_total_line,
+    looks_like_receipt_amount,
+    parse_receipt_amount,
+)
 from receipt_dynamo.constants import ValidationStatus
 from receipt_dynamo.entities.identifier_mixins import ReceiptIdentifierMixin
 from receipt_dynamo.entities.util import validate_non_negative_int
@@ -353,6 +361,157 @@ def _extract_summary_fields(
 
 
 # =============================================================================
+# Label-independent printed-total fallback
+# =============================================================================
+
+# Minimum same-row y tolerance (normalized units). Receipt OCR splits a
+# summary row into separate "lines" per column ("Total:" on one line,
+# "USD$ 42.54" on another), so row membership is decided by y-band overlap
+# rather than line_id adjacency.
+_MIN_ROW_BAND = 0.005
+
+
+def _word_y_center(word: "ReceiptWord") -> float | None:
+    """Return the normalized y-center of a word, or None without geometry."""
+    box = getattr(word, "bounding_box", None)
+    if not box:
+        return None
+    y = box.get("y")
+    if y is None:
+        return None
+    return y + (box.get("height") or 0.0) / 2.0
+
+
+def _word_height(word: "ReceiptWord") -> float:
+    """Return the normalized height of a word (0.0 without geometry)."""
+    box = getattr(word, "bounding_box", None)
+    if not box:
+        return 0.0
+    return box.get("height") or 0.0
+
+
+def _positive_amount(text: str) -> float | None:
+    """Parse text as a positive printed amount, else None.
+
+    Requires amount-like punctuation (decimals or a currency symbol) so
+    bare integers such as store numbers never qualify.
+    """
+    if not looks_like_receipt_amount(text):
+        return None
+    value = parse_receipt_amount(text)
+    if value is None or value <= 0:
+        return None
+    return value
+
+
+def _is_summary_noise_line(line_text: str) -> bool:
+    """Return whether a line is a subtotal/tax/non-payment summary row."""
+    return bool(
+        SUBTOTAL_KEYWORD_RE.search(line_text)
+        or TAX_KEYWORD_RE.search(line_text)
+        or NON_PAYMENT_SUMMARY_RE.search(line_text)
+    )
+
+
+def find_printed_grand_total(words: list["ReceiptWord"]) -> float | None:
+    """Find the printed grand total from receipt words, without labels.
+
+    Deterministic fallback for receipts whose GRAND_TOTAL labels are
+    missing or attached to the wrong words (the evaluator then rejects
+    them and the summary is left with no total even though one is
+    printed). Sprouts is the canonical case: it prints "Total:" /
+    "BALANCE DUE" and "USD$ 42.54" as separate OCR lines in the same
+    visual row.
+
+    Strategy:
+    1. Find anchor lines whose joined text reads as a grand-total row
+       (shared ``is_grand_total_line`` keywords).
+    2. Take amounts printed on the anchor line itself; otherwise pair the
+       anchor with amount words on other lines whose y-center falls in
+       the anchor's row band (skipping subtotal/tax/savings rows).
+    3. Return the largest anchored amount, mirroring the GRAND_TOTAL
+       label handler's largest-value semantics.
+
+    Args:
+        words: ReceiptWord records (text + normalized bounding boxes).
+
+    Returns:
+        The printed grand total, or None when no anchored amount exists.
+    """
+    lines: dict[int, list["ReceiptWord"]] = {}
+    for word in words:
+        line_id = getattr(word, "line_id", None)
+        if line_id is None:
+            continue
+        lines.setdefault(line_id, []).append(word)
+    for line_words in lines.values():
+        line_words.sort(key=lambda w: getattr(w, "word_id", 0))
+    line_texts = {
+        line_id: " ".join(str(getattr(w, "text", "")) for w in line_words)
+        for line_id, line_words in lines.items()
+    }
+
+    anchor_ids = [
+        line_id
+        for line_id, text in line_texts.items()
+        if is_grand_total_line(text)
+    ]
+    if not anchor_ids:
+        return None
+
+    anchored: list[float] = []
+    for anchor_id in anchor_ids:
+        anchor_words = lines[anchor_id]
+
+        # Amounts printed on the anchor line itself win outright.
+        same_line = [
+            amount
+            for w in anchor_words
+            if (amount := _positive_amount(str(getattr(w, "text", ""))))
+            is not None
+        ]
+        if same_line:
+            anchored.extend(same_line)
+            continue
+
+        # Pair with amount words in the anchor's y-band on other lines.
+        centers = [
+            c for w in anchor_words if (c := _word_y_center(w)) is not None
+        ]
+        if not centers:
+            continue
+        anchor_y = sum(centers) / len(centers)
+        anchor_height = max(_word_height(w) for w in anchor_words)
+        band = max(0.6 * anchor_height, _MIN_ROW_BAND)
+
+        for line_id, line_words in lines.items():
+            if line_id == anchor_id:
+                continue
+            if _is_summary_noise_line(line_texts[line_id]):
+                continue
+            for w in line_words:
+                center = _word_y_center(w)
+                if center is None or abs(center - anchor_y) > band:
+                    continue
+                amount = _positive_amount(str(getattr(w, "text", "")))
+                if amount is not None:
+                    anchored.append(amount)
+
+    return max(anchored) if anchored else None
+
+
+def _apply_printed_total_fallback(
+    totals: MonetaryTotals, words: list["ReceiptWord"]
+) -> None:
+    """Fill grand_total from the printed total when labels produced none."""
+    if totals.grand_total is not None and totals.grand_total > 0:
+        return
+    printed = find_printed_grand_total(words)
+    if printed is not None:
+        totals.grand_total = printed
+
+
+# =============================================================================
 # ReceiptSummary dataclass
 # =============================================================================
 
@@ -447,6 +606,7 @@ class ReceiptSummary(ReceiptIdentifierMixin):
         totals, date, item_count = _extract_summary_fields(
             word_labels, word_text_lookup
         )
+        _apply_printed_total_fallback(totals, words)
 
         return cls(
             image_id=receipt.image_id,
@@ -490,6 +650,7 @@ class ReceiptSummary(ReceiptIdentifierMixin):
         totals, date, item_count = _extract_summary_fields(
             word_labels, word_text_lookup
         )
+        _apply_printed_total_fallback(totals, words)
 
         return cls(
             image_id=image_id,

--- a/receipt_dynamo/tests/unit/test_receipt_summary_printed_total.py
+++ b/receipt_dynamo/tests/unit/test_receipt_summary_printed_total.py
@@ -1,0 +1,228 @@
+"""Printed grand-total fallback for ReceiptSummary.
+
+The word/line fixtures reproduce real dev receipts (Sprouts Farmers
+Market) whose GRAND_TOTAL labels were attached to garbage words and
+rejected by the evaluator, leaving summaries with grand_total None/0.0
+even though the total is printed. Sprouts prints summary rows as two
+OCR lines in the same visual row: "Total:" / "BALANCE DUE" in one
+column and "USD$ 42.54" / "42.54" in the other.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from receipt_dynamo.constants import ValidationStatus
+from receipt_dynamo.entities.receipt_summary import (
+    ReceiptSummary,
+    find_printed_grand_total,
+)
+from receipt_dynamo.entities.receipt_word_label import ReceiptWordLabel
+
+pytestmark = pytest.mark.unit
+
+IMAGE_ID = "a0301717-d765-4f34-a15d-48c362ebf9fd"
+TIMESTAMP = "2026-01-01T00:00:00.000+00:00"
+
+_LINE_HEIGHT = 0.012
+
+
+def _word(
+    line_id: int,
+    word_id: int,
+    text: str,
+    y_center: float,
+    x: float = 0.1,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        line_id=line_id,
+        word_id=word_id,
+        text=text,
+        bounding_box={
+            "x": x,
+            "y": y_center - _LINE_HEIGHT / 2,
+            "width": 0.1,
+            "height": _LINE_HEIGHT,
+        },
+    )
+
+
+def _label(
+    line_id: int, word_id: int, label: str, status: str
+) -> ReceiptWordLabel:
+    return ReceiptWordLabel(
+        image_id=IMAGE_ID,
+        receipt_id=1,
+        line_id=line_id,
+        word_id=word_id,
+        label=label,
+        reasoning="test",
+        timestamp_added=TIMESTAMP,
+        validation_status=status,
+    )
+
+
+def _sprouts_a0301717_words() -> list[SimpleNamespace]:
+    """Summary zone of dev receipt a0301717:1 (grand total 42.54)."""
+    return [
+        # Card-slip row: "USD$ 42.54" and "Total:" are separate lines.
+        _word(26, 1, "USD$", 0.2169, x=0.166),
+        _word(26, 2, "42.54", 0.2169, x=0.220),
+        _word(13, 1, "Total:", 0.2188, x=0.837),
+        # Item rows (must never be picked up).
+        _word(43, 1, "LARGE", 0.4865, x=0.833),
+        _word(43, 2, "GRADE", 0.4865, x=0.870),
+        _word(43, 3, "A", 0.4865, x=0.900),
+        _word(43, 4, "EGGS", 0.4865, x=0.920),
+        _word(49, 1, "6.99", 0.4876, x=0.092),
+        # Summary rows, split across per-column OCR lines.
+        _word(54, 1, "BALANCE", 0.5659, x=0.688),
+        _word(54, 2, "DUE", 0.5659, x=0.740),
+        _word(55, 1, "42.54", 0.5665, x=0.092),
+        _word(56, 1, "CREDIT", 0.5794, x=0.716),
+        _word(57, 1, "$42.54", 0.5800, x=0.091),
+        _word(61, 1, "CHANGE", 0.6194, x=0.717),
+        _word(62, 1, "0.00", 0.6194, x=0.092),
+    ]
+
+
+def test_finds_balance_due_row_split_across_ocr_lines():
+    assert find_printed_grand_total(_sprouts_a0301717_words()) == 42.54
+
+
+def test_total_keyword_pairs_with_usd_amount_line():
+    # Sprouts 0fd6e62e:1 card slip: only "Total:" + "USD$ 47.44" remain.
+    words = [
+        _word(14, 1, "Total:", 0.2188, x=0.837),
+        _word(27, 1, "USD$", 0.2169, x=0.166),
+        _word(27, 2, "47.44", 0.2169, x=0.220),
+    ]
+    assert find_printed_grand_total(words) == 47.44
+
+
+def test_same_line_amount_wins_without_geometry_pairing():
+    words = [
+        _word(1, 1, "Total", 0.5),
+        _word(1, 2, "$9.54", 0.5),
+    ]
+    assert find_printed_grand_total(words) == 9.54
+
+
+def test_item_count_total_row_is_not_an_anchor():
+    words = [
+        _word(1, 1, "TOTAL", 0.5),
+        _word(1, 2, "NUMBER", 0.5),
+        _word(1, 3, "OF", 0.5),
+        _word(1, 4, "ITEMS", 0.5),
+        _word(1, 5, "SOLD", 0.5),
+        _word(2, 1, "12.00", 0.5005),
+    ]
+    assert find_printed_grand_total(words) is None
+
+
+def test_savings_total_row_is_not_an_anchor():
+    words = [
+        _word(1, 1, "TOTAL", 0.5),
+        _word(1, 2, "SAVINGS", 0.5),
+        _word(2, 1, "5.00", 0.5005),
+    ]
+    assert find_printed_grand_total(words) is None
+
+
+def test_subtotal_row_is_not_an_anchor():
+    words = [
+        _word(1, 1, "Sub-Total", 0.5),
+        _word(2, 1, "39.90", 0.5005),
+    ]
+    assert find_printed_grand_total(words) is None
+
+
+def test_change_row_zero_amount_is_never_a_total():
+    words = [
+        _word(61, 1, "CHANGE", 0.6194),
+        _word(62, 1, "0.00", 0.6194),
+    ]
+    assert find_printed_grand_total(words) is None
+
+
+def test_bare_integers_never_qualify_as_amounts():
+    # "Store: 220" style rows must not pair with a keyword anchor.
+    words = [
+        _word(1, 1, "BALANCE", 0.5),
+        _word(1, 2, "DUE", 0.5),
+        _word(2, 1, "220", 0.5005),
+    ]
+    assert find_printed_grand_total(words) is None
+
+
+def test_amount_outside_row_band_is_ignored():
+    words = [
+        _word(1, 1, "BALANCE", 0.5),
+        _word(1, 2, "DUE", 0.5),
+        _word(2, 1, "42.54", 0.55),
+    ]
+    assert find_printed_grand_total(words) is None
+
+
+def test_summary_fallback_recovers_total_from_rejected_labels():
+    # Real failure mode: every GRAND_TOTAL label sits on a garbage word
+    # ("Cashier:", "@") and is INVALID, so the label pass yields None.
+    words = _sprouts_a0301717_words() + [
+        _word(71, 1, "Cashier:", 0.8182, x=0.803),
+        _word(37, 1, "@", 0.4071, x=0.808),
+    ]
+    labels = [
+        _label(71, 1, "GRAND_TOTAL", ValidationStatus.INVALID.value),
+        _label(37, 1, "GRAND_TOTAL", ValidationStatus.INVALID.value),
+    ]
+
+    summary = ReceiptSummary.from_word_labels_and_words(
+        image_id=IMAGE_ID,
+        receipt_id=1,
+        merchant_name="Sprouts Farmers Market",
+        word_labels=labels,
+        words=words,
+    )
+
+    assert summary.grand_total == 42.54
+
+
+def test_valid_grand_total_label_bypasses_fallback():
+    words = [
+        _word(22, 1, "$8.49", 0.3),
+        _word(1, 1, "Total:", 0.5),
+        _word(2, 1, "10.00", 0.5005),
+    ]
+    labels = [_label(22, 1, "GRAND_TOTAL", ValidationStatus.VALID.value)]
+
+    summary = ReceiptSummary.from_word_labels_and_words(
+        image_id=IMAGE_ID,
+        receipt_id=1,
+        merchant_name=None,
+        word_labels=labels,
+        words=words,
+    )
+
+    assert summary.grand_total == 8.49
+
+
+def test_fallback_overrides_zero_label_total():
+    # A VALID GRAND_TOTAL on a "0.00" word (e.g. the CHANGE row) must not
+    # freeze the summary at 0.0 when a real total is printed.
+    words = [
+        _word(24, 1, "0.00", 0.32),
+        _word(1, 1, "BALANCE", 0.5),
+        _word(1, 2, "DUE", 0.5),
+        _word(2, 1, "8.49", 0.5005),
+    ]
+    labels = [_label(24, 1, "GRAND_TOTAL", ValidationStatus.VALID.value)]
+
+    summary = ReceiptSummary.from_word_labels_and_words(
+        image_id=IMAGE_ID,
+        receipt_id=1,
+        merchant_name=None,
+        word_labels=labels,
+        words=words,
+    )
+
+    assert summary.grand_total == 8.49

--- a/receipt_upload/receipt_upload/label_validation/amount_classifier.py
+++ b/receipt_upload/receipt_upload/label_validation/amount_classifier.py
@@ -6,18 +6,16 @@ import re
 from dataclasses import dataclass
 from typing import Iterable
 
-from receipt_dynamo.amounts import parse_receipt_amount
-
-_TOTAL_RE = re.compile(r"\b(total|amount\s+due|balance|authorized)\b", re.I)
-_SUBTOTAL_RE = re.compile(r"\bsub[-\s]?total\b", re.I)
-_TAX_RE = re.compile(r"\b(tax|vat)\b", re.I)
-_NON_PAYMENT_SUMMARY_RE = re.compile(
-    r"\b("
-    r"savings?|discounts?|refunds?|returns?|coupons?|promos?|"
-    r"promotion|rewards?|loyalty|cash\s+back|cashback|store\s+credit"
-    r")\b",
-    re.I,
+from receipt_dynamo.amounts import (
+    NON_PAYMENT_SUMMARY_RE as _NON_PAYMENT_SUMMARY_RE,
 )
+from receipt_dynamo.amounts import SUBTOTAL_KEYWORD_RE as _SUBTOTAL_RE
+from receipt_dynamo.amounts import TAX_KEYWORD_RE as _TAX_RE
+from receipt_dynamo.amounts import TOTAL_KEYWORD_RE as _TOTAL_RE
+from receipt_dynamo.amounts import (
+    parse_receipt_amount,
+)
+
 _SUMMARY_RE = re.compile(
     r"\b("
     r"total|sub[-\s]?total|tax|vat|amount\s+due|balance|authorized|"

--- a/receipt_upload/receipt_upload/line_items/reconstructor.py
+++ b/receipt_upload/receipt_upload/line_items/reconstructor.py
@@ -20,6 +20,7 @@ import statistics
 from datetime import datetime, timezone
 from typing import Dict, List, Set, Tuple
 
+from receipt_dynamo.amounts import GRAND_TOTAL_DISQUALIFIER_TOKENS
 from receipt_dynamo.constants import ValidationStatus
 from receipt_dynamo.entities.receipt_word_label import ReceiptWordLabel
 
@@ -38,24 +39,9 @@ _GRAND_TOTAL_KEYWORDS = frozenset(
 )
 # Tokens that turn a "total" row into a non-monetary count/summary row (e.g.
 # "TOTAL NUMBER OF ITEMS SOLD"), which must NOT anchor a grand-total election.
-_GRAND_TOTAL_DISQUALIFIERS = frozenset(
-    {
-        "number",
-        "items",
-        "item",
-        "qty",
-        "quantity",
-        "count",
-        "sold",
-        "transactions",
-        "transaction",
-        "pieces",
-        "units",
-        "lines",
-        "savings",
-        "saved",
-    }
-)
+# Canonical copy lives in receipt_dynamo.amounts, shared with the
+# ReceiptSummary printed-total fallback.
+_GRAND_TOTAL_DISQUALIFIERS = GRAND_TOTAL_DISQUALIFIER_TOKENS
 _PROPOSED_BY = "geometry_line_items"
 _RECLASS_BY = "arithmetic_totals_reclass"
 


### PR DESCRIPTION
## Root cause

The bank join (TASK #12) surfaced 34 Sprouts dev receipts whose ReceiptSummary `grand_total` was `None`/`0.0` despite clearly printed totals. Tracing 5 of them through words → labels → summary on `ReceiptsTable-dc5be22`:

1. **The model mislabels GRAND_TOTAL onto garbage words.** On `a0301717:1` the GRAND_TOTAL labels sit on `"2"`, `"@"`, and `"Cashier:"`; on `0fd6e62e:1` on `"GROCERY"`, `"CREAM"`, `"Thursday,"`.
2. **The evaluator (correctly) rejects them all as INVALID.** `_extract_summary_fields` skips every non-VALID label, so the label pass produces nothing.
3. **The printed total never gets a usable label** because Sprouts prints summary rows as *two separate OCR lines in the same visual row* — `Total:` / `BALANCE DUE` in one column and `USD$ 42.54` / `42.54` in the other — so no single word carries both the keyword and the amount, and the summary computation had no label-independent fallback. Result: `grand_total = None` (or frozen at `0.0` from a VALID label on a `0.00` CHANGE-row word).

## Fix (at the computation layer)

The summary-updater Lambda bundles only the `receipt_dynamo` layer, so the fix lives there:

- **`receipt_dynamo/amounts.py`** — the summary-row keyword patterns that previously lived only in `receipt_upload`'s amount classifier (`TOTAL/SUBTOTAL/TAX` keyword regexes, non-payment-summary regex, count-row disqualifier tokens) move here, the bottom of the dependency graph, plus a shared `is_grand_total_line()`. `receipt_upload`'s `amount_classifier.py` and `reconstructor.py` now import them — one canonical copy, no forks.
- **`receipt_dynamo/entities/receipt_summary.py`** — new deterministic `find_printed_grand_total(words)`: anchors on grand-total keyword lines (excluding subtotal/tax/savings/item-count rows), takes amounts printed on the anchor line first, otherwise pairs the anchor with amount-looking words whose y-center falls in the anchor's row band (`max(0.6 × anchor height, 0.005)`), requiring decimal/currency form (bare integers like store numbers never qualify) and a positive value (the `CHANGE 0.00` row can never win). Returns the largest anchored amount, mirroring the existing GRAND_TOTAL handler's largest-value semantics.
- The fallback engages **only when the label pass yields `None` or `<= 0`** — valid labels always win.

## Verification

- 12 new unit tests in `receipt_dynamo/tests/unit/test_receipt_summary_printed_total.py` built from the real failing Sprouts text/geometry (split `BALANCE DUE` row, `Total:` + `USD$ 47.44` pairing, CHANGE/savings/item-count non-anchors, label-precedence guards).
- `receipt_dynamo` unit suite: **2320 passed**. `receipt_upload` suite: **all passing** (pre-existing skips only).
- Read-only recompute of all 34 Sprouts receipts from the join list against dev (no writes): **label-only path leaves 7 broken (None/0.0); with the fallback 0 remain.** Every recovered value matches the receipt's printed total, and where the join list carried an expected amount the fallback reproduces it exactly (e.g. `95718576:2` → 19.20, `9a3a28ce:1` → 14.42, `d076611b:2` → 10.99, `f30c3d0f:2` → 12.39 — receipts whose labels have since churned back to producing nothing). The join-list JSON is partially stale: some rows listed as 0.0 already recompute correctly from labels alone after later re-validation; the table below shows both paths as of today.

## 34-receipt before/after (local recompute, no writes)

| image_id | rid | date | join-list total | label-only (before) | with fallback (after) | recovered |
|---|---|---|---|---|---|---|
| `a0301717` | 1 | 2024-03-13 | None | None | 42.54 | **yes** |
| `0fd6e62e` | 1 | 2024-03-21 | None | None | 47.44 | **yes** |
| `303ef1c5` | 1 | 2024-04-14 | 17.99 | 17.99 | 17.99 |  |
| `1d3b61e9` | 1 | 2024-04-14 | 19.98 | 19.98 | 19.98 |  |
| `d5f79185` | 1 | 2024-05-14 | 0.00 | 24.98 | 24.98 |  |
| `9af03fd2` | 1 | 2024-05-28 | 0.00 | 22.48 | 22.48 |  |
| `44dc1b44` | 1 | 2024-08-12 | 19.59 | 19.59 | 19.59 |  |
| `47343fdf` | 2 | 2024-08-19 | None | None | 17.98 | **yes** |
| `646f8f0f` | 2 | 2024-08-25 | 0.00 | 21.67 | 21.67 |  |
| `d28fcc1e` | 1 | 2024-08-26 | 18.08 | 18.08 | 18.08 |  |
| `e936747a` | 1 | 2024-08-30 | 13.29 | 50.21 | 50.21 |  |
| `aabbf168` | 1 | 2024-09-01 | 39.96 | 39.96 | 39.96 |  |
| `99a224b4` | 1 | 2024-09-22 | 0.00 | 10.99 | 10.99 |  |
| `95718576` | 2 | 2024-09-23 | 19.20 | None | 19.20 | **yes** |
| `99a224b4` | 2 | 2024-09-23 | 17.99 | 17.99 | 17.99 |  |
| `6e58ca91` | 2 | 2024-12-14 | 0.00 | 18.85 | 18.85 |  |
| `223c03e2` | 2 | 2024-12-22 | 18.85 | 18.85 | 18.85 |  |
| `6a23eb4b` | 1 | 2025-01-04 | 0.00 | 8.49 | 8.49 |  |
| `37900099` | 2 | 2025-01-18 | 6.99 | 18.08 | 18.08 |  |
| `c985752b` | 1 | 2025-02-03 | 15.98 | 15.98 | 15.98 |  |
| `a2d33e1e` | 2 | 2025-02-24 | 21.98 | 21.98 | 21.98 |  |
| `37c9f558` | 1 | 2025-03-27 | 0.65 | 0.65 | 0.65 |  |
| `45af80b3` | 1 | 2025-05-08 | 30.97 | 30.97 | 30.97 |  |
| `9a3a28ce` | 1 | 2025-05-26 | 14.42 | None | 14.42 | **yes** |
| `d076611b` | 2 | 2025-06-06 | 10.99 | None | 10.99 | **yes** |
| `0fca7cfd` | 1 | 2025-06-22 | 0.00 | 14.48 | 14.48 |  |
| `b9fa1498` | 2 | 2025-06-23 | 13.98 | 13.98 | 13.98 |  |
| `c2c5aadf` | 1 | 2024-09-23 | 23.26 | 23.26 | 23.26 |  |
| `37333eb8` | 1 | 2025-02-06 | 29.08 | 29.08 | 29.08 |  |
| `220e6c8d` | 2 | 2025-10-12 | 18.99 | 18.99 | 18.99 |  |
| `f30c3d0f` | 2 | 2025-11-13 | 12.39 | None | 12.39 | **yes** |
| `982d59a4` | 1 | 2025-12-07 | 13.99 | 13.99 | 13.99 |  |
| `ebab3df7` | 1 | 2025-12-11 | 7.12 | 7.12 | 7.12 |  |
| `c6b66d97` | 1 | 2026-02-12 | 5.99 | 5.99 | 5.99 |  |

Deploy note: no infra/ changes; the Lambda picks this up on the next receipt_dynamo layer publish. Existing bad summaries heal on their next SQS-triggered recompute (or a targeted backfill).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KMeX4w8g3NsVg7ckN7wyBh


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved receipt total detection when labeled totals are missing, invalid, or zero.
  * Recognizes totals across split OCR rows and supports valid printed USD amounts.
  * Filters out subtotals, taxes, item counts, savings, change, and other non-payment values.
  * Preserves valid labeled totals when available.

* **Tests**
  * Added comprehensive coverage for printed grand-total detection and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->