### PR TITLE
fix(labels): prefer TOTAL_LINE section over PAYMENT row when deduping GRAND_TOTAL

### DIFF
--- a/receipt_upload/receipt_upload/line_items/reconstructor.py
+++ b/receipt_upload/receipt_upload/line_items/reconstructor.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import re
 import statistics
 from datetime import datetime, timezone
-from typing import Dict, List, Set, Tuple
+from typing import Dict, List, Optional, Sequence, Set, Tuple
 
 from receipt_dynamo.amounts import GRAND_TOTAL_DISQUALIFIER_TOKENS
 from receipt_dynamo.constants import ValidationStatus
@@ -42,6 +42,17 @@ _GRAND_TOTAL_KEYWORDS = frozenset(
 # Canonical copy lives in receipt_dynamo.amounts, shared with the
 # ReceiptSummary printed-total fallback.
 _GRAND_TOTAL_DISQUALIFIERS = GRAND_TOTAL_DISQUALIFIER_TOKENS
+# Election rank a candidate inherits from the receipt's section layer, when the
+# caller supplies sections (lower is better). The section decoder
+# (swift-worker-v1) explicitly separates the printed TOTAL_LINE row from the
+# PAYMENT (tender) block, so a GRAND_TOTAL copy sitting on the TOTAL_LINE row
+# must out-rank the restatement on the card slip — the keyword/lowest-y
+# heuristics alone get this backwards when the tender row also carries a
+# grand-total keyword ("Amount", "Total Tender") and prints lower on the paper.
+# Lines in neither section (or with no section info at all) rank in between,
+# which keeps the pre-section behavior as the fallback.
+_SECTION_TIEBREAK_RANK: Dict[str, int] = {"TOTAL_LINE": 0, "PAYMENT": 2}
+_SECTION_RANK_NEUTRAL = 1
 _PROPOSED_BY = "geometry_line_items"
 _RECLASS_BY = "arithmetic_totals_reclass"
 
@@ -281,7 +292,9 @@ def reclassify_mislabeled_totals(
 
 
 def dedupe_grand_total(
-    words: List, existing_labels: List[ReceiptWordLabel]
+    words: List,
+    existing_labels: List[ReceiptWordLabel],
+    sections: Optional[Sequence] = None,
 ) -> List[ReceiptWordLabel]:
     """Return redundant ``GRAND_TOTAL`` labels that should be invalidated.
 
@@ -307,7 +320,17 @@ def dedupe_grand_total(
       that copy is canonical and only the ``PENDING`` duplicates of it are
       reported. If a group has *multiple* confirmed copies we abstain entirely.
     * When every copy in a value-group is ``PENDING``, the canonical kept copy is
-      preferred by **grand-total-keyword context first** (a copy whose row carries
+      preferred by **section context first** when ``sections`` is provided: a
+      copy whose line sits inside a ``TOTAL_LINE`` section out-ranks one in
+      neither section, which out-ranks one inside a ``PAYMENT`` (tender)
+      section. The section layer has already decided which row *is* the printed
+      total (swift-worker-v1 marks it at high confidence), and the audited
+      failure mode — "TOTAL $20.56" invalidated while the equal "DEBIT PAYMENT"
+      amount stayed — happens exactly because the tender row both carries a
+      grand-total keyword ("Amount"/"Total Tender") and prints lower. Within
+      the winning section tier (or whenever section info is absent, the
+      pre-existing behavior), the copy is
+      preferred by **grand-total-keyword context** (a copy whose row carries
       "TOTAL"/"BALANCE"/"DUE"/"GRAND"/"AMOUNT" out-ranks a bare restated number),
       then by **lowest-on-receipt** (smallest y-center — header is high-y, the
       final total prints last/lowest). Keyword anchoring matters: a stray copy of
@@ -316,6 +339,11 @@ def dedupe_grand_total(
       downstream validator may invalidate the kept stray and strand the receipt
       with **no** grand total. The equal-valued restatements are the redundant
       copies.
+
+    ``sections`` is optional and advisory: any iterable of objects carrying
+    ``section_type`` (``SectionType`` or its string value) and ``line_ids``
+    (e.g. ``ReceiptSection`` entities). Passing ``None`` or an empty sequence
+    reproduces the pre-section behavior exactly.
 
     Callers should mark each returned label ``INVALID`` (audit trail, never
     delete) and drop it from the pending set so the validators don't resurrect it.
@@ -365,6 +393,28 @@ def dedupe_grand_total(
         and not (toks & _GRAND_TOTAL_DISQUALIFIERS)
     }
 
+    # Line-id -> election rank from the receipt's section layer (see
+    # ``_SECTION_TIEBREAK_RANK``). Empty when the caller has no section info,
+    # which neutralizes the tier entirely.
+    section_rank: Dict[int, int] = {}
+    for sec in sections or ():
+        stype = getattr(sec, "section_type", None)
+        stype = getattr(stype, "value", stype)  # unwrap SectionType enum
+        rank = _SECTION_TIEBREAK_RANK.get(stype)
+        if rank is None:
+            continue
+        for raw_line_id in getattr(sec, "line_ids", None) or ():
+            try:
+                line_id = int(raw_line_id)
+            except (TypeError, ValueError):
+                continue
+            # If a line somehow appears in both a TOTAL_LINE and a PAYMENT
+            # section, the better (TOTAL_LINE) rank wins.
+            section_rank[line_id] = min(rank, section_rank.get(line_id, rank))
+
+    def _rank(lab: ReceiptWordLabel) -> int:
+        return section_rank.get(lab.line_id, _SECTION_RANK_NEUTRAL)
+
     redundant: List[ReceiptWordLabel] = []
     for _val, labs in by_value.items():
         if len(labs) < 2:
@@ -387,11 +437,17 @@ def dedupe_grand_total(
             # duplicates are redundant (never invalidate the confirmed one).
             redundant.extend(pending)
             continue
-        # All PENDING: elect a canonical copy and invalidate the rest. Prefer a
-        # keyword-anchored row (the explicit total) over a bare restated number;
-        # among the chosen pool, keep the lowest-on-receipt copy.
-        anchored = [lab for lab in pending if lab.line_id in keyword_line_ids]
-        candidates = anchored or pending
+        # All PENDING: elect a canonical copy and invalidate the rest. Section
+        # tier first — a copy on the section layer's TOTAL_LINE row out-ranks
+        # an unsectioned copy, which out-ranks a copy inside the PAYMENT
+        # (tender) block. Without section info every copy shares the neutral
+        # tier and this is a no-op. Then prefer a keyword-anchored row (the
+        # explicit total) over a bare restated number; among the chosen pool,
+        # keep the lowest-on-receipt copy.
+        best_rank = min(_rank(lab) for lab in pending)
+        tier = [lab for lab in pending if _rank(lab) == best_rank]
+        anchored = [lab for lab in tier if lab.line_id in keyword_line_ids]
+        candidates = anchored or tier
         candidates.sort(
             key=lambda lab: pos.get((lab.line_id, lab.word_id), 0.0)
         )

--- a/receipt_upload/receipt_upload/merchant_resolution/embedding_processor.py
+++ b/receipt_upload/receipt_upload/merchant_resolution/embedding_processor.py
@@ -1078,12 +1078,28 @@ def _run_words_pipeline_worker(
             # Keep one canonical copy and invalidate the equal-valued duplicates
             # BEFORE validation, so they neither corrupt arithmetic nor inflate the
             # LLM validator's workload. Conservative: only exact-value duplicates.
-            for dup in dedupe_grand_total(words, word_labels):
+            #
+            # The section layer (swift-worker-v1) has usually already decided
+            # which row is the printed TOTAL_LINE vs the PAYMENT (tender)
+            # restatement, so hand dedupe the sections as its primary tiebreak
+            # — keyword/lowest-y alone kept the tender-row copy and invalidated
+            # the printed "TOTAL" row. Sections are advisory: any read failure
+            # (or a receipt with none yet) falls back to the old election.
+            try:
+                receipt_sections = dynamo.get_receipt_sections_from_receipt(
+                    image_id, receipt_id
+                )
+            except Exception:  # pylint: disable=broad-except
+                receipt_sections = []
+            for dup in dedupe_grand_total(
+                words, word_labels, sections=receipt_sections
+            ):
                 dup.validation_status = ValidationStatus.INVALID.value
                 dup.label_proposed_by = "dedupe_grand_total"
                 dup.reasoning = (
                     "Redundant GRAND_TOTAL: the receipt restates the final total "
-                    "on multiple rows; the canonical (lowest) copy is kept."
+                    "on multiple rows; the canonical copy (TOTAL_LINE section / "
+                    "keyword-anchored / lowest) is kept."
                 )
                 dynamo.update_receipt_word_label(dup)
                 _remove_label_from_list(pending_labels, dup)

--- a/receipt_upload/tests/test_dedupe_grand_total.py
+++ b/receipt_upload/tests/test_dedupe_grand_total.py
@@ -174,6 +174,91 @@ def test_different_values_are_not_deduped():
     assert dedupe_grand_total(words, labels) == []
 
 
+def _section(section_type, line_ids):
+    return SimpleNamespace(section_type=section_type, line_ids=line_ids)
+
+
+def _payment_vs_total_words():
+    """The 2026-08-10 audit shape: the printed total row and the tender row
+    carry the identical amount, BOTH rows are grand-total-keyword anchored
+    ("TOTAL" / "AMOUNT"), and the tender row prints lower on the paper."""
+    return [
+        _w(19, 1, "TOTAL", 0.10, 0.30),
+        _w(19, 2, "$20.56", 0.72, 0.30),  # the printed grand total
+        _w(25, 1, "DEBIT", 0.05, 0.18),
+        _w(25, 2, "PAYMENT", 0.20, 0.18),
+        _w(25, 3, "AMOUNT", 0.40, 0.18),  # "amount" keyword-anchors the row
+        _w(25, 4, "$20.56", 0.72, 0.18),  # tender restatement, lower
+    ]
+
+
+def _payment_vs_total_labels():
+    return [
+        _label(19, 2, "GRAND_TOTAL", _PENDING),
+        _label(25, 4, "GRAND_TOTAL", _PENDING),
+    ]
+
+
+def test_without_sections_lower_anchored_payment_row_wins():
+    """Documents the fallback (and the audited bug shape): with no section
+    info, both rows are keyword-anchored so lowest-y elects the tender row and
+    the printed TOTAL row is reported redundant."""
+    redundant = dedupe_grand_total(
+        _payment_vs_total_words(), _payment_vs_total_labels()
+    )
+    assert _keys(redundant) == {(19, 2)}
+
+
+def test_empty_sections_matches_no_sections():
+    """An empty section list must reproduce the pre-section election exactly."""
+    redundant = dedupe_grand_total(
+        _payment_vs_total_words(), _payment_vs_total_labels(), sections=[]
+    )
+    assert _keys(redundant) == {(19, 2)}
+
+
+def test_total_line_section_beats_lower_anchored_payment_row():
+    """Regression for the 2026-08-10 audit (dev images 6e00af0f / f98c0c1a /
+    8f31f88a): swift-worker-v1 had already marked the printed "TOTAL $20.56"
+    row a TOTAL_LINE section (0.95) with the duplicate inside a PAYMENT
+    section, yet dedupe invalidated the printed total and kept the tender-row
+    copy. With sections supplied, the TOTAL_LINE copy must be canonical."""
+    sections = [
+        _section("TOTAL_LINE", [19]),
+        _section("PAYMENT", [24, 25, 26]),
+    ]
+    redundant = dedupe_grand_total(
+        _payment_vs_total_words(), _payment_vs_total_labels(), sections
+    )
+    assert _keys(redundant) == {(25, 4)}
+    assert (19, 2) not in _keys(redundant)
+
+
+def test_unsectioned_copy_beats_payment_section_copy():
+    """Even without a TOTAL_LINE section, a copy inside the PAYMENT (tender)
+    block must lose to a copy in no section at all."""
+    sections = [_section("PAYMENT", [25])]
+    redundant = dedupe_grand_total(
+        _payment_vs_total_words(), _payment_vs_total_labels(), sections
+    )
+    assert _keys(redundant) == {(25, 4)}
+
+
+def test_section_type_enum_is_unwrapped():
+    """ReceiptSection entities may carry SectionType enum members, not bare
+    strings; the tiebreak must read them the same way."""
+    from receipt_dynamo.constants import SectionType
+
+    sections = [
+        _section(SectionType.TOTAL_LINE, [19]),
+        _section(SectionType.PAYMENT, [25]),
+    ]
+    redundant = dedupe_grand_total(
+        _payment_vs_total_words(), _payment_vs_total_labels(), sections
+    )
+    assert _keys(redundant) == {(25, 4)}
+
+
 def test_invalid_duplicate_is_ignored():
     """An already-INVALID copy doesn't count toward the duplicate set."""
     words = [


### PR DESCRIPTION
## Problem

`dedupe_grand_total` elects the canonical GRAND_TOTAL copy by grand-total-keyword anchoring, then lowest-on-receipt. When the tender row also carries a grand-total keyword ("Amount", "Total Tender") **and** prints lower on the paper, both rules favor the payment row: the printed TOTAL row gets marked INVALID while the identical amount on the tender row stays.

Today's audit of freshly ingested receipts hit this on **3 of 3** receipts where both rows exist (dev image_ids `6e00af0f…`, `f98c0c1a…`, `8f31f88a…`): the printed total row ("Total: \$11.43", "TOTAL \$20.56") had its GRAND_TOTAL invalidated while the payment/tender row (VISA Paid, DEBIT PAYMENT) kept it — even though the section layer (swift-worker-v1) had already marked the correct row a `TOTAL_LINE` section at 0.95 confidence, with the duplicate inside a `PAYMENT` section. The dedupe step just never consulted sections.

## Fix

- `receipt_upload/line_items/reconstructor.py` — `dedupe_grand_total` takes an optional, advisory `sections` sequence (any objects with `section_type` + `line_ids`, e.g. `ReceiptSection`). The all-PENDING election now applies a **section tier before** the keyword/lowest-y rules: a copy on a `TOTAL_LINE` row out-ranks an unsectioned copy, which out-ranks a copy inside the `PAYMENT` (tender) block. With no section info every copy shares the neutral tier and the election is exactly the old one — current behavior is the fallback. Confirmed-copy handling (VALID is canonical; multiple VALID ⇒ abstain) is untouched.
- `receipt_upload/merchant_resolution/embedding_processor.py` — the words-pipeline worker fetches the receipt's sections via `dynamo.get_receipt_sections_from_receipt` (failure-tolerant: any read error falls back to the old election) and passes them through.
- `receipt_upload/tests/test_dedupe_grand_total.py` — 5 new tests, including the audit repro: printed "TOTAL \$20.56" vs a lower, keyword-anchored "DEBIT PAYMENT AMOUNT \$20.56" row. One test documents the fallback (without sections the tender row still wins — that is the pre-existing conservative behavior), plus empty-sections no-op, PAYMENT-section demotion without a TOTAL_LINE section, and SectionType-enum unwrapping.

## Swift parity

Regenerated all three fixtures via `python receipt_ocr_swift/Scripts/generate_line_items_parity.py` — **byte-identical**, so nothing is committed for them. `dedupe_grand_total` is outside the parity surface (the generator exercises `extract_items` / summary filtering / reconcile / printed-total anchors), and the Swift worker performs no GRAND_TOTAL label dedupe — the dedupe runs only in the Python words-pipeline Lambda — so no Swift port is required. `test_swift_line_item_parity_fixture.py` (the anti-drift gate): 6 passed.

## Gates

- `receipt_upload` full suite (CI flags, `PYTHONPATH` = repo root): **892 passed, 13 skipped, 0 failed**
- `tests/test_line_item_golden_regression.py`: **1 passed** (per-merchant floors intact)
- `tests/test_dedupe_grand_total.py`: **13 passed** (8 existing + 5 new)
- `black --check` / `isort --check-only --profile=black` on `receipt_upload`: clean

## Deliberately not done

- "Nearest to a TOTAL_LINE section" distance fallback — membership only; sections are row-granular so membership covers the audited cases, and distance would add a second geometry heuristic to the very rule this replaces.
- No section plumbing into `labels.py`'s `_elect_grand_total_word` (derived-label minting): it calls `dedupe_grand_total` without sections and keeps its fail-closed behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)