### PR TITLE
chore: CI-exact lint sweep of #1361 files + summary-backfill warning

### DIFF
--- a/docs/line-items/STATE_OF_THE_SYSTEM.md
+++ b/docs/line-items/STATE_OF_THE_SYSTEM.md
@@ -73,6 +73,13 @@ canonical decoder.
 8. Batch label writes have no condition expression and clobber VALID rows —
    use the conditional singular path.
 9. Never merge frontend/visual changes without the user's review (#1316/#1317).
+10. `scripts/backfill_receipt_summaries.py` writes summaries DIRECTLY,
+    bypassing the summary-updater's carry-over — run only with its
+    tender/bank carry-over path intact (2026-08-04: a run without it nulled
+    bank_amount table-wide on dev and collapsed dev PROVEN 281 → 2; the
+    offline bank fields cannot be re-derived in the cloud). The upsert guard
+    (#1361) now raises on such writes; restore is
+    `scripts/backfill_tender_bank.py --apply`.
 
 ## Session-conduct rules (from the retrospective — retro/retro_strategist.md)
 

--- a/scripts/backfill_receipt_summaries.py
+++ b/scripts/backfill_receipt_summaries.py
@@ -118,12 +118,8 @@ def backfill_summaries(
                     merchant_name=merchant_name,
                     word_labels=bundle.word_labels,
                     words=bundle.words,
-                    tender_class=(
-                        existing.tender_class if existing else None
-                    ),
-                    card_network=(
-                        existing.card_network if existing else None
-                    ),
+                    tender_class=(existing.tender_class if existing else None),
+                    card_network=(existing.card_network if existing else None),
                     card_last4=existing.card_last4 if existing else None,
                     ledger=existing.ledger if existing else None,
                     bank_amount=existing.bank_amount if existing else None,
@@ -162,7 +158,11 @@ def backfill_summaries(
                                 try:
                                     client.upsert_receipt_summaries([record])
                                     stats["summaries_created"] += 1
-                                except (EntityError, OperationError, DynamoDBError):
+                                except (
+                                    EntityError,
+                                    OperationError,
+                                    DynamoDBError,
+                                ):
                                     logger.exception(
                                         "Failed to upsert %s:%d",
                                         record.image_id[:8],
@@ -195,7 +195,9 @@ def backfill_summaries(
             try:
                 client.upsert_receipt_summaries(pending_records)
                 stats["summaries_created"] += len(pending_records)
-                logger.info("  Upserted final %d summaries", len(pending_records))
+                logger.info(
+                    "  Upserted final %d summaries", len(pending_records)
+                )
             except (EntityError, OperationError, DynamoDBError):
                 logger.exception(
                     "Final batch upsert failed, falling back to per-record"
@@ -215,7 +217,8 @@ def backfill_summaries(
         else:
             stats["summaries_created"] += len(pending_records)
             logger.info(
-                "  [DRY RUN] Would upsert final %d summaries", len(pending_records)
+                "  [DRY RUN] Would upsert final %d summaries",
+                len(pending_records),
             )
 
     return stats

--- a/scripts/backfill_tender_bank.py
+++ b/scripts/backfill_tender_bank.py
@@ -588,9 +588,7 @@ def run(args: argparse.Namespace) -> None:
         # so it may legitimately retract a match (null a bank_amount) when
         # the curated ledger no longer carries it — hence the explicit
         # opt-out from the offline-field clobber guard.
-        client.upsert_receipt_summaries(
-            batch, allow_offline_field_clear=True
-        )
+        client.upsert_receipt_summaries(batch, allow_offline_field_clear=True)
         written += len(batch)
         logger.info("upserted %d / %d", written, len(to_write))
     print(f"\nwrote {written} summary records")


### PR DESCRIPTION
## Summary

Per review feedback on the #1361 formatting failures:

- **Why whack-a-mole happened**: the receipt_agent job lints changed files in a per-file loop that aborts at the first failure — #1361's `scripts/` violations were masked behind the test-file failure, and #1362 (which only changed the test file) diffed clean. Latent violations would have failed the next PR touching those scripts.
- **Bare-venv sweep** (fresh `python -m venv`, `pip install black isort`, CI's exact flags: `black --check --line-length=79`, `isort --check-only --profile=black --line-length=79`) over **every** file #1361 touched: 2 script files reformatted; all five files now pass both tools per-file, matching the CI loop's invocation.
- **Standing WARNING 10** added to `docs/line-items/STATE_OF_THE_SYSTEM.md`: `backfill_receipt_summaries.py` writes summaries directly and must never run without its tender/bank carry-over (the 2026-08-04 dev wipe), with pointers to the #1361 guard and the restore path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)