### PR TITLE
feat(reocr): SMART re-OCR — strategy ladder, OCRJob contract fields, outcome harvest

### DIFF
--- a/docs/line-items/agentic-review/REOCR_STRATEGY.md
+++ b/docs/line-items/agentic-review/REOCR_STRATEGY.md
@@ -1,0 +1,110 @@
+# SMART Re-OCR: Strategy Ladder + Outcome Harvest
+
+The re-OCR loop stopped being "crop and hope": every REGIONAL_REOCR
+attempt now carries a *capture strategy* chosen from the diagnosed
+OCR-failure *mechanism*, and every completed attempt reports metrics
+that feed back into the strategy ordering. The Swift worker consumes
+the contract fields below; this doc records the Python-side wiring.
+
+## Contract (OCRJob optional fields)
+
+All fields are optional and absent-tolerant — legacy jobs parse
+unchanged (`receipt_dynamo/receipt_dynamo/entities/ocr_job.py`).
+
+| Field | Writer | Meaning |
+|---|---|---|
+| `reocr_strategy` | trigger | `plain` \| `invert` \| `deskew` \| `upscale2x` |
+| `reocr_mechanism` | trigger | free string, e.g. `reverse-video-total`, `tilted-0deg-quads`, `small-print`, `pen-stroke` |
+| `reocr_words_accepted` | overlay | overlaid + added words at completion |
+| `reocr_words_rejected` | overlay | guard-rejected overlay matches |
+| `reocr_delta_before` | overlay | items-sum − printed subtotal before the overlay (null when no ITEMS section/subtotal) |
+| `reocr_delta_after` | overlay | same, from the post-overlay word set |
+
+## Strategy ladder
+
+`receipt_upload/receipt_upload/line_items/reocr_strategy.py` (pure,
+stdlib-only, bundled into the line-item updater Lambda next to
+`blocks.py`/`reocr.py`).
+
+Default mechanism → ordered strategies:
+
+- `reverse-video*` → `[invert, plain]`
+- `tilted*` → `[deskew, plain]`
+- `small-print*` → `[upscale2x, plain]`
+- anything else (incl. `pen-stroke`) → `[plain, upscale2x]`
+
+`choose_strategy(mechanism, attempt_number, ledger)` returns the
+ladder rung for the 1-based attempt: attempt 2 is always a DIFFERENT
+strategy than attempt 1 (the full order appends the remaining
+strategies, so the first four attempts never repeat). The `ledger`
+argument overrides the hand-written order by measured success: a
+mechanism × strategy pair with ≥ 3 harvested attempts is ranked by
+(acceptance rate, mean |delta| improvement) ahead of unmeasured
+strategies. `ledger=None` loads the committed asset.
+
+## Outcome harvest
+
+`scripts/harvest_reocr_outcomes.py --table <ReceiptsTable>` scans
+completed REGIONAL_REOCR OCRJobs and aggregates, per mechanism ×
+strategy: attempts, word-level acceptance rate, and mean
+`|delta_before| − |delta_after|`. It writes
+`receipt_upload/receipt_upload/line_items/assets/reocr_ladder.json` —
+a committed asset (same pattern as the block-role priors), so a
+harvest run is a reviewable diff, not hidden state. The aggregation
+itself is `reocr_strategy.build_ledger()` and is unit-tested with
+fixture jobs (`receipt_upload/tests/test_reocr_strategy.py`).
+
+## Trigger wiring
+
+1. **Reconciliation loop** —
+   `infra/receipt_line_item_updater/line_item_processor.py::`
+   `_maybe_trigger_items_reocr` counts prior `line_items_recon`
+   attempts (cap 2) and passes `attempt_number = prior + 1` to
+   `choose_strategy`, so the capped second attempt climbs the ladder
+   instead of repeating the failed capture.
+   `update_receipt_line_items(..., reocr_mechanism=...)` threads an
+   optional mechanism from direct callers; the SQS summary-stream path
+   never sets it (unknown ladder applies).
+2. **Trigger Lambda** —
+   `infra/trigger_reocr_lambda/lambdas/trigger_reocr.py` accepts
+   optional `reocr_strategy` (validated against the contract set) and
+   `reocr_mechanism`, and stamps both onto the created OCRJob. It
+   deliberately does NOT compute a default strategy: it only bundles
+   `receipt_dynamo`, so ladder decisions stay with callers.
+3. **MCP tool** — `trigger_reocr` in BOTH server variants
+   (`scripts/receipt_mcp_server.py`,
+   `infra/mcp_server_lambda/lambdas/receipt_mcp_server_server.py`)
+   gained optional `strategy` + `mechanism` args, forwarded to the
+   Lambda as `reocr_strategy`/`reocr_mechanism`.
+
+## Mechanism source: triage dossiers
+
+Dossier v2 files (`.dev-harness/dossiers/<image_id>-<receipt_id>.json`,
+schema in `RUNBOOK_TRIAGE.md`) carry the diagnosed failure in
+`mode` + `visual_evidence`. `reocr_strategy.mechanism_from_dossier()`
+derives the canonical mechanism string from that text
+(reverse-video/inverted → `reverse-video-total`; tilt/skew/rotation →
+`tilted`; small/fine print → `small-print`; pen/ink/handwriting →
+`pen-stroke`; else None).
+
+Escalation paths that hold a dossier (the adjudicator's T2 queue and
+the writer's post-session flows) should call
+`mechanism_from_dossier(dossier)` and pass the result as `mechanism`
+to the MCP `trigger_reocr` tool (with `compute_reocr_region` first,
+and a `strategy` only when deliberately overriding the ladder).
+Neither `agentic_adjudicate.py` nor `agentic_writer.py` triggers
+re-OCR programmatically today — re-OCR from those flows goes through
+the MCP tool under the existing write rules (dev table, writer
+serialization, backup first).
+
+## Completion metrics
+
+The container OCR handler's regional overlay
+(`infra/upload_images/container_ocr/handler/ocr_processor.py::`
+`_process_regional_reocr_job`) already counted accepted/rejected
+overlays; it now persists them onto the OCRJob at completion together
+with the items-zone delta before/after (computed with the same
+`extract_items` decode the line-item updater uses, against the
+ITEMS-section line ids and the printed subtotal; null when either is
+missing). Metrics persistence is best-effort and never fails the
+overlay.

--- a/infra/chromadb_compaction/components/lambda_functions.py
+++ b/infra/chromadb_compaction/components/lambda_functions.py
@@ -541,6 +541,13 @@ class HybridLambdaDeployment(ComponentResource):
                     / "line_items"
                     / "reocr.py"
                 ),
+                "receipt_upload/line_items/reocr_strategy.py": pulumi.FileAsset(
+                    _repo_root
+                    / "receipt_upload"
+                    / "receipt_upload"
+                    / "line_items"
+                    / "reocr_strategy.py"
+                ),
                 # reocr.py imports geometry.transformations directly; the
                 # real geometry __init__ pulls the full package.
                 "receipt_upload/geometry/__init__.py": pulumi.StringAsset(
@@ -568,6 +575,14 @@ class HybridLambdaDeployment(ComponentResource):
                     / "line_items"
                     / "assets"
                     / "block_role_priors_v2.json"
+                ),
+                "receipt_upload/line_items/assets/reocr_ladder.json": pulumi.FileAsset(
+                    _repo_root
+                    / "receipt_upload"
+                    / "receipt_upload"
+                    / "line_items"
+                    / "assets"
+                    / "reocr_ladder.json"
                 ),
             }
         )

--- a/infra/mcp_server_lambda/lambdas/receipt_mcp_server_server.py
+++ b/infra/mcp_server_lambda/lambdas/receipt_mcp_server_server.py
@@ -1323,6 +1323,26 @@ Back up the receipt with export_image before triggering.""",
                         "description": "Reason for re-OCR. Default: manual_trigger",
                         "default": "manual_trigger",
                     },
+                    "strategy": {
+                        "type": "string",
+                        "enum": ["plain", "invert", "deskew", "upscale2x"],
+                        "description": (
+                            "Optional capture strategy for the Swift "
+                            "worker (SMART re-OCR ladder). Omit to let "
+                            "the worker use its default (plain)."
+                        ),
+                    },
+                    "mechanism": {
+                        "type": "string",
+                        "description": (
+                            "Optional diagnosed OCR-failure mechanism "
+                            "(free string, e.g. reverse-video-total, "
+                            "tilted-0deg-quads, small-print, "
+                            "pen-stroke). Read it from the triage "
+                            "dossier when one exists; recorded on the "
+                            "OCRJob for outcome harvesting."
+                        ),
+                    },
                 },
                 "required": ["image_id", "receipt_id", "reocr_region"],
             },
@@ -2269,6 +2289,8 @@ async def call_tool(
                 receipt_id=arguments["receipt_id"],
                 reocr_region=arguments["reocr_region"],
                 reocr_reason=arguments.get("reocr_reason", "manual_trigger"),
+                strategy=arguments.get("strategy"),
+                mechanism=arguments.get("mechanism"),
             )
         elif name == "list_recent_uploads":
             result = await list_recent_uploads_impl(
@@ -4246,6 +4268,8 @@ async def trigger_reocr_impl(
     receipt_id: int,
     reocr_region: dict,
     reocr_reason: str = "manual_trigger",
+    strategy: str | None = None,
+    mechanism: str | None = None,
 ) -> dict:
     """Invoke the trigger-reocr Lambda to start regional re-OCR."""
     try:
@@ -4257,6 +4281,8 @@ async def trigger_reocr_impl(
                 "receipt_id": receipt_id,
                 "reocr_region": reocr_region,
                 "reocr_reason": reocr_reason,
+                "reocr_strategy": strategy,
+                "reocr_mechanism": mechanism,
             },
         )
     except Exception as e:

--- a/infra/receipt_line_item_updater/line_item_processor.py
+++ b/infra/receipt_line_item_updater/line_item_processor.py
@@ -49,9 +49,18 @@ BOUNDARY_EXTENSION_SOURCE = "zone-gap-extend-v1"
 
 
 def update_receipt_line_items(
-    image_id: str, receipt_id: int
+    image_id: str,
+    receipt_id: int,
+    reocr_mechanism: str | None = None,
 ) -> dict[str, Any]:
-    """Recompute and rewrite RECEIPT_LINE_ITEM rows for one receipt."""
+    """Recompute and rewrite RECEIPT_LINE_ITEM rows for one receipt.
+
+    ``reocr_mechanism`` is an optional diagnosed OCR-failure mechanism
+    (e.g. "reverse-video-total" from a triage dossier) threaded through
+    to the re-OCR trigger so the strategy ladder can pick a targeted
+    capture strategy. The SQS path never sets it; direct callers
+    (scripts, agents) may.
+    """
     if dynamo_client is None:
         raise ValueError("DYNAMODB_TABLE_NAME environment variable not set")
 
@@ -192,6 +201,7 @@ def update_receipt_line_items(
         items,
         summary_dict,
         [word for word in word_dicts if word["line_id"] in line_ids],
+        reocr_mechanism=reocr_mechanism,
     )
     return {
         "items": len(entities),
@@ -273,6 +283,7 @@ def _maybe_trigger_items_reocr(
     items: list[dict],
     summary_dict: dict | None,
     zone_words: list[dict],
+    reocr_mechanism: str | None = None,
 ) -> bool:
     """Fire a capped REGIONAL_REOCR of the ITEMS zone on reconciliation
     mismatch (the digit-misread signature no downstream logic can fix).
@@ -282,6 +293,10 @@ def _maybe_trigger_items_reocr(
     requirement. The attempt cap exists because some glyphs are
     unreadable at any resolution (Twin Peaks) -- without it, every
     recompute of a permanently-mismatched receipt would re-fire.
+
+    Each attempt climbs the SMART strategy ladder: attempt 1 gets the
+    mechanism's best strategy, attempt 2 a DIFFERENT one (never a
+    repeat of a capture that already failed).
     """
     fn = os.environ.get("TRIGGER_REOCR_FUNCTION_NAME")
     if not fn or dynamo_client is None:
@@ -313,6 +328,7 @@ def _maybe_trigger_items_reocr(
             return False
 
         from receipt_upload.line_items.reocr import items_zone_reocr_region
+        from receipt_upload.line_items.reocr_strategy import choose_strategy
 
         receipt = dynamo_client.get_receipt(image_id, receipt_id)
         image = dynamo_client.get_image(image_id)
@@ -321,6 +337,9 @@ def _maybe_trigger_items_reocr(
         )
         if region is None:
             return False
+
+        attempt_number = len(prior) + 1
+        strategy = choose_strategy(reocr_mechanism, attempt_number)
 
         import boto3
 
@@ -333,14 +352,20 @@ def _maybe_trigger_items_reocr(
                     "receipt_id": receipt_id,
                     "reocr_region": region,
                     "reocr_reason": REOCR_REASON,
+                    "reocr_strategy": strategy,
+                    "reocr_mechanism": reocr_mechanism,
                 }
             ).encode(),
         )
         logger.info(
-            "triggered items-zone re-OCR for %s:%d region=%s",
+            "triggered items-zone re-OCR for %s:%d region=%s "
+            "strategy=%s mechanism=%s attempt=%d",
             image_id[:8],
             receipt_id,
             region,
+            strategy,
+            reocr_mechanism,
+            attempt_number,
         )
         return True
     except Exception:  # noqa: BLE001 - best-effort improvement pass

--- a/infra/trigger_reocr_lambda/lambdas/trigger_reocr.py
+++ b/infra/trigger_reocr_lambda/lambdas/trigger_reocr.py
@@ -160,16 +160,23 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
 
         # Write to DynamoDB
         dynamo_client.add_ocr_job(ocr_job)
-        logger.info("Created OCR job %s for image %s receipt %d", job_id, image_id, receipt_id)
+        logger.info(
+            "Created OCR job %s for image %s receipt %d",
+            job_id,
+            image_id,
+            receipt_id,
+        )
 
         # Send SQS message
         sqs = boto3.client("sqs")
         sqs.send_message(
             QueueUrl=queue_url,
-            MessageBody=json.dumps({
-                "job_id": job_id,
-                "image_id": image_id,
-            }),
+            MessageBody=json.dumps(
+                {
+                    "job_id": job_id,
+                    "image_id": image_id,
+                }
+            ),
         )
         logger.info("Sent SQS message to %s", queue_url)
 

--- a/infra/trigger_reocr_lambda/lambdas/trigger_reocr.py
+++ b/infra/trigger_reocr_lambda/lambdas/trigger_reocr.py
@@ -6,7 +6,9 @@ Input:
         "image_id": "uuid-string",
         "receipt_id": 1,
         "reocr_region": {"x": 0.65, "y": 0.0, "width": 0.35, "height": 1.0},
-        "reocr_reason": "manual_trigger"  // optional, defaults to "manual_trigger"
+        "reocr_reason": "manual_trigger",  // optional, defaults to "manual_trigger"
+        "reocr_strategy": "invert",        // optional: plain|invert|deskew|upscale2x
+        "reocr_mechanism": "reverse-video-total"  // optional free string
     }
 
 Output:
@@ -35,6 +37,7 @@ import boto3
 from receipt_dynamo import DynamoClient
 from receipt_dynamo.constants import OCRJobType, OCRStatus
 from receipt_dynamo.entities import Image, OCRJob
+from receipt_dynamo.entities.ocr_job import VALID_REOCR_STRATEGIES
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -83,6 +86,19 @@ def _validate_input(event: dict[str, Any]) -> str | None:
     if reason is not None and not isinstance(reason, str):
         return "reocr_reason must be a string"
 
+    strategy = event.get("reocr_strategy")
+    if strategy is not None and strategy not in VALID_REOCR_STRATEGIES:
+        return (
+            "reocr_strategy must be one of "
+            f"{', '.join(VALID_REOCR_STRATEGIES)}"
+        )
+
+    mechanism = event.get("reocr_mechanism")
+    if mechanism is not None and (
+        not isinstance(mechanism, str) or not mechanism
+    ):
+        return "reocr_mechanism must be a non-empty string"
+
     return None
 
 
@@ -100,6 +116,11 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
     receipt_id: int = event["receipt_id"]
     reocr_region: dict[str, float] = event["reocr_region"]
     reocr_reason: str = event.get("reocr_reason", "manual_trigger")
+    # SMART re-OCR: pass strategy + mechanism through to the OCRJob so
+    # the Swift worker can apply the targeted capture and the harvest
+    # can attribute the outcome. Both optional and non-breaking.
+    reocr_strategy: str | None = event.get("reocr_strategy")
+    reocr_mechanism: str | None = event.get("reocr_mechanism")
 
     table_name = os.environ["DYNAMODB_TABLE_NAME"]
     queue_url = os.environ["OCR_JOB_QUEUE_URL"]
@@ -133,6 +154,8 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
                 "height": float(reocr_region["height"]),
             },
             reocr_reason=reocr_reason,
+            reocr_strategy=reocr_strategy,
+            reocr_mechanism=reocr_mechanism,
         )
 
         # Write to DynamoDB
@@ -154,6 +177,8 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
             "success": True,
             "job_id": job_id,
             "region": ocr_job.reocr_region,
+            "strategy": ocr_job.reocr_strategy,
+            "mechanism": ocr_job.reocr_mechanism,
         }
 
     except Exception as e:

--- a/infra/upload_images/container_ocr/handler/ocr_processor.py
+++ b/infra/upload_images/container_ocr/handler/ocr_processor.py
@@ -41,6 +41,7 @@ from receipt_dynamo.entities import (
     Word,
 )
 from receipt_upload.geometry.transformations import find_perspective_coeffs
+from receipt_upload.line_items.geometry import extract_items
 from receipt_upload.ocr import process_ocr_dict_as_image
 from receipt_upload.receipt_processing.native import process_native
 from receipt_upload.receipt_processing.photo import process_photo
@@ -621,6 +622,129 @@ class OCRProcessor:
 
         return matches
 
+    def _items_zone_baseline(
+        self, image_id: str, receipt_id: int
+    ) -> Dict[str, Any] | None:
+        """ITEMS-zone line ids + summary figures for delta metrics.
+
+        Returns {"line_ids", "summary"} or None when the receipt has
+        no usable ITEMS section or printed subtotal -- the SMART
+        re-OCR completion deltas are then null (metrics are recorded
+        only where cheaply available).
+        """
+        try:
+            sections = self.dynamo.get_receipt_sections_from_receipt(
+                image_id, receipt_id
+            )
+            items_section = None
+            for section in sections:
+                s_type = str(
+                    getattr(section, "section_type", "") or ""
+                ).upper()
+                if s_type != "ITEMS":
+                    continue
+                status = str(
+                    getattr(section, "validation_status", "") or ""
+                ).upper()
+                if status == "INVALID":
+                    continue
+                if items_section is None or status == "VALID":
+                    items_section = section
+                if status == "VALID":
+                    break
+            if items_section is None:
+                return None
+            record = self.dynamo.get_receipt_summary(image_id, receipt_id)
+            inner = getattr(record, "summary", None)
+            subtotal = getattr(inner, "subtotal", None)
+            if subtotal is None:
+                return None
+            return {
+                "line_ids": {
+                    int(x) for x in (items_section.line_ids or [])
+                },
+                "summary": {
+                    "subtotal": float(subtotal),
+                    "grand_total": getattr(inner, "grand_total", None),
+                    "tax": getattr(inner, "tax", None),
+                },
+            }
+        except Exception:  # pylint: disable=broad-exception-caught
+            logger.info(
+                "items-zone baseline unavailable for %s#%s "
+                "(re-OCR deltas will be null)",
+                image_id,
+                receipt_id,
+            )
+            return None
+
+    def _items_zone_delta(
+        self, words: list, baseline: Dict[str, Any] | None
+    ) -> float | None:
+        """Signed items-sum minus printed subtotal for a word set.
+
+        Same decode the line-item updater uses, so before/after deltas
+        are comparable to reconciliation deltas downstream.
+        """
+        if baseline is None:
+            return None
+        try:
+            word_dicts = [
+                {
+                    "line_id": w.line_id,
+                    "word_id": w.word_id,
+                    "text": w.text,
+                    "x": w.bounding_box.get("x", 0.0),
+                    "y_mid": w.bounding_box.get("y", 0.0)
+                    + w.bounding_box.get("height", 0.0) / 2,
+                    "h": w.bounding_box.get("height", 0.0),
+                }
+                for w in words
+                if w.line_id in baseline["line_ids"]
+            ]
+            items, _ = extract_items(
+                word_dicts,
+                baseline["line_ids"],
+                summary=baseline["summary"],
+            )
+            total = sum(
+                item["price"]
+                for item in items
+                if not item.get("is_discount")
+                and isinstance(item.get("price"), (int, float))
+            )
+            return round(total - baseline["summary"]["subtotal"], 2)
+        except Exception:  # pylint: disable=broad-exception-caught
+            logger.info("items-zone delta computation failed (non-fatal)")
+            return None
+
+    def _record_reocr_completion_metrics(
+        self,
+        ocr_job: Any,
+        words_accepted: int,
+        words_rejected: int,
+        delta_before: float | None,
+        delta_after: float | None,
+    ) -> None:
+        """Persist SMART re-OCR completion metrics onto the OCRJob.
+
+        The harvest (scripts/harvest_reocr_outcomes.py) aggregates
+        these per mechanism x strategy to tune the strategy ladder.
+        Best-effort: a metrics failure never fails the overlay.
+        """
+        try:
+            ocr_job.reocr_words_accepted = words_accepted
+            ocr_job.reocr_words_rejected = words_rejected
+            ocr_job.reocr_delta_before = delta_before
+            ocr_job.reocr_delta_after = delta_after
+            ocr_job.status = OCRStatus.COMPLETED.value
+            ocr_job.updated_at = datetime.now(timezone.utc)
+            self.dynamo.update_ocr_job(ocr_job)
+        except Exception:  # pylint: disable=broad-exception-caught
+            logger.exception(
+                "Failed to record re-OCR completion metrics (non-fatal)"
+            )
+
     def _process_regional_reocr_job(
         self, ocr_job: Any, ocr_routing_decision: Any
     ) -> Dict[str, Any]:
@@ -780,6 +904,16 @@ class OCRProcessor:
                 last_evaluated_key=lek,
             )
             labels.extend(page or [])
+
+        # SMART re-OCR completion metrics: measure the items-zone delta
+        # against the printed subtotal BEFORE any word mutation. Null
+        # when the receipt has no ITEMS section / subtotal (cheap-only).
+        zone_baseline = self._items_zone_baseline(
+            ocr_job.image_id, ocr_job.receipt_id
+        )
+        reocr_delta_before = self._items_zone_delta(
+            existing_words, zone_baseline
+        )
 
         candidate_words = [
             word
@@ -1182,6 +1316,26 @@ class OCRProcessor:
             if lines_to_update:
                 self.dynamo.update_receipt_lines(lines_to_update)
 
+        # SMART re-OCR completion metrics: post-overlay delta from the
+        # in-memory word set (matched words were mutated in place;
+        # orphans removed; unmatched additions appended).
+        post_overlay_words = [
+            w
+            for w in existing_words
+            if (w.line_id, w.word_id) not in deleted_word_ids
+        ] + words_to_add
+        reocr_delta_after = self._items_zone_delta(
+            post_overlay_words, zone_baseline
+        )
+        words_accepted = len(words_to_update) + len(words_to_add)
+        self._record_reocr_completion_metrics(
+            ocr_job,
+            words_accepted=words_accepted,
+            words_rejected=words_rejected,
+            delta_before=reocr_delta_before,
+            delta_after=reocr_delta_after,
+        )
+
         ocr_routing_decision.status = OCRStatus.COMPLETED.value
         ocr_routing_decision.receipt_count = 1
         ocr_routing_decision.updated_at = datetime.now(timezone.utc)
@@ -1279,6 +1433,8 @@ class OCRProcessor:
             "words_added": len(words_to_add),
             "words_deleted": len(words_to_delete),
             "words_rejected": words_rejected,
+            "reocr_delta_before": reocr_delta_before,
+            "reocr_delta_after": reocr_delta_after,
             "labels_revalidated": len(labels_to_revalidate),
             "labels_deleted": len(labels_to_delete),
             "lines_rebuilt": len(lines_to_update),

--- a/infra/upload_images/container_ocr/handler/ocr_processor.py
+++ b/infra/upload_images/container_ocr/handler/ocr_processor.py
@@ -660,9 +660,7 @@ class OCRProcessor:
             if subtotal is None:
                 return None
             return {
-                "line_ids": {
-                    int(x) for x in (items_section.line_ids or [])
-                },
+                "line_ids": {int(x) for x in (items_section.line_ids or [])},
                 "summary": {
                     "subtotal": float(subtotal),
                     "grand_total": getattr(inner, "grand_total", None),

--- a/infra/upload_images/container_ocr/handler/tests/test_overlay.py
+++ b/infra/upload_images/container_ocr/handler/tests/test_overlay.py
@@ -191,10 +191,9 @@ def _make_processor():
 # 0. Full-receipt refinement
 # ===========================================================================
 
+
 class TestRefinementRowIdentity:
-    def test_forwards_nondefault_receipt_id_to_row_persistence(
-        self, tmp_path
-    ):
+    def test_forwards_nondefault_receipt_id_to_row_persistence(self, tmp_path):
         proc = _make_processor()
         ocr_job = SimpleNamespace(
             image_id=_IMG_ID,
@@ -240,6 +239,7 @@ class TestRefinementRowIdentity:
 # ===========================================================================
 # 1. Coordinate remapping (pure, no mocking)
 # ===========================================================================
+
 
 class TestMapBboxToRegion:
     def test_identity_region(self):
@@ -323,11 +323,14 @@ class TestApplyRegionMapping:
 # 1b. Bbox containment ratio (pure)
 # ===========================================================================
 
+
 class TestBboxContainmentRatio:
     def test_fully_contained(self):
         proc = _make_processor()
         bbox = {"x": 0.3, "y": 0.3, "width": 0.1, "height": 0.1}
-        assert proc._bbox_containment_ratio(bbox, 0.0, 0.0, 1.0, 1.0) == pytest.approx(1.0)
+        assert proc._bbox_containment_ratio(
+            bbox, 0.0, 0.0, 1.0, 1.0
+        ) == pytest.approx(1.0)
 
     def test_half_contained_x(self):
         """Word straddles the right edge — only 50% inside."""
@@ -335,17 +338,23 @@ class TestBboxContainmentRatio:
         bbox = {"x": 0.9, "y": 0.1, "width": 0.2, "height": 0.1}
         # region covers x=[0.7, 1.0]. Word x=[0.9, 1.1]. Overlap x=[0.9, 1.0]=0.1
         # word area = 0.2*0.1 = 0.02, overlap area = 0.1*0.1 = 0.01
-        assert proc._bbox_containment_ratio(bbox, 0.7, 0.0, 1.0, 1.0) == pytest.approx(0.5)
+        assert proc._bbox_containment_ratio(
+            bbox, 0.7, 0.0, 1.0, 1.0
+        ) == pytest.approx(0.5)
 
     def test_no_overlap(self):
         proc = _make_processor()
         bbox = {"x": 0.0, "y": 0.0, "width": 0.1, "height": 0.1}
-        assert proc._bbox_containment_ratio(bbox, 0.5, 0.5, 1.0, 1.0) == pytest.approx(0.0)
+        assert proc._bbox_containment_ratio(
+            bbox, 0.5, 0.5, 1.0, 1.0
+        ) == pytest.approx(0.0)
 
     def test_zero_area_bbox(self):
         proc = _make_processor()
         bbox = {"x": 0.5, "y": 0.5, "width": 0.0, "height": 0.0}
-        assert proc._bbox_containment_ratio(bbox, 0.0, 0.0, 1.0, 1.0) == pytest.approx(0.0)
+        assert proc._bbox_containment_ratio(
+            bbox, 0.0, 0.0, 1.0, 1.0
+        ) == pytest.approx(0.0)
 
     def test_barely_inside(self):
         """Word mostly outside the region — only ~25% contained."""
@@ -362,6 +371,7 @@ class TestBboxContainmentRatio:
 # ===========================================================================
 # 2. Word matching (pure)
 # ===========================================================================
+
 
 class TestYOverlapRatio:
     def test_perfect_overlap(self):
@@ -385,7 +395,9 @@ class TestYOverlapRatio:
 
 class TestBboxCenterX:
     def test_basic(self):
-        assert OCRProcessor._bbox_center_x({"x": 0.2, "width": 0.1}) == pytest.approx(0.25)
+        assert OCRProcessor._bbox_center_x(
+            {"x": 0.2, "width": 0.1}
+        ) == pytest.approx(0.25)
 
     def test_missing_keys(self):
         assert OCRProcessor._bbox_center_x({}) == pytest.approx(0.0)
@@ -396,7 +408,9 @@ class TestMatchRegionalWords:
         """Each new word matches exactly one existing word."""
         proc = _make_processor()
         new_w = _make_word(text="NEW", x=0.8, y=0.1, w=0.1, h=0.05)
-        old_w = _make_word(text="OLD", x=0.8, y=0.1, w=0.1, h=0.05, line_id=2, word_id=2)
+        old_w = _make_word(
+            text="OLD", x=0.8, y=0.1, w=0.1, h=0.05, line_id=2, word_id=2
+        )
         matches = proc._match_regional_words([new_w], [old_w])
         assert len(matches) == 1
         assert matches[0] == (new_w, old_w)
@@ -405,25 +419,39 @@ class TestMatchRegionalWords:
         """Words with no y-overlap should not match."""
         proc = _make_processor()
         new_w = _make_word(text="NEW", x=0.8, y=0.0, w=0.1, h=0.02)
-        old_w = _make_word(text="OLD", x=0.8, y=0.9, w=0.1, h=0.02, line_id=2, word_id=2)
+        old_w = _make_word(
+            text="OLD", x=0.8, y=0.9, w=0.1, h=0.02, line_id=2, word_id=2
+        )
         matches = proc._match_regional_words([new_w], [old_w])
         assert len(matches) == 0
 
     def test_greedy_consumption(self):
         """Once an old word is consumed, it cannot match again."""
         proc = _make_processor()
-        new1 = _make_word(text="A", x=0.8, y=0.1, w=0.1, h=0.05, line_id=1, word_id=1)
-        new2 = _make_word(text="B", x=0.8, y=0.1, w=0.1, h=0.05, line_id=1, word_id=2)
-        old = _make_word(text="OLD", x=0.8, y=0.1, w=0.1, h=0.05, line_id=2, word_id=1)
+        new1 = _make_word(
+            text="A", x=0.8, y=0.1, w=0.1, h=0.05, line_id=1, word_id=1
+        )
+        new2 = _make_word(
+            text="B", x=0.8, y=0.1, w=0.1, h=0.05, line_id=1, word_id=2
+        )
+        old = _make_word(
+            text="OLD", x=0.8, y=0.1, w=0.1, h=0.05, line_id=2, word_id=1
+        )
         matches = proc._match_regional_words([new1, new2], [old])
         assert len(matches) == 1
 
     def test_x_preference(self):
         """When y-overlap is equal, closer x-center is preferred."""
         proc = _make_processor()
-        new_w = _make_word(text="N", x=0.80, y=0.1, w=0.05, h=0.05, line_id=1, word_id=1)
-        old_close = _make_word(text="CLOSE", x=0.80, y=0.1, w=0.05, h=0.05, line_id=2, word_id=1)
-        old_far = _make_word(text="FAR", x=0.50, y=0.1, w=0.05, h=0.05, line_id=2, word_id=2)
+        new_w = _make_word(
+            text="N", x=0.80, y=0.1, w=0.05, h=0.05, line_id=1, word_id=1
+        )
+        old_close = _make_word(
+            text="CLOSE", x=0.80, y=0.1, w=0.05, h=0.05, line_id=2, word_id=1
+        )
+        old_far = _make_word(
+            text="FAR", x=0.50, y=0.1, w=0.05, h=0.05, line_id=2, word_id=2
+        )
         matches = proc._match_regional_words([new_w], [old_close, old_far])
         assert len(matches) == 1
         assert matches[0][1].text == "CLOSE"
@@ -431,10 +459,18 @@ class TestMatchRegionalWords:
     def test_word_splits(self):
         """Multiple new words can match multiple old words."""
         proc = _make_processor()
-        new1 = _make_word(text="A", x=0.7, y=0.1, w=0.05, h=0.05, line_id=1, word_id=1)
-        new2 = _make_word(text="B", x=0.85, y=0.1, w=0.05, h=0.05, line_id=1, word_id=2)
-        old1 = _make_word(text="X", x=0.7, y=0.1, w=0.05, h=0.05, line_id=2, word_id=1)
-        old2 = _make_word(text="Y", x=0.85, y=0.1, w=0.05, h=0.05, line_id=2, word_id=2)
+        new1 = _make_word(
+            text="A", x=0.7, y=0.1, w=0.05, h=0.05, line_id=1, word_id=1
+        )
+        new2 = _make_word(
+            text="B", x=0.85, y=0.1, w=0.05, h=0.05, line_id=1, word_id=2
+        )
+        old1 = _make_word(
+            text="X", x=0.7, y=0.1, w=0.05, h=0.05, line_id=2, word_id=1
+        )
+        old2 = _make_word(
+            text="Y", x=0.85, y=0.1, w=0.05, h=0.05, line_id=2, word_id=2
+        )
         matches = proc._match_regional_words([new1, new2], [old1, old2])
         assert len(matches) == 2
 
@@ -442,6 +478,7 @@ class TestMatchRegionalWords:
 # ===========================================================================
 # 3. Candidate selection (mocked DynamoDB)
 # ===========================================================================
+
 
 class TestCandidateSelection:
     def _run_overlay(self, proc, existing_words, labels, region=None):
@@ -464,7 +501,9 @@ class TestCandidateSelection:
             updated_at=None,
         )
 
-        proc.dynamo.list_receipt_words_from_receipt.return_value = existing_words
+        proc.dynamo.list_receipt_words_from_receipt.return_value = (
+            existing_words
+        )
 
         label_page = labels if labels else []
         proc.dynamo.list_receipt_word_labels_for_receipt.return_value = (
@@ -479,7 +518,12 @@ class TestCandidateSelection:
             "lines": [
                 {
                     "text": "99.99",
-                    "bounding_box": {"x": 0.0, "y": 0.1, "width": 1.0, "height": 0.05},
+                    "bounding_box": {
+                        "x": 0.0,
+                        "y": 0.1,
+                        "width": 1.0,
+                        "height": 0.05,
+                    },
                     "top_left": {"x": 0.0, "y": 0.1},
                     "top_right": {"x": 1.0, "y": 0.1},
                     "bottom_left": {"x": 0.0, "y": 0.15},
@@ -488,7 +532,12 @@ class TestCandidateSelection:
                     "words": [
                         {
                             "text": "99.99",
-                            "bounding_box": {"x": 0.0, "y": 0.1, "width": 1.0, "height": 0.05},
+                            "bounding_box": {
+                                "x": 0.0,
+                                "y": 0.1,
+                                "width": 1.0,
+                                "height": 0.05,
+                            },
                             "top_left": {"x": 0.0, "y": 0.1},
                             "top_right": {"x": 1.0, "y": 0.1},
                             "bottom_left": {"x": 0.0, "y": 0.15},
@@ -504,20 +553,33 @@ class TestCandidateSelection:
         tmp = Path(tempfile.mkstemp(suffix=".json")[1])
         tmp.write_text(json.dumps(ocr_json))
 
-        with patch(
-            "handler.ocr_processor.download_file_from_s3", return_value=tmp
-        ), patch(
-            "handler.ocr_processor.process_ocr_dict_as_image"
-        ) as mock_parse, patch(
-            "handler.ocr_processor.image_ocr_to_receipt_ocr"
-        ) as mock_convert:
+        with (
+            patch(
+                "handler.ocr_processor.download_file_from_s3", return_value=tmp
+            ),
+            patch(
+                "handler.ocr_processor.process_ocr_dict_as_image"
+            ) as mock_parse,
+            patch(
+                "handler.ocr_processor.image_ocr_to_receipt_ocr"
+            ) as mock_convert,
+        ):
             # Simulate a single word from the regional OCR
             receipt_word = _make_word(
-                text="99.99", x=0.0, y=0.1, w=1.0, h=0.05,
-                line_id=1, word_id=1,
+                text="99.99",
+                x=0.0,
+                y=0.1,
+                w=1.0,
+                h=0.05,
+                line_id=1,
+                word_id=1,
             )
             receipt_line = _make_line(
-                text="99.99", x=0.0, y=0.1, w=1.0, h=0.05,
+                text="99.99",
+                x=0.0,
+                y=0.1,
+                w=1.0,
+                h=0.05,
                 line_id=1,
             )
             mock_parse.return_value = ([], [], [])
@@ -529,8 +591,12 @@ class TestCandidateSelection:
     def test_region_x_filter(self):
         """Only words whose center-x falls in the region are candidates."""
         proc = _make_processor()
-        inside = _make_word(text="IN", x=0.80, y=0.1, w=0.1, h=0.05, line_id=1, word_id=1)
-        outside = _make_word(text="OUT", x=0.10, y=0.1, w=0.1, h=0.05, line_id=1, word_id=2)
+        inside = _make_word(
+            text="IN", x=0.80, y=0.1, w=0.1, h=0.05, line_id=1, word_id=1
+        )
+        outside = _make_word(
+            text="OUT", x=0.10, y=0.1, w=0.1, h=0.05, line_id=1, word_id=2
+        )
         self._run_overlay(proc, [inside, outside], labels=[])
         # The match should only use 'inside' since 'outside' center-x is ~0.15
         if proc.dynamo.update_receipt_words.called:
@@ -578,8 +644,16 @@ class TestUnmatchedWordAddition:
     """When re-OCR finds words that don't match any existing candidate,
     they should be added as new ReceiptWords on the best-matching line."""
 
-    def _run_overlay(self, proc, existing_words, new_words, new_lines=None,
-                     region=None, labels=None, new_letters=None):
+    def _run_overlay(
+        self,
+        proc,
+        existing_words,
+        new_words,
+        new_lines=None,
+        region=None,
+        labels=None,
+        new_letters=None,
+    ):
         """Run the overlay pipeline with explicit new words."""
         if region is None:
             region = {"x": 0.0, "y": 0.0, "width": 1.0, "height": 1.0}
@@ -589,20 +663,30 @@ class TestUnmatchedWordAddition:
             new_letters = []
 
         ocr_job = SimpleNamespace(
-            image_id=_IMG_ID, receipt_id=1,
-            reocr_region=region, s3_bucket="b", s3_key="k",
+            image_id=_IMG_ID,
+            receipt_id=1,
+            reocr_region=region,
+            s3_bucket="b",
+            s3_key="k",
         )
         routing = SimpleNamespace(
-            s3_bucket="b", s3_key="r.json",
-            status=None, receipt_count=None, updated_at=None,
+            s3_bucket="b",
+            s3_key="r.json",
+            status=None,
+            receipt_count=None,
+            updated_at=None,
         )
 
-        proc.dynamo.list_receipt_words_from_receipt.return_value = existing_words
+        proc.dynamo.list_receipt_words_from_receipt.return_value = (
+            existing_words
+        )
         proc.dynamo.list_receipt_word_labels_for_receipt.return_value = (
             [
-                l
-                if hasattr(l, "label")
-                else SimpleNamespace(line_id=l.line_id, word_id=l.word_id)
+                (
+                    l
+                    if hasattr(l, "label")
+                    else SimpleNamespace(line_id=l.line_id, word_id=l.word_id)
+                )
                 for l in (labels or [])
             ],
             None,
@@ -617,10 +701,19 @@ class TestUnmatchedWordAddition:
         tmp = Path(tempfile.mkstemp(suffix=".json")[1])
         tmp.write_text(json.dumps(ocr_json))
 
-        with patch("handler.ocr_processor.download_file_from_s3", return_value=tmp), \
-             patch("handler.ocr_processor.process_ocr_dict_as_image", return_value=([], [], [])), \
-             patch("handler.ocr_processor.image_ocr_to_receipt_ocr",
-                   return_value=(new_lines, new_words, new_letters)):
+        with (
+            patch(
+                "handler.ocr_processor.download_file_from_s3", return_value=tmp
+            ),
+            patch(
+                "handler.ocr_processor.process_ocr_dict_as_image",
+                return_value=([], [], []),
+            ),
+            patch(
+                "handler.ocr_processor.image_ocr_to_receipt_ocr",
+                return_value=(new_lines, new_words, new_letters),
+            ),
+        ):
             result = proc._process_regional_reocr_job(ocr_job, routing)
         return result
 
@@ -628,13 +721,16 @@ class TestUnmatchedWordAddition:
         """A new OCR word with no remaining candidate gets added."""
         proc = _make_processor()
         # One existing word on line 1
-        existing = _make_word(text="CARLON", x=0.1, y=0.5, w=0.15, h=0.05,
-                              line_id=1, word_id=1)
+        existing = _make_word(
+            text="CARLON", x=0.1, y=0.5, w=0.15, h=0.05, line_id=1, word_id=1
+        )
         # Two new OCR words: first one matches existing, second has no match
-        new_match = _make_word(text="CARLON", x=0.1, y=0.5, w=0.15, h=0.05,
-                               line_id=1, word_id=1)
-        new_extra = _make_word(text="8.68", x=0.85, y=0.5, w=0.1, h=0.05,
-                               line_id=1, word_id=2)
+        new_match = _make_word(
+            text="CARLON", x=0.1, y=0.5, w=0.15, h=0.05, line_id=1, word_id=1
+        )
+        new_extra = _make_word(
+            text="8.68", x=0.85, y=0.5, w=0.1, h=0.05, line_id=1, word_id=2
+        )
 
         result = self._run_overlay(proc, [existing], [new_match, new_extra])
 
@@ -649,11 +745,13 @@ class TestUnmatchedWordAddition:
     def test_unmatched_word_no_overlap_skipped(self):
         """A new word with no Y-overlap to any line is skipped."""
         proc = _make_processor()
-        existing = _make_word(text="A", x=0.1, y=0.1, w=0.1, h=0.05,
-                              line_id=1, word_id=1)
+        existing = _make_word(
+            text="A", x=0.1, y=0.1, w=0.1, h=0.05, line_id=1, word_id=1
+        )
         # New word at completely different Y
-        new_word = _make_word(text="X", x=0.1, y=0.9, w=0.1, h=0.05,
-                              line_id=1, word_id=1)
+        new_word = _make_word(
+            text="X", x=0.1, y=0.9, w=0.1, h=0.05, line_id=1, word_id=1
+        )
 
         result = self._run_overlay(proc, [existing], [new_word])
 
@@ -662,10 +760,19 @@ class TestUnmatchedWordAddition:
     def test_unmatched_word_low_confidence_skipped(self):
         """A new word with confidence below 0.5 is not added."""
         proc = _make_processor()
-        existing = _make_word(text="A", x=0.1, y=0.1, w=0.1, h=0.05,
-                              line_id=1, word_id=1)
-        new_word = _make_word(text="X", x=0.5, y=0.1, w=0.1, h=0.05,
-                              line_id=1, word_id=2, confidence=0.3)
+        existing = _make_word(
+            text="A", x=0.1, y=0.1, w=0.1, h=0.05, line_id=1, word_id=1
+        )
+        new_word = _make_word(
+            text="X",
+            x=0.5,
+            y=0.1,
+            w=0.1,
+            h=0.05,
+            line_id=1,
+            word_id=2,
+            confidence=0.3,
+        )
 
         result = self._run_overlay(proc, [existing], [new_word])
 
@@ -674,10 +781,12 @@ class TestUnmatchedWordAddition:
     def test_unmatched_word_noise_skipped(self):
         """A new word that is noise text (e.g. 'SA-/') is not added."""
         proc = _make_processor()
-        existing = _make_word(text="A", x=0.1, y=0.1, w=0.1, h=0.05,
-                              line_id=1, word_id=1)
-        new_word = _make_word(text="SA-/", x=0.5, y=0.1, w=0.1, h=0.05,
-                              line_id=1, word_id=2)
+        existing = _make_word(
+            text="A", x=0.1, y=0.1, w=0.1, h=0.05, line_id=1, word_id=1
+        )
+        new_word = _make_word(
+            text="SA-/", x=0.5, y=0.1, w=0.1, h=0.05, line_id=1, word_id=2
+        )
 
         result = self._run_overlay(proc, [existing], [new_word])
 
@@ -686,10 +795,18 @@ class TestUnmatchedWordAddition:
     def test_line_text_includes_added_words(self):
         """ReceiptLine text is rebuilt to include the added word."""
         proc = _make_processor()
-        existing = _make_word(text="ADJUSTABLE", x=0.1, y=0.5, w=0.2, h=0.05,
-                              line_id=1, word_id=1)
-        new_word = _make_word(text="8.68", x=0.85, y=0.5, w=0.1, h=0.05,
-                              line_id=1, word_id=1)
+        existing = _make_word(
+            text="ADJUSTABLE",
+            x=0.1,
+            y=0.5,
+            w=0.2,
+            h=0.05,
+            line_id=1,
+            word_id=1,
+        )
+        new_word = _make_word(
+            text="8.68", x=0.85, y=0.5, w=0.1, h=0.05, line_id=1, word_id=1
+        )
 
         self._run_overlay(proc, [existing], [new_word])
 
@@ -701,12 +818,22 @@ class TestUnmatchedWordAddition:
         """When re-OCR changes word text, attached labels need revalidation."""
         proc = _make_processor()
         existing = _make_word(
-            text="579199", x=0.1, y=0.5, w=0.15, h=0.05,
-            line_id=1, word_id=1,
+            text="579199",
+            x=0.1,
+            y=0.5,
+            w=0.15,
+            h=0.05,
+            line_id=1,
+            word_id=1,
         )
         new_word = _make_word(
-            text="579.99", x=0.1, y=0.5, w=0.15, h=0.05,
-            line_id=1, word_id=1,
+            text="579.99",
+            x=0.1,
+            y=0.5,
+            w=0.15,
+            h=0.05,
+            line_id=1,
+            word_id=1,
         )
         label = _make_label(line_id=1, word_id=1)
 
@@ -730,8 +857,13 @@ class TestUnmatchedWordAddition:
         """Labels attached to words deleted by re-OCR must not be orphaned."""
         proc = _make_processor()
         existing = _make_word(
-            text="GARBLED", x=0.1, y=0.5, w=0.15, h=0.05,
-            line_id=1, word_id=1,
+            text="GARBLED",
+            x=0.1,
+            y=0.5,
+            w=0.15,
+            h=0.05,
+            line_id=1,
+            word_id=1,
         )
         label = _make_label(line_id=1, word_id=1)
 
@@ -747,6 +879,7 @@ class TestUnmatchedWordAddition:
 # 4. ReceiptLine.text rebuild
 # ===========================================================================
 
+
 class TestLineTextRebuild:
     def test_line_text_reconstructed(self):
         """Line text is rebuilt from updated words joined by spaces."""
@@ -759,29 +892,90 @@ class TestLineTextRebuild:
             s3_key="k",
         )
         routing = SimpleNamespace(
-            s3_bucket="b", s3_key="r.json",
-            status=None, receipt_count=None, updated_at=None,
+            s3_bucket="b",
+            s3_key="r.json",
+            status=None,
+            receipt_count=None,
+            updated_at=None,
         )
 
-        existing_w1 = _make_word(text="TOTAL", x=0.30, y=0.1, w=0.1, h=0.05, line_id=1, word_id=1)
-        existing_w2 = _make_word(text="99.98", x=0.80, y=0.1, w=0.1, h=0.05, line_id=1, word_id=2)
+        existing_w1 = _make_word(
+            text="TOTAL", x=0.30, y=0.1, w=0.1, h=0.05, line_id=1, word_id=1
+        )
+        existing_w2 = _make_word(
+            text="99.98", x=0.80, y=0.1, w=0.1, h=0.05, line_id=1, word_id=2
+        )
         existing_line = _make_line(text="TOTAL 99.98", line_id=1)
 
-        proc.dynamo.list_receipt_words_from_receipt.return_value = [existing_w1, existing_w2]
-        proc.dynamo.list_receipt_word_labels_for_receipt.return_value = ([], None)
+        proc.dynamo.list_receipt_words_from_receipt.return_value = [
+            existing_w1,
+            existing_w2,
+        ]
+        proc.dynamo.list_receipt_word_labels_for_receipt.return_value = (
+            [],
+            None,
+        )
         proc.dynamo.list_receipt_letters_from_word.return_value = []
-        proc.dynamo.list_receipt_lines_from_receipt.return_value = [existing_line]
+        proc.dynamo.list_receipt_lines_from_receipt.return_value = [
+            existing_line
+        ]
 
-        new_receipt_word = _make_word(text="99.99", x=0.0, y=0.1, w=1.0, h=0.05, line_id=1, word_id=1)
+        new_receipt_word = _make_word(
+            text="99.99", x=0.0, y=0.1, w=1.0, h=0.05, line_id=1, word_id=1
+        )
         new_receipt_line = _make_line(text="99.99", line_id=1)
 
-        ocr_json = {"lines": [{"text": "99.99", "bounding_box": {"x": 0, "y": 0.1, "width": 1, "height": 0.05}, "top_left": {"x": 0, "y": 0.1}, "top_right": {"x": 1, "y": 0.1}, "bottom_left": {"x": 0, "y": 0.15}, "bottom_right": {"x": 1, "y": 0.15}, "confidence": 0.99, "words": [{"text": "99.99", "bounding_box": {"x": 0, "y": 0.1, "width": 1, "height": 0.05}, "top_left": {"x": 0, "y": 0.1}, "top_right": {"x": 1, "y": 0.1}, "bottom_left": {"x": 0, "y": 0.15}, "bottom_right": {"x": 1, "y": 0.15}, "confidence": 0.99, "letters": []}]}]}
+        ocr_json = {
+            "lines": [
+                {
+                    "text": "99.99",
+                    "bounding_box": {
+                        "x": 0,
+                        "y": 0.1,
+                        "width": 1,
+                        "height": 0.05,
+                    },
+                    "top_left": {"x": 0, "y": 0.1},
+                    "top_right": {"x": 1, "y": 0.1},
+                    "bottom_left": {"x": 0, "y": 0.15},
+                    "bottom_right": {"x": 1, "y": 0.15},
+                    "confidence": 0.99,
+                    "words": [
+                        {
+                            "text": "99.99",
+                            "bounding_box": {
+                                "x": 0,
+                                "y": 0.1,
+                                "width": 1,
+                                "height": 0.05,
+                            },
+                            "top_left": {"x": 0, "y": 0.1},
+                            "top_right": {"x": 1, "y": 0.1},
+                            "bottom_left": {"x": 0, "y": 0.15},
+                            "bottom_right": {"x": 1, "y": 0.15},
+                            "confidence": 0.99,
+                            "letters": [],
+                        }
+                    ],
+                }
+            ]
+        }
         tmp = Path(tempfile.mkstemp(suffix=".json")[1])
         tmp.write_text(json.dumps(ocr_json))
 
-        with patch("handler.ocr_processor.download_file_from_s3", return_value=tmp), \
-             patch("handler.ocr_processor.process_ocr_dict_as_image", return_value=([], [], [])), \
-             patch("handler.ocr_processor.image_ocr_to_receipt_ocr", return_value=([new_receipt_line], [new_receipt_word], [])):
+        with (
+            patch(
+                "handler.ocr_processor.download_file_from_s3", return_value=tmp
+            ),
+            patch(
+                "handler.ocr_processor.process_ocr_dict_as_image",
+                return_value=([], [], []),
+            ),
+            patch(
+                "handler.ocr_processor.image_ocr_to_receipt_ocr",
+                return_value=([new_receipt_line], [new_receipt_word], []),
+            ),
+        ):
             proc._process_regional_reocr_job(ocr_job, routing)
 
         assert proc.dynamo.update_receipt_lines.called
@@ -793,34 +987,93 @@ class TestLineTextRebuild:
         """Lines without overlaid words should not be updated."""
         proc = _make_processor()
         ocr_job = SimpleNamespace(
-            image_id="00000000-0000-4000-8000-000000000001", receipt_id=1,
+            image_id="00000000-0000-4000-8000-000000000001",
+            receipt_id=1,
             reocr_region={"x": 0.70, "y": 0.0, "width": 0.30, "height": 1.0},
-            s3_bucket="b", s3_key="k",
+            s3_bucket="b",
+            s3_key="k",
         )
         routing = SimpleNamespace(
-            s3_bucket="b", s3_key="r.json",
-            status=None, receipt_count=None, updated_at=None,
+            s3_bucket="b",
+            s3_key="r.json",
+            status=None,
+            receipt_count=None,
+            updated_at=None,
         )
 
-        existing_w = _make_word(text="99.98", x=0.80, y=0.1, w=0.1, h=0.05, line_id=1, word_id=1)
+        existing_w = _make_word(
+            text="99.98", x=0.80, y=0.1, w=0.1, h=0.05, line_id=1, word_id=1
+        )
         line1 = _make_line(text="99.98", line_id=1)
         line2 = _make_line(text="OTHER LINE", line_id=2, y=0.5)
 
         proc.dynamo.list_receipt_words_from_receipt.return_value = [existing_w]
-        proc.dynamo.list_receipt_word_labels_for_receipt.return_value = ([], None)
+        proc.dynamo.list_receipt_word_labels_for_receipt.return_value = (
+            [],
+            None,
+        )
         proc.dynamo.list_receipt_letters_from_word.return_value = []
-        proc.dynamo.list_receipt_lines_from_receipt.return_value = [line1, line2]
+        proc.dynamo.list_receipt_lines_from_receipt.return_value = [
+            line1,
+            line2,
+        ]
 
-        new_receipt_word = _make_word(text="99.99", x=0.0, y=0.1, w=1.0, h=0.05, line_id=1, word_id=1)
+        new_receipt_word = _make_word(
+            text="99.99", x=0.0, y=0.1, w=1.0, h=0.05, line_id=1, word_id=1
+        )
         new_receipt_line = _make_line(text="99.99", line_id=1)
 
-        ocr_json = {"lines": [{"text": "99.99", "bounding_box": {"x": 0, "y": 0.1, "width": 1, "height": 0.05}, "top_left": {"x": 0, "y": 0.1}, "top_right": {"x": 1, "y": 0.1}, "bottom_left": {"x": 0, "y": 0.15}, "bottom_right": {"x": 1, "y": 0.15}, "confidence": 0.99, "words": [{"text": "99.99", "bounding_box": {"x": 0, "y": 0.1, "width": 1, "height": 0.05}, "top_left": {"x": 0, "y": 0.1}, "top_right": {"x": 1, "y": 0.1}, "bottom_left": {"x": 0, "y": 0.15}, "bottom_right": {"x": 1, "y": 0.15}, "confidence": 0.99, "letters": []}]}]}
+        ocr_json = {
+            "lines": [
+                {
+                    "text": "99.99",
+                    "bounding_box": {
+                        "x": 0,
+                        "y": 0.1,
+                        "width": 1,
+                        "height": 0.05,
+                    },
+                    "top_left": {"x": 0, "y": 0.1},
+                    "top_right": {"x": 1, "y": 0.1},
+                    "bottom_left": {"x": 0, "y": 0.15},
+                    "bottom_right": {"x": 1, "y": 0.15},
+                    "confidence": 0.99,
+                    "words": [
+                        {
+                            "text": "99.99",
+                            "bounding_box": {
+                                "x": 0,
+                                "y": 0.1,
+                                "width": 1,
+                                "height": 0.05,
+                            },
+                            "top_left": {"x": 0, "y": 0.1},
+                            "top_right": {"x": 1, "y": 0.1},
+                            "bottom_left": {"x": 0, "y": 0.15},
+                            "bottom_right": {"x": 1, "y": 0.15},
+                            "confidence": 0.99,
+                            "letters": [],
+                        }
+                    ],
+                }
+            ]
+        }
         tmp = Path(tempfile.mkstemp(suffix=".json")[1])
         tmp.write_text(json.dumps(ocr_json))
 
-        with patch("handler.ocr_processor.download_file_from_s3", return_value=tmp), \
-             patch("handler.ocr_processor.process_ocr_dict_as_image", return_value=([], [], [])), \
-             patch("handler.ocr_processor.image_ocr_to_receipt_ocr", return_value=([new_receipt_line], [new_receipt_word], [])):
+        with (
+            patch(
+                "handler.ocr_processor.download_file_from_s3", return_value=tmp
+            ),
+            patch(
+                "handler.ocr_processor.process_ocr_dict_as_image",
+                return_value=([], [], []),
+            ),
+            patch(
+                "handler.ocr_processor.image_ocr_to_receipt_ocr",
+                return_value=([new_receipt_line], [new_receipt_word], []),
+            ),
+        ):
             proc._process_regional_reocr_job(ocr_job, routing)
 
         updated_lines = proc.dynamo.update_receipt_lines.call_args[0][0]
@@ -831,35 +1084,93 @@ class TestLineTextRebuild:
         """Words should be ordered by word_id when rebuilding text."""
         proc = _make_processor()
         ocr_job = SimpleNamespace(
-            image_id="00000000-0000-4000-8000-000000000001", receipt_id=1,
+            image_id="00000000-0000-4000-8000-000000000001",
+            receipt_id=1,
             reocr_region={"x": 0.70, "y": 0.0, "width": 0.30, "height": 1.0},
-            s3_bucket="b", s3_key="k",
+            s3_bucket="b",
+            s3_key="k",
         )
         routing = SimpleNamespace(
-            s3_bucket="b", s3_key="r.json",
-            status=None, receipt_count=None, updated_at=None,
+            s3_bucket="b",
+            s3_key="r.json",
+            status=None,
+            receipt_count=None,
+            updated_at=None,
         )
 
         # word_id=2 appears first in list but should be second in text
-        w1 = _make_word(text="TOTAL", x=0.30, y=0.1, w=0.1, h=0.05, line_id=1, word_id=1)
-        w2 = _make_word(text="OLD", x=0.80, y=0.1, w=0.1, h=0.05, line_id=1, word_id=2)
+        w1 = _make_word(
+            text="TOTAL", x=0.30, y=0.1, w=0.1, h=0.05, line_id=1, word_id=1
+        )
+        w2 = _make_word(
+            text="OLD", x=0.80, y=0.1, w=0.1, h=0.05, line_id=1, word_id=2
+        )
         line = _make_line(text="TOTAL OLD", line_id=1)
 
         proc.dynamo.list_receipt_words_from_receipt.return_value = [w2, w1]
-        proc.dynamo.list_receipt_word_labels_for_receipt.return_value = ([], None)
+        proc.dynamo.list_receipt_word_labels_for_receipt.return_value = (
+            [],
+            None,
+        )
         proc.dynamo.list_receipt_letters_from_word.return_value = []
         proc.dynamo.list_receipt_lines_from_receipt.return_value = [line]
 
-        new_word = _make_word(text="NEW", x=0.0, y=0.1, w=1.0, h=0.05, line_id=1, word_id=1)
+        new_word = _make_word(
+            text="NEW", x=0.0, y=0.1, w=1.0, h=0.05, line_id=1, word_id=1
+        )
         new_line = _make_line(text="NEW", line_id=1)
 
-        ocr_json = {"lines": [{"text": "NEW", "bounding_box": {"x": 0, "y": 0.1, "width": 1, "height": 0.05}, "top_left": {"x": 0, "y": 0.1}, "top_right": {"x": 1, "y": 0.1}, "bottom_left": {"x": 0, "y": 0.15}, "bottom_right": {"x": 1, "y": 0.15}, "confidence": 0.99, "words": [{"text": "NEW", "bounding_box": {"x": 0, "y": 0.1, "width": 1, "height": 0.05}, "top_left": {"x": 0, "y": 0.1}, "top_right": {"x": 1, "y": 0.1}, "bottom_left": {"x": 0, "y": 0.15}, "bottom_right": {"x": 1, "y": 0.15}, "confidence": 0.99, "letters": []}]}]}
+        ocr_json = {
+            "lines": [
+                {
+                    "text": "NEW",
+                    "bounding_box": {
+                        "x": 0,
+                        "y": 0.1,
+                        "width": 1,
+                        "height": 0.05,
+                    },
+                    "top_left": {"x": 0, "y": 0.1},
+                    "top_right": {"x": 1, "y": 0.1},
+                    "bottom_left": {"x": 0, "y": 0.15},
+                    "bottom_right": {"x": 1, "y": 0.15},
+                    "confidence": 0.99,
+                    "words": [
+                        {
+                            "text": "NEW",
+                            "bounding_box": {
+                                "x": 0,
+                                "y": 0.1,
+                                "width": 1,
+                                "height": 0.05,
+                            },
+                            "top_left": {"x": 0, "y": 0.1},
+                            "top_right": {"x": 1, "y": 0.1},
+                            "bottom_left": {"x": 0, "y": 0.15},
+                            "bottom_right": {"x": 1, "y": 0.15},
+                            "confidence": 0.99,
+                            "letters": [],
+                        }
+                    ],
+                }
+            ]
+        }
         tmp = Path(tempfile.mkstemp(suffix=".json")[1])
         tmp.write_text(json.dumps(ocr_json))
 
-        with patch("handler.ocr_processor.download_file_from_s3", return_value=tmp), \
-             patch("handler.ocr_processor.process_ocr_dict_as_image", return_value=([], [], [])), \
-             patch("handler.ocr_processor.image_ocr_to_receipt_ocr", return_value=([new_line], [new_word], [])):
+        with (
+            patch(
+                "handler.ocr_processor.download_file_from_s3", return_value=tmp
+            ),
+            patch(
+                "handler.ocr_processor.process_ocr_dict_as_image",
+                return_value=([], [], []),
+            ),
+            patch(
+                "handler.ocr_processor.image_ocr_to_receipt_ocr",
+                return_value=([new_line], [new_word], []),
+            ),
+        ):
             proc._process_regional_reocr_job(ocr_job, routing)
 
         updated_lines = proc.dynamo.update_receipt_lines.call_args[0][0]
@@ -870,35 +1181,92 @@ class TestLineTextRebuild:
 # 5. ReceiptLetter replacement
 # ===========================================================================
 
+
 class TestLetterReplacement:
     def _run_with_letters(self, proc, old_letters, new_letters_from_ocr):
         """Run overlay and return (letters_to_add, letters_to_delete) from mock calls."""
         ocr_job = SimpleNamespace(
-            image_id="00000000-0000-4000-8000-000000000001", receipt_id=1,
+            image_id="00000000-0000-4000-8000-000000000001",
+            receipt_id=1,
             reocr_region={"x": 0.70, "y": 0.0, "width": 0.30, "height": 1.0},
-            s3_bucket="b", s3_key="k",
+            s3_bucket="b",
+            s3_key="k",
         )
         routing = SimpleNamespace(
-            s3_bucket="b", s3_key="r.json",
-            status=None, receipt_count=None, updated_at=None,
+            s3_bucket="b",
+            s3_key="r.json",
+            status=None,
+            receipt_count=None,
+            updated_at=None,
         )
 
-        existing_w = _make_word(text="AB", x=0.80, y=0.1, w=0.1, h=0.05, line_id=1, word_id=1)
+        existing_w = _make_word(
+            text="AB", x=0.80, y=0.1, w=0.1, h=0.05, line_id=1, word_id=1
+        )
         proc.dynamo.list_receipt_words_from_receipt.return_value = [existing_w]
-        proc.dynamo.list_receipt_word_labels_for_receipt.return_value = ([], None)
+        proc.dynamo.list_receipt_word_labels_for_receipt.return_value = (
+            [],
+            None,
+        )
         proc.dynamo.list_receipt_letters_from_word.return_value = old_letters
         proc.dynamo.list_receipt_lines_from_receipt.return_value = []
 
-        new_word = _make_word(text="CD", x=0.0, y=0.1, w=1.0, h=0.05, line_id=1, word_id=1)
+        new_word = _make_word(
+            text="CD", x=0.0, y=0.1, w=1.0, h=0.05, line_id=1, word_id=1
+        )
         new_line = _make_line(text="CD", line_id=1)
 
-        ocr_json = {"lines": [{"text": "CD", "bounding_box": {"x": 0, "y": 0.1, "width": 1, "height": 0.05}, "top_left": {"x": 0, "y": 0.1}, "top_right": {"x": 1, "y": 0.1}, "bottom_left": {"x": 0, "y": 0.15}, "bottom_right": {"x": 1, "y": 0.15}, "confidence": 0.99, "words": [{"text": "CD", "bounding_box": {"x": 0, "y": 0.1, "width": 1, "height": 0.05}, "top_left": {"x": 0, "y": 0.1}, "top_right": {"x": 1, "y": 0.1}, "bottom_left": {"x": 0, "y": 0.15}, "bottom_right": {"x": 1, "y": 0.15}, "confidence": 0.99, "letters": []}]}]}
+        ocr_json = {
+            "lines": [
+                {
+                    "text": "CD",
+                    "bounding_box": {
+                        "x": 0,
+                        "y": 0.1,
+                        "width": 1,
+                        "height": 0.05,
+                    },
+                    "top_left": {"x": 0, "y": 0.1},
+                    "top_right": {"x": 1, "y": 0.1},
+                    "bottom_left": {"x": 0, "y": 0.15},
+                    "bottom_right": {"x": 1, "y": 0.15},
+                    "confidence": 0.99,
+                    "words": [
+                        {
+                            "text": "CD",
+                            "bounding_box": {
+                                "x": 0,
+                                "y": 0.1,
+                                "width": 1,
+                                "height": 0.05,
+                            },
+                            "top_left": {"x": 0, "y": 0.1},
+                            "top_right": {"x": 1, "y": 0.1},
+                            "bottom_left": {"x": 0, "y": 0.15},
+                            "bottom_right": {"x": 1, "y": 0.15},
+                            "confidence": 0.99,
+                            "letters": [],
+                        }
+                    ],
+                }
+            ]
+        }
         tmp = Path(tempfile.mkstemp(suffix=".json")[1])
         tmp.write_text(json.dumps(ocr_json))
 
-        with patch("handler.ocr_processor.download_file_from_s3", return_value=tmp), \
-             patch("handler.ocr_processor.process_ocr_dict_as_image", return_value=([], [], [])), \
-             patch("handler.ocr_processor.image_ocr_to_receipt_ocr", return_value=([new_line], [new_word], new_letters_from_ocr)):
+        with (
+            patch(
+                "handler.ocr_processor.download_file_from_s3", return_value=tmp
+            ),
+            patch(
+                "handler.ocr_processor.process_ocr_dict_as_image",
+                return_value=([], [], []),
+            ),
+            patch(
+                "handler.ocr_processor.image_ocr_to_receipt_ocr",
+                return_value=([new_line], [new_word], new_letters_from_ocr),
+            ),
+        ):
             proc._process_regional_reocr_job(ocr_job, routing)
 
         return proc
@@ -906,7 +1274,9 @@ class TestLetterReplacement:
     def test_old_letters_deleted(self):
         proc = _make_processor()
         old_letter = _make_letter(text="A", letter_id=1)
-        self._run_with_letters(proc, old_letters=[old_letter], new_letters_from_ocr=[])
+        self._run_with_letters(
+            proc, old_letters=[old_letter], new_letters_from_ocr=[]
+        )
         assert proc.dynamo.remove_receipt_letters.called
         deleted = proc.dynamo.remove_receipt_letters.call_args[0][0]
         assert len(deleted) == 1
@@ -914,9 +1284,31 @@ class TestLetterReplacement:
 
     def test_new_letters_use_existing_word_ids(self):
         proc = _make_processor()
-        new_letter_c = _make_letter(text="C", line_id=1, word_id=1, letter_id=1, x=0.0, y=0.1, w=0.01, h=0.05)
-        new_letter_d = _make_letter(text="D", line_id=1, word_id=1, letter_id=2, x=0.01, y=0.1, w=0.01, h=0.05)
-        self._run_with_letters(proc, old_letters=[], new_letters_from_ocr=[new_letter_c, new_letter_d])
+        new_letter_c = _make_letter(
+            text="C",
+            line_id=1,
+            word_id=1,
+            letter_id=1,
+            x=0.0,
+            y=0.1,
+            w=0.01,
+            h=0.05,
+        )
+        new_letter_d = _make_letter(
+            text="D",
+            line_id=1,
+            word_id=1,
+            letter_id=2,
+            x=0.01,
+            y=0.1,
+            w=0.01,
+            h=0.05,
+        )
+        self._run_with_letters(
+            proc,
+            old_letters=[],
+            new_letters_from_ocr=[new_letter_c, new_letter_d],
+        )
         assert proc.dynamo.put_receipt_letters.called
         added = proc.dynamo.put_receipt_letters.call_args[0][0]
         assert len(added) == 2
@@ -927,9 +1319,31 @@ class TestLetterReplacement:
 
     def test_sequential_letter_ids_starting_at_1(self):
         proc = _make_processor()
-        new_letter_c = _make_letter(text="C", line_id=1, word_id=1, letter_id=1, x=0.0, y=0.1, w=0.01, h=0.05)
-        new_letter_d = _make_letter(text="D", line_id=1, word_id=1, letter_id=2, x=0.01, y=0.1, w=0.01, h=0.05)
-        self._run_with_letters(proc, old_letters=[], new_letters_from_ocr=[new_letter_c, new_letter_d])
+        new_letter_c = _make_letter(
+            text="C",
+            line_id=1,
+            word_id=1,
+            letter_id=1,
+            x=0.0,
+            y=0.1,
+            w=0.01,
+            h=0.05,
+        )
+        new_letter_d = _make_letter(
+            text="D",
+            line_id=1,
+            word_id=1,
+            letter_id=2,
+            x=0.01,
+            y=0.1,
+            w=0.01,
+            h=0.05,
+        )
+        self._run_with_letters(
+            proc,
+            old_letters=[],
+            new_letters_from_ocr=[new_letter_c, new_letter_d],
+        )
         added = proc.dynamo.put_receipt_letters.call_args[0][0]
         letter_ids = [l.letter_id for l in added]
         assert letter_ids == [1, 2]
@@ -938,6 +1352,7 @@ class TestLetterReplacement:
 # ===========================================================================
 # 6. DynamoDB write ordering
 # ===========================================================================
+
 
 class TestWriteOrdering:
     def test_delete_before_add(self):
@@ -948,34 +1363,99 @@ class TestWriteOrdering:
         """
         proc = _make_processor()
         ocr_job = SimpleNamespace(
-            image_id="00000000-0000-4000-8000-000000000001", receipt_id=1,
+            image_id="00000000-0000-4000-8000-000000000001",
+            receipt_id=1,
             reocr_region={"x": 0.70, "y": 0.0, "width": 0.30, "height": 1.0},
-            s3_bucket="b", s3_key="k",
+            s3_bucket="b",
+            s3_key="k",
         )
         routing = SimpleNamespace(
-            s3_bucket="b", s3_key="r.json",
-            status=None, receipt_count=None, updated_at=None,
+            s3_bucket="b",
+            s3_key="r.json",
+            status=None,
+            receipt_count=None,
+            updated_at=None,
         )
 
-        existing_w = _make_word(text="OLD", x=0.80, y=0.1, w=0.1, h=0.05, line_id=1, word_id=1)
+        existing_w = _make_word(
+            text="OLD", x=0.80, y=0.1, w=0.1, h=0.05, line_id=1, word_id=1
+        )
         old_letter = _make_letter(text="O", letter_id=1)
 
         proc.dynamo.list_receipt_words_from_receipt.return_value = [existing_w]
-        proc.dynamo.list_receipt_word_labels_for_receipt.return_value = ([], None)
+        proc.dynamo.list_receipt_word_labels_for_receipt.return_value = (
+            [],
+            None,
+        )
         proc.dynamo.list_receipt_letters_from_word.return_value = [old_letter]
         proc.dynamo.list_receipt_lines_from_receipt.return_value = []
 
-        new_letter = _make_letter(text="N", line_id=1, word_id=1, letter_id=1, x=0.0, y=0.1, w=0.01, h=0.05)
-        new_word = _make_word(text="NEW", x=0.0, y=0.1, w=1.0, h=0.05, line_id=1, word_id=1)
+        new_letter = _make_letter(
+            text="N",
+            line_id=1,
+            word_id=1,
+            letter_id=1,
+            x=0.0,
+            y=0.1,
+            w=0.01,
+            h=0.05,
+        )
+        new_word = _make_word(
+            text="NEW", x=0.0, y=0.1, w=1.0, h=0.05, line_id=1, word_id=1
+        )
         new_line = _make_line(text="NEW", line_id=1)
 
-        ocr_json = {"lines": [{"text": "NEW", "bounding_box": {"x": 0, "y": 0.1, "width": 1, "height": 0.05}, "top_left": {"x": 0, "y": 0.1}, "top_right": {"x": 1, "y": 0.1}, "bottom_left": {"x": 0, "y": 0.15}, "bottom_right": {"x": 1, "y": 0.15}, "confidence": 0.99, "words": [{"text": "NEW", "bounding_box": {"x": 0, "y": 0.1, "width": 1, "height": 0.05}, "top_left": {"x": 0, "y": 0.1}, "top_right": {"x": 1, "y": 0.1}, "bottom_left": {"x": 0, "y": 0.15}, "bottom_right": {"x": 1, "y": 0.15}, "confidence": 0.99, "letters": []}]}]}
+        ocr_json = {
+            "lines": [
+                {
+                    "text": "NEW",
+                    "bounding_box": {
+                        "x": 0,
+                        "y": 0.1,
+                        "width": 1,
+                        "height": 0.05,
+                    },
+                    "top_left": {"x": 0, "y": 0.1},
+                    "top_right": {"x": 1, "y": 0.1},
+                    "bottom_left": {"x": 0, "y": 0.15},
+                    "bottom_right": {"x": 1, "y": 0.15},
+                    "confidence": 0.99,
+                    "words": [
+                        {
+                            "text": "NEW",
+                            "bounding_box": {
+                                "x": 0,
+                                "y": 0.1,
+                                "width": 1,
+                                "height": 0.05,
+                            },
+                            "top_left": {"x": 0, "y": 0.1},
+                            "top_right": {"x": 1, "y": 0.1},
+                            "bottom_left": {"x": 0, "y": 0.15},
+                            "bottom_right": {"x": 1, "y": 0.15},
+                            "confidence": 0.99,
+                            "letters": [],
+                        }
+                    ],
+                }
+            ]
+        }
         tmp = Path(tempfile.mkstemp(suffix=".json")[1])
         tmp.write_text(json.dumps(ocr_json))
 
-        with patch("handler.ocr_processor.download_file_from_s3", return_value=tmp), \
-             patch("handler.ocr_processor.process_ocr_dict_as_image", return_value=([], [], [])), \
-             patch("handler.ocr_processor.image_ocr_to_receipt_ocr", return_value=([new_line], [new_word], [new_letter])):
+        with (
+            patch(
+                "handler.ocr_processor.download_file_from_s3", return_value=tmp
+            ),
+            patch(
+                "handler.ocr_processor.process_ocr_dict_as_image",
+                return_value=([], [], []),
+            ),
+            patch(
+                "handler.ocr_processor.image_ocr_to_receipt_ocr",
+                return_value=([new_line], [new_word], [new_letter]),
+            ),
+        ):
             proc._process_regional_reocr_job(ocr_job, routing)
 
         # Extract call order from the mock manager
@@ -989,41 +1469,100 @@ class TestWriteOrdering:
                 del_idx = i
         assert add_idx is not None, "put_receipt_letters was never called"
         assert del_idx is not None, "remove_receipt_letters was never called"
-        assert del_idx < add_idx, "remove_receipt_letters must be called before put_receipt_letters"
+        assert (
+            del_idx < add_idx
+        ), "remove_receipt_letters must be called before put_receipt_letters"
 
 
 # ===========================================================================
 # 7. is_noise recomputation
 # ===========================================================================
 
+
 class TestIsNoiseRecomputation:
     def _run_overlay_with_text(self, proc, new_text):
         ocr_job = SimpleNamespace(
-            image_id="00000000-0000-4000-8000-000000000001", receipt_id=1,
+            image_id="00000000-0000-4000-8000-000000000001",
+            receipt_id=1,
             reocr_region={"x": 0.70, "y": 0.0, "width": 0.30, "height": 1.0},
-            s3_bucket="b", s3_key="k",
+            s3_bucket="b",
+            s3_key="k",
         )
         routing = SimpleNamespace(
-            s3_bucket="b", s3_key="r.json",
-            status=None, receipt_count=None, updated_at=None,
+            s3_bucket="b",
+            s3_key="r.json",
+            status=None,
+            receipt_count=None,
+            updated_at=None,
         )
 
-        existing_w = _make_word(text="OLD", x=0.80, y=0.1, w=0.1, h=0.05, line_id=1, word_id=1)
+        existing_w = _make_word(
+            text="OLD", x=0.80, y=0.1, w=0.1, h=0.05, line_id=1, word_id=1
+        )
         proc.dynamo.list_receipt_words_from_receipt.return_value = [existing_w]
-        proc.dynamo.list_receipt_word_labels_for_receipt.return_value = ([], None)
+        proc.dynamo.list_receipt_word_labels_for_receipt.return_value = (
+            [],
+            None,
+        )
         proc.dynamo.list_receipt_letters_from_word.return_value = []
         proc.dynamo.list_receipt_lines_from_receipt.return_value = []
 
-        new_word = _make_word(text=new_text, x=0.0, y=0.1, w=1.0, h=0.05, line_id=1, word_id=1)
+        new_word = _make_word(
+            text=new_text, x=0.0, y=0.1, w=1.0, h=0.05, line_id=1, word_id=1
+        )
         new_line = _make_line(text=new_text, line_id=1)
 
-        ocr_json = {"lines": [{"text": new_text, "bounding_box": {"x": 0, "y": 0.1, "width": 1, "height": 0.05}, "top_left": {"x": 0, "y": 0.1}, "top_right": {"x": 1, "y": 0.1}, "bottom_left": {"x": 0, "y": 0.15}, "bottom_right": {"x": 1, "y": 0.15}, "confidence": 0.99, "words": [{"text": new_text, "bounding_box": {"x": 0, "y": 0.1, "width": 1, "height": 0.05}, "top_left": {"x": 0, "y": 0.1}, "top_right": {"x": 1, "y": 0.1}, "bottom_left": {"x": 0, "y": 0.15}, "bottom_right": {"x": 1, "y": 0.15}, "confidence": 0.99, "letters": []}]}]}
+        ocr_json = {
+            "lines": [
+                {
+                    "text": new_text,
+                    "bounding_box": {
+                        "x": 0,
+                        "y": 0.1,
+                        "width": 1,
+                        "height": 0.05,
+                    },
+                    "top_left": {"x": 0, "y": 0.1},
+                    "top_right": {"x": 1, "y": 0.1},
+                    "bottom_left": {"x": 0, "y": 0.15},
+                    "bottom_right": {"x": 1, "y": 0.15},
+                    "confidence": 0.99,
+                    "words": [
+                        {
+                            "text": new_text,
+                            "bounding_box": {
+                                "x": 0,
+                                "y": 0.1,
+                                "width": 1,
+                                "height": 0.05,
+                            },
+                            "top_left": {"x": 0, "y": 0.1},
+                            "top_right": {"x": 1, "y": 0.1},
+                            "bottom_left": {"x": 0, "y": 0.15},
+                            "bottom_right": {"x": 1, "y": 0.15},
+                            "confidence": 0.99,
+                            "letters": [],
+                        }
+                    ],
+                }
+            ]
+        }
         tmp = Path(tempfile.mkstemp(suffix=".json")[1])
         tmp.write_text(json.dumps(ocr_json))
 
-        with patch("handler.ocr_processor.download_file_from_s3", return_value=tmp), \
-             patch("handler.ocr_processor.process_ocr_dict_as_image", return_value=([], [], [])), \
-             patch("handler.ocr_processor.image_ocr_to_receipt_ocr", return_value=([new_line], [new_word], [])):
+        with (
+            patch(
+                "handler.ocr_processor.download_file_from_s3", return_value=tmp
+            ),
+            patch(
+                "handler.ocr_processor.process_ocr_dict_as_image",
+                return_value=([], [], []),
+            ),
+            patch(
+                "handler.ocr_processor.image_ocr_to_receipt_ocr",
+                return_value=([new_line], [new_word], []),
+            ),
+        ):
             proc._process_regional_reocr_job(ocr_job, routing)
         return proc
 
@@ -1046,68 +1585,125 @@ class TestIsNoiseRecomputation:
 # 8. Integration / end-to-end (fully mocked)
 # ===========================================================================
 
+
 class TestIntegrationEndToEnd:
     def _build_ocr_json(self, words_data):
         """Build a minimal OCR JSON with the given words."""
         words = []
         for wd in words_data:
-            words.append({
-                "text": wd["text"],
-                "bounding_box": {"x": wd.get("x", 0.0), "y": wd.get("y", 0.1), "width": wd.get("w", 1.0), "height": wd.get("h", 0.05)},
-                "top_left": {"x": wd.get("x", 0.0), "y": wd.get("y", 0.1)},
-                "top_right": {"x": wd.get("x", 0.0) + wd.get("w", 1.0), "y": wd.get("y", 0.1)},
-                "bottom_left": {"x": wd.get("x", 0.0), "y": wd.get("y", 0.1) + wd.get("h", 0.05)},
-                "bottom_right": {"x": wd.get("x", 0.0) + wd.get("w", 1.0), "y": wd.get("y", 0.1) + wd.get("h", 0.05)},
-                "confidence": 0.99,
-                "letters": [],
-            })
+            words.append(
+                {
+                    "text": wd["text"],
+                    "bounding_box": {
+                        "x": wd.get("x", 0.0),
+                        "y": wd.get("y", 0.1),
+                        "width": wd.get("w", 1.0),
+                        "height": wd.get("h", 0.05),
+                    },
+                    "top_left": {"x": wd.get("x", 0.0), "y": wd.get("y", 0.1)},
+                    "top_right": {
+                        "x": wd.get("x", 0.0) + wd.get("w", 1.0),
+                        "y": wd.get("y", 0.1),
+                    },
+                    "bottom_left": {
+                        "x": wd.get("x", 0.0),
+                        "y": wd.get("y", 0.1) + wd.get("h", 0.05),
+                    },
+                    "bottom_right": {
+                        "x": wd.get("x", 0.0) + wd.get("w", 1.0),
+                        "y": wd.get("y", 0.1) + wd.get("h", 0.05),
+                    },
+                    "confidence": 0.99,
+                    "letters": [],
+                }
+            )
         line_text = " ".join(wd["text"] for wd in words_data)
         return {
-            "lines": [{
-                "text": line_text,
-                "bounding_box": {"x": 0.0, "y": 0.1, "width": 1.0, "height": 0.05},
-                "top_left": {"x": 0.0, "y": 0.1},
-                "top_right": {"x": 1.0, "y": 0.1},
-                "bottom_left": {"x": 0.0, "y": 0.15},
-                "bottom_right": {"x": 1.0, "y": 0.15},
-                "confidence": 0.99,
-                "words": words,
-            }]
+            "lines": [
+                {
+                    "text": line_text,
+                    "bounding_box": {
+                        "x": 0.0,
+                        "y": 0.1,
+                        "width": 1.0,
+                        "height": 0.05,
+                    },
+                    "top_left": {"x": 0.0, "y": 0.1},
+                    "top_right": {"x": 1.0, "y": 0.1},
+                    "bottom_left": {"x": 0.0, "y": 0.15},
+                    "bottom_right": {"x": 1.0, "y": 0.15},
+                    "confidence": 0.99,
+                    "words": words,
+                }
+            ]
         }
 
     def test_full_flow(self):
         """End-to-end: one new word overlays one existing word, letters replaced, line rebuilt."""
         proc = _make_processor()
         ocr_job = SimpleNamespace(
-            image_id="00000000-0000-4000-8000-000000000001", receipt_id=1,
+            image_id="00000000-0000-4000-8000-000000000001",
+            receipt_id=1,
             reocr_region={"x": 0.70, "y": 0.0, "width": 0.30, "height": 1.0},
-            s3_bucket="b", s3_key="k",
+            s3_bucket="b",
+            s3_key="k",
         )
         routing = SimpleNamespace(
-            s3_bucket="b", s3_key="r.json",
-            status=None, receipt_count=None, updated_at=None,
+            s3_bucket="b",
+            s3_key="r.json",
+            status=None,
+            receipt_count=None,
+            updated_at=None,
         )
 
-        existing_w = _make_word(text="OLD", x=0.80, y=0.1, w=0.1, h=0.05, line_id=1, word_id=1)
+        existing_w = _make_word(
+            text="OLD", x=0.80, y=0.1, w=0.1, h=0.05, line_id=1, word_id=1
+        )
         existing_line = _make_line(text="OLD", line_id=1)
         old_letter = _make_letter(text="O", letter_id=1)
 
         proc.dynamo.list_receipt_words_from_receipt.return_value = [existing_w]
-        proc.dynamo.list_receipt_word_labels_for_receipt.return_value = ([], None)
+        proc.dynamo.list_receipt_word_labels_for_receipt.return_value = (
+            [],
+            None,
+        )
         proc.dynamo.list_receipt_letters_from_word.return_value = [old_letter]
-        proc.dynamo.list_receipt_lines_from_receipt.return_value = [existing_line]
+        proc.dynamo.list_receipt_lines_from_receipt.return_value = [
+            existing_line
+        ]
 
-        new_word = _make_word(text="NEW", x=0.0, y=0.1, w=1.0, h=0.05, line_id=1, word_id=1)
+        new_word = _make_word(
+            text="NEW", x=0.0, y=0.1, w=1.0, h=0.05, line_id=1, word_id=1
+        )
         new_line = _make_line(text="NEW", line_id=1)
-        new_letter_n = _make_letter(text="N", line_id=1, word_id=1, letter_id=1, x=0.0, y=0.1, w=0.01, h=0.05)
+        new_letter_n = _make_letter(
+            text="N",
+            line_id=1,
+            word_id=1,
+            letter_id=1,
+            x=0.0,
+            y=0.1,
+            w=0.01,
+            h=0.05,
+        )
 
         ocr_json = self._build_ocr_json([{"text": "NEW"}])
         tmp = Path(tempfile.mkstemp(suffix=".json")[1])
         tmp.write_text(json.dumps(ocr_json))
 
-        with patch("handler.ocr_processor.download_file_from_s3", return_value=tmp), \
-             patch("handler.ocr_processor.process_ocr_dict_as_image", return_value=([], [], [])), \
-             patch("handler.ocr_processor.image_ocr_to_receipt_ocr", return_value=([new_line], [new_word], [new_letter_n])):
+        with (
+            patch(
+                "handler.ocr_processor.download_file_from_s3", return_value=tmp
+            ),
+            patch(
+                "handler.ocr_processor.process_ocr_dict_as_image",
+                return_value=([], [], []),
+            ),
+            patch(
+                "handler.ocr_processor.image_ocr_to_receipt_ocr",
+                return_value=([new_line], [new_word], [new_letter_n]),
+            ),
+        ):
             result = proc._process_regional_reocr_job(ocr_job, routing)
 
         assert result["success"] is True
@@ -1123,13 +1719,18 @@ class TestIntegrationEndToEnd:
         """Should return error when no existing words found."""
         proc = _make_processor()
         ocr_job = SimpleNamespace(
-            image_id="00000000-0000-4000-8000-000000000001", receipt_id=1,
+            image_id="00000000-0000-4000-8000-000000000001",
+            receipt_id=1,
             reocr_region={"x": 0.70, "y": 0.0, "width": 0.30, "height": 1.0},
-            s3_bucket="b", s3_key="k",
+            s3_bucket="b",
+            s3_key="k",
         )
         routing = SimpleNamespace(
-            s3_bucket="b", s3_key="r.json",
-            status=None, receipt_count=None, updated_at=None,
+            s3_bucket="b",
+            s3_key="r.json",
+            status=None,
+            receipt_count=None,
+            updated_at=None,
         )
 
         proc.dynamo.list_receipt_words_from_receipt.return_value = []
@@ -1138,9 +1739,19 @@ class TestIntegrationEndToEnd:
         tmp = Path(tempfile.mkstemp(suffix=".json")[1])
         tmp.write_text(json.dumps(ocr_json))
 
-        with patch("handler.ocr_processor.download_file_from_s3", return_value=tmp), \
-             patch("handler.ocr_processor.process_ocr_dict_as_image", return_value=([], [], [])), \
-             patch("handler.ocr_processor.image_ocr_to_receipt_ocr", return_value=([], [], [])):
+        with (
+            patch(
+                "handler.ocr_processor.download_file_from_s3", return_value=tmp
+            ),
+            patch(
+                "handler.ocr_processor.process_ocr_dict_as_image",
+                return_value=([], [], []),
+            ),
+            patch(
+                "handler.ocr_processor.image_ocr_to_receipt_ocr",
+                return_value=([], [], []),
+            ),
+        ):
             result = proc._process_regional_reocr_job(ocr_job, routing)
 
         assert result["success"] is False
@@ -1150,32 +1761,54 @@ class TestIntegrationEndToEnd:
         """If regional words don't match any existing words, overlay still succeeds with 0 replacements."""
         proc = _make_processor()
         ocr_job = SimpleNamespace(
-            image_id="00000000-0000-4000-8000-000000000001", receipt_id=1,
+            image_id="00000000-0000-4000-8000-000000000001",
+            receipt_id=1,
             reocr_region={"x": 0.70, "y": 0.0, "width": 0.30, "height": 1.0},
-            s3_bucket="b", s3_key="k",
+            s3_bucket="b",
+            s3_key="k",
         )
         routing = SimpleNamespace(
-            s3_bucket="b", s3_key="r.json",
-            status=None, receipt_count=None, updated_at=None,
+            s3_bucket="b",
+            s3_key="r.json",
+            status=None,
+            receipt_count=None,
+            updated_at=None,
         )
 
         # Existing word is far from where the regional word will land
-        existing_w = _make_word(text="FAR", x=0.80, y=0.9, w=0.1, h=0.02, line_id=1, word_id=1)
+        existing_w = _make_word(
+            text="FAR", x=0.80, y=0.9, w=0.1, h=0.02, line_id=1, word_id=1
+        )
         proc.dynamo.list_receipt_words_from_receipt.return_value = [existing_w]
-        proc.dynamo.list_receipt_word_labels_for_receipt.return_value = ([], None)
+        proc.dynamo.list_receipt_word_labels_for_receipt.return_value = (
+            [],
+            None,
+        )
         proc.dynamo.list_receipt_lines_from_receipt.return_value = []
 
         # New word lands at y=0.1 which has no overlap with existing at y=0.9
-        new_word = _make_word(text="99.99", x=0.0, y=0.1, w=1.0, h=0.02, line_id=1, word_id=1)
+        new_word = _make_word(
+            text="99.99", x=0.0, y=0.1, w=1.0, h=0.02, line_id=1, word_id=1
+        )
         new_line = _make_line(text="99.99", line_id=1)
 
         ocr_json = self._build_ocr_json([{"text": "99.99", "h": 0.02}])
         tmp = Path(tempfile.mkstemp(suffix=".json")[1])
         tmp.write_text(json.dumps(ocr_json))
 
-        with patch("handler.ocr_processor.download_file_from_s3", return_value=tmp), \
-             patch("handler.ocr_processor.process_ocr_dict_as_image", return_value=([], [], [])), \
-             patch("handler.ocr_processor.image_ocr_to_receipt_ocr", return_value=([new_line], [new_word], [])):
+        with (
+            patch(
+                "handler.ocr_processor.download_file_from_s3", return_value=tmp
+            ),
+            patch(
+                "handler.ocr_processor.process_ocr_dict_as_image",
+                return_value=([], [], []),
+            ),
+            patch(
+                "handler.ocr_processor.image_ocr_to_receipt_ocr",
+                return_value=([new_line], [new_word], []),
+            ),
+        ):
             result = proc._process_regional_reocr_job(ocr_job, routing)
 
         assert result["success"] is True
@@ -1185,7 +1818,8 @@ class TestIntegrationEndToEnd:
         """Should return error when receipt_id is None."""
         proc = _make_processor()
         ocr_job = SimpleNamespace(
-            image_id="00000000-0000-4000-8000-000000000001", receipt_id=None,
+            image_id="00000000-0000-4000-8000-000000000001",
+            receipt_id=None,
             reocr_region={"x": 0.70, "y": 0.0, "width": 0.30, "height": 1.0},
         )
         routing = SimpleNamespace()
@@ -1197,7 +1831,8 @@ class TestIntegrationEndToEnd:
         """Should return error when reocr_region is missing/empty."""
         proc = _make_processor()
         ocr_job = SimpleNamespace(
-            image_id="00000000-0000-4000-8000-000000000001", receipt_id=1,
+            image_id="00000000-0000-4000-8000-000000000001",
+            receipt_id=1,
             reocr_region=None,
         )
         routing = SimpleNamespace()
@@ -1210,6 +1845,7 @@ class TestIntegrationEndToEnd:
 # 9. Orphan deletion
 # ===========================================================================
 
+
 class TestOrphanDeletion:
     """Tests for deleting candidate words that aren't matched by new re-OCR words."""
 
@@ -1217,72 +1853,138 @@ class TestOrphanDeletion:
         """Build a minimal OCR JSON with the given words."""
         words = []
         for wd in words_data:
-            words.append({
-                "text": wd["text"],
-                "bounding_box": {"x": wd.get("x", 0.0), "y": wd.get("y", 0.1), "width": wd.get("w", 1.0), "height": wd.get("h", 0.05)},
-                "top_left": {"x": wd.get("x", 0.0), "y": wd.get("y", 0.1)},
-                "top_right": {"x": wd.get("x", 0.0) + wd.get("w", 1.0), "y": wd.get("y", 0.1)},
-                "bottom_left": {"x": wd.get("x", 0.0), "y": wd.get("y", 0.1) + wd.get("h", 0.05)},
-                "bottom_right": {"x": wd.get("x", 0.0) + wd.get("w", 1.0), "y": wd.get("y", 0.1) + wd.get("h", 0.05)},
-                "confidence": 0.99,
-                "letters": [],
-            })
+            words.append(
+                {
+                    "text": wd["text"],
+                    "bounding_box": {
+                        "x": wd.get("x", 0.0),
+                        "y": wd.get("y", 0.1),
+                        "width": wd.get("w", 1.0),
+                        "height": wd.get("h", 0.05),
+                    },
+                    "top_left": {"x": wd.get("x", 0.0), "y": wd.get("y", 0.1)},
+                    "top_right": {
+                        "x": wd.get("x", 0.0) + wd.get("w", 1.0),
+                        "y": wd.get("y", 0.1),
+                    },
+                    "bottom_left": {
+                        "x": wd.get("x", 0.0),
+                        "y": wd.get("y", 0.1) + wd.get("h", 0.05),
+                    },
+                    "bottom_right": {
+                        "x": wd.get("x", 0.0) + wd.get("w", 1.0),
+                        "y": wd.get("y", 0.1) + wd.get("h", 0.05),
+                    },
+                    "confidence": 0.99,
+                    "letters": [],
+                }
+            )
         line_text = " ".join(wd["text"] for wd in words_data)
         return {
-            "lines": [{
-                "text": line_text,
-                "bounding_box": {"x": 0.0, "y": 0.1, "width": 1.0, "height": 0.05},
-                "top_left": {"x": 0.0, "y": 0.1},
-                "top_right": {"x": 1.0, "y": 0.1},
-                "bottom_left": {"x": 0.0, "y": 0.15},
-                "bottom_right": {"x": 1.0, "y": 0.15},
-                "confidence": 0.99,
-                "words": words,
-            }]
+            "lines": [
+                {
+                    "text": line_text,
+                    "bounding_box": {
+                        "x": 0.0,
+                        "y": 0.1,
+                        "width": 1.0,
+                        "height": 0.05,
+                    },
+                    "top_left": {"x": 0.0, "y": 0.1},
+                    "top_right": {"x": 1.0, "y": 0.1},
+                    "bottom_left": {"x": 0.0, "y": 0.15},
+                    "bottom_right": {"x": 1.0, "y": 0.15},
+                    "confidence": 0.99,
+                    "words": words,
+                }
+            ]
         }
 
     def test_orphaned_word_deleted(self):
         """An existing word in the re-OCR region that no new word matches should be deleted."""
         proc = _make_processor()
         ocr_job = SimpleNamespace(
-            image_id=_IMG_ID, receipt_id=1,
+            image_id=_IMG_ID,
+            receipt_id=1,
             reocr_region={"x": 0.70, "y": 0.0, "width": 0.30, "height": 1.0},
-            s3_bucket="b", s3_key="k",
+            s3_bucket="b",
+            s3_key="k",
         )
         routing = SimpleNamespace(
-            s3_bucket="b", s3_key="r.json",
-            status=None, receipt_count=None, updated_at=None,
+            s3_bucket="b",
+            s3_key="r.json",
+            status=None,
+            receipt_count=None,
+            updated_at=None,
         )
 
         # Two existing words in the region: "GOOD" at x=0.75, "JUNK" at x=0.90.
         # Re-OCR produces only one word ("GOOD") matching the first.
         # "JUNK" becomes an orphan and should be deleted.
-        existing_good = _make_word(text="GOOD", x=0.75, y=0.1, w=0.1, h=0.05, line_id=1, word_id=1)
-        existing_junk = _make_word(text="JUNK", x=0.90, y=0.1, w=0.05, h=0.05, line_id=1, word_id=2)
-        junk_letter = _make_letter(text="J", line_id=1, word_id=2, letter_id=1, x=0.90, y=0.1, w=0.01, h=0.05)
+        existing_good = _make_word(
+            text="GOOD", x=0.75, y=0.1, w=0.1, h=0.05, line_id=1, word_id=1
+        )
+        existing_junk = _make_word(
+            text="JUNK", x=0.90, y=0.1, w=0.05, h=0.05, line_id=1, word_id=2
+        )
+        junk_letter = _make_letter(
+            text="J",
+            line_id=1,
+            word_id=2,
+            letter_id=1,
+            x=0.90,
+            y=0.1,
+            w=0.01,
+            h=0.05,
+        )
 
-        proc.dynamo.list_receipt_words_from_receipt.return_value = [existing_good, existing_junk]
-        proc.dynamo.list_receipt_word_labels_for_receipt.return_value = ([], None)
+        proc.dynamo.list_receipt_words_from_receipt.return_value = [
+            existing_good,
+            existing_junk,
+        ]
+        proc.dynamo.list_receipt_word_labels_for_receipt.return_value = (
+            [],
+            None,
+        )
 
         # list_receipt_letters_from_word is called for matched words AND orphans.
         # First call: matched word (existing_good) — returns empty.
         # Second call: orphan (existing_junk) — returns its letter.
-        proc.dynamo.list_receipt_letters_from_word.side_effect = [[], [junk_letter]]
+        proc.dynamo.list_receipt_letters_from_word.side_effect = [
+            [],
+            [junk_letter],
+        ]
 
         existing_line = _make_line(text="GOOD JUNK", line_id=1)
-        proc.dynamo.list_receipt_lines_from_receipt.return_value = [existing_line]
+        proc.dynamo.list_receipt_lines_from_receipt.return_value = [
+            existing_line
+        ]
 
         # Re-OCR produces one word "BETTER" that matches "GOOD" by position.
-        new_word = _make_word(text="BETTER", x=0.0, y=0.1, w=0.5, h=0.05, line_id=1, word_id=1)
+        new_word = _make_word(
+            text="BETTER", x=0.0, y=0.1, w=0.5, h=0.05, line_id=1, word_id=1
+        )
         new_line = _make_line(text="BETTER", line_id=1)
 
-        ocr_json = self._build_ocr_json([{"text": "BETTER", "x": 0.0, "w": 0.5}])
+        ocr_json = self._build_ocr_json(
+            [{"text": "BETTER", "x": 0.0, "w": 0.5}]
+        )
         tmp = Path(tempfile.mkstemp(suffix=".json")[1])
         tmp.write_text(json.dumps(ocr_json))
 
-        with patch("handler.ocr_processor.download_file_from_s3", return_value=tmp), \
-             patch("handler.ocr_processor.process_ocr_dict_as_image", return_value=([], [], [])), \
-             patch("handler.ocr_processor.image_ocr_to_receipt_ocr", return_value=([new_line], [new_word], [])):
+        with (
+            patch(
+                "handler.ocr_processor.download_file_from_s3", return_value=tmp
+            ),
+            patch(
+                "handler.ocr_processor.process_ocr_dict_as_image",
+                return_value=([], [], []),
+            ),
+            patch(
+                "handler.ocr_processor.image_ocr_to_receipt_ocr",
+                return_value=([new_line], [new_word], []),
+            ),
+        ):
             result = proc._process_regional_reocr_job(ocr_job, routing)
 
         assert result["success"] is True
@@ -1304,50 +2006,94 @@ class TestOrphanDeletion:
         """Rebuilt ReceiptLine.text must not contain orphaned words."""
         proc = _make_processor()
         ocr_job = SimpleNamespace(
-            image_id=_IMG_ID, receipt_id=1,
+            image_id=_IMG_ID,
+            receipt_id=1,
             reocr_region={"x": 0.70, "y": 0.0, "width": 0.30, "height": 1.0},
-            s3_bucket="b", s3_key="k",
+            s3_bucket="b",
+            s3_key="k",
         )
         routing = SimpleNamespace(
-            s3_bucket="b", s3_key="r.json",
-            status=None, receipt_count=None, updated_at=None,
+            s3_bucket="b",
+            s3_key="r.json",
+            status=None,
+            receipt_count=None,
+            updated_at=None,
         )
 
         # Three existing words on line 1, all inside the region.
         # Re-OCR matches word 1 ("AAA") and word 3 ("CCC") but NOT word 2 ("GARBLED").
-        existing_a = _make_word(text="AAA", x=0.72, y=0.1, w=0.05, h=0.05, line_id=1, word_id=1)
-        existing_garble = _make_word(text="GARBLED", x=0.80, y=0.1, w=0.05, h=0.05, line_id=1, word_id=2)
-        existing_c = _make_word(text="CCC", x=0.88, y=0.1, w=0.05, h=0.05, line_id=1, word_id=3)
+        existing_a = _make_word(
+            text="AAA", x=0.72, y=0.1, w=0.05, h=0.05, line_id=1, word_id=1
+        )
+        existing_garble = _make_word(
+            text="GARBLED", x=0.80, y=0.1, w=0.05, h=0.05, line_id=1, word_id=2
+        )
+        existing_c = _make_word(
+            text="CCC", x=0.88, y=0.1, w=0.05, h=0.05, line_id=1, word_id=3
+        )
 
-        proc.dynamo.list_receipt_words_from_receipt.return_value = [existing_a, existing_garble, existing_c]
-        proc.dynamo.list_receipt_word_labels_for_receipt.return_value = ([], None)
+        proc.dynamo.list_receipt_words_from_receipt.return_value = [
+            existing_a,
+            existing_garble,
+            existing_c,
+        ]
+        proc.dynamo.list_receipt_word_labels_for_receipt.return_value = (
+            [],
+            None,
+        )
 
         # Letters: matched words return empty, orphan returns its letters.
         garble_letters = [
-            _make_letter(text="G", line_id=1, word_id=2, letter_id=1, x=0.80, y=0.1),
-            _make_letter(text="A", line_id=1, word_id=2, letter_id=2, x=0.81, y=0.1),
+            _make_letter(
+                text="G", line_id=1, word_id=2, letter_id=1, x=0.80, y=0.1
+            ),
+            _make_letter(
+                text="A", line_id=1, word_id=2, letter_id=2, x=0.81, y=0.1
+            ),
         ]
         # Calls: word_id=1 match, word_id=3 match, then orphan word_id=2.
-        proc.dynamo.list_receipt_letters_from_word.side_effect = [[], [], garble_letters]
+        proc.dynamo.list_receipt_letters_from_word.side_effect = [
+            [],
+            [],
+            garble_letters,
+        ]
 
         existing_line = _make_line(text="AAA GARBLED CCC", line_id=1)
-        proc.dynamo.list_receipt_lines_from_receipt.return_value = [existing_line]
+        proc.dynamo.list_receipt_lines_from_receipt.return_value = [
+            existing_line
+        ]
 
         # Re-OCR produces 2 words at the same Y, matching word 1 and word 3.
-        new_a = _make_word(text="ALPHA", x=0.0, y=0.1, w=0.3, h=0.05, line_id=1, word_id=1)
-        new_c = _make_word(text="GAMMA", x=0.5, y=0.1, w=0.3, h=0.05, line_id=1, word_id=2)
+        new_a = _make_word(
+            text="ALPHA", x=0.0, y=0.1, w=0.3, h=0.05, line_id=1, word_id=1
+        )
+        new_c = _make_word(
+            text="GAMMA", x=0.5, y=0.1, w=0.3, h=0.05, line_id=1, word_id=2
+        )
         new_line = _make_line(text="ALPHA GAMMA", line_id=1)
 
-        ocr_json = self._build_ocr_json([
-            {"text": "ALPHA", "x": 0.0, "w": 0.3},
-            {"text": "GAMMA", "x": 0.5, "w": 0.3},
-        ])
+        ocr_json = self._build_ocr_json(
+            [
+                {"text": "ALPHA", "x": 0.0, "w": 0.3},
+                {"text": "GAMMA", "x": 0.5, "w": 0.3},
+            ]
+        )
         tmp = Path(tempfile.mkstemp(suffix=".json")[1])
         tmp.write_text(json.dumps(ocr_json))
 
-        with patch("handler.ocr_processor.download_file_from_s3", return_value=tmp), \
-             patch("handler.ocr_processor.process_ocr_dict_as_image", return_value=([], [], [])), \
-             patch("handler.ocr_processor.image_ocr_to_receipt_ocr", return_value=([new_line], [new_a, new_c], [])):
+        with (
+            patch(
+                "handler.ocr_processor.download_file_from_s3", return_value=tmp
+            ),
+            patch(
+                "handler.ocr_processor.process_ocr_dict_as_image",
+                return_value=([], [], []),
+            ),
+            patch(
+                "handler.ocr_processor.image_ocr_to_receipt_ocr",
+                return_value=([new_line], [new_a, new_c], []),
+            ),
+        ):
             result = proc._process_regional_reocr_job(ocr_job, routing)
 
         assert result["success"] is True
@@ -1365,79 +2111,140 @@ class TestOrphanDeletion:
         """Orphan letters must be removed before orphan words are deleted."""
         proc = _make_processor()
         ocr_job = SimpleNamespace(
-            image_id=_IMG_ID, receipt_id=1,
+            image_id=_IMG_ID,
+            receipt_id=1,
             reocr_region={"x": 0.70, "y": 0.0, "width": 0.30, "height": 1.0},
-            s3_bucket="b", s3_key="k",
+            s3_bucket="b",
+            s3_key="k",
         )
         routing = SimpleNamespace(
-            s3_bucket="b", s3_key="r.json",
-            status=None, receipt_count=None, updated_at=None,
+            s3_bucket="b",
+            s3_key="r.json",
+            status=None,
+            receipt_count=None,
+            updated_at=None,
         )
 
         # One existing word in the region, no re-OCR words match it.
-        existing_orphan = _make_word(text="STALE", x=0.80, y=0.1, w=0.1, h=0.05, line_id=1, word_id=1)
-        orphan_letter = _make_letter(text="S", line_id=1, word_id=1, letter_id=1, x=0.80, y=0.1)
+        existing_orphan = _make_word(
+            text="STALE", x=0.80, y=0.1, w=0.1, h=0.05, line_id=1, word_id=1
+        )
+        orphan_letter = _make_letter(
+            text="S", line_id=1, word_id=1, letter_id=1, x=0.80, y=0.1
+        )
 
         # Also add an existing word OUTSIDE the region so the receipt has words.
-        existing_outside = _make_word(text="KEEPER", x=0.10, y=0.1, w=0.1, h=0.05, line_id=1, word_id=2)
+        existing_outside = _make_word(
+            text="KEEPER", x=0.10, y=0.1, w=0.1, h=0.05, line_id=1, word_id=2
+        )
 
-        proc.dynamo.list_receipt_words_from_receipt.return_value = [existing_orphan, existing_outside]
-        proc.dynamo.list_receipt_word_labels_for_receipt.return_value = ([], None)
-        proc.dynamo.list_receipt_letters_from_word.return_value = [orphan_letter]
+        proc.dynamo.list_receipt_words_from_receipt.return_value = [
+            existing_orphan,
+            existing_outside,
+        ]
+        proc.dynamo.list_receipt_word_labels_for_receipt.return_value = (
+            [],
+            None,
+        )
+        proc.dynamo.list_receipt_letters_from_word.return_value = [
+            orphan_letter
+        ]
         proc.dynamo.list_receipt_lines_from_receipt.return_value = [
             _make_line(text="STALE KEEPER", line_id=1),
         ]
 
         # Re-OCR produces no words (region was all noise).
-        ocr_json = self._build_ocr_json([{"text": "X", "x": 0.0, "y": 0.8, "h": 0.01}])
+        ocr_json = self._build_ocr_json(
+            [{"text": "X", "x": 0.0, "y": 0.8, "h": 0.01}]
+        )
         tmp = Path(tempfile.mkstemp(suffix=".json")[1])
         tmp.write_text(json.dumps(ocr_json))
 
-        new_word = _make_word(text="X", x=0.0, y=0.8, w=0.01, h=0.01, line_id=1, word_id=1)
+        new_word = _make_word(
+            text="X", x=0.0, y=0.8, w=0.01, h=0.01, line_id=1, word_id=1
+        )
         new_line = _make_line(text="X", line_id=1)
 
-        with patch("handler.ocr_processor.download_file_from_s3", return_value=tmp), \
-             patch("handler.ocr_processor.process_ocr_dict_as_image", return_value=([], [], [])), \
-             patch("handler.ocr_processor.image_ocr_to_receipt_ocr", return_value=([new_line], [new_word], [])):
+        with (
+            patch(
+                "handler.ocr_processor.download_file_from_s3", return_value=tmp
+            ),
+            patch(
+                "handler.ocr_processor.process_ocr_dict_as_image",
+                return_value=([], [], []),
+            ),
+            patch(
+                "handler.ocr_processor.image_ocr_to_receipt_ocr",
+                return_value=([new_line], [new_word], []),
+            ),
+        ):
             proc._process_regional_reocr_job(ocr_job, routing)
 
         # Extract call order: remove_receipt_letters must precede delete_receipt_words.
         call_names = [c[0] for c in proc.dynamo.method_calls]
-        remove_idx = next(i for i, n in enumerate(call_names) if n == "remove_receipt_letters")
-        delete_idx = next(i for i, n in enumerate(call_names) if n == "delete_receipt_words")
-        assert remove_idx < delete_idx, (
-            "remove_receipt_letters must be called before delete_receipt_words"
+        remove_idx = next(
+            i
+            for i, n in enumerate(call_names)
+            if n == "remove_receipt_letters"
         )
+        delete_idx = next(
+            i for i, n in enumerate(call_names) if n == "delete_receipt_words"
+        )
+        assert (
+            remove_idx < delete_idx
+        ), "remove_receipt_letters must be called before delete_receipt_words"
 
     def test_no_orphans_when_all_matched(self):
         """When every candidate word matches a re-OCR word, nothing should be deleted."""
         proc = _make_processor()
         ocr_job = SimpleNamespace(
-            image_id=_IMG_ID, receipt_id=1,
+            image_id=_IMG_ID,
+            receipt_id=1,
             reocr_region={"x": 0.70, "y": 0.0, "width": 0.30, "height": 1.0},
-            s3_bucket="b", s3_key="k",
+            s3_bucket="b",
+            s3_key="k",
         )
         routing = SimpleNamespace(
-            s3_bucket="b", s3_key="r.json",
-            status=None, receipt_count=None, updated_at=None,
+            s3_bucket="b",
+            s3_key="r.json",
+            status=None,
+            receipt_count=None,
+            updated_at=None,
         )
 
-        existing_w = _make_word(text="OLD", x=0.80, y=0.1, w=0.1, h=0.05, line_id=1, word_id=1)
+        existing_w = _make_word(
+            text="OLD", x=0.80, y=0.1, w=0.1, h=0.05, line_id=1, word_id=1
+        )
         proc.dynamo.list_receipt_words_from_receipt.return_value = [existing_w]
-        proc.dynamo.list_receipt_word_labels_for_receipt.return_value = ([], None)
+        proc.dynamo.list_receipt_word_labels_for_receipt.return_value = (
+            [],
+            None,
+        )
         proc.dynamo.list_receipt_letters_from_word.return_value = []
         proc.dynamo.list_receipt_lines_from_receipt.return_value = []
 
-        new_word = _make_word(text="NEW", x=0.0, y=0.1, w=1.0, h=0.05, line_id=1, word_id=1)
+        new_word = _make_word(
+            text="NEW", x=0.0, y=0.1, w=1.0, h=0.05, line_id=1, word_id=1
+        )
         new_line = _make_line(text="NEW", line_id=1)
 
         ocr_json = self._build_ocr_json([{"text": "NEW"}])
         tmp = Path(tempfile.mkstemp(suffix=".json")[1])
         tmp.write_text(json.dumps(ocr_json))
 
-        with patch("handler.ocr_processor.download_file_from_s3", return_value=tmp), \
-             patch("handler.ocr_processor.process_ocr_dict_as_image", return_value=([], [], [])), \
-             patch("handler.ocr_processor.image_ocr_to_receipt_ocr", return_value=([new_line], [new_word], [])):
+        with (
+            patch(
+                "handler.ocr_processor.download_file_from_s3", return_value=tmp
+            ),
+            patch(
+                "handler.ocr_processor.process_ocr_dict_as_image",
+                return_value=([], [], []),
+            ),
+            patch(
+                "handler.ocr_processor.image_ocr_to_receipt_ocr",
+                return_value=([new_line], [new_word], []),
+            ),
+        ):
             result = proc._process_regional_reocr_job(ocr_job, routing)
 
         assert result["success"] is True
@@ -1448,40 +2255,69 @@ class TestOrphanDeletion:
         """A word straddling the region edge (<80% contained) must NOT be deleted."""
         proc = _make_processor()
         ocr_job = SimpleNamespace(
-            image_id=_IMG_ID, receipt_id=1,
+            image_id=_IMG_ID,
+            receipt_id=1,
             # Region covers x=[0.70, 1.0], y=[0.0, 1.0]
             reocr_region={"x": 0.70, "y": 0.0, "width": 0.30, "height": 1.0},
-            s3_bucket="b", s3_key="k",
+            s3_bucket="b",
+            s3_key="k",
         )
         routing = SimpleNamespace(
-            s3_bucket="b", s3_key="r.json",
-            status=None, receipt_count=None, updated_at=None,
+            s3_bucket="b",
+            s3_key="r.json",
+            status=None,
+            receipt_count=None,
+            updated_at=None,
         )
 
         # "GOOD" is fully inside the region (center at x=0.85) — will match.
-        existing_good = _make_word(text="GOOD", x=0.80, y=0.1, w=0.1, h=0.05, line_id=1, word_id=1)
+        existing_good = _make_word(
+            text="GOOD", x=0.80, y=0.1, w=0.1, h=0.05, line_id=1, word_id=1
+        )
         # "EDGE" straddles the left boundary: x=[0.65, 0.85], center=0.75
         # (inside region), but containment ~75% < 80% threshold.
-        existing_edge = _make_word(text="EDGE", x=0.65, y=0.1, w=0.20, h=0.05, line_id=1, word_id=2)
+        existing_edge = _make_word(
+            text="EDGE", x=0.65, y=0.1, w=0.20, h=0.05, line_id=1, word_id=2
+        )
 
-        proc.dynamo.list_receipt_words_from_receipt.return_value = [existing_good, existing_edge]
-        proc.dynamo.list_receipt_word_labels_for_receipt.return_value = ([], None)
+        proc.dynamo.list_receipt_words_from_receipt.return_value = [
+            existing_good,
+            existing_edge,
+        ]
+        proc.dynamo.list_receipt_word_labels_for_receipt.return_value = (
+            [],
+            None,
+        )
         proc.dynamo.list_receipt_letters_from_word.return_value = []
         proc.dynamo.list_receipt_lines_from_receipt.return_value = []
 
         # Re-OCR produces one word at crop-space x=0.5 → receipt-relative x~0.85,
         # which is closer to GOOD (center=0.85) than EDGE (center=0.75).
         # The greedy matcher will pair it with GOOD, leaving EDGE unmatched.
-        new_word = _make_word(text="BETTER", x=0.5, y=0.1, w=0.5, h=0.05, line_id=1, word_id=1)
+        new_word = _make_word(
+            text="BETTER", x=0.5, y=0.1, w=0.5, h=0.05, line_id=1, word_id=1
+        )
         new_line = _make_line(text="BETTER", line_id=1)
 
-        ocr_json = self._build_ocr_json([{"text": "BETTER", "x": 0.5, "w": 0.5}])
+        ocr_json = self._build_ocr_json(
+            [{"text": "BETTER", "x": 0.5, "w": 0.5}]
+        )
         tmp = Path(tempfile.mkstemp(suffix=".json")[1])
         tmp.write_text(json.dumps(ocr_json))
 
-        with patch("handler.ocr_processor.download_file_from_s3", return_value=tmp), \
-             patch("handler.ocr_processor.process_ocr_dict_as_image", return_value=([], [], [])), \
-             patch("handler.ocr_processor.image_ocr_to_receipt_ocr", return_value=([new_line], [new_word], [])):
+        with (
+            patch(
+                "handler.ocr_processor.download_file_from_s3", return_value=tmp
+            ),
+            patch(
+                "handler.ocr_processor.process_ocr_dict_as_image",
+                return_value=([], [], []),
+            ),
+            patch(
+                "handler.ocr_processor.image_ocr_to_receipt_ocr",
+                return_value=([new_line], [new_word], []),
+            ),
+        ):
             result = proc._process_regional_reocr_job(ocr_job, routing)
 
         assert result["success"] is True
@@ -1493,34 +2329,63 @@ class TestOrphanDeletion:
         """A word fully inside the region (100% contained) that isn't matched SHOULD be deleted."""
         proc = _make_processor()
         ocr_job = SimpleNamespace(
-            image_id=_IMG_ID, receipt_id=1,
+            image_id=_IMG_ID,
+            receipt_id=1,
             reocr_region={"x": 0.70, "y": 0.0, "width": 0.30, "height": 1.0},
-            s3_bucket="b", s3_key="k",
+            s3_bucket="b",
+            s3_key="k",
         )
         routing = SimpleNamespace(
-            s3_bucket="b", s3_key="r.json",
-            status=None, receipt_count=None, updated_at=None,
+            s3_bucket="b",
+            s3_key="r.json",
+            status=None,
+            receipt_count=None,
+            updated_at=None,
         )
 
         # "GOOD" matches, "JUNK" is fully inside (x=[0.90, 0.95]) — 100% contained.
-        existing_good = _make_word(text="GOOD", x=0.80, y=0.1, w=0.1, h=0.05, line_id=1, word_id=1)
-        existing_junk = _make_word(text="JUNK", x=0.90, y=0.1, w=0.05, h=0.05, line_id=1, word_id=2)
+        existing_good = _make_word(
+            text="GOOD", x=0.80, y=0.1, w=0.1, h=0.05, line_id=1, word_id=1
+        )
+        existing_junk = _make_word(
+            text="JUNK", x=0.90, y=0.1, w=0.05, h=0.05, line_id=1, word_id=2
+        )
 
-        proc.dynamo.list_receipt_words_from_receipt.return_value = [existing_good, existing_junk]
-        proc.dynamo.list_receipt_word_labels_for_receipt.return_value = ([], None)
+        proc.dynamo.list_receipt_words_from_receipt.return_value = [
+            existing_good,
+            existing_junk,
+        ]
+        proc.dynamo.list_receipt_word_labels_for_receipt.return_value = (
+            [],
+            None,
+        )
         proc.dynamo.list_receipt_letters_from_word.side_effect = [[], []]
         proc.dynamo.list_receipt_lines_from_receipt.return_value = []
 
-        new_word = _make_word(text="BETTER", x=0.0, y=0.1, w=0.5, h=0.05, line_id=1, word_id=1)
+        new_word = _make_word(
+            text="BETTER", x=0.0, y=0.1, w=0.5, h=0.05, line_id=1, word_id=1
+        )
         new_line = _make_line(text="BETTER", line_id=1)
 
-        ocr_json = self._build_ocr_json([{"text": "BETTER", "x": 0.0, "w": 0.5}])
+        ocr_json = self._build_ocr_json(
+            [{"text": "BETTER", "x": 0.0, "w": 0.5}]
+        )
         tmp = Path(tempfile.mkstemp(suffix=".json")[1])
         tmp.write_text(json.dumps(ocr_json))
 
-        with patch("handler.ocr_processor.download_file_from_s3", return_value=tmp), \
-             patch("handler.ocr_processor.process_ocr_dict_as_image", return_value=([], [], [])), \
-             patch("handler.ocr_processor.image_ocr_to_receipt_ocr", return_value=([new_line], [new_word], [])):
+        with (
+            patch(
+                "handler.ocr_processor.download_file_from_s3", return_value=tmp
+            ),
+            patch(
+                "handler.ocr_processor.process_ocr_dict_as_image",
+                return_value=([], [], []),
+            ),
+            patch(
+                "handler.ocr_processor.image_ocr_to_receipt_ocr",
+                return_value=([new_line], [new_word], []),
+            ),
+        ):
             result = proc._process_regional_reocr_job(ocr_job, routing)
 
         assert result["success"] is True
@@ -1534,20 +2399,30 @@ class TestOrphanDeletion:
 # 9. SMART re-OCR completion metrics on the OCRJob
 # ===========================================================================
 
+
 class TestReocrCompletionMetrics:
     def _run(self, proc, existing_words, new_words, region=None):
         if region is None:
             region = {"x": 0.70, "y": 0.0, "width": 0.30, "height": 1.0}
         ocr_job = SimpleNamespace(
-            image_id=_IMG_ID, receipt_id=1,
-            reocr_region=region, s3_bucket="b", s3_key="k",
-            status=None, updated_at=None,
-            reocr_words_accepted=None, reocr_words_rejected=None,
-            reocr_delta_before=None, reocr_delta_after=None,
+            image_id=_IMG_ID,
+            receipt_id=1,
+            reocr_region=region,
+            s3_bucket="b",
+            s3_key="k",
+            status=None,
+            updated_at=None,
+            reocr_words_accepted=None,
+            reocr_words_rejected=None,
+            reocr_delta_before=None,
+            reocr_delta_after=None,
         )
         routing = SimpleNamespace(
-            s3_bucket="b", s3_key="r.json",
-            status=None, receipt_count=None, updated_at=None,
+            s3_bucket="b",
+            s3_key="r.json",
+            status=None,
+            receipt_count=None,
+            updated_at=None,
         )
         proc.dynamo.list_receipt_words_from_receipt.return_value = (
             existing_words
@@ -1562,17 +2437,22 @@ class TestReocrCompletionMetrics:
         tmp = Path(tempfile.mkstemp(suffix=".json")[1])
         tmp.write_text(json.dumps({"lines": []}))
 
-        new_lines = [_make_line(text=w.text, line_id=w.line_id)
-                     for w in new_words]
-        with patch(
-            "handler.ocr_processor.download_file_from_s3",
-            return_value=tmp,
-        ), patch(
-            "handler.ocr_processor.process_ocr_dict_as_image",
-            return_value=([], [], []),
-        ), patch(
-            "handler.ocr_processor.image_ocr_to_receipt_ocr",
-            return_value=(new_lines, new_words, []),
+        new_lines = [
+            _make_line(text=w.text, line_id=w.line_id) for w in new_words
+        ]
+        with (
+            patch(
+                "handler.ocr_processor.download_file_from_s3",
+                return_value=tmp,
+            ),
+            patch(
+                "handler.ocr_processor.process_ocr_dict_as_image",
+                return_value=([], [], []),
+            ),
+            patch(
+                "handler.ocr_processor.image_ocr_to_receipt_ocr",
+                return_value=(new_lines, new_words, []),
+            ),
         ):
             result = proc._process_regional_reocr_job(ocr_job, routing)
         return result, ocr_job
@@ -1586,9 +2466,7 @@ class TestReocrCompletionMetrics:
             )
         ]
         proc.dynamo.get_receipt_summary.return_value = SimpleNamespace(
-            summary=SimpleNamespace(
-                subtotal=9.99, grand_total=None, tax=None
-            )
+            summary=SimpleNamespace(subtotal=9.99, grand_total=None, tax=None)
         )
 
     def test_metrics_persisted_on_ocr_job(self):
@@ -1597,14 +2475,19 @@ class TestReocrCompletionMetrics:
 
         # Line 1: "ITEM" (left, outside region) + "8.99" (right, inside).
         existing = [
-            _make_word(text="ITEM", x=0.1, y=0.1, w=0.1, h=0.05,
-                       line_id=1, word_id=1),
-            _make_word(text="8.99", x=0.75, y=0.1, w=0.1, h=0.05,
-                       line_id=1, word_id=2),
+            _make_word(
+                text="ITEM", x=0.1, y=0.1, w=0.1, h=0.05, line_id=1, word_id=1
+            ),
+            _make_word(
+                text="8.99", x=0.75, y=0.1, w=0.1, h=0.05, line_id=1, word_id=2
+            ),
         ]
         # Regional pass reads the price correctly as 9.99.
-        new = [_make_word(text="9.99", x=0.0, y=0.1, w=1.0, h=0.05,
-                          line_id=1, word_id=1)]
+        new = [
+            _make_word(
+                text="9.99", x=0.0, y=0.1, w=1.0, h=0.05, line_id=1, word_id=1
+            )
+        ]
 
         result, ocr_job = self._run(proc, existing, new)
 
@@ -1626,12 +2509,30 @@ class TestReocrCompletionMetrics:
         proc = _make_processor()
         self._with_items_baseline(proc, subtotal=9.99)
         existing = [
-            _make_word(text="8.99", x=0.75, y=0.1, w=0.1, h=0.05,
-                       line_id=1, word_id=2, confidence=0.99),
+            _make_word(
+                text="8.99",
+                x=0.75,
+                y=0.1,
+                w=0.1,
+                h=0.05,
+                line_id=1,
+                word_id=2,
+                confidence=0.99,
+            ),
         ]
         # Low-confidence replacement is rejected by Guard 3a.
-        new = [_make_word(text="9.99", x=0.0, y=0.1, w=1.0, h=0.05,
-                          line_id=1, word_id=1, confidence=0.3)]
+        new = [
+            _make_word(
+                text="9.99",
+                x=0.0,
+                y=0.1,
+                w=1.0,
+                h=0.05,
+                line_id=1,
+                word_id=1,
+                confidence=0.3,
+            )
+        ]
 
         result, ocr_job = self._run(proc, existing, new)
 
@@ -1645,11 +2546,15 @@ class TestReocrCompletionMetrics:
         # No sections / summary mocks configured: MagicMock defaults are
         # not iterable, so the baseline lookup fails soft -> null deltas.
         existing = [
-            _make_word(text="8.99", x=0.75, y=0.1, w=0.1, h=0.05,
-                       line_id=1, word_id=2),
+            _make_word(
+                text="8.99", x=0.75, y=0.1, w=0.1, h=0.05, line_id=1, word_id=2
+            ),
         ]
-        new = [_make_word(text="9.99", x=0.0, y=0.1, w=1.0, h=0.05,
-                          line_id=1, word_id=1)]
+        new = [
+            _make_word(
+                text="9.99", x=0.0, y=0.1, w=1.0, h=0.05, line_id=1, word_id=1
+            )
+        ]
 
         result, ocr_job = self._run(proc, existing, new)
 
@@ -1666,11 +2571,15 @@ class TestReocrCompletionMetrics:
         proc = _make_processor()
         proc.dynamo.update_ocr_job.side_effect = RuntimeError("boom")
         existing = [
-            _make_word(text="8.99", x=0.75, y=0.1, w=0.1, h=0.05,
-                       line_id=1, word_id=2),
+            _make_word(
+                text="8.99", x=0.75, y=0.1, w=0.1, h=0.05, line_id=1, word_id=2
+            ),
         ]
-        new = [_make_word(text="9.99", x=0.0, y=0.1, w=1.0, h=0.05,
-                          line_id=1, word_id=1)]
+        new = [
+            _make_word(
+                text="9.99", x=0.0, y=0.1, w=1.0, h=0.05, line_id=1, word_id=1
+            )
+        ]
 
         result, _ = self._run(proc, existing, new)
         assert result["success"] is True

--- a/infra/upload_images/container_ocr/handler/tests/test_overlay.py
+++ b/infra/upload_images/container_ocr/handler/tests/test_overlay.py
@@ -1528,3 +1528,149 @@ class TestOrphanDeletion:
         proc.dynamo.delete_receipt_words.assert_called_once()
         deleted = proc.dynamo.delete_receipt_words.call_args[0][0]
         assert deleted[0].text == "JUNK"
+
+
+# ===========================================================================
+# 9. SMART re-OCR completion metrics on the OCRJob
+# ===========================================================================
+
+class TestReocrCompletionMetrics:
+    def _run(self, proc, existing_words, new_words, region=None):
+        if region is None:
+            region = {"x": 0.70, "y": 0.0, "width": 0.30, "height": 1.0}
+        ocr_job = SimpleNamespace(
+            image_id=_IMG_ID, receipt_id=1,
+            reocr_region=region, s3_bucket="b", s3_key="k",
+            status=None, updated_at=None,
+            reocr_words_accepted=None, reocr_words_rejected=None,
+            reocr_delta_before=None, reocr_delta_after=None,
+        )
+        routing = SimpleNamespace(
+            s3_bucket="b", s3_key="r.json",
+            status=None, receipt_count=None, updated_at=None,
+        )
+        proc.dynamo.list_receipt_words_from_receipt.return_value = (
+            existing_words
+        )
+        proc.dynamo.list_receipt_word_labels_for_receipt.return_value = (
+            [],
+            None,
+        )
+        proc.dynamo.list_receipt_letters_from_word.return_value = []
+        proc.dynamo.list_receipt_lines_from_receipt.return_value = []
+
+        tmp = Path(tempfile.mkstemp(suffix=".json")[1])
+        tmp.write_text(json.dumps({"lines": []}))
+
+        new_lines = [_make_line(text=w.text, line_id=w.line_id)
+                     for w in new_words]
+        with patch(
+            "handler.ocr_processor.download_file_from_s3",
+            return_value=tmp,
+        ), patch(
+            "handler.ocr_processor.process_ocr_dict_as_image",
+            return_value=([], [], []),
+        ), patch(
+            "handler.ocr_processor.image_ocr_to_receipt_ocr",
+            return_value=(new_lines, new_words, []),
+        ):
+            result = proc._process_regional_reocr_job(ocr_job, routing)
+        return result, ocr_job
+
+    def _with_items_baseline(self, proc, subtotal=9.99):
+        proc.dynamo.get_receipt_sections_from_receipt.return_value = [
+            SimpleNamespace(
+                section_type="ITEMS",
+                validation_status="VALID",
+                line_ids=[1],
+            )
+        ]
+        proc.dynamo.get_receipt_summary.return_value = SimpleNamespace(
+            summary=SimpleNamespace(
+                subtotal=9.99, grand_total=None, tax=None
+            )
+        )
+
+    def test_metrics_persisted_on_ocr_job(self):
+        proc = _make_processor()
+        self._with_items_baseline(proc, subtotal=9.99)
+
+        # Line 1: "ITEM" (left, outside region) + "8.99" (right, inside).
+        existing = [
+            _make_word(text="ITEM", x=0.1, y=0.1, w=0.1, h=0.05,
+                       line_id=1, word_id=1),
+            _make_word(text="8.99", x=0.75, y=0.1, w=0.1, h=0.05,
+                       line_id=1, word_id=2),
+        ]
+        # Regional pass reads the price correctly as 9.99.
+        new = [_make_word(text="9.99", x=0.0, y=0.1, w=1.0, h=0.05,
+                          line_id=1, word_id=1)]
+
+        result, ocr_job = self._run(proc, existing, new)
+
+        assert result["success"] is True
+        assert result["words_replaced"] == 1
+        assert result["reocr_delta_before"] == -1.0
+        assert result["reocr_delta_after"] == 0.0
+
+        proc.dynamo.update_ocr_job.assert_called_once()
+        persisted = proc.dynamo.update_ocr_job.call_args[0][0]
+        assert persisted is ocr_job
+        assert ocr_job.reocr_words_accepted == 1
+        assert ocr_job.reocr_words_rejected == 0
+        assert ocr_job.reocr_delta_before == -1.0
+        assert ocr_job.reocr_delta_after == 0.0
+        assert ocr_job.status == "COMPLETED"
+
+    def test_rejected_overlay_counts_persisted(self):
+        proc = _make_processor()
+        self._with_items_baseline(proc, subtotal=9.99)
+        existing = [
+            _make_word(text="8.99", x=0.75, y=0.1, w=0.1, h=0.05,
+                       line_id=1, word_id=2, confidence=0.99),
+        ]
+        # Low-confidence replacement is rejected by Guard 3a.
+        new = [_make_word(text="9.99", x=0.0, y=0.1, w=1.0, h=0.05,
+                          line_id=1, word_id=1, confidence=0.3)]
+
+        result, ocr_job = self._run(proc, existing, new)
+
+        assert result["success"] is True
+        assert result["words_rejected"] == 1
+        assert ocr_job.reocr_words_accepted == 0
+        assert ocr_job.reocr_words_rejected == 1
+
+    def test_deltas_null_without_items_baseline(self):
+        proc = _make_processor()
+        # No sections / summary mocks configured: MagicMock defaults are
+        # not iterable, so the baseline lookup fails soft -> null deltas.
+        existing = [
+            _make_word(text="8.99", x=0.75, y=0.1, w=0.1, h=0.05,
+                       line_id=1, word_id=2),
+        ]
+        new = [_make_word(text="9.99", x=0.0, y=0.1, w=1.0, h=0.05,
+                          line_id=1, word_id=1)]
+
+        result, ocr_job = self._run(proc, existing, new)
+
+        assert result["success"] is True
+        assert result["reocr_delta_before"] is None
+        assert result["reocr_delta_after"] is None
+        assert ocr_job.reocr_delta_before is None
+        assert ocr_job.reocr_delta_after is None
+        # Word counts still persist even without deltas.
+        assert ocr_job.reocr_words_accepted == 1
+        proc.dynamo.update_ocr_job.assert_called_once()
+
+    def test_metrics_failure_is_nonfatal(self):
+        proc = _make_processor()
+        proc.dynamo.update_ocr_job.side_effect = RuntimeError("boom")
+        existing = [
+            _make_word(text="8.99", x=0.75, y=0.1, w=0.1, h=0.05,
+                       line_id=1, word_id=2),
+        ]
+        new = [_make_word(text="9.99", x=0.0, y=0.1, w=1.0, h=0.05,
+                          line_id=1, word_id=1)]
+
+        result, _ = self._run(proc, existing, new)
+        assert result["success"] is True

--- a/receipt_dynamo/receipt_dynamo/entities/ocr_job.py
+++ b/receipt_dynamo/receipt_dynamo/entities/ocr_job.py
@@ -17,6 +17,10 @@ from receipt_dynamo.entities.util import (
     normalize_enum,
 )
 
+# Contract shared with the Swift OCR worker and the strategy ladder in
+# receipt_upload.line_items.reocr_strategy -- keep the values in sync.
+VALID_REOCR_STRATEGIES = ("plain", "invert", "deskew", "upscale2x")
+
 
 @dataclass(eq=True, unsafe_hash=False)
 class OCRJob:
@@ -47,6 +51,15 @@ class OCRJob:
     receipt_id: int | None = None
     reocr_region: dict[str, float] | None = None
     reocr_reason: str | None = None
+    # SMART re-OCR fields (all optional / absent-tolerant). The trigger
+    # writes strategy + mechanism; the overlay writes the completion
+    # metrics. Consumed by the Swift worker under exactly these names.
+    reocr_strategy: str | None = None
+    reocr_mechanism: str | None = None
+    reocr_words_accepted: int | None = None
+    reocr_words_rejected: int | None = None
+    reocr_delta_before: float | None = None
+    reocr_delta_after: float | None = None
 
     def __post_init__(self) -> None:
         """Validate and normalize initialization arguments."""
@@ -120,6 +133,45 @@ class OCRJob:
         ):
             raise ValueError("reocr_reason must be a string or None")
 
+        if self.reocr_strategy is not None and (
+            not isinstance(self.reocr_strategy, str)
+            or self.reocr_strategy not in VALID_REOCR_STRATEGIES
+        ):
+            raise ValueError(
+                "reocr_strategy must be one of "
+                f"{VALID_REOCR_STRATEGIES} or None"
+            )
+
+        if self.reocr_mechanism is not None and (
+            not isinstance(self.reocr_mechanism, str)
+            or not self.reocr_mechanism
+        ):
+            raise ValueError(
+                "reocr_mechanism must be a non-empty string or None"
+            )
+
+        for count_field in ("reocr_words_accepted", "reocr_words_rejected"):
+            count = getattr(self, count_field)
+            if count is None:
+                continue
+            if isinstance(count, bool) or not isinstance(count, int):
+                raise ValueError(f"{count_field} must be an integer or None")
+            if count < 0:
+                raise ValueError(f"{count_field} must not be negative")
+
+        for delta_field in ("reocr_delta_before", "reocr_delta_after"):
+            delta = getattr(self, delta_field)
+            if delta is None:
+                continue
+            if (
+                isinstance(delta, bool)
+                or not isinstance(delta, int | float)
+                or not isfinite(delta)
+            ):
+                raise ValueError(
+                    f"{delta_field} must be a finite number or None"
+                )
+
     @property
     def key(self) -> dict[str, Any]:
         return {
@@ -178,6 +230,36 @@ class OCRJob:
                 if self.reocr_reason is not None
                 else {"NULL": True}
             ),
+            "reocr_strategy": (
+                {"S": self.reocr_strategy}
+                if self.reocr_strategy is not None
+                else {"NULL": True}
+            ),
+            "reocr_mechanism": (
+                {"S": self.reocr_mechanism}
+                if self.reocr_mechanism is not None
+                else {"NULL": True}
+            ),
+            "reocr_words_accepted": (
+                {"N": str(self.reocr_words_accepted)}
+                if self.reocr_words_accepted is not None
+                else {"NULL": True}
+            ),
+            "reocr_words_rejected": (
+                {"N": str(self.reocr_words_rejected)}
+                if self.reocr_words_rejected is not None
+                else {"NULL": True}
+            ),
+            "reocr_delta_before": (
+                {"N": str(float(self.reocr_delta_before))}
+                if self.reocr_delta_before is not None
+                else {"NULL": True}
+            ),
+            "reocr_delta_after": (
+                {"N": str(float(self.reocr_delta_after))}
+                if self.reocr_delta_after is not None
+                else {"NULL": True}
+            ),
         }
 
     def __repr__(self) -> str:
@@ -193,7 +275,13 @@ class OCRJob:
             f"job_type={_repr_str(self.job_type)}, "
             f"receipt_id={self.receipt_id}, "
             f"reocr_region={self.reocr_region}, "
-            f"reocr_reason={_repr_str(self.reocr_reason)}"
+            f"reocr_reason={_repr_str(self.reocr_reason)}, "
+            f"reocr_strategy={_repr_str(self.reocr_strategy)}, "
+            f"reocr_mechanism={_repr_str(self.reocr_mechanism)}, "
+            f"reocr_words_accepted={self.reocr_words_accepted}, "
+            f"reocr_words_rejected={self.reocr_words_rejected}, "
+            f"reocr_delta_before={self.reocr_delta_before}, "
+            f"reocr_delta_after={self.reocr_delta_after}"
             ")"
         )
 
@@ -209,6 +297,12 @@ class OCRJob:
         yield "receipt_id", self.receipt_id
         yield "reocr_region", self.reocr_region
         yield "reocr_reason", self.reocr_reason
+        yield "reocr_strategy", self.reocr_strategy
+        yield "reocr_mechanism", self.reocr_mechanism
+        yield "reocr_words_accepted", self.reocr_words_accepted
+        yield "reocr_words_rejected", self.reocr_words_rejected
+        yield "reocr_delta_before", self.reocr_delta_before
+        yield "reocr_delta_after", self.reocr_delta_after
 
     def __eq__(self, other) -> bool:
         if not isinstance(other, OCRJob):
@@ -225,6 +319,12 @@ class OCRJob:
             and self.receipt_id == other.receipt_id
             and self.reocr_region == other.reocr_region
             and self.reocr_reason == other.reocr_reason
+            and self.reocr_strategy == other.reocr_strategy
+            and self.reocr_mechanism == other.reocr_mechanism
+            and self.reocr_words_accepted == other.reocr_words_accepted
+            and self.reocr_words_rejected == other.reocr_words_rejected
+            and self.reocr_delta_before == other.reocr_delta_before
+            and self.reocr_delta_after == other.reocr_delta_after
         )
 
     def __hash__(self) -> int:
@@ -245,6 +345,12 @@ class OCRJob:
                     else None
                 ),
                 self.reocr_reason,
+                self.reocr_strategy,
+                self.reocr_mechanism,
+                self.reocr_words_accepted,
+                self.reocr_words_rejected,
+                self.reocr_delta_before,
+                self.reocr_delta_after,
             )
         )
 
@@ -310,6 +416,20 @@ class OCRJob:
             "receipt_id": EntityFactory.extract_int_field("receipt_id"),
             "reocr_region": _extract_reocr_region,
             "reocr_reason": _extract_optional_string("reocr_reason"),
+            "reocr_strategy": _extract_optional_string("reocr_strategy"),
+            "reocr_mechanism": _extract_optional_string("reocr_mechanism"),
+            "reocr_words_accepted": EntityFactory.extract_int_field(
+                "reocr_words_accepted"
+            ),
+            "reocr_words_rejected": EntityFactory.extract_int_field(
+                "reocr_words_rejected"
+            ),
+            "reocr_delta_before": EntityFactory.extract_float_field(
+                "reocr_delta_before"
+            ),
+            "reocr_delta_after": EntityFactory.extract_float_field(
+                "reocr_delta_after"
+            ),
         }
 
         if item.get("TYPE", {}).get("S") != "OCR_JOB":

--- a/receipt_dynamo/tests/unit/test_refinement_job.py
+++ b/receipt_dynamo/tests/unit/test_refinement_job.py
@@ -154,6 +154,97 @@ def test_ocr_job_regional_reocr_fields_roundtrip():
     assert restored.reocr_reason == "subtotal_mismatch_phantom_values"
 
 
+def _smart_reocr_job(**overrides):
+    values = {
+        "image_id": "3f52804b-2fad-4e00-92c8-b593da3a8ed3",
+        "job_id": "4f52804b-2fad-4e00-92c8-b593da3a8ed3",
+        "s3_bucket": "test-bucket",
+        "s3_key": "receipts/test.png",
+        "created_at": datetime(2025, 5, 1, 12, 0, 0),
+        "status": OCRStatus.COMPLETED,
+        "job_type": OCRJobType.REGIONAL_REOCR,
+        "receipt_id": 7,
+        "reocr_region": {"x": 0.0, "y": 0.2, "width": 1.0, "height": 0.5},
+        "reocr_reason": "line_items_recon",
+        "reocr_strategy": "invert",
+        "reocr_mechanism": "reverse-video-total",
+        "reocr_words_accepted": 12,
+        "reocr_words_rejected": 3,
+        "reocr_delta_before": -61.85,
+        "reocr_delta_after": 0.0,
+    }
+    values.update(overrides)
+    return OCRJob(**values)
+
+
+@pytest.mark.unit
+def test_ocr_job_smart_reocr_fields_roundtrip():
+    job = _smart_reocr_job()
+    restored = item_to_ocr_job(job.to_item())
+    assert restored == job
+    assert restored.reocr_strategy == "invert"
+    assert restored.reocr_mechanism == "reverse-video-total"
+    assert restored.reocr_words_accepted == 12
+    assert restored.reocr_words_rejected == 3
+    assert restored.reocr_delta_before == -61.85
+    assert restored.reocr_delta_after == 0.0
+
+
+@pytest.mark.unit
+def test_ocr_job_smart_reocr_fields_absent_tolerant():
+    """Legacy items without the SMART re-OCR attributes still parse."""
+    item = _smart_reocr_job().to_item()
+    for field in (
+        "reocr_strategy",
+        "reocr_mechanism",
+        "reocr_words_accepted",
+        "reocr_words_rejected",
+        "reocr_delta_before",
+        "reocr_delta_after",
+    ):
+        del item[field]
+    restored = item_to_ocr_job(item)
+    assert restored.reocr_strategy is None
+    assert restored.reocr_mechanism is None
+    assert restored.reocr_words_accepted is None
+    assert restored.reocr_words_rejected is None
+    assert restored.reocr_delta_before is None
+    assert restored.reocr_delta_after is None
+    # A None-valued job round-trips (NULL attributes) too.
+    assert item_to_ocr_job(restored.to_item()) == restored
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("reocr_strategy", "sharpen"),
+        ("reocr_strategy", 1),
+        ("reocr_mechanism", ""),
+        ("reocr_mechanism", 5),
+        ("reocr_words_accepted", True),
+        ("reocr_words_accepted", -1),
+        ("reocr_words_accepted", 1.5),
+        ("reocr_words_rejected", True),
+        ("reocr_words_rejected", -2),
+        ("reocr_delta_before", True),
+        ("reocr_delta_before", float("nan")),
+        ("reocr_delta_after", "0.0"),
+        ("reocr_delta_after", float("inf")),
+    ],
+)
+def test_ocr_job_smart_reocr_field_validation(field, value):
+    with pytest.raises(ValueError):
+        _smart_reocr_job(**{field: value})
+
+
+@pytest.mark.unit
+def test_ocr_job_smart_reocr_strategy_values():
+    for strategy in ("plain", "invert", "deskew", "upscale2x"):
+        job = _smart_reocr_job(reocr_strategy=strategy)
+        assert item_to_ocr_job(job.to_item()).reocr_strategy == strategy
+
+
 @pytest.mark.unit
 def test_ocr_job_invalid_s3_bucket():
     with pytest.raises(ValueError, match="s3_bucket must be a string"):

--- a/receipt_upload/receipt_upload/line_items/assets/reocr_ladder.json
+++ b/receipt_upload/receipt_upload/line_items/assets/reocr_ladder.json
@@ -1,0 +1,6 @@
+{
+  "schema": "reocr-ladder-v1",
+  "generated_at": null,
+  "source": "scripts/harvest_reocr_outcomes.py (no harvest run yet)",
+  "mechanisms": {}
+}

--- a/receipt_upload/receipt_upload/line_items/reocr_strategy.py
+++ b/receipt_upload/receipt_upload/line_items/reocr_strategy.py
@@ -1,0 +1,273 @@
+"""SMART re-OCR strategy ladder (pure, bundleable).
+
+Maps a diagnosed OCR-failure mechanism (free string carried on triage
+dossiers and OCRJob.reocr_mechanism, e.g. "reverse-video-total",
+"tilted-0deg-quads", "small-print", "pen-stroke") to an ordered ladder
+of capture strategies the Swift worker executes: ``plain`` crop,
+``invert`` (reverse-video), ``deskew``, or ``upscale2x``.
+
+``choose_strategy()`` picks the strategy for a given attempt number so
+attempt 2 tries something DIFFERENT from attempt 1 instead of repeating
+a strategy that already failed. A measured-outcome ledger -- built by
+``scripts/harvest_reocr_outcomes.py`` from completed OCRJobs and
+committed at ``assets/reocr_ladder.json`` (same pattern as the
+block-role priors) -- overrides the hand-written default ordering once
+a mechanism x strategy pair has enough recorded attempts.
+
+Dependency-free (stdlib only) so the module bundles into the line-item
+updater Lambda alongside blocks.py/reocr.py.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any, Iterable
+
+# Contract shared with receipt_dynamo.entities.ocr_job and the Swift
+# worker -- keep the values in sync.
+STRATEGIES = ("plain", "invert", "deskew", "upscale2x")
+
+# Mechanism-key -> default strategy ordering. Free-string mechanisms
+# are normalised onto these keys by prefix (mechanism_key below).
+DEFAULT_LADDERS: dict[str, list[str]] = {
+    "reverse-video": ["invert", "plain"],
+    "tilted": ["deskew", "plain"],
+    "small-print": ["upscale2x", "plain"],
+}
+UNKNOWN_LADDER = ["plain", "upscale2x"]
+
+# A mechanism x strategy pair needs this many harvested attempts before
+# its measured acceptance rate outranks the hand-written default order.
+MIN_LEDGER_ATTEMPTS = 3
+
+LEDGER_ASSET = Path(__file__).parent / "assets" / "reocr_ladder.json"
+
+_LEDGER_CACHE: dict[str, dict] | None = None
+
+# Dossier-text hints -> canonical mechanism string. Order matters: the
+# first matching mechanism wins. Patterns are regexes over the
+# lower-cased mode + visual_evidence text.
+_MECHANISM_HINTS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    (
+        "reverse-video-total",
+        (
+            r"reverse[- ]video",
+            r"\binverted\b",
+            r"white[- ]on[- ]black",
+            r"\bknockout\b",
+        ),
+    ),
+    (
+        "tilted",
+        (r"\btilt", r"skew", r"rotat", r"\bslant"),
+    ),
+    (
+        "small-print",
+        (
+            r"small[- ]print",
+            r"\btiny\b",
+            r"fine[- ]print",
+            r"microprint",
+        ),
+    ),
+    (
+        "pen-stroke",
+        (r"\bpen\b", r"handwrit", r"\bink\b", r"scribble"),
+    ),
+)
+
+
+def mechanism_key(mechanism: str | None) -> str:
+    """Normalise a free-string mechanism onto a ladder key.
+
+    "reverse-video-total" -> "reverse-video"; "tilted-0deg-quads" ->
+    "tilted"; anything unrecognised (including "pen-stroke", which has
+    no strategy that helps) -> "unknown".
+    """
+    if not mechanism:
+        return "unknown"
+    normalised = str(mechanism).strip().lower().replace("_", "-")
+    for key in DEFAULT_LADDERS:
+        if normalised.startswith(key):
+            return key
+    return "unknown"
+
+
+def default_ladder(mechanism: str | None) -> list[str]:
+    """Full default strategy order for a mechanism.
+
+    The mechanism's ladder comes first; the remaining strategies are
+    appended so attempts past the ladder still try something new
+    before any repeat.
+    """
+    base = DEFAULT_LADDERS.get(mechanism_key(mechanism), UNKNOWN_LADDER)
+    return list(base) + [s for s in STRATEGIES if s not in base]
+
+
+def load_ledger(path: Path | None = None) -> dict[str, dict]:
+    """Load the committed outcome ledger; {} when absent or invalid."""
+    global _LEDGER_CACHE  # pylint: disable=global-statement
+    if path is None and _LEDGER_CACHE is not None:
+        return _LEDGER_CACHE
+    ledger_path = path or LEDGER_ASSET
+    try:
+        with open(ledger_path, encoding="utf-8") as handle:
+            data = json.load(handle)
+        mechanisms = data.get("mechanisms")
+        ledger = mechanisms if isinstance(mechanisms, dict) else {}
+    except (OSError, ValueError):
+        ledger = {}
+    if path is None:
+        _LEDGER_CACHE = ledger
+    return ledger
+
+
+def _measured_score(
+    stats: dict[str, Any], strategy: str
+) -> tuple[float, float] | None:
+    """(acceptance_rate, mean_delta_improvement) when measured enough."""
+    entry = stats.get(strategy)
+    if not isinstance(entry, dict):
+        return None
+    try:
+        attempts = int(entry.get("attempts", 0))
+    except (TypeError, ValueError):
+        return None
+    if attempts < MIN_LEDGER_ATTEMPTS:
+        return None
+    rate = entry.get("acceptance_rate")
+    improvement = entry.get("mean_delta_improvement")
+    try:
+        return (
+            float(rate) if rate is not None else 0.0,
+            float(improvement) if improvement is not None else 0.0,
+        )
+    except (TypeError, ValueError):
+        return None
+
+
+def ladder(
+    mechanism: str | None, ledger: dict[str, dict] | None = None
+) -> list[str]:
+    """Strategy order for a mechanism, ledger-adjusted.
+
+    Strategies with enough harvested attempts are promoted ahead of the
+    unmeasured ones and ordered by (acceptance_rate,
+    mean_delta_improvement) descending; unmeasured strategies keep the
+    default relative order after them.
+    """
+    order = default_ladder(mechanism)
+    if ledger is None:
+        ledger = load_ledger()
+    stats = ledger.get(mechanism_key(mechanism))
+    if not isinstance(stats, dict) or not stats:
+        return order
+    measured = [s for s in order if _measured_score(stats, s) is not None]
+    unmeasured = [s for s in order if _measured_score(stats, s) is None]
+    measured.sort(key=lambda s: _measured_score(stats, s), reverse=True)
+    return measured + unmeasured
+
+
+def choose_strategy(
+    mechanism: str | None,
+    attempt_number: int,
+    ledger: dict[str, dict] | None = None,
+) -> str:
+    """Strategy for the given 1-based attempt number.
+
+    Attempt 1 gets the ladder head; attempt 2 the next rung -- a
+    DIFFERENT strategy, never a repeat until every strategy has been
+    tried once (the full order covers all four).
+    """
+    if attempt_number < 1:
+        attempt_number = 1
+    order = ladder(mechanism, ledger)
+    return order[(attempt_number - 1) % len(order)]
+
+
+def mechanism_from_dossier(dossier: Any) -> str | None:
+    """Best-effort mechanism from a triage dossier (schema v2).
+
+    Scans ``mode`` plus the ``visual_evidence`` transcript for the
+    failure-mechanism vocabulary the triage agents use. Returns a
+    canonical mechanism string, or None when nothing matches (callers
+    then fall back to the unknown ladder).
+    """
+    if not isinstance(dossier, dict):
+        return None
+    texts = [str(dossier.get("mode") or "")]
+    evidence = dossier.get("visual_evidence")
+    if isinstance(evidence, list):
+        texts.extend(str(entry) for entry in evidence)
+    blob = " ".join(texts).lower()
+    if not blob.strip():
+        return None
+    for mechanism, patterns in _MECHANISM_HINTS:
+        if any(re.search(pattern, blob) for pattern in patterns):
+            return mechanism
+    return None
+
+
+def build_ledger(jobs: Iterable[Any]) -> dict[str, dict]:
+    """Aggregate completed REGIONAL_REOCR jobs into ledger stats.
+
+    ``jobs`` is any iterable of OCRJob-like objects (attribute access).
+    Only COMPLETED jobs with a known strategy and at least one recorded
+    word count contribute. Per mechanism-key x strategy: attempts,
+    word-level acceptance rate, and mean |delta| improvement over the
+    jobs where both deltas were recorded.
+    """
+    agg: dict[str, dict[str, dict[str, Any]]] = {}
+    for job in jobs:
+        if str(getattr(job, "status", "")) != "COMPLETED":
+            continue
+        if str(getattr(job, "job_type", "")) != "REGIONAL_REOCR":
+            continue
+        strategy = getattr(job, "reocr_strategy", None)
+        if strategy not in STRATEGIES:
+            continue
+        accepted = getattr(job, "reocr_words_accepted", None)
+        rejected = getattr(job, "reocr_words_rejected", None)
+        if accepted is None and rejected is None:
+            continue
+        key = mechanism_key(getattr(job, "reocr_mechanism", None))
+        entry = agg.setdefault(key, {}).setdefault(
+            strategy,
+            {
+                "attempts": 0,
+                "words_accepted": 0,
+                "words_rejected": 0,
+                "_improvements": [],
+            },
+        )
+        entry["attempts"] += 1
+        entry["words_accepted"] += int(accepted or 0)
+        entry["words_rejected"] += int(rejected or 0)
+        before = getattr(job, "reocr_delta_before", None)
+        after = getattr(job, "reocr_delta_after", None)
+        if before is not None and after is not None:
+            entry["_improvements"].append(abs(before) - abs(after))
+
+    ledger: dict[str, dict] = {}
+    for key in sorted(agg):
+        ledger[key] = {}
+        for strategy in sorted(agg[key]):
+            entry = agg[key][strategy]
+            total = entry["words_accepted"] + entry["words_rejected"]
+            improvements = entry["_improvements"]
+            ledger[key][strategy] = {
+                "attempts": entry["attempts"],
+                "words_accepted": entry["words_accepted"],
+                "words_rejected": entry["words_rejected"],
+                "acceptance_rate": (
+                    round(entry["words_accepted"] / total, 4) if total else 0.0
+                ),
+                "mean_delta_improvement": (
+                    round(sum(improvements) / len(improvements), 4)
+                    if improvements
+                    else None
+                ),
+            }
+    return ledger

--- a/receipt_upload/tests/test_line_item_reocr_trigger.py
+++ b/receipt_upload/tests/test_line_item_reocr_trigger.py
@@ -1,0 +1,125 @@
+"""SMART re-OCR trigger tests: _maybe_trigger_items_reocr threads the
+strategy ladder (mechanism + attempt number) into the trigger payload."""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+# isort: off
+# Editable local packages land in different groups across the two CI venvs.
+from infra.receipt_line_item_updater import line_item_processor
+
+# isort: on
+
+IMAGE_ID = "3f2a1b0c-4d5e-4f70-8192-a3b4c5d6e7f8"
+
+# Items sum (1.00) is wildly off the printed subtotal (50.0), so
+# should_reocr_items_zone fires.
+MISMATCH_ITEMS = [{"price": 1.00}]
+MISMATCH_SUMMARY = {"subtotal": 50.0, "grand_total": None, "tax": None}
+ZONE_WORDS = [
+    {
+        "line_id": 1,
+        "word_id": 1,
+        "text": "1.00",
+        "x": 0.8,
+        "y_mid": 0.5,
+        "h": 0.02,
+    }
+]
+
+
+def _prior_job():
+    return SimpleNamespace(
+        job_type="REGIONAL_REOCR",
+        receipt_id=1,
+        reocr_reason=line_item_processor.REOCR_REASON,
+    )
+
+
+def _setup(monkeypatch, prior_jobs):
+    monkeypatch.setenv("TRIGGER_REOCR_FUNCTION_NAME", "trigger-fn")
+    client = MagicMock()
+    client.list_ocr_jobs_for_image.return_value = (prior_jobs, None)
+    # Identity unit-square receipt: receipt-relative == image coords.
+    client.get_receipt.return_value = SimpleNamespace(
+        top_left={"x": 0.0, "y": 1.0},
+        top_right={"x": 1.0, "y": 1.0},
+        bottom_right={"x": 1.0, "y": 0.0},
+        bottom_left={"x": 0.0, "y": 0.0},
+        width=1000,
+        height=2000,
+    )
+    client.get_image.return_value = SimpleNamespace(width=1000, height=2000)
+    monkeypatch.setattr(line_item_processor, "dynamo_client", client)
+
+    lambda_client = MagicMock()
+    import boto3
+
+    monkeypatch.setattr(boto3, "client", MagicMock(return_value=lambda_client))
+    return lambda_client
+
+
+def _invoke_payload(lambda_client):
+    lambda_client.invoke.assert_called_once()
+    return json.loads(lambda_client.invoke.call_args.kwargs["Payload"])
+
+
+def test_attempt_one_uses_mechanism_ladder_head(monkeypatch):
+    lambda_client = _setup(monkeypatch, prior_jobs=[])
+    fired = line_item_processor._maybe_trigger_items_reocr(
+        IMAGE_ID,
+        1,
+        MISMATCH_ITEMS,
+        MISMATCH_SUMMARY,
+        ZONE_WORDS,
+        reocr_mechanism="reverse-video-total",
+    )
+    assert fired is True
+    payload = _invoke_payload(lambda_client)
+    assert payload["reocr_strategy"] == "invert"
+    assert payload["reocr_mechanism"] == "reverse-video-total"
+    assert payload["reocr_reason"] == line_item_processor.REOCR_REASON
+
+
+def test_attempt_two_uses_a_different_strategy(monkeypatch):
+    lambda_client = _setup(monkeypatch, prior_jobs=[_prior_job()])
+    fired = line_item_processor._maybe_trigger_items_reocr(
+        IMAGE_ID,
+        1,
+        MISMATCH_ITEMS,
+        MISMATCH_SUMMARY,
+        ZONE_WORDS,
+        reocr_mechanism="reverse-video-total",
+    )
+    assert fired is True
+    payload = _invoke_payload(lambda_client)
+    # Second rung of the reverse-video ladder, not a repeat of invert.
+    assert payload["reocr_strategy"] == "plain"
+
+
+def test_no_mechanism_climbs_unknown_ladder(monkeypatch):
+    lambda_client = _setup(monkeypatch, prior_jobs=[_prior_job()])
+    fired = line_item_processor._maybe_trigger_items_reocr(
+        IMAGE_ID, 1, MISMATCH_ITEMS, MISMATCH_SUMMARY, ZONE_WORDS
+    )
+    assert fired is True
+    payload = _invoke_payload(lambda_client)
+    assert payload["reocr_strategy"] == "upscale2x"
+    assert payload["reocr_mechanism"] is None
+
+
+def test_attempt_cap_still_blocks(monkeypatch):
+    lambda_client = _setup(
+        monkeypatch, prior_jobs=[_prior_job(), _prior_job()]
+    )
+    fired = line_item_processor._maybe_trigger_items_reocr(
+        IMAGE_ID,
+        1,
+        MISMATCH_ITEMS,
+        MISMATCH_SUMMARY,
+        ZONE_WORDS,
+        reocr_mechanism="reverse-video-total",
+    )
+    assert fired is False
+    lambda_client.invoke.assert_not_called()

--- a/receipt_upload/tests/test_reocr_strategy.py
+++ b/receipt_upload/tests/test_reocr_strategy.py
@@ -1,0 +1,309 @@
+"""Unit tests for the SMART re-OCR strategy ladder and harvest
+aggregation (receipt_upload.line_items.reocr_strategy)."""
+
+import json
+from datetime import datetime
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from receipt_upload.line_items.reocr_strategy import (
+    LEDGER_ASSET,
+    MIN_LEDGER_ATTEMPTS,
+    STRATEGIES,
+    build_ledger,
+    choose_strategy,
+    default_ladder,
+    ladder,
+    load_ledger,
+    mechanism_from_dossier,
+    mechanism_key,
+)
+
+# ---------------------------------------------------------------------------
+# Mechanism normalisation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("mechanism", "expected"),
+    [
+        ("reverse-video-total", "reverse-video"),
+        ("Reverse_Video_Total", "reverse-video"),
+        ("tilted-0deg-quads", "tilted"),
+        ("small-print", "small-print"),
+        ("pen-stroke", "unknown"),
+        ("", "unknown"),
+        (None, "unknown"),
+        ("something-else", "unknown"),
+    ],
+)
+def test_mechanism_key(mechanism, expected):
+    assert mechanism_key(mechanism) == expected
+
+
+# ---------------------------------------------------------------------------
+# Default ladders
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("mechanism", "head"),
+    [
+        ("reverse-video-total", ["invert", "plain"]),
+        ("tilted-0deg-quads", ["deskew", "plain"]),
+        ("small-print", ["upscale2x", "plain"]),
+        ("pen-stroke", ["plain", "upscale2x"]),
+        (None, ["plain", "upscale2x"]),
+    ],
+)
+def test_default_ladder_heads(mechanism, head):
+    order = default_ladder(mechanism)
+    assert order[: len(head)] == head
+    # Every strategy appears exactly once so retries never repeat
+    # before all four are exhausted.
+    assert sorted(order) == sorted(STRATEGIES)
+
+
+def test_choose_strategy_attempt_two_differs():
+    for mechanism in (
+        "reverse-video-total",
+        "tilted-0deg-quads",
+        "small-print",
+        "pen-stroke",
+        None,
+    ):
+        first = choose_strategy(mechanism, 1, ledger={})
+        second = choose_strategy(mechanism, 2, ledger={})
+        assert first != second
+
+
+def test_choose_strategy_first_four_attempts_all_distinct():
+    picks = [
+        choose_strategy("reverse-video-total", n, ledger={})
+        for n in range(1, 5)
+    ]
+    assert sorted(picks) == sorted(STRATEGIES)
+
+
+def test_choose_strategy_defaults():
+    assert choose_strategy("reverse-video-total", 1, ledger={}) == "invert"
+    assert choose_strategy("reverse-video-total", 2, ledger={}) == "plain"
+    assert choose_strategy("tilted-0deg-quads", 1, ledger={}) == "deskew"
+    assert choose_strategy("small-print", 1, ledger={}) == "upscale2x"
+    assert choose_strategy(None, 1, ledger={}) == "plain"
+    assert choose_strategy(None, 2, ledger={}) == "upscale2x"
+    # attempt_number below 1 clamps to attempt 1
+    assert choose_strategy(None, 0, ledger={}) == "plain"
+
+
+# ---------------------------------------------------------------------------
+# Ledger override
+# ---------------------------------------------------------------------------
+
+
+def _ledger_entry(attempts, rate, improvement=0.0):
+    return {
+        "attempts": attempts,
+        "acceptance_rate": rate,
+        "mean_delta_improvement": improvement,
+    }
+
+
+def test_ledger_overrides_default_order():
+    # Measured: plain beats invert for reverse-video (hypothetically).
+    ledger = {
+        "reverse-video": {
+            "invert": _ledger_entry(5, 0.2),
+            "plain": _ledger_entry(5, 0.9),
+        }
+    }
+    assert ladder("reverse-video-total", ledger)[:2] == ["plain", "invert"]
+    assert choose_strategy("reverse-video-total", 1, ledger) == "plain"
+    assert choose_strategy("reverse-video-total", 2, ledger) == "invert"
+
+
+def test_ledger_below_min_attempts_is_ignored():
+    ledger = {
+        "reverse-video": {
+            "invert": _ledger_entry(MIN_LEDGER_ATTEMPTS - 1, 0.0),
+            "plain": _ledger_entry(MIN_LEDGER_ATTEMPTS - 1, 1.0),
+        }
+    }
+    # Not enough evidence: hand-written default order stands.
+    assert ladder("reverse-video-total", ledger)[:2] == ["invert", "plain"]
+
+
+def test_ledger_tie_breaks_on_delta_improvement():
+    ledger = {
+        "unknown": {
+            "plain": _ledger_entry(4, 0.5, improvement=0.1),
+            "upscale2x": _ledger_entry(4, 0.5, improvement=2.5),
+        }
+    }
+    assert ladder("pen-stroke", ledger)[:2] == ["upscale2x", "plain"]
+
+
+def test_ledger_for_other_mechanism_does_not_leak():
+    ledger = {"tilted": {"plain": _ledger_entry(9, 1.0)}}
+    assert ladder("reverse-video-total", ledger)[:2] == ["invert", "plain"]
+
+
+def test_load_ledger_missing_file_returns_empty(tmp_path):
+    assert load_ledger(tmp_path / "nope.json") == {}
+
+
+def test_load_ledger_invalid_json_returns_empty(tmp_path):
+    bad = tmp_path / "bad.json"
+    bad.write_text("{not json", encoding="utf-8")
+    assert load_ledger(bad) == {}
+
+
+def test_committed_asset_is_valid():
+    data = json.loads(Path(LEDGER_ASSET).read_text(encoding="utf-8"))
+    assert data["schema"] == "reocr-ladder-v1"
+    assert isinstance(data["mechanisms"], dict)
+    # And the loader accepts it.
+    assert isinstance(load_ledger(LEDGER_ASSET), dict)
+
+
+# ---------------------------------------------------------------------------
+# Dossier -> mechanism
+# ---------------------------------------------------------------------------
+
+
+def test_mechanism_from_dossier_reverse_video():
+    dossier = {
+        "mode": "E-image-suspect",
+        "visual_evidence": [
+            "Transcribed rows: BURGER 9.99, FRIES 3.49",
+            "Printed TOTAL is reverse-video (white on black); OCR "
+            "dropped it",
+        ],
+    }
+    assert mechanism_from_dossier(dossier) == "reverse-video-total"
+
+
+def test_mechanism_from_dossier_tilted():
+    dossier = {
+        "mode": "J-unknown",
+        "visual_evidence": ["Receipt photographed tilted; rows skewed"],
+    }
+    assert mechanism_from_dossier(dossier) == "tilted"
+
+
+def test_mechanism_from_dossier_small_print():
+    dossier = {"visual_evidence": ["fine print at the bottom unreadable"]}
+    assert mechanism_from_dossier(dossier) == "small-print"
+
+
+def test_mechanism_from_dossier_pen_stroke():
+    dossier = {"visual_evidence": ["a pen stroke crosses the total line"]}
+    assert mechanism_from_dossier(dossier) == "pen-stroke"
+
+
+def test_mechanism_from_dossier_no_false_pen_match():
+    # "open" must not substring-match the pen hint.
+    dossier = {"visual_evidence": ["store was open late; totals match"]}
+    assert mechanism_from_dossier(dossier) is None
+
+
+@pytest.mark.parametrize("dossier", [None, [], "text", {}, {"mode": ""}])
+def test_mechanism_from_dossier_degenerate_inputs(dossier):
+    assert mechanism_from_dossier(dossier) is None
+
+
+# ---------------------------------------------------------------------------
+# Harvest aggregation (build_ledger)
+# ---------------------------------------------------------------------------
+
+
+def _job(**overrides):
+    values = {
+        "status": "COMPLETED",
+        "job_type": "REGIONAL_REOCR",
+        "reocr_strategy": "invert",
+        "reocr_mechanism": "reverse-video-total",
+        "reocr_words_accepted": 8,
+        "reocr_words_rejected": 2,
+        "reocr_delta_before": -4.0,
+        "reocr_delta_after": 0.0,
+        "created_at": datetime(2026, 8, 1),
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def test_build_ledger_aggregates_fixture_jobs():
+    jobs = [
+        _job(),
+        _job(
+            reocr_words_accepted=2,
+            reocr_words_rejected=8,
+            reocr_delta_before=-4.0,
+            reocr_delta_after=-3.0,
+        ),
+        _job(
+            reocr_strategy="plain",
+            reocr_words_accepted=0,
+            reocr_words_rejected=5,
+            reocr_delta_before=None,
+            reocr_delta_after=None,
+        ),
+        _job(reocr_mechanism="tilted-0deg-quads", reocr_strategy="deskew"),
+    ]
+    ledger = build_ledger(jobs)
+
+    rv_invert = ledger["reverse-video"]["invert"]
+    assert rv_invert["attempts"] == 2
+    assert rv_invert["words_accepted"] == 10
+    assert rv_invert["words_rejected"] == 10
+    assert rv_invert["acceptance_rate"] == 0.5
+    # improvements: (4.0 - 0.0) and (4.0 - 3.0) -> mean 2.5
+    assert rv_invert["mean_delta_improvement"] == 2.5
+
+    rv_plain = ledger["reverse-video"]["plain"]
+    assert rv_plain["attempts"] == 1
+    assert rv_plain["acceptance_rate"] == 0.0
+    assert rv_plain["mean_delta_improvement"] is None
+
+    assert ledger["tilted"]["deskew"]["attempts"] == 1
+
+
+def test_build_ledger_filters_non_contributing_jobs():
+    jobs = [
+        _job(status="PENDING"),
+        _job(job_type="FIRST_PASS"),
+        _job(reocr_strategy=None),
+        _job(reocr_strategy="sharpen"),
+        _job(reocr_words_accepted=None, reocr_words_rejected=None),
+    ]
+    assert build_ledger(jobs) == {}
+
+
+def test_build_ledger_unknown_mechanism_bucket():
+    ledger = build_ledger([_job(reocr_mechanism="pen-stroke")])
+    assert list(ledger) == ["unknown"]
+
+
+def test_build_ledger_feeds_choose_strategy():
+    # Harvested outcomes flip the reverse-video ordering.
+    jobs = [
+        _job(
+            reocr_strategy="invert",
+            reocr_words_accepted=0,
+            reocr_words_rejected=10,
+        )
+        for _ in range(MIN_LEDGER_ATTEMPTS)
+    ] + [
+        _job(
+            reocr_strategy="plain",
+            reocr_words_accepted=10,
+            reocr_words_rejected=0,
+        )
+        for _ in range(MIN_LEDGER_ATTEMPTS)
+    ]
+    ledger = build_ledger(jobs)
+    assert choose_strategy("reverse-video-total", 1, ledger) == "plain"
+    assert choose_strategy("reverse-video-total", 2, ledger) == "invert"

--- a/scripts/harvest_reocr_outcomes.py
+++ b/scripts/harvest_reocr_outcomes.py
@@ -30,7 +30,6 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from receipt_dynamo import DynamoClient
-
 from receipt_upload.line_items.reocr_strategy import (
     LEDGER_ASSET,
     build_ledger,

--- a/scripts/harvest_reocr_outcomes.py
+++ b/scripts/harvest_reocr_outcomes.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Harvest SMART re-OCR outcomes into the strategy-ladder asset.
+
+Scans completed REGIONAL_REOCR OCRJobs (which carry reocr_strategy /
+reocr_mechanism from the trigger and reocr_words_accepted /
+reocr_words_rejected / reocr_delta_before / reocr_delta_after from the
+overlay) and aggregates them per mechanism x strategy: attempts,
+word-level acceptance rate, and mean |delta| improvement. The result
+is written to receipt_upload/receipt_upload/line_items/assets/
+reocr_ladder.json -- a committed asset (same pattern as the block-role
+priors) that choose_strategy() uses to override the hand-written
+default ladder ordering by measured success.
+
+Usage:
+    python scripts/harvest_reocr_outcomes.py --table ReceiptsTable-dc5be22
+    python scripts/harvest_reocr_outcomes.py --table ... --dry-run
+
+The aggregation itself is pure and lives in
+receipt_upload.line_items.reocr_strategy.build_ledger so it is unit
+tested next to the ladder.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+from receipt_dynamo import DynamoClient
+
+from receipt_upload.line_items.reocr_strategy import (
+    LEDGER_ASSET,
+    build_ledger,
+)
+
+
+def fetch_ocr_jobs(client: DynamoClient) -> list:
+    """Page through every OCR job in the table."""
+    jobs: list = []
+    last_evaluated_key = None
+    while True:
+        page, last_evaluated_key = client.list_ocr_jobs(
+            limit=500, last_evaluated_key=last_evaluated_key
+        )
+        jobs.extend(page)
+        if not last_evaluated_key:
+            break
+    return jobs
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--table",
+        default=os.environ.get("DYNAMODB_TABLE_NAME", ""),
+        help="DynamoDB table name (default: $DYNAMODB_TABLE_NAME)",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=LEDGER_ASSET,
+        help=f"Ledger JSON path (default: {LEDGER_ASSET})",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the ledger instead of writing the asset",
+    )
+    args = parser.parse_args(argv)
+
+    if not args.table:
+        parser.error("--table (or $DYNAMODB_TABLE_NAME) is required")
+
+    client = DynamoClient(args.table)
+    jobs = fetch_ocr_jobs(client)
+    mechanisms = build_ledger(jobs)
+
+    payload = {
+        "schema": "reocr-ladder-v1",
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "source": f"scripts/harvest_reocr_outcomes.py --table {args.table}",
+        "mechanisms": mechanisms,
+    }
+    rendered = json.dumps(payload, indent=2) + "\n"
+
+    total = sum(
+        entry["attempts"]
+        for per_strategy in mechanisms.values()
+        for entry in per_strategy.values()
+    )
+    print(
+        f"Harvested {total} completed re-OCR attempts across "
+        f"{len(mechanisms)} mechanism(s) from {len(jobs)} OCR jobs."
+    )
+    if args.dry_run:
+        print(rendered)
+        return 0
+
+    args.output.write_text(rendered, encoding="utf-8")
+    print(f"Wrote {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/receipt_mcp_server.py
+++ b/scripts/receipt_mcp_server.py
@@ -1301,6 +1301,26 @@ Back up the receipt with export_image before triggering.""",
                         "description": "Reason for re-OCR. Default: manual_trigger",
                         "default": "manual_trigger",
                     },
+                    "strategy": {
+                        "type": "string",
+                        "enum": ["plain", "invert", "deskew", "upscale2x"],
+                        "description": (
+                            "Optional capture strategy for the Swift "
+                            "worker (SMART re-OCR ladder). Omit to let "
+                            "the worker use its default (plain)."
+                        ),
+                    },
+                    "mechanism": {
+                        "type": "string",
+                        "description": (
+                            "Optional diagnosed OCR-failure mechanism "
+                            "(free string, e.g. reverse-video-total, "
+                            "tilted-0deg-quads, small-print, "
+                            "pen-stroke). Read it from the triage "
+                            "dossier when one exists; recorded on the "
+                            "OCRJob for outcome harvesting."
+                        ),
+                    },
                 },
                 "required": ["image_id", "receipt_id", "reocr_region"],
             },
@@ -2247,6 +2267,8 @@ async def call_tool(
                 receipt_id=arguments["receipt_id"],
                 reocr_region=arguments["reocr_region"],
                 reocr_reason=arguments.get("reocr_reason", "manual_trigger"),
+                strategy=arguments.get("strategy"),
+                mechanism=arguments.get("mechanism"),
             )
         elif name == "list_recent_uploads":
             result = await list_recent_uploads_impl(
@@ -4224,6 +4246,8 @@ async def trigger_reocr_impl(
     receipt_id: int,
     reocr_region: dict,
     reocr_reason: str = "manual_trigger",
+    strategy: str | None = None,
+    mechanism: str | None = None,
 ) -> dict:
     """Invoke the trigger-reocr Lambda to start regional re-OCR."""
     try:
@@ -4235,6 +4259,8 @@ async def trigger_reocr_impl(
                 "receipt_id": receipt_id,
                 "reocr_region": reocr_region,
                 "reocr_reason": reocr_reason,
+                "reocr_strategy": strategy,
+                "reocr_mechanism": mechanism,
             },
         )
     except Exception as e:


### PR DESCRIPTION
## Summary

Python half of the SMART re-OCR system. The Swift worker is being extended in a parallel PR to consume **exactly** these OCRJob field names.

### 1. OCRJob contract fields (`receipt_dynamo`)
Optional, absent-tolerant, non-breaking: `reocr_strategy` (`plain|invert|deskew|upscale2x`), `reocr_mechanism` (free string, e.g. `reverse-video-total`, `tilted-0deg-quads`, `small-print`, `pen-stroke`), and overlay completion metrics `reocr_words_accepted`, `reocr_words_rejected`, `reocr_delta_before`, `reocr_delta_after`. Round-trip, absent-tolerant (legacy items), and validation tests in `test_refinement_job.py`.

### 2. Strategy ladder + harvest (`receipt_upload.line_items.reocr_strategy`)
- Mechanism → default ladder: reverse-video→`[invert, plain]`, tilted→`[deskew, plain]`, small-print→`[upscale2x, plain]`, unknown→`[plain, upscale2x]`; full order appends remaining strategies so the first four attempts never repeat.
- `choose_strategy(mechanism, attempt_number, ledger)` — the ledger (per mechanism×strategy: attempts, acceptance rate, mean |delta| improvement) overrides ordering by measured success (≥3 attempts).
- `mechanism_from_dossier()` derives the mechanism from triage dossier v2 `mode`/`visual_evidence`.
- `scripts/harvest_reocr_outcomes.py` builds the ledger from completed OCRJobs and writes the committed asset `assets/reocr_ladder.json` (block-role-priors pattern); aggregation is pure (`build_ledger`) and unit-tested with fixture jobs.

### 3. Trigger enrichment
- `_maybe_trigger_items_reocr` passes attempt-aware strategy + optional mechanism through the trigger Lambda; the capped **attempt 2 climbs the ladder instead of repeating** the failed capture (tests in `test_line_item_reocr_trigger.py`).
- `trigger_reocr` Lambda validates + stamps `reocr_strategy`/`reocr_mechanism` onto the OCRJob.
- MCP `trigger_reocr` tool (BOTH server variants) gains optional `strategy` + `mechanism` args.
- New module + asset added to the line-item updater Lambda bundle.
- Wiring documented in `docs/line-items/agentic-review/REOCR_STRATEGY.md`.

### 4. Overlay completion metrics
The container OCR handler's regional overlay persists accepted/rejected counts and the items-zone delta before/after (same `extract_items` decode as the line-item updater; null when no ITEMS section/subtotal) onto the OCRJob at completion — best-effort, never fails the overlay. Tests in `test_overlay.py` (`TestReocrCompletionMetrics`).

## Test plan
- `receipt_dynamo/tests/unit` — 2357 passed
- `receipt_upload/tests` full suite (CI marker filter, `PYTHONPATH` repo root) — exit 0, incl. golden regression
- `infra/upload_images/container_ocr/handler/tests` — 82 passed
- black/isort (79, profile=black) clean on both gated packages; all changed files `py_compile` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SMART re-OCR strategy selection based on failure mechanisms and prior outcomes.
  * Added support for specifying OCR strategies and failure mechanisms when triggering re-OCR.
  * Added completion metrics, including accepted/rejected words and before/after accuracy deltas.
  * Added outcome harvesting to improve future strategy ordering.

* **Bug Fixes**
  * OCR overlay completion now succeeds even if metric persistence fails.

* **Documentation**
  * Documented the re-OCR strategy ladder, outcome tracking, and integration flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->