### PR TITLE
fix: guard offline bank fields against recompute clobber

### DIFF
--- a/receipt_dynamo/receipt_dynamo/data/_receipt_summary.py
+++ b/receipt_dynamo/receipt_dynamo/data/_receipt_summary.py
@@ -19,10 +19,12 @@ from receipt_dynamo.data.base_operations import (
 )
 from receipt_dynamo.data.shared_exceptions import (
     EntityNotFoundError,
+    EntityValidationError,
 )
 from receipt_dynamo.entities.receipt_summary_record import (
     ReceiptSummaryRecord,
     item_to_receipt_summary_record,
+    offline_fields_cleared,
 )
 
 
@@ -286,8 +288,45 @@ class _ReceiptSummary(FlattenedStandardMixin):
             last_evaluated_key=last_evaluated_key,
         )
 
+    def _guard_offline_fields(
+        self, summary: ReceiptSummaryRecord, allow_offline_field_clear: bool
+    ) -> None:
+        """Refuse to null offline bank fields a stored summary carries.
+
+        ledger / bank_amount / bank_match_confidence come from the LOCAL
+        Chase + Apple ledgers (scripts/backfill_tender_bank.py) and
+        cannot be re-derived in the cloud; bank_amount is half of the
+        PROVEN definition. A recompute must carry them over (see
+        infra/receipt_summary_updater/summary_processor.py) or pass
+        allow_offline_field_clear=True to clear them deliberately.
+        """
+        if allow_offline_field_clear:
+            return
+        try:
+            existing = self.get_receipt_summary(
+                summary.image_id, summary.receipt_id
+            )
+        except EntityNotFoundError:
+            return
+        cleared = offline_fields_cleared(summary, existing)
+        if cleared:
+            raise EntityValidationError(
+                f"upsert for {summary.image_id}#{summary.receipt_id} would "
+                f"null offline bank field(s) {cleared} that the stored "
+                "summary carries. These are computed offline "
+                "(scripts/backfill_tender_bank.py) and cannot be re-derived "
+                "in the cloud. Carry them over from the existing summary, "
+                "or pass allow_offline_field_clear=True to clear them "
+                "deliberately."
+            )
+
     @handle_dynamodb_errors("upsert_receipt_summary")
-    def upsert_receipt_summary(self, summary: ReceiptSummaryRecord) -> None:
+    def upsert_receipt_summary(
+        self,
+        summary: ReceiptSummaryRecord,
+        *,
+        allow_offline_field_clear: bool = False,
+    ) -> None:
         """
         Upserts a ReceiptSummaryRecord to DynamoDB.
 
@@ -298,13 +337,20 @@ class _ReceiptSummary(FlattenedStandardMixin):
         ----------
         summary : ReceiptSummaryRecord
             The summary instance to upsert.
+        allow_offline_field_clear : bool
+            Explicit opt-in to null offline bank fields
+            (ledger / bank_amount / bank_match_confidence) that the
+            stored summary carries. Defaults to False: such a write
+            raises instead of silently destroying offline data.
 
         Raises
         ------
         ValueError
-            If summary is invalid.
+            If summary is invalid, or if the write would null offline
+            bank fields without allow_offline_field_clear.
         """
         self._validate_entity(summary, ReceiptSummaryRecord, "summary")
+        self._guard_offline_fields(summary, allow_offline_field_clear)
         # Use put_item without condition - overwrites if exists
         self._client.put_item(
             TableName=self.table_name,
@@ -313,7 +359,10 @@ class _ReceiptSummary(FlattenedStandardMixin):
 
     @handle_dynamodb_errors("upsert_receipt_summaries")
     def upsert_receipt_summaries(
-        self, summaries: list[ReceiptSummaryRecord]
+        self,
+        summaries: list[ReceiptSummaryRecord],
+        *,
+        allow_offline_field_clear: bool = False,
     ) -> None:
         """
         Upserts multiple ReceiptSummaryRecord items to DynamoDB.
@@ -325,15 +374,24 @@ class _ReceiptSummary(FlattenedStandardMixin):
         ----------
         summaries : list[ReceiptSummaryRecord]
             A list of summary instances to upsert.
+        allow_offline_field_clear : bool
+            Explicit opt-in to null offline bank fields
+            (ledger / bank_amount / bank_match_confidence) that a
+            stored summary carries. Defaults to False: such a write
+            raises instead of silently destroying offline data.
 
         Raises
         ------
         ValueError
-            If summaries is invalid or if an error occurs during batch write.
+            If summaries is invalid, if an error occurs during batch
+            write, or if a write would null offline bank fields without
+            allow_offline_field_clear.
         """
         self._validate_entity_list(
             summaries, ReceiptSummaryRecord, "summaries"
         )
+        for summary in summaries:
+            self._guard_offline_fields(summary, allow_offline_field_clear)
 
         # batch_write_item is idempotent - overwrites if exists
         request_items = [

--- a/receipt_dynamo/receipt_dynamo/entities/receipt_summary_record.py
+++ b/receipt_dynamo/receipt_dynamo/entities/receipt_summary_record.py
@@ -364,3 +364,29 @@ def item_to_receipt_summary_record(
 ) -> ReceiptSummaryRecord:
     """Convert a DynamoDB item to a ReceiptSummaryRecord."""
     return ReceiptSummaryRecord.from_item(item)
+
+
+# Fields computed OFFLINE from the local Chase + Apple ledgers
+# (scripts/backfill_tender_bank.py). They cannot be re-derived in the
+# cloud, and bank_amount is half of the PROVEN definition — a recompute
+# that nulls them destroys data that only a laptop can restore. The
+# 2026-08-04 dev incident: a summary backfill without carry-over wiped
+# bank_amount on 422 receipts and collapsed dev PROVEN 281 -> 2.
+OFFLINE_BANK_FIELDS = ("ledger", "bank_amount", "bank_match_confidence")
+
+
+def offline_fields_cleared(
+    new: ReceiptSummaryRecord, existing: ReceiptSummaryRecord
+) -> list[str]:
+    """Offline bank fields populated on ``existing`` but nulled on ``new``.
+
+    Used by the upsert guard: writers recomputing a summary must carry
+    these over (see infra/receipt_summary_updater/summary_processor.py)
+    or explicitly opt in to clearing them.
+    """
+    return [
+        field
+        for field in OFFLINE_BANK_FIELDS
+        if getattr(existing, field, None) is not None
+        and getattr(new, field, None) is None
+    ]

--- a/receipt_dynamo/tests/unit/test_receipt_summary_offline_guard.py
+++ b/receipt_dynamo/tests/unit/test_receipt_summary_offline_guard.py
@@ -1,0 +1,147 @@
+"""Unit tests for the offline-bank-field guard on summary upserts.
+
+ledger / bank_amount / bank_match_confidence are computed OFFLINE from
+the local Chase + Apple ledgers (scripts/backfill_tender_bank.py) and
+cannot be re-derived in the cloud; bank_amount is half of the PROVEN
+definition. A summary recompute that writes without carrying them over
+destroys data only a laptop can restore — this wiped dev table-wide on
+2026-08-04 (bank_amount 425 -> 3, dev PROVEN 281 -> 2). These tests pin
+the pure detector and the upsert guard that makes it loud.
+"""
+
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import pytest
+
+from receipt_dynamo.data.dynamo_client import DynamoClient
+from receipt_dynamo.data.shared_exceptions import EntityNotFoundError
+from receipt_dynamo.entities.receipt_summary import (
+    MonetaryTotals,
+    ReceiptSummary,
+)
+from receipt_dynamo.entities.receipt_summary_record import (
+    OFFLINE_BANK_FIELDS,
+    ReceiptSummaryRecord,
+    offline_fields_cleared,
+)
+
+IMAGE_ID = "3f52804b-2fad-4e00-92c8-b593da3a8ed3"
+
+
+def make_record(
+    *,
+    ledger: str | None = None,
+    bank_amount: float | None = None,
+    bank_match_confidence: float | None = None,
+) -> ReceiptSummaryRecord:
+    summary = ReceiptSummary(
+        image_id=IMAGE_ID,
+        receipt_id=7,
+        merchant_name="Sprouts Farmers Market",
+        date=datetime(2025, 5, 28),
+        totals=MonetaryTotals(grand_total=47.18, tax=1.23),
+        item_count=4,
+        ledger=ledger,
+        bank_amount=bank_amount,
+        bank_match_confidence=bank_match_confidence,
+    )
+    return ReceiptSummaryRecord.from_summary(summary)
+
+
+BANKED = dict(ledger="apple", bank_amount=47.18, bank_match_confidence=0.95)
+
+
+# === offline_fields_cleared (pure detector) ===
+
+
+@pytest.mark.unit
+def test_detects_all_offline_fields_cleared():
+    cleared = offline_fields_cleared(make_record(), make_record(**BANKED))
+    assert cleared == list(OFFLINE_BANK_FIELDS)
+
+
+@pytest.mark.unit
+def test_carry_over_clears_nothing():
+    assert (
+        offline_fields_cleared(make_record(**BANKED), make_record(**BANKED))
+        == []
+    )
+
+
+@pytest.mark.unit
+def test_never_populated_clears_nothing():
+    assert offline_fields_cleared(make_record(), make_record()) == []
+
+
+@pytest.mark.unit
+def test_partial_clear_names_only_the_cleared_fields():
+    new = make_record(ledger="apple")  # bank_amount + confidence nulled
+    cleared = offline_fields_cleared(new, make_record(**BANKED))
+    assert cleared == ["bank_amount", "bank_match_confidence"]
+
+
+# === upsert guard wiring ===
+
+
+def guarded_client(existing: ReceiptSummaryRecord | None) -> DynamoClient:
+    """DynamoClient with stubbed I/O: get returns `existing`, writes record."""
+    client = DynamoClient.__new__(DynamoClient)
+    client.table_name = "test-table"
+    client._client = MagicMock()
+    client._batch_write_with_retry = MagicMock()
+    if existing is None:
+        client.get_receipt_summary = MagicMock(
+            side_effect=EntityNotFoundError("not found")
+        )
+    else:
+        client.get_receipt_summary = MagicMock(return_value=existing)
+    return client
+
+
+@pytest.mark.unit
+def test_upsert_raises_when_clearing_stored_bank_fields():
+    client = guarded_client(existing=make_record(**BANKED))
+    with pytest.raises(ValueError, match="offline bank field"):
+        client.upsert_receipt_summary(make_record())
+    client._client.put_item.assert_not_called()
+
+
+@pytest.mark.unit
+def test_upsert_allows_clear_with_explicit_opt_in():
+    client = guarded_client(existing=make_record(**BANKED))
+    client.upsert_receipt_summary(
+        make_record(), allow_offline_field_clear=True
+    )
+    client._client.put_item.assert_called_once()
+
+
+@pytest.mark.unit
+def test_upsert_passes_when_fields_carried_over():
+    client = guarded_client(existing=make_record(**BANKED))
+    client.upsert_receipt_summary(make_record(**BANKED))
+    client._client.put_item.assert_called_once()
+
+
+@pytest.mark.unit
+def test_upsert_passes_when_no_stored_summary():
+    client = guarded_client(existing=None)
+    client.upsert_receipt_summary(make_record())
+    client._client.put_item.assert_called_once()
+
+
+@pytest.mark.unit
+def test_batch_upsert_raises_when_any_record_clears_bank_fields():
+    client = guarded_client(existing=make_record(**BANKED))
+    with pytest.raises(ValueError, match="offline bank field"):
+        client.upsert_receipt_summaries(
+            [make_record(**BANKED), make_record()]
+        )
+    client._batch_write_with_retry.assert_not_called()
+
+
+@pytest.mark.unit
+def test_batch_upsert_passes_with_carry_over():
+    client = guarded_client(existing=make_record(**BANKED))
+    client.upsert_receipt_summaries([make_record(**BANKED)])
+    client._batch_write_with_retry.assert_called_once()

--- a/scripts/backfill_receipt_summaries.py
+++ b/scripts/backfill_receipt_summaries.py
@@ -68,6 +68,27 @@ def backfill_summaries(
             break
     logger.info("Loaded %d places", len(places_by_key))
 
+    # Load the stored summaries so tender + offline bank fields survive the
+    # recompute. tender is classified elsewhere (this script never runs the
+    # classifier), and ledger / bank_amount / bank_match_confidence come
+    # from the LOCAL Chase + Apple ledgers and cannot be re-derived here —
+    # writing without this carry-over wiped them table-wide on 2026-08-04
+    # and collapsed dev PROVEN 281 -> 2.
+    logger.info("Loading existing summaries for field carry-over...")
+    existing_by_key = {}
+    last_key = None
+    while True:
+        summaries, last_key = client.list_receipt_summaries(
+            limit=1000,
+            last_evaluated_key=last_key,
+        )
+        for existing in summaries:
+            key = f"{existing.image_id}_{existing.receipt_id}"
+            existing_by_key[key] = existing
+        if last_key is None:
+            break
+    logger.info("Loaded %d existing summaries", len(existing_by_key))
+
     # Process receipts in batches
     pending_records: list[ReceiptSummaryRecord] = []
     last_key = None
@@ -88,13 +109,27 @@ def backfill_summaries(
                 place = places_by_key.get(key)
                 merchant_name = place.merchant_name if place else None
 
-                # Compute summary from word labels
+                # Compute summary from word labels, carrying over tender
+                # and offline bank fields from the stored summary.
+                existing = existing_by_key.get(key)
                 summary = ReceiptSummary.from_word_labels_and_words(
                     image_id=bundle.receipt.image_id,
                     receipt_id=bundle.receipt.receipt_id,
                     merchant_name=merchant_name,
                     word_labels=bundle.word_labels,
                     words=bundle.words,
+                    tender_class=(
+                        existing.tender_class if existing else None
+                    ),
+                    card_network=(
+                        existing.card_network if existing else None
+                    ),
+                    card_last4=existing.card_last4 if existing else None,
+                    ledger=existing.ledger if existing else None,
+                    bank_amount=existing.bank_amount if existing else None,
+                    bank_match_confidence=(
+                        existing.bank_match_confidence if existing else None
+                    ),
                 )
 
                 # Create record for persistence

--- a/scripts/backfill_tender_bank.py
+++ b/scripts/backfill_tender_bank.py
@@ -584,7 +584,13 @@ def run(args: argparse.Namespace) -> None:
     written = 0
     for start in range(0, len(to_write), args.batch_size):
         batch = to_write[start : start + args.batch_size]
-        client.upsert_receipt_summaries(batch)
+        # This script IS the offline source of truth for the bank fields,
+        # so it may legitimately retract a match (null a bank_amount) when
+        # the curated ledger no longer carries it — hence the explicit
+        # opt-out from the offline-field clobber guard.
+        client.upsert_receipt_summaries(
+            batch, allow_offline_field_clear=True
+        )
         written += len(batch)
         logger.info("upserted %d / %d", written, len(to_write))
     print(f"\nwrote {written} summary records")


### PR DESCRIPTION
## Summary

Closes out the offline-bank-field destruction investigation:

**1. Why the regen path drops them** — it doesn't, mostly. The deployed summary-updater Lambda (the #1322 path, consumed via `RECEIPT_SUMMARY_QUEUE`) carries `ledger`/`bank_amount`/`bank_match_confidence` over correctly: prod's bank_amount count stayed **exactly 439** through today's entire re-OCR wave, and today's 85 prod recomputes split 28 bank+ledger / 35 ledger-only / 22 neither — the 57 "missing bank" summaries are receipts whose offline join never found a bank match (ledger-preserved-but-bank-absent is the preserving updater's signature, not erosion; mismatched receipts correlate with lacking bank anchors). The wholesale destroyer was **`scripts/backfill_receipt_summaries.py`**, which bypasses the updater and builds records with tender/bank = None — its single 18:52Z dev run accounts for the whole dev wipe (tender 813→27, bank 425→3).

**2. Merge-not-overwrite + test** — the backfill script now preloads stored summaries and carries over tender + offline bank fields; 10 new unit tests pin the detector and the guard (raises before any write; opt-in, carry-over, and no-stored-summary paths; batch variant).

**4. Loud guard** — `upsert_receipt_summary`/`upsert_receipt_summaries` now **refuse** to null an offline bank field the stored summary carries, raising `EntityValidationError` with a message pointing at the restore path, unless the caller passes `allow_offline_field_clear=True`. `backfill_tender_bank.py` opts out explicitly (it is the offline source of truth and may legitimately retract a match). Cost: one strongly-typed read per summary write.

**3. Restore** — after this merges: re-run `backfill_tender_bank.py --env dev --apply` (dry-run already validated: 810 records, 443 bank-matched). No prod repair needed per the measurements above.

Full `receipt_dynamo` unit suite: **2373 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)