### PR TITLE
fix(tender): attribute card 8712 to Chase, make the ledger dispatch exhaustive, and measure matcher recall

### DIFF
--- a/scripts/backfill_tender_bank.py
+++ b/scripts/backfill_tender_bank.py
@@ -7,7 +7,7 @@ For every receipt in the target table this script:
    payment zone via the canonical ``receipt_upload.tender`` classifier.
 2. Assigns the card to a ledger using the per-card rules from the
    2026-07 tender report (Apple Card 7645/5061/1769; Chase debit
-   1454/3931/0663/5894/7123/3960; 8712/9297/6081 have no export and
+   1454/3931/0663/5894/7123/3960/8712; 9297/6081 have no export and
    7739 is a checking account on ATM slips, so both map to ``none``).
 3. Joins the two ledgers OFFLINE:
    - Chase: curated matches in ``email_receipts.db`` (read-only).
@@ -68,12 +68,33 @@ logger = logging.getLogger(__name__)
 # 148 Chase / ~2 Apple. 5061 is the same Apple Card as 7645 before its
 # 2024-10 renumbering.
 APPLE_CARDS = frozenset({"7645", "5061", "1769"})
-CHASE_CARDS = frozenset({"1454", "3931", "0663", "5894", "7123", "3960"})
-# 8712/9297 read as Visa debits but only ~10%/0% of their amounts
-# appear in Chase (chance level); 6081 is an Amex. No export is held.
-NO_LEDGER_CARDS = frozenset({"8712", "9297", "6081"})
+# 8712 is a card on Chase account 5981, which the held export only covers
+# from 2025-04-25. The earlier "~10% of 8712 amounts appear in Chase, i.e.
+# chance level" reading measured 8712 across its whole span -- most of which
+# predates 5981's window -- and against the wrong account. Scored inside
+# 5981's own window it hits 8 of 9 (89%), matching the confirmed Chase
+# debits (1454 88%, 3931 85%, 5894 89%) against a date-resampled control of
+# ~0.2 expected, with same-day same-merchant settlements (THE STAND-WESTLAKE,
+# IN-N-OUTWESTLAKEVILL, ANAWALT LUMBER, COSTCO WHSE #0117 x2, WILD FORK
+# FOODS, SPROUTS FARMERS MKT#).
+CHASE_CARDS = frozenset(
+    {"1454", "3931", "0663", "5894", "7123", "3960", "8712"}
+)
+# 9297's identity is still undetermined at n=5; 6081 is an Amex and no
+# export is held for it.
+NO_LEDGER_CARDS = frozenset({"9297", "6081"})
 # Chase checking account number printed on ATM/bank slips, not a card.
 NON_PURCHASE = frozenset({"7739"})
+
+# Ledger sentinels. ``LEDGER_NONE`` is a *decided* value that persists to
+# DynamoDB ("this card has no held ledger"); ``LEDGER_UNKNOWN`` is the
+# absence of a decision. They are NOT interchangeable, and the string
+# "none" satisfies no ``is None`` test -- keep every branch below explicit
+# so a value can never fall through the match dispatch unnoticed again.
+LEDGER_APPLE = "apple"
+LEDGER_CHASE = "chase"
+LEDGER_NONE = "none"
+LEDGER_UNKNOWN = None
 
 DEFAULT_DB = "/Users/tnorlund/receipts-email/email_receipts.db"
 DEFAULT_APPLE_PDF_TXNS = (
@@ -323,6 +344,11 @@ def match_apple(
     return None
 
 
+def _chase_result(chase: dict[str, Any]) -> tuple[float, float]:
+    """Amount + confidence for a curated Chase match."""
+    return chase["amount"], 1.0 if chase["status"] == "confirmed" else 0.9
+
+
 # ------------------------------------------------------------------- main
 def fetch_all(client: DynamoClient) -> dict[str, Any]:
     """Pull receipts+words+labels, lines, sections, places, summaries."""
@@ -489,40 +515,54 @@ def run(args: argparse.Namespace) -> None:
         # ledger from the per-card rules
         last4 = tender.card_last4
         if last4 in APPLE_CARDS:
-            ledger = "apple"
+            ledger = LEDGER_APPLE
         elif last4 in CHASE_CARDS:
-            ledger = "chase"
+            ledger = LEDGER_CHASE
         elif last4 in NO_LEDGER_CARDS or last4 in NON_PURCHASE:
-            ledger = "none"
+            ledger = LEDGER_NONE
         elif tender.tender_class == "cash":
-            ledger = "none"
+            ledger = LEDGER_NONE
         else:
-            ledger = None  # unknown card / unknown tender
+            ledger = LEDGER_UNKNOWN  # unknown card / unknown tender
 
-        # bank match, gated on the card's ledger where known
+        # bank match, gated on the card's ledger where known.
+        # Every ledger value is handled explicitly; the trailing ``else``
+        # makes an unhandled value loud instead of silently dropping a
+        # match that was already fetched.
         bank_amount = confidence = None
         chase = chase_matches.get(receipt_key)
-        apple = None
-        if ledger in (None, "apple"):
+
+        if ledger == LEDGER_CHASE:
+            if chase:
+                bank_amount, confidence = _chase_result(chase)
+        elif ledger == LEDGER_APPLE:
             apple = match_apple(
                 apple_by_amount, date, total, merchant, category
             )
-        if ledger == "chase" and chase:
-            bank_amount = chase["amount"]
-            confidence = 1.0 if chase["status"] == "confirmed" else 0.9
-        elif ledger == "apple" and apple:
-            bank_amount = apple["amount"]
-            confidence = apple["confidence"]
-        elif ledger is None:
+            if apple:
+                bank_amount = apple["amount"]
+                confidence = apple["confidence"]
+        elif ledger == LEDGER_UNKNOWN:
             # no attributable card: accept whichever ledger matched
+            apple = match_apple(
+                apple_by_amount, date, total, merchant, category
+            )
             if chase:
-                bank_amount = chase["amount"]
-                confidence = 1.0 if chase["status"] == "confirmed" else 0.9
-                ledger = "chase"
+                bank_amount, confidence = _chase_result(chase)
+                ledger = LEDGER_CHASE
             elif apple:
                 bank_amount = apple["amount"]
                 confidence = apple["confidence"]
-                ledger = "apple"
+                ledger = LEDGER_APPLE
+        elif ledger == LEDGER_NONE:
+            # Deliberate: this card has no held ledger, so any curated
+            # match is not trustworthy evidence for it. Counted, not
+            # silently dropped -- a rising number here means a card was
+            # misfiled into NO_LEDGER_CARDS/NON_PURCHASE.
+            if chase:
+                stats["suppressed_chase_match_no_ledger"] += 1
+        else:
+            raise ValueError(f"unhandled ledger value: {ledger!r}")
 
         if bank_amount is not None:
             stats["bank_matched"] += 1
@@ -561,6 +601,10 @@ def run(args: argparse.Namespace) -> None:
     print(f"already up to date:      {stats['unchanged']}")
     print(f"records to write:        {len(to_write)}")
     print(f"bank-matched:            {stats['bank_matched']}")
+    print(
+        "curated matches suppressed (ledger=none): "
+        f"{stats['suppressed_chase_match_no_ledger']}"
+    )
     print("\ntender_detail distribution:")
     for name, count in tender_dist.most_common():
         print(f"  {name:22s} {count:5d}")


### PR DESCRIPTION
## Part 1 — the bug

Card `8712` sat in `NO_LEDGER_CARDS`, which sets `ledger = "none"` — a **string**. The match block then tested `if ledger == "chase"` and `elif ledger is None`. `"none"` satisfies **neither**, so a curated Chase match was fetched from `email_receipts.db` and silently dropped on the floor.

Two things are fixed, because the misfiled card and the type confusion are separate defects:

1. **`8712` → `CHASE_CARDS`.** It's a card on Chase account **5981**. The comment justifying its exclusion ("only ~10% of its amounts appear in Chase, i.e. chance level") measured 8712 across its *whole span* — most of which predates 5981's `2025-04-25` export window — and against the *wrong account*. Scored inside 5981's own window it hits **8 of 9 (89%)**, matching the confirmed Chase debits (1454 88%, 3931 85%, 5894 89%) against a date-resampled control of ~0.2 expected. `9297` (undetermined at n=5) and `6081` (Amex, no export held) stay excluded.
2. **The dispatch.** Every ledger value is now handled explicitly via named constants (`LEDGER_APPLE/CHASE/NONE/UNKNOWN`), and an unhandled value **raises** rather than discarding an already-fetched match. The deliberate `ledger="none"` suppression is now **counted and printed** instead of silent — a rising count there means a card has been misfiled.

### Measured effect on dev (applied and verified)

| | before | after |
|---|---|---|
| `bank_amount` set | 446 | **452** |
| ledger `chase` / `none` | 284 / 80 | 323 / 43 |
| matches **retracted** | — | **0** |

40 rows written: 37 × `8712`, 2 × `1454`, 1 × `5061`. Six gained a `bank_amount`:

| receipt | card | merchant | date | change |
|---|---|---|---|---|
| `57cb7f2c:1` | 8712 | Costco Wholesale | 2025-10-04 | `none`→`chase`, `$303.83` @0.9 |
| `84efc4e9:2` | 8712 | Costco Wholesale | 2025-09-25 | `none`→`chase`, `$64.64` @0.9 |
| `caf19581:1` | 8712 | Wild Fork | 2025-08-14 | `none`→`chase`, `$86.46` @0.9 |
| `d67ee0e3:1` | 8712 | Anawalt Lumber | 2025-09-23 | `none`→`chase`, `$21.94` @0.9 |
| `e1c30be9:1` | 8712 | In-N-Out Burger | 2025-08-14 | `none`→`chase`, `$26.23` @0.9 |
| `fa23150b:1` | 5061 | Vons | 2024-06-03 | *pre-existing drift* — the unmodified script writes this too |

So **+5 attributable to this fix**. Prod is untouched and will recover **6** on its next run.

## Part 2 — where bank coverage is actually lost

Measured on both tables. **No ledger data was imported, modified, or repaired.**

Dev: 828 summaries, **376** still lack a `bank_amount`.

| bucket | dev | prod | meaning |
|---|---|---|---|
| **should have matched** (ledger held, date in window) | **107** | 120 | recall loss |
| no `card_last4` | 157 | 150 | unattributable |
| outside ledger window | 42 | 44 | statement genuinely missing |
| card's ledger not held | 43 | 45 | statement genuinely missing |
| no date on receipt | 27 | 28 | receipt-side data gap |

Of the 107: **77 Chase, 30 Apple**.

**Tolerance is not the binding constraint.** Exact-amount held txn within ±1 / ±4 / ±7 days — Chase `34 / 34 / 35`, Apple `0 / 2 / 9`. Widening ±1→±4 buys **nothing** on Chase. Curation does.

### Why each one missed (dev)

| cause | n | |
|---|---|---|
| `chase:NEVER_CURATED_exact_d1` | **34** | exact amount, same day, right account — never written to `matches` |
| `chase:TIP_no_chase_matcher` | 20 | tippable merchant settled above printed total |
| `apple:merchant_present_amount_differs` | 13 | different trip, correctly rejected |
| `chase:no_total_on_receipt` | 11 | receipt-side gap |
| `apple:exact_outside_3d_gate` | 7 | `match_apple`'s `day_delta > 3` |
| `chase:merchant_present_amount_differs` | 7 | |
| `chase:no_held_txn` / `apple:no_held_txn` | 4 / 3 | genuinely missing |
| others (apple tip band, matcher rejected, no total) | 8 | |

**The structural finding:** the script has **no Chase matcher at all**. Apple is matched live and amount-anchored; Chase relies entirely on hand-curated rows in sqlite. That asymmetry — not missing statements, not the date window — is the dominant recall loss. Corroboration: Apple has **zero** in-window exact-amount misses, and 28 of the 34 Chase exact same-day misses have merchant agreement (sim ≥ 0.72) with a free, uncurated transaction.

### Highest-value single change

**Give the backfill a Chase matcher symmetric with `match_apple`** — same amount anchor, same ±3-day gate, same category-gated tip band.

Simulated by feeding Chase transactions to the **existing, unmodified** `match_apple` (replica asserted equal to the real matcher on every row):

> **+101 dev receipts** (34 card-exact, 15 card-tip, 29 no-last4-exact, 23 no-last4-tip) — and **+101 on prod**.

That takes dev bank coverage **452/828 (55%) → 553/828 (67%)**, and it beats importing *every* nameable missing statement (~80 receipts) while requiring **no new data**. 54 of the 101 land at confidence 0.95.

Two caveats worth pricing in before implementing: the 101 receipts consume only **93 distinct transactions** — 8 txns are claimed by 2 receipts each, which are duplicate images of one purchase (Urth Caffe, Twin Peaks, Sakura Ramen), so they're arguably correct but should be deduped deliberately rather than by accident; and **4** of those transactions are already curated to a *different* receipt, so the matcher needs to respect existing curation.

## Verification

- `black --check --line-length=79` and `isort --check-only --profile=black --line-length=79` pass in a bare 3.12 venv (CI's `receipt_agent` job lints changed `.py` files, which includes `scripts/`). No imports changed, so the isort split-personality issue doesn't apply.
- `infra/receipt_summary_updater/summary_processor.py` **carries over** the offline bank fields from the stored summary rather than recomputing them, so there is no duplicated card→ledger mapping to keep in sync and the dev writes won't be clobbered.
- Dry-run diffed per-receipt before applying; re-read from DynamoDB after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TzUnnRheR1xinDRCS6s4fB
