### PR TITLE
docs(line-items): record the unit-rate gate as unfalsified, and what --check cannot see

### DIFF
--- a/receipt_upload/tests/test_unit_rate_rows.py
+++ b/receipt_upload/tests/test_unit_rate_rows.py
@@ -16,11 +16,29 @@ BOTH the rate and the total ("GROUND BEEF $4.99 per lb   7.48"), and there
 the 7.48 is a real line total. Only a row whose single amount IS the rate
 is an annotation -- which is what lets this ship without a merchant list.
 
-PROVENANCE, so this does not read as a tuned constant: a scan of all
-1,421 receipts across dev + prod (2026-08-05) found exactly ONE instance
-of this row family -- prod 37f2d81f. The unit spellings below beyond that
-row, and the deli-row gate, are extrapolation from n=1. Re-measure with
-the corpus drift check rather than by eye::
+PROVENANCE, so this does not read as a tuned constant. Scanning every
+ITEMS-zone band across all 1,421 receipts in dev + prod for whole-word
+"PER" (2026-08-05, measured twice independently)::
+
+    bands containing whole-word PER:      1   <- prod 37f2d81f, 1 amount
+    bands with a rate AND >=2 amounts:    0   <- the deli shape
+
+Read that second line carefully before trusting this file: **no receipt
+in either corpus exercises the amount gate at all.** Every test below
+that distinguishes the gate from a bare "per <unit>" text match is
+synthetic. The gate is UNFALSIFIED here, not validated, and "we found no
+counterexample" is not evidence for it -- that is precisely the shape of
+the #1313 parity snapshot, a check that measured nothing and read as a
+passing check.
+
+Keep it anyway, and keep it specifically BECAUSE it is untested here: it
+costs nothing on the one observed row (which has a single amount either
+way) and fails safe on a shape that certainly exists in the wild. A bare
+text match would be equally green today and silently wrong the first
+time a deli receipt lands. The unit spellings beyond the observed row
+are extrapolation on the same terms.
+
+Re-measure with the corpus drift check rather than by eye::
 
     python3.12 scripts/backfill_receipt_line_items.py --check \\
         --table ReceiptsTable-d7ff76a

--- a/scripts/backfill_receipt_line_items.py
+++ b/scripts/backfill_receipt_line_items.py
@@ -26,6 +26,17 @@ could reach one prod receipt out of 730 (dev: 667 VALID, 17 PENDING,
 7 INVALID). A recompute that cannot reach the rows is not a recompute
 path.
 
+WHAT ``--check`` CANNOT SEE, because two harnesses now measure this
+corpus and neither is a superset of the other. This one compares STORED
+against LIVE, so it is blind to any receipt with no stored rows at all
+-- 28 in prod, 25 in dev (2026-08-05) have an ITEMS section and zero
+RECEIPT_LINE_ITEM rows, and they are reported only as a
+``no-stored-rows`` count, never as drift. A LIVE-ONLY sweep sees those
+and is in turn blind to the stored column: prod 916d7955 stores
+``no-baseline``, which says its rows were written before the receipt had
+a usable printed baseline, and no amount of recomputing can recover that
+fact. Use both, and do not read either one's silence as coverage.
+
 Usage:
     # read-only drift report (works against prod)
     python3.12 scripts/backfill_receipt_line_items.py --check \


### PR DESCRIPTION
Follow-up to #1383, which merged before this strengthening landed on its branch. **Comments only — no test, guard, vocabulary or logic changes.**

Two additions, both prompted by cross-checking with `header-row-guard`.

## 1. The unit-rate provenance note now reports what the scan actually showed

**Calibration first, so this PR is not over-weighted:** what merged in #1383 is incomplete, not wrong. Main already says the family was found once in 1,421 receipts and explicitly names *"the unit spellings below beyond that row, and the deli-row gate"* as extrapolation from n=1 — an honest provenance note. If this PR never merges the tree still carries one; it just lacks the sharper framing below. Refinement, not a correction of something misleading. (There is a real open item in this thread — see the bottom — and it isn't this.)

With that said, I re-derived the number independently — scanning every ITEMS-zone band (`blocks._zone_bands`, the decoder's own unit) across both tables for whole-word `PER`, deliberately **wider** than the guard's own regex so a rate spelled with an unknown unit would still surface:

```
dev  ReceiptsTable-dc5be22  (691 receipts):  bands with whole-word PER: 0
prod ReceiptsTable-d7ff76a  (730 receipts):  bands with whole-word PER: 1
    37f2d81f:1  amounts=1  matches_guard_regex=1  'Weight: 21.5 oz 8 $0.67 per oz'

rate AND >=2 amounts (the deli shape), either table:  0
```

Two independent measurements, same result. **The second line is the one that matters**: no receipt in either corpus exercises the amount gate at all. Every test that distinguishes the gate from a bare `per <unit>` text match is synthetic, so the gate is **unfalsified, not validated** — and "we found no counterexample" is recorded as what it is, which is not evidence for it. That is exactly the shape the #1313 parity snapshot died of: a check that measured nothing, reading as a passing check.

The docstring also now says to **keep the gate because it is untested here** (`header-row-guard`'s point, and the right one): it costs nothing on the single observed row and fails safe on a shape that certainly exists in the wild, where a bare text match would be equally green today and silently wrong the first time a deli receipt lands.

## 2. `--check` now documents what it cannot see

Two harnesses measure this corpus and **neither is a superset**:

* `--check` compares STORED against LIVE, so it is blind to receipts with no stored rows — 28 prod / 25 dev have an ITEMS section and zero `RECEIPT_LINE_ITEM` rows, surfacing only as a `no-stored-rows` count, never as drift.
* A live-only sweep sees exactly those, and is blind to the stored column: prod `916d7955` stores `no-baseline`, recording that its rows were written before the receipt had a usable printed baseline. No amount of recomputing recovers that fact.

Neither one's silence is coverage. Written down where the next person will be standing, rather than rediscovered.

## Gates

* `test_unit_rate_rows.py` + `test_branded_tender_rows.py` + `test_line_item_golden_regression.py`: **47 passed**. Golden floors untouched.
* root `tests/`: **743 passed, 1 skipped**.
* Both lint personalities run **separately**: per-file `black`/`isort` over the two changed files, and whole-package over `receipt_upload` (134 files). Clean.

## Still open, unchanged by this PR

Prod carries **18 receipts** whose stored `reconciliation_status` disagrees with a live recompute (`recon-match` 507, drift 18, re-measured at current main). `--apply` refuses the prod table by design; clearing them is a prod write needing its own explicit go-ahead and a reviewed run. `header-row-guard` has surfaced this to the user separately; neither of us is acting on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TzUnnRheR1xinDRCS6s4fB


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded documentation for unit-rate row detection, including corpus scan results, test coverage limitations, fail-safe behavior, and future validation guidance.
  * Clarified backfill verification behavior, including comparisons with live recomputation, handling of missing stored rows, and limitations around `no-baseline` metadata.
  * Documented the need to use both reconciliation checks for complete coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
