### PR TITLE
fix: decode reocr_strategy/mechanism on the Soto production read path

### DIFF
--- a/receipt_ocr_swift/Sources/ReceiptOCRCore/AWS/SotoAWSClients.swift
+++ b/receipt_ocr_swift/Sources/ReceiptOCRCore/AWS/SotoAWSClients.swift
@@ -252,7 +252,9 @@ public final class SotoDynamoClient: DynamoClientProtocol {
         return result
     }
 
-    private static func decodeOCRJob(_ attrs: [String: DynamoDB.AttributeValue]) throws -> OCRJob {
+    // internal (not private) so the contract test can decode real
+    // AttributeValue shapes — the fromItem-based tests missed this path.
+    static func decodeOCRJob(_ attrs: [String: DynamoDB.AttributeValue]) throws -> OCRJob {
         func getS(_ key: String) throws -> String {
             guard case .s(let v)? = attrs[key] else { throw DynamoMapError.missing(key) }
             return v
@@ -312,7 +314,13 @@ public final class SotoDynamoClient: DynamoClientProtocol {
             jobType: jobType,
             receiptId: getOptionalInt("receipt_id"),
             reocrRegion: try getOptionalRegion("reocr_region"),
-            reocrReason: getOptionalS("reocr_reason")
+            reocrReason: getOptionalS("reocr_reason"),
+            // Contract: absent (or unrecognized) -> .plain, mirroring
+            // OCRJob.fromItem. This decoder is the PRODUCTION read path —
+            // omitting the fields here silently downgraded every strategy
+            // to plain while the fromItem-based tests stayed green.
+            reocrStrategy: getOptionalS("reocr_strategy").flatMap(ReOCRStrategy.init(rawValue:)) ?? .plain,
+            reocrMechanism: getOptionalS("reocr_mechanism")
         )
     }
 }

--- a/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/SotoOCRJobDecoderTests.swift
+++ b/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/SotoOCRJobDecoderTests.swift
@@ -1,0 +1,64 @@
+import Foundation
+import SotoDynamoDB
+import Testing
+
+@testable import ReceiptOCRCore
+
+/// The PRODUCTION OCRJob read path is SotoDynamoClient.decodeOCRJob, not
+/// OCRJob.fromItem — the two decoders must agree on the smart re-OCR
+/// contract. The strategy fields were originally added only to fromItem,
+/// so every live job decoded as .plain while the fromItem tests stayed
+/// green; this suite pins the Soto path directly.
+@Suite struct SotoOCRJobDecoderTests {
+
+    private func baseAttrs(
+        strategy: DynamoDB.AttributeValue? = nil,
+        mechanism: DynamoDB.AttributeValue? = nil
+    ) -> [String: DynamoDB.AttributeValue] {
+        var attrs: [String: DynamoDB.AttributeValue] = [
+            "PK": .s("IMAGE#img-1"),
+            "SK": .s("OCR_JOB#job-1"),
+            "s3_bucket": .s("b"),
+            "s3_key": .s("raw/img.png"),
+            "created_at": .s("2026-08-04T00:00:00.000+00:00"),
+            "updated_at": .s("2026-08-04T00:00:00.000+00:00"),
+            "status": .s("PENDING"),
+            "job_type": .s("REGIONAL_REOCR"),
+        ]
+        if let strategy = strategy { attrs["reocr_strategy"] = strategy }
+        if let mechanism = mechanism { attrs["reocr_mechanism"] = mechanism }
+        return attrs
+    }
+
+    @Test func strategyAndMechanismDecodeFromSotoAttributes() throws {
+        let job = try SotoDynamoClient.decodeOCRJob(
+            baseAttrs(strategy: .s("invert"), mechanism: .s("reverse-video"))
+        )
+        #expect(job.reocrStrategy == .invert)
+        #expect(job.reocrMechanism == "reverse-video")
+    }
+
+    @Test func everyStrategyStringDecodes() throws {
+        for strategy in ReOCRStrategy.allCases {
+            let job = try SotoDynamoClient.decodeOCRJob(baseAttrs(strategy: .s(strategy.rawValue)))
+            #expect(job.reocrStrategy == strategy, "raw=\(strategy.rawValue)")
+        }
+    }
+
+    @Test func absentStrategyDefaultsToPlain() throws {
+        let job = try SotoDynamoClient.decodeOCRJob(baseAttrs())
+        #expect(job.reocrStrategy == .plain)
+        #expect(job.reocrMechanism == nil)
+    }
+
+    @Test func nullOrUnrecognizedStrategyFallsBackToPlain() throws {
+        let nullJob = try SotoDynamoClient.decodeOCRJob(
+            baseAttrs(strategy: .null(true), mechanism: .null(true))
+        )
+        #expect(nullJob.reocrStrategy == .plain)
+        #expect(nullJob.reocrMechanism == nil)
+
+        let bogusJob = try SotoDynamoClient.decodeOCRJob(baseAttrs(strategy: .s("sharpen4x")))
+        #expect(bogusJob.reocrStrategy == .plain)
+    }
+}


### PR DESCRIPTION
## Summary

Caught in the first end-to-end ladder proof after #1353 deployed: a job carrying `reocr_strategy: invert` in DynamoDB logged `strategy=plain` in the drain.

Root cause: there are **two** OCRJob decoders. #1353 added the strategy fields to `OCRJob.fromItem` (the `[String: Any]` path the tests use), but the worker's production read path is `SotoDynamoClient.decodeOCRJob` (Soto `AttributeValue`s), which never populated them — so every live job silently decoded as `.plain` and the preprocessor never fired, while all tests stayed green.

- `decodeOCRJob` now decodes `reocr_strategy` / `reocr_mechanism` with the same contract as `fromItem` (absent / NULL / unrecognized → `plain`).
- New `SotoOCRJobDecoderTests` pin the Soto path directly (`decodeOCRJob` made internal for the test): all four strategies decode; fallback cases covered.

## Testing

Full suite on the Mac mini (Xcode): green, including the 4 new decoder tests.

## After merge

`scripts/update_ocr_workers.sh` again — then re-trigger the ladder-proof jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved OCR job data handling when strategy or mechanism information is missing, null, or unrecognized.
  - Unrecognized or unavailable OCR strategies now consistently default to the standard processing mode.
  - OCR reprocessing mechanism details are preserved when available.

- **Tests**
  - Added coverage for supported, missing, null, and invalid OCR configuration values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->