### PR TITLE
chore: dual-Mac OCR worker update script and runbook

### DIFF
--- a/docs/line-items/agentic-review/RUNNERS.md
+++ b/docs/line-items/agentic-review/RUNNERS.md
@@ -1,0 +1,193 @@
+# Dev OCR Queue Runners (dual-Mac)
+
+Two Macs drain the dev OCR job queue (`upload-images-dev-ocr-queue`) on a
+schedule, so re-OCR jobs queued by the agentic review loop get processed without
+anyone babysitting a terminal.
+
+| Machine | Hostname | Checkout used for the binary | Schedule |
+|---|---|---|---|
+| MacBook Pro | `Tylers-MacBook-Pro` (local) | `/Users/tnorlund/Portfolio/.claude/worktrees/backfill-main` | `:00 :15 :30 :45` |
+| Mac mini | `Tylers-Mac-mini`, `mini` (ssh alias) | `/Users/tnorlund/ocr-runner-main` | `:07 :22 :37 :52` |
+
+The offset schedules interleave the two machines so they do not contend for the
+same SQS messages.
+
+`StartCalendarInterval` is used rather than `StartInterval`, because launchd has
+no way to phase-offset an interval timer: the phase of a `StartInterval` agent
+depends on when it happened to be loaded and drifts across reboots. Fixed
+minutes are the only way to hold a durable 7-minute offset between the machines.
+
+## What runs
+
+Both machines run the same command through a wrapper script:
+
+```bash
+receipt-ocr --env dev --continuous --log-level info
+```
+
+`--continuous` means "process until the queue is empty, then exit". Each
+scheduled start is a fresh process, so a wedged run dies with its own
+invocation instead of being resurrected forever. That is also why the agents set
+`KeepAlive` to false.
+
+## Files
+
+| Purpose | Path (same on both machines) | Canonical copy in this repo |
+|---|---|---|
+| Wrapper script | `~/receipt_ocr_runner/run-dev.sh` | `scripts/ocr_runner/run-dev.sh` |
+| LaunchAgent | `~/Library/LaunchAgents/com.tnorlund.receipt-ocr-dev.plist` | `scripts/ocr_runner/com.tnorlund.receipt-ocr-dev.{macbook,mini}.plist` |
+| Log | `~/Library/Logs/receipt-ocr-dev.log` | — |
+| Overlap lock | `/tmp/receipt-ocr-dev.lock` (directory, created atomically) | — |
+
+The wrapper is byte-identical on both machines: it picks the first checkout path
+that exists on the host, so there is nothing per-machine to keep in sync. The
+two plists differ only in their four scheduled minutes.
+
+## Updating after a merge
+
+**The binaries do not auto-update.** The agents run a binary built from a
+checkout pinned to `main`, and nothing rebuilds it. After merging anything under
+`receipt_ocr_swift/`, the workers keep draining the queue with stale code until
+you run:
+
+```bash
+./scripts/update_ocr_workers.sh
+```
+
+For each host this fetches `origin/main`, re-pins the checkout, runs
+`swift build --configuration release`, proves the new binary runs, and
+kickstarts the LaunchAgent.
+
+| Flag | Effect |
+|---|---|
+| `--host local\|mini\|both` | Which worker to update (default `both`) |
+| `--dry-run` | Print what would run, change nothing |
+| `--skip-build` | Re-pin and kickstart without rebuilding |
+
+The script is idempotent — re-running it on an up-to-date machine reports
+`already current`, rebuilds in a few seconds, and kickstarts again. It exits
+non-zero if any host fails, and prints the last 20 lines of build output when a
+`swift build` breaks.
+
+The checkouts are detached worktrees, so the script uses
+`git fetch` + `git checkout --detach origin/main` rather than `git pull`. That
+preserves untracked files and *refuses* rather than clobbering if someone left
+tracked edits on the box.
+
+## Two gotchas that will silently break this
+
+**PATH.** `--env dev` resolves queue URLs, the Dynamo table name, and the
+LayoutLM model bucket/key by shelling out to `/usr/bin/env pulumi stack output`.
+`PulumiLoader.loadOutputs` returns an empty dict on any non-zero exit rather
+than raising, so if `pulumi` is not on `PATH` the worker starts up with no queue
+URL and quietly does nothing. launchd's default `PATH` does not include the
+pulumi install, so the wrapper exports it explicitly. The install location
+differs per machine — `~/.pulumi/bin/pulumi` on the MacBook,
+`/opt/homebrew/bin/pulumi` on the mini — so the wrapper puts both on `PATH`.
+
+**Working directory.** The LayoutLM CoreML bundle is cached at the relative
+path `.models/layoutlm`. The wrapper `cd`s into `receipt_ocr_swift` first so the
+~400 MB model is downloaded once and reused, rather than re-fetched from S3 into
+whatever directory launchd happened to pick.
+
+## Xcode vs Command Line Tools
+
+Both machines run the same Swift toolchain version (6.3.3), but they get it from
+different places:
+
+| Machine | `xcode-select -p` |
+|---|---|
+| MacBook Pro | `/Library/Developer/CommandLineTools` |
+| Mac mini | `/Applications/Xcode.app/Contents/Developer` |
+
+Command Line Tools is enough to build and run this CLI, so the MacBook is fine
+as a runner. **Do Swift development on the mini**: only it has full Xcode, and
+therefore simulators, Instruments, `docc`, and anything that needs an SDK beyond
+the macOS one. A change that builds under CLT on the MacBook can still fail on a
+machine that resolves a different SDK, so treat the mini's build as the
+authoritative one.
+
+## Install (first time on a new machine)
+
+```bash
+mkdir -p ~/receipt_ocr_runner
+cp scripts/ocr_runner/run-dev.sh ~/receipt_ocr_runner/run-dev.sh
+chmod +x ~/receipt_ocr_runner/run-dev.sh
+cp scripts/ocr_runner/com.tnorlund.receipt-ocr-dev.mini.plist \
+   ~/Library/LaunchAgents/com.tnorlund.receipt-ocr-dev.plist
+
+plutil -lint ~/Library/LaunchAgents/com.tnorlund.receipt-ocr-dev.plist
+launchctl load -w ~/Library/LaunchAgents/com.tnorlund.receipt-ocr-dev.plist
+launchctl list | grep receipt-ocr        # confirm it registered
+```
+
+Pick the plist whose schedule that machine should own, and give the machine a
+checkout pinned to `main` (`git worktree add --detach ~/ocr-runner-main origin/main`).
+Do not point a runner at a checkout anyone works in: `~/Portfolio` on the mini
+carries ~100 uncommitted modifications, and pointing the runner there would
+either fail to update or clobber work in progress.
+
+Kick off a run immediately instead of waiting for the next quarter hour:
+
+```bash
+launchctl kickstart -k gui/$(id -u)/com.tnorlund.receipt-ocr-dev
+```
+
+Installing is idempotent: re-running `load -w` on an already-loaded agent is a
+no-op, and the wrapper's lock directory makes a double start harmless.
+
+Note that `launchctl load` does **not** run the job, and `RunAtLoad` is false —
+so a freshly loaded agent sits at `runs = 0` until the first scheduled minute.
+`launchctl list | grep receipt` showing the label is *not* evidence it has ever
+run; check `launchctl print gui/$(id -u)/com.tnorlund.receipt-ocr-dev` for
+`runs =` and confirm the log file exists.
+
+## Disable
+
+```bash
+launchctl unload -w ~/Library/LaunchAgents/com.tnorlund.receipt-ocr-dev.plist
+```
+
+To remove it permanently, delete the plist and `~/receipt_ocr_runner/`. If a run
+was killed mid-flight the lock can survive; clear it with
+`rmdir /tmp/receipt-ocr-dev.lock`.
+
+**Do not touch the `actions.runner.tnorlund-Portfolio.*` agents** in the same
+LaunchAgents directory. Those are the GitHub Actions self-hosted runners, they
+are managed by `svc.sh`, and they are unrelated to OCR.
+
+## Verifying it works
+
+```bash
+aws sqs get-queue-attributes \
+  --queue-url https://sqs.us-east-1.amazonaws.com/681647709217/upload-images-dev-ocr-queue \
+  --attribute-names ApproximateNumberOfMessages
+tail -f ~/Library/Logs/receipt-ocr-dev.log
+```
+
+A healthy run logs `job_start` / `regional_reocr_crop_complete` / `ocr_run` /
+`job_complete` / `sqs_delete_batch` lines per job and then exits when the queue
+empties.
+
+Vision OCR runs fine headless over SSH with the screen locked; no TCC prompt is
+involved for image-buffer requests. This is confirmed on the mini.
+
+### A failing job aborts the rest of the batch
+
+If a single job throws, the worker prints `Error: NotFound: Not Found` and the
+whole drain stops early rather than skipping that message and continuing. The
+message then returns to the queue after its visibility timeout and blocks the
+next drain the same way, on whichever machine picks it up. Symptom: queue depth
+that will not go to zero, and both logs ending at the same `job_start`. Until
+the worker isolates per-job failures, find the offending `image_id` in the log
+and deal with that message directly.
+
+### Reading job status in DynamoDB
+
+Check the `status` attribute, not the GSI partition. `OCRJob` rows never
+rewrite `GSI1PK`/`GSI2PK` on a status transition, so a completed job still sits
+in the `OCR_JOB_STATUS#PENDING` partition. `receipt_dynamo/entities/ocr_job.py`
+documents this and tolerates the stale partition on read. Querying GSI1 for
+`OCR_JOB_STATUS#PENDING` therefore massively overcounts pending work — in dev it
+returns ~1250 rows against a queue depth of a few dozen. The SQS queue depth is
+the honest signal for "how much work is left".

--- a/scripts/ocr_runner/com.tnorlund.receipt-ocr-dev.macbook.plist
+++ b/scripts/ocr_runner/com.tnorlund.receipt-ocr-dev.macbook.plist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key><string>com.tnorlund.receipt-ocr-dev</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/Users/tnorlund/receipt_ocr_runner/run-dev.sh</string>
+    </array>
+    <!-- MacBook Pro drains at :00 :15 :30 :45; the Mac mini agent uses
+         :07 :22 :37 :52 so the two machines interleave. -->
+    <key>StartCalendarInterval</key>
+    <array>
+        <dict><key>Minute</key><integer>0</integer></dict>
+        <dict><key>Minute</key><integer>15</integer></dict>
+        <dict><key>Minute</key><integer>30</integer></dict>
+        <dict><key>Minute</key><integer>45</integer></dict>
+    </array>
+    <!-- Deliberately NOT KeepAlive: a wedged worker should die with its run,
+         not be resurrected in a loop. Each run exits when the queue is empty. -->
+    <key>KeepAlive</key><false/>
+    <key>RunAtLoad</key><false/>
+    <key>ProcessType</key><string>Background</string>
+    <key>StandardOutPath</key><string>/Users/tnorlund/Library/Logs/receipt-ocr-dev.log</string>
+    <key>StandardErrorPath</key><string>/Users/tnorlund/Library/Logs/receipt-ocr-dev.log</string>
+</dict>
+</plist>

--- a/scripts/ocr_runner/com.tnorlund.receipt-ocr-dev.mini.plist
+++ b/scripts/ocr_runner/com.tnorlund.receipt-ocr-dev.mini.plist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key><string>com.tnorlund.receipt-ocr-dev</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/Users/tnorlund/receipt_ocr_runner/run-dev.sh</string>
+    </array>
+    <!-- Mac mini drains at :07 :22 :37 :52; the MacBook Pro agent uses
+         :00 :15 :30 :45 so the two machines interleave. -->
+    <key>StartCalendarInterval</key>
+    <array>
+        <dict><key>Minute</key><integer>7</integer></dict>
+        <dict><key>Minute</key><integer>22</integer></dict>
+        <dict><key>Minute</key><integer>37</integer></dict>
+        <dict><key>Minute</key><integer>52</integer></dict>
+    </array>
+    <!-- Deliberately NOT KeepAlive: a wedged worker should die with its run,
+         not be resurrected in a loop. Each run exits when the queue is empty. -->
+    <key>KeepAlive</key><false/>
+    <key>RunAtLoad</key><false/>
+    <key>ProcessType</key><string>Background</string>
+    <key>StandardOutPath</key><string>/Users/tnorlund/Library/Logs/receipt-ocr-dev.log</string>
+    <key>StandardErrorPath</key><string>/Users/tnorlund/Library/Logs/receipt-ocr-dev.log</string>
+</dict>
+</plist>

--- a/scripts/ocr_runner/run-dev.sh
+++ b/scripts/ocr_runner/run-dev.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# Drain the dev OCR job queue with the Swift Vision/LayoutLM worker.
+# Installed at ~/receipt_ocr_runner/run-dev.sh and started by
+# com.tnorlund.receipt-ocr-dev.plist. See
+# docs/line-items/agentic-review/RUNNERS.md.
+set -uo pipefail
+
+# Each machine pins its own checkout to main. The first candidate that exists
+# wins, so this script is byte-identical on every machine; set
+# RECEIPT_OCR_SWIFT_DIR to override.
+SWIFT_DIR_CANDIDATES="
+/Users/tnorlund/ocr-runner-main/receipt_ocr_swift
+/Users/tnorlund/Portfolio/.claude/worktrees/backfill-main/receipt_ocr_swift
+"
+
+SWIFT_DIR="${RECEIPT_OCR_SWIFT_DIR:-}"
+if [ -z "$SWIFT_DIR" ]; then
+  for candidate in $SWIFT_DIR_CANDIDATES; do
+    if [ -d "$candidate" ]; then
+      SWIFT_DIR="$candidate"
+      break
+    fi
+  done
+fi
+
+LOCK="/tmp/receipt-ocr-dev.lock"
+
+# `--env dev` shells out to `/usr/bin/env pulumi` to read stack outputs, and
+# launchd's default PATH does not include the pulumi install. PulumiLoader
+# returns an empty config on a non-zero exit rather than raising, so without
+# this the worker starts with no queue URL and quietly does nothing. pulumi
+# lives in ~/.pulumi/bin on the MacBook and /opt/homebrew/bin on the mini.
+export PATH="/Users/tnorlund/.pulumi/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+
+if [ -z "$SWIFT_DIR" ]; then
+  echo "$(date -u +%FT%TZ) ERROR: no receipt_ocr_swift checkout found on this host"
+  exit 1
+fi
+
+BIN="${SWIFT_DIR}/.build/arm64-apple-macosx/release/receipt-ocr"
+
+# mkdir is atomic; keeps a slow drain from overlapping the next scheduled start.
+if ! mkdir "$LOCK" 2>/dev/null; then
+  echo "$(date -u +%FT%TZ) skip: previous run still holding $LOCK"
+  exit 0
+fi
+trap 'rmdir "$LOCK" 2>/dev/null' EXIT
+
+if [ ! -x "$BIN" ]; then
+  echo "$(date -u +%FT%TZ) ERROR: worker binary missing at $BIN"
+  echo "  rebuild with: cd $SWIFT_DIR && swift build --configuration release"
+  exit 1
+fi
+
+# The LayoutLM CoreML bundle caches to the relative path .models/layoutlm, so
+# cd first or the ~220 MB model is refetched into whatever directory launchd
+# happened to pick.
+cd "$SWIFT_DIR" || exit 1
+echo "$(date -u +%FT%TZ) starting drain on $(hostname -s)"
+"$BIN" --env dev --continuous --log-level info
+echo "$(date -u +%FT%TZ) drain exited rc=$?"

--- a/scripts/update_ocr_workers.sh
+++ b/scripts/update_ocr_workers.sh
@@ -1,0 +1,161 @@
+#!/bin/bash
+# Update the dev OCR queue workers on both Macs.
+#
+# The LaunchAgents run a binary built from a checkout pinned to main; nothing
+# rebuilds itself. Run this after merging anything under receipt_ocr_swift/ or
+# the workers keep draining the queue with stale code.
+#
+# See docs/line-items/agentic-review/RUNNERS.md.
+set -euo pipefail
+
+LABEL="com.tnorlund.receipt-ocr-dev"
+LOCAL_CHECKOUT="/Users/tnorlund/Portfolio/.claude/worktrees/backfill-main"
+MINI_CHECKOUT="/Users/tnorlund/ocr-runner-main"
+MINI_SSH="mini"
+
+HOSTS="local mini"
+DRY_RUN=0
+SKIP_BUILD=0
+
+usage() {
+  cat <<'USAGE'
+usage: update_ocr_workers.sh [--host local|mini|both] [--dry-run] [--skip-build]
+
+  --host        Which worker to update (default: both).
+  --dry-run     Print what would run without changing anything.
+  --skip-build  Refresh the checkout and kickstart, but skip `swift build`.
+  -h, --help    Show this message.
+USAGE
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --host)
+      [ $# -ge 2 ] || { echo "--host needs a value" >&2; exit 2; }
+      case "$2" in
+        local) HOSTS="local" ;;
+        mini)  HOSTS="mini" ;;
+        both)  HOSTS="local mini" ;;
+        *) echo "unknown host '$2' (want local|mini|both)" >&2; exit 2 ;;
+      esac
+      shift 2
+      ;;
+    --dry-run)    DRY_RUN=1; shift ;;
+    --skip-build) SKIP_BUILD=1; shift ;;
+    -h|--help)    usage; exit 0 ;;
+    *) echo "unknown argument '$1'" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+# The body that runs on each machine. Kept as one blob so the local and remote
+# paths execute byte-identical logic; it reads its settings from argv.
+worker_script() {
+  cat <<'REMOTE'
+set -uo pipefail
+CHECKOUT="$1"; LABEL="$2"; DRY_RUN="$3"; SKIP_BUILD="$4"
+SWIFT_DIR="${CHECKOUT}/receipt_ocr_swift"
+BIN="${SWIFT_DIR}/.build/arm64-apple-macosx/release/receipt-ocr"
+HOST="$(hostname -s)"
+fail() { echo "  FAIL  $*"; exit 1; }
+run() {
+  if [ "$DRY_RUN" = "1" ]; then echo "  dry   $*"; return 0; fi
+  "$@"
+}
+
+echo "  host  ${HOST}"
+echo "  path  ${CHECKOUT}"
+[ -d "$SWIFT_DIR" ] || fail "no receipt_ocr_swift at ${SWIFT_DIR}"
+
+cd "$CHECKOUT" || fail "cannot cd ${CHECKOUT}"
+
+# These are dedicated detached worktrees pinned to main, so `pull` does not
+# apply. checkout --detach keeps untracked files and refuses rather than
+# clobbering tracked local edits, which is the behaviour we want on a box that
+# might have been poked at by hand.
+run git fetch origin main --quiet || fail "git fetch failed"
+BEFORE="$(git rev-parse --short HEAD)"
+run git checkout --detach origin/main --quiet || fail "git checkout failed (local edits?)"
+AFTER="$(git rev-parse --short HEAD)"
+if [ "$BEFORE" = "$AFTER" ]; then
+  echo "  git   ${AFTER} (already current)"
+else
+  echo "  git   ${BEFORE} -> ${AFTER}"
+fi
+
+if [ "$SKIP_BUILD" = "1" ]; then
+  echo "  build skipped (--skip-build)"
+else
+  cd "$SWIFT_DIR" || fail "cannot cd ${SWIFT_DIR}"
+  if [ "$DRY_RUN" = "1" ]; then
+    echo "  dry   swift build --configuration release"
+  else
+    echo "  build swift build --configuration release ..."
+    BUILD_LOG="$(mktemp -t ocr-build)"
+    if swift build --configuration release >"$BUILD_LOG" 2>&1; then
+      echo "  build $(tail -1 "$BUILD_LOG")"
+      rm -f "$BUILD_LOG"
+    else
+      echo "  ---- last 20 lines of build output ----"
+      tail -20 "$BUILD_LOG"
+      rm -f "$BUILD_LOG"
+      fail "swift build failed"
+    fi
+  fi
+fi
+
+# A binary that cannot even print usage is worse than a stale one, so prove it
+# runs before handing it back to launchd.
+if [ "$DRY_RUN" = "1" ]; then
+  echo "  dry   ${BIN} --help"
+else
+  [ -x "$BIN" ] || fail "binary missing at ${BIN}"
+  "$BIN" --help >/dev/null 2>&1 || fail "binary did not run (--help failed)"
+  echo "  bin   ok ($(cd "$(dirname "$BIN")" && ls -lh "$(basename "$BIN")" | awk '{print $5}'))"
+fi
+
+if ! launchctl list | grep -q "$LABEL"; then
+  fail "LaunchAgent ${LABEL} is not loaded (see RUNNERS.md to install)"
+fi
+run launchctl kickstart -k "gui/$(id -u)/${LABEL}" || fail "kickstart failed"
+if [ "$DRY_RUN" != "1" ]; then
+  echo "  agent kickstarted ${LABEL}"
+fi
+REMOTE
+}
+
+echo "receipt-ocr worker update"
+[ "$DRY_RUN" = "1" ] && echo "(dry run: nothing will be changed)"
+echo
+
+STATUS=0
+for host in $HOSTS; do
+  case "$host" in
+    local) checkout="$LOCAL_CHECKOUT" ;;
+    mini)  checkout="$MINI_CHECKOUT" ;;
+  esac
+
+  echo "=== ${host} ==="
+  if [ "$host" = "local" ]; then
+    if worker_script | bash -s -- "$checkout" "$LABEL" "$DRY_RUN" "$SKIP_BUILD"; then
+      echo "  ==> ${host}: OK"
+    else
+      echo "  ==> ${host}: FAILED"
+      STATUS=1
+    fi
+  else
+    if worker_script | ssh "$MINI_SSH" bash -s -- "$checkout" "$LABEL" "$DRY_RUN" "$SKIP_BUILD"; then
+      echo "  ==> ${host}: OK"
+    else
+      echo "  ==> ${host}: FAILED"
+      STATUS=1
+    fi
+  fi
+  echo
+done
+
+if [ "$STATUS" -eq 0 ]; then
+  echo "all requested workers updated"
+else
+  echo "one or more workers failed; see output above" >&2
+fi
+exit "$STATUS"


### PR DESCRIPTION
## Why

The dev OCR queue (`upload-images-dev-ocr-queue`) is drained by LaunchAgents on two Macs, each running a `receipt-ocr` binary built from a checkout pinned to `main`. **Nothing rebuilds those binaries.** After any `receipt_ocr_swift/` merge, both machines keep draining the queue with stale code until someone SSHes in and rebuilds by hand.

Auditing the two machines while setting this up turned up that the fleet was not actually running:

- The MacBook's LaunchAgent was installed but **never loaded** (`runs = 0`, no log file). `launchctl load` does not run the job and `RunAtLoad` is false, so the label showing up in `launchctl list` was not evidence it had ever run.
- The mini had **no agent and no wrapper script at all** — only a stale binary.

Both are now loaded and draining; the queue went from 23 visible messages to 0 during verification.

## What's here

- `scripts/update_ocr_workers.sh` — for each host: fetch `origin/main`, re-pin the checkout, `swift build --configuration release`, prove the binary runs (`--help`), then `launchctl kickstart -k`. Flags: `--host local|mini|both` (default both), `--dry-run`, `--skip-build`. Idempotent, exits non-zero if any host fails, prints the last 20 lines of build output on a build failure.
- `scripts/ocr_runner/run-dev.sh` — the wrapper the agents invoke, now byte-identical on both machines (it picks whichever pinned checkout exists on the host).
- `scripts/ocr_runner/com.tnorlund.receipt-ocr-dev.{macbook,mini}.plist` — the two LaunchAgents, so a runner can be reinstalled from the repo rather than from memory.
- `docs/line-items/agentic-review/RUNNERS.md` — what each machine runs, the plists, log paths, how to disable, the update workflow, and the Xcode-vs-CLT note.

## Notes on two design choices

**`StartCalendarInterval`, not `StartInterval`.** launchd has no way to phase-offset an interval timer — the phase of a `StartInterval` agent depends on when it was loaded and drifts across reboots. Fixed minutes (`:00 :15 :30 :45` on the MacBook, `:07 :22 :37 :52` on the mini) are the only way to hold a durable offset so the two machines interleave.

**The mini uses `~/ocr-runner-main`, not `~/Portfolio`.** That checkout carries ~100 uncommitted modifications and is 351 commits behind; pointing a runner at it would either fail to update or clobber work in progress. The script uses `git checkout --detach origin/main` rather than `git pull` so it preserves untracked files and refuses rather than clobbering tracked edits.

## Verification

`--dry-run` and a real run both pass on both hosts; both logs show a drain starting within seconds of the script's kickstart. Vision OCR confirmed working headless over SSH on the mini with the screen locked — full `job_start` → `ocr_run` → `job_complete` → `sqs_delete_batch` cycle, no TCC prompt.

## Pre-existing bug found, not fixed here

A single failing job aborts the whole drain: the worker prints `Error: NotFound: Not Found` and stops rather than skipping that message. The message returns after its visibility timeout and blocks the next drain on whichever machine picks it up — the same `image_id` stalled both machines during testing. Documented in RUNNERS.md under "A failing job aborts the rest of the batch"; the fix belongs in the worker's per-job error handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated development OCR queue runners for two Mac environments, scheduled throughout the hour.
  * Added safeguards to prevent overlapping processing and support continuous worker operation.
  * Added tooling to update, build, verify, and restart OCR workers locally or remotely, with dry-run support.

* **Documentation**
  * Added setup, configuration, verification, disabling, and troubleshooting guidance for OCR queue runners.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->