### PR TITLE
feat(labels): mint deterministic word labels from the reconciled line-item decode

### DIFF
--- a/receipt_dynamo/receipt_dynamo/entities/receipt_summary.py
+++ b/receipt_dynamo/receipt_dynamo/entities/receipt_summary.py
@@ -456,6 +456,27 @@ def _is_subtotal_noise_line(line_text: str) -> bool:
     )
 
 
+def _is_tax_anchor(line_text: str) -> bool:
+    """A tax anchor row (never a total/subtotal/tender variant)."""
+    return bool(
+        TAX_KEYWORD_RE.search(line_text)
+        and not TOTAL_KEYWORD_RE.search(line_text)
+        and not SUBTOTAL_KEYWORD_RE.search(line_text)
+        and not NON_PAYMENT_SUMMARY_RE.search(line_text)
+        and not TENDER_KEYWORD_RE.search(line_text)
+    )
+
+
+def _is_tax_noise_line(line_text: str) -> bool:
+    """Rows a tax anchor must not pair with across the y-band."""
+    return bool(
+        TOTAL_KEYWORD_RE.search(line_text)
+        or SUBTOTAL_KEYWORD_RE.search(line_text)
+        or NON_PAYMENT_SUMMARY_RE.search(line_text)
+        or TENDER_KEYWORD_RE.search(line_text)
+    )
+
+
 def find_printed_grand_total(words: list["ReceiptWord"]) -> float | None:
     """Find the printed grand total from receipt words, without labels.
 
@@ -499,12 +520,57 @@ def find_printed_subtotal(words: list["ReceiptWord"]) -> float | None:
     )
 
 
+def find_printed_tax_words(
+    words: list["ReceiptWord"],
+) -> list[tuple[float, "ReceiptWord"]]:
+    """Every amount word anchored to a printed tax row.
+
+    Unlike grand total and subtotal there is no single "the" printed tax
+    (receipts print several tax rows that the summary sums), so this
+    returns all anchored candidates and leaves the choice to the caller.
+    """
+    return _anchored_amount_words(words, _is_tax_anchor, _is_tax_noise_line)
+
+
+def find_printed_grand_total_words(
+    words: list["ReceiptWord"],
+) -> list[tuple[float, "ReceiptWord"]]:
+    """Amount words anchored to a printed grand-total row.
+
+    The word-level companion to :func:`find_printed_grand_total`, which
+    returns only the winning value. Callers that need to point a label at
+    the printed figure need the word it was printed on.
+    """
+    return _anchored_amount_words(
+        words, _is_grand_total_anchor, _is_summary_noise_line
+    )
+
+
+def find_printed_subtotal_words(
+    words: list["ReceiptWord"],
+) -> list[tuple[float, "ReceiptWord"]]:
+    """Amount words anchored to a printed subtotal row."""
+    return _anchored_amount_words(
+        words, _is_subtotal_anchor, _is_subtotal_noise_line
+    )
+
+
 def _find_anchored_amount(
     words: list["ReceiptWord"],
     is_anchor: Callable[[str], bool],
     is_noise: Callable[[str], bool],
 ) -> float | None:
     """Largest amount printed on (or row-banded with) an anchor line."""
+    anchored = _anchored_amount_words(words, is_anchor, is_noise)
+    return max(amount for amount, _ in anchored) if anchored else None
+
+
+def _anchored_amount_words(
+    words: list["ReceiptWord"],
+    is_anchor: Callable[[str], bool],
+    is_noise: Callable[[str], bool],
+) -> list[tuple[float, "ReceiptWord"]]:
+    """Amounts printed on (or row-banded with) an anchor line, with words."""
     lines: dict[int, list["ReceiptWord"]] = {}
     for word in words:
         line_id = getattr(word, "line_id", None)
@@ -522,15 +588,15 @@ def _find_anchored_amount(
         line_id for line_id, text in line_texts.items() if is_anchor(text)
     ]
     if not anchor_ids:
-        return None
+        return []
 
-    anchored: list[float] = []
+    anchored: list[tuple[float, "ReceiptWord"]] = []
     for anchor_id in anchor_ids:
         anchor_words = lines[anchor_id]
 
         # Amounts printed on the anchor line itself win outright.
         same_line = [
-            amount
+            (amount, w)
             for w in anchor_words
             if (amount := _positive_amount(str(getattr(w, "text", ""))))
             is not None
@@ -560,9 +626,9 @@ def _find_anchored_amount(
                     continue
                 amount = _positive_amount(str(getattr(w, "text", "")))
                 if amount is not None:
-                    anchored.append(amount)
+                    anchored.append((amount, w))
 
-    return max(anchored) if anchored else None
+    return anchored
 
 
 def _apply_printed_total_fallback(

--- a/receipt_upload/receipt_upload/line_items/__init__.py
+++ b/receipt_upload/receipt_upload/line_items/__init__.py
@@ -1,5 +1,11 @@
 """Line-item labeling: deterministic geometry + semantic (Chroma) recovery."""
 
+from receipt_upload.line_items.labels import (
+    DECODER_PROPOSED_BY,
+    DerivationResult,
+    DerivedLabel,
+    derive_labels,
+)
 from receipt_upload.line_items.reconstructor import (
     dedupe_grand_total,
     propose_line_item_labels,
@@ -8,7 +14,11 @@ from receipt_upload.line_items.reconstructor import (
 from receipt_upload.line_items.semantic_proposer import propose_product_names
 
 __all__ = [
+    "DECODER_PROPOSED_BY",
+    "DerivationResult",
+    "DerivedLabel",
     "dedupe_grand_total",
+    "derive_labels",
     "propose_line_item_labels",
     "propose_product_names",
     "reclassify_mislabeled_totals",

--- a/receipt_upload/receipt_upload/line_items/blocks.py
+++ b/receipt_upload/receipt_upload/line_items/blocks.py
@@ -725,13 +725,22 @@ def decode_band_blocks(
             # discarded them -- the boundary-steal guarantee failure the
             # first integration attempt was reverted on.
             cands = [
-                (len(bands[i]["text"]), bands[i]["text"])
+                (len(bands[i]["text"]), bands[i]["text"], i)
                 for i in blocks[p]
                 if _name_is_real(bands[i]["text"])
             ]
             if cands:
-                parsed["name"] = max(cands)[1].strip()
+                donor = max(cands)
+                parsed["name"] = donor[1].strip()
                 parsed["stacked"] = True
+                # The name now comes from the donor band, so its word
+                # provenance must follow it. Left pointing at the price
+                # band, name_word_ids would name the SKU words instead of
+                # the product words for every stacked layout.
+                parsed["name_word_ids"] = [
+                    {"line_id": w["line_id"], "word_id": w["word_id"]}
+                    for w in bands[donor[2]]["words"]
+                ]
         if not _name_is_real(parsed.get("name") or ""):
             # No name anywhere: keep the price, flag the quality --
             # identical semantics to the banded path.

--- a/receipt_upload/receipt_upload/line_items/geometry.py
+++ b/receipt_upload/receipt_upload/line_items/geometry.py
@@ -424,17 +424,23 @@ def parse_band(band: list[dict]) -> Optional[dict[str, Any]]:
             continue  # taxability flag
         name_idxs.append(i)
 
-    # Leading quantity forms consume their word
+    # Leading quantity forms consume their word. The consumed index is
+    # recorded in qty_word_idxs so downstream consumers (word-level label
+    # derivation) can point QUANTITY at the exact word the quantity came
+    # from; name_idxs was already computed above, so widening the set here
+    # cannot change the decoded name, price or quantity.
     if qty is None and name_idxs:
         first = texts[name_idxs[0]]
         m3 = QTY_MULT_RE.match(first)
         if m3:
             qty = float(m3.group(1))
+            qty_word_idxs.add(name_idxs[0])
             name_idxs.pop(0)
         elif re.fullmatch(r"\d{1,2}", first) and any(
             re.search(r"[A-Za-z]{2,}", texts[i]) for i in name_idxs[1:]
         ):
             qty = float(first)
+            qty_word_idxs.add(name_idxs[0])
             name_idxs.pop(0)
 
     # Trailing single-letter token: a taxability flag the fixed [TFNOAB]

--- a/receipt_upload/receipt_upload/line_items/labels.py
+++ b/receipt_upload/receipt_upload/line_items/labels.py
@@ -1,0 +1,447 @@
+"""Deterministic ReceiptWordLabel derivation from the decoded line items.
+
+The band-block decoder already knows, word for word, which words are a
+product's name, which word carries its extended price, and which words
+carry the quantity and unit price -- ``parse_band`` returns
+``name_word_ids`` / ``price_word_id`` / ``qty_word_ids`` alongside every
+item it emits. Nothing wrote that knowledge down, so receipts ingested by
+the Swift worker end up with header/footer metadata labels and zero
+product or financial labels.
+
+This module turns the decode into label proposals. It mints nothing on
+its own judgement: every proposal points at a word the decoder already
+identified, or at a printed summary figure that equals the receipt's
+stored summary value to the cent.
+
+The gate is arithmetic, not heuristic. Labels are derived only when the
+decoded items reconcile to the receipt's printed baseline as a full
+``match`` (``near`` never qualifies, however small the band), which means
+the name-to-price pairing is arithmetically proven: change any pairing
+and the sum stops landing on the printed figure. ``require_proven``
+tightens the gate to the PROVEN tier (``geometry.is_proven``), where the
+printed total also agrees with the settled bank amount to the cent.
+
+Writing is deliberately not this module's job -- it returns proposals and
+lets the caller decide, so the same derivation serves a backfill script,
+an MCP tool and (later) the ingest path.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any, Iterable, Optional, Sequence
+
+from receipt_dynamo.amounts import (
+    looks_like_receipt_amount,
+    parse_receipt_amount,
+)
+from receipt_dynamo.entities.receipt_summary import (
+    find_printed_grand_total_words,
+    find_printed_subtotal_words,
+    find_printed_tax_words,
+)
+
+from receipt_upload.line_items.geometry import (
+    extract_items,
+    is_proven,
+    reconcile_detailed,
+)
+
+# The provenance marker for every label this module derives. Distinct from
+# every LLM proposer ("llm_valid", "llm_needs_review", "*_analyzer_llm")
+# so a later sweep can find, audit or retract exactly this population.
+DECODER_PROPOSED_BY = "decoder_reconciled"
+
+# Cent tolerance when matching a printed word's amount to the stored
+# summary figure. Both sides are printed money, so this is exact-match
+# slack for float representation only, not a comparison band.
+_CENT = 0.005
+
+# Gate verdicts (why a receipt did or did not produce labels).
+GATE_OK = "ok"
+GATE_NO_ITEMS_SECTION = "no-items-section"
+GATE_NO_ITEMS = "no-items"
+GATE_NOT_MATCHED = "not-matched"
+GATE_COLLAPSED_BANDING = "collapsed-banding"
+GATE_NOT_PROVEN = "not-proven"
+
+
+@dataclass(frozen=True)
+class DerivedLabel:
+    """One label proposal: a word, a label, and why the decoder said so."""
+
+    line_id: int
+    word_id: int
+    label: str
+    reasoning: str
+    text: str = ""
+
+    @property
+    def word_key(self) -> tuple[int, int]:
+        """The (line_id, word_id) this proposal targets."""
+        return (self.line_id, self.word_id)
+
+
+@dataclass
+class DerivationResult:
+    """The outcome of deriving labels for one receipt."""
+
+    gate: str
+    labels: list[DerivedLabel] = field(default_factory=list)
+    reconciliation_status: Optional[str] = None
+    baseline_figures_agreeing: Optional[int] = None
+    item_sum: Optional[float] = None
+    baseline: Optional[float] = None
+    item_count: int = 0
+
+    @property
+    def derived(self) -> bool:
+        """Whether the receipt passed the gate and produced proposals."""
+        return self.gate == GATE_OK
+
+
+def _word_key(ref: Any) -> Optional[tuple[int, int]]:
+    """Normalize a decoder word reference to (line_id, word_id)."""
+    if not ref:
+        return None
+    try:
+        return (int(ref["line_id"]), int(ref["word_id"]))
+    except (KeyError, TypeError, ValueError):
+        return None
+
+
+def _to_geometry_word(word: Any) -> Optional[dict[str, Any]]:
+    """Adapt a ReceiptWord entity to the decoder's word-dict shape."""
+    box = getattr(word, "bounding_box", None) or {}
+    try:
+        height = float(box.get("height", 0.0))
+        return {
+            "line_id": int(word.line_id),
+            "word_id": int(word.word_id),
+            "text": str(word.text),
+            "x": float(box.get("x", 0.0)),
+            "y_mid": float(box.get("y", 0.0)) + height / 2.0,
+            "h": height,
+        }
+    except (AttributeError, TypeError, ValueError):
+        return None
+
+
+def _has_letters(text: str) -> bool:
+    """Whether a token carries alphabetic content."""
+    return bool(re.search(r"[A-Za-z]", text or ""))
+
+
+def _amount_of(text: str) -> Optional[float]:
+    """Parse a word as a printed amount, or None."""
+    if not looks_like_receipt_amount(text):
+        return None
+    return parse_receipt_amount(text)
+
+
+def _numeric_of(text: str) -> Optional[float]:
+    """Parse a word as a bare number ("2", "2x", "1.31"), or None."""
+    match = re.match(r"^\s*(\d+(?:\.\d+)?)", text or "")
+    if not match:
+        return None
+    try:
+        return float(match.group(1))
+    except ValueError:
+        return None
+
+
+def _summary_value(summary: Optional[dict], key: str) -> Optional[float]:
+    """Read one numeric figure off the stored receipt summary."""
+    if not summary:
+        return None
+    value = summary.get(key)
+    try:
+        return float(value) if value is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _item_labels(
+    item: dict, texts: dict[tuple[int, int], str]
+) -> list[DerivedLabel]:
+    """Label proposals for one decoded item."""
+    out: list[DerivedLabel] = []
+    name = item.get("name") or ""
+    price = item.get("price")
+    is_discount = bool(item.get("is_discount"))
+
+    # The extended price word. A discount row's price IS the discount
+    # amount, so it takes DISCOUNT rather than LINE_TOTAL -- labelling it
+    # LINE_TOTAL would teach the model that a negative line total is
+    # normal and would double-count in every downstream sum.
+    price_key = _word_key(item.get("price_word_id"))
+    if price_key is not None and price is not None:
+        label = "DISCOUNT" if is_discount else "LINE_TOTAL"
+        out.append(
+            DerivedLabel(
+                line_id=price_key[0],
+                word_id=price_key[1],
+                label=label,
+                reasoning=(
+                    f"Decoder paired this amount with item {name!r} at "
+                    f"{price:.2f}; the receipt's items reconcile to its "
+                    "printed baseline"
+                ),
+                text=texts.get(price_key, ""),
+            )
+        )
+
+    # Product-name words. "low" name quality means the decoder recovered a
+    # price with no readable name, so there is nothing to name. Words with
+    # no letters are skipped: PRODUCT_NAME is descriptive text, and a bare
+    # numeric token in a name span is a SKU echo or an unrecognized
+    # quantity, never a product name.
+    if not is_discount and item.get("name_quality") != "low" and name:
+        priced = f" priced at {price:.2f}" if price is not None else ""
+        reasoning = (
+            f"Decoder read this word as part of the product name "
+            f"{name!r}{priced}; the receipt's items reconcile to its "
+            "printed baseline"
+        )
+        seen: set[tuple[int, int]] = set()
+        for ref in item.get("name_word_ids") or []:
+            key = _word_key(ref)
+            if key is None or key in seen:
+                continue
+            seen.add(key)
+            text = texts.get(key, "")
+            if not _has_letters(text):
+                continue
+            out.append(
+                DerivedLabel(
+                    line_id=key[0],
+                    word_id=key[1],
+                    label="PRODUCT_NAME",
+                    reasoning=reasoning,
+                    text=text,
+                )
+            )
+
+    out.extend(_quantity_labels(item, texts))
+    return out
+
+
+def _quantity_labels(
+    item: dict, texts: dict[tuple[int, int], str]
+) -> list[DerivedLabel]:
+    """QUANTITY / UNIT_PRICE proposals from the decoder's quantity span.
+
+    ``qty_word_ids`` covers the whole quantity expression ("2 @ 8.99",
+    a bare leading "3"), so the two roles are separated by value: the word
+    whose printed amount equals the parsed unit price is UNIT_PRICE, and
+    the word whose number equals the parsed quantity is QUANTITY. When a
+    role has no unambiguous single word, nothing is minted for it -- the
+    span is evidence, not a guess.
+    """
+    quantity = item.get("quantity")
+    unit_price = item.get("unit_price")
+    keys = [
+        key
+        for key in (_word_key(ref) for ref in item.get("qty_word_ids") or [])
+        if key is not None
+    ]
+    if not keys or quantity is None:
+        return []
+
+    unit_keys = (
+        [
+            key
+            for key in keys
+            if (amount := _amount_of(texts.get(key, ""))) is not None
+            and abs(amount - unit_price) < _CENT
+        ]
+        if unit_price is not None
+        else []
+    )
+    qty_keys = [
+        key
+        for key in keys
+        if key not in unit_keys
+        and (value := _numeric_of(texts.get(key, ""))) is not None
+        and abs(value - quantity) < 1e-9
+    ]
+
+    out: list[DerivedLabel] = []
+    if len(qty_keys) == 1:
+        key = qty_keys[0]
+        out.append(
+            DerivedLabel(
+                line_id=key[0],
+                word_id=key[1],
+                label="QUANTITY",
+                reasoning=(
+                    f"Decoder parsed quantity {quantity:g} for item "
+                    f"{item.get('name') or ''!r} from this word"
+                ),
+                text=texts.get(key, ""),
+            )
+        )
+    if len(unit_keys) == 1 and unit_price is not None:
+        key = unit_keys[0]
+        out.append(
+            DerivedLabel(
+                line_id=key[0],
+                word_id=key[1],
+                label="UNIT_PRICE",
+                reasoning=(
+                    f"Decoder parsed unit price {unit_price:.2f} x "
+                    f"{quantity:g} for item {item.get('name') or ''!r}"
+                ),
+                text=texts.get(key, ""),
+            )
+        )
+    return out
+
+
+def _summary_labels(
+    receipt_words: Sequence[Any], summary: Optional[dict]
+) -> list[DerivedLabel]:
+    """GRAND_TOTAL / SUBTOTAL / TAX proposals for printed summary words.
+
+    A word is labelled only when it sits on a summary anchor row AND its
+    printed amount equals the receipt's stored summary figure to the cent,
+    and only when exactly one anchored word carries that value. Two words
+    printing the same figure (a total echoed by a tender row) are
+    ambiguous, and ambiguity mints nothing.
+    """
+    out: list[DerivedLabel] = []
+    finders = (
+        ("GRAND_TOTAL", "grand_total", find_printed_grand_total_words),
+        ("SUBTOTAL", "subtotal", find_printed_subtotal_words),
+        ("TAX", "tax", find_printed_tax_words),
+    )
+    for label, key, finder in finders:
+        value = _summary_value(summary, key)
+        if value is None:
+            continue
+        matches = [
+            word
+            for amount, word in finder(list(receipt_words))
+            if abs(amount - value) < _CENT
+        ]
+        unique = {(int(w.line_id), int(w.word_id)): w for w in matches}
+        if len(unique) != 1:
+            continue
+        (line_id, word_id), word = next(iter(unique.items()))
+        out.append(
+            DerivedLabel(
+                line_id=line_id,
+                word_id=word_id,
+                label=label,
+                reasoning=(
+                    f"Printed {label.replace('_', ' ').lower()} row carries "
+                    f"{value:.2f}, matching the receipt summary; the "
+                    "decoded items reconcile to the printed baseline"
+                ),
+                text=str(word.text),
+            )
+        )
+    return out
+
+
+def derive_labels(
+    receipt_words: Sequence[Any],
+    items_line_ids: Iterable[int],
+    summary: Optional[dict],
+    *,
+    require_proven: bool = False,
+    printed_total: Optional[float] = None,
+    bank_amount: Optional[float] = None,
+) -> DerivationResult:
+    """Derive word labels from the reconciled line-item decode.
+
+    Args:
+        receipt_words: The receipt's ``ReceiptWord`` entities.
+        items_line_ids: Line ids of the receipt's ITEMS section.
+        summary: The stored receipt summary ({subtotal, tax, grand_total,
+            ...}), used both as the reconciliation baseline and as the
+            cross-check for the printed summary figures.
+        require_proven: Tighten the gate to the PROVEN tier -- the
+            printed total must also agree with the settled bank amount to
+            the cent (``geometry.is_proven``).
+        printed_total: The printed grand total, for the PROVEN check.
+            Defaults to the summary's grand total.
+        bank_amount: The settled bank amount, for the PROVEN check.
+
+    Returns:
+        A :class:`DerivationResult`. ``labels`` is empty unless ``gate``
+        is :data:`GATE_OK`.
+    """
+    line_ids = {int(x) for x in items_line_ids}
+    if not line_ids:
+        return DerivationResult(GATE_NO_ITEMS_SECTION)
+
+    words = [w for w in (_to_geometry_word(w) for w in receipt_words) if w]
+    texts = {(w["line_id"], w["word_id"]): w["text"] for w in words}
+
+    items, collapsed = extract_items(words, line_ids, summary=summary)
+    recon = reconcile_detailed(
+        [item for item in items if not item.get("is_discount")], summary
+    )
+    result = DerivationResult(
+        gate=GATE_OK,
+        reconciliation_status=recon.status,
+        baseline_figures_agreeing=recon.baseline_figures_agreeing,
+        item_sum=recon.item_sum,
+        baseline=recon.baseline,
+        item_count=len(items),
+    )
+
+    if not items:
+        result.gate = GATE_NO_ITEMS
+        return result
+    if recon.status != "match":
+        result.gate = GATE_NOT_MATCHED
+        return result
+    # Degenerate banding merged several prices into one band, so the
+    # word-to-item mapping is not trustworthy even when the sum lands.
+    if collapsed:
+        result.gate = GATE_COLLAPSED_BANDING
+        return result
+    if require_proven:
+        total = (
+            printed_total
+            if printed_total is not None
+            else _summary_value(summary, "grand_total")
+        )
+        if not is_proven(recon.status, total, bank_amount):
+            result.gate = GATE_NOT_PROVEN
+            return result
+
+    labels: list[DerivedLabel] = []
+    for item in items:
+        labels.extend(_item_labels(item, texts))
+    labels.extend(_summary_labels(receipt_words, summary))
+
+    # One word, one derived label. A word the decoder claims twice (a
+    # price that is also a summary figure) is ambiguous, and ambiguity
+    # mints nothing.
+    by_word: dict[tuple[int, int], list[DerivedLabel]] = {}
+    for proposal in labels:
+        by_word.setdefault(proposal.word_key, []).append(proposal)
+    result.labels = [
+        proposals[0]
+        for _, proposals in sorted(by_word.items())
+        if len({p.label for p in proposals}) == 1
+    ]
+    return result
+
+
+__all__ = [
+    "DECODER_PROPOSED_BY",
+    "DerivationResult",
+    "DerivedLabel",
+    "GATE_COLLAPSED_BANDING",
+    "GATE_NOT_MATCHED",
+    "GATE_NOT_PROVEN",
+    "GATE_NO_ITEMS",
+    "GATE_NO_ITEMS_SECTION",
+    "GATE_OK",
+    "derive_labels",
+]

--- a/receipt_upload/tests/test_line_item_label_derivation.py
+++ b/receipt_upload/tests/test_line_item_label_derivation.py
@@ -1,0 +1,230 @@
+"""Unit tests for deterministic word-label derivation from the decode.
+
+The gate is arithmetic: labels exist only when the decoded items sum to
+the receipt's printed baseline exactly. These tests pin that gate, the
+word-level placement of every label type, and the fail-closed rules
+(ambiguous summary figures, name words with no letters, discount rows).
+"""
+
+import pytest
+
+from receipt_upload.line_items.labels import (
+    DECODER_PROPOSED_BY,
+    GATE_NO_ITEMS_SECTION,
+    GATE_NOT_MATCHED,
+    GATE_NOT_PROVEN,
+    GATE_OK,
+    derive_labels,
+)
+
+
+class FakeWord:
+    """The ReceiptWord surface the derivation actually reads."""
+
+    def __init__(self, line_id, word_id, text, x, y, h=0.02):
+        self.line_id = line_id
+        self.word_id = word_id
+        self.text = text
+        self.bounding_box = {"x": x, "y": y - h / 2, "width": 0.1, "height": h}
+
+
+def row(line_id, y, *tokens, x0=0.1, dx=0.2):
+    return [
+        FakeWord(line_id, i + 1, t, x0 + dx * i, y)
+        for i, t in enumerate(tokens)
+    ]
+
+
+def placed(result):
+    """{(line_id, word_id): label} for every derived proposal."""
+    return {(p.line_id, p.word_id): p.label for p in result.labels}
+
+
+def by_label(result):
+    """{label: {word texts}} for every derived proposal."""
+    out = {}
+    for proposal in result.labels:
+        out.setdefault(proposal.label, set()).add(proposal.text)
+    return out
+
+
+def test_names_and_prices_land_on_the_right_words():
+    words = row(1, 0.10, "ORGANIC", "BANANAS", "2.99") + row(
+        2, 0.15, "WHOLE", "MILK", "4.49"
+    )
+    result = derive_labels(words, {1, 2}, {"subtotal": 7.48})
+
+    assert result.gate == GATE_OK
+    assert result.reconciliation_status == "match"
+    assert by_label(result) == {
+        "PRODUCT_NAME": {"ORGANIC", "BANANAS", "WHOLE", "MILK"},
+        "LINE_TOTAL": {"2.99", "4.49"},
+    }
+    assert placed(result)[(1, 3)] == "LINE_TOTAL"
+    assert placed(result)[(2, 3)] == "LINE_TOTAL"
+
+
+def test_mismatch_mints_nothing():
+    words = row(1, 0.10, "ORGANIC", "BANANAS", "2.99")
+    result = derive_labels(words, {1}, {"subtotal": 99.00})
+
+    assert result.gate == GATE_NOT_MATCHED
+    assert result.reconciliation_status == "mismatch"
+    assert result.labels == []
+
+
+def test_no_baseline_mints_nothing():
+    words = row(1, 0.10, "ORGANIC", "BANANAS", "2.99")
+    result = derive_labels(words, {1}, None)
+
+    assert result.gate == GATE_NOT_MATCHED
+    assert result.reconciliation_status == "no-baseline"
+    assert result.labels == []
+
+
+def test_near_never_qualifies():
+    # 2.99 against a 3.05 baseline is "near", not "match".
+    words = row(1, 0.10, "ORGANIC", "BANANAS", "2.99")
+    result = derive_labels(words, {1}, {"subtotal": 3.05})
+
+    assert result.reconciliation_status == "near"
+    assert result.gate == GATE_NOT_MATCHED
+    assert result.labels == []
+
+
+def test_empty_items_section_mints_nothing():
+    words = row(1, 0.10, "ORGANIC", "BANANAS", "2.99")
+    result = derive_labels(words, set(), {"subtotal": 2.99})
+
+    assert result.gate == GATE_NO_ITEMS_SECTION
+    assert result.labels == []
+
+
+def test_name_words_without_letters_are_skipped():
+    # The trailing "1" is a quantity the decoder folded into the name; a
+    # bare numeric token is never descriptive text.
+    words = row(1, 0.10, "Large", "Popcorn", "1", "12.99")
+    result = derive_labels(words, {1}, {"subtotal": 12.99})
+
+    assert result.gate == GATE_OK
+    assert by_label(result)["PRODUCT_NAME"] == {"Large", "Popcorn"}
+    assert (1, 3) not in placed(result)
+
+
+def test_discount_row_takes_discount_not_line_total():
+    words = (
+        row(1, 0.10, "ORGANIC", "BANANAS", "5.00")
+        + row(2, 0.15, "MEMBER", "SAVINGS", "-1.00")
+        + row(3, 0.20, "WHOLE", "MILK", "4.00")
+    )
+    result = derive_labels(words, {1, 2, 3}, {"subtotal": 9.00})
+
+    assert result.gate == GATE_OK
+    labels = by_label(result)
+    assert labels["DISCOUNT"] == {"-1.00"}
+    assert labels["LINE_TOTAL"] == {"5.00", "4.00"}
+    # A discount row's words are not a product name.
+    assert "MEMBER" not in labels["PRODUCT_NAME"]
+
+
+def test_quantity_and_unit_price_split_by_value():
+    words = row(1, 0.10, "SODA", "2", "@", "1.50", "3.00")
+    result = derive_labels(words, {1}, {"subtotal": 3.00})
+
+    assert result.gate == GATE_OK
+    labels = by_label(result)
+    assert labels["QUANTITY"] == {"2"}
+    assert labels["UNIT_PRICE"] == {"1.50"}
+    assert labels["LINE_TOTAL"] == {"3.00"}
+    assert labels["PRODUCT_NAME"] == {"SODA"}
+
+
+def test_leading_quantity_word_is_labelled():
+    words = row(1, 0.10, "3", "ORGANIC", "BANANAS", "6.00")
+    result = derive_labels(words, {1}, {"subtotal": 6.00})
+
+    assert result.gate == GATE_OK
+    assert placed(result)[(1, 1)] == "QUANTITY"
+    assert by_label(result)["PRODUCT_NAME"] == {"ORGANIC", "BANANAS"}
+
+
+def test_printed_summary_figures_are_labelled():
+    words = (
+        row(1, 0.10, "ORGANIC", "BANANAS", "2.99")
+        + row(2, 0.20, "SUBTOTAL", "2.99")
+        + row(3, 0.25, "TAX", "0.21")
+        + row(4, 0.30, "TOTAL", "3.20")
+    )
+    result = derive_labels(
+        words, {1}, {"subtotal": 2.99, "tax": 0.21, "grand_total": 3.20}
+    )
+
+    assert result.gate == GATE_OK
+    assert placed(result)[(2, 2)] == "SUBTOTAL"
+    assert placed(result)[(3, 2)] == "TAX"
+    assert placed(result)[(4, 2)] == "GRAND_TOTAL"
+
+
+def test_summary_figure_printed_twice_is_ambiguous():
+    # "Balance to pay 37.51" and the terminal's "TOTAL PURCHASE 37.51"
+    # are both grand-total anchors: picking one would be a guess.
+    words = (
+        row(1, 0.10, "ORGANIC", "BANANAS", "37.51")
+        + row(2, 0.20, "Balance", "to", "pay", "37.51")
+        + row(3, 0.30, "TOTAL", "PURCHASE", "37.51")
+    )
+    result = derive_labels(words, {1}, {"grand_total": 37.51})
+
+    assert result.gate == GATE_OK
+    assert "GRAND_TOTAL" not in by_label(result)
+
+
+def test_summary_word_disagreeing_with_the_summary_is_not_labelled():
+    words = row(1, 0.10, "ORGANIC", "BANANAS", "2.99") + row(
+        2, 0.20, "TOTAL", "9.99"
+    )
+    result = derive_labels(words, {1}, {"subtotal": 2.99, "grand_total": 3.20})
+
+    assert result.gate == GATE_OK
+    assert "GRAND_TOTAL" not in by_label(result)
+
+
+def test_one_word_never_gets_two_labels():
+    words = row(1, 0.10, "ORGANIC", "BANANAS", "2.99") + row(
+        2, 0.20, "SUBTOTAL", "2.99"
+    )
+    result = derive_labels(words, {1}, {"subtotal": 2.99})
+
+    counted = {}
+    for proposal in result.labels:
+        counted[proposal.word_key] = counted.get(proposal.word_key, 0) + 1
+    assert set(counted.values()) == {1}
+
+
+@pytest.mark.parametrize(
+    "bank_amount,expected_gate",
+    [(3.20, GATE_OK), (3.21, GATE_NOT_PROVEN), (None, GATE_NOT_PROVEN)],
+)
+def test_require_proven_needs_the_bank_hop(bank_amount, expected_gate):
+    words = row(1, 0.10, "ORGANIC", "BANANAS", "2.99")
+    result = derive_labels(
+        words,
+        {1},
+        {"subtotal": 2.99, "grand_total": 3.20},
+        require_proven=True,
+        bank_amount=bank_amount,
+    )
+    assert result.gate == expected_gate
+
+
+def test_proposed_by_marker_is_distinct_from_llm_proposers():
+    assert DECODER_PROPOSED_BY == "decoder_reconciled"
+    assert "llm" not in DECODER_PROPOSED_BY
+
+
+def test_every_proposal_carries_reasoning():
+    words = row(1, 0.10, "ORGANIC", "BANANAS", "2.99")
+    result = derive_labels(words, {1}, {"subtotal": 2.99})
+    assert result.labels
+    for proposal in result.labels:
+        assert proposal.reasoning.strip()

--- a/scripts/backfill_decoder_word_labels.py
+++ b/scripts/backfill_decoder_word_labels.py
@@ -51,6 +51,12 @@ for _pkg in ("receipt_dynamo", "receipt_upload"):
     if _p.is_dir():
         sys.path.insert(0, str(_p))
 
+# isort: off
+# These imports must follow the sys.path bootstrap above, and the repo has
+# no root isort config: whether receipt_dynamo and receipt_upload are one
+# import block or two depends on which package's pyproject the linter
+# happens to resolve, and the two CI lint jobs disagree. Fenced so neither
+# can reorder them.
 from receipt_dynamo.data.dynamo_client import DynamoClient  # noqa: E402
 from receipt_dynamo.data.shared_exceptions import (  # noqa: E402
     EntityAlreadyExistsError,
@@ -59,12 +65,13 @@ from receipt_dynamo.entities.receipt_word import ReceiptWord  # noqa: E402
 from receipt_dynamo.entities.receipt_word_label import (  # noqa: E402
     ReceiptWordLabel,
 )
-
 from receipt_upload.line_items.labels import (  # noqa: E402
     DECODER_PROPOSED_BY,
     GATE_OK,
     derive_labels,
 )
+
+# isort: on
 
 DEV_TABLE = "ReceiptsTable-dc5be22"
 PROD_MARKER = "d7ff76a"

--- a/scripts/backfill_decoder_word_labels.py
+++ b/scripts/backfill_decoder_word_labels.py
@@ -1,0 +1,365 @@
+"""Backfill deterministic ReceiptWordLabel rows from the reconciled decode.
+
+The band-block decoder knows word for word which words are a product's
+name and which word carries its extended price, but nothing wrote that
+down: receipts ingested by the Swift worker get header/footer metadata
+labels and zero product or financial labels.
+
+This script runs ``receipt_upload.line_items.labels.derive_labels`` over
+every receipt with an ITEMS section, gates on the decode reconciling to
+the receipt's printed baseline as a full ``match``, and writes the
+proposals as ``label_proposed_by="decoder_reconciled"``.
+
+Never clobbers. Every write goes through the singular conditional put
+(``add_receipt_word_label``, ``attribute_not_exists(PK)``), and any word
+that already carries ANY label -- human, LLM or otherwise -- is skipped
+before the write is even attempted.
+
+Usage:
+    # dry run over the dev corpus, with a blast-radius report
+    python3.12 scripts/backfill_decoder_word_labels.py
+
+    # one receipt, showing every proposed word
+    python3.12 scripts/backfill_decoder_word_labels.py \
+        --receipt 90af9793-b468-475c-bd31-902a922830d4:1 --verbose
+
+    # write to dev
+    python3.12 scripts/backfill_decoder_word_labels.py --apply
+
+    # prod writes need the explicit opt-in
+    python3.12 scripts/backfill_decoder_word_labels.py \
+        --table ReceiptsTable-d7ff76a --apply --allow-prod
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+import boto3
+from boto3.dynamodb.types import TypeDeserializer
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+for _pkg in ("receipt_dynamo", "receipt_upload"):
+    _p = _REPO_ROOT / _pkg
+    if _p.is_dir():
+        sys.path.insert(0, str(_p))
+
+from receipt_dynamo.data.dynamo_client import DynamoClient  # noqa: E402
+from receipt_dynamo.data.shared_exceptions import (  # noqa: E402
+    EntityAlreadyExistsError,
+)
+from receipt_dynamo.entities.receipt_word import ReceiptWord  # noqa: E402
+from receipt_dynamo.entities.receipt_word_label import (  # noqa: E402
+    ReceiptWordLabel,
+)
+
+from receipt_upload.line_items.labels import (  # noqa: E402
+    DECODER_PROPOSED_BY,
+    GATE_OK,
+    derive_labels,
+)
+
+DEV_TABLE = "ReceiptsTable-dc5be22"
+PROD_MARKER = "d7ff76a"
+_DES = TypeDeserializer()
+_WORD_SK_RE = re.compile(r"^RECEIPT#\d+#LINE#(\d+)#WORD#(\d+)$")
+_LABEL_SK_RE = re.compile(r"^RECEIPT#\d+#LINE#(\d+)#WORD#(\d+)#LABEL#")
+
+
+def _query_all(client, **kwargs):
+    while True:
+        resp = client.query(**kwargs)
+        yield from resp["Items"]
+        if "LastEvaluatedKey" not in resp:
+            return
+        kwargs["ExclusiveStartKey"] = resp["LastEvaluatedKey"]
+
+
+def _deser(item: dict) -> dict:
+    return {k: _DES.deserialize(v) for k, v in item.items()}
+
+
+def _fetch(client, table: str, image_id: str, receipt_id: int):
+    """One query per receipt: words, sections, summary, existing labels."""
+    words: list[ReceiptWord] = []
+    sections: list[dict] = []
+    summary: Optional[dict] = None
+    labeled: dict[tuple[int, int], set[str]] = {}
+    for raw in _query_all(
+        client,
+        TableName=table,
+        KeyConditionExpression="PK = :pk AND begins_with(SK, :sk)",
+        ExpressionAttributeValues={
+            ":pk": {"S": f"IMAGE#{image_id}"},
+            ":sk": {"S": f"RECEIPT#{receipt_id:05d}"},
+        },
+    ):
+        entity_type = raw.get("TYPE", {}).get("S")
+        if entity_type == "RECEIPT_WORD":
+            if _WORD_SK_RE.match(raw["SK"]["S"]):
+                try:
+                    words.append(ReceiptWord.from_item(raw))
+                except (ValueError, KeyError):
+                    continue
+        elif entity_type == "RECEIPT_SECTION":
+            sections.append(_deser(raw))
+        elif entity_type == "RECEIPT_SUMMARY":
+            summary = _deser(raw)
+        elif entity_type == "RECEIPT_WORD_LABEL":
+            match = _LABEL_SK_RE.match(raw["SK"]["S"])
+            if match:
+                key = (int(match.group(1)), int(match.group(2)))
+                label = raw["SK"]["S"].split("#LABEL#", 1)[1]
+                labeled.setdefault(key, set()).add(label)
+    return words, sections, summary, labeled
+
+
+def _items_line_ids(sections: list[dict]) -> set[int]:
+    """Line ids of the receipt's ITEMS section, whatever its status.
+
+    Worker-ingested receipts carry PENDING sections (model_source
+    ``swift-worker-v1``); older ones carry VALID. The section's status is
+    not the trust signal here -- the arithmetic gate is.
+    """
+    for section in sections:
+        if section.get("section_type") == "ITEMS":
+            return {int(x) for x in (section.get("line_ids") or [])}
+    return set()
+
+
+def _scan_targets(client, table: str) -> list[tuple[str, int]]:
+    """Every receipt with an ITEMS section."""
+    targets: set[tuple[str, int]] = set()
+    kwargs: dict[str, Any] = dict(
+        TableName=table,
+        IndexName="GSITYPE",
+        KeyConditionExpression="#t = :t",
+        ExpressionAttributeNames={"#t": "TYPE"},
+        ExpressionAttributeValues={":t": {"S": "RECEIPT_SECTION"}},
+    )
+    for raw in _query_all(client, **kwargs):
+        if raw.get("section_type", {}).get("S") != "ITEMS":
+            continue
+        image = re.match(r"IMAGE#(.+)", raw["PK"]["S"])
+        receipt = re.match(r"RECEIPT#(\d+)#", raw["SK"]["S"])
+        if image and receipt:
+            targets.add((image.group(1), int(receipt.group(1))))
+    return sorted(targets)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--table", default=DEV_TABLE)
+    parser.add_argument(
+        "--apply", action="store_true", help="write labels (default dry-run)"
+    )
+    parser.add_argument(
+        "--allow-prod",
+        action="store_true",
+        help="required alongside --apply to write to the prod table",
+    )
+    parser.add_argument("--receipt", help="IMAGE_ID:RID single-receipt mode")
+    parser.add_argument("--limit", type=int)
+    parser.add_argument(
+        "--require-proven",
+        action="store_true",
+        help="tighten the gate to the PROVEN tier (bank-amount agreement)",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="print every proposed word label",
+    )
+    parser.add_argument("--json-out", help="write per-receipt detail as JSONL")
+    args = parser.parse_args()
+
+    is_prod = PROD_MARKER in args.table
+    if is_prod and args.apply and not args.allow_prod:
+        sys.exit(
+            "REFUSED: writing to the prod table requires --allow-prod. "
+            "Dry runs against prod are always allowed."
+        )
+
+    client = boto3.client("dynamodb", region_name="us-east-1")
+    dynamo = DynamoClient(args.table) if args.apply else None
+
+    if args.receipt:
+        image_id, rid = args.receipt.split(":")
+        targets = [(image_id, int(rid))]
+    else:
+        targets = _scan_targets(client, args.table)
+        if args.limit:
+            targets = targets[: args.limit]
+
+    now = datetime.now(timezone.utc).isoformat()
+    gates: Counter = Counter()
+    minted: Counter = Counter()
+    collided: Counter = Counter()
+    written: Counter = Counter()
+    agreement: Counter = Counter()
+    disagreements: Counter = Counter()
+    receipts_with_labels = 0
+    out_handle = open(args.json_out, "w") if args.json_out else None
+
+    for index, (image_id, receipt_id) in enumerate(targets):
+        words, sections, summary, labeled = _fetch(
+            client, args.table, image_id, receipt_id
+        )
+        result = derive_labels(
+            words,
+            _items_line_ids(sections),
+            summary,
+            require_proven=args.require_proven,
+        )
+        gates[result.gate] += 1
+        if result.gate != GATE_OK:
+            if out_handle:
+                out_handle.write(
+                    json.dumps(
+                        {
+                            "image_id": image_id,
+                            "receipt_id": receipt_id,
+                            "gate": result.gate,
+                            "reconciliation_status": (
+                                result.reconciliation_status
+                            ),
+                        }
+                    )
+                    + "\n"
+                )
+            continue
+
+        fresh = [p for p in result.labels if p.word_key not in labeled]
+        for proposal in result.labels:
+            existing = labeled.get(proposal.word_key)
+            if existing is None:
+                minted[proposal.label] += 1
+                continue
+            collided[proposal.label] += 1
+            # The collisions are free validation: where the corpus
+            # already has an opinion about a word, does the arithmetic
+            # derivation agree with it?
+            agreement[
+                "agree" if proposal.label in existing else "disagree"
+            ] += 1
+            if proposal.label not in existing:
+                disagreements[
+                    (proposal.label, "|".join(sorted(existing)))
+                ] += 1
+        if fresh:
+            receipts_with_labels += 1
+
+        if args.verbose or args.receipt:
+            print(
+                f"\n{image_id}:{receipt_id}  recon="
+                f"{result.reconciliation_status} "
+                f"agree={result.baseline_figures_agreeing} "
+                f"items={result.item_count} "
+                f"sum={result.item_sum} baseline={result.baseline}"
+            )
+            for proposal in result.labels:
+                flag = (
+                    "SKIP(existing label)"
+                    if proposal.word_key in labeled
+                    else "MINT"
+                )
+                print(
+                    f"  {flag:20s} L{proposal.line_id:05d}"
+                    f"W{proposal.word_id:05d} {proposal.label:13s} "
+                    f"{proposal.text!r}"
+                )
+
+        if out_handle:
+            out_handle.write(
+                json.dumps(
+                    {
+                        "image_id": image_id,
+                        "receipt_id": receipt_id,
+                        "gate": result.gate,
+                        "reconciliation_status": result.reconciliation_status,
+                        "baseline_figures_agreeing": (
+                            result.baseline_figures_agreeing
+                        ),
+                        "labels": [
+                            {
+                                "line_id": p.line_id,
+                                "word_id": p.word_id,
+                                "label": p.label,
+                                "text": p.text,
+                                "existing": sorted(
+                                    labeled.get(p.word_key, ())
+                                ),
+                            }
+                            for p in result.labels
+                        ],
+                    }
+                )
+                + "\n"
+            )
+
+        if args.apply and dynamo is not None:
+            for proposal in fresh:
+                label = ReceiptWordLabel(
+                    image_id=image_id,
+                    receipt_id=receipt_id,
+                    line_id=proposal.line_id,
+                    word_id=proposal.word_id,
+                    label=proposal.label,
+                    reasoning=proposal.reasoning,
+                    timestamp_added=now,
+                    validation_status="PENDING",
+                    label_proposed_by=DECODER_PROPOSED_BY,
+                )
+                try:
+                    dynamo.add_receipt_word_label(label)
+                    written[proposal.label] += 1
+                except EntityAlreadyExistsError:
+                    collided[proposal.label] += 1
+
+        if (index + 1) % 100 == 0:
+            print(f"  {index + 1}/{len(targets)}", file=sys.stderr, flush=True)
+
+    if out_handle:
+        out_handle.close()
+
+    mode = "APPLY" if args.apply else "dry-run"
+    print(f"\n[{mode}] table={args.table} receipts_scanned={len(targets)}")
+    print(f"  gates: {dict(sorted(gates.items()))}")
+    print(f"  receipts producing new labels: {receipts_with_labels}")
+    print(
+        f"  would mint: {dict(sorted(minted.items()))} "
+        f"total={sum(minted.values())}"
+    )
+    print(
+        f"  collisions skipped: {dict(sorted(collided.items()))} "
+        f"total={sum(collided.values())}"
+    )
+    if agreement:
+        agree, disagree = agreement["agree"], agreement["disagree"]
+        rate = agree / max(1, agree + disagree)
+        print(
+            f"  collision agreement: {agree} agree / {disagree} disagree "
+            f"({rate:.1%})"
+        )
+        print("  top disagreements (derived -> existing):")
+        for (derived, existing), count in disagreements.most_common(15):
+            print(f"    {derived:13s} -> {existing:30s} {count}")
+    if args.apply:
+        print(
+            f"  written: {dict(sorted(written.items()))} "
+            f"total={sum(written.values())}"
+        )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## The gap

The band-block decoder already knows, word for word, which words are a product's name and which word carries its extended price — `parse_band` returns `name_word_ids` / `price_word_id` / `qty_word_ids` on every item it emits. Nothing wrote that down.

So receipts ingested by the Swift worker land with header/footer metadata labels only (MERCHANT_NAME, STORE_HOURS, PAYMENT_METHOD, DATE, TIME, WEBSITE) and **zero** product or financial labels, while older prod receipts carry PRODUCT_NAME 6107, LINE_TOTAL 2695, UNIT_PRICE 1898, QUANTITY 1126, GRAND_TOTAL 1393, SUBTOTAL 903, TAX 687, DISCOUNT 1278. That's a gap in the new ingest path, not a design choice.

## What this adds

`receipt_upload/receipt_upload/line_items/labels.py` — `derive_labels()` turns the decode into label proposals.

**The gate is arithmetic, not heuristic.** Labels exist only when the decoded items reconcile to the receipt's printed baseline as a full `match` (`near` never qualifies, however small the band). That makes the name↔price pairing arithmetically proven: change any pairing and the sum stops landing on the printed figure. `require_proven=True` tightens to the PROVEN tier via `geometry.is_proven` (printed total also agrees with the settled bank amount to the cent).

Nothing is minted on the module's own judgement. Every proposal points at a word the decoder already identified, or at a printed summary figure whose value equals the stored summary figure to the cent.

**Fail-closed wherever ambiguity exists:**
- a summary figure printed twice (Trader Joe's `Balance to pay 37.51` plus the terminal's `TOTAL PURCHASE 37.51`) mints no GRAND_TOTAL
- a quantity span whose roles can't be split by value mints neither QUANTITY nor UNIT_PRICE
- a word two rules claim mints nothing
- discount rows take DISCOUNT, not a negative LINE_TOTAL
- name words with no letters are skipped — PRODUCT_NAME is descriptive text, and a bare numeric in a name span is a SKU echo or unrecognized quantity

**Never clobbers.** `scripts/backfill_decoder_word_labels.py` writes through the singular conditional put (`add_receipt_word_label`, `attribute_not_exists(PK)`), and any word already carrying *any* label — human, LLM or otherwise — is skipped before the write is attempted. Prod writes require an explicit `--allow-prod`. Labels land PENDING with `label_proposed_by="decoder_reconciled"`, distinct from every LLM proposer so the population stays auditable and retractable.

## Why cloud-side, not Swift worker-side

Derivation from stored records reaches the ~500 already-reconciling receipts per table in one backfill pass and keeps the worker's job narrow. Delivered as library + script; no Lambda wiring, no changes to `infra/receipt_line_item_updater/`.

## Supporting decoder changes (provably output-neutral)

Two provenance fixes, both purely additive to the emitted item dicts:

1. `parse_band` records the word a leading quantity was consumed from, so QUANTITY can point at it.
2. `decode_band_blocks` carries `name_word_ids` to the donor band when a stacked layout's name comes from another band. Left pointing at the price band, it would have named the **SKU words** for every stacked item.

Verified neutral: decoded `(name, price, quantity, unit_price, is_discount, line_ids, name_quality)` over all 691 dev receipts hashes to the identical sha256 `a521f9af…` with and without these changes.

`receipt_summary` gains word-returning companions to the printed-figure finders (`find_printed_grand_total_words` / `_subtotal_words` / `_tax_words`) by splitting `_find_anchored_amount`, whose semantics are unchanged.

## Verification — the 3 receipts ingested today

All three reconcile at `match`; dry-run output confirmed by eye against the known item names.

**IMG_3420** Trader Joe's, 7 items, 39.49 (`90af9793…`) → 24 PRODUCT_NAME + 7 LINE_TOTAL

```
PRODUCT_NAME  L8:'BBQ' 'CHICKEN' 'PIZZA'   L9:'CHICKEN' 'MARSALA' 'MASH' 'POT'
              L10:'MILK' 'QUART' 'WHOLE'   L11:'HAM' 'AND' 'CHEESE' 'POCKET' 'FU'
              L12:'STEEL' 'CUT' 'OATMEAL'  L13:'COHO' 'SALMON' 'FILLETS'
              L14:"TU'S" 'FROSTED' 'FLAKES'
LINE_TOTAL    L20:'$5.99' L21:'$8.49' L22:'$1.79' L23:'$4.99'
              L24:'$2.29' L25:'$13.15' L26:'$2.79'
```

**IMG_3404** Trader Joe's, 5 items, 37.51 (`2b630bec…`) → 18 PRODUCT_NAME + 5 LINE_TOTAL, names on `PORK AL PASTOR DICED`, both `SALMON FILLET SKIN OFF` rows, `VILLA ITALIA ITAL BLOOD`, `LEMON EACH`; totals on `$10.19 $9.74 $10.85 $3.79 $2.94`.

**IMG_3411** Regal, 1 item, 12.99 (`67b149c0…`) → `PRODUCT_NAME 'Large' 'Popcorn'`, `LINE_TOTAL '12.99'`, `SUBTOTAL '12.99'`, `GRAND_TOTAL '14.08'`. The bare `'1'` in the decoded name `"Large Popcorn 1"` was correctly excluded by the no-letters rule.

Neither Trader Joe's receipt got a GRAND_TOTAL: both print the total twice (`Balance to pay $37.51` and the payment terminal's `TOTAL PURCHASE $37.51`), and picking one would be a guess. `reconstructor.dedupe_grand_total` exists for that case; this module stays fail-closed.

**Written to dev** (`ReceiptsTable-dc5be22`) for all three: 23 + 5 + 31 = 59 rows, all `PENDING` / `decoder_reconciled`, full GSI1–4 key set, zero collisions. Re-running is a no-op (31/31 skipped, 100% agreement). **Nothing written to prod.**

## Corpus blast radius (dry-run, both tables)

| | prod `d7ff76a` | dev `dc5be22` |
|---|---|---|
| receipts with an ITEMS section | 730 | 691 |
| pass the arithmetic gate | **505** | **520** |
| not-matched / no-items | 196 / 29 | 142 / 29 |
| receipts gaining labels | 180 | 194 |
| **new labels** | **807** | **965** |
| — PRODUCT_NAME / LINE_TOTAL | 664 / 75 | 770 / 96 |
| — QUANTITY / GRAND_TOTAL / SUBTOTAL / DISCOUNT | 50 / 9 / 5 / 4 | 67 / 16 / 13 / 3 |
| collisions skipped | 5563 | 5795 |

The collisions are free validation — where the corpus already has an opinion about a word, does the arithmetic derivation agree?

**prod: 5399 agree / 164 disagree (97.1%)** · **dev: 5599 / 196 (96.6%)**

Top prod disagreements (derived → existing), honestly reported:

| derived | existing | n |
|---|---|---|
| PRODUCT_NAME | QUANTITY | 23 |
| LINE_TOTAL | PRODUCT_NAME | 10 |
| PRODUCT_NAME | LINE_TOTAL\|UNIT_PRICE | 8 |
| PRODUCT_NAME | WEBSITE | 8 |
| PRODUCT_NAME | PAYMENT_METHOD | 7 |
| PRODUCT_NAME | UNIT_PRICE | 7 |

These are all skipped (never written), so they cost nothing today — but the PRODUCT_NAME→WEBSITE / PAYMENT_METHOD cluster is a real signal that a handful of ITEMS sections still over-reach into footer rows. Worth a follow-up look at those receipts.

Note this does **not** subsume `reconstructor.propose_line_item_labels` (`geometry_line_items`, F1 0.85/0.82): that one needs pre-existing SUBTOTAL/TAX/GRAND_TOTAL anchor labels to bound the region, which the worker path never creates. This one needs no anchors and gates on arithmetic instead.

## Testing

- 19 new unit tests in `receipt_upload/tests/test_line_item_label_derivation.py` pinning the gate (match/near/mismatch/no-baseline/proven), word-level placement of all 7 label types, and every fail-closed rule
- golden floors, `receipt_upload` suite, `receipt_dynamo` unit suite (2373), root `tests/` all green
- `black`/`isort` replicated from a bare 3.12 venv, per-package exactly as `main.yml` runs them

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TzUnnRheR1xinDRCS6s4fB
