### PR TITLE
chore: gitignore local analysis caches + codify lint-loop short-circuit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -262,3 +262,9 @@ backups/
 # Archived review-loop runs keep their small timing/verification logs, which
 # the blanket *.log rule above would otherwise drop.
 !docs/review-loops/**/*.log
+
+# Local analysis caches (multi-MB, machine-local; a `git add -A` once staged
+# a 28 MB label cache and needed a force-push rewrite)
+logs/
+.local-qa-out/
+.row_backfill_cache/

--- a/docs/line-items/STATE_OF_THE_SYSTEM.md
+++ b/docs/line-items/STATE_OF_THE_SYSTEM.md
@@ -69,6 +69,11 @@ canonical decoder.
    should be checked.
 6. Two CI lint jobs have OPPOSITE isort personalities (no root config):
    replicate the exact bare venv from main.yml before "fixing" imports.
+   Also: the receipt_agent job lints changed files in a per-file loop that
+   SHORT-CIRCUITS at the first failure — green-after-one-fix proves nothing
+   about the rest. Sweep EVERY changed file with CI's exact flags
+   (`black --check --line-length=79`, `isort --check-only --profile=black
+   --line-length=79`) in one pass (#1361→#1363 whack-a-mole).
 7. New Lambdas under `ignore_changes=["layers"]` are born with stale layers.
 8. Batch label writes have no condition expression and clobber VALID rows —
    use the conditional singular path.


### PR DESCRIPTION
Two review leftovers:

- **.gitignore**: `logs/`, `.local-qa-out/`, `.row_backfill_cache/` — multi-MB machine-local caches; a `git add -A` staged a 28 MB label cache once (rewritten + force-pushed) and would again.
- **Warning 6 extended**: the receipt_agent job's per-file lint loop short-circuits at the first failure, so green-after-one-fix is not proof the rest are clean — sweep every changed file with CI's exact flags in one pass (the #1361→#1363 whack-a-mole).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance explaining that the receipt-agent CI check may stop after the first lint failure.
  * Clarified that all changed files should be checked with the required formatting and import-sorting commands.

* **Chores**
  * Excluded local analysis caches, logs, and generated quality-assurance output from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->