### PR TITLE
fix(reseg): harden apply path — async job-id, CAS status guard, summary tombstone, embeddings default

### DIFF
--- a/infra/mcp_server_lambda/lambdas/receipt_mcp_server_server.py
+++ b/infra/mcp_server_lambda/lambdas/receipt_mcp_server_server.py
@@ -1082,12 +1082,23 @@ masked output rendering is explicitly enabled.""",
 
 Returns the immutable assignment evidence, metrics, findings, artifact hashes,
 and freshly signed visualization URLs. Use this whenever preview URLs expire or
-before revising/applying to verify that a revision is still latest and applicable.""",
+before revising/applying to verify that a revision is still latest and applicable.
+
+Pass job_id (returned by apply_receipt_resegmentation) to poll an async apply
+instead: the response then reports the job status (PENDING/APPLIED/
+CLEANUP_PENDING/FAILED) and the current plan head status.""",
             inputSchema={
                 "type": "object",
                 "properties": {
                     "plan_id": {"type": "string"},
                     "revision": {"type": "integer", "minimum": 1},
+                    "job_id": {
+                        "type": "string",
+                        "description": (
+                            "Async apply job id to poll; when set, returns "
+                            "the job status instead of the plan document"
+                        ),
+                    },
                 },
                 "required": ["plan_id"],
             },
@@ -1138,12 +1149,25 @@ the output parents replace the source parent atomically. Cleanup is resumable.
 
 WARNING: This creates new receipt records and deletes the source receipt after
 the staged outputs are ready. Superseded revisions and plans with blocking
-findings—including layered PHOTO plans—are rejected.""",
+findings—including layered PHOTO plans—are rejected.
+
+By default the apply runs asynchronously: this returns immediately with a
+job_id, and the apply continues in the background (an apply outlives the
+gateway timeout, so a synchronous call would report an error while the apply
+keeps working). Poll progress with get_receipt_resegmentation_plan(plan_id,
+job_id=...). Set synchronous=true only for fast direct invocations.""",
             inputSchema={
                 "type": "object",
                 "properties": {
                     "plan_id": {"type": "string"},
                     "plan_hash": {"type": "string"},
+                    "synchronous": {
+                        "type": "boolean",
+                        "description": (
+                            "Wait for the apply to finish instead of "
+                            "returning a pollable job_id (default false)"
+                        ),
+                    },
                 },
                 "required": ["plan_id", "plan_hash"],
             },
@@ -2196,6 +2220,7 @@ async def call_tool(
             result = await get_receipt_resegmentation_plan_impl(
                 plan_id=arguments["plan_id"],
                 revision=arguments.get("revision"),
+                job_id=arguments.get("job_id"),
             )
         elif name == "revise_receipt_resegmentation_plan":
             result = await revise_receipt_resegmentation_plan_impl(arguments)
@@ -2203,6 +2228,7 @@ async def call_tool(
             result = await apply_receipt_resegmentation_impl(
                 plan_id=arguments["plan_id"],
                 plan_hash=arguments["plan_hash"],
+                synchronous=arguments.get("synchronous", False),
             )
         elif name == "get_receipt_words":
             result = await get_receipt_words_impl(
@@ -3941,14 +3967,28 @@ async def plan_receipt_resegmentation_impl(arguments: dict) -> dict:
 
 
 async def get_receipt_resegmentation_plan_impl(
-    plan_id: str, revision: int | None = None
+    plan_id: str,
+    revision: int | None = None,
+    job_id: str | None = None,
 ) -> dict:
-    """Retrieve a plan and refresh its signed visualization URLs."""
+    """Retrieve a plan (or poll an async apply job) via the Lambda.
+
+    With ``job_id`` this polls the status of an asynchronous apply started
+    by ``apply_receipt_resegmentation`` instead of fetching the plan
+    document.
+    """
     try:
         env = os.environ.get("PORTFOLIO_ENV", "dev")
-        payload = {"mode": "get", "plan_id": plan_id}
-        if revision is not None:
-            payload["revision"] = revision
+        if job_id is not None:
+            payload = {
+                "mode": "status",
+                "plan_id": plan_id,
+                "job_id": job_id,
+            }
+        else:
+            payload = {"mode": "get", "plan_id": plan_id}
+            if revision is not None:
+                payload["revision"] = revision
         return await _invoke_lambda(
             f"resegment-receipt-{env}-resegment-receipt", payload
         )
@@ -3971,14 +4011,26 @@ async def revise_receipt_resegmentation_plan_impl(arguments: dict) -> dict:
 
 
 async def apply_receipt_resegmentation_impl(
-    plan_id: str, plan_hash: str
+    plan_id: str, plan_hash: str, synchronous: bool = False
 ) -> dict:
-    """Invoke the receipt re-segmentation Lambda in apply mode."""
+    """Invoke the receipt re-segmentation Lambda in apply mode.
+
+    An apply outlives the MCP gateway timeout, so by default it dispatches
+    asynchronously: the Lambda returns a job_id immediately and keeps
+    working in the background. Poll with
+    ``get_receipt_resegmentation_plan(plan_id, job_id=...)``.
+    """
     try:
         env = os.environ.get("PORTFOLIO_ENV", "dev")
+        payload = {
+            "mode": "apply",
+            "plan_id": plan_id,
+            "plan_hash": plan_hash,
+        }
+        if not synchronous:
+            payload["async"] = True
         return await _invoke_lambda(
-            f"resegment-receipt-{env}-resegment-receipt",
-            {"mode": "apply", "plan_id": plan_id, "plan_hash": plan_hash},
+            f"resegment-receipt-{env}-resegment-receipt", payload
         )
     except Exception as e:
         logger.exception("Error applying receipt re-segmentation")

--- a/infra/receipt_summary_updater/summary_processor.py
+++ b/infra/receipt_summary_updater/summary_processor.py
@@ -46,6 +46,41 @@ def update_receipt_summary(image_id: str, receipt_id: int) -> dict[str, Any]:
     if dynamo_client is None:
         raise ValueError("DYNAMODB_TABLE_NAME environment variable not set")
 
+    # Tombstone guard: the parent receipt must still exist. The Dynamo
+    # stream fires on child-row deletions too, so when a re-segmentation
+    # apply deletes a source receipt, the deletion events for its labels
+    # would otherwise resurrect an orphan RECEIPT#N#SUMMARY row minutes
+    # after the receipt is gone. Skip the recompute and clear any freshly
+    # re-created orphan summary instead (self-healing: a later event for
+    # the same deleted receipt sweeps whatever an earlier race left).
+    #
+    # A parent row that exists but does not parse as a Receipt (e.g. a
+    # RESEGMENT_RESERVATION placeholder) raises OperationError, which
+    # propagates so the SQS message is retried after the apply commits.
+    try:
+        dynamo_client.get_receipt(image_id, receipt_id)
+    except EntityNotFoundError:
+        orphan_summary_deleted = False
+        try:
+            orphan = dynamo_client.get_receipt_summary(image_id, receipt_id)
+            dynamo_client.delete_receipt_summary(orphan)
+            orphan_summary_deleted = True
+        except EntityNotFoundError:
+            pass
+        logger.info(
+            "Skipping summary regen for %s:%d: parent receipt no longer "
+            "exists (orphan summary deleted: %s)",
+            image_id[:8],
+            receipt_id,
+            orphan_summary_deleted,
+        )
+        return {
+            "image_id": image_id,
+            "receipt_id": receipt_id,
+            "skipped": "parent receipt deleted",
+            "orphan_summary_deleted": orphan_summary_deleted,
+        }
+
     # Fetch all word labels with pagination
     word_labels = []
     last_key = None

--- a/infra/resegment_receipt_lambda/infrastructure.py
+++ b/infra/resegment_receipt_lambda/infrastructure.py
@@ -4,6 +4,7 @@ import json
 from typing import Optional
 
 import pulumi
+import pulumi_aws as aws
 from pulumi import ComponentResource, Config, Output, ResourceOptions
 from pulumi_aws.iam import Role, RolePolicy, RolePolicyAttachment
 
@@ -65,7 +66,8 @@ class ResegmentReceiptLambda(ComponentResource):
             f"{name}-lambda-basic-exec",
             role=role.name,
             policy_arn=(
-                "arn:aws:iam::aws:policy/service-role/" "AWSLambdaBasicExecutionRole"
+                "arn:aws:iam::aws:policy/service-role/"
+                "AWSLambdaBasicExecutionRole"
             ),
             opts=ResourceOptions(parent=role),
         )
@@ -160,9 +162,39 @@ class ResegmentReceiptLambda(ComponentResource):
             opts=ResourceOptions(parent=role),
         )
 
+        # The async apply path self-invokes the function with
+        # InvocationType=Event so gateway callers get a pollable job id
+        # instead of a timeout. The function name is deterministic, so the
+        # ARN can be granted before the function exists.
+        function_name = f"{name}-{stack}-resegment-receipt"
+        region = aws.config.region or aws.get_region().name
+        account_id = aws.get_caller_identity().account_id
+        RolePolicy(
+            f"{name}-lambda-self-invoke-policy",
+            role=role.id,
+            policy=json.dumps(
+                {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Action": ["lambda:InvokeFunction"],
+                            "Resource": (
+                                f"arn:aws:lambda:{region}:{account_id}:"
+                                f"function:{function_name}"
+                            ),
+                        }
+                    ],
+                }
+            ),
+            opts=ResourceOptions(parent=role),
+        )
+
         docker_image = CodeBuildDockerImage(
             f"{name}-img",
-            dockerfile_path=("infra/resegment_receipt_lambda/lambdas/Dockerfile"),
+            dockerfile_path=(
+                "infra/resegment_receipt_lambda/lambdas/Dockerfile"
+            ),
             build_context_path=".",
             source_paths=[
                 "receipt_dynamo",
@@ -171,7 +203,7 @@ class ResegmentReceiptLambda(ComponentResource):
                 "receipt_upload",
                 "receipt_places",
             ],
-            lambda_function_name=f"{name}-{stack}-resegment-receipt",
+            lambda_function_name=function_name,
             lambda_config={
                 "role_arn": role.arn,
                 "timeout": 900,

--- a/infra/resegment_receipt_lambda/lambdas/resegment_receipt.py
+++ b/infra/resegment_receipt_lambda/lambdas/resegment_receipt.py
@@ -279,6 +279,162 @@ def _load_revision(
     return json.loads(response["Body"].read())
 
 
+def _job_key(plan_id: str, job_id: str) -> str:
+    return (
+        f"{PLAN_PREFIX}/{_validate_plan_id(plan_id)}/jobs/"
+        f"{_validate_plan_id(job_id)}.json"
+    )
+
+
+def _write_job_record(
+    s3_client: "S3Client",
+    bucket: str,
+    plan_id: str,
+    job_id: str,
+    record: Mapping[str, Any],
+) -> None:
+    s3_client.put_object(
+        Bucket=bucket,
+        Key=_job_key(plan_id, job_id),
+        Body=json.dumps(record, sort_keys=True, default=str).encode("utf-8"),
+        ContentType="application/json",
+    )
+
+
+def _read_job_record(
+    s3_client: "S3Client", bucket: str, plan_id: str, job_id: str
+) -> dict[str, Any] | None:
+    try:
+        response = s3_client.get_object(
+            Bucket=bucket, Key=_job_key(plan_id, job_id)
+        )
+    except ClientError as error:
+        if error.response.get("Error", {}).get("Code") in (
+            "NoSuchKey",
+            "404",
+        ):
+            return None
+        raise
+    return json.loads(response["Body"].read())
+
+
+def _record_job_outcome(
+    s3_client: "S3Client",
+    bucket: str,
+    plan_id: str,
+    job_id: str,
+    *,
+    result: Mapping[str, Any] | None = None,
+    error: str | None = None,
+) -> None:
+    """Persist an apply job's terminal status; never raise past logging."""
+    record: dict[str, Any] = {
+        "job_id": str(job_id),
+        "plan_id": str(plan_id),
+        "finished_at": datetime.now(timezone.utc).isoformat(),
+    }
+    if error is not None:
+        record["status"] = "FAILED"
+        record["error"] = error
+    else:
+        record["status"] = str((result or {}).get("status", "APPLIED"))
+        record["result"] = dict(result or {})
+    try:
+        _write_job_record(s3_client, bucket, str(plan_id), str(job_id), record)
+    except Exception:  # pylint: disable=broad-except
+        logger.exception(
+            "Failed to record apply job outcome for plan %s job %s",
+            plan_id,
+            job_id,
+        )
+
+
+def start_async_apply(
+    event: dict[str, Any],
+    *,
+    s3_client: "S3Client",
+    raw_bucket: str,
+    lambda_client: Any = None,
+    function_name: str | None = None,
+) -> dict[str, Any]:
+    """Dispatch an apply to a background self-invoke and return a job id.
+
+    The MCP gateway fronting this Lambda times out long before a real apply
+    finishes, so a synchronous apply through it reports an error while the
+    apply keeps working — dangerous ambiguity. This path validates the
+    request cheaply, records a pollable job-status object next to the plan,
+    self-invokes with ``InvocationType=Event``, and returns immediately.
+    Poll with ``{"mode": "status", "plan_id": ..., "job_id": ...}``.
+    """
+    plan_id = str(event["plan_id"])
+    plan = _load_plan(s3_client, raw_bucket, plan_id)
+    if event.get("plan_hash") != plan["plan_hash"]:
+        raise ValueError("plan_hash does not match the stored plan")
+    if plan["status"] == "APPLIED":
+        return {"status": "APPLIED", **plan["result"]}
+
+    job_id = str(uuid.uuid4())
+    submitted_at = datetime.now(timezone.utc).isoformat()
+    _write_job_record(
+        s3_client,
+        raw_bucket,
+        plan_id,
+        job_id,
+        {
+            "job_id": job_id,
+            "plan_id": plan_id,
+            "status": "PENDING",
+            "submitted_at": submitted_at,
+        },
+    )
+    if function_name is None:
+        function_name = os.environ["AWS_LAMBDA_FUNCTION_NAME"]
+    if lambda_client is None:
+        lambda_client = boto3.client("lambda")
+    lambda_client.invoke(
+        FunctionName=function_name,
+        InvocationType="Event",
+        Payload=json.dumps(
+            {
+                "mode": "apply",
+                "plan_id": plan_id,
+                "plan_hash": event.get("plan_hash"),
+                "job_id": job_id,
+            }
+        ).encode("utf-8"),
+    )
+    return {
+        "status": "PENDING",
+        "job_id": job_id,
+        "plan_id": plan_id,
+        "submitted_at": submitted_at,
+        "poll": {"mode": "status", "plan_id": plan_id, "job_id": job_id},
+    }
+
+
+def get_apply_status(
+    event: dict[str, Any],
+    *,
+    s3_client: "S3Client",
+    raw_bucket: str,
+) -> dict[str, Any]:
+    """Report an async apply job's progress plus the plan head status."""
+    plan_id = str(event["plan_id"])
+    head = _load_plan(s3_client, raw_bucket, plan_id)
+    response: dict[str, Any] = {
+        "plan_id": plan_id,
+        "plan_status": head.get("status"),
+        "revision": head.get("revision", 1),
+    }
+    if head.get("status") == "APPLIED" and head.get("result"):
+        response["result"] = head["result"]
+    job_id = event.get("job_id")
+    if job_id is not None:
+        job = _read_job_record(s3_client, raw_bucket, plan_id, str(job_id))
+        response["job"] = job or {"job_id": str(job_id), "status": "UNKNOWN"}
+    return response
+
+
 def _word_ref_set(segment: dict[str, Any]) -> set[tuple[int, int]]:
     return {
         (int(ref["line_id"]), int(ref["word_id"]))
@@ -1336,6 +1492,7 @@ def apply_plan(
             # also loaded this COMMITTING plan loses here and bails before it
             # could release the winning worker's freshly-reserved rows.
             plan["status"] = "PLANNED"
+            plan.pop("apply_token", None)
             try:
                 plan_etag = _save_plan(
                     s3_client, raw_bucket, plan, if_match=plan_etag
@@ -1448,7 +1605,15 @@ def apply_plan(
     # apply that also read the PLANNED head loses the swap and bails here,
     # so it can never reserve IDs, delete staged child rows, race the commit,
     # destroy the winner's committed outputs.
+    #
+    # The apply_token makes each COMMITTING head byte-unique. S3 ETags are
+    # content-derived, so without it a recover-and-retry cycle rewrites the
+    # exact bytes of an earlier COMMITTING head and resurrects its ETag,
+    # letting a stale worker's If-Match rollback (below) clobber the new
+    # lock holder (the CAS-loser status revert observed in prod 2026-08-01).
+    apply_token = str(uuid.uuid4())
     plan["status"] = "COMMITTING"
+    plan["apply_token"] = apply_token
     try:
         plan_etag = _save_plan(s3_client, raw_bucket, plan, if_match=plan_etag)
     except PlanPreconditionError as error:
@@ -1475,7 +1640,10 @@ def apply_plan(
             uploaded_keys=uploaded_keys,
         )
         run_ids = []
-        if event.get("create_embeddings", True):
+        # Embeddings default OFF: running them inline OOMs the deployed
+        # Lambda at its memory limit, and the outputs' embeddings self-heal
+        # through the normal pipeline. Opt in explicitly for tests/tools.
+        if event.get("create_embeddings", False):
             run_ids = _embed_outputs(
                 outputs=outputs,
                 dynamo_client=dynamo_client,
@@ -1562,30 +1730,61 @@ def apply_plan(
         return {"status": "APPLIED", **result}
     except Exception:
         if not committed:
-            if plan["status"] == "COMMITTING":
-                # The COMMITTING lock was acquired before staging; revert it so
-                # a retry re-runs the full plan validation instead of the
+            # Status guard: only the current lock holder may roll back. The
+            # head is re-read and both the status and this attempt's unique
+            # apply_token are verified before ANY rollback step, so a CAS
+            # loser (or a worker whose lock was recovered by a peer) can
+            # never stamp PLANNED over a status another worker has since
+            # advanced (COMMITTING/APPLIED), release the winner's
+            # reservations, or delete the winner's staged objects.
+            still_owner = False
+            head_etag = None
+            try:
+                head, head_etag = _load_plan_with_etag(
+                    s3_client, raw_bucket, plan["plan_id"]
+                )
+                still_owner = (
+                    head.get("status") == "COMMITTING"
+                    and head.get("apply_token") == apply_token
+                )
+            except Exception:  # pylint: disable=broad-except
+                logger.exception(
+                    "Could not re-read plan %s to verify rollback "
+                    "ownership; leaving state for the resume path",
+                    plan["plan_id"],
+                )
+            if still_owner:
+                # The COMMITTING lock was acquired before staging; revert it
+                # so a retry re-runs the full plan validation instead of the
                 # resume path. The conditional write keeps this worker from
                 # stamping over a status another worker has since advanced.
                 plan["status"] = "PLANNED"
+                plan.pop("apply_token", None)
                 try:
                     plan_etag = _save_plan(
-                        s3_client, raw_bucket, plan, if_match=plan_etag
+                        s3_client, raw_bucket, plan, if_match=head_etag
                     )
                 except Exception:  # pylint: disable=broad-except
                     logger.exception(
                         "Failed to revert plan %s to PLANNED", plan["plan_id"]
                     )
-            try:
-                dynamo_client.release_receipt_id_reservations(
-                    plan["image_id"], output_ids, plan["plan_id"]
-                )
-            finally:
-                _delete_uploaded_objects(
-                    s3_client,
-                    raw_bucket,
-                    site_bucket,
-                    uploaded_keys,
+                try:
+                    dynamo_client.release_receipt_id_reservations(
+                        plan["image_id"], output_ids, plan["plan_id"]
+                    )
+                finally:
+                    _delete_uploaded_objects(
+                        s3_client,
+                        raw_bucket,
+                        site_bucket,
+                        uploaded_keys,
+                    )
+            else:
+                logger.warning(
+                    "Plan %s is no longer held by this apply attempt; "
+                    "skipping rollback so the current lock holder's "
+                    "progress is preserved",
+                    plan["plan_id"],
                 )
         raise
 
@@ -1595,10 +1794,10 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
     del context
     try:
         mode = event.get("mode")
-        if mode not in {"plan", "get", "revise", "apply"}:
+        if mode not in {"plan", "get", "revise", "apply", "status"}:
             return {
                 "status": "error",
-                "error": "mode must be plan, get, revise, or apply",
+                "error": "mode must be plan, get, revise, apply, or status",
             }
 
         table_name = os.environ["DYNAMODB_TABLE_NAME"]
@@ -1626,6 +1825,15 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
                 s3_client=s3_client,
                 raw_bucket=raw_bucket,
             )
+        if mode == "status":
+            return get_apply_status(
+                {
+                    "plan_id": event.get("plan_id"),
+                    "job_id": event.get("job_id"),
+                },
+                s3_client=s3_client,
+                raw_bucket=raw_bucket,
+            )
         if mode == "revise":
             return revise_plan(
                 {
@@ -1641,17 +1849,49 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
                 s3_client=s3_client,
                 raw_bucket=raw_bucket,
             )
-        return apply_plan(
-            {
-                "plan_id": event.get("plan_id"),
-                "plan_hash": event.get("plan_hash"),
-            },
-            dynamo_client=dynamo_client,
-            s3_client=s3_client,
-            raw_bucket=raw_bucket,
-            site_bucket=site_bucket,
-            chromadb_bucket=chromadb_bucket,
-        )
+        apply_event = {
+            "plan_id": event.get("plan_id"),
+            "plan_hash": event.get("plan_hash"),
+        }
+        if event.get("async"):
+            # Gateway callers time out before a synchronous apply finishes,
+            # leaving them unable to tell an error from a success. Dispatch
+            # the apply to a background self-invoke and return a job id the
+            # caller can poll with mode=status.
+            return start_async_apply(
+                apply_event,
+                s3_client=s3_client,
+                raw_bucket=raw_bucket,
+            )
+        job_id = event.get("job_id")
+        try:
+            result = apply_plan(
+                apply_event,
+                dynamo_client=dynamo_client,
+                s3_client=s3_client,
+                raw_bucket=raw_bucket,
+                site_bucket=site_bucket,
+                chromadb_bucket=chromadb_bucket,
+            )
+        except Exception as exc:
+            if job_id is not None:
+                _record_job_outcome(
+                    s3_client,
+                    raw_bucket,
+                    str(event.get("plan_id")),
+                    str(job_id),
+                    error=str(exc),
+                )
+            raise
+        if job_id is not None:
+            _record_job_outcome(
+                s3_client,
+                raw_bucket,
+                str(event.get("plan_id")),
+                str(job_id),
+                result=result,
+            )
+        return result
     except Exception as exc:  # pylint: disable=broad-except
         logger.exception("Receipt re-segmentation failed")
         return {"status": "error", "error": str(exc)}

--- a/receipt_upload/receipt_upload/resegment/planner.py
+++ b/receipt_upload/receipt_upload/resegment/planner.py
@@ -806,7 +806,16 @@ def build_source_fingerprint(
 def compute_plan_hash(plan: Mapping[str, Any]) -> str:
     """Return a stable hash while excluding mutable delivery metadata."""
     payload = deepcopy(dict(plan))
-    for key in ("plan_hash", "preview_urls", "delivery", "status", "result"):
+    # apply_token is per-attempt apply bookkeeping (the COMMITTING lock
+    # holder's identity), not plan content, so it must not perturb the hash.
+    for key in (
+        "plan_hash",
+        "preview_urls",
+        "delivery",
+        "status",
+        "result",
+        "apply_token",
+    ):
         payload.pop(key, None)
     encoded = json.dumps(
         payload, sort_keys=True, separators=(",", ":"), default=str

--- a/scripts/receipt_mcp_server.py
+++ b/scripts/receipt_mcp_server.py
@@ -1060,12 +1060,23 @@ masked output rendering is explicitly enabled.""",
 
 Returns the immutable assignment evidence, metrics, findings, artifact hashes,
 and freshly signed visualization URLs. Use this whenever preview URLs expire or
-before revising/applying to verify that a revision is still latest and applicable.""",
+before revising/applying to verify that a revision is still latest and applicable.
+
+Pass job_id (returned by apply_receipt_resegmentation) to poll an async apply
+instead: the response then reports the job status (PENDING/APPLIED/
+CLEANUP_PENDING/FAILED) and the current plan head status.""",
             inputSchema={
                 "type": "object",
                 "properties": {
                     "plan_id": {"type": "string"},
                     "revision": {"type": "integer", "minimum": 1},
+                    "job_id": {
+                        "type": "string",
+                        "description": (
+                            "Async apply job id to poll; when set, returns "
+                            "the job status instead of the plan document"
+                        ),
+                    },
                 },
                 "required": ["plan_id"],
             },
@@ -1116,12 +1127,25 @@ the output parents replace the source parent atomically. Cleanup is resumable.
 
 WARNING: This creates new receipt records and deletes the source receipt after
 the staged outputs are ready. Superseded revisions and plans with blocking
-findings—including layered PHOTO plans—are rejected.""",
+findings—including layered PHOTO plans—are rejected.
+
+By default the apply runs asynchronously: this returns immediately with a
+job_id, and the apply continues in the background (an apply outlives the
+gateway timeout, so a synchronous call would report an error while the apply
+keeps working). Poll progress with get_receipt_resegmentation_plan(plan_id,
+job_id=...). Set synchronous=true only for fast direct invocations.""",
             inputSchema={
                 "type": "object",
                 "properties": {
                     "plan_id": {"type": "string"},
                     "plan_hash": {"type": "string"},
+                    "synchronous": {
+                        "type": "boolean",
+                        "description": (
+                            "Wait for the apply to finish instead of "
+                            "returning a pollable job_id (default false)"
+                        ),
+                    },
                 },
                 "required": ["plan_id", "plan_hash"],
             },
@@ -2174,6 +2198,7 @@ async def call_tool(
             result = await get_receipt_resegmentation_plan_impl(
                 plan_id=arguments["plan_id"],
                 revision=arguments.get("revision"),
+                job_id=arguments.get("job_id"),
             )
         elif name == "revise_receipt_resegmentation_plan":
             result = await revise_receipt_resegmentation_plan_impl(arguments)
@@ -2181,6 +2206,7 @@ async def call_tool(
             result = await apply_receipt_resegmentation_impl(
                 plan_id=arguments["plan_id"],
                 plan_hash=arguments["plan_hash"],
+                synchronous=arguments.get("synchronous", False),
             )
         elif name == "get_receipt_words":
             result = await get_receipt_words_impl(
@@ -3919,14 +3945,28 @@ async def plan_receipt_resegmentation_impl(arguments: dict) -> dict:
 
 
 async def get_receipt_resegmentation_plan_impl(
-    plan_id: str, revision: int | None = None
+    plan_id: str,
+    revision: int | None = None,
+    job_id: str | None = None,
 ) -> dict:
-    """Retrieve a plan and refresh its signed visualization URLs."""
+    """Retrieve a plan (or poll an async apply job) via the Lambda.
+
+    With ``job_id`` this polls the status of an asynchronous apply started
+    by ``apply_receipt_resegmentation`` instead of fetching the plan
+    document.
+    """
     try:
         env = os.environ.get("PORTFOLIO_ENV", "dev")
-        payload = {"mode": "get", "plan_id": plan_id}
-        if revision is not None:
-            payload["revision"] = revision
+        if job_id is not None:
+            payload = {
+                "mode": "status",
+                "plan_id": plan_id,
+                "job_id": job_id,
+            }
+        else:
+            payload = {"mode": "get", "plan_id": plan_id}
+            if revision is not None:
+                payload["revision"] = revision
         return await _invoke_lambda(
             f"resegment-receipt-{env}-resegment-receipt", payload
         )
@@ -3949,14 +3989,26 @@ async def revise_receipt_resegmentation_plan_impl(arguments: dict) -> dict:
 
 
 async def apply_receipt_resegmentation_impl(
-    plan_id: str, plan_hash: str
+    plan_id: str, plan_hash: str, synchronous: bool = False
 ) -> dict:
-    """Invoke the receipt re-segmentation Lambda in apply mode."""
+    """Invoke the receipt re-segmentation Lambda in apply mode.
+
+    An apply outlives the MCP gateway timeout, so by default it dispatches
+    asynchronously: the Lambda returns a job_id immediately and keeps
+    working in the background. Poll with
+    ``get_receipt_resegmentation_plan(plan_id, job_id=...)``.
+    """
     try:
         env = os.environ.get("PORTFOLIO_ENV", "dev")
+        payload = {
+            "mode": "apply",
+            "plan_id": plan_id,
+            "plan_hash": plan_hash,
+        }
+        if not synchronous:
+            payload["async"] = True
         return await _invoke_lambda(
-            f"resegment-receipt-{env}-resegment-receipt",
-            {"mode": "apply", "plan_id": plan_id, "plan_hash": plan_hash},
+            f"resegment-receipt-{env}-resegment-receipt", payload
         )
     except Exception as e:
         logger.exception("Error applying receipt re-segmentation")

--- a/tests/test_receipt_summary_updater_tender.py
+++ b/tests/test_receipt_summary_updater_tender.py
@@ -47,9 +47,11 @@ def _label(line_id, word_id, label, status="VALID"):
 class FakeClient:
     """Minimal DynamoClient stand-in for update_receipt_summary."""
 
-    def __init__(self, existing_summary=None):
+    def __init__(self, existing_summary=None, receipt_exists=True):
         self.existing_summary = existing_summary
+        self.receipt_exists = receipt_exists
         self.upserted = []
+        self.deleted_summaries = []
         self.lines = [
             {"line_id": 1, "text": "TOTAL 47.18", "y": 0.5},
             {"line_id": 2, "text": "VISA US DEBIT", "y": 0.4},
@@ -60,6 +62,15 @@ class FakeClient:
         ]
         self.words = [_word(1, 2, "47.18")]
         self.word_labels = [_label(1, 2, "GRAND_TOTAL")]
+
+    def get_receipt(self, image_id, receipt_id):
+        if not self.receipt_exists:
+            raise EntityNotFoundError("no receipt")
+        return SimpleNamespace(image_id=image_id, receipt_id=receipt_id)
+
+    def delete_receipt_summary(self, record):
+        self.deleted_summaries.append(record)
+        self.existing_summary = None
 
     def list_receipt_word_labels_for_receipt(
         self, image_id, receipt_id, last_evaluated_key=None
@@ -136,6 +147,39 @@ def test_recompute_preserves_offline_bank_fields(monkeypatch):
     assert record.ledger == "chase"
     assert record.bank_amount == 47.18
     assert record.bank_match_confidence == 0.95
+
+
+def test_skips_regen_and_sweeps_orphan_when_parent_deleted(monkeypatch):
+    """A re-segmentation apply deletes the source receipt; the child-row
+    deletion events must NOT resurrect its summary. The updater skips the
+    recompute and deletes any freshly re-created orphan summary row."""
+    existing = ReceiptSummary(
+        image_id=IMAGE_ID,
+        receipt_id=RECEIPT_ID,
+        totals=MonetaryTotals(grand_total=47.18),
+    )
+    client = FakeClient(existing_summary=existing, receipt_exists=False)
+    monkeypatch.setattr(summary_processor, "dynamo_client", client)
+
+    result = summary_processor.update_receipt_summary(IMAGE_ID, RECEIPT_ID)
+
+    assert result["skipped"] == "parent receipt deleted"
+    assert result["orphan_summary_deleted"] is True
+    assert client.upserted == []
+    assert len(client.deleted_summaries) == 1
+
+
+def test_skips_regen_when_parent_deleted_and_no_orphan(monkeypatch):
+    """Parent gone and no summary row present: skip without writing."""
+    client = FakeClient(receipt_exists=False)
+    monkeypatch.setattr(summary_processor, "dynamo_client", client)
+
+    result = summary_processor.update_receipt_summary(IMAGE_ID, RECEIPT_ID)
+
+    assert result["skipped"] == "parent receipt deleted"
+    assert result["orphan_summary_deleted"] is False
+    assert client.upserted == []
+    assert client.deleted_summaries == []
 
 
 def test_cash_receipt_classified(monkeypatch):

--- a/tests/test_resegment_receipt_lambda.py
+++ b/tests/test_resegment_receipt_lambda.py
@@ -1,6 +1,7 @@
 """End-to-end local test for plan/apply receipt re-segmentation."""
 
 import io
+import json
 from datetime import datetime, timezone
 from types import SimpleNamespace
 from uuid import uuid4
@@ -1245,3 +1246,286 @@ def test_v1_plan_binds_source_image_identity():
         )
     # Rejected before any destructive work.
     assert client.get_receipt(image_id, 1).receipt_id == 1
+
+
+@mock_aws
+def test_apply_defaults_to_no_inline_embeddings(monkeypatch):
+    """The deployed Lambda OOMs at its memory limit when embeddings run
+    inline, so an apply event without create_embeddings must never enter
+    the embedding path (outputs self-heal via the normal pipeline)."""
+    raw_bucket = "resegment-raw"
+    client, s3_client, image_id = _seed_two_line_receipt(
+        "ReceiptResegmentNoEmbed", raw_bucket, "resegment-images"
+    )
+    plan = create_plan(
+        _v1_plan_event(image_id),
+        dynamo_client=client,
+        s3_client=s3_client,
+        raw_bucket=raw_bucket,
+    )
+
+    def forbidden_embed(**kwargs):
+        del kwargs
+        raise AssertionError("embeddings must not run by default")
+
+    monkeypatch.setattr(resegment_receipt, "_embed_outputs", forbidden_embed)
+
+    result = apply_plan(
+        {"plan_id": plan["plan_id"], "plan_hash": plan["plan_hash"]},
+        dynamo_client=client,
+        s3_client=s3_client,
+        raw_bucket=raw_bucket,
+        site_bucket="resegment-site",
+        chromadb_bucket="resegment-chroma",
+    )
+
+    assert result["status"] == "APPLIED"
+    assert result["compaction_run_ids"] == []
+    assert result["output_receipt_ids"] == [2, 3]
+
+
+@mock_aws
+def test_failed_apply_never_clobbers_another_workers_lock(monkeypatch):
+    """Status guard: a worker whose apply fails after another worker has
+    since taken over the COMMITTING lock must not stamp PLANNED over the
+    new holder's status, release its reservations, or delete its staged
+    objects. (S3 ETags are content-derived, so a recover-and-retry cycle
+    can resurrect the exact ETag a stale worker still holds; the rollback
+    therefore re-reads the head and verifies the per-attempt apply_token
+    before doing anything destructive.)"""
+    raw_bucket = "resegment-raw"
+    client, s3_client, image_id = _seed_two_line_receipt(
+        "ReceiptResegmentClobber", raw_bucket, "resegment-images"
+    )
+    plan = create_plan(
+        _v1_plan_event(image_id),
+        dynamo_client=client,
+        s3_client=s3_client,
+        raw_bucket=raw_bucket,
+    )
+
+    real_stage = resegment_receipt._stage_outputs
+
+    def stage_then_lose_lock(**kwargs):
+        real_stage(**kwargs)
+        # Simulate a second worker recovering the plan and acquiring the
+        # COMMITTING lock with its own apply_token.
+        head = resegment_receipt._load_plan(
+            s3_client, raw_bucket, plan["plan_id"]
+        )
+        head["apply_token"] = "other-worker-token"
+        resegment_receipt._save_plan(s3_client, raw_bucket, head)
+        raise RuntimeError("simulated failure after losing the lock")
+
+    monkeypatch.setattr(
+        resegment_receipt, "_stage_outputs", stage_then_lose_lock
+    )
+
+    with pytest.raises(RuntimeError, match="losing the lock"):
+        apply_plan(
+            {
+                "plan_id": plan["plan_id"],
+                "plan_hash": plan["plan_hash"],
+                "create_embeddings": False,
+            },
+            dynamo_client=client,
+            s3_client=s3_client,
+            raw_bucket=raw_bucket,
+            site_bucket="resegment-site",
+            chromadb_bucket="resegment-chroma",
+        )
+
+    # The loser left the new lock holder's status and token untouched.
+    stored = resegment_receipt._load_plan(
+        s3_client, raw_bucket, plan["plan_id"]
+    )
+    assert stored["status"] == "COMMITTING"
+    assert stored["apply_token"] == "other-worker-token"
+    # The loser did not release the new holder's reservations.
+    for output_id in (2, 3):
+        counts = client.get_receipt_item_type_counts(image_id, output_id)
+        assert counts.get("RESEGMENT_RESERVATION") == 1
+    # The loser did not delete the staged output crops either.
+    staged_key = f"receipts/{image_id}/{image_id}_RECEIPT_00002.png"
+    assert s3_client.get_object(Bucket=raw_bucket, Key=staged_key)["Body"]
+
+
+class _RecordingLambdaClient:
+    """Captures self-invocations dispatched by start_async_apply."""
+
+    def __init__(self):
+        self.invocations = []
+
+    def invoke(self, **kwargs):
+        self.invocations.append(kwargs)
+        return {"StatusCode": 202}
+
+
+def _set_handler_env(monkeypatch, table_name):
+    monkeypatch.setenv("DYNAMODB_TABLE_NAME", table_name)
+    monkeypatch.setenv("RAW_BUCKET", "resegment-raw")
+    monkeypatch.setenv("SITE_BUCKET", "resegment-site")
+    monkeypatch.setenv("CHROMADB_BUCKET", "resegment-chroma")
+
+
+@mock_aws
+def test_async_apply_returns_job_id_and_is_pollable(monkeypatch):
+    """A gateway apply dispatches a background self-invoke and returns a
+    job id immediately; the job is pollable through mode=status before,
+    during, and after the background worker runs."""
+    table_name = "ReceiptResegmentAsync"
+    raw_bucket = "resegment-raw"
+    client, s3_client, image_id = _seed_two_line_receipt(
+        table_name, raw_bucket, "resegment-images"
+    )
+    plan = create_plan(
+        _v1_plan_event(image_id),
+        dynamo_client=client,
+        s3_client=s3_client,
+        raw_bucket=raw_bucket,
+    )
+
+    fake_lambda = _RecordingLambdaClient()
+    response = resegment_receipt.start_async_apply(
+        {"plan_id": plan["plan_id"], "plan_hash": plan["plan_hash"]},
+        s3_client=s3_client,
+        raw_bucket=raw_bucket,
+        lambda_client=fake_lambda,
+        function_name="resegment-self",
+    )
+
+    assert response["status"] == "PENDING"
+    job_id = response["job_id"]
+    assert job_id
+    assert response["poll"] == {
+        "mode": "status",
+        "plan_id": plan["plan_id"],
+        "job_id": job_id,
+    }
+    [invocation] = fake_lambda.invocations
+    assert invocation["FunctionName"] == "resegment-self"
+    assert invocation["InvocationType"] == "Event"
+    worker_event = json.loads(invocation["Payload"])
+    assert worker_event == {
+        "mode": "apply",
+        "plan_id": plan["plan_id"],
+        "plan_hash": plan["plan_hash"],
+        "job_id": job_id,
+    }
+
+    # Before the background worker runs the job polls PENDING.
+    _set_handler_env(monkeypatch, table_name)
+    status = resegment_receipt.handler(
+        {"mode": "status", "plan_id": plan["plan_id"], "job_id": job_id},
+        None,
+    )
+    assert status["plan_status"] == "PLANNED"
+    assert status["job"]["status"] == "PENDING"
+
+    # Run the dispatched worker event through the real handler.
+    result = resegment_receipt.handler(worker_event, None)
+    assert result["status"] == "APPLIED"
+    assert result["output_receipt_ids"] == [2, 3]
+
+    status = resegment_receipt.handler(
+        {"mode": "status", "plan_id": plan["plan_id"], "job_id": job_id},
+        None,
+    )
+    assert status["plan_status"] == "APPLIED"
+    assert status["job"]["status"] == "APPLIED"
+    assert status["job"]["result"]["output_receipt_ids"] == [2, 3]
+
+    # Re-dispatching an already-applied plan short-circuits synchronously
+    # without another background invocation.
+    repeat = resegment_receipt.start_async_apply(
+        {"plan_id": plan["plan_id"], "plan_hash": plan["plan_hash"]},
+        s3_client=s3_client,
+        raw_bucket=raw_bucket,
+        lambda_client=fake_lambda,
+        function_name="resegment-self",
+    )
+    assert repeat["status"] == "APPLIED"
+    assert repeat["output_receipt_ids"] == [2, 3]
+    assert len(fake_lambda.invocations) == 1
+
+
+@mock_aws
+def test_async_worker_records_failure_for_polling(monkeypatch):
+    """A background apply that fails must surface FAILED (with the error)
+    to pollers instead of leaving them guessing at a gateway timeout."""
+    table_name = "ReceiptResegmentAsyncFail"
+    raw_bucket = "resegment-raw"
+    client, s3_client, image_id = _seed_two_line_receipt(
+        table_name, raw_bucket, "resegment-images"
+    )
+    plan = create_plan(
+        _v1_plan_event(image_id),
+        dynamo_client=client,
+        s3_client=s3_client,
+        raw_bucket=raw_bucket,
+    )
+
+    _set_handler_env(monkeypatch, table_name)
+    result = resegment_receipt.handler(
+        {
+            "mode": "apply",
+            "plan_id": plan["plan_id"],
+            "plan_hash": "not-the-stored-hash",
+            "job_id": "job-fail",
+        },
+        None,
+    )
+    assert result["status"] == "error"
+
+    status = resegment_receipt.handler(
+        {"mode": "status", "plan_id": plan["plan_id"], "job_id": "job-fail"},
+        None,
+    )
+    assert status["plan_status"] == "PLANNED"
+    assert status["job"]["status"] == "FAILED"
+    assert "plan_hash" in status["job"]["error"]
+
+    unknown = resegment_receipt.handler(
+        {"mode": "status", "plan_id": plan["plan_id"], "job_id": "job-nope"},
+        None,
+    )
+    assert unknown["job"] == {"job_id": "job-nope", "status": "UNKNOWN"}
+
+
+def test_handler_routes_async_apply_to_dispatcher(monkeypatch):
+    """The async flag routes to the dispatcher with the same sanitized
+    event as a synchronous apply (no test-only controls forwarded)."""
+    captured = {}
+
+    monkeypatch.setenv("DYNAMODB_TABLE_NAME", "table")
+    monkeypatch.setenv("RAW_BUCKET", "raw")
+    monkeypatch.setenv("SITE_BUCKET", "site")
+    monkeypatch.setenv("CHROMADB_BUCKET", "chroma")
+    monkeypatch.setattr(
+        receipt_dynamo, "DynamoClient", lambda table_name: object()
+    )
+    monkeypatch.setattr(
+        resegment_receipt.boto3, "client", lambda service: object()
+    )
+
+    def fake_start(event, **kwargs):
+        del kwargs
+        captured.update(event)
+        return {"status": "PENDING", "job_id": "job-1"}
+
+    monkeypatch.setattr(resegment_receipt, "start_async_apply", fake_start)
+
+    result = resegment_receipt.handler(
+        {
+            "mode": "apply",
+            "plan_id": "plan-1",
+            "plan_hash": "hash-1",
+            "async": True,
+            "create_embeddings": True,
+            "wait_for_embeddings": True,
+        },
+        None,
+    )
+
+    assert result == {"status": "PENDING", "job_id": "job-1"}
+    assert captured == {"plan_id": "plan-1", "plan_hash": "hash-1"}


### PR DESCRIPTION
Fixes four defects in the receipt resegmentation tool documented from live prod operation on 2026-08-01.

## 1. Async job-id for gateway applies

**Defect:** an apply invoked through the MCP gateway outlives the gateway timeout — the caller got a 503 while the Lambda kept applying, so an "error" could actually be a success (dangerous ambiguity).

**Fix:** the resegment Lambda handler accepts `async: true` on apply events. It validates the plan/hash cheaply, writes a pollable job-status object at `resegment-plans/<plan_id>/jobs/<job_id>.json`, self-invokes with `InvocationType=Event`, and returns `{"status": "PENDING", "job_id": ...}` immediately. The background worker records `APPLIED`/`CLEANUP_PENDING`/`FAILED` (with the error) on completion, and a new `mode=status` returns the job record plus the current plan-head status. Both MCP servers (stdio + Lambda) now default `apply_receipt_resegmentation` to the async path (`synchronous: true` opts out) and `get_receipt_resegmentation_plan` accepts `job_id` to poll. The Lambda role gains self-invoke IAM (deterministic function ARN). Synchronous direct invocation and the test path are unchanged.

## 2. CAS-loser status guard

**Defect:** the failed-apply rollback stamped the plan head back to `PLANNED` guarded only by S3 `If-Match` — but S3 ETags are content-derived, so a recover-and-retry cycle rewrites the exact bytes of an earlier `COMMITTING` head and resurrects the ETag a stale loser still holds (ABA). The loser could then revert the winner's advanced status (`COMMITTING`/`APPLIED`), release the winner's reservations, and delete its staged S3 objects.

**Fix:** every `COMMITTING` acquisition stamps a unique per-attempt `apply_token` (hash-exempt in `compute_plan_hash`), which both makes each lock head byte-unique (no ETag recurrence) and gives the rollback an ownership check: the except path now re-reads the head and only reverts/releases/deletes when the head is still `COMMITTING` **and** carries this attempt's token. A loser that is no longer the lock holder skips the entire rollback and leaves the winner's progress intact.

## 3. Summary tombstone on delete

**Defect:** when an apply deletes a source receipt, the DynamoDB-stream summary-regen stage (`infra/receipt_summary_updater`) fires on the child-row deletions and re-created the deleted receipt's `RECEIPT#N#SUMMARY` row minutes later (manually swept 3× in prod).

**Fix:** `update_receipt_summary` verifies the parent receipt row still exists before recomputing. If the parent is gone it skips the regen and deletes any freshly re-created orphan summary (self-healing, no new schema). A parent that exists as a `RESEGMENT_RESERVATION` still raises `OperationError` so those SQS messages retry until the apply commits and the outputs get real summaries.

## 4. create_embeddings defaults to False

**Defect:** `apply_plan` defaulted `create_embeddings` to `True`; the deployed Lambda OOMs at its 3GB limit when it runs embeddings inline (the working prod recipe has always been `create_embeddings=False`).

**Fix:** the default is now `False` — the deployed Lambda never runs embeddings unless explicitly asked; output embeddings self-heal via the normal pipeline.

## Tests

- `tests/test_resegment_receipt_lambda.py`: async apply returns job id + pollable through PENDING → APPLIED (and FAILED with error surfaced); handler routes/sanitizes the async event; CAS loser cannot revert the winner's status, release its reservations, or delete its staged crops; apply without `create_embeddings` never enters the embedding path. 21 tests pass.
- `tests/test_receipt_summary_updater_tender.py`: regen skipped + orphan summary swept when the parent receipt is deleted (with and without an orphan present). 5 tests pass.
- `receipt_upload` planner/preview suites (16), MCP server suites (86) all pass. All changed files pass `black --check --line-length=79`, `isort --check-only --profile=black --line-length=79`, and `python -m py_compile`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)