### PR TITLE
fix: isolate poison SQS messages instead of aborting the whole drain

### DIFF
--- a/receipt_ocr_swift/Sources/ReceiptOCRCore/AWS/AWSProtocols.swift
+++ b/receipt_ocr_swift/Sources/ReceiptOCRCore/AWS/AWSProtocols.swift
@@ -17,6 +17,19 @@ public struct SQSDeleteEntry {
     public let receiptHandle: String
 }
 
+/// Thrown by `S3ClientProtocol.getObject` when the object does not exist.
+/// A typed error so the worker can tell "source image was deleted" (permanent,
+/// fail the job and drop the message) from transient S3 failures (leave the
+/// message for redelivery) without importing Soto types.
+public struct ObjectNotFoundError: Error {
+    public let bucket: String
+    public let key: String
+    public init(bucket: String, key: String) {
+        self.bucket = bucket
+        self.key = key
+    }
+}
+
 public protocol S3ClientProtocol {
     func getObject(bucket: String, key: String) async throws -> Data
     func uploadFile(url: URL, bucket: String, key: String) async throws

--- a/receipt_ocr_swift/Sources/ReceiptOCRCore/AWS/SotoAWSClients.swift
+++ b/receipt_ocr_swift/Sources/ReceiptOCRCore/AWS/SotoAWSClients.swift
@@ -77,12 +77,16 @@ public final class SotoS3Client: S3ClientProtocol {
     public func getObject(bucket: String, key: String) async throws -> Data {
         let req = S3.GetObjectRequest(bucket: bucket, key: key)
         var data = Data()
-        _ = try await s3.multipartDownload(
-            req,
-            logger: AWSClient.loggingDisabled,
-            on: nil
-        ) { byteBuffer, _, _ in
-            data.append(contentsOf: byteBuffer.readableBytesView)
+        do {
+            _ = try await s3.multipartDownload(
+                req,
+                logger: AWSClient.loggingDisabled,
+                on: nil
+            ) { byteBuffer, _, _ in
+                data.append(contentsOf: byteBuffer.readableBytesView)
+            }
+        } catch let error as AWSErrorType where error.context?.responseCode == .notFound {
+            throw ObjectNotFoundError(bucket: bucket, key: key)
         }
         return data
     }

--- a/receipt_ocr_swift/Sources/ReceiptOCRCore/Worker/OCRWorker.swift
+++ b/receipt_ocr_swift/Sources/ReceiptOCRCore/Worker/OCRWorker.swift
@@ -270,14 +270,39 @@ public final class OCRWorker {
         var imageURLs: [URL] = []
         var contexts: [Context] = []
 
+        // Messages that can never succeed (job row deleted, source image
+        // gone, malformed body). Deleted from the queue at the end of the
+        // prep loop; previously one such message threw out of processBatch,
+        // aborting the whole drain, and — with no DLQ on the queue — came
+        // back after its visibility timeout to abort the next drain too.
+        var poisonEntries: [SQSDeleteEntry] = []
+
         for msg in messages {
             guard let data = msg.body.data(using: .utf8),
                   let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
                   let imageId = obj["image_id"] as? String,
                   let jobId = obj["job_id"] as? String
-            else { continue }
+            else {
+                logger.warning("job_skipped_malformed_body message_id=\(msg.messageId)")
+                poisonEntries.append(SQSDeleteEntry(id: msg.messageId, receiptHandle: msg.receiptHandle))
+                continue
+            }
             logger.info("job_start image_id=\(imageId) job_id=\(jobId)")
-            let job = try await Retry.withBackoff { try await self.dynamo.getOCRJob(imageId: imageId, jobId: jobId) }
+            let job: OCRJob
+            do {
+                job = try await Retry.withBackoff { try await self.dynamo.getOCRJob(imageId: imageId, jobId: jobId) }
+            } catch DynamoMapError.missing {
+                // Job row deleted (image cleanup) after the message was
+                // queued. It can never succeed; drop the message.
+                logger.warning("job_skipped_no_job_row image_id=\(imageId) job_id=\(jobId)")
+                poisonEntries.append(SQSDeleteEntry(id: msg.messageId, receiptHandle: msg.receiptHandle))
+                continue
+            } catch {
+                // Transient (throttle, network): leave the message for
+                // redelivery and keep draining the rest of the batch.
+                logger.warning("job_deferred stage=get_job image_id=\(imageId) job_id=\(jobId) error=\(error)")
+                continue
+            }
             // Update processing stage to DOWNLOADING
             do {
                 try await self.dynamo.updateOCRJobStage(imageId: imageId, jobId: jobId, stage: "DOWNLOADING")
@@ -286,7 +311,23 @@ public final class OCRWorker {
             }
             logger.debug("download_image bucket=\(job.s3Bucket) key=\(job.s3Key)")
             // Download image
-            let imageData = try await Retry.withBackoff { try await self.s3.getObject(bucket: job.s3Bucket, key: job.s3Key) }
+            let imageData: Data
+            do {
+                imageData = try await Retry.withBackoff { try await self.s3.getObject(bucket: job.s3Bucket, key: job.s3Key) }
+            } catch let notFound as ObjectNotFoundError {
+                // Source image deleted from S3: the job can never succeed.
+                // Mark it FAILED (best effort) and drop the message.
+                logger.warning("job_skipped_missing_image image_id=\(imageId) job_id=\(jobId) bucket=\(notFound.bucket) key=\(notFound.key)")
+                var failed = job
+                failed.status = .failed
+                failed.updatedAt = Date()
+                try? await dynamo.updateOCRJob(failed)
+                poisonEntries.append(SQSDeleteEntry(id: msg.messageId, receiptHandle: msg.receiptHandle))
+                continue
+            } catch {
+                logger.warning("job_deferred stage=download image_id=\(imageId) job_id=\(jobId) error=\(error)")
+                continue
+            }
             let baseName = (job.s3Key as NSString).lastPathComponent
             let name = baseName.isEmpty ? "\(imageId)" : (baseName as NSString).deletingPathExtension
             let ext = (baseName as NSString).pathExtension
@@ -295,7 +336,19 @@ public final class OCRWorker {
             if job.jobType == .regionalReocr, let region = job.reocrRegion {
                 #if os(macOS)
                 let strategy = job.reocrStrategy
-                let cropped = try cropImageData(imageData, region: region, strategy: strategy)
+                let cropped: Data
+                do {
+                    cropped = try cropImageData(imageData, region: region, strategy: strategy)
+                } catch {
+                    // Undecodable/corrupt image: retrying cannot help.
+                    logger.warning("job_skipped_crop_failed image_id=\(imageId) job_id=\(jobId) error=\(error)")
+                    var failed = job
+                    failed.status = .failed
+                    failed.updatedAt = Date()
+                    try? await dynamo.updateOCRJob(failed)
+                    poisonEntries.append(SQSDeleteEntry(id: msg.messageId, receiptHandle: msg.receiptHandle))
+                    continue
+                }
                 localName = "\(name)-\(jobId)-reocr.png"
                 let croppedURL = tempDir.appendingPathComponent(localName)
                 try cropped.write(to: croppedURL)
@@ -331,6 +384,17 @@ public final class OCRWorker {
                     strategyApplied: nil
                 )
             )
+        }
+
+        // Drop poison messages now, before any OCR work: even if something
+        // later in the batch throws, these must not return to the queue.
+        if !poisonEntries.isEmpty {
+            logger.info("sqs_delete_poison count=\(poisonEntries.count)")
+            do {
+                try await Retry.withBackoff { try await self.sqs.deleteMessages(queueURL: self.config.ocrJobQueueURL, entries: poisonEntries) }
+            } catch {
+                logger.warning("sqs_delete_poison_failed count=\(poisonEntries.count) error=\(error)")
+            }
         }
 
         // Update all jobs to OCR_RUNNING stage
@@ -506,8 +570,10 @@ public final class OCRWorker {
             logger.info("job_complete image_id=\(ctx.imageId) job_id=\(ctx.jobId) receipts=\(receipts.count)")
         }
 
-        // Delete processed messages
+        // Delete processed messages. Guard the empty case: an all-poison
+        // batch leaves no contexts, and SQS rejects an empty delete batch.
         let entries = contexts.map { SQSDeleteEntry(id: $0.message.messageId, receiptHandle: $0.message.receiptHandle) }
+        guard !entries.isEmpty else { return true }
         logger.info("sqs_delete_batch count=\(entries.count)")
         try await Retry.withBackoff { try await self.sqs.deleteMessages(queueURL: self.config.ocrJobQueueURL, entries: entries) }
         

--- a/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/OCRWorkerPoisonMessageTests.swift
+++ b/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/OCRWorkerPoisonMessageTests.swift
@@ -1,0 +1,200 @@
+import Foundation
+import Testing
+
+@testable import ReceiptOCRCore
+
+#if os(macOS)
+import CoreGraphics
+
+/// A message whose job row or source image was deleted must be dropped from
+/// the queue — not thrown out of `processBatch`, which aborted the whole
+/// drain and (with no DLQ) let the message come back to abort the next one.
+/// Uses swift-testing so the suite also runs under CommandLineTools.
+@Suite struct OCRWorkerPoisonMessageTests {
+
+    final class SQSMock: SQSClientProtocol {
+        var messages: [SQSMessage] = []
+        var sentMessages: [String] = []
+        var deleted: [SQSDeleteEntry] = []
+        var emptyDeleteBatches = 0
+        func receiveMessages(queueURL: String, maxNumber: Int, visibilityTimeout: Int) async throws -> [SQSMessage] { messages }
+        func deleteMessages(queueURL: String, entries: [SQSDeleteEntry]) async throws {
+            if entries.isEmpty { emptyDeleteBatches += 1 }
+            deleted.append(contentsOf: entries)
+        }
+        func sendMessage(queueURL: String, body: String) async throws { sentMessages.append(body) }
+    }
+
+    final class S3Mock: S3ClientProtocol {
+        var objects: [String: Data] = [:] // "bucket:key" -> Data
+        var uploads: [(bucket: String, key: String, data: Data)] = []
+        func getObject(bucket: String, key: String) async throws -> Data {
+            guard let data = objects["\(bucket):\(key)"] else {
+                throw ObjectNotFoundError(bucket: bucket, key: key)
+            }
+            return data
+        }
+        func uploadFile(url: URL, bucket: String, key: String) async throws {
+            let data = try Data(contentsOf: url)
+            uploads.append((bucket, key, data))
+        }
+    }
+
+    final class DynamoMock: DynamoClientProtocol {
+        var jobs: [String: OCRJob] = [:] // "imageId:jobId"
+        var stages: [String: String] = [:]
+        func getOCRJob(imageId: String, jobId: String) async throws -> OCRJob {
+            guard let job = jobs["\(imageId):\(jobId)"] else {
+                throw DynamoMapError.missing("item")
+            }
+            return job
+        }
+        func updateOCRJob(_ job: OCRJob) async throws { jobs["\(job.imageId):\(job.jobId)"] = job }
+        func updateOCRJobStage(imageId: String, jobId: String, stage: String) async throws {
+            stages["\(imageId):\(jobId)"] = stage
+        }
+        func addOCRRoutingDecision(_ decision: OCRRoutingDecision) async throws {}
+        func addReceiptWordLabels(_ labels: [ReceiptWordLabel]) async throws {}
+    }
+
+    struct StubOCREngine: OCREngineProtocol {
+        func process(images: [URL], outputDirectory: URL, includeClassification: Bool) throws -> [URL] {
+            try images.map { url in
+                let out = outputDirectory.appendingPathComponent(url.deletingPathExtension().lastPathComponent + ".json")
+                try Data("{\"lines\": []}".utf8).write(to: out)
+                return out
+            }
+        }
+    }
+
+    private func makeConfig() -> Config {
+        Config(
+            ocrJobQueueURL: "q1",
+            ocrResultsQueueURL: "q2",
+            dynamoTableName: "tbl",
+            region: "us-west-2",
+            localstackEndpoint: nil,
+            logLevel: "error",
+            rawBucketName: "test-bucket"
+        )
+    }
+
+    private func message(_ id: String, imageId: String, jobId: String) -> SQSMessage {
+        SQSMessage(
+            messageId: id,
+            receiptHandle: "rh-\(id)",
+            body: "{\"image_id\":\"\(imageId)\",\"job_id\":\"\(jobId)\"}"
+        )
+    }
+
+    private func addHealthyJob(_ dynamo: DynamoMock, _ s3: S3Mock, imageId: String, jobId: String) {
+        let now = Date()
+        dynamo.jobs["\(imageId):\(jobId)"] = OCRJob(
+            imageId: imageId,
+            jobId: jobId,
+            s3Bucket: "b",
+            s3Key: "raw/\(imageId).png",
+            createdAt: now,
+            updatedAt: now,
+            status: .pending
+        )
+        s3.objects["b:raw/\(imageId).png"] = ReOCRTestImages.pngData(
+            from: ReOCRTestImages.makeImage(width: 10, height: 10) { ctx in
+                ctx.setFillColor(CGColor(red: 1, green: 1, blue: 1, alpha: 1))
+                ctx.fill(CGRect(x: 0, y: 0, width: 10, height: 10))
+            }
+        )
+    }
+
+    private func makeWorker(_ sqs: SQSMock, _ s3: S3Mock, _ dynamo: DynamoMock) -> OCRWorker {
+        OCRWorker(
+            config: makeConfig(),
+            ocr: StubOCREngine(),
+            sqs: sqs,
+            s3: s3,
+            dynamo: dynamo
+        )
+    }
+
+    @Test func missingJobRowIsDroppedAndBatchContinues() async throws {
+        let sqs = SQSMock()
+        let s3 = S3Mock()
+        let dynamo = DynamoMock()
+        // m1 has no job row (image deleted after the message was queued);
+        // m2 is healthy and must still complete.
+        sqs.messages = [
+            message("m1", imageId: "gone", jobId: "job-gone"),
+            message("m2", imageId: "ok", jobId: "job-ok"),
+        ]
+        addHealthyJob(dynamo, s3, imageId: "ok", jobId: "job-ok")
+
+        let hadMessages = try await makeWorker(sqs, s3, dynamo).processBatch()
+
+        #expect(hadMessages)
+        #expect(sqs.deleted.map(\.id).sorted() == ["m1", "m2"])
+        #expect(dynamo.jobs["ok:job-ok"]?.status == .completed)
+    }
+
+    @Test func missingSourceImageFailsJobAndDropsMessage() async throws {
+        let sqs = SQSMock()
+        let s3 = S3Mock()
+        let dynamo = DynamoMock()
+        sqs.messages = [
+            message("m1", imageId: "img-404", jobId: "job-404"),
+            message("m2", imageId: "ok", jobId: "job-ok"),
+        ]
+        // Job row exists but the raw object was deleted from S3.
+        let now = Date()
+        dynamo.jobs["img-404:job-404"] = OCRJob(
+            imageId: "img-404",
+            jobId: "job-404",
+            s3Bucket: "b",
+            s3Key: "raw/img-404.png",
+            createdAt: now,
+            updatedAt: now,
+            status: .pending
+        )
+        addHealthyJob(dynamo, s3, imageId: "ok", jobId: "job-ok")
+
+        _ = try await makeWorker(sqs, s3, dynamo).processBatch()
+
+        #expect(sqs.deleted.map(\.id).sorted() == ["m1", "m2"])
+        #expect(dynamo.jobs["img-404:job-404"]?.status == .failed)
+        #expect(dynamo.jobs["ok:job-ok"]?.status == .completed)
+    }
+
+    @Test func malformedBodyIsDropped() async throws {
+        let sqs = SQSMock()
+        let s3 = S3Mock()
+        let dynamo = DynamoMock()
+        sqs.messages = [
+            SQSMessage(messageId: "m1", receiptHandle: "rh-m1", body: "not json"),
+            message("m2", imageId: "ok", jobId: "job-ok"),
+        ]
+        addHealthyJob(dynamo, s3, imageId: "ok", jobId: "job-ok")
+
+        _ = try await makeWorker(sqs, s3, dynamo).processBatch()
+
+        #expect(sqs.deleted.map(\.id).sorted() == ["m1", "m2"])
+    }
+
+    @Test func allPoisonBatchSendsNoEmptyDeleteAndReportsMessages() async throws {
+        let sqs = SQSMock()
+        let s3 = S3Mock()
+        let dynamo = DynamoMock()
+        sqs.messages = [
+            message("m1", imageId: "gone-1", jobId: "j1"),
+            message("m2", imageId: "gone-2", jobId: "j2"),
+        ]
+
+        let hadMessages = try await makeWorker(sqs, s3, dynamo).processBatch()
+
+        // Still reports messages were seen (the drain loop keeps polling),
+        // deletes exactly the poison pair, and never issues an empty
+        // delete batch (SQS rejects those).
+        #expect(hadMessages)
+        #expect(sqs.deleted.map(\.id).sorted() == ["m1", "m2"])
+        #expect(sqs.emptyDeleteBatches == 0)
+    }
+}
+#endif


### PR DESCRIPTION
## Summary

Stacked on #1353 (both touch `OCRWorker.swift`).

Diagnosis of the recurring `Error: missing("item")` in both Macs' drain logs: one SQS message whose Dynamo job row (or raw S3 object) was deleted **aborts the entire drain run** — `processBatch` throws out of the CLI loop, no message in the batch gets deleted, and with no DLQ on the queue the poison message returns after its 60s visibility timeout to abort the next drain too. The dev queue currently holds 10 valid PENDING jobs starving behind two such messages (image `e1f519d5…` deleted from Dynamo; image `5985d2dd…` whose raw PNG is gone from S3). The prod queue (153 never-drained messages) is old enough to be worse.

Per-message classification in the prep loop:

| Failure | Action |
|---|---|
| Job row gone (`DynamoMapError.missing`) | drop the message |
| Raw object gone (new typed `ObjectNotFoundError` from the S3 client) | mark job FAILED, drop the message |
| Undecodable crop | mark job FAILED, drop the message |
| Malformed body | drop the message |
| Anything else (throttle, network) | leave for redelivery, keep draining the rest |

Poison deletions happen **before** OCR work so a later batch failure can't resurrect them, and an all-poison batch no longer sends an empty `DeleteMessageBatch` (SQS rejects those).

Once deployed via `scripts/update_ocr_workers.sh`, the workers clean their own queues — no manual SQS surgery needed. This is also the gate for enabling the prod runners (#1354).

## Testing

New `OCRWorkerPoisonMessageTests` (4 tests, mocked AWS): missing job row, missing S3 object, malformed body, all-poison batch. Full suite on the Mac mini (Xcode): **24/24 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)