### PR TITLE
fix(labels): constrain create_word_label to the CORE_LABELS vocabulary

### DIFF
--- a/infra/mcp_server_lambda/lambdas/receipt_mcp_server_server.py
+++ b/infra/mcp_server_lambda/lambdas/receipt_mcp_server_server.py
@@ -48,6 +48,17 @@ from mcp.server import Server
 from mcp.server.stdio import stdio_server
 from mcp.types import ImageContent, TextContent, Tool
 
+# The canonical word-label vocabulary. Imported at module scope (not lazily
+# inside the impl) because `list_tools` has to publish it as the JSON-Schema
+# `enum` for create_word_label's `label` argument -- the label name becomes
+# part of the DynamoDB sort key, so a caller must be told the legal values
+# up front instead of minting a new pseudo-label-type.
+from receipt_dynamo.constants import (  # noqa: E402
+    CORE_LABEL_NAMES,
+    invalid_label_message,
+    normalize_label_alias,
+)
+
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
@@ -941,7 +952,15 @@ image_id/receipt_id/line_id/word_id/label already exists.""",
                     },
                     "label": {
                         "type": "string",
-                        "description": "The label to assign (e.g., CASH_BACK, GRAND_TOTAL)",
+                        "enum": list(CORE_LABEL_NAMES),
+                        "description": (
+                            "The label to assign. Must be one of the "
+                            "canonical CORE_LABELS values listed in `enum` "
+                            "(e.g., CASH_BACK, GRAND_TOTAL). This string "
+                            "becomes part of the DynamoDB sort key, so free "
+                            "text is REFUSED -- never pass a sentence, an "
+                            "amount, or a correction note."
+                        ),
                     },
                     "reasoning": {
                         "type": "string",
@@ -3766,7 +3785,16 @@ async def create_word_label_impl(
     from receipt_dynamo.entities.receipt_word_label import ReceiptWordLabel
 
     try:
-        normalized_label = label.upper()
+        # The label becomes part of the DynamoDB sort key, so every distinct
+        # string mints a pseudo-label-type. Refuse anything outside
+        # CORE_LABELS here, at the tool boundary, so the caller gets
+        # "label must be one of ..." instead of a stack trace from the
+        # add_receipt_word_label guard -- and so nothing is written at all.
+        # Known soft aliases (ADDRESS -> ADDRESS_LINE) are rewritten; nothing
+        # else is guessed at.
+        normalized_label = normalize_label_alias(label)
+        if normalized_label is None:
+            return {"error": invalid_label_message(label)}
         # Only the four workflow statuses are valid on create; a null/omitted
         # arg falls back to VALID. NONE is deliberately excluded so a stray
         # null can't silently persist a non-ground-truth row.

--- a/receipt_agent/receipt_agent/agents/label_evaluator/graph.py
+++ b/receipt_agent/receipt_agent/agents/label_evaluator/graph.py
@@ -66,7 +66,7 @@ from receipt_agent.agents.label_evaluator.word_context import (
     assemble_visual_lines,
     build_word_contexts,
 )
-from receipt_agent.constants import CORE_LABELS
+from receipt_agent.constants import CORE_LABELS, normalize_label_alias
 
 # LLM factory for creating OpenRouter-based LLMs
 from receipt_agent.utils.llm_factory import create_llm
@@ -493,7 +493,8 @@ def create_label_evaluator_graph(
             skip_labels: list[ReceiptWordLabel] = []
             for issue in state.issues_found:
                 eval_label = _create_evaluation_label(issue, None)
-                skip_labels.append(eval_label)
+                if eval_label is not None:
+                    skip_labels.append(eval_label)
             return {"review_results": [], "new_labels": skip_labels}
 
         # Skip LLM review if LLM is not available
@@ -504,7 +505,8 @@ def create_label_evaluator_graph(
             fallback_labels: list[ReceiptWordLabel] = []
             for issue in state.issues_found:
                 eval_label = _create_evaluation_label(issue, None)
-                fallback_labels.append(eval_label)
+                if eval_label is not None:
+                    fallback_labels.append(eval_label)
             return {"review_results": [], "new_labels": fallback_labels}
 
         merchant_name = "Unknown"
@@ -617,7 +619,8 @@ def create_label_evaluator_graph(
             fallback_labels_on_error: list[ReceiptWordLabel] = []
             for issue in state.issues_found:
                 eval_label = _create_evaluation_label(issue, None)
-                fallback_labels_on_error.append(eval_label)
+                if eval_label is not None:
+                    fallback_labels_on_error.append(eval_label)
             return {
                 "review_results": [],
                 "new_labels": fallback_labels_on_error,
@@ -647,7 +650,8 @@ def create_label_evaluator_graph(
 
             # Create label based on review result
             label = _create_evaluation_label(issue, review_result)
-            new_labels.append(label)
+            if label is not None:
+                new_labels.append(label)
 
             logger.info(
                 "Reviewed '%s': %s - %s...",
@@ -717,7 +721,7 @@ def create_label_evaluator_graph(
 def _create_evaluation_label(
     issue: EvaluationIssue,
     review_result: ReviewResult | None = None,
-) -> ReceiptWordLabel:
+) -> ReceiptWordLabel | None:
     """
     Create a new ReceiptWordLabel documenting the evaluation result.
 
@@ -727,7 +731,9 @@ def _create_evaluation_label(
             result)
 
     Returns:
-        New ReceiptWordLabel with validation status and reasoning
+        New ReceiptWordLabel with validation status and reasoning, or None
+        when no CORE_LABELS name can be determined for the word (the row is
+        skipped rather than minting a new label type).
     """
     if review_result:
         # Use LLM review result
@@ -738,10 +744,8 @@ def _create_evaluation_label(
             label = review_result.suggested_label
         elif issue.suggested_label:
             label = issue.suggested_label
-        elif issue.current_label:
-            label = issue.current_label
         else:
-            label = "UNKNOWN"
+            label = issue.current_label
 
         validation_status = review_result.decision
         reasoning = f"[LLM Review] {review_result.reasoning}"
@@ -750,14 +754,32 @@ def _create_evaluation_label(
         # Use evaluator result directly
         if issue.suggested_label:
             label = issue.suggested_label
-        elif issue.current_label:
-            label = issue.current_label
         else:
-            label = "UNKNOWN"
+            label = issue.current_label
 
         validation_status = issue.suggested_status
         reasoning = f"[Evaluator] {issue.reasoning}"
         proposed_by = "label_evaluator_agent:pattern_match"
+
+    # The label becomes part of the DynamoDB sort key, so it must be a real
+    # CORE_LABELS name.  Previously this fell back to the sentinel "UNKNOWN"
+    # (and could carry a legacy malformed label forward off
+    # `issue.current_label`), which mints a pseudo-label-type -- and, since
+    # #1291, makes `add_receipt_word_labels` reject the whole batch, losing
+    # every other decision for the receipt.  Skip the row instead.
+    normalized_label = normalize_label_alias(label)
+    if normalized_label is None:
+        logger.warning(
+            "Skipping evaluation label for word %s/%s/%s/%s: %r is not a "
+            "CORE_LABELS name",
+            issue.word.image_id,
+            issue.word.receipt_id,
+            issue.word.line_id,
+            issue.word.word_id,
+            label,
+        )
+        return None
+    label = normalized_label
 
     return ReceiptWordLabel(
         image_id=issue.word.image_id,

--- a/receipt_agent/receipt_agent/constants.py
+++ b/receipt_agent/receipt_agent/constants.py
@@ -4,10 +4,26 @@ CORE_LABELS is imported from receipt_dynamo.constants (single source of truth).
 This module extends with receipt_agent-specific groupings and relationships.
 """
 
-from receipt_dynamo.constants import CORE_LABELS
+from receipt_dynamo.constants import (
+    CORE_LABEL_NAMES,
+    CORE_LABELS,
+    NON_CORE_LABEL_ALIASES,
+    is_core_label,
+    normalize_core_label,
+    normalize_label_alias,
+)
 
 # Set of valid core label names for quick lookup
 CORE_LABELS_SET = set(CORE_LABELS.keys())
+
+# Re-exported so agent code has one import for the vocabulary and its guards.
+_VOCABULARY_REEXPORTS = (
+    CORE_LABEL_NAMES,
+    NON_CORE_LABEL_ALIASES,
+    is_core_label,
+    normalize_core_label,
+    normalize_label_alias,
+)
 
 # =============================================================================
 # Label Semantic Groupings (for pattern analysis)

--- a/receipt_agent/tests/test_label_evaluator_label_vocabulary.py
+++ b/receipt_agent/tests/test_label_evaluator_label_vocabulary.py
@@ -1,0 +1,120 @@
+"""The label evaluator must never mint a label outside CORE_LABELS.
+
+``_create_evaluation_label`` used to fall back to the sentinel ``"UNKNOWN"``
+when an issue had neither a suggested nor a current label, and to carry
+``issue.current_label`` forward verbatim. Both put a non-CORE_LABELS string
+into a DynamoDB sort key. Since #1291 they also make
+``add_receipt_word_labels`` reject the whole transaction, so a single bad
+label silently discarded every other decision for the receipt.
+
+The row is now skipped instead.
+"""
+
+import pytest
+from receipt_dynamo.entities.receipt_word import ReceiptWord
+
+from receipt_agent.agents.label_evaluator.graph import (
+    _create_evaluation_label,
+)
+from receipt_agent.agents.label_evaluator.state import (
+    EvaluationIssue,
+    ReviewResult,
+)
+
+IMAGE_ID = "344f4a1b-1476-442e-bb01-7eed30934285"
+
+
+def _word():
+    return ReceiptWord(
+        receipt_id=1,
+        image_id=IMAGE_ID,
+        line_id=10,
+        word_id=1,
+        text="12.34",
+        bounding_box={
+            "x": 0.1,
+            "y": 0.1,
+            "width": 0.1,
+            "height": 0.02,
+        },
+        top_right={"x": 0.2, "y": 0.12},
+        top_left={"x": 0.1, "y": 0.12},
+        bottom_right={"x": 0.2, "y": 0.1},
+        bottom_left={"x": 0.1, "y": 0.1},
+        angle_degrees=0.0,
+        angle_radians=0.0,
+        confidence=0.99,
+    )
+
+
+def _issue(current_label=None, suggested_label=None):
+    return EvaluationIssue(
+        issue_type="position_anomaly",
+        word=_word(),
+        current_label=current_label,
+        suggested_status="NEEDS_REVIEW",
+        reasoning="test",
+        suggested_label=suggested_label,
+    )
+
+
+@pytest.mark.unit
+def test_issue_without_any_label_is_skipped_not_labelled_unknown():
+    assert _create_evaluation_label(_issue(), None) is None
+
+
+@pytest.mark.unit
+def test_core_label_is_kept():
+    label = _create_evaluation_label(_issue(current_label="GRAND_TOTAL"), None)
+    assert label is not None
+    assert label.label == "GRAND_TOTAL"
+
+
+@pytest.mark.unit
+def test_known_alias_is_normalized():
+    label = _create_evaluation_label(_issue(suggested_label="ADDRESS"), None)
+    assert label is not None
+    assert label.label == "ADDRESS_LINE"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "malformed",
+    [
+        "LINE_TOTAL (SHOULD BE 69.60)",
+        "7829.53",
+        "UNKNOWN",
+    ],
+)
+def test_legacy_malformed_current_label_is_not_carried_forward(malformed):
+    """A malformed label read off a stored row must not be re-minted."""
+    assert (
+        _create_evaluation_label(_issue(current_label=malformed), None) is None
+    )
+
+
+@pytest.mark.unit
+def test_llm_review_path_also_refuses_a_non_core_label():
+    issue = _issue(current_label="LINE_TOTAL (SHOULD BE 69.60)")
+    review = ReviewResult(
+        issue=issue,
+        decision="INVALID",
+        reasoning="whatever",
+        suggested_label=None,
+    )
+    assert _create_evaluation_label(issue, review) is None
+
+
+@pytest.mark.unit
+def test_llm_review_path_keeps_a_valid_suggestion():
+    issue = _issue(current_label="LINE_TOTAL")
+    review = ReviewResult(
+        issue=issue,
+        decision="INVALID",
+        reasoning="it is a unit price",
+        suggested_label="UNIT_PRICE",
+    )
+    label = _create_evaluation_label(issue, review)
+    assert label is not None
+    assert label.label == "UNIT_PRICE"
+    assert label.validation_status == "INVALID"

--- a/receipt_dynamo/receipt_dynamo/constants.py
+++ b/receipt_dynamo/receipt_dynamo/constants.py
@@ -4,6 +4,7 @@ receipt parsing, labeling, embedding, and batch processing.
 """
 
 from enum import Enum
+from typing import Any
 
 
 class ValidationStatus(str, Enum):
@@ -219,3 +220,77 @@ CORE_LABELS: dict[str, str] = {
     "CASH_BACK": "Cash back amount dispensed from purchase.",
     "REFUND": "Refund amount (full or partial return).",
 }
+
+# Sorted tuple of the canonical label names.  Used to declare the allowed
+# values of a `label` argument (e.g. an MCP tool's JSON-Schema ``enum``) so a
+# caller is told what is legal instead of discovering it from a stack trace.
+CORE_LABEL_NAMES: tuple[str, ...] = tuple(sorted(CORE_LABELS))
+
+# Soft aliases: label names that writers commonly emit but that are not
+# themselves canonical.  Rewriting one of these to its CORE_LABELS target is
+# lossless and unambiguous.  A label that is neither a core label nor a known
+# alias is refused, never guessed at -- guessing is how 72 distinct malformed
+# label strings ended up as real DynamoDB sort keys.
+NON_CORE_LABEL_ALIASES: dict[str, str] = {
+    "ADDRESS": "ADDRESS_LINE",
+    "BUSINESS_NAME": "MERCHANT_NAME",
+    "CARD_NUMBER": "PAYMENT_METHOD",
+    "PAYMENT_TYPE": "PAYMENT_METHOD",
+}
+
+
+def canonical_label_name(label: Any) -> str:
+    """Normalize a model or stored label into the Dynamo label format."""
+    if label is None:
+        return ""
+    return str(label).strip().upper()
+
+
+def is_core_label(label: Any) -> bool:
+    """Return whether a label is part of the canonical receipt label set."""
+    return canonical_label_name(label) in CORE_LABELS
+
+
+def normalize_label_alias(label: Any) -> str | None:
+    """Map known non-core aliases to CORE_LABELS, if the mapping is safe.
+
+    Returns ``None`` when the label is neither a core label nor a known
+    alias.  Callers minting a *new* label row must treat ``None`` as a
+    refusal; they must not fall back to the raw string.
+    """
+    canonical = canonical_label_name(label)
+    if canonical in CORE_LABELS:
+        return canonical
+    return NON_CORE_LABEL_ALIASES.get(canonical)
+
+
+def invalid_label_message(label: Any) -> str:
+    """Build the caller-facing message for a label outside the vocabulary."""
+    canonical = canonical_label_name(label)
+    message = (
+        f"Invalid label {canonical!r}: label must be one of "
+        f"{list(CORE_LABEL_NAMES)}"
+    )
+    suggestion = NON_CORE_LABEL_ALIASES.get(canonical)
+    if suggestion is not None:
+        message += f". Did you mean {suggestion!r}?"
+    return message
+
+
+def normalize_core_label(label: Any) -> str:
+    """Return the canonical CORE_LABELS name for ``label``.
+
+    Accepts a core label in any casing and the soft aliases in
+    ``NON_CORE_LABEL_ALIASES``.  Raises ``ValueError`` for anything else.
+
+    This is the *authoring* guard: use it wherever a label name arrives as
+    free text (an agent argument, an LLM response, a CLI flag) and BEFORE a
+    ``ReceiptWordLabel`` is constructed, because the label name becomes part
+    of the DynamoDB sort key.  Do NOT use it on a label read back out of
+    DynamoDB -- 394 production rows carry historical labels outside this
+    vocabulary and must stay readable.
+    """
+    normalized = normalize_label_alias(label)
+    if normalized is None:
+        raise ValueError(invalid_label_message(label))
+    return normalized

--- a/receipt_dynamo/receipt_dynamo/data/_receipt_word_label.py
+++ b/receipt_dynamo/receipt_dynamo/data/_receipt_word_label.py
@@ -9,7 +9,12 @@ from typing import Any
 
 from botocore.exceptions import ClientError
 
-from receipt_dynamo.constants import CORE_LABELS, ValidationStatus
+from receipt_dynamo.constants import (
+    CORE_LABEL_NAMES,
+    CORE_LABELS,
+    NON_CORE_LABEL_ALIASES,
+    ValidationStatus,
+)
 from receipt_dynamo.data.base_operations import (
     FlattenedStandardMixin,
     TransactWriteItemTypeDef,
@@ -80,10 +85,18 @@ class _ReceiptWordLabel(
             {item.label for item in receipt_word_labels} - set(CORE_LABELS)
         )
         if invalid_labels:
-            rendered = ", ".join(repr(label) for label in invalid_labels)
+            rendered = ", ".join(
+                (
+                    f"{label!r} (did you mean {suggestion!r}?)"
+                    if (suggestion := NON_CORE_LABEL_ALIASES.get(label))
+                    else repr(label)
+                )
+                for label in invalid_labels
+            )
             raise EntityValidationError(
                 "Cannot add non-core receipt word label(s): "
-                f"{rendered}. New labels must be present in CORE_LABELS; "
+                f"{rendered}. New labels must be one of "
+                f"{list(CORE_LABEL_NAMES)}; "
                 "allow_non_core_labels=True is reserved for controlled "
                 "legacy restoration."
             )

--- a/receipt_dynamo/receipt_dynamo/entities/receipt_word_label.py
+++ b/receipt_dynamo/receipt_dynamo/entities/receipt_word_label.py
@@ -64,6 +64,18 @@ class ReceiptWordLabel:
             raise ValueError("label must be a string")
         if not self.label:
             raise ValueError("label cannot be empty")
+        # NOTE: the CORE_LABELS vocabulary is deliberately NOT enforced here.
+        # __post_init__ runs on every construction, including `from_item`,
+        # `ReceiptWordLabel(**asdict(existing))` and every read-modify-write
+        # of an already-stored row (resegmentation, dedup, label sync, the
+        # MCP `update_word_label` tool).  394 production rows carry labels
+        # outside CORE_LABELS, so a raise here would fire on reads and break
+        # the very tools needed to triage them.  The vocabulary is enforced
+        # on the one path that MINTS a new label sort key --
+        # `_ReceiptWordLabel._validate_receipt_word_labels_for_add`, reached
+        # only via `add_receipt_word_label(s)` (attribute_not_exists) -- and
+        # at the authoring boundary via
+        # `receipt_dynamo.constants.normalize_core_label`.
         self.label = (
             self.label.upper()
         )  # Store labels in uppercase for consistency

--- a/receipt_dynamo/tests/unit/test_receipt_word_label_vocabulary.py
+++ b/receipt_dynamo/tests/unit/test_receipt_word_label_vocabulary.py
@@ -1,0 +1,254 @@
+"""The CORE_LABELS vocabulary guard for receipt word labels.
+
+A word label's name is part of its DynamoDB sort key
+(``...#WORD#00001#LABEL#<label>``), so every distinct string a writer emits
+mints a new pseudo-label-type. Production already carries 394 rows across 72
+malformed label strings written by a since-fixed free-text parser (#758).
+
+These tests pin the two halves of the contract:
+
+* **Write** -- ``add_receipt_word_label(s)`` is the only path that can mint a
+  new label sort key (``attribute_not_exists``), and it refuses any label
+  outside ``CORE_LABELS``.
+* **Read** -- nothing on a read or read-modify-write path may raise on the
+  existing malformed corpus. The fixture below is a byte-for-byte copy of a
+  real production row from ``ReceiptsTable-d7ff76a``.
+"""
+
+from dataclasses import asdict
+
+import pytest
+
+from receipt_dynamo.constants import (
+    CORE_LABEL_NAMES,
+    CORE_LABELS,
+    NON_CORE_LABEL_ALIASES,
+    canonical_label_name,
+    invalid_label_message,
+    is_core_label,
+    normalize_core_label,
+    normalize_label_alias,
+)
+from receipt_dynamo.data._receipt_word_label import _ReceiptWordLabel
+from receipt_dynamo.data.shared_exceptions import EntityValidationError
+from receipt_dynamo.entities.receipt_word_label import (
+    ReceiptWordLabel,
+    item_to_receipt_word_label,
+)
+
+IMAGE_ID = "344f4a1b-1476-442e-bb01-7eed30934285"
+
+# A real malformed row read (read-only) out of production table
+# ReceiptsTable-d7ff76a. Written 2026-01-18 by ``label-evaluator-llm``, the
+# free-text parser fixed by #758. Reading it must never raise.
+STORED_MALFORMED_ITEM = {
+    "PK": {"S": f"IMAGE#{IMAGE_ID}"},
+    "SK": {
+        "S": (
+            "RECEIPT#00001#LINE#00010#WORD#00001"
+            "#LABEL#LINE_TOTAL (SHOULD BE 69.60)"
+        )
+    },
+    "TYPE": {"S": "RECEIPT_WORD_LABEL"},
+    "validation_status": {"S": "INVALID"},
+    "label_consolidated_from": {"NULL": True},
+    "label_proposed_by": {"S": "label-evaluator-llm"},
+    "timestamp_added": {"S": "2026-01-18T17:12:51.520489+00:00"},
+    "reasoning": {
+        "S": (
+            "[label-evaluator phase1] Decision: INVALID (high). "
+            '"3.25" is a price amount; it belongs to UNIT_PRICE, '
+            "not LINE_TOTAL."
+        )
+    },
+}
+
+MALFORMED_LABEL = "LINE_TOTAL (SHOULD BE 69.60)"
+
+# Other real shapes from the malformed corpus: a whole sentence and a bare
+# amount. Both were minted purely because nothing checked the vocabulary.
+JUNK_LABELS = (
+    "SUBTOTAL SHOULD BE $214.46 (OR THE $4014.97 ENTRY SHOULD BE "
+    "CORRECTED/REMOVED)",
+    "7829.53",
+    MALFORMED_LABEL,
+)
+
+
+class _Validator(_ReceiptWordLabel):
+    """The add-path validator in isolation -- it never touches the network."""
+
+    table_name = "ReceiptsTable-test"
+
+
+def _label(label: str, **overrides) -> ReceiptWordLabel:
+    kwargs = {
+        "image_id": IMAGE_ID,
+        "receipt_id": 1,
+        "line_id": 10,
+        "word_id": 1,
+        "label": label,
+        "reasoning": "because",
+        "timestamp_added": "2026-08-05T00:00:00+00:00",
+    }
+    kwargs.update(overrides)
+    return ReceiptWordLabel(**kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Vocabulary helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_core_label_names_matches_core_labels():
+    assert set(CORE_LABEL_NAMES) == set(CORE_LABELS)
+    assert list(CORE_LABEL_NAMES) == sorted(CORE_LABELS)
+    assert len(CORE_LABEL_NAMES) == 22
+
+
+@pytest.mark.unit
+def test_aliases_all_point_at_core_labels():
+    for alias, target in NON_CORE_LABEL_ALIASES.items():
+        assert alias not in CORE_LABELS
+        assert target in CORE_LABELS
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("label", sorted(CORE_LABELS))
+def test_core_label_normalizes_to_itself(label):
+    assert is_core_label(label)
+    assert normalize_core_label(label.lower()) == label
+    assert normalize_label_alias(f"  {label}  ") == label
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "alias,expected", sorted(NON_CORE_LABEL_ALIASES.items())
+)
+def test_alias_normalizes_to_core_label(alias, expected):
+    assert not is_core_label(alias)
+    assert normalize_core_label(alias) == expected
+    assert normalize_core_label(alias.lower()) == expected
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("junk", JUNK_LABELS)
+def test_junk_label_is_refused_with_a_clear_message(junk):
+    assert normalize_label_alias(junk) is None
+    with pytest.raises(ValueError) as excinfo:
+        normalize_core_label(junk)
+    message = str(excinfo.value)
+    assert "label must be one of" in message
+    assert "GRAND_TOTAL" in message
+    assert canonical_label_name(junk) in message
+
+
+@pytest.mark.unit
+def test_invalid_label_message_suggests_a_known_alias():
+    message = invalid_label_message("address")
+    assert "label must be one of" in message
+    assert "Did you mean 'ADDRESS_LINE'?" in message
+
+
+# ---------------------------------------------------------------------------
+# WRITE path: add_receipt_word_label(s) is the only sort-key minting path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_add_validator_accepts_a_core_label():
+    _Validator()._validate_receipt_word_labels_for_add([_label("GRAND_TOTAL")])
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("junk", JUNK_LABELS)
+def test_add_validator_refuses_junk_before_any_write(junk):
+    with pytest.raises(EntityValidationError) as excinfo:
+        _Validator()._validate_receipt_word_labels_for_add([_label(junk)])
+    message = str(excinfo.value)
+    assert "Cannot add non-core receipt word label" in message
+    assert "must be one of" in message
+    assert "GRAND_TOTAL" in message
+
+
+@pytest.mark.unit
+def test_add_validator_refuses_an_alias_and_names_the_target():
+    with pytest.raises(EntityValidationError) as excinfo:
+        _Validator()._validate_receipt_word_labels_for_add([_label("ADDRESS")])
+    assert "did you mean 'ADDRESS_LINE'?" in str(excinfo.value)
+
+
+@pytest.mark.unit
+def test_normalized_alias_then_passes_the_add_validator():
+    normalized = normalize_core_label("ADDRESS")
+    _Validator()._validate_receipt_word_labels_for_add([_label(normalized)])
+    assert _label(normalized).key["SK"]["S"].endswith("#LABEL#ADDRESS_LINE")
+
+
+@pytest.mark.unit
+def test_legacy_restore_escape_hatch_is_explicit():
+    """The only way past the guard is an explicit, named argument."""
+    _Validator()._validate_receipt_word_labels_for_add(
+        [_label(MALFORMED_LABEL)], allow_non_core_labels=True
+    )
+
+
+# ---------------------------------------------------------------------------
+# READ path: the existing malformed corpus must stay fully readable
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_stored_malformed_row_still_deserialises():
+    """from_item on a real production malformed row must not raise."""
+    entity = ReceiptWordLabel.from_item(STORED_MALFORMED_ITEM)
+    assert entity.label == MALFORMED_LABEL
+    assert entity.image_id == IMAGE_ID
+    assert entity.validation_status == "INVALID"
+
+    # ...and via the module-level converter the data layer actually calls.
+    assert item_to_receipt_word_label(STORED_MALFORMED_ITEM) == entity
+
+
+@pytest.mark.unit
+def test_stored_malformed_row_round_trips_through_to_item():
+    """to_item() re-runs __post_init__; a legacy row must survive it."""
+    entity = ReceiptWordLabel.from_item(STORED_MALFORMED_ITEM)
+    item = entity.to_item()
+    assert item["SK"] == STORED_MALFORMED_ITEM["SK"]
+    assert ReceiptWordLabel.from_item(item) == entity
+
+
+@pytest.mark.unit
+def test_stored_malformed_row_round_trips_through_asdict():
+    """Step Functions and the copy scripts rebuild labels from plain dicts."""
+    entity = ReceiptWordLabel.from_item(STORED_MALFORMED_ITEM)
+    assert ReceiptWordLabel(**asdict(entity)) == entity
+    assert ReceiptWordLabel(**dict(entity)) == entity
+
+
+@pytest.mark.unit
+def test_read_modify_write_of_a_malformed_row_is_not_blocked():
+    """Marking a legacy malformed row INVALID must keep working.
+
+    ``update_receipt_word_label`` is conditional on ``attribute_exists(PK)``,
+    so it cannot mint a new sort key and therefore must NOT run the
+    vocabulary guard -- otherwise the tooling needed to triage the 394
+    malformed rows would be the first casualty of the guard.
+    """
+    entity = ReceiptWordLabel.from_item(STORED_MALFORMED_ITEM)
+    updated = ReceiptWordLabel(
+        image_id=entity.image_id,
+        receipt_id=entity.receipt_id,
+        line_id=entity.line_id,
+        word_id=entity.word_id,
+        label=entity.label,
+        reasoning="triage: malformed label name",
+        timestamp_added=entity.timestamp_added,
+        validation_status="INVALID",
+        label_proposed_by="mcp-claude-review",
+        label_consolidated_from=entity.label_consolidated_from,
+    )
+    assert updated.label == MALFORMED_LABEL
+    assert updated.to_item()["SK"] == STORED_MALFORMED_ITEM["SK"]

--- a/receipt_upload/receipt_upload/label_validation/label_normalization.py
+++ b/receipt_upload/receipt_upload/label_validation/label_normalization.py
@@ -1,34 +1,30 @@
-"""Helpers for keeping receipt word labels inside CORE_LABELS."""
+"""Helpers for keeping receipt word labels inside CORE_LABELS.
+
+The vocabulary itself now lives in :mod:`receipt_dynamo.constants`, next to
+``CORE_LABELS`` and to the ``add_receipt_word_label`` guard that enforces it,
+so every writer -- including the two MCP servers, which do not import
+``receipt_upload`` -- shares one definition.  This module stays as the
+import path several call sites already use.
+"""
 
 from __future__ import annotations
 
-from typing import Any
+from receipt_dynamo.constants import (
+    CORE_LABEL_NAMES,
+    NON_CORE_LABEL_ALIASES,
+    canonical_label_name,
+    invalid_label_message,
+    is_core_label,
+    normalize_core_label,
+    normalize_label_alias,
+)
 
-from receipt_dynamo.constants import CORE_LABELS
-
-NON_CORE_LABEL_ALIASES: dict[str, str] = {
-    "ADDRESS": "ADDRESS_LINE",
-    "BUSINESS_NAME": "MERCHANT_NAME",
-    "CARD_NUMBER": "PAYMENT_METHOD",
-    "PAYMENT_TYPE": "PAYMENT_METHOD",
-}
-
-
-def canonical_label_name(label: Any) -> str:
-    """Normalize a model or stored label into the Dynamo label format."""
-    if label is None:
-        return ""
-    return str(label).strip().upper()
-
-
-def is_core_label(label: Any) -> bool:
-    """Return whether a label is part of the canonical receipt label set."""
-    return canonical_label_name(label) in CORE_LABELS
-
-
-def normalize_label_alias(label: Any) -> str | None:
-    """Map known non-core aliases to CORE_LABELS, if the mapping is safe."""
-    canonical = canonical_label_name(label)
-    if canonical in CORE_LABELS:
-        return canonical
-    return NON_CORE_LABEL_ALIASES.get(canonical)
+__all__ = [
+    "CORE_LABEL_NAMES",
+    "NON_CORE_LABEL_ALIASES",
+    "canonical_label_name",
+    "invalid_label_message",
+    "is_core_label",
+    "normalize_core_label",
+    "normalize_label_alias",
+]

--- a/scripts/receipt_mcp_server.py
+++ b/scripts/receipt_mcp_server.py
@@ -48,6 +48,17 @@ from mcp.server import Server
 from mcp.server.stdio import stdio_server
 from mcp.types import ImageContent, TextContent, Tool
 
+# The canonical word-label vocabulary. Imported at module scope (not lazily
+# inside the impl) because `list_tools` has to publish it as the JSON-Schema
+# `enum` for create_word_label's `label` argument -- the label name becomes
+# part of the DynamoDB sort key, so a caller must be told the legal values
+# up front instead of minting a new pseudo-label-type.
+from receipt_dynamo.constants import (  # noqa: E402
+    CORE_LABEL_NAMES,
+    invalid_label_message,
+    normalize_label_alias,
+)
+
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
@@ -919,7 +930,15 @@ image_id/receipt_id/line_id/word_id/label already exists.""",
                     },
                     "label": {
                         "type": "string",
-                        "description": "The label to assign (e.g., CASH_BACK, GRAND_TOTAL)",
+                        "enum": list(CORE_LABEL_NAMES),
+                        "description": (
+                            "The label to assign. Must be one of the "
+                            "canonical CORE_LABELS values listed in `enum` "
+                            "(e.g., CASH_BACK, GRAND_TOTAL). This string "
+                            "becomes part of the DynamoDB sort key, so free "
+                            "text is REFUSED -- never pass a sentence, an "
+                            "amount, or a correction note."
+                        ),
                     },
                     "reasoning": {
                         "type": "string",
@@ -3744,7 +3763,16 @@ async def create_word_label_impl(
     from receipt_dynamo.entities.receipt_word_label import ReceiptWordLabel
 
     try:
-        normalized_label = label.upper()
+        # The label becomes part of the DynamoDB sort key, so every distinct
+        # string mints a pseudo-label-type. Refuse anything outside
+        # CORE_LABELS here, at the tool boundary, so the caller gets
+        # "label must be one of ..." instead of a stack trace from the
+        # add_receipt_word_label guard -- and so nothing is written at all.
+        # Known soft aliases (ADDRESS -> ADDRESS_LINE) are rewritten; nothing
+        # else is guessed at.
+        normalized_label = normalize_label_alias(label)
+        if normalized_label is None:
+            return {"error": invalid_label_message(label)}
         # Only the four workflow statuses are valid on create; a null/omitted
         # arg falls back to VALID. NONE is deliberately excluded so a stray
         # null can't silently persist a non-ground-truth row.

--- a/tests/test_receipt_mcp_label_vocabulary.py
+++ b/tests/test_receipt_mcp_label_vocabulary.py
@@ -1,0 +1,325 @@
+"""``create_word_label`` must not be able to mint a new label type.
+
+A word label's name is part of its DynamoDB sort key, so every distinct
+string a caller passes becomes a new pseudo-label-type. Production carries
+394 rows across 72 malformed label strings from a since-fixed free-text
+parser (#758); the MCP ``create_word_label`` tool was the remaining
+structurally-open writer.
+
+These tests exercise the real tool path on BOTH server copies -- the stdio
+``scripts/receipt_mcp_server.py`` and the deployed Lambda
+``infra/mcp_server_lambda/lambdas/receipt_mcp_server_server.py`` -- which
+must stay identical. They assert:
+
+* the published ``inputSchema`` declares the allowed values as an ``enum``,
+* ``create_word_label_impl`` refuses free text *before* touching DynamoDB,
+* a known soft alias is normalised and written,
+* ``update_word_label_impl`` still works on a stored malformed row, i.e.
+  the guard is on the write path only and never on a read.
+"""
+
+import asyncio
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from receipt_dynamo.constants import CORE_LABELS
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+SERVER_FILES = {
+    "stdio": REPO_ROOT / "scripts" / "receipt_mcp_server.py",
+    "lambda": (
+        REPO_ROOT
+        / "infra"
+        / "mcp_server_lambda"
+        / "lambdas"
+        / "receipt_mcp_server_server.py"
+    ),
+}
+
+VALID_IMAGE_ID = "344f4a1b-1476-442e-bb01-7eed30934285"
+
+# Real malformed label strings from the production corpus.
+JUNK_LABELS = [
+    "SUBTOTAL SHOULD BE $214.46 (OR THE $4014.97 ENTRY SHOULD BE "
+    "CORRECTED/REMOVED)",
+    "LINE_TOTAL (SHOULD BE 69.60)",
+    "7829.53",
+    "grand total",
+]
+
+MALFORMED_STORED_LABEL = "LINE_TOTAL (SHOULD BE 69.60)"
+
+
+class _FakeTool:
+    def __init__(self, name, description, inputSchema):
+        self.name = name
+        self.description = description
+        self.inputSchema = inputSchema
+
+
+class _FakeContent:
+    def __init__(self, **kwargs):
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+
+def _install_mcp_stubs():
+    """Register a minimal fake `mcp` package so the servers import cleanly."""
+    mcp_mod = types.ModuleType("mcp")
+    server_mod = types.ModuleType("mcp.server")
+    stdio_mod = types.ModuleType("mcp.server.stdio")
+    types_mod = types.ModuleType("mcp.types")
+
+    class _FakeServer:
+        def __init__(self, name):
+            self.name = name
+
+        def list_tools(self):
+            def decorator(func):
+                return func
+
+            return decorator
+
+        def call_tool(self):
+            def decorator(func):
+                return func
+
+            return decorator
+
+    def _fake_stdio_server(*args, **kwargs):  # pragma: no cover - unused
+        raise RuntimeError("stdio_server is not exercised in tests")
+
+    server_mod.Server = _FakeServer
+    stdio_mod.stdio_server = _fake_stdio_server
+    types_mod.Tool = _FakeTool
+    types_mod.TextContent = _FakeContent
+    types_mod.ImageContent = _FakeContent
+
+    sys.modules["mcp"] = mcp_mod
+    sys.modules["mcp.server"] = server_mod
+    sys.modules["mcp.server.stdio"] = stdio_mod
+    sys.modules["mcp.types"] = types_mod
+
+
+def _load_module(label, path):
+    _install_mcp_stubs()
+    spec = importlib.util.spec_from_file_location(
+        f"receipt_mcp_server_vocab_{label}", path
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _create_word_label_schema(module):
+    tools = asyncio.run(module.list_tools())
+    by_name = {t.name: t for t in tools}
+    return by_name["create_word_label"].inputSchema
+
+
+class _RecordingDynamoClient:
+    """Records writes; raises if the impl ever reaches DynamoDB unexpectedly.
+
+    ``add_receipt_word_label`` mirrors the real guard so this test proves the
+    tool boundary refuses first (``added`` stays empty and no exception is
+    raised), not that the deeper guard happens to catch it.
+    """
+
+    def __init__(self, existing=None):
+        self.added = []
+        self.updated = []
+        self.existing = existing or {}
+
+    def add_receipt_word_label(self, label, **kwargs):
+        if label.label not in CORE_LABELS and not kwargs.get(
+            "allow_non_core_labels"
+        ):
+            raise AssertionError(
+                "non-core label reached DynamoDB: " + repr(label.label)
+            )
+        self.added.append(label)
+
+    def get_receipt_word_label(
+        self, image_id, receipt_id, line_id, word_id, label
+    ):
+        return self.existing[label]
+
+    def update_receipt_word_label(self, label):
+        self.updated.append(label)
+
+
+def _stored_label(label):
+    from receipt_dynamo.entities.receipt_word_label import ReceiptWordLabel
+
+    return ReceiptWordLabel(
+        image_id=VALID_IMAGE_ID,
+        receipt_id=1,
+        line_id=10,
+        word_id=1,
+        label=label,
+        reasoning="written 2026-01-18 by the label-evaluator free-text parser",
+        timestamp_added="2026-01-18T17:12:51.520489+00:00",
+        validation_status="VALID",
+        label_proposed_by="label-evaluator-llm",
+    )
+
+
+def _create(module, client, label, **overrides):
+    kwargs = {
+        "image_id": VALID_IMAGE_ID,
+        "receipt_id": 1,
+        "line_id": 10,
+        "word_id": 1,
+        "label": label,
+        "reasoning": "test",
+    }
+    kwargs.update(overrides)
+    return asyncio.run(module.create_word_label_impl(client, **kwargs))
+
+
+# ---------------------------------------------------------------------------
+# Tool boundary: the schema declares the vocabulary
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("server", sorted(SERVER_FILES))
+def test_create_word_label_schema_declares_the_enum(server):
+    schema = _create_word_label_schema(
+        _load_module(server, SERVER_FILES[server])
+    )
+    label_schema = schema["properties"]["label"]
+    assert label_schema["type"] == "string"
+    assert set(label_schema["enum"]) == set(CORE_LABELS)
+    assert label_schema["enum"] == sorted(CORE_LABELS)
+
+
+def test_both_servers_publish_the_same_create_word_label_schema():
+    stdio = _load_module("stdio-vocab", SERVER_FILES["stdio"])
+    lam = _load_module("lambda-vocab", SERVER_FILES["lambda"])
+    assert _create_word_label_schema(stdio) == _create_word_label_schema(lam)
+
+
+@pytest.mark.parametrize("server", sorted(SERVER_FILES))
+def test_update_word_label_schema_is_not_enum_constrained(server):
+    """update targets an EXISTING row; constraining it would make the 394
+    malformed rows untouchable by the tool needed to triage them."""
+    module = _load_module(server, SERVER_FILES[server])
+    tools = asyncio.run(module.list_tools())
+    schema = {t.name: t.inputSchema for t in tools}["update_word_label"]
+    assert "enum" not in schema["properties"]["label"]
+
+
+# ---------------------------------------------------------------------------
+# WRITE path: junk is refused at the tool boundary, before any DynamoDB call
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("server", sorted(SERVER_FILES))
+@pytest.mark.parametrize("junk", JUNK_LABELS)
+def test_create_word_label_refuses_junk(server, junk):
+    module = _load_module(server, SERVER_FILES[server])
+    client = _RecordingDynamoClient()
+
+    result = _create(module, client, junk)
+
+    assert "error" in result, result
+    assert "label must be one of" in result["error"]
+    assert "GRAND_TOTAL" in result["error"]
+    assert result.get("success") is None
+    # Nothing was written, and the refusal happened before DynamoDB.
+    assert client.added == []
+
+
+@pytest.mark.parametrize("server", sorted(SERVER_FILES))
+def test_create_word_label_writes_a_core_label(server):
+    module = _load_module(server, SERVER_FILES[server])
+    client = _RecordingDynamoClient()
+
+    result = _create(module, client, "cash_back")
+
+    assert result["success"] is True
+    assert result["label"] == "CASH_BACK"
+    assert [lbl.label for lbl in client.added] == ["CASH_BACK"]
+    assert client.added[0].key["SK"]["S"].endswith("#LABEL#CASH_BACK")
+
+
+@pytest.mark.parametrize("server", sorted(SERVER_FILES))
+def test_create_word_label_normalises_a_known_alias(server):
+    module = _load_module(server, SERVER_FILES[server])
+    client = _RecordingDynamoClient()
+
+    result = _create(module, client, "ADDRESS")
+
+    assert result["success"] is True
+    assert result["label"] == "ADDRESS_LINE"
+    assert [lbl.label for lbl in client.added] == ["ADDRESS_LINE"]
+
+
+@pytest.mark.parametrize("server", sorted(SERVER_FILES))
+def test_create_word_label_error_suggests_an_alias_target(server):
+    module = _load_module(server, SERVER_FILES[server])
+    client = _RecordingDynamoClient()
+
+    result = _create(module, client, "card number")
+
+    # "CARD NUMBER" is not the "CARD_NUMBER" alias -- it is refused outright.
+    assert "label must be one of" in result["error"]
+    assert client.added == []
+
+
+# ---------------------------------------------------------------------------
+# READ path: the stored malformed corpus stays usable through the tools
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("server", sorted(SERVER_FILES))
+def test_update_word_label_still_works_on_a_stored_malformed_row(server):
+    """The guard must not fire on a read-modify-write of a legacy row."""
+    module = _load_module(server, SERVER_FILES[server])
+    client = _RecordingDynamoClient(
+        existing={
+            MALFORMED_STORED_LABEL: _stored_label(MALFORMED_STORED_LABEL)
+        }
+    )
+
+    result = asyncio.run(
+        module.update_word_label_impl(
+            client,
+            image_id=VALID_IMAGE_ID,
+            receipt_id=1,
+            line_id=10,
+            word_id=1,
+            label=MALFORMED_STORED_LABEL,
+            new_status="INVALID",
+            reasoning="triage: malformed label name",
+        )
+    )
+
+    assert result.get("success") is True, result
+    assert result["label"] == MALFORMED_STORED_LABEL
+    assert [lbl.label for lbl in client.updated] == [MALFORMED_STORED_LABEL]
+
+
+@pytest.mark.parametrize("server", sorted(SERVER_FILES))
+def test_no_impl_reconstructs_a_read_label_through_the_guard(server):
+    """create_word_label is the only label-minting tool on either server."""
+    module = _load_module(server, SERVER_FILES[server])
+    tools = asyncio.run(module.list_tools())
+    minting = {
+        t.name
+        for t in tools
+        if "label" in t.inputSchema.get("properties", {})
+        and "enum" in t.inputSchema["properties"]["label"]
+    }
+    assert minting == {"create_word_label"}
+
+
+def _fake_ns(**kwargs):  # pragma: no cover - helper kept for readability
+    return SimpleNamespace(**kwargs)


### PR DESCRIPTION
## The gap

`create_word_label` on **both** MCP server copies declared `label` as a bare `{"type": "string"}` and `create_word_label_impl` only called `label.upper()` before constructing the entity. The label name is part of the DynamoDB **sort key** (`...#WORD#00001#LABEL#<label>`), so every distinct string mints a new pseudo-label-type.

Prod carries **394 rows across 72 malformed label strings** — 46% of the distinct label vocabulary — e.g. `SUBTOTAL SHOULD BE $214.46 (OR THE $4014.97 ENTRY SHOULD BE CORRECTED/REMOVED)`, `LINE_TOTAL (SHOULD BE 69.60)`, bare amounts like `7829.53`. Dev has 353 / 64. The historical writer was fixed by #758 (zero malformed rows since 2026-02-10, ~6 months clean); this was a remaining structurally-open one. It must close before those rows are cleaned or the cleanup refills.

## Where the guard goes — and why not in `__post_init__`

`ReceiptWordLabel.__post_init__` looks like the one chokepoint every writer passes through, but it runs on **every construction, including reads**:

- `from_item` / `item_to_receipt_word_label`
- `ReceiptWordLabel(**asdict(existing))` and `ReceiptWordLabel(**dict(existing))` — how Step Function state and the copy scripts rebuild labels
- every read-modify-write of an already-stored row

An audit of all ~24 `ReceiptWordLabel(` construction sites found **12 that carry a label off an already-stored row**: the resegment / merge / combine Lambdas, `dedup/apply`, `label_sync/union`, four dev→prod copy scripts, Step Function (de)serialization, and — decisively — the MCP `update_word_label` tool itself, i.e. the very tool needed to mark the 394 malformed rows INVALID. A raise in `__post_init__` fires on reads and breaks all of them.

So the entity keeps only its structural check (non-empty string), now with a comment recording the decision. The vocabulary is enforced on the one path that **mints** a new label sort key:

| Path | Condition | Guarded? |
|---|---|---|
| `add_receipt_word_label(s)` | `attribute_not_exists` — the only way to mint a new SK | **yes** (CORE_LABELS, since #1291) |
| `update_receipt_word_label(s)` | `attribute_exists` — cannot mint | no, deliberately |
| `from_item` / `asdict` round trips | read | no, deliberately |

…plus a new **tool-boundary** guard so a caller is told the legal values instead of getting a stack trace.

## Changes

- **`receipt_dynamo.constants` is now the single home for the vocabulary**: `CORE_LABEL_NAMES`, `NON_CORE_LABEL_ALIASES`, `canonical_label_name`, `is_core_label`, `normalize_label_alias`, `invalid_label_message`, `normalize_core_label`. `receipt_upload`'s `label_normalization` and `receipt_agent`'s `constants` re-export them (no behaviour change for their 5 + N existing importers), so the two MCP servers — which do not import `receipt_upload` — share one definition with zero new dependencies.
- **Both MCP copies**: `create_word_label`'s `inputSchema` declares the 22 allowed values as a JSON-Schema `enum`; `create_word_label_impl` normalises known soft aliases (`ADDRESS` → `ADDRESS_LINE`) and refuses anything else with `label must be one of [...]` **before** touching DynamoDB. The changed regions of the two files are byte-identical (asserted by a test).
- **`update_word_label` is deliberately NOT enum-constrained** — it targets an existing row and must be able to reach a legacy malformed label.
- **Add-path refusal message** now lists the legal values and suggests an alias target (`'ADDRESS' (did you mean 'ADDRESS_LINE'?)`).
- **label_evaluator no longer mints `"UNKNOWN"`.** The audit turned up one genuinely open non-core writer: `_create_evaluation_label` fell back to the sentinel `"UNKNOWN"` (and could carry a legacy malformed label forward off `issue.current_label`). Since #1291 a single such label makes `add_receipt_word_labels` reject the whole transaction, silently discarding every other decision for that receipt. It now skips and logs the row.

### Does anything legitimately write a non-core label?

**No.** Every producer of a *new* label row derives its string from a fixed literal set (`amount_classifier`, `line_items/reconstructor`, `semantic_proposer`, `line_items/labels`, `backfill_reverse_ocr`) or already filters on CORE_LABELS (`llm_review` via `_normalize_suggested_label` + the `LabelEnum` pydantic enum, `llm_runner` via an explicit membership gate). The only legitimate non-core writes are **snapshot restore** and **migration of pre-existing rows** — already served by the explicit `allow_non_core_labels=True` escape hatch (`import_image.py`). That strengthens the case for the strict add-path guard.

## Read-path proof

The single biggest risk. A **byte-for-byte copy of a real production malformed row** (`ReceiptsTable-d7ff76a`, `LINE_TOTAL (SHOULD BE 69.60)`, written 2026-01-18 by `label-evaluator-llm`) is pinned as a fixture and asserted to survive:

- `ReceiptWordLabel.from_item(...)` and `item_to_receipt_word_label(...)`
- a `to_item()` round trip (which re-runs `__post_init__`)
- `ReceiptWordLabel(**asdict(entity))` and `ReceiptWordLabel(**dict(entity))`
- a read-modify-write through the MCP `update_word_label_impl` on **both** servers

## What a caller passing junk now sees

```
{"error": "Invalid label 'SUBTOTAL SHOULD BE $214.46 (OR THE ...)': label
 must be one of ['ADDRESS_LINE', 'CASH_BACK', 'CHANGE', 'COUPON', 'DATE',
 'DISCOUNT', 'GRAND_TOTAL', 'LINE_TOTAL', 'LOYALTY_ID', 'MERCHANT_NAME',
 'PAYMENT_METHOD', 'PHONE_NUMBER', 'PRODUCT_NAME', 'QUANTITY', 'REFUND',
 'STORE_HOURS', 'SUBTOTAL', 'TAX', 'TIME', 'TIP', 'UNIT_PRICE', 'WEBSITE']"}
```

Nothing is written; DynamoDB is never reached. A known alias is normalised and written instead of refused.

## Tests

| Suite | Result |
|---|---|
| `receipt_dynamo/tests/unit` (incl. 43 new) | 2426 passed |
| `receipt_upload/tests` | passed |
| `receipt_agent/tests` (incl. 8 new) | 379 passed, 22 skipped |
| root `tests/` (incl. 23 new) | 736 passed, 1 skipped |
| `lambda-syntax` (py_compile over all `infra/**.py`) | passed |
| black + isort, **both** CI personalities run separately | passed |

New files: `receipt_dynamo/tests/unit/test_receipt_word_label_vocabulary.py`, `tests/test_receipt_mcp_label_vocabulary.py` (exercises both server copies), `receipt_agent/tests/test_label_evaluator_label_vocabulary.py`.

## Not in scope

**No malformed row was cleaned, deleted, or modified** — that is a separate authorized step. Prod was touched with a single read-only query to capture the fixture. No `pulumi up`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TzUnnRheR1xinDRCS6s4fB


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a shared canonical vocabulary for receipt labels.
  * Supported recognized label aliases by automatically converting them to canonical labels.
  * Added clearer validation messages, including suggested aliases where applicable.
  * Label creation now presents the approved label options and rejects unsupported labels.

* **Bug Fixes**
  * Prevented invalid or malformed labels from being created or propagated during evaluation.
  * Preserved compatibility when reading and updating existing malformed labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->