### PR TITLE
fix: package line_items assets into the receipt_upload wheel

### DIFF
--- a/receipt_upload/pyproject.toml
+++ b/receipt_upload/pyproject.toml
@@ -96,11 +96,17 @@ include = ["receipt_upload/py.typed"]
 [tool.hatch.build.targets.wheel.force-include]
 "receipt_upload/assets/section_order_priors_v2.json" = "receipt_upload/assets/section_order_priors_v2.json"
 "receipt_upload/assets/section_label_priors_v1.json" = "receipt_upload/assets/section_label_priors_v1.json"
+"receipt_upload/line_items/assets/block_role_priors_v1.json" = "receipt_upload/line_items/assets/block_role_priors_v1.json"
+"receipt_upload/line_items/assets/block_role_priors_v2.json" = "receipt_upload/line_items/assets/block_role_priors_v2.json"
+"receipt_upload/line_items/assets/reocr_ladder.json" = "receipt_upload/line_items/assets/reocr_ladder.json"
 
 # The global exclude drops *.json, so sdists need the assets re-included too.
 [tool.hatch.build.targets.sdist.force-include]
 "receipt_upload/assets/section_order_priors_v2.json" = "receipt_upload/assets/section_order_priors_v2.json"
 "receipt_upload/assets/section_label_priors_v1.json" = "receipt_upload/assets/section_label_priors_v1.json"
+"receipt_upload/line_items/assets/block_role_priors_v1.json" = "receipt_upload/line_items/assets/block_role_priors_v1.json"
+"receipt_upload/line_items/assets/block_role_priors_v2.json" = "receipt_upload/line_items/assets/block_role_priors_v2.json"
+"receipt_upload/line_items/assets/reocr_ladder.json" = "receipt_upload/line_items/assets/reocr_ladder.json"
 
 [tool.black]
 line-length = 79


### PR DESCRIPTION
## Summary

Root cause of every SMART re-OCR `delta_before`/`delta_after` being null, found by running the delta computation **inside the deployed container image**:

```
FileNotFoundError: /var/lang/lib/python3.12/site-packages/receipt_upload/line_items/assets/block_role_priors_v2.json
```

`receipt_upload/pyproject.toml` globally excludes `*.json` from builds and force-includes only the two `receipt_upload/assets/` section priors. The `line_items/assets/` JSONs (block-role priors v1/v2 + the re-OCR outcome ledger) were never added, so every **pip-installed** `receipt_upload` — i.e. every Lambda container image — ships without them:

- `extract_items()` → `load_default_priors()` raises on every call in-container; the overlay's broad except nulls the re-OCR deltas (the metric the strategy ladder tunes on).
- `choose_strategy()`'s ledger load fails softly to `{}`, so measured outcomes could never override the default ladders in Lambda-triggered re-OCR.

Local checkouts and CI never see this because they import from source, and the handler + `geometry.py` inside the image are byte-identical to main — only the asset files are missing. Verified blast radius: the `upload-images` container image; other images that pip-install `receipt_upload` would be equally affected.

## Fix

Force-include the three `line_items/assets/*.json` files in both wheel and sdist targets. Wheel contents verified post-fix: all five JSON assets present.

## After merge

Deploy the dev stack (CodeBuild image rebuild) so the overlay starts recording real deltas, then re-run `scripts/harvest_reocr_outcomes.py` to replace the seeded ledger with delta-bearing outcomes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)