### PR TITLE
style: black-format the offline-guard test file

### DIFF
--- a/receipt_dynamo/tests/unit/test_receipt_summary_offline_guard.py
+++ b/receipt_dynamo/tests/unit/test_receipt_summary_offline_guard.py
@@ -134,9 +134,7 @@ def test_upsert_passes_when_no_stored_summary():
 def test_batch_upsert_raises_when_any_record_clears_bank_fields():
     client = guarded_client(existing=make_record(**BANKED))
     with pytest.raises(ValueError, match="offline bank field"):
-        client.upsert_receipt_summaries(
-            [make_record(**BANKED), make_record()]
-        )
+        client.upsert_receipt_summaries([make_record(**BANKED), make_record()])
     client._batch_write_with_retry.assert_not_called()
 
 


### PR DESCRIPTION
#1361 was merged with both Python jobs failing on **formatting only** — black would-reformat the new test file (no functional failures; the 10 guard tests pass). This formats it so main's CI goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)