### PR TITLE
fix(line-items): two non-product rows the decoder still counts as items

### DIFF
--- a/receipt_upload/receipt_upload/line_items/blocks.py
+++ b/receipt_upload/receipt_upload/line_items/blocks.py
@@ -625,6 +625,7 @@ def decode_band_blocks(
         SALE_PRICE_RE,
         WAS_PRICE_RE,
         is_settlement_row,
+        is_unit_rate_row,
         parse_band,
     )
 
@@ -637,12 +638,21 @@ def decode_band_blocks(
         # when a broken ITEMS section includes them and regardless of any
         # template prior. Strip amounts before the settlement test so
         # "CHANGE 0.00" reduces to its vocabulary.
+        #
+        # is_unit_rate_row is applied HERE and not in geometry's
+        # _is_non_product_row, which shares the other four guards. That
+        # function answers "where does the ITEMS zone end?" for boundary
+        # extension, and a weight annotation sits BETWEEN two products --
+        # treating it as a terminator would stop a scan mid-zone. This
+        # guard answers a different question: is this band's amount a
+        # price? Same row, different verdicts, deliberately.
         bare = re.sub(r"\$?\d[\d.,]*", " ", b["text"]).strip()
         if (
             is_settlement_row(bare)
             or WAS_PRICE_RE.search(b["text"])
             or SALE_PRICE_RE.search(b["text"])
             or NON_PRODUCT_NOTE_RE.search(b["text"])
+            or is_unit_rate_row(b["text"], len(b["amounts"]))
         ):
             b["role"] = "OUTSIDE"
             continue

--- a/receipt_upload/receipt_upload/line_items/geometry.py
+++ b/receipt_upload/receipt_upload/line_items/geometry.py
@@ -96,6 +96,14 @@ TENDER_ANCHOR_TOKENS = frozenset(
         "debit",
         "tender",
         "tendered",
+        # "Paid with card (8644): 32.30" (Stanley of New Orleans, prod
+        # 916d7955) states the settlement without naming a network or a
+        # tender: every word is payment vocabulary but NONE was an anchor,
+        # so the row decoded as a 32.30 item and put the receipt at
+        # mismatch (61.55 vs a printed 29.25 its two real items hit
+        # exactly). Promoted from affix, which is the maintenance path
+        # test_branded_tender_rows documents for exactly this case.
+        "paid",
     }
 )
 # Words that may surround an anchor: card-entry modes, transaction-id
@@ -132,7 +140,7 @@ PAYMENT_AFFIX_TOKENS = frozenset(
         "no",
         "num",
         "number",
-        "paid",
+        # "paid" is an ANCHOR, not an affix -- see TENDER_ANCHOR_TOKENS.
         "pay",
         "payment",
         "payments",
@@ -156,6 +164,7 @@ PAYMENT_AFFIX_TOKENS = frozenset(
         "us",
         "usd",
         "verified",
+        "with",  # "Paid with card (8644)"
     }
 )
 # A run of masking characters left behind once digits are stripped
@@ -308,6 +317,34 @@ SALE_PRICE_RE = re.compile(
     r"\b(?:(?:SALE|REG(?:ULAR)?\.?)\s+PRICE|COMPARABLE\s+VALUE)\b",
     re.IGNORECASE,
 )
+# An amount qualified "per <unit>" is a RATE, not an extended price. The
+# decoder already knows this shape in its punctuated forms -- QTY_AT_RE
+# reads "1.23 lb @ 4.99/lb" and the 3-decimal rule keeps fuel's
+# "$5.299/Gal" out of `amounts` -- but the spelled-out "per oz" had no
+# reader, so Yogurtland's weight line ("Weight: 21.5 oz 8 $0.67 per oz",
+# the "8" being OCR of "@") decoded as a $0.67 item and put the receipt at
+# `near` (15.07 against a printed 14.40 its one real item hits exactly).
+#
+# Whole-token "PER" only: a substring scan matches inside PEPPER, and the
+# corpus sells "PEPPER BELL GREEN EACH".
+PER_UNIT_RATE_RE = re.compile(
+    r"\bPER\s+(?:OZ|LB|LBS|KG|G|GAL|EA|EACH|CT|PK|ITEM|UNIT)\b",
+    re.IGNORECASE,
+)
+
+
+def is_unit_rate_row(text: str, n_amounts: int) -> bool:
+    """Whether a row states a per-unit rate and NO extended total.
+
+    The amount count is the load-bearing half. A deli row really does
+    print both -- "GROUND BEEF $4.99 per lb   7.48" -- and there the 7.48
+    is a genuine line total that must survive. Only a row whose single
+    amount IS the rate is an annotation, which is what makes this safe
+    without a merchant list.
+    """
+    return n_amounts <= 1 and bool(PER_UNIT_RATE_RE.search(text or ""))
+
+
 # Non-product annotations that carry an amount but are never items:
 # tip-suggestion footers ("22% Tip = 4.40", "15% = 10.73", "18%: (Tip
 # Total 9.27)") and transaction-count notes ("Items in Transaction: 5").
@@ -1549,6 +1586,7 @@ __all__ = [
     "LEAD_QTY_RE",
     "NOISY_MONEY_RE",
     "NON_ITEM_SECTIONS",
+    "PER_UNIT_RATE_RE",
     "PRICE_RE",
     "PROVEN_CENT_TOLERANCE",
     "QTY_AT_RE",
@@ -1569,6 +1607,7 @@ __all__ = [
     "is_column_header_row",
     "is_proven",
     "is_settlement_row",
+    "is_unit_rate_row",
     "items_boundary_extension_guard",
     "parse_band",
     "propose_items_boundary_extension",

--- a/receipt_upload/tests/test_branded_tender_rows.py
+++ b/receipt_upload/tests/test_branded_tender_rows.py
@@ -31,6 +31,14 @@ PROD_TENDER_PHANTOMS = [
     "Payment (Cash):",  # Green NV Henderson, RISE Recreational
     "Visa Debit",  # TRADER JOE'S IMG_3404 (the new golden receipt)
     "MASTERCARD ...8644 for 32.30",  # Stanley of New Orleans
+    # 2026-08-05: the anchorless form. Every word here is payment
+    # vocabulary, but "paid"/"with"/"card" were all AFFIXES, and affixes
+    # alone are (correctly) never enough -- so this row decoded as a
+    # 32.30 item and left Stanley of New Orleans (prod 916d7955) at
+    # mismatch, 61.55 against the 29.25 its two real dishes sum to
+    # exactly. Fixed by promoting "paid" to an anchor, which is the
+    # maintenance path the note below prescribes.
+    "Paid with card (8644): 32.30",  # Stanley of New Orleans
 ]
 
 # Real items that carry payment vocabulary and MUST survive.
@@ -39,6 +47,11 @@ REAL_PRODUCTS = [
     "E 33965 PORK TENDER",  # Costco c1672313 (with the dept prefix)
     "CHICKEN TENDER",  # Millennium Maxwell House fa48c537
     "TENDER GREENS SALAD",
+    # Promoting "paid" to an anchor must not reach food. A real row needs
+    # only ONE word outside the vocabulary to survive, and these have it.
+    "PAID LEAVE GIFT BOX",
+    "PREPAID PHONE CARD",  # substring "paid" inside "PREPAID"
+    "CHICKEN WITH RICE",  # "with" is an affix, never an anchor
     "GIFT CARD",
     "VISA GIFT CARD",
     "LOCAL HONEY",

--- a/receipt_upload/tests/test_unit_rate_rows.py
+++ b/receipt_upload/tests/test_unit_rate_rows.py
@@ -1,0 +1,120 @@
+"""A per-unit RATE row is never a line item.
+
+The decoder already knows that an amount qualified by a unit is a rate
+rather than an extended price -- ``QTY_AT_RE`` reads "1.23 lb @ 4.99/lb"
+and the three-decimal rule keeps fuel's "$5.299/Gal" out of a band's
+amounts entirely. The spelled-out form had no reader, so Yogurtland's
+weight line reached the decode as a $0.67 item:
+
+    Weight: 21.5 oz 8 $0.67 per oz      <- the "8" is OCR of "@"
+
+That put prod 37f2d81f at ``near`` (15.07) against a printed 14.40 that
+its one real item, "1 MED 14.40", hits exactly.
+
+The amount count is the load-bearing half of the guard. A deli row prints
+BOTH the rate and the total ("GROUND BEEF $4.99 per lb   7.48"), and there
+the 7.48 is a real line total. Only a row whose single amount IS the rate
+is an annotation -- which is what lets this ship without a merchant list.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from receipt_upload.line_items.geometry import (
+    PER_UNIT_RATE_RE,
+    is_unit_rate_row,
+)
+
+# The motivating row, plus the unit spellings receipts actually print.
+RATE_ROWS = [
+    ("Weight: 21.5 oz 8 $0.67 per oz", 1),
+    ("$0.67 per oz", 1),
+    ("2.99 per lb", 1),
+    ("1.49 PER EACH", 1),
+    ("$3.20 per kg", 1),
+    ("4.99 Per Gal", 1),
+]
+
+# Rows that must stay items even though they carry "per <unit>", because
+# they also carry an extended total.
+RATE_PLUS_TOTAL_ROWS = [
+    ("GROUND BEEF $4.99 per lb 7.48", 2),
+    ("BANANAS 0.59 per lb 1.77", 2),
+]
+
+# "PER" inside a longer word. The corpus sells "PEPPER BELL GREEN EACH",
+# and a substring scan would eat it -- the same failure shape as "OFF"
+# inside COFFEE.
+SUBSTRING_TRAPS = [
+    "PEPPER BELL GREEN EACH",
+    "PEPPERONI PIZZA",
+    "PAPER TOWELS PER PACK",  # "per pack" is not a unit spelling here
+    "SUPERIOR OZ BOTTLE",
+    "OPERA CAKE EACH",
+]
+
+
+@pytest.mark.parametrize("text,n_amounts", RATE_ROWS)
+def test_rate_rows_are_recognized(text: str, n_amounts: int) -> None:
+    assert is_unit_rate_row(text, n_amounts), text
+
+
+@pytest.mark.parametrize("text,n_amounts", RATE_PLUS_TOTAL_ROWS)
+def test_a_rate_printed_beside_a_total_stays_an_item(
+    text: str, n_amounts: int
+) -> None:
+    assert not is_unit_rate_row(text, n_amounts), text
+
+
+@pytest.mark.parametrize("text", SUBSTRING_TRAPS)
+def test_per_inside_a_longer_word_does_not_match(text: str) -> None:
+    assert not PER_UNIT_RATE_RE.search(text), text
+    assert not is_unit_rate_row(text, 1), text
+
+
+def test_a_row_with_no_amount_is_not_a_rate_row() -> None:
+    """Zero amounts is still <= 1, so the text anchor must do real work."""
+    assert not is_unit_rate_row("ORGANIC BANANAS", 0)
+    assert not is_unit_rate_row("", 0)
+
+
+def test_the_yogurtland_receipt_decodes_to_its_printed_total() -> None:
+    """End to end on the row geometry that motivated the guard.
+
+    Two bands: the real item and the weight annotation below it. Before
+    the guard the decode summed 15.07 against a printed 14.40; after, the
+    annotation is OUTSIDE and the single real item reconciles exactly.
+    """
+    from receipt_upload.line_items.geometry import (
+        extract_items,
+        reconcile_detailed,
+    )
+
+    def w(line_id, word_id, text, x, y):
+        return {
+            "line_id": line_id,
+            "word_id": word_id,
+            "text": text,
+            "x": x,
+            "y_mid": y,
+            "h": 0.02,
+        }
+
+    words = [
+        w(17, 1, "1", 0.10, 0.50),
+        w(17, 2, "MED", 0.20, 0.50),
+        w(19, 1, "14.40", 0.80, 0.50),
+        w(20, 1, "Weight:", 0.10, 0.44),
+        w(20, 2, "21.5", 0.25, 0.44),
+        w(20, 3, "oz", 0.33, 0.44),
+        w(20, 4, "8", 0.40, 0.44),
+        w(20, 5, "$0.67", 0.48, 0.44),
+        w(20, 6, "per", 0.58, 0.44),
+        w(20, 7, "oz", 0.64, 0.44),
+    ]
+    items, _ = extract_items(words, {17, 19, 20})
+    recon = reconcile_detailed(items, {"subtotal": 14.40})
+
+    assert [i["price"] for i in items] == [14.40]
+    assert recon.status == "match"


### PR DESCRIPTION
Follow-up to #1378, from the two rows [@recon-consistency](https://github.com/tnorlund/Portfolio/pull/1381) surfaced. Both verified independently against the dev + prod corpora here before touching anything.

These are the **inverse** risk profile from #1378. There, the junk items were load-bearing — 20 of 22 receipts balanced *with* them, so dropping any would have flipped a `match`. Here both receipts are already **failing** to reconcile, and their real items hit the printed baseline exactly. Removing the phantom is a strict improvement under the same invariant.

## 1. Anchorless settlement row

`Paid with card (8644): 32.30` — Stanley of New Orleans, prod `916d7955`

#1369's closed vocabulary carries `paid`, `card` and `for` as **affixes**, but the row names no card network and no tender word, so it has **no anchor** — and affixes alone are (correctly) never enough. The row decoded as a `32.30` item:

```
1 Crab Cakes Benedict          23.75
1 Creole Breakfast Potatoes     5.50
Paid with card (8644):         32.30   <- phantom
                        sum =   61.55   vs printed subtotal 29.25  -> mismatch
```

`23.75 + 5.50 = 29.25` exactly. Note the *next* row, `MASTERCARD ...8644 for 32.30`, **is** already caught — same settlement, but it happens to name a network.

Fix: promote `paid` from affix to anchor, add `with` as an affix. This is precisely the maintenance path `test_branded_tender_rows.py` already prescribes:

> *"If one ever shows up in a live items zone, add … to `PAYMENT_AFFIX_TOKENS` and move the string into `PROD_TENDER_PHANTOMS` — this test failing is the signal to re-measure, not to delete it."*

## 2. Per-unit rate row

`Weight: 21.5 oz 8 $0.67 per oz` — Yogurtland Henderson, prod `37f2d81f` (the `8` is OCR of `@`)

The decoder **already knows** a unit-qualified amount is a rate, not an extended price — `QTY_AT_RE` reads `1.23 lb @ 4.99/lb`, and the three-decimal rule keeps fuel's `$5.299/Gal` out of a band's amounts entirely. The spelled-out `per oz` simply had no reader:

```
1 MED                          14.40
Weight: 21.5 oz 8 $0.67 per oz  0.67   <- phantom (21.5 oz x $0.67 = the 14.40)
                        sum =  15.07   vs printed subtotal 14.40  -> near
```

**The amount count is the load-bearing half of this guard.** A deli row prints *both* the rate and the total — `GROUND BEEF $4.99 per lb   7.48` — and there the `7.48` is a genuine line total. Only a row whose **single** amount *is* the rate is an annotation. That is what lets this ship without a merchant list, and it's pinned as a test.

`is_unit_rate_row` is applied in `decode_band_blocks` and **deliberately not** in `geometry._is_non_product_row`, which shares the other four guards. That function answers *"where does the ITEMS zone end?"* for boundary extension — and a weight annotation sits **between** two products, so treating it as a terminator would stop a scan mid-zone. Same row, different questions, different verdicts.

## Evidence before writing either vocabulary

Scanned every ITEMS-zone band across **all 1,421 receipts** (dev 691 + prod 730):

| family | instances |
|---|---|
| `PAID` rows not recognized as settlement | **1** (the one above) |
| `per <unit>` rows | **1** (the one above) |

Zero collateral surface — but also **n=1 evidence**, which is recorded in both test files so a future reader knows exactly what the provenance was rather than inheriting a tuned constant.

Whole-token matching throughout: a substring scan for `PER` matches inside `PEPPER`, and the corpus sells `PEPPER BELL GREEN EACH`. Same shape as the `OFF`-inside-`COFFEE` bug. Pinned in `SUBSTRING_TRAPS`, alongside `PREPAID PHONE CARD` for the `paid` promotion.

## Gates

**1. Golden floors** — pass, unchanged, none lowered. Both Swift parity fixtures (`line_items_parity` **and** `receipt_structure_parity_expected.json`) are byte-unchanged, so **no Swift port is needed** — no golden receipt carries either row shape. Full `receipt_upload` suite green.

**2. Per-receipt flip check**, dev + prod:

```
dev    LEFT match: 0    ENTERED: 0    item-count changes: 0
prod   LEFT match: 0    ENTERED: 2    item-count changes: 2
         37f2d81f:1   near     -> match   (2 -> 1 items)
         916d7955:1   mismatch -> match   (3 -> 2 items)
```

Exactly the two target receipts move, both **into** `match`. Nothing else in either corpus changes.

## Label impact

Prod gate `ok` **505 → 507**. Mint totals unchanged (1,005) because both receipts' words already carry labels — the gain is **32 additional collision-validation datapoints** and two receipts now eligible for derivation at all. Dev is entirely unchanged (both images decode differently there).

## Notes

- Read-only against prod throughout; no writes to any table; no `pulumi up`.
- Both CI isort personalities replicated in separate bare python3.12 venvs and run separately. Clean.
- Also confirming @recon-consistency's third observation: `reconcile_detailed([], summary)` returns `"mismatch"` (item_sum 0.0 vs baseline), not a zero-item verdict — reproduced on prod `cee0fbe1:1`. `derive_labels` handles it correctly (`GATE_NO_ITEMS` precedes the status check), so it is a cosmetic status string only. Left alone here rather than bundled into a decoder PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TzUnnRheR1xinDRCS6s4fB
