### PR TITLE
fix(money): parse trailing-minus negatives and surface TIP in amounts

### DIFF
--- a/infra/mcp_server_lambda/lambdas/receipt_mcp_server_server.py
+++ b/infra/mcp_server_lambda/lambdas/receipt_mcp_server_server.py
@@ -2726,7 +2726,13 @@ async def get_receipt_impl(
 
         formatted_receipt = "\n".join(formatted_lines)
 
-        # Extract amounts
+        # Extract amounts. parse_receipt_amount accepts the accounting
+        # negatives return receipts print ("$16.25-" trailing minus,
+        # parenthesized, leading minus) that a bare float() rejects, so
+        # refunds stay visible to spend aggregation. TIP is a money
+        # label like the others and must surface here too.
+        from receipt_dynamo.amounts import parse_receipt_amount
+
         amounts = []
         currency_labels = [
             "TAX",
@@ -2734,11 +2740,12 @@ async def get_receipt_impl(
             "GRAND_TOTAL",
             "LINE_TOTAL",
             "UNIT_PRICE",
+            "TIP",
         ]
         for w in sorted_words:
             if w["label"] in currency_labels:
-                try:
-                    amount = float(w["text"].replace("$", "").replace(",", ""))
+                amount = parse_receipt_amount(w["text"])
+                if amount is not None:
                     amounts.append(
                         {
                             "label": w["label"],
@@ -2746,8 +2753,6 @@ async def get_receipt_impl(
                             "amount": amount,
                         }
                     )
-                except ValueError:
-                    pass
 
         return {
             "image_id": image_id,

--- a/receipt_agent/receipt_agent/agents/question_answering/tools/search.py
+++ b/receipt_agent/receipt_agent/agents/question_answering/tools/search.py
@@ -298,7 +298,12 @@ def create_qa_tools(
                     for w in line_words
                 ]
 
-            # Extract amounts with line context
+            # Extract amounts with line context. parse_receipt_amount
+            # accepts the accounting negatives return receipts print
+            # ("$16.25-" trailing minus) that a bare float() rejects,
+            # and TIP is a money label like the others.
+            from receipt_dynamo.amounts import parse_receipt_amount
+
             amounts = []
             currency_labels = [
                 "TAX",
@@ -306,14 +311,13 @@ def create_qa_tools(
                 "GRAND_TOTAL",
                 "LINE_TOTAL",
                 "UNIT_PRICE",
+                "TIP",
             ]
             for line_idx, line_words in words_by_line.items():
                 for w in line_words:
                     if w["label"] in currency_labels:
-                        try:
-                            amount = float(
-                                w["text"].replace("$", "").replace(",", "")
-                            )
+                        amount = parse_receipt_amount(w["text"])
+                        if amount is not None:
                             amounts.append(
                                 {
                                     "label": w["label"],
@@ -323,8 +327,6 @@ def create_qa_tools(
                                     "word_id": w["word_id"],
                                 }
                             )
-                        except ValueError:
-                            pass
 
             # Format as text for LLM display (still useful for debugging/display)
             formatted_lines = []

--- a/receipt_agent/receipt_agent/agents/question_answering/tools_simplified.py
+++ b/receipt_agent/receipt_agent/agents/question_answering/tools_simplified.py
@@ -349,7 +349,12 @@ def create_simplified_qa_tools(
 
             formatted_receipt = "\n".join(formatted_lines)
 
-            # Extract amounts summary
+            # Extract amounts summary. parse_receipt_amount accepts the
+            # accounting negatives return receipts print ("$16.25-"
+            # trailing minus) that a bare float() rejects, and TIP is a
+            # money label like the others.
+            from receipt_dynamo.amounts import parse_receipt_amount
+
             amounts = []
             currency_labels = [
                 "TAX",
@@ -357,13 +362,12 @@ def create_simplified_qa_tools(
                 "GRAND_TOTAL",
                 "LINE_TOTAL",
                 "UNIT_PRICE",
+                "TIP",
             ]
             for w in sorted_words:
                 if w["label"] in currency_labels:
-                    try:
-                        amount = float(
-                            w["text"].replace("$", "").replace(",", "")
-                        )
+                    amount = parse_receipt_amount(w["text"])
+                    if amount is not None:
                         amounts.append(
                             {
                                 "label": w["label"],
@@ -371,8 +375,6 @@ def create_simplified_qa_tools(
                                 "amount": amount,
                             }
                         )
-                    except ValueError:
-                        pass
 
             return {
                 "image_id": image_id,

--- a/receipt_dynamo/receipt_dynamo/entities/receipt_summary.py
+++ b/receipt_dynamo/receipt_dynamo/entities/receipt_summary.py
@@ -94,9 +94,13 @@ class MonetaryTotals:
 # Regex pattern to extract monetary values from text
 # Matches: $12.99, 12.99, $1,234.56, 1234.56, $1234, 1234
 # Order matters: try comma-grouped first, then ungrouped amounts
+# A trailing "-" is the accounting negative some registers print on
+# refunds (Target returns print "$16.25-"); it is captured so
+# extract_amount can negate, and stays optional so ordinary amounts,
+# dates ("01-15-2024") and phone numbers parse exactly as before.
 MONEY_PATTERN = re.compile(
-    r"\$?\d{1,3}(?:,\d{3})+(?:\.\d{2})?"  # Comma-grouped: $1,234.56
-    r"|\$?\d+(?:\.\d{2})?"  # Ungrouped: $1234.56, 1234, $50
+    r"\$?\d{1,3}(?:,\d{3})+(?:\.\d{2})?-?"  # Comma-grouped: $1,234.56
+    r"|\$?\d+(?:\.\d{2})?-?"  # Ungrouped: $1234.56, 1234, $50, 16.25-
 )
 
 # Regex patterns for date parsing
@@ -170,12 +174,19 @@ def extract_amount(text: str) -> float | None:
 
     # Take the last match (usually the actual amount, not a product code)
     amount_str = matches[-1]
+    # Trailing "-" is the accounting negative refund registers print
+    # ("$16.25-"); strip it and negate so refunds carry their sign into
+    # the summary financial math instead of parsing as positive spend.
+    is_negative = amount_str.endswith("-")
+    if is_negative:
+        amount_str = amount_str[:-1]
     # Remove $ and commas
     amount_str = amount_str.replace("$", "").replace(",", "")
     try:
-        return float(amount_str)
+        value = float(amount_str)
     except ValueError:
         return None
+    return -value if is_negative else value
 
 
 def parse_date(text: str) -> datetime | None:
@@ -634,12 +645,20 @@ def _anchored_amount_words(
 def _apply_printed_total_fallback(
     totals: MonetaryTotals, words: list["ReceiptWord"]
 ) -> None:
-    """Fill grand_total/subtotal from printed rows when labels gave none."""
-    if totals.grand_total is None or totals.grand_total <= 0:
+    """Fill grand_total/subtotal from printed rows when labels gave none.
+
+    A NEGATIVE label-derived total is a real figure, not a missing one:
+    return receipts print trailing-minus amounts ("$16.25-") and
+    extract_amount now carries the sign through. The fallback only knows
+    positive printed amounts, so letting it run on negatives would
+    replace a refund's total with whatever stray positive figure sits in
+    the total row's y-band. Only None/zero totals fall back.
+    """
+    if totals.grand_total is None or totals.grand_total == 0:
         printed = find_printed_grand_total(words)
         if printed is not None:
             totals.grand_total = printed
-    if totals.subtotal is None or totals.subtotal <= 0:
+    if totals.subtotal is None or totals.subtotal == 0:
         printed = find_printed_subtotal(words)
         if printed is not None:
             totals.subtotal = printed

--- a/receipt_dynamo/tests/unit/test_receipt_analysis_summary_contracts.py
+++ b/receipt_dynamo/tests/unit/test_receipt_analysis_summary_contracts.py
@@ -69,6 +69,16 @@ def test_receipt_analysis_rejects_invalid_contracts(
         ("SKU 100 TOTAL 12.99", 12.99),
         ("no amount", None),
         ("", None),
+        # Trailing-minus accounting negatives (Target return receipts
+        # print refunds as "$16.25-"): the sign must carry through.
+        ("$16.25-", -16.25),
+        ("16.25-", -16.25),
+        ("$1.26-", -1.26),
+        ("REFUND $1,234.56-", -1234.56),
+        # Hyphens that are separators, not signs, stay positive: the
+        # last match wins and never inherits an interior hyphen.
+        ("01-15-2024", 2024.0),
+        ("TEL 555-1234", 1234.0),
     ],
 )
 def test_extract_amount(text: str, expected: float | None):

--- a/receipt_dynamo/tests/unit/test_receipt_summary_trailing_minus.py
+++ b/receipt_dynamo/tests/unit/test_receipt_summary_trailing_minus.py
@@ -1,0 +1,129 @@
+"""Trailing-minus (accounting negative) totals in ReceiptSummary.
+
+Target return receipts print refunds with a trailing minus -- dev
+receipt d30ba860-4bd6-4c9e-a6d7-c2eaed0c2149 (receipt 1) prints
+"$16.25-" / "$14.99-" / "$1.26-" with correct VALID labels -- yet the
+old extract_amount dropped the sign (parsing +16.25) and the printed
+fallback treated any <= 0 label total as "missing", clobbering it with
+whatever positive figure sat in the total row's y-band. These tests pin
+the fixed behavior: signs carry through, the refund reconciles
+(subtotal + tax == grand_total), and the fallback leaves negative
+label-derived totals alone.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from receipt_dynamo.constants import ValidationStatus
+from receipt_dynamo.entities.receipt_summary import (
+    MonetaryTotals,
+    ReceiptSummary,
+    _apply_printed_total_fallback,
+)
+from receipt_dynamo.entities.receipt_word_label import ReceiptWordLabel
+
+pytestmark = pytest.mark.unit
+
+IMAGE_ID = "d30ba860-4bd6-4c9e-a6d7-c2eaed0c2149"
+TIMESTAMP = "2026-08-10T00:00:00.000+00:00"
+
+_LINE_HEIGHT = 0.012
+
+
+def _word(
+    line_id: int,
+    word_id: int,
+    text: str,
+    y_center: float,
+    x: float = 0.1,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        line_id=line_id,
+        word_id=word_id,
+        text=text,
+        bounding_box={
+            "x": x,
+            "y": y_center - _LINE_HEIGHT / 2,
+            "width": 0.1,
+            "height": _LINE_HEIGHT,
+        },
+    )
+
+
+def _label(line_id: int, word_id: int, label: str) -> ReceiptWordLabel:
+    return ReceiptWordLabel(
+        image_id=IMAGE_ID,
+        receipt_id=1,
+        line_id=line_id,
+        word_id=word_id,
+        label=label,
+        reasoning="test",
+        timestamp_added=TIMESTAMP,
+        validation_status=ValidationStatus.VALID.value,
+    )
+
+
+def _target_return_words() -> list[SimpleNamespace]:
+    """Summary zone of a Target return: all three figures print 'N.NN-'."""
+    return [
+        _word(10, 1, "SUBTOTAL", 0.30, x=0.1),
+        _word(10, 2, "$14.99-", 0.30, x=0.8),
+        _word(11, 1, "TAX", 0.32, x=0.1),
+        _word(11, 2, "$1.26-", 0.32, x=0.8),
+        _word(12, 1, "TOTAL", 0.34, x=0.1),
+        _word(12, 2, "$16.25-", 0.34, x=0.8),
+    ]
+
+
+def _target_return_labels() -> list[ReceiptWordLabel]:
+    return [
+        _label(10, 2, "SUBTOTAL"),
+        _label(11, 2, "TAX"),
+        _label(12, 2, "GRAND_TOTAL"),
+    ]
+
+
+def test_trailing_minus_totals_parse_negative_and_reconcile():
+    summary = ReceiptSummary.from_word_labels_and_words(
+        image_id=IMAGE_ID,
+        receipt_id=1,
+        merchant_name="Target",
+        word_labels=_target_return_labels(),
+        words=_target_return_words(),
+    )
+
+    assert summary.grand_total == pytest.approx(-16.25)
+    assert summary.subtotal == pytest.approx(-14.99)
+    assert summary.tax == pytest.approx(-1.26)
+    # The refund reconciles with its sign intact.
+    assert summary.subtotal + summary.tax == pytest.approx(summary.grand_total)
+
+
+def test_printed_fallback_leaves_negative_label_totals_alone():
+    """A stray positive figure in the total row's band must not clobber
+    a label-derived refund total (the old <= 0 guard let it)."""
+    words = _target_return_words() + [
+        # Loyalty figure sharing the TOTAL row's y-band; positive, so
+        # the printed fallback would anchor on it if it ran.
+        _word(13, 1, "$5.00", 0.34, x=0.5),
+    ]
+    totals = MonetaryTotals(grand_total=-16.25, subtotal=-14.99, tax=-1.26)
+
+    _apply_printed_total_fallback(totals, words)
+
+    assert totals.grand_total == pytest.approx(-16.25)
+    assert totals.subtotal == pytest.approx(-14.99)
+
+
+def test_printed_fallback_still_fills_missing_totals():
+    """None/zero totals keep falling back to printed positive rows."""
+    words = [
+        _word(12, 1, "TOTAL", 0.34, x=0.1),
+        _word(12, 2, "$16.25", 0.34, x=0.8),
+    ]
+    totals = MonetaryTotals(grand_total=None, subtotal=None, tax=None)
+
+    _apply_printed_total_fallback(totals, words)
+
+    assert totals.grand_total == pytest.approx(16.25)

--- a/scripts/receipt_mcp_server.py
+++ b/scripts/receipt_mcp_server.py
@@ -2704,7 +2704,13 @@ async def get_receipt_impl(
 
         formatted_receipt = "\n".join(formatted_lines)
 
-        # Extract amounts
+        # Extract amounts. parse_receipt_amount accepts the accounting
+        # negatives return receipts print ("$16.25-" trailing minus,
+        # parenthesized, leading minus) that a bare float() rejects, so
+        # refunds stay visible to spend aggregation. TIP is a money
+        # label like the others and must surface here too.
+        from receipt_dynamo.amounts import parse_receipt_amount
+
         amounts = []
         currency_labels = [
             "TAX",
@@ -2712,11 +2718,12 @@ async def get_receipt_impl(
             "GRAND_TOTAL",
             "LINE_TOTAL",
             "UNIT_PRICE",
+            "TIP",
         ]
         for w in sorted_words:
             if w["label"] in currency_labels:
-                try:
-                    amount = float(w["text"].replace("$", "").replace(",", ""))
+                amount = parse_receipt_amount(w["text"])
+                if amount is not None:
                     amounts.append(
                         {
                             "label": w["label"],
@@ -2724,8 +2731,6 @@ async def get_receipt_impl(
                             "amount": amount,
                         }
                     )
-                except ValueError:
-                    pass
 
         return {
             "image_id": image_id,

--- a/tests/test_receipt_mcp_get_receipt_amounts.py
+++ b/tests/test_receipt_mcp_get_receipt_amounts.py
@@ -1,0 +1,204 @@
+"""get_receipt amounts extraction on both MCP servers.
+
+Two gaps found in the 2026-08-10 receipt audit, pinned here for both
+the stdio server (``scripts/receipt_mcp_server.py``) and the Lambda
+copy (``infra/mcp_server_lambda/lambdas/receipt_mcp_server_server.py``):
+
+1. Trailing-minus accounting negatives -- Target return receipts print
+   refunds as "$16.25-" (dev receipt
+   d30ba860-4bd6-4c9e-a6d7-c2eaed0c2149 receipt 1 prints "$16.25-" /
+   "$14.99-" / "$1.26-" with correct VALID labels). The old
+   ``float(text.replace("$", ""))`` parse raised ValueError on every
+   one, so the receipt's ``amounts`` came back EMPTY and refunds were
+   invisible to spend aggregation.
+2. TIP was missing from the money-label list, so a VALID TIP label
+   (dev receipt 29a3b291-ac80-47bf-bdc9-2cde1d79f1b6, TIP $2.00) never
+   surfaced in ``amounts`` at all.
+"""
+
+import asyncio
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+SERVER_FILES = {
+    "stdio": REPO_ROOT / "scripts" / "receipt_mcp_server.py",
+    "lambda": (
+        REPO_ROOT
+        / "infra"
+        / "mcp_server_lambda"
+        / "lambdas"
+        / "receipt_mcp_server_server.py"
+    ),
+}
+
+RETURN_IMAGE_ID = "d30ba860-4bd6-4c9e-a6d7-c2eaed0c2149"
+TIP_IMAGE_ID = "29a3b291-ac80-47bf-bdc9-2cde1d79f1b6"
+
+
+class _FakeTool:
+    def __init__(self, name, description, inputSchema):
+        self.name = name
+        self.description = description
+        self.inputSchema = inputSchema
+
+
+class _FakeContent:
+    def __init__(self, **kwargs):
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+
+def _install_mcp_stubs():
+    """Register a minimal fake `mcp` package so the servers import cleanly."""
+    mcp_mod = types.ModuleType("mcp")
+    server_mod = types.ModuleType("mcp.server")
+    stdio_mod = types.ModuleType("mcp.server.stdio")
+    types_mod = types.ModuleType("mcp.types")
+
+    class _FakeServer:
+        def __init__(self, name):
+            self.name = name
+
+        def list_tools(self):
+            def decorator(func):
+                return func
+
+            return decorator
+
+        def call_tool(self):
+            def decorator(func):
+                return func
+
+            return decorator
+
+    def _fake_stdio_server(*args, **kwargs):  # pragma: no cover - unused
+        raise RuntimeError("stdio_server is not exercised in tests")
+
+    server_mod.Server = _FakeServer
+    stdio_mod.stdio_server = _fake_stdio_server
+    types_mod.Tool = _FakeTool
+    types_mod.TextContent = _FakeContent
+    types_mod.ImageContent = _FakeContent
+
+    sys.modules["mcp"] = mcp_mod
+    sys.modules["mcp.server"] = server_mod
+    sys.modules["mcp.server.stdio"] = stdio_mod
+    sys.modules["mcp.types"] = types_mod
+
+
+def _load_module(label, path):
+    _install_mcp_stubs()
+    spec = importlib.util.spec_from_file_location(
+        f"receipt_mcp_server_amounts_{label}", path
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _word(line_id, word_id, text, x, y):
+    return SimpleNamespace(
+        line_id=line_id,
+        word_id=word_id,
+        text=text,
+        bounding_box={"x": x, "y": y, "width": 0.1, "height": 0.012},
+        calculate_centroid=lambda x=x, y=y: (x, y),
+    )
+
+
+def _valid_label(line_id, word_id, label):
+    return SimpleNamespace(
+        line_id=line_id,
+        word_id=word_id,
+        label=label,
+        validation_status="VALID",
+        timestamp_added="2026-08-10T00:00:00+00:00",
+    )
+
+
+class _StubDynamo:
+    def __init__(self, words, labels, merchant):
+        self._details = SimpleNamespace(
+            words=words,
+            labels=labels,
+            place=SimpleNamespace(merchant_name=merchant),
+        )
+
+    def get_receipt_details(self, image_id, receipt_id):
+        return self._details
+
+
+def _target_return_client():
+    """Target return d30ba860 r1: every summary figure prints 'N.NN-'."""
+    words = [
+        _word(10, 1, "SUBTOTAL", 0.1, 0.34),
+        _word(10, 2, "$14.99-", 0.8, 0.34),
+        _word(11, 1, "TAX", 0.1, 0.32),
+        _word(11, 2, "$1.26-", 0.8, 0.32),
+        _word(12, 1, "TOTAL", 0.1, 0.30),
+        _word(12, 2, "$16.25-", 0.8, 0.30),
+    ]
+    labels = [
+        _valid_label(10, 2, "SUBTOTAL"),
+        _valid_label(11, 2, "TAX"),
+        _valid_label(12, 2, "GRAND_TOTAL"),
+    ]
+    return _StubDynamo(words, labels, "Target")
+
+
+def _tip_client():
+    """29a3b291: a VALID TIP $2.00 that must surface in amounts."""
+    words = [
+        _word(20, 1, "Tip:", 0.1, 0.30),
+        _word(20, 2, "$2.00", 0.8, 0.30),
+        _word(21, 1, "Total:", 0.1, 0.28),
+        _word(21, 2, "$12.00", 0.8, 0.28),
+    ]
+    labels = [
+        _valid_label(20, 2, "TIP"),
+        _valid_label(21, 2, "GRAND_TOTAL"),
+    ]
+    return _StubDynamo(words, labels, "Some Restaurant")
+
+
+@pytest.mark.parametrize("label", sorted(SERVER_FILES))
+def test_trailing_minus_amounts_parse_negative(label):
+    module = _load_module(label, SERVER_FILES[label])
+    result = asyncio.run(
+        module.get_receipt_impl(_target_return_client(), RETURN_IMAGE_ID, 1)
+    )
+
+    assert "error" not in result
+    amounts = {a["label"]: a["amount"] for a in result["amounts"]}
+    # The audit found this receipt's amounts EMPTY; all three refund
+    # figures must now parse, with their accounting sign intact.
+    assert amounts == {
+        "GRAND_TOTAL": pytest.approx(-16.25),
+        "SUBTOTAL": pytest.approx(-14.99),
+        "TAX": pytest.approx(-1.26),
+    }
+    # Negative reconciliation: the refund's own arithmetic holds.
+    assert amounts["SUBTOTAL"] + amounts["TAX"] == pytest.approx(
+        amounts["GRAND_TOTAL"]
+    )
+
+
+@pytest.mark.parametrize("label", sorted(SERVER_FILES))
+def test_tip_label_surfaces_in_amounts(label):
+    module = _load_module(label, SERVER_FILES[label])
+    result = asyncio.run(
+        module.get_receipt_impl(_tip_client(), TIP_IMAGE_ID, 1)
+    )
+
+    assert "error" not in result
+    amounts = {a["label"]: a["amount"] for a in result["amounts"]}
+    assert amounts["TIP"] == pytest.approx(2.00)
+    assert amounts["GRAND_TOTAL"] == pytest.approx(12.00)


### PR DESCRIPTION
## Summary

Two money-parsing gaps found in today's receipt audit (2026-08-10):

### 1. Trailing-minus amounts don't parse
Target return receipts print negatives as `$16.25-` / `$14.99-` / `$1.26-`. Dev receipt **d30ba860-4bd6-4c9e-a6d7-c2eaed0c2149** (receipt 1) has correct VALID labels on those tokens, yet its `amounts` array came back **EMPTY** — the get_receipt extraction used a bare `float(text.replace("$",""))` that raises `ValueError` on every trailing-minus token, so refunds were invisible to spend aggregation. The summary layer's `extract_amount` had the sibling bug: it matched `16.25` inside `$16.25-` and dropped the sign, recording a refund as positive spend.

- All four copies of the get_receipt amounts extraction now parse through the shared `receipt_dynamo.amounts.parse_receipt_amount`, which already handles trailing-minus, leading-minus, and parenthesized accounting negatives.
- `extract_amount` / `MONEY_PATTERN` in `receipt_summary.py` now capture a trailing `-` and negate, so refund summaries reconcile with their sign intact (`-14.99 + -1.26 == -16.25`). Separator hyphens (dates `01-15-2024`, phone numbers) parse exactly as before.
- `_apply_printed_total_fallback` no longer treats a negative label-derived total as "missing" (`<= 0`): the fallback only knows positive printed figures, so running it on a refund would have clobbered the correct negative total with a stray positive figure in the total row's y-band.

### 2. TIP labels never surface in `amounts`
Dev receipt **29a3b291-ac80-47bf-bdc9-2cde1d79f1b6** has a VALID TIP $2.00 label that never appeared in the amounts array — the `currency_labels` lists omitted TIP. TIP is now included alongside SUBTOTAL/TAX/GRAND_TOTAL/LINE_TOTAL/UNIT_PRICE in all four copies.

## Files changed

| File | Change |
|---|---|
| `scripts/receipt_mcp_server.py` | get_receipt amounts: `parse_receipt_amount` + TIP |
| `infra/mcp_server_lambda/lambdas/receipt_mcp_server_server.py` | same (Lambda copy of the MCP server) |
| `receipt_agent/.../question_answering/tools/search.py` | same (QA agent get_receipt copy) |
| `receipt_agent/.../question_answering/tools_simplified.py` | same (simplified QA tools copy) |
| `receipt_dynamo/receipt_dynamo/entities/receipt_summary.py` | trailing-minus in `MONEY_PATTERN`/`extract_amount`; fallback guard `<= 0` → `None/0` |
| `receipt_dynamo/tests/unit/test_receipt_analysis_summary_contracts.py` | trailing-minus + separator-hyphen `extract_amount` cases |
| `receipt_dynamo/tests/unit/test_receipt_summary_trailing_minus.py` | new: Target-return summary parses negative, reconciles, fallback doesn't clobber |
| `tests/test_receipt_mcp_get_receipt_amounts.py` | new: both MCP servers — trailing-minus negatives + negative reconciliation + TIP in amounts |

## Decoder path / Swift parity

**Untouched.** The line-item decoder already parses money via `parse_receipt_amount` / `looks_like_receipt_amount` (both handle trailing-minus), and Swift's `Amounts.swift` already ports the `hasSuffix("-")` negation. `stripTaxFlag` (`7.32N`/`1.25T` fused taxability flags) is unmodified — trailing `-` is handled inside the shared amount parser, not the flag stripper. All three parity fixtures were regenerated via the generator scripts and came back **byte-identical** (no fixture diffs in this PR).

## Gates

- `receipt_upload/tests` full suite: green (exit 0, 12 known skips), including `test_line_item_golden_regression.py` (per-merchant floors unchanged — no ratchet regression)
- `receipt_dynamo/tests/unit`: 2435 passed
- New MCP tests + existing MCP tool tests (`tests/test_receipt_mcp_*`): 113 passed
- `receipt_agent/tests/test_qa_agent_improvements.py`: 25 passed
- `black --check --line-length=79` and `isort --check-only --profile=black --line-length=79` clean on every changed file (per-file, matching CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)