### PR TITLE
feat(labels): elect the canonical grand total and derive verified header fields

### DIFF
--- a/receipt_upload/receipt_upload/line_items/labels.py
+++ b/receipt_upload/receipt_upload/line_items/labels.py
@@ -10,8 +10,9 @@ product or financial labels.
 
 This module turns the decode into label proposals. It mints nothing on
 its own judgement: every proposal points at a word the decoder already
-identified, or at a printed summary figure that equals the receipt's
-stored summary value to the cent.
+identified, or at printed text that equals a value the receipt already
+stores -- a summary figure to the cent, the ReceiptPlace row's address
+or phone, the summary's settled card last four.
 
 The gate is arithmetic, not heuristic. Labels are derived only when the
 decoded items reconcile to the receipt's printed baseline as a full
@@ -47,6 +48,7 @@ from receipt_upload.line_items.geometry import (
     is_proven,
     reconcile_detailed,
 )
+from receipt_upload.line_items.reconstructor import dedupe_grand_total
 
 # The provenance marker for every label this module derives. Distinct from
 # every LLM proposer ("llm_valid", "llm_needs_review", "*_analyzer_llm")
@@ -57,6 +59,29 @@ DECODER_PROPOSED_BY = "decoder_reconciled"
 # summary figure. Both sides are printed money, so this is exact-match
 # slack for float representation only, not a comparison band.
 _CENT = 0.005
+
+# Floor for "same visual row" when checking that a grand-total election
+# actually discriminated between two restatements of the total. Two
+# anchored copies printed side by side on one row cannot be told apart by
+# any row-ordering rule, so that case still mints nothing.
+_MIN_ROW_BAND = 0.005
+
+# Mask glyphs a receipt uses to redact a card number.
+_PAN_MASK_CHARS = "*#xX•·"
+
+# The trailing country component of a formatted address, dropped before
+# the street/city/state/postal split.
+_COUNTRY_TOKENS = frozenset({"usa", "us", "unitedstates"})
+
+# A US phone number, allowing the separators OCR actually preserves.
+_PHONE_RE = re.compile(r"(?:\+?1[-. ]?)?\(?\d{3}\)?[-. ]?\d{3}[-. ]?\d{4}")
+# Phone-shaped punctuation. Without a merchant phone to verify against, a
+# run of digits separated only by spaces is an order number as often as a
+# phone, so only a formatted number qualifies.
+_PHONE_PUNCT_RE = re.compile(r"[-.()]")
+# The longest word span the phone scan will join. A US number never needs
+# more than "(702)" "433" "-" "6773".
+_PHONE_MAX_SPAN = 4
 
 # Gate verdicts (why a receipt did or did not produce labels).
 GATE_OK = "ok"
@@ -299,16 +324,109 @@ def _quantity_labels(
     return out
 
 
+@dataclass
+class _ElectionCandidate:
+    """A stand-in GRAND_TOTAL label, for ``dedupe_grand_total`` to elect.
+
+    ``dedupe_grand_total`` decides which of a receipt's restatements of
+    the total is canonical, reading only these four fields off each
+    label. Handing it stand-ins for the words we are *about* to label
+    runs the corpus's own election rule over our proposals, instead of
+    inventing a second one that could disagree with it.
+    """
+
+    line_id: int
+    word_id: int
+    label: str = "GRAND_TOTAL"
+    validation_status: str = "PENDING"
+
+
+def _y_center(word: Any) -> Optional[float]:
+    """Normalized y-center of a word's bounding box, or None."""
+    box = getattr(word, "bounding_box", None) or {}
+    try:
+        return float(box.get("y", 0.0)) + float(box.get("height", 0.0)) / 2.0
+    except (TypeError, ValueError):
+        return None
+
+
+def _row_band(word: Any) -> float:
+    """Half-row tolerance around a word, in normalized units."""
+    box = getattr(word, "bounding_box", None) or {}
+    try:
+        height = float(box.get("height", 0.0))
+    except (TypeError, ValueError):
+        height = 0.0
+    return max(0.6 * height, _MIN_ROW_BAND)
+
+
+def _elect_grand_total_word(
+    receipt_words: Sequence[Any], candidates: Sequence[Any]
+) -> Optional[Any]:
+    """Pick the one word that carries the receipt's grand total.
+
+    Receipts restate the total: Trader Joe's prints it against "Balance
+    to pay" on the store copy and again against "TOTAL PURCHASE" on the
+    card slip, and both are legitimate grand-total anchors. A receipt has
+    exactly one grand total, and ``reconstructor.dedupe_grand_total``
+    already decides which restatement is canonical and invalidates the
+    rest -- so labelling every copy would mint labels the pipeline's own
+    dedupe pass then has to retract, and would teach a model that echoes
+    of the total are grand totals. We label the copy dedupe would keep.
+
+    Still fail-closed where the anchor genuinely cannot discriminate:
+    if the election leaves more than one survivor, or if a losing copy
+    shares the winner's visual row (so no row-ordering rule could have
+    separated them), nothing is minted.
+    """
+    if not candidates:
+        return None
+    if len(candidates) == 1:
+        return candidates[0]
+
+    stand_ins = [
+        _ElectionCandidate(int(w.line_id), int(w.word_id)) for w in candidates
+    ]
+    redundant = {
+        id(x)
+        for x in dedupe_grand_total(
+            list(receipt_words), stand_ins  # type: ignore[arg-type]
+        )
+    }
+    survivors = [
+        word
+        for word, stand_in in zip(candidates, stand_ins)
+        if id(stand_in) not in redundant
+    ]
+    if len(survivors) != 1:
+        return None
+    elected = survivors[0]
+
+    elected_y = _y_center(elected)
+    if elected_y is None:
+        return None
+    band = _row_band(elected)
+    for other in candidates:
+        if other is elected:
+            continue
+        other_y = _y_center(other)
+        if other_y is None or abs(other_y - elected_y) <= band:
+            return None
+    return elected
+
+
 def _summary_labels(
     receipt_words: Sequence[Any], summary: Optional[dict]
 ) -> list[DerivedLabel]:
     """GRAND_TOTAL / SUBTOTAL / TAX proposals for printed summary words.
 
     A word is labelled only when it sits on a summary anchor row AND its
-    printed amount equals the receipt's stored summary figure to the cent,
-    and only when exactly one anchored word carries that value. Two words
-    printing the same figure (a total echoed by a tender row) are
-    ambiguous, and ambiguity mints nothing.
+    printed amount equals the receipt's stored summary figure to the
+    cent. GRAND_TOTAL tolerates the figure being restated -- receipts
+    print the total against several anchors -- and elects the canonical
+    copy via :func:`_elect_grand_total_word`. SUBTOTAL and TAX have no
+    such election rule, so for them two words printing the same figure
+    stay ambiguous, and ambiguity mints nothing.
     """
     out: list[DerivedLabel] = []
     finders = (
@@ -326,9 +444,17 @@ def _summary_labels(
             if abs(amount - value) < _CENT
         ]
         unique = {(int(w.line_id), int(w.word_id)): w for w in matches}
-        if len(unique) != 1:
-            continue
-        (line_id, word_id), word = next(iter(unique.items()))
+        if label == "GRAND_TOTAL":
+            word = _elect_grand_total_word(
+                receipt_words, list(unique.values())
+            )
+            if word is None:
+                continue
+            line_id, word_id = int(word.line_id), int(word.word_id)
+        else:
+            if len(unique) != 1:
+                continue
+            (line_id, word_id), word = next(iter(unique.items()))
         out.append(
             DerivedLabel(
                 line_id=line_id,
@@ -345,6 +471,303 @@ def _summary_labels(
     return out
 
 
+def _norm_token(text: str) -> str:
+    """Lowercase alphanumeric form of a word ("Henderson," -> henderson)."""
+    return re.sub(r"[^a-z0-9]", "", (text or "").lower())
+
+
+def _tokens(text: str) -> list[str]:
+    """Normalized tokens of a phrase, dropping punctuation-only words."""
+    return [t for t in (_norm_token(part) for part in text.split()) if t]
+
+
+@dataclass(frozen=True)
+class _PlaceAddress:
+    """The verified address, split into the parts that anchor a match."""
+
+    tokens: frozenset[str]
+    street_number: Optional[str]
+    street_names: frozenset[str]
+    city: frozenset[str]
+    state: frozenset[str]
+    postal: frozenset[str]
+
+
+def _parse_place_address(place: Optional[dict]) -> Optional[_PlaceAddress]:
+    """Split the ReceiptPlace ``formatted_address`` into match anchors."""
+    address = (place or {}).get("formatted_address") or ""
+    parts = [p.strip() for p in str(address).split(",") if p.strip()]
+    if len(parts) < 2:
+        return None
+    if _norm_token(parts[-1]) in _COUNTRY_TOKENS:
+        parts = parts[:-1]
+    if len(parts) < 2:
+        return None
+
+    street = _tokens(parts[0])
+    number = street[0] if street and street[0].isdigit() else None
+    postal, state = set(), set()
+    for token in _tokens(parts[-1]):
+        if re.fullmatch(r"\d{5}(?:\d{4})?", token):
+            postal.add(token)
+        elif len(token) == 2 and token.isalpha():
+            state.add(token)
+    city = (
+        {t for t in _tokens(parts[-2]) if t.isalpha() and len(t) >= 3}
+        if len(parts) >= 3
+        else set()
+    )
+    return _PlaceAddress(
+        tokens=frozenset(t for part in parts for t in _tokens(part)),
+        street_number=number,
+        # One- and two-letter street tokens ("N", "St") are too common to
+        # anchor on; the distinctive part of a street name is the rest.
+        street_names=frozenset(
+            t for t in street if t.isalpha() and len(t) >= 3
+        ),
+        city=frozenset(city),
+        state=frozenset(state),
+        postal=frozenset(postal),
+    )
+
+
+def _is_address_line(tokens: Sequence[str], addr: _PlaceAddress) -> bool:
+    """Whether a line's tokens anchor onto the verified place address.
+
+    Three anchors, each distinctive enough to stand alone: the street
+    number printed with a street-name word, the postal code, or the city
+    printed with the state. Position on the receipt is deliberately not
+    consulted -- the header is not always the geometric top line, and the
+    place row is the authority either way.
+    """
+    seen = set(tokens)
+    street_hit = (
+        addr.street_number is not None
+        and addr.street_number in seen
+        and bool(seen & addr.street_names)
+    )
+    postal_hit = bool(seen & addr.postal)
+    city_hit = bool(seen & addr.city) and (
+        bool(seen & addr.state) or postal_hit
+    )
+    return street_hit or postal_hit or city_hit
+
+
+def _address_labels(
+    lines: dict[int, list[Any]], place: Optional[dict]
+) -> list[DerivedLabel]:
+    """ADDRESS_LINE proposals for lines that match the ReceiptPlace row.
+
+    The whole matched line is labelled, not just the words that echo the
+    place record: "2716 North Green Valley Par way" is one address line
+    even though Places spells it "2716 N Green Valley Pkwy" and OCR broke
+    "Parkway" in half. To keep that from swallowing a neighbour, every
+    word on the line must be address-plausible -- an address token, a
+    word, or a short number. One phone number or price on the row and the
+    whole line is declined.
+    """
+    addr = _parse_place_address(place)
+    if addr is None:
+        return []
+
+    out: list[DerivedLabel] = []
+    for line_id in sorted(lines):
+        words = sorted(lines[line_id], key=lambda w: int(w.word_id))
+        tokens = [_norm_token(str(w.text)) for w in words]
+        present = [t for t in tokens if t]
+        if not present or not _is_address_line(present, addr):
+            continue
+        if not all(
+            token in addr.tokens
+            or token.isalpha()
+            or (token.isdigit() and len(token) <= 5)
+            for token in present
+        ):
+            continue
+        for word, token in zip(words, tokens):
+            if not token:
+                continue
+            out.append(
+                DerivedLabel(
+                    line_id=int(word.line_id),
+                    word_id=int(word.word_id),
+                    label="ADDRESS_LINE",
+                    reasoning=(
+                        "Line matches the receipt's verified place address "
+                        f"{(place or {}).get('formatted_address')!r}"
+                    ),
+                    text=str(word.text),
+                )
+            )
+    return out
+
+
+def _phone_spans(words: Sequence[Any]) -> list[list[Any]]:
+    """Maximal word spans on one line that read as a phone number."""
+    spans: list[tuple[int, int]] = []
+    for start in range(len(words)):
+        for end in range(min(start + _PHONE_MAX_SPAN, len(words)), start, -1):
+            text = " ".join(str(w.text) for w in words[start:end])
+            if _PHONE_RE.fullmatch(text.strip()):
+                spans.append((start, end))
+                break
+    maximal = [
+        (start, end)
+        for start, end in spans
+        if not any(
+            (s, e) != (start, end) and s <= start and end <= e
+            for s, e in spans
+        )
+    ]
+    return [list(words[start:end]) for start, end in maximal]
+
+
+def _phone_labels(
+    lines: dict[int, list[Any]], place: Optional[dict]
+) -> list[DerivedLabel]:
+    """PHONE_NUMBER proposals for the merchant's printed phone number.
+
+    Verified against the place row when it carries a phone, and otherwise
+    held to a strict printed format plus receipt-wide uniqueness.
+
+    OCR drops digits from phone numbers often enough that "702 433-67 3"
+    has to decline rather than be repaired: nine digits is not a phone
+    number, and a repaired guess would be indistinguishable in the corpus
+    from a real one.
+    """
+    verified = _digits(
+        (place or {}).get("phone_number") or (place or {}).get("phone_intl")
+    )
+    candidates: list[list[Any]] = []
+    for line_id in sorted(lines):
+        words = sorted(lines[line_id], key=lambda w: int(w.word_id))
+        candidates.extend(_phone_spans(words))
+
+    if verified and len(verified) >= 10:
+        spans = [
+            span
+            for span in candidates
+            if _digits(" ".join(str(w.text) for w in span))[-10:]
+            == verified[-10:]
+        ]
+        reason = (
+            "Printed phone number matches the receipt's verified place "
+            f"record ({(place or {}).get('phone_number')!r})"
+        )
+    else:
+        spans = [
+            span
+            for span in candidates
+            if _PHONE_PUNCT_RE.search(" ".join(str(w.text) for w in span))
+        ]
+        # Nothing external to check an unverified number against, so a
+        # receipt printing two different phone-shaped numbers is
+        # ambiguous and mints neither.
+        if len(spans) != 1:
+            return []
+        reason = "Printed in the format of a phone number"
+
+    out: list[DerivedLabel] = []
+    for span in spans:
+        for word in span:
+            out.append(
+                DerivedLabel(
+                    line_id=int(word.line_id),
+                    word_id=int(word.word_id),
+                    label="PHONE_NUMBER",
+                    reasoning=reason,
+                    text=str(word.text),
+                )
+            )
+    return out
+
+
+def _digits(value: Any) -> str:
+    """Every digit in a value, in order."""
+    return re.sub(r"\D", "", str(value or ""))
+
+
+def _masked_last4(text: str) -> Optional[str]:
+    """Last four digits of a masked card number, or None.
+
+    The mask has to do the work: a word qualifies only when its digits
+    are exactly four and terminal, behind at least four mask glyphs.
+    "MID: *******04690" (five trailing digits) and a bare "1454" both
+    fail, which is what keeps a merchant id or an item count out.
+    """
+    match = re.fullmatch(r"([^0-9]*)(\d{4})", (text or "").strip())
+    if match is None:
+        return None
+    masks = sum(1 for ch in match.group(1) if ch in _PAN_MASK_CHARS)
+    return match.group(2) if masks >= 4 else None
+
+
+def _masked_pan_labels(
+    receipt_words: Sequence[Any], summary: Optional[dict]
+) -> list[DerivedLabel]:
+    """PAYMENT_METHOD for the masked PAN the summary settled against.
+
+    Deliberately not ``CARD_NUMBER``. That reads like the more precise
+    label and an LLM proposer reaches for it, but it is not in
+    ``CORE_LABELS``: ``label_normalization.NON_CORE_LABEL_ALIASES`` maps
+    CARD_NUMBER onto PAYMENT_METHOD, whose definition ("payment
+    instrument summary, e.g. VISA ••••1234") is exactly a masked PAN.
+    Minting the alias would put a label outside the canonical vocabulary
+    into the corpus that every consumer then has to normalize back.
+    """
+    last4 = str((summary or {}).get("card_last4") or "").strip()
+    if not re.fullmatch(r"\d{4}", last4):
+        return []
+    matches = [
+        word
+        for word in receipt_words
+        if _masked_last4(str(getattr(word, "text", ""))) == last4
+    ]
+    # A receipt printing the masked PAN twice cannot say which copy the
+    # summary read, so it mints neither.
+    if len(matches) != 1:
+        return []
+    word = matches[0]
+    return [
+        DerivedLabel(
+            line_id=int(word.line_id),
+            word_id=int(word.word_id),
+            label="PAYMENT_METHOD",
+            reasoning=(
+                "Masked card number ending "
+                f"{last4}, matching the receipt summary's settled card"
+            ),
+            text=str(word.text),
+        )
+    ]
+
+
+def _header_labels(
+    receipt_words: Sequence[Any],
+    summary: Optional[dict],
+    place: Optional[dict],
+) -> list[DerivedLabel]:
+    """ADDRESS_LINE / PHONE_NUMBER / PAYMENT_METHOD from stored records.
+
+    None of these come from the decode. Each is checked against a record
+    the receipt already carries -- the ReceiptPlace row for the address
+    and phone, the receipt summary's settled card for the masked PAN --
+    so the derivation stays a lookup rather than a judgement, and
+    declines when the record is missing or disagrees.
+    """
+    lines: dict[int, list[Any]] = {}
+    for word in receipt_words:
+        try:
+            lines.setdefault(int(word.line_id), []).append(word)
+        except (AttributeError, TypeError, ValueError):
+            continue
+    return [
+        *_address_labels(lines, place),
+        *_phone_labels(lines, place),
+        *_masked_pan_labels(receipt_words, summary),
+    ]
+
+
 def derive_labels(
     receipt_words: Sequence[Any],
     items_line_ids: Iterable[int],
@@ -353,6 +776,7 @@ def derive_labels(
     require_proven: bool = False,
     printed_total: Optional[float] = None,
     bank_amount: Optional[float] = None,
+    place: Optional[dict] = None,
 ) -> DerivationResult:
     """Derive word labels from the reconciled line-item decode.
 
@@ -368,6 +792,9 @@ def derive_labels(
         printed_total: The printed grand total, for the PROVEN check.
             Defaults to the summary's grand total.
         bank_amount: The settled bank amount, for the PROVEN check.
+        place: The receipt's stored ``ReceiptPlace`` row, whose
+            ``formatted_address`` and ``phone_number`` verify the header
+            proposals. Without it no header label is derived.
 
     Returns:
         A :class:`DerivationResult`. ``labels`` is empty unless ``gate``
@@ -418,6 +845,7 @@ def derive_labels(
     for item in items:
         labels.extend(_item_labels(item, texts))
     labels.extend(_summary_labels(receipt_words, summary))
+    labels.extend(_header_labels(receipt_words, summary, place))
 
     # One word, one derived label. A word the decoder claims twice (a
     # price that is also a summary figure) is ambiguous, and ambiguity

--- a/receipt_upload/tests/test_line_item_label_derivation.py
+++ b/receipt_upload/tests/test_line_item_label_derivation.py
@@ -8,12 +8,14 @@ word-level placement of every label type, and the fail-closed rules
 
 import pytest
 
+from receipt_upload.label_validation.label_normalization import is_core_label
 from receipt_upload.line_items.labels import (
     DECODER_PROPOSED_BY,
     GATE_NO_ITEMS_SECTION,
     GATE_NOT_MATCHED,
     GATE_NOT_PROVEN,
     GATE_OK,
+    _quantity_labels,
     derive_labels,
 )
 
@@ -165,18 +167,75 @@ def test_printed_summary_figures_are_labelled():
     assert placed(result)[(4, 2)] == "GRAND_TOTAL"
 
 
-def test_summary_figure_printed_twice_is_ambiguous():
-    # "Balance to pay 37.51" and the terminal's "TOTAL PURCHASE 37.51"
-    # are both grand-total anchors: picking one would be a guess.
-    words = (
-        row(1, 0.10, "ORGANIC", "BANANAS", "37.51")
-        + row(2, 0.20, "Balance", "to", "pay", "37.51")
-        + row(3, 0.30, "TOTAL", "PURCHASE", "37.51")
+def trader_joes_restated_total():
+    """The Trader Joe's two-column layout, in receipt coordinates.
+
+    The amount column is printed as its own OCR lines, paired with the
+    descriptive text by vertical position: "Balance to pay" on the store
+    copy and "TOTAL PURCHASE" on the card slip both anchor the same
+    37.51. y decreases down the receipt (Vision's bottom-left origin).
+    """
+    return (
+        row(1, 0.6745, "PORK", "AL", "PASTOR", "DICED")
+        + row(20, 0.6842, "$37.51")
+        + row(15, 0.5202, "Items", "in", "Transaction:", "10")
+        + row(25, 0.5113, "$37.51")
+        + row(16, 0.4976, "Balance", "to", "pay")
+        + row(26, 0.4895, "$37.51")
+        + row(30, 0.3029, "TOTAL", "PURCHASE")
+        + row(37, 0.3142, "$37.51")
+    )
+
+
+def test_restated_grand_total_elects_one_canonical_copy():
+    # Three words print 37.51. "Items in Transaction" is not a
+    # grand-total anchor at all; "Balance to pay" and "TOTAL PURCHASE"
+    # both are. A receipt has exactly one grand total, so exactly one
+    # word is labelled -- the copy dedupe_grand_total keeps.
+    result = derive_labels(
+        trader_joes_restated_total(), {1, 20}, {"grand_total": 37.51}
+    )
+
+    assert result.gate == GATE_OK
+    assert by_label(result)["GRAND_TOTAL"] == {"$37.51"}
+    grand = [p for p in result.labels if p.label == "GRAND_TOTAL"]
+    assert len(grand) == 1
+    assert grand[0].word_key == (37, 1)
+
+
+def test_amount_beside_a_non_total_row_is_never_the_grand_total():
+    # The 37.51 paired with "Items in Transaction: 10" is a column
+    # neighbour, not a total: no anchor, no label, election or not.
+    result = derive_labels(
+        trader_joes_restated_total(), {1, 20}, {"grand_total": 37.51}
+    )
+    assert (25, 1) not in placed(result)
+
+
+def test_two_total_copies_on_one_row_mint_nothing():
+    # Both copies sit on the same visual row, so no row-ordering rule
+    # can tell them apart. Election declines rather than guessing.
+    words = row(1, 0.60, "ORGANIC", "BANANAS", "37.51") + row(
+        2, 0.30, "TOTAL", "37.51", "37.51"
     )
     result = derive_labels(words, {1}, {"grand_total": 37.51})
 
     assert result.gate == GATE_OK
     assert "GRAND_TOTAL" not in by_label(result)
+
+
+def test_restated_subtotal_stays_ambiguous():
+    # Only GRAND_TOTAL has a canonical-copy election rule. A subtotal
+    # printed twice still mints nothing.
+    words = (
+        row(1, 0.60, "ORGANIC", "BANANAS", "2.99")
+        + row(2, 0.40, "SUBTOTAL", "2.99")
+        + row(3, 0.30, "Sub", "Total", "2.99")
+    )
+    result = derive_labels(words, {1}, {"subtotal": 2.99})
+
+    assert result.gate == GATE_OK
+    assert "SUBTOTAL" not in by_label(result)
 
 
 def test_summary_word_disagreeing_with_the_summary_is_not_labelled():
@@ -215,6 +274,254 @@ def test_require_proven_needs_the_bank_hop(bank_amount, expected_gate):
         bank_amount=bank_amount,
     )
     assert result.gate == expected_gate
+
+
+TRADER_JOES_PLACE = {
+    "formatted_address": "2716 N Green Valley Pkwy, Henderson, NV 89014, USA"
+}
+
+
+def header_receipt(*extra_rows):
+    """A reconciling one-item receipt plus whatever header rows a test
+    wants to put in front of it."""
+    return row(1, 0.60, "ORGANIC", "BANANAS", "2.99") + [
+        word for extra in extra_rows for word in extra
+    ]
+
+
+def test_address_lines_match_the_place_row_through_ocr_damage():
+    # Places says "2716 N Green Valley Pkwy"; the receipt prints
+    # "North" and OCR breaks "Parkway" into "Par" + "way". The line is
+    # still the address, and the whole line is labelled.
+    words = header_receipt(
+        row(3, 0.85, "2716", "North", "Green", "Valley", "Par", "way"),
+        row(4, 0.83, "Henderson,", "NV"),
+        row(5, 0.82, "89014"),
+    )
+    result = derive_labels(
+        words, {1}, {"subtotal": 2.99}, place=TRADER_JOES_PLACE
+    )
+
+    assert by_label(result)["ADDRESS_LINE"] == {
+        "2716",
+        "North",
+        "Green",
+        "Valley",
+        "Par",
+        "way",
+        "Henderson,",
+        "NV",
+        "89014",
+    }
+
+
+def test_no_place_row_means_no_address_label():
+    words = header_receipt(row(3, 0.85, "2716", "North", "Green", "Valley"))
+    result = derive_labels(words, {1}, {"subtotal": 2.99})
+
+    assert "ADDRESS_LINE" not in by_label(result)
+
+
+def test_address_of_a_different_merchant_is_declined():
+    words = header_receipt(row(3, 0.85, "4001", "South", "Rainbow", "Blvd"))
+    result = derive_labels(
+        words, {1}, {"subtotal": 2.99}, place=TRADER_JOES_PLACE
+    )
+
+    assert "ADDRESS_LINE" not in by_label(result)
+
+
+def test_address_line_carrying_a_foreign_token_is_declined():
+    # A phone number sharing the address row would be swallowed by a
+    # whole-line label, so the whole line declines instead.
+    words = header_receipt(
+        row(3, 0.85, "2716", "Green", "Valley", "702-433-6773")
+    )
+    result = derive_labels(
+        words, {1}, {"subtotal": 2.99}, place=TRADER_JOES_PLACE
+    )
+
+    assert "ADDRESS_LINE" not in by_label(result)
+
+
+def test_address_is_found_wherever_it_is_printed():
+    # The header is not always the geometric top line -- some receipts
+    # read bottom-origin, and the address can print in the footer.
+    words = header_receipt(row(48, 0.04, "Henderson,", "NV", "89014"))
+    result = derive_labels(
+        words, {1}, {"subtotal": 2.99}, place=TRADER_JOES_PLACE
+    )
+
+    assert by_label(result)["ADDRESS_LINE"] == {"Henderson,", "NV", "89014"}
+
+
+def test_phone_number_spans_the_words_it_is_split_across():
+    words = header_receipt(
+        row(6, 0.81, "Store", "#0097", "-", "702", "433-6773")
+    )
+    result = derive_labels(
+        words, {1}, {"subtotal": 2.99}, place=TRADER_JOES_PLACE
+    )
+
+    assert by_label(result)["PHONE_NUMBER"] == {"702", "433-6773"}
+    assert "Store" not in by_label(result).get("PHONE_NUMBER", set())
+
+
+def test_phone_number_missing_a_digit_is_declined():
+    # OCR dropped a digit: "702 433-67 3" is nine digits, not a phone
+    # number, and repairing it would be a guess.
+    words = header_receipt(
+        row(6, 0.81, "Store", "#0097", "-", "702", "433-67", "3")
+    )
+    result = derive_labels(
+        words, {1}, {"subtotal": 2.99}, place=TRADER_JOES_PLACE
+    )
+
+    assert "PHONE_NUMBER" not in by_label(result)
+
+
+def test_two_unverified_phone_numbers_mint_neither():
+    words = header_receipt(
+        row(6, 0.81, "702-433-6773"), row(7, 0.79, "702-555-0100")
+    )
+    result = derive_labels(
+        words, {1}, {"subtotal": 2.99}, place=TRADER_JOES_PLACE
+    )
+
+    assert "PHONE_NUMBER" not in by_label(result)
+
+
+def test_place_phone_picks_the_merchant_number_out_of_several():
+    place = dict(TRADER_JOES_PLACE, phone_number="(702) 433-6773")
+    words = header_receipt(
+        row(6, 0.81, "702-433-6773"), row(7, 0.79, "702-555-0100")
+    )
+    result = derive_labels(words, {1}, {"subtotal": 2.99}, place=place)
+
+    assert by_label(result)["PHONE_NUMBER"] == {"702-433-6773"}
+
+
+def test_masked_pan_matches_the_summary_last_four():
+    # The merchant id (five trailing digits) and the terminal id (wrong
+    # four) are the two near-misses every card slip prints.
+    words = header_receipt(
+        row(29, 0.32, "MID:", "*******04690"),
+        row(32, 0.38, "******|*****1454"),
+        row(36, 0.34, "****0159"),
+    )
+    result = derive_labels(
+        words, {1}, {"subtotal": 2.99, "card_last4": "1454"}
+    )
+
+    assert by_label(result)["PAYMENT_METHOD"] == {"******|*****1454"}
+
+
+def test_masked_pan_is_never_labelled_with_a_non_core_alias():
+    # CARD_NUMBER reads like the more precise label, but it is not in
+    # CORE_LABELS -- the corpus normalizes it to PAYMENT_METHOD.
+    words = header_receipt(row(32, 0.38, "******|*****1454"))
+    result = derive_labels(
+        words, {1}, {"subtotal": 2.99, "card_last4": "1454"}
+    )
+
+    assert "CARD_NUMBER" not in by_label(result)
+    assert is_core_label("PAYMENT_METHOD")
+    assert not is_core_label("CARD_NUMBER")
+
+
+def test_masked_pan_needs_the_summary_to_say_which_card():
+    words = header_receipt(row(32, 0.38, "******|*****1454"))
+    result = derive_labels(words, {1}, {"subtotal": 2.99})
+
+    assert "PAYMENT_METHOD" not in by_label(result)
+
+
+def test_unmasked_trailing_digits_are_not_a_card():
+    words = header_receipt(row(32, 0.38, "Ref", "1454"))
+    result = derive_labels(
+        words, {1}, {"subtotal": 2.99, "card_last4": "1454"}
+    )
+
+    assert "PAYMENT_METHOD" not in by_label(result)
+
+
+def test_every_derived_label_is_a_core_label():
+    words = (
+        header_receipt(
+            row(3, 0.85, "2716", "North", "Green", "Valley", "Par", "way"),
+            row(6, 0.81, "Store", "#0097", "-", "702", "433-6773"),
+            row(32, 0.38, "******|*****1454"),
+        )
+        + row(2, 0.40, "TOTAL", "2.99")[:]
+    )
+    result = derive_labels(
+        words,
+        {1},
+        {"subtotal": 2.99, "grand_total": 2.99, "card_last4": "1454"},
+        place=TRADER_JOES_PLACE,
+    )
+
+    assert result.labels
+    for proposal in result.labels:
+        assert is_core_label(proposal.label), proposal.label
+
+
+@pytest.mark.parametrize(
+    "item,expected",
+    [
+        (
+            {
+                "name": "SODA",
+                "quantity": 2,
+                "unit_price": 1.5,
+                "qty_word_ids": [
+                    {"line_id": 1, "word_id": 2},
+                    {"line_id": 1, "word_id": 4},
+                ],
+            },
+            {"QUANTITY": {"2"}, "UNIT_PRICE": {"1.50"}},
+        ),
+        # An item the decoder emitted without a quantity span at all --
+        # the shape every decode has today, and the shape a decode that
+        # simply could not read the quantity keeps.
+        ({"name": "SODA"}, {}),
+        # A quantity with no unit price still names the quantity word.
+        (
+            {
+                "name": "SODA",
+                "quantity": 2,
+                "qty_word_ids": [{"line_id": 1, "word_id": 2}],
+            },
+            {"QUANTITY": {"2"}},
+        ),
+    ],
+)
+def test_quantity_span_contract_tolerates_a_decode_without_quantities(
+    item, expected
+):
+    # Pinned against the decoder's item dict directly: whichever of
+    # these fields a decode carries, the derivation reads what is there
+    # and mints nothing for what is not.
+    texts = {(1, 1): "SODA", (1, 2): "2", (1, 3): "@", (1, 4): "1.50"}
+    labels = _quantity_labels(item, texts)
+
+    by_type = {}
+    for proposal in labels:
+        by_type.setdefault(proposal.label, set()).add(proposal.text)
+    assert by_type == expected
+
+
+def test_quantity_labels_skip_cleanly_when_the_decode_has_no_quantity():
+    # QUANTITY / UNIT_PRICE come from the decoder's quantity span. A
+    # decode that never parsed one mints neither, and mints everything
+    # else as usual.
+    words = row(1, 0.60, "ORGANIC", "BANANAS", "2.99")
+    result = derive_labels(words, {1}, {"subtotal": 2.99})
+
+    labels = by_label(result)
+    assert "QUANTITY" not in labels
+    assert "UNIT_PRICE" not in labels
+    assert labels["LINE_TOTAL"] == {"2.99"}
 
 
 def test_proposed_by_marker_is_distinct_from_llm_proposers():

--- a/scripts/backfill_decoder_word_labels.py
+++ b/scripts/backfill_decoder_word_labels.py
@@ -65,6 +65,9 @@ from receipt_dynamo.entities.receipt_word import ReceiptWord  # noqa: E402
 from receipt_dynamo.entities.receipt_word_label import (  # noqa: E402
     ReceiptWordLabel,
 )
+from receipt_upload.label_validation.label_normalization import (  # noqa: E402
+    normalize_label_alias,
+)
 from receipt_upload.line_items.labels import (  # noqa: E402
     DECODER_PROPOSED_BY,
     GATE_OK,
@@ -94,10 +97,11 @@ def _deser(item: dict) -> dict:
 
 
 def _fetch(client, table: str, image_id: str, receipt_id: int):
-    """One query per receipt: words, sections, summary, existing labels."""
+    """One query per receipt: words, sections, summary, place, labels."""
     words: list[ReceiptWord] = []
     sections: list[dict] = []
     summary: Optional[dict] = None
+    place: Optional[dict] = None
     labeled: dict[tuple[int, int], set[str]] = {}
     for raw in _query_all(
         client,
@@ -119,13 +123,15 @@ def _fetch(client, table: str, image_id: str, receipt_id: int):
             sections.append(_deser(raw))
         elif entity_type == "RECEIPT_SUMMARY":
             summary = _deser(raw)
+        elif entity_type == "RECEIPT_PLACE":
+            place = _deser(raw)
         elif entity_type == "RECEIPT_WORD_LABEL":
             match = _LABEL_SK_RE.match(raw["SK"]["S"])
             if match:
                 key = (int(match.group(1)), int(match.group(2)))
                 label = raw["SK"]["S"].split("#LABEL#", 1)[1]
                 labeled.setdefault(key, set()).add(label)
-    return words, sections, summary, labeled
+    return words, sections, summary, place, labeled
 
 
 def _items_line_ids(sections: list[dict]) -> set[int]:
@@ -214,12 +220,16 @@ def main() -> None:
     collided: Counter = Counter()
     written: Counter = Counter()
     agreement: Counter = Counter()
+    # Per-label agreement, because one label type disagreeing wholesale
+    # (a masked PAN the corpus calls PAYMENT_METHOD) moves the aggregate
+    # rate enough to hide every other type holding steady.
+    agreement_by_label: Counter = Counter()
     disagreements: Counter = Counter()
     receipts_with_labels = 0
     out_handle = open(args.json_out, "w") if args.json_out else None
 
     for index, (image_id, receipt_id) in enumerate(targets):
-        words, sections, summary, labeled = _fetch(
+        words, sections, summary, place, labeled = _fetch(
             client, args.table, image_id, receipt_id
         )
         result = derive_labels(
@@ -227,6 +237,7 @@ def main() -> None:
             _items_line_ids(sections),
             summary,
             require_proven=args.require_proven,
+            place=place,
         )
         gates[result.gate] += 1
         if result.gate != GATE_OK:
@@ -255,11 +266,14 @@ def main() -> None:
             collided[proposal.label] += 1
             # The collisions are free validation: where the corpus
             # already has an opinion about a word, does the arithmetic
-            # derivation agree with it?
-            agreement[
-                "agree" if proposal.label in existing else "disagree"
-            ] += 1
-            if proposal.label not in existing:
+            # derivation agree with it? Compared against the CORE_LABELS
+            # form of the existing label, because a stray "ADDRESS" row
+            # is the same opinion as ADDRESS_LINE, not a contradiction.
+            canonical = {normalize_label_alias(x) or x for x in existing}
+            verdict = "agree" if proposal.label in canonical else "disagree"
+            agreement[verdict] += 1
+            agreement_by_label[(proposal.label, verdict)] += 1
+            if verdict == "disagree":
                 disagreements[
                     (proposal.label, "|".join(sorted(existing)))
                 ] += 1
@@ -358,6 +372,14 @@ def main() -> None:
             f"  collision agreement: {agree} agree / {disagree} disagree "
             f"({rate:.1%})"
         )
+        print("  collision agreement by label:")
+        for label in sorted({label for label, _ in agreement_by_label}):
+            hit = agreement_by_label[(label, "agree")]
+            miss = agreement_by_label[(label, "disagree")]
+            print(
+                f"    {label:13s} {hit} agree / {miss} disagree "
+                f"({hit / max(1, hit + miss):.1%})"
+            )
         print("  top disagreements (derived -> existing):")
         for (derived, existing), count in disagreements.most_common(15):
             print(f"    {derived:13s} -> {existing:30s} {count}")


### PR DESCRIPTION
Follow-up to #1372. That PR minted product and financial labels from the reconciled
line-item decode, but covered only **36% / 13% / 39%** of the words on the three
receipts ingested 2026-08-04. This closes the three gaps.

## 1. GRAND_TOTAL never minted on Trader Joe's

Both TJ receipts print the total against two legitimate grand-total anchors, in a
two-column layout where the descriptive text is a separate OCR line from the amount:

```
L15 'Items in Transaction: 10'  y=0.520   L25 '$37.51'  y=0.511   <- not an anchor
L16 'Balance to pay'            y=0.498   L26 '$37.51'  y=0.490   <- store copy
L30 'TOTAL PURCHASE'            y=0.303   L37 '$37.51'  y=0.314   <- card slip
```

`find_printed_grand_total_words` already discriminates correctly — it returns L26 and
L37 and **not** L25, because "Items in Transaction" is not a total row. The old rule
then required exactly one anchored word and declined on the remaining two.

**Decision: label one, elected by `reconstructor.dedupe_grand_total`.**

- *Both* is wrong. A receipt has exactly one grand total, and `dedupe_grand_total`
  exists to invalidate the restatements. Labelling every copy mints work the pipeline
  immediately retracts, and teaches a model that echoes of the total are grand totals.
- *Neither* is a needless abstention: this multiplicity is precisely the case
  `dedupe_grand_total` was written for.
- *One* — and specifically the copy `dedupe_grand_total` keeps. The election runs
  through that function itself, on stand-in labels for the words we are about to
  label, rather than a second rule that could disagree with it. So if an LLM later
  tags the sibling copies, our label is the canonical survivor, not the one dedupe
  invalidates.

Still fail-closed where the anchor genuinely cannot discriminate: more than one
survivor, or a losing copy sharing the winner's visual row (where no row-ordering rule
could have separated them), mints nothing. SUBTOTAL and TAX have no election rule and
stay strictly one-word-or-nothing.

## 2. Header fields never minted

ADDRESS_LINE, PHONE_NUMBER and the masked PAN are now derived — each verified against
a record the receipt already stores, never recognized by shape alone:

| Label | Verified against | Declines when |
|---|---|---|
| ADDRESS_LINE | `ReceiptPlace.formatted_address` | no place row, or the line does not anchor onto the address |
| PHONE_NUMBER | `ReceiptPlace.phone_number`, else strict format + receipt-wide uniqueness | digits disagree with the place record, or two unverified numbers |
| PAYMENT_METHOD | `ReceiptSummary.card_last4` | no stored last four, or two masked PANs match |

The whole matched address line is labelled — `2716 North Green Valley Par way` is one
address line even though Places spells it `2716 N Green Valley Pkwy` and OCR broke
"Parkway" in half — but only when every word on the line is address-plausible, so a
phone number sharing the row declines the line instead of being swallowed by it.
Position is never consulted: some receipts read bottom-origin and the address can print
in the footer (#1371's hazard).

`702 433-67 3` on IMG_3404 declines. Nine digits is not a phone number, the place row
carries no phone to repair it from, and a repaired guess would be indistinguishable in
the corpus from a real one.

### The masked PAN takes PAYMENT_METHOD, not CARD_NUMBER

CARD_NUMBER reads like the more precise label and an LLM proposer reaches for it, but
it is **not in `CORE_LABELS`** — `label_normalization.NON_CORE_LABEL_ALIASES` maps
CARD_NUMBER onto PAYMENT_METHOD, whose definition ("payment instrument summary, e.g.
VISA ••••1234") is exactly a masked PAN. So the existing NEEDS_REVIEW PAYMENT_METHOD
labels on those words are **right, not known-wrong**, and the count of known-wrong
labels blocking a better derived one is **0**. Minting the alias would have put a
non-canonical label into the corpus that every consumer then normalizes back — the
first draft of this PR did exactly that, and 203/213 dev collisions "disagreed" as a
result. No re-adjudication path is built here.

## 3. QUANTITY / UNIT_PRICE

Already reads the decoder's `qty_word_ids` / `quantity` / `unit_price` and returns
nothing when a decode carries none. That contract is now pinned directly against the
item dict, so it holds whichever of those fields a decode grows — no dependency on, and
no edits to, `geometry.py` / `blocks.py`.

## Verification

Dry run, no writes to either table.

### Per receipt (dev), word-level label coverage

| Receipt | Before | After | New labels |
|---|---|---|---|
| IMG_3404 `2b630bec` | 41/113 = **36.3%** | 51/113 = **45.1%** | 9 ADDRESS_LINE, 1 GRAND_TOTAL |
| IMG_3420 `90af9793` | 45/113 = **39.8%** | 56/113 = **49.6%** | 8 ADDRESS_LINE, 2 PHONE_NUMBER, 1 GRAND_TOTAL |
| IMG_3411 `67b149c0` | 12/91 = **13.2%** | 18/91 = **19.8%** | 6 ADDRESS_LINE |

Every newly derived label, with the word text it lands on:

```
IMG_3404  L3  ADDRESS_LINE  '2716' 'North' 'Green' 'Valley' 'Par' 'way'
          L4  ADDRESS_LINE  'Henderson,' 'NV'
          L5  ADDRESS_LINE  '89014'
          L37 GRAND_TOTAL   '$37.51'          (the 'TOTAL PURCHASE' copy)
          L32 PAYMENT_METHOD '******|*****1454'  SKIPPED - already PAYMENT_METHOD
IMG_3420  L2  ADDRESS_LINE  '2716' 'North' 'Green' 'Valley' 'Parkway'
          L3  ADDRESS_LINE  'Henderson,' 'NV'
          L4  ADDRESS_LINE  '89014'
          L5  PHONE_NUMBER  '702' '433-6773'
          L39 GRAND_TOTAL   '$39.49'
          L34 PAYMENT_METHOD '************1454'  SKIPPED - already PAYMENT_METHOD
IMG_3411  L2  ADDRESS_LINE  '2300' 'Paseo' 'Verde'
          L3  ADDRESS_LINE  'Henderson,' 'NU.' '89052'
```

All three receipts: **100% collision agreement**, 0 disagreements.

### Corpus

Both runs re-measured today on origin/main and on this branch, with one identical
alias-normalized metric (a stray `ADDRESS` row is the same opinion as ADDRESS_LINE, not
a contradiction — the script now reports it that way, and per label).

| | prod before (#1372) | prod after | dev before | dev after |
|---|---|---|---|---|
| receipts passing the gate | 505 | 505 | 520 | 520 |
| new labels | 807 | **1020** (+213) | 906 | **1202** (+296) |
| collisions skipped | 5563 | 9212 | 5854 | 10079 |
| overall agreement | 97.1% | **97.8%** | 96.7% | **97.6%** |
| agreement on #1372's label types | 97.1% | **97.0%** | 96.7% | **96.6%** |

**No drop in agreement.** Every pre-existing label type's agree/disagree counts are
byte-identical before and after; the only one that moves is GRAND_TOTAL, because the
election proposes on receipts that previously declined — and those 154 extra prod
collisions are 95% agreements (prod 241/5 -> 387/13). The new types land at 99.9%
ADDRESS_LINE, 99.5% PAYMENT_METHOD, 96.0% PHONE_NUMBER against the corpus's existing
opinion.

Remaining PHONE_NUMBER disagreements are almost entirely `PHONE_NUMBER -> ADDRESS_LINE`
(15 prod): the corpus labelled a whole header line ADDRESS_LINE including the phone on
it. Those words are already labelled, so nothing is written either way.

### Tests / lint

`receipt_upload/tests/test_line_item_label_derivation.py` grows from 20 to 39 tests,
covering the election, the same-row abstention, address matching through OCR damage,
address decline on a foreign token, footer-printed addresses, phone span assembly,
digit-dropped phone decline, the non-core-alias guard, and a blanket
"every derived label is in CORE_LABELS" assertion.

Linted with a bare python3.12 venv reproducing both CI personalities separately —
whole-package `isort receipt_upload` and per-file over every changed path, including
`scripts/` where no isort config resolves (the `# isort: off/on` fence from #1372 is
preserved and the new import sits inside it).

## Not in this PR

- TAX derived arithmetically when the summary has none but subtotal and grand total are
  both known (IMG_3411 prints `TAX: 1.09` = 14.08 - 12.99). Deterministic and cheap, but
  out of the stated scope.
- Header labels are still behind the arithmetic item gate, so a receipt whose items do
  not reconcile gets no address either, even though the address proof is independent of
  the decode. Loosening that changes the population materially and deserves its own
  measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TzUnnRheR1xinDRCS6s4fB


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved receipt label detection for store addresses, phone numbers, and masked payment cards.
  * Added smarter handling for grand totals, including clearer selection when multiple totals appear on a receipt.
* **Bug Fixes**
  * Reduced false labels when receipt details are ambiguous, missing, or appear in multiple places.
  * Improved matching for split phone numbers, OCR-damaged address lines, and card numbers with extra digits.
  * Made quantity and price labeling more tolerant when some receipt data is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->