### PR TITLE
docs(line-items): make the worker/cloud tie rule intentional, and log the unlogged skip

### DIFF
--- a/docs/architecture/mac-ocr-aws-handoff.md
+++ b/docs/architecture/mac-ocr-aws-handoff.md
@@ -111,27 +111,62 @@ Flow:
    Preserved rows keep the worker's decode and gain the merchant and graded
    reconciliation only the cloud has.
 
-### Querying divergence
+   **Ties go to the recompute, deliberately.** Both sides are deterministic
+   ports of the same decoder, so equal status and equal `|delta|` is the
+   *normal* outcome and the cloud overwrites the worker on essentially every
+   receipt — the worker survives only as the inherited
+   `source_model_source == "swift-worker-v1"`. That is not an oversight; the
+   rationale (the on-device contract has no `raw_text`, a tie is not an
+   identical decode, and the decoder version does not move when decoder
+   behavior does) is in `line_item_processor`'s module docstring. #1368's
+   deliverable is the agreement signal below, not the row's stamp.
 
-Every receipt that arrives carrying worker rows emits exactly one log line
-from the line-item updater:
+### Querying divergence and coverage
+
+Every receipt reaching the comparison emits exactly one log line from the
+line-item updater — and every receipt that *skips* the comparison emits the
+other one, so silence never has to be interpreted:
 
 ```
 LINE_ITEM_DIVERGENCE {"image_id": ..., "receipt_id": ..., "divergent": 0|1,
   "decision": "keep-worker"|"keep-recompute", "guard_reason": ...,
   "worker_extractor_version": ..., "worker_count": ..., "cloud_count": ...,
   "worker_status": ..., "cloud_status": ..., "worker_delta": ...,
-  "cloud_delta": ..., "name_mismatches": ..., "price_mismatches": ...}
+  "cloud_delta": ..., "name_mismatches": ..., "price_mismatches": ...,
+  "worker_rows_missing_raw_text": ...}
+
+LINE_ITEM_NO_WORKER_ROWS {"image_id": ..., "receipt_id": ...,
+  "stored_count": ..., "cloud_count": ..., "cloud_status": ...,
+  "worker_sourced_section": 0|1}
 ```
 
-WARNING when the two decodes disagree, INFO when they agree — so the
-agreement *rate* is measurable, not just the failures:
+DIVERGENCE is WARNING when the two decodes disagree and INFO when they
+agree; NO_WORKER_ROWS is always INFO. Without the second marker a receipt
+whose worker rows an earlier recompute already replaced looks identical to
+one that agreed, and the corpus-wide agreement rate is uncomputable —
+which is the whole point of the checker.
 
 ```
-fields @timestamp, @message
-| filter @message like /LINE_ITEM_DIVERGENCE/
-| parse @message 'LINE_ITEM_DIVERGENCE *' as body
-| stats count() by divergent, decision
+fields @timestamp,
+    (@message like /LINE_ITEM_NO_WORKER_ROWS/) as never_compared,
+    (@message like /"divergent": 0/) as agreed,
+    (@message like /"divergent": 1/) as diverged
+| filter @message like /LINE_ITEM_DIVERGENCE|LINE_ITEM_NO_WORKER_ROWS/
+| stats sum(agreed) as agreed,
+        sum(diverged) as diverged,
+        sum(never_compared) as never_compared
+```
+
+`agreed / (agreed + diverged)` is the cross-language agreement rate;
+`(agreed + diverged) / total` is comparison coverage. `worker_sourced_section`
+splits the skips into *already overwritten by a previous recompute* (1) and
+*outside worker coverage* (0) — count them separately or the second bucket
+absorbs the first:
+
+```
+fields @timestamp, (@message like /"worker_sourced_section": 1/) as seen
+| filter @message like /LINE_ITEM_NO_WORKER_ROWS/
+| stats sum(seen) as already_overwritten, count() - sum(seen) as no_worker
 ```
 
 A rising `divergent` count with matching `worker_extractor_version` and

--- a/infra/receipt_line_item_updater/line_item_processor.py
+++ b/infra/receipt_line_item_updater/line_item_processor.py
@@ -33,14 +33,104 @@ blindly overwriting:
   side). Preserved rows are re-stamped with the merchant/summary context the
   cloud has and the worker did not.
 
-Every receipt that arrives with worker rows emits one queryable log line
-prefixed ``LINE_ITEM_DIVERGENCE`` carrying a JSON body (counts, names,
-prices, both reconciliation statuses and deltas, and the decision), so
-divergence is a CloudWatch Insights filter, not an archaeology exercise::
+TIE HANDLING -- WHY THE CLOUD WINS
+----------------------------------
+A "tie" is equal reconciliation status AND equal |delta|. The guard
+resolves every one of them for the recompute (``shrinks`` is false when the
+deltas are equal, and a ``match`` baseline short-circuits before the
+comparison even runs). Because both implementations are deterministic ports
+of the same decoder, agreement -- and therefore a tie -- is the *normal*
+outcome, so this rule decides the steady state: the cloud's rows overwrite
+the worker's on essentially every receipt, and the worker survives only as
+the inherited ``source_model_source == "swift-worker-v1"``.
+
+That is deliberate, and it stays. Three findings, not one, drive it:
+
+1. **The worker's row payload is a strict SUBSET of the cloud's.** The
+   on-device JSON contract (``ReceiptLineItemPayload`` in
+   ``ReceiptStructurePipeline.swift``) has no ``raw_text`` field at all, so
+   every worker row lands with ``raw_text == ""``; ``collapsed_banding`` is
+   likewise cloud-only. Preferring the worker on ties would therefore *lose
+   the band text on every receipt it fired for* -- a corpus-wide data
+   regression in exchange for a provenance stamp. This is observable today:
+   dev ``2b630bec`` (IMG_3404) is the one live keep-worker receipt, and its
+   five preserved rows carry ``raw_text == ""`` while the byte-identical
+   prod copy carries ``"LEMON EACH $2.94"`` and friends. ``divergence
+   .worker_rows_missing_raw_text`` counts the cost so it stays auditable
+   instead of anecdotal.
+2. **A tie is not an identical decode.** ``(status, |delta|)`` is a
+   two-scalar projection: any regrouping that preserves the item sum --
+   merging or splitting bands, moving a name between adjacent rows -- ties
+   exactly while producing different rows. "Prefer the worker on ties"
+   would hand those cases to the worker on an arithmetic coincidence, not
+   on evidence that the worker was right.
+3. **Version-gated tie-breaking cannot detect the staleness it exists to
+   catch.** The obvious middle path -- prefer the worker only when its
+   decoder version is at or ahead of the cloud's -- assumes the version
+   moves when behavior does. It does not: #1369 shipped three real decoder
+   fixes (branded tender rows, the printed-total baseline, the OFF
+   substring bug) with ``line-items-blocks-v2`` unchanged on both sides. A
+   worker built before #1369 and a Lambda built after it are indis-
+   tinguishable by version string, which is exactly the skew the gate would
+   need to see. The gate becomes implementable the day
+   ``SWIFT_WORKER_DECODER_VERSION`` is bumped on every behavior change; it
+   is not implementable before then, and a gate that silently never fires
+   is worse than no gate.
+
+The asymmetry underneath all three: the Lambda redeploys with CI, while
+worker binaries need a manual ``scripts/update_ocr_workers.sh`` run after
+every ``receipt_ocr_swift`` merge. Preferring the freshest *deployable*
+decoder on a tie is the conservative default, and the strict-improvement
+escape hatch still lets a worker that is genuinely, arithmetically better
+win -- which is precisely what happened on dev IMG_3404 when dev's Lambda
+was running pre-#1369 code.
+
+None of this discards the on-device work: it is what makes the cloud a
+*checker*. The value #1368 delivers is the cross-implementation agreement
+signal below, not the ``extractor_version`` string on the row.
+
+MEASURING AGREEMENT FROM LOGS ALONE
+-----------------------------------
+Every receipt reaching the comparison emits exactly one queryable line:
+
+* ``LINE_ITEM_DIVERGENCE`` + JSON (counts, names, prices, both
+  reconciliation statuses and deltas, and the decision) when worker rows
+  were found and compared -- ``divergent`` is 0 or 1;
+* ``LINE_ITEM_NO_WORKER_ROWS`` + JSON when there were none to compare, so a
+  skip is a *countable* event rather than silence. Without it, a receipt
+  whose worker rows a previous recompute already replaced is indis-
+  tinguishable from one the worker never touched, and "no log line" reads
+  as consensus when it may mean no comparison happened at all.
+
+The skip record carries ``worker_sourced_section``: 1 means the ITEMS
+section was proposed by a worker, i.e. the worker *did* run on this receipt
+and its rows have since been overwritten -- a second recompute of an
+already-checked receipt, not a receipt outside worker coverage.
+
+Coverage and agreement rate, from these two markers alone::
+
+    fields @timestamp,
+        (@message like /LINE_ITEM_NO_WORKER_ROWS/) as never_compared,
+        (@message like /"divergent": 0/) as agreed,
+        (@message like /"divergent": 1/) as diverged
+    | filter @message like /LINE_ITEM_DIVERGENCE|LINE_ITEM_NO_WORKER_ROWS/
+    | stats sum(agreed) as agreed,
+            sum(diverged) as diverged,
+            sum(never_compared) as never_compared
+
+``agreed / (agreed + diverged)`` is the cross-language agreement rate;
+``(agreed + diverged) / total`` is comparison coverage. Split the skips
+into "already overwritten" vs "no worker ever ran"::
+
+    fields @timestamp, (@message like /"worker_sourced_section": 1/) as seen
+    | filter @message like /LINE_ITEM_NO_WORKER_ROWS/
+    | stats sum(seen) as already_overwritten, count() - sum(seen) as no_worker
+
+And the divergent receipts themselves, for triage::
 
     fields @timestamp, @message
     | filter @message like /LINE_ITEM_DIVERGENCE/
-    | filter divergent = 1
+    | filter @message like /"divergent": 1/
 """
 
 import json
@@ -64,6 +154,7 @@ from receipt_upload.line_items.geometry import (
 )
 from receipt_upload.line_items.provenance import (
     is_worker_extractor_version,
+    is_worker_model_source,
 )
 
 # isort: on
@@ -254,6 +345,7 @@ def update_receipt_line_items(
 
 
 DIVERGENCE_MARKER = "LINE_ITEM_DIVERGENCE"
+NO_WORKER_ROWS_MARKER = "LINE_ITEM_NO_WORKER_ROWS"
 
 
 def _delta(result: Any) -> float | None:
@@ -305,7 +397,13 @@ def _reconcile_with_worker_rows(
     conservative cases fall out for free -- a matching recompute is never
     displaced, and a no-baseline side is never ranked against a baselined
     one (which is exactly the common case, since the worker decodes before
-    any summary exists).
+    any summary exists). TIES GO TO THE RECOMPUTE, on purpose; see the
+    module docstring for why that is not a bug to be fixed.
+
+    The skip -- no worker rows to compare -- is LOGGED, not silent: see
+    ``NO_WORKER_ROWS_MARKER``. A silent skip makes an already-overwritten
+    receipt look exactly like an agreeing one in CloudWatch, which would
+    make the corpus-wide agreement rate uncomputable.
     """
     try:
         stored = dynamo_client.get_receipt_line_items_from_receipt(
@@ -319,6 +417,31 @@ def _reconcile_with_worker_rows(
         if is_worker_extractor_version(getattr(row, "extractor_version", None))
     ]
     if not worker_rows:
+        logger.info(
+            "%s %s",
+            NO_WORKER_ROWS_MARKER,
+            json.dumps(
+                {
+                    "image_id": image_id,
+                    "receipt_id": receipt_id,
+                    "stored_count": len(stored),
+                    "cloud_count": len(entities),
+                    "cloud_status": recon.status,
+                    # 1 => a worker DID decode this receipt and its rows
+                    # have already been replaced by an earlier recompute;
+                    # 0 => the receipt is outside worker coverage.
+                    "worker_sourced_section": int(
+                        any(
+                            is_worker_model_source(
+                                getattr(row, "source_model_source", None)
+                            )
+                            for row in stored
+                        )
+                    ),
+                },
+                sort_keys=True,
+            ),
+        )
         return entities, items, recon, None
 
     worker_rows = sorted(worker_rows, key=lambda row: row.item_index)
@@ -355,6 +478,12 @@ def _reconcile_with_worker_rows(
         "cloud_status": recon.status,
         "worker_delta": after["delta"],
         "cloud_delta": before["delta"],
+        # The on-device contract has no raw_text field, so preserving the
+        # worker's rows always costs the band text. Counted, not assumed --
+        # this is the measured price of the tie rule (module docstring).
+        "worker_rows_missing_raw_text": sum(
+            1 for row in worker_rows if not (row.raw_text or "")
+        ),
         "name_mismatches": sum(
             1
             for cloud, worker in zip(cloud_names, worker_names)

--- a/receipt_upload/tests/test_line_item_worker_consistency.py
+++ b/receipt_upload/tests/test_line_item_worker_consistency.py
@@ -9,7 +9,10 @@ Pinned here:
   1. no worker rows -> byte-identical to the pre-worker behavior
   2. a strictly better worker result is preserved, not clobbered
   3. a worse (or unrankable) worker result loses to the recompute
-  4. divergence is logged under a single queryable marker either way
+  4. a TIE (equal status, equal |delta|) goes to the recompute, on purpose
+  5. divergence is logged under a single queryable marker either way, and
+     the skip -- no worker rows to compare -- is logged too, so coverage
+     and the agreement rate are computable from logs alone
 """
 
 import json
@@ -152,16 +155,20 @@ def run(monkeypatch):
     return _run
 
 
-def _divergence_logs(caplog):
+def _marker_logs(caplog, marker):
     return [
-        json.loads(
-            record.getMessage().split(
-                line_item_processor.DIVERGENCE_MARKER + " ", 1
-            )[1]
-        )
+        json.loads(record.getMessage().split(marker + " ", 1)[1])
         for record in caplog.records
-        if line_item_processor.DIVERGENCE_MARKER in record.getMessage()
+        if record.getMessage().startswith(marker)
     ]
+
+
+def _divergence_logs(caplog):
+    return _marker_logs(caplog, line_item_processor.DIVERGENCE_MARKER)
+
+
+def _skip_logs(caplog):
+    return _marker_logs(caplog, line_item_processor.NO_WORKER_ROWS_MARKER)
 
 
 # ---------------------------------------------------------------------------
@@ -346,4 +353,202 @@ def test_divergence_marker_is_greppable_json(run, caplog):
         "name_mismatches",
         "price_mismatches",
         "worker_extractor_version",
+    }
+
+
+# ---------------------------------------------------------------------------
+# 4. Ties go to the recompute -- deliberately, not incidentally
+# ---------------------------------------------------------------------------
+
+
+def test_tie_on_status_and_delta_goes_to_the_recompute(run, caplog):
+    """Equal status AND equal |delta| is a tie, and the cloud wins it.
+
+    A printed subtotal of 12.00 leaves the cloud's three items (9.00) at
+    delta -3.00 / mismatch. The worker decodes only TWO items that also sum
+    to 9.00 -- a genuinely different decode with an identical arithmetic
+    projection. This is the steady-state case (both sides are ports of the
+    same decoder, so agreement is normal), and preferring the worker here
+    would hand the rows over on a coincidence of sums while dropping the
+    band text the on-device contract has no field for.
+    """
+    caplog.set_level(logging.INFO)
+    worker = [
+        _worker_row(index, name, price)
+        for index, (name, price) in enumerate(
+            [("BUNDLE", 5.00), ("BREAD", 4.00)]
+        )
+    ]
+    fake = _FakeDynamo(stored_line_items=worker, subtotal=12.00)
+
+    result = run(fake)
+
+    record = result["worker_divergence"]
+    assert record["worker_status"] == record["cloud_status"] == "mismatch"
+    assert record["worker_delta"] == record["cloud_delta"] == -3.00
+    assert record["decision"] == "keep-recompute"
+    assert "Arithmetic guard failed" in record["guard_reason"]
+    # The recompute's rows -- and its raw_text -- are what get stored.
+    assert [item.name for item in fake.written] == [
+        name for name, _ in _PRODUCTS
+    ]
+    assert all(
+        item.extractor_version == CLOUD_EXTRACTOR_VERSION
+        for item in fake.written
+    )
+
+
+def test_strict_improvement_still_beats_the_tie_rule(run):
+    """The tie rule must not swallow the strict-improvement escape hatch.
+
+    Same fixture as the tie test, but the worker's extra item closes the
+    3.00 gap exactly: strictly smaller |delta| AND a better status, so the
+    worker still wins. This is the dev IMG_3404 shape -- a Lambda running
+    older decoder code losing to a worker that is arithmetically right.
+    """
+    worker = [
+        _worker_row(index, name, price)
+        for index, (name, price) in enumerate(_PRODUCTS + [("EGGS", 3.00)])
+    ]
+    fake = _FakeDynamo(stored_line_items=worker, subtotal=12.00)
+
+    result = run(fake)
+
+    assert result["worker_divergence"]["decision"] == "keep-worker"
+    assert abs(result["worker_divergence"]["worker_delta"]) < abs(
+        result["worker_divergence"]["cloud_delta"]
+    )
+    assert all(
+        item.extractor_version == SWIFT_WORKER_EXTRACTOR_VERSION
+        for item in fake.written
+    )
+
+
+def test_strict_regression_is_still_rejected(run):
+    """A worker that widens |delta| loses even against a non-match cloud."""
+    worker = [_worker_row(0, "APPLES", 3.00)]
+    fake = _FakeDynamo(stored_line_items=worker, subtotal=12.00)
+
+    result = run(fake)
+
+    record = result["worker_divergence"]
+    assert record["decision"] == "keep-recompute"
+    assert abs(record["worker_delta"]) > abs(record["cloud_delta"])
+    assert all(
+        item.extractor_version == CLOUD_EXTRACTOR_VERSION
+        for item in fake.written
+    )
+
+
+def test_preserving_the_worker_costs_the_band_text(run):
+    """The measured price of ever preferring the worker, made countable.
+
+    ``ReceiptLineItemPayload`` (Swift) has no ``raw_text`` field, so worker
+    rows always arrive with an empty one. The divergence record counts them
+    so the cost of the keep-worker path is auditable in CloudWatch rather
+    than anecdotal.
+    """
+    worker = [
+        _worker_row(index, name, price)
+        for index, (name, price) in enumerate(_PRODUCTS + [("EGGS", 3.00)])
+    ]
+    fake = _FakeDynamo(stored_line_items=worker, subtotal=12.00)
+
+    result = run(fake)
+
+    assert result["worker_divergence"]["decision"] == "keep-worker"
+    assert result["worker_divergence"]["worker_rows_missing_raw_text"] == 4
+    assert all(item.raw_text == "" for item in fake.written)
+
+
+# ---------------------------------------------------------------------------
+# 5. The skip is countable, so agreement rate is computable from logs alone
+# ---------------------------------------------------------------------------
+
+
+def test_no_worker_rows_emits_the_skip_marker_exactly_once(run, caplog):
+    caplog.set_level(logging.INFO)
+    fake = _FakeDynamo()
+
+    run(fake)
+
+    skips = _skip_logs(caplog)
+    assert len(skips) == 1
+    assert skips[0] == {
+        "image_id": IMAGE_ID,
+        "receipt_id": RECEIPT_ID,
+        "stored_count": 0,
+        "cloud_count": 3,
+        "cloud_status": "match",
+        "worker_sourced_section": 0,
+    }
+    # ...and it is NOT a divergence line: the two markers are disjoint so a
+    # CloudWatch query can bucket them independently.
+    assert _divergence_logs(caplog) == []
+
+
+def test_skip_marker_flags_an_already_overwritten_receipt(run, caplog):
+    """The case silence used to hide: worker ran, cloud already replaced it.
+
+    Rows stamped with the cloud's extractor_version but inheriting
+    ``source_model_source == "swift-worker-v1"`` are a second recompute of a
+    receipt the worker DID decode -- not a receipt outside worker coverage.
+    Counting the two together would inflate the "never compared" bucket.
+    """
+    caplog.set_level(logging.INFO)
+    overwritten = [
+        _worker_row(
+            index, name, price, extractor_version=CLOUD_EXTRACTOR_VERSION
+        )
+        for index, (name, price) in enumerate(_PRODUCTS)
+    ]
+    fake = _FakeDynamo(stored_line_items=overwritten)
+
+    run(fake)
+
+    skips = _skip_logs(caplog)
+    assert len(skips) == 1
+    assert skips[0]["worker_sourced_section"] == 1
+    assert skips[0]["stored_count"] == 3
+
+
+def test_skip_marker_is_absent_whenever_a_comparison_happened(run, caplog):
+    """Every receipt emits exactly one of the two markers, never both."""
+    caplog.set_level(logging.INFO)
+    worker = [
+        _worker_row(index, name, price)
+        for index, (name, price) in enumerate(_PRODUCTS)
+    ]
+    fake = _FakeDynamo(stored_line_items=worker)
+
+    run(fake)
+
+    assert _skip_logs(caplog) == []
+    assert len(_divergence_logs(caplog)) == 1
+
+
+def test_skip_marker_is_greppable_json(run, caplog):
+    caplog.set_level(logging.INFO)
+
+    run(_FakeDynamo())
+
+    messages = [
+        record.getMessage()
+        for record in caplog.records
+        if record.getMessage().startswith(
+            line_item_processor.NO_WORKER_ROWS_MARKER
+        )
+    ]
+    assert len(messages) == 1
+    prefix, body = messages[0].split(" ", 1)
+    assert prefix == "LINE_ITEM_NO_WORKER_ROWS"
+    # The documented CloudWatch bucketing greps these literals.
+    assert '"worker_sourced_section": 0' in body
+    assert set(json.loads(body)) >= {
+        "image_id",
+        "receipt_id",
+        "stored_count",
+        "cloud_count",
+        "cloud_status",
+        "worker_sourced_section",
     }


### PR DESCRIPTION
## Summary

#1368 made the Mac worker produce line items on device and the cloud stream stage a consistency checker. Landing three fresh receipts through the real chain (IMG_3404 TJ, IMG_3411 Regal, IMG_3420 TJ — dev + prod = six copies) showed what that means in steady state: both sides are deterministic ports of the same decoder, they agree exactly, so the worker never *strictly* improves and the cloud's rows overwrite the worker's on every receipt. Five of six copies are cloud-stamped; the one survivor (dev `2b630bec`) won only because dev's Lambda was running pre-#1369 code and produced a genuinely worse result.

This PR makes that outcome **intentional and documented**, and makes the checker's coverage **countable**. No decision behaviour changes.

## Tie decision: the cloud keeps winning ties

I went in expecting to flip it. Three findings say don't.

**1. The worker's row payload is a strict SUBSET of the cloud's.** `ReceiptLineItemPayload` in `ReceiptStructurePipeline.swift` has no `raw_text` field at all (nor `collapsed_banding`), so every worker row lands with `raw_text == ""`. Preferring the worker on ties would trade the band text on every receipt it fired for, in exchange for a provenance stamp. This is live, not theoretical — dev `2b630bec`'s five preserved worker rows:

```
'LEMON EACH'  2.94  raw=''
'SALMON FILLET SKIN OFF'  10.85  raw=''
```

versus the byte-identical prod copy `1bd6f221`:

```
'LEMON EACH'  2.94  raw='LEMON EACH $2.94'
'SALMON FILLET SKIN OFF'  10.85  raw='SALMON FILLET SKIN OFF C $10.85'
```

Across the six copies that is **26 rows** that would go from populated `raw_text` to empty.

**2. A tie is not an identical decode.** `(status, |delta|)` is a two-scalar projection. Any regrouping that preserves the item sum — merging or splitting bands, moving a name between adjacent rows — ties exactly while producing different rows. "Prefer the worker on ties" hands those over on an arithmetic coincidence, not on evidence the worker was right.

**3. The version-gated middle path cannot detect the staleness it exists to catch.** It assumes the decoder version moves when behaviour does. It doesn't: #1369 shipped three real decoder fixes (branded tender rows, printed-total baseline, the `OFF` substring bug) with `line-items-blocks-v2` unchanged on *both* sides. A pre-#1369 worker and a post-#1369 Lambda are indistinguishable by version string — exactly the skew the gate would need to see. A gate that silently never fires is worse than no gate. It becomes implementable the day `SWIFT_WORKER_DECODER_VERSION` is bumped on every behaviour change; that is stated in the docstring as the precondition.

Underneath all three: the Lambda redeploys with CI, worker binaries need a manual `scripts/update_ocr_workers.sh` after every `receipt_ocr_swift` merge. Preferring the freshest *deployable* decoder on a tie is the conservative default, and the strict-improvement escape hatch is untouched — a worker that is arithmetically better still wins, which is precisely what happened on dev IMG_3404.

The reframe: #1368's deliverable is the **cross-implementation agreement signal**, not the `extractor_version` string on the row. Which is what the rest of this PR makes measurable.

## Skip marker

`if not worker_rows: return entities, items, recon, None` emitted nothing. A receipt whose worker rows an earlier recompute had already replaced was indistinguishable in logs from one that agreed — silence read as consensus, and the corpus agreement rate was uncomputable.

```
LINE_ITEM_NO_WORKER_ROWS {"cloud_count": 5, "cloud_status": "match",
  "image_id": "1bd6f221-...", "receipt_id": 1, "stored_count": 5,
  "worker_sourced_section": 1}
```

INFO, one per skipped receipt. `worker_sourced_section` is the load-bearing field: `1` means the ITEMS section was worker-proposed, i.e. the worker *did* decode this receipt and its rows are already gone (a second recompute of an already-checked receipt); `0` means the receipt is outside worker coverage. Counting them together would let the "no worker ever ran" bucket absorb the "already overwritten" one.

Every receipt now emits exactly one of the two markers, so agreement rate and coverage come from logs alone:

```
fields @timestamp,
    (@message like /LINE_ITEM_NO_WORKER_ROWS/) as never_compared,
    (@message like /"divergent": 0/) as agreed,
    (@message like /"divergent": 1/) as diverged
| filter @message like /LINE_ITEM_DIVERGENCE|LINE_ITEM_NO_WORKER_ROWS/
| stats sum(agreed) as agreed, sum(diverged) as diverged,
        sum(never_compared) as never_compared
```

`agreed / (agreed + diverged)` is the agreement rate; `(agreed + diverged) / total` is coverage. (The previously documented `| filter divergent = 1` never worked — Insights does not extract fields from JSON embedded in a larger message. The queries here grep the literals `json.dumps(sort_keys=True)` emits.)

Also adds `worker_rows_missing_raw_text` to the divergence record so finding 1 stays auditable in prod rather than anecdotal.

## Six-copy replay (read-only, live tables)

Replayed the full stage against `ReceiptsTable-dc5be22` and `ReceiptsTable-d7ff76a` with every mutating client method intercepted. Pass A = table as it stands today; pass B = worker rows reconstructed (same decode, `raw_text=""`, worker stamp) to model the moment the cloud first recomputed.

| Receipt | Copy | Stored today | Replay decision | Marker | Changed by this PR? |
|---|---|---|---|---|---|
| IMG_3404 TJ, 5 items 37.51 | dev `2b630bec` | 5 rows, **worker**-stamped | keep-recompute (tie: both `match`, both delta 0.00) | `DIVERGENCE divergent=0` | No |
| IMG_3404 TJ | prod `1bd6f221` | 5 rows, cloud | A: skip · B: keep-recompute (tie) | A: `NO_WORKER_ROWS worker_sourced_section=1` · B: `DIVERGENCE divergent=0` | No |
| IMG_3411 Regal, 1 item 12.99 | dev `67b149c0` | 1 row, cloud | A: skip · B: keep-recompute (tie) | same shape | No |
| IMG_3411 Regal | prod `9aeacb6a` | 1 row, cloud | A: skip · B: keep-recompute (tie) | same shape | No |
| IMG_3420 TJ, 7 items 39.49 | dev `90af9793` | 7 rows, cloud | A: skip · B: keep-recompute (tie) | same shape | No |
| IMG_3420 TJ | prod `082136bd` | 7 rows, cloud | A: skip · B: keep-recompute (tie) | same shape | No |

**All six unchanged.** Every copy reconciles at `match` with cloud delta 0.00 and worker delta 0.00 — a perfect tie in which the guard short-circuits on `"Current ITEMS zone already reconciles (match); nothing to repair."` before it ever compares deltas. `worker_rows_missing_raw_text` is 5/1/7 — **100% of worker rows in every copy**, which is finding 1 measured rather than argued.

Two things the replay surfaced that are worth knowing:

- **Every skip in the corpus reports `worker_sourced_section: 1`.** All five cloud-stamped copies are receipts the worker *did* decode and whose rows were already replaced. Before this PR all five were silent and indistinguishable from receipts the worker never touched.
- **dev `2b630bec` is about to stop being worker-stamped.** Pass A runs post-#1369 code and produces the same 5 items at `match` — so the next summary change after dev's Lambda is redeployed will overwrite the last worker-stamped copy in the corpus. Expected, and the reason "the worker is the producer" needs the log signal rather than the row stamp to be true.

## Verification

- 14 tests in `test_line_item_worker_consistency.py` (was 6), all passing. New: tie goes to the recompute, strict improvement still beats the tie rule, strict regression still rejected, preserving the worker costs the band text, skip marker fires exactly once, skip marker flags an already-overwritten receipt, the two markers are mutually exclusive, skip marker is greppable JSON.
- 27 tests across all four `infra`-importing line-item modules pass.
- CI lint replicated in a bare 3.12 venv built exactly as `main.yml`'s `receipt_upload` job: `black --check --line-length=79 receipt_upload` and `isort --check-only --profile=black --line-length=79 receipt_upload` clean, plus the `receipt_agent` job's per-file sweep over **both** changed `.py` files at once.
- `lambda-syntax`: `py_compile` clean on the changed infra file.

Note: `provenance.py` already ships whole via its existing FileAsset, so `is_worker_model_source` needs no bundle wiring change. No new module added.

**Pre-existing gap, not introduced here:** the four `receipt_upload` test modules that `import infra.*` (including this one and three I didn't touch) fail to collect under CI's `cd receipt_upload && pytest tests`, because that makes `receipt_upload/` the rootdir and the repo root is not on `sys.path`. They pass from the repo root. Worth a separate fix — as written, these tests are not actually guarding anything in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TzUnnRheR1xinDRCS6s4fB


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Observability**
  * Improved receipt reconciliation logs with cloud-versus-worker differences, missing text counts, stored/cloud totals, and worker-data provenance.
  * Added clear markers for receipts skipped because no comparable worker line items were available.
  * Added CloudWatch queries for agreement, divergence, coverage, and previously overwritten worker data.
* **Documentation**
  * Clarified tie handling and reconciliation outcomes between cloud and worker data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->