### PR TITLE
fix(line-items): agentic writer honors freeze markers, re-checked before every write

### DIFF
--- a/docs/line-items/agentic-review/OPERATING_MODEL.md
+++ b/docs/line-items/agentic-review/OPERATING_MODEL.md
@@ -85,6 +85,12 @@ disagreement freezes that tier/class: a marker file in
 `.dev-harness/freeze/<tier-or-class>` demotes the frozen class to T2 in
 every subsequent adjudication run until the marker is removed, and
 auto-verdicts of that class since the last clean audit are re-queued.
+The writer independently re-reads the freeze dir before every single
+write (so a marker landing mid-session stops the remaining entries of
+that class immediately), and regardless of that check, re-running the
+adjudicator after any audit disagreement — before any further writer
+run — is the standing process; the writer-side check is defense in
+depth, not a substitute.
 
 ## Failure containment
 

--- a/scripts/agentic_writer.py
+++ b/scripts/agentic_writer.py
@@ -24,7 +24,11 @@ report, and exits nonzero. Never a retry.
 
 Safety rails: ``--dry-run`` is the default (``--apply`` required for
 writes); a lockfile in `.dev-harness/writer.lock` enforces single
-flight; the prod table (d7ff76a) is refused outright.
+flight; the prod table (d7ff76a) is refused outright; and freeze
+markers in `.dev-harness/freeze/` (tier names or A-J mode-class
+letters, same semantics as the adjudicator's) are honored here too —
+re-read before EVERY write, so an audit-deck disagreement landing
+mid-session stops the remaining entries of that class immediately.
 
 Duplicate retirement (destructive; T2 sign-off required):
 
@@ -58,6 +62,7 @@ HARNESS_DIR = REPO_ROOT / ".dev-harness"
 DEFAULT_VERDICTS_DIR = HARNESS_DIR / "verdicts"
 DEFAULT_APPROVALS_DIR = HARNESS_DIR / "approvals"
 DEFAULT_BACKUP_DIR = HARNESS_DIR / "backups"
+DEFAULT_FREEZE_DIR = HARNESS_DIR / "freeze"
 DEFAULT_LOCK_PATH = HARNESS_DIR / "writer.lock"
 
 DEV_TABLE = "ReceiptsTable-dc5be22"
@@ -130,12 +135,10 @@ class WriterLock:
             pass
 
 
-def _load_helpers():
-    """Load scripts/agentic_triage_helpers.py (shares the MCP loader)."""
-    name = "_agentic_writer_helpers"
+def _load_by_path(name: str, filename: str):
     if name in sys.modules:
         return sys.modules[name]
-    path = REPO_ROOT / "scripts" / "agentic_triage_helpers.py"
+    path = REPO_ROOT / "scripts" / filename
     spec = importlib.util.spec_from_file_location(name, path)
     if spec is None or spec.loader is None:
         raise ImportError(f"cannot load {path}")
@@ -143,6 +146,38 @@ def _load_helpers():
     sys.modules[name] = module
     spec.loader.exec_module(module)
     return module
+
+
+def _load_helpers():
+    """Load scripts/agentic_triage_helpers.py (shares the MCP loader)."""
+    return _load_by_path(
+        "_agentic_writer_helpers", "agentic_triage_helpers.py"
+    )
+
+
+def _load_adjudicator():
+    """Load scripts/agentic_adjudicate.py for its freeze semantics.
+
+    ``load_frozen`` (marker names in the freeze dir: tier names or A-J
+    class letters) and ``mode_class`` are imported, never mirrored, so
+    the writer and the adjudicator can never disagree about what a
+    freeze means.
+    """
+    return _load_by_path(
+        "_agentic_writer_adjudicator", "agentic_adjudicate.py"
+    )
+
+
+def _frozen_marker(entry: dict[str, Any], frozen: set[str]) -> Optional[str]:
+    """The freeze marker hitting this entry's tier or mode class."""
+    if not frozen:
+        return None
+    adjudicator = _load_adjudicator()
+    cls = adjudicator.mode_class(entry)
+    return next(
+        (name for name in (entry.get("tier"), cls) if name in frozen),
+        None,
+    )
 
 
 def _run(coro):
@@ -177,16 +212,22 @@ def load_approvals(path: Path) -> dict[str, Any]:
 
 
 def select_applicable(
-    entries: list[dict[str, Any]], approvals: dict[str, Any]
+    entries: list[dict[str, Any]],
+    approvals: dict[str, Any],
+    frozen: set[str] = frozenset(),
 ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
     """(to_apply, skipped). T0 always; T1 only when its group is
-    approved; golden never."""
+    approved; golden never; nothing whose tier or mode class carries a
+    freeze marker (an audit disagreement outranks any verdict)."""
     approved_groups = set(approvals.get("approved_groups") or [])
     to_apply, skipped = [], []
     for entry in entries:
         proposal = entry.get("proposal") or {}
         reason = None
-        if entry.get("golden"):
+        marker = _frozen_marker(entry, frozen)
+        if marker is not None:
+            reason = f"frozen:{marker}"
+        elif entry.get("golden"):
             reason = "golden-never-auto-applied"
         elif entry.get("tier") == "T0":
             pass
@@ -370,6 +411,7 @@ def run_apply(
     apply: bool,
     verdicts_dir: Path = DEFAULT_VERDICTS_DIR,
     approvals_dir: Path = DEFAULT_APPROVALS_DIR,
+    freeze_dir: Path = DEFAULT_FREEZE_DIR,
     lock_path: Path = DEFAULT_LOCK_PATH,
     poll_attempts: int = DEFAULT_POLL_ATTEMPTS,
     poll_interval: float = DEFAULT_POLL_INTERVAL,
@@ -382,11 +424,26 @@ def run_apply(
         return 1
     entries = load_verdicts(verdicts_path)
     approvals = load_approvals(Path(approvals_dir) / f"{pass_id}.json")
-    to_apply, skipped = select_applicable(entries, approvals)
+    adjudicator = _load_adjudicator()
+    to_apply, skipped = select_applicable(
+        entries, approvals, frozen=adjudicator.load_frozen(Path(freeze_dir))
+    )
 
     applied_records: list[dict[str, Any]] = []
+    processed = 0
     with WriterLock(lock_path):
         for entry in to_apply:
+            processed += 1
+            # Re-read the freeze dir before EVERY write: an audit deck
+            # disagreement mid-session must stop the writer from
+            # applying the very class the audit just condemned, not
+            # merely the adjudicator's next run.
+            marker = _frozen_marker(
+                entry, adjudicator.load_frozen(Path(freeze_dir))
+            )
+            if marker is not None:
+                skipped.append({**entry, "skip_reason": f"frozen:{marker}"})
+                continue
             try:
                 applied_records.append(
                     apply_one(
@@ -410,7 +467,7 @@ def run_apply(
                             "image_id": e.get("image_id"),
                             "receipt_id": e.get("receipt_id"),
                         }
-                        for e in to_apply[len(applied_records) + 1 :]
+                        for e in to_apply[processed:]
                     ],
                 }
                 path = _write_divergence_report(
@@ -621,6 +678,13 @@ def main(argv: Optional[list[str]] = None) -> int:
         "--approvals-dir", type=Path, default=DEFAULT_APPROVALS_DIR
     )
     p_apply.add_argument(
+        "--freeze-dir",
+        type=Path,
+        default=DEFAULT_FREEZE_DIR,
+        help="freeze markers (tier names or A-J class letters); "
+        "re-checked before every write",
+    )
+    p_apply.add_argument(
         "--poll-attempts", type=int, default=DEFAULT_POLL_ATTEMPTS
     )
     p_apply.add_argument(
@@ -662,6 +726,7 @@ def main(argv: Optional[list[str]] = None) -> int:
                 apply=args.apply,
                 verdicts_dir=args.verdicts_dir,
                 approvals_dir=args.approvals_dir,
+                freeze_dir=args.freeze_dir,
                 poll_attempts=args.poll_attempts,
                 poll_interval=args.poll_interval,
             )

--- a/tests/test_agentic_writer.py
+++ b/tests/test_agentic_writer.py
@@ -222,12 +222,20 @@ def _run(tmp_path, world, entries, approvals=None, apply=True, **kwargs):
         apply=apply,
         verdicts_dir=verdicts_dir,
         approvals_dir=approvals_dir,
+        freeze_dir=kwargs.pop("freeze_dir", tmp_path / "freeze"),
         lock_path=tmp_path / "writer.lock",
         poll_attempts=kwargs.pop("poll_attempts", 3),
         poll_interval=0.0,
         sleep=lambda _s: None,
         **kwargs,
     )
+
+
+def _freeze(tmp_path, marker):
+    freeze_dir = tmp_path / "freeze"
+    freeze_dir.mkdir(exist_ok=True)
+    (freeze_dir / marker).write_text("audit disagreement")
+    return freeze_dir
 
 
 # --------------------------------------------------------------------------
@@ -433,6 +441,76 @@ def test_t2_never_applied(tmp_path, capsys):
     assert world.summary_updates == []
     summary = json.loads(capsys.readouterr().out)
     assert summary["skipped"][0]["skip_reason"] == "tier-T2-not-writable"
+
+
+# --------------------------------------------------------------------------
+# Freeze markers: the writer honors them too, re-checked before every
+# write (a mid-session audit freeze must stop the writer immediately,
+# not merely the adjudicator's next run).
+# --------------------------------------------------------------------------
+
+
+def test_frozen_tier_skips_t0_entry(tmp_path, capsys):
+    _freeze(tmp_path, "T0")
+    world = MutableWorld()
+    rc = _run(tmp_path, world, [_verdict()])
+    assert rc == 0
+    assert world.summary_updates == []
+    assert world.section_updates == []
+    summary = json.loads(capsys.readouterr().out)
+    assert summary["applied"] == []
+    assert summary["skipped"][0]["skip_reason"] == "frozen:T0"
+
+
+def test_frozen_mode_class_skips_entry(tmp_path, capsys):
+    _freeze(tmp_path, "H")  # _verdict() mode is H-clean-extension
+    world = MutableWorld()
+    rc = _run(tmp_path, world, [_verdict()])
+    assert rc == 0
+    assert world.summary_updates == []
+    summary = json.loads(capsys.readouterr().out)
+    assert summary["skipped"][0]["skip_reason"] == "frozen:H"
+
+
+def test_unrelated_freeze_does_not_block(tmp_path, capsys):
+    _freeze(tmp_path, "B")  # different mode class entirely
+    world = MutableWorld()
+    rc = _run(tmp_path, world, [_verdict()])
+    assert rc == 0
+    summary = json.loads(capsys.readouterr().out)
+    assert summary["applied"][0]["confirmed"] is True
+
+
+class _FreezeMidRunWorld(MutableWorld):
+    """The audit deck writes a freeze marker while the writer runs.
+
+    ``update_receipt_summary`` is the last write of the guarded apply,
+    so dropping the marker there lands it exactly between entry #1's
+    apply and entry #2's — the writer must re-check per receipt and
+    skip #2.
+    """
+
+    def __init__(self, tmp_path):
+        super().__init__()
+        self._tmp_path = tmp_path
+
+    def update_receipt_summary(self, record):
+        super().update_receipt_summary(record)
+        _freeze(self._tmp_path, "T0")
+
+
+def test_freeze_appearing_mid_run_stops_later_entries(tmp_path, capsys):
+    world = _FreezeMidRunWorld(tmp_path)
+    # Two identical T0 verdicts: without the per-receipt re-check the
+    # second would reach the guard (and diverge); with it, the freeze
+    # written during the first apply skips the second cleanly.
+    rc = _run(tmp_path, world, [_verdict(), _verdict()])
+    assert rc == 0
+    summary = json.loads(capsys.readouterr().out)
+    assert len(summary["applied"]) == 1
+    assert summary["applied"][0]["confirmed"] is True
+    assert summary["skipped"][0]["skip_reason"] == "frozen:T0"
+    assert len(world.summary_updates) == 1
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
Closes the safety gap found in #1331: `agentic_writer.py` never read `.dev-harness/freeze/`, so an audit-deck freeze written mid-session could not stop the writer from applying the very entries the audit just condemned — only the adjudicator's next run honored it.

## Changes

| Layer | Change |
|---|---|
| Code | `select_applicable` now takes the frozen set and skips any entry whose **tier or A–J mode class** carries a marker, logged `frozen:<marker>`. Freeze semantics are imported from `agentic_adjudicate.py` (`load_frozen` / `mode_class`) by path — never mirrored — so the two layers cannot disagree. `run_apply` additionally **re-reads the freeze dir before every single write**, so a marker landing between load and apply stops the remaining entries of that class immediately. New `--freeze-dir` arg (default `.dev-harness/freeze`). |
| Docs | `OPERATING_MODEL.md`: re-running the adjudicator after any audit disagreement is the standing process regardless; the writer-side check is defense in depth, not a substitute. |

## Tests (+4, writer suite now 19, all green)

- T0 entry skipped when `freeze/T0` present (nothing written)
- H-mode entry skipped when `freeze/H` present
- Unrelated freeze (`freeze/B`) does not block an H entry
- Freeze appearing **between load and apply**: a marker written during entry #1's apply causes entry #2 to be skipped via the per-receipt re-check

black/isort (`--profile=black --line-length=79`) clean; AST-parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)