### PR TITLE
feat(line-items): zone-gap ITEMS boundary extension

### DIFF
--- a/infra/receipt_line_item_updater/line_item_processor.py
+++ b/infra/receipt_line_item_updater/line_item_processor.py
@@ -22,16 +22,22 @@ import json
 import logging
 import os
 from collections import defaultdict
+from dataclasses import replace
 from datetime import datetime, timezone
 from typing import Any
 
+# Warning #6 requires one first-party block in infra files.
+# isort: off
 from receipt_dynamo.data.dynamo_client import DynamoClient
 from receipt_dynamo.data.shared_exceptions import EntityNotFoundError
 from receipt_dynamo.entities.receipt_line_item import ReceiptLineItem
 from receipt_upload.line_items.geometry import (
     extract_items,
+    propose_items_boundary_extension,
     reconcile_detailed,
 )
+
+# isort: on
 
 logger = logging.getLogger(__name__)
 
@@ -39,6 +45,7 @@ TABLE_NAME = os.environ.get("DYNAMODB_TABLE_NAME", "")
 dynamo_client = DynamoClient(TABLE_NAME) if TABLE_NAME else None
 
 EXTRACTOR_VERSION = "line-items-blocks-v2"
+BOUNDARY_EXTENSION_SOURCE = "zone-gap-extend-v1"
 
 
 def update_receipt_line_items(
@@ -77,7 +84,6 @@ def update_receipt_line_items(
         )
         return {"items": 0, "deleted": deleted, "reason": "no-items-zone"}
 
-    line_ids = {int(x) for x in (items_section.line_ids or [])}
     word_dicts = [
         {
             "line_id": w.line_id,
@@ -89,7 +95,6 @@ def update_receipt_line_items(
             "h": w.bounding_box.get("height", 0.0),
         }
         for w in words
-        if w.line_id in line_ids
     ]
 
     # Summary is fetched BEFORE extraction: the decoder's non-product
@@ -117,6 +122,19 @@ def update_receipt_line_items(
             image_id[:8],
             receipt_id,
         )
+
+    extension = None
+    if summary_dict is not None:
+        items_section, extension = _maybe_extend_items_section(
+            image_id,
+            receipt_id,
+            items_section,
+            sections,
+            word_dicts,
+            summary_dict,
+        )
+
+    line_ids = {int(x) for x in (items_section.line_ids or [])}
 
     items, collapsed = extract_items(
         word_dicts, line_ids, summary=summary_dict
@@ -169,7 +187,11 @@ def update_receipt_line_items(
         dynamo_client.add_receipt_line_items(entities)
 
     reocr = _maybe_trigger_items_reocr(
-        image_id, receipt_id, items, summary_dict, word_dicts
+        image_id,
+        receipt_id,
+        items,
+        summary_dict,
+        [word for word in word_dicts if word["line_id"] in line_ids],
     )
     return {
         "items": len(entities),
@@ -177,7 +199,67 @@ def update_receipt_line_items(
         "reconciliation": status,
         "baseline_source": recon.baseline_source,
         "baseline_figures_agreeing": recon.baseline_figures_agreeing,
+        "section_extension": extension,
         "reocr_triggered": reocr,
+    }
+
+
+def _maybe_extend_items_section(
+    image_id: str,
+    receipt_id: int,
+    items_section: Any,
+    sections: list[Any],
+    words: list[dict],
+    summary: dict,
+) -> tuple[Any, dict[str, Any] | None]:
+    """Persist a reconciliation-verified adjacent-row ITEMS extension."""
+
+    try:
+        rows = dynamo_client.get_receipt_rows_from_receipt(
+            image_id, receipt_id
+        )
+    except EntityNotFoundError:
+        rows = []
+    proposal = propose_items_boundary_extension(
+        words=words,
+        summary=summary,
+        current_line_ids={int(x) for x in (items_section.line_ids or [])},
+        sections=sections,
+        rows=rows,
+        current_row_ids=getattr(items_section, "row_ids", None),
+    )
+    if proposal is None:
+        return items_section, None
+
+    model_source = str(getattr(items_section, "model_source", "") or "")
+    sources = [part for part in model_source.split("+") if part]
+    if BOUNDARY_EXTENSION_SOURCE not in sources:
+        sources.append(BOUNDARY_EXTENSION_SOURCE)
+    updated = replace(
+        items_section,
+        line_ids=proposal["line_ids"],
+        row_ids=proposal["row_ids"],
+        model_source="+".join(sources),
+    )
+    # replace() preserves validation_status and all verifier provenance.  In
+    # particular, a VALID section must never be demoted by automatic repair.
+    dynamo_client.update_receipt_section(updated)
+    logger.info(
+        "extended ITEMS boundary for %s:%d with lines=%s (%s/%s -> %s/%s)",
+        image_id[:8],
+        receipt_id,
+        proposal["added_line_ids"],
+        proposal["before"]["status"],
+        proposal["before"]["delta"],
+        proposal["after"]["status"],
+        proposal["after"]["delta"],
+    )
+    return updated, {
+        "added_line_ids": proposal["added_line_ids"],
+        "added_row_ids": proposal["added_row_ids"],
+        "before": proposal["before"],
+        "after": proposal["after"],
+        "model_source": updated.model_source,
     }
 
 

--- a/receipt_upload/receipt_upload/line_items/geometry.py
+++ b/receipt_upload/receipt_upload/line_items/geometry.py
@@ -765,6 +765,320 @@ def reconcile(
     return r.status, r.item_sum, r.baseline
 
 
+# Reconciliation rank for the ITEMS-boundary repair guard.  no-baseline is
+# deliberately absent: an extension cannot be arithmetic-verified when
+# either side has no comparable baseline.
+_BOUNDARY_RECON_RANK = {"match": 0, "near": 1, "mismatch": 2}
+
+
+def evaluate_items_zone(
+    words: list[dict], summary: Optional[dict], line_ids: set[int]
+) -> dict[str, Any]:
+    """Decode and reconcile one proposed ITEMS zone.
+
+    This is shared by the MCP repair tool and the automatic ingest repair so
+    the verifier cannot drift.  Discounts are excluded from the arithmetic,
+    matching every canonical line-item writer.
+    """
+
+    items, collapsed = extract_items(words, set(line_ids), summary=summary)
+    result = reconcile_detailed(
+        [item for item in items if not item.get("is_discount")], summary
+    )
+    delta = (
+        round(result.item_sum - result.baseline, 2)
+        if result.item_sum is not None and result.baseline is not None
+        else None
+    )
+    return {
+        "status": result.status,
+        "items_sum": result.item_sum,
+        "baseline": result.baseline,
+        "delta": delta,
+        "n_items": len(items),
+        "collapsed_banding": collapsed,
+    }
+
+
+def items_boundary_extension_guard(
+    before: dict[str, Any], after: dict[str, Any]
+) -> tuple[bool, Optional[str]]:
+    """Apply the exact reconciliation guard for an ITEMS extension.
+
+    Acceptance requires both a strictly smaller absolute delta and a better
+    reconciliation status: mismatch -> near/match or near -> match.
+    """
+
+    if before.get("status") == "match":
+        return False, (
+            "Current ITEMS zone already reconciles (match); nothing to "
+            "repair."
+        )
+    if (
+        before.get("status") not in _BOUNDARY_RECON_RANK
+        or after.get("status") not in _BOUNDARY_RECON_RANK
+        or before.get("delta") is None
+        or after.get("delta") is None
+    ):
+        return False, (
+            "Cannot verify the extension: reconciliation did not produce "
+            "comparable deltas for both zones."
+        )
+
+    shrinks = abs(after["delta"]) < abs(before["delta"])
+    improves = (
+        _BOUNDARY_RECON_RANK[after["status"]]
+        < _BOUNDARY_RECON_RANK[before["status"]]
+    )
+    if not (shrinks and improves):
+        return False, (
+            "Arithmetic guard failed: extension must strictly shrink "
+            f"|delta| (before {before['delta']}, after {after['delta']}) "
+            f"AND improve status (before {before['status']!r}, after "
+            f"{after['status']!r})."
+        )
+    return True, None
+
+
+def _entity_field(entity: Any, name: str, default: Any = None) -> Any:
+    if isinstance(entity, dict):
+        return entity.get(name, default)
+    return getattr(entity, name, default)
+
+
+def _is_non_product_row(row_words: list[dict]) -> bool:
+    """Whether the decoder structurally recognizes a settlement/note row."""
+
+    for band in band_words(row_words):
+        text = " ".join(str(word.get("text") or "") for word in band)
+        bare = re.sub(r"\$?\d[\d.,]*", " ", text).strip()
+        if (
+            SETTLEMENT_RE.match(bare)
+            or WAS_PRICE_RE.search(text)
+            or SALE_PRICE_RE.search(text)
+            or NON_PRODUCT_NOTE_RE.search(text)
+        ):
+            return True
+    return False
+
+
+def _is_priced_product_row(row_words: list[dict]) -> bool:
+    """Whether one visual row is safe to consider as a boundary item."""
+
+    if _is_non_product_row(row_words):
+        return False
+    has_price = False
+    for band in band_words(row_words):
+        parsed = parse_band(band)
+        if parsed is not None and parsed.get("price") not in (None, 0):
+            has_price = True
+    return has_price
+
+
+def propose_items_boundary_extension(
+    words: list[dict],
+    summary: Optional[dict],
+    current_line_ids: set[int],
+    sections: list[Any],
+    rows: list[Any],
+    current_row_ids: Optional[list[int]] = None,
+) -> Optional[dict[str, Any]]:
+    """Return the best reconciliation-verified adjacent-row extension.
+
+    Only whole, unclaimed, priced ReceiptRows in gaps inside the ITEMS span or
+    adjacent to either edge are candidates.  Edge candidates are contiguous
+    prefixes of the unclaimed zone (neutral barcode/SKU rows may separate
+    printed product rows); claimed or settlement rows terminate the scan.
+    Among verified proposals, prefer the best status, then the smallest
+    absolute delta, then the smallest boundary change.
+    """
+
+    current = {int(line_id) for line_id in current_line_ids}
+    if not words or not current or not rows:
+        return None
+
+    other_claimed: set[int] = set()
+    for section in sections:
+        if str(_entity_field(section, "section_type", "")).upper() == "ITEMS":
+            continue
+        other_claimed.update(
+            int(line_id)
+            for line_id in (_entity_field(section, "line_ids", []) or [])
+        )
+
+    words_by_line: dict[int, list[dict]] = {}
+    for word in words:
+        try:
+            line_id = int(word["line_id"])
+        except (KeyError, TypeError, ValueError):
+            continue
+        words_by_line.setdefault(line_id, []).append(word)
+
+    visual_rows: list[dict[str, Any]] = []
+    for row in rows:
+        line_ids = {
+            int(line_id)
+            for line_id in (_entity_field(row, "line_ids", []) or [])
+        }
+        row_words = [
+            word
+            for line_id in line_ids
+            for word in words_by_line.get(line_id, [])
+        ]
+        if not line_ids or not row_words:
+            continue
+        y_min = _entity_field(row, "y_min")
+        if y_min is None:
+            y_min = min(float(word.get("y_mid", 0.0)) for word in row_words)
+        visual_rows.append(
+            {
+                "row_id": int(_entity_field(row, "row_id")),
+                "line_ids": line_ids,
+                "words": row_words,
+                "y_min": float(y_min),
+            }
+        )
+    visual_rows.sort(key=lambda row: (row["y_min"], row["row_id"]))
+
+    item_indexes = [
+        index
+        for index, row in enumerate(visual_rows)
+        if row["line_ids"] & current
+    ]
+    if not item_indexes:
+        return None
+
+    def adjacent_chain(indexes: range) -> list[dict[str, Any]]:
+        chain = []
+        for index in indexes:
+            row = visual_rows[index]
+            if row["line_ids"] & (current | other_claimed):
+                break
+            if _is_non_product_row(row["words"]):
+                break
+            if _is_priced_product_row(row["words"]):
+                chain.append(row)
+        return chain
+
+    first, last = min(item_indexes), max(item_indexes)
+    interior = [
+        row
+        for row in visual_rows[first : last + 1]
+        if not row["line_ids"] & (current | other_claimed)
+        and _is_priced_product_row(row["words"])
+    ]
+    above = adjacent_chain(range(first - 1, -1, -1))
+    below = adjacent_chain(range(last + 1, len(visual_rows)))
+    if not interior and not above and not below:
+        return None
+
+    before = evaluate_items_zone(words, summary, current)
+    proposals = []
+
+    def record_proposal(added_rows: list[dict[str, Any]]) -> None:
+        added_line_ids = {
+            line_id for row in added_rows for line_id in row["line_ids"]
+        }
+        proposed_line_ids = current | added_line_ids
+        after = evaluate_items_zone(words, summary, proposed_line_ids)
+        verified, _ = items_boundary_extension_guard(before, after)
+        if not verified:
+            return
+        proposal = {
+            "line_ids": sorted(proposed_line_ids),
+            "added_line_ids": sorted(added_line_ids),
+            "added_row_ids": sorted(row["row_id"] for row in added_rows),
+            "row_ids": (
+                sorted(
+                    {int(row_id) for row_id in current_row_ids}
+                    | {row["row_id"] for row in added_rows}
+                )
+                if current_row_ids is not None
+                else None
+            ),
+            "before": before,
+            "after": after,
+        }
+        signature = tuple(proposal["added_line_ids"])
+        if not any(
+            tuple(existing["added_line_ids"]) == signature
+            for existing in proposals
+        ):
+            proposals.append(proposal)
+
+    # Whole-zone proposals preserve every priced row inside the current span
+    # and grow outward only as contiguous edge prefixes.
+    for above_count in range(len(above) + 1):
+        for below_count in range(len(below) + 1):
+            if not interior and above_count == 0 and below_count == 0:
+                continue
+            record_proposal(
+                interior + above[:above_count] + below[:below_count]
+            )
+
+    # Some OCR sections have several independent internal holes.  Follow the
+    # arithmetic downhill one row at a time, but do not persist an
+    # intermediate mismatch: only record states that pass the original
+    # strict status-and-delta guard.  Edge availability remains prefix-based,
+    # so the search cannot jump over a nearer priced row.
+    selected: list[dict[str, Any]] = []
+    remaining_interior = list(interior)
+    above_count = below_count = 0
+    current_evaluation = before
+    while current_evaluation.get("delta") is not None:
+        available = list(remaining_interior)
+        if above_count < len(above):
+            available.append(above[above_count])
+        if below_count < len(below):
+            available.append(below[below_count])
+        downhill = []
+        for row in available:
+            candidate_rows = selected + [row]
+            candidate_line_ids = current | {
+                line_id
+                for candidate in candidate_rows
+                for line_id in candidate["line_ids"]
+            }
+            evaluation = evaluate_items_zone(
+                words, summary, candidate_line_ids
+            )
+            if evaluation.get("delta") is not None and abs(
+                evaluation["delta"]
+            ) < abs(current_evaluation["delta"]):
+                downhill.append((evaluation, row))
+        if not downhill:
+            break
+        current_evaluation, chosen = min(
+            downhill,
+            key=lambda option: (
+                abs(option[0]["delta"]),
+                _BOUNDARY_RECON_RANK.get(option[0]["status"], 99),
+                option[1]["row_id"],
+            ),
+        )
+        selected.append(chosen)
+        if chosen in remaining_interior:
+            remaining_interior.remove(chosen)
+        elif above_count < len(above) and chosen is above[above_count]:
+            above_count += 1
+        elif below_count < len(below) and chosen is below[below_count]:
+            below_count += 1
+        record_proposal(selected)
+        if current_evaluation["status"] == "match":
+            break
+    if not proposals:
+        return None
+    return min(
+        proposals,
+        key=lambda proposal: (
+            _BOUNDARY_RECON_RANK[proposal["after"]["status"]],
+            abs(proposal["after"]["delta"]),
+            len(proposal["added_line_ids"]),
+            proposal["added_line_ids"],
+        ),
+    )
+
+
 __all__ = [
     "DISCOUNT_WORDS",
     "LEAD_QTY_RE",
@@ -778,8 +1092,11 @@ __all__ = [
     "UNIT_WORDS",
     "band_words",
     "estimate_skew",
+    "evaluate_items_zone",
     "extract_items",
+    "items_boundary_extension_guard",
     "parse_band",
+    "propose_items_boundary_extension",
     "reconcile",
     "reconcile_detailed",
 ]

--- a/receipt_upload/tests/test_line_item_boundary_extension.py
+++ b/receipt_upload/tests/test_line_item_boundary_extension.py
@@ -1,0 +1,190 @@
+"""Reconciliation-gated ITEMS boundary extension tests."""
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+# isort: off
+# Editable local packages land in different groups across the two CI venvs.
+from infra.receipt_line_item_updater import line_item_processor
+from receipt_dynamo.entities.receipt_section import ReceiptSection
+from receipt_upload.line_items.geometry import (
+    propose_items_boundary_extension,
+)
+
+# isort: on
+
+IMAGE_ID = "3f2a1b0c-4d5e-4f70-8192-a3b4c5d6e7f8"
+
+
+def _word(line_id: int, word_id: int, text: str, x: float, y: float):
+    return {
+        "line_id": line_id,
+        "word_id": word_id,
+        "text": text,
+        "x": x,
+        "y_mid": y,
+        "h": 0.02,
+    }
+
+
+def _row(line_id: int, y: float):
+    return SimpleNamespace(row_id=line_id, line_ids=[line_id], y_min=y)
+
+
+def _items_section(
+    line_ids: list[int] | None = None, validation_status: str = "VALID"
+) -> ReceiptSection:
+    ids = line_ids or [1, 2]
+    return ReceiptSection(
+        receipt_id=1,
+        image_id=IMAGE_ID,
+        section_type="ITEMS",
+        line_ids=ids,
+        row_ids=ids,
+        created_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        model_source="section-seed-v0",
+        validation_status=validation_status,
+    )
+
+
+def _product_words(
+    third_name: str = "ORANGES", third_price: str = "4.00"
+) -> list[dict]:
+    return [
+        _word(1, 1, "APPLES", 0.05, 0.10),
+        _word(1, 2, "3.00", 0.80, 0.10),
+        _word(2, 1, "BANANAS", 0.05, 0.15),
+        _word(2, 2, "2.00", 0.80, 0.15),
+        _word(3, 1, third_name, 0.05, 0.20),
+        _word(3, 2, third_price, 0.80, 0.20),
+    ]
+
+
+def _proposal(words: list[dict], subtotal: float):
+    return propose_items_boundary_extension(
+        words=words,
+        summary={"subtotal": subtotal, "tax": None, "grand_total": None},
+        current_line_ids={1, 2},
+        sections=[_items_section()],
+        rows=[_row(1, 0.10), _row(2, 0.15), _row(3, 0.20)],
+        current_row_ids=[1, 2],
+    )
+
+
+def test_extension_accepted_when_delta_shrinks_and_status_improves():
+    proposal = _proposal(_product_words(), subtotal=9.00)
+
+    assert proposal is not None
+    assert proposal["added_line_ids"] == [3]
+    assert proposal["before"]["status"] == "mismatch"
+    assert proposal["after"]["status"] == "match"
+    assert abs(proposal["after"]["delta"]) < abs(proposal["before"]["delta"])
+
+
+def test_extension_refused_when_delta_grows():
+    assert _proposal(_product_words(third_price="50.00"), 9.00) is None
+
+
+def test_extension_refused_when_status_does_not_improve():
+    # 5 -> 9 shrinks the shortfall against 20, but both verdicts mismatch.
+    assert _proposal(_product_words(), 20.00) is None
+
+
+def test_extension_refused_for_settlement_row():
+    # The amount closes the gap arithmetically, but TOTAL is a settlement
+    # band and therefore cannot be an adjacent priced-product candidate.
+    assert _proposal(_product_words(third_name="TOTAL"), 9.00) is None
+
+
+def test_extension_can_cross_shrinking_mismatch_before_final_match():
+    words = _product_words(third_price="4.00") + [
+        _word(4, 1, "PEARS", 0.05, 0.25),
+        _word(4, 2, "6.00", 0.80, 0.25),
+    ]
+    proposal = propose_items_boundary_extension(
+        words=words,
+        summary={"subtotal": 15.00, "tax": None, "grand_total": None},
+        current_line_ids={1, 2},
+        sections=[_items_section()],
+        rows=[
+            _row(1, 0.10),
+            _row(2, 0.15),
+            _row(3, 0.20),
+            _row(4, 0.25),
+        ],
+        current_row_ids=[1, 2],
+    )
+
+    assert proposal is not None
+    assert proposal["added_line_ids"] == [3, 4]
+    assert proposal["before"]["status"] == "mismatch"
+    assert proposal["after"]["status"] == "match"
+
+
+class _FakeDynamo:
+    def __init__(self, validation_status: str = "VALID"):
+        self.section = _items_section(validation_status=validation_status)
+        self.updated_sections = []
+        self.line_items = []
+
+    def list_receipt_words_from_receipt(self, _image_id, _receipt_id):
+        return [
+            SimpleNamespace(
+                line_id=word["line_id"],
+                word_id=word["word_id"],
+                text=word["text"],
+                bounding_box={
+                    "x": word["x"],
+                    "y": word["y_mid"] - word["h"] / 2,
+                    "height": word["h"],
+                },
+            )
+            for word in _product_words()
+        ]
+
+    def get_receipt_sections_from_receipt(self, _image_id, _receipt_id):
+        return [self.section]
+
+    def get_receipt_summary(self, _image_id, _receipt_id):
+        return SimpleNamespace(
+            summary=SimpleNamespace(
+                subtotal=9.00,
+                tax=0.72,
+                grand_total=9.72,
+                merchant_name="Test Mart",
+            )
+        )
+
+    def get_receipt_rows_from_receipt(self, _image_id, _receipt_id):
+        return [_row(1, 0.10), _row(2, 0.15), _row(3, 0.20)]
+
+    def update_receipt_section(self, section):
+        self.updated_sections.append(section)
+
+    def delete_receipt_line_items_for_receipt(self, _image_id, _receipt_id):
+        return 0
+
+    def add_receipt_line_items(self, line_items):
+        self.line_items.extend(line_items)
+
+
+def test_automatic_extension_preserves_valid_status_and_stamps_provenance(
+    monkeypatch,
+):
+    fake = _FakeDynamo(validation_status="VALID")
+    monkeypatch.setattr(line_item_processor, "dynamo_client", fake)
+    monkeypatch.delenv("TRIGGER_REOCR_FUNCTION_NAME", raising=False)
+
+    result = line_item_processor.update_receipt_line_items(IMAGE_ID, 1)
+
+    assert result["reconciliation"] == "match"
+    assert result["section_extension"]["added_line_ids"] == [3]
+    assert len(fake.updated_sections) == 1
+    updated = fake.updated_sections[0]
+    assert updated.validation_status == "VALID"
+    assert updated.line_ids == [1, 2, 3]
+    assert updated.row_ids == [1, 2, 3]
+    assert updated.model_source.endswith("+zone-gap-extend-v1")
+    assert all(
+        item.source_section_status == "VALID" for item in fake.line_items
+    )

--- a/scripts/extend_items_zone_gaps.py
+++ b/scripts/extend_items_zone_gaps.py
@@ -76,6 +76,8 @@ sys.path.insert(
     ),
 )
 
+# isort: off
+# Script-local and editable imports group differently across the two CI venvs.
 import boto3  # noqa: E402
 from extract_line_items import _query_all, fetch_receipt_records  # noqa: E402
 from repair_item_sections import (  # noqa: E402
@@ -95,6 +97,8 @@ from receipt_upload.line_items.geometry import (  # noqa: E402
     band_words,
     parse_band,
 )
+
+# isort: on
 
 DEV_TABLE = "ReceiptsTable-dc5be22"
 PROD_MARKER = "d7ff76a"

--- a/scripts/extend_items_zone_gaps.py
+++ b/scripts/extend_items_zone_gaps.py
@@ -1,0 +1,563 @@
+#!/usr/bin/env python3.12
+"""Zone-gap ITEMS boundary extension (failure-mode H batch repair).
+
+Mode H in the failure-mode audit is 45% of dev reconciliation mismatches
+(68 receipts): priced item text sits just OUTSIDE the ITEMS section
+boundary, so the extractor never sees it. 47 of the 68 were judged
+recoverable WITHOUT re-OCR — the content was OCR'd, the zone just does
+not reach it. This script finds those receipts and repairs the boundary,
+receipt by receipt, under the same arithmetic guard the MCP
+``extend_items_section`` tool enforces.
+
+Discovery (pure functions, unit-tested in
+tests/test_extend_items_zone_gaps.py):
+  * candidates are UNSECTIONED priced bands in the corridor directly
+    above/below the ITEMS zone (bounded by the nearest other section on
+    each side, orientation-agnostic);
+  * each band's price must sit in the receipt's price column
+    (|x - price_column_x| < 0.15 — the load-bearing column gate from the
+    ReceiptRow convention; a previous repair veto hinged on it);
+  * settlement/tender/summary-arithmetic bands are never candidates
+    (geometry's decoder vocabulary via the OCR-tolerant
+    ``looks_arithmetic``, plus geometry's WAS/SALE-PRICE and
+    non-product-note guards);
+  * a band whose amount equals a printed summary figure is never
+    absorbed when the receipt already extracts >= 2 items (on single-
+    item receipts the item legitimately equals the total);
+  * a candidate subset must close the reconciliation gap arithmetically
+    (``subset_closing_gap``, match tolerance first, then near).
+
+Accept authority: ``extend_items_section_impl`` from
+scripts/receipt_mcp_server.py — the SAME guard the MCP tool uses. It
+re-runs the real extractor and refuses unless |delta| strictly shrinks
+AND the reconciliation status improves; it also refuses double-claimed
+lines, keeps the section's row anchor consistent, PRESERVES the prior
+validation_status (the repair_item_sections lesson: a careless write
+demoted VALID -> PENDING and hid sections from the extractor's VALID
+gate), and bumps the summary timestamp so the stream stage regenerates
+the receipt's line items.
+
+Deliberate exclusions, reported per run:
+  * split receipts — fragments sharing merchant+date+grand_total across
+    DIFFERENT image ids carry the full printed total but only part of
+    the items, so they can never reconcile (audit caveat; they need
+    merging at ingest, not boundary repair);
+  * receipts with no ITEMS section (class-A jurisdiction of
+    repair_item_sections.py) and receipts with no usable baseline.
+
+Safety: dry-run by default; --apply to write; hard refusal of the prod
+table; gzip pre-image journal fsynced before the first write (the
+repair_item_sections Journal).
+
+Usage:
+    python3.12 scripts/extend_items_zone_gaps.py                # dry run
+    python3.12 scripts/extend_items_zone_gaps.py --apply
+    python3.12 scripts/extend_items_zone_gaps.py --histogram
+    python3.12 scripts/extend_items_zone_gaps.py --receipt IMG_ID:1
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import re
+import sys
+from collections import Counter, defaultdict
+from statistics import median
+from typing import Any, Optional
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(
+    0,
+    os.path.join(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+        "receipt_dynamo",
+    ),
+)
+
+import boto3  # noqa: E402
+from extract_line_items import _query_all, fetch_receipt_records  # noqa: E402
+from repair_item_sections import (  # noqa: E402
+    Journal,
+    evaluate,
+    forbidden_values,
+    looks_arithmetic,
+    subset_closing_gap,
+)
+
+from receipt_dynamo.amounts import looks_like_receipt_amount  # noqa: E402
+from receipt_dynamo.data.dynamo_client import DynamoClient  # noqa: E402
+from receipt_upload.line_items.geometry import (  # noqa: E402
+    NON_PRODUCT_NOTE_RE,
+    SALE_PRICE_RE,
+    WAS_PRICE_RE,
+    band_words,
+    parse_band,
+)
+
+DEV_TABLE = "ReceiptsTable-dc5be22"
+PROD_MARKER = "d7ff76a"
+# The load-bearing price-column gate: a candidate's price word must sit
+# within this x-distance of the receipt's price column.
+PRICE_COLUMN_TOL = 0.15
+# Receipt-level status = worst item status (mirrors the MCP servers).
+_SEVERITY = {"match": 0, "near": 1, "no-baseline": 2, "mismatch": 3}
+# Amount words are 2-decimal money (mirrors geometry.parse_band's gate).
+_TWO_DECIMAL_RE = re.compile(r"\d[.,]\d{2}(?!\d)")
+
+
+# ---------------------------------------------------------------------------
+# pure discovery helpers (unit-tested)
+# ---------------------------------------------------------------------------
+def receipt_price_column_x(
+    rows: list[Any], words: list[dict], items_lids: set[int]
+) -> Optional[float]:
+    """The receipt's price-column x.
+
+    ``ReceiptRow.price_column_x`` is the canonical convention (median
+    over rows that carry one). Fallback: the median x of amount words
+    inside the current ITEMS zone. None when neither exists — the
+    column gate then rejects every candidate (fail closed).
+    """
+    xs = [
+        float(r.price_column_x)
+        for r in rows or []
+        if getattr(r, "price_column_x", None) is not None
+    ]
+    if xs:
+        return float(median(xs))
+    xs = [
+        w["x"]
+        for w in words
+        if w["line_id"] in items_lids
+        and looks_like_receipt_amount(w["text"])
+        and _TWO_DECIMAL_RE.search(w["text"])
+    ]
+    return float(median(xs)) if xs else None
+
+
+def items_corridor(
+    words: list[dict], sections: list[dict]
+) -> Optional[tuple[float, float]]:
+    """Y interval from the ITEMS zone out to the nearest other section.
+
+    Orientation-agnostic: any non-ITEMS section whose y-span lies
+    entirely beyond one side of the ITEMS span bounds the corridor on
+    that side; with no bounding section the corridor runs to the
+    receipt edge. Candidates outside the corridor would have to jump
+    OVER another section to reach ITEMS — never a zone gap.
+    """
+
+    def yspan(lids: set[int]) -> Optional[tuple[float, float]]:
+        ys = [w["y_mid"] for w in words if w["line_id"] in lids]
+        return (min(ys), max(ys)) if ys else None
+
+    items_span: Optional[tuple[float, float]] = None
+    other_spans: list[tuple[float, float]] = []
+    for s in sections:
+        span = yspan({int(x) for x in (s.get("line_ids") or [])})
+        if span is None:
+            continue
+        if str(s.get("section_type")) == "ITEMS":
+            items_span = (
+                span
+                if items_span is None
+                else (
+                    min(items_span[0], span[0]),
+                    max(items_span[1], span[1]),
+                )
+            )
+        else:
+            other_spans.append(span)
+    if items_span is None:
+        return None
+    lo, hi = 0.0, 1.0
+    for s_lo, s_hi in other_spans:
+        if s_hi <= items_span[0]:
+            lo = max(lo, s_hi)
+        if s_lo >= items_span[1]:
+            hi = min(hi, s_lo)
+    return lo, hi
+
+
+def discover_candidates(
+    words: list[dict],
+    sections: list[dict],
+    summary: Optional[dict],
+    rows: list[Any],
+    n_items: int,
+) -> list[dict]:
+    """Zone-gap candidate bands, nearest to the ITEMS boundary first.
+
+    Each candidate carries the band's line_ids, its parsed price, a
+    text preview, and its y-distance from the ITEMS span edge. Every
+    veto here is a NON-candidate; final acceptance still belongs to
+    the extend_items_section arithmetic guard.
+    """
+    corridor = items_corridor(words, sections)
+    if corridor is None:
+        return []
+    lo, hi = corridor
+
+    sectioned: set[int] = set()
+    items_lids: set[int] = set()
+    for s in sections:
+        lids = {int(x) for x in (s.get("line_ids") or [])}
+        sectioned |= lids
+        if str(s.get("section_type")) == "ITEMS":
+            items_lids |= lids
+    items_ys = [w["y_mid"] for w in words if w["line_id"] in items_lids]
+    if not items_ys:
+        return []
+    i_lo, i_hi = min(items_ys), max(items_ys)
+
+    col_x = receipt_price_column_x(rows, words, items_lids)
+    if col_x is None:
+        return []  # no price column to align against: fail closed
+
+    fv = forbidden_values(summary)
+    free = [w for w in words if w["line_id"] not in sectioned]
+    out: list[dict] = []
+    for band in band_words(free):
+        y = sum(w["y_mid"] for w in band) / len(band)
+        if not (lo <= y <= hi):
+            continue
+        parsed = parse_band(band)
+        if parsed is None or not parsed.get("price"):
+            continue
+        text = parsed["raw_text"]
+        # Settlement/tender/summary arithmetic rows are never items —
+        # the OCR-tolerant detector covers geometry's SETTLEMENT_RE
+        # vocabulary plus mangled forms ("Sustota.: $15.00").
+        if looks_arithmetic(text):
+            continue
+        # Price-echo annotations the decoder drops anyway: absorbing
+        # them cannot shrink |delta|, so spend the proposal elsewhere.
+        if (
+            WAS_PRICE_RE.search(text)
+            or SALE_PRICE_RE.search(text)
+            or NON_PRODUCT_NOTE_RE.search(text)
+        ):
+            continue
+        ref = parsed.get("price_word_id")
+        price_x = None
+        if ref:
+            for w in band:
+                if (
+                    w["line_id"] == ref["line_id"]
+                    and w["word_id"] == ref["word_id"]
+                ):
+                    price_x = w["x"]
+                    break
+        if price_x is None or abs(price_x - col_x) >= PRICE_COLUMN_TOL:
+            continue  # the load-bearing column gate
+        # Never absorb a printed summary figure when the receipt
+        # already extracts >= 2 items (single-item receipts may
+        # legitimately equal the total).
+        if n_items >= 2 and round(abs(parsed["price"]), 2) in fv:
+            continue
+        dist = 0.0 if i_lo <= y <= i_hi else min(abs(y - i_lo), abs(y - i_hi))
+        out.append(
+            {
+                "lids": sorted({w["line_id"] for w in band}),
+                "price": parsed["price"],
+                "text": text[:60],
+                "distance": round(dist, 4),
+            }
+        )
+    out.sort(key=lambda c: (c["distance"], c["lids"]))
+    return out
+
+
+def propose_extension(
+    cands: list[dict], delta: float, baseline: Optional[float]
+) -> Optional[list[int]]:
+    """Candidate subset whose prices close the reconciliation gap.
+
+    ``delta`` is baseline - item_sum (the shortfall). Match tolerance
+    first; the near tolerance only when the current gap is itself
+    beyond near (mismatch -> near still improves the status, which the
+    arithmetic guard requires). Returns the line_ids to add, or None.
+    """
+    if baseline is None or not cands:
+        return None
+    tol_match = max(0.02, baseline * 0.01)
+    combo = subset_closing_gap(cands, delta, tol_match)
+    if not combo:
+        tol_near = max(1.0, baseline * 0.10)
+        if abs(delta) > tol_near:
+            combo = subset_closing_gap(cands, delta, tol_near)
+    if not combo:
+        return None
+    return sorted({lid for i in combo for lid in cands[i]["lids"]})
+
+
+def split_groups_from_summaries(
+    summaries: list[dict],
+) -> set[tuple[str, int]]:
+    """Receipts that are fragments of the same physical receipt.
+
+    Same merchant + date + printed grand total under DIFFERENT image
+    ids = one receipt photographed/cropped more than once. Each
+    fragment carries the FULL printed total but only PART of the
+    items, so no boundary repair can ever reconcile it (audit caveat).
+    """
+    groups: dict[tuple, set[tuple[str, int]]] = defaultdict(set)
+    for s in summaries:
+        merchant = str(s.get("merchant_name") or "").strip().lower()
+        date = str(s.get("date") or "")[:10]
+        total = s.get("grand_total")
+        if not merchant or not date or total in (None, ""):
+            continue
+        try:
+            key = (merchant, date, round(float(total), 2))
+        except (TypeError, ValueError):
+            continue
+        groups[key].add((str(s["image_id"]), int(s["receipt_id"])))
+    excluded: set[tuple[str, int]] = set()
+    for members in groups.values():
+        if len({img for img, _ in members}) >= 2:
+            excluded |= members
+    return excluded
+
+
+# ---------------------------------------------------------------------------
+# table scans
+# ---------------------------------------------------------------------------
+def receipt_recon_statuses(client, table: str) -> dict[tuple[str, int], str]:
+    """Receipt-level reconciliation_status over RECEIPT_LINE_ITEM rows."""
+    out: dict[tuple[str, int], str] = {}
+    for raw in _query_all(
+        client,
+        TableName=table,
+        IndexName="GSITYPE",
+        KeyConditionExpression="#t = :t",
+        ExpressionAttributeNames={"#t": "TYPE"},
+        ExpressionAttributeValues={":t": {"S": "RECEIPT_LINE_ITEM"}},
+        ProjectionExpression="PK, SK, reconciliation_status",
+    ):
+        m = re.match(r"IMAGE#(.+)", raw["PK"]["S"])
+        m2 = re.match(r"RECEIPT#(\d+)#LINE_ITEM#", raw["SK"]["S"])
+        status = (raw.get("reconciliation_status") or {}).get("S")
+        if not (m and m2 and status):
+            continue
+        key = (m.group(1), int(m2.group(1)))
+        prev = out.get(key)
+        if prev is None or _SEVERITY.get(status, -1) > _SEVERITY.get(prev, -1):
+            out[key] = status
+    return out
+
+
+def fetch_all_summaries(client, table: str) -> list[dict]:
+    """Every RECEIPT_SUMMARY row (flat fields) with parsed identity."""
+    from boto3.dynamodb.types import TypeDeserializer
+
+    des = TypeDeserializer()
+    out: list[dict] = []
+    for raw in _query_all(
+        client,
+        TableName=table,
+        IndexName="GSITYPE",
+        KeyConditionExpression="#t = :t",
+        ExpressionAttributeNames={"#t": "TYPE"},
+        ExpressionAttributeValues={":t": {"S": "RECEIPT_SUMMARY"}},
+    ):
+        m = re.match(r"IMAGE#(.+)", raw["PK"]["S"])
+        m2 = re.match(r"RECEIPT#(\d+)#SUMMARY", raw["SK"]["S"])
+        if not (m and m2):
+            continue
+        item = {k: des.deserialize(v) for k, v in raw.items()}
+        item["image_id"] = m.group(1)
+        item["receipt_id"] = int(m2.group(1))
+        out.append(item)
+    return out
+
+
+def print_histogram(statuses: dict[tuple[str, int], str]) -> None:
+    counts = Counter(statuses.values())
+    total = sum(counts.values())
+    print(f"receipt-level reconciliation histogram ({total} receipts):")
+    for status in ("match", "near", "mismatch", "no-baseline"):
+        n = counts.get(status, 0)
+        pct = 100.0 * n / total if total else 0.0
+        print(f"  {status:<12} {n:>5}  {pct:5.1f}%")
+
+
+# ---------------------------------------------------------------------------
+def _load_extend_impl():
+    """The MCP server's guarded extension — the single accept authority."""
+    import receipt_mcp_server  # noqa: PLC0415 — needs `mcp` installed
+
+    return receipt_mcp_server.extend_items_section_impl
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    ap.add_argument("--table", default=DEV_TABLE)
+    ap.add_argument("--apply", action="store_true")
+    ap.add_argument(
+        "--histogram",
+        action="store_true",
+        help="print the receipt-level reconciliation histogram and exit",
+    )
+    ap.add_argument("--limit", type=int, default=None)
+    ap.add_argument(
+        "--receipt", help="IMAGE_ID:RECEIPT_ID single-receipt mode"
+    )
+    args = ap.parse_args()
+
+    if PROD_MARKER in args.table:
+        sys.exit("REFUSED: this script never writes to the prod table.")
+
+    client = boto3.client("dynamodb", region_name="us-east-1")
+    statuses = receipt_recon_statuses(client, args.table)
+    if args.histogram:
+        print_histogram(statuses)
+        return
+
+    dynamo = DynamoClient(args.table)
+    extend_impl = _load_extend_impl()
+    excluded_split = split_groups_from_summaries(
+        fetch_all_summaries(client, args.table)
+    )
+
+    targets = sorted(
+        k for k, s in statuses.items() if s in ("mismatch", "near")
+    )
+    if args.receipt:
+        img, rid = args.receipt.split(":")
+        targets = [t for t in targets if t == (img, int(rid))]
+    if args.limit:
+        targets = targets[: args.limit]
+
+    journal = Journal("H-zone-gap", args.apply)
+    stats: Counter = Counter()
+    transitions: Counter = Counter()
+    split_excluded_hits: list[str] = []
+
+    for img, rid in targets:
+        stats["examined"] += 1
+        key = f"{img}:{rid}"
+        rec: dict[str, Any] = {"class": "H-zone-gap", "key": key}
+        if (img, rid) in excluded_split:
+            stats["excluded-split-receipt"] += 1
+            split_excluded_hits.append(key)
+            rec["decision"] = "skip: split-receipt fragment"
+            journal.propose(rec)
+            continue
+
+        words, sections, summary = fetch_receipt_records(
+            client, args.table, img, rid
+        )
+        items_secs = [
+            s for s in sections if str(s.get("section_type")) == "ITEMS"
+        ]
+        if not items_secs:
+            stats["skip-no-items-section"] += 1
+            continue
+        cur_lids = {int(x) for x in items_secs[0].get("line_ids") or []}
+        st0, sum0, base0, n0, _ = evaluate(words, summary, cur_lids)
+        rec["before"] = {"status": st0, "sum": sum0, "baseline": base0}
+        if st0 == "match":
+            stats["skip-already-match"] += 1
+            continue
+        if base0 is None:
+            stats["skip-no-baseline"] += 1
+            continue
+
+        rows = dynamo.get_receipt_rows_from_receipt(img, rid) or []
+        cands = discover_candidates(words, sections, summary, rows, n0)
+        if not cands:
+            stats["no-candidates"] += 1
+            rec["decision"] = "skip: no zone-gap candidates"
+            journal.propose(rec)
+            continue
+        stats["with-candidates"] += 1
+        stats["candidate-bands"] += len(cands)
+
+        delta = round(base0 - (sum0 or 0.0), 2)
+        added = propose_extension(cands, delta, base0)
+        if not added:
+            stats["no-closing-subset"] += 1
+            rec["decision"] = "skip: no subset closes the gap"
+            rec["n_candidates"] = len(cands)
+            journal.propose(rec)
+            continue
+        rec["added_line_ids"] = added
+
+        verdict = asyncio.run(
+            extend_impl(dynamo, img, rid, added, dry_run=True)
+        )
+        if verdict.get("error") or not verdict.get("verified"):
+            stats["guard-refused"] += 1
+            rec["decision"] = "refused: " + str(
+                verdict.get("refusal") or verdict.get("error")
+            )
+            journal.propose(rec)
+            continue
+
+        stats["guard-passed"] += 1
+        before_s = verdict["before"]["status"]
+        after_s = verdict["after"]["status"]
+        transitions[(before_s, after_s)] += 1
+        rec["after"] = verdict["after"]
+        rec["decision"] = "apply" if args.apply else "would-apply"
+        journal.propose(rec)
+        print(
+            f"  {key}  {before_s}({verdict['before']['delta']}) -> "
+            f"{after_s}({verdict['after']['delta']})  +lines {added}"
+        )
+
+        if args.apply:
+            sec_dict = items_secs[0]
+            journal.backup(
+                {
+                    "action": "zone-gap-extend",
+                    "pre_image": sec_dict,
+                    "summary_timestamp": (summary or {}).get(
+                        "timestamp_computed"
+                    ),
+                    "key": key,
+                }
+            )
+            applied = asyncio.run(
+                extend_impl(dynamo, img, rid, added, dry_run=False)
+            )
+            if applied.get("applied"):
+                stats["applied"] += 1
+            else:
+                stats["apply-failed"] += 1
+                print(f"    APPLY FAILED for {key}: {applied}")
+    journal.close()
+
+    print("\n=== zone-gap extension report ===")
+    print_histogram(statuses)
+    print("stats:", dict(stats))
+    if transitions:
+        print("guard-passed transitions:")
+        for (b, a), n in sorted(transitions.items()):
+            print(f"  {b} -> {a}: {n}")
+        projected = Counter(statuses.values())
+        for (b, a), n in transitions.items():
+            projected[b] -= n
+            projected[a] += n
+        print("projected histogram after apply + stream regen:")
+        for status in ("match", "near", "mismatch", "no-baseline"):
+            print(f"  {status:<12} {projected.get(status, 0):>5}")
+    if split_excluded_hits:
+        print(
+            f"excluded split-receipt fragments ({len(split_excluded_hits)}):"
+        )
+        for key in split_excluded_hits:
+            print(f"  {key}")
+    print(f"journal: {journal.proposal_path}")
+    if args.apply:
+        print(f"backups: {journal.backup_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/receipt_mcp_server.py
+++ b/scripts/receipt_mcp_server.py
@@ -4762,25 +4762,9 @@ def _evaluate_items_zone(words: list[dict], summary: dict, line_ids) -> dict:
     Discounts are excluded from the sum, matching the stream stage and
     scripts/repair_item_sections.evaluate.
     """
-    from receipt_upload.line_items.geometry import extract_items, reconcile
+    from receipt_upload.line_items.geometry import evaluate_items_zone
 
-    items, collapsed = extract_items(words, set(line_ids))
-    status, items_sum, baseline = reconcile(
-        [x for x in items if not x["is_discount"]], summary
-    )
-    delta = (
-        round(items_sum - baseline, 2)
-        if items_sum is not None and baseline is not None
-        else None
-    )
-    return {
-        "status": status,
-        "items_sum": items_sum,
-        "baseline": baseline,
-        "delta": delta,
-        "n_items": len(items),
-        "collapsed_banding": collapsed,
-    }
+    return evaluate_items_zone(words, summary, set(line_ids))
 
 
 async def get_receipt_line_items_impl(
@@ -4898,10 +4882,6 @@ async def extend_items_section_impl(
     from receipt_dynamo.entities.receipt_summary_record import (
         ReceiptSummaryRecord,
     )
-
-    # Guard ranking (strict improvement required to apply). Distinct from
-    # _RECON_SEVERITY: "no-baseline" is never rankable here.
-    guard_rank = {"match": 0, "near": 1, "mismatch": 2}
 
     try:
         try:
@@ -5041,36 +5021,14 @@ async def extend_items_section_impl(
             "applied": False,
         }
 
-        if before["status"] == "match":
-            result["verified"] = False
-            result["refusal"] = (
-                "Current ITEMS zone already reconciles (match); nothing "
-                "to repair."
-            )
-            return result
-        if (
-            before["status"] not in guard_rank
-            or after["status"] not in guard_rank
-            or before["delta"] is None
-            or after["delta"] is None
-        ):
-            result["verified"] = False
-            result["refusal"] = (
-                "Cannot verify the extension: reconciliation did not "
-                "produce comparable deltas for both zones."
-            )
-            return result
+        from receipt_upload.line_items.geometry import (
+            items_boundary_extension_guard,
+        )
 
-        shrinks = abs(after["delta"]) < abs(before["delta"])
-        improves = guard_rank[after["status"]] < guard_rank[before["status"]]
-        if not (shrinks and improves):
+        verified, refusal = items_boundary_extension_guard(before, after)
+        if not verified:
             result["verified"] = False
-            result["refusal"] = (
-                "Arithmetic guard failed: extension must strictly shrink "
-                f"|delta| (before {before['delta']}, after "
-                f"{after['delta']}) AND improve status (before "
-                f"{before['status']!r}, after {after['status']!r})."
-            )
+            result["refusal"] = refusal
             return result
 
         result["verified"] = True

--- a/tests/test_extend_items_zone_gaps.py
+++ b/tests/test_extend_items_zone_gaps.py
@@ -1,0 +1,473 @@
+"""Tests for the zone-gap ITEMS boundary extension (failure-mode H).
+
+The discovery pass in scripts/extend_items_zone_gaps.py must only ever
+PROPOSE: candidates are unsectioned priced bands adjacent to the ITEMS
+zone, gated by the price-column alignment (|x - col_x| < 0.15), the
+settlement/arithmetic vocabulary, and the printed-summary-figure veto.
+Final acceptance belongs to extend_items_section_impl's arithmetic
+guard, exercised end-to-end here with the same stub-client pattern as
+tests/test_receipt_mcp_line_item_tools.py.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import types
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+
+# isort: off
+# receipt_upload lands in a different import group depending on whether
+# the venv has it installed, so the grouping here is not reproducible
+# across environments. Pin it (same fence as
+# tests/test_evaluate_section_geometry.py).
+from scripts.extend_items_zone_gaps import (
+    PRICE_COLUMN_TOL,
+    discover_candidates,
+    items_corridor,
+    propose_extension,
+    receipt_price_column_x,
+    split_groups_from_summaries,
+)
+
+# isort: on
+
+VALID_IMAGE_ID = "3f2a1b0c-4d5e-4f70-8192-a3b4c5d6e7f8"
+OTHER_IMAGE_ID = "9e8d7c6b-5a49-4382-a1b0-c9d8e7f6a5b4"
+
+
+# ---------------------------------------------------------------------------
+# Fixture world: a receipt whose arithmetic is fully known.
+#   line 1  APPLES    3.00   (ITEMS)
+#   line 2  BANANAS   2.00   (ITEMS)
+#   line 3  ORANGES   4.00   (unsectioned, price in column — the zone gap)
+#   line 4  BALANCE DUE 9.00 (unsectioned — settlement vocabulary)
+#   line 5  OFFCOL    4.00   (unsectioned, price OFF the column)
+#   line 6  MYSTERY   9.00   (unsectioned, amount == printed subtotal)
+#   line 7  TOTAL     9.72   (SUMMARY section — already claimed)
+# summary: subtotal 9.00, tax 0.72, grand_total 9.72
+# ---------------------------------------------------------------------------
+
+
+def _w(line_id, word_id, text, x, y):
+    return {
+        "line_id": line_id,
+        "word_id": word_id,
+        "text": text,
+        "x": x,
+        "y_mid": y,
+        "h": 0.02,
+    }
+
+
+def _world_words():
+    return [
+        _w(1, 1, "APPLES", 0.05, 0.10),
+        _w(1, 2, "3.00", 0.80, 0.10),
+        _w(2, 1, "BANANAS", 0.05, 0.15),
+        _w(2, 2, "2.00", 0.80, 0.15),
+        _w(3, 1, "ORANGES", 0.05, 0.20),
+        _w(3, 2, "4.00", 0.80, 0.20),
+        _w(4, 1, "BALANCE", 0.05, 0.25),
+        _w(4, 2, "DUE", 0.30, 0.25),
+        _w(4, 3, "9.00", 0.80, 0.25),
+        _w(5, 1, "OFFCOL", 0.05, 0.30),
+        _w(5, 2, "4.00", 0.40, 0.30),
+        _w(6, 1, "MYSTERY", 0.05, 0.35),
+        _w(6, 2, "9.00", 0.80, 0.35),
+        _w(7, 1, "TOTAL", 0.05, 0.45),
+        _w(7, 2, "9.72", 0.80, 0.45),
+    ]
+
+
+def _world_sections():
+    return [
+        {"section_type": "ITEMS", "line_ids": [1, 2]},
+        {"section_type": "SUMMARY", "line_ids": [7]},
+    ]
+
+
+_SUMMARY = {"subtotal": 9.00, "tax": 0.72, "grand_total": 9.72}
+_ROWS = [SimpleNamespace(price_column_x=0.80)]
+
+
+# ---------------------------------------------------------------------------
+# price column
+# ---------------------------------------------------------------------------
+
+
+def test_price_column_prefers_receipt_row_convention():
+    rows = [
+        SimpleNamespace(price_column_x=0.78),
+        SimpleNamespace(price_column_x=0.82),
+        SimpleNamespace(price_column_x=None),
+    ]
+    assert receipt_price_column_x(rows, _world_words(), {1, 2}) == 0.80
+
+
+def test_price_column_falls_back_to_items_zone_amounts():
+    # No ReceiptRow carries a column: median x of ITEMS-zone amount words.
+    assert receipt_price_column_x([], _world_words(), {1, 2}) == 0.80
+
+
+def test_price_column_none_without_any_signal():
+    words = [_w(1, 1, "APPLES", 0.05, 0.10)]  # no amounts anywhere
+    assert receipt_price_column_x([], words, {1}) is None
+
+
+# ---------------------------------------------------------------------------
+# corridor
+# ---------------------------------------------------------------------------
+
+
+def test_corridor_bounded_by_adjacent_sections():
+    words = _world_words() + [
+        _w(9, 1, "STORE", 0.05, 0.02),
+        _w(9, 2, "NAME", 0.30, 0.02),
+    ]
+    sections = _world_sections() + [
+        {"section_type": "STOREFRONT", "line_ids": [9]}
+    ]
+    lo, hi = items_corridor(words, sections)
+    assert lo == 0.02  # header span bounds the top side
+    assert hi == 0.45  # summary span bounds the bottom side
+
+
+def test_corridor_none_without_items_section():
+    assert (
+        items_corridor(_world_words(), [{"section_type": "SUMMARY"}]) is None
+    )
+
+
+def test_corridor_excludes_bands_beyond_another_section():
+    # A priced band ABOVE the STOREFRONT header would have to jump over
+    # it to reach ITEMS — never a zone gap.
+    words = _world_words() + [
+        _w(8, 1, "GHOST", 0.05, 0.01),
+        _w(8, 2, "4.00", 0.80, 0.01),
+        _w(9, 1, "STOREHEADER", 0.05, 0.05),
+    ]
+    sections = _world_sections() + [
+        {"section_type": "STOREFRONT", "line_ids": [9]}
+    ]
+    cands = discover_candidates(words, sections, _SUMMARY, _ROWS, n_items=2)
+    assert all(8 not in c["lids"] for c in cands)
+
+
+# ---------------------------------------------------------------------------
+# discovery vetoes
+# ---------------------------------------------------------------------------
+
+
+def test_discovery_finds_the_zone_gap_line_and_only_it():
+    cands = discover_candidates(
+        _world_words(), _world_sections(), _SUMMARY, _ROWS, n_items=2
+    )
+    assert [c["lids"] for c in cands] == [[3]]
+    assert cands[0]["price"] == 4.00
+    assert "ORANGES" in cands[0]["text"]
+
+
+def test_discovery_vetoes_settlement_bands():
+    cands = discover_candidates(
+        _world_words(), _world_sections(), _SUMMARY, _ROWS, n_items=2
+    )
+    assert all(4 not in c["lids"] for c in cands)  # BALANCE DUE
+
+
+def test_discovery_vetoes_off_column_amounts():
+    # OFFCOL's price sits at x=0.40 vs column 0.80 — outside the
+    # load-bearing |x - col_x| < 0.15 gate.
+    assert abs(0.40 - 0.80) >= PRICE_COLUMN_TOL
+    cands = discover_candidates(
+        _world_words(), _world_sections(), _SUMMARY, _ROWS, n_items=2
+    )
+    assert all(5 not in c["lids"] for c in cands)
+
+
+def test_discovery_vetoes_printed_summary_figures_with_two_items():
+    cands = discover_candidates(
+        _world_words(), _world_sections(), _SUMMARY, _ROWS, n_items=2
+    )
+    assert all(6 not in c["lids"] for c in cands)  # MYSTERY 9.00
+
+
+def test_summary_figure_allowed_on_single_item_receipts():
+    # On a 1-item receipt the item legitimately equals the total.
+    cands = discover_candidates(
+        _world_words(), _world_sections(), _SUMMARY, _ROWS, n_items=1
+    )
+    assert [3] in [c["lids"] for c in cands]
+    assert [6] in [c["lids"] for c in cands]
+
+
+def test_discovery_ignores_lines_claimed_by_other_sections():
+    cands = discover_candidates(
+        _world_words(), _world_sections(), _SUMMARY, _ROWS, n_items=2
+    )
+    assert all(7 not in c["lids"] for c in cands)  # SUMMARY-claimed
+
+
+def test_discovery_fails_closed_without_a_price_column():
+    words = [
+        w
+        for w in _world_words()
+        if not (w["line_id"] in (1, 2) and w["word_id"] == 2)
+    ]
+    # ITEMS zone carries no amounts and no ReceiptRow has a column.
+    cands = discover_candidates(
+        words, _world_sections(), _SUMMARY, [], n_items=2
+    )
+    assert cands == []
+
+
+def test_discovery_orders_candidates_nearest_first():
+    cands = discover_candidates(
+        _world_words(), _world_sections(), _SUMMARY, _ROWS, n_items=1
+    )
+    distances = [c["distance"] for c in cands]
+    assert distances == sorted(distances)
+
+
+# ---------------------------------------------------------------------------
+# subset proposal
+# ---------------------------------------------------------------------------
+
+
+def _cand(lids, price):
+    return {"lids": lids, "price": price, "text": "X", "distance": 0.01}
+
+
+def test_propose_extension_closes_gap_within_match_tolerance():
+    assert propose_extension([_cand([3], 4.00)], 4.00, 9.00) == [3]
+
+
+def test_propose_extension_accepts_near_band_only_from_mismatch():
+    # 3.60 vs gap 4.00 misses match tol (0.09) but lands inside the
+    # near tol (1.00), and the current gap is beyond near — a
+    # mismatch -> near improvement the guard accepts.
+    assert propose_extension([_cand([3], 3.60)], 4.00, 9.00) == [3]
+    # A gap already within the near band never takes a near-only fix:
+    # near -> near is not a status improvement.
+    assert propose_extension([_cand([3], 0.50)], 0.90, 9.00) is None
+
+
+def test_propose_extension_refuses_overshoot():
+    assert propose_extension([_cand([4], 50.00)], 4.00, 9.00) is None
+
+
+def test_propose_extension_combines_multiple_bands():
+    cands = [_cand([3], 2.50), _cand([5], 1.50)]
+    assert propose_extension(cands, 4.00, 9.00) == [3, 5]
+
+
+def test_propose_extension_handles_missing_baseline():
+    assert propose_extension([_cand([3], 4.00)], 4.00, None) is None
+    assert propose_extension([], 4.00, 9.00) is None
+
+
+# ---------------------------------------------------------------------------
+# split-receipt exclusion (audit caveat: fragments can never reconcile)
+# ---------------------------------------------------------------------------
+
+
+def _summary_row(image_id, receipt_id, merchant, date, total):
+    return {
+        "image_id": image_id,
+        "receipt_id": receipt_id,
+        "merchant_name": merchant,
+        "date": date,
+        "grand_total": total,
+    }
+
+
+def test_split_groups_flags_same_total_across_image_ids():
+    rows = [
+        _summary_row(VALID_IMAGE_ID, 1, "Gelson's", "2024-12-16", 39.58),
+        _summary_row(OTHER_IMAGE_ID, 1, "GELSON'S", "2024-12-16", 39.58),
+        _summary_row(VALID_IMAGE_ID, 2, "Vons", "2024-12-16", 12.00),
+    ]
+    excluded = split_groups_from_summaries(rows)
+    assert (VALID_IMAGE_ID, 1) in excluded
+    assert (OTHER_IMAGE_ID, 1) in excluded
+    assert (VALID_IMAGE_ID, 2) not in excluded
+
+
+def test_split_groups_same_image_multiple_receipts_not_flagged():
+    # Two receipts on ONE image (a genuine two-receipt photo) are not
+    # split fragments.
+    rows = [
+        _summary_row(VALID_IMAGE_ID, 1, "Vons", "2024-12-16", 12.00),
+        _summary_row(VALID_IMAGE_ID, 2, "Vons", "2024-12-16", 12.00),
+    ]
+    assert split_groups_from_summaries(rows) == set()
+
+
+def test_split_groups_requires_merchant_date_and_total():
+    rows = [
+        _summary_row(VALID_IMAGE_ID, 1, "", "2024-12-16", 39.58),
+        _summary_row(OTHER_IMAGE_ID, 1, "", "2024-12-16", 39.58),
+        _summary_row(VALID_IMAGE_ID, 2, "Vons", "", 12.00),
+        _summary_row(OTHER_IMAGE_ID, 2, "Vons", "", 12.00),
+        _summary_row(VALID_IMAGE_ID, 3, "Ralphs", "2024-12-16", None),
+        _summary_row(OTHER_IMAGE_ID, 3, "Ralphs", "2024-12-16", None),
+    ]
+    assert split_groups_from_summaries(rows) == set()
+
+
+# ---------------------------------------------------------------------------
+# end-to-end: discovery feeds the extend_items_section arithmetic guard
+# (same fake-mcp + stub-client pattern as
+# tests/test_receipt_mcp_line_item_tools.py)
+# ---------------------------------------------------------------------------
+
+
+def _install_mcp_stubs():
+    mcp_mod = types.ModuleType("mcp")
+    server_mod = types.ModuleType("mcp.server")
+    stdio_mod = types.ModuleType("mcp.server.stdio")
+    types_mod = types.ModuleType("mcp.types")
+
+    class _FakeServer:
+        def __init__(self, name):
+            self.name = name
+
+        def list_tools(self):
+            return lambda func: func
+
+        def call_tool(self):
+            return lambda func: func
+
+    class _FakeContent:
+        def __init__(self, **kwargs):
+            for key, value in kwargs.items():
+                setattr(self, key, value)
+
+    server_mod.Server = _FakeServer
+    stdio_mod.stdio_server = lambda *a, **k: None
+    types_mod.Tool = _FakeContent
+    types_mod.TextContent = _FakeContent
+    types_mod.ImageContent = _FakeContent
+    sys.modules["mcp"] = mcp_mod
+    sys.modules["mcp.server"] = server_mod
+    sys.modules["mcp.server.stdio"] = stdio_mod
+    sys.modules["mcp.types"] = types_mod
+
+
+class _StubDynamoClient:
+    def __init__(self, sections):
+        self.sections = sections
+        self.updated_sections = []
+        self.updated_summaries = []
+
+    def get_receipt_details(self, image_id, receipt_id):
+        words = [
+            SimpleNamespace(
+                line_id=w["line_id"],
+                word_id=w["word_id"],
+                text=w["text"],
+                bounding_box={
+                    "x": w["x"],
+                    "y": w["y_mid"] - 0.01,
+                    "width": 0.1,
+                    "height": 0.02,
+                },
+            )
+            for w in _world_words()
+        ]
+        return SimpleNamespace(
+            lines=[SimpleNamespace(line_id=i) for i in range(1, 8)],
+            words=words,
+        )
+
+    def get_receipt_sections_from_receipt(self, image_id, receipt_id):
+        return self.sections
+
+    def get_receipt_summary(self, image_id, receipt_id):
+        from receipt_dynamo.entities.receipt_summary import (
+            MonetaryTotals,
+            ReceiptSummary,
+        )
+        from receipt_dynamo.entities.receipt_summary_record import (
+            ReceiptSummaryRecord,
+        )
+
+        return ReceiptSummaryRecord(
+            summary=ReceiptSummary(
+                image_id=VALID_IMAGE_ID,
+                receipt_id=1,
+                merchant_name="Test Mart",
+                totals=MonetaryTotals(
+                    grand_total=9.72, subtotal=9.00, tax=0.72
+                ),
+                item_count=3,
+            ),
+            timestamp_computed="2026-01-01T00:00:00+00:00",
+        )
+
+    def update_receipt_section(self, section):
+        self.updated_sections.append(section)
+
+    def update_receipt_summary(self, record):
+        self.updated_summaries.append(record)
+
+
+def _entity_sections():
+    from receipt_dynamo.entities.receipt_section import ReceiptSection
+
+    def sec(section_type, line_ids):
+        return ReceiptSection(
+            receipt_id=1,
+            image_id=VALID_IMAGE_ID,
+            section_type=section_type,
+            line_ids=line_ids,
+            created_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            model_source="section-seed-v0",
+            validation_status="VALID",
+        )
+
+    return [sec("ITEMS", [1, 2]), sec("SUMMARY", [7])]
+
+
+def test_discovered_extension_passes_the_arithmetic_guard():
+    pytest.importorskip("receipt_dynamo")
+    pytest.importorskip("receipt_upload")
+    _install_mcp_stubs()
+    from scripts.extend_items_zone_gaps import _load_extend_impl
+
+    cands = discover_candidates(
+        _world_words(), _world_sections(), _SUMMARY, _ROWS, n_items=2
+    )
+    added = propose_extension(cands, 4.00, 9.00)
+    assert added == [3]
+
+    client = _StubDynamoClient(_entity_sections())
+    verdict = asyncio.run(
+        _load_extend_impl()(client, VALID_IMAGE_ID, 1, added)
+    )
+    assert "error" not in verdict
+    assert verdict["verified"] is True
+    assert verdict["before"]["status"] == "mismatch"
+    assert verdict["after"]["status"] == "match"
+    assert client.updated_sections == []  # dry run never writes
+
+
+def test_guard_refuses_a_forced_bad_extension():
+    # Lines the discovery vetoes would ALSO be refused by the guard
+    # (defense in depth): absorbing OFFCOL (4.00) + MYSTERY (9.00)
+    # lifts the item sum to 18.00 vs baseline 9.00 — |delta| grows, so
+    # the extension must be refused.
+    pytest.importorskip("receipt_dynamo")
+    pytest.importorskip("receipt_upload")
+    _install_mcp_stubs()
+    from scripts.extend_items_zone_gaps import _load_extend_impl
+
+    client = _StubDynamoClient(_entity_sections())
+    verdict = asyncio.run(
+        _load_extend_impl()(client, VALID_IMAGE_ID, 1, [5, 6])
+    )
+    assert verdict.get("verified") is not True
+    assert client.updated_sections == []


### PR DESCRIPTION
## What

Implements PLAN.md NOW-item 3: reconciliation-guided ITEMS boundary extension for zone-gap receipts.

This PR now has both delivery paths:

- `scripts/extend_items_zone_gaps.py` discovers and applies guarded repairs in a dev-only backfill (dry-run by default; hard prod refusal; pre-image journal).
- `infra/receipt_line_item_updater/line_item_processor.py` runs the repair automatically before canonical line-item regeneration, so future summary-driven recomputes do not require a manual pass.
- `receipt_upload.line_items.geometry` owns the shared evaluator, strict arithmetic guard, adjacent-row discovery, and deterministic proposal selection.
- `scripts/receipt_mcp_server.py` imports that shared evaluator/guard instead of maintaining a fork.

## Guard and safety

An extension is accepted only when both conditions hold:

1. `abs(after_delta) < abs(before_delta)` (strict), and
2. reconciliation status improves (`mismatch -> near/match` or `near -> match`).

Discovery uses structural receipt evidence (unclaimed priced rows in or adjacent to the ITEMS span, price-column alignment in the backfill, and canonical settlement/note exclusions). No error-fitted acceptance threshold was added; arithmetic remains the verifier.

Additional invariants:

- rows owned by another section are never absorbed;
- settlement/summary/payment rows terminate discovery or are rejected;
- row-anchored sections remain unions of complete `ReceiptRow`s;
- existing `validation_status` and verifier provenance are preserved (a `VALID` section is never demoted);
- automatic extensions are stamped with the `+zone-gap-extend-v1` model-source suffix;
- prod writes are refused by the backfill, and no prod writes were made.

## Corpus gate — dev `ReceiptsTable-dc5be22`

AWS identity was verified before the sweep. All corpus comparisons recomputed the canonical decoder live rather than trusting stale stored rows.

The dev backfill applied 23 guard-passed extensions (11 mismatch->match, 7 mismatch->near, 5 near->match). A subsequent in-memory sweep of the automatic pass found the remaining 15 status improvements (14 mismatch->match, 1 mismatch->near). Combined result over the 680-receipt extraction population:

| status | before | after | delta |
|---|---:|---:|---:|
| match | 454 | 484 | **+30** |
| near | 38 | 41 | +3 |
| mismatch | 122 | 89 | -33 |
| no-baseline | 66 | 66 | 0 |

Per-receipt flip check: **zero previously matching receipts lost**. The automatic residual sweep itself was `470 -> 484` matches (`+14`) with zero losses; the earlier guarded backfill contributes the other 16 match gains. This separation is recorded because the dev table changed during the session.

### Per-merchant match counts

| merchant | before | after | delta |
|---|---:|---:|---:|
| Sprouts Farmers Market | 140 | 149 | **+9** |
| Vons | 17 | 20 | **+3** |
| Target | 21 | 24 | **+3** |
| 7 ELEVEN | 0 | 1 | +1 |
| AIM Mail Center | 0 | 1 | +1 |
| Corner Bakery Cafe #207 | 0 | 1 | +1 |
| Costco Wholesale | 26 | 27 | +1 |
| DIY Home Center | 2 | 3 | +1 |
| East Coast Bagel Co. | 5 | 6 | +1 |
| Gelson's Westlake Village | 3 | 4 | +1 |
| Harbor Freight | 1 | 2 | +1 |
| In-N-Out Burger | 14 | 15 | +1 |
| Kruse + Company Bicycles | 0 | 1 | +1 |
| ROCCO'S NY PIZZERIA AND | 0 | 1 | +1 |
| The Home Depot | 3 | 4 | +1 |
| Urbane Cafe | 1 | 2 | +1 |
| Walmart Supercenter | 0 | 1 | +1 |
| Whole Foods Market | 2 | 3 | +1 |
| Smith's aliases (combined) | 5 | 5 | 0 |

Smith's did move at status level (`mismatch -> near`) but not into the match column; Gelson's moved `+1` match. This is consistent with the remaining Smith's OCR/value defects after its zone gap was filled.

## Tests and formatting

Fresh venv setup used the requested editable installs:

```text
pip install --no-deps -e receipt_upload -e receipt_dynamo
```

Current combined branch:

- 94 targeted tests passed: golden regression, geometry, reconstructor, shared MCP guard, automatic Lambda extension, and backfill discovery tests.
- Golden floors were not changed.
- The earlier full backfill commit also recorded `receipt_upload/tests`: 511 passed, 13 skipped; repository tests: 653 passed, 1 skipped.
- Black and isort (`--profile=black --line-length=79`) pass. Infra imports retain one protected first-party block per warning #6.
- Python compilation and `git diff --check` pass.

## Dev apply audit

The guarded backfill touched dev only. It wrote 23 section extensions and summary timestamp refreshes; backups/journals were created by the script before writes. Production was untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved receipt line-item extraction by extending ITEMS boundaries when adjacent product rows are safely identified.
  * Extensions are validated against receipt totals and exclude settlement, summary, and unrelated rows.
  * Added safeguards, dry-run support, backups, journaling, status reporting, and receipt filtering for repair operations.
  * Preserved validation status and recorded extension details when boundaries are updated.

* **Bug Fixes**
  * Improved reconciliation for receipts where product rows fall just outside the detected ITEMS section.
  * Prevented boundary changes that worsen or fail to resolve total mismatches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->