### PR TITLE
feat(line-items): capture printed quantity and unit price, gated on arithmetic

### DIFF
--- a/receipt_ocr_swift/Scripts/generate_receipt_structure_parity.py
+++ b/receipt_ocr_swift/Scripts/generate_receipt_structure_parity.py
@@ -56,17 +56,28 @@ def _printed_subtotal(rows, lines, words) -> float | None:
     return None
 
 
-def main() -> None:
-    script_dir = Path(__file__).resolve().parent
-    package_dir = script_dir.parent
-    repo_root = package_dir.parent
-    input_path = (
-        repo_root / "receipt_upload/tests/fixtures/line_items_golden_ocr.json"
-    )
-    output_path = (
-        package_dir
-        / "Tests/ReceiptOCRCoreTests/Fixtures/receipt_structure_parity_expected.json"
-    )
+_SCRIPT_DIR = Path(__file__).resolve().parent
+_PACKAGE_DIR = _SCRIPT_DIR.parent
+_REPO_ROOT = _PACKAGE_DIR.parent
+DEFAULT_INPUT = (
+    _REPO_ROOT / "receipt_upload/tests/fixtures/line_items_golden_ocr.json"
+)
+DEFAULT_OUTPUT = (
+    _PACKAGE_DIR
+    / "Tests/ReceiptOCRCoreTests/Fixtures/receipt_structure_parity_expected.json"
+)
+
+
+def generate(input_path: Path = DEFAULT_INPUT) -> str:
+    """The expectation file's exact bytes, without writing anything.
+
+    Split out of ``main`` so the anti-drift gate in the receipt_upload
+    matrix can regenerate and diff this fixture the same way it does the
+    line-item one. It carries decoded ITEMS too, so a decoder change rots
+    it just as fast -- and until this split it rotted INVISIBLY: the
+    Python-side gate only covered generate_line_items_parity.py, and
+    swift-ci.yml does not run on receipt_upload changes.
+    """
     fixture = json.loads(input_path.read_text(encoding="utf-8"))
     model = load_prior_model()
     expected = []
@@ -143,10 +154,14 @@ def main() -> None:
             f"expected {len(fixture['receipts'])} receipts, "
             f"got {len(expected)}"
         )
-    output_path.write_text(
-        json.dumps(expected, indent=2) + "\n", encoding="utf-8"
-    )
-    print(f"wrote {len(expected)} receipts to {output_path}")
+    return json.dumps(expected, indent=2) + "\n"
+
+
+def main() -> None:
+    payload = generate()
+    DEFAULT_OUTPUT.write_text(payload, encoding="utf-8")
+    count = len(json.loads(payload))
+    print(f"wrote {count} receipts to {DEFAULT_OUTPUT}")
 
 
 if __name__ == "__main__":

--- a/receipt_ocr_swift/Sources/ReceiptOCRCore/LineItems/LineItemDecoder.swift
+++ b/receipt_ocr_swift/Sources/ReceiptOCRCore/LineItems/LineItemDecoder.swift
@@ -88,6 +88,19 @@ enum LineItemRegex {
     static let qtyAtOcr = Rx("(\\d+(?:\\.\\d+)?)\\s*g\\s*\\$(\\d+\\.\\d{2,3})")
     /// QTY_MULT_RE: leading "1x" / "2X" multiplier
     static let qtyMult = Rx("^(\\d{1,2})[xX]$")
+    /// NOISY_MONEY_RE: money token whose currency sign OCR mangled ("$"
+    /// read as "S"/"s"/"5") or dropped. Deliberately loose — every pair
+    /// built from it is accepted only when the arithmetic checks out.
+    static let noisyMoney = Rx("^[Ss5$]?(\\d{1,4}(?:,\\d{3})*\\.\\d{2,3})$")
+    /// QTY_SEPARATOR_RE: the "@" glyph however OCR read it, or a unit word
+    /// an "N EA @ X" layout prints between count and unit price. "FOR" is
+    /// excluded: "4 FOR 1.00" is a deal price with different arithmetic,
+    /// already carried by QTY_FOR_RE.
+    static let qtySeparator = Rx(
+        "^(?:[@8gGaAeE0oO&©®*x×X]|EA|EACH|LB|KG|OZ|CT|PK|QTY)$", ci: true
+    )
+    /// Bare whole count, 1-2 digits (fullmatch), for quantityCandidates.
+    static let bareCount = Rx("^\\d{1,2}$")
     /// LEAD_QTY_RE (ported for completeness)
     static let leadQty = Rx("^(\\d{1,2})\\s+(?=[A-Za-z])")
     /// TAX_FLAG_RE (ported for completeness)
@@ -371,6 +384,9 @@ final class ParsedBand {
     var nameQuality: String?
     var stacked: Bool = false
     var lineIds: [Int] = []
+    /// The band's own words (Python's `band` key). Carried so the
+    /// quantity-attachment pass can re-read the row's glyphs.
+    var bandWords: [ZoneWord] = []
 
     init(
         name: String, quantity: Double?, unitPrice: Double?, price: Double,
@@ -383,6 +399,101 @@ final class ParsedBand {
         self.isDiscount = isDiscount
         self.rawText = rawText
         self.nAmounts = nAmounts
+    }
+}
+
+/// Cent-exact tolerance for accepting a quantity pair (Python
+/// `QTY_CENT_TOLERANCE`).
+let qtyCentTolerance = 0.005
+
+/// One (quantity, unit price) pair the glyphs could support.
+struct QuantityCandidate {
+    let quantity: Double
+    let unitPrice: Double
+}
+
+/// Port of `geometry.quantity_candidates`. Tolerant on purpose: it
+/// proposes, `acceptQuantityPair` decides. A candidate is a whole count
+/// token (2..99) standing immediately before a money token, optionally one
+/// separator glyph away. Quantity 1 is excluded — it multiplies out
+/// against any price and would "prove" itself on every single-unit row.
+func quantityCandidates(_ band: [ZoneWord]) -> [QuantityCandidate] {
+    var out: [QuantityCandidate] = []
+    for (i, w) in band.enumerated() {
+        guard LineItemRegex.bareCount.fullMatch(w.text) != nil,
+            let count = Int(w.text), count >= 2
+        else { continue }
+        for j in [i + 1, i + 2] {
+            guard j < band.count else { break }
+            if j == i + 2,
+                LineItemRegex.qtySeparator.fullMatch(band[i + 1].text) == nil
+            {
+                break
+            }
+            guard let m = LineItemRegex.noisyMoney.fullMatch(band[j].text),
+                let raw = m.group(1),
+                let unit = Double(raw.replacingOccurrences(of: ",", with: "")),
+                unit > 0
+            else { continue }
+            out.append(
+                QuantityCandidate(quantity: Double(count), unitPrice: unit)
+            )
+            break
+        }
+    }
+    return out
+}
+
+/// Port of `geometry.accept_quantity_pair`: quantity x unit price must
+/// reproduce the item's own printed price to the cent. This is the only
+/// thing that ever lets a quantity onto an item.
+func acceptQuantityPair(
+    _ quantity: Double?, _ unitPrice: Double?, _ price: Double
+) -> Bool {
+    guard let q = quantity, let u = unitPrice, price > 0 else { return false }
+    return abs(q * u - price) <= qtyCentTolerance
+}
+
+/// Port of `geometry.implied_unit_price`: the unit price a known quantity
+/// implies, when it divides into whole cents. Quantity 1 is refused —
+/// its unit price is the extended price by definition and the word
+/// carrying it is already the line total.
+func impliedUnitPrice(_ quantity: Double?, _ price: Double) -> Double? {
+    guard let q = quantity, q >= 2, price > 0 else { return nil }
+    let unit = pythonRound2(price / q)
+    guard unit > 0, acceptQuantityPair(q, unit, price) else { return nil }
+    return unit
+}
+
+/// Port of `blocks.attach_printed_quantities`. STRICTLY ADDITIVE: writes
+/// only quantity and unitPrice, so names, prices, line ids and the item
+/// count are untouched and the reconciliation cannot move. Kept a
+/// separate pass for the same reason Python does — quantity words
+/// participate in parseBand's price and name selection, so widening the
+/// shapes it recognizes there would silently re-decode the corpus.
+func attachPrintedQuantities(
+    _ items: [ParsedBand], donorsFor: [Int: [[ZoneWord]]] = [:]
+) {
+    for (idx, it) in items.enumerated() {
+        if it.quantity != nil && it.unitPrice != nil { continue }
+        if it.quantity != nil {
+            if let unit = impliedUnitPrice(it.quantity, it.price) {
+                it.unitPrice = unit
+            }
+            continue
+        }
+        var donors: [[ZoneWord]] = [it.bandWords]
+        donors.append(contentsOf: donorsFor[idx] ?? [])
+        for donor in donors {
+            guard
+                let hit = quantityCandidates(donor).first(where: {
+                    acceptQuantityPair($0.quantity, $0.unitPrice, it.price)
+                })
+            else { continue }
+            it.quantity = hit.quantity
+            it.unitPrice = hit.unitPrice
+            break
+        }
     }
 }
 
@@ -517,7 +628,7 @@ func parseBand(_ band: [ZoneWord]) -> ParsedBand? {
         [" ", "@", "$", "-"]
     )
 
-    return ParsedBand(
+    let parsed = ParsedBand(
         name: name,
         quantity: qty,
         unitPrice: unitPrice,
@@ -526,6 +637,8 @@ func parseBand(_ band: [ZoneWord]) -> ParsedBand? {
         rawText: joined,
         nAmounts: amounts.count
     )
+    parsed.bandWords = band
+    return parsed
 }
 
 // MARK: - Zone bands (blocks._zone_bands)
@@ -781,12 +894,24 @@ func decodeBandBlocks(
         }
     }
 
+    // Bands no item speaks for: not a price band, not a member of any
+    // block. Trader Joe's quantity line reaches OCR as "6 8 S0.49", which
+    // carries no parseable amount and no three-letter word, so it lands in
+    // OUTSIDE and every other quantity path skips it.
+    var claimed = Set(priceIdx)
+    for p in priceIdx { claimed.formUnion(blocks[p]!) }
+    let unclaimed = bands.indices.filter { !claimed.contains($0) }
+
     // Hybrid emission in ascending-y order (bottom of the receipt first):
     // item order is a pinned guarantee.
     var items: [ParsedBand] = []
+    var donorsFor: [Int: [[ZoneWord]]] = [:]
     for p in priceIdx.reversed() {
         guard let parsed = parsedCache[p] ?? parseBand(bands[p].words)
         else { continue }
+        var donorIdxs = Set(blocks[p]!)
+        donorIdxs.formUnion(unclaimed.filter { abs($0 - p) == 1 })
+        donorsFor[items.count] = donorIdxs.sorted().map { bands[$0].words }
         if parsed.quantity == nil {
             for i in blocks[p]! {
                 if let mp = parseBand(bands[i].words),
@@ -830,6 +955,10 @@ func decodeBandBlocks(
         parsed.lineIds = lids.sorted()
         items.append(parsed)
     }
+    // Runs before the summary-figure filter purely so donor indices line
+    // up with `items`; the filter reads only price, name and isDiscount,
+    // so which items it drops cannot depend on it.
+    attachPrintedQuantities(items, donorsFor: donorsFor)
     return filterSummaryFigureItems(items, summary: summary)
 }
 

--- a/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/Fixtures/line_items_parity_expected.json
+++ b/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/Fixtures/line_items_parity_expected.json
@@ -1070,7 +1070,7 @@
     "name": "Meat Patty",
     "price": 9.75,
     "quantity": 5.0,
-    "unit_price": null,
+    "unit_price": 1.95,
     "is_discount": false,
     "name_quality": null,
     "line_ids": [
@@ -1102,7 +1102,7 @@
     "name": "Meat Patty",
     "price": 9.75,
     "quantity": 5.0,
-    "unit_price": null,
+    "unit_price": 1.95,
     "is_discount": false,
     "name_quality": null,
     "line_ids": [
@@ -9602,8 +9602,8 @@
    {
     "name": "*CRV FS 05",
     "price": 0.1,
-    "quantity": null,
-    "unit_price": null,
+    "quantity": 2.0,
+    "unit_price": 0.05,
     "is_discount": false,
     "name_quality": null,
     "line_ids": [
@@ -9790,8 +9790,8 @@
    {
     "name": "*CRV FS 05",
     "price": 0.1,
-    "quantity": null,
-    "unit_price": null,
+    "quantity": 2.0,
+    "unit_price": 0.05,
     "is_discount": false,
     "name_quality": null,
     "line_ids": [
@@ -12838,8 +12838,8 @@
    {
     "name": "LEMON EACH",
     "price": 2.94,
-    "quantity": null,
-    "unit_price": null,
+    "quantity": 6.0,
+    "unit_price": 0.49,
     "is_discount": false,
     "name_quality": null,
     "line_ids": [
@@ -12906,8 +12906,8 @@
    {
     "name": "LEMON EACH",
     "price": 2.94,
-    "quantity": null,
-    "unit_price": null,
+    "quantity": 6.0,
+    "unit_price": 0.49,
     "is_discount": false,
     "name_quality": null,
     "line_ids": [

--- a/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/Fixtures/receipt_structure_parity_expected.json
+++ b/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/Fixtures/receipt_structure_parity_expected.json
@@ -404,7 +404,7 @@
         "name": "Meat Patty",
         "price": 9.75,
         "quantity": 5.0,
-        "unit_price": null,
+        "unit_price": 1.95,
         "is_discount": false,
         "name_quality": "ok",
         "line_ids": [
@@ -3347,8 +3347,8 @@
         "item_index": 4,
         "name": "*CRV FS 05",
         "price": 0.1,
-        "quantity": null,
-        "unit_price": null,
+        "quantity": 2.0,
+        "unit_price": 0.05,
         "is_discount": false,
         "name_quality": "ok",
         "line_ids": [
@@ -4424,8 +4424,8 @@
         "item_index": 0,
         "name": "LEMON EACH",
         "price": 2.94,
-        "quantity": null,
-        "unit_price": null,
+        "quantity": 6.0,
+        "unit_price": 0.49,
         "is_discount": false,
         "name_quality": "ok",
         "line_ids": [

--- a/receipt_upload/receipt_upload/line_items/blocks.py
+++ b/receipt_upload/receipt_upload/line_items/blocks.py
@@ -39,6 +39,7 @@ from receipt_dynamo.amounts import (
 )
 
 __all__ = [
+    "attach_printed_quantities",
     "derive_block_labels",
     "filter_summary_figure_items",
     "templatize",
@@ -531,6 +532,83 @@ def filter_summary_figure_items(
     return [it for i, it in enumerate(items) if i not in drop]
 
 
+def attach_printed_quantities(
+    items: list[dict],
+    donors_for: dict[int, list[list[dict]]] | None = None,
+) -> list[dict]:
+    """Populate quantity / unit_price where the printed band proves them.
+
+    STRICTLY ADDITIVE. Runs after the decode is finished and writes only
+    ``quantity``, ``unit_price`` and ``qty_word_ids``; names, prices,
+    line_ids, discount flags and the item count are never touched, so the
+    reconciliation this decode feeds cannot move. That is the whole reason
+    it is a separate pass instead of another branch inside ``parse_band``:
+    quantity words participate in ``parse_band``'s price and name
+    selection, and widening the shapes it recognizes there would silently
+    re-decode names and prices across the corpus.
+
+    Three sources, all gated on the same arithmetic (see
+    ``accept_quantity_pair`` -- quantity x unit_price must reproduce the
+    item's own printed price to the cent):
+
+    1. An item that already carries both is left alone.
+    2. An item that carries a quantity but no unit price (every
+       leading-quantity row: "2 BURRITO ... 9.98", "2X ...") gets the unit
+       price its own price implies, when the division is cent-exact. This
+       is the LEAD_QTY path finishing its arithmetic rather than a second
+       mechanism.
+    3. An item that carries neither is offered candidate word pairs from
+       its own band and from ``donors_for`` -- the member and unclaimed
+       neighbour bands around it. The first pair that multiplies out wins.
+       Trader Joe's "6 @ $0.49" reaching OCR as "6" / "8" / "S0.49" is the
+       motivating case: no clean glyph survives, but 6 x 0.49 == 2.94 is
+       unambiguous, and the receipt's own "Items in Transaction: 10"
+       corroborates it (4 single items + 6 lemons).
+
+    ``donors_for`` maps item index -> candidate donor bands (each a list
+    of word dicts). Omitted, only sources 1-3-own-band apply.
+    """
+    from receipt_upload.line_items.geometry import (
+        accept_quantity_pair,
+        implied_unit_price,
+        quantity_candidates,
+    )
+
+    for idx, it in enumerate(items):
+        price = it.get("price")
+        if it.get("quantity") is not None and it.get("unit_price") is not None:
+            continue
+        if it.get("quantity") is not None:
+            unit = implied_unit_price(it["quantity"], price)
+            if unit is not None:
+                it["unit_price"] = unit
+            continue
+        bands = [it.get("band") or []]
+        bands.extend((donors_for or {}).get(idx) or [])
+        for donor in bands:
+            hit = next(
+                (
+                    c
+                    for c in quantity_candidates(list(donor))
+                    if accept_quantity_pair(
+                        c["quantity"], c["unit_price"], price
+                    )
+                ),
+                None,
+            )
+            if hit is None:
+                continue
+            it["quantity"] = hit["quantity"]
+            it["unit_price"] = hit["unit_price"]
+            # Provenance follows the arithmetic: point the quantity span
+            # at the two words that proved it, so word-level QUANTITY /
+            # UNIT_PRICE derivation names the right words even when the
+            # pair came from a neighbouring band.
+            it["qty_word_ids"] = list(hit["qty_word_ids"])
+            break
+    return items
+
+
 def decode_band_blocks(
     ocr_receipt: dict, priors: dict, summary: dict | None = None
 ) -> list[dict]:
@@ -696,13 +774,29 @@ def decode_band_blocks(
         stripped = re.sub(r"\d{4,}", " ", name or "")
         return len(re.findall(r"[A-Za-z]{2,}", stripped)) < 2
 
+    # Bands no item speaks for: not a price band, not a member of any
+    # block. Trader Joe's quantity line reaches OCR as "6 8 S0.49", which
+    # carries no parseable amount and no three-letter word, so it lands in
+    # OUTSIDE and every existing quantity path skips it. Kept per band
+    # index so the quantity pass can offer an item only its own immediate
+    # neighbours.
+    claimed = set(price_idx) | {i for p in price_idx for i in blocks[p]}
+    unclaimed = [i for i in range(len(bands)) if i not in claimed]
+
     items = []
+    donors_for: dict[int, list[list[dict]]] = {}
     # Emission order matches the banded implementation (ascending y --
     # bottom of the receipt first): item order is a pinned guarantee.
     for p in reversed(price_idx):
         parsed = parsed_cache.get(p) or parse_band(list(bands[p]["words"]))
         if parsed is None or parsed.get("price") is None:
             continue
+        donors_for[len(items)] = [
+            bands[i]["words"]
+            for i in sorted(
+                set(blocks[p]) | {u for u in unclaimed if abs(u - p) == 1}
+            )
+        ]
         if parsed.get("quantity") is None:
             for i in blocks[p]:
                 mp = parse_band(list(bands[i]["words"]))
@@ -753,6 +847,10 @@ def decode_band_blocks(
             else set(bands[p]["line_ids"])
         )
         items.append(parsed)
+    # Quantity attachment runs before the summary-figure filter purely so
+    # donor indices line up with `items`; the filter reads only price,
+    # name and is_discount, so which items it drops cannot depend on it.
+    attach_printed_quantities(items, donors_for)
     return filter_summary_figure_items(items, summary)
 
 

--- a/receipt_upload/receipt_upload/line_items/geometry.py
+++ b/receipt_upload/receipt_upload/line_items/geometry.py
@@ -210,8 +210,40 @@ NON_PRODUCT_NOTE_RE = re.compile(
     r"|\bITEMS?\s+IN\s+TRANSACTION\b",
     re.IGNORECASE,
 )
-# Standalone leading quantity: "2 BURRITO ..." only when integer < 100
+# Standalone leading quantity: "2 BURRITO ..." only when integer < 100.
+# parse_band applies this shape inline (word-level, so it can record which
+# word the quantity came from); the compiled pattern is kept exported
+# because the Swift port mirrors the module's regex surface.
 LEAD_QTY_RE = re.compile(r"^(\d{1,2})\s+(?=[A-Za-z])")
+# --- OCR-tolerant quantity expression -------------------------------------
+# The regexes above require clean glyphs: a literal "@" (or the single "g"
+# misread QTY_AT_OCR_RE covers) and a literal "$". Vision does much worse
+# than that on the small type receipts print quantity lines in -- Trader
+# Joe's "6 @ $0.49" came back as the three words "6", "8", "S0.49", so the
+# whole band parsed to None and 6 lemons at 0.49 were lost even though
+# 6 x 0.49 == the item's printed 2.94 exactly.
+#
+# These two patterns are deliberately LOOSE. They never decide anything on
+# their own: every pair they propose is accepted only when
+# quantity x unit_price equals the item's own price to the cent
+# (``quantity_candidates`` -> ``accept_quantity_pair``). The arithmetic is
+# the arbiter, so the parser can afford to be generous with glyphs.
+#
+# Money token with an OCR-mangled currency sign: "$" read as "S"/"s"/"5",
+# or simply absent. Two or three decimals (fuel/unit prices print three).
+NOISY_MONEY_RE = re.compile(r"^[Ss5$]?(\d{1,4}(?:,\d{3})*\.\d{2,3})$")
+# A lone token sitting between quantity and unit price that is the "@"
+# glyph, however OCR read it ("8", "g", "a", "e", "0"/"O", "&", "©"), or a
+# unit word an "N EA @ X" layout prints there. "FOR" is excluded on
+# purpose: "4 FOR 1.00" is a deal price, not a unit price, and QTY_FOR_RE
+# already carries its different arithmetic.
+QTY_SEPARATOR_RE = re.compile(
+    r"^(?:[@8gGaAeE0oO&©®*x×X]|EA|EACH|LB|KG|OZ|CT|PK|QTY)$",
+    re.IGNORECASE,
+)
+# Cent-exact tolerance for accepting a quantity pair. Both sides are
+# printed money, so this is float-representation slack, not a band.
+QTY_CENT_TOLERANCE = 0.005
 TAX_FLAG_RE = re.compile(r"\s+[TFNOAB]X?$")
 DISCOUNT_WORDS = ("SAVED", "SAVING", "OFF", "COUPON", "DISCOUNT", "PROMO")
 # Discount markers, matched as WORDS. The tuple above was tested with a
@@ -493,6 +525,112 @@ def parse_band(band: list[dict]) -> Optional[dict[str, Any]]:
         ],
         "n_amounts": len(amounts),
     }
+
+
+def quantity_candidates(band: list[dict]) -> list[dict[str, Any]]:
+    """Every (quantity, unit_price) pair the band's glyphs could support.
+
+    Tolerant on purpose -- this is the PARSING half of the contract, and
+    it proposes rather than decides. A candidate is a whole-integer count
+    token (2..99) standing immediately before a money token, optionally
+    with one separator token between them ("@" however OCR read it, or a
+    unit word). Nothing here is believed until ``accept_quantity_pair``
+    checks the arithmetic against the item's own printed price.
+
+    Returned dicts carry the two word references the pair came from, so a
+    caller can point QUANTITY / UNIT_PRICE word labels at the exact words
+    (the same provenance ``parse_band`` records in ``qty_word_ids``).
+
+    Quantity 1 is excluded: it multiplies out trivially against any price
+    and would "prove" itself on every single-unit row, which is precisely
+    the coincidence the arithmetic gate exists to reject.
+    """
+    out: list[dict[str, Any]] = []
+    n = len(band)
+    for i, w in enumerate(band):
+        if not re.fullmatch(r"\d{1,2}", w["text"] or ""):
+            continue
+        count = int(w["text"])
+        if count < 2:
+            continue
+        # money token adjacent, or one separator glyph away
+        for j in (i + 1, i + 2):
+            if j >= n:
+                break
+            if j == i + 2 and not QTY_SEPARATOR_RE.match(band[i + 1]["text"]):
+                break
+            m = NOISY_MONEY_RE.match(band[j]["text"] or "")
+            if not m:
+                continue
+            try:
+                unit = float(m.group(1).replace(",", ""))
+            except ValueError:
+                continue
+            if unit <= 0:
+                continue
+            out.append(
+                {
+                    "quantity": float(count),
+                    "unit_price": unit,
+                    "qty_word_ids": [
+                        {
+                            "line_id": band[k]["line_id"],
+                            "word_id": band[k]["word_id"],
+                        }
+                        for k in (i, j)
+                    ],
+                }
+            )
+            break
+    return out
+
+
+def accept_quantity_pair(
+    quantity: Optional[float], unit_price: Optional[float], price: Any
+) -> bool:
+    """Whether quantity x unit_price reproduces ``price`` to the cent.
+
+    The ACCEPTANCE half of the contract, and the only thing that ever lets
+    a quantity onto an item. Deliberately cent-exact rather than the 0.02
+    band the META-absorption paths use: those paths also require a
+    structural relationship (an adjacent unnamed price band), where this
+    one is asked to believe glyphs that OCR already mangled once.
+    """
+    if quantity is None or unit_price is None:
+        return False
+    if not isinstance(price, (int, float)) or price <= 0:
+        return False
+    return abs(quantity * unit_price - price) <= QTY_CENT_TOLERANCE
+
+
+def implied_unit_price(quantity: Any, price: Any) -> Optional[float]:
+    """The unit price a known quantity implies, when it divides exactly.
+
+    The leading-quantity forms ("2 BURRITO 9.98", "2X ...") record a count
+    and nothing else, so half of every such row's arithmetic went unstored
+    even though the receipt proves it. Returns None unless the division
+    lands on a whole cent that multiplies back to the printed price.
+
+    Two populations are refused on purpose:
+
+    * quantity 1 (every restaurant "1 Cheese Fry 4.75" row, 218 of the
+      233 dev items that carry a count but no unit price). Its unit price
+      would equal the extended price by definition, and the word carrying
+      it is the one already labelled LINE_TOTAL -- storing it would put
+      two contradictory financial roles on one word for no information.
+    * counts that are really name content ("12 Naked Wings" at 18.49,
+      "3 CHEESE SPINACH & ARTIC" at 3.79). Neither divides into whole
+      cents, so the arithmetic rejects them without needing to know they
+      are false quantities -- which is the entire point of the gate.
+    """
+    if not isinstance(quantity, (int, float)) or quantity < 2:
+        return None
+    if not isinstance(price, (int, float)) or price <= 0:
+        return None
+    unit = round(price / quantity, 2)
+    if unit <= 0 or not accept_quantity_pair(quantity, unit, price):
+        return None
+    return unit
 
 
 # Tokens that don't count as product-name content (units, tax flags, SKU-ish)
@@ -1299,24 +1437,30 @@ __all__ = [
     "DISCOUNT_WORDS",
     "DISCOUNT_WORD_RE",
     "LEAD_QTY_RE",
+    "NOISY_MONEY_RE",
     "NON_ITEM_SECTIONS",
     "PRICE_RE",
     "PROVEN_CENT_TOLERANCE",
     "QTY_AT_RE",
+    "QTY_CENT_TOLERANCE",
     "QTY_MULT_RE",
+    "QTY_SEPARATOR_RE",
     "ReconcileResult",
     "SKU_LIKE_RE",
     "TAX_FLAG_RE",
     "UNIT_WORDS",
+    "accept_quantity_pair",
     "band_words",
     "estimate_skew",
     "evaluate_items_zone",
     "extract_items",
+    "implied_unit_price",
     "is_proven",
     "is_settlement_row",
     "items_boundary_extension_guard",
     "parse_band",
     "propose_items_boundary_extension",
+    "quantity_candidates",
     "reconcile",
     "reconcile_detailed",
 ]

--- a/receipt_upload/tests/test_line_item_quantity_extraction.py
+++ b/receipt_upload/tests/test_line_item_quantity_extraction.py
@@ -1,0 +1,313 @@
+"""Printed-quantity / unit-price capture on decoded line items.
+
+The band-block decoder used to throw away quantity and unit price the
+receipt had already proved. Trader Joe's dev receipt 2b630bec prints
+"6 @ $0.49" under a 2.94 LEMON EACH row; Vision read it as the three
+words "6", "8", "S0.49", so the band parsed to nothing, landed in
+OUTSIDE, and the stored item carried neither field -- even though
+6 x 0.49 == 2.94 exactly and the receipt's own "Items in Transaction: 10"
+corroborates it (4 single items + 6 lemons).
+
+The rule these tests pin: PARSING is tolerant of OCR damage, ACCEPTANCE
+is not. A pair is believed only when quantity x unit_price reproduces the
+item's own printed price to the cent.
+"""
+
+import json
+import re
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+
+from receipt_upload.line_items.blocks import attach_printed_quantities
+from receipt_upload.line_items.geometry import (
+    accept_quantity_pair,
+    extract_items,
+    implied_unit_price,
+    quantity_candidates,
+)
+
+_FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def W(line_id, word_id, text, x, y, h=0.02):
+    return {
+        "line_id": line_id,
+        "word_id": word_id,
+        "text": text,
+        "x": x,
+        "y_mid": y,
+        "h": h,
+    }
+
+
+def row(line_id, y, *tokens):
+    return [
+        W(line_id, i + 1, t, 0.1 + 0.2 * i, y) for i, t in enumerate(tokens)
+    ]
+
+
+def items_for(words):
+    items, _ = extract_items(words, {w["line_id"] for w in words})
+    return items
+
+
+def by_name(items, name):
+    return next(i for i in items if i["name"] == name)
+
+
+# --- the parser proposes -------------------------------------------------
+
+
+def test_candidates_read_the_ocr_mangled_at_and_dollar():
+    # "6 @ $0.49" as Vision actually returned it on 2b630bec
+    cands = quantity_candidates(row(14, 0.2, "6", "8", "S0.49"))
+    assert (cands[0]["quantity"], cands[0]["unit_price"]) == (6.0, 0.49)
+
+
+def test_candidates_read_the_clean_form_and_the_adjacent_form():
+    clean = quantity_candidates(row(1, 0.2, "2", "@", "3.49"))
+    bare = quantity_candidates(row(1, 0.2, "2", "3.49"))
+    assert clean[0]["unit_price"] == bare[0]["unit_price"] == 3.49
+    assert clean[0]["quantity"] == bare[0]["quantity"] == 2.0
+
+
+def test_candidates_point_at_the_two_words_that_prove_the_pair():
+    cands = quantity_candidates(row(14, 0.2, "6", "8", "S0.49"))
+    assert cands[0]["qty_word_ids"] == [
+        {"line_id": 14, "word_id": 1},
+        {"line_id": 14, "word_id": 3},
+    ]
+
+
+def test_candidates_ignore_quantity_one():
+    # A count of 1 multiplies out against any price, so it can never be
+    # evidence of anything.
+    assert quantity_candidates(row(1, 0.2, "1", "@", "4.75")) == []
+
+
+def test_candidates_need_the_count_before_the_money():
+    # Two tokens with a word between them are not a quantity expression.
+    assert quantity_candidates(row(1, 0.2, "3", "CHEESE", "3.79")) == []
+
+
+# --- the arithmetic decides ----------------------------------------------
+
+
+def test_acceptance_is_cent_exact():
+    assert accept_quantity_pair(6, 0.49, 2.94)
+    assert not accept_quantity_pair(6, 0.49, 2.95)
+    assert not accept_quantity_pair(6, 0.49, None)
+    assert not accept_quantity_pair(None, 0.49, 2.94)
+
+
+def test_implied_unit_price_completes_a_lead_quantity_row():
+    # "2 BURRITO ... 9.98" records a count and nothing else; the row's own
+    # price supplies the rest.
+    assert implied_unit_price(2, 9.98) == 4.99
+
+
+def test_implied_unit_price_refuses_a_count_that_is_name_content():
+    # Twin Peaks "12 Naked Wings" at 18.49 -- 18.49/12 is not whole cents,
+    # so the false quantity never gains a unit price.
+    assert implied_unit_price(12, 18.49) is None
+
+
+def test_implied_unit_price_refuses_quantity_one():
+    # Its unit price would be the extended price, on the word already
+    # labelled LINE_TOTAL.
+    assert implied_unit_price(1, 4.75) is None
+
+
+# --- end to end through the decoder --------------------------------------
+
+
+def test_outside_band_quantity_reaches_the_item():
+    # The 2b630bec layout: name+price on one visual row, the mangled
+    # quantity line on the row below carrying no parseable amount at all.
+    words = row(13, 0.20, "LEMON", "EACH", "$2.94") + row(
+        14, 0.10, "6", "8", "S0.49"
+    )
+    item = by_name(items_for(words), "LEMON EACH")
+    assert (item["quantity"], item["unit_price"]) == (6.0, 0.49)
+    assert item["price"] == 2.94
+
+
+def test_quantity_span_follows_the_donor_band():
+    words = row(13, 0.20, "LEMON", "EACH", "$2.94") + row(
+        14, 0.10, "6", "8", "S0.49"
+    )
+    item = by_name(items_for(words), "LEMON EACH")
+    assert item["qty_word_ids"] == [
+        {"line_id": 14, "word_id": 1},
+        {"line_id": 14, "word_id": 3},
+    ]
+
+
+def test_neighbour_quantity_that_does_not_multiply_out_is_refused():
+    # Same layout, one cent off. Nothing is stored rather than something
+    # plausible: the arithmetic is the only evidence there is.
+    words = row(13, 0.20, "LEMON", "EACH", "$2.95") + row(
+        14, 0.10, "6", "8", "S0.49"
+    )
+    item = by_name(items_for(words), "LEMON EACH")
+    assert item["quantity"] is None
+    assert item["unit_price"] is None
+
+
+def test_lead_quantity_row_gains_its_unit_price():
+    item = by_name(items_for(row(1, 0.2, "2", "BURRITO", "9.98")), "BURRITO")
+    assert (item["quantity"], item["unit_price"]) == (2.0, 4.99)
+
+
+def test_attachment_never_rewrites_an_existing_pair():
+    items = [
+        {
+            "name": "X",
+            "price": 2.94,
+            "quantity": 3.0,
+            "unit_price": 0.98,
+            "band": row(1, 0.2, "6", "8", "S0.49"),
+        }
+    ]
+    attach_printed_quantities(items)
+    assert (items[0]["quantity"], items[0]["unit_price"]) == (3.0, 0.98)
+
+
+def test_attachment_touches_nothing_but_the_quantity_fields():
+    before = {
+        "name": "LEMON EACH",
+        "price": 2.94,
+        "is_discount": False,
+        "line_ids": [13, 24],
+        "quantity": None,
+        "unit_price": None,
+        "band": row(14, 0.2, "6", "8", "S0.49"),
+    }
+    after = dict(before)
+    attach_printed_quantities([after])
+    assert after["quantity"] == 6.0 and after["unit_price"] == 0.49
+    for key in ("name", "price", "is_discount", "line_ids"):
+        assert after[key] == before[key]
+
+
+# --- golden-set floor ----------------------------------------------------
+#
+# The hand-labeled golden set carries 84 true quantities across 224 items,
+# which is ground truth the recall/name/precision floors never scored. The
+# floors below are FLOORS in the same sense as the golden regression
+# gate's: raise them when a change genuinely improves the decode, never
+# lower them to go green.
+#
+# Measured 2026-08-05 over the hermetic OCR fixture:
+#   quantity  41 correct / 0 wrong   (was 39 / 0)
+#   unit price 27 correct / 0 wrong  (was 25 / 0)
+# The zeros are the load-bearing part: the arithmetic gate means a wrong
+# quantity should be impossible, not merely rare.
+_QTY_CORRECT_FLOOR = 41
+_UNIT_CORRECT_FLOOR = 27
+
+
+def _money(v):
+    if v is None:
+        return None
+    t = str(v).replace("$", "").replace(",", "").strip().lstrip("-")
+    try:
+        return Decimal(t)
+    except InvalidOperation:
+        return None
+
+
+def _norm(s: str) -> str:
+    t = re.sub(r"\s+", " ", (s or "").strip().upper())
+    t = re.sub(r"<[A-Z]>", " ", t)
+    t = re.sub(r"\b\d{5,}\b", " ", t)
+    t = re.sub(r"[^A-Z0-9 ]", " ", t)
+    t = re.sub(r"\b\d+\b", " ", t)
+    return re.sub(r"\s+", " ", t).strip()
+
+
+def _golden_quantity_scores():
+    """(qty_correct, qty_wrong, unit_correct, unit_wrong, wrong_detail).
+
+    Pairing is the golden gate's price-first greedy match, so a truth item
+    is scored against the predicted item the gate itself would call it.
+    """
+    golden = json.loads(
+        (_FIXTURES / "line_items_golden.json").read_text(encoding="utf-8")
+    )
+    golden = golden["receipts"] if isinstance(golden, dict) else golden
+    ocr = {
+        (r["image_id"], r["receipt_id"]): r
+        for r in json.loads(
+            (_FIXTURES / "line_items_golden_ocr.json").read_text(
+                encoding="utf-8"
+            )
+        )["receipts"]
+    }
+    tally = {"qty_ok": 0, "qty_bad": 0, "unit_ok": 0, "unit_bad": 0}
+    detail = []
+    for g in golden:
+        o = ocr.get((g["image_id"], g["receipt_id"]))
+        if o is None:
+            continue
+        pred, _ = extract_items(o["words"], set(o["items_line_ids"]))
+        used: set[int] = set()
+        for truth in g["true_items"]:
+            tp = _money(truth.get("price"))
+            best, best_score = None, 0.0
+            for i, p in enumerate(pred):
+                if i in used:
+                    continue
+                price_ok = tp is not None and _money(p.get("price")) == tp
+                ta = set(_norm(truth.get("name", "")).split())
+                tb = set(_norm(p.get("name", "")).split())
+                sim = (
+                    len(ta & tb) / max(len(ta), len(tb)) if ta and tb else 0.0
+                )
+                score = (2.0 if price_ok else 0.0) + sim
+                if score > best_score:
+                    best, best_score = i, score
+            if best is None or best_score < 0.5:
+                continue
+            used.add(best)
+            for field, key in (("quantity", "qty"), ("unit_price", "unit")):
+                tv, pv = _money(truth.get(field)), _money(
+                    pred[best].get(field)
+                )
+                if tv is None or pv is None:
+                    continue
+                if abs(float(tv) - float(pv)) < 0.005:
+                    tally[f"{key}_ok"] += 1
+                else:
+                    tally[f"{key}_bad"] += 1
+                    detail.append(
+                        (
+                            g.get("merchant"),
+                            truth.get("name"),
+                            field,
+                            str(tv),
+                            str(pv),
+                        )
+                    )
+    return tally, detail
+
+
+def test_golden_quantities_are_never_wrong():
+    # The arithmetic gate's whole promise: a quantity is stored only when
+    # it reproduces the printed price, so it cannot disagree with a hand
+    # label that was read off the same row.
+    tally, detail = _golden_quantity_scores()
+    assert tally["qty_bad"] == 0, f"quantity disagreements: {detail}"
+    assert tally["unit_bad"] == 0, f"unit price disagreements: {detail}"
+
+
+def test_golden_quantity_coverage_floor():
+    tally, _ = _golden_quantity_scores()
+    assert tally["qty_ok"] >= _QTY_CORRECT_FLOOR, (
+        f"quantity coverage regressed: {tally['qty_ok']} < "
+        f"{_QTY_CORRECT_FLOOR}"
+    )
+    assert tally["unit_ok"] >= _UNIT_CORRECT_FLOOR, (
+        f"unit price coverage regressed: {tally['unit_ok']} < "
+        f"{_UNIT_CORRECT_FLOOR}"
+    )

--- a/receipt_upload/tests/test_swift_line_item_parity_fixture.py
+++ b/receipt_upload/tests/test_swift_line_item_parity_fixture.py
@@ -91,6 +91,33 @@ def test_swift_parity_expectations_match_the_live_python_decoder() -> None:
     )
 
 
+def test_swift_structure_expectations_match_the_live_python_decoder() -> None:
+    """Same gate, for the end-to-end structure fixture.
+
+    ``receipt_structure_parity_expected.json`` carries decoded ITEMS (with
+    quantity and unit price) alongside the rows and sections, so a decoder
+    change rots it exactly as fast as the line-item fixture -- but it was
+    not covered here, and ``swift-ci.yml`` does not run on
+    ``receipt_upload`` changes. The gap was found the expensive way: a
+    decoder change passed this file's own anti-drift test and every
+    receipt_upload test, then failed
+    ``ReceiptStructurePipelineTests.goldenEndToEndParityAcrossTheWholeGoldenSet``
+    in CI on three receipts. Regenerate with
+    ``python receipt_ocr_swift/Scripts/generate_receipt_structure_parity.py``.
+    """
+    import generate_receipt_structure_parity as structure
+
+    committed = structure.DEFAULT_OUTPUT.read_text(encoding="utf-8")
+    regenerated = structure.generate()
+    assert committed == regenerated, (
+        "Swift structure parity expectations are STALE against the current "
+        f"Python decoder: {len(committed)} bytes committed vs "
+        f"{len(regenerated)} bytes regenerated. Regenerate with "
+        "`python receipt_ocr_swift/Scripts/"
+        "generate_receipt_structure_parity.py` and update the Swift port."
+    )
+
+
 def test_swift_golden_ocr_copy_is_byte_identical() -> None:
     """The Swift package's copy of the golden OCR words is not a fork."""
     generator = _generator()


### PR DESCRIPTION
## The defect

The band-block decoder discarded printed quantity and unit price even when the receipt's own arithmetic proved them.

Dev `IMG_3404` (`2b630bec-ecd6-4c22-b9de-554dca66c146`) prints `6 @ $0.49` under a 2.94 `LEMON EACH` row. Vision returned it as the three words `6` / `8` / `S0.49` — the `@` read as `8`, the `$` as `S`. That band carries no parseable amount and no three-letter word, so it parsed to `None`, landed in `OUTSIDE`, and no quantity path ever looked at it. The stored item had **no `quantity` and no `unit_price` attribute at all** — even though:

- 6 x 0.49 = 2.94 exactly, matching the stored price, and
- the receipt prints `Items in Transaction: 10`, and 4 single items + 6 lemons = 10.

Two independent checks confirm it. The hand-labeled golden set records exactly `quantity 6 / unit_price 0.49` for that item. We stored neither.

Downstream, #1372's label derivation minted **zero** new `QUANTITY` and **zero** new `UNIT_PRICE` labels corpus-wide. That was attributed to the corpus already covering them; on these receipts the true cause is that the decoder never extracted them.

## Tolerant in parsing, strict in acceptance

`geometry.quantity_candidates` reads a count-and-money pair through OCR damage — the `@` glyph however Vision rendered it, `$` read as `S`/`5`, or no separator at all. It **proposes**; it never decides.

`geometry.accept_quantity_pair` is the only thing that ever lets a quantity onto an item, and it demands that `quantity x unit_price` reproduce that item's own printed price **to the cent** (0.005 — tighter than the 0.02 the META-absorption paths use, because those also require a structural relationship where this one is asked to believe glyphs OCR already mangled once).

Quantity 1 is refused everywhere: it multiplies out against any price, so it is evidence of nothing.

`blocks.attach_printed_quantities` runs **after** the decode and writes only `quantity` / `unit_price` / `qty_word_ids`. It is a separate pass rather than another branch in `parse_band` precisely because quantity words participate in `parse_band`'s price and name selection — widening the shapes recognized there would silently re-decode names and prices across the corpus. Three sources:

1. an item with both is left alone;
2. an item with a count but no unit price gets the one its own price implies when the division is cent-exact — this is the existing lead-quantity path (`2 BURRITO ... 9.98`) finishing its arithmetic, **not** a second mechanism;
3. an item with neither is offered pairs from its own band and from its member and *unclaimed neighbour* bands. Unclaimed bands are the new reach: `OUTSIDE` rows like `6 8 S0.49` that no existing quantity path looked at.

(Aside found on the way: `LEAD_QTY_RE` is exported and ported to Swift "for completeness" but never actually applied — `parse_band` uses an inline word-level match instead. Left as-is; noted so the next reader does not assume it is live.)

## Invariant: names, prices, count and status are unchanged — proven

sha256 over the decoded items (names + prices + count + reconciliation status + line_ids, **excluding** the new fields), same technique #1372 used:

| corpus | receipts | items | hash before | hash after |
|---|---|---|---|---|
| dev `dc5be22` | 684 | 2203 | `b30fcd22…8fdf464e` | `b30fcd22…8fdf464e` |
| prod `d7ff76a` | 730 | 2516 | `df592900…07071bce` | `df592900…07071bce` |

**Identical.** Zero receipts change reconciliation status (dev match 520/520, prod 505/505) — no receipt at `match` leaves `match`. No existing quantity or unit price is ever rewritten.

## Gates

**Golden floors** — `test_line_item_golden_regression.py` passes unchanged; no floor touched, none lowered. My change cannot move recall/name/precision, so there is nothing to ratchet there. Instead this PR **adds** a floor the golden set never scored, over the same fixtures:

| | before | after |
|---|---|---|
| quantity correct / **wrong** | 39 / **0** | 41 / **0** |
| unit price correct / **wrong** | 25 / **0** | 27 / **0** |

The zeros are the load-bearing number, and are asserted: the arithmetic gate means a *wrong* quantity should be impossible, not merely rare.

The gate also refuses what it should — Twin Peaks `12 Naked Wings` at 18.49 and Trader Joe's `3 CHEESE SPINACH & ARTIC` at 3.79 carry counts that are really name content; neither divides into whole cents, so no unit price is invented for them.

**Corpus sweep with per-receipt flip check** — run over every receipt with an ITEMS section in both tables, comparing status per receipt:

| | quantity | unit price | status flips | receipts leaving `match` |
|---|---|---|---|---|
| dev | 357 → 371 (+14) | 98 → 137 (+39) | 0 | 0 |
| prod | 419 → 437 (+18) | 132 → 177 (+45) | 0 | 0 |

## Verification

`LEMON EACH` on IMG_3404 now decodes **quantity 6.0, unit_price 0.49**, price 2.94 unchanged, matching hand truth. IMG_3411 (1 item / 12.99) and IMG_3420 (7 items / 39.49) decode identically to before and correctly gain nothing — every row is single-unit.

Remaining gap, honestly separated (dev items after the change):

| bucket | dev (2203 items) | prod (2516 items) | |
|---|---|---|---|
| has quantity | 371 | 437 | |
| **printed but unparsed** | **66** | **93** | dev: 42 where the parser proposed a pair the arithmetic rejected + 24 where a quantity marker is printed but no pair was proposable; prod: 53 + 40 |
| no printed quantity | 1766 | 1986 | plain single-unit rows — legitimately neither |

Those 66 / 93 are the real residual. They are dominated by **weight-based** rows (`0.31 lb @ $5.49/lb`, `18.871 Gallons @ $5.299/Gal`) where the quantity is fractional and retailer rounding means it does not multiply out cent-exact, plus reversed layouts (`8.99 @ 2`). Extending to those needs a rounding model, which is a different (and riskier) change than this one.

233 dev items carry a quantity but still no unit price. 218 of those are quantity 1 (`1 Cheese Fry 4.75`) — refused on purpose: its unit price equals the extended price by definition and the word carrying it is already labelled `LINE_TOTAL`, so storing it would put two contradictory financial roles on one word. The other 15 are false quantities the arithmetic correctly declines to legitimise.

## Downstream: #1372's label derivation

Running #1372's `derive_labels` over the whole dev corpus (520 gate-ok receipts), before vs after:

| label | before | after |
|---|---|---|
| QUANTITY | 240 | **254** (+14) |
| UNIT_PRICE | 10 | **23** (+13) |
| PRODUCT_NAME | 4245 | 4245 |
| LINE_TOTAL | 1584 | 1584 |
| GRAND_TOTAL / SUBTOTAL / TAX / DISCOUNT | 267 / 248 / 141 / 25 | 267 / 248 / 141 / 25 |

Gate distribution is unchanged (ok 520 / not-matched 139 / no-items 25) and every non-quantity label count is identical — a fourth confirmation that the decode itself did not move. On IMG_3404 specifically, derivation now mints `QUANTITY` on word (14,1) `"6"` with reasoning *"Decoder parsed quantity 6 for item 'LEMON EACH' from this word"*, where it previously minted nothing.

One residual is on the **labels.py** side, not the decoder's, so it is flagged rather than fixed here (that file is owned by another agent this session): `labels._amount_of` gates on `looks_like_receipt_amount`, which returns `False` for `"S0.49"` even though `parse_receipt_amount` happily returns `0.49`. So IMG_3404's `UNIT_PRICE` word cannot be labelled even though the decoder now knows the value. That is why UNIT_PRICE gains +13 rather than +39 — the rest are implied unit prices with no printed unit-price word to point at, which correctly mint nothing.

## Swift port

`receipt_ocr_swift` mirrors this decoder and its parity fixture encodes `quantity` / `unit_price` per item, so **this change does alter the contract those fixtures encode**. The port is included and expectations regenerated. The regenerated diff is exactly six `null -> value` edits with every name, price and `line_ids` byte unchanged — a second independent proof of the invariant.

`swift test` cannot run on a CommandLineTools-only Mac, so instead the Swift decoder was driven over all 37 parity receipts and diffed against Python field by field: **431 items, 0 mismatches**. `swift build` is clean.

### A gate that wasn't watching (second commit)

The first push passed every Python check and then failed `ReceiptStructurePipelineTests` on exactly three receipts. `receipt_structure_parity_expected.json` **also** encodes decoded items, so it rots just as fast — but `test_swift_line_item_parity_fixture.py` regenerates only the line-item generator's artifacts, and `swift-ci.yml` does not trigger on `receipt_upload/**`. Each half of the fence assumed the other covered it. That is the exact failure mode that test file's docstring was written to prevent, one generator over.

The second commit regenerates that fixture (five lines: the same three items gain quantity/unit_price, every name, price and `line_ids` byte unchanged — a third independent proof of the invariant) and closes the hole: `generate()` is split out of `main()` in the structure generator so the anti-drift gate byte-diffs it too. Verified the new gate bites — reverting the fixture fails it.

## Persistence

**No writer changes were needed.** `ocr_processor`, `line_item_processor` and `backfill_receipt_line_items` already pass `quantity` / `unit_price` straight through to `ReceiptLineItem`, and the entity has carried both fields all along. The plumbing was there; only the decoder was empty. Rows populate on the next recompute after merge and deploy.

No dev or prod writes were made by this PR — prod was read-only throughout, and writing dev rows from an undeployed branch would only be undone by the next recompute.

## CI

Both isort personalities swept over all changed files at once (bare 3.12 venv replicating `main.yml`, black 26.5.1 / isort 8.0.1): package mode and the per-file loop both clean. Full `receipt_upload` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TzUnnRheR1xinDRCS6s4fB
