### PR TITLE
feat: dead-letter queues for the OCR job and results queues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -262,3 +262,9 @@ backups/
 # Archived review-loop runs keep their small timing/verification logs, which
 # the blanket *.log rule above would otherwise drop.
 !docs/review-loops/**/*.log
+
+# Local analysis caches (multi-MB, machine-local; a `git add -A` once staged
+# a 28 MB label cache and needed a force-push rewrite)
+logs/
+.local-qa-out/
+.row_backfill_cache/

--- a/docs/line-items/STATE_OF_THE_SYSTEM.md
+++ b/docs/line-items/STATE_OF_THE_SYSTEM.md
@@ -69,6 +69,11 @@ canonical decoder.
    should be checked.
 6. Two CI lint jobs have OPPOSITE isort personalities (no root config):
    replicate the exact bare venv from main.yml before "fixing" imports.
+   Also: the receipt_agent job lints changed files in a per-file loop that
+   SHORT-CIRCUITS at the first failure — green-after-one-fix proves nothing
+   about the rest. Sweep EVERY changed file with CI's exact flags
+   (`black --check --line-length=79`, `isort --check-only --profile=black
+   --line-length=79`) in one pass (#1361→#1363 whack-a-mole).
 7. New Lambdas under `ignore_changes=["layers"]` are born with stale layers.
 8. Batch label writes have no condition expression and clobber VALID rows —
    use the conditional singular path.

--- a/infra/upload_images/infra.py
+++ b/infra/upload_images/infra.py
@@ -113,6 +113,25 @@ class UploadImages(ComponentResource):
             opts=ResourceOptions(parent=self),
         )
 
+        # Dead-letter queue for OCR jobs. Before this existed, a message
+        # whose job row or raw image had been deleted recycled forever —
+        # the 2026-08-04 poison messages aborted every Mac-worker drain
+        # until #1355 taught the worker to drop them. The worker is the
+        # first net; this DLQ catches messages it keeps deferring
+        # (persistent transient errors) so they park for inspection
+        # instead of cycling for the full 14-day retention.
+        self.ocr_dlq = Queue(
+            f"{name}-ocr-dlq",
+            name=f"{name}-{stack}-ocr-dlq",
+            message_retention_seconds=1209600,  # 14 days
+            tags={
+                "Purpose": "OCR Job DLQ",
+                "Component": name,
+                "Environment": pulumi.get_stack(),
+            },
+            opts=ResourceOptions(parent=self),
+        )
+
         # Create SQS queue for OCR results
         self.ocr_queue = Queue(
             f"{name}-ocr-queue",
@@ -120,9 +139,32 @@ class UploadImages(ComponentResource):
             visibility_timeout_seconds=3600,
             message_retention_seconds=1209600,  # 14 days
             receive_wait_time_seconds=0,  # Short polling
-            redrive_policy=None,  # No DLQ for now
+            # maxReceiveCount is generous: the Mac workers drain on
+            # quarter-hour schedules and legitimately re-receive deferred
+            # messages across drains; 8 receipts ≈ an hour of retries
+            # before a message parks.
+            redrive_policy=self.ocr_dlq.arn.apply(
+                lambda arn: json.dumps(
+                    {"deadLetterTargetArn": arn, "maxReceiveCount": 8}
+                )
+            ),
             tags={
                 "Purpose": "OCR Job Queue",
+                "Component": name,
+                "Environment": pulumi.get_stack(),
+            },
+            opts=ResourceOptions(parent=self),
+        )
+
+        # Dead-letter queue for OCR results: a payload the process_ocr
+        # Lambda cannot parse must park for replay, not recycle until the
+        # 4-day retention silently drops it.
+        self.ocr_results_dlq = Queue(
+            f"{name}-ocr-results-dlq",
+            name=f"{name}-{stack}-ocr-results-dlq",
+            message_retention_seconds=1209600,  # 14 days
+            tags={
+                "Purpose": "OCR Results DLQ",
                 "Component": name,
                 "Environment": pulumi.get_stack(),
             },
@@ -136,7 +178,11 @@ class UploadImages(ComponentResource):
             visibility_timeout_seconds=900,  # Must be >= Lambda timeout (900s for container-based process_ocr)
             message_retention_seconds=345600,  # 4 days
             receive_wait_time_seconds=0,  # Short polling
-            redrive_policy=None,  # No DLQ for now
+            redrive_policy=self.ocr_results_dlq.arn.apply(
+                lambda arn: json.dumps(
+                    {"deadLetterTargetArn": arn, "maxReceiveCount": 5}
+                )
+            ),
             tags={
                 "Purpose": "OCR Results Processing",
                 "Component": name,


### PR DESCRIPTION
## Summary

#1355 fixed the **worker**, not the **infra**: neither OCR queue had a DLQ, so a message the worker can't or won't consume recycles for the full retention (14 days on jobs, 4 on results). The 2026-08-04 poison pair demonstrated the failure mode end-to-end.

Mirrors the existing `llm-validation` DLQ pattern:

| Queue | DLQ | maxReceiveCount | Rationale |
|---|---|---|---|
| `*-ocr-queue` | `*-ocr-dlq` | 8 | Mac workers drain on quarter-hour schedules and legitimately re-receive deferred messages; 8 receipts ≈ an hour of retries before parking |
| `*-ocr-results-queue` | `*-ocr-results-dlq` | 5 | unparseable payloads park for replay instead of being silently dropped at retention |

Both DLQs: 14-day retention. Applies to dev and prod via the shared component.

`pulumi preview --stack dev` verified: `+2 to create`, redrive-policy updates on both queues, nothing else touched by this diff.

## After merge

CI deploys prod; run `pulumi up --stack dev` for dev (no CodeBuild dependency — plain SQS resources).

🤖 Generated with [Claude Code](https://claude.com/claude-code)