### PR TITLE
chore: seed the re-OCR outcome ledger from the first real strategy runs

### DIFF
--- a/receipt_upload/receipt_upload/line_items/assets/reocr_ladder.json
+++ b/receipt_upload/receipt_upload/line_items/assets/reocr_ladder.json
@@ -1,6 +1,34 @@
 {
   "schema": "reocr-ladder-v1",
-  "generated_at": null,
-  "source": "scripts/harvest_reocr_outcomes.py (no harvest run yet)",
-  "mechanisms": {}
+  "generated_at": "2026-08-04T19:23:06.557980+00:00",
+  "source": "scripts/harvest_reocr_outcomes.py --table ReceiptsTable-dc5be22",
+  "mechanisms": {
+    "reverse-video": {
+      "invert": {
+        "attempts": 2,
+        "words_accepted": 117,
+        "words_rejected": 4,
+        "acceptance_rate": 0.9669,
+        "mean_delta_improvement": null
+      }
+    },
+    "small-print": {
+      "upscale2x": {
+        "attempts": 2,
+        "words_accepted": 52,
+        "words_rejected": 0,
+        "acceptance_rate": 1.0,
+        "mean_delta_improvement": null
+      }
+    },
+    "unknown": {
+      "upscale2x": {
+        "attempts": 2,
+        "words_accepted": 56,
+        "words_rejected": 2,
+        "acceptance_rate": 0.9655,
+        "mean_delta_improvement": null
+      }
+    }
+  }
 }


### PR DESCRIPTION
## Summary

`scripts/harvest_reocr_outcomes.py --table ReceiptsTable-dc5be22` after the first end-to-end smart re-OCR runs (post #1353/#1355/#1357 + worker redeploy):

- **reverse-video → invert**: Costco `471788b6…` — 59 words accepted / 1 rejected on the reverse-video totals crop
- **small-print → upscale2x**: Target `b3ff79e6…` — 26/26 accepted (attempt 2, a different rung than its plain attempt 1)
- plus plain/unknown baseline attempts from the drained backlog

Ladder-proof verification behind this: jobs carry `reocr_strategy`/`reocr_mechanism` in DynamoDB, the worker logs `regional_reocr_crop_complete … strategy=invert mechanism=reverse-video`, the result JSON carries `reocr_strategy_applied`, and the overlay persisted `reocr_words_accepted/rejected` back onto the jobs.

All pairs are still under `MIN_LEDGER_ATTEMPTS=3`, so default ladders keep governing until more outcomes accrue — this just starts the measured record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)