### PR TITLE
golden: first agent-originated promotions (user-signed-off)

### DIFF
--- a/receipt_upload/tests/fixtures/line_items_golden.json
+++ b/receipt_upload/tests/fixtures/line_items_golden.json
@@ -3060,6 +3060,52 @@
      "is_discount": false
     }
    ]
+  },
+  {
+   "image_id": "49d8fde2-7ffd-4913-a9c0-6731e74fa147",
+   "receipt_id": 1,
+   "merchant": "Sprouts Farmers Market",
+   "printed_subtotal": null,
+   "printed_total": "17.99",
+   "items_sum": "17.99",
+   "sum_matches_subtotal": true,
+   "reconcile_note": "no printed subtotal/tax; single item equals BALANCE DUE / CREDIT / EMV Total 17.99 exactly, and the bank settlement 17.99 (conf 0.95) agrees to the cent. Store header block is printed twice (scanner artifact); body printed once.",
+   "true_items": [
+    {
+     "name": "RAW WHOLE MILK",
+     "price": "17.99",
+     "quantity": null,
+     "unit_price": null,
+     "line_ids": [
+      14,
+      15
+     ],
+     "is_discount": false
+    }
+   ]
+  },
+  {
+   "image_id": "9cf39343-8eb3-4fdb-bcea-843d6388b8d2",
+   "receipt_id": 1,
+   "merchant": "Sprouts Farmers Market",
+   "printed_subtotal": null,
+   "printed_total": "8.49",
+   "items_sum": "8.49",
+   "sum_matches_subtotal": true,
+   "reconcile_note": "no printed subtotal/tax; single item equals BALANCE DUE / DEBIT / EMV Total 8.49 exactly, and the bank settlement 8.49 (conf 0.90) agrees to the cent.",
+   "true_items": [
+    {
+     "name": "ORG FF GRASSFED MILK",
+     "price": "8.49",
+     "quantity": null,
+     "unit_price": null,
+     "line_ids": [
+      35,
+      36
+     ],
+     "is_discount": false
+    }
+   ]
   }
  ]
 }

--- a/receipt_upload/tests/fixtures/line_items_golden_ocr.json
+++ b/receipt_upload/tests/fixtures/line_items_golden_ocr.json
@@ -13803,6 +13803,109 @@
      "h": 0.013035
     }
    ]
+  },
+  {
+   "image_id": "49d8fde2-7ffd-4913-a9c0-6731e74fa147",
+   "receipt_id": 1,
+   "merchant": "Sprouts Farmers Market",
+   "items_line_ids": [
+    14,
+    15
+   ],
+   "words": [
+    {
+     "line_id": 15,
+     "word_id": 1,
+     "text": "17.99",
+     "x": 0.783173,
+     "y_mid": 0.725511,
+     "h": 0.013119
+    },
+    {
+     "line_id": 14,
+     "word_id": 3,
+     "text": "MILK",
+     "x": 0.27425,
+     "y_mid": 0.725568,
+     "h": 0.010879
+    },
+    {
+     "line_id": 14,
+     "word_id": 2,
+     "text": "WHOLE",
+     "x": 0.1325,
+     "y_mid": 0.725581,
+     "h": 0.010853
+    },
+    {
+     "line_id": 14,
+     "word_id": 1,
+     "text": "RAW",
+     "x": 0.0375,
+     "y_mid": 0.725568,
+     "h": 0.010879
+    }
+   ]
+  },
+  {
+   "image_id": "9cf39343-8eb3-4fdb-bcea-843d6388b8d2",
+   "receipt_id": 1,
+   "merchant": "Sprouts Farmers Market",
+   "items_line_ids": [
+    34,
+    35,
+    36
+   ],
+   "words": [
+    {
+     "line_id": 35,
+     "word_id": 4,
+     "text": "MILK",
+     "x": 0.429688,
+     "y_mid": 0.545942,
+     "h": 0.017539
+    },
+    {
+     "line_id": 35,
+     "word_id": 2,
+     "text": "FF",
+     "x": 0.163649,
+     "y_mid": 0.539932,
+     "h": 0.016436
+    },
+    {
+     "line_id": 35,
+     "word_id": 1,
+     "text": "ORG",
+     "x": 0.076674,
+     "y_mid": 0.538106,
+     "h": 0.0172
+    },
+    {
+     "line_id": 36,
+     "word_id": 1,
+     "text": "8.49",
+     "x": 0.783465,
+     "y_mid": 0.551599,
+     "h": 0.015988
+    },
+    {
+     "line_id": 34,
+     "word_id": 1,
+     "text": "DAIRY",
+     "x": 0.055118,
+     "y_mid": 0.554506,
+     "h": 0.018895
+    },
+    {
+     "line_id": 35,
+     "word_id": 3,
+     "text": "GRASSFED",
+     "x": 0.230159,
+     "y_mid": 0.54282,
+     "h": 0.019325
+    }
+   ]
   }
  ]
 }

--- a/receipt_upload/tests/test_line_item_golden_regression.py
+++ b/receipt_upload/tests/test_line_item_golden_regression.py
@@ -77,7 +77,9 @@ def _score_receipt(
 # (+70 items corpus-wide): over-generation is invisible to recall and
 # names, so it must be gated explicitly.
 _FLOORS = {
-    "Sprouts Farmers Market": (1.00, 0.85, 0.95),
+    # Name floor raised 0.85 -> 0.90 with the 2026-08-03 agent-originated
+    # promotions (two single-item Sprouts receipts, measured names 0.949).
+    "Sprouts Farmers Market": (1.00, 0.90, 0.95),
     "Roast & Rice Asian Fusion": (1.00, 1.00, 0.95),
     "TRADER JOE'S": (1.00, 1.00, 0.95),
     "Trader Joe's": (1.00, 1.00, 0.95),


### PR DESCRIPTION
## Summary

Promotes the two golden candidates from adjudication pass-20260803 (tier T1, `golden: true`, reason `golden-candidate`) into `receipt_upload/tests/fixtures/line_items_golden.json`. Both are Sprouts Farmers Market `no-baseline-total-printed-legible` receipts. User signed off on the promotion; each receipt was re-verified live today (not from the stale dossiers) before promoting.

## Verification evidence (recomputed 2026-08-03 against ReceiptsTable-dc5be22)

### 49d8fde2-7ffd-4913-a9c0-6731e74fa147 receipt 1 — Sprouts Westlake Village, 08/02/2024
| Signal | Result |
|---|---|
| Decode (live words, ITEMS lines 14-15) | 1 item: RAW WHOLE MILK **17.99**; items_sum 17.99 |
| Printed figures (full-res image viewed) | BALANCE DUE 17.99, CREDIT $17.99, CHANGE 0.00, EMV `Total: USD$ 17.99` — all agree |
| Bank | summary bank_amount **17.99** (conf 0.95, card) — cent-exact vs printed total |
| Stored summary | grand_total still `None` (the no-baseline mode is an extraction gap, not a data problem) |

Image note: the store header block is printed twice (scanner artifact); the body is printed once — confirmed visually, not a duplicate transaction.

### 9cf39343-8eb3-4fdb-bcea-843d6388b8d2 receipt 1 — Sprouts Henderson NV, 06/30/2026
| Signal | Result |
|---|---|
| Decode (live words, ITEMS lines 34-36) | 1 item: ORG FF GRASSFED MILK **8.49**; items_sum 8.49 |
| Printed figures (full-res image viewed) | BALANCE DUE 8.49, DEBIT $8.49, CHANGE 0.00, EMV `Total: USD$ 8.49` — all agree |
| Bank | summary bank_amount **8.49** (conf 0.90, card) — cent-exact vs printed total |
| Stored summary | grand_total still `None` |

## Changes

- `line_items_golden.json`: +2 entries (35 total). Conventions followed: printed_subtotal null, items sum to printed total to the cent, reconcile_note on each; the two `local_only` entries untouched.
- `line_items_golden_ocr.json`: the two new receipts' ITEMS word geometry appended **surgically** onto the committed capture. A full regeneration via `scripts/export_line_item_golden_ocr.py` was run and rejected: unrelated Costco/Target dev OCR has drifted since the last capture and a wholesale recapture broke their floors (Costco precision 80% vs floor 85%, Target recall 54% vs floor 65%). That drift is a separate investigation, not this promotion.
- `test_line_item_golden_regression.py`: Sprouts name floor raised 0.85 → 0.90 (measured 0.949 post-promotion). No floor lowered.

## Gates

- `test_line_item_golden_regression.py` — pass
- `test_geometry.py`, `test_geometry_extended.py`, `test_line_item_geometry.py` — 49 passed
- black / isort clean on the touched test file
- Corpus sweep not run: fixtures-only change, no decoder change

🤖 Generated with [Claude Code](https://claude.com/claude-code)