### PR TITLE
feat(line-items): Mac worker produces sections + line items; stream stage becomes a consistency checker

### DIFF
--- a/docs/architecture/mac-ocr-aws-handoff.md
+++ b/docs/architecture/mac-ocr-aws-handoff.md
@@ -61,11 +61,82 @@ evaluation).
 | Label validation (Chroma KNN + LLM) | AWS Lambda (words pipeline) | `receipt_upload/label_validation/` |
 | Chroma compaction (snapshot merge) | AWS, async | triggered by `CompactionRun` Dynamo stream |
 
-Section segmentation is deliberately **not** ported to Swift. The Mac worker
-ships evidence (OCR geometry + LayoutLM labels); every merchant-conditioned
-or cross-receipt decision (merchant resolution, sections, verification,
-validation) runs in AWS where the priors, Chroma index, and DynamoDB state
-live.
+Section assignment and line-item decoding are **now also run on the Mac**
+(ported in #1314/#1315, brought to decoder parity in #1367). Both are
+deterministic and merchant-conditioned only through priors the worker ships
+in its bundle, so they need neither Chroma nor DynamoDB. Everything that
+depends on cross-receipt state — merchant *resolution*, KNN section
+verification, label validation, compaction — still runs in AWS, and the
+cloud keeps its own copy of both decoders as the canonical implementation
+(see "Two producers" below).
+
+| Stage | Executes on | Code |
+|---|---|---|
+| Section assignment (on device) | Mac | `Sections/SectionAssignment.swift` + `section_order_priors_v2.json` |
+| Line-item decode (on device) | Mac | `LineItems/` + `block_role_priors_v2.json` |
+
+## Two producers, one canonical decoder
+
+The worker and the cloud run the SAME algorithm, so rows say which one wrote
+them (`receipt_upload/line_items/provenance.py`):
+
+| Field | Worker | Cloud |
+|---|---|---|
+| `ReceiptSection.model_source` | `swift-worker-v1` | `upload-determinism-v1` |
+| `ReceiptLineItem.extractor_version` | `swift-worker-v1+line-items-blocks-v2` | `line-items-blocks-v2` |
+
+`extractor_version` carries the build AND the algorithm version because a
+cloud recompute over a worker-provided ITEMS section inherits
+`source_model_source = "swift-worker-v1"` and cannot be told apart on that
+field alone.
+
+Flow:
+
+1. **Ingest** (`_process_swift_single_pass`) persists worker sections and
+   RECEIPT_LINE_ITEM rows. Strictly additive — a payload with neither
+   `sections` nor `line_items` behaves exactly as it did before. Provenance
+   claimed by the payload is never trusted: rows are always re-stamped as
+   worker-written.
+2. **Lines pipeline** then runs `assign_and_persist_sections`, which is
+   additive-only, so worker sections suppress a duplicate cloud proposal for
+   the same types rather than racing them. KNN verification still covers
+   them (`VERIFIABLE_MODEL_SOURCES`).
+3. **Stream stage** (`infra/receipt_line_item_updater`) recomputes on every
+   summary change and acts as a CONSISTENCY CHECKER. The recompute wins by
+   default; the worker's rows are preserved only when they pass
+   `items_boundary_extension_guard` with the recompute as `before` — the
+   same arithmetic guard the ITEMS-boundary repair uses (strictly smaller
+   `|delta|` AND a strictly better reconciliation status; a matching
+   recompute is never displaced and no-baseline sides are never ranked).
+   Preserved rows keep the worker's decode and gain the merchant and graded
+   reconciliation only the cloud has.
+
+### Querying divergence
+
+Every receipt that arrives carrying worker rows emits exactly one log line
+from the line-item updater:
+
+```
+LINE_ITEM_DIVERGENCE {"image_id": ..., "receipt_id": ..., "divergent": 0|1,
+  "decision": "keep-worker"|"keep-recompute", "guard_reason": ...,
+  "worker_extractor_version": ..., "worker_count": ..., "cloud_count": ...,
+  "worker_status": ..., "cloud_status": ..., "worker_delta": ...,
+  "cloud_delta": ..., "name_mismatches": ..., "price_mismatches": ...}
+```
+
+WARNING when the two decodes disagree, INFO when they agree — so the
+agreement *rate* is measurable, not just the failures:
+
+```
+fields @timestamp, @message
+| filter @message like /LINE_ITEM_DIVERGENCE/
+| parse @message 'LINE_ITEM_DIVERGENCE *' as body
+| stats count() by divergent, decision
+```
+
+A rising `divergent` count with matching `worker_extractor_version` and
+cloud `EXTRACTOR_VERSION` means the Swift port has forked from the Python
+decoder again — the failure mode STATE_OF_THE_SYSTEM warning #1 describes.
 
 ## Artifacts crossing the boundary
 
@@ -186,15 +257,18 @@ later reads the labels back from DynamoDB.
 - `assign_and_persist_sections` is **additive**: it only `add`s sections of
   types absent for the receipt, always `PENDING` with
   `model_source="upload-determinism-v1"`. It never updates existing
-  sections, so human/VALID sections are never overwritten. Concurrent adds
-  are absorbed via `EntityAlreadyExistsError`.
+  sections, so human/VALID sections — and the worker's sections written at
+  ingest — are never overwritten. Concurrent adds are absorbed via
+  `EntityAlreadyExistsError`.
 - The returned `line_id → section_type` map prefers VALID sections over
   PENDING ones (`sections_to_line_map`), so human truth wins in Chroma
   metadata.
 - `verify_receipt_sections` **annotates only**: it sets
   `verification_source/status/section_type/confidence`,
   `disagreement_row_ids`, `verified_at`. It never changes `section_type`,
-  `line_ids`, or `row_ids`, never touches non-model sections, and never
+  `line_ids`, or `row_ids`, never touches sections outside
+  `VERIFIABLE_MODEL_SOURCES` (the cloud assigner + the worker running the
+  same assigner), and never
   demotes a VALID section (disagreement leaves PENDING sections PENDING and
   records the independent prediction as provenance:
   AGREED / DISAGREED / ABSTAINED).

--- a/docs/line-items/STATE_OF_THE_SYSTEM.md
+++ b/docs/line-items/STATE_OF_THE_SYSTEM.md
@@ -61,7 +61,12 @@ canonical decoder.
    in `--check` mode — never hand-edit the expectation JSON. Note the
    golden set alone cannot see the #1320 guards (it decodes identically
    with the pre-#1320 regexes); the synthetic guard vectors in that
-   generator are what covers them.
+   generator are what covers them. **Phase 2**: the worker now WRITES what
+   it decodes (sections + line items, stamped
+   `swift-worker-v1+line-items-blocks-v2`) and the stream stage compares
+   instead of overwriting — so a fork no longer just fails a test, it
+   shows up in prod as `LINE_ITEM_DIVERGENCE` log lines from the line-item
+   updater (see docs/architecture/mac-ocr-aws-handoff.md).
 2. MCP receipt tools default to DEV (`PORTFOLIO_ENV`); prod writes need
    explicit `DynamoClient("ReceiptsTable-d7ff76a")`.
 3. CI deploys PROD only — after merging Lambda/entity changes, deploy the dev

--- a/infra/chromadb_compaction/components/lambda_functions.py
+++ b/infra/chromadb_compaction/components/lambda_functions.py
@@ -534,6 +534,16 @@ class HybridLambdaDeployment(ComponentResource):
                     / "line_items"
                     / "blocks.py"
                 ),
+                # Producer stamps shared with the Mac worker's ingest path;
+                # the consistency checker needs them to tell worker-written
+                # rows from its own recompute.
+                "receipt_upload/line_items/provenance.py": pulumi.FileAsset(
+                    _repo_root
+                    / "receipt_upload"
+                    / "receipt_upload"
+                    / "line_items"
+                    / "provenance.py"
+                ),
                 "receipt_upload/line_items/reocr.py": pulumi.FileAsset(
                     _repo_root
                     / "receipt_upload"

--- a/infra/receipt_line_item_updater/line_item_processor.py
+++ b/infra/receipt_line_item_updater/line_item_processor.py
@@ -16,6 +16,31 @@ stage extracts on PENDING sections too and records
 ``source_section_status`` -- consumers filter on VALID when they want
 precision; gating production on VALID is what once limited coverage to
 hand-repaired receipts.
+
+CONSISTENCY CHECKER
+-------------------
+The Mac worker now runs the same decoder on device and ships its rows with
+the OCR upload (``receipt_upload.line_items.provenance``). When this stage
+finds worker-written rows already in the table it COMPARES instead of
+blindly overwriting:
+
+* the recompute wins by default -- byte-identical to the pre-worker
+  behavior, and the only outcome possible for a receipt with no worker rows;
+* the worker's rows are preserved only when they are *strictly better* by
+  ``items_boundary_extension_guard`` -- the same arithmetic guard the ITEMS
+  boundary repair uses (smaller |delta| AND a better reconciliation status,
+  never against an already-matching baseline, never across a no-baseline
+  side). Preserved rows are re-stamped with the merchant/summary context the
+  cloud has and the worker did not.
+
+Every receipt that arrives with worker rows emits one queryable log line
+prefixed ``LINE_ITEM_DIVERGENCE`` carrying a JSON body (counts, names,
+prices, both reconciliation statuses and deltas, and the decision), so
+divergence is a CloudWatch Insights filter, not an archaeology exercise::
+
+    fields @timestamp, @message
+    | filter @message like /LINE_ITEM_DIVERGENCE/
+    | filter divergent = 1
 """
 
 import json
@@ -33,8 +58,12 @@ from receipt_dynamo.data.shared_exceptions import EntityNotFoundError
 from receipt_dynamo.entities.receipt_line_item import ReceiptLineItem
 from receipt_upload.line_items.geometry import (
     extract_items,
+    items_boundary_extension_guard,
     propose_items_boundary_extension,
     reconcile_detailed,
+)
+from receipt_upload.line_items.provenance import (
+    is_worker_extractor_version,
 )
 
 # isort: on
@@ -189,6 +218,15 @@ def update_receipt_line_items(
             )
         )
 
+    # Consistency check against rows the Mac worker already decoded on
+    # device. No worker rows -> `entities`/`items`/`recon` are used verbatim
+    # and this stage behaves exactly as it did before the worker produced
+    # anything.
+    entities, items, recon, divergence = _reconcile_with_worker_rows(
+        image_id, receipt_id, entities, items, recon, summary_dict, merchant
+    )
+    status = recon.status
+
     deleted = dynamo_client.delete_receipt_line_items_for_receipt(
         image_id, receipt_id
     )
@@ -211,7 +249,147 @@ def update_receipt_line_items(
         "baseline_figures_agreeing": recon.baseline_figures_agreeing,
         "section_extension": extension,
         "reocr_triggered": reocr,
+        "worker_divergence": divergence,
     }
+
+
+DIVERGENCE_MARKER = "LINE_ITEM_DIVERGENCE"
+
+
+def _delta(result: Any) -> float | None:
+    """|item sum - baseline| in the shape ``evaluate_items_zone`` returns."""
+
+    if result.item_sum is None or result.baseline is None:
+        return None
+    return round(result.item_sum - result.baseline, 2)
+
+
+def _row_to_item(row: Any) -> dict[str, Any]:
+    """A stored ReceiptLineItem as the decoder's item dict."""
+
+    try:
+        price = float(row.price)
+    except (TypeError, ValueError):
+        price = 0.0
+    return {
+        "name": row.name,
+        "price": price,
+        "quantity": row.quantity,
+        "unit_price": row.unit_price,
+        "is_discount": bool(row.is_discount),
+        "name_quality": row.name_quality,
+        "line_ids": list(row.line_ids or []),
+        "raw_text": row.raw_text,
+    }
+
+
+def _reconcile_with_worker_rows(
+    image_id: str,
+    receipt_id: int,
+    entities: list[ReceiptLineItem],
+    items: list[dict],
+    recon: Any,
+    summary_dict: dict | None,
+    merchant: str | None,
+) -> tuple[list[ReceiptLineItem], list[dict], Any, dict[str, Any] | None]:
+    """Compare a fresh recompute against worker-written rows.
+
+    Returns the rows to persist, their item dicts (for the re-OCR trigger),
+    their reconciliation result, and a divergence record (``None`` when the
+    receipt carries no worker rows -- the pre-worker path).
+
+    The recompute wins unless the worker's rows pass
+    ``items_boundary_extension_guard`` with the recompute as ``before``: the
+    worker is preserved only when it strictly shrinks |delta| AND strictly
+    improves reconciliation status. Reusing that guard verbatim means the
+    conservative cases fall out for free -- a matching recompute is never
+    displaced, and a no-baseline side is never ranked against a baselined
+    one (which is exactly the common case, since the worker decodes before
+    any summary exists).
+    """
+    try:
+        stored = dynamo_client.get_receipt_line_items_from_receipt(
+            image_id, receipt_id
+        )
+    except EntityNotFoundError:
+        stored = []
+    worker_rows = [
+        row
+        for row in stored
+        if is_worker_extractor_version(getattr(row, "extractor_version", None))
+    ]
+    if not worker_rows:
+        return entities, items, recon, None
+
+    worker_rows = sorted(worker_rows, key=lambda row: row.item_index)
+    worker_items = [_row_to_item(row) for row in worker_rows]
+    worker_recon = reconcile_detailed(
+        [item for item in worker_items if not item["is_discount"]],
+        summary_dict,
+    )
+
+    before = {"status": recon.status, "delta": _delta(recon)}
+    after = {"status": worker_recon.status, "delta": _delta(worker_recon)}
+    keep_worker, guard_reason = items_boundary_extension_guard(before, after)
+
+    cloud_names = [entity.name for entity in entities]
+    cloud_prices = [entity.price for entity in entities]
+    worker_names = [row.name for row in worker_rows]
+    worker_prices = [f"{item['price']:.2f}" for item in worker_items]
+    divergent = (
+        cloud_names != worker_names
+        or cloud_prices != worker_prices
+        or recon.status != worker_recon.status
+    )
+
+    record = {
+        "image_id": image_id,
+        "receipt_id": receipt_id,
+        "divergent": int(divergent),
+        "decision": "keep-worker" if keep_worker else "keep-recompute",
+        "guard_reason": guard_reason,
+        "worker_extractor_version": worker_rows[0].extractor_version,
+        "worker_count": len(worker_rows),
+        "cloud_count": len(entities),
+        "worker_status": worker_recon.status,
+        "cloud_status": recon.status,
+        "worker_delta": after["delta"],
+        "cloud_delta": before["delta"],
+        "name_mismatches": sum(
+            1
+            for cloud, worker in zip(cloud_names, worker_names)
+            if cloud != worker
+        ),
+        "price_mismatches": sum(
+            1
+            for cloud, worker in zip(cloud_prices, worker_prices)
+            if cloud != worker
+        ),
+    }
+    logger.log(
+        logging.WARNING if divergent else logging.INFO,
+        "%s %s",
+        DIVERGENCE_MARKER,
+        json.dumps(record, sort_keys=True),
+    )
+    if not keep_worker:
+        return entities, items, recon, record
+
+    # Preserve the worker's DECODE, refresh its CONTEXT: merchant and the
+    # graded reconciliation only exist in the cloud, and the worker had no
+    # summary to reconcile against when it wrote these rows.
+    now = datetime.now(timezone.utc)
+    kept = [
+        replace(
+            row,
+            extracted_at=now,
+            merchant_name=merchant,
+            reconciliation_status=worker_recon.status,
+            baseline_figures_agreeing=(worker_recon.baseline_figures_agreeing),
+        )
+        for row in worker_rows
+    ]
+    return kept, worker_items, worker_recon, record
 
 
 def _maybe_extend_items_section(

--- a/infra/upload_images/container_ocr/handler/ocr_processor.py
+++ b/infra/upload_images/container_ocr/handler/ocr_processor.py
@@ -37,11 +37,19 @@ from receipt_dynamo.entities import (
     ReceiptBarcode,
     ReceiptLetter,
     ReceiptLine,
+    ReceiptLineItem,
+    ReceiptSection,
     ReceiptWord,
     Word,
 )
 from receipt_upload.geometry.transformations import find_perspective_coeffs
 from receipt_upload.line_items.geometry import extract_items
+from receipt_upload.line_items.provenance import (
+    SWIFT_WORKER_EXTRACTOR_VERSION,
+    SWIFT_WORKER_MODEL_SOURCE,
+    is_worker_extractor_version,
+    is_worker_model_source,
+)
 from receipt_upload.ocr import process_ocr_dict_as_image
 from receipt_upload.receipt_processing.native import process_native
 from receipt_upload.receipt_processing.photo import process_photo
@@ -1637,6 +1645,13 @@ class OCRProcessor:
             if receipt_barcodes:
                 self.dynamo.add_receipt_barcodes(receipt_barcodes)
 
+            # Sections + line items the worker already decoded on device.
+            # Must run AFTER persist_receipt_rows: ReceiptSection.row_ids
+            # reference the ReceiptRow ids that call materializes.
+            worker_structure = self._persist_worker_structure(
+                image_id, receipt_id, receipt_data, current_time
+            )
+
             logger.info(
                 "Created receipt %s: %s lines, %s words, %s letters, "
                 "%s barcodes",
@@ -1653,6 +1668,7 @@ class OCRProcessor:
             per_receipt_data[receipt_id] = {
                 "lines": receipt_lines,
                 "words": receipt_words,
+                "worker_structure": worker_structure,
             }
 
         # Update routing decision
@@ -1729,6 +1745,151 @@ class OCRProcessor:
             "word_count": len(all_receipt_words),
             "swift_single_pass": True,  # Flag for handler to enable embeddings
         }
+
+    def _persist_worker_structure(
+        self,
+        image_id: str,
+        receipt_id: int,
+        receipt_data: Dict[str, Any],
+        created_at: datetime,
+    ) -> Optional[Dict[str, Any]]:
+        """Persist sections + line items the Mac worker decoded on device.
+
+        Strictly additive. A payload carrying neither ``sections`` nor
+        ``line_items`` -- every worker build before that contract, and every
+        legacy/PHOTO path -- returns ``None`` and leaves ingest byte-identical
+        to its previous behavior.
+
+        Two downstream stages already know how to defer to these rows:
+
+        * ``assign_and_persist_sections`` (run by the embedding processor
+          right after this method) skips section types that already exist, so
+          worker sections suppress a duplicate cloud proposal instead of
+          racing it;
+        * the stream stage (``infra/receipt_line_item_updater``) recognizes
+          the worker ``extractor_version`` and compares rather than blindly
+          overwriting.
+
+        Provenance is never taken on faith: whatever the payload claims, rows
+        are stamped with a worker source, so an ingest payload can never
+        impersonate the cloud producer. Malformed entries are skipped
+        individually -- structure is a bonus on top of OCR persistence and
+        must never cost the receipt its words.
+        """
+        sections_payload = receipt_data.get("sections") or []
+        items_payload = receipt_data.get("line_items") or []
+        if not sections_payload and not items_payload:
+            return None
+
+        sections: list[ReceiptSection] = []
+        for entry in sections_payload:
+            try:
+                model_source = entry.get("model_source")
+                if not is_worker_model_source(model_source):
+                    model_source = SWIFT_WORKER_MODEL_SOURCE
+                sections.append(
+                    ReceiptSection(
+                        image_id=image_id,
+                        receipt_id=receipt_id,
+                        section_type=str(entry["section_type"]),
+                        line_ids=[int(x) for x in entry["line_ids"]],
+                        row_ids=(
+                            [int(x) for x in entry["row_ids"]]
+                            if entry.get("row_ids")
+                            else None
+                        ),
+                        confidence=(
+                            float(entry["confidence"])
+                            if entry.get("confidence") is not None
+                            else None
+                        ),
+                        validation_status=ValidationStatus.PENDING.value,
+                        model_source=model_source,
+                        created_at=created_at,
+                    )
+                )
+            except (KeyError, TypeError, ValueError) as exc:
+                logger.warning(
+                    "Skipping malformed worker section for %s:%s: %s",
+                    image_id,
+                    receipt_id,
+                    exc,
+                )
+
+        line_items: list[ReceiptLineItem] = []
+        for entry in items_payload:
+            try:
+                extractor_version = entry.get("extractor_version")
+                if not is_worker_extractor_version(extractor_version):
+                    # Pre-contract worker builds shipped line items with no
+                    # extractor_version; stamp them so the consistency
+                    # checker can still tell them from a cloud recompute.
+                    extractor_version = SWIFT_WORKER_EXTRACTOR_VERSION
+                name = str(entry.get("name") or "")
+                quality = (
+                    "low"
+                    if entry.get("name_quality") == "low" or not name
+                    else "ok"
+                )
+                line_items.append(
+                    ReceiptLineItem(
+                        image_id=image_id,
+                        receipt_id=receipt_id,
+                        item_index=int(entry["item_index"]),
+                        name=name,
+                        price=float(entry["price"]),
+                        line_ids=[int(x) for x in entry["line_ids"]],
+                        extractor_version=extractor_version,
+                        extracted_at=created_at,
+                        quantity=entry.get("quantity"),
+                        unit_price=entry.get("unit_price"),
+                        is_discount=bool(entry.get("is_discount")),
+                        name_quality=quality,
+                        # No summary exists at ingest, so the worker's
+                        # reconciliation is almost always "no-baseline"; the
+                        # stream stage re-reconciles once one is written.
+                        reconciliation_status=(
+                            entry.get("reconciliation_status") or None
+                        ),
+                        source_model_source=SWIFT_WORKER_MODEL_SOURCE,
+                        source_section_status=ValidationStatus.PENDING.value,
+                    )
+                )
+            except (KeyError, TypeError, ValueError) as exc:
+                logger.warning(
+                    "Skipping malformed worker line item for %s:%s: %s",
+                    image_id,
+                    receipt_id,
+                    exc,
+                )
+
+        if sections:
+            # Batch put (not add_receipt_section) so an SQS redelivery
+            # rewrites rather than raising EntityAlreadyExistsError.
+            self.dynamo.add_receipt_sections(sections)
+        if line_items:
+            self.dynamo.delete_receipt_line_items_for_receipt(
+                image_id, receipt_id
+            )
+            self.dynamo.add_receipt_line_items(line_items)
+
+        summary = {
+            "sections": len(sections),
+            "line_items": len(line_items),
+            "section_types": sorted(
+                str(section.section_type) for section in sections
+            ),
+            "extractor_version": (
+                line_items[0].extractor_version if line_items else None
+            ),
+        }
+        logger.info(
+            "Persisted worker-decoded structure for %s:%s: %s",
+            image_id,
+            receipt_id,
+            summary,
+        )
+        return summary
 
     def _parse_receipt_barcodes_from_swift(
         self,

--- a/infra/upload_images/container_ocr/handler/tests/test_swift_payload_contract.py
+++ b/infra/upload_images/container_ocr/handler/tests/test_swift_payload_contract.py
@@ -18,6 +18,9 @@ Covered contract points:
   6. OCR-results SQS messages are never misrouted to the LLM-validation path
   7. visual ReceiptRows are persisted by ingest, BEFORE the handler invokes
      the embedding/section pipeline
+  8. worker-decoded sections + RECEIPT_LINE_ITEM rows are persisted on
+     ingest, provenance-stamped -- and payloads without them behave exactly
+     as they did before the worker became a producer
 """
 
 import json
@@ -359,6 +362,164 @@ def test_swift_single_pass_persists_rows_before_embedding(
 
     barcodes = dynamo.list_receipt_barcodes_from_receipt(IMAGE_ID, 1)
     assert len(barcodes) == 1
+
+
+# ---------------------------------------------------------------------------
+# 7. Worker-decoded sections + line items land on ingest (Phase 2)
+# ---------------------------------------------------------------------------
+
+
+def _processor(table_name):
+    return OCRProcessor(
+        table_name=table_name,
+        raw_bucket="raw-bucket",
+        site_bucket="site-bucket",
+        ocr_job_queue_url="https://sqs.test/jobs",
+        ocr_results_queue_url="https://sqs.test/results",
+    )
+
+
+def _seed_job(processor):
+    now = datetime.now(timezone.utc)
+    processor.dynamo.add_ocr_job(
+        OCRJob(
+            image_id=IMAGE_ID,
+            job_id=JOB_ID,
+            s3_bucket="raw-bucket",
+            s3_key=f"images/{IMAGE_ID}.png",
+            created_at=now,
+            updated_at=now,
+        )
+    )
+    routing = OCRRoutingDecision(
+        image_id=IMAGE_ID,
+        job_id=JOB_ID,
+        s3_bucket="raw-bucket",
+        s3_key=f"ocr_results/{IMAGE_ID}.json",
+        created_at=now,
+        updated_at=now,
+        receipt_count=0,
+    )
+    processor.dynamo.add_ocr_routing_decision(routing)
+    return processor.dynamo.get_ocr_job(IMAGE_ID, JOB_ID), routing
+
+
+def test_swift_single_pass_persists_worker_sections_and_line_items(
+    aws_stack, swift_payload
+):
+    """The worker's on-device decode is accepted verbatim at ingest.
+
+    Sections must exist before the embedding pipeline runs its own assigner
+    (which is additive-only and skips types already present), and the line
+    items must carry the worker provenance stamp so the stream stage can
+    recognize them as pre-computed rather than overwrite them blindly.
+    """
+    processor = _processor(aws_stack)
+    ocr_job, routing = _seed_job(processor)
+
+    processor._process_swift_single_pass(swift_payload, ocr_job, routing)
+
+    dynamo = DynamoClient(aws_stack)
+    sections = dynamo.get_receipt_sections_from_receipt(IMAGE_ID, 1)
+    assert {section.section_type for section in sections} == {
+        "ITEMS",
+        "STOREFRONT",
+        "TOTAL_LINE",
+    }
+    for section in sections:
+        assert section.model_source == "swift-worker-v1"
+        assert section.validation_status == "PENDING"
+        assert section.line_ids
+        assert section.row_ids
+
+    line_items = dynamo.get_receipt_line_items_from_receipt(IMAGE_ID, 1)
+    assert [item.name for item in line_items] == ["ORGANIC"]
+    assert line_items[0].price == "3.99"
+    assert line_items[0].line_ids == [3]
+    assert line_items[0].extractor_version == (
+        "swift-worker-v1+line-items-blocks-v2"
+    )
+    assert line_items[0].source_model_source == "swift-worker-v1"
+    # No summary exists at ingest, so the worker's own verdict rides along.
+    assert line_items[0].reconciliation_status == "no-baseline"
+
+
+def test_worker_structure_is_ignored_when_the_payload_omits_it(
+    aws_stack, swift_payload
+):
+    """Back-compat: pre-contract payloads keep exactly today's behavior."""
+    legacy = json.loads(json.dumps(swift_payload))
+    for receipt in legacy["receipts"]:
+        receipt.pop("sections", None)
+        receipt.pop("line_items", None)
+
+    processor = _processor(aws_stack)
+    ocr_job, routing = _seed_job(processor)
+
+    result = processor._process_swift_single_pass(legacy, ocr_job, routing)
+
+    assert result["success"] is True
+    assert result["receipt_ids"] == [1]
+    assert result["per_receipt_data"][1]["worker_structure"] is None
+
+    dynamo = DynamoClient(aws_stack)
+    assert dynamo.get_receipt_sections_from_receipt(IMAGE_ID, 1) == []
+    assert dynamo.get_receipt_line_items_from_receipt(IMAGE_ID, 1) == []
+    # The OCR entities are untouched by the additive path.
+    rows = dynamo.get_receipt_rows_from_receipt(IMAGE_ID, 1)
+    assert sorted(line_id for row in rows for line_id in row.line_ids) == [
+        1,
+        3,
+        4,
+    ]
+
+
+def test_worker_payload_cannot_impersonate_the_cloud_producer(
+    aws_stack, swift_payload
+):
+    """An ingest payload never gets to claim the cloud's provenance.
+
+    ``upload-determinism-v1`` and the bare cloud ``extractor_version`` mean
+    "the stream stage wrote this"; a worker payload asserting either would
+    make its rows invisible to the consistency checker.
+    """
+    spoofed = json.loads(json.dumps(swift_payload))
+    for receipt in spoofed["receipts"]:
+        for section in receipt["sections"]:
+            section["model_source"] = "upload-determinism-v1"
+        for item in receipt["line_items"]:
+            item["extractor_version"] = "line-items-blocks-v2"
+
+    processor = _processor(aws_stack)
+    ocr_job, routing = _seed_job(processor)
+    processor._process_swift_single_pass(spoofed, ocr_job, routing)
+
+    dynamo = DynamoClient(aws_stack)
+    assert all(
+        section.model_source == "swift-worker-v1"
+        for section in dynamo.get_receipt_sections_from_receipt(IMAGE_ID, 1)
+    )
+    assert all(
+        item.extractor_version == "swift-worker-v1+line-items-blocks-v2"
+        for item in dynamo.get_receipt_line_items_from_receipt(IMAGE_ID, 1)
+    )
+
+
+def test_malformed_worker_rows_are_skipped_not_fatal(aws_stack, swift_payload):
+    """Structure is a bonus on top of OCR; it must never cost the words."""
+    broken = json.loads(json.dumps(swift_payload))
+    for receipt in broken["receipts"]:
+        receipt["sections"].append({"section_type": "ITEMS"})  # no line_ids
+        receipt["line_items"].append({"item_index": 9})  # no price/line_ids
+
+    processor = _processor(aws_stack)
+    ocr_job, routing = _seed_job(processor)
+    result = processor._process_swift_single_pass(broken, ocr_job, routing)
+
+    assert result["success"] is True
+    structure = result["per_receipt_data"][1]["worker_structure"]
+    assert structure["sections"] == 3
+    assert structure["line_items"] == 1
 
 
 def test_handler_runs_embedding_after_ocr_persistence(monkeypatch):

--- a/receipt_ocr_swift/Sources/ReceiptOCRCore/ReceiptProcessing/ReceiptStructurePipeline.swift
+++ b/receipt_ocr_swift/Sources/ReceiptOCRCore/ReceiptProcessing/ReceiptStructurePipeline.swift
@@ -1,6 +1,22 @@
 import Foundation
 
+/// Which producer wrote a row. The cloud's stream stage stamps
+/// `upload-determinism-v1`; anything starting with `swift-worker-` came from
+/// a Mac worker build and is treated as pre-computed by the ingest handler.
 public let swiftWorkerModelSource = "swift-worker-v1"
+
+/// Version of the decode ALGORITHM, kept in lockstep with the canonical
+/// Python decoder's `EXTRACTOR_VERSION`
+/// (`infra/receipt_line_item_updater/line_item_processor.py`). Bump both
+/// together: a mismatch between the two constants in production rows is the
+/// signal that the Swift port has fallen behind again (Warning #1).
+public let swiftWorkerDecoderVersion = "line-items-blocks-v2"
+
+/// The stamp written to `ReceiptLineItem.extractor_version`. Worker build and
+/// decoder version travel together in one queryable field so a divergent row
+/// identifies both which producer wrote it and which algorithm it ran.
+public let swiftWorkerExtractorVersion =
+    "\(swiftWorkerModelSource)+\(swiftWorkerDecoderVersion)"
 
 /// JSON contract for one on-device section prediction.
 public struct ReceiptSectionPayload: Codable, Sendable, Equatable {
@@ -9,6 +25,7 @@ public struct ReceiptSectionPayload: Codable, Sendable, Equatable {
     public let rowIds: [Int]
     public let confidence: Double
     public let modelSource: String
+    public let extractorVersion: String
 
     enum CodingKeys: String, CodingKey {
         case sectionType = "section_type"
@@ -16,6 +33,7 @@ public struct ReceiptSectionPayload: Codable, Sendable, Equatable {
         case rowIds = "row_ids"
         case confidence
         case modelSource = "model_source"
+        case extractorVersion = "extractor_version"
     }
 }
 
@@ -31,6 +49,7 @@ public struct ReceiptLineItemPayload: Codable, Sendable, Equatable {
     public let lineIds: [Int]
     public let reconciliationStatus: String
     public let modelSource: String
+    public let extractorVersion: String
 
     enum CodingKeys: String, CodingKey {
         case itemIndex = "item_index"
@@ -43,6 +62,7 @@ public struct ReceiptLineItemPayload: Codable, Sendable, Equatable {
         case lineIds = "line_ids"
         case reconciliationStatus = "reconciliation_status"
         case modelSource = "model_source"
+        case extractorVersion = "extractor_version"
     }
 }
 
@@ -150,7 +170,8 @@ public func buildOnDeviceReceiptStructure(
             lineIds: section.lineIds,
             rowIds: section.rowIds,
             confidence: section.confidence,
-            modelSource: swiftWorkerModelSource
+            modelSource: swiftWorkerModelSource,
+            extractorVersion: swiftWorkerExtractorVersion
         )
     }
 
@@ -185,7 +206,8 @@ public func buildOnDeviceReceiptStructure(
             nameQuality: item.nameQuality ?? "ok",
             lineIds: item.lineIds,
             reconciliationStatus: reconciliation.status,
-            modelSource: swiftWorkerModelSource
+            modelSource: swiftWorkerModelSource,
+            extractorVersion: swiftWorkerExtractorVersion
         )
     }
     return OnDeviceReceiptStructure(

--- a/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/Fixtures/swift_single_pass_contract.json
+++ b/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/Fixtures/swift_single_pass_contract.json
@@ -899,7 +899,8 @@
             3
           ],
           "confidence": 0.9999816459913875,
-          "model_source": "swift-worker-v1"
+          "model_source": "swift-worker-v1",
+          "extractor_version": "swift-worker-v1+line-items-blocks-v2"
         },
         {
           "section_type": "STOREFRONT",
@@ -910,7 +911,8 @@
             1
           ],
           "confidence": 0.9068789909517392,
-          "model_source": "swift-worker-v1"
+          "model_source": "swift-worker-v1",
+          "extractor_version": "swift-worker-v1+line-items-blocks-v2"
         },
         {
           "section_type": "TOTAL_LINE",
@@ -921,7 +923,8 @@
             4
           ],
           "confidence": 0.9565566777426845,
-          "model_source": "swift-worker-v1"
+          "model_source": "swift-worker-v1",
+          "extractor_version": "swift-worker-v1+line-items-blocks-v2"
         }
       ],
       "line_items": [
@@ -937,7 +940,8 @@
             3
           ],
           "reconciliation_status": "no-baseline",
-          "model_source": "swift-worker-v1"
+          "model_source": "swift-worker-v1",
+          "extractor_version": "swift-worker-v1+line-items-blocks-v2"
         }
       ],
       "needs_review": false

--- a/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/OCRResultContractTests.swift
+++ b/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/OCRResultContractTests.swift
@@ -147,14 +147,23 @@ final class OCRResultContractTests: XCTestCase {
 
         // On-device deterministic structure is additive to the established
         // receipt contract, including empty arrays when no items are decoded.
+        // Both provenance stamps are required: `model_source` names the
+        // producer (the Lambda skips its own section assigner for types the
+        // worker already wrote) and `extractor_version` names the producer +
+        // decode algorithm (the stream stage's consistency checker keys on it
+        // to tell worker rows from its own recompute).
         let sections = try XCTUnwrap(json["sections"] as? [[String: Any]])
         XCTAssertFalse(sections.isEmpty)
-        for section in sections {
+        let lineItems = try XCTUnwrap(json["line_items"] as? [[String: Any]])
+        for row in sections + lineItems {
             XCTAssertEqual(
-                section["model_source"] as? String, "swift-worker-v1"
+                row["model_source"] as? String, "swift-worker-v1"
+            )
+            XCTAssertEqual(
+                row["extractor_version"] as? String,
+                "swift-worker-v1+line-items-blocks-v2"
             )
         }
-        XCTAssertNotNil(json["line_items"] as? [[String: Any]])
     }
 
     func test_classification_encodes_python_parser_contract_keys() throws {

--- a/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/ReceiptStructurePipelineTests.swift
+++ b/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/ReceiptStructurePipelineTests.swift
@@ -208,6 +208,8 @@ import Testing
                         || got.reconciliationStatus
                             != wanted.reconciliationStatus
                         || got.modelSource != swiftWorkerModelSource
+                        || got.extractorVersion
+                            != swiftWorkerExtractorVersion
                     {
                         differences.append("item[\(got.itemIndex)]")
                     }
@@ -230,6 +232,7 @@ import Testing
             }
             if result.sections.contains(where: {
                 $0.modelSource != swiftWorkerModelSource
+                    || $0.extractorVersion != swiftWorkerExtractorVersion
             }) {
                 differences.append("section provenance")
             }
@@ -284,5 +287,32 @@ import Testing
         #expect(result.lineItems.count == 1)
         #expect(equalMoney(result.lineItems.first?.price, 3.99))
         #expect(result.lineItems.first?.modelSource == swiftWorkerModelSource)
+        #expect(
+            result.lineItems.first?.extractorVersion
+                == swiftWorkerExtractorVersion
+        )
+    }
+
+    /// The decoder version the worker stamps must stay equal to the canonical
+    /// Python `EXTRACTOR_VERSION`; a silent skew is what let the port fork
+    /// once already (STATE_OF_THE_SYSTEM warning #1).
+    @Test func extractorVersionTracksCanonicalPythonDecoder() throws {
+        let processor = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()  // ReceiptOCRCoreTests
+            .deletingLastPathComponent()  // Tests
+            .deletingLastPathComponent()  // receipt_ocr_swift
+            .appendingPathComponent(
+                "infra/receipt_line_item_updater/line_item_processor.py"
+            )
+        let source = try String(contentsOf: processor, encoding: .utf8)
+        #expect(
+            source.contains("EXTRACTOR_VERSION = \"\(swiftWorkerDecoderVersion)\""),
+            "Swift decoder version \(swiftWorkerDecoderVersion) no longer "
+                + "matches the canonical Python EXTRACTOR_VERSION"
+        )
+        #expect(
+            swiftWorkerExtractorVersion
+                == "\(swiftWorkerModelSource)+\(swiftWorkerDecoderVersion)"
+        )
     }
 }

--- a/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/ReceiptStructurePipelineTests.swift
+++ b/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/ReceiptStructurePipelineTests.swift
@@ -301,14 +301,20 @@ import Testing
             .deletingLastPathComponent()  // ReceiptOCRCoreTests
             .deletingLastPathComponent()  // Tests
             .deletingLastPathComponent()  // receipt_ocr_swift
+            .deletingLastPathComponent()  // repo root
             .appendingPathComponent(
                 "infra/receipt_line_item_updater/line_item_processor.py"
             )
         let source = try String(contentsOf: processor, encoding: .utf8)
+        let expected =
+            "EXTRACTOR_VERSION = \"\(swiftWorkerDecoderVersion)\""
         #expect(
-            source.contains("EXTRACTOR_VERSION = \"\(swiftWorkerDecoderVersion)\""),
-            "Swift decoder version \(swiftWorkerDecoderVersion) no longer "
-                + "matches the canonical Python EXTRACTOR_VERSION"
+            source.contains(expected),
+            Comment(
+                rawValue:
+                    "Swift decoder version \(swiftWorkerDecoderVersion) no "
+                    + "longer matches the canonical Python EXTRACTOR_VERSION"
+            )
         )
         #expect(
             swiftWorkerExtractorVersion

--- a/receipt_upload/receipt_upload/line_items/provenance.py
+++ b/receipt_upload/receipt_upload/line_items/provenance.py
@@ -1,0 +1,55 @@
+"""Producer provenance for sections and RECEIPT_LINE_ITEM rows.
+
+Two producers now write receipt structure:
+
+* the **Mac worker** (``receipt_ocr_swift``) decodes sections and line items
+  on device and ships them inside the single-pass OCR payload, and
+* the **stream stage** (``infra/receipt_line_item_updater``) recomputes them
+  in the cloud whenever a receipt's summary changes.
+
+Rows therefore have to say which one wrote them, so the stream stage can act
+as a CONSISTENCY CHECKER instead of an unconditional overwriter. The stamp
+lives in two fields that already exist on the entities:
+
+``ReceiptSection.model_source``
+    ``"swift-worker-v1"`` (worker) vs ``"upload-determinism-v1"`` (cloud).
+    May carry ``+``-joined suffixes appended by later repairs, e.g.
+    ``"swift-worker-v1+zone-gap-extend-v1"``.
+
+``ReceiptLineItem.extractor_version``
+    ``"swift-worker-v1+line-items-blocks-v2"`` (worker: build + algorithm)
+    vs ``"line-items-blocks-v2"`` (cloud: algorithm only). The worker build
+    prefix is what distinguishes the two, because a cloud recompute over a
+    worker-provided ITEMS section inherits ``source_model_source ==
+    "swift-worker-v1"`` and so cannot be told apart on that field alone.
+
+Keep ``SWIFT_WORKER_DECODER_VERSION`` equal to the Lambda's
+``EXTRACTOR_VERSION`` and to ``swiftWorkerDecoderVersion`` in
+``ReceiptStructurePipeline.swift``: a skew between the three is the signal
+that the Swift port has forked from the canonical Python decoder again.
+"""
+
+SWIFT_WORKER_MODEL_SOURCE = "swift-worker-v1"
+SWIFT_WORKER_DECODER_VERSION = "line-items-blocks-v2"
+SWIFT_WORKER_EXTRACTOR_VERSION = (
+    f"{SWIFT_WORKER_MODEL_SOURCE}+{SWIFT_WORKER_DECODER_VERSION}"
+)
+
+# Any worker build, not just today's, is "pre-computed on device".
+WORKER_PREFIX = "swift-worker-"
+
+
+def is_worker_extractor_version(extractor_version) -> bool:
+    """Whether a RECEIPT_LINE_ITEM row was written by a Mac worker build."""
+
+    return str(extractor_version or "").startswith(WORKER_PREFIX)
+
+
+def is_worker_model_source(model_source) -> bool:
+    """Whether a section was first proposed by a Mac worker build.
+
+    Tolerates the ``+``-joined repair suffixes later stages append to
+    ``model_source`` (e.g. ``zone-gap-extend-v1``).
+    """
+
+    return str(model_source or "").split("+")[0].startswith(WORKER_PREFIX)

--- a/receipt_upload/receipt_upload/merchant_resolution/embedding_processor.py
+++ b/receipt_upload/receipt_upload/merchant_resolution/embedding_processor.py
@@ -690,7 +690,7 @@ def _run_lines_pipeline_worker(
         merchant_name_matches_receipt,
     )
     from receipt_upload.section_assignment import (
-        MODEL_SOURCE,
+        VERIFIABLE_MODEL_SOURCES,
         assign_and_persist_sections,
     )
     from receipt_upload.section_verifier import verify_receipt_sections
@@ -838,16 +838,18 @@ def _run_lines_pipeline_worker(
                 )
                 from collections import Counter as _Counter
 
-                # NOTE: exact model_source match. The deterministic pipeline's
-                # sections are identified by MODEL_SOURCE verbatim (also in
-                # section_verifier._record_verification); provenance must ship
-                # in a separate additive field, never a model_source suffix.
+                # NOTE: exact model_source match against the deterministic
+                # producer set (also in
+                # section_verifier._record_verification) -- the cloud
+                # assigner and the Mac worker running the same assigner on
+                # device. Provenance must ship in a separate additive field,
+                # never a model_source suffix.
                 status_counts = _Counter(
                     section.verification_status
                     for section in dynamo.get_receipt_sections_from_receipt(
                         image_id, receipt_id
                     )
-                    if section.model_source == MODEL_SOURCE
+                    if section.model_source in VERIFIABLE_MODEL_SOURCES
                     and section.verification_status
                 )
                 verification_stats = {

--- a/receipt_upload/receipt_upload/section_assignment.py
+++ b/receipt_upload/receipt_upload/section_assignment.py
@@ -24,7 +24,18 @@ from receipt_dynamo.constants import ValidationStatus
 from receipt_dynamo.data.shared_exceptions import EntityAlreadyExistsError
 from receipt_dynamo.entities import ReceiptRow, ReceiptSection
 
+from receipt_upload.line_items.provenance import SWIFT_WORKER_MODEL_SOURCE
+
 MODEL_SOURCE = "upload-determinism-v1"
+
+# Sections the KNN verifier is allowed to annotate. The Mac worker runs the
+# SAME deterministic assigner on device and writes its proposals at ingest
+# (which suppresses a duplicate cloud proposal for those types), so leaving
+# them out would silently drop verification coverage for every worker-
+# produced receipt. Still an exact-match set, never a model_source
+# substring: repair stages append "+"-joined suffixes and those must not
+# accidentally qualify.
+VERIFIABLE_MODEL_SOURCES = frozenset({MODEL_SOURCE, SWIFT_WORKER_MODEL_SOURCE})
 _TOKEN_RE = re.compile(r"[a-z]+|\d+(?:\.\d+)?")
 _QUANTITY_RE = re.compile(
     r"(?:\b\d+\s*(?:@|x)\s*\$?\d)|(?:\b(?:each|ea)\b)|(?:/\s*lb\b)",

--- a/receipt_upload/receipt_upload/section_verifier.py
+++ b/receipt_upload/receipt_upload/section_verifier.py
@@ -19,7 +19,7 @@ from receipt_chroma import propagate_knn
 from receipt_dynamo.constants import ValidationStatus
 from receipt_dynamo.entities import ReceiptRow, ReceiptSection
 
-from receipt_upload.section_assignment import MODEL_SOURCE
+from receipt_upload.section_assignment import VERIFIABLE_MODEL_SOURCES
 
 VERIFICATION_SOURCE = "glyphstudio-knn-v1"
 KNN_NEIGHBORS = 15
@@ -182,7 +182,10 @@ def _record_verification(
     )
     now = datetime.now(timezone.utc)
     for section in sections:
-        if section.model_source != MODEL_SOURCE or not section.row_ids:
+        if (
+            section.model_source not in VERIFIABLE_MODEL_SOURCES
+            or not section.row_ids
+        ):
             continue
         available = [
             predictions[row_id]

--- a/receipt_upload/tests/test_line_item_boundary_extension.py
+++ b/receipt_upload/tests/test_line_item_boundary_extension.py
@@ -158,6 +158,12 @@ class _FakeDynamo:
     def get_receipt_rows_from_receipt(self, _image_id, _receipt_id):
         return [_row(1, 0.10), _row(2, 0.15), _row(3, 0.20)]
 
+    def get_receipt_line_items_from_receipt(self, _image_id, _receipt_id):
+        # No worker-written rows: the consistency checker is a no-op and the
+        # recompute is persisted exactly as it was before the Mac worker
+        # became a producer.
+        return list(self.line_items)
+
     def update_receipt_section(self, section):
         self.updated_sections.append(section)
 

--- a/receipt_upload/tests/test_line_item_worker_consistency.py
+++ b/receipt_upload/tests/test_line_item_worker_consistency.py
@@ -1,0 +1,349 @@
+"""The stream stage as a CONSISTENCY CHECKER over worker-written rows.
+
+Phase 2 of moving line-item production onto the Mac worker: the worker
+decodes sections + items on device and the ingest handler persists them, so
+by the time a summary change fires this Lambda the rows may already exist.
+It must then COMPARE rather than blindly overwrite.
+
+Pinned here:
+  1. no worker rows -> byte-identical to the pre-worker behavior
+  2. a strictly better worker result is preserved, not clobbered
+  3. a worse (or unrankable) worker result loses to the recompute
+  4. divergence is logged under a single queryable marker either way
+"""
+
+import json
+import logging
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+from infra.receipt_line_item_updater import line_item_processor
+from receipt_dynamo.entities.receipt_line_item import ReceiptLineItem
+
+from receipt_upload.line_items.provenance import (
+    SWIFT_WORKER_EXTRACTOR_VERSION,
+)
+
+IMAGE_ID = "11111111-2222-4333-8444-555555555555"
+RECEIPT_ID = 1
+CLOUD_EXTRACTOR_VERSION = line_item_processor.EXTRACTOR_VERSION
+
+
+# ---------------------------------------------------------------------------
+# Fixture receipt: three priced product rows summing to 9.00, which is also
+# the printed subtotal -- so the cloud recompute reconciles to "match".
+# ---------------------------------------------------------------------------
+
+_PRODUCTS = [("APPLES", 3.00), ("BREAD", 4.00), ("MILK", 2.00)]
+
+
+def _word(line_id, word_id, text, x, y):
+    return {
+        "line_id": line_id,
+        "word_id": word_id,
+        "text": text,
+        "x": x,
+        "y_mid": y,
+        "h": 0.01,
+    }
+
+
+def _product_words():
+    words = []
+    for index, (name, price) in enumerate(_PRODUCTS, start=1):
+        y = 0.10 + index * 0.05
+        words.append(_word(index, 1, name, 0.10, y))
+        words.append(_word(index, 2, f"{price:.2f}", 0.80, y))
+    return words
+
+
+def _items_section():
+    return SimpleNamespace(
+        section_type="ITEMS",
+        line_ids=[1, 2, 3],
+        row_ids=[1, 2, 3],
+        validation_status="PENDING",
+        model_source="swift-worker-v1",
+    )
+
+
+def _worker_row(item_index, name, price, extractor_version=None):
+    return ReceiptLineItem(
+        image_id=IMAGE_ID,
+        receipt_id=RECEIPT_ID,
+        item_index=item_index,
+        name=name,
+        price=f"{price:.2f}",
+        line_ids=[item_index + 1],
+        extractor_version=(
+            extractor_version or SWIFT_WORKER_EXTRACTOR_VERSION
+        ),
+        extracted_at=datetime(2026, 8, 1, tzinfo=timezone.utc),
+        reconciliation_status="no-baseline",
+        source_model_source="swift-worker-v1",
+        source_section_status="PENDING",
+    )
+
+
+class _FakeDynamo:
+    """Enough DynamoClient surface for one receipt's recompute."""
+
+    def __init__(self, stored_line_items=None, subtotal=9.00):
+        self.stored = list(stored_line_items or [])
+        self.subtotal = subtotal
+        self.written = []
+        self.deleted = 0
+
+    def list_receipt_words_from_receipt(self, _image_id, _receipt_id):
+        return [
+            SimpleNamespace(
+                line_id=word["line_id"],
+                word_id=word["word_id"],
+                text=word["text"],
+                bounding_box={
+                    "x": word["x"],
+                    "y": word["y_mid"] - word["h"] / 2,
+                    "height": word["h"],
+                },
+            )
+            for word in _product_words()
+        ]
+
+    def get_receipt_sections_from_receipt(self, _image_id, _receipt_id):
+        return [_items_section()]
+
+    def get_receipt_summary(self, _image_id, _receipt_id):
+        return SimpleNamespace(
+            summary=SimpleNamespace(
+                subtotal=self.subtotal,
+                tax=0.72,
+                grand_total=round(self.subtotal + 0.72, 2),
+                merchant_name="Test Mart",
+            )
+        )
+
+    def get_receipt_rows_from_receipt(self, _image_id, _receipt_id):
+        return []
+
+    def update_receipt_section(self, _section):
+        raise AssertionError("no boundary extension expected")
+
+    def get_receipt_line_items_from_receipt(self, _image_id, _receipt_id):
+        return list(self.stored)
+
+    def delete_receipt_line_items_for_receipt(self, _image_id, _receipt_id):
+        self.deleted = len(self.stored)
+        return self.deleted
+
+    def add_receipt_line_items(self, line_items):
+        self.written.extend(line_items)
+
+
+@pytest.fixture
+def run(monkeypatch):
+    def _run(fake):
+        monkeypatch.setattr(line_item_processor, "dynamo_client", fake)
+        monkeypatch.delenv("TRIGGER_REOCR_FUNCTION_NAME", raising=False)
+        return line_item_processor.update_receipt_line_items(
+            IMAGE_ID, RECEIPT_ID
+        )
+
+    return _run
+
+
+def _divergence_logs(caplog):
+    return [
+        json.loads(
+            record.getMessage().split(
+                line_item_processor.DIVERGENCE_MARKER + " ", 1
+            )[1]
+        )
+        for record in caplog.records
+        if line_item_processor.DIVERGENCE_MARKER in record.getMessage()
+    ]
+
+
+# ---------------------------------------------------------------------------
+# 1. Back-compat: nothing worker-written -> nothing changes
+# ---------------------------------------------------------------------------
+
+
+def test_no_worker_rows_keeps_the_pre_worker_behavior(run, caplog):
+    caplog.set_level(logging.INFO)
+    fake = _FakeDynamo()
+
+    result = run(fake)
+
+    assert result["reconciliation"] == "match"
+    assert result["worker_divergence"] is None
+    assert [item.name for item in fake.written] == [
+        name for name, _ in _PRODUCTS
+    ]
+    assert all(
+        item.extractor_version == CLOUD_EXTRACTOR_VERSION
+        for item in fake.written
+    )
+    assert _divergence_logs(caplog) == []
+
+
+def test_prior_cloud_rows_are_not_mistaken_for_worker_rows(run, caplog):
+    """A previous recompute's own rows must not trip the checker."""
+    caplog.set_level(logging.INFO)
+    stale = [
+        _worker_row(
+            index,
+            name,
+            price,
+            extractor_version=CLOUD_EXTRACTOR_VERSION,
+        )
+        for index, (name, price) in enumerate(_PRODUCTS)
+    ]
+    fake = _FakeDynamo(stored_line_items=stale)
+
+    result = run(fake)
+
+    assert result["worker_divergence"] is None
+    assert _divergence_logs(caplog) == []
+
+
+# ---------------------------------------------------------------------------
+# 2. A strictly better worker result survives the recompute
+# ---------------------------------------------------------------------------
+
+
+def test_strictly_better_worker_rows_are_not_clobbered(run, caplog):
+    """Worker reconciles to match; the recompute misses an item entirely.
+
+    A printed subtotal of 12.00 makes the cloud's three-item decode a
+    mismatch (delta -3.00) while the worker's four-item decode lands on the
+    baseline exactly -- smaller |delta| AND a better status, the two things
+    ``items_boundary_extension_guard`` demands.
+    """
+    caplog.set_level(logging.INFO)
+    worker = [
+        _worker_row(index, name, price)
+        for index, (name, price) in enumerate(_PRODUCTS + [("EGGS", 3.00)])
+    ]
+    fake = _FakeDynamo(stored_line_items=worker, subtotal=12.00)
+
+    result = run(fake)
+
+    assert result["reconciliation"] == "match"
+    assert [item.name for item in fake.written] == [
+        "APPLES",
+        "BREAD",
+        "MILK",
+        "EGGS",
+    ]
+    # Preserved rows keep the worker's provenance...
+    assert all(
+        item.extractor_version == SWIFT_WORKER_EXTRACTOR_VERSION
+        for item in fake.written
+    )
+    # ...and gain the context only the cloud has.
+    assert all(item.merchant_name == "Test Mart" for item in fake.written)
+    assert all(item.reconciliation_status == "match" for item in fake.written)
+    assert all(item.baseline_figures_agreeing for item in fake.written)
+
+    record = result["worker_divergence"]
+    assert record["decision"] == "keep-worker"
+    assert record["divergent"] == 1
+    assert record["worker_status"] == "match"
+    assert record["cloud_status"] == "mismatch"
+    assert record["worker_count"] == 4
+    assert record["cloud_count"] == 3
+    assert record["worker_extractor_version"] == (
+        SWIFT_WORKER_EXTRACTOR_VERSION
+    )
+    assert _divergence_logs(caplog) == [record]
+
+
+# ---------------------------------------------------------------------------
+# 3. A worse (or unrankable) worker result loses
+# ---------------------------------------------------------------------------
+
+
+def test_worse_worker_rows_lose_to_the_recompute(run, caplog):
+    caplog.set_level(logging.INFO)
+    worker = [_worker_row(0, "APPLES", 3.00)]
+    fake = _FakeDynamo(stored_line_items=worker)
+
+    result = run(fake)
+
+    assert result["reconciliation"] == "match"
+    assert [item.name for item in fake.written] == [
+        name for name, _ in _PRODUCTS
+    ]
+    assert all(
+        item.extractor_version == CLOUD_EXTRACTOR_VERSION
+        for item in fake.written
+    )
+    record = result["worker_divergence"]
+    assert record["decision"] == "keep-recompute"
+    assert record["divergent"] == 1
+    assert record["cloud_status"] == "match"
+    # The guard refuses to displace an already-matching recompute, and says
+    # so -- reusing the ITEMS-boundary wording verbatim.
+    assert "already reconciles" in record["guard_reason"]
+
+
+def test_agreeing_worker_rows_are_logged_but_not_flagged(run, caplog):
+    """Identical decodes still emit the marker, with divergent = 0.
+
+    The recompute wins by default (it carries the graded reconciliation),
+    but the line must exist so a CloudWatch query can measure the agreement
+    rate, not just the failures.
+    """
+    caplog.set_level(logging.INFO)
+    worker = [
+        _worker_row(index, name, price)
+        for index, (name, price) in enumerate(_PRODUCTS)
+    ]
+    fake = _FakeDynamo(stored_line_items=worker)
+
+    result = run(fake)
+
+    record = result["worker_divergence"]
+    assert record["divergent"] == 0
+    assert record["decision"] == "keep-recompute"
+    assert record["name_mismatches"] == 0
+    assert record["price_mismatches"] == 0
+    logged = _divergence_logs(caplog)
+    assert logged == [record]
+
+
+def test_divergence_marker_is_greppable_json(run, caplog):
+    """One marker, one JSON body -> a CloudWatch Insights filter."""
+    caplog.set_level(logging.INFO)
+    worker = [_worker_row(0, "APPLES", 3.00)]
+    fake = _FakeDynamo(stored_line_items=worker)
+
+    run(fake)
+
+    messages = [
+        record.getMessage()
+        for record in caplog.records
+        if record.getMessage().startswith(
+            line_item_processor.DIVERGENCE_MARKER
+        )
+    ]
+    assert len(messages) == 1
+    prefix, body = messages[0].split(" ", 1)
+    assert prefix == "LINE_ITEM_DIVERGENCE"
+    payload = json.loads(body)
+    assert set(payload) >= {
+        "image_id",
+        "receipt_id",
+        "divergent",
+        "decision",
+        "worker_count",
+        "cloud_count",
+        "worker_status",
+        "cloud_status",
+        "worker_delta",
+        "cloud_delta",
+        "name_mismatches",
+        "price_mismatches",
+        "worker_extractor_version",
+    }

--- a/receipt_upload/tests/test_section_verifier.py
+++ b/receipt_upload/tests/test_section_verifier.py
@@ -6,6 +6,7 @@ import pytest
 from receipt_dynamo.constants import ValidationStatus
 from receipt_dynamo.entities import ReceiptRow, ReceiptSection
 
+from receipt_upload.line_items.provenance import SWIFT_WORKER_MODEL_SOURCE
 from receipt_upload.section_assignment import MODEL_SOURCE
 from receipt_upload.section_verifier import verify_receipt_sections
 
@@ -44,6 +45,13 @@ class FakeDynamo:
 
 
 @pytest.mark.parametrize(
+    "model_source",
+    # The Mac worker runs the SAME deterministic assigner on device and its
+    # sections suppress a duplicate cloud proposal, so verification must
+    # cover both producers or worker receipts silently lose the KNN check.
+    [MODEL_SOURCE, SWIFT_WORKER_MODEL_SOURCE],
+)
+@pytest.mark.parametrize(
     ("current_status", "expected_status"),
     [
         (ValidationStatus.PENDING.value, ValidationStatus.PENDING.value),
@@ -51,7 +59,7 @@ class FakeDynamo:
     ],
 )
 def test_disagreement_is_recorded_without_overriding_sync_assignment(
-    current_status: str, expected_status: str
+    current_status: str, expected_status: str, model_source: str
 ) -> None:
     now = datetime(2026, 7, 14, tzinfo=timezone.utc)
     row = ReceiptRow(
@@ -74,7 +82,7 @@ def test_disagreement_is_recorded_without_overriding_sync_assignment(
         row_ids=[1],
         created_at=now,
         validation_status=current_status,
-        model_source=MODEL_SOURCE,
+        model_source=model_source,
     )
     valid_neighbor = ReceiptSection(
         image_id=_NEIGHBOR,


### PR DESCRIPTION
Phase 2 of moving line-item production onto the Mac worker. Builds on #1367 (decoder at 35/35 parity, expectations regenerated in CI).

One PR, not two: the Swift payload, the cloud reader, and the checker all key off the same two provenance stamps, and the Swift/Python contract fixture is shared between both test suites — splitting would land a half-wired contract in `main`.

## 1. Worker side

`ReceiptSectionPayload` / `ReceiptLineItemPayload` now carry **both** stamps:

| Field | Value | Meaning |
|---|---|---|
| `model_source` | `swift-worker-v1` | which producer |
| `extractor_version` | `swift-worker-v1+line-items-blocks-v2` | producer **+** decode algorithm |

Both are needed: a cloud recompute over a worker-provided ITEMS section inherits `source_model_source = "swift-worker-v1"`, so `model_source` alone cannot tell the two producers apart.

`swiftWorkerDecoderVersion` is pinned against the canonical Python `EXTRACTOR_VERSION` by a Swift test — the port cannot silently fork again (STATE_OF_THE_SYSTEM warning #1).

## 2. Cloud side

`OCRProcessor._process_swift_single_pass` persists worker sections and `RECEIPT_LINE_ITEM` rows at ingest, right after `persist_receipt_rows` (`ReceiptSection.row_ids` reference the rows that call materializes).

**Strictly additive.** A payload carrying neither `sections` nor `line_items` returns `None` and leaves ingest byte-identical — pinned by `test_worker_structure_is_ignored_when_the_payload_omits_it`.

Two hardening details:
- **Provenance is never taken on faith.** A payload claiming `upload-determinism-v1` or the bare cloud `extractor_version` is re-stamped as worker-written, so it can never hide from the checker.
- **Malformed rows are skipped individually.** Structure is a bonus on top of OCR persistence; it must never cost the receipt its words.

Downstream already knows how to defer: `assign_and_persist_sections` is additive-only, so worker sections suppress a duplicate cloud proposal rather than racing it. To stop that silently dropping KNN verification coverage, the verifier and its EMF counters now accept the deterministic producer **set** (`VERIFIABLE_MODEL_SOURCES`) instead of the cloud source verbatim.

## 3. Consistency checker

`infra/receipt_line_item_updater` still recomputes on every summary change. When worker rows already exist it **compares**:

- **The recompute wins by default** — today's behavior, and the only possible outcome for a receipt with no worker rows.
- **The worker's rows survive only when strictly better**, decided by `items_boundary_extension_guard(before=recompute, after=worker)` — the existing ITEMS-boundary guard, unchanged and unforked. Its refusals fall out correctly for free: a matching recompute is never displaced, and a `no-baseline` side is never ranked against a baselined one (the common case, since the worker decodes before any summary exists).
- Preserved rows keep the worker's **decode** and gain the cloud's **context** (merchant, graded reconciliation) that the worker had no way to know.

### Divergence is queryable

One log line per receipt carrying worker rows — WARNING when the decodes disagree, INFO when they agree, so the *agreement rate* is measurable too:

```
LINE_ITEM_DIVERGENCE {"image_id":…, "receipt_id":…, "divergent":0|1,
  "decision":"keep-worker"|"keep-recompute", "guard_reason":…,
  "worker_extractor_version":…, "worker_count":…, "cloud_count":…,
  "worker_status":…, "cloud_status":…, "worker_delta":…, "cloud_delta":…,
  "name_mismatches":…, "price_mismatches":…}
```

```
fields @timestamp, @message
| filter @message like /LINE_ITEM_DIVERGENCE/
| stats count() by divergent, decision
```

A rising `divergent` count while the two version strings agree is the Swift-fork signature — now visible in prod, not just in a failing test. Documented in `docs/architecture/mac-ocr-aws-handoff.md`.

## Tests

| Suite | Result |
|---|---|
| `receipt_upload/tests` (incl. golden regression) | **597 passed** |
| `infra/upload_images/container_ocr/handler/tests` | **86 passed** |
| Swift (`swift test`, on the mini) | **35 swift-testing + 53 XCTest** |

New coverage: 6 checker tests (`test_line_item_worker_consistency.py`) — back-compat no-op, prior cloud rows not mistaken for worker rows, strictly-better worker preserved, worse worker loses, agreement logged, marker is greppable JSON; 4 ingest tests (persist, back-compat, anti-impersonation, malformed-skip); verifier parametrized over both producers; Swift decoder-version pin + provenance assertions on the shared fixture.

Lint swept over all 11 changed `.py` files with CI's exact flags in one pass (warning #6: CI's per-file loop short-circuits).

3 pre-existing `GeometryTests` failures (IoU / `reorderBoxPoints`) reproduce identically on `origin/main` — unrelated, untouched here.

## Not done here

No deploys, no table writes. Note for whoever deploys: `receipt_upload/line_items/provenance.py` is registered as a new FileAsset in the line-item updater's `AssetArchive`, so that Lambda needs a redeploy before the checker is live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Swift OCR results now include extractor version information for receipt sections and line items.
  - Worker-generated receipt sections and line items are preserved during ingestion with provenance and validation metadata.
  - Cloud processing now compares worker results and retains higher-quality matches when appropriate.
- **Bug Fixes**
  - Improved redelivery handling safely replaces existing line items.
  - Malformed worker data is skipped individually without interrupting receipt processing.
  - Added structured divergence reporting when worker and cloud results differ.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->