### PR TITLE
Expand Dependabot coverage across the repository

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,10 @@
 version: 2
+
 updates:
-  # Enable version updates for npm (JavaScript/TypeScript)
+  # Monitor every current and future npm manifest in the repository.
   - package-ecosystem: "npm"
-    directory: "/portfolio"
+    directories:
+      - "**/*"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 3
@@ -13,59 +15,34 @@ updates:
       prefix: "chore"
       include: "scope"
 
-  # Enable version updates for pip (Python)
+  # Monitor every current and future Python dependency manifest.
   - package-ecosystem: "pip"
-    directory: "/infra"
+    directories:
+      - "**/*"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 6
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
+  # Monitor base-image tags in Dockerfiles throughout the repository.
+  - package-ecosystem: "docker"
+    directories:
+      - "**/*"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 3
     labels:
       - "dependencies"
-      - "python"
+      - "component: infra"
     commit-message:
       prefix: "chore"
       include: "scope"
 
-  # Enable version updates for pip (Python) - receipt_layoutlm
-  - package-ecosystem: "pip"
-    directory: "/receipt_layoutlm"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 3
-    labels:
-      - "dependencies"
-      - "python"
-    commit-message:
-      prefix: "chore"
-      include: "scope"
-
-  # Enable version updates for pip (Python) - receipt_dynamo
-  - package-ecosystem: "pip"
-    directory: "/receipt_dynamo"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 3
-    labels:
-      - "dependencies"
-      - "python"
-    commit-message:
-      prefix: "chore"
-      include: "scope"
-
-  # Enable version updates for pip (Python) - receipt_upload
-  - package-ecosystem: "pip"
-    directory: "/receipt_upload"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 3
-    labels:
-      - "dependencies"
-      - "python"
-    commit-message:
-      prefix: "chore"
-      include: "scope"
-
-  # Enable version updates for GitHub Actions
+  # Monitor actions and reusable workflows under .github/workflows.
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -73,8 +50,6 @@ updates:
     open-pull-requests-limit: 2
     labels:
       - "dependencies"
-      - "github-actions"
     commit-message:
       prefix: "ci"
       include: "scope"
-


### PR DESCRIPTION
## Summary

- scan npm and pip manifests recursively across the repository
- add recursive Docker base-image monitoring
- retain GitHub Actions monitoring and existing schedules
- remove labels that do not exist in the repository
- cap concurrent update PRs per ecosystem to keep review volume manageable

## Why

The previous configuration covered only `/portfolio` and four Python directories, leaving several application packages, tools, nested infrastructure manifests, and Dockerfiles unmonitored. Recursive directory patterns cover the current monorepo and automatically include future manifests.

## Validation

- parsed `.github/dependabot.yml` as YAML
- asserted the expected npm, pip, Docker, and GitHub Actions update entries
- verified recursive coverage is configured for npm, pip, and Docker
- ran `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated dependency update monitoring across npm, pip, Docker, and GitHub Actions configuration files.
  * Consolidated Python dependency tracking and increased the allowed number of dependency update pull requests.
  * Added infrastructure labeling for Docker-related updates and removed outdated labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->