### PR TITLE
fix(line-items): tender rows never anchor printed totals + writer re-run idempotency

### DIFF
--- a/receipt_dynamo/receipt_dynamo/amounts.py
+++ b/receipt_dynamo/receipt_dynamo/amounts.py
@@ -30,6 +30,18 @@ NON_PAYMENT_SUMMARY_RE = re.compile(
     r")\b",
     re.I,
 )
+# Settlement/tender vocabulary that can collide with TOTAL_KEYWORD_RE
+# ("Total Tender", "Amount Tendered", "Cash Total", "Change Due").
+# These rows record how the customer PAID -- tender can include tip and
+# cash-given, change is money returned -- never what the receipt
+# totals, so they must not anchor a printed grand total (Moody Market
+# a8d7ab9f r4: "Total Tender 24.67" = total 21.45 + tips 3.22 outranked
+# the plain "Total 21.45" row). Minimal mirror of the canonical
+# settlement vocabulary in receipt_upload.line_items.geometry
+# .SETTLEMENT_RE; receipt_dynamo sits below receipt_upload in the
+# dependency graph, so the colliding subset is mirrored here rather
+# than imported.
+TENDER_KEYWORD_RE = re.compile(r"\b(tender(?:ed)?|cash|change)\b", re.I)
 # Tokens that turn a "total" row into a non-monetary count/summary row
 # (e.g. "TOTAL NUMBER OF ITEMS SOLD"), which must NOT be read as a
 # grand-total row.

--- a/receipt_dynamo/receipt_dynamo/entities/receipt_summary.py
+++ b/receipt_dynamo/receipt_dynamo/entities/receipt_summary.py
@@ -24,6 +24,8 @@ from receipt_dynamo.amounts import (
     NON_PAYMENT_SUMMARY_RE,
     SUBTOTAL_KEYWORD_RE,
     TAX_KEYWORD_RE,
+    TENDER_KEYWORD_RE,
+    TOTAL_KEYWORD_RE,
     is_grand_total_line,
     looks_like_receipt_amount,
     parse_receipt_amount,
@@ -411,11 +413,46 @@ def _positive_amount(text: str) -> float | None:
 
 
 def _is_summary_noise_line(line_text: str) -> bool:
-    """Return whether a line is a subtotal/tax/non-payment summary row."""
+    """Return whether a line is a subtotal/tax/tender/non-payment row."""
     return bool(
         SUBTOTAL_KEYWORD_RE.search(line_text)
         or TAX_KEYWORD_RE.search(line_text)
         or NON_PAYMENT_SUMMARY_RE.search(line_text)
+        or TENDER_KEYWORD_RE.search(line_text)
+    )
+
+
+def _is_grand_total_anchor(line_text: str) -> bool:
+    """A grand-total anchor row: a total row that is not a tender row.
+
+    Tender/settlement rows ("Total Tender", "Amount Tendered", "Cash",
+    "Change") record how the customer paid -- tender can include tip --
+    so a plain "Total" row must always outrank them. Moody Market
+    (a8d7ab9f r4) printed "Total 21.45" and "Total Tender 24.67"
+    (total + tips); anchoring on the tender row broke reconciliation.
+    """
+    return bool(
+        is_grand_total_line(line_text)
+        and not TENDER_KEYWORD_RE.search(line_text)
+    )
+
+
+def _is_subtotal_anchor(line_text: str) -> bool:
+    """A subtotal anchor row (never a savings/tender variant)."""
+    return bool(
+        SUBTOTAL_KEYWORD_RE.search(line_text)
+        and not NON_PAYMENT_SUMMARY_RE.search(line_text)
+        and not TENDER_KEYWORD_RE.search(line_text)
+    )
+
+
+def _is_subtotal_noise_line(line_text: str) -> bool:
+    """Rows a subtotal anchor must not pair with across the y-band."""
+    return bool(
+        TOTAL_KEYWORD_RE.search(line_text)
+        or TAX_KEYWORD_RE.search(line_text)
+        or NON_PAYMENT_SUMMARY_RE.search(line_text)
+        or TENDER_KEYWORD_RE.search(line_text)
     )
 
 
@@ -431,10 +468,11 @@ def find_printed_grand_total(words: list["ReceiptWord"]) -> float | None:
 
     Strategy:
     1. Find anchor lines whose joined text reads as a grand-total row
-       (shared ``is_grand_total_line`` keywords).
+       (shared ``is_grand_total_line`` keywords) and is not a
+       tender/settlement row (``_is_grand_total_anchor``).
     2. Take amounts printed on the anchor line itself; otherwise pair the
        anchor with amount words on other lines whose y-center falls in
-       the anchor's row band (skipping subtotal/tax/savings rows).
+       the anchor's row band (skipping subtotal/tax/tender/savings rows).
     3. Return the largest anchored amount, mirroring the GRAND_TOTAL
        label handler's largest-value semantics.
 
@@ -444,6 +482,29 @@ def find_printed_grand_total(words: list["ReceiptWord"]) -> float | None:
     Returns:
         The printed grand total, or None when no anchored amount exists.
     """
+    return _find_anchored_amount(
+        words, _is_grand_total_anchor, _is_summary_noise_line
+    )
+
+
+def find_printed_subtotal(words: list["ReceiptWord"]) -> float | None:
+    """Find the printed subtotal from receipt words, without labels.
+
+    Same anchored-row strategy as :func:`find_printed_grand_total`,
+    anchored on subtotal rows and skipping total/tax/tender/savings
+    rows when pairing across the y-band.
+    """
+    return _find_anchored_amount(
+        words, _is_subtotal_anchor, _is_subtotal_noise_line
+    )
+
+
+def _find_anchored_amount(
+    words: list["ReceiptWord"],
+    is_anchor: Callable[[str], bool],
+    is_noise: Callable[[str], bool],
+) -> float | None:
+    """Largest amount printed on (or row-banded with) an anchor line."""
     lines: dict[int, list["ReceiptWord"]] = {}
     for word in words:
         line_id = getattr(word, "line_id", None)
@@ -458,9 +519,7 @@ def find_printed_grand_total(words: list["ReceiptWord"]) -> float | None:
     }
 
     anchor_ids = [
-        line_id
-        for line_id, text in line_texts.items()
-        if is_grand_total_line(text)
+        line_id for line_id, text in line_texts.items() if is_anchor(text)
     ]
     if not anchor_ids:
         return None
@@ -493,7 +552,7 @@ def find_printed_grand_total(words: list["ReceiptWord"]) -> float | None:
         for line_id, line_words in lines.items():
             if line_id == anchor_id:
                 continue
-            if _is_summary_noise_line(line_texts[line_id]):
+            if is_noise(line_texts[line_id]):
                 continue
             for w in line_words:
                 center = _word_y_center(w)
@@ -509,12 +568,15 @@ def find_printed_grand_total(words: list["ReceiptWord"]) -> float | None:
 def _apply_printed_total_fallback(
     totals: MonetaryTotals, words: list["ReceiptWord"]
 ) -> None:
-    """Fill grand_total from the printed total when labels produced none."""
-    if totals.grand_total is not None and totals.grand_total > 0:
-        return
-    printed = find_printed_grand_total(words)
-    if printed is not None:
-        totals.grand_total = printed
+    """Fill grand_total/subtotal from printed rows when labels gave none."""
+    if totals.grand_total is None or totals.grand_total <= 0:
+        printed = find_printed_grand_total(words)
+        if printed is not None:
+            totals.grand_total = printed
+    if totals.subtotal is None or totals.subtotal <= 0:
+        printed = find_printed_subtotal(words)
+        if printed is not None:
+            totals.subtotal = printed
 
 
 # =============================================================================

--- a/receipt_dynamo/tests/unit/test_receipt_summary_printed_total.py
+++ b/receipt_dynamo/tests/unit/test_receipt_summary_printed_total.py
@@ -14,8 +14,11 @@ import pytest
 
 from receipt_dynamo.constants import ValidationStatus
 from receipt_dynamo.entities.receipt_summary import (
+    MonetaryTotals,
     ReceiptSummary,
+    _apply_printed_total_fallback,
     find_printed_grand_total,
+    find_printed_subtotal,
 )
 from receipt_dynamo.entities.receipt_word_label import ReceiptWordLabel
 
@@ -226,3 +229,97 @@ def test_fallback_overrides_zero_label_total():
     )
 
     assert summary.grand_total == 8.49
+
+
+# ---------------------------------------------------------------------------
+# Moody Market a8d7ab9f:4 — tender rows must never anchor the total.
+# Real line texts and y-geometry from dev: the receipt prints
+# "Subtotal 20.00 / Tax 1.45 / Total 21.45 / Tips 3.22 /
+# Total Tender 24.67 / Change 0.00" with labels and amounts as
+# separate per-column OCR lines. The old anchor logic accepted
+# "Total Tender" as a grand-total row and max() picked 24.67
+# (total + tips) over the plain "Total 21.45".
+# ---------------------------------------------------------------------------
+
+
+def _moody_a8d7ab9f_words() -> list[SimpleNamespace]:
+    return [
+        # Item row: "Big Waygu Beef Bowl" / "20.00".
+        _word(19, 1, "Big", 0.5029, x=0.00),
+        _word(19, 2, "Waygu", 0.5029, x=0.08),
+        _word(19, 3, "Beef", 0.5029, x=0.20),
+        _word(19, 4, "Bowl", 0.5029, x=0.30),
+        _word(2, 1, "20.00", 0.4999, x=0.89),
+        # Summary rows: keyword column and amount column are separate
+        # OCR lines paired only by the y-band.
+        _word(20, 1, "Subtotal", 0.4163, x=0.00),
+        _word(4, 1, "20.00", 0.4171, x=0.89),
+        _word(21, 1, "Tax", 0.3888, x=0.00),
+        _word(6, 1, "1.45", 0.3905, x=0.91),
+        _word(22, 1, "Total", 0.3626, x=0.00),
+        _word(8, 1, "21.45", 0.3631, x=0.89),
+        _word(23, 1, "Visa", 0.2797, x=0.00),
+        _word(23, 2, "...3931", 0.2797, x=0.11),
+        _word(10, 1, "21.45", 0.2797, x=0.89),
+        _word(24, 1, "Tips", 0.2253, x=0.00),
+        _word(12, 1, "3.22", 0.2261, x=0.91),
+        _word(25, 1, "Total", 0.1720, x=0.00),
+        _word(25, 2, "Tender", 0.1720, x=0.12),
+        _word(14, 1, "24.67", 0.1720, x=0.89),
+        _word(26, 1, "Change", 0.1439, x=0.00),
+        _word(16, 1, "0.00", 0.1439, x=0.91),
+    ]
+
+
+def test_moody_plain_total_outranks_total_tender():
+    assert find_printed_grand_total(_moody_a8d7ab9f_words()) == 21.45
+
+
+def test_moody_tender_rows_alone_anchor_nothing():
+    # Only the settlement block: no total row at all -> no anchor.
+    words = [
+        _word(24, 1, "Tips", 0.2253, x=0.00),
+        _word(12, 1, "3.22", 0.2261, x=0.91),
+        _word(25, 1, "Total", 0.1720, x=0.00),
+        _word(25, 2, "Tender", 0.1720, x=0.12),
+        _word(14, 1, "24.67", 0.1720, x=0.89),
+        _word(26, 1, "Change", 0.1439, x=0.00),
+        _word(16, 1, "0.00", 0.1439, x=0.91),
+    ]
+    assert find_printed_grand_total(words) is None
+
+
+def test_amount_tendered_and_cash_total_are_not_anchors():
+    words = [
+        _word(1, 1, "AMOUNT", 0.5),
+        _word(1, 2, "TENDERED", 0.5),
+        _word(2, 1, "50.00", 0.5005),
+        _word(3, 1, "CASH", 0.45),
+        _word(3, 2, "TOTAL", 0.45),
+        _word(4, 1, "50.00", 0.4505),
+    ]
+    assert find_printed_grand_total(words) is None
+
+
+def test_moody_printed_subtotal_is_anchored():
+    # The subtotal anchor pairs with the 20.00 in ITS row band, not the
+    # identical 20.00 on the item row (y 0.4999) and not the total.
+    assert find_printed_subtotal(_moody_a8d7ab9f_words()) == 20.00
+
+
+def test_subtotal_anchor_ignores_savings_subtotal():
+    words = [
+        _word(1, 1, "SUBTOTAL", 0.5),
+        _word(1, 2, "SAVINGS", 0.5),
+        _word(2, 1, "5.00", 0.5005),
+    ]
+    assert find_printed_subtotal(words) is None
+
+
+def test_moody_fallback_fills_grand_total_and_subtotal():
+    totals = MonetaryTotals(grand_total=None, subtotal=None, tax=None)
+    _apply_printed_total_fallback(totals, _moody_a8d7ab9f_words())
+    # 21.45 (not the 24.67 tender row); subtotal anchored at 20.00, so
+    # the $20 bowl reconciles against baseline 20.00.
+    assert totals.grand_total == 21.45
+    assert totals.subtotal == 20.00

--- a/scripts/agentic_writer.py
+++ b/scripts/agentic_writer.py
@@ -287,6 +287,77 @@ def _stamp_provenance(client, image_id: str, receipt_id: int) -> str:
     return model_source
 
 
+def _applied_previously(
+    mcp_server, client, entry: dict[str, Any], where: dict[str, Any]
+) -> Optional[dict[str, Any]]:
+    """Skip-record when this entry's extension is already in place.
+
+    A previous (possibly halted) run of the same pass may have applied
+    and confirmed some entries; the guard then refuses them on re-run
+    ("already in the ITEMS section" / "already reconciles"). That is
+    idempotent success, not divergence — IF the current world matches
+    the prediction: the ITEMS section must contain every add_line_id
+    AND the current reconciliation must equal the predicted post-state
+    (delta to the cent; status when both sides carry one). A superset
+    section whose reconciliation does NOT match the prediction is a
+    real halt.
+
+    Returns a skip record ('skip_reason': 'applied-previously'), None
+    when the extension is simply not applied (genuine refusal), or
+    raises DivergenceError for the superset-but-diverged case.
+    """
+    proposal = entry.get("proposal") or {}
+    add = {int(x) for x in proposal.get("add_line_ids") or []}
+    predicted = proposal.get("after") or {}
+    view = _run(
+        mcp_server.get_receipt_line_items_impl(
+            client, where["image_id"], where["receipt_id"]
+        )
+    )
+    current = {int(x) for x in view.get("items_section_line_ids") or []}
+    if not add or not add <= current:
+        return None  # not previously applied; the refusal stands
+
+    predicted_delta = predicted.get("delta")
+    predicted_status = predicted.get("status")
+    observed_delta = view.get("delta")
+    observed_status = view.get("reconciliation_status")
+    delta_ok = (
+        observed_delta is not None
+        and predicted_delta is not None
+        and abs(observed_delta - predicted_delta) < DELTA_CONFIRM_TOLERANCE
+    )
+    status_ok = (
+        observed_status is None
+        or predicted_status is None
+        or observed_status == predicted_status
+    )
+    if delta_ok and status_ok:
+        return {
+            **where,
+            "add_line_ids": sorted(add),
+            "skip_reason": "applied-previously",
+            "predicted_status": predicted_status,
+            "predicted_delta": predicted_delta,
+            "observed_delta": observed_delta,
+            "applied": False,
+            "confirmed": True,
+        }
+    raise DivergenceError(
+        "section already contains the extension but reconciliation "
+        "does not match the prediction",
+        {
+            **where,
+            "kind": "applied-previously-diverged",
+            "add_line_ids": sorted(add),
+            "predicted_status": predicted_status,
+            "predicted_delta": predicted_delta,
+            "observed_status": observed_status,
+            "observed_delta": observed_delta,
+        },
+    )
+
+
 def apply_one(
     mcp_server,
     client,
@@ -313,6 +384,13 @@ def apply_one(
         )
     )
     if dry.get("error") or not dry.get("verified"):
+        # Re-run idempotency (pass-20260803 lesson): a refusal on a
+        # receipt this pass ALREADY applied and confirmed is not a
+        # divergence — verify and skip it, so a partially-applied pass
+        # can be re-run without a run-wide halt.
+        prior = _applied_previously(mcp_server, client, entry, where)
+        if prior is not None:
+            return prior
         raise DivergenceError(
             "guard refused at write time (world changed since "
             "adjudication)",
@@ -483,17 +561,21 @@ def run_apply(
                 skipped.append({**entry, "skip_reason": f"frozen:{marker}"})
                 continue
             try:
-                applied_records.append(
-                    apply_one(
-                        mcp_server,
-                        client,
-                        entry,
-                        apply=apply,
-                        poll_attempts=poll_attempts,
-                        poll_interval=poll_interval,
-                        sleep=sleep,
-                    )
+                outcome = apply_one(
+                    mcp_server,
+                    client,
+                    entry,
+                    apply=apply,
+                    poll_attempts=poll_attempts,
+                    poll_interval=poll_interval,
+                    sleep=sleep,
                 )
+                if outcome.get("skip_reason"):
+                    # e.g. applied-previously: idempotent re-run of a
+                    # partially-applied pass; continue, don't halt.
+                    skipped.append(outcome)
+                else:
+                    applied_records.append(outcome)
             except DivergenceError as exc:
                 report = {
                     "pass_id": pass_id,

--- a/tests/test_agentic_writer.py
+++ b/tests/test_agentic_writer.py
@@ -369,10 +369,12 @@ def test_true_divergence_halts_immediately(tmp_path):
     assert report["divergence"]["poll_attempts"] == 1
 
 
-def test_halt_when_guard_refuses_at_write_time(tmp_path):
+def test_halt_when_stale_superset_does_not_reconcile(tmp_path):
     # Adjudicated against a stale world: line 3 is already inside the
-    # section, so the write-time dry run refuses and the run halts
-    # without writing anything.
+    # section but the stored reconciliation is still the pre-apply one,
+    # so the run halts (with the sharper applied-previously-diverged
+    # kind) without writing anything. A refusal with NO prior apply is
+    # covered by test_refusal_without_prior_apply_still_halts.
     world = MutableWorld()
     world.sections = [_items_section([1, 2, 3])]
     rc = _run(tmp_path, world, [_verdict()])
@@ -380,7 +382,9 @@ def test_halt_when_guard_refuses_at_write_time(tmp_path):
     report = json.loads(
         (tmp_path / "verdicts" / "p1.divergence.json").read_text()
     )
-    assert report["divergence"]["kind"] == "guard-refusal"
+    assert report["divergence"]["kind"] == "applied-previously-diverged"
+    assert report["divergence"]["observed_delta"] == -4.0
+    assert report["divergence"]["predicted_delta"] == 0.0
     assert world.summary_updates == []
 
 
@@ -394,6 +398,108 @@ def test_divergence_halts_remaining_entries(tmp_path):
         (tmp_path / "verdicts" / "p1.divergence.json").read_text()
     )
     assert len(report["remaining_unapplied"]) == 1
+
+
+# --------------------------------------------------------------------------
+# Re-run idempotency (pass-20260803 lesson): a re-run over a partially
+# applied pass must classify already-applied entries as skipped
+# 'applied-previously' and continue — unless the section is a superset
+# but the reconciliation does NOT match the prediction, which is real.
+# --------------------------------------------------------------------------
+
+
+class _TwoReceiptWorld:
+    """Routes calls to per-receipt MutableWorlds.
+
+    Getters carry (image_id, receipt_id) so they dispatch directly;
+    update_* calls carry only the entity, so they route to the receipt
+    of the most recent getter — sound here because the writer is
+    strictly serial (one receipt at a time).
+    """
+
+    def __init__(self, worlds):
+        self.worlds = worlds
+        self._current = None
+
+    def _get(self, name, image_id, receipt_id):
+        self._current = int(receipt_id)
+        return getattr(self.worlds[self._current], name)(image_id, receipt_id)
+
+    def get_receipt_details(self, image_id, receipt_id):
+        return self._get("get_receipt_details", image_id, receipt_id)
+
+    def get_receipt_sections_from_receipt(self, image_id, receipt_id):
+        return self._get(
+            "get_receipt_sections_from_receipt", image_id, receipt_id
+        )
+
+    def get_receipt_summary(self, image_id, receipt_id):
+        return self._get("get_receipt_summary", image_id, receipt_id)
+
+    def get_receipt_line_items_from_receipt(self, image_id, receipt_id):
+        return self._get(
+            "get_receipt_line_items_from_receipt", image_id, receipt_id
+        )
+
+    def update_receipt_section(self, section):
+        self.worlds[self._current].update_receipt_section(section)
+
+    def update_receipt_summary(self, record):
+        self.worlds[self._current].update_receipt_summary(record)
+
+
+def _post_applied_world():
+    """A world where the [3] extension already landed and confirmed."""
+    world = MutableWorld()
+    world.sections = [_items_section([1, 2, 3])]
+    world.line_items = world._items_for([1, 2, 3])
+    return world
+
+
+def test_rerun_skips_applied_entry_and_continues(tmp_path, capsys):
+    # Receipt 1 was applied+confirmed by the previous (halted) run;
+    # receipt 2 was never reached. The re-run must skip 1 and apply 2.
+    worlds = {1: _post_applied_world(), 2: MutableWorld()}
+    client = _TwoReceiptWorld(worlds)
+    second = _verdict()
+    second["receipt_id"] = 2
+    rc = _run(tmp_path, client, [_verdict(), second])
+    assert rc == 0
+
+    summary = json.loads(capsys.readouterr().out)
+    assert summary["skipped"][0]["skip_reason"] == "applied-previously"
+    assert summary["skipped"][0]["receipt_id"] == 1
+    (record,) = summary["applied"]
+    assert record["receipt_id"] == 2
+    assert record["confirmed"] is True
+    # Receipt 1 was not re-written.
+    assert worlds[1].summary_updates == []
+    assert worlds[2].summary_updates != []
+
+
+def test_refusal_without_prior_apply_still_halts(tmp_path):
+    # Guard refusal where the section does NOT contain the added lines
+    # (e.g. line claimed by another section) stays a guard-refusal halt.
+    from receipt_dynamo.entities.receipt_section import ReceiptSection
+
+    world = MutableWorld()
+    world.sections.append(
+        ReceiptSection(
+            receipt_id=1,
+            image_id=IMAGE_ID,
+            section_type="SUMMARY",
+            line_ids=[3],
+            created_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            model_source="seed",
+            validation_status="NONE",
+        )
+    )
+    rc = _run(tmp_path, world, [_verdict()])
+    assert rc == 2
+    report = json.loads(
+        (tmp_path / "verdicts" / "p1.divergence.json").read_text()
+    )
+    assert report["divergence"]["kind"] == "guard-refusal"
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
Two fixes from the pass-20260803 live-loop shakeout, per coordinator direction (combined by invitation).

## 1. Tender rows must never anchor the printed grand total (Moody Market a8d7ab9f r4)

Live dev repro: `find_printed_grand_total` anchored on both `Total 21.45` and `Total Tender 24.67` (total + tips 3.22) and `max()` picked the tender row → `grand_total=24.67, subtotal=None`, mismatching the $20 bowl.

- **`receipt_dynamo/amounts.py`**: new `TENDER_KEYWORD_RE` (`tender|tendered|cash|change`) — minimal mirror of the colliding subset of `receipt_upload` geometry's `SETTLEMENT_RE` (canonical settlement vocabulary; mirrored not imported, since receipt_dynamo sits below receipt_upload in the dependency graph).
- **`receipt_summary.py`**: grand-total anchors = total rows that are **not** tender rows, so plain "Total" always outranks compound tender phrases; tender rows are also y-band pairing noise. The anchored scan is factored into `_find_anchored_amount`, reused by a new **`find_printed_subtotal`**, and `_apply_printed_total_fallback` now fills subtotal too (`Subtotal 20.00` is printed and legible here).
- **Regression tests (+8)** with the receipt's real line texts/geometry (`Subtotal 20.00 / Tax 1.45 / Total 21.45 / Visa 21.45 / Tips 3.22 / Total Tender 24.67 / Change 0.00`). **Live verification on dev words: 21.45 / 20.00** — ready for the summary re-regen as the third live test.

## 2. Writer re-run idempotency (`scripts/agentic_writer.py`)

Re-running pass-20260803 halted at 03c61992 (applied+confirmed in run 1) with guard-refusal "already in the ITEMS section". On a write-time refusal the writer now verifies prior application — section ⊇ `add_line_ids` AND current recon matches the predicted post-state (delta to the cent, status when present) — and classifies it skip `applied-previously`, continuing the run. Superset-but-diverged recon is a real halt (`applied-previously-diverged`); refusal with no prior apply stays `guard-refusal`.

Tests: two-receipt re-run skips the applied entry and applies the rest; superset-with-diverged-recon halts; genuine refusal halts.

## Verification

Writer suite 24/24, printed-total suite 18/18, amount classifier + golden line-item regression green. black/isort per-file; AST-parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)