### PR TITLE
fix(summary): count real line items, and reject address-as-merchant-name

### DIFF
--- a/infra/receipt_summary_updater/summary_processor.py
+++ b/infra/receipt_summary_updater/summary_processor.py
@@ -129,6 +129,28 @@ def update_receipt_summary(image_id: str, receipt_id: int) -> dict[str, Any]:
             receipt_id,
         )
 
+    # item_count: prefer the receipt's extracted ReceiptLineItem rows over
+    # the legacy "count VALID LINE_TOTAL labels" rule. Receipts ingested
+    # through the current pipeline never get LINE_TOTAL labels, so the
+    # label rule reported 0 for receipts that hold real line items.
+    #
+    # Ordering caveat: a summary write is what triggers the line-item
+    # updater (RECEIPT_SUMMARY -> LINE_ITEMS queue), so on a receipt's
+    # FIRST summary write there are no rows yet and the count still falls
+    # back to labels. It becomes correct on the next recompute (any label
+    # or place change). A stream back-edge from RECEIPT_LINE_ITEM to this
+    # queue is deliberately NOT added: the line-item updater
+    # delete-then-inserts every row on each run, so that edge would be an
+    # unbounded recompute loop.
+    try:
+        line_item_count = len(
+            dynamo_client.get_receipt_line_items_from_receipt(
+                image_id, receipt_id
+            )
+        )
+    except EntityNotFoundError:
+        line_item_count = 0
+
     # Compute summary from labels and words
     summary = ReceiptSummary.from_word_labels_and_words(
         image_id=image_id,
@@ -142,6 +164,7 @@ def update_receipt_summary(image_id: str, receipt_id: int) -> dict[str, Any]:
         ledger=ledger,
         bank_amount=bank_amount,
         bank_match_confidence=bank_match_confidence,
+        line_item_count=line_item_count,
     )
 
     # Convert to record and upsert

--- a/receipt_dynamo/receipt_dynamo/entities/receipt_summary.py
+++ b/receipt_dynamo/receipt_dynamo/entities/receipt_summary.py
@@ -580,6 +580,47 @@ def _apply_printed_total_fallback(
 
 
 # =============================================================================
+# item_count resolution
+# =============================================================================
+
+
+def resolve_item_count(
+    label_item_count: int,
+    line_item_count: int | None,
+) -> int:
+    """Pick the authoritative item count for a receipt summary.
+
+    ``item_count`` has two possible sources and they do not agree:
+
+    * ``ReceiptLineItem`` rows -- the real extracted line items (name,
+      price, line_ids), written by the line-item updater's band-block
+      decoder. This is the authoritative count when rows exist.
+    * VALID ``LINE_TOTAL`` word labels -- the legacy source. Receipts
+      ingested through the current pipeline never receive ``LINE_TOTAL``
+      labels at all, which is why freshly-ingested receipts holding real
+      line items still reported ``item_count == 0``.
+
+    The label count is kept as the fallback rather than dropped: a
+    receipt can carry ``LINE_TOTAL`` labels while the line-item extractor
+    produced no rows (no ITEMS zone, decode declined). Preferring rows
+    only when they exist raises the fresh-ingest receipts to a correct
+    count without regressing those to zero.
+
+    Args:
+        label_item_count: Count of VALID ``LINE_TOTAL`` word labels.
+        line_item_count: Count of ``ReceiptLineItem`` rows, or ``None``
+            when the caller did not look them up (in which case the
+            legacy label count is used unchanged).
+
+    Returns:
+        The item count to store on the summary.
+    """
+    if line_item_count:
+        return line_item_count
+    return label_item_count
+
+
+# =============================================================================
 # ReceiptSummary dataclass
 # =============================================================================
 
@@ -597,7 +638,11 @@ class ReceiptSummary(ReceiptIdentifierMixin):
         merchant_name: Name of the merchant (from ReceiptPlace).
         date: Date of the receipt (parsed from DATE label).
         totals: Grouped monetary totals (grand_total, subtotal, tax, tip).
-        item_count: Number of line items (count of LINE_TOTAL labels).
+        item_count: Number of line items on the receipt. Preferred source
+            is the receipt's extracted ``ReceiptLineItem`` rows; the count
+            of VALID ``LINE_TOTAL`` word labels is the fallback for
+            receipts the line-item extractor has not produced rows for.
+            See :func:`resolve_item_count`.
         tender_class: How the receipt was paid -- ``cash``, ``card`` or
             ``unknown`` (None when tender was never classified).
         card_network: Card network printed on the receipt
@@ -712,6 +757,8 @@ class ReceiptSummary(ReceiptIdentifierMixin):
         place: "ReceiptPlace | None",
         word_labels: list["ReceiptWordLabel"],
         words: list["ReceiptWord"],
+        *,
+        line_item_count: int | None = None,
     ) -> "ReceiptSummary":
         """Compute a summary from receipt data.
 
@@ -720,6 +767,9 @@ class ReceiptSummary(ReceiptIdentifierMixin):
             place: The ReceiptPlace entity (may be None if not matched).
             word_labels: List of ReceiptWordLabel records for this receipt.
             words: List of ReceiptWord records for this receipt.
+            line_item_count: Number of ``ReceiptLineItem`` rows the
+                receipt currently holds. Preferred over the LINE_TOTAL
+                label count when non-zero (see :func:`resolve_item_count`).
 
         Returns:
             A ReceiptSummary with computed fields.
@@ -741,7 +791,7 @@ class ReceiptSummary(ReceiptIdentifierMixin):
             merchant_name=place.merchant_name if place else None,
             date=date,
             totals=totals,
-            item_count=item_count,
+            item_count=resolve_item_count(item_count, line_item_count),
         )
 
     @classmethod
@@ -759,6 +809,7 @@ class ReceiptSummary(ReceiptIdentifierMixin):
         ledger: str | None = None,
         bank_amount: float | None = None,
         bank_match_confidence: float | None = None,
+        line_item_count: int | None = None,
     ) -> "ReceiptSummary":
         """Compute a summary from word labels and words directly.
 
@@ -777,6 +828,9 @@ class ReceiptSummary(ReceiptIdentifierMixin):
             ledger: Optional bank ledger (chase/apple/none).
             bank_amount: Optional matched bank transaction amount.
             bank_match_confidence: Optional match confidence in [0, 1].
+            line_item_count: Number of ``ReceiptLineItem`` rows the
+                receipt currently holds. Preferred over the LINE_TOTAL
+                label count when non-zero (see :func:`resolve_item_count`).
 
         Returns:
             A ReceiptSummary with computed fields.
@@ -798,7 +852,7 @@ class ReceiptSummary(ReceiptIdentifierMixin):
             merchant_name=merchant_name,
             date=date,
             totals=totals,
-            item_count=item_count,
+            item_count=resolve_item_count(item_count, line_item_count),
             tender_class=tender_class,
             card_network=card_network,
             card_last4=card_last4,

--- a/receipt_dynamo/tests/unit/test_receipt_summary_item_count.py
+++ b/receipt_dynamo/tests/unit/test_receipt_summary_item_count.py
@@ -1,0 +1,139 @@
+"""``item_count`` prefers real ReceiptLineItem rows over LINE_TOTAL labels.
+
+Receipts ingested through the current pipeline never receive
+``LINE_TOTAL`` word labels -- their line items are ``ReceiptLineItem``
+rows written by the line-item updater's band-block decoder. The legacy
+"count VALID LINE_TOTAL labels" rule therefore reported ``item_count ==
+0`` for freshly-ingested receipts that hold real line items (observed on
+IMG_3404 / IMG_3411 / IMG_3420, holding 5 / 1 / 7 items).
+
+The label count stays as the fallback: 25 prod summaries carry
+LINE_TOTAL labels while the extractor produced no rows, and those must
+not regress to zero.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from receipt_dynamo.constants import ValidationStatus
+from receipt_dynamo.entities.receipt_summary import (
+    ReceiptSummary,
+    resolve_item_count,
+)
+from receipt_dynamo.entities.receipt_word_label import ReceiptWordLabel
+
+pytestmark = pytest.mark.unit
+
+IMAGE_ID = "2b630bec-ecd6-4c22-b9de-554dca66c146"
+TIMESTAMP = "2026-01-01T00:00:00.000+00:00"
+
+
+def _word(line_id: int, word_id: int, text: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        line_id=line_id,
+        word_id=word_id,
+        text=text,
+        bounding_box={
+            "x": 0.1,
+            "y": 0.5 - line_id * 0.02,
+            "width": 0.2,
+            "height": 0.012,
+        },
+    )
+
+
+def _line_total_label(line_id: int) -> ReceiptWordLabel:
+    return ReceiptWordLabel(
+        image_id=IMAGE_ID,
+        receipt_id=1,
+        line_id=line_id,
+        word_id=1,
+        label="LINE_TOTAL",
+        reasoning=None,
+        timestamp_added=TIMESTAMP,
+        validation_status=ValidationStatus.VALID.value,
+    )
+
+
+class TestResolveItemCount:
+    """The resolution rule itself."""
+
+    def test_line_items_win_when_present(self) -> None:
+        assert resolve_item_count(label_item_count=0, line_item_count=5) == 5
+
+    def test_line_items_win_even_when_labels_disagree(self) -> None:
+        assert resolve_item_count(label_item_count=3, line_item_count=7) == 7
+
+    def test_falls_back_to_labels_when_no_rows(self) -> None:
+        assert resolve_item_count(label_item_count=4, line_item_count=0) == 4
+
+    def test_falls_back_to_labels_when_not_looked_up(self) -> None:
+        assert (
+            resolve_item_count(label_item_count=4, line_item_count=None) == 4
+        )
+
+    def test_zero_when_neither_source_has_anything(self) -> None:
+        assert resolve_item_count(label_item_count=0, line_item_count=0) == 0
+
+
+class TestFromWordLabelsAndWords:
+    """The constructor the summary updater Lambda calls."""
+
+    def test_fresh_ingest_receipt_counts_line_item_rows(self) -> None:
+        """IMG_3404: no LINE_TOTAL labels, 5 ReceiptLineItem rows."""
+        summary = ReceiptSummary.from_word_labels_and_words(
+            image_id=IMAGE_ID,
+            receipt_id=1,
+            merchant_name="Trader Joe's",
+            word_labels=[],
+            words=[_word(1, 1, "TRADER")],
+            line_item_count=5,
+        )
+        assert summary.item_count == 5
+
+    def test_no_rows_keeps_legacy_label_count(self) -> None:
+        summary = ReceiptSummary.from_word_labels_and_words(
+            image_id=IMAGE_ID,
+            receipt_id=1,
+            merchant_name="Sprouts Farmers Market",
+            word_labels=[_line_total_label(3), _line_total_label(4)],
+            words=[_word(3, 1, "2.99"), _word(4, 1, "3.49")],
+            line_item_count=0,
+        )
+        assert summary.item_count == 2
+
+    def test_omitting_the_argument_is_backwards_compatible(self) -> None:
+        summary = ReceiptSummary.from_word_labels_and_words(
+            image_id=IMAGE_ID,
+            receipt_id=1,
+            merchant_name="Sprouts Farmers Market",
+            word_labels=[_line_total_label(3)],
+            words=[_word(3, 1, "2.99")],
+        )
+        assert summary.item_count == 1
+
+
+class TestFromReceiptData:
+    """The other constructor keeps the same rule."""
+
+    def test_line_item_rows_win(self) -> None:
+        receipt = SimpleNamespace(image_id=IMAGE_ID, receipt_id=1)
+        summary = ReceiptSummary.from_receipt_data(
+            receipt=receipt,
+            place=SimpleNamespace(merchant_name="Trader Joe's"),
+            word_labels=[],
+            words=[_word(1, 1, "TRADER")],
+            line_item_count=7,
+        )
+        assert summary.item_count == 7
+
+    def test_defaults_to_labels(self) -> None:
+        receipt = SimpleNamespace(image_id=IMAGE_ID, receipt_id=1)
+        summary = ReceiptSummary.from_receipt_data(
+            receipt=receipt,
+            place=None,
+            word_labels=[_line_total_label(3)],
+            words=[_word(3, 1, "2.99")],
+        )
+        assert summary.item_count == 1

--- a/receipt_upload/receipt_upload/merchant_resolution/resolver.py
+++ b/receipt_upload/receipt_upload/merchant_resolution/resolver.py
@@ -553,6 +553,175 @@ def merchant_name_matches_receipt(
     return False
 
 
+# Street-type tokens that terminate a US street address. Used only to
+# recognise a Places ``displayName`` that is really a street address, never
+# to parse an address.
+_STREET_SUFFIX_TOKENS = (
+    "st|street|ave|avenue|blvd|boulevard|rd|road|dr|drive|ln|lane|way|"
+    "ct|court|pkwy|parkway|hwy|highway|pl|place|ter|terrace|cir|circle|"
+    "trl|trail|pike|rte|route|sq|square|loop|expy|expressway|byp|bypass"
+)
+
+# "<house number> [directional] <street words> <street type>", whole string.
+# Anchored at both ends on purpose: a business name that merely *contains* a
+# street type ("9255 Sunset Blvd. Garage (Imperial Parking)") is a real
+# business name and must not be flagged, and neither must "14 Cannons".
+_STREET_ADDRESS_RE = re.compile(
+    r"^\s*\d+[\w\-]*\s+"
+    r"(?:(?:[NSEW]\.?|north|south|east|west|northeast|northwest|"
+    r"southeast|southwest)\s+)?"
+    r"[\w'\.\- ]*?\b(?:" + _STREET_SUFFIX_TOKENS + r")\b\.?\s*$",
+    re.IGNORECASE,
+)
+
+
+def looks_like_street_address(name: Optional[str]) -> bool:
+    """True when *name* reads as a bare street address, not a business name.
+
+    Requires BOTH a leading house number and a trailing street-type token,
+    so numeric brand names ("7-Eleven", "14 Cannons") and businesses that
+    merely embed a street ("9255 Sunset Blvd. Garage (Imperial Parking)")
+    are not flagged.
+    """
+    if not name:
+        return False
+    return bool(_STREET_ADDRESS_RE.match(name.strip()))
+
+
+def place_name_is_address_derived(
+    place_name: Optional[str],
+    place_address: Optional[str],
+) -> bool:
+    """True when a Places ``displayName`` is really the site's street address.
+
+    Google Places returns street-address / premise entries whose
+    ``displayName`` is the address itself (e.g. place
+    ``ChIJO1cwiRDQyIAR5C3eBgKmGcw`` displays as "2716 N Green Valley Pkwy"
+    for the Trader Joe's at that address). Storing that as
+    ``merchant_name`` also poisons the ``MERCHANT#`` GSI partition keys
+    derived from it, so per-merchant grouping breaks for the receipt.
+
+    Both signals are required — the name looks like a street address AND
+    the place's own ``formatted_address`` starts with it — which is what
+    makes this precise enough to act on automatically.
+    """
+    if not looks_like_street_address(place_name):
+        return False
+    if not place_address:
+        return False
+    return (
+        place_address.strip()
+        .lower()
+        .startswith((place_name or "").strip().lower())
+    )
+
+
+# A merchant name is a short phrase. Anything longer is a footer sentence
+# that leaked in through a header/first-line heuristic (observed: the Regal
+# receipt's topmost line by y-centroid is
+# "purchases of gift cards or alcohol. Restrictions apply.", because these
+# receipts are bottom-origin and the header sits at HIGH y).
+_MAX_MERCHANT_NAME_CHARS = 48
+_MAX_MERCHANT_NAME_TOKENS = 6
+
+
+def _collapse_repeated_phrase(name: str) -> str:
+    """Collapse a name that repeats itself: "TRADER JOE'S TRADER JOE'S".
+
+    MERCHANT_NAME labels are attached wherever the brand appears, header
+    AND footer, and joining every labeled word concatenates the phrase
+    once per occurrence. Left uncollapsed that produces the GSI partition
+    key ``MERCHANT#TRADER_JOE_S_TRADER_JOE_S``, which is a worse grouping
+    key than the address it replaced.
+    """
+    tokens = name.split()
+    n = len(tokens)
+    for period in range(1, n // 2 + 1):
+        if n % period:
+            continue
+        block = tokens[:period]
+        if all(tokens[i : i + period] == block for i in range(0, n, period)):
+            return " ".join(block)
+    return name
+
+
+def _numeric_tokens(text: str) -> Set[str]:
+    return set(re.findall(r"\d+", text or ""))
+
+
+def _echoes_the_address(name: str, place_address: Optional[str]) -> bool:
+    """True when *name* is really the address wearing a brand prefix.
+
+    "WF 101 Westlake Blvd." is not address-*shaped* (it starts with a
+    letter) but it is still the street address, so substituting it buys
+    nothing. Requires a street-type token AND a number the place's own
+    address also contains, which no ordinary business name has.
+    """
+    if not place_address:
+        return False
+    lowered = name.lower()
+    has_street_token = bool(
+        re.search(r"\b(?:" + _STREET_SUFFIX_TOKENS + r")\b", lowered)
+    )
+    if not has_street_token:
+        return False
+    return bool(_numeric_tokens(name) & _numeric_tokens(place_address))
+
+
+def sanitize_receipt_merchant_name(
+    receipt_name: Optional[str],
+    place_address: Optional[str] = None,
+) -> Optional[str]:
+    """Normalise an OCR-derived merchant name, or reject it as unusable.
+
+    Returns ``None`` rather than guessing: the caller keeps the Places
+    name when this declines, so a rejection is always a no-op, never a
+    downgrade.
+    """
+    if not receipt_name:
+        return None
+    name = _collapse_repeated_phrase(" ".join(receipt_name.split()))
+    if len(name) < 3 or len(name) > _MAX_MERCHANT_NAME_CHARS:
+        return None
+    if len(name.split()) > _MAX_MERCHANT_NAME_TOKENS:
+        return None
+    if looks_like_street_address(name):
+        return None
+    if _echoes_the_address(name, place_address):
+        return None
+    # A URL/e-mail is a footer artefact, not a merchant name.
+    if re.search(r"(?:https?://|www\.|@|\.com\b|\.net\b|\.org\b)", name, re.I):
+        return None
+    return name
+
+
+def prefer_receipt_name_over_address(
+    place_name: Optional[str],
+    place_address: Optional[str],
+    receipt_name: Optional[str],
+) -> Optional[str]:
+    """Return the merchant name to persist for a Places match.
+
+    Substitutes the receipt's own OCR-derived merchant name when the
+    Places display name is really a street address. Falls back to the
+    Places name whenever there is no usable receipt-derived alternative,
+    so this can only ever replace an address with a business name — never
+    blank a name out and never store a footer sentence.
+    """
+    if not place_name_is_address_derived(place_name, place_address):
+        return place_name
+    candidate = sanitize_receipt_merchant_name(receipt_name, place_address)
+    if not candidate:
+        return place_name
+    _log(
+        "Places displayName %r is this place's street address; "
+        "using receipt-derived merchant name %r instead",
+        place_name,
+        candidate,
+    )
+    return candidate
+
+
 @dataclass
 class SimilarityMatch:
     """A candidate match from ChromaDB similarity search."""
@@ -858,6 +1027,9 @@ class MerchantResolver:
                 address=address,
                 phone=phone,
                 expected_state=expected_state,
+                labeled_merchant_name=(
+                    merchant_hint if has_labeled_merchant else None
+                ),
             )
             if result.place_id:
                 _log(
@@ -995,6 +1167,7 @@ class MerchantResolver:
                 address=address,
                 phone=phone,
                 expected_state=expected_state,
+                labeled_merchant_name=merchant_hint,
             )
             if result.place_id:
                 _log(
@@ -1409,6 +1582,7 @@ class MerchantResolver:
         address: Optional[str],
         phone: Optional[str],
         expected_state: Optional[str] = None,
+        labeled_merchant_name: Optional[str] = None,
     ) -> MerchantResult:
         """Search Places directly using receipt evidence (phone/address/name).
 
@@ -1417,6 +1591,11 @@ class MerchantResolver:
         as ANY of phone/address/name is present — a phone- or address-only receipt
         resolves without a labeled name. ``expected_state`` (the receipt's parsed
         2-letter state) lets the finder reject a wrong-state Places hit.
+
+        ``labeled_merchant_name`` is the receipt's own MERCHANT_NAME-*labeled*
+        text (never the geometric top-line guess). It is used only to replace
+        a Places display name that turns out to be the site's street address —
+        see :func:`prefer_receipt_name_over_address`.
         """
         if not self.places_client or not (merchant_name or address or phone):
             return MerchantResult()
@@ -1451,7 +1630,11 @@ class MerchantResolver:
 
             return MerchantResult(
                 place_id=match.place_id,
-                merchant_name=match.place_name,
+                merchant_name=prefer_receipt_name_over_address(
+                    match.place_name,
+                    match.place_address,
+                    labeled_merchant_name,
+                ),
                 address=match.place_address,
                 phone=match.place_phone,
                 confidence=confidence or 0.0,
@@ -1713,9 +1896,22 @@ class MerchantResolver:
             )
 
             if result and result.get("found") and result.get("place_id"):
+                # Labeled text ONLY. _extract_merchant_name(lines) is the
+                # geometric top-line guess and is deliberately not used
+                # here: these receipts are bottom-origin, so the "first"
+                # line by y-centroid is the footer (observed:
+                # "purchases of gift cards or alcohol. Restrictions
+                # apply.", "www.traderjoes.com").
+                receipt_derived_name = self._extract_labeled_text(
+                    words, word_labels or [], "MERCHANT_NAME"
+                )
                 return MerchantResult(
                     place_id=result["place_id"],
-                    merchant_name=result.get("place_name"),
+                    merchant_name=prefer_receipt_name_over_address(
+                        result.get("place_name"),
+                        result.get("place_address"),
+                        receipt_derived_name,
+                    ),
                     address=result.get("place_address"),
                     phone=result.get("place_phone"),
                     confidence=result.get("confidence", 0.0),
@@ -1758,9 +1954,16 @@ class MerchantResolver:
 
             # Extract merchant info from lines/words for the finder
             word_labels = word_labels or []
-            merchant_name = self._extract_labeled_text(
+            labeled_merchant_name = self._extract_labeled_text(
                 words, word_labels, "MERCHANT_NAME"
-            ) or self._extract_merchant_name(lines)
+            )
+            # The geometric top-line guess is fine as a Places *text query*
+            # hint but must never be persisted as merchant_name (see the
+            # agentic branch above), so it is kept out of
+            # labeled_merchant_name.
+            merchant_name = (
+                labeled_merchant_name or self._extract_merchant_name(lines)
+            )
             phone = self._extract_phone(words)
             address = self._extract_labeled_text(
                 words, word_labels, "ADDRESS_LINE"
@@ -1793,7 +1996,11 @@ class MerchantResolver:
 
                 return MerchantResult(
                     place_id=match.place_id,
-                    merchant_name=match.place_name,
+                    merchant_name=prefer_receipt_name_over_address(
+                        match.place_name,
+                        match.place_address,
+                        labeled_merchant_name,
+                    ),
                     address=match.place_address,
                     phone=match.place_phone,
                     confidence=confidence or 0.0,

--- a/receipt_upload/tests/test_merchant_name_address_guard.py
+++ b/receipt_upload/tests/test_merchant_name_address_guard.py
@@ -1,0 +1,225 @@
+"""Reject a Google Places ``displayName`` that is really a street address.
+
+Google returns street-address / premise entries whose ``displayName`` is
+the address itself. Observed on freshly-ingested receipts: place
+``ChIJO1cwiRDQyIAR5C3eBgKmGcw`` (the Trader Joe's at 2716 N Green Valley
+Pkwy, Henderson NV) displays as "2716 N Green Valley Pkwy", and that
+string was stored as ``ReceiptPlace.merchant_name`` -> ``ReceiptSummary
+.merchant_name`` -> the ``MERCHANT#`` GSI1 partition keys, so the receipt
+grouped under its own address instead of under Trader Joe's.
+"""
+
+import pytest
+
+from receipt_upload.merchant_resolution.resolver import (
+    looks_like_street_address,
+    place_name_is_address_derived,
+    prefer_receipt_name_over_address,
+    sanitize_receipt_merchant_name,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class TestLooksLikeStreetAddress:
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "2716 N Green Valley Pkwy",
+            "2300 Paseo Verde Pkwy",
+            "614 Gravier St",
+            "101 N Westlake Blvd",
+            "1234 South Main Street",
+            "500 Sunset Blvd.",
+        ],
+    )
+    def test_flags_bare_street_addresses(self, name: str) -> None:
+        assert looks_like_street_address(name) is True
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "Trader Joe's",
+            "Sprouts Farmers Market",
+            "Costco Wholesale",
+            "In-N-Out Burger",
+            "7-Eleven",
+            # Numeric leading token but no street type -- a real pub name.
+            "14 Cannons",
+            # Street type embedded but the name continues past it.
+            "9255 Sunset Blvd. Garage (Imperial Parking)",
+            "99 Ranch Market",
+            "",
+            None,
+        ],
+    )
+    def test_does_not_flag_business_names(self, name) -> None:
+        assert looks_like_street_address(name) is False
+
+
+class TestPlaceNameIsAddressDerived:
+    def test_requires_both_signals(self) -> None:
+        assert (
+            place_name_is_address_derived(
+                "2716 N Green Valley Pkwy",
+                "2716 N Green Valley Pkwy, Henderson, NV 89014, USA",
+            )
+            is True
+        )
+
+    def test_address_shaped_name_that_is_not_this_places_address(self) -> None:
+        """A street-address-shaped name is left alone if it does not
+        prefix the place's own formatted address -- that would be a
+        different (and unexplained) mismatch, not this defect."""
+        assert (
+            place_name_is_address_derived(
+                "2716 N Green Valley Pkwy",
+                "17 Elm Street, Boston, MA 02108, USA",
+            )
+            is False
+        )
+
+    def test_business_name_never_flagged(self) -> None:
+        assert (
+            place_name_is_address_derived(
+                "Trader Joe's",
+                "2716 N Green Valley Pkwy, Henderson, NV 89014, USA",
+            )
+            is False
+        )
+
+    def test_missing_address_is_not_enough(self) -> None:
+        assert (
+            place_name_is_address_derived("2716 N Green Valley Pkwy", None)
+            is False
+        )
+
+
+class TestSanitizeReceiptMerchantName:
+    """The OCR-derived candidate is normalised, or rejected outright."""
+
+    def test_collapses_a_doubled_phrase(self) -> None:
+        """IMG_3404 labels TRADER JOE'S in both header and footer, so the
+        joined labeled text is the brand twice. Uncollapsed that yields
+        the GSI key MERCHANT#TRADER_JOE_S_TRADER_JOE_S."""
+        assert (
+            sanitize_receipt_merchant_name("TRADER JOE'S TRADER JOE'S")
+            == "TRADER JOE'S"
+        )
+
+    def test_collapses_a_tripled_phrase(self) -> None:
+        assert sanitize_receipt_merchant_name("VONS VONS VONS") == "VONS"
+
+    def test_keeps_a_name_that_merely_repeats_one_token(self) -> None:
+        assert (
+            sanitize_receipt_merchant_name("Wild Fork Fork Market")
+            == "Wild Fork Fork Market"
+        )
+
+    def test_rejects_a_footer_sentence(self) -> None:
+        """The Regal receipt's topmost line by y-centroid: these receipts
+        are bottom-origin so the geometric 'first line' is the footer."""
+        assert (
+            sanitize_receipt_merchant_name(
+                "purchases of gift cards or alcohol. Restrictions apply."
+            )
+            is None
+        )
+
+    def test_rejects_a_website(self) -> None:
+        assert sanitize_receipt_merchant_name("www.traderjoes.com") is None
+
+    def test_rejects_a_brand_prefixed_address_echo(self) -> None:
+        """'WF 101 Westlake Blvd.' is not address-shaped (starts with a
+        letter) but is still the address, so substituting buys nothing."""
+        assert (
+            sanitize_receipt_merchant_name(
+                "WF 101 Westlake Blvd.",
+                "101 N Westlake Blvd, Thousand Oaks, CA 91362, USA",
+            )
+            is None
+        )
+
+    def test_keeps_a_business_name_containing_a_street_word(self) -> None:
+        """No shared number with the place address -> not an echo."""
+        assert (
+            sanitize_receipt_merchant_name(
+                "614 Gravier LLC",
+                "614 Gravier St, New Orleans, LA 70130, USA",
+            )
+            == "614 Gravier LLC"
+        )
+
+    @pytest.mark.parametrize("name", ["", None, "TJ"])
+    def test_rejects_empty_or_too_short(self, name) -> None:
+        assert sanitize_receipt_merchant_name(name) is None
+
+
+class TestPreferReceiptNameOverAddress:
+    ADDR = "2716 N Green Valley Pkwy"
+    FULL = "2716 N Green Valley Pkwy, Henderson, NV 89014, USA"
+
+    def test_substitutes_the_receipts_own_merchant_name(self) -> None:
+        assert (
+            prefer_receipt_name_over_address(
+                self.ADDR, self.FULL, "TRADER JOE'S"
+            )
+            == "TRADER JOE'S"
+        )
+
+    def test_substitutes_the_collapsed_doubled_name(self) -> None:
+        """End-to-end for IMG_3404 / IMG_3420."""
+        assert (
+            prefer_receipt_name_over_address(
+                self.ADDR, self.FULL, "TRADER JOE'S TRADER JOE'S"
+            )
+            == "TRADER JOE'S"
+        )
+
+    def test_declines_when_the_receipt_offers_only_a_footer_sentence(
+        self,
+    ) -> None:
+        """IMG_3411 (Regal) has no MERCHANT_NAME label; the guard must be
+        a no-op rather than storing junk."""
+        assert (
+            prefer_receipt_name_over_address(
+                "2300 Paseo Verde Pkwy",
+                "2300 Paseo Verde Pkwy, Henderson, NV 89052, USA",
+                "purchases of gift cards or alcohol. Restrictions apply.",
+            )
+            == "2300 Paseo Verde Pkwy"
+        )
+
+    def test_keeps_places_name_when_it_is_a_business_name(self) -> None:
+        assert (
+            prefer_receipt_name_over_address(
+                "Trader Joe's", self.FULL, "SOMETHING ELSE"
+            )
+            == "Trader Joe's"
+        )
+
+    def test_never_blanks_the_name_when_no_receipt_name(self) -> None:
+        """Falling back to the address beats storing None: ReceiptPlace
+        requires a non-empty merchant_name."""
+        assert (
+            prefer_receipt_name_over_address(self.ADDR, self.FULL, None)
+            == self.ADDR
+        )
+        assert (
+            prefer_receipt_name_over_address(self.ADDR, self.FULL, "  ")
+            == self.ADDR
+        )
+
+    def test_rejects_a_receipt_name_that_is_also_an_address(self) -> None:
+        assert (
+            prefer_receipt_name_over_address(
+                self.ADDR, self.FULL, "2716 North Green Valley Parkway"
+            )
+            == self.ADDR
+        )
+
+    def test_rejects_a_too_short_receipt_name(self) -> None:
+        assert (
+            prefer_receipt_name_over_address(self.ADDR, self.FULL, "TJ")
+            == self.ADDR
+        )

--- a/receipt_upload/tests/test_merchant_resolver.py
+++ b/receipt_upload/tests/test_merchant_resolver.py
@@ -1345,6 +1345,10 @@ class TestMerchantResolverLabeledFields:
             address="123 Main",
             phone=None,
             expected_state=None,
+            # The MERCHANT_NAME-*labeled* text, forwarded so a Places
+            # displayName that turns out to be the site's street address
+            # can be replaced (see prefer_receipt_name_over_address).
+            labeled_merchant_name="Whole Foods",
         )
         chroma_search.assert_not_called()
 

--- a/scripts/backfill_summary_item_count.py
+++ b/scripts/backfill_summary_item_count.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Backfill ``ReceiptSummary.item_count`` from real ReceiptLineItem rows.
+
+``item_count`` was derived solely from VALID ``LINE_TOTAL`` word labels.
+Receipts ingested through the current pipeline never receive those
+labels -- their line items are ``ReceiptLineItem`` rows written by the
+line-item updater's band-block decoder -- so freshly-ingested receipts
+holding real line items reported ``item_count == 0``.
+
+The shipped rule (``receipt_dynamo.entities.receipt_summary
+.resolve_item_count``) prefers the row count when rows exist and keeps
+the label count otherwise. This script applies that same rule to
+summaries already in the table. It rewrites nothing else: the record is
+re-put with only ``item_count`` changed, so the offline bank/tender
+fields are carried through untouched.
+
+Measured 2026-08-04 (before any write):
+
+    prod ReceiptsTable-d7ff76a   826 summaries
+        220 with item_count == 0, of which 121 hold line-item rows
+        327 summaries where stored != row count
+        302 would change under the fallback rule
+         25 are protected BY the fallback (labels but no rows)
+
+    dev  ReceiptsTable-dc5be22   828 summaries
+        246 with item_count == 0, of which 118 hold line-item rows
+
+Blast radius: ``item_count`` is not read by the Next.js frontend, by any
+API route, or by the Swift worker. Its only substantive consumers are
+the QA agent's evidence prose and the MCP ``get_receipt_summaries``
+pass-through.
+
+Note that every write emits a DynamoDB stream event that routes to the
+LINE_ITEMS queue, so a full backfill also triggers one line-item
+recompute per changed receipt. That is idempotent but not free; use
+``--limit`` to stage it.
+
+DRY-RUN BY DEFAULT: pass ``--apply`` to write.
+
+Usage:
+    python scripts/backfill_summary_item_count.py --env dev
+    python scripts/backfill_summary_item_count.py --env dev --apply
+    python scripts/backfill_summary_item_count.py \
+        --table-name ReceiptsTable-d7ff76a --apply --limit 25
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from collections import Counter
+from dataclasses import dataclass
+
+from receipt_dynamo.data.dynamo_client import DynamoClient
+from receipt_dynamo.entities.receipt_summary import resolve_item_count
+from receipt_dynamo.entities.receipt_summary_record import (
+    ReceiptSummaryRecord,
+)
+
+logger = logging.getLogger("backfill_summary_item_count")
+
+ENV_TABLES = {
+    "dev": "ReceiptsTable-dc5be22",
+    "prod": "ReceiptsTable-d7ff76a",
+}
+
+
+@dataclass
+class Change:
+    """One summary whose stored item_count disagrees with its rows."""
+
+    image_id: str
+    receipt_id: int
+    merchant_name: str | None
+    stored: int
+    computed: int
+
+
+def _iter_summaries(client: DynamoClient):
+    """Yield every ReceiptSummaryRecord in the table, via GSI2."""
+    last_key = None
+    while True:
+        records, last_key = client.list_receipt_summaries(
+            last_evaluated_key=last_key
+        )
+        yield from records
+        if last_key is None:
+            return
+
+
+def plan(client: DynamoClient, limit: int | None) -> list[Change]:
+    """Compute the pending changes without writing anything."""
+    changes: list[Change] = []
+    scanned = 0
+    for record in _iter_summaries(client):
+        scanned += 1
+        rows = client.get_receipt_line_items_from_receipt(
+            record.image_id, record.receipt_id
+        )
+        computed = resolve_item_count(
+            label_item_count=record.item_count,
+            line_item_count=len(rows),
+        )
+        if computed != record.item_count:
+            changes.append(
+                Change(
+                    image_id=record.image_id,
+                    receipt_id=record.receipt_id,
+                    merchant_name=record.merchant_name,
+                    stored=record.item_count,
+                    computed=computed,
+                )
+            )
+            if limit is not None and len(changes) >= limit:
+                break
+    logger.info("Scanned %d summaries", scanned)
+    return changes
+
+
+def apply(client: DynamoClient, changes: list[Change]) -> int:
+    """Re-put each changed summary with the corrected item_count."""
+    written = 0
+    for change in changes:
+        record = client.get_receipt_summary(change.image_id, change.receipt_id)
+        summary = record.to_summary()
+        summary.item_count = change.computed
+        client.upsert_receipt_summary(
+            ReceiptSummaryRecord.from_summary(summary)
+        )
+        written += 1
+        if written % 50 == 0:
+            logger.info("Wrote %d/%d", written, len(changes))
+    return written
+
+
+def _report(changes: list[Change]) -> None:
+    ups = sum(1 for c in changes if c.computed > c.stored)
+    downs = len(changes) - ups
+    print(f"\n{len(changes)} summaries would change ({ups} up, {downs} down)")
+    hist = Counter(c.computed - c.stored for c in changes)
+    print(f"delta histogram: {dict(sorted(hist.items()))}\n")
+    for change in changes[:40]:
+        print(
+            f"  {change.image_id} #{change.receipt_id:05d}  "
+            f"{change.stored:>3} -> {change.computed:<3}  "
+            f"{change.merchant_name!r}"
+        )
+    if len(changes) > 40:
+        print(f"  ... and {len(changes) - 40} more")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--env", choices=sorted(ENV_TABLES))
+    parser.add_argument(
+        "--table-name",
+        help="Explicit table name; overrides --env.",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Write the changes. Without this the script only reports.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        help="Stop after this many pending changes (staging aid).",
+    )
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+
+    table = args.table_name or ENV_TABLES.get(args.env or "")
+    if not table:
+        parser.error("pass --env dev|prod or --table-name NAME")
+
+    print(f"Table: {table}   mode: {'APPLY' if args.apply else 'dry-run'}")
+    client = DynamoClient(table)
+    changes = plan(client, args.limit)
+    _report(changes)
+
+    if not args.apply:
+        print("\nDry run. Re-run with --apply to write.")
+        return 0
+
+    written = apply(client, changes)
+    print(f"\nWrote {written} summaries.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_receipt_summary_updater_tender.py
+++ b/tests/test_receipt_summary_updater_tender.py
@@ -62,6 +62,11 @@ class FakeClient:
         ]
         self.words = [_word(1, 2, "47.18")]
         self.word_labels = [_label(1, 2, "GRAND_TOTAL")]
+        # ReceiptLineItem rows are the authoritative source for
+        # summary.item_count (the LINE_TOTAL-label count is only the
+        # fallback). Default to none so these tender tests exercise the
+        # fallback path unchanged.
+        self.line_items = []
 
     def get_receipt(self, image_id, receipt_id):
         if not self.receipt_exists:
@@ -85,6 +90,9 @@ class FakeClient:
 
     def get_receipt_sections_from_receipt(self, image_id, receipt_id):
         return self.sections
+
+    def get_receipt_line_items_from_receipt(self, image_id, receipt_id):
+        return self.line_items
 
     def get_receipt_place(self, image_id, receipt_id):
         raise EntityNotFoundError("no place")
@@ -197,3 +205,38 @@ def test_cash_receipt_classified(monkeypatch):
     assert record.tender_class == "cash"
     assert record.card_network is None
     assert record.card_last4 is None
+
+
+def test_item_count_uses_line_item_rows(monkeypatch):
+    """Reproduces IMG_3404: 5 ReceiptLineItem rows, zero LINE_TOTAL labels.
+
+    The receipt's line items are RECEIPT_LINE_ITEM rows written by the
+    line-item updater's band-block decoder; the current ingest pipeline
+    emits no LINE_TOTAL word labels at all, so the legacy label-count
+    rule reported item_count == 0 for a receipt holding 5 items.
+    """
+    client = FakeClient()
+    client.line_items = [object()] * 5
+    monkeypatch.setattr(summary_processor, "dynamo_client", client)
+
+    result = summary_processor.update_receipt_summary(IMAGE_ID, RECEIPT_ID)
+
+    assert client.upserted[0].item_count == 5
+    assert result["item_count"] == 5
+
+
+def test_item_count_falls_back_to_labels_without_rows(monkeypatch):
+    """Receipts with LINE_TOTAL labels but no extracted rows keep their
+    label-derived count (25 such summaries exist in prod)."""
+    client = FakeClient()
+    client.line_items = []
+    client.word_labels = [
+        _label(2, 1, "LINE_TOTAL"),
+        _label(3, 1, "LINE_TOTAL"),
+    ]
+    client.words = [_word(2, 1, "2.99"), _word(3, 1, "3.49")]
+    monkeypatch.setattr(summary_processor, "dynamo_client", client)
+
+    summary_processor.update_receipt_summary(IMAGE_ID, RECEIPT_ID)
+
+    assert client.upserted[0].item_count == 2


### PR DESCRIPTION
Two independent `ReceiptSummary` data-quality defects, both reproduced on the three receipts ingested today. All investigation was **read-only against dev and prod** — no table was written.

## Defect A — `item_count` was reading the wrong source

**Root cause is not staleness.** `item_count` counted VALID `LINE_TOTAL` word labels. The current ingest pipeline emits **no `LINE_TOTAL` labels at all** — a receipt's line items are `RECEIPT_LINE_ITEM` rows written by the line-item updater's band-block decoder. IMG_3404 has 18 word labels (MERCHANT_NAME, STORE_HOURS, PAYMENT_METHOD, DATE, TIME, WEBSITE) and zero LINE_TOTAL, alongside 5 real line-item rows. The field and the data were simply disconnected.

`resolve_item_count` now prefers the row count, keeping the label count as the fallback. **The fallback is load-bearing**: 25 prod summaries carry LINE_TOTAL labels with no extracted rows and would regress to zero under a naive "count the rows" rule.

### Corpus (measured 2026-08-04, read-only)

| | prod `d7ff76a` | dev `dc5be22` |
|---|---|---|
| summaries | 826 | 828 |
| `item_count == 0` | 220 | 246 |
| …of those, holding line-item rows (**fixable**) | **121** | 118 |
| …of those, correctly zero | 99 | 128 |
| stored ≠ row count | 327 | 287 |
| would change under the fallback rule | **302** | — |
| protected *by* the fallback | 25 | 41 |

### Blast radius

`item_count` has **no consumer** in `portfolio/`, in any `infra/routes/` API Lambda, or in `receipt_ocr_swift/`. Its only substantive readers are QA-agent evidence prose (`graph.py:590`, `:677`) and the MCP `get_receipt_summaries` pass-through. Nothing aggregates it.

### Known limitation (deliberate, not a bug)

A summary write is what *triggers* the line-item updater (`RECEIPT_SUMMARY` → LINE_ITEMS queue), so on a receipt's **first** summary write there are no rows yet and the count still falls back to labels. It becomes correct on the next recompute (any label or place change).

A stream back-edge from `RECEIPT_LINE_ITEM` back to the summary queue is **deliberately not added**: `line_item_processor.py` delete-then-inserts every row on each run, and the `RECEIPT_SUMMARY` change detector tracks only `timestamp_computed` (which changes on every write), so that edge would be an **unbounded recompute loop**. Closing the fresh-ingest gap cleanly needs a one-line change in the line-item updater, which this PR does not touch — see the proposals below.

## Defect B — `merchant_name` resolved to a street address

Google Places returns street-address entries whose `displayName` is the address itself. Place `ChIJO1cwiRDQyIAR5C3eBgKmGcw` displays as `"2716 N Green Valley Pkwy"` for the Trader Joe's at that address. That string became `ReceiptPlace.merchant_name` → `ReceiptSummary.merchant_name` → the `MERCHANT#` GSI partition keys, so those receipts grouped under their own address.

**The correct name is not on the `ReceiptPlace` row** — nothing there holds "Trader Joe's". It *is* available from the receipt's own OCR: lines 1–2 read `TRADER JOE'S` and carry VALID `MERCHANT_NAME` word labels.

The resolver now substitutes that labeled text when the Places name is address-derived. Both signals are required — the name is address-shaped (leading house number **and** trailing street-type token) **and** it prefixes the place's own `formatted_address` — and the guard **declines rather than downgrades**: it can only replace an address with a business name, never blank one out.

### Two hazards found by validating the substitute against real data

Simulating the naive version against the actual rows produced *worse* names than the address, so both are guarded explicitly:

1. **Doubled name.** MERCHANT_NAME labels attach in header **and** footer, so the joined labeled text was `"TRADER JOE'S TRADER JOE'S"` → GSI key `MERCHANT#TRADER_JOE_S_TRADER_JOE_S`. Repeated phrases are now collapsed.
2. **Footer-as-header.** `_extract_merchant_name(lines)` takes the lowest-y line, but these receipts are **bottom-origin**, so the "first" line is the footer — `"purchases of gift cards or alcohol. Restrictions apply."` and `"www.traderjoes.com"`. It stays a Places *text-query* hint but is no longer eligible to be persisted as `merchant_name`.

Also rejected: brand-prefixed address echoes (`"WF 101 Westlake Blvd."`), URLs, sentence-length strings, and anything itself address-shaped.

### Corpus-wide rate — much smaller than the historical 55%

That 55% was one ingest session's rate, not the corpus. Scanning every summary with the **shipped regex**:

| | prod | dev |
|---|---|---|
| address-shaped `merchant_name` | **5 / 826 (0.6%)** | 4 / 828 |
| distinct addresses | 4 | 3 |

prod: `2716 N Green Valley Pkwy` ×2, `2300 Paseo Verde Pkwy`, `614 Gravier St`, `101 N Westlake Blvd`. All 4 confirmed against `ReceiptPlace.formatted_address` (each is an exact prefix). No false positives on `"14 Cannons"` or `"9255 Sunset Blvd. Garage (Imperial Parking)"`.

**No corpus rename is performed.** `merchant_name` feeds a GSI partition key; a rewrite is a proposal with a measured blast radius (below), not something this PR executes.

## Per-receipt before → after

Simulated with the shipped helpers and the shipped wiring, against live rows:

| receipt | env | `item_count` | `merchant_name` |
|---|---|---|---|
| IMG_3404 Trader Joe's | dev + prod | `0` → **`5`** | `'2716 N Green Valley Pkwy'` → **`"TRADER JOE'S"`** |
| IMG_3411 Regal | dev + prod | `0` → **`1`** | unchanged — guard declined (no MERCHANT_NAME label; only the footer sentence was on offer) |
| IMG_3420 Trader Joe's | dev + prod | `0` → **`7`** | `'2716 N Green Valley Pkwy'` → **`"TRADER JOE'S"`** |

Item counts match the stated 5 / 1 / 7 and their sums reconcile (37.51 / 12.99 / 39.49). `"TRADER JOE'S"` normalises to `MERCHANT#TRADER_JOE_S`, joining the 25 existing Trader Joe's receipts.

The other two corpus rows, for completeness: `614 Gravier St` → `614 Gravier LLC` (the entity printed on the receipt); `101 N Westlake Blvd` → unchanged, guard declined the address echo.

## Not done — proposals needing your approval

1. **`item_count` prod backfill.** `scripts/backfill_summary_item_count.py`, dry-run by default, `--apply` to write, `--limit` to stage. 302 prod summaries change. Note each write emits a stream event routing to the LINE_ITEMS queue, so a full backfill also triggers one idempotent line-item recompute per changed receipt. Dry-run verified against dev; **not run against any table**.
2. **Closing the fresh-ingest gap** needs the line-item updater to enqueue a summary recompute after it writes rows. `infra/receipt_line_item_updater/` is owned by another agent right now, so it is untouched here.
3. **Renaming the 5 prod address-merchants.** Blast radius: 5 `RECEIPT_SUMMARY` rows, 5 `RECEIPT_PLACE` rows (`GSI1PK` rewrite), and every `RECEIPT_LINE_ITEM` row under them (`MERCHANT#…` `GSI1PK` rewrite). Only 3 of the 5 have a usable substitute.

## Verification

- `receipt_dynamo`: 2383 unit tests pass (10 new)
- `receipt_upload`: full suite passes (24 new; 1 existing kwargs assertion updated)
- root `tests/`: 713 pass, 1 skip (2 new for the Lambda wiring)
- `lambda-syntax`: every `infra/**/*.py` compiles
- lint: `black --check --line-length=79` and `isort --check-only --profile=black --line-length=79` clean over `receipt_dynamo` and `receipt_upload`, in a bare py3.12 venv shaped like CI's per-package job

No changes under `portfolio/`. No `pulumi up`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TzUnnRheR1xinDRCS6s4fB
