### PR TITLE
fix(line-items): writer confirm loop — stale-stream vs true divergence (112ed08b root cause)

### DIFF
--- a/scripts/agentic_writer.py
+++ b/scripts/agentic_writer.py
@@ -70,7 +70,9 @@ PROD_TABLE_FRAGMENT = "d7ff76a"  # hard refusal; this loop is dev-only
 PROVENANCE_SUFFIX = "agentic-vision-v1"
 DELTA_CONFIRM_TOLERANCE = 0.005
 
-DEFAULT_POLL_ATTEMPTS = 10
+# pass-20260803 measured ~33s from summary bump to the stream stage's
+# recompute landing (SQS batching); 10 x 3s lost that race by 3 seconds.
+DEFAULT_POLL_ATTEMPTS = 30
 DEFAULT_POLL_INTERVAL = 3.0
 
 
@@ -358,7 +360,22 @@ def apply_one(
     # The apply bumped the summary timestamp; the stream stage now
     # regenerates the line items. Wait for it, then CONFIRM the delta
     # landed exactly as the dry run predicted.
+    #
+    # Three observable states, learned from the pass-20260803 halt on
+    # 112ed08b (stream latency ~33s beat the old 30s window by 3s):
+    #   observed == predicted  -> confirmed.
+    #   observed == before     -> the stream has NOT landed yet (stored
+    #                             rows are still the pre-apply ones);
+    #                             keep polling, this refutes nothing.
+    #   anything else          -> the world moved somewhere the dry run
+    #                             did not predict: a TRUE divergence,
+    #                             halt immediately (no point waiting).
+    # Exhausting the window while still stale is reported as
+    # confirmation-timeout, not delta-divergence — the prediction was
+    # never refuted, the stream was just slower than the window.
     predicted_delta = predicted.get("delta")
+    before_delta = (dry.get("before") or {}).get("delta")
+    record["before_delta"] = before_delta
     observed_delta = None
     for attempt in range(poll_attempts):
         if attempt:
@@ -377,14 +394,35 @@ def apply_one(
             record["confirmed"] = True
             record["observed_delta"] = observed_delta
             return record
+        stale = observed_delta is None or (
+            before_delta is not None
+            and abs(observed_delta - before_delta) < DELTA_CONFIRM_TOLERANCE
+        )
+        if not stale:
+            raise DivergenceError(
+                "post-apply delta diverged from the dry-run prediction",
+                {
+                    **where,
+                    "kind": "delta-divergence",
+                    "add_line_ids": add_line_ids,
+                    "predicted_delta": predicted_delta,
+                    "before_delta": before_delta,
+                    "observed_delta": observed_delta,
+                    "poll_attempts": attempt + 1,
+                },
+            )
 
     raise DivergenceError(
-        "post-apply delta diverged from the dry-run prediction",
+        "stream regeneration did not land inside the poll window "
+        "(stored deltas are still pre-apply; the prediction was not "
+        "refuted — widen --poll-attempts/--poll-interval or re-check "
+        "this receipt before re-running)",
         {
             **where,
-            "kind": "delta-divergence",
+            "kind": "confirmation-timeout",
             "add_line_ids": add_line_ids,
             "predicted_delta": predicted_delta,
+            "before_delta": before_delta,
             "observed_delta": observed_delta,
             "poll_attempts": poll_attempts,
         },

--- a/tests/test_agentic_writer.py
+++ b/tests/test_agentic_writer.py
@@ -282,11 +282,15 @@ def test_dry_run_default_writes_nothing(tmp_path, capsys):
 
 
 # --------------------------------------------------------------------------
-# Halt on divergence
+# Halt on divergence / confirmation timing (pass-20260803 lessons)
 # --------------------------------------------------------------------------
 
 
-def test_halt_on_divergence_when_delta_never_lands(tmp_path, capsys):
+def test_halt_reports_timeout_when_stream_never_lands(tmp_path, capsys):
+    # Observed delta stays at the PRE-APPLY value: the stream simply
+    # has not landed, which refutes nothing — the halt must say
+    # confirmation-timeout, not delta-divergence (the 112ed08b
+    # misattribution).
     world = MutableWorld(stream_works=False)  # stream never regenerates
     rc = _run(tmp_path, world, [_verdict()])
     assert rc == 2
@@ -294,10 +298,75 @@ def test_halt_on_divergence_when_delta_never_lands(tmp_path, capsys):
     report_path = tmp_path / "verdicts" / "p1.divergence.json"
     assert report_path.exists()
     report = json.loads(report_path.read_text())
-    assert report["divergence"]["kind"] == "delta-divergence"
+    assert report["divergence"]["kind"] == "confirmation-timeout"
     assert report["divergence"]["predicted_delta"] == 0.0
+    assert report["divergence"]["before_delta"] == -4.0
     assert report["divergence"]["observed_delta"] == -4.0
     assert not (tmp_path / "writer.lock").exists()
+
+
+class _DelayedStreamWorld(MutableWorld):
+    """Stream regeneration lands only after ``lag_reads`` re-reads.
+
+    Models the pass-20260803 reality: ~33s of stream/SQS latency
+    between the summary bump and the recompute landing, during which
+    the stored rows still show the pre-apply delta.
+    """
+
+    def __init__(self, lag_reads):
+        super().__init__(stream_works=False)
+        self.lag_reads = lag_reads
+        self._reads_since_apply = None
+
+    def update_receipt_summary(self, record):
+        super().update_receipt_summary(record)
+        self._reads_since_apply = 0
+
+    def get_receipt_line_items_from_receipt(self, image_id, receipt_id):
+        if self._reads_since_apply is not None:
+            self._reads_since_apply += 1
+            if self._reads_since_apply > self.lag_reads:
+                items_section = next(
+                    s for s in self.sections if s.section_type == "ITEMS"
+                )
+                self.line_items = self._items_for(items_section.line_ids)
+        return self.line_items
+
+
+def test_late_stream_still_confirms_within_window(tmp_path, capsys):
+    # 112ed08b regression: while observed == pre-apply delta the writer
+    # must keep polling, and a stream landing late (but inside the
+    # window) is a clean confirmation, not a halt.
+    world = _DelayedStreamWorld(lag_reads=3)
+    rc = _run(tmp_path, world, [_verdict()], poll_attempts=6)
+    assert rc == 0
+    summary = json.loads(capsys.readouterr().out)
+    assert summary["applied"][0]["confirmed"] is True
+    assert summary["applied"][0]["observed_delta"] == 0.0
+
+
+class _WrongRegenWorld(MutableWorld):
+    """Stream lands on a delta that is neither before nor predicted."""
+
+    def update_receipt_summary(self, record):
+        self.summary_updates.append(record)
+        # Regenerate to APPLES only: delta -6.00 (before was -4.00,
+        # predicted 0.0) — a true divergence.
+        self.line_items = self._items_for([1])
+
+
+def test_true_divergence_halts_immediately(tmp_path):
+    world = _WrongRegenWorld()
+    rc = _run(tmp_path, world, [_verdict()], poll_attempts=10)
+    assert rc == 2
+    report = json.loads(
+        (tmp_path / "verdicts" / "p1.divergence.json").read_text()
+    )
+    assert report["divergence"]["kind"] == "delta-divergence"
+    assert report["divergence"]["observed_delta"] == -6.0
+    assert report["divergence"]["before_delta"] == -4.0
+    # Fail-fast: a genuinely wrong delta must not wait out the window.
+    assert report["divergence"]["poll_attempts"] == 1
 
 
 def test_halt_when_guard_refuses_at_write_time(tmp_path):
@@ -654,3 +723,167 @@ def test_retire_dry_run_backs_up_but_does_not_delete(tmp_path, capsys):
     assert world.deleted == []
     out = json.loads(capsys.readouterr().out)
     assert out["retired"][0]["deletion"]["dry_run"] is True
+
+
+# --------------------------------------------------------------------------
+# Simulator fidelity: 112ed08b (Sprouts) shape. OCR split each visual
+# item row into a name-only line and a price-only line (15/34, 16/35,
+# 17/36); the section is row-anchored, so extending with the two name
+# lines widens to their price lines (+9.98). The dry-run prediction
+# must equal a Lambda-style recompute (line_item_processor's exact
+# word/summary construction) over the section as stored post-apply.
+# --------------------------------------------------------------------------
+
+
+class _SproutsWorld:
+    """Row-anchored stub shaped like dev receipt 112ed08b r1."""
+
+    LINES = {
+        15: ("ORG SWT POTATO 3LB", 0.10),
+        34: ("4.99", 0.10),
+        16: ("SEEDLESS LEMONS BAG", 0.15),
+        35: ("4.99", 0.15),
+        17: ("SHALLOTS", 0.20),
+        36: ("0.84", 0.20),
+    }
+
+    def __init__(self):
+        from receipt_dynamo.entities.receipt_section import ReceiptSection
+
+        self.words = [
+            _word(lid, 1, text, 0.80 if text[0].isdigit() else 0.05, y)
+            for lid, (text, y) in self.LINES.items()
+        ]
+        self.sections = [
+            ReceiptSection(
+                receipt_id=1,
+                image_id=IMAGE_ID,
+                section_type="ITEMS",
+                line_ids=[17, 36],
+                created_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+                model_source="section-seed-v0",
+                validation_status="VALID",
+                row_ids=[17],
+            )
+        ]
+        self.rows = [
+            SimpleNamespace(row_id=15, line_ids=[15, 34]),
+            SimpleNamespace(row_id=16, line_ids=[16, 35]),
+            SimpleNamespace(row_id=17, line_ids=[17, 36]),
+        ]
+        self.summary_updates = []
+
+    def get_receipt_details(self, image_id, receipt_id):
+        return SimpleNamespace(
+            lines=[SimpleNamespace(line_id=i) for i in self.LINES],
+            words=self.words,
+        )
+
+    def get_receipt_sections_from_receipt(self, image_id, receipt_id):
+        return self.sections
+
+    def get_receipt_rows_from_receipt(self, image_id, receipt_id):
+        return self.rows
+
+    def get_receipt_summary(self, image_id, receipt_id):
+        from receipt_dynamo.entities.receipt_summary import (
+            MonetaryTotals,
+            ReceiptSummary,
+        )
+        from receipt_dynamo.entities.receipt_summary_record import (
+            ReceiptSummaryRecord,
+        )
+
+        return ReceiptSummaryRecord(
+            summary=ReceiptSummary(
+                image_id=IMAGE_ID,
+                receipt_id=1,
+                merchant_name="Sprouts Farmers Market",
+                totals=MonetaryTotals(
+                    grand_total=10.82, subtotal=None, tax=None
+                ),
+                item_count=3,
+            ),
+            timestamp_computed="2026-01-01T00:00:00+00:00",
+        )
+
+    def update_receipt_section(self, section):
+        self.sections = [
+            section if s.section_type == "ITEMS" else s for s in self.sections
+        ]
+
+    def update_receipt_summary(self, record):
+        self.summary_updates.append(record)
+
+
+def test_sprouts_row_widening_prediction_matches_lambda_recompute():
+    from receipt_upload.line_items.geometry import (
+        extract_items,
+        reconcile_detailed,
+    )
+
+    world = _SproutsWorld()
+
+    dry = writer._run(
+        mcp_server.extend_items_section_impl(
+            world, IMAGE_ID, 1, [15, 16], dry_run=True
+        )
+    )
+    assert dry.get("verified") is True, dry
+    # The 112ed08b shape: adding the two NAME lines widens (via the row
+    # anchor) to their price lines, moving -9.98 -> 0.0.
+    assert dry["before"]["delta"] == -9.98
+    assert dry["after"] == {
+        "status": "match",
+        "items_sum": 10.82,
+        "baseline": 10.82,
+        "delta": 0.0,
+        "n_items": 3,
+        "collapsed_banding": False,
+    }
+    assert set(dry["extended_line_ids"]) == {15, 16, 17, 34, 35, 36}
+
+    applied = writer._run(
+        mcp_server.extend_items_section_impl(
+            world, IMAGE_ID, 1, [15, 16], dry_run=False
+        )
+    )
+    assert applied.get("applied") is True
+
+    # Lambda-style recompute over the section AS STORED, using
+    # line_item_processor.update_receipt_line_items's exact input
+    # construction: word dicts from the word entities and a summary
+    # dict from the inner ReceiptSummary attributes.
+    stored = next(s for s in world.sections if s.section_type == "ITEMS")
+    lambda_words = [
+        {
+            "line_id": w.line_id,
+            "word_id": w.word_id,
+            "text": w.text,
+            "x": w.bounding_box.get("x", 0.0),
+            "y_mid": w.bounding_box.get("y", 0.0)
+            + w.bounding_box.get("height", 0.0) / 2,
+            "h": w.bounding_box.get("height", 0.0),
+        }
+        for w in world.words
+    ]
+    inner = world.get_receipt_summary(IMAGE_ID, 1).summary
+    lambda_summary = {
+        "subtotal": getattr(inner, "subtotal", None),
+        "grand_total": getattr(inner, "grand_total", None),
+        "tax": getattr(inner, "tax", None),
+    }
+    items, _ = extract_items(
+        lambda_words,
+        {int(x) for x in stored.line_ids},
+        summary=lambda_summary,
+    )
+    recon = reconcile_detailed(
+        [i for i in items if not i.get("is_discount")], lambda_summary
+    )
+
+    # Parity: what the stream stage will store equals the prediction.
+    assert recon.status == dry["after"]["status"]
+    assert recon.item_sum == dry["after"]["items_sum"]
+    assert round(recon.item_sum - recon.baseline, 2) == dry["after"]["delta"]
+    assert len(items) == dry["after"]["n_items"]


### PR DESCRIPTION
Root-causes the first live writer halt (pass-20260803, receipt 112ed08b r1, Sprouts). **The simulator-fidelity hypothesis is falsified**: reproduced read-only on dev, the dry-run simulation and a Lambda-style recompute (`line_item_processor.update_receipt_line_items`'s exact word-dict and summary-dict construction) agree bit-for-bit on identical inputs (9 items, 37.36, match, delta 0.0).

## Actual root cause: confirmation timing, not prediction error

CloudWatch (`/aws/lambda/chromadb-dev-line-item-updater-017d2bb`):

| Time (UTC) | Event |
|---|---|
| ~22:42:50 | writer applies [15,16] extension, starts polling |
| 22:43:20 | writer exhausts 10×3s window, halts with observed −9.98 |
| **22:43:23** | updater Lambda for this receipt finally runs (stream/SQS latency ~33s) |

The stored rows the writer re-read were still the **pre-apply** ones (delta −9.98 == the before-delta); the prediction (0.0) was correct, just late — today's stored items are 37.36/match. The halt misattributed staleness as `delta-divergence`.

## Fix (scripts/agentic_writer.py)

Confirm loop now recognizes three states: `observed == predicted` → confirmed; `observed == before` (pre-apply) → stream not landed, keep polling; **anything else → true divergence, halt on the spot** (fail fast, no window wait). Window exhaustion while stale reports kind `confirmation-timeout` (prediction never refuted) with before/predicted/observed in the report. Default window widened 10×3s → 30×3s.

## Regression tests (writer suite 22/22 green; full agentic+MCP suites 78 green)

- `test_sprouts_row_widening_prediction_matches_lambda_recompute` — the 112ed08b shape (name-only lines row-anchored to price-only lines; extending 2 name lines widens +9.98 via covering rows to a 0.0 match); asserts dry-run prediction == Lambda-style recompute of the section **as stored post-apply**.
- `test_late_stream_still_confirms_within_window` — stream lands after 3 stale reads → clean confirm.
- `test_true_divergence_halts_immediately` — wrong delta (≠ before, ≠ predicted) halts on poll 1.
- `test_halt_reports_timeout_when_stream_never_lands` — never-landing stream reports `confirmation-timeout`, not `delta-divergence`.

## Re-verification of the 5 unapplied entries (dev, dry-run)

All 5 predictions hold verbatim: `223c03e2 r1` near/−3.23, `5985d2dd r2` match/0.0, `6e58ca91 r2` match/0.0, `909a2b84 r2` match/0.0, `9c788a60 r1` match/0.0 — safe to re-run the writer on this pass after merge.

black/isort clean; AST-parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)