### PR TITLE
docs(line-items): point the closed-vocabulary tests at their re-measurement

### DIFF
--- a/receipt_upload/tests/test_branded_tender_rows.py
+++ b/receipt_upload/tests/test_branded_tender_rows.py
@@ -7,6 +7,19 @@ scan of prod found 12 receipts carrying one; Trader Joe's Henderson
 
 The guard must not reach real food: dev stores two genuine products whose
 names contain a tender word, and they are pinned here as keeps.
+
+The vocabulary is CLOSED and every entry below is a measured observation,
+not a guess -- so it goes stale silently unless someone re-measures. The
+corpus drift check is that re-measurement::
+
+    python3.12 scripts/backfill_receipt_line_items.py --check \\
+        --table ReceiptsTable-d7ff76a
+
+It is read-only (prod-safe) and prints every receipt whose STORED
+reconciliation_status disagrees with a live recompute, with sums and
+baselines. That is how "Paid with card (8644): 32.30" surfaced -- as a
+drift row on 916d7955, not by anyone reading receipts. A new branded form
+appears there the same way; PROD_TENDER_PHANTOMS is where to add it.
 """
 
 from __future__ import annotations

--- a/receipt_upload/tests/test_unit_rate_rows.py
+++ b/receipt_upload/tests/test_unit_rate_rows.py
@@ -15,6 +15,20 @@ The amount count is the load-bearing half of the guard. A deli row prints
 BOTH the rate and the total ("GROUND BEEF $4.99 per lb   7.48"), and there
 the 7.48 is a real line total. Only a row whose single amount IS the rate
 is an annotation -- which is what lets this ship without a merchant list.
+
+PROVENANCE, so this does not read as a tuned constant: a scan of all
+1,421 receipts across dev + prod (2026-08-05) found exactly ONE instance
+of this row family -- prod 37f2d81f. The unit spellings below beyond that
+row, and the deli-row gate, are extrapolation from n=1. Re-measure with
+the corpus drift check rather than by eye::
+
+    python3.12 scripts/backfill_receipt_line_items.py --check \\
+        --table ReceiptsTable-d7ff76a
+
+It is read-only (prod-safe) and prints every receipt whose STORED
+reconciliation_status disagrees with a live recompute, with sums and
+baselines. A second instance of this family shows up there as a drift
+row before anyone goes looking; RATE_ROWS is where to add it.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Follow-up to #1381 / #1382, at `header-row-guard`'s suggestion. **Comments only — no test, guard or vocabulary changes.**

## Why

#1382's two guards are *measured observations*, not derived rules:

* the branded-tender vocabulary is deliberately **CLOSED** — every entry is a string someone found in the corpus;
* the unit-rate row family was found **exactly once** across all 1,421 dev + prod receipts.

Both therefore go stale silently. The failure mode is not a red test — it is a guard that quietly stops covering the corpus while every test still passes. `test_branded_tender_rows.py` already says as much ("this test failing is the signal to re-measure, not to delete it") but never said *how* to re-measure.

#1381 shipped the tool that does it and could not reference it: at the time it was the unmerged side of the pair, and a pointer to an unmerged tool is a dangling reference in `main`. Both are merged now, so the pointer is valid.

## What

Each module docstring now carries the exact read-only command:

```
python3.12 scripts/backfill_receipt_line_items.py --check \
    --table ReceiptsTable-d7ff76a
```

and names the list to extend when it turns something up (`PROD_TENDER_PHANTOMS` / `RATE_ROWS`). `test_unit_rate_rows.py` additionally records the **n=1 provenance** explicitly, so the deli-row gate and the extra unit spellings read as extrapolation from one observed row rather than as tuned constants.

This is not hypothetical — it is how the anchorless `Paid with card (8644): 32.30` was found in the first place: it surfaced as a drift row on prod `916d7955`, not by anyone reading receipts.

## Verification at current main

Re-ran the check on both tables with #1381 and #1382 both merged:

| table | receipts | stored rows | agree | drift | `recon-match` |
|---|---|---|---|---|---|
| prod `d7ff76a` | 730 | 702 | 684 | **18** | **507** |
| dev `dc5be22` | 684 | 659 | 659 | **0** | 520 |

Prod `recon-match` 505 → **507** reproduces #1382's claim independently (`37f2d81f:1` → 14.40 = subtotal exactly; `916d7955:1` → 23.75 + 5.50 = 29.25 exactly).

**Prod drift is unchanged at 18**, which is the point the docstrings now make findable: #1382 improved where a recompute *lands*; it did not remove the need for one. Prod still carries 18 receipts whose stored verdict no code in the tree would produce.

## Gates

* `receipt_upload/tests/test_unit_rate_rows.py` + `test_branded_tender_rows.py` + `test_line_item_golden_regression.py`: **47 passed**. Golden floors untouched.
* Lint run as CI runs it, both personalities **separately**: `black --check --line-length=79` and `isort --check-only --profile=black --line-length=79` per changed file (receipt_agent job), and over the whole `receipt_upload` package (receipt_upload job, 134 files). Both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TzUnnRheR1xinDRCS6s4fB


---

## Update: the n=1 claim re-derived, and the harness blind spots documented

`header-row-guard` re-scanned the corpus for the unit-rate family; I re-derived it independently rather than take the number, scanning every ITEMS-zone band (`blocks._zone_bands`, the decoder's own unit) across both tables for whole-word `PER` — deliberately **wider** than the guard's regex, so a rate spelled with a unit the guard doesn't know would still surface:

```
dev  ReceiptsTable-dc5be22  (691 receipts):  bands with whole-word PER: 0
prod ReceiptsTable-d7ff76a  (730 receipts):  bands with whole-word PER: 1
    37f2d81f:1  amounts=1  matches_guard_regex=1  'Weight: 21.5 oz 8 $0.67 per oz'
rate AND >=2 amounts (the deli shape), either table:  0
```

Two independent measurements, same result. The second line is the one that matters and it is now in the test file verbatim: **no receipt in either corpus exercises the amount gate at all.** Every test distinguishing the gate from a bare `per <unit>` text match is synthetic.

So the docstring now says the gate is **unfalsified, not validated** — and, per `header-row-guard`'s point, says to keep it *because* it is untested here: it costs nothing on the single observed row and fails safe on a shape that certainly exists in the wild, where a bare text match would be equally green today and silently wrong the first time a deli receipt lands. "We found no counterexample" is recorded as what it is, which is not evidence for the gate. That is the #1313 parity failure mode — a check that measured nothing, reading as a passing check.

### Also added: what `--check` cannot see

Two harnesses now measure this corpus and **neither is a superset**, so the script docstring says so:

* `--check` compares STORED against LIVE, so it is blind to receipts with no stored rows — 28 prod / 25 dev have an ITEMS section and zero `RECEIPT_LINE_ITEM` rows, surfacing only as a `no-stored-rows` count, never as drift.
* A live-only sweep sees those, and is blind to the stored column: prod `916d7955` stores `no-baseline`, which records that its rows were written before the receipt had a usable printed baseline. No amount of recomputing recovers that.

Neither one's silence is coverage. Worth having written down where the next person is standing rather than rediscovered.

### Gates (re-run after the amendment)

* `test_unit_rate_rows.py` + `test_branded_tender_rows.py` + `test_line_item_golden_regression.py`: **47 passed**. `tests/test_backfill_line_items_targets.py`: **7 passed**.
* Both lint personalities, run separately: per-file `black`/`isort` over all three changed files, and whole-package over `receipt_upload` (134 files). Clean.

Still comments only — no test, guard, vocabulary or logic changes.
