### PR TITLE
fix(line-items): read amounts through fused taxability flags (CVS zero-item receipts)

### DIFF
--- a/receipt_ocr_swift/Sources/ReceiptOCRCore/LineItems/LineItemDecoder.swift
+++ b/receipt_ocr_swift/Sources/ReceiptOCRCore/LineItems/LineItemDecoder.swift
@@ -103,8 +103,13 @@ enum LineItemRegex {
     static let bareCount = Rx("^\\d{1,2}$")
     /// LEAD_QTY_RE (ported for completeness)
     static let leadQty = Rx("^(\\d{1,2})\\s+(?=[A-Za-z])")
-    /// TAX_FLAG_RE (ported for completeness)
-    static let taxFlag = Rx("\\s+[TFNOAB]X?$")
+    /// TAX_FLAG_RE: a taxability flag printed directly after an amount,
+    /// whether or not OCR left a space ("7.32 N" / "7.32N"). The digit
+    /// lookbehind keeps it off ordinary words ending in a flag letter.
+    static let taxFlag = Rx("(?<=\\d)\\s*[TFNOAB]X?$")
+    /// FLAGGED_AMOUNT_RE: a whole token that is an amount plus such a
+    /// flag, capturing the amount. `stripTaxFlag` reads group 1.
+    static let flaggedAmount = Rx("^(\\$?-?\\d[\\d.,]*\\d)\\s*[TFNOAB]X?$")
     /// SETTLEMENT_RE: settlement lines are never items, even when a broken
     /// ITEMS section includes them. OCR sometimes scrambles word order
     /// ("17.98 DUE BALANCE") or prefixes an item count ("[1 item] Sub Total
@@ -153,8 +158,6 @@ enum LineItemRegex {
     static let skuLike = Rx("\\d{4,}")
     /// Amount fraction gate: r"\d[.,]\d{2}(?!\d)"
     static let twoDecimal = Rx("\\d[.,]\\d{2}(?!\\d)")
-    /// Fused taxability flag on an amount: r"\$?\d[\d.,]*\d[A-Z]" (fullmatch)
-    static let fusedFlagAmount = Rx("\\$?\\d[\\d.,]*\\d[A-Z]")
     static let alpha2 = Rx("[A-Za-z]{2,}")
     static let alpha3 = Rx("[A-Za-z]{3,}")
     static let multiSpace = Rx("\\s{2,}")
@@ -397,6 +400,16 @@ func bandWords(_ words: [ZoneWord]) -> [[ZoneWord]] {
 
 // MARK: - Amount extraction per line/band (blocks._line_amounts)
 
+/// Port of `geometry.strip_tax_flag`: drop a taxability flag fused onto
+/// (or spaced after) an amount. Shape-gated, so anything that is not a
+/// money token plus a flag comes back unchanged.
+func stripTaxFlag(_ token: String) -> String {
+    guard let m = LineItemRegex.flaggedAmount.fullMatch(pyStrip(token)),
+        let amount = m.group(1)
+    else { return token }
+    return amount
+}
+
 /// Port of `blocks._line_amounts`.
 func lineAmounts(_ words: [ZoneWord]) -> [Double] {
     var out: [Double] = []
@@ -404,10 +417,11 @@ func lineAmounts(_ words: [ZoneWord]) -> [Double] {
         var t = w.text
         // OCR carcass ("80.00)" from "@0.00)"), never a price
         if t.hasSuffix(")") && !t.contains("(") { continue }
-        // Strip a single fused trailing taxability flag ("0.38N")
-        if LineItemRegex.fusedFlagAmount.fullMatch(t) != nil {
-            t = String(t.dropLast())
-        }
+        // Strip a fused trailing taxability flag ("0.38N"). One shared
+        // rule with parseBand; this used to strip any trailing [A-Z],
+        // which scored "BERNZOMATIC MAP-PRO FUEL 14.10Z" (a 14.1-oz
+        // product SIZE) as a $14.10 price band.
+        t = stripTaxFlag(t)
         if Amounts.looksLikeReceiptAmount(t),
             LineItemRegex.twoDecimal.hasMatch(t),
             let v = Amounts.parseReceiptAmount(t)
@@ -573,6 +587,9 @@ func parseBand(_ band: [ZoneWord]) -> ParsedBand? {
     var amounts: [(Int, Double)] = []
     for (i, t) in texts.enumerated() {
         if t.hasSuffix(")") && !t.contains("(") { continue }
+        // A fused taxability flag is stripped before the amount test, the
+        // same rule lineAmounts applies when it decides band roles.
+        let t = stripTaxFlag(t)
         if Amounts.looksLikeReceiptAmount(t),
             LineItemRegex.twoDecimal.hasMatch(t),
             let v = Amounts.parseReceiptAmount(t), abs(v) < 100000
@@ -637,7 +654,7 @@ func parseBand(_ band: [ZoneWord]) -> ParsedBand? {
     var nameIdxs: [Int] = []
     for (i, t) in texts.enumerated() {
         if consumed.contains(i) { continue }
-        if Amounts.looksLikeReceiptAmount(t) { continue }
+        if Amounts.looksLikeReceiptAmount(stripTaxFlag(t)) { continue }
         if LineItemRegex.taxFlagWord.fullMatch(t) != nil { continue }
         nameIdxs.append(i)
     }

--- a/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/Fixtures/line_items_parity_expected.json
+++ b/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/Fixtures/line_items_parity_expected.json
@@ -4530,7 +4530,7 @@
    },
    {
     "name": "CA LUMBER FEE",
-    "price": 0.0,
+    "price": 0.25,
     "quantity": 5.0,
     "unit_price": 0.05,
     "is_discount": false,
@@ -4539,6 +4539,32 @@
      18,
      19,
      20
+    ]
+   },
+   {
+    "name": "0000-999-735 CA LBR FEE <A,U\u00bb",
+    "price": 0.1,
+    "quantity": null,
+    "unit_price": null,
+    "is_discount": false,
+    "name_quality": null,
+    "line_ids": [
+     14,
+     15,
+     16,
+     17
+    ]
+   },
+   {
+    "name": "0000-999-735 CA_LBR FEE \u00abA, U=",
+    "price": 0.38,
+    "quantity": null,
+    "unit_price": null,
+    "is_discount": false,
+    "name_quality": null,
+    "line_ids": [
+     11,
+     12
     ]
    },
    {
@@ -4785,7 +4811,7 @@
    },
    {
     "name": "CA LUMBER FEE",
-    "price": 0.0,
+    "price": 0.25,
     "quantity": 5.0,
     "unit_price": 0.05,
     "is_discount": false,
@@ -4794,6 +4820,32 @@
      18,
      19,
      20
+    ]
+   },
+   {
+    "name": "0000-999-735 CA LBR FEE <A,U\u00bb",
+    "price": 0.1,
+    "quantity": null,
+    "unit_price": null,
+    "is_discount": false,
+    "name_quality": null,
+    "line_ids": [
+     14,
+     15,
+     16,
+     17
+    ]
+   },
+   {
+    "name": "0000-999-735 CA_LBR FEE \u00abA, U=",
+    "price": 0.38,
+    "quantity": null,
+    "unit_price": null,
+    "is_discount": false,
+    "name_quality": null,
+    "line_ids": [
+     11,
+     12
     ]
    },
    {
@@ -4812,7 +4864,7 @@
   ],
   "reconcile": {
    "status": "mismatch",
-   "item_sum": 282.64,
+   "item_sum": 283.37,
    "baseline": 195.86,
    "baseline_source": "subtotal",
    "baseline_figures_agreeing": null
@@ -5764,7 +5816,7 @@
    },
    {
     "name": "CA LUMBER FEE",
-    "price": 200.1,
+    "price": 0.2,
     "quantity": null,
     "unit_price": null,
     "is_discount": false,
@@ -6224,7 +6276,7 @@
    },
    {
     "name": "CA LUMBER FEE",
-    "price": 200.1,
+    "price": 0.2,
     "quantity": null,
     "unit_price": null,
     "is_discount": false,
@@ -6267,7 +6319,7 @@
   ],
   "reconcile": {
    "status": "mismatch",
-   "item_sum": 1395.36,
+   "item_sum": 1195.46,
    "baseline": 1023.48,
    "baseline_source": "subtotal",
    "baseline_figures_agreeing": null

--- a/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/Fixtures/receipt_structure_parity_expected.json
+++ b/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/Fixtures/receipt_structure_parity_expected.json
@@ -1808,8 +1808,8 @@
       },
       {
         "item_index": 17,
-        "name": "0.25N",
-        "price": 0.0,
+        "name": "",
+        "price": 0.25,
         "quantity": 5.0,
         "unit_price": 0.05,
         "is_discount": false,
@@ -1822,6 +1822,35 @@
       },
       {
         "item_index": 18,
+        "name": "0000-999-735 CA LBR FEE <A,U\u00bb",
+        "price": 0.1,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          14,
+          15,
+          17
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 19,
+        "name": "0000-999-735 CA_LBR FEE \u00abA, U=",
+        "price": 0.38,
+        "quantity": null,
+        "unit_price": null,
+        "is_discount": false,
+        "name_quality": "ok",
+        "line_ids": [
+          11,
+          12
+        ],
+        "reconciliation_status": "no-baseline"
+      },
+      {
+        "item_index": 20,
         "name": "0.750INX23. 75INX97IN WHT MEL",
         "price": 38.97,
         "quantity": null,
@@ -2403,8 +2432,8 @@
       },
       {
         "item_index": 28,
-        "name": "0.20N",
-        "price": 200.1,
+        "name": "",
+        "price": 0.2,
         "quantity": null,
         "unit_price": null,
         "is_discount": false,

--- a/receipt_upload/receipt_upload/line_items/blocks.py
+++ b/receipt_upload/receipt_upload/line_items/blocks.py
@@ -66,16 +66,21 @@ def _money(v: Any) -> float | None:
 
 
 def _line_amounts(words: list[dict]) -> list[float]:
+    # Local import for the same reason every other geometry reference in
+    # this module is local: geometry pulls in blocks from extract_items.
+    from receipt_upload.line_items.geometry import strip_tax_flag
+
     out = []
     for w in words:
         t = w["text"]
         if t.endswith(")") and "(" not in t:
             continue  # OCR carcass ("80.00)" from "@0.00)"), never a price
         # OCR fuses trailing taxability flags onto amounts ("0.38N",
-        # "0.20N" on Home Depot fee lines); strip a single trailing letter
-        # when what remains is an amount shape.
-        if re.fullmatch(r"\$?\d[\d.,]*\d[A-Z]", t):
-            t = t[:-1]
+        # "0.20N" on Home Depot fee lines). One shared rule with
+        # parse_band -- this used to strip any trailing [A-Z], which
+        # scored Home Depot's "BERNZOMATIC MAP-PRO FUEL 14.10Z" (a 14.1-oz
+        # product SIZE) as a $14.10 price band.
+        t = strip_tax_flag(t)
         if looks_like_receipt_amount(t) and re.search(r"\d[.,]\d{2}(?!\d)", t):
             v = parse_receipt_amount(t)
             if v is not None:
@@ -516,9 +521,42 @@ def filter_summary_figure_items(
                 for f in figures
             ):
                 continue
-            if len(non_disc) - len(drop) - 1 < 2:
-                continue  # at least 2 other items must survive
             new_diff = abs(round(cur - price, 2) - baseline)
+            if len(non_disc) - len(drop) - 1 < 2:
+                # Normally at least 2 other items must survive: a
+                # single-item receipt legitimately has item price ==
+                # total (Barnes & Noble / CVS / Target / LA County), and
+                # dropping its one item would empty the receipt.
+                #
+                # The one exception is fully self-verifying: a band with
+                # NO name text at all, whose removal leaves items that
+                # all DO carry name text and that then reconcile EXACTLY.
+                # That shape is a summary/tender amount the ITEMS
+                # boundary swallowed -- CVS d04dea42 prints its
+                # subtotal's amount one OCR line above the "SUBTOTAL"
+                # label, and 2c9b770c its "20.00 20.00" tender pair below
+                # a "TOTAL 20.00" the zone excluded. The protected
+                # single-item case cannot reach it: that receipt's one
+                # item is a named product, so it is never the candidate.
+                #
+                # "No name text" is deliberately stricter than the
+                # _name_is_real test used above -- 2c9b770c's real item
+                # is "RX #: ****2130000", which is not a real NAME but is
+                # not a bare amount either, and it must be the survivor.
+                survivors = [
+                    it2
+                    for j, it2 in enumerate(items)
+                    if j != idx
+                    and j not in drop
+                    and not it2.get("is_discount")
+                ]
+                if not (
+                    not (it.get("name") or "").strip()
+                    and survivors
+                    and all((s.get("name") or "").strip() for s in survivors)
+                    and new_diff <= tol
+                ):
+                    continue
             if unnamed:
                 ok = new_diff < abs(cur - baseline) - 0.005
             else:

--- a/receipt_upload/receipt_upload/line_items/geometry.py
+++ b/receipt_upload/receipt_upload/line_items/geometry.py
@@ -366,10 +366,13 @@ WAS_PRICE_RE = re.compile(r"\b(?:WAS|REG)\b[:.]?\s*\$?\d", re.IGNORECASE)
 # it double-counts. Target prints the same echo as "Regular Price $22.99"
 # under each discounted item (mode D in the failure-mode report: dropping
 # that one band closes the delta exactly), and Nordstrom Rack prints it as
-# "Comparable Value 59.95". Exact phrases only — "BAG SALE PAPER EA" is a
-# real item.
+# "Comparable Value 59.95". CVS prints it as "ORIGINAL PRICE 49.99" above
+# the coupon line that discounts it, which is the same annotation under a
+# third name -- and it is the only reason CVS 5a7b884a decoded a $49.99
+# phantom next to its real $49.89 item. Exact phrases only — "BAG SALE
+# PAPER EA" is a real item.
 SALE_PRICE_RE = re.compile(
-    r"\b(?:(?:SALE|REG(?:ULAR)?\.?)\s+PRICE|COMPARABLE\s+VALUE)\b",
+    r"\b(?:(?:SALE|REG(?:ULAR)?\.?|ORIGINAL)\s+PRICE|COMPARABLE\s+VALUE)\b",
     re.IGNORECASE,
 )
 # An amount qualified "per <unit>" is a RATE, not an extended price. The
@@ -444,7 +447,46 @@ QTY_SEPARATOR_RE = re.compile(
 # Cent-exact tolerance for accepting a quantity pair. Both sides are
 # printed money, so this is float-representation slack, not a band.
 QTY_CENT_TOLERANCE = 0.005
-TAX_FLAG_RE = re.compile(r"\s+[TFNOAB]X?$")
+# --- Taxability flags fused onto the amount they annotate ----------------
+# Registers print a taxability code after the price -- CVS "7.32N", Home
+# Depot "0.38N", Dollar Tree "1.25T" -- and whether OCR returns it as its
+# own word ("7.32" "N") or fused into one ("7.32N") is a property of the
+# glyph spacing, not of the receipt. Both are the same printed thing, so
+# one rule covers both: the old ``\s+`` form could only strip the split
+# case, and the fused case fell through to ``looks_like_receipt_amount``,
+# which rejects "7.32N" outright. CVS never prints a currency symbol, so
+# every CVS line price was invisible to the decoder (11 prod / 11 dev
+# receipts decoded ZERO items with a perfectly good ITEMS section).
+#
+# The flag alphabet stays the one this module already declares, and is
+# NOT widened to a bare [A-Z]: the trailing letter is not always a flag.
+# "BERNZOMATIC MAP-PRO FUEL 14.10Z" is a 14.1-OUNCE product size and
+# "Diamonds 0.95g" is a weight; both read as money under [A-Z] and
+# neither is money. Restricting to [TFNOAB] and anchoring on a whole
+# money-shaped token is what keeps SKUs, store numbers and loyalty ids
+# ("4006N", "123456F") out -- they carry no 2-decimal fraction, so they
+# fail the amount test even after the flag comes off.
+#
+# The digit lookbehind keeps the suffix pattern from firing on ordinary
+# words that happen to end in a flag letter ("CAT", "SKIN OFF").
+TAX_FLAG_RE = re.compile(r"(?<=\d)\s*[TFNOAB]X?$")
+# A whole token that is an amount carrying such a flag, capturing the
+# amount. strip_tax_flag reads group 1 rather than substituting, so the
+# Swift port is the same two operations in the same order.
+FLAGGED_AMOUNT_RE = re.compile(r"^(\$?-?\d[\d.,]*\d)\s*[TFNOAB]X?$")
+
+
+def strip_tax_flag(token: str) -> str:
+    """Return ``token`` without a taxability flag fused onto its amount.
+
+    Shape-gated: anything that is not a money token plus a flag comes back
+    unchanged, so this can be applied to every word of a band without
+    risking a product name.
+    """
+    match = FLAGGED_AMOUNT_RE.fullmatch((token or "").strip())
+    return match.group(1) if match else (token or "")
+
+
 DISCOUNT_WORDS = ("SAVED", "SAVING", "OFF", "COUPON", "DISCOUNT", "PROMO")
 # Discount markers, matched as WORDS. The tuple above was tested with a
 # plain substring scan, which read "OFF" inside COFFEE / TOFFEE / Office
@@ -589,6 +631,12 @@ def parse_band(band: list[dict]) -> Optional[dict[str, Any]]:
         # "(2" + "80.00)") — never a price.
         if t.endswith(")") and "(" not in t:
             continue
+        # A fused taxability flag is stripped before the amount test, the
+        # same rule blocks._line_amounts applies when it decides band
+        # roles. Without this the two disagreed: a CVS band was scored
+        # PRICE on its "7.32N" and then parsed to None here, so the row
+        # produced no item at all.
+        t = strip_tax_flag(t)
         if looks_like_receipt_amount(t) and re.search(r"\d[.,]\d{2}(?!\d)", t):
             v = parse_receipt_amount(t)
             if v is not None and abs(v) < 100000:
@@ -650,7 +698,7 @@ def parse_band(band: list[dict]) -> Optional[dict[str, Any]]:
     for i, t in enumerate(texts):
         if i in consumed:
             continue
-        if looks_like_receipt_amount(t):
+        if looks_like_receipt_amount(strip_tax_flag(t)):
             continue  # an earlier price on the band is never name content
         if re.fullmatch(r"[TFNOAB]X?", t):
             continue  # taxability flag
@@ -1638,6 +1686,7 @@ __all__ = [
     "COLUMN_HEADER_ANCHOR_TOKENS",
     "DISCOUNT_WORDS",
     "DISCOUNT_WORD_RE",
+    "FLAGGED_AMOUNT_RE",
     "LEAD_QTY_RE",
     "NOISY_MONEY_RE",
     "NON_ITEM_SECTIONS",
@@ -1669,4 +1718,5 @@ __all__ = [
     "quantity_candidates",
     "reconcile",
     "reconcile_detailed",
+    "strip_tax_flag",
 ]

--- a/receipt_upload/tests/test_line_item_geometry.py
+++ b/receipt_upload/tests/test_line_item_geometry.py
@@ -142,6 +142,27 @@ def test_one_decimal_and_bare_thousands_are_not_prices():
     assert parsed["price"] == 11.62
 
 
+def test_fused_tax_flag_amount_is_a_price():
+    # Registers print a taxability code after the price and OCR may fuse
+    # the two into one token ("7.32N"). CVS never prints a currency
+    # symbol, so without the strip its every line price was invisible
+    # (11 prod / 12 dev CVS receipts decoded zero items).
+    items, _ = items_for(row(1, 0.30, "ADVIL", "TABLETS", "7.32N"))
+    assert [(i["name"], i["price"]) for i in items] == [
+        ("ADVIL TABLETS", 7.32)
+    ]
+
+
+def test_trailing_letter_is_not_always_a_tax_flag():
+    # "14.10Z" is a 14.1-OUNCE product size on Home Depot's BERNZOMATIC
+    # row, not $14.10. The flag alphabet stays [TFNOAB]; under a bare
+    # [A-Z] strip this band grew a phantom price.
+    items, _ = items_for(
+        row(1, 0.30, "BERNZOMATIC", "MAP-PRO", "FUEL", "14.10Z")
+    )
+    assert items == []
+
+
 def test_close_paren_orphan_is_not_a_price():
     # "(2 @0.00)" OCRs as "(2" + "80.00)": the close-paren orphan must not
     # become the price; the band pairs with the price-column META instead.
@@ -220,6 +241,39 @@ def test_summary_figure_single_item_receipt_untouched():
     )
     assert len(items) == 1
     assert items[0]["price"] == 24.99
+
+
+def test_summary_figure_nameless_band_dropped_below_two_survivors():
+    # The self-verifying exception to the two-survivor guard: a band with
+    # NO name text at all, whose removal leaves all-named items that then
+    # reconcile EXACTLY, is a summary amount the ITEMS boundary swallowed
+    # (CVS d04dea42 prints its subtotal's amount one OCR line above the
+    # "SUBTOTAL" label). The bare-amount band drops even though only one
+    # item survives.
+    words = row(1, 0.30, "PLAN", "B", "ONE", "STEP", "49.89") + row(
+        2, 0.25, "49.89"
+    )
+    items = items_with_summary(
+        words, {"subtotal": "49.89", "grand_total": "53.63"}
+    )
+    assert [i["price"] for i in items] == [49.89]
+    assert "PLAN" in items[0]["name"]
+
+
+def test_summary_figure_exception_needs_a_texted_survivor():
+    # The exception is stricter than _name_is_real on purpose: CVS
+    # 2c9b770c's real item is "RX #: ****2130000" -- not a real NAME but
+    # not a bare amount either -- and it must be the survivor when the
+    # "20.00 20.00" tender pair below the excluded TOTAL drops.
+    words = row(1, 0.30, "RX", "#:", "****2130000", "20.00") + row(
+        2, 0.25, "20.00", "20.00"
+    )
+    items = items_with_summary(
+        words, {"subtotal": "20.00", "grand_total": "20.00", "tax": "0.0"}
+    )
+    assert [(i["name"], i["price"]) for i in items] == [
+        ("RX #: ****2130000", 20.0)
+    ]
 
 
 def test_named_item_at_tax_amount_survives():

--- a/receipt_upload/tests/test_line_item_label_derivation.py
+++ b/receipt_upload/tests/test_line_item_label_derivation.py
@@ -669,11 +669,20 @@ def test_header_row_price_word_is_not_a_line_total_either():
     # the pre-markdown price, printed beside a differently-priced item.
     # Minting LINE_TOTAL on it would teach the model that a header row's
     # amount is an extended total, on the strength of a sum that lands.
-    words = row(1, 0.10, "ORIGINAL", "PRICE", "49.99")
-    result = derive_labels(words, {1}, {"subtotal": 49.99})
+    #
+    # Shape taken from CVS 5a7b884a, which prints exactly this: a $49.89
+    # item with its $49.99 pre-coupon price on the next row. The
+    # annotation is now recognized by SALE_PRICE_RE, so it never becomes
+    # an item at all -- a stronger form of the same guarantee, and the
+    # real item beside it keeps its own labels.
+    words = row(1, 0.10, "PLAN", "B", "ONE", "STEP", "49.89") + row(
+        2, 0.15, "ORIGINAL", "PRICE", "49.99"
+    )
+    result = derive_labels(words, {1, 2}, {"subtotal": 49.89})
 
     assert result.gate == GATE_OK
-    assert "LINE_TOTAL" not in by_label(result)
+    assert by_label(result).get("LINE_TOTAL") == {"49.89"}
+    assert "49.99" not in {p.text for p in result.labels}
 
 
 def test_header_name_borrowed_from_another_row_keeps_its_line_total():


### PR DESCRIPTION
## What

Registers print a taxability code after the price — CVS `7.32N`, Home Depot `0.38N`, Dollar Tree `1.25T` — and OCR returns it either as its own word or fused into the amount token depending on glyph spacing. `TAX_FLAG_RE` only stripped the split form; the fused form fell through to `looks_like_receipt_amount`, which rejects `7.32N` while accepting `$7.32N`. CVS never prints a currency symbol, so every CVS line price was invisible and 11 prod / 12 dev CVS receipts decoded ZERO items from a perfectly good ITEMS section.

One shared shape-gated rule (`strip_tax_flag` / `FLAGGED_AMOUNT_RE`) now covers both forms, applied in `_line_amounts` **and** `parse_band` so band scoring and parsing can no longer disagree (a CVS band used to be scored PRICE on its `7.32N` and then parse to `None`). The flag alphabet stays `[TFNOAB]` and is deliberately NOT widened to `[A-Z]`: `14.10Z` is a 14.1-ounce fuel-canister size and `0.95g` is a weight; both read as money under the old any-letter strip — which is exactly how Home Depot's BERNZOMATIC row grew a phantom $14.10 price band.

Also:
- `SALE_PRICE_RE` learns `ORIGINAL PRICE` (CVS's name for the pre-discount echo Target prints as `Regular Price`; the cause of 5a7b884a's $49.99 phantom beside its real $49.89 item).
- `filter_summary_figure_items` gains a fully self-verifying exception to the two-survivor guard: a band with NO name text whose removal leaves all-named items that then reconcile EXACTLY (CVS d04dea42 prints its subtotal's amount one OCR line above the `SUBTOTAL` label; 2c9b770c's `20.00 20.00` tender pair below an excluded `TOTAL 20.00`).
- Swift decoder ports `stripTaxFlag` into `lineAmounts`/`parseBand` (the parity surface), and **all three parity fixtures** (line-item, receipt-structure, section-assignment) are regenerated from the live Python decoder — the Swift suites pass 35/35 against them locally.

## Gates

**Golden floors** (ratchet-up only): all floors hold. Home Depot recall 86.5% → 90.4%, precision 64.3% → 65.3%; names 46.7% → 44.7% because the newly matched fee lines carry junk names (`0000-999-735 CA LBR FEE`).

**Corpus sweep with per-receipt flip check** (dev AND prod, decoded from cached table state before/after):

| stack | match | mismatch | flips | left match |
|---|---|---|---|---|
| dev | 522 → 534 | 95 → 84 | 14 | **0** |
| prod | 530 → 544 | 113 → 100 | 16 | **0** |

The two non-improving flips are explained, not regressions:
- dev `879b0fa6#2` no-baseline → mismatch: the old code decoded a phantom **$200.10** `CA LUMBER FEE` from a fused-flag token, pushing item_sum past 3× baseline and tripping `_baseline_implausible`. With the phantom gone (→ $0.20) the baseline is plausible again and the receipt is an honest mismatch (it's the known split-receipt twin that can never reconcile).
- prod `1ac815c4#1` near → mismatch: prod's stale ITEMS section carries an extra swallowed 25.40 band; the same decoder over dev's sections lands an **exact match** (23.49). The planned prod summary-regen sweep clears it.

**Money-string sweep** (every corpus word, dev+prod): the only tokens newly accepted as money are genuine flagged amounts (`1.25T`, `0.10N`, `7.32N`, `49.89T`, … 27 distinct); the only token newly rejected is `14.10Z` (intended).

## Split

The remainder of the Swift port (salePrice `ORIGINAL PRICE`, the summary-figure filter's new exception — both off the parity-fixture surface) lands as a separate stacked PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved receipt item and price recognition for tax flags attached to or separated from amounts.
  * Prevented product-size values from being misread as prices.
  * Improved handling of sale prices, including “ORIGINAL PRICE” entries.
  * Refined summary-item filtering to preserve valid named products.
  * Corrected receipt totals, item names, prices, and labor-fee entries across supported receipts.

* **Tests**
  * Added regression coverage for tax-flag parsing, sale-price labeling, and summary filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->