### PR TITLE
fix(line-items): make the line-item recompute reach the rows it must fix

### DIFF
--- a/scripts/backfill_receipt_line_items.py
+++ b/scripts/backfill_receipt_line_items.py
@@ -1,17 +1,41 @@
-"""Backfill RECEIPT_LINE_ITEM rows from the geometric extractor.
+"""Backfill (and audit) RECEIPT_LINE_ITEM rows from the geometric extractor.
 
-For every receipt with a VALID ITEMS section, runs the extractor live
-(words + section line_ids from the current table state), builds
-ReceiptLineItem entities with provenance + trust signals, and persists
-them via the idempotent delete-then-put rewrite
+For every receipt the line-item writer would extract from, runs the
+extractor live (words + section line_ids from the current table state),
+builds ReceiptLineItem entities with provenance + trust signals, and
+persists them via the idempotent delete-then-put rewrite
 (delete_receipt_line_items_for_receipt + add_receipt_line_items).
 
 Re-running is safe: same input -> same items -> byte-identical rows.
 
+WHY THIS SCRIPT MATTERS: nothing recomputes line items when the DECODER
+changes. The stream stage (infra/receipt_line_item_updater) fires on a
+summary write, so a decoder fix leaves every untouched receipt carrying
+the verdict the old code produced -- indistinguishable from a fresh row,
+because ``extractor_version`` names the algorithm family and does not
+move with behaviour. This is the corpus recompute path, and ``--check``
+is the detector that says how many stored verdicts have gone stale.
+
+Target population: any receipt with a non-INVALID ITEMS section,
+preferring VALID when a receipt somehow has more than one -- exactly
+what ``line_item_processor.update_receipt_line_items`` picks. It used to
+demand ``validation_status == "VALID"``, which is *nearly the whole
+corpus in dev and almost nothing in prod*: measured 2026-08-05, prod
+carries 729 PENDING ITEMS sections and 1 VALID, so the recompute path
+could reach one prod receipt out of 730 (dev: 667 VALID, 17 PENDING,
+7 INVALID). A recompute that cannot reach the rows is not a recompute
+path.
+
 Usage:
-    python3.12 scripts/backfill_receipt_line_items.py [--dry-run only by
-        default; pass --apply to write] [--table ReceiptsTable-dc5be22]
-        [--receipt IMAGE_ID:RID]
+    # read-only drift report (works against prod)
+    python3.12 scripts/backfill_receipt_line_items.py --check \
+        --table ReceiptsTable-d7ff76a
+
+    # dry run / write, dev only
+    python3.12 scripts/backfill_receipt_line_items.py
+    python3.12 scripts/backfill_receipt_line_items.py --apply
+    python3.12 scripts/backfill_receipt_line_items.py \
+        --receipt IMAGE_ID:RID --apply
 """
 
 from __future__ import annotations
@@ -22,9 +46,9 @@ import re
 import sys
 from collections import Counter
 from datetime import datetime, timezone
+from typing import Any, Optional
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-sys.path.insert(0, "/Users/tnorlund/Portfolio/receipt_dynamo")
 
 import boto3  # noqa: E402
 from boto3.dynamodb.types import TypeDeserializer  # noqa: E402
@@ -34,32 +58,124 @@ from extract_line_items import (  # noqa: E402
     reconcile_detailed,
 )
 
+# isort: off
+# The repo has no root isort config, so whether receipt_dynamo and
+# receipt_upload land in one import block or two depends on which
+# package's pyproject the linter happens to resolve, and the two CI lint
+# jobs disagree. Fenced so neither can reorder them (same fence, same
+# reason, as scripts/backfill_decoder_word_labels.py).
 from receipt_dynamo.data.dynamo_client import DynamoClient  # noqa: E402
 from receipt_dynamo.entities.receipt_line_item import (  # noqa: E402
     ReceiptLineItem,
 )
+from receipt_upload.line_items.provenance import (  # noqa: E402
+    is_worker_extractor_version,
+)
+
+# isort: on
 
 DEV_TABLE = "ReceiptsTable-dc5be22"
 PROD_MARKER = "d7ff76a"
 EXTRACTOR_VERSION = "line-items-blocks-v2"
 
 
+def select_items_section(sections: list[dict]) -> Optional[dict]:
+    """The ITEMS section the line-item writer would extract from.
+
+    Mirrors ``line_item_processor.update_receipt_line_items``: any
+    non-INVALID canonical ITEMS section, preferring VALID over PENDING so
+    provenance reflects the strongest source. Legacy ITEMS_VALUE /
+    ITEMS_DESCRIPTION zones are partial (prices-only or names-only) and
+    are excluded by the exact ``ITEMS`` match.
+    """
+    picked: Optional[dict] = None
+    for section in sections:
+        if str(section.get("section_type") or "").upper() != "ITEMS":
+            continue
+        status = str(section.get("validation_status") or "").upper()
+        if status == "INVALID":
+            continue
+        if picked is None or status == "VALID":
+            picked = section
+        if status == "VALID":
+            break
+    return picked
+
+
+def _stored_line_items(client, table: str, image_id: str, receipt_id: int):
+    """The RECEIPT_LINE_ITEM rows currently stored for one receipt."""
+    des = TypeDeserializer()
+    rows: list[dict] = []
+    kwargs: dict[str, Any] = dict(
+        TableName=table,
+        KeyConditionExpression="PK = :pk AND begins_with(SK, :sk)",
+        ExpressionAttributeValues={
+            ":pk": {"S": f"IMAGE#{image_id}"},
+            ":sk": {"S": f"RECEIPT#{receipt_id:05d}#LINE_ITEM#"},
+        },
+    )
+    while True:
+        resp = client.query(**kwargs)
+        rows.extend(
+            {k: des.deserialize(v) for k, v in raw.items()}
+            for raw in resp["Items"]
+        )
+        if "LastEvaluatedKey" not in resp:
+            return rows
+        kwargs["ExclusiveStartKey"] = resp["LastEvaluatedKey"]
+
+
+def _stored_status(rows: list[dict]) -> Optional[str]:
+    """The reconciliation verdict the stored rows agree on.
+
+    Every row of a receipt is written in one pass with one verdict, so
+    disagreement means the rows were written by two different runs --
+    reported as-is rather than silently collapsed.
+    """
+    statuses = {r.get("reconciliation_status") for r in rows}
+    if not statuses:
+        return None
+    if len(statuses) > 1:
+        return "|".join(sorted(str(s) for s in statuses))
+    return statuses.pop()
+
+
 def main() -> None:
     ap = argparse.ArgumentParser()
     ap.add_argument("--table", default=DEV_TABLE)
     ap.add_argument("--apply", action="store_true")
+    ap.add_argument(
+        "--check",
+        action="store_true",
+        help=(
+            "read-only: report every receipt whose STORED "
+            "reconciliation_status disagrees with a live recompute "
+            "(decoder drift). Never writes, so prod is allowed."
+        ),
+    )
+    ap.add_argument(
+        "--replace-worker-rows",
+        action="store_true",
+        help=(
+            "also rewrite receipts whose stored rows were decoded on "
+            "device by the Mac worker. Off by default: the stream stage "
+            "preserves a worker decode when it reconciles better "
+            "(_reconcile_with_worker_rows), and this script's blind "
+            "delete-then-put would discard it."
+        ),
+    )
     ap.add_argument("--receipt", help="IMAGE_ID:RID single-receipt mode")
     args = ap.parse_args()
 
-    if PROD_MARKER in args.table:
+    if PROD_MARKER in args.table and args.apply:
         sys.exit("REFUSED: this script never writes to the prod table.")
 
     client = boto3.client("dynamodb", region_name="us-east-1")
-    dynamo = DynamoClient(args.table)
+    dynamo = DynamoClient(args.table) if args.apply else None
     des = TypeDeserializer()
 
-    # Every receipt with a VALID ITEMS section (extraction population)
-    targets: dict[tuple[str, int], dict] = {}
+    # Every receipt the writer would extract from (extraction population).
+    candidates: dict[tuple[str, int], list[dict]] = {}
     kwargs = dict(
         TableName=args.table,
         IndexName="GSITYPE",
@@ -71,17 +187,23 @@ def main() -> None:
         resp = client.query(**kwargs)
         for raw in resp["Items"]:
             item = {k: des.deserialize(v) for k, v in raw.items()}
-            if (
-                item.get("section_type") == "ITEMS"
-                and item.get("validation_status") == "VALID"
-            ):
-                m = re.match(r"IMAGE#(.+)", item["PK"])
-                m2 = re.match(r"RECEIPT#(\d+)#", item["SK"])
-                if m and m2:
-                    targets[(m.group(1), int(m2.group(1)))] = item
+            if str(item.get("section_type") or "").upper() != "ITEMS":
+                continue
+            m = re.match(r"IMAGE#(.+)", item["PK"])
+            m2 = re.match(r"RECEIPT#(\d+)#", item["SK"])
+            if m and m2:
+                candidates.setdefault(
+                    (m.group(1), int(m2.group(1))), []
+                ).append(item)
         if "LastEvaluatedKey" not in resp:
             break
         kwargs["ExclusiveStartKey"] = resp["LastEvaluatedKey"]
+
+    targets: dict[tuple[str, int], dict] = {}
+    for key, sections in candidates.items():
+        section = select_items_section(sections)
+        if section is not None:
+            targets[key] = section
 
     keys = sorted(targets)
     if args.receipt:
@@ -89,9 +211,13 @@ def main() -> None:
         keys = [(img, int(rid))]
 
     stats: Counter = Counter()
+    flips: Counter = Counter()
     now = datetime.now(timezone.utc)
     for n, (img, rid) in enumerate(keys):
         sec = targets.get((img, rid))
+        if sec is None:
+            stats["no-items-section"] += 1
+            continue
         words, _, summary = fetch_receipt_records(client, args.table, img, rid)
         line_ids = {int(x) for x in (sec.get("line_ids") or [])}
         items, collapsed = extract_items(words, line_ids, summary=summary)
@@ -134,17 +260,60 @@ def main() -> None:
         stats["receipts"] += 1
         stats["items"] += len(entities)
         stats[f"recon-{status}"] += 1
-        if args.apply:
-            deleted = dynamo.delete_receipt_line_items_for_receipt(img, rid)
-            if entities:
-                dynamo.add_receipt_line_items(entities)
-            stats["deleted"] += deleted
-            stats["written"] += len(entities)
+
+        stored = (
+            _stored_line_items(client, args.table, img, rid)
+            if (args.check or args.apply)
+            else []
+        )
+        worker_decoded = any(
+            is_worker_extractor_version(r.get("extractor_version"))
+            for r in stored
+        )
+        if args.check:
+            if not stored:
+                stats["no-stored-rows"] += 1
+            else:
+                before = _stored_status(stored)
+                stats["stored-rows"] += 1
+                if before == status:
+                    stats["agree"] += 1
+                else:
+                    stats["drift"] += 1
+                    flips[(str(before), str(status))] += 1
+                    stored_sum = round(
+                        sum(
+                            float(r["price"])
+                            for r in stored
+                            if not r.get("is_discount")
+                        ),
+                        2,
+                    )
+                    print(
+                        f"DRIFT {img}:{rid} {before} -> {status}  "
+                        f"items {len(stored)} -> {len(entities)}  "
+                        f"sum {stored_sum} -> {recon_result.item_sum}  "
+                        f"baseline {recon_result.baseline}  "
+                        f"worker_decoded={int(worker_decoded)}"
+                    )
+        if args.apply and dynamo is not None:
+            if worker_decoded and not args.replace_worker_rows:
+                stats["skipped-worker-decoded"] += 1
+            else:
+                deleted = dynamo.delete_receipt_line_items_for_receipt(
+                    img, rid
+                )
+                if entities:
+                    dynamo.add_receipt_line_items(entities)
+                stats["deleted"] += deleted
+                stats["written"] += len(entities)
         if (n + 1) % 100 == 0:
             print(f"  {n + 1}/{len(keys)}", file=sys.stderr, flush=True)
 
-    mode = "APPLY" if args.apply else "dry-run"
+    mode = "APPLY" if args.apply else ("check" if args.check else "dry-run")
     print(f"[{mode}] {dict(stats)}")
+    if flips:
+        print(f"[{mode}] transitions {dict(flips)}")
 
 
 if __name__ == "__main__":

--- a/tests/test_backfill_line_items_targets.py
+++ b/tests/test_backfill_line_items_targets.py
@@ -1,0 +1,91 @@
+"""The line-item recompute path must target what the WRITER targets.
+
+``scripts/backfill_receipt_line_items.py`` is the only corpus-wide
+recompute for RECEIPT_LINE_ITEM rows: the stream stage
+(``infra/receipt_line_item_updater``) fires on a summary write, so a
+decoder change leaves every untouched receipt carrying the verdict the
+old code produced. The script used to select ``validation_status ==
+"VALID"`` while the writer accepts any non-INVALID ITEMS section --
+measured 2026-08-05 that was 1 reachable prod receipt out of 730 (729
+PENDING sections), and 17 unreachable receipts in dev. These tests pin
+the two selections to the same rule.
+"""
+
+from __future__ import annotations
+
+# isort: off
+# receipt_upload lands in a different import group depending on whether
+# the venv has it installed, so the grouping here is not reproducible
+# across environments. Pin it (same fence as
+# tests/test_extend_items_zone_gaps.py).
+from scripts.backfill_receipt_line_items import (
+    _stored_status,
+    select_items_section,
+)
+
+# isort: on
+
+
+def section(
+    status,
+    model_source="upload-determinism-v1",
+    section_type="ITEMS",
+):
+    return {
+        "section_type": section_type,
+        "validation_status": status,
+        "model_source": model_source,
+        "line_ids": [1, 2],
+    }
+
+
+def test_pending_items_section_is_a_target():
+    """The worker ships PENDING sections; prod is almost entirely PENDING."""
+    assert select_items_section([section("PENDING")]) is not None
+
+
+def test_valid_items_section_is_a_target():
+    assert select_items_section([section("VALID")]) is not None
+
+
+def test_invalid_items_section_is_refused():
+    assert select_items_section([section("INVALID")]) is None
+
+
+def test_valid_wins_over_pending():
+    picked = select_items_section([section("PENDING"), section("VALID")])
+    assert picked["validation_status"] == "VALID"
+    picked = select_items_section([section("VALID"), section("PENDING")])
+    assert picked["validation_status"] == "VALID"
+
+
+def test_partial_legacy_zones_are_not_items_sections():
+    """ITEMS_VALUE / ITEMS_DESCRIPTION are prices-only / names-only."""
+    assert (
+        select_items_section(
+            [
+                section("VALID", section_type="ITEMS_VALUE"),
+                section("VALID", section_type="ITEMS_DESCRIPTION"),
+            ]
+        )
+        is None
+    )
+
+
+def test_missing_validation_status_is_still_a_target():
+    """Absent status is not INVALID; the writer extracts from it."""
+    assert select_items_section([section(None)]) is not None
+
+
+def test_stored_status_reports_a_split_verdict():
+    assert _stored_status([]) is None
+    assert _stored_status([{"reconciliation_status": "match"}] * 3) == "match"
+    assert (
+        _stored_status(
+            [
+                {"reconciliation_status": "match"},
+                {"reconciliation_status": "near"},
+            ]
+        )
+        == "match|near"
+    )


### PR DESCRIPTION
## Which side was right

**Neither of the reported disagreements was real.** The 18-receipt table in the
brief does not reproduce. Measured at HEAD over the whole corpus with the exact
inputs `derive_labels` uses (`scripts/backfill_decoder_word_labels.py::_items_line_ids`
+ the raw `RECEIPT_SUMMARY` item), stored and live agree on **652 / 659** dev
receipts. Every one of the 10 named dev images agrees exactly:

| image | rid | stored | live | gate |
|---|---|---|---|---|
| 069e270a | 1 | mismatch | mismatch | not-matched |
| 32e93177 | 1 | **match** | **match** | **ok** |
| 32e93177 | 2 | near | near | not-matched |
| 383a90d8 | 1 | match | match | ok |
| 383a90d8 | 2 | no-baseline | no-baseline | not-matched |
| 426be8ef | 1 | near | near | not-matched |
| 47343fdf | 1 | match | match | ok |
| 47343fdf | 2 | mismatch | mismatch | not-matched |
| 687da832 | 1 | match | match | ok |
| 687da832 | 2 | mismatch | mismatch | not-matched |
| 6a4be38a | 1 | match | match | ok |
| 6a4be38a | 2 | near | near | not-matched |
| 6f2f1d08 | 1 | match | match | ok |
| 6f2f1d08 | 2 | near | near | not-matched |
| 9ee70dd3 | 1 | near | near | not-matched |
| b50ba18b | 1 | match | match | ok |
| b50ba18b | 2 | near | near | not-matched |

Two measurement bugs produced the phantom:

1. **`not-matched` is a gate verdict, not a reconciliation status.** `derive_labels`
   returns `GATE_OK` only when `recon.status == "match"`; `near`, `mismatch` and
   `no-baseline` all collapse into `GATE_NOT_MATCHED`. Comparing that string to a
   stored `near`/`mismatch` reports a disagreement where there is none — that alone
   accounts for 069e270a, 426be8ef and 9ee70dd3, whose stored statuses are
   `mismatch`/`near`/`near`.
2. **The gate was joined on `image_id`, dropping `receipt_id`.** Every remaining
   image in the list has a *second* receipt whose live gate genuinely is
   `not-matched`. The brief's "stored item status" column is receipt 1; the live
   gate it was compared against is receipt 2.

The `baseline_figures_agreeing = None` "hint" is a third artifact: **it is not a
field on `RECEIPT_SUMMARY`.** `ReceiptSummaryRecord.to_item` writes
`grand_total / subtotal / tax / tip / tender / bank_*` and nothing else. The field
lives on `RECEIPT_LINE_ITEM`, where 32e93177:1 carries `2`. Reading it off the
summary returns `None` for every receipt ever written, so its being `None` on all
18 says nothing about those 18.

The gate counts quoted downstream are therefore **correct as measured**: dev
`520 ok / 142 not-matched / 29 no-items` of 691 receipts with an ITEMS section.

## The real disagreement, and the root cause

7 dev / 18 prod receipts *do* have a stale stored status, and **the live side is
right in every case**. All of them are #1369 landing after the rows were written:

* **FIX 3, the `OFF` substring bug** — `DISCOUNT_WORDS` was substring-scanned, so
  `OFF` matched inside `COFFEE`, `TOFFEE`, `EASY OFF`, `Office Supply`. Discounts
  are excluded from the sum, so those receipts could not balance.
* **FIX 1, branded settlement rows** — `Visa`, `MASTERCARD`, `Local Cash`,
  `Payment (Cash):`, `Visa ...3931`, `xXXX5061 MASTERCARD` decoded as phantom items.

Dev's rows were bulk-written `2026-08-04T21:11Z`; #1369 merged `2026-08-05T02:24Z`.

**Nothing recomputes line items when the *decoder* changes.** The stream stage
(`infra/receipt_line_item_updater`) fires on a summary write, and `extractor_version`
names the algorithm family (`line-items-blocks-v2`) without moving when behaviour
moves — a pre-fix row is byte-indistinguishable from a fresh one. That leaves
`scripts/backfill_receipt_line_items.py` as the only corpus recompute, and it
selected `validation_status == "VALID"` while the writer accepts any non-INVALID
ITEMS section. Measured 2026-08-05:

| table | VALID | PENDING | INVALID |
|---|---|---|---|
| dev `dc5be22` | 667 | 17 | 7 |
| prod `d7ff76a` | **1** | **729** | 0 |

**The recompute path could reach one prod receipt out of 730.**

## Corpus-wide disagreement (both tables)

Run `scripts/backfill_receipt_line_items.py --check --table <table>`.

| table | receipts w/ ITEMS section | w/ stored rows | agree | **drift** |
|---|---|---|---|---|
| dev `ReceiptsTable-dc5be22` (before) | 684 | 659 | 652 | **7** |
| dev `ReceiptsTable-dc5be22` (after apply) | 684 | 659 | 659 | **0** |
| prod `ReceiptsTable-d7ff76a` (read-only) | 730 | 702 | 684 | **18** |

### Dev flips — applied, each justified

| receipt | flip | why |
|---|---|---|
| 205f9a41:1 | mismatch → **match** | `VT ICD COFFEE 7.15` was flagged a discount (OFF in COFFEE) so the sum was 0.00; now 7.15 = printed subtotal exactly, bank 7.75 = grand total |
| 249e7199:1 | mismatch → **match** | `003050188 EASY OFF 5.29` un-flagged; 5.29+3.99+3.69 = 12.97 = subtotal, grade 3 (subtotal+tax=grand) |
| 750e0675:2 | mismatch → **match** | `ORG BIRCHWOOD COFFEE 15.99` un-flagged; sum 32.01 = grand total (no printed subtotal), bank 32.01 |
| 887079fa:1 | mismatch → **match** | `TOFFEE ICE CREAM BAR 6.99` un-flagged; 6.99+10.99 = 17.98 = grand total, bank 17.98 |
| 955da9a2:2 | mismatch → **match** | `Drip Coffee 5.50` un-flagged; 31.00+0.00+5.50 = 36.50 = subtotal, grade 3 |
| b7f7ecfb:1 | mismatch → **match** | `ORG BIRCHWOOD COFFEE 18.99` un-flagged; sum 40.38 = grand total, bank 40.38 |
| 61c65be3:1 | match → **mismatch** | the one flip *away* from match, and it is a correction. `Coffee Sm 3.29` was flagged a discount, and a `zone-gap-extend-v1` extension had swallowed the printed Subtotal row (OCR `cublotal 3.29`). Excluding the real product and summing the *subtotal row* landed on 3.29 = subtotal — a match by coincidence. With the discount fix both rows count (6.58) and the extraction's genuine defect is now visible. Ground truth: one item at 3.29; the remaining bug is the extension pulling in a summary row, not the reconciliation. |

### Prod flips — reported only, no writes

12 mismatch→match, 3 mismatch→near, 1 near→match, 1 no-baseline→mismatch,
1 near→mismatch. Spot-checked individually; the improvements are all phantom
settlement rows disappearing (`Visa 13.01` off Omaha Bar leaving 12.00 = subtotal;
`Local Cash 10.44` off Trader Joe's leaving 29.44 = grand total; `Payment (Cash):
40.00` off RISE leaving 30.26 = subtotal; `Visa ...3931 22.52` off Moody leaving
21.00 = subtotal) or the OFF fix (`Office Supply 0.25` un-flagged, 0.80+0.25 = 1.05
= subtotal exactly).

The two non-improving flips are honest re-diagnoses, not regressions:

* `916d7955:1` no-baseline → mismatch. `MASTERCARD 32.30` removed, so the sum drops
  93.85 → 61.55 and no longer exceeds 3× the 29.25 baseline, which is what tripped
  the #1324 implausibility escape hatch. Still not a match either way. **Open defect
  surfaced:** `Paid with card (8644): 32.30` is still decoded as an item — a
  settlement row not in the closed vocabulary.
* `cee0fbe1:1` near → mismatch. Its *only* stored item was `xXXX5061 MASTERCARD
  42.14` — the card total, not an item. Removing it leaves 0 items, and
  `reconcile_detailed([], summary)` reports `mismatch` (item_sum 0 vs baseline
  39.29) rather than a zero-item verdict. `derive_labels` handles this correctly
  (`GATE_NO_ITEMS` precedes the status check); the mislabel is confined to the
  status string. Pre-existing, not touched here.

Two more open decoder defects, **flagged rather than fixed** so this diff stays out
of `geometry.py`/`labels.py` while `header-row-guard` owns them:

* `37f2d81f:1` (Yogurtland) counts `Weight: 21.5 oz 8 $0.67 per oz` as a 0.67 item.
* `916d7955:1` counts `Paid with card (8644): 32.30`.

## What changed

Only `scripts/` and `tests/` — **no overlap with `labels.py`, `geometry.py` or
`blocks.py`.**

* `select_items_section()` mirrors `line_item_processor.update_receipt_line_items`
  (non-INVALID, prefer VALID), pinned by tests so the two selections cannot drift
  apart again.
* `--check`: read-only per-receipt drift report, allowed against prod. The missing
  detector.
* `--apply` skips worker-decoded rows unless `--replace-worker-rows`. Widening to
  PENDING sections is exactly widening to worker-ingested receipts, and this
  script's delete-then-put would discard an on-device decode the stream stage
  preserves under `_reconcile_with_worker_rows`. 0 worker-decoded receipts in
  either table today; the guard is for when Phase 2 rows persist.
* Drops the hardcoded `/Users/tnorlund/Portfolio/receipt_dynamo` sys.path.

## Gates

* **Golden floors**: unchanged and not touched — this diff contains no decoder
  change. `receipt_upload/tests/test_line_item_golden_regression.py` passes.
* `receipt_upload`: **812 passed, 13 skipped**.
* root `tests/`: **720 passed, 1 skipped** (7 new).
* Lint replicated as CI runs it — bare `python3.12` venv, `black --check
  --line-length=79` and `isort --check-only --profile=black --line-length=79`
  invoked **separately** per changed file. Both clean. Imports fenced
  `# isort: off/on` in both files for the same reason
  `scripts/backfill_decoder_word_labels.py` fences them: no root isort config, so
  the two CI lint jobs place `receipt_dynamo`/`receipt_upload` differently.

## Caveats

* Prod's 18 stale receipts are **not** fixed here. `--apply` still refuses the prod
  table; recomputing them needs a deliberate, separately-reviewed run.
* CI deploys **prod only**. The dev line-item Lambda still runs pre-#1369 code, so a
  dev summary write can re-stale the 7 receipts this recompute just fixed until
  someone runs `pulumi up --stack dev`.
* The deeper fix — making `extractor_version` move when decoder *behaviour* moves,
  so staleness is detectable from the row itself rather than by recomputing the
  whole corpus — is not attempted here: the stamp is shared with the Swift port
  (`provenance.SWIFT_WORKER_DECODER_VERSION`) and changing it is a cross-language
  change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TzUnnRheR1xinDRCS6s4fB


---

## Update: two of the 18 prod rows re-measured against #1382

The two open decoder defects flagged above are fixed in #1382 (`fix/settlement-anchor-and-weight-rows`, open). I re-ran `--check` with that branch merged locally into this one, read-only against both tables, rather than take the numbers on trust:

| prod row | at `origin/main` | with #1382 |
|---|---|---|
| `37f2d81f:1` | mismatch → near (2 items, 15.07 vs 14.40) | mismatch → **match** (1 item, **14.40 = subtotal exactly**) |
| `916d7955:1` | no-baseline → mismatch (3 items, 61.55 vs 29.25) | no-baseline → **match** (2 items, **23.75 + 5.50 = 29.25 = subtotal exactly**) |

Prod `recon-match` **505 → 507**, independently reproducing #1382's own claim. Transitions become 13 mismatch→match, 2 mismatch→near, 1 no-baseline→match, 1 near→match, 1 near→mismatch.

**The drift count itself is unchanged at 18.** That is the point worth being precise about: those receipts' stored rows were stale before #1382 and are stale after it — #1382 improves where a recompute *lands*, not whether one is needed. Which is exactly the gap this PR closes: prod has 18 receipts carrying a verdict no code in the tree would produce, and until the target population is fixed the recompute path can reach one of the 730.

Dev is unaffected by #1382: drift stays **0**, `recon-match` stays **520**. The 7 rows recomputed here remain correct under it.

`cee0fbe1:1`'s `near → mismatch` also stands under #1382 — the zero-item status string is cosmetic and deliberately left alone by both PRs (`derive_labels` gates on `GATE_NO_ITEMS` first).
