### PR TITLE
fix: bound mcp pin to <2 (prod MCP cold-start outage)

### DIFF
--- a/infra/glyph_mcp_lambda/lambdas/Dockerfile
+++ b/infra/glyph_mcp_lambda/lambdas/Dockerfile
@@ -10,7 +10,7 @@ COPY tools/glyph-studio/py/ /tmp/glyphstudio_pkg/
 
 RUN pip install --no-cache-dir /tmp/glyphstudio_pkg && \
     pip install --no-cache-dir \
-        mcp \
+        "mcp>=1.26.0,<2" \
         boto3 \
         run-mcp-servers-with-aws-lambda==0.5.21 && \
     rm -rf /tmp/glyphstudio_pkg

--- a/infra/mcp_server_lambda/lambdas/Dockerfile
+++ b/infra/mcp_server_lambda/lambdas/Dockerfile
@@ -24,7 +24,7 @@ RUN pip install --no-cache-dir /tmp/receipt_dynamo && \
     pip install --no-cache-dir /tmp/receipt_places && \
     pip install --no-cache-dir /tmp/receipt_upload && \
     pip install --no-cache-dir /tmp/receipt_agent && \
-    pip install --no-cache-dir run-mcp-servers-with-aws-lambda==0.5.21 && \
+    pip install --no-cache-dir "mcp>=1.26.0,<2" run-mcp-servers-with-aws-lambda==0.5.21 && \
     rm -rf /tmp/receipt_dynamo /tmp/receipt_chroma /tmp/receipt_upload /tmp/receipt_places /tmp/receipt_agent
 
 # Stage 2: Copy Lambda-specific code (changes frequently, but doesn't invalidate deps cache)

--- a/receipt_logo/pyproject.toml
+++ b/receipt_logo/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
     { name = "Tyler Norlund" }
 ]
 dependencies = [
-    "mcp>=1.26.0",
+    "mcp>=1.26.0,<2",
     "numpy>=1.26.0,<3.0.0",
     "Pillow>=10.0.0,<13.0.0",
 ]


### PR DESCRIPTION
## Outage

Last night the prod-facing Lambda MCP server (and the local `scripts/receipt_mcp_server.py` stdio server) started crashing on cold start. Root cause: **mcp 2.x removed the `@server.list_tools()` decorator API**, and our pins were unbounded, so any fresh dependency resolution (Lambda image rebuild, fresh venv) pulled 2.x and died at import/registration time. This took the remote MCP endpoint down.

## Fix

Bound every place `mcp` is resolved to `>=1.26.0,<2`:

- `receipt_logo/pyproject.toml` — `"mcp>=1.26.0"` → `"mcp>=1.26.0,<2"` (the only unbounded pin in any pyproject/requirements file, verified repo-wide)
- `infra/glyph_mcp_lambda/lambdas/Dockerfile` — bare `mcp` → `"mcp>=1.26.0,<2"`
- `infra/mcp_server_lambda/lambdas/Dockerfile` — added explicit `"mcp>=1.26.0,<2"` alongside `run-mcp-servers-with-aws-lambda==0.5.21`, which otherwise pulls `mcp` transitively with no upper bound

## Verification

Fresh venv (Python 3.14): `pip install "mcp>=1.26.0,<2"` resolves **mcp 1.29.0**, and `scripts/receipt_mcp_server.py` imports cleanly (module exec of the full file, all tool registrations included).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KMeX4w8g3NsVg7ckN7wyBh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the MCP dependency requirements to use supported versions starting at 1.26.0 and below 2.0.0.
  * Applied consistent dependency constraints across the application’s deployment components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->