### PR TITLE
fix(swift-parity): finish the CVS-fix port (ORIGINAL PRICE, filter single-item exception)

### DIFF
--- a/receipt_ocr_swift/Sources/ReceiptOCRCore/LineItems/LineItemDecoder.swift
+++ b/receipt_ocr_swift/Sources/ReceiptOCRCore/LineItems/LineItemDecoder.swift
@@ -137,12 +137,14 @@ enum LineItemRegex {
     )
     /// WAS_PRICE_RE: price-comparison metadata ("WAS: $3.59 each")
     static let wasPrice = Rx("\\b(?:WAS|REG)\\b[:.]?\\s*\\$?\\d", ci: true)
-    /// SALE_PRICE_RE: annotation echo that restates a post-discount unit
-    /// price ("Sale Price 1.99", Target's "Regular Price $22.99", Nordstrom
-    /// Rack's "Comparable Value 59.95"). Exact phrases only — "BAG SALE
-    /// PAPER EA" is a real item.
+    /// SALE_PRICE_RE: annotation echo that restates a pre/post-discount
+    /// unit price ("Sale Price 1.99", Target's "Regular Price $22.99",
+    /// Nordstrom Rack's "Comparable Value 59.95", CVS's "ORIGINAL PRICE
+    /// 49.99" above the coupon that discounts it). Exact phrases only —
+    /// "BAG SALE PAPER EA" is a real item.
     static let salePrice = Rx(
-        "\\b(?:(?:SALE|REG(?:ULAR)?\\.?)\\s+PRICE|COMPARABLE\\s+VALUE)\\b",
+        "\\b(?:(?:SALE|REG(?:ULAR)?\\.?|ORIGINAL)\\s+PRICE"
+            + "|COMPARABLE\\s+VALUE)\\b",
         ci: true
     )
     /// NON_PRODUCT_NOTE_RE: tip-suggestion footers ("22% Tip = 4.40",
@@ -766,7 +768,8 @@ public struct LineItemSummary: Sendable, Equatable {
 ///   * runs only when the receipt does NOT already reconcile, so the filter
 ///     can never lose a currently-matching receipt;
 ///   * at least 2 other non-discount items must survive every drop
-///     (single-item receipts legitimately have item price == total);
+///     (single-item receipts legitimately have item price == total),
+///     except the self-verifying nameless-band case documented inline;
 ///   * an UNNAMED band may match subtotal / tax / grand_total and is dropped
 ///     only when the drop strictly improves the delta;
 ///   * a NAMED band may match only subtotal / grand_total and is dropped
@@ -806,8 +809,32 @@ func filterSummaryFigureItems(
                 return abs(price - f) <= max(0.02, f * 0.01)
             }
             if !matchesFigure { continue }
-            if nonDisc.count - drop.count - 1 < 2 { continue }
             let newDiff = abs(pythonRound2(cur - price) - base)
+            if nonDisc.count - drop.count - 1 < 2 {
+                // Normally at least 2 other items must survive: a
+                // single-item receipt legitimately has item price ==
+                // total, and dropping its one item would empty the
+                // receipt. The one exception is fully self-verifying: a
+                // band with NO name text at all, whose removal leaves
+                // items that all DO carry name text and that then
+                // reconcile EXACTLY (CVS d04dea42 prints its subtotal's
+                // amount one OCR line above the "SUBTOTAL" label;
+                // 2c9b770c its "20.00 20.00" tender pair below an
+                // excluded "TOTAL 20.00"). "No name text" is stricter
+                // than `nameIsReal` on purpose — 2c9b770c's survivor is
+                // "RX #: ****2130000", not a real NAME but not a bare
+                // amount either.
+                let survivors = items.enumerated().filter { j, it2 in
+                    j != idx && !drop.contains(j) && !it2.isDiscount
+                }.map(\.element)
+                let bandNameless = pyStrip(it.name).isEmpty
+                let allNamed =
+                    !survivors.isEmpty
+                    && survivors.allSatisfy { !pyStrip($0.name).isEmpty }
+                if !(bandNameless && allNamed && newDiff <= tol) {
+                    continue
+                }
+            }
             let ok =
                 unnamed
                 ? newDiff < abs(cur - base) - 0.005

--- a/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/SummaryFigureFilterTests.swift
+++ b/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/SummaryFigureFilterTests.swift
@@ -1,0 +1,103 @@
+import Foundation
+import Testing
+
+@testable import ReceiptOCRCore
+
+/// Direct ports of the Python summary-figure-filter and fused-tax-flag
+/// tests in `receipt_upload/tests/test_line_item_geometry.py`. The guard
+/// parity fixture only exercises golden receipts, none of which hit the
+/// single-item exception or a fused flag, so these shapes are pinned
+/// here with the same words and the same expected outcomes as Python.
+@Suite struct SummaryFigureFilterTests {
+
+    /// One visual row: tokens laid out left to right (Python `row`).
+    private func row(
+        _ lineId: Int, _ y: Double, _ tokens: String...
+    ) -> [ZoneWord] {
+        tokens.enumerated().map { i, t in
+            ZoneWord(
+                lineId: lineId, wordId: i + 1, text: t,
+                x: 0.1 + 0.2 * Double(i), yMid: y, h: 0.02
+            )
+        }
+    }
+
+    @Test func fusedTaxFlagAmountIsAPrice() {
+        // CVS prints "7.32N" with no currency symbol; without the strip
+        // its every line price was invisible to the decoder.
+        let items = extractLineItems(
+            words: row(1, 0.30, "ADVIL", "TABLETS", "7.32N"),
+            zoneLineIds: [1]
+        )
+        #expect(items.count == 1)
+        #expect(items.first?.name == "ADVIL TABLETS")
+        #expect(items.first?.price == 7.32)
+    }
+
+    @Test func trailingLetterIsNotAlwaysATaxFlag() {
+        // "14.10Z" is a 14.1-OUNCE product size on Home Depot's
+        // BERNZOMATIC row, not $14.10. The flag alphabet stays [TFNOAB].
+        let items = extractLineItems(
+            words: row(1, 0.30, "BERNZOMATIC", "MAP-PRO", "FUEL", "14.10Z"),
+            zoneLineIds: [1]
+        )
+        #expect(items.isEmpty)
+    }
+
+    @Test func originalPriceEchoIsNeverAnItem() {
+        // CVS's "ORIGINAL PRICE 49.99" is the same pre-discount echo
+        // Target prints as "Regular Price"; it must not decode as a
+        // phantom item beside the real one.
+        let items = extractLineItems(
+            words: row(1, 0.30, "PLAN", "B", "ONE", "STEP", "49.89")
+                + row(2, 0.25, "ORIGINAL", "PRICE", "49.99"),
+            zoneLineIds: [1, 2]
+        )
+        #expect(items.map(\.price) == [49.89])
+    }
+
+    @Test func namelessSummaryBandDroppedBelowTwoSurvivors() {
+        // The self-verifying exception to the two-survivor guard: a band
+        // with NO name text, whose removal leaves all-named items that
+        // then reconcile EXACTLY (CVS d04dea42 prints its subtotal's
+        // amount one OCR line above the "SUBTOTAL" label).
+        let items = extractLineItems(
+            words: row(1, 0.30, "PLAN", "B", "ONE", "STEP", "49.89")
+                + row(2, 0.25, "49.89"),
+            zoneLineIds: [1, 2],
+            summary: LineItemSummary(subtotal: 49.89, grandTotal: 53.63)
+        )
+        #expect(items.map(\.price) == [49.89])
+        #expect(items.first?.name.contains("PLAN") == true)
+    }
+
+    @Test func exceptionNeedsATextedSurvivor() {
+        // Stricter than nameIsReal on purpose: CVS 2c9b770c's real item
+        // is "RX #: ****2130000" -- not a real NAME but not a bare
+        // amount either -- and it must be the survivor when the
+        // "20.00 20.00" tender pair drops.
+        let items = extractLineItems(
+            words: row(1, 0.30, "RX", "#:", "****2130000", "20.00")
+                + row(2, 0.25, "20.00", "20.00"),
+            zoneLineIds: [1, 2],
+            summary: LineItemSummary(
+                subtotal: 20.00, tax: 0.0, grandTotal: 20.00
+            )
+        )
+        #expect(items.count == 1)
+        #expect(items.first?.name == "RX #: ****2130000")
+        #expect(items.first?.price == 20.0)
+    }
+
+    @Test func twoSurvivorGuardStillHoldsForTextedBands() {
+        // The In-N-Out shape: the candidate band carries name text, so
+        // the exception never fires and both items survive.
+        let items = extractLineItems(
+            words: row(1, 0.30, "2", "Animal", "Fry", "9.20")
+                + row(2, 0.25, "DRIVE", "Eat", "In", "9.20"),
+            zoneLineIds: [1, 2],
+            summary: LineItemSummary(subtotal: 9.2, grandTotal: 9.97)
+        )
+        #expect(items.map(\.price).sorted() == [9.2, 9.2])
+    }
+}


### PR DESCRIPTION
Stacked on #1387 (merge that first, then retarget/merge this — per the stacked-PR convention: parent `--merge`, child `--squash`).

Completes the Swift side of the fused-taxability-flag fix. The parity fixtures only pin `extract_items` over golden receipts, none of which print `ORIGINAL PRICE` or hit the summary-figure filter's new exception — so #1387 stays green without these, which is exactly how the decoder forked from Python once before (#1313..#1329). This ports the rest same-day and pins the off-fixture shapes with direct tests.

- `salePrice` regex learns `ORIGINAL PRICE` (Python got it in #1387).
- `filterSummaryFigureItems` ports the self-verifying exception to the two-survivor guard: a band with NO name text, whose removal leaves all-named items that then reconcile EXACTLY, drops even when only one item would survive (CVS d04dea42 subtotal-above-label; 2c9b770c tender pair beside an `RX #:` survivor).
- `SummaryFigureFilterTests` pins six shapes verbatim from the Python tests in `test_line_item_geometry.py`, with outcomes verified against the live Python decoder: fused-flag price (`7.32N`), `14.10Z` size token, `ORIGINAL PRICE` echo, the exception, its texted-survivor requirement, and the intact two-survivor guard.

`swift test`: 41 tests, 10 suites, all passing locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)