### PR TITLE
fix(labels): stop minting column headers as PRODUCT_NAME

### DIFF
--- a/receipt_upload/receipt_upload/line_items/geometry.py
+++ b/receipt_upload/receipt_upload/line_items/geometry.py
@@ -186,6 +186,114 @@ def is_settlement_row(bare: str) -> bool:
     )
 
 
+# --- Column-header vocabulary --------------------------------------------
+# The words a receipt prints ABOVE its item table ("Item Qty Price Total",
+# "Description Qty Amount", "Unit Price") and the price-qualifier headings
+# it prints beside a markdown ("ORIGINAL PRICE", "Reguler Price"). None of
+# them is a product; all of them are printed on a row that also carries an
+# amount, so the decoder sees a priced row and names an item after it.
+#
+# Same shape as the tender vocabulary above, and for the same reason: a
+# header row is a row whose EVERY word is header vocabulary. A closed,
+# whole-token vocabulary is what keeps real food safe here -- a receipt can
+# and does sell an item whose name contains a header word ("HOUSE REGULAR
+# COFFEE CUP", "THE ORIGINAL MINI KABOB WRAP", "BAG SALE PAPER EA",
+# "LEMON EACH", "CUSTOM ITEM", "PRICE MATCH"), and each of those carries a
+# word this vocabulary does not contain, so each stays an item.
+#
+# Whole-token matching is not a style preference. A substring scan for the
+# OCR misread "UTY" matches inside "BEAUTY", and this corpus really does
+# contain "BEAUTY SECRETS NOVELTY TWEEZERS GARDEN" -- the same failure that
+# made a substring scan for "OFF" read COFFEE / TOFFEE as a discount.
+COLUMN_HEADER_ANCHOR_TOKENS = frozenset(
+    {
+        "amount",
+        "amounts",
+        "descrip",  # OCR truncation of a narrow header column
+        "description",
+        "descriptions",
+        "item",
+        "items",
+        "price",
+        "prices",
+        "pricing",
+        "qty",
+        "quantity",
+        "subtotal",
+        "tax",
+        "total",
+        "totals",
+        "unit",
+        "units",
+        "uty",  # Vision reads "QTY" as "UTY" on small type
+    }
+)
+# Words that only ever QUALIFY a header anchor. Affixes alone are never
+# enough, so a bare "EACH" or "EA" -- which is unit vocabulary a real item
+# ends in -- never makes a row a header.
+COLUMN_HEADER_AFFIX_TOKENS = frozenset(
+    {
+        "ea",
+        "each",
+        "ext",
+        "extended",
+        "list",
+        "net",
+        "orig",
+        "original",
+        "per",
+        "regul",  # OCR: "REGUL R PRICE"
+        "regular",
+        "reguler",  # OCR: "Reguler Price"
+        "retail",
+        "sale",
+        "your",
+    }
+)
+# Restriction/disclaimer footer legalese. Deliberately ONE family: the
+# corpus's other footer-shaped names are real charged rows ("BOTTLE
+# RETURN") or real printed annotations the decoder must keep ("MAX REFUND
+# VALUE", 40 occurrences), so REFUND / RETURN / VALUE are NOT vocabulary
+# here. "RESTRICT" is: no receipt in dev or prod sells anything whose name
+# contains it, and every occurrence is the tail of "...tobacco or alcohol.
+# Restrictions apply."
+RESTRICTION_NOTE_RE = re.compile(
+    r"\bRESTRICT(?:S|ED|ION|IONS)?\b", re.IGNORECASE
+)
+
+
+def is_column_header_row(name: str) -> bool:
+    """Whether a decoded item name is a column header or footer legalese.
+
+    ``name`` is the decoder's name for an item, NOT raw row text: amounts
+    are already stripped out by ``parse_band``, so "Unit Price 25.00"
+    arrives as "Unit Price".
+
+    Two closed rules, both anchored:
+
+    * at least one COLUMN_HEADER_ANCHOR token is present AND every
+      multi-letter token is an anchor or an affix -- the ``is_settlement_row``
+      shape;
+    * or the name carries restriction-footer vocabulary.
+
+    Single-letter tokens are ignored ("REGUL R PRICE" keeps its "R"), which
+    cannot widen the rule: an anchor is still required, and one letter
+    carries no product identity.
+    """
+    text = name or ""
+    if RESTRICTION_NOTE_RE.search(text):
+        return True
+    tokens = [t.lower() for t in re.findall(r"[A-Za-z]{2,}", text)]
+    if not tokens:
+        return False
+    if not any(t in COLUMN_HEADER_ANCHOR_TOKENS for t in tokens):
+        return False
+    return all(
+        t in COLUMN_HEADER_ANCHOR_TOKENS or t in COLUMN_HEADER_AFFIX_TOKENS
+        for t in tokens
+    )
+
+
 # Price-comparison metadata ("SALE 2 @ $1.89, WAS: $3.59 each"): the WAS
 # amount is not a line price and the real item price is on its own band
 WAS_PRICE_RE = re.compile(r"\b(?:WAS|REG)\b[:.]?\s*\$?\d", re.IGNORECASE)
@@ -1434,6 +1542,8 @@ def propose_items_boundary_extension(
 
 
 __all__ = [
+    "COLUMN_HEADER_AFFIX_TOKENS",
+    "COLUMN_HEADER_ANCHOR_TOKENS",
     "DISCOUNT_WORDS",
     "DISCOUNT_WORD_RE",
     "LEAD_QTY_RE",
@@ -1442,6 +1552,7 @@ __all__ = [
     "PRICE_RE",
     "PROVEN_CENT_TOLERANCE",
     "QTY_AT_RE",
+    "RESTRICTION_NOTE_RE",
     "QTY_CENT_TOLERANCE",
     "QTY_MULT_RE",
     "QTY_SEPARATOR_RE",
@@ -1455,6 +1566,7 @@ __all__ = [
     "evaluate_items_zone",
     "extract_items",
     "implied_unit_price",
+    "is_column_header_row",
     "is_proven",
     "is_settlement_row",
     "items_boundary_extension_guard",

--- a/receipt_upload/receipt_upload/line_items/labels.py
+++ b/receipt_upload/receipt_upload/line_items/labels.py
@@ -45,6 +45,7 @@ from receipt_dynamo.entities.receipt_summary import (
 
 from receipt_upload.line_items.geometry import (
     extract_items,
+    is_column_header_row,
     is_proven,
     reconcile_detailed,
 )
@@ -226,20 +227,64 @@ def _summary_value(summary: Optional[dict], key: str) -> Optional[float]:
         return None
 
 
+def _name_from_price_band(item: dict) -> bool:
+    """Whether the item's name words come from its own price band.
+
+    ``parse_band`` names an item from the words left over on the priced
+    band itself, and the block decoder overrides that with a neighbouring
+    description band only for stacked layouts. So a name span contained in
+    the price band means name and price were printed on ONE row; a span
+    outside it means the name was borrowed from another row.
+    """
+    band_keys = {
+        key
+        for key in (_word_key(ref) for ref in item.get("band") or [])
+        if key is not None
+    }
+    name_keys = {
+        key
+        for key in (_word_key(ref) for ref in item.get("name_word_ids") or [])
+        if key is not None
+    }
+    return bool(name_keys) and name_keys <= band_keys
+
+
 def _item_labels(
     item: dict, texts: dict[tuple[int, int], str]
 ) -> list[DerivedLabel]:
-    """Label proposals for one decoded item."""
+    """Label proposals for one decoded item.
+
+    A decoded item whose NAME is a column header ("Unit Price", "Item Qty
+    Price Total") or footer legalese is a real defect in the decode, and
+    it is deliberately handled here rather than by dropping the item: the
+    corpus sweep found 20 of 22 such items load-bearing -- every one of
+    their receipts reconciles to its printed baseline WITH the item
+    included, so removing it would flip the receipt out of ``match`` and
+    cost the whole receipt its labels. The price is real; only the name is
+    wrong. Labels are a training corpus, so the answer is to abstain on
+    the part that is wrong and keep the part that is proven.
+    """
     out: list[DerivedLabel] = []
     name = item.get("name") or ""
     price = item.get("price")
     is_discount = bool(item.get("is_discount"))
+    header_name = is_column_header_row(name)
 
     # The extended price word. A discount row's price IS the discount
     # amount, so it takes DISCOUNT rather than LINE_TOTAL -- labelling it
     # LINE_TOTAL would teach the model that a negative line total is
     # normal and would double-count in every downstream sum.
+    #
+    # When the header text and the price sit on the SAME row, the amount
+    # is not vouched for either: "ORIGINAL PRICE 49.99" prints the
+    # pre-markdown price beside a 49.89 item, and "Unit Price 25.00" is
+    # the receipt's own word for that amount. Both would be minted
+    # LINE_TOTAL on the strength of a sum that happens to land. A header
+    # name borrowed from ANOTHER row leaves the price word untouched, so
+    # that case keeps its LINE_TOTAL.
     price_key = _word_key(item.get("price_word_id"))
+    if header_name and _name_from_price_band(item):
+        price_key = None
     if price_key is not None and price is not None:
         label = "DISCOUNT" if is_discount else "LINE_TOTAL"
         out.append(
@@ -261,7 +306,12 @@ def _item_labels(
     # no letters are skipped: PRODUCT_NAME is descriptive text, and a bare
     # numeric token in a name span is a SKU echo or an unrecognized
     # quantity, never a product name.
-    if not is_discount and item.get("name_quality") != "low" and name:
+    if (
+        not is_discount
+        and item.get("name_quality") != "low"
+        and name
+        and not header_name
+    ):
         priced = f" priced at {price:.2f}" if price is not None else ""
         reasoning = (
             f"Decoder read this word as part of the product name "

--- a/receipt_upload/tests/test_column_header_rows.py
+++ b/receipt_upload/tests/test_column_header_rows.py
@@ -1,0 +1,185 @@
+"""Column-header rows must never be minted as a product name.
+
+The band-block decoder emits an item whose NAME is the receipt's column
+header ("Unit Price", "Item Qty Price Total", "Description Qty Amount"),
+its markdown annotation ("ORIGINAL PRICE", "Reguler Price") or its footer
+legalese. A sweep of every decoded item in dev (691 receipts) and prod
+(730 receipts) on 2026-08-05 found 22 such items, 18 of them on receipts
+that reconcile as a full ``match`` -- so the arithmetic gate cannot see
+them and they flow straight into the training corpus as PRODUCT_NAME.
+
+The guard is a CLOSED vocabulary, tested here in both directions: every
+boilerplate name the corpus actually produced must be recognized, and
+every real product that happens to carry a header word must survive.
+
+The keeps are the load-bearing half. A receipt genuinely sells items whose
+names contain "PRICE", "ORIGINAL", "REGULAR", "ITEM" and "EACH", and all
+of them are here, taken from the corpus rather than invented.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+from receipt_upload.line_items.geometry import is_column_header_row
+
+# Every distinct boilerplate item NAME the dev + prod sweep produced
+# (2026-08-05; ReceiptsTable-dc5be22 and ReceiptsTable-d7ff76a).
+CORPUS_HEADER_NAMES = [
+    "# • ITEM PRICE",
+    "4 ITEMS",
+    "9.75% TAX",
+    "AMOUNT:",
+    "DESCRIPTION QTY",
+    "DESCRIPTION QTY AMOUNT",
+    "DESCRIPTION QTY PRICE TOTAL",
+    "Description Qty Amount",
+    "ITEM QTY PRICE",
+    "ITEM QTY PRICE AMOUNT",
+    "ITEM QTY PRICE TOTAL",
+    "ITEM UTY PRICE TOTAL",  # OCR reads "QTY" as "UTY"
+    "Item Qty Price",
+    "Item Uty Price Total",
+    "ORIGINAL PRICE",
+    "ORIGINAL PRICE:",
+    "PRICING",
+    "REGUL R PRICE",  # OCR dropped the "A" out of REGULAR
+    "REGULER PRICE",  # OCR misspelling
+    "Reguler Price",
+    "TOTAL TAX",
+    "TOTAL: SALE",
+    "UNIT PRICE",
+    "UNIT PRICE:",
+    "Unit Price",
+    "of trusards or alcotial. Restrict",  # "...or alcohol. Restrictions"
+]
+
+# Real items from the same sweep that carry header vocabulary and MUST
+# survive. Every one of these is a genuine purchased line.
+REAL_PRODUCTS = [
+    "BAG SALE PAPER EA",
+    "BANANA EACH",
+    "BEAUTY SECRETS NOVELTY TWEEZERS GARDEN",
+    "CUSTOM ITEM",
+    "EA",
+    "EACH",
+    "HARD DELUXE 19.9 EA",
+    "HOUSE REGULAR COFFEE CUP",
+    "ITEM SUBTRACTED EA",
+    "LEMON EACH",
+    "ORIGINAL OAK SMOKED SALMO",
+    "PEPPER BELL GREEN EACH",
+    "POTATO SWEET EACH",
+    "PRICE MATCH",
+    "THE ORIGINAL MINI KABOB WRAP",
+    "TOTAL SAVINGS (7 PERCENT)",
+    "VERIFIED TOTAL SAVINGS",
+    "16oz TRI TIP",
+    "GRACO 50 MESH GUN FILTER 015-029 TIP",
+    "MAX REFUND VALUE",
+    "BOTTLE RETURN",
+]
+
+# The OFF-inside-COFFEE class of bug, pinned. A substring scan for the
+# OCR misread "UTY" matches inside "BEAUTY"; one for "EA" matches inside
+# almost everything. Whole-token matching is what makes the vocabulary
+# safe, so these are asserted explicitly rather than left implicit.
+SUBSTRING_TRAPS = [
+    "BEAUTY SECRETS NOVELTY TWEEZERS GARDEN",  # UTY inside BEAUTY
+    "PRICELESS COLLECTION",  # PRICE inside PRICELESS
+    "UNITED FARMS SALSA",  # UNIT inside UNITED
+    "TOTALLY CHOCOLATE",  # TOTAL inside TOTALLY
+    "SUBTOTALLY IRRELEVANT BRAND",
+    "ITEMIZED TOOL SET",  # ITEM inside ITEMIZED
+]
+
+
+@pytest.mark.parametrize("name", CORPUS_HEADER_NAMES)
+def test_corpus_header_names_are_recognized(name: str) -> None:
+    assert is_column_header_row(name), name
+
+
+@pytest.mark.parametrize("name", REAL_PRODUCTS)
+def test_real_products_survive(name: str) -> None:
+    assert not is_column_header_row(name), name
+
+
+@pytest.mark.parametrize("name", SUBSTRING_TRAPS)
+def test_header_words_inside_longer_words_do_not_match(name: str) -> None:
+    assert not is_column_header_row(name), name
+
+
+def test_affixes_alone_are_never_a_header() -> None:
+    """A qualifier with no anchor is unit vocabulary, not a header.
+
+    Real items end in "EACH" / "EA" all the time, and "SALE" and
+    "ORIGINAL" open real product names. Only an ANCHOR (a column noun)
+    can start the match, exactly as a tender word must for
+    ``is_settlement_row``.
+    """
+    for text in ("EACH", "EA", "SALE", "ORIGINAL", "REGULAR", "RETAIL"):
+        assert not is_column_header_row(text), text
+
+
+def test_empty_and_numeric_names_are_not_headers() -> None:
+    for text in ("", "   ", "764666103221", "1900 1", "$3.19"):
+        assert not is_column_header_row(text), text
+
+
+def test_restriction_footer_is_recognized_through_ocr_damage() -> None:
+    """Regal's ticket footer, as Vision actually read it.
+
+    Deliberately the ONLY legalese family in the vocabulary. The corpus's
+    other footer-shaped names are real charged rows or real annotations --
+    "BOTTLE RETURN" is a CRV deposit and "MAX REFUND VALUE" appears 40
+    times -- so REFUND / RETURN / VALUE are not vocabulary and those rows
+    keep their names.
+    """
+    assert is_column_header_row("of trusards or alcotial. Restrict")
+    assert is_column_header_row("Restrictions apply")
+    assert not is_column_header_row("MAX REFUND VALUE")
+    assert not is_column_header_row("BOTTLE RETURN")
+
+
+def test_no_golden_truth_item_is_read_as_a_header() -> None:
+    """The hand-labeled golden set is the strongest keep-list there is."""
+    fixture = Path(__file__).parent / "fixtures" / "line_items_golden.json"
+    golden = json.load(open(fixture))
+    eaten = [
+        (receipt["merchant"], item.get("name"))
+        for receipt in golden["receipts"]
+        for item in receipt["true_items"]
+        if is_column_header_row(item.get("name") or "")
+    ]
+    assert not eaten, f"golden true_items read as headers: {eaten}"
+
+
+def test_vocabulary_is_disjoint_from_the_settlement_vocabulary() -> None:
+    """Two guards, two jobs.
+
+    A row is either a tender row or a header row; nothing should be both,
+    and an overlap would mean one vocabulary had drifted into the other's
+    territory (where a change to one silently changes the other).
+    """
+    from receipt_upload.line_items.geometry import (
+        COLUMN_HEADER_ANCHOR_TOKENS,
+        TENDER_ANCHOR_TOKENS,
+    )
+
+    assert not (COLUMN_HEADER_ANCHOR_TOKENS & TENDER_ANCHOR_TOKENS)
+
+
+def test_amounts_are_already_stripped_by_the_caller() -> None:
+    """The predicate reads a decoded NAME, not raw row text.
+
+    ``parse_band`` removes the price before the name reaches here, so
+    "Unit Price 25.00" arrives as "Unit Price". Passing raw text is not
+    the contract, but it must not blow up, and a trailing amount must not
+    rescue a header from the match.
+    """
+    assert is_column_header_row("Unit Price 25.00")
+    assert re.search(r"\d", "Unit Price 25.00")

--- a/receipt_upload/tests/test_line_item_label_derivation.py
+++ b/receipt_upload/tests/test_line_item_label_derivation.py
@@ -636,3 +636,95 @@ def test_every_proposal_carries_reasoning():
     assert result.labels
     for proposal in result.labels:
         assert proposal.reasoning.strip()
+
+
+# --- Column-header / boilerplate item names --------------------------------
+#
+# The band-block decoder names an item after a column-header row
+# ("Unit Price 25.00") or footer legalese often enough to matter: 22 of
+# 4730 decoded items across dev and prod, 18 of them on receipts that
+# reconcile to their printed baseline as a full match, so the arithmetic
+# gate passes them straight into the training corpus.
+#
+# They are NOT dropped, here or in the decoder. The corpus sweep measured
+# 20 of those 22 load-bearing: their receipts balance WITH the item
+# included, and removing one flips the receipt out of `match`, costing the
+# whole receipt every label it would otherwise contribute. The price is
+# real; only the name is wrong. So the derivation abstains on the name.
+
+
+def test_column_header_name_mints_no_product_name():
+    # "Unit Price 25.00" is one printed row: header words beside a real
+    # price. Rise Henderson prints five of them on one receipt.
+    words = row(1, 0.10, "Unit", "Price", "25.00")
+    result = derive_labels(words, {1}, {"subtotal": 25.00})
+
+    assert result.gate == GATE_OK
+    assert result.reconciliation_status == "match"
+    assert by_label(result) == {}
+
+
+def test_header_row_price_word_is_not_a_line_total_either():
+    # The receipt's own word for this amount is "ORIGINAL PRICE" -- it is
+    # the pre-markdown price, printed beside a differently-priced item.
+    # Minting LINE_TOTAL on it would teach the model that a header row's
+    # amount is an extended total, on the strength of a sum that lands.
+    words = row(1, 0.10, "ORIGINAL", "PRICE", "49.99")
+    result = derive_labels(words, {1}, {"subtotal": 49.99})
+
+    assert result.gate == GATE_OK
+    assert "LINE_TOTAL" not in by_label(result)
+
+
+def test_header_name_borrowed_from_another_row_keeps_its_line_total():
+    # Here the header is its own row and the price row carries a real
+    # name, so the decoder stacks them and the header contaminates the
+    # NAME only. The price word was printed beside "EXTRASTRTHSCT" and is
+    # a genuine extended total, so it keeps LINE_TOTAL.
+    words = row(1, 0.30, "Description", "Qty", "Amount") + row(
+        2, 0.10, "T", "EXTRASTRTHSCT", "3.59"
+    )
+    result = derive_labels(words, {1, 2}, {"subtotal": 3.59})
+
+    assert result.gate == GATE_OK
+    labels = by_label(result)
+    assert labels.get("LINE_TOTAL") == {"3.59"}
+    named = labels.get("PRODUCT_NAME", set())
+    assert "Description" not in named
+    assert "Amount" not in named
+
+
+def test_real_items_keep_their_names_beside_a_header_item():
+    # Abstention is per item, not per receipt: a header-named item must
+    # not cost its neighbours their labels.
+    words = (
+        row(1, 0.30, "Item", "Qty", "Price", "6.00")
+        + row(2, 0.20, "ORGANIC", "BANANAS", "2.99")
+        + row(3, 0.10, "WHOLE", "MILK", "4.49")
+    )
+    result = derive_labels(words, {1, 2, 3}, {"subtotal": 13.48})
+
+    assert result.gate == GATE_OK
+    labels = by_label(result)
+    assert labels["PRODUCT_NAME"] == {
+        "ORGANIC",
+        "BANANAS",
+        "WHOLE",
+        "MILK",
+    }
+    assert labels["LINE_TOTAL"] == {"2.99", "4.49"}
+
+
+def test_a_header_named_item_still_counts_toward_reconciliation():
+    # The whole point: the item stays in the decode and keeps the receipt
+    # balancing. If it were dropped the sum would miss and the gate would
+    # close on every other item too.
+    words = row(1, 0.30, "Unit", "Price", "25.00") + row(
+        2, 0.10, "ORGANIC", "BANANAS", "2.99"
+    )
+    result = derive_labels(words, {1, 2}, {"subtotal": 27.99})
+
+    assert result.gate == GATE_OK
+    assert result.item_count == 2
+    assert result.item_sum == pytest.approx(27.99)
+    assert by_label(result)["PRODUCT_NAME"] == {"ORGANIC", "BANANAS"}


### PR DESCRIPTION
## The finding

A dry run of `scripts/backfill_decoder_word_labels.py` was about to seed the training corpus with the receipt's own **column headers** as product names.

Sweeping every decoded item across dev (`dc5be22`, 691 receipts) and prod (`d7ff76a`, 730 receipts, read-only): **22 items** are named after a header row (`Unit Price`, `Item Qty Price Total`, `Description Qty Amount`), a markdown annotation (`ORIGINAL PRICE`, `Reguler Price`) or footer legalese (`of trusards or alcotial. Restrict` — OCR for "…or alcohol. Restrictions"). **18 sit on receipts that reconcile as a full `match`**, so the arithmetic gate never sees them: 55 junk labels in dev, 26 in prod.

## The important part: these items are load-bearing

The obvious fix — drop the junk rows — is a **regression**, not a fix. The sweep measured the drop-impact on every one:

| | count |
|---|---|
| dropping the item flips the receipt out of `match` | **20 of 22** |
| droppable without effect (price 0.00 / 0.01) | 2 |

Rise Henderson `78c7449c` is the clearest case — five items, all named `Unit Price`, prices `25.00 + 2.46×3 + 5.00` = the printed subtotal `37.38` **exactly**. The prices are right. Only the names are wrong.

### Hypothesis split (a) phantom vs (b) real item, wrong name

**(b) dominates, 20 of 22.** The price is a genuine product price and the decoder's name assignment grabbed a header band. Two mechanisms, both verified against the actual receipt lines:

- *Header banded with the price row* (11 items): `Unit Price 25.00` is one visual band, so `parse_band` names the item `Unit Price`. The real name is the member band above it (`F (Shake) -L'Orange-7.0g-S (.70g)`).
- *Header won the name-donor slot* (9 items): `_sku_dominated()` fires on any single-token name, and the donor search then picks the **longest** member band — which is the column header. `0025c3ff` had already parsed the correct name `EXTRASTRTHSCT`; `db2cea4b` had `Meatballs`; `37f2d81f` had `MED`. All three were overwritten by a header.

**(a) phantom, 2 of 22** — and both are load-bearing anyway:
- `5925105a` `Reguler Price $3.19` — a genuine markdown annotation that `SALE_PRICE_RE` was *designed* to drop; only the OCR misspelling (`REGULER`) defeats it. Dropping it moves the sum 150.32 → 147.13 against a 150.12 baseline: **`match` → `near`**.
- `5a7b884a` `ORIGINAL PRICE 49.99` — the pre-markdown annotation, emitted as the item while the real `PLAN B ONE STEP … 49.89` row was classified `OUTSIDE` by a template prior. Dropping it leaves zero items.

## Tier 1 — what shipped

`is_column_header_row()` in `geometry.py`, in the closed-vocabulary shape of `is_settlement_row` (#1369): at least one **column-noun anchor**, every other multi-letter token an anchor or a qualifier. Wired into `labels.py` only.

**Whole-token matching is the load-bearing part.** A substring scan for the OCR misread `UTY` matches inside `BEAUTY` — and the corpus contains `BEAUTY SECRETS NOVELTY TWEEZERS GARDEN`. Same shape as the `OFF`-inside-`COFFEE` bug. Pinned in `SUBSTRING_TRAPS`.

Vocabulary built from the corpus, not imagination — every string in the test's eat-list and keep-list came out of the sweep. Vetted three ways:

| check | result |
|---|---|
| 4,628 decoded item names | 21 distinct boilerplate names eaten, **4,570 real items untouched** |
| 224 hand-labeled golden `true_items` | **0 eaten** |
| 7,978 existing `PRODUCT_NAME` spans | fires on 185 — **all** corpus mislabels (`TOTAL`, `TAX`, `SUBTOTAL`, `AMOUNT:`) |

Real products that carry header words and **survive**: `HOUSE REGULAR COFFEE CUP`, `THE ORIGINAL MINI KABOB WRAP`, `BAG SALE PAPER EA`, `LEMON EACH`, `CUSTOM ITEM`, `PRICE MATCH`, `MAX REFUND VALUE`, `BOTTLE RETURN`.

`LINE_TOTAL` is refused **only when the header shares the price word's row** — `ORIGINAL PRICE 49.99` prints the pre-markdown price beside a 49.89 item, so that amount is not an extended total either. Where the header was borrowed from a *different* row, the price word is untouched and keeps its `LINE_TOTAL`.

## Tier 2 — measured and rejected, not skipped

Excluding header bands from the name-donor list in `blocks.py` is fully reconciliation-neutral (0 status changes, 0 item-count changes, dev + prod) and recovers 6 correct names. But it also lets a **tare-weight line** (`0.7 oz Tare 22`) and a **server-name line** (`Annie B 77429`) win the vacated donor slot. Label-level ledger:

> **10 new `PRODUCT_NAME` labels: 4 correct, 5 wrong** (`oz`, `Tare`, `1.25T`, `Annie`, `B`)

It converts correct abstentions into confidently wrong labels. For a training corpus that is the wrong trade, so it is **not** in this PR.

A wider variant (donor trigger `_sku_dominated` → `not _name_is_real`) *does* fix both, and **passes the golden floors** — but the corpus sweep vetoed it: it regresses Home Depot names exactly as the code comment warns, e.g. `'1-5/8" COARSE DRYWALL SCREW 5 LB'` → `'764666103221 15/8CRDWSC5# <A>'`, across 144 items. The Home Depot name floor (0.25) has too much slack to catch it. Good demonstration of why the corpus gate exists alongside the golden gate.

The residual defect is **donor selection by max-length**. This evidence (2 counterexamples) is too thin to redesign it; worth its own corpus study.

## Gates

**1. Golden floors** — pass, unchanged, none lowered. Both Swift parity gates pass: `line_items_parity` *and* `receipt_structure_parity_expected.json` (the one #1374 was bitten by). Full `receipt_upload` suite green.

**2. Corpus sweep, per-receipt flip check** — dev and prod:

```
LEFT match:  0      ENTERED: 0      other status changes: 0
item-count changes: 0
```

Stronger than required: the decode is **byte-identical** before and after on both tables (`cmp` clean), so no receipt *can* move. Nothing in the decode path changed.

## The 18 cases, before → after

Every one **kept**, every receipt **stays at `match`**, every junk name **abstained**.

| receipt | price | name | item | recon | PRODUCT_NAME | LINE_TOTAL | hypothesis |
|---|---|---|---|---|---|---|---|
| `0025c3ff:1` | 3.59 | `Description Qty Amount` | kept | match → match | 3 → 0 | yes → yes | (b) donor; real name `EXTRASTRTHSCT` |
| `0cb38cb3:1` | 15.00 | `Unit Price` | kept | match → match | 2 → 0 | yes → **no** | (b) banded |
| `37f2d81f:1` | 14.40 | `Item Qty Price` | kept | match → match | 3 → 0 | yes → yes | (b) donor; real name `MED` |
| `5925105a:1` | 3.19 | `Reguler Price` | kept | match → match | 2 → 0 | yes → **no** | **(a) phantom**, load-bearing |
| `5a7b884a:1` | 49.99 | `ORIGINAL PRICE` | kept | match → match | 2 → 0 | yes → **no** | **(a) phantom**, load-bearing |
| `6f546a68:1` | 30.00 | `Unit Price` | kept | match → match | 2 → 0 | yes → **no** | (b) banded |
| `711608e5:1` | 1.25 | `DESCRIPTION QTY PRICE TOTAL` | kept | match → match | 4 → 0 | yes → yes | (b) donor; real name `BOUIN` |
| `78c7449c:1` | 5.00 | `Unit Price` | kept | match → match | 2 → 0 | yes → **no** | (b) banded |
| `78c7449c:1` | 2.46 | `Unit Price` | kept | match → match | 2 → 0 | yes → **no** | (b) banded |
| `78c7449c:1` | 2.46 | `Unit Price` | kept | match → match | 2 → 0 | yes → **no** | (b) banded |
| `78c7449c:1` | 2.46 | `Unit Price` | kept | match → match | 2 → 0 | yes → **no** | (b) banded |
| `78c7449c:1` | 25.00 | `Unit Price` | kept | match → match | 2 → 0 | yes → **no** | (b) banded |
| `9fe5ed9f:1` | 11.99 | `of trusards or alcotial. Restrict` | kept | match → match | 5 → 0 | yes → yes | (b) donor = footer legalese |
| `bea3e62c:1` | 75.00 | `Item Qty Price Amount` | kept | match → match | 4 → 0 | yes → yes | (b) donor |
| `c81f5364:1` | 0.01 | `Unit Price` | kept | match → match | 2 → 0 | yes → **no** | (b) banded |
| `c81f5364:1` | 8.00 | `Unit Price` | kept | match → match | 2 → 0 | yes → **no** | (b) banded |
| `caf19581:1` | 6.00 | `Item Qty Price Total` | kept | match → match | 4 → 0 | yes → yes | (b) donor |
| `db2cea4b:1` | 22.00 | `# • Item Price` | kept | match → match | 2 → 0 | yes → yes | (b) donor; real name `Meatballs` |

Plus 4 more the sweep found beyond the reported set, same defect, same outcome: `758cbedf:2` `Item Uty Price Total` (6.98), `94676cfe:2` `UNIT PRICE:` (0.00), `ab732680:2` `Description Qty` (33.00), `fb588a3b:2` `Item Qty Price Total` (44.98).

## Dry-run totals

**Dev — 1,181 → 1,126 (−55)**

| label | before | after |
|---|---|---|
| PRODUCT_NAME | 726 | **673** |
| LINE_TOTAL | 83 | **81** |
| ADDRESS_LINE | 163 | 163 |
| PHONE_NUMBER | 93 | 93 |
| QUANTITY | 71 | 71 |
| GRAND_TOTAL | 25 | 25 |
| SUBTOTAL | 12 | 12 |
| DISCOUNT / PAYMENT_METHOD / UNIT_PRICE | 3 / 3 / 2 | 3 / 3 / 2 |

**Prod — 1,031 → 1,005 (−26):** PRODUCT_NAME 664 → 639, LINE_TOTAL 75 → 74, nothing else moves.

Exactly as predicted: only PRODUCT_NAME and LINE_TOTAL fall. Gate counts identical (dev `ok=520`, prod `ok=505`). The full label diff is **0 added, 0 relabeled**, and every one of the 81 removals is a header or legalese word.

## Notes

- No writes to any table. Prod was read-only throughout; no `pulumi up`.
- No Swift port needed — the Python decoder contract is unchanged (byte-identical decode), so neither parity fixture moves. Both are asserted anyway.
- Both CI isort personalities replicated in separate bare python3.12 venvs (per-file and whole-package) and run separately. Both clean.
- 4 pre-existing collection errors in `receipt_upload/tests` (`No module named 'infra'` / `scripts.build_section_order_priors`) confirmed present on clean `HEAD`; unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TzUnnRheR1xinDRCS6s4fB


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved receipt processing to recognize column-header rows and restriction-note text.
  - Prevented header or boilerplate text from being mistaken for product names.
  - Preserved accurate labeling for genuine products and legitimate totals.

- **Bug Fixes**
  - Reduced false positives when product names contain header-like wording.
  - Improved handling of OCR-damaged footer text and trailing amounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->