### PR TITLE
chore: prod OCR queue runners for both Macs

### DIFF
--- a/docs/line-items/agentic-review/RUNNERS.md
+++ b/docs/line-items/agentic-review/RUNNERS.md
@@ -1,16 +1,22 @@
-# Dev OCR Queue Runners (dual-Mac)
+# OCR Queue Runners (dual-Mac, dev + prod)
 
-Two Macs drain the dev OCR job queue (`upload-images-dev-ocr-queue`) on a
-schedule, so re-OCR jobs queued by the agentic review loop get processed without
-anyone babysitting a terminal.
+Two Macs drain both OCR job queues (`upload-images-dev-ocr-queue` and
+`upload-images-prod-ocr-queue`) on a schedule, so re-OCR jobs queued by the
+agentic review loop get processed without anyone babysitting a terminal.
 
-| Machine | Hostname | Checkout used for the binary | Schedule |
-|---|---|---|---|
-| MacBook Pro | `Tylers-MacBook-Pro` (local) | `/Users/tnorlund/Portfolio/.claude/worktrees/backfill-main` | `:00 :15 :30 :45` |
-| Mac mini | `Tylers-Mac-mini`, `mini` (ssh alias) | `/Users/tnorlund/ocr-runner-main` | `:07 :22 :37 :52` |
+These Macs are the **only** Vision OCR consumers that exist — there is no
+cloud worker. Before the prod agents were added (2026-08-04) nothing had ever
+drained the prod queue, and its REGIONAL_REOCR jobs sat PENDING forever.
+
+| Machine | Hostname | Checkout used for the binary | dev schedule | prod schedule |
+|---|---|---|---|---|
+| MacBook Pro | `Tylers-MacBook-Pro` (local) | `/Users/tnorlund/Portfolio/.claude/worktrees/backfill-main` | `:00 :15 :30 :45` | `:05 :20 :35 :50` |
+| Mac mini | `Tylers-Mac-mini`, `mini` (ssh alias) | `/Users/tnorlund/ocr-runner-main` | `:07 :22 :37 :52` | `:12 :27 :42 :57` |
 
 The offset schedules interleave the two machines so they do not contend for the
-same SQS messages.
+same SQS messages, and stagger dev from prod on each machine so a host rarely
+runs two drains at once (the per-env locks make an overlap harmless, just
+slow).
 
 `StartCalendarInterval` is used rather than `StartInterval`, because launchd has
 no way to phase-offset an interval timer: the phase of a `StartInterval` agent
@@ -19,7 +25,8 @@ minutes are the only way to hold a durable 7-minute offset between the machines.
 
 ## What runs
 
-Both machines run the same command through a wrapper script:
+Both machines run the same command through per-env wrapper scripts (the prod
+agent is identical except `--env prod`):
 
 ```bash
 receipt-ocr --env dev --continuous --log-level info
@@ -34,14 +41,20 @@ invocation instead of being resurrected forever. That is also why the agents set
 
 | Purpose | Path (same on both machines) | Canonical copy in this repo |
 |---|---|---|
-| Wrapper script | `~/receipt_ocr_runner/run-dev.sh` | `scripts/ocr_runner/run-dev.sh` |
-| LaunchAgent | `~/Library/LaunchAgents/com.tnorlund.receipt-ocr-dev.plist` | `scripts/ocr_runner/com.tnorlund.receipt-ocr-dev.{macbook,mini}.plist` |
-| Log | `~/Library/Logs/receipt-ocr-dev.log` | — |
-| Overlap lock | `/tmp/receipt-ocr-dev.lock` (directory, created atomically) | — |
+| Wrapper script (dev) | `~/receipt_ocr_runner/run-dev.sh` | `scripts/ocr_runner/run-dev.sh` |
+| Wrapper script (prod) | `~/receipt_ocr_runner/run-prod.sh` | `scripts/ocr_runner/run-prod.sh` |
+| LaunchAgent (dev) | `~/Library/LaunchAgents/com.tnorlund.receipt-ocr-dev.plist` | `scripts/ocr_runner/com.tnorlund.receipt-ocr-dev.{macbook,mini}.plist` |
+| LaunchAgent (prod) | `~/Library/LaunchAgents/com.tnorlund.receipt-ocr-prod.plist` | `scripts/ocr_runner/com.tnorlund.receipt-ocr-prod.{macbook,mini}.plist` |
+| Log | `~/Library/Logs/receipt-ocr-{dev,prod}.log` | — |
+| Overlap lock | `/tmp/receipt-ocr-{dev,prod}.lock` (directory, created atomically) | — |
 
-The wrapper is byte-identical on both machines: it picks the first checkout path
-that exists on the host, so there is nothing per-machine to keep in sync. The
-two plists differ only in their four scheduled minutes.
+The wrappers are byte-identical on both machines: each picks the first checkout
+path that exists on the host, so there is nothing per-machine to keep in sync.
+The two envs' wrappers differ only in the env flag, lock, and log; the plists
+differ only in their four scheduled minutes. Both envs run the **same binary**
+from the same checkout — `--env` selects the Pulumi stack outputs (queue URLs,
+Dynamo table) at startup, so one `update_ocr_workers.sh` run refreshes dev and
+prod alike.
 
 ## Updating after a merge
 
@@ -111,14 +124,15 @@ authoritative one.
 
 ```bash
 mkdir -p ~/receipt_ocr_runner
-cp scripts/ocr_runner/run-dev.sh ~/receipt_ocr_runner/run-dev.sh
-chmod +x ~/receipt_ocr_runner/run-dev.sh
-cp scripts/ocr_runner/com.tnorlund.receipt-ocr-dev.mini.plist \
-   ~/Library/LaunchAgents/com.tnorlund.receipt-ocr-dev.plist
-
-plutil -lint ~/Library/LaunchAgents/com.tnorlund.receipt-ocr-dev.plist
-launchctl load -w ~/Library/LaunchAgents/com.tnorlund.receipt-ocr-dev.plist
-launchctl list | grep receipt-ocr        # confirm it registered
+for env in dev prod; do
+  cp scripts/ocr_runner/run-$env.sh ~/receipt_ocr_runner/run-$env.sh
+  chmod +x ~/receipt_ocr_runner/run-$env.sh
+  cp scripts/ocr_runner/com.tnorlund.receipt-ocr-$env.mini.plist \
+     ~/Library/LaunchAgents/com.tnorlund.receipt-ocr-$env.plist
+  plutil -lint ~/Library/LaunchAgents/com.tnorlund.receipt-ocr-$env.plist
+  launchctl load -w ~/Library/LaunchAgents/com.tnorlund.receipt-ocr-$env.plist
+done
+launchctl list | grep receipt-ocr        # confirm both registered
 ```
 
 Pick the plist whose schedule that machine should own, and give the machine a

--- a/scripts/ocr_runner/com.tnorlund.receipt-ocr-prod.macbook.plist
+++ b/scripts/ocr_runner/com.tnorlund.receipt-ocr-prod.macbook.plist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key><string>com.tnorlund.receipt-ocr-prod</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/Users/tnorlund/receipt_ocr_runner/run-prod.sh</string>
+    </array>
+    <!-- MacBook Pro drains prod at :05 :20 :35 :50; the Mac mini prod agent
+         uses :12 :27 :42 :57. Offset from the dev agents (:00/:15/:30/:45
+         and :07/:22/:37/:52) so a machine rarely runs both drains at once;
+         the per-env locks make an overlap harmless, just slow. -->
+    <key>StartCalendarInterval</key>
+    <array>
+        <dict><key>Minute</key><integer>5</integer></dict>
+        <dict><key>Minute</key><integer>20</integer></dict>
+        <dict><key>Minute</key><integer>35</integer></dict>
+        <dict><key>Minute</key><integer>50</integer></dict>
+    </array>
+    <!-- Deliberately NOT KeepAlive: a wedged worker should die with its run,
+         not be resurrected in a loop. Each run exits when the queue is empty. -->
+    <key>KeepAlive</key><false/>
+    <key>RunAtLoad</key><false/>
+    <key>ProcessType</key><string>Background</string>
+    <key>StandardOutPath</key><string>/Users/tnorlund/Library/Logs/receipt-ocr-prod.log</string>
+    <key>StandardErrorPath</key><string>/Users/tnorlund/Library/Logs/receipt-ocr-prod.log</string>
+</dict>
+</plist>

--- a/scripts/ocr_runner/com.tnorlund.receipt-ocr-prod.mini.plist
+++ b/scripts/ocr_runner/com.tnorlund.receipt-ocr-prod.mini.plist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key><string>com.tnorlund.receipt-ocr-prod</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/Users/tnorlund/receipt_ocr_runner/run-prod.sh</string>
+    </array>
+    <!-- Mac mini drains prod at :12 :27 :42 :57; the MacBook Pro prod agent
+         uses :05 :20 :35 :50. Offset from the dev agents (:00/:15/:30/:45
+         and :07/:22/:37/:52) so a machine rarely runs both drains at once;
+         the per-env locks make an overlap harmless, just slow. -->
+    <key>StartCalendarInterval</key>
+    <array>
+        <dict><key>Minute</key><integer>12</integer></dict>
+        <dict><key>Minute</key><integer>27</integer></dict>
+        <dict><key>Minute</key><integer>42</integer></dict>
+        <dict><key>Minute</key><integer>57</integer></dict>
+    </array>
+    <!-- Deliberately NOT KeepAlive: a wedged worker should die with its run,
+         not be resurrected in a loop. Each run exits when the queue is empty. -->
+    <key>KeepAlive</key><false/>
+    <key>RunAtLoad</key><false/>
+    <key>ProcessType</key><string>Background</string>
+    <key>StandardOutPath</key><string>/Users/tnorlund/Library/Logs/receipt-ocr-prod.log</string>
+    <key>StandardErrorPath</key><string>/Users/tnorlund/Library/Logs/receipt-ocr-prod.log</string>
+</dict>
+</plist>

--- a/scripts/ocr_runner/run-prod.sh
+++ b/scripts/ocr_runner/run-prod.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# Drain the prod OCR job queue with the Swift Vision/LayoutLM worker.
+# Installed at ~/receipt_ocr_runner/run-prod.sh and started by
+# com.tnorlund.receipt-ocr-prod.plist. See
+# docs/line-items/agentic-review/RUNNERS.md.
+set -uo pipefail
+
+# Each machine pins its own checkout to main. The first candidate that exists
+# wins, so this script is byte-identical on every machine; set
+# RECEIPT_OCR_SWIFT_DIR to override.
+SWIFT_DIR_CANDIDATES="
+/Users/tnorlund/ocr-runner-main/receipt_ocr_swift
+/Users/tnorlund/Portfolio/.claude/worktrees/backfill-main/receipt_ocr_swift
+"
+
+SWIFT_DIR="${RECEIPT_OCR_SWIFT_DIR:-}"
+if [ -z "$SWIFT_DIR" ]; then
+  for candidate in $SWIFT_DIR_CANDIDATES; do
+    if [ -d "$candidate" ]; then
+      SWIFT_DIR="$candidate"
+      break
+    fi
+  done
+fi
+
+LOCK="/tmp/receipt-ocr-prod.lock"
+
+# `--env prod` shells out to `/usr/bin/env pulumi` to read stack outputs, and
+# launchd's default PATH does not include the pulumi install. PulumiLoader
+# returns an empty config on a non-zero exit rather than raising, so without
+# this the worker starts with no queue URL and quietly does nothing. pulumi
+# lives in ~/.pulumi/bin on the MacBook and /opt/homebrew/bin on the mini.
+export PATH="/Users/tnorlund/.pulumi/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+
+if [ -z "$SWIFT_DIR" ]; then
+  echo "$(date -u +%FT%TZ) ERROR: no receipt_ocr_swift checkout found on this host"
+  exit 1
+fi
+
+BIN="${SWIFT_DIR}/.build/arm64-apple-macosx/release/receipt-ocr"
+
+# mkdir is atomic; keeps a slow drain from overlapping the next scheduled start.
+if ! mkdir "$LOCK" 2>/dev/null; then
+  echo "$(date -u +%FT%TZ) skip: previous run still holding $LOCK"
+  exit 0
+fi
+trap 'rmdir "$LOCK" 2>/dev/null' EXIT
+
+if [ ! -x "$BIN" ]; then
+  echo "$(date -u +%FT%TZ) ERROR: worker binary missing at $BIN"
+  echo "  rebuild with: cd $SWIFT_DIR && swift build --configuration release"
+  exit 1
+fi
+
+# The LayoutLM CoreML bundle caches to the relative path .models/layoutlm, so
+# cd first or the ~220 MB model is refetched into whatever directory launchd
+# happened to pick.
+cd "$SWIFT_DIR" || exit 1
+echo "$(date -u +%FT%TZ) starting drain on $(hostname -s)"
+"$BIN" --env prod --continuous --log-level info
+echo "$(date -u +%FT%TZ) drain exited rc=$?"


### PR DESCRIPTION
## Summary

Resolves the open question from the smart re-OCR handoff: **yes, both Macs should drain prod too.** Nothing has ever consumed `upload-images-prod-ocr-queue` — 153 messages, 64 PENDING REGIONAL_REOCR jobs, no consumer anywhere — and these two Macs are the only Vision OCR muscle that exists. The declared metric (prod PROVEN) cannot move while prod re-OCR jobs sit PENDING forever.

- `run-prod.sh` — byte-identical to `run-dev.sh` except `--env prod`, its own lock (`/tmp/receipt-ocr-prod.lock`) and log (`~/Library/Logs/receipt-ocr-prod.log`)
- Prod LaunchAgents at `:05/:20/:35/:50` (MacBook) and `:12/:27/:42/:57` (mini) — interleaved across machines, staggered from the dev agents on each machine
- RUNNERS.md updated for both envs

Both envs run the **same binary** — `--env` picks the Pulumi stack outputs at startup — so `scripts/update_ocr_workers.sh` keeps covering both.

## Activation plan (after merge)

Deliberately not loading the prod agents until the worker is poison-resilient: prod's queue is old enough to contain messages for deleted images, and today one bad message aborts an entire drain (see the dev `missing("item")` diagnosis). Order: merge #1353 (strategies) → merge the per-message error-handling fix → `./scripts/update_ocr_workers.sh` → install + `launchctl load -w` the prod agents on both machines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)